### PR TITLE
Add interactive credential manager

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -42,9 +42,11 @@ library
                     , Agent.CLI.Clipboard
                     , Agent.CLI.Compaction
                     , Agent.CLI.Command
+                    , Agent.CLI.CredentialStore
                     , Agent.CLI.ImagePreview
                     , Agent.CLI.Input
                     , Agent.CLI.Interrupt
+                    , Agent.CLI.Login
                     , Agent.CLI.Markdown
                     , Agent.CLI.ModelPicker
                     , Agent.CLI.Models
@@ -108,9 +110,11 @@ test-suite agent-cli-test
                     , Agent.CLI.CancelWatchSpec
                     , Agent.CLI.ClipboardSpec
                     , Agent.CLI.CommandSpec
+                    , Agent.CLI.CredentialStoreSpec
                     , Agent.CLI.ImagePreviewSpec
                     , Agent.CLI.InputSpec
                     , Agent.CLI.InterruptSpec
+                    , Agent.CLI.LoginSpec
                     , Agent.CLI.MarkdownSpec
                     , Agent.CLI.ModelPickerSpec
                     , Agent.CLI.ModelsSpec
@@ -145,6 +149,7 @@ test-suite agent-cli-test
                     , haskeline >= 0.8 && < 0.9
                     , hspec >= 2.11 && < 2.12
                     , process
+                    , safe-exceptions
                     , text
                     , time
                     , unix

--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -46,6 +46,7 @@ import Agent.CLI.Interrupt
     , newInterruptState
     , withCtrlCHandler
     )
+import Agent.CLI.Login (runLoginManager)
 import Agent.CLI.ModelPicker (pickModel)
 import Agent.CLI.Models (ModelOption(..))
 import Agent.CLI.Options
@@ -264,6 +265,10 @@ devMain = do
             die err
         Right ShowHelp -> putStr usage >> pure DevQuit
         Right ShowVersion -> putStrLn "agent-cli 0.1.0.0" >> pure DevQuit
+        Right Login -> do
+            color <- resolveColor stderr
+            runLoginManager color
+            pure DevQuit
         Right ListSessions -> runListSessions >> pure DevQuit
         Right (ShowSession sessionId) -> runShowSession sessionId >> pure DevQuit
         Right (RunAgent options) -> do
@@ -279,6 +284,9 @@ run = do
         Left err -> die err
         Right ShowHelp -> putStr usage
         Right ShowVersion -> putStrLn "agent-cli 0.1.0.0"
+        Right Login -> do
+            color <- resolveColor stderr
+            runLoginManager color
         Right ListSessions -> runListSessions
         Right (ShowSession sessionId) -> runShowSession sessionId
         Right (RunAgent options) -> do
@@ -1264,6 +1272,10 @@ replWithDraft env@SessionEnv
                                         Text.putStrLn
                                             (roleMuted color
                                                 (glyphSession <> "session: " <> handle.sessionMeta.metaId))
+                        continue
+                    ReplLogin -> do
+                        color <- resolveColor stderr
+                        runLoginManager color
                         continue
                     ReplReloadAuth -> do
                         reloadAuth provider tokenProvider

--- a/packages/agent-cli/src/Agent/CLI/Auth.hs
+++ b/packages/agent-cli/src/Agent/CLI/Auth.hs
@@ -8,6 +8,13 @@ module Agent.CLI.Auth
     ) where
 
 import Agent.Broker (BrokerOptions(..), newBrokerTokenProviderFor)
+import Agent.CLI.CredentialStore
+    ( ManagedAuthKind(..)
+    , ManagedCredential(..)
+    , ManagedSecret(..)
+    , loadManagedCredentials
+    , upsertManagedCredential
+    )
 import Agent.Error (ApiError(..), ErrorType(..))
 import qualified Agent.OpenAI.Auth as OpenAI
 import qualified Agent.OpenAI.Credential as OpenAICredential
@@ -104,25 +111,41 @@ loadBroker url requested = do
 
 loadXai :: IO (Either String LoadedAuth)
 loadXai = do
-    credential <- loadGrokCredential
+    credential <- loadXaiCredential
     case credential of
         Nothing -> pure (Left noAuthHint)
         Just loaded -> do
-            provider <- reloadableFileCredentialProvider XAIProvider loaded loadGrokCredential
+            provider <- reloadableFileCredentialProvider
+                XAIProvider loaded loadXaiCredential
             pure $ Right LoadedAuth
                 { loadedProvider = XAIProvider
                 , loadedTokenProvider = provider
                 }
 
+loadXaiCredential :: IO (Maybe Credential)
+loadXaiCredential = do
+    managed <- loadManagedCredential XAIProvider
+    case managed of
+        Just (metadata, secret) ->
+            pure $ managedBearerCredential metadata secret
+        Nothing -> loadGrokCredential
+
+loadOpenRouterKey :: IO (Maybe Text)
+loadOpenRouterKey = do
+    managed <- loadManagedCredential OpenRouterProvider
+    case managed of
+        Just (_, secret) -> pure (Just secret.secretPayload)
+        Nothing -> lookupNonEmpty "OPENROUTER_API_KEY"
+
 loadOpenRouter :: IO (Either String LoadedAuth)
 loadOpenRouter = do
-    key <- lookupNonEmpty "OPENROUTER_API_KEY"
+    key <- loadOpenRouterKey
     case key of
         Nothing -> pure (Left noAuthHint)
         Just apiKey -> do
             let initial = credentialFromApiKey apiKey
             provider <- reloadableFileCredentialProvider OpenRouterProvider initial
-                (fmap (fmap credentialFromApiKey) (lookupNonEmpty "OPENROUTER_API_KEY"))
+                (fmap (fmap credentialFromApiKey) loadOpenRouterKey)
             pure $ Right LoadedAuth
                 { loadedProvider = OpenRouterProvider
                 , loadedTokenProvider = provider
@@ -130,6 +153,7 @@ loadOpenRouter = do
 
 loadOpenAi :: IO (Either String LoadedAuth)
 loadOpenAi = do
+    managed <- loadManagedCredential OpenAIProvider
     fromEnvToken <- lookupNonEmpty "CODEX_ACCESS_TOKEN"
     fromEnvJson <- lookupNonEmpty "CODEX_AUTH_JSON"
     home <- getHomeDirectory
@@ -137,41 +161,136 @@ loadOpenAi = do
     fileExists <- doesFileExist filePath
     fileBytes <- if fileExists then Just <$> LBS.readFile filePath else pure Nothing
     now <- getCurrentTime
-    case fromEnvToken of
-        Just token -> do
-            accountId <- openaiAccountIdForToken token
+    case managed of
+        Just (metadata, secret) ->
+            loadManagedOpenAI now metadata secret
+        Nothing ->
+            case fromEnvToken of
+                Just token -> do
+                    accountId <- openaiAccountIdForToken token
+                    pure $ Right LoadedAuth
+                        { loadedProvider = OpenAIProvider
+                        , loadedTokenProvider = staticCredentialProvider Credential
+                            { accessToken = token
+                            , accountId
+                            , leaseId = Nothing
+                            , provider = OpenAIProvider
+                            }
+                        }
+                Nothing -> case envOrFileState now fromEnvJson fileBytes of
+                    Nothing -> pure (Left noAuthHint)
+                    Just state ->
+                        openAiPoolAuth fileExists filePath state
+
+loadManagedOpenAI
+    :: UTCTime
+    -> ManagedCredential
+    -> ManagedSecret
+    -> IO (Either String LoadedAuth)
+loadManagedOpenAI now metadata secret =
+    case metadata.managedAuthKind of
+        ManagedOpenAIAuthJson ->
+            case openaiAuthStateFromJson now
+                (LBS.fromStrict (TextEncoding.encodeUtf8 secret.secretPayload)) of
+                Nothing ->
+                    pure $ Left
+                        "managed OpenAI OAuth credential contains invalid auth JSON"
+                Just state -> do
+                    clientId <- lookupNonEmpty "OPENAI_OAUTH_CLIENT_ID"
+                    let refresh stale = case clientId of
+                            Nothing ->
+                                pure $ Left $ ProviderError AuthenticationError
+                                    "OPENAI_OAUTH_CLIENT_ID is required to refresh ChatGPT OAuth"
+                                    Nothing
+                            Just oauthClientId ->
+                                OpenAI.refreshAccessTokenHTTP oauthClientId stale >>= \case
+                                    Left err -> pure (Left err)
+                                    Right newState -> do
+                                        stamped <- authStateToJson newState <$> getCurrentTime
+                                        let payload =
+                                                TextEncoding.decodeUtf8
+                                                    (LBS.toStrict (Aeson.encode stamped))
+                                        upsertManagedCredential
+                                            metadata
+                                            secret { secretPayload = payload }
+                                            >>= \case
+                                                Left err ->
+                                                    pure $ Left $ ConnectionError err
+                                                Right () -> pure (Right newState)
+                    pool <- OpenAI.newPool [state] refresh
+                    tokenProvider <- OpenAICredential.poolTokenProvider pool
+                    pure $ Right LoadedAuth
+                        { loadedProvider = OpenAIProvider
+                        , loadedTokenProvider = tokenProvider
+                        }
+        _ ->
             pure $ Right LoadedAuth
                 { loadedProvider = OpenAIProvider
-                , loadedTokenProvider = staticCredentialProvider Credential
-                    { accessToken = token
-                    , accountId
-                    , leaseId = Nothing
-                    , provider = OpenAIProvider
-                    }
+                , loadedTokenProvider =
+                    staticCredentialProvider Credential
+                        { accessToken = secret.secretPayload
+                        , accountId = metadata.managedAccountId
+                        , leaseId = Nothing
+                        , provider = OpenAIProvider
+                        }
                 }
-        Nothing -> case envOrFileState now fromEnvJson fileBytes of
-            Nothing -> pure (Left noAuthHint)
-            Just state -> do
-                clientId <- lookupNonEmpty "OPENAI_OAUTH_CLIENT_ID"
-                let refresh stale = case clientId of
-                        Nothing -> pure $ Left $ ProviderError AuthenticationError
-                            "OPENAI_OAUTH_CLIENT_ID is required to refresh ~/.codex/auth.json"
-                            Nothing
-                        Just oauthClientId ->
-                            OpenAI.refreshAccessTokenHTTP oauthClientId stale >>= \case
-                                Left err -> pure (Left err)
-                                Right newState
-                                    | fileExists -> do
-                                        stamped <- authStateToJson newState <$> getCurrentTime
-                                        OpenAILogin.writeAuthFile filePath stamped
-                                        pure (Right newState)
-                                    | otherwise -> pure (Right newState)
-                pool <- OpenAI.newPool [state] refresh
-                tokenProvider <- OpenAICredential.poolTokenProvider pool
-                pure $ Right LoadedAuth
-                    { loadedProvider = OpenAIProvider
-                    , loadedTokenProvider = tokenProvider
-                    }
+
+openAiPoolAuth
+    :: Bool
+    -> FilePath
+    -> OpenAI.AuthState
+    -> IO (Either String LoadedAuth)
+openAiPoolAuth persistRefresh filePath state = do
+    clientId <- lookupNonEmpty "OPENAI_OAUTH_CLIENT_ID"
+    let refresh stale = case clientId of
+            Nothing -> pure $ Left $ ProviderError AuthenticationError
+                "OPENAI_OAUTH_CLIENT_ID is required to refresh ChatGPT OAuth"
+                Nothing
+            Just oauthClientId ->
+                OpenAI.refreshAccessTokenHTTP oauthClientId stale >>= \case
+                    Left err -> pure (Left err)
+                    Right newState
+                        | persistRefresh -> do
+                            stamped <- authStateToJson newState <$> getCurrentTime
+                            OpenAILogin.writeAuthFile filePath stamped
+                            pure (Right newState)
+                        | otherwise -> pure (Right newState)
+    pool <- OpenAI.newPool [state] refresh
+    tokenProvider <- OpenAICredential.poolTokenProvider pool
+    pure $ Right LoadedAuth
+        { loadedProvider = OpenAIProvider
+        , loadedTokenProvider = tokenProvider
+        }
+
+loadManagedCredential
+    :: Provider
+    -> IO (Maybe (ManagedCredential, ManagedSecret))
+loadManagedCredential provider =
+    loadManagedCredentials >>= \case
+        Left _ -> pure Nothing
+        Right credentials ->
+            pure $ listToMaybe
+                [ (metadata, secret)
+                | (metadata, secret) <- credentials
+                , metadata.managedEnabled
+                , metadata.managedProvider == provider
+                ]
+
+managedBearerCredential
+    :: ManagedCredential
+    -> ManagedSecret
+    -> Maybe Credential
+managedBearerCredential metadata secret =
+    let token = case metadata.managedAuthKind of
+            ManagedGrokAuthJson ->
+                grokCredentialFromAuthJson secret.secretPayload
+            _ -> Just secret.secretPayload
+    in (\accessToken -> Credential
+        { accessToken
+        , accountId = metadata.managedAccountId
+        , leaseId = Nothing
+        , provider = metadata.managedProvider
+        }) <$> token
 
 envOrFileState
     :: UTCTime
@@ -279,7 +398,8 @@ hasGrokAuth = do
     envToken <- lookupNonEmpty "GROK_ACCESS_TOKEN"
     home <- getHomeDirectory
     file <- doesFileExist (home </> ".grok" </> "auth.json")
-    pure (isJust envJson || isJust envToken || file)
+    managed <- hasManagedProvider XAIProvider
+    pure (isJust envJson || isJust envToken || file || managed)
 
 hasOpenAiAuth :: IO Bool
 hasOpenAiAuth = do
@@ -287,10 +407,18 @@ hasOpenAiAuth = do
     envToken <- lookupNonEmpty "CODEX_ACCESS_TOKEN"
     home <- getHomeDirectory
     file <- doesFileExist (home </> ".codex" </> "auth.json")
-    pure (isJust envJson || isJust envToken || file)
+    managed <- hasManagedProvider OpenAIProvider
+    pure (isJust envJson || isJust envToken || file || managed)
 
 hasOpenRouterAuth :: IO Bool
-hasOpenRouterAuth = isJust <$> lookupNonEmpty "OPENROUTER_API_KEY"
+hasOpenRouterAuth = do
+    environment <- isJust <$> lookupNonEmpty "OPENROUTER_API_KEY"
+    managed <- hasManagedProvider OpenRouterProvider
+    pure (environment || managed)
+
+hasManagedProvider :: Provider -> IO Bool
+hasManagedProvider provider =
+    isJust <$> loadManagedCredential provider
 
 -- | Cache one credential and only re-read disk/env after the provider rejects
 -- it for authentication. Rate-limit failures stay exhausted rather than

--- a/packages/agent-cli/src/Agent/CLI/Command.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command.hs
@@ -37,6 +37,7 @@ data ReplAction
     | ReplPlan (Maybe Text)
     -- ^ Enter plan mode. @Just@ starts a turn with that description.
     | ReplShowSession
+    | ReplLogin
     | ReplReloadAuth
     | ReplPaste
         { pasteImmediate :: !Bool
@@ -74,6 +75,7 @@ slashCommands =
     , cmd "effort" [] "/effort [none|low|medium|high|xhigh|max]" "Show or set reasoning effort"
     , cmd "plan" [] "/plan [description]" "Enter plan mode (or Shift+Tab)"
     , cmd "session" [] "/session" "Print the current session id"
+    , cmd "login" ["accounts"] "/login" "Manage provider credentials and usage"
     , cmd "resume" [] "/resume [ID]" "Pick a session to resume, or print a --resume hint"
     , cmd "compact" [] "/compact [FOCUS]" "Summarize history to free context"
     , cmd "clear" [] "/clear" "Reset the live conversation (same session id)"
@@ -134,6 +136,10 @@ parseSlash line = case Text.words line of
                 if null args
                     then ReplShowSession
                     else ReplCommandError "usage: /session"
+            "login" ->
+                if null args
+                    then ReplLogin
+                    else ReplCommandError "usage: /login"
             "resume" -> parseResumeCommand args
             "compact" ->
                 let focus =

--- a/packages/agent-cli/src/Agent/CLI/CredentialStore.hs
+++ b/packages/agent-cli/src/Agent/CLI/CredentialStore.hs
@@ -1,0 +1,300 @@
+-- | Restricted-file credential store used by the interactive login manager.
+module Agent.CLI.CredentialStore
+    ( ManagedAuthKind(..)
+    , ManagedBilling(..)
+    , ManagedCredential(..)
+    , ManagedSecret(..)
+    , deleteManagedCredential
+    , loadManagedCredentials
+    , managedCredentialsPath
+    , managedSecretsPath
+    , newManagedCredentialId
+    , setManagedCredentialEnabled
+    , upsertManagedCredential
+    ) where
+
+import Agent.Provider (Provider(..), parseProvider, providerSlug)
+import Control.Exception.Safe (tryIO)
+import qualified Data.Aeson as Aeson
+import Data.Aeson ((.:), (.:?), (.=))
+import qualified Data.ByteString.Lazy as LBS
+import Data.List (find)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import System.Directory
+    ( createDirectoryIfMissing
+    , doesFileExist
+    , getHomeDirectory
+    , renameFile
+    )
+import System.FilePath (takeDirectory, (</>))
+import System.Posix.Files (setFileMode)
+
+data ManagedAuthKind
+    = ManagedBearerToken
+    | ManagedOpenAIAuthJson
+    | ManagedGrokAuthJson
+    deriving (Eq, Show)
+
+data ManagedBilling
+    = ManagedSubscription
+    | ManagedApiCredits
+    deriving (Eq, Show)
+
+data ManagedCredential = ManagedCredential
+    { managedId :: !Text
+    , managedProvider :: !Provider
+    , managedAccountId :: !Text
+    , managedLabel :: !Text
+    , managedBilling :: !ManagedBilling
+    , managedAuthKind :: !ManagedAuthKind
+    , managedEnabled :: !Bool
+    }
+    deriving (Eq, Show)
+
+data ManagedSecret = ManagedSecret
+    { secretManagedId :: !Text
+    , secretPayload :: !Text
+    }
+    deriving (Eq)
+
+instance Show ManagedSecret where
+    show secret =
+        "ManagedSecret { secretManagedId = "
+            <> show secret.secretManagedId
+            <> ", secretPayload = <redacted> }"
+
+instance Aeson.ToJSON ManagedAuthKind where
+    toJSON = Aeson.String . \case
+        ManagedBearerToken -> "bearer"
+        ManagedOpenAIAuthJson -> "openai_oauth"
+        ManagedGrokAuthJson -> "grok_oauth"
+
+instance Aeson.FromJSON ManagedAuthKind where
+    parseJSON = Aeson.withText "ManagedAuthKind" \case
+        "bearer" -> pure ManagedBearerToken
+        "openai_oauth" -> pure ManagedOpenAIAuthJson
+        "grok_oauth" -> pure ManagedGrokAuthJson
+        other -> fail ("unknown managed auth kind: " <> Text.unpack other)
+
+instance Aeson.ToJSON ManagedBilling where
+    toJSON = Aeson.String . \case
+        ManagedSubscription -> "subscription"
+        ManagedApiCredits -> "api_credits"
+
+instance Aeson.FromJSON ManagedBilling where
+    parseJSON = Aeson.withText "ManagedBilling" \case
+        "subscription" -> pure ManagedSubscription
+        "api_credits" -> pure ManagedApiCredits
+        other -> fail ("unknown managed billing kind: " <> Text.unpack other)
+
+instance Aeson.ToJSON ManagedCredential where
+    toJSON credential = Aeson.object
+        [ "id" .= credential.managedId
+        , "provider" .= providerSlug credential.managedProvider
+        , "account_id" .= credential.managedAccountId
+        , "label" .= credential.managedLabel
+        , "billing" .= credential.managedBilling
+        , "auth_kind" .= credential.managedAuthKind
+        , "enabled" .= credential.managedEnabled
+        ]
+
+instance Aeson.FromJSON ManagedCredential where
+    parseJSON = Aeson.withObject "ManagedCredential" \object -> do
+        providerText <- object .: "provider"
+        managedProvider <- maybe
+            (fail ("unknown provider: " <> Text.unpack providerText))
+            pure
+            (parseProvider providerText)
+        ManagedCredential
+            <$> object .: "id"
+            <*> pure managedProvider
+            <*> object .: "account_id"
+            <*> object .: "label"
+            <*> object .: "billing"
+            <*> object .: "auth_kind"
+            <*> object .:? "enabled" Aeson..!= True
+
+instance Aeson.ToJSON ManagedSecret where
+    toJSON secret = Aeson.object
+        [ "id" .= secret.secretManagedId
+        , "payload" .= secret.secretPayload
+        ]
+
+instance Aeson.FromJSON ManagedSecret where
+    parseJSON = Aeson.withObject "ManagedSecret" \object ->
+        ManagedSecret
+            <$> object .: "id"
+            <*> object .: "payload"
+
+data MetadataFile = MetadataFile
+    { metadataVersion :: !Int
+    , metadataAccounts :: ![ManagedCredential]
+    }
+
+instance Aeson.ToJSON MetadataFile where
+    toJSON file = Aeson.object
+        [ "version" .= file.metadataVersion
+        , "accounts" .= file.metadataAccounts
+        ]
+
+instance Aeson.FromJSON MetadataFile where
+    parseJSON = Aeson.withObject "Credential metadata" \object ->
+        MetadataFile
+            <$> object .:? "version" Aeson..!= 1
+            <*> object .:? "accounts" Aeson..!= []
+
+data SecretsFile = SecretsFile
+    { secretsVersion :: !Int
+    , storedSecrets :: ![ManagedSecret]
+    }
+
+instance Aeson.ToJSON SecretsFile where
+    toJSON file = Aeson.object
+        [ "version" .= file.secretsVersion
+        , "secrets" .= file.storedSecrets
+        ]
+
+instance Aeson.FromJSON SecretsFile where
+    parseJSON = Aeson.withObject "Credential secrets" \object ->
+        SecretsFile
+            <$> object .:? "version" Aeson..!= 1
+            <*> object .:? "secrets" Aeson..!= []
+
+managedCredentialsPath :: FilePath -> FilePath
+managedCredentialsPath home =
+    home </> ".haskell-agent" </> "credentials" </> "accounts.json"
+
+managedSecretsPath :: FilePath -> FilePath
+managedSecretsPath home =
+    home </> ".haskell-agent" </> "credentials" </> "secrets.json"
+
+loadManagedCredentials
+    :: IO (Either Text [(ManagedCredential, ManagedSecret)])
+loadManagedCredentials = do
+    home <- getHomeDirectory
+    metadataResult <- decodeFileOrEmpty
+        (managedCredentialsPath home)
+        (MetadataFile 1 [])
+    secretsResult <- decodeFileOrEmpty
+        (managedSecretsPath home)
+        (SecretsFile 1 [])
+    pure do
+        metadata <- metadataResult
+        secrets <- secretsResult
+        traverse (attachSecret secrets.storedSecrets) metadata.metadataAccounts
+  where
+    attachSecret secrets credential =
+        case find
+            ((== credential.managedId) . (.secretManagedId))
+            secrets of
+            Nothing ->
+                Left
+                    ("missing secret for managed credential "
+                        <> credential.managedId)
+            Just secret -> Right (credential, secret)
+
+upsertManagedCredential
+    :: ManagedCredential
+    -> ManagedSecret
+    -> IO (Either Text ())
+upsertManagedCredential credential secret = mutateStore \accounts secrets ->
+    ( upsertBy (.managedId) credential accounts
+    , upsertBy (.secretManagedId) secret secrets
+    )
+
+setManagedCredentialEnabled :: Text -> Bool -> IO (Either Text ())
+setManagedCredentialEnabled credentialId enabled =
+    mutateStore \accounts secrets ->
+        ( map
+            (\account ->
+                if account.managedId == credentialId
+                    then account { managedEnabled = enabled }
+                    else account)
+            accounts
+        , secrets
+        )
+
+deleteManagedCredential :: Text -> IO (Either Text ())
+deleteManagedCredential credentialId =
+    mutateStore \accounts secrets ->
+        ( filter ((/= credentialId) . (.managedId)) accounts
+        , filter ((/= credentialId) . (.secretManagedId)) secrets
+        )
+
+newManagedCredentialId :: Provider -> Text -> IO Text
+newManagedCredentialId provider accountId = do
+    micros <- floor . (* 1_000_000) <$> getPOSIXTime :: IO Integer
+    let suffix
+            | Text.null (Text.strip accountId) = Text.pack (show micros)
+            | otherwise =
+                Text.take 24 $
+                    Text.map
+                        (\c -> if allowed c then c else '-')
+                        accountId
+    pure (providerSlug provider <> "-" <> suffix <> "-" <> Text.pack (show micros))
+  where
+    allowed c =
+        (c >= 'a' && c <= 'z')
+            || (c >= 'A' && c <= 'Z')
+            || (c >= '0' && c <= '9')
+
+mutateStore
+    :: ([ManagedCredential] -> [ManagedSecret] -> ([ManagedCredential], [ManagedSecret]))
+    -> IO (Either Text ())
+mutateStore update = do
+    home <- getHomeDirectory
+    loaded <- loadManagedCredentials
+    case loaded of
+        Left err -> pure (Left err)
+        Right entries -> do
+            let (accounts, secrets) = unzip entries
+                (accounts', secrets') = update accounts secrets
+            writeResult <- writePrivateJson
+                (managedCredentialsPath home)
+                (MetadataFile 1 accounts')
+            case writeResult of
+                Left err -> pure (Left err)
+                Right () ->
+                    writePrivateJson
+                        (managedSecretsPath home)
+                        (SecretsFile 1 secrets')
+
+decodeFileOrEmpty :: Aeson.FromJSON value => FilePath -> value -> IO (Either Text value)
+decodeFileOrEmpty path empty = do
+    exists <- doesFileExist path
+    if not exists
+        then pure (Right empty)
+        else tryIO (LBS.readFile path) >>= \case
+            Left exception ->
+                pure $ Left
+                    ("could not read " <> Text.pack path <> ": "
+                        <> Text.pack (show exception))
+            Right bytes -> pure case Aeson.eitherDecode bytes of
+                Left err ->
+                    Left
+                        ("invalid credential store " <> Text.pack path <> ": "
+                            <> Text.pack err)
+                Right value -> Right value
+
+writePrivateJson :: Aeson.ToJSON value => FilePath -> value -> IO (Either Text ())
+writePrivateJson path value =
+    tryIO action >>= \case
+        Left exception ->
+            pure $ Left
+                ("could not write " <> Text.pack path <> ": "
+                    <> Text.pack (show exception))
+        Right () -> pure (Right ())
+  where
+    action = do
+        createDirectoryIfMissing True (takeDirectory path)
+        setFileMode (takeDirectory path) 0o700
+        let temporary = path <> ".tmp"
+        LBS.writeFile temporary (Aeson.encode value)
+        setFileMode temporary 0o600
+        renameFile temporary path
+
+upsertBy :: Eq key => (value -> key) -> value -> [value] -> [value]
+upsertBy keyOf value values =
+    value : filter ((/= keyOf value) . keyOf) values

--- a/packages/agent-cli/src/Agent/CLI/Login.hs
+++ b/packages/agent-cli/src/Agent/CLI/Login.hs
@@ -1,0 +1,879 @@
+-- | Interactive credential dashboard for @/login@.
+module Agent.CLI.Login
+    ( AccountBilling(..)
+    , AccountUsage(..)
+    , LoginAccount(..)
+    , LoginAction(..)
+    , LoginState(..)
+    , UsageState(..)
+    , UsageWindow(..)
+    , applyLoginKey
+    , discoverLoginAccounts
+    , formatLoginAccounts
+    , initialLoginState
+    , renderLoginFrame
+    , runLoginManager
+    ) where
+
+import Agent.CLI.Auth
+    ( grokCredentialFromAuthJson
+    , openaiAuthStateFromJson
+    )
+import Agent.CLI.CredentialStore
+    ( ManagedAuthKind(..)
+    , ManagedBilling(..)
+    , ManagedCredential(..)
+    , ManagedSecret(..)
+    , deleteManagedCredential
+    , loadManagedCredentials
+    , newManagedCredentialId
+    , setManagedCredentialEnabled
+    , upsertManagedCredential
+    )
+import Agent.CLI.Input (readApprovalLine)
+import Agent.CLI.Picker (PickerKey(..), runOverlay)
+import Agent.CLI.Style
+    ( glyphErr
+    , glyphOk
+    , roleError
+    , roleMuted
+    , rolePrompt
+    , roleSuccess
+    , roleWarn
+    )
+import qualified Agent.OpenAI.Auth as OpenAI
+import qualified Agent.OpenAI.Login as OpenAILogin
+import qualified Agent.OpenAI.Usage as OpenAI
+import qualified Agent.OpenRouter.Usage as OpenRouter
+import Agent.Provider (Provider(..), providerSlug)
+import qualified Agent.XAI.Auth as XAIAuth
+import qualified Agent.XAI.Usage as XAI
+import Control.Applicative ((<|>))
+import Control.Exception.Safe (bracket)
+import Control.Monad (join)
+import qualified Data.Aeson as Aeson
+import Data.Aeson ((.=))
+import qualified Data.ByteString.Lazy as LBS
+import Data.List (nubBy)
+import Data.Maybe (catMaybes, fromMaybe)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
+import qualified Data.Text.IO as Text
+import Data.Time.Clock (UTCTime, getCurrentTime)
+import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
+import System.Directory (doesFileExist, getHomeDirectory)
+import System.Environment (lookupEnv)
+import System.FilePath ((</>))
+import System.IO
+    ( hFlush
+    , hGetEcho
+    , hIsTerminalDevice
+    , hSetEcho
+    , stderr
+    , stdin
+    )
+
+data AccountBilling
+    = SubscriptionBilling !(Maybe Text)
+    | ApiCreditsBilling
+    deriving (Eq, Show)
+
+data UsageWindow = UsageWindow
+    { windowName :: !Text
+    , usedPercent :: !Int
+    , windowSeconds :: !Int
+    , resetsAt :: !UTCTime
+    }
+    deriving (Eq, Show)
+
+data AccountUsage = AccountUsage
+    { usagePlan :: !(Maybe Text)
+    , usageWindows :: ![UsageWindow]
+    , creditsRemaining :: !(Maybe Text)
+    , creditsUsed :: !(Maybe Text)
+    }
+    deriving (Eq, Show)
+
+data UsageState
+    = UsageNotChecked
+    | UsageAvailable !AccountUsage
+    | UsageUnavailable !Text
+    deriving (Eq, Show)
+
+data LoginAccount = LoginAccount
+    { loginManagedId :: !(Maybe Text)
+    , loginProvider :: !Provider
+    , loginAccountId :: !Text
+    , loginLabel :: !Text
+    , loginBilling :: !AccountBilling
+    , loginSource :: !Text
+    , loginUsage :: !UsageState
+    , loginAccessToken :: !Text
+    , loginAuthKind :: !ManagedAuthKind
+    , loginSecretPayload :: !Text
+    , loginEnabled :: !Bool
+    }
+    deriving (Eq)
+
+instance Show LoginAccount where
+    show account =
+        "LoginAccount { loginProvider = "
+            <> show account.loginProvider
+            <> ", loginAccountId = "
+            <> show account.loginAccountId
+            <> ", loginLabel = "
+            <> show account.loginLabel
+            <> ", loginBilling = "
+            <> show account.loginBilling
+            <> ", loginSource = "
+            <> show account.loginSource
+            <> ", loginUsage = "
+            <> show account.loginUsage
+            <> ", loginAccessToken = <redacted> }"
+
+data LoginState = LoginState
+    { loginAccounts :: ![LoginAccount]
+    , loginIndex :: !Int
+    }
+    deriving (Eq, Show)
+
+data LoginAction
+    = LoginClose
+    | LoginRefresh !Int
+    | LoginAdd
+    | LoginToggle !Int
+    | LoginDelete !Int
+    | LoginImport !Int
+    deriving (Eq, Show)
+
+initialLoginState :: [LoginAccount] -> LoginState
+initialLoginState accounts = LoginState
+    { loginAccounts = accounts
+    , loginIndex = 0
+    }
+
+applyLoginKey :: PickerKey -> LoginState -> Either LoginAction LoginState
+applyLoginKey key state = case key of
+    PickerKeyCancel -> Left LoginClose
+    PickerKeyConfirm -> refresh
+    PickerKeyChar 'r' -> refresh
+    PickerKeyChar 'R' -> refresh
+    PickerKeyChar 'a' -> Left LoginAdd
+    PickerKeyChar 'A' -> Left LoginAdd
+    PickerKeyChar 'e' -> selected LoginToggle
+    PickerKeyChar 'E' -> selected LoginToggle
+    PickerKeyChar 'd' -> selected LoginDelete
+    PickerKeyChar 'D' -> selected LoginDelete
+    PickerKeyChar 'i' -> selected LoginImport
+    PickerKeyChar 'I' -> selected LoginImport
+    PickerKeyUp -> Right (move (-1))
+    PickerKeyDown -> Right (move 1)
+    _ -> Right state
+  where
+    count = length state.loginAccounts
+    move delta
+        | count == 0 = state { loginIndex = 0 }
+        | otherwise =
+            state
+                { loginIndex = (state.loginIndex + delta) `mod` count
+                }
+    refresh
+        | count == 0 = Left LoginClose
+        | otherwise = Left (LoginRefresh (min (count - 1) state.loginIndex))
+    selected constructor
+        | count == 0 = Right state
+        | otherwise = Left (constructor (min (count - 1) state.loginIndex))
+
+runLoginManager :: Bool -> IO ()
+runLoginManager color = do
+    accounts <- discoverLoginAccounts
+    tty <- hIsTerminalDevice stdin
+    if not tty
+        then do
+            Text.hPutStrLn stderr (formatLoginAccounts color accounts)
+            hFlush stderr
+        else loop (initialLoginState accounts)
+  where
+    loop state =
+        runOverlay (renderLoginFrame color) applyLoginKey state >>= \case
+            Nothing -> pure ()
+            Just LoginClose -> pure ()
+            Just (LoginRefresh index) -> do
+                accounts <- refreshAt index state.loginAccounts
+                loop state
+                    { loginAccounts = accounts
+                    , loginIndex = index
+                    }
+            Just LoginAdd -> do
+                connectAccount color
+                discoverLoginAccounts >>= loop . initialLoginState
+            Just (LoginToggle index) -> do
+                toggleAt color index state.loginAccounts
+                discoverLoginAccounts >>= loop . initialLoginState
+            Just (LoginDelete index) -> do
+                deleteAt color index state.loginAccounts
+                discoverLoginAccounts >>= loop . initialLoginState
+            Just (LoginImport index) -> do
+                importAt color index state.loginAccounts
+                discoverLoginAccounts >>= loop . initialLoginState
+
+refreshAt :: Int -> [LoginAccount] -> IO [LoginAccount]
+refreshAt index accounts =
+    case splitAt index accounts of
+        (before, account : after) -> do
+            refreshed <- refreshLoginAccount account
+            pure (before <> (refreshed : after))
+        _ -> pure accounts
+
+discoverLoginAccounts :: IO [LoginAccount]
+discoverLoginAccounts = do
+    home <- getHomeDirectory
+    now <- getCurrentTime
+    openaiEnv <- discoverOpenAIEnv
+    openaiFile <- discoverOpenAIFile now (home </> ".codex" </> "auth.json")
+    grokEnv <- discoverGrokEnv
+    grokFile <- discoverGrokFile (home </> ".grok" </> "auth.json")
+    openRouter <- discoverOpenRouter
+    broker <- discoverBroker
+    managed <- loadManagedCredentials
+    let managedAccounts = case managed of
+            Left _ -> []
+            Right entries -> map (managedLoginAccount now) entries
+    pure $ nubBy sameAccount $
+        managedAccounts
+            <> catMaybes
+                [ broker
+                , openaiEnv
+                , openaiFile
+                , grokEnv
+                , grokFile
+                , openRouter
+                ]
+  where
+    sameAccount left right =
+        left.loginProvider == right.loginProvider
+            && left.loginAccountId == right.loginAccountId
+
+managedLoginAccount
+    :: UTCTime
+    -> (ManagedCredential, ManagedSecret)
+    -> LoginAccount
+managedLoginAccount now (metadata, secret) =
+    LoginAccount
+        { loginManagedId = Just metadata.managedId
+        , loginProvider = metadata.managedProvider
+        , loginAccountId = metadata.managedAccountId
+        , loginLabel = metadata.managedLabel
+        , loginBilling = case metadata.managedBilling of
+            ManagedSubscription -> SubscriptionBilling Nothing
+            ManagedApiCredits -> ApiCreditsBilling
+        , loginSource = "managed"
+        , loginUsage = UsageNotChecked
+        , loginAccessToken = accessToken
+        , loginAuthKind = metadata.managedAuthKind
+        , loginSecretPayload = secret.secretPayload
+        , loginEnabled = metadata.managedEnabled
+        }
+  where
+    accessToken = fromMaybe "" case metadata.managedAuthKind of
+        ManagedBearerToken -> Just secret.secretPayload
+        ManagedOpenAIAuthJson ->
+            (.accessToken) <$> openaiAuthStateFromJson now
+                (LBS.fromStrict (Text.encodeUtf8 secret.secretPayload))
+        ManagedGrokAuthJson ->
+            grokCredentialFromAuthJson secret.secretPayload
+
+toggleAt :: Bool -> Int -> [LoginAccount] -> IO ()
+toggleAt color index accounts =
+    case accountAt index accounts of
+        Nothing -> pure ()
+        Just account -> case account.loginManagedId of
+            Nothing ->
+                printLoginMessage color False
+                    "external credentials are read-only; import them before changing state"
+            Just credentialId ->
+                setManagedCredentialEnabled
+                    credentialId
+                    (not account.loginEnabled)
+                    >>= printStoreResult color
+                        (if account.loginEnabled
+                            then "credential disabled"
+                            else "credential enabled")
+
+deleteAt :: Bool -> Int -> [LoginAccount] -> IO ()
+deleteAt color index accounts =
+    case accountAt index accounts of
+        Nothing -> pure ()
+        Just account -> case account.loginManagedId of
+            Nothing ->
+                printLoginMessage color False
+                    "external credentials are read-only; remove them from their source"
+            Just credentialId ->
+                readApprovalLine
+                    ("Disconnect " <> account.loginLabel <> "? [y/N] ")
+                    >>= \case
+                        Just answer
+                            | Text.toLower (Text.strip answer) `elem` ["y", "yes"] ->
+                                deleteManagedCredential credentialId
+                                    >>= printStoreResult color
+                                        "credential disconnected"
+                        _ -> pure ()
+
+importAt :: Bool -> Int -> [LoginAccount] -> IO ()
+importAt color index accounts =
+    case accountAt index accounts of
+        Nothing -> pure ()
+        Just account -> case account.loginManagedId of
+            Just _ ->
+                printLoginMessage color False "credential is already managed"
+            Nothing
+                | Text.null account.loginSecretPayload ->
+                    printLoginMessage color False
+                        "this credential source cannot be imported"
+                | otherwise -> do
+                    credentialId <-
+                        newManagedCredentialId
+                            account.loginProvider account.loginAccountId
+                    upsertManagedCredential
+                        ManagedCredential
+                            { managedId = credentialId
+                            , managedProvider = account.loginProvider
+                            , managedAccountId = account.loginAccountId
+                            , managedLabel = account.loginLabel
+                            , managedBilling = case account.loginBilling of
+                                SubscriptionBilling _ -> ManagedSubscription
+                                ApiCreditsBilling -> ManagedApiCredits
+                            , managedAuthKind = account.loginAuthKind
+                            , managedEnabled = True
+                            }
+                        ManagedSecret
+                            { secretManagedId = credentialId
+                            , secretPayload = account.loginSecretPayload
+                            }
+                        >>= printStoreResult color
+                            "credential imported into the managed store"
+
+accountAt :: Int -> [account] -> Maybe account
+accountAt index accounts =
+    case drop index accounts of
+        account : _ -> Just account
+        [] -> Nothing
+
+connectAccount :: Bool -> IO ()
+connectAccount color =
+    pickConnectProvider color >>= \case
+        Nothing -> pure ()
+        Just OpenAIProvider -> connectOpenAI color
+        Just XAIProvider -> connectXAI color
+        Just OpenRouterProvider -> connectOpenRouter color
+
+pickConnectProvider :: Bool -> IO (Maybe Provider)
+pickConnectProvider color =
+    join <$> runOverlay render step (0 :: Int)
+  where
+    providers = [OpenAIProvider, XAIProvider, OpenRouterProvider]
+    render index =
+        Text.intercalate "\n" $
+            [rolePrompt color "connect account"]
+                <> zipWith
+                    (\i provider ->
+                        (if i == index then roleWarn color "› " else "  ")
+                            <> roleMuted color (providerSlug provider))
+                    [0 ..]
+                    providers
+                <> [roleMuted color "↑↓/jk · enter · esc/q"]
+    step key index = case key of
+        PickerKeyCancel -> Left Nothing
+        PickerKeyConfirm -> Left (accountAt index providers)
+        PickerKeyUp ->
+            Right ((index - 1) `mod` length providers)
+        PickerKeyDown ->
+            Right ((index + 1) `mod` length providers)
+        _ -> Right index
+
+connectOpenAI :: Bool -> IO ()
+connectOpenAI color =
+    lookupNonEmpty "OPENAI_OAUTH_CLIENT_ID" >>= \case
+        Nothing ->
+            printLoginMessage color False
+                "set OPENAI_OAUTH_CLIENT_ID before connecting a ChatGPT account"
+        Just clientId -> do
+            let options = OpenAILogin.defaultLoginOptions clientId
+            OpenAILogin.requestDeviceCode options >>= \case
+                Left err -> printLoginMessage color False err
+                Right device -> do
+                    Text.hPutStrLn stderr $
+                        roleMuted color "Open "
+                            <> rolePrompt color (Text.pack device.verificationUrl)
+                    Text.hPutStrLn stderr $
+                        roleMuted color "Enter code "
+                            <> rolePrompt color device.userCode
+                    hFlush stderr
+                    OpenAILogin.completeDeviceCodeLogin options device >>= \case
+                        Left err -> printLoginMessage color False err
+                        Right authJson -> do
+                            now <- getCurrentTime
+                            case openaiAuthStateFromJson now (Aeson.encode authJson) of
+                                Nothing ->
+                                    printLoginMessage color False
+                                        "OpenAI login returned invalid account data"
+                                Just auth ->
+                                    storeConnectedCredential color
+                                        OpenAIProvider
+                                        auth.accountId
+                                        "ChatGPT"
+                                        ManagedSubscription
+                                        ManagedOpenAIAuthJson
+                                        (Text.decodeUtf8
+                                            (LBS.toStrict (Aeson.encode authJson)))
+
+connectXAI :: Bool -> IO ()
+connectXAI color =
+    lookupNonEmpty "XAI_OAUTH_CLIENT_ID" >>= \case
+        Nothing ->
+            printLoginMessage color False
+                "set XAI_OAUTH_CLIENT_ID before connecting a Grok account"
+        Just clientId -> do
+            let options = XAIAuth.defaultOAuthOptions clientId
+            XAIAuth.requestDeviceAuthorization options >>= \case
+                Left err -> printLoginMessage color False err
+                Right device -> do
+                    Text.hPutStrLn stderr $
+                        roleMuted color "Open "
+                            <> rolePrompt color device.verificationUrl
+                    Text.hPutStrLn stderr $
+                        roleMuted color "Enter code "
+                            <> rolePrompt color device.userCode
+                    hFlush stderr
+                    XAIAuth.completeDeviceAuthorization options device >>= \case
+                        Left err -> printLoginMessage color False err
+                        Right tokens -> do
+                            let accountId =
+                                    fromMaybe "grok"
+                                        (XAIAuth.accountIdFromAccessToken
+                                            tokens.accessToken)
+                                authJson = Aeson.object
+                                    [ "access_token" .= tokens.accessToken
+                                    , "refresh_token" .= tokens.refreshToken
+                                    , "id_token" .= tokens.idToken
+                                    ]
+                            storeConnectedCredential color
+                                XAIProvider
+                                accountId
+                                "Grok"
+                                ManagedSubscription
+                                ManagedGrokAuthJson
+                                (Text.decodeUtf8
+                                    (LBS.toStrict (Aeson.encode authJson)))
+
+connectOpenRouter :: Bool -> IO ()
+connectOpenRouter color =
+    readSecretLine "OpenRouter API key: " >>= \case
+        Nothing -> pure ()
+        Just apiKey ->
+            OpenRouter.fetchOpenRouterUsage apiKey >>= \case
+                Left err ->
+                    printLoginMessage color False
+                        ("OpenRouter rejected the key: " <> err)
+                Right usage -> do
+                    let accountId =
+                            fromMaybe "openrouter" usage.keyLabel
+                        label =
+                            fromMaybe "OpenRouter" usage.keyLabel
+                    storeConnectedCredential color
+                        OpenRouterProvider
+                        accountId
+                        label
+                        ManagedApiCredits
+                        ManagedBearerToken
+                        apiKey
+
+storeConnectedCredential
+    :: Bool
+    -> Provider
+    -> Text
+    -> Text
+    -> ManagedBilling
+    -> ManagedAuthKind
+    -> Text
+    -> IO ()
+storeConnectedCredential color provider accountId label billing authKind payload = do
+    credentialId <- newManagedCredentialId provider accountId
+    upsertManagedCredential
+        ManagedCredential
+            { managedId = credentialId
+            , managedProvider = provider
+            , managedAccountId = accountId
+            , managedLabel = label
+            , managedBilling = billing
+            , managedAuthKind = authKind
+            , managedEnabled = True
+            }
+        ManagedSecret
+            { secretManagedId = credentialId
+            , secretPayload = payload
+            }
+        >>= printStoreResult color
+            "credential connected; restart or reload auth to use it"
+
+readSecretLine :: Text -> IO (Maybe Text)
+readSecretLine prompt = do
+    Text.hPutStr stderr prompt
+    hFlush stderr
+    tty <- hIsTerminalDevice stdin
+    if not tty
+        then nonEmpty . Text.strip <$> Text.getLine
+        else do
+            oldEcho <- hGetEcho stdin
+            value <- bracket
+                (hSetEcho stdin False)
+                (const (hSetEcho stdin oldEcho))
+                (\() -> Text.getLine)
+            Text.hPutStrLn stderr ""
+            pure (nonEmpty (Text.strip value))
+  where
+    nonEmpty value
+        | Text.null value = Nothing
+        | otherwise = Just value
+
+printStoreResult :: Bool -> Text -> Either Text () -> IO ()
+printStoreResult color success = \case
+    Left err -> printLoginMessage color False err
+    Right () -> printLoginMessage color True success
+
+printLoginMessage :: Bool -> Bool -> Text -> IO ()
+printLoginMessage color success message = do
+    Text.hPutStrLn stderr $
+        if success
+            then roleSuccess color (glyphOk <> message)
+            else roleError color (glyphErr <> message)
+    hFlush stderr
+
+discoverOpenAIEnv :: IO (Maybe LoginAccount)
+discoverOpenAIEnv = do
+    token <- lookupNonEmpty "CODEX_ACCESS_TOKEN"
+    explicitAccount <- lookupNonEmpty "CODEX_ACCOUNT_ID"
+    idToken <- lookupNonEmpty "CODEX_ID_TOKEN"
+    pure $ do
+        accessToken <- token
+        let accountId =
+                fromMaybe "openai-env" $
+                    explicitAccount
+                        <|> (idToken >>= OpenAI.deriveAccountId)
+                        <|> OpenAI.deriveAccountId accessToken
+        pure $ subscriptionAccount
+            OpenAIProvider accountId "ChatGPT" "environment"
+            accessToken ManagedBearerToken accessToken
+
+discoverOpenAIFile :: UTCTime -> FilePath -> IO (Maybe LoginAccount)
+discoverOpenAIFile now path = do
+    exists <- doesFileExist path
+    if not exists
+        then pure Nothing
+        else do
+            bytes <- LBS.readFile path
+            pure $ do
+                auth <- openaiAuthStateFromJson now bytes
+                pure $ subscriptionAccount
+                    OpenAIProvider
+                    auth.accountId
+                    "ChatGPT"
+                    (Text.pack path)
+                    auth.accessToken
+                    ManagedOpenAIAuthJson
+                    (Text.decodeUtf8 (LBS.toStrict bytes))
+
+discoverGrokEnv :: IO (Maybe LoginAccount)
+discoverGrokEnv = do
+    rawJson <- lookupNonEmpty "GROK_AUTH_JSON"
+    rawToken <- lookupNonEmpty "GROK_ACCESS_TOKEN"
+    pure $ case rawJson >>= grokCredentialFromAuthJson of
+        Just token ->
+            Just (grokAccount token "environment"
+                ManagedGrokAuthJson (fromMaybe "" rawJson))
+        Nothing ->
+            (\token -> grokAccount token "environment"
+                ManagedBearerToken token) <$> rawToken
+
+discoverGrokFile :: FilePath -> IO (Maybe LoginAccount)
+discoverGrokFile path = do
+    exists <- doesFileExist path
+    if not exists
+        then pure Nothing
+        else do
+            raw <- Text.decodeUtf8 . LBS.toStrict <$> LBS.readFile path
+            pure $ do
+                token <- grokCredentialFromAuthJson raw
+                pure (grokAccount token (Text.pack path)
+                    ManagedGrokAuthJson raw)
+
+discoverOpenRouter :: IO (Maybe LoginAccount)
+discoverOpenRouter = do
+    token <- lookupNonEmpty "OPENROUTER_API_KEY"
+    pure $ do
+        accessToken <- token
+        pure LoginAccount
+            { loginManagedId = Nothing
+            , loginProvider = OpenRouterProvider
+            , loginAccountId = "openrouter"
+            , loginLabel = "OpenRouter"
+            , loginBilling = ApiCreditsBilling
+            , loginSource = "environment"
+            , loginUsage = UsageNotChecked
+            , loginAccessToken = accessToken
+            , loginAuthKind = ManagedBearerToken
+            , loginSecretPayload = accessToken
+            , loginEnabled = True
+            }
+
+discoverBroker :: IO (Maybe LoginAccount)
+discoverBroker = do
+    url <- lookupNonEmpty "AGENT_BROKER_URL"
+    token <- lookupNonEmpty "AGENT_BROKER_TOKEN"
+    pure case (url, token) of
+        (Just brokerUrl, Just _) ->
+            Just LoginAccount
+                { loginManagedId = Nothing
+                , loginProvider = OpenAIProvider
+                , loginAccountId = "broker"
+                , loginLabel = "Credential broker"
+                , loginBilling = SubscriptionBilling Nothing
+                , loginSource = brokerUrl
+                , loginUsage =
+                    UsageUnavailable
+                        "account listing is not exposed by the broker client yet"
+                , loginAccessToken = ""
+                , loginAuthKind = ManagedBearerToken
+                , loginSecretPayload = ""
+                , loginEnabled = True
+                }
+        _ -> Nothing
+
+subscriptionAccount
+    :: Provider
+    -> Text
+    -> Text
+    -> Text
+    -> Text
+    -> ManagedAuthKind
+    -> Text
+    -> LoginAccount
+subscriptionAccount provider accountId label source token authKind payload =
+    LoginAccount
+        { loginManagedId = Nothing
+        , loginProvider = provider
+        , loginAccountId = accountId
+        , loginLabel = label
+        , loginBilling = SubscriptionBilling Nothing
+        , loginSource = source
+        , loginUsage = UsageNotChecked
+        , loginAccessToken = token
+        , loginAuthKind = authKind
+        , loginSecretPayload = payload
+        , loginEnabled = True
+        }
+
+grokAccount :: Text -> Text -> ManagedAuthKind -> Text -> LoginAccount
+grokAccount token source authKind payload =
+    subscriptionAccount
+        XAIProvider
+        (fromMaybe "grok" (XAIAuth.accountIdFromAccessToken token))
+        "Grok"
+        source
+        token
+        authKind
+        payload
+
+refreshLoginAccount :: LoginAccount -> IO LoginAccount
+refreshLoginAccount account
+    | Text.null account.loginAccessToken = pure account
+    | otherwise = case account.loginProvider of
+        OpenAIProvider ->
+            if account.loginAccountId == "openai-env"
+                then pure account
+                    { loginUsage =
+                        UsageUnavailable
+                            "ChatGPT account id is unavailable"
+                    }
+                else OpenAI.fetchUsage
+                    account.loginAccessToken account.loginAccountId >>= \case
+                        Left err ->
+                            pure account
+                                { loginUsage =
+                                    UsageUnavailable (Text.pack (show err))
+                                }
+                        Right snapshot ->
+                            pure account
+                                { loginBilling =
+                                    SubscriptionBilling
+                                        (Just snapshot.planType)
+                                , loginUsage =
+                                    UsageAvailable
+                                        (openAIUsage snapshot)
+                                }
+        XAIProvider ->
+            XAI.fetchGrokUsage account.loginAccessToken >>= \case
+                Left err ->
+                    pure account { loginUsage = UsageUnavailable err }
+                Right snapshot ->
+                    pure account
+                        { loginUsage =
+                            UsageAvailable AccountUsage
+                                { usagePlan = Nothing
+                                , usageWindows =
+                                    [ UsageWindow
+                                        { windowName = "current period"
+                                        , usedPercent = snapshot.usedPercent
+                                        , windowSeconds = snapshot.windowSeconds
+                                        , resetsAt = snapshot.resetsAt
+                                        }
+                                    ]
+                                , creditsRemaining = Nothing
+                                , creditsUsed = Nothing
+                                }
+                        }
+        OpenRouterProvider ->
+            OpenRouter.fetchOpenRouterUsage account.loginAccessToken >>= \case
+                Left err ->
+                    pure account { loginUsage = UsageUnavailable err }
+                Right snapshot ->
+                    pure account
+                        { loginLabel =
+                            fromMaybe account.loginLabel snapshot.keyLabel
+                        , loginUsage =
+                            UsageAvailable AccountUsage
+                                { usagePlan =
+                                    if snapshot.isFreeTier == Just True
+                                        then Just "free tier"
+                                        else Nothing
+                                , usageWindows = []
+                                , creditsRemaining =
+                                    formatAmount
+                                        (snapshot.keyLimitRemaining
+                                            <|> ((-) <$> snapshot.totalCredits
+                                                <*> snapshot.totalUsage))
+                                , creditsUsed =
+                                    formatAmount
+                                        (snapshot.totalUsage
+                                            <|> snapshot.keyUsage)
+                                }
+                        }
+  where
+    formatAmount = fmap (("$" <>) . Text.pack . show)
+
+openAIUsage :: OpenAI.UsageSnapshot -> AccountUsage
+openAIUsage snapshot = AccountUsage
+    { usagePlan = Just snapshot.planType
+    , usageWindows =
+        catMaybes
+            [ toWindow "primary" <$> (snapshot.rateLimit >>= (.primaryWindow))
+            , toWindow "secondary" <$> (snapshot.rateLimit >>= (.secondaryWindow))
+            ]
+    , creditsRemaining = Nothing
+    , creditsUsed = Nothing
+    }
+  where
+    toWindow name window = UsageWindow
+        { windowName = name
+        , usedPercent = window.usedPercent
+        , windowSeconds = window.limitWindowSeconds
+        , resetsAt =
+            posixSecondsToUTCTime (fromIntegral window.resetAt)
+        }
+
+formatLoginAccounts :: Bool -> [LoginAccount] -> Text
+formatLoginAccounts color accounts =
+    renderLoginFrame color (initialLoginState accounts)
+
+renderLoginFrame :: Bool -> LoginState -> Text
+renderLoginFrame color state =
+    Text.intercalate "\n" $
+        [ rolePrompt color "credentials"
+            <> roleMuted color
+                (" · " <> Text.pack (show (length state.loginAccounts))
+                    <> " connected")
+        ]
+            <> body
+            <> [ roleMuted color
+                    "↑↓/jk · r refresh · a add · i import · e enable/disable · d disconnect · esc/q"
+               ]
+  where
+    body
+        | null state.loginAccounts =
+            [ roleWarn color "No credentials found."
+            , roleMuted color
+                "Set provider credentials or import an existing Codex/Grok login."
+            ]
+        | otherwise =
+            concat $
+                zipWith
+                    (renderAccount color state.loginIndex)
+                    [0 ..]
+                    state.loginAccounts
+
+renderAccount :: Bool -> Int -> Int -> LoginAccount -> [Text]
+renderAccount color selected index account =
+    [ cursor
+        <> health
+        <> provider
+        <> " · "
+        <> label
+        <> " · "
+        <> billing
+        <> enabledSuffix
+    , "    "
+        <> roleMuted color
+            (accountId <> " · " <> account.loginSource)
+    ]
+        <> usageLines
+  where
+    cursor = if selected == index then roleWarn color "› " else "  "
+    health
+        | not account.loginEnabled = roleWarn color "○ "
+        | otherwise = case account.loginUsage of
+            UsageUnavailable _ -> roleError color glyphErr
+            _ -> roleSuccess color glyphOk
+    provider = rolePrompt color (providerSlug account.loginProvider)
+    label = roleMuted color account.loginLabel
+    billing = roleMuted color case account.loginBilling of
+        SubscriptionBilling plan ->
+            "subscription" <> maybe "" (" · " <>) plan
+        ApiCreditsBilling -> "API credits"
+    enabledSuffix
+        | account.loginEnabled = ""
+        | otherwise = roleWarn color " · disabled"
+    accountId
+        | Text.null account.loginAccountId = "(unknown account)"
+        | otherwise = Text.take 24 account.loginAccountId
+    usageLines = case account.loginUsage of
+        UsageNotChecked ->
+            ["    " <> roleMuted color "usage not checked"]
+        UsageUnavailable err ->
+            ["    " <> roleError color ("usage unavailable · " <> Text.take 100 err)]
+        UsageAvailable usage ->
+            map ("    " <>) $
+                map (roleMuted color . formatWindow) usage.usageWindows
+                    <> creditLines usage
+
+formatWindow :: UsageWindow -> Text
+formatWindow window =
+    window.windowName
+        <> " "
+        <> Text.pack (show window.usedPercent)
+        <> "% used · resets "
+        <> Text.pack (show window.resetsAt)
+
+creditLines :: AccountUsage -> [Text]
+creditLines usage =
+    catMaybes
+        [ ("credits remaining " <>) <$> usage.creditsRemaining
+        , ("used " <>) <$> usage.creditsUsed
+        ]
+
+lookupNonEmpty :: String -> IO (Maybe Text)
+lookupNonEmpty name = do
+    value <- lookupEnv name
+    pure case value of
+        Just text | not (null text) -> Just (Text.pack text)
+        _ -> Nothing

--- a/packages/agent-cli/src/Agent/CLI/Options.hs
+++ b/packages/agent-cli/src/Agent/CLI/Options.hs
@@ -23,6 +23,7 @@ import qualified Data.Text as Text
 data Command
     = ShowHelp
     | ShowVersion
+    | Login
     | ListSessions
     | ShowSession Text
     | RunAgent CliOptions
@@ -112,7 +113,10 @@ parseArgs :: [String] -> Either String Command
 parseArgs args
     | any (`elem` ["--help", "-h"]) args = Right ShowHelp
     | "--version" `elem` args = Right ShowVersion
-    | take 1 args == ["login"] = Left loginHint
+    | take 1 args == ["login"] =
+        if length args == 1
+            then Right Login
+            else Left "usage: agent-cli login"
     | take 1 args == ["sessions"] = parseSessionsCommand (drop 1 args)
     | otherwise = RunAgent <$> parseOptions defaultCliOptions args
 
@@ -204,14 +208,10 @@ parseEffort raw =
                 <> ")"
             )
 
-loginHint :: String
-loginHint =
-    "login is not in this slice. Place credentials in ~/.codex/auth.json \
-    \or ~/.grok/auth.json, or set CODEX_ACCESS_TOKEN / GROK_ACCESS_TOKEN."
-
 usage :: String
 usage = unlines
     [ "Usage: agent-cli [OPTIONS]"
+    , "       agent-cli login"
     , "       agent-cli sessions [list]"
     , "       agent-cli sessions show <session-id>"
     , ""

--- a/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
@@ -58,6 +58,12 @@ spec = do
             parseReplLine "/reload-auth now"
                 `shouldBe` ReplCommandError "usage: /reload-auth"
 
+        it "opens the credential manager" do
+            parseReplLine "/login" `shouldBe` ReplLogin
+            parseReplLine "/accounts" `shouldBe` ReplLogin
+            parseReplLine "/login openai"
+                `shouldBe` ReplCommandError "usage: /login"
+
         it "clears or starts a new session" do
             parseReplLine "/clear" `shouldBe` ReplClear
             parseReplLine "/new" `shouldBe` ReplNew
@@ -149,6 +155,7 @@ spec = do
                     , "effort"
                     , "plan"
                     , "session"
+                    , "login"
                     , "resume"
                     , "compact"
                     , "clear"
@@ -164,6 +171,8 @@ spec = do
             fmap (.slashName) (lookupSlashCommand "m") `shouldBe` Just "model"
             fmap (.slashName) (lookupSlashCommand "/yolo")
                 `shouldBe` Just "always-approve"
+            fmap (.slashName) (lookupSlashCommand "/accounts")
+                `shouldBe` Just "login"
 
         it "completes command names from a leading slash" do
             slashCompletionCandidates "" "/"

--- a/packages/agent-cli/test/Agent/CLI/CredentialStoreSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CredentialStoreSpec.hs
@@ -1,0 +1,89 @@
+module Agent.CLI.CredentialStoreSpec (spec) where
+
+import Agent.CLI.CredentialStore
+import Agent.Provider (Provider(..))
+import Control.Exception.Safe (bracket)
+import qualified Data.ByteString.Lazy.Char8 as LBS
+import Data.Bits ((.&.))
+import Data.List (isInfixOf)
+import System.Directory
+    ( createDirectory
+    , getTemporaryDirectory
+    , removeFile
+    , removePathForcibly
+    )
+import System.Environment (lookupEnv, setEnv, unsetEnv)
+import System.IO (hClose, openTempFile)
+import System.Posix.Files (fileMode, getFileStatus)
+import Test.Hspec
+
+spec :: Spec
+spec =
+    describe "managed credential store" do
+        it "round-trips metadata and a separately stored secret" $
+            withTempHome \home -> do
+                upsertManagedCredential account secret `shouldReturn` Right ()
+                loadManagedCredentials `shouldReturn` Right [(account, secret)]
+
+                metadata <- LBS.readFile (managedCredentialsPath home)
+                secrets <- LBS.readFile (managedSecretsPath home)
+                LBS.unpack metadata `shouldNotSatisfy` isInfixOf "super-secret"
+                LBS.unpack secrets `shouldSatisfy` isInfixOf "super-secret"
+
+        it "writes private directories and files" $
+            withTempHome \home -> do
+                upsertManagedCredential account secret `shouldReturn` Right ()
+                metadataStatus <- getFileStatus (managedCredentialsPath home)
+                secretStatus <- getFileStatus (managedSecretsPath home)
+                fileMode metadataStatus .&. 0o777 `shouldBe` 0o600
+                fileMode secretStatus .&. 0o777 `shouldBe` 0o600
+
+        it "enables, disables, and deletes a managed credential" $
+            withTempHome \_ -> do
+                upsertManagedCredential account secret `shouldReturn` Right ()
+                setManagedCredentialEnabled account.managedId False
+                    `shouldReturn` Right ()
+                loaded <- loadManagedCredentials
+                fmap (map ((.managedEnabled) . fst)) loaded
+                    `shouldBe` Right [False]
+                deleteManagedCredential account.managedId
+                    `shouldReturn` Right ()
+                loadManagedCredentials `shouldReturn` Right []
+
+account :: ManagedCredential
+account = ManagedCredential
+    { managedId = "openrouter-test"
+    , managedProvider = OpenRouterProvider
+    , managedAccountId = "account"
+    , managedLabel = "Test"
+    , managedBilling = ManagedApiCredits
+    , managedAuthKind = ManagedBearerToken
+    , managedEnabled = True
+    }
+
+secret :: ManagedSecret
+secret = ManagedSecret
+    { secretManagedId = account.managedId
+    , secretPayload = "super-secret"
+    }
+
+withTempHome :: (FilePath -> IO a) -> IO a
+withTempHome action =
+    bracket create removePathForcibly \home ->
+        bracket
+            (do
+                old <- lookupEnv "HOME"
+                setEnv "HOME" home
+                pure old)
+            (\case
+                Just old -> setEnv "HOME" old
+                Nothing -> unsetEnv "HOME")
+            (\_ -> action home)
+  where
+    create = do
+        temporary <- getTemporaryDirectory
+        (path, handle) <- openTempFile temporary "agent-credential-store"
+        hClose handle
+        removeFile path
+        createDirectory path
+        pure path

--- a/packages/agent-cli/test/Agent/CLI/LoginSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/LoginSpec.hs
@@ -1,0 +1,124 @@
+module Agent.CLI.LoginSpec (spec) where
+
+import Agent.CLI.Login
+import Agent.CLI.CredentialStore (ManagedAuthKind(..))
+import Agent.CLI.Picker (PickerKey(..))
+import Agent.Provider (Provider(..))
+import Data.Either (isLeft)
+import qualified Data.Text as Text
+import Data.Time.Calendar (fromGregorian)
+import Data.Time.Clock (UTCTime(..))
+import Test.Hspec
+
+spec :: Spec
+spec = do
+    describe "applyLoginKey" do
+        it "moves and wraps the selected credential" do
+            let state = initialLoginState [openai, grok]
+            applyLoginKey PickerKeyUp state
+                `shouldBe` Right state { loginIndex = 1 }
+            applyLoginKey PickerKeyDown state
+                `shouldBe` Right state { loginIndex = 1 }
+
+        it "refreshes the selected credential on enter or r" do
+            let state = (initialLoginState [openai, grok]) { loginIndex = 1 }
+            applyLoginKey PickerKeyConfirm state
+                `shouldBe` Left (LoginRefresh 1)
+            applyLoginKey (PickerKeyChar 'r') state
+                `shouldBe` Left (LoginRefresh 1)
+
+        it "opens add, toggle, and delete actions" do
+            let state = initialLoginState [openai]
+            applyLoginKey (PickerKeyChar 'a') state
+                `shouldBe` Left LoginAdd
+            applyLoginKey (PickerKeyChar 'e') state
+                `shouldBe` Left (LoginToggle 0)
+            applyLoginKey (PickerKeyChar 'd') state
+                `shouldBe` Left (LoginDelete 0)
+            applyLoginKey (PickerKeyChar 'i') state
+                `shouldBe` Left (LoginImport 0)
+
+        it "closes an empty dashboard instead of refreshing" do
+            applyLoginKey PickerKeyConfirm (initialLoginState [])
+                `shouldSatisfy` isLeft
+
+    describe "renderLoginFrame" do
+        it "shows providers, billing modes, sources, and usage" do
+            let body = renderLoginFrame False $
+                    initialLoginState
+                        [ openai
+                            { loginUsage =
+                                UsageAvailable AccountUsage
+                                    { usagePlan = Just "plus"
+                                    , usageWindows =
+                                        [ UsageWindow
+                                            { windowName = "primary"
+                                            , usedPercent = 31
+                                            , windowSeconds = 18000
+                                            , resetsAt = epoch
+                                            }
+                                        ]
+                                    , creditsRemaining = Nothing
+                                    , creditsUsed = Nothing
+                                    }
+                            }
+                        , openRouter
+                        ]
+            body `shouldSatisfy` Text.isInfixOf "openai"
+            body `shouldSatisfy` Text.isInfixOf "subscription"
+            body `shouldSatisfy` Text.isInfixOf "31% used"
+            body `shouldSatisfy` Text.isInfixOf "openrouter"
+            body `shouldSatisfy` Text.isInfixOf "API credits"
+            body `shouldSatisfy` Text.isInfixOf "environment"
+
+        it "does not render access tokens" do
+            renderLoginFrame False (initialLoginState [openai])
+                `shouldSatisfy` (not . Text.isInfixOf "secret-openai")
+
+openai :: LoginAccount
+openai = LoginAccount
+    { loginManagedId = Nothing
+    , loginProvider = OpenAIProvider
+    , loginAccountId = "acc-openai"
+    , loginLabel = "ChatGPT"
+    , loginBilling = SubscriptionBilling Nothing
+    , loginSource = "~/.codex/auth.json"
+    , loginUsage = UsageNotChecked
+    , loginAccessToken = "secret-openai"
+    , loginAuthKind = ManagedBearerToken
+    , loginSecretPayload = "secret-openai"
+    , loginEnabled = True
+    }
+
+grok :: LoginAccount
+grok = LoginAccount
+    { loginManagedId = Nothing
+    , loginProvider = XAIProvider
+    , loginAccountId = "acc-grok"
+    , loginLabel = "Grok"
+    , loginBilling = SubscriptionBilling Nothing
+    , loginSource = "~/.grok/auth.json"
+    , loginUsage = UsageNotChecked
+    , loginAccessToken = "secret-grok"
+    , loginAuthKind = ManagedBearerToken
+    , loginSecretPayload = "secret-grok"
+    , loginEnabled = True
+    }
+
+openRouter :: LoginAccount
+openRouter = LoginAccount
+    { loginManagedId = Nothing
+    , loginProvider = OpenRouterProvider
+    , loginAccountId = "openrouter"
+    , loginLabel = "OpenRouter"
+    , loginBilling = ApiCreditsBilling
+    , loginSource = "environment"
+    , loginUsage = UsageNotChecked
+    , loginAccessToken = "secret-openrouter"
+    , loginAuthKind = ManagedBearerToken
+    , loginSecretPayload = "secret-openrouter"
+    , loginEnabled = True
+    }
+
+epoch :: UTCTime
+epoch = UTCTime (fromGregorian 2026 1 1) 0

--- a/packages/agent-cli/test/Agent/CLI/OptionsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/OptionsSpec.hs
@@ -69,8 +69,9 @@ spec = do
         it "rejects using both -p and --prompt-file" do
             parseArgs ["-p", "a", "--prompt-file", "b"] `shouldSatisfy` isLeft
 
-        it "explains that login is not in this slice" do
-            parseArgs ["login"] `shouldSatisfy` isLeft
+        it "opens the credential manager without starting an agent" do
+            parseArgs ["login"] `shouldBe` Right Login
+            parseArgs ["login", "openai"] `shouldSatisfy` isLeft
 
 
         it "parses sessions list and show" do

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -7,9 +7,11 @@ import qualified Agent.CLI.AuthSpec as AuthSpec
 import qualified Agent.CLI.CancelWatchSpec as CancelWatchSpec
 import qualified Agent.CLI.ClipboardSpec as ClipboardSpec
 import qualified Agent.CLI.CommandSpec as CommandSpec
+import qualified Agent.CLI.CredentialStoreSpec as CredentialStoreSpec
 import qualified Agent.CLI.ImagePreviewSpec as ImagePreviewSpec
 import qualified Agent.CLI.InputSpec as InputSpec
 import qualified Agent.CLI.InterruptSpec as InterruptSpec
+import qualified Agent.CLI.LoginSpec as LoginSpec
 import qualified Agent.CLI.MarkdownSpec as MarkdownSpec
 import qualified Agent.CLI.ModelPickerSpec as ModelPickerSpec
 import qualified Agent.CLI.ModelsSpec as ModelsSpec
@@ -38,9 +40,11 @@ main = hspec do
     CancelWatchSpec.spec
     ClipboardSpec.spec
     CommandSpec.spec
+    CredentialStoreSpec.spec
     ImagePreviewSpec.spec
     InputSpec.spec
     InterruptSpec.spec
+    LoginSpec.spec
     MarkdownSpec.spec
     ModelPickerSpec.spec
     ModelsSpec.spec

--- a/packages/agent-openrouter/agent-openrouter.cabal
+++ b/packages/agent-openrouter/agent-openrouter.cabal
@@ -40,6 +40,7 @@ library
                     , Agent.OpenRouter.Options
                     , Agent.OpenRouter.Request
                     , Agent.OpenRouter.Stream
+                    , Agent.OpenRouter.Usage
     hs-source-dirs:   src
     build-depends:    base                  >= 4.14 && < 5
                     , agent-core            >= 0.1 && < 0.2
@@ -51,6 +52,7 @@ library
                     , http-conduit
                     , http-types
                     , safe-exceptions
+                    , scientific
                     , time
 
 test-suite agent-openrouter-test
@@ -64,6 +66,7 @@ test-suite agent-openrouter-test
                     , Agent.OpenRouter.FunctionalSpec
                     , Agent.OpenRouter.LoopBackendSpec
                     , Agent.OpenRouter.RequestSpec
+                    , Agent.OpenRouter.UsageSpec
     ghc-options:      -threaded
     build-depends:    base >= 4.14 && < 5
                     , agent-core

--- a/packages/agent-openrouter/src/Agent/OpenRouter/Usage.hs
+++ b/packages/agent-openrouter/src/Agent/OpenRouter/Usage.hs
@@ -1,0 +1,128 @@
+-- | Credit and key-limit inspection for an OpenRouter API key.
+module Agent.OpenRouter.Usage
+    ( OpenRouterUsage(..)
+    , decodeCredits
+    , decodeKeyInfo
+    , fetchOpenRouterUsage
+    ) where
+
+import Control.Exception.Safe (tryAny)
+import qualified Data.Aeson as Aeson
+import Data.Aeson ((.:), (.:?))
+import qualified Data.ByteString.Lazy as LBS
+import Data.Scientific (Scientific)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
+import qualified Network.HTTP.Client as HttpClient
+import Network.HTTP.Simple
+
+data OpenRouterUsage = OpenRouterUsage
+    { keyLabel :: !(Maybe Text)
+    , keyUsage :: !(Maybe Scientific)
+    , keyLimit :: !(Maybe Scientific)
+    , keyLimitRemaining :: !(Maybe Scientific)
+    , isFreeTier :: !(Maybe Bool)
+    , totalCredits :: !(Maybe Scientific)
+    , totalUsage :: !(Maybe Scientific)
+    }
+    deriving (Eq, Show)
+
+data KeyInfo = KeyInfo
+    { label :: !(Maybe Text)
+    , usage :: !(Maybe Scientific)
+    , limit :: !(Maybe Scientific)
+    , limitRemaining :: !(Maybe Scientific)
+    , freeTier :: !(Maybe Bool)
+    }
+
+instance Aeson.FromJSON KeyInfo where
+    parseJSON = Aeson.withObject "OpenRouter key response" \outer -> do
+        value <- outer .: "data"
+        Aeson.withObject "OpenRouter key data" parseData value
+      where
+        parseData object =
+            KeyInfo
+                <$> object .:? "label"
+                <*> object .:? "usage"
+                <*> object .:? "limit"
+                <*> object .:? "limit_remaining"
+                <*> object .:? "is_free_tier"
+
+data Credits = Credits
+    { credits :: !(Maybe Scientific)
+    , used :: !(Maybe Scientific)
+    }
+
+instance Aeson.FromJSON Credits where
+    parseJSON = Aeson.withObject "OpenRouter credits response" \outer -> do
+        value <- outer .: "data"
+        Aeson.withObject "OpenRouter credits data" parseData value
+      where
+        parseData object =
+            Credits
+                <$> object .:? "total_credits"
+                <*> object .:? "total_usage"
+
+decodeKeyInfo
+    :: LBS.ByteString
+    -> Either Text
+        (Maybe Text, Maybe Scientific, Maybe Scientific, Maybe Scientific, Maybe Bool)
+decodeKeyInfo body = case Aeson.eitherDecode body of
+    Left detail ->
+        Left ("OpenRouter key response could not be decoded: " <> Text.pack detail)
+    Right KeyInfo{label, usage, limit, limitRemaining, freeTier} ->
+        Right (label, usage, limit, limitRemaining, freeTier)
+
+decodeCredits
+    :: LBS.ByteString
+    -> Either Text (Maybe Scientific, Maybe Scientific)
+decodeCredits body = case Aeson.eitherDecode body of
+    Left detail ->
+        Left
+            ("OpenRouter credits response could not be decoded: "
+                <> Text.pack detail)
+    Right Credits{credits, used} -> Right (credits, used)
+
+fetchOpenRouterUsage :: Text -> IO (Either Text OpenRouterUsage)
+fetchOpenRouterUsage apiKey = do
+    keyResult <- fetch "/key" decodeKeyInfo
+    creditResult <- fetch "/credits" decodeCredits
+    pure $ do
+        (label, usage, limit, remaining, freeTier) <- keyResult
+        (credits, used) <- creditResult
+        pure OpenRouterUsage
+            { keyLabel = label
+            , keyUsage = usage
+            , keyLimit = limit
+            , keyLimitRemaining = remaining
+            , isFreeTier = freeTier
+            , totalCredits = credits
+            , totalUsage = used
+            }
+  where
+    fetch path decode = do
+        result <- tryAny do
+            request <- parseRequest ("https://openrouter.ai/api/v1" <> path)
+            httpLBS
+                $ setRequestHeader
+                    "Authorization"
+                    ["Bearer " <> Text.encodeUtf8 apiKey]
+                $ setRequestHeader "Accept" ["application/json"]
+                $ setRequestResponseTimeout
+                    (HttpClient.responseTimeoutMicro (30 * 1_000_000))
+                    request
+        pure case result of
+            Left exception ->
+                Left
+                    ("OpenRouter usage request failed: "
+                        <> Text.pack (show exception))
+            Right response
+                | let status = getResponseStatusCode response
+                , status >= 200
+                , status < 300 ->
+                    decode (getResponseBody response)
+                | otherwise ->
+                    Left
+                        ("OpenRouter usage returned HTTP "
+                            <> Text.pack (show (getResponseStatusCode response)))

--- a/packages/agent-openrouter/test/Agent/OpenRouter/UsageSpec.hs
+++ b/packages/agent-openrouter/test/Agent/OpenRouter/UsageSpec.hs
@@ -1,0 +1,21 @@
+module Agent.OpenRouter.UsageSpec (spec) where
+
+import Agent.OpenRouter.Usage
+import qualified Data.ByteString.Lazy.Char8 as LBS
+import Test.Hspec
+
+spec :: Spec
+spec = do
+    describe "decodeKeyInfo" do
+        it "decodes key usage, limit, and free-tier status" do
+            decodeKeyInfo (LBS.pack
+                "{\"data\":{\"label\":\"agent\",\"usage\":12.5,\"limit\":50,\
+                \\"limit_remaining\":37.5,\"is_free_tier\":false}}")
+                `shouldBe` Right
+                    (Just "agent", Just 12.5, Just 50, Just 37.5, Just False)
+
+    describe "decodeCredits" do
+        it "decodes total credits and usage" do
+            decodeCredits (LBS.pack
+                "{\"data\":{\"total_credits\":100,\"total_usage\":25.25}}")
+                `shouldBe` Right (Just 100, Just 25.25)

--- a/packages/agent-openrouter/test/Spec.hs
+++ b/packages/agent-openrouter/test/Spec.hs
@@ -8,6 +8,7 @@ import qualified Agent.OpenRouter.ErrorSpec as ErrorSpec
 import qualified Agent.OpenRouter.FunctionalSpec as FunctionalSpec
 import qualified Agent.OpenRouter.LoopBackendSpec as LoopBackendSpec
 import qualified Agent.OpenRouter.RequestSpec as RequestSpec
+import qualified Agent.OpenRouter.UsageSpec as UsageSpec
 
 main :: IO ()
 main = hspec do
@@ -17,3 +18,4 @@ main = hspec do
     ClientSpec.spec
     LoopBackendSpec.spec
     FunctionalSpec.spec
+    UsageSpec.spec

--- a/packages/agent-xai/agent-xai.cabal
+++ b/packages/agent-xai/agent-xai.cabal
@@ -39,6 +39,7 @@ library
                     , Agent.XAI.Options
                     , Agent.XAI.Request
                     , Agent.XAI.Stream
+                    , Agent.XAI.Usage
     hs-source-dirs:   src
     build-depends:    base                  >= 4.14 && < 5
                     , agent-core            >= 0.1 && < 0.2
@@ -51,6 +52,8 @@ library
                     , base64-bytestring
                     , retry
                     , safe-exceptions
+                    , scientific
+                    , time
 
 test-suite agent-xai-test
     import:           common-opts
@@ -62,6 +65,7 @@ test-suite agent-xai-test
                     , Agent.XAI.FunctionalSpec
                     , Agent.XAI.LoopBackendSpec
                     , Agent.XAI.ResponsesSpec
+                    , Agent.XAI.UsageSpec
     ghc-options:      -threaded
     build-depends:    base >= 4.14 && < 5
                     , agent-core

--- a/packages/agent-xai/src/Agent/XAI/Usage.hs
+++ b/packages/agent-xai/src/Agent/XAI/Usage.hs
@@ -1,0 +1,84 @@
+-- | Usage-window client for Grok subscription credentials.
+module Agent.XAI.Usage
+    ( GrokUsageSnapshot(..)
+    , decodeGrokUsage
+    , fetchGrokUsage
+    ) where
+
+import Control.Exception.Safe (tryAny)
+import qualified Data.Aeson as Aeson
+import Data.Aeson ((.:))
+import Data.Aeson.Types (Parser)
+import qualified Data.ByteString.Lazy as LBS
+import Data.Scientific (Scientific)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
+import Data.Time.Clock (UTCTime, diffUTCTime)
+import qualified Network.HTTP.Client as HttpClient
+import Network.HTTP.Simple
+
+data GrokUsageSnapshot = GrokUsageSnapshot
+    { usedPercent :: !Int
+    , windowSeconds :: !Int
+    , resetsAt :: !UTCTime
+    }
+    deriving (Eq, Show)
+
+instance Aeson.FromJSON GrokUsageSnapshot where
+    parseJSON = Aeson.withObject "Grok billing response" \response -> do
+        config <- response .: "config"
+        Aeson.withObject "Grok billing config" parseConfig config
+      where
+        parseConfig config = do
+            creditUsagePercent <-
+                config .: "creditUsagePercent" :: Parser Scientific
+            currentPeriod <- config .: "currentPeriod"
+            (startsAt, resetsAt) <-
+                Aeson.withObject "Grok billing period" parsePeriod currentPeriod
+            let usedPercent = max 0 (min 100 (floor creditUsagePercent))
+                windowSeconds =
+                    max 1 (round (diffUTCTime resetsAt startsAt))
+            pure GrokUsageSnapshot
+                { usedPercent
+                , windowSeconds
+                , resetsAt
+                }
+
+        parsePeriod period =
+            (,) <$> period .: "start" <*> period .: "end"
+
+decodeGrokUsage :: LBS.ByteString -> Either Text GrokUsageSnapshot
+decodeGrokUsage body = case Aeson.eitherDecode body of
+    Left detail ->
+        Left ("Grok billing response could not be decoded: " <> Text.pack detail)
+    Right snapshot -> Right snapshot
+
+fetchGrokUsage :: Text -> IO (Either Text GrokUsageSnapshot)
+fetchGrokUsage accessToken =
+    tryAny requestUsage >>= \case
+        Left exception ->
+            pure $ Left
+                ("Grok billing request failed: " <> Text.pack (show exception))
+        Right response -> do
+            let status = getResponseStatusCode response
+            pure $
+                if status >= 200 && status < 300
+                    then decodeGrokUsage (getResponseBody response)
+                    else Left
+                        ("Grok billing returned HTTP " <> Text.pack (show status))
+  where
+    requestUsage = do
+        request <-
+            parseRequest
+                "https://cli-chat-proxy.grok.com/v1/billing?format=credits"
+        httpLBS
+            $ setRequestHeader
+                "Authorization"
+                ["Bearer " <> Text.encodeUtf8 accessToken]
+            $ setRequestHeader "Accept" ["application/json"]
+            $ setRequestHeader "x-grok-client-mode" ["shell"]
+            $ setRequestHeader "x-grok-client-version" ["0.2.118"]
+            $ setRequestResponseTimeout
+                (HttpClient.responseTimeoutMicro (30 * 1_000_000))
+                request

--- a/packages/agent-xai/test/Agent/XAI/UsageSpec.hs
+++ b/packages/agent-xai/test/Agent/XAI/UsageSpec.hs
@@ -1,0 +1,26 @@
+module Agent.XAI.UsageSpec (spec) where
+
+import Agent.XAI.Usage
+import qualified Data.ByteString.Lazy.Char8 as LBS
+import Test.Hspec
+
+spec :: Spec
+spec =
+    describe "decodeGrokUsage" do
+        it "decodes and floors the current subscription period" do
+            let body = LBS.pack
+                    "{\"config\":{\"creditUsagePercent\":31.9,\
+                    \\"currentPeriod\":{\"start\":\"2026-08-20T00:00:00Z\",\
+                    \\"end\":\"2026-08-21T00:00:00Z\"}}}"
+            case decodeGrokUsage body of
+                Left err -> expectationFailure (show err)
+                Right snapshot -> do
+                    snapshot.usedPercent `shouldBe` 31
+                    snapshot.windowSeconds `shouldBe` 86400
+
+        it "clamps percentages to the provider range" do
+            let body = LBS.pack
+                    "{\"config\":{\"creditUsagePercent\":140,\
+                    \\"currentPeriod\":{\"start\":\"2026-08-20T00:00:00Z\",\
+                    \\"end\":\"2026-08-21T00:00:00Z\"}}}"
+            fmap (.usedPercent) (decodeGrokUsage body) `shouldBe` Right 100

--- a/packages/agent-xai/test/Spec.hs
+++ b/packages/agent-xai/test/Spec.hs
@@ -7,6 +7,7 @@ import qualified Agent.XAI.ClientSpec as ClientSpec
 import qualified Agent.XAI.FunctionalSpec as FunctionalSpec
 import qualified Agent.XAI.LoopBackendSpec as LoopBackendSpec
 import qualified Agent.XAI.ResponsesSpec as ResponsesSpec
+import qualified Agent.XAI.UsageSpec as UsageSpec
 
 main :: IO ()
 main = hspec do
@@ -15,3 +16,4 @@ main = hspec do
     FunctionalSpec.spec
     LoopBackendSpec.spec
     ResponsesSpec.spec
+    UsageSpec.spec


### PR DESCRIPTION
## Summary

- add `/login` and `/accounts` plus standalone `agent-cli login`
- discover existing OpenAI, Grok, OpenRouter, and broker credentials
- show subscription/API billing type and refresh provider usage interactively
- connect OpenAI and Grok through device OAuth, and OpenRouter through validated API-key entry
- import external credentials into a managed store, enable/disable them, and disconnect them
- load enabled managed credentials through the existing runtime auth providers

## Credential storage

Managed metadata and secrets are stored separately under `~/.haskell-agent/credentials/`:

- `accounts.json`
- `secrets.json`

The directory is mode `0700`, files are mode `0600`, writes use temporary-file replacement, and secret-bearing values have redacted `Show` instances.

## Usage integrations

- OpenAI ChatGPT plan and primary/secondary quota windows
- Grok subscription billing period via the same billing endpoint used by `llm-router`
- OpenRouter key limits, remaining allowance, free-tier state, total credits, and total usage

## Validation

- `agent-cli`: 271 examples, 0 failures
- `agent-xai`: 38 examples, 0 failures, 1 live test pending
- `agent-openrouter`: 30 examples, 0 failures, 1 live test pending
- `git diff --check`
- tmux smoke tests for standalone login, dashboard navigation, usage refresh, provider picker, hidden key entry, cancellation, and terminal restoration
