### PR TITLE
Fix OpenAI custom and collaboration tool schemas

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Tools.hs
+++ b/packages/agent-cli/src/Agent/CLI/Tools.hs
@@ -72,8 +72,14 @@ multiAgentNamespaceTool tools = KnownResponseTool ToolNamespace TaggedObject
         , "name" .= tool.appToolName
         , "description" .= tool.appToolDescription
         , "strict" .= False
-        , "parameters" .= parametersObjectLoose tool.appToolParameters
+        , "parameters" .= namespaceParameters tool.appToolParameters
         ]
+
+    namespaceParameters parameters = case parametersObjectLoose parameters of
+        Aeson.Object schema
+            | Just (Aeson.Array required) <- KeyMap.lookup "required" schema
+            , null required -> Aeson.Object (KeyMap.delete "required" schema)
+        schema -> schema
 
 -- | Codex registers apply_patch as a Responses custom tool with a Lark grammar.
 applyPatchCustomTool :: Text -> Text -> ResponseTool

--- a/packages/agent-cli/test/Agent/CLI/ToolsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ToolsSpec.hs
@@ -10,7 +10,9 @@ import Agent.Tools.Types (AppTool(..), AppToolKind(..))
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KeyMap
+import Data.Foldable (toList)
 import Data.Text (Text)
+import qualified Data.Text as Text
 import Test.Hspec
 
 spec :: Spec
@@ -47,8 +49,12 @@ spec = describe "schemasFromAppTools" do
                 case KeyMap.lookup "format" tagged.fields of
                     Just (Aeson.Object format) -> do
                         KeyMap.lookup "syntax" format `shouldBe` Just (Aeson.String "lark")
-                        KeyMap.lookup "definition" format
-                            `shouldBe` Just (Aeson.String applyPatchGrammar)
+                        let definition = KeyMap.lookup "definition" format
+                        definition `shouldBe` Just (Aeson.String applyPatchGrammar)
+                        definition `shouldSatisfy` \case
+                            Just (Aeson.String grammar) ->
+                                Text.isInfixOf "%import common.LF" grammar
+                            _ -> False
                     other -> expectationFailure ("expected format object, got " <> show other)
             other -> expectationFailure ("expected custom tool, got " <> show other)
 
@@ -69,6 +75,28 @@ spec = describe "schemasFromAppTools" do
                 KeyMap.lookup "name" tagged.fields
                     `shouldBe` Just (Aeson.String "collaboration")
             other -> expectationFailure ("expected namespace tool, got " <> show other)
+
+    it "omits an empty required list from reserved collaboration schemas" do
+        let wait = patchTool
+                { appToolName = "wait_agent"
+                , appToolKind = JsonFunction
+                , appToolParameters =
+                    [ PropertySchema "timeout_ms" PropertyNumber False Nothing ]
+                }
+        case schemasFromAppTools OpenAIProvider [wait] of
+            [_, KnownResponseTool ToolNamespace tagged] ->
+                case KeyMap.lookup "tools" tagged.fields of
+                    Just (Aeson.Array tools) -> case toList tools of
+                        [Aeson.Object tool] -> do
+                            Just (Aeson.Object parameters) <-
+                                pure (KeyMap.lookup "parameters" tool)
+                            KeyMap.lookup "required" parameters `shouldBe` Nothing
+                        other -> expectationFailure
+                            ("expected one nested tool, got " <> show other)
+                    other -> expectationFailure
+                        ("expected namespace tools, got " <> show other)
+            other -> expectationFailure
+                ("expected collaboration namespace, got " <> show other)
 
 jsonTool :: AppTool
 jsonTool = AppTool

--- a/packages/agent-core/src/Agent/Tools/ApplyPatch.hs
+++ b/packages/agent-core/src/Agent/Tools/ApplyPatch.hs
@@ -42,7 +42,9 @@ applyPatchGrammar =
     \change: (change_context | change_line)+ eof_line?\n\
     \change_context: (\"@@\" | \"@@ \" /(.+)/) LF\n\
     \change_line: (\"+\" | \"-\" | \" \") /(.*)/ LF\n\
-    \eof_line: \"*** End of File\" LF\n"
+    \eof_line: \"*** End of File\" LF\n\
+    \\n\
+    \%import common.LF\n"
 
 data Hunk
     = AddFile FilePath Text

--- a/packages/agent-core/src/Agent/Tools/MultiAgents.hs
+++ b/packages/agent-core/src/Agent/Tools/MultiAgents.hs
@@ -17,8 +17,6 @@ import Agent.Subagents
     , encodeStatus
     , interruptSubagent
     , listAgents
-    , maxWaitTimeoutMs
-    , minWaitTimeoutMs
     , queueMessage
     , resolveAgentTarget
     , sendInput
@@ -28,7 +26,6 @@ import Agent.Subagents
     )
 import Agent.Subagents.TaskPath
     ( TaskPath
-    , taskPathRoot
     , taskPathText
     )
 import Agent.ToolArgs
@@ -117,7 +114,6 @@ jsonTool name description parameters readOnly handler = AppTool
 data SpawnAgentArgs = SpawnAgentArgs
     { taskName :: Text
     , message :: Text
-    , agentType :: Maybe Text
     , model :: Maybe Text
     , reasoningEffort :: Maybe Text
     , forkTurns :: Maybe Text
@@ -127,7 +123,6 @@ instance FromJSON SpawnAgentArgs where
     parseJSON = objectArgs \object_ -> SpawnAgentArgs
         <$> reqText object_ "task_name"
         <*> reqText object_ "message"
-        <*> optText object_ "agent_type"
         <*> optText object_ "model"
         <*> optText object_ "reasoning_effort"
         <*> optText object_ "fork_turns"
@@ -136,16 +131,14 @@ spawnAgentTool :: MultiAgentContext -> AppTool
 spawnAgentTool ctx = jsonTool "spawn_agent" spawnAgentDescription
     [ PropertySchema "task_name" PropertyString True $ Just
         "Task name for the new agent. Use lowercase letters, digits, and underscores."
-    , PropertySchema "message" PropertyString True $ Just
-        "Initial plain-text task for the new agent."
-    , PropertySchema "agent_type" PropertyString False $ Just
-        "Optional agent type override. Omit unless explicitly asked."
+    , PropertySchema "message"
+        (encryptedString "Initial plain-text task for the new agent.") True Nothing
     , PropertySchema "model" PropertyString False $ Just
         "Model override for the new agent. Omit unless an explicit override is needed."
     , PropertySchema "reasoning_effort" PropertyString False $ Just
         "Reasoning effort override for the new agent. Omit to inherit the parent effort."
     , PropertySchema "fork_turns" PropertyString False $ Just
-        "Optional number of turns to fork. Defaults to all. Use none, all, or a positive integer. Full-history fork is not supported yet; none starts fresh (the default behavior)."
+        "Optional number of turns to fork. Defaults to `all`. Use `none`, `all`, or a positive integer string such as `3` to fork only the most recent turns."
     ]
     False
     (typedTool "spawn_agent" (runSpawn ctx))
@@ -164,7 +157,7 @@ runSpawn ctx args
     | not (validForkTurns args.forkTurns) =
         pure (Left "fork_turns must be none, all, or a positive integer string")
     | otherwise = do
-        _ <- pure (args.agentType, args.model, args.reasoningEffort, args.forkTurns)
+        _ <- pure (args.model, args.reasoningEffort, args.forkTurns)
         result <- spawnSubagentAt
             ctx.multiRegistry
             ctx.multiSelfId
@@ -208,16 +201,8 @@ instance FromJSON WaitAgentArgs where
 
 waitAgentTool :: MultiAgentContext -> AppTool
 waitAgentTool ctx = jsonTool "wait_agent" waitAgentDescription
-    [ PropertySchema "targets" (PropertyArray PropertyString) False $ Just
-        "Optional agent task names or ids to wait on. Omit to wait for any live agent."
-    , PropertySchema "timeout_ms" PropertyInteger False $ Just $
-        "Timeout in milliseconds. Defaults to "
-            <> Text.pack (show defaultWaitTimeoutMs)
-            <> ", min "
-            <> Text.pack (show minWaitTimeoutMs)
-            <> ", max "
-            <> Text.pack (show maxWaitTimeoutMs)
-            <> "."
+    [ PropertySchema "timeout_ms" PropertyNumber False $ Just
+        "Timeout in milliseconds. Defaults to 30000 ms."
     ]
     True
     (typedTool "wait_agent" (runWait ctx))
@@ -296,8 +281,8 @@ sendMessageTool :: MultiAgentContext -> AppTool
 sendMessageTool ctx = jsonTool "send_message" sendMessageDescription
     [ PropertySchema "target" PropertyString True $ Just
         "Relative or canonical task name to message (from spawn_agent)."
-    , PropertySchema "message" PropertyString True $ Just
-        "Message text to queue on the target agent."
+    , PropertySchema "message"
+        (encryptedString "Message text to queue on the target agent.") True Nothing
     ]
     False
     (typedTool "send_message" (runSendMessage ctx))
@@ -322,8 +307,8 @@ followupTaskTool :: MultiAgentContext -> AppTool
 followupTaskTool ctx = jsonTool "followup_task" followupDescription
     [ PropertySchema "target" PropertyString True $ Just
         "Agent id or canonical task name to send a follow-up task to (from spawn_agent)."
-    , PropertySchema "message" PropertyString True $ Just
-        "Message text to send to the target agent."
+    , PropertySchema "message"
+        (encryptedString "Message text to send to the target agent.") True Nothing
     ]
     False
     (typedTool "followup_task" (runFollowup ctx))
@@ -416,6 +401,13 @@ interruptDescription :: Text
 interruptDescription =
     "Interrupt an agent's current turn, if any, and return its previous status. \
     \The agent remains available for messages and follow-up tasks."
+
+encryptedString :: Text -> PropertyType
+encryptedString description = PropertyRaw $ object
+    [ "type" .= ("string" :: Text)
+    , "description" .= description
+    , "encrypted" .= True
+    ]
 
 runInterrupt :: MultiAgentContext -> InterruptAgentArgs -> IO (Either Text Text)
 runInterrupt ctx args = do

--- a/packages/agent-core/test/Agent/Tools/CodexSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/CodexSpec.hs
@@ -11,6 +11,7 @@ import Agent.ToolDispatch
     , dispatchToolCall
     , functionToolCall
     )
+import Agent.ToolDSL (PropertySchema(..), PropertyType(..))
 import Agent.Tools (CodingTools(..), appToolHandlers, codingToolsFor, defaultToolEnv)
 import Agent.Tools.ApplyPatch (parsePatch)
 import Agent.Tools.Codex (codexTools)
@@ -18,6 +19,8 @@ import Agent.Tools.Ghci (closeGhciSession, newGhciSession)
 import Agent.Tools.PlanMode (newPlanModeEnv)
 import Agent.Tools.Types (AppTool(..), ToolEnv(..))
 import Control.Exception.Safe (bracket, finally)
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.KeyMap as KeyMap
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
@@ -58,6 +61,27 @@ spec = describe "Agent.Tools.Codex" do
             coding <- codingToolsFor OpenAIProvider env Nothing (Just ctx)
             let names = map (.appToolName) coding.codingAppTools
             names `shouldContain` ["spawn_agent", "wait_agent", "send_message", "followup_task", "list_agents", "interrupt_agent"]
+            let parameters name =
+                    [ property
+                    | tool <- coding.codingAppTools
+                    , tool.appToolName == name
+                    , property <- tool.appToolParameters
+                    ]
+            map (.propertyName) (parameters "spawn_agent") `shouldBe`
+                [ "task_name"
+                , "message"
+                , "model"
+                , "reasoning_effort"
+                , "fork_turns"
+                ]
+            map (.propertyType) (parameters "wait_agent") `shouldBe`
+                [PropertyNumber]
+            case map (.propertyType) (parameters "spawn_agent") of
+                _ : PropertyRaw (Aeson.Object messageSchema) : _ ->
+                    KeyMap.lookup "encrypted" messageSchema
+                        `shouldBe` Just (Aeson.Bool True)
+                other -> expectationFailure
+                    ("expected encrypted spawn message schema, got " <> show other)
             coding.codingClose
             closeSubagentRegistry registry
 


### PR DESCRIPTION
## Summary
- import the `LF` terminal in the apply_patch Lark grammar
- align reserved collaboration inputs with the OpenAI model schema
- preserve encrypted message markers and omit empty `required` arrays
- add regression coverage for both wire contracts

## Verification
- agent-cli GHCi suite: 242 examples, 0 failures
- agent-core GHCi suite: 131 examples, 0 failures
- live tmux smoke test: OpenAI `gpt-5.6-luna` answered `hi` successfully