### PR TITLE
fix: give nix flake checks git and ripgrep

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -80,11 +80,18 @@
 
                 haskellPackages = pkgs.haskellPackages.extend (
                     final: _previous: {
-                        agent-core = final.callCabal2nix "agent-core" agentCoreSource { };
+                        agent-core = pkgs.haskell.lib.addTestToolDepends
+                            (final.callCabal2nix "agent-core" agentCoreSource { })
+                            [
+                                pkgs.git
+                                pkgs.ripgrep
+                            ];
                         agent-openai = final.callCabal2nix "agent-openai" agentOpenaiSource { };
                         agent-xai = final.callCabal2nix "agent-xai" agentXaiSource { };
                         agent-openrouter = final.callCabal2nix "agent-openrouter" agentOpenrouterSource { };
-                        agent-cli = final.callCabal2nix "agent-cli" agentCliSource { };
+                        agent-cli = pkgs.haskell.lib.addTestToolDepends
+                            (final.callCabal2nix "agent-cli" agentCliSource { })
+                            [ pkgs.git ];
                     }
                 );
 

--- a/packages/agent-core/test/Agent/Tools/GrokSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/GrokSpec.hs
@@ -129,8 +129,9 @@ spec = describe "Agent.Tools.Grok" do
         withTempEnv \env -> do
             Text.writeFile (env.toolCwd </> ".gitignore") "secret.txt\n"
             Text.writeFile (env.toolCwd </> "secret.txt") "hidden\n"
-            _ <- runTool env "run_terminal_cmd"
+            initOut <- runTool env "run_terminal_cmd"
                 "{\"command\":\"git init\",\"description\":\"init git\"}"
+            initOut `shouldSatisfy` Text.isPrefixOf "exit: 0"
             output <- runTool env "search_replace"
                 "{\"file_path\":\"secret.txt\",\"old_string\":\"hidden\",\"new_string\":\"shown\"}"
             output `shouldSatisfy` Text.isInfixOf "gitignore"


### PR DESCRIPTION
## Summary
Master's `nix flake check` was red after PRs #2 and #3 merged: `agent-core` tests look up `rg` and `git` on PATH, and the flake check sandbox did not provide either.

- Put `git` and `ripgrep` on the `agent-core` test PATH via `addTestToolDepends`.
- Put `git` on the `agent-cli` test PATH for `WorktreeSpec`.
- Assert `git init` succeeds in the gitignore test so a missing `git` fails clearly.

Verified locally with ghci: `Agent.Tools.Grok` 14 examples, 0 failures.

## Test plan
- [x] `Agent.Tools.Grok` spec via `cabal repl` / ghci
- [ ] GitHub Actions `Nix flake check` on this PR