### PR TITLE
fix(openrouter): stream response events incrementally

### DIFF
--- a/packages/agent-openrouter/README.md
+++ b/packages/agent-openrouter/README.md
@@ -6,7 +6,8 @@ OpenRouter transport package for the agent harness.
   OpenAI-compatible Responses dialect while keeping the request typed.
 - Forces `store = false` and omits `previous_response_id` — OpenRouter's
   Responses API is stateless and rejects server-side transcripts.
-- Decodes SSE into the canonical typed `ResponseStreamEvent` union and
+- Decodes SSE incrementally into the canonical typed `ResponseStreamEvent`
+  union, delivers callbacks while the response is still arriving, and
   assembles the terminal `Response`.
 - Authenticates with a static OpenRouter API key.
 

--- a/packages/agent-openrouter/agent-openrouter.cabal
+++ b/packages/agent-openrouter/agent-openrouter.cabal
@@ -48,6 +48,7 @@ library
                     , bytestring
                     , aeson                 >= 2.0
                     , http-client
+                    , http-client-tls
                     , http-conduit
                     , http-types
                     , safe-exceptions

--- a/packages/agent-openrouter/package.nix
+++ b/packages/agent-openrouter/package.nix
@@ -1,5 +1,5 @@
 { mkDerivation, aeson, agent-core, agent-openai, base, bytestring
-, case-insensitive, hspec, http-client, http-conduit, http-types
+, case-insensitive, hspec, http-client, http-client-tls, http-conduit, http-types
 , lib, safe-exceptions, text, time, wai, warp
 }:
 mkDerivation {
@@ -7,7 +7,7 @@ mkDerivation {
   version = "0.1.0.0";
   src = ./.;
   libraryHaskellDepends = [
-    aeson agent-core agent-openai base bytestring http-client
+    aeson agent-core agent-openai base bytestring http-client http-client-tls
     http-conduit http-types safe-exceptions text time
   ];
   testHaskellDepends = [

--- a/packages/agent-openrouter/src/Agent/OpenRouter/Client.hs
+++ b/packages/agent-openrouter/src/Agent/OpenRouter/Client.hs
@@ -13,9 +13,15 @@ import Agent.Provider (Credential(..), Provider(..))
 import Agent.OpenRouter.Error (classifyFailure)
 import Agent.OpenRouter.Options
 import Agent.OpenRouter.Request (buildRequest)
-import Agent.OpenRouter.Stream (buildResponse, parseSseEvents)
+import Agent.OpenRouter.Stream
+    ( buildResponse
+    , feedSseDecoder
+    , finishSseDecoder
+    , newSseDecoder
+    )
 import Control.Exception.Safe (tryAny)
 import qualified Data.Aeson as Aeson
+import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BS8
 import qualified Data.ByteString.Lazy as LBS
 import Data.Text (Text)
@@ -23,6 +29,7 @@ import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import qualified Data.Text.Encoding.Error as Text (lenientDecode)
 import qualified Network.HTTP.Client as HttpClient
+import qualified Network.HTTP.Client.TLS as HttpTls
 import Network.HTTP.Simple hiding (Response)
 import Network.HTTP.Types (HeaderName)
 
@@ -43,9 +50,8 @@ createResponseWith
 createResponseWith options credential request =
     createResponseWithEvents options credential request (const (pure ()))
 
--- | Send one request and deliver every decoded typed Responses event before
--- returning the assembled terminal response. The current HTTP backend buffers
--- the response body, so callbacks run in wire order after the body completes.
+-- | Send one request and deliver decoded typed Responses events incrementally
+-- in wire order before returning the assembled terminal response.
 createResponseWithEvents
     :: ClientOptions
     -> Credential
@@ -59,12 +65,13 @@ createResponseWithEvents options credential request onEvent
     | otherwise = tryAny performRequest >>= \case
         Left exception -> pure $ Left $ ConnectionError
             ("OpenRouter request failed: " <> Text.pack (show exception))
-        Right response -> handleResponse response
+        Right result -> pure result
   where
     performRequest = do
         httpRequest <- parseRequest ("POST " <> trimTrailingSlash options.baseUrl <> "/responses")
-        httpLBS
-            $ setRequestBodyLBS (Aeson.encode (buildRequest options request))
+        manager <- HttpTls.getGlobalManager
+        HttpClient.withResponse
+            ( setRequestBodyLBS (Aeson.encode (buildRequest options request))
             $ setRequestHeader "Authorization"
                 ["Bearer " <> Text.encodeUtf8 credential.accessToken]
             $ setRequestHeader "Content-Type" ["application/json"]
@@ -73,6 +80,9 @@ createResponseWithEvents options credential request onEvent
             $ optionalHeader "HTTP-Referer" options.httpReferer
             $ optionalHeader "X-Title" options.appTitle
             $ withTimeout httpRequest
+            )
+            manager
+            handleResponse
 
     withTimeout httpRequest = httpRequest
         { HttpClient.responseTimeout =
@@ -81,15 +91,48 @@ createResponseWithEvents options credential request onEvent
 
     handleResponse response = do
         let status = getResponseStatusCode response
-            bodyText = Text.decodeUtf8With Text.lenientDecode
-                (LBS.toStrict (getResponseBody response))
         if status >= 200 && status < 300
-            then case parseSseEvents bodyText of
-                Left err -> pure (Left err)
-                Right events -> do
-                    mapM_ onEvent events
-                    pure (buildResponse events)
-            else pure $ Left $ classifyFailure status (retryAfterSeconds response) bodyText
+            then consumeSse (HttpClient.responseBody response)
+            else do
+                body <- consumeBody (HttpClient.responseBody response)
+                let bodyText = Text.decodeUtf8With Text.lenientDecode
+                        (LBS.toStrict body)
+                pure $ Left $
+                    classifyFailure status (retryAfterSeconds response) bodyText
+
+    consumeSse body = go newSseDecoder []
+      where
+        go decoder reversedEvents = do
+            chunk <- HttpClient.brRead body
+            if BS.null chunk
+                then case finishSseDecoder decoder of
+                    Left err -> pure (Left err)
+                    Right trailing -> do
+                        mapM_ onEvent trailing
+                        pure $ buildResponse
+                            (reverse reversedEvents <> trailing)
+                else case feedSseDecoder decoder chunk of
+                    Left err -> pure (Left err)
+                    Right (nextDecoder, events) -> do
+                        mapM_ onEvent events
+                        let retained = filter retainForResponse events
+                        go nextDecoder (reverse retained <> reversedEvents)
+
+    consumeBody body = LBS.fromChunks <$> readChunks []
+      where
+        readChunks reversedChunks = do
+            chunk <- HttpClient.brRead body
+            if BS.null chunk
+                then pure (reverse reversedChunks)
+                else readChunks (chunk : reversedChunks)
+
+    retainForResponse = \case
+        ResponseOutputItemDoneEvent {} -> True
+        ResponseCompletedEvent {} -> True
+        ResponseErrorEvent {} -> True
+        ResponseNestedErrorEvent {} -> True
+        ResponseFailedEvent {} -> True
+        _ -> False
 
     retryAfterSeconds response = case getResponseHeader "Retry-After" response of
         (value : _) -> case reads (BS8.unpack value) of

--- a/packages/agent-openrouter/src/Agent/OpenRouter/Stream.hs
+++ b/packages/agent-openrouter/src/Agent/OpenRouter/Stream.hs
@@ -1,6 +1,10 @@
 -- | Typed decoding and terminal-response assembly for OpenRouter Responses SSE.
 module Agent.OpenRouter.Stream
-    ( parseSseEvents
+    ( SseDecoder
+    , newSseDecoder
+    , feedSseDecoder
+    , finishSseDecoder
+    , parseSseEvents
     , buildResponse
     ) where
 
@@ -10,54 +14,125 @@ import qualified Agent.OpenAI.Responses.Codec as ResponsesCodec
 import Agent.OpenAI.Responses.Types
 import Agent.OpenRouter.Error (classifyStreamError)
 import qualified Data.Aeson as Aeson
+import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Maybe as Maybe
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import qualified Data.Text.Encoding.Error as Text (lenientDecode)
+import Data.Word (Word8)
 
--- | Decode an SSE body into the canonical typed Responses event union.
--- The discriminator may be supplied by the SSE @event:@ line, by the JSON
--- @type@ member, or by both when they agree.
-parseSseEvents :: Text -> Either ApiError [ResponseStreamEvent]
-parseSseEvents sseText = Maybe.catMaybes <$> traverse parseBlock blocks
+-- | Incremental SSE decoder. Only bytes belonging to the current incomplete
+-- event block are retained between HTTP chunks.
+newtype SseDecoder = SseDecoder BS.ByteString
+
+newSseDecoder :: SseDecoder
+newSseDecoder = SseDecoder BS.empty
+
+-- | Feed an arbitrary HTTP body chunk. Completed events are returned in wire
+-- order as soon as their terminating blank line arrives.
+feedSseDecoder
+    :: SseDecoder
+    -> BS.ByteString
+    -> Either ApiError (SseDecoder, [ResponseStreamEvent])
+feedSseDecoder (SseDecoder buffered) chunk =
+    decodeAvailable [] (buffered <> chunk)
   where
-    normalized = Text.replace "\r\n" "\n" sseText
-    blocks = filter (not . Text.null . Text.strip) (Text.splitOn "\n\n" normalized)
+    decodeAvailable events bytes = case takeBlock bytes of
+        Nothing -> Right (SseDecoder bytes, reverse events)
+        Just (block, rest) -> do
+            decoded <- parseBlockBytes block
+            decodeAvailable (maybe events (: events) decoded) rest
 
-    parseBlock block
-        | Text.null dataText = Right Nothing
-        | Text.strip dataText == "[DONE]" = Right Nothing
-        | otherwise = Just <$> decodeEvent eventType dataText
-      where
-        blockLines = Text.lines block
-        eventType = Maybe.listToMaybe
-            [ Text.strip (Text.drop 6 line)
-            | line <- blockLines
-            , "event:" `Text.isPrefixOf` line
-            ]
-        dataText = Text.intercalate "\n"
-            [ Text.strip (Text.drop 5 line)
-            | line <- blockLines
-            , "data:" `Text.isPrefixOf` line
-            ]
+-- | Finish an SSE stream, accepting a final event without a trailing blank
+-- line.
+finishSseDecoder :: SseDecoder -> Either ApiError [ResponseStreamEvent]
+finishSseDecoder (SseDecoder buffered)
+    | BS.null (BS.dropWhile isSseWhitespace buffered) = Right []
+    | otherwise = maybe [] pure <$> parseBlockBytes buffered
 
-    decodeEvent eventType dataText = do
-        value <- case Aeson.eitherDecodeStrict' (Text.encodeUtf8 dataText) of
-            Left err -> Left (decodeError (Text.pack err) dataText)
-            Right value -> Right value
-        let decoded = case eventType of
-                Just suppliedType ->
-                    ResponsesCodec.decodeResponseStreamEventWithType suppliedType value
-                Nothing -> case ResponsesCodec.decodeResponseStreamEventValue value of
-                    Aeson.Success event -> Right event
-                    Aeson.Error err -> Left err
-        case decoded of
-            Left err -> Left (decodeError (Text.pack err) dataText)
-            Right event -> Right event
+-- | Decode a complete SSE body into the canonical typed Responses event union.
+parseSseEvents :: Text -> Either ApiError [ResponseStreamEvent]
+parseSseEvents sseText = do
+    (decoder, events) <- feedSseDecoder newSseDecoder (Text.encodeUtf8 sseText)
+    trailing <- finishSseDecoder decoder
+    pure (events <> trailing)
 
+parseBlockBytes :: BS.ByteString -> Either ApiError (Maybe ResponseStreamEvent)
+parseBlockBytes bytes = case Text.decodeUtf8' bytes of
+    Left err -> Left $ JsonDecodeError
+        ("Invalid UTF-8 in OpenRouter SSE event: " <> Text.pack (show err))
+        (Text.take 2000 (Text.decodeUtf8With Text.lenientDecode bytes))
+    Right block -> parseBlock (Text.replace "\r\n" "\n" block)
+
+parseBlock :: Text -> Either ApiError (Maybe ResponseStreamEvent)
+parseBlock block
+    | Text.null dataText = Right Nothing
+    | Text.strip dataText == "[DONE]" = Right Nothing
+    | otherwise = Just <$> decodeEvent eventType dataText
+  where
+    blockLines = Text.lines block
+    eventType = Maybe.listToMaybe
+        [ Text.strip (Text.drop 6 line)
+        | line <- blockLines
+        , "event:" `Text.isPrefixOf` line
+        ]
+    dataText = Text.intercalate "\n"
+        [ stripOptionalSpace (Text.drop 5 line)
+        | line <- blockLines
+        , "data:" `Text.isPrefixOf` line
+        ]
+
+    stripOptionalSpace line = Maybe.fromMaybe line (Text.stripPrefix " " line)
+
+decodeEvent :: Maybe Text -> Text -> Either ApiError ResponseStreamEvent
+decodeEvent eventType dataText = do
+    value <- case Aeson.eitherDecodeStrict' (Text.encodeUtf8 dataText) of
+        Left err -> Left (decodeError (Text.pack err) dataText)
+        Right value -> Right value
+    let decoded = case eventType of
+            Just suppliedType ->
+                ResponsesCodec.decodeResponseStreamEventWithType suppliedType value
+            Nothing -> case ResponsesCodec.decodeResponseStreamEventValue value of
+                Aeson.Success event -> Right event
+                Aeson.Error err -> Left err
+    case decoded of
+        Left err -> Left (decodeError (Text.pack err) dataText)
+        Right event -> Right event
+  where
     decodeError message body = JsonDecodeError message (Text.take 2000 body)
+
+takeBlock :: BS.ByteString -> Maybe (BS.ByteString, BS.ByteString)
+takeBlock bytes = do
+    (offset, delimiterLength) <- earliestDelimiter bytes
+    pure
+        ( BS.take offset bytes
+        , BS.drop (offset + delimiterLength) bytes
+        )
+
+earliestDelimiter :: BS.ByteString -> Maybe (Int, Int)
+earliestDelimiter bytes = case
+    ( findSubstring "\n\n" bytes
+    , findSubstring "\r\n\r\n" bytes
+    ) of
+        (Nothing, Nothing) -> Nothing
+        (Just offset, Nothing) -> Just (offset, 2)
+        (Nothing, Just offset) -> Just (offset, 4)
+        (Just lfOffset, Just crlfOffset)
+            | lfOffset <= crlfOffset -> Just (lfOffset, 2)
+            | otherwise -> Just (crlfOffset, 4)
+
+findSubstring :: BS.ByteString -> BS.ByteString -> Maybe Int
+findSubstring needle haystack
+    | BS.null needle = Just 0
+    | otherwise =
+        let (prefix, suffix) = BS.breakSubstring needle haystack
+        in if BS.null suffix then Nothing else Just (BS.length prefix)
+
+isSseWhitespace :: Word8 -> Bool
+isSseWhitespace byte =
+    byte == 0x20 || byte == 0x09 || byte == 0x0a || byte == 0x0d
 
 -- | Merge streamed output-item events into the terminal completed response.
 buildResponse :: [ResponseStreamEvent] -> Either ApiError Response

--- a/packages/agent-openrouter/test/Agent/OpenRouter/ClientSpec.hs
+++ b/packages/agent-openrouter/test/Agent/OpenRouter/ClientSpec.hs
@@ -6,7 +6,10 @@ import Agent.OpenRouter.Client
 import Agent.OpenRouter.Options
 import Agent.Provider (Credential(..), Provider(..))
 import Agent.OpenAI.Responses.Types
+import Control.Concurrent.MVar
+import Control.Monad (when)
 import qualified Data.Aeson as Aeson
+import qualified Data.ByteString.Builder as Builder
 import qualified Data.Aeson.KeyMap as KeyMap
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.CaseInsensitive as CI
@@ -17,6 +20,7 @@ import qualified Data.Text.Encoding as Text
 import qualified Network.HTTP.Types as HTTP
 import qualified Network.Wai as Wai
 import qualified Network.Wai.Handler.Warp as Warp
+import System.Timeout (timeout)
 import Test.Hspec
 
 spec :: Spec
@@ -45,6 +49,21 @@ spec = do
             requestModel request `shouldBe` Just "openai/gpt-5.1"
             (instructionsOf <$> requestBodyObject request)
                 `shouldBe` Just (Just "You are a test agent.")
+
+        it "streams callbacks before the response completes" do
+            recorded <- newIORef []
+            callbackSeen <- newEmptyMVar
+            serverSawCallback <- newIORef False
+            let handler _ = pure $
+                    streamingResponse callbackSeen serverSawCallback
+            withMockOpenRouter recorded handler \options -> do
+                result <- createResponseWithEvents options
+                    (openRouterCredential "token-a")
+                    (helloRequest "hi")
+                    (recordOutputItem callbackSeen)
+                response <- expectRight result
+                response.responseId `shouldBe` "resp-stream"
+            readIORef serverSawCallback `shouldReturn` True
 
         it "rejects a non-OpenRouter credential before contacting the host" do
             recorded <- newIORef []
@@ -239,3 +258,24 @@ expectRight :: Show e => Either e a -> IO a
 expectRight = \case
     Left err -> expectationFailure ("expected Right, got Left " <> show err) >> fail "unreachable"
     Right value -> pure value
+
+recordOutputItem :: MVar () -> ResponseStreamEvent -> IO ()
+recordOutputItem callbackSeen event =
+    when (responseStreamEventType event == EventOutputItemDone) do
+        tryPutMVar callbackSeen ()
+        pure ()
+
+streamingResponse :: MVar () -> IORef Bool -> Wai.Response
+streamingResponse callbackSeen serverSawCallback =
+    Wai.responseStream HTTP.status200
+        [("Content-Type", "text/event-stream")]
+        \write flush -> do
+            writeSse write (outputItemDone (assistantMessage "hello"))
+            flush
+            seen <- timeout 2_000_000 (readMVar callbackSeen)
+            writeIORef serverSawCallback (maybe False (const True) seen)
+            writeSse write (completedEvent "resp-stream" [])
+            flush
+
+writeSse :: (Builder.Builder -> IO ()) -> Text -> IO ()
+writeSse write = write . Builder.byteString . Text.encodeUtf8

--- a/packages/agent-openrouter/test/Agent/OpenRouter/RequestSpec.hs
+++ b/packages/agent-openrouter/test/Agent/OpenRouter/RequestSpec.hs
@@ -8,9 +8,11 @@ import Agent.OpenRouter.Stream
 import qualified Data.Aeson as Aeson
 import Data.Aeson ((.=))
 import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString as BS
 import qualified Data.Maybe as Maybe
 import Data.Text (Text)
 import qualified Data.Text as Text
+import qualified Data.Text.Encoding as TextEncoding
 import Test.Hspec
 
 spec :: Spec
@@ -95,6 +97,13 @@ spec = do
                 "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp-2\",\"created_at\":0,\"model\":\"openai/gpt-5.1\",\"status\":\"completed\"}}\n\n"
             map responseStreamEventType events `shouldBe` [EventResponseCompleted]
 
+        it "accepts a final event without a trailing blank line" do
+            events <- expectRight $ parseSseEvents finalEventWithoutBlankLine
+            map responseStreamEventType events `shouldBe` [EventResponseCompleted]
+
+        it "decodes arbitrary HTTP chunk boundaries" do
+            mapM_ checkSplit [0 .. BS.length splitBytes]
+
         it "maps response.failed and missing completion to transport-level errors" do
             failedEvents <- expectRight $ parseSseEvents $ sseBlock "response.failed"
                 "{\"type\":\"response.failed\",\"response\":{\"id\":\"resp-f\",\"created_at\":0,\"model\":\"openai/gpt-5.1\",\"status\":\"failed\",\"incomplete_details\":{\"reason\":\"overloaded\"}}}"
@@ -174,3 +183,32 @@ expectRight :: Show e => Either e a -> IO a
 expectRight = \case
     Left err -> expectationFailure ("expected Right, got Left " <> show err) >> fail "unreachable"
     Right value -> pure value
+
+finalEventWithoutBlankLine :: Text
+finalEventWithoutBlankLine = Text.dropEnd 2 completedBlock
+
+completedBlock :: Text
+completedBlock = sseBlock "response.completed" completedJson
+
+completedJson :: Text
+completedJson = "{\"type\":\"response.completed\",\"response\":{\"id\":\"resp-final\",\"created_at\":0,\"model\":\"openai/gpt-5.1\",\"status\":\"completed\"}}"
+
+splitBytes :: BS.ByteString
+splitBytes = TextEncoding.encodeUtf8 (itemBlock <> completedBlock)
+
+itemBlock :: Text
+itemBlock = sseBlock "response.output_item.done" itemJson
+
+itemJson :: Text
+itemJson = "{\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"héllo\"}]}}"
+
+checkSplit :: Int -> IO ()
+checkSplit offset = do
+    let (first, second) = BS.splitAt offset splitBytes
+    (decoder, firstEvents) <- expectRight
+        (feedSseDecoder newSseDecoder first)
+    (finalDecoder, secondEvents) <- expectRight
+        (feedSseDecoder decoder second)
+    trailing <- expectRight (finishSseDecoder finalDecoder)
+    map responseStreamEventType (firstEvents <> secondEvents <> trailing)
+        `shouldBe` [EventOutputItemDone, EventResponseCompleted]


### PR DESCRIPTION
## Summary

- replace the buffered OpenRouter `httpLBS` request path with incremental `BodyReader` consumption
- add a chunk-safe SSE decoder that handles arbitrary HTTP boundaries, split UTF-8, CRLF/LF delimiters, and a final unterminated event
- deliver typed stream callbacks while the response is still arriving and retain only events needed for terminal response assembly
- add callback-timing and exhaustive chunk-boundary coverage
- update package dependencies and transport documentation

## Verification

- `nix develop -c cabal repl agent-openrouter:test:agent-openrouter-test`
  - 31 examples, 0 failures, 1 pending live test when no key is configured
- live tmux smoke test with OpenRouter `stealth/ox-alpha`
  - first visible output at approximately 5.8 seconds
  - response completed at approximately 35.6 seconds
  - captured a partial frame before the terminal event, confirming end-to-end incremental rendering
