### PR TITLE
feat: default 8GiB RTS heap cap for agent and repl

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,16 @@ Same `withArgs ... run` / `:q` / `:r` loop. Dependency packages are linked as bu
 - Use `ghcid` for typecheck-on-save; keep `cabal repl` + `withArgs ... run` for running the live agent.
 - Prefer `repl` when you want automatic `:reload` + session resume instead of the manual `:q` / `:r` / `run` loop.
 
+### memory / RTS heap cap
+
+`nix develop` and the `repl` wrapper default `GHCRTS` to `-M8G -A64m` so the agent/GHCi process dies at an 8 GiB heap instead of OOMing the whole machine. The `agent-cli` executable is built with the same `-M8G -A64m` RTS defaults (overridable via `+RTS` because `-rtsopts` is enabled). Override when needed:
+
+```
+GHCRTS='-M16G -A64m' repl
+GHCRTS='-M4G -A32m' cabal repl agent-cli
+cabal run agent-cli -- +RTS -M16G -RTS
+```
+
 
 # haskell
 - Prefer Control.Exception.Safe over Control.Exception

--- a/flake.nix
+++ b/flake.nix
@@ -125,6 +125,11 @@
                       echo "repl: missing $script" >&2
                       exit 1
                     fi
+                    # Cap the agent/GHCi heap so a runaway session OOMs itself
+                    # instead of the whole machine. Override with GHCRTS=...
+                    if [ -z "''${GHCRTS:-}" ]; then
+                      export GHCRTS="-M8G -A64m"
+                    fi
                     cabal="${haskellPackages.cabal-install}/bin/cabal"
                     expect_bin="${pkgs.expect}/bin/expect"
                     export AGENT_REPL_SCRIPT="$script"
@@ -185,6 +190,14 @@
                             ripgrep
                         ])
                         ++ [ agentRepl ];
+                    # Default RTS heap ceiling for GHCi / agent runs started from
+                    # this shell (including `cabal repl` and `cabal run`). The
+                    # `repl` wrapper sets the same default if GHCRTS is unset.
+                    shellHook = ''
+                      if [ -z "''${GHCRTS:-}" ]; then
+                        export GHCRTS="-M8G -A64m"
+                      fi
+                    '';
                 };
 
                 checks = {

--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -74,7 +74,7 @@ executable agent-cli
     import:           common-options
     hs-source-dirs:   app
     main-is:          Main.hs
-    ghc-options:      -threaded -rtsopts -with-rtsopts=-N
+    ghc-options:      -threaded -rtsopts "-with-rtsopts=-N -M8G -A64m"
     build-depends:    agent-cli
                     , base >= 4.17 && < 5
 


### PR DESCRIPTION
## Summary
After an OOM laptop crash, cap the agent/GHCi heap by default:

- `nix develop` `shellHook` sets `GHCRTS=-M8G -A64m` when unset
- `repl` wrapper sets the same default before spawning `cabal repl`
- `agent-cli` executable `-with-rtsopts` includes `-N -M8G -A64m` (still overridable via `+RTS` / `GHCRTS`)

Documented overrides in `AGENTS.md`.

## Test plan
- [x] `nix flake check --no-build`
- [x] `nix-instantiate --parse flake.nix`
- [ ] `nix develop` then `echo $GHCRTS` → `-M8G -A64m`
- [ ] `repl` starts normally; `GHCRTS='-M4G' repl` overrides
- [ ] Optional: force a large allocation and confirm the process dies with a heap-exhaustion error instead of wedging the machine