### PR TITLE
feat: submit tool approval with a single keypress

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Input.hs
+++ b/packages/agent-cli/src/Agent/CLI/Input.hs
@@ -4,11 +4,12 @@
 module Agent.CLI.Input
     ( readReplLine
     , readApprovalLine
+    , approvalKeyText
     , replHistoryPath
     ) where
 
 import Control.Exception (AsyncException(UserInterrupt))
-import Control.Exception.Safe (catchIO, throwIO)
+import Control.Exception.Safe (bracket, catchIO, throwIO, tryIO)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
@@ -25,8 +26,30 @@ import System.Directory
     , getHomeDirectory
     )
 import System.FilePath (takeDirectory, (</>))
-import System.IO (hFlush, hIsTerminalDevice, isEOF, stderr, stdin, stdout)
+import System.IO
+    ( BufferMode(..)
+    , hFlush
+    , hGetBuffering
+    , hGetChar
+    , hIsTerminalDevice
+    , hSetBuffering
+    , isEOF
+    , stderr
+    , stdin
+    , stdout
+    )
+import System.IO.Error (isEOFError)
 import System.Posix.Files (setFileMode)
+import System.Posix.IO (stdInput)
+import System.Posix.Terminal
+    ( TerminalMode(..)
+    , TerminalState(..)
+    , getTerminalAttributes
+    , setTerminalAttributes
+    , withMinInput
+    , withTime
+    , withoutMode
+    )
 import System.Posix.Types (FileMode)
 
 -- | @~/.haskell-agent/history@ given the user's home directory.
@@ -56,14 +79,55 @@ readReplLine prompt = do
 
 -- | Read a one-shot approval answer. The question is always written to
 -- stderr (matching the pre-haskeline behavior) so redirected stdout does
--- not swallow the prompt. Uses cooked 'getLine' so answer echo stays on
--- the controlling TTY rather than haskeline's stdout handle. Does not
--- touch REPL history.
+-- not swallow the prompt. Does not touch REPL history.
+--
+-- On a TTY, a single keypress submits immediately (@y@ / @n@ / @a@, or
+-- Enter for the default deny) so the user does not need a trailing Enter.
+-- Non-TTY keeps cooked 'getLine' for scripts that pipe a full line.
 readApprovalLine :: Text -> IO (Maybe Text)
 readApprovalLine prompt = do
     Text.hPutStr stderr prompt
     hFlush stderr
-    readAnswerOnly
+    isTty <- hIsTerminalDevice stdin
+    if isTty
+        then readApprovalKey
+        else readAnswerOnly
+
+-- | Map one approval keypress to the text 'parseApprovalAnswer' expects.
+-- Enter / Return become empty (deny by default).
+approvalKeyText :: Char -> Text
+approvalKeyText c
+    | c == '\n' || c == '\r' = ""
+    | otherwise = Text.singleton c
+
+-- | Single-key approval on a TTY: disable canonical input, read one byte,
+-- echo it (except bare Enter), then restore the previous terminal state.
+readApprovalKey :: IO (Maybe Text)
+readApprovalKey = do
+    oldTerm <- getTerminalAttributes stdInput
+    oldBuf <- hGetBuffering stdin
+    let enter = do
+            -- Keep ProcessInput so Ctrl-C still becomes SIGINT while waiting.
+            let raw =
+                    flip withMinInput 1
+                        . flip withTime 0
+                        . flip withoutMode EnableEcho
+                        $ oldTerm
+            setTerminalAttributes stdInput raw Immediately
+            hSetBuffering stdin NoBuffering
+        restore = do
+            setTerminalAttributes stdInput oldTerm Immediately
+            hSetBuffering stdin oldBuf
+    bracket enter (const restore) \() -> do
+        result <- tryIO (hGetChar stdin)
+        case result of
+            Left err
+                | isEOFError err -> pure Nothing
+                | otherwise -> throwIO err
+            Right c -> do
+                let answer = approvalKeyText c
+                Text.hPutStrLn stderr answer
+                pure (Just answer)
 
 readEditedLine :: Settings IO -> Text -> IO (Maybe Text)
 readEditedLine settings prompt =

--- a/packages/agent-cli/test/Agent/CLI/InputSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/InputSpec.hs
@@ -1,6 +1,6 @@
 module Agent.CLI.InputSpec (spec) where
 
-import Agent.CLI.Input (replHistoryPath)
+import Agent.CLI.Input (approvalKeyText, replHistoryPath)
 import System.FilePath ((</>))
 import Test.Hspec
 
@@ -10,3 +10,13 @@ spec = do
         it "is ~/.haskell-agent/history" do
             replHistoryPath "/home/marc"
                 `shouldBe` "/home/marc" </> ".haskell-agent" </> "history"
+
+    describe "approvalKeyText" do
+        it "keeps a printable key as a one-character answer" do
+            approvalKeyText 'y' `shouldBe` "y"
+            approvalKeyText 'A' `shouldBe` "A"
+            approvalKeyText 'n' `shouldBe` "n"
+
+        it "maps Enter / Return to the empty default deny" do
+            approvalKeyText '\n' `shouldBe` ""
+            approvalKeyText '\r' `shouldBe` ""


### PR DESCRIPTION
## Summary
- On a TTY, mutating-tool `[y/N/a]` prompts submit as soon as `y`, `n`, or `a` is pressed (no Enter).
- Bare Enter still denies (same default as before).
- Non-TTY / piped stdin keeps cooked line input so scripts are unchanged.

## Test plan
- [x] `cabal repl agent-cli:lib:agent-cli` loads `Agent.CLI.Input`
- [ ] Trigger a mutating-tool approval prompt; press `a` alone and confirm it enables auto-approve without Enter
- [ ] Press `y` alone → allow once; `n` or Enter alone → deny
- [ ] Pipe an answer (`printf 'a\n' | agent-cli …`) and confirm line-based approval still works