### PR TITLE
feat: hard-deny rm -rf shell commands even under yolo

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -88,6 +88,7 @@ import Agent.Tools.PlanMode
     , planModeReminder
     , writePlanMarkdown
     )
+import Agent.Tools.Dangerous (shellCommandBlocked)
 import Agent.Tools.Types (AppTool(..), ToolEnv(..), defaultToolEnv, toolAllowsWithoutPrompt)
 import Agent.OpenRouter.LoopBackend (openRouterBackend)
 import qualified Agent.OpenRouter.Options as OpenRouter
@@ -924,46 +925,53 @@ approveToolDecision policyRef tools planMode call projectRoot = do
     policy <- readIORef policyRef
     planActive <- isPlanModeActive planMode
     planPath <- planFilePath planMode
-    -- Plan mode: reject mutating file edits except plan.md (even under yolo).
-    -- Grok search_replace also enforces this in-tool; this covers apply_patch
-    -- and any other write tool before dispatch.
-    blocked <- planModeBlocksCall planMode planActive planPath call
-    if blocked
-        then do
-            let msg = planModeBlockedEditMessage planPath
+    -- Hard deny for catastrophic shell deletes, even under ApproveAll / yolo.
+    case shellCommandBlocked call.name call.arguments of
+        Just msg -> do
             color <- resolveColor stderr
-            putTextLn stderr (roleWarn color msg)
+            putTextLn stderr (roleWarn color (glyphWarn <> msg))
             pure (Left msg)
-        else do
-            readOnly <- case lookupAppTool call.name tools of
-                Nothing -> pure False
-                Just tool -> toolAllowsWithoutPrompt tool call
-            -- plan.md edits are auto-approved while plan mode is active.
-            planFileOk <- isPlanFileWrite planMode planActive planPath call
-            if planFileOk
-                then pure (Right True)
-                else case policy of
-                    ApproveAll -> pure (Right True)
-                    DenyMutating -> pure (Right readOnly)
-                    PromptMutating
-                        | readOnly -> pure (Right True)
-                        | otherwise -> do
-                            color <- resolveColor stderr
-                            let question =
-                                    roleWarn color
-                                        (glyphWarn <> "Allow " <> summarizeToolCall call <> "? [y/N/a] ")
-                            readApprovalLine question >>= \case
-                                Nothing -> pure (Right False)
-                                Just raw -> case parseApprovalAnswer raw of
-                                    AllowOnce -> pure (Right True)
-                                    AllowAlways -> do
-                                        writeIORef policyRef ApproveAll
-                                        saveProjectAutoApprove projectRoot True
-                                        putTextLn stderr
-                                            (roleSuccess color
-                                                glyphOk <> "auto-approve on (saved for project)")
-                                        pure (Right True)
-                                    Deny -> pure (Right False)
+        Nothing -> do
+            -- Plan mode: reject mutating file edits except plan.md (even under yolo).
+            -- Grok search_replace also enforces this in-tool; this covers apply_patch
+            -- and any other write tool before dispatch.
+            blocked <- planModeBlocksCall planMode planActive planPath call
+            if blocked
+                then do
+                    let msg = planModeBlockedEditMessage planPath
+                    color <- resolveColor stderr
+                    putTextLn stderr (roleWarn color msg)
+                    pure (Left msg)
+                else do
+                    readOnly <- case lookupAppTool call.name tools of
+                        Nothing -> pure False
+                        Just tool -> toolAllowsWithoutPrompt tool call
+                    -- plan.md edits are auto-approved while plan mode is active.
+                    planFileOk <- isPlanFileWrite planMode planActive planPath call
+                    if planFileOk
+                        then pure (Right True)
+                        else case policy of
+                            ApproveAll -> pure (Right True)
+                            DenyMutating -> pure (Right readOnly)
+                            PromptMutating
+                                | readOnly -> pure (Right True)
+                                | otherwise -> do
+                                    color <- resolveColor stderr
+                                    let question =
+                                            roleWarn color
+                                                (glyphWarn <> "Allow " <> summarizeToolCall call <> "? [y/N/a] ")
+                                    readApprovalLine question >>= \case
+                                        Nothing -> pure (Right False)
+                                        Just raw -> case parseApprovalAnswer raw of
+                                            AllowOnce -> pure (Right True)
+                                            AllowAlways -> do
+                                                writeIORef policyRef ApproveAll
+                                                saveProjectAutoApprove projectRoot True
+                                                putTextLn stderr
+                                                    (roleSuccess color
+                                                        glyphOk <> "auto-approve on (saved for project)")
+                                                pure (Right True)
+                                            Deny -> pure (Right False)
 
 planModeBlocksCall :: PlanModeEnv -> Bool -> FilePath -> ToolCall -> IO Bool
 planModeBlocksCall _planMode active planPath call

--- a/packages/agent-core/agent-core.cabal
+++ b/packages/agent-core/agent-core.cabal
@@ -43,6 +43,7 @@ library
                     , Agent.Tools
                     , Agent.Tools.ApplyPatch
                     , Agent.Tools.Codex
+                    , Agent.Tools.Dangerous
                     , Agent.Tools.Grok
                     , Agent.Tools.Grok.Prompt
                     , Agent.Tools.Grok.Shell
@@ -81,6 +82,7 @@ test-suite agent-core-test
                     , Agent.ToolArgsSpec
                     , Agent.ToolDispatchSpec
                     , Agent.Tools.CodexSpec
+                    , Agent.Tools.DangerousSpec
                     , Agent.Tools.GrokSpec
                     , Agent.Tools.GhciSpec
                     , Agent.Tools.IOSpec

--- a/packages/agent-core/src/Agent/Tools/Codex.hs
+++ b/packages/agent-core/src/Agent/Tools/Codex.hs
@@ -20,6 +20,7 @@ import Agent.ToolDSL
 import Agent.ToolDispatch (ToolHandler, typedTool)
 import Agent.Tools.ApplyPatch (applyPatch)
 import Agent.Tools.Ghci (GhciSession, runGhciTool)
+import Agent.Tools.Dangerous (forbiddenRmRfReason, commandLooksLikeRmRf)
 import Agent.Tools.IO (CommandResult(..), resolveUnderCwd, runShellCommand)
 import Agent.Tools.PlanMode
     ( PlanModeEnv
@@ -110,29 +111,33 @@ shellDescription =
     \- Always set the `workdir` param when using the shell_command function. Do not use `cd` unless absolutely necessary."
 
 runShell :: ToolEnv -> ShellCommandArgs -> IO (Either Text Text)
-runShell env args = do
-    let timeoutMs = min 300000 (max 1 (fromMaybe 10000 args.timeoutMs))
-    workdir <- case args.workdir of
-        Nothing -> pure (Right env.toolCwd)
-        Just dir -> resolveUnderCwd env (Text.unpack dir)
-    case workdir of
-        Left err -> pure (Left err)
-        Right dir -> do
-            result <- runShellCommand env dir (Text.unpack args.command) timeoutMs
-            if result.commandCancelled
-                then pure $ Left "Error: Command cancelled"
-                else if result.commandTimedOut
-                then pure $ Left $
-                    "Error: Command timed out after " <> Text.pack (show timeoutMs) <> "ms"
-                else
-                    let code = fromMaybe 1 result.commandExitCode
-                        body
-                            | Text.null result.commandStderr = result.commandStdout
-                            | Text.null result.commandStdout = result.commandStderr
-                            | otherwise =
-                                result.commandStdout <> "\nstderr:\n" <> result.commandStderr
-                    in pure $ Right $
-                        "Exit code: " <> Text.pack (show code) <> "\n" <> body
+runShell env args
+    | commandLooksLikeRmRf args.command =
+        pure (Left (forbiddenRmRfReason args.command))
+    | otherwise = do
+        let timeoutMs = min 300000 (max 1 (fromMaybe 10000 args.timeoutMs))
+        workdir <- case args.workdir of
+            Nothing -> pure (Right env.toolCwd)
+            Just dir -> resolveUnderCwd env (Text.unpack dir)
+        case workdir of
+            Left err -> pure (Left err)
+            Right dir -> do
+                result <- runShellCommand env dir (Text.unpack args.command) timeoutMs
+                if result.commandCancelled
+                    then pure $ Left "Error: Command cancelled"
+                    else if result.commandTimedOut
+                    then pure $ Left $
+                        "Error: Command timed out after " <> Text.pack (show timeoutMs) <> "ms"
+                    else
+                        let code = fromMaybe 1 result.commandExitCode
+                            body
+                                | Text.null result.commandStderr = result.commandStdout
+                                | Text.null result.commandStdout = result.commandStderr
+                                | otherwise =
+                                    result.commandStdout <> "\nstderr:\n" <> result.commandStderr
+                        in pure $ Right $
+                            "Exit code: " <> Text.pack (show code) <> "\n" <> body
+
 
 --------------------------------------------------------------------------------
 -- apply_patch

--- a/packages/agent-core/src/Agent/Tools/Dangerous.hs
+++ b/packages/agent-core/src/Agent/Tools/Dangerous.hs
@@ -1,0 +1,122 @@
+-- | Hard-deny patterns for shell tools, even under auto-approve / yolo.
+--
+-- Inspired by Grok Build's "always-approve + deny rules" and Codex's forbidden
+-- exec-policy prefixes. First cut blocks recursive force deletes.
+module Agent.Tools.Dangerous
+    ( shellCommandBlocked
+    , commandLooksLikeRmRf
+    , forbiddenRmRfReason
+    ) where
+
+import Data.Char (isAlphaNum, toLower)
+import Data.Text (Text)
+import qualified Data.Text as Text
+
+-- | If @toolName@ is a shell tool and @argumentsJson@ contains a forbidden
+-- command, return a rejection message for the model. Otherwise 'Nothing'.
+shellCommandBlocked :: Text -> Text -> Maybe Text
+shellCommandBlocked toolName argumentsJson
+    | toolName `elem` ["run_terminal_cmd", "shell_command"] =
+        case jsonStringField "command" argumentsJson of
+            Nothing -> Nothing
+            Just command
+                | commandLooksLikeRmRf command ->
+                    Just (forbiddenRmRfReason command)
+                | otherwise -> Nothing
+    | otherwise = Nothing
+
+forbiddenRmRfReason :: Text -> Text
+forbiddenRmRfReason command =
+    "Blocked dangerous shell command (rm -rf / recursive force delete). "
+        <> "Remove files more narrowly, or ask the user to run the delete outside the agent. "
+        <> "Command: "
+        <> Text.take 200 (Text.strip command)
+
+-- | Best-effort detection for recursive force deletes.
+--
+-- Splits on common shell chain/pipe separators so @ls && rm -rf tmp@ is still
+-- caught. Looks for an @rm@ invocation whose flags include both recursive and
+-- force (any order, clustered or separate: @-rf@, @-fr@, @-r -f@, long opts).
+commandLooksLikeRmRf :: Text -> Bool
+commandLooksLikeRmRf command =
+    any segmentLooksLikeRmRf (splitShellSegments command)
+
+splitShellSegments :: Text -> [Text]
+splitShellSegments =
+    filter (not . Text.null . Text.strip)
+        . Text.split (\c -> c == ';' || c == '|' || c == '&' || c == '\n')
+
+segmentLooksLikeRmRf :: Text -> Bool
+segmentLooksLikeRmRf segment =
+    case dropEnvPrefixes (tokenize segment) of
+        (cmd : rest)
+            | isRmCommand cmd -> flagsHaveRecursiveForce rest
+        _ -> False
+
+-- | Strip leading @VAR=val@ assignments and common wrappers (@sudo@, @env@,
+-- @command@, @nice@, @nohup@, @time@).
+dropEnvPrefixes :: [Text] -> [Text]
+dropEnvPrefixes = go
+  where
+    go [] = []
+    go (t : ts)
+        | Text.any (== '=') t
+            && not (Text.isPrefixOf "-" t)
+            && Text.all isEnvAssignChar (Text.takeWhile (/= '=') t) =
+            go ts
+        | Text.toLower t `elem` wrappers = go ts
+        | otherwise = t : ts
+    wrappers = ["sudo", "env", "command", "nice", "nohup", "time", "stdbuf"]
+    isEnvAssignChar c = isAlphaNum c || c == '_'
+
+isRmCommand :: Text -> Bool
+isRmCommand cmd =
+    let base = Text.toLower (Text.takeWhileEnd (/= '/') cmd)
+    in base == "rm" || base == "rm.exe"
+
+flagsHaveRecursiveForce :: [Text] -> Bool
+flagsHaveRecursiveForce args =
+    let flags = takeWhile isFlag args
+        clustered = Text.concat (map stripDashes flags)
+        lower = Text.map toLower clustered
+        hasR = Text.any (== 'r') lower || any isLongRecursive flags
+        hasF = Text.any (== 'f') lower || any isLongForce flags
+    in hasR && hasF
+  where
+    isFlag t = Text.isPrefixOf "-" t
+    stripDashes = Text.dropWhile (== '-')
+    isLongRecursive t =
+        let x = Text.toLower t
+        in x == "--recursive" || Text.isPrefixOf "--recursive=" x
+    isLongForce t =
+        let x = Text.toLower t
+        in x == "--force" || Text.isPrefixOf "--force=" x
+
+tokenize :: Text -> [Text]
+tokenize = filter (not . Text.null) . Text.words
+
+-- | Minimal JSON string-field extractor for @{"command":"..."}@ payloads.
+-- Avoids pulling aeson into this leaf helper; sufficient for our tool args.
+jsonStringField :: Text -> Text -> Maybe Text
+jsonStringField key raw =
+    let needle = "\"" <> key <> "\""
+    in case Text.breakOn needle raw of
+        (_, rest)
+            | Text.null rest -> Nothing
+            | otherwise ->
+                let afterKey = Text.drop (Text.length needle) rest
+                    afterColon = Text.dropWhile (\c -> c == ' ' || c == '\t' || c == '\n' || c == ':') afterKey
+                in parseJsonString afterColon
+
+parseJsonString :: Text -> Maybe Text
+parseJsonString t = case Text.uncons t of
+    Just ('"', rest) -> go rest ""
+    _ -> Nothing
+  where
+    go txt acc = case Text.uncons txt of
+        Nothing -> Nothing
+        Just ('"', _) -> Just (Text.reverse acc)
+        Just ('\\', rest) -> case Text.uncons rest of
+            Just (c, rest') -> go rest' (Text.cons c acc)
+            Nothing -> Nothing
+        Just (c, rest) -> go rest (Text.cons c acc)

--- a/packages/agent-core/src/Agent/Tools/Dangerous.hs
+++ b/packages/agent-core/src/Agent/Tools/Dangerous.hs
@@ -93,7 +93,29 @@ flagsHaveRecursiveForce args =
         in x == "--force" || Text.isPrefixOf "--force=" x
 
 tokenize :: Text -> [Text]
-tokenize = filter (not . Text.null) . Text.words
+tokenize = map Text.pack . go [] . Text.unpack
+  where
+    go acc [] = reverse (filter (not . null) acc)
+    go acc cs =
+        let cs' = dropWhile isHorzSpace cs
+        in case cs' of
+            [] -> reverse (filter (not . null) acc)
+            '\'' : rest ->
+                let (body, after) = break (== '\'') rest
+                    rest' = case after of
+                        '\'' : more -> more
+                        _ -> after
+                in go (body : acc) rest'
+            '"' : rest ->
+                let (body, after) = break (== '"') rest
+                    rest' = case after of
+                        '"' : more -> more
+                        _ -> after
+                in go (body : acc) rest'
+            _ ->
+                let (tok, rest) = break isHorzSpace cs'
+                in go (tok : acc) rest
+    isHorzSpace c = c == ' ' || c == '\t' || c == '\n'
 
 -- | Minimal JSON string-field extractor for @{"command":"..."}@ payloads.
 -- Avoids pulling aeson into this leaf helper; sufficient for our tool args.

--- a/packages/agent-core/src/Agent/Tools/Grok.hs
+++ b/packages/agent-core/src/Agent/Tools/Grok.hs
@@ -51,6 +51,7 @@ import Agent.Tools.PlanMode
     , planFilePath
     , planModeBlockedEditMessage
     )
+import Agent.Tools.Dangerous (commandLooksLikeRmRf, forbiddenRmRfReason)
 import Agent.Tools.Types
     ( AppTool(..)
     , AppToolKind(..)
@@ -728,6 +729,8 @@ runTerminal :: GrokSession -> TerminalArgs -> IO (Either Text Text)
 runTerminal session args
     | Text.null args.description =
         pure (Left "Missing parameter: description")
+    | commandLooksLikeRmRf args.command =
+        pure (Left (forbiddenRmRfReason args.command))
     | not args.background && hasUnwaitedBackgroundOp args.command =
         pure $ Left
             "The command contains a background '&'. Set background=true to run it as a background task, or append `wait` if you meant to wait for the children."

--- a/packages/agent-core/test/Agent/Tools/CodexSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/CodexSpec.hs
@@ -113,6 +113,13 @@ spec = describe "Agent.Tools.Codex" do
                 ]
         parsed `shouldSatisfy` either (const False) ((== 3) . length)
 
+    it "rejects rm -rf via shell_command even before execution" do
+        withTempEnv \env -> do
+            output <- runFn env "shell_command"
+                "{\"command\":\"rm -rf /tmp/should-not-run\",\"workdir\":\".\"}"
+            output `shouldSatisfy` Text.isInfixOf "Blocked dangerous shell command"
+            output `shouldSatisfy` Text.isInfixOf "rm -rf"
+
     it "runs shell_command and times out" do
         withTempEnv \env -> do
             output <- runFn env "shell_command"

--- a/packages/agent-core/test/Agent/Tools/DangerousSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/DangerousSpec.hs
@@ -1,31 +1,86 @@
 module Agent.Tools.DangerousSpec (spec) where
 
-import Agent.Tools.Dangerous (shellCommandBlocked)
+import Agent.Tools.Dangerous
+    ( commandLooksLikeRmRf
+    , forbiddenRmRfReason
+    , shellCommandBlocked
+    )
 import qualified Data.Text as Text
 import Test.Hspec
 
 spec :: Spec
-spec = describe "shellCommandBlocked" do
-    it "blocks rm -rf / rm -fr / separate flags" do
-        shouldBlock "run_terminal_cmd" "{\"command\":\"rm -rf /tmp/x\"}"
-        shouldBlock "shell_command" "{\"command\":\"rm -fr ./build\"}"
-        shouldBlock "run_terminal_cmd" "{\"command\":\"rm -r -f out\"}"
-        shouldBlock "run_terminal_cmd" "{\"command\":\"rm --recursive --force out\"}"
+spec = do
+    describe "commandLooksLikeRmRf" do
+        it "detects clustered and split short flags" do
+            commandLooksLikeRmRf "rm -rf /tmp/x" `shouldBe` True
+            commandLooksLikeRmRf "rm -fr ./build" `shouldBe` True
+            commandLooksLikeRmRf "rm -r -f out" `shouldBe` True
+            commandLooksLikeRmRf "rm -f -r out" `shouldBe` True
+            commandLooksLikeRmRf "rm -Rf /tmp/x" `shouldBe` True
+            commandLooksLikeRmRf "rm -vfr cache" `shouldBe` True
 
-    it "blocks chained and wrapped forms" do
-        shouldBlock "run_terminal_cmd" "{\"command\":\"ls && rm -rf tmp\"}"
-        shouldBlock "run_terminal_cmd" "{\"command\":\"sudo rm -rf /var/tmp/x\"}"
-        shouldBlock "run_terminal_cmd" "{\"command\":\"FOO=1 rm -rf ./cache\"}"
+        it "detects long options" do
+            commandLooksLikeRmRf "rm --recursive --force out" `shouldBe` True
+            commandLooksLikeRmRf "rm --force --recursive out" `shouldBe` True
 
-    it "allows non-force recursive rm and unrelated commands" do
-        shouldAllow "run_terminal_cmd" "{\"command\":\"rm -r build\"}"
-        shouldAllow "run_terminal_cmd" "{\"command\":\"rm file.txt\"}"
-        shouldAllow "run_terminal_cmd" "{\"command\":\"ls -la\"}"
-        shouldAllow "run_terminal_cmd" "{\"command\":\"git status\"}"
+        it "detects absolute rm paths and .exe" do
+            commandLooksLikeRmRf "/bin/rm -rf /tmp/x" `shouldBe` True
+            commandLooksLikeRmRf "rm.exe -rf C:\\Temp\\x" `shouldBe` True
 
-    it "ignores non-shell tools" do
-        shellCommandBlocked "search_replace" "{\"command\":\"rm -rf x\"}"
-            `shouldBe` Nothing
+        it "detects chained and piped forms" do
+            commandLooksLikeRmRf "ls && rm -rf tmp" `shouldBe` True
+            commandLooksLikeRmRf "true; rm -rf tmp" `shouldBe` True
+            commandLooksLikeRmRf "echo hi | rm -rf tmp" `shouldBe` True
+            commandLooksLikeRmRf "rm -rf a || true" `shouldBe` True
+
+        it "detects common wrappers and env assignments" do
+            commandLooksLikeRmRf "sudo rm -rf /var/tmp/x" `shouldBe` True
+            commandLooksLikeRmRf "env rm -rf ./cache" `shouldBe` True
+            commandLooksLikeRmRf "FOO=1 BAR=2 rm -rf ./cache" `shouldBe` True
+            commandLooksLikeRmRf "nohup rm -rf ./cache" `shouldBe` True
+            commandLooksLikeRmRf "command rm -rf ./cache" `shouldBe` True
+
+        it "allows safe rm and unrelated commands" do
+            commandLooksLikeRmRf "rm -r build" `shouldBe` False
+            commandLooksLikeRmRf "rm -f file.txt" `shouldBe` False
+            commandLooksLikeRmRf "rm file.txt" `shouldBe` False
+            commandLooksLikeRmRf "ls -la" `shouldBe` False
+            commandLooksLikeRmRf "git status" `shouldBe` False
+            commandLooksLikeRmRf "echo 'rm -rf tmp'" `shouldBe` False
+            commandLooksLikeRmRf "echo \"rm -rf tmp\"" `shouldBe` False
+            commandLooksLikeRmRf "rmdir empty-dir" `shouldBe` False
+            commandLooksLikeRmRf "rclone sync --force" `shouldBe` False
+            -- Nested shells are out of scope for this best-effort gate.
+            commandLooksLikeRmRf "bash -lc 'rm -rf tmp'" `shouldBe` False
+
+    describe "shellCommandBlocked" do
+        it "blocks shell tools with a clear reason" do
+            shouldBlock "run_terminal_cmd" "{\"command\":\"rm -rf /tmp/x\"}"
+            shouldBlock "shell_command" "{\"command\":\"rm -fr ./build\"}"
+            shouldBlock "run_terminal_cmd" "{\"command\":\"ls && rm -rf tmp\"}"
+
+        it "includes a truncated command snippet in the reason" do
+            let msg = forbiddenRmRfReason "rm -rf /tmp/very-important"
+            msg `shouldSatisfy` Text.isInfixOf "Blocked dangerous shell command"
+            msg `shouldSatisfy` Text.isInfixOf "rm -rf /tmp/very-important"
+
+        it "parses JSON with whitespace around the command value" do
+            shouldBlock "run_terminal_cmd" "{\"command\" : \"rm -rf x\"}"
+
+        it "allows non-matching shell commands" do
+            shouldAllow "run_terminal_cmd" "{\"command\":\"rm -r build\"}"
+            shouldAllow "run_terminal_cmd" "{\"command\":\"rm file.txt\"}"
+            shouldAllow "shell_command" "{\"command\":\"ls -la\"}"
+
+        it "ignores non-shell tools even if arguments look dangerous" do
+            shellCommandBlocked "search_replace" "{\"command\":\"rm -rf x\"}"
+                `shouldBe` Nothing
+            shellCommandBlocked "read_file" "{\"command\":\"rm -rf x\"}"
+                `shouldBe` Nothing
+
+        it "does nothing when the command field is missing" do
+            shellCommandBlocked "run_terminal_cmd" "{\"description\":\"nope\"}"
+                `shouldBe` Nothing
 
   where
     shouldBlock tool args =

--- a/packages/agent-core/test/Agent/Tools/DangerousSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/DangerousSpec.hs
@@ -1,0 +1,36 @@
+module Agent.Tools.DangerousSpec (spec) where
+
+import Agent.Tools.Dangerous (shellCommandBlocked)
+import qualified Data.Text as Text
+import Test.Hspec
+
+spec :: Spec
+spec = describe "shellCommandBlocked" do
+    it "blocks rm -rf / rm -fr / separate flags" do
+        shouldBlock "run_terminal_cmd" "{\"command\":\"rm -rf /tmp/x\"}"
+        shouldBlock "shell_command" "{\"command\":\"rm -fr ./build\"}"
+        shouldBlock "run_terminal_cmd" "{\"command\":\"rm -r -f out\"}"
+        shouldBlock "run_terminal_cmd" "{\"command\":\"rm --recursive --force out\"}"
+
+    it "blocks chained and wrapped forms" do
+        shouldBlock "run_terminal_cmd" "{\"command\":\"ls && rm -rf tmp\"}"
+        shouldBlock "run_terminal_cmd" "{\"command\":\"sudo rm -rf /var/tmp/x\"}"
+        shouldBlock "run_terminal_cmd" "{\"command\":\"FOO=1 rm -rf ./cache\"}"
+
+    it "allows non-force recursive rm and unrelated commands" do
+        shouldAllow "run_terminal_cmd" "{\"command\":\"rm -r build\"}"
+        shouldAllow "run_terminal_cmd" "{\"command\":\"rm file.txt\"}"
+        shouldAllow "run_terminal_cmd" "{\"command\":\"ls -la\"}"
+        shouldAllow "run_terminal_cmd" "{\"command\":\"git status\"}"
+
+    it "ignores non-shell tools" do
+        shellCommandBlocked "search_replace" "{\"command\":\"rm -rf x\"}"
+            `shouldBe` Nothing
+
+  where
+    shouldBlock tool args =
+        case shellCommandBlocked tool args of
+            Just msg -> msg `shouldSatisfy` Text.isInfixOf "Blocked dangerous shell command"
+            Nothing -> expectationFailure ("expected block for " <> Text.unpack args)
+    shouldAllow tool args =
+        shellCommandBlocked tool args `shouldBe` Nothing

--- a/packages/agent-core/test/Agent/Tools/GrokSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/GrokSpec.hs
@@ -116,6 +116,13 @@ spec = describe "Agent.Tools.Grok" do
             output `shouldNotSatisfy` Text.isInfixOf "hit.md"
             output `shouldNotSatisfy` Text.isInfixOf "No such file or directory"
 
+    it "rejects rm -rf via run_terminal_cmd even before execution" do
+        withTempSession \(session, ghci) -> do
+            output <- runTool session ghci "run_terminal_cmd"
+                "{\"command\":\"rm -rf /tmp/should-not-run\",\"description\":\"dangerous delete\"}"
+            output `shouldSatisfy` Text.isInfixOf "Blocked dangerous shell command"
+            output `shouldSatisfy` Text.isInfixOf "rm -rf"
+
     it "runs a foreground shell command" do
         withTempSession \(session, ghci) -> do
             output <- runTool session ghci "run_terminal_cmd"

--- a/packages/agent-core/test/Spec.hs
+++ b/packages/agent-core/test/Spec.hs
@@ -8,6 +8,7 @@ import qualified Agent.ToolArgsSpec as ToolArgsSpec
 import qualified Agent.ToolDispatchSpec as ToolDispatchSpec
 import qualified Agent.ToolDSLSpec as ToolDSLSpec
 import qualified Agent.Tools.CodexSpec as CodexToolsSpec
+import qualified Agent.Tools.DangerousSpec as DangerousSpec
 import qualified Agent.Tools.GrokSpec as GrokToolsSpec
 import qualified Agent.Tools.GhciSpec as GhciSpec
 import qualified Agent.Tools.IOSpec as IOSpec
@@ -27,4 +28,5 @@ main = hspec do
     GhciSpec.spec
     IOSpec.spec
     CodexToolsSpec.spec
+    DangerousSpec.spec
     WebSocketSpec.spec


### PR DESCRIPTION
## Summary
- Add `Agent.Tools.Dangerous` to detect recursive force deletes (`rm -rf`, `-fr`, `-r -f`, `--recursive --force`).
- Reject matching `run_terminal_cmd` / `shell_command` calls **even under `ApproveAll` / yolo**, mirroring Grok’s “always-approve + deny” and Codex forbidden prefixes.
- Also guard the Codex/Grok shell runners so the deny cannot be bypassed if approval is skipped.
- Best-effort chain splitting (`&&`, `||`, `;`, `|`) and common wrappers (`sudo`, `env`, `VAR=…`).

## Test plan
- [x] `cabal test agent-core:agent-core-test` (includes `DangerousSpec`)
- [x] `cabal test agent-cli:agent-cli-test`
- [ ] With `/always-approve` on, ask the agent to `rm -rf` something and confirm it is blocked with a clear message