### PR TITLE
feat: show Ghostty native loading indicator while reasoning

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -51,6 +51,7 @@ library
                     , Agent.CLI.Permission
                     , Agent.CLI.Picker
                     , Agent.CLI.Plan
+                    , Agent.CLI.Progress
                     , Agent.CLI.Project
                     , Agent.CLI.Prompt
                     , Agent.CLI.Render
@@ -108,6 +109,7 @@ test-suite agent-cli-test
                     , Agent.CLI.PlanSpec
                     , Agent.CLI.ProjectSpec
                     , Agent.CLI.PermissionSpec
+                    , Agent.CLI.ProgressSpec
                     , Agent.CLI.PromptSpec
                     , Agent.CLI.RenderSpec
                     , Agent.CLI.ReplStatusSpec

--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -7,7 +7,6 @@ module Agent.CLI
     , run
     ) where
 
-import Agent.CLI.Accounts (runAccountsList, runAccountsRemove, runLogin)
 import Agent.CLI.Auth (LoadedAuth(..), loadAuth)
 import Agent.CLI.CancelWatch (withEscCancel, withStdinPaused)
 import Agent.CLI.Clipboard
@@ -45,6 +44,10 @@ import Agent.CLI.Resume (pickResumeSession)
 import Agent.CLI.Plan
     ( cliPlanHooks
     , extractProposedPlan
+    )
+import Agent.CLI.Progress
+    ( osc9ProgressRemove
+    , wrapOscForTmux
     )
 import Agent.CLI.Project
     ( ProjectSettings(..)
@@ -234,9 +237,6 @@ devMain = do
         Right ShowVersion -> putStrLn "agent-cli 0.1.0.0" >> pure DevQuit
         Right ListSessions -> runListSessions >> pure DevQuit
         Right (ShowSession sessionId) -> runShowSession sessionId >> pure DevQuit
-        Right (LoginAccount provider label) -> runLogin provider label >> pure DevQuit
-        Right ListAccounts -> runAccountsList >> pure DevQuit
-        Right (RemoveAccount accountId) -> runAccountsRemove accountId >> pure DevQuit
         Right (RunAgent options) -> do
             result <- runAgent options
             case result of
@@ -252,9 +252,6 @@ run = do
         Right ShowVersion -> putStrLn "agent-cli 0.1.0.0"
         Right ListSessions -> runListSessions
         Right (ShowSession sessionId) -> runShowSession sessionId
-        Right (LoginAccount provider label) -> runLogin provider label
-        Right ListAccounts -> runAccountsList
-        Right (RemoveAccount accountId) -> runAccountsRemove accountId
         Right (RunAgent options) -> do
             result <- runAgent options
             case result of
@@ -350,7 +347,7 @@ runAgent options = do
     interrupt <- newInterruptState \msg -> do
         -- Drop an in-place "thinking…" status so the hint is its own line.
         Text.hPutStr stderr "\r\ESC[K"
-        hFlush stderr
+        clearNativeProgress stderr
         color <- resolveColor stderr
         putTextLn stderr (roleMuted color msg)
     -- Shared with Esc cancel and plan prompts so arrow-key pickers own stdin.
@@ -589,7 +586,7 @@ printResumeHint progName = \case
             Right handle -> do
                 -- Drop an in-place "thinking…" status so the hint is its own line.
                 Text.hPutStr stderr "\r\ESC[K"
-                hFlush stderr
+                clearNativeProgress stderr
                 color <- resolveColor stderr
                 putTextLn stderr
                     (roleMuted color (resumeHint progName handle.sessionMeta.metaId))
@@ -697,6 +694,10 @@ runSession options provider policy tools toolEnv planMode prompt paramsRef trans
             , renderModelRef = modelRef
             , renderActivityRef = activityRef
             , renderStartedAt = startedAtRef
+            -- OSC 9;4 is ignored by terminals that do not implement it.
+            -- Gate on the same TTY check as the in-pane spinner so pipes
+            -- and redirected stderr stay clean.
+            , renderNativeProgress = stderrTty
             }
         config = LoopConfig
             { loopBackend = backend
@@ -1437,6 +1438,16 @@ loadAgentsContext options provider home cwd initialItems initialPrevious
                             <> Text.pack (show (length files))
                             <> if length files == 1 then " file" else " files"))
                 newIORef (Just text)
+
+-- | Drop Ghostty / Windows Terminal native progress (OSC 9;4) on stderr.
+-- Safe when the bar was never shown; unknown terminals ignore the sequence.
+clearNativeProgress :: Handle -> IO ()
+clearNativeProgress handle = do
+    tty <- hIsTerminalDevice handle
+    when tty do
+        inTmux <- isJust <$> lookupEnv "TMUX"
+        Text.hPutStr handle (wrapOscForTmux inTmux osc9ProgressRemove)
+        hFlush handle
 
 -- | Color when the handle is a TTY and NO_COLOR is unset.
 resolveColor :: Handle -> IO Bool

--- a/packages/agent-cli/src/Agent/CLI/Progress.hs
+++ b/packages/agent-cli/src/Agent/CLI/Progress.hs
@@ -1,0 +1,49 @@
+-- | Native terminal progress (Ghostty / Windows Terminal / ConEmu OSC 9;4).
+--
+-- Ghostty shows this as the macOS window/tab loading indicator (and a
+-- colored progress overlay on the tab). State 3 is the indeterminate pulse
+-- used while the agent is reasoning; state 0 removes it.
+--
+-- Unknown terminals ignore OSC 9;4. tmux needs DCS passthrough so the
+-- outer emulator still sees the sequence.
+module Agent.CLI.Progress
+    ( osc9ProgressRemove
+    , osc9ProgressIndeterminate
+    , osc9ProgressSequence
+    , wrapOscForTmux
+    ) where
+
+import Agent.CLI.ImagePreview (wrapTmuxPassthrough)
+import Data.Text (Text)
+import qualified Data.Text as Text
+
+-- | OSC 9;4 states from ConEmu / Windows Terminal / Ghostty.
+-- 0 remove, 1 set percent, 2 error, 3 indeterminate, 4 paused.
+osc9ProgressSequence :: Int -> Maybe Int -> Text
+osc9ProgressSequence state mPercent =
+    "\ESC]9;4;"
+        <> Text.pack (show state)
+        <> case mPercent of
+            Just percent -> ";" <> Text.pack (show (clampPercent percent))
+            Nothing -> ""
+        <> "\BEL"
+
+osc9ProgressRemove :: Text
+osc9ProgressRemove = osc9ProgressSequence 0 Nothing
+
+-- | Indeterminate / busy pulse. Ghostty treats this as the native loading
+-- spinner; Windows Terminal animates a cycling bar.
+osc9ProgressIndeterminate :: Text
+osc9ProgressIndeterminate = osc9ProgressSequence 3 Nothing
+
+clampPercent :: Int -> Int
+clampPercent n
+    | n < 0 = 0
+    | n > 100 = 100
+    | otherwise = n
+
+-- | tmux DCS passthrough so OSC 9;4 reaches Ghostty (or WT) outside tmux.
+wrapOscForTmux :: Bool -> Text -> Text
+wrapOscForTmux inTmux payload
+    | inTmux = wrapTmuxPassthrough payload
+    | otherwise = payload

--- a/packages/agent-cli/src/Agent/CLI/Render.hs
+++ b/packages/agent-cli/src/Agent/CLI/Render.hs
@@ -22,6 +22,11 @@ module Agent.CLI.Render
     ) where
 
 import Agent.CLI.Markdown (renderMarkdown)
+import Agent.CLI.Progress
+    ( osc9ProgressIndeterminate
+    , osc9ProgressRemove
+    , wrapOscForTmux
+    )
 import Agent.CLI.Style
     ( agentBackground
     , glyphCancel
@@ -56,7 +61,7 @@ import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KeyMap
 import Data.IORef
-import Data.Maybe (fromMaybe)
+import Data.Maybe (fromMaybe, isJust)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
@@ -67,6 +72,7 @@ import System.Console.ANSI.Codes
     ( clearFromCursorToScreenEndCode
     , setCursorColumnCode
     )
+import System.Environment (lookupEnv)
 import System.IO (Handle, hFlush)
 
 data RenderConfig = RenderConfig
@@ -89,6 +95,7 @@ data RenderConfig = RenderConfig
     , renderModelRef :: !(IORef Text)
     , renderActivityRef :: !(IORef Text)
     , renderStartedAt :: !(IORef (Maybe UTCTime))
+    , renderNativeProgress :: !Bool -- ^ Ghostty / WT OSC 9;4; off in tests
     }
 
 -- | Grok-build @max_thoughts_width@: wrap reasoning display at this column.
@@ -275,6 +282,7 @@ startThinkingSpinnerUnlocked :: RenderConfig -> IO ()
 startThinkingSpinnerUnlocked config
     | not config.renderShowThinking = pure ()
     | otherwise = do
+        emitNativeProgress config True
         -- A live reasoning block already owns stderr; don't overlay a spinner.
         live <- readIORef config.renderReasoningLive
         unless live do
@@ -302,6 +310,20 @@ stopThinkingSpinnerUnlocked config = do
             hFlush config.renderStderr
         writeIORef config.renderThinkingVisible False
 
+-- | Ghostty (and Windows Terminal / ConEmu) native loading indicator.
+-- Harmless no-op on terminals that do not implement OSC 9;4.
+emitNativeProgress :: RenderConfig -> Bool -> IO ()
+emitNativeProgress config active
+    | not config.renderNativeProgress = pure ()
+    | otherwise = do
+        inTmux <- isJust <$> lookupEnv "TMUX"
+        let seq_ =
+                wrapOscForTmux inTmux $
+                    if active then osc9ProgressIndeterminate else osc9ProgressRemove
+        void $ tryIO do
+            Text.hPutStr config.renderStderr seq_
+            hFlush config.renderStderr
+
 spinnerLoop :: RenderConfig -> Int -> IO ()
 spinnerLoop config frame = do
     threadDelay 80000
@@ -311,7 +333,10 @@ spinnerLoop config frame = do
             next = (frame + 1) `mod` length frames
         withMVar config.renderLock \_ -> do
             still <- readIORef config.renderThinkingVisible
-            when still (paintThinkingFrame config next)
+            when still do
+                -- Ghostty hides OSC 9;4 after ~15s without an update.
+                when (next == 0) (emitNativeProgress config True)
+                paintThinkingFrame config next
         spinnerLoop config next
 
 paintThinkingFrame :: RenderConfig -> Int -> IO ()
@@ -356,12 +381,15 @@ appendReasoningUnlocked config delta
         -- First summary token replaces the one-line spinner; later tokens
         -- restyle the live truncated block in place. Elapsed time on the
         -- header updates with each delta rather than a dedicated spinner.
+        -- Keep Ghostty's native bar up until the round is committed.
         stopThinkingSpinnerUnlocked config
+        emitNativeProgress config True
         redrawLiveReasoning config True elapsed buffered
 
 commitThinkingUnlocked :: RenderConfig -> IO ()
 commitThinkingUnlocked config = do
     stopThinkingSpinnerUnlocked config
+    emitNativeProgress config False
     buffered <- readIORef config.renderReasoningBuffer
     writeIORef config.renderReasoningBuffer ""
     if Text.null (Text.strip buffered)

--- a/packages/agent-cli/test/Agent/CLI/ProgressSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ProgressSpec.hs
@@ -1,0 +1,30 @@
+module Agent.CLI.ProgressSpec (spec) where
+
+import Agent.CLI.Progress
+import qualified Data.Text as Text
+import Test.Hspec
+
+spec :: Spec
+spec = do
+    describe "osc9ProgressSequence" do
+        it "emits ConEmu/Ghostty remove and indeterminate states" do
+            osc9ProgressRemove `shouldBe` "\ESC]9;4;0\BEL"
+            osc9ProgressIndeterminate `shouldBe` "\ESC]9;4;3\BEL"
+
+        it "includes a clamped percent for determinate progress" do
+            osc9ProgressSequence 1 (Just 42) `shouldBe` "\ESC]9;4;1;42\BEL"
+            osc9ProgressSequence 1 (Just 150) `shouldBe` "\ESC]9;4;1;100\BEL"
+            osc9ProgressSequence 1 (Just (-3)) `shouldBe` "\ESC]9;4;1;0\BEL"
+
+    describe "wrapOscForTmux" do
+        it "leaves the sequence alone outside tmux" do
+            wrapOscForTmux False osc9ProgressIndeterminate
+                `shouldBe` osc9ProgressIndeterminate
+
+        it "doubles ESC so tmux forwards the inner OSC" do
+            wrapOscForTmux True osc9ProgressRemove
+                `shouldBe` "\ESCPtmux;\ESC\ESC]9;4;0\BEL\ESC\\"
+            wrapOscForTmux True osc9ProgressIndeterminate
+                `shouldSatisfy` Text.isPrefixOf "\ESCPtmux;"
+            wrapOscForTmux True osc9ProgressIndeterminate
+                `shouldSatisfy` Text.isSuffixOf "\ESC\\"

--- a/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
@@ -250,6 +250,17 @@ spec = do
                 hClose handle
                 body <- Text.readFile path
                 body `shouldSatisfy` (Text.isInfixOf "thinking…")
+                body `shouldSatisfy` (not . Text.isInfixOf "\ESC]9;4;")
+
+        it "emits Ghostty OSC 9;4 while thinking and clears it after" do
+            withRenderConfigNative True False True \config handle path -> do
+                renderEvent config TurnStarted
+                renderEvent config (ReasoningDelta "plan")
+                clearThinking config
+                hClose handle
+                body <- Text.readFile path
+                body `shouldSatisfy` containsOsc9 3
+                body `shouldSatisfy` containsOsc9 0
 
     describe "formatThinkingBlock" do
         it "headers a live preview and a finished duration" do
@@ -283,12 +294,27 @@ spec = do
             let painted = "\ESC[1mabcdefghij\ESC[0m"
             visibleDisplayRows 5 painted `shouldBe` 2
 
+containsOsc9 :: Int -> Text.Text -> Bool
+containsOsc9 state body =
+    let raw = "\ESC]9;4;" <> Text.pack (show state) <> "\BEL"
+        wrapped = "\ESCPtmux;\ESC" <> raw <> "\ESC\\"
+    in raw `Text.isInfixOf` body || wrapped `Text.isInfixOf` body
+
 withRenderConfig
     :: Bool
     -> Bool
     -> (RenderConfig -> Handle -> FilePath -> IO ())
     -> IO ()
-withRenderConfig showThinking color action = do
+withRenderConfig showThinking color =
+    withRenderConfigNative showThinking color False
+
+withRenderConfigNative
+    :: Bool
+    -> Bool
+    -> Bool
+    -> (RenderConfig -> Handle -> FilePath -> IO ())
+    -> IO ()
+withRenderConfigNative showThinking color native action = do
     printed <- newIORef False
     thinking <- newIORef False
     spinner <- newIORef Nothing
@@ -320,6 +346,7 @@ withRenderConfig showThinking color action = do
                 , renderModelRef = modelRef
                 , renderActivityRef = activityRef
                 , renderStartedAt = startedAt
+                , renderNativeProgress = native
                 }
         action config handle path
         clearThinking config

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -15,6 +15,7 @@ import qualified Agent.CLI.ModelsSpec as ModelsSpec
 import qualified Agent.CLI.OptionsSpec as OptionsSpec
 import qualified Agent.CLI.PermissionSpec as PermissionSpec
 import qualified Agent.CLI.PlanSpec as PlanSpec
+import qualified Agent.CLI.ProgressSpec as ProgressSpec
 import qualified Agent.CLI.ProjectSpec as ProjectSpec
 import qualified Agent.CLI.PromptSpec as PromptSpec
 import qualified Agent.CLI.RenderSpec as RenderSpec
@@ -42,6 +43,7 @@ main = hspec do
     OptionsSpec.spec
     PermissionSpec.spec
     PlanSpec.spec
+    ProgressSpec.spec
     ProjectSpec.spec
     PromptSpec.spec
     RenderSpec.spec


### PR DESCRIPTION
## Summary
- Drive Ghostty's native window/tab loading indicator from the thinking spinner via OSC 9;4 (ConEmu / Windows Terminal progress). State 3 (indeterminate) while a turn is running; state 0 when it finishes, is cancelled, or is interrupted.
- Keep the bar up across live reasoning summaries and tool calls. Refresh it once per spinner cycle because Ghostty hides OSC 9;4 after ~15s without an update.
- Wrap the sequence in tmux DCS passthrough. Gate it on a TTY so pipes stay clean. Unknown terminals ignore OSC 9;4.
- Drop a leftover `Agent.CLI.Accounts` dispatch that does not compile (`LoginAccount` is not a `Command` constructor).

## Test plan
- [x] `GHCRTS= cabal test agent-cli` (222 examples, 0 failures)
- [ ] Interactive in Ghostty: send a prompt and confirm the native tab/window loading indicator appears during `thinking…` / live reasoning, then disappears when the turn ends
- [ ] Interactive in Ghostty + tmux: same, with `allow-passthrough` on
- [ ] Ctrl-C / Esc during a turn clears the native indicator