### PR TITLE
feat: support none and max reasoning efforts

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Command.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command.hs
@@ -14,7 +14,7 @@ module Agent.CLI.Command
     ) where
 
 import Agent.CLI.Models (catalogModelIds)
-import Agent.CLI.Options (parseEffort)
+import Agent.CLI.Options (parseEffort, reasoningEfforts)
 import Agent.CLI.Style (roleMuted, rolePrompt)
 import Agent.OpenAI.Responses.Types
 
@@ -71,7 +71,7 @@ slashCommands :: [SlashCommand]
 slashCommands =
     [ cmd "help" [] "/help [NAME]" "List slash commands, or describe one"
     , cmd "model" ["m"] "/model [NAME]" "Open the model picker, or set a model"
-    , cmd "effort" [] "/effort [low|medium|high|xhigh]" "Show or set reasoning effort"
+    , cmd "effort" [] "/effort [none|low|medium|high|xhigh|max]" "Show or set reasoning effort"
     , cmd "plan" [] "/plan [description]" "Enter plan mode (or Shift+Tab)"
     , cmd "session" [] "/session" "Print the current session id"
     , cmd "resume" [] "/resume [ID]" "Pick a session to resume, or print a --resume hint"
@@ -212,7 +212,7 @@ parseEffortCommand = \case
     [level] -> case parseEffort level of
         Right effort -> ReplSetEffort effort
         Left err -> ReplCommandError (Text.pack err)
-    _ -> ReplCommandError "usage: /effort [low|medium|high|xhigh]"
+    _ -> ReplCommandError "usage: /effort [none|low|medium|high|xhigh|max]"
 
 parseModelCommand :: [Text] -> ReplAction
 parseModelCommand = \case
@@ -323,7 +323,7 @@ completeSlashArgs cmd word =
 
 argCompletions :: SlashCommand -> [Text]
 argCompletions spec = case spec.slashName of
-    "effort" -> ["low", "medium", "high", "xhigh"]
+    "effort" -> reasoningEfforts
     "model" -> catalogModelIds
     "help" -> map (.slashName) slashCommands
     "paste" -> ["--send"]

--- a/packages/agent-cli/src/Agent/CLI/Options.hs
+++ b/packages/agent-cli/src/Agent/CLI/Options.hs
@@ -10,6 +10,7 @@ module Agent.CLI.Options
     , parseApprovalAnswer
     , parseArgs
     , parseEffort
+    , reasoningEfforts
     , resolveApprovalPolicy
     , usage
     ) where
@@ -189,14 +190,19 @@ parseInt flag value = case reads value of
     [(n, "")] | n >= 1 -> Right n
     _ -> Left (flag <> " expects a positive integer, got " <> value)
 
+reasoningEfforts :: [Text]
+reasoningEfforts = ["none", "low", "medium", "high", "xhigh", "max"]
+
 parseEffort :: Text -> Either String Text
-parseEffort raw = case Text.toLower (Text.strip raw) of
-    "low" -> Right "low"
-    "medium" -> Right "medium"
-    "high" -> Right "high"
-    "xhigh" -> Right "xhigh"
-    other ->
-        Left ("effort must be low, medium, high, or xhigh (got " <> Text.unpack other <> ")")
+parseEffort raw =
+    let effort = Text.toLower (Text.strip raw)
+    in if effort `elem` reasoningEfforts
+        then Right effort
+        else Left
+            ( "effort must be none, low, medium, high, xhigh, or max (got "
+                <> Text.unpack effort
+                <> ")"
+            )
 
 loginHint :: String
 loginHint =
@@ -222,7 +228,7 @@ usage = unlines
     , "      --yolo              Auto-approve every tool"
     , "      --no-yolo           Never auto-approve; deny mutating tools without a TTY"
     , "      --max-turns N       Stop after N model turns (default: 500)"
-    , "      --effort LEVEL      Reasoning effort: low, medium, high, xhigh"
+    , "      --effort LEVEL      Reasoning effort: none, low, medium, high, xhigh, max"
     , "                          (default: high for xai/grok, medium otherwise)"
     , "      --version           Print the agent-cli version"
     , "      --help              Show this help"

--- a/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
@@ -28,8 +28,10 @@ spec = do
             parseReplLine "  /Effort  " `shouldBe` ReplShowEffort
 
         it "sets a valid effort level" do
+            parseReplLine "/effort none" `shouldBe` ReplSetEffort "none"
             parseReplLine "/effort high" `shouldBe` ReplSetEffort "high"
             parseReplLine "/effort XHIGH" `shouldBe` ReplSetEffort "xhigh"
+            parseReplLine "/effort MAX" `shouldBe` ReplSetEffort "max"
             parseReplLine "/effort medium" `shouldBe` ReplSetEffort "medium"
 
         it "toggles always-approve from slash and colon aliases" do
@@ -128,9 +130,10 @@ spec = do
         it "rejects unknown levels, extra args, and unknown commands" do
             parseReplLine "/effort bogus"
                 `shouldBe` ReplCommandError
-                    "effort must be low, medium, high, or xhigh (got bogus)"
+                    "effort must be none, low, medium, high, xhigh, or max (got bogus)"
             parseReplLine "/effort high extra"
-                `shouldBe` ReplCommandError "usage: /effort [low|medium|high|xhigh]"
+                `shouldBe` ReplCommandError
+                    "usage: /effort [none|low|medium|high|xhigh|max]"
             parseReplLine "/bogus"
                 `shouldBe` ReplCommandError "unknown command: /bogus (try /help)"
             parseReplLine "/"
@@ -170,6 +173,8 @@ spec = do
 
         it "completes effort and model arguments" do
             slashCompletionCandidates "troffe/" "h" `shouldBe` ["high"]
+            slashCompletionCandidates "troffe/" "m" `shouldBe` ["medium", "max"]
+            slashCompletionCandidates "troffe/" "n" `shouldBe` ["none"]
             slashCompletionCandidates "m/" "grok-4"
                 `shouldSatisfy` (\xs ->
                     "grok-4.6" `elem` xs
@@ -187,7 +192,8 @@ spec = do
             listing `shouldSatisfy` ("preview it in the terminal" `isInfixOf`)
             listing `shouldSatisfy` ("(/m)" `isInfixOf`)
             Text.unpack (formatSlashHelp False (Just "effort"))
-                `shouldSatisfy` ("/effort [low|medium|high|xhigh]" `isInfixOf`)
+                `shouldSatisfy`
+                    ("/effort [none|low|medium|high|xhigh|max]" `isInfixOf`)
 
     describe "setReasoningEffort" do
         it "writes effort onto an empty reasoning config" do

--- a/packages/agent-cli/test/Agent/CLI/OptionsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/OptionsSpec.hs
@@ -43,14 +43,18 @@ spec = do
                     , optPrompt = Just "hello"
                     })
 
-        it "accepts xhigh effort" do
+        it "accepts none, xhigh, and max effort" do
+            parseArgs ["--effort", "none"]
+                `shouldBe` Right (RunAgent defaultCliOptions { optEffort = Just "none" })
             parseArgs ["--effort", "xhigh"]
                 `shouldBe` Right (RunAgent defaultCliOptions { optEffort = Just "xhigh" })
+            parseArgs ["--effort", "max"]
+                `shouldBe` Right (RunAgent defaultCliOptions { optEffort = Just "max" })
             parseArgs ["--effort", "HIGH"]
                 `shouldBe` Right (RunAgent defaultCliOptions { optEffort = Just "high" })
 
         it "rejects unknown effort levels" do
-            parseArgs ["--effort", "max"] `shouldSatisfy` isLeft
+            parseArgs ["--effort", "extreme"] `shouldSatisfy` isLeft
 
         it "accepts openrouter as a provider" do
             parseArgs ["--provider", "openrouter", "-p", "hi"]

--- a/packages/agent-xai/test/Agent/XAI/ResponsesSpec.hs
+++ b/packages/agent-xai/test/Agent/XAI/ResponsesSpec.hs
@@ -100,6 +100,10 @@ spec = do
                 >>= (`shouldBe` Just (Aeson.String "medium"))
             effortOf (withEffort "low" sampleRequest)
                 >>= (`shouldBe` Just (Aeson.String "low"))
+            effortOf (withEffort "xhigh" sampleRequest)
+                >>= (`shouldBe` Just (Aeson.String "high"))
+            effortOf (withEffort "max" sampleRequest)
+                >>= (`shouldBe` Just (Aeson.String "high"))
             -- Unset effort defaults to high for Grok.
             effortOf (clearEffort sampleRequest)
                 >>= (`shouldBe` Just (Aeson.String "high"))


### PR DESCRIPTION
## Summary
- Accept GPT-5.6's `none` and `max` reasoning efforts through `--effort` and `/effort`.
- Share the supported effort list with slash completion and update CLI help/error text.
- Cover xAI's compatibility mapping (`none` → `low`, `xhigh`/`max` → `high`).

## Test plan
- [x] `agent-cli` suite in GHCi — 242 examples, 0 failures
- [x] `agent-xai` suite in GHCi — 35 examples, 0 failures, 1 pending live test
- [x] tmux smoke check: `/help effort`, `/effort none`, `/effort max`, invalid effort, and prompt status updates
- [x] `git diff --check`