### PR TITLE
feat: stamp user turns with local wall-clock time

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -49,6 +49,7 @@ library
                     , Agent.CLI.Render
                     , Agent.CLI.Session
                     , Agent.CLI.Style
+                    , Agent.CLI.Timestamp
                     , Agent.CLI.Tools
                     , Agent.CLI.Worktree
     build-depends:    agent-core >= 0.1 && < 0.2
@@ -94,6 +95,7 @@ test-suite agent-cli-test
                     , Agent.CLI.PromptSpec
                     , Agent.CLI.RenderSpec
                     , Agent.CLI.StyleSpec
+                    , Agent.CLI.TimestampSpec
                     , Agent.CLI.SessionSpec
                     , Agent.CLI.ToolsSpec
                     , Agent.CLI.WorktreeSpec

--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -48,6 +48,7 @@ import Agent.CLI.Style
     , setCliWindowTitle
     , userBackground
     )
+import Agent.CLI.Timestamp (stampTurnInputs, stripBracketedTimestamps)
 import Agent.CLI.Tools (lookupAppTool, schemasFromAppTools)
 import Agent.CLI.Worktree (createWorktree, isUnderWorktreeRoot, worktreeRoot)
 import Agent.Loop
@@ -770,9 +771,10 @@ runOneTurn config render previous printed transcriptRef persist planMode agentsC
             Just agents | null beforeItems && isNothing prev ->
                 UserMessage agents : inputs
             _ -> inputs
-        turnInputs = case planReminder of
+        turnInputs0 = case planReminder of
             Just reminder -> UserMessage reminder : baseInputs
             Nothing -> baseInputs
+    turnInputs <- stampTurnInputs turnInputs0
     result <- runLoopInputs config prev turnInputs
     clearThinking render
     case result of
@@ -791,7 +793,9 @@ runOneTurn config render previous printed transcriptRef persist planMode agentsC
             writeIORef previous (Just loopResult.finalResponseId)
             followUp <- handleProposedPlan planMode loopResult.finalText
             printedText <- readIORef printed
-            case (printedText, loopResult.finalText) of
+            let assistantText =
+                    fmap stripBracketedTimestamps loopResult.finalText
+            case (printedText, assistantText) of
                 (False, Just text) | not (Text.null (Text.strip text)) -> do
                     useColor <- resolveColor stdout
                     putTextLn stdout (renderAssistantText useColor text)
@@ -815,7 +819,7 @@ runOneTurn config render previous printed transcriptRef persist planMode agentsC
                     let turn = SessionTurn
                             { turnAt = now
                             , turnUserText = promptText
-                            , turnAssistantText = loopResult.finalText
+                            , turnAssistantText = assistantText
                             , turnResponseId = Just loopResult.finalResponseId
                             , turnItems = newItems
                             }

--- a/packages/agent-cli/src/Agent/CLI/Prompt.hs
+++ b/packages/agent-cli/src/Agent/CLI/Prompt.hs
@@ -4,6 +4,7 @@ module Agent.CLI.Prompt
     , systemPrompt
     ) where
 
+import Agent.CLI.Timestamp (timeContextGuidance)
 import Agent.Provider (Provider(..))
 import Agent.Tools.Grok.Prompt (codingGrokPromptTools, grokSystemPrompt)
 import Data.Text (Text)
@@ -20,7 +21,7 @@ defaultModelFor = \case
 -- | @isNonInteractive@ is True for one-shot @-p@ (no human in the loop).
 systemPrompt :: Provider -> FilePath -> Day -> Bool -> Text
 systemPrompt provider cwd today isNonInteractive =
-    base <> "\n\n" <> ghciGuidance
+    base <> "\n\n" <> ghciGuidance <> "\n" <> timeContextGuidance
   where
     base = case provider of
         XAIProvider -> grokSystemPrompt codingGrokPromptTools cwd today isNonInteractive

--- a/packages/agent-cli/src/Agent/CLI/Render.hs
+++ b/packages/agent-cli/src/Agent/CLI/Render.hs
@@ -13,6 +13,7 @@ module Agent.CLI.Render
     ) where
 
 import Agent.CLI.Markdown (renderMarkdown)
+import Agent.CLI.Timestamp (stripBracketedTimestamps)
 import Agent.CLI.Style
     ( agentBackground
     , glyphCancel
@@ -95,7 +96,8 @@ renderEventUnlocked config = \case
 -- Color mode also paints each line with 'agentBackground'.
 renderAssistantText :: Bool -> Text -> Text
 renderAssistantText color text =
-    paintBackgroundLines color agentBackground (renderMarkdown color text)
+    paintBackgroundLines color agentBackground
+        (renderMarkdown color (stripBracketedTimestamps text))
 
 -- | End-of-turn flush for color mode: prefer streamed deltas, else the
 -- completed 'assistantText' from non-streaming backends.

--- a/packages/agent-cli/src/Agent/CLI/Timestamp.hs
+++ b/packages/agent-cli/src/Agent/CLI/Timestamp.hs
@@ -1,0 +1,136 @@
+-- | Wall-clock stamps on model-facing user messages (belege.ai style).
+--
+-- Each user turn sent to the model ends with a local timestamp like
+-- @[2026-08-20 16:45 CEST]@ so the agent can judge pauses between turns.
+-- The REPL UI keeps the unstamped text; assistant replies are scrubbed if
+-- the model echoes a stamp.
+module Agent.CLI.Timestamp
+    ( renderMessageTimestamp
+    , stampUserText
+    , stampUserTextAt
+    , stampTurnInputs
+    , stripBracketedTimestamps
+    , timeContextGuidance
+    ) where
+
+import Agent.Loop (TurnInput(..))
+import Data.Char (isAsciiUpper, isDigit)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Data.Time.Clock (UTCTime, getCurrentTime)
+import Data.Time.Format (defaultTimeLocale, formatTime)
+import Data.Time.LocalTime
+    ( TimeZone
+    , getCurrentTimeZone
+    , timeZoneName
+    , utcToZonedTime
+    )
+
+-- | Format @utc@ in @tz@ as @[YYYY-MM-DD HH:MM TZ]@.
+renderMessageTimestamp :: TimeZone -> UTCTime -> Text
+renderMessageTimestamp tz utc =
+    let local = utcToZonedTime tz utc
+    in Text.pack $
+        formatTime defaultTimeLocale "[%Y-%m-%d %H:%M " local
+            <> timeZoneName tz
+            <> "]"
+
+-- | Append a local timestamp to @text@ (idempotent if one is already present).
+stampUserText :: Text -> IO Text
+stampUserText text = do
+    now <- getCurrentTime
+    tz <- getCurrentTimeZone
+    pure (stampUserTextAt tz now text)
+
+-- | Pure variant for tests.
+stampUserTextAt :: TimeZone -> UTCTime -> Text -> Text
+stampUserTextAt tz now text =
+    let stripped = Text.stripEnd text
+        stamp = renderMessageTimestamp tz now
+    in if Text.null stripped
+        then stamp
+        else if hasTrailingTimestamp stripped
+            then stripped
+            else stripped <> " " <> stamp
+
+-- | Stamp every human 'UserMessage' / 'UserMultimodal' payload. Tool results
+-- and other turn inputs are left unchanged.
+stampTurnInputs :: [TurnInput] -> IO [TurnInput]
+stampTurnInputs inputs = do
+    now <- getCurrentTime
+    tz <- getCurrentTimeZone
+    pure (map (stampOne tz now) inputs)
+  where
+    stampOne tz now = \case
+        UserMessage text -> UserMessage (stampUserTextAt tz now text)
+        UserMultimodal{userText, userImages} ->
+            UserMultimodal
+                { userText = stampUserTextAt tz now userText
+                , userImages
+                }
+        other -> other
+
+hasTrailingTimestamp :: Text -> Bool
+hasTrailingTimestamp text =
+    let stripped = Text.stripEnd text
+    in case Text.breakOnEnd "[" stripped of
+        (before, rest)
+            | Text.null rest -> False
+            -- 'breakOnEnd' keeps the '[' on @before@, so accept
+            -- @"… ["@ or a stamp-only @"["@.
+            | not (Text.isSuffixOf " [" before || before == "[") -> False
+            | otherwise -> case matchTimestamp rest of
+                Just leftover -> Text.null leftover
+                Nothing -> False
+
+-- | Remove belege-style @[YYYY-MM-DD HH:MM TZ]@ fragments the model may echo.
+stripBracketedTimestamps :: Text -> Text
+stripBracketedTimestamps = Text.strip . go
+  where
+    go :: Text -> Text
+    go t = case Text.uncons t of
+        Nothing -> t
+        Just ('[', rest) -> case matchTimestamp rest of
+            Just after -> go after
+            Nothing -> Text.cons '[' (go rest)
+        Just (c, rest) -> Text.cons c (go rest)
+
+matchTimestamp :: Text -> Maybe Text
+matchTimestamp s
+    | Text.length s < 18 = Nothing
+    | not (isDate (Text.take 10 s)) = Nothing
+    | Text.index s 10 /= ' ' = Nothing
+    | not (isTime (Text.take 5 (Text.drop 11 s))) = Nothing
+    | Text.index s 16 /= ' ' = Nothing
+    | otherwise =
+        let (tz, rest1) = Text.span isAsciiUpper (Text.drop 17 s)
+        in case Text.uncons rest1 of
+            Just (']', rest2) | not (Text.null tz) -> Just rest2
+            _ -> Nothing
+
+isDate :: Text -> Bool
+isDate d =
+    Text.length d == 10
+        && Text.all isDigit (Text.take 4 d)
+        && Text.index d 4 == '-'
+        && Text.all isDigit (Text.take 2 (Text.drop 5 d))
+        && Text.index d 7 == '-'
+        && Text.all isDigit (Text.take 2 (Text.drop 8 d))
+
+isTime :: Text -> Bool
+isTime t =
+    Text.length t == 5
+        && Text.all isDigit (Text.take 2 t)
+        && Text.index t 2 == ':'
+        && Text.all isDigit (Text.take 2 (Text.drop 3 t))
+
+-- | System-prompt note mirroring belege.ai Zeitkontext (English for this harness).
+timeContextGuidance :: Text
+timeContextGuidance =
+    Text.unlines
+        [ "Time context:"
+        , "User messages in the conversation history end with a timestamp like [YYYY-MM-DD HH:MM CET] or [YYYY-MM-DD HH:MM CEST] (local timezone, including DST)."
+        , "Use those stamps to judge how much wall-clock time passed between turns."
+        , "Never include such a bracketed timestamp in your own replies — it is metadata only, not part of the answer."
+        , "When speaking times to the user, use the same local timezone — not UTC."
+        ]

--- a/packages/agent-cli/test/Agent/CLI/PromptSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/PromptSpec.hs
@@ -45,6 +45,8 @@ spec = describe "systemPrompt" do
             grok = systemPrompt XAIProvider "/tmp/repo" day False
             openai = systemPrompt OpenAIProvider "/tmp/repo" day False
         grok `shouldSatisfy` Text.isInfixOf "Prefer ghci for scripting"
+        grok `shouldSatisfy` Text.isInfixOf "Time context:"
+        openai `shouldSatisfy` Text.isInfixOf "Time context:"
         openai `shouldSatisfy` Text.isInfixOf "Prefer ghci for scripting"
         grok `shouldSatisfy` Text.isInfixOf "Python, Node, bash"
         openai `shouldSatisfy` Text.isInfixOf "Python, Node, bash"

--- a/packages/agent-cli/test/Agent/CLI/TimestampSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TimestampSpec.hs
@@ -1,0 +1,67 @@
+module Agent.CLI.TimestampSpec (spec) where
+
+import Agent.CLI.Timestamp
+import Data.Time.Calendar (fromGregorian)
+import Data.Time.Clock (UTCTime(..), secondsToDiffTime)
+import Data.Time.LocalTime (TimeZone(..))
+import qualified Data.Text as Text
+import Test.Hspec
+
+-- Fixed offset used as a stand-in for CEST (+02:00) in pure tests.
+cest :: TimeZone
+cest = TimeZone (2 * 60) True "CEST"
+
+utcSample :: UTCTime
+utcSample = UTCTime (fromGregorian 2026 8 20) (secondsToDiffTime (14 * 3600 + 45 * 60))
+-- 14:45 UTC -> 16:45 CEST
+
+spec :: Spec
+spec = do
+    describe "renderMessageTimestamp" do
+        it "formats local wall-clock with timezone name" do
+            renderMessageTimestamp cest utcSample
+                `shouldBe` "[2026-08-20 16:45 CEST]"
+
+    describe "stampUserTextAt" do
+        it "appends a trailing stamp" do
+            stampUserTextAt cest utcSample "hello"
+                `shouldBe` "hello [2026-08-20 16:45 CEST]"
+
+        it "does not double-stamp" do
+            let once = stampUserTextAt cest utcSample "hello"
+            stampUserTextAt cest utcSample once `shouldBe` once
+
+        it "stamps an empty message as metadata-only" do
+            stampUserTextAt cest utcSample ""
+                `shouldBe` "[2026-08-20 16:45 CEST]"
+
+    describe "stripBracketedTimestamps" do
+        it "removes a trailing stamp glued without a space" do
+            stripBracketedTimestamps
+                "I'll retry now.[2026-04-20 18:06 CEST]"
+                `shouldBe` "I'll retry now."
+
+        it "removes a trailing stamp with a space" do
+            stripBracketedTimestamps
+                "Ok then. [2026-04-20 18:08 CEST]"
+                `shouldBe` "Ok then."
+
+        it "collapses a stamp-only reply to empty" do
+            stripBracketedTimestamps "[2026-04-20 20:02 CEST]" `shouldBe` ""
+
+        it "leaves non-timestamp brackets alone" do
+            stripBracketedTimestamps "see [Anlage 1] please"
+                `shouldBe` "see [Anlage 1] please"
+            stripBracketedTimestamps "Beleg vom [2026-04-20] liegt vor"
+                `shouldBe` "Beleg vom [2026-04-20] liegt vor"
+
+        it "removes leading and mid-string stamps" do
+            stripBracketedTimestamps "[2026-04-20 18:06 CEST] Alles klar."
+                `shouldBe` "Alles klar."
+            stripBracketedTimestamps "Ja[2026-04-20 18:06 CEST], passt."
+                `shouldBe` "Ja, passt."
+
+    describe "timeContextGuidance" do
+        it "teaches the model about stamps and forbids echoing them" do
+            timeContextGuidance `shouldSatisfy` Text.isInfixOf "[YYYY-MM-DD HH:MM"
+            timeContextGuidance `shouldSatisfy` Text.isInfixOf "Never include"

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -14,6 +14,7 @@ import qualified Agent.CLI.PromptSpec as PromptSpec
 import qualified Agent.CLI.RenderSpec as RenderSpec
 import qualified Agent.CLI.SessionSpec as SessionSpec
 import qualified Agent.CLI.StyleSpec as StyleSpec
+import qualified Agent.CLI.TimestampSpec as TimestampSpec
 import qualified Agent.CLI.ToolsSpec as ToolsSpec
 import qualified Agent.CLI.WorktreeSpec as WorktreeSpec
 
@@ -30,6 +31,7 @@ main = hspec do
     PromptSpec.spec
     RenderSpec.spec
     StyleSpec.spec
+    TimestampSpec.spec
     SessionSpec.spec
     ToolsSpec.spec
     WorktreeSpec.spec


### PR DESCRIPTION
## Summary
- Add belege.ai-style local timestamps on model-facing user messages: `hello [2026-08-20 16:45 CEST]`.
- Teach the system prompt (`Time context`) to use those stamps to judge elapsed time and never echo them.
- Strip bracketed stamps from assistant text (streamed + final) so UI/session history stay clean.
- REPL still shows the unstamped user prompt.

## Test plan
- [x] `cabal test agent-cli:agent-cli-test` (includes `TimestampSpec`)
- [ ] Send two prompts with a pause between them and confirm the model can talk about elapsed time
- [ ] Confirm the REPL does not display the `[YYYY-MM-DD HH:MM TZ]` suffix