### PR TITLE
fix: replace callCabal2nix IFD with checked-in package.nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,17 @@ A universal coding-agent harness written in Haskell.
 
 All compiler and package dependencies come from the pinned Nix flake.
 
+Each package has a checked-in `package.nix` generated with `cabal2nix` (no IFD).
+After changing a `.cabal` file, regenerate that package's Nix expression:
+
+```console
+(cd packages/agent-core && cabal2nix . > package.nix)
+(cd packages/agent-openai && cabal2nix . > package.nix)
+(cd packages/agent-xai && cabal2nix . > package.nix)
+(cd packages/agent-openrouter && cabal2nix . > package.nix)
+(cd packages/agent-cli && cabal2nix . > package.nix)
+```
+
 ```console
 nix develop
 cabal build all

--- a/flake.nix
+++ b/flake.nix
@@ -147,6 +147,7 @@
                             haskell-language-server
                         ])
                         ++ (with pkgs; [
+                            cabal2nix
                             ripgrep
                         ]);
                 };

--- a/flake.nix
+++ b/flake.nix
@@ -81,16 +81,26 @@
                 haskellPackages = pkgs.haskellPackages.extend (
                     final: _previous: {
                         agent-core = pkgs.haskell.lib.addTestToolDepends
-                            (final.callCabal2nix "agent-core" agentCoreSource { })
+                            (pkgs.haskell.lib.overrideSrc (final.callPackage ./packages/agent-core/package.nix { }) {
+                                src = agentCoreSource;
+                            })
                             [
                                 pkgs.git
                                 pkgs.ripgrep
                             ];
-                        agent-openai = final.callCabal2nix "agent-openai" agentOpenaiSource { };
-                        agent-xai = final.callCabal2nix "agent-xai" agentXaiSource { };
-                        agent-openrouter = final.callCabal2nix "agent-openrouter" agentOpenrouterSource { };
+                        agent-openai = pkgs.haskell.lib.overrideSrc (final.callPackage ./packages/agent-openai/package.nix { }) {
+                            src = agentOpenaiSource;
+                        };
+                        agent-xai = pkgs.haskell.lib.overrideSrc (final.callPackage ./packages/agent-xai/package.nix { }) {
+                            src = agentXaiSource;
+                        };
+                        agent-openrouter = pkgs.haskell.lib.overrideSrc (final.callPackage ./packages/agent-openrouter/package.nix { }) {
+                            src = agentOpenrouterSource;
+                        };
                         agent-cli = pkgs.haskell.lib.addTestToolDepends
-                            (final.callCabal2nix "agent-cli" agentCliSource { })
+                            (pkgs.haskell.lib.overrideSrc (final.callPackage ./packages/agent-cli/package.nix { }) {
+                                src = agentCliSource;
+                            })
                             [ pkgs.git ];
                     }
                 );

--- a/packages/agent-cli/package.nix
+++ b/packages/agent-cli/package.nix
@@ -1,0 +1,24 @@
+{ mkDerivation, aeson, agent-core, agent-openai, agent-openrouter
+, agent-xai, ansi-terminal, base, bytestring, directory, filepath
+, hspec, lib, process, text, time, unix
+}:
+mkDerivation {
+  pname = "agent-cli";
+  version = "0.1.0.0";
+  src = ./.;
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [
+    aeson agent-core agent-openai agent-openrouter agent-xai
+    ansi-terminal base bytestring directory filepath process text time
+    unix
+  ];
+  executableHaskellDepends = [ base ];
+  testHaskellDepends = [
+    aeson agent-core agent-openai ansi-terminal base bytestring
+    directory filepath hspec process text time unix
+  ];
+  description = "Command-line interface for the universal agent harness";
+  license = lib.licenses.bsd3;
+  mainProgram = "agent-cli";
+}

--- a/packages/agent-core/package.nix
+++ b/packages/agent-core/package.nix
@@ -1,0 +1,20 @@
+{ mkDerivation, aeson, async, base, bytestring, containers
+, directory, filepath, hspec, http-conduit, lib, process
+, safe-exceptions, stm, text, time, unix, vector, websockets
+}:
+mkDerivation {
+  pname = "agent-core";
+  version = "0.1.0.0";
+  src = ./.;
+  libraryHaskellDepends = [
+    aeson async base bytestring containers directory filepath
+    http-conduit process safe-exceptions stm text time unix vector
+    websockets
+  ];
+  testHaskellDepends = [
+    aeson base bytestring directory filepath hspec safe-exceptions text
+    time unix websockets
+  ];
+  description = "Provider-neutral infrastructure for the agent harness";
+  license = lib.licenses.bsd3;
+}

--- a/packages/agent-openai/package.nix
+++ b/packages/agent-openai/package.nix
@@ -1,0 +1,30 @@
+{ mkDerivation, aeson, agent-core, base, base64-bytestring
+, bytestring, case-insensitive, containers, directory, exceptions
+, filepath, hashable, HsOpenSSL, hspec, http-client
+, http-client-tls, http-conduit, http-streams, http-types
+, io-streams, lib, network-uri, retry, safe-exceptions, scientific
+, temporary, text, time, unix, vector, wai, warp, websockets, wuss
+}:
+mkDerivation {
+  pname = "agent-openai";
+  version = "0.1.0.0";
+  src = ./.;
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [
+    aeson agent-core base base64-bytestring bytestring containers
+    directory exceptions filepath hashable HsOpenSSL http-client
+    http-client-tls http-conduit http-streams http-types io-streams
+    network-uri retry safe-exceptions scientific text time unix vector
+    websockets wuss
+  ];
+  executableHaskellDepends = [ base directory filepath text ];
+  testHaskellDepends = [
+    aeson agent-core base base64-bytestring bytestring case-insensitive
+    directory filepath hspec http-types retry temporary text time unix
+    vector wai warp websockets
+  ];
+  description = "Haskell client for the OpenAI Responses API";
+  license = lib.licenses.bsd3;
+  mainProgram = "agent-openai-login";
+}

--- a/packages/agent-openrouter/package.nix
+++ b/packages/agent-openrouter/package.nix
@@ -1,0 +1,19 @@
+{ mkDerivation, aeson, agent-core, agent-openai, base, bytestring
+, case-insensitive, hspec, http-client, http-conduit, http-types
+, lib, safe-exceptions, text, time, wai, warp
+}:
+mkDerivation {
+  pname = "agent-openrouter";
+  version = "0.1.0.0";
+  src = ./.;
+  libraryHaskellDepends = [
+    aeson agent-core agent-openai base bytestring http-client
+    http-conduit http-types safe-exceptions text time
+  ];
+  testHaskellDepends = [
+    aeson agent-core agent-openai base bytestring case-insensitive
+    hspec http-types text time wai warp
+  ];
+  description = "Haskell client for the OpenRouter Responses transport";
+  license = lib.licenses.bsd3;
+}

--- a/packages/agent-xai/package.nix
+++ b/packages/agent-xai/package.nix
@@ -1,0 +1,20 @@
+{ mkDerivation, aeson, agent-core, agent-openai, base
+, base64-bytestring, bytestring, case-insensitive, hspec
+, http-client, http-conduit, http-types, lib, safe-exceptions, text
+, wai, warp
+}:
+mkDerivation {
+  pname = "agent-xai";
+  version = "0.1.0.0";
+  src = ./.;
+  libraryHaskellDepends = [
+    aeson agent-core agent-openai base base64-bytestring bytestring
+    http-client http-conduit safe-exceptions text
+  ];
+  testHaskellDepends = [
+    aeson agent-core agent-openai base base64-bytestring bytestring
+    case-insensitive hspec http-types text wai warp
+  ];
+  description = "Haskell client for the xAI Grok subscription transport";
+  license = lib.licenses.bsd3;
+}


### PR DESCRIPTION
## Summary
- Replace `callCabal2nix` (Nix IFD) with checked-in `packages/*/package.nix` generated by `cabal2nix`.
- Keep `nix-filter` source filtering via `overrideSrc`.
- Document regeneration steps in the README so `.cabal` changes stay in sync.

## Why
Each `nix develop` / flake eval was rebuilding package metadata through IFD even when no files changed, which made shell entry and Nix evaluation slower than necessary.

## Test plan
- [x] `nix eval .#devShells.aarch64-darwin.default.name`
- [x] `nix eval` package names for agent-core, agent-cli, agent-openai, agent-xai, agent-openrouter
- [ ] `nix develop` then `cabal build all`
- [ ] Confirm no remaining `callCabal2nix` in `flake.nix`