### PR TITLE
docs: document cabal multi-repl development feedback loop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,9 +29,11 @@ Prefer `cabal repl` over `cabal run` when iterating on the agent itself. Do not 
 
 Load every library you may edit so `:r` recompiles across package boundaries (`agent-cli`, `agent-core`, providers, …):
 
+`cabal.project` sets `multi-repl: True`, so multiple library targets share one GHCi session by default:
+
 ```
 nix develop
-cabal repl --enable-multi-repl \
+cabal repl \
   agent-cli:lib:agent-cli \
   agent-core:lib:agent-core \
   agent-openai:lib:agent-openai \
@@ -55,12 +57,6 @@ withArgs ["--worktree"] run
 ```
 
 Name **library** components explicitly (`pkg:lib:pkg`). Bare package names also pull in tests and executables and load far more modules than you need.
-
-Optional: put this in `cabal.project.local` so you can omit `--enable-multi-repl`:
-
-```
-multi-repl: True
-```
 
 ### lighter: `agent-cli` only
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,5 +21,64 @@ we follow the tool defintions that are used by the first party lab harnesses. e.
 
 use ghci instead of compiling the code. E.g. instead of nix flake check start a ghci and load in the necessary modules. This is way faster than doing a full compile.
 
+## development feedback loop
+
+Prefer `cabal repl` over `cabal run` when iterating on the agent itself. Do not rebuild the binary between UI/logic tweaks; reload in GHCi instead.
+
+### recommended: multi-package repl
+
+Load every library you may edit so `:r` recompiles across package boundaries (`agent-cli`, `agent-core`, providers, …):
+
+```
+nix develop
+cabal repl --enable-multi-repl \
+  agent-cli:lib:agent-cli \
+  agent-core:lib:agent-core \
+  agent-openai:lib:agent-openai \
+  agent-xai:lib:agent-xai \
+  agent-openrouter:lib:agent-openrouter
+```
+
+In GHCi:
+
+```
+import System.Environment (withArgs)
+withArgs ["--worktree"] run
+```
+
+After code changes (any of those packages), stop the running agent, reload, and start again:
+
+```
+:q
+:r
+withArgs ["--worktree"] run
+```
+
+Name **library** components explicitly (`pkg:lib:pkg`). Bare package names also pull in tests and executables and load far more modules than you need.
+
+Optional: put this in `cabal.project.local` so you can omit `--enable-multi-repl`:
+
+```
+multi-repl: True
+```
+
+### lighter: `agent-cli` only
+
+If you are only editing `packages/agent-cli/src`:
+
+```
+cabal repl agent-cli
+```
+
+Same `withArgs ... run` / `:q` / `:r` loop. Dependency packages are linked as built libraries here, so changes in `agent-core` / providers need a repl restart or the multi-package command above.
+
+### pitfalls
+
+- Exit the agent (`:q` or Ctrl-D) before `:r`; a live stdin/WebSocket session blocks GHCi.
+- `--worktree` creates a new worktree each start. To keep iterating in the same tree, use `--resume <id>` or `--cwd <existing-worktree>`.
+- `run` calls `setCurrentDirectory`, so later runs in the same GHCi process inherit that cwd.
+- `cabal repl agent-cli:exe:agent-cli` + `:main` looks convenient but only interprets `Main.hs` and does **not** reload library source changes.
+- Use `ghcid` for typecheck-on-save; keep `cabal repl` + `withArgs ... run` for running the live agent.
+
 # haskell
 - Prefer Control.Exception.Safe over Control.Exception

--- a/cabal.project
+++ b/cabal.project
@@ -6,3 +6,4 @@ packages:
     packages/agent-openrouter
 
 tests: True
+multi-repl: True


### PR DESCRIPTION
## Summary
- Document the GHCi/`cabal repl` development feedback loop in `AGENTS.md` so iterating on the agent does not require `cabal run` rebuilds.
- Recommend multi-package `--enable-multi-repl` with explicit library targets so `:r` picks up edits across `agent-cli`, `agent-core`, and provider packages.
- Call out pitfalls: exe-target `:main` does not reload library sources, quit before `:r`, and worktree/cwd reuse.

## Test plan
- [x] Verified `cabal repl agent-cli` + `withArgs ... run` reloads an `agent>` prompt change via `:r`
- [x] Verified `cabal repl agent-cli:exe:agent-cli` + `:main` does **not** reload library source changes
- [x] Verified multi-repl with all five `:lib:` targets reloads both `agent-cli` prompt edits and `agent-core` source edits via `:r`