### PR TITLE
Align Grok subagents with Grok Build

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -152,9 +152,11 @@ import Agent.Subagents
     , formatCompletionNotice
     , getPreviousResponseId
     , getStatus
+    , getSubagentCwd
     , getTaskPath
     , newSubagentRegistry
     , restoreSubagent
+    , restoreSubagentWithCwd
     , setSubagentOnComplete
     , setSubagentRunner
     )
@@ -165,7 +167,14 @@ import Agent.Tools
     , codingToolsForWithTypes
     , filterChildGrokTools
     )
-import Agent.Tools.Grok.Task (defaultSubagentType, lookupAgentType, recordAgentType)
+import Agent.Tools.Grok.Task
+    ( GrokSubagentSpec(..)
+    , GrokSubagentSpecs
+    , defaultSubagentType
+    , lookupAgentModel
+    , lookupAgentType
+    , recordAgentSpec
+    )
 import Agent.Subagents.TaskPath (taskPathRoot)
 import Agent.Tools.MultiAgents (MultiAgentContext(..))
 import Agent.Tools.PlanMode
@@ -439,6 +448,10 @@ runAgent options transition = do
             , multiTaskPath = taskPathRoot
             , multiResumeFromDisk = Just
                 (restoreAgentFromDisk subagentStoreRoot registry subagentSessions agentTypesRef)
+            , multiCreateWorktree = Just \source ->
+                createWorktree source (worktreeRoot home) >>= \case
+                    Left err -> pure (Left (Text.pack err))
+                    Right path -> pure (Right path)
             }
     coding <- codingToolsForWithTypes provider toolEnv (Just planHooks) multiCtx agentTypesRef
     case multiCtx of
@@ -1782,7 +1795,7 @@ syncStoreRootFromPlan storeRootRef planMode = do
 persistSubagentSnapshot
     :: SubagentStoreRoot
     -> SubagentRegistry
-    -> IORef (Map SubagentId Text)
+    -> GrokSubagentSpecs
     -> SubagentId
     -> IORef [ResponseItem]
     -> IO ()
@@ -1794,14 +1807,17 @@ persistSubagentSnapshot storeRootRef registry typesRef agentId transcriptRef = d
             items <- readIORef transcriptRef
             previous <- getPreviousResponseId registry agentId
             agentType <- lookupAgentType typesRef agentId
-            _ <- saveSubagentState sessionDir agentId items previous agentType
+            agentModel <- lookupAgentModel typesRef agentId
+            agentCwd <- getSubagentCwd registry agentId
+            _ <- saveSubagentState
+                sessionDir agentId items previous agentType agentModel agentCwd
             pure ()
 
 flushAllSubagentSnapshots
     :: SubagentStoreRoot
     -> SubagentRegistry
     -> IORef (Map SubagentId SubagentSession)
-    -> IORef (Map SubagentId Text)
+    -> GrokSubagentSpecs
     -> IO ()
 flushAllSubagentSnapshots storeRootRef registry sessionsRef typesRef = do
     sessions <- readIORef sessionsRef
@@ -1817,7 +1833,7 @@ restoreAgentFromDisk
     :: SubagentStoreRoot
     -> SubagentRegistry
     -> IORef (Map SubagentId SubagentSession)
-    -> IORef (Map SubagentId Text)
+    -> GrokSubagentSpecs
     -> SubagentId
     -> IO (Either Text ())
 restoreAgentFromDisk storeRootRef registry sessionsRef typesRef agentId = do
@@ -1837,15 +1853,18 @@ restoreAgentFromDisk storeRootRef registry sessionsRef typesRef agentId = do
                     Left err -> pure (Left err)
                     Right Nothing ->
                         -- Same-process close with no disk yet: still reopen.
-                        reopenInMemory Nothing
+                        reopenInMemory Nothing Nothing
                     Right (Just (items, meta)) -> do
-                        result <- reopenInMemory meta.diskPreviousResponseId
+                        result <- reopenInMemory meta.diskPreviousResponseId meta.diskCwd
                         case result of
                             Left err -> pure (Left err)
                             Right () -> do
                                 case meta.diskAgentType of
                                     Just agentType ->
-                                        recordAgentType typesRef agentId agentType
+                                        recordAgentSpec typesRef agentId GrokSubagentSpec
+                                            { agentType
+                                            , modelOverride = meta.diskAgentModel
+                                            }
                                     Nothing -> pure ()
                                 transcript <- newIORef items
                                 let session =
@@ -1855,8 +1874,13 @@ restoreAgentFromDisk storeRootRef registry sessionsRef typesRef agentId = do
                                 atomicModifyIORef' sessionsRef \m ->
                                     (Map.insert agentId session m, ())
                                 pure (Right ())
-    reopenInMemory previous = do
-        restored <- restoreSubagent registry agentId Nothing 1 Nothing previous
+    reopenInMemory previous requestedCwd = do
+        restored <- case requestedCwd of
+            Just childCwd ->
+                restoreSubagentWithCwd
+                    registry childCwd agentId Nothing 1 Nothing previous
+            Nothing ->
+                restoreSubagent registry agentId Nothing 1 Nothing previous
         pure $ case restored of
             Left err -> Left err
             Right _ -> Right ()
@@ -1900,7 +1924,7 @@ runCodexSubagent
     -> SubagentRegistry
     -> IORef (Map SubagentId SubagentSession)
     -> SubagentStoreRoot
-    -> IORef (Map SubagentId Text)
+    -> GrokSubagentSpecs
     -> RunSubagent
 runCodexSubagent options policy planHooks paramsRef wsLock tokenProvider connectionHealthy conn registry sessionsRef storeRootRef typesRef =
     \env previous prompt onEvent -> do
@@ -1915,6 +1939,7 @@ runCodexSubagent options policy planHooks paramsRef wsLock tokenProvider connect
                 , multiDepth = env.subDepth
                 , multiTaskPath = childPath
                 , multiResumeFromDisk = Nothing
+                , multiCreateWorktree = Nothing
                 }
         -- Child tools create their own PlanModeEnv; sync store root from parent
         -- params is handled by noteSessionDir on the parent path. If the parent
@@ -1970,7 +1995,7 @@ runHttpSubagent
     -> (IORef ResponseCreateParams -> IORef [ResponseItem] -> Backend)
     -> SubagentRegistry
     -> IORef (Map SubagentId SubagentSession)
-    -> IORef (Map SubagentId Text)
+    -> GrokSubagentSpecs
     -> SubagentStoreRoot
     -> RunSubagent
 runHttpSubagent options policy planHooks paramsRef provider mkBackend registry sessionsRef typesRef storeRootRef =
@@ -1985,20 +2010,21 @@ runHttpSubagent options policy planHooks paramsRef provider mkBackend registry s
                 , multiDepth = env.subDepth
                 , multiTaskPath = childPath
                 , multiResumeFromDisk = Nothing
+                , multiCreateWorktree = Nothing
                 }
         session <- lookupOrCreateSubagentSession sessionsRef storeRootRef typesRef env.subId
         agentType <- fromMaybe defaultSubagentType <$> lookupAgentType typesRef env.subId
+        childModel <- lookupAgentModel typesRef env.subId
         coding <- codingToolsFor provider childToolEnv (Just planHooks) (Just childCtx)
         flip finally coding.codingClose do
             today <- utctDay <$> getCurrentTime
-            let model = fromMaybe (defaultModelFor provider) parentParams.model
+            let model = fromMaybe
+                    (fromMaybe (defaultModelFor provider) parentParams.model)
+                    childModel
                 effort = case parentParams.reasoning of
                     Just cfg -> fromMaybe (defaultEffortFor provider) cfg.effort
                     Nothing -> defaultEffortFor provider
-                baseInstructions =
-                    fromMaybe
-                        (systemPrompt provider env.subCwd today True)
-                        parentParams.instructions
+                baseInstructions = systemPrompt provider env.subCwd today True
                 instructions =
                     baseInstructions
                         <> "\n\n"
@@ -2026,26 +2052,31 @@ runHttpSubagent options policy planHooks paramsRef provider mkBackend registry s
 
 grokSubagentSuffix :: Text -> SubagentId -> Text
 grokSubagentSuffix agentType agentId =
-    "You are a Grok Build subagent (type: "
+    "You are a Grok Build subagent — a focused worker delegated a specific task.\n\
+    \Complete the assigned task directly and efficiently. Do not broaden scope beyond what was asked. \
+    \Report blocked or unverified work explicitly.\n\n\
+    \Subagent type: "
         <> agentType
-        <> "). Your agent id is "
+        <> "\nAgent id: "
         <> agentId.unSubagentId
-        <> ". Complete the assigned task directly and report results clearly."
         <> case agentType of
             "explore" ->
                 "\n\n=== READ-ONLY MODE ===\n\
-                \Do not create, modify, or delete files. Use run_terminal_cmd only \
-                \for read-only commands (ls, git status, git log, git diff, find, cat, head, tail)."
+                \You have no file editing or command execution tools. Search broadly, narrow down, \
+                \and return absolute file paths and relevant findings."
             "plan" ->
                 "\n\n=== READ-ONLY MODE ===\n\
-                \Do not create, modify, or delete files except plan.md while in plan mode. \
-                \Use run_terminal_cmd only for read-only commands."
-            _ -> ""
+                \Do not create, modify, or delete implementation files. Explore the codebase, \
+                \consider trade-offs, and produce a concrete implementation strategy. End with \
+                \a Critical Files for Implementation section listing 3-5 files."
+            _ ->
+                "\n\nStart broad and narrow down. Check multiple locations and naming conventions. \
+                \Never create documentation files unless explicitly requested."
 
 lookupOrCreateSubagentSession
     :: IORef (Map SubagentId SubagentSession)
     -> SubagentStoreRoot
-    -> IORef (Map SubagentId Text)
+    -> GrokSubagentSpecs
     -> SubagentId
     -> IO SubagentSession
 lookupOrCreateSubagentSession sessionsRef storeRootRef typesRef agentId = do
@@ -2063,8 +2094,10 @@ lookupOrCreateSubagentSession sessionsRef storeRootRef typesRef agentId = do
             transcript <- newIORef items
             case meta >>= (.diskAgentType) of
                 Just agentType ->
-                    atomicModifyIORef' typesRef \m ->
-                        (Map.insertWith (\_ new -> new) agentId agentType m, ())
+                    recordAgentSpec typesRef agentId GrokSubagentSpec
+                        { agentType
+                        , modelOverride = meta >>= (.diskAgentModel)
+                        }
                 Nothing -> pure ()
             let session = SubagentSession { subSessionTranscript = transcript }
             atomicModifyIORef' sessionsRef \m -> (Map.insert agentId session m, ())

--- a/packages/agent-cli/src/Agent/CLI/SubagentStore.hs
+++ b/packages/agent-cli/src/Agent/CLI/SubagentStore.hs
@@ -34,12 +34,16 @@ import System.Posix.Files (setFileMode)
 data SubagentDiskMeta = SubagentDiskMeta
     { diskPreviousResponseId :: !(Maybe Text)
     , diskAgentType :: !(Maybe Text)
+    , diskAgentModel :: !(Maybe Text)
+    , diskCwd :: !(Maybe FilePath)
     } deriving (Eq, Show)
 
 instance ToJSON SubagentDiskMeta where
     toJSON meta = object
         [ "previousResponseId" .= meta.diskPreviousResponseId
         , "agentType" .= meta.diskAgentType
+        , "agentModel" .= meta.diskAgentModel
+        , "cwd" .= meta.diskCwd
         ]
 
 instance FromJSON SubagentDiskMeta where
@@ -47,6 +51,8 @@ instance FromJSON SubagentDiskMeta where
         SubagentDiskMeta
             <$> o .:? "previousResponseId"
             <*> o .:? "agentType"
+            <*> o .:? "agentModel"
+            <*> o .:? "cwd"
 
 -- | Generated ids look like @agent-<hex>-<n>@. Reject path separators and
 -- traversal so resume paths cannot escape @agents/@.
@@ -74,8 +80,10 @@ saveSubagentState
     -> [ResponseItem]
     -> Maybe Text
     -> Maybe Text
+    -> Maybe Text
+    -> Maybe FilePath
     -> IO (Either Text ())
-saveSubagentState sessionDir agentId items previous agentType =
+saveSubagentState sessionDir agentId items previous agentType agentModel cwd =
     case subagentStoreDir sessionDir agentId of
         Left err -> pure (Left err)
         Right dir -> do
@@ -88,6 +96,8 @@ saveSubagentState sessionDir agentId items previous agentType =
             LBS.writeFile metaTmp $ Aeson.encode SubagentDiskMeta
                 { diskPreviousResponseId = previous
                 , diskAgentType = agentType
+                , diskAgentModel = agentModel
+                , diskCwd = cwd
                 }
             _ <- tryAny (setFileMode metaTmp 0o600)
             LBS.writeFile transcriptTmp (Aeson.encode items)
@@ -113,7 +123,7 @@ loadSubagentState sessionDir agentId =
                 else do
                     metaResult <- if hasMeta
                         then decodeFile metaPath
-                        else pure (Right (SubagentDiskMeta Nothing Nothing))
+                        else pure (Right (SubagentDiskMeta Nothing Nothing Nothing Nothing))
                     itemsResult <- if hasTranscript
                         then decodeFile transcriptPath
                         else pure (Right [])

--- a/packages/agent-cli/test/Agent/CLI/SubagentStoreSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SubagentStoreSpec.hs
@@ -29,6 +29,7 @@ spec = describe "Agent.CLI.SubagentStore" do
                     , extraFields = KeyMap.empty
                     }
             saveSubagentState dir agentId [item] (Just "resp-1") (Just "explore")
+                (Just "grok-4.5-mini") (Just "/tmp/work")
                 `shouldReturn` Right ()
             loaded <- loadSubagentState dir agentId
             case loaded of
@@ -36,6 +37,8 @@ spec = describe "Agent.CLI.SubagentStore" do
                     length items `shouldBe` 1
                     meta.diskPreviousResponseId `shouldBe` Just "resp-1"
                     meta.diskAgentType `shouldBe` Just "explore"
+                    meta.diskAgentModel `shouldBe` Just "grok-4.5-mini"
+                    meta.diskCwd `shouldBe` Just "/tmp/work"
                 other -> expectationFailure ("unexpected load: " <> show other)
             case subagentStoreDir dir agentId of
                 Right path ->
@@ -52,7 +55,7 @@ spec = describe "Agent.CLI.SubagentStore" do
     it "fails closed on corrupt transcript JSON" do
         withTempDir \dir -> do
             let agentId = SubagentId "agent-corrupt-1"
-            saveSubagentState dir agentId [] (Just "r") Nothing
+            saveSubagentState dir agentId [] (Just "r") Nothing Nothing Nothing
                 `shouldReturn` Right ()
             Right path <- pure (subagentStoreDir dir agentId)
             LBS.writeFile (path </> "transcript.json") "{not-json"

--- a/packages/agent-core/src/Agent/Subagents/Registry.hs
+++ b/packages/agent-core/src/Agent/Subagents/Registry.hs
@@ -11,8 +11,10 @@ module Agent.Subagents.Registry
     , closeSubagentRegistry
     , resetSubagentRegistry
     , spawnSubagent
+    , spawnSubagentWithCwd
     , spawnSubagentAt
     , restoreSubagent
+    , restoreSubagentWithCwd
     , waitSubagents
     , waitAnyLive
     , sendInput
@@ -22,6 +24,7 @@ module Agent.Subagents.Registry
     , resumeSubagent
     , getStatus
     , getPreviousResponseId
+    , getSubagentCwd
     , getTaskPath
     , resolveAgentTarget
     , listLive
@@ -76,6 +79,7 @@ data SubagentRecord = SubagentRecord
       -- | Last successful response id for conversation continuity.
     , recordPreviousResponseId :: !(TVar (Maybe Text))
     , recordTaskPath :: !TaskPath
+    , recordCwd :: !FilePath
     }
 
 data SubagentRegistry = SubagentRegistry
@@ -152,7 +156,18 @@ spawnSubagent
     -> Text
     -> Maybe Text
     -> IO (Either Text SubagentId)
-spawnSubagent registry parentId parentDepth message nickname = do
+spawnSubagent registry =
+    spawnSubagentWithCwd registry registry.registryCwd
+
+spawnSubagentWithCwd
+    :: SubagentRegistry
+    -> FilePath
+    -> Maybe SubagentId
+    -> Int
+    -> Text
+    -> Maybe Text
+    -> IO (Either Text SubagentId)
+spawnSubagentWithCwd registry childCwd parentId parentDepth message nickname = do
     parentPath <- case parentId of
         Nothing -> pure taskPathRoot
         Just pid -> do
@@ -165,7 +180,8 @@ spawnSubagent registry parentId parentDepth message nickname = do
     -- Reuse the generated id by spawning with an explicit path helper that
     -- still allocates internally; uniqueness comes from the id-derived name.
     fmap (fmap fst) $
-        spawnSubagentAt registry parentId parentPath parentDepth taskName message nickname
+        spawnSubagentAtWithCwd
+            registry childCwd parentId parentPath parentDepth taskName message nickname
 
 -- | Spawn with an explicit parent path and task_name (Codex multi-agent v2).
 spawnSubagentAt
@@ -177,7 +193,20 @@ spawnSubagentAt
     -> Text
     -> Maybe Text
     -> IO (Either Text (SubagentId, TaskPath))
-spawnSubagentAt registry parentId parentPath parentDepth taskName message nickname = do
+spawnSubagentAt registry =
+    spawnSubagentAtWithCwd registry registry.registryCwd
+
+spawnSubagentAtWithCwd
+    :: SubagentRegistry
+    -> FilePath
+    -> Maybe SubagentId
+    -> TaskPath
+    -> Int
+    -> Text
+    -> Text
+    -> Maybe Text
+    -> IO (Either Text (SubagentId, TaskPath))
+spawnSubagentAtWithCwd registry childCwd parentId parentPath parentDepth taskName message nickname = do
     let nextDepth = parentDepth + 1
         cfg = registry.registryConfig
     case cfg.maxDepth of
@@ -205,6 +234,7 @@ spawnSubagentAt registry parentId parentPath parentDepth taskName message nickna
                         , recordSlotHeld = slotHeld
                         , recordPreviousResponseId = previousVar
                         , recordTaskPath = childPath
+                        , recordCwd = childCwd
                         }
                 admitted <- atomically do
                     closed <- readTVar registry.registryClosed
@@ -241,7 +271,7 @@ runWorker registry record firstPrompt = do
             { subId = record.recordId
             , subDepth = record.recordDepth
             , subParentId = record.recordParent
-            , subCwd = registry.registryCwd
+            , subCwd = record.recordCwd
             , subCancel = record.recordCancel
             }
         onEvent = registry.registryOnEvent record.recordId
@@ -458,7 +488,19 @@ restoreSubagent
     -> Maybe Text
     -> Maybe Text
     -> IO (Either Text SubagentId)
-restoreSubagent registry agentId parentId depth nickname previous = do
+restoreSubagent registry =
+    restoreSubagentWithCwd registry registry.registryCwd
+
+restoreSubagentWithCwd
+    :: SubagentRegistry
+    -> FilePath
+    -> SubagentId
+    -> Maybe SubagentId
+    -> Int
+    -> Maybe Text
+    -> Maybe Text
+    -> IO (Either Text SubagentId)
+restoreSubagentWithCwd registry childCwd agentId parentId depth nickname previous = do
     existing <- atomically $ Map.lookup agentId <$> readTVar registry.registryAgents
     case existing of
         Just record -> do
@@ -487,6 +529,7 @@ restoreSubagent registry agentId parentId depth nickname previous = do
                     , recordSlotHeld = slotHeld
                     , recordPreviousResponseId = previousVar
                     , recordTaskPath = taskPathRoot
+                    , recordCwd = childCwd
                     }
             atomically do
                 closed <- readTVar registry.registryClosed
@@ -523,6 +566,11 @@ getPreviousResponseId registry agentId = atomically do
     case Map.lookup agentId agents of
         Nothing -> pure Nothing
         Just record -> readTVar record.recordPreviousResponseId
+
+getSubagentCwd :: SubagentRegistry -> SubagentId -> IO (Maybe FilePath)
+getSubagentCwd registry agentId = atomically do
+    agents <- readTVar registry.registryAgents
+    pure ((.recordCwd) <$> Map.lookup agentId agents)
 
 readStatusSTM :: SubagentRegistry -> SubagentId -> STM SubagentStatus
 readStatusSTM registry agentId = do

--- a/packages/agent-core/src/Agent/Tools.hs
+++ b/packages/agent-core/src/Agent/Tools.hs
@@ -17,15 +17,14 @@ module Agent.Tools
     ) where
 
 import Agent.Provider (Provider(..))
-import Agent.Subagents (SubagentId)
 import Agent.Tools.Codex (codexTools)
 import Agent.Tools.Ghci (closeGhciSession, newGhciSession)
 import Agent.Tools.Grok (closeGrokSession, filterGrokToolsForType, grokTools, newGrokSession)
+import Agent.Tools.Grok.Task (GrokSubagentSpecs)
 import Agent.Tools.MultiAgents (MultiAgentContext)
 import Agent.Tools.PlanMode (PlanModeEnv, PlanModeHooks, newPlanModeEnv)
 import Agent.Tools.Types
 import Data.IORef
-import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Text (Text)
 
@@ -34,8 +33,8 @@ data CodingTools = CodingTools
     { codingAppTools :: ![AppTool]
     , codingPlanMode :: !PlanModeEnv
     , codingClose :: !(IO ())
-      -- | Grok/OpenRouter: maps spawned agent ids to subagent_type.
-    , codingAgentTypes :: !(IORef (Map SubagentId Text))
+      -- | Grok/OpenRouter: model-facing type and runtime overrides per child.
+    , codingAgentTypes :: !GrokSubagentSpecs
     }
 
 -- | Tools advertised for a model vendor. Surfaces are never mixed.
@@ -59,7 +58,7 @@ codingToolsForWithTypes
     -> ToolEnv
     -> Maybe PlanModeHooks
     -> Maybe MultiAgentContext
-    -> IORef (Map SubagentId Text)
+    -> GrokSubagentSpecs
     -> IO CodingTools
 codingToolsForWithTypes provider env hooks multi typesRef = do
     plan <- newPlanModeEnv env.toolCwd hooks

--- a/packages/agent-core/src/Agent/Tools/Grok.hs
+++ b/packages/agent-core/src/Agent/Tools/Grok.hs
@@ -11,7 +11,6 @@ module Agent.Tools.Grok
     , GrokSession
     ) where
 
-import Agent.Subagents (SubagentId)
 import Agent.Tools.Ghci (GhciSession, runGhciTool)
 import Agent.Tools.Grok.Grep (grepTool)
 import Agent.Tools.Grok.ListDir (listDirTool)
@@ -23,7 +22,8 @@ import Agent.Tools.Grok.Shell
     , newGrokSession
     )
 import Agent.Tools.Grok.Task
-    ( filterGrokToolsForType
+    ( GrokSubagentSpecs
+    , filterGrokToolsForType
     , taskTool
     )
 import Agent.Tools.Grok.TaskControl
@@ -38,10 +38,7 @@ import Agent.Tools.PlanMode
     , enterPlanModeTool
     , exitPlanModeTool
     )
-import Agent.Tools.Types (AppTool)
-import Data.IORef (IORef)
-import Data.Map.Strict (Map)
-import Data.Text (Text)
+import Agent.Tools.Types (AppTool, ToolEnv(..))
 
 -- Upstream: grok-build grok_build::{read_file, grep, list_dir, search_replace, bash,
 -- get_task_output, kill_task, task, enter_plan_mode, exit_plan_mode, ask_user_question}.
@@ -51,7 +48,7 @@ grokTools
     -> GhciSession
     -> PlanModeEnv
     -> Maybe MultiAgentContext
-    -> IORef (Map SubagentId Text)
+    -> GrokSubagentSpecs
     -> [AppTool]
 grokTools session ghci planMode multi typesRef =
     let env = session.grokEnv
@@ -70,4 +67,4 @@ grokTools session ghci planMode multi typesRef =
             ]
     in case multi of
         Nothing -> base
-        Just ctx -> base ++ [taskTool ctx typesRef]
+        Just ctx -> base ++ [taskTool env.toolCwd ctx typesRef]

--- a/packages/agent-core/src/Agent/Tools/Grok/Task.hs
+++ b/packages/agent-core/src/Agent/Tools/Grok/Task.hs
@@ -1,4 +1,4 @@
--- | Grok-build @task@ tool — spawn nestable subagents.
+-- | Grok-build @task@ tool — spawn one level of subagents.
 --
 -- Wire names and defaults follow xai-org/grok-build TaskToolInput /
 -- build_task_description. Runtime reuses 'Agent.Subagents'.
@@ -7,11 +7,15 @@ module Agent.Tools.Grok.Task
     , filterGrokToolsForType
     , knownSubagentTypes
     , defaultSubagentType
+    , GrokSubagentSpec(..)
+    , GrokSubagentSpecs
     , isSubagentIdText
     , formatTaskStarted
     , formatTaskCompleted
+    , recordAgentSpec
     , recordAgentType
     , lookupAgentType
+    , lookupAgentModel
     ) where
 
 import Agent.Subagents
@@ -20,7 +24,7 @@ import Agent.Subagents
     , defaultWaitTimeoutMs
     , getStatus
     , sendInput
-    , spawnSubagent
+    , spawnSubagentWithCwd
     , waitSubagents
     )
 import Agent.ToolArgs
@@ -33,7 +37,7 @@ import Agent.ToolDSL
     ( PropertySchema(..)
     , PropertyType(..)
     )
-import Agent.ToolDispatch (ToolHandler, typedTool)
+import Agent.ToolDispatch (typedTool)
 import Agent.Tools.MultiAgents (MultiAgentContext(..))
 import Agent.Tools.Types
     ( AppTool(..)
@@ -46,12 +50,21 @@ import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
+import System.Directory (doesDirectoryExist)
+import System.FilePath (isAbsolute, normalise, (</>))
 
 defaultSubagentType :: Text
 defaultSubagentType = "general-purpose"
 
 knownSubagentTypes :: [Text]
 knownSubagentTypes = ["general-purpose", "explore", "plan"]
+
+data GrokSubagentSpec = GrokSubagentSpec
+    { agentType :: !Text
+    , modelOverride :: !(Maybe Text)
+    } deriving (Eq, Show)
+
+type GrokSubagentSpecs = IORef (Map SubagentId GrokSubagentSpec)
 
 -- | True when the id looks like a registry subagent id (not a shell @tN@ id).
 isSubagentIdText :: Text -> Bool
@@ -74,10 +87,10 @@ instance FromJSON TaskArgs where
         description <- reqText object "description"
         subagentType <- fromMaybe defaultSubagentType <$> optText object "subagent_type"
         runInBackground <- fromMaybe True <$> optBool object "run_in_background"
-        resumeFrom <- optText object "resume_from"
-        cwd <- optText object "cwd"
-        model <- optText object "model"
-        isolation <- optText object "isolation"
+        resumeFrom <- sanitizeOptional <$> optText object "resume_from"
+        cwd <- sanitizeOptional <$> optText object "cwd"
+        model <- sanitizeOptional <$> optText object "model"
+        isolation <- sanitizeOptional <$> optText object "isolation"
         pure TaskArgs
             { prompt
             , description
@@ -89,8 +102,16 @@ instance FromJSON TaskArgs where
             , isolation
             }
 
-taskTool :: MultiAgentContext -> IORef (Map SubagentId Text) -> AppTool
-taskTool ctx typesRef = AppTool
+sanitizeOptional :: Maybe Text -> Maybe Text
+sanitizeOptional value = value >>= \raw ->
+    let stripped = Text.strip raw
+        lowered = Text.toLower stripped
+    in if Text.null stripped || lowered `elem` ["null", "none", "undefined"]
+        then Nothing
+        else Just stripped
+
+taskTool :: FilePath -> MultiAgentContext -> GrokSubagentSpecs -> AppTool
+taskTool baseCwd ctx specsRef = AppTool
     { appToolName = "task"
     , appToolDescription = taskDescription
     , appToolParameters =
@@ -109,9 +130,9 @@ taskTool ctx typesRef = AppTool
         , PropertySchema "model" PropertyString False $ Just
             "Optional model slug. Omit to inherit the parent model."
         , PropertySchema "isolation" PropertyString False $ Just
-            "Isolation mode: \"none\" (default) or \"worktree\". Worktree isolation is not supported yet."
+            "Isolation mode: \"none\" (default) or \"worktree\". Worktree mode prevents child edits from affecting the parent workspace until explicitly applied."
         ]
-    , appToolHandler = typedTool "task" (runTask ctx typesRef)
+    , appToolHandler = typedTool "task" (runTask baseCwd ctx specsRef)
     , appToolKind = JsonFunction
     , appToolReadOnly = False
     , appToolIsReadOnlyCall = Nothing
@@ -121,26 +142,28 @@ taskDescription :: Text
 taskDescription =
     "Start a subagent that works on a task independently and reports back.\n\n\
     \Agent types:\n\n\
-    \- **general-purpose**: General purpose agent for multi-step tasks. Has access to all tools including task.\n\
+    \- **general-purpose**: General purpose agent for multi-step tasks. Has access to all parent tools except task.\n\
     \- **explore**: Fast, read-only agent specialized for codebase exploration. Read-only — has access to: read_file, list_dir, grep.\n\
-    \- **plan**: Software architect for planning implementation strategies. Read-only — has access to: read_file, list_dir, grep, enter_plan_mode, exit_plan_mode, ask_user_question.\n\n\
+    \- **plan**: Software architect for planning implementation strategies. Read-only — has access to: read_file, list_dir, grep, web_search, enter_plan_mode, exit_plan_mode, ask_user_question.\n\n\
     \## Usage notes\n\
     \- When the agent is done, it returns a single message with its agent ID. Use that ID to resume the agent later for follow-up work.\n\
     \- run_in_background: Returns immediately with a subagent_id. Use get_task_output to retrieve results. This is set to true by default.\n\
+    \- Subagents receive project instructions from AGENTS.md. Include any especially important task-specific conventions directly in the prompt.\n\
     \- When using the task tool, you must specify a subagent_type parameter to select which agent type to use.\n\
     \- When launching independent subagents, you MUST incorporate the results into the task based on requirements BEFORE concluding.\n\n\
     \Resuming a previous agent (resume_from):\n\
-    \- Use resume_from to continue a previously completed subagent's conversation. Pass the subagent_id returned by a prior task call.\n\
+    \- Use resume_from to continue a previously completed subagent's conversation. Pass the subagent_id returned by a prior task call. A resumed agent keeps its transcript, so only describe what changed since the last run.\n\
     \- The resumed agent must use the same subagent_type as the source.\n\n\
     \Isolation mode:\n\
-    \- isolation=\"worktree\" is not supported yet; use the default shared workspace."
+    \- Use isolation=\"worktree\" to run the child in an isolated git worktree. The worktree is preserved after completion and its path is returned in the output."
 
 runTask
-    :: MultiAgentContext
-    -> IORef (Map SubagentId Text)
+    :: FilePath
+    -> MultiAgentContext
+    -> GrokSubagentSpecs
     -> TaskArgs
     -> IO (Either Text Text)
-runTask ctx typesRef args
+runTask baseCwd ctx typesRef args
     | Text.null (Text.strip args.prompt) =
         pure (Left "task requires a non-empty prompt")
     | Text.null (Text.strip args.description) =
@@ -151,30 +174,27 @@ runTask ctx typesRef args
                 <> args.subagentType
                 <> ". Known types: "
                 <> Text.intercalate ", " knownSubagentTypes
-    | Just iso <- args.isolation
-    , Text.toLower (Text.strip iso) `elem` ["worktree", "work_tree", "work-tree"] =
-        pure (Left "isolation=\"worktree\" is not supported yet. Omit isolation or use \"none\".")
+    | Just resumeId <- args.resumeFrom = resumeTask ctx typesRef args resumeId
     | Just _ <- args.cwd
     , Just iso <- args.isolation
-    , Text.toLower (Text.strip iso) `notElem` ["none", ""] =
+    , isWorktreeIsolation iso =
         pure (Left "cwd and isolation are mutually exclusive.")
-    | Just _ <- args.cwd =
-        -- Explicit cwd overrides are accepted later; for v1 reject to avoid
-        -- surprising ToolEnv mismatches until child cwd wiring exists.
-        pure (Left "task cwd overrides are not supported yet. Omit cwd to use the parent working directory.")
-    | Just resumeId <- args.resumeFrom = resumeTask ctx typesRef args resumeId
-    | otherwise = spawnFresh ctx typesRef args
+    | otherwise = resolveTaskWorkspace baseCwd ctx args >>= \case
+        Left err -> pure (Left err)
+        Right (childCwd, worktreePath) ->
+            spawnFresh childCwd worktreePath ctx typesRef args
 
 spawnFresh
-    :: MultiAgentContext
-    -> IORef (Map SubagentId Text)
+    :: FilePath
+    -> Maybe FilePath
+    -> MultiAgentContext
+    -> GrokSubagentSpecs
     -> TaskArgs
     -> IO (Either Text Text)
-spawnFresh ctx typesRef args = do
-    -- model override accepted but unused until child runners plumb it.
-    _ <- pure args.model
-    result <- spawnSubagent
+spawnFresh childCwd worktreePath ctx typesRef args = do
+    result <- spawnSubagentWithCwd
         ctx.multiRegistry
+        childCwd
         ctx.multiSelfId
         ctx.multiDepth
         args.prompt
@@ -182,18 +202,59 @@ spawnFresh ctx typesRef args = do
     case result of
         Left err -> pure (Left err)
         Right agentId -> do
-            recordAgentType typesRef agentId args.subagentType
+            recordAgentSpec typesRef agentId GrokSubagentSpec
+                { agentType = args.subagentType
+                , modelOverride = args.model
+                }
             if args.runInBackground
-                then pure $ Right $ formatTaskStarted agentId args
+                then pure $ Right $ formatTaskStarted agentId args worktreePath
                 else do
                     (statuses, timedOut) <-
                         waitSubagents ctx.multiRegistry [agentId] defaultWaitTimeoutMs
-                    pure $ Right $ formatTaskCompleted agentId args timedOut
+                    pure $ Right $ formatTaskCompleted agentId args worktreePath timedOut
                         (Map.lookup agentId statuses)
+
+resolveTaskWorkspace
+    :: FilePath
+    -> MultiAgentContext
+    -> TaskArgs
+    -> IO (Either Text (FilePath, Maybe FilePath))
+resolveTaskWorkspace baseCwd ctx args
+    | maybe False isWorktreeIsolation args.isolation =
+        case ctx.multiCreateWorktree of
+            Nothing -> pure (Left "isolation=\"worktree\" is unavailable in this host.")
+            Just create ->
+                create baseCwd >>= \case
+                    Left err -> pure (Left err)
+                    Right path -> pure (Right (path, Just path))
+    | otherwise = do
+        resolved <- resolveTaskCwd baseCwd args.cwd
+        pure $ case resolved of
+            Left err -> Left err
+            Right path -> Right (path, Nothing)
+
+isWorktreeIsolation :: Text -> Bool
+isWorktreeIsolation isolation =
+    Text.toLower (Text.strip isolation)
+        `elem` ["worktree", "work_tree", "work-tree"]
+
+resolveTaskCwd :: FilePath -> Maybe Text -> IO (Either Text FilePath)
+resolveTaskCwd baseCwd requested = do
+    let path = case requested of
+            Nothing -> baseCwd
+            Just raw ->
+                let supplied = Text.unpack (Text.strip raw)
+                in if isAbsolute supplied
+                    then normalise supplied
+                    else normalise (baseCwd </> supplied)
+    exists <- doesDirectoryExist path
+    pure $ if exists
+        then Right path
+        else Left ("task cwd is not an existing directory: " <> Text.pack path)
 
 resumeTask
     :: MultiAgentContext
-    -> IORef (Map SubagentId Text)
+    -> GrokSubagentSpecs
     -> TaskArgs
     -> Text
     -> IO (Either Text Text)
@@ -225,15 +286,15 @@ resumeTask ctx typesRef args resumeId = do
                         Left err -> pure (Left err)
                         Right _ ->
                             if args.runInBackground
-                                then pure $ Right $ formatTaskStarted agentId args
+                                then pure $ Right $ formatTaskStarted agentId args Nothing
                                 else do
                                     (statuses, timedOut) <-
                                         waitSubagents ctx.multiRegistry [agentId] defaultWaitTimeoutMs
-                                    pure $ Right $ formatTaskCompleted agentId args timedOut
+                                    pure $ Right $ formatTaskCompleted agentId args Nothing timedOut
                                         (Map.lookup agentId statuses)
 
-formatTaskStarted :: SubagentId -> TaskArgs -> Text
-formatTaskStarted agentId args =
+formatTaskStarted :: SubagentId -> TaskArgs -> Maybe FilePath -> Text
+formatTaskStarted agentId args worktreePath =
     "Subagent started in background.\n\
     \subagent_id: "
         <> agentId.unSubagentId
@@ -243,16 +304,20 @@ formatTaskStarted agentId args =
         <> "\n\
         \description: "
         <> args.description
-        <> "\n\
-        \Use get_task_output with this subagent_id to retrieve results. Do not poll in a loop."
+        <> maybe "" (\path -> "\nworktree_path: " <> Text.pack path) worktreePath
+        <> "\n\n\
+        \When you need its result, use get_task_output with task_ids=[\""
+        <> agentId.unSubagentId
+        <> "\"] and a positive timeout_ms."
 
 formatTaskCompleted
     :: SubagentId
     -> TaskArgs
+    -> Maybe FilePath
     -> Bool
     -> Maybe SubagentStatus
     -> Text
-formatTaskCompleted agentId args timedOut mstatus =
+formatTaskCompleted agentId args worktreePath timedOut mstatus =
     let header =
             "subagent_id: "
                 <> agentId.unSubagentId
@@ -260,6 +325,7 @@ formatTaskCompleted agentId args timedOut mstatus =
                 <> args.subagentType
                 <> "\ndescription: "
                 <> args.description
+                <> maybe "" (\path -> "\nworktree_path: " <> Text.pack path) worktreePath
                 <> "\n"
         body = case mstatus of
             Just (Completed (Just text)) -> "status: completed\nfinal:\n" <> text
@@ -275,37 +341,44 @@ formatTaskCompleted agentId args timedOut mstatus =
             Nothing -> "status: unknown"
     in header <> body
 
-recordAgentType :: IORef (Map SubagentId Text) -> SubagentId -> Text -> IO ()
-recordAgentType typesRef agentId agentType =
-    atomicModifyIORef' typesRef \m -> (Map.insert agentId agentType m, ())
+recordAgentSpec :: GrokSubagentSpecs -> SubagentId -> GrokSubagentSpec -> IO ()
+recordAgentSpec specsRef agentId spec =
+    atomicModifyIORef' specsRef update
+  where
+    update specs = (Map.insert agentId spec specs, ())
 
-lookupAgentType :: IORef (Map SubagentId Text) -> SubagentId -> IO (Maybe Text)
-lookupAgentType typesRef agentId = Map.lookup agentId <$> readIORef typesRef
+recordAgentType :: GrokSubagentSpecs -> SubagentId -> Text -> IO ()
+recordAgentType specsRef agentId agentType = do
+    specs <- readIORef specsRef
+    let model = maybe Nothing (\spec -> spec.modelOverride) (Map.lookup agentId specs)
+    recordAgentSpec specsRef agentId (GrokSubagentSpec agentType model)
+
+lookupAgentType :: GrokSubagentSpecs -> SubagentId -> IO (Maybe Text)
+lookupAgentType specsRef agentId = do
+    specs <- readIORef specsRef
+    pure ((\spec -> spec.agentType) <$> Map.lookup agentId specs)
+
+lookupAgentModel :: GrokSubagentSpecs -> SubagentId -> IO (Maybe Text)
+lookupAgentModel specsRef agentId = do
+    specs <- readIORef specsRef
+    pure (Map.lookup agentId specs >>= \spec -> spec.modelOverride)
 
 -- | Restrict the child tool surface by subagent type.
 filterGrokToolsForType :: Text -> [AppTool] -> [AppTool]
 filterGrokToolsForType agentType tools = case agentType of
     "explore" -> filter ((`elem` exploreNames) . (.appToolName)) tools
     "plan" -> filter ((`elem` planNames) . (.appToolName)) tools
-    _ -> tools
+    _ -> filter ((/= "task") . (.appToolName)) tools
   where
     exploreNames =
         [ "read_file"
         , "list_dir"
         , "grep"
-        , "run_terminal_cmd"
-        , "run_ghci"
-        , "get_task_output"
-        , "kill_task"
         ]
     planNames =
         [ "read_file"
         , "list_dir"
         , "grep"
-        , "run_terminal_cmd"
-        , "run_ghci"
-        , "get_task_output"
-        , "kill_task"
         , "enter_plan_mode"
         , "exit_plan_mode"
         , "ask_user_question"

--- a/packages/agent-core/src/Agent/Tools/Grok/TaskControl.hs
+++ b/packages/agent-core/src/Agent/Tools/Grok/TaskControl.hs
@@ -10,10 +10,10 @@ import Agent.Subagents
     , getStatus
     , waitSubagents
     )
-import Agent.ToolArgs (objectArgs, reqText)
+import Agent.ToolArgs (objectArgs, optInt, reqText, reqTextList)
 import Agent.ToolDSL (PropertySchema(..), PropertyType(..))
 import Agent.ToolDispatch (typedTool)
-import Agent.Tools.Grok.Common (jsonTool, optionalTimeout, stripAnsi)
+import Agent.Tools.Grok.Common (jsonTool, stripAnsi)
 import Agent.Tools.Grok.Shell
     ( GrokSession
     , killTask
@@ -23,56 +23,150 @@ import Agent.Tools.Grok.Task (isSubagentIdText)
 import Agent.Tools.MultiAgents (MultiAgentContext(..))
 import Agent.Tools.Types (AppTool)
 import Control.Applicative ((<|>))
+import Control.Concurrent.Async (mapConcurrently)
 import Data.Aeson (FromJSON(..))
+import Data.List (nub)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
+import qualified Data.Text as Text
 
 data TaskOutputArgs = TaskOutputArgs
-    { taskId :: Text
-    , timeout :: Maybe Int
+    { taskIds :: [Text]
+    , timeoutMs :: Maybe Int
     }
 
 instance FromJSON TaskOutputArgs where
-    parseJSON = objectArgs \object ->
-        TaskOutputArgs
-            <$> (reqText object "task_id" <|> reqText object "task_ids")
-            <*> optionalTimeout object
+    parseJSON = objectArgs \object -> do
+        taskIds <-
+            reqTextList object "task_ids"
+                <|> reqTextList object "task_id"
+        canonicalTimeout <- optInt object "timeout_ms"
+        legacyTimeout <- optInt object "timeout"
+        pure TaskOutputArgs
+            { taskIds
+            , timeoutMs = canonicalTimeout <|> legacyTimeout
+            }
 
 getTaskOutputTool :: GrokSession -> Maybe MultiAgentContext -> AppTool
 getTaskOutputTool session multi = jsonTool "get_task_output" getTaskOutputDescription
-    [ PropertySchema "task_id" PropertyString True $ Just
-        "The task id from a background run_terminal_cmd or the subagent_id from task."
-    , PropertySchema "timeout" PropertyInteger False $ Just
-        "Optional wait in milliseconds. If omitted, return a snapshot immediately."
+    [ PropertySchema "task_ids" (PropertyArray PropertyString) True $ Just
+        "Task IDs to get output from. For a single task use a one-element array."
+    , PropertySchema "timeout_ms" PropertyInteger False $ Just
+        "Max wait time in milliseconds, up to 600000. A positive value waits for completion; omit or pass 0 for a non-blocking status snapshot."
     ]
     True
     (typedTool "get_task_output" (runGetTaskOutput session multi))
 
 getTaskOutputDescription :: Text
 getTaskOutputDescription =
-    "Read output from a background command or subagent.\n\
-    \Use this for a snapshot of current output, or one bounded wait — not a polling loop."
+    "Get output and status from a background task or subagent.\n\n\
+    \Usage notes:\n\
+    \- Pass task_ids with one or more ids from background=true commands or run_in_background=true subagents; for a single task use a one-element array. Multiple ids with a positive timeout_ms wait until all complete\n\
+    \- Omit timeout_ms or pass 0 for a non-blocking status snapshot; set a positive timeout_ms to wait up to that many milliseconds, capped at 600000 (~10 min)\n\
+    \- Returns current output and status."
 
 runGetTaskOutput
     :: GrokSession
     -> Maybe MultiAgentContext
     -> TaskOutputArgs
     -> IO (Either Text Text)
-runGetTaskOutput session multi args = case multi of
-    Just ctx | isSubagentIdText args.taskId -> do
-        let agentId = SubagentId args.taskId
-            timeoutMs = fromMaybe 0 args.timeout
-        if timeoutMs <= 0
-            then do
-                status <- getStatus ctx.multiRegistry agentId
-                pure $ Right $ formatAgentWait args.taskId False (Just status)
-            else do
-                (statuses, timedOut) <-
+runGetTaskOutput session multi args
+    | null resolvedIds =
+        pure (Left "Provide a non-empty task_ids list.")
+    | length resolvedIds > maxTaskOutputIds =
+        pure $ Left $
+            "task_ids exceeds maximum of "
+                <> Text.pack (show maxTaskOutputIds)
+                <> " entries."
+    | otherwise = do
+        entries <- mapConcurrently
+            (runOneTaskOutput session multi effectiveTimeout)
+            resolvedIds
+        pure $ Right $ case entries of
+            [entry] -> entry.output
+            _ -> formatMultiTaskOutput waits entries
+  where
+    resolvedIds =
+        nub
+            [ stripped
+            | taskId <- args.taskIds
+            , let stripped = Text.strip taskId
+            , not (Text.null stripped)
+            ]
+    waits = maybe False (> 0) args.timeoutMs
+    effectiveTimeout
+        | waits = Just (min maxTaskOutputWaitMs (fromMaybe 0 args.timeoutMs))
+        | otherwise = Nothing
+
+maxTaskOutputIds :: Int
+maxTaskOutputIds = 20
+
+maxTaskOutputWaitMs :: Int
+maxTaskOutputWaitMs = 600000
+
+data TaskOutputEntry = TaskOutputEntry
+    { taskOutputId :: !Text
+    , output :: !Text
+    , terminal :: !Bool
+    }
+
+runOneTaskOutput
+    :: GrokSession
+    -> Maybe MultiAgentContext
+    -> Maybe Int
+    -> Text
+    -> IO TaskOutputEntry
+runOneTaskOutput session multi timeout taskId = case multi of
+    Just ctx | isSubagentIdText taskId -> do
+        let agentId = SubagentId taskId
+        (status, timedOut) <- case timeout of
+            Nothing -> do
+                current <- getStatus ctx.multiRegistry agentId
+                pure (current, False)
+            Just timeoutMs -> do
+                (statuses, didTimeOut) <-
                     waitSubagents ctx.multiRegistry [agentId] timeoutMs
-                pure $ Right $ formatAgentWait args.taskId timedOut (Map.lookup agentId statuses)
-    _ ->
-        Right . stripAnsi <$> readTaskOutput session args.taskId args.timeout
+                pure (fromMaybe NotFound (Map.lookup agentId statuses), didTimeOut)
+        pure TaskOutputEntry
+            { taskOutputId = taskId
+            , output = formatAgentWait taskId timedOut (Just status)
+            , terminal = isTerminalAgentStatus status
+            }
+    _ -> do
+        text <- stripAnsi <$> readTaskOutput session taskId timeout
+        pure TaskOutputEntry
+            { taskOutputId = taskId
+            , output = text
+            , terminal = terminalCommandOutput text
+            }
+
+isTerminalAgentStatus :: SubagentStatus -> Bool
+isTerminalAgentStatus = \case
+    Completed {} -> True
+    Errored {} -> True
+    Interrupted -> True
+    Closed -> True
+    _ -> False
+
+terminalCommandOutput :: Text -> Bool
+terminalCommandOutput text =
+    "exit:" `Text.isPrefixOf` text
+        || "killed " `Text.isPrefixOf` text
+
+formatMultiTaskOutput :: Bool -> [TaskOutputEntry] -> Text
+formatMultiTaskOutput waits entries =
+    Text.intercalate "\n\n"
+        [ "task_id: " <> entry.taskOutputId <> "\n" <> entry.output
+        | entry <- entries
+        ]
+        <> "\n\n"
+        <> Text.pack (show (length (filter (.terminal) entries)))
+        <> "/"
+        <> Text.pack (show (length entries))
+        <> " tasks completed ("
+        <> (if waits then "wait_all" else "poll")
+        <> ")"
 
 formatAgentWait :: Text -> Bool -> Maybe SubagentStatus -> Text
 formatAgentWait taskId timedOut mstatus = case mstatus of

--- a/packages/agent-core/src/Agent/Tools/MultiAgents.hs
+++ b/packages/agent-core/src/Agent/Tools/MultiAgents.hs
@@ -65,6 +65,8 @@ data MultiAgentContext = MultiAgentContext
       -- | Optional host hook to rehydrate a closed/missing agent from disk
       -- before follow-ups. 'Nothing' means in-memory only.
     , multiResumeFromDisk :: !(Maybe (SubagentId -> IO (Either Text ())))
+      -- | Optional host hook for Grok-style isolated worktree children.
+    , multiCreateWorktree :: !(Maybe (FilePath -> IO (Either Text FilePath)))
     }
 
 multiAgentNamespace :: Text

--- a/packages/agent-core/test/Agent/Tools/CodexSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/CodexSpec.hs
@@ -57,6 +57,7 @@ spec = describe "Agent.Tools.Codex" do
                     , multiDepth = 0
                     , multiTaskPath = taskPathRoot
                     , multiResumeFromDisk = Nothing
+                    , multiCreateWorktree = Nothing
                     }
             coding <- codingToolsFor OpenAIProvider env Nothing (Just ctx)
             let names = map (.appToolName) coding.codingAppTools

--- a/packages/agent-core/test/Agent/Tools/Grok/TaskSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/Grok/TaskSpec.hs
@@ -30,16 +30,18 @@ spec = describe "Agent.Tools.Grok.Task" do
                 })
             (\_ _ -> pure ())
         typesRef <- newIORef Map.empty
-        let ctx = MultiAgentContext registry Nothing 0 taskPathRoot Nothing
-            tool = taskTool ctx typesRef
+        let ctx = MultiAgentContext registry Nothing 0 taskPathRoot Nothing Nothing
+            tool = taskTool "/tmp" ctx typesRef
         result <- dispatchToolCall defaultLoopDispatch [tool.appToolHandler]
             (functionToolCall "c1" "task"
-                "{\"prompt\":\"hello\",\"description\":\"test task\"}")
+                "{\"prompt\":\"hello\",\"description\":\"test task\",\"model\":\"grok-4.5-mini\"}")
         result.output `shouldSatisfy` Text.isInfixOf "Subagent started in background"
         result.output `shouldSatisfy` Text.isInfixOf "subagent_id: agent-"
+        specs <- Map.elems <$> readIORef typesRef
+        map (\entry -> entry.modelOverride) specs `shouldBe` [Just "grok-4.5-mini"]
         closeSubagentRegistry registry
 
-    it "filters explore tools to a read-mostly set" do
+    it "filters explore tools to the Grok Build read-only set" do
         let tools =
                 [ fake "read_file"
                 , fake "search_replace"
@@ -48,21 +50,28 @@ spec = describe "Agent.Tools.Grok.Task" do
                 , fake "run_terminal_cmd"
                 ]
             names = map (.appToolName) (filterGrokToolsForType "explore" tools)
-        names `shouldBe` ["read_file", "grep", "run_terminal_cmd"]
+        names `shouldBe` ["read_file", "grep"]
         names `shouldNotContain` ["search_replace"]
         names `shouldNotContain` ["task"]
 
-    it "rejects worktree isolation" do
+    it "filters task out of general-purpose children" do
+        let tools = [fake "read_file", fake "task"]
+            names = map (.appToolName) (filterGrokToolsForType "general-purpose" tools)
+        names `shouldBe` ["read_file"]
+
+    it "uses the host worktree hook for isolated children" do
         registry <- newSubagentRegistry defaultSubagentConfig "/tmp"
             (\_ _ _ _ -> pure $ Left LoopNoResponseId)
             (\_ _ -> pure ())
         typesRef <- newIORef Map.empty
-        let ctx = MultiAgentContext registry Nothing 0 taskPathRoot Nothing
-            tool = taskTool ctx typesRef
+        let createIsolated _ = pure (Right "/tmp")
+            ctx = MultiAgentContext registry Nothing 0 taskPathRoot Nothing
+                (Just createIsolated)
+            tool = taskTool "/tmp" ctx typesRef
         result <- dispatchToolCall defaultLoopDispatch [tool.appToolHandler]
             (functionToolCall "c1" "task"
                 "{\"prompt\":\"x\",\"description\":\"y\",\"isolation\":\"worktree\"}")
-        result.output `shouldSatisfy` Text.isInfixOf "worktree"
+        result.output `shouldSatisfy` Text.isInfixOf "worktree_path: /tmp"
         closeSubagentRegistry registry
 
 fake :: Text -> AppTool

--- a/packages/agent-core/test/Agent/Tools/GrokSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/GrokSpec.hs
@@ -4,8 +4,10 @@ import Agent.Loop (LoopError(..), defaultLoopDispatch)
 import Agent.Provider (Provider(..))
 import Agent.Subagents (SubagentId, closeSubagentRegistry, defaultSubagentConfig, newSubagentRegistry)
 import Agent.ToolDispatch (ToolCallResult(..), dispatchToolCall, functionToolCall)
+import Agent.ToolDSL (PropertySchema(..))
 import Agent.Tools (CodingTools(..), appToolHandlers, codingToolsFor, defaultToolEnv)
 import Agent.Tools.Grok (closeGrokSession, grokTools, newGrokSession)
+import Agent.Tools.Grok.Task (GrokSubagentSpec)
 import Agent.Tools.Ghci (GhciSession, closeGhciSession, newGhciSession)
 import Agent.Tools.Grok.Shell (GrokSession(..), PersistentShell(..), hasUnwaitedBackgroundOp)
 import Agent.Subagents.TaskPath (taskPathRoot)
@@ -36,7 +38,7 @@ spec = describe "Agent.Tools.Grok" do
     it "advertises grok-build wire names and not Codex names" do
         withTempSession \(session, ghci) -> do
             plan <- newPlanModeEnv session.grokEnv.toolCwd Nothing
-            typesRef <- newIORef (Map.empty :: Map SubagentId Text)
+            typesRef <- newIORef (Map.empty :: Map SubagentId GrokSubagentSpec)
             let names = map (.appToolName) (grokTools session ghci plan Nothing typesRef)
             names `shouldBe`
                 [ "read_file"
@@ -53,6 +55,13 @@ spec = describe "Agent.Tools.Grok" do
                 ]
             names `shouldNotContain` ["apply_patch"]
             names `shouldNotContain` ["shell_command"]
+            let outputSchemas =
+                    [ tool.appToolParameters
+                    | tool <- grokTools session ghci plan Nothing typesRef
+                    , tool.appToolName == "get_task_output"
+                    ]
+            map (map (.propertyName)) outputSchemas
+                `shouldBe` [["task_ids", "timeout_ms"]]
             xai <- codingToolsFor XAIProvider session.grokEnv Nothing Nothing
             openrouter <- codingToolsFor OpenRouterProvider session.grokEnv Nothing Nothing
             (do
@@ -68,7 +77,7 @@ spec = describe "Agent.Tools.Grok" do
                 (\_ _ _ _ -> pure $ Left LoopNoResponseId)
                 (\_ _ -> pure ())
             typesRef <- newIORef Map.empty
-            let ctx = MultiAgentContext registry Nothing 0 taskPathRoot Nothing
+            let ctx = MultiAgentContext registry Nothing 0 taskPathRoot Nothing Nothing
                 names = map (.appToolName) (grokTools session ghci plan (Just ctx) typesRef)
             names `shouldContain` ["task"]
             closeSubagentRegistry registry
@@ -215,11 +224,11 @@ spec = describe "Agent.Tools.Grok" do
             started `shouldSatisfy` Text.isInfixOf "task_id:"
             let taskId = taskIdFrom started
             snapshot <- runTool session ghci "get_task_output"
-                ("{\"task_id\":\"" <> taskId <> "\"}")
+                ("{\"task_ids\":[\"" <> taskId <> "\"]}")
             snapshot `shouldSatisfy` \text ->
                 Text.isInfixOf "still running" text || Text.isInfixOf "bgdone" text
             finished <- runTool session ghci "get_task_output"
-                ("{\"task_id\":\"" <> taskId <> "\",\"timeout\":5000}")
+                ("{\"task_ids\":[\"" <> taskId <> "\"],\"timeout_ms\":5000}")
             finished `shouldSatisfy` Text.isInfixOf "exit: 0"
             finished `shouldSatisfy` Text.isInfixOf "bgdone"
 
@@ -288,7 +297,7 @@ spec = describe "Agent.Tools.Grok" do
 runTool :: GrokSession -> GhciSession -> Text -> Text -> IO Text
 runTool session ghci name arguments = do
     plan <- newPlanModeEnv session.grokEnv.toolCwd Nothing
-    typesRef <- newIORef (Map.empty :: Map SubagentId Text)
+    typesRef <- newIORef (Map.empty :: Map SubagentId GrokSubagentSpec)
     result <- dispatchToolCall defaultLoopDispatch
         (appToolHandlers (grokTools session ghci plan Nothing typesRef))
         (functionToolCall "call-1" name arguments)


### PR DESCRIPTION
## Summary

- align `get_task_output` with Grok Build's canonical `task_ids` / `timeout_ms` contract while retaining legacy aliases
- support concurrent multi-task retrieval, Grok-style child tool restrictions, and one-level Grok subagents
- honor and persist child `model` and `cwd` overrides across resume
- support preserved `isolation="worktree"` children through the existing CLI worktree manager
- refresh child prompts and task descriptions to better match Grok Build behavior

## Validation

- `agent-core`: 133 examples, 0 failures
- `agent-cli`: 274 examples, 0 failures
- multi-package GHCi load: 113 modules
- `git diff --check`

## Remaining differences

- custom agent/role/persona discovery
- model-slug validation
- richer structured completion statistics and resume footer
- MCP inheritance and an explicit worktree-apply workflow
