### PR TITLE
feat: render grok-style tool verbs and pretty headings

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -346,7 +346,7 @@ runAgent options = do
 
     toolEnv <- defaultToolEnv cwd
     interrupt <- newInterruptState \msg -> do
-        -- Drop an in-place "thinking…" status so the hint is its own line.
+        -- Drop an in-place "Thinking…" status so the hint is its own line.
         Text.hPutStr stderr "\r\ESC[K"
         clearNativeProgress stderr
         color <- resolveColor stderr
@@ -588,7 +588,7 @@ printResumeHint progName = \case
         case slot of
             Left _ -> pure ()
             Right handle -> do
-                -- Drop an in-place "thinking…" status so the hint is its own line.
+                -- Drop an in-place "Thinking…" status so the hint is its own line.
                 Text.hPutStr stderr "\r\ESC[K"
                 clearNativeProgress stderr
                 color <- resolveColor stderr
@@ -704,7 +704,7 @@ runSession options provider policy tools toolEnv planMode prompt paramsRef trans
     spinnerRef <- newIORef Nothing
     reasoningBuffer <- newIORef ""
     reasoningLive <- newIORef False
-    activityRef <- newIORef "thinking…"
+    activityRef <- newIORef "Thinking…"
     startedAtRef <- newIORef Nothing
     allowedToolsRef <- newIORef Set.empty
     modelRef <- newIORef =<< (currentModel <$> readIORef paramsRef)

--- a/packages/agent-cli/src/Agent/CLI/Markdown.hs
+++ b/packages/agent-cli/src/Agent/CLI/Markdown.hs
@@ -65,9 +65,8 @@ renderBlocks = go
         | Just (styled, after) <- takeTable (line : rest) =
             styled ++ go after
         | Just (level, title) <- headingLine line =
-            let marker = Text.replicate level "#"
-                prefix = md (headingPrefixStyle level) (marker <> " ")
-            in (prefix <> styleInline title) : go rest
+            -- Hide the markdown `#` markers (grok pretty mode); color the title.
+            md (headingPrefixStyle level) (styleInline title) : go rest
         | Just item <- unorderedItem line =
             ( md listMarkerStyle "• "
                 <> styleInline item
@@ -90,12 +89,10 @@ renderBlocks = go
         | Text.null (Text.strip line) = line : go rest
         | otherwise = styleInline line : go rest
 
--- | Heading marker style: bold + underline + level color.
+-- | Heading title style: bold + level color. Markdown `#` markers are hidden.
 headingPrefixStyle :: Int -> [SGR]
 headingPrefixStyle level =
-    SetConsoleIntensity BoldIntensity
-        : SetUnderlining SingleUnderline
-        : headingColor level
+    SetConsoleIntensity BoldIntensity : headingColor level
 
 headingColor :: Int -> [SGR]
 headingColor = \case

--- a/packages/agent-cli/src/Agent/CLI/Render.hs
+++ b/packages/agent-cli/src/Agent/CLI/Render.hs
@@ -42,9 +42,11 @@ import Agent.CLI.Style
     , roleSuccess
     , roleThinking
     , roleToolArrow
+    , roleToolCommand
     , roleToolDetail
     , roleToolName
     , roleToolOutput
+    , roleToolPath
     , solarizedGreen
     , solarizedRed
     , spinnerFrames
@@ -126,7 +128,7 @@ renderEventUnlocked config = \case
         writeIORef config.renderLiveActive False
         writeIORef config.renderReasoningBuffer ""
         writeIORef config.renderReasoningLive False
-        writeIORef config.renderActivityRef "thinking…"
+        writeIORef config.renderActivityRef "Thinking…"
         now <- getCurrentTime
         writeIORef config.renderStartedAt (Just now)
         startThinkingSpinnerUnlocked config
@@ -442,7 +444,9 @@ formatThinkingBlock color streaming elapsed raw =
             if streaming
                 then roleThinking color (glyphThink <> "Thinking…")
                     <> roleMuted color ("  " <> formatElapsed elapsed)
-                else roleThinking color (glyphThink <> "Thought for " <> formatElapsed elapsed)
+                else
+                    roleThinking color (glyphThink <> "Thought")
+                        <> roleMuted color (" for " <> formatElapsed elapsed)
         wrapped = wrapThinkingLines thinkingMaxWidth (Text.strip raw)
         preview
             | streaming = take thinkingPreviewLines wrapped
@@ -535,18 +539,80 @@ putTextLn handle text = do
 
 summarizeToolCall :: ToolCall -> Text
 summarizeToolCall call =
-    let detail = toolDetail call
-    in if Text.null detail then call.name else call.name <> " " <> detail
+    let verb = toolVerb call.name
+        detail = toolDetail call
+    in if Text.null detail then verb else verb <> " " <> detail
 
 -- | Colored tool-start line for stderr chrome.
+--
+-- Known coding tools use English verbs (Read / Listed / $) instead of
+-- wire names, matching grok-build's linear chrome while staying Solarized.
 formatToolStarted :: Bool -> ToolCall -> Text
 formatToolStarted color call =
-    let detail = toolDetail call
-        arrow = roleToolArrow color glyphTool
-        name = roleToolName color call.name
-    in if Text.null detail
-        then arrow <> name
-        else arrow <> name <> " " <> roleToolDetail color detail
+    let arrow = roleToolArrow color glyphTool
+        detail = toolDetail call
+    in case toolChrome call.name of
+        ToolChromeShell ->
+            let prompt = roleMuted color "$ "
+                command =
+                    if Text.null detail
+                        then roleMuted color "…"
+                        else roleToolCommand color detail
+            in arrow <> prompt <> command
+        ToolChrome verb kind ->
+            let name = roleToolName color verb
+                paintedDetail = case kind of
+                    ToolDetailNone -> ""
+                    ToolDetailMuted
+                        | Text.null detail -> ""
+                        | otherwise -> " " <> roleToolDetail color detail
+                    ToolDetailPath
+                        | Text.null detail -> ""
+                        | otherwise -> " " <> roleToolPath color detail
+                    ToolDetailCommand
+                        | Text.null detail -> ""
+                        | otherwise -> " " <> roleToolCommand color detail
+            in arrow <> name <> paintedDetail
+
+data ToolChrome
+    = ToolChromeShell
+    | ToolChrome Text ToolDetailKind
+
+data ToolDetailKind
+    = ToolDetailNone
+    | ToolDetailMuted
+    | ToolDetailPath
+    | ToolDetailCommand
+
+toolChrome :: Text -> ToolChrome
+toolChrome = \case
+    "read_file" -> ToolChrome "Read" ToolDetailPath
+    "list_dir" -> ToolChrome "Listed" ToolDetailPath
+    "grep" -> ToolChrome "Searched" ToolDetailMuted
+    "search_replace" -> ToolChrome "Edited" ToolDetailPath
+    "apply_patch" -> ToolChrome "Edited" ToolDetailPath
+    "run_terminal_cmd" -> ToolChromeShell
+    "shell_command" -> ToolChromeShell
+    "run_ghci" -> ToolChromeShell
+    "get_task_output" -> ToolChrome "Read" ToolDetailMuted
+    "kill_task" -> ToolChrome "Killed" ToolDetailMuted
+    "task" -> ToolChrome "Ran" ToolDetailMuted
+    "spawn_agent" -> ToolChrome "Spawned" ToolDetailMuted
+    "wait_agent" -> ToolChrome "Waited" ToolDetailMuted
+    "send_message" -> ToolChrome "Sent" ToolDetailMuted
+    "followup_task" -> ToolChrome "Followed up" ToolDetailMuted
+    "list_agents" -> ToolChrome "Listed" ToolDetailMuted
+    "interrupt_agent" -> ToolChrome "Interrupted" ToolDetailMuted
+    "update_plan" -> ToolChrome "Updated" ToolDetailMuted
+    "enter_plan_mode" -> ToolChrome "Entered" ToolDetailMuted
+    "exit_plan_mode" -> ToolChrome "Exited" ToolDetailMuted
+    "ask_user_question" -> ToolChrome "Asked" ToolDetailMuted
+    name -> ToolChrome name ToolDetailMuted
+
+toolVerb :: Text -> Text
+toolVerb name = case toolChrome name of
+    ToolChromeShell -> "$"
+    ToolChrome verb _ -> verb
 
 formatToolBody :: Bool -> ToolCall -> Text
 formatToolBody color call = case call.name of
@@ -560,8 +626,10 @@ formatSearchReplaceDiff color arguments =
         oldText = jsonTextFieldDefault "old_string" arguments
         newText = jsonTextFieldDefault "new_string" arguments
         header = case (Text.null oldText, Text.null newText) of
-            (True, False) -> roleMuted color ("  create " <> path)
-            (False, True) -> roleMuted color ("  delete " <> path)
+            (True, False) ->
+                roleMuted color "  create " <> roleToolPath color path
+            (False, True) ->
+                roleMuted color "  delete " <> roleToolPath color path
             _ -> ""
         oldLines = Text.lines oldText
         newLines = Text.lines newText

--- a/packages/agent-cli/src/Agent/CLI/Style.hs
+++ b/packages/agent-cli/src/Agent/CLI/Style.hs
@@ -15,6 +15,8 @@ module Agent.CLI.Style
     , roleToolArrow
     , roleToolName
     , roleToolDetail
+    , roleToolPath
+    , roleToolCommand
     , roleToolOutput
     , roleThinking
     , roleError
@@ -171,6 +173,14 @@ roleToolName color =
 roleToolDetail :: Bool -> Text -> Text
 roleToolDetail color = style color [fg solarizedBase01]
 
+-- | File paths on tool rows (Solarized orange).
+roleToolPath :: Bool -> Text -> Text
+roleToolPath color = style color [fg solarizedOrange]
+
+-- | Shell / GHCi command text on tool rows (Solarized yellow).
+roleToolCommand :: Bool -> Text -> Text
+roleToolCommand color = style color [fg solarizedYellow]
+
 roleToolOutput :: Bool -> Text -> Text
 roleToolOutput color = style color [fg solarizedBase01]
 
@@ -231,7 +241,7 @@ glyphErr = pickGlyph "✗ " "x "
 glyphWarn = pickGlyph "⚠ " "! "
 glyphCancel = pickGlyph "⊘ " "o "
 glyphSession = pickGlyph "⧉ " "# "
-glyphThink = pickGlyph "◌ " ". "
+glyphThink = pickGlyph "◆ " "* "
 
 spinnerFrames :: [Text]
 spinnerFrames

--- a/packages/agent-cli/test/Agent/CLI/MarkdownSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/MarkdownSpec.hs
@@ -45,12 +45,14 @@ spec = do
             out `shouldSatisfy` Text.isInfixOf "body"
             out `shouldSatisfy` (not . Text.isInfixOf "~~~")
 
-        it "colors heading markers by level" do
+        it "hides heading markers and colors titles by level" do
             let h1 = renderMarkdown True "# Title"
                 h2 = renderMarkdown True "## Title"
             h1 `shouldSatisfy` Text.isInfixOf "Title"
             h1 `shouldSatisfy` Text.isInfixOf "\ESC["
+            h1 `shouldSatisfy` (not . Text.isInfixOf "# Title")
             h2 `shouldSatisfy` Text.isInfixOf "Title"
+            h2 `shouldSatisfy` (not . Text.isInfixOf "## Title")
             h1 `shouldSatisfy` (/= h2)
 
         it "colors unordered and ordered list markers" do

--- a/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
@@ -21,20 +21,24 @@ import Test.Hspec
 spec :: Spec
 spec = do
     describe "summarizeToolCall" do
-        it "includes JSON argument highlights" do
+        it "uses English verbs and argument highlights" do
             summarizeToolCall (functionToolCall "c1" "read_file" "{\"target_file\":\"src/A.hs\"}")
-                `shouldBe` "read_file src/A.hs"
+                `shouldBe` "Read src/A.hs"
             summarizeToolCall (functionToolCall "c2" "shell_command" "{\"command\":\"ls -l\"}")
-                `shouldBe` "shell_command ls -l"
+                `shouldBe` "$ ls -l"
             summarizeToolCall (functionToolCall "c3" "run_terminal_cmd" "{\"command\":\"git status\"}")
-                `shouldBe` "run_terminal_cmd git status"
+                `shouldBe` "$ git status"
             summarizeToolCall (functionToolCall "c3b" "run_ghci" "{\"expression\":\"1 + 1\"}")
-                `shouldBe` "run_ghci 1 + 1"
+                `shouldBe` "$ 1 + 1"
+            summarizeToolCall (functionToolCall "c3c" "list_dir" "{\"target_directory\":\"packages\"}")
+                `shouldBe` "Listed packages"
+            summarizeToolCall (functionToolCall "c3d" "grep" "{\"pattern\":\"foo\"}")
+                `shouldBe` "Searched foo"
 
         it "pulls the first path out of an apply_patch body" do
             let patch = "*** Begin Patch\n*** Update File: src/Foo.hs\n@@\n-a\n+b\n*** End Patch"
             summarizeToolCall (customToolCall "c4" "apply_patch" patch)
-                `shouldBe` "apply_patch src/Foo.hs"
+                `shouldBe` "Edited src/Foo.hs"
 
     describe "truncateToolOutput" do
         it "keeps the first line and marks empty output" do
@@ -55,8 +59,21 @@ spec = do
 
     describe "formatActivityLine" do
         it "joins spinner, activity, and elapsed" do
-            formatActivityLine False "⠋" "thinking…" 1.2
-                `shouldBe` "⠋ thinking…  1.2s"
+            formatActivityLine False "⠋" "Thinking…" 1.2
+                `shouldBe` "⠋ Thinking…  1.2s"
+
+    describe "formatToolStarted" do
+        it "renders English verbs for known tools" do
+            formatToolStarted False (functionToolCall "c1" "read_file" "{\"target_file\":\"src/A.hs\"}")
+                `shouldBe` "◆ Read src/A.hs"
+            formatToolStarted False (functionToolCall "c2" "run_terminal_cmd" "{\"command\":\"git status\"}")
+                `shouldBe` "◆ $ git status"
+            formatToolStarted False (functionToolCall "c3" "search_replace" "{\"file_path\":\"src/A.hs\"}")
+                `shouldBe` "◆ Edited src/A.hs"
+
+        it "keeps unknown tool names" do
+            formatToolStarted False (functionToolCall "c4" "custom_tool" "{\"x\":1}")
+                `shouldBe` "◆ custom_tool"
 
     describe "formatSearchReplaceDiff" do
         it "renders a compact unified diff" do
@@ -103,7 +120,7 @@ spec = do
                 let lines_ = filter (not . Text.null) (Text.lines body)
                 length lines_ `shouldBe` 80
                 lines_ `shouldMatchList`
-                    [ "◆ list_dir packages/agent-" <> Text.pack (show i)
+                    [ "◆ Listed packages/agent-" <> Text.pack (show i)
                     | i <- [1 :: Int .. 80]
                     ]
 
@@ -116,11 +133,11 @@ spec = do
                 visibleAfter <- readIORef config.renderThinkingVisible
                 visibleAfter `shouldBe` True
                 activity <- readIORef config.renderActivityRef
-                activity `shouldBe` "list_dir ."
+                activity `shouldBe` "Listed ."
                 hClose handle
                 body <- Text.readFile path
-                body `shouldSatisfy` (Text.isInfixOf "thinking…")
-                body `shouldSatisfy` ("◆ list_dir ." `Text.isInfixOf`)
+                body `shouldSatisfy` (Text.isInfixOf "Thinking…")
+                body `shouldSatisfy` ("◆ Listed ." `Text.isInfixOf`)
 
         it "streams reasoning summaries as a thinking block" do
             withRenderConfig True False \config handle path -> do
@@ -149,7 +166,7 @@ spec = do
                 hClose handle
                 body <- Text.readFile path
                 let thoughtIdx = Text.length (fst (Text.breakOn "Thought for" body))
-                    toolIdx = Text.length (fst (Text.breakOn "list_dir" body))
+                    toolIdx = Text.length (fst (Text.breakOn "Listed" body))
                 thoughtIdx `shouldSatisfy` (< toolIdx)
                 body `shouldSatisfy` (Text.isInfixOf "look at src")
 
@@ -246,7 +263,7 @@ spec = do
                     })
                 hClose handle
                 body <- Text.readFile path
-                body `shouldSatisfy` Text.isInfixOf "list_dir"
+                body `shouldSatisfy` Text.isInfixOf "Listed"
                 body `shouldSatisfy` Text.isInfixOf "\ESC["
                 body `shouldSatisfy` Text.isInfixOf "ok"
 
@@ -255,7 +272,7 @@ spec = do
                 renderEvent config TurnStarted
                 hClose handle
                 body <- Text.readFile path
-                body `shouldSatisfy` (Text.isInfixOf "thinking…")
+                body `shouldSatisfy` (Text.isInfixOf "Thinking…")
                 body `shouldSatisfy` (not . Text.isInfixOf "\ESC]9;4;")
 
         it "emits Ghostty OSC 9;4 while thinking and clears it after" do
@@ -327,7 +344,7 @@ withRenderConfigNative showThinking color native action = do
     reasoningBuffer <- newIORef ""
     reasoningLive <- newIORef False
     modelRef <- newIORef "test-model"
-    activityRef <- newIORef "thinking…"
+    activityRef <- newIORef "Thinking…"
     startedAt <- newIORef Nothing
     textBuffer <- newIORef ""
     liveActive <- newIORef False

--- a/packages/agent-cli/test/Agent/CLI/StyleSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/StyleSpec.hs
@@ -33,7 +33,9 @@ spec = do
 
     describe "roles" do
         it "keeps tool labels readable with color off" do
-            roleToolName False "read_file" `shouldBe` "read_file"
+            roleToolName False "Read" `shouldBe` "Read"
+            roleToolPath False "src/A.hs" `shouldBe` "src/A.hs"
+            roleToolCommand False "git status" `shouldBe` "git status"
             roleError False "boom" `shouldBe` "boom"
             roleMuted False "session: 1" `shouldBe` "session: 1"
 
@@ -52,7 +54,7 @@ spec = do
             glyphWarn `shouldSatisfy` (`elem` ["⚠ ", "! "])
             glyphCancel `shouldSatisfy` (`elem` ["⊘ ", "o "])
             glyphSession `shouldSatisfy` (`elem` ["⧉ ", "# "])
-            glyphThink `shouldSatisfy` (`elem` ["◌ ", ". "])
+            glyphThink `shouldSatisfy` (`elem` ["◆ ", "* "])
             glyphToolOut `shouldSatisfy` (`elem` ["┊ ", "| "])
             spinnerFrames `shouldSatisfy` (not . null)
 


### PR DESCRIPTION
## Summary
- Keep Solarized Dark and the `λ` prompt. Steal grok-build *structure and copy*, not its palette.
- Tool start lines use English verbs (`Read`, `Listed`, `Searched`, `Edited`) instead of wire names; shells render as `$ command`. Paths use Solarized orange, commands yellow.
- Thinking chrome shares the diamond bullet (`◆ Thinking…` / `◆ Thought for 1.2s`); the committed duration stays muted.
- Color-mode markdown hides heading `#` markers (pretty headings) while keeping Solarized heading colors.

## Test plan
- [x] `GHCRTS= cabal test agent-cli:test:agent-cli-test` — 231 examples, 0 failures
- [x] tmux one-shot smoke: `list_dir` painted as `◆ Listed packages/agent-cli/src/Agent/CLI` with truncated output and Solarized chrome
- [ ] Interactive REPL glance: idle `λ` prompt unchanged; a `read_file` / `run_terminal_cmd` turn shows `◆ Read path` and `◆ $ command`