### PR TITLE
feat: detect pasted REPL input via bracketed paste

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -7,6 +7,7 @@ module Agent.CLI
     , run
     ) where
 
+import Agent.CLI.Accounts (runAccountsList, runAccountsRemove, runLogin)
 import Agent.CLI.Auth (LoadedAuth(..), loadAuth)
 import Agent.CLI.CancelWatch (withEscCancel, withStdinPaused)
 import Agent.CLI.Clipboard
@@ -27,7 +28,7 @@ import Agent.CLI.ImagePreview
     , previewRowsFor
     , renderImagePreview
     )
-import Agent.CLI.Input (ReplLine(..), readReplLine)
+import Agent.CLI.Input (ReplLine(..), formatPasteChip, readReplLine)
 import Agent.CLI.Interrupt
     ( InterruptState
     , newInterruptState
@@ -233,6 +234,9 @@ devMain = do
         Right ShowVersion -> putStrLn "agent-cli 0.1.0.0" >> pure DevQuit
         Right ListSessions -> runListSessions >> pure DevQuit
         Right (ShowSession sessionId) -> runShowSession sessionId >> pure DevQuit
+        Right (LoginAccount provider label) -> runLogin provider label >> pure DevQuit
+        Right ListAccounts -> runAccountsList >> pure DevQuit
+        Right (RemoveAccount accountId) -> runAccountsRemove accountId >> pure DevQuit
         Right (RunAgent options) -> do
             result <- runAgent options
             case result of
@@ -248,6 +252,9 @@ run = do
         Right ShowVersion -> putStrLn "agent-cli 0.1.0.0"
         Right ListSessions -> runListSessions
         Right (ShowSession sessionId) -> runShowSession sessionId
+        Right (LoginAccount provider label) -> runLogin provider label
+        Right ListAccounts -> runAccountsList
+        Right (RemoveAccount accountId) -> runAccountsRemove accountId
         Right (RunAgent options) -> do
             result <- runAgent options
             case result of
@@ -770,11 +777,21 @@ repl config render provider previous printed paramsRef policyRef transcriptRef p
             -- Confirmed double Ctrl-C: rethrow so withInterruptResume prints
             -- the --resume hint and the process exits.
             throwIO UserInterrupt
+        ReplPasted pasted ->
+            submitLine continue stdoutColor True pasted
         ReplText line ->
-            let stripped = Text.strip line
-            in if Text.null stripped
-                then continue
-                else case parseReplLine stripped of
+            submitLine continue stdoutColor False line
+  where
+    submitLine continue color pasted line =
+        let stripped = Text.strip line
+        in if Text.null stripped
+            then continue
+            else do
+                when pasted do
+                    let chip = formatPasteChip stripped
+                    when (chip /= stripped) do
+                        Text.putStrLn (roleMuted color chip)
+                case parseReplLine stripped of
                     ReplQuit -> pure DevQuit
                     ReplReload -> requestReload persist
                     ReplPrompt text -> do
@@ -786,7 +803,7 @@ repl config render provider previous printed paramsRef policyRef transcriptRef p
                         case pastedImages of
                             Just images@(_:_) -> do
                                 queueAttachedImages
-                                    attachmentsRef previewIdRef stdoutColor images
+                                    attachmentsRef previewIdRef color images
                                 continue
                             _ -> do
                                 pendingImages <- atomicModifyIORef' attachmentsRef \imgs -> ([], imgs)
@@ -1098,7 +1115,6 @@ repl config render provider previous printed paramsRef policyRef transcriptRef p
                         color <- resolveColor stderr
                         Text.hPutStrLn stderr (roleError color err)
                         continue
-  where
     continue =
         repl config render provider previous printed paramsRef policyRef
             transcriptRef persist planMode projectRoot tokenProvider agentsContext

--- a/packages/agent-cli/src/Agent/CLI/Input.hs
+++ b/packages/agent-cli/src/Agent/CLI/Input.hs
@@ -10,6 +10,8 @@ module Agent.CLI.Input
     , ChoiceKey(..)
     , parseChoiceKey
     , choiceMoveIndex
+    , classifyPastedText
+    , formatPasteChip
     , replHistoryPath
     ) where
 
@@ -85,8 +87,37 @@ import System.Posix.Types (FileMode)
 data ReplLine
     = ReplEof
     | ReplText Text
+    -- | Submitted text that arrived as a paste (bracketed paste, or a
+    -- multi-line / burst heuristic). @replText@ is the payload with CSI
+    -- paste wrappers stripped.
+    | ReplPasted Text
     | ReplQuitInterrupt
     deriving (Eq, Show)
+
+-- | Strip terminal bracketed-paste wrappers (@CSI 200~@ / @CSI 201~@)
+-- and decide whether the buffer looks pasted rather than typed.
+classifyPastedText :: Text -> (Text, Bool)
+classifyPastedText raw =
+    let stripped = stripBracketedPaste raw
+        looksPasted =
+            raw /= stripped
+                || Text.count "\n" stripped >= 3
+    in (stripped, looksPasted)
+
+-- | Compact prompt chip for a multi-line paste. Single-line pastes stay inline.
+formatPasteChip :: Text -> Text
+formatPasteChip text =
+    let n = max 1 (length (Text.lines text))
+    in if n < 4
+        then text
+        else "[Pasted: " <> Text.pack (show n) <> " lines]"
+
+stripBracketedPaste :: Text -> Text
+stripBracketedPaste text =
+    Text.replace pasteEnd "" (Text.replace pasteStart "" text)
+  where
+    pasteStart = "\ESC[200~"
+    pasteEnd = "\ESC[201~"
 
 -- | @~/.haskell-agent/history@ given the user's home directory.
 replHistoryPath :: FilePath -> FilePath
@@ -144,17 +175,25 @@ readReplLine interrupt prompt = do
             home <- getHomeDirectory
             let path = replHistoryPath home
             ensureHistoryParent path
-            readEditedLine interrupt
-                (setComplete completeSlash
-                    defaultSettings
-                        { historyFile = Just path
-                        , autoAddHistory = True
-                        })
-                prompt
+            classifyLine <$>
+                readEditedLine interrupt
+                    (setComplete completeSlash
+                        defaultSettings
+                            { historyFile = Just path
+                            , autoAddHistory = True
+                            })
+                    prompt
         else do
             Text.hPutStr stdout prompt
             hFlush stdout
-            fmap (maybe ReplEof ReplText) readAnswerOnly
+            fmap (maybe ReplEof (classifySubmitted . Text.strip)) readAnswerOnly
+  where
+    classifyLine = \case
+        ReplText text -> classifySubmitted text
+        other -> other
+    classifySubmitted text =
+        let (stripped, pasted) = classifyPastedText text
+        in if pasted then ReplPasted stripped else ReplText stripped
 -- | Read a one-shot approval answer. The question is always written to
 -- stderr (matching the pre-haskeline behavior) so redirected stdout does
 -- not swallow the prompt. Does not touch REPL history.
@@ -367,7 +406,8 @@ withChoiceRawStdin action = do
     bracket enter (const restore) \() -> action
 
 readEditedLine :: InterruptState -> Settings IO -> Text -> IO ReplLine
-readEditedLine interrupt settings prompt = go
+readEditedLine interrupt settings prompt =
+    withBracketedPaste go
   where
     go =
         -- Haskeline turns Ctrl-C into 'Interrupt' and replaces our SIGINT
@@ -382,6 +422,22 @@ readEditedLine interrupt settings prompt = go
         noteIdleCtrlC interrupt >>= \case
             ContinuePrompt -> go
             QuitProcess -> pure ReplQuitInterrupt
+
+-- | Ask the terminal to wrap pastes in CSI 200~ … CSI 201~ so we can
+-- distinguish them from typed keystrokes. Restored on exit.
+withBracketedPaste :: IO a -> IO a
+withBracketedPaste action = do
+    isTty <- hIsTerminalDevice stdin
+    if not isTty
+        then action
+        else bracket enable disable (const action)
+  where
+    enable = do
+        Text.hPutStr stdout "\ESC[?2004h"
+        hFlush stdout
+    disable _ = do
+        Text.hPutStr stdout "\ESC[?2004l"
+        hFlush stdout
 
 -- | Tab-complete slash command names and a few known argument tokens.
 completeSlash :: CompletionFunc IO

--- a/packages/agent-cli/src/Agent/CLI/Plan.hs
+++ b/packages/agent-cli/src/Agent/CLI/Plan.hs
@@ -106,6 +106,8 @@ readChangeNotes interrupt color = do
     readReplLine interrupt chrome >>= \case
         ReplEof -> pure "(no notes)"
         ReplQuitInterrupt -> throwIO UserInterrupt
+        ReplPasted text ->
+            if Text.null (Text.strip text) then pure "(no notes)" else pure (Text.strip text)
         ReplText text
             | Text.null (Text.strip text) -> pure "(no notes)"
             | otherwise -> pure (Text.strip text)
@@ -127,6 +129,10 @@ askQuestion interrupt resolveColor question options = do
                 readReplLine interrupt chrome >>= \case
                     ReplEof -> pure Nothing
                     ReplQuitInterrupt -> throwIO UserInterrupt
+                    ReplPasted text ->
+                        if Text.null (Text.strip text)
+                            then pure Nothing
+                            else pure (Just (Text.strip text))
                     ReplText text
                         | Text.null (Text.strip text) -> pure Nothing
                         | otherwise -> pure (Just (Text.strip text))

--- a/packages/agent-cli/test/Agent/CLI/InputSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/InputSpec.hs
@@ -4,9 +4,12 @@ import Agent.CLI.Input
     ( ChoiceKey(..)
     , approvalKeyText
     , choiceMoveIndex
+    , classifyPastedText
+    , formatPasteChip
     , parseChoiceKey
     , replHistoryPath
     )
+import qualified Data.Text as Text
 import System.FilePath ((</>))
 import Test.Hspec
 
@@ -49,3 +52,20 @@ spec = do
             choiceMoveIndex 3 1 ChoiceUp `shouldBe` 0
             choiceMoveIndex 3 1 ChoiceDown `shouldBe` 2
             choiceMoveIndex 3 1 ChoiceEnter `shouldBe` 1
+
+    describe "classifyPastedText" do
+        it "detects bracketed-paste CSI wrappers" do
+            let payload = "hello from clipboard"
+                wrapped = "\ESC[200~" <> payload <> "\ESC[201~"
+            classifyPastedText wrapped `shouldBe` (payload, True)
+            classifyPastedText payload `shouldBe` (payload, False)
+
+        it "treats a 4-line burst as a paste" do
+            let burst = Text.unlines ["one", "two", "three", "four"]
+            classifyPastedText burst `shouldBe` (burst, True)
+
+    describe "formatPasteChip" do
+        it "keeps short pastes inline and chips long ones" do
+            formatPasteChip "one line" `shouldBe` "one line"
+            formatPasteChip (Text.unlines ["a", "b", "c", "d"])
+                `shouldBe` "[Pasted: 4 lines]"


### PR DESCRIPTION
## Summary
- Enable terminal bracketed paste (`CSI ?2004h`) around the haskeline prompt.
- Classify a submitted line as pasted when it contains `CSI 200~` / `CSI 201~`, or when it has 4+ lines.
- Strip those wrappers before parsing; long pastes print `[Pasted: N lines]` (full text still goes to the model).
- Plan-mode note/answer prompts accept pasted text the same way.

Haskeline has no paste callback, so this is post-read classification plus enabling the terminal mode.

## Test plan
- [x] `cabal test agent-cli:agent-cli-test` (211 examples, 0 failures)
- [ ] In a TTY REPL, paste a 4+ line block and confirm the chip appears
- [ ] Paste a short line and confirm it stays inline
- [ ] Confirm the model still receives the full pasted text