### PR TITLE
Default development REPL to GPT-5.6 Sol in YOLO mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,10 +21,10 @@ we follow the tool defintions that are used by the first party lab harnesses. e.
 
 use ghci instead of compiling the code. E.g. instead of nix flake check start a ghci and load in the necessary modules. This is way faster than doing a full compile.
 
-From `nix develop`, run `repl` to open the agent under GHCi. On first open it
-passes `--worktree` when the cwd is not already under
-`~/.haskell-agent/worktrees`. Agent `:reload` returns to GHCi, reloads
-modules, and resumes the previous session.
+From `nix develop`, run `repl` to open the agent under GHCi. It defaults to
+OpenAI `gpt-5.6-sol` with `--yolo`. On first open it passes `--worktree` when
+the cwd is not already under `~/.haskell-agent/worktrees`. Agent `:reload`
+returns to GHCi, reloads modules, and resumes the previous session.
 
 ## development feedback loop
 

--- a/README.md
+++ b/README.md
@@ -43,11 +43,12 @@ cabal run agent-cli -- -p "list the files here"
 ```
 
 From `nix develop`, `repl` opens `cabal repl lib:agent-cli` (via expect) and
-starts the agent with a GHCi `:cmd` loop. On first open it passes `--worktree`
-when the cwd is not already under `~/.haskell-agent/worktrees`. Inside the
-agent REPL, `:reload` writes `~/.haskell-agent/dev-resume`, returns to GHCi,
-reloads modules, and resumes the same session automatically. `:q` exits the
-agent back to `ghci>`.
+starts the agent with a GHCi `:cmd` loop. Development REPL sessions default to
+OpenAI `gpt-5.6-sol` with `--yolo`. On first open it also passes `--worktree`
+when the cwd is not already under `~/.haskell-agent/worktrees`. Inside the agent
+REPL, `:reload` writes `~/.haskell-agent/dev-resume`, returns to GHCi, reloads
+modules, and resumes the same session automatically. `:q` exits the agent back
+to `ghci>`.
 
 Without `-p` / `--prompt-file` the CLI starts a REPL. Credentials come from
 `~/.grok/auth.json` / `GROK_ACCESS_TOKEN` (xAI), `~/.codex/auth.json` /

--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -4,6 +4,7 @@ module Agent.CLI
     , afterDev
     , applyReplMode
     , cycleReplInteraction
+    , devArgs
     , devMain
     , formatReplStatusLine
     , formatTokenUsage
@@ -234,19 +235,38 @@ afterDev = \case
         , ":cmd afterDev =<< devMain"
         ]
 
+-- | Arguments used by the development @repl@ launcher.
+--
+-- Fresh sessions use OpenAI's frontier model in yolo mode. Reloaded sessions
+-- keep their persisted provider and model while reapplying the yolo default.
+devArgs :: Maybe Text -> Bool -> [String]
+devArgs resumeId underWorktree = case resumeId of
+    Just sessionId ->
+        [ "--yolo"
+        , "--resume", Text.unpack sessionId
+        ]
+    Nothing ->
+        [ "--provider", "openai"
+        , "--model", "gpt-5.6-sol"
+        , "--yolo"
+        ]
+            <> ["--worktree" | not underWorktree]
+
 -- | Start the agent from GHCi (@repl@). Resumes the session written by @:reload@.
--- On first open (no resume pointer), passes @--worktree@ unless the cwd is
--- already under @~/.haskell-agent/worktrees@.
+-- On first open (no resume pointer), selects OpenAI/gpt-5.6-sol with yolo
+-- enabled and passes @--worktree@ unless the cwd is already under
+-- @~/.haskell-agent/worktrees@.
 devMain :: IO DevResult
 devMain = do
     home <- getHomeDirectory
     resumeId <- readDevResumePointer home
-    args <- case resumeId of
-        Just sessionId -> pure ["--resume", Text.unpack sessionId]
+    underWorktree <- case resumeId of
+        Just _ -> pure True
         Nothing -> do
             cwd <- makeAbsolute =<< getCurrentDirectory
             root <- makeAbsolute (worktreeRoot home)
-            pure $ if isUnderWorktreeRoot root cwd then [] else ["--worktree"]
+            pure (isUnderWorktreeRoot root cwd)
+    let args = devArgs resumeId underWorktree
     case parseArgs args of
         Left err -> do
             clearDevResumePointer home

--- a/packages/agent-cli/test/Agent/CLI/ReplStatusSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ReplStatusSpec.hs
@@ -1,6 +1,12 @@
 module Agent.CLI.ReplStatusSpec (spec) where
 
-import Agent.CLI (applyReplMode, cycleReplInteraction, formatReplStatusLine, formatTokenUsage)
+import Agent.CLI
+    ( applyReplMode
+    , cycleReplInteraction
+    , devArgs
+    , formatReplStatusLine
+    , formatTokenUsage
+    )
 import Agent.CLI.Options (ApprovalPolicy(..))
 import Agent.CLI.Project (ProjectSettings(..), loadProjectSettings)
 import Agent.CLI.ReplMode
@@ -18,6 +24,29 @@ import Test.Hspec
 
 spec :: Spec
 spec = do
+    describe "devArgs" do
+        it "starts fresh REPL sessions on gpt-5.6-sol in yolo mode" do
+            devArgs Nothing False
+                `shouldBe`
+                    [ "--provider", "openai"
+                    , "--model", "gpt-5.6-sol"
+                    , "--yolo"
+                    , "--worktree"
+                    ]
+            devArgs Nothing True
+                `shouldBe`
+                    [ "--provider", "openai"
+                    , "--model", "gpt-5.6-sol"
+                    , "--yolo"
+                    ]
+
+        it "keeps the session model and reapplies yolo when reloading" do
+            devArgs (Just "2026-08-20-abcd1234") True
+                `shouldBe`
+                    [ "--yolo"
+                    , "--resume", "2026-08-20-abcd1234"
+                    ]
+
     describe "formatReplStatusLine" do
         it "shows model, effort, and interaction mode" do
             formatReplStatusLine False Nothing "grok-4.6" "high" ReplModeNormal emptyTokenUsage


### PR DESCRIPTION
## Summary
- start fresh development REPL sessions with OpenAI `gpt-5.6-sol`
- enable YOLO mode for fresh and reloaded development sessions
- preserve the persisted provider and model across `:reload`
- document and test the new defaults

## Validation
- focused GHCi Hspec run: 14 examples, 0 failures
- live tmux smoke test showed `gpt-5.6-sol · medium · yolo`
- `git diff --check`