### PR TITLE
feat: CLI chrome (diamonds, spinner, turn status)

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -27,6 +27,7 @@ import Agent.CLI.Render
     ( RenderConfig(..)
     , clearThinking
     , formatLoopErrorColored
+    , formatTurnStatus
     , putTextLn
     , renderAssistantText
     , renderEvent
@@ -48,7 +49,6 @@ import Agent.CLI.Style
     , setCliWindowTitle
     , userBackground
     )
-import Agent.CLI.Timestamp (stampTurnInputs, stripBracketedTimestamps)
 import Agent.CLI.Tools (lookupAppTool, schemasFromAppTools)
 import Agent.CLI.Worktree (createWorktree, isUnderWorktreeRoot, worktreeRoot)
 import Agent.Loop
@@ -432,6 +432,8 @@ runSession options provider policy tools toolEnv planMode prompt paramsRef trans
     escPaused <- newIORef False
     textBuffer <- newIORef ""
     thinkingVisible <- newIORef False
+    spinnerRef <- newIORef Nothing
+    modelRef <- newIORef =<< (currentModel <$> readIORef paramsRef)
     ioLock <- newMVar ()
     previous <- newIORef initialPrevious
     policyRef <- newIORef policy
@@ -440,12 +442,14 @@ runSession options provider policy tools toolEnv planMode prompt paramsRef trans
     let render = RenderConfig
             { renderShowThinking = stderrTty
             , renderThinkingVisible = thinkingVisible
+            , renderThinkingSpinner = spinnerRef
             , renderColor = useColor
             , renderPrintedText = printed
             , renderTextBuffer = textBuffer
             , renderLock = ioLock
             , renderStdout = stdout
             , renderStderr = stderr
+            , renderModelRef = modelRef
             }
         config = LoopConfig
             { loopBackend = backend
@@ -580,6 +584,7 @@ repl config render provider previous printed paramsRef policyRef transcriptRef p
                         continue
                     ReplSetModel name -> do
                         modifyIORef' paramsRef (setModel name)
+                        writeIORef render.renderModelRef name
                         clearedChain <- case provider of
                             OpenAIProvider ->
                                 atomicModifyIORef' previous \prev ->
@@ -771,10 +776,9 @@ runOneTurn config render previous printed transcriptRef persist planMode agentsC
             Just agents | null beforeItems && isNothing prev ->
                 UserMessage agents : inputs
             _ -> inputs
-        turnInputs0 = case planReminder of
+        turnInputs = case planReminder of
             Just reminder -> UserMessage reminder : baseInputs
             Nothing -> baseInputs
-    turnInputs <- stampTurnInputs turnInputs0
     result <- runLoopInputs config prev turnInputs
     clearThinking render
     case result of
@@ -784,18 +788,27 @@ runOneTurn config render previous printed transcriptRef persist planMode agentsC
                     (<> map toolResultToItem toolResults)
             color <- resolveColor stderr
             putTextLn stderr (formatLoopErrorColored color (LoopCancelled toolResults))
+            model <- readIORef render.renderModelRef
+            putTextLn stderr (formatTurnStatus color "cancelled" model)
             pure True
         Left err -> do
             color <- resolveColor stderr
             putTextLn stderr (formatLoopErrorColored color err)
+            model <- readIORef render.renderModelRef
+            putTextLn stderr (formatTurnStatus color "error" model)
             pure False
         Right loopResult -> do
             writeIORef previous (Just loopResult.finalResponseId)
+            do
+                color <- resolveColor stderr
+                model <- readIORef render.renderModelRef
+                let turns = Text.pack (show loopResult.turnsUsed)
+                    unit = if loopResult.turnsUsed == 1 then " turn" else " turns"
+                putTextLn stderr
+                    (formatTurnStatus color "ok" (model <> " · " <> turns <> unit))
             followUp <- handleProposedPlan planMode loopResult.finalText
             printedText <- readIORef printed
-            let assistantText =
-                    fmap stripBracketedTimestamps loopResult.finalText
-            case (printedText, assistantText) of
+            case (printedText, loopResult.finalText) of
                 (False, Just text) | not (Text.null (Text.strip text)) -> do
                     useColor <- resolveColor stdout
                     putTextLn stdout (renderAssistantText useColor text)
@@ -819,7 +832,7 @@ runOneTurn config render previous printed transcriptRef persist planMode agentsC
                     let turn = SessionTurn
                             { turnAt = now
                             , turnUserText = promptText
-                            , turnAssistantText = assistantText
+                            , turnAssistantText = loopResult.finalText
                             , turnResponseId = Just loopResult.finalResponseId
                             , turnItems = newItems
                             }

--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -49,6 +49,7 @@ import Agent.CLI.Style
     , setCliWindowTitle
     , userBackground
     )
+import Agent.CLI.Timestamp (stampTurnInputs, stripBracketedTimestamps)
 import Agent.CLI.Tools (lookupAppTool, schemasFromAppTools)
 import Agent.CLI.Worktree (createWorktree, isUnderWorktreeRoot, worktreeRoot)
 import Agent.Loop
@@ -776,9 +777,10 @@ runOneTurn config render previous printed transcriptRef persist planMode agentsC
             Just agents | null beforeItems && isNothing prev ->
                 UserMessage agents : inputs
             _ -> inputs
-        turnInputs = case planReminder of
+        turnInputs0 = case planReminder of
             Just reminder -> UserMessage reminder : baseInputs
             Nothing -> baseInputs
+    turnInputs <- stampTurnInputs turnInputs0
     result <- runLoopInputs config prev turnInputs
     clearThinking render
     case result of
@@ -808,7 +810,9 @@ runOneTurn config render previous printed transcriptRef persist planMode agentsC
                     (formatTurnStatus color "ok" (model <> " · " <> turns <> unit))
             followUp <- handleProposedPlan planMode loopResult.finalText
             printedText <- readIORef printed
-            case (printedText, loopResult.finalText) of
+            let assistantText =
+                    fmap stripBracketedTimestamps loopResult.finalText
+            case (printedText, assistantText) of
                 (False, Just text) | not (Text.null (Text.strip text)) -> do
                     useColor <- resolveColor stdout
                     putTextLn stdout (renderAssistantText useColor text)
@@ -832,7 +836,7 @@ runOneTurn config render previous printed transcriptRef persist planMode agentsC
                     let turn = SessionTurn
                             { turnAt = now
                             , turnUserText = promptText
-                            , turnAssistantText = loopResult.finalText
+                            , turnAssistantText = assistantText
                             , turnResponseId = Just loopResult.finalResponseId
                             , turnItems = newItems
                             }

--- a/packages/agent-cli/src/Agent/CLI/Markdown.hs
+++ b/packages/agent-cli/src/Agent/CLI/Markdown.hs
@@ -5,6 +5,7 @@ module Agent.CLI.Markdown
 
 import Agent.CLI.Style
     ( agentBackground
+    , osc8Link
     , solarizedBase01
     , solarizedBlue
     , solarizedCyan
@@ -207,13 +208,21 @@ takeTable (header : sep : rest)
         let (body, after) = span isTableRow rest
             rows = map splitRow (header : body)
             widths = columnWidths rows
-            styled =
-                zipWith
-                    (\i row -> styleTableRow (i == 0) widths row)
-                    [0 :: Int ..]
-                    rows
+            top = md [fg solarizedBase01] (boxLine '┌' '┬' '┐' '─' widths)
+            mid = md [fg solarizedBase01] (boxLine '├' '┼' '┤' '─' widths)
+            bot = md [fg solarizedBase01] (boxLine '└' '┴' '┘' '─' widths)
+            headerRow = styleTableRow True widths (head rows)
+            bodyRows = map (styleTableRow False widths) (drop 1 rows)
+            styled = [top, headerRow, mid] ++ bodyRows ++ [bot]
         in Just (styled, after)
 takeTable _ = Nothing
+
+boxLine :: Char -> Char -> Char -> Char -> [Int] -> Text
+boxLine left mid right fill widths =
+    Text.singleton left
+        <> Text.intercalate (Text.singleton mid)
+            [ Text.replicate (w + 2) (Text.singleton fill) | w <- widths ]
+        <> Text.singleton right
 
 isTableRow :: Text -> Bool
 isTableRow line =
@@ -243,15 +252,15 @@ columnWidths rows =
 
 styleTableRow :: Bool -> [Int] -> [Text] -> Text
 styleTableRow isHeader widths cells =
-    let padded =
-            zipWith
-                (\w c -> c <> Text.replicate (max 0 (w - Text.length c)) " ")
-                widths
-                (cells ++ repeat "")
-        line = Text.intercalate "  " (take (length widths) padded)
-    in if isHeader
-        then md [SetConsoleIntensity BoldIntensity] line
-        else styleInline line
+    let cellText w c =
+            let pad = max 0 (w - Text.length c)
+                body = " " <> c <> Text.replicate pad " " <> " "
+            in if isHeader
+                then md [SetConsoleIntensity BoldIntensity] body
+                else styleInline body
+        parts = zipWith cellText widths (cells ++ repeat "")
+        bar = md [fg solarizedBase01] "│"
+    in bar <> Text.intercalate bar (take (length widths) parts) <> bar
 
 styleInline :: Text -> Text
 styleInline = Text.concat . go Nothing
@@ -262,7 +271,8 @@ styleInline = Text.concat . go Nothing
         | Just (code, rest) <- takeInlineCode t =
             md codeStyle code : go (Text.unsnoc code >>= Just . snd) rest
         | Just (linkText, url, rest) <- takeLink t =
-            md linkStyle (styleInline linkText)
+            let label = md linkStyle (styleInline linkText)
+            in osc8Link True url label
                 : md urlStyle (" (" <> url <> ")")
                 : go (Just ')') rest
         | Just (inner, rest) <- takeEmphasis prev "**" t =

--- a/packages/agent-cli/src/Agent/CLI/Markdown.hs
+++ b/packages/agent-cli/src/Agent/CLI/Markdown.hs
@@ -248,16 +248,26 @@ splitRow line =
 columnWidths :: [[Text]] -> [Int]
 columnWidths rows =
     let cols = transpose rows
-    in map (maximum . (0 :) . map Text.length) cols
+    in map (maximum . (0 :) . map (Text.length . visibleCellText)) cols
+
+-- | Approximate rendered cell text width by stripping common inline markers
+-- before padding, so borders align when body cells contain ``code`` / emphasis.
+visibleCellText :: Text -> Text
+visibleCellText = Text.replace "`" "" . Text.replace "**" "" . Text.replace "__" ""
+    . Text.replace "*" "" . Text.replace "_" ""
 
 styleTableRow :: Bool -> [Int] -> [Text] -> Text
 styleTableRow isHeader widths cells =
     let cellText w c =
-            let pad = max 0 (w - Text.length c)
-                body = " " <> c <> Text.replicate pad " " <> " "
+            let visible = visibleCellText c
+                pad = max 0 (w - Text.length visible)
+                body = " " <> visible <> Text.replicate pad " " <> " "
             in if isHeader
                 then md [SetConsoleIntensity BoldIntensity] body
-                else styleInline body
+                else
+                    -- Markers were stripped for width; re-apply inline styling
+                    -- only for bare visible text (no markers left to parse).
+                    md [] body
         parts = zipWith cellText widths (cells ++ repeat "")
         bar = md [fg solarizedBase01] "│"
     in bar <> Text.intercalate bar (take (length widths) parts) <> bar

--- a/packages/agent-cli/src/Agent/CLI/Render.hs
+++ b/packages/agent-cli/src/Agent/CLI/Render.hs
@@ -5,6 +5,7 @@ module Agent.CLI.Render
     , formatLoopError
     , formatLoopErrorColored
     , formatToolStarted
+    , formatTurnStatus
     , putTextLn
     , renderAssistantText
     , renderEvent
@@ -13,27 +14,31 @@ module Agent.CLI.Render
     ) where
 
 import Agent.CLI.Markdown (renderMarkdown)
-import Agent.CLI.Timestamp (stripBracketedTimestamps)
 import Agent.CLI.Style
     ( agentBackground
     , glyphCancel
     , glyphErr
-    , glyphThink
+    , glyphOk
     , glyphTool
+    , glyphToolAccent
     , glyphToolOut
     , paintBackgroundLines
     , roleError
     , roleMuted
+    , roleSuccess
     , roleThinking
     , roleToolArrow
     , roleToolDetail
     , roleToolName
     , roleToolOutput
+    , spinnerFrames
     )
 import Agent.Loop (LoopError(..), LoopEvent(..), TurnOutput(..))
 import Agent.ToolDispatch (ToolCall(..), ToolCallResult(..))
+import Control.Concurrent (ThreadId, forkIO, killThread, threadDelay)
 import Control.Concurrent.MVar (MVar, withMVar)
-import Control.Monad (when)
+import Control.Exception.Safe (tryIO)
+import Control.Monad (void, when)
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KeyMap
@@ -47,14 +52,15 @@ import System.IO (Handle, hFlush)
 
 data RenderConfig = RenderConfig
     { renderShowThinking :: !Bool
-      -- | True while the static "thinking…" status line is on stderr.
     , renderThinkingVisible :: !(IORef Bool)
+    , renderThinkingSpinner :: !(IORef (Maybe ThreadId))
     , renderColor :: !Bool
     , renderPrintedText :: !(IORef Bool)
     , renderTextBuffer :: !(IORef Text)
     , renderLock :: !(MVar ())
     , renderStdout :: !Handle
     , renderStderr :: !Handle
+    , renderModelRef :: !(IORef Text)
     }
 
 renderEvent :: RenderConfig -> LoopEvent -> IO ()
@@ -76,7 +82,7 @@ renderEventUnlocked config = \case
     ReasoningDelta _ -> pure ()
     TurnStarted -> do
         writeIORef config.renderTextBuffer ""
-        showThinkingUnlocked config
+        startThinkingSpinnerUnlocked config
     -- Flush styled text on every completed turn. Pre-tool prose ("I'll check…")
     -- is shown before tool lines; the final tool-free turn is the main answer.
     TurnFinished turn -> do
@@ -96,8 +102,7 @@ renderEventUnlocked config = \case
 -- Color mode also paints each line with 'agentBackground'.
 renderAssistantText :: Bool -> Text -> Text
 renderAssistantText color text =
-    paintBackgroundLines color agentBackground
-        (renderMarkdown color (stripBracketedTimestamps text))
+    paintBackgroundLines color agentBackground (renderMarkdown color text)
 
 -- | End-of-turn flush for color mode: prefer streamed deltas, else the
 -- completed 'assistantText' from non-streaming backends.
@@ -122,28 +127,63 @@ clearThinking :: RenderConfig -> IO ()
 clearThinking config =
     withMVar config.renderLock \_ -> clearThinkingUnlocked config
 
-showThinkingUnlocked :: RenderConfig -> IO ()
-showThinkingUnlocked config
+startThinkingSpinnerUnlocked :: RenderConfig -> IO ()
+startThinkingSpinnerUnlocked config
     | not config.renderShowThinking = pure ()
     | otherwise = do
         visible <- readIORef config.renderThinkingVisible
         if visible
             then pure ()
             else do
-                Text.hPutStr config.renderStderr
-                    (roleThinking config.renderColor (glyphThink <> "thinking…"))
-                hFlush config.renderStderr
                 writeIORef config.renderThinkingVisible True
+                paintThinkingFrame config 0
+                tid <- forkIO (spinnerLoop config 0)
+                writeIORef config.renderThinkingSpinner (Just tid)
 
 clearThinkingUnlocked :: RenderConfig -> IO ()
 clearThinkingUnlocked config = do
+    mtid <- atomicModifyIORef' config.renderThinkingSpinner \mt -> (Nothing, mt)
+    case mtid of
+        Just tid -> killThread tid
+        Nothing -> pure ()
     visible <- readIORef config.renderThinkingVisible
-    if not visible
-        then pure ()
-        else do
+    when visible do
+        void $ tryIO do
             Text.hPutStr config.renderStderr "\r\ESC[K"
             hFlush config.renderStderr
-            writeIORef config.renderThinkingVisible False
+        writeIORef config.renderThinkingVisible False
+
+spinnerLoop :: RenderConfig -> Int -> IO ()
+spinnerLoop config frame = do
+    threadDelay 80000
+    visible <- readIORef config.renderThinkingVisible
+    when visible do
+        let frames = spinnerFrames
+            next = (frame + 1) `mod` length frames
+        withMVar config.renderLock \_ -> do
+            still <- readIORef config.renderThinkingVisible
+            when still (paintThinkingFrame config next)
+        spinnerLoop config next
+
+paintThinkingFrame :: RenderConfig -> Int -> IO ()
+paintThinkingFrame config frame = do
+    let frames = spinnerFrames
+        glyph = frames !! (frame `mod` length frames)
+        line = roleThinking config.renderColor (glyph <> " thinking…")
+    void $ tryIO do
+        Text.hPutStr config.renderStderr ("\r\ESC[K" <> line)
+        hFlush config.renderStderr
+
+formatTurnStatus :: Bool -> Text -> Text -> Text
+formatTurnStatus color outcome detail =
+    let mark
+            | outcome == "ok" = roleSuccess color glyphOk
+            | outcome == "cancelled" = roleMuted color glyphCancel
+            | otherwise = roleError color glyphErr
+        body
+            | Text.null detail = outcome
+            | otherwise = outcome <> " · " <> detail
+    in mark <> roleMuted color body
 
 -- | Write @text@ plus a newline as one 'Text.hPutStr'. @hPutStrLn@ on a
 -- 'String' is @hPutStr@ then @hPutChar '\n'@ over a @[Char]@ spine, so
@@ -213,8 +253,8 @@ truncateToolOutput output =
             | Text.length line <= 160 = line
             | otherwise = Text.take 157 line <> "..."
     in if Text.null shortened
-        then glyphToolOut <> "(empty)"
-        else glyphToolOut <> shortened
+        then glyphToolAccent <> glyphToolOut <> "(empty)"
+        else glyphToolAccent <> glyphToolOut <> shortened
 
 firstLine :: Text -> Text
 firstLine = Text.takeWhile (/= '\n')

--- a/packages/agent-cli/src/Agent/CLI/Style.hs
+++ b/packages/agent-cli/src/Agent/CLI/Style.hs
@@ -23,12 +23,18 @@ module Agent.CLI.Style
     , roleSuccess
     , glyphTool
     , glyphToolOut
+    , glyphToolAccent
     , glyphOk
     , glyphErr
     , glyphWarn
     , glyphCancel
     , glyphSession
     , glyphThink
+    , spinnerFrames
+    , ColorLevel(..)
+    , detectColorLevel
+    , adaptSgr
+    , osc8Link
     , solarizedCyan
     , solarizedMagenta
     , solarizedYellow
@@ -43,9 +49,10 @@ module Agent.CLI.Style
     ) where
 
 import Data.Colour (Colour)
-import Data.Colour.SRGB (sRGB24)
+import Data.Colour.SRGB (RGB(..), sRGB24, toSRGB24)
 import Data.Text (Text)
 import qualified Data.Text as Text
+import Data.Word (Word8)
 import System.Console.ANSI
     ( ConsoleIntensity(..)
     , ConsoleLayer(..)
@@ -56,8 +63,10 @@ import System.Console.ANSI.Codes
     ( clearFromCursorToLineEndCode
     , setSGRCode
     )
+import System.Environment (lookupEnv)
 import System.FilePath (takeFileName)
 import System.IO (Handle)
+import System.IO.Unsafe (unsafePerformIO)
 
 -- Solarized Dark (https://ethanschoonover.com/solarized/)
 solarizedBase03, solarizedBase02, solarizedBase01 :: Colour Float
@@ -194,16 +203,94 @@ roleSuccess color =
         [ fg solarizedGreen
         ]
 
--- | Shared Unicode chrome for TTY status lines.
-glyphTool, glyphToolOut, glyphOk, glyphErr, glyphWarn, glyphCancel, glyphSession, glyphThink :: Text
-glyphTool = "▸ "
-glyphToolOut = "┊ "
-glyphOk = "✓ "
-glyphErr = "✗ "
-glyphWarn = "⚠ "
-glyphCancel = "⊘ "
-glyphSession = "⧉ "
-glyphThink = "◌ "
+supportsUnicodeChrome :: Bool
+supportsUnicodeChrome = unsafePerformIO do
+    lang <- lookupEnv "LANG"
+    lc <- lookupEnv "LC_ALL"
+    lcctype <- lookupEnv "LC_CTYPE"
+    let hay = mconcat [lang, lc, lcctype]
+    pure $ case hay of
+        Nothing -> True
+        Just s ->
+            any (`Text.isInfixOf` Text.toLower (Text.pack s))
+                ["utf-8", "utf8"]
+{-# NOINLINE supportsUnicodeChrome #-}
+
+pickGlyph :: Text -> Text -> Text
+pickGlyph fancy ascii
+    | supportsUnicodeChrome = fancy
+    | otherwise = ascii
+
+glyphTool, glyphToolOut, glyphToolAccent, glyphOk, glyphErr :: Text
+glyphWarn, glyphCancel, glyphSession, glyphThink :: Text
+glyphTool = pickGlyph "◆ " "* "
+glyphToolOut = pickGlyph "┊ " "| "
+glyphToolAccent = pickGlyph "❙ " "| "
+glyphOk = pickGlyph "✓ " "+ "
+glyphErr = pickGlyph "✗ " "x "
+glyphWarn = pickGlyph "⚠ " "! "
+glyphCancel = pickGlyph "⊘ " "o "
+glyphSession = pickGlyph "⧉ " "# "
+glyphThink = pickGlyph "◌ " ". "
+
+spinnerFrames :: [Text]
+spinnerFrames
+    | supportsUnicodeChrome =
+        ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
+    | otherwise =
+        ["|", "/", "-", "\\"]
+
+data ColorLevel = ColorNone | ColorBasic | Color256 | ColorTrue
+    deriving (Eq, Ord, Show)
+
+detectColorLevel :: IO ColorLevel
+detectColorLevel = do
+    noColor <- lookupEnv "NO_COLOR"
+    case noColor of
+        Just _ -> pure ColorNone
+        Nothing -> do
+            colorterm <- lookupEnv "COLORTERM"
+            term <- lookupEnv "TERM"
+            pure $ case fmap Text.toLower (Text.pack <$> colorterm) of
+                Just ct | ct `elem` ["truecolor", "24bit"] -> ColorTrue
+                _ -> case Text.pack <$> term of
+                    Just t
+                        | "256color" `Text.isInfixOf` t -> Color256
+                        | "color" `Text.isInfixOf` t -> ColorBasic
+                        | otherwise -> ColorBasic
+                    Nothing -> ColorTrue
+
+adaptSgr :: ColorLevel -> [SGR] -> [SGR]
+adaptSgr ColorTrue attrs = attrs
+adaptSgr ColorNone _ = []
+adaptSgr _ attrs = map adaptOne attrs
+
+adaptOne :: SGR -> SGR
+adaptOne = \case
+    SetRGBColor layer colour -> SetPaletteColor layer (rgbToXterm256 colour)
+    other -> other
+
+rgbToXterm256 :: Colour Float -> Word8
+rgbToXterm256 colour =
+    let RGB r g b = toSRGB24 colour
+        mx = maximum [r, g, b]
+        mn = minimum [r, g, b]
+    in if fromIntegral (mx - mn) < (24 :: Double)
+        then grayIndex (fromIntegral r)
+        else cubeIndex r g b
+  where
+    cubeIndex r g b =
+        let q x = min (5 :: Word8) (x `div` 51)
+        in 16 + 36 * q r + 6 * q g + q b
+    grayIndex avg =
+        let idx = round ((avg - 8) / 10) :: Int
+        in fromIntegral (max 0 (min 23 idx) + 232)
+
+osc8Link :: Bool -> Text -> Text -> Text
+osc8Link color url label
+    | not color || Text.null url = label
+    | otherwise =
+        "\ESC]8;;" <> url <> "\ESC\\" <> label <> "\ESC]8;;\ESC\\"
 
 -- | Window title: session name when known, otherwise the working directory.
 cliWindowTitle :: FilePath -> Maybe Text -> Text

--- a/packages/agent-cli/test/Agent/CLI/MarkdownSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/MarkdownSpec.hs
@@ -1,8 +1,18 @@
 module Agent.CLI.MarkdownSpec (spec) where
 
 import Agent.CLI.Markdown (renderMarkdown)
+import Data.Text (Text)
 import qualified Data.Text as Text
 import Test.Hspec
+
+stripAnsi :: Text -> Text
+stripAnsi text = case Text.break (== '\ESC') text of
+    (before, rest)
+        | Text.null rest -> before
+        | otherwise ->
+            let afterEsc = Text.drop 1 rest
+                dropped = Text.drop 1 (Text.dropWhile (/= 'm') afterEsc)
+            in before <> stripAnsi dropped
 
 spec :: Spec
 spec = do
@@ -82,6 +92,25 @@ spec = do
             let out = renderMarkdown True "# see `Render.hs`"
             out `shouldSatisfy` Text.isInfixOf "Render.hs"
             out `shouldSatisfy` (not . Text.isInfixOf "`Render.hs`")
+
+        it "keeps box borders aligned when cells have inline markers" do
+            let mdTable = Text.unlines
+                    [ "| a | b |"
+                    , "| --- | --- |"
+                    , "| **x** | `y` |"
+                    ]
+                out = renderMarkdown True mdTable
+                cleaned =
+                    map stripAnsi
+                        (filter (not . Text.null . Text.strip) (Text.lines out))
+                body =
+                    [ l
+                    | l <- cleaned
+                    , "│" `Text.isInfixOf` l
+                    , not ("─" `Text.isInfixOf` l)
+                    ]
+            length body `shouldBe` 2
+            Text.length (head body) `shouldBe` Text.length (body !! 1)
 
         it "renders a basic pipe table" do
             let sample = "| file | status |\n| --- | --- |\n| a.hs | ok |"

--- a/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
@@ -38,8 +38,10 @@ spec = do
 
     describe "truncateToolOutput" do
         it "keeps the first line and marks empty output" do
-            truncateToolOutput "Exit code: 0\nhello" `shouldBe` "┊ Exit code: 0"
-            truncateToolOutput "   " `shouldBe` "┊ (empty)"
+            truncateToolOutput "Exit code: 0\nhello"
+                `shouldSatisfy` ("Exit code: 0" `Text.isSuffixOf`)
+            truncateToolOutput "   "
+                `shouldSatisfy` ("(empty)" `Text.isSuffixOf`)
 
     describe "formatLoopError" do
         it "explains a max-turn stop" do
@@ -69,7 +71,7 @@ spec = do
                 let lines_ = filter (not . Text.null) (Text.lines body)
                 length lines_ `shouldBe` 80
                 lines_ `shouldMatchList`
-                    [ "▸ list_dir packages/agent-" <> Text.pack (show i)
+                    [ "◆ list_dir packages/agent-" <> Text.pack (show i)
                     | i <- [1 :: Int .. 80]
                     ]
 
@@ -83,10 +85,10 @@ spec = do
                 visibleAfter `shouldBe` False
                 hClose handle
                 body <- Text.readFile path
-                body `shouldSatisfy` ("◌ thinking…" `Text.isPrefixOf`)
+                body `shouldSatisfy` (Text.isInfixOf "thinking…")
                 -- Clear uses CR + erase, so the tool summary shares the buffer
                 -- line with the status text rather than starting a new line.
-                body `shouldSatisfy` ("▸ list_dir ." `Text.isInfixOf`)
+                body `shouldSatisfy` ("◆ list_dir ." `Text.isInfixOf`)
 
         it "ignores reasoning deltas" do
             withRenderConfig True False \config handle path -> do
@@ -94,7 +96,7 @@ spec = do
                 renderEvent config (ReasoningDelta "secret plan")
                 hClose handle
                 body <- Text.readFile path
-                body `shouldBe` "◌ thinking…"
+                body `shouldSatisfy` (Text.isInfixOf "thinking…")
 
         it "buffers colored TextDelta until TurnFinished" do
             withRenderConfig False True \config handle path -> do
@@ -148,7 +150,7 @@ spec = do
                 renderEvent config TurnStarted
                 hClose handle
                 body <- Text.readFile path
-                body `shouldBe` "◌ thinking…"
+                body `shouldSatisfy` (Text.isInfixOf "thinking…")
 
 withRenderConfig
     :: Bool
@@ -158,6 +160,8 @@ withRenderConfig
 withRenderConfig showThinking color action = do
     printed <- newIORef False
     thinking <- newIORef False
+    spinner <- newIORef Nothing
+    modelRef <- newIORef "test-model"
     textBuffer <- newIORef ""
     lock <- newMVar ()
     tmp <- getTemporaryDirectory
@@ -167,11 +171,14 @@ withRenderConfig showThinking color action = do
         let config = RenderConfig
                 { renderShowThinking = showThinking
                 , renderThinkingVisible = thinking
+                , renderThinkingSpinner = spinner
                 , renderColor = color
                 , renderPrintedText = printed
                 , renderTextBuffer = textBuffer
                 , renderLock = lock
                 , renderStdout = handle
                 , renderStderr = handle
+                , renderModelRef = modelRef
                 }
         action config handle path
+        clearThinking config

--- a/packages/agent-cli/test/Agent/CLI/StyleSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/StyleSpec.hs
@@ -45,14 +45,16 @@ spec = do
 
     describe "chrome glyphs" do
         it "exposes the shared Unicode markers" do
-            glyphTool `shouldBe` "▸ "
-            glyphOk `shouldBe` "✓ "
-            glyphErr `shouldBe` "✗ "
-            glyphWarn `shouldBe` "⚠ "
-            glyphCancel `shouldBe` "⊘ "
-            glyphSession `shouldBe` "⧉ "
-            glyphThink `shouldBe` "◌ "
-            glyphToolOut `shouldBe` "┊ "
+            glyphTool `shouldSatisfy` (`elem` ["◆ ", "* "])
+            glyphToolAccent `shouldSatisfy` (`elem` ["❙ ", "| "])
+            glyphOk `shouldSatisfy` (`elem` ["✓ ", "+ "])
+            glyphErr `shouldSatisfy` (`elem` ["✗ ", "x "])
+            glyphWarn `shouldSatisfy` (`elem` ["⚠ ", "! "])
+            glyphCancel `shouldSatisfy` (`elem` ["⊘ ", "o "])
+            glyphSession `shouldSatisfy` (`elem` ["⧉ ", "# "])
+            glyphThink `shouldSatisfy` (`elem` ["◌ ", ". "])
+            glyphToolOut `shouldSatisfy` (`elem` ["┊ ", "| "])
+            spinnerFrames `shouldSatisfy` (not . null)
 
     describe "cliWindowTitle" do
         it "uses the cwd basename when no session title is set" do


### PR DESCRIPTION
## Summary

- **Tool chrome**: `◆` bullets + `❙ ┊` accented output lines (ASCII fallbacks)
- **Thinking spinner**: braille frames while a turn runs
- **Turn status footer**: `✓ ok · model · N turns` / `⊘ cancelled` / `✗ error`
- **Markdown tables**: box-drawing borders
- **OSC-8** hyperlinks on markdown links
- **Color helpers**: `detectColorLevel` / `adaptSgr` for truecolor→256 downgrade
- **Glyph fallbacks** when the locale is not UTF-8

Deferred (follow-ups): fence syntax highlighting (skylighting nix dep), foldable tool cards, themes, fullscreen TUI.

## Test plan
- [x] `cabal test agent-cli:agent-cli-test` (in dedicated worktree)
- [ ] Reload REPL: tools show `◆`, thinking animates, turn ends with status footer
- [ ] Markdown table renders with `┌─┬─┐` borders
- [ ] Cmd-click markdown links in iTerm/Ghostty (OSC-8)