### PR TITLE
feat: use haskeline for REPL line editing

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -39,6 +39,7 @@ library
                     , Agent.CLI.Auth
                     , Agent.CLI.Clipboard
                     , Agent.CLI.Command
+                    , Agent.CLI.Input
                     , Agent.CLI.Markdown
                     , Agent.CLI.Options
                     , Agent.CLI.Project
@@ -58,6 +59,7 @@ library
                     , bytestring
                     , directory
                     , filepath
+                    , haskeline >= 0.8 && < 0.9
                     , process
                     , safe-exceptions
                     , text >= 2.0 && < 2.2
@@ -80,6 +82,7 @@ test-suite agent-cli-test
     other-modules:    Agent.CLI.AuthSpec
                     , Agent.CLI.ClipboardSpec
                     , Agent.CLI.CommandSpec
+                    , Agent.CLI.InputSpec
                     , Agent.CLI.MarkdownSpec
                     , Agent.CLI.OptionsSpec
                     , Agent.CLI.ProjectSpec
@@ -98,6 +101,7 @@ test-suite agent-cli-test
                     , bytestring
                     , directory
                     , filepath
+                    , haskeline >= 0.8 && < 0.9
                     , hspec >= 2.11 && < 2.12
                     , process
                     , text

--- a/packages/agent-cli/package.nix
+++ b/packages/agent-cli/package.nix
@@ -1,6 +1,6 @@
 { mkDerivation, aeson, agent-core, agent-openai, agent-openrouter
 , agent-xai, ansi-terminal, base, bytestring, directory, filepath
-, hspec, lib, process, safe-exceptions, text, time, unix
+, haskeline, hspec, lib, process, safe-exceptions, text, time, unix
 }:
 mkDerivation {
   pname = "agent-cli";
@@ -10,13 +10,13 @@ mkDerivation {
   isExecutable = true;
   libraryHaskellDepends = [
     aeson agent-core agent-openai agent-openrouter agent-xai
-    ansi-terminal base bytestring directory filepath process
+    ansi-terminal base bytestring directory filepath haskeline process
     safe-exceptions text time unix
   ];
   executableHaskellDepends = [ base ];
   testHaskellDepends = [
     aeson agent-core agent-openai ansi-terminal base bytestring
-    directory filepath hspec process text time unix
+    directory filepath haskeline hspec process text time unix
   ];
   description = "Command-line interface for the universal agent harness";
   license = lib.meta.getLicenseFromSpdxId "BSD-3-Clause";

--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -9,6 +9,7 @@ module Agent.CLI
 import Agent.CLI.Auth (LoadedAuth(..), loadAuth)
 import Agent.CLI.Clipboard (formatImageSize, readClipboardImage)
 import Agent.CLI.Command
+import Agent.CLI.Input (readApprovalLine, readReplLine)
 import Agent.CLI.Options
 import Agent.CLI.Project
     ( ProjectSettings(..)
@@ -87,7 +88,7 @@ import System.Environment (getArgs, getProgName, lookupEnv)
 import System.FilePath ((</>))
 import System.Console.ANSI.Codes (clearFromCursorToLineEndCode)
 import System.Exit (die, exitFailure)
-import System.IO (Handle, hFlush, hIsTerminalDevice, isEOF, stderr, stdin, stdout)
+import System.IO (Handle, hFlush, hIsTerminalDevice, stderr, stdin, stdout)
 
 -- | How the GHCi-driven agent REPL finished.
 data DevResult
@@ -436,28 +437,25 @@ repl
 repl config render provider previous printed paramsRef policyRef transcriptRef persist projectRoot tokenProvider agentsContext = do
     stdoutColor <- resolveColor stdout
     -- Prompt + typed input share a navy wash; clear-to-EOL paints the rest
-    -- of the line immediately. Reset after the line is read.
-    Text.putStr
-        ( beginBackground stdoutColor userBackground
-            <> rolePrompt stdoutColor "λ> "
-            <> if stdoutColor
-                then Text.pack clearFromCursorToLineEndCode
-                else mempty
-        )
+    -- of the line immediately. Haskeline redraws this prompt on edit.
+    let chromePrompt =
+            beginBackground stdoutColor userBackground
+                <> rolePrompt stdoutColor "λ> "
+                <> if stdoutColor
+                    then Text.pack clearFromCursorToLineEndCode
+                    else mempty
+    mline <- readReplLine chromePrompt
+    Text.putStr (endBackground stdoutColor)
     hFlush stdout
-    done <- isEOF
-    if done
-        then do
-            Text.putStr (endBackground stdoutColor)
+    case mline of
+        Nothing -> do
             putStrLn ""
             pure DevQuit
-        else do
-            line <- Text.strip <$> Text.getLine
-            Text.putStr (endBackground stdoutColor)
-            hFlush stdout
-            if Text.null line
+        Just line ->
+            let stripped = Text.strip line
+            in if Text.null stripped
                 then continue
-                else case parseReplLine line of
+                else case parseReplLine stripped of
                     ReplQuit -> pure DevQuit
                     ReplReload -> requestReload persist
                     ReplPrompt text -> do
@@ -760,22 +758,19 @@ approveTool policyRef tools call projectRoot = do
             | readOnly -> pure True
             | otherwise -> do
                 color <- resolveColor stderr
-                putTextLn stderr
-                    (roleWarn color ("Allow " <> summarizeToolCall call <> "? [y/N/a]"))
-                eof <- isEOF
-                if eof
-                    then pure False
-                    else do
-                        answer <- parseApprovalAnswer <$> Text.getLine
-                        case answer of
-                            AllowOnce -> pure True
-                            AllowAlways -> do
-                                writeIORef policyRef ApproveAll
-                                saveProjectAutoApprove projectRoot True
-                                putTextLn stderr
-                                    (roleSuccess color "auto-approve on (saved for project)")
-                                pure True
-                            Deny -> pure False
+                let question =
+                        roleWarn color ("Allow " <> summarizeToolCall call <> "? [y/N/a] ")
+                readApprovalLine question >>= \case
+                    Nothing -> pure False
+                    Just raw -> case parseApprovalAnswer raw of
+                        AllowOnce -> pure True
+                        AllowAlways -> do
+                            writeIORef policyRef ApproveAll
+                            saveProjectAutoApprove projectRoot True
+                            putTextLn stderr
+                                (roleSuccess color "auto-approve on (saved for project)")
+                            pure True
+                        Deny -> pure False
 
 toggleAlwaysApprove :: IORef ApprovalPolicy -> FilePath -> IO ()
 toggleAlwaysApprove policyRef projectRoot = do

--- a/packages/agent-cli/src/Agent/CLI/Input.hs
+++ b/packages/agent-cli/src/Agent/CLI/Input.hs
@@ -1,0 +1,94 @@
+-- | Line editing for interactive prompts. TTY sessions use haskeline so
+-- arrow keys move the cursor / recall history instead of echoing escape
+-- sequences; non-TTY falls back to plain 'getLine'.
+module Agent.CLI.Input
+    ( readReplLine
+    , readApprovalLine
+    , replHistoryPath
+    ) where
+
+import Control.Exception (AsyncException(UserInterrupt))
+import Control.Exception.Safe (catchIO, throwIO)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.IO as Text
+import System.Console.Haskeline
+    ( Settings(..)
+    , defaultSettings
+    , getInputLine
+    , handleInterrupt
+    , runInputT
+    , withInterrupt
+    )
+import System.Directory
+    ( createDirectoryIfMissing
+    , getHomeDirectory
+    )
+import System.FilePath (takeDirectory, (</>))
+import System.IO (hFlush, hIsTerminalDevice, isEOF, stdin, stdout)
+import System.Posix.Files (setFileMode)
+import System.Posix.Types (FileMode)
+
+-- | @~/.haskell-agent/history@ given the user's home directory.
+replHistoryPath :: FilePath -> FilePath
+replHistoryPath home = home </> ".haskell-agent" </> "history"
+
+-- | Read a REPL prompt line. Persists history under 'replHistoryPath' when
+-- stdin is a TTY. 'Nothing' means EOF.
+readReplLine :: Text -> IO (Maybe Text)
+readReplLine prompt = do
+    isTty <- hIsTerminalDevice stdin
+    if isTty
+        then do
+            home <- getHomeDirectory
+            let path = replHistoryPath home
+            ensureHistoryParent path
+            readEditedLine
+                defaultSettings
+                    { historyFile = Just path
+                    , autoAddHistory = True
+                    }
+                prompt
+        else readPlainLine prompt
+
+-- | Read a one-shot approval answer without touching REPL history.
+readApprovalLine :: Text -> IO (Maybe Text)
+readApprovalLine prompt = do
+    isTty <- hIsTerminalDevice stdin
+    if isTty
+        then readEditedLine
+            defaultSettings
+                { historyFile = Nothing
+                , autoAddHistory = False
+                }
+            prompt
+        else readPlainLine prompt
+
+readEditedLine :: Settings IO -> Text -> IO (Maybe Text)
+readEditedLine settings prompt =
+    -- Haskeline turns Ctrl-C into 'Interrupt'; rethrow as 'UserInterrupt'
+    -- so the outer resume-hint handler still runs.
+    handleInterrupt (throwIO UserInterrupt) $
+        runInputT settings $
+            withInterrupt $
+                fmap (fmap Text.pack) (getInputLine (Text.unpack prompt))
+
+readPlainLine :: Text -> IO (Maybe Text)
+readPlainLine prompt = do
+    Text.putStr prompt
+    hFlush stdout
+    done <- isEOF
+    if done
+        then pure Nothing
+        else Just . Text.strip <$> Text.getLine
+
+ensureHistoryParent :: FilePath -> IO ()
+ensureHistoryParent path = do
+    let dir = takeDirectory path
+    createDirectoryIfMissing True dir
+    -- Best-effort private mode; ignore failures on filesystems that refuse.
+    trySetMode dir 0o700
+
+trySetMode :: FilePath -> FileMode -> IO ()
+trySetMode path mode =
+    setFileMode path mode `catchIO` \_ -> pure ()

--- a/packages/agent-cli/src/Agent/CLI/Input.hs
+++ b/packages/agent-cli/src/Agent/CLI/Input.hs
@@ -25,7 +25,7 @@ import System.Directory
     , getHomeDirectory
     )
 import System.FilePath (takeDirectory, (</>))
-import System.IO (hFlush, hIsTerminalDevice, isEOF, stdin, stdout)
+import System.IO (hFlush, hIsTerminalDevice, isEOF, stderr, stdin, stdout)
 import System.Posix.Files (setFileMode)
 import System.Posix.Types (FileMode)
 
@@ -34,7 +34,7 @@ replHistoryPath :: FilePath -> FilePath
 replHistoryPath home = home </> ".haskell-agent" </> "history"
 
 -- | Read a REPL prompt line. Persists history under 'replHistoryPath' when
--- stdin is a TTY. 'Nothing' means EOF.
+-- stdin is a TTY. 'Nothing' means EOF. The prompt is drawn on stdout.
 readReplLine :: Text -> IO (Maybe Text)
 readReplLine prompt = do
     isTty <- hIsTerminalDevice stdin
@@ -49,20 +49,21 @@ readReplLine prompt = do
                     , autoAddHistory = True
                     }
                 prompt
-        else readPlainLine prompt
+        else do
+            Text.hPutStr stdout prompt
+            hFlush stdout
+            readAnswerOnly
 
--- | Read a one-shot approval answer without touching REPL history.
+-- | Read a one-shot approval answer. The question is always written to
+-- stderr (matching the pre-haskeline behavior) so redirected stdout does
+-- not swallow the prompt. Uses cooked 'getLine' so answer echo stays on
+-- the controlling TTY rather than haskeline's stdout handle. Does not
+-- touch REPL history.
 readApprovalLine :: Text -> IO (Maybe Text)
 readApprovalLine prompt = do
-    isTty <- hIsTerminalDevice stdin
-    if isTty
-        then readEditedLine
-            defaultSettings
-                { historyFile = Nothing
-                , autoAddHistory = False
-                }
-            prompt
-        else readPlainLine prompt
+    Text.hPutStr stderr prompt
+    hFlush stderr
+    readAnswerOnly
 
 readEditedLine :: Settings IO -> Text -> IO (Maybe Text)
 readEditedLine settings prompt =
@@ -73,10 +74,8 @@ readEditedLine settings prompt =
             withInterrupt $
                 fmap (fmap Text.pack) (getInputLine (Text.unpack prompt))
 
-readPlainLine :: Text -> IO (Maybe Text)
-readPlainLine prompt = do
-    Text.putStr prompt
-    hFlush stdout
+readAnswerOnly :: IO (Maybe Text)
+readAnswerOnly = do
     done <- isEOF
     if done
         then pure Nothing

--- a/packages/agent-cli/test/Agent/CLI/InputSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/InputSpec.hs
@@ -1,0 +1,12 @@
+module Agent.CLI.InputSpec (spec) where
+
+import Agent.CLI.Input (replHistoryPath)
+import System.FilePath ((</>))
+import Test.Hspec
+
+spec :: Spec
+spec = do
+    describe "replHistoryPath" do
+        it "is ~/.haskell-agent/history" do
+            replHistoryPath "/home/marc"
+                `shouldBe` "/home/marc" </> ".haskell-agent" </> "history"

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -5,6 +5,7 @@ import Test.Hspec (hspec)
 import qualified Agent.CLI.AuthSpec as AuthSpec
 import qualified Agent.CLI.ClipboardSpec as ClipboardSpec
 import qualified Agent.CLI.CommandSpec as CommandSpec
+import qualified Agent.CLI.InputSpec as InputSpec
 import qualified Agent.CLI.MarkdownSpec as MarkdownSpec
 import qualified Agent.CLI.OptionsSpec as OptionsSpec
 import qualified Agent.CLI.ProjectSpec as ProjectSpec
@@ -20,6 +21,7 @@ main = hspec do
     AuthSpec.spec
     ClipboardSpec.spec
     CommandSpec.spec
+    InputSpec.spec
     MarkdownSpec.spec
     OptionsSpec.spec
     ProjectSpec.spec


### PR DESCRIPTION
## Summary
- Replace plain `Text.getLine` REPL/approval input with haskeline on TTYs so arrow keys edit/recall instead of printing escape junk
- Persist REPL history under `~/.haskell-agent/history`; keep non-TTY `getLine` for pipes/tests
- Rethrow haskeline Ctrl-C as `UserInterrupt` so the existing resume hint still runs

## Test plan
- [x] `cabal build agent-cli:lib:agent-cli`
- [x] `cabal test agent-cli:agent-cli-test` (113 examples)
- [ ] Manual: start interactive REPL, confirm left/right/up arrows work at `λ>` and do not print `^[[A`-style junk
- [ ] Manual: Ctrl-C at the prompt still prints the `--resume` hint when a session exists