### PR TITLE
fix: pass ripgrep options before path terminator

### DIFF
--- a/packages/agent-core/src/Agent/Tools/Grok.hs
+++ b/packages/agent-core/src/Agent/Tools/Grok.hs
@@ -320,10 +320,11 @@ runRipgrep rgPath path args _limit = do
             GrepContent -> ["--heading", "--with-filename", "--line-number"]
             GrepFilesWithMatches -> ["--files-with-matches"]
             GrepCount -> ["--count"]
+        -- All options must come before `--`; ripgrep treats everything after
+        -- as paths, so a trailing `--glob` becomes "No such file or directory".
         rgArgs = concat
             [ modeFlags
             , ["--color=never", "--max-columns", "1000"]
-            , ["--regexp", Text.unpack args.pattern, "--", path]
             , maybe [] (\g -> ["--glob", Text.unpack g]) args.glob
             , maybe [] (\n -> ["-B", show n]) args.before
             , maybe [] (\n -> ["-A", show n]) args.after
@@ -331,6 +332,7 @@ runRipgrep rgPath path args _limit = do
             , ["-i" | args.caseInsensitive]
             , maybe [] (\t -> ["--type", Text.unpack t]) args.fileType
             , if args.multiline then ["-U", "--multiline-dotall"] else []
+            , ["--regexp", Text.unpack args.pattern, "--", path]
             ]
     (code, stdout, stderr) <- readProcessWithExitCode rgPath rgArgs ""
     let raw = Text.pack stdout

--- a/packages/agent-core/test/Agent/Tools/GrokSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/GrokSpec.hs
@@ -99,6 +99,16 @@ spec = describe "Agent.Tools.Grok" do
             output <- runTool session "grep" "{\"pattern\":\"needle\"}"
             output `shouldSatisfy` Text.isInfixOf "needle"
 
+    it "grep accepts glob before the path terminator" do
+        withTempSession \session -> do
+            Text.writeFile (session.grokEnv.toolCwd </> "hit.txt") "needle in haystack\n"
+            Text.writeFile (session.grokEnv.toolCwd </> "hit.md") "needle in markdown\n"
+            output <- runTool session "grep"
+                "{\"pattern\":\"needle\",\"glob\":\"*.txt\"}"
+            output `shouldSatisfy` Text.isInfixOf "hit.txt"
+            output `shouldNotSatisfy` Text.isInfixOf "hit.md"
+            output `shouldNotSatisfy` Text.isInfixOf "No such file or directory"
+
     it "runs a foreground shell command" do
         withTempSession \session -> do
             output <- runTool session "run_terminal_cmd"


### PR DESCRIPTION
## Summary
- Move `--glob`, context flags, `--type`, and multiline options before `--` in `runRipgrep`.
- Add a regression test that greps with `glob` and asserts matches are filtered instead of treating `--glob` as a path.

## Why
When the grep tool was called with `glob` (or `-A`/`-B`/`-C`/`type`/`multiline`), ripgrep failed with `rg: --glob: No such file or directory` even though `rg` was on `PATH` from `nix develop`. Everything after `--` is a path argument.

## Test plan
- [x] `cabal test agent-core --test-options='--match "grep accepts glob"'`
- [ ] Re-run an agent session that previously failed with the `--glob` error