### PR TITLE
feat: show session token usage on the REPL status line

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -4,6 +4,7 @@ module Agent.CLI
     , afterDev
     , devMain
     , formatReplStatusLine
+    , formatTokenUsage
     , run
     ) where
 
@@ -411,6 +412,9 @@ runAgent options = do
         agentsContext <- loadAgentsContext options provider home cwd initialItems initialPrevious
 
         persist <- preparePersistence options root provider model cwd effort prompt resumed
+        usageRef <- newIORef $ case resumed of
+            Just (meta, turns) -> sessionUsageFromTurns meta turns
+            Nothing -> emptyTokenUsage
         case persist of
             Just slotRef -> do
                 slot <- readIORef slotRef
@@ -450,7 +454,7 @@ runAgent options = do
                                         withPendingNotices pendingNotices lockedBackend
                                 runSession options provider policy tools toolEnv planMode prompt paramsRef transcriptRef
                                     initialPrevious persist projectRoot home cwd (Just loaded.loadedTokenProvider) agentsContext escPaused interrupt
-                                    multiCtx subagentSessions pendingNotices subagentStoreRoot noticingBackend)
+                                    multiCtx subagentSessions pendingNotices subagentStoreRoot usageRef noticingBackend)
                             >>= \case
                                 Left (CodexAuthFailed err) -> die ("openai auth: " <> show err)
                                 Right result -> pure result
@@ -479,7 +483,7 @@ runAgent options = do
                                         (readIORef paramsRef) transcriptRef
                         runSession options provider policy tools toolEnv planMode prompt paramsRef transcriptRef
                             initialPrevious persist projectRoot home cwd (Just loaded.loadedTokenProvider) agentsContext escPaused interrupt
-                            multiCtx subagentSessions pendingNotices subagentStoreRoot backend
+                            multiCtx subagentSessions pendingNotices subagentStoreRoot usageRef backend
                     OpenRouterProvider -> do
                         openRouterOptions <- OpenRouter.clientOptionsFromEnv
                         case multiCtx of
@@ -505,7 +509,7 @@ runAgent options = do
                                         (readIORef paramsRef) transcriptRef
                         runSession options provider policy tools toolEnv planMode prompt paramsRef transcriptRef
                             initialPrevious persist projectRoot home cwd (Just loaded.loadedTokenProvider) agentsContext escPaused interrupt
-                            multiCtx subagentSessions pendingNotices subagentStoreRoot backend
+                            multiCtx subagentSessions pendingNotices subagentStoreRoot usageRef backend
 
 preparePersistence
     :: CliOptions
@@ -583,21 +587,69 @@ printResumeHint progName = \case
                 putTextLn stderr
                     (roleMuted color (resumeHint progName handle.sessionMeta.metaId))
 
--- | Idle prompt chrome: model, reasoning effort, approval mode.
-formatReplStatusLine :: Bool -> Text -> Text -> ApprovalPolicy -> Text
-formatReplStatusLine color model effort policy =
-    roleMuted color $
-        "  "
-            <> model
-            <> " · "
-            <> effort
-            <> " · "
-            <> approvalLabel policy
+-- | Idle prompt chrome: model, reasoning effort, approval mode on the left;
+-- session token totals right-aligned when the TTY width is known.
+formatReplStatusLine
+    :: Bool
+    -> Maybe Int
+    -> Text
+    -> Text
+    -> ApprovalPolicy
+    -> TokenUsage
+    -> Text
+formatReplStatusLine color width model effort policy usage =
+    let left = "  " <> model <> " · " <> effort <> " · " <> approvalLabel policy
+        right = formatTokenUsage usage
+        padded = case width of
+            Just cols | cols > 0, not (Text.null right) ->
+                let gap = cols - Text.length left - Text.length right
+                in if gap > 0
+                    then left <> Text.replicate gap " " <> right
+                    else left <> "  " <> right
+            _ | Text.null right -> left
+            _ -> left <> "  " <> right
+    in roleMuted color padded
   where
     approvalLabel = \case
         ApproveAll -> "yolo"
         PromptMutating -> "ask"
         DenyMutating -> "deny"
+
+-- | Compact session totals: @1.2k in · 340 out@. Cached tokens are shown
+-- only when the provider reported a non-zero cache hit.
+formatTokenUsage :: TokenUsage -> Text
+formatTokenUsage usage
+    | usage == emptyTokenUsage = ""
+    | otherwise =
+        formatTokenCount usage.inputTokens
+            <> " in · "
+            <> formatTokenCount usage.outputTokens
+            <> " out"
+            <> cachedSuffix
+  where
+    cachedSuffix
+        | usage.cachedTokens > 0 =
+            " · " <> formatTokenCount usage.cachedTokens <> " cached"
+        | otherwise = ""
+
+formatTokenCount :: Int -> Text
+formatTokenCount n
+    | n < 0 = "0"
+    | n < 1000 = Text.pack (show n)
+    | n < 10000 =
+        let tenths = (n + 50) `div` 100
+            whole = tenths `div` 10
+            frac = tenths `mod` 10
+        in Text.pack (show whole <> "." <> show frac <> "k")
+    | n < 1000000 =
+        Text.pack (show ((n + 500) `div` 1000) <> "k")
+    | n < 10000000 =
+        let tenths = (n + 50000) `div` 100000
+            whole = tenths `div` 10
+            frac = tenths `mod` 10
+        in Text.pack (show whole <> "." <> show frac <> "M")
+    | otherwise =
+        Text.pack (show ((n + 500000) `div` 1000000) <> "M")
 
 shouldPersist :: CliOptions -> Bool
 shouldPersist options = not (isOneShot options) || options.optSaveSession
@@ -631,9 +683,10 @@ runSession
     -> IORef (Map SubagentId SubagentSession)
     -> IORef [Text]
     -> SubagentStoreRoot
+    -> IORef TokenUsage
     -> Backend
     -> IO DevResult
-runSession options provider policy tools toolEnv planMode prompt paramsRef transcriptRef initialPrevious persist projectRoot home cwd tokenProvider agentsContext escPaused interrupt multiCtx subagentSessions pendingNotices storeRoot backend = do
+runSession options provider policy tools toolEnv planMode prompt paramsRef transcriptRef initialPrevious persist projectRoot home cwd tokenProvider agentsContext escPaused interrupt multiCtx subagentSessions pendingNotices storeRoot usageRef backend = do
     printed <- newIORef False
     attachmentsRef <- newIORef []
     previewIdRef <- newIORef (1 :: Int)
@@ -649,6 +702,7 @@ runSession options provider policy tools toolEnv planMode prompt paramsRef trans
     previous <- newIORef initialPrevious
     let sessionReset = do
             resetLiveConversation previous transcriptRef attachmentsRef planMode
+            writeIORef usageRef emptyTokenUsage
             writeIORef pendingNotices []
             writeIORef subagentSessions Map.empty
             case multiCtx of
@@ -699,14 +753,14 @@ runSession options provider policy tools toolEnv planMode prompt paramsRef trans
     case prompt of
         Just text -> do
             ok <- runOneTurn config render previous printed transcriptRef persist
-                planMode agentsContext escPaused interrupt storeRoot text [UserMessage text]
+                planMode agentsContext escPaused interrupt storeRoot usageRef text [UserMessage text]
             if ok
                 then putTrailingNewline printed >> pure DevQuit
                 else exitFailure
         Nothing ->
             repl config render provider previous printed paramsRef policyRef
                 transcriptRef persist planMode projectRoot tokenProvider agentsContext
-                escPaused attachmentsRef previewIdRef interrupt storeRoot sessionReset
+                escPaused attachmentsRef previewIdRef interrupt storeRoot usageRef sessionReset
 
 repl
     :: LoopConfig
@@ -727,9 +781,10 @@ repl
     -> IORef Int
     -> InterruptState
     -> SubagentStoreRoot
+    -> IORef TokenUsage
     -> IO ()
     -> IO DevResult
-repl config render provider previous printed paramsRef policyRef transcriptRef persist planMode projectRoot tokenProvider agentsContext escPaused attachmentsRef previewIdRef interrupt storeRoot sessionReset = do
+repl config render provider previous printed paramsRef policyRef transcriptRef persist planMode projectRoot tokenProvider agentsContext escPaused attachmentsRef previewIdRef interrupt storeRoot usageRef sessionReset = do
     stdoutColor <- resolveColor stdout
     planActive <- isPlanModeActive planMode
     planPending <- (== PlanPending) <$> readIORef planMode.planStateRef
@@ -737,10 +792,14 @@ repl config render provider previous printed paramsRef policyRef transcriptRef p
     policy <- readIORef policyRef
     -- Status sits on the line above λ so haskeline can keep the cursor on
     -- the input. Haskeline cannot park a persistent footer under the draft.
-    Text.putStrLn $ formatReplStatusLine stdoutColor
+    -- Token totals sit on the right of that line when the TTY width is known.
+    termCols <- fmap snd <$> getTerminalSize
+    usage <- readIORef usageRef
+    Text.putStrLn $ formatReplStatusLine stdoutColor termCols
         (currentModel params)
         (currentEffort params)
         policy
+        usage
     hFlush stdout
     -- Solarized user wash under the prompt; haskeline redraws it on edit.
     -- Cmd+Delete / Ctrl+U kill-to-start via haskeline Emacs bindings.
@@ -797,7 +856,7 @@ repl config render provider previous printed paramsRef policyRef transcriptRef p
                                                     }
                                                 ]
                                 _ <- runOneTurn config render previous printed
-                                    transcriptRef persist planMode agentsContext escPaused interrupt storeRoot text
+                                    transcriptRef persist planMode agentsContext escPaused interrupt storeRoot usageRef text
                                     turnInputs
                                 putTrailingNewline printed
                                 continue
@@ -843,7 +902,7 @@ repl config render provider previous printed paramsRef policyRef transcriptRef p
                                             (roleMuted color (glyphOk <> "pasted " <> sizes))
                                         writeIORef printed False
                                         _ <- runOneTurn config render previous printed
-                                            transcriptRef persist planMode agentsContext escPaused interrupt storeRoot promptText
+                                            transcriptRef persist planMode agentsContext escPaused interrupt storeRoot usageRef promptText
                                             [ UserMultimodal
                                                 { userText = promptText
                                                 , userImages = images
@@ -950,6 +1009,7 @@ repl config render provider previous printed paramsRef policyRef transcriptRef p
                                                 , turnAssistantText = Just outcome.compactSummary
                                                 , turnResponseId = Nothing
                                                 , turnItems = outcome.compactHistory
+                                                , turnUsage = Nothing
                                                 }
                                         handle' <- appendTurn handle turn
                                         writeIORef slotRef (Right handle')
@@ -961,7 +1021,7 @@ repl config render provider previous printed paramsRef policyRef transcriptRef p
                                 continue
                     ReplPlan maybeDescription -> do
                         enterPlanFromSlash planMode persist maybeDescription
-                            config render previous printed transcriptRef agentsContext escPaused interrupt
+                            config render previous printed transcriptRef agentsContext escPaused interrupt usageRef
                         continue
                     ReplResume maybeId -> do
                         handleResume maybeId persist
@@ -988,11 +1048,15 @@ repl config render provider previous printed paramsRef policyRef transcriptRef p
                                                     Just "Conversation cleared."
                                                 , turnResponseId = Nothing
                                                 , turnItems = []
+                                                , turnUsage = Nothing
                                                 }
                                         handle' <- appendTurnKeepTitle handle turn
                                         let meta = handle'.sessionMeta
                                                 { metaLastResponseId = Nothing
                                                 , metaUpdatedAt = now
+                                                , metaInputTokens = 0
+                                                , metaOutputTokens = 0
+                                                , metaCachedTokens = 0
                                                 }
                                         writeSessionMeta handle'.sessionMetaPath meta
                                         writeIORef slotRef
@@ -1046,6 +1110,7 @@ repl config render provider previous printed paramsRef policyRef transcriptRef p
                                             Just "Started a new session."
                                         , turnResponseId = Nothing
                                         , turnItems = []
+                                        , turnUsage = Nothing
                                         }
                                 handle' <- appendTurnKeepTitle handle turn
                                 let meta = handle'.sessionMeta
@@ -1098,7 +1163,7 @@ repl config render provider previous printed paramsRef policyRef transcriptRef p
     continue =
         repl config render provider previous printed paramsRef policyRef
             transcriptRef persist planMode projectRoot tokenProvider agentsContext
-            escPaused attachmentsRef previewIdRef interrupt storeRoot sessionReset
+            escPaused attachmentsRef previewIdRef interrupt storeRoot usageRef sessionReset
 
 applyModelChange
     :: Provider
@@ -1203,9 +1268,10 @@ enterPlanFromSlash
     -> IORef (Maybe Text)
     -> IORef Bool
     -> InterruptState
+    -> IORef TokenUsage
     -> IO ()
 enterPlanFromSlash planMode persist maybeDescription config render previous printed
-    transcriptRef agentsContext escPaused interrupt = do
+    transcriptRef agentsContext escPaused interrupt usageRef = do
     discardStore <- newIORef Nothing
     color <- resolveColor stderr
     case persist of
@@ -1230,7 +1296,7 @@ enterPlanFromSlash planMode persist maybeDescription config render previous prin
                 (roleMuted color (glyphSession <> "plan mode on (" <> Text.pack path <> ")"))
             writeIORef printed False
             _ <- runOneTurn config render previous printed transcriptRef persist
-                planMode agentsContext escPaused interrupt discardStore description [UserMessage description]
+                planMode agentsContext escPaused interrupt discardStore usageRef description [UserMessage description]
             putTrailingNewline printed
 
 runOneTurn
@@ -1245,10 +1311,11 @@ runOneTurn
     -> IORef Bool
     -> InterruptState
     -> SubagentStoreRoot
+    -> IORef TokenUsage
     -> Text
     -> [TurnInput]
     -> IO Bool
-runOneTurn config render previous printed transcriptRef persist planMode agentsContext escPaused interrupt storeRoot promptText inputs =
+runOneTurn config render previous printed transcriptRef persist planMode agentsContext escPaused interrupt storeRoot usageRef promptText inputs =
   withTurnCancel interrupt config.loopCancel $
   withEscCancel config.loopCancel escPaused do
     pending <- readIORef planMode.planStateRef
@@ -1309,14 +1376,19 @@ runOneTurn config render previous printed transcriptRef persist planMode agentsC
             pure False
         Right loopResult -> do
             writeIORef previous (Just loopResult.finalResponseId)
+            modifyIORef' usageRef (`addTokenUsage` loopResult.tokenUsage)
             do
                 color <- resolveColor stderr
                 model <- readIORef render.renderModelRef
                 let turns = Text.pack (show loopResult.turnsUsed)
                     unit = if loopResult.turnsUsed == 1 then " turn" else " turns"
+                    usageDetail = formatTokenUsage loopResult.tokenUsage
+                    extra =
+                        if Text.null usageDetail
+                            then model <> " · " <> turns <> unit
+                            else model <> " · " <> turns <> unit <> " · " <> usageDetail
                 putTextLn stderr
-                    (formatTurnStatus color "ok"
-                        (elapsedDetail (model <> " · " <> turns <> unit)))
+                    (formatTurnStatus color "ok" (elapsedDetail extra))
             followUp <- handleProposedPlan planMode loopResult.finalText
             printedText <- readIORef printed
             let assistantText =
@@ -1341,6 +1413,7 @@ runOneTurn config render previous printed transcriptRef persist planMode agentsC
                             , turnAssistantText = assistantText
                             , turnResponseId = Just loopResult.finalResponseId
                             , turnItems = newItems
+                            , turnUsage = Just loopResult.tokenUsage
                             }
                     handle' <- appendTurn handle turn
                     writeIORef slotRef (Right handle')
@@ -1354,7 +1427,7 @@ runOneTurn config render previous printed transcriptRef persist planMode agentsC
                 Just notes -> do
                     writeIORef printed False
                     _ <- runOneTurn config render previous printed transcriptRef persist
-                        planMode agentsContext escPaused interrupt storeRoot notes [UserMessage notes]
+                        planMode agentsContext escPaused interrupt storeRoot usageRef notes [UserMessage notes]
                     pure True
 
 handleProposedPlan :: PlanModeEnv -> Maybe Text -> IO (Maybe Text)

--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -8,7 +8,6 @@ module Agent.CLI
     , run
     ) where
 
-import Agent.CLI.Accounts (runAccountsList, runAccountsRemove, runLogin)
 import Agent.CLI.Auth (LoadedAuth(..), loadAuth)
 import Agent.CLI.CancelWatch (withEscCancel, withStdinPaused)
 import Agent.CLI.Clipboard
@@ -235,9 +234,6 @@ devMain = do
         Right ShowVersion -> putStrLn "agent-cli 0.1.0.0" >> pure DevQuit
         Right ListSessions -> runListSessions >> pure DevQuit
         Right (ShowSession sessionId) -> runShowSession sessionId >> pure DevQuit
-        Right (LoginAccount provider label) -> runLogin provider label >> pure DevQuit
-        Right ListAccounts -> runAccountsList >> pure DevQuit
-        Right (RemoveAccount accountId) -> runAccountsRemove accountId >> pure DevQuit
         Right (RunAgent options) -> do
             result <- runAgent options
             case result of
@@ -253,9 +249,6 @@ run = do
         Right ShowVersion -> putStrLn "agent-cli 0.1.0.0"
         Right ListSessions -> runListSessions
         Right (ShowSession sessionId) -> runShowSession sessionId
-        Right (LoginAccount provider label) -> runLogin provider label
-        Right ListAccounts -> runAccountsList
-        Right (RemoveAccount accountId) -> runAccountsRemove accountId
         Right (RunAgent options) -> do
             result <- runAgent options
             case result of

--- a/packages/agent-cli/src/Agent/CLI/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session.hs
@@ -18,14 +18,15 @@ module Agent.CLI.Session
     , readDevResumePointer
     , clearDevResumePointer
     , resumeHint
-
+    , sessionUsageFromTurns
     ) where
 
+import Agent.Loop (TokenUsage(..))
 import Agent.OpenAI.Responses.Types (ResponseItem)
 import Agent.Provider (Provider(..), parseProvider, providerSlug)
 import Control.Applicative ((<|>))
 import Control.Exception (try)
-import Data.Aeson (FromJSON(..), ToJSON(..), object, withObject, (.:), (.:?), (.=))
+import Data.Aeson (FromJSON(..), ToJSON(..), object, withObject, (.:), (.:?), (.!=), (.=))
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy as LBS
 import Data.IORef
@@ -98,6 +99,9 @@ data SessionMeta = SessionMeta
     , metaEffort :: !Text
     , metaTitle :: !Text
     , metaLastResponseId :: !(Maybe Text)
+    , metaInputTokens :: !Int
+    , metaOutputTokens :: !Int
+    , metaCachedTokens :: !Int
     } deriving (Eq, Show)
 
 instance ToJSON SessionMeta where
@@ -112,6 +116,9 @@ instance ToJSON SessionMeta where
         , "effort" .= meta.metaEffort
         , "title" .= meta.metaTitle
         , "lastResponseId" .= meta.metaLastResponseId
+        , "inputTokens" .= meta.metaInputTokens
+        , "outputTokens" .= meta.metaOutputTokens
+        , "cachedTokens" .= meta.metaCachedTokens
         ]
 
 instance FromJSON SessionMeta where
@@ -131,6 +138,9 @@ instance FromJSON SessionMeta where
             <*> o .: "effort"
             <*> o .: "title"
             <*> o .:? "lastResponseId"
+            <*> (o .:? "inputTokens" .!= 0)
+            <*> (o .:? "outputTokens" .!= 0)
+            <*> (o .:? "cachedTokens" .!= 0)
 
 data SessionTurn = SessionTurn
     { turnAt :: !UTCTime
@@ -138,6 +148,7 @@ data SessionTurn = SessionTurn
     , turnAssistantText :: !(Maybe Text)
     , turnResponseId :: !(Maybe Text)
     , turnItems :: ![ResponseItem]
+    , turnUsage :: !(Maybe TokenUsage)
     } deriving (Eq, Show)
 
 instance ToJSON SessionTurn where
@@ -147,6 +158,7 @@ instance ToJSON SessionTurn where
         , "assistantText" .= turn.turnAssistantText
         , "responseId" .= turn.turnResponseId
         , "items" .= turn.turnItems
+        , "usage" .= turn.turnUsage
         ]
 
 instance FromJSON SessionTurn where
@@ -157,6 +169,7 @@ instance FromJSON SessionTurn where
             <*> o .:? "assistantText"
             <*> o .:? "responseId"
             <*> o .: "items"
+            <*> o .:? "usage"
 
 data SessionHandle = SessionHandle
     { sessionDir :: !FilePath
@@ -194,6 +207,9 @@ createSession spec = do
             , metaEffort = spec.createEffort
             , metaTitle = title
             , metaLastResponseId = Nothing
+            , metaInputTokens = 0
+            , metaOutputTokens = 0
+            , metaCachedTokens = 0
             }
         handle = SessionHandle
             { sessionDir = dir
@@ -230,6 +246,12 @@ appendTurn handle turn = do
                 if meta0.metaTitle == "untitled" && not (Text.null turn.turnUserText)
                     then sessionTitleFromPrompt turn.turnUserText
                     else meta0.metaTitle
+            , metaInputTokens =
+                meta0.metaInputTokens + maybe 0 (.inputTokens) turn.turnUsage
+            , metaOutputTokens =
+                meta0.metaOutputTokens + maybe 0 (.outputTokens) turn.turnUsage
+            , metaCachedTokens =
+                meta0.metaCachedTokens + maybe 0 (.cachedTokens) turn.turnUsage
             }
     writeSessionMeta handle.sessionMetaPath meta
     pure handle { sessionMeta = meta }
@@ -300,6 +322,18 @@ sessionTitleFromPrompt prompt =
     in if Text.length oneLine <= 72
         then oneLine
         else Text.take 69 oneLine <> "..."
+
+sessionUsageFromMeta :: SessionMeta -> TokenUsage
+sessionUsageFromMeta meta = TokenUsage
+    { inputTokens = meta.metaInputTokens
+    , outputTokens = meta.metaOutputTokens
+    , cachedTokens = meta.metaCachedTokens
+    }
+
+-- | Session totals come from meta. Older sessions without those fields
+-- decode as zero and start accumulating from new turns.
+sessionUsageFromTurns :: SessionMeta -> [SessionTurn] -> TokenUsage
+sessionUsageFromTurns meta _turns = sessionUsageFromMeta meta
 
 -- | Copy-pasteable resume line printed on Ctrl-C, matching grok build.
 resumeHint :: String -> Text -> Text

--- a/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
@@ -130,6 +130,7 @@ spec = do
                     { responseId = "r1"
                     , toolCalls = []
                     , assistantText = Nothing
+                    , tokenUsage = emptyTokenUsage
                     })
                 hClose handle
                 body <- Text.readFile path
@@ -160,6 +161,7 @@ spec = do
                     { responseId = "r1"
                     , toolCalls = []
                     , assistantText = Nothing
+                    , tokenUsage = emptyTokenUsage
                     })
                 hClose handle
                 body <- Text.readFile path

--- a/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
@@ -1,7 +1,7 @@
 module Agent.CLI.RenderSpec (spec) where
 
 import Agent.CLI.Render
-import Agent.Loop (LoopError(..), LoopEvent(..), TurnOutput(..))
+import Agent.Loop (LoopError(..), LoopEvent(..), TurnOutput(..), emptyTokenUsage)
 import Agent.ToolDispatch
     ( ToolCallKind(..)
     , ToolCallResult(..)
@@ -80,6 +80,7 @@ spec = do
                 { responseId = "r"
                 , toolCalls = []
                 , assistantText = Just "almost"
+                , tokenUsage = emptyTokenUsage
                 })
                 `shouldSatisfy` (/= "")
 
@@ -142,6 +143,7 @@ spec = do
                     { responseId = "r1"
                     , toolCalls = []
                     , assistantText = Nothing
+                    , tokenUsage = emptyTokenUsage
                     })
                 hClose handle
                 body <- Text.readFile path
@@ -173,6 +175,7 @@ spec = do
                     { responseId = "r1"
                     , toolCalls = [call]
                     , assistantText = Nothing
+                    , tokenUsage = emptyTokenUsage
                     })
                 hClose handle
                 body <- Text.readFile path
@@ -186,6 +189,7 @@ spec = do
                     { responseId = "r1"
                     , toolCalls = []
                     , assistantText = Just "see `file.txt`"
+                    , tokenUsage = emptyTokenUsage
                     })
                 hClose handle
                 body <- Text.readFile path

--- a/packages/agent-cli/test/Agent/CLI/ReplStatusSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ReplStatusSpec.hs
@@ -1,15 +1,57 @@
 module Agent.CLI.ReplStatusSpec (spec) where
 
-import Agent.CLI (formatReplStatusLine)
+import Agent.CLI (formatReplStatusLine, formatTokenUsage)
 import Agent.CLI.Options (ApprovalPolicy(..))
+import Agent.Loop (TokenUsage(..), emptyTokenUsage)
 import Test.Hspec
 
 spec :: Spec
-spec = describe "formatReplStatusLine" do
-    it "shows model, effort, and approval mode" do
-        formatReplStatusLine False "grok-4.6" "high" PromptMutating
-            `shouldBe` "  grok-4.6 · high · ask"
-        formatReplStatusLine False "gpt-5.1-codex" "medium" ApproveAll
-            `shouldBe` "  gpt-5.1-codex · medium · yolo"
-        formatReplStatusLine False "gpt-5.1" "low" DenyMutating
-            `shouldBe` "  gpt-5.1 · low · deny"
+spec = do
+    describe "formatReplStatusLine" do
+        it "shows model, effort, and approval mode" do
+            formatReplStatusLine False Nothing "grok-4.6" "high" PromptMutating emptyTokenUsage
+                `shouldBe` "  grok-4.6 · high · ask"
+            formatReplStatusLine False Nothing "gpt-5.1-codex" "medium" ApproveAll emptyTokenUsage
+                `shouldBe` "  gpt-5.1-codex · medium · yolo"
+            formatReplStatusLine False Nothing "gpt-5.1" "low" DenyMutating emptyTokenUsage
+                `shouldBe` "  gpt-5.1 · low · deny"
+
+        it "appends session usage when no width is known" do
+            formatReplStatusLine False Nothing "grok-4.6" "high" PromptMutating
+                TokenUsage { inputTokens = 1200, outputTokens = 340, cachedTokens = 0 }
+                `shouldBe` "  grok-4.6 · high · ask  1.2k in · 340 out"
+
+        it "right-aligns session usage when the TTY is wide enough" do
+            formatReplStatusLine False (Just 48) "grok-4.6" "high" PromptMutating
+                TokenUsage { inputTokens = 1200, outputTokens = 340, cachedTokens = 0 }
+                `shouldBe` "  grok-4.6 · high · ask        1.2k in · 340 out"
+
+        it "keeps a two-space gap when the line would overflow" do
+            formatReplStatusLine False (Just 20) "grok-4.6" "high" PromptMutating
+                TokenUsage { inputTokens = 1200, outputTokens = 340, cachedTokens = 0 }
+                `shouldBe` "  grok-4.6 · high · ask  1.2k in · 340 out"
+
+    describe "formatTokenUsage" do
+        it "omits empty totals" do
+            formatTokenUsage emptyTokenUsage `shouldBe` ""
+
+        it "formats compact in/out counts" do
+            formatTokenUsage TokenUsage
+                { inputTokens = 42
+                , outputTokens = 7
+                , cachedTokens = 0
+                } `shouldBe` "42 in · 7 out"
+
+        it "includes cached tokens when present" do
+            formatTokenUsage TokenUsage
+                { inputTokens = 1500
+                , outputTokens = 80
+                , cachedTokens = 1200
+                } `shouldBe` "1.5k in · 80 out · 1.2k cached"
+
+        it "uses k/M suffixes" do
+            formatTokenUsage TokenUsage
+                { inputTokens = 12500
+                , outputTokens = 1500000
+                , cachedTokens = 0
+                } `shouldBe` "13k in · 1.5M out"

--- a/packages/agent-cli/test/Agent/CLI/ResumeSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ResumeSpec.hs
@@ -71,4 +71,7 @@ sampleMeta sid title =
         , metaEffort = "high"
         , metaTitle = title
         , metaLastResponseId = Nothing
+        , metaInputTokens = 0
+        , metaOutputTokens = 0
+        , metaCachedTokens = 0
         }

--- a/packages/agent-cli/test/Agent/CLI/SessionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SessionSpec.hs
@@ -1,6 +1,7 @@
 module Agent.CLI.SessionSpec (spec) where
 
 import Agent.CLI.Session
+import Agent.Loop (TokenUsage(..))
 import Agent.OpenAI.Responses.Types
 import Agent.Provider (Provider(..))
 import Control.Exception (bracket)
@@ -83,10 +84,18 @@ spec = describe "Agent.CLI.Session" do
                         , turnAssistantText = Just "hello"
                         , turnResponseId = Just "resp-1"
                         , turnItems = [item]
+                        , turnUsage = Just TokenUsage
+                            { inputTokens = 10
+                            , outputTokens = 4
+                            , cachedTokens = 2
+                            }
                         }
                 handle' <- appendTurn handle turn
                 handle'.sessionMeta.metaTitle `shouldBe` "hi there"
                 handle'.sessionMeta.metaLastResponseId `shouldBe` Just "resp-1"
+                handle'.sessionMeta.metaInputTokens `shouldBe` 10
+                handle'.sessionMeta.metaOutputTokens `shouldBe` 4
+                handle'.sessionMeta.metaCachedTokens `shouldBe` 2
                 modeOf handle.sessionTranscriptPath `shouldReturn` 0o600
 
                 loaded <- loadSession root handle.sessionMeta.metaId
@@ -101,6 +110,16 @@ spec = describe "Agent.CLI.Session" do
                             [loadedTurn] -> do
                                 loadedTurn.turnUserText `shouldBe` "hi there"
                                 loadedTurn.turnItems `shouldBe` [item]
+                                loadedTurn.turnUsage `shouldBe` Just TokenUsage
+                                    { inputTokens = 10
+                                    , outputTokens = 4
+                                    , cachedTokens = 2
+                                    }
+                                sessionUsageFromTurns meta turns `shouldBe` TokenUsage
+                                    { inputTokens = 10
+                                    , outputTokens = 4
+                                    , cachedTokens = 2
+                                    }
                             other ->
                                 expectationFailure
                                     ("expected one turn, got " <> show (length other))
@@ -135,6 +154,7 @@ spec = describe "Agent.CLI.Session" do
                     , turnAssistantText = Nothing
                     , turnResponseId = Nothing
                     , turnItems = []
+                    , turnUsage = Nothing
                     }
             Aeson.eitherDecode (Aeson.encode turn) `shouldBe` Right turn
 

--- a/packages/agent-core/src/Agent/Loop.hs
+++ b/packages/agent-core/src/Agent/Loop.hs
@@ -10,10 +10,14 @@ module Agent.Loop
     , LoopEvent(..)
     , LoopError(..)
     , LoopResult(..)
+    , TokenUsage(..)
     , TurnInput(..)
     , TurnOutput(..)
+    , addTokenUsage
     , defaultLoopMaxTurns
     , defaultLoopDispatch
+    , emptyTokenUsage
+    , emptyTurnOutput
     , runLoop
     , runLoopInputs
     ) where
@@ -30,6 +34,7 @@ import Agent.ToolDispatch
 import Control.Concurrent.Async (mapConcurrently, race)
 import Control.Concurrent.MVar (newMVar, withMVar)
 import Control.Exception (SomeException)
+import Data.Aeson (FromJSON(..), ToJSON(..), object, withObject, (.:), (.:?), (.!=), (.=))
 import Data.ByteString (ByteString)
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -49,11 +54,57 @@ data TurnInput
     | CompletedTool ToolCallResult
     deriving (Eq, Show)
 
+-- | Provider-reported token counts for one model response. @inputTokens@
+-- typically includes any cached prefix; @cachedTokens@ is that subset when
+-- the provider reports it.
+data TokenUsage = TokenUsage
+    { inputTokens :: !Int
+    , outputTokens :: !Int
+    , cachedTokens :: !Int
+    } deriving (Eq, Show)
+
+emptyTokenUsage :: TokenUsage
+emptyTokenUsage = TokenUsage
+    { inputTokens = 0
+    , outputTokens = 0
+    , cachedTokens = 0
+    }
+
+instance ToJSON TokenUsage where
+    toJSON usage = object
+        [ "input" .= usage.inputTokens
+        , "output" .= usage.outputTokens
+        , "cached" .= usage.cachedTokens
+        ]
+
+instance FromJSON TokenUsage where
+    parseJSON = withObject "TokenUsage" \o ->
+        TokenUsage
+            <$> o .: "input"
+            <*> o .: "output"
+            <*> (o .:? "cached" .!= 0)
+
+addTokenUsage :: TokenUsage -> TokenUsage -> TokenUsage
+addTokenUsage a b = TokenUsage
+    { inputTokens = a.inputTokens + b.inputTokens
+    , outputTokens = a.outputTokens + b.outputTokens
+    , cachedTokens = a.cachedTokens + b.cachedTokens
+    }
+
 data TurnOutput = TurnOutput
     { responseId :: !Text
     , toolCalls :: ![ToolCall]
     , assistantText :: !(Maybe Text)
+    , tokenUsage :: !TokenUsage
     } deriving (Eq, Show)
+
+emptyTurnOutput :: Text -> [ToolCall] -> Maybe Text -> TurnOutput
+emptyTurnOutput responseId toolCalls assistantText = TurnOutput
+    { responseId
+    , toolCalls
+    , assistantText
+    , tokenUsage = emptyTokenUsage
+    }
 
 newtype Backend = Backend
     { submitTurn
@@ -90,6 +141,7 @@ data LoopResult = LoopResult
     { finalResponseId :: !Text
     , finalText :: !(Maybe Text)
     , turnsUsed :: !Int
+    , tokenUsage :: !TokenUsage
     } deriving (Eq, Show)
 
 data LoopError
@@ -141,7 +193,7 @@ runLoopInputs config0 previousResponseId firstInputs = do
             { loopOnEvent = \event ->
                 withMVar eventLock \_ -> config0.loopOnEvent event
             }
-        go prev turnsUsed inputs lastOutput
+        go prev turnsUsed inputs lastOutput usageAcc
             | turnsUsed >= config.loopMaxTurns =
                 pure $ case lastOutput of
                     Just turn -> Left (LoopMaxTurns turn)
@@ -169,6 +221,7 @@ runLoopInputs config0 previousResponseId firstInputs = do
                                     -- A cancel that landed during submitTurn
                                     -- after the race chose Right still counts.
                                     cancelledMid <- isCancelled config.loopCancel
+                                    let usageAcc' = addTokenUsage usageAcc turn.tokenUsage
                                     if cancelledMid
                                         then pure (Left (LoopCancelled []))
                                         else do
@@ -179,6 +232,7 @@ runLoopInputs config0 previousResponseId firstInputs = do
                                                     { finalResponseId = turn.responseId
                                                     , finalText = turn.assistantText
                                                     , turnsUsed = nextTurnsUsed
+                                                    , tokenUsage = usageAcc'
                                                     }
                                                 else do
                                                     results <- mapConcurrently (runOne config) turn.toolCalls
@@ -186,8 +240,8 @@ runLoopInputs config0 previousResponseId firstInputs = do
                                                     if cancelledAfter
                                                         then pure (Left (LoopCancelled results))
                                                         else go (Just turn.responseId) nextTurnsUsed
-                                                            (map CompletedTool results) (Just turn)
-    go previousResponseId 0 firstInputs Nothing
+                                                            (map CompletedTool results) (Just turn) usageAcc'
+    go previousResponseId 0 firstInputs Nothing emptyTokenUsage
 
 runOne :: LoopConfig -> ToolCall -> IO ToolCallResult
 runOne config call = do

--- a/packages/agent-core/test/Agent/LoopSpec.hs
+++ b/packages/agent-core/test/Agent/LoopSpec.hs
@@ -18,16 +18,10 @@ spec = describe "runLoop" do
     it "threads previous_response_id and sends only CompletedTool on the follow-up" do
         submissions <- newIORef []
         backend <- scriptedBackend submissions
-            [ Right TurnOutput
-                { responseId = "resp-1"
-                , toolCalls = [functionToolCall "c1" "echo" "{\"message\":\"hi\"}"]
-                , assistantText = Just "calling echo"
-                }
-            , Right TurnOutput
-                { responseId = "resp-2"
-                , toolCalls = []
-                , assistantText = Just "done"
-                }
+            [ Right $ emptyTurnOutput "resp-1"
+                [functionToolCall "c1" "echo" "{\"message\":\"hi\"}"]
+                (Just "calling echo")
+            , Right $ emptyTurnOutput "resp-2" [] (Just "done")
             ]
         config <- testConfig backend
         result <- runLoop config Nothing "hello"
@@ -35,6 +29,7 @@ spec = describe "runLoop" do
             { finalResponseId = "resp-2"
             , finalText = Just "done"
             , turnsUsed = 2
+            , tokenUsage = emptyTokenUsage
             }
         seen <- readIORef submissions
         seen `shouldBe`
@@ -45,11 +40,7 @@ spec = describe "runLoop" do
     it "accepts multimodal first turns via runLoopInputs" do
         submissions <- newIORef []
         backend <- scriptedBackend submissions
-            [ Right TurnOutput
-                { responseId = "resp-m"
-                , toolCalls = []
-                , assistantText = Just "saw it"
-                }
+            [ Right $ emptyTurnOutput "resp-m" [] (Just "saw it")
             ]
         let image = ImageAttachment "image/png" "abc"
             inputs =
@@ -64,6 +55,7 @@ spec = describe "runLoop" do
             { finalResponseId = "resp-m"
             , finalText = Just "saw it"
             , turnsUsed = 1
+            , tokenUsage = emptyTokenUsage
             }
         seen <- readIORef submissions
         seen `shouldBe` [(Nothing, inputs)]
@@ -73,19 +65,12 @@ spec = describe "runLoop" do
         maxInFlight <- newIORef (0 :: Int)
         submissions <- newIORef []
         backend <- scriptedBackend submissions
-            [ Right TurnOutput
-                { responseId = "resp-1"
-                , toolCalls =
-                    [ functionToolCall "c1" "a" "{}"
-                    , functionToolCall "c2" "b" "{}"
-                    ]
-                , assistantText = Nothing
-                }
-            , Right TurnOutput
-                { responseId = "resp-2"
-                , toolCalls = []
-                , assistantText = Just "ok"
-                }
+            [ Right $ emptyTurnOutput "resp-1"
+                [ functionToolCall "c1" "a" "{}"
+                , functionToolCall "c2" "b" "{}"
+                ]
+                Nothing
+            , Right $ emptyTurnOutput "resp-2" [] (Just "ok")
             ]
         let onEvent _ = do
                 now <- atomicModifyIORef' inFlight \n -> (n + 1, n + 1)
@@ -106,6 +91,7 @@ spec = describe "runLoop" do
             { finalResponseId = "resp-2"
             , finalText = Just "ok"
             , turnsUsed = 2
+            , tokenUsage = emptyTokenUsage
             }
         readIORef maxInFlight `shouldReturn` 1
 
@@ -124,19 +110,12 @@ spec = describe "runLoop" do
                 ]
         submissions <- newIORef []
         backend <- scriptedBackend submissions
-            [ Right TurnOutput
-                { responseId = "resp-1"
-                , toolCalls =
-                    [ functionToolCall "c1" "a" "{}"
-                    , functionToolCall "c2" "b" "{}"
-                    ]
-                , assistantText = Nothing
-                }
-            , Right TurnOutput
-                { responseId = "resp-2"
-                , toolCalls = []
-                , assistantText = Just "ok"
-                }
+            [ Right $ emptyTurnOutput "resp-1"
+                [ functionToolCall "c1" "a" "{}"
+                , functionToolCall "c2" "b" "{}"
+                ]
+                Nothing
+            , Right $ emptyTurnOutput "resp-2" [] (Just "ok")
             ]
         config0 <- testConfig backend
         result <- runLoop config0 { loopHandlers = handlers } Nothing "go"
@@ -144,22 +123,17 @@ spec = describe "runLoop" do
             { finalResponseId = "resp-2"
             , finalText = Just "ok"
             , turnsUsed = 2
+            , tokenUsage = emptyTokenUsage
             }
         readIORef maxInFlight `shouldReturn` 2
 
     it "returns a denial as tool output when approval is refused" do
         submissions <- newIORef []
         backend <- scriptedBackend submissions
-            [ Right TurnOutput
-                { responseId = "resp-1"
-                , toolCalls = [functionToolCall "c1" "echo" "{\"message\":\"nope\"}"]
-                , assistantText = Nothing
-                }
-            , Right TurnOutput
-                { responseId = "resp-2"
-                , toolCalls = []
-                , assistantText = Just "understood"
-                }
+            [ Right $ emptyTurnOutput "resp-1"
+                [functionToolCall "c1" "echo" "{\"message\":\"nope\"}"]
+                Nothing
+            , Right $ emptyTurnOutput "resp-2" [] (Just "understood")
             ]
         config0 <- testConfig backend
         let config = config0 { loopApprove = \_ -> pure (Right False) }
@@ -168,6 +142,7 @@ spec = describe "runLoop" do
             { finalResponseId = "resp-2"
             , finalText = Just "understood"
             , turnsUsed = 2
+            , tokenUsage = emptyTokenUsage
             }
         seen <- readIORef submissions
         case seen of
@@ -189,16 +164,10 @@ spec = describe "runLoop" do
     it "keeps looping after a handler exception" do
         submissions <- newIORef []
         backend <- scriptedBackend submissions
-            [ Right TurnOutput
-                { responseId = "resp-1"
-                , toolCalls = [functionToolCall "c1" "explode" "{}"]
-                , assistantText = Nothing
-                }
-            , Right TurnOutput
-                { responseId = "resp-2"
-                , toolCalls = []
-                , assistantText = Just "survived"
-                }
+            [ Right $ emptyTurnOutput "resp-1"
+                [functionToolCall "c1" "explode" "{}"]
+                Nothing
+            , Right $ emptyTurnOutput "resp-2" [] (Just "survived")
             ]
         let handlers = [noArgsTool "explode" (error "boom")]
         config0 <- testConfig backend
@@ -207,6 +176,7 @@ spec = describe "runLoop" do
             { finalResponseId = "resp-2"
             , finalText = Just "survived"
             , turnsUsed = 2
+            , tokenUsage = emptyTokenUsage
             }
         seen <- readIORef submissions
         case seen of
@@ -226,11 +196,7 @@ spec = describe "runLoop" do
         events <- newIORef []
         submissions <- newIORef []
         backend <- scriptedBackend submissions
-            [ Right TurnOutput
-                { responseId = "resp-1"
-                , toolCalls = []
-                , assistantText = Just "hi"
-                }
+            [ Right $ emptyTurnOutput "resp-1" [] (Just "hi")
             ]
         config0 <- testConfig backend
         let config = config0
@@ -240,27 +206,17 @@ spec = describe "runLoop" do
         seen <- reverse <$> readIORef events
         seen `shouldBe`
             [ TurnStarted
-            , TurnFinished TurnOutput
-                { responseId = "resp-1"
-                , toolCalls = []
-                , assistantText = Just "hi"
-                }
+            , TurnFinished (emptyTurnOutput "resp-1" [] (Just "hi"))
             ]
 
     it "emits ToolStarted and ToolFinished around each dispatched call" do
         events <- newIORef []
         submissions <- newIORef []
         backend <- scriptedBackend submissions
-            [ Right TurnOutput
-                { responseId = "resp-1"
-                , toolCalls = [functionToolCall "c1" "echo" "{\"message\":\"hi\"}"]
-                , assistantText = Nothing
-                }
-            , Right TurnOutput
-                { responseId = "resp-2"
-                , toolCalls = []
-                , assistantText = Just "done"
-                }
+            [ Right $ emptyTurnOutput "resp-1"
+                [functionToolCall "c1" "echo" "{\"message\":\"hi\"}"]
+                Nothing
+            , Right $ emptyTurnOutput "resp-2" [] (Just "done")
             ]
         config0 <- testConfig backend
         let config = config0
@@ -270,30 +226,22 @@ spec = describe "runLoop" do
         seen <- reverse <$> readIORef events
         seen `shouldBe`
             [ TurnStarted
-            , TurnFinished TurnOutput
-                { responseId = "resp-1"
-                , toolCalls = [functionToolCall "c1" "echo" "{\"message\":\"hi\"}"]
-                , assistantText = Nothing
-                }
+            , TurnFinished $ emptyTurnOutput "resp-1"
+                [functionToolCall "c1" "echo" "{\"message\":\"hi\"}"]
+                Nothing
             , ToolStarted (functionToolCall "c1" "echo" "{\"message\":\"hi\"}")
             , ToolFinished (functionResult "c1" "echo:hi")
             , TurnStarted
-            , TurnFinished TurnOutput
-                { responseId = "resp-2"
-                , toolCalls = []
-                , assistantText = Just "done"
-                }
+            , TurnFinished (emptyTurnOutput "resp-2" [] (Just "done"))
             ]
 
 
     it "returns LoopCancelled when the cancel flag is set during tools" do
         submissions <- newIORef []
         backend <- scriptedBackend submissions
-            [ Right TurnOutput
-                { responseId = "resp-1"
-                , toolCalls = [functionToolCall "c1" "slow" "{}"]
-                , assistantText = Nothing
-                }
+            [ Right $ emptyTurnOutput "resp-1"
+                [functionToolCall "c1" "slow" "{}"]
+                Nothing
             ]
         config0 <- testConfig backend
         let cancel = case config0 of
@@ -316,11 +264,7 @@ spec = describe "runLoop" do
         config0 <- testConfig $ Backend \_prev _inputs _onEvent -> do
             putMVar started ()
             threadDelay 2000000
-            pure $ Right TurnOutput
-                { responseId = "resp-slow"
-                , toolCalls = []
-                , assistantText = Just "too late"
-                }
+            pure $ Right (emptyTurnOutput "resp-slow" [] (Just "too late"))
         let cancel = case config0 of
                 LoopConfig{loopCancel = c} -> c
         _ <- forkIO do
@@ -328,6 +272,31 @@ spec = describe "runLoop" do
             requestCancel cancel
         result <- runLoop config0 Nothing "go"
         result `shouldBe` Left (LoopCancelled [])
+
+    it "sums token usage across model steps in one user turn" do
+        submissions <- newIORef []
+        backend <- scriptedBackend submissions
+            [ Right TurnOutput
+                { responseId = "resp-1"
+                , toolCalls = [functionToolCall "c1" "echo" "{\"message\":\"hi\"}"]
+                , assistantText = Just "calling"
+                , tokenUsage = TokenUsage 10 4 2
+                }
+            , Right TurnOutput
+                { responseId = "resp-2"
+                , toolCalls = []
+                , assistantText = Just "done"
+                , tokenUsage = TokenUsage 12 6 0
+                }
+            ]
+        config <- testConfig backend
+        result <- runLoop config Nothing "hello"
+        result `shouldBe` Right LoopResult
+            { finalResponseId = "resp-2"
+            , finalText = Just "done"
+            , turnsUsed = 2
+            , tokenUsage = TokenUsage 22 10 2
+            }
 
 --------------------------------------------------------------------------------
 -- Helpers
@@ -379,8 +348,6 @@ endlessToolsBackend = do
     pure $ Backend \_prev _inputs _onEvent -> do
         n <- atomicModifyIORef' counter \i -> (i + 1, i + 1)
         let responseId = "resp-" <> Text.pack (show n)
-        pure $ Right TurnOutput
-            { responseId
-            , toolCalls = [functionToolCall "c1" "echo" "{\"message\":\"again\"}"]
-            , assistantText = Nothing
-            }
+        pure $ Right $ emptyTurnOutput responseId
+            [functionToolCall "c1" "echo" "{\"message\":\"again\"}"]
+            Nothing

--- a/packages/agent-core/test/Agent/SubagentsSpec.hs
+++ b/packages/agent-core/test/Agent/SubagentsSpec.hs
@@ -1,6 +1,6 @@
 module Agent.SubagentsSpec (spec) where
 
-import Agent.Loop (LoopError(..), LoopResult(..))
+import Agent.Loop (LoopError(..), LoopResult(..), emptyTokenUsage)
 import Agent.Subagents
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.STM
@@ -20,6 +20,7 @@ spec = describe "Agent.Subagents" do
                 { finalResponseId = "child"
                 , finalText = Just ("done:" <> prompt)
                 , turnsUsed = 1
+                , tokenUsage = emptyTokenUsage
                 })
             (\_ _ -> pure ())
         Right agentId <- spawnSubagent registry Nothing 0 "hello" Nothing
@@ -34,6 +35,7 @@ spec = describe "Agent.Subagents" do
                 { finalResponseId = "x"
                 , finalText = Just "ok"
                 , turnsUsed = 1
+                , tokenUsage = emptyTokenUsage
                 })
             (\_ _ -> pure ())
         Right child <- spawnSubagent registry Nothing 0 "one" Nothing
@@ -51,6 +53,7 @@ spec = describe "Agent.Subagents" do
                     { finalResponseId = "x"
                     , finalText = Just "ok"
                     , turnsUsed = 1
+                    , tokenUsage = emptyTokenUsage
                     })
             (\_ _ -> pure ())
         Right first <- spawnSubagent registry Nothing 0 "a" Nothing
@@ -81,12 +84,14 @@ spec = describe "Agent.Subagents" do
                         { finalResponseId = "child"
                         , finalText = Just ("parent-of-" <> gid.unSubagentId)
                         , turnsUsed = 1
+                        , tokenUsage = emptyTokenUsage
                         }
                 else
                     pure $ Right LoopResult
                         { finalResponseId = "grand"
                         , finalText = Just ("leaf:" <> prompt)
                         , turnsUsed = 1
+                        , tokenUsage = emptyTokenUsage
                         }
         Right child <- spawnSubagent registry Nothing 0 "root-task" Nothing
         (statuses, timedOut) <- waitSubagents registry [child] 20000
@@ -104,6 +109,7 @@ spec = describe "Agent.Subagents" do
                     { finalResponseId = "fast"
                     , finalText = Just "done-fast"
                     , turnsUsed = 1
+                    , tokenUsage = emptyTokenUsage
                     }
                 _ -> do
                     atomically $ readTVar gate >>= \ready -> unless ready retry
@@ -111,6 +117,7 @@ spec = describe "Agent.Subagents" do
                         { finalResponseId = "slow"
                         , finalText = Just "done-slow"
                         , turnsUsed = 1
+                        , tokenUsage = emptyTokenUsage
                         })
             (\_ _ -> pure ())
         Right fast <- spawnSubagent registry Nothing 0 "fast" Nothing
@@ -137,6 +144,7 @@ spec = describe "Agent.Subagents" do
                     { finalResponseId = "resp-" <> prompt
                     , finalText = Just prompt
                     , turnsUsed = 1
+                    , tokenUsage = emptyTokenUsage
                     })
             (\_ _ -> pure ())
         Right agentId <- spawnSubagent registry Nothing 0 "one" Nothing
@@ -157,11 +165,13 @@ spec = describe "Agent.Subagents" do
                         { finalResponseId = "hold"
                         , finalText = Just "holding"
                         , turnsUsed = 1
+                        , tokenUsage = emptyTokenUsage
                         }
                 other -> pure $ Right LoopResult
                     { finalResponseId = "done"
                     , finalText = Just other
                     , turnsUsed = 1
+                    , tokenUsage = emptyTokenUsage
                     })
             (\_ _ -> pure ())
         Right idle <- spawnSubagent registry Nothing 0 "idle" Nothing
@@ -190,6 +200,7 @@ spec = describe "Agent.Subagents" do
                 { finalResponseId = "c"
                 , finalText = Just prompt
                 , turnsUsed = 1
+                , tokenUsage = emptyTokenUsage
                 })
             (\_ _ -> pure ())
         setSubagentOnComplete registry \agentId status ->
@@ -207,6 +218,7 @@ spec = describe "Agent.Subagents" do
                 { finalResponseId = fromMaybe "resp" previous
                 , finalText = Just prompt
                 , turnsUsed = 1
+                , tokenUsage = emptyTokenUsage
                 })
             (\_ _ -> pure ())
         let agentId = SubagentId "agent-restored-1"
@@ -226,6 +238,7 @@ spec = describe "Agent.Subagents" do
                 { finalResponseId = "r"
                 , finalText = Just prompt
                 , turnsUsed = 1
+                , tokenUsage = emptyTokenUsage
                 })
             (\_ _ -> pure ())
         Right agentId <- spawnSubagent registry Nothing 0 "first" Nothing

--- a/packages/agent-core/test/Agent/SubagentsSpec.hs
+++ b/packages/agent-core/test/Agent/SubagentsSpec.hs
@@ -259,6 +259,7 @@ spec = describe "Agent.Subagents" do
                 { finalResponseId = "c"
                 , finalText = Just prompt
                 , turnsUsed = 1
+                , tokenUsage = emptyTokenUsage
                 })
             (\_ _ -> pure ())
         Right (agentId, path) <-
@@ -279,6 +280,7 @@ spec = describe "Agent.Subagents" do
                     { finalResponseId = "c"
                     , finalText = Just prompt
                     , turnsUsed = 1
+                    , tokenUsage = emptyTokenUsage
                     })
             (\_ _ -> pure ())
         Right agentId <- spawnSubagent registry Nothing 0 "one" Nothing

--- a/packages/agent-core/test/Agent/Tools/Grok/TaskSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/Grok/TaskSpec.hs
@@ -1,6 +1,6 @@
 module Agent.Tools.Grok.TaskSpec (spec) where
 
-import Agent.Loop (LoopError(..), LoopResult(..), defaultLoopDispatch)
+import Agent.Loop (LoopError(..), LoopResult(..), defaultLoopDispatch, emptyTokenUsage)
 import Agent.Subagents
 import Agent.ToolDispatch
     ( ToolCallResult(..)
@@ -25,6 +25,7 @@ spec = describe "Agent.Tools.Grok.Task" do
                 { finalResponseId = "c"
                 , finalText = Just ("done:" <> prompt)
                 , turnsUsed = 1
+                , tokenUsage = emptyTokenUsage
                 })
             (\_ _ -> pure ())
         typesRef <- newIORef Map.empty

--- a/packages/agent-openai/src/Agent/OpenAI/LoopBackend.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/LoopBackend.hs
@@ -19,8 +19,10 @@ import Agent.Loop
     ( Backend(..)
     , ImageAttachment(..)
     , LoopEvent(..)
+    , TokenUsage(..)
     , TurnInput(..)
     , TurnOutput(..)
+    , emptyTokenUsage
     )
 import Agent.OpenAI.Responses.Types
 import Agent.OpenAI.WebSocketClient
@@ -39,7 +41,7 @@ import qualified Data.Aeson.KeyMap as KeyMap
 import Data.ByteString (ByteString)
 import qualified "base64-bytestring" Data.ByteString.Base64 as Base64
 import Data.IORef
-import Data.Maybe (mapMaybe)
+import Data.Maybe (fromMaybe, mapMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
@@ -172,7 +174,16 @@ responseToTurnOutput response = TurnOutput
     { responseId = response.responseId
     , toolCalls = mapMaybe responseItemToToolCall response.output
     , assistantText = assistantTextFromResponse response
+    , tokenUsage = tokenUsageFromResponse response.usage
     }
+
+tokenUsageFromResponse :: Maybe ResponseUsage -> TokenUsage
+tokenUsageFromResponse = maybe emptyTokenUsage \usage ->
+    TokenUsage
+        { inputTokens = usage.inputTokens
+        , outputTokens = usage.outputTokens
+        , cachedTokens = fromMaybe 0 (usage.inputTokensDetails >>= (.cachedTokens))
+        }
 
 responseItemToToolCall :: ResponseItem -> Maybe ToolCall
 responseItemToToolCall = \case

--- a/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
@@ -76,14 +76,11 @@ spec = do
                     , assistantItem "working"
                     , customCallItem "cc1" "apply_patch" "*** Begin Patch\n*** End Patch"
                     ]
-            turn `shouldBe` TurnOutput
-                { responseId = "resp-9"
-                , toolCalls =
-                    [ functionToolCall "fc1" "shell_command" "{\"command\":\"ls\"}"
-                    , customToolCall "cc1" "apply_patch" "*** Begin Patch\n*** End Patch"
-                    ]
-                , assistantText = Just "working"
-                }
+            turn `shouldBe` emptyTurnOutput "resp-9"
+                [ functionToolCall "fc1" "shell_command" "{\"command\":\"ls\"}"
+                , customToolCall "cc1" "apply_patch" "*** Begin Patch\n*** End Patch"
+                ]
+                (Just "working")
 
         it "joins multiple assistant messages" do
             let turn = responseToTurnOutput $ testResponse "resp-text"
@@ -92,6 +89,23 @@ spec = do
                     , assistantItem "second"
                     ]
             turn.assistantText `shouldBe` Just "first\nsecond"
+
+        it "copies provider usage including cached input tokens" do
+            let turn = responseToTurnOutput $ testResponseWithUsage "resp-u"
+                    [assistantItem "ok"]
+                    (Aeson.object
+                        [ "input_tokens" Aeson..= (120 :: Int)
+                        , "output_tokens" Aeson..= (30 :: Int)
+                        , "total_tokens" Aeson..= (150 :: Int)
+                        , "input_tokens_details" Aeson..= Aeson.object
+                            [ "cached_tokens" Aeson..= (80 :: Int)
+                            ]
+                        ])
+            turn.tokenUsage `shouldBe` TokenUsage
+                { inputTokens = 120
+                , outputTokens = 30
+                , cachedTokens = 80
+                }
 
     describe "streamEventToLoopEvent" do
         it "maps output_text.delta and reasoning deltas" do
@@ -123,11 +137,7 @@ spec = do
             result <- backend.submitTurn (Just "resp-prev")
                 [UserMessage "hello"]
                 (modifyIORef' events . (:))
-            result `shouldBe` Right TurnOutput
-                { responseId = "resp-1"
-                , toolCalls = []
-                , assistantText = Just "ok"
-                }
+            result `shouldBe` Right (emptyTurnOutput "resp-1" [] (Just "ok"))
             [(request, previous)] <- readIORef seen
             previous `shouldBe` Just "resp-prev"
             request.model `shouldBe` Just "gpt-5.6-luna"
@@ -177,11 +187,7 @@ spec = do
             result <- backend.submitTurn (Just "resp-missing")
                 [UserMessage "new"]
                 (const (pure ()))
-            result `shouldBe` Right TurnOutput
-                { responseId = "resp-2"
-                , toolCalls = []
-                , assistantText = Just "ok"
-                }
+            result `shouldBe` Right (emptyTurnOutput "resp-2" [] (Just "ok"))
             requests <- readIORef seen
             map snd requests `shouldBe` [Just "resp-missing", Nothing]
             map (inputItems . fst) requests `shouldBe`
@@ -276,15 +282,23 @@ deltaEvent otherEventType delta = OtherResponseStreamEvent
     }
 
 testResponse :: Text -> [ResponseItem] -> Response
-testResponse responseId output = case Aeson.fromJSON $ Aeson.object
+testResponse responseId output = testResponseWithUsage responseId output Aeson.Null
+
+testResponseWithUsage :: Text -> [ResponseItem] -> Aeson.Value -> Response
+testResponseWithUsage responseId output usage = case Aeson.fromJSON $ Aeson.object $
     [ "id" Aeson..= responseId
     , "created_at" Aeson..= (0 :: Int)
     , "model" Aeson..= ("test-model" :: Text)
     , "status" Aeson..= ("completed" :: Text)
     , "output" Aeson..= output
-    ] of
+    ] <> usageField
+  of
     Aeson.Success response -> response
     Aeson.Error err -> error err
+  where
+    usageField = case usage of
+        Aeson.Null -> []
+        value -> ["usage" Aeson..= value]
 
 itemType :: Aeson.ToJSON a => a -> Text
 itemType value = case Aeson.toJSON value of

--- a/packages/agent-openrouter/test/Agent/OpenRouter/LoopBackendSpec.hs
+++ b/packages/agent-openrouter/test/Agent/OpenRouter/LoopBackendSpec.hs
@@ -28,21 +28,14 @@ spec = do
 
             first <- backend.submitTurn Nothing [UserMessage "read it"]
                 (modifyIORef' events . (:))
-            first `shouldBe` Right TurnOutput
-                { responseId = "resp-1"
-                , toolCalls =
-                    [ functionToolCall "c1" "read_file" "{\"target_file\":\"README.md\"}" ]
-                , assistantText = Nothing
-                }
+            first `shouldBe` Right (emptyTurnOutput "resp-1"
+                [ functionToolCall "c1" "read_file" "{\"target_file\":\"README.md\"}" ]
+                Nothing)
 
             second <- backend.submitTurn (Just "resp-1")
                 [CompletedTool (functionResult "c1" "file contents")]
                 (const (pure ()))
-            second `shouldBe` Right TurnOutput
-                { responseId = "resp-2"
-                , toolCalls = []
-                , assistantText = Just "done"
-                }
+            second `shouldBe` Right (emptyTurnOutput "resp-2" [] (Just "done"))
 
             requests <- readIORef seen
             map inputItems requests `shouldBe`
@@ -74,11 +67,7 @@ spec = do
             failed `shouldBe` Left (ConnectionError "boom")
 
             recovered <- backend.submitTurn Nothing [UserMessage "hi"] (const (pure ()))
-            recovered `shouldBe` Right TurnOutput
-                { responseId = "resp-1"
-                , toolCalls = []
-                , assistantText = Just "hi"
-                }
+            recovered `shouldBe` Right (emptyTurnOutput "resp-1" [] (Just "hi"))
             map inputItems <$> readIORef seen `shouldReturn`
                 [ [userItem "hi"]
                 , [userItem "hi"]

--- a/packages/agent-xai/test/Agent/XAI/LoopBackendSpec.hs
+++ b/packages/agent-xai/test/Agent/XAI/LoopBackendSpec.hs
@@ -28,21 +28,14 @@ spec = do
 
             first <- backend.submitTurn Nothing [UserMessage "read it"]
                 (modifyIORef' events . (:))
-            first `shouldBe` Right TurnOutput
-                { responseId = "resp-1"
-                , toolCalls =
-                    [ functionToolCall "c1" "read_file" "{\"target_file\":\"README.md\"}" ]
-                , assistantText = Nothing
-                }
+            first `shouldBe` Right (emptyTurnOutput "resp-1"
+                [ functionToolCall "c1" "read_file" "{\"target_file\":\"README.md\"}" ]
+                Nothing)
 
             second <- backend.submitTurn (Just "resp-1")
                 [CompletedTool (functionResult "c1" "file contents")]
                 (const (pure ()))
-            second `shouldBe` Right TurnOutput
-                { responseId = "resp-2"
-                , toolCalls = []
-                , assistantText = Just "done"
-                }
+            second `shouldBe` Right (emptyTurnOutput "resp-2" [] (Just "done"))
 
             requests <- readIORef seen
             map inputItems requests `shouldBe`
@@ -74,11 +67,7 @@ spec = do
             failed `shouldBe` Left (ConnectionError "boom")
 
             recovered <- backend.submitTurn Nothing [UserMessage "hi"] (const (pure ()))
-            recovered `shouldBe` Right TurnOutput
-                { responseId = "resp-1"
-                , toolCalls = []
-                , assistantText = Just "hi"
-                }
+            recovered `shouldBe` Right (emptyTurnOutput "resp-1" [] (Just "hi"))
             map inputItems <$> readIORef seen `shouldReturn`
                 [ [userItem "hi"]
                 , [userItem "hi"]


### PR DESCRIPTION
## Summary
- Keep provider-reported input, output, and cached token counts on each model turn instead of dropping them at the loop boundary.
- Accumulate those counts for the current session and right-align them on the idle status line above `λ` (`1.2k in · 340 out`, plus cached when the provider reports a hit).
- Persist the same totals in session meta/turns so resume restores them, `/clear` and `/new` reset them, and the end-of-turn status line includes that turn's usage.

## Test plan
- [x] `cabal test agent-core`
- [x] `cabal test agent-cli`
- [x] `cabal test agent-openai`
- [x] `cabal test agent-xai`
- [x] `cabal test agent-openrouter`
- [ ] TTY: after a turn, the line above `λ` shows session totals on the right
- [ ] Resume a session and confirm the totals come back; `/clear` and `/new` hide them until the next turn