### PR TITLE
fix: quit cleanly on Ctrl-C instead of dumping UserInterrupt

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -333,18 +333,19 @@ isLeftSlot = \case
     Left _ -> True
     Right _ -> False
 
--- | On Ctrl-C, print a copy-pasteable --resume line when a session exists.
+-- | On Ctrl-C, print a copy-pasteable --resume line when a session exists,
+-- then quit without dumping a 'UserInterrupt' exception trace.
 withInterruptResume
     :: String
     -> Maybe (IORef (Either SessionCreate SessionHandle))
-    -> IO a
-    -> IO a
+    -> IO DevResult
+    -> IO DevResult
 withInterruptResume progName persist action =
     action `catchAsync` \(e :: AsyncException) ->
         case e of
             UserInterrupt -> do
                 printResumeHint progName persist
-                throwIO e
+                pure DevQuit
             _ -> throwIO e
 
 printResumeHint


### PR DESCRIPTION
## Summary
- Ctrl-C still prints the copy-pasteable `--resume` hint when a session exists.
- Instead of rethrowing `UserInterrupt` (which dumped a Haskell exception trace), return `DevQuit` so the agent exits cleanly.
- Tool cleanup via `finally closeTools` still runs.

## Test plan
- [ ] Start an interactive REPL session, complete one turn so a session is persisted, then Ctrl-C and confirm the resume hint prints with no exception stack.
- [ ] Ctrl-C before any turn is persisted and confirm a clean exit with no resume hint and no exception stack.
- [ ] From `repl`, Ctrl-C and confirm GHCi returns without a `UserInterrupt` dump.