### PR TITLE
feat: interactive /model picker for the CLI REPL

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -42,6 +42,8 @@ library
                     , Agent.CLI.Command
                     , Agent.CLI.Input
                     , Agent.CLI.Markdown
+                    , Agent.CLI.ModelPicker
+                    , Agent.CLI.Models
                     , Agent.CLI.Options
                     , Agent.CLI.Plan
                     , Agent.CLI.Project
@@ -89,6 +91,8 @@ test-suite agent-cli-test
                     , Agent.CLI.CommandSpec
                     , Agent.CLI.InputSpec
                     , Agent.CLI.MarkdownSpec
+                    , Agent.CLI.ModelPickerSpec
+                    , Agent.CLI.ModelsSpec
                     , Agent.CLI.OptionsSpec
                     , Agent.CLI.PlanSpec
                     , Agent.CLI.ProjectSpec

--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -16,6 +16,7 @@ import Agent.CLI.Clipboard
     )
 import Agent.CLI.Command
 import Agent.CLI.Input (readApprovalLine, readReplLine)
+import Agent.CLI.ModelPicker (pickModel)
 import Agent.CLI.Options
 import Agent.CLI.Plan
     ( cliPlanHooks
@@ -652,35 +653,24 @@ repl config render provider previous printed paramsRef policyRef transcriptRef p
                                             (Right handle { sessionMeta = meta })
                         continue
                     ReplShowModel -> do
+                        color <- resolveColor stderr
                         params <- readIORef paramsRef
-                        Text.putStrLn (glyphSession <> "model: " <> currentModel params)
-                        continue
+                        let current = currentModel params
+                        pickModel color provider current >>= \case
+                            Nothing -> continue
+                            Just name
+                                | name == current -> do
+                                    Text.putStrLn
+                                        (roleMuted color
+                                            (glyphSession <> "model: " <> name))
+                                    continue
+                                | otherwise -> do
+                                    applyModelChange
+                                        provider name paramsRef render previous persist
+                                    continue
                     ReplSetModel name -> do
-                        modifyIORef' paramsRef (setModel name)
-                        writeIORef render.renderModelRef name
-                        clearedChain <- case provider of
-                            OpenAIProvider ->
-                                atomicModifyIORef' previous \prev ->
-                                    (Nothing, isJust prev)
-                            _ -> pure False
-                        if clearedChain
-                            then Text.putStrLn
-                                ("model set to " <> name
-                                    <> " (conversation continued locally)")
-                            else Text.putStrLn ("model set to " <> name)
-                        case persist of
-                            Nothing -> pure ()
-                            Just slotRef -> do
-                                slot <- readIORef slotRef
-                                case slot of
-                                    Left pending ->
-                                        writeIORef slotRef
-                                            (Left pending { createModel = name })
-                                    Right handle -> do
-                                        let meta = handle.sessionMeta { metaModel = name }
-                                        writeSessionMeta handle.sessionMetaPath meta
-                                        writeIORef slotRef
-                                            (Right handle { sessionMeta = meta })
+                        applyModelChange
+                            provider name paramsRef render previous persist
                         continue
                     ReplToggleAlwaysApprove -> do
                         toggleAlwaysApprove policyRef projectRoot
@@ -718,6 +708,44 @@ repl config render provider previous printed paramsRef policyRef transcriptRef p
         repl config render provider previous printed paramsRef policyRef
             transcriptRef persist planMode projectRoot tokenProvider agentsContext
             escPaused attachmentsRef
+
+applyModelChange
+    :: Provider
+    -> Text
+    -> IORef ResponseCreateParams
+    -> RenderConfig
+    -> IORef (Maybe Text)
+    -> Maybe (IORef (Either SessionCreate SessionHandle))
+    -> IO ()
+applyModelChange provider name paramsRef render previous persist = do
+    color <- resolveColor stdout
+    modifyIORef' paramsRef (setModel name)
+    writeIORef render.renderModelRef name
+    clearedChain <- case provider of
+        OpenAIProvider ->
+            atomicModifyIORef' previous \prev ->
+                (Nothing, isJust prev)
+        _ -> pure False
+    if clearedChain
+        then Text.putStrLn
+            (roleMuted color
+                (glyphOk <> "model set to " <> name
+                    <> " (conversation continued locally)"))
+        else Text.putStrLn
+            (roleMuted color (glyphOk <> "model set to " <> name))
+    case persist of
+        Nothing -> pure ()
+        Just slotRef -> do
+            slot <- readIORef slotRef
+            case slot of
+                Left pending ->
+                    writeIORef slotRef
+                        (Left pending { createModel = name })
+                Right handle -> do
+                    let meta = handle.sessionMeta { metaModel = name }
+                    writeSessionMeta handle.sessionMetaPath meta
+                    writeIORef slotRef
+                        (Right handle { sessionMeta = meta })
 
 reloadAuth :: Provider -> Maybe TokenProvider -> IO ()
 reloadAuth provider = \case

--- a/packages/agent-cli/src/Agent/CLI/ModelPicker.hs
+++ b/packages/agent-cli/src/Agent/CLI/ModelPicker.hs
@@ -1,0 +1,270 @@
+-- | Interactive TTY model picker for bare @/model@.
+module Agent.CLI.ModelPicker
+    ( pickModel
+    , formatCatalogListing
+    , renderPickerFrame
+    , decodePickerKey
+    ) where
+
+import Agent.CLI.Models
+import Agent.CLI.Style
+    ( glyphOk
+    , roleMuted
+    , rolePrompt
+    , roleSuccess
+    , roleWarn
+    )
+import Agent.Provider (Provider, providerSlug)
+import Control.Exception.Safe (bracket, throwIO, tryIO)
+import Control.Monad (when)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.IO as Text
+import System.Console.ANSI (hHideCursor, hShowCursor)
+import System.Console.ANSI.Codes
+    ( clearLineCode
+    , cursorUpCode
+    )
+import System.IO
+    ( BufferMode(..)
+    , Handle
+    , hFlush
+    , hGetBuffering
+    , hGetChar
+    , hIsTerminalDevice
+    , hPutStr
+    , hSetBuffering
+    , hWaitForInput
+    , stderr
+    , stdin
+    )
+import System.IO.Error (isEOFError)
+import System.Posix.IO (stdInput)
+import System.Posix.Terminal
+    ( TerminalAttributes
+    , TerminalMode(..)
+    , TerminalState(..)
+    , getTerminalAttributes
+    , setTerminalAttributes
+    , withMinInput
+    , withMode
+    , withTime
+    , withoutMode
+    )
+
+-- | Open the picker when stdin is a TTY; otherwise print the catalog.
+-- Returns @Just name@ on confirm, @Nothing@ on cancel / EOF / non-TTY.
+pickModel :: Bool -> Provider -> Text -> IO (Maybe Text)
+pickModel color provider current = do
+    isTty <- hIsTerminalDevice stdin
+    if not isTty
+        then do
+            Text.hPutStrLn stderr (formatCatalogListing color provider current)
+            hFlush stderr
+            pure Nothing
+        else runInteractivePicker color provider current
+
+formatCatalogListing :: Bool -> Provider -> Text -> Text
+formatCatalogListing color provider current =
+    let state = initialPickerState provider current
+        header =
+            roleMuted color
+                (glyphSessionLike
+                    <> "model: "
+                    <> current
+                    <> " · "
+                    <> providerSlug provider)
+        rows =
+            map
+                (\opt ->
+                    let mark
+                            | opt.modelId == current =
+                                roleSuccess color (glyphOk <> opt.modelId)
+                            | otherwise = roleMuted color ("  " <> opt.modelId)
+                        label = case opt.modelLabel of
+                            Nothing -> ""
+                            Just l -> roleMuted color ("  " <> l)
+                    in mark <> label)
+                state.pickerAll
+    in Text.intercalate "\n" (header : rows)
+
+-- | Pure frame used by the interactive loop (and tests).
+renderPickerFrame :: Bool -> PickerState -> Text
+renderPickerFrame color state =
+    let visible = visibleOptions state
+        n = length visible
+        idx = if n == 0 then 0 else min state.pickerIndex (n - 1)
+        header =
+            rolePrompt color "model"
+                <> roleMuted color
+                    (" · "
+                        <> providerSlug state.pickerProvider
+                        <> " · current "
+                        <> state.pickerCurrent)
+        filterLine
+            | Text.null state.pickerFilter =
+                roleMuted color "filter: (type to narrow)"
+            | otherwise =
+                roleMuted color "filter: "
+                    <> roleWarn color state.pickerFilter
+        body = case visible of
+            [] -> [roleMuted color "(no matches)"]
+            opts ->
+                zipWith
+                    (\i opt -> renderRow color (i == idx) state.pickerCurrent opt)
+                    [0 ..]
+                    opts
+        footer =
+            roleMuted color "↑↓/jk · enter · esc/q · type to filter"
+    in Text.intercalate "\n" (header : filterLine : body <> [footer])
+
+renderRow :: Bool -> Bool -> Text -> ModelOption -> Text
+renderRow color selected current opt =
+    let cursor = if selected then roleWarn color "› " else "  "
+        name
+            | selected = roleSuccess color opt.modelId
+            | otherwise = roleMuted color opt.modelId
+        currentMark
+            | opt.modelId == current = roleSuccess color " ✓"
+            | otherwise = ""
+        label = case opt.modelLabel of
+            Nothing -> ""
+            Just l -> roleMuted color ("  " <> l)
+    in cursor <> name <> currentMark <> label
+
+-- | Decode one keypress (including CSI arrow sequences) into a picker event.
+decodePickerKey :: String -> Maybe PickerEvent
+decodePickerKey = \case
+    "\n" -> Just PickerConfirm
+    "\r" -> Just PickerConfirm
+    "\ESC" -> Just PickerCancel
+    "q" -> Just PickerCancel
+    "Q" -> Just PickerCancel
+    "k" -> Just PickerUp
+    "K" -> Just PickerUp
+    "j" -> Just PickerDown
+    "J" -> Just PickerDown
+    "\ESC[A" -> Just PickerUp
+    "\ESC[B" -> Just PickerDown
+    "\ESC[OA" -> Just PickerUp
+    "\ESC[OB" -> Just PickerDown
+    "\DEL" -> Just PickerBackspace
+    "\b" -> Just PickerBackspace
+    [c] -> Just (PickerType c)
+    _ -> Nothing
+
+runInteractivePicker :: Bool -> Provider -> Text -> IO (Maybe Text)
+runInteractivePicker color provider current = do
+    let state0 = initialPickerState provider current
+    oldTerm <- getTerminalAttributes stdInput
+    oldBuf <- hGetBuffering stdin
+    let enter = do
+            setTerminalAttributes stdInput (rawAttrs oldTerm) Immediately
+            hSetBuffering stdin NoBuffering
+            hHideCursor stderr
+        restore = do
+            hShowCursor stderr
+            setTerminalAttributes stdInput oldTerm Immediately
+            hSetBuffering stdin oldBuf
+    bracket enter (const restore) \() -> do
+        let frame0 = renderPickerFrame color state0
+            lines0 = frameLineCount frame0
+        drawFrame stderr frame0
+        loop color stderr state0 lines0
+
+loop :: Bool -> Handle -> PickerState -> Int -> IO (Maybe Text)
+loop color h state drawnLines = do
+    mkey <- readPickerKey
+    case mkey of
+        Nothing -> do
+            clearDrawn h drawnLines
+            pure Nothing
+        Just key -> case decodePickerKey key of
+            Nothing -> loop color h state drawnLines
+            Just event -> case applyPickerEvent event state of
+                Left result -> do
+                    clearDrawn h drawnLines
+                    pure result
+                Right state' -> do
+                    let frame = renderPickerFrame color state'
+                        n = frameLineCount frame
+                    redraw h drawnLines frame
+                    loop color h state' n
+
+frameLineCount :: Text -> Int
+frameLineCount frame =
+    length (Text.splitOn "\n" frame)
+
+drawFrame :: Handle -> Text -> IO ()
+drawFrame h frame = do
+    Text.hPutStr h frame
+    Text.hPutStr h "\n"
+    hFlush h
+
+redraw :: Handle -> Int -> Text -> IO ()
+redraw h drawnLines frame = do
+    when (drawnLines > 0) do
+        hPutStr h (cursorUpCode drawnLines)
+    mapM_ (redrawLine h) (Text.splitOn "\n" frame)
+    -- Clear any leftover lines if the new frame is shorter.
+    let newLines = frameLineCount frame
+    when (drawnLines > newLines) do
+        mapM_ (\_ -> do
+            hPutStr h clearLineCode
+            Text.hPutStr h "\n")
+            [1 .. drawnLines - newLines]
+        hPutStr h (cursorUpCode (drawnLines - newLines))
+    hFlush h
+
+redrawLine :: Handle -> Text -> IO ()
+redrawLine h line = do
+    hPutStr h clearLineCode
+    Text.hPutStr h line
+    Text.hPutStr h "\n"
+
+clearDrawn :: Handle -> Int -> IO ()
+clearDrawn h drawnLines = when (drawnLines > 0) do
+    hPutStr h (cursorUpCode drawnLines)
+    mapM_ (\_ -> do
+        hPutStr h clearLineCode
+        Text.hPutStr h "\n")
+        [1 .. drawnLines]
+    hPutStr h (cursorUpCode drawnLines)
+    hFlush h
+
+readPickerKey :: IO (Maybe String)
+readPickerKey = do
+    result <- tryIO (hGetChar stdin)
+    case result of
+        Left err
+            | isEOFError err -> pure Nothing
+            | otherwise -> throwIO err
+        Right '\ESC' -> do
+            -- Distinguish bare Esc from CSI / SS3 arrow sequences.
+            more <- hWaitForInput stdin 50
+            if not more
+                then pure (Just "\ESC")
+                else do
+                    c2 <- hGetChar stdin
+                    case c2 of
+                        '[' -> do
+                            c3 <- hGetChar stdin
+                            pure (Just ['\ESC', '[', c3])
+                        'O' -> do
+                            c3 <- hGetChar stdin
+                            pure (Just ['\ESC', 'O', c3])
+                        _ -> pure (Just ['\ESC', c2])
+        Right c -> pure (Just [c])
+
+rawAttrs :: TerminalAttributes -> TerminalAttributes
+rawAttrs oldTerm =
+    flip withMinInput 1
+        . flip withTime 0
+        . flip withoutMode EnableEcho
+        . flip withoutMode ProcessInput
+        . flip withMode KeyboardInterrupts
+        $ oldTerm
+
+-- Matches Style.glyphSession without pulling unicode env probing here.
+glyphSessionLike :: Text
+glyphSessionLike = "⧉ "

--- a/packages/agent-cli/src/Agent/CLI/Models.hs
+++ b/packages/agent-cli/src/Agent/CLI/Models.hs
@@ -1,0 +1,164 @@
+-- | Curated model catalogs and pure picker navigation helpers.
+module Agent.CLI.Models
+    ( ModelOption(..)
+    , PickerState(..)
+    , PickerEvent(..)
+    , modelsForProvider
+    , ensureCurrentInList
+    , initialPickerState
+    , visibleOptions
+    , selectedOption
+    , applyPickerEvent
+    ) where
+
+import Agent.CLI.Prompt (defaultModelFor)
+import Agent.Provider (Provider(..))
+import Data.List (find)
+import Data.Maybe (fromMaybe)
+import Data.Text (Text)
+import qualified Data.Text as Text
+
+data ModelOption = ModelOption
+    { modelId :: !Text
+    , modelLabel :: !(Maybe Text)
+    }
+    deriving (Eq, Show)
+
+-- | Interactive picker state. @pickerIndex@ indexes into 'visibleOptions'.
+data PickerState = PickerState
+    { pickerProvider :: !Provider
+    , pickerCurrent :: !Text
+    , pickerAll :: ![ModelOption]
+    , pickerFilter :: !Text
+    , pickerIndex :: !Int
+    }
+    deriving (Eq, Show)
+
+data PickerEvent
+    = PickerUp
+    | PickerDown
+    | PickerConfirm
+    | PickerCancel
+    | PickerBackspace
+    | PickerType Char
+    deriving (Eq, Show)
+
+modelsForProvider :: Provider -> [ModelOption]
+modelsForProvider provider =
+    let opts = case provider of
+            XAIProvider ->
+                [ opt "grok-4.6" (Just "default")
+                , opt "grok-4.5" Nothing
+                , opt "grok-4.5-mini" (Just "faster")
+                , opt "grok-3" Nothing
+                ]
+            OpenAIProvider ->
+                [ opt "gpt-5.1-codex" (Just "default")
+                , opt "gpt-5.1-codex-mini" (Just "faster")
+                , opt "gpt-5.1" Nothing
+                , opt "o3" Nothing
+                ]
+            OpenRouterProvider ->
+                [ opt "openai/gpt-5.1" (Just "default")
+                , opt "anthropic/claude-sonnet-4" Nothing
+                , opt "x-ai/grok-4" Nothing
+                , opt "google/gemini-2.5-pro" Nothing
+                ]
+        -- Keep the provider default first even if the table drifts.
+        def = defaultModelFor provider
+    in ensureCurrentInList def opts
+  where
+    opt mid label = ModelOption { modelId = mid, modelLabel = label }
+
+-- | Prepend @current@ when it is missing so the active model stays visible.
+ensureCurrentInList :: Text -> [ModelOption] -> [ModelOption]
+ensureCurrentInList current options
+    | Text.null current || current == "(unset)" = options
+    | any (\opt -> opt.modelId == current) options = options
+    | otherwise =
+        ModelOption { modelId = current, modelLabel = Just "current" }
+            : options
+
+initialPickerState :: Provider -> Text -> PickerState
+initialPickerState provider current =
+    let allOpts = ensureCurrentInList current (modelsForProvider provider)
+        idx = fromMaybe 0 $
+            fmap fst $
+                find (\(_, opt) -> opt.modelId == current) (zip [0 ..] allOpts)
+    in PickerState
+        { pickerProvider = provider
+        , pickerCurrent = current
+        , pickerAll = allOpts
+        , pickerFilter = ""
+        , pickerIndex = idx
+        }
+
+visibleOptions :: PickerState -> [ModelOption]
+visibleOptions state
+    | Text.null needle = state.pickerAll
+    | otherwise =
+        filter
+            (\opt -> needle `Text.isInfixOf` Text.toLower opt.modelId
+                || maybe
+                    False
+                    ((needle `Text.isInfixOf`) . Text.toLower)
+                    opt.modelLabel)
+            state.pickerAll
+  where
+    needle = Text.toLower state.pickerFilter
+
+selectedOption :: PickerState -> Maybe ModelOption
+selectedOption state =
+    case visibleOptions state of
+        [] -> Nothing
+        opts ->
+            let i = clampIndex (length opts) state.pickerIndex
+            in Just (opts !! i)
+
+applyPickerEvent :: PickerEvent -> PickerState -> Either (Maybe Text) PickerState
+applyPickerEvent event state = case event of
+    PickerCancel -> Left Nothing
+    PickerConfirm -> Left ((.modelId) <$> selectedOption state)
+    PickerUp -> Right (move (-1) state)
+    PickerDown -> Right (move 1 state)
+    PickerBackspace ->
+        Right $ clampSelection state
+            { pickerFilter = Text.dropEnd 1 state.pickerFilter
+            , pickerIndex = 0
+            }
+    PickerType c
+        | isFilterChar c ->
+            Right $ clampSelection state
+                { pickerFilter = state.pickerFilter <> Text.singleton c
+                , pickerIndex = 0
+                }
+        | otherwise -> Right state
+
+move :: Int -> PickerState -> PickerState
+move delta state =
+    let n = length (visibleOptions state)
+    in if n == 0
+        then state { pickerIndex = 0 }
+        else
+            let i = clampIndex n state.pickerIndex
+                i' = (i + delta) `mod` n
+            in state { pickerIndex = i' }
+
+clampSelection :: PickerState -> PickerState
+clampSelection state =
+    let n = length (visibleOptions state)
+    in state { pickerIndex = clampIndex n state.pickerIndex }
+
+clampIndex :: Int -> Int -> Int
+clampIndex n i
+    | n <= 0 = 0
+    | i < 0 = 0
+    | i >= n = n - 1
+    | otherwise = i
+
+isFilterChar :: Char -> Bool
+isFilterChar c =
+    c == '-' || c == '/' || c == '.' || c == '_'
+        || (c >= 'a' && c <= 'z')
+        || (c >= 'A' && c <= 'Z')
+        || (c >= '0' && c <= '9')

--- a/packages/agent-cli/src/Agent/CLI/Options.hs
+++ b/packages/agent-cli/src/Agent/CLI/Options.hs
@@ -229,7 +229,7 @@ usage = unlines
     , ""
     , "Without -p/--prompt-file, start a REPL. Interactive REPL sessions are"
     , "persisted under ~/.haskell-agent/sessions. /effort [LEVEL] changes"
-    , "reasoning effort. /model [NAME] shows or changes the model."
+    , "reasoning effort. /model opens the model picker; /model NAME sets it."
     , "/plan [description] enters plan mode (read-only except plan.md);"
     , "when a plan is presented, approve (a), request changes (s), or cancel (q)."
     , "/always-approve (or :yolo) toggles auto-approve and saves it under"

--- a/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
@@ -73,7 +73,7 @@ spec = do
             parseReplLine "/attachments" `shouldBe` ReplShowAttachments
             parseReplLine "/clear-attachments" `shouldBe` ReplClearAttachments
 
-        it "shows the current model with a bare /model" do
+        it "opens the model picker with a bare /model" do
             parseReplLine "/model" `shouldBe` ReplShowModel
             parseReplLine "  /Model  " `shouldBe` ReplShowModel
 

--- a/packages/agent-cli/test/Agent/CLI/ModelPickerSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ModelPickerSpec.hs
@@ -1,0 +1,44 @@
+module Agent.CLI.ModelPickerSpec (spec) where
+
+import Agent.CLI.ModelPicker
+import Agent.CLI.Models
+import Agent.CLI.Prompt (defaultModelFor)
+import Agent.Provider (Provider(..))
+import qualified Data.Text as Text
+import Test.Hspec
+
+spec :: Spec
+spec = do
+    describe "decodePickerKey" do
+        it "maps arrows and vim keys" do
+            decodePickerKey "\ESC[A" `shouldBe` Just PickerUp
+            decodePickerKey "\ESC[B" `shouldBe` Just PickerDown
+            decodePickerKey "k" `shouldBe` Just PickerUp
+            decodePickerKey "j" `shouldBe` Just PickerDown
+
+        it "maps confirm and cancel" do
+            decodePickerKey "\n" `shouldBe` Just PickerConfirm
+            decodePickerKey "\r" `shouldBe` Just PickerConfirm
+            decodePickerKey "\ESC" `shouldBe` Just PickerCancel
+            decodePickerKey "q" `shouldBe` Just PickerCancel
+
+        it "maps filter editing" do
+            decodePickerKey "\DEL" `shouldBe` Just PickerBackspace
+            decodePickerKey "g" `shouldBe` Just (PickerType 'g')
+
+    describe "renderPickerFrame" do
+        it "mentions provider, current model, and controls" do
+            let frame =
+                    renderPickerFrame False $
+                        initialPickerState XAIProvider (defaultModelFor XAIProvider)
+            frame `shouldSatisfy` Text.isInfixOf "xai"
+            frame `shouldSatisfy` Text.isInfixOf (defaultModelFor XAIProvider)
+            frame `shouldSatisfy` Text.isInfixOf "enter"
+            frame `shouldSatisfy` Text.isInfixOf "filter"
+
+    describe "formatCatalogListing" do
+        it "lists the current model and catalog entries" do
+            let listing =
+                    formatCatalogListing False OpenAIProvider "gpt-5.1-codex"
+            listing `shouldSatisfy` Text.isInfixOf "gpt-5.1-codex"
+            listing `shouldSatisfy` Text.isInfixOf "openai"

--- a/packages/agent-cli/test/Agent/CLI/ModelsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ModelsSpec.hs
@@ -1,0 +1,90 @@
+module Agent.CLI.ModelsSpec (spec) where
+
+import Agent.CLI.Models
+import Agent.CLI.Prompt (defaultModelFor)
+import Agent.Provider (Provider(..))
+import Data.Maybe (listToMaybe)
+import qualified Data.Text as Text
+import Test.Hspec
+
+firstId :: [ModelOption] -> Maybe Text.Text
+firstId = fmap (.modelId) . listToMaybe
+
+spec :: Spec
+spec = do
+    describe "modelsForProvider" do
+        it "puts the provider default first" do
+            firstId (modelsForProvider XAIProvider)
+                `shouldBe` Just (defaultModelFor XAIProvider)
+            firstId (modelsForProvider OpenAIProvider)
+                `shouldBe` Just (defaultModelFor OpenAIProvider)
+            firstId (modelsForProvider OpenRouterProvider)
+                `shouldBe` Just (defaultModelFor OpenRouterProvider)
+
+        it "lists several options per provider" do
+            length (modelsForProvider XAIProvider) `shouldSatisfy` (>= 2)
+            length (modelsForProvider OpenAIProvider) `shouldSatisfy` (>= 2)
+            length (modelsForProvider OpenRouterProvider) `shouldSatisfy` (>= 2)
+
+    describe "ensureCurrentInList" do
+        it "prepends an unknown current model" do
+            let base = modelsForProvider XAIProvider
+                opts = ensureCurrentInList "custom-model" base
+            firstId opts `shouldBe` Just "custom-model"
+            fmap (.modelLabel) (listToMaybe opts) `shouldBe` Just (Just "current")
+
+        it "does not duplicate a known current model" do
+            let base = modelsForProvider XAIProvider
+                def = defaultModelFor XAIProvider
+                opts = ensureCurrentInList def base
+            length (filter (\opt -> opt.modelId == def) opts) `shouldBe` 1
+
+        it "ignores unset placeholders" do
+            ensureCurrentInList "(unset)" [ModelOption "a" Nothing]
+                `shouldBe` [ModelOption "a" Nothing]
+
+    describe "picker navigation" do
+        let state0 = initialPickerState XAIProvider (defaultModelFor XAIProvider)
+
+        it "starts on the current model" do
+            fmap (.modelId) (selectedOption state0)
+                `shouldBe` Just (defaultModelFor XAIProvider)
+
+        it "moves down and wraps" do
+            let n = length (visibleOptions state0)
+                down = case applyPickerEvent PickerDown state0 of
+                    Right s -> s
+                    Left _ -> state0
+                walked = foldl
+                    (\s _ -> case applyPickerEvent PickerDown s of
+                        Right s' -> s'
+                        Left _ -> s)
+                    state0
+                    [1 .. n]
+            down.pickerIndex `shouldBe` 1 `mod` max 1 n
+            walked.pickerIndex `shouldBe` state0.pickerIndex
+
+        it "confirms the selected model id" do
+            applyPickerEvent PickerConfirm state0
+                `shouldBe` Left (Just (defaultModelFor XAIProvider))
+
+        it "cancels without a selection" do
+            applyPickerEvent PickerCancel state0 `shouldBe` Left Nothing
+
+        it "filters by typed characters" do
+            let typed =
+                    foldl
+                        (\s c -> case applyPickerEvent (PickerType c) s of
+                            Right s' -> s'
+                            Left _ -> s)
+                        state0
+                        ("mini" :: String)
+            not (null (visibleOptions typed)) `shouldBe` True
+            all
+                (\opt -> "mini" `Text.isInfixOf` Text.toLower opt.modelId
+                    || maybe
+                        False
+                        (("mini" `Text.isInfixOf`) . Text.toLower)
+                        opt.modelLabel)
+                (visibleOptions typed)
+                `shouldBe` True

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -8,6 +8,8 @@ import qualified Agent.CLI.ClipboardSpec as ClipboardSpec
 import qualified Agent.CLI.CommandSpec as CommandSpec
 import qualified Agent.CLI.InputSpec as InputSpec
 import qualified Agent.CLI.MarkdownSpec as MarkdownSpec
+import qualified Agent.CLI.ModelPickerSpec as ModelPickerSpec
+import qualified Agent.CLI.ModelsSpec as ModelsSpec
 import qualified Agent.CLI.OptionsSpec as OptionsSpec
 import qualified Agent.CLI.ProjectSpec as ProjectSpec
 import qualified Agent.CLI.PromptSpec as PromptSpec
@@ -26,6 +28,8 @@ main = hspec do
     CommandSpec.spec
     InputSpec.spec
     MarkdownSpec.spec
+    ModelPickerSpec.spec
+    ModelsSpec.spec
     OptionsSpec.spec
     ProjectSpec.spec
     PromptSpec.spec


### PR DESCRIPTION
## Summary
- Bare `/model` opens a Solarized-styled interactive TTY picker (↑↓/jk, Enter, Esc/q, type-to-filter) over a curated per-provider catalog.
- `/model NAME` still sets arbitrary model ids; non-TTY sessions print the catalog + current model without hanging.
- Selection reuses the existing model-change path (request params, session meta, OpenAI previous-response chain clear).

## Test plan
- [x] `cabal test agent-cli:agent-cli-test` (148 examples, 0 failures)
- [ ] In a TTY REPL, `/model` navigates with arrows/jk, Enter selects, Esc cancels, typing filters
- [ ] `/model some-custom-id` still sets an arbitrary name
- [ ] Confirm session meta / status line update after a picker selection