### PR TITLE
feat: default OpenAI model to gpt-5.6-luna

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Prompt.hs
+++ b/packages/agent-cli/src/Agent/CLI/Prompt.hs
@@ -15,7 +15,7 @@ import Data.Time.Format (defaultTimeLocale, formatTime)
 defaultModelFor :: Provider -> Text
 defaultModelFor = \case
     XAIProvider -> "grok-4.5"
-    OpenAIProvider -> "gpt-5.1-codex"
+    OpenAIProvider -> "gpt-5.6-luna"
     OpenRouterProvider -> "openai/gpt-5.1"
 
 -- | @isNonInteractive@ is True for one-shot @-p@ (no human in the loop).

--- a/packages/agent-cli/test/Agent/CLI/PromptSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/PromptSpec.hs
@@ -56,5 +56,5 @@ spec = describe "systemPrompt" do
 
     it "picks the documented default models" do
         defaultModelFor XAIProvider `shouldBe` "grok-4.5"
-        defaultModelFor OpenAIProvider `shouldBe` "gpt-5.1-codex"
+        defaultModelFor OpenAIProvider `shouldBe` "gpt-5.6-luna"
         defaultModelFor OpenRouterProvider `shouldBe` "openai/gpt-5.1"

--- a/packages/agent-openai/README.md
+++ b/packages/agent-openai/README.md
@@ -27,7 +27,7 @@ main = do
     provider <- poolTokenProvider pool
 
     let request = defaultResponseCreateParams
-            { model = Just "gpt-5.1-codex"
+            { model = Just "gpt-5.6-luna"
             , instructions = Just "You are a helpful assistant."
             , input = Just (ResponseInputText "Say hi")
             , reasoning = Just ReasoningConfig

--- a/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
@@ -130,7 +130,7 @@ spec = do
                 }
             [(request, previous)] <- readIORef seen
             previous `shouldBe` Just "resp-prev"
-            request.model `shouldBe` Just "gpt-5.1-codex"
+            request.model `shouldBe` Just "gpt-5.6-luna"
             request.input `shouldBe` Just (ResponseInputItems (turnInputsToItems [UserMessage "hello"]))
             reverse <$> readIORef events `shouldReturn` [TextDelta "ok"]
 
@@ -194,7 +194,7 @@ spec = do
 --------------------------------------------------------------------------------
 
 baseParams :: ResponseCreateParams
-baseParams = defaultResponseCreateParams { model = Just "gpt-5.1-codex" }
+baseParams = defaultResponseCreateParams { model = Just "gpt-5.6-luna" }
 
 withEffort :: Text -> ResponseCreateParams -> ResponseCreateParams
 withEffort effort ResponseCreateParams { reasoning = _, .. } =


### PR DESCRIPTION
## Summary
- Change `defaultModelFor OpenAIProvider` from `gpt-5.1-codex` to `gpt-5.6-luna`.
- Update PromptSpec, OpenAI LoopBackendSpec fixtures, and the OpenAI README example.

OpenRouter default is unchanged (`openai/gpt-5.1`). Existing sessions keep their stored model until `/model` is changed.

## Test plan
- [x] `cabal test agent-cli:agent-cli-test`
- [ ] Start with `--provider openai` and confirm `/model` shows `gpt-5.6-luna`
- [ ] Smoke a short turn / tool call on OpenAI