### PR TITLE
refactor: share JSON field and URL slash helpers

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -86,6 +86,7 @@ import Agent.CLI.Style
 import Agent.CLI.Timestamp (stampTurnInputs, stripBracketedTimestamps)
 import Agent.CLI.Tools (lookupAppTool, schemasFromAppTools)
 import Agent.CLI.Worktree (createWorktree, isUnderWorktreeRoot, worktreeRoot)
+import Agent.JsonText (jsonTextFieldDefault)
 import Agent.Loop
 import Agent.ProjectInstructions
     ( DiscoverOptions(..)
@@ -1581,7 +1582,7 @@ planModeBlocksCall _planMode active planPath call
     | not active = pure False
     | call.name == "apply_patch" = pure True
     | call.name == "search_replace" =
-        let target = jsonArg "file_path" call.arguments
+        let target = jsonTextFieldDefault "file_path" call.arguments
         in pure $
             Text.null target
                 || not (isPlanFileEditTarget planPath (Text.unpack target))
@@ -1591,18 +1592,11 @@ isPlanFileWrite :: PlanModeEnv -> Bool -> FilePath -> ToolCall -> IO Bool
 isPlanFileWrite _planMode active planPath call
     | not active = pure False
     | call.name == "search_replace" =
-        let target = jsonArg "file_path" call.arguments
+        let target = jsonTextFieldDefault "file_path" call.arguments
         in pure $
             not (Text.null target)
                 && isPlanFileEditTarget planPath (Text.unpack target)
     | otherwise = pure False
-
-jsonArg :: Text -> Text -> Text
-jsonArg key arguments = case Aeson.decodeStrict (TextEncoding.encodeUtf8 arguments) of
-    Just (Aeson.Object object) -> case KeyMap.lookup (Key.fromText key) object of
-        Just (Aeson.String value) -> value
-        _ -> ""
-    _ -> ""
 
 toggleAlwaysApprove :: IORef ApprovalPolicy -> FilePath -> IO ()
 toggleAlwaysApprove policyRef projectRoot = do

--- a/packages/agent-cli/src/Agent/CLI/Render.hs
+++ b/packages/agent-cli/src/Agent/CLI/Render.hs
@@ -40,6 +40,7 @@ import Agent.CLI.Style
     , spinnerFrames
     , style
     )
+import Agent.JsonText (jsonTextFieldDefault)
 import Agent.Loop (LoopError(..), LoopEvent(..), TurnOutput(..))
 import Agent.ToolDispatch (ToolCall(..), ToolCallResult(..))
 import Control.Concurrent (ThreadId, forkIO, killThread, threadDelay)
@@ -376,9 +377,9 @@ formatToolBody color call = case call.name of
 -- | Compact unified-diff preview for @search_replace@ arguments.
 formatSearchReplaceDiff :: Bool -> Text -> Text
 formatSearchReplaceDiff color arguments =
-    let path = jsonField "file_path" arguments
-        oldText = jsonField "old_string" arguments
-        newText = jsonField "new_string" arguments
+    let path = jsonTextFieldDefault "file_path" arguments
+        oldText = jsonTextFieldDefault "old_string" arguments
+        newText = jsonTextFieldDefault "new_string" arguments
         header = case (Text.null oldText, Text.null newText) of
             (True, False) -> roleMuted color ("  create " <> path)
             (False, True) -> roleMuted color ("  delete " <> path)
@@ -400,25 +401,18 @@ formatSearchReplaceDiff color arguments =
 
 toolDetail :: ToolCall -> Text
 toolDetail call = case call.name of
-    "read_file" -> jsonField "target_file" call.arguments
-    "list_dir" -> jsonField "target_directory" call.arguments
-    "search_replace" -> jsonField "file_path" call.arguments
-    "grep" -> jsonField "pattern" call.arguments
-    "run_terminal_cmd" -> firstLine (jsonField "command" call.arguments)
-    "run_ghci" -> firstLine (jsonField "expression" call.arguments)
-    "shell_command" -> firstLine (jsonField "command" call.arguments)
+    "read_file" -> jsonTextFieldDefault "target_file" call.arguments
+    "list_dir" -> jsonTextFieldDefault "target_directory" call.arguments
+    "search_replace" -> jsonTextFieldDefault "file_path" call.arguments
+    "grep" -> jsonTextFieldDefault "pattern" call.arguments
+    "run_terminal_cmd" -> firstLine (jsonTextFieldDefault "command" call.arguments)
+    "run_ghci" -> firstLine (jsonTextFieldDefault "expression" call.arguments)
+    "shell_command" -> firstLine (jsonTextFieldDefault "command" call.arguments)
     "apply_patch" -> fromMaybe "patch" (firstPatchPath call.arguments)
     "update_plan" -> "plan"
     "enter_plan_mode" -> "enter"
     "exit_plan_mode" -> "exit"
-    "ask_user_question" -> firstLine (jsonField "question" call.arguments)
-    _ -> ""
-
-jsonField :: Text -> Text -> Text
-jsonField key arguments = case Aeson.decodeStrict (TextEncoding.encodeUtf8 arguments) of
-    Just (Aeson.Object object) -> case KeyMap.lookup (Key.fromText key) object of
-        Just (Aeson.String value) -> value
-        _ -> ""
+    "ask_user_question" -> firstLine (jsonTextFieldDefault "question" call.arguments)
     _ -> ""
 
 firstPatchPath :: Text -> Maybe Text

--- a/packages/agent-core/agent-core.cabal
+++ b/packages/agent-core/agent-core.cabal
@@ -36,6 +36,8 @@ library
                     , Agent.Provider
                     , Agent.Broker
                     , Agent.Loop
+                    , Agent.JsonText
+                    , Agent.Http.Url
                     , Agent.ProjectInstructions
                     , Agent.Subagents
                     , Agent.ToolArgs
@@ -81,6 +83,7 @@ test-suite agent-core-test
     other-modules:    Agent.CancelSpec
                     , Agent.ErrorSpec
                     , Agent.LoopSpec
+                    , Agent.JsonTextSpec
                     , Agent.ProjectInstructionsSpec
                     , Agent.SubagentsSpec
                     , Agent.ToolArgsSpec

--- a/packages/agent-core/src/Agent/Broker.hs
+++ b/packages/agent-core/src/Agent/Broker.hs
@@ -6,6 +6,7 @@ module Agent.Broker
     , newBrokerTokenProviderWithClock
     ) where
 
+import Agent.Http.Url (trimTrailingSlash)
 import Agent.Error (ApiError(..), ErrorType(..))
 import Agent.Provider
     ( AccountFailure(..)
@@ -192,7 +193,7 @@ fetchBrokerTokenExcluding options supportedProviders failed excludedAccountIds =
                     Right token -> pure (Right (Just token))
   where
     requestToken = do
-        request <- parseRequest (trimSlash options.baseUrl <> "/api/v1/token")
+        request <- parseRequest (trimTrailingSlash options.baseUrl <> "/api/v1/token")
         httpLBS
             $ addFailureHeaders failed
             $ setRequestMethod "POST"
@@ -238,5 +239,3 @@ brokerHttpError status body
         } <- Aeson.eitherDecode body = CredentialsExhausted retryAt
     | otherwise = HttpError status "broker could not issue an access token"
 
-trimSlash :: String -> String
-trimSlash = reverse . dropWhile (== '/') . reverse

--- a/packages/agent-core/src/Agent/Http/Url.hs
+++ b/packages/agent-core/src/Agent/Http/Url.hs
@@ -1,0 +1,8 @@
+-- | Small URL helpers shared by HTTP clients.
+module Agent.Http.Url
+    ( trimTrailingSlash
+    ) where
+
+-- | Drop trailing @/@ characters from a URL prefix.
+trimTrailingSlash :: String -> String
+trimTrailingSlash = reverse . dropWhile (== '/') . reverse

--- a/packages/agent-core/src/Agent/JsonText.hs
+++ b/packages/agent-core/src/Agent/JsonText.hs
@@ -1,0 +1,25 @@
+-- | Extract a string field from a JSON object payload (tool arguments).
+module Agent.JsonText
+    ( jsonTextField
+    , jsonTextFieldDefault
+    ) where
+
+import Data.Aeson (Value(..))
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import Data.Text (Text)
+import qualified Data.Text.Encoding as TextEncoding
+
+-- | Read a string field from a JSON object encoded as 'Text'.
+jsonTextField :: Text -> Text -> Maybe Text
+jsonTextField key arguments = case Aeson.decodeStrict (TextEncoding.encodeUtf8 arguments) of
+    Just (Object object) -> case KeyMap.lookup (Key.fromText key) object of
+        Just (String value) -> Just value
+        _ -> Nothing
+    _ -> Nothing
+
+-- | Like 'jsonTextField', returning empty text when missing or not a string.
+jsonTextFieldDefault :: Text -> Text -> Text
+jsonTextFieldDefault key arguments =
+    maybe "" id (jsonTextField key arguments)

--- a/packages/agent-core/src/Agent/Tools/Dangerous.hs
+++ b/packages/agent-core/src/Agent/Tools/Dangerous.hs
@@ -8,6 +8,7 @@ module Agent.Tools.Dangerous
     , forbiddenRmRfReason
     ) where
 
+import Agent.JsonText (jsonTextField)
 import Data.Char (isAlphaNum, toLower)
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -17,7 +18,7 @@ import qualified Data.Text as Text
 shellCommandBlocked :: Text -> Text -> Maybe Text
 shellCommandBlocked toolName argumentsJson
     | toolName `elem` ["run_terminal_cmd", "shell_command"] =
-        case jsonStringField "command" argumentsJson of
+        case jsonTextField "command" argumentsJson of
             Nothing -> Nothing
             Just command
                 | commandLooksLikeRmRf command ->
@@ -116,29 +117,3 @@ tokenize = map Text.pack . go [] . Text.unpack
                 let (tok, rest) = break isHorzSpace cs'
                 in go (tok : acc) rest
     isHorzSpace c = c == ' ' || c == '\t' || c == '\n'
-
--- | Minimal JSON string-field extractor for @{"command":"..."}@ payloads.
--- Avoids pulling aeson into this leaf helper; sufficient for our tool args.
-jsonStringField :: Text -> Text -> Maybe Text
-jsonStringField key raw =
-    let needle = "\"" <> key <> "\""
-    in case Text.breakOn needle raw of
-        (_, rest)
-            | Text.null rest -> Nothing
-            | otherwise ->
-                let afterKey = Text.drop (Text.length needle) rest
-                    afterColon = Text.dropWhile (\c -> c == ' ' || c == '\t' || c == '\n' || c == ':') afterKey
-                in parseJsonString afterColon
-
-parseJsonString :: Text -> Maybe Text
-parseJsonString t = case Text.uncons t of
-    Just ('"', rest) -> go rest ""
-    _ -> Nothing
-  where
-    go txt acc = case Text.uncons txt of
-        Nothing -> Nothing
-        Just ('"', _) -> Just (Text.reverse acc)
-        Just ('\\', rest) -> case Text.uncons rest of
-            Just (c, rest') -> go rest' (Text.cons c acc)
-            Nothing -> Nothing
-        Just (c, rest) -> go rest (Text.cons c acc)

--- a/packages/agent-core/test/Agent/JsonTextSpec.hs
+++ b/packages/agent-core/test/Agent/JsonTextSpec.hs
@@ -1,0 +1,15 @@
+module Agent.JsonTextSpec (spec) where
+
+import Agent.JsonText
+import Test.Hspec
+
+spec :: Spec
+spec = describe "jsonTextField" do
+    it "reads a string field" do
+        jsonTextField "command" "{\"command\":\"ls\"}" `shouldBe` Just "ls"
+        jsonTextFieldDefault "command" "{\"command\":\"ls\"}" `shouldBe` "ls"
+
+    it "returns Nothing / empty for missing or non-string fields" do
+        jsonTextField "command" "{\"description\":\"x\"}" `shouldBe` Nothing
+        jsonTextFieldDefault "command" "not-json" `shouldBe` ""
+        jsonTextField "n" "{\"n\":1}" `shouldBe` Nothing

--- a/packages/agent-core/test/Spec.hs
+++ b/packages/agent-core/test/Spec.hs
@@ -2,6 +2,7 @@ module Main (main) where
 
 import qualified Agent.CancelSpec as CancelSpec
 import qualified Agent.ErrorSpec as ErrorSpec
+import qualified Agent.JsonTextSpec as JsonTextSpec
 import qualified Agent.LoopSpec as LoopSpec
 import qualified Agent.ProjectInstructionsSpec as ProjectInstructionsSpec
 import qualified Agent.SubagentsSpec as SubagentsSpec
@@ -21,6 +22,7 @@ main :: IO ()
 main = hspec do
     CancelSpec.spec
     ErrorSpec.spec
+    JsonTextSpec.spec
     LoopSpec.spec
     ProjectInstructionsSpec.spec
     SubagentsSpec.spec

--- a/packages/agent-openai/src/Agent/OpenAI/Login.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Login.hs
@@ -9,6 +9,7 @@ module Agent.OpenAI.Login
     , writeAuthFile
     ) where
 
+import Agent.Http.Url (trimTrailingSlash)
 import Agent.OpenAI.Auth (deriveAccountId)
 import Control.Concurrent (threadDelay)
 import Control.Exception.Safe (tryAny)
@@ -55,7 +56,7 @@ data Tokens = Tokens
 
 requestDeviceCode :: LoginOptions -> IO (Either Text DeviceCode)
 requestDeviceCode options = safely do
-    request <- parseRequest (trimIssuer options.issuer <> "/api/accounts/deviceauth/usercode")
+    request <- parseRequest (trimTrailingSlash options.issuer <> "/api/accounts/deviceauth/usercode")
     response <- httpLBS
         $ setRequestMethod "POST"
         $ setRequestHeader "Content-Type" ["application/json"]
@@ -66,7 +67,7 @@ requestDeviceCode options = safely do
     authId <- field "device_auth_id" object
     interval <- intervalField object
     pure DeviceCode
-        { verificationUrl = trimIssuer options.issuer <> "/codex/device"
+        { verificationUrl = trimTrailingSlash options.issuer <> "/codex/device"
         , userCode = code
         , deviceAuthId = authId
         , pollIntervalSeconds = max 1 interval
@@ -111,7 +112,7 @@ authValue tokens = do
         ]
 pollOnce :: LoginOptions -> DeviceCode -> IO (Maybe Tokens)
 pollOnce options deviceCode = do
-    request <- parseRequest (trimIssuer options.issuer <> "/api/accounts/deviceauth/token")
+    request <- parseRequest (trimTrailingSlash options.issuer <> "/api/accounts/deviceauth/token")
     response <- httpLBS
         $ setRequestMethod "POST"
         $ setRequestHeader "Content-Type" ["application/json"]
@@ -130,14 +131,14 @@ pollOnce options deviceCode = do
         status -> fail ("device authorization failed with HTTP " <> show status)
   where
     exchange authorizationCode codeVerifier = do
-        request <- parseRequest (trimIssuer options.issuer <> "/oauth/token")
+        request <- parseRequest (trimTrailingSlash options.issuer <> "/oauth/token")
         response <- httpLBS
             $ setRequestMethod "POST"
             $ setRequestHeader "Content-Type" ["application/x-www-form-urlencoded"]
             $ setRequestBodyURLEncoded
                 [ ("grant_type", "authorization_code")
                 , ("code", encode authorizationCode)
-                , ("redirect_uri", encode (Text.pack (trimIssuer options.issuer <> "/deviceauth/callback")))
+                , ("redirect_uri", encode (Text.pack (trimTrailingSlash options.issuer <> "/deviceauth/callback")))
                 , ("client_id", encode options.clientId)
                 , ("code_verifier", encode codeVerifier)
                 ] request
@@ -183,7 +184,6 @@ intervalField object = case KeyMap.lookup "interval" object of
 
 encode = Text.encodeUtf8
 
-trimIssuer = reverse . dropWhile (== '/') . reverse
 
 readMaybeInt value = case reads (Text.unpack value) of
     [(number, "")] -> Just number

--- a/packages/agent-openrouter/src/Agent/OpenRouter/Client.hs
+++ b/packages/agent-openrouter/src/Agent/OpenRouter/Client.hs
@@ -6,6 +6,7 @@ module Agent.OpenRouter.Client
     , createResponseWithEvents
     ) where
 
+import Agent.Http.Url (trimTrailingSlash)
 import Agent.Error (ApiError(..), ErrorType(..))
 import Agent.OpenAI.Responses.Types
 import Agent.Provider (Credential(..), Provider(..))
@@ -61,7 +62,7 @@ createResponseWithEvents options credential request onEvent
         Right response -> handleResponse response
   where
     performRequest = do
-        httpRequest <- parseRequest ("POST " <> trimSlash options.baseUrl <> "/responses")
+        httpRequest <- parseRequest ("POST " <> trimTrailingSlash options.baseUrl <> "/responses")
         httpLBS
             $ setRequestBodyLBS (Aeson.encode (buildRequest options request))
             $ setRequestHeader "Authorization"
@@ -105,5 +106,3 @@ nonEmptyText :: Maybe Text -> Maybe Text
 nonEmptyText (Just value) | not (Text.null (Text.strip value)) = Just value
 nonEmptyText _ = Nothing
 
-trimSlash :: String -> String
-trimSlash = reverse . dropWhile (== '/') . reverse

--- a/packages/agent-xai/src/Agent/XAI/Auth.hs
+++ b/packages/agent-xai/src/Agent/XAI/Auth.hs
@@ -28,6 +28,7 @@ module Agent.XAI.Auth
     , accountIdFromAccessToken
     ) where
 
+import Agent.Http.Url (trimTrailingSlash)
 import Agent.Error (ApiError(..), ErrorType(..))
 import Control.Concurrent (threadDelay)
 import Control.Exception.Safe (tryAny)
@@ -126,7 +127,7 @@ instance Show OAuthTokens where
 -- callers can fall back to credential import.
 requestDeviceAuthorization :: OAuthOptions -> IO (Either Text DeviceAuthorization)
 requestDeviceAuthorization options = safely do
-    request <- parseRequest ("POST " <> trimIssuer options.issuer <> "/oauth2/device/code")
+    request <- parseRequest ("POST " <> trimTrailingSlash options.issuer <> "/oauth2/device/code")
     response <- httpLBS
         $ setRequestHeader "Content-Type" ["application/x-www-form-urlencoded"]
         $ setRequestBodyURLEncoded
@@ -224,7 +225,7 @@ principalFields options = Maybe.catMaybes
 
 postTokenForm :: OAuthOptions -> [(BS.ByteString, BS.ByteString)] -> IO (Response LBS.ByteString)
 postTokenForm options formFields = do
-    request <- parseRequest ("POST " <> trimIssuer options.issuer <> "/oauth2/token")
+    request <- parseRequest ("POST " <> trimTrailingSlash options.issuer <> "/oauth2/token")
     httpLBS
         $ setRequestHeader "Content-Type" ["application/x-www-form-urlencoded"]
         $ setRequestBodyURLEncoded formFields request
@@ -306,5 +307,3 @@ decodeResponse label response = case Aeson.eitherDecode (getResponseBody respons
 lbsPreview :: LBS.ByteString -> String
 lbsPreview = Text.unpack . Text.take 300 . Text.decodeUtf8With (\_ _ -> Just '?') . LBS.toStrict
 
-trimIssuer :: String -> String
-trimIssuer = reverse . dropWhile (== '/') . reverse

--- a/packages/agent-xai/src/Agent/XAI/Client.hs
+++ b/packages/agent-xai/src/Agent/XAI/Client.hs
@@ -8,6 +8,7 @@ module Agent.XAI.Client
     , retryTransientXaiResultWithPolicy
     ) where
 
+import Agent.Http.Url (trimTrailingSlash)
 import Agent.Error
     ( ApiError(..)
     , ErrorType(..)
@@ -95,7 +96,7 @@ createResponseWithEventsPolicy policy options credential request onEvent
             Right response -> handleResponse response
 
     performRequest = do
-        httpRequest <- parseRequest ("POST " <> trimSlash options.baseUrl <> "/responses")
+        httpRequest <- parseRequest ("POST " <> trimTrailingSlash options.baseUrl <> "/responses")
         httpLBS
             $ setRequestBodyLBS (Aeson.encode (buildRequest options request))
             $ setRequestHeader "Authorization"
@@ -161,5 +162,3 @@ isCapacityRetryable = \case
     ConnectionError message -> isCapacityBody message
     _ -> False
 
-trimSlash :: String -> String
-trimSlash = reverse . dropWhile (== '/') . reverse


### PR DESCRIPTION
## Summary
- **`Agent.JsonText`**: shared Aeson helper for tool-argument string fields (`CLI`, `Render`, `Dangerous`).
- **`Agent.Http.Url.trimTrailingSlash`**: shared URL prefix trim (Broker, xAI, OpenRouter, OpenAI login).
- **Reasoning effort stays `Text`.** Effort is model-specific, so there is no shared four-level enum.

## Test plan
- [x] `cabal test` agent-core, agent-cli, agent-openai, agent-xai
- [ ] `/effort` still accepts `low|medium|high|xhigh` as today (provider mapping unchanged)