### PR TITLE
feat: soft-cancel in-flight tools with Esc

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -37,6 +37,7 @@ library
     hs-source-dirs:   src
     exposed-modules:  Agent.CLI
                     , Agent.CLI.Auth
+                    , Agent.CLI.CancelWatch
                     , Agent.CLI.Clipboard
                     , Agent.CLI.Command
                     , Agent.CLI.Input
@@ -81,6 +82,7 @@ test-suite agent-cli-test
     hs-source-dirs:   test
     main-is:          Spec.hs
     other-modules:    Agent.CLI.AuthSpec
+                    , Agent.CLI.CancelWatchSpec
                     , Agent.CLI.ClipboardSpec
                     , Agent.CLI.CommandSpec
                     , Agent.CLI.InputSpec

--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -7,6 +7,7 @@ module Agent.CLI
     ) where
 
 import Agent.CLI.Auth (LoadedAuth(..), loadAuth)
+import Agent.CLI.CancelWatch (withEscCancel)
 import Agent.CLI.Clipboard (formatImageSize, readClipboardImage)
 import Agent.CLI.Command
 import Agent.CLI.Input (readApprovalLine, readReplLine)
@@ -65,7 +66,7 @@ import Agent.Provider
     )
 import Agent.ToolDispatch (ToolCall(..))
 import Agent.Tools (appToolHandlers, codingToolsFor)
-import Agent.Tools.Types (AppTool(..), defaultToolEnv, toolAllowsWithoutPrompt)
+import Agent.Tools.Types (AppTool(..), ToolEnv(..), defaultToolEnv, toolAllowsWithoutPrompt)
 import Agent.OpenRouter.LoopBackend (openRouterBackend)
 import qualified Agent.OpenRouter.Options as OpenRouter
 import Agent.XAI.LoopBackend (xaiBackend)
@@ -226,7 +227,8 @@ runAgent options = do
             | otherwise -> pure ()
         Nothing -> pure ()
 
-    (tools, closeTools) <- codingToolsFor loaded.loadedProvider (defaultToolEnv cwd)
+    toolEnv <- defaultToolEnv cwd
+    (tools, closeTools) <- codingToolsFor loaded.loadedProvider toolEnv
     flip finally closeTools do
         today <- utctDay <$> getCurrentTime
         let provider = loaded.loadedProvider
@@ -259,7 +261,7 @@ runAgent options = do
                 OpenAIProvider ->
                     try @_ @CodexAuthFailed
                         (withCodexWsWithProvider loaded.loadedTokenProvider \conn _credential ->
-                            runSession options provider policy tools prompt paramsRef transcriptRef
+                            runSession options provider policy tools toolEnv prompt paramsRef transcriptRef
                                 initialPrevious persist projectRoot Nothing agentsContext
                                 (openAiBackend conn (readIORef paramsRef) transcriptRef))
                         >>= \case
@@ -270,14 +272,14 @@ runAgent options = do
                     let backend =
                             xaiBackend xaiOptions loaded.loadedTokenProvider
                                 (readIORef paramsRef) transcriptRef
-                    runSession options provider policy tools prompt paramsRef transcriptRef
+                    runSession options provider policy tools toolEnv prompt paramsRef transcriptRef
                         initialPrevious persist projectRoot (Just loaded.loadedTokenProvider) agentsContext backend
                 OpenRouterProvider -> do
                     openRouterOptions <- OpenRouter.clientOptionsFromEnv
                     let backend =
                             openRouterBackend openRouterOptions loaded.loadedTokenProvider
                                 (readIORef paramsRef) transcriptRef
-                    runSession options provider policy tools prompt paramsRef transcriptRef
+                    runSession options provider policy tools toolEnv prompt paramsRef transcriptRef
                         initialPrevious persist projectRoot (Just loaded.loadedTokenProvider) agentsContext backend
 
 preparePersistence
@@ -370,6 +372,7 @@ runSession
     -> Provider
     -> ApprovalPolicy
     -> [AppTool]
+    -> ToolEnv
     -> Maybe Text
     -> IORef ResponseCreateParams
     -> IORef [ResponseItem]
@@ -380,7 +383,7 @@ runSession
     -> IORef (Maybe Text)
     -> Backend
     -> IO DevResult
-runSession options provider policy tools prompt paramsRef transcriptRef initialPrevious persist projectRoot tokenProvider agentsContext backend = do
+runSession options provider policy tools toolEnv prompt paramsRef transcriptRef initialPrevious persist projectRoot tokenProvider agentsContext backend = do
     printed <- newIORef False
     textBuffer <- newIORef ""
     thinkingVisible <- newIORef False
@@ -408,6 +411,7 @@ runSession options provider policy tools prompt paramsRef transcriptRef initialP
             , loopApprove = \call ->
                 withMVar ioLock \_ ->
                     approveTool policyRef tools call projectRoot
+            , loopCancel = toolEnv.toolCancel
             }
     case prompt of
         Just text -> do
@@ -640,7 +644,8 @@ runOneTurn
     -> Text
     -> [TurnInput]
     -> IO Bool
-runOneTurn config render previous printed transcriptRef persist agentsContext promptText inputs = do
+runOneTurn config render previous printed transcriptRef persist agentsContext promptText inputs =
+  withEscCancel config.loopCancel do
     prev <- readIORef previous
     beforeItems <- readIORef transcriptRef
     pendingAgents <- atomicModifyIORef' agentsContext \pending -> (Nothing, pending)
@@ -651,6 +656,10 @@ runOneTurn config render previous printed transcriptRef persist agentsContext pr
     result <- runLoopInputs config prev turnInputs
     clearThinking render
     case result of
+        Left LoopCancelled -> do
+            color <- resolveColor stderr
+            putTextLn stderr (formatLoopErrorColored color LoopCancelled)
+            pure True
         Left err -> do
             color <- resolveColor stderr
             putTextLn stderr (formatLoopErrorColored color err)

--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -7,7 +7,7 @@ module Agent.CLI
     ) where
 
 import Agent.CLI.Auth (LoadedAuth(..), loadAuth)
-import Agent.CLI.CancelWatch (withEscCancel)
+import Agent.CLI.CancelWatch (withEscCancel, withStdinPaused)
 import Agent.CLI.Clipboard (formatImageSize, readClipboardImage)
 import Agent.CLI.Command
 import Agent.CLI.Input (readApprovalLine, readReplLine)
@@ -52,7 +52,7 @@ import Agent.ProjectInstructions
     , globalAgentsHomeDir
     , loadedInstructionFiles
     )
-import Agent.OpenAI.LoopBackend (openAiBackend)
+import Agent.OpenAI.LoopBackend (openAiBackend, toolResultToItem)
 import Agent.OpenAI.Responses.Types
 import Agent.OpenAI.WebSocketClient (CodexAuthFailed(..), withCodexWsWithProvider)
 import Agent.Provider
@@ -74,7 +74,7 @@ import qualified Agent.XAI.Options as XAI
 import Control.Concurrent.MVar (newMVar, withMVar)
 import Control.Exception (AsyncException(UserInterrupt))
 import Control.Exception.Safe (catchAsync, finally, throwIO, try)
-import Control.Monad (when)
+import Control.Monad (unless, when)
 import qualified Data.ByteString as BS
 import Data.IORef
 import Data.Maybe (fromMaybe, isJust, isNothing)
@@ -385,6 +385,7 @@ runSession
     -> IO DevResult
 runSession options provider policy tools toolEnv prompt paramsRef transcriptRef initialPrevious persist projectRoot tokenProvider agentsContext backend = do
     printed <- newIORef False
+    escPaused <- newIORef False
     textBuffer <- newIORef ""
     thinkingVisible <- newIORef False
     ioLock <- newMVar ()
@@ -410,19 +411,20 @@ runSession options provider policy tools toolEnv prompt paramsRef transcriptRef 
             , loopOnEvent = renderEvent render
             , loopApprove = \call ->
                 withMVar ioLock \_ ->
-                    approveTool policyRef tools call projectRoot
+                    withStdinPaused escPaused $
+                        approveTool policyRef tools call projectRoot
             , loopCancel = toolEnv.toolCancel
             }
     case prompt of
         Just text -> do
-            ok <- runOneTurn config render previous printed transcriptRef persist agentsContext text
+            ok <- runOneTurn config render previous printed transcriptRef persist agentsContext escPaused text
                 [UserMessage text]
             if ok
                 then putTrailingNewline printed >> pure DevQuit
                 else exitFailure
         Nothing ->
             repl config render provider previous printed paramsRef policyRef
-                transcriptRef persist projectRoot tokenProvider agentsContext
+                transcriptRef persist projectRoot tokenProvider agentsContext escPaused
 
 repl
     :: LoopConfig
@@ -437,8 +439,9 @@ repl
     -> FilePath
     -> Maybe TokenProvider
     -> IORef (Maybe Text)
+    -> IORef Bool
     -> IO DevResult
-repl config render provider previous printed paramsRef policyRef transcriptRef persist projectRoot tokenProvider agentsContext = do
+repl config render provider previous printed paramsRef policyRef transcriptRef persist projectRoot tokenProvider agentsContext escPaused = do
     stdoutColor <- resolveColor stdout
     -- Solarized user wash under the prompt; haskeline redraws it on edit.
     -- Cmd+Delete / Ctrl+U kill-to-start via haskeline Emacs bindings.
@@ -465,7 +468,7 @@ repl config render provider previous printed paramsRef policyRef transcriptRef p
                     ReplPrompt text -> do
                         writeIORef printed False
                         _ <- runOneTurn config render previous printed
-                            transcriptRef persist agentsContext text [UserMessage text]
+                            transcriptRef persist agentsContext escPaused text [UserMessage text]
                         putTrailingNewline printed
                         continue
                     ReplPaste caption -> do
@@ -487,7 +490,7 @@ repl config render provider previous printed paramsRef policyRef transcriptRef p
                                         ("pasted " <> image.imageMime <> " (" <> size <> ")"))
                                 writeIORef printed False
                                 _ <- runOneTurn config render previous printed
-                                    transcriptRef persist agentsContext promptText
+                                    transcriptRef persist agentsContext escPaused promptText
                                     [ UserMultimodal
                                         { userText = promptText
                                         , userImages = [image]
@@ -578,7 +581,7 @@ repl config render provider previous printed paramsRef policyRef transcriptRef p
   where
     continue =
         repl config render provider previous printed paramsRef policyRef
-            transcriptRef persist projectRoot tokenProvider agentsContext
+            transcriptRef persist projectRoot tokenProvider agentsContext escPaused
 
 reloadAuth :: Provider -> Maybe TokenProvider -> IO ()
 reloadAuth provider = \case
@@ -641,11 +644,12 @@ runOneTurn
     -> IORef [ResponseItem]
     -> Maybe (IORef (Either SessionCreate SessionHandle))
     -> IORef (Maybe Text)
+    -> IORef Bool
     -> Text
     -> [TurnInput]
     -> IO Bool
-runOneTurn config render previous printed transcriptRef persist agentsContext promptText inputs =
-  withEscCancel config.loopCancel do
+runOneTurn config render previous printed transcriptRef persist agentsContext escPaused promptText inputs =
+  withEscCancel config.loopCancel escPaused do
     prev <- readIORef previous
     beforeItems <- readIORef transcriptRef
     pendingAgents <- atomicModifyIORef' agentsContext \pending -> (Nothing, pending)
@@ -656,9 +660,14 @@ runOneTurn config render previous printed transcriptRef persist agentsContext pr
     result <- runLoopInputs config prev turnInputs
     clearThinking render
     case result of
-        Left LoopCancelled -> do
+        Left (LoopCancelled toolResults) -> do
+            -- Commit tool outputs so function_call items are not left dangling
+            -- in the local transcript (xAI / OpenRouter / OpenAI mirror).
+            unless (null toolResults) do
+                modifyIORef' transcriptRef
+                    (<> map toolResultToItem toolResults)
             color <- resolveColor stderr
-            putTextLn stderr (formatLoopErrorColored color LoopCancelled)
+            putTextLn stderr (formatLoopErrorColored color (LoopCancelled toolResults))
             pure True
         Left err -> do
             color <- resolveColor stderr

--- a/packages/agent-cli/src/Agent/CLI/CancelWatch.hs
+++ b/packages/agent-cli/src/Agent/CLI/CancelWatch.hs
@@ -1,0 +1,111 @@
+-- | Watch stdin for a bare Esc during an agent turn and soft-cancel.
+module Agent.CLI.CancelWatch
+    ( withEscCancel
+    , isBareEscape
+    ) where
+
+import Agent.Cancel (CancelFlag, requestCancel)
+import Control.Concurrent (forkIO, killThread)
+import Control.Exception.Safe (bracket, finally)
+import Control.Monad (when)
+import Data.IORef (IORef, newIORef, readIORef, writeIORef)
+import System.IO
+    ( BufferMode(..)
+    , Handle
+    , hGetBuffering
+    , hGetChar
+    , hIsTerminalDevice
+    , hReady
+    , hSetBuffering
+    , hWaitForInput
+    , stdin
+    )
+import System.Posix.IO (stdInput)
+import System.Posix.Terminal
+    ( TerminalMode(..)
+    , TerminalState(..)
+    , getTerminalAttributes
+    , setTerminalAttributes
+    , withMinInput
+    , withTime
+    , withoutMode
+    )
+
+-- | Run @action@ while Esc on a TTY stdin requests soft cancel.
+-- Restores terminal attributes afterward. Non-TTY is a no-op wrapper.
+withEscCancel :: CancelFlag -> IO a -> IO a
+withEscCancel cancel action = do
+    tty <- hIsTerminalDevice stdin
+    if not tty
+        then action
+        else do
+            oldTerm <- getTerminalAttributes stdInput
+            oldBuf <- hGetBuffering stdin
+            stopped <- newIORef False
+            let enter = do
+                    let raw =
+                            flip withMinInput 1
+                                . flip withTime 0
+                                . flip withoutMode EnableEcho
+                                -- Keep ProcessInput so Ctrl-C still becomes SIGINT.
+                                $ oldTerm
+                    setTerminalAttributes stdInput raw Immediately
+                    hSetBuffering stdin NoBuffering
+                restore = do
+                    setTerminalAttributes stdInput oldTerm Immediately
+                    hSetBuffering stdin oldBuf
+            bracket enter (const restore) \() -> do
+                tid <- forkIO (escLoop cancel stopped)
+                action `finally` do
+                    writeIORef stopped True
+                    -- Unblock a stuck hWaitForInput by killing the watcher.
+                    killThread tid
+
+-- | True when @bytes@ is a lone ESC, not the start of a CSI/SS3 sequence.
+isBareEscape :: String -> Bool
+isBareEscape = \case
+    "\ESC" -> True
+    _ -> False
+
+escLoop :: CancelFlag -> IORef Bool -> IO ()
+escLoop cancel stopped = go
+  where
+    go = do
+        done <- readIORef stopped
+        if done
+            then pure ()
+            else do
+                ready <- hWaitForInput stdin 100
+                done' <- readIORef stopped
+                if done'
+                    then pure ()
+                    else if not ready
+                        then go
+                        else do
+                            c <- hGetChar stdin
+                            if c /= '\ESC'
+                                then go
+                                else do
+                                    -- Peek for CSI / SS3 so arrows do not cancel.
+                                    more <- hWaitForInput stdin 50
+                                    if not more
+                                        then requestCancel cancel
+                                        else do
+                                            c2 <- hGetChar stdin
+                                            case c2 of
+                                                '[' -> drainCsi stdin >> go
+                                                'O' -> do
+                                                    _ <- hGetChar stdin
+                                                    go
+                                                _ -> go
+
+drainCsi :: Handle -> IO ()
+drainCsi h = go
+  where
+    go = do
+        ready <- hReady h
+        when ready do
+            c <- hGetChar h
+            if c >= '@' && c <= '~'
+                then pure ()
+                else go

--- a/packages/agent-cli/src/Agent/CLI/CancelWatch.hs
+++ b/packages/agent-cli/src/Agent/CLI/CancelWatch.hs
@@ -1,6 +1,7 @@
 -- | Watch stdin for a bare Esc during an agent turn and soft-cancel.
 module Agent.CLI.CancelWatch
     ( withEscCancel
+    , withStdinPaused
     , isBareEscape
     ) where
 
@@ -22,19 +23,24 @@ import System.IO
     )
 import System.Posix.IO (stdInput)
 import System.Posix.Terminal
-    ( TerminalMode(..)
+    ( TerminalAttributes
+    , TerminalMode(..)
     , TerminalState(..)
     , getTerminalAttributes
     , setTerminalAttributes
     , withMinInput
+    , withMode
     , withTime
     , withoutMode
     )
 
 -- | Run @action@ while Esc on a TTY stdin requests soft cancel.
 -- Restores terminal attributes afterward. Non-TTY is a no-op wrapper.
-withEscCancel :: CancelFlag -> IO a -> IO a
-withEscCancel cancel action = do
+--
+-- @paused@ suspends stdin reads (see 'withStdinPaused') so approval prompts
+-- can use cooked 'getLine' without the watcher stealing keystrokes.
+withEscCancel :: CancelFlag -> IORef Bool -> IO a -> IO a
+withEscCancel cancel paused action = do
     tty <- hIsTerminalDevice stdin
     if not tty
         then action
@@ -43,23 +49,52 @@ withEscCancel cancel action = do
             oldBuf <- hGetBuffering stdin
             stopped <- newIORef False
             let enter = do
-                    let raw =
-                            flip withMinInput 1
-                                . flip withTime 0
-                                . flip withoutMode EnableEcho
-                                -- Keep ProcessInput so Ctrl-C still becomes SIGINT.
-                                $ oldTerm
-                    setTerminalAttributes stdInput raw Immediately
+                    setTerminalAttributes stdInput (rawAttrs oldTerm) Immediately
                     hSetBuffering stdin NoBuffering
                 restore = do
                     setTerminalAttributes stdInput oldTerm Immediately
                     hSetBuffering stdin oldBuf
             bracket enter (const restore) \() -> do
-                tid <- forkIO (escLoop cancel stopped)
+                tid <- forkIO (escLoop cancel paused stopped)
                 action `finally` do
                     writeIORef stopped True
                     -- Unblock a stuck hWaitForInput by killing the watcher.
                     killThread tid
+
+-- | Temporarily stop the Esc watcher and restore cooked stdin for approval.
+withStdinPaused :: IORef Bool -> IO a -> IO a
+withStdinPaused paused action = do
+    tty <- hIsTerminalDevice stdin
+    if not tty
+        then action
+        else do
+            rawTerm <- getTerminalAttributes stdInput
+            rawBuf <- hGetBuffering stdin
+            let cooked =
+                    flip withMode ProcessInput
+                        . flip withMode EnableEcho
+                        . flip withMode EchoLF
+                        $ rawTerm
+                enter = do
+                    writeIORef paused True
+                    setTerminalAttributes stdInput cooked Immediately
+                    hSetBuffering stdin LineBuffering
+                restore = do
+                    setTerminalAttributes stdInput (rawAttrs rawTerm) Immediately
+                    hSetBuffering stdin rawBuf
+                    writeIORef paused False
+            bracket enter (const restore) (\_ -> action)
+
+rawAttrs :: TerminalAttributes -> TerminalAttributes
+rawAttrs oldTerm =
+    flip withMinInput 1
+        . flip withTime 0
+        . flip withoutMode EnableEcho
+        -- Non-canonical so VMIN/VTIME expose a lone Esc.
+        . flip withoutMode ProcessInput
+        -- Keep Ctrl-C as SIGINT / UserInterrupt.
+        . flip withMode KeyboardInterrupts
+        $ oldTerm
 
 -- | True when @bytes@ is a lone ESC, not the start of a CSI/SS3 sequence.
 isBareEscape :: String -> Bool
@@ -67,37 +102,47 @@ isBareEscape = \case
     "\ESC" -> True
     _ -> False
 
-escLoop :: CancelFlag -> IORef Bool -> IO ()
-escLoop cancel stopped = go
+escLoop :: CancelFlag -> IORef Bool -> IORef Bool -> IO ()
+escLoop cancel paused stopped = go
   where
     go = do
         done <- readIORef stopped
         if done
             then pure ()
             else do
-                ready <- hWaitForInput stdin 100
-                done' <- readIORef stopped
-                if done'
-                    then pure ()
-                    else if not ready
-                        then go
-                        else do
-                            c <- hGetChar stdin
-                            if c /= '\ESC'
+                isPaused <- readIORef paused
+                if isPaused
+                    then hWaitForInput stdin 100 >> go
+                    else do
+                        ready <- hWaitForInput stdin 100
+                        done' <- readIORef stopped
+                        if done'
+                            then pure ()
+                            else if not ready
                                 then go
                                 else do
-                                    -- Peek for CSI / SS3 so arrows do not cancel.
-                                    more <- hWaitForInput stdin 50
-                                    if not more
-                                        then requestCancel cancel
+                                    -- Re-check pause: approval may have started
+                                    -- between wait and read.
+                                    isPaused' <- readIORef paused
+                                    if isPaused'
+                                        then go
                                         else do
-                                            c2 <- hGetChar stdin
-                                            case c2 of
-                                                '[' -> drainCsi stdin >> go
-                                                'O' -> do
-                                                    _ <- hGetChar stdin
-                                                    go
-                                                _ -> go
+                                            c <- hGetChar stdin
+                                            if c /= '\ESC'
+                                                then go
+                                                else do
+                                                    -- Peek for CSI / SS3 so arrows do not cancel.
+                                                    more <- hWaitForInput stdin 50
+                                                    if not more
+                                                        then requestCancel cancel
+                                                        else do
+                                                            c2 <- hGetChar stdin
+                                                            case c2 of
+                                                                '[' -> drainCsi stdin >> go
+                                                                'O' -> do
+                                                                    _ <- hGetChar stdin
+                                                                    go
+                                                                _ -> go
 
 drainCsi :: Handle -> IO ()
 drainCsi h = go

--- a/packages/agent-cli/src/Agent/CLI/Render.hs
+++ b/packages/agent-cli/src/Agent/CLI/Render.hs
@@ -17,6 +17,7 @@ import Agent.CLI.Style
     ( agentBackground
     , paintBackgroundLines
     , roleError
+    , roleMuted
     , roleThinking
     , roleToolArrow
     , roleToolDetail
@@ -219,3 +220,5 @@ formatLoopErrorColored color = \case
             <> maybe "" (\text -> "\n" <> text) turn.assistantText
     LoopNoResponseId ->
         roleError color "transport error: response had no id"
+    LoopCancelled ->
+        roleMuted color "cancelled"

--- a/packages/agent-cli/src/Agent/CLI/Render.hs
+++ b/packages/agent-cli/src/Agent/CLI/Render.hs
@@ -220,5 +220,5 @@ formatLoopErrorColored color = \case
             <> maybe "" (\text -> "\n" <> text) turn.assistantText
     LoopNoResponseId ->
         roleError color "transport error: response had no id"
-    LoopCancelled ->
+    LoopCancelled _ ->
         roleMuted color "cancelled"

--- a/packages/agent-cli/test/Agent/CLI/CancelWatchSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CancelWatchSpec.hs
@@ -1,0 +1,14 @@
+module Agent.CLI.CancelWatchSpec (spec) where
+
+import Agent.CLI.CancelWatch (isBareEscape)
+import Test.Hspec
+
+spec :: Spec
+spec = describe "isBareEscape" do
+    it "accepts a lone ESC" do
+        isBareEscape "\ESC" `shouldBe` True
+
+    it "rejects CSI / empty / other" do
+        isBareEscape "\ESC[" `shouldBe` False
+        isBareEscape "" `shouldBe` False
+        isBareEscape "a" `shouldBe` False

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -3,6 +3,7 @@ module Main (main) where
 import Test.Hspec (hspec)
 
 import qualified Agent.CLI.AuthSpec as AuthSpec
+import qualified Agent.CLI.CancelWatchSpec as CancelWatchSpec
 import qualified Agent.CLI.ClipboardSpec as ClipboardSpec
 import qualified Agent.CLI.CommandSpec as CommandSpec
 import qualified Agent.CLI.InputSpec as InputSpec
@@ -19,6 +20,7 @@ import qualified Agent.CLI.WorktreeSpec as WorktreeSpec
 main :: IO ()
 main = hspec do
     AuthSpec.spec
+    CancelWatchSpec.spec
     ClipboardSpec.spec
     CommandSpec.spec
     InputSpec.spec

--- a/packages/agent-core/agent-core.cabal
+++ b/packages/agent-core/agent-core.cabal
@@ -31,7 +31,8 @@ common common-opts
 
 library
     import:           common-opts
-    exposed-modules:  Agent.Error
+    exposed-modules:  Agent.Cancel
+                    , Agent.Error
                     , Agent.Provider
                     , Agent.Broker
                     , Agent.Loop
@@ -72,7 +73,8 @@ test-suite agent-core-test
     type:             exitcode-stdio-1.0
     hs-source-dirs:   test
     main-is:          Spec.hs
-    other-modules:    Agent.ErrorSpec
+    other-modules:    Agent.CancelSpec
+                    , Agent.ErrorSpec
                     , Agent.LoopSpec
                     , Agent.ProjectInstructionsSpec
                     , Agent.ToolArgsSpec

--- a/packages/agent-core/src/Agent/Cancel.hs
+++ b/packages/agent-core/src/Agent/Cancel.hs
@@ -1,0 +1,47 @@
+-- | Soft-cancel signal shared by the agent loop and long-running tools.
+--
+-- Distinct from Ctrl-C / 'UserInterrupt': a cancel asks the current turn to
+-- stop and return to the REPL, without tearing the process down.
+module Agent.Cancel
+    ( CancelFlag
+    , newCancelFlag
+    , requestCancel
+    , isCancelled
+    , waitCancel
+    , resetCancel
+    ) where
+
+import Control.Concurrent.STM
+    ( TMVar
+    , atomically
+    , isEmptyTMVar
+    , newEmptyTMVarIO
+    , readTMVar
+    , tryPutTMVar
+    , tryTakeTMVar
+    )
+
+-- | One-shot cancel latch for a single agent turn.
+newtype CancelFlag = CancelFlag (TMVar ())
+
+newCancelFlag :: IO CancelFlag
+newCancelFlag = CancelFlag <$> newEmptyTMVarIO
+
+-- | Signal cancel. Idempotent: later calls are no-ops once latched.
+requestCancel :: CancelFlag -> IO ()
+requestCancel (CancelFlag var) = atomically do
+    _ <- tryPutTMVar var ()
+    pure ()
+
+isCancelled :: CancelFlag -> IO Bool
+isCancelled (CancelFlag var) = atomically (not <$> isEmptyTMVar var)
+
+-- | Block until cancel is requested.
+waitCancel :: CancelFlag -> IO ()
+waitCancel (CancelFlag var) = atomically (readTMVar var)
+
+-- | Clear a previous cancel so the flag can be reused for another turn.
+resetCancel :: CancelFlag -> IO ()
+resetCancel (CancelFlag var) = atomically do
+    _ <- tryTakeTMVar var
+    pure ()

--- a/packages/agent-core/src/Agent/Loop.hs
+++ b/packages/agent-core/src/Agent/Loop.hs
@@ -18,6 +18,7 @@ module Agent.Loop
     , runLoopInputs
     ) where
 
+import Agent.Cancel (CancelFlag, isCancelled, resetCancel)
 import Agent.Error (ApiError)
 import Agent.ToolDispatch
     ( ToolCall(..)
@@ -78,6 +79,9 @@ data LoopConfig = LoopConfig
     , loopMaxTurns :: !Int
     , loopOnEvent :: !(LoopEvent -> IO ())
     , loopApprove :: !(ToolCall -> IO Bool)
+      -- | Soft-cancel latch. When set, the loop stops after the current tool
+      -- batch instead of asking the model for another step.
+    , loopCancel :: !CancelFlag
     }
 
 data LoopResult = LoopResult
@@ -90,6 +94,7 @@ data LoopError
     = LoopTransport ApiError
     | LoopMaxTurns TurnOutput
     | LoopNoResponseId
+    | LoopCancelled
     deriving (Eq, Show)
 
 defaultLoopMaxTurns :: Int
@@ -126,6 +131,7 @@ runLoopInputs config0 previousResponseId firstInputs = do
     -- Tools run with mapConcurrently. Serialize onEvent so a printer
     -- (hPutStrLn on String is not atomic) cannot interleave characters.
     eventLock <- newMVar ()
+    resetCancel config0.loopCancel
     let config = config0
             { loopOnEvent = \event ->
                 withMVar eventLock \_ -> config0.loopOnEvent event
@@ -136,26 +142,33 @@ runLoopInputs config0 previousResponseId firstInputs = do
                     Just turn -> Left (LoopMaxTurns turn)
                     Nothing -> Left LoopNoResponseId
             | otherwise = do
-                config.loopOnEvent TurnStarted
-                result <- config.loopBackend.submitTurn prev inputs config.loopOnEvent
-                case result of
-                    Left err -> pure (Left (LoopTransport err))
-                    Right turn
-                        | Text.null turn.responseId ->
-                            pure (Left LoopNoResponseId)
-                        | otherwise -> do
-                            config.loopOnEvent (TurnFinished turn)
-                            let nextTurnsUsed = turnsUsed + 1
-                            if null turn.toolCalls
-                                then pure $ Right LoopResult
-                                    { finalResponseId = turn.responseId
-                                    , finalText = turn.assistantText
-                                    , turnsUsed = nextTurnsUsed
-                                    }
-                                else do
-                                    results <- mapConcurrently (runOne config) turn.toolCalls
-                                    go (Just turn.responseId) nextTurnsUsed
-                                        (map CompletedTool results) (Just turn)
+                cancelled <- isCancelled config.loopCancel
+                if cancelled
+                    then pure (Left LoopCancelled)
+                    else do
+                        config.loopOnEvent TurnStarted
+                        result <- config.loopBackend.submitTurn prev inputs config.loopOnEvent
+                        case result of
+                            Left err -> pure (Left (LoopTransport err))
+                            Right turn
+                                | Text.null turn.responseId ->
+                                    pure (Left LoopNoResponseId)
+                                | otherwise -> do
+                                    config.loopOnEvent (TurnFinished turn)
+                                    let nextTurnsUsed = turnsUsed + 1
+                                    if null turn.toolCalls
+                                        then pure $ Right LoopResult
+                                            { finalResponseId = turn.responseId
+                                            , finalText = turn.assistantText
+                                            , turnsUsed = nextTurnsUsed
+                                            }
+                                        else do
+                                            results <- mapConcurrently (runOne config) turn.toolCalls
+                                            cancelledAfter <- isCancelled config.loopCancel
+                                            if cancelledAfter
+                                                then pure (Left LoopCancelled)
+                                                else go (Just turn.responseId) nextTurnsUsed
+                                                    (map CompletedTool results) (Just turn)
     go previousResponseId 0 firstInputs Nothing
 
 runOne :: LoopConfig -> ToolCall -> IO ToolCallResult

--- a/packages/agent-core/src/Agent/Loop.hs
+++ b/packages/agent-core/src/Agent/Loop.hs
@@ -94,7 +94,10 @@ data LoopError
     = LoopTransport ApiError
     | LoopMaxTurns TurnOutput
     | LoopNoResponseId
-    | LoopCancelled
+    -- | Soft-cancel after tools ran. Carries the tool results that must be
+    -- committed to the local transcript so function_call items are not left
+    -- without matching outputs.
+    | LoopCancelled [ToolCallResult]
     deriving (Eq, Show)
 
 defaultLoopMaxTurns :: Int
@@ -144,7 +147,7 @@ runLoopInputs config0 previousResponseId firstInputs = do
             | otherwise = do
                 cancelled <- isCancelled config.loopCancel
                 if cancelled
-                    then pure (Left LoopCancelled)
+                    then pure (Left (LoopCancelled []))
                     else do
                         config.loopOnEvent TurnStarted
                         result <- config.loopBackend.submitTurn prev inputs config.loopOnEvent
@@ -166,7 +169,7 @@ runLoopInputs config0 previousResponseId firstInputs = do
                                             results <- mapConcurrently (runOne config) turn.toolCalls
                                             cancelledAfter <- isCancelled config.loopCancel
                                             if cancelledAfter
-                                                then pure (Left LoopCancelled)
+                                                then pure (Left (LoopCancelled results))
                                                 else go (Just turn.responseId) nextTurnsUsed
                                                     (map CompletedTool results) (Just turn)
     go previousResponseId 0 firstInputs Nothing

--- a/packages/agent-core/src/Agent/Tools/Codex.hs
+++ b/packages/agent-core/src/Agent/Tools/Codex.hs
@@ -115,7 +115,9 @@ runShell env args = do
         Left err -> pure (Left err)
         Right dir -> do
             result <- runShellCommand env dir (Text.unpack args.command) timeoutMs
-            if result.commandTimedOut
+            if result.commandCancelled
+                then pure $ Left "Error: Command cancelled"
+                else if result.commandTimedOut
                 then pure $ Left $
                     "Error: Command timed out after " <> Text.pack (show timeoutMs) <> "ms"
                 else

--- a/packages/agent-core/src/Agent/Tools/Grok.hs
+++ b/packages/agent-core/src/Agent/Tools/Grok.hs
@@ -707,7 +707,9 @@ runTerminal session args
         let timeoutMs = min 300000 (max 1 (fromMaybe 120000 args.timeout))
         result <- runForeground session (Text.unpack args.command) timeoutMs
         let body = stripAnsi (combinedOutput result)
-        if result.commandTimedOut
+        if result.commandCancelled
+            then pure $ Right $ "exit: cancelled\n" <> body
+            else if result.commandTimedOut
             then pure $ Right $ "exit: killed (timeout)\n" <> body
             else
                 let code = fromMaybe 1 result.commandExitCode

--- a/packages/agent-core/src/Agent/Tools/Grok/Shell.hs
+++ b/packages/agent-core/src/Agent/Tools/Grok/Shell.hs
@@ -99,7 +99,7 @@ runForeground session command timeoutMs =
     modifyMVar session.grokShell \shell -> do
         let wrapped = bashWrap (wrapScript shell True command)
         result <- runShellCommand session.grokEnv session.grokEnv.toolCwd wrapped timeoutMs
-        next <- if result.commandTimedOut
+        next <- if result.commandTimedOut || result.commandCancelled
             then pure shell
             else refreshCwd session.grokEnv shell
         pure (next, result)
@@ -219,6 +219,7 @@ quote path = "'" <> concatMap escape path <> "'"
 
 formatExit :: CommandResult -> Text
 formatExit result
+    | result.commandCancelled = "exit: cancelled\n" <> body
     | result.commandTimedOut = "exit: killed (timeout)\n" <> body
     | otherwise = "exit: " <> Text.pack (show (fromMaybe 1 result.commandExitCode)) <> "\n" <> body
   where

--- a/packages/agent-core/src/Agent/Tools/IO.hs
+++ b/packages/agent-core/src/Agent/Tools/IO.hs
@@ -14,8 +14,10 @@ module Agent.Tools.IO
     , truncateText
     ) where
 
+import Agent.Cancel (isCancelled, waitCancel)
 import Agent.Tools.Types (ToolEnv(..))
 import Control.Concurrent (forkIO, threadDelay)
+import Control.Monad (void)
 import Control.Concurrent.Async (async, concurrently, race, wait)
 import Control.Concurrent.MVar (MVar, newEmptyMVar, putMVar)
 import Control.Exception (evaluate)
@@ -160,6 +162,7 @@ data CommandResult = CommandResult
     , commandStdout :: !Text
     , commandStderr :: !Text
     , commandTimedOut :: !Bool
+    , commandCancelled :: !Bool
     } deriving (Eq, Show)
 
 data RunningCommand = RunningCommand
@@ -201,6 +204,7 @@ runShellCommand env workdir command timeoutMs = do
             , commandStdout = ""
             , commandStderr = "Failed to start command: " <> Text.pack (show err)
             , commandTimedOut = False
+            , commandCancelled = False
             }
         Right (Just hin, Just hout, Just herr, processHandle) -> do
             hClose hin
@@ -212,32 +216,67 @@ runShellCommand env workdir command timeoutMs = do
                         (strictGetContents herr)
                     code <- waitForProcess processHandle
                     pure (outBytes, errBytes, code)
-            raced <- race (threadDelay (max 1 timeoutMs * 1000)) collect
-            case raced of
-                Left () -> do
-                    _ <- try @_ @SomeException (interruptProcessGroupOf processHandle)
-                    pure CommandResult
-                        { commandExitCode = Nothing
-                        , commandStdout = ""
-                        , commandStderr = ""
-                        , commandTimedOut = True
-                        }
-                Right (outBytes, errBytes, code) ->
-                    pure CommandResult
-                        { commandExitCode = Just (exitCodeInt code)
-                        , commandStdout = truncateText env.toolStdoutCap
-                            (decodeUtf8With lenientDecode outBytes)
-                        , commandStderr = truncateText env.toolStdoutCap
-                            (decodeUtf8With lenientDecode errBytes)
-                        , commandTimedOut = False
-                        }
+                killGroup = void $ try @_ @SomeException
+                    (interruptProcessGroupOf processHandle)
+                -- Prefer cancel over timeout when both fire: race cancel
+                -- against (timeout `race` collect).
+                waitStop = do
+                    timed <- race (threadDelay (max 1 timeoutMs * 1000)) collect
+                    pure $ case timed of
+                        Left () -> StopTimeout
+                        Right triple -> StopDone triple
+            already <- isCancelled env.toolCancel
+            if already
+                then do
+                    killGroup
+                    pure cancelledResult
+                else do
+                    stopped <- race (waitCancel env.toolCancel) waitStop
+                    case stopped of
+                        Left () -> do
+                            killGroup
+                            pure cancelledResult
+                        Right StopTimeout -> do
+                            killGroup
+                            pure CommandResult
+                                { commandExitCode = Nothing
+                                , commandStdout = ""
+                                , commandStderr = ""
+                                , commandTimedOut = True
+                                , commandCancelled = False
+                                }
+                        Right (StopDone (outBytes, errBytes, code)) ->
+                            pure CommandResult
+                                { commandExitCode = Just (exitCodeInt code)
+                                , commandStdout = truncateText env.toolStdoutCap
+                                    (decodeUtf8With lenientDecode outBytes)
+                                , commandStderr = truncateText env.toolStdoutCap
+                                    (decodeUtf8With lenientDecode errBytes)
+                                , commandTimedOut = False
+                                , commandCancelled = False
+                                }
         Right _ ->
             pure CommandResult
                 { commandExitCode = Just 127
                 , commandStdout = ""
                 , commandStderr = "Failed to capture command output"
                 , commandTimedOut = False
+                , commandCancelled = False
                 }
+
+-- | Outcomes of racing timeout against completion (cancel is the other race arm).
+data ShellStop
+    = StopTimeout
+    | StopDone (BS.ByteString, BS.ByteString, ExitCode)
+
+cancelledResult :: CommandResult
+cancelledResult = CommandResult
+    { commandExitCode = Nothing
+    , commandStdout = ""
+    , commandStderr = ""
+    , commandTimedOut = False
+    , commandCancelled = True
+    }
 
 -- | Start a command without waiting. The result is written to 'runningResult'
 -- when the process exits. Use 'interruptProcessGroupOf' on 'runningHandle' to kill it.
@@ -275,6 +314,7 @@ startShellCommand env workdir command = do
                         , commandStdout = ""
                         , commandStderr = Text.pack (show exception)
                         , commandTimedOut = False
+                        , commandCancelled = False
                         }
                     Right (outBytes, errBytes, code) -> CommandResult
                         { commandExitCode = Just (exitCodeInt code)
@@ -283,6 +323,7 @@ startShellCommand env workdir command = do
                         , commandStderr = truncateText env.toolStdoutCap
                             (decodeUtf8With lenientDecode errBytes)
                         , commandTimedOut = False
+                        , commandCancelled = False
                         }
             pure $ Right RunningCommand
                 { runningHandle = processHandle

--- a/packages/agent-core/src/Agent/Tools/Types.hs
+++ b/packages/agent-core/src/Agent/Tools/Types.hs
@@ -7,6 +7,7 @@ module Agent.Tools.Types
     , toolAllowsWithoutPrompt
     ) where
 
+import Agent.Cancel (CancelFlag, newCancelFlag)
 import Agent.ToolDSL (PropertySchema)
 import Agent.ToolDispatch (ToolCall, ToolHandler)
 import Data.Text (Text)
@@ -32,13 +33,18 @@ data AppTool = AppTool
 data ToolEnv = ToolEnv
     { toolCwd :: !FilePath
     , toolStdoutCap :: !Int
-    } deriving (Eq, Show)
-
-defaultToolEnv :: FilePath -> ToolEnv
-defaultToolEnv cwd = ToolEnv
-    { toolCwd = dropTrailingPathSeparator cwd
-    , toolStdoutCap = 100000
+      -- | Soft-cancel latch for the active turn. Shell tools race against it.
+    , toolCancel :: !CancelFlag
     }
+
+defaultToolEnv :: FilePath -> IO ToolEnv
+defaultToolEnv cwd = do
+    cancel <- newCancelFlag
+    pure ToolEnv
+        { toolCwd = dropTrailingPathSeparator cwd
+        , toolStdoutCap = 100000
+        , toolCancel = cancel
+        }
 
 appToolHandlers :: [AppTool] -> [ToolHandler]
 appToolHandlers = map (.appToolHandler)

--- a/packages/agent-core/test/Agent/CancelSpec.hs
+++ b/packages/agent-core/test/Agent/CancelSpec.hs
@@ -1,0 +1,35 @@
+module Agent.CancelSpec (spec) where
+
+import Agent.Cancel
+import Control.Concurrent (forkIO, threadDelay)
+import Control.Concurrent.MVar (newEmptyMVar, putMVar, takeMVar)
+import Test.Hspec
+
+spec :: Spec
+spec = describe "CancelFlag" do
+    it "starts unset" do
+        flag <- newCancelFlag
+        isCancelled flag `shouldReturn` False
+
+    it "latches requestCancel idempotently" do
+        flag <- newCancelFlag
+        requestCancel flag
+        requestCancel flag
+        isCancelled flag `shouldReturn` True
+
+    it "unblocks waitCancel" do
+        flag <- newCancelFlag
+        done <- newEmptyMVar
+        _ <- forkIO do
+            waitCancel flag
+            putMVar done ()
+        threadDelay 20000
+        requestCancel flag
+        takeMVar done
+        pure ()
+
+    it "resetCancel clears the latch" do
+        flag <- newCancelFlag
+        requestCancel flag
+        resetCancel flag
+        isCancelled flag `shouldReturn` False

--- a/packages/agent-core/test/Agent/LoopSpec.hs
+++ b/packages/agent-core/test/Agent/LoopSpec.hs
@@ -305,7 +305,10 @@ spec = describe "runLoop" do
                 ]
             config = config0 { loopHandlers = handlers }
         result <- runLoop config Nothing "go"
-        result `shouldBe` Left LoopCancelled
+        case result of
+            Left (LoopCancelled results) ->
+                results `shouldNotBe` []
+            other -> expectationFailure ("expected LoopCancelled, got " <> show other)
 
 --------------------------------------------------------------------------------
 -- Helpers

--- a/packages/agent-core/test/Agent/LoopSpec.hs
+++ b/packages/agent-core/test/Agent/LoopSpec.hs
@@ -1,5 +1,6 @@
 module Agent.LoopSpec (spec) where
 
+import Agent.Cancel (newCancelFlag, requestCancel)
 import Agent.Error (ApiError(..))
 import Agent.Loop
 import Agent.ToolArgs (objectArgs, reqText)
@@ -27,7 +28,8 @@ spec = describe "runLoop" do
                 , assistantText = Just "done"
                 }
             ]
-        result <- runLoop (testConfig backend) Nothing "hello"
+        config <- testConfig backend
+        result <- runLoop config Nothing "hello"
         result `shouldBe` Right LoopResult
             { finalResponseId = "resp-2"
             , finalText = Just "done"
@@ -55,7 +57,8 @@ spec = describe "runLoop" do
                     , userImages = [image]
                     }
                 ]
-        result <- runLoopInputs (testConfig backend) Nothing inputs
+        config <- testConfig backend
+        result <- runLoopInputs config Nothing inputs
         result `shouldBe` Right LoopResult
             { finalResponseId = "resp-m"
             , finalText = Just "saw it"
@@ -92,7 +95,8 @@ spec = describe "runLoop" do
                 [ noArgsTool "a" (pure (Right "ok"))
                 , noArgsTool "b" (pure (Right "ok"))
                 ]
-            config = (testConfig backend)
+        config0 <- testConfig backend
+        let config = config0
                 { loopHandlers = handlers
                 , loopOnEvent = onEvent
                 }
@@ -133,7 +137,8 @@ spec = describe "runLoop" do
                 , assistantText = Just "ok"
                 }
             ]
-        result <- runLoop (testConfig backend) { loopHandlers = handlers } Nothing "go"
+        config0 <- testConfig backend
+        result <- runLoop config0 { loopHandlers = handlers } Nothing "go"
         result `shouldBe` Right LoopResult
             { finalResponseId = "resp-2"
             , finalText = Just "ok"
@@ -155,7 +160,8 @@ spec = describe "runLoop" do
                 , assistantText = Just "understood"
                 }
             ]
-        let config = (testConfig backend) { loopApprove = \_ -> pure False }
+        config0 <- testConfig backend
+        let config = config0 { loopApprove = \_ -> pure False }
         result <- runLoop config Nothing "please"
         result `shouldBe` Right LoopResult
             { finalResponseId = "resp-2"
@@ -170,7 +176,8 @@ spec = describe "runLoop" do
 
     it "returns LoopMaxTurns when the model keeps calling tools" do
         backend <- endlessToolsBackend
-        let config = (testConfig backend) { loopMaxTurns = 1 }
+        config0 <- testConfig backend
+        let config = config0 { loopMaxTurns = 1 }
         result <- runLoop config Nothing "loop forever"
         case result of
             Left (LoopMaxTurns turn) -> do
@@ -193,7 +200,8 @@ spec = describe "runLoop" do
                 }
             ]
         let handlers = [noArgsTool "explode" (error "boom")]
-        result <- runLoop (testConfig backend) { loopHandlers = handlers } Nothing "go"
+        config0 <- testConfig backend
+        result <- runLoop config0 { loopHandlers = handlers } Nothing "go"
         result `shouldBe` Right LoopResult
             { finalResponseId = "resp-2"
             , finalText = Just "survived"
@@ -209,7 +217,8 @@ spec = describe "runLoop" do
         submissions <- newIORef []
         backend <- scriptedBackend submissions
             [Left (ConnectionError "down")]
-        result <- runLoop (testConfig backend) Nothing "hello"
+        config <- testConfig backend
+        result <- runLoop config Nothing "hello"
         result `shouldBe` Left (LoopTransport (ConnectionError "down"))
 
     it "emits TurnStarted and TurnFinished around each backend submit" do
@@ -222,7 +231,8 @@ spec = describe "runLoop" do
                 , assistantText = Just "hi"
                 }
             ]
-        let config = (testConfig backend)
+        config0 <- testConfig backend
+        let config = config0
                 { loopOnEvent = \event -> modifyIORef' events (event :)
                 }
         _ <- runLoop config Nothing "hello"
@@ -251,7 +261,8 @@ spec = describe "runLoop" do
                 , assistantText = Just "done"
                 }
             ]
-        let config = (testConfig backend)
+        config0 <- testConfig backend
+        let config = config0
                 { loopOnEvent = \event -> modifyIORef' events (event :)
                 }
         _ <- runLoop config Nothing "hello"
@@ -273,22 +284,48 @@ spec = describe "runLoop" do
                 }
             ]
 
+
+    it "returns LoopCancelled when the cancel flag is set during tools" do
+        submissions <- newIORef []
+        backend <- scriptedBackend submissions
+            [ Right TurnOutput
+                { responseId = "resp-1"
+                , toolCalls = [functionToolCall "c1" "slow" "{}"]
+                , assistantText = Nothing
+                }
+            ]
+        config0 <- testConfig backend
+        let cancel = case config0 of
+                LoopConfig{loopCancel = c} -> c
+            handlers =
+                [ noArgsTool "slow" do
+                    requestCancel cancel
+                    threadDelay 10000
+                    pure (Right "should-not-continue")
+                ]
+            config = config0 { loopHandlers = handlers }
+        result <- runLoop config Nothing "go"
+        result `shouldBe` Left LoopCancelled
+
 --------------------------------------------------------------------------------
 -- Helpers
 --------------------------------------------------------------------------------
 
-testConfig :: Backend -> LoopConfig
-testConfig backend = LoopConfig
-    { loopBackend = backend
-    , loopHandlers =
-        [ typedTool "echo" $ \EchoArgs { message } ->
-            pure (Right ("echo:" <> message))
-        ]
-    , loopDispatch = defaultLoopDispatch
-    , loopMaxTurns = defaultLoopMaxTurns
-    , loopOnEvent = \_ -> pure ()
-    , loopApprove = \_ -> pure True
-    }
+testConfig :: Backend -> IO LoopConfig
+testConfig backend = do
+    cancel <- newCancelFlag
+    pure LoopConfig
+        { loopBackend = backend
+        , loopHandlers =
+            [ typedTool "echo" $ \EchoArgs { message } ->
+                pure (Right ("echo:" <> message))
+            ]
+        , loopDispatch = defaultLoopDispatch
+        , loopMaxTurns = defaultLoopMaxTurns
+        , loopOnEvent = \_ -> pure ()
+        , loopApprove = \_ -> pure True
+        , loopCancel = cancel
+        }
 
 data EchoArgs = EchoArgs { message :: Text }
 

--- a/packages/agent-core/test/Agent/Tools/CodexSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/CodexSpec.hs
@@ -160,4 +160,4 @@ withTempEnv action = do
     bracket
         (mkdtemp (tmp </> "agent-codex-XXXXXX"))
         removeDirectoryRecursive
-        (\dir -> action (defaultToolEnv dir))
+        (\dir -> defaultToolEnv dir >>= action)

--- a/packages/agent-core/test/Agent/Tools/GhciSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/GhciSpec.hs
@@ -86,7 +86,7 @@ spec = describe "Agent.Tools.Ghci" do
 
 withTempEnv :: (ToolEnv -> IO a) -> IO a
 withTempEnv action =
-    bracket acquire release \dir -> action (defaultToolEnv dir)
+    bracket acquire release \dir -> defaultToolEnv dir >>= action
   where
     acquire = do
         tmp <- getTemporaryDirectory
@@ -100,7 +100,8 @@ withTempGhci action =
     acquire = do
         tmp <- getTemporaryDirectory
         dir <- mkdtemp (tmp </> "agent-ghci-")
-        ghci <- newGhciSession (defaultToolEnv dir)
+        env <- defaultToolEnv dir
+        ghci <- newGhciSession env
         pure (dir, ghci)
     release (dir, ghci) = do
         closeGhciSession ghci
@@ -113,7 +114,7 @@ withTempTools action =
     acquire = do
         tmp <- getTemporaryDirectory
         dir <- mkdtemp (tmp </> "agent-ghci-tools-")
-        let env = defaultToolEnv dir
+        env <- defaultToolEnv dir
         session <- newGrokSession env
         ghci <- newGhciSession env
         pure (dir, (session, ghci), grokTools session ghci)

--- a/packages/agent-core/test/Agent/Tools/GrokSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/GrokSpec.hs
@@ -282,7 +282,7 @@ withTempSession action = do
         (mkdtemp (tmp </> "agent-grok-XXXXXX"))
         (\dir -> removeDirectoryRecursive dir)
         \dir -> do
-            let env = defaultToolEnv dir
+            env <- defaultToolEnv dir
             session <- newGrokSession env
             ghci <- newGhciSession env
             action (session, ghci) `finally` (closeGrokSession session >> closeGhciSession ghci)

--- a/packages/agent-core/test/Agent/Tools/IOSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/IOSpec.hs
@@ -1,6 +1,13 @@
 module Agent.Tools.IOSpec (spec) where
 
-import Agent.Tools.IO (readTextFile, writeTextFile)
+import Agent.Cancel (requestCancel)
+import Agent.Tools.IO
+    ( CommandResult(..)
+    , readTextFile
+    , runShellCommand
+    , writeTextFile
+    )
+import Agent.Tools.Types (ToolEnv(..), defaultToolEnv)
 import Control.Concurrent (forkIO, newEmptyMVar, putMVar, takeMVar, threadDelay)
 import Control.Exception.Safe (bracket)
 import Control.Monad (replicateM)
@@ -55,6 +62,19 @@ spec = describe "Agent.Tools.IO" do
             mapM_ (\var -> forkIO $ readTextFile path >>= putMVar var) vars
             results <- mapM takeMVar vars
             results `shouldBe` replicate 32 (Right body)
+
+    it "cancels a long-running shell command via toolCancel" do
+        withTempDir \dir -> do
+            env@ToolEnv{toolCancel} <- defaultToolEnv dir
+            done <- newEmptyMVar
+            _ <- forkIO do
+                result <- runShellCommand env dir "sleep 30" 60000
+                putMVar done result
+            threadDelay 100000
+            requestCancel toolCancel
+            CommandResult{commandCancelled, commandTimedOut} <- takeMVar done
+            commandCancelled `shouldBe` True
+            commandTimedOut `shouldBe` False
 
 withTempDir :: (FilePath -> IO a) -> IO a
 withTempDir action = do

--- a/packages/agent-core/test/Spec.hs
+++ b/packages/agent-core/test/Spec.hs
@@ -1,5 +1,6 @@
 module Main (main) where
 
+import qualified Agent.CancelSpec as CancelSpec
 import qualified Agent.ErrorSpec as ErrorSpec
 import qualified Agent.LoopSpec as LoopSpec
 import qualified Agent.ProjectInstructionsSpec as ProjectInstructionsSpec
@@ -15,6 +16,7 @@ import Test.Hspec (hspec)
 
 main :: IO ()
 main = hspec do
+    CancelSpec.spec
     ErrorSpec.spec
     LoopSpec.spec
     ProjectInstructionsSpec.spec

--- a/packages/agent-openai/src/Agent/OpenAI/LoopBackend.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/LoopBackend.hs
@@ -9,6 +9,7 @@ module Agent.OpenAI.LoopBackend
     , responseToTurnOutput
     , streamEventToLoopEvent
     , assistantTextFromResponse
+    , toolResultToItem
     , withRequestInput
     ) where
 


### PR DESCRIPTION
## Summary
- Add `Agent.Cancel` latch shared by the loop and tools.
- Race foreground shell commands against cancel (in addition to timeout) and abort the turn with `LoopCancelled`.
- Watch TTY stdin during a turn for a bare Esc (not CSI/arrow sequences) and soft-cancel; print muted `cancelled` and return to the prompt.
- Ctrl-C remains the hard interrupt / resume-hint path.

## Test plan
- [x] `cabal test agent-core:agent-core-test`
- [x] `cabal test agent-cli:agent-cli-test`
- [ ] Start a turn that runs `sleep 30` via a shell tool; press Esc; expect `cancelled` and a fresh `λ>`
- [ ] Press an arrow key during a tool run; should not cancel
- [ ] Ctrl-C still prints the resume hint when a session exists