### PR TITLE
feat: replace agent REPL prompt with unicode lambda

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -307,7 +307,7 @@ repl
     -> IO ()
 repl config render previous printed paramsRef policyRef transcriptRef persist = do
     stdoutColor <- resolveColor stdout
-    Text.putStr (rolePrompt stdoutColor "agent> ")
+    Text.putStr (rolePrompt stdoutColor "λ> ")
     hFlush stdout
     done <- isEOF
     if done

--- a/packages/agent-cli/test/Agent/CLI/StyleSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/StyleSpec.hs
@@ -11,10 +11,10 @@ spec = do
             style False [] "plain" `shouldBe` "plain"
 
         it "wraps text in SGR codes when color is on" do
-            let out = rolePrompt True "agent>"
-            out `shouldSatisfy` Text.isInfixOf "agent>"
+            let out = rolePrompt True "λ>"
+            out `shouldSatisfy` Text.isInfixOf "λ>"
             out `shouldSatisfy` Text.isInfixOf "\ESC["
-            out `shouldSatisfy` (not . Text.isPrefixOf "agent>")
+            out `shouldSatisfy` (not . Text.isPrefixOf "λ>")
 
     describe "roles" do
         it "keeps tool labels readable with color off" do


### PR DESCRIPTION
## Summary
- Change the CLI REPL input prompt from `agent>` to `λ>`
- Update the style test fixture to match the new prompt text

## Test plan
- [x] `cabal test agent-cli --test-options='-m "style"'`