### PR TITLE
fix: reconnect dead OpenAI WebSockets

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -112,7 +112,7 @@ import Agent.OpenAI.Compaction
     , isTranscriptResetTurn
     , newSessionUserText
     )
-import Agent.OpenAI.LoopBackend (openAiBackend)
+import Agent.OpenAI.LoopBackend (openAiBackendReconnecting)
 import Agent.OpenAI.Responses.Types
 import Agent.OpenAI.WebSocketClient
     ( CodexAuthFailed(..)
@@ -478,6 +478,7 @@ runAgent options = do
                         try @_ @CodexAuthFailed
                             (withCodexWsWithProvider loaded.loadedTokenProvider \conn _credential -> do
                                 wsLock <- newMVar ()
+                                wsHealthy <- newIORef True
                                 case multiCtx of
                                     Just ctx ->
                                         setSubagentRunner ctx.multiRegistry $
@@ -487,6 +488,8 @@ runAgent options = do
                                                 planHooks
                                                 paramsRef
                                                 wsLock
+                                                loaded.loadedTokenProvider
+                                                wsHealthy
                                                 conn
                                                 ctx.multiRegistry
                                                 subagentSessions
@@ -494,7 +497,11 @@ runAgent options = do
                                                 agentTypesRef
                                     Nothing -> pure ()
                                 let lockedBackend =
-                                        lockedOpenAiBackend wsLock conn
+                                        lockedOpenAiBackend
+                                            wsLock
+                                            loaded.loadedTokenProvider
+                                            wsHealthy
+                                            conn
                                             (readIORef paramsRef)
                                             transcriptRef
                                     noticingBackend =
@@ -1606,12 +1613,15 @@ restoreAgentFromDisk storeRootRef registry sessionsRef typesRef agentId = do
 -- and 'receiveWsResponse' is not multiplexed.
 lockedOpenAiBackend
     :: MVar ()
+    -> TokenProvider
+    -> IORef Bool
     -> CodexConn
     -> IO ResponseCreateParams
     -> IORef [ResponseItem]
     -> Backend
-lockedOpenAiBackend wsLock conn getParams transcript =
-    let Backend submit = openAiBackend conn getParams transcript
+lockedOpenAiBackend wsLock provider connectionHealthy conn getParams transcript =
+    let Backend submit =
+            openAiBackendReconnecting provider connectionHealthy conn getParams transcript
     in Backend \previous inputs onEvent ->
         withMVar wsLock \_ -> submit previous inputs onEvent
 
@@ -1632,13 +1642,15 @@ runCodexSubagent
     -> PlanModeHooks
     -> IORef ResponseCreateParams
     -> MVar ()
+    -> TokenProvider
+    -> IORef Bool
     -> CodexConn
     -> SubagentRegistry
     -> IORef (Map SubagentId SubagentSession)
     -> SubagentStoreRoot
     -> IORef (Map SubagentId Text)
     -> RunSubagent
-runCodexSubagent options policy planHooks paramsRef wsLock conn registry sessionsRef storeRootRef typesRef =
+runCodexSubagent options policy planHooks paramsRef wsLock tokenProvider connectionHealthy conn registry sessionsRef storeRootRef typesRef =
     \env previous prompt onEvent -> do
         parentParams <- readIORef paramsRef
         childEnv <- defaultToolEnv env.subCwd
@@ -1679,7 +1691,7 @@ runCodexSubagent options policy planHooks paramsRef wsLock conn registry session
                     (schemasFromAppTools OpenAIProvider tools) effort
             childParamsRef <- newIORef childParams
             let backend =
-                    lockedOpenAiBackend wsLock conn
+                    lockedOpenAiBackend wsLock tokenProvider connectionHealthy conn
                         (readIORef childParamsRef)
                         session.subSessionTranscript
                 config = LoopConfig

--- a/packages/agent-openai/src/Agent/OpenAI/LoopBackend.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/LoopBackend.hs
@@ -4,7 +4,9 @@
 -- adapter can reuse the same function_call and custom_tool_call encoding.
 module Agent.OpenAI.LoopBackend
     ( openAiBackend
+    , openAiBackendReconnecting
     , openAiBackendWith
+    , openAiBackendWithConnectionRecovery
     , turnInputsToItems
     , responseToTurnOutput
     , streamEventToLoopEvent
@@ -13,7 +15,7 @@ module Agent.OpenAI.LoopBackend
     , withRequestInput
     ) where
 
-import Agent.Error (ApiError)
+import Agent.Error (ApiError(..))
 import Agent.OpenAI.Error (isPreviousResponseIdError)
 import Agent.Loop
     ( Backend(..)
@@ -28,7 +30,9 @@ import Agent.OpenAI.Responses.Types
 import Agent.OpenAI.WebSocketClient
     ( CodexConn
     , sendWsRequestWithEvents
+    , withCodexWsRetrying
     )
+import Agent.Provider (TokenProvider)
 import Agent.ToolDispatch
     ( ToolCall(..)
     , ToolCallKind(..)
@@ -41,7 +45,7 @@ import qualified Data.Aeson.KeyMap as KeyMap
 import Data.ByteString (ByteString)
 import qualified "base64-bytestring" Data.ByteString.Base64 as Base64
 import Data.IORef
-import Data.Maybe (fromMaybe, mapMaybe)
+import Data.Maybe (fromMaybe, isJust, mapMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
@@ -61,6 +65,67 @@ openAiBackend
 openAiBackend conn =
     openAiBackendWith \request previousResponseId onEvent ->
         sendWsRequestWithEvents conn request previousResponseId onEvent
+
+-- | Reuse the session WebSocket while it is healthy, reconnecting after it dies.
+openAiBackendReconnecting
+    :: TokenProvider
+    -> IORef Bool
+    -> CodexConn
+    -> IO ResponseCreateParams
+    -> IORef [ResponseItem]
+    -> Backend
+openAiBackendReconnecting provider connectionHealthy conn =
+    openAiBackendWithConnectionRecovery connectionHealthy sendCurrent sendFresh
+  where
+    sendCurrent request previousResponseId onEvent =
+        sendWsRequestWithEvents conn request previousResponseId onEvent
+    sendFresh request previousResponseId onEvent =
+        withCodexWsRetrying provider
+            (sendOnFresh request previousResponseId onEvent)
+    sendOnFresh request previousResponseId onEvent freshConn _credential =
+        sendWsRequestWithEvents freshConn request previousResponseId onEvent
+
+-- | Injectable connection recovery used by the reconnecting backend.
+openAiBackendWithConnectionRecovery
+    :: IORef Bool
+    -> (ResponseCreateParams
+        -> Maybe Text
+        -> (ResponseStreamEvent -> IO ())
+        -> IO (Either ApiError Response))
+    -> (ResponseCreateParams
+        -> Maybe Text
+        -> (ResponseStreamEvent -> IO ())
+        -> IO (Either ApiError Response))
+    -> IO ResponseCreateParams
+    -> IORef [ResponseItem]
+    -> Backend
+openAiBackendWithConnectionRecovery connectionHealthy sendCurrent sendFresh =
+    openAiBackendWith sendWithRecovery
+  where
+    sendWithRecovery request previousResponseId onEvent = do
+        healthy <- readIORef connectionHealthy
+        if healthy
+            then tryCurrent request previousResponseId onEvent
+            else sendFresh request previousResponseId onEvent
+
+    tryCurrent request previousResponseId onEvent = do
+        emittedLoopEvent <- newIORef False
+        result <- sendCurrent request previousResponseId
+            (trackOutput emittedLoopEvent onEvent)
+        case result of
+            Left ConnectionError {} -> do
+                writeIORef connectionHealthy False
+                emitted <- readIORef emittedLoopEvent
+                if emitted
+                    then pure result
+                    else sendFresh request previousResponseId onEvent
+            _ -> pure result
+
+    trackOutput emittedLoopEvent onEvent event = do
+        if isJust (streamEventToLoopEvent event)
+            then writeIORef emittedLoopEvent True
+            else pure ()
+        onEvent event
 
 -- | Same mapping as 'openAiBackend', with an injectable transport for tests.
 openAiBackendWith

--- a/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
@@ -195,6 +195,66 @@ spec = do
                 , seed <> turnInputsToItems [UserMessage "new"]
                 ]
 
+    describe "openAiBackendWithConnectionRecovery" do
+        it "replays on a fresh connection when the reusable socket dies before output" do
+            currentCalls <- newIORef (0 :: Int)
+            freshCalls <- newIORef (0 :: Int)
+            healthy <- newIORef True
+            transcript <- newIORef []
+            let sendCurrent _request _previous _onEvent = do
+                    modifyIORef' currentCalls (+ 1)
+                    pure $ Left $ ConnectionError "socket closed"
+                sendFresh _request _previous _onEvent = do
+                    modifyIORef' freshCalls (+ 1)
+                    pure $ Right (testResponse "resp-fresh" [assistantItem "ok"])
+                backend = openAiBackendWithConnectionRecovery
+                    healthy sendCurrent sendFresh (pure baseParams) transcript
+            first <- backend.submitTurn Nothing [UserMessage "one"] (const (pure ()))
+            second <- backend.submitTurn (Just "resp-fresh")
+                [UserMessage "two"] (const (pure ()))
+            first `shouldBe` Right (emptyTurnOutput "resp-fresh" [] (Just "ok"))
+            second `shouldBe` Right (emptyTurnOutput "resp-fresh" [] (Just "ok"))
+            readIORef healthy `shouldReturn` False
+            readIORef currentCalls `shouldReturn` 1
+            readIORef freshCalls `shouldReturn` 2
+
+        it "does not replay after loop-visible output was already streamed" do
+            freshCalls <- newIORef (0 :: Int)
+            healthy <- newIORef True
+            transcript <- newIORef []
+            events <- newIORef []
+            let sendCurrent _request _previous onEvent = do
+                    onEvent (deltaEvent EventOutputTextDelta "partial")
+                    pure $ Left $ ConnectionError "socket closed"
+                sendFresh _request _previous _onEvent = do
+                    modifyIORef' freshCalls (+ 1)
+                    pure $ Right (testResponse "resp-fresh" [assistantItem "ok"])
+                streamingBackend = openAiBackendWithConnectionRecovery
+                    healthy sendCurrent sendFresh (pure baseParams) transcript
+            result <- streamingBackend.submitTurn Nothing [UserMessage "one"]
+                (modifyIORef' events . (:))
+            result `shouldBe` Left (ConnectionError "socket closed")
+            reverse <$> readIORef events `shouldReturn` [TextDelta "partial"]
+            readIORef healthy `shouldReturn` False
+            readIORef freshCalls `shouldReturn` 0
+
+        it "does not treat provider errors as a dead connection" do
+            freshCalls <- newIORef (0 :: Int)
+            healthy <- newIORef True
+            transcript <- newIORef []
+            let sendCurrent _request _previous _onEvent =
+                    pure $ Left $ ProviderError OverloadedError "busy" Nothing
+                sendFresh _request _previous _onEvent = do
+                    modifyIORef' freshCalls (+ 1)
+                    pure $ Right (testResponse "resp-fresh" [assistantItem "ok"])
+                providerErrorBackend = openAiBackendWithConnectionRecovery
+                    healthy sendCurrent sendFresh (pure baseParams) transcript
+            result <- providerErrorBackend.submitTurn Nothing
+                [UserMessage "one"] (const (pure ()))
+            result `shouldBe` Left (ProviderError OverloadedError "busy" Nothing)
+            readIORef healthy `shouldReturn` True
+            readIORef freshCalls `shouldReturn` 0
+
 --------------------------------------------------------------------------------
 -- Fixtures
 --------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Detect a dead shared Codex WebSocket and reacquire a fresh connection for parent and subagent turns.
- Replay the interrupted request only when no loop-visible output has streamed, avoiding duplicated assistant output.
- Route later turns directly through fresh connections after the reusable socket is known to be dead, while leaving non-connection provider errors unchanged.

## Test plan
- [x] `cabal repl agent-openai:test:agent-openai-test` + `:main` — 125 examples, 0 failures, 1 pending live credential test
- [x] `cabal repl agent-cli:test:agent-cli-test` + `:main` — 250 examples, 0 failures
- [x] Multi-package GHCi typecheck for `agent-cli` and `agent-openai`
- [x] `git diff --check`