### PR TITLE
feat: add /paste command for clipboard images

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -37,6 +37,7 @@ library
     hs-source-dirs:   src
     exposed-modules:  Agent.CLI
                     , Agent.CLI.Auth
+                    , Agent.CLI.Clipboard
                     , Agent.CLI.Command
                     , Agent.CLI.Markdown
                     , Agent.CLI.Options
@@ -75,6 +76,7 @@ test-suite agent-cli-test
     hs-source-dirs:   test
     main-is:          Spec.hs
     other-modules:    Agent.CLI.AuthSpec
+                    , Agent.CLI.ClipboardSpec
                     , Agent.CLI.CommandSpec
                     , Agent.CLI.MarkdownSpec
                     , Agent.CLI.OptionsSpec

--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -4,6 +4,7 @@ module Agent.CLI
     ) where
 
 import Agent.CLI.Auth (LoadedAuth(..), loadAuth)
+import Agent.CLI.Clipboard (formatImageSize, readClipboardImage)
 import Agent.CLI.Command
 import Agent.CLI.Options
 import Agent.CLI.Prompt (defaultModelFor, systemPrompt)
@@ -45,6 +46,7 @@ import Agent.XAI.LoopBackend (xaiBackend)
 import qualified Agent.XAI.Options as XAI
 import Control.Concurrent.MVar (newMVar, withMVar)
 import Control.Exception (finally, try)
+import qualified Data.ByteString as BS
 import Data.IORef
 import Data.Maybe (fromMaybe, isJust)
 import Data.Text (Text)
@@ -292,6 +294,7 @@ runSession options provider policy tools prompt paramsRef transcriptRef initialP
     case prompt of
         Just text -> do
             ok <- runOneTurn config render previous printed transcriptRef persist text
+                [UserMessage text]
             if ok then putTrailingNewline printed else exitFailure
         Nothing ->
             repl config render provider previous printed paramsRef policyRef transcriptRef persist
@@ -323,9 +326,36 @@ repl config render provider previous printed paramsRef policyRef transcriptRef p
                     ReplPrompt text -> do
                         writeIORef printed False
                         _ <- runOneTurn config render previous printed
-                            transcriptRef persist text
+                            transcriptRef persist text [UserMessage text]
                         putTrailingNewline printed
                         continue
+                    ReplPaste caption -> do
+                        clipboard <- readClipboardImage
+                        case clipboard of
+                            Left err -> do
+                                color <- resolveColor stderr
+                                Text.hPutStrLn stderr (roleError color err)
+                                continue
+                            Right image -> do
+                                let promptText =
+                                        if Text.null caption
+                                            then "See attached image."
+                                            else caption
+                                    size = formatImageSize (BS.length image.imageBytes)
+                                color <- resolveColor stdout
+                                Text.putStrLn
+                                    (roleMuted color
+                                        ("pasted " <> image.imageMime <> " (" <> size <> ")"))
+                                writeIORef printed False
+                                _ <- runOneTurn config render previous printed
+                                    transcriptRef persist promptText
+                                    [ UserMultimodal
+                                        { userText = promptText
+                                        , userImages = [image]
+                                        }
+                                    ]
+                                putTrailingNewline printed
+                                continue
                     ReplShowEffort -> do
                         color <- resolveColor stdout
                         params <- readIORef paramsRef
@@ -415,11 +445,12 @@ runOneTurn
     -> IORef [ResponseItem]
     -> Maybe (IORef (Either SessionCreate SessionHandle))
     -> Text
+    -> [TurnInput]
     -> IO Bool
-runOneTurn config render previous printed transcriptRef persist prompt = do
+runOneTurn config render previous printed transcriptRef persist promptText inputs = do
     prev <- readIORef previous
     beforeItems <- readIORef transcriptRef
-    result <- runLoop config prev prompt
+    result <- runLoopInputs config prev inputs
     clearThinking render
     case result of
         Left err -> do
@@ -451,7 +482,7 @@ runOneTurn config render previous printed transcriptRef persist prompt = do
                         else pure ()
                     let turn = SessionTurn
                             { turnAt = now
-                            , turnUserText = prompt
+                            , turnUserText = promptText
                             , turnAssistantText = loopResult.finalText
                             , turnResponseId = Just loopResult.finalResponseId
                             , turnItems = newItems

--- a/packages/agent-cli/src/Agent/CLI/Clipboard.hs
+++ b/packages/agent-cli/src/Agent/CLI/Clipboard.hs
@@ -1,0 +1,99 @@
+-- | Read image bytes from the system clipboard (macOS).
+module Agent.CLI.Clipboard
+    ( readClipboardImage
+    , formatImageSize
+    ) where
+
+import Agent.Loop (ImageAttachment(..))
+import Control.Exception (SomeException, try)
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import Data.Char (toLower)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import System.Directory (getTemporaryDirectory, removeFile)
+import System.Exit (ExitCode(..))
+import System.IO (hClose, openBinaryTempFile)
+import System.Info (os)
+import System.Process (readProcessWithExitCode)
+
+-- | Prefer PNG; fall back to JPEG. macOS only for now.
+readClipboardImage :: IO (Either Text ImageAttachment)
+readClipboardImage
+    | os /= "darwin" =
+        pure (Left "clipboard images are only supported on macOS for now")
+    | otherwise = do
+        png <- readMacClipboardClass "«class PNGf»"
+        case png of
+            Right bytes | not (BS.null bytes) ->
+                pure (Right (ImageAttachment "image/png" bytes))
+            _ -> do
+                jpg <- readMacClipboardClass "JPEG picture"
+                case jpg of
+                    Right bytes | not (BS.null bytes) ->
+                        pure (Right (ImageAttachment "image/jpeg" bytes))
+                    _ ->
+                        pure (Left "no image found on the clipboard")
+
+formatImageSize :: Int -> Text
+formatImageSize n
+    | n < 1024 = Text.pack (show n) <> " B"
+    | n < 1024 * 1024 =
+        Text.pack (show (n `div` 1024)) <> " KB"
+    | otherwise =
+        Text.pack (show (n `div` (1024 * 1024))) <> " MB"
+
+-- | Dump a macOS clipboard type class to a temp file via osascript, then read it.
+readMacClipboardClass :: String -> IO (Either Text ByteString)
+readMacClipboardClass typeClass = do
+    tmpDir <- getTemporaryDirectory
+    result <- try @SomeException do
+        (path, handle) <- openBinaryTempFile tmpDir "agent-clipboard-.bin"
+        hClose handle
+        removeFile path
+        let script =
+                unlines
+                    [ "try"
+                    , "  set clipData to the clipboard as " <> typeClass
+                    , "  set outFile to open for access POSIX file "
+                        <> appleString path
+                        <> " with write permission"
+                    , "  set eof of outFile to 0"
+                    , "  write clipData to outFile"
+                    , "  close access outFile"
+                    , "  return \"ok\""
+                    , "on error errMsg"
+                    , "  try"
+                    , "    close access POSIX file " <> appleString path
+                    , "  end try"
+                    , "  error errMsg"
+                    , "end try"
+                    ]
+        (code, _out, err) <- readProcessWithExitCode "osascript" ["-e", script] ""
+        case code of
+            ExitSuccess -> do
+                bytes <- BS.readFile path
+                _ <- try @SomeException (removeFile path)
+                pure (Right bytes)
+            ExitFailure _ -> do
+                _ <- try @SomeException (removeFile path)
+                pure (Left (clipboardErrorMessage typeClass err))
+    case result of
+        Left ex -> pure (Left (Text.pack (show ex)))
+        Right value -> pure value
+
+clipboardErrorMessage :: String -> String -> Text
+clipboardErrorMessage typeClass err =
+    let cleaned = Text.strip (Text.pack err)
+        lower = Text.pack (map toLower typeClass)
+    in if Text.null cleaned
+        then "no image found on the clipboard (" <> lower <> ")"
+        else "clipboard: " <> cleaned
+
+appleString :: FilePath -> String
+appleString path = "\"" <> escapeApple path <> "\""
+  where
+    escapeApple = concatMap \case
+        '"' -> "\\\""
+        '\\' -> "\\\\"
+        c -> [c]

--- a/packages/agent-cli/src/Agent/CLI/Command.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command.hs
@@ -24,6 +24,7 @@ data ReplAction
     | ReplSetModel Text
     | ReplToggleAlwaysApprove
     | ReplShowSession
+    | ReplPaste Text
     | ReplCommandError Text
     deriving (Eq, Show)
 
@@ -52,6 +53,8 @@ parseSlash line = case Text.words line of
             if null args
                 then ReplShowSession
                 else ReplCommandError "usage: /session"
+        | Text.toLower command == "/paste" ->
+            ReplPaste (Text.strip (Text.drop (Text.length command) line))
         | isAlwaysApproveAlias (Text.drop 1 command) ->
             if null args
                 then ReplToggleAlwaysApprove

--- a/packages/agent-cli/src/Agent/CLI/Options.hs
+++ b/packages/agent-cli/src/Agent/CLI/Options.hs
@@ -219,5 +219,6 @@ usage = unlines
     , "persisted under ~/.haskell-agent/sessions. /effort [LEVEL] changes"
     , "reasoning effort. /model [NAME] shows or changes the model."
     , "/always-approve (or :yolo) toggles auto-approve."
+    , "/paste [TEXT] sends the clipboard image (macOS) with an optional caption."
     , "/session prints the current session id. Ctrl-D or :q exits."
     ]

--- a/packages/agent-cli/test/Agent/CLI/ClipboardSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ClipboardSpec.hs
@@ -1,0 +1,29 @@
+module Agent.CLI.ClipboardSpec (spec) where
+
+import Agent.CLI.Clipboard
+import Agent.Loop (ImageAttachment(..))
+import qualified Data.ByteString as BS
+import qualified Data.Text as Text
+import System.Info (os)
+import Test.Hspec
+
+spec :: Spec
+spec = do
+    describe "formatImageSize" do
+        it "formats bytes, kilobytes, and megabytes" do
+            formatImageSize 500 `shouldBe` "500 B"
+            formatImageSize 2048 `shouldBe` "2 KB"
+            formatImageSize (3 * 1024 * 1024) `shouldBe` "3 MB"
+
+    describe "readClipboardImage" do
+        it "reports unsupported platforms clearly" do
+            result <- readClipboardImage
+            if os == "darwin"
+                then case result of
+                    Left err ->
+                        err `shouldSatisfy` (not . Text.null)
+                    Right ImageAttachment{imageMime, imageBytes} -> do
+                        imageMime `shouldSatisfy` (`elem` ["image/png", "image/jpeg"])
+                        BS.length imageBytes `shouldSatisfy` (> 0)
+                else result `shouldBe`
+                    Left "clipboard images are only supported on macOS for now"

--- a/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
@@ -44,6 +44,14 @@ spec = do
             parseReplLine "/session now"
                 `shouldBe` ReplCommandError "usage: /session"
 
+        it "pastes clipboard images with an optional caption" do
+            parseReplLine "/paste" `shouldBe` ReplPaste ""
+            parseReplLine "  /Paste  " `shouldBe` ReplPaste ""
+            parseReplLine "/paste what is this?"
+                `shouldBe` ReplPaste "what is this?"
+            parseReplLine "/paste   keep  spaces"
+                `shouldBe` ReplPaste "keep  spaces"
+
         it "shows the current model with a bare /model" do
             parseReplLine "/model" `shouldBe` ReplShowModel
             parseReplLine "  /Model  " `shouldBe` ReplShowModel

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -3,6 +3,7 @@ module Main (main) where
 import Test.Hspec (hspec)
 
 import qualified Agent.CLI.AuthSpec as AuthSpec
+import qualified Agent.CLI.ClipboardSpec as ClipboardSpec
 import qualified Agent.CLI.CommandSpec as CommandSpec
 import qualified Agent.CLI.MarkdownSpec as MarkdownSpec
 import qualified Agent.CLI.OptionsSpec as OptionsSpec
@@ -16,6 +17,7 @@ import qualified Agent.CLI.WorktreeSpec as WorktreeSpec
 main :: IO ()
 main = hspec do
     AuthSpec.spec
+    ClipboardSpec.spec
     CommandSpec.spec
     MarkdownSpec.spec
     OptionsSpec.spec

--- a/packages/agent-core/src/Agent/Loop.hs
+++ b/packages/agent-core/src/Agent/Loop.hs
@@ -5,6 +5,7 @@
 -- only sees 'ToolCall' / 'ToolCallResult' and a 'Backend' callback.
 module Agent.Loop
     ( Backend(..)
+    , ImageAttachment(..)
     , LoopConfig(..)
     , LoopEvent(..)
     , LoopError(..)
@@ -14,6 +15,7 @@ module Agent.Loop
     , defaultLoopMaxTurns
     , defaultLoopDispatch
     , runLoop
+    , runLoopInputs
     ) where
 
 import Agent.Error (ApiError)
@@ -27,11 +29,22 @@ import Agent.ToolDispatch
 import Control.Concurrent.Async (mapConcurrently)
 import Control.Concurrent.MVar (newMVar, withMVar)
 import Control.Exception (SomeException)
+import Data.ByteString (ByteString)
 import Data.Text (Text)
 import qualified Data.Text as Text
 
+-- | Image bytes attached to a user turn (PNG/JPEG/…).
+data ImageAttachment = ImageAttachment
+    { imageMime :: !Text
+    , imageBytes :: !ByteString
+    } deriving (Eq, Show)
+
 data TurnInput
     = UserMessage Text
+    | UserMultimodal
+        { userText :: !Text
+        , userImages :: ![ImageAttachment]
+        }
     | CompletedTool ToolCallResult
     deriving (Eq, Show)
 
@@ -100,7 +113,16 @@ runLoop
     -> Maybe Text
     -> Text
     -> IO (Either LoopError LoopResult)
-runLoop config0 previousResponseId prompt = do
+runLoop config previousResponseId prompt =
+    runLoopInputs config previousResponseId [UserMessage prompt]
+
+-- | Same as 'runLoop', but the first turn may be multimodal.
+runLoopInputs
+    :: LoopConfig
+    -> Maybe Text
+    -> [TurnInput]
+    -> IO (Either LoopError LoopResult)
+runLoopInputs config0 previousResponseId firstInputs = do
     -- Tools run with mapConcurrently. Serialize onEvent so a printer
     -- (hPutStrLn on String is not atomic) cannot interleave characters.
     eventLock <- newMVar ()
@@ -134,7 +156,7 @@ runLoop config0 previousResponseId prompt = do
                                     results <- mapConcurrently (runOne config) turn.toolCalls
                                     go (Just turn.responseId) nextTurnsUsed
                                         (map CompletedTool results) (Just turn)
-    go previousResponseId 0 [UserMessage prompt] Nothing
+    go previousResponseId 0 firstInputs Nothing
 
 runOne :: LoopConfig -> ToolCall -> IO ToolCallResult
 runOne config call = do

--- a/packages/agent-core/test/Agent/LoopSpec.hs
+++ b/packages/agent-core/test/Agent/LoopSpec.hs
@@ -39,6 +39,31 @@ spec = describe "runLoop" do
             , (Just "resp-1", [CompletedTool (functionResult "c1" "echo:hi")])
             ]
 
+    it "accepts multimodal first turns via runLoopInputs" do
+        submissions <- newIORef []
+        backend <- scriptedBackend submissions
+            [ Right TurnOutput
+                { responseId = "resp-m"
+                , toolCalls = []
+                , assistantText = Just "saw it"
+                }
+            ]
+        let image = ImageAttachment "image/png" "abc"
+            inputs =
+                [ UserMultimodal
+                    { userText = "see this"
+                    , userImages = [image]
+                    }
+                ]
+        result <- runLoopInputs (testConfig backend) Nothing inputs
+        result `shouldBe` Right LoopResult
+            { finalResponseId = "resp-m"
+            , finalText = Just "saw it"
+            , turnsUsed = 1
+            }
+        seen <- readIORef submissions
+        seen `shouldBe` [(Nothing, inputs)]
+
     it "serializes loopOnEvent across parallel tool calls" do
         inFlight <- newIORef (0 :: Int)
         maxInFlight <- newIORef (0 :: Int)

--- a/packages/agent-openai/src/Agent/OpenAI/LoopBackend.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/LoopBackend.hs
@@ -16,6 +16,7 @@ import Agent.Error (ApiError)
 import Agent.OpenAI.Error (isPreviousResponseIdError)
 import Agent.Loop
     ( Backend(..)
+    , ImageAttachment(..)
     , LoopEvent(..)
     , TurnInput(..)
     , TurnOutput(..)
@@ -34,10 +35,13 @@ import Control.Applicative ((<|>))
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KeyMap
+import Data.ByteString (ByteString)
+import qualified "base64-bytestring" Data.ByteString.Base64 as Base64
 import Data.IORef
 import Data.Maybe (mapMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
 
 -- | Close over a live Codex WebSocket and the request fields the loop does
 -- not own (model, instructions, tools, reasoning). The params action is
@@ -98,6 +102,7 @@ turnInputsToItems = map turnInputToItem
 turnInputToItem :: TurnInput -> ResponseItem
 turnInputToItem = \case
     UserMessage text -> userMessageItem text
+    UserMultimodal{userText, userImages} -> multimodalUserItem userText userImages
     CompletedTool result -> toolResultToItem result
 
 userMessageItem :: Text -> ResponseItem
@@ -109,6 +114,33 @@ userMessageItem text = MessageItem ResponseMessage
     , phase = Nothing
     , extraFields = KeyMap.empty
     }
+
+multimodalUserItem :: Text -> [ImageAttachment] -> ResponseItem
+multimodalUserItem text images = MessageItem ResponseMessage
+    { messageId = Nothing
+    , content = MessageContentParts
+        ( InputTextPart text Nothing KeyMap.empty
+        : map imageAttachmentPart images
+        )
+    , role = RoleUser
+    , status = Nothing
+    , phase = Nothing
+    , extraFields = KeyMap.empty
+    }
+
+imageAttachmentPart :: ImageAttachment -> ResponseContentPart
+imageAttachmentPart ImageAttachment{imageMime, imageBytes} =
+    InputImagePart
+        { detail = Just "auto"
+        , fileId = Nothing
+        , imageUrl = Just (imageDataUrl imageMime imageBytes)
+        , promptCacheBreakpoint = Nothing
+        , extraFields = KeyMap.empty
+        }
+
+imageDataUrl :: Text -> ByteString -> Text
+imageDataUrl mime bytes =
+    "data:" <> mime <> ";base64," <> Text.decodeUtf8 (Base64.encode bytes)
 
 toolResultToItem :: ToolCallResult -> ResponseItem
 toolResultToItem result = case result.callKind of

--- a/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
@@ -23,6 +23,32 @@ spec = do
                         MessageContentParts [InputTextPart "hello" Nothing KeyMap.empty]
                 other -> expectationFailure ("expected one user message, got " <> show other)
 
+        it "encodes multimodal turns as input_text plus input_image data URLs" do
+            let image = ImageAttachment "image/png" "png-bytes"
+            case turnInputsToItems
+                    [UserMultimodal "see this" [image]] of
+                [MessageItem message] -> do
+                    message.role `shouldBe` RoleUser
+                    case message.content of
+                        MessageContentParts
+                            [ InputTextPart text Nothing _
+                            , InputImagePart
+                                { detail
+                                , fileId
+                                , imageUrl
+                                }
+                            ] -> do
+                            text `shouldBe` "see this"
+                            detail `shouldBe` Just "auto"
+                            fileId `shouldBe` Nothing
+                            imageUrl `shouldBe`
+                                Just "data:image/png;base64,cG5nLWJ5dGVz"
+                        other ->
+                            expectationFailure
+                                ("expected text+image parts, got " <> show other)
+                other ->
+                    expectationFailure ("expected one user message, got " <> show other)
+
         it "encodes function results as function_call_output strings" do
             let items = turnInputsToItems
                     [CompletedTool (functionResult "c1" "echoed")]


### PR DESCRIPTION
## Summary
- Adds `/paste [caption]` to read a macOS clipboard image and send it as a multimodal user turn.
- Extends the agent loop with `UserMultimodal` / `ImageAttachment` and encodes images as `input_image` data URLs in the OpenAI Responses backend (shared by xAI / OpenRouter).
- Includes command, loop, backend, and clipboard helper tests.

## Test plan
- [ ] `cabal test agent-core agent-openai agent-cli`
- [ ] In the REPL on macOS, copy an image and run `/paste` and `/paste what is this?`
- [ ] Confirm non-image clipboard / non-macOS cases print a clear error and do not send a turn