### PR TITLE
fix: retry xAI capacity errors after 30s

### DIFF
--- a/packages/agent-xai/README.md
+++ b/packages/agent-xai/README.md
@@ -12,9 +12,10 @@ xAI-specific transport package for the agent harness.
 `Agent.Loop`. The proxy does not store transcripts, so the adapter keeps a
 local item list and resends it on each turn.
 
-The package contains no agent loop, context trimming, retry policy, or
-credential failover. Those concerns belong to the harness around the provider
-client.
+The package contains no agent loop, context trimming, or credential failover.
+Those concerns belong to the harness around the provider client. The HTTP
+client does retry short-lived capacity / overload failures (30s delay, a few
+attempts) before returning them to the loop.
 
 OAuth login options require the application's public client id at runtime;
 `agent-xai` does not embed one in its source.

--- a/packages/agent-xai/agent-xai.cabal
+++ b/packages/agent-xai/agent-xai.cabal
@@ -49,6 +49,7 @@ library
                     , http-client
                     , http-conduit
                     , base64-bytestring
+                    , retry
                     , safe-exceptions
 
 test-suite agent-xai-test
@@ -73,5 +74,6 @@ test-suite agent-xai-test
                     , base64-bytestring
                     , case-insensitive
                     , http-types
+                    , retry
                     , wai
                     , warp

--- a/packages/agent-xai/src/Agent/XAI/Client.hs
+++ b/packages/agent-xai/src/Agent/XAI/Client.hs
@@ -4,16 +4,31 @@ module Agent.XAI.Client
     , createResponse
     , createResponseWith
     , createResponseWithEvents
+    , createResponseWithEventsPolicy
+    , retryTransientXaiResultWithPolicy
     ) where
 
-import Agent.Error (ApiError(..), ErrorType(..))
+import Agent.Error
+    ( ApiError(..)
+    , ErrorType(..)
+    )
 import Agent.OpenAI.Responses.Types
 import Agent.Provider (Credential(..), Provider(..))
-import Agent.XAI.Error (classifyFailure)
+import Agent.XAI.Error
+    ( capacityRetryAfterSeconds
+    , classifyFailure
+    , isCapacityBody
+    )
 import Agent.XAI.Options
 import Agent.XAI.Request (buildRequest)
 import Agent.XAI.Stream (buildResponse, parseSseEvents)
 import Control.Exception.Safe (tryAny)
+import Control.Retry
+    ( RetryPolicyM
+    , constantDelay
+    , limitRetries
+    , retrying
+    )
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Char8 as BS8
 import qualified Data.ByteString.Lazy as LBS
@@ -43,21 +58,42 @@ createResponseWith options credential request =
 -- | Send one request and deliver every decoded typed Responses event before
 -- returning the assembled terminal response. The current HTTP backend buffers
 -- the response body, so callbacks run in wire order after the body completes.
+-- Transient capacity / overload failures wait 30s and retry a few times before
+-- surfacing to the loop.
 createResponseWithEvents
     :: ClientOptions
     -> Credential
     -> ResponseCreateParams
     -> StreamEventCallback
     -> IO (Either ApiError Response)
-createResponseWithEvents options credential request onEvent
+createResponseWithEvents options credential request onEvent =
+    createResponseWithEventsPolicy defaultTransientPolicy options credential request onEvent
+  where
+    defaultTransientPolicy =
+        constantDelay (capacityRetryAfterSeconds * 1_000_000) <> limitRetries 3
+
+-- | Same as 'createResponseWithEvents', with an injectable retry policy so
+-- tests can use a zero delay without waiting on the production 30s backoff.
+createResponseWithEventsPolicy
+    :: RetryPolicyM IO
+    -> ClientOptions
+    -> Credential
+    -> ResponseCreateParams
+    -> StreamEventCallback
+    -> IO (Either ApiError Response)
+createResponseWithEventsPolicy policy options credential request onEvent
     | credential.provider /= XAIProvider = pure $ Left $ ProviderError ApiErrorType
         "agent-xai requires an xAI credential"
         Nothing
-    | otherwise = tryAny performRequest >>= \case
-        Left exception -> pure $ Left $ ConnectionError
-            ("xAI request failed: " <> Text.pack (show exception))
-        Right response -> handleResponse response
+    | otherwise =
+        retryTransientXaiResultWithPolicy policy performOnce
   where
+    performOnce =
+        tryAny performRequest >>= \case
+            Left exception -> pure $ Left $ ConnectionError
+                ("xAI request failed: " <> Text.pack (show exception))
+            Right response -> handleResponse response
+
     performRequest = do
         httpRequest <- parseRequest ("POST " <> trimSlash options.baseUrl <> "/responses")
         httpLBS
@@ -95,6 +131,35 @@ createResponseWithEvents options credential request onEvent
             [(seconds, "")] -> Just (max 1 seconds)
             _ -> Nothing
         [] -> Nothing
+
+-- | Retry capacity / overload pressure and short-lived 5xx failures. Generic
+-- connection drops and quota errors are left to the caller. Production uses a
+-- 30s constant delay so capacity pressure can clear between attempts.
+retryTransientXaiResultWithPolicy
+    :: RetryPolicyM IO
+    -> IO (Either ApiError value)
+    -> IO (Either ApiError value)
+retryTransientXaiResultWithPolicy policy request =
+    retrying policy shouldRetry (const request)
+  where
+    shouldRetry _retryStatus = \case
+        Left apiError | isCapacityRetryable apiError -> pure True
+        _ -> pure False
+
+-- | Capacity text is classified as 'OverloadedError' with a 30s interval.
+-- Keep a ConnectionError fallback for older wrappers that still prefix the
+-- same message, and retry ordinary 5xx / overload shapes the same way.
+isCapacityRetryable :: ApiError -> Bool
+isCapacityRetryable = \case
+    ProviderError OverloadedError _ _ -> True
+    ProviderError ServiceUnavailableError _ _ -> True
+    ProviderError ApiErrorType _ _ -> True
+    HttpError status _
+        | status `elem` [408, 409, 425] -> True
+        | status >= 500 && status < 600 -> True
+        | otherwise -> False
+    ConnectionError message -> isCapacityBody message
+    _ -> False
 
 trimSlash :: String -> String
 trimSlash = reverse . dropWhile (== '/') . reverse

--- a/packages/agent-xai/src/Agent/XAI/Error.hs
+++ b/packages/agent-xai/src/Agent/XAI/Error.hs
@@ -3,6 +3,8 @@ module Agent.XAI.Error
     ( classifyFailure
     , classifyStreamError
     , isFreeLimitBody
+    , isCapacityBody
+    , capacityRetryAfterSeconds
     ) where
 
 import Agent.Error (ApiError(..), ErrorType(..), errorTypeFromText)
@@ -10,6 +12,11 @@ import Agent.OpenAI.Error (classifyHttpFailure, mkOpenAIError)
 import Agent.OpenAI.Responses.Types (ResponseStreamError(..))
 import Data.Text (Text)
 import qualified Data.Text as Text
+
+-- | Default wait when xAI reports model capacity pressure without a
+-- structured @resets_in_seconds@ / @Retry-After@ value.
+capacityRetryAfterSeconds :: Int
+capacityRetryAfterSeconds = 30
 
 -- | Classify a non-success response from the Grok subscription proxy.
 classifyFailure :: Int -> Maybe Int -> Text -> ApiError
@@ -20,6 +27,9 @@ classifyFailure status retryAfterHeader body
             Nothing
     | isFreeLimitBody body =
         ProviderError UsageLimitReached (Text.take 500 body) retryAfterHeader
+    | isCapacityBody body =
+        ProviderError OverloadedError (Text.take 500 body)
+            (retryAfterHeader `orElse` Just capacityRetryAfterSeconds)
     | otherwise = case classifyHttpFailure status body of
         ProviderError errType message retryAfter ->
             ProviderError errType message (retryAfter `orElse` retryAfterHeader)
@@ -35,6 +45,9 @@ classifyStreamError :: ResponseStreamError -> ApiError
 classifyStreamError streamError
     | isFreeLimitBody streamError.message =
         ProviderError UsageLimitReached streamError.message streamError.retryAfter
+    | isCapacityBody streamError.message =
+        ProviderError OverloadedError streamError.message
+            (streamError.retryAfter `orElse` Just capacityRetryAfterSeconds)
     | Just errorType <- streamError.errorType =
         mkOpenAIError
             (errorTypeFromText errorType)
@@ -43,6 +56,9 @@ classifyStreamError streamError
             streamError.retryAfter
     | otherwise = ConnectionError
         ("xAI stream error: " <> streamError.message)
+  where
+    Just value `orElse` _ = Just value
+    Nothing `orElse` fallback = fallback
 
 -- | The subscription proxy sometimes reports quota exhaustion as upsell text
 -- instead of a structured error.
@@ -50,5 +66,16 @@ isFreeLimitBody :: Text -> Bool
 isFreeLimitBody body =
     "grok.com/supergrok" `Text.isInfixOf` lowered
         || "upgrade to a grok subscription" `Text.isInfixOf` lowered
+  where
+    lowered = Text.toLower body
+
+-- | Detect capacity / priority-processing pressure from unstructured xAI
+-- stream and HTTP bodies. These are short-lived overloads, not quota caps.
+isCapacityBody :: Text -> Bool
+isCapacityBody body =
+    "currently at capacity" `Text.isInfixOf` lowered
+        || "at capacity due to high demand" `Text.isInfixOf` lowered
+        || "use a higher service tier" `Text.isInfixOf` lowered
+        || "priority processing" `Text.isInfixOf` lowered
   where
     lowered = Text.toLower body

--- a/packages/agent-xai/test/Agent/XAI/ClientSpec.hs
+++ b/packages/agent-xai/test/Agent/XAI/ClientSpec.hs
@@ -1,11 +1,12 @@
 -- | Functional tests for the xAI client against an in-process HTTP mock.
 module Agent.XAI.ClientSpec (spec) where
 
-import Agent.Error (ApiError(..))
+import Agent.Error (ApiError(..), ErrorType(..))
 import Agent.XAI.Client
 import Agent.XAI.Options
 import Agent.Provider (Credential(..), Provider(..))
 import Agent.OpenAI.Responses.Types
+import Control.Retry (constantDelay, limitRetries)
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.KeyMap as KeyMap
 import qualified Data.ByteString.Lazy as LBS
@@ -68,6 +69,69 @@ spec = do
 
             requests <- readIORef recorded
             length requests `shouldBe` 1
+
+        it "retries capacity stream errors before returning success" do
+            recorded <- newIORef []
+            attempts <- newIORef (0 :: Int)
+            let capacityMessage :: Text
+                capacityMessage =
+                    "The model is currently at capacity due to high demand. \
+                    \Please try again in a few minutes, or use a higher service \
+                    \tier for priority processing"
+                handler _request = do
+                    n <- atomicModifyIORef' attempts \i -> (i + 1, i + 1)
+                    pure $ if n == 1
+                        then sseResponse
+                            [ sseEvent "error" $ Aeson.object
+                                [ "type" Aeson..= ("error" :: Text)
+                                , "error" Aeson..= Aeson.object
+                                    [ "message" Aeson..= capacityMessage
+                                    ]
+                                ]
+                            ]
+                        else sseResponse
+                            [ outputItemDone (assistantMessage "hello after capacity")
+                            , completedEvent "resp-retry" []
+                            ]
+            withMockGrok recorded handler \options -> do
+                result <- createResponseWithEventsPolicy
+                    (constantDelay 0 <> limitRetries 3)
+                    options
+                    (xaiCredential "token-a")
+                    (helloRequest "hi")
+                    (const (pure ()))
+                response <- expectRight result
+                response.responseId `shouldBe` "resp-retry"
+
+            requests <- readIORef recorded
+            length requests `shouldBe` 2
+
+        it "retries capacity Left values under a zero-delay policy" do
+            let capacity = ProviderError OverloadedError
+                    "The model is currently at capacity due to high demand"
+                    (Just 30)
+            responses <- newIORef
+                [ Left capacity
+                , Left capacity
+                , Right ("completed" :: Text)
+                ]
+            result <- retryTransientXaiResultWithPolicy
+                (constantDelay 0 <> limitRetries 3)
+                (atomicModifyIORef' responses \case
+                    next : rest -> (rest, next)
+                    [] -> error "unexpected extra xAI request")
+            result `shouldBe` Right "completed"
+            readIORef responses `shouldReturn` []
+
+        it "does not retry quota errors" do
+            attempts <- newIORef (0 :: Int)
+            let quota = ProviderError UsageLimitReached "quota" (Just 3600)
+            result <- retryTransientXaiResultWithPolicy
+                (constantDelay 0 <> limitRetries 3)
+                (modifyIORef' attempts (+ 1)
+                    >> pure (Left quota :: Either ApiError Text))
+            result `shouldBe` Left quota
+            readIORef attempts `shouldReturn` 1
 
 --------------------------------------------------------------------------------
 -- Mock server

--- a/packages/agent-xai/test/Agent/XAI/ResponsesSpec.hs
+++ b/packages/agent-xai/test/Agent/XAI/ResponsesSpec.hs
@@ -127,6 +127,34 @@ spec = do
             classifyFailure 503 Nothing "unavailable"
                 `shouldBe` HttpError 503 "unavailable"
 
+        it "types capacity pressure as OverloadedError with a 30s retry" do
+            let body =
+                    "The model is currently at capacity due to high demand. \
+                    \Please try again in a few minutes, or use a higher service \
+                    \tier for priority processing: \
+                    \https://docs.x.ai/developers/advanced-api-usage/priority-processing"
+            classifyFailure 503 Nothing body
+                `shouldBe` ProviderError OverloadedError body (Just 30)
+            classifyFailure 429 (Just 12) body
+                `shouldBe` ProviderError OverloadedError body (Just 12)
+
+    describe "classifyStreamError" do
+        it "types unstructured capacity stream errors as OverloadedError" do
+            let message =
+                    "The model is currently at capacity due to high demand. \
+                    \Please try again in a few minutes, or use a higher service \
+                    \tier for priority processing"
+                streamError = ResponseStreamError
+                    { errorType = Nothing
+                    , code = Nothing
+                    , message
+                    , param = Nothing
+                    , retryAfter = Nothing
+                    , extraFields = mempty
+                    }
+            classifyStreamError streamError
+                `shouldBe` ProviderError OverloadedError message (Just 30)
+
     describe "SSE assembly" do
         it "decodes typed event constructors and builds the merged final response" do
             let sse = Text.intercalate ""


### PR DESCRIPTION
## Summary
- Detect xAI capacity / priority-processing messages (e.g. "currently at capacity due to high demand") and classify them as `OverloadedError` with a default 30s `retryAfter`.
- Retry those short-lived capacity/overload failures in the xAI HTTP client (30s delay, up to 3 retries) instead of failing the turn immediately as a transport error.
- Leave quota and ordinary stream `ConnectionError` failures non-retried; add unit coverage for classification and zero-delay retry policy.

## Test plan
- [x] `cabal test agent-xai` (35 examples, 0 failures; live functional pending)
- [ ] Manually confirm a capacity stream error waits ~30s and succeeds on a later attempt when capacity clears