### PR TITLE
feat: refresh OpenAI catalog to gpt-5.6 series only

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Models.hs
+++ b/packages/agent-cli/src/Agent/CLI/Models.hs
@@ -54,11 +54,9 @@ modelsForProvider provider =
                 , opt "grok-3" Nothing
                 ]
             OpenAIProvider ->
-                [ opt "gpt-5.6-luna" (Just "default")
-                , opt "gpt-5.1-codex" Nothing
-                , opt "gpt-5.1-codex-mini" (Just "faster")
-                , opt "gpt-5.1" Nothing
-                , opt "o3" Nothing
+                [ opt "gpt-5.6-luna" (Just "default · fast")
+                , opt "gpt-5.6-terra" (Just "balanced")
+                , opt "gpt-5.6-sol" (Just "frontier")
                 ]
             OpenRouterProvider ->
                 [ opt "openai/gpt-5.1" (Just "default")

--- a/packages/agent-cli/test/Agent/CLI/ModelPickerSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ModelPickerSpec.hs
@@ -39,6 +39,8 @@ spec = do
     describe "formatCatalogListing" do
         it "lists the current model and catalog entries" do
             let listing =
-                    formatCatalogListing False OpenAIProvider "gpt-5.1-codex"
-            listing `shouldSatisfy` Text.isInfixOf "gpt-5.1-codex"
+                    formatCatalogListing False OpenAIProvider "gpt-5.6-luna"
+            listing `shouldSatisfy` Text.isInfixOf "gpt-5.6-luna"
+            listing `shouldSatisfy` Text.isInfixOf "gpt-5.6-terra"
+            listing `shouldSatisfy` Text.isInfixOf "gpt-5.6-sol"
             listing `shouldSatisfy` Text.isInfixOf "openai"

--- a/packages/agent-cli/test/Agent/CLI/ModelsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ModelsSpec.hs
@@ -21,6 +21,10 @@ spec = do
             firstId (modelsForProvider OpenRouterProvider)
                 `shouldBe` Just (defaultModelFor OpenRouterProvider)
 
+
+        it "lists the gpt-5.6 series for OpenAI" do
+            let ids = map (.modelId) (modelsForProvider OpenAIProvider)
+            ids `shouldBe` ["gpt-5.6-luna", "gpt-5.6-terra", "gpt-5.6-sol"]
         it "lists several options per provider" do
             length (modelsForProvider XAIProvider) `shouldSatisfy` (>= 2)
             length (modelsForProvider OpenAIProvider) `shouldSatisfy` (>= 2)


### PR DESCRIPTION
## Summary
Update the curated OpenAI `/model` catalog to Codex's current **gpt-5.6** series and drop older entries:

- `gpt-5.6-luna` (default · fast)
- `gpt-5.6-terra` (balanced)
- `gpt-5.6-sol` (frontier)

Removed: `gpt-5.1-codex`, `gpt-5.1-codex-mini`, `gpt-5.1`, `o3`.

`/model NAME` still accepts arbitrary ids; this only changes the picker catalog. Default model remains `gpt-5.6-luna`.

## Test plan
- [x] `cabal test agent-cli:agent-cli-test` (188 examples)
- [ ] Open `/model` on an OpenAI session and confirm the three 5.6 options