### PR TITLE
feat: add /clear and /new session commands

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -89,8 +89,10 @@ import Agent.ProjectInstructions
     , loadedInstructionFiles
     )
 import Agent.OpenAI.Compaction
-    ( compactSessionUserText
-    , isCompactSessionTurn
+    ( clearSessionUserText
+    , compactSessionUserText
+    , isTranscriptResetTurn
+    , newSessionUserText
     )
 import Agent.OpenAI.LoopBackend (openAiBackend, toolResultToItem)
 import Agent.OpenAI.Responses.Types
@@ -117,6 +119,7 @@ import Agent.Subagents
     , SubagentSpawnEnv(..)
     , SubagentStatus(..)
     , closeSubagentRegistry
+    , resetSubagentRegistry
     , defaultSubagentConfig
     , formatCompletionNotice
     , getPreviousResponseId
@@ -177,7 +180,7 @@ import Data.Time.Clock (diffUTCTime, getCurrentTime, utctDay)
 import Data.Time.Format (defaultTimeLocale, formatTime)
 import System.Directory (getCurrentDirectory, getHomeDirectory, makeAbsolute, setCurrentDirectory)
 import System.Environment (getArgs, getProgName, lookupEnv)
-import System.FilePath ((</>))
+import System.FilePath ((</>), takeDirectory)
 import System.Console.ANSI.Codes (clearFromCursorToLineEndCode)
 import System.Exit (die, exitFailure)
 import System.IO (Handle, hFlush, hIsTerminalDevice, stderr, stdin, stdout)
@@ -438,8 +441,8 @@ runAgent options = do
                                     noticingBackend =
                                         withPendingNotices pendingNotices lockedBackend
                                 runSession options provider policy tools toolEnv planMode prompt paramsRef transcriptRef
-                                    initialPrevious persist projectRoot (Just loaded.loadedTokenProvider) agentsContext escPaused interrupt
-                                    subagentStoreRoot noticingBackend)
+                                    initialPrevious persist projectRoot home cwd (Just loaded.loadedTokenProvider) agentsContext escPaused interrupt
+                                    multiCtx subagentSessions pendingNotices subagentStoreRoot noticingBackend)
                             >>= \case
                                 Left (CodexAuthFailed err) -> die ("openai auth: " <> show err)
                                 Right result -> pure result
@@ -467,8 +470,8 @@ runAgent options = do
                                     xaiBackend xaiOptions loaded.loadedTokenProvider
                                         (readIORef paramsRef) transcriptRef
                         runSession options provider policy tools toolEnv planMode prompt paramsRef transcriptRef
-                            initialPrevious persist projectRoot (Just loaded.loadedTokenProvider) agentsContext escPaused interrupt
-                            subagentStoreRoot backend
+                            initialPrevious persist projectRoot home cwd (Just loaded.loadedTokenProvider) agentsContext escPaused interrupt
+                            multiCtx subagentSessions pendingNotices subagentStoreRoot backend
                     OpenRouterProvider -> do
                         openRouterOptions <- OpenRouter.clientOptionsFromEnv
                         case multiCtx of
@@ -493,8 +496,8 @@ runAgent options = do
                                     openRouterBackend openRouterOptions loaded.loadedTokenProvider
                                         (readIORef paramsRef) transcriptRef
                         runSession options provider policy tools toolEnv planMode prompt paramsRef transcriptRef
-                            initialPrevious persist projectRoot (Just loaded.loadedTokenProvider) agentsContext escPaused interrupt
-                            subagentStoreRoot backend
+                            initialPrevious persist projectRoot home cwd (Just loaded.loadedTokenProvider) agentsContext escPaused interrupt
+                            multiCtx subagentSessions pendingNotices subagentStoreRoot backend
 
 preparePersistence
     :: CliOptions
@@ -610,14 +613,19 @@ runSession
     -> Maybe Text
     -> Maybe (IORef (Either SessionCreate SessionHandle))
     -> FilePath
+    -> FilePath
+    -> FilePath
     -> Maybe TokenProvider
     -> IORef (Maybe Text)
     -> IORef Bool
     -> InterruptState
+    -> Maybe MultiAgentContext
+    -> IORef (Map SubagentId SubagentSession)
+    -> IORef [Text]
     -> SubagentStoreRoot
     -> Backend
     -> IO DevResult
-runSession options provider policy tools toolEnv planMode prompt paramsRef transcriptRef initialPrevious persist projectRoot tokenProvider agentsContext escPaused interrupt storeRoot backend = do
+runSession options provider policy tools toolEnv planMode prompt paramsRef transcriptRef initialPrevious persist projectRoot home cwd tokenProvider agentsContext escPaused interrupt multiCtx subagentSessions pendingNotices storeRoot backend = do
     printed <- newIORef False
     attachmentsRef <- newIORef []
     textBuffer <- newIORef ""
@@ -630,6 +638,17 @@ runSession options provider policy tools toolEnv planMode prompt paramsRef trans
     modelRef <- newIORef =<< (currentModel <$> readIORef paramsRef)
     ioLock <- newMVar ()
     previous <- newIORef initialPrevious
+    let sessionReset = do
+            resetLiveConversation previous transcriptRef attachmentsRef planMode
+            writeIORef pendingNotices []
+            writeIORef subagentSessions Map.empty
+            case multiCtx of
+                Just ctx -> resetSubagentRegistry ctx.multiRegistry
+                Nothing -> pure ()
+            freshAgents <-
+                loadAgentsContext options provider home cwd [] Nothing
+            fresh <- readIORef freshAgents
+            writeIORef agentsContext fresh
     policyRef <- newIORef policy
     stderrTty <- hIsTerminalDevice stderr
     useColor <- resolveColor stdout
@@ -678,7 +697,7 @@ runSession options provider policy tools toolEnv planMode prompt paramsRef trans
         Nothing ->
             repl config render provider previous printed paramsRef policyRef
                 transcriptRef persist planMode projectRoot tokenProvider agentsContext
-                escPaused attachmentsRef interrupt storeRoot
+                escPaused attachmentsRef interrupt storeRoot sessionReset
 
 repl
     :: LoopConfig
@@ -698,8 +717,9 @@ repl
     -> IORef [ImageAttachment]
     -> InterruptState
     -> SubagentStoreRoot
+    -> IO ()
     -> IO DevResult
-repl config render provider previous printed paramsRef policyRef transcriptRef persist planMode projectRoot tokenProvider agentsContext escPaused attachmentsRef interrupt storeRoot = do
+repl config render provider previous printed paramsRef policyRef transcriptRef persist planMode projectRoot tokenProvider agentsContext escPaused attachmentsRef interrupt storeRoot sessionReset = do
     stdoutColor <- resolveColor stdout
     planActive <- isPlanModeActive planMode
     planPending <- (== PlanPending) <$> readIORef planMode.planStateRef
@@ -932,6 +952,106 @@ repl config render provider previous printed paramsRef policyRef transcriptRef p
                     ReplResume maybeId -> do
                         handleResume maybeId persist
                         continue
+                    ReplClear -> do
+                        sessionReset
+                        color <- resolveColor stderr
+                        case persist of
+                            Nothing ->
+                                Text.hPutStrLn stderr
+                                    (roleMuted color (glyphOk <> "conversation cleared"))
+                            Just slotRef -> do
+                                now <- getCurrentTime
+                                slot <- readIORef slotRef
+                                case slot of
+                                    Left _ ->
+                                        Text.hPutStrLn stderr
+                                            (roleMuted color (glyphOk <> "conversation cleared"))
+                                    Right handle -> do
+                                        let turn = SessionTurn
+                                                { turnAt = now
+                                                , turnUserText = clearSessionUserText
+                                                , turnAssistantText =
+                                                    Just "Conversation cleared."
+                                                , turnResponseId = Nothing
+                                                , turnItems = []
+                                                }
+                                        handle' <- appendTurnKeepTitle handle turn
+                                        let meta = handle'.sessionMeta
+                                                { metaLastResponseId = Nothing
+                                                , metaUpdatedAt = now
+                                                }
+                                        writeSessionMeta handle'.sessionMetaPath meta
+                                        writeIORef slotRef
+                                            (Right handle'{sessionMeta = meta})
+                                        Text.hPutStrLn stderr
+                                            (roleMuted color
+                                                (glyphOk
+                                                    <> "conversation cleared (session "
+                                                    <> meta.metaId
+                                                    <> ")"))
+                        continue
+                    ReplNew -> do
+                        sessionReset
+                        color <- resolveColor stderr
+                        case persist of
+                            Nothing -> do
+                                Text.hPutStrLn stderr
+                                    (roleMuted color
+                                        (glyphOk <> "started a fresh conversation"))
+                                continue
+                            Just slotRef -> do
+                                now <- getCurrentTime
+                                params <- readIORef paramsRef
+                                home <- getHomeDirectory
+                                slot <- readIORef slotRef
+                                let model = currentModel params
+                                    effort = currentEffort params
+                                    create = case slot of
+                                        Left pending ->
+                                            pending
+                                                { createModel = model
+                                                , createEffort = effort
+                                                , createTitleHint = Nothing
+                                                }
+                                        Right handle ->
+                                            SessionCreate
+                                                { createRoot =
+                                                    takeDirectory handle.sessionDir
+                                                , createProvider = provider
+                                                , createModel = model
+                                                , createCwd =
+                                                    handle.sessionMeta.metaCwd
+                                                , createEffort = effort
+                                                , createTitleHint = Nothing
+                                                }
+                                handle <- createSession create
+                                let turn = SessionTurn
+                                        { turnAt = now
+                                        , turnUserText = newSessionUserText
+                                        , turnAssistantText =
+                                            Just "Started a new session."
+                                        , turnResponseId = Nothing
+                                        , turnItems = []
+                                        }
+                                handle' <- appendTurnKeepTitle handle turn
+                                let meta = handle'.sessionMeta
+                                        { metaLastResponseId = Nothing
+                                        , metaUpdatedAt = now
+                                        }
+                                writeSessionMeta handle'.sessionMetaPath meta
+                                writeIORef slotRef
+                                    (Right handle'{sessionMeta = meta})
+                                writeIORef planMode.planSessionDir
+                                    (Just handle'.sessionDir)
+                                writeIORef storeRoot (Just handle'.sessionDir)
+                                tty <- hIsTerminalDevice stdout
+                                setCliWindowTitle tty stdout
+                                    (cliWindowTitle meta.metaCwd
+                                        (Just meta.metaTitle))
+                                Text.hPutStrLn stderr
+                                    (roleMuted color
+                                        (glyphOk <> "new session: " <> meta.metaId))
+                                continue
                     ReplShowSession -> do
                         color <- resolveColor stdout
                         case persist of
@@ -964,7 +1084,7 @@ repl config render provider previous printed paramsRef policyRef transcriptRef p
     continue =
         repl config render provider previous printed paramsRef policyRef
             transcriptRef persist planMode projectRoot tokenProvider agentsContext
-            escPaused attachmentsRef interrupt storeRoot
+            escPaused attachmentsRef interrupt storeRoot sessionReset
 
 applyModelChange
     :: Provider
@@ -1740,14 +1860,29 @@ childApprove policy tools call = case policy of
 -- OpenAI keeps @store = true@ so @previous_response_id@ can continue a chain;
 -- xAI/OpenRouter force @store = false@ and replay local transcripts instead.
 
+
+-- | Drop live conversation state without touching persisted session files.
+resetLiveConversation
+    :: IORef (Maybe Text)
+    -> IORef [ResponseItem]
+    -> IORef [ImageAttachment]
+    -> PlanModeEnv
+    -> IO ()
+resetLiveConversation previous transcriptRef attachmentsRef planMode = do
+    writeIORef previous Nothing
+    writeIORef transcriptRef []
+    writeIORef attachmentsRef []
+    deactivatePlanMode planMode
+
 -- | Apply compact turns as full transcript replacements when resuming.
 foldSessionItems :: [SessionTurn] -> [ResponseItem]
 foldSessionItems = go []
   where
     go acc [] = acc
     go acc (turn:rest)
-        | isCompactSessionTurn turn.turnUserText
-            && not (null turn.turnItems) =
+        | isTranscriptResetTurn turn.turnUserText =
+            -- /clear and /new store an empty snapshot; /compact stores the
+            -- rebuilt history. Either way, turnItems replaces prior history.
             go turn.turnItems rest
         | otherwise = go (acc <> turn.turnItems) rest
 

--- a/packages/agent-cli/src/Agent/CLI/Command.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command.hs
@@ -50,6 +50,10 @@ data ReplAction
     -- ^ @Nothing@ opens the session picker; @Just@ is a session id.
     | ReplCompact (Maybe Text)
     -- ^ Optional focus note for what to keep while compacting history.
+    | ReplClear
+      -- ^ Soft-reset live transcript; keep the same session id.
+    | ReplNew
+      -- ^ Start a fresh persisted session id with empty history.
     | ReplCommandError Text
     deriving (Eq, Show)
 
@@ -72,6 +76,8 @@ slashCommands =
     , cmd "session" [] "/session" "Print the current session id"
     , cmd "resume" [] "/resume [ID]" "Pick a session to resume, or print a --resume hint"
     , cmd "compact" [] "/compact [FOCUS]" "Summarize history to free context"
+    , cmd "clear" [] "/clear" "Reset the live conversation (same session id)"
+    , cmd "new" [] "/new" "Start a fresh persisted session id"
     , cmd "reload-auth" [] "/reload-auth" "Re-read xAI/OpenRouter credentials"
     , cmd "paste" [] "/paste [--send] [TEXT]" "Attach a clipboard image to the next prompt"
     , cmd "attachments" [] "/attachments" "List queued clipboard images"
@@ -134,6 +140,14 @@ parseSlash line = case Text.words line of
                         Text.strip (Text.drop (Text.length command) line)
                 in ReplCompact
                     (if Text.null focus then Nothing else Just focus)
+            "clear" ->
+                if null args
+                    then ReplClear
+                    else ReplCommandError "usage: /clear"
+            "new" ->
+                if null args
+                    then ReplNew
+                    else ReplCommandError "usage: /new"
             "reload-auth" ->
                 if null args
                     then ReplReloadAuth

--- a/packages/agent-cli/src/Agent/CLI/Options.hs
+++ b/packages/agent-cli/src/Agent/CLI/Options.hs
@@ -243,6 +243,7 @@ usage = unlines
     , "message; /paste --send [TEXT] sends immediately. /attachments lists queued"
     , "images; /clear-attachments drops them. Linux uses wl-paste/xclip."
     , "with an optional caption. /session prints the current session id."
+    , "/clear resets the live conversation; /new starts a fresh session id."
     , "/reload-auth forces a re-read of xAI/OpenRouter credentials;"
     , "auth failures also reload once and retry automatically."
     , "Ctrl-D or :q exits."

--- a/packages/agent-cli/src/Agent/CLI/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session.hs
@@ -6,6 +6,7 @@ module Agent.CLI.Session
     , SessionCreate(..)
     , createSession
     , appendTurn
+    , appendTurnKeepTitle
     , loadSession
     , listSessions
     , sessionsRoot
@@ -232,6 +233,24 @@ appendTurn handle turn = do
             }
     writeSessionMeta handle.sessionMetaPath meta
     pure handle { sessionMeta = meta }
+
+-- | Like 'appendTurn', but never derives the session title from this turn.
+-- Used for synthetic markers such as @/new@ and @/clear@.
+appendTurnKeepTitle :: SessionHandle -> SessionTurn -> IO SessionHandle
+appendTurnKeepTitle handle turn = do
+    let path = handle.sessionTranscriptPath
+    existed <- doesFileExist path
+    LBS.appendFile path (Aeson.encode turn <> "\n")
+    if existed then pure () else setFileMode path 0o600
+    now <- getCurrentTime
+    let meta0 = handle.sessionMeta
+        meta = meta0
+            { metaUpdatedAt = now
+            , metaLastResponseId = turn.turnResponseId <|> meta0.metaLastResponseId
+            }
+    writeSessionMeta handle.sessionMetaPath meta
+    pure handle { sessionMeta = meta }
+
 
 loadSession :: FilePath -> Text -> IO (Either String (SessionMeta, [SessionTurn]))
 loadSession root sessionId = do

--- a/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
@@ -56,6 +56,14 @@ spec = do
             parseReplLine "/reload-auth now"
                 `shouldBe` ReplCommandError "usage: /reload-auth"
 
+        it "clears or starts a new session" do
+            parseReplLine "/clear" `shouldBe` ReplClear
+            parseReplLine "/new" `shouldBe` ReplNew
+            parseReplLine "/clear now"
+                `shouldBe` ReplCommandError "usage: /clear"
+            parseReplLine "/new now"
+                `shouldBe` ReplCommandError "usage: /new"
+
         it "compacts with optional focus text" do
             parseReplLine "/compact" `shouldBe` ReplCompact Nothing
             parseReplLine "/compact focus auth"

--- a/packages/agent-core/src/Agent/Subagents.hs
+++ b/packages/agent-core/src/Agent/Subagents.hs
@@ -19,6 +19,7 @@ module Agent.Subagents
     , setSubagentRunner
     , setSubagentOnComplete
     , closeSubagentRegistry
+    , resetSubagentRegistry
     , spawnSubagent
     , restoreSubagent
     , waitSubagents
@@ -180,6 +181,15 @@ closeSubagentRegistry registry = do
         writeTVar registry.registryClosed True
         Map.elems <$> readTVar registry.registryAgents
     mapM_ (shutdownRecord registry) records
+
+-- | Shut down live children and reopen the registry for a fresh session.
+resetSubagentRegistry :: SubagentRegistry -> IO ()
+resetSubagentRegistry registry = do
+    closeSubagentRegistry registry
+    atomically do
+        writeTVar registry.registryAgents Map.empty
+        writeTVar registry.registryLiveCount 0
+        writeTVar registry.registryClosed False
 
 spawnSubagent
     :: SubagentRegistry

--- a/packages/agent-openai/src/Agent/OpenAI/Compaction.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Compaction.hs
@@ -10,7 +10,12 @@ module Agent.OpenAI.Compaction
     , assistantSummaryItem
     , userTextItem
     , isCompactSessionTurn
+    , isClearSessionTurn
+    , isNewSessionTurn
+    , isTranscriptResetTurn
     , compactSessionUserText
+    , clearSessionUserText
+    , newSessionUserText
     ) where
 
 import Agent.OpenAI.Responses.Types
@@ -127,3 +132,23 @@ isCompactSessionTurn :: Text -> Bool
 isCompactSessionTurn text =
     let stripped = Text.strip text
     in stripped == "/compact" || Text.isPrefixOf "/compact " stripped
+
+clearSessionUserText :: Text
+clearSessionUserText = "/clear"
+
+newSessionUserText :: Text
+newSessionUserText = "/new"
+
+isClearSessionTurn :: Text -> Bool
+isClearSessionTurn text = Text.strip text == clearSessionUserText
+
+isNewSessionTurn :: Text -> Bool
+isNewSessionTurn text = Text.strip text == newSessionUserText
+
+-- | Turns that replace the live transcript with their turnItems snapshot
+-- (compact) or empty it (/clear, /new).
+isTranscriptResetTurn :: Text -> Bool
+isTranscriptResetTurn text =
+    isCompactSessionTurn text
+        || isClearSessionTurn text
+        || isNewSessionTurn text

--- a/packages/agent-openai/test/Agent/OpenAI/CompactionSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/CompactionSpec.hs
@@ -36,6 +36,15 @@ spec = do
             isCompactSessionTurn "/compact focus auth" `shouldBe` True
             isCompactSessionTurn "hello" `shouldBe` False
 
+    describe "clear/new session markers" do
+        it "recognizes /clear and /new as transcript resets" do
+            isClearSessionTurn "/clear" `shouldBe` True
+            isNewSessionTurn "/new" `shouldBe` True
+            isTranscriptResetTurn "/clear" `shouldBe` True
+            isTranscriptResetTurn "/new" `shouldBe` True
+            isTranscriptResetTurn "/compact" `shouldBe` True
+            isTranscriptResetTurn "hello" `shouldBe` False
+
   where
     user text = MessageItem ResponseMessage
         { messageId = Nothing


### PR DESCRIPTION
## Summary
- **`/clear`**: soft-reset the live conversation (transcript, `previous_response_id`, attachments, plan mode) while keeping the same session id.
- **`/new`**: start a fresh persisted session id with empty history; updates window title and `dev-resume` pointer.
- Both append a transcript-reset marker (`/clear` / `/new`) so `--resume` reconstructs an empty conversation after that point.
- `/compact` continue to replace history via the same reset-fold path.

## Test plan
- [x] parse tests for `/clear` / `/new`
- [x] marker tests in CompactionSpec
- [ ] Interactive: chat a bit → `/clear` → model has no prior context; `/session` id unchanged
- [ ] Interactive: `/new` → new session id; `/session` shows it; resume stays empty