### PR TITLE
feat: denser Unicode chrome for REPL status lines

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -33,6 +33,9 @@ import Agent.CLI.Style
     ( beginBackground
     , cliWindowTitle
     , endBackground
+    , glyphOk
+    , glyphSession
+    , glyphWarn
     , roleError
     , roleMuted
     , rolePrompt
@@ -211,7 +214,7 @@ runAgent options = do
             | options.optWorktree -> do
                 createWorktree source (worktreeRoot home) >>= either die \path -> do
                     color <- resolveColor stderr
-                    putTextLn stderr (roleMuted color ("worktree: " <> Text.pack path))
+                    putTextLn stderr (roleMuted color (glyphSession <> "worktree: " <> Text.pack path))
                     pure path
             | otherwise -> pure source
     setCurrentDirectory cwd
@@ -312,7 +315,7 @@ preparePersistence options root provider model cwd effort prompt resumed =
             color <- resolveColor stderr
             putTextLn stderr
                 (roleMuted color
-                    ("session: " <> meta.metaId <> " (resumed)"))
+                    (glyphSession <> "session: " <> meta.metaId <> " (resumed)"))
             Just <$> newIORef (Right handle)
         Nothing
             | shouldPersist options ->
@@ -495,7 +498,7 @@ repl config render provider previous printed paramsRef policyRef transcriptRef p
                                 color <- resolveColor stdout
                                 Text.putStrLn
                                     (roleMuted color
-                                        ("pasted " <> image.imageMime <> " (" <> size <> ")"))
+                                        (glyphOk <> "pasted " <> image.imageMime <> " (" <> size <> ")"))
                                 writeIORef printed False
                                 _ <- runOneTurn config render previous printed
                                     transcriptRef persist agentsContext escPaused promptText
@@ -509,12 +512,12 @@ repl config render provider previous printed paramsRef policyRef transcriptRef p
                     ReplShowEffort -> do
                         color <- resolveColor stdout
                         params <- readIORef paramsRef
-                        Text.putStrLn (roleMuted color ("effort: " <> currentEffort params))
+                        Text.putStrLn (roleMuted color (glyphSession <> "effort: " <> currentEffort params))
                         continue
                     ReplSetEffort level -> do
                         color <- resolveColor stdout
                         modifyIORef' paramsRef (setReasoningEffort level)
-                        Text.putStrLn (roleMuted color ("effort set to " <> level))
+                        Text.putStrLn (roleMuted color (glyphOk <> "effort set to " <> level))
                         case persist of
                             Nothing -> pure ()
                             Just slotRef -> do
@@ -531,7 +534,7 @@ repl config render provider previous printed paramsRef policyRef transcriptRef p
                         continue
                     ReplShowModel -> do
                         params <- readIORef paramsRef
-                        Text.putStrLn ("model: " <> currentModel params)
+                        Text.putStrLn (glyphSession <> "model: " <> currentModel params)
                         continue
                     ReplSetModel name -> do
                         modifyIORef' paramsRef (setModel name)
@@ -542,9 +545,9 @@ repl config render provider previous printed paramsRef policyRef transcriptRef p
                             _ -> pure False
                         if clearedChain
                             then Text.putStrLn
-                                ("model set to " <> name
+                                (glyphOk <> "model set to " <> name
                                     <> " (conversation continued locally)")
-                            else Text.putStrLn ("model set to " <> name)
+                            else Text.putStrLn (glyphOk <> "model set to " <> name)
                         case persist of
                             Nothing -> pure ()
                             Just slotRef -> do
@@ -566,18 +569,18 @@ repl config render provider previous printed paramsRef policyRef transcriptRef p
                         color <- resolveColor stdout
                         case persist of
                             Nothing ->
-                                Text.putStrLn (roleMuted color "session: (not persisted)")
+                                Text.putStrLn (roleMuted color (glyphSession <> "session: (not persisted)"))
                             Just slotRef -> do
                                 slot <- readIORef slotRef
                                 case slot of
                                     Left _ ->
                                         Text.putStrLn
                                             (roleMuted color
-                                                "session: (pending until first turn)")
+                                                (glyphSession <> "session: (pending until first turn)"))
                                     Right handle ->
                                         Text.putStrLn
                                             (roleMuted color
-                                                ("session: " <> handle.sessionMeta.metaId))
+                                                (glyphSession <> "session: " <> handle.sessionMeta.metaId))
                         continue
                     ReplReloadAuth -> do
                         reloadAuth provider tokenProvider
@@ -618,7 +621,7 @@ reloadAuth provider = \case
             Right credential -> do
                 color <- resolveColor stdout
                 Text.putStrLn $ roleSuccess color $
-                    "auth reloaded ("
+                    glyphOk <> "auth reloaded ("
                         <> providerSlug provider
                         <> " account "
                         <> credential.accountId
@@ -641,7 +644,7 @@ requestReload persist = do
             writeDevResumePointer home handle.sessionMeta.metaId
             putTextLn stderr
                 (roleMuted color
-                    ("reloading; session " <> handle.sessionMeta.metaId))
+                    (glyphSession <> "reloading; session " <> handle.sessionMeta.metaId))
             pure DevReload
 
 runOneTurn
@@ -702,7 +705,7 @@ runOneTurn config render previous printed transcriptRef persist agentsContext es
                             color <- resolveColor stderr
                             putTextLn stderr
                                 (roleMuted color
-                                    ("session: " <> handle.sessionMeta.metaId))
+                                    (glyphSession <> "session: " <> handle.sessionMeta.metaId))
                         else pure ()
                     let turn = SessionTurn
                             { turnAt = now
@@ -748,7 +751,7 @@ loadAgentsContext options provider home cwd initialItems initialPrevious
                 color <- resolveColor stderr
                 putTextLn stderr
                     (roleMuted color
-                        ("agents.md: loaded "
+                        (glyphSession <> "agents.md: loaded "
                             <> Text.pack (show (length files))
                             <> if length files == 1 then " file" else " files"))
                 newIORef (Just text)
@@ -785,7 +788,7 @@ approveTool policyRef tools call projectRoot = do
             | otherwise -> do
                 color <- resolveColor stderr
                 let question =
-                        roleWarn color ("Allow " <> summarizeToolCall call <> "? [y/N/a] ")
+                        roleWarn color (glyphWarn <> "Allow " <> summarizeToolCall call <> "? [y/N/a] ")
                 readApprovalLine question >>= \case
                     Nothing -> pure False
                     Just raw -> case parseApprovalAnswer raw of
@@ -794,7 +797,7 @@ approveTool policyRef tools call projectRoot = do
                             writeIORef policyRef ApproveAll
                             saveProjectAutoApprove projectRoot True
                             putTextLn stderr
-                                (roleSuccess color "auto-approve on (saved for project)")
+                                (roleSuccess color (glyphOk <> "auto-approve on (saved for project)"))
                             pure True
                         Deny -> pure False
 
@@ -807,8 +810,8 @@ toggleAlwaysApprove policyRef projectRoot = do
             else (ApproveAll, ApproveAll)
     saveProjectAutoApprove projectRoot (next == ApproveAll)
     putTextLn stderr (case next of
-        ApproveAll -> roleSuccess color "auto-approve on (saved for project)"
-        _ -> roleMuted color "auto-approve off (saved for project)")
+        ApproveAll -> roleSuccess color (glyphOk <> "auto-approve on (saved for project)")
+        _ -> roleMuted color (glyphSession <> "auto-approve off (saved for project)"))
 
 -- | Rebuild from the constructor: 'input' is also a field on 'CustomToolCall'.
 -- OpenAI keeps @store = true@ so @previous_response_id@ can continue a chain;

--- a/packages/agent-cli/src/Agent/CLI/Render.hs
+++ b/packages/agent-cli/src/Agent/CLI/Render.hs
@@ -15,6 +15,11 @@ module Agent.CLI.Render
 import Agent.CLI.Markdown (renderMarkdown)
 import Agent.CLI.Style
     ( agentBackground
+    , glyphCancel
+    , glyphErr
+    , glyphThink
+    , glyphTool
+    , glyphToolOut
     , paintBackgroundLines
     , roleError
     , roleMuted
@@ -124,7 +129,7 @@ showThinkingUnlocked config
             then pure ()
             else do
                 Text.hPutStr config.renderStderr
-                    (roleThinking config.renderColor "thinking…")
+                    (roleThinking config.renderColor (glyphThink <> "thinking…"))
                 hFlush config.renderStderr
                 writeIORef config.renderThinkingVisible True
 
@@ -159,7 +164,7 @@ summarizeToolCall call =
 formatToolStarted :: Bool -> ToolCall -> Text
 formatToolStarted color call =
     let detail = toolDetail call
-        arrow = roleToolArrow color "→ "
+        arrow = roleToolArrow color glyphTool
         name = roleToolName color call.name
     in if Text.null detail
         then arrow <> name
@@ -202,7 +207,9 @@ truncateToolOutput output =
         shortened
             | Text.length line <= 160 = line
             | otherwise = Text.take 157 line <> "..."
-    in if Text.null shortened then "(empty)" else shortened
+    in if Text.null shortened
+        then glyphToolOut <> "(empty)"
+        else glyphToolOut <> shortened
 
 firstLine :: Text -> Text
 firstLine = Text.takeWhile (/= '\n')
@@ -214,11 +221,11 @@ formatLoopError = formatLoopErrorColored False
 formatLoopErrorColored :: Bool -> LoopError -> Text
 formatLoopErrorColored color = \case
     LoopTransport err ->
-        roleError color ("transport error: " <> Text.pack (show err))
+        roleError color (glyphErr <> "transport error: " <> Text.pack (show err))
     LoopMaxTurns turn ->
-        roleError color "stopped: max turns reached"
+        roleError color (glyphErr <> "stopped: max turns reached")
             <> maybe "" (\text -> "\n" <> text) turn.assistantText
     LoopNoResponseId ->
-        roleError color "transport error: response had no id"
+        roleError color (glyphErr <> "transport error: response had no id")
     LoopCancelled _ ->
-        roleMuted color "cancelled"
+        roleMuted color (glyphCancel <> "cancelled")

--- a/packages/agent-cli/src/Agent/CLI/Style.hs
+++ b/packages/agent-cli/src/Agent/CLI/Style.hs
@@ -21,6 +21,14 @@ module Agent.CLI.Style
     , roleWarn
     , roleMuted
     , roleSuccess
+    , glyphTool
+    , glyphToolOut
+    , glyphOk
+    , glyphErr
+    , glyphWarn
+    , glyphCancel
+    , glyphSession
+    , glyphThink
     , solarizedCyan
     , solarizedMagenta
     , solarizedYellow
@@ -185,6 +193,17 @@ roleSuccess color =
     style color
         [ fg solarizedGreen
         ]
+
+-- | Shared Unicode chrome for TTY status lines.
+glyphTool, glyphToolOut, glyphOk, glyphErr, glyphWarn, glyphCancel, glyphSession, glyphThink :: Text
+glyphTool = "▸ "
+glyphToolOut = "┊ "
+glyphOk = "✓ "
+glyphErr = "✗ "
+glyphWarn = "⚠ "
+glyphCancel = "⊘ "
+glyphSession = "⧉ "
+glyphThink = "◌ "
 
 -- | Window title: session name when known, otherwise the working directory.
 cliWindowTitle :: FilePath -> Maybe Text -> Text

--- a/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
@@ -38,8 +38,8 @@ spec = do
 
     describe "truncateToolOutput" do
         it "keeps the first line and marks empty output" do
-            truncateToolOutput "Exit code: 0\nhello" `shouldBe` "Exit code: 0"
-            truncateToolOutput "   " `shouldBe` "(empty)"
+            truncateToolOutput "Exit code: 0\nhello" `shouldBe` "┊ Exit code: 0"
+            truncateToolOutput "   " `shouldBe` "┊ (empty)"
 
     describe "formatLoopError" do
         it "explains a max-turn stop" do
@@ -69,7 +69,7 @@ spec = do
                 let lines_ = filter (not . Text.null) (Text.lines body)
                 length lines_ `shouldBe` 80
                 lines_ `shouldMatchList`
-                    [ "→ list_dir packages/agent-" <> Text.pack (show i)
+                    [ "▸ list_dir packages/agent-" <> Text.pack (show i)
                     | i <- [1 :: Int .. 80]
                     ]
 
@@ -83,10 +83,10 @@ spec = do
                 visibleAfter `shouldBe` False
                 hClose handle
                 body <- Text.readFile path
-                body `shouldSatisfy` ("thinking…" `Text.isPrefixOf`)
+                body `shouldSatisfy` ("◌ thinking…" `Text.isPrefixOf`)
                 -- Clear uses CR + erase, so the tool summary shares the buffer
                 -- line with the status text rather than starting a new line.
-                body `shouldSatisfy` ("→ list_dir ." `Text.isInfixOf`)
+                body `shouldSatisfy` ("▸ list_dir ." `Text.isInfixOf`)
 
         it "ignores reasoning deltas" do
             withRenderConfig True False \config handle path -> do
@@ -94,7 +94,7 @@ spec = do
                 renderEvent config (ReasoningDelta "secret plan")
                 hClose handle
                 body <- Text.readFile path
-                body `shouldBe` "thinking…"
+                body `shouldBe` "◌ thinking…"
 
         it "buffers colored TextDelta until TurnFinished" do
             withRenderConfig False True \config handle path -> do
@@ -148,7 +148,7 @@ spec = do
                 renderEvent config TurnStarted
                 hClose handle
                 body <- Text.readFile path
-                body `shouldBe` "thinking…"
+                body `shouldBe` "◌ thinking…"
 
 withRenderConfig
     :: Bool

--- a/packages/agent-cli/test/Agent/CLI/StyleSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/StyleSpec.hs
@@ -43,6 +43,17 @@ spec = do
             out `shouldSatisfy` Text.isInfixOf "48;2;7;54;66"
             out `shouldSatisfy` Text.isInfixOf "\ESC[0;48;2;7;54;66m"
 
+    describe "chrome glyphs" do
+        it "exposes the shared Unicode markers" do
+            glyphTool `shouldBe` "▸ "
+            glyphOk `shouldBe` "✓ "
+            glyphErr `shouldBe` "✗ "
+            glyphWarn `shouldBe` "⚠ "
+            glyphCancel `shouldBe` "⊘ "
+            glyphSession `shouldBe` "⧉ "
+            glyphThink `shouldBe` "◌ "
+            glyphToolOut `shouldBe` "┊ "
+
     describe "cliWindowTitle" do
         it "uses the cwd basename when no session title is set" do
             cliWindowTitle "/tmp/haskell-agent" Nothing


### PR DESCRIPTION
## Summary
- Add shared Unicode chrome glyphs in `Agent.CLI.Style` (`▸`, `┊`, `✓`, `✗`, `⚠`, `⊘`, `⧉`, `◌`).
- Use them for tool start/output, thinking, loop errors/cancel, approvals, session/worktree/auth/model/effort status lines.
- Chrome-only: no behavior changes.

## Test plan
- [x] `cabal test agent-cli:agent-cli-test`
- [ ] Reload REPL and confirm tool/thinking/session lines show the new glyphs