### PR TITLE
feat: add /model REPL command

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -46,7 +46,7 @@ import qualified Agent.XAI.Options as XAI
 import Control.Concurrent.MVar (newMVar, withMVar)
 import Control.Exception (finally, try)
 import Data.IORef
-import Data.Maybe (fromMaybe)
+import Data.Maybe (fromMaybe, isJust)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
@@ -174,7 +174,7 @@ runAgent options = do
             OpenAIProvider ->
                 try @CodexAuthFailed
                     (withCodexWsWithProvider loaded.loadedTokenProvider \conn _credential ->
-                        runSession options policy tools prompt paramsRef transcriptRef
+                        runSession options provider policy tools prompt paramsRef transcriptRef
                             initialPrevious persist
                             (openAiBackend conn (readIORef paramsRef) transcriptRef))
                     >>= \case
@@ -184,7 +184,7 @@ runAgent options = do
                 xaiOptions <- XAI.clientOptionsFromEnv
                 credential <- firstCredential loaded
                 let backend = xaiBackend xaiOptions credential (readIORef paramsRef) transcriptRef
-                runSession options policy tools prompt paramsRef transcriptRef
+                runSession options provider policy tools prompt paramsRef transcriptRef
                     initialPrevious persist backend
             OpenRouterProvider -> do
                 openRouterOptions <- OpenRouter.clientOptionsFromEnv
@@ -192,7 +192,7 @@ runAgent options = do
                 let backend =
                         openRouterBackend openRouterOptions credential
                             (readIORef paramsRef) transcriptRef
-                runSession options policy tools prompt paramsRef transcriptRef
+                runSession options provider policy tools prompt paramsRef transcriptRef
                     initialPrevious persist backend
 
 preparePersistence
@@ -250,6 +250,7 @@ isJustCwd options = case options.optCwd of
 
 runSession
     :: CliOptions
+    -> Provider
     -> ApprovalPolicy
     -> [AppTool]
     -> Maybe Text
@@ -259,7 +260,7 @@ runSession
     -> Maybe (IORef (Either SessionCreate SessionHandle))
     -> Backend
     -> IO ()
-runSession options policy tools prompt paramsRef transcriptRef initialPrevious persist backend = do
+runSession options provider policy tools prompt paramsRef transcriptRef initialPrevious persist backend = do
     printed <- newIORef False
     textBuffer <- newIORef ""
     thinkingVisible <- newIORef False
@@ -293,11 +294,12 @@ runSession options policy tools prompt paramsRef transcriptRef initialPrevious p
             ok <- runOneTurn config render previous printed transcriptRef persist text
             if ok then putTrailingNewline printed else exitFailure
         Nothing ->
-            repl config render previous printed paramsRef policyRef transcriptRef persist
+            repl config render provider previous printed paramsRef policyRef transcriptRef persist
 
 repl
     :: LoopConfig
     -> RenderConfig
+    -> Provider
     -> IORef (Maybe Text)
     -> IORef Bool
     -> IORef ResponseCreateParams
@@ -305,7 +307,7 @@ repl
     -> IORef [ResponseItem]
     -> Maybe (IORef (Either SessionCreate SessionHandle))
     -> IO ()
-repl config render previous printed paramsRef policyRef transcriptRef persist = do
+repl config render provider previous printed paramsRef policyRef transcriptRef persist = do
     stdoutColor <- resolveColor stdout
     Text.putStr (rolePrompt stdoutColor "agent> ")
     hFlush stdout
@@ -347,6 +349,36 @@ repl config render previous printed paramsRef policyRef transcriptRef persist = 
                                         writeIORef slotRef
                                             (Right handle { sessionMeta = meta })
                         continue
+                    ReplShowModel -> do
+                        params <- readIORef paramsRef
+                        Text.putStrLn ("model: " <> currentModel params)
+                        continue
+                    ReplSetModel name -> do
+                        modifyIORef' paramsRef (setModel name)
+                        clearedChain <- case provider of
+                            OpenAIProvider ->
+                                atomicModifyIORef' previous \prev ->
+                                    (Nothing, isJust prev)
+                            _ -> pure False
+                        if clearedChain
+                            then Text.putStrLn
+                                ("model set to " <> name
+                                    <> " (conversation continued locally)")
+                            else Text.putStrLn ("model set to " <> name)
+                        case persist of
+                            Nothing -> pure ()
+                            Just slotRef -> do
+                                slot <- readIORef slotRef
+                                case slot of
+                                    Left pending ->
+                                        writeIORef slotRef
+                                            (Left pending { createModel = name })
+                                    Right handle -> do
+                                        let meta = handle.sessionMeta { metaModel = name }
+                                        writeSessionMeta handle.sessionMetaPath meta
+                                        writeIORef slotRef
+                                            (Right handle { sessionMeta = meta })
+                        continue
                     ReplToggleAlwaysApprove -> do
                         toggleAlwaysApprove policyRef
                         continue
@@ -372,7 +404,8 @@ repl config render previous printed paramsRef policyRef transcriptRef persist = 
                         Text.hPutStrLn stderr (roleError color err)
                         continue
   where
-    continue = repl config render previous printed paramsRef policyRef transcriptRef persist
+    continue =
+        repl config render provider previous printed paramsRef policyRef transcriptRef persist
 
 runOneTurn
     :: LoopConfig

--- a/packages/agent-cli/src/Agent/CLI/Command.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command.hs
@@ -2,7 +2,9 @@
 module Agent.CLI.Command
     ( ReplAction(..)
     , currentEffort
+    , currentModel
     , parseReplLine
+    , setModel
     , setReasoningEffort
     ) where
 
@@ -18,6 +20,8 @@ data ReplAction
     | ReplPrompt Text
     | ReplShowEffort
     | ReplSetEffort Text
+    | ReplShowModel
+    | ReplSetModel Text
     | ReplToggleAlwaysApprove
     | ReplShowSession
     | ReplCommandError Text
@@ -43,6 +47,7 @@ parseSlash line = case Text.words line of
     [] -> ReplCommandError "unknown command: /"
     command : args
         | Text.toLower command == "/effort" -> parseEffortCommand args
+        | Text.toLower command == "/model" -> parseModelCommand args
         | Text.toLower command == "/session" ->
             if null args
                 then ReplShowSession
@@ -64,6 +69,15 @@ parseEffortCommand = \case
         Right effort -> ReplSetEffort effort
         Left err -> ReplCommandError (Text.pack err)
     _ -> ReplCommandError "usage: /effort [low|medium|high|xhigh]"
+
+parseModelCommand :: [Text] -> ReplAction
+parseModelCommand = \case
+    [] -> ReplShowModel
+    [name]
+        | Text.null (Text.strip name) ->
+            ReplCommandError "usage: /model [NAME]"
+        | otherwise -> ReplSetModel name
+    _ -> ReplCommandError "usage: /model [NAME]"
 
 -- | Rebuild from the constructor: 'input' is also a field on 'CustomToolCall'.
 setReasoningEffort :: Text -> ResponseCreateParams -> ResponseCreateParams
@@ -87,3 +101,15 @@ setReasoningEffort level ResponseCreateParams{..} =
 currentEffort :: ResponseCreateParams -> Text
 currentEffort params =
     fromMaybe "low" (params.reasoning >>= (.effort))
+
+-- | Rebuild from the constructor: 'input' is also a field on 'CustomToolCall'.
+setModel :: Text -> ResponseCreateParams -> ResponseCreateParams
+setModel name ResponseCreateParams{..} =
+    ResponseCreateParams
+        { model = Just name
+        , ..
+        }
+
+currentModel :: ResponseCreateParams -> Text
+currentModel params =
+    fromMaybe "(unset)" params.model

--- a/packages/agent-cli/src/Agent/CLI/Options.hs
+++ b/packages/agent-cli/src/Agent/CLI/Options.hs
@@ -217,6 +217,7 @@ usage = unlines
     , ""
     , "Without -p/--prompt-file, start a REPL. Interactive REPL sessions are"
     , "persisted under ~/.haskell-agent/sessions. /effort [LEVEL] changes"
-    , "reasoning effort. /always-approve (or :yolo) toggles auto-approve."
+    , "reasoning effort. /model [NAME] shows or changes the model."
+    , "/always-approve (or :yolo) toggles auto-approve."
     , "/session prints the current session id. Ctrl-D or :q exits."
     ]

--- a/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
@@ -44,14 +44,27 @@ spec = do
             parseReplLine "/session now"
                 `shouldBe` ReplCommandError "usage: /session"
 
+        it "shows the current model with a bare /model" do
+            parseReplLine "/model" `shouldBe` ReplShowModel
+            parseReplLine "  /Model  " `shouldBe` ReplShowModel
+
+        it "sets a model name" do
+            parseReplLine "/model grok-4.5" `shouldBe` ReplSetModel "grok-4.5"
+            parseReplLine "/model openai/gpt-5.1"
+                `shouldBe` ReplSetModel "openai/gpt-5.1"
+
+        it "rejects extra args on /model" do
+            parseReplLine "/model grok-4.5 extra"
+                `shouldBe` ReplCommandError "usage: /model [NAME]"
+
         it "rejects unknown levels, extra args, and unknown commands" do
             parseReplLine "/effort bogus"
                 `shouldBe` ReplCommandError
                     "effort must be low, medium, high, or xhigh (got bogus)"
             parseReplLine "/effort high extra"
                 `shouldBe` ReplCommandError "usage: /effort [low|medium|high|xhigh]"
-            parseReplLine "/model grok-4.5"
-                `shouldBe` ReplCommandError "unknown command: /model"
+            parseReplLine "/bogus"
+                `shouldBe` ReplCommandError "unknown command: /bogus"
             parseReplLine "/"
                 `shouldBe` ReplCommandError "unknown command: /"
 
@@ -86,3 +99,26 @@ spec = do
     describe "currentEffort" do
         it "defaults to low when reasoning is missing" do
             currentEffort defaultResponseCreateParams `shouldBe` "low"
+
+    describe "setModel" do
+        it "writes the model onto request params" do
+            let updated = setModel "grok-4.5" defaultResponseCreateParams
+            currentModel updated `shouldBe` "grok-4.5"
+            updated.model `shouldBe` Just "grok-4.5"
+
+        it "preserves other request fields" do
+            let original = case defaultResponseCreateParams of
+                    ResponseCreateParams{..} -> ResponseCreateParams
+                        { model = Just "old-model"
+                        , instructions = Just "keep me"
+                        , store = Just True
+                        , ..
+                        }
+                updated = setModel "new-model" original
+            currentModel updated `shouldBe` "new-model"
+            updated.instructions `shouldBe` Just "keep me"
+            updated.store `shouldBe` Just True
+
+    describe "currentModel" do
+        it "defaults to (unset) when model is missing" do
+            currentModel defaultResponseCreateParams `shouldBe` "(unset)"


### PR DESCRIPTION
## Summary
- Adds `/model` and `/model NAME` to the interactive REPL, parallel to `/effort`.
- Persists the chosen model on session create/meta so resumes keep it.
- On OpenAI, clears `previous_response_id` after a model change and continues from the local transcript.

## Test plan
- [x] `cabal test agent-cli:test:agent-cli-test` (86 examples)
- [ ] Manually: start REPL, `/model`, `/model <name>`, confirm next turn uses the new model
- [ ] On OpenAI after a turn: `/model <other>` should print the local-continuation note