### PR TITLE
feat: cycle idle mode with Shift+Tab

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -54,6 +54,7 @@ library
                     , Agent.CLI.Project
                     , Agent.CLI.Prompt
                     , Agent.CLI.Render
+                    , Agent.CLI.ReplMode
                     , Agent.CLI.Resume
                     , Agent.CLI.Session
                     , Agent.CLI.SubagentStore

--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -2,6 +2,8 @@
 module Agent.CLI
     ( DevResult(..)
     , afterDev
+    , applyReplMode
+    , cycleReplInteraction
     , devMain
     , formatReplStatusLine
     , run
@@ -27,7 +29,13 @@ import Agent.CLI.ImagePreview
     , previewRowsFor
     , renderImagePreview
     )
-import Agent.CLI.Input (ReplLine(..), readReplLine)
+import Agent.CLI.Input (ReplLine(..), readReplLineWithInitial)
+import Agent.CLI.ReplMode
+    ( ReplMode(..)
+    , cycleReplMode
+    , replModeFromState
+    , replModeLabel
+    )
 import Agent.CLI.Interrupt
     ( InterruptState
     , newInterruptState
@@ -583,21 +591,43 @@ printResumeHint progName = \case
                 putTextLn stderr
                     (roleMuted color (resumeHint progName handle.sessionMeta.metaId))
 
--- | Idle prompt chrome: model, reasoning effort, approval mode.
-formatReplStatusLine :: Bool -> Text -> Text -> ApprovalPolicy -> Text
-formatReplStatusLine color model effort policy =
+-- | Idle prompt chrome: model, reasoning effort, interaction mode.
+formatReplStatusLine :: Bool -> Text -> Text -> ReplMode -> Text
+formatReplStatusLine color model effort mode =
     roleMuted color $
         "  "
             <> model
             <> " · "
             <> effort
             <> " · "
-            <> approvalLabel policy
-  where
-    approvalLabel = \case
-        ApproveAll -> "yolo"
-        PromptMutating -> "ask"
-        DenyMutating -> "deny"
+            <> replModeLabel mode
+
+-- | Apply a cycled idle mode: plan pending vs always-approve vs ask.
+-- Always-approve still persists to project settings, matching /always-approve.
+applyReplMode
+    :: PlanModeEnv
+    -> IORef ApprovalPolicy
+    -> FilePath
+    -> ReplMode
+    -> IO ()
+applyReplMode planMode policyRef projectRoot = \case
+    ReplModePlan -> do
+        writeIORef planMode.planStateRef PlanPending
+    ReplModeAlwaysApprove -> do
+        deactivatePlanMode planMode
+        writeIORef policyRef ApproveAll
+        saveProjectAutoApprove projectRoot True
+    ReplModeNormal -> do
+        deactivatePlanMode planMode
+        current <- readIORef policyRef
+        when (current == ApproveAll) do
+            writeIORef policyRef PromptMutating
+            saveProjectAutoApprove projectRoot False
+
+-- | Pure next-mode helper used by tests and the Shift+Tab handler.
+cycleReplInteraction :: PlanModeState -> ApprovalPolicy -> ReplMode
+cycleReplInteraction planState policy =
+    cycleReplMode (replModeFromState planState policy)
 
 shouldPersist :: CliOptions -> Bool
 shouldPersist options = not (isOneShot options) || options.optSaveSession
@@ -729,24 +759,55 @@ repl
     -> SubagentStoreRoot
     -> IO ()
     -> IO DevResult
-repl config render provider previous printed paramsRef policyRef transcriptRef persist planMode projectRoot tokenProvider agentsContext escPaused attachmentsRef previewIdRef interrupt storeRoot sessionReset = do
+repl config render provider previous printed paramsRef policyRef transcriptRef persist planMode projectRoot tokenProvider agentsContext escPaused attachmentsRef previewIdRef interrupt storeRoot sessionReset =
+    replWithDraft config render provider previous printed paramsRef policyRef
+        transcriptRef persist planMode projectRoot tokenProvider agentsContext
+        escPaused attachmentsRef previewIdRef interrupt storeRoot sessionReset ""
+
+replWithDraft
+    :: LoopConfig
+    -> RenderConfig
+    -> Provider
+    -> IORef (Maybe Text)
+    -> IORef Bool
+    -> IORef ResponseCreateParams
+    -> IORef ApprovalPolicy
+    -> IORef [ResponseItem]
+    -> Maybe (IORef (Either SessionCreate SessionHandle))
+    -> PlanModeEnv
+    -> FilePath
+    -> Maybe TokenProvider
+    -> IORef (Maybe Text)
+    -> IORef Bool
+    -> IORef [ImageAttachment]
+    -> IORef Int
+    -> InterruptState
+    -> SubagentStoreRoot
+    -> IO ()
+    -> Text
+    -> IO DevResult
+replWithDraft config render provider previous printed paramsRef policyRef transcriptRef persist planMode projectRoot tokenProvider agentsContext escPaused attachmentsRef previewIdRef interrupt storeRoot sessionReset draft = do
     stdoutColor <- resolveColor stdout
-    planActive <- isPlanModeActive planMode
-    planPending <- (== PlanPending) <$> readIORef planMode.planStateRef
+    planState <- readIORef planMode.planStateRef
+    let planActive = planState == PlanActive
+        planPending = planState == PlanPending
     params <- readIORef paramsRef
     policy <- readIORef policyRef
+    let idleMode = replModeFromState planState policy
     -- Status sits on the line above λ so haskeline can keep the cursor on
     -- the input. Haskeline cannot park a persistent footer under the draft.
     Text.putStrLn $ formatReplStatusLine stdoutColor
         (currentModel params)
         (currentEffort params)
-        policy
+        idleMode
     hFlush stdout
     -- Solarized user wash under the prompt; haskeline redraws it on edit.
     -- Cmd+Delete / Ctrl+U kill-to-start via haskeline Emacs bindings.
     let modeTag
             | planActive = roleWarn stdoutColor "[plan] "
             | planPending = roleMuted stdoutColor "[plan…] "
+            | idleMode == ReplModeAlwaysApprove =
+                roleSuccess stdoutColor "[yolo] "
             | otherwise = ""
         chromePrompt =
             beginBackground stdoutColor userBackground
@@ -755,7 +816,7 @@ repl config render provider previous printed paramsRef policyRef transcriptRef p
                 <> if stdoutColor
                     then Text.pack clearFromCursorToLineEndCode
                     else mempty
-    mline <- readReplLine interrupt chromePrompt
+    mline <- readReplLineWithInitial interrupt chromePrompt draft
     Text.putStr (endBackground stdoutColor)
     hFlush stdout
     case mline of
@@ -766,6 +827,14 @@ repl config render provider previous printed paramsRef policyRef transcriptRef p
             -- Confirmed double Ctrl-C: rethrow so withInterruptResume prints
             -- the --resume hint and the process exits.
             throwIO UserInterrupt
+        ReplCycleMode keptDraft -> do
+            let next = cycleReplInteraction planState policy
+            applyReplMode planMode policyRef projectRoot next
+            -- Haskeline already advanced a line; walk back over the
+            -- previous status + prompt so the next chrome replaces them.
+            putStr "\ESC[2A\r\ESC[J"
+            hFlush stdout
+            continueWith keptDraft
         ReplText line ->
             let stripped = Text.strip line
             in if Text.null stripped
@@ -1095,10 +1164,12 @@ repl config render provider previous printed paramsRef policyRef transcriptRef p
                         Text.hPutStrLn stderr (roleError color err)
                         continue
   where
-    continue =
-        repl config render provider previous printed paramsRef policyRef
+    continue = continueWith ""
+    continueWith keptDraft =
+        replWithDraft config render provider previous printed paramsRef policyRef
             transcriptRef persist planMode projectRoot tokenProvider agentsContext
             escPaused attachmentsRef previewIdRef interrupt storeRoot sessionReset
+            keptDraft
 
 applyModelChange
     :: Provider

--- a/packages/agent-cli/src/Agent/CLI/Command.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command.hs
@@ -72,7 +72,7 @@ slashCommands =
     [ cmd "help" [] "/help [NAME]" "List slash commands, or describe one"
     , cmd "model" ["m"] "/model [NAME]" "Open the model picker, or set a model"
     , cmd "effort" [] "/effort [low|medium|high|xhigh]" "Show or set reasoning effort"
-    , cmd "plan" [] "/plan [description]" "Enter plan mode"
+    , cmd "plan" [] "/plan [description]" "Enter plan mode (or Shift+Tab)"
     , cmd "session" [] "/session" "Print the current session id"
     , cmd "resume" [] "/resume [ID]" "Pick a session to resume, or print a --resume hint"
     , cmd "compact" [] "/compact [FOCUS]" "Summarize history to free context"
@@ -82,7 +82,7 @@ slashCommands =
     , cmd "paste" [] "/paste [--send] [TEXT]" "Attach a clipboard image (Cmd+V / Ctrl+V) and preview it in the terminal"
     , cmd "attachments" [] "/attachments" "List queued clipboard images"
     , cmd "clear-attachments" [] "/clear-attachments" "Drop queued clipboard images"
-    , cmd "always-approve" ["yolo"] "/always-approve" "Toggle project auto-approve"
+    , cmd "always-approve" ["yolo"] "/always-approve" "Toggle project auto-approve (or Shift+Tab)"
     ]
   where
     cmd name aliases usage summary =

--- a/packages/agent-cli/src/Agent/CLI/Input.hs
+++ b/packages/agent-cli/src/Agent/CLI/Input.hs
@@ -4,13 +4,17 @@
 module Agent.CLI.Input
     ( ReplLine(..)
     , readReplLine
+    , readReplLineWithInitial
     , readApprovalLine
     , readChoiceSelection
     , approvalKeyText
     , ChoiceKey(..)
     , parseChoiceKey
     , choiceMoveIndex
+    , isCycleModeSentinel
+    , dropCycleModeSentinel
     , replHistoryPath
+    , shiftTabPrefsText
     ) where
 
 import Agent.CLI.Command (slashCompletionCandidates)
@@ -19,8 +23,8 @@ import Agent.CLI.Interrupt
     , InterruptState
     , noteIdleCtrlC
     )
-import Control.Exception.Safe (bracket, catchIO, throwIO, tryIO)
-import Control.Monad (when)
+import Control.Exception.Safe (bracket, catchIO, finally, throwIO, tryIO)
+import Control.Monad (unless, when)
 import Data.Char (ord)
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -34,11 +38,15 @@ import System.Console.ANSI.Codes
     , cursorUpCode
     )
 import System.Console.Haskeline
-    ( Settings(..)
+    ( Prefs
+    , Settings(..)
     , defaultSettings
-    , getInputLine
+    , getHistory
+    , getInputLineWithInitial
     , handleInterrupt
-    , runInputT
+    , putHistory
+    , readPrefs
+    , runInputTWithPrefs
     , setComplete
     , withInterrupt
     )
@@ -47,14 +55,19 @@ import System.Console.Haskeline.Completion
     , CompletionFunc
     , completeWordWithPrev
     )
+import System.Console.Haskeline.History (addHistory)
 import System.Directory
     ( createDirectoryIfMissing
+    , doesFileExist
     , getHomeDirectory
+    , getTemporaryDirectory
+    , removeFile
     )
 import System.FilePath (takeDirectory, (</>))
 import System.IO
     ( BufferMode(..)
     , Handle
+    , hClose
     , hFlush
     , hGetBuffering
     , hGetChar
@@ -62,6 +75,7 @@ import System.IO
     , hSetBuffering
     , hWaitForInput
     , isEOF
+    , openTempFile
     , stderr
     , stdin
     , stdout
@@ -85,6 +99,8 @@ import System.Posix.Types (FileMode)
 data ReplLine
     = ReplEof
     | ReplText Text
+    | ReplCycleMode Text
+    -- ^ Shift+Tab: cycle idle mode and keep the current draft.
     | ReplQuitInterrupt
     deriving (Eq, Show)
 
@@ -137,7 +153,12 @@ choiceMoveIndex len idx key
 -- Haskeline installs its own SIGINT handler while reading, so idle Ctrl-C
 -- goes through 'noteIdleCtrlC' rather than the outer signal handler.
 readReplLine :: InterruptState -> Text -> IO ReplLine
-readReplLine interrupt prompt = do
+readReplLine interrupt prompt =
+    readReplLineWithInitial interrupt prompt ""
+
+-- | Like 'readReplLine', restoring @initial@ as the in-progress draft.
+readReplLineWithInitial :: InterruptState -> Text -> Text -> IO ReplLine
+readReplLineWithInitial interrupt prompt initial = do
     isTty <- hIsTerminalDevice stdin
     if isTty
         then do
@@ -148,13 +169,15 @@ readReplLine interrupt prompt = do
                 (setComplete completeSlash
                     defaultSettings
                         { historyFile = Just path
-                        , autoAddHistory = True
+                        , autoAddHistory = False
                         })
                 prompt
+                initial
         else do
             Text.hPutStr stdout prompt
             hFlush stdout
             fmap (maybe ReplEof ReplText) readAnswerOnly
+
 -- | Read a one-shot approval answer. The question is always written to
 -- stderr (matching the pre-haskeline behavior) so redirected stdout does
 -- not swallow the prompt. Does not touch REPL history.
@@ -366,22 +389,79 @@ withChoiceRawStdin action = do
             hSetBuffering stdin oldBuf
     bracket enter (const restore) \() -> action
 
-readEditedLine :: InterruptState -> Settings IO -> Text -> IO ReplLine
-readEditedLine interrupt settings prompt = go
-  where
-    go =
-        -- Haskeline turns Ctrl-C into 'Interrupt' and replaces our SIGINT
-        -- handler for the duration of the prompt. Soft-warn / double-quit
-        -- are applied here via 'noteIdleCtrlC'.
-        handleInterrupt onInterrupt $
-            runInputT settings $
-                withInterrupt $
-                    fmap (maybe ReplEof (ReplText . Text.pack))
-                        (getInputLine (Text.unpack prompt))
-    onInterrupt = do
-        noteIdleCtrlC interrupt >>= \case
-            ContinuePrompt -> go
-            QuitProcess -> pure ReplQuitInterrupt
+-- | Object-replacement character inserted by the Shift+Tab haskeline
+-- bind so the line can finish. Must be 'isPrint' or haskeline drops
+-- the bind; stripped before the draft is restored.
+cycleModeSentinel :: Char
+cycleModeSentinel = '\xFFFC'
+
+isCycleModeSentinel :: Text -> Bool
+isCycleModeSentinel = Text.any (== cycleModeSentinel)
+
+dropCycleModeSentinel :: Text -> Text
+dropCycleModeSentinel = Text.filter (/= cycleModeSentinel)
+
+-- | Map CSI/SS3 Shift+Tab onto unused f24, then insert the sentinel and
+-- submit. haskeline canonicalizes the name "shift-tab" to Tab (stealing
+-- completion), so the sequences bind to a function key instead.
+-- Exported so tests can assert the bind file parses.
+shiftTabPrefsText :: Text
+shiftTabPrefsText =
+    Text.unlines
+        [ "keyseq: \"\\x1b[Z\" f24"
+        , "keyseq: \"\\x1b[1;2Z\" f24"
+        , "keyseq: \"\\x1bOZ\" f24"
+        , "bind: f24 " <> Text.singleton cycleModeSentinel <> " Return"
+        ]
+
+loadReplPrefs :: IO Prefs
+loadReplPrefs = do
+    home <- getHomeDirectory
+    let userPath = home </> ".haskeline"
+    exists <- doesFileExist userPath
+    userText <- if exists then Text.readFile userPath else pure ""
+    tmpDir <- getTemporaryDirectory
+    (path, handle) <- openTempFile tmpDir "haskell-agent-haskeline"
+    -- User prefs first, then ours, so later bind/keyseq lines win.
+    Text.hPutStr handle userText
+    unless (Text.null userText || Text.isSuffixOf "\n" userText) $
+        Text.hPutStr handle "\n"
+    Text.hPutStr handle shiftTabPrefsText
+    hClose handle
+    readPrefs path `finally` (removeFile path `catchIO` \_ -> pure ())
+
+readEditedLine :: InterruptState -> Settings IO -> Text -> Text -> IO ReplLine
+readEditedLine interrupt settings prompt initial = do
+    prefs <- loadReplPrefs
+    let go =
+            -- Haskeline turns Ctrl-C into 'Interrupt' and replaces our SIGINT
+            -- handler for the duration of the prompt. Soft-warn / double-quit
+            -- are applied here via 'noteIdleCtrlC'.
+            handleInterrupt onInterrupt $
+                runInputTWithPrefs prefs settings $
+                    withInterrupt do
+                        result <- getInputLineWithInitial
+                            (Text.unpack prompt)
+                            (Text.unpack initial, "")
+                        case result of
+                            Nothing -> pure ReplEof
+                            Just raw
+                                | isCycleModeSentinel packed ->
+                                    -- Leave history unchanged; the REPL
+                                    -- restores @draft@ on the next prompt.
+                                    pure (ReplCycleMode (dropCycleModeSentinel packed))
+                                | otherwise -> do
+                                    unless (all (== ' ') raw) do
+                                        hist <- getHistory
+                                        putHistory (addHistory raw hist)
+                                    pure (ReplText packed)
+                              where
+                                packed = Text.pack raw
+        onInterrupt = do
+            noteIdleCtrlC interrupt >>= \case
+                ContinuePrompt -> go
+                QuitProcess -> pure ReplQuitInterrupt
+    go
 
 -- | Tab-complete slash command names and a few known argument tokens.
 completeSlash :: CompletionFunc IO

--- a/packages/agent-cli/src/Agent/CLI/Options.hs
+++ b/packages/agent-cli/src/Agent/CLI/Options.hs
@@ -231,6 +231,7 @@ usage = unlines
     , "persisted under ~/.haskell-agent/sessions. /effort [LEVEL] changes"
     , "reasoning effort. /model (alias /m) opens the model picker; /model NAME"
     , "sets it. /help [NAME] lists slash commands. Tab completes / commands."
+    , "Shift+Tab cycles idle mode: ask (normal) → plan → always-approve → ask."
     , "/compact [FOCUS] summarizes history (OpenAI remote compact;"
     , "xAI/OpenRouter local summary) to free context."
     , "/plan [description] enters plan mode (read-only except plan.md);"

--- a/packages/agent-cli/src/Agent/CLI/Plan.hs
+++ b/packages/agent-cli/src/Agent/CLI/Plan.hs
@@ -106,6 +106,9 @@ readChangeNotes interrupt color = do
     readReplLine interrupt chrome >>= \case
         ReplEof -> pure "(no notes)"
         ReplQuitInterrupt -> throwIO UserInterrupt
+        ReplCycleMode _ ->
+            -- Shift+Tab is idle-prompt only; keep asking for notes.
+            readChangeNotes interrupt color
         ReplText text
             | Text.null (Text.strip text) -> pure "(no notes)"
             | otherwise -> pure (Text.strip text)
@@ -127,6 +130,8 @@ askQuestion interrupt resolveColor question options = do
                 readReplLine interrupt chrome >>= \case
                     ReplEof -> pure Nothing
                     ReplQuitInterrupt -> throwIO UserInterrupt
+                    ReplCycleMode _ ->
+                        askQuestion interrupt resolveColor question []
                     ReplText text
                         | Text.null (Text.strip text) -> pure Nothing
                         | otherwise -> pure (Just (Text.strip text))

--- a/packages/agent-cli/src/Agent/CLI/ReplMode.hs
+++ b/packages/agent-cli/src/Agent/CLI/ReplMode.hs
@@ -1,0 +1,42 @@
+-- | Idle REPL interaction mode: ask (normal), plan, or always-approve.
+module Agent.CLI.ReplMode
+    ( ReplMode(..)
+    , cycleReplMode
+    , replModeLabel
+    , replModeFromState
+    ) where
+
+import Agent.CLI.Options (ApprovalPolicy(..))
+import Agent.Tools.PlanMode (PlanModeState(..))
+import Data.Text (Text)
+
+-- | The three modes Shift+Tab cycles at the idle prompt.
+data ReplMode
+    = ReplModeNormal
+    -- ^ Prompt for mutating tools (status label "ask").
+    | ReplModePlan
+    -- ^ Read-only except plan.md.
+    | ReplModeAlwaysApprove
+    -- ^ Auto-approve mutating tools (status label "yolo").
+    deriving (Eq, Show)
+
+-- | Shift+Tab order: normal → plan → always-approve → normal.
+cycleReplMode :: ReplMode -> ReplMode
+cycleReplMode = \case
+    ReplModeNormal -> ReplModePlan
+    ReplModePlan -> ReplModeAlwaysApprove
+    ReplModeAlwaysApprove -> ReplModeNormal
+
+replModeLabel :: ReplMode -> Text
+replModeLabel = \case
+    ReplModeNormal -> "ask"
+    ReplModePlan -> "plan"
+    ReplModeAlwaysApprove -> "yolo"
+
+-- | Plan pending/active wins over yolo so cycling out of plan is well-defined
+-- even when auto-approve is also on.
+replModeFromState :: PlanModeState -> ApprovalPolicy -> ReplMode
+replModeFromState planState policy
+    | planState /= PlanInactive = ReplModePlan
+    | policy == ApproveAll = ReplModeAlwaysApprove
+    | otherwise = ReplModeNormal

--- a/packages/agent-cli/test/Agent/CLI/InputSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/InputSpec.hs
@@ -4,9 +4,21 @@ import Agent.CLI.Input
     ( ChoiceKey(..)
     , approvalKeyText
     , choiceMoveIndex
+    , dropCycleModeSentinel
+    , isCycleModeSentinel
     , parseChoiceKey
     , replHistoryPath
+    , shiftTabPrefsText
     )
+import Control.Exception (bracket)
+import qualified Data.Text as Text
+import qualified Data.Text.IO as Text
+import System.Console.Haskeline (readPrefs)
+import System.Directory
+    ( getTemporaryDirectory
+    , removeFile
+    )
+import System.IO (hClose, openTempFile)
 import System.FilePath ((</>))
 import Test.Hspec
 
@@ -49,3 +61,23 @@ spec = do
             choiceMoveIndex 3 1 ChoiceUp `shouldBe` 0
             choiceMoveIndex 3 1 ChoiceDown `shouldBe` 2
             choiceMoveIndex 3 1 ChoiceEnter `shouldBe` 1
+
+    describe "cycle mode sentinel" do
+        it "detects and strips the Shift+Tab marker" do
+            let marked = "hello" <> Text.singleton '\xFFFC'
+            isCycleModeSentinel marked `shouldBe` True
+            dropCycleModeSentinel marked `shouldBe` "hello"
+            isCycleModeSentinel "hello" `shouldBe` False
+            dropCycleModeSentinel "hello" `shouldBe` "hello"
+
+        it "parses Shift+Tab keyseq and bind lines" $ do
+            tmp <- getTemporaryDirectory
+            bracket
+                (openTempFile tmp "haskeline-shift-tab")
+                (\(path, _) -> removeFile path)
+                \(path, handle) -> do
+                    Text.hPutStr handle shiftTabPrefsText
+                    hClose handle
+                    prefs <- readPrefs path
+                    show prefs `shouldSatisfy` ("f24" `Text.isInfixOf`) . Text.pack
+                    show prefs `shouldSatisfy` ("\\ESC[Z" `Text.isInfixOf`) . Text.pack

--- a/packages/agent-cli/test/Agent/CLI/ReplStatusSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ReplStatusSpec.hs
@@ -1,15 +1,73 @@
 module Agent.CLI.ReplStatusSpec (spec) where
 
-import Agent.CLI (formatReplStatusLine)
+import Agent.CLI (applyReplMode, cycleReplInteraction, formatReplStatusLine)
 import Agent.CLI.Options (ApprovalPolicy(..))
+import Agent.CLI.Project (ProjectSettings(..), loadProjectSettings)
+import Agent.CLI.ReplMode
+    ( ReplMode(..)
+    , cycleReplMode
+    , replModeFromState
+    )
+import Agent.Tools.PlanMode (PlanModeEnv(..), PlanModeState(..), newPlanModeEnv)
+import Control.Exception (bracket)
+import Data.IORef (newIORef, readIORef)
+import System.Directory (getTemporaryDirectory, removeDirectoryRecursive)
+import System.Posix.Temp (mkdtemp)
 import Test.Hspec
 
 spec :: Spec
-spec = describe "formatReplStatusLine" do
-    it "shows model, effort, and approval mode" do
-        formatReplStatusLine False "grok-4.6" "high" PromptMutating
-            `shouldBe` "  grok-4.6 · high · ask"
-        formatReplStatusLine False "gpt-5.1-codex" "medium" ApproveAll
-            `shouldBe` "  gpt-5.1-codex · medium · yolo"
-        formatReplStatusLine False "gpt-5.1" "low" DenyMutating
-            `shouldBe` "  gpt-5.1 · low · deny"
+spec = do
+    describe "formatReplStatusLine" do
+        it "shows model, effort, and interaction mode" do
+            formatReplStatusLine False "grok-4.6" "high" ReplModeNormal
+                `shouldBe` "  grok-4.6 · high · ask"
+            formatReplStatusLine False "gpt-5.1-codex" "medium" ReplModeAlwaysApprove
+                `shouldBe` "  gpt-5.1-codex · medium · yolo"
+            formatReplStatusLine False "gpt-5.1" "low" ReplModePlan
+                `shouldBe` "  gpt-5.1 · low · plan"
+
+    describe "cycleReplMode" do
+        it "walks ask → plan → always-approve → ask" do
+            cycleReplMode ReplModeNormal `shouldBe` ReplModePlan
+            cycleReplMode ReplModePlan `shouldBe` ReplModeAlwaysApprove
+            cycleReplMode ReplModeAlwaysApprove `shouldBe` ReplModeNormal
+
+        it "treats pending/active plan as plan even under yolo" do
+            replModeFromState PlanPending ApproveAll `shouldBe` ReplModePlan
+            replModeFromState PlanActive PromptMutating `shouldBe` ReplModePlan
+            replModeFromState PlanInactive ApproveAll `shouldBe` ReplModeAlwaysApprove
+            replModeFromState PlanInactive PromptMutating `shouldBe` ReplModeNormal
+            replModeFromState PlanInactive DenyMutating `shouldBe` ReplModeNormal
+
+        it "cycles from current plan/approval state" do
+            cycleReplInteraction PlanInactive PromptMutating
+                `shouldBe` ReplModePlan
+            cycleReplInteraction PlanPending PromptMutating
+                `shouldBe` ReplModeAlwaysApprove
+            cycleReplInteraction PlanInactive ApproveAll
+                `shouldBe` ReplModeNormal
+
+        it "applies plan, yolo, then ask" $
+            withTempDir "agent-mode-" \root -> do
+                plan <- newPlanModeEnv root Nothing
+                policyRef <- newIORef PromptMutating
+                applyReplMode plan policyRef root ReplModePlan
+                readIORef plan.planStateRef `shouldReturn` PlanPending
+                readIORef policyRef `shouldReturn` PromptMutating
+
+                applyReplMode plan policyRef root ReplModeAlwaysApprove
+                readIORef plan.planStateRef `shouldReturn` PlanInactive
+                readIORef policyRef `shouldReturn` ApproveAll
+                settings <- loadProjectSettings root
+                settings.settingsAutoApprove `shouldBe` True
+
+                applyReplMode plan policyRef root ReplModeNormal
+                readIORef plan.planStateRef `shouldReturn` PlanInactive
+                readIORef policyRef `shouldReturn` PromptMutating
+                settings' <- loadProjectSettings root
+                settings'.settingsAutoApprove `shouldBe` False
+
+withTempDir :: String -> (FilePath -> IO a) -> IO a
+withTempDir prefix action = do
+    tmp <- getTemporaryDirectory
+    bracket (mkdtemp (tmp <> "/" <> prefix)) removeDirectoryRecursive action


### PR DESCRIPTION
## Summary
- Shift+Tab at the idle REPL prompt cycles **ask → plan → always-approve → ask**.
- The status line and λ tag update (`[plan…]` / `[yolo]`), and the in-progress draft is kept.
- Always-approve still writes project settings, matching `/always-approve`. Tab completion is unchanged.

## Test plan
- [x] `agent-cli-test` (214 examples)
- [x] tmux: type a draft, send CSI Z three times, confirm ask → plan → yolo → ask with the draft still present
- [ ] Manual: Shift+Tab on a real keyboard (Ghostty/Kitty/xterm CSI `Z`)