### PR TITLE
feat: enable default language extensions in run_ghci

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Prompt.hs
+++ b/packages/agent-cli/src/Agent/CLI/Prompt.hs
@@ -35,6 +35,7 @@ ghciGuidance =
         [ "Prefer ghci for scripting."
         , "When you need a short program, calculation, or one-off script, use the run_ghci tool rather than Python, Node, bash, or compiling a binary."
         , "run_ghci keeps a persistent GHCi session: bindings and loaded modules stick across calls."
+        , "The session enables GHC2021 plus BlockArguments, OverloadedStrings, OverloadedRecordDot, DuplicateRecordFields, NoFieldSelectors, LambdaCase, and RecordWildCards."
         , "Pure expressions do not need user approval; IO and side-effecting GHCi commands do."
         , "Prefer shell tools (run_terminal_cmd or shell_command) for OS commands, package installs, servers, and anything that is not Haskell evaluation."
         , "Drive GHCi with complete expressions; do not expect interactive human input."

--- a/packages/agent-cli/test/Agent/CLI/PromptSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/PromptSpec.hs
@@ -52,6 +52,8 @@ spec = describe "systemPrompt" do
         openai `shouldSatisfy` Text.isInfixOf "Python, Node, bash"
         grok `shouldSatisfy` Text.isInfixOf "run_ghci"
         openai `shouldSatisfy` Text.isInfixOf "run_ghci"
+        grok `shouldSatisfy` Text.isInfixOf "OverloadedStrings"
+        openai `shouldSatisfy` Text.isInfixOf "LambdaCase"
         grok `shouldSatisfy` Text.isInfixOf "Pure expressions do not need user approval"
 
     it "picks the documented default models" do

--- a/packages/agent-core/src/Agent/Tools/Ghci.hs
+++ b/packages/agent-core/src/Agent/Tools/Ghci.hs
@@ -13,6 +13,7 @@ module Agent.Tools.Ghci
     , classifyGhciInput
     , typeLooksEffectful
     , runGhciTool
+    , defaultGhciExtensions
     ) where
 
 import Agent.ToolArgs
@@ -331,9 +332,30 @@ restartProcess session =
         mapM_ shutdownProcess current
         Just <$> spawnProcess session.ghciEnv
 
+-- | Extra @-X@ flags on top of GHC2021. Matches @agent-cli@ / @agent-core@
+-- @default-extensions@ so snippets the model writes (@"hello"@, @\\case@,
+-- @do@ after @id@, @person.name@) work without LANGUAGE pragmas.
+--
+-- GHC2021 already includes NamedFieldPuns, TypeApplications, and
+-- ScopedTypeVariables. NoFieldSelectors is set explicitly because GHC2021
+-- turns FieldSelectors on.
+defaultGhciExtensions :: [String]
+defaultGhciExtensions =
+    [ "BlockArguments"
+    , "OverloadedStrings"
+    , "OverloadedRecordDot"
+    , "DuplicateRecordFields"
+    , "NoFieldSelectors"
+    , "LambdaCase"
+    , "RecordWildCards"
+    ]
+
+ghciArgs :: [String]
+ghciArgs = "-v0" : "-XGHC2021" : map ("-X" <>) defaultGhciExtensions
+
 spawnProcess :: ToolEnv -> IO GhciProcess
 spawnProcess env = do
-    let spec = (proc "ghci" ["-v0"])
+    let spec = (proc "ghci" ghciArgs)
             { cwd = Just env.toolCwd
             , std_in = CreatePipe
             , std_out = CreatePipe
@@ -466,7 +488,10 @@ ghciDescription =
     "Evaluate Haskell in a persistent GHCi session for this agent.\n\
     \Bindings and loaded modules persist across calls.\n\
     \Pure expressions auto-approve; IO and side-effecting GHCi commands need approval.\n\
-    \Prefer this over shell tools for calculations, type exploration, and small Haskell scripts."
+    \Prefer this over shell tools for calculations, type exploration, and small Haskell scripts.\n\
+    \The session starts with GHC2021 plus BlockArguments, OverloadedStrings, \
+    \OverloadedRecordDot, DuplicateRecordFields, NoFieldSelectors, LambdaCase, \
+    \and RecordWildCards — LANGUAGE pragmas are not required for those."
 
 isGhciReadOnlyCall :: GhciSession -> ToolCall -> IO Bool
 isGhciReadOnlyCall session call =

--- a/packages/agent-core/test/Agent/Tools/GhciSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/GhciSpec.hs
@@ -13,6 +13,7 @@ import Agent.Tools.Ghci
     , classifyGhci
     , classifyGhciInput
     , closeGhciSession
+    , defaultGhciExtensions
     , evalGhci
     , newGhciSession
     , typeLooksEffectful
@@ -46,6 +47,19 @@ spec = describe "Agent.Tools.Ghci" do
             typeLooksEffectful "id :: a -> a" `shouldBe` False
             typeLooksEffectful "getLine :: IO String" `shouldBe` True
 
+    describe "defaultGhciExtensions" do
+        it "covers the extra extensions this repo enables on top of GHC2021" do
+            defaultGhciExtensions
+                `shouldBe`
+                    [ "BlockArguments"
+                    , "OverloadedStrings"
+                    , "OverloadedRecordDot"
+                    , "DuplicateRecordFields"
+                    , "NoFieldSelectors"
+                    , "LambdaCase"
+                    , "RecordWildCards"
+                    ]
+
     it "persists bindings across evalGhci calls" do
         withTempGhci \ghci -> do
             bind <- evalGhci ghci "let x = 41 + 1" 10000
@@ -54,6 +68,20 @@ spec = describe "Agent.Tools.Ghci" do
             value <- evalGhci ghci "x" 10000
             value.ghciOk `shouldBe` True
             value.ghciOutput `shouldSatisfy` Text.isInfixOf "42"
+
+    it "evaluates OverloadedStrings and LambdaCase without LANGUAGE pragmas" do
+        withTempGhci \ghci -> do
+            str <- evalGhci ghci "\"hello\"" 10000
+            str.ghciOk `shouldBe` True
+            str.ghciOutput `shouldSatisfy` Text.isInfixOf "hello"
+            lam <- evalGhci ghci "(\\case 1 -> True; _ -> False) 1" 10000
+            lam.ghciOk `shouldBe` True
+            lam.ghciOutput `shouldSatisfy` Text.isInfixOf "True"
+            shown <- evalGhci ghci ":show language" 10000
+            shown.ghciOk `shouldBe` True
+            mapM_
+                (\ext -> shown.ghciOutput `shouldSatisfy` Text.isInfixOf (Text.pack ext))
+                defaultGhciExtensions
 
     it "classifies putStrLn as effectful and 1+1 as pure" do
         withTempGhci \ghci -> do


### PR DESCRIPTION
## Summary
- Spawn the persistent `run_ghci` session with `-XGHC2021` plus the extra extensions this repo already uses: BlockArguments, OverloadedStrings, OverloadedRecordDot, DuplicateRecordFields, NoFieldSelectors, LambdaCase, RecordWildCards.
- NamedFieldPuns / TypeApplications / ScopedTypeVariables stay implicit via GHC2021.
- Document the set on the tool description and in the system prompt so the model does not emit LANGUAGE pragmas for those.

## Test plan
- [x] `GHCRTS= cabal test agent-core:test:agent-core-test --test-option='--match=Agent.Tools.Ghci'` — OverloadedStrings (`"hello"`) and LambdaCase (`\\case`) work without pragmas; `:show language` lists the extensions
- [x] `GHCRTS= cabal test agent-cli:test:agent-cli-test --test-option='--match=systemPrompt'` — prompt mentions OverloadedStrings / LambdaCase
- [ ] Optional live check: `run_ghci` `"hello"` and `(\\case 1 -> True; _ -> False) 1`