### PR TITLE
feat: set terminal window title from session title

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -24,11 +24,13 @@ import Agent.CLI.Render
     , summarizeToolCall
     )
 import Agent.CLI.Style
-    ( roleError
+    ( cliWindowTitle
+    , roleError
     , roleMuted
     , rolePrompt
     , roleSuccess
     , roleWarn
+    , setCliWindowTitle
     )
 import Agent.CLI.Session
 import Agent.CLI.Tools (lookupAppTool, schemasFromAppTools)
@@ -64,6 +66,7 @@ import qualified Agent.XAI.Options as XAI
 import Control.Concurrent.MVar (newMVar, withMVar)
 import Control.Exception (AsyncException(UserInterrupt))
 import Control.Exception.Safe (catchAsync, finally, throwIO, try)
+import Control.Monad (when)
 import qualified Data.ByteString as BS
 import Data.IORef
 import Data.Maybe (fromMaybe, isJust, isNothing)
@@ -157,6 +160,7 @@ runAgent options = do
     projectRoot <- resolveProjectRoot cwd
     projectSettings <- loadProjectSettings projectRoot
     isTty <- hIsTerminalDevice stdin
+    stdoutTty <- hIsTerminalDevice stdout
     let requestedProvider = case resumed of
             Just (meta, _) -> Just meta.metaProvider
             Nothing -> options.optProvider
@@ -191,6 +195,10 @@ runAgent options = do
         paramsRef <- newIORef params
         transcriptRef <- newIORef initialItems
         prompt <- loadPrompt options
+        let titleHint = case resumed of
+                Just (meta, _) -> Just meta.metaTitle
+                Nothing -> sessionTitleFromPrompt <$> prompt
+        setCliWindowTitle stdoutTty stdout (cliWindowTitle cwd titleHint)
         agentsContext <- loadAgentsContext options provider home cwd initialItems initialPrevious
 
         persist <- preparePersistence options root provider model cwd effort prompt resumed
@@ -595,6 +603,11 @@ runOneTurn config render previous printed transcriptRef persist agentsContext pr
                             }
                     handle' <- appendTurn handle turn
                     writeIORef slotRef (Right handle')
+                    when (handle'.sessionMeta.metaTitle /= handle.sessionMeta.metaTitle) do
+                        tty <- hIsTerminalDevice stdout
+                        setCliWindowTitle tty stdout
+                            (cliWindowTitle handle'.sessionMeta.metaCwd
+                                (Just handle'.sessionMeta.metaTitle))
             pure True
 
 

--- a/packages/agent-cli/src/Agent/CLI/Style.hs
+++ b/packages/agent-cli/src/Agent/CLI/Style.hs
@@ -12,6 +12,8 @@ module Agent.CLI.Style
     , roleWarn
     , roleMuted
     , roleSuccess
+    , cliWindowTitle
+    , setCliWindowTitle
     ) where
 
 import Data.Text (Text)
@@ -22,8 +24,11 @@ import System.Console.ANSI
     , ConsoleIntensity(..)
     , ConsoleLayer(..)
     , SGR(..)
+    , hSetTitle
     )
 import System.Console.ANSI.Codes (setSGRCode)
+import System.FilePath (takeFileName)
+import System.IO (Handle)
 
 -- | Apply SGR attributes when @color@ is 'True'; otherwise return @text@.
 style :: Bool -> [SGR] -> Text -> Text
@@ -84,3 +89,18 @@ roleSuccess color =
     style color
         [ SetColor Foreground Dull Green
         ]
+
+-- | Window title: session name when known, otherwise the working directory.
+cliWindowTitle :: FilePath -> Maybe Text -> Text
+cliWindowTitle cwd sessionTitle =
+    case sessionTitle of
+        Just title
+            | not (Text.null title)
+            , title /= "untitled" -> title
+        _ -> Text.pack (takeFileName cwd)
+
+-- | Set the terminal window title when @tty@ is 'True'; no-op otherwise.
+setCliWindowTitle :: Bool -> Handle -> Text -> IO ()
+setCliWindowTitle tty handle title
+    | not tty = pure ()
+    | otherwise = hSetTitle handle (Text.unpack title)

--- a/packages/agent-cli/test/Agent/CLI/StyleSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/StyleSpec.hs
@@ -21,3 +21,16 @@ spec = do
             roleToolName False "read_file" `shouldBe` "read_file"
             roleError False "boom" `shouldBe` "boom"
             roleMuted False "session: 1" `shouldBe` "session: 1"
+
+    describe "cliWindowTitle" do
+        it "uses the cwd basename when no session title is set" do
+            cliWindowTitle "/tmp/haskell-agent" Nothing
+                `shouldBe` "haskell-agent"
+
+        it "prefers a real session title over cwd" do
+            cliWindowTitle "/tmp/haskell-agent" (Just "fix the title")
+                `shouldBe` "fix the title"
+
+        it "ignores untitled placeholders" do
+            cliWindowTitle "/tmp/haskell-agent" (Just "untitled")
+                `shouldBe` "haskell-agent"


### PR DESCRIPTION
## Summary
- Set the terminal window/tab title when stdout is a TTY so `cabal run ...` is replaced with something useful.
- Prefer the session title; fall back to the cwd basename when the session is still untitled or not persisted.
- Refresh the title after the first turn updates an untitled session.

## Test plan
- [ ] `cabal run agent-cli` in a TTY and confirm the tab title becomes the cwd basename (or prompt text with `-p`).
- [ ] Resume a named session and confirm the tab title uses that session title.
- [ ] Start a REPL, send a first message, and confirm the title updates once the session is named.
- [ ] Pipe stdout (`cabal run agent-cli -- -p hi | cat`) and confirm no OSC title escape leaks into output.
- [ ] `cabal test agent-cli` (or StyleSpec) for `cliWindowTitle` cases.