### PR TITLE
feat: persist auto-approve in project settings

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -41,6 +41,7 @@ library
                     , Agent.CLI.Command
                     , Agent.CLI.Markdown
                     , Agent.CLI.Options
+                    , Agent.CLI.Project
                     , Agent.CLI.Prompt
                     , Agent.CLI.Render
                     , Agent.CLI.Session
@@ -81,6 +82,7 @@ test-suite agent-cli-test
                     , Agent.CLI.CommandSpec
                     , Agent.CLI.MarkdownSpec
                     , Agent.CLI.OptionsSpec
+                    , Agent.CLI.ProjectSpec
                     , Agent.CLI.PromptSpec
                     , Agent.CLI.RenderSpec
                     , Agent.CLI.StyleSpec

--- a/packages/agent-cli/package.nix
+++ b/packages/agent-cli/package.nix
@@ -19,6 +19,6 @@ mkDerivation {
     directory filepath hspec process text time unix
   ];
   description = "Command-line interface for the universal agent harness";
-  license = lib.licenses.bsd3;
+  license = lib.meta.getLicenseFromSpdxId "BSD-3-Clause";
   mainProgram = "agent-cli";
 }

--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -7,6 +7,12 @@ import Agent.CLI.Auth (LoadedAuth(..), loadAuth)
 import Agent.CLI.Clipboard (formatImageSize, readClipboardImage)
 import Agent.CLI.Command
 import Agent.CLI.Options
+import Agent.CLI.Project
+    ( ProjectSettings(..)
+    , loadProjectSettings
+    , resolveProjectRoot
+    , saveProjectAutoApprove
+    )
 import Agent.CLI.Prompt (defaultModelFor, systemPrompt)
 import Agent.CLI.Render
     ( RenderConfig(..)
@@ -148,6 +154,8 @@ runAgent options = do
             | otherwise -> pure source
     setCurrentDirectory cwd
 
+    projectRoot <- resolveProjectRoot cwd
+    projectSettings <- loadProjectSettings projectRoot
     isTty <- hIsTerminalDevice stdin
     let requestedProvider = case resumed of
             Just (meta, _) -> Just meta.metaProvider
@@ -177,6 +185,7 @@ runAgent options = do
             params = requestParams provider model instructions
                 (schemasFromAppTools provider tools) effort
             policy = resolveApprovalPolicy options isTty
+                projectSettings.settingsAutoApprove
             initialItems = maybe [] (concatMap (.turnItems) . snd) resumed
             initialPrevious = resumed >>= \(meta, _) -> meta.metaLastResponseId
         paramsRef <- newIORef params
@@ -192,7 +201,7 @@ runAgent options = do
                     try @_ @CodexAuthFailed
                         (withCodexWsWithProvider loaded.loadedTokenProvider \conn _credential ->
                             runSession options provider policy tools prompt paramsRef transcriptRef
-                                initialPrevious persist Nothing agentsContext
+                                initialPrevious persist projectRoot Nothing agentsContext
                                 (openAiBackend conn (readIORef paramsRef) transcriptRef))
                         >>= \case
                             Left (CodexAuthFailed err) -> die ("openai auth: " <> show err)
@@ -203,14 +212,14 @@ runAgent options = do
                             xaiBackend xaiOptions loaded.loadedTokenProvider
                                 (readIORef paramsRef) transcriptRef
                     runSession options provider policy tools prompt paramsRef transcriptRef
-                        initialPrevious persist (Just loaded.loadedTokenProvider) agentsContext backend
+                        initialPrevious persist projectRoot (Just loaded.loadedTokenProvider) agentsContext backend
                 OpenRouterProvider -> do
                     openRouterOptions <- OpenRouter.clientOptionsFromEnv
                     let backend =
                             openRouterBackend openRouterOptions loaded.loadedTokenProvider
                                 (readIORef paramsRef) transcriptRef
                     runSession options provider policy tools prompt paramsRef transcriptRef
-                        initialPrevious persist (Just loaded.loadedTokenProvider) agentsContext backend
+                        initialPrevious persist projectRoot (Just loaded.loadedTokenProvider) agentsContext backend
 
 preparePersistence
     :: CliOptions
@@ -307,11 +316,12 @@ runSession
     -> IORef [ResponseItem]
     -> Maybe Text
     -> Maybe (IORef (Either SessionCreate SessionHandle))
+    -> FilePath
     -> Maybe TokenProvider
     -> IORef (Maybe Text)
     -> Backend
     -> IO ()
-runSession options provider policy tools prompt paramsRef transcriptRef initialPrevious persist tokenProvider agentsContext backend = do
+runSession options provider policy tools prompt paramsRef transcriptRef initialPrevious persist projectRoot tokenProvider agentsContext backend = do
     printed <- newIORef False
     textBuffer <- newIORef ""
     thinkingVisible <- newIORef False
@@ -338,7 +348,7 @@ runSession options provider policy tools prompt paramsRef transcriptRef initialP
             , loopOnEvent = renderEvent render
             , loopApprove = \call ->
                 withMVar ioLock \_ ->
-                    approveTool policyRef tools call
+                    approveTool policyRef tools call projectRoot
             }
     case prompt of
         Just text -> do
@@ -347,7 +357,7 @@ runSession options provider policy tools prompt paramsRef transcriptRef initialP
             if ok then putTrailingNewline printed else exitFailure
         Nothing ->
             repl config render provider previous printed paramsRef policyRef
-                transcriptRef persist tokenProvider agentsContext
+                transcriptRef persist projectRoot tokenProvider agentsContext
 
 repl
     :: LoopConfig
@@ -359,10 +369,11 @@ repl
     -> IORef ApprovalPolicy
     -> IORef [ResponseItem]
     -> Maybe (IORef (Either SessionCreate SessionHandle))
+    -> FilePath
     -> Maybe TokenProvider
     -> IORef (Maybe Text)
     -> IO ()
-repl config render provider previous printed paramsRef policyRef transcriptRef persist tokenProvider agentsContext = do
+repl config render provider previous printed paramsRef policyRef transcriptRef persist projectRoot tokenProvider agentsContext = do
     stdoutColor <- resolveColor stdout
     Text.putStr (rolePrompt stdoutColor "λ> ")
     hFlush stdout
@@ -462,7 +473,7 @@ repl config render provider previous printed paramsRef policyRef transcriptRef p
                                             (Right handle { sessionMeta = meta })
                         continue
                     ReplToggleAlwaysApprove -> do
-                        toggleAlwaysApprove policyRef
+                        toggleAlwaysApprove policyRef projectRoot
                         continue
                     ReplShowSession -> do
                         color <- resolveColor stdout
@@ -491,7 +502,7 @@ repl config render provider previous printed paramsRef policyRef transcriptRef p
   where
     continue =
         repl config render provider previous printed paramsRef policyRef
-            transcriptRef persist tokenProvider agentsContext
+            transcriptRef persist projectRoot tokenProvider agentsContext
 
 reloadAuth :: Provider -> Maybe TokenProvider -> IO ()
 reloadAuth provider = \case
@@ -637,8 +648,8 @@ loadPrompt options = case (options.optPrompt, options.optPromptFile) of
     (_, Just path) -> Just . Text.strip <$> Text.readFile path
     _ -> pure Nothing
 
-approveTool :: IORef ApprovalPolicy -> [AppTool] -> ToolCall -> IO Bool
-approveTool policyRef tools call = do
+approveTool :: IORef ApprovalPolicy -> [AppTool] -> ToolCall -> FilePath -> IO Bool
+approveTool policyRef tools call projectRoot = do
     policy <- readIORef policyRef
     readOnly <- case lookupAppTool call.name tools of
         Nothing -> pure False
@@ -661,20 +672,23 @@ approveTool policyRef tools call = do
                             AllowOnce -> pure True
                             AllowAlways -> do
                                 writeIORef policyRef ApproveAll
-                                putTextLn stderr (roleSuccess color "auto-approve on")
+                                saveProjectAutoApprove projectRoot True
+                                putTextLn stderr
+                                    (roleSuccess color "auto-approve on (saved for project)")
                                 pure True
                             Deny -> pure False
 
-toggleAlwaysApprove :: IORef ApprovalPolicy -> IO ()
-toggleAlwaysApprove policyRef = do
+toggleAlwaysApprove :: IORef ApprovalPolicy -> FilePath -> IO ()
+toggleAlwaysApprove policyRef projectRoot = do
     color <- resolveColor stderr
     next <- atomicModifyIORef' policyRef \policy ->
         if policy == ApproveAll
             then (PromptMutating, PromptMutating)
             else (ApproveAll, ApproveAll)
+    saveProjectAutoApprove projectRoot (next == ApproveAll)
     putTextLn stderr (case next of
-        ApproveAll -> roleSuccess color "auto-approve on"
-        _ -> roleMuted color "auto-approve off")
+        ApproveAll -> roleSuccess color "auto-approve on (saved for project)"
+        _ -> roleMuted color "auto-approve off (saved for project)")
 
 -- | Rebuild from the constructor: 'input' is also a field on 'CustomToolCall'.
 -- OpenAI keeps @store = true@ so @previous_response_id@ can continue a chain;

--- a/packages/agent-cli/src/Agent/CLI/Options.hs
+++ b/packages/agent-cli/src/Agent/CLI/Options.hs
@@ -96,12 +96,15 @@ isOneShot :: CliOptions -> Bool
 isOneShot options = isJust options.optPrompt || isJust options.optPromptFile
 
 -- | One-shot without a TTY auto-approves so scripts do not hang, unless
--- @--no-yolo@ is set. Interactive sessions prompt on mutating tools.
-resolveApprovalPolicy :: CliOptions -> Bool -> ApprovalPolicy
-resolveApprovalPolicy options isTty
+-- @--no-yolo@ is set. Interactive sessions prompt on mutating tools, unless
+-- project settings already enabled auto-approve (and @--no-yolo@ was not set).
+resolveApprovalPolicy :: CliOptions -> Bool -> Bool -> ApprovalPolicy
+resolveApprovalPolicy options isTty projectAutoApprove
     | options.optYolo && not options.optNoYolo = ApproveAll
     | options.optNoYolo && not isTty = DenyMutating
     | not isTty = ApproveAll
+    | options.optNoYolo = PromptMutating
+    | projectAutoApprove = ApproveAll
     | otherwise = PromptMutating
 
 parseArgs :: [String] -> Either String Command
@@ -227,9 +230,10 @@ usage = unlines
     , "Without -p/--prompt-file, start a REPL. Interactive REPL sessions are"
     , "persisted under ~/.haskell-agent/sessions. /effort [LEVEL] changes"
     , "reasoning effort. /model [NAME] shows or changes the model."
-    , "/always-approve (or :yolo) toggles auto-approve."
-    , "/paste [TEXT] sends the clipboard image (macOS) with an optional caption."
-    , "/session prints the current session id."
+    , "/always-approve (or :yolo) toggles auto-approve and saves it under"
+    , "<project>/.haskell-agent/settings.json (answering a at a permission"
+    , "prompt does the same). /paste [TEXT] sends the clipboard image (macOS)"
+    , "with an optional caption. /session prints the current session id."
     , "/reload-auth forces a re-read of xAI/OpenRouter credentials;"
     , "auth failures also reload once and retry automatically."
     , "Ctrl-D or :q exits."

--- a/packages/agent-cli/src/Agent/CLI/Project.hs
+++ b/packages/agent-cli/src/Agent/CLI/Project.hs
@@ -1,0 +1,128 @@
+-- | Project-scoped settings under @<project>/.haskell-agent/settings.json@.
+module Agent.CLI.Project
+    ( ProjectSettings(..)
+    , defaultProjectSettings
+    , loadProjectSettings
+    , projectSettingsPath
+    , resolveProjectRoot
+    , saveProjectAutoApprove
+    ) where
+
+import Control.Exception (try)
+import Data.Aeson (FromJSON(..), ToJSON(..), object, withObject, (.:?), (.=))
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString.Lazy as LBS
+import Data.Char (isSpace)
+import Data.List (dropWhileEnd)
+import Data.Maybe (fromMaybe)
+import System.Directory
+    ( canonicalizePath
+    , createDirectoryIfMissing
+    , doesFileExist
+    , removeFile
+    , renameFile
+    )
+import System.Exit (ExitCode(..))
+import System.FilePath ((</>))
+import System.Posix.Files (setFileMode)
+import System.Process (CreateProcess(..), proc, readCreateProcessWithExitCode)
+
+settingsSchemaVersion :: Int
+settingsSchemaVersion = 1
+
+-- | @dir/.haskell-agent/settings.json@.
+projectSettingsPath :: FilePath -> FilePath
+projectSettingsPath projectRoot =
+    projectRoot </> ".haskell-agent" </> "settings.json"
+
+data ProjectSettings = ProjectSettings
+    { settingsVersion :: !Int
+    , settingsAutoApprove :: !Bool
+    } deriving (Eq, Show)
+
+defaultProjectSettings :: ProjectSettings
+defaultProjectSettings = ProjectSettings
+    { settingsVersion = settingsSchemaVersion
+    , settingsAutoApprove = False
+    }
+
+instance ToJSON ProjectSettings where
+    toJSON settings = object
+        [ "version" .= settings.settingsVersion
+        , "autoApprove" .= settings.settingsAutoApprove
+        ]
+
+instance FromJSON ProjectSettings where
+    parseJSON = withObject "ProjectSettings" \o -> do
+        version <- fromMaybe settingsSchemaVersion <$> o .:? "version"
+        autoApprove <- fromMaybe False <$> o .:? "autoApprove"
+        pure ProjectSettings
+            { settingsVersion = version
+            , settingsAutoApprove = autoApprove
+            }
+
+-- | Git toplevel when @cwd@ is inside a repo; otherwise @cwd@ itself.
+-- Paths are canonicalized so macOS @/var@ vs @/private/var@ does not diverge.
+resolveProjectRoot :: FilePath -> IO FilePath
+resolveProjectRoot cwd = do
+    root <- gitToplevel cwd >>= \case
+        Just toplevel -> pure toplevel
+        Nothing -> pure cwd
+    canonicalizePath root
+
+-- | Missing or unreadable settings files yield the defaults.
+loadProjectSettings :: FilePath -> IO ProjectSettings
+loadProjectSettings projectRoot = do
+    let path = projectSettingsPath projectRoot
+    exists <- doesFileExist path
+    if not exists
+        then pure defaultProjectSettings
+        else do
+            result <- try @IOError (LBS.readFile path)
+            pure $ case result of
+                Left _ -> defaultProjectSettings
+                Right bytes ->
+                    case Aeson.eitherDecode' bytes of
+                        Left _ -> defaultProjectSettings
+                        Right settings -> settings
+
+-- | Persist the project-wide auto-approve flag, creating @.haskell-agent@ as needed.
+saveProjectAutoApprove :: FilePath -> Bool -> IO ()
+saveProjectAutoApprove projectRoot autoApprove = do
+    let dir = projectRoot </> ".haskell-agent"
+        path = projectSettingsPath projectRoot
+        tmp = path <> ".tmp"
+        settings = defaultProjectSettings { settingsAutoApprove = autoApprove }
+    createDirectoryIfMissing True dir
+    _ <- try @IOError (setFileMode dir 0o700)
+    LBS.writeFile tmp (Aeson.encode settings)
+    setFileMode tmp 0o600
+    renameOrReplace tmp path
+    setFileMode path 0o600
+
+gitToplevel :: FilePath -> IO (Maybe FilePath)
+gitToplevel dir = do
+    result <- try @IOError $
+        readCreateProcessWithExitCode
+            (proc "git" ["rev-parse", "--show-toplevel"]) { cwd = Just dir }
+            ""
+    pure $ case result of
+        Left _ -> Nothing
+        Right (ExitSuccess, out, _) ->
+            let trimmed = trim out
+            in if null trimmed then Nothing else Just trimmed
+        Right _ -> Nothing
+
+renameOrReplace :: FilePath -> FilePath -> IO ()
+renameOrReplace tmp path = do
+    result <- try @IOError (renameFile tmp path)
+    case result of
+        Right () -> pure ()
+        Left _ -> do
+            bytes <- LBS.readFile tmp
+            LBS.writeFile path bytes
+            _ <- try @IOError (removeFile tmp)
+            pure ()
+
+trim :: String -> String
+trim = dropWhileEnd isSpace . dropWhile isSpace

--- a/packages/agent-cli/test/Agent/CLI/OptionsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/OptionsSpec.hs
@@ -102,17 +102,22 @@ spec = do
 
     describe "resolveApprovalPolicy" do
         it "auto-approves one-shot scripts without a TTY" do
-            resolveApprovalPolicy defaultCliOptions { optPrompt = Just "hi" } False
+            resolveApprovalPolicy defaultCliOptions { optPrompt = Just "hi" } False False
                 `shouldBe` ApproveAll
 
         it "denies mutating tools without a TTY when --no-yolo is set" do
-            resolveApprovalPolicy defaultCliOptions { optNoYolo = True } False
+            resolveApprovalPolicy defaultCliOptions { optNoYolo = True } False False
                 `shouldBe` DenyMutating
 
         it "prompts on a TTY unless --yolo is set" do
-            resolveApprovalPolicy defaultCliOptions True `shouldBe` PromptMutating
-            resolveApprovalPolicy defaultCliOptions { optYolo = True } True
+            resolveApprovalPolicy defaultCliOptions True False `shouldBe` PromptMutating
+            resolveApprovalPolicy defaultCliOptions { optYolo = True } True False
                 `shouldBe` ApproveAll
+
+        it "honors project auto-approve on a TTY unless --no-yolo is set" do
+            resolveApprovalPolicy defaultCliOptions True True `shouldBe` ApproveAll
+            resolveApprovalPolicy defaultCliOptions { optNoYolo = True } True True
+                `shouldBe` PromptMutating
 
     describe "parseApprovalAnswer" do
         it "allows once, always, or denies" do

--- a/packages/agent-cli/test/Agent/CLI/ProjectSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ProjectSpec.hs
@@ -1,0 +1,89 @@
+module Agent.CLI.ProjectSpec (spec) where
+
+import Agent.CLI.Project
+import Control.Exception (bracket)
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString.Lazy as LBS
+import System.Directory
+    ( canonicalizePath
+    , createDirectoryIfMissing
+    , doesFileExist
+    , getTemporaryDirectory
+    , removeDirectoryRecursive
+    )
+import System.Exit (ExitCode(..))
+import System.FilePath ((</>))
+import System.Posix.Files (fileMode, getFileStatus)
+import System.Posix.Temp (mkdtemp)
+import System.Posix.Types (FileMode)
+import System.Process (CreateProcess(..), proc, readCreateProcessWithExitCode)
+import Test.Hspec
+
+spec :: Spec
+spec = describe "Agent.CLI.Project" do
+    describe "projectSettingsPath" do
+        it "is <project>/.haskell-agent/settings.json" do
+            projectSettingsPath "/tmp/repo"
+                `shouldBe` "/tmp/repo" </> ".haskell-agent" </> "settings.json"
+
+    describe "loadProjectSettings/saveProjectAutoApprove" do
+        it "defaults when settings are missing" $
+            withTempDir "agent-project-" \root -> do
+                settings <- loadProjectSettings root
+                settings `shouldBe` defaultProjectSettings
+
+        it "round-trips auto-approve with private file mode" $
+            withTempDir "agent-project-" \root -> do
+                saveProjectAutoApprove root True
+                let path = projectSettingsPath root
+                doesFileExist path `shouldReturn` True
+                modeOf path `shouldReturn` 0o600
+                settings <- loadProjectSettings root
+                settings.settingsAutoApprove `shouldBe` True
+                bytes <- LBS.readFile path
+                Aeson.eitherDecode' bytes
+                    `shouldBe` Right (defaultProjectSettings { settingsAutoApprove = True })
+
+                saveProjectAutoApprove root False
+                settings' <- loadProjectSettings root
+                settings'.settingsAutoApprove `shouldBe` False
+
+        it "ignores corrupt settings files" $
+            withTempDir "agent-project-" \root -> do
+                let dir = root </> ".haskell-agent"
+                    path = projectSettingsPath root
+                createDirectoryIfMissing True dir
+                LBS.writeFile path "{not-json"
+                loadProjectSettings root `shouldReturn` defaultProjectSettings
+
+    describe "resolveProjectRoot" do
+        it "uses the git toplevel when available" $
+            withTempDir "agent-git-" \root -> do
+                git_ root ["init"]
+                expected <- canonicalizePath root
+                let nested = root </> "packages" </> "cli"
+                createDirectoryIfMissing True nested
+                resolveProjectRoot nested `shouldReturn` expected
+
+        it "falls back to cwd outside a git repo" $
+            withTempDir "agent-nogit-" \root -> do
+                expected <- canonicalizePath root
+                resolveProjectRoot root `shouldReturn` expected
+
+withTempDir :: String -> (FilePath -> IO a) -> IO a
+withTempDir prefix action = do
+    tmp <- getTemporaryDirectory
+    bracket (mkdtemp (tmp </> prefix)) removeDirectoryRecursive action
+
+modeOf :: FilePath -> IO FileMode
+modeOf path = do
+    status <- getFileStatus path
+    pure (fileMode status `mod` 0o1000)
+
+git_ :: FilePath -> [String] -> IO ()
+git_ dir args = do
+    (code, _out, err) <-
+        readCreateProcessWithExitCode (proc "git" args) { cwd = Just dir } ""
+    case code of
+        ExitSuccess -> pure ()
+        ExitFailure _ -> expectationFailure ("git " <> unwords args <> ": " <> err)

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -7,6 +7,7 @@ import qualified Agent.CLI.ClipboardSpec as ClipboardSpec
 import qualified Agent.CLI.CommandSpec as CommandSpec
 import qualified Agent.CLI.MarkdownSpec as MarkdownSpec
 import qualified Agent.CLI.OptionsSpec as OptionsSpec
+import qualified Agent.CLI.ProjectSpec as ProjectSpec
 import qualified Agent.CLI.PromptSpec as PromptSpec
 import qualified Agent.CLI.RenderSpec as RenderSpec
 import qualified Agent.CLI.SessionSpec as SessionSpec
@@ -21,6 +22,7 @@ main = hspec do
     CommandSpec.spec
     MarkdownSpec.spec
     OptionsSpec.spec
+    ProjectSpec.spec
     PromptSpec.spec
     RenderSpec.spec
     StyleSpec.spec


### PR DESCRIPTION
## Summary
- Persist auto-approve when answering `a` at a permission prompt (or toggling `/always-approve`) to `<project>/.haskell-agent/settings.json`.
- Load that project setting on startup so later sessions skip mutating-tool prompts unless `--no-yolo` is set.
- Resolve the project root from the git toplevel when available, otherwise the working directory.

## Test plan
- [x] `cabal test agent-cli` (102 examples, 0 failures)
- [ ] Manually: start a REPL, allow a mutating tool with `a`, confirm `.haskell-agent/settings.json` is written, restart, and confirm no prompt.
- [ ] Manually: `/always-approve` off, confirm settings flip to `false` and prompts return.