### PR TITLE
fix: share project auto-approve across git worktrees

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Project.hs
+++ b/packages/agent-cli/src/Agent/CLI/Project.hs
@@ -13,8 +13,8 @@ import Data.Aeson (FromJSON(..), ToJSON(..), object, withObject, (.:?), (.=))
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy as LBS
 import Data.Char (isSpace)
-import Data.List (dropWhileEnd)
-import Data.Maybe (fromMaybe)
+import Data.List (dropWhileEnd, stripPrefix)
+import Data.Maybe (fromMaybe, listToMaybe, mapMaybe)
 import System.Directory
     ( canonicalizePath
     , createDirectoryIfMissing
@@ -61,13 +61,19 @@ instance FromJSON ProjectSettings where
             , settingsAutoApprove = autoApprove
             }
 
--- | Git toplevel when @cwd@ is inside a repo; otherwise @cwd@ itself.
--- Paths are canonicalized so macOS @/var@ vs @/private/var@ does not diverge.
+-- | Shared settings root for the repo that contains @cwd@.
+-- Uses the primary git worktree when available so linked worktrees created with
+-- @--worktree@ share @.haskell-agent/settings.json@ with the main checkout.
+-- Falls back to the cwd toplevel, then @cwd@ itself. Paths are canonicalized
+-- so macOS @/var@ vs @/private/var@ does not diverge.
 resolveProjectRoot :: FilePath -> IO FilePath
 resolveProjectRoot cwd = do
-    root <- gitToplevel cwd >>= \case
-        Just toplevel -> pure toplevel
-        Nothing -> pure cwd
+    root <- gitPrimaryWorktree cwd >>= \case
+        Just primary -> pure primary
+        Nothing ->
+            gitToplevel cwd >>= \case
+                Just toplevel -> pure toplevel
+                Nothing -> pure cwd
     canonicalizePath root
 
 -- | Missing or unreadable settings files yield the defaults.
@@ -112,6 +118,24 @@ gitToplevel dir = do
             let trimmed = trim out
             in if null trimmed then Nothing else Just trimmed
         Right _ -> Nothing
+
+-- | First worktree from @git worktree list --porcelain@ is the primary checkout.
+gitPrimaryWorktree :: FilePath -> IO (Maybe FilePath)
+gitPrimaryWorktree dir = do
+    result <- try @IOError $
+        readCreateProcessWithExitCode
+            (proc "git" ["worktree", "list", "--porcelain"]) { cwd = Just dir }
+            ""
+    pure $ case result of
+        Left _ -> Nothing
+        Right (ExitSuccess, out, _) ->
+            listToMaybe (mapMaybe parseWorktreeLine (lines out))
+        Right _ -> Nothing
+
+parseWorktreeLine :: String -> Maybe FilePath
+parseWorktreeLine line = case stripPrefix "worktree " line of
+    Just path | not (null (trim path)) -> Just (trim path)
+    _ -> Nothing
 
 renameOrReplace :: FilePath -> FilePath -> IO ()
 renameOrReplace tmp path = do

--- a/packages/agent-cli/test/Agent/CLI/ProjectSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ProjectSpec.hs
@@ -65,6 +65,23 @@ spec = describe "Agent.CLI.Project" do
                 createDirectoryIfMissing True nested
                 resolveProjectRoot nested `shouldReturn` expected
 
+        it "uses the primary worktree for linked worktrees" $
+            withTempDir "agent-wt-" \root -> do
+                let mainRepo = root </> "main"
+                    linked = root </> "linked"
+                createDirectoryIfMissing True mainRepo
+                git_ mainRepo ["init"]
+                git_ mainRepo ["config", "user.email", "test@example.com"]
+                git_ mainRepo ["config", "user.name", "Test"]
+                git_ mainRepo ["config", "commit.gpgsign", "false"]
+                git_ mainRepo ["commit", "--allow-empty", "-m", "init"]
+                git_ mainRepo ["worktree", "add", "--detach", linked]
+                expected <- canonicalizePath mainRepo
+                resolveProjectRoot linked `shouldReturn` expected
+                saveProjectAutoApprove expected True
+                settings <- loadProjectSettings =<< resolveProjectRoot linked
+                settings.settingsAutoApprove `shouldBe` True
+
         it "falls back to cwd outside a git repo" $
             withTempDir "agent-nogit-" \root -> do
                 expected <- canonicalizePath root


### PR DESCRIPTION
## Summary
- `--worktree` creates a linked checkout whose own toplevel never saw the main repo's `.haskell-agent/settings.json`, so project auto-approve kept prompting.
- `resolveProjectRoot` now prefers the primary worktree from `git worktree list --porcelain`, falling back to the cwd toplevel / cwd.
- Adds a unit test that linked worktrees load auto-approve saved on the main checkout.

## Test plan
- [x] `cabal test agent-cli --test-options='--match "Agent.CLI.Project"'`
- [ ] Start with `--worktree` from a repo that already has `autoApprove: true` and confirm mutating tools are not prompted
- [ ] Toggle `/always-approve` in a linked worktree and confirm it updates the main checkout settings file