### PR TITLE
feat: add nix develop `repl` with agent :reload via GHCi

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,5 +21,8 @@ we follow the tool defintions that are used by the first party lab harnesses. e.
 
 use ghci instead of compiling the code. E.g. instead of nix flake check start a ghci and load in the necessary modules. This is way faster than doing a full compile.
 
+From `nix develop`, run `repl` to open the agent under GHCi. Agent `:reload`
+returns to GHCi, reloads modules, and resumes the previous session.
+
 # haskell
 - Prefer Control.Exception.Safe over Control.Exception

--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ cabal run agent-cli -- --help
 cabal run agent-cli -- -p "list the files here"
 ```
 
+From `nix develop`, `repl` opens `cabal repl lib:agent-cli` (via expect) and
+starts the agent with a GHCi `:cmd` loop. Inside the agent REPL, `:reload`
+writes `~/.haskell-agent/dev-resume`, returns to GHCi, reloads modules, and
+resumes the same session automatically. `:q` exits the agent back to `ghci>`.
+
 Without `-p` / `--prompt-file` the CLI starts a REPL. Credentials come from
 `~/.grok/auth.json` / `GROK_ACCESS_TOKEN` (xAI), `~/.codex/auth.json` /
 `CODEX_ACCESS_TOKEN` (OpenAI), or `OPENROUTER_API_KEY` (OpenRouter).

--- a/flake.nix
+++ b/flake.nix
@@ -112,6 +112,41 @@
                 agentCliPackage = haskellPackages.agent-cli;
                 agentCliExecutable = pkgs.haskell.lib.justStaticExecutables agentCliPackage;
                 agentOpenaiExecutables = pkgs.haskell.lib.justStaticExecutables agentOpenaiPackage;
+
+                # Opens cabal repl on the agent-cli library and enters the
+                # GHCi :cmd loop that reloads + resumes after agent :reload.
+                # expect waits for modules to load, then starts the agent
+                # (ghci scripts run before cabal loads the package).
+                agentRepl = pkgs.writeShellScriptBin "repl" ''
+                    set -euo pipefail
+                    root="$(${pkgs.git}/bin/git rev-parse --show-toplevel 2>/dev/null || pwd)"
+                    script="$root/scripts/agent-repl.ghci"
+                    if [ ! -f "$script" ]; then
+                      echo "repl: missing $script" >&2
+                      exit 1
+                    fi
+                    cabal="${haskellPackages.cabal-install}/bin/cabal"
+                    expect_bin="${pkgs.expect}/bin/expect"
+                    export AGENT_REPL_SCRIPT="$script"
+                    export AGENT_REPL_CABAL="$cabal"
+                    exec "$expect_bin" -c '
+                      set timeout -1
+                      set cabal $env(AGENT_REPL_CABAL)
+                      set script $env(AGENT_REPL_SCRIPT)
+                      spawn -noecho $cabal repl lib:agent-cli --repl-options=-ghci-script=$script
+                      expect {
+                        -re {Ok, [0-9]+ modules? loaded\.} {}
+                        eof {
+                          puts stderr "repl: cabal repl exited before modules loaded"
+                          exit 1
+                        }
+                      }
+                      send -- ":module +Agent.CLI\r"
+                      expect -re {ghci>}
+                      send -- ":cmd afterDev =<< devMain\r"
+                      interact
+                    '
+                '';
             in
             {
                 packages.default = agentCliExecutable;
@@ -148,7 +183,8 @@
                         ++ (with pkgs; [
                             cabal2nix
                             ripgrep
-                        ]);
+                        ])
+                        ++ [ agentRepl ];
                 };
 
                 checks = {

--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -1,6 +1,9 @@
 -- | Command-line entry point: one-shot @-p@ or an interactive REPL.
 module Agent.CLI
-    ( run
+    ( DevResult(..)
+    , afterDev
+    , devMain
+    , run
     ) where
 
 import Agent.CLI.Auth (LoadedAuth(..), loadAuth)
@@ -59,6 +62,42 @@ import System.FilePath ((</>))
 import System.Exit (die, exitFailure)
 import System.IO (Handle, hFlush, hIsTerminalDevice, isEOF, stderr, stdin, stdout)
 
+-- | How the GHCi-driven agent REPL finished.
+data DevResult
+    = DevQuit
+    | DevReload
+    deriving (Eq, Show)
+
+-- | GHCi @:cmd@ helper: on 'DevReload', reload modules and re-enter 'devMain'.
+afterDev :: DevResult -> IO String
+afterDev = \case
+    DevQuit -> pure ""
+    DevReload -> pure $ unlines
+        [ ":reload"
+        , ":module +Agent.CLI"
+        , ":cmd afterDev =<< devMain"
+        ]
+
+-- | Start the agent from GHCi (@repl@). Resumes the session written by @:reload@.
+devMain :: IO DevResult
+devMain = do
+    home <- getHomeDirectory
+    resumeId <- readDevResumePointer home
+    let args = maybe [] (\sessionId -> ["--resume", Text.unpack sessionId]) resumeId
+    case parseArgs args of
+        Left err -> do
+            clearDevResumePointer home
+            die err
+        Right ShowHelp -> putStr usage >> pure DevQuit
+        Right ShowVersion -> putStrLn "agent-cli 0.1.0.0" >> pure DevQuit
+        Right ListSessions -> runListSessions >> pure DevQuit
+        Right (ShowSession sessionId) -> runShowSession sessionId >> pure DevQuit
+        Right (RunAgent options) -> do
+            result <- runAgent options
+            case result of
+                DevQuit -> clearDevResumePointer home >> pure DevQuit
+                DevReload -> pure DevReload
+
 run :: IO ()
 run = do
     args <- getArgs
@@ -68,7 +107,14 @@ run = do
         Right ShowVersion -> putStrLn "agent-cli 0.1.0.0"
         Right ListSessions -> runListSessions
         Right (ShowSession sessionId) -> runShowSession sessionId
-        Right (RunAgent options) -> runAgent options
+        Right (RunAgent options) -> do
+            result <- runAgent options
+            case result of
+                DevQuit -> pure ()
+                DevReload -> do
+                    home <- getHomeDirectory
+                    clearDevResumePointer home
+                    die ":reload is only available under `repl` (nix develop)"
 
 runListSessions :: IO ()
 runListSessions = do
@@ -109,7 +155,7 @@ printTurn turn = do
         _ -> pure ()
     putStrLn ""
 
-runAgent :: CliOptions -> IO ()
+runAgent :: CliOptions -> IO DevResult
 runAgent options = do
     home <- getHomeDirectory
     let root = sessionsRoot home
@@ -179,7 +225,7 @@ runAgent options = do
                             (openAiBackend conn (readIORef paramsRef) transcriptRef))
                     >>= \case
                         Left (CodexAuthFailed err) -> die ("openai auth: " <> show err)
-                        Right () -> pure ()
+                        Right result -> pure result
             XAIProvider -> do
                 xaiOptions <- XAI.clientOptionsFromEnv
                 credential <- firstCredential loaded
@@ -259,7 +305,7 @@ runSession
     -> Maybe Text
     -> Maybe (IORef (Either SessionCreate SessionHandle))
     -> Backend
-    -> IO ()
+    -> IO DevResult
 runSession options provider policy tools prompt paramsRef transcriptRef initialPrevious persist backend = do
     printed <- newIORef False
     textBuffer <- newIORef ""
@@ -292,7 +338,9 @@ runSession options provider policy tools prompt paramsRef transcriptRef initialP
     case prompt of
         Just text -> do
             ok <- runOneTurn config render previous printed transcriptRef persist text
-            if ok then putTrailingNewline printed else exitFailure
+            if ok
+                then putTrailingNewline printed >> pure DevQuit
+                else exitFailure
         Nothing ->
             repl config render provider previous printed paramsRef policyRef transcriptRef persist
 
@@ -306,20 +354,21 @@ repl
     -> IORef ApprovalPolicy
     -> IORef [ResponseItem]
     -> Maybe (IORef (Either SessionCreate SessionHandle))
-    -> IO ()
+    -> IO DevResult
 repl config render provider previous printed paramsRef policyRef transcriptRef persist = do
     stdoutColor <- resolveColor stdout
     Text.putStr (rolePrompt stdoutColor "λ> ")
     hFlush stdout
     done <- isEOF
     if done
-        then putStrLn ""
+        then putStrLn "" >> pure DevQuit
         else do
             line <- Text.strip <$> Text.getLine
             if Text.null line
                 then continue
                 else case parseReplLine line of
-                    ReplQuit -> pure ()
+                    ReplQuit -> pure DevQuit
+                    ReplReload -> requestReload persist
                     ReplPrompt text -> do
                         writeIORef printed False
                         _ <- runOneTurn config render previous printed
@@ -406,6 +455,25 @@ repl config render provider previous printed paramsRef policyRef transcriptRef p
   where
     continue =
         repl config render provider previous printed paramsRef policyRef transcriptRef persist
+
+requestReload
+    :: Maybe (IORef (Either SessionCreate SessionHandle))
+    -> IO DevResult
+requestReload persist = do
+    home <- getHomeDirectory
+    color <- resolveColor stderr
+    case persist of
+        Nothing -> do
+            putTextLn stderr
+                (roleError color ":reload needs a persisted REPL session")
+            pure DevQuit
+        Just slotRef -> do
+            handle <- ensureSession slotRef
+            writeDevResumePointer home handle.sessionMeta.metaId
+            putTextLn stderr
+                (roleMuted color
+                    ("reloading; session " <> handle.sessionMeta.metaId))
+            pure DevReload
 
 runOneTurn
     :: LoopConfig

--- a/packages/agent-cli/src/Agent/CLI/Command.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command.hs
@@ -17,6 +17,7 @@ import qualified Data.Text as Text
 
 data ReplAction
     = ReplQuit
+    | ReplReload
     | ReplPrompt Text
     | ReplShowEffort
     | ReplSetEffort Text
@@ -32,10 +33,12 @@ parseReplLine raw =
     let line = Text.strip raw
     in if line == ":q" || line == ":quit"
         then ReplQuit
-        else case Text.uncons line of
-            Just ('/', _) -> parseSlash line
-            Just (':', _) -> parseColon line
-            _ -> ReplPrompt line
+        else if line == ":reload"
+            then ReplReload
+            else case Text.uncons line of
+                Just ('/', _) -> parseSlash line
+                Just (':', _) -> parseColon line
+                _ -> ReplPrompt line
 
 parseColon :: Text -> ReplAction
 parseColon line

--- a/packages/agent-cli/src/Agent/CLI/Options.hs
+++ b/packages/agent-cli/src/Agent/CLI/Options.hs
@@ -220,4 +220,6 @@ usage = unlines
     , "reasoning effort. /model [NAME] shows or changes the model."
     , "/always-approve (or :yolo) toggles auto-approve."
     , "/session prints the current session id. Ctrl-D or :q exits."
+    , "Under `repl` (nix develop), :reload returns to GHCi, reloads modules,"
+    , "and resumes the same session."
     ]

--- a/packages/agent-cli/src/Agent/CLI/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session.hs
@@ -12,6 +12,10 @@ module Agent.CLI.Session
     , sessionTitleFromPrompt
     , writeSessionMeta
     , ensureSession
+    , devResumePointerPath
+    , writeDevResumePointer
+    , readDevResumePointer
+    , clearDevResumePointer
     ) where
 
 import Agent.OpenAI.Responses.Types (ResponseItem)
@@ -23,7 +27,7 @@ import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy as LBS
 import Data.IORef
 import Data.List (sortOn)
-import Data.Maybe (catMaybes, fromMaybe)
+import Data.Maybe (catMaybes)
 import Data.Ord (Down(..))
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -51,6 +55,34 @@ sessionSchemaVersion = 1
 -- | @~/.haskell-agent/sessions@ given the user's home directory.
 sessionsRoot :: FilePath -> FilePath
 sessionsRoot home = home </> ".haskell-agent" </> "sessions"
+
+-- | Pointer written before a GHCi @:reload@ so @devMain@ can resume.
+devResumePointerPath :: FilePath -> FilePath
+devResumePointerPath home = home </> ".haskell-agent" </> "dev-resume"
+
+writeDevResumePointer :: FilePath -> Text -> IO ()
+writeDevResumePointer home sessionId = do
+    let root = home </> ".haskell-agent"
+        path = devResumePointerPath home
+    ensurePrivateDir root
+    Text.writeFile path (sessionId <> "\n")
+    setFileMode path 0o600
+
+readDevResumePointer :: FilePath -> IO (Maybe Text)
+readDevResumePointer home = do
+    let path = devResumePointerPath home
+    exists <- doesFileExist path
+    if not exists
+        then pure Nothing
+        else do
+            raw <- Text.strip <$> Text.readFile path
+            pure (if Text.null raw then Nothing else Just raw)
+
+clearDevResumePointer :: FilePath -> IO ()
+clearDevResumePointer home = do
+    let path = devResumePointerPath home
+    _ <- try @IOError (removeFile path)
+    pure ()
 
 data SessionMeta = SessionMeta
     { metaVersion :: !Int

--- a/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
@@ -13,6 +13,10 @@ spec = do
             parseReplLine ":quit" `shouldBe` ReplQuit
             parseReplLine "  :quit  " `shouldBe` ReplQuit
 
+        it "treats :reload as a GHCi reload request" do
+            parseReplLine ":reload" `shouldBe` ReplReload
+            parseReplLine "  :reload  " `shouldBe` ReplReload
+
         it "sends ordinary lines to the model" do
             parseReplLine "list the files" `shouldBe` ReplPrompt "list the files"
             parseReplLine ":status" `shouldBe` ReplPrompt ":status"

--- a/packages/agent-cli/test/Agent/CLI/SessionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SessionSpec.hs
@@ -29,6 +29,17 @@ spec = describe "Agent.CLI.Session" do
             sessionsRoot "/home/marc"
                 `shouldBe` "/home/marc" </> ".haskell-agent" </> "sessions"
 
+    describe "dev resume pointer" do
+        it "round-trips and clears under ~/.haskell-agent/dev-resume" $
+            withTempDir "agent-home-" \home -> do
+                readDevResumePointer home `shouldReturn` Nothing
+                writeDevResumePointer home "2026-08-20-abcd1234"
+                modeOf (devResumePointerPath home) `shouldReturn` 0o600
+                readDevResumePointer home
+                    `shouldReturn` Just "2026-08-20-abcd1234"
+                clearDevResumePointer home
+                readDevResumePointer home `shouldReturn` Nothing
+
     describe "sessionTitleFromPrompt" do
         it "collapses whitespace and truncates long prompts" do
             sessionTitleFromPrompt "  hello   world  " `shouldBe` "hello world"

--- a/scripts/agent-repl.ghci
+++ b/scripts/agent-repl.ghci
@@ -1,0 +1,6 @@
+-- Driven by the `repl` shortcut from nix develop.
+-- The wrapper waits for "Ok, N modules loaded." then runs:
+--   :module +Agent.CLI
+--   :cmd afterDev =<< devMain
+-- Agent :reload returns DevReload; afterDev asks GHCi to :reload and re-enter.
+:set prompt "ghci> "


### PR DESCRIPTION
## Summary
- Add a `repl` command to the Nix `devShell` that opens `cabal repl lib:agent-cli` and starts the agent via a GHCi `:cmd` loop (`devMain` / `afterDev`).
- Teach the agent REPL `:reload` to write `~/.haskell-agent/dev-resume`, return to GHCi, reload modules, and resume the same session.
- Document the flow in README/AGENTS and cover parsing + resume-pointer round-trips in unit tests.

## Test plan
- [x] `nix develop -c cabal test agent-cli` (88 examples, 0 failures)
- [x] `nix develop -c repl` reaches `λ>`
- [x] Agent `:reload` prints `reloading; session …`, GHCi reloads modules, and resumes with `session: … (resumed)`
- [x] Touching a source file then `:reload` recompiles and resumes the same session
- [x] `:q` returns to `ghci>` and clears `~/.haskell-agent/dev-resume`