### PR TITLE
Type Grok and Codex transport errors

### DIFF
--- a/packages/agent-core/src/Agent/Error.hs
+++ b/packages/agent-core/src/Agent/Error.hs
@@ -1,8 +1,10 @@
 module Agent.Error
     ( ApiError(..)
     , ErrorType(..)
+    , RetryDisposition(..)
     , errorTypeFromText
     , errorTypeText
+    , retryDisposition
     , isRetryable
     , isInlineRetryableProviderError
     , isInlineRetryableProviderResponseError
@@ -22,13 +24,33 @@ data ErrorType
     | PermissionError
     | NotFoundError
     | PreviousResponseNotFound
+    | ContextWindowExceeded
+    | InvalidImageError
     | RateLimitError
     | UsageLimitReached
+    | UsageBalanceExhausted
+    | QuotaExceeded
+    | UsageNotIncluded
     | ApiErrorType
     | OverloadedError
     | ServiceUnavailableError
     | BillingError
+    | ClientUpdateRequired
+    | PayloadTooLargeError
+    | WebSocketConnectionLimitReached
+    | CyberPolicyError
+    | MisalignmentPolicyViolation
     | UnknownErrorType !Text
+    deriving (Eq, Show)
+
+-- | Whether retrying can help, and which layer should own the retry.
+--
+-- A usage-window exhaustion must not be retried inline: the credential
+-- orchestrator parks or replaces that account until the provider reset.
+data RetryDisposition
+    = DoNotRetry
+    | RetryTransiently
+    | RetryAfterLimitReset
     deriving (Eq, Show)
 
 instance FromJSON ErrorType where
@@ -40,16 +62,36 @@ instance ToJSON ErrorType where
 errorTypeFromText :: Text -> ErrorType
 errorTypeFromText = \case
     "invalid_request_error" -> InvalidRequestError
+    "invalid_prompt" -> InvalidRequestError
+    "bio_policy" -> InvalidRequestError
     "authentication_error" -> AuthenticationError
+    "invalid_api_key" -> AuthenticationError
     "permission_error" -> PermissionError
     "not_found_error" -> NotFoundError
     "previous_response_not_found" -> PreviousResponseNotFound
+    "context_length_exceeded" -> ContextWindowExceeded
+    "model_context_window_exceeded" -> ContextWindowExceeded
+    "invalid_image" -> InvalidImageError
     "rate_limit_error" -> RateLimitError
+    "rate_limit_exceeded" -> RateLimitError
+    "rate_limited" -> RateLimitError
     "usage_limit_reached" -> UsageLimitReached
+    "usage_balance_exhausted" -> UsageBalanceExhausted
+    "insufficient_quota" -> QuotaExceeded
+    "usage_not_included" -> UsageNotIncluded
     "api_error" -> ApiErrorType
+    "server_error" -> ApiErrorType
+    "internal_error" -> ApiErrorType
     "overloaded_error" -> OverloadedError
+    "server_is_overloaded" -> OverloadedError
+    "slow_down" -> OverloadedError
     "service_unavailable_error" -> ServiceUnavailableError
     "billing_error" -> BillingError
+    "client_update_required" -> ClientUpdateRequired
+    "payload_too_large" -> PayloadTooLargeError
+    "websocket_connection_limit_reached" -> WebSocketConnectionLimitReached
+    "cyber_policy" -> CyberPolicyError
+    "misalignment_policy_violation" -> MisalignmentPolicyViolation
     other -> UnknownErrorType other
 
 errorTypeText :: ErrorType -> Text
@@ -59,12 +101,22 @@ errorTypeText = \case
     PermissionError -> "permission_error"
     NotFoundError -> "not_found_error"
     PreviousResponseNotFound -> "previous_response_not_found"
+    ContextWindowExceeded -> "context_length_exceeded"
+    InvalidImageError -> "invalid_image"
     RateLimitError -> "rate_limit_error"
     UsageLimitReached -> "usage_limit_reached"
+    UsageBalanceExhausted -> "usage_balance_exhausted"
+    QuotaExceeded -> "insufficient_quota"
+    UsageNotIncluded -> "usage_not_included"
     ApiErrorType -> "api_error"
     OverloadedError -> "overloaded_error"
     ServiceUnavailableError -> "service_unavailable_error"
     BillingError -> "billing_error"
+    ClientUpdateRequired -> "client_update_required"
+    PayloadTooLargeError -> "payload_too_large"
+    WebSocketConnectionLimitReached -> "websocket_connection_limit_reached"
+    CyberPolicyError -> "cyber_policy"
+    MisalignmentPolicyViolation -> "misalignment_policy_violation"
     UnknownErrorType value -> value
 
 data ApiError
@@ -79,13 +131,24 @@ data ApiError
     | CredentialsExhausted { retryAt :: !UTCTime }
     deriving (Eq, Show)
 
+retryDisposition :: ApiError -> RetryDisposition
+retryDisposition = \case
+    ProviderError RateLimitError _ _ -> RetryAfterLimitReset
+    ProviderError UsageLimitReached _ _ -> RetryAfterLimitReset
+    ProviderError UsageBalanceExhausted _ _ -> RetryAfterLimitReset
+    ProviderError OverloadedError _ _ -> RetryTransiently
+    ProviderError ServiceUnavailableError _ _ -> RetryTransiently
+    ProviderError ApiErrorType _ _ -> RetryTransiently
+    ProviderError WebSocketConnectionLimitReached _ _ -> RetryTransiently
+    ConnectionError _ -> RetryTransiently
+    HttpError 429 _ -> RetryAfterLimitReset
+    HttpError status _
+        | status `elem` [408, 409, 425] -> RetryTransiently
+        | status >= 500 && status < 600 -> RetryTransiently
+    _ -> DoNotRetry
+
 isRetryable :: ApiError -> Bool
-isRetryable (ProviderError RateLimitError _ _) = True
-isRetryable (ProviderError UsageLimitReached _ _) = True
-isRetryable (ProviderError OverloadedError _ _) = True
-isRetryable (ProviderError ServiceUnavailableError _ _) = True
-isRetryable (ProviderError ApiErrorType _ _) = True
-isRetryable _ = False
+isRetryable = (/= DoNotRetry) . retryDisposition
 
 -- | Short-lived failures that are safe to retry inside one transport call.
 -- Credential quota failures are handled by provider failover instead.
@@ -98,6 +161,7 @@ isInlineRetryableProviderError = \case
     ProviderError OverloadedError _ _ -> True
     ProviderError ServiceUnavailableError _ _ -> True
     ProviderError ApiErrorType _ _ -> True
+    ProviderError WebSocketConnectionLimitReached _ _ -> True
     _ -> False
 
 -- | Failures repeatable on an existing connection. A broken connection must

--- a/packages/agent-core/src/Agent/Provider.hs
+++ b/packages/agent-core/src/Agent/Provider.hs
@@ -116,6 +116,7 @@ accountFailureFromApiError err = case err of
     HttpError 429 _ -> rateLimited
     ProviderError RateLimitError _ _ -> rateLimited
     ProviderError UsageLimitReached _ _ -> rateLimited
+    ProviderError UsageBalanceExhausted _ _ -> rateLimited
     HttpError 401 _ -> authenticationRejected
     HttpError 403 _ -> authenticationRejected
     ProviderError AuthenticationError _ _ -> authenticationRejected

--- a/packages/agent-core/test/Agent/ErrorSpec.hs
+++ b/packages/agent-core/test/Agent/ErrorSpec.hs
@@ -5,12 +5,27 @@ import qualified Data.Aeson as Aeson
 import Test.Hspec
 
 spec :: Spec
-spec = describe "ErrorType" do
+spec = do
+  describe "ErrorType" do
     it "maps wire discriminators directly" do
         errorTypeFromText "usage_limit_reached" `shouldBe` UsageLimitReached
-        errorTypeText UsageLimitReached `shouldBe` "usage_limit_reached"
+        errorTypeFromText "invalid_image" `shouldBe` InvalidImageError
+        errorTypeFromText "insufficient_quota" `shouldBe` QuotaExceeded
+        errorTypeText UsageBalanceExhausted `shouldBe` "usage_balance_exhausted"
 
     it "preserves unknown discriminators" do
         let unknown = UnknownErrorType "future_error"
         errorTypeFromText "future_error" `shouldBe` unknown
         Aeson.fromJSON (Aeson.toJSON unknown) `shouldBe` Aeson.Success unknown
+
+  describe "retryDisposition" do
+    it "separates transient retries from usage-reset retries" do
+        retryDisposition
+            (ProviderError UsageBalanceExhausted "balance exhausted" Nothing)
+            `shouldBe` RetryAfterLimitReset
+        retryDisposition
+            (ProviderError OverloadedError "busy" (Just 30))
+            `shouldBe` RetryTransiently
+        retryDisposition
+            (ProviderError InvalidRequestError "bad request" Nothing)
+            `shouldBe` DoNotRetry

--- a/packages/agent-openai/src/Agent/OpenAI/Error.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Error.hs
@@ -7,26 +7,29 @@ module Agent.OpenAI.Error
     ) where
 
 import Agent.Error
-import Data.Aeson ((.:), (.:?), FromJSON(..), eitherDecodeStrict', withObject)
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import Data.Scientific (toBoundedInteger)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 
-newtype OpenAIErrorEnvelope = OpenAIErrorEnvelope ApiError
-
-instance FromJSON OpenAIErrorEnvelope where
-    parseJSON = withObject "OpenAI error envelope" \object -> do
-        errObject <- object .: "error"
-        message <- errObject .: "message"
-        code <- errObject .:? "code"
-        errorType <- errObject .: "type"
-        retryAfter <- errObject .:? "resets_in_seconds"
-        pure (OpenAIErrorEnvelope (mkOpenAIError errorType message code retryAfter))
+data ProviderErrorPayload = ProviderErrorPayload
+    { payloadType :: !(Maybe Text)
+    , payloadCode :: !(Maybe Text)
+    , payloadMessage :: !Text
+    , payloadRetryAfter :: !(Maybe Int)
+    }
 
 decodeOpenAIError :: Text -> Either String ApiError
 decodeOpenAIError body = do
-    OpenAIErrorEnvelope apiError <- eitherDecodeStrict' (Text.encodeUtf8 body)
-    pure apiError
+    payload <- decodeProviderErrorPayload body
+    pure $ mkOpenAIError
+        (maybe ApiErrorType errorTypeFromText payload.payloadType)
+        payload.payloadMessage
+        payload.payloadCode
+        payload.payloadRetryAfter
 
 -- | Build an error from OpenAI's structured error fields, normalizing the
 -- several wire shapes used for a missing @previous_response_id@.
@@ -35,12 +38,33 @@ mkOpenAIError errorType message code retryAfter =
     ProviderError
         (classifyErrorType errorType message code)
         (appendErrorCode code message)
-        retryAfter
+        (retryAfter `orElse` retryAfterFromMessage message)
 
 classifyErrorType :: ErrorType -> Text -> Maybe Text -> ErrorType
 classifyErrorType errorType message code
     | isPreviousResponseNotFound errorType message code = PreviousResponseNotFound
-    | normalizedCode == Just "server_is_overloaded" = OverloadedError
+    | normalizedCode `elem` map Just ["context_length_exceeded", "model_context_window_exceeded"] =
+        ContextWindowExceeded
+    | normalizedCode == Just "invalid_image" = InvalidImageError
+    | normalizedCode `elem` map Just ["invalid_api_key", "token_expired"] =
+        AuthenticationError
+    | normalizedCode `elem` map Just ["permission_denied", "forbidden"] =
+        PermissionError
+    | normalizedCode `elem` map Just ["model_not_found", "not_found"] =
+        NotFoundError
+    | normalizedCode `elem` map Just ["rate_limit_exceeded", "rate_limit_error"] = RateLimitError
+    | normalizedCode == Just "usage_limit_reached" = UsageLimitReached
+    | normalizedCode == Just "usage_balance_exhausted" = UsageBalanceExhausted
+    | normalizedCode == Just "insufficient_quota" = QuotaExceeded
+    | normalizedCode == Just "usage_not_included" = UsageNotIncluded
+    | normalizedCode `elem` map Just ["server_is_overloaded", "slow_down"] = OverloadedError
+    | normalizedCode == Just "service_unavailable_error" = ServiceUnavailableError
+    | normalizedCode == Just "websocket_connection_limit_reached" =
+        WebSocketConnectionLimitReached
+    | normalizedCode == Just "cyber_policy" = CyberPolicyError
+    | normalizedCode == Just "misalignment_policy_violation" =
+        MisalignmentPolicyViolation
+    | normalizedCode `elem` map Just ["invalid_prompt", "bio_policy"] = InvalidRequestError
     | normalizedCode `elem` map Just ["server_error", "internal_error"] = ApiErrorType
     | normalizedErrorType == Just "overloaded_error" = OverloadedError
     | normalizedErrorType `elem` map Just ["server_error", "internal_error"] = ApiErrorType
@@ -70,9 +94,155 @@ appendErrorCode (Just code) message
 
 classifyHttpFailure :: Int -> Text -> ApiError
 classifyHttpFailure status body =
-    case decodeOpenAIError body of
-        Right apiError -> apiError
+    case decodeProviderErrorPayload body of
+        Right payload ->
+            mkOpenAIError
+                (maybe (errorTypeFromStatus status) errorTypeFromText payload.payloadType)
+                payload.payloadMessage
+                payload.payloadCode
+                payload.payloadRetryAfter
         Left _ -> HttpError status (Text.take 1000 body)
+
+decodeProviderErrorPayload :: Text -> Either String ProviderErrorPayload
+decodeProviderErrorPayload body = do
+    value <- Aeson.eitherDecodeStrict' (Text.encodeUtf8 body)
+    maybe (Left "JSON body contains no provider error") Right (payloadFromValue value)
+
+payloadFromValue :: Aeson.Value -> Maybe ProviderErrorPayload
+payloadFromValue = \case
+    Aeson.Object object ->
+        case KeyMap.lookup "error" object of
+            Just (Aeson.Object nested) -> payloadFromObjects object nested
+            Just (Aeson.String message)
+                | not (Text.null (Text.strip message)) ->
+                    Just ProviderErrorPayload
+                        { payloadType = providerTypeField object
+                        , payloadCode = scalarTextField "code" object
+                            `orElse` scalarTextField "error_code" object
+                        , payloadMessage = message
+                        , payloadRetryAfter = retryAfterField object
+                            `orElse` retryAfterFromMessage message
+                        }
+            Just value -> payloadFromValue value
+            Nothing -> payloadFromTopLevel object
+    Aeson.String message
+        | not (Text.null (Text.strip message)) ->
+            Just ProviderErrorPayload
+                { payloadType = Nothing
+                , payloadCode = Nothing
+                , payloadMessage = message
+                , payloadRetryAfter = retryAfterFromMessage message
+                }
+    Aeson.Array values -> firstJust (map payloadFromValue (foldr (:) [] values))
+    _ -> Nothing
+
+payloadFromObjects :: Aeson.Object -> Aeson.Object -> Maybe ProviderErrorPayload
+payloadFromObjects outer nested = do
+    message <- firstTextField ["message", "error", "detail", "description"] nested
+        `orElse` textField "type" nested
+    pure ProviderErrorPayload
+        { payloadType = providerTypeField nested `orElse` providerTypeField outer
+        , payloadCode = scalarTextField "code" nested
+            `orElse` scalarTextField "error_code" nested
+            `orElse` scalarTextField "code" outer
+        , payloadMessage = message
+        , payloadRetryAfter = retryAfterField nested
+            `orElse` retryAfterField outer
+            `orElse` retryAfterFromMessage message
+        }
+
+payloadFromTopLevel :: Aeson.Object -> Maybe ProviderErrorPayload
+payloadFromTopLevel object = do
+    message <- firstTextField ["message", "detail", "msg", "description"] object
+    pure ProviderErrorPayload
+        { payloadType = providerTypeField object
+        , payloadCode = scalarTextField "code" object
+            `orElse` scalarTextField "error_code" object
+        , payloadMessage = message
+        , payloadRetryAfter = retryAfterField object
+            `orElse` retryAfterFromMessage message
+        }
+
+errorTypeFromStatus :: Int -> ErrorType
+errorTypeFromStatus = \case
+    400 -> InvalidRequestError
+    401 -> AuthenticationError
+    402 -> BillingError
+    403 -> PermissionError
+    404 -> NotFoundError
+    408 -> ApiErrorType
+    413 -> PayloadTooLargeError
+    422 -> InvalidRequestError
+    426 -> ClientUpdateRequired
+    429 -> RateLimitError
+    500 -> ApiErrorType
+    502 -> ServiceUnavailableError
+    503 -> ServiceUnavailableError
+    504 -> ServiceUnavailableError
+    529 -> OverloadedError
+    _ -> ApiErrorType
+
+textField :: Text -> Aeson.Object -> Maybe Text
+textField name object = case KeyMap.lookup (Key.fromText name) object of
+    Just (Aeson.String value) | not (Text.null (Text.strip value)) -> Just value
+    _ -> Nothing
+
+providerTypeField :: Aeson.Object -> Maybe Text
+providerTypeField object = do
+    value <- textField "type" object
+    if Text.toLower value `elem` ["error", "errors", "unknown", "unknown_error"]
+        then Nothing
+        else Just value
+
+scalarTextField :: Text -> Aeson.Object -> Maybe Text
+scalarTextField name object = case KeyMap.lookup (Key.fromText name) object of
+    Just (Aeson.String value) | not (Text.null (Text.strip value)) -> Just value
+    Just (Aeson.Number value) -> Just (Text.pack (show value))
+    Just (Aeson.Bool value) -> Just (if value then "true" else "false")
+    _ -> Nothing
+
+firstTextField :: [Text] -> Aeson.Object -> Maybe Text
+firstTextField names object = firstJust (map (`textField` object) names)
+
+retryAfterField :: Aeson.Object -> Maybe Int
+retryAfterField object =
+    numberField "resets_in_seconds" object
+        `orElse` numberField "retry_after" object
+
+numberField :: Text -> Aeson.Object -> Maybe Int
+numberField name object = case KeyMap.lookup (Key.fromText name) object of
+    Just (Aeson.Number value) -> max 1 <$> toBoundedInteger value
+    Just (Aeson.String value) -> case reads (Text.unpack value) of
+        [(seconds, "")] -> Just (max 1 seconds)
+        _ -> Nothing
+    _ -> Nothing
+
+retryAfterFromMessage :: Text -> Maybe Int
+retryAfterFromMessage message = do
+    let lowered = Text.toLower message
+        (_, suffix) = Text.breakOn "try again in" lowered
+    rest <- Text.stripPrefix "try again in" suffix
+    let stripped = Text.stripStart rest
+        token = Text.takeWhile isNumericCharacter stripped
+        unit = Text.toLower
+            $ Text.takeWhile isAsciiLetter
+            $ Text.stripStart
+            $ Text.drop (Text.length token) stripped
+    value <- case reads (Text.unpack token) of
+        [(seconds, "")] -> Just (seconds :: Double)
+        _ -> Nothing
+    pure $ max 1 $ ceiling $
+        if unit == "ms" then value / 1000 else value
+  where
+    isNumericCharacter character =
+        character == '.' || character >= '0' && character <= '9'
+    isAsciiLetter character =
+        character >= 'a' && character <= 'z'
+
+firstJust :: [Maybe a] -> Maybe a
+firstJust [] = Nothing
+firstJust (Just value : _) = Just value
+firstJust (Nothing : rest) = firstJust rest
 
 isPreviousResponseIdError :: ApiError -> Bool
 isPreviousResponseIdError = \case
@@ -93,3 +263,7 @@ mentionsPreviousResponse value =
         || "previous response" `Text.isInfixOf` lowered
         || "response_not_found" `Text.isInfixOf` lowered
         || "previous_response_not_found" `Text.isInfixOf` lowered
+
+orElse :: Maybe a -> Maybe a -> Maybe a
+orElse (Just value) _ = Just value
+orElse Nothing fallback = fallback

--- a/packages/agent-openai/src/Agent/OpenAI/Http.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Http.hs
@@ -3,7 +3,7 @@ module Agent.OpenAI.Http
     , rejectFailedCodexResponse
     ) where
 
-import Agent.Error (ApiError(..), ErrorType(..))
+import Agent.Error (ApiError(..), ErrorType(..), errorTypeFromText)
 import Agent.OpenAI.Error (mkOpenAIError)
 import Agent.OpenAI.ResponseMerge (mergeCompletedResponseOutput)
 import qualified Agent.OpenAI.Responses.Types as OpenAI
@@ -59,7 +59,7 @@ failedResponseError Nothing =
     ProviderError ApiErrorType "Codex response failed without error details" Nothing
 failedResponseError (Just responseError) =
     mkOpenAIError
-        ApiErrorType
+        (errorTypeFromText responseError.code)
         responseError.message
         (Just responseError.code)
         Nothing

--- a/packages/agent-openai/src/Agent/OpenAI/WebSocketClient.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/WebSocketClient.hs
@@ -402,19 +402,23 @@ receiveWsResponse cc onEvent = do
 --
 -- We lift typed server errors into 'ProviderError', carrying the exact
 -- @resets_in_seconds@ (if present), so the caller can pass rate-limit windows
--- straight through to 'Agent.OpenAI.Auth.reportRateLimit'. Error events without a
--- server type still fall back to 'ConnectionError' unless their code/message
--- identifies a missing @previous_response_id@.
+-- straight through to 'Agent.OpenAI.Auth.reportRateLimit'. A code-only event
+-- is also typed; only events with neither a type nor a code fall back to
+-- 'ConnectionError' (apart from previous-response wording).
 parseWsErrorEvent :: ResponseStreamError -> ApiError
 parseWsErrorEvent streamError =
     let parsedError = mkOpenAIError
-            (maybe (UnknownErrorType "") errorTypeFromText streamError.errorType)
+            (maybe
+                (maybe (UnknownErrorType "") errorTypeFromText streamError.code)
+                errorTypeFromText
+                streamError.errorType)
             streamError.message
             streamError.code
             streamError.retryAfter
-    in case streamError.errorType of
-        Just _ -> parsedError
-        Nothing
+    in case (streamError.errorType, streamError.code) of
+        (Just _, _) -> parsedError
+        (Nothing, Just _) -> parsedError
+        (Nothing, Nothing)
             | isPreviousResponseIdError parsedError -> parsedError
             | otherwise -> ConnectionError
                 ("WebSocket error (no type): "

--- a/packages/agent-openai/test/Agent/OpenAI/CredentialSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/CredentialSpec.hs
@@ -43,6 +43,9 @@ spec = do
             accountFailureFromApiError
                 (ProviderError UsageLimitReached "limited" (Just 120))
                 `shouldBe` Just (AccountRateLimited (Just 120))
+            accountFailureFromApiError
+                (ProviderError UsageBalanceExhausted "balance exhausted" (Just 3600))
+                `shouldBe` Just (AccountRateLimited (Just 3600))
 
         it "classifies authentication failures but not connection errors" do
             accountFailureFromApiError (HttpError 401 "rejected")

--- a/packages/agent-openai/test/Agent/OpenAI/ErrorSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/ErrorSpec.hs
@@ -73,13 +73,49 @@ spec = do
             classifyHttpFailure 429 "{\"error\":{\"type\":\"rate_limit_error\",\"message\":\"slow down\"}}"
                 `shouldBe` ProviderError RateLimitError "slow down" Nothing
 
+        it "classifies Codex response error codes exhaustively" do
+            let classify code =
+                    mkOpenAIError ApiErrorType "failed" (Just code) Nothing
+            classify "context_length_exceeded"
+                `shouldBe` ProviderError ContextWindowExceeded
+                    "failed (code: context_length_exceeded)" Nothing
+            classify "invalid_image"
+                `shouldBe` ProviderError InvalidImageError
+                    "failed (code: invalid_image)" Nothing
+            classify "insufficient_quota"
+                `shouldBe` ProviderError QuotaExceeded
+                    "failed (code: insufficient_quota)" Nothing
+            classify "usage_not_included"
+                `shouldBe` ProviderError UsageNotIncluded
+                    "failed (code: usage_not_included)" Nothing
+            classify "cyber_policy"
+                `shouldBe` ProviderError CyberPolicyError
+                    "failed (code: cyber_policy)" Nothing
+            classify "misalignment_policy_violation"
+                `shouldBe` ProviderError MisalignmentPolicyViolation
+                    "failed (code: misalignment_policy_violation)" Nothing
+
+        it "parses flat provider bodies and prose retry delays" do
+            classifyHttpFailure 400
+                "{\"code\":\"invalid_image\",\"error\":\"Invalid PNG image.\"}"
+                `shouldBe` ProviderError InvalidImageError
+                    "Invalid PNG image. (code: invalid_image)"
+                    Nothing
+            classifyHttpFailure 429
+                "{\"error\":{\"code\":\"rate_limit_exceeded\",\"message\":\"Rate limit exceeded. Please try again in 1.898s.\"}}"
+                `shouldBe` ProviderError RateLimitError
+                    "Rate limit exceeded. Please try again in 1.898s. (code: rate_limit_exceeded)"
+                    (Just 2)
+            classifyHttpFailure 429 "{\"type\":\"error\",\"error\":\"slow down\"}"
+                `shouldBe` ProviderError RateLimitError "slow down" Nothing
+
         it "falls back to HttpError for non-JSON bodies" do
             classifyHttpFailure 502 "Bad Gateway"
                 `shouldBe` HttpError 502 "Bad Gateway"
 
-        it "falls back to HttpError for JSON bodies without an error object" do
+        it "types JSON detail bodies using the HTTP status" do
             classifyHttpFailure 429 "{\"detail\":\"too many requests\"}"
-                `shouldBe` HttpError 429 "{\"detail\":\"too many requests\"}"
+                `shouldBe` ProviderError RateLimitError "too many requests" Nothing
 
     describe "isInlineRetryableProviderError" do
         it "retries overload, server, connection, and transient HTTP failures" do

--- a/packages/agent-openrouter/src/Agent/OpenRouter/Error.hs
+++ b/packages/agent-openrouter/src/Agent/OpenRouter/Error.hs
@@ -51,6 +51,7 @@ classifyFailure status retryAfterHeader body =
   where
     openRouterEnvelope = decodeOpenRouterError body
     auth = ProviderError AuthenticationError (preview body) Nothing
+    fromOpenRouterEnvelope :: OpenRouterErrorEnvelope -> ApiError
     fromOpenRouterEnvelope envelope =
         ProviderError
             (errorTypeFromOpenRouter status envelope.envelopeCode)

--- a/packages/agent-openrouter/src/Agent/OpenRouter/Error.hs
+++ b/packages/agent-openrouter/src/Agent/OpenRouter/Error.hs
@@ -29,27 +29,33 @@ instance FromJSON OpenRouterErrorEnvelope where
 -- | Classify a non-success response from OpenRouter.
 classifyFailure :: Int -> Maybe Int -> Text -> ApiError
 classifyFailure status retryAfterHeader body =
-    case decodeOpenAIError body of
-        Right (ProviderError errType message retryAfter) ->
-            ProviderError errType message (retryAfter `orElse` retryAfterHeader)
-        Right other -> other
-        Left _ -> case decodeOpenRouterError body of
-            Just envelope ->
-                ProviderError
-                    (errorTypeFromOpenRouter status envelope.envelopeCode)
-                    (nonEmptyMessage envelope.envelopeMessage body)
-                    retryAfterHeader
-            Nothing -> case status of
-                401 -> auth
-                403 -> auth
-                402 -> ProviderError BillingError (preview body) Nothing
-                429 -> ProviderError RateLimitError (preview body) retryAfterHeader
-                _ -> case classifyHttpFailure status body of
-                    HttpError 429 message ->
-                        ProviderError RateLimitError (preview message) retryAfterHeader
-                    other -> other
+    case openRouterEnvelope of
+        Just envelope
+            | isOpenRouterSpecificCode envelope.envelopeCode ->
+                fromOpenRouterEnvelope envelope
+        _ -> case decodeOpenAIError body of
+            Right (ProviderError errType message retryAfter) ->
+                ProviderError errType message (retryAfter `orElse` retryAfterHeader)
+            Right other -> other
+            Left _ -> case openRouterEnvelope of
+                Just envelope -> fromOpenRouterEnvelope envelope
+                Nothing -> case status of
+                    401 -> auth
+                    403 -> auth
+                    402 -> ProviderError BillingError (preview body) Nothing
+                    429 -> ProviderError RateLimitError (preview body) retryAfterHeader
+                    _ -> case classifyHttpFailure status body of
+                        HttpError 429 message ->
+                            ProviderError RateLimitError (preview message) retryAfterHeader
+                        other -> other
   where
+    openRouterEnvelope = decodeOpenRouterError body
     auth = ProviderError AuthenticationError (preview body) Nothing
+    fromOpenRouterEnvelope envelope =
+        ProviderError
+            (errorTypeFromOpenRouter status envelope.envelopeCode)
+            (nonEmptyMessage envelope.envelopeMessage body)
+            retryAfterHeader
 
 -- | Convert a typed Responses streaming error into the shared error channel.
 classifyStreamError :: ResponseStreamError -> ApiError
@@ -90,6 +96,21 @@ errorTypeFromOpenRouter status code = case Text.toLower <$> code of
         404 -> NotFoundError
         429 -> RateLimitError
         _ -> ApiErrorType
+
+isOpenRouterSpecificCode :: Maybe Text -> Bool
+isOpenRouterSpecificCode code =
+    (Text.toLower <$> code) `elem` map Just
+        [ "invalid_prompt"
+        , "invalid_request"
+        , "invalid_request_error"
+        , "authentication"
+        , "unauthorized"
+        , "forbidden"
+        , "rate_limit"
+        , "insufficient_credits"
+        , "payment_required"
+        , "billing_error"
+        ]
 
 nonEmptyMessage :: Text -> Text -> Text
 nonEmptyMessage message body

--- a/packages/agent-xai/src/Agent/XAI/Error.hs
+++ b/packages/agent-xai/src/Agent/XAI/Error.hs
@@ -3,6 +3,7 @@ module Agent.XAI.Error
     ( classifyFailure
     , classifyStreamError
     , isFreeLimitBody
+    , isUsageBalanceBody
     , isCapacityBody
     , capacityRetryAfterSeconds
     ) where
@@ -22,9 +23,11 @@ capacityRetryAfterSeconds = 30
 classifyFailure :: Int -> Maybe Int -> Text -> ApiError
 classifyFailure status retryAfterHeader body
     | status == 426 =
-        ProviderError InvalidRequestError
+        ProviderError ClientUpdateRequired
             ("xAI proxy rejected the client version: " <> Text.take 500 body)
             Nothing
+    | isUsageBalanceBody body =
+        ProviderError UsageBalanceExhausted (Text.take 500 body) retryAfterHeader
     | isFreeLimitBody body =
         ProviderError UsageLimitReached (Text.take 500 body) retryAfterHeader
     | isCapacityBody body =
@@ -43,12 +46,14 @@ classifyFailure status retryAfterHeader body
 -- | Convert a typed Responses streaming error into the shared error channel.
 classifyStreamError :: ResponseStreamError -> ApiError
 classifyStreamError streamError
+    | isUsageBalanceBody streamError.message =
+        ProviderError UsageBalanceExhausted streamError.message streamError.retryAfter
     | isFreeLimitBody streamError.message =
         ProviderError UsageLimitReached streamError.message streamError.retryAfter
     | isCapacityBody streamError.message =
         ProviderError OverloadedError streamError.message
             (streamError.retryAfter `orElse` Just capacityRetryAfterSeconds)
-    | Just errorType <- streamError.errorType =
+    | Just errorType <- streamError.errorType `orElse` streamError.code =
         mkOpenAIError
             (errorTypeFromText errorType)
             streamError.message
@@ -66,9 +71,14 @@ isFreeLimitBody :: Text -> Bool
 isFreeLimitBody body =
     "grok.com/supergrok" `Text.isInfixOf` lowered
         || "upgrade to a grok subscription" `Text.isInfixOf` lowered
-        || "grok build usage balance exhausted" `Text.isInfixOf` lowered
   where
     lowered = Text.toLower body
+
+-- | Grok's subscription proxy reports an exhausted metered balance as a
+-- flat HTTP 402 body instead of an OpenAI-shaped error object.
+isUsageBalanceBody :: Text -> Bool
+isUsageBalanceBody body =
+    "grok build usage balance exhausted" `Text.isInfixOf` Text.toLower body
 
 -- | Detect capacity / priority-processing pressure from unstructured xAI
 -- stream and HTTP bodies. These are short-lived overloads, not quota caps.

--- a/packages/agent-xai/src/Agent/XAI/Stream.hs
+++ b/packages/agent-xai/src/Agent/XAI/Stream.hs
@@ -4,7 +4,8 @@ module Agent.XAI.Stream
     , buildResponse
     ) where
 
-import Agent.Error (ApiError(..))
+import Agent.Error (ApiError(..), errorTypeFromText)
+import Agent.OpenAI.Error (mkOpenAIError)
 import Agent.OpenAI.ResponseMerge (mergeCompletedResponseOutput)
 import qualified Agent.OpenAI.Responses.Codec as ResponsesCodec
 import Agent.OpenAI.Responses.Types
@@ -94,8 +95,18 @@ firstFailure = Maybe.listToMaybe . Maybe.mapMaybe failure
     failure = \case
         ResponseErrorEvent { streamError } -> Just (classifyStreamError streamError)
         ResponseNestedErrorEvent { streamError } -> Just (classifyStreamError streamError)
-        ResponseFailedEvent { response } -> Just (ConnectionError (failedResponseMessage response))
+        ResponseFailedEvent { response } -> Just (failedResponseError response)
         _ -> Nothing
+
+failedResponseError :: Response -> ApiError
+failedResponseError response = case response.error of
+    Just responseError ->
+        mkOpenAIError
+            (errorTypeFromText responseError.code)
+            responseError.message
+            (Just responseError.code)
+            Nothing
+    Nothing -> ConnectionError (failedResponseMessage response)
 
 failedResponseMessage :: Response -> Text
 failedResponseMessage response = case response.error of

--- a/packages/agent-xai/test/Agent/XAI/ResponsesSpec.hs
+++ b/packages/agent-xai/test/Agent/XAI/ResponsesSpec.hs
@@ -1,6 +1,11 @@
 module Agent.XAI.ResponsesSpec (spec) where
 
-import Agent.Error (ApiError(..), ErrorType(..))
+import Agent.Error
+    ( ApiError(..)
+    , ErrorType(..)
+    , RetryDisposition(..)
+    , retryDisposition
+    )
 import Agent.XAI.Error
 import Agent.XAI.Options
 import Agent.XAI.Request
@@ -130,7 +135,16 @@ spec = do
         it "recognises an exhausted Grok Build usage balance" do
             let body = "{\"error\":\"Grok Build usage balance exhausted\"}"
             classifyFailure 402 Nothing body
-                `shouldBe` ProviderError UsageLimitReached body Nothing
+                `shouldBe` ProviderError UsageBalanceExhausted body Nothing
+            retryDisposition (classifyFailure 402 (Just 3600) body)
+                `shouldBe` RetryAfterLimitReset
+
+        it "types Grok's flat invalid-image envelope" do
+            classifyFailure 400 Nothing
+                "{\"code\":\"invalid_image\",\"error\":\"Invalid PNG image.\"}"
+                `shouldBe` ProviderError InvalidImageError
+                    "Invalid PNG image. (code: invalid_image)"
+                    Nothing
 
         it "leaves other statuses as plain HTTP errors" do
             classifyFailure 503 Nothing "unavailable"
@@ -148,6 +162,20 @@ spec = do
                 `shouldBe` ProviderError OverloadedError body (Just 12)
 
     describe "classifyStreamError" do
+        it "uses a code-only stream error as the typed discriminator" do
+            let streamError = ResponseStreamError
+                    { errorType = Nothing
+                    , code = Just "context_length_exceeded"
+                    , message = "prompt is too long"
+                    , param = Nothing
+                    , retryAfter = Nothing
+                    , extraFields = mempty
+                    }
+            classifyStreamError streamError
+                `shouldBe` ProviderError ContextWindowExceeded
+                    "prompt is too long (code: context_length_exceeded)"
+                    Nothing
+
         it "types unstructured capacity stream errors as OverloadedError" do
             let message =
                     "The model is currently at capacity due to high demand. \


### PR DESCRIPTION
## Summary

- expand the shared provider error enum with the semantic Grok/Codex transport failures currently used upstream
- add tolerant parsing for nested, flat, detail-only, HTTP, SSE, WebSocket, and `response.failed` error shapes
- classify Grok Build balance exhaustion separately and route it through reset-aware credential cooldown/failover
- preserve unknown future provider discriminators while parsing retry/reset metadata when available

## Tests

- agent-core: 132 examples, 0 failures
- agent-openai: 127 examples, 0 failures, 1 live credential test pending
- agent-xai: 40 examples, 0 failures, 1 live credential test pending
