### PR TITLE
fix: harden subagent transcript persistence

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -1093,14 +1093,19 @@ runOneTurn config render previous printed transcriptRef persist planMode agentsC
   withEscCancel config.loopCancel escPaused do
     pending <- readIORef planMode.planStateRef
     when (pending == PlanPending) (activatePlanMode planMode)
+    -- Create the session directory before tools run so first-turn subagents
+    -- can persist under agents/<id>/ as they complete.
     case persist of
         Just slotRef -> do
-            slot <- readIORef slotRef
-            case slot of
-                Right handle -> do
-                    writeIORef planMode.planSessionDir (Just handle.sessionDir)
-                    writeIORef storeRoot (Just handle.sessionDir)
-                Left _ -> pure ()
+            created <- isLeftSlot <$> readIORef slotRef
+            handle <- ensureSession slotRef
+            writeIORef planMode.planSessionDir (Just handle.sessionDir)
+            writeIORef storeRoot (Just handle.sessionDir)
+            when created do
+                color <- resolveColor stderr
+                putTextLn stderr
+                    (roleMuted color
+                        (glyphSession <> "session: " <> handle.sessionMeta.metaId))
         Nothing -> pure ()
     prev <- readIORef previous
     beforeItems <- readIORef transcriptRef
@@ -1167,17 +1172,9 @@ runOneTurn config render previous printed transcriptRef persist planMode agentsC
                 Nothing -> pure ()
                 Just slotRef -> do
                     now <- getCurrentTime
-                    created <- isLeftSlot <$> readIORef slotRef
                     handle <- ensureSession slotRef
                     writeIORef planMode.planSessionDir (Just handle.sessionDir)
                     writeIORef storeRoot (Just handle.sessionDir)
-                    if created
-                        then do
-                            color <- resolveColor stderr
-                            putTextLn stderr
-                                (roleMuted color
-                                    (glyphSession <> "session: " <> handle.sessionMeta.metaId))
-                        else pure ()
                     let turn = SessionTurn
                             { turnAt = now
                             , turnUserText = promptText
@@ -1450,7 +1447,22 @@ persistSubagentSnapshot storeRootRef registry typesRef agentId transcriptRef = d
             items <- readIORef transcriptRef
             previous <- getPreviousResponseId registry agentId
             agentType <- lookupAgentType typesRef agentId
-            saveSubagentState sessionDir agentId items previous agentType
+            _ <- saveSubagentState sessionDir agentId items previous agentType
+            pure ()
+
+flushAllSubagentSnapshots
+    :: SubagentStoreRoot
+    -> SubagentRegistry
+    -> IORef (Map SubagentId SubagentSession)
+    -> IORef (Map SubagentId Text)
+    -> IO ()
+flushAllSubagentSnapshots storeRootRef registry sessionsRef typesRef = do
+    sessions <- readIORef sessionsRef
+    mapM_
+        (\(agentId, session) ->
+            persistSubagentSnapshot storeRootRef registry typesRef agentId
+                session.subSessionTranscript)
+        (Map.toList sessions)
 
 -- | Rehydrate a closed/missing agent from @sessionDir/agents/<id>@ so
 -- 'resume_agent' / 'resume_from' can continue the prior transcript.
@@ -1475,19 +1487,32 @@ restoreAgentFromDisk storeRootRef registry sessionsRef typesRef agentId = do
                 pure (Left "no session directory; cannot restore subagent from disk")
             Just sessionDir ->
                 loadSubagentState sessionDir agentId >>= \case
-                    Nothing ->
-                        pure (Left ("no persisted transcript for " <> agentId.unSubagentId))
-                    Just (items, meta) -> do
-                        _ <- restoreSubagent registry agentId Nothing 1 Nothing
-                            meta.diskPreviousResponseId
-                        case meta.diskAgentType of
-                            Just agentType -> recordAgentType typesRef agentId agentType
-                            Nothing -> pure ()
-                        transcript <- newIORef items
-                        let session = SubagentSession { subSessionTranscript = transcript }
-                        atomicModifyIORef' sessionsRef \m ->
-                            (Map.insert agentId session m, ())
-                        pure (Right ())
+                    Left err -> pure (Left err)
+                    Right Nothing ->
+                        -- Same-process close with no disk yet: still reopen.
+                        reopenInMemory Nothing
+                    Right (Just (items, meta)) -> do
+                        result <- reopenInMemory meta.diskPreviousResponseId
+                        case result of
+                            Left err -> pure (Left err)
+                            Right () -> do
+                                case meta.diskAgentType of
+                                    Just agentType ->
+                                        recordAgentType typesRef agentId agentType
+                                    Nothing -> pure ()
+                                transcript <- newIORef items
+                                let session =
+                                        SubagentSession
+                                            { subSessionTranscript = transcript
+                                            }
+                                atomicModifyIORef' sessionsRef \m ->
+                                    (Map.insert agentId session m, ())
+                                pure (Right ())
+    reopenInMemory previous = do
+        restored <- restoreSubagent registry agentId Nothing 1 Nothing previous
+        pure $ case restored of
+            Left err -> Left err
+            Right _ -> Right ()
 
 -- | Serialize OpenAI WebSocket turns: parent and children share one connection,
 -- and 'receiveWsResponse' is not multiplexed.
@@ -1675,17 +1700,15 @@ lookupOrCreateSubagentSession sessionsRef storeRootRef typesRef agentId = do
             mroot <- readIORef storeRootRef
             loaded <- case mroot of
                 Just sessionDir -> loadSubagentState sessionDir agentId
-                Nothing -> pure Nothing
-            transcript <- newIORef $ case loaded of
-                Just (items, _) -> items
-                Nothing -> []
-            case loaded of
-                Just (_, meta) ->
-                    case meta.diskAgentType of
-                        Just agentType ->
-                            atomicModifyIORef' typesRef \m ->
-                                (Map.insertWith (\_ new -> new) agentId agentType m, ())
-                        Nothing -> pure ()
+                Nothing -> pure (Right Nothing)
+            let (items, meta) = case loaded of
+                    Right (Just (xs, m)) -> (xs, Just m)
+                    _ -> ([], Nothing)
+            transcript <- newIORef items
+            case meta >>= (.diskAgentType) of
+                Just agentType ->
+                    atomicModifyIORef' typesRef \m ->
+                        (Map.insertWith (\_ new -> new) agentId agentType m, ())
                 Nothing -> pure ()
             let session = SubagentSession { subSessionTranscript = transcript }
             atomicModifyIORef' sessionsRef \m -> (Map.insert agentId session m, ())

--- a/packages/agent-cli/src/Agent/CLI/SubagentStore.hs
+++ b/packages/agent-cli/src/Agent/CLI/SubagentStore.hs
@@ -8,6 +8,7 @@
 -- @
 module Agent.CLI.SubagentStore
     ( SubagentDiskMeta(..)
+    , isValidSubagentStoreId
     , subagentStoreDir
     , saveSubagentState
     , loadSubagentState
@@ -15,16 +16,17 @@ module Agent.CLI.SubagentStore
 
 import Agent.OpenAI.Responses.Types (ResponseItem)
 import Agent.Subagents (SubagentId(..))
-import Control.Exception (try)
-import Data.Aeson (FromJSON(..), ToJSON(..), object, withObject, (.:), (.:?), (.=))
+import Control.Exception.Safe (tryAny)
+import Data.Aeson (FromJSON(..), ToJSON(..), object, withObject, (.:?), (.=))
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy as LBS
-import Data.Maybe (fromMaybe)
+import Data.Char (isAlphaNum)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import System.Directory
     ( createDirectoryIfMissing
     , doesFileExist
+    , renameFile
     )
 import System.FilePath ((</>))
 import System.Posix.Files (setFileMode)
@@ -46,9 +48,25 @@ instance FromJSON SubagentDiskMeta where
             <$> o .:? "previousResponseId"
             <*> o .:? "agentType"
 
-subagentStoreDir :: FilePath -> SubagentId -> FilePath
-subagentStoreDir sessionDir agentId =
-    sessionDir </> "agents" </> Text.unpack agentId.unSubagentId
+-- | Generated ids look like @agent-<hex>-<n>@. Reject path separators and
+-- traversal so resume paths cannot escape @agents/@.
+isValidSubagentStoreId :: SubagentId -> Bool
+isValidSubagentStoreId (SubagentId text) =
+    let name = Text.unpack text
+    in not (null name)
+        && all isSafeNameChar name
+        && name /= "."
+        && name /= ".."
+        && "agent-" `Text.isPrefixOf` text
+  where
+    isSafeNameChar c = isAlphaNum c || c == '-' || c == '_'
+
+subagentStoreDir :: FilePath -> SubagentId -> Either Text FilePath
+subagentStoreDir sessionDir agentId
+    | not (isValidSubagentStoreId agentId) =
+        Left ("invalid subagent id for store path: " <> agentId.unSubagentId)
+    | otherwise =
+        Right (sessionDir </> "agents" </> Text.unpack agentId.unSubagentId)
 
 saveSubagentState
     :: FilePath
@@ -56,45 +74,62 @@ saveSubagentState
     -> [ResponseItem]
     -> Maybe Text
     -> Maybe Text
-    -> IO ()
-saveSubagentState sessionDir agentId items previous agentType = do
-    let dir = subagentStoreDir sessionDir agentId
-        metaPath = dir </> "meta.json"
-        transcriptPath = dir </> "transcript.json"
-    createDirectoryIfMissing True dir
-    _ <- try @IOError (setFileMode dir 0o700)
-    LBS.writeFile metaPath $ Aeson.encode SubagentDiskMeta
-        { diskPreviousResponseId = previous
-        , diskAgentType = agentType
-        }
-    _ <- try @IOError (setFileMode metaPath 0o600)
-    LBS.writeFile transcriptPath (Aeson.encode items)
-    _ <- try @IOError (setFileMode transcriptPath 0o600)
-    pure ()
+    -> IO (Either Text ())
+saveSubagentState sessionDir agentId items previous agentType =
+    case subagentStoreDir sessionDir agentId of
+        Left err -> pure (Left err)
+        Right dir -> do
+            let metaPath = dir </> "meta.json"
+                transcriptPath = dir </> "transcript.json"
+                metaTmp = metaPath <> ".tmp"
+                transcriptTmp = transcriptPath <> ".tmp"
+            createDirectoryIfMissing True dir
+            _ <- tryAny (setFileMode dir 0o700)
+            LBS.writeFile metaTmp $ Aeson.encode SubagentDiskMeta
+                { diskPreviousResponseId = previous
+                , diskAgentType = agentType
+                }
+            _ <- tryAny (setFileMode metaTmp 0o600)
+            LBS.writeFile transcriptTmp (Aeson.encode items)
+            _ <- tryAny (setFileMode transcriptTmp 0o600)
+            renameFile metaTmp metaPath
+            renameFile transcriptTmp transcriptPath
+            pure (Right ())
 
 loadSubagentState
     :: FilePath
     -> SubagentId
-    -> IO (Maybe ([ResponseItem], SubagentDiskMeta))
-loadSubagentState sessionDir agentId = do
-    let dir = subagentStoreDir sessionDir agentId
-        metaPath = dir </> "meta.json"
-        transcriptPath = dir </> "transcript.json"
-    hasMeta <- doesFileExist metaPath
-    hasTranscript <- doesFileExist transcriptPath
-    if not (hasMeta || hasTranscript)
-        then pure Nothing
-        else do
-            meta <- if hasMeta
-                then do
-                    raw <- LBS.readFile metaPath
-                    pure $ fromMaybe emptyMeta (Aeson.decode raw)
-                else pure emptyMeta
-            items <- if hasTranscript
-                then do
-                    raw <- LBS.readFile transcriptPath
-                    pure $ fromMaybe [] (Aeson.decode raw)
-                else pure []
-            pure $ Just (items, meta)
+    -> IO (Either Text (Maybe ([ResponseItem], SubagentDiskMeta)))
+loadSubagentState sessionDir agentId =
+    case subagentStoreDir sessionDir agentId of
+        Left err -> pure (Left err)
+        Right dir -> do
+            let metaPath = dir </> "meta.json"
+                transcriptPath = dir </> "transcript.json"
+            hasMeta <- doesFileExist metaPath
+            hasTranscript <- doesFileExist transcriptPath
+            if not (hasMeta || hasTranscript)
+                then pure (Right Nothing)
+                else do
+                    metaResult <- if hasMeta
+                        then decodeFile metaPath
+                        else pure (Right (SubagentDiskMeta Nothing Nothing))
+                    itemsResult <- if hasTranscript
+                        then decodeFile transcriptPath
+                        else pure (Right [])
+                    pure $ case (metaResult, itemsResult) of
+                        (Left err, _) -> Left err
+                        (_, Left err) -> Left err
+                        (Right meta, Right items) ->
+                            Right (Just (items, meta))
   where
-    emptyMeta = SubagentDiskMeta Nothing Nothing
+    decodeFile path = do
+        raw <- LBS.readFile path
+        case Aeson.eitherDecode raw of
+            Left err ->
+                pure $ Left $
+                    "failed to decode "
+                        <> Text.pack path
+                        <> ": "
+                        <> Text.pack err
+            Right value -> pure (Right value)

--- a/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
@@ -148,6 +148,8 @@ spec = do
                     , "session"
                     , "resume"
                     , "compact"
+                    , "clear"
+                    , "new"
                     , "reload-auth"
                     , "paste"
                     , "attachments"

--- a/packages/agent-cli/test/Agent/CLI/SubagentStoreSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SubagentStoreSpec.hs
@@ -5,7 +5,12 @@ import Agent.OpenAI.Responses.Types
 import Agent.Subagents (SubagentId(..))
 import Control.Exception (bracket)
 import qualified Data.Aeson.KeyMap as KeyMap
-import System.Directory (getTemporaryDirectory, removeDirectoryRecursive, doesFileExist)
+import qualified Data.ByteString.Lazy as LBS
+import System.Directory
+    ( doesFileExist
+    , getTemporaryDirectory
+    , removeDirectoryRecursive
+    )
 import System.FilePath ((</>))
 import System.Posix.Temp (mkdtemp)
 import Test.Hspec
@@ -24,15 +29,36 @@ spec = describe "Agent.CLI.SubagentStore" do
                     , extraFields = KeyMap.empty
                     }
             saveSubagentState dir agentId [item] (Just "resp-1") (Just "explore")
+                `shouldReturn` Right ()
             loaded <- loadSubagentState dir agentId
             case loaded of
-                Nothing -> expectationFailure "expected persisted state"
-                Just (items, meta) -> do
+                Right (Just (items, meta)) -> do
                     length items `shouldBe` 1
                     meta.diskPreviousResponseId `shouldBe` Just "resp-1"
                     meta.diskAgentType `shouldBe` Just "explore"
-            doesFileExist (subagentStoreDir dir agentId </> "transcript.json")
-                `shouldReturn` True
+                other -> expectationFailure ("unexpected load: " <> show other)
+            case subagentStoreDir dir agentId of
+                Right path ->
+                    doesFileExist (path </> "transcript.json") `shouldReturn` True
+                Left err -> expectationFailure (show err)
+
+    it "rejects path-traversal agent ids" do
+        isValidSubagentStoreId (SubagentId "../..") `shouldBe` False
+        isValidSubagentStoreId (SubagentId "agent/../x") `shouldBe` False
+        case subagentStoreDir "/tmp/session" (SubagentId "../..") of
+            Left _ -> pure ()
+            Right _ -> expectationFailure "expected invalid id"
+
+    it "fails closed on corrupt transcript JSON" do
+        withTempDir \dir -> do
+            let agentId = SubagentId "agent-corrupt-1"
+            saveSubagentState dir agentId [] (Just "r") Nothing
+                `shouldReturn` Right ()
+            Right path <- pure (subagentStoreDir dir agentId)
+            LBS.writeFile (path </> "transcript.json") "{not-json"
+            loadSubagentState dir agentId >>= \case
+                Left err -> err `shouldSatisfy` (not . null . show)
+                Right _ -> expectationFailure "expected decode failure"
 
 withTempDir :: (FilePath -> IO a) -> IO a
 withTempDir action = do

--- a/packages/agent-core/src/Agent/Subagents.hs
+++ b/packages/agent-core/src/Agent/Subagents.hs
@@ -463,7 +463,13 @@ restoreSubagent
 restoreSubagent registry agentId parentId depth nickname previous = do
     existing <- atomically $ Map.lookup agentId <$> readTVar registry.registryAgents
     case existing of
-        Just _ -> pure (Right agentId)
+        Just record -> do
+            -- Same-process resume after close: reopen without consuming a slot.
+            atomically do
+                writeTVar record.recordStatus (Completed Nothing)
+                writeTVar record.recordPreviousResponseId previous
+                writeTVar record.recordAsync Nothing
+            pure (Right agentId)
         Nothing -> do
             cancelFlag <- newCancelFlag
             mailbox <- newTQueueIO

--- a/packages/agent-core/test/Agent/SubagentsSpec.hs
+++ b/packages/agent-core/test/Agent/SubagentsSpec.hs
@@ -219,3 +219,22 @@ spec = describe "Agent.Subagents" do
         (statuses, timedOut) <- waitSubagents registry [agentId] 15000
         timedOut `shouldBe` False
         Map.lookup agentId statuses `shouldBe` Just (Completed (Just "follow"))
+
+    it "reopens a closed agent via restoreSubagent" do
+        registry <- newSubagentRegistry defaultSubagentConfig "/tmp"
+            (\_ _ prompt _ -> pure $ Right LoopResult
+                { finalResponseId = "r"
+                , finalText = Just prompt
+                , turnsUsed = 1
+                })
+            (\_ _ -> pure ())
+        Right agentId <- spawnSubagent registry Nothing 0 "first" Nothing
+        _ <- waitSubagents registry [agentId] 15000
+        _ <- closeSubagent registry agentId
+        status0 <- getStatus registry agentId
+        status0 `shouldBe` Closed
+        Right _ <- restoreSubagent registry agentId Nothing 1 Nothing (Just "prev")
+        status1 <- getStatus registry agentId
+        status1 `shouldBe` Completed Nothing
+        previous <- getPreviousResponseId registry agentId
+        previous `shouldBe` Just "prev"


### PR DESCRIPTION
## Summary
Follow-up to #59 review comments:
- Ensure the session directory exists **before** the first turn so early subagent completions can persist.
- Validate agent ids before building `agents/<id>` paths (blocks `../..` traversal).
- Reopen closed in-memory agents on `restoreSubagent` / Grok `resume_from`.
- Fail closed on corrupt transcript/meta JSON; save via atomic temp + rename.
- Use `Control.Exception.Safe`.

## Test plan
- [x] `cabal test agent-core` (closed-agent restore)
- [x] `cabal test agent-cli` (path rejection + corrupt JSON)