### PR TITLE
Fix Grok subagent startup race and worktree cleanup

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -145,7 +145,12 @@ import Agent.CLI.Usage
     ( AccountUsageLine(..)
     , formatUsageReport
     )
-import Agent.CLI.Worktree (createWorktree, isUnderWorktreeRoot, worktreeRoot)
+import Agent.CLI.Worktree
+    ( createWorktree
+    , isUnderWorktreeRoot
+    , removeWorktree
+    , worktreeRoot
+    )
 import Agent.Loop
 import Agent.Error (ApiError)
 import Agent.InterAgentMessage (InterAgentMessage, interAgentMessagePayload)
@@ -221,7 +226,7 @@ import Agent.Tools.Grok.Task
     , recordAgentSpec
     )
 import Agent.Subagents.TaskPath (taskPathRoot, taskPathText)
-import Agent.Tools.MultiAgents (MultiAgentContext(..))
+import Agent.Tools.MultiAgents (MultiAgentContext(..), SubagentWorktree(..))
 import Agent.Tools.PlanMode
     ( PlanModeEnv(..)
     , PlanModeHooks
@@ -526,7 +531,13 @@ runAgent options transition = do
             , multiCreateWorktree = Just \source ->
                 createWorktree source (worktreeRoot home) >>= \case
                     Left err -> pure (Left (Text.pack err))
-                    Right path -> pure (Right path)
+                    Right path -> pure $ Right SubagentWorktree
+                        { subagentWorktreePath = path
+                        , subagentWorktreeCleanup =
+                            removeWorktree source path >>= \case
+                                Left err -> pure (Left (Text.pack err))
+                                Right () -> pure (Right ())
+                        }
             , multiSendToRoot = Just sendToRoot
             }
     coding <- codingToolsForWithTypes provider toolEnv (Just planHooks) multiCtx agentTypesRef

--- a/packages/agent-cli/src/Agent/CLI/Worktree.hs
+++ b/packages/agent-cli/src/Agent/CLI/Worktree.hs
@@ -1,12 +1,14 @@
 -- | Create isolated git worktrees under @~/.haskell-agent/worktrees@.
 module Agent.CLI.Worktree
     ( createWorktree
+    , removeWorktree
     , isUnderWorktreeRoot
     , worktreePath
     , worktreeRoot
     ) where
 
 import Agent.OsPath (OsPath, fromFilePath, toFilePath)
+import Control.Exception.Safe (mask, onException, tryAny)
 import Data.Char (isSpace)
 import Data.List (dropWhileEnd, isInfixOf, isPrefixOf)
 import Data.Time.Calendar (Day)
@@ -14,7 +16,11 @@ import Data.Time.Clock (UTCTime(..), getCurrentTime, nominalDiffTimeToSeconds)
 import Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds)
 import Data.Time.Format (defaultTimeLocale, formatTime)
 import Numeric (showHex)
-import System.Directory.OsPath (createDirectoryIfMissing, doesPathExist)
+import System.Directory.OsPath
+    ( createDirectoryIfMissing
+    , doesPathExist
+    , removePathForcibly
+    )
 import System.Exit (ExitCode(..))
 import System.OsPath
     ( equalFilePath
@@ -55,6 +61,18 @@ createWorktree source root = do
             createDirectoryIfMissing True (root </> repoName)
             addUnique repo root repoName day start 0
 
+-- | Remove a managed worktree and the branch created for it.
+removeWorktree :: OsPath -> OsPath -> IO (Either String ())
+removeWorktree source path = do
+    gitToplevel source >>= \case
+        Left err -> pure (Left err)
+        Right repo ->
+            git repo ["worktree", "remove", "--force", toFilePath path] >>= \case
+                Left err -> pure (Left err)
+                Right _ ->
+                    fmap (fmap (const ())) $
+                        git repo ["branch", "-D", toFilePath (takeFileName path)]
+
 addUnique
     :: OsPath
     -> OsPath
@@ -71,12 +89,23 @@ addUnique repo root repoName day start attempt
         exists <- doesPathExist path
         if exists
             then addUnique repo root repoName day start (attempt + 1)
-            else git repo ["worktree", "add", toFilePath path] >>= \case
-                Left err
-                    | branchTaken err ->
-                        addUnique repo root repoName day start (attempt + 1)
-                    | otherwise -> pure (Left err)
-                Right _ -> pure (Right path)
+            else mask \restore -> do
+                added <- restore (git repo ["worktree", "add", toFilePath path])
+                    `onException` cleanupWorktreeCandidate repo path
+                case added of
+                    Left err
+                        | branchTaken err ->
+                            addUnique repo root repoName day start (attempt + 1)
+                        | otherwise -> pure (Left err)
+                    Right _ -> pure (Right path)
+
+cleanupWorktreeCandidate :: OsPath -> OsPath -> IO ()
+cleanupWorktreeCandidate repo path = do
+    _ <- git repo ["worktree", "remove", "--force", toFilePath path]
+    _ <- tryAny (removePathForcibly path)
+    _ <- git repo ["worktree", "prune"]
+    _ <- git repo ["branch", "-D", toFilePath (takeFileName path)]
+    pure ()
 
 gitToplevel :: OsPath -> IO (Either String OsPath)
 gitToplevel source = git source ["rev-parse", "--show-toplevel"] >>= \case

--- a/packages/agent-cli/test/Agent/CLI/WorktreeSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/WorktreeSpec.hs
@@ -79,6 +79,16 @@ spec = describe "Agent.CLI.Worktree" do
                 doesDirectoryExist first `shouldReturn` True
                 doesDirectoryExist second `shouldReturn` True
 
+        it "removes the worktree and its generated branch" $
+            withTempGitRepo \repo ->
+            withTempDir "agent-home-" \home -> do
+                path <- expectRight =<< createWorktree repo (worktreeRoot home)
+                let branch = toFilePath (takeFileName path)
+                removeWorktree repo path `shouldReturn` Right ()
+                doesDirectoryExist path `shouldReturn` False
+                branches <- git repo ["branch", "--list", branch]
+                branches `shouldBe` ""
+
 expectRight :: Either String OsPath -> IO OsPath
 expectRight = \case
     Right path -> pure path

--- a/packages/agent-core/src/Agent/Subagents/Registry.hs
+++ b/packages/agent-core/src/Agent/Subagents/Registry.hs
@@ -13,7 +13,9 @@ module Agent.Subagents.Registry
     , resetSubagentRegistry
     , spawnSubagent
     , spawnSubagentWithCwd
+    , spawnSubagentWithCwdPrepared
     , spawnSubagentAt
+    , spawnSubagentAtWithCwdPrepared
     , restoreSubagent
     , restoreSubagentWithCwd
     , waitSubagents
@@ -188,7 +190,20 @@ spawnSubagentWithCwd
     -> Text
     -> Maybe Text
     -> IO (Either Text SubagentId)
-spawnSubagentWithCwd registry childCwd parentId parentDepth message nickname = do
+spawnSubagentWithCwd registry childCwd =
+    spawnSubagentWithCwdPrepared registry childCwd (\_ -> pure ())
+
+-- | Run host preparation after admission but before the worker starts.
+spawnSubagentWithCwdPrepared
+    :: SubagentRegistry
+    -> OsPath
+    -> (SubagentId -> IO ())
+    -> Maybe SubagentId
+    -> Int
+    -> Text
+    -> Maybe Text
+    -> IO (Either Text SubagentId)
+spawnSubagentWithCwdPrepared registry childCwd beforeStart parentId parentDepth message nickname = do
     parentPath <- case parentId of
         Nothing -> pure taskPathRoot
         Just pid -> do
@@ -201,8 +216,8 @@ spawnSubagentWithCwd registry childCwd parentId parentDepth message nickname = d
     -- Reuse the generated id by spawning with an explicit path helper that
     -- still allocates internally; uniqueness comes from the id-derived name.
     fmap (fmap fst) $
-        spawnSubagentAtWithCwd
-            registry childCwd parentId parentPath parentDepth taskName
+        spawnSubagentAtWithCwdPrepared
+            registry childCwd beforeStart parentId parentPath parentDepth taskName
                 (plainInterAgentContent message) nickname
 
 -- | Spawn with an explicit parent path and task_name (Codex multi-agent v2).
@@ -216,11 +231,12 @@ spawnSubagentAt
     -> Maybe Text
     -> IO (Either Text (SubagentId, TaskPath))
 spawnSubagentAt registry =
-    spawnSubagentAtWithCwd registry registry.registryCwd
+    spawnSubagentAtWithCwdPrepared registry registry.registryCwd (\_ -> pure ())
 
-spawnSubagentAtWithCwd
+spawnSubagentAtWithCwdPrepared
     :: SubagentRegistry
     -> OsPath
+    -> (SubagentId -> IO ())
     -> Maybe SubagentId
     -> TaskPath
     -> Int
@@ -228,7 +244,7 @@ spawnSubagentAtWithCwd
     -> InterAgentMessageContent
     -> Maybe Text
     -> IO (Either Text (SubagentId, TaskPath))
-spawnSubagentAtWithCwd registry childCwd parentId parentPath parentDepth taskName content nickname = do
+spawnSubagentAtWithCwdPrepared registry childCwd beforeStart parentId parentPath parentDepth taskName content nickname = do
     let nextDepth = parentDepth + 1
         cfg = registry.registryConfig
     case cfg.maxDepth of
@@ -281,22 +297,53 @@ spawnSubagentAtWithCwd registry childCwd parentId parentPath parentDepth taskNam
                                             pure (Right ())
                 case admitted of
                     Left err -> pure (Left err)
-                    Right () -> do
-                        let message = InterAgentMessage
-                                { messageAuthor = taskPathText parentPath
-                                , messageRecipient = taskPathText childPath
-                                , messageType = NewTaskMessage
-                                , messageContent = content
-                                }
-                        started <-
-                            startRecordWorker registry record
-                                (runWorker registry record message)
-                                `onException` shutdownRecord registry record
-                        if started
-                            then pure (Right (agentId, childPath))
-                            else do
-                                shutdownRecord registry record
-                                pure (Left "Subagent closed before its worker started.")
+                    Right () -> mask \restore ->
+                        (do
+                            prepared <- tryAny (restore (beforeStart agentId))
+                            case prepared of
+                                Left (exc :: SomeException) -> do
+                                    rollbackAdmission registry record
+                                    pure $ Left $
+                                        "Failed to prepare subagent: "
+                                            <> Text.pack (show exc)
+                                Right () ->
+                                    startPrepared restore agentId childPath record)
+                            `onException` rollbackAdmission registry record
+  where
+    startPrepared restore agentId childPath record = do
+        let message = InterAgentMessage
+                { messageAuthor = taskPathText parentPath
+                , messageRecipient = taskPathText childPath
+                , messageType = NewTaskMessage
+                , messageContent = content
+                }
+        started <-
+            restore
+                (startRecordWorker registry record
+                    (runWorker registry record message))
+                `onException` shutdownRecord registry record
+        if started
+            then pure (Right (agentId, childPath))
+            else do
+                rollbackAdmission registry record
+                pure (Left "Subagent closed before its worker started.")
+
+rollbackAdmission :: SubagentRegistry -> SubagentRecord -> IO ()
+rollbackAdmission registry record = atomically do
+    modifyTVar' registry.registryAgents (Map.delete record.recordId)
+    modifyTVar' registry.registryPaths $
+        deleteOwnedPath record.recordTaskPath record.recordId
+    held <- readTVar record.recordSlotHeld
+    whenSTM held do
+        writeTVar record.recordSlotHeld False
+        live <- readTVar registry.registryLiveCount
+        writeTVar registry.registryLiveCount (max 0 (live - 1))
+
+deleteOwnedPath :: TaskPath -> SubagentId -> Map TaskPath SubagentId -> Map TaskPath SubagentId
+deleteOwnedPath key expected mappings =
+    case Map.lookup key mappings of
+        Just actual | actual == expected -> Map.delete key mappings
+        _ -> mappings
 
 runWorker :: SubagentRegistry -> SubagentRecord -> InterAgentMessage -> IO ()
 runWorker registry record firstPrompt = do

--- a/packages/agent-core/src/Agent/Tools/Grok/Task.hs
+++ b/packages/agent-core/src/Agent/Tools/Grok/Task.hs
@@ -25,7 +25,7 @@ import Agent.Subagents
     , defaultWaitTimeoutMs
     , getStatus
     , sendInput
-    , spawnSubagentWithCwd
+    , spawnSubagentWithCwdPrepared
     , waitSubagents
     )
 import Agent.ToolArgs
@@ -39,11 +39,12 @@ import Agent.ToolDSL
     , PropertyType(..)
     )
 import Agent.ToolDispatch (typedTool)
-import Agent.Tools.MultiAgents (MultiAgentContext(..))
+import Agent.Tools.MultiAgents (MultiAgentContext(..), SubagentWorktree(..))
 import Agent.Tools.Types
     ( AppTool(..)
     , AppToolKind(..)
     )
+import Control.Exception.Safe (mask, onException)
 import Data.Aeson (FromJSON(..))
 import Data.IORef
 import Data.Map.Strict (Map)
@@ -180,33 +181,38 @@ runTask baseCwd ctx typesRef args
     , Just iso <- args.isolation
     , isWorktreeIsolation iso =
         pure (Left "cwd and isolation are mutually exclusive.")
-    | otherwise = resolveTaskWorkspace baseCwd ctx args >>= \case
-        Left err -> pure (Left err)
-        Right (childCwd, worktreePath) ->
-            spawnFresh childCwd worktreePath ctx typesRef args
+    | otherwise = mask \restore ->
+        resolveTaskWorkspace baseCwd ctx args >>= \case
+            Left err -> pure (Left err)
+            Right (childCwd, worktree) ->
+                restore (spawnFresh childCwd worktree ctx typesRef args)
 
 spawnFresh
     :: OsPath
-    -> Maybe OsPath
+    -> Maybe SubagentWorktree
     -> MultiAgentContext
     -> GrokSubagentSpecs
     -> TaskArgs
     -> IO (Either Text Text)
-spawnFresh childCwd worktreePath ctx typesRef args = do
-    result <- spawnSubagentWithCwd
-        ctx.multiRegistry
-        childCwd
-        ctx.multiSelfId
-        ctx.multiDepth
-        args.prompt
-        (Just args.description)
+spawnFresh childCwd worktree ctx typesRef args = mask \restore -> do
+    let spec = GrokSubagentSpec
+            { agentType = args.subagentType
+            , modelOverride = args.model
+            }
+        worktreePath = (.subagentWorktreePath) <$> worktree
+    result <- restore
+        (spawnSubagentWithCwdPrepared
+            ctx.multiRegistry
+            childCwd
+            (\agentId -> recordAgentSpec typesRef agentId spec)
+            ctx.multiSelfId
+            ctx.multiDepth
+            args.prompt
+            (Just args.description))
+        `onException` cleanupWorktreeQuietly worktree
     case result of
-        Left err -> pure (Left err)
-        Right agentId -> do
-            recordAgentSpec typesRef agentId GrokSubagentSpec
-                { agentType = args.subagentType
-                , modelOverride = args.model
-                }
+        Left err -> cleanupFailedWorktree worktree err
+        Right agentId -> restore do
             if args.runInBackground
                 then pure $ Right $ formatTaskStarted agentId args worktreePath
                 else do
@@ -215,11 +221,29 @@ spawnFresh childCwd worktreePath ctx typesRef args = do
                     pure $ Right $ formatTaskCompleted agentId args worktreePath timedOut
                         (Map.lookup agentId statuses)
 
+cleanupWorktreeQuietly :: Maybe SubagentWorktree -> IO ()
+cleanupWorktreeQuietly Nothing = pure ()
+cleanupWorktreeQuietly (Just worktree) = do
+    _ <- worktree.subagentWorktreeCleanup
+    pure ()
+
+cleanupFailedWorktree
+    :: Maybe SubagentWorktree
+    -> Text
+    -> IO (Either Text Text)
+cleanupFailedWorktree Nothing spawnError = pure (Left spawnError)
+cleanupFailedWorktree (Just worktree) spawnError =
+    worktree.subagentWorktreeCleanup >>= \case
+        Right () -> pure (Left spawnError)
+        Left cleanupError ->
+            pure $ Left $
+                spawnError <> "\nAdditionally, worktree cleanup failed: " <> cleanupError
+
 resolveTaskWorkspace
     :: OsPath
     -> MultiAgentContext
     -> TaskArgs
-    -> IO (Either Text (OsPath, Maybe OsPath))
+    -> IO (Either Text (OsPath, Maybe SubagentWorktree))
 resolveTaskWorkspace baseCwd ctx args
     | maybe False isWorktreeIsolation args.isolation =
         case ctx.multiCreateWorktree of
@@ -227,7 +251,8 @@ resolveTaskWorkspace baseCwd ctx args
             Just create ->
                 create baseCwd >>= \case
                     Left err -> pure (Left err)
-                    Right path -> pure (Right (path, Just path))
+                    Right worktree ->
+                        pure (Right (worktree.subagentWorktreePath, Just worktree))
     | otherwise = do
         resolved <- resolveTaskCwd baseCwd args.cwd
         pure $ case resolved of

--- a/packages/agent-core/src/Agent/Tools/MultiAgents.hs
+++ b/packages/agent-core/src/Agent/Tools/MultiAgents.hs
@@ -4,6 +4,7 @@
 -- @codex-rs/core/src/tools/handlers/multi_agents_spec.rs@ (v2).
 module Agent.Tools.MultiAgents
     ( MultiAgentContext(..)
+    , SubagentWorktree(..)
     , multiAgentTools
     , multiAgentNamespace
     , multiAgentToolNames
@@ -66,6 +67,11 @@ import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 
+data SubagentWorktree = SubagentWorktree
+    { subagentWorktreePath :: !OsPath
+    , subagentWorktreeCleanup :: !(IO (Either Text ()))
+    }
+
 -- | Per-agent identity for nesting depth / parent linkage / task path.
 data MultiAgentContext = MultiAgentContext
     { multiRegistry :: !SubagentRegistry
@@ -76,7 +82,7 @@ data MultiAgentContext = MultiAgentContext
       -- before follow-ups. 'Nothing' means in-memory only.
     , multiResumeFromDisk :: !(Maybe (SubagentId -> IO (Either Text ())))
       -- | Optional host hook for Grok-style isolated worktree children.
-    , multiCreateWorktree :: !(Maybe (OsPath -> IO (Either Text OsPath)))
+    , multiCreateWorktree :: !(Maybe (OsPath -> IO (Either Text SubagentWorktree)))
       -- | Deliver a child message to the root agent's next model turn.
     , multiSendToRoot :: !(Maybe (InterAgentMessage -> IO (Either Text Text)))
     }

--- a/packages/agent-core/test/Agent/SubagentsSpec.hs
+++ b/packages/agent-core/test/Agent/SubagentsSpec.hs
@@ -4,8 +4,10 @@ import Agent.InterAgentMessage
 import Agent.Loop (LoopError(..), LoopResult(..), emptyTokenUsage)
 import Agent.OsPath (fromFilePath)
 import Agent.Subagents
-import Agent.Subagents.TaskPath (taskPathRoot, taskPathText)
+import Agent.Subagents.TaskPath (TaskPath, taskPathRoot, taskPathText)
 import Control.Concurrent (threadDelay)
+import qualified Control.Concurrent.Async as Async
+import Control.Concurrent.MVar
 import Control.Concurrent.STM
 import Control.Exception.Safe (finally)
 import Control.Monad (unless)
@@ -40,6 +42,55 @@ spec = describe "Agent.Subagents" do
         (statuses, timedOut) <- waitSubagents registry [agentId] 15000
         timedOut `shouldBe` False
         Map.lookup agentId statuses `shouldBe` Just (Completed (Just "done:hello"))
+
+    it "does not launch a prepared worker after registry shutdown" do
+        entered <- newEmptyMVar
+        release <- newEmptyMVar
+        ran <- newIORef False
+        registry <- shutdownRaceRegistry ran
+        spawning <- Async.async $
+            spawnSubagentWithCwdPrepared registry (fromFilePath "/tmp")
+                (blockPreparation entered release)
+                Nothing 0 "task" Nothing
+        takeMVar entered
+        closeSubagentRegistry registry
+        putMVar release ()
+        Async.wait spawning `shouldReturn`
+            Left "Subagent closed before its worker started."
+        readIORef ran `shouldReturn` False
+
+    it "rolls back prepared admission when spawning is cancelled" do
+        entered <- newEmptyMVar
+        release <- newEmptyMVar
+        ran <- newIORef False
+        registry <- shutdownRaceRegistry ran
+        spawning <- Async.async $
+            spawnSubagentWithCwdPrepared registry (fromFilePath "/tmp")
+                (blockPreparation entered release)
+                Nothing 0 "cancelled" Nothing
+        takeMVar entered
+        Async.cancel spawning
+        _ <- Async.waitCatch spawning
+        Right _ <- spawnSubagent registry Nothing 0 "next" Nothing
+        closeSubagentRegistry registry
+
+    it "preserves replacement paths when an old spawn rolls back" do
+        entered <- newEmptyMVar
+        release <- newEmptyMVar
+        ran <- newIORef False
+        registry <- shutdownRaceRegistry ran
+        oldSpawn <- Async.async $
+            spawnPreparedAt registry entered release
+        takeMVar entered
+        resetSubagentRegistry registry
+        Right (replacement, _) <-
+            spawnSubagentAt registry Nothing taskPathRoot 0 "worker"
+                (plainInterAgentContent "new") Nothing
+        putMVar release ()
+        _ <- Async.wait oldSpawn
+        resolveAgentTarget registry taskPathRoot "worker"
+            `shouldReturn` Right replacement
+        closeSubagentRegistry registry
 
     it "rejects spawn past maxDepth" do
         let config = defaultSubagentConfig { maxDepth = Just 1 }
@@ -347,3 +398,24 @@ spec = describe "Agent.Subagents" do
             Right _ -> True
             Left _ -> False
         closeSubagentRegistry registry
+
+shutdownRaceRegistry :: IORef Bool -> IO SubagentRegistry
+shutdownRaceRegistry ran =
+    newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
+        (\_ _ _ _ -> writeIORef ran True >> pure (Left LoopNoResponseId))
+        (\_ _ -> pure ())
+
+blockPreparation :: MVar () -> MVar () -> SubagentId -> IO ()
+blockPreparation entered release _ =
+    putMVar entered () >> takeMVar release
+
+spawnPreparedAt
+    :: SubagentRegistry
+    -> MVar ()
+    -> MVar ()
+    -> IO (Either Text (SubagentId, TaskPath))
+spawnPreparedAt registry entered release =
+    spawnSubagentAtWithCwdPrepared registry (fromFilePath "/tmp")
+        (blockPreparation entered release)
+        Nothing taskPathRoot 0 "worker"
+        (plainInterAgentContent "old") Nothing

--- a/packages/agent-core/test/Agent/Tools/Grok/TaskSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/Grok/TaskSpec.hs
@@ -2,7 +2,7 @@ module Agent.Tools.Grok.TaskSpec (spec) where
 
 import Agent.Loop (LoopError(..), LoopResult(..), defaultLoopDispatch, emptyTokenUsage)
 import Agent.InterAgentMessage (interAgentMessagePayload)
-import Agent.OsPath (fromFilePath)
+import Agent.OsPath (OsPath, fromFilePath)
 import Agent.Subagents
 import Agent.ToolDispatch
     ( ToolCallResult(..)
@@ -12,8 +12,9 @@ import Agent.ToolDispatch
     )
 import Agent.Tools.Grok.Task
 import Agent.Subagents.TaskPath (taskPathRoot)
-import Agent.Tools.MultiAgents (MultiAgentContext(..))
+import Agent.Tools.MultiAgents (MultiAgentContext(..), SubagentWorktree(..))
 import Agent.Tools.Types (AppTool(..), AppToolKind(..))
+import Control.Concurrent.MVar
 import Data.IORef
 import qualified Data.Map.Strict as Map
 import Data.Text (Text)
@@ -44,6 +45,20 @@ spec = describe "Agent.Tools.Grok.Task" do
         map (\entry -> entry.modelOverride) specs `shouldBe` [Just "grok-4.5-mini"]
         closeSubagentRegistry registry
 
+    it "records overrides before the child worker starts" do
+        typesRef <- newIORef Map.empty
+        observed <- newEmptyMVar
+        registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
+            (observeSpec typesRef observed)
+            (\_ _ -> pure ())
+        let ctx = MultiAgentContext registry Nothing 0 taskPathRoot
+                Nothing Nothing Nothing
+            tool = taskTool (fromFilePath "/tmp") ctx typesRef
+        _ <- dispatchToolCall defaultLoopDispatch [tool.appToolHandler]
+            (functionToolCall "c1" "task" raceArgs)
+        takeMVar observed `shouldReturn` (Just "explore", Just "grok-4.5-mini")
+        closeSubagentRegistry registry
+
     it "filters explore tools to the Grok Build read-only set" do
         let tools =
                 [ fake "read_file"
@@ -67,7 +82,10 @@ spec = describe "Agent.Tools.Grok.Task" do
             (\_ _ _ _ -> pure $ Left LoopNoResponseId)
             (\_ _ -> pure ())
         typesRef <- newIORef Map.empty
-        let createIsolated _ = pure (Right (fromFilePath "/tmp"))
+        let createIsolated _ = pure $ Right SubagentWorktree
+                { subagentWorktreePath = fromFilePath "/tmp"
+                , subagentWorktreeCleanup = pure (Right ())
+                }
             ctx = MultiAgentContext registry Nothing 0 taskPathRoot Nothing
                 (Just createIsolated) Nothing
             tool = taskTool (fromFilePath "/tmp") ctx typesRef
@@ -76,6 +94,18 @@ spec = describe "Agent.Tools.Grok.Task" do
                 "{\"prompt\":\"x\",\"description\":\"y\",\"isolation\":\"worktree\"}")
         result.output `shouldSatisfy` Text.isInfixOf "worktree_path: /tmp"
         closeSubagentRegistry registry
+
+    it "cleans up worktrees after failed registry admission" do
+        cleaned <- newIORef False
+        registry <- closedRegistry
+        typesRef <- newIORef Map.empty
+        let ctx = MultiAgentContext registry Nothing 0 taskPathRoot Nothing
+                (Just (cleanupLease cleaned)) Nothing
+            tool = taskTool (fromFilePath "/tmp") ctx typesRef
+        result <- dispatchToolCall defaultLoopDispatch [tool.appToolHandler]
+            (functionToolCall "c1" "task" worktreeArgs)
+        result.output `shouldSatisfy` Text.isInfixOf "registry is closed"
+        readIORef cleaned `shouldReturn` True
 
 fake :: Text -> AppTool
 fake name = AppTool
@@ -87,3 +117,44 @@ fake name = AppTool
     , appToolReadOnly = True
     , appToolIsReadOnlyCall = Nothing
     }
+
+raceArgs :: Text
+raceArgs =
+    "{\"prompt\":\"hello\",\"description\":\"race test\",\
+    \\"subagent_type\":\"explore\",\"model\":\"grok-4.5-mini\"}"
+
+observeSpec
+    :: GrokSubagentSpecs
+    -> MVar (Maybe Text, Maybe Text)
+    -> RunSubagent
+observeSpec specs observed env _ _ _ = do
+    agentType <- lookupAgentType specs env.subId
+    agentModel <- lookupAgentModel specs env.subId
+    putMVar observed (agentType, agentModel)
+    pure $ Right LoopResult
+        { finalResponseId = "c"
+        , finalText = Just "done"
+        , turnsUsed = 1
+        , tokenUsage = emptyTokenUsage
+        }
+
+worktreeArgs :: Text
+worktreeArgs =
+    "{\"prompt\":\"x\",\"description\":\"cleanup\",\
+    \\"isolation\":\"worktree\"}"
+
+closedRegistry :: IO SubagentRegistry
+closedRegistry = do
+    registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
+        (\_ _ _ _ -> pure $ Left LoopNoResponseId)
+        (\_ _ -> pure ())
+    closeSubagentRegistry registry
+    pure registry
+
+cleanupLease :: IORef Bool -> OsPath -> IO (Either Text SubagentWorktree)
+cleanupLease cleaned _ =
+    pure $ Right SubagentWorktree
+        { subagentWorktreePath = fromFilePath "/tmp/isolate"
+        , subagentWorktreeCleanup =
+            writeIORef cleaned True >> pure (Right ())
+        }


### PR DESCRIPTION
## Summary

Follow-up to #96 addressing all inline review findings:

- register `GrokSubagentSpec` after registry admission but before the child worker is released
- use master’s scoped `Worker` lifecycle so shutdown can always cancel and join startup
- roll back admission on preparation failure or asynchronous cancellation
- preserve replacement task-path mappings when an older prepared spawn rolls back after reset
- release rolled-back map ownership and concurrency slots in one STM transaction
- restore unmasked child execution after safely acquiring the worktree lease
- make interrupted `git worktree add` clean partial checkout, registration, and branch state
- clean worktrees on admission failure or cancellation
- preserve current master’s `OsPath`, terminal/usage, encrypted inter-agent messaging, notifications, and scoped-worker behavior

## Regression coverage

- child worker observes `explore` and the explicit model on its first instruction
- closed-registry admission failure invokes the worktree cleanup lease
- shutdown overlapping pre-start preparation never launches the child worker
- cancellation during preparation releases the registry slot
- old rollback preserves a replacement agent's task-path mapping after reset
- managed worktree removal deletes both checkout and generated branch

## Validation

- `agent-core`: 154 examples, 0 failures
- `agent-cli`: 334 examples, 0 failures
- `git diff --check`
