### PR TITLE
feat: colorize CLI chrome with shared ANSI roles

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -43,6 +43,7 @@ library
                     , Agent.CLI.Prompt
                     , Agent.CLI.Render
                     , Agent.CLI.Session
+                    , Agent.CLI.Style
                     , Agent.CLI.Tools
                     , Agent.CLI.Worktree
     build-depends:    agent-core >= 0.1 && < 0.2
@@ -79,6 +80,7 @@ test-suite agent-cli-test
                     , Agent.CLI.OptionsSpec
                     , Agent.CLI.PromptSpec
                     , Agent.CLI.RenderSpec
+                    , Agent.CLI.StyleSpec
                     , Agent.CLI.SessionSpec
                     , Agent.CLI.ToolsSpec
                     , Agent.CLI.WorktreeSpec

--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -10,11 +10,18 @@ import Agent.CLI.Prompt (defaultModelFor, systemPrompt)
 import Agent.CLI.Render
     ( RenderConfig(..)
     , clearThinking
-    , formatLoopError
+    , formatLoopErrorColored
     , putTextLn
     , renderAssistantText
     , renderEvent
     , summarizeToolCall
+    )
+import Agent.CLI.Style
+    ( roleError
+    , roleMuted
+    , rolePrompt
+    , roleSuccess
+    , roleWarn
     )
 import Agent.CLI.Session
 import Agent.CLI.Tools (lookupAppTool, schemasFromAppTools)
@@ -50,7 +57,7 @@ import System.Directory (getCurrentDirectory, getHomeDirectory, makeAbsolute, se
 import System.Environment (getArgs, lookupEnv)
 import System.FilePath ((</>))
 import System.Exit (die, exitFailure)
-import System.IO (hFlush, hIsTerminalDevice, hPutStrLn, isEOF, stderr, stdin, stdout)
+import System.IO (Handle, hFlush, hIsTerminalDevice, isEOF, stderr, stdin, stdout)
 
 run :: IO ()
 run = do
@@ -121,7 +128,8 @@ runAgent options = do
         Nothing
             | options.optWorktree -> do
                 createWorktree source (worktreeRoot home) >>= either die \path -> do
-                    hPutStrLn stderr ("worktree: " <> path)
+                    color <- resolveColor stderr
+                    putTextLn stderr (roleMuted color ("worktree: " <> Text.pack path))
                     pure path
             | otherwise -> pure source
     setCurrentDirectory cwd
@@ -207,7 +215,10 @@ preparePersistence options root provider model cwd effort prompt resumed =
                         root </> Text.unpack meta.metaId </> "transcript.jsonl"
                     , sessionMeta = meta
                     }
-            hPutStrLn stderr ("session: " <> Text.unpack meta.metaId <> " (resumed)")
+            color <- resolveColor stderr
+            putTextLn stderr
+                (roleMuted color
+                    ("session: " <> meta.metaId <> " (resumed)"))
             Just <$> newIORef (Right handle)
         Nothing
             | shouldPersist options ->
@@ -255,11 +266,9 @@ runSession options policy tools prompt paramsRef transcriptRef initialPrevious p
     ioLock <- newMVar ()
     previous <- newIORef initialPrevious
     policyRef <- newIORef policy
-    stdoutTty <- hIsTerminalDevice stdout
     stderrTty <- hIsTerminalDevice stderr
-    noColor <- lookupEnv "NO_COLOR"
-    let useColor = stdoutTty && maybe True (\_ -> False) noColor
-        render = RenderConfig
+    useColor <- resolveColor stdout
+    let render = RenderConfig
             { renderShowThinking = stderrTty
             , renderThinkingVisible = thinkingVisible
             , renderColor = useColor
@@ -297,7 +306,8 @@ repl
     -> Maybe (IORef (Either SessionCreate SessionHandle))
     -> IO ()
 repl config render previous printed paramsRef policyRef transcriptRef persist = do
-    putStr "agent> "
+    stdoutColor <- resolveColor stdout
+    Text.putStr (rolePrompt stdoutColor "agent> ")
     hFlush stdout
     done <- isEOF
     if done
@@ -315,12 +325,14 @@ repl config render previous printed paramsRef policyRef transcriptRef persist = 
                         putTrailingNewline printed
                         continue
                     ReplShowEffort -> do
+                        color <- resolveColor stdout
                         params <- readIORef paramsRef
-                        Text.putStrLn ("effort: " <> currentEffort params)
+                        Text.putStrLn (roleMuted color ("effort: " <> currentEffort params))
                         continue
                     ReplSetEffort level -> do
+                        color <- resolveColor stdout
                         modifyIORef' paramsRef (setReasoningEffort level)
-                        Text.putStrLn ("effort set to " <> level)
+                        Text.putStrLn (roleMuted color ("effort set to " <> level))
                         case persist of
                             Nothing -> pure ()
                             Just slotRef -> do
@@ -339,20 +351,25 @@ repl config render previous printed paramsRef policyRef transcriptRef persist = 
                         toggleAlwaysApprove policyRef
                         continue
                     ReplShowSession -> do
+                        color <- resolveColor stdout
                         case persist of
-                            Nothing -> Text.putStrLn "session: (not persisted)"
+                            Nothing ->
+                                Text.putStrLn (roleMuted color "session: (not persisted)")
                             Just slotRef -> do
                                 slot <- readIORef slotRef
                                 case slot of
                                     Left _ ->
                                         Text.putStrLn
-                                            "session: (pending until first turn)"
+                                            (roleMuted color
+                                                "session: (pending until first turn)")
                                     Right handle ->
                                         Text.putStrLn
-                                            ("session: " <> handle.sessionMeta.metaId)
+                                            (roleMuted color
+                                                ("session: " <> handle.sessionMeta.metaId))
                         continue
                     ReplCommandError err -> do
-                        Text.hPutStrLn stderr err
+                        color <- resolveColor stderr
+                        Text.hPutStrLn stderr (roleError color err)
                         continue
   where
     continue = repl config render previous printed paramsRef policyRef transcriptRef persist
@@ -373,16 +390,15 @@ runOneTurn config render previous printed transcriptRef persist prompt = do
     clearThinking render
     case result of
         Left err -> do
-            putTextLn stderr (formatLoopError err)
+            color <- resolveColor stderr
+            putTextLn stderr (formatLoopErrorColored color err)
             pure False
         Right loopResult -> do
             writeIORef previous (Just loopResult.finalResponseId)
             printedText <- readIORef printed
             case (printedText, loopResult.finalText) of
                 (False, Just text) | not (Text.null (Text.strip text)) -> do
-                    color <- hIsTerminalDevice stdout
-                    noColor <- lookupEnv "NO_COLOR"
-                    let useColor = color && maybe True (\_ -> False) noColor
+                    useColor <- resolveColor stdout
                     putTextLn stdout (renderAssistantText useColor text)
                 _ -> pure ()
             afterItems <- readIORef transcriptRef
@@ -394,8 +410,11 @@ runOneTurn config render previous printed transcriptRef persist prompt = do
                     created <- isLeftSlot <$> readIORef slotRef
                     handle <- ensureSession slotRef
                     if created
-                        then hPutStrLn stderr
-                            ("session: " <> Text.unpack handle.sessionMeta.metaId)
+                        then do
+                            color <- resolveColor stderr
+                            putTextLn stderr
+                                (roleMuted color
+                                    ("session: " <> handle.sessionMeta.metaId))
                         else pure ()
                     let turn = SessionTurn
                             { turnAt = now
@@ -407,6 +426,14 @@ runOneTurn config render previous printed transcriptRef persist prompt = do
                     handle' <- appendTurn handle turn
                     writeIORef slotRef (Right handle')
             pure True
+
+
+-- | Color when the handle is a TTY and NO_COLOR is unset.
+resolveColor :: Handle -> IO Bool
+resolveColor handle = do
+    isTty <- hIsTerminalDevice handle
+    noColor <- lookupEnv "NO_COLOR"
+    pure (isTty && maybe True (\_ -> False) noColor)
 
 putTrailingNewline :: IORef Bool -> IO ()
 putTrailingNewline printed = do
@@ -435,7 +462,9 @@ approveTool policyRef tools call = do
         PromptMutating
             | readOnly -> pure True
             | otherwise -> do
-                putTextLn stderr ("Allow " <> summarizeToolCall call <> "? [y/N/a]")
+                color <- resolveColor stderr
+                putTextLn stderr
+                    (roleWarn color ("Allow " <> summarizeToolCall call <> "? [y/N/a]"))
                 eof <- isEOF
                 if eof
                     then pure False
@@ -445,19 +474,20 @@ approveTool policyRef tools call = do
                             AllowOnce -> pure True
                             AllowAlways -> do
                                 writeIORef policyRef ApproveAll
-                                putTextLn stderr "auto-approve on"
+                                putTextLn stderr (roleSuccess color "auto-approve on")
                                 pure True
                             Deny -> pure False
 
 toggleAlwaysApprove :: IORef ApprovalPolicy -> IO ()
 toggleAlwaysApprove policyRef = do
+    color <- resolveColor stderr
     next <- atomicModifyIORef' policyRef \policy ->
         if policy == ApproveAll
             then (PromptMutating, PromptMutating)
             else (ApproveAll, ApproveAll)
     putTextLn stderr (case next of
-        ApproveAll -> "auto-approve on"
-        _ -> "auto-approve off")
+        ApproveAll -> roleSuccess color "auto-approve on"
+        _ -> roleMuted color "auto-approve off")
 
 -- | Rebuild from the constructor: 'input' is also a field on 'CustomToolCall'.
 -- OpenAI keeps @store = true@ so @previous_response_id@ can continue a chain;

--- a/packages/agent-cli/src/Agent/CLI/Markdown.hs
+++ b/packages/agent-cli/src/Agent/CLI/Markdown.hs
@@ -3,6 +3,7 @@ module Agent.CLI.Markdown
     ( renderMarkdown
     ) where
 
+import Agent.CLI.Style (style)
 import Control.Applicative ((<|>))
 import Data.Char (isAlphaNum, isDigit, isSpace)
 import Data.List (transpose)
@@ -16,7 +17,6 @@ import System.Console.ANSI
     , SGR(..)
     , Underlining(..)
     )
-import System.Console.ANSI.Codes (setSGRCode)
 
 -- | When @color@ is 'True', style a useful subset of GFM for a TTY.
 -- When 'False', return @text@ unchanged (pipes, redirects, tests).
@@ -43,14 +43,14 @@ renderBlocks = go
                 header =
                     if Text.null info
                         then []
-                        else [style [SetConsoleIntensity FaintIntensity] info]
+                        else [style True [SetConsoleIntensity FaintIntensity] info]
             in header ++ body ++ go after
         | Just (styled, after) <- takeTable (line : rest) =
             styled ++ go after
         | Just (level, title) <- headingLine line =
             let marker = Text.replicate level "#"
                 prefix =
-                    style
+                    style True
                         [ SetConsoleIntensity BoldIntensity
                         , SetUnderlining SingleUnderline
                         ]
@@ -61,12 +61,12 @@ renderBlocks = go
         | Just item <- orderedItem line =
             styleInline item : go rest
         | Just quote <- blockQuote line =
-            ( style [SetConsoleIntensity FaintIntensity] "│ "
+            ( style True [SetConsoleIntensity FaintIntensity] "│ "
                 <> styleInline quote
             )
                 : go rest
         | isThematicBreak line =
-            style [SetConsoleIntensity FaintIntensity] (Text.replicate 40 "─")
+            style True [SetConsoleIntensity FaintIntensity] (Text.replicate 40 "─")
                 : go rest
         | Text.null (Text.strip line) = line : go rest
         | otherwise = styleInline line : go rest
@@ -201,7 +201,7 @@ styleTableRow isHeader widths cells =
                 (cells ++ repeat "")
         line = Text.intercalate "  " (take (length widths) padded)
     in if isHeader
-        then style [SetConsoleIntensity BoldIntensity] line
+        then style True [SetConsoleIntensity BoldIntensity] line
         else styleInline line
 
 styleInline :: Text -> Text
@@ -211,22 +211,22 @@ styleInline = Text.concat . go Nothing
     go prev t
         | Text.null t = []
         | Just (code, rest) <- takeInlineCode t =
-            style codeStyle code : go (Text.unsnoc code >>= Just . snd) rest
+            style True codeStyle code : go (Text.unsnoc code >>= Just . snd) rest
         | Just (linkText, url, rest) <- takeLink t =
-            style linkStyle (styleInline linkText)
-                : style urlStyle (" (" <> url <> ")")
+            style True linkStyle (styleInline linkText)
+                : style True urlStyle (" (" <> url <> ")")
                 : go (Just ')') rest
         | Just (inner, rest) <- takeEmphasis prev "**" t =
-            style [SetConsoleIntensity BoldIntensity] (styleInline inner)
+            style True [SetConsoleIntensity BoldIntensity] (styleInline inner)
                 : go (Text.unsnoc inner >>= Just . snd) rest
         | Just (inner, rest) <- takeEmphasis prev "__" t =
-            style [SetConsoleIntensity BoldIntensity] (styleInline inner)
+            style True [SetConsoleIntensity BoldIntensity] (styleInline inner)
                 : go (Text.unsnoc inner >>= Just . snd) rest
         | Just (inner, rest) <- takeEmphasis prev "*" t =
-            style [SetItalicized True] (styleInline inner)
+            style True [SetItalicized True] (styleInline inner)
                 : go (Text.unsnoc inner >>= Just . snd) rest
         | Just (inner, rest) <- takeEmphasis prev "_" t =
-            style [SetItalicized True] (styleInline inner)
+            style True [SetItalicized True] (styleInline inner)
                 : go (Text.unsnoc inner >>= Just . snd) rest
         | otherwise =
             let (plain, rest) = Text.break (`elem` ['`', '[', '*', '_']) t
@@ -322,7 +322,3 @@ canClose delim inner after =
 
 isWordChar :: Char -> Bool
 isWordChar c = isAlphaNum c || c == '_'
-
-style :: [SGR] -> Text -> Text
-style attrs text =
-    Text.pack (setSGRCode attrs) <> text <> Text.pack (setSGRCode [Reset])

--- a/packages/agent-cli/src/Agent/CLI/Render.hs
+++ b/packages/agent-cli/src/Agent/CLI/Render.hs
@@ -3,6 +3,8 @@ module Agent.CLI.Render
     ( RenderConfig(..)
     , clearThinking
     , formatLoopError
+    , formatLoopErrorColored
+    , formatToolStarted
     , putTextLn
     , renderAssistantText
     , renderEvent
@@ -11,6 +13,14 @@ module Agent.CLI.Render
     ) where
 
 import Agent.CLI.Markdown (renderMarkdown)
+import Agent.CLI.Style
+    ( roleError
+    , roleThinking
+    , roleToolArrow
+    , roleToolDetail
+    , roleToolName
+    , roleToolOutput
+    )
 import Agent.Loop (LoopError(..), LoopEvent(..), TurnOutput(..))
 import Agent.ToolDispatch (ToolCall(..), ToolCallResult(..))
 import Control.Concurrent.MVar (MVar, withMVar)
@@ -68,9 +78,10 @@ renderEventUnlocked config = \case
                 putTextLn config.renderStdout ""
     ToolStarted call -> do
         clearThinkingUnlocked config
-        putTextLn config.renderStderr ("→ " <> summarizeToolCall call)
+        putTextLn config.renderStderr (formatToolStarted config.renderColor call)
     ToolFinished result ->
-        putTextLn config.renderStderr (truncateToolOutput result.output)
+        putTextLn config.renderStderr
+            (roleToolOutput config.renderColor (truncateToolOutput result.output))
 
 -- | Style assistant markdown when color is enabled; otherwise return plain text.
 renderAssistantText :: Bool -> Text -> Text
@@ -107,7 +118,8 @@ showThinkingUnlocked config
         if visible
             then pure ()
             else do
-                Text.hPutStr config.renderStderr "thinking…"
+                Text.hPutStr config.renderStderr
+                    (roleThinking config.renderColor "thinking…")
                 hFlush config.renderStderr
                 writeIORef config.renderThinkingVisible True
 
@@ -122,7 +134,7 @@ clearThinkingUnlocked config = do
             writeIORef config.renderThinkingVisible False
 
 -- | Write @text@ plus a newline as one 'Text.hPutStr'. @hPutStrLn@ on a
--- 'String' is @hPutStr@ then @hPutChar '\\n'@ over a @[Char]@ spine, so
+-- 'String' is @hPutStr@ then @hPutChar '\n'@ over a @[Char]@ spine, so
 -- concurrent tool threads can interleave characters on the TTY.
 --
 -- Does not take 'renderLock': callers that also read stdin (approval)
@@ -137,6 +149,16 @@ summarizeToolCall :: ToolCall -> Text
 summarizeToolCall call =
     let detail = toolDetail call
     in if Text.null detail then call.name else call.name <> " " <> detail
+
+-- | Colored tool-start line for stderr chrome.
+formatToolStarted :: Bool -> ToolCall -> Text
+formatToolStarted color call =
+    let detail = toolDetail call
+        arrow = roleToolArrow color "→ "
+        name = roleToolName color call.name
+    in if Text.null detail
+        then arrow <> name
+        else arrow <> name <> " " <> roleToolDetail color detail
 
 toolDetail :: ToolCall -> Text
 toolDetail call = case call.name of
@@ -180,9 +202,15 @@ firstLine :: Text -> Text
 firstLine = Text.takeWhile (/= '\n')
 
 formatLoopError :: LoopError -> Text
-formatLoopError = \case
-    LoopTransport err -> "transport error: " <> Text.pack (show err)
+formatLoopError = formatLoopErrorColored False
+
+-- | Like 'formatLoopError', with optional ANSI styling for TTY stderr.
+formatLoopErrorColored :: Bool -> LoopError -> Text
+formatLoopErrorColored color = \case
+    LoopTransport err ->
+        roleError color ("transport error: " <> Text.pack (show err))
     LoopMaxTurns turn ->
-        "stopped: max turns reached"
+        roleError color "stopped: max turns reached"
             <> maybe "" (\text -> "\n" <> text) turn.assistantText
-    LoopNoResponseId -> "transport error: response had no id"
+    LoopNoResponseId ->
+        roleError color "transport error: response had no id"

--- a/packages/agent-cli/src/Agent/CLI/Style.hs
+++ b/packages/agent-cli/src/Agent/CLI/Style.hs
@@ -1,0 +1,86 @@
+-- | Shared ANSI roles for TTY chrome and markdown. Callers pass a color
+-- flag; when 'False' (pipes, 'NO_COLOR', tests) text is unchanged.
+module Agent.CLI.Style
+    ( style
+    , rolePrompt
+    , roleToolArrow
+    , roleToolName
+    , roleToolDetail
+    , roleToolOutput
+    , roleThinking
+    , roleError
+    , roleWarn
+    , roleMuted
+    , roleSuccess
+    ) where
+
+import Data.Text (Text)
+import qualified Data.Text as Text
+import System.Console.ANSI
+    ( Color(..)
+    , ColorIntensity(..)
+    , ConsoleIntensity(..)
+    , ConsoleLayer(..)
+    , SGR(..)
+    )
+import System.Console.ANSI.Codes (setSGRCode)
+
+-- | Apply SGR attributes when @color@ is 'True'; otherwise return @text@.
+style :: Bool -> [SGR] -> Text -> Text
+style color attrs text
+    | not color || Text.null text = text
+    | otherwise =
+        Text.pack (setSGRCode attrs) <> text <> Text.pack (setSGRCode [Reset])
+
+rolePrompt :: Bool -> Text -> Text
+rolePrompt color =
+    style color
+        [ SetConsoleIntensity BoldIntensity
+        , SetColor Foreground Dull Cyan
+        ]
+
+roleToolArrow :: Bool -> Text -> Text
+roleToolArrow color = style color [SetConsoleIntensity FaintIntensity]
+
+roleToolName :: Bool -> Text -> Text
+roleToolName color =
+    style color
+        [ SetConsoleIntensity BoldIntensity
+        , SetColor Foreground Dull Magenta
+        ]
+
+roleToolDetail :: Bool -> Text -> Text
+roleToolDetail color = style color [SetConsoleIntensity FaintIntensity]
+
+roleToolOutput :: Bool -> Text -> Text
+roleToolOutput color = style color [SetConsoleIntensity FaintIntensity]
+
+roleThinking :: Bool -> Text -> Text
+roleThinking color =
+    style color
+        [ SetConsoleIntensity FaintIntensity
+        , SetColor Foreground Dull Yellow
+        ]
+
+roleError :: Bool -> Text -> Text
+roleError color =
+    style color
+        [ SetConsoleIntensity BoldIntensity
+        , SetColor Foreground Vivid Red
+        ]
+
+roleWarn :: Bool -> Text -> Text
+roleWarn color =
+    style color
+        [ SetConsoleIntensity BoldIntensity
+        , SetColor Foreground Dull Yellow
+        ]
+
+roleMuted :: Bool -> Text -> Text
+roleMuted color = style color [SetConsoleIntensity FaintIntensity]
+
+roleSuccess :: Bool -> Text -> Text
+roleSuccess color =
+    style color
+        [ SetColor Foreground Dull Green
+        ]

--- a/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
@@ -2,7 +2,12 @@ module Agent.CLI.RenderSpec (spec) where
 
 import Agent.CLI.Render
 import Agent.Loop (LoopError(..), LoopEvent(..), TurnOutput(..))
-import Agent.ToolDispatch (customToolCall, functionToolCall)
+import Agent.ToolDispatch
+    ( ToolCallKind(..)
+    , ToolCallResult(..)
+    , customToolCall
+    , functionToolCall
+    )
 import Control.Concurrent (forkIO)
 import Control.Concurrent.MVar (newEmptyMVar, newMVar, putMVar, takeMVar)
 import Control.Exception (finally)
@@ -119,6 +124,28 @@ spec = do
                 body `shouldSatisfy` Text.isInfixOf "src"
                 body `shouldSatisfy` Text.isInfixOf "\ESC["
                 readIORef config.renderTextBuffer `shouldReturn` ""
+
+        it "styles tool chrome when color is on" do
+            withRenderConfig False True \config handle path -> do
+                let call = functionToolCall "c1" "list_dir" "{\"target_directory\":\".\"}"
+                renderEvent config (ToolStarted call)
+                renderEvent config (ToolFinished ToolCallResult
+                    { callId = "c1"
+                    , output = "ok\nmore"
+                    , callKind = FunctionCallKind
+                    })
+                hClose handle
+                body <- Text.readFile path
+                body `shouldSatisfy` Text.isInfixOf "list_dir"
+                body `shouldSatisfy` Text.isInfixOf "\ESC["
+                body `shouldSatisfy` Text.isInfixOf "ok"
+
+        it "keeps thinking plain when color is off" do
+            withRenderConfig True False \config handle path -> do
+                renderEvent config TurnStarted
+                hClose handle
+                body <- Text.readFile path
+                body `shouldBe` "thinking…"
 
 withRenderConfig
     :: Bool

--- a/packages/agent-cli/test/Agent/CLI/StyleSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/StyleSpec.hs
@@ -1,0 +1,23 @@
+module Agent.CLI.StyleSpec (spec) where
+
+import Agent.CLI.Style
+import qualified Data.Text as Text
+import Test.Hspec
+
+spec :: Spec
+spec = do
+    describe "style" do
+        it "leaves text unchanged when color is off" do
+            style False [] "plain" `shouldBe` "plain"
+
+        it "wraps text in SGR codes when color is on" do
+            let out = rolePrompt True "agent>"
+            out `shouldSatisfy` Text.isInfixOf "agent>"
+            out `shouldSatisfy` Text.isInfixOf "\ESC["
+            out `shouldSatisfy` (not . Text.isPrefixOf "agent>")
+
+    describe "roles" do
+        it "keeps tool labels readable with color off" do
+            roleToolName False "read_file" `shouldBe` "read_file"
+            roleError False "boom" `shouldBe` "boom"
+            roleMuted False "session: 1" `shouldBe` "session: 1"

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -9,6 +9,7 @@ import qualified Agent.CLI.OptionsSpec as OptionsSpec
 import qualified Agent.CLI.PromptSpec as PromptSpec
 import qualified Agent.CLI.RenderSpec as RenderSpec
 import qualified Agent.CLI.SessionSpec as SessionSpec
+import qualified Agent.CLI.StyleSpec as StyleSpec
 import qualified Agent.CLI.ToolsSpec as ToolsSpec
 import qualified Agent.CLI.WorktreeSpec as WorktreeSpec
 
@@ -20,6 +21,7 @@ main = hspec do
     OptionsSpec.spec
     PromptSpec.spec
     RenderSpec.spec
+    StyleSpec.spec
     SessionSpec.spec
     ToolsSpec.spec
     WorktreeSpec.spec


### PR DESCRIPTION
## Summary
- Add `Agent.CLI.Style` with shared ANSI roles gated by TTY / `NO_COLOR`.
- Color the REPL prompt, tool start/output lines, thinking status, approvals, errors, and muted session/worktree/effort notices.
- Enrich markdown TTY styling: level-colored heading markers, dimmed fenced code bodies, tinted list markers, muted plain blockquotes.
- Keep pipes and `NO_COLOR` plain; strip raw ESC from model output.

## Test plan
- [x] `nix develop -c cabal test agent-cli` (80 examples, 0 failures)
- [ ] Interactive TTY: confirm colored `agent>`, tool lines, thinking, approval prompt, headings/lists/fences
- [ ] `NO_COLOR=1` or redirected stdout: confirm no ANSI codes