### PR TITLE
feat: reload xAI/OpenRouter auth on provider rejection

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -31,8 +31,11 @@ import Agent.OpenAI.LoopBackend (openAiBackend)
 import Agent.OpenAI.Responses.Types
 import Agent.OpenAI.WebSocketClient (CodexAuthFailed(..), withCodexWsWithProvider)
 import Agent.Provider
-    ( Credential(..)
+    ( AccountFailure(..)
+    , Credential(..)
+    , FailedCredential(..)
     , Provider(..)
+    , TokenProvider
     , getNextToken
     , providerSlug
     )
@@ -175,25 +178,25 @@ runAgent options = do
                 try @CodexAuthFailed
                     (withCodexWsWithProvider loaded.loadedTokenProvider \conn _credential ->
                         runSession options provider policy tools prompt paramsRef transcriptRef
-                            initialPrevious persist
+                            initialPrevious persist Nothing
                             (openAiBackend conn (readIORef paramsRef) transcriptRef))
                     >>= \case
                         Left (CodexAuthFailed err) -> die ("openai auth: " <> show err)
                         Right () -> pure ()
             XAIProvider -> do
                 xaiOptions <- XAI.clientOptionsFromEnv
-                credential <- firstCredential loaded
-                let backend = xaiBackend xaiOptions credential (readIORef paramsRef) transcriptRef
-                runSession options provider policy tools prompt paramsRef transcriptRef
-                    initialPrevious persist backend
-            OpenRouterProvider -> do
-                openRouterOptions <- OpenRouter.clientOptionsFromEnv
-                credential <- firstCredential loaded
                 let backend =
-                        openRouterBackend openRouterOptions credential
+                        xaiBackend xaiOptions loaded.loadedTokenProvider
                             (readIORef paramsRef) transcriptRef
                 runSession options provider policy tools prompt paramsRef transcriptRef
-                    initialPrevious persist backend
+                    initialPrevious persist (Just loaded.loadedTokenProvider) backend
+            OpenRouterProvider -> do
+                openRouterOptions <- OpenRouter.clientOptionsFromEnv
+                let backend =
+                        openRouterBackend openRouterOptions loaded.loadedTokenProvider
+                            (readIORef paramsRef) transcriptRef
+                runSession options provider policy tools prompt paramsRef transcriptRef
+                    initialPrevious persist (Just loaded.loadedTokenProvider) backend
 
 preparePersistence
     :: CliOptions
@@ -258,9 +261,10 @@ runSession
     -> IORef [ResponseItem]
     -> Maybe Text
     -> Maybe (IORef (Either SessionCreate SessionHandle))
+    -> Maybe TokenProvider
     -> Backend
     -> IO ()
-runSession options provider policy tools prompt paramsRef transcriptRef initialPrevious persist backend = do
+runSession options provider policy tools prompt paramsRef transcriptRef initialPrevious persist tokenProvider backend = do
     printed <- newIORef False
     textBuffer <- newIORef ""
     thinkingVisible <- newIORef False
@@ -294,7 +298,8 @@ runSession options provider policy tools prompt paramsRef transcriptRef initialP
             ok <- runOneTurn config render previous printed transcriptRef persist text
             if ok then putTrailingNewline printed else exitFailure
         Nothing ->
-            repl config render provider previous printed paramsRef policyRef transcriptRef persist
+            repl config render provider previous printed paramsRef policyRef
+                transcriptRef persist tokenProvider
 
 repl
     :: LoopConfig
@@ -306,8 +311,9 @@ repl
     -> IORef ApprovalPolicy
     -> IORef [ResponseItem]
     -> Maybe (IORef (Either SessionCreate SessionHandle))
+    -> Maybe TokenProvider
     -> IO ()
-repl config render provider previous printed paramsRef policyRef transcriptRef persist = do
+repl config render provider previous printed paramsRef policyRef transcriptRef persist tokenProvider = do
     stdoutColor <- resolveColor stdout
     Text.putStr (rolePrompt stdoutColor "λ> ")
     hFlush stdout
@@ -399,13 +405,50 @@ repl config render provider previous printed paramsRef policyRef transcriptRef p
                                             (roleMuted color
                                                 ("session: " <> handle.sessionMeta.metaId))
                         continue
+                    ReplReloadAuth -> do
+                        reloadAuth provider tokenProvider
+                        continue
                     ReplCommandError err -> do
                         color <- resolveColor stderr
                         Text.hPutStrLn stderr (roleError color err)
                         continue
   where
     continue =
-        repl config render provider previous printed paramsRef policyRef transcriptRef persist
+        repl config render provider previous printed paramsRef policyRef
+            transcriptRef persist tokenProvider
+
+reloadAuth :: Provider -> Maybe TokenProvider -> IO ()
+reloadAuth provider = \case
+    Nothing -> do
+        color <- resolveColor stderr
+        putTextLn stderr $ roleMuted color $
+            "reload-auth: OpenAI WebSocket auth is fixed for this process; "
+                <> "restart after refreshing ~/.codex/auth.json "
+                <> "(OAuth pools already rotate on handshake failure)"
+    Just tokenProvider ->
+        -- Force a disk/env re-read by pretending the cached credential was
+        -- rejected for authentication; the reloadable provider clears its cache.
+        getNextToken tokenProvider (Just FailedCredential
+            { credential = Credential
+                { accessToken = ""
+                , accountId = ""
+                , leaseId = Nothing
+                , provider
+                }
+            , failure = AccountAuthenticationRejected
+            }) >>= \case
+            Left err -> do
+                color <- resolveColor stderr
+                putTextLn stderr $ roleError color $
+                    "reload-auth failed: " <> Text.pack (show err)
+            Right credential -> do
+                color <- resolveColor stdout
+                Text.putStrLn $ roleSuccess color $
+                    "auth reloaded ("
+                        <> providerSlug provider
+                        <> " account "
+                        <> credential.accountId
+                        <> ")"
 
 runOneTurn
     :: LoopConfig
@@ -478,12 +521,6 @@ loadPrompt options = case (options.optPrompt, options.optPromptFile) of
     (Just text, _) -> pure (Just text)
     (_, Just path) -> Just . Text.strip <$> Text.readFile path
     _ -> pure Nothing
-
-firstCredential :: LoadedAuth -> IO Credential
-firstCredential loaded =
-    getNextToken loaded.loadedTokenProvider Nothing >>= \case
-        Left err -> die ("credential: " <> show err)
-        Right credential -> pure credential
 
 approveTool :: IORef ApprovalPolicy -> [AppTool] -> ToolCall -> IO Bool
 approveTool policyRef tools call = do

--- a/packages/agent-cli/src/Agent/CLI/Auth.hs
+++ b/packages/agent-cli/src/Agent/CLI/Auth.hs
@@ -4,6 +4,7 @@ module Agent.CLI.Auth
     , grokCredentialFromAuthJson
     , loadAuth
     , openaiAuthStateFromJson
+    , reloadableFileCredentialProvider
     ) where
 
 import Agent.Broker (BrokerOptions(..), newBrokerTokenProvider)
@@ -12,7 +13,9 @@ import qualified Agent.OpenAI.Auth as OpenAI
 import qualified Agent.OpenAI.Credential as OpenAICredential
 import qualified Agent.OpenAI.Login as OpenAILogin
 import Agent.Provider
-    ( Credential(..)
+    ( AccountFailure(..)
+    , Credential(..)
+    , FailedCredential(..)
     , Provider(..)
     , TokenProvider(..)
     , getNextToken
@@ -26,11 +29,12 @@ import Data.Aeson ((.=))
 import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KeyMap
 import qualified Data.ByteString.Lazy as LBS
+import Data.IORef (newIORef, readIORef, writeIORef)
 import Data.Maybe (fromMaybe, isJust, listToMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
-import Data.Time.Clock (UTCTime, getCurrentTime)
+import Data.Time.Clock (UTCTime, addUTCTime, getCurrentTime)
 import System.Directory (doesFileExist, getHomeDirectory)
 import System.Environment (lookupEnv)
 import System.FilePath ((</>))
@@ -98,20 +102,26 @@ loadXai = do
     credential <- loadGrokCredential
     case credential of
         Nothing -> pure (Left noAuthHint)
-        Just loaded -> pure $ Right LoadedAuth
-            { loadedProvider = XAIProvider
-            , loadedTokenProvider = staticCredentialProvider loaded
-            }
+        Just loaded -> do
+            provider <- reloadableFileCredentialProvider XAIProvider loaded loadGrokCredential
+            pure $ Right LoadedAuth
+                { loadedProvider = XAIProvider
+                , loadedTokenProvider = provider
+                }
 
 loadOpenRouter :: IO (Either String LoadedAuth)
 loadOpenRouter = do
     key <- lookupNonEmpty "OPENROUTER_API_KEY"
     case key of
         Nothing -> pure (Left noAuthHint)
-        Just apiKey -> pure $ Right LoadedAuth
-            { loadedProvider = OpenRouterProvider
-            , loadedTokenProvider = staticCredentialProvider (credentialFromApiKey apiKey)
-            }
+        Just apiKey -> do
+            let initial = credentialFromApiKey apiKey
+            provider <- reloadableFileCredentialProvider OpenRouterProvider initial
+                (fmap (fmap credentialFromApiKey) (lookupNonEmpty "OPENROUTER_API_KEY"))
+            pure $ Right LoadedAuth
+                { loadedProvider = OpenRouterProvider
+                , loadedTokenProvider = provider
+                }
 
 loadOpenAi :: IO (Either String LoadedAuth)
 loadOpenAi = do
@@ -276,6 +286,54 @@ hasOpenAiAuth = do
 
 hasOpenRouterAuth :: IO Bool
 hasOpenRouterAuth = isJust <$> lookupNonEmpty "OPENROUTER_API_KEY"
+
+-- | Cache one credential and only re-read disk/env after the provider rejects
+-- it for authentication. Rate-limit failures stay exhausted rather than
+-- spinning on the same key.
+reloadableFileCredentialProvider
+    :: Provider
+    -> Credential
+    -> IO (Maybe Credential)
+    -> IO TokenProvider
+reloadableFileCredentialProvider expectedProvider initial reload = do
+    cache <- newIORef (Just initial)
+    let loadFresh rejectedToken =
+            reload >>= \case
+                Nothing ->
+                    pure $ Left $ ProviderError AuthenticationError
+                        "no credentials found while reloading auth"
+                        Nothing
+                Just credential
+                    | credential.provider /= expectedProvider ->
+                        pure $ Left $ ProviderError AuthenticationError
+                            ("reloaded auth resolved "
+                                <> Text.pack (show credential.provider)
+                                <> " but this session expects "
+                                <> Text.pack (show expectedProvider))
+                            Nothing
+                    | rejectedToken == Just credential.accessToken ->
+                        pure $ Left $ ProviderError AuthenticationError
+                            "reloaded credential is unchanged; refresh ~/.grok/auth.json or OPENROUTER_API_KEY and retry"
+                            Nothing
+                    | otherwise -> do
+                        writeIORef cache (Just credential)
+                        pure (Right credential)
+    pure $ TokenProvider \failed -> case failed of
+        Just FailedCredential { failure = AccountRateLimited { retryAfterSeconds } } -> do
+            now <- getCurrentTime
+            let seconds = max 1 (fromMaybe 60 retryAfterSeconds)
+            pure $ Left $ CredentialsExhausted
+                (addUTCTime (fromIntegral seconds) now)
+        Just FailedCredential
+            { credential = rejected
+            , failure = AccountAuthenticationRejected
+            } -> do
+            writeIORef cache Nothing
+            loadFresh (Just rejected.accessToken)
+        Nothing ->
+            readIORef cache >>= \case
+                Just credential -> pure (Right credential)
+                Nothing -> loadFresh Nothing
 
 staticCredentialProvider :: Credential -> TokenProvider
 staticCredentialProvider credential = TokenProvider \failed ->

--- a/packages/agent-cli/src/Agent/CLI/Command.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command.hs
@@ -24,6 +24,7 @@ data ReplAction
     | ReplSetModel Text
     | ReplToggleAlwaysApprove
     | ReplShowSession
+    | ReplReloadAuth
     | ReplCommandError Text
     deriving (Eq, Show)
 
@@ -52,6 +53,10 @@ parseSlash line = case Text.words line of
             if null args
                 then ReplShowSession
                 else ReplCommandError "usage: /session"
+        | Text.toLower command == "/reload-auth" ->
+            if null args
+                then ReplReloadAuth
+                else ReplCommandError "usage: /reload-auth"
         | isAlwaysApproveAlias (Text.drop 1 command) ->
             if null args
                 then ReplToggleAlwaysApprove

--- a/packages/agent-cli/src/Agent/CLI/Options.hs
+++ b/packages/agent-cli/src/Agent/CLI/Options.hs
@@ -219,5 +219,8 @@ usage = unlines
     , "persisted under ~/.haskell-agent/sessions. /effort [LEVEL] changes"
     , "reasoning effort. /model [NAME] shows or changes the model."
     , "/always-approve (or :yolo) toggles auto-approve."
-    , "/session prints the current session id. Ctrl-D or :q exits."
+    , "/session prints the current session id."
+    , "/reload-auth forces a re-read of xAI/OpenRouter credentials;"
+    , "auth failures also reload once and retry automatically."
+    , "Ctrl-D or :q exits."
     ]

--- a/packages/agent-cli/test/Agent/CLI/AuthSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/AuthSpec.hs
@@ -1,11 +1,21 @@
 module Agent.CLI.AuthSpec (spec) where
 
 import Agent.CLI.Auth
+import Agent.Error (ApiError(..), ErrorType(..))
 import Agent.OpenAI.Auth (AuthState(..))
+import Agent.Provider
+    ( AccountFailure(..)
+    , Credential(..)
+    , FailedCredential(..)
+    , Provider(..)
+    , getNextToken
+    )
 import Data.Aeson ((.=))
 import qualified Data.Aeson as Aeson
+import Data.IORef
 import Data.Maybe (isNothing)
 import Data.Text (Text)
+import qualified Data.Text as Text
 import Data.Time.Calendar (fromGregorian)
 import Data.Time.Clock (UTCTime(..))
 import Test.Hspec
@@ -42,6 +52,58 @@ spec = do
             grokCredentialFromAuthJson
                 "{\"issuer::client\":{\"access_token\":\"nested-tok\"}}"
                 `shouldBe` Just "nested-tok"
+
+    describe "reloadableFileCredentialProvider" do
+        it "returns the cached credential without reloading" do
+            loads <- newIORef (0 :: Int)
+            provider <- reloadableFileCredentialProvider XAIProvider staleGrok
+                (modifyIORef' loads (+ 1) >> pure (Just freshGrok))
+            first <- getNextToken provider Nothing
+            second <- getNextToken provider Nothing
+            first `shouldBe` Right staleGrok
+            second `shouldBe` Right staleGrok
+            readIORef loads `shouldReturn` 0
+
+        it "reloads after an authentication rejection" do
+            loads <- newIORef (0 :: Int)
+            provider <- reloadableFileCredentialProvider XAIProvider staleGrok
+                (modifyIORef' loads (+ 1) >> pure (Just freshGrok))
+            reloaded <- getNextToken provider (Just FailedCredential
+                { credential = staleGrok
+                , failure = AccountAuthenticationRejected
+                })
+            reloaded `shouldBe` Right freshGrok
+            getNextToken provider Nothing `shouldReturn` Right freshGrok
+            readIORef loads `shouldReturn` 1
+
+        it "rejects an unchanged reload after authentication failure" do
+            provider <- reloadableFileCredentialProvider XAIProvider staleGrok
+                (pure (Just staleGrok))
+            result <- getNextToken provider (Just FailedCredential
+                { credential = staleGrok
+                , failure = AccountAuthenticationRejected
+                })
+            case result of
+                Left (ProviderError AuthenticationError message _) ->
+                    Text.unpack message `shouldContain`
+                        "reloaded credential is unchanged"
+                other -> expectationFailure ("expected AuthenticationError, got " <> show other)
+
+staleGrok :: Credential
+staleGrok = Credential
+    { accessToken = "stale"
+    , accountId = "acc-stale"
+    , leaseId = Nothing
+    , provider = XAIProvider
+    }
+
+freshGrok :: Credential
+freshGrok = Credential
+    { accessToken = "fresh"
+    , accountId = "acc-fresh"
+    , leaseId = Nothing
+    , provider = XAIProvider
+    }
 
 epoch :: UTCTime
 epoch = UTCTime (fromGregorian 2026 1 1) 0

--- a/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
@@ -44,6 +44,12 @@ spec = do
             parseReplLine "/session now"
                 `shouldBe` ReplCommandError "usage: /session"
 
+        it "reloads auth from disk/env" do
+            parseReplLine "/reload-auth" `shouldBe` ReplReloadAuth
+            parseReplLine "  /Reload-Auth  " `shouldBe` ReplReloadAuth
+            parseReplLine "/reload-auth now"
+                `shouldBe` ReplCommandError "usage: /reload-auth"
+
         it "shows the current model with a bare /model" do
             parseReplLine "/model" `shouldBe` ReplShowModel
             parseReplLine "  /Model  " `shouldBe` ReplShowModel

--- a/packages/agent-openrouter/src/Agent/OpenRouter/LoopBackend.hs
+++ b/packages/agent-openrouter/src/Agent/OpenRouter/LoopBackend.hs
@@ -19,23 +19,29 @@ import Agent.OpenAI.LoopBackend
     , withRequestInput
     )
 import Agent.OpenAI.Responses.Types
-import Agent.Provider (Credential)
+import Agent.Provider
+    ( TokenProvider
+    , runWithTokenProvider
+    )
 import Agent.OpenRouter.Client (createResponseWithEvents)
 import Agent.OpenRouter.Options (ClientOptions)
 import Data.IORef
 
--- | Close over OpenRouter options, credential, and the request fields the
--- loop does not own (model, instructions, tools, reasoning). The params
--- action is re-run each turn so the REPL can change reasoning effort
+-- | Close over OpenRouter options, a token provider, and the request fields
+-- the loop does not own (model, instructions, tools, reasoning). Credentials
+-- stay cached; an auth rejection triggers one provider reload and retry.
+-- Params are re-read each turn so the REPL can change reasoning effort
 -- without dropping the local transcript.
 openRouterBackend
     :: ClientOptions
-    -> Credential
+    -> TokenProvider
     -> IO ResponseCreateParams
     -> IORef [ResponseItem]
     -> Backend
-openRouterBackend options credential =
-    openRouterBackendWith (createResponseWithEvents options credential)
+openRouterBackend options provider =
+    openRouterBackendWith \params onEvent ->
+        runWithTokenProvider provider \credential ->
+            createResponseWithEvents options credential params onEvent
 
 -- | Same mapping as 'openRouterBackend', with an injectable transport for tests.
 openRouterBackendWith

--- a/packages/agent-xai/src/Agent/XAI/LoopBackend.hs
+++ b/packages/agent-xai/src/Agent/XAI/LoopBackend.hs
@@ -19,23 +19,29 @@ import Agent.OpenAI.LoopBackend
     , withRequestInput
     )
 import Agent.OpenAI.Responses.Types
-import Agent.Provider (Credential)
+import Agent.Provider
+    ( TokenProvider
+    , runWithTokenProvider
+    )
 import Agent.XAI.Client (createResponseWithEvents)
 import Agent.XAI.Options (ClientOptions)
 import Data.IORef
 
--- | Close over xAI options, credential, and the request fields the loop does
--- not own (model, instructions, tools, reasoning). The params action is
--- re-run each turn so the REPL can change reasoning effort without dropping
--- the local transcript.
+-- | Close over xAI options, a token provider, and the request fields the loop
+-- does not own (model, instructions, tools, reasoning). Credentials stay
+-- cached; an auth rejection from the proxy triggers one provider reload and
+-- retry. Params are re-read each turn so the REPL can change reasoning effort
+-- without dropping the local transcript.
 xaiBackend
     :: ClientOptions
-    -> Credential
+    -> TokenProvider
     -> IO ResponseCreateParams
     -> IORef [ResponseItem]
     -> Backend
-xaiBackend options credential =
-    xaiBackendWith (createResponseWithEvents options credential)
+xaiBackend options provider =
+    xaiBackendWith \params onEvent ->
+        runWithTokenProvider provider \credential ->
+            createResponseWithEvents options credential params onEvent
 
 -- | Same mapping as 'xaiBackend', with an injectable transport for tests.
 xaiBackendWith


### PR DESCRIPTION
## Summary
- Cache xAI/OpenRouter credentials for normal turns instead of freezing a static token for the whole process.
- On provider auth rejection (or `/reload-auth`), re-read disk/env once, reject unchanged tokens, and retry the request.
- Wire `xaiBackend` / `openRouterBackend` through `TokenProvider` + `runWithTokenProvider` so the retry path is shared.

## Test plan
- [x] `cabal test agent-cli` (includes new reloadable provider + `/reload-auth` parse tests)
- [x] `cabal test agent-xai`
- [x] `cabal test agent-openrouter`
- [ ] Manual: start a Grok REPL, expire/replace `~/.grok/auth.json`, confirm the next turn reloads and continues without restart
- [ ] Manual: `/reload-auth` after `grok login --oauth` reports the reloaded account id