### PR TITLE
feat: persist subagent transcripts under the session directory

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -55,6 +55,7 @@ library
                     , Agent.CLI.Render
                     , Agent.CLI.Resume
                     , Agent.CLI.Session
+                    , Agent.CLI.SubagentStore
                     , Agent.CLI.Style
                     , Agent.CLI.Timestamp
                     , Agent.CLI.Tools
@@ -110,6 +111,7 @@ test-suite agent-cli-test
                     , Agent.CLI.StyleSpec
                     , Agent.CLI.TimestampSpec
                     , Agent.CLI.SessionSpec
+                    , Agent.CLI.SubagentStoreSpec
                     , Agent.CLI.ToolsSpec
                     , Agent.CLI.WorktreeSpec
     build-depends:    agent-cli

--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -55,6 +55,11 @@ import Agent.CLI.Render
     , renderEvent
     )
 import Agent.CLI.Session
+import Agent.CLI.SubagentStore
+    ( SubagentDiskMeta(..)
+    , loadSubagentState
+    , saveSubagentState
+    )
 import Agent.CLI.Style
     ( beginBackground
     , cliWindowTitle
@@ -113,12 +118,21 @@ import Agent.Subagents
     , closeSubagentRegistry
     , defaultSubagentConfig
     , formatCompletionNotice
+    , getPreviousResponseId
+    , getStatus
     , newSubagentRegistry
+    , restoreSubagent
     , setSubagentOnComplete
     , setSubagentRunner
     )
-import Agent.Tools (CodingTools(..), appToolHandlers, codingToolsFor, filterChildGrokTools)
-import Agent.Tools.Grok.Task (defaultSubagentType, lookupAgentType)
+import Agent.Tools
+    ( CodingTools(..)
+    , appToolHandlers
+    , codingToolsFor
+    , codingToolsForWithTypes
+    , filterChildGrokTools
+    )
+import Agent.Tools.Grok.Task (defaultSubagentType, lookupAgentType, recordAgentType)
 import Agent.Tools.MultiAgents (MultiAgentContext(..))
 import Agent.Tools.PlanMode
     ( PlanDecision(..)
@@ -321,28 +335,40 @@ runAgent options = do
     escPaused <- newIORef False
     let planHooks = cliPlanHooks interrupt escPaused (resolveColor stderr)
         provider = loaded.loadedProvider
-    multiCtx <- do
-        registry <- newSubagentRegistry defaultSubagentConfig cwd
-            (\_ _ _ _ -> pure $ Left LoopNoResponseId)
-            (\_ _ -> pure ())
-        pure $ Just MultiAgentContext
+    -- Per-subagent transcripts / previous ids, shared across send_input / task.
+    subagentSessions <- newIORef Map.empty
+    subagentStoreRoot <- newIORef Nothing
+    pendingNotices <- newIORef ([] :: [Text])
+    registry <- newSubagentRegistry defaultSubagentConfig cwd
+        (\_ _ _ _ -> pure $ Left LoopNoResponseId)
+        (\_ _ -> pure ())
+    agentTypesRef <- newIORef Map.empty
+    let multiCtx = Just MultiAgentContext
             { multiRegistry = registry
             , multiSelfId = Nothing
             , multiDepth = 0
+            , multiResumeFromDisk = Just
+                (restoreAgentFromDisk subagentStoreRoot registry subagentSessions agentTypesRef)
             }
-    -- Per-subagent transcripts / previous ids, shared across send_input / task.
-    subagentSessions <- newIORef Map.empty
-    pendingNotices <- newIORef ([] :: [Text])
+    coding <- codingToolsForWithTypes provider toolEnv (Just planHooks) multiCtx agentTypesRef
     case multiCtx of
         Just ctx ->
-            setSubagentOnComplete ctx.multiRegistry \agentId status ->
+            setSubagentOnComplete ctx.multiRegistry \agentId status -> do
                 atomicModifyIORef' pendingNotices \xs ->
                     (xs <> [formatCompletionNotice agentId status], ())
+                sessions <- readIORef subagentSessions
+                case Map.lookup agentId sessions of
+                    Just session ->
+                        persistSubagentSnapshot subagentStoreRoot ctx.multiRegistry
+                            agentTypesRef agentId session.subSessionTranscript
+                    Nothing -> pure ()
         Nothing -> pure ()
-    coding <- codingToolsFor provider toolEnv (Just planHooks) multiCtx
     let tools = coding.codingAppTools
         planMode = coding.codingPlanMode
-        agentTypesRef = coding.codingAgentTypes
+        -- Keep planSessionDir and subagent store root in sync.
+        noteSessionDir dir = do
+            writeIORef planMode.planSessionDir (Just dir)
+            writeIORef subagentStoreRoot (Just dir)
         closeAll = do
             case multiCtx of
                 Just ctx -> closeSubagentRegistry ctx.multiRegistry
@@ -378,7 +404,7 @@ runAgent options = do
                 slot <- readIORef slotRef
                 case slot of
                     Right handle ->
-                        writeIORef planMode.planSessionDir (Just handle.sessionDir)
+                        noteSessionDir handle.sessionDir
                     Left _ -> pure ()
             Nothing -> pure ()
         progName <- getProgName
@@ -401,6 +427,8 @@ runAgent options = do
                                                 conn
                                                 ctx.multiRegistry
                                                 subagentSessions
+                                                subagentStoreRoot
+                                                agentTypesRef
                                     Nothing -> pure ()
                                 let lockedBackend =
                                         lockedOpenAiBackend wsLock conn
@@ -410,7 +438,7 @@ runAgent options = do
                                         withPendingNotices pendingNotices lockedBackend
                                 runSession options provider policy tools toolEnv planMode prompt paramsRef transcriptRef
                                     initialPrevious persist projectRoot (Just loaded.loadedTokenProvider) agentsContext escPaused interrupt
-                                    noticingBackend)
+                                    subagentStoreRoot noticingBackend)
                             >>= \case
                                 Left (CodexAuthFailed err) -> die ("openai auth: " <> show err)
                                 Right result -> pure result
@@ -431,13 +459,15 @@ runAgent options = do
                                         ctx.multiRegistry
                                         subagentSessions
                                         agentTypesRef
+                                        subagentStoreRoot
                             Nothing -> pure ()
                         let backend =
                                 withPendingNotices pendingNotices $
                                     xaiBackend xaiOptions loaded.loadedTokenProvider
                                         (readIORef paramsRef) transcriptRef
                         runSession options provider policy tools toolEnv planMode prompt paramsRef transcriptRef
-                            initialPrevious persist projectRoot (Just loaded.loadedTokenProvider) agentsContext escPaused interrupt backend
+                            initialPrevious persist projectRoot (Just loaded.loadedTokenProvider) agentsContext escPaused interrupt
+                            subagentStoreRoot backend
                     OpenRouterProvider -> do
                         openRouterOptions <- OpenRouter.clientOptionsFromEnv
                         case multiCtx of
@@ -455,13 +485,15 @@ runAgent options = do
                                         ctx.multiRegistry
                                         subagentSessions
                                         agentTypesRef
+                                        subagentStoreRoot
                             Nothing -> pure ()
                         let backend =
                                 withPendingNotices pendingNotices $
                                     openRouterBackend openRouterOptions loaded.loadedTokenProvider
                                         (readIORef paramsRef) transcriptRef
                         runSession options provider policy tools toolEnv planMode prompt paramsRef transcriptRef
-                            initialPrevious persist projectRoot (Just loaded.loadedTokenProvider) agentsContext escPaused interrupt backend
+                            initialPrevious persist projectRoot (Just loaded.loadedTokenProvider) agentsContext escPaused interrupt
+                            subagentStoreRoot backend
 
 preparePersistence
     :: CliOptions
@@ -565,9 +597,10 @@ runSession
     -> IORef (Maybe Text)
     -> IORef Bool
     -> InterruptState
+    -> SubagentStoreRoot
     -> Backend
     -> IO DevResult
-runSession options provider policy tools toolEnv planMode prompt paramsRef transcriptRef initialPrevious persist projectRoot tokenProvider agentsContext escPaused interrupt backend = do
+runSession options provider policy tools toolEnv planMode prompt paramsRef transcriptRef initialPrevious persist projectRoot tokenProvider agentsContext escPaused interrupt storeRoot backend = do
     printed <- newIORef False
     attachmentsRef <- newIORef []
     textBuffer <- newIORef ""
@@ -583,6 +616,13 @@ runSession options provider policy tools toolEnv planMode prompt paramsRef trans
     policyRef <- newIORef policy
     stderrTty <- hIsTerminalDevice stderr
     useColor <- resolveColor stdout
+    -- Mirror plan session dir into the subagent store root for this session.
+    let syncStore = do
+            sessionDir <- readIORef planMode.planSessionDir
+            case sessionDir of
+                Just dir -> writeIORef storeRoot (Just dir)
+                Nothing -> pure ()
+    syncStore
     let render = RenderConfig
             { renderShowThinking = stderrTty
             , renderThinkingVisible = thinkingVisible
@@ -614,14 +654,14 @@ runSession options provider policy tools toolEnv planMode prompt paramsRef trans
     case prompt of
         Just text -> do
             ok <- runOneTurn config render previous printed transcriptRef persist
-                planMode agentsContext escPaused interrupt text [UserMessage text]
+                planMode agentsContext escPaused interrupt storeRoot text [UserMessage text]
             if ok
                 then putTrailingNewline printed >> pure DevQuit
                 else exitFailure
         Nothing ->
             repl config render provider previous printed paramsRef policyRef
                 transcriptRef persist planMode projectRoot tokenProvider agentsContext
-                escPaused attachmentsRef interrupt
+                escPaused attachmentsRef interrupt storeRoot
 
 repl
     :: LoopConfig
@@ -640,8 +680,9 @@ repl
     -> IORef Bool
     -> IORef [ImageAttachment]
     -> InterruptState
+    -> SubagentStoreRoot
     -> IO DevResult
-repl config render provider previous printed paramsRef policyRef transcriptRef persist planMode projectRoot tokenProvider agentsContext escPaused attachmentsRef interrupt = do
+repl config render provider previous printed paramsRef policyRef transcriptRef persist planMode projectRoot tokenProvider agentsContext escPaused attachmentsRef interrupt storeRoot = do
     stdoutColor <- resolveColor stdout
     planActive <- isPlanModeActive planMode
     planPending <- (== PlanPending) <$> readIORef planMode.planStateRef
@@ -689,7 +730,7 @@ repl config render provider previous printed paramsRef policyRef transcriptRef p
                                             }
                                         ]
                         _ <- runOneTurn config render previous printed
-                            transcriptRef persist planMode agentsContext escPaused interrupt text
+                            transcriptRef persist planMode agentsContext escPaused interrupt storeRoot text
                             turnInputs
                         putTrailingNewline printed
                         continue
@@ -734,7 +775,7 @@ repl config render provider previous printed paramsRef policyRef transcriptRef p
                                             (roleMuted color (glyphOk <> "pasted " <> sizes))
                                         writeIORef printed False
                                         _ <- runOneTurn config render previous printed
-                                            transcriptRef persist planMode agentsContext escPaused interrupt promptText
+                                            transcriptRef persist planMode agentsContext escPaused interrupt storeRoot promptText
                                             [ UserMultimodal
                                                 { userText = promptText
                                                 , userImages = images
@@ -897,7 +938,7 @@ repl config render provider previous printed paramsRef policyRef transcriptRef p
     continue =
         repl config render provider previous printed paramsRef policyRef
             transcriptRef persist planMode projectRoot tokenProvider agentsContext
-            escPaused attachmentsRef interrupt
+            escPaused attachmentsRef interrupt storeRoot
 
 applyModelChange
     :: Provider
@@ -1005,6 +1046,7 @@ enterPlanFromSlash
     -> IO ()
 enterPlanFromSlash planMode persist maybeDescription config render previous printed
     transcriptRef agentsContext escPaused interrupt = do
+    discardStore <- newIORef Nothing
     color <- resolveColor stderr
     case persist of
         Just slotRef -> do
@@ -1028,7 +1070,7 @@ enterPlanFromSlash planMode persist maybeDescription config render previous prin
                 (roleMuted color (glyphSession <> "plan mode on (" <> Text.pack path <> ")"))
             writeIORef printed False
             _ <- runOneTurn config render previous printed transcriptRef persist
-                planMode agentsContext escPaused interrupt description [UserMessage description]
+                planMode agentsContext escPaused interrupt discardStore description [UserMessage description]
             putTrailingNewline printed
 
 runOneTurn
@@ -1042,10 +1084,11 @@ runOneTurn
     -> IORef (Maybe Text)
     -> IORef Bool
     -> InterruptState
+    -> SubagentStoreRoot
     -> Text
     -> [TurnInput]
     -> IO Bool
-runOneTurn config render previous printed transcriptRef persist planMode agentsContext escPaused interrupt promptText inputs =
+runOneTurn config render previous printed transcriptRef persist planMode agentsContext escPaused interrupt storeRoot promptText inputs =
   withTurnCancel interrupt config.loopCancel $
   withEscCancel config.loopCancel escPaused do
     pending <- readIORef planMode.planStateRef
@@ -1054,8 +1097,9 @@ runOneTurn config render previous printed transcriptRef persist planMode agentsC
         Just slotRef -> do
             slot <- readIORef slotRef
             case slot of
-                Right handle ->
+                Right handle -> do
                     writeIORef planMode.planSessionDir (Just handle.sessionDir)
+                    writeIORef storeRoot (Just handle.sessionDir)
                 Left _ -> pure ()
         Nothing -> pure ()
     prev <- readIORef previous
@@ -1126,6 +1170,7 @@ runOneTurn config render previous printed transcriptRef persist planMode agentsC
                     created <- isLeftSlot <$> readIORef slotRef
                     handle <- ensureSession slotRef
                     writeIORef planMode.planSessionDir (Just handle.sessionDir)
+                    writeIORef storeRoot (Just handle.sessionDir)
                     if created
                         then do
                             color <- resolveColor stderr
@@ -1152,7 +1197,7 @@ runOneTurn config render previous printed transcriptRef persist planMode agentsC
                 Just notes -> do
                     writeIORef printed False
                     _ <- runOneTurn config render previous printed transcriptRef persist
-                        planMode agentsContext escPaused interrupt notes [UserMessage notes]
+                        planMode agentsContext escPaused interrupt storeRoot notes [UserMessage notes]
                     pure True
 
 handleProposedPlan :: PlanModeEnv -> Maybe Text -> IO (Maybe Text)
@@ -1375,6 +1420,75 @@ data SubagentSession = SubagentSession
     { subSessionTranscript :: !(IORef [ResponseItem])
     }
 
+-- | Optional on-disk root for child transcripts (@sessionDir/agents/<id>@).
+type SubagentStoreRoot = IORef (Maybe FilePath)
+
+-- | Prefer an explicit store root; otherwise fall back to planMode's session dir.
+syncStoreRootFromPlan :: SubagentStoreRoot -> PlanModeEnv -> IO ()
+syncStoreRootFromPlan storeRootRef planMode = do
+    mroot <- readIORef storeRootRef
+    case mroot of
+        Just _ -> pure ()
+        Nothing -> do
+            sessionDir <- readIORef planMode.planSessionDir
+            case sessionDir of
+                Just dir -> writeIORef storeRootRef (Just dir)
+                Nothing -> pure ()
+
+persistSubagentSnapshot
+    :: SubagentStoreRoot
+    -> SubagentRegistry
+    -> IORef (Map SubagentId Text)
+    -> SubagentId
+    -> IORef [ResponseItem]
+    -> IO ()
+persistSubagentSnapshot storeRootRef registry typesRef agentId transcriptRef = do
+    mroot <- readIORef storeRootRef
+    case mroot of
+        Nothing -> pure ()
+        Just sessionDir -> do
+            items <- readIORef transcriptRef
+            previous <- getPreviousResponseId registry agentId
+            agentType <- lookupAgentType typesRef agentId
+            saveSubagentState sessionDir agentId items previous agentType
+
+-- | Rehydrate a closed/missing agent from @sessionDir/agents/<id>@ so
+-- 'resume_agent' / 'resume_from' can continue the prior transcript.
+restoreAgentFromDisk
+    :: SubagentStoreRoot
+    -> SubagentRegistry
+    -> IORef (Map SubagentId SubagentSession)
+    -> IORef (Map SubagentId Text)
+    -> SubagentId
+    -> IO (Either Text ())
+restoreAgentFromDisk storeRootRef registry sessionsRef typesRef agentId = do
+    status <- getStatus registry agentId
+    case status of
+        NotFound -> restore
+        Closed -> restore
+        _ -> pure (Right ())
+  where
+    restore = do
+        mroot <- readIORef storeRootRef
+        case mroot of
+            Nothing ->
+                pure (Left "no session directory; cannot restore subagent from disk")
+            Just sessionDir ->
+                loadSubagentState sessionDir agentId >>= \case
+                    Nothing ->
+                        pure (Left ("no persisted transcript for " <> agentId.unSubagentId))
+                    Just (items, meta) -> do
+                        _ <- restoreSubagent registry agentId Nothing 1 Nothing
+                            meta.diskPreviousResponseId
+                        case meta.diskAgentType of
+                            Just agentType -> recordAgentType typesRef agentId agentType
+                            Nothing -> pure ()
+                        transcript <- newIORef items
+                        let session = SubagentSession { subSessionTranscript = transcript }
+                        atomicModifyIORef' sessionsRef \m ->
+                            (Map.insert agentId session m, ())
+                        pure (Right ())
+
 -- | Serialize OpenAI WebSocket turns: parent and children share one connection,
 -- and 'receiveWsResponse' is not multiplexed.
 lockedOpenAiBackend
@@ -1408,8 +1522,10 @@ runCodexSubagent
     -> CodexConn
     -> SubagentRegistry
     -> IORef (Map SubagentId SubagentSession)
+    -> SubagentStoreRoot
+    -> IORef (Map SubagentId Text)
     -> RunSubagent
-runCodexSubagent options policy planHooks paramsRef wsLock conn registry sessionsRef =
+runCodexSubagent options policy planHooks paramsRef wsLock conn registry sessionsRef storeRootRef typesRef =
     \env previous prompt onEvent -> do
         parentParams <- readIORef paramsRef
         childEnv <- defaultToolEnv env.subCwd
@@ -1419,9 +1535,14 @@ runCodexSubagent options policy planHooks paramsRef wsLock conn registry session
                 { multiRegistry = registry
                 , multiSelfId = Just env.subId
                 , multiDepth = env.subDepth
+                , multiResumeFromDisk = Nothing
                 }
-        session <- lookupOrCreateSubagentSession sessionsRef env.subId
+        -- Child tools create their own PlanModeEnv; sync store root from parent
+        -- params is handled by noteSessionDir on the parent path. If the parent
+        -- already has a session dir in storeRootRef, we persist; otherwise skip.
+        session <- lookupOrCreateSubagentSession sessionsRef storeRootRef typesRef env.subId
         coding <- codingToolsFor OpenAIProvider childToolEnv (Just planHooks) (Just childCtx)
+        syncStoreRootFromPlan storeRootRef coding.codingPlanMode
         flip finally coding.codingClose do
             today <- utctDay <$> getCurrentTime
             let model = fromMaybe (defaultModelFor OpenAIProvider) parentParams.model
@@ -1455,7 +1576,10 @@ runCodexSubagent options policy planHooks paramsRef wsLock conn registry session
                     , loopApprove = \call -> childApprove policy tools call
                     , loopCancel = env.subCancel
                     }
-            runLoop config previous prompt
+            result <- runLoop config previous prompt
+            persistSubagentSnapshot storeRootRef registry typesRef env.subId
+                session.subSessionTranscript
+            pure result
 
 -- | Child XAI/OpenRouter agent: HTTP backend, filtered tools by subagent_type.
 runHttpSubagent
@@ -1468,8 +1592,9 @@ runHttpSubagent
     -> SubagentRegistry
     -> IORef (Map SubagentId SubagentSession)
     -> IORef (Map SubagentId Text)
+    -> SubagentStoreRoot
     -> RunSubagent
-runHttpSubagent options policy planHooks paramsRef provider mkBackend registry sessionsRef typesRef =
+runHttpSubagent options policy planHooks paramsRef provider mkBackend registry sessionsRef typesRef storeRootRef =
     \env previous prompt onEvent -> do
         parentParams <- readIORef paramsRef
         childEnv <- defaultToolEnv env.subCwd
@@ -1478,8 +1603,9 @@ runHttpSubagent options policy planHooks paramsRef provider mkBackend registry s
                 { multiRegistry = registry
                 , multiSelfId = Just env.subId
                 , multiDepth = env.subDepth
+                , multiResumeFromDisk = Nothing
                 }
-        session <- lookupOrCreateSubagentSession sessionsRef env.subId
+        session <- lookupOrCreateSubagentSession sessionsRef storeRootRef typesRef env.subId
         agentType <- fromMaybe defaultSubagentType <$> lookupAgentType typesRef env.subId
         coding <- codingToolsFor provider childToolEnv (Just planHooks) (Just childCtx)
         flip finally coding.codingClose do
@@ -1512,7 +1638,10 @@ runHttpSubagent options policy planHooks paramsRef provider mkBackend registry s
                     }
             -- XAI/OpenRouter ignore previous_response_id and replay local
             -- transcripts; still pass previous for API symmetry.
-            runLoop config previous prompt
+            result <- runLoop config previous prompt
+            persistSubagentSnapshot storeRootRef registry typesRef env.subId
+                session.subSessionTranscript
+            pure result
 
 grokSubagentSuffix :: Text -> SubagentId -> Text
 grokSubagentSuffix agentType agentId =
@@ -1534,14 +1663,30 @@ grokSubagentSuffix agentType agentId =
 
 lookupOrCreateSubagentSession
     :: IORef (Map SubagentId SubagentSession)
+    -> SubagentStoreRoot
+    -> IORef (Map SubagentId Text)
     -> SubagentId
     -> IO SubagentSession
-lookupOrCreateSubagentSession sessionsRef agentId = do
+lookupOrCreateSubagentSession sessionsRef storeRootRef typesRef agentId = do
     sessions <- readIORef sessionsRef
     case Map.lookup agentId sessions of
         Just session -> pure session
         Nothing -> do
-            transcript <- newIORef ([] :: [ResponseItem])
+            mroot <- readIORef storeRootRef
+            loaded <- case mroot of
+                Just sessionDir -> loadSubagentState sessionDir agentId
+                Nothing -> pure Nothing
+            transcript <- newIORef $ case loaded of
+                Just (items, _) -> items
+                Nothing -> []
+            case loaded of
+                Just (_, meta) ->
+                    case meta.diskAgentType of
+                        Just agentType ->
+                            atomicModifyIORef' typesRef \m ->
+                                (Map.insertWith (\_ new -> new) agentId agentType m, ())
+                        Nothing -> pure ()
+                Nothing -> pure ()
             let session = SubagentSession { subSessionTranscript = transcript }
             atomicModifyIORef' sessionsRef \m -> (Map.insert agentId session m, ())
             pure session

--- a/packages/agent-cli/src/Agent/CLI/SubagentStore.hs
+++ b/packages/agent-cli/src/Agent/CLI/SubagentStore.hs
@@ -1,0 +1,100 @@
+-- | Persist per-subagent transcripts under a parent session directory.
+--
+-- Layout:
+--
+-- @
+--   <sessionDir>/agents/<agentId>/meta.json
+--   <sessionDir>/agents/<agentId>/transcript.json
+-- @
+module Agent.CLI.SubagentStore
+    ( SubagentDiskMeta(..)
+    , subagentStoreDir
+    , saveSubagentState
+    , loadSubagentState
+    ) where
+
+import Agent.OpenAI.Responses.Types (ResponseItem)
+import Agent.Subagents (SubagentId(..))
+import Control.Exception (try)
+import Data.Aeson (FromJSON(..), ToJSON(..), object, withObject, (.:), (.:?), (.=))
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString.Lazy as LBS
+import Data.Maybe (fromMaybe)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import System.Directory
+    ( createDirectoryIfMissing
+    , doesFileExist
+    )
+import System.FilePath ((</>))
+import System.Posix.Files (setFileMode)
+
+data SubagentDiskMeta = SubagentDiskMeta
+    { diskPreviousResponseId :: !(Maybe Text)
+    , diskAgentType :: !(Maybe Text)
+    } deriving (Eq, Show)
+
+instance ToJSON SubagentDiskMeta where
+    toJSON meta = object
+        [ "previousResponseId" .= meta.diskPreviousResponseId
+        , "agentType" .= meta.diskAgentType
+        ]
+
+instance FromJSON SubagentDiskMeta where
+    parseJSON = withObject "SubagentDiskMeta" \o ->
+        SubagentDiskMeta
+            <$> o .:? "previousResponseId"
+            <*> o .:? "agentType"
+
+subagentStoreDir :: FilePath -> SubagentId -> FilePath
+subagentStoreDir sessionDir agentId =
+    sessionDir </> "agents" </> Text.unpack agentId.unSubagentId
+
+saveSubagentState
+    :: FilePath
+    -> SubagentId
+    -> [ResponseItem]
+    -> Maybe Text
+    -> Maybe Text
+    -> IO ()
+saveSubagentState sessionDir agentId items previous agentType = do
+    let dir = subagentStoreDir sessionDir agentId
+        metaPath = dir </> "meta.json"
+        transcriptPath = dir </> "transcript.json"
+    createDirectoryIfMissing True dir
+    _ <- try @IOError (setFileMode dir 0o700)
+    LBS.writeFile metaPath $ Aeson.encode SubagentDiskMeta
+        { diskPreviousResponseId = previous
+        , diskAgentType = agentType
+        }
+    _ <- try @IOError (setFileMode metaPath 0o600)
+    LBS.writeFile transcriptPath (Aeson.encode items)
+    _ <- try @IOError (setFileMode transcriptPath 0o600)
+    pure ()
+
+loadSubagentState
+    :: FilePath
+    -> SubagentId
+    -> IO (Maybe ([ResponseItem], SubagentDiskMeta))
+loadSubagentState sessionDir agentId = do
+    let dir = subagentStoreDir sessionDir agentId
+        metaPath = dir </> "meta.json"
+        transcriptPath = dir </> "transcript.json"
+    hasMeta <- doesFileExist metaPath
+    hasTranscript <- doesFileExist transcriptPath
+    if not (hasMeta || hasTranscript)
+        then pure Nothing
+        else do
+            meta <- if hasMeta
+                then do
+                    raw <- LBS.readFile metaPath
+                    pure $ fromMaybe emptyMeta (Aeson.decode raw)
+                else pure emptyMeta
+            items <- if hasTranscript
+                then do
+                    raw <- LBS.readFile transcriptPath
+                    pure $ fromMaybe [] (Aeson.decode raw)
+                else pure []
+            pure $ Just (items, meta)
+  where
+    emptyMeta = SubagentDiskMeta Nothing Nothing

--- a/packages/agent-cli/test/Agent/CLI/SubagentStoreSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SubagentStoreSpec.hs
@@ -1,0 +1,40 @@
+module Agent.CLI.SubagentStoreSpec (spec) where
+
+import Agent.CLI.SubagentStore
+import Agent.OpenAI.Responses.Types
+import Agent.Subagents (SubagentId(..))
+import Control.Exception (bracket)
+import qualified Data.Aeson.KeyMap as KeyMap
+import System.Directory (getTemporaryDirectory, removeDirectoryRecursive, doesFileExist)
+import System.FilePath ((</>))
+import System.Posix.Temp (mkdtemp)
+import Test.Hspec
+
+spec :: Spec
+spec = describe "Agent.CLI.SubagentStore" do
+    it "round-trips transcript items and meta" do
+        withTempDir \dir -> do
+            let agentId = SubagentId "agent-test-1"
+                item = MessageItem ResponseMessage
+                    { messageId = Nothing
+                    , content = MessageContentText "hello"
+                    , role = RoleUser
+                    , status = Nothing
+                    , phase = Nothing
+                    , extraFields = KeyMap.empty
+                    }
+            saveSubagentState dir agentId [item] (Just "resp-1") (Just "explore")
+            loaded <- loadSubagentState dir agentId
+            case loaded of
+                Nothing -> expectationFailure "expected persisted state"
+                Just (items, meta) -> do
+                    length items `shouldBe` 1
+                    meta.diskPreviousResponseId `shouldBe` Just "resp-1"
+                    meta.diskAgentType `shouldBe` Just "explore"
+            doesFileExist (subagentStoreDir dir agentId </> "transcript.json")
+                `shouldReturn` True
+
+withTempDir :: (FilePath -> IO a) -> IO a
+withTempDir action = do
+    tmp <- getTemporaryDirectory
+    bracket (mkdtemp (tmp </> "subagent-store-")) removeDirectoryRecursive action

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -19,6 +19,7 @@ import qualified Agent.CLI.PromptSpec as PromptSpec
 import qualified Agent.CLI.RenderSpec as RenderSpec
 import qualified Agent.CLI.ResumeSpec as ResumeSpec
 import qualified Agent.CLI.SessionSpec as SessionSpec
+import qualified Agent.CLI.SubagentStoreSpec as SubagentStoreSpec
 import qualified Agent.CLI.StyleSpec as StyleSpec
 import qualified Agent.CLI.TimestampSpec as TimestampSpec
 import qualified Agent.CLI.ToolsSpec as ToolsSpec
@@ -45,5 +46,6 @@ main = hspec do
     StyleSpec.spec
     TimestampSpec.spec
     SessionSpec.spec
+    SubagentStoreSpec.spec
     ToolsSpec.spec
     WorktreeSpec.spec

--- a/packages/agent-core/src/Agent/Subagents.hs
+++ b/packages/agent-core/src/Agent/Subagents.hs
@@ -20,11 +20,13 @@ module Agent.Subagents
     , setSubagentOnComplete
     , closeSubagentRegistry
     , spawnSubagent
+    , restoreSubagent
     , waitSubagents
     , sendInput
     , closeSubagent
     , resumeSubagent
     , getStatus
+    , getPreviousResponseId
     , listLive
     , encodeStatus
     , isFinalStatus
@@ -446,6 +448,51 @@ shutdownRecord registry record = do
             pure ()
     releaseSlot registry record
 
+-- | Re-admit a previously persisted agent that is not currently in the
+-- in-memory map (e.g. after close, or across a process restart within the
+-- same session directory). Does not start a worker; callers follow with
+-- 'sendInput'. Does not consume a concurrency slot until the next turn.
+restoreSubagent
+    :: SubagentRegistry
+    -> SubagentId
+    -> Maybe SubagentId
+    -> Int
+    -> Maybe Text
+    -> Maybe Text
+    -> IO (Either Text SubagentId)
+restoreSubagent registry agentId parentId depth nickname previous = do
+    existing <- atomically $ Map.lookup agentId <$> readTVar registry.registryAgents
+    case existing of
+        Just _ -> pure (Right agentId)
+        Nothing -> do
+            cancelFlag <- newCancelFlag
+            mailbox <- newTQueueIO
+            statusVar <- newTVarIO (Completed Nothing)
+            asyncVar <- newTVarIO Nothing
+            slotHeld <- newTVarIO False
+            previousVar <- newTVarIO previous
+            let record = SubagentRecord
+                    { recordId = agentId
+                    , recordParent = parentId
+                    , recordDepth = depth
+                    , recordNickname = nickname
+                    , recordStatus = statusVar
+                    , recordCancel = cancelFlag
+                    , recordMailbox = mailbox
+                    , recordAsync = asyncVar
+                    , recordSlotHeld = slotHeld
+                    , recordPreviousResponseId = previousVar
+                    }
+            atomically do
+                closed <- readTVar registry.registryClosed
+                if closed
+                    then pure ()
+                    else modifyTVar' registry.registryAgents (Map.insert agentId record)
+            closed <- atomically $ readTVar registry.registryClosed
+            if closed
+                then pure (Left "Subagent registry is closed.")
+                else pure (Right agentId)
+
 resumeSubagent
     :: SubagentRegistry
     -> SubagentId
@@ -464,6 +511,13 @@ resumeSubagent registry agentId = do
 
 getStatus :: SubagentRegistry -> SubagentId -> IO SubagentStatus
 getStatus registry agentId = atomically (readStatusSTM registry agentId)
+
+getPreviousResponseId :: SubagentRegistry -> SubagentId -> IO (Maybe Text)
+getPreviousResponseId registry agentId = atomically do
+    agents <- readTVar registry.registryAgents
+    case Map.lookup agentId agents of
+        Nothing -> pure Nothing
+        Just record -> readTVar record.recordPreviousResponseId
 
 readStatusSTM :: SubagentRegistry -> SubagentId -> STM SubagentStatus
 readStatusSTM registry agentId = do

--- a/packages/agent-core/src/Agent/Tools.hs
+++ b/packages/agent-core/src/Agent/Tools.hs
@@ -12,6 +12,7 @@ module Agent.Tools
     , appToolHandlers
     , CodingTools(..)
     , codingToolsFor
+    , codingToolsForWithTypes
     , filterChildGrokTools
     ) where
 
@@ -48,8 +49,20 @@ codingToolsFor
     -> Maybe MultiAgentContext
     -> IO CodingTools
 codingToolsFor provider env hooks multi = do
-    plan <- newPlanModeEnv env.toolCwd hooks
     typesRef <- newIORef Map.empty
+    codingToolsForWithTypes provider env hooks multi typesRef
+
+-- | Same as 'codingToolsFor', but reuses an existing agent-type map so the
+-- host can wire resume-from-disk before tools are built.
+codingToolsForWithTypes
+    :: Provider
+    -> ToolEnv
+    -> Maybe PlanModeHooks
+    -> Maybe MultiAgentContext
+    -> IORef (Map SubagentId Text)
+    -> IO CodingTools
+codingToolsForWithTypes provider env hooks multi typesRef = do
+    plan <- newPlanModeEnv env.toolCwd hooks
     case provider of
         XAIProvider -> do
             session <- newGrokSession env

--- a/packages/agent-core/src/Agent/Tools/Grok/Task.hs
+++ b/packages/agent-core/src/Agent/Tools/Grok/Task.hs
@@ -199,6 +199,9 @@ resumeTask
     -> IO (Either Text Text)
 resumeTask ctx typesRef args resumeId = do
     let agentId = SubagentId resumeId
+    _ <- case ctx.multiResumeFromDisk of
+        Just restore -> restore agentId
+        Nothing -> pure (Right ())
     status <- getStatus ctx.multiRegistry agentId
     case status of
         NotFound -> pure (Left ("unknown subagent id: " <> resumeId))

--- a/packages/agent-core/src/Agent/Tools/MultiAgents.hs
+++ b/packages/agent-core/src/Agent/Tools/MultiAgents.hs
@@ -57,6 +57,9 @@ data MultiAgentContext = MultiAgentContext
     { multiRegistry :: !SubagentRegistry
     , multiSelfId :: !(Maybe SubagentId)
     , multiDepth :: !Int
+      -- | Optional host hook to rehydrate a closed/missing agent from disk
+      -- before 'resume_agent' / follow-ups. 'Nothing' means in-memory only.
+    , multiResumeFromDisk :: !(Maybe (SubagentId -> IO (Either Text ())))
     }
 
 multiAgentNamespace :: Text
@@ -335,7 +338,11 @@ resumeAgentDescription =
 
 runResume :: MultiAgentContext -> ResumeAgentArgs -> IO (Either Text Text)
 runResume ctx args = do
-    result <- resumeSubagent ctx.multiRegistry (SubagentId args.resumeId)
+    let agentId = SubagentId args.resumeId
+    _ <- case ctx.multiResumeFromDisk of
+        Just restore -> restore agentId
+        Nothing -> pure (Right ())
+    result <- resumeSubagent ctx.multiRegistry agentId
     pure $ case result of
         Left err -> Left err
         Right status ->

--- a/packages/agent-core/test/Agent/SubagentsSpec.hs
+++ b/packages/agent-core/test/Agent/SubagentsSpec.hs
@@ -6,6 +6,7 @@ import Control.Concurrent (threadDelay)
 import Control.Concurrent.STM
 import Control.Monad (unless)
 import Data.IORef
+import Data.Maybe (fromMaybe)
 import qualified Data.Map.Strict as Map
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -199,3 +200,22 @@ spec = describe "Agent.Subagents" do
         threadDelay 50000
         seen <- readIORef notices
         seen `shouldBe` [(agentId, Completed (Just "notify-me"))]
+
+    it "restores a missing agent id into the registry" do
+        registry <- newSubagentRegistry defaultSubagentConfig "/tmp"
+            (\_ previous prompt _ -> pure $ Right LoopResult
+                { finalResponseId = fromMaybe "resp" previous
+                , finalText = Just prompt
+                , turnsUsed = 1
+                })
+            (\_ _ -> pure ())
+        let agentId = SubagentId "agent-restored-1"
+        Right _ <- restoreSubagent registry agentId Nothing 1 Nothing (Just "prev-1")
+        status <- getStatus registry agentId
+        status `shouldBe` Completed Nothing
+        previous <- getPreviousResponseId registry agentId
+        previous `shouldBe` Just "prev-1"
+        Right _ <- sendInput registry agentId "follow" False
+        (statuses, timedOut) <- waitSubagents registry [agentId] 15000
+        timedOut `shouldBe` False
+        Map.lookup agentId statuses `shouldBe` Just (Completed (Just "follow"))

--- a/packages/agent-core/test/Agent/Tools/CodexSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/CodexSpec.hs
@@ -51,6 +51,7 @@ spec = describe "Agent.Tools.Codex" do
                     { multiRegistry = registry
                     , multiSelfId = Nothing
                     , multiDepth = 0
+                    , multiResumeFromDisk = Nothing
                     }
             coding <- codingToolsFor OpenAIProvider env Nothing (Just ctx)
             let names = map (.appToolName) coding.codingAppTools

--- a/packages/agent-core/test/Agent/Tools/Grok/TaskSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/Grok/TaskSpec.hs
@@ -28,7 +28,7 @@ spec = describe "Agent.Tools.Grok.Task" do
                 })
             (\_ _ -> pure ())
         typesRef <- newIORef Map.empty
-        let ctx = MultiAgentContext registry Nothing 0
+        let ctx = MultiAgentContext registry Nothing 0 Nothing
             tool = taskTool ctx typesRef
         result <- dispatchToolCall defaultLoopDispatch [tool.appToolHandler]
             (functionToolCall "c1" "task"
@@ -55,7 +55,7 @@ spec = describe "Agent.Tools.Grok.Task" do
             (\_ _ _ _ -> pure $ Left LoopNoResponseId)
             (\_ _ -> pure ())
         typesRef <- newIORef Map.empty
-        let ctx = MultiAgentContext registry Nothing 0
+        let ctx = MultiAgentContext registry Nothing 0 Nothing
             tool = taskTool ctx typesRef
         result <- dispatchToolCall defaultLoopDispatch [tool.appToolHandler]
             (functionToolCall "c1" "task"

--- a/packages/agent-core/test/Agent/Tools/GrokSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/GrokSpec.hs
@@ -67,7 +67,7 @@ spec = describe "Agent.Tools.Grok" do
                 (\_ _ _ _ -> pure $ Left LoopNoResponseId)
                 (\_ _ -> pure ())
             typesRef <- newIORef Map.empty
-            let ctx = MultiAgentContext registry Nothing 0
+            let ctx = MultiAgentContext registry Nothing 0 Nothing
                 names = map (.appToolName) (grokTools session ghci plan (Just ctx) typesRef)
             names `shouldContain` ["task"]
             closeSubagentRegistry registry


### PR DESCRIPTION
## Summary
- Persist each subagent’s transcript and `previous_response_id` under `sessionDir/agents/<id>/`.
- Reload that state for Codex `resume_agent` and Grok `task` `resume_from` via `restoreSubagent` + disk hooks.
- Keep the in-memory registry behavior for live agents; disk is the source of truth after close/restart within a saved session.

## Test plan
- [x] `cabal test agent-core` (includes restore + previous-id coverage)
- [x] `cabal test agent-cli` (includes `SubagentStoreSpec` round-trip)
- [ ] Manual: spawn a Codex/Grok subagent with `--save-session`, close it, resume, confirm follow-up continues prior context