### PR TITLE
Render plan approvals as Markdown

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Markdown.hs
+++ b/packages/agent-cli/src/Agent/CLI/Markdown.hs
@@ -67,13 +67,15 @@ renderBlocks = go
         | Just (level, title) <- headingLine line =
             -- Hide the markdown `#` markers (grok pretty mode); color the title.
             md (headingPrefixStyle level) (styleInline title) : go rest
-        | Just item <- unorderedItem line =
-            ( md listMarkerStyle "• "
+        | Just (indent, item) <- unorderedItemParts line =
+            ( indent
+                <> md listMarkerStyle "• "
                 <> styleInline item
             )
                 : go rest
-        | Just (digits, item) <- orderedItemParts line =
-            ( md listMarkerStyle (digits <> ". ")
+        | Just (indent, digits, item) <- orderedItemParts line =
+            ( indent
+                <> md listMarkerStyle (digits <> ". ")
                 <> styleInline item
             )
                 : go rest
@@ -162,26 +164,26 @@ startsWithSpace t = case Text.uncons t of
     Just (c, _) -> isSpace c
     Nothing -> False
 
-unorderedItem :: Text -> Maybe Text
-unorderedItem line =
-    let stripped = Text.stripStart line
+unorderedItemParts :: Text -> Maybe (Text, Text)
+unorderedItemParts line =
+    let (indent, stripped) = Text.span isSpace line
     in case Text.uncons stripped of
         Just (c, rest)
             | c `elem` ['-', '*', '+']
             , Just (sp, after) <- Text.uncons rest
             , isSpace sp ->
-                Just (Text.strip after)
+                Just (indent, Text.strip after)
         _ -> Nothing
 
 -- | Ordered list: number marker and item body separately so the marker can
 -- be colored without restyling the whole line twice.
-orderedItemParts :: Text -> Maybe (Text, Text)
+orderedItemParts :: Text -> Maybe (Text, Text, Text)
 orderedItemParts line =
-    let stripped = Text.stripStart line
+    let (indent, stripped) = Text.span isSpace line
         (digits, after) = Text.span isDigit stripped
     in if not (Text.null digits)
         then case Text.stripPrefix ". " after of
-            Just item -> Just (digits, Text.strip item)
+            Just item -> Just (indent, digits, Text.strip item)
             Nothing -> Nothing
         else Nothing
 

--- a/packages/agent-cli/src/Agent/CLI/Plan.hs
+++ b/packages/agent-cli/src/Agent/CLI/Plan.hs
@@ -4,6 +4,7 @@ module Agent.CLI.Plan
     ( cliPlanHooks
     , extractProposedPlan
     , stripProposedPlan
+    , renderPlanMarkdown
     , parsePlanDecisionAnswer
     ) where
 
@@ -15,8 +16,11 @@ import Agent.CLI.Input
     , readReplLine
     )
 import Agent.CLI.Interrupt (InterruptState)
+import Agent.CLI.Markdown (renderMarkdown)
 import Agent.CLI.Style
-    ( roleMuted
+    ( agentBackground
+    , paintBackgroundLines
+    , roleMuted
     , rolePrompt
     , roleSuccess
     , roleWarn
@@ -68,7 +72,7 @@ decideExit interrupt resolveColor planBody = do
     isTty <- hIsTerminalDevice stdin
     putTextLn stderr ""
     putTextLn stderr (roleMuted color "── plan ──")
-    Text.hPutStrLn stderr planBody
+    Text.hPutStrLn stderr (renderPlanMarkdown color planBody)
     hFlush stderr
     putTextLn stderr (roleMuted color "──────────")
     if not isTty
@@ -153,6 +157,10 @@ formatChoiceLine color selected label
             ]
             label
     | otherwise = roleMuted color label
+
+renderPlanMarkdown :: Bool -> Text -> Text
+renderPlanMarkdown color text =
+    paintBackgroundLines color agentBackground (renderMarkdown color text)
 
 parsePlanDecisionAnswer :: Text -> Maybe PlanDecision
 parsePlanDecisionAnswer raw = case Text.toLower (Text.strip raw) of

--- a/packages/agent-cli/test/Agent/CLI/MarkdownSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/MarkdownSpec.hs
@@ -64,6 +64,11 @@ spec = do
             ol `shouldSatisfy` Text.isInfixOf "item"
             ol `shouldSatisfy` Text.isInfixOf "\ESC["
 
+        it "preserves indentation for nested lists" do
+            let out = renderMarkdown True "- parent\n  - child\n    1. grandchild"
+                cleaned = Text.lines (stripAnsi out)
+            cleaned `shouldBe` ["• parent", "  • child", "    1. grandchild"]
+
         it "mutes plain blockquotes" do
             let out = renderMarkdown True "> note"
             out `shouldSatisfy` Text.isInfixOf "note"

--- a/packages/agent-cli/test/Agent/CLI/PlanSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/PlanSpec.hs
@@ -2,6 +2,7 @@ module Agent.CLI.PlanSpec (spec) where
 
 import Agent.CLI.Plan
 import Agent.Tools.PlanMode (PlanDecision(..))
+import qualified Data.Text as Text
 import Test.Hspec
 
 spec :: Spec
@@ -21,6 +22,16 @@ spec = do
             stripProposedPlan
                 "before\n<proposed_plan>\nplan\n</proposed_plan>\nafter"
                 `shouldBe` "before\n\nafter"
+
+    describe "renderPlanMarkdown" do
+        it "leaves plan Markdown unchanged when color is off" do
+            let plan = "# Plan\n\n- edit `Plan.hs`"
+            renderPlanMarkdown False plan `shouldBe` plan
+
+        it "styles plan Markdown when color is on" do
+            let out = renderPlanMarkdown True "# Plan"
+            out `shouldSatisfy` Text.isInfixOf "Plan"
+            out `shouldSatisfy` (not . Text.isInfixOf "# Plan")
 
     describe "parsePlanDecisionAnswer" do
         it "maps approve / changes / cancel aliases" do


### PR DESCRIPTION
## Summary
- render proposed plans with the existing terminal Markdown renderer
- apply the assistant background wash to plan approval content
- preserve unchanged output when color is disabled
- add focused regression coverage

## Testing
- `cabal repl agent-cli:test:agent-cli-test` with `:main --match renderPlanMarkdown` (2 examples, 0 failures)
- tmux TTY smoke test of the plan approval prompt with headings, lists, inline code, bold text, and a fenced code block