### PR TITLE
feat: add /compact with Codex remote and Grok local paths

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -39,6 +39,7 @@ library
                     , Agent.CLI.Auth
                     , Agent.CLI.CancelWatch
                     , Agent.CLI.Clipboard
+                    , Agent.CLI.Compaction
                     , Agent.CLI.Command
                     , Agent.CLI.Input
                     , Agent.CLI.Interrupt

--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -15,6 +15,10 @@ import Agent.CLI.Clipboard
     , readClipboardImages
     )
 import Agent.CLI.Command
+import Agent.CLI.Compaction
+    ( CompactOutcome(..)
+    , runProviderCompact
+    )
 import Agent.CLI.Input (ReplLine(..), readApprovalLine, readReplLine)
 import Agent.CLI.Interrupt
     ( InterruptState
@@ -72,6 +76,10 @@ import Agent.ProjectInstructions
     , formatAgentsMdForProvider
     , globalAgentsHomeDir
     , loadedInstructionFiles
+    )
+import Agent.OpenAI.Compaction
+    ( compactSessionUserText
+    , isCompactSessionTurn
     )
 import Agent.OpenAI.LoopBackend (openAiBackend, toolResultToItem)
 import Agent.OpenAI.Responses.Types
@@ -346,7 +354,7 @@ runAgent options = do
                 (schemasFromAppTools provider tools) effort
             policy = resolveApprovalPolicy options isTty
                 projectSettings.settingsAutoApprove
-            initialItems = maybe [] (concatMap (.turnItems) . snd) resumed
+            initialItems = maybe [] (foldSessionItems . snd) resumed
             initialPrevious = resumed >>= \(meta, _) -> meta.metaLastResponseId
         paramsRef <- newIORef params
         transcriptRef <- newIORef initialItems
@@ -394,7 +402,7 @@ runAgent options = do
                                     noticingBackend =
                                         withPendingNotices pendingNotices lockedBackend
                                 runSession options provider policy tools toolEnv planMode prompt paramsRef transcriptRef
-                                    initialPrevious persist projectRoot Nothing agentsContext escPaused interrupt
+                                    initialPrevious persist projectRoot (Just loaded.loadedTokenProvider) agentsContext escPaused interrupt
                                     noticingBackend)
                             >>= \case
                                 Left (CodexAuthFailed err) -> die ("openai auth: " <> show err)
@@ -766,6 +774,45 @@ repl config render provider previous printed paramsRef policyRef transcriptRef p
                     ReplToggleAlwaysApprove -> do
                         toggleAlwaysApprove policyRef projectRoot
                         continue
+                    ReplCompact focus -> do
+                        color <- resolveColor stderr
+                        result <- runProviderCompact provider tokenProvider paramsRef transcriptRef focus
+                        case result of
+                            Left err -> do
+                                Text.hPutStrLn stderr (roleError color err)
+                                continue
+                            Right outcome -> do
+                                writeIORef transcriptRef outcome.compactHistory
+                                writeIORef previous Nothing
+                                Text.hPutStrLn stderr $ roleMuted color $
+                                    glyphSession
+                                        <> "compacted "
+                                        <> Text.pack (show outcome.compactBeforeTokens)
+                                        <> " → "
+                                        <> Text.pack (show outcome.compactAfterTokens)
+                                        <> " tokens ("
+                                        <> Text.pack (show (length outcome.compactHistory))
+                                        <> " items)"
+                                case persist of
+                                    Nothing -> pure ()
+                                    Just slotRef -> do
+                                        now <- getCurrentTime
+                                        handle <- ensureSession slotRef
+                                        let turn = SessionTurn
+                                                { turnAt = now
+                                                , turnUserText = compactSessionUserText focus
+                                                , turnAssistantText = Just outcome.compactSummary
+                                                , turnResponseId = Nothing
+                                                , turnItems = outcome.compactHistory
+                                                }
+                                        handle' <- appendTurn handle turn
+                                        writeIORef slotRef (Right handle')
+                                        writeSessionMeta handle'.sessionMetaPath $
+                                            handle'.sessionMeta
+                                                { metaLastResponseId = Nothing
+                                                , metaUpdatedAt = now
+                                                }
+                                continue
                     ReplPlan maybeDescription -> do
                         enterPlanFromSlash planMode persist maybeDescription
                             config render previous printed transcriptRef agentsContext escPaused interrupt
@@ -1346,6 +1393,18 @@ childApprove policy tools call = case policy of
 -- | Rebuild from the constructor: 'input' is also a field on 'CustomToolCall'.
 -- OpenAI keeps @store = true@ so @previous_response_id@ can continue a chain;
 -- xAI/OpenRouter force @store = false@ and replay local transcripts instead.
+
+-- | Apply compact turns as full transcript replacements when resuming.
+foldSessionItems :: [SessionTurn] -> [ResponseItem]
+foldSessionItems = go []
+  where
+    go acc [] = acc
+    go acc (turn:rest)
+        | isCompactSessionTurn turn.turnUserText
+            && not (null turn.turnItems) =
+            go turn.turnItems rest
+        | otherwise = go (acc <> turn.turnItems) rest
+
 requestParams
     :: Provider
     -> Text

--- a/packages/agent-cli/src/Agent/CLI/Command.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command.hs
@@ -34,6 +34,7 @@ data ReplAction
         }
     | ReplClearAttachments
     | ReplShowAttachments
+    | ReplCompact (Maybe Text)
     | ReplCommandError Text
     deriving (Eq, Show)
 
@@ -73,6 +74,9 @@ parseSlash line = case Text.words line of
             if null args
                 then ReplReloadAuth
                 else ReplCommandError "usage: /reload-auth"
+        | Text.toLower command == "/compact" ->
+            let focus = Text.strip (Text.drop (Text.length command) line)
+            in ReplCompact (if Text.null focus then Nothing else Just focus)
         | Text.toLower command == "/paste" ->
             parsePasteCommand (Text.strip (Text.drop (Text.length command) line))
         | Text.toLower command == "/attachments" ->

--- a/packages/agent-cli/src/Agent/CLI/Compaction.hs
+++ b/packages/agent-cli/src/Agent/CLI/Compaction.hs
@@ -1,0 +1,198 @@
+-- | Run provider compaction and rewrite the local transcript.
+module Agent.CLI.Compaction
+    ( CompactOutcome(..)
+    , runProviderCompact
+    ) where
+
+import Agent.Error (ApiError)
+import Agent.OpenAI.CompactClient
+    ( CompactRequest(..)
+    , compactConversation
+    )
+import Agent.OpenAI.Compaction
+    ( buildLocalCompactedHistory
+    , estimateItemsTokens
+    , summarizationPrompt
+    , userTextItem
+    , userTextItem
+    , userTextItem
+    )
+import Agent.OpenAI.LoopBackend
+    ( assistantTextFromResponse
+    , withRequestInput
+    )
+import Agent.OpenAI.Responses.Types
+import Agent.Provider
+    ( Credential
+    , Provider(..)
+    , TokenProvider
+    , runWithTokenProvider
+    )
+import qualified Agent.OpenRouter.Client as OpenRouter
+import qualified Agent.OpenRouter.Options as OpenRouter
+import qualified Agent.XAI.Client as XAI
+import qualified Agent.XAI.Options as XAI
+import Data.IORef (IORef, readIORef)
+import Data.Maybe (fromMaybe)
+import Data.Text (Text)
+import qualified Data.Text as Text
+
+data CompactOutcome = CompactOutcome
+    { compactBeforeTokens :: !Int
+    , compactAfterTokens :: !Int
+    , compactHistory :: ![ResponseItem]
+    , compactSummary :: !Text
+    } deriving (Eq, Show)
+
+runProviderCompact
+    :: Provider
+    -> Maybe TokenProvider
+    -> IORef ResponseCreateParams
+    -> IORef [ResponseItem]
+    -> Maybe Text
+    -> IO (Either Text CompactOutcome)
+runProviderCompact provider tokenProvider paramsRef transcriptRef focus = do
+    params <- readIORef paramsRef
+    history <- readIORef transcriptRef
+    let before = estimateItemsTokens history
+    case provider of
+        OpenAIProvider ->
+            compactOpenAI tokenProvider params history before focus
+        XAIProvider ->
+            compactLocalXai tokenProvider params history before focus
+        OpenRouterProvider ->
+            compactLocalOpenRouter tokenProvider params history before focus
+
+compactOpenAI
+    :: Maybe TokenProvider
+    -> ResponseCreateParams
+    -> [ResponseItem]
+    -> Int
+    -> Maybe Text
+    -> IO (Either Text CompactOutcome)
+compactOpenAI tokenProvider params history before focus =
+    case tokenProvider of
+        Nothing -> pure (Left "openai compact requires a token provider")
+        Just provider
+            | null history -> pure (Left "nothing to compact")
+            | otherwise -> do
+                let model = fromMaybe "gpt-5.6-luna" params.model
+                    focusedHistory = case focus of
+                        Just text | not (Text.null (Text.strip text)) ->
+                            history
+                                <> [ userTextItem
+                                        ( "Compaction focus from the user: "
+                                            <> Text.strip text
+                                        )
+                                   ]
+                        _ -> history
+                    request =
+                        CompactRequest
+                            { compactModel = model
+                            , compactInput = focusedHistory
+                            , compactInstructions = params.instructions
+                            , compactTools = params.tools
+                            , compactParallelToolCalls =
+                                fromMaybe True params.parallelToolCalls
+                            , compactReasoning = params.reasoning
+                            }
+                compactConversation provider request >>= \case
+                    Left err -> pure (Left (formatApiError err))
+                    Right items ->
+                        pure $
+                            Right
+                                CompactOutcome
+                                    { compactBeforeTokens = before
+                                    , compactAfterTokens = estimateItemsTokens items
+                                    , compactHistory = items
+                                    , compactSummary =
+                                        "remote compact returned "
+                                            <> Text.pack (show (length items))
+                                            <> " items"
+                                    }
+
+compactLocalXai
+    :: Maybe TokenProvider
+    -> ResponseCreateParams
+    -> [ResponseItem]
+    -> Int
+    -> Maybe Text
+    -> IO (Either Text CompactOutcome)
+compactLocalXai tokenProvider params history before focus =
+    case tokenProvider of
+        Nothing -> pure (Left "xai compact requires a token provider")
+        Just provider -> do
+            options <- XAI.clientOptionsFromEnv
+            summarizeLocal
+                (XAI.createResponseWith options)
+                provider
+                params
+                history
+                before
+                focus
+
+compactLocalOpenRouter
+    :: Maybe TokenProvider
+    -> ResponseCreateParams
+    -> [ResponseItem]
+    -> Int
+    -> Maybe Text
+    -> IO (Either Text CompactOutcome)
+compactLocalOpenRouter tokenProvider params history before focus =
+    case tokenProvider of
+        Nothing -> pure (Left "openrouter compact requires a token provider")
+        Just provider -> do
+            options <- OpenRouter.clientOptionsFromEnv
+            summarizeLocal
+                (OpenRouter.createResponseWith options)
+                provider
+                params
+                history
+                before
+                focus
+
+summarizeLocal
+    :: (Credential -> ResponseCreateParams -> IO (Either ApiError Response))
+    -> TokenProvider
+    -> ResponseCreateParams
+    -> [ResponseItem]
+    -> Int
+    -> Maybe Text
+    -> IO (Either Text CompactOutcome)
+summarizeLocal send provider params history before focus
+    | null history = pure (Left "nothing to compact")
+    | otherwise = do
+        let summaryPrompt = summarizationPrompt focus
+            ResponseCreateParams{..} = params
+            summaryParams =
+                ResponseCreateParams
+                    { tools = Nothing
+                    , parallelToolCalls = Just False
+                    , ..
+                    }
+            request =
+                withRequestInput
+                    summaryParams
+                    (history <> [userTextItem summaryPrompt])
+        result <- runWithTokenProvider provider \credential ->
+            send credential request
+        case result of
+            Left err -> pure (Left (formatApiError err))
+            Right response ->
+                case assistantTextFromResponse response of
+                    Nothing ->
+                        pure (Left "compaction produced no summary text")
+                    Just summary -> do
+                        let items =
+                                buildLocalCompactedHistory 6 history summary
+                        pure $
+                            Right
+                                CompactOutcome
+                                    { compactBeforeTokens = before
+                                    , compactAfterTokens = estimateItemsTokens items
+                                    , compactHistory = items
+                                    , compactSummary = summary
+                                    }
+
+formatApiError :: ApiError -> Text
+formatApiError err = Text.pack (show err)

--- a/packages/agent-cli/src/Agent/CLI/Options.hs
+++ b/packages/agent-cli/src/Agent/CLI/Options.hs
@@ -230,7 +230,7 @@ usage = unlines
     , "Without -p/--prompt-file, start a REPL. Interactive REPL sessions are"
     , "persisted under ~/.haskell-agent/sessions. /effort [LEVEL] changes"
     , "reasoning effort. /model opens the model picker; /model NAME sets it."
-    , "/compact [FOCUS] summarizes history (OpenAI remote compact;
+    , "/compact [FOCUS] summarizes history (OpenAI remote compact;"
     , "xAI/OpenRouter local summary) to free context."
     , "/plan [description] enters plan mode (read-only except plan.md);"
     , "when a plan is presented, approve (a), request changes (s), or cancel (q)."

--- a/packages/agent-cli/src/Agent/CLI/Options.hs
+++ b/packages/agent-cli/src/Agent/CLI/Options.hs
@@ -230,6 +230,8 @@ usage = unlines
     , "Without -p/--prompt-file, start a REPL. Interactive REPL sessions are"
     , "persisted under ~/.haskell-agent/sessions. /effort [LEVEL] changes"
     , "reasoning effort. /model opens the model picker; /model NAME sets it."
+    , "/compact [FOCUS] summarizes history (OpenAI remote compact;
+    , "xAI/OpenRouter local summary) to free context."
     , "/plan [description] enters plan mode (read-only except plan.md);"
     , "when a plan is presented, approve (a), request changes (s), or cancel (q)."
     , "/always-approve (or :yolo) toggles auto-approve and saves it under"

--- a/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
@@ -54,6 +54,11 @@ spec = do
             parseReplLine "/reload-auth now"
                 `shouldBe` ReplCommandError "usage: /reload-auth"
 
+        it "compacts with optional focus text" do
+            parseReplLine "/compact" `shouldBe` ReplCompact Nothing
+            parseReplLine "/compact focus auth"
+                `shouldBe` ReplCompact (Just "focus auth")
+
         it "pastes clipboard images with an optional caption" do
             parseReplLine "/paste"
                 `shouldBe` ReplPaste { pasteImmediate = False, pasteCaption = "" }

--- a/packages/agent-openai/agent-openai.cabal
+++ b/packages/agent-openai/agent-openai.cabal
@@ -52,6 +52,8 @@ library
                     , Agent.OpenAI.ResponseMerge
                     , Agent.OpenAI.WebSocketClient
                     , Agent.OpenAI.LoopBackend
+                    , Agent.OpenAI.CompactClient
+                    , Agent.OpenAI.Compaction
                     , Agent.OpenAI.ToolDSL
     hs-source-dirs:   src
     build-depends:    base                  >= 4.14 && < 5
@@ -104,6 +106,7 @@ test-suite agent-openai-test
                     , Agent.OpenAI.FunctionalSpec
                     , Agent.OpenAI.LoginSpec
                     , Agent.OpenAI.LoopBackendSpec
+                    , Agent.OpenAI.CompactionSpec
                     , Agent.OpenAI.ResponsesSpec
                     , Agent.OpenAI.ResponseMergeSpec
                     , Agent.OpenAI.ToolDSLSpec

--- a/packages/agent-openai/src/Agent/OpenAI/CompactClient.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/CompactClient.hs
@@ -1,0 +1,128 @@
+-- | Codex remote conversation compaction via POST /responses/compact.
+module Agent.OpenAI.CompactClient
+    ( CompactRequest(..)
+    , compactConversation
+    , compactConversationAt
+    ) where
+
+import Agent.Error (ApiError(..))
+import Agent.OpenAI.Client (defaultCodexBaseUrl)
+import Agent.OpenAI.Error (classifyHttpFailure)
+import Agent.OpenAI.Responses.Types hiding (Response)
+import Agent.Provider (Credential(..), TokenProvider, runWithTokenProvider)
+import Control.Monad (when)
+import Data.Aeson ((.=))
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString as BS
+import Data.Maybe (catMaybes)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
+import Network.Http.Client
+    ( Method(POST)
+    , Response
+    , buildRequest1
+    , establishConnection
+    , getStatusCode
+    , http
+    , jsonBody
+    , receiveResponse
+    , sendRequest
+    , setContentType
+    , setHeader
+    , withConnection
+    )
+import OpenSSL (withOpenSSL)
+import qualified System.IO.Streams as Streams
+import qualified Network.URI as URI
+
+-- | Body for Codex @/responses/compact@ (subset of CompactionInput).
+data CompactRequest = CompactRequest
+    { compactModel :: !Text
+    , compactInput :: ![ResponseItem]
+    , compactInstructions :: !(Maybe Text)
+    , compactTools :: !(Maybe [ResponseTool])
+    , compactParallelToolCalls :: !Bool
+    , compactReasoning :: !(Maybe ReasoningConfig)
+    } deriving (Eq, Show)
+
+instance Aeson.ToJSON CompactRequest where
+    toJSON req =
+        Aeson.object $ catMaybes
+            [ Just ("model" .= req.compactModel)
+            , Just ("input" .= req.compactInput)
+            , ("instructions" .=) <$> req.compactInstructions
+            , ("tools" .=) <$> req.compactTools
+            , Just ("parallel_tool_calls" .= req.compactParallelToolCalls)
+            , ("reasoning" .=) <$> req.compactReasoning
+            ]
+
+compactConversation
+    :: TokenProvider
+    -> CompactRequest
+    -> IO (Either ApiError [ResponseItem])
+compactConversation =
+    compactConversationAt defaultCodexBaseUrl
+
+compactConversationAt
+    :: Text
+    -> TokenProvider
+    -> CompactRequest
+    -> IO (Either ApiError [ResponseItem])
+compactConversationAt baseUrl provider request =
+    runWithTokenProvider provider \credential ->
+        postCompact baseUrl credential request
+
+postCompact
+    :: Text
+    -> Credential
+    -> CompactRequest
+    -> IO (Either ApiError [ResponseItem])
+postCompact baseUrl credential request = do
+    let url = Text.dropWhileEnd (== '/') baseUrl <> "/responses/compact"
+        body = Aeson.toJSON request
+    case URI.parseURI (Text.unpack url) of
+        Nothing -> pure $ Left (JsonDecodeError ("Invalid URL: " <> url) "")
+        Just uri ->
+            withOpenSSL $
+                withConnection (establishConnection (Text.encodeUtf8 url)) $ \conn -> do
+                    let path = Text.encodeUtf8 (Text.pack uri.uriPath)
+                        req = buildRequest1 $ do
+                            http POST path
+                            setContentType "application/json"
+                            setHeader "Authorization"
+                                ("Bearer " <> Text.encodeUtf8 credential.accessToken)
+                            when (not (Text.null (Text.strip credential.accountId))) $
+                                setHeader "chatgpt-account-id"
+                                    (Text.encodeUtf8 credential.accountId)
+                    sendRequest conn req (jsonBody body)
+                    receiveResponse conn compactResponseHandler
+
+compactResponseHandler
+    :: Response
+    -> Streams.InputStream BS.ByteString
+    -> IO (Either ApiError [ResponseItem])
+compactResponseHandler response stream = do
+    let status = getStatusCode response
+    bytes <- Streams.fold mappend mempty stream
+    let bodyText = Text.decodeUtf8 bytes
+    if status >= 200 && status < 300
+        then pure (decodeCompactBody bodyText)
+        else pure $ Left (classifyHttpFailure status bodyText)
+
+decodeCompactBody :: Text -> Either ApiError [ResponseItem]
+decodeCompactBody bodyText =
+    case Aeson.eitherDecodeStrict (Text.encodeUtf8 bodyText) of
+        Left err -> Left (JsonDecodeError (Text.pack err) bodyText)
+        Right (Aeson.Object object) ->
+            case KeyMap.lookup "output" object of
+                Just value ->
+                    case Aeson.fromJSON value of
+                        Aeson.Success items -> Right items
+                        Aeson.Error err ->
+                            Left (JsonDecodeError (Text.pack err) bodyText)
+                Nothing ->
+                    Left (JsonDecodeError "compact response missing output" bodyText)
+        Right _ ->
+            Left (JsonDecodeError "compact response was not an object" bodyText)

--- a/packages/agent-openai/src/Agent/OpenAI/Compaction.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Compaction.hs
@@ -1,0 +1,129 @@
+-- | Conversation compaction helpers shared by OpenAI remote compact and
+-- xAI/OpenRouter local summarization.
+module Agent.OpenAI.Compaction
+    ( summaryPrefix
+    , summarizationPrompt
+    , estimateTokens
+    , estimateItemsTokens
+    , collectRecentUserTexts
+    , buildLocalCompactedHistory
+    , assistantSummaryItem
+    , userTextItem
+    , isCompactSessionTurn
+    , compactSessionUserText
+    ) where
+
+import Agent.OpenAI.Responses.Types
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.KeyMap as KeyMap
+import Data.Maybe (mapMaybe)
+import qualified Data.ByteString.Lazy as LBS
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as TextEncoding
+
+-- | Marker prefix for compacted summary messages.
+summaryPrefix :: Text
+summaryPrefix = "Compacted conversation summary:"
+
+-- | User-visible / persisted marker for a compact turn.
+compactSessionUserText :: Maybe Text -> Text
+compactSessionUserText focus = case focus of
+    Just text | not (Text.null (Text.strip text)) ->
+        "/compact " <> Text.strip text
+    _ -> "/compact"
+
+-- | Prompt used for local (Grok-style) summarization turns.
+summarizationPrompt :: Maybe Text -> Text
+summarizationPrompt focus =
+    Text.unlines $
+        [ "Summarize the conversation so far for a successor coding agent."
+        , "The successor will only see this summary plus a few recent user messages;"
+        , "it will not see prior tool calls or tool outputs."
+        , "Preserve: the user's goals, important file paths, decisions made,"
+        , "errors encountered and how they were fixed, and remaining work."
+        , "Be concrete and concise. Do not call tools."
+        ]
+            <> case focus of
+                Just text | not (Text.null (Text.strip text)) ->
+                    [ ""
+                    , "Additional focus from the user:"
+                    , Text.strip text
+                    ]
+                _ -> []
+
+estimateTokens :: Text -> Int
+estimateTokens text = max 1 (Text.length text `div` 4)
+
+estimateItemsTokens :: [ResponseItem] -> Int
+estimateItemsTokens items =
+    sum
+        [ estimateTokens (TextEncoding.decodeUtf8 (LBS.toStrict (Aeson.encode item)))
+        | item <- items
+        ]
+
+-- | Collect recent real user message texts (newest last), skipping /compact markers.
+collectRecentUserTexts :: Int -> [ResponseItem] -> [Text]
+collectRecentUserTexts keep items =
+    reverse (take keep (reverse (mapMaybe userTextOf items)))
+  where
+    userTextOf = \case
+        MessageItem message
+            | message.role == RoleUser ->
+                case messageText message of
+                    Just text
+                        | Text.isPrefixOf "/compact" (Text.strip text) -> Nothing
+                        | otherwise -> Just text
+                    Nothing -> Nothing
+        _ -> Nothing
+
+messageText :: ResponseMessage -> Maybe Text
+messageText message = case message.content of
+    MessageContentText text -> Just text
+    MessageContentParts parts ->
+        let texts =
+                [ text
+                | InputTextPart { text } <- parts
+                ]
+        in case texts of
+            [] -> Nothing
+            xs -> Just (Text.intercalate "\n" xs)
+
+userTextItem :: Text -> ResponseItem
+userTextItem text = MessageItem ResponseMessage
+    { messageId = Nothing
+    , content = MessageContentParts [InputTextPart text Nothing KeyMap.empty]
+    , role = RoleUser
+    , status = Nothing
+    , phase = Nothing
+    , extraFields = KeyMap.empty
+    }
+
+assistantSummaryItem :: Text -> ResponseItem
+assistantSummaryItem summary =
+    MessageItem ResponseMessage
+        { messageId = Nothing
+        , content =
+            MessageContentParts
+                [ InputTextPart
+                    (summaryPrefix <> "\n" <> Text.strip summary)
+                    Nothing
+                    KeyMap.empty
+                ]
+        , role = RoleAssistant
+        , status = Nothing
+        , phase = Nothing
+        , extraFields = KeyMap.empty
+        }
+
+-- | Grok-style local rebuild: recent user texts + assistant summary.
+buildLocalCompactedHistory :: Int -> [ResponseItem] -> Text -> [ResponseItem]
+buildLocalCompactedHistory keepRecent history summary =
+    map userTextItem (collectRecentUserTexts keepRecent history)
+        <> [assistantSummaryItem summary]
+
+-- | Session turns that represent a compaction checkpoint.
+isCompactSessionTurn :: Text -> Bool
+isCompactSessionTurn text =
+    let stripped = Text.strip text
+    in stripped == "/compact" || Text.isPrefixOf "/compact " stripped

--- a/packages/agent-openai/src/Agent/OpenAI/LoopBackend.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/LoopBackend.hs
@@ -76,7 +76,13 @@ openAiBackendWith send getParams transcript = Backend \previousResponseId inputs
         deltaRequest = withRequestInput baseParams newItems
         fullRequest = withRequestInput baseParams (history <> newItems)
         emit event = mapM_ onEvent (streamEventToLoopEvent event)
-    result <- send deltaRequest previousResponseId emit
+        -- After compaction (or any cleared chain), previousResponseId is Nothing
+        -- but local history is the compacted transcript — send it as a fresh chain.
+        (initialRequest, initialPrevious) =
+            case previousResponseId of
+                Nothing | not (null history) -> (fullRequest, Nothing)
+                _ -> (deltaRequest, previousResponseId)
+    result <- send initialRequest initialPrevious emit
     recovered <- case result of
         Left err
             | isPreviousResponseIdError err && not (null history) ->

--- a/packages/agent-openai/test/Agent/OpenAI/CompactionSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/CompactionSpec.hs
@@ -1,0 +1,66 @@
+module Agent.OpenAI.CompactionSpec (spec) where
+
+import Agent.OpenAI.Compaction
+import Agent.OpenAI.Responses.Types
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.Text as Text
+import Test.Hspec
+
+spec :: Spec
+spec = do
+    describe "buildLocalCompactedHistory" do
+        it "keeps recent user texts and an assistant summary" do
+            let history =
+                    [ user "one"
+                    , assistant "a1"
+                    , user "two"
+                    , assistant "a2"
+                    , user "three"
+                    ]
+                compacted = buildLocalCompactedHistory 2 history "did stuff"
+            length compacted `shouldBe` 3
+            compacted `shouldSatisfy` any isSummary
+            -- newest users retained
+            let texts = [userOnly m | MessageItem m <- compacted, m.role == RoleUser]
+            texts `shouldBe` ["two", "three"]
+
+        it "skips prior /compact user markers" do
+            let history = [user "/compact", user "keep me", assistant "x"]
+                compacted = buildLocalCompactedHistory 3 history "summary"
+            let texts = [userOnly m | MessageItem m <- compacted, m.role == RoleUser]
+            texts `shouldBe` ["keep me"]
+
+    describe "isCompactSessionTurn" do
+        it "recognizes compact markers" do
+            isCompactSessionTurn "/compact" `shouldBe` True
+            isCompactSessionTurn "/compact focus auth" `shouldBe` True
+            isCompactSessionTurn "hello" `shouldBe` False
+
+  where
+    user text = MessageItem ResponseMessage
+        { messageId = Nothing
+        , content = MessageContentParts [InputTextPart text Nothing KeyMap.empty]
+        , role = RoleUser
+        , status = Nothing
+        , phase = Nothing
+        , extraFields = KeyMap.empty
+        }
+    assistant text = MessageItem ResponseMessage
+        { messageId = Nothing
+        , content = MessageContentParts [InputTextPart text Nothing KeyMap.empty]
+        , role = RoleAssistant
+        , status = Nothing
+        , phase = Nothing
+        , extraFields = KeyMap.empty
+        }
+    isSummary (MessageItem m) =
+        m.role == RoleAssistant
+            && case m.content of
+                MessageContentParts (InputTextPart text _ _ : _) ->
+                    Text.isPrefixOf summaryPrefix text
+                _ -> False
+    isSummary _ = False
+    userOnly m = case m.content of
+        MessageContentParts (InputTextPart text _ _ : _) -> text
+        MessageContentText text -> text
+        _ -> ""

--- a/packages/agent-openai/test/Spec.hs
+++ b/packages/agent-openai/test/Spec.hs
@@ -9,6 +9,7 @@ import qualified Agent.OpenAI.ErrorSpec as ErrorSpec
 import qualified Agent.OpenAI.FunctionalSpec as FunctionalSpec
 import qualified Agent.OpenAI.LoginSpec as LoginSpec
 import qualified Agent.OpenAI.LoopBackendSpec as LoopBackendSpec
+import qualified Agent.OpenAI.CompactionSpec as CompactionSpec
 import qualified Agent.OpenAI.ResponsesSpec as ResponsesSpec
 import qualified Agent.OpenAI.ResponseMergeSpec as ResponseMergeSpec
 import qualified Agent.OpenAI.ToolDSLSpec as ToolDSLSpec
@@ -24,6 +25,7 @@ main = hspec do
     FunctionalSpec.spec
     LoginSpec.spec
     LoopBackendSpec.spec
+    CompactionSpec.spec
     ResponsesSpec.spec
     ResponseMergeSpec.spec
     ToolDSLSpec.spec


### PR DESCRIPTION
## Summary
Implements conversation compaction:

- **OpenAI / Codex:** remote `POST {codexBase}/responses/compact`, then replace local transcript and clear `previous_response_id`.
- **xAI / OpenRouter:** local no-tools summarization + rebuilt history (recent user messages + summary), Grok Build–style.
- **CLI:** `/compact` and `/compact <focus>`
- **Resume:** compact session turns replace the transcript snapshot when loading.

## Test plan
- [x] `cabal test agent-openai:agent-openai-test`
- [x] `cabal test agent-cli:agent-cli-test`
- [ ] OpenAI: long chat → `/compact` → continued turn works
- [ ] xAI: long chat → `/compact` → token estimate drops; model retains task context
- [ ] `--resume` after compact loads the compacted history