### PR TITLE
chore: slim nix develop and add direnv flake .envrc

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 /dist-newstyle/
 /.direnv/
-/.envrc
 /result
 /result-*
 /.ghc.environment.*

--- a/flake.nix
+++ b/flake.nix
@@ -144,7 +144,6 @@
                         (with haskellPackages; [
                             cabal-install
                             ghcid
-                            haskell-language-server
                         ])
                         ++ (with pkgs; [
                             cabal2nix


### PR DESCRIPTION
## Summary
- Drop `haskell-language-server` from the default `nix develop` shell so every enter does not pull/eval HLS.
- Add a tracked `.envrc` with `use flake` and stop gitignoring it so direnv loads the flake shell automatically.

## Test plan
- [x] `nix eval` / `nix develop -c true` after the HLS removal (HLS absent from shell env)
- [ ] `direnv allow` in the repo and confirm the flake shell activates on `cd`