### PR TITLE
feat: distinguish user and agent CLI line backgrounds

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -16,14 +16,17 @@ import Agent.CLI.Render
     , renderEvent
     , summarizeToolCall
     )
+import Agent.CLI.Session
 import Agent.CLI.Style
-    ( roleError
+    ( beginBackground
+    , endBackground
+    , roleError
     , roleMuted
     , rolePrompt
     , roleSuccess
     , roleWarn
+    , userBackground
     )
-import Agent.CLI.Session
 import Agent.CLI.Tools (lookupAppTool, schemasFromAppTools)
 import Agent.CLI.Worktree (createWorktree, worktreeRoot)
 import Agent.Loop
@@ -56,6 +59,7 @@ import qualified Data.Aeson.KeyMap as KeyMap
 import System.Directory (getCurrentDirectory, getHomeDirectory, makeAbsolute, setCurrentDirectory)
 import System.Environment (getArgs, lookupEnv)
 import System.FilePath ((</>))
+import System.Console.ANSI.Codes (clearFromCursorToLineEndCode)
 import System.Exit (die, exitFailure)
 import System.IO (Handle, hFlush, hIsTerminalDevice, isEOF, stderr, stdin, stdout)
 
@@ -309,13 +313,25 @@ repl
     -> IO ()
 repl config render provider previous printed paramsRef policyRef transcriptRef persist = do
     stdoutColor <- resolveColor stdout
-    Text.putStr (rolePrompt stdoutColor "λ> ")
+    -- Prompt + typed input share a navy wash; clear-to-EOL paints the rest
+    -- of the line immediately. Reset after the line is read.
+    Text.putStr
+        ( beginBackground stdoutColor userBackground
+            <> rolePrompt stdoutColor "λ> "
+            <> if stdoutColor
+                then Text.pack clearFromCursorToLineEndCode
+                else mempty
+        )
     hFlush stdout
     done <- isEOF
     if done
-        then putStrLn ""
+        then do
+            Text.putStr (endBackground stdoutColor)
+            putStrLn ""
         else do
             line <- Text.strip <$> Text.getLine
+            Text.putStr (endBackground stdoutColor)
+            hFlush stdout
             if Text.null line
                 then continue
                 else case parseReplLine line of

--- a/packages/agent-cli/src/Agent/CLI/Markdown.hs
+++ b/packages/agent-cli/src/Agent/CLI/Markdown.hs
@@ -3,7 +3,7 @@ module Agent.CLI.Markdown
     ( renderMarkdown
     ) where
 
-import Agent.CLI.Style (style)
+import Agent.CLI.Style (agentBackground, styleBase)
 import Control.Applicative ((<|>))
 import Data.Char (isAlphaNum, isDigit, isSpace)
 import Data.List (transpose)
@@ -20,6 +20,7 @@ import System.Console.ANSI
 
 -- | When @color@ is 'True', style a useful subset of GFM for a TTY.
 -- When 'False', return @text@ unchanged (pipes, redirects, tests).
+-- Nested spans restore 'agentBackground' after each 'Reset'.
 renderMarkdown :: Bool -> Text -> Text
 renderMarkdown color text
     | not color = text
@@ -33,6 +34,10 @@ renderMarkdown color text
             rendered = Text.intercalate "\n" (renderBlocks linesForParse)
         in if endsWithNewline then rendered <> "\n" else rendered
 
+-- | Style helper that keeps the agent line wash across nested SGR.
+md :: [SGR] -> Text -> Text
+md = styleBase True agentBackground
+
 renderBlocks :: [Text] -> [Text]
 renderBlocks = go
   where
@@ -44,38 +49,38 @@ renderBlocks = go
                     if Text.null info
                         then []
                         else
-                            [ style True
+                            [ md
                                 [ SetConsoleIntensity FaintIntensity
                                 , SetColor Foreground Dull Cyan
                                 ]
                                 info
                             ]
-                styledBody = map (style True [SetConsoleIntensity FaintIntensity]) body
+                styledBody = map (md [SetConsoleIntensity FaintIntensity]) body
             in header ++ styledBody ++ go after
         | Just (styled, after) <- takeTable (line : rest) =
             styled ++ go after
         | Just (level, title) <- headingLine line =
             let marker = Text.replicate level "#"
-                prefix = style True (headingPrefixStyle level) (marker <> " ")
+                prefix = md (headingPrefixStyle level) (marker <> " ")
             in (prefix <> styleInline title) : go rest
         | Just item <- unorderedItem line =
-            ( style True listMarkerStyle "• "
+            ( md listMarkerStyle "• "
                 <> styleInline item
             )
                 : go rest
         | Just (digits, item) <- orderedItemParts line =
-            ( style True listMarkerStyle (digits <> ". ")
+            ( md listMarkerStyle (digits <> ". ")
                 <> styleInline item
             )
                 : go rest
         | Just quote <- blockQuote line =
             let body
                     | Text.any (`elem` ['`', '*', '_', '[']) quote = styleInline quote
-                    | otherwise = style True quoteStyle quote
-            in (style True [SetConsoleIntensity FaintIntensity] "│ " <> body)
+                    | otherwise = md quoteStyle quote
+            in (md [SetConsoleIntensity FaintIntensity] "│ " <> body)
                 : go rest
         | isThematicBreak line =
-            style True [SetConsoleIntensity FaintIntensity] (Text.replicate 40 "─")
+            md [SetConsoleIntensity FaintIntensity] (Text.replicate 40 "─")
                 : go rest
         | Text.null (Text.strip line) = line : go rest
         | otherwise = styleInline line : go rest
@@ -238,7 +243,7 @@ styleTableRow isHeader widths cells =
                 (cells ++ repeat "")
         line = Text.intercalate "  " (take (length widths) padded)
     in if isHeader
-        then style True [SetConsoleIntensity BoldIntensity] line
+        then md [SetConsoleIntensity BoldIntensity] line
         else styleInline line
 
 styleInline :: Text -> Text
@@ -248,22 +253,22 @@ styleInline = Text.concat . go Nothing
     go prev t
         | Text.null t = []
         | Just (code, rest) <- takeInlineCode t =
-            style True codeStyle code : go (Text.unsnoc code >>= Just . snd) rest
+            md codeStyle code : go (Text.unsnoc code >>= Just . snd) rest
         | Just (linkText, url, rest) <- takeLink t =
-            style True linkStyle (styleInline linkText)
-                : style True urlStyle (" (" <> url <> ")")
+            md linkStyle (styleInline linkText)
+                : md urlStyle (" (" <> url <> ")")
                 : go (Just ')') rest
         | Just (inner, rest) <- takeEmphasis prev "**" t =
-            style True [SetConsoleIntensity BoldIntensity] (styleInline inner)
+            md [SetConsoleIntensity BoldIntensity] (styleInline inner)
                 : go (Text.unsnoc inner >>= Just . snd) rest
         | Just (inner, rest) <- takeEmphasis prev "__" t =
-            style True [SetConsoleIntensity BoldIntensity] (styleInline inner)
+            md [SetConsoleIntensity BoldIntensity] (styleInline inner)
                 : go (Text.unsnoc inner >>= Just . snd) rest
         | Just (inner, rest) <- takeEmphasis prev "*" t =
-            style True [SetItalicized True] (styleInline inner)
+            md [SetItalicized True] (styleInline inner)
                 : go (Text.unsnoc inner >>= Just . snd) rest
         | Just (inner, rest) <- takeEmphasis prev "_" t =
-            style True [SetItalicized True] (styleInline inner)
+            md [SetItalicized True] (styleInline inner)
                 : go (Text.unsnoc inner >>= Just . snd) rest
         | otherwise =
             let (plain, rest) = Text.break (`elem` ['`', '[', '*', '_']) t

--- a/packages/agent-cli/src/Agent/CLI/Render.hs
+++ b/packages/agent-cli/src/Agent/CLI/Render.hs
@@ -14,7 +14,9 @@ module Agent.CLI.Render
 
 import Agent.CLI.Markdown (renderMarkdown)
 import Agent.CLI.Style
-    ( roleError
+    ( agentBackground
+    , paintBackgroundLines
+    , roleError
     , roleThinking
     , roleToolArrow
     , roleToolDetail
@@ -84,8 +86,10 @@ renderEventUnlocked config = \case
             (roleToolOutput config.renderColor (truncateToolOutput result.output))
 
 -- | Style assistant markdown when color is enabled; otherwise return plain text.
+-- Color mode also paints each line with 'agentBackground'.
 renderAssistantText :: Bool -> Text -> Text
-renderAssistantText = renderMarkdown
+renderAssistantText color text =
+    paintBackgroundLines color agentBackground (renderMarkdown color text)
 
 -- | End-of-turn flush for color mode: prefer streamed deltas, else the
 -- completed 'assistantText' from non-streaming backends.
@@ -101,7 +105,7 @@ flushAssistantBuffer config assistantText = do
         then pure False
         else do
             writeIORef config.renderPrintedText True
-            Text.hPutStr config.renderStdout (renderMarkdown True raw)
+            Text.hPutStr config.renderStdout (renderAssistantText True raw)
             hFlush config.renderStdout
             pure True
 

--- a/packages/agent-cli/src/Agent/CLI/Style.hs
+++ b/packages/agent-cli/src/Agent/CLI/Style.hs
@@ -2,6 +2,12 @@
 -- flag; when 'False' (pipes, 'NO_COLOR', tests) text is unchanged.
 module Agent.CLI.Style
     ( style
+    , styleBase
+    , paintBackgroundLines
+    , userBackground
+    , agentBackground
+    , beginBackground
+    , endBackground
     , rolePrompt
     , roleToolArrow
     , roleToolName
@@ -23,18 +29,71 @@ import System.Console.ANSI
     , ConsoleLayer(..)
     , SGR(..)
     )
-import System.Console.ANSI.Codes (setSGRCode)
+import System.Console.ANSI.Codes
+    ( clearFromCursorToLineEndCode
+    , setSGRCode
+    )
+
+-- | Deep navy strip behind the REPL prompt and typed input.
+userBackground :: [SGR]
+userBackground = [SetPaletteColor Background 17]
+
+-- | Charcoal strip behind assistant stdout lines.
+agentBackground :: [SGR]
+agentBackground = [SetPaletteColor Background 236]
 
 -- | Apply SGR attributes when @color@ is 'True'; otherwise return @text@.
+-- Ends with a full 'Reset'.
 style :: Bool -> [SGR] -> Text -> Text
-style color attrs text
+style color attrs = styleBase color [] attrs
+
+-- | Like 'style', but after the span re-applies @base@ (e.g. a line
+-- background) so nested chrome does not wipe the wash.
+styleBase :: Bool -> [SGR] -> [SGR] -> Text -> Text
+styleBase color base attrs text
     | not color || Text.null text = text
     | otherwise =
-        Text.pack (setSGRCode attrs) <> text <> Text.pack (setSGRCode [Reset])
+        Text.pack (setSGRCode (base <> attrs))
+            <> text
+            <> Text.pack (setSGRCode (Reset : base))
+
+-- | Open a background wash and leave it active (for live typed input).
+beginBackground :: Bool -> [SGR] -> Text
+beginBackground color bg
+    | not color || null bg = ""
+    | otherwise = Text.pack (setSGRCode bg)
+
+-- | Clear all SGR after a background wash.
+endBackground :: Bool -> Text
+endBackground color
+    | not color = ""
+    | otherwise = Text.pack (setSGRCode [Reset])
+
+-- | Prefix each line with @bg@, extend the wash to the terminal edge via
+-- clear-to-EOL, then reset. Preserves a trailing newline on @text@.
+paintBackgroundLines :: Bool -> [SGR] -> Text -> Text
+paintBackgroundLines color bg text
+    | not color || null bg || Text.null text = text
+    | otherwise =
+        let endsWithNewline = Text.isSuffixOf "\n" text
+            parts = Text.splitOn "\n" text
+            lines_
+                | endsWithNewline && not (null parts) = init parts
+                | otherwise = parts
+            painted = map (paintLine bg) lines_
+        in Text.intercalate "\n" painted
+            <> if endsWithNewline then "\n" else ""
+
+paintLine :: [SGR] -> Text -> Text
+paintLine bg line =
+    Text.pack (setSGRCode bg)
+        <> line
+        <> Text.pack clearFromCursorToLineEndCode
+        <> Text.pack (setSGRCode [Reset])
 
 rolePrompt :: Bool -> Text -> Text
 rolePrompt color =
-    style color
+    styleBase color userBackground
         [ SetConsoleIntensity BoldIntensity
         , SetColor Foreground Dull Cyan
         ]

--- a/packages/agent-cli/test/Agent/CLI/MarkdownSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/MarkdownSpec.hs
@@ -97,3 +97,8 @@ spec = do
 
         it "preserves a trailing newline" do
             renderMarkdown True "hi\n" `shouldSatisfy` Text.isSuffixOf "\n"
+
+        it "restores the agent wash after inline spans" do
+            let out = renderMarkdown True "see `file.txt` now"
+            -- Nested Reset must re-open palette 236 so line painting sticks.
+            out `shouldSatisfy` Text.isInfixOf "\ESC[0;48;5;236m"

--- a/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
@@ -108,6 +108,7 @@ spec = do
                 body <- Text.readFile path
                 body `shouldSatisfy` Text.isInfixOf "file.txt"
                 body `shouldSatisfy` Text.isInfixOf "\ESC["
+                body `shouldSatisfy` Text.isInfixOf "\ESC[48;5;236m"
                 body `shouldSatisfy` (not . Text.isInfixOf "`file.txt`")
 
         it "flushes pre-tool assistant prose before tool lines" do

--- a/packages/agent-cli/test/Agent/CLI/StyleSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/StyleSpec.hs
@@ -16,8 +16,29 @@ spec = do
             out `shouldSatisfy` Text.isInfixOf "\ESC["
             out `shouldSatisfy` (not . Text.isPrefixOf "λ>")
 
+        it "restores a base wash after nested styling" do
+            let out = styleBase True agentBackground [] "hi"
+            -- Reset then reopen palette 236 (combined into one SGR sequence).
+            out `shouldSatisfy` Text.isInfixOf "\ESC[0;48;5;236m"
+
+    describe "paintBackgroundLines" do
+        it "leaves text unchanged when color is off" do
+            paintBackgroundLines False agentBackground "a\nb" `shouldBe` "a\nb"
+
+        it "paints each line and preserves a trailing newline" do
+            let out = paintBackgroundLines True agentBackground "a\nb\n"
+            Text.count "\ESC[48;5;236m" out `shouldBe` 2
+            out `shouldSatisfy` Text.isSuffixOf "\n"
+            out `shouldSatisfy` Text.isInfixOf "\ESC[0K"
+
     describe "roles" do
         it "keeps tool labels readable with color off" do
             roleToolName False "read_file" `shouldBe` "read_file"
             roleError False "boom" `shouldBe` "boom"
             roleMuted False "session: 1" `shouldBe` "session: 1"
+
+        it "keeps the user wash under the prompt glyph" do
+            let out = rolePrompt True "λ>"
+            -- Background may share an SGR sequence with bold/cyan attrs.
+            out `shouldSatisfy` Text.isInfixOf "48;5;17"
+            out `shouldSatisfy` Text.isInfixOf "\ESC[0;48;5;17m"


### PR DESCRIPTION
## Summary
- Give REPL prompt/input lines a navy background wash (palette 17) and assistant stdout lines a charcoal wash (palette 236).
- Restore the agent background after nested markdown SGR resets so inline styling does not wipe the line wash.
- Keep the behavior gated on existing color detection (`NO_COLOR`, non-TTY, pipes).

## Test plan
- [x] `cabal test agent-cli:agent-cli-test`
- [ ] Interactive REPL: confirm navy input strip and charcoal agent output on a color TTY
- [ ] Confirm no background escapes when piped or with `NO_COLOR=1`