### PR TITLE
feat: print --resume hint on Ctrl-C

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -58,6 +58,7 @@ library
                     , directory
                     , filepath
                     , process
+                    , safe-exceptions
                     , text >= 2.0 && < 2.2
                     , time
                     , unix

--- a/packages/agent-cli/package.nix
+++ b/packages/agent-cli/package.nix
@@ -1,6 +1,6 @@
 { mkDerivation, aeson, agent-core, agent-openai, agent-openrouter
 , agent-xai, ansi-terminal, base, bytestring, directory, filepath
-, hspec, lib, process, text, time, unix
+, hspec, lib, process, safe-exceptions, text, time, unix
 }:
 mkDerivation {
   pname = "agent-cli";
@@ -10,8 +10,8 @@ mkDerivation {
   isExecutable = true;
   libraryHaskellDepends = [
     aeson agent-core agent-openai agent-openrouter agent-xai
-    ansi-terminal base bytestring directory filepath process text time
-    unix
+    ansi-terminal base bytestring directory filepath process
+    safe-exceptions text time unix
   ];
   executableHaskellDepends = [ base ];
   testHaskellDepends = [

--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -44,7 +44,13 @@ import qualified Agent.OpenRouter.Options as OpenRouter
 import Agent.XAI.LoopBackend (xaiBackend)
 import qualified Agent.XAI.Options as XAI
 import Control.Concurrent.MVar (newMVar, withMVar)
-import Control.Exception (finally, try)
+import Control.Exception
+    ( AsyncException(UserInterrupt)
+    , catch
+    , finally
+    , throwIO
+    , try
+    )
 import Data.IORef
 import Data.Maybe (fromMaybe, isJust)
 import Data.Text (Text)
@@ -54,7 +60,7 @@ import Data.Time.Clock (getCurrentTime, utctDay)
 import Data.Time.Format (defaultTimeLocale, formatTime)
 import qualified Data.Aeson.KeyMap as KeyMap
 import System.Directory (getCurrentDirectory, getHomeDirectory, makeAbsolute, setCurrentDirectory)
-import System.Environment (getArgs, lookupEnv)
+import System.Environment (getArgs, getProgName, lookupEnv)
 import System.FilePath ((</>))
 import System.Exit (die, exitFailure)
 import System.IO (Handle, hFlush, hIsTerminalDevice, isEOF, stderr, stdin, stdout)
@@ -170,30 +176,32 @@ runAgent options = do
         prompt <- loadPrompt options
 
         persist <- preparePersistence options root provider model cwd effort prompt resumed
-        case provider of
-            OpenAIProvider ->
-                try @CodexAuthFailed
-                    (withCodexWsWithProvider loaded.loadedTokenProvider \conn _credential ->
-                        runSession options provider policy tools prompt paramsRef transcriptRef
-                            initialPrevious persist
-                            (openAiBackend conn (readIORef paramsRef) transcriptRef))
-                    >>= \case
-                        Left (CodexAuthFailed err) -> die ("openai auth: " <> show err)
-                        Right () -> pure ()
-            XAIProvider -> do
-                xaiOptions <- XAI.clientOptionsFromEnv
-                credential <- firstCredential loaded
-                let backend = xaiBackend xaiOptions credential (readIORef paramsRef) transcriptRef
-                runSession options provider policy tools prompt paramsRef transcriptRef
-                    initialPrevious persist backend
-            OpenRouterProvider -> do
-                openRouterOptions <- OpenRouter.clientOptionsFromEnv
-                credential <- firstCredential loaded
-                let backend =
-                        openRouterBackend openRouterOptions credential
-                            (readIORef paramsRef) transcriptRef
-                runSession options provider policy tools prompt paramsRef transcriptRef
-                    initialPrevious persist backend
+        progName <- getProgName
+        withInterruptResume progName persist do
+            case provider of
+                OpenAIProvider ->
+                    try @CodexAuthFailed
+                        (withCodexWsWithProvider loaded.loadedTokenProvider \conn _credential ->
+                            runSession options provider policy tools prompt paramsRef transcriptRef
+                                initialPrevious persist
+                                (openAiBackend conn (readIORef paramsRef) transcriptRef))
+                        >>= \case
+                            Left (CodexAuthFailed err) -> die ("openai auth: " <> show err)
+                            Right () -> pure ()
+                XAIProvider -> do
+                    xaiOptions <- XAI.clientOptionsFromEnv
+                    credential <- firstCredential loaded
+                    let backend = xaiBackend xaiOptions credential (readIORef paramsRef) transcriptRef
+                    runSession options provider policy tools prompt paramsRef transcriptRef
+                        initialPrevious persist backend
+                OpenRouterProvider -> do
+                    openRouterOptions <- OpenRouter.clientOptionsFromEnv
+                    credential <- firstCredential loaded
+                    let backend =
+                            openRouterBackend openRouterOptions credential
+                                (readIORef paramsRef) transcriptRef
+                    runSession options provider policy tools prompt paramsRef transcriptRef
+                        initialPrevious persist backend
 
 preparePersistence
     :: CliOptions
@@ -238,6 +246,35 @@ isLeftSlot :: Either a b -> Bool
 isLeftSlot = \case
     Left _ -> True
     Right _ -> False
+
+-- | On Ctrl-C, print a copy-pasteable --resume line when a session exists.
+withInterruptResume
+    :: String
+    -> Maybe (IORef (Either SessionCreate SessionHandle))
+    -> IO a
+    -> IO a
+withInterruptResume progName persist action =
+    action `catch` \(e :: AsyncException) ->
+        case e of
+            UserInterrupt -> do
+                printResumeHint progName persist
+                throwIO e
+            _ -> throwIO e
+
+printResumeHint
+    :: String
+    -> Maybe (IORef (Either SessionCreate SessionHandle))
+    -> IO ()
+printResumeHint progName = \case
+    Nothing -> pure ()
+    Just slotRef -> do
+        slot <- readIORef slotRef
+        case slot of
+            Left _ -> pure ()
+            Right handle -> do
+                color <- resolveColor stderr
+                putTextLn stderr
+                    (roleMuted color (resumeHint progName handle.sessionMeta.metaId))
 
 shouldPersist :: CliOptions -> Bool
 shouldPersist options = not (isOneShot options) || options.optSaveSession

--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -45,13 +45,8 @@ import qualified Agent.OpenRouter.Options as OpenRouter
 import Agent.XAI.LoopBackend (xaiBackend)
 import qualified Agent.XAI.Options as XAI
 import Control.Concurrent.MVar (newMVar, withMVar)
-import Control.Exception
-    ( AsyncException(UserInterrupt)
-    , catch
-    , finally
-    , throwIO
-    , try
-    )
+import Control.Exception (AsyncException(UserInterrupt))
+import Control.Exception.Safe (catchAsync, finally, throwIO, try)
 import qualified Data.ByteString as BS
 import Data.IORef
 import Data.Maybe (fromMaybe, isJust)
@@ -182,7 +177,7 @@ runAgent options = do
         withInterruptResume progName persist do
             case provider of
                 OpenAIProvider ->
-                    try @CodexAuthFailed
+                    try @_ @CodexAuthFailed
                         (withCodexWsWithProvider loaded.loadedTokenProvider \conn _credential ->
                             runSession options provider policy tools prompt paramsRef transcriptRef
                                 initialPrevious persist
@@ -256,7 +251,7 @@ withInterruptResume
     -> IO a
     -> IO a
 withInterruptResume progName persist action =
-    action `catch` \(e :: AsyncException) ->
+    action `catchAsync` \(e :: AsyncException) ->
         case e of
             UserInterrupt -> do
                 printResumeHint progName persist

--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -281,6 +281,9 @@ printResumeHint progName = \case
         case slot of
             Left _ -> pure ()
             Right handle -> do
+                -- Drop an in-place "thinking…" status so the hint is its own line.
+                Text.hPutStr stderr "\r\ESC[K"
+                hFlush stderr
                 color <- resolveColor stderr
                 putTextLn stderr
                     (roleMuted color (resumeHint progName handle.sessionMeta.metaId))

--- a/packages/agent-cli/src/Agent/CLI/Options.hs
+++ b/packages/agent-cli/src/Agent/CLI/Options.hs
@@ -220,4 +220,5 @@ usage = unlines
     , "reasoning effort. /model [NAME] shows or changes the model."
     , "/always-approve (or :yolo) toggles auto-approve."
     , "/session prints the current session id. Ctrl-D or :q exits."
+    , "Ctrl-C prints a --resume command when a session has been persisted."
     ]

--- a/packages/agent-cli/src/Agent/CLI/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session.hs
@@ -24,7 +24,7 @@ import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy as LBS
 import Data.IORef
 import Data.List (sortOn)
-import Data.Maybe (catMaybes, fromMaybe)
+import Data.Maybe (catMaybes)
 import Data.Ord (Down(..))
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -253,9 +253,14 @@ sessionTitleFromPrompt prompt =
 resumeHint :: String -> Text -> Text
 resumeHint progName sessionId =
     "Resume this session with: "
-        <> Text.pack progName
+        <> shellSingleQuote progName
         <> " --resume "
         <> sessionId
+
+-- | POSIX single-quote so paths with spaces stay one shell word.
+shellSingleQuote :: String -> Text
+shellSingleQuote s =
+    "'" <> Text.replace "'" "'\\''" (Text.pack s) <> "'"
 
 allocateSessionDir :: FilePath -> UTCTime -> IO (Text, FilePath)
 allocateSessionDir root now = go (0 :: Int)

--- a/packages/agent-cli/src/Agent/CLI/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session.hs
@@ -12,6 +12,7 @@ module Agent.CLI.Session
     , sessionTitleFromPrompt
     , writeSessionMeta
     , ensureSession
+    , resumeHint
     ) where
 
 import Agent.OpenAI.Responses.Types (ResponseItem)
@@ -247,6 +248,14 @@ sessionTitleFromPrompt prompt =
     in if Text.length oneLine <= 72
         then oneLine
         else Text.take 69 oneLine <> "..."
+
+-- | Copy-pasteable resume line printed on Ctrl-C, matching grok build.
+resumeHint :: String -> Text -> Text
+resumeHint progName sessionId =
+    "Resume this session with: "
+        <> Text.pack progName
+        <> " --resume "
+        <> sessionId
 
 allocateSessionDir :: FilePath -> UTCTime -> IO (Text, FilePath)
 allocateSessionDir root now = go (0 :: Int)

--- a/packages/agent-cli/test/Agent/CLI/SessionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SessionSpec.hs
@@ -35,6 +35,13 @@ spec = describe "Agent.CLI.Session" do
             let long = Text.replicate 100 "a"
             Text.length (sessionTitleFromPrompt long) `shouldBe` 72
 
+    describe "resumeHint" do
+        it "prints a copy-pasteable --resume line" do
+            resumeHint "agent-cli" "2026-08-20-abcd1234"
+                `shouldBe` "Resume this session with: agent-cli --resume 2026-08-20-abcd1234"
+            resumeHint "grok" "2026-08-20-abcd1234"
+                `shouldBe` "Resume this session with: grok --resume 2026-08-20-abcd1234"
+
     describe "createSession/appendTurn/loadSession" do
         it "round-trips meta and transcript items with private modes" $
             withTempDir "agent-sessions-" \root -> do

--- a/packages/agent-cli/test/Agent/CLI/SessionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SessionSpec.hs
@@ -36,11 +36,16 @@ spec = describe "Agent.CLI.Session" do
             Text.length (sessionTitleFromPrompt long) `shouldBe` 72
 
     describe "resumeHint" do
-        it "prints a copy-pasteable --resume line" do
+        it "prints a copy-pasteable --resume line with a quoted program name" do
             resumeHint "agent-cli" "2026-08-20-abcd1234"
-                `shouldBe` "Resume this session with: agent-cli --resume 2026-08-20-abcd1234"
+                `shouldBe` "Resume this session with: 'agent-cli' --resume 2026-08-20-abcd1234"
             resumeHint "grok" "2026-08-20-abcd1234"
-                `shouldBe` "Resume this session with: grok --resume 2026-08-20-abcd1234"
+                `shouldBe` "Resume this session with: 'grok' --resume 2026-08-20-abcd1234"
+            resumeHint "/path with spaces/agent-cli" "2026-08-20-abcd1234"
+                `shouldBe`
+                    "Resume this session with: '/path with spaces/agent-cli' --resume 2026-08-20-abcd1234"
+            resumeHint "it's" "id"
+                `shouldBe` "Resume this session with: 'it'\\''s' --resume id"
 
     describe "createSession/appendTurn/loadSession" do
         it "round-trips meta and transcript items with private modes" $


### PR DESCRIPTION
## Summary
- On Ctrl-C (`UserInterrupt`), print `Resume this session with: <prog> --resume <id>` when a session has already been persisted.
- Use `getProgName` so aliases (e.g. `grok`) appear correctly in the hint.
- Document the behavior in `--help` and cover `resumeHint` with a unit test.

## Test plan
- [x] `cabal test agent-cli --test-options="--match Agent.CLI.Session"`
- [ ] Start an interactive REPL, complete one turn so a session is created, then Ctrl-C and confirm the resume line is printed
- [ ] Ctrl-C before the first turn (pending session) and confirm no resume line is printed
- [ ] Run the printed `--resume` command and confirm the session loads