### PR TITLE
feat: show model, effort, and approval above the REPL prompt

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -107,6 +107,7 @@ test-suite agent-cli-test
                     , Agent.CLI.PermissionSpec
                     , Agent.CLI.PromptSpec
                     , Agent.CLI.RenderSpec
+                    , Agent.CLI.ReplStatusSpec
                     , Agent.CLI.ResumeSpec
                     , Agent.CLI.StyleSpec
                     , Agent.CLI.TimestampSpec

--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -3,6 +3,7 @@ module Agent.CLI
     ( DevResult(..)
     , afterDev
     , devMain
+    , formatReplStatusLine
     , run
     ) where
 
@@ -571,6 +572,22 @@ printResumeHint progName = \case
                 putTextLn stderr
                     (roleMuted color (resumeHint progName handle.sessionMeta.metaId))
 
+-- | Idle prompt chrome: model, reasoning effort, approval mode.
+formatReplStatusLine :: Bool -> Text -> Text -> ApprovalPolicy -> Text
+formatReplStatusLine color model effort policy =
+    roleMuted color $
+        "  "
+            <> model
+            <> " · "
+            <> effort
+            <> " · "
+            <> approvalLabel policy
+  where
+    approvalLabel = \case
+        ApproveAll -> "yolo"
+        PromptMutating -> "ask"
+        DenyMutating -> "deny"
+
 shouldPersist :: CliOptions -> Bool
 shouldPersist options = not (isOneShot options) || options.optSaveSession
 
@@ -686,6 +703,15 @@ repl config render provider previous printed paramsRef policyRef transcriptRef p
     stdoutColor <- resolveColor stdout
     planActive <- isPlanModeActive planMode
     planPending <- (== PlanPending) <$> readIORef planMode.planStateRef
+    params <- readIORef paramsRef
+    policy <- readIORef policyRef
+    -- Status sits on the line above λ so haskeline can keep the cursor on
+    -- the input. Haskeline cannot park a persistent footer under the draft.
+    Text.putStrLn $ formatReplStatusLine stdoutColor
+        (currentModel params)
+        (currentEffort params)
+        policy
+    hFlush stdout
     -- Solarized user wash under the prompt; haskeline redraws it on edit.
     -- Cmd+Delete / Ctrl+U kill-to-start via haskeline Emacs bindings.
     let modeTag

--- a/packages/agent-cli/test/Agent/CLI/ReplStatusSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ReplStatusSpec.hs
@@ -1,0 +1,15 @@
+module Agent.CLI.ReplStatusSpec (spec) where
+
+import Agent.CLI (formatReplStatusLine)
+import Agent.CLI.Options (ApprovalPolicy(..))
+import Test.Hspec
+
+spec :: Spec
+spec = describe "formatReplStatusLine" do
+    it "shows model, effort, and approval mode" do
+        formatReplStatusLine False "grok-4.6" "high" PromptMutating
+            `shouldBe` "  grok-4.6 · high · ask"
+        formatReplStatusLine False "gpt-5.1-codex" "medium" ApproveAll
+            `shouldBe` "  gpt-5.1-codex · medium · yolo"
+        formatReplStatusLine False "gpt-5.1" "low" DenyMutating
+            `shouldBe` "  gpt-5.1 · low · deny"

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -17,6 +17,7 @@ import qualified Agent.CLI.PlanSpec as PlanSpec
 import qualified Agent.CLI.ProjectSpec as ProjectSpec
 import qualified Agent.CLI.PromptSpec as PromptSpec
 import qualified Agent.CLI.RenderSpec as RenderSpec
+import qualified Agent.CLI.ReplStatusSpec as ReplStatusSpec
 import qualified Agent.CLI.ResumeSpec as ResumeSpec
 import qualified Agent.CLI.SessionSpec as SessionSpec
 import qualified Agent.CLI.SubagentStoreSpec as SubagentStoreSpec
@@ -42,6 +43,7 @@ main = hspec do
     ProjectSpec.spec
     PromptSpec.spec
     RenderSpec.spec
+    ReplStatusSpec.spec
     ResumeSpec.spec
     StyleSpec.spec
     TimestampSpec.spec


### PR DESCRIPTION
## Summary
- Idle REPL prints a muted status line above \`λ\`: \`model · effort · ask|yolo|deny\`.
- Lives on the line above the prompt because haskeline cannot keep a persistent footer under the draft.

## Test plan
- [x] \`cabal test agent-cli:agent-cli-test\` (189 examples, 0 failures)
- [ ] Start a TTY REPL and confirm the line above \`λ\` shows the current model, effort, and approval mode
- [ ] \`/model\`, \`/effort\`, and \`/always-approve\` refresh the line on the next prompt