### PR TITLE
refactor: split CLI turn and approval logic

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -36,6 +36,7 @@ library
     import:           common-options
     hs-source-dirs:   src
     exposed-modules:  Agent.CLI
+                    , Agent.CLI.Approval
                     , Agent.CLI.Auth
                     , Agent.CLI.CancelWatch
                     , Agent.CLI.Clipboard
@@ -59,10 +60,13 @@ library
                     , Agent.CLI.Resume
                     , Agent.CLI.Session
                     , Agent.CLI.SessionEnv
+                    , Agent.CLI.Status
                     , Agent.CLI.SubagentStore
                     , Agent.CLI.Style
+                    , Agent.CLI.Terminal
                     , Agent.CLI.Timestamp
                     , Agent.CLI.Tools
+                    , Agent.CLI.Turn
                     , Agent.CLI.Worktree
     build-depends:    agent-core >= 0.1 && < 0.2
                     , agent-openai >= 0.1 && < 0.2
@@ -97,7 +101,8 @@ test-suite agent-cli-test
     type:             exitcode-stdio-1.0
     hs-source-dirs:   test
     main-is:          Spec.hs
-    other-modules:    Agent.CLI.AuthSpec
+    other-modules:    Agent.CLI.ApprovalSpec
+                    , Agent.CLI.AuthSpec
                     , Agent.CLI.CancelWatchSpec
                     , Agent.CLI.ClipboardSpec
                     , Agent.CLI.CommandSpec

--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -11,7 +11,12 @@ module Agent.CLI
     ) where
 
 import Agent.CLI.Auth (LoadedAuth(..), loadAuth)
-import Agent.CLI.CancelWatch (withEscCancel, withStdinPaused)
+import Agent.CLI.Approval
+    ( approveToolDecision
+    , childApprove
+    , toggleAlwaysApprove
+    )
+import Agent.CLI.CancelWatch (withStdinPaused)
 import Agent.CLI.Clipboard
     ( ClipboardContent(..)
     , formatImageSize
@@ -33,28 +38,18 @@ import Agent.CLI.ImagePreview
 import Agent.CLI.Input (ReplLine(..), formatPasteChip, readReplLineWithInitial)
 import Agent.CLI.ReplMode
     ( ReplMode(..)
-    , cycleReplMode
     , replModeFromState
-    , replModeLabel
     )
 import Agent.CLI.Interrupt
     ( InterruptState
     , newInterruptState
     , withCtrlCHandler
-    , withTurnCancel
     )
 import Agent.CLI.ModelPicker (pickModel)
 import Agent.CLI.Models (ModelOption(..))
 import Agent.CLI.Options
-import Agent.CLI.Permission
-    ( PermissionChoice(..)
-    , promptPermission
-    )
 import Agent.CLI.Resume (pickResumeSession)
-import Agent.CLI.Plan
-    ( cliPlanHooks
-    , extractProposedPlan
-    )
+import Agent.CLI.Plan (cliPlanHooks)
 import Agent.CLI.Progress
     ( osc9ProgressRemove
     , wrapOscForTmux
@@ -63,21 +58,21 @@ import Agent.CLI.Project
     ( ProjectSettings(..)
     , loadProjectSettings
     , resolveProjectRoot
-    , saveProjectAutoApprove
     )
 import Agent.CLI.Prompt (defaultModelFor, systemPrompt)
 import Agent.CLI.Render
     ( RenderConfig(..)
-    , clearThinking
-    , formatLoopErrorColored
-    , formatElapsed
-    , formatTurnStatus
     , putTextLn
-    , renderAssistantText
     , renderEvent
     )
 import Agent.CLI.Session
 import Agent.CLI.SessionEnv (SessionEnv(..))
+import Agent.CLI.Status
+    ( applyReplMode
+    , cycleReplInteraction
+    , formatReplStatusLine
+    , formatTokenUsage
+    )
 import Agent.CLI.SubagentStore
     ( SubagentDiskMeta(..)
     , loadSubagentState
@@ -89,7 +84,6 @@ import Agent.CLI.Style
     , endBackground
     , glyphOk
     , glyphSession
-    , glyphWarn
     , roleError
     , roleMuted
     , rolePrompt
@@ -98,10 +92,10 @@ import Agent.CLI.Style
     , setCliWindowTitle
     , userBackground
     )
-import Agent.CLI.Timestamp (stampTurnInputs, stripBracketedTimestamps)
-import Agent.CLI.Tools (lookupAppTool, schemasFromAppTools)
+import Agent.CLI.Terminal (resolveColor)
+import Agent.CLI.Tools (schemasFromAppTools)
+import Agent.CLI.Turn (runOneTurn)
 import Agent.CLI.Worktree (createWorktree, isUnderWorktreeRoot, worktreeRoot)
-import Agent.JsonText (jsonTextFieldDefault)
 import Agent.Loop
 import Agent.ProjectInstructions
     ( DiscoverOptions(..)
@@ -117,7 +111,7 @@ import Agent.OpenAI.Compaction
     , isTranscriptResetTurn
     , newSessionUserText
     )
-import Agent.OpenAI.LoopBackend (openAiBackend, toolResultToItem)
+import Agent.OpenAI.LoopBackend (openAiBackend)
 import Agent.OpenAI.Responses.Types
 import Agent.OpenAI.WebSocketClient
     ( CodexAuthFailed(..)
@@ -133,10 +127,8 @@ import Agent.Provider
     , getNextToken
     , providerSlug
     )
-import Agent.ToolDispatch (ToolCall(..))
 import Agent.Subagents
     ( RunSubagent
-    , SubagentConfig(..)
     , SubagentId(..)
     , SubagentRegistry
     , SubagentSpawnEnv(..)
@@ -164,21 +156,14 @@ import Agent.Tools.Grok.Task (defaultSubagentType, lookupAgentType, recordAgentT
 import Agent.Subagents.TaskPath (taskPathRoot)
 import Agent.Tools.MultiAgents (MultiAgentContext(..))
 import Agent.Tools.PlanMode
-    ( PlanDecision(..)
-    , PlanModeEnv(..)
-    , PlanModeHooks(..)
+    ( PlanModeEnv(..)
+    , PlanModeHooks
     , PlanModeState(..)
     , activatePlanMode
     , deactivatePlanMode
-    , isPlanFileEditTarget
-    , isPlanModeActive
     , planFilePath
-    , planModeBlockedEditMessage
-    , planModeReminder
-    , writePlanMarkdown
     )
-import Agent.Tools.Dangerous (shellCommandBlocked)
-import Agent.Tools.Types (AppTool(..), ToolEnv(..), defaultToolEnv, toolAllowsWithoutPrompt)
+import Agent.Tools.Types (AppTool(..), ToolEnv(..), defaultToolEnv)
 import Agent.OpenRouter.LoopBackend (openRouterBackend)
 import qualified Agent.OpenRouter.Options as OpenRouter
 import Agent.XAI.LoopBackend (xaiBackend)
@@ -186,22 +171,18 @@ import qualified Agent.XAI.Options as XAI
 import Control.Concurrent.MVar (MVar, newMVar, withMVar)
 import Control.Exception (AsyncException(UserInterrupt))
 import Control.Exception.Safe (catchAsync, finally, throwIO, try)
-import Control.Monad (unless, when)
-import qualified Data.Aeson as Aeson
-import qualified Data.Aeson.Key as Key
+import Control.Monad (when)
 import qualified Data.Aeson.KeyMap as KeyMap
 import qualified Data.ByteString as BS
 import Data.IORef
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import Data.Maybe (fromMaybe, isJust, isNothing)
+import Data.Maybe (fromMaybe, isJust)
 import Data.Text (Text)
 import qualified Data.Text as Text
-import qualified Data.Text.Encoding as TextEncoding
 import qualified Data.Text.IO as Text
-import Data.Set (Set)
 import qualified Data.Set as Set
-import Data.Time.Clock (diffUTCTime, getCurrentTime, utctDay)
+import Data.Time.Clock (getCurrentTime, utctDay)
 import Data.Time.Format (defaultTimeLocale, formatTime)
 import System.Directory (getCurrentDirectory, getHomeDirectory, makeAbsolute, setCurrentDirectory)
 import System.Environment (getArgs, getProgName, lookupEnv)
@@ -596,11 +577,6 @@ preparePersistence options root provider model cwd effort prompt resumed =
                     })
             | otherwise -> pure Nothing
 
-isLeftSlot :: Either a b -> Bool
-isLeftSlot = \case
-    Left _ -> True
-    Right _ -> False
-
 -- | On Ctrl-C, print a copy-pasteable --resume line when a session exists.
 withInterruptResume
     :: String
@@ -632,92 +608,6 @@ printResumeHint progName = \case
                 color <- resolveColor stderr
                 putTextLn stderr
                     (roleMuted color (resumeHint progName handle.sessionMeta.metaId))
-
--- | Idle prompt chrome: model, reasoning effort, interaction mode on the
--- left; session token totals right-aligned when the TTY width is known.
-formatReplStatusLine
-    :: Bool
-    -> Maybe Int
-    -> Text
-    -> Text
-    -> ReplMode
-    -> TokenUsage
-    -> Text
-formatReplStatusLine color width model effort mode usage =
-    let left = "  " <> model <> " · " <> effort <> " · " <> replModeLabel mode
-        right = formatTokenUsage usage
-        padded = case width of
-            Just cols | cols > 0, not (Text.null right) ->
-                let gap = cols - Text.length left - Text.length right
-                in if gap > 0
-                    then left <> Text.replicate gap " " <> right
-                    else left <> "  " <> right
-            _ | Text.null right -> left
-            _ -> left <> "  " <> right
-    in roleMuted color padded
-
--- | Apply a cycled idle mode: plan pending vs always-approve vs ask.
--- Always-approve still persists to project settings, matching /always-approve.
-applyReplMode
-    :: PlanModeEnv
-    -> IORef ApprovalPolicy
-    -> FilePath
-    -> ReplMode
-    -> IO ()
-applyReplMode planMode policyRef projectRoot = \case
-    ReplModePlan ->
-        writeIORef planMode.planStateRef PlanPending
-    ReplModeAlwaysApprove -> do
-        deactivatePlanMode planMode
-        writeIORef policyRef ApproveAll
-        saveProjectAutoApprove projectRoot True
-    ReplModeNormal -> do
-        deactivatePlanMode planMode
-        current <- readIORef policyRef
-        when (current == ApproveAll) do
-            writeIORef policyRef PromptMutating
-            saveProjectAutoApprove projectRoot False
-
--- | Pure next-mode helper used by tests and the Shift+Tab handler.
-cycleReplInteraction :: PlanModeState -> ApprovalPolicy -> ReplMode
-cycleReplInteraction planState policy =
-    cycleReplMode (replModeFromState planState policy)
-
--- | Compact session totals: @1.2k in · 340 out@. Cached tokens are shown
--- only when the provider reported a non-zero cache hit.
-formatTokenUsage :: TokenUsage -> Text
-formatTokenUsage usage
-    | usage == emptyTokenUsage = ""
-    | otherwise =
-        formatTokenCount usage.inputTokens
-            <> " in · "
-            <> formatTokenCount usage.outputTokens
-            <> " out"
-            <> cachedSuffix
-  where
-    cachedSuffix
-        | usage.cachedTokens > 0 =
-            " · " <> formatTokenCount usage.cachedTokens <> " cached"
-        | otherwise = ""
-
-formatTokenCount :: Int -> Text
-formatTokenCount n
-    | n < 0 = "0"
-    | n < 1000 = Text.pack (show n)
-    | n < 10000 =
-        let tenths = (n + 50) `div` 100
-            whole = tenths `div` 10
-            frac = tenths `mod` 10
-        in Text.pack (show whole <> "." <> show frac <> "k")
-    | n < 1000000 =
-        Text.pack (show ((n + 500) `div` 1000) <> "k")
-    | n < 10000000 =
-        let tenths = (n + 50000) `div` 100000
-            whole = tenths `div` 10
-            frac = tenths `mod` 10
-        in Text.pack (show whole <> "." <> show frac <> "M")
-    | otherwise =
-        Text.pack (show ((n + 500000) `div` 1000000) <> "M")
 
 shouldPersist :: CliOptions -> Bool
 shouldPersist options = not (isOneShot options) || options.optSaveSession
@@ -823,7 +713,7 @@ runSession options provider policy tools toolEnv planMode prompt paramsRef trans
                 withMVar ioLock \_ ->
                     withStdinPaused escPaused $
                         approveToolDecision
-                            policyRef allowedToolsRef tools planMode call projectRoot
+                            policyRef allowedToolsRef tools planMode call
             , loopCancel = toolEnv.toolCancel
             }
         env = SessionEnv
@@ -863,8 +753,7 @@ repl env = replWithDraft env ""
 
 replWithDraft :: SessionEnv -> Text -> IO RunResult
 replWithDraft env@SessionEnv
-    { sessionLoop = config
-    , sessionRender = render
+    { sessionRender = render
     , sessionProvider = provider
     , sessionPrevious = previous
     , sessionPrinted = printed
@@ -874,10 +763,7 @@ replWithDraft env@SessionEnv
     , sessionPersist = persist
     , sessionPlanMode = planMode
     , sessionProjectRoot = projectRoot
-    , sessionHome = home
     , sessionTokenProvider = tokenProvider
-    , sessionAgentsContext = agentsContext
-    , sessionEscPaused = escPaused
     , sessionAttachments = attachmentsRef
     , sessionPreviewId = previewIdRef
     , sessionInterrupt = interrupt
@@ -1209,7 +1095,6 @@ replWithDraft env@SessionEnv
                             Just slotRef -> do
                                 now <- getCurrentTime
                                 params <- readIORef paramsRef
-                                home <- getHomeDirectory
                                 slot <- readIORef slotRef
                                 let model = currentModel params
                                     effort = currentEffort params
@@ -1464,159 +1349,6 @@ enterPlanFromSlash env@SessionEnv{sessionPlanMode = planMode, sessionPersist = p
             _ <- runOneTurn planEnv description [UserMessage description]
             putTrailingNewline printed
 
-runOneTurn :: SessionEnv -> Text -> [TurnInput] -> IO Bool
-runOneTurn env@SessionEnv
-    { sessionLoop = config
-    , sessionRender = render
-    , sessionPrevious = previous
-    , sessionPrinted = printed
-    , sessionTranscript = transcriptRef
-    , sessionPersist = persist
-    , sessionPlanMode = planMode
-    , sessionAgentsContext = agentsContext
-    , sessionEscPaused = escPaused
-    , sessionInterrupt = interrupt
-    , sessionStoreRoot = storeRoot
-    , sessionUsage = usageRef
-    } promptText inputs =
-  withTurnCancel interrupt config.loopCancel $
-  withEscCancel config.loopCancel escPaused do
-    pending <- readIORef planMode.planStateRef
-    when (pending == PlanPending) (activatePlanMode planMode)
-    -- Create the session directory before tools run so first-turn subagents
-    -- can persist under agents/<id>/ as they complete.
-    case persist of
-        Just slotRef -> do
-            created <- isLeftSlot <$> readIORef slotRef
-            handle <- ensureSession slotRef
-            writeIORef planMode.planSessionDir (Just handle.sessionDir)
-            writeIORef storeRoot (Just handle.sessionDir)
-            when created do
-                color <- resolveColor stderr
-                putTextLn stderr
-                    (roleMuted color
-                        (glyphSession <> "session: " <> handle.sessionMeta.metaId))
-        Nothing -> pure ()
-    prev <- readIORef previous
-    beforeItems <- readIORef transcriptRef
-    pendingAgents <- atomicModifyIORef' agentsContext \pendingCtx -> (Nothing, pendingCtx)
-    planActive <- isPlanModeActive planMode
-    planPath <- planFilePath planMode
-    let planReminder =
-            if planActive
-                then Just (planModeReminder planPath)
-                else Nothing
-        baseInputs = case pendingAgents of
-            Just agents | null beforeItems && isNothing prev ->
-                UserMessage agents : inputs
-            _ -> inputs
-        turnInputs0 = case planReminder of
-            Just reminder -> UserMessage reminder : baseInputs
-            Nothing -> baseInputs
-    turnInputs <- stampTurnInputs turnInputs0
-    startedAt <- readIORef render.renderStartedAt
-    result <- runLoopInputs config prev turnInputs
-    clearThinking render
-    finishedAt <- getCurrentTime
-    let elapsedDetail extra = case startedAt of
-            Nothing -> extra
-            Just t0 -> extra <> " · " <> formatElapsed (realToFrac (diffUTCTime finishedAt t0))
-    case result of
-        Left (LoopCancelled toolResults) -> do
-            unless (null toolResults) do
-                modifyIORef' transcriptRef
-                    (<> map toolResultToItem toolResults)
-            color <- resolveColor stderr
-            putTextLn stderr (formatLoopErrorColored color (LoopCancelled toolResults))
-            model <- readIORef render.renderModelRef
-            putTextLn stderr (formatTurnStatus color "cancelled" (elapsedDetail model))
-            pure True
-        Left err -> do
-            color <- resolveColor stderr
-            putTextLn stderr (formatLoopErrorColored color err)
-            model <- readIORef render.renderModelRef
-            putTextLn stderr (formatTurnStatus color "error" (elapsedDetail model))
-            pure False
-        Right loopResult -> do
-            writeIORef previous (Just loopResult.finalResponseId)
-            modifyIORef' usageRef (`addTokenUsage` loopResult.tokenUsage)
-            do
-                color <- resolveColor stderr
-                model <- readIORef render.renderModelRef
-                let turns = Text.pack (show loopResult.turnsUsed)
-                    unit = if loopResult.turnsUsed == 1 then " turn" else " turns"
-                    usageDetail = formatTokenUsage loopResult.tokenUsage
-                    extra =
-                        if Text.null usageDetail
-                            then model <> " · " <> turns <> unit
-                            else model <> " · " <> turns <> unit <> " · " <> usageDetail
-                putTextLn stderr
-                    (formatTurnStatus color "ok" (elapsedDetail extra))
-            followUp <- handleProposedPlan planMode loopResult.finalText
-            printedText <- readIORef printed
-            let assistantText =
-                    fmap stripBracketedTimestamps loopResult.finalText
-            case (printedText, assistantText) of
-                (False, Just text) | not (Text.null (Text.strip text)) -> do
-                    useColor <- resolveColor stdout
-                    putTextLn stdout (renderAssistantText useColor text)
-                _ -> pure ()
-            afterItems <- readIORef transcriptRef
-            let newItems = drop (length beforeItems) afterItems
-            case persist of
-                Nothing -> pure ()
-                Just slotRef -> do
-                    now <- getCurrentTime
-                    handle <- ensureSession slotRef
-                    writeIORef planMode.planSessionDir (Just handle.sessionDir)
-                    writeIORef storeRoot (Just handle.sessionDir)
-                    let turn = SessionTurn
-                            { turnAt = now
-                            , turnUserText = promptText
-                            , turnAssistantText = assistantText
-                            , turnResponseId = Just loopResult.finalResponseId
-                            , turnItems = newItems
-                            , turnUsage = Just loopResult.tokenUsage
-                            }
-                    handle' <- appendTurn handle turn
-                    writeIORef slotRef (Right handle')
-                    when (handle'.sessionMeta.metaTitle /= handle.sessionMeta.metaTitle) do
-                        tty <- hIsTerminalDevice stdout
-                        setCliWindowTitle tty stdout
-                            (cliWindowTitle handle'.sessionMeta.metaCwd
-                                (Just handle'.sessionMeta.metaTitle))
-            case followUp of
-                Nothing -> pure True
-                Just notes -> do
-                    writeIORef printed False
-                    _ <- runOneTurn env notes [UserMessage notes]
-                    pure True
-
-handleProposedPlan :: PlanModeEnv -> Maybe Text -> IO (Maybe Text)
-handleProposedPlan planMode = \case
-    Nothing -> pure Nothing
-    Just text -> do
-        active <- isPlanModeActive planMode
-        case (active, extractProposedPlan text) of
-            (True, Just planBody) -> do
-                _ <- writePlanMarkdown planMode planBody
-                let PlanModeHooks{ planDecideExit = decideExit } = planMode.planHooks
-                decision <- decideExit planBody
-                case decision of
-                    PlanApprove -> do
-                        deactivatePlanMode planMode
-                        pure Nothing
-                    PlanCancel -> do
-                        deactivatePlanMode planMode
-                        pure Nothing
-                    PlanRequestChanges notes ->
-                        pure $ Just $
-                            "The user requested changes to the plan. Stay in plan mode and revise.\n\
-                            \Feedback:\n"
-                                <> notes
-            _ -> pure Nothing
-
-
 -- | Discover AGENTS.md once for a fresh session. Resumed transcripts keep
 -- whatever instructions were already in history.
 loadAgentsContext
@@ -1658,13 +1390,6 @@ clearNativeProgress handle = do
         inTmux <- isJust <$> lookupEnv "TMUX"
         Text.hPutStr handle (wrapOscForTmux inTmux osc9ProgressRemove)
         hFlush handle
-
--- | Color when the handle is a TTY and NO_COLOR is unset.
-resolveColor :: Handle -> IO Bool
-resolveColor handle = do
-    isTty <- hIsTerminalDevice handle
-    noColor <- lookupEnv "NO_COLOR"
-    pure (isTty && maybe True (\_ -> False) noColor)
 
 -- | Queue clipboard / Finder-paste images and draw an in-terminal thumbnail
 -- (Kitty graphics or iTerm2 OSC 1337, matching Grok Build).
@@ -1755,104 +1480,6 @@ currentSessionId = \case
         pure $ case slot of
             Left _ -> Nothing
             Right handle -> Just handle.sessionMeta.metaId
-
-approveToolDecision
-    :: IORef ApprovalPolicy
-    -> IORef (Set Text)
-    -> [AppTool]
-    -> PlanModeEnv
-    -> ToolCall
-    -> FilePath
-    -> IO (Either Text Bool)
-approveToolDecision policyRef allowedToolsRef tools planMode call _projectRoot = do
-    policy <- readIORef policyRef
-    planActive <- isPlanModeActive planMode
-    planPath <- planFilePath planMode
-    -- Hard deny for catastrophic shell deletes, even under ApproveAll / yolo.
-    case shellCommandBlocked call.name call.arguments of
-        Just msg -> do
-            color <- resolveColor stderr
-            putTextLn stderr (roleWarn color (glyphWarn <> msg))
-            pure (Left msg)
-        Nothing -> do
-            -- Plan mode: reject mutating file edits except plan.md (even under yolo).
-            -- Grok search_replace also enforces this in-tool; this covers apply_patch
-            -- and any other write tool before dispatch.
-            blocked <- planModeBlocksCall planMode planActive planPath call
-            if blocked
-                then do
-                    let msg = planModeBlockedEditMessage planPath
-                    color <- resolveColor stderr
-                    putTextLn stderr (roleWarn color msg)
-                    pure (Left msg)
-                else do
-                    readOnly <- case lookupAppTool call.name tools of
-                        Nothing -> pure False
-                        Just tool -> toolAllowsWithoutPrompt tool call
-                    -- plan.md edits are auto-approved while plan mode is active.
-                    planFileOk <- isPlanFileWrite planMode planActive planPath call
-                    if planFileOk
-                        then pure (Right True)
-                        else do
-                            allowed <- readIORef allowedToolsRef
-                            if Set.member call.name allowed
-                                then pure (Right True)
-                                else case policy of
-                                    ApproveAll -> pure (Right True)
-                                    DenyMutating -> pure (Right readOnly)
-                                    PromptMutating
-                                        | readOnly -> pure (Right True)
-                                        | otherwise -> do
-                                            color <- resolveColor stderr
-                                            promptPermission color call >>= \case
-                                                Nothing -> pure (Right False)
-                                                Just PermissionAllowOnce ->
-                                                    pure (Right True)
-                                                Just PermissionAllowTool -> do
-                                                    modifyIORef' allowedToolsRef
-                                                        (Set.insert call.name)
-                                                    putTextLn stderr
-                                                        (roleSuccess color
-                                                            (glyphOk
-                                                                <> "always allow "
-                                                                <> call.name
-                                                                <> " this session"))
-                                                    pure (Right True)
-                                                Just PermissionDeny ->
-                                                    pure (Right False)
-
-planModeBlocksCall :: PlanModeEnv -> Bool -> FilePath -> ToolCall -> IO Bool
-planModeBlocksCall _planMode active planPath call
-    | not active = pure False
-    | call.name == "apply_patch" = pure True
-    | call.name == "search_replace" =
-        let target = jsonTextFieldDefault "file_path" call.arguments
-        in pure $
-            Text.null target
-                || not (isPlanFileEditTarget planPath (Text.unpack target))
-    | otherwise = pure False
-
-isPlanFileWrite :: PlanModeEnv -> Bool -> FilePath -> ToolCall -> IO Bool
-isPlanFileWrite _planMode active planPath call
-    | not active = pure False
-    | call.name == "search_replace" =
-        let target = jsonTextFieldDefault "file_path" call.arguments
-        in pure $
-            not (Text.null target)
-                && isPlanFileEditTarget planPath (Text.unpack target)
-    | otherwise = pure False
-
-toggleAlwaysApprove :: IORef ApprovalPolicy -> FilePath -> IO ()
-toggleAlwaysApprove policyRef projectRoot = do
-    color <- resolveColor stderr
-    next <- atomicModifyIORef' policyRef \policy ->
-        if policy == ApproveAll
-            then (PromptMutating, PromptMutating)
-            else (ApproveAll, ApproveAll)
-    saveProjectAutoApprove projectRoot (next == ApproveAll)
-    putTextLn stderr (case next of
-        ApproveAll -> roleSuccess color (glyphOk <> "auto-approve on (saved for project)")
-        _ -> roleMuted color (glyphSession <> "auto-approve off (saved for project)"))
 
 data SubagentSession = SubagentSession
     { subSessionTranscript :: !(IORef [ResponseItem])
@@ -2158,25 +1785,6 @@ lookupOrCreateSubagentSession sessionsRef storeRootRef typesRef agentId = do
             let session = SubagentSession { subSessionTranscript = transcript }
             atomicModifyIORef' sessionsRef \m -> (Map.insert agentId session m, ())
             pure session
-
-childApprove :: ApprovalPolicy -> [AppTool] -> ToolCall -> IO (Either Text Bool)
-childApprove policy tools call = case policy of
-    ApproveAll -> pure (Right True)
-    DenyMutating -> do
-        allowed <- case lookupAppTool call.name tools of
-            Just tool -> toolAllowsWithoutPrompt tool call
-            Nothing -> pure False
-        pure $ if allowed then Right True else Right False
-    PromptMutating -> do
-        allowed <- case lookupAppTool call.name tools of
-            Just tool -> toolAllowsWithoutPrompt tool call
-            Nothing -> pure False
-        if allowed
-            then pure (Right True)
-            else pure $ Left
-                "Subagent cannot prompt for approval on mutating tools. \
-                \Re-run the parent with auto-approve/--yolo, or have the \
-                \parent perform this edit."
 
 -- | Drop live conversation state without touching persisted session files.
 resetLiveConversation

--- a/packages/agent-cli/src/Agent/CLI/Approval.hs
+++ b/packages/agent-cli/src/Agent/CLI/Approval.hs
@@ -1,0 +1,159 @@
+-- | Parent and child tool-approval policy for interactive CLI sessions.
+module Agent.CLI.Approval
+    ( approveToolDecision
+    , childApprove
+    , toggleAlwaysApprove
+    ) where
+
+import Agent.CLI.Options (ApprovalPolicy(..))
+import Agent.CLI.Permission
+    ( PermissionChoice(..)
+    , promptPermission
+    )
+import Agent.CLI.Project (saveProjectAutoApprove)
+import Agent.CLI.Render (putTextLn)
+import Agent.CLI.Style
+    ( glyphOk
+    , glyphSession
+    , glyphWarn
+    , roleMuted
+    , roleSuccess
+    , roleWarn
+    )
+import Agent.CLI.Terminal (resolveColor)
+import Agent.CLI.Tools (lookupAppTool)
+import Agent.JsonText (jsonTextFieldDefault)
+import Agent.ToolDispatch (ToolCall(..))
+import Agent.Tools.Dangerous (shellCommandBlocked)
+import Agent.Tools.PlanMode
+    ( PlanModeEnv
+    , isPlanFileEditTarget
+    , isPlanModeActive
+    , planFilePath
+    , planModeBlockedEditMessage
+    )
+import Agent.Tools.Types (AppTool, toolAllowsWithoutPrompt)
+import Data.IORef
+    ( IORef
+    , atomicModifyIORef'
+    , modifyIORef'
+    , readIORef
+    )
+import Data.Set (Set)
+import qualified Data.Set as Set
+import Data.Text (Text)
+import qualified Data.Text as Text
+import System.IO (stderr)
+
+approveToolDecision
+    :: IORef ApprovalPolicy
+    -> IORef (Set Text)
+    -> [AppTool]
+    -> PlanModeEnv
+    -> ToolCall
+    -> IO (Either Text Bool)
+approveToolDecision policyRef allowedToolsRef tools planMode call = do
+    policy <- readIORef policyRef
+    planActive <- isPlanModeActive planMode
+    planPath <- planFilePath planMode
+    -- Hard deny for catastrophic shell deletes, even under ApproveAll / yolo.
+    case shellCommandBlocked call.name call.arguments of
+        Just msg -> do
+            color <- resolveColor stderr
+            putTextLn stderr (roleWarn color (glyphWarn <> msg))
+            pure (Left msg)
+        Nothing -> do
+            -- Plan mode: reject mutating file edits except plan.md (even under yolo).
+            -- Grok search_replace also enforces this in-tool; this covers apply_patch
+            -- and any other write tool before dispatch.
+            if planModeBlocksCall planActive planPath call
+                then do
+                    let msg = planModeBlockedEditMessage planPath
+                    color <- resolveColor stderr
+                    putTextLn stderr (roleWarn color msg)
+                    pure (Left msg)
+                else do
+                    readOnly <- case lookupAppTool call.name tools of
+                        Nothing -> pure False
+                        Just tool -> toolAllowsWithoutPrompt tool call
+                    -- plan.md edits are auto-approved while plan mode is active.
+                    if isPlanFileWrite planActive planPath call
+                        then pure (Right True)
+                        else do
+                            allowed <- readIORef allowedToolsRef
+                            if Set.member call.name allowed
+                                then pure (Right True)
+                                else case policy of
+                                    ApproveAll -> pure (Right True)
+                                    DenyMutating -> pure (Right readOnly)
+                                    PromptMutating
+                                        | readOnly -> pure (Right True)
+                                        | otherwise -> do
+                                            color <- resolveColor stderr
+                                            promptPermission color call >>= \case
+                                                Nothing -> pure (Right False)
+                                                Just PermissionAllowOnce ->
+                                                    pure (Right True)
+                                                Just PermissionAllowTool -> do
+                                                    modifyIORef' allowedToolsRef
+                                                        (Set.insert call.name)
+                                                    putTextLn stderr
+                                                        (roleSuccess color
+                                                            (glyphOk
+                                                                <> "always allow "
+                                                                <> call.name
+                                                                <> " this session"))
+                                                    pure (Right True)
+                                                Just PermissionDeny ->
+                                                    pure (Right False)
+
+planModeBlocksCall :: Bool -> FilePath -> ToolCall -> Bool
+planModeBlocksCall active planPath call
+    | not active = False
+    | call.name == "apply_patch" = True
+    | call.name == "search_replace" =
+        let target = jsonTextFieldDefault "file_path" call.arguments
+        in Text.null target
+            || not (isPlanFileEditTarget planPath (Text.unpack target))
+    | otherwise = False
+
+isPlanFileWrite :: Bool -> FilePath -> ToolCall -> Bool
+isPlanFileWrite active planPath call
+    | not active = False
+    | call.name == "search_replace" =
+        let target = jsonTextFieldDefault "file_path" call.arguments
+        in not (Text.null target)
+            && isPlanFileEditTarget planPath (Text.unpack target)
+    | otherwise = False
+
+toggleAlwaysApprove :: IORef ApprovalPolicy -> FilePath -> IO ()
+toggleAlwaysApprove policyRef projectRoot = do
+    color <- resolveColor stderr
+    next <- atomicModifyIORef' policyRef \policy ->
+        if policy == ApproveAll
+            then (PromptMutating, PromptMutating)
+            else (ApproveAll, ApproveAll)
+    saveProjectAutoApprove projectRoot (next == ApproveAll)
+    putTextLn stderr (case next of
+        ApproveAll -> roleSuccess color (glyphOk <> "auto-approve on (saved for project)")
+        _ -> roleMuted color (glyphSession <> "auto-approve off (saved for project)"))
+
+childApprove :: ApprovalPolicy -> [AppTool] -> ToolCall -> IO (Either Text Bool)
+childApprove policy tools call = case policy of
+    ApproveAll -> pure (Right True)
+    DenyMutating -> do
+        allowed <- isReadOnlyCall tools call
+        pure $ if allowed then Right True else Right False
+    PromptMutating -> do
+        allowed <- isReadOnlyCall tools call
+        if allowed
+            then pure (Right True)
+            else pure $ Left
+                "Subagent cannot prompt for approval on mutating tools. \
+                \Re-run the parent with auto-approve/--yolo, or have the \
+                \parent perform this edit."
+
+isReadOnlyCall :: [AppTool] -> ToolCall -> IO Bool
+isReadOnlyCall tools call = case lookupAppTool call.name tools of
+    Just tool -> toolAllowsWithoutPrompt tool call
+    Nothing -> pure False

--- a/packages/agent-cli/src/Agent/CLI/Status.hs
+++ b/packages/agent-cli/src/Agent/CLI/Status.hs
@@ -1,0 +1,113 @@
+-- | Idle REPL mode transitions and compact status-line formatting.
+module Agent.CLI.Status
+    ( applyReplMode
+    , cycleReplInteraction
+    , formatReplStatusLine
+    , formatTokenUsage
+    ) where
+
+import Agent.CLI.Options (ApprovalPolicy(..))
+import Agent.CLI.Project (saveProjectAutoApprove)
+import Agent.CLI.ReplMode
+    ( ReplMode(..)
+    , cycleReplMode
+    , replModeFromState
+    , replModeLabel
+    )
+import Agent.CLI.Style (roleMuted)
+import Agent.Loop (TokenUsage(..), emptyTokenUsage)
+import Agent.Tools.PlanMode
+    ( PlanModeEnv(..)
+    , PlanModeState(..)
+    , deactivatePlanMode
+    )
+import Control.Monad (when)
+import Data.IORef (IORef, readIORef, writeIORef)
+import Data.Text (Text)
+import qualified Data.Text as Text
+
+-- | Idle prompt chrome: model, reasoning effort, interaction mode on the
+-- left; session token totals right-aligned when the TTY width is known.
+formatReplStatusLine
+    :: Bool
+    -> Maybe Int
+    -> Text
+    -> Text
+    -> ReplMode
+    -> TokenUsage
+    -> Text
+formatReplStatusLine color width model effort mode usage =
+    let left = "  " <> model <> " · " <> effort <> " · " <> replModeLabel mode
+        right = formatTokenUsage usage
+        padded = case width of
+            Just cols | cols > 0, not (Text.null right) ->
+                let gap = cols - Text.length left - Text.length right
+                in if gap > 0
+                    then left <> Text.replicate gap " " <> right
+                    else left <> "  " <> right
+            _ | Text.null right -> left
+            _ -> left <> "  " <> right
+    in roleMuted color padded
+
+-- | Apply a cycled idle mode: plan pending vs always-approve vs ask.
+-- Always-approve still persists to project settings, matching /always-approve.
+applyReplMode
+    :: PlanModeEnv
+    -> IORef ApprovalPolicy
+    -> FilePath
+    -> ReplMode
+    -> IO ()
+applyReplMode planMode policyRef projectRoot = \case
+    ReplModePlan ->
+        writeIORef planMode.planStateRef PlanPending
+    ReplModeAlwaysApprove -> do
+        deactivatePlanMode planMode
+        writeIORef policyRef ApproveAll
+        saveProjectAutoApprove projectRoot True
+    ReplModeNormal -> do
+        deactivatePlanMode planMode
+        current <- readIORef policyRef
+        when (current == ApproveAll) do
+            writeIORef policyRef PromptMutating
+            saveProjectAutoApprove projectRoot False
+
+-- | Pure next-mode helper used by tests and the Shift+Tab handler.
+cycleReplInteraction :: PlanModeState -> ApprovalPolicy -> ReplMode
+cycleReplInteraction planState policy =
+    cycleReplMode (replModeFromState planState policy)
+
+-- | Compact session totals: @1.2k in · 340 out@. Cached tokens are shown
+-- only when the provider reported a non-zero cache hit.
+formatTokenUsage :: TokenUsage -> Text
+formatTokenUsage usage
+    | usage == emptyTokenUsage = ""
+    | otherwise =
+        formatTokenCount usage.inputTokens
+            <> " in · "
+            <> formatTokenCount usage.outputTokens
+            <> " out"
+            <> cachedSuffix
+  where
+    cachedSuffix
+        | usage.cachedTokens > 0 =
+            " · " <> formatTokenCount usage.cachedTokens <> " cached"
+        | otherwise = ""
+
+formatTokenCount :: Int -> Text
+formatTokenCount n
+    | n < 0 = "0"
+    | n < 1000 = Text.pack (show n)
+    | n < 10000 =
+        let tenths = (n + 50) `div` 100
+            whole = tenths `div` 10
+            frac = tenths `mod` 10
+        in Text.pack (show whole <> "." <> show frac <> "k")
+    | n < 1000000 =
+        Text.pack (show ((n + 500) `div` 1000) <> "k")
+    | n < 10000000 =
+        let tenths = (n + 50000) `div` 100000
+            whole = tenths `div` 10
+            frac = tenths `mod` 10
+        in Text.pack (show whole <> "." <> show frac <> "M")
+    | otherwise =
+        Text.pack (show ((n + 500000) `div` 1000000) <> "M")

--- a/packages/agent-cli/src/Agent/CLI/Terminal.hs
+++ b/packages/agent-cli/src/Agent/CLI/Terminal.hs
@@ -1,0 +1,14 @@
+-- | Small terminal capability helpers shared by CLI orchestration modules.
+module Agent.CLI.Terminal
+    ( resolveColor
+    ) where
+
+import System.Environment (lookupEnv)
+import System.IO (Handle, hIsTerminalDevice)
+
+-- | Color when the handle is a TTY and @NO_COLOR@ is unset.
+resolveColor :: Handle -> IO Bool
+resolveColor handle = do
+    isTty <- hIsTerminalDevice handle
+    noColor <- lookupEnv "NO_COLOR"
+    pure (isTty && maybe True (const False) noColor)

--- a/packages/agent-cli/src/Agent/CLI/Turn.hs
+++ b/packages/agent-cli/src/Agent/CLI/Turn.hs
@@ -1,0 +1,224 @@
+-- | Execute one model turn and commit its observable session state.
+module Agent.CLI.Turn
+    ( runOneTurn
+    ) where
+
+import Agent.CLI.CancelWatch (withEscCancel)
+import Agent.CLI.Interrupt (withTurnCancel)
+import Agent.CLI.Plan (extractProposedPlan)
+import Agent.CLI.Render
+    ( RenderConfig(..)
+    , clearThinking
+    , formatElapsed
+    , formatLoopErrorColored
+    , formatTurnStatus
+    , putTextLn
+    , renderAssistantText
+    )
+import Agent.CLI.Session
+    ( SessionHandle(..)
+    , SessionMeta(..)
+    , SessionTurn(..)
+    , appendTurn
+    , ensureSession
+    )
+import Agent.CLI.SessionEnv (SessionEnv(..))
+import Agent.CLI.Status (formatTokenUsage)
+import Agent.CLI.Style
+    ( cliWindowTitle
+    , glyphSession
+    , roleMuted
+    , setCliWindowTitle
+    )
+import Agent.CLI.Terminal (resolveColor)
+import Agent.CLI.Timestamp (stampTurnInputs, stripBracketedTimestamps)
+import Agent.Loop
+    ( LoopConfig(..)
+    , LoopError(..)
+    , LoopResult(..)
+    , TurnInput(..)
+    , addTokenUsage
+    , runLoopInputs
+    )
+import Agent.OpenAI.LoopBackend (toolResultToItem)
+import Agent.Tools.PlanMode
+    ( PlanDecision(..)
+    , PlanModeEnv(..)
+    , PlanModeHooks(..)
+    , PlanModeState(..)
+    , activatePlanMode
+    , deactivatePlanMode
+    , isPlanModeActive
+    , planFilePath
+    , planModeReminder
+    , writePlanMarkdown
+    )
+import Control.Monad (unless, when)
+import Data.IORef
+    ( atomicModifyIORef'
+    , modifyIORef'
+    , readIORef
+    , writeIORef
+    )
+import Data.Maybe (isNothing)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Data.Time.Clock (diffUTCTime, getCurrentTime)
+import System.IO (hIsTerminalDevice, stderr, stdout)
+
+runOneTurn :: SessionEnv -> Text -> [TurnInput] -> IO Bool
+runOneTurn env@SessionEnv
+    { sessionLoop = config
+    , sessionRender = render
+    , sessionPrevious = previous
+    , sessionPrinted = printed
+    , sessionTranscript = transcriptRef
+    , sessionPersist = persist
+    , sessionPlanMode = planMode
+    , sessionAgentsContext = agentsContext
+    , sessionEscPaused = escPaused
+    , sessionInterrupt = interrupt
+    , sessionStoreRoot = storeRoot
+    , sessionUsage = usageRef
+    } promptText inputs =
+  withTurnCancel interrupt config.loopCancel $
+  withEscCancel config.loopCancel escPaused do
+    pending <- readIORef planMode.planStateRef
+    when (pending == PlanPending) (activatePlanMode planMode)
+    -- Create the session directory before tools run so first-turn subagents
+    -- can persist under agents/<id>/ as they complete.
+    case persist of
+        Just slotRef -> do
+            created <- isLeftSlot <$> readIORef slotRef
+            handle <- ensureSession slotRef
+            writeIORef planMode.planSessionDir (Just handle.sessionDir)
+            writeIORef storeRoot (Just handle.sessionDir)
+            when created do
+                color <- resolveColor stderr
+                putTextLn stderr
+                    (roleMuted color
+                        (glyphSession <> "session: " <> handle.sessionMeta.metaId))
+        Nothing -> pure ()
+    prev <- readIORef previous
+    beforeItems <- readIORef transcriptRef
+    pendingAgents <- atomicModifyIORef' agentsContext \pendingCtx -> (Nothing, pendingCtx)
+    planActive <- isPlanModeActive planMode
+    planPath <- planFilePath planMode
+    let planReminder =
+            if planActive
+                then Just (planModeReminder planPath)
+                else Nothing
+        baseInputs = case pendingAgents of
+            Just agents | null beforeItems && isNothing prev ->
+                UserMessage agents : inputs
+            _ -> inputs
+        turnInputs0 = case planReminder of
+            Just reminder -> UserMessage reminder : baseInputs
+            Nothing -> baseInputs
+    turnInputs <- stampTurnInputs turnInputs0
+    startedAt <- readIORef render.renderStartedAt
+    result <- runLoopInputs config prev turnInputs
+    clearThinking render
+    finishedAt <- getCurrentTime
+    let elapsedDetail extra = case startedAt of
+            Nothing -> extra
+            Just t0 -> extra <> " · " <> formatElapsed (realToFrac (diffUTCTime finishedAt t0))
+    case result of
+        Left (LoopCancelled toolResults) -> do
+            unless (null toolResults) do
+                modifyIORef' transcriptRef
+                    (<> map toolResultToItem toolResults)
+            color <- resolveColor stderr
+            putTextLn stderr (formatLoopErrorColored color (LoopCancelled toolResults))
+            model <- readIORef render.renderModelRef
+            putTextLn stderr (formatTurnStatus color "cancelled" (elapsedDetail model))
+            pure True
+        Left err -> do
+            color <- resolveColor stderr
+            putTextLn stderr (formatLoopErrorColored color err)
+            model <- readIORef render.renderModelRef
+            putTextLn stderr (formatTurnStatus color "error" (elapsedDetail model))
+            pure False
+        Right loopResult -> do
+            writeIORef previous (Just loopResult.finalResponseId)
+            modifyIORef' usageRef (`addTokenUsage` loopResult.tokenUsage)
+            do
+                color <- resolveColor stderr
+                model <- readIORef render.renderModelRef
+                let turns = Text.pack (show loopResult.turnsUsed)
+                    unit = if loopResult.turnsUsed == 1 then " turn" else " turns"
+                    usageDetail = formatTokenUsage loopResult.tokenUsage
+                    extra =
+                        if Text.null usageDetail
+                            then model <> " · " <> turns <> unit
+                            else model <> " · " <> turns <> unit <> " · " <> usageDetail
+                putTextLn stderr
+                    (formatTurnStatus color "ok" (elapsedDetail extra))
+            followUp <- handleProposedPlan planMode loopResult.finalText
+            printedText <- readIORef printed
+            let assistantText =
+                    fmap stripBracketedTimestamps loopResult.finalText
+            case (printedText, assistantText) of
+                (False, Just text) | not (Text.null (Text.strip text)) -> do
+                    useColor <- resolveColor stdout
+                    putTextLn stdout (renderAssistantText useColor text)
+                _ -> pure ()
+            afterItems <- readIORef transcriptRef
+            let newItems = drop (length beforeItems) afterItems
+            case persist of
+                Nothing -> pure ()
+                Just slotRef -> do
+                    now <- getCurrentTime
+                    handle <- ensureSession slotRef
+                    writeIORef planMode.planSessionDir (Just handle.sessionDir)
+                    writeIORef storeRoot (Just handle.sessionDir)
+                    let turn = SessionTurn
+                            { turnAt = now
+                            , turnUserText = promptText
+                            , turnAssistantText = assistantText
+                            , turnResponseId = Just loopResult.finalResponseId
+                            , turnItems = newItems
+                            , turnUsage = Just loopResult.tokenUsage
+                            }
+                    handle' <- appendTurn handle turn
+                    writeIORef slotRef (Right handle')
+                    when (handle'.sessionMeta.metaTitle /= handle.sessionMeta.metaTitle) do
+                        tty <- hIsTerminalDevice stdout
+                        setCliWindowTitle tty stdout
+                            (cliWindowTitle handle'.sessionMeta.metaCwd
+                                (Just handle'.sessionMeta.metaTitle))
+            case followUp of
+                Nothing -> pure True
+                Just notes -> do
+                    writeIORef printed False
+                    _ <- runOneTurn env notes [UserMessage notes]
+                    pure True
+
+isLeftSlot :: Either a b -> Bool
+isLeftSlot = \case
+    Left _ -> True
+    Right _ -> False
+
+handleProposedPlan :: PlanModeEnv -> Maybe Text -> IO (Maybe Text)
+handleProposedPlan planMode = \case
+    Nothing -> pure Nothing
+    Just text -> do
+        active <- isPlanModeActive planMode
+        case (active, extractProposedPlan text) of
+            (True, Just planBody) -> do
+                _ <- writePlanMarkdown planMode planBody
+                let PlanModeHooks{ planDecideExit = decideExit } = planMode.planHooks
+                decision <- decideExit planBody
+                case decision of
+                    PlanApprove -> do
+                        deactivatePlanMode planMode
+                        pure Nothing
+                    PlanCancel -> do
+                        deactivatePlanMode planMode
+                        pure Nothing
+                    PlanRequestChanges notes ->
+                        pure $ Just $
+                            "The user requested changes to the plan. Stay in plan mode and revise.\n\
+                            \Feedback:\n"
+                                <> notes
+            _ -> pure Nothing

--- a/packages/agent-cli/test/Agent/CLI/ApprovalSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ApprovalSpec.hs
@@ -1,0 +1,72 @@
+module Agent.CLI.ApprovalSpec (spec) where
+
+import Agent.CLI.Approval (childApprove)
+import Agent.CLI.Options (ApprovalPolicy(..))
+import Agent.ToolDispatch
+    ( ToolCall
+    , functionToolCall
+    , noArgsTool
+    )
+import Agent.Tools.Types
+    ( AppTool(..)
+    , AppToolKind(..)
+    )
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Test.Hspec
+
+spec :: Spec
+spec = describe "childApprove" do
+    it "allows every known tool under ApproveAll" do
+        childApprove ApproveAll [mutatingTool] mutatingCall
+            `shouldReturn` Right True
+
+    it "allows only read-only tools under DenyMutating" do
+        childApprove DenyMutating [readOnlyTool] readOnlyCall
+            `shouldReturn` Right True
+        childApprove DenyMutating [mutatingTool] mutatingCall
+            `shouldReturn` Right False
+
+    it "returns an in-band denial when a child would need to prompt" do
+        result <- childApprove PromptMutating [mutatingTool] mutatingCall
+        result `shouldSatisfy` \case
+            Left message -> "cannot prompt for approval" `Text.isInfixOf` message
+            Right _ -> False
+
+    it "honors per-call read-only classifiers" do
+        childApprove DenyMutating [dynamicTool] dynamicReadCall
+            `shouldReturn` Right True
+        childApprove DenyMutating [dynamicTool] dynamicWriteCall
+            `shouldReturn` Right False
+
+readOnlyCall :: ToolCall
+readOnlyCall = functionToolCall "call-read" "read" "{}"
+
+mutatingCall :: ToolCall
+mutatingCall = functionToolCall "call-write" "write" "{}"
+
+dynamicReadCall :: ToolCall
+dynamicReadCall = functionToolCall "call-dynamic-read" "dynamic" "read"
+
+dynamicWriteCall :: ToolCall
+dynamicWriteCall = functionToolCall "call-dynamic-write" "dynamic" "write"
+
+readOnlyTool :: AppTool
+readOnlyTool = tool "read" True Nothing
+
+mutatingTool :: AppTool
+mutatingTool = tool "write" False Nothing
+
+dynamicTool :: AppTool
+dynamicTool = tool "dynamic" False (Just (\call -> pure (call == dynamicReadCall)))
+
+tool :: Text -> Bool -> Maybe (ToolCall -> IO Bool) -> AppTool
+tool name readOnly classify = AppTool
+    { appToolName = name
+    , appToolDescription = ""
+    , appToolParameters = []
+    , appToolHandler = noArgsTool name (pure (Right "ok"))
+    , appToolKind = JsonFunction
+    , appToolReadOnly = readOnly
+    , appToolIsReadOnlyCall = classify
+    }

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -2,6 +2,7 @@ module Main (main) where
 
 import Test.Hspec (hspec)
 
+import qualified Agent.CLI.ApprovalSpec as ApprovalSpec
 import qualified Agent.CLI.AuthSpec as AuthSpec
 import qualified Agent.CLI.CancelWatchSpec as CancelWatchSpec
 import qualified Agent.CLI.ClipboardSpec as ClipboardSpec
@@ -30,6 +31,7 @@ import qualified Agent.CLI.WorktreeSpec as WorktreeSpec
 
 main :: IO ()
 main = hspec do
+    ApprovalSpec.spec
     AuthSpec.spec
     CancelWatchSpec.spec
     ClipboardSpec.spec


### PR DESCRIPTION
## Summary

- extract REPL status and mode transitions into `Agent.CLI.Status`
- extract parent/child tool approval into `Agent.CLI.Approval`
- extract model turn execution and persistence into `Agent.CLI.Turn`
- centralize terminal color detection in `Agent.CLI.Terminal`
- keep the existing `Agent.CLI` public status API and add focused child-approval tests

This reduces `Agent.CLI.hs` from 2,231 to 1,839 lines without changing CLI behavior.

## Validation

- multi-package GHCi load succeeds
- `agent-cli` library GHCi load succeeds
- CLI test suite: 246 examples, 0 failures
- `git diff --check`