### PR TITLE
Add interactive session resume picker

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -225,6 +225,9 @@ data RunResult
     | RunReload
     | RunSwitchProvider ProviderTransition
     | RunProviderStartFailed ApiError
+    | RunResumeSession Text
+      -- ^ Persisted session id. Consumed after the current provider-specific
+      -- backend shuts down before starting the selected session.
 
 -- | GHCi @:cmd@ helper: on 'DevReload', reload modules and re-enter 'devMain'.
 afterDev :: DevResult -> IO String
@@ -281,7 +284,7 @@ devMain = do
         Right ListSessions -> runListSessions >> pure DevQuit
         Right (ShowSession sessionId) -> runShowSession sessionId >> pure DevQuit
         Right (RunAgent options) -> do
-            result <- runAgentWithProviderSwitches options
+            result <- runAgentWithRestarts options
             case result of
                 DevQuit -> clearDevResumePointer home >> pure DevQuit
                 DevReload -> pure DevReload
@@ -299,7 +302,7 @@ run = do
         Right ListSessions -> runListSessions
         Right (ShowSession sessionId) -> runShowSession sessionId
         Right (RunAgent options) -> do
-            result <- runAgentWithProviderSwitches options
+            result <- runAgentWithRestarts options
             case result of
                 DevQuit -> pure ()
                 DevReload -> do
@@ -310,11 +313,24 @@ run = do
 -- | Tear down and rebuild provider-specific auth, tools, prompt, and transport.
 -- Automatic transitions carry the exact failed turn in memory and commit
 -- persisted provider metadata only after the replacement backend succeeds.
-runAgentWithProviderSwitches :: CliOptions -> IO DevResult
-runAgentWithProviderSwitches options = go options Nothing
+runAgentWithRestarts :: CliOptions -> IO DevResult
+runAgentWithRestarts options = go options Nothing
   where
     go current transition =
         runAgent current transition >>= \case
+            RunResumeSession sessionId ->
+                go
+                    current
+                        { optProvider = Nothing
+                        , optModel = Nothing
+                        , optCwd = Nothing
+                        , optWorktree = False
+                        , optEffort = Nothing
+                        , optPrompt = Nothing
+                        , optPromptFile = Nothing
+                        , optResume = Just sessionId
+                        }
+                    Nothing
             RunSwitchProvider next ->
                 go (applyProviderTransition current next) (Just next)
             RunProviderStartFailed apiError ->
@@ -1163,8 +1179,9 @@ replWithDraft env@SessionEnv
                                 pure (RunSwitchProvider providerSwitch)
                             Nothing -> continue
                     ReplResume maybeId -> do
-                        handleResume maybeId persist
-                        continue
+                        handleResume maybeId persist >>= \case
+                            Nothing -> continue
+                            Just result -> pure result
                     ReplClear -> do
                         sessionReset
                         color <- resolveColor stderr
@@ -1740,27 +1757,32 @@ loadPrompt options = case (options.optPrompt, options.optPromptFile) of
 handleResume
     :: Maybe Text
     -> Maybe (IORef (Either SessionCreate SessionHandle))
-    -> IO ()
+    -> IO (Maybe RunResult)
 handleResume maybeId persist = do
     color <- resolveColor stderr
     home <- getHomeDirectory
-    prog <- getProgName
-    let printHint sessionId =
-            Text.hPutStrLn stderr
-                (roleMuted color (resumeHint prog sessionId))
-    case maybeId of
-        Just sessionId -> printHint sessionId
-        Nothing -> do
-            sessions <- listSessions (sessionsRoot home)
+    let root = sessionsRoot home
+        resume sessionId = do
             currentId <- currentSessionId persist
-            pickResumeSession color sessions >>= \case
-                Nothing -> pure ()
-                Just sessionId
-                    | Just sessionId == currentId ->
-                        Text.hPutStrLn stderr
-                            (roleMuted color
-                                (glyphSession <> "already on session " <> sessionId))
-                    | otherwise -> printHint sessionId
+            if Just sessionId == currentId
+                then do
+                    Text.hPutStrLn stderr
+                        (roleMuted color
+                            (glyphSession <> "already on session " <> sessionId))
+                    pure Nothing
+                else
+                    loadSession root sessionId >>= \case
+                        Left err -> do
+                            Text.hPutStrLn stderr (roleError color (Text.pack err))
+                            pure Nothing
+                        Right _ -> pure (Just (RunResumeSession sessionId))
+    case maybeId of
+        Just sessionId -> resume sessionId
+        Nothing -> do
+            sessions <- listSessions root
+            pickResumeSession color root sessions >>= \case
+                Nothing -> pure Nothing
+                Just sessionId -> resume sessionId
 
 currentSessionId
     :: Maybe (IORef (Either SessionCreate SessionHandle))

--- a/packages/agent-cli/src/Agent/CLI/Command.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command.hs
@@ -76,7 +76,7 @@ slashCommands =
     , cmd "plan" [] "/plan [description]" "Enter plan mode (or Shift+Tab)"
     , cmd "session" [] "/session" "Print the current session id"
     , cmd "login" ["accounts"] "/login" "Manage provider credentials and usage"
-    , cmd "resume" [] "/resume [ID]" "Pick a session to resume, or print a --resume hint"
+    , cmd "resume" [] "/resume [ID]" "Pick a session to resume, or resume ID"
     , cmd "compact" [] "/compact [FOCUS]" "Summarize history to free context"
     , cmd "clear" [] "/clear" "Reset the live conversation (same session id)"
     , cmd "new" [] "/new" "Start a fresh persisted session id"

--- a/packages/agent-cli/src/Agent/CLI/Options.hs
+++ b/packages/agent-cli/src/Agent/CLI/Options.hs
@@ -245,7 +245,7 @@ usage = unlines
     , "/always-approve (or :yolo) toggles auto-approve and saves it under"
     , "<project>/.haskell-agent/settings.json. Permission prompts offer Allow once"
     , "or Always this tool this session; /always-approve still enables project yolo."
-    , "/resume [ID] prints a --resume hint (TTY: session picker)."
+    , "/resume [ID] resumes a persisted session (TTY: two-pane picker)."
     , "/paste [TEXT] attaches a clipboard image to the next"
     , "message and draws an in-terminal preview (Kitty/Ghostty/WezTerm/iTerm2);"
     , "/paste --send [TEXT] sends immediately. Cmd+V of a Finder image path also"

--- a/packages/agent-cli/src/Agent/CLI/Resume.hs
+++ b/packages/agent-cli/src/Agent/CLI/Resume.hs
@@ -7,19 +7,26 @@ module Agent.CLI.Resume
     , initialResumeState
     , pickResumeSession
     , renderResumeFrame
+    , renderResumeFrameFor
     , resumeEntriesFrom
     , visibleResume
     ) where
 
 import Agent.CLI.Picker (PickerKey(..), runOverlay)
-import Agent.CLI.Session (SessionMeta(..))
-import Agent.CLI.Style (roleMuted, rolePrompt, roleSuccess, roleWarn)
+import Agent.CLI.Session
+    ( SessionMeta(..)
+    , SessionTurn(..)
+    , loadSession
+    )
+import Agent.CLI.Style (roleMuted, rolePrompt, roleSuccess)
 import Agent.Provider (providerSlug)
+import Control.Monad (forM)
 import Data.Char (isAlphaNum)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
 import Data.Time.Format (defaultTimeLocale, formatTime)
+import System.Console.ANSI (getTerminalSize)
 import System.FilePath (takeFileName)
 import System.IO (hFlush, hIsTerminalDevice, stderr, stdin)
 
@@ -30,6 +37,7 @@ data ResumeEntry = ResumeEntry
     , resumeCwd :: !Text
     , resumeWhen :: !Text
     , resumeProvider :: !Text
+    , resumeTranscript :: ![Text]
     }
     deriving (Eq, Show)
 
@@ -40,20 +48,23 @@ data ResumeState = ResumeState
     }
     deriving (Eq, Show)
 
-resumeEntriesFrom :: [SessionMeta] -> [ResumeEntry]
-resumeEntriesFrom = map toEntry
-  where
-    toEntry meta =
-        ResumeEntry
-            { resumeId = meta.metaId
-            , resumeTitle =
-                if Text.null meta.metaTitle then "(untitled)" else meta.metaTitle
-            , resumeModel = meta.metaModel
-            , resumeCwd = Text.pack (takeFileName meta.metaCwd)
-            , resumeWhen =
-                Text.pack (formatTime defaultTimeLocale "%Y-%m-%d %H:%M" meta.metaUpdatedAt)
-            , resumeProvider = providerSlug meta.metaProvider
-            }
+-- | Build picker entries from already loaded sessions.
+resumeEntriesFrom :: [(SessionMeta, [SessionTurn])] -> [ResumeEntry]
+resumeEntriesFrom = map (uncurry entryFrom)
+
+entryFrom :: SessionMeta -> [SessionTurn] -> ResumeEntry
+entryFrom meta turns =
+    ResumeEntry
+        { resumeId = meta.metaId
+        , resumeTitle =
+            if Text.null meta.metaTitle then "(untitled)" else meta.metaTitle
+        , resumeModel = meta.metaModel
+        , resumeCwd = Text.pack (takeFileName meta.metaCwd)
+        , resumeWhen =
+            Text.pack (formatTime defaultTimeLocale "%Y-%m-%d %H:%M" meta.metaUpdatedAt)
+        , resumeProvider = providerSlug meta.metaProvider
+        , resumeTranscript = transcriptLines turns
+        }
 
 initialResumeState :: [ResumeEntry] -> ResumeState
 initialResumeState entries =
@@ -121,35 +132,118 @@ isFilterChar :: Char -> Bool
 isFilterChar c =
     isAlphaNum c || c `elem` ("-_/." :: String)
 
+-- | Stable default size for tests and non-interactive callers.
 renderResumeFrame :: Bool -> ResumeState -> Text
-renderResumeFrame color state =
-    let visible = visibleResume state
-        n = length visible
-        idx = clamp n state.resumeIndex
-        header = rolePrompt color "resume" <> roleMuted color " · pick a session"
-        filterLine
-            | Text.null state.resumeFilter =
-                roleMuted color "filter: (type to narrow)"
-            | otherwise =
-                roleMuted color "filter: " <> roleWarn color state.resumeFilter
-        body = case visible of
-            [] -> [roleMuted color "(no sessions)"]
-            opts ->
-                zipWith
-                    (\i e -> renderRow color (i == idx) e)
-                    [0 ..]
-                    opts
-        footer = roleMuted color "↑↓/jk · enter · esc/q · type to filter"
-    in Text.intercalate "\n" (header : filterLine : body <> [footer])
+renderResumeFrame color = renderResumeFrameFor color 24 100
 
-renderRow :: Bool -> Bool -> ResumeEntry -> Text
-renderRow color selected e =
-    let cursor = if selected then roleWarn color "› " else "  "
-        title = if selected then roleSuccess color e.resumeTitle else e.resumeTitle
-        meta =
-            roleMuted color
-                (e.resumeWhen <> "  " <> e.resumeModel <> "  " <> e.resumeCwd)
-    in cursor <> title <> "\n    " <> meta
+-- | Render a fixed-height, two-column picker. The left column follows the
+-- selection through the recent session titles; the right column shows the
+-- tail of that selected session's transcript.
+renderResumeFrameFor :: Bool -> Int -> Int -> ResumeState -> Text
+renderResumeFrameFor color terminalRows terminalCols state =
+    Text.intercalate "\n" (header : headings : body <> [footer])
+  where
+    cols = max 12 terminalCols
+    -- Leave the final terminal row unused. Redrawing a frame that exactly
+    -- fills the viewport would scroll its first line and duplicate the header.
+    bodyRows = max 1 (terminalRows - 4)
+    divider = roleMuted color " │ "
+    leftWidth = max 8 (min 34 ((cols - 3) * 2 `div` 5))
+    rightWidth = max 1 (cols - leftWidth - 3)
+    visible = visibleResume state
+    n = length visible
+    idx = clamp n state.resumeIndex
+    shown = sessionWindow bodyRows idx visible
+    selected = selectedResume state
+    filterText
+        | Text.null state.resumeFilter = "type to filter"
+        | otherwise = "filter: " <> state.resumeFilter
+    header =
+        rolePrompt color "resume"
+            <> roleMuted color
+                (fitCell (max 0 (cols - 6)) (" · " <> filterText))
+    headings =
+        rolePrompt color (fitCell leftWidth "sessions")
+            <> divider
+            <> rolePrompt color
+                (fitCell rightWidth
+                    ("transcript"
+                        <> maybe "" (\entry -> " · " <> entry.resumeTitle) selected))
+    leftRows =
+        map
+            (\(absoluteIndex, entry) ->
+                let prefix = if absoluteIndex == idx then "› " else "  "
+                    text = fitCell leftWidth (prefix <> entry.resumeTitle)
+                in if absoluteIndex == idx
+                    then roleSuccess color text
+                    else text)
+            shown
+            <> repeat (Text.replicate leftWidth " ")
+    rightRows = case selected of
+        Nothing -> roleMuted color (fitCell rightWidth "(no sessions)") : repeat ""
+        Just entry ->
+            let preview = previewRows rightWidth bodyRows entry.resumeTranscript
+            in map (fitCell rightWidth) preview <> repeat ""
+    body =
+        take bodyRows $
+            zipWith
+                (\left right -> left <> divider <> right)
+                leftRows
+                rightRows
+    footer =
+        roleMuted color $
+            fitCell cols "↑↓/jk select · enter resume · esc/q cancel · type to filter"
+
+sessionWindow :: Int -> Int -> [a] -> [(Int, a)]
+sessionWindow count selected xs =
+    let total = length xs
+        start = max 0 (min selected (total - count))
+    in zip [start ..] (take count (drop start xs))
+
+previewRows :: Int -> Int -> [Text] -> [Text]
+previewRows width count logicalLines =
+    let wrapped = concatMap (hardWrap width) logicalLines
+        rows
+            | null wrapped = ["(empty transcript)"]
+            | otherwise = wrapped
+    in drop (max 0 (length rows - count)) rows
+
+hardWrap :: Int -> Text -> [Text]
+hardWrap width raw
+    | Text.null raw = [""]
+    | otherwise = go raw
+  where
+    width' = max 1 width
+    go text
+        | Text.null text = []
+        | otherwise =
+            let (line, rest) = Text.splitAt width' text
+            in line : go rest
+
+fitCell :: Int -> Text -> Text
+fitCell width raw
+    | width <= 0 = ""
+    | Text.length clean <= width =
+        clean <> Text.replicate (width - Text.length clean) " "
+    | width == 1 = "…"
+    | otherwise = Text.take (width - 1) clean <> "…"
+  where
+    clean = Text.map (\c -> if c == '\t' || c == '\r' || c == '\n' then ' ' else c) raw
+
+transcriptLines :: [SessionTurn] -> [Text]
+transcriptLines = concatMap turnLines
+  where
+    turnLines turn =
+        labelled "user: " turn.turnUserText
+            <> maybe [] (labelled "assistant: ") turn.turnAssistantText
+            <> [""]
+
+    labelled prefix raw =
+        case Text.lines (Text.strip raw) of
+            [] -> []
+            firstLine : rest ->
+                (prefix <> firstLine)
+                    : map (Text.replicate (Text.length prefix) " " <>) rest
 
 formatResumeListing :: Bool -> [ResumeEntry] -> Text
 formatResumeListing color entries =
@@ -158,28 +252,52 @@ formatResumeListing color entries =
         else Text.intercalate "\n" (map (formatOne color) entries)
 
 formatOne :: Bool -> ResumeEntry -> Text
-formatOne color e =
-    roleMuted color (Text.take 8 e.resumeId)
+formatOne color entry =
+    roleMuted color (Text.take 8 entry.resumeId)
         <> "  "
-        <> e.resumeTitle
-        <> roleMuted color ("  " <> e.resumeModel)
+        <> entry.resumeTitle
+        <> roleMuted color ("  " <> entry.resumeModel)
 
 -- | TTY picker; non-TTY prints the list. Confirm returns the session id.
-pickResumeSession :: Bool -> [SessionMeta] -> IO (Maybe Text)
-pickResumeSession color metas = do
-    let entries = resumeEntriesFrom metas
+-- Loading is capped to the latest sessions so opening the picker stays cheap.
+pickResumeSession :: Bool -> FilePath -> [SessionMeta] -> IO (Maybe Text)
+pickResumeSession color root metas = do
     isTty <- hIsTerminalDevice stdin
+    loaded <- loadRecentSessions root metas
+    let entries = resumeEntriesFrom loaded
     if not isTty
         then do
             Text.hPutStrLn stderr (formatResumeListing color entries)
             hFlush stderr
             pure Nothing
         else do
+            size <- getTerminalSize
+            let (rows, cols) = maybe (24, 100) id size
             result <-
                 runOverlay
-                    (renderResumeFrame color)
+                    (renderResumeFrameFor color rows cols)
                     applyResumeKey
                     (initialResumeState entries)
             pure $ case result of
                 Just (Just entry) -> Just entry.resumeId
                 _ -> Nothing
+
+loadRecentSessions :: FilePath -> [SessionMeta] -> IO [(SessionMeta, [SessionTurn])]
+loadRecentSessions root metas =
+    forM (take 20 metas) \meta ->
+        loadSession root meta.metaId >>= \case
+            Right loaded -> pure loaded
+            Left err ->
+                pure
+                    ( meta
+                    , [ SessionTurn
+                            { turnAt = meta.metaUpdatedAt
+                            , turnUserText = ""
+                            , turnAssistantText =
+                                Just ("Transcript unavailable: " <> Text.pack err)
+                            , turnResponseId = Nothing
+                            , turnItems = []
+                            , turnUsage = Nothing
+                            }
+                      ]
+                    )

--- a/packages/agent-cli/test/Agent/CLI/ResumeSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ResumeSpec.hs
@@ -2,7 +2,7 @@ module Agent.CLI.ResumeSpec (spec) where
 
 import Agent.CLI.Picker (PickerKey(..))
 import Agent.CLI.Resume
-import Agent.CLI.Session (SessionMeta(..))
+import Agent.CLI.Session (SessionMeta(..), SessionTurn(..))
 import Agent.Provider (Provider(..))
 import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
 import qualified Data.Text as Text
@@ -12,7 +12,7 @@ spec :: Spec
 spec = do
     describe "resumeEntriesFrom" do
         it "uses untitled when the title is empty" do
-            case resumeEntriesFrom [sampleMeta "abc" ""] of
+            case resumeEntriesFrom [(sampleMeta "abc" "", [])] of
                 [entry] -> do
                     entry.resumeTitle `shouldBe` "(untitled)"
                     entry.resumeId `shouldBe` "abc"
@@ -22,8 +22,8 @@ spec = do
     describe "applyResumeKey" do
         let entries =
                 resumeEntriesFrom
-                    [ sampleMeta "one" "first"
-                    , sampleMeta "two" "second"
+                    [ (sampleMeta "one" "first", [])
+                    , (sampleMeta "two" "second", [])
                     ]
             state0 = initialResumeState entries
 
@@ -54,9 +54,35 @@ spec = do
         it "lists titles" do
             let frame =
                     renderResumeFrame False $
-                        initialResumeState (resumeEntriesFrom [sampleMeta "one" "first"])
+                        initialResumeState
+                            (resumeEntriesFrom
+                                [(sampleMeta "one" "first", [sampleTurn])])
             frame `shouldSatisfy` Text.isInfixOf "first"
             frame `shouldSatisfy` Text.isInfixOf "resume"
+            frame `shouldSatisfy` Text.isInfixOf "transcript"
+            frame `shouldSatisfy` Text.isInfixOf "user: hello"
+
+        it "keeps the selected title and transcript in separate columns" do
+            let frame =
+                    renderResumeFrameFor False 10 80 $
+                        initialResumeState
+                            (resumeEntriesFrom
+                                [(sampleMeta "one" "first", [sampleTurn])])
+            frame `shouldSatisfy` Text.isInfixOf "sessions"
+            frame `shouldSatisfy` Text.isInfixOf " │ "
+            frame `shouldSatisfy` Text.isInfixOf "assistant: hi"
+            length (Text.lines frame) `shouldBe` 9
+
+sampleTurn :: SessionTurn
+sampleTurn =
+    SessionTurn
+        { turnAt = posixSecondsToUTCTime 0
+        , turnUserText = "hello"
+        , turnAssistantText = Just "hi"
+        , turnResponseId = Nothing
+        , turnItems = []
+        , turnUsage = Nothing
+        }
 
 sampleMeta :: Text.Text -> Text.Text -> SessionMeta
 sampleMeta sid title =


### PR DESCRIPTION
## Summary
- render `/resume` as a terminal-sized two-column picker with recent session titles and a live transcript preview
- restart the active runtime on Enter so the selected persisted session is resumed immediately, including provider/model/cwd reconstruction
- integrate session restarts with provider transitions and automatic provider fallback
- keep filtering, keyboard navigation, non-TTY listing, corrupt-transcript fallback, and current-session handling
- update slash-command help and add focused picker rendering/transcript tests

## Validation
- `nix develop -c cabal repl agent-cli:test:agent-cli-test` (`:main`): **275 examples, 0 failures**
- live tmux TTY smoke test: navigation, redraw, transcript preview, cancel, and Enter-to-resume verified
- rebased onto current `master`
- `git diff --check`
