### PR TITLE
feat: restyle CLI chrome with Solarized Dark truecolor

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -57,6 +57,7 @@ library
                     , ansi-terminal >= 1.0
                     , base >= 4.17 && < 5
                     , bytestring
+                    , colour >= 2.3
                     , directory
                     , filepath
                     , haskeline >= 0.8 && < 0.9
@@ -99,6 +100,7 @@ test-suite agent-cli-test
                     , ansi-terminal
                     , base >= 4.17 && < 5
                     , bytestring
+                    , colour
                     , directory
                     , filepath
                     , haskeline >= 0.8 && < 0.9

--- a/packages/agent-cli/package.nix
+++ b/packages/agent-cli/package.nix
@@ -1,6 +1,7 @@
 { mkDerivation, aeson, agent-core, agent-openai, agent-openrouter
-, agent-xai, ansi-terminal, base, bytestring, directory, filepath
-, haskeline, hspec, lib, process, safe-exceptions, text, time, unix
+, agent-xai, ansi-terminal, base, bytestring, colour, directory
+, filepath, haskeline, hspec, lib, process, safe-exceptions, text
+, time, unix
 }:
 mkDerivation {
   pname = "agent-cli";
@@ -10,12 +11,12 @@ mkDerivation {
   isExecutable = true;
   libraryHaskellDepends = [
     aeson agent-core agent-openai agent-openrouter agent-xai
-    ansi-terminal base bytestring directory filepath haskeline process
-    safe-exceptions text time unix
+    ansi-terminal base bytestring colour directory filepath haskeline
+    process safe-exceptions text time unix
   ];
   executableHaskellDepends = [ base ];
   testHaskellDepends = [
-    aeson agent-core agent-openai ansi-terminal base bytestring
+    aeson agent-core agent-openai ansi-terminal base bytestring colour
     directory filepath haskeline hspec process text time unix
   ];
   description = "Command-line interface for the universal agent harness";

--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -436,8 +436,8 @@ repl
     -> IO DevResult
 repl config render provider previous printed paramsRef policyRef transcriptRef persist projectRoot tokenProvider agentsContext = do
     stdoutColor <- resolveColor stdout
-    -- Prompt + typed input share a navy wash; clear-to-EOL paints the rest
-    -- of the line immediately. Haskeline redraws this prompt on edit.
+    -- Solarized user wash under the prompt; haskeline redraws it on edit.
+    -- Cmd+Delete / Ctrl+U kill-to-start via haskeline Emacs bindings.
     let chromePrompt =
             beginBackground stdoutColor userBackground
                 <> rolePrompt stdoutColor "λ> "

--- a/packages/agent-cli/src/Agent/CLI/Markdown.hs
+++ b/packages/agent-cli/src/Agent/CLI/Markdown.hs
@@ -3,16 +3,25 @@ module Agent.CLI.Markdown
     ( renderMarkdown
     ) where
 
-import Agent.CLI.Style (agentBackground, styleBase)
+import Agent.CLI.Style
+    ( agentBackground
+    , solarizedBase01
+    , solarizedBlue
+    , solarizedCyan
+    , solarizedGreen
+    , solarizedMagenta
+    , solarizedViolet
+    , solarizedYellow
+    , styleBase
+    )
 import Control.Applicative ((<|>))
 import Data.Char (isAlphaNum, isDigit, isSpace)
+import Data.Colour (Colour)
 import Data.List (transpose)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import System.Console.ANSI
-    ( Color(..)
-    , ColorIntensity(..)
-    , ConsoleIntensity(..)
+    ( ConsoleIntensity(..)
     , ConsoleLayer(..)
     , SGR(..)
     , Underlining(..)
@@ -49,13 +58,8 @@ renderBlocks = go
                     if Text.null info
                         then []
                         else
-                            [ md
-                                [ SetConsoleIntensity FaintIntensity
-                                , SetColor Foreground Dull Cyan
-                                ]
-                                info
-                            ]
-                styledBody = map (md [SetConsoleIntensity FaintIntensity]) body
+                            [ md [fg solarizedCyan] info ]
+                styledBody = map (md [fg solarizedBase01]) body
             in header ++ styledBody ++ go after
         | Just (styled, after) <- takeTable (line : rest) =
             styled ++ go after
@@ -77,10 +81,10 @@ renderBlocks = go
             let body
                     | Text.any (`elem` ['`', '*', '_', '[']) quote = styleInline quote
                     | otherwise = md quoteStyle quote
-            in (md [SetConsoleIntensity FaintIntensity] "│ " <> body)
+            in (md [fg solarizedBase01] "│ " <> body)
                 : go rest
         | isThematicBreak line =
-            md [SetConsoleIntensity FaintIntensity] (Text.replicate 40 "─")
+            md [fg solarizedBase01] (Text.replicate 40 "─")
                 : go rest
         | Text.null (Text.strip line) = line : go rest
         | otherwise = styleInline line : go rest
@@ -94,22 +98,25 @@ headingPrefixStyle level =
 
 headingColor :: Int -> [SGR]
 headingColor = \case
-    1 -> [SetColor Foreground Dull Magenta]
-    2 -> [SetColor Foreground Dull Cyan]
-    3 -> [SetColor Foreground Dull Blue]
-    4 -> [SetColor Foreground Dull Yellow]
-    5 -> [SetColor Foreground Dull Green]
-    _ -> []
+    1 -> [fg solarizedMagenta]
+    2 -> [fg solarizedCyan]
+    3 -> [fg solarizedBlue]
+    4 -> [fg solarizedYellow]
+    5 -> [fg solarizedGreen]
+    _ -> [fg solarizedViolet]
 
 listMarkerStyle :: [SGR]
 listMarkerStyle =
     [ SetConsoleIntensity BoldIntensity
-    , SetColor Foreground Dull Cyan
+    , fg solarizedCyan
     ]
 
--- | Blockquote body: faint so it sits behind surrounding prose.
+fg :: Colour Float -> SGR
+fg = SetRGBColor Foreground
+
+-- | Blockquote body: muted so it sits behind surrounding prose.
 quoteStyle :: [SGR]
-quoteStyle = [SetConsoleIntensity FaintIntensity]
+quoteStyle = [fg solarizedBase01]
 
 data FenceMarker = BacktickFence !Int | TildeFence !Int
 
@@ -283,13 +290,13 @@ styleInline = Text.concat . go Nothing
 
     codeStyle =
         [ SetConsoleIntensity BoldIntensity
-        , SetColor Foreground Dull Cyan
+        , fg solarizedCyan
         ]
     linkStyle =
-        [ SetColor Foreground Dull Blue
+        [ fg solarizedBlue
         , SetUnderlining SingleUnderline
         ]
-    urlStyle = [SetConsoleIntensity FaintIntensity]
+    urlStyle = [fg solarizedBase01]
 
 takeInlineCode :: Text -> Maybe (Text, Text)
 takeInlineCode t =

--- a/packages/agent-cli/src/Agent/CLI/Style.hs
+++ b/packages/agent-cli/src/Agent/CLI/Style.hs
@@ -1,5 +1,8 @@
 -- | Shared ANSI roles for TTY chrome and markdown. Callers pass a color
 -- flag; when 'False' (pipes, 'NO_COLOR', tests) text is unchanged.
+--
+-- Palette is Solarized Dark (Ethan Schoonover): truecolor RGB, not the
+-- 256-color approximation, so washes match a Solarized terminal theme.
 module Agent.CLI.Style
     ( style
     , styleBase
@@ -18,16 +21,25 @@ module Agent.CLI.Style
     , roleWarn
     , roleMuted
     , roleSuccess
+    , solarizedCyan
+    , solarizedMagenta
+    , solarizedYellow
+    , solarizedRed
+    , solarizedGreen
+    , solarizedBlue
+    , solarizedViolet
+    , solarizedOrange
+    , solarizedBase01
     , cliWindowTitle
     , setCliWindowTitle
     ) where
 
+import Data.Colour (Colour)
+import Data.Colour.SRGB (sRGB24)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import System.Console.ANSI
-    ( Color(..)
-    , ColorIntensity(..)
-    , ConsoleIntensity(..)
+    ( ConsoleIntensity(..)
     , ConsoleLayer(..)
     , SGR(..)
     , hSetTitle
@@ -39,13 +51,39 @@ import System.Console.ANSI.Codes
 import System.FilePath (takeFileName)
 import System.IO (Handle)
 
--- | Deep navy strip behind the REPL prompt and typed input.
-userBackground :: [SGR]
-userBackground = [SetPaletteColor Background 17]
+-- Solarized Dark (https://ethanschoonover.com/solarized/)
+solarizedBase03, solarizedBase02, solarizedBase01 :: Colour Float
+solarizedBase03 = sRGB24 0x00 0x2b 0x36
+solarizedBase02 = sRGB24 0x07 0x36 0x42
+solarizedBase01 = sRGB24 0x58 0x6e 0x75
 
--- | Charcoal strip behind assistant stdout lines.
+solarizedYellow, solarizedOrange, solarizedRed :: Colour Float
+solarizedYellow = sRGB24 0xb5 0x89 0x00
+solarizedOrange = sRGB24 0xcb 0x4b 0x16
+solarizedRed = sRGB24 0xdc 0x32 0x2f
+
+solarizedMagenta, solarizedViolet, solarizedBlue :: Colour Float
+solarizedMagenta = sRGB24 0xd3 0x36 0x82
+solarizedViolet = sRGB24 0x6c 0x71 0xc4
+solarizedBlue = sRGB24 0x26 0x8b 0xd2
+
+solarizedCyan, solarizedGreen :: Colour Float
+solarizedCyan = sRGB24 0x2a 0xa1 0x98
+solarizedGreen = sRGB24 0x85 0x99 0x00
+
+fg :: Colour Float -> SGR
+fg = SetRGBColor Foreground
+
+bg :: Colour Float -> SGR
+bg = SetRGBColor Background
+
+-- | Solarized base02 strip behind the REPL prompt and typed input.
+userBackground :: [SGR]
+userBackground = [bg solarizedBase02]
+
+-- | Solarized base03 strip behind assistant stdout lines.
 agentBackground :: [SGR]
-agentBackground = [SetPaletteColor Background 236]
+agentBackground = [bg solarizedBase03]
 
 -- | Apply SGR attributes when @color@ is 'True'; otherwise return @text@.
 -- Ends with a full 'Reset'.
@@ -64,9 +102,9 @@ styleBase color base attrs text
 
 -- | Open a background wash and leave it active (for live typed input).
 beginBackground :: Bool -> [SGR] -> Text
-beginBackground color bg
-    | not color || null bg = ""
-    | otherwise = Text.pack (setSGRCode bg)
+beginBackground color bgAttrs
+    | not color || null bgAttrs = ""
+    | otherwise = Text.pack (setSGRCode bgAttrs)
 
 -- | Clear all SGR after a background wash.
 endBackground :: Bool -> Text
@@ -77,21 +115,21 @@ endBackground color
 -- | Prefix each line with @bg@, extend the wash to the terminal edge via
 -- clear-to-EOL, then reset. Preserves a trailing newline on @text@.
 paintBackgroundLines :: Bool -> [SGR] -> Text -> Text
-paintBackgroundLines color bg text
-    | not color || null bg || Text.null text = text
+paintBackgroundLines color bgAttrs text
+    | not color || null bgAttrs || Text.null text = text
     | otherwise =
         let endsWithNewline = Text.isSuffixOf "\n" text
             parts = Text.splitOn "\n" text
             lines_
                 | endsWithNewline && not (null parts) = init parts
                 | otherwise = parts
-            painted = map (paintLine bg) lines_
+            painted = map (paintLine bgAttrs) lines_
         in Text.intercalate "\n" painted
             <> if endsWithNewline then "\n" else ""
 
 paintLine :: [SGR] -> Text -> Text
-paintLine bg line =
-    Text.pack (setSGRCode bg)
+paintLine bgAttrs line =
+    Text.pack (setSGRCode bgAttrs)
         <> line
         <> Text.pack clearFromCursorToLineEndCode
         <> Text.pack (setSGRCode [Reset])
@@ -100,53 +138,52 @@ rolePrompt :: Bool -> Text -> Text
 rolePrompt color =
     styleBase color userBackground
         [ SetConsoleIntensity BoldIntensity
-        , SetColor Foreground Dull Cyan
+        , fg solarizedCyan
         ]
 
 roleToolArrow :: Bool -> Text -> Text
-roleToolArrow color = style color [SetConsoleIntensity FaintIntensity]
+roleToolArrow color = style color [fg solarizedBase01]
 
 roleToolName :: Bool -> Text -> Text
 roleToolName color =
     style color
         [ SetConsoleIntensity BoldIntensity
-        , SetColor Foreground Dull Magenta
+        , fg solarizedMagenta
         ]
 
 roleToolDetail :: Bool -> Text -> Text
-roleToolDetail color = style color [SetConsoleIntensity FaintIntensity]
+roleToolDetail color = style color [fg solarizedBase01]
 
 roleToolOutput :: Bool -> Text -> Text
-roleToolOutput color = style color [SetConsoleIntensity FaintIntensity]
+roleToolOutput color = style color [fg solarizedBase01]
 
 roleThinking :: Bool -> Text -> Text
 roleThinking color =
     style color
-        [ SetConsoleIntensity FaintIntensity
-        , SetColor Foreground Dull Yellow
+        [ fg solarizedYellow
         ]
 
 roleError :: Bool -> Text -> Text
 roleError color =
     style color
         [ SetConsoleIntensity BoldIntensity
-        , SetColor Foreground Vivid Red
+        , fg solarizedRed
         ]
 
 roleWarn :: Bool -> Text -> Text
 roleWarn color =
     style color
         [ SetConsoleIntensity BoldIntensity
-        , SetColor Foreground Dull Yellow
+        , fg solarizedYellow
         ]
 
 roleMuted :: Bool -> Text -> Text
-roleMuted color = style color [SetConsoleIntensity FaintIntensity]
+roleMuted color = style color [fg solarizedBase01]
 
 roleSuccess :: Bool -> Text -> Text
 roleSuccess color =
     style color
-        [ SetColor Foreground Dull Green
+        [ fg solarizedGreen
         ]
 
 -- | Window title: session name when known, otherwise the working directory.

--- a/packages/agent-cli/test/Agent/CLI/MarkdownSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/MarkdownSpec.hs
@@ -100,5 +100,5 @@ spec = do
 
         it "restores the agent wash after inline spans" do
             let out = renderMarkdown True "see `file.txt` now"
-            -- Nested Reset must re-open palette 236 so line painting sticks.
-            out `shouldSatisfy` Text.isInfixOf "\ESC[0;48;5;236m"
+            -- Nested Reset must re-open Solarized base03 so line painting sticks.
+            out `shouldSatisfy` Text.isInfixOf "\ESC[0;48;2;0;43;54m"

--- a/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
@@ -110,7 +110,7 @@ spec = do
                 body <- Text.readFile path
                 body `shouldSatisfy` Text.isInfixOf "file.txt"
                 body `shouldSatisfy` Text.isInfixOf "\ESC["
-                body `shouldSatisfy` Text.isInfixOf "\ESC[48;5;236m"
+                body `shouldSatisfy` Text.isInfixOf "\ESC[48;2;0;43;54m"
                 body `shouldSatisfy` (not . Text.isInfixOf "`file.txt`")
 
         it "flushes pre-tool assistant prose before tool lines" do

--- a/packages/agent-cli/test/Agent/CLI/StyleSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/StyleSpec.hs
@@ -18,8 +18,8 @@ spec = do
 
         it "restores a base wash after nested styling" do
             let out = styleBase True agentBackground [] "hi"
-            -- Reset then reopen palette 236 (combined into one SGR sequence).
-            out `shouldSatisfy` Text.isInfixOf "\ESC[0;48;5;236m"
+            -- Reset then reopen Solarized base03 (combined into one SGR sequence).
+            out `shouldSatisfy` Text.isInfixOf "\ESC[0;48;2;0;43;54m"
 
     describe "paintBackgroundLines" do
         it "leaves text unchanged when color is off" do
@@ -27,7 +27,7 @@ spec = do
 
         it "paints each line and preserves a trailing newline" do
             let out = paintBackgroundLines True agentBackground "a\nb\n"
-            Text.count "\ESC[48;5;236m" out `shouldBe` 2
+            Text.count "\ESC[48;2;0;43;54m" out `shouldBe` 2
             out `shouldSatisfy` Text.isSuffixOf "\n"
             out `shouldSatisfy` Text.isInfixOf "\ESC[0K"
 
@@ -39,9 +39,9 @@ spec = do
 
         it "keeps the user wash under the prompt glyph" do
             let out = rolePrompt True "λ>"
-            -- Background may share an SGR sequence with bold/cyan attrs.
-            out `shouldSatisfy` Text.isInfixOf "48;5;17"
-            out `shouldSatisfy` Text.isInfixOf "\ESC[0;48;5;17m"
+            -- Background may share an SGR sequence with bold/cyan attrs (truecolor).
+            out `shouldSatisfy` Text.isInfixOf "48;2;7;54;66"
+            out `shouldSatisfy` Text.isInfixOf "\ESC[0;48;2;7;54;66m"
 
     describe "cliWindowTitle" do
         it "uses the cwd basename when no session title is set" do


### PR DESCRIPTION
## Summary
- Restyle agent-cli TTY chrome and markdown accents to Solarized Dark truecolor (`base02` user wash, `base03` agent wash, Solarized accents).
- Keep master's haskeline-based line editor (`Agent.CLI.Input`); Cmd+Delete / Ctrl+U already work there.

## Test plan
- [x] `cabal test agent-cli:agent-cli-test`
- [ ] Reload the agent REPL and confirm prompt/agent washes look Solarized
- [ ] Type text at `λ>` and press Cmd+Delete (or Ctrl+U); the typed text should clear