### PR TITLE
feat: default nix develop repl to --worktree on first open

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,8 +21,10 @@ we follow the tool defintions that are used by the first party lab harnesses. e.
 
 use ghci instead of compiling the code. E.g. instead of nix flake check start a ghci and load in the necessary modules. This is way faster than doing a full compile.
 
-From `nix develop`, run `repl` to open the agent under GHCi. Agent `:reload`
-returns to GHCi, reloads modules, and resumes the previous session.
+From `nix develop`, run `repl` to open the agent under GHCi. On first open it
+passes `--worktree` when the cwd is not already under
+`~/.haskell-agent/worktrees`. Agent `:reload` returns to GHCi, reloads
+modules, and resumes the previous session.
 
 ## development feedback loop
 
@@ -74,7 +76,7 @@ Same `withArgs ... run` / `:q` / `:r` loop. Dependency packages are linked as bu
 ### pitfalls
 
 - Exit the agent (`:q` or Ctrl-D) before `:r`; a live stdin/WebSocket session blocks GHCi.
-- `--worktree` creates a new worktree each start. To keep iterating in the same tree, use `--resume <id>` or `--cwd <existing-worktree>`.
+- `repl` / `devMain` creates a new worktree on first open when not already under `~/.haskell-agent/worktrees`. `:reload` resumes the same session (and cwd). Manual `run` still needs `withArgs ["--worktree"]` (or `--resume` / `--cwd`) if you want a worktree.
 - `run` calls `setCurrentDirectory`, so later runs in the same GHCi process inherit that cwd.
 - `cabal repl agent-cli:exe:agent-cli` + `:main` looks convenient but only interprets `Main.hs` and does **not** reload library source changes.
 - Use `ghcid` for typecheck-on-save; keep `cabal repl` + `withArgs ... run` for running the live agent.

--- a/README.md
+++ b/README.md
@@ -43,9 +43,11 @@ cabal run agent-cli -- -p "list the files here"
 ```
 
 From `nix develop`, `repl` opens `cabal repl lib:agent-cli` (via expect) and
-starts the agent with a GHCi `:cmd` loop. Inside the agent REPL, `:reload`
-writes `~/.haskell-agent/dev-resume`, returns to GHCi, reloads modules, and
-resumes the same session automatically. `:q` exits the agent back to `ghci>`.
+starts the agent with a GHCi `:cmd` loop. On first open it passes `--worktree`
+when the cwd is not already under `~/.haskell-agent/worktrees`. Inside the
+agent REPL, `:reload` writes `~/.haskell-agent/dev-resume`, returns to GHCi,
+reloads modules, and resumes the same session automatically. `:q` exits the
+agent back to `ghci>`.
 
 Without `-p` / `--prompt-file` the CLI starts a REPL. Credentials come from
 `~/.grok/auth.json` / `GROK_ACCESS_TOKEN` (xAI), `~/.codex/auth.json` /

--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -41,7 +41,7 @@ import Agent.CLI.Style
     , userBackground
     )
 import Agent.CLI.Tools (lookupAppTool, schemasFromAppTools)
-import Agent.CLI.Worktree (createWorktree, worktreeRoot)
+import Agent.CLI.Worktree (createWorktree, isUnderWorktreeRoot, worktreeRoot)
 import Agent.Loop
 import Agent.ProjectInstructions
     ( DiscoverOptions(..)
@@ -107,11 +107,18 @@ afterDev = \case
         ]
 
 -- | Start the agent from GHCi (@repl@). Resumes the session written by @:reload@.
+-- On first open (no resume pointer), passes @--worktree@ unless the cwd is
+-- already under @~/.haskell-agent/worktrees@.
 devMain :: IO DevResult
 devMain = do
     home <- getHomeDirectory
     resumeId <- readDevResumePointer home
-    let args = maybe [] (\sessionId -> ["--resume", Text.unpack sessionId]) resumeId
+    args <- case resumeId of
+        Just sessionId -> pure ["--resume", Text.unpack sessionId]
+        Nothing -> do
+            cwd <- makeAbsolute =<< getCurrentDirectory
+            root <- makeAbsolute (worktreeRoot home)
+            pure $ if isUnderWorktreeRoot root cwd then [] else ["--worktree"]
     case parseArgs args of
         Left err -> do
             clearDevResumePointer home

--- a/packages/agent-cli/src/Agent/CLI/Options.hs
+++ b/packages/agent-cli/src/Agent/CLI/Options.hs
@@ -238,7 +238,8 @@ usage = unlines
     , "auth failures also reload once and retry automatically."
     , "Ctrl-D or :q exits."
     , "Ctrl-C prints a --resume command when a session has been persisted."
-    , "Under `repl` (nix develop), :reload returns to GHCi, reloads modules,"
-    , "and resumes the same session."
+    , "Under `repl` (nix develop), first open passes --worktree unless the"
+    , "cwd is already under ~/.haskell-agent/worktrees. :reload returns to"
+    , "GHCi, reloads modules, and resumes the same session."
 
     ]

--- a/packages/agent-cli/src/Agent/CLI/Worktree.hs
+++ b/packages/agent-cli/src/Agent/CLI/Worktree.hs
@@ -1,12 +1,13 @@
 -- | Create isolated git worktrees under @~/.haskell-agent/worktrees@.
 module Agent.CLI.Worktree
     ( createWorktree
+    , isUnderWorktreeRoot
     , worktreePath
     , worktreeRoot
     ) where
 
 import Data.Char (isSpace)
-import Data.List (dropWhileEnd, isInfixOf)
+import Data.List (dropWhileEnd, isInfixOf, isPrefixOf)
 import Data.Time.Calendar (Day)
 import Data.Time.Clock (UTCTime(..), getCurrentTime, nominalDiffTimeToSeconds)
 import Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds)
@@ -14,12 +15,24 @@ import Data.Time.Format (defaultTimeLocale, formatTime)
 import Numeric (showHex)
 import System.Directory (createDirectoryIfMissing, doesPathExist)
 import System.Exit (ExitCode(..))
-import System.FilePath (takeFileName, (</>))
+import System.FilePath
+    ( addTrailingPathSeparator
+    , equalFilePath
+    , takeFileName
+    , (</>)
+    )
 import System.Process (CreateProcess(..), proc, readCreateProcessWithExitCode)
 
 -- | @~/.haskell-agent/worktrees@ given the user's home directory.
 worktreeRoot :: FilePath -> FilePath
 worktreeRoot home = home </> ".haskell-agent" </> "worktrees"
+
+-- | True when @path@ is @root@ or a subdirectory of it.
+-- Both paths should already be absolute (or otherwise comparable).
+isUnderWorktreeRoot :: FilePath -> FilePath -> Bool
+isUnderWorktreeRoot root path =
+    equalFilePath root path
+        || addTrailingPathSeparator root `isPrefixOf` path
 
 -- | @root/repo/YYYY-MM-DD-\<hex8\>@.
 worktreePath :: FilePath -> FilePath -> Day -> String -> FilePath

--- a/packages/agent-cli/test/Agent/CLI/WorktreeSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/WorktreeSpec.hs
@@ -27,6 +27,15 @@ spec = describe "Agent.CLI.Worktree" do
             worktreeRoot "/home/marc"
                 `shouldBe` "/home/marc" </> ".haskell-agent" </> "worktrees"
 
+    describe "isUnderWorktreeRoot" do
+        it "matches the root and its subdirectories" do
+            let root = "/home/marc" </> ".haskell-agent" </> "worktrees"
+            isUnderWorktreeRoot root root `shouldBe` True
+            isUnderWorktreeRoot root (root </> "haskell-agent" </> "2026-08-20-abcd")
+                `shouldBe` True
+            isUnderWorktreeRoot root "/home/marc/src/haskell-agent" `shouldBe` False
+            isUnderWorktreeRoot root (root <> "-extra") `shouldBe` False
+
     describe "createWorktree" do
         it "adds a worktree under the injected root on a new branch" $
             withTempGitRepo \repo ->


### PR DESCRIPTION
## Summary
- `devMain` (used by the nix `repl` shortcut) passes `--worktree` on first open when the cwd is not already under `~/.haskell-agent/worktrees`.
- Resume via `:reload` / the dev-resume pointer still uses `--resume` and keeps the same session cwd.
- Adds `isUnderWorktreeRoot` plus a unit test; docs and `--help` updated.

## Test plan
- [x] `cabal test agent-cli --test-options='-m "isUnderWorktreeRoot"'`
- [ ] From the main repo checkout (not under `~/.haskell-agent/worktrees`), run `nix develop` then `repl` and confirm a new worktree is created
- [ ] From an existing agent worktree, run `repl` with no resume pointer and confirm it does not nest another worktree
- [ ] `:reload` resumes the same session/cwd without creating a new worktree