### PR TITLE
feat: use a bare lambda as the REPL prompt

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -458,7 +458,7 @@ repl config render provider previous printed paramsRef policyRef transcriptRef p
     -- Cmd+Delete / Ctrl+U kill-to-start via haskeline Emacs bindings.
     let chromePrompt =
             beginBackground stdoutColor userBackground
-                <> rolePrompt stdoutColor "λ> "
+                <> rolePrompt stdoutColor "λ "
                 <> if stdoutColor
                     then Text.pack clearFromCursorToLineEndCode
                     else mempty

--- a/packages/agent-cli/test/Agent/CLI/StyleSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/StyleSpec.hs
@@ -11,10 +11,10 @@ spec = do
             style False [] "plain" `shouldBe` "plain"
 
         it "wraps text in SGR codes when color is on" do
-            let out = rolePrompt True "λ>"
-            out `shouldSatisfy` Text.isInfixOf "λ>"
+            let out = rolePrompt True "λ"
+            out `shouldSatisfy` Text.isInfixOf "λ"
             out `shouldSatisfy` Text.isInfixOf "\ESC["
-            out `shouldSatisfy` (not . Text.isPrefixOf "λ>")
+            out `shouldSatisfy` (not . Text.isPrefixOf "λ")
 
         it "restores a base wash after nested styling" do
             let out = styleBase True agentBackground [] "hi"
@@ -38,7 +38,7 @@ spec = do
             roleMuted False "session: 1" `shouldBe` "session: 1"
 
         it "keeps the user wash under the prompt glyph" do
-            let out = rolePrompt True "λ>"
+            let out = rolePrompt True "λ"
             -- Background may share an SGR sequence with bold/cyan attrs (truecolor).
             out `shouldSatisfy` Text.isInfixOf "48;2;7;54;66"
             out `shouldSatisfy` Text.isInfixOf "\ESC[0;48;2;7;54;66m"


### PR DESCRIPTION
## Summary
- Change the REPL prompt from `λ>` to `λ ` (lambda plus a trailing space).

## Test plan
- [x] `cabal test agent-cli:agent-cli-test`
- [ ] Reload the REPL and confirm the prompt shows as `λ`