### PR TITLE
ci: run nix flake check on the office-builder runner

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,7 @@
+self-hosted-runner:
+  labels:
+    - haskell-agent
+    - office-builder
+    - x86_64-linux
+
+config-variables: null

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,45 @@
+name: Tests
+
+# Test every PR revision, including drafts. Runs are keyed by commit so a newer
+# push does not cancel the evidence for an earlier revision.
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: haskell-agent-tests-${{ github.workflow }}-${{ github.event.pull_request.head.sha || github.sha }}
+  cancel-in-progress: false
+
+jobs:
+  tests:
+    name: Nix flake check
+    runs-on: [self-hosted, haskell-agent, office-builder, x86_64-linux]
+    timeout-minutes: 90
+    env:
+      NIX_CONFIG: |
+        experimental-features = nix-command flakes
+        accept-flake-config = false
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+
+      - name: Run Nix flake checks
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          nix_bin="$(command -v nix || true)"
+          if [[ -z "$nix_bin" && -x /run/current-system/sw/bin/nix ]]; then
+            nix_bin=/run/current-system/sw/bin/nix
+          fi
+          if [[ -z "$nix_bin" ]]; then
+            echo "::error title=Missing Nix binary::nix is required to run the haskell-agent checks"
+            exit 1
+          fi
+
+          "$nix_bin" flake check --no-write-lock-file --print-build-logs


### PR DESCRIPTION
Adds a GitHub Actions workflow that runs `nix flake check` on the office-builder self-hosted runners, following the llm-router CI pattern.

The workflow:
- runs on every PR revision (including drafts) and `workflow_dispatch`
- keys concurrency by commit so a newer push does not cancel evidence for an earlier revision
- uses the system Nix on `[self-hosted, haskell-agent, office-builder, x86_64-linux]`

Two office-builder workers (`office-builder-haskell-agent` and `-2`) are already registered and online. Flake inputs are public, so no deploy keys are needed. Live functional tests stay pending without credentials.

Office-builder NixOS runner config lives in `digitallyinduced/servers` (`office-builder/haskell-agent-runners.nix`) and is already deployed.