### PR TITLE
Fall back to OpenAI when Grok usage is exhausted

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -55,6 +55,7 @@ library
                     , Agent.CLI.Progress
                     , Agent.CLI.Project
                     , Agent.CLI.Prompt
+                    , Agent.CLI.ProviderFallback
                     , Agent.CLI.Render
                     , Agent.CLI.ReplMode
                     , Agent.CLI.Resume
@@ -118,6 +119,7 @@ test-suite agent-cli-test
                     , Agent.CLI.PermissionSpec
                     , Agent.CLI.ProgressSpec
                     , Agent.CLI.PromptSpec
+                    , Agent.CLI.ProviderFallbackSpec
                     , Agent.CLI.RenderSpec
                     , Agent.CLI.ReplStatusSpec
                     , Agent.CLI.ResumeSpec

--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -56,6 +56,7 @@ library
                     , Agent.CLI.Project
                     , Agent.CLI.Prompt
                     , Agent.CLI.ProviderFallback
+                    , Agent.CLI.ProviderTransition
                     , Agent.CLI.Render
                     , Agent.CLI.ReplMode
                     , Agent.CLI.Resume
@@ -120,6 +121,7 @@ test-suite agent-cli-test
                     , Agent.CLI.ProgressSpec
                     , Agent.CLI.PromptSpec
                     , Agent.CLI.ProviderFallbackSpec
+                    , Agent.CLI.ProviderTransitionSpec
                     , Agent.CLI.RenderSpec
                     , Agent.CLI.ReplStatusSpec
                     , Agent.CLI.ResumeSpec

--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -61,6 +61,7 @@ import Agent.CLI.Project
     , resolveProjectRoot
     )
 import Agent.CLI.Prompt (defaultModelFor, systemPrompt)
+import Agent.CLI.ProviderFallback (fallbackCandidates)
 import Agent.CLI.Render
     ( RenderConfig(..)
     , putTextLn
@@ -85,6 +86,7 @@ import Agent.CLI.Style
     , endBackground
     , glyphOk
     , glyphSession
+    , glyphWarn
     , roleError
     , roleMuted
     , rolePrompt
@@ -95,9 +97,10 @@ import Agent.CLI.Style
     )
 import Agent.CLI.Terminal (resolveColor)
 import Agent.CLI.Tools (schemasFromAppTools)
-import Agent.CLI.Turn (runOneTurn)
+import Agent.CLI.Turn (TurnResult(..), runOneTurn)
 import Agent.CLI.Worktree (createWorktree, isUnderWorktreeRoot, worktreeRoot)
 import Agent.Loop
+import Agent.Error (ApiError)
 import Agent.ProjectInstructions
     ( DiscoverOptions(..)
     , defaultDiscoverOptions
@@ -202,9 +205,19 @@ data DevResult
 data RunResult
     = RunQuit
     | RunReload
-    | RunSwitchProvider Text
-      -- ^ Persisted session id. Consumed after the current provider-specific
-      -- backend shuts down.
+    | RunSwitchProvider ProviderSwitch
+
+data ProviderSwitch = ProviderSwitch
+    { switchSessionId :: !Text
+    , switchPendingTurn :: !(Maybe PendingTurn)
+    , switchUnavailableProviders :: ![Provider]
+    }
+
+data PendingTurn = PendingTurn
+    { pendingPromptText :: !Text
+    , pendingInputs :: ![TurnInput]
+    , pendingExitAfter :: !Bool
+    }
 
 -- | GHCi @:cmd@ helper: on 'DevReload', reload modules and re-enter 'devMain'.
 afterDev :: DevResult -> IO String
@@ -285,21 +298,26 @@ run = do
 -- produced, so resuming reconstructs auth, tools, prompt, and transport from
 -- the newly selected provider while keeping the local transcript.
 runAgentWithProviderSwitches :: CliOptions -> IO DevResult
-runAgentWithProviderSwitches options =
-    runAgent options >>= \case
-        RunSwitchProvider sessionId ->
-            runAgentWithProviderSwitches options
-                { optProvider = Nothing
-                , optModel = Nothing
-                , optCwd = Nothing
-                , optWorktree = False
-                , optEffort = Nothing
-                , optPrompt = Nothing
-                , optPromptFile = Nothing
-                , optResume = Just sessionId
-                }
-        RunQuit -> pure DevQuit
-        RunReload -> pure DevReload
+runAgentWithProviderSwitches options = go options Nothing []
+  where
+    go current pending unavailable =
+        runAgent current pending unavailable >>= \case
+            RunSwitchProvider providerSwitch ->
+                go
+                    current
+                        { optProvider = Nothing
+                        , optModel = Nothing
+                        , optCwd = Nothing
+                        , optWorktree = False
+                        , optEffort = Nothing
+                        , optPrompt = Nothing
+                        , optPromptFile = Nothing
+                        , optResume = Just providerSwitch.switchSessionId
+                        }
+                    providerSwitch.switchPendingTurn
+                    providerSwitch.switchUnavailableProviders
+            RunQuit -> pure DevQuit
+            RunReload -> pure DevReload
 
 runListSessions :: IO ()
 runListSessions = do
@@ -340,8 +358,8 @@ printTurn turn = do
         _ -> pure ()
     putStrLn ""
 
-runAgent :: CliOptions -> IO RunResult
-runAgent options = do
+runAgent :: CliOptions -> Maybe PendingTurn -> [Provider] -> IO RunResult
+runAgent options pendingTurn unavailableProviders = do
     home <- getHomeDirectory
     let root = sessionsRoot home
     resumed <- case options.optResume of
@@ -506,7 +524,7 @@ runAgent options = do
                                             transcriptRef
                                     noticingBackend =
                                         withPendingNotices pendingNotices lockedBackend
-                                runSession options provider policy tools toolEnv planMode prompt paramsRef transcriptRef
+                                runSession options provider policy tools toolEnv planMode prompt pendingTurn unavailableProviders paramsRef transcriptRef
                                     initialPrevious persist projectRoot home cwd (Just loaded.loadedTokenProvider) agentsContext escPaused interrupt
                                     multiCtx subagentSessions pendingNotices subagentStoreRoot usageRef noticingBackend)
                             >>= \case
@@ -535,7 +553,7 @@ runAgent options = do
                                 withPendingNotices pendingNotices $
                                     xaiBackend xaiOptions loaded.loadedTokenProvider
                                         (readIORef paramsRef) transcriptRef
-                        runSession options provider policy tools toolEnv planMode prompt paramsRef transcriptRef
+                        runSession options provider policy tools toolEnv planMode prompt pendingTurn unavailableProviders paramsRef transcriptRef
                             initialPrevious persist projectRoot home cwd (Just loaded.loadedTokenProvider) agentsContext escPaused interrupt
                             multiCtx subagentSessions pendingNotices subagentStoreRoot usageRef backend
                     OpenRouterProvider -> do
@@ -561,7 +579,7 @@ runAgent options = do
                                 withPendingNotices pendingNotices $
                                     openRouterBackend openRouterOptions loaded.loadedTokenProvider
                                         (readIORef paramsRef) transcriptRef
-                        runSession options provider policy tools toolEnv planMode prompt paramsRef transcriptRef
+                        runSession options provider policy tools toolEnv planMode prompt pendingTurn unavailableProviders paramsRef transcriptRef
                             initialPrevious persist projectRoot home cwd (Just loaded.loadedTokenProvider) agentsContext escPaused interrupt
                             multiCtx subagentSessions pendingNotices subagentStoreRoot usageRef backend
 
@@ -653,6 +671,8 @@ runSession
     -> ToolEnv
     -> PlanModeEnv
     -> Maybe Text
+    -> Maybe PendingTurn
+    -> [Provider]
     -> IORef ResponseCreateParams
     -> IORef [ResponseItem]
     -> Maybe Text
@@ -671,7 +691,7 @@ runSession
     -> IORef TokenUsage
     -> Backend
     -> IO RunResult
-runSession options provider policy tools toolEnv planMode prompt paramsRef transcriptRef initialPrevious persist projectRoot home cwd tokenProvider agentsContext escPaused interrupt multiCtx subagentSessions pendingNotices storeRoot usageRef backend = do
+runSession options provider policy tools toolEnv planMode prompt pendingTurn unavailableProviders paramsRef transcriptRef initialPrevious persist projectRoot home cwd tokenProvider agentsContext escPaused interrupt multiCtx subagentSessions pendingNotices storeRoot usageRef backend = do
     printed <- newIORef False
     attachmentsRef <- newIORef []
     previewIdRef <- newIORef (1 :: Int)
@@ -745,6 +765,7 @@ runSession options provider policy tools toolEnv planMode prompt paramsRef trans
             { sessionLoop = config
             , sessionRender = render
             , sessionProvider = provider
+            , sessionUnavailableProviders = unavailableProviders
             , sessionPrevious = previous
             , sessionPrinted = printed
             , sessionParams = paramsRef
@@ -764,14 +785,59 @@ runSession options provider policy tools toolEnv planMode prompt paramsRef trans
             , sessionUsage = usageRef
             , sessionReset = sessionReset
             }
-    case prompt of
-        Just text -> do
-            ok <- runOneTurn env text [UserMessage text]
-            if ok
-                then putTrailingNewline printed >> pure RunQuit
-                else exitFailure
-        Nothing ->
-            repl env
+    case pendingTurn of
+        Just pending ->
+            runPendingTurn env pending
+        Nothing -> case prompt of
+            Just text -> do
+                result <- runOneTurn env text [UserMessage text]
+                finishTurn env True text [UserMessage text] result
+            Nothing ->
+                repl env
+
+runPendingTurn :: SessionEnv -> PendingTurn -> IO RunResult
+runPendingTurn env pending = do
+    result <- runOneTurn env pending.pendingPromptText pending.pendingInputs
+    finishTurn
+        env
+        pending.pendingExitAfter
+        pending.pendingPromptText
+        pending.pendingInputs
+        result
+
+finishTurn
+    :: SessionEnv
+    -> Bool
+    -> Text
+    -> [TurnInput]
+    -> TurnResult
+    -> IO RunResult
+finishTurn env exitAfter promptText inputs = \case
+    TurnSucceeded -> do
+        putTrailingNewline env.sessionPrinted
+        if exitAfter
+            then pure RunQuit
+            else repl env
+    TurnFailed ->
+        if exitAfter
+            then exitFailure
+            else do
+                putTrailingNewline env.sessionPrinted
+                repl env
+    TurnUsageExhausted apiError ->
+        requestAutomaticProviderFallback env promptText inputs apiError >>= \case
+            Just providerSwitch ->
+                pure $ RunSwitchProvider providerSwitch
+                    { switchPendingTurn = Just PendingTurn
+                        { pendingPromptText = promptText
+                        , pendingInputs = inputs
+                        , pendingExitAfter = exitAfter
+                        }
+                    }
+            Nothing ->
+                if exitAfter
+                    then exitFailure
+                    else repl env
 
 repl :: SessionEnv -> IO RunResult
 repl env = replWithDraft env ""
@@ -888,9 +954,8 @@ replWithDraft env@SessionEnv
                                                     , userImages = pendingImages
                                                     }
                                                 ]
-                                _ <- runOneTurn env text turnInputs
-                                putTrailingNewline printed
-                                continue
+                                result <- runOneTurn env text turnInputs
+                                finishTurn env False text turnInputs result
                     ReplPaste{pasteImmediate, pasteCaption} -> do
                         color <- resolveColor stdout
                         errColor <- resolveColor stderr
@@ -932,14 +997,14 @@ replWithDraft env@SessionEnv
                                         Text.putStrLn
                                             (roleMuted color (glyphOk <> "pasted " <> sizes))
                                         writeIORef printed False
-                                        _ <- runOneTurn env promptText
-                                            [ UserMultimodal
-                                                { userText = promptText
-                                                , userImages = images
-                                                }
-                                            ]
-                                        putTrailingNewline printed
-                                        continue
+                                        let turnInputs =
+                                                [ UserMultimodal
+                                                    { userText = promptText
+                                                    , userImages = images
+                                                    }
+                                                ]
+                                        result <- runOneTurn env promptText turnInputs
+                                        finishTurn env False promptText turnInputs result
                                     else do
                                         queueAttachedImages
                                             attachmentsRef previewIdRef color images
@@ -1060,9 +1125,11 @@ replWithDraft env@SessionEnv
                                                 , metaUpdatedAt = now
                                                 }
                                 continue
-                    ReplPlan maybeDescription -> do
-                        enterPlanFromSlash env maybeDescription
-                        continue
+                    ReplPlan maybeDescription ->
+                        enterPlanFromSlash env maybeDescription >>= \case
+                            Just providerSwitch ->
+                                pure (RunSwitchProvider providerSwitch)
+                            Nothing -> continue
                     ReplResume maybeId -> do
                         handleResume maybeId persist
                         continue
@@ -1290,7 +1357,56 @@ requestModelProviderSwitch choice persist = case persist of
                             <> "/"
                             <> choice.modelId
                             <> " (conversation continued locally)"
-                    pure $ Right (RunSwitchProvider handle.sessionMeta.metaId)
+                    pure $ Right $ RunSwitchProvider ProviderSwitch
+                        { switchSessionId = handle.sessionMeta.metaId
+                        , switchPendingTurn = Nothing
+                        , switchUnavailableProviders = []
+                        }
+
+requestAutomaticProviderFallback
+    :: SessionEnv
+    -> Text
+    -> [TurnInput]
+    -> ApiError
+    -> IO (Maybe ProviderSwitch)
+requestAutomaticProviderFallback env _promptText _inputs apiError = do
+    let current = env.sessionProvider
+        unavailable = markUnavailable current env.sessionUnavailableProviders
+        candidates =
+            fallbackCandidates env.sessionUnavailableProviders current apiError
+    tryCandidates unavailable candidates
+  where
+    tryCandidates unavailable = \case
+        [] -> do
+            color <- resolveColor stderr
+            putTextLn stderr $ roleError color $
+                "usage exhausted; no other configured provider account is available"
+            pure Nothing
+        choice : rest ->
+            requestModelProviderSwitch choice env.sessionPersist >>= \case
+                Left _ ->
+                    tryCandidates
+                        (markUnavailable choice.modelProvider unavailable)
+                        rest
+                Right (RunSwitchProvider providerSwitch) -> do
+                    color <- resolveColor stderr
+                    putTextLn stderr $ roleWarn color $
+                        glyphWarn
+                            <> providerSlug env.sessionProvider
+                            <> " usage exhausted; switching to best available model "
+                            <> providerSlug choice.modelProvider
+                            <> "/"
+                            <> choice.modelId
+                    pure $ Just providerSwitch
+                        { switchUnavailableProviders = unavailable
+                        }
+                Right _ ->
+                    tryCandidates unavailable rest
+
+markUnavailable :: Provider -> [Provider] -> [Provider]
+markUnavailable provider unavailable
+    | provider `elem` unavailable = unavailable
+    | otherwise = unavailable <> [provider]
 
 reloadAuth :: Provider -> Maybe TokenProvider -> IO ()
 reloadAuth provider = \case
@@ -1345,7 +1461,7 @@ requestReload persist = do
                     (glyphSession <> "reloading; session " <> handle.sessionMeta.metaId))
             pure RunReload
 
-enterPlanFromSlash :: SessionEnv -> Maybe Text -> IO ()
+enterPlanFromSlash :: SessionEnv -> Maybe Text -> IO (Maybe ProviderSwitch)
 enterPlanFromSlash env@SessionEnv{sessionPlanMode = planMode, sessionPersist = persist, sessionPrinted = printed} maybeDescription = do
     discardStore <- newIORef Nothing
     color <- resolveColor stderr
@@ -1364,6 +1480,7 @@ enterPlanFromSlash env@SessionEnv{sessionPlanMode = planMode, sessionPersist = p
                 (roleMuted color
                     (glyphSession
                         <> "plan mode armed; send a prompt to activate (or /plan <description>)"))
+            pure Nothing
         Just description -> do
             activatePlanMode planMode
             path <- planFilePath planMode
@@ -1371,8 +1488,24 @@ enterPlanFromSlash env@SessionEnv{sessionPlanMode = planMode, sessionPersist = p
                 (roleMuted color (glyphSession <> "plan mode on (" <> Text.pack path <> ")"))
             writeIORef printed False
             let planEnv = env { sessionStoreRoot = discardStore }
-            _ <- runOneTurn planEnv description [UserMessage description]
-            putTrailingNewline printed
+                inputs = [UserMessage description]
+            result <- runOneTurn planEnv description inputs
+            case result of
+                TurnUsageExhausted apiError ->
+                    requestAutomaticProviderFallback
+                        planEnv description inputs apiError >>= \case
+                            Nothing -> pure Nothing
+                            Just providerSwitch ->
+                                pure $ Just providerSwitch
+                                    { switchPendingTurn = Just PendingTurn
+                                        { pendingPromptText = description
+                                        , pendingInputs = inputs
+                                        , pendingExitAfter = False
+                                        }
+                                    }
+                _ -> do
+                    putTrailingNewline printed
+                    pure Nothing
 
 -- | Discover AGENTS.md once for a fresh session. Resumed transcripts keep
 -- whatever instructions were already in history.

--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -62,6 +62,14 @@ import Agent.CLI.Project
     )
 import Agent.CLI.Prompt (defaultModelFor, systemPrompt)
 import Agent.CLI.ProviderFallback (fallbackCandidates)
+import Agent.CLI.ProviderTransition
+    ( PendingTurn(..)
+    , ProviderTransition(..)
+    , TransitionCause(..)
+    , TurnResult(..)
+    , applyProviderTransition
+    , setPendingExitAfter
+    )
 import Agent.CLI.Render
     ( RenderConfig(..)
     , putTextLn
@@ -97,7 +105,7 @@ import Agent.CLI.Style
     )
 import Agent.CLI.Terminal (resolveColor)
 import Agent.CLI.Tools (schemasFromAppTools)
-import Agent.CLI.Turn (TurnResult(..), runOneTurn)
+import Agent.CLI.Turn (runOneTurn)
 import Agent.CLI.Worktree (createWorktree, isUnderWorktreeRoot, worktreeRoot)
 import Agent.Loop
 import Agent.Error (ApiError)
@@ -205,19 +213,8 @@ data DevResult
 data RunResult
     = RunQuit
     | RunReload
-    | RunSwitchProvider ProviderSwitch
-
-data ProviderSwitch = ProviderSwitch
-    { switchSessionId :: !Text
-    , switchPendingTurn :: !(Maybe PendingTurn)
-    , switchUnavailableProviders :: ![Provider]
-    }
-
-data PendingTurn = PendingTurn
-    { pendingPromptText :: !Text
-    , pendingInputs :: ![TurnInput]
-    , pendingExitAfter :: !Bool
-    }
+    | RunSwitchProvider ProviderTransition
+    | RunProviderStartFailed ApiError
 
 -- | GHCi @:cmd@ helper: on 'DevReload', reload modules and re-enter 'devMain'.
 afterDev :: DevResult -> IO String
@@ -293,29 +290,25 @@ run = do
                     clearDevResumePointer home
                     die ":reload is only available under `repl` (nix develop)"
 
--- | Tear down and rebuild the provider-specific backend when the picker moves
--- between providers. The session metadata is updated before this result is
--- produced, so resuming reconstructs auth, tools, prompt, and transport from
--- the newly selected provider while keeping the local transcript.
+-- | Tear down and rebuild provider-specific auth, tools, prompt, and transport.
+-- Automatic transitions carry the exact failed turn in memory and commit
+-- persisted provider metadata only after the replacement backend succeeds.
 runAgentWithProviderSwitches :: CliOptions -> IO DevResult
-runAgentWithProviderSwitches options = go options Nothing []
+runAgentWithProviderSwitches options = go options Nothing
   where
-    go current pending unavailable =
-        runAgent current pending unavailable >>= \case
-            RunSwitchProvider providerSwitch ->
-                go
-                    current
-                        { optProvider = Nothing
-                        , optModel = Nothing
-                        , optCwd = Nothing
-                        , optWorktree = False
-                        , optEffort = Nothing
-                        , optPrompt = Nothing
-                        , optPromptFile = Nothing
-                        , optResume = Just providerSwitch.switchSessionId
-                        }
-                    providerSwitch.switchPendingTurn
-                    providerSwitch.switchUnavailableProviders
+    go current transition =
+        runAgent current transition >>= \case
+            RunSwitchProvider next ->
+                go (applyProviderTransition current next) (Just next)
+            RunProviderStartFailed apiError ->
+                case transition of
+                    Just failed
+                        | failed.transitionCause == AutomaticFallback ->
+                            continueAutomaticFallback failed apiError >>= \case
+                                Just next ->
+                                    go (applyProviderTransition current next) (Just next)
+                                Nothing -> pure DevQuit
+                    _ -> pure DevQuit
             RunQuit -> pure DevQuit
             RunReload -> pure DevReload
 
@@ -358,8 +351,8 @@ printTurn turn = do
         _ -> pure ()
     putStrLn ""
 
-runAgent :: CliOptions -> Maybe PendingTurn -> [Provider] -> IO RunResult
-runAgent options pendingTurn unavailableProviders = do
+runAgent :: CliOptions -> Maybe ProviderTransition -> IO RunResult
+runAgent options transition = do
     home <- getHomeDirectory
     let root = sessionsRoot home
     resumed <- case options.optResume of
@@ -387,19 +380,30 @@ runAgent options pendingTurn unavailableProviders = do
     projectSettings <- loadProjectSettings projectRoot
     isTty <- hIsTerminalDevice stdin
     stdoutTty <- hIsTerminalDevice stdout
-    let requestedProvider = case resumed of
-            Just (meta, _) -> Just meta.metaProvider
-            Nothing -> options.optProvider
+    let transitionTarget = (.transitionTarget) <$> transition
+        pendingTurn = transition >>= (.transitionPendingTurn)
+        unavailableProviders =
+            maybe [] (.transitionUnavailableProviders) transition
+        requestedProvider = case transitionTarget of
+            Just target -> Just target.modelProvider
+            Nothing -> case resumed of
+                Just (meta, _) -> Just meta.metaProvider
+                Nothing -> options.optProvider
     loaded <- loadAuth requestedProvider >>= either die pure
-    case resumed of
-        Just (meta, _)
+    case (transitionTarget, resumed) of
+        (Just target, _)
+            | loaded.loadedProvider /= target.modelProvider ->
+                die $ "provider transition requested "
+                    <> Text.unpack (providerSlug target.modelProvider)
+                    <> " but auth resolved "
+                    <> Text.unpack (providerSlug loaded.loadedProvider)
+        (Nothing, Just (meta, _))
             | loaded.loadedProvider /= meta.metaProvider ->
                 die $ "session provider is "
                     <> Text.unpack (providerSlug meta.metaProvider)
                     <> " but auth resolved "
                     <> Text.unpack (providerSlug loaded.loadedProvider)
-            | otherwise -> pure ()
-        Nothing -> pure ()
+        _ -> pure ()
 
     toolEnv <- defaultToolEnv cwd
     interrupt <- newInterruptState \msg -> do
@@ -455,7 +459,10 @@ runAgent options pendingTurn unavailableProviders = do
     flip finally closeAll do
         today <- utctDay <$> getCurrentTime
         let model = fromMaybe
-                (maybe (defaultModelFor provider) (.metaModel) (fst <$> resumed))
+                (case transitionTarget of
+                    Just target -> target.modelId
+                    Nothing ->
+                        maybe (defaultModelFor provider) (.metaModel) (fst <$> resumed))
                 options.optModel
             instructions = systemPrompt provider cwd today (isOneShot options)
             effort = fromMaybe
@@ -466,7 +473,9 @@ runAgent options pendingTurn unavailableProviders = do
             policy = resolveApprovalPolicy options isTty
                 projectSettings.settingsAutoApprove
             initialItems = maybe [] (foldSessionItems . snd) resumed
-            initialPrevious = resumed >>= \(meta, _) -> meta.metaLastResponseId
+            initialPrevious = case transition of
+                Just _ -> Nothing
+                Nothing -> resumed >>= \(meta, _) -> meta.metaLastResponseId
         paramsRef <- newIORef params
         transcriptRef <- newIORef initialItems
         prompt <- loadPrompt options
@@ -524,11 +533,18 @@ runAgent options pendingTurn unavailableProviders = do
                                             transcriptRef
                                     noticingBackend =
                                         withPendingNotices pendingNotices lockedBackend
+                                activeBackend <-
+                                    prepareTransitionBackend transition persist noticingBackend
                                 runSession options provider policy tools toolEnv planMode prompt pendingTurn unavailableProviders paramsRef transcriptRef
                                     initialPrevious persist projectRoot home cwd (Just loaded.loadedTokenProvider) agentsContext escPaused interrupt
-                                    multiCtx subagentSessions pendingNotices subagentStoreRoot usageRef noticingBackend)
+                                    multiCtx subagentSessions pendingNotices subagentStoreRoot usageRef activeBackend)
                             >>= \case
-                                Left (CodexAuthFailed err) -> die ("openai auth: " <> show err)
+                                Left (CodexAuthFailed err) ->
+                                    case transition of
+                                        Just active
+                                            | active.transitionCause == AutomaticFallback ->
+                                                pure (RunProviderStartFailed err)
+                                        _ -> die ("openai auth: " <> show err)
                                 Right result -> pure result
                     XAIProvider -> do
                         xaiOptions <- XAI.clientOptionsFromEnv
@@ -553,9 +569,11 @@ runAgent options pendingTurn unavailableProviders = do
                                 withPendingNotices pendingNotices $
                                     xaiBackend xaiOptions loaded.loadedTokenProvider
                                         (readIORef paramsRef) transcriptRef
+                        activeBackend <-
+                            prepareTransitionBackend transition persist backend
                         runSession options provider policy tools toolEnv planMode prompt pendingTurn unavailableProviders paramsRef transcriptRef
                             initialPrevious persist projectRoot home cwd (Just loaded.loadedTokenProvider) agentsContext escPaused interrupt
-                            multiCtx subagentSessions pendingNotices subagentStoreRoot usageRef backend
+                            multiCtx subagentSessions pendingNotices subagentStoreRoot usageRef activeBackend
                     OpenRouterProvider -> do
                         openRouterOptions <- OpenRouter.clientOptionsFromEnv
                         case multiCtx of
@@ -579,9 +597,11 @@ runAgent options pendingTurn unavailableProviders = do
                                 withPendingNotices pendingNotices $
                                     openRouterBackend openRouterOptions loaded.loadedTokenProvider
                                         (readIORef paramsRef) transcriptRef
+                        activeBackend <-
+                            prepareTransitionBackend transition persist backend
                         runSession options provider policy tools toolEnv planMode prompt pendingTurn unavailableProviders paramsRef transcriptRef
                             initialPrevious persist projectRoot home cwd (Just loaded.loadedTokenProvider) agentsContext escPaused interrupt
-                            multiCtx subagentSessions pendingNotices subagentStoreRoot usageRef backend
+                            multiCtx subagentSessions pendingNotices subagentStoreRoot usageRef activeBackend
 
 preparePersistence
     :: CliOptions
@@ -704,6 +724,7 @@ runSession options provider policy tools toolEnv planMode prompt pendingTurn una
     startedAtRef <- newIORef Nothing
     allowedToolsRef <- newIORef Set.empty
     modelRef <- newIORef =<< (currentModel <$> readIORef paramsRef)
+    unavailableProvidersRef <- newIORef unavailableProviders
     ioLock <- newMVar ()
     previous <- newIORef initialPrevious
     let sessionReset = do
@@ -765,7 +786,7 @@ runSession options provider policy tools toolEnv planMode prompt pendingTurn una
             { sessionLoop = config
             , sessionRender = render
             , sessionProvider = provider
-            , sessionUnavailableProviders = unavailableProviders
+            , sessionUnavailableProviders = unavailableProvidersRef
             , sessionPrevious = previous
             , sessionPrinted = printed
             , sessionParams = paramsRef
@@ -791,29 +812,24 @@ runSession options provider policy tools toolEnv planMode prompt pendingTurn una
         Nothing -> case prompt of
             Just text -> do
                 result <- runOneTurn env text [UserMessage text]
-                finishTurn env True text [UserMessage text] result
+                finishTurn env True result
             Nothing ->
                 repl env
 
 runPendingTurn :: SessionEnv -> PendingTurn -> IO RunResult
 runPendingTurn env pending = do
+    writeIORef env.sessionPlanMode.planStateRef pending.pendingPlanState
     result <- runOneTurn env pending.pendingPromptText pending.pendingInputs
-    finishTurn
-        env
-        pending.pendingExitAfter
-        pending.pendingPromptText
-        pending.pendingInputs
-        result
+    finishTurn env pending.pendingExitAfter result
 
 finishTurn
     :: SessionEnv
     -> Bool
-    -> Text
-    -> [TurnInput]
     -> TurnResult
     -> IO RunResult
-finishTurn env exitAfter promptText inputs = \case
+finishTurn env exitAfter = \case
     TurnSucceeded -> do
+        writeIORef env.sessionUnavailableProviders []
         putTrailingNewline env.sessionPrinted
         if exitAfter
             then pure RunQuit
@@ -824,16 +840,11 @@ finishTurn env exitAfter promptText inputs = \case
             else do
                 putTrailingNewline env.sessionPrinted
                 repl env
-    TurnUsageExhausted apiError ->
-        requestAutomaticProviderFallback env promptText inputs apiError >>= \case
-            Just providerSwitch ->
-                pure $ RunSwitchProvider providerSwitch
-                    { switchPendingTurn = Just PendingTurn
-                        { pendingPromptText = promptText
-                        , pendingInputs = inputs
-                        , pendingExitAfter = exitAfter
-                        }
-                    }
+    TurnProviderUnavailable apiError pending ->
+        requestAutomaticProviderFallback
+            env apiError (setPendingExitAfter exitAfter pending) >>= \case
+            Just providerTransition ->
+                pure (RunSwitchProvider providerTransition)
             Nothing ->
                 if exitAfter
                     then exitFailure
@@ -955,7 +966,7 @@ replWithDraft env@SessionEnv
                                                     }
                                                 ]
                                 result <- runOneTurn env text turnInputs
-                                finishTurn env False text turnInputs result
+                                finishTurn env False result
                     ReplPaste{pasteImmediate, pasteCaption} -> do
                         color <- resolveColor stdout
                         errColor <- resolveColor stderr
@@ -1004,7 +1015,7 @@ replWithDraft env@SessionEnv
                                                     }
                                                 ]
                                         result <- runOneTurn env promptText turnInputs
-                                        finishTurn env False promptText turnInputs result
+                                        finishTurn env False result
                                     else do
                                         queueAttachedImages
                                             attachmentsRef previewIdRef color images
@@ -1311,97 +1322,201 @@ requestModelProviderSwitch
     :: ModelOption
     -> Maybe (IORef (Either SessionCreate SessionHandle))
     -> IO (Either Text RunResult)
-requestModelProviderSwitch choice persist = case persist of
-    Nothing -> pure $ Left
-        "switching providers requires a persisted interactive session"
-    Just slotRef ->
-        loadAuth (Just choice.modelProvider) >>= \case
-            Left err -> pure $ Left $
-                "cannot switch to "
-                    <> providerSlug choice.modelProvider
-                    <> ": "
-                    <> Text.pack err
-            Right loaded
-                | loaded.loadedProvider /= choice.modelProvider ->
-                    pure $ Left $
-                        "cannot switch to "
-                            <> providerSlug choice.modelProvider
-                            <> ": auth resolved "
-                            <> providerSlug loaded.loadedProvider
-                | otherwise -> do
-                    slot <- readIORef slotRef
-                    handle <- case slot of
-                        Left pending -> do
-                            writeIORef slotRef $ Left pending
-                                { createProvider = choice.modelProvider
-                                , createModel = choice.modelId
-                                }
-                            ensureSession slotRef
-                        Right currentHandle -> do
-                            now <- getCurrentTime
-                            let meta = currentHandle.sessionMeta
-                                    { metaProvider = choice.modelProvider
-                                    , metaModel = choice.modelId
-                                    , metaLastResponseId = Nothing
-                                    , metaUpdatedAt = now
-                                    }
-                                updated = currentHandle { sessionMeta = meta }
-                            writeSessionMeta currentHandle.sessionMetaPath meta
-                            writeIORef slotRef (Right updated)
-                            pure updated
-                    color <- resolveColor stdout
-                    Text.putStrLn $ roleMuted color $
-                        glyphOk
-                            <> "switching to "
-                            <> providerSlug choice.modelProvider
-                            <> "/"
-                            <> choice.modelId
-                            <> " (conversation continued locally)"
-                    pure $ Right $ RunSwitchProvider ProviderSwitch
-                        { switchSessionId = handle.sessionMeta.metaId
-                        , switchPendingTurn = Nothing
-                        , switchUnavailableProviders = []
-                        }
+requestModelProviderSwitch choice persist =
+    prepareProviderTransition
+        ManualTransition [] Nothing choice persist >>= \case
+            Left err -> pure (Left err)
+            Right transition -> do
+                color <- resolveColor stdout
+                Text.putStrLn $ roleMuted color $
+                    glyphOk
+                        <> "switching to "
+                        <> providerSlug choice.modelProvider
+                        <> "/"
+                        <> choice.modelId
+                        <> " (conversation continued locally)"
+                pure (Right (RunSwitchProvider transition))
 
 requestAutomaticProviderFallback
     :: SessionEnv
-    -> Text
-    -> [TurnInput]
     -> ApiError
-    -> IO (Maybe ProviderSwitch)
-requestAutomaticProviderFallback env _promptText _inputs apiError = do
-    let current = env.sessionProvider
-        unavailable = markUnavailable current env.sessionUnavailableProviders
-        candidates =
-            fallbackCandidates env.sessionUnavailableProviders current apiError
+    -> PendingTurn
+    -> IO (Maybe ProviderTransition)
+requestAutomaticProviderFallback env apiError pending = do
+    sessionId <- ensureTransitionSessionId env.sessionPersist
+    unavailable <- readIORef env.sessionUnavailableProviders
+    chooseAutomaticProviderTransition
+        env.sessionProvider
+        unavailable
+        sessionId
+        pending
+        apiError
+
+continueAutomaticFallback
+    :: ProviderTransition
+    -> ApiError
+    -> IO (Maybe ProviderTransition)
+continueAutomaticFallback failed apiError =
+    case failed.transitionPendingTurn of
+        Nothing -> pure Nothing
+        Just pending ->
+            chooseAutomaticProviderTransition
+                failed.transitionTarget.modelProvider
+                failed.transitionUnavailableProviders
+                failed.transitionSessionId
+                pending
+                apiError
+
+chooseAutomaticProviderTransition
+    :: Provider
+    -> [Provider]
+    -> Maybe Text
+    -> PendingTurn
+    -> ApiError
+    -> IO (Maybe ProviderTransition)
+chooseAutomaticProviderTransition current unavailable0 sessionId pending apiError =
     tryCandidates unavailable candidates
   where
+    unavailable = markUnavailable current unavailable0
+    candidates = fallbackCandidates unavailable0 current apiError
+
     tryCandidates unavailable = \case
         [] -> do
             color <- resolveColor stderr
             putTextLn stderr $ roleError color $
-                "usage exhausted; no other configured provider account is available"
+                "provider unavailable; no other configured provider account is available: "
+                    <> Text.pack (show apiError)
             pure Nothing
         choice : rest ->
-            requestModelProviderSwitch choice env.sessionPersist >>= \case
-                Left _ ->
+            validateProviderTarget choice >>= \case
+                Left err -> do
+                    color <- resolveColor stderr
+                    putTextLn stderr $ roleMuted color $
+                        "skipping "
+                            <> providerSlug choice.modelProvider
+                            <> ": "
+                            <> err
                     tryCandidates
                         (markUnavailable choice.modelProvider unavailable)
                         rest
-                Right (RunSwitchProvider providerSwitch) -> do
+                Right () -> do
                     color <- resolveColor stderr
                     putTextLn stderr $ roleWarn color $
                         glyphWarn
-                            <> providerSlug env.sessionProvider
-                            <> " usage exhausted; switching to best available model "
+                            <> providerSlug current
+                            <> " unavailable; switching to "
                             <> providerSlug choice.modelProvider
                             <> "/"
                             <> choice.modelId
-                    pure $ Just providerSwitch
-                        { switchUnavailableProviders = unavailable
+                    pure $ Just ProviderTransition
+                        { transitionTarget = choice
+                        , transitionSessionId = sessionId
+                        , transitionPendingTurn = Just pending
+                        , transitionUnavailableProviders = unavailable
+                        , transitionCause = AutomaticFallback
                         }
-                Right _ ->
-                    tryCandidates unavailable rest
+
+prepareProviderTransition
+    :: TransitionCause
+    -> [Provider]
+    -> Maybe PendingTurn
+    -> ModelOption
+    -> Maybe (IORef (Either SessionCreate SessionHandle))
+    -> IO (Either Text ProviderTransition)
+prepareProviderTransition cause unavailable pending choice persist =
+    validateProviderTarget choice >>= \case
+        Left err -> pure (Left err)
+        Right () -> do
+            sessionId <- ensureTransitionSessionId persist
+            pure $ Right ProviderTransition
+                { transitionTarget = choice
+                , transitionSessionId = sessionId
+                , transitionPendingTurn = pending
+                , transitionUnavailableProviders = unavailable
+                , transitionCause = cause
+                }
+
+validateProviderTarget :: ModelOption -> IO (Either Text ())
+validateProviderTarget choice =
+    loadAuth (Just choice.modelProvider) >>= \case
+        Left err -> pure $ Left $
+            "cannot switch to "
+                <> providerSlug choice.modelProvider
+                <> ": "
+                <> Text.pack err
+        Right loaded
+            | loaded.loadedProvider /= choice.modelProvider ->
+                pure $ Left $
+                    "cannot switch to "
+                        <> providerSlug choice.modelProvider
+                        <> ": auth resolved "
+                        <> providerSlug loaded.loadedProvider
+            | otherwise -> pure (Right ())
+
+ensureTransitionSessionId
+    :: Maybe (IORef (Either SessionCreate SessionHandle))
+    -> IO (Maybe Text)
+ensureTransitionSessionId Nothing = pure Nothing
+ensureTransitionSessionId (Just slotRef) = do
+    handle <- ensureSession slotRef
+    pure (Just handle.sessionMeta.metaId)
+
+commitProviderTransition
+    :: Maybe ProviderTransition
+    -> Maybe (IORef (Either SessionCreate SessionHandle))
+    -> IO ()
+commitProviderTransition Nothing _ = pure ()
+commitProviderTransition _ Nothing = pure ()
+commitProviderTransition (Just transition) (Just slotRef) = do
+    slot <- readIORef slotRef
+    case slot of
+        Left pending ->
+            writeIORef slotRef $ Left pending
+                { createProvider = transition.transitionTarget.modelProvider
+                , createModel = transition.transitionTarget.modelId
+                }
+        Right handle -> do
+            now <- getCurrentTime
+            let meta = handle.sessionMeta
+                    { metaProvider = transition.transitionTarget.modelProvider
+                    , metaModel = transition.transitionTarget.modelId
+                    , metaLastResponseId = Nothing
+                    , metaUpdatedAt = now
+                    }
+            writeSessionMeta handle.sessionMetaPath meta
+            writeIORef slotRef (Right handle { sessionMeta = meta })
+
+prepareTransitionBackend
+    :: Maybe ProviderTransition
+    -> Maybe (IORef (Either SessionCreate SessionHandle))
+    -> Backend
+    -> IO Backend
+prepareTransitionBackend Nothing _ backend = pure backend
+prepareTransitionBackend (Just transition) persist backend
+    | transition.transitionCause == ManualTransition = do
+        commitProviderTransition (Just transition) persist
+        pure backend
+    | otherwise = do
+        committed <- newIORef False
+        pure $ commitBackendOnSuccess committed transition persist backend
+
+commitBackendOnSuccess
+    :: IORef Bool
+    -> ProviderTransition
+    -> Maybe (IORef (Either SessionCreate SessionHandle))
+    -> Backend
+    -> Backend
+commitBackendOnSuccess committed transition persist (Backend submit) =
+    Backend \previous inputs onEvent -> do
+        result <- submit previous inputs onEvent
+        case result of
+            Right _ -> do
+                shouldCommit <- atomicModifyIORef' committed \done ->
+                    (True, not done)
+                when shouldCommit $
+                    commitProviderTransition (Just transition) persist
+            Left _ -> pure ()
+        pure result
 
 markUnavailable :: Provider -> [Provider] -> [Provider]
 markUnavailable provider unavailable
@@ -1461,7 +1576,7 @@ requestReload persist = do
                     (glyphSession <> "reloading; session " <> handle.sessionMeta.metaId))
             pure RunReload
 
-enterPlanFromSlash :: SessionEnv -> Maybe Text -> IO (Maybe ProviderSwitch)
+enterPlanFromSlash :: SessionEnv -> Maybe Text -> IO (Maybe ProviderTransition)
 enterPlanFromSlash env@SessionEnv{sessionPlanMode = planMode, sessionPersist = persist, sessionPrinted = printed} maybeDescription = do
     discardStore <- newIORef Nothing
     color <- resolveColor stderr
@@ -1491,18 +1606,12 @@ enterPlanFromSlash env@SessionEnv{sessionPlanMode = planMode, sessionPersist = p
                 inputs = [UserMessage description]
             result <- runOneTurn planEnv description inputs
             case result of
-                TurnUsageExhausted apiError ->
+                TurnProviderUnavailable apiError pending ->
                     requestAutomaticProviderFallback
-                        planEnv description inputs apiError >>= \case
+                        planEnv apiError pending >>= \case
                             Nothing -> pure Nothing
-                            Just providerSwitch ->
-                                pure $ Just providerSwitch
-                                    { switchPendingTurn = Just PendingTurn
-                                        { pendingPromptText = description
-                                        , pendingInputs = inputs
-                                        , pendingExitAfter = False
-                                        }
-                                    }
+                            Just providerTransition ->
+                                pure (Just providerTransition)
                 _ -> do
                     putTrailingNewline printed
                     pure Nothing

--- a/packages/agent-cli/src/Agent/CLI/ProviderFallback.hs
+++ b/packages/agent-cli/src/Agent/CLI/ProviderFallback.hs
@@ -1,0 +1,60 @@
+-- | Automatic cross-provider fallback policy.
+module Agent.CLI.ProviderFallback
+    ( fallbackCandidates
+    , isUsageExhausted
+    , rankedModels
+    ) where
+
+import Agent.CLI.Models (ModelOption(..), modelCatalog)
+import Agent.Error (ApiError(..), ErrorType(..))
+import Agent.Provider (Provider(..))
+import Data.List (nubBy, sortOn)
+
+-- | Curated models ordered from strongest to weakest for automatic selection.
+--
+-- Availability is account-level: once a provider reports that all of its
+-- credentials are exhausted, trying a weaker model on the same account would
+-- only loop. 'fallbackCandidates' therefore keeps the highest-ranked model for
+-- each still-eligible provider.
+rankedModels :: [ModelOption]
+rankedModels = sortOn modelRank modelCatalog
+  where
+    modelRank option = case (option.modelProvider, option.modelId) of
+        (OpenAIProvider, "gpt-5.6-sol") -> 0 :: Int
+        (XAIProvider, "grok-4.6") -> 10
+        (OpenAIProvider, "gpt-5.6-terra") -> 20
+        (OpenAIProvider, "gpt-5.6-luna") -> 30
+        (XAIProvider, "grok-4.5") -> 40
+        (XAIProvider, "grok-4.5-mini") -> 50
+        (OpenRouterProvider, "openai/gpt-5.1") -> 60
+        (OpenRouterProvider, "anthropic/claude-sonnet-4") -> 70
+        (OpenRouterProvider, "x-ai/grok-4") -> 80
+        (OpenRouterProvider, "google/gemini-2.5-pro") -> 90
+        (XAIProvider, "grok-3") -> 100
+        _ -> 1000
+
+-- | Return the best model for every provider that may still have a usable
+-- account. Providers already observed as exhausted, including the provider
+-- that produced this error, are excluded.
+fallbackCandidates
+    :: [Provider]
+    -> Provider
+    -> ApiError
+    -> [ModelOption]
+fallbackCandidates unavailable current err
+    | not (isUsageExhausted err) = []
+    | otherwise =
+        filter
+            (\option ->
+                option.modelProvider /= current
+                    && option.modelProvider `notElem` unavailable)
+            (nubBy sameProvider rankedModels)
+  where
+    sameProvider left right =
+        left.modelProvider == right.modelProvider
+
+isUsageExhausted :: ApiError -> Bool
+isUsageExhausted = \case
+    CredentialsExhausted{} -> True
+    ProviderError UsageLimitReached _ _ -> True
+    _ -> False

--- a/packages/agent-cli/src/Agent/CLI/ProviderFallback.hs
+++ b/packages/agent-cli/src/Agent/CLI/ProviderFallback.hs
@@ -1,6 +1,7 @@
 -- | Automatic cross-provider fallback policy.
 module Agent.CLI.ProviderFallback
     ( fallbackCandidates
+    , isProviderUnavailable
     , isUsageExhausted
     , rankedModels
     ) where
@@ -42,7 +43,7 @@ fallbackCandidates
     -> ApiError
     -> [ModelOption]
 fallbackCandidates unavailable current err
-    | not (isUsageExhausted err) = []
+    | not (isProviderUnavailable err) = []
     | otherwise =
         filter
             (\option ->
@@ -58,3 +59,16 @@ isUsageExhausted = \case
     CredentialsExhausted{} -> True
     ProviderError UsageLimitReached _ _ -> True
     _ -> False
+
+-- | Failures for which rebuilding the same provider cannot make progress.
+-- Authentication failures are included so an automatic transition whose
+-- replacement backend rejects its credentials can continue to another
+-- configured provider.
+isProviderUnavailable :: ApiError -> Bool
+isProviderUnavailable err
+    | isUsageExhausted err = True
+    | otherwise = case err of
+        HttpError status _ -> status == 401 || status == 403
+        ProviderError AuthenticationError _ _ -> True
+        ProviderError PermissionError _ _ -> True
+        _ -> False

--- a/packages/agent-cli/src/Agent/CLI/ProviderTransition.hs
+++ b/packages/agent-cli/src/Agent/CLI/ProviderTransition.hs
@@ -1,0 +1,61 @@
+-- | Provider-independent state carried while rebuilding a backend.
+module Agent.CLI.ProviderTransition
+    ( PendingTurn(..)
+    , ProviderTransition(..)
+    , TransitionCause(..)
+    , TurnResult(..)
+    , applyProviderTransition
+    , setPendingExitAfter
+    ) where
+
+import Agent.CLI.Models (ModelOption(..))
+import Agent.CLI.Options (CliOptions(..))
+import Agent.Error (ApiError)
+import Agent.Loop (TurnInput)
+import Agent.Provider (Provider)
+import Agent.Tools.PlanMode (PlanModeState)
+import Control.Applicative ((<|>))
+import Data.Text (Text)
+
+data PendingTurn = PendingTurn
+    { pendingPromptText :: !Text
+    , pendingInputs :: ![TurnInput]
+    , pendingExitAfter :: !Bool
+    , pendingPlanState :: !PlanModeState
+    }
+
+data TransitionCause
+    = ManualTransition
+    | AutomaticFallback
+    deriving (Eq, Show)
+
+data ProviderTransition = ProviderTransition
+    { transitionTarget :: !ModelOption
+    , transitionSessionId :: !(Maybe Text)
+    , transitionPendingTurn :: !(Maybe PendingTurn)
+    , transitionUnavailableProviders :: ![Provider]
+    , transitionCause :: !TransitionCause
+    }
+
+data TurnResult
+    = TurnSucceeded
+    | TurnFailed
+    | TurnProviderUnavailable !ApiError !PendingTurn
+
+-- | Rebuild provider-specific state without changing how the invocation was
+-- launched. In particular, one-shot prompt flags remain set so approval policy
+-- and autonomous prompting do not silently become interactive after fallback.
+applyProviderTransition :: CliOptions -> ProviderTransition -> CliOptions
+applyProviderTransition options transition =
+    options
+        { optProvider = Just transition.transitionTarget.modelProvider
+        , optModel = Just transition.transitionTarget.modelId
+        , optCwd = Nothing
+        , optWorktree = False
+        , optEffort = Nothing
+        , optResume = transition.transitionSessionId <|> options.optResume
+        }
+
+setPendingExitAfter :: Bool -> PendingTurn -> PendingTurn
+setPendingExitAfter exitAfter pending =
+    pending { pendingExitAfter = exitAfter }

--- a/packages/agent-cli/src/Agent/CLI/SessionEnv.hs
+++ b/packages/agent-cli/src/Agent/CLI/SessionEnv.hs
@@ -18,7 +18,7 @@ data SessionEnv = SessionEnv
     { sessionLoop :: !LoopConfig
     , sessionRender :: !RenderConfig
     , sessionProvider :: !Provider
-    , sessionUnavailableProviders :: ![Provider]
+    , sessionUnavailableProviders :: !(IORef [Provider])
     , sessionPrevious :: !(IORef (Maybe Text))
     , sessionPrinted :: !(IORef Bool)
     , sessionParams :: !(IORef ResponseCreateParams)

--- a/packages/agent-cli/src/Agent/CLI/SessionEnv.hs
+++ b/packages/agent-cli/src/Agent/CLI/SessionEnv.hs
@@ -18,6 +18,7 @@ data SessionEnv = SessionEnv
     { sessionLoop :: !LoopConfig
     , sessionRender :: !RenderConfig
     , sessionProvider :: !Provider
+    , sessionUnavailableProviders :: ![Provider]
     , sessionPrevious :: !(IORef (Maybe Text))
     , sessionPrinted :: !(IORef Bool)
     , sessionParams :: !(IORef ResponseCreateParams)

--- a/packages/agent-cli/src/Agent/CLI/Turn.hs
+++ b/packages/agent-cli/src/Agent/CLI/Turn.hs
@@ -1,11 +1,13 @@
 -- | Execute one model turn and commit its observable session state.
 module Agent.CLI.Turn
-    ( runOneTurn
+    ( TurnResult(..)
+    , runOneTurn
     ) where
 
 import Agent.CLI.CancelWatch (withEscCancel)
 import Agent.CLI.Interrupt (withTurnCancel)
 import Agent.CLI.Plan (extractProposedPlan)
+import Agent.CLI.ProviderFallback (isUsageExhausted)
 import Agent.CLI.Render
     ( RenderConfig(..)
     , clearThinking
@@ -32,6 +34,7 @@ import Agent.CLI.Style
     )
 import Agent.CLI.Terminal (resolveColor)
 import Agent.CLI.Timestamp (stampTurnInputs, stripBracketedTimestamps)
+import Agent.Error (ApiError)
 import Agent.Loop
     ( LoopConfig(..)
     , LoopError(..)
@@ -66,7 +69,12 @@ import qualified Data.Text as Text
 import Data.Time.Clock (diffUTCTime, getCurrentTime)
 import System.IO (hIsTerminalDevice, stderr, stdout)
 
-runOneTurn :: SessionEnv -> Text -> [TurnInput] -> IO Bool
+data TurnResult
+    = TurnSucceeded
+    | TurnFailed
+    | TurnUsageExhausted ApiError
+
+runOneTurn :: SessionEnv -> Text -> [TurnInput] -> IO TurnResult
 runOneTurn env@SessionEnv
     { sessionLoop = config
     , sessionRender = render
@@ -132,13 +140,20 @@ runOneTurn env@SessionEnv
             putTextLn stderr (formatLoopErrorColored color (LoopCancelled toolResults))
             model <- readIORef render.renderModelRef
             putTextLn stderr (formatTurnStatus color "cancelled" (elapsedDetail model))
-            pure True
+            pure TurnSucceeded
         Left err -> do
-            color <- resolveColor stderr
-            putTextLn stderr (formatLoopErrorColored color err)
-            model <- readIORef render.renderModelRef
-            putTextLn stderr (formatTurnStatus color "error" (elapsedDetail model))
-            pure False
+            afterItems <- readIORef transcriptRef
+            case err of
+                LoopTransport apiError
+                    | length afterItems == length beforeItems
+                    , isUsageExhausted apiError ->
+                        pure (TurnUsageExhausted apiError)
+                _ -> do
+                    color <- resolveColor stderr
+                    putTextLn stderr (formatLoopErrorColored color err)
+                    model <- readIORef render.renderModelRef
+                    putTextLn stderr (formatTurnStatus color "error" (elapsedDetail model))
+                    pure TurnFailed
         Right loopResult -> do
             writeIORef previous (Just loopResult.finalResponseId)
             modifyIORef' usageRef (`addTokenUsage` loopResult.tokenUsage)
@@ -188,11 +203,10 @@ runOneTurn env@SessionEnv
                             (cliWindowTitle handle'.sessionMeta.metaCwd
                                 (Just handle'.sessionMeta.metaTitle))
             case followUp of
-                Nothing -> pure True
+                Nothing -> pure TurnSucceeded
                 Just notes -> do
                     writeIORef printed False
-                    _ <- runOneTurn env notes [UserMessage notes]
-                    pure True
+                    runOneTurn env notes [UserMessage notes]
 
 isLeftSlot :: Either a b -> Bool
 isLeftSlot = \case

--- a/packages/agent-cli/src/Agent/CLI/Turn.hs
+++ b/packages/agent-cli/src/Agent/CLI/Turn.hs
@@ -1,13 +1,16 @@
 -- | Execute one model turn and commit its observable session state.
 module Agent.CLI.Turn
-    ( TurnResult(..)
-    , runOneTurn
+    ( runOneTurn
     ) where
 
 import Agent.CLI.CancelWatch (withEscCancel)
 import Agent.CLI.Interrupt (withTurnCancel)
 import Agent.CLI.Plan (extractProposedPlan)
-import Agent.CLI.ProviderFallback (isUsageExhausted)
+import Agent.CLI.ProviderFallback (isProviderUnavailable)
+import Agent.CLI.ProviderTransition
+    ( PendingTurn(..)
+    , TurnResult(..)
+    )
 import Agent.CLI.Render
     ( RenderConfig(..)
     , clearThinking
@@ -34,7 +37,6 @@ import Agent.CLI.Style
     )
 import Agent.CLI.Terminal (resolveColor)
 import Agent.CLI.Timestamp (stampTurnInputs, stripBracketedTimestamps)
-import Agent.Error (ApiError)
 import Agent.Loop
     ( LoopConfig(..)
     , LoopError(..)
@@ -68,11 +70,6 @@ import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Time.Clock (diffUTCTime, getCurrentTime)
 import System.IO (hIsTerminalDevice, stderr, stdout)
-
-data TurnResult
-    = TurnSucceeded
-    | TurnFailed
-    | TurnUsageExhausted ApiError
 
 runOneTurn :: SessionEnv -> Text -> [TurnInput] -> IO TurnResult
 runOneTurn env@SessionEnv
@@ -146,8 +143,14 @@ runOneTurn env@SessionEnv
             case err of
                 LoopTransport apiError
                     | length afterItems == length beforeItems
-                    , isUsageExhausted apiError ->
-                        pure (TurnUsageExhausted apiError)
+                    , isProviderUnavailable apiError -> do
+                        planState <- readIORef planMode.planStateRef
+                        pure $ TurnProviderUnavailable apiError PendingTurn
+                            { pendingPromptText = promptText
+                            , pendingInputs = inputs
+                            , pendingExitAfter = False
+                            , pendingPlanState = planState
+                            }
                 _ -> do
                     color <- resolveColor stderr
                     putTextLn stderr (formatLoopErrorColored color err)

--- a/packages/agent-cli/test/Agent/CLI/ProviderFallbackSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ProviderFallbackSpec.hs
@@ -1,0 +1,67 @@
+module Agent.CLI.ProviderFallbackSpec (spec) where
+
+import Agent.CLI.Models (ModelOption(..))
+import Agent.CLI.ProviderFallback
+    ( fallbackCandidates
+    , rankedModels
+    )
+import Agent.Error (ApiError(..), ErrorType(..))
+import Agent.Provider (Provider(..))
+import Data.List (elemIndex)
+import Data.Time.Calendar (fromGregorian)
+import Data.Time.Clock (UTCTime(..))
+import Test.Hspec
+
+spec :: Spec
+spec = do
+    describe "rankedModels" do
+        it "prefers sol over luna" do
+            let ids = map (.modelId) rankedModels
+            elemIndex "gpt-5.6-sol" ids
+                `shouldSatisfy` (< elemIndex "gpt-5.6-luna" ids)
+
+        it "puts the strongest OpenAI model first" do
+            fmap (\model -> (model.modelProvider, model.modelId))
+                (safeHead rankedModels)
+                `shouldBe` Just (OpenAIProvider, "gpt-5.6-sol")
+
+    describe "fallbackCandidates" do
+        let exhausted =
+                CredentialsExhausted
+                    (UTCTime (fromGregorian 2026 8 20) 0)
+
+        it "selects the best model for each other provider" do
+            map (\model -> (model.modelProvider, model.modelId))
+                (fallbackCandidates [] XAIProvider exhausted)
+                `shouldBe`
+                    [ (OpenAIProvider, "gpt-5.6-sol")
+                    , (OpenRouterProvider, "openai/gpt-5.1")
+                    ]
+
+        it "falls back from OpenAI to the best configured alternatives" do
+            map (\model -> (model.modelProvider, model.modelId))
+                (fallbackCandidates [] OpenAIProvider exhausted)
+                `shouldBe`
+                    [ (XAIProvider, "grok-4.6")
+                    , (OpenRouterProvider, "openai/gpt-5.1")
+                    ]
+
+        it "skips providers already found unavailable" do
+            map (.modelProvider)
+                (fallbackCandidates [OpenAIProvider] XAIProvider exhausted)
+                `shouldBe` [OpenRouterProvider]
+
+        it "accepts direct usage-limit errors from every provider" do
+            fallbackCandidates [] OpenRouterProvider
+                (ProviderError UsageLimitReached "quota exhausted" (Just 3600))
+                `shouldSatisfy` (not . null)
+
+        it "does not switch for transient capacity failures" do
+            fallbackCandidates [] XAIProvider
+                (ProviderError OverloadedError "busy" (Just 30))
+                `shouldBe` []
+
+safeHead :: [a] -> Maybe a
+safeHead = \case
+    [] -> Nothing
+    value : _ -> Just value

--- a/packages/agent-cli/test/Agent/CLI/ProviderFallbackSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ProviderFallbackSpec.hs
@@ -61,6 +61,12 @@ spec = do
                 (ProviderError OverloadedError "busy" (Just 30))
                 `shouldBe` []
 
+        it "can continue past a replacement provider with rejected auth" do
+            map (.modelProvider)
+                (fallbackCandidates [XAIProvider] OpenAIProvider
+                    (ProviderError AuthenticationError "rejected" Nothing))
+                `shouldBe` [OpenRouterProvider]
+
 safeHead :: [a] -> Maybe a
 safeHead = \case
     [] -> Nothing

--- a/packages/agent-cli/test/Agent/CLI/ProviderTransitionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ProviderTransitionSpec.hs
@@ -1,0 +1,58 @@
+module Agent.CLI.ProviderTransitionSpec (spec) where
+
+import Agent.CLI.Models (ModelOption(..))
+import Agent.CLI.Options (CliOptions(..), defaultCliOptions, isOneShot)
+import Agent.CLI.ProviderTransition
+import Agent.Provider (Provider(..))
+import Agent.Tools.PlanMode (PlanModeState(..))
+import Data.Text (Text)
+import Test.Hspec
+
+spec :: Spec
+spec = do
+    describe "applyProviderTransition" do
+        it "preserves one-shot invocation mode without requiring persistence" do
+            let options = defaultCliOptions
+                    { optPrompt = Just "hello"
+                    , optProvider = Just XAIProvider
+                    }
+                transitioned = applyProviderTransition options
+                    (transition Nothing Nothing)
+            isOneShot transitioned `shouldBe` True
+            transitioned.optPrompt `shouldBe` Just "hello"
+            transitioned.optResume `shouldBe` Nothing
+            transitioned.optProvider `shouldBe` Just OpenAIProvider
+            transitioned.optModel `shouldBe` Just "gpt-5.6-sol"
+
+        it "uses a persisted session when one exists" do
+            let transitioned = applyProviderTransition defaultCliOptions
+                    (transition (Just "session-1") Nothing)
+            transitioned.optResume `shouldBe` Just "session-1"
+
+    describe "setPendingExitAfter" do
+        it "preserves the plan state while changing exit behavior" do
+            let pending = PendingTurn
+                    { pendingPromptText = "make a plan"
+                    , pendingInputs = []
+                    , pendingExitAfter = False
+                    , pendingPlanState = PlanActive
+                    }
+                updated = setPendingExitAfter True pending
+            updated.pendingExitAfter `shouldBe` True
+            updated.pendingPlanState `shouldBe` PlanActive
+
+transition
+    :: Maybe Text
+    -> Maybe PendingTurn
+    -> ProviderTransition
+transition sessionId pending = ProviderTransition
+    { transitionTarget = ModelOption
+        { modelProvider = OpenAIProvider
+        , modelId = "gpt-5.6-sol"
+        , modelLabel = Nothing
+        }
+    , transitionSessionId = sessionId
+    , transitionPendingTurn = pending
+    , transitionUnavailableProviders = [XAIProvider]
+    , transitionCause = AutomaticFallback
+    }

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -19,6 +19,7 @@ import qualified Agent.CLI.PlanSpec as PlanSpec
 import qualified Agent.CLI.ProgressSpec as ProgressSpec
 import qualified Agent.CLI.ProjectSpec as ProjectSpec
 import qualified Agent.CLI.PromptSpec as PromptSpec
+import qualified Agent.CLI.ProviderFallbackSpec as ProviderFallbackSpec
 import qualified Agent.CLI.RenderSpec as RenderSpec
 import qualified Agent.CLI.ReplStatusSpec as ReplStatusSpec
 import qualified Agent.CLI.ResumeSpec as ResumeSpec
@@ -48,6 +49,7 @@ main = hspec do
     ProgressSpec.spec
     ProjectSpec.spec
     PromptSpec.spec
+    ProviderFallbackSpec.spec
     RenderSpec.spec
     ReplStatusSpec.spec
     ResumeSpec.spec

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -20,6 +20,7 @@ import qualified Agent.CLI.ProgressSpec as ProgressSpec
 import qualified Agent.CLI.ProjectSpec as ProjectSpec
 import qualified Agent.CLI.PromptSpec as PromptSpec
 import qualified Agent.CLI.ProviderFallbackSpec as ProviderFallbackSpec
+import qualified Agent.CLI.ProviderTransitionSpec as ProviderTransitionSpec
 import qualified Agent.CLI.RenderSpec as RenderSpec
 import qualified Agent.CLI.ReplStatusSpec as ReplStatusSpec
 import qualified Agent.CLI.ResumeSpec as ResumeSpec
@@ -50,6 +51,7 @@ main = hspec do
     ProjectSpec.spec
     PromptSpec.spec
     ProviderFallbackSpec.spec
+    ProviderTransitionSpec.spec
     RenderSpec.spec
     ReplStatusSpec.spec
     ResumeSpec.spec

--- a/packages/agent-xai/src/Agent/XAI/Error.hs
+++ b/packages/agent-xai/src/Agent/XAI/Error.hs
@@ -66,6 +66,7 @@ isFreeLimitBody :: Text -> Bool
 isFreeLimitBody body =
     "grok.com/supergrok" `Text.isInfixOf` lowered
         || "upgrade to a grok subscription" `Text.isInfixOf` lowered
+        || "grok build usage balance exhausted" `Text.isInfixOf` lowered
   where
     lowered = Text.toLower body
 

--- a/packages/agent-xai/test/Agent/XAI/ResponsesSpec.hs
+++ b/packages/agent-xai/test/Agent/XAI/ResponsesSpec.hs
@@ -127,6 +127,11 @@ spec = do
                 ProviderError UsageLimitReached _ _ -> pure ()
                 other -> expectationFailure ("expected UsageLimitReached, got " <> show other)
 
+        it "recognises an exhausted Grok Build usage balance" do
+            let body = "{\"error\":\"Grok Build usage balance exhausted\"}"
+            classifyFailure 402 Nothing body
+                `shouldBe` ProviderError UsageLimitReached body Nothing
+
         it "leaves other statuses as plain HTTP errors" do
             classifyFailure 503 Nothing "unavailable"
                 `shouldBe` HttpError 503 "unavailable"


### PR DESCRIPTION
## Summary

- recognize Grok Build's HTTP 402 usage-balance response as an exhausted usage limit
- generalize backend rebuilds around an explicit provider transition containing the target model, optional session, exact replay turn, plan state, and fallback chain state
- support automatic fallback for ordinary one-shot commands without requiring `--save-session`
- preserve one-shot policy/system prompting and plan-mode restrictions while replaying on the replacement provider
- continue to another configured provider when replacement auth or OpenAI WebSocket startup fails
- delay automatic transition metadata updates until the replacement backend completes a request successfully
- reset the temporary unavailable-provider chain after a successful turn, so recovered providers can be considered later
- preserve the exact nested plan-revision prompt rather than replaying the outer user prompt

## Testing

- `agent-cli`: 261 examples, 0 failures
- `agent-xai`: 36 examples, 0 failures, 1 expected live-test pending
- tmux one-shot smoke test with the real `Grok Build usage balance exhausted` response: xAI switched to OpenAI without persistence and returned `OK`
- tmux plan-mode smoke test: `/plan ...` exhausted xAI, switched to OpenAI, resumed the same session, and retained plan-mode tool restrictions
- `git diff --check`
