### PR TITLE
feat: pick models from all providers

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -44,6 +44,7 @@ import Agent.CLI.Interrupt
     , withTurnCancel
     )
 import Agent.CLI.ModelPicker (pickModel)
+import Agent.CLI.Models (ModelOption(..))
 import Agent.CLI.Options
 import Agent.CLI.Permission
     ( PermissionChoice(..)
@@ -216,6 +217,13 @@ data DevResult
     | DevReload
     deriving (Eq, Show)
 
+data RunResult
+    = RunQuit
+    | RunReload
+    | RunSwitchProvider Text
+      -- ^ Persisted session id. Consumed after the current provider-specific
+      -- backend shuts down.
+
 -- | GHCi @:cmd@ helper: on 'DevReload', reload modules and re-enter 'devMain'.
 afterDev :: DevResult -> IO String
 afterDev = \case
@@ -248,7 +256,7 @@ devMain = do
         Right ListSessions -> runListSessions >> pure DevQuit
         Right (ShowSession sessionId) -> runShowSession sessionId >> pure DevQuit
         Right (RunAgent options) -> do
-            result <- runAgent options
+            result <- runAgentWithProviderSwitches options
             case result of
                 DevQuit -> clearDevResumePointer home >> pure DevQuit
                 DevReload -> pure DevReload
@@ -263,13 +271,34 @@ run = do
         Right ListSessions -> runListSessions
         Right (ShowSession sessionId) -> runShowSession sessionId
         Right (RunAgent options) -> do
-            result <- runAgent options
+            result <- runAgentWithProviderSwitches options
             case result of
                 DevQuit -> pure ()
                 DevReload -> do
                     home <- getHomeDirectory
                     clearDevResumePointer home
                     die ":reload is only available under `repl` (nix develop)"
+
+-- | Tear down and rebuild the provider-specific backend when the picker moves
+-- between providers. The session metadata is updated before this result is
+-- produced, so resuming reconstructs auth, tools, prompt, and transport from
+-- the newly selected provider while keeping the local transcript.
+runAgentWithProviderSwitches :: CliOptions -> IO DevResult
+runAgentWithProviderSwitches options =
+    runAgent options >>= \case
+        RunSwitchProvider sessionId ->
+            runAgentWithProviderSwitches options
+                { optProvider = Nothing
+                , optModel = Nothing
+                , optCwd = Nothing
+                , optWorktree = False
+                , optEffort = Nothing
+                , optPrompt = Nothing
+                , optPromptFile = Nothing
+                , optResume = Just sessionId
+                }
+        RunQuit -> pure DevQuit
+        RunReload -> pure DevReload
 
 runListSessions :: IO ()
 runListSessions = do
@@ -310,7 +339,7 @@ printTurn turn = do
         _ -> pure ()
     putStrLn ""
 
-runAgent :: CliOptions -> IO DevResult
+runAgent :: CliOptions -> IO RunResult
 runAgent options = do
     home <- getHomeDirectory
     let root = sessionsRoot home
@@ -724,7 +753,7 @@ runSession
     -> SubagentStoreRoot
     -> IORef TokenUsage
     -> Backend
-    -> IO DevResult
+    -> IO RunResult
 runSession options provider policy tools toolEnv planMode prompt paramsRef transcriptRef initialPrevious persist projectRoot home cwd tokenProvider agentsContext escPaused interrupt multiCtx subagentSessions pendingNotices storeRoot usageRef backend = do
     printed <- newIORef False
     attachmentsRef <- newIORef []
@@ -824,15 +853,15 @@ runSession options provider policy tools toolEnv planMode prompt paramsRef trans
         Just text -> do
             ok <- runOneTurn env text [UserMessage text]
             if ok
-                then putTrailingNewline printed >> pure DevQuit
+                then putTrailingNewline printed >> pure RunQuit
                 else exitFailure
         Nothing ->
             repl env
 
-repl :: SessionEnv -> IO DevResult
+repl :: SessionEnv -> IO RunResult
 repl env = replWithDraft env ""
 
-replWithDraft :: SessionEnv -> Text -> IO DevResult
+replWithDraft :: SessionEnv -> Text -> IO RunResult
 replWithDraft env@SessionEnv
     { sessionLoop = config
     , sessionRender = render
@@ -895,7 +924,7 @@ replWithDraft env@SessionEnv
     case mline of
         ReplEof -> do
             putStrLn ""
-            pure DevQuit
+            pure RunQuit
         ReplQuitInterrupt ->
             -- Confirmed double Ctrl-C: rethrow so withInterruptResume prints
             -- the --resume hint and the process exits.
@@ -923,7 +952,7 @@ replWithDraft env@SessionEnv
                     when (chip /= stripped) do
                         Text.putStrLn (roleMuted color chip)
                 case parseReplLine stripped of
-                    ReplQuit -> pure DevQuit
+                    ReplQuit -> pure RunQuit
                     ReplReload -> requestReload persist
                     ReplPrompt text -> do
                         -- Native Cmd+V of a Finder image often pastes a path
@@ -1052,16 +1081,27 @@ replWithDraft env@SessionEnv
                         let current = currentModel params
                         pickModel color provider current >>= \case
                             Nothing -> continue
-                            Just name
-                                | name == current -> do
+                            Just choice
+                                | choice.modelProvider == provider
+                                , choice.modelId == current -> do
                                     Text.putStrLn
                                         (roleMuted color
-                                            (glyphSession <> "model: " <> name))
+                                            (glyphSession
+                                                <> "model: "
+                                                <> providerSlug provider
+                                                <> "/"
+                                                <> choice.modelId))
                                     continue
-                                | otherwise -> do
+                                | choice.modelProvider == provider -> do
                                     applyModelChange
-                                        provider name paramsRef render previous persist
+                                        provider choice.modelId paramsRef render previous persist
                                     continue
+                                | otherwise ->
+                                    requestModelProviderSwitch choice persist >>= \case
+                                        Left err -> do
+                                            Text.hPutStrLn stderr (roleError color err)
+                                            continue
+                                        Right result -> pure result
                     ReplSetModel name -> do
                         applyModelChange
                             provider name paramsRef render previous persist
@@ -1290,6 +1330,58 @@ applyModelChange provider name paramsRef render previous persist = do
                     writeIORef slotRef
                         (Right handle { sessionMeta = meta })
 
+requestModelProviderSwitch
+    :: ModelOption
+    -> Maybe (IORef (Either SessionCreate SessionHandle))
+    -> IO (Either Text RunResult)
+requestModelProviderSwitch choice persist = case persist of
+    Nothing -> pure $ Left
+        "switching providers requires a persisted interactive session"
+    Just slotRef ->
+        loadAuth (Just choice.modelProvider) >>= \case
+            Left err -> pure $ Left $
+                "cannot switch to "
+                    <> providerSlug choice.modelProvider
+                    <> ": "
+                    <> Text.pack err
+            Right loaded
+                | loaded.loadedProvider /= choice.modelProvider ->
+                    pure $ Left $
+                        "cannot switch to "
+                            <> providerSlug choice.modelProvider
+                            <> ": auth resolved "
+                            <> providerSlug loaded.loadedProvider
+                | otherwise -> do
+                    slot <- readIORef slotRef
+                    handle <- case slot of
+                        Left pending -> do
+                            writeIORef slotRef $ Left pending
+                                { createProvider = choice.modelProvider
+                                , createModel = choice.modelId
+                                }
+                            ensureSession slotRef
+                        Right currentHandle -> do
+                            now <- getCurrentTime
+                            let meta = currentHandle.sessionMeta
+                                    { metaProvider = choice.modelProvider
+                                    , metaModel = choice.modelId
+                                    , metaLastResponseId = Nothing
+                                    , metaUpdatedAt = now
+                                    }
+                                updated = currentHandle { sessionMeta = meta }
+                            writeSessionMeta currentHandle.sessionMetaPath meta
+                            writeIORef slotRef (Right updated)
+                            pure updated
+                    color <- resolveColor stdout
+                    Text.putStrLn $ roleMuted color $
+                        glyphOk
+                            <> "switching to "
+                            <> providerSlug choice.modelProvider
+                            <> "/"
+                            <> choice.modelId
+                            <> " (conversation continued locally)"
+                    pure $ Right (RunSwitchProvider handle.sessionMeta.metaId)
+
 reloadAuth :: Provider -> Maybe TokenProvider -> IO ()
 reloadAuth provider = \case
     Nothing -> do
@@ -1326,7 +1418,7 @@ reloadAuth provider = \case
 
 requestReload
     :: Maybe (IORef (Either SessionCreate SessionHandle))
-    -> IO DevResult
+    -> IO RunResult
 requestReload persist = do
     home <- getHomeDirectory
     color <- resolveColor stderr
@@ -1334,14 +1426,14 @@ requestReload persist = do
         Nothing -> do
             putTextLn stderr
                 (roleError color ":reload needs a persisted REPL session")
-            pure DevQuit
+            pure RunQuit
         Just slotRef -> do
             handle <- ensureSession slotRef
             writeDevResumePointer home handle.sessionMeta.metaId
             putTextLn stderr
                 (roleMuted color
                     (glyphSession <> "reloading; session " <> handle.sessionMeta.metaId))
-            pure DevReload
+            pure RunReload
 
 enterPlanFromSlash :: SessionEnv -> Maybe Text -> IO ()
 enterPlanFromSlash env@SessionEnv{sessionPlanMode = planMode, sessionPersist = persist, sessionPrinted = printed} maybeDescription = do

--- a/packages/agent-cli/src/Agent/CLI/Auth.hs
+++ b/packages/agent-cli/src/Agent/CLI/Auth.hs
@@ -7,7 +7,7 @@ module Agent.CLI.Auth
     , reloadableFileCredentialProvider
     ) where
 
-import Agent.Broker (BrokerOptions(..), newBrokerTokenProvider)
+import Agent.Broker (BrokerOptions(..), newBrokerTokenProviderFor)
 import Agent.Error (ApiError(..), ErrorType(..))
 import qualified Agent.OpenAI.Auth as OpenAI
 import qualified Agent.OpenAI.Credential as OpenAICredential
@@ -77,10 +77,15 @@ loadBroker url requested = do
     case token of
         Nothing -> pure (Left "AGENT_BROKER_URL is set; also set AGENT_BROKER_TOKEN")
         Just serviceToken -> do
-            provider <- newBrokerTokenProvider BrokerOptions
-                { baseUrl = Text.unpack url
-                , serviceToken
-                }
+            let supportedProviders = case requested of
+                    Just selected -> [selected]
+                    Nothing -> [OpenAIProvider, XAIProvider, OpenRouterProvider]
+            provider <- newBrokerTokenProviderFor
+                BrokerOptions
+                    { baseUrl = Text.unpack url
+                    , serviceToken
+                    }
+                supportedProviders
             first <- getNextToken provider Nothing
             case first of
                 Left err -> pure (Left ("broker: " <> show err))

--- a/packages/agent-cli/src/Agent/CLI/ModelPicker.hs
+++ b/packages/agent-cli/src/Agent/CLI/ModelPicker.hs
@@ -37,8 +37,9 @@ toEvent = \case
     PickerKeyChar c -> PickerType c
 
 -- | Open the picker when stdin is a TTY; otherwise print the catalog.
--- Returns @Just name@ on confirm, @Nothing@ on cancel / EOF / non-TTY.
-pickModel :: Bool -> Provider -> Text -> IO (Maybe Text)
+-- Returns the provider/model choice on confirm and @Nothing@ on cancel, EOF,
+-- or non-TTY input.
+pickModel :: Bool -> Provider -> Text -> IO (Maybe ModelOption)
 pickModel color provider current = do
     isTty <- hIsTerminalDevice stdin
     if not isTty
@@ -60,16 +61,19 @@ formatCatalogListing color provider current =
             roleMuted color
                 (glyphSessionLike
                     <> "model: "
+                    <> providerSlug provider
+                    <> "/"
                     <> current
-                    <> " · "
-                    <> providerSlug provider)
+                    <> " · all providers")
         rows =
             map
                 (\opt ->
                     let mark
-                            | opt.modelId == current =
-                                roleSuccess color (glyphOk <> opt.modelId)
-                            | otherwise = roleMuted color ("  " <> opt.modelId)
+                            | isCurrent provider current opt =
+                                roleSuccess color
+                                    (glyphOk <> formatOptionName opt)
+                            | otherwise =
+                                roleMuted color ("  " <> formatOptionName opt)
                         label = case opt.modelLabel of
                             Nothing -> ""
                             Just l -> roleMuted color ("  " <> l)
@@ -86,9 +90,9 @@ renderPickerFrame color state =
         header =
             rolePrompt color "model"
                 <> roleMuted color
-                    (" · "
+                    (" · all providers · current "
                         <> providerSlug state.pickerProvider
-                        <> " · current "
+                        <> "/"
                         <> state.pickerCurrent)
         filterLine
             | Text.null state.pickerFilter =
@@ -100,21 +104,22 @@ renderPickerFrame color state =
             [] -> [roleMuted color "(no matches)"]
             opts ->
                 zipWith
-                    (\i opt -> renderRow color (i == idx) state.pickerCurrent opt)
+                    (\i opt -> renderRow color (i == idx)
+                        state.pickerProvider state.pickerCurrent opt)
                     [0 ..]
                     opts
         footer =
             roleMuted color "↑↓/jk · enter · esc/q · type to filter"
     in Text.intercalate "\n" (header : filterLine : body <> [footer])
 
-renderRow :: Bool -> Bool -> Text -> ModelOption -> Text
-renderRow color selected current opt =
+renderRow :: Bool -> Bool -> Provider -> Text -> ModelOption -> Text
+renderRow color selected currentProvider current opt =
     let cursor = if selected then roleWarn color "› " else "  "
         name
-            | selected = roleSuccess color opt.modelId
-            | otherwise = roleMuted color opt.modelId
+            | selected = roleSuccess color (formatOptionName opt)
+            | otherwise = roleMuted color (formatOptionName opt)
         currentMark
-            | opt.modelId == current = roleSuccess color " ✓"
+            | isCurrent currentProvider current opt = roleSuccess color " ✓"
             | otherwise = ""
         label = case opt.modelLabel of
             Nothing -> ""
@@ -124,3 +129,10 @@ renderRow color selected current opt =
 -- Matches Style.glyphSession without pulling unicode env probing here.
 glyphSessionLike :: Text
 glyphSessionLike = "⧉ "
+
+formatOptionName :: ModelOption -> Text
+formatOptionName opt = providerSlug opt.modelProvider <> " · " <> opt.modelId
+
+isCurrent :: Provider -> Text -> ModelOption -> Bool
+isCurrent provider current opt =
+    opt.modelProvider == provider && opt.modelId == current

--- a/packages/agent-cli/src/Agent/CLI/Models.hs
+++ b/packages/agent-cli/src/Agent/CLI/Models.hs
@@ -4,6 +4,7 @@ module Agent.CLI.Models
     , PickerState(..)
     , PickerEvent(..)
     , modelsForProvider
+    , modelCatalog
     , catalogModelIds
     , ensureCurrentInList
     , initialPickerState
@@ -13,14 +14,15 @@ module Agent.CLI.Models
     ) where
 
 import Agent.CLI.Prompt (defaultModelFor)
-import Agent.Provider (Provider(..))
+import Agent.Provider (Provider(..), providerSlug)
 import Data.List (find, nub)
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
 
 data ModelOption = ModelOption
-    { modelId :: !Text
+    { modelProvider :: !Provider
+    , modelId :: !Text
     , modelLabel :: !(Maybe Text)
     }
     deriving (Eq, Show)
@@ -66,33 +68,47 @@ modelsForProvider provider =
                 ]
         -- Keep the provider default first even if the table drifts.
         def = defaultModelFor provider
-    in ensureCurrentInList def opts
+    in ensureCurrentInList provider def opts
   where
-    opt mid label = ModelOption { modelId = mid, modelLabel = label }
+    opt mid label = ModelOption
+        { modelProvider = provider
+        , modelId = mid
+        , modelLabel = label
+        }
+
+allProviders :: [Provider]
+allProviders = [OpenAIProvider, XAIProvider, OpenRouterProvider]
+
+-- | Every curated model, grouped by provider.
+modelCatalog :: [ModelOption]
+modelCatalog = concatMap modelsForProvider allProviders
 
 -- | Every curated catalog id across providers, de-duplicated, for completion.
 catalogModelIds :: [Text]
 catalogModelIds =
-    nub $
-        concatMap
-            (map (\opt -> opt.modelId) . modelsForProvider)
-            [XAIProvider, OpenAIProvider, OpenRouterProvider]
+    nub (map (\opt -> opt.modelId) modelCatalog)
 
 -- | Prepend @current@ when it is missing so the active model stays visible.
-ensureCurrentInList :: Text -> [ModelOption] -> [ModelOption]
-ensureCurrentInList current options
+ensureCurrentInList :: Provider -> Text -> [ModelOption] -> [ModelOption]
+ensureCurrentInList provider current options
     | Text.null current || current == "(unset)" = options
-    | any (\opt -> opt.modelId == current) options = options
+    | any (isCurrent provider current) options = options
     | otherwise =
-        ModelOption { modelId = current, modelLabel = Just "current" }
+        ModelOption
+            { modelProvider = provider
+            , modelId = current
+            , modelLabel = Just "current"
+            }
             : options
 
 initialPickerState :: Provider -> Text -> PickerState
 initialPickerState provider current =
-    let allOpts = ensureCurrentInList current (modelsForProvider provider)
+    let providerOrder = provider : filter (/= provider) allProviders
+        allOpts = ensureCurrentInList provider current
+            (concatMap modelsForProvider providerOrder)
         idx = fromMaybe 0 $
             fmap fst $
-                find (\(_, opt) -> opt.modelId == current) (zip [0 ..] allOpts)
+                find (\(_, opt) -> isCurrent provider current opt) (zip [0 ..] allOpts)
     in PickerState
         { pickerProvider = provider
         , pickerCurrent = current
@@ -107,6 +123,7 @@ visibleOptions state
     | otherwise =
         filter
             (\opt -> needle `Text.isInfixOf` Text.toLower opt.modelId
+                || needle `Text.isInfixOf` Text.toLower (providerSlug opt.modelProvider)
                 || maybe
                     False
                     ((needle `Text.isInfixOf`) . Text.toLower)
@@ -123,10 +140,10 @@ selectedOption state =
             let i = clampIndex (length opts) state.pickerIndex
             in Just (opts !! i)
 
-applyPickerEvent :: PickerEvent -> PickerState -> Either (Maybe Text) PickerState
+applyPickerEvent :: PickerEvent -> PickerState -> Either (Maybe ModelOption) PickerState
 applyPickerEvent event state = case event of
     PickerCancel -> Left Nothing
-    PickerConfirm -> Left ((.modelId) <$> selectedOption state)
+    PickerConfirm -> Left (selectedOption state)
     PickerUp -> Right (move (-1) state)
     PickerDown -> Right (move 1 state)
     PickerBackspace ->
@@ -170,3 +187,7 @@ isFilterChar c =
         || (c >= 'a' && c <= 'z')
         || (c >= 'A' && c <= 'Z')
         || (c >= '0' && c <= '9')
+
+isCurrent :: Provider -> Text -> ModelOption -> Bool
+isCurrent provider current option =
+    option.modelProvider == provider && option.modelId == current

--- a/packages/agent-cli/test/Agent/CLI/ModelPickerSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ModelPickerSpec.hs
@@ -27,20 +27,24 @@ spec = do
             decodePickerKey "g" `shouldBe` Just (PickerType 'g')
 
     describe "renderPickerFrame" do
-        it "mentions provider, current model, and controls" do
+        it "mentions all providers, current model, and controls" do
             let frame =
                     renderPickerFrame False $
                         initialPickerState XAIProvider (defaultModelFor XAIProvider)
             frame `shouldSatisfy` Text.isInfixOf "xai"
+            frame `shouldSatisfy` Text.isInfixOf "openai"
+            frame `shouldSatisfy` Text.isInfixOf "openrouter"
             frame `shouldSatisfy` Text.isInfixOf (defaultModelFor XAIProvider)
             frame `shouldSatisfy` Text.isInfixOf "enter"
             frame `shouldSatisfy` Text.isInfixOf "filter"
 
     describe "formatCatalogListing" do
-        it "lists the current model and catalog entries" do
+        it "lists the current model and entries from every provider" do
             let listing =
                     formatCatalogListing False OpenAIProvider "gpt-5.6-luna"
             listing `shouldSatisfy` Text.isInfixOf "gpt-5.6-luna"
             listing `shouldSatisfy` Text.isInfixOf "gpt-5.6-terra"
             listing `shouldSatisfy` Text.isInfixOf "gpt-5.6-sol"
             listing `shouldSatisfy` Text.isInfixOf "openai"
+            listing `shouldSatisfy` Text.isInfixOf "grok-4.6"
+            listing `shouldSatisfy` Text.isInfixOf "openrouter"

--- a/packages/agent-cli/test/Agent/CLI/ModelsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ModelsSpec.hs
@@ -3,6 +3,7 @@ module Agent.CLI.ModelsSpec (spec) where
 import Agent.CLI.Models
 import Agent.CLI.Prompt (defaultModelFor)
 import Agent.Provider (Provider(..))
+import Data.List (nub)
 import Data.Maybe (listToMaybe)
 import qualified Data.Text as Text
 import Test.Hspec
@@ -30,29 +31,48 @@ spec = do
             length (modelsForProvider OpenAIProvider) `shouldSatisfy` (>= 2)
             length (modelsForProvider OpenRouterProvider) `shouldSatisfy` (>= 2)
 
+        it "tags every option with its provider" do
+            all ((== OpenAIProvider) . (.modelProvider))
+                (modelsForProvider OpenAIProvider)
+                `shouldBe` True
+
+    describe "modelCatalog" do
+        it "includes every provider" do
+            nub (map (.modelProvider) modelCatalog)
+                `shouldMatchList`
+                    [OpenAIProvider, XAIProvider, OpenRouterProvider]
+
     describe "ensureCurrentInList" do
         it "prepends an unknown current model" do
             let base = modelsForProvider XAIProvider
-                opts = ensureCurrentInList "custom-model" base
+                opts = ensureCurrentInList XAIProvider "custom-model" base
             firstId opts `shouldBe` Just "custom-model"
             fmap (.modelLabel) (listToMaybe opts) `shouldBe` Just (Just "current")
+            fmap (.modelProvider) (listToMaybe opts) `shouldBe` Just XAIProvider
 
         it "does not duplicate a known current model" do
             let base = modelsForProvider XAIProvider
                 def = defaultModelFor XAIProvider
-                opts = ensureCurrentInList def base
+                opts = ensureCurrentInList XAIProvider def base
             length (filter (\opt -> opt.modelId == def) opts) `shouldBe` 1
 
         it "ignores unset placeholders" do
-            ensureCurrentInList "(unset)" [ModelOption "a" Nothing]
-                `shouldBe` [ModelOption "a" Nothing]
+            let option = ModelOption XAIProvider "a" Nothing
+            ensureCurrentInList XAIProvider "(unset)" [option]
+                `shouldBe` [option]
 
     describe "picker navigation" do
         let state0 = initialPickerState XAIProvider (defaultModelFor XAIProvider)
 
         it "starts on the current model" do
-            fmap (.modelId) (selectedOption state0)
-                `shouldBe` Just (defaultModelFor XAIProvider)
+            fmap (\option -> (option.modelProvider, option.modelId))
+                (selectedOption state0)
+                `shouldBe` Just (XAIProvider, defaultModelFor XAIProvider)
+
+        it "shows models from every provider" do
+            nub (map (.modelProvider) (visibleOptions state0))
+                `shouldMatchList`
+                    [OpenAIProvider, XAIProvider, OpenRouterProvider]
 
         it "moves down and wraps" do
             let n = length (visibleOptions state0)
@@ -70,7 +90,11 @@ spec = do
 
         it "confirms the selected model id" do
             applyPickerEvent PickerConfirm state0
-                `shouldBe` Left (Just (defaultModelFor XAIProvider))
+                `shouldBe` Left (Just ModelOption
+                    { modelProvider = XAIProvider
+                    , modelId = defaultModelFor XAIProvider
+                    , modelLabel = Just "default"
+                    })
 
         it "cancels without a selection" do
             applyPickerEvent PickerCancel state0 `shouldBe` Left Nothing
@@ -91,4 +115,16 @@ spec = do
                         (("mini" `Text.isInfixOf`) . Text.toLower)
                         opt.modelLabel)
                 (visibleOptions typed)
+                `shouldBe` True
+
+        it "filters by provider" do
+            let typed =
+                    foldl
+                        (\s c -> case applyPickerEvent (PickerType c) s of
+                            Right s' -> s'
+                            Left _ -> s)
+                        state0
+                        ("openrouter" :: String)
+            visibleOptions typed `shouldSatisfy` (not . null)
+            all ((== OpenRouterProvider) . (.modelProvider)) (visibleOptions typed)
                 `shouldBe` True

--- a/packages/agent-core/src/Agent/Broker.hs
+++ b/packages/agent-core/src/Agent/Broker.hs
@@ -2,6 +2,7 @@
 module Agent.Broker
     ( BrokerOptions(..)
     , newBrokerTokenProvider
+    , newBrokerTokenProviderFor
     , newBrokerTokenProviderWith
     , newBrokerTokenProviderWithClock
     ) where
@@ -73,8 +74,16 @@ instance Aeson.FromJSON BrokerToken where
 -- lease-aware broker can include a @lease_id@ without changing transport call
 -- sites.
 newBrokerTokenProvider :: BrokerOptions -> IO TokenProvider
-newBrokerTokenProvider options =
-    newBrokerTokenProviderWith (fetchBrokerCredentialExcluding options)
+newBrokerTokenProvider options = newBrokerTokenProviderFor options
+    [OpenAIProvider, XAIProvider, OpenRouterProvider]
+
+-- | Build a broker-backed provider restricted to the transports the caller is
+-- prepared to use. This keeps every failover credential on the same transport
+-- after a CLI session explicitly selects a provider.
+newBrokerTokenProviderFor :: BrokerOptions -> [Provider] -> IO TokenProvider
+newBrokerTokenProviderFor options supportedProviders =
+    newBrokerTokenProviderWith
+        (fetchBrokerCredentialExcluding options supportedProviders)
 
 -- | Construct a broker provider around a credential-fetch callback. This is
 -- useful for custom broker transports and deterministic integration tests.
@@ -152,13 +161,14 @@ instance Aeson.FromJSON BrokerError where
 
 fetchBrokerCredentialExcluding
     :: BrokerOptions
+    -> [Provider]
     -> Maybe FailedCredential
     -> [Text]
     -> IO (Either ApiError (Maybe Credential))
-fetchBrokerCredentialExcluding options failed excludedAccountIds =
+fetchBrokerCredentialExcluding options supportedProviders failed excludedAccountIds =
     fmap (fmap brokerCredential)
         <$> fetchBrokerTokenExcluding options
-            [OpenAIProvider, XAIProvider, OpenRouterProvider]
+            supportedProviders
             failed excludedAccountIds
   where
     brokerCredential BrokerToken { accessToken, accountId, brokerLeaseId, brokerProvider } =
@@ -238,4 +248,3 @@ brokerHttpError status body
         , brokerRetryAt = Just retryAt
         } <- Aeson.eitherDecode body = CredentialsExhausted retryAt
     | otherwise = HttpError status "broker could not issue an access token"
-


### PR DESCRIPTION
## Summary
- show one provider-qualified `/model` catalog containing xAI, OpenAI, and OpenRouter models
- rebuild auth, transport, tools, and prompt when a picker selection changes provider while continuing the persisted local conversation
- pin broker credential acquisition to the selected provider across failover

## Test plan
- [x] Multi-package GHCi load for `agent-cli`, `agent-core`, and all provider libraries
- [x] Agent CLI Hspec suite in GHCi (241 examples, 0 failures)
- [x] Live tmux smoke test from an xAI session: `/model` showed all providers, filtering worked, and Esc returned to the prompt