### PR TITLE
feat: render assistant markdown with ANSI in the CLI

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -38,6 +38,7 @@ library
     exposed-modules:  Agent.CLI
                     , Agent.CLI.Auth
                     , Agent.CLI.Command
+                    , Agent.CLI.Markdown
                     , Agent.CLI.Options
                     , Agent.CLI.Prompt
                     , Agent.CLI.Render
@@ -48,6 +49,7 @@ library
                     , agent-openrouter >= 0.1 && < 0.2
                     , agent-xai >= 0.1 && < 0.2
                     , aeson >= 2.0
+                    , ansi-terminal >= 1.0
                     , base >= 4.17 && < 5
                     , bytestring
                     , directory
@@ -71,6 +73,7 @@ test-suite agent-cli-test
     main-is:          Spec.hs
     other-modules:    Agent.CLI.AuthSpec
                     , Agent.CLI.CommandSpec
+                    , Agent.CLI.MarkdownSpec
                     , Agent.CLI.OptionsSpec
                     , Agent.CLI.PromptSpec
                     , Agent.CLI.RenderSpec
@@ -80,6 +83,7 @@ test-suite agent-cli-test
                     , agent-core
                     , agent-openai
                     , aeson
+                    , ansi-terminal
                     , base >= 4.17 && < 5
                     , bytestring
                     , directory

--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -36,7 +36,7 @@ import qualified Data.Text.IO as Text
 import Data.Time.Clock (getCurrentTime, utctDay)
 import qualified Data.Aeson.KeyMap as KeyMap
 import System.Directory (getCurrentDirectory, getHomeDirectory, makeAbsolute, setCurrentDirectory)
-import System.Environment (getArgs)
+import System.Environment (getArgs, lookupEnv)
 import System.Exit (die, exitFailure)
 import System.IO (hFlush, hIsTerminalDevice, hPutStrLn, isEOF, stderr, stdin, stdout)
 
@@ -102,12 +102,18 @@ runSession
     -> IO ()
 runSession options policy tools prompt paramsRef backend = do
     printed <- newIORef False
+    textBuffer <- newIORef ""
     ioLock <- newMVar ()
     previous <- newIORef Nothing
     policyRef <- newIORef policy
-    let render = RenderConfig
+    stdoutTty <- hIsTerminalDevice stdout
+    noColor <- lookupEnv "NO_COLOR"
+    let useColor = stdoutTty && maybe True (\_ -> False) noColor
+        render = RenderConfig
             { renderShowReasoning = options.optShowReasoning
+            , renderColor = useColor
             , renderPrintedText = printed
+            , renderTextBuffer = textBuffer
             , renderLock = ioLock
             , renderStdout = stdout
             , renderStderr = stderr
@@ -186,8 +192,11 @@ runOneTurn config previous printed prompt = do
             writeIORef previous (Just loopResult.finalResponseId)
             printedText <- readIORef printed
             case (printedText, loopResult.finalText) of
-                (False, Just text) | not (Text.null (Text.strip text)) ->
-                    putTextLn stdout text
+                (False, Just text) | not (Text.null (Text.strip text)) -> do
+                    color <- hIsTerminalDevice stdout
+                    noColor <- lookupEnv "NO_COLOR"
+                    let useColor = color && maybe True (\_ -> False) noColor
+                    putTextLn stdout (renderAssistantText useColor text)
                 _ -> pure ()
             pure True
 

--- a/packages/agent-cli/src/Agent/CLI/Markdown.hs
+++ b/packages/agent-cli/src/Agent/CLI/Markdown.hs
@@ -1,0 +1,328 @@
+-- | Turn CommonMark-ish assistant text into ANSI-styled terminal output.
+module Agent.CLI.Markdown
+    ( renderMarkdown
+    ) where
+
+import Control.Applicative ((<|>))
+import Data.Char (isAlphaNum, isDigit, isSpace)
+import Data.List (transpose)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import System.Console.ANSI
+    ( Color(..)
+    , ColorIntensity(..)
+    , ConsoleIntensity(..)
+    , ConsoleLayer(..)
+    , SGR(..)
+    , Underlining(..)
+    )
+import System.Console.ANSI.Codes (setSGRCode)
+
+-- | When @color@ is 'True', style a useful subset of GFM for a TTY.
+-- When 'False', return @text@ unchanged (pipes, redirects, tests).
+renderMarkdown :: Bool -> Text -> Text
+renderMarkdown color text
+    | not color = text
+    | otherwise =
+        let cleaned = Text.filter (/= '\ESC') text
+            endsWithNewline = Text.isSuffixOf "\n" cleaned
+            lines_ = Text.splitOn "\n" cleaned
+            linesForParse
+                | endsWithNewline && not (null lines_) = init lines_
+                | otherwise = lines_
+            rendered = Text.intercalate "\n" (renderBlocks linesForParse)
+        in if endsWithNewline then rendered <> "\n" else rendered
+
+renderBlocks :: [Text] -> [Text]
+renderBlocks = go
+  where
+    go [] = []
+    go (line : rest)
+        | Just (marker, info) <- fenceOpen line =
+            let (body, after) = takeFenceBody marker rest
+                header =
+                    if Text.null info
+                        then []
+                        else [style [SetConsoleIntensity FaintIntensity] info]
+            in header ++ body ++ go after
+        | Just (styled, after) <- takeTable (line : rest) =
+            styled ++ go after
+        | Just (level, title) <- headingLine line =
+            let marker = Text.replicate level "#"
+                prefix =
+                    style
+                        [ SetConsoleIntensity BoldIntensity
+                        , SetUnderlining SingleUnderline
+                        ]
+                        (marker <> " ")
+            in (prefix <> styleInline title) : go rest
+        | Just item <- unorderedItem line =
+            styleInline ("• " <> item) : go rest
+        | Just item <- orderedItem line =
+            styleInline item : go rest
+        | Just quote <- blockQuote line =
+            ( style [SetConsoleIntensity FaintIntensity] "│ "
+                <> styleInline quote
+            )
+                : go rest
+        | isThematicBreak line =
+            style [SetConsoleIntensity FaintIntensity] (Text.replicate 40 "─")
+                : go rest
+        | Text.null (Text.strip line) = line : go rest
+        | otherwise = styleInline line : go rest
+
+data FenceMarker = BacktickFence !Int | TildeFence !Int
+
+fenceOpen :: Text -> Maybe (FenceMarker, Text)
+fenceOpen line =
+    let stripped = Text.stripStart line
+        tryFence char ctor =
+            let (run, after) = Text.span (== char) stripped
+                n = Text.length run
+            in if n >= 3
+                then Just (ctor n, Text.strip after)
+                else Nothing
+    in tryFence '`' BacktickFence <|> tryFence '~' TildeFence
+
+takeFenceBody :: FenceMarker -> [Text] -> ([Text], [Text])
+takeFenceBody marker = go
+  where
+    go [] = ([], [])
+    go (line : rest)
+        | isFenceClose marker line = ([], rest)
+        | otherwise =
+            let (body, after) = go rest
+            in (line : body, after)
+
+isFenceClose :: FenceMarker -> Text -> Bool
+isFenceClose marker line =
+    let stripped = Text.strip line
+        (char, need) = case marker of
+            BacktickFence n -> ('`', n)
+            TildeFence n -> ('~', n)
+        (run, after) = Text.span (== char) stripped
+    in Text.length run >= need && Text.null (Text.strip after)
+
+headingLine :: Text -> Maybe (Int, Text)
+headingLine line =
+    let stripped = Text.stripStart line
+        (marks, after) = Text.span (== '#') stripped
+        level = Text.length marks
+    in if level >= 1 && level <= 6 && startsWithSpace after
+        then Just (level, Text.strip after)
+        else Nothing
+
+startsWithSpace :: Text -> Bool
+startsWithSpace t = case Text.uncons t of
+    Just (c, _) -> isSpace c
+    Nothing -> False
+
+unorderedItem :: Text -> Maybe Text
+unorderedItem line =
+    let stripped = Text.stripStart line
+    in case Text.uncons stripped of
+        Just (c, rest)
+            | c `elem` ['-', '*', '+']
+            , Just (sp, after) <- Text.uncons rest
+            , isSpace sp ->
+                Just (Text.strip after)
+        _ -> Nothing
+
+orderedItem :: Text -> Maybe Text
+orderedItem line =
+    let stripped = Text.stripStart line
+        (digits, after) = Text.span isDigit stripped
+    in if not (Text.null digits)
+        then case Text.stripPrefix ". " after of
+            Just item -> Just (digits <> ". " <> Text.strip item)
+            Nothing -> Nothing
+        else Nothing
+
+blockQuote :: Text -> Maybe Text
+blockQuote line = case Text.stripPrefix ">" (Text.stripStart line) of
+    Just rest -> Just (Text.stripStart rest)
+    Nothing -> Nothing
+
+isThematicBreak :: Text -> Bool
+isThematicBreak line =
+    let stripped = Text.filter (not . isSpace) (Text.strip line)
+    in Text.length stripped >= 3
+        && (Text.all (== '-') stripped
+            || Text.all (== '*') stripped
+            || Text.all (== '_') stripped)
+
+takeTable :: [Text] -> Maybe ([Text], [Text])
+takeTable (header : sep : rest)
+    | isTableRow header
+    , isSeparatorRow sep =
+        let (body, after) = span isTableRow rest
+            rows = map splitRow (header : body)
+            widths = columnWidths rows
+            styled =
+                zipWith
+                    (\i row -> styleTableRow (i == 0) widths row)
+                    [0 :: Int ..]
+                    rows
+        in Just (styled, after)
+takeTable _ = Nothing
+
+isTableRow :: Text -> Bool
+isTableRow line =
+    let stripped = Text.strip line
+    in Text.isPrefixOf "|" stripped && Text.count "|" stripped >= 2
+
+isSeparatorRow :: Text -> Bool
+isSeparatorRow line =
+    isTableRow line && all isSepCell (splitRow line)
+  where
+    isSepCell cell =
+        let t = Text.filter (`notElem` ['-', ':', ' ']) cell
+        in Text.null t && Text.any (== '-') cell
+
+splitRow :: Text -> [Text]
+splitRow line =
+    let stripped = Text.strip line
+        trimmed =
+            Text.dropWhile (== '|')
+                (Text.dropWhileEnd (== '|') stripped)
+    in map Text.strip (Text.splitOn "|" trimmed)
+
+columnWidths :: [[Text]] -> [Int]
+columnWidths rows =
+    let cols = transpose rows
+    in map (maximum . (0 :) . map Text.length) cols
+
+styleTableRow :: Bool -> [Int] -> [Text] -> Text
+styleTableRow isHeader widths cells =
+    let padded =
+            zipWith
+                (\w c -> c <> Text.replicate (max 0 (w - Text.length c)) " ")
+                widths
+                (cells ++ repeat "")
+        line = Text.intercalate "  " (take (length widths) padded)
+    in if isHeader
+        then style [SetConsoleIntensity BoldIntensity] line
+        else styleInline line
+
+styleInline :: Text -> Text
+styleInline = Text.concat . go Nothing
+  where
+    go :: Maybe Char -> Text -> [Text]
+    go prev t
+        | Text.null t = []
+        | Just (code, rest) <- takeInlineCode t =
+            style codeStyle code : go (Text.unsnoc code >>= Just . snd) rest
+        | Just (linkText, url, rest) <- takeLink t =
+            style linkStyle (styleInline linkText)
+                : style urlStyle (" (" <> url <> ")")
+                : go (Just ')') rest
+        | Just (inner, rest) <- takeEmphasis prev "**" t =
+            style [SetConsoleIntensity BoldIntensity] (styleInline inner)
+                : go (Text.unsnoc inner >>= Just . snd) rest
+        | Just (inner, rest) <- takeEmphasis prev "__" t =
+            style [SetConsoleIntensity BoldIntensity] (styleInline inner)
+                : go (Text.unsnoc inner >>= Just . snd) rest
+        | Just (inner, rest) <- takeEmphasis prev "*" t =
+            style [SetItalicized True] (styleInline inner)
+                : go (Text.unsnoc inner >>= Just . snd) rest
+        | Just (inner, rest) <- takeEmphasis prev "_" t =
+            style [SetItalicized True] (styleInline inner)
+                : go (Text.unsnoc inner >>= Just . snd) rest
+        | otherwise =
+            let (plain, rest) = Text.break (`elem` ['`', '[', '*', '_']) t
+            in if Text.null plain
+                then
+                    let c = Text.take 1 t
+                        rest' = Text.drop 1 t
+                    in c : go (Text.uncons c >>= Just . fst) rest'
+                else
+                    plain
+                        : go (Text.unsnoc plain >>= Just . snd) rest
+
+    codeStyle =
+        [ SetConsoleIntensity BoldIntensity
+        , SetColor Foreground Dull Cyan
+        ]
+    linkStyle =
+        [ SetColor Foreground Dull Blue
+        , SetUnderlining SingleUnderline
+        ]
+    urlStyle = [SetConsoleIntensity FaintIntensity]
+
+takeInlineCode :: Text -> Maybe (Text, Text)
+takeInlineCode t =
+    let (ticks, afterOpen) = Text.span (== '`') t
+        n = Text.length ticks
+    in if n == 0 then Nothing else findClose n afterOpen
+  where
+    findClose n body =
+        case Text.break (== '`') body of
+            (_, rest) | Text.null rest -> Nothing
+            (before, rest) ->
+                let (closeRun, afterClose) = Text.span (== '`') rest
+                    closeLen = Text.length closeRun
+                in if closeLen == n
+                    then Just (before, afterClose)
+                    else do
+                        (code, rest') <- findClose n afterClose
+                        Just (before <> closeRun <> code, rest')
+
+takeLink :: Text -> Maybe (Text, Text, Text)
+takeLink t = do
+    afterBracket <- Text.stripPrefix "[" t
+    case Text.breakOn "]" afterBracket of
+        (linkText, rest0)
+            | not (Text.null linkText)
+            , Just afterBracketClose <- Text.stripPrefix "]" rest0
+            , Just afterParen <- Text.stripPrefix "(" afterBracketClose ->
+                case Text.breakOn ")" afterParen of
+                    (url, rest1)
+                        | not (Text.null url)
+                        , Just rest <- Text.stripPrefix ")" rest1 ->
+                            Just (linkText, url, rest)
+                    _ -> Nothing
+            | otherwise -> Nothing
+
+takeEmphasis :: Maybe Char -> Text -> Text -> Maybe (Text, Text)
+takeEmphasis prevChar delim t
+    | not (delim `Text.isPrefixOf` t) = Nothing
+    | not (canOpen prevChar delim (Text.drop (Text.length delim) t)) = Nothing
+    | otherwise = do
+        afterOpen <- Text.stripPrefix delim t
+        case Text.breakOn delim afterOpen of
+            (inner, rest)
+                | not (Text.null inner)
+                , not (Text.any (== '\n') inner)
+                , Just afterClose <- Text.stripPrefix delim rest
+                , canClose delim inner afterClose ->
+                    Just (inner, afterClose)
+            _ -> Nothing
+
+canOpen :: Maybe Char -> Text -> Text -> Bool
+canOpen prevChar delim after =
+    case Text.uncons after of
+        Nothing -> False
+        Just (first, _)
+            | isSpace first -> False
+            | delim == "_" || delim == "__" ->
+                maybe True (not . isWordChar) prevChar
+            | otherwise -> True
+
+canClose :: Text -> Text -> Text -> Bool
+canClose delim inner after =
+    case Text.unsnoc inner of
+        Nothing -> False
+        Just (_, lastChar)
+            | isSpace lastChar -> False
+            | delim == "_" || delim == "__" ->
+                case Text.uncons after of
+                    Just (c, _) -> not (isWordChar c)
+                    Nothing -> True
+            | otherwise -> True
+
+isWordChar :: Char -> Bool
+isWordChar c = isAlphaNum c || c == '_'
+
+style :: [SGR] -> Text -> Text
+style attrs text =
+    Text.pack (setSGRCode attrs) <> text <> Text.pack (setSGRCode [Reset])

--- a/packages/agent-cli/src/Agent/CLI/Render.hs
+++ b/packages/agent-cli/src/Agent/CLI/Render.hs
@@ -3,14 +3,17 @@ module Agent.CLI.Render
     ( RenderConfig(..)
     , formatLoopError
     , putTextLn
+    , renderAssistantText
     , renderEvent
     , summarizeToolCall
     , truncateToolOutput
     ) where
 
+import Agent.CLI.Markdown (renderMarkdown)
 import Agent.Loop (LoopError(..), LoopEvent(..), TurnOutput(..))
 import Agent.ToolDispatch (ToolCall(..), ToolCallResult(..))
 import Control.Concurrent.MVar (MVar, withMVar)
+import Control.Monad (when)
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KeyMap
@@ -24,7 +27,9 @@ import System.IO (Handle, hFlush)
 
 data RenderConfig = RenderConfig
     { renderShowReasoning :: !Bool
+    , renderColor :: !Bool
     , renderPrintedText :: !(IORef Bool)
+    , renderTextBuffer :: !(IORef Text)
     , renderLock :: !(MVar ())
     , renderStdout :: !Handle
     , renderStderr :: !Handle
@@ -36,21 +41,53 @@ renderEvent config event =
 
 renderEventUnlocked :: RenderConfig -> LoopEvent -> IO ()
 renderEventUnlocked config = \case
-    TextDelta delta -> do
-        writeIORef config.renderPrintedText True
-        Text.hPutStr config.renderStdout delta
-        hFlush config.renderStdout
+    TextDelta delta ->
+        if config.renderColor
+            then modifyIORef' config.renderTextBuffer (<> delta)
+            else do
+                writeIORef config.renderPrintedText True
+                Text.hPutStr config.renderStdout delta
+                hFlush config.renderStdout
     ReasoningDelta delta
         | config.renderShowReasoning -> do
             Text.hPutStr config.renderStderr (dimText delta)
             hFlush config.renderStderr
         | otherwise -> pure ()
-    TurnStarted -> pure ()
-    TurnFinished _ -> pure ()
+    TurnStarted -> writeIORef config.renderTextBuffer ""
+    -- Flush styled text on every completed turn. Pre-tool prose ("I'll check…")
+    -- is shown before tool lines; the final tool-free turn is the main answer.
+    TurnFinished turn
+        | config.renderColor -> do
+            didPrint <- flushAssistantBuffer config turn.assistantText
+            when (didPrint && not (null turn.toolCalls)) do
+                putTextLn config.renderStdout ""
+        | otherwise -> pure ()
     ToolStarted call ->
         putTextLn config.renderStderr ("→ " <> summarizeToolCall call)
     ToolFinished result ->
         putTextLn config.renderStderr (truncateToolOutput result.output)
+
+-- | Style assistant markdown when color is enabled; otherwise return plain text.
+renderAssistantText :: Bool -> Text -> Text
+renderAssistantText = renderMarkdown
+
+-- | End-of-turn flush for color mode: prefer streamed deltas, else the
+-- completed 'assistantText' from non-streaming backends.
+-- Returns whether anything was written.
+flushAssistantBuffer :: RenderConfig -> Maybe Text -> IO Bool
+flushAssistantBuffer config assistantText = do
+    buffered <- readIORef config.renderTextBuffer
+    writeIORef config.renderTextBuffer ""
+    let raw
+            | not (Text.null buffered) = buffered
+            | otherwise = fromMaybe "" assistantText
+    if Text.null raw
+        then pure False
+        else do
+            writeIORef config.renderPrintedText True
+            Text.hPutStr config.renderStdout (renderMarkdown True raw)
+            hFlush config.renderStdout
+            pure True
 
 -- | Write @text@ plus a newline as one 'Text.hPutStr'. @hPutStrLn@ on a
 -- 'String' is @hPutStr@ then @hPutChar '\\n'@ over a @[Char]@ spine, so

--- a/packages/agent-cli/test/Agent/CLI/MarkdownSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/MarkdownSpec.hs
@@ -1,0 +1,73 @@
+module Agent.CLI.MarkdownSpec (spec) where
+
+import Agent.CLI.Markdown (renderMarkdown)
+import qualified Data.Text as Text
+import Test.Hspec
+
+spec :: Spec
+spec = do
+    describe "renderMarkdown" do
+        it "leaves text unchanged when color is off" do
+            let sample = "see `file.txt` and **bold**"
+            renderMarkdown False sample `shouldBe` sample
+
+        it "styles inline code when color is on" do
+            let out = renderMarkdown True "see `file.txt` now"
+            out `shouldSatisfy` Text.isInfixOf "file.txt"
+            out `shouldSatisfy` Text.isInfixOf "\ESC["
+            out `shouldSatisfy` (not . Text.isInfixOf "`file.txt`")
+
+        it "does not treat fence interiors as inline code" do
+            let sample = "```\nuse `code` here\n```"
+                out = renderMarkdown True sample
+            out `shouldSatisfy` Text.isInfixOf "use `code` here"
+            Text.count "`code`" out `shouldBe` 1
+
+        it "keeps fence body at normal intensity and drops fence markers" do
+            let out = renderMarkdown True "```haskell\nmain = pure ()\n```"
+            out `shouldSatisfy` Text.isInfixOf "main = pure ()"
+            out `shouldSatisfy` (not . Text.isInfixOf "```")
+            out `shouldSatisfy` Text.isInfixOf "haskell"
+
+        it "supports tilde fences" do
+            let out = renderMarkdown True "~~~\nbody\n~~~"
+            out `shouldBe` "body"
+
+        it "styles bold markers" do
+            let out = renderMarkdown True "say **hello** there"
+            out `shouldSatisfy` Text.isInfixOf "hello"
+            out `shouldSatisfy` (not . Text.isInfixOf "**hello**")
+
+        it "does not italicize snake_case identifiers" do
+            let out = renderMarkdown True "use snake_case_name please"
+            out `shouldBe` "use snake_case_name please"
+
+        it "still italicizes flanked underscores" do
+            let out = renderMarkdown True "use _already established_ terms"
+            out `shouldSatisfy` Text.isInfixOf "already established"
+            out `shouldSatisfy` (not . Text.isInfixOf "_already established_")
+
+        it "supports multi-backtick inline code" do
+            let out = renderMarkdown True "see ``code `with` ticks`` now"
+            out `shouldSatisfy` Text.isInfixOf "code `with` ticks"
+            out `shouldSatisfy` (not . Text.isInfixOf "``")
+
+        it "styles inline code inside headings" do
+            let out = renderMarkdown True "# see `Render.hs`"
+            out `shouldSatisfy` Text.isInfixOf "Render.hs"
+            out `shouldSatisfy` (not . Text.isInfixOf "`Render.hs`")
+
+        it "renders a basic pipe table" do
+            let sample = "| file | status |\n| --- | --- |\n| a.hs | ok |"
+                out = renderMarkdown True sample
+            out `shouldSatisfy` Text.isInfixOf "file"
+            out `shouldSatisfy` Text.isInfixOf "a.hs"
+            out `shouldSatisfy` (not . Text.isInfixOf "|")
+
+        it "strips raw ESC from model output" do
+            let out = renderMarkdown True ("hi" <> "\ESC[31m" <> "x")
+            out `shouldSatisfy` (not . Text.isInfixOf "\ESC[31m")
+            out `shouldSatisfy` Text.isInfixOf "x"
+
+        it "preserves a trailing newline" do
+            renderMarkdown True "hi\n" `shouldSatisfy` Text.isSuffixOf "\n"

--- a/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
@@ -6,7 +6,7 @@ import Agent.ToolDispatch (customToolCall, functionToolCall)
 import Control.Concurrent (forkIO)
 import Control.Concurrent.MVar (newEmptyMVar, newMVar, putMVar, takeMVar)
 import Control.Exception (finally)
-import Data.IORef (newIORef)
+import Data.IORef (newIORef, readIORef)
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
 import System.Directory (getTemporaryDirectory, removeFile)
@@ -51,9 +51,12 @@ spec = do
             (path, handle) <- openTempFile tmp "agent-render-spec"
             flip finally (removeFile path) do
                 hSetBuffering handle NoBuffering
+                textBuffer <- newIORef ""
                 let config = RenderConfig
                         { renderShowReasoning = False
+                        , renderColor = False
                         , renderPrintedText = printed
+                        , renderTextBuffer = textBuffer
                         , renderLock = lock
                         , renderStdout = handle
                         , renderStderr = handle
@@ -77,3 +80,64 @@ spec = do
                     [ "→ list_dir packages/agent-" <> Text.pack (show i)
                     | i <- [1 :: Int .. 80]
                     ]
+
+        it "buffers colored TextDelta until TurnFinished" do
+            printed <- newIORef False
+            textBuffer <- newIORef ""
+            lock <- newMVar ()
+            tmp <- getTemporaryDirectory
+            (path, handle) <- openTempFile tmp "agent-render-md"
+            flip finally (removeFile path) do
+                hSetBuffering handle NoBuffering
+                let config = RenderConfig
+                        { renderShowReasoning = False
+                        , renderColor = True
+                        , renderPrintedText = printed
+                        , renderTextBuffer = textBuffer
+                        , renderLock = lock
+                        , renderStdout = handle
+                        , renderStderr = handle
+                        }
+                renderEvent config (TextDelta "see `file.txt`")
+                buffered <- readIORef textBuffer
+                buffered `shouldBe` "see `file.txt`"
+                renderEvent config (TurnFinished TurnOutput
+                    { responseId = "r1"
+                    , toolCalls = []
+                    , assistantText = Nothing
+                    })
+                hClose handle
+                body <- Text.readFile path
+                body `shouldSatisfy` Text.isInfixOf "file.txt"
+                body `shouldSatisfy` Text.isInfixOf "\ESC["
+                body `shouldSatisfy` (not . Text.isInfixOf "`file.txt`")
+
+        it "flushes pre-tool assistant prose before tool lines" do
+            printed <- newIORef False
+            textBuffer <- newIORef ""
+            lock <- newMVar ()
+            tmp <- getTemporaryDirectory
+            (path, handle) <- openTempFile tmp "agent-render-pretool"
+            flip finally (removeFile path) do
+                hSetBuffering handle NoBuffering
+                let config = RenderConfig
+                        { renderShowReasoning = False
+                        , renderColor = True
+                        , renderPrintedText = printed
+                        , renderTextBuffer = textBuffer
+                        , renderLock = lock
+                        , renderStdout = handle
+                        , renderStderr = handle
+                        }
+                    call = functionToolCall "c1" "list_dir" "{\"target_directory\":\".\"}"
+                renderEvent config (TextDelta "checking `src`")
+                renderEvent config (TurnFinished TurnOutput
+                    { responseId = "r1"
+                    , toolCalls = [call]
+                    , assistantText = Nothing
+                    })
+                hClose handle
+                body <- Text.readFile path
+                body `shouldSatisfy` Text.isInfixOf "src"
+                body `shouldSatisfy` Text.isInfixOf "\ESC["
+                readIORef textBuffer `shouldReturn` ""

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -4,6 +4,7 @@ import Test.Hspec (hspec)
 
 import qualified Agent.CLI.AuthSpec as AuthSpec
 import qualified Agent.CLI.CommandSpec as CommandSpec
+import qualified Agent.CLI.MarkdownSpec as MarkdownSpec
 import qualified Agent.CLI.OptionsSpec as OptionsSpec
 import qualified Agent.CLI.PromptSpec as PromptSpec
 import qualified Agent.CLI.RenderSpec as RenderSpec
@@ -14,6 +15,7 @@ main :: IO ()
 main = hspec do
     AuthSpec.spec
     CommandSpec.spec
+    MarkdownSpec.spec
     OptionsSpec.spec
     PromptSpec.spec
     RenderSpec.spec


### PR DESCRIPTION
## Summary
- Add `Agent.CLI.Markdown` to style a useful GFM subset (inline code, multi-backtick spans, fences, headings, lists, tables, blockquotes) as ANSI on TTY output.
- Buffer assistant `TextDelta`s in color mode and flush styled text on `TurnFinished`, including pre-tool prose before tool lines.
- Keep plain streaming when stdout is not a TTY or `NO_COLOR` is set; strip raw ESC from model text before styling.

## Test plan
- [x] `cabal test agent-cli --disable-optimization`
- [ ] One-shot `-p` on a TTY asking for an answer with `` `paths` `` and a small table; confirm styling.
- [ ] Same command piped to a file / with `NO_COLOR=1`; confirm plain text and no ANSI.