### PR TITLE
fix: retry tool file IO on GHC resource-busy locks

### DIFF
--- a/packages/agent-core/agent-core.cabal
+++ b/packages/agent-core/agent-core.cabal
@@ -76,6 +76,7 @@ test-suite agent-core-test
                     , Agent.ToolDispatchSpec
                     , Agent.Tools.CodexSpec
                     , Agent.Tools.GrokSpec
+                    , Agent.Tools.IOSpec
                     , Agent.ToolDSLSpec
                     , Agent.Transport.WebSocketSpec
     build-depends:    base >= 4.14 && < 5

--- a/packages/agent-core/agent-core.cabal
+++ b/packages/agent-core/agent-core.cabal
@@ -85,6 +85,7 @@ test-suite agent-core-test
                     , directory
                     , filepath
                     , hspec
+                    , safe-exceptions
                     , text
                     , time
                     , bytestring

--- a/packages/agent-core/src/Agent/Tools/IO.hs
+++ b/packages/agent-core/src/Agent/Tools/IO.hs
@@ -18,7 +18,8 @@ import Agent.Tools.Types (ToolEnv(..))
 import Control.Concurrent (forkIO, threadDelay)
 import Control.Concurrent.Async (async, concurrently, race, wait)
 import Control.Concurrent.MVar (MVar, newEmptyMVar, putMVar)
-import Control.Exception (SomeException, evaluate, try)
+import Control.Exception (evaluate)
+import Control.Exception.Safe (SomeException, catchIO, throwIO, try)
 import Data.IORef (IORef, atomicModifyIORef', newIORef, readIORef)
 import Data.List (isPrefixOf)
 import Data.Text (Text)
@@ -36,7 +37,7 @@ import System.Directory
     , renameFile
     )
 import System.Exit (ExitCode(..))
-import System.IO.Error (catchIOError, ioError, isAlreadyInUseError)
+import System.IO.Error (isAlreadyInUseError)
 import System.FilePath
     ( addTrailingPathSeparator
     , isAbsolute
@@ -111,10 +112,10 @@ retryOnBusy action = go lockRetryDelaysUs
   where
     go [] = action
     go (delayUs : rest) =
-        catchIOError action \err ->
+        catchIO action \err ->
             if isAlreadyInUseError err
                 then threadDelay delayUs >> go rest
-                else ioError err
+                else throwIO err
 
 readTextFile :: FilePath -> IO (Either Text Text)
 readTextFile path = try @SomeException (retryOnBusy (BS.readFile path)) >>= \case

--- a/packages/agent-core/src/Agent/Tools/IO.hs
+++ b/packages/agent-core/src/Agent/Tools/IO.hs
@@ -118,7 +118,7 @@ retryOnBusy action = go lockRetryDelaysUs
                 else throwIO err
 
 readTextFile :: FilePath -> IO (Either Text Text)
-readTextFile path = try @SomeException (retryOnBusy (BS.readFile path)) >>= \case
+readTextFile path = try @_ @SomeException (retryOnBusy (BS.readFile path)) >>= \case
     Left err -> pure $ Left $ "Failed to read file: " <> Text.pack (show err)
     Right bytes
         | BS.elem 0 (BS.take 8192 bytes) ->
@@ -129,25 +129,25 @@ readTextFile path = try @SomeException (retryOnBusy (BS.readFile path)) >>= \cas
 writeTextFile :: FilePath -> Text -> IO (Either Text ())
 writeTextFile path content = do
     createDirectoryIfMissing True (takeDirectory path)
-    try @SomeException (retryOnBusy (BS.writeFile path (encodeUtf8 content))) >>= \case
+    try @_ @SomeException (retryOnBusy (BS.writeFile path (encodeUtf8 content))) >>= \case
         Left err -> pure $ Left $ "Failed to write file: " <> Text.pack (show err)
         Right () -> pure (Right ())
 
 deleteTextFile :: FilePath -> IO (Either Text ())
 deleteTextFile path =
-    try @SomeException (removeFile path) >>= \case
+    try @_ @SomeException (removeFile path) >>= \case
         Left err -> pure $ Left $ "Failed to delete file: " <> Text.pack (show err)
         Right () -> pure (Right ())
 
 renameTextFile :: FilePath -> FilePath -> IO (Either Text ())
 renameTextFile from to = do
     createDirectoryIfMissing True (takeDirectory to)
-    try @SomeException (renameFile from to) >>= \case
+    try @_ @SomeException (renameFile from to) >>= \case
         Left err -> pure $ Left $ "Failed to move file: " <> Text.pack (show err)
         Right () -> pure (Right ())
 
 listDirectoryEntries :: FilePath -> IO (Either Text [(FilePath, Bool)])
-listDirectoryEntries path = try @SomeException (listDirectory path) >>= \case
+listDirectoryEntries path = try @_ @SomeException (listDirectory path) >>= \case
     Left err -> pure $ Left $ "Failed to list directory: " <> Text.pack (show err)
     Right names -> Right <$> mapM (classify path) names
   where
@@ -195,7 +195,7 @@ runShellCommand env workdir command timeoutMs = do
             , std_err = CreatePipe
             , create_group = True
             }
-    try @SomeException (createProcess spec) >>= \case
+    try @_ @SomeException (createProcess spec) >>= \case
         Left err -> pure CommandResult
             { commandExitCode = Just 127
             , commandStdout = ""
@@ -215,7 +215,7 @@ runShellCommand env workdir command timeoutMs = do
             raced <- race (threadDelay (max 1 timeoutMs * 1000)) collect
             case raced of
                 Left () -> do
-                    _ <- try @SomeException (interruptProcessGroupOf processHandle)
+                    _ <- try @_ @SomeException (interruptProcessGroupOf processHandle)
                     pure CommandResult
                         { commandExitCode = Nothing
                         , commandStdout = ""
@@ -254,7 +254,7 @@ startShellCommand env workdir command = do
             , std_err = CreatePipe
             , create_group = True
             }
-    try @SomeException (createProcess spec) >>= \case
+    try @_ @SomeException (createProcess spec) >>= \case
         Left err -> pure $ Left $ "Failed to start command: " <> Text.pack (show err)
         Right (Just hin, Just hout, Just herr, processHandle) -> do
             hClose hin
@@ -264,7 +264,7 @@ startShellCommand env workdir command = do
             outA <- async (drainHandle hout stdoutRef)
             errA <- async (drainHandle herr stderrRef)
             _ <- forkIO do
-                result <- try @SomeException do
+                result <- try @_ @SomeException do
                     code <- waitForProcess processHandle
                     outBytes <- wait outA
                     errBytes <- wait errA

--- a/packages/agent-core/src/Agent/Tools/IO.hs
+++ b/packages/agent-core/src/Agent/Tools/IO.hs
@@ -23,9 +23,8 @@ import Data.IORef (IORef, atomicModifyIORef', newIORef, readIORef)
 import Data.List (isPrefixOf)
 import Data.Text (Text)
 import qualified Data.Text as Text
-import qualified Data.Text.IO as Text
 import qualified Data.ByteString as BS
-import Data.Text.Encoding (decodeUtf8With)
+import Data.Text.Encoding (decodeUtf8With, encodeUtf8)
 import Data.Text.Encoding.Error (lenientDecode)
 import System.Directory
     ( canonicalizePath
@@ -37,6 +36,7 @@ import System.Directory
     , renameFile
     )
 import System.Exit (ExitCode(..))
+import System.IO.Error (catchIOError, ioError, isAlreadyInUseError)
 import System.FilePath
     ( addTrailingPathSeparator
     , isAbsolute
@@ -100,8 +100,24 @@ isInside root path =
     let root' = addTrailingPathSeparator root
     in path == root || root' `isPrefixOf` path
 
+-- | GHC Handle locks throw @isAlreadyInUseError@ when another Handle
+-- still has the path open. Retry briefly so overlapping tool calls
+-- (e.g. parallel @search_replace@) can wait the lock out.
+lockRetryDelaysUs :: [Int]
+lockRetryDelaysUs = [1000, 2000, 4000, 8000, 16000]
+
+retryOnBusy :: IO a -> IO a
+retryOnBusy action = go lockRetryDelaysUs
+  where
+    go [] = action
+    go (delayUs : rest) =
+        catchIOError action \err ->
+            if isAlreadyInUseError err
+                then threadDelay delayUs >> go rest
+                else ioError err
+
 readTextFile :: FilePath -> IO (Either Text Text)
-readTextFile path = try @SomeException (BS.readFile path) >>= \case
+readTextFile path = try @SomeException (retryOnBusy (BS.readFile path)) >>= \case
     Left err -> pure $ Left $ "Failed to read file: " <> Text.pack (show err)
     Right bytes
         | BS.elem 0 (BS.take 8192 bytes) ->
@@ -112,7 +128,7 @@ readTextFile path = try @SomeException (BS.readFile path) >>= \case
 writeTextFile :: FilePath -> Text -> IO (Either Text ())
 writeTextFile path content = do
     createDirectoryIfMissing True (takeDirectory path)
-    try @SomeException (Text.writeFile path content) >>= \case
+    try @SomeException (retryOnBusy (BS.writeFile path (encodeUtf8 content))) >>= \case
         Left err -> pure $ Left $ "Failed to write file: " <> Text.pack (show err)
         Right () -> pure (Right ())
 

--- a/packages/agent-core/test/Agent/Tools/IOSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/IOSpec.hs
@@ -1,0 +1,65 @@
+module Agent.Tools.IOSpec (spec) where
+
+import Agent.Tools.IO (readTextFile, writeTextFile)
+import Control.Concurrent (forkIO, newEmptyMVar, putMVar, takeMVar, threadDelay)
+import Control.Exception (bracket)
+import Control.Monad (replicateM)
+import Data.Either (isLeft)
+import qualified Data.Text as Text
+import System.Directory (getTemporaryDirectory, removeDirectoryRecursive)
+import System.FilePath ((</>))
+import System.IO (IOMode(..), hClose, openFile)
+import System.Posix.Temp (mkdtemp)
+import Test.Hspec
+
+spec :: Spec
+spec = describe "Agent.Tools.IO" do
+    it "retries a write after a transient GHC file lock" do
+        withTempDir \dir -> do
+            let path = dir </> "held.txt"
+            writeFile path "old\n"
+            h <- openFile path AppendMode
+            _ <- forkIO do
+                threadDelay 5000
+                hClose h
+            writeTextFile path "new\n" `shouldReturn` Right ()
+            readTextFile path `shouldReturn` Right "new\n"
+
+    it "gives up when the GHC file lock is held for the whole retry window" do
+        withTempDir \dir -> do
+            let path = dir </> "held.txt"
+            writeFile path "old\n"
+            bracket (openFile path ReadMode) hClose \_ -> do
+                result <- writeTextFile path "new\n"
+                result `shouldSatisfy` isLeft
+                result `shouldSatisfy` either (Text.isInfixOf "resource busy") (const False)
+
+    it "lets several threads write the same file without a lock error" do
+        withTempDir \dir -> do
+            let path = dir </> "race.txt"
+            writeFile path "start\n"
+            vars <- replicateM 8 newEmptyMVar
+            mapM_
+                (\(i, var) -> forkIO $
+                    writeTextFile path (Text.pack (show i) <> "\n") >>= putMVar var)
+                (zip [1 :: Int ..] vars)
+            results <- mapM takeMVar vars
+            results `shouldBe` replicate 8 (Right ())
+
+    it "reads the same file from many threads at once" do
+        withTempDir \dir -> do
+            let path = dir </> "shared.txt"
+                body = Text.replicate 2000 "concurrent-read\n"
+            writeTextFile path body `shouldReturn` Right ()
+            vars <- replicateM 32 newEmptyMVar
+            mapM_ (\var -> forkIO $ readTextFile path >>= putMVar var) vars
+            results <- mapM takeMVar vars
+            results `shouldBe` replicate 32 (Right body)
+
+withTempDir :: (FilePath -> IO a) -> IO a
+withTempDir action = do
+    tmp <- getTemporaryDirectory
+    bracket
+        (mkdtemp (tmp </> "agent-io-XXXXXX"))
+        removeDirectoryRecursive
+        action

--- a/packages/agent-core/test/Agent/Tools/IOSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/IOSpec.hs
@@ -2,7 +2,7 @@ module Agent.Tools.IOSpec (spec) where
 
 import Agent.Tools.IO (readTextFile, writeTextFile)
 import Control.Concurrent (forkIO, newEmptyMVar, putMVar, takeMVar, threadDelay)
-import Control.Exception (bracket)
+import Control.Exception.Safe (bracket)
 import Control.Monad (replicateM)
 import Data.Either (isLeft)
 import qualified Data.Text as Text

--- a/packages/agent-core/test/Spec.hs
+++ b/packages/agent-core/test/Spec.hs
@@ -7,6 +7,7 @@ import qualified Agent.ToolDispatchSpec as ToolDispatchSpec
 import qualified Agent.ToolDSLSpec as ToolDSLSpec
 import qualified Agent.Tools.CodexSpec as CodexToolsSpec
 import qualified Agent.Tools.GrokSpec as GrokToolsSpec
+import qualified Agent.Tools.IOSpec as IOSpec
 import qualified Agent.Transport.WebSocketSpec as WebSocketSpec
 import Test.Hspec (hspec)
 
@@ -18,5 +19,6 @@ main = hspec do
     ToolDispatchSpec.spec
     ToolDSLSpec.spec
     GrokToolsSpec.spec
+    IOSpec.spec
     CodexToolsSpec.spec
     WebSocketSpec.spec


### PR DESCRIPTION
## Summary
- Parallel `search_replace` on the same path can fail with `withFile: resource busy (file is locked)` because GHC refuses a second Handle while another is still open.
- Retry `readTextFile` / `writeTextFile` on `isAlreadyInUseError` with a short backoff (1–16 ms, six attempts).
- Write UTF-8 via `ByteString` instead of locale-sensitive `Text.writeFile`.

This covers the transient overlap from `mapConcurrently` tool calls. A Handle that stays open for the whole retry window still fails.

## Test plan
- [x] `nix develop` GHCi: `Agent.Tools.IOSpec` (4 examples) and `Agent.Tools.GrokSpec` (14 examples)
- [ ] CI `nix flake check`