### PR TITLE
feat: default Grok/xAI reasoning effort to high

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -74,8 +74,9 @@ runAgent options = do
     let provider = loaded.loadedProvider
         model = fromMaybe (defaultModelFor provider) options.optModel
         instructions = systemPrompt provider cwd today (isOneShot options)
+        effort = fromMaybe (defaultEffortFor provider) options.optEffort
         params = requestParams model instructions
-            (schemasFromAppTools provider tools) options.optEffort
+            (schemasFromAppTools provider tools) effort
         policy = resolveApprovalPolicy options isTty
     paramsRef <- newIORef params
     prompt <- loadPrompt options

--- a/packages/agent-cli/src/Agent/CLI/Options.hs
+++ b/packages/agent-cli/src/Agent/CLI/Options.hs
@@ -5,6 +5,7 @@ module Agent.CLI.Options
     , CliOptions(..)
     , Command(..)
     , defaultCliOptions
+    , defaultEffortFor
     , isOneShot
     , parseApprovalAnswer
     , parseArgs
@@ -55,7 +56,8 @@ data CliOptions = CliOptions
     , optYolo :: !Bool
     , optNoYolo :: !Bool
     , optMaxTurns :: !Int
-    , optEffort :: !Text
+    , optEffort :: !(Maybe Text)
+      -- ^ 'Nothing' means use 'defaultEffortFor' once the provider is known.
     , optPrompt :: !(Maybe Text)
     , optPromptFile :: !(Maybe FilePath)
     } deriving (Eq, Show)
@@ -69,10 +71,17 @@ defaultCliOptions = CliOptions
     , optYolo = False
     , optNoYolo = False
     , optMaxTurns = 50
-    , optEffort = "low"
+    , optEffort = Nothing
     , optPrompt = Nothing
     , optPromptFile = Nothing
     }
+
+-- | Provider default when @--effort@ is omitted. Grok runs at high effort.
+defaultEffortFor :: Provider -> Text
+defaultEffortFor = \case
+    XAIProvider -> "high"
+    OpenAIProvider -> "low"
+    OpenRouterProvider -> "low"
 
 isOneShot :: CliOptions -> Bool
 isOneShot options = isJust options.optPrompt || isJust options.optPromptFile
@@ -119,7 +128,7 @@ parseOptions options = \case
         parseOptions options { optMaxTurns = turns } rest
     "--effort" : value : rest -> do
         effort <- parseEffort (Text.pack value)
-        parseOptions options { optEffort = effort } rest
+        parseOptions options { optEffort = Just effort } rest
     "-p" : value : rest ->
         parseOptions options { optPrompt = Just (Text.pack value) } rest
     "--prompt" : value : rest ->
@@ -174,7 +183,8 @@ usage = unlines
     , "      --yolo              Auto-approve every tool"
     , "      --no-yolo           Never auto-approve; deny mutating tools without a TTY"
     , "      --max-turns N       Stop after N model turns (default: 50)"
-    , "      --effort LEVEL      Reasoning effort: low, medium, high, xhigh (default: low)"
+    , "      --effort LEVEL      Reasoning effort: low, medium, high, xhigh"
+    , "                          (default: high for xai/grok, low otherwise)"
     , "      --version           Print the agent-cli version"
     , "      --help              Show this help"
     , ""

--- a/packages/agent-cli/src/Agent/CLI/Options.hs
+++ b/packages/agent-cli/src/Agent/CLI/Options.hs
@@ -80,8 +80,8 @@ defaultCliOptions = CliOptions
 defaultEffortFor :: Provider -> Text
 defaultEffortFor = \case
     XAIProvider -> "high"
-    OpenAIProvider -> "low"
-    OpenRouterProvider -> "low"
+    OpenAIProvider -> "medium"
+    OpenRouterProvider -> "medium"
 
 isOneShot :: CliOptions -> Bool
 isOneShot options = isJust options.optPrompt || isJust options.optPromptFile
@@ -184,7 +184,7 @@ usage = unlines
     , "      --no-yolo           Never auto-approve; deny mutating tools without a TTY"
     , "      --max-turns N       Stop after N model turns (default: 50)"
     , "      --effort LEVEL      Reasoning effort: low, medium, high, xhigh"
-    , "                          (default: high for xai/grok, low otherwise)"
+    , "                          (default: high for xai/grok, medium otherwise)"
     , "      --version           Print the agent-cli version"
     , "      --help              Show this help"
     , ""

--- a/packages/agent-cli/test/Agent/CLI/OptionsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/OptionsSpec.hs
@@ -96,10 +96,10 @@ spec = do
             parseApprovalAnswer "maybe" `shouldBe` Deny
 
     describe "defaultEffortFor" do
-        it "defaults grok/xai to high and other providers to low" do
+        it "defaults grok/xai to high and other providers to medium" do
             defaultEffortFor XAIProvider `shouldBe` "high"
-            defaultEffortFor OpenAIProvider `shouldBe` "low"
-            defaultEffortFor OpenRouterProvider `shouldBe` "low"
+            defaultEffortFor OpenAIProvider `shouldBe` "medium"
+            defaultEffortFor OpenRouterProvider `shouldBe` "medium"
 
     describe "isOneShot" do
         it "is true for -p and --prompt-file" do

--- a/packages/agent-cli/test/Agent/CLI/OptionsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/OptionsSpec.hs
@@ -29,7 +29,7 @@ spec = do
                     , optCwd = Just "/tmp/work"
                     , optYolo = True
                     , optMaxTurns = 3
-                    , optEffort = "high"
+                    , optEffort = Just "high"
                     , optPrompt = Just "hello"
                     })
 
@@ -45,9 +45,9 @@ spec = do
 
         it "accepts xhigh effort" do
             parseArgs ["--effort", "xhigh"]
-                `shouldBe` Right (RunAgent defaultCliOptions { optEffort = "xhigh" })
+                `shouldBe` Right (RunAgent defaultCliOptions { optEffort = Just "xhigh" })
             parseArgs ["--effort", "HIGH"]
-                `shouldBe` Right (RunAgent defaultCliOptions { optEffort = "high" })
+                `shouldBe` Right (RunAgent defaultCliOptions { optEffort = Just "high" })
 
         it "rejects unknown effort levels" do
             parseArgs ["--effort", "max"] `shouldSatisfy` isLeft
@@ -94,6 +94,12 @@ spec = do
             parseApprovalAnswer "n" `shouldBe` Deny
             parseApprovalAnswer "no" `shouldBe` Deny
             parseApprovalAnswer "maybe" `shouldBe` Deny
+
+    describe "defaultEffortFor" do
+        it "defaults grok/xai to high and other providers to low" do
+            defaultEffortFor XAIProvider `shouldBe` "high"
+            defaultEffortFor OpenAIProvider `shouldBe` "low"
+            defaultEffortFor OpenRouterProvider `shouldBe` "low"
 
     describe "isOneShot" do
         it "is true for -p and --prompt-file" do

--- a/packages/agent-xai/src/Agent/XAI/Request.hs
+++ b/packages/agent-xai/src/Agent/XAI/Request.hs
@@ -72,11 +72,15 @@ buildRequest options request = defaultResponseCreateParams
 
 xaiReasoningEffort :: Maybe Text -> Text
 xaiReasoningEffort = \case
+    Nothing -> "high"
+    Just "low" -> "low"
+    Just "none" -> "low"
+    Just "minimal" -> "low"
     Just "medium" -> "medium"
     Just "high" -> "high"
     Just "xhigh" -> "high"
     Just "max" -> "high"
-    _ -> "low"
+    _ -> "high"
 
 requestInputItems :: ResponseCreateParams -> [ResponseItem]
 requestInputItems request = case request.input of

--- a/packages/agent-xai/test/Agent/XAI/ResponsesSpec.hs
+++ b/packages/agent-xai/test/Agent/XAI/ResponsesSpec.hs
@@ -98,6 +98,11 @@ spec = do
                 >>= (`shouldBe` Just (Aeson.String "low"))
             effortOf (withEffort "medium" sampleRequest)
                 >>= (`shouldBe` Just (Aeson.String "medium"))
+            effortOf (withEffort "low" sampleRequest)
+                >>= (`shouldBe` Just (Aeson.String "low"))
+            -- Unset effort defaults to high for Grok.
+            effortOf (clearEffort sampleRequest)
+                >>= (`shouldBe` Just (Aeson.String "high"))
 
     describe "classifyFailure" do
         it "types a bare 429 and honours the Retry-After header" do
@@ -219,6 +224,10 @@ reasoningConfig effort = ReasoningConfig
 withEffort :: Text -> ResponseCreateParams -> ResponseCreateParams
 withEffort effort ResponseCreateParams { reasoning = _, .. } =
     ResponseCreateParams { reasoning = Just (reasoningConfig effort), .. }
+
+clearEffort :: ResponseCreateParams -> ResponseCreateParams
+clearEffort ResponseCreateParams { reasoning = _, .. } =
+    ResponseCreateParams { reasoning = Nothing, .. }
 
 setInstructions :: Maybe Text -> ResponseCreateParams -> ResponseCreateParams
 setInstructions newInstructions ResponseCreateParams { instructions = _, .. } =


### PR DESCRIPTION
## Summary
- Default reasoning effort to **high** for xAI/Grok when `--effort` is omitted; use **medium** for OpenAI and OpenRouter.
- In the xAI request mapper, unset effort now maps to **high** while explicit `low` / `none` / `minimal` still map to `low`.

## Test plan
- [x] `cabal test agent-cli agent-xai`
- [ ] Smoke: run `agent-cli --provider xai` without `--effort` and confirm session effort is high
- [ ] Smoke: `agent-cli --provider openai` without `--effort` and confirm session effort is medium
- [ ] Smoke: `agent-cli --provider xai --effort low` still sends low