### PR TITLE
feat: default xAI model to grok-4.6

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Prompt.hs
+++ b/packages/agent-cli/src/Agent/CLI/Prompt.hs
@@ -14,7 +14,7 @@ import Data.Time.Format (defaultTimeLocale, formatTime)
 
 defaultModelFor :: Provider -> Text
 defaultModelFor = \case
-    XAIProvider -> "grok-4.5"
+    XAIProvider -> "grok-4.6"
     OpenAIProvider -> "gpt-5.1-codex"
     OpenRouterProvider -> "openai/gpt-5.1"
 

--- a/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
@@ -67,12 +67,12 @@ spec = do
             parseReplLine "  /Model  " `shouldBe` ReplShowModel
 
         it "sets a model name" do
-            parseReplLine "/model grok-4.5" `shouldBe` ReplSetModel "grok-4.5"
+            parseReplLine "/model grok-4.6" `shouldBe` ReplSetModel "grok-4.6"
             parseReplLine "/model openai/gpt-5.1"
                 `shouldBe` ReplSetModel "openai/gpt-5.1"
 
         it "rejects extra args on /model" do
-            parseReplLine "/model grok-4.5 extra"
+            parseReplLine "/model grok-4.6 extra"
                 `shouldBe` ReplCommandError "usage: /model [NAME]"
 
         it "enters plan mode with optional description" do
@@ -128,9 +128,9 @@ spec = do
 
     describe "setModel" do
         it "writes the model onto request params" do
-            let updated = setModel "grok-4.5" defaultResponseCreateParams
-            currentModel updated `shouldBe` "grok-4.5"
-            updated.model `shouldBe` Just "grok-4.5"
+            let updated = setModel "grok-4.6" defaultResponseCreateParams
+            currentModel updated `shouldBe` "grok-4.6"
+            updated.model `shouldBe` Just "grok-4.6"
 
         it "preserves other request fields" do
             let original = case defaultResponseCreateParams of

--- a/packages/agent-cli/test/Agent/CLI/OptionsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/OptionsSpec.hs
@@ -16,7 +16,7 @@ spec = do
         it "parses one-shot flags" do
             parseArgs
                 [ "--provider", "xai"
-                , "--model", "grok-4.5"
+                , "--model", "grok-4.6"
                 , "--cwd", "/tmp/work"
                 , "--yolo"
                 , "--max-turns", "3"
@@ -25,7 +25,7 @@ spec = do
                 ]
                 `shouldBe` Right (RunAgent defaultCliOptions
                     { optProvider = Just XAIProvider
-                    , optModel = Just "grok-4.5"
+                    , optModel = Just "grok-4.6"
                     , optCwd = Just "/tmp/work"
                     , optYolo = True
                     , optMaxTurns = 3

--- a/packages/agent-cli/test/Agent/CLI/PromptSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/PromptSpec.hs
@@ -55,6 +55,6 @@ spec = describe "systemPrompt" do
         grok `shouldSatisfy` Text.isInfixOf "Pure expressions do not need user approval"
 
     it "picks the documented default models" do
-        defaultModelFor XAIProvider `shouldBe` "grok-4.5"
+        defaultModelFor XAIProvider `shouldBe` "grok-4.6"
         defaultModelFor OpenAIProvider `shouldBe` "gpt-5.1-codex"
         defaultModelFor OpenRouterProvider `shouldBe` "openai/gpt-5.1"

--- a/packages/agent-xai/README.md
+++ b/packages/agent-xai/README.md
@@ -25,7 +25,7 @@ import Agent.OpenAI.Responses.Types
 import Agent.XAI
 
 request = defaultResponseCreateParams
-    { model = Just "grok-4.5"
+    { model = Just "grok-4.6"
     , input = Just (ResponseInputText "Hello")
     }
 

--- a/packages/agent-xai/src/Agent/XAI/Options.hs
+++ b/packages/agent-xai/src/Agent/XAI/Options.hs
@@ -27,7 +27,7 @@ defaultClientOptions :: ClientOptions
 defaultClientOptions = ClientOptions
     { baseUrl = "https://cli-chat-proxy.grok.com/v1"
     , modelOverrides = []
-    , defaultModel = "grok-4.5"
+    , defaultModel = "grok-4.6"
     , requestTimeoutSeconds = 600
     , clientVersion = "0.2.118"
     }

--- a/packages/agent-xai/test/Agent/XAI/ClientSpec.hs
+++ b/packages/agent-xai/test/Agent/XAI/ClientSpec.hs
@@ -40,7 +40,7 @@ spec = do
             request.path `shouldBe` "/v1/responses"
             lookup "Authorization" request.headers `shouldBe` Just "Bearer token-a"
             lookup "X-XAI-Token-Auth" request.headers `shouldBe` Just "xai-grok-cli"
-            requestModel request `shouldBe` Just "grok-4.5"
+            requestModel request `shouldBe` Just "grok-4.6"
             -- instructions travel as the leading system item
             (inputRoles <$> requestBodyObject request) `shouldBe` Just ["system", "user"]
 
@@ -54,7 +54,7 @@ spec = do
                         , "response" Aeson..= Aeson.object
                             [ "id" Aeson..= ("resp-failed" :: Text)
                             , "created_at" Aeson..= (0 :: Int)
-                            , "model" Aeson..= ("grok-4.5" :: Text)
+                            , "model" Aeson..= ("grok-4.6" :: Text)
                             , "status" Aeson..= ("failed" :: Text)
                             , "incomplete_details" Aeson..= Aeson.object
                                 ["reason" Aeson..= ("overloaded" :: Text)]
@@ -186,7 +186,7 @@ completedEvent responseId output = sseEvent "response.completed" $ Aeson.object
     , "response" Aeson..= Aeson.object
         [ "id" Aeson..= responseId
         , "created_at" Aeson..= (0 :: Int)
-        , "model" Aeson..= ("grok-4.5" :: Text)
+        , "model" Aeson..= ("grok-4.6" :: Text)
         , "status" Aeson..= ("completed" :: Text)
         , "output" Aeson..= output
         , "usage" Aeson..= Aeson.object

--- a/packages/agent-xai/test/Agent/XAI/LoopBackendSpec.hs
+++ b/packages/agent-xai/test/Agent/XAI/LoopBackendSpec.hs
@@ -108,7 +108,7 @@ spec = do
 --------------------------------------------------------------------------------
 
 baseParams :: ResponseCreateParams
-baseParams = defaultResponseCreateParams { model = Just "grok-4.5" }
+baseParams = defaultResponseCreateParams { model = Just "grok-4.6" }
 
 withEffort :: Text -> ResponseCreateParams -> ResponseCreateParams
 withEffort effort ResponseCreateParams { reasoning = _, .. } =
@@ -201,7 +201,7 @@ testResponse :: Text -> [ResponseItem] -> Response
 testResponse responseId output = case Aeson.fromJSON $ Aeson.object
     [ "id" Aeson..= responseId
     , "created_at" Aeson..= (0 :: Int)
-    , "model" Aeson..= ("grok-4.5" :: Text)
+    , "model" Aeson..= ("grok-4.6" :: Text)
     , "status" Aeson..= ("completed" :: Text)
     , "output" Aeson..= output
     ] of

--- a/packages/agent-xai/test/Agent/XAI/ResponsesSpec.hs
+++ b/packages/agent-xai/test/Agent/XAI/ResponsesSpec.hs
@@ -19,19 +19,19 @@ spec = do
     describe "mapModel" do
         it "prefers exact overrides, passes grok names through, and falls back otherwise" do
             let options = defaultClientOptions
-                    { modelOverrides = [("gpt-5.6-sol", "grok-4.5-mini")]
-                    , defaultModel = "grok-4.5"
+                    { modelOverrides = [("gpt-5.6-sol", "grok-4.6-mini")]
+                    , defaultModel = "grok-4.6"
                     }
-            mapModel options "gpt-5.6-sol" `shouldBe` "grok-4.5-mini"
+            mapModel options "gpt-5.6-sol" `shouldBe` "grok-4.6-mini"
             mapModel options "grok-3" `shouldBe` "grok-3"
-            mapModel options "gpt-5.6-terra" `shouldBe` "grok-4.5"
+            mapModel options "gpt-5.6-terra" `shouldBe` "grok-4.6"
 
     describe "buildRequest" do
         it "maps canonical Responses fields onto the Grok proxy dialect" do
             let value = requestValue defaultClientOptions sampleRequest
             object <- expectObject value
 
-            KeyMap.lookup "model" object `shouldBe` Just (Aeson.String "grok-4.5")
+            KeyMap.lookup "model" object `shouldBe` Just (Aeson.String "grok-4.6")
             KeyMap.lookup "store" object `shouldBe` Just (Aeson.Bool False)
             KeyMap.lookup "stream" object `shouldBe` Just (Aeson.Bool True)
             KeyMap.lookup "reasoning" object `shouldBe` Just (Aeson.object
@@ -161,7 +161,7 @@ spec = do
                     [ sseBlock "response.output_item.done"
                         "{\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"type\":\"function_call\",\"call_id\":\"call-1\",\"name\":\"echo\",\"arguments\":\"{}\"}}"
                     , sseBlock "response.completed"
-                        "{\"type\":\"response.completed\",\"response\":{\"id\":\"resp-1\",\"created_at\":0,\"model\":\"grok-4.5\",\"status\":\"completed\",\"output\":[],\"usage\":{\"input_tokens\":10,\"output_tokens\":5,\"total_tokens\":15}}}"
+                        "{\"type\":\"response.completed\",\"response\":{\"id\":\"resp-1\",\"created_at\":0,\"model\":\"grok-4.6\",\"status\":\"completed\",\"output\":[],\"usage\":{\"input_tokens\":10,\"output_tokens\":5,\"total_tokens\":15}}}"
                     ]
             events <- expectRight (parseSseEvents sse)
             map responseStreamEventType events
@@ -174,7 +174,7 @@ spec = do
 
         it "reads the event type from the data object when no event line exists" do
             events <- expectRight $ parseSseEvents
-                "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp-2\",\"created_at\":0,\"model\":\"grok-4.5\",\"status\":\"completed\"}}\n\n"
+                "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp-2\",\"created_at\":0,\"model\":\"grok-4.6\",\"status\":\"completed\"}}\n\n"
             map responseStreamEventType events `shouldBe` [EventResponseCompleted]
 
         it "surfaces typed stream errors" do
@@ -185,7 +185,7 @@ spec = do
 
         it "maps response.failed and missing completion to transport-level errors" do
             failedEvents <- expectRight $ parseSseEvents $ sseBlock "response.failed"
-                "{\"type\":\"response.failed\",\"response\":{\"id\":\"resp-f\",\"created_at\":0,\"model\":\"grok-4.5\",\"status\":\"failed\",\"incomplete_details\":{\"reason\":\"overloaded\"}}}"
+                "{\"type\":\"response.failed\",\"response\":{\"id\":\"resp-f\",\"created_at\":0,\"model\":\"grok-4.6\",\"status\":\"failed\",\"incomplete_details\":{\"reason\":\"overloaded\"}}}"
             case buildResponse failedEvents of
                 Left (ConnectionError message) ->
                     message `shouldSatisfy` Text.isInfixOf "overloaded"


### PR DESCRIPTION
## Summary
- Bump the default xAI / Grok model from `grok-4.5` to `grok-4.6` in `agent-xai` and the CLI.
- Update README example and unit-test fixtures to match.

Existing `grok-*` names still pass through unchanged; `grok-4.5` remains selectable via `--model` / `/model`.

## Test plan
- [x] `cabal test agent-xai agent-cli`
- [ ] Start the agent without `--model` and confirm it reports / uses `grok-4.6`