### PR TITLE
Split OpenAI auth pool, refresh, and JWT modules

### DIFF
--- a/packages/agent-openai/agent-openai.cabal
+++ b/packages/agent-openai/agent-openai.cabal
@@ -45,6 +45,9 @@ library
                     , Agent.OpenAI.Error
                     , Agent.OpenAI.Http
                     , Agent.OpenAI.Auth
+                    , Agent.OpenAI.Auth.JWT
+                    , Agent.OpenAI.Auth.Refresh
+                    , Agent.OpenAI.Auth.Types
                     , Agent.OpenAI.Credential
                     , Agent.OpenAI.Login
                     , Agent.OpenAI.Usage

--- a/packages/agent-openai/src/Agent/OpenAI/Auth.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Auth.hs
@@ -40,45 +40,25 @@ module Agent.OpenAI.Auth
     ) where
 
 import Agent.Error (ApiError(..), ErrorType(..))
-import Control.Applicative ((<|>))
+import Agent.OpenAI.Auth.JWT
+    ( deriveAccountId
+    , needsRefresh
+    , parseJwtExp
+    )
+import Agent.OpenAI.Auth.Refresh (refreshAccessTokenHTTP)
+import Agent.OpenAI.Auth.Types (AuthState(..))
 import Control.Concurrent.MVar (MVar, newMVar, withMVar)
-import Control.Exception (SomeException, try)
 import Control.Monad (forM, when)
-import qualified Data.Aeson as Aeson
-import qualified Data.Aeson.Key as Key
-import qualified Data.Aeson.KeyMap as KeyMap
-import qualified "base64-bytestring" Data.ByteString.Base64 as Base64
-import qualified Data.ByteString.Lazy as LBS
 import Data.IORef
 import Data.List (find)
 import Data.Maybe (catMaybes, fromMaybe)
 import qualified Data.Set as Set
 import Data.Text (Text)
-import qualified Data.Text as Text
-import qualified Data.Text.Encoding as Text
-import Data.Time.Calendar (fromGregorian)
-import Data.Time.Clock (UTCTime(..), addUTCTime, diffUTCTime, getCurrentTime, utctDayTime)
-import Network.HTTP.Simple
-    ( getResponseBody
-    , getResponseStatusCode
-    , httpLBS
-    , parseRequest_
-    , setRequestBodyLBS
-    , setRequestHeader
-    )
+import Data.Time.Clock (UTCTime, addUTCTime, getCurrentTime, utctDayTime)
 
 --------------------------------------------------------------------------------
 -- State
 --------------------------------------------------------------------------------
-
--- | In-memory auth state for a single ChatGPT account.
-data AuthState = AuthState
-    { accessToken  :: !Text
-    , refreshToken :: !Text
-    , accountId    :: !Text
-    , idToken      :: !(Maybe Text)
-    , lastRefresh  :: !UTCTime
-    } deriving (Show)
 
 -- | Per-account mutable state in the pool.
 data AccountEntry = AccountEntry
@@ -114,18 +94,12 @@ data Pool = Pool
 -- Configuration
 --------------------------------------------------------------------------------
 
-tokenEndpoint :: String
-tokenEndpoint = "https://auth.openai.com/oauth/token"
-
 -- | Refresh when the access-token JWT has less than this many seconds left.
 -- ChatGPT Codex access tokens are long-lived (~9 days), so this is the only
 -- trigger the pool uses — no periodic wall-clock refresh. A looser
 -- interval-based refresh would just burn through refresh tokens
 -- unnecessarily, and an exhausted refresh-token family can't be recovered
 -- without re-running @npx \@openai/codex login@ interactively.
-refreshMarginSeconds :: Int
-refreshMarginSeconds = 10 * 60
-
 -- | How long to mark an account as unavailable after a rate-limit error
 -- when the server does not provide @resets_in_seconds@.
 rateLimitCooldownSeconds :: Int
@@ -477,135 +451,3 @@ findEntry :: Pool -> Text -> IO (Maybe AccountEntry)
 findEntry pool targetAccountId = do
     entries <- readIORef pool.poolEntries
     pure (find ((== targetAccountId) . (.entryAccountId)) entries)
-
---------------------------------------------------------------------------------
--- Refresh
---------------------------------------------------------------------------------
-
--- | Pure HTTP call to OpenAI's @/oauth/token@ endpoint to rotate the access
--- and refresh tokens for a single account. The OAuth public client id is
--- supplied at runtime and is never embedded in this package.
---
--- Does NOT persist the result anywhere — callers are expected to handle
--- persistence and cross-process locking themselves. This is the default
--- callback for 'newPool'; wrap it with your own transaction logic if you
--- run multiple workers against a shared token store (OpenAI rotates the
--- refresh token on every use, so concurrent POSTs of the same refresh token
--- fail with @refresh_token_reused@).
-refreshAccessTokenHTTP :: Text -> AuthState -> IO (Either ApiError AuthState)
-refreshAccessTokenHTTP oauthClientId state = do
-    let body = Aeson.encode $ Aeson.object
-            [ "grant_type"    Aeson..= ("refresh_token" :: Text)
-            , "refresh_token" Aeson..= state.refreshToken
-            , "client_id"     Aeson..= oauthClientId
-            , "scope"         Aeson..= ("openid profile email offline_access" :: Text)
-            ]
-    let request = setRequestBodyLBS body
-            $ setRequestHeader "Content-Type" ["application/json"]
-            $ parseRequest_ ("POST " <> tokenEndpoint)
-    eResponse <- try @SomeException (httpLBS request)
-    case eResponse of
-        Left e -> pure $ Left (ConnectionError (Text.pack (show e)))
-        Right response -> do
-            let status = getResponseStatusCode response
-            if status < 200 || status >= 300
-                then pure $ Left $ ProviderError AuthenticationError
-                    ("Codex token refresh failed with HTTP "
-                        <> Text.pack (show status) <> ": "
-                        <> Text.decodeUtf8 (LBS.toStrict (LBS.take 500 (getResponseBody response))))
-                    Nothing
-                else case Aeson.eitherDecode (getResponseBody response) of
-                    Left err ->
-                        pure $ Left $ ProviderError AuthenticationError
-                            ("Failed to parse token refresh response: " <> Text.pack err)
-                            Nothing
-                    Right (obj :: Aeson.Value) ->
-                        case jsonTextMaybe obj "access_token" of
-                            Nothing ->
-                                pure $ Left $ ProviderError AuthenticationError
-                                    "Token refresh response missing access_token"
-                                    Nothing
-                            Just newAccessToken -> do
-                                let newRefreshToken = fromMaybe state.refreshToken (jsonTextMaybe obj "refresh_token")
-                                    newIdToken = jsonTextMaybe obj "id_token"
-                                    newAccountId = fromMaybe state.accountId (newIdToken >>= deriveAccountId)
-                                now <- getCurrentTime
-                                pure $ Right state
-                                    { accessToken  = newAccessToken
-                                    , refreshToken = newRefreshToken
-                                    , accountId    = newAccountId
-                                    , idToken      = newIdToken <|> state.idToken
-                                    , lastRefresh  = now
-                                    }
-
---------------------------------------------------------------------------------
--- JWT helpers
---------------------------------------------------------------------------------
-
--- | Refresh only when the access-token JWT is about to expire. We
--- intentionally do NOT refresh on any wall-clock interval — rotating healthy
--- tokens early is the fastest way to exhaust a refresh-token family, and the
--- only recovery path is interactive re-login.
-needsRefresh :: AuthState -> UTCTime -> Bool
-needsRefresh state now =
-    case parseJwtExp state.accessToken of
-        Nothing    -> True  -- can't parse, refresh to be safe
-        Just expAt -> diffUTCTime expAt now < fromIntegral refreshMarginSeconds
-
--- | Parse the @exp@ claim from a JWT (no signature verification).
-parseJwtExp :: Text -> Maybe UTCTime
-parseJwtExp token = do
-    let parts = Text.splitOn "." token
-    payloadB64 <- parts !!? 1
-    let padded = base64UrlToBase64 payloadB64
-    payloadBytes <- either (const Nothing) Just (Base64.decode (Text.encodeUtf8 padded))
-    obj <- Aeson.decode (LBS.fromStrict payloadBytes)
-    expAt <- jsonIntMaybe obj "exp"
-    let epoch = UTCTime (fromGregorian 1970 1 1) 0
-    pure $ addUTCTime (fromIntegral expAt) epoch
-
--- | Derive the ChatGPT @accountId@ from the @id_token@ JWT claims
--- (specifically the @https://api.openai.com/auth.chatgpt_account_id@ claim).
-deriveAccountId :: Text -> Maybe Text
-deriveAccountId idTok = do
-    let parts = Text.splitOn "." idTok
-    payloadB64 <- parts !!? 1
-    let padded = base64UrlToBase64 payloadB64
-    payloadBytes <- either (const Nothing) Just (Base64.decode (Text.encodeUtf8 padded))
-    Aeson.Object km <- Aeson.decode (LBS.fromStrict payloadBytes)
-    Aeson.Object authKm <- KeyMap.lookup "https://api.openai.com/auth" km
-    Aeson.String accId <- KeyMap.lookup "chatgpt_account_id" authKm
-    pure accId
-
---------------------------------------------------------------------------------
--- Internal helpers
---------------------------------------------------------------------------------
-
-base64UrlToBase64 :: Text -> Text
-base64UrlToBase64 t =
-    let replaced = Text.replace "-" "+" (Text.replace "_" "/" t)
-        padLen = (4 - Text.length replaced `mod` 4) `mod` 4
-    in replaced <> Text.replicate padLen "="
-
-(!!?) :: [a] -> Int -> Maybe a
-(!!?) xs i
-    | i < 0     = Nothing
-    | otherwise = go xs i
-  where
-    go [] _     = Nothing
-    go (x:_) 0  = Just x
-    go (_:rest) n = go rest (n - 1)
-
-jsonTextMaybe :: Aeson.Value -> Text -> Maybe Text
-jsonTextMaybe (Aeson.Object obj) key =
-    case KeyMap.lookup (Key.fromText key) obj of
-        Just (Aeson.String t) -> Just t
-        _ -> Nothing
-jsonTextMaybe _ _ = Nothing
-
-jsonIntMaybe :: Aeson.Value -> Text -> Maybe Int
-jsonIntMaybe (Aeson.Object obj) key =
-    case KeyMap.lookup (Key.fromText key) obj of
-        Just (Aeson.Number n) -> Just (round n)
-        _ -> Nothing
-jsonIntMaybe _ _ = Nothing

--- a/packages/agent-openai/src/Agent/OpenAI/Auth/JWT.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Auth/JWT.hs
@@ -1,0 +1,73 @@
+module Agent.OpenAI.Auth.JWT
+    ( deriveAccountId
+    , needsRefresh
+    , parseJwtExp
+    , refreshMarginSeconds
+    ) where
+
+import Agent.OpenAI.Auth.Types (AuthState(..))
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified "base64-bytestring" Data.ByteString.Base64 as Base64
+import qualified Data.ByteString.Lazy as LBS
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
+import Data.Time.Calendar (fromGregorian)
+import Data.Time.Clock (UTCTime(..), addUTCTime, diffUTCTime)
+
+-- | Refresh when the access-token JWT has less than this many seconds left.
+refreshMarginSeconds :: Int
+refreshMarginSeconds = 10 * 60
+
+-- | Refresh only when the access-token JWT is about to expire.
+needsRefresh :: AuthState -> UTCTime -> Bool
+needsRefresh state now =
+    case parseJwtExp state.accessToken of
+        Nothing    -> True
+        Just expAt -> diffUTCTime expAt now < fromIntegral refreshMarginSeconds
+
+-- | Parse the @exp@ claim from a JWT without signature verification.
+parseJwtExp :: Text -> Maybe UTCTime
+parseJwtExp token = do
+    payloadB64 <- Text.splitOn "." token !!? 1
+    payloadBytes <- either (const Nothing) Just
+        (Base64.decode (Text.encodeUtf8 (base64UrlToBase64 payloadB64)))
+    obj <- Aeson.decode (LBS.fromStrict payloadBytes)
+    expAt <- jsonIntMaybe obj "exp"
+    let epoch = UTCTime (fromGregorian 1970 1 1) 0
+    pure $ addUTCTime (fromIntegral expAt) epoch
+
+-- | Derive the ChatGPT account id from an @id_token@ JWT.
+deriveAccountId :: Text -> Maybe Text
+deriveAccountId idTok = do
+    payloadB64 <- Text.splitOn "." idTok !!? 1
+    payloadBytes <- either (const Nothing) Just
+        (Base64.decode (Text.encodeUtf8 (base64UrlToBase64 payloadB64)))
+    Aeson.Object km <- Aeson.decode (LBS.fromStrict payloadBytes)
+    Aeson.Object authKm <- KeyMap.lookup "https://api.openai.com/auth" km
+    Aeson.String accId <- KeyMap.lookup "chatgpt_account_id" authKm
+    pure accId
+
+base64UrlToBase64 :: Text -> Text
+base64UrlToBase64 text =
+    let replaced = Text.replace "-" "+" (Text.replace "_" "/" text)
+        padLen = (4 - Text.length replaced `mod` 4) `mod` 4
+    in replaced <> Text.replicate padLen "="
+
+(!!?) :: [a] -> Int -> Maybe a
+(!!?) xs index
+    | index < 0 = Nothing
+    | otherwise = go xs index
+  where
+    go [] _ = Nothing
+    go (x:_) 0 = Just x
+    go (_:rest) n = go rest (n - 1)
+
+jsonIntMaybe :: Aeson.Value -> Text -> Maybe Int
+jsonIntMaybe (Aeson.Object object) key =
+    case KeyMap.lookup (Key.fromText key) object of
+        Just (Aeson.Number n) -> Just (round n)
+        _ -> Nothing
+jsonIntMaybe _ _ = Nothing

--- a/packages/agent-openai/src/Agent/OpenAI/Auth/Refresh.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Auth/Refresh.hs
@@ -1,0 +1,88 @@
+module Agent.OpenAI.Auth.Refresh (refreshAccessTokenHTTP) where
+
+import Agent.Error (ApiError(..), ErrorType(..))
+import Agent.OpenAI.Auth.JWT (deriveAccountId)
+import Agent.OpenAI.Auth.Types (AuthState(..))
+import Control.Applicative ((<|>))
+import Control.Exception.Safe (tryAny)
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy as LBS
+import Data.Maybe (fromMaybe)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
+import Data.Time.Clock (getCurrentTime)
+import Network.HTTP.Simple
+    ( getResponseBody
+    , getResponseStatusCode
+    , httpLBS
+    , parseRequest_
+    , setRequestBodyLBS
+    , setRequestHeader
+    )
+
+tokenEndpoint :: String
+tokenEndpoint = "https://auth.openai.com/oauth/token"
+
+-- | Pure HTTP call to OpenAI's @/oauth/token@ endpoint to rotate the access
+-- and refresh tokens for a single account. Persistence and cross-process
+-- locking remain the caller's responsibility.
+refreshAccessTokenHTTP :: Text -> AuthState -> IO (Either ApiError AuthState)
+refreshAccessTokenHTTP oauthClientId state = do
+    let body = Aeson.encode $ Aeson.object
+            [ "grant_type"    Aeson..= ("refresh_token" :: Text)
+            , "refresh_token" Aeson..= state.refreshToken
+            , "client_id"     Aeson..= oauthClientId
+            , "scope"         Aeson..= ("openid profile email offline_access" :: Text)
+            ]
+        request = setRequestBodyLBS body
+            $ setRequestHeader "Content-Type" ["application/json"]
+            $ parseRequest_ ("POST " <> tokenEndpoint)
+    tryAny (httpLBS request) >>= \case
+        Left exception ->
+            pure $ Left (ConnectionError (Text.pack (show exception)))
+        Right response -> do
+            let status = getResponseStatusCode response
+            if status < 200 || status >= 300
+                then pure $ Left $ ProviderError AuthenticationError
+                    ("Codex token refresh failed with HTTP "
+                        <> Text.pack (show status) <> ": "
+                        <> Text.decodeUtf8
+                            (LBS.toStrict (LBS.take 500 (getResponseBody response))))
+                    Nothing
+                else case Aeson.eitherDecode (getResponseBody response) of
+                    Left err ->
+                        pure $ Left $ ProviderError AuthenticationError
+                            ("Failed to parse token refresh response: " <> Text.pack err)
+                            Nothing
+                    Right (object :: Aeson.Value) ->
+                        case jsonTextMaybe object "access_token" of
+                            Nothing ->
+                                pure $ Left $ ProviderError AuthenticationError
+                                    "Token refresh response missing access_token"
+                                    Nothing
+                            Just newAccessToken -> do
+                                let newRefreshToken =
+                                        fromMaybe state.refreshToken
+                                            (jsonTextMaybe object "refresh_token")
+                                    newIdToken = jsonTextMaybe object "id_token"
+                                    newAccountId =
+                                        fromMaybe state.accountId
+                                            (newIdToken >>= deriveAccountId)
+                                now <- getCurrentTime
+                                pure $ Right state
+                                    { accessToken = newAccessToken
+                                    , refreshToken = newRefreshToken
+                                    , accountId = newAccountId
+                                    , idToken = newIdToken <|> state.idToken
+                                    , lastRefresh = now
+                                    }
+
+jsonTextMaybe :: Aeson.Value -> Text -> Maybe Text
+jsonTextMaybe (Aeson.Object object) key =
+    case KeyMap.lookup (Key.fromText key) object of
+        Just (Aeson.String text) -> Just text
+        _ -> Nothing
+jsonTextMaybe _ _ = Nothing

--- a/packages/agent-openai/src/Agent/OpenAI/Auth/Types.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Auth/Types.hs
@@ -1,0 +1,13 @@
+module Agent.OpenAI.Auth.Types (AuthState(..)) where
+
+import Data.Text (Text)
+import Data.Time.Clock (UTCTime)
+
+-- | In-memory auth state for a single ChatGPT account.
+data AuthState = AuthState
+    { accessToken  :: !Text
+    , refreshToken :: !Text
+    , accountId    :: !Text
+    , idToken      :: !(Maybe Text)
+    , lastRefresh  :: !UTCTime
+    } deriving (Show)


### PR DESCRIPTION
## Summary

- keep `Agent.OpenAI.Auth` focused on account-pool selection and cooldown state
- move the public `AuthState` model into `Agent.OpenAI.Auth.Types`
- move JWT parsing and refresh-decision logic into `Agent.OpenAI.Auth.JWT`
- move OAuth token-refresh HTTP into `Agent.OpenAI.Auth.Refresh`
- preserve the existing `Agent.OpenAI.Auth` public API through imports/re-exports

## Motivation

The auth module mixed three independently evolving concerns: concurrent account-pool policy, OAuth HTTP transport, and pure JWT claim parsing. Separating those boundaries reduces the main module and makes transport and pure parsing changes easier to review independently.

## Validation

- loaded `Agent.OpenAI.Auth` in `cabal repl agent-openai:lib:agent-openai`
- ran `cabal repl agent-openai:test:agent-openai-test`, then `:main`
- 125 examples, 0 failures, 1 expected pending live test
- `git diff --check`
