### PR TITLE
chore: raise default max turns from 50 to 500

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Options.hs
+++ b/packages/agent-cli/src/Agent/CLI/Options.hs
@@ -76,7 +76,7 @@ defaultCliOptions = CliOptions
     , optWorktree = False
     , optYolo = False
     , optNoYolo = False
-    , optMaxTurns = 50
+    , optMaxTurns = 500
     , optEffort = Nothing
     , optPrompt = Nothing
     , optPromptFile = Nothing
@@ -221,7 +221,7 @@ usage = unlines
     , "      --no-agents-md      Skip AGENTS.md discovery"
     , "      --yolo              Auto-approve every tool"
     , "      --no-yolo           Never auto-approve; deny mutating tools without a TTY"
-    , "      --max-turns N       Stop after N model turns (default: 50)"
+    , "      --max-turns N       Stop after N model turns (default: 500)"
     , "      --effort LEVEL      Reasoning effort: low, medium, high, xhigh"
     , "                          (default: high for xai/grok, medium otherwise)"
     , "      --version           Print the agent-cli version"

--- a/packages/agent-core/src/Agent/Loop.hs
+++ b/packages/agent-core/src/Agent/Loop.hs
@@ -101,7 +101,7 @@ data LoopError
     deriving (Eq, Show)
 
 defaultLoopMaxTurns :: Int
-defaultLoopMaxTurns = 50
+defaultLoopMaxTurns = 500
 
 -- | CLI-facing formatter: unknown tools, handler errors, and crashes stay
 -- in-band as tool output so the model can continue.


### PR DESCRIPTION
## Summary
- Raise `defaultLoopMaxTurns` / `--max-turns` default from 50 to 500 so long tool-using sessions do not stop early with `stopped: max turns reached`.
- Keep `--max-turns N` as an override; update the CLI help text to match.

## Context
Agents were hitting the 50-turn loop budget on larger tasks. Grok Build has `--max-turns` mainly for headless mode (ignored in interactive TUI); Codex does not appear to enforce a comparable hard turn budget. This keeps a safety cap while making the default usable for longer interactive runs.

## Test plan
- [ ] Start the agent without `--max-turns` and confirm help / defaults report 500.
- [ ] Run a short session and confirm it still completes normally under the new default.
- [ ] Pass `--max-turns 2` and confirm the loop still stops with `stopped: max turns reached` when the model keeps calling tools.