### PR TITLE
feat: enrich markdown TTY styling for headings, fences, and lists

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Markdown.hs
+++ b/packages/agent-cli/src/Agent/CLI/Markdown.hs
@@ -43,33 +43,68 @@ renderBlocks = go
                 header =
                     if Text.null info
                         then []
-                        else [style True [SetConsoleIntensity FaintIntensity] info]
-            in header ++ body ++ go after
+                        else
+                            [ style True
+                                [ SetConsoleIntensity FaintIntensity
+                                , SetColor Foreground Dull Cyan
+                                ]
+                                info
+                            ]
+                styledBody = map (style True [SetConsoleIntensity FaintIntensity]) body
+            in header ++ styledBody ++ go after
         | Just (styled, after) <- takeTable (line : rest) =
             styled ++ go after
         | Just (level, title) <- headingLine line =
             let marker = Text.replicate level "#"
-                prefix =
-                    style True
-                        [ SetConsoleIntensity BoldIntensity
-                        , SetUnderlining SingleUnderline
-                        ]
-                        (marker <> " ")
+                prefix = style True (headingPrefixStyle level) (marker <> " ")
             in (prefix <> styleInline title) : go rest
         | Just item <- unorderedItem line =
-            styleInline ("• " <> item) : go rest
-        | Just item <- orderedItem line =
-            styleInline item : go rest
-        | Just quote <- blockQuote line =
-            ( style True [SetConsoleIntensity FaintIntensity] "│ "
-                <> styleInline quote
+            ( style True listMarkerStyle "• "
+                <> styleInline item
             )
+                : go rest
+        | Just (digits, item) <- orderedItemParts line =
+            ( style True listMarkerStyle (digits <> ". ")
+                <> styleInline item
+            )
+                : go rest
+        | Just quote <- blockQuote line =
+            let body
+                    | Text.any (`elem` ['`', '*', '_', '[']) quote = styleInline quote
+                    | otherwise = style True quoteStyle quote
+            in (style True [SetConsoleIntensity FaintIntensity] "│ " <> body)
                 : go rest
         | isThematicBreak line =
             style True [SetConsoleIntensity FaintIntensity] (Text.replicate 40 "─")
                 : go rest
         | Text.null (Text.strip line) = line : go rest
         | otherwise = styleInline line : go rest
+
+-- | Heading marker style: bold + underline + level color.
+headingPrefixStyle :: Int -> [SGR]
+headingPrefixStyle level =
+    SetConsoleIntensity BoldIntensity
+        : SetUnderlining SingleUnderline
+        : headingColor level
+
+headingColor :: Int -> [SGR]
+headingColor = \case
+    1 -> [SetColor Foreground Dull Magenta]
+    2 -> [SetColor Foreground Dull Cyan]
+    3 -> [SetColor Foreground Dull Blue]
+    4 -> [SetColor Foreground Dull Yellow]
+    5 -> [SetColor Foreground Dull Green]
+    _ -> []
+
+listMarkerStyle :: [SGR]
+listMarkerStyle =
+    [ SetConsoleIntensity BoldIntensity
+    , SetColor Foreground Dull Cyan
+    ]
+
+-- | Blockquote body: faint so it sits behind surrounding prose.
+quoteStyle :: [SGR]
+quoteStyle = [SetConsoleIntensity FaintIntensity]
 
 data FenceMarker = BacktickFence !Int | TildeFence !Int
 
@@ -128,13 +163,15 @@ unorderedItem line =
                 Just (Text.strip after)
         _ -> Nothing
 
-orderedItem :: Text -> Maybe Text
-orderedItem line =
+-- | Ordered list: number marker and item body separately so the marker can
+-- be colored without restyling the whole line twice.
+orderedItemParts :: Text -> Maybe (Text, Text)
+orderedItemParts line =
     let stripped = Text.stripStart line
         (digits, after) = Text.span isDigit stripped
     in if not (Text.null digits)
         then case Text.stripPrefix ". " after of
-            Just item -> Just (digits <> ". " <> Text.strip item)
+            Just item -> Just (digits, Text.strip item)
             Nothing -> Nothing
         else Nothing
 

--- a/packages/agent-cli/test/Agent/CLI/MarkdownSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/MarkdownSpec.hs
@@ -23,15 +23,41 @@ spec = do
             out `shouldSatisfy` Text.isInfixOf "use `code` here"
             Text.count "`code`" out `shouldBe` 1
 
-        it "keeps fence body at normal intensity and drops fence markers" do
+        it "dims fence bodies and drops fence markers" do
             let out = renderMarkdown True "```haskell\nmain = pure ()\n```"
             out `shouldSatisfy` Text.isInfixOf "main = pure ()"
             out `shouldSatisfy` (not . Text.isInfixOf "```")
             out `shouldSatisfy` Text.isInfixOf "haskell"
+            out `shouldSatisfy` Text.isInfixOf "\ESC["
 
         it "supports tilde fences" do
             let out = renderMarkdown True "~~~\nbody\n~~~"
-            out `shouldBe` "body"
+            out `shouldSatisfy` Text.isInfixOf "body"
+            out `shouldSatisfy` (not . Text.isInfixOf "~~~")
+
+        it "colors heading markers by level" do
+            let h1 = renderMarkdown True "# Title"
+                h2 = renderMarkdown True "## Title"
+            h1 `shouldSatisfy` Text.isInfixOf "Title"
+            h1 `shouldSatisfy` Text.isInfixOf "\ESC["
+            h2 `shouldSatisfy` Text.isInfixOf "Title"
+            h1 `shouldSatisfy` (/= h2)
+
+        it "colors unordered and ordered list markers" do
+            let ul = renderMarkdown True "- item"
+                ol = renderMarkdown True "1. item"
+            ul `shouldSatisfy` Text.isInfixOf "item"
+            ul `shouldSatisfy` Text.isInfixOf "\ESC["
+            ul `shouldSatisfy` (not . Text.isInfixOf "- item")
+            ol `shouldSatisfy` Text.isInfixOf "item"
+            ol `shouldSatisfy` Text.isInfixOf "\ESC["
+
+        it "mutes plain blockquotes" do
+            let out = renderMarkdown True "> note"
+            out `shouldSatisfy` Text.isInfixOf "note"
+            out `shouldSatisfy` Text.isInfixOf "│"
+            out `shouldSatisfy` Text.isInfixOf "\ESC["
+            out `shouldSatisfy` (not . Text.isInfixOf "> note")
 
         it "styles bold markers" do
             let out = renderMarkdown True "say **hello** there"


### PR DESCRIPTION
## Summary
- Color heading markers by level (magenta → cyan → blue → yellow → green).
- Dim fenced code bodies and tint language tags.
- Tint unordered/ordered list markers and mute plain blockquotes.
- Keep color-off / `NO_COLOR` / pipe output unchanged.

Follow-up to #10 (chrome coloring). This commit landed after that PR merged.

## Test plan
- [x] `nix develop -c cabal test agent-cli` (80 examples, 0 failures)
- [ ] Interactive TTY: headings, lists, fences, blockquotes look distinct
- [ ] `NO_COLOR=1` or redirected stdout: no ANSI codes