### PR TITLE
feat: Codex multi-agent v2 collaboration tools

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -131,6 +131,7 @@ import Agent.Subagents
     , formatCompletionNotice
     , getPreviousResponseId
     , getStatus
+    , getTaskPath
     , newSubagentRegistry
     , restoreSubagent
     , setSubagentOnComplete
@@ -144,6 +145,7 @@ import Agent.Tools
     , filterChildGrokTools
     )
 import Agent.Tools.Grok.Task (defaultSubagentType, lookupAgentType, recordAgentType)
+import Agent.Subagents.TaskPath (taskPathRoot)
 import Agent.Tools.MultiAgents (MultiAgentContext(..))
 import Agent.Tools.PlanMode
     ( PlanDecision(..)
@@ -359,6 +361,7 @@ runAgent options = do
             { multiRegistry = registry
             , multiSelfId = Nothing
             , multiDepth = 0
+            , multiTaskPath = taskPathRoot
             , multiResumeFromDisk = Just
                 (restoreAgentFromDisk subagentStoreRoot registry subagentSessions agentTypesRef)
             }
@@ -1757,12 +1760,14 @@ runCodexSubagent options policy planHooks paramsRef wsLock conn registry session
     \env previous prompt onEvent -> do
         parentParams <- readIORef paramsRef
         childEnv <- defaultToolEnv env.subCwd
+        childPath <- fromMaybe taskPathRoot <$> getTaskPath registry env.subId
         -- Inherit soft-cancel from the registry-owned child flag.
         let childToolEnv = childEnv { toolCancel = env.subCancel }
             childCtx = MultiAgentContext
                 { multiRegistry = registry
                 , multiSelfId = Just env.subId
                 , multiDepth = env.subDepth
+                , multiTaskPath = childPath
                 , multiResumeFromDisk = Nothing
                 }
         -- Child tools create their own PlanModeEnv; sync store root from parent
@@ -1826,11 +1831,13 @@ runHttpSubagent options policy planHooks paramsRef provider mkBackend registry s
     \env previous prompt onEvent -> do
         parentParams <- readIORef paramsRef
         childEnv <- defaultToolEnv env.subCwd
+        childPath <- fromMaybe taskPathRoot <$> getTaskPath registry env.subId
         let childToolEnv = childEnv { toolCancel = env.subCancel }
             childCtx = MultiAgentContext
                 { multiRegistry = registry
                 , multiSelfId = Just env.subId
                 , multiDepth = env.subDepth
+                , multiTaskPath = childPath
                 , multiResumeFromDisk = Nothing
                 }
         session <- lookupOrCreateSubagentSession sessionsRef storeRootRef typesRef env.subId

--- a/packages/agent-cli/src/Agent/CLI/Tools.hs
+++ b/packages/agent-cli/src/Agent/CLI/Tools.hs
@@ -55,7 +55,7 @@ schemaFromAppTool provider tool = case tool.appToolKind of
     FreeformApplyPatch ->
         applyPatchCustomTool tool.appToolName tool.appToolDescription
 
--- | Codex multi_agent_v1 namespace: nested non-strict function tools.
+-- | Codex collaboration namespace: nested non-strict function tools.
 multiAgentNamespaceTool :: [AppTool] -> ResponseTool
 multiAgentNamespaceTool tools = KnownResponseTool ToolNamespace TaggedObject
     { tag = "namespace"

--- a/packages/agent-cli/test/Agent/CLI/ToolsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ToolsSpec.hs
@@ -52,7 +52,7 @@ spec = describe "schemasFromAppTools" do
                     other -> expectationFailure ("expected format object, got " <> show other)
             other -> expectationFailure ("expected custom tool, got " <> show other)
 
-    it "emits multi_agent_v1 as a Responses namespace tool" do
+    it "emits collaboration as a Responses namespace tool" do
         let spawn = AppTool
                 { appToolName = "spawn_agent"
                 , appToolDescription = "Spawn."
@@ -67,7 +67,7 @@ spec = describe "schemasFromAppTools" do
             [_, FunctionToolValue _, KnownResponseTool ToolNamespace tagged] -> do
                 tagged.tag `shouldBe` "namespace"
                 KeyMap.lookup "name" tagged.fields
-                    `shouldBe` Just (Aeson.String "multi_agent_v1")
+                    `shouldBe` Just (Aeson.String "collaboration")
             other -> expectationFailure ("expected namespace tool, got " <> show other)
 
 jsonTool :: AppTool

--- a/packages/agent-core/agent-core.cabal
+++ b/packages/agent-core/agent-core.cabal
@@ -38,6 +38,7 @@ library
                     , Agent.Loop
                     , Agent.ProjectInstructions
                     , Agent.Subagents
+                    , Agent.Subagents.TaskPath
                     , Agent.ToolArgs
                     , Agent.ToolDSL
                     , Agent.ToolDispatch
@@ -83,6 +84,7 @@ test-suite agent-core-test
                     , Agent.LoopSpec
                     , Agent.ProjectInstructionsSpec
                     , Agent.SubagentsSpec
+                    , Agent.Subagents.TaskPathSpec
                     , Agent.ToolArgsSpec
                     , Agent.ToolDispatchSpec
                     , Agent.Tools.CodexSpec

--- a/packages/agent-core/src/Agent/Subagents.hs
+++ b/packages/agent-core/src/Agent/Subagents.hs
@@ -21,14 +21,21 @@ module Agent.Subagents
     , closeSubagentRegistry
     , resetSubagentRegistry
     , spawnSubagent
+    , spawnSubagentAt
     , restoreSubagent
     , waitSubagents
+    , waitAnyLive
     , sendInput
+    , queueMessage
     , closeSubagent
+    , interruptSubagent
     , resumeSubagent
     , getStatus
     , getPreviousResponseId
+    , getTaskPath
+    , resolveAgentTarget
     , listLive
+    , listAgents
     , encodeStatus
     , isFinalStatus
     , formatCompletionNotice
@@ -43,6 +50,7 @@ import Control.Exception.Safe (SomeException, tryAny)
 import Data.Aeson ((.=), object)
 import qualified Data.Aeson as Aeson
 import Data.IORef
+import Data.Maybe (fromMaybe)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Text (Text)
@@ -50,6 +58,15 @@ import qualified Data.Text as Text
 import Data.Time.Clock (getCurrentTime)
 import Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds)
 import Numeric (showHex)
+import Agent.Subagents.TaskPath
+    ( TaskPath
+    , joinTaskPath
+    , parseTaskPath
+    , resolveTaskPath
+    , taskPathRoot
+    , taskPathText
+    , validateTaskName
+    )
 import System.IO.Unsafe (unsafePerformIO)
 
 newtype SubagentId = SubagentId { unSubagentId :: Text }
@@ -126,10 +143,12 @@ data SubagentRecord = SubagentRecord
     , recordSlotHeld :: !(TVar Bool)
       -- | Last successful response id for conversation continuity.
     , recordPreviousResponseId :: !(TVar (Maybe Text))
+    , recordTaskPath :: !TaskPath
     }
 
 data SubagentRegistry = SubagentRegistry
     { registryAgents :: !(TVar (Map SubagentId SubagentRecord))
+    , registryPaths :: !(TVar (Map TaskPath SubagentId))
     , registryLiveCount :: !(TVar Int)
     , registryConfig :: !SubagentConfig
     , registryRunRef :: !(IORef RunSubagent)
@@ -147,12 +166,14 @@ newSubagentRegistry
     -> IO SubagentRegistry
 newSubagentRegistry config cwd run onEvent = do
     agents <- newTVarIO Map.empty
+    paths <- newTVarIO Map.empty
     live <- newTVarIO 0
     closed <- newTVarIO False
     runRef <- newIORef run
     onCompleteRef <- newIORef (\_ _ -> pure ())
     pure SubagentRegistry
         { registryAgents = agents
+        , registryPaths = paths
         , registryLiveCount = live
         , registryConfig = config
             { maxConcurrent = max 1 config.maxConcurrent
@@ -188,6 +209,7 @@ resetSubagentRegistry registry = do
     closeSubagentRegistry registry
     atomically do
         writeTVar registry.registryAgents Map.empty
+        writeTVar registry.registryPaths Map.empty
         writeTVar registry.registryLiveCount 0
         writeTVar registry.registryClosed False
 
@@ -199,52 +221,86 @@ spawnSubagent
     -> Maybe Text
     -> IO (Either Text SubagentId)
 spawnSubagent registry parentId parentDepth message nickname = do
+    parentPath <- case parentId of
+        Nothing -> pure taskPathRoot
+        Just pid -> do
+            mpath <- getTaskPath registry pid
+            pure (fromMaybe taskPathRoot mpath)
+    agentIdPreview <- newSubagentId
+    let taskName =
+            "a"
+                <> Text.filter (\c -> c /= '-') agentIdPreview.unSubagentId
+    -- Reuse the generated id by spawning with an explicit path helper that
+    -- still allocates internally; uniqueness comes from the id-derived name.
+    fmap (fmap fst) $
+        spawnSubagentAt registry parentId parentPath parentDepth taskName message nickname
+
+-- | Spawn with an explicit parent path and task_name (Codex multi-agent v2).
+spawnSubagentAt
+    :: SubagentRegistry
+    -> Maybe SubagentId
+    -> TaskPath
+    -> Int
+    -> Text
+    -> Text
+    -> Maybe Text
+    -> IO (Either Text (SubagentId, TaskPath))
+spawnSubagentAt registry parentId parentPath parentDepth taskName message nickname = do
     let nextDepth = parentDepth + 1
         cfg = registry.registryConfig
     case cfg.maxDepth of
         Just limit | nextDepth > limit ->
             pure $ Left "Agent depth limit reached. Solve the task yourself."
-        _ -> do
-            agentId <- newSubagentId
-            cancelFlag <- newCancelFlag
-            mailbox <- newTQueueIO
-            statusVar <- newTVarIO Pending
-            asyncVar <- newTVarIO Nothing
-            slotHeld <- newTVarIO True
-            previousVar <- newTVarIO Nothing
-            let record = SubagentRecord
-                    { recordId = agentId
-                    , recordParent = parentId
-                    , recordDepth = nextDepth
-                    , recordNickname = nickname
-                    , recordStatus = statusVar
-                    , recordCancel = cancelFlag
-                    , recordMailbox = mailbox
-                    , recordAsync = asyncVar
-                    , recordSlotHeld = slotHeld
-                    , recordPreviousResponseId = previousVar
-                    }
-            admitted <- atomically do
-                closed <- readTVar registry.registryClosed
-                if closed
-                    then pure (Left "Subagent registry is closed.")
-                    else do
-                        live <- readTVar registry.registryLiveCount
-                        if live >= cfg.maxConcurrent
-                            then pure $ Left $
-                                "Concurrent subagent limit reached: "
-                                    <> Text.pack (show cfg.maxConcurrent)
-                                    <> " agents are already open. Close finished agents before spawning more."
-                            else do
-                                modifyTVar' registry.registryLiveCount (+ 1)
-                                modifyTVar' registry.registryAgents (Map.insert agentId record)
-                                pure (Right ())
-            case admitted of
-                Left err -> pure (Left err)
-                Right () -> do
-                    child <- async (runWorker registry record message)
-                    atomically $ writeTVar asyncVar (Just child)
-                    pure (Right agentId)
+        _ -> case joinTaskPath parentPath taskName of
+            Left err -> pure (Left err)
+            Right childPath -> do
+                agentId <- newSubagentId
+                cancelFlag <- newCancelFlag
+                mailbox <- newTQueueIO
+                statusVar <- newTVarIO Pending
+                asyncVar <- newTVarIO Nothing
+                slotHeld <- newTVarIO True
+                previousVar <- newTVarIO Nothing
+                let record = SubagentRecord
+                        { recordId = agentId
+                        , recordParent = parentId
+                        , recordDepth = nextDepth
+                        , recordNickname = nickname
+                        , recordStatus = statusVar
+                        , recordCancel = cancelFlag
+                        , recordMailbox = mailbox
+                        , recordAsync = asyncVar
+                        , recordSlotHeld = slotHeld
+                        , recordPreviousResponseId = previousVar
+                        , recordTaskPath = childPath
+                        }
+                admitted <- atomically do
+                    closed <- readTVar registry.registryClosed
+                    if closed
+                        then pure (Left "Subagent registry is closed.")
+                        else do
+                            paths <- readTVar registry.registryPaths
+                            if Map.member childPath paths
+                                then pure $ Left $
+                                    "task path already in use: " <> taskPathText childPath
+                                else do
+                                    live <- readTVar registry.registryLiveCount
+                                    if live >= cfg.maxConcurrent
+                                        then pure $ Left $
+                                            "Concurrent subagent limit reached: "
+                                                <> Text.pack (show cfg.maxConcurrent)
+                                                <> " agents are already open. Close finished agents before spawning more."
+                                        else do
+                                            modifyTVar' registry.registryLiveCount (+ 1)
+                                            modifyTVar' registry.registryAgents (Map.insert agentId record)
+                                            modifyTVar' registry.registryPaths (Map.insert childPath agentId)
+                                            pure (Right ())
+                case admitted of
+                    Left err -> pure (Left err)
+                    Right () -> do
+                        child <- async (runWorker registry record message)
+                        atomically $ writeTVar asyncVar (Just child)
+                        pure (Right (agentId, childPath))
 
 runWorker :: SubagentRegistry -> SubagentRecord -> Text -> IO ()
 runWorker registry record firstPrompt = do
@@ -498,6 +554,7 @@ restoreSubagent registry agentId parentId depth nickname previous = do
                     , recordAsync = asyncVar
                     , recordSlotHeld = slotHeld
                     , recordPreviousResponseId = previousVar
+                    , recordTaskPath = taskPathRoot
                     }
             atomically do
                 closed <- readTVar registry.registryClosed
@@ -604,3 +661,92 @@ newSubagentId = do
 subagentIdCounter :: IORef Int
 subagentIdCounter = unsafePerformIO (newIORef (0 :: Int))
 {-# NOINLINE subagentIdCounter #-}
+
+getTaskPath :: SubagentRegistry -> SubagentId -> IO (Maybe TaskPath)
+getTaskPath registry agentId = atomically do
+    agents <- readTVar registry.registryAgents
+    pure (fmap (.recordTaskPath) (Map.lookup agentId agents))
+
+resolveAgentTarget
+    :: SubagentRegistry
+    -> TaskPath
+    -> Text
+    -> IO (Either Text SubagentId)
+resolveAgentTarget registry callerPath target
+    | "agent-" `Text.isPrefixOf` target = do
+        status <- getStatus registry (SubagentId target)
+        pure $ case status of
+            NotFound -> Left ("unknown agent id: " <> target)
+            _ -> Right (SubagentId target)
+    | otherwise = case resolveTaskPath callerPath target of
+        Left err -> pure (Left err)
+        Right path -> atomically do
+            paths <- readTVar registry.registryPaths
+            pure $ case Map.lookup path paths of
+                Just agentId -> Right agentId
+                Nothing -> Left ("unknown task path: " <> taskPathText path)
+
+listAgents
+    :: SubagentRegistry
+    -> Maybe Text
+    -> IO [(TaskPath, SubagentId, SubagentStatus)]
+listAgents registry pathPrefix = atomically do
+    agents <- readTVar registry.registryAgents
+    let prefix = maybe "" Text.strip pathPrefix
+    fmap concat $ mapM
+        (\record -> do
+            status <- readTVar record.recordStatus
+            let pathText = taskPathText record.recordTaskPath
+                keep =
+                    status /= Closed
+                        && status /= NotFound
+                        && (Text.null prefix || prefix `Text.isPrefixOf` pathText)
+            pure $ if keep
+                then [(record.recordTaskPath, record.recordId, status)]
+                else [])
+        (Map.elems agents)
+
+interruptSubagent
+    :: SubagentRegistry
+    -> SubagentId
+    -> IO (Either Text SubagentStatus)
+interruptSubagent registry agentId = do
+    mrecord <- atomically $ Map.lookup agentId <$> readTVar registry.registryAgents
+    case mrecord of
+        Nothing -> pure (Left ("unknown agent id: " <> agentId.unSubagentId))
+        Just record -> do
+            previous <- atomically $ readTVar record.recordStatus
+            requestCancel record.recordCancel
+            pure (Right previous)
+
+-- | Queue a message without starting a new turn when idle (v2 send_message).
+queueMessage
+    :: SubagentRegistry
+    -> SubagentId
+    -> Text
+    -> IO (Either Text Text)
+queueMessage registry agentId message = do
+    mrecord <- atomically $ Map.lookup agentId <$> readTVar registry.registryAgents
+    case mrecord of
+        Nothing -> pure (Left ("unknown agent id: " <> agentId.unSubagentId))
+        Just record -> do
+            status <- atomically $ readTVar record.recordStatus
+            case status of
+                Closed -> pure (Left "agent is closed")
+                NotFound -> pure (Left "agent not found")
+                _ -> do
+                    atomically $ writeTQueue record.recordMailbox message
+                    pure (Right "queued")
+
+-- | Wait until any live non-final agent reaches a final status (or timeout).
+waitAnyLive
+    :: SubagentRegistry
+    -> Int
+    -> IO (Map SubagentId SubagentStatus, Bool)
+waitAnyLive registry timeoutMs = do
+    nonFinal <- fmap (map fst . filter (not . isFinalStatus . snd)) (listLive registry)
+    if null nonFinal
+        then do
+            pairs <- listLive registry
+            pure (Map.fromList pairs, False)
+        else waitSubagents registry nonFinal timeoutMs

--- a/packages/agent-core/src/Agent/Subagents/TaskPath.hs
+++ b/packages/agent-core/src/Agent/Subagents/TaskPath.hs
@@ -1,0 +1,89 @@
+-- | Codex multi-agent v2 task paths (@/root/...@).
+--
+-- Subset of openai/codex 'AgentPath': absolute paths under @/root@ with
+-- lowercase alphanumeric / underscore segments.
+module Agent.Subagents.TaskPath
+    ( TaskPath
+    , taskPathRoot
+    , taskPathText
+    , taskPathName
+    , isTaskPathRoot
+    , parseTaskPath
+    , joinTaskPath
+    , resolveTaskPath
+    , validateTaskName
+    ) where
+
+import Data.Char (isAsciiLower, isDigit)
+import Data.Text (Text)
+import qualified Data.Text as Text
+
+newtype TaskPath = TaskPath { unTaskPath :: Text }
+    deriving (Eq, Ord, Show)
+
+taskPathRoot :: TaskPath
+taskPathRoot = TaskPath "/root"
+
+taskPathText :: TaskPath -> Text
+taskPathText (TaskPath text) = text
+
+isTaskPathRoot :: TaskPath -> Bool
+isTaskPathRoot (TaskPath text) = text == "/root"
+
+taskPathName :: TaskPath -> Text
+taskPathName path@(TaskPath text)
+    | isTaskPathRoot path = "root"
+    | otherwise =
+        case reverse (Text.splitOn "/" text) of
+            (name : _) | not (Text.null name) -> name
+            _ -> "root"
+
+parseTaskPath :: Text -> Either Text TaskPath
+parseTaskPath raw = do
+    let path = Text.strip raw
+    if Text.null path
+        then Left "task path must not be empty"
+        else do
+            validateAbsolute path
+            pure (TaskPath path)
+
+validateTaskName :: Text -> Either Text Text
+validateTaskName name
+    | Text.null name = Left "task_name must not be empty"
+    | name == "root" = Left "task_name must not be \"root\""
+    | Text.any (not . isNameChar) name =
+        Left "task_name must use lowercase letters, digits, and underscores only"
+    | otherwise = Right name
+  where
+    isNameChar c = isAsciiLower c || isDigit c || c == '_'
+
+joinTaskPath :: TaskPath -> Text -> Either Text TaskPath
+joinTaskPath (TaskPath parent) name = do
+    validated <- validateTaskName name
+    parseTaskPath (parent <> "/" <> validated)
+
+-- | Resolve a target reference relative to the caller's path.
+-- Absolute @/root/...@ paths parse directly; relative names join the caller.
+resolveTaskPath :: TaskPath -> Text -> Either Text TaskPath
+resolveTaskPath current@(TaskPath currentText) reference
+    | Text.null reference = Left "target must not be empty"
+    | reference == "/root" = Right taskPathRoot
+    | "/" `Text.isPrefixOf` reference = parseTaskPath reference
+    | otherwise = do
+        validateRelative reference
+        parseTaskPath (currentText <> "/" <> reference)
+
+validateAbsolute :: Text -> Either Text ()
+validateAbsolute path
+    | path == "/root" = Right ()
+    | "/root/" `Text.isPrefixOf` path = do
+        let rest = Text.drop (Text.length "/root/") path
+        mapM_ validateTaskName (filter (not . Text.null) (Text.splitOn "/" rest))
+    | otherwise = Left "task path must start with /root"
+
+validateRelative :: Text -> Either Text ()
+validateRelative reference
+    | "/" `Text.isPrefixOf` reference =
+        Left "relative target must not start with /"
+    | otherwise =
+        mapM_ validateTaskName (filter (not . Text.null) (Text.splitOn "/" reference))

--- a/packages/agent-core/src/Agent/ToolDispatch.hs
+++ b/packages/agent-core/src/Agent/ToolDispatch.hs
@@ -119,22 +119,32 @@ findHandler name handlers =
     find ((== name) . handlerName) handlers
         <|> find ((== stripNamespace name) . handlerName) handlers
 
--- | Codex namespaced tools may arrive as @multi_agent_v1.spawn_agent@ or
--- @multi_agent_v1spawn_agent@ (concatenated Display form). Match the bare
--- function name either way.
+-- | Codex namespaced tools may arrive as @collaboration.spawn_agent@ or
+-- legacy @multi_agent_v1.spawn_agent@ (and concatenated Display forms).
 stripNamespace :: Text -> Text
 stripNamespace name
+    | Just rest <- Text.stripPrefix "collaboration." name = rest
+    | Just rest <- Text.stripPrefix "collaboration" name
+    , rest `elem` multiAgentBareNames =
+        rest
     | Just rest <- Text.stripPrefix "multi_agent_v1." name = rest
     | Just rest <- Text.stripPrefix "multi_agent_v1" name
-    , rest `elem`
-        [ "spawn_agent"
-        , "wait_agent"
-        , "send_input"
-        , "close_agent"
-        , "resume_agent"
-        ] =
+    , rest `elem` multiAgentBareNames =
         rest
     | otherwise = name
+
+multiAgentBareNames :: [Text]
+multiAgentBareNames =
+    [ "spawn_agent"
+    , "wait_agent"
+    , "send_message"
+    , "followup_task"
+    , "list_agents"
+    , "interrupt_agent"
+    , "send_input"
+    , "close_agent"
+    , "resume_agent"
+    ]
 
 handlerName :: ToolHandler -> Text
 handlerName = \case

--- a/packages/agent-core/src/Agent/Tools/MultiAgents.hs
+++ b/packages/agent-core/src/Agent/Tools/MultiAgents.hs
@@ -1,7 +1,7 @@
--- | Codex multi-agent v1 tools (spawn_agent, wait_agent, …).
+-- | Codex multi-agent v2 tools (collaboration namespace).
 --
 -- Wire names and schemas follow openai/codex
--- @codex-rs/core/src/tools/handlers/multi_agents_spec.rs@ (v1 namespace).
+-- @codex-rs/core/src/tools/handlers/multi_agents_spec.rs@ (v2).
 module Agent.Tools.MultiAgents
     ( MultiAgentContext(..)
     , multiAgentTools
@@ -12,20 +12,27 @@ module Agent.Tools.MultiAgents
 import Agent.Subagents
     ( SubagentId(..)
     , SubagentRegistry
-    , SubagentStatus
-    , closeSubagent
+    , SubagentStatus(..)
     , defaultWaitTimeoutMs
     , encodeStatus
+    , interruptSubagent
+    , listAgents
     , maxWaitTimeoutMs
     , minWaitTimeoutMs
-    , resumeSubagent
+    , queueMessage
+    , resolveAgentTarget
     , sendInput
-    , spawnSubagent
+    , spawnSubagentAt
+    , waitAnyLive
     , waitSubagents
+    )
+import Agent.Subagents.TaskPath
+    ( TaskPath
+    , taskPathRoot
+    , taskPathText
     )
 import Agent.ToolArgs
     ( objectArgs
-    , optBool
     , optInt
     , optText
     , reqText
@@ -52,35 +59,38 @@ import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 
--- | Per-agent identity for nesting depth / parent linkage.
+-- | Per-agent identity for nesting depth / parent linkage / task path.
 data MultiAgentContext = MultiAgentContext
     { multiRegistry :: !SubagentRegistry
     , multiSelfId :: !(Maybe SubagentId)
     , multiDepth :: !Int
+    , multiTaskPath :: !TaskPath
       -- | Optional host hook to rehydrate a closed/missing agent from disk
-      -- before 'resume_agent' / follow-ups. 'Nothing' means in-memory only.
+      -- before follow-ups. 'Nothing' means in-memory only.
     , multiResumeFromDisk :: !(Maybe (SubagentId -> IO (Either Text ())))
     }
 
 multiAgentNamespace :: Text
-multiAgentNamespace = "multi_agent_v1"
+multiAgentNamespace = "collaboration"
 
 multiAgentToolNames :: [Text]
 multiAgentToolNames =
     [ "spawn_agent"
     , "wait_agent"
-    , "send_input"
-    , "close_agent"
-    , "resume_agent"
+    , "send_message"
+    , "followup_task"
+    , "list_agents"
+    , "interrupt_agent"
     ]
 
 multiAgentTools :: MultiAgentContext -> [AppTool]
 multiAgentTools ctx =
     [ spawnAgentTool ctx
     , waitAgentTool ctx
-    , sendInputTool ctx
-    , closeAgentTool ctx
-    , resumeAgentTool ctx
+    , sendMessageTool ctx
+    , followupTaskTool ctx
+    , listAgentsTool ctx
+    , interruptAgentTool ctx
     ]
 
 jsonTool
@@ -105,89 +115,101 @@ jsonTool name description parameters readOnly handler = AppTool
 --------------------------------------------------------------------------------
 
 data SpawnAgentArgs = SpawnAgentArgs
-    { message :: Maybe Text
+    { taskName :: Text
+    , message :: Text
     , agentType :: Maybe Text
     , model :: Maybe Text
     , reasoningEffort :: Maybe Text
-    , forkContext :: Bool
+    , forkTurns :: Maybe Text
     }
 
 instance FromJSON SpawnAgentArgs where
-    parseJSON = objectArgs \object -> SpawnAgentArgs
-        <$> optText object "message"
-        <*> optText object "agent_type"
-        <*> optText object "model"
-        <*> optText object "reasoning_effort"
-        <*> (fromMaybe False <$> optBool object "fork_context")
+    parseJSON = objectArgs \object_ -> SpawnAgentArgs
+        <$> reqText object_ "task_name"
+        <*> reqText object_ "message"
+        <*> optText object_ "agent_type"
+        <*> optText object_ "model"
+        <*> optText object_ "reasoning_effort"
+        <*> optText object_ "fork_turns"
 
 spawnAgentTool :: MultiAgentContext -> AppTool
 spawnAgentTool ctx = jsonTool "spawn_agent" spawnAgentDescription
-    [ PropertySchema "message" PropertyString False $ Just
+    [ PropertySchema "task_name" PropertyString True $ Just
+        "Task name for the new agent. Use lowercase letters, digits, and underscores."
+    , PropertySchema "message" PropertyString True $ Just
         "Initial plain-text task for the new agent."
     , PropertySchema "agent_type" PropertyString False $ Just
-        "Optional agent type override. Omit to use the default worker."
+        "Optional agent type override. Omit unless explicitly asked."
     , PropertySchema "model" PropertyString False $ Just
         "Model override for the new agent. Omit unless an explicit override is needed."
     , PropertySchema "reasoning_effort" PropertyString False $ Just
         "Reasoning effort override for the new agent. Omit to inherit the parent effort."
-    , PropertySchema "fork_context" PropertyBoolean False $ Just
-        "True forks the current thread history into the new agent; false or omitted starts with only the initial prompt. Full-history fork is not supported yet."
+    , PropertySchema "fork_turns" PropertyString False $ Just
+        "Optional number of turns to fork. Defaults to all. Use none, all, or a positive integer. Full-history fork is not supported yet; none starts fresh (the default behavior)."
     ]
     False
     (typedTool "spawn_agent" (runSpawn ctx))
 
 spawnAgentDescription :: Text
 spawnAgentDescription =
-    "Spawn a sub-agent for a well-scoped task. Returns the spawned agent id \
-    \plus the user-facing nickname when available. Spawned agents inherit your \
-    \current model by default. Do not spawn sub-agents unless the user or \
-    \applicable AGENTS.md instructions explicitly ask for sub-agents, \
-    \delegation, or parallel agent work. After spawning, prefer useful local \
-    \work over busy-waiting; call wait_agent only when blocked on the result."
+    "Spawns an agent to work on the specified task. If your current task is \
+    \/root/task1 and you spawn_agent with task_name \"task_3\" the agent will \
+    \have canonical task name /root/task1/task_3. You may refer to this agent \
+    \as task_3 or /root/task1/task_3. Returns the canonical task_name."
 
 runSpawn :: MultiAgentContext -> SpawnAgentArgs -> IO (Either Text Text)
-runSpawn ctx args = case args.message of
-    Nothing -> pure (Left "spawn_agent requires message")
-    Just message
-        | Text.null (Text.strip message) ->
-            pure (Left "spawn_agent requires a non-empty message")
-        | args.forkContext ->
-            pure (Left "fork_context is not supported yet; spawn with a fresh prompt.")
-        | otherwise -> do
-            -- model / agent_type / reasoning_effort accepted but unused in v1.
-            _ <- pure (args.agentType, args.model, args.reasoningEffort)
-            result <- spawnSubagent
-                ctx.multiRegistry
-                ctx.multiSelfId
-                ctx.multiDepth
-                message
-                Nothing
-            pure $ case result of
-                Left err -> Left err
-                Right agentId ->
-                    Right $ encodeJson $ object
-                        [ "agent_id" .= agentId.unSubagentId
-                        , "nickname" .= Aeson.Null
-                        ]
+runSpawn ctx args
+    | Text.null (Text.strip args.message) =
+        pure (Left "spawn_agent requires a non-empty message")
+    | not (validForkTurns args.forkTurns) =
+        pure (Left "fork_turns must be none, all, or a positive integer string")
+    | otherwise = do
+        _ <- pure (args.agentType, args.model, args.reasoningEffort, args.forkTurns)
+        result <- spawnSubagentAt
+            ctx.multiRegistry
+            ctx.multiSelfId
+            ctx.multiTaskPath
+            ctx.multiDepth
+            args.taskName
+            args.message
+            Nothing
+        pure $ case result of
+            Left err -> Left err
+            Right (_agentId, path) ->
+                Right $ encodeJson $ object
+                    [ "task_name" .= taskPathText path
+                    , "nickname" .= Aeson.Null
+                    ]
+
+validForkTurns :: Maybe Text -> Bool
+validForkTurns = \case
+    Nothing -> True
+    Just turns ->
+        let stripped = Text.toLower (Text.strip turns)
+        in stripped `elem` ["none", "all", ""]
+            || (not (Text.null stripped) && Text.all (\c -> c >= '0' && c <= '9') stripped)
 
 --------------------------------------------------------------------------------
 -- wait_agent
 --------------------------------------------------------------------------------
 
 data WaitAgentArgs = WaitAgentArgs
-    { targets :: [Text]
+    { targets :: Maybe [Text]
     , timeoutMs :: Maybe Int
     }
 
 instance FromJSON WaitAgentArgs where
-    parseJSON = objectArgs \object_ -> WaitAgentArgs
-        <$> reqTextList object_ "targets"
-        <*> optInt object_ "timeout_ms"
+    parseJSON = objectArgs \object_ -> do
+        targets <- case KeyMap.lookup (Key.fromText "targets") object_ of
+            Nothing -> pure Nothing
+            Just _ -> Just <$> reqTextList object_ "targets"
+        timeoutMs <- optInt object_ "timeout_ms"
+        pure WaitAgentArgs { targets, timeoutMs }
 
 waitAgentTool :: MultiAgentContext -> AppTool
 waitAgentTool ctx = jsonTool "wait_agent" waitAgentDescription
-    [ PropertySchema "targets" (PropertyArray PropertyString) True $ Just
-        "Agent ids to wait on. Pass multiple ids to wait for whichever finishes first."
+    [ PropertySchema "targets" (PropertyArray PropertyString) False $ Just
+        "Optional agent task names or ids to wait on. Omit to wait for any live agent."
     , PropertySchema "timeout_ms" PropertyInteger False $ Just $
         "Timeout in milliseconds. Defaults to "
             <> Text.pack (show defaultWaitTimeoutMs)
@@ -195,29 +217,59 @@ waitAgentTool ctx = jsonTool "wait_agent" waitAgentDescription
             <> Text.pack (show minWaitTimeoutMs)
             <> ", max "
             <> Text.pack (show maxWaitTimeoutMs)
-            <> ". Prefer longer waits (minutes) to avoid busy polling."
+            <> "."
     ]
     True
     (typedTool "wait_agent" (runWait ctx))
 
 waitAgentDescription :: Text
 waitAgentDescription =
-    "Wait for agents to reach a final status. Completed statuses may include \
-    \the agent's final message. Returns empty status when timed out. Once the \
-    \agent reaches a final status, a notification message will be received \
-    \containing the same completed status."
+    "Wait for a mailbox update from live agents, including final-status \
+    \notifications. Returns a summary of which agents have updates, or a \
+    \timeout summary if no activity arrives before the deadline."
 
 runWait :: MultiAgentContext -> WaitAgentArgs -> IO (Either Text Text)
-runWait ctx args
-    | null args.targets = pure (Left "agent ids must be non-empty")
-    | otherwise = do
-        let ids = map SubagentId args.targets
-            timeoutMs = fromMaybe defaultWaitTimeoutMs args.timeoutMs
-        (statuses, timedOut) <- waitSubagents ctx.multiRegistry ids timeoutMs
-        pure $ Right $ encodeJson $ object
-            [ "status" .= statusObject statuses
-            , "timed_out" .= timedOut
-            ]
+runWait ctx args = do
+    let timeoutMs = fromMaybe defaultWaitTimeoutMs args.timeoutMs
+    case args.targets of
+        Nothing -> do
+            (statuses, timedOut) <- waitAnyLive ctx.multiRegistry timeoutMs
+            pure $ Right $ encodeJson $ object
+                [ "message" .= waitSummary timedOut statuses
+                , "timed_out" .= timedOut
+                ]
+        Just [] -> pure (Left "targets must be non-empty when provided")
+        Just targets -> do
+            resolved <- mapM (resolveAgentTarget ctx.multiRegistry ctx.multiTaskPath) targets
+            case sequence resolved of
+                Left err -> pure (Left err)
+                Right ids -> do
+                    (statuses, timedOut) <- waitSubagents ctx.multiRegistry ids timeoutMs
+                    pure $ Right $ encodeJson $ object
+                        [ "message" .= waitSummary timedOut statuses
+                        , "timed_out" .= timedOut
+                        , "status" .= statusObject statuses
+                        ]
+
+waitSummary :: Bool -> Map SubagentId SubagentStatus -> Text
+waitSummary timedOut statuses
+    | timedOut = "timed out waiting for agent updates"
+    | otherwise =
+        let finals =
+                [ agentId.unSubagentId <> "=" <> shortStatus status
+                | (agentId, status) <- Map.toList statuses
+                ]
+        in "agent updates: " <> Text.intercalate ", " finals
+
+shortStatus :: SubagentStatus -> Text
+shortStatus = \case
+    Completed _ -> "completed"
+    Errored _ -> "errored"
+    Interrupted -> "interrupted"
+    Closed -> "shutdown"
+    Running -> "running"
+    Pending -> "pending"
+    NotFound -> "not_found"
 
 statusObject :: Map SubagentId SubagentStatus -> Value
 statusObject =
@@ -227,128 +279,157 @@ statusObject =
         . Map.toList
 
 --------------------------------------------------------------------------------
--- send_input
+-- send_message / followup_task
 --------------------------------------------------------------------------------
 
-data SendInputArgs = SendInputArgs
+data MessageArgs = MessageArgs
     { target :: Text
-    , message :: Maybe Text
-    , interrupt :: Bool
+    , message :: Text
     }
 
-instance FromJSON SendInputArgs where
-    parseJSON = objectArgs \object_ -> SendInputArgs
+instance FromJSON MessageArgs where
+    parseJSON = objectArgs \object_ -> MessageArgs
         <$> reqText object_ "target"
-        <*> optText object_ "message"
-        <*> (fromMaybe False <$> optBool object_ "interrupt")
+        <*> reqText object_ "message"
 
-sendInputTool :: MultiAgentContext -> AppTool
-sendInputTool ctx = jsonTool "send_input" sendInputDescription
+sendMessageTool :: MultiAgentContext -> AppTool
+sendMessageTool ctx = jsonTool "send_message" sendMessageDescription
     [ PropertySchema "target" PropertyString True $ Just
-        "Agent id to message (from spawn_agent)."
-    , PropertySchema "message" PropertyString False $ Just
-        "Plain-text message to send to the agent."
-    , PropertySchema "interrupt" PropertyBoolean False $ Just
-        "True interrupts the current task and handles this message immediately; false or omitted queues it."
+        "Relative or canonical task name to message (from spawn_agent)."
+    , PropertySchema "message" PropertyString True $ Just
+        "Message text to queue on the target agent."
     ]
     False
-    (typedTool "send_input" (runSendInput ctx))
+    (typedTool "send_message" (runSendMessage ctx))
 
-sendInputDescription :: Text
-sendInputDescription =
-    "Send a message to an existing agent. Use interrupt=true to redirect work \
-    \immediately. You should reuse the agent by send_input if you believe your \
-    \assigned task is highly dependent on the context of a previous task."
+sendMessageDescription :: Text
+sendMessageDescription =
+    "Send a message to an existing agent. The message will be delivered \
+    \promptly. Does not trigger a new turn."
 
-runSendInput :: MultiAgentContext -> SendInputArgs -> IO (Either Text Text)
-runSendInput ctx args = case args.message of
-    Nothing -> pure (Left "send_input requires message")
-    Just message
-        | Text.null (Text.strip message) ->
-            pure (Left "send_input requires a non-empty message")
-        | otherwise -> do
-            result <- sendInput
-                ctx.multiRegistry
-                (SubagentId args.target)
-                message
-                args.interrupt
+runSendMessage :: MultiAgentContext -> MessageArgs -> IO (Either Text Text)
+runSendMessage ctx args
+    | Text.null (Text.strip args.message) =
+        pure (Left "send_message requires a non-empty message")
+    | otherwise = do
+        _ <- maybeRestore ctx args.target
+        resolved <- resolveAgentTarget ctx.multiRegistry ctx.multiTaskPath args.target
+        case resolved of
+            Left err -> pure (Left err)
+            Right agentId -> queueMessage ctx.multiRegistry agentId args.message
+
+followupTaskTool :: MultiAgentContext -> AppTool
+followupTaskTool ctx = jsonTool "followup_task" followupDescription
+    [ PropertySchema "target" PropertyString True $ Just
+        "Agent id or canonical task name to send a follow-up task to (from spawn_agent)."
+    , PropertySchema "message" PropertyString True $ Just
+        "Message text to send to the target agent."
+    ]
+    False
+    (typedTool "followup_task" (runFollowup ctx))
+
+followupDescription :: Text
+followupDescription =
+    "Send a follow-up task to an existing non-root target agent and trigger a \
+    \turn if it is idle. If the target is already running, deliver the task \
+    \promptly at message boundaries."
+
+runFollowup :: MultiAgentContext -> MessageArgs -> IO (Either Text Text)
+runFollowup ctx args
+    | Text.null (Text.strip args.message) =
+        pure (Left "followup_task requires a non-empty message")
+    | otherwise = do
+        _ <- maybeRestore ctx args.target
+        resolved <- resolveAgentTarget ctx.multiRegistry ctx.multiTaskPath args.target
+        case resolved of
+            Left err -> pure (Left err)
+            Right agentId -> sendInput ctx.multiRegistry agentId args.message False
+
+maybeRestore :: MultiAgentContext -> Text -> IO (Either Text ())
+maybeRestore ctx target = case ctx.multiResumeFromDisk of
+    Nothing -> pure (Right ())
+    Just restore ->
+        resolveAgentTarget ctx.multiRegistry ctx.multiTaskPath target >>= \case
+            Left _ ->
+                -- Target may only exist on disk as agent id.
+                if "agent-" `Text.isPrefixOf` target
+                    then restore (SubagentId target)
+                    else pure (Right ())
+            Right agentId -> restore agentId
+
+--------------------------------------------------------------------------------
+-- list_agents
+--------------------------------------------------------------------------------
+
+data ListAgentsArgs = ListAgentsArgs
+    { pathPrefix :: Maybe Text
+    }
+
+instance FromJSON ListAgentsArgs where
+    parseJSON = objectArgs \object_ -> ListAgentsArgs
+        <$> optText object_ "path_prefix"
+
+listAgentsTool :: MultiAgentContext -> AppTool
+listAgentsTool ctx = jsonTool "list_agents" listAgentsDescription
+    [ PropertySchema "path_prefix" PropertyString False $ Just
+        "Task-path prefix filter without a trailing slash. Omit to list all live agents."
+    ]
+    True
+    (typedTool "list_agents" (runListAgents ctx))
+
+listAgentsDescription :: Text
+listAgentsDescription =
+    "List live agents in the current root thread tree. Optionally filter by \
+    \task-path prefix."
+
+runListAgents :: MultiAgentContext -> ListAgentsArgs -> IO (Either Text Text)
+runListAgents ctx args = do
+    agents <- listAgents ctx.multiRegistry args.pathPrefix
+    let payload =
+            [ object
+                [ "agent_name" .= taskPathText path
+                , "agent_id" .= agentId.unSubagentId
+                , "agent_status" .= encodeStatus status
+                ]
+            | (path, agentId, status) <- agents
+            ]
+    pure $ Right $ encodeJson $ object [ "agents" .= payload ]
+
+--------------------------------------------------------------------------------
+-- interrupt_agent
+--------------------------------------------------------------------------------
+
+newtype InterruptAgentArgs = InterruptAgentArgs { target :: Text }
+
+instance FromJSON InterruptAgentArgs where
+    parseJSON = objectArgs \object_ -> InterruptAgentArgs <$> reqText object_ "target"
+
+interruptAgentTool :: MultiAgentContext -> AppTool
+interruptAgentTool ctx = jsonTool "interrupt_agent" interruptDescription
+    [ PropertySchema "target" PropertyString True $ Just
+        "Agent id or canonical task name to interrupt (from spawn_agent)."
+    ]
+    False
+    (typedTool "interrupt_agent" (runInterrupt ctx))
+
+interruptDescription :: Text
+interruptDescription =
+    "Interrupt an agent's current turn, if any, and return its previous status. \
+    \The agent remains available for messages and follow-up tasks."
+
+runInterrupt :: MultiAgentContext -> InterruptAgentArgs -> IO (Either Text Text)
+runInterrupt ctx args = do
+    resolved <- resolveAgentTarget ctx.multiRegistry ctx.multiTaskPath args.target
+    case resolved of
+        Left err -> pure (Left err)
+        Right agentId -> do
+            result <- interruptSubagent ctx.multiRegistry agentId
             pure $ case result of
                 Left err -> Left err
-                Right _ ->
+                Right previous ->
                     Right $ encodeJson $ object
-                        [ "submission_id" .= ("queued" :: Text)
+                        [ "previous_status" .= encodeStatus previous
                         ]
-
---------------------------------------------------------------------------------
--- close_agent
---------------------------------------------------------------------------------
-
-newtype CloseAgentArgs = CloseAgentArgs { target :: Text }
-
-instance FromJSON CloseAgentArgs where
-    parseJSON = objectArgs \object_ -> CloseAgentArgs <$> reqText object_ "target"
-
-closeAgentTool :: MultiAgentContext -> AppTool
-closeAgentTool ctx = jsonTool "close_agent" closeAgentDescription
-    [ PropertySchema "target" PropertyString True $ Just
-        "Agent id to close (from spawn_agent)."
-    ]
-    False
-    (typedTool "close_agent" (runClose ctx))
-
-closeAgentDescription :: Text
-closeAgentDescription =
-    "Close an agent and any open descendants when they are no longer needed, \
-    \and return the target agent's previous status before shutdown was \
-    \requested. Completed agents remain open and count toward the concurrency \
-    \limit until closed. Don't keep agents open for too long if they are not \
-    \needed anymore."
-
-runClose :: MultiAgentContext -> CloseAgentArgs -> IO (Either Text Text)
-runClose ctx args = do
-    result <- closeSubagent ctx.multiRegistry (SubagentId args.target)
-    pure $ case result of
-        Left err -> Left err
-        Right previous ->
-            Right $ encodeJson $ object
-                [ "previous_status" .= encodeStatus previous
-                ]
-
---------------------------------------------------------------------------------
--- resume_agent
---------------------------------------------------------------------------------
-
-newtype ResumeAgentArgs = ResumeAgentArgs { resumeId :: Text }
-
-instance FromJSON ResumeAgentArgs where
-    parseJSON = objectArgs \object_ -> ResumeAgentArgs <$> reqText object_ "id"
-
-resumeAgentTool :: MultiAgentContext -> AppTool
-resumeAgentTool ctx = jsonTool "resume_agent" resumeAgentDescription
-    [ PropertySchema "id" PropertyString True $ Just
-        "Agent id to resume."
-    ]
-    False
-    (typedTool "resume_agent" (runResume ctx))
-
-resumeAgentDescription :: Text
-resumeAgentDescription =
-    "Resume a previously closed agent by id so it can receive send_input and \
-    \wait_agent calls."
-
-runResume :: MultiAgentContext -> ResumeAgentArgs -> IO (Either Text Text)
-runResume ctx args = do
-    let agentId = SubagentId args.resumeId
-    _ <- case ctx.multiResumeFromDisk of
-        Just restore -> restore agentId
-        Nothing -> pure (Right ())
-    result <- resumeSubagent ctx.multiRegistry agentId
-    pure $ case result of
-        Left err -> Left err
-        Right status ->
-            Right $ encodeJson $ object
-                [ "status" .= encodeStatus status
-                ]
 
 encodeJson :: Value -> Text
 encodeJson = Text.decodeUtf8 . LBS.toStrict . Aeson.encode

--- a/packages/agent-core/test/Agent/Subagents/TaskPathSpec.hs
+++ b/packages/agent-core/test/Agent/Subagents/TaskPathSpec.hs
@@ -1,0 +1,25 @@
+module Agent.Subagents.TaskPathSpec (spec) where
+
+import Agent.Subagents.TaskPath
+import Test.Hspec
+
+spec :: Spec
+spec = describe "Agent.Subagents.TaskPath" do
+    it "joins and names child paths" do
+        joinTaskPath taskPathRoot "worker"
+            `shouldBe` Right (either (error "bad") id (parseTaskPath "/root/worker"))
+        fmap taskPathName (parseTaskPath "/root/worker") `shouldBe` Right "worker"
+
+    it "resolves relative and absolute targets" do
+        let current = either (error "bad") id (parseTaskPath "/root/task1")
+        resolveTaskPath current "task_3"
+            `shouldBe` parseTaskPath "/root/task1/task_3"
+        resolveTaskPath current "/root/other"
+            `shouldBe` parseTaskPath "/root/other"
+
+    it "rejects invalid names and paths" do
+        validateTaskName "Bad" `shouldSatisfy` isLeft
+        validateTaskName "a/b" `shouldSatisfy` isLeft
+        parseTaskPath "/not-root" `shouldSatisfy` isLeft
+  where
+    isLeft = either (const True) (const False)

--- a/packages/agent-core/test/Agent/SubagentsSpec.hs
+++ b/packages/agent-core/test/Agent/SubagentsSpec.hs
@@ -2,6 +2,7 @@ module Agent.SubagentsSpec (spec) where
 
 import Agent.Loop (LoopError(..), LoopResult(..))
 import Agent.Subagents
+import Agent.Subagents.TaskPath (taskPathRoot, taskPathText)
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.STM
 import Control.Monad (unless)
@@ -238,3 +239,41 @@ spec = describe "Agent.Subagents" do
         status1 `shouldBe` Completed Nothing
         previous <- getPreviousResponseId registry agentId
         previous `shouldBe` Just "prev"
+
+    it "spawns at a task path and resolves relative targets" do
+        registry <- newSubagentRegistry defaultSubagentConfig "/tmp"
+            (\_ _ prompt _ -> pure $ Right LoopResult
+                { finalResponseId = "c"
+                , finalText = Just prompt
+                , turnsUsed = 1
+                })
+            (\_ _ -> pure ())
+        Right (agentId, path) <-
+            spawnSubagentAt registry Nothing taskPathRoot 0 "worker" "do it" Nothing
+        taskPathText path `shouldBe` "/root/worker"
+        resolved <- resolveAgentTarget registry taskPathRoot "worker"
+        resolved `shouldBe` Right agentId
+        agents <- listAgents registry (Just "/root")
+        map (\(p, _, _) -> taskPathText p) agents `shouldContain` ["/root/worker"]
+        closeSubagentRegistry registry
+
+    it "queueMessage does not kick an idle agent" do
+        started <- newIORef (0 :: Int)
+        registry <- newSubagentRegistry defaultSubagentConfig "/tmp"
+            (\_ _ prompt _ -> do
+                atomicModifyIORef' started \n -> (n + 1, ())
+                pure $ Right LoopResult
+                    { finalResponseId = "c"
+                    , finalText = Just prompt
+                    , turnsUsed = 1
+                    })
+            (\_ _ -> pure ())
+        Right agentId <- spawnSubagent registry Nothing 0 "one" Nothing
+        _ <- waitSubagents registry [agentId] 15000
+        before <- readIORef started
+        Right _ <- queueMessage registry agentId "queued-only"
+        threadDelay 50000
+        after <- readIORef started
+        after `shouldBe` before
+        status <- getStatus registry agentId
+        status `shouldBe` Completed (Just "one")

--- a/packages/agent-core/test/Agent/Tools/CodexSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/CodexSpec.hs
@@ -2,6 +2,7 @@ module Agent.Tools.CodexSpec (spec) where
 
 import Agent.Loop (LoopError(..), defaultLoopDispatch)
 import Agent.Subagents (closeSubagentRegistry, defaultSubagentConfig, newSubagentRegistry)
+import Agent.Subagents.TaskPath (taskPathRoot)
 import Agent.Tools.MultiAgents (MultiAgentContext(..))
 import Agent.Provider (Provider(..))
 import Agent.ToolDispatch
@@ -51,11 +52,12 @@ spec = describe "Agent.Tools.Codex" do
                     { multiRegistry = registry
                     , multiSelfId = Nothing
                     , multiDepth = 0
+                    , multiTaskPath = taskPathRoot
                     , multiResumeFromDisk = Nothing
                     }
             coding <- codingToolsFor OpenAIProvider env Nothing (Just ctx)
             let names = map (.appToolName) coding.codingAppTools
-            names `shouldContain` ["spawn_agent", "wait_agent", "send_input", "close_agent", "resume_agent"]
+            names `shouldContain` ["spawn_agent", "wait_agent", "send_message", "followup_task", "list_agents", "interrupt_agent"]
             coding.codingClose
             closeSubagentRegistry registry
 

--- a/packages/agent-core/test/Agent/Tools/Grok/TaskSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/Grok/TaskSpec.hs
@@ -9,6 +9,7 @@ import Agent.ToolDispatch
     , noArgsTool
     )
 import Agent.Tools.Grok.Task
+import Agent.Subagents.TaskPath (taskPathRoot)
 import Agent.Tools.MultiAgents (MultiAgentContext(..))
 import Agent.Tools.Types (AppTool(..), AppToolKind(..))
 import Data.IORef
@@ -28,7 +29,7 @@ spec = describe "Agent.Tools.Grok.Task" do
                 })
             (\_ _ -> pure ())
         typesRef <- newIORef Map.empty
-        let ctx = MultiAgentContext registry Nothing 0 Nothing
+        let ctx = MultiAgentContext registry Nothing 0 taskPathRoot Nothing
             tool = taskTool ctx typesRef
         result <- dispatchToolCall defaultLoopDispatch [tool.appToolHandler]
             (functionToolCall "c1" "task"
@@ -55,7 +56,7 @@ spec = describe "Agent.Tools.Grok.Task" do
             (\_ _ _ _ -> pure $ Left LoopNoResponseId)
             (\_ _ -> pure ())
         typesRef <- newIORef Map.empty
-        let ctx = MultiAgentContext registry Nothing 0 Nothing
+        let ctx = MultiAgentContext registry Nothing 0 taskPathRoot Nothing
             tool = taskTool ctx typesRef
         result <- dispatchToolCall defaultLoopDispatch [tool.appToolHandler]
             (functionToolCall "c1" "task"

--- a/packages/agent-core/test/Agent/Tools/GrokSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/GrokSpec.hs
@@ -8,6 +8,7 @@ import Agent.Tools (CodingTools(..), appToolHandlers, codingToolsFor, defaultToo
 import Agent.Tools.Grok (closeGrokSession, grokTools, newGrokSession)
 import Agent.Tools.Ghci (GhciSession, closeGhciSession, newGhciSession)
 import Agent.Tools.Grok.Shell (GrokSession(..), PersistentShell(..), hasUnwaitedBackgroundOp)
+import Agent.Subagents.TaskPath (taskPathRoot)
 import Agent.Tools.MultiAgents (MultiAgentContext(..))
 import Agent.Tools.PlanMode (newPlanModeEnv)
 import Agent.Tools.Types (AppTool(..), ToolEnv(..))
@@ -67,7 +68,7 @@ spec = describe "Agent.Tools.Grok" do
                 (\_ _ _ _ -> pure $ Left LoopNoResponseId)
                 (\_ _ -> pure ())
             typesRef <- newIORef Map.empty
-            let ctx = MultiAgentContext registry Nothing 0 Nothing
+            let ctx = MultiAgentContext registry Nothing 0 taskPathRoot Nothing
                 names = map (.appToolName) (grokTools session ghci plan (Just ctx) typesRef)
             names `shouldContain` ["task"]
             closeSubagentRegistry registry

--- a/packages/agent-core/test/Spec.hs
+++ b/packages/agent-core/test/Spec.hs
@@ -5,6 +5,7 @@ import qualified Agent.ErrorSpec as ErrorSpec
 import qualified Agent.LoopSpec as LoopSpec
 import qualified Agent.ProjectInstructionsSpec as ProjectInstructionsSpec
 import qualified Agent.SubagentsSpec as SubagentsSpec
+import qualified Agent.Subagents.TaskPathSpec as TaskPathSpec
 import qualified Agent.ToolArgsSpec as ToolArgsSpec
 import qualified Agent.ToolDispatchSpec as ToolDispatchSpec
 import qualified Agent.ToolDSLSpec as ToolDSLSpec
@@ -24,6 +25,7 @@ main = hspec do
     LoopSpec.spec
     ProjectInstructionsSpec.spec
     SubagentsSpec.spec
+    TaskPathSpec.spec
     ToolArgsSpec.spec
     ToolDispatchSpec.spec
     ToolDSLSpec.spec


### PR DESCRIPTION
## Summary
- Replace OpenAI `multi_agent_v1` with Codex **multi-agent v2** (`collaboration` namespace).
- Add `/root/...` task paths; `spawn_agent` requires `task_name` and returns the canonical path.
- New tools: `send_message` (queue only), `followup_task` (queue + kick), `list_agents`, `interrupt_agent`.
- Keep Grok/OpenRouter `task` surface unchanged.

## Test plan
- [x] `cabal test agent-core` (TaskPath + path spawn/resolve + queueMessage)
- [x] `cabal test agent-cli` (collaboration namespace schema)
- [ ] Manual OpenAI smoke: spawn with `task_name`, `list_agents`, `followup_task`, `wait_agent`