### PR TITLE
feat: persist and resume CLI sessions on disk

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -42,6 +42,7 @@ library
                     , Agent.CLI.Options
                     , Agent.CLI.Prompt
                     , Agent.CLI.Render
+                    , Agent.CLI.Session
                     , Agent.CLI.Tools
                     , Agent.CLI.Worktree
     build-depends:    agent-core >= 0.1 && < 0.2
@@ -77,6 +78,7 @@ test-suite agent-cli-test
                     , Agent.CLI.OptionsSpec
                     , Agent.CLI.PromptSpec
                     , Agent.CLI.RenderSpec
+                    , Agent.CLI.SessionSpec
                     , Agent.CLI.ToolsSpec
                     , Agent.CLI.WorktreeSpec
     build-depends:    agent-cli

--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -58,6 +58,7 @@ library
                     , process
                     , text >= 2.0 && < 2.2
                     , time
+                    , unix
 
 executable agent-cli
     import:           common-options

--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -16,6 +16,7 @@ import Agent.CLI.Render
     , renderEvent
     , summarizeToolCall
     )
+import Agent.CLI.Session
 import Agent.CLI.Tools (lookupAppTool, schemasFromAppTools)
 import Agent.CLI.Worktree (createWorktree, worktreeRoot)
 import Agent.Loop
@@ -26,6 +27,7 @@ import Agent.Provider
     ( Credential(..)
     , Provider(..)
     , getNextToken
+    , providerSlug
     )
 import Agent.ToolDispatch (ToolCall(..))
 import Agent.Tools (appToolHandlers, codingToolsFor)
@@ -42,9 +44,11 @@ import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
 import Data.Time.Clock (getCurrentTime, utctDay)
+import Data.Time.Format (defaultTimeLocale, formatTime)
 import qualified Data.Aeson.KeyMap as KeyMap
 import System.Directory (getCurrentDirectory, getHomeDirectory, makeAbsolute, setCurrentDirectory)
 import System.Environment (getArgs, lookupEnv)
+import System.FilePath ((</>))
 import System.Exit (die, exitFailure)
 import System.IO (hFlush, hIsTerminalDevice, hPutStrLn, isEOF, stderr, stdin, stdout)
 
@@ -55,52 +59,172 @@ run = do
         Left err -> die err
         Right ShowHelp -> putStr usage
         Right ShowVersion -> putStrLn "agent-cli 0.1.0.0"
+        Right ListSessions -> runListSessions
+        Right (ShowSession sessionId) -> runShowSession sessionId
         Right (RunAgent options) -> runAgent options
+
+runListSessions :: IO ()
+runListSessions = do
+    home <- getHomeDirectory
+    sessions <- listSessions (sessionsRoot home)
+    if null sessions
+        then putStrLn "No sessions in ~/.haskell-agent/sessions"
+        else mapM_ printSessionSummary sessions
+
+runShowSession :: Text -> IO ()
+runShowSession sessionId = do
+    home <- getHomeDirectory
+    loadSession (sessionsRoot home) sessionId >>= \case
+        Left err -> die err
+        Right (meta, turns) -> do
+            printSessionSummary meta
+            putStrLn ""
+            if null turns
+                then putStrLn "(empty transcript)"
+                else mapM_ printTurn turns
+
+printSessionSummary :: SessionMeta -> IO ()
+printSessionSummary meta =
+    putStrLn $ Text.unpack $ Text.intercalate "  "
+        [ meta.metaId
+        , Text.pack (formatTime defaultTimeLocale "%Y-%m-%d %H:%M" meta.metaUpdatedAt)
+        , providerSlug meta.metaProvider
+        , meta.metaModel
+        , meta.metaTitle
+        ]
+
+printTurn :: SessionTurn -> IO ()
+printTurn turn = do
+    Text.putStrLn ("user> " <> turn.turnUserText)
+    case turn.turnAssistantText of
+        Just text | not (Text.null (Text.strip text)) ->
+            Text.putStrLn ("assistant> " <> text)
+        _ -> pure ()
+    putStrLn ""
 
 runAgent :: CliOptions -> IO ()
 runAgent options = do
+    home <- getHomeDirectory
+    let root = sessionsRoot home
+    resumed <- case options.optResume of
+        Nothing -> pure Nothing
+        Just sessionId ->
+            loadSession root sessionId >>= \case
+                Left err -> die err
+                Right loaded -> pure (Just loaded)
+
     source <- maybe getCurrentDirectory makeAbsolute options.optCwd
-    cwd <- if options.optWorktree
-        then do
-            home <- getHomeDirectory
-            createWorktree source (worktreeRoot home) >>= either die \path -> do
-                hPutStrLn stderr ("worktree: " <> path)
-                pure path
-        else pure source
+    cwd <- case resumed of
+        Just (meta, _)
+            | isJustCwd options -> pure source
+            | otherwise -> makeAbsolute meta.metaCwd
+        Nothing
+            | options.optWorktree -> do
+                createWorktree source (worktreeRoot home) >>= either die \path -> do
+                    hPutStrLn stderr ("worktree: " <> path)
+                    pure path
+            | otherwise -> pure source
     setCurrentDirectory cwd
+
     isTty <- hIsTerminalDevice stdin
-    loaded <- loadAuth options.optProvider >>= either die pure
+    let requestedProvider = case resumed of
+            Just (meta, _) -> Just meta.metaProvider
+            Nothing -> options.optProvider
+    loaded <- loadAuth requestedProvider >>= either die pure
+    case resumed of
+        Just (meta, _)
+            | loaded.loadedProvider /= meta.metaProvider ->
+                die $ "session provider is "
+                    <> Text.unpack (providerSlug meta.metaProvider)
+                    <> " but auth resolved "
+                    <> Text.unpack (providerSlug loaded.loadedProvider)
+            | otherwise -> pure ()
+        Nothing -> pure ()
+
     (tools, closeTools) <- codingToolsFor loaded.loadedProvider (defaultToolEnv cwd)
     flip finally closeTools do
         today <- utctDay <$> getCurrentTime
         let provider = loaded.loadedProvider
-            model = fromMaybe (defaultModelFor provider) options.optModel
+            model = fromMaybe
+                (maybe (defaultModelFor provider) (.metaModel) (fst <$> resumed))
+                options.optModel
             instructions = systemPrompt provider cwd today (isOneShot options)
-            effort = fromMaybe (defaultEffortFor provider) options.optEffort
+            effort = fromMaybe
+                (maybe (defaultEffortFor provider) (.metaEffort) (fst <$> resumed))
+                options.optEffort
             params = requestParams model instructions
                 (schemasFromAppTools provider tools) effort
             policy = resolveApprovalPolicy options isTty
+            initialItems = maybe [] (concatMap (.turnItems) . snd) resumed
+            initialPrevious = resumed >>= \(meta, _) -> meta.metaLastResponseId
         paramsRef <- newIORef params
+        transcriptRef <- newIORef initialItems
         prompt <- loadPrompt options
+
+        persist <- preparePersistence options root provider model cwd effort prompt resumed
         case provider of
             OpenAIProvider ->
                 try @CodexAuthFailed
                     (withCodexWsWithProvider loaded.loadedTokenProvider \conn _credential ->
-                        runSession options policy tools prompt paramsRef
-                            (openAiBackend conn (readIORef paramsRef)))
+                        runSession options policy tools prompt paramsRef transcriptRef
+                            initialPrevious persist
+                            (openAiBackend conn (readIORef paramsRef) transcriptRef))
                     >>= \case
                         Left (CodexAuthFailed err) -> die ("openai auth: " <> show err)
                         Right () -> pure ()
             XAIProvider -> do
                 xaiOptions <- XAI.clientOptionsFromEnv
                 credential <- firstCredential loaded
-                backend <- xaiBackend xaiOptions credential (readIORef paramsRef)
-                runSession options policy tools prompt paramsRef backend
+                let backend = xaiBackend xaiOptions credential (readIORef paramsRef) transcriptRef
+                runSession options policy tools prompt paramsRef transcriptRef
+                    initialPrevious persist backend
             OpenRouterProvider -> do
                 openRouterOptions <- OpenRouter.clientOptionsFromEnv
                 credential <- firstCredential loaded
-                backend <- openRouterBackend openRouterOptions credential (readIORef paramsRef)
-                runSession options policy tools prompt paramsRef backend
+                let backend =
+                        openRouterBackend openRouterOptions credential
+                            (readIORef paramsRef) transcriptRef
+                runSession options policy tools prompt paramsRef transcriptRef
+                    initialPrevious persist backend
+
+preparePersistence
+    :: CliOptions
+    -> FilePath
+    -> Provider
+    -> Text
+    -> FilePath
+    -> Text
+    -> Maybe Text
+    -> Maybe (SessionMeta, [SessionTurn])
+    -> IO (Maybe (IORef SessionHandle))
+preparePersistence options root provider model cwd effort prompt resumed =
+    case resumed of
+        Just (meta, _) -> do
+            let handle = SessionHandle
+                    { sessionDir = root </> Text.unpack meta.metaId
+                    , sessionMetaPath = root </> Text.unpack meta.metaId </> "meta.json"
+                    , sessionTranscriptPath =
+                        root </> Text.unpack meta.metaId </> "transcript.jsonl"
+                    , sessionMeta = meta
+                    }
+            hPutStrLn stderr ("session: " <> Text.unpack meta.metaId <> " (resumed)")
+            Just <$> newIORef handle
+        Nothing
+            | shouldPersist options -> do
+                handle <- createSession root provider model cwd effort
+                    (sessionTitleFromPrompt <$> prompt)
+                hPutStrLn stderr ("session: " <> Text.unpack handle.sessionMeta.metaId)
+                Just <$> newIORef handle
+            | otherwise -> pure Nothing
+
+shouldPersist :: CliOptions -> Bool
+shouldPersist options = not (isOneShot options) || options.optSaveSession
+
+isJustCwd :: CliOptions -> Bool
+isJustCwd options = case options.optCwd of
+    Just _ -> True
+    Nothing -> False
+
 
 runSession
     :: CliOptions
@@ -108,14 +232,17 @@ runSession
     -> [AppTool]
     -> Maybe Text
     -> IORef ResponseCreateParams
+    -> IORef [ResponseItem]
+    -> Maybe Text
+    -> Maybe (IORef SessionHandle)
     -> Backend
     -> IO ()
-runSession options policy tools prompt paramsRef backend = do
+runSession options policy tools prompt paramsRef transcriptRef initialPrevious persist backend = do
     printed <- newIORef False
     textBuffer <- newIORef ""
     thinkingVisible <- newIORef False
     ioLock <- newMVar ()
-    previous <- newIORef Nothing
+    previous <- newIORef initialPrevious
     policyRef <- newIORef policy
     stdoutTty <- hIsTerminalDevice stdout
     stderrTty <- hIsTerminalDevice stderr
@@ -143,9 +270,10 @@ runSession options policy tools prompt paramsRef backend = do
             }
     case prompt of
         Just text -> do
-            ok <- runOneTurn config render previous printed text
+            ok <- runOneTurn config render previous printed transcriptRef persist text
             if ok then putTrailingNewline printed else exitFailure
-        Nothing -> repl config render previous printed paramsRef policyRef
+        Nothing ->
+            repl config render previous printed paramsRef policyRef transcriptRef persist
 
 repl
     :: LoopConfig
@@ -154,8 +282,10 @@ repl
     -> IORef Bool
     -> IORef ResponseCreateParams
     -> IORef ApprovalPolicy
+    -> IORef [ResponseItem]
+    -> Maybe (IORef SessionHandle)
     -> IO ()
-repl config render previous printed paramsRef policyRef = do
+repl config render previous printed paramsRef policyRef transcriptRef persist = do
     putStr "agent> "
     hFlush stdout
     done <- isEOF
@@ -169,7 +299,8 @@ repl config render previous printed paramsRef policyRef = do
                     ReplQuit -> pure ()
                     ReplPrompt text -> do
                         writeIORef printed False
-                        _ <- runOneTurn config render previous printed text
+                        _ <- runOneTurn config render previous printed
+                            transcriptRef persist text
                         putTrailingNewline printed
                         continue
                     ReplShowEffort -> do
@@ -179,25 +310,42 @@ repl config render previous printed paramsRef policyRef = do
                     ReplSetEffort level -> do
                         modifyIORef' paramsRef (setReasoningEffort level)
                         Text.putStrLn ("effort set to " <> level)
+                        case persist of
+                            Nothing -> pure ()
+                            Just handleRef -> do
+                                handle <- readIORef handleRef
+                                let meta = handle.sessionMeta { metaEffort = level }
+                                writeSessionMeta handle.sessionMetaPath meta
+                                writeIORef handleRef handle { sessionMeta = meta }
                         continue
                     ReplToggleAlwaysApprove -> do
                         toggleAlwaysApprove policyRef
+                        continue
+                    ReplShowSession -> do
+                        case persist of
+                            Nothing -> Text.putStrLn "session: (not persisted)"
+                            Just handleRef -> do
+                                handle <- readIORef handleRef
+                                Text.putStrLn ("session: " <> handle.sessionMeta.metaId)
                         continue
                     ReplCommandError err -> do
                         Text.hPutStrLn stderr err
                         continue
   where
-    continue = repl config render previous printed paramsRef policyRef
+    continue = repl config render previous printed paramsRef policyRef transcriptRef persist
 
 runOneTurn
     :: LoopConfig
     -> RenderConfig
     -> IORef (Maybe Text)
     -> IORef Bool
+    -> IORef [ResponseItem]
+    -> Maybe (IORef SessionHandle)
     -> Text
     -> IO Bool
-runOneTurn config render previous printed prompt = do
+runOneTurn config render previous printed transcriptRef persist prompt = do
     prev <- readIORef previous
+    beforeItems <- readIORef transcriptRef
     result <- runLoop config prev prompt
     clearThinking render
     case result of
@@ -214,6 +362,22 @@ runOneTurn config render previous printed prompt = do
                     let useColor = color && maybe True (\_ -> False) noColor
                     putTextLn stdout (renderAssistantText useColor text)
                 _ -> pure ()
+            afterItems <- readIORef transcriptRef
+            let newItems = drop (length beforeItems) afterItems
+            case persist of
+                Nothing -> pure ()
+                Just handleRef -> do
+                    now <- getCurrentTime
+                    handle <- readIORef handleRef
+                    let turn = SessionTurn
+                            { turnAt = now
+                            , turnUserText = prompt
+                            , turnAssistantText = loopResult.finalText
+                            , turnResponseId = Just loopResult.finalResponseId
+                            , turnItems = newItems
+                            }
+                    handle' <- appendTurn handle turn
+                    writeIORef handleRef handle'
             pure True
 
 putTrailingNewline :: IORef Bool -> IO ()

--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -152,7 +152,7 @@ runAgent options = do
             effort = fromMaybe
                 (maybe (defaultEffortFor provider) (.metaEffort) (fst <$> resumed))
                 options.optEffort
-            params = requestParams model instructions
+            params = requestParams provider model instructions
                 (schemasFromAppTools provider tools) effort
             policy = resolveApprovalPolicy options isTty
             initialItems = maybe [] (concatMap (.turnItems) . snd) resumed
@@ -196,7 +196,7 @@ preparePersistence
     -> Text
     -> Maybe Text
     -> Maybe (SessionMeta, [SessionTurn])
-    -> IO (Maybe (IORef SessionHandle))
+    -> IO (Maybe (IORef (Either SessionCreate SessionHandle)))
 preparePersistence options root provider model cwd effort prompt resumed =
     case resumed of
         Just (meta, _) -> do
@@ -208,14 +208,25 @@ preparePersistence options root provider model cwd effort prompt resumed =
                     , sessionMeta = meta
                     }
             hPutStrLn stderr ("session: " <> Text.unpack meta.metaId <> " (resumed)")
-            Just <$> newIORef handle
+            Just <$> newIORef (Right handle)
         Nothing
-            | shouldPersist options -> do
-                handle <- createSession root provider model cwd effort
-                    (sessionTitleFromPrompt <$> prompt)
-                hPutStrLn stderr ("session: " <> Text.unpack handle.sessionMeta.metaId)
-                Just <$> newIORef handle
+            | shouldPersist options ->
+                -- Defer directory creation until the first successful turn so
+                -- an abandoned REPL does not leave empty session folders.
+                Just <$> newIORef (Left SessionCreate
+                    { createRoot = root
+                    , createProvider = provider
+                    , createModel = model
+                    , createCwd = cwd
+                    , createEffort = effort
+                    , createTitleHint = sessionTitleFromPrompt <$> prompt
+                    })
             | otherwise -> pure Nothing
+
+isLeftSlot :: Either a b -> Bool
+isLeftSlot = \case
+    Left _ -> True
+    Right _ -> False
 
 shouldPersist :: CliOptions -> Bool
 shouldPersist options = not (isOneShot options) || options.optSaveSession
@@ -234,7 +245,7 @@ runSession
     -> IORef ResponseCreateParams
     -> IORef [ResponseItem]
     -> Maybe Text
-    -> Maybe (IORef SessionHandle)
+    -> Maybe (IORef (Either SessionCreate SessionHandle))
     -> Backend
     -> IO ()
 runSession options policy tools prompt paramsRef transcriptRef initialPrevious persist backend = do
@@ -283,7 +294,7 @@ repl
     -> IORef ResponseCreateParams
     -> IORef ApprovalPolicy
     -> IORef [ResponseItem]
-    -> Maybe (IORef SessionHandle)
+    -> Maybe (IORef (Either SessionCreate SessionHandle))
     -> IO ()
 repl config render previous printed paramsRef policyRef transcriptRef persist = do
     putStr "agent> "
@@ -312,11 +323,17 @@ repl config render previous printed paramsRef policyRef transcriptRef persist = 
                         Text.putStrLn ("effort set to " <> level)
                         case persist of
                             Nothing -> pure ()
-                            Just handleRef -> do
-                                handle <- readIORef handleRef
-                                let meta = handle.sessionMeta { metaEffort = level }
-                                writeSessionMeta handle.sessionMetaPath meta
-                                writeIORef handleRef handle { sessionMeta = meta }
+                            Just slotRef -> do
+                                slot <- readIORef slotRef
+                                case slot of
+                                    Left pending ->
+                                        writeIORef slotRef
+                                            (Left pending { createEffort = level })
+                                    Right handle -> do
+                                        let meta = handle.sessionMeta { metaEffort = level }
+                                        writeSessionMeta handle.sessionMetaPath meta
+                                        writeIORef slotRef
+                                            (Right handle { sessionMeta = meta })
                         continue
                     ReplToggleAlwaysApprove -> do
                         toggleAlwaysApprove policyRef
@@ -324,9 +341,15 @@ repl config render previous printed paramsRef policyRef transcriptRef persist = 
                     ReplShowSession -> do
                         case persist of
                             Nothing -> Text.putStrLn "session: (not persisted)"
-                            Just handleRef -> do
-                                handle <- readIORef handleRef
-                                Text.putStrLn ("session: " <> handle.sessionMeta.metaId)
+                            Just slotRef -> do
+                                slot <- readIORef slotRef
+                                case slot of
+                                    Left _ ->
+                                        Text.putStrLn
+                                            "session: (pending until first turn)"
+                                    Right handle ->
+                                        Text.putStrLn
+                                            ("session: " <> handle.sessionMeta.metaId)
                         continue
                     ReplCommandError err -> do
                         Text.hPutStrLn stderr err
@@ -340,7 +363,7 @@ runOneTurn
     -> IORef (Maybe Text)
     -> IORef Bool
     -> IORef [ResponseItem]
-    -> Maybe (IORef SessionHandle)
+    -> Maybe (IORef (Either SessionCreate SessionHandle))
     -> Text
     -> IO Bool
 runOneTurn config render previous printed transcriptRef persist prompt = do
@@ -366,9 +389,14 @@ runOneTurn config render previous printed transcriptRef persist prompt = do
             let newItems = drop (length beforeItems) afterItems
             case persist of
                 Nothing -> pure ()
-                Just handleRef -> do
+                Just slotRef -> do
                     now <- getCurrentTime
-                    handle <- readIORef handleRef
+                    created <- isLeftSlot <$> readIORef slotRef
+                    handle <- ensureSession slotRef
+                    if created
+                        then hPutStrLn stderr
+                            ("session: " <> Text.unpack handle.sessionMeta.metaId)
+                        else pure ()
                     let turn = SessionTurn
                             { turnAt = now
                             , turnUserText = prompt
@@ -377,7 +405,7 @@ runOneTurn config render previous printed transcriptRef persist prompt = do
                             , turnItems = newItems
                             }
                     handle' <- appendTurn handle turn
-                    writeIORef handleRef handle'
+                    writeIORef slotRef (Right handle')
             pure True
 
 putTrailingNewline :: IORef Bool -> IO ()
@@ -432,13 +460,16 @@ toggleAlwaysApprove policyRef = do
         _ -> "auto-approve off")
 
 -- | Rebuild from the constructor: 'input' is also a field on 'CustomToolCall'.
+-- OpenAI keeps @store = true@ so @previous_response_id@ can continue a chain;
+-- xAI/OpenRouter force @store = false@ and replay local transcripts instead.
 requestParams
-    :: Text
+    :: Provider
+    -> Text
     -> Text
     -> [ResponseTool]
     -> Text
     -> ResponseCreateParams
-requestParams modelName instructionText toolSchemas effort =
+requestParams provider modelName instructionText toolSchemas effort =
     case defaultResponseCreateParams of
         ResponseCreateParams{..} ->
             ResponseCreateParams
@@ -453,6 +484,6 @@ requestParams modelName instructionText toolSchemas effort =
                     , summary = Nothing
                     , extraFields = KeyMap.empty
                     }
-                , store = Just False
+                , store = Just (provider == OpenAIProvider)
                 , ..
                 }

--- a/packages/agent-cli/src/Agent/CLI/Command.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command.hs
@@ -19,6 +19,7 @@ data ReplAction
     | ReplShowEffort
     | ReplSetEffort Text
     | ReplToggleAlwaysApprove
+    | ReplShowSession
     | ReplCommandError Text
     deriving (Eq, Show)
 
@@ -42,6 +43,10 @@ parseSlash line = case Text.words line of
     [] -> ReplCommandError "unknown command: /"
     command : args
         | Text.toLower command == "/effort" -> parseEffortCommand args
+        | Text.toLower command == "/session" ->
+            if null args
+                then ReplShowSession
+                else ReplCommandError "usage: /session"
         | isAlwaysApproveAlias (Text.drop 1 command) ->
             if null args
                 then ReplToggleAlwaysApprove

--- a/packages/agent-cli/src/Agent/CLI/Options.hs
+++ b/packages/agent-cli/src/Agent/CLI/Options.hs
@@ -22,6 +22,8 @@ import qualified Data.Text as Text
 data Command
     = ShowHelp
     | ShowVersion
+    | ListSessions
+    | ShowSession Text
     | RunAgent CliOptions
     deriving (Eq, Show)
 
@@ -60,6 +62,8 @@ data CliOptions = CliOptions
       -- ^ 'Nothing' means use 'defaultEffortFor' once the provider is known.
     , optPrompt :: !(Maybe Text)
     , optPromptFile :: !(Maybe FilePath)
+    , optResume :: !(Maybe Text)
+    , optSaveSession :: !Bool
     } deriving (Eq, Show)
 
 defaultCliOptions :: CliOptions
@@ -74,6 +78,8 @@ defaultCliOptions = CliOptions
     , optEffort = Nothing
     , optPrompt = Nothing
     , optPromptFile = Nothing
+    , optResume = Nothing
+    , optSaveSession = False
     }
 
 -- | Provider default when @--effort@ is omitted. Grok runs at high effort.
@@ -100,7 +106,18 @@ parseArgs args
     | any (`elem` ["--help", "-h"]) args = Right ShowHelp
     | "--version" `elem` args = Right ShowVersion
     | take 1 args == ["login"] = Left loginHint
+    | take 1 args == ["sessions"] = parseSessionsCommand (drop 1 args)
     | otherwise = RunAgent <$> parseOptions defaultCliOptions args
+
+parseSessionsCommand :: [String] -> Either String Command
+parseSessionsCommand = \case
+    [] -> Right ListSessions
+    ["list"] -> Right ListSessions
+    ["show", sessionId] -> Right (ShowSession (Text.pack sessionId))
+    ["show"] -> Left "usage: agent-cli sessions show <session-id>"
+    other ->
+        Left ("unknown sessions command: " <> unwords other
+            <> "\nusage: agent-cli sessions [list|show <id>]")
 
 parseOptions :: CliOptions -> [String] -> Either String CliOptions
 parseOptions options = \case
@@ -135,6 +152,10 @@ parseOptions options = \case
         parseOptions options { optPrompt = Just (Text.pack value) } rest
     "--prompt-file" : value : rest ->
         parseOptions options { optPromptFile = Just value } rest
+    "--resume" : value : rest ->
+        parseOptions options { optResume = Just (Text.pack value) } rest
+    "--save-session" : rest ->
+        parseOptions options { optSaveSession = True } rest
     flag : _
         | flag == "openai-base-url" ->
             Left "openai-base-url was removed; run agent-cli --help"
@@ -149,6 +170,8 @@ validate options
         Left "use either -p/--prompt or --prompt-file, not both"
     | options.optMaxTurns < 1 =
         Left "--max-turns must be at least 1"
+    | isJust options.optResume && options.optWorktree =
+        Left "use either --resume or --worktree, not both"
     | otherwise = Right options
 
 parseInt :: String -> String -> Either String Int
@@ -173,6 +196,8 @@ loginHint =
 usage :: String
 usage = unlines
     [ "Usage: agent-cli [OPTIONS]"
+    , "       agent-cli sessions [list]"
+    , "       agent-cli sessions show <session-id>"
     , ""
     , "  -p, --prompt TEXT       Run one prompt and exit"
     , "      --prompt-file FILE  Read the one-shot prompt from a file"
@@ -180,6 +205,8 @@ usage = unlines
     , "      --model NAME        Override the provider default model"
     , "      --cwd DIR           Working directory for tools (default: current)"
     , "      --worktree          Create a new git worktree under ~/.haskell-agent/worktrees"
+    , "      --resume ID         Resume a persisted session from ~/.haskell-agent/sessions"
+    , "      --save-session      Persist a one-shot (-p) run as a session"
     , "      --yolo              Auto-approve every tool"
     , "      --no-yolo           Never auto-approve; deny mutating tools without a TTY"
     , "      --max-turns N       Stop after N model turns (default: 50)"
@@ -188,7 +215,8 @@ usage = unlines
     , "      --version           Print the agent-cli version"
     , "      --help              Show this help"
     , ""
-    , "Without -p/--prompt-file, start a REPL. /effort [LEVEL] changes"
+    , "Without -p/--prompt-file, start a REPL. Interactive REPL sessions are"
+    , "persisted under ~/.haskell-agent/sessions. /effort [LEVEL] changes"
     , "reasoning effort. /always-approve (or :yolo) toggles auto-approve."
-    , "Ctrl-D or :q exits."
+    , "/session prints the current session id. Ctrl-D or :q exits."
     ]

--- a/packages/agent-cli/src/Agent/CLI/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session.hs
@@ -3,6 +3,7 @@ module Agent.CLI.Session
     ( SessionHandle(..)
     , SessionMeta(..)
     , SessionTurn(..)
+    , SessionCreate(..)
     , createSession
     , appendTurn
     , loadSession
@@ -10,6 +11,7 @@ module Agent.CLI.Session
     , sessionsRoot
     , sessionTitleFromPrompt
     , writeSessionMeta
+    , ensureSession
     ) where
 
 import Agent.OpenAI.Responses.Types (ResponseItem)
@@ -19,6 +21,7 @@ import Control.Exception (try)
 import Data.Aeson (FromJSON(..), ToJSON(..), object, withObject, (.:), (.:?), (.=))
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy as LBS
+import Data.IORef
 import Data.List (sortOn)
 import Data.Maybe (catMaybes, fromMaybe)
 import Data.Ord (Down(..))
@@ -31,7 +34,8 @@ import Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds)
 import Data.Time.Format (defaultTimeLocale, formatTime)
 import Numeric (showHex)
 import System.Directory
-    ( createDirectoryIfMissing
+    ( createDirectory
+    , createDirectoryIfMissing
     , doesDirectoryExist
     , doesFileExist
     , listDirectory
@@ -39,6 +43,7 @@ import System.Directory
     , renameFile
     )
 import System.FilePath ((</>))
+import System.Posix.Files (setFileMode)
 
 sessionSchemaVersion :: Int
 sessionSchemaVersion = 1
@@ -125,29 +130,33 @@ data SessionHandle = SessionHandle
     , sessionMeta :: !SessionMeta
     } deriving (Eq, Show)
 
-createSession
-    :: FilePath
-    -> Provider
-    -> Text
-    -> FilePath
-    -> Text
-    -> Maybe Text
-    -> IO SessionHandle
-createSession root provider model cwd effort titleHint = do
-    createDirectoryIfMissing True root
+-- | Parameters for creating a session on the first persisted turn.
+data SessionCreate = SessionCreate
+    { createRoot :: !FilePath
+    , createProvider :: !Provider
+    , createModel :: !Text
+    , createCwd :: !FilePath
+    , createEffort :: !Text
+    , createTitleHint :: !(Maybe Text)
+    } deriving (Eq, Show)
+
+createSession :: SessionCreate -> IO SessionHandle
+createSession spec = do
+    ensurePrivateDir spec.createRoot
     now <- getCurrentTime
-    sessionId <- allocateSessionId root now
-    let dir = root </> Text.unpack sessionId
-        title = fromMaybe "untitled" titleHint
+    (sessionId, dir) <- allocateSessionDir spec.createRoot now
+    let title = case spec.createTitleHint of
+            Just hint | not (Text.null hint) -> hint
+            _ -> "untitled"
         meta = SessionMeta
             { metaVersion = sessionSchemaVersion
             , metaId = sessionId
             , metaCreatedAt = now
             , metaUpdatedAt = now
-            , metaProvider = provider
-            , metaModel = model
-            , metaCwd = cwd
-            , metaEffort = effort
+            , metaProvider = spec.createProvider
+            , metaModel = spec.createModel
+            , metaCwd = spec.createCwd
+            , metaEffort = spec.createEffort
             , metaTitle = title
             , metaLastResponseId = Nothing
             }
@@ -157,13 +166,26 @@ createSession root provider model cwd effort titleHint = do
             , sessionTranscriptPath = dir </> "transcript.jsonl"
             , sessionMeta = meta
             }
-    createDirectoryIfMissing True dir
     writeSessionMeta handle.sessionMetaPath meta
     pure handle
 
+-- | Create the session directory on first use when the slot is still pending.
+ensureSession :: IORef (Either SessionCreate SessionHandle) -> IO SessionHandle
+ensureSession slotRef = do
+    slot <- readIORef slotRef
+    case slot of
+        Right handle -> pure handle
+        Left spec -> do
+            handle <- createSession spec
+            writeIORef slotRef (Right handle)
+            pure handle
+
 appendTurn :: SessionHandle -> SessionTurn -> IO SessionHandle
 appendTurn handle turn = do
-    LBS.appendFile handle.sessionTranscriptPath (Aeson.encode turn <> "\n")
+    let path = handle.sessionTranscriptPath
+    existed <- doesFileExist path
+    LBS.appendFile path (Aeson.encode turn <> "\n")
+    if existed then pure () else setFileMode path 0o600
     now <- getCurrentTime
     let meta0 = handle.sessionMeta
         meta = meta0
@@ -189,9 +211,17 @@ loadSession root sessionId = do
             metaResult <- decodeFileEither metaPath
             case metaResult of
                 Left err -> pure (Left err)
-                Right meta -> do
-                    turnsResult <- loadTranscript transcriptPath
-                    pure ((meta,) <$> turnsResult)
+                Right meta
+                    | meta.metaVersion /= sessionSchemaVersion ->
+                        pure $ Left $
+                            "unsupported session schema version "
+                                <> show meta.metaVersion
+                                <> " (expected "
+                                <> show sessionSchemaVersion
+                                <> ")"
+                    | otherwise -> do
+                        turnsResult <- loadTranscript transcriptPath
+                        pure ((meta,) <$> turnsResult)
 
 listSessions :: FilePath -> IO [SessionMeta]
 listSessions root = do
@@ -207,7 +237,9 @@ writeSessionMeta :: FilePath -> SessionMeta -> IO ()
 writeSessionMeta path meta = do
     let tmp = path <> ".tmp"
     LBS.writeFile tmp (Aeson.encode meta)
+    setFileMode tmp 0o600
     renameOrReplace tmp path
+    setFileMode path 0o600
 
 sessionTitleFromPrompt :: Text -> Text
 sessionTitleFromPrompt prompt =
@@ -216,8 +248,8 @@ sessionTitleFromPrompt prompt =
         then oneLine
         else Text.take 69 oneLine <> "..."
 
-allocateSessionId :: FilePath -> UTCTime -> IO Text
-allocateSessionId root now = go (0 :: Int)
+allocateSessionDir :: FilePath -> UTCTime -> IO (Text, FilePath)
+allocateSessionDir root now = go (0 :: Int)
   where
     day = formatTime defaultTimeLocale "%Y-%m-%d" now
     start = floor (nominalDiffTimeToSeconds (utcTimeToPOSIXSeconds now) * 1000000) :: Integer
@@ -227,13 +259,23 @@ allocateSessionId root now = go (0 :: Int)
             let hex = hex8 (start + fromIntegral attempt)
                 sessionId = Text.pack (day <> "-" <> hex)
                 dir = root </> Text.unpack sessionId
-            exists <- doesDirectoryExist dir
-            if exists then go (attempt + 1) else pure sessionId
+            result <- try @IOError (createDirectory dir)
+            case result of
+                Left _ -> go (attempt + 1)
+                Right () -> do
+                    setFileMode dir 0o700
+                    pure (sessionId, dir)
 
 hex8 :: Integer -> String
 hex8 n =
     let s = showHex (n `mod` 0x100000000) ""
     in replicate (8 - length s) '0' <> s
+
+ensurePrivateDir :: FilePath -> IO ()
+ensurePrivateDir path = do
+    createDirectoryIfMissing True path
+    _ <- try @IOError (setFileMode path 0o700)
+    pure ()
 
 loadTranscript :: FilePath -> IO (Either String [SessionTurn])
 loadTranscript path = do
@@ -269,7 +311,9 @@ readMetaQuiet root name = do
     pure $ case result of
         Left _ -> Nothing
         Right (Left _) -> Nothing
-        Right (Right meta) -> Just meta
+        Right (Right meta)
+            | meta.metaVersion == sessionSchemaVersion -> Just meta
+            | otherwise -> Nothing
 
 renameOrReplace :: FilePath -> FilePath -> IO ()
 renameOrReplace tmp path = do

--- a/packages/agent-cli/src/Agent/CLI/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session.hs
@@ -1,0 +1,283 @@
+-- | Persist REPL conversations under @~/.haskell-agent/sessions@.
+module Agent.CLI.Session
+    ( SessionHandle(..)
+    , SessionMeta(..)
+    , SessionTurn(..)
+    , createSession
+    , appendTurn
+    , loadSession
+    , listSessions
+    , sessionsRoot
+    , sessionTitleFromPrompt
+    , writeSessionMeta
+    ) where
+
+import Agent.OpenAI.Responses.Types (ResponseItem)
+import Agent.Provider (Provider(..), parseProvider, providerSlug)
+import Control.Applicative ((<|>))
+import Control.Exception (try)
+import Data.Aeson (FromJSON(..), ToJSON(..), object, withObject, (.:), (.:?), (.=))
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString.Lazy as LBS
+import Data.List (sortOn)
+import Data.Maybe (catMaybes, fromMaybe)
+import Data.Ord (Down(..))
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
+import qualified Data.Text.IO as Text
+import Data.Time.Clock (UTCTime, getCurrentTime, nominalDiffTimeToSeconds)
+import Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds)
+import Data.Time.Format (defaultTimeLocale, formatTime)
+import Numeric (showHex)
+import System.Directory
+    ( createDirectoryIfMissing
+    , doesDirectoryExist
+    , doesFileExist
+    , listDirectory
+    , removeFile
+    , renameFile
+    )
+import System.FilePath ((</>))
+
+sessionSchemaVersion :: Int
+sessionSchemaVersion = 1
+
+-- | @~/.haskell-agent/sessions@ given the user's home directory.
+sessionsRoot :: FilePath -> FilePath
+sessionsRoot home = home </> ".haskell-agent" </> "sessions"
+
+data SessionMeta = SessionMeta
+    { metaVersion :: !Int
+    , metaId :: !Text
+    , metaCreatedAt :: !UTCTime
+    , metaUpdatedAt :: !UTCTime
+    , metaProvider :: !Provider
+    , metaModel :: !Text
+    , metaCwd :: !FilePath
+    , metaEffort :: !Text
+    , metaTitle :: !Text
+    , metaLastResponseId :: !(Maybe Text)
+    } deriving (Eq, Show)
+
+instance ToJSON SessionMeta where
+    toJSON meta = object
+        [ "version" .= meta.metaVersion
+        , "id" .= meta.metaId
+        , "createdAt" .= meta.metaCreatedAt
+        , "updatedAt" .= meta.metaUpdatedAt
+        , "provider" .= providerSlug meta.metaProvider
+        , "model" .= meta.metaModel
+        , "cwd" .= meta.metaCwd
+        , "effort" .= meta.metaEffort
+        , "title" .= meta.metaTitle
+        , "lastResponseId" .= meta.metaLastResponseId
+        ]
+
+instance FromJSON SessionMeta where
+    parseJSON = withObject "SessionMeta" \o -> do
+        version <- o .: "version"
+        providerText <- o .: "provider"
+        provider <- case parseProvider providerText of
+            Just p -> pure p
+            Nothing -> fail ("unknown provider: " <> Text.unpack providerText)
+        SessionMeta version
+            <$> o .: "id"
+            <*> o .: "createdAt"
+            <*> o .: "updatedAt"
+            <*> pure provider
+            <*> o .: "model"
+            <*> o .: "cwd"
+            <*> o .: "effort"
+            <*> o .: "title"
+            <*> o .:? "lastResponseId"
+
+data SessionTurn = SessionTurn
+    { turnAt :: !UTCTime
+    , turnUserText :: !Text
+    , turnAssistantText :: !(Maybe Text)
+    , turnResponseId :: !(Maybe Text)
+    , turnItems :: ![ResponseItem]
+    } deriving (Eq, Show)
+
+instance ToJSON SessionTurn where
+    toJSON turn = object
+        [ "at" .= turn.turnAt
+        , "userText" .= turn.turnUserText
+        , "assistantText" .= turn.turnAssistantText
+        , "responseId" .= turn.turnResponseId
+        , "items" .= turn.turnItems
+        ]
+
+instance FromJSON SessionTurn where
+    parseJSON = withObject "SessionTurn" \o ->
+        SessionTurn
+            <$> o .: "at"
+            <*> o .: "userText"
+            <*> o .:? "assistantText"
+            <*> o .:? "responseId"
+            <*> o .: "items"
+
+data SessionHandle = SessionHandle
+    { sessionDir :: !FilePath
+    , sessionMetaPath :: !FilePath
+    , sessionTranscriptPath :: !FilePath
+    , sessionMeta :: !SessionMeta
+    } deriving (Eq, Show)
+
+createSession
+    :: FilePath
+    -> Provider
+    -> Text
+    -> FilePath
+    -> Text
+    -> Maybe Text
+    -> IO SessionHandle
+createSession root provider model cwd effort titleHint = do
+    createDirectoryIfMissing True root
+    now <- getCurrentTime
+    sessionId <- allocateSessionId root now
+    let dir = root </> Text.unpack sessionId
+        title = fromMaybe "untitled" titleHint
+        meta = SessionMeta
+            { metaVersion = sessionSchemaVersion
+            , metaId = sessionId
+            , metaCreatedAt = now
+            , metaUpdatedAt = now
+            , metaProvider = provider
+            , metaModel = model
+            , metaCwd = cwd
+            , metaEffort = effort
+            , metaTitle = title
+            , metaLastResponseId = Nothing
+            }
+        handle = SessionHandle
+            { sessionDir = dir
+            , sessionMetaPath = dir </> "meta.json"
+            , sessionTranscriptPath = dir </> "transcript.jsonl"
+            , sessionMeta = meta
+            }
+    createDirectoryIfMissing True dir
+    writeSessionMeta handle.sessionMetaPath meta
+    pure handle
+
+appendTurn :: SessionHandle -> SessionTurn -> IO SessionHandle
+appendTurn handle turn = do
+    LBS.appendFile handle.sessionTranscriptPath (Aeson.encode turn <> "\n")
+    now <- getCurrentTime
+    let meta0 = handle.sessionMeta
+        meta = meta0
+            { metaUpdatedAt = now
+            , metaLastResponseId = turn.turnResponseId <|> meta0.metaLastResponseId
+            , metaTitle =
+                if meta0.metaTitle == "untitled" && not (Text.null turn.turnUserText)
+                    then sessionTitleFromPrompt turn.turnUserText
+                    else meta0.metaTitle
+            }
+    writeSessionMeta handle.sessionMetaPath meta
+    pure handle { sessionMeta = meta }
+
+loadSession :: FilePath -> Text -> IO (Either String (SessionMeta, [SessionTurn]))
+loadSession root sessionId = do
+    let dir = root </> Text.unpack sessionId
+        metaPath = dir </> "meta.json"
+        transcriptPath = dir </> "transcript.jsonl"
+    exists <- doesDirectoryExist dir
+    if not exists
+        then pure (Left ("session not found: " <> Text.unpack sessionId))
+        else do
+            metaResult <- decodeFileEither metaPath
+            case metaResult of
+                Left err -> pure (Left err)
+                Right meta -> do
+                    turnsResult <- loadTranscript transcriptPath
+                    pure ((meta,) <$> turnsResult)
+
+listSessions :: FilePath -> IO [SessionMeta]
+listSessions root = do
+    exists <- doesDirectoryExist root
+    if not exists
+        then pure []
+        else do
+            names <- listDirectory root
+            metas <- mapM (readMetaQuiet root) names
+            pure (sortOn (Down . (.metaUpdatedAt)) (catMaybes metas))
+
+writeSessionMeta :: FilePath -> SessionMeta -> IO ()
+writeSessionMeta path meta = do
+    let tmp = path <> ".tmp"
+    LBS.writeFile tmp (Aeson.encode meta)
+    renameOrReplace tmp path
+
+sessionTitleFromPrompt :: Text -> Text
+sessionTitleFromPrompt prompt =
+    let oneLine = Text.unwords (Text.words (Text.strip prompt))
+    in if Text.length oneLine <= 72
+        then oneLine
+        else Text.take 69 oneLine <> "..."
+
+allocateSessionId :: FilePath -> UTCTime -> IO Text
+allocateSessionId root now = go (0 :: Int)
+  where
+    day = formatTime defaultTimeLocale "%Y-%m-%d" now
+    start = floor (nominalDiffTimeToSeconds (utcTimeToPOSIXSeconds now) * 1000000) :: Integer
+    go attempt
+        | attempt >= 32 = fail "could not allocate a unique session id"
+        | otherwise = do
+            let hex = hex8 (start + fromIntegral attempt)
+                sessionId = Text.pack (day <> "-" <> hex)
+                dir = root </> Text.unpack sessionId
+            exists <- doesDirectoryExist dir
+            if exists then go (attempt + 1) else pure sessionId
+
+hex8 :: Integer -> String
+hex8 n =
+    let s = showHex (n `mod` 0x100000000) ""
+    in replicate (8 - length s) '0' <> s
+
+loadTranscript :: FilePath -> IO (Either String [SessionTurn])
+loadTranscript path = do
+    exists <- doesFileExist path
+    if not exists
+        then pure (Right [])
+        else do
+            raw <- Text.readFile path
+            let linesOf = filter (not . Text.null) (Text.lines raw)
+            pure (mapM decodeTurnLine linesOf)
+
+decodeTurnLine :: Text -> Either String SessionTurn
+decodeTurnLine line =
+    case Aeson.eitherDecodeStrict' (Text.encodeUtf8 line) of
+        Left err -> Left ("invalid transcript line: " <> err)
+        Right turn -> Right turn
+
+decodeFileEither :: FromJSON a => FilePath -> IO (Either String a)
+decodeFileEither path = do
+    exists <- doesFileExist path
+    if not exists
+        then pure (Left ("missing file: " <> path))
+        else do
+            bytes <- LBS.readFile path
+            pure (case Aeson.eitherDecode' bytes of
+                Left err -> Left (path <> ": " <> err)
+                Right value -> Right value)
+
+readMetaQuiet :: FilePath -> FilePath -> IO (Maybe SessionMeta)
+readMetaQuiet root name = do
+    let path = root </> name </> "meta.json"
+    result <- try @IOError (decodeFileEither path)
+    pure $ case result of
+        Left _ -> Nothing
+        Right (Left _) -> Nothing
+        Right (Right meta) -> Just meta
+
+renameOrReplace :: FilePath -> FilePath -> IO ()
+renameOrReplace tmp path = do
+    result <- try @IOError (renameFile tmp path)
+    case result of
+        Right () -> pure ()
+        Left _ -> do
+            bytes <- LBS.readFile tmp
+            LBS.writeFile path bytes
+            _ <- try @IOError (removeFile tmp)
+            pure ()

--- a/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
@@ -39,6 +39,11 @@ spec = do
             parseReplLine "/yolo on"
                 `shouldBe` ReplCommandError "usage: /always-approve"
 
+        it "prints the current session id" do
+            parseReplLine "/session" `shouldBe` ReplShowSession
+            parseReplLine "/session now"
+                `shouldBe` ReplCommandError "usage: /session"
+
         it "rejects unknown levels, extra args, and unknown commands" do
             parseReplLine "/effort bogus"
                 `shouldBe` ReplCommandError

--- a/packages/agent-cli/test/Agent/CLI/OptionsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/OptionsSpec.hs
@@ -68,6 +68,26 @@ spec = do
         it "explains that login is not in this slice" do
             parseArgs ["login"] `shouldSatisfy` isLeft
 
+
+        it "parses sessions list and show" do
+            parseArgs ["sessions"] `shouldBe` Right ListSessions
+            parseArgs ["sessions", "list"] `shouldBe` Right ListSessions
+            parseArgs ["sessions", "show", "2026-08-19-abcd1234"]
+                `shouldBe` Right (ShowSession "2026-08-19-abcd1234")
+
+        it "parses --resume and --save-session" do
+            parseArgs ["--resume", "2026-08-19-abcd1234"]
+                `shouldBe` Right (RunAgent defaultCliOptions
+                    { optResume = Just "2026-08-19-abcd1234" })
+            parseArgs ["-p", "hi", "--save-session"]
+                `shouldBe` Right (RunAgent defaultCliOptions
+                    { optPrompt = Just "hi"
+                    , optSaveSession = True
+                    })
+
+        it "rejects --resume with --worktree" do
+            parseArgs ["--resume", "abc", "--worktree"] `shouldSatisfy` isLeft
+
     describe "resolveApprovalPolicy" do
         it "auto-approves one-shot scripts without a TTY" do
             resolveApprovalPolicy defaultCliOptions { optPrompt = Just "hi" } False

--- a/packages/agent-cli/test/Agent/CLI/SessionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SessionSpec.hs
@@ -3,20 +3,23 @@ module Agent.CLI.SessionSpec (spec) where
 import Agent.CLI.Session
 import Agent.OpenAI.Responses.Types
 import Agent.Provider (Provider(..))
+import Control.Exception (bracket)
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.KeyMap as KeyMap
-import Data.Time.Clock (UTCTime(..), secondsToDiffTime)
+import Data.IORef
+import qualified Data.Text as Text
 import Data.Time.Calendar (fromGregorian)
+import Data.Time.Clock (UTCTime(..), secondsToDiffTime)
 import System.Directory
     ( doesDirectoryExist
     , doesFileExist
     , getTemporaryDirectory
+    , listDirectory
     , removeDirectoryRecursive
     )
 import System.FilePath ((</>))
+import System.Posix.Files (fileMode, getFileStatus)
 import System.Posix.Temp (mkdtemp)
-import Control.Exception (bracket)
-import qualified Data.Text as Text
 import Test.Hspec
 
 spec :: Spec
@@ -33,12 +36,14 @@ spec = describe "Agent.CLI.Session" do
             Text.length (sessionTitleFromPrompt long) `shouldBe` 72
 
     describe "createSession/appendTurn/loadSession" do
-        it "round-trips meta and transcript items" $
+        it "round-trips meta and transcript items with private modes" $
             withTempDir "agent-sessions-" \root -> do
-                handle <- createSession root XAIProvider "grok-4" "/tmp/work" "low" Nothing
+                handle <- createSession (testCreate root)
                 doesDirectoryExist handle.sessionDir `shouldReturn` True
                 doesFileExist handle.sessionMetaPath `shouldReturn` True
                 handle.sessionMeta.metaTitle `shouldBe` "untitled"
+                modeOf handle.sessionDir `shouldReturn` 0o700
+                modeOf handle.sessionMetaPath `shouldReturn` 0o600
 
                 let item = MessageItem ResponseMessage
                         { messageId = Nothing
@@ -59,6 +64,7 @@ spec = describe "Agent.CLI.Session" do
                 handle' <- appendTurn handle turn
                 handle'.sessionMeta.metaTitle `shouldBe` "hi there"
                 handle'.sessionMeta.metaLastResponseId `shouldBe` Just "resp-1"
+                modeOf handle.sessionTranscriptPath `shouldReturn` 0o600
 
                 loaded <- loadSession root handle.sessionMeta.metaId
                 case loaded of
@@ -79,6 +85,25 @@ spec = describe "Agent.CLI.Session" do
                 listed <- listSessions root
                 map (.metaId) listed `shouldBe` [handle.sessionMeta.metaId]
 
+        it "rejects unsupported schema versions" $
+            withTempDir "agent-sessions-" \root -> do
+                handle <- createSession (testCreate root)
+                let bad = handle.sessionMeta { metaVersion = 99 }
+                writeSessionMeta handle.sessionMetaPath bad
+                loadSession root handle.sessionMeta.metaId
+                    >>= \case
+                        Left err -> err `shouldContain` "unsupported session schema"
+                        Right _ -> expectationFailure "expected schema failure"
+
+        it "creates a pending session only when ensureSession runs" $
+            withTempDir "agent-sessions-" \root -> do
+                slot <- newIORef (Left (testCreate root))
+                listDirectory root `shouldReturn` []
+                handle <- ensureSession slot
+                doesDirectoryExist handle.sessionDir `shouldReturn` True
+                Right again <- readIORef slot
+                again.sessionMeta.metaId `shouldBe` handle.sessionMeta.metaId
+
     describe "json codec" do
         it "encodes and decodes SessionTurn" do
             let turn = SessionTurn
@@ -90,11 +115,25 @@ spec = describe "Agent.CLI.Session" do
                     }
             Aeson.eitherDecode (Aeson.encode turn) `shouldBe` Right turn
 
+testCreate :: FilePath -> SessionCreate
+testCreate root = SessionCreate
+    { createRoot = root
+    , createProvider = XAIProvider
+    , createModel = "grok-4"
+    , createCwd = "/tmp/work"
+    , createEffort = "low"
+    , createTitleHint = Nothing
+    }
+
 fixedTime :: UTCTime
 fixedTime = UTCTime (fromGregorian 2026 8 19) (secondsToDiffTime 0)
+
+modeOf :: FilePath -> IO Integer
+modeOf path = do
+    status <- getFileStatus path
+    pure (fromIntegral (fileMode status `mod` 0o1000))
 
 withTempDir :: String -> (FilePath -> IO a) -> IO a
 withTempDir prefix action = do
     tmp <- getTemporaryDirectory
     bracket (mkdtemp (tmp </> prefix)) removeDirectoryRecursive action
-

--- a/packages/agent-cli/test/Agent/CLI/SessionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SessionSpec.hs
@@ -1,0 +1,100 @@
+module Agent.CLI.SessionSpec (spec) where
+
+import Agent.CLI.Session
+import Agent.OpenAI.Responses.Types
+import Agent.Provider (Provider(..))
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.KeyMap as KeyMap
+import Data.Time.Clock (UTCTime(..), secondsToDiffTime)
+import Data.Time.Calendar (fromGregorian)
+import System.Directory
+    ( doesDirectoryExist
+    , doesFileExist
+    , getTemporaryDirectory
+    , removeDirectoryRecursive
+    )
+import System.FilePath ((</>))
+import System.Posix.Temp (mkdtemp)
+import Control.Exception (bracket)
+import qualified Data.Text as Text
+import Test.Hspec
+
+spec :: Spec
+spec = describe "Agent.CLI.Session" do
+    describe "sessionsRoot" do
+        it "is ~/.haskell-agent/sessions" do
+            sessionsRoot "/home/marc"
+                `shouldBe` "/home/marc" </> ".haskell-agent" </> "sessions"
+
+    describe "sessionTitleFromPrompt" do
+        it "collapses whitespace and truncates long prompts" do
+            sessionTitleFromPrompt "  hello   world  " `shouldBe` "hello world"
+            let long = Text.replicate 100 "a"
+            Text.length (sessionTitleFromPrompt long) `shouldBe` 72
+
+    describe "createSession/appendTurn/loadSession" do
+        it "round-trips meta and transcript items" $
+            withTempDir "agent-sessions-" \root -> do
+                handle <- createSession root XAIProvider "grok-4" "/tmp/work" "low" Nothing
+                doesDirectoryExist handle.sessionDir `shouldReturn` True
+                doesFileExist handle.sessionMetaPath `shouldReturn` True
+                handle.sessionMeta.metaTitle `shouldBe` "untitled"
+
+                let item = MessageItem ResponseMessage
+                        { messageId = Nothing
+                        , content = MessageContentParts
+                            [InputTextPart "hi" Nothing KeyMap.empty]
+                        , role = RoleUser
+                        , status = Nothing
+                        , phase = Nothing
+                        , extraFields = KeyMap.empty
+                        }
+                    turn = SessionTurn
+                        { turnAt = fixedTime
+                        , turnUserText = "hi there"
+                        , turnAssistantText = Just "hello"
+                        , turnResponseId = Just "resp-1"
+                        , turnItems = [item]
+                        }
+                handle' <- appendTurn handle turn
+                handle'.sessionMeta.metaTitle `shouldBe` "hi there"
+                handle'.sessionMeta.metaLastResponseId `shouldBe` Just "resp-1"
+
+                loaded <- loadSession root handle.sessionMeta.metaId
+                case loaded of
+                    Left err -> expectationFailure err
+                    Right (meta, turns) -> do
+                        meta.metaId `shouldBe` handle.sessionMeta.metaId
+                        meta.metaProvider `shouldBe` XAIProvider
+                        meta.metaModel `shouldBe` "grok-4"
+                        meta.metaCwd `shouldBe` "/tmp/work"
+                        case turns of
+                            [loadedTurn] -> do
+                                loadedTurn.turnUserText `shouldBe` "hi there"
+                                loadedTurn.turnItems `shouldBe` [item]
+                            other ->
+                                expectationFailure
+                                    ("expected one turn, got " <> show (length other))
+
+                listed <- listSessions root
+                map (.metaId) listed `shouldBe` [handle.sessionMeta.metaId]
+
+    describe "json codec" do
+        it "encodes and decodes SessionTurn" do
+            let turn = SessionTurn
+                    { turnAt = fixedTime
+                    , turnUserText = "q"
+                    , turnAssistantText = Nothing
+                    , turnResponseId = Nothing
+                    , turnItems = []
+                    }
+            Aeson.eitherDecode (Aeson.encode turn) `shouldBe` Right turn
+
+fixedTime :: UTCTime
+fixedTime = UTCTime (fromGregorian 2026 8 19) (secondsToDiffTime 0)
+
+withTempDir :: String -> (FilePath -> IO a) -> IO a
+withTempDir prefix action = do
+    tmp <- getTemporaryDirectory
+    bracket (mkdtemp (tmp </> prefix)) removeDirectoryRecursive action
+

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -8,6 +8,7 @@ import qualified Agent.CLI.MarkdownSpec as MarkdownSpec
 import qualified Agent.CLI.OptionsSpec as OptionsSpec
 import qualified Agent.CLI.PromptSpec as PromptSpec
 import qualified Agent.CLI.RenderSpec as RenderSpec
+import qualified Agent.CLI.SessionSpec as SessionSpec
 import qualified Agent.CLI.ToolsSpec as ToolsSpec
 import qualified Agent.CLI.WorktreeSpec as WorktreeSpec
 
@@ -19,5 +20,6 @@ main = hspec do
     OptionsSpec.spec
     PromptSpec.spec
     RenderSpec.spec
+    SessionSpec.spec
     ToolsSpec.spec
     WorktreeSpec.spec

--- a/packages/agent-openai/src/Agent/OpenAI/LoopBackend.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/LoopBackend.hs
@@ -33,6 +33,7 @@ import Control.Applicative ((<|>))
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KeyMap
+import Data.IORef
 import Data.Maybe (mapMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -40,7 +41,15 @@ import qualified Data.Text as Text
 -- | Close over a live Codex WebSocket and the request fields the loop does
 -- not own (model, instructions, tools, reasoning). The params action is
 -- re-run each turn so the REPL can change reasoning effort in place.
-openAiBackend :: CodexConn -> IO ResponseCreateParams -> Backend
+--
+-- The wire protocol still sends only new items plus @previous_response_id@.
+-- The shared 'IORef' mirrors the full transcript locally so sessions can be
+-- persisted and resumed when the server-side chain is gone.
+openAiBackend
+    :: CodexConn
+    -> IO ResponseCreateParams
+    -> IORef [ResponseItem]
+    -> Backend
 openAiBackend conn =
     openAiBackendWith \request previousResponseId onEvent ->
         sendWsRequestWithEvents conn request previousResponseId onEvent
@@ -52,13 +61,19 @@ openAiBackendWith
         -> (ResponseStreamEvent -> IO ())
         -> IO (Either ApiError Response))
     -> IO ResponseCreateParams
+    -> IORef [ResponseItem]
     -> Backend
-openAiBackendWith send getParams = Backend \previousResponseId inputs onEvent -> do
+openAiBackendWith send getParams transcript = Backend \previousResponseId inputs onEvent -> do
     baseParams <- getParams
-    let request = withRequestInput baseParams (turnInputsToItems inputs)
+    let newItems = turnInputsToItems inputs
+        request = withRequestInput baseParams newItems
     result <- send request previousResponseId \event ->
         mapM_ onEvent (streamEventToLoopEvent event)
-    pure (responseToTurnOutput <$> result)
+    case result of
+        Left err -> pure (Left err)
+        Right response -> do
+            modifyIORef' transcript (<> newItems <> response.output)
+            pure (Right (responseToTurnOutput response))
 
 -- | 'input' is also a field on 'CustomToolCall', so a record update is
 -- ambiguous. Rebuild from the constructor instead.

--- a/packages/agent-openai/src/Agent/OpenAI/LoopBackend.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/LoopBackend.hs
@@ -13,6 +13,7 @@ module Agent.OpenAI.LoopBackend
     ) where
 
 import Agent.Error (ApiError)
+import Agent.OpenAI.Error (isPreviousResponseIdError)
 import Agent.Loop
     ( Backend(..)
     , LoopEvent(..)
@@ -65,14 +66,24 @@ openAiBackendWith
     -> Backend
 openAiBackendWith send getParams transcript = Backend \previousResponseId inputs onEvent -> do
     baseParams <- getParams
+    history <- readIORef transcript
     let newItems = turnInputsToItems inputs
-        request = withRequestInput baseParams newItems
-    result <- send request previousResponseId \event ->
-        mapM_ onEvent (streamEventToLoopEvent event)
-    case result of
+        deltaRequest = withRequestInput baseParams newItems
+        fullRequest = withRequestInput baseParams (history <> newItems)
+        emit event = mapM_ onEvent (streamEventToLoopEvent event)
+    result <- send deltaRequest previousResponseId emit
+    recovered <- case result of
+        Left err
+            | isPreviousResponseIdError err && not (null history) ->
+                -- Server forgot the chain; replay the local transcript as a
+                -- fresh turn so resumed sessions keep working.
+                send fullRequest Nothing emit
+            | otherwise -> pure (Left err)
+        Right response -> pure (Right response)
+    case recovered of
         Left err -> pure (Left err)
         Right response -> do
-            modifyIORef' transcript (<> newItems <> response.output)
+            writeIORef transcript (history <> newItems <> response.output)
             pure (Right (responseToTurnOutput response))
 
 -- | 'input' is also a field on 'CustomToolCall', so a record update is

--- a/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
@@ -92,7 +92,8 @@ spec = do
         it "sends only the new items and threads previous_response_id" do
             seen <- newIORef []
             events <- newIORef []
-            let backend = openAiBackendWith (recordingSend seen) (pure baseParams)
+            transcript <- newIORef []
+            let backend = openAiBackendWith (recordingSend seen) (pure baseParams) transcript
             result <- backend.submitTurn (Just "resp-prev")
                 [UserMessage "hello"]
                 (modifyIORef' events . (:))
@@ -109,7 +110,8 @@ spec = do
 
         it "does not accumulate prior turns on the OpenAI transport" do
             seen <- newIORef []
-            let backend = openAiBackendWith (recordingSend seen) (pure baseParams)
+            transcript <- newIORef []
+            let backend = openAiBackendWith (recordingSend seen) (pure baseParams) transcript
             _ <- backend.submitTurn Nothing [UserMessage "one"] (const (pure ()))
             _ <- backend.submitTurn (Just "resp-1")
                 [CompletedTool (functionResult "c1" "out")]
@@ -119,11 +121,13 @@ spec = do
                 [ turnInputsToItems [UserMessage "one"]
                 , turnInputsToItems [CompletedTool (functionResult "c1" "out")]
                 ]
+            length <$> readIORef transcript `shouldReturn` 4
 
         it "re-reads request params on each turn so effort can change" do
             seen <- newIORef []
             paramsRef <- newIORef (withEffort "low" baseParams)
-            let backend = openAiBackendWith (recordingSend seen) (readIORef paramsRef)
+            transcript <- newIORef []
+            let backend = openAiBackendWith (recordingSend seen) (readIORef paramsRef) transcript
             _ <- backend.submitTurn Nothing [UserMessage "one"] (const (pure ()))
             writeIORef paramsRef (withEffort "high" baseParams)
             _ <- backend.submitTurn (Just "resp-1") [UserMessage "two"] (const (pure ()))

--- a/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
@@ -1,6 +1,6 @@
 module Agent.OpenAI.LoopBackendSpec (spec) where
 
-import Agent.Error (ApiError(..))
+import Agent.Error (ApiError(..), ErrorType(..))
 import Agent.Loop
 import Agent.OpenAI.LoopBackend
 import Agent.OpenAI.Responses.Types
@@ -133,6 +133,35 @@ spec = do
             _ <- backend.submitTurn (Just "resp-1") [UserMessage "two"] (const (pure ()))
             map (reasoningEffort . fst) <$> readIORef seen
                 `shouldReturn` [Just "low", Just "high"]
+
+        it "replays the local transcript when previous_response_id is missing" do
+            seen <- newIORef []
+            let seed = turnInputsToItems [UserMessage "old"]
+            transcript <- newIORef seed
+            let send request previous onEvent = do
+                    modifyIORef' seen (++ [(request, previous)])
+                    case previous of
+                        Just _ ->
+                            pure $ Left $ ProviderError PreviousResponseNotFound
+                                "previous_response_id was not found" Nothing
+                        Nothing -> do
+                            onEvent (deltaEvent EventOutputTextDelta "ok")
+                            pure $ Right (testResponse "resp-2" [assistantItem "ok"])
+                backend = openAiBackendWith send (pure baseParams) transcript
+            result <- backend.submitTurn (Just "resp-missing")
+                [UserMessage "new"]
+                (const (pure ()))
+            result `shouldBe` Right TurnOutput
+                { responseId = "resp-2"
+                , toolCalls = []
+                , assistantText = Just "ok"
+                }
+            requests <- readIORef seen
+            map snd requests `shouldBe` [Just "resp-missing", Nothing]
+            map (inputItems . fst) requests `shouldBe`
+                [ turnInputsToItems [UserMessage "new"]
+                , seed <> turnInputsToItems [UserMessage "new"]
+                ]
 
 --------------------------------------------------------------------------------
 -- Fixtures

--- a/packages/agent-openrouter/src/Agent/OpenRouter/LoopBackend.hs
+++ b/packages/agent-openrouter/src/Agent/OpenRouter/LoopBackend.hs
@@ -3,7 +3,8 @@
 -- OpenRouter does not store transcripts ('store = false', no
 -- @previous_response_id@). This backend keeps a local item list so tool
 -- follow-ups can resend the conversation the loop only supplies as
--- 'CompletedTool' items.
+-- 'CompletedTool' items. Callers own the 'IORef' so a resumed session can
+-- seed history and the CLI can persist it.
 module Agent.OpenRouter.LoopBackend
     ( openRouterBackend
     , openRouterBackendWith
@@ -31,7 +32,8 @@ openRouterBackend
     :: ClientOptions
     -> Credential
     -> IO ResponseCreateParams
-    -> IO Backend
+    -> IORef [ResponseItem]
+    -> Backend
 openRouterBackend options credential =
     openRouterBackendWith (createResponseWithEvents options credential)
 
@@ -41,12 +43,11 @@ openRouterBackendWith
         -> (ResponseStreamEvent -> IO ())
         -> IO (Either ApiError Response))
     -> IO ResponseCreateParams
-    -> IO Backend
-openRouterBackendWith send getParams = do
-    transcript <- newIORef []
-    pure $ Backend \_previousResponseId inputs onEvent -> do
-        baseParams <- getParams
-        submitOpenRouterTurn send baseParams transcript inputs onEvent
+    -> IORef [ResponseItem]
+    -> Backend
+openRouterBackendWith send getParams transcript = Backend \_previousResponseId inputs onEvent -> do
+    baseParams <- getParams
+    submitOpenRouterTurn send baseParams transcript inputs onEvent
 
 submitOpenRouterTurn
     :: (ResponseCreateParams

--- a/packages/agent-openrouter/test/Agent/OpenRouter/LoopBackendSpec.hs
+++ b/packages/agent-openrouter/test/Agent/OpenRouter/LoopBackendSpec.hs
@@ -23,7 +23,8 @@ spec = do
                     [ functionCallItem "c1" "read_file" "{\"target_file\":\"README.md\"}" ]
                 , testResponse "resp-2" [assistantItem "done"]
                 ]
-            backend <- openRouterBackendWith (scriptedSend seen remaining) (pure baseParams)
+            transcript <- newIORef []
+            let backend = openRouterBackendWith (scriptedSend seen remaining) (pure baseParams) transcript
 
             first <- backend.submitTurn Nothing [UserMessage "read it"]
                 (modifyIORef' events . (:))
@@ -57,15 +58,17 @@ spec = do
             seen <- newIORef []
             remaining <- newIORef
                 [ testResponse "resp-1" [assistantItem "hi"] ]
-            backend <- openRouterBackendWith
-                (\request onEvent -> do
-                    n <- length <$> readIORef seen
-                    if n == 0
-                        then do
-                            modifyIORef' seen (++ [request])
-                            pure (Left (ConnectionError "boom"))
-                        else scriptedSend seen remaining request onEvent)
-                (pure baseParams)
+            transcript <- newIORef []
+            let backend = openRouterBackendWith
+                    (\request onEvent -> do
+                        n <- length <$> readIORef seen
+                        if n == 0
+                            then do
+                                modifyIORef' seen (++ [request])
+                                pure (Left (ConnectionError "boom"))
+                            else scriptedSend seen remaining request onEvent)
+                    (pure baseParams)
+                    transcript
 
             failed <- backend.submitTurn Nothing [UserMessage "hi"] (const (pure ()))
             failed `shouldBe` Left (ConnectionError "boom")
@@ -88,7 +91,8 @@ spec = do
                 , testResponse "resp-2" [assistantItem "two"]
                 ]
             paramsRef <- newIORef (withEffort "low" baseParams)
-            backend <- openRouterBackendWith (scriptedSend seen remaining) (readIORef paramsRef)
+            transcript <- newIORef []
+            let backend = openRouterBackendWith (scriptedSend seen remaining) (readIORef paramsRef) transcript
             _ <- backend.submitTurn Nothing [UserMessage "one"] (const (pure ()))
             writeIORef paramsRef (withEffort "high" baseParams)
             _ <- backend.submitTurn (Just "resp-1") [UserMessage "two"] (const (pure ()))

--- a/packages/agent-xai/src/Agent/XAI/LoopBackend.hs
+++ b/packages/agent-xai/src/Agent/XAI/LoopBackend.hs
@@ -3,7 +3,8 @@
 -- The proxy does not store transcripts ('store = false', no
 -- @previous_response_id@). This backend keeps a local item list so tool
 -- follow-ups can resend the conversation the loop only supplies as
--- 'CompletedTool' items.
+-- 'CompletedTool' items. Callers own the 'IORef' so a resumed session can
+-- seed history and the CLI can persist it.
 module Agent.XAI.LoopBackend
     ( xaiBackend
     , xaiBackendWith
@@ -27,7 +28,12 @@ import Data.IORef
 -- not own (model, instructions, tools, reasoning). The params action is
 -- re-run each turn so the REPL can change reasoning effort without dropping
 -- the local transcript.
-xaiBackend :: ClientOptions -> Credential -> IO ResponseCreateParams -> IO Backend
+xaiBackend
+    :: ClientOptions
+    -> Credential
+    -> IO ResponseCreateParams
+    -> IORef [ResponseItem]
+    -> Backend
 xaiBackend options credential =
     xaiBackendWith (createResponseWithEvents options credential)
 
@@ -37,12 +43,11 @@ xaiBackendWith
         -> (ResponseStreamEvent -> IO ())
         -> IO (Either ApiError Response))
     -> IO ResponseCreateParams
-    -> IO Backend
-xaiBackendWith send getParams = do
-    transcript <- newIORef []
-    pure $ Backend \_previousResponseId inputs onEvent -> do
-        baseParams <- getParams
-        submitXaiTurn send baseParams transcript inputs onEvent
+    -> IORef [ResponseItem]
+    -> Backend
+xaiBackendWith send getParams transcript = Backend \_previousResponseId inputs onEvent -> do
+    baseParams <- getParams
+    submitXaiTurn send baseParams transcript inputs onEvent
 
 submitXaiTurn
     :: (ResponseCreateParams

--- a/packages/agent-xai/test/Agent/XAI/LoopBackendSpec.hs
+++ b/packages/agent-xai/test/Agent/XAI/LoopBackendSpec.hs
@@ -23,7 +23,8 @@ spec = do
                     [ functionCallItem "c1" "read_file" "{\"target_file\":\"README.md\"}" ]
                 , testResponse "resp-2" [assistantItem "done"]
                 ]
-            backend <- xaiBackendWith (scriptedSend seen remaining) (pure baseParams)
+            transcript <- newIORef []
+            let backend = xaiBackendWith (scriptedSend seen remaining) (pure baseParams) transcript
 
             first <- backend.submitTurn Nothing [UserMessage "read it"]
                 (modifyIORef' events . (:))
@@ -57,15 +58,17 @@ spec = do
             seen <- newIORef []
             remaining <- newIORef
                 [ testResponse "resp-1" [assistantItem "hi"] ]
-            backend <- xaiBackendWith
-                (\request onEvent -> do
-                    n <- length <$> readIORef seen
-                    if n == 0
-                        then do
-                            modifyIORef' seen (++ [request])
-                            pure (Left (ConnectionError "boom"))
-                        else scriptedSend seen remaining request onEvent)
-                (pure baseParams)
+            transcript <- newIORef []
+            let backend = xaiBackendWith
+                    (\request onEvent -> do
+                        n <- length <$> readIORef seen
+                        if n == 0
+                            then do
+                                modifyIORef' seen (++ [request])
+                                pure (Left (ConnectionError "boom"))
+                            else scriptedSend seen remaining request onEvent)
+                    (pure baseParams)
+                    transcript
 
             failed <- backend.submitTurn Nothing [UserMessage "hi"] (const (pure ()))
             failed `shouldBe` Left (ConnectionError "boom")
@@ -88,7 +91,8 @@ spec = do
                 , testResponse "resp-2" [assistantItem "two"]
                 ]
             paramsRef <- newIORef (withEffort "low" baseParams)
-            backend <- xaiBackendWith (scriptedSend seen remaining) (readIORef paramsRef)
+            transcript <- newIORef []
+            let backend = xaiBackendWith (scriptedSend seen remaining) (readIORef paramsRef) transcript
             _ <- backend.submitTurn Nothing [UserMessage "one"] (const (pure ()))
             writeIORef paramsRef (withEffort "high" baseParams)
             _ <- backend.submitTurn (Just "resp-1") [UserMessage "two"] (const (pure ()))


### PR DESCRIPTION
## Summary
- Persist interactive REPL sessions under `~/.haskell-agent/sessions/<id>/` (`meta.json` + append-only `transcript.jsonl`)
- Add `agent-cli sessions [list|show]`, `--resume <id>`, `--save-session` for one-shots, and REPL `/session`
- Share a caller-owned transcript `IORef` across OpenAI/xAI/OpenRouter backends so history can be seeded on resume

## Test plan
- [x] `cabal test agent-cli agent-xai agent-openrouter agent-openai`
- [x] `agent-cli --help` shows sessions/resume flags
- [x] `agent-cli sessions` reports empty store
- [ ] Start a REPL, send a turn, confirm `~/.haskell-agent/sessions/<id>/` is written
- [ ] `agent-cli --resume <id>` continues the conversation
- [ ] `agent-cli sessions show <id>` prints the transcript