### PR TITLE
Fix Codex requests rejected by store flag

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -442,7 +442,7 @@ runAgent options = do
             effort = fromMaybe
                 (maybe (defaultEffortFor provider) (.metaEffort) (fst <$> resumed))
                 options.optEffort
-            params = requestParams provider model instructions
+            params = requestParams model instructions
                 (schemasFromAppTools provider tools) effort
             policy = resolveApprovalPolicy options isTty
                 projectSettings.settingsAutoApprove
@@ -2028,7 +2028,7 @@ runCodexSubagent options policy planHooks paramsRef wsLock conn registry session
                         <> env.subId.unSubagentId
                         <> "."
                 tools = coding.codingAppTools
-                childParams = requestParams OpenAIProvider model instructions
+                childParams = requestParams model instructions
                     (schemasFromAppTools OpenAIProvider tools) effort
             childParamsRef <- newIORef childParams
             let backend =
@@ -2093,7 +2093,7 @@ runHttpSubagent options policy planHooks paramsRef provider mkBackend registry s
                         <> "\n\n"
                         <> grokSubagentSuffix agentType env.subId
                 tools = filterChildGrokTools agentType coding.codingAppTools
-                childParams = requestParams provider model instructions
+                childParams = requestParams model instructions
                     (schemasFromAppTools provider tools) effort
             childParamsRef <- newIORef childParams
             let backend = mkBackend childParamsRef session.subSessionTranscript
@@ -2178,11 +2178,6 @@ childApprove policy tools call = case policy of
                 \Re-run the parent with auto-approve/--yolo, or have the \
                 \parent perform this edit."
 
--- | Rebuild from the constructor: 'input' is also a field on 'CustomToolCall'.
--- OpenAI keeps @store = true@ so @previous_response_id@ can continue a chain;
--- xAI/OpenRouter force @store = false@ and replay local transcripts instead.
-
-
 -- | Drop live conversation state without touching persisted session files.
 resetLiveConversation
     :: IORef (Maybe Text)
@@ -2208,14 +2203,15 @@ foldSessionItems = go []
             go turn.turnItems rest
         | otherwise = go (acc <> turn.turnItems) rest
 
+-- | Codex requires @store = false@. Continuation still uses
+-- @previous_response_id@, with the local transcript available for recovery.
 requestParams
-    :: Provider
-    -> Text
+    :: Text
     -> Text
     -> [ResponseTool]
     -> Text
     -> ResponseCreateParams
-requestParams provider modelName instructionText toolSchemas effort =
+requestParams modelName instructionText toolSchemas effort =
     case defaultResponseCreateParams of
         ResponseCreateParams{..} ->
             ResponseCreateParams
@@ -2230,6 +2226,6 @@ requestParams provider modelName instructionText toolSchemas effort =
                     , summary = Nothing
                     , extraFields = KeyMap.empty
                     }
-                , store = Just (provider == OpenAIProvider)
+                , store = Just False
                 , ..
                 }

--- a/packages/agent-openai/src/Agent/OpenAI/WebSocketClient.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/WebSocketClient.hs
@@ -297,6 +297,7 @@ buildWsPayloadWithOptions options request previousResponseId =
         Aeson.Object object -> Aeson.Object
             $ addContextManagement
             $ addPreviousResponseId
+            $ KeyMap.insert "store" (Aeson.Bool False)
             $ KeyMap.insert "type" (Aeson.String "response.create") object
         other -> other
   where

--- a/packages/agent-openai/test/Agent/OpenAI/WebSocketClientSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/WebSocketClientSpec.hs
@@ -6,6 +6,7 @@ import Agent.OpenAI.Responses.Types
 import Agent.OpenAI.WebSocketClient
 import Control.Retry (constantDelay, limitRetries)
 import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KeyMap
 import Data.IORef
 import Data.Text (Text)
@@ -13,6 +14,11 @@ import Data.Text (Text)
 spec :: Spec
 spec = do
   describe "buildWsPayloadWithOptions" do
+    it "forces store=false for the Codex WebSocket contract" do
+        let request = sampleRequest { store = Just True }
+        field "store" (buildWsPayloadWithOptions defaultCodexWsOptions request Nothing)
+            `shouldBe` Just (Aeson.Bool False)
+
     it "omits context_management by default" do
         contextManagement defaultCodexWsOptions `shouldBe` Nothing
 
@@ -59,9 +65,13 @@ spec = do
 
 contextManagement :: CodexWsOptions -> Maybe Aeson.Value
 contextManagement options =
-    case buildWsPayloadWithOptions options sampleRequest (Just "previous-1") of
-        Aeson.Object object -> KeyMap.lookup "context_management" object
-        _ -> Nothing
+    field "context_management" $
+        buildWsPayloadWithOptions options sampleRequest (Just "previous-1")
+
+field :: Key.Key -> Aeson.Value -> Maybe Aeson.Value
+field name = \case
+    Aeson.Object object -> KeyMap.lookup name object
+    _ -> Nothing
 
 sampleRequest :: ResponseCreateParams
 sampleRequest = defaultResponseCreateParams


### PR DESCRIPTION
## Summary
- set `store = false` when constructing provider request parameters
- enforce `store = false` at the Codex WebSocket payload boundary
- add a regression test for the wire contract

## Verification
- agent-openai GHCi test suite: 122 examples, 0 failures, 1 pending live-auth test
- multi-package GHCi reload: 87 modules loaded successfully