### PR TITLE
Harden persistent GHCi runtime

### DIFF
--- a/packages/agent-core/agent-core.cabal
+++ b/packages/agent-core/agent-core.cabal
@@ -66,6 +66,7 @@ library
                     , Agent.Tools.Ghci
                     , Agent.Tools.Ghci.Classify
                     , Agent.Tools.Ghci.Runtime
+                    , Agent.Tools.Ghci.Tool
                     , Agent.Tools.IO
                     , Agent.Tools.MultiAgents
                     , Agent.Tools.PlanMode

--- a/packages/agent-core/src/Agent/Tools/Ghci.hs
+++ b/packages/agent-core/src/Agent/Tools/Ghci.hs
@@ -2,7 +2,9 @@
 module Agent.Tools.Ghci
     ( module Agent.Tools.Ghci.Classify
     , module Agent.Tools.Ghci.Runtime
+    , module Agent.Tools.Ghci.Tool
     ) where
 
 import Agent.Tools.Ghci.Classify
 import Agent.Tools.Ghci.Runtime
+import Agent.Tools.Ghci.Tool

--- a/packages/agent-core/src/Agent/Tools/Ghci/Runtime.hs
+++ b/packages/agent-core/src/Agent/Tools/Ghci/Runtime.hs
@@ -1,49 +1,45 @@
 -- | Persistent GHCi session shared by coding-tool providers.
 --
--- Frames replies with a unique @putStrLn@ marker instead of relying on the
--- GHCi prompt (which is suppressed when stdin is not a TTY).
+-- Replies are framed with unique markers written to both stdout and stderr.
+-- Waiting for both markers prevents diagnostics on stderr from arriving after
+-- a stdout-only completion marker.
 module Agent.Tools.Ghci.Runtime
-    ( GhciSession(..)
+    ( GhciSession
+    , GhciOutcome(..)
     , GhciResult(..)
     , newGhciSession
     , closeGhciSession
     , evalGhci
     , classifyGhci
-    , runGhciTool
     ) where
 
-import Agent.ToolArgs
-    ( objectArgs
-    , optInt
-    , optText
-    , reqText
-    )
-import Agent.ToolDSL
-    ( PropertySchema(..)
-    , PropertyType(..)
-    )
-import Agent.ToolDispatch (ToolCall(..), typedTool)
+import Agent.Cancel (CancelFlag, isCancelled, waitCancel)
 import Agent.Tools.Ghci.Classify
     ( GhciClass(..)
     , classifyGhciInput
     , defaultGhciExtensions
     , typeLooksEffectful
     )
-import Agent.Tools.Types (AppTool(..), AppToolKind(..), ToolEnv(..))
-import Control.Applicative ((<|>))
-import Data.Aeson (FromJSON(..), Object)
-import qualified Data.Aeson as Aeson
-import qualified Data.Aeson.Key as Key
-import qualified Data.Aeson.KeyMap as KeyMap
-import Data.Aeson.Types (Parser)
-import Data.Maybe (fromMaybe)
-import qualified Data.Text.Encoding as TextEncoding
-
-import Control.Concurrent (forkIO, threadDelay)
-import Control.Concurrent.Async (concurrently, race)
+import Agent.Tools.Types (ToolEnv(..))
+import Control.Concurrent (threadDelay)
+import Control.Concurrent.Async (Async, async, cancel, race)
 import Control.Concurrent.MVar
-import Control.Exception.Safe (SomeException, try)
-import Control.Monad (void, when)
+import Control.Concurrent.STM
+    ( STM
+    , TChan
+    , atomically
+    , newTChanIO
+    , readTChan
+    , tryReadTChan
+    , writeTChan
+    )
+import Control.Exception.Safe
+    ( SomeException
+    , finally
+    , onException
+    , try
+    )
+import Control.Monad (unless, void)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import Data.IORef
@@ -51,84 +47,150 @@ import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Text.Encoding (decodeUtf8With, encodeUtf8)
 import Data.Text.Encoding.Error (lenientDecode)
-import System.IO (BufferMode(..), Handle, hClose, hFlush, hSetBinaryMode, hSetBuffering)
+import Data.Word (Word64)
+import GHC.Clock (getMonotonicTimeNSec)
+import System.IO
+    ( BufferMode(..)
+    , Handle
+    , hClose
+    , hFlush
+    , hSetBinaryMode
+    , hSetBuffering
+    )
 import System.Process
     ( CreateProcess(..)
     , ProcessHandle
     , StdStream(..)
     , createProcess
+    , getPid
     , getProcessExitCode
     , interruptProcessGroupOf
     , proc
     , terminateProcess
-    , waitForProcess
     )
+import System.Posix.Signals (sigKILL, signalProcessGroup)
+
+data GhciOutcome
+    = GhciCompleted
+    | GhciTimedOut
+    | GhciCancelled
+    | GhciProcessFailed
+    deriving (Eq, Show)
 
 data GhciResult = GhciResult
-    { ghciOk :: !Bool
+    { ghciOutcome :: !GhciOutcome
+    , ghciOk :: !Bool
     , ghciTimedOut :: !Bool
+    , ghciCancelled :: !Bool
     , ghciClass :: !GhciClass
     , ghciOutput :: !Text
+    , ghciStdout :: !Text
+    , ghciStderr :: !Text
+    , ghciTruncated :: !Bool
+    , ghciRestarted :: !Bool
     } deriving (Eq, Show)
+
+data GhciStream
+    = GhciStdout
+    | GhciStderr
+    deriving (Eq, Show)
+
+data GhciEvent
+    = GhciChunk !GhciStream !ByteString
+    | GhciStreamClosed !GhciStream
 
 data GhciProcess = GhciProcess
     { ghciStdin :: !Handle
-    , ghciStdout :: !Handle
-    , ghciStderr :: !Handle
+    , ghciStdoutHandle :: !Handle
+    , ghciStderrHandle :: !Handle
     , ghciHandle :: !ProcessHandle
-    , ghciBuffer :: !(IORef ByteString)
-    , ghciDrainDone :: !(MVar ())
+    , ghciEvents :: !(TChan GhciEvent)
+    , ghciStdoutDrain :: !(Async ())
+    , ghciStderrDrain :: !(Async ())
     }
+
+data GhciSessionState
+    = GhciNotStarted
+    | GhciRunning !GhciProcess
+    | GhciClosed
 
 data GhciSession = GhciSession
     { ghciEnv :: !ToolEnv
     , ghciLock :: !(MVar ())
-    , ghciProcess :: !(MVar (Maybe GhciProcess))
+    , ghciState :: !(IORef GhciSessionState)
     , ghciNextMarker :: !(IORef Int)
+    , ghciMarkerSeed :: !Text
+    , ghciClassificationCache :: !(IORef (Maybe (Text, GhciClass)))
     }
 
 newGhciSession :: ToolEnv -> IO GhciSession
 newGhciSession env = do
     lock <- newMVar ()
-    processVar <- newMVar Nothing
-    nextMarker <- newIORef 0
+    state <- newIORef GhciNotStarted
+    nextMarkerRef <- newIORef 0
+    seed <- Text.pack . show <$> getMonotonicTimeNSec
+    classificationCache <- newIORef Nothing
     pure GhciSession
         { ghciEnv = env
         , ghciLock = lock
-        , ghciProcess = processVar
-        , ghciNextMarker = nextMarker
+        , ghciState = state
+        , ghciNextMarker = nextMarkerRef
+        , ghciMarkerSeed = seed
+        , ghciClassificationCache = classificationCache
         }
 
 closeGhciSession :: GhciSession -> IO ()
 closeGhciSession session =
-    modifyMVar_ session.ghciProcess \current -> do
-        mapM_ shutdownProcess current
-        pure Nothing
+    withGhciLock session do
+        current <- atomicModifyIORef' session.ghciState \state ->
+            (GhciClosed, state)
+        writeIORef session.ghciClassificationCache Nothing
+        case current of
+            GhciRunning process -> shutdownProcess process
+            GhciNotStarted -> pure ()
+            GhciClosed -> pure ()
 
 -- | Evaluate @expression@ in the persistent GHCi, classifying side effects first.
+-- The timeout is an overall budget for classification and execution.
 evalGhci :: GhciSession -> Text -> Int -> IO GhciResult
-evalGhci session expression timeoutMs =
+evalGhci session expression requestedTimeout =
     withGhciLock session do
-        classification <- classifyGhciLocked session expression
-        result <- evalRawGhci session expression timeoutMs
-        pure result { ghciClass = classification }
+        let timeoutMs = normalizeTimeout requestedTimeout
+        started <- getMonotonicTimeNSec
+        cached <- readIORef session.ghciClassificationCache
+        classification <- case cached of
+            Just (cachedExpression, cls)
+                | cachedExpression == expression -> pure cls
+            _ -> classifyGhciLocked session expression (min 15000 timeoutMs)
+        writeIORef session.ghciClassificationCache Nothing
+        remaining <- remainingMillis started timeoutMs
+        if remaining <= 0
+            then pure $ emptyResult GhciTimedOut classification
+                "Timed out while classifying the GHCi input."
+            else do
+                result <- evalRawGhci session expression remaining
+                pure result { ghciClass = classification }
 
 -- | Classify without evaluating. Fail closed on ambiguity.
 classifyGhci :: GhciSession -> Text -> IO GhciClass
 classifyGhci session expression =
-    withGhciLock session (classifyGhciLocked session expression)
+    withGhciLock session do
+        classification <- classifyGhciLocked session expression 15000
+        writeIORef session.ghciClassificationCache
+            (Just (expression, classification))
+        pure classification
 
 withGhciLock :: GhciSession -> IO a -> IO a
 withGhciLock session action =
     withMVar session.ghciLock (const action)
 
-classifyGhciLocked :: GhciSession -> Text -> IO GhciClass
-classifyGhciLocked session expression =
+classifyGhciLocked :: GhciSession -> Text -> Int -> IO GhciClass
+classifyGhciLocked session expression timeoutMs =
     case classifyGhciInput expression of
         Just cls -> pure cls
         Nothing -> do
-            typeResult <- evalRawGhci session (":type " <> expression) 15000
-            if typeResult.ghciTimedOut || not typeResult.ghciOk
+            typeResult <- evalRawGhci session (":type " <> expression) timeoutMs
+            if typeResult.ghciOutcome /= GhciCompleted || not typeResult.ghciOk
                 then pure GhciEffectful
                 else
                     if typeLooksEffectful typeResult.ghciOutput
@@ -136,83 +198,197 @@ classifyGhciLocked session expression =
                         else pure GhciPure
 
 evalRawGhci :: GhciSession -> Text -> Int -> IO GhciResult
-evalRawGhci session expression timeoutMs = do
-    process <- ensureProcess session
-    marker <- nextMarker session
-    let markerLine = "Prelude.putStrLn " <> Text.pack (show (Text.unpack marker))
-    clearBuffer process
-    sendLine process expression
-    sendLine process markerLine
-    awaited <- awaitMarker process marker timeoutMs
-    case awaited of
-        Left partial -> do
-            void $ try @_ @SomeException (interruptProcessGroupOf process.ghciHandle)
-            threadDelay 200000
-            -- Drop any leftover output, then verify the process still responds.
-            clearBuffer process
-            recovered <- recoverAfterInterrupt session process
-            when (not recovered) (restartProcess session)
-            pure GhciResult
-                { ghciOk = False
-                , ghciTimedOut = True
-                , ghciClass = GhciEffectful
-                , ghciOutput = Text.strip partial
-                }
-        Right body ->
-            pure GhciResult
-                { ghciOk = not (isGhciError body)
-                , ghciTimedOut = False
-                , ghciClass = GhciPure
-                , ghciOutput = Text.strip body
-                }
+evalRawGhci session expression requestedTimeout = do
+    let timeoutMs = normalizeTimeout requestedTimeout
+    cancelled <- isCancelled session.ghciEnv.toolCancel
+    if cancelled
+        then pure $ emptyResult GhciCancelled GhciEffectful "GHCi evaluation cancelled."
+        else ensureProcess session >>= \case
+            Left err ->
+                pure $ emptyResult GhciProcessFailed GhciEffectful err
+            Right process -> do
+                flushEvents process
+                marker <- nextMarker session
+                sent <- try @_ @SomeException do
+                    sendGhciInput process expression
+                    sendMarker process marker
+                case sent of
+                    Left err -> do
+                        restarted <- restartProcess session
+                        pure $ (emptyResult GhciProcessFailed GhciEffectful
+                            ("Failed to send input to GHCi: " <> Text.pack (show err)))
+                                { ghciRestarted = restarted }
+                    Right () -> do
+                        awaited <- awaitMarker
+                            (Just session.ghciEnv.toolCancel)
+                            session.ghciEnv.toolStdoutCap
+                            process
+                            marker
+                            timeoutMs
+                        finishAwaited session process awaited
+
+finishAwaited
+    :: GhciSession
+    -> GhciProcess
+    -> Awaited
+    -> IO GhciResult
+finishAwaited session process awaited =
+    case awaited.awaitReason of
+        AwaitMarkers -> pure $ capturedResult GhciCompleted awaited.awaitOutput False
+        AwaitTimeout -> recover GhciTimedOut
+        AwaitCancellation -> recover GhciCancelled
+        AwaitProcessExit -> do
+            restarted <- restartProcess session
+            pure $ (capturedResult GhciProcessFailed awaited.awaitOutput restarted)
+                { ghciOk = False }
+  where
+    recover outcome = do
+        void $ try @_ @SomeException
+            (interruptProcessGroupOf process.ghciHandle)
+        recovered <- recoverAfterInterrupt session process
+        restarted <- if recovered
+            then pure False
+            else restartProcess session
+        pure $ (capturedResult outcome awaited.awaitOutput restarted)
+            { ghciOk = False }
 
 recoverAfterInterrupt :: GhciSession -> GhciProcess -> IO Bool
 recoverAfterInterrupt session process = do
+    flushEvents process
     marker <- nextMarker session
-    let markerLine = "Prelude.putStrLn " <> Text.pack (show (Text.unpack marker))
-    sendLine process ":type ()"
-    sendLine process markerLine
-    awaited <- awaitMarker process marker 5000
-    pure (either (const False) (const True) awaited)
+    sent <- try @_ @SomeException do
+        sendLine process ":type ()"
+        sendMarker process marker
+    case sent of
+        Left _ -> pure False
+        Right () -> do
+            awaited <- awaitMarker Nothing
+                session.ghciEnv.toolStdoutCap process marker 5000
+            pure (awaited.awaitReason == AwaitMarkers)
+
+capturedResult :: GhciOutcome -> CapturedOutput -> Bool -> GhciResult
+capturedResult outcome captured restarted =
+    let stdout = Text.strip captured.capturedStdout
+        stderr = Text.strip captured.capturedStderr
+        output = combineOutput stdout stderr
+        ok = outcome == GhciCompleted && not (isGhciError stderr)
+    in GhciResult
+        { ghciOutcome = outcome
+        , ghciOk = ok
+        , ghciTimedOut = outcome == GhciTimedOut
+        , ghciCancelled = outcome == GhciCancelled
+        , ghciClass = GhciPure
+        , ghciOutput = output
+        , ghciStdout = stdout
+        , ghciStderr = stderr
+        , ghciTruncated = captured.capturedTruncated
+        , ghciRestarted = restarted
+        }
+
+emptyResult :: GhciOutcome -> GhciClass -> Text -> GhciResult
+emptyResult outcome classification message = GhciResult
+    { ghciOutcome = outcome
+    , ghciOk = False
+    , ghciTimedOut = outcome == GhciTimedOut
+    , ghciCancelled = outcome == GhciCancelled
+    , ghciClass = classification
+    , ghciOutput = message
+    , ghciStdout = ""
+    , ghciStderr = message
+    , ghciTruncated = False
+    , ghciRestarted = False
+    }
+
+combineOutput :: Text -> Text -> Text
+combineOutput stdout stderr =
+    Text.intercalate "\n" (filter (not . Text.null) [stdout, stderr])
 
 isGhciError :: Text -> Bool
-isGhciError body =
-    any (`Text.isInfixOf` body)
-        [ "error:"
-        , "<interactive>:"
-        , "Exception:"
-        ]
+isGhciError stderr =
+    any isErrorLine (Text.lines stderr)
+  where
+    isErrorLine line =
+        let stripped = Text.strip line
+        in "*** Exception:" `Text.isPrefixOf` stripped
+            || (": error:" `Text.isInfixOf` stripped)
 
 nextMarker :: GhciSession -> IO Text
 nextMarker session = do
     n <- atomicModifyIORef' session.ghciNextMarker \i -> (i + 1, i + 1)
-    pure $ "{- AGENT_GHCI_DONE:" <> Text.pack (show n) <> " -}"
+    pure $
+        "{- AGENT_GHCI_DONE:"
+            <> session.ghciMarkerSeed
+            <> ":"
+            <> Text.pack (show n)
+            <> " -}"
 
-ensureProcess :: GhciSession -> IO GhciProcess
+ensureProcess :: GhciSession -> IO (Either Text GhciProcess)
 ensureProcess session =
-    modifyMVar session.ghciProcess \current -> case current of
-        Just process -> do
+    readIORef session.ghciState >>= \case
+        GhciClosed -> pure (Left "GHCi session is closed.")
+        GhciNotStarted -> startProcess session
+        GhciRunning process -> do
             exited <- getProcessExitCode process.ghciHandle
             case exited of
-                Nothing -> pure (Just process, process)
+                Nothing -> pure (Right process)
                 Just _ -> do
                     shutdownProcess process
-                    process' <- spawnProcess session.ghciEnv
-                    pure (Just process', process')
-        Nothing -> do
-            process <- spawnProcess session.ghciEnv
-            pure (Just process, process)
+                    writeIORef session.ghciState GhciNotStarted
+                    startProcess session
 
-restartProcess :: GhciSession -> IO ()
-restartProcess session =
-    modifyMVar_ session.ghciProcess \current -> do
-        mapM_ shutdownProcess current
-        Just <$> spawnProcess session.ghciEnv
+startProcess :: GhciSession -> IO (Either Text GhciProcess)
+startProcess session =
+    spawnProcess session.ghciEnv >>= \case
+        Left err -> pure (Left err)
+        Right process -> do
+            flushEvents process
+            marker <- nextMarker session
+            sent <- try @_ @SomeException (sendMarker process marker)
+            case sent of
+                Left err -> do
+                    shutdownProcess process
+                    pure $ Left
+                        ("Failed to initialize GHCi: " <> Text.pack (show err))
+                Right () -> do
+                    awaited <- awaitMarker Nothing
+                        session.ghciEnv.toolStdoutCap process marker 5000
+                    if awaited.awaitReason == AwaitMarkers
+                        && not (isGhciError awaited.awaitOutput.capturedStderr)
+                        then do
+                            writeIORef session.ghciState (GhciRunning process)
+                            pure (Right process)
+                        else do
+                            shutdownProcess process
+                            pure $ Left $
+                                "GHCi failed its startup handshake.\n"
+                                    <> combineOutput
+                                        awaited.awaitOutput.capturedStdout
+                                        awaited.awaitOutput.capturedStderr
+
+restartProcess :: GhciSession -> IO Bool
+restartProcess session = do
+    current <- atomicModifyIORef' session.ghciState \state ->
+        (case state of
+            GhciClosed -> GhciClosed
+            _ -> GhciNotStarted, state)
+    case current of
+        GhciRunning process -> shutdownProcess process
+        GhciNotStarted -> pure ()
+        GhciClosed -> pure ()
+    writeIORef session.ghciClassificationCache Nothing
+    case current of
+        GhciClosed -> pure False
+        _ -> either (const False) (const True) <$> startProcess session
 
 ghciArgs :: [String]
-ghciArgs = "-v0" : "-XGHC2021" : map ("-X" <>) defaultGhciExtensions
+ghciArgs =
+    [ "-ignore-dot-ghci"
+    , "-v0"
+    , "-XGHC2021"
+    ]
+        ++ map ("-X" <>) defaultGhciExtensions
 
-spawnProcess :: ToolEnv -> IO GhciProcess
+spawnProcess :: ToolEnv -> IO (Either Text GhciProcess)
 spawnProcess env = do
     let spec = (proc "ghci" ghciArgs)
             { cwd = Just env.toolCwd
@@ -221,25 +397,33 @@ spawnProcess env = do
             , std_err = CreatePipe
             , create_group = True
             }
-    createProcess spec >>= \case
-        (Just hin, Just hout, Just herr, handle) -> do
-            mapM_ prepareHandle [hin, hout, herr]
-            buffer <- newIORef BS.empty
-            drainDone <- newEmptyMVar
-            _ <- forkIO do
-                _ <- concurrently (drainHandle hout buffer) (drainHandle herr buffer)
-                putMVar drainDone ()
-            -- Give GHCi a moment to boot before the first eval.
-            threadDelay 100000
-            pure GhciProcess
-                { ghciStdin = hin
-                , ghciStdout = hout
-                , ghciStderr = herr
-                , ghciHandle = handle
-                , ghciBuffer = buffer
-                , ghciDrainDone = drainDone
-                }
-        _ -> error "Agent.Tools.Ghci: failed to create ghci pipes"
+    try @_ @SomeException (createProcess spec) >>= \case
+        Left err ->
+            pure $ Left ("Failed to start GHCi: " <> Text.pack (show err))
+        Right (Just hin, Just hout, Just herr, handle) -> do
+            let closeCreated = do
+                    mapM_ (void . try @_ @SomeException . hClose)
+                        [hin, hout, herr]
+                    void $ try @_ @SomeException (terminateProcess handle)
+            (do
+                mapM_ prepareHandle [hin, hout, herr]
+                events <- newTChanIO
+                stdoutDrain <- async
+                    (drainHandle GhciStdout hout events)
+                stderrDrain <- async
+                    (drainHandle GhciStderr herr events)
+                pure $ Right GhciProcess
+                    { ghciStdin = hin
+                    , ghciStdoutHandle = hout
+                    , ghciStderrHandle = herr
+                    , ghciHandle = handle
+                    , ghciEvents = events
+                    , ghciStdoutDrain = stdoutDrain
+                    , ghciStderrDrain = stderrDrain
+                    })
+                `onException` closeCreated
+        Right _ ->
+            pure (Left "Failed to create GHCi pipes.")
 
 prepareHandle :: Handle -> IO ()
 prepareHandle handle = do
@@ -248,144 +432,317 @@ prepareHandle handle = do
 
 shutdownProcess :: GhciProcess -> IO ()
 shutdownProcess process = do
-    void $ try @_ @SomeException do
-        sendLine process ":quit"
-        threadDelay 200000
-    void $ try @_ @SomeException (terminateProcess process.ghciHandle)
-    void $ try @_ @SomeException (waitForProcess process.ghciHandle)
-    void $ try @_ @SomeException (hClose process.ghciStdin)
-    void $ try @_ @SomeException (hClose process.ghciStdout)
-    void $ try @_ @SomeException (hClose process.ghciStderr)
+    void $ try @_ @SomeException (sendLine process ":quit")
+    exited <- waitForExit process.ghciHandle 200
+    unless exited do
+        void $ try @_ @SomeException
+            (interruptProcessGroupOf process.ghciHandle)
+        void $ try @_ @SomeException (terminateProcess process.ghciHandle)
+        terminated <- waitForExit process.ghciHandle 1000
+        unless terminated do
+            getPid process.ghciHandle >>= mapM_ \pid ->
+                void $ try @_ @SomeException (signalProcessGroup sigKILL pid)
+            void $ waitForExit process.ghciHandle 1000
+    mapM_ (void . try @_ @SomeException . hClose)
+        [ process.ghciStdin
+        , process.ghciStdoutHandle
+        , process.ghciStderrHandle
+        ]
+    cancel process.ghciStdoutDrain
+    cancel process.ghciStderrDrain
+
+waitForExit :: ProcessHandle -> Int -> IO Bool
+waitForExit handle timeoutMs = go (max 1 timeoutMs)
+  where
+    go remaining = do
+        getProcessExitCode handle >>= \case
+            Just _ -> pure True
+            Nothing
+                | remaining <= 0 -> pure False
+                | otherwise -> do
+                    let delayMs = min 10 remaining
+                    threadDelay (delayMs * 1000)
+                    go (remaining - delayMs)
+
+sendGhciInput :: GhciProcess -> Text -> IO ()
+sendGhciInput process expression =
+    sendLine process (frameGhciInput expression)
+
+frameGhciInput :: Text -> Text
+frameGhciInput expression
+    | not ("\n" `Text.isInfixOf` expression) = expression
+    | ":" `Text.isPrefixOf` Text.stripStart expression = expression
+    | Just binding <- multilineLetBinding expression =
+        ":{\n" <> binding <> "\n:}"
+    | otherwise = ":{\n" <> expression <> "\n:}"
+
+multilineLetBinding :: Text -> Maybe Text
+multilineLetBinding expression = do
+    let stripped = Text.stripStart expression
+    binding <- Text.stripPrefix "let " stripped
+    if "\nin " `Text.isInfixOf` expression
+        then Nothing
+        else Just binding
+
+sendMarker :: GhciProcess -> Text -> IO ()
+sendMarker process marker = do
+    let quoted = Text.pack (show (Text.unpack marker))
+    -- An explicit qualified Prelude import makes GHCi drop its implicit
+    -- unqualified Prelude import. Restore the ordinary interactive context
+    -- before installing the private aliases used by the marker action.
+    sendLine process "import Prelude"
+    sendLine process
+        "import qualified Prelude as AgentGhciPreludeInternal"
+    sendLine process
+        "import qualified System.IO as AgentGhciIOInternal"
+    sendLine process $
+        "AgentGhciPreludeInternal.putStrLn " <> quoted
+            <> " AgentGhciPreludeInternal.>> "
+            <> "AgentGhciIOInternal.hPutStrLn "
+            <> "AgentGhciIOInternal.stderr "
+            <> quoted
+            <> " AgentGhciPreludeInternal.>> "
+            <> "AgentGhciIOInternal.hFlush AgentGhciIOInternal.stdout "
+            <> "AgentGhciPreludeInternal.>> "
+            <> "AgentGhciIOInternal.hFlush AgentGhciIOInternal.stderr"
 
 sendLine :: GhciProcess -> Text -> IO ()
 sendLine process text = do
     BS.hPut process.ghciStdin (encodeUtf8 (text <> "\n"))
     hFlush process.ghciStdin
 
-clearBuffer :: GhciProcess -> IO ()
-clearBuffer process = writeIORef process.ghciBuffer BS.empty
+flushEvents :: GhciProcess -> IO ()
+flushEvents process =
+    atomically (tryReadTChan process.ghciEvents) >>= \case
+        Nothing -> pure ()
+        Just _ -> flushEvents process
 
-awaitMarker :: GhciProcess -> Text -> Int -> IO (Either Text Text)
-awaitMarker process marker timeoutMs = do
-    let needle = encodeUtf8 marker
-        budget = max 1 timeoutMs * 1000
-    raced <- race (threadDelay budget) (waitFor needle)
-    case raced of
-        Left () -> Left . decodeUtf8With lenientDecode <$> readIORef process.ghciBuffer
-        Right body -> pure (Right body)
+data AwaitReason
+    = AwaitMarkers
+    | AwaitTimeout
+    | AwaitCancellation
+    | AwaitProcessExit
+    deriving (Eq, Show)
+
+data Awaited = Awaited
+    { awaitReason :: !AwaitReason
+    , awaitOutput :: !CapturedOutput
+    }
+
+data CapturedOutput = CapturedOutput
+    { capturedStdout :: !Text
+    , capturedStderr :: !Text
+    , capturedTruncated :: !Bool
+    }
+
+data StreamCapture = StreamCapture
+    { streamPending :: !ByteString
+    , streamOutput :: !ByteString
+    , streamDropped :: !Int
+    , streamDone :: !Bool
+    , streamClosed :: !Bool
+    }
+
+data CaptureState = CaptureState
+    { stdoutCapture :: !StreamCapture
+    , stderrCapture :: !StreamCapture
+    }
+
+emptyStreamCapture :: StreamCapture
+emptyStreamCapture = StreamCapture
+    { streamPending = BS.empty
+    , streamOutput = BS.empty
+    , streamDropped = 0
+    , streamDone = False
+    , streamClosed = False
+    }
+
+emptyCaptureState :: CaptureState
+emptyCaptureState = CaptureState
+    { stdoutCapture = emptyStreamCapture
+    , stderrCapture = emptyStreamCapture
+    }
+
+awaitMarker
+    :: Maybe CancelFlag
+    -> Int
+    -> GhciProcess
+    -> Text
+    -> Int
+    -> IO Awaited
+awaitMarker cancelFlag cap process marker requestedTimeout = do
+    stateRef <- newIORef emptyCaptureState
+    alreadyCancelled <- maybe (pure False) isCancelled cancelFlag
+    reason <-
+        if alreadyCancelled
+            then pure AwaitCancellation
+            else do
+                let timeoutMs = normalizeTimeout requestedTimeout
+                    collect = collectEvents
+                        stateRef cap (encodeUtf8 marker) process
+                    timed = race
+                        (threadDelay (timeoutMs * 1000))
+                        collect
+                case cancelFlag of
+                    Nothing ->
+                        timed >>= \case
+                            Left () -> pure AwaitTimeout
+                            Right completed -> pure completed
+                    Just flag ->
+                        race (waitCancel flag) timed >>= \case
+                            Left () -> pure AwaitCancellation
+                            Right (Left ()) -> pure AwaitTimeout
+                            Right (Right completed) -> pure completed
+    drainAvailable stateRef cap (encodeUtf8 marker) process
+    captured <- renderCapture cap <$> readIORef stateRef
+    pure Awaited
+        { awaitReason = reason
+        , awaitOutput = captured
+        }
+
+collectEvents
+    :: IORef CaptureState
+    -> Int
+    -> ByteString
+    -> GhciProcess
+    -> IO AwaitReason
+collectEvents stateRef cap marker process = go
   where
-    waitFor needle = do
-        bytes <- readIORef process.ghciBuffer
-        case BS.breakSubstring needle bytes of
-            (before, after)
-                | BS.null after -> threadDelay 5000 >> waitFor needle
-                | otherwise -> do
-                    writeIORef process.ghciBuffer (BS.drop (BS.length needle) after)
-                    pure (decodeUtf8With lenientDecode before)
+    go = do
+        event <- atomically (readTChanCompat process.ghciEvents)
+        state <- atomicModifyIORef' stateRef \current ->
+            let updated = applyEvent cap marker event current
+            in (updated, updated)
+        if state.stdoutCapture.streamDone
+            && state.stderrCapture.streamDone
+            then pure AwaitMarkers
+            else if state.stdoutCapture.streamClosed
+                && state.stderrCapture.streamClosed
+                then pure AwaitProcessExit
+                else go
 
-drainHandle :: Handle -> IORef ByteString -> IO ()
-drainHandle handle ref = go
+-- Kept as a helper so the blocking operation is visually distinct from
+-- non-blocking queue drains.
+readTChanCompat :: TChan a -> STM a
+readTChanCompat = readTChan
+
+drainAvailable
+    :: IORef CaptureState
+    -> Int
+    -> ByteString
+    -> GhciProcess
+    -> IO ()
+drainAvailable stateRef cap marker process =
+    atomically (tryReadTChan process.ghciEvents) >>= \case
+        Nothing -> pure ()
+        Just event -> do
+            atomicModifyIORef' stateRef \current ->
+                (applyEvent cap marker event current, ())
+            drainAvailable stateRef cap marker process
+
+applyEvent :: Int -> ByteString -> GhciEvent -> CaptureState -> CaptureState
+applyEvent cap marker event state =
+    case event of
+        GhciChunk GhciStdout bytes ->
+            state
+                { stdoutCapture =
+                    consumeChunk cap marker bytes state.stdoutCapture
+                }
+        GhciChunk GhciStderr bytes ->
+            state
+                { stderrCapture =
+                    consumeChunk cap marker bytes state.stderrCapture
+                }
+        GhciStreamClosed GhciStdout ->
+            state
+                { stdoutCapture = state.stdoutCapture { streamClosed = True } }
+        GhciStreamClosed GhciStderr ->
+            state
+                { stderrCapture = state.stderrCapture { streamClosed = True } }
+
+consumeChunk
+    :: Int
+    -> ByteString
+    -> ByteString
+    -> StreamCapture
+    -> StreamCapture
+consumeChunk cap marker chunk capture
+    | capture.streamDone = capture
+    | otherwise =
+        let combined = capture.streamPending <> chunk
+            (before, after) = BS.breakSubstring marker combined
+        in if not (BS.null after)
+            then (appendBounded cap before capture)
+                { streamPending = BS.empty
+                , streamDone = True
+                }
+            else
+                let keep = min
+                        (max 0 (BS.length marker - 1))
+                        (BS.length combined)
+                    emitLength = BS.length combined - keep
+                    emitted = BS.take emitLength combined
+                    pending = BS.drop emitLength combined
+                in (appendBounded cap emitted capture)
+                    { streamPending = pending }
+
+appendBounded :: Int -> ByteString -> StreamCapture -> StreamCapture
+appendBounded cap bytes capture
+    | BS.null bytes = capture
+    | cap <= 0 =
+        capture { streamOutput = capture.streamOutput <> bytes }
+    | otherwise =
+        let remaining = max 0 (cap - BS.length capture.streamOutput)
+            kept = BS.take remaining bytes
+            dropped = BS.length bytes - BS.length kept
+        in capture
+            { streamOutput = capture.streamOutput <> kept
+            , streamDropped = capture.streamDropped + dropped
+            }
+
+renderCapture :: Int -> CaptureState -> CapturedOutput
+renderCapture cap state =
+    let (stdout, stdoutDropped) = renderStream cap state.stdoutCapture
+        (stderr, stderrDropped) = renderStream cap state.stderrCapture
+    in CapturedOutput
+        { capturedStdout = stdout
+        , capturedStderr = stderr
+        , capturedTruncated = stdoutDropped > 0 || stderrDropped > 0
+        }
+
+renderStream :: Int -> StreamCapture -> (Text, Int)
+renderStream cap capture =
+    let finalized =
+            if capture.streamDone
+                then capture
+                else appendBounded cap capture.streamPending capture
+        decoded = decodeUtf8With lenientDecode finalized.streamOutput
+        dropped = finalized.streamDropped
+        suffix
+            | dropped <= 0 = ""
+            | otherwise =
+                "\n...[truncated "
+                    <> Text.pack (show dropped)
+                    <> " bytes]"
+    in (decoded <> suffix, dropped)
+
+drainHandle :: GhciStream -> Handle -> TChan GhciEvent -> IO ()
+drainHandle stream handle events =
+    go `finally` atomically (writeTChan events (GhciStreamClosed stream))
   where
     go = do
         chunk <- BS.hGetSome handle 4096
         if BS.null chunk
             then pure ()
             else do
-                atomicModifyIORef' ref \soFar -> (soFar <> chunk, ())
+                atomically (writeTChan events (GhciChunk stream chunk))
                 go
 
+normalizeTimeout :: Int -> Int
+normalizeTimeout = min 300000 . max 1
 
---------------------------------------------------------------------------------
--- run_ghci AppTool
---------------------------------------------------------------------------------
-
-data GhciArgs = GhciArgs
-    { expression :: Text
-    , timeout :: Maybe Int
-    , description :: Text
-    }
-
-instance FromJSON GhciArgs where
-    parseJSON = objectArgs \object -> GhciArgs
-        <$> reqText object "expression"
-        <*> optionalTimeout object
-        <*> reqText object "description"
-
-optionalTimeout :: Object -> Parser (Maybe Int)
-optionalTimeout object = do
-    fromInt <- optInt object "timeout"
-    fromText <- optText object "timeout"
-    pure (fromInt <|> (fromText >>= readTimeout))
-
-readTimeout :: Text -> Maybe Int
-readTimeout text =
-    case reads (Text.unpack text) of
-        [(n, "")] -> Just n
-        _ -> Nothing
-
--- | Provider-neutral persistent GHCi tool with per-call purity approval.
-runGhciTool :: GhciSession -> AppTool
-runGhciTool session = AppTool
-    { appToolName = "run_ghci"
-    , appToolDescription = ghciDescription
-    , appToolParameters =
-        [ PropertySchema "expression" PropertyString True $ Just
-            "Haskell expression, statement, or GHCi :command to evaluate."
-        , PropertySchema "timeout" PropertyInteger False $ Just
-            "Optional timeout in milliseconds (max 300000). Default: 30000."
-        , PropertySchema "description" PropertyString True $ Just
-            "One sentence explanation as to why this evaluation is needed."
-        ]
-    , appToolHandler = typedTool "run_ghci" (runGhci session)
-    , appToolKind = JsonFunction
-    , appToolReadOnly = False
-    , appToolIsReadOnlyCall = Just (isGhciReadOnlyCall session)
-    }
-
-ghciDescription :: Text
-ghciDescription =
-    "Evaluate Haskell in a persistent GHCi session for this agent.\n\
-    \Bindings and loaded modules persist across calls.\n\
-    \Pure expressions auto-approve; IO and side-effecting GHCi commands need approval.\n\
-    \Prefer this over shell tools for calculations, type exploration, and small Haskell scripts.\n\
-    \The session starts with GHC2021 plus BlockArguments, OverloadedStrings, \
-    \OverloadedRecordDot, DuplicateRecordFields, NoFieldSelectors, LambdaCase, \
-    \and RecordWildCards — LANGUAGE pragmas are not required for those."
-
-isGhciReadOnlyCall :: GhciSession -> ToolCall -> IO Bool
-isGhciReadOnlyCall session call =
-    case decodeExpression call.arguments of
-        Nothing -> pure False
-        Just expression -> do
-            classification <- classifyGhci session expression
-            pure (classification == GhciPure)
-
-decodeExpression :: Text -> Maybe Text
-decodeExpression arguments =
-    case Aeson.decodeStrict (TextEncoding.encodeUtf8 arguments) of
-        Just (Aeson.Object object) ->
-            case KeyMap.lookup (Key.fromText "expression") object of
-                Just (Aeson.String value) -> Just value
-                _ -> Nothing
-        _ -> Nothing
-
-runGhci :: GhciSession -> GhciArgs -> IO (Either Text Text)
-runGhci session args
-    | Text.null args.description =
-        pure (Left "Missing parameter: description")
-    | Text.null (Text.strip args.expression) =
-        pure (Left "Missing parameter: expression")
-    | otherwise = do
-        let timeoutMs = min 300000 (max 1 (fromMaybe 30000 args.timeout))
-        result <- evalGhci session args.expression timeoutMs
-        let classLabel = case result.ghciClass of
-                GhciPure -> "pure"
-                GhciEffectful -> "io"
-            body = result.ghciOutput
-        if result.ghciTimedOut
-            then pure $ Right $
-                "class: " <> classLabel <> "\nexit: killed (timeout)\n" <> body
-            else
-                let status = if result.ghciOk then "ok" else "error"
-                in pure $ Right $
-                    "class: " <> classLabel <> "\n" <> status <> "\n" <> body
+remainingMillis :: Word64 -> Int -> IO Int
+remainingMillis started budget = do
+    now <- getMonotonicTimeNSec
+    let elapsed = fromIntegral ((now - started) `div` 1000000)
+    pure (max 0 (budget - elapsed))

--- a/packages/agent-core/src/Agent/Tools/Ghci/Tool.hs
+++ b/packages/agent-core/src/Agent/Tools/Ghci/Tool.hs
@@ -1,0 +1,147 @@
+-- | Provider-neutral @run_ghci@ tool adapter.
+module Agent.Tools.Ghci.Tool
+    ( runGhciTool
+    ) where
+
+import Agent.ToolArgs
+    ( objectArgs
+    , optInt
+    , optText
+    , reqText
+    )
+import Agent.ToolDSL
+    ( PropertySchema(..)
+    , PropertyType(..)
+    )
+import Agent.ToolDispatch (ToolCall(..), typedTool)
+import Agent.Tools.Ghci.Classify (GhciClass(..))
+import Agent.Tools.Ghci.Runtime
+    ( GhciOutcome(..)
+    , GhciResult(..)
+    , GhciSession
+    , classifyGhci
+    , evalGhci
+    )
+import Agent.Tools.Types (AppTool(..), AppToolKind(..))
+import Control.Applicative ((<|>))
+import Data.Aeson (FromJSON(..), Object)
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import Data.Aeson.Types (Parser)
+import Data.Maybe (fromMaybe)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as TextEncoding
+
+data GhciArgs = GhciArgs
+    { expression :: Text
+    , timeout :: Maybe Int
+    , description :: Text
+    }
+
+instance FromJSON GhciArgs where
+    parseJSON = objectArgs \object -> GhciArgs
+        <$> reqText object "expression"
+        <*> optionalTimeout object
+        <*> reqText object "description"
+
+optionalTimeout :: Object -> Parser (Maybe Int)
+optionalTimeout object = do
+    fromInt <- optInt object "timeout"
+    fromText <- optText object "timeout"
+    pure (fromInt <|> (fromText >>= readTimeout))
+
+readTimeout :: Text -> Maybe Int
+readTimeout text =
+    case reads (Text.unpack text) of
+        [(n, "")] -> Just n
+        _ -> Nothing
+
+runGhciTool :: GhciSession -> AppTool
+runGhciTool session = AppTool
+    { appToolName = "run_ghci"
+    , appToolDescription = ghciDescription
+    , appToolParameters =
+        [ PropertySchema "expression" PropertyString True $ Just
+            "Haskell expression, statement, or GHCi :command to evaluate."
+        , PropertySchema "timeout" PropertyInteger False $ Just
+            "Optional timeout in milliseconds (max 300000). Default: 30000."
+        , PropertySchema "description" PropertyString True $ Just
+            "One sentence explanation as to why this evaluation is needed."
+        ]
+    , appToolHandler = typedTool "run_ghci" (runGhci session)
+    , appToolKind = JsonFunction
+    , appToolReadOnly = False
+    , appToolIsReadOnlyCall = Just (isGhciReadOnlyCall session)
+    }
+
+ghciDescription :: Text
+ghciDescription =
+    "Evaluate Haskell in a persistent GHCi session for this agent.\n\
+    \Bindings and loaded modules persist across calls.\n\
+    \Pure expressions auto-approve; IO and side-effecting GHCi commands need approval.\n\
+    \Prefer this over shell tools for calculations, type exploration, and small Haskell scripts.\n\
+    \The session starts with GHC2021 plus BlockArguments, OverloadedStrings, \
+    \OverloadedRecordDot, DuplicateRecordFields, NoFieldSelectors, LambdaCase, \
+    \and RecordWildCards — LANGUAGE pragmas are not required for those."
+
+isGhciReadOnlyCall :: GhciSession -> ToolCall -> IO Bool
+isGhciReadOnlyCall session call =
+    case decodeExpression call.arguments of
+        Nothing -> pure False
+        Just expression -> do
+            classification <- classifyGhci session expression
+            pure (classification == GhciPure)
+
+decodeExpression :: Text -> Maybe Text
+decodeExpression arguments =
+    case Aeson.decodeStrict (TextEncoding.encodeUtf8 arguments) of
+        Just (Aeson.Object object) ->
+            case KeyMap.lookup (Key.fromText "expression") object of
+                Just (Aeson.String value) -> Just value
+                _ -> Nothing
+        _ -> Nothing
+
+runGhci :: GhciSession -> GhciArgs -> IO (Either Text Text)
+runGhci session args
+    | Text.null (Text.strip args.description) =
+        pure (Left "Missing parameter: description")
+    | Text.null (Text.strip args.expression) =
+        pure (Left "Missing parameter: expression")
+    | otherwise = do
+        let timeoutMs = normalizeTimeout (fromMaybe 30000 args.timeout)
+        result <- evalGhci session args.expression timeoutMs
+        let classLabel = case result.ghciClass of
+                GhciPure -> "pure"
+                GhciEffectful -> "io"
+            status = case result.ghciOutcome of
+                GhciCompleted
+                    | result.ghciOk -> "ok"
+                    | otherwise -> "error"
+                GhciTimedOut
+                    | result.ghciRestarted ->
+                        "timeout (session restarted; bindings lost)"
+                    | otherwise -> "timeout"
+                GhciCancelled
+                    | result.ghciRestarted ->
+                        "cancelled (session restarted; bindings lost)"
+                    | otherwise -> "cancelled"
+                GhciProcessFailed
+                    | result.ghciRestarted ->
+                        "process failed (session restarted; bindings lost)"
+                    | otherwise -> "process failed"
+            truncated =
+                if result.ghciTruncated then "\noutput: truncated" else ""
+            body
+                | Text.null result.ghciOutput = ""
+                | otherwise = "\n" <> result.ghciOutput
+        pure $ Right $
+            "class: " <> classLabel
+                <> "\n"
+                <> status
+                <> truncated
+                <> body
+
+normalizeTimeout :: Int -> Int
+normalizeTimeout = min 300000 . max 1

--- a/packages/agent-core/test/Agent/Tools/GhciSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/GhciSpec.hs
@@ -1,13 +1,13 @@
 module Agent.Tools.GhciSpec (spec) where
 
+import Agent.Cancel (requestCancel, resetCancel)
 import Agent.Loop (defaultLoopDispatch)
-import Agent.ToolDispatch (ToolCallResult(..), dispatchToolCall, functionToolCall)
 import Agent.Provider (Provider(..))
+import Agent.ToolDispatch (ToolCallResult(..), dispatchToolCall, functionToolCall)
 import Agent.Tools (CodingTools(..), appToolHandlers, codingToolsFor, defaultToolEnv)
-import Agent.Tools.Grok (closeGrokSession, grokTools, newGrokSession)
-import Agent.Tools.PlanMode (newPlanModeEnv)
 import Agent.Tools.Ghci
     ( GhciClass(..)
+    , GhciOutcome(..)
     , GhciResult(..)
     , GhciSession
     , classifyGhci
@@ -18,14 +18,18 @@ import Agent.Tools.Ghci
     , newGhciSession
     , typeLooksEffectful
     )
+import Agent.Tools.Grok (closeGrokSession, grokTools, newGrokSession)
+import Agent.Tools.PlanMode (newPlanModeEnv)
 import Agent.Tools.Types (AppTool(..), ToolEnv(..))
+import Control.Concurrent (threadDelay)
+import Control.Concurrent.Async (async, wait)
 import Control.Exception.Safe (bracket)
+import Data.IORef
+import qualified Data.Map.Strict as Map
 import qualified Data.Text as Text
 import System.Directory (getTemporaryDirectory, removeDirectoryRecursive)
 import System.FilePath ((</>))
 import System.Posix.Temp (mkdtemp)
-import Data.IORef
-import qualified Data.Map.Strict as Map
 import Test.Hspec
 
 spec :: Spec
@@ -69,6 +73,17 @@ spec = describe "Agent.Tools.Ghci" do
             value.ghciOk `shouldBe` True
             value.ghciOutput `shouldSatisfy` Text.isInfixOf "42"
 
+    it "supports multiline bindings and do blocks" do
+        withTempGhci \ghci -> do
+            bind <- evalGhci ghci "let addOne x =\n  x + 1" 10000
+            bind.ghciOk `shouldBe` True
+            value <- evalGhci ghci "addOne 41" 10000
+            value.ghciOk `shouldBe` True
+            value.ghciOutput `shouldSatisfy` Text.isInfixOf "42"
+            action <- evalGhci ghci "do\n  let x = 1\n  print (x + 1)" 10000
+            action.ghciOk `shouldBe` True
+            action.ghciOutput `shouldSatisfy` Text.isInfixOf "2"
+
     it "evaluates OverloadedStrings and LambdaCase without LANGUAGE pragmas" do
         withTempGhci \ghci -> do
             str <- evalGhci ghci "\"hello\"" 10000
@@ -82,6 +97,20 @@ spec = describe "Agent.Tools.Ghci" do
             mapM_
                 (\ext -> shown.ghciOutput `shouldSatisfy` Text.isInfixOf (Text.pack ext))
                 defaultGhciExtensions
+
+    it "does not mistake ordinary output for diagnostics" do
+        withTempGhci \ghci -> do
+            result <- evalGhci ghci "\"error: Exception: <interactive>:\"" 10000
+            result.ghciOk `shouldBe` True
+            result.ghciStdout
+                `shouldSatisfy` Text.isInfixOf "error: Exception: <interactive>:"
+            result.ghciStderr `shouldBe` ""
+
+    it "captures runtime exceptions from stderr" do
+        withTempGhci \ghci -> do
+            result <- evalGhci ghci "error \"boom\"" 10000
+            result.ghciOk `shouldBe` False
+            result.ghciStderr `shouldSatisfy` Text.isInfixOf "*** Exception: boom"
 
     it "classifies putStrLn as effectful and 1+1 as pure" do
         withTempGhci \ghci -> do
@@ -97,6 +126,64 @@ spec = describe "Agent.Tools.Ghci" do
             recovered.ghciOk `shouldBe` True
             recovered.ghciOutput `shouldSatisfy` Text.isInfixOf "4"
 
+    it "honors cancellation and recovers the persistent process" do
+        withTempEnv \env ->
+            bracket (newGhciSession env) closeGhciSession \ghci -> do
+                running <- async (evalGhci ghci "last [1..]" 10000)
+                threadDelay 100000
+                requestCancel env.toolCancel
+                cancelled <- wait running
+                cancelled.ghciOutcome `shouldBe` GhciCancelled
+                resetCancel env.toolCancel
+                recovered <- evalGhci ghci "2 + 3" 10000
+                recovered.ghciOk `shouldBe` True
+                recovered.ghciOutput `shouldSatisfy` Text.isInfixOf "5"
+
+    it "caps retained output and reports truncation" do
+        withTempEnv \baseEnv -> do
+            let env = baseEnv { toolStdoutCap = 32 }
+            bracket (newGhciSession env) closeGhciSession \ghci -> do
+                result <- evalGhci ghci "replicate 200 'x'" 10000
+                result.ghciOk `shouldBe` True
+                result.ghciTruncated `shouldBe` True
+                result.ghciOutput `shouldSatisfy` Text.isInfixOf "[truncated"
+                Text.length result.ghciStdout `shouldSatisfy` (< 100)
+
+    it "ignores repository .ghci files" do
+        withTempEnv \env -> do
+            writeFile (env.toolCwd </> ".ghci")
+                "let injectedByDotGhci = (99 :: Int)\n"
+            bracket (newGhciSession env) closeGhciSession \ghci -> do
+                result <- evalGhci ghci "injectedByDotGhci" 10000
+                result.ghciOk `shouldBe` False
+                result.ghciOutput
+                    `shouldSatisfy` Text.isInfixOf "Variable not in scope"
+
+    it "keeps its framing working after NoImplicitPrelude" do
+        withTempGhci \ghci -> do
+            changed <- evalGhci ghci ":set -XNoImplicitPrelude" 10000
+            changed.ghciOk `shouldBe` True
+            result <- evalGhci ghci "1 + 1" 10000
+            result.ghciOk `shouldBe` True
+            result.ghciOutput `shouldSatisfy` Text.isInfixOf "2"
+
+    it "restarts after the evaluated command exits GHCi" do
+        withTempGhci \ghci -> do
+            exited <- evalGhci ghci ":quit" 10000
+            exited.ghciOutcome `shouldBe` GhciProcessFailed
+            recovered <- evalGhci ghci "6 * 7" 10000
+            recovered.ghciOk `shouldBe` True
+            recovered.ghciOutput `shouldSatisfy` Text.isInfixOf "42"
+
+    it "is terminal and idempotent after close" do
+        withTempEnv \env -> do
+            ghci <- newGhciSession env
+            closeGhciSession ghci
+            closeGhciSession ghci
+            result <- evalGhci ghci "1 + 1" 10000
+            result.ghciOutcome `shouldBe` GhciProcessFailed
+            result.ghciOutput `shouldSatisfy` Text.isInfixOf "closed"
+
     it "exposes run_ghci through grokTools dispatch" do
         withTempTools \tools -> do
             let handlers = appToolHandlers tools
@@ -107,7 +194,6 @@ spec = describe "Agent.Tools.Ghci" do
             result.output `shouldSatisfy` Text.isInfixOf "7"
             let names = map (.appToolName) tools
             names `shouldContain` ["run_ghci"]
-
 
     it "is registered for OpenAI via codingToolsFor" do
         withTempEnv \env -> do


### PR DESCRIPTION
## Summary

- harden the persistent GHCi process lifecycle with startup handshakes, terminal close state, bounded shutdown, and automatic restart reporting
- frame both stdout and stderr with event-driven, bounded capture; add cancellation, multiline input, output truncation, and structured outcomes
- ignore repository `.ghci` files and move the provider-neutral tool adapter into `Agent.Tools.Ghci.Tool`
- preserve the existing pure-expression auto-approval behavior

## Tests

- targeted `Agent.Tools.Ghci` suite: 18 examples, 0 failures
- full `agent-core` suite: 140 examples, 0 failures
- multi-package GHCi load (`agent-cli`, `agent-core`, OpenAI, XAI, OpenRouter): 114 modules loaded
- `git diff --check`
