### PR TITLE
Notify when the agent needs human attention

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -51,6 +51,7 @@ library
                     , Agent.CLI.Markdown
                     , Agent.CLI.ModelPicker
                     , Agent.CLI.Models
+                    , Agent.CLI.Notification
                     , Agent.CLI.Options
                     , Agent.CLI.Permission
                     , Agent.CLI.Picker
@@ -121,6 +122,7 @@ test-suite agent-cli-test
                     , Agent.CLI.MarkdownSpec
                     , Agent.CLI.ModelPickerSpec
                     , Agent.CLI.ModelsSpec
+                    , Agent.CLI.NotificationSpec
                     , Agent.CLI.OptionsSpec
                     , Agent.CLI.PlanSpec
                     , Agent.CLI.ProjectSpec

--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -55,6 +55,10 @@ import Agent.CLI.Interrupt
 import Agent.CLI.Login (runLoginManager)
 import Agent.CLI.ModelPicker (pickModel)
 import Agent.CLI.Models (ModelOption(..))
+import Agent.CLI.Notification
+    ( AttentionRequest(InputRequested)
+    , notifyAttention
+    )
 import Agent.CLI.Options
 import Agent.CLI.Resume (pickResumeSession)
 import Agent.CLI.Plan (cliPlanHooks)
@@ -891,12 +895,15 @@ finishTurn env exitAfter = \case
         putTrailingNewline env.sessionPrinted
         if exitAfter
             then pure RunQuit
-            else repl env
+            else do
+                notifyAttention stderr InputRequested
+                repl env
     TurnFailed ->
         if exitAfter
             then exitFailure
             else do
                 putTrailingNewline env.sessionPrinted
+                notifyAttention stderr InputRequested
                 repl env
     TurnProviderUnavailable apiError pending ->
         requestAutomaticProviderFallback
@@ -906,7 +913,9 @@ finishTurn env exitAfter = \case
             Nothing ->
                 if exitAfter
                     then exitFailure
-                    else repl env
+                    else do
+                        notifyAttention stderr InputRequested
+                        repl env
 
 repl :: SessionEnv -> IO RunResult
 repl env = replWithDraft env ""

--- a/packages/agent-cli/src/Agent/CLI/Notification.hs
+++ b/packages/agent-cli/src/Agent/CLI/Notification.hs
@@ -1,0 +1,49 @@
+-- | Native terminal desktop notifications for human-attention points.
+--
+-- Ghostty and iTerm-compatible terminals implement OSC 9 as a desktop
+-- notification. Unknown terminals ignore it. tmux needs DCS passthrough (and
+-- @allow-passthrough on@) so the outer terminal receives the OSC sequence.
+module Agent.CLI.Notification
+    ( AttentionRequest(..)
+    , attentionNotificationSequence
+    , notifyAttention
+    ) where
+
+import Agent.CLI.ImagePreview (wrapTmuxPassthrough)
+import Control.Exception.Safe (tryIO)
+import Control.Monad (void, when)
+import Data.Maybe (isJust)
+import Data.Text (Text)
+import qualified Data.Text.IO as Text
+import System.Environment (lookupEnv)
+import System.IO (Handle, hFlush, hIsTerminalDevice)
+
+data AttentionRequest
+    = InputRequested
+    | PermissionRequested
+    deriving (Eq, Show)
+
+attentionNotificationSequence :: AttentionRequest -> Text
+attentionNotificationSequence request =
+    "\ESC]9;" <> notificationTitle request <> "\ESC\\"
+
+notificationTitle :: AttentionRequest -> Text
+notificationTitle = \case
+    InputRequested -> "Haskell Agent: input requested"
+    PermissionRequested -> "Haskell Agent: permission required"
+
+-- | Notify only when the destination is a TTY, keeping pipes and redirected
+-- stderr free of terminal control sequences. Notification failures must never
+-- interfere with the prompt that follows.
+notifyAttention :: Handle -> AttentionRequest -> IO ()
+notifyAttention handle request = do
+    tty <- hIsTerminalDevice handle
+    when tty do
+        inTmux <- isJust <$> lookupEnv "TMUX"
+        let raw = attentionNotificationSequence request
+            sequence_
+                | inTmux = wrapTmuxPassthrough raw
+                | otherwise = raw
+        void $ tryIO do
+            Text.hPutStr handle sequence_
+            hFlush handle

--- a/packages/agent-cli/src/Agent/CLI/Permission.hs
+++ b/packages/agent-cli/src/Agent/CLI/Permission.hs
@@ -9,6 +9,10 @@ module Agent.CLI.Permission
     ) where
 
 import Agent.CLI.Input (readApprovalLine)
+import Agent.CLI.Notification
+    ( AttentionRequest(PermissionRequested)
+    , notifyAttention
+    )
 import Agent.CLI.Options (ApprovalAnswer(..), parseApprovalAnswer)
 import Agent.CLI.Picker (PickerKey(..), runOverlay)
 import Agent.CLI.Render (summarizeToolCall)
@@ -17,7 +21,7 @@ import Agent.ToolDispatch (ToolCall)
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
-import System.IO (hIsTerminalDevice, stdin)
+import System.IO (hIsTerminalDevice, stderr, stdin)
 
 data PermissionChoice
     = PermissionAllowOnce
@@ -95,6 +99,7 @@ promptPermission color call = do
     if not isTty
         then cooked color summary
         else do
+            notifyAttention stderr PermissionRequested
             result <-
                 runOverlay
                     (renderPermissionFrame color)

--- a/packages/agent-cli/src/Agent/CLI/Plan.hs
+++ b/packages/agent-cli/src/Agent/CLI/Plan.hs
@@ -17,6 +17,10 @@ import Agent.CLI.Input
     )
 import Agent.CLI.Interrupt (InterruptState)
 import Agent.CLI.Markdown (renderMarkdown)
+import Agent.CLI.Notification
+    ( AttentionRequest(InputRequested)
+    , notifyAttention
+    )
 import Agent.CLI.Style
     ( agentBackground
     , paintBackgroundLines
@@ -60,6 +64,7 @@ confirmEnter resolveColor reason = do
         then pure False
         else do
             putTextLn stderr (roleMuted color reason)
+            notifyAttention stderr InputRequested
             let question = roleWarn color "Enter plan mode? [y/N] "
             readApprovalLine question >>= \case
                 Nothing -> pure False
@@ -77,7 +82,9 @@ decideExit interrupt resolveColor planBody = do
     putTextLn stderr (roleMuted color "──────────")
     if not isTty
         then pure PlanCancel
-        else promptDecision interrupt color
+        else do
+            notifyAttention stderr InputRequested
+            promptDecision interrupt color
 
 promptDecision :: InterruptState -> Bool -> IO PlanDecision
 promptDecision interrupt color = do
@@ -102,6 +109,7 @@ promptDecision interrupt color = do
 
 readChangeNotes :: InterruptState -> Bool -> IO Text
 readChangeNotes interrupt color = do
+    notifyAttention stderr InputRequested
     let chrome =
             rolePrompt color "changes> "
                 <> if color
@@ -126,27 +134,29 @@ askQuestion interrupt resolveColor question options = do
     putTextLn stderr (roleMuted color question)
     if not isTty
         then pure Nothing
-        else case options of
-            [] -> do
-                let chrome =
-                        rolePrompt color "answer> "
-                            <> if color
-                                then Text.pack clearFromCursorToLineEndCode
-                                else mempty
-                readReplLine interrupt chrome >>= \case
-                    ReplEof -> pure Nothing
-                    ReplQuitInterrupt -> throwIO UserInterrupt
-                    ReplPasted text ->
-                        if Text.null (Text.strip text)
-                            then pure Nothing
-                            else pure (Just (Text.strip text))
-                    ReplCycleMode _ ->
-                        askQuestion interrupt resolveColor question []
-                    ReplText text
-                        | Text.null (Text.strip text) -> pure Nothing
-                        | otherwise -> pure (Just (Text.strip text))
-            opts ->
-                readChoiceSelection (formatChoiceLine color) opts
+        else do
+            notifyAttention stderr InputRequested
+            case options of
+                [] -> do
+                    let chrome =
+                            rolePrompt color "answer> "
+                                <> if color
+                                    then Text.pack clearFromCursorToLineEndCode
+                                    else mempty
+                    readReplLine interrupt chrome >>= \case
+                        ReplEof -> pure Nothing
+                        ReplQuitInterrupt -> throwIO UserInterrupt
+                        ReplPasted text ->
+                            if Text.null (Text.strip text)
+                                then pure Nothing
+                                else pure (Just (Text.strip text))
+                        ReplCycleMode _ ->
+                            askQuestion interrupt resolveColor question []
+                        ReplText text
+                            | Text.null (Text.strip text) -> pure Nothing
+                            | otherwise -> pure (Just (Text.strip text))
+                opts ->
+                    readChoiceSelection (formatChoiceLine color) opts
 
 formatChoiceLine :: Bool -> Bool -> Text -> Text
 formatChoiceLine color selected label

--- a/packages/agent-cli/test/Agent/CLI/NotificationSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/NotificationSpec.hs
@@ -1,0 +1,15 @@
+module Agent.CLI.NotificationSpec (spec) where
+
+import Agent.CLI.Notification
+import Test.Hspec
+
+spec :: Spec
+spec =
+    describe "attentionNotificationSequence" do
+        it "requests input with a Ghostty OSC 9 notification" do
+            attentionNotificationSequence InputRequested
+                `shouldBe` "\ESC]9;Haskell Agent: input requested\ESC\\"
+
+        it "distinguishes permission prompts" do
+            attentionNotificationSequence PermissionRequested
+                `shouldBe` "\ESC]9;Haskell Agent: permission required\ESC\\"

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -16,6 +16,7 @@ import qualified Agent.CLI.LoginSpec as LoginSpec
 import qualified Agent.CLI.MarkdownSpec as MarkdownSpec
 import qualified Agent.CLI.ModelPickerSpec as ModelPickerSpec
 import qualified Agent.CLI.ModelsSpec as ModelsSpec
+import qualified Agent.CLI.NotificationSpec as NotificationSpec
 import qualified Agent.CLI.OptionsSpec as OptionsSpec
 import qualified Agent.CLI.PermissionSpec as PermissionSpec
 import qualified Agent.CLI.PlanSpec as PlanSpec
@@ -50,6 +51,7 @@ main = hspec do
     MarkdownSpec.spec
     ModelPickerSpec.spec
     ModelsSpec.spec
+    NotificationSpec.spec
     OptionsSpec.spec
     PermissionSpec.spec
     PlanSpec.spec


### PR DESCRIPTION
## Summary
- emit Ghostty/iTerm-compatible OSC 9 desktop notifications when tool permission is required
- notify when plan mode asks for input or approval and when an interactive turn returns to the REPL
- pass notification sequences through tmux using the existing DCS wrapper and keep redirected output clean

## Testing
- `nix develop -c cabal repl agent-cli:test:agent-cli-test` then `main` — 285 examples, 0 failures
- exercised the permission overlay in a real tmux TTY
- sent a notification through `Agent.CLI.Notification.notifyAttention` to the active Ghostty pane and confirmed it appeared on macOS
