### PR TITLE
feat: prefer ghci for scripting in Grok and OpenAI prompts

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Prompt.hs
+++ b/packages/agent-cli/src/Agent/CLI/Prompt.hs
@@ -19,10 +19,22 @@ defaultModelFor = \case
 
 -- | @isNonInteractive@ is True for one-shot @-p@ (no human in the loop).
 systemPrompt :: Provider -> FilePath -> Day -> Bool -> Text
-systemPrompt provider cwd today isNonInteractive = case provider of
-    XAIProvider -> grokSystemPrompt codingGrokPromptTools cwd today isNonInteractive
-    OpenRouterProvider -> grokSystemPrompt codingGrokPromptTools cwd today isNonInteractive
-    OpenAIProvider -> codexSystemPrompt cwd today
+systemPrompt provider cwd today isNonInteractive =
+    base <> "\n\n" <> ghciGuidance
+  where
+    base = case provider of
+        XAIProvider -> grokSystemPrompt codingGrokPromptTools cwd today isNonInteractive
+        OpenRouterProvider -> grokSystemPrompt codingGrokPromptTools cwd today isNonInteractive
+        OpenAIProvider -> codexSystemPrompt cwd today
+
+-- | Prefer GHCI as the general-purpose scripting environment.
+ghciGuidance :: Text
+ghciGuidance =
+    Text.unlines
+        [ "Prefer ghci for scripting."
+        , "When you need a short program, calculation, or one-off script, use ghci rather than Python, Node, bash, or compiling a binary."
+        , "Drive ghci with stdin or -e so it does not wait for interactive input."
+        ]
 
 codexSystemPrompt :: FilePath -> Day -> Text
 codexSystemPrompt cwd today =

--- a/packages/agent-cli/test/Agent/CLI/PromptSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/PromptSpec.hs
@@ -32,6 +32,17 @@ spec = describe "systemPrompt" do
         let grok = systemPrompt XAIProvider "/tmp/repo" (fromGregorian 2026 8 19) True
         grok `shouldSatisfy` Text.isInfixOf "no human operator"
 
+    it "tells grok and openai to prefer ghci for general-purpose scripting" do
+        let day = fromGregorian 2026 8 19
+            grok = systemPrompt XAIProvider "/tmp/repo" day False
+            openai = systemPrompt OpenAIProvider "/tmp/repo" day False
+        grok `shouldSatisfy` Text.isInfixOf "Prefer ghci for scripting"
+        openai `shouldSatisfy` Text.isInfixOf "Prefer ghci for scripting"
+        grok `shouldSatisfy` Text.isInfixOf "Python, Node, bash"
+        openai `shouldSatisfy` Text.isInfixOf "Python, Node, bash"
+        grok `shouldSatisfy` Text.isInfixOf "stdin or -e"
+        openai `shouldSatisfy` Text.isInfixOf "stdin or -e"
+
     it "picks the documented default models" do
         defaultModelFor XAIProvider `shouldBe` "grok-4.5"
         defaultModelFor OpenAIProvider `shouldBe` "gpt-5.1-codex"


### PR DESCRIPTION
## Summary
- Append GHCI scripting guidance to Grok and OpenAI system prompts (OpenRouter shares the Grok prompt)
- Prefer `ghci` for short programs, calculations, and one-off scripts instead of Python, Node, bash, or compiling a binary
- Drive `ghci` with stdin or `-e` so it does not wait for interactive input

## Test plan
- [x] PromptSpec asserts Grok and OpenAI prompts include the GHCI guidance
- [x] Loaded `Agent.CLI.Prompt` in GHCI and checked Grok, OpenAI, and OpenRouter prompts
- [ ] `cabal test agent-cli`