### PR TITLE
feat: Grok/OpenRouter task subagents

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -112,7 +112,8 @@ import Agent.Subagents
     , setSubagentOnComplete
     , setSubagentRunner
     )
-import Agent.Tools (CodingTools(..), appToolHandlers, codingToolsFor)
+import Agent.Tools (CodingTools(..), appToolHandlers, codingToolsFor, filterChildGrokTools)
+import Agent.Tools.Grok.Task (defaultSubagentType, lookupAgentType)
 import Agent.Tools.MultiAgents (MultiAgentContext(..))
 import Agent.Tools.PlanMode
     ( PlanDecision(..)
@@ -313,18 +314,16 @@ runAgent options = do
     escPaused <- newIORef False
     let planHooks = cliPlanHooks interrupt escPaused (resolveColor stderr)
         provider = loaded.loadedProvider
-    multiCtx <- case provider of
-        OpenAIProvider -> do
-            registry <- newSubagentRegistry defaultSubagentConfig cwd
-                (\_ _ _ _ -> pure $ Left LoopNoResponseId)
-                (\_ _ -> pure ())
-            pure $ Just MultiAgentContext
-                { multiRegistry = registry
-                , multiSelfId = Nothing
-                , multiDepth = 0
-                }
-        _ -> pure Nothing
-    -- Per-subagent OpenAI transcripts / previous ids, shared across send_input.
+    multiCtx <- do
+        registry <- newSubagentRegistry defaultSubagentConfig cwd
+            (\_ _ _ _ -> pure $ Left LoopNoResponseId)
+            (\_ _ -> pure ())
+        pure $ Just MultiAgentContext
+            { multiRegistry = registry
+            , multiSelfId = Nothing
+            , multiDepth = 0
+            }
+    -- Per-subagent transcripts / previous ids, shared across send_input / task.
     subagentSessions <- newIORef Map.empty
     pendingNotices <- newIORef ([] :: [Text])
     case multiCtx of
@@ -336,6 +335,7 @@ runAgent options = do
     coding <- codingToolsFor provider toolEnv (Just planHooks) multiCtx
     let tools = coding.codingAppTools
         planMode = coding.codingPlanMode
+        agentTypesRef = coding.codingAgentTypes
         closeAll = do
             case multiCtx of
                 Just ctx -> closeSubagentRegistry ctx.multiRegistry
@@ -409,16 +409,50 @@ runAgent options = do
                                 Right result -> pure result
                     XAIProvider -> do
                         xaiOptions <- XAI.clientOptionsFromEnv
+                        case multiCtx of
+                            Just ctx ->
+                                setSubagentRunner ctx.multiRegistry $
+                                    runHttpSubagent
+                                        options
+                                        policy
+                                        planHooks
+                                        paramsRef
+                                        XAIProvider
+                                        (\childParamsRef childTranscript ->
+                                            xaiBackend xaiOptions loaded.loadedTokenProvider
+                                                (readIORef childParamsRef) childTranscript)
+                                        ctx.multiRegistry
+                                        subagentSessions
+                                        agentTypesRef
+                            Nothing -> pure ()
                         let backend =
-                                xaiBackend xaiOptions loaded.loadedTokenProvider
-                                    (readIORef paramsRef) transcriptRef
+                                withPendingNotices pendingNotices $
+                                    xaiBackend xaiOptions loaded.loadedTokenProvider
+                                        (readIORef paramsRef) transcriptRef
                         runSession options provider policy tools toolEnv planMode prompt paramsRef transcriptRef
                             initialPrevious persist projectRoot (Just loaded.loadedTokenProvider) agentsContext escPaused interrupt backend
                     OpenRouterProvider -> do
                         openRouterOptions <- OpenRouter.clientOptionsFromEnv
+                        case multiCtx of
+                            Just ctx ->
+                                setSubagentRunner ctx.multiRegistry $
+                                    runHttpSubagent
+                                        options
+                                        policy
+                                        planHooks
+                                        paramsRef
+                                        OpenRouterProvider
+                                        (\childParamsRef childTranscript ->
+                                            openRouterBackend openRouterOptions loaded.loadedTokenProvider
+                                                (readIORef childParamsRef) childTranscript)
+                                        ctx.multiRegistry
+                                        subagentSessions
+                                        agentTypesRef
+                            Nothing -> pure ()
                         let backend =
-                                openRouterBackend openRouterOptions loaded.loadedTokenProvider
-                                    (readIORef paramsRef) transcriptRef
+                                withPendingNotices pendingNotices $
+                                    openRouterBackend openRouterOptions loaded.loadedTokenProvider
+                                        (readIORef paramsRef) transcriptRef
                         runSession options provider policy tools toolEnv planMode prompt paramsRef transcriptRef
                             initialPrevious persist projectRoot (Just loaded.loadedTokenProvider) agentsContext escPaused interrupt backend
 
@@ -1356,6 +1390,81 @@ runCodexSubagent options policy planHooks paramsRef wsLock conn registry session
                     , loopCancel = env.subCancel
                     }
             runLoop config previous prompt
+
+-- | Child XAI/OpenRouter agent: HTTP backend, filtered tools by subagent_type.
+runHttpSubagent
+    :: CliOptions
+    -> ApprovalPolicy
+    -> PlanModeHooks
+    -> IORef ResponseCreateParams
+    -> Provider
+    -> (IORef ResponseCreateParams -> IORef [ResponseItem] -> Backend)
+    -> SubagentRegistry
+    -> IORef (Map SubagentId SubagentSession)
+    -> IORef (Map SubagentId Text)
+    -> RunSubagent
+runHttpSubagent options policy planHooks paramsRef provider mkBackend registry sessionsRef typesRef =
+    \env previous prompt onEvent -> do
+        parentParams <- readIORef paramsRef
+        childEnv <- defaultToolEnv env.subCwd
+        let childToolEnv = childEnv { toolCancel = env.subCancel }
+            childCtx = MultiAgentContext
+                { multiRegistry = registry
+                , multiSelfId = Just env.subId
+                , multiDepth = env.subDepth
+                }
+        session <- lookupOrCreateSubagentSession sessionsRef env.subId
+        agentType <- fromMaybe defaultSubagentType <$> lookupAgentType typesRef env.subId
+        coding <- codingToolsFor provider childToolEnv (Just planHooks) (Just childCtx)
+        flip finally coding.codingClose do
+            today <- utctDay <$> getCurrentTime
+            let model = fromMaybe (defaultModelFor provider) parentParams.model
+                effort = case parentParams.reasoning of
+                    Just cfg -> fromMaybe (defaultEffortFor provider) cfg.effort
+                    Nothing -> defaultEffortFor provider
+                baseInstructions =
+                    fromMaybe
+                        (systemPrompt provider env.subCwd today True)
+                        parentParams.instructions
+                instructions =
+                    baseInstructions
+                        <> "\n\n"
+                        <> grokSubagentSuffix agentType env.subId
+                tools = filterChildGrokTools agentType coding.codingAppTools
+                childParams = requestParams provider model instructions
+                    (schemasFromAppTools provider tools) effort
+            childParamsRef <- newIORef childParams
+            let backend = mkBackend childParamsRef session.subSessionTranscript
+                config = LoopConfig
+                    { loopBackend = backend
+                    , loopHandlers = appToolHandlers tools
+                    , loopDispatch = defaultLoopDispatch
+                    , loopMaxTurns = options.optMaxTurns
+                    , loopOnEvent = onEvent
+                    , loopApprove = \call -> childApprove policy tools call
+                    , loopCancel = env.subCancel
+                    }
+            -- XAI/OpenRouter ignore previous_response_id and replay local
+            -- transcripts; still pass previous for API symmetry.
+            runLoop config previous prompt
+
+grokSubagentSuffix :: Text -> SubagentId -> Text
+grokSubagentSuffix agentType agentId =
+    "You are a Grok Build subagent (type: "
+        <> agentType
+        <> "). Your agent id is "
+        <> agentId.unSubagentId
+        <> ". Complete the assigned task directly and report results clearly."
+        <> case agentType of
+            "explore" ->
+                "\n\n=== READ-ONLY MODE ===\n\
+                \Do not create, modify, or delete files. Use run_terminal_cmd only \
+                \for read-only commands (ls, git status, git log, git diff, find, cat, head, tail)."
+            "plan" ->
+                "\n\n=== READ-ONLY MODE ===\n\
+                \Do not create, modify, or delete files except plan.md while in plan mode. \
+                \Use run_terminal_cmd only for read-only commands."
+            _ -> ""
 
 lookupOrCreateSubagentSession
     :: IORef (Map SubagentId SubagentSession)

--- a/packages/agent-core/agent-core.cabal
+++ b/packages/agent-core/agent-core.cabal
@@ -48,6 +48,7 @@ library
                     , Agent.Tools.Grok
                     , Agent.Tools.Grok.Prompt
                     , Agent.Tools.Grok.Shell
+                    , Agent.Tools.Grok.Task
                     , Agent.Tools.Ghci
                     , Agent.Tools.IO
                     , Agent.Tools.MultiAgents
@@ -87,6 +88,7 @@ test-suite agent-core-test
                     , Agent.Tools.CodexSpec
                     , Agent.Tools.DangerousSpec
                     , Agent.Tools.GrokSpec
+                    , Agent.Tools.Grok.TaskSpec
                     , Agent.Tools.GhciSpec
                     , Agent.Tools.IOSpec
                     , Agent.Tools.PlanModeSpec

--- a/packages/agent-core/src/Agent/Tools.hs
+++ b/packages/agent-core/src/Agent/Tools.hs
@@ -12,21 +12,29 @@ module Agent.Tools
     , appToolHandlers
     , CodingTools(..)
     , codingToolsFor
+    , filterChildGrokTools
     ) where
 
 import Agent.Provider (Provider(..))
+import Agent.Subagents (SubagentId)
 import Agent.Tools.Codex (codexTools)
 import Agent.Tools.Ghci (closeGhciSession, newGhciSession)
-import Agent.Tools.Grok (closeGrokSession, grokTools, newGrokSession)
+import Agent.Tools.Grok (closeGrokSession, filterGrokToolsForType, grokTools, newGrokSession)
 import Agent.Tools.MultiAgents (MultiAgentContext)
 import Agent.Tools.PlanMode (PlanModeEnv, PlanModeHooks, newPlanModeEnv)
 import Agent.Tools.Types
+import Data.IORef
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import Data.Text (Text)
 
 -- | Tools plus the session plan-mode env (shared across providers).
 data CodingTools = CodingTools
     { codingAppTools :: ![AppTool]
     , codingPlanMode :: !PlanModeEnv
     , codingClose :: !(IO ())
+      -- | Grok/OpenRouter: maps spawned agent ids to subagent_type.
+    , codingAgentTypes :: !(IORef (Map SubagentId Text))
     }
 
 -- | Tools advertised for a model vendor. Surfaces are never mixed.
@@ -41,22 +49,25 @@ codingToolsFor
     -> IO CodingTools
 codingToolsFor provider env hooks multi = do
     plan <- newPlanModeEnv env.toolCwd hooks
+    typesRef <- newIORef Map.empty
     case provider of
         XAIProvider -> do
             session <- newGrokSession env
             ghci <- newGhciSession env
             pure CodingTools
-                { codingAppTools = grokTools session ghci plan
+                { codingAppTools = grokTools session ghci plan multi typesRef
                 , codingPlanMode = plan
                 , codingClose = closeGrokSession session >> closeGhciSession ghci
+                , codingAgentTypes = typesRef
                 }
         OpenRouterProvider -> do
             session <- newGrokSession env
             ghci <- newGhciSession env
             pure CodingTools
-                { codingAppTools = grokTools session ghci plan
+                { codingAppTools = grokTools session ghci plan multi typesRef
                 , codingPlanMode = plan
                 , codingClose = closeGrokSession session >> closeGhciSession ghci
+                , codingAgentTypes = typesRef
                 }
         OpenAIProvider -> do
             ghci <- newGhciSession env
@@ -65,4 +76,10 @@ codingToolsFor provider env hooks multi = do
                 { codingAppTools = tools
                 , codingPlanMode = plan
                 , codingClose = closeGhciSession ghci
+                , codingAgentTypes = typesRef
                 }
+
+-- | Re-export for CLI child runners.
+filterChildGrokTools :: Text -> [AppTool] -> [AppTool]
+filterChildGrokTools = filterGrokToolsForType
+

--- a/packages/agent-core/src/Agent/Tools/Grok.hs
+++ b/packages/agent-core/src/Agent/Tools/Grok.hs
@@ -5,6 +5,7 @@
 -- Do not rename these to match Codex; Grok models are trained on this dialect.
 module Agent.Tools.Grok
     ( grokTools
+    , filterGrokToolsForType
     , newGrokSession
     , closeGrokSession
     , GrokSession
@@ -52,6 +53,19 @@ import Agent.Tools.PlanMode
     , planModeBlockedEditMessage
     )
 import Agent.Tools.Dangerous (commandLooksLikeRmRf, forbiddenRmRfReason)
+import Agent.Tools.Grok.Task
+    ( filterGrokToolsForType
+    , isSubagentIdText
+    , taskTool
+    )
+import Agent.Tools.MultiAgents (MultiAgentContext(..))
+import Agent.Subagents
+    ( SubagentId(..)
+    , SubagentStatus(..)
+    , closeSubagent
+    , getStatus
+    , waitSubagents
+    )
 import Agent.Tools.Types
     ( AppTool(..)
     , AppToolKind(..)
@@ -59,8 +73,10 @@ import Agent.Tools.Types
     )
 import Data.Aeson (FromJSON(..), Object)
 import Data.Aeson.Types (Parser)
+import Data.IORef
 import Data.List (sortOn)
 import Data.Maybe (fromMaybe, listToMaybe)
+import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -70,24 +86,33 @@ import System.FilePath (takeExtension, (</>))
 import System.Process (readProcessWithExitCode)
 
 -- Upstream: grok-build grok_build::{read_file, grep, list_dir, search_replace, bash,
--- get_task_output, kill_task, enter_plan_mode, exit_plan_mode, ask_user_question}.
+-- get_task_output, kill_task, task, enter_plan_mode, exit_plan_mode, ask_user_question}.
 -- Local extension: run_ghci (persistent GHCi with per-call purity approval).
-grokTools :: GrokSession -> GhciSession -> PlanModeEnv -> [AppTool]
-grokTools session ghci planMode =
+grokTools
+    :: GrokSession
+    -> GhciSession
+    -> PlanModeEnv
+    -> Maybe MultiAgentContext
+    -> IORef (Map SubagentId Text)
+    -> [AppTool]
+grokTools session ghci planMode multi typesRef =
     let env = session.grokEnv
-    in
-        [ readFileTool env
-        , grepTool env
-        , listDirTool env
-        , searchReplaceTool env planMode
-        , runTerminalCmdTool session
-        , runGhciTool ghci
-        , getTaskOutputTool session
-        , killTaskTool session
-        , enterPlanModeTool planMode
-        , exitPlanModeTool planMode
-        , askUserQuestionTool planMode
-        ]
+        base =
+            [ readFileTool env
+            , grepTool env
+            , listDirTool env
+            , searchReplaceTool env planMode
+            , runTerminalCmdTool session
+            , runGhciTool ghci
+            , getTaskOutputTool session multi
+            , killTaskTool session multi
+            , enterPlanModeTool planMode
+            , exitPlanModeTool planMode
+            , askUserQuestionTool planMode
+            ]
+    in case multi of
+        Nothing -> base
+        Just ctx -> base ++ [taskTool ctx typesRef]
 
 jsonTool
     :: Text
@@ -753,49 +778,98 @@ data TaskOutputArgs = TaskOutputArgs
     }
 
 instance FromJSON TaskOutputArgs where
-    parseJSON = objectArgs \object -> TaskOutputArgs
-        <$> reqText object "task_id"
-        <*> optionalTimeout object
+    parseJSON = objectArgs \object ->
+        TaskOutputArgs
+            <$> (reqText object "task_id" <|> reqText object "task_ids")
+            <*> optionalTimeout object
 
-getTaskOutputTool :: GrokSession -> AppTool
-getTaskOutputTool session = jsonTool "get_task_output" getTaskOutputDescription
+getTaskOutputTool :: GrokSession -> Maybe MultiAgentContext -> AppTool
+getTaskOutputTool session multi = jsonTool "get_task_output" getTaskOutputDescription
     [ PropertySchema "task_id" PropertyString True $ Just
-        "The task id returned by a background run_terminal_cmd."
+        "The task id from a background run_terminal_cmd or the subagent_id from task."
     , PropertySchema "timeout" PropertyInteger False $ Just
         "Optional wait in milliseconds. If omitted, return a snapshot immediately."
     ]
     True
-    (typedTool "get_task_output" (runGetTaskOutput session))
+    (typedTool "get_task_output" (runGetTaskOutput session multi))
 
 getTaskOutputDescription :: Text
 getTaskOutputDescription =
-    "Read output from a background task started with run_terminal_cmd.\n\
+    "Read output from a background command or subagent.\n\
     \Use this for a snapshot of current output, or one bounded wait — not a polling loop."
 
-runGetTaskOutput :: GrokSession -> TaskOutputArgs -> IO (Either Text Text)
-runGetTaskOutput session args =
-    Right . stripAnsi <$> readTaskOutput session args.taskId args.timeout
+runGetTaskOutput
+    :: GrokSession
+    -> Maybe MultiAgentContext
+    -> TaskOutputArgs
+    -> IO (Either Text Text)
+runGetTaskOutput session multi args = case multi of
+    Just ctx | isSubagentIdText args.taskId -> do
+        let agentId = SubagentId args.taskId
+            timeoutMs = fromMaybe 0 args.timeout
+        if timeoutMs <= 0
+            then do
+                status <- getStatus ctx.multiRegistry agentId
+                pure $ Right $ formatAgentWait args.taskId False (Just status)
+            else do
+                (statuses, timedOut) <-
+                    waitSubagents ctx.multiRegistry [agentId] timeoutMs
+                pure $ Right $ formatAgentWait args.taskId timedOut (Map.lookup agentId statuses)
+    _ ->
+        Right . stripAnsi <$> readTaskOutput session args.taskId args.timeout
+
+formatAgentWait :: Text -> Bool -> Maybe SubagentStatus -> Text
+formatAgentWait taskId timedOut mstatus = case mstatus of
+    Just (Completed (Just text)) ->
+        "subagent_id: " <> taskId <> "\nstatus: completed\nfinal:\n" <> text
+    Just (Completed Nothing) ->
+        "subagent_id: " <> taskId <> "\nstatus: completed"
+    Just (Errored err) ->
+        "subagent_id: " <> taskId <> "\nstatus: errored\nerror: " <> err
+    Just Interrupted ->
+        "subagent_id: " <> taskId <> "\nstatus: interrupted"
+    Just Closed ->
+        "subagent_id: " <> taskId <> "\nstatus: shutdown"
+    Just Running
+        | timedOut -> "subagent_id: " <> taskId <> "\nstatus: running (wait timed out)"
+        | otherwise -> "subagent_id: " <> taskId <> "\nstatus: running"
+    Just Pending ->
+        "subagent_id: " <> taskId <> "\nstatus: pending"
+    Just NotFound ->
+        "Unknown task_id: " <> taskId
+    Nothing ->
+        "Unknown task_id: " <> taskId
 
 newtype KillTaskArgs = KillTaskArgs { taskId :: Text }
 
 instance FromJSON KillTaskArgs where
     parseJSON = objectArgs \object -> KillTaskArgs <$> reqText object "task_id"
 
-killTaskTool :: GrokSession -> AppTool
-killTaskTool session = jsonTool "kill_task" killTaskDescription
+killTaskTool :: GrokSession -> Maybe MultiAgentContext -> AppTool
+killTaskTool session multi = jsonTool "kill_task" killTaskDescription
     [ PropertySchema "task_id" PropertyString True $ Just
-        "The task id returned by a background run_terminal_cmd."
+        "The task id from a background run_terminal_cmd or the subagent_id from task."
     ]
     False
-    (typedTool "kill_task" (runKillTask session))
+    (typedTool "kill_task" (runKillTask session multi))
 
 killTaskDescription :: Text
 killTaskDescription =
-    "Kill a background task started with run_terminal_cmd."
+    "Kill a background command or close a subagent."
 
-runKillTask :: GrokSession -> KillTaskArgs -> IO (Either Text Text)
-runKillTask session args =
-    Right . stripAnsi <$> killTask session args.taskId
+runKillTask
+    :: GrokSession
+    -> Maybe MultiAgentContext
+    -> KillTaskArgs
+    -> IO (Either Text Text)
+runKillTask session multi args = case multi of
+    Just ctx | isSubagentIdText args.taskId -> do
+        result <- closeSubagent ctx.multiRegistry (SubagentId args.taskId)
+        pure $ case result of
+            Left err -> Left err
+            Right _ -> Right ("closed subagent " <> args.taskId)
+    _ ->
+        Right . stripAnsi <$> killTask session args.taskId
 
 combinedOutput :: CommandResult -> Text
 combinedOutput result

--- a/packages/agent-core/src/Agent/Tools/Grok/Task.hs
+++ b/packages/agent-core/src/Agent/Tools/Grok/Task.hs
@@ -1,0 +1,309 @@
+-- | Grok-build @task@ tool — spawn nestable subagents.
+--
+-- Wire names and defaults follow xai-org/grok-build TaskToolInput /
+-- build_task_description. Runtime reuses 'Agent.Subagents'.
+module Agent.Tools.Grok.Task
+    ( taskTool
+    , filterGrokToolsForType
+    , knownSubagentTypes
+    , defaultSubagentType
+    , isSubagentIdText
+    , formatTaskStarted
+    , formatTaskCompleted
+    , recordAgentType
+    , lookupAgentType
+    ) where
+
+import Agent.Subagents
+    ( SubagentId(..)
+    , SubagentStatus(..)
+    , defaultWaitTimeoutMs
+    , getStatus
+    , sendInput
+    , spawnSubagent
+    , waitSubagents
+    )
+import Agent.ToolArgs
+    ( objectArgs
+    , optBool
+    , optText
+    , reqText
+    )
+import Agent.ToolDSL
+    ( PropertySchema(..)
+    , PropertyType(..)
+    )
+import Agent.ToolDispatch (ToolHandler, typedTool)
+import Agent.Tools.MultiAgents (MultiAgentContext(..))
+import Agent.Tools.Types
+    ( AppTool(..)
+    , AppToolKind(..)
+    )
+import Data.Aeson (FromJSON(..))
+import Data.IORef
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import Data.Maybe (fromMaybe)
+import Data.Text (Text)
+import qualified Data.Text as Text
+
+defaultSubagentType :: Text
+defaultSubagentType = "general-purpose"
+
+knownSubagentTypes :: [Text]
+knownSubagentTypes = ["general-purpose", "explore", "plan"]
+
+-- | True when the id looks like a registry subagent id (not a shell @tN@ id).
+isSubagentIdText :: Text -> Bool
+isSubagentIdText text = "agent-" `Text.isPrefixOf` text
+
+data TaskArgs = TaskArgs
+    { prompt :: Text
+    , description :: Text
+    , subagentType :: Text
+    , runInBackground :: Bool
+    , resumeFrom :: Maybe Text
+    , cwd :: Maybe Text
+    , model :: Maybe Text
+    , isolation :: Maybe Text
+    }
+
+instance FromJSON TaskArgs where
+    parseJSON = objectArgs \object -> do
+        prompt <- reqText object "prompt"
+        description <- reqText object "description"
+        subagentType <- fromMaybe defaultSubagentType <$> optText object "subagent_type"
+        runInBackground <- fromMaybe True <$> optBool object "run_in_background"
+        resumeFrom <- optText object "resume_from"
+        cwd <- optText object "cwd"
+        model <- optText object "model"
+        isolation <- optText object "isolation"
+        pure TaskArgs
+            { prompt
+            , description
+            , subagentType
+            , runInBackground
+            , resumeFrom
+            , cwd
+            , model
+            , isolation
+            }
+
+taskTool :: MultiAgentContext -> IORef (Map SubagentId Text) -> AppTool
+taskTool ctx typesRef = AppTool
+    { appToolName = "task"
+    , appToolDescription = taskDescription
+    , appToolParameters =
+        [ PropertySchema "prompt" PropertyString True $ Just
+            "The full task prompt for the subagent to execute."
+        , PropertySchema "description" PropertyString True $ Just
+            "Short description of the task (3-5 words)."
+        , PropertySchema "subagent_type" PropertyString False $ Just
+            "Name of the subagent type to launch. Built-in types: \"general-purpose\", \"explore\", \"plan\"."
+        , PropertySchema "run_in_background" PropertyBoolean False $ Just
+            "Returns immediately with a subagent_id. Use get_task_output to retrieve results. Defaults to true."
+        , PropertySchema "resume_from" PropertyString False $ Just
+            "Resume from a previously completed subagent's conversation. Pass the subagent_id from a prior task call."
+        , PropertySchema "cwd" PropertyString False $ Just
+            "Explicit working directory for the subagent. Mutually exclusive with isolation=\"worktree\"."
+        , PropertySchema "model" PropertyString False $ Just
+            "Optional model slug. Omit to inherit the parent model."
+        , PropertySchema "isolation" PropertyString False $ Just
+            "Isolation mode: \"none\" (default) or \"worktree\". Worktree isolation is not supported yet."
+        ]
+    , appToolHandler = typedTool "task" (runTask ctx typesRef)
+    , appToolKind = JsonFunction
+    , appToolReadOnly = False
+    , appToolIsReadOnlyCall = Nothing
+    }
+
+taskDescription :: Text
+taskDescription =
+    "Start a subagent that works on a task independently and reports back.\n\n\
+    \Agent types:\n\n\
+    \- **general-purpose**: General purpose agent for multi-step tasks. Has access to all tools including task.\n\
+    \- **explore**: Fast, read-only agent specialized for codebase exploration. Read-only — has access to: read_file, list_dir, grep.\n\
+    \- **plan**: Software architect for planning implementation strategies. Read-only — has access to: read_file, list_dir, grep, enter_plan_mode, exit_plan_mode, ask_user_question.\n\n\
+    \## Usage notes\n\
+    \- When the agent is done, it returns a single message with its agent ID. Use that ID to resume the agent later for follow-up work.\n\
+    \- run_in_background: Returns immediately with a subagent_id. Use get_task_output to retrieve results. This is set to true by default.\n\
+    \- When using the task tool, you must specify a subagent_type parameter to select which agent type to use.\n\
+    \- When launching independent subagents, you MUST incorporate the results into the task based on requirements BEFORE concluding.\n\n\
+    \Resuming a previous agent (resume_from):\n\
+    \- Use resume_from to continue a previously completed subagent's conversation. Pass the subagent_id returned by a prior task call.\n\
+    \- The resumed agent must use the same subagent_type as the source.\n\n\
+    \Isolation mode:\n\
+    \- isolation=\"worktree\" is not supported yet; use the default shared workspace."
+
+runTask
+    :: MultiAgentContext
+    -> IORef (Map SubagentId Text)
+    -> TaskArgs
+    -> IO (Either Text Text)
+runTask ctx typesRef args
+    | Text.null (Text.strip args.prompt) =
+        pure (Left "task requires a non-empty prompt")
+    | Text.null (Text.strip args.description) =
+        pure (Left "task requires a non-empty description")
+    | args.subagentType `notElem` knownSubagentTypes =
+        pure $ Left $
+            "Unknown subagent_type: "
+                <> args.subagentType
+                <> ". Known types: "
+                <> Text.intercalate ", " knownSubagentTypes
+    | Just iso <- args.isolation
+    , Text.toLower (Text.strip iso) `elem` ["worktree", "work_tree", "work-tree"] =
+        pure (Left "isolation=\"worktree\" is not supported yet. Omit isolation or use \"none\".")
+    | Just _ <- args.cwd
+    , Just iso <- args.isolation
+    , Text.toLower (Text.strip iso) `notElem` ["none", ""] =
+        pure (Left "cwd and isolation are mutually exclusive.")
+    | Just _ <- args.cwd =
+        -- Explicit cwd overrides are accepted later; for v1 reject to avoid
+        -- surprising ToolEnv mismatches until child cwd wiring exists.
+        pure (Left "task cwd overrides are not supported yet. Omit cwd to use the parent working directory.")
+    | Just resumeId <- args.resumeFrom = resumeTask ctx typesRef args resumeId
+    | otherwise = spawnFresh ctx typesRef args
+
+spawnFresh
+    :: MultiAgentContext
+    -> IORef (Map SubagentId Text)
+    -> TaskArgs
+    -> IO (Either Text Text)
+spawnFresh ctx typesRef args = do
+    -- model override accepted but unused until child runners plumb it.
+    _ <- pure args.model
+    result <- spawnSubagent
+        ctx.multiRegistry
+        ctx.multiSelfId
+        ctx.multiDepth
+        args.prompt
+        (Just args.description)
+    case result of
+        Left err -> pure (Left err)
+        Right agentId -> do
+            recordAgentType typesRef agentId args.subagentType
+            if args.runInBackground
+                then pure $ Right $ formatTaskStarted agentId args
+                else do
+                    (statuses, timedOut) <-
+                        waitSubagents ctx.multiRegistry [agentId] defaultWaitTimeoutMs
+                    pure $ Right $ formatTaskCompleted agentId args timedOut
+                        (Map.lookup agentId statuses)
+
+resumeTask
+    :: MultiAgentContext
+    -> IORef (Map SubagentId Text)
+    -> TaskArgs
+    -> Text
+    -> IO (Either Text Text)
+resumeTask ctx typesRef args resumeId = do
+    let agentId = SubagentId resumeId
+    status <- getStatus ctx.multiRegistry agentId
+    case status of
+        NotFound -> pure (Left ("unknown subagent id: " <> resumeId))
+        Closed -> pure (Left "cannot resume a closed subagent; it must still be open (completed).")
+        Running -> pure (Left "cannot resume_from a running subagent; wait for it to finish first.")
+        Pending -> pure (Left "cannot resume_from a pending subagent; wait for it to finish first.")
+        _ -> do
+            mtype <- lookupAgentType typesRef agentId
+            case mtype of
+                Just prior
+                    | prior /= args.subagentType ->
+                        pure $ Left $
+                            "resume_from subagent_type mismatch: source is "
+                                <> prior
+                                <> ", requested "
+                                <> args.subagentType
+                _ -> do
+                    recordAgentType typesRef agentId args.subagentType
+                    sent <- sendInput ctx.multiRegistry agentId args.prompt False
+                    case sent of
+                        Left err -> pure (Left err)
+                        Right _ ->
+                            if args.runInBackground
+                                then pure $ Right $ formatTaskStarted agentId args
+                                else do
+                                    (statuses, timedOut) <-
+                                        waitSubagents ctx.multiRegistry [agentId] defaultWaitTimeoutMs
+                                    pure $ Right $ formatTaskCompleted agentId args timedOut
+                                        (Map.lookup agentId statuses)
+
+formatTaskStarted :: SubagentId -> TaskArgs -> Text
+formatTaskStarted agentId args =
+    "Subagent started in background.\n\
+    \subagent_id: "
+        <> agentId.unSubagentId
+        <> "\n\
+        \type: "
+        <> args.subagentType
+        <> "\n\
+        \description: "
+        <> args.description
+        <> "\n\
+        \Use get_task_output with this subagent_id to retrieve results. Do not poll in a loop."
+
+formatTaskCompleted
+    :: SubagentId
+    -> TaskArgs
+    -> Bool
+    -> Maybe SubagentStatus
+    -> Text
+formatTaskCompleted agentId args timedOut mstatus =
+    let header =
+            "subagent_id: "
+                <> agentId.unSubagentId
+                <> "\ntype: "
+                <> args.subagentType
+                <> "\ndescription: "
+                <> args.description
+                <> "\n"
+        body = case mstatus of
+            Just (Completed (Just text)) -> "status: completed\nfinal:\n" <> text
+            Just (Completed Nothing) -> "status: completed"
+            Just (Errored err) -> "status: errored\nerror: " <> err
+            Just Interrupted -> "status: interrupted"
+            Just Closed -> "status: shutdown"
+            Just Running
+                | timedOut -> "status: running (wait timed out)"
+                | otherwise -> "status: running"
+            Just Pending -> "status: pending"
+            Just NotFound -> "status: not_found"
+            Nothing -> "status: unknown"
+    in header <> body
+
+recordAgentType :: IORef (Map SubagentId Text) -> SubagentId -> Text -> IO ()
+recordAgentType typesRef agentId agentType =
+    atomicModifyIORef' typesRef \m -> (Map.insert agentId agentType m, ())
+
+lookupAgentType :: IORef (Map SubagentId Text) -> SubagentId -> IO (Maybe Text)
+lookupAgentType typesRef agentId = Map.lookup agentId <$> readIORef typesRef
+
+-- | Restrict the child tool surface by subagent type.
+filterGrokToolsForType :: Text -> [AppTool] -> [AppTool]
+filterGrokToolsForType agentType tools = case agentType of
+    "explore" -> filter ((`elem` exploreNames) . (.appToolName)) tools
+    "plan" -> filter ((`elem` planNames) . (.appToolName)) tools
+    _ -> tools
+  where
+    exploreNames =
+        [ "read_file"
+        , "list_dir"
+        , "grep"
+        , "run_terminal_cmd"
+        , "run_ghci"
+        , "get_task_output"
+        , "kill_task"
+        ]
+    planNames =
+        [ "read_file"
+        , "list_dir"
+        , "grep"
+        , "run_terminal_cmd"
+        , "run_ghci"
+        , "get_task_output"
+        , "kill_task"
+        , "enter_plan_mode"
+        , "exit_plan_mode"
+        , "ask_user_question"
+        ]

--- a/packages/agent-core/test/Agent/Tools/GhciSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/GhciSpec.hs
@@ -23,6 +23,8 @@ import qualified Data.Text as Text
 import System.Directory (getTemporaryDirectory, removeDirectoryRecursive)
 import System.FilePath ((</>))
 import System.Posix.Temp (mkdtemp)
+import Data.IORef
+import qualified Data.Map.Strict as Map
 import Test.Hspec
 
 spec :: Spec
@@ -119,7 +121,8 @@ withTempTools action =
         session <- newGrokSession env
         ghci <- newGhciSession env
         plan <- newPlanModeEnv env.toolCwd Nothing
-        pure (dir, (session, ghci), grokTools session ghci plan)
+        typesRef <- newIORef Map.empty
+        pure (dir, (session, ghci), grokTools session ghci plan Nothing typesRef)
     release (dir, (session, ghci), _) = do
         closeGrokSession session
         closeGhciSession ghci

--- a/packages/agent-core/test/Agent/Tools/Grok/TaskSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/Grok/TaskSpec.hs
@@ -1,0 +1,75 @@
+module Agent.Tools.Grok.TaskSpec (spec) where
+
+import Agent.Loop (LoopError(..), LoopResult(..), defaultLoopDispatch)
+import Agent.Subagents
+import Agent.ToolDispatch
+    ( ToolCallResult(..)
+    , dispatchToolCall
+    , functionToolCall
+    , noArgsTool
+    )
+import Agent.Tools.Grok.Task
+import Agent.Tools.MultiAgents (MultiAgentContext(..))
+import Agent.Tools.Types (AppTool(..), AppToolKind(..))
+import Data.IORef
+import qualified Data.Map.Strict as Map
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Test.Hspec
+
+spec :: Spec
+spec = describe "Agent.Tools.Grok.Task" do
+    it "defaults run_in_background and spawns a background agent" do
+        registry <- newSubagentRegistry defaultSubagentConfig "/tmp"
+            (\_ _ prompt _ -> pure $ Right LoopResult
+                { finalResponseId = "c"
+                , finalText = Just ("done:" <> prompt)
+                , turnsUsed = 1
+                })
+            (\_ _ -> pure ())
+        typesRef <- newIORef Map.empty
+        let ctx = MultiAgentContext registry Nothing 0
+            tool = taskTool ctx typesRef
+        result <- dispatchToolCall defaultLoopDispatch [tool.appToolHandler]
+            (functionToolCall "c1" "task"
+                "{\"prompt\":\"hello\",\"description\":\"test task\"}")
+        result.output `shouldSatisfy` Text.isInfixOf "Subagent started in background"
+        result.output `shouldSatisfy` Text.isInfixOf "subagent_id: agent-"
+        closeSubagentRegistry registry
+
+    it "filters explore tools to a read-mostly set" do
+        let tools =
+                [ fake "read_file"
+                , fake "search_replace"
+                , fake "task"
+                , fake "grep"
+                , fake "run_terminal_cmd"
+                ]
+            names = map (.appToolName) (filterGrokToolsForType "explore" tools)
+        names `shouldBe` ["read_file", "grep", "run_terminal_cmd"]
+        names `shouldNotContain` ["search_replace"]
+        names `shouldNotContain` ["task"]
+
+    it "rejects worktree isolation" do
+        registry <- newSubagentRegistry defaultSubagentConfig "/tmp"
+            (\_ _ _ _ -> pure $ Left LoopNoResponseId)
+            (\_ _ -> pure ())
+        typesRef <- newIORef Map.empty
+        let ctx = MultiAgentContext registry Nothing 0
+            tool = taskTool ctx typesRef
+        result <- dispatchToolCall defaultLoopDispatch [tool.appToolHandler]
+            (functionToolCall "c1" "task"
+                "{\"prompt\":\"x\",\"description\":\"y\",\"isolation\":\"worktree\"}")
+        result.output `shouldSatisfy` Text.isInfixOf "worktree"
+        closeSubagentRegistry registry
+
+fake :: Text -> AppTool
+fake name = AppTool
+    { appToolName = name
+    , appToolDescription = name
+    , appToolParameters = []
+    , appToolHandler = noArgsTool name (pure (Right "ok"))
+    , appToolKind = JsonFunction
+    , appToolReadOnly = True
+    , appToolIsReadOnlyCall = Nothing
+    }

--- a/packages/agent-core/test/Agent/Tools/GrokSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/GrokSpec.hs
@@ -1,15 +1,20 @@
 module Agent.Tools.GrokSpec (spec) where
 
-import Agent.Loop (defaultLoopDispatch)
+import Agent.Loop (LoopError(..), defaultLoopDispatch)
 import Agent.Provider (Provider(..))
+import Agent.Subagents (SubagentId, closeSubagentRegistry, defaultSubagentConfig, newSubagentRegistry)
 import Agent.ToolDispatch (ToolCallResult(..), dispatchToolCall, functionToolCall)
 import Agent.Tools (CodingTools(..), appToolHandlers, codingToolsFor, defaultToolEnv)
 import Agent.Tools.Grok (closeGrokSession, grokTools, newGrokSession)
 import Agent.Tools.Ghci (GhciSession, closeGhciSession, newGhciSession)
 import Agent.Tools.Grok.Shell (GrokSession(..), PersistentShell(..), hasUnwaitedBackgroundOp)
+import Agent.Tools.MultiAgents (MultiAgentContext(..))
 import Agent.Tools.PlanMode (newPlanModeEnv)
 import Agent.Tools.Types (AppTool(..), ToolEnv(..))
 import Control.Concurrent (threadDelay)
+import Data.IORef
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
 import Control.Concurrent.MVar (readMVar)
 import Control.Exception (bracket, finally)
 import Data.Text (Text)
@@ -30,7 +35,8 @@ spec = describe "Agent.Tools.Grok" do
     it "advertises grok-build wire names and not Codex names" do
         withTempSession \(session, ghci) -> do
             plan <- newPlanModeEnv session.grokEnv.toolCwd Nothing
-            let names = map (.appToolName) (grokTools session ghci plan)
+            typesRef <- newIORef (Map.empty :: Map SubagentId Text)
+            let names = map (.appToolName) (grokTools session ghci plan Nothing typesRef)
             names `shouldBe`
                 [ "read_file"
                 , "grep"
@@ -52,6 +58,19 @@ spec = describe "Agent.Tools.Grok" do
                 map (.appToolName) xai.codingAppTools `shouldBe` names
                 map (.appToolName) openrouter.codingAppTools `shouldBe` names)
                 `finally` (xai.codingClose >> openrouter.codingClose)
+
+
+    it "registers task when a multi-agent context is provided" do
+        withTempSession \(session, ghci) -> do
+            plan <- newPlanModeEnv session.grokEnv.toolCwd Nothing
+            registry <- newSubagentRegistry defaultSubagentConfig session.grokEnv.toolCwd
+                (\_ _ _ _ -> pure $ Left LoopNoResponseId)
+                (\_ _ -> pure ())
+            typesRef <- newIORef Map.empty
+            let ctx = MultiAgentContext registry Nothing 0
+                names = map (.appToolName) (grokTools session ghci plan (Just ctx) typesRef)
+            names `shouldContain` ["task"]
+            closeSubagentRegistry registry
 
     it "reads a file with grok line-number anchors" do
         withTempSession \(session, ghci) -> do
@@ -268,8 +287,9 @@ spec = describe "Agent.Tools.Grok" do
 runTool :: GrokSession -> GhciSession -> Text -> Text -> IO Text
 runTool session ghci name arguments = do
     plan <- newPlanModeEnv session.grokEnv.toolCwd Nothing
+    typesRef <- newIORef (Map.empty :: Map SubagentId Text)
     result <- dispatchToolCall defaultLoopDispatch
-        (appToolHandlers (grokTools session ghci plan))
+        (appToolHandlers (grokTools session ghci plan Nothing typesRef))
         (functionToolCall "call-1" name arguments)
     pure result.output
 

--- a/packages/agent-core/test/Spec.hs
+++ b/packages/agent-core/test/Spec.hs
@@ -11,6 +11,7 @@ import qualified Agent.ToolDSLSpec as ToolDSLSpec
 import qualified Agent.Tools.CodexSpec as CodexToolsSpec
 import qualified Agent.Tools.DangerousSpec as DangerousSpec
 import qualified Agent.Tools.GrokSpec as GrokToolsSpec
+import qualified Agent.Tools.Grok.TaskSpec as GrokTaskSpec
 import qualified Agent.Tools.GhciSpec as GhciSpec
 import qualified Agent.Tools.IOSpec as IOSpec
 import qualified Agent.Transport.WebSocketSpec as WebSocketSpec
@@ -27,6 +28,7 @@ main = hspec do
     ToolDispatchSpec.spec
     ToolDSLSpec.spec
     GrokToolsSpec.spec
+    GrokTaskSpec.spec
     GhciSpec.spec
     IOSpec.spec
     CodexToolsSpec.spec


### PR DESCRIPTION
## Summary
- Add grok-build `task` for XAI/OpenRouter on the existing STM `SubagentRegistry` (nestable; background spawn by default).
- Route `get_task_output` / `kill_task` to shell tasks (`tN`) or subagents (`agent-…`) by id.
- Filter child tools for `general-purpose` / `explore` / `plan`; wire HTTP child runners with per-agent transcripts and completion notices.

## Test plan
- [x] `cabal test agent-core` (includes `Agent.Tools.Grok.TaskSpec` + task registration)
- [x] `cabal test agent-cli`
- [ ] Manual XAI smoke: `task` with `run_in_background`, then `get_task_output` / `kill_task`