### PR TITLE
fix: avoid unscoped async workers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,3 +104,7 @@ cabal run agent-cli -- +RTS -M16G -RTS
 
 # haskell
 - Prefer Control.Exception.Safe over Control.Exception
+- Never use bare `Control.Concurrent.Async.async`. Prefer structured
+  concurrency (`withAsync`, `race`, `concurrently`, etc.) so child lifetimes
+  are scoped. If work must outlive the current call, track its lifecycle and
+  completion explicitly, and cancel and join it when its owner closes.

--- a/packages/agent-core/src/Agent/Subagents/Registry.hs
+++ b/packages/agent-core/src/Agent/Subagents/Registry.hs
@@ -1,8 +1,8 @@
 -- | Nestable subagent registry.
 --
 -- Shared state (agent map, status, mailboxes, admission count) lives in STM.
--- IO is only used to allocate ids, start child 'Async' loops, and wait with
--- timeouts via 'threadDelay'.
+-- IO is only used to allocate ids, start explicitly tracked child threads,
+-- and wait with timeouts via 'threadDelay'.
 module Agent.Subagents.Registry
     ( SubagentRegistry
     , newSubagentRegistry
@@ -53,10 +53,15 @@ import Agent.Subagents.Types
     , maxWaitTimeoutMs
     , minWaitTimeoutMs
     )
-import Control.Concurrent (threadDelay)
-import Control.Concurrent.Async (Async, async, cancel, waitCatch)
+import Control.Concurrent
+    ( ThreadId
+    , forkFinally
+    , killThread
+    , threadDelay
+    )
+import Control.Concurrent.Async (race)
 import Control.Concurrent.STM
-import Control.Exception.Safe (SomeException, tryAny)
+import Control.Exception.Safe (SomeException, mask, onException, tryAny)
 import Data.IORef
 import Data.Maybe (fromMaybe)
 import Data.Map.Strict (Map)
@@ -83,13 +88,18 @@ data SubagentRecord = SubagentRecord
     , recordStatus :: !(TVar SubagentStatus)
     , recordCancel :: !CancelFlag
     , recordMailbox :: !(TQueue InterAgentMessage)
-    , recordAsync :: !(TVar (Maybe (Async ())))
+    , recordWorker :: !(TVar (Maybe Worker))
       -- | Whether this agent currently occupies a concurrency slot.
     , recordSlotHeld :: !(TVar Bool)
       -- | Last successful response id for conversation continuity.
     , recordPreviousResponseId :: !(TVar (Maybe Text))
     , recordTaskPath :: !TaskPath
     , recordCwd :: !OsPath
+    }
+
+data Worker = Worker
+    { workerThreadId :: !(TMVar ThreadId)
+    , workerDone :: !(TMVar ())
     }
 
 data SubagentRegistry = SubagentRegistry
@@ -230,7 +240,7 @@ spawnSubagentAtWithCwd registry childCwd parentId parentPath parentDepth taskNam
                 cancelFlag <- newCancelFlag
                 mailbox <- newTQueueIO
                 statusVar <- newTVarIO Pending
-                asyncVar <- newTVarIO Nothing
+                workerVar <- newTVarIO Nothing
                 slotHeld <- newTVarIO True
                 previousVar <- newTVarIO Nothing
                 let record = SubagentRecord
@@ -241,7 +251,7 @@ spawnSubagentAtWithCwd registry childCwd parentId parentPath parentDepth taskNam
                         , recordStatus = statusVar
                         , recordCancel = cancelFlag
                         , recordMailbox = mailbox
-                        , recordAsync = asyncVar
+                        , recordWorker = workerVar
                         , recordSlotHeld = slotHeld
                         , recordPreviousResponseId = previousVar
                         , recordTaskPath = childPath
@@ -277,13 +287,26 @@ spawnSubagentAtWithCwd registry childCwd parentId parentPath parentDepth taskNam
                                 , messageType = NewTaskMessage
                                 , messageContent = content
                                 }
-                        child <- async (runWorker registry record message)
-                        atomically $ writeTVar asyncVar (Just child)
-                        pure (Right (agentId, childPath))
+                        started <-
+                            startRecordWorker registry record
+                                (runWorker registry record message)
+                                `onException` shutdownRecord registry record
+                        if started
+                            then pure (Right (agentId, childPath))
+                            else do
+                                shutdownRecord registry record
+                                pure (Left "Subagent closed before its worker started.")
 
 runWorker :: SubagentRegistry -> SubagentRecord -> InterAgentMessage -> IO ()
 runWorker registry record firstPrompt = do
-    atomically $ writeTVar record.recordStatus Running
+    mayRun <- atomically do
+        closed <- readTVar registry.registryClosed
+        current <- readTVar record.recordStatus
+        if closed || current == Closed
+            then pure False
+            else do
+                writeTVar record.recordStatus Running
+                pure True
     let env = SubagentSpawnEnv
             { subId = record.recordId
             , subDepth = record.recordDepth
@@ -328,10 +351,60 @@ runWorker registry record firstPrompt = do
             case next of
                 -- Completed/errored/interrupted agents stay open and keep their
                 -- concurrency slot until close_agent, matching Codex v1.
-                Nothing -> do
-                    notifyComplete registry record.recordId status
+                Nothing -> notifyComplete registry record.recordId status
                 Just msg -> loop msg
-    loop firstPrompt
+    whenIO mayRun (loop firstPrompt)
+
+-- | Record ownership before forking. The thread id is published immediately
+-- afterward, so shutdown can safely race startup and still cancel and join.
+startRecordWorker
+    :: SubagentRegistry
+    -> SubagentRecord
+    -> IO ()
+    -> IO Bool
+startRecordWorker registry record action = mask \restore -> do
+    -- A completed turn publishes its status just before its worker exits.
+    -- Wait for that short tail before replacing the tracked worker.
+    atomically do
+        current <- readTVar record.recordWorker
+        case current of
+            Nothing -> pure ()
+            Just worker -> readTMVar worker.workerDone
+    threadIdVar <- newEmptyTMVarIO
+    done <- newEmptyTMVarIO
+    let worker = Worker
+            { workerThreadId = threadIdVar
+            , workerDone = done
+            }
+    started <- atomically do
+        closed <- readTVar registry.registryClosed
+        status <- readTVar record.recordStatus
+        current <- readTVar record.recordWorker
+        case current of
+            Just _ -> pure False
+            Nothing
+                | closed || status == Closed -> pure False
+                | otherwise -> do
+                    writeTVar record.recordWorker (Just worker)
+                    pure True
+    if started
+        then do
+            tid <- forkFinally (restore action) (\_ -> finishWorker record worker)
+                `onException` finishWorker record worker
+            atomically $ putTMVar threadIdVar tid
+            pure True
+        else pure False
+
+finishWorker :: SubagentRecord -> Worker -> IO ()
+finishWorker record worker = atomically do
+    writeTVar record.recordWorker Nothing
+    putTMVar worker.workerDone ()
+
+stopWorker :: Worker -> IO ()
+stopWorker worker = do
+    threadId <- atomically $ readTMVar worker.workerThreadId
+    killThread threadId
+    atomically $ readTMVar worker.workerDone
 
 notifyComplete :: SubagentRegistry -> SubagentId -> SubagentStatus -> IO ()
 notifyComplete registry agentId status
@@ -383,23 +456,20 @@ waitSubagents
     -> IO (Map SubagentId SubagentStatus, Bool)
 waitSubagents registry targets timeoutMs = do
     let clamped = max minWaitTimeoutMs (min maxWaitTimeoutMs (max 1 timeoutMs))
-    done <- newEmptyTMVarIO
-    waiter <- async $ atomically do
-        statuses <- mapM (readStatusSTM registry) targets
-        let pairs = zip targets statuses
-        if any (isFinalStatus . snd) pairs
-            then putTMVar done (Map.fromList pairs, False)
-            else retry
-    timer <- async do
-        threadDelay (clamped * 1000)
-        atomically do
+        waitForFinal = atomically do
             statuses <- mapM (readStatusSTM registry) targets
-            _ <- tryPutTMVar done (Map.fromList (zip targets statuses), True)
-            pure ()
-    result <- atomically (takeTMVar done)
-    cancel waiter
-    cancel timer
-    pure result
+            let pairs = zip targets statuses
+            if any (isFinalStatus . snd) pairs
+                then pure (Map.fromList pairs)
+                else retry
+        waitForTimeout = do
+            threadDelay (clamped * 1000)
+            atomically do
+                statuses <- mapM (readStatusSTM registry) targets
+                pure (Map.fromList (zip targets statuses))
+    race waitForFinal waitForTimeout >>= \case
+        Left statuses -> pure (statuses, False)
+        Right statuses -> pure (statuses, True)
 
 data SendKick
     = KickNone
@@ -463,11 +533,13 @@ sendInputMessage registry senderPath agentId content interrupt = do
                         KickFail err -> pure (Left err)
                         KickNone -> pure (Right "queued")
                         KickStart -> do
-                            child <- async do
-                                msg <- atomically $ readTQueue record.recordMailbox
-                                runWorker registry record msg
-                            atomically $ writeTVar record.recordAsync (Just child)
-                            pure (Right "queued")
+                            started <-
+                                startRecordWorker registry record do
+                                    msg <- atomically $ readTQueue record.recordMailbox
+                                    runWorker registry record msg
+                            if started
+                                then pure (Right "queued")
+                                else pure (Left "agent was closed before its worker started")
 
 whenIO :: Bool -> IO () -> IO ()
 whenIO True action = action
@@ -497,17 +569,12 @@ descendants agents parentId =
 shutdownRecord :: SubagentRegistry -> SubagentRecord -> IO ()
 shutdownRecord registry record = do
     requestCancel record.recordCancel
-    masync <- atomically do
+    mworker <- atomically do
         writeTVar record.recordStatus Closed
-        a <- readTVar record.recordAsync
-        writeTVar record.recordAsync Nothing
-        pure a
-    case masync of
+        readTVar record.recordWorker
+    case mworker of
         Nothing -> pure ()
-        Just child -> do
-            cancel child
-            _ <- tryAny (waitCatch child)
-            pure ()
+        Just worker -> stopWorker worker
     releaseSlot registry record
 
 -- | Re-admit a previously persisted agent that is not currently in the
@@ -542,13 +609,13 @@ restoreSubagentWithCwd registry childCwd agentId parentId depth nickname previou
             atomically do
                 writeTVar record.recordStatus (Completed Nothing)
                 writeTVar record.recordPreviousResponseId previous
-                writeTVar record.recordAsync Nothing
+                writeTVar record.recordWorker Nothing
             pure (Right agentId)
         Nothing -> do
             cancelFlag <- newCancelFlag
             mailbox <- newTQueueIO
             statusVar <- newTVarIO (Completed Nothing)
-            asyncVar <- newTVarIO Nothing
+            workerVar <- newTVarIO Nothing
             slotHeld <- newTVarIO False
             previousVar <- newTVarIO previous
             let record = SubagentRecord
@@ -559,7 +626,7 @@ restoreSubagentWithCwd registry childCwd agentId parentId depth nickname previou
                     , recordStatus = statusVar
                     , recordCancel = cancelFlag
                     , recordMailbox = mailbox
-                    , recordAsync = asyncVar
+                    , recordWorker = workerVar
                     , recordSlotHeld = slotHeld
                     , recordPreviousResponseId = previousVar
                     , recordTaskPath = taskPathRoot

--- a/packages/agent-core/src/Agent/Tools/IO.hs
+++ b/packages/agent-core/src/Agent/Tools/IO.hs
@@ -25,9 +25,9 @@ import Agent.Tools.FileSystem
     , writeTextFile
     )
 import Agent.Tools.Types (ToolEnv(..))
-import Control.Concurrent (forkIO, threadDelay)
+import Control.Concurrent (forkFinally, threadDelay)
 import Control.Monad (void)
-import Control.Concurrent.Async (async, concurrently, race, wait)
+import Control.Concurrent.Async (concurrently, race)
 import Control.Concurrent.MVar (MVar, newEmptyMVar, putMVar)
 import Control.Exception (evaluate)
 import Control.Exception.Safe (SomeException, try)
@@ -192,23 +192,14 @@ startShellCommand env workdir command = do
             resultVar <- newEmptyMVar
             stdoutRef <- newIORef BS.empty
             stderrRef <- newIORef BS.empty
-            outA <- async (drainHandle hout stdoutRef)
-            errA <- async (drainHandle herr stderrRef)
-            _ <- forkIO do
-                result <- try @_ @SomeException do
-                    code <- waitForProcess processHandle
-                    outBytes <- wait outA
-                    errBytes <- wait errA
-                    pure (outBytes, errBytes, code)
-                putMVar resultVar $ case result of
-                    Left exception -> CommandResult
-                        { commandExitCode = Just 127
-                        , commandStdout = ""
-                        , commandStderr = Text.pack (show exception)
-                        , commandTimedOut = False
-                        , commandCancelled = False
-                        }
-                    Right (outBytes, errBytes, code) -> CommandResult
+            _ <- forkFinally
+                (do
+                    ((outBytes, errBytes), code) <- concurrently
+                        (concurrently
+                            (drainHandle hout stdoutRef)
+                            (drainHandle herr stderrRef))
+                        (waitForProcess processHandle)
+                    pure CommandResult
                         { commandExitCode = Just (exitCodeInt code)
                         , commandStdout = truncateText env.toolStdoutCap
                             (decodeUtf8With lenientDecode outBytes)
@@ -216,7 +207,8 @@ startShellCommand env workdir command = do
                             (decodeUtf8With lenientDecode errBytes)
                         , commandTimedOut = False
                         , commandCancelled = False
-                        }
+                        })
+                (publishCommandResult resultVar)
             pure $ Right RunningCommand
                 { runningHandle = processHandle
                 , runningResult = resultVar
@@ -226,6 +218,19 @@ startShellCommand env workdir command = do
                 }
         Right _ ->
             pure $ Left "Failed to capture command output"
+
+publishCommandResult :: MVar CommandResult -> Either SomeException CommandResult -> IO ()
+publishCommandResult resultVar result =
+    putMVar resultVar (either failedCommandResult id result)
+
+failedCommandResult :: SomeException -> CommandResult
+failedCommandResult exception = CommandResult
+    { commandExitCode = Just 127
+    , commandStdout = ""
+    , commandStderr = Text.pack (show exception)
+    , commandTimedOut = False
+    , commandCancelled = False
+    }
 
 strictGetContents :: Handle -> IO BS.ByteString
 strictGetContents handle = do

--- a/packages/agent-core/test/Agent/SubagentsSpec.hs
+++ b/packages/agent-core/test/Agent/SubagentsSpec.hs
@@ -7,6 +7,7 @@ import Agent.Subagents
 import Agent.Subagents.TaskPath (taskPathRoot, taskPathText)
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.STM
+import Control.Exception.Safe (finally)
 import Control.Monad (unless)
 import Data.IORef
 import Data.Maybe (fromMaybe)
@@ -19,6 +20,10 @@ messagePayload :: InterAgentMessage -> Text
 messagePayload message = case message.messageContent of
     PlainInterAgentContent text -> text
     EncryptedInterAgentContent text -> text
+
+blockingRunner started cleanedUp _ _ _ _ =
+    (atomically (putTMVar started ()) >> atomically retry)
+        `finally` atomically (putTMVar cleanedUp ())
 
 spec :: Spec
 spec = describe "Agent.Subagents" do
@@ -219,6 +224,17 @@ spec = describe "Agent.Subagents" do
         threadDelay 50000
         seen <- readIORef notices
         seen `shouldBe` [(agentId, Completed (Just "notify-me"))]
+
+    it "cancels and joins a running worker when the registry closes" do
+        started <- newEmptyTMVarIO
+        cleanedUp <- newEmptyTMVarIO
+        registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
+            (blockingRunner started cleanedUp)
+            (\_ _ -> pure ())
+        Right _ <- spawnSubagent registry Nothing 0 "wait" Nothing
+        atomically $ takeTMVar started
+        closeSubagentRegistry registry
+        atomically $ readTMVar cleanedUp
 
     it "restores a missing agent id into the registry" do
         registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")

--- a/packages/agent-core/test/Agent/Tools/GhciSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/GhciSpec.hs
@@ -23,7 +23,7 @@ import Agent.Tools.Grok (closeGrokSession, grokTools, newGrokSession)
 import Agent.Tools.PlanMode (newPlanModeEnv)
 import Agent.Tools.Types (AppTool(..), ToolEnv(..))
 import Control.Concurrent (threadDelay)
-import Control.Concurrent.Async (async, wait)
+import Control.Concurrent.Async (wait, withAsync)
 import Control.Exception.Safe (bracket)
 import Data.IORef
 import qualified Data.Map.Strict as Map
@@ -130,11 +130,11 @@ spec = describe "Agent.Tools.Ghci" do
     it "honors cancellation and recovers the persistent process" do
         withTempEnv \env ->
             bracket (newGhciSession env) closeGhciSession \ghci -> do
-                running <- async (evalGhci ghci "last [1..]" 10000)
-                threadDelay 100000
-                requestCancel env.toolCancel
-                cancelled <- wait running
-                cancelled.ghciOutcome `shouldBe` GhciCancelled
+                withAsync (evalGhci ghci "last [1..]" 10000) \running -> do
+                    threadDelay 100000
+                    requestCancel env.toolCancel
+                    cancelled <- wait running
+                    cancelled.ghciOutcome `shouldBe` GhciCancelled
                 resetCancel env.toolCancel
                 recovered <- evalGhci ghci "2 + 3" 10000
                 recovered.ghciOk `shouldBe` True

--- a/packages/agent-core/test/Agent/Tools/IOSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/IOSpec.hs
@@ -4,12 +4,15 @@ import Agent.Cancel (requestCancel)
 import Agent.OsPath (fromFilePath)
 import Agent.Tools.IO
     ( CommandResult(..)
+    , RunningCommand(..)
     , readTextFile
     , runShellCommand
+    , startShellCommand
     , writeTextFile
     )
 import Agent.Tools.Types (ToolEnv(..), defaultToolEnv)
 import Control.Concurrent (forkIO, newEmptyMVar, putMVar, takeMVar, threadDelay)
+import Control.Concurrent.MVar (readMVar)
 import Control.Exception.Safe (bracket)
 import Control.Monad (replicateM)
 import Data.Either (isLeft)
@@ -77,6 +80,19 @@ spec = describe "Agent.Tools.IO" do
             CommandResult{commandCancelled, commandTimedOut} <- takeMVar done
             commandCancelled `shouldBe` True
             commandTimedOut `shouldBe` False
+
+    it "collects both output streams from a background shell command" do
+        withTempDir checkBackgroundOutput
+
+checkBackgroundOutput dir = do
+    let osDir = fromFilePath dir
+    env <- defaultToolEnv osDir
+    Right running <-
+        startShellCommand env osDir "printf stdout; printf stderr >&2"
+    result <- readMVar running.runningResult
+    result.commandExitCode `shouldBe` Just 0
+    result.commandStdout `shouldBe` "stdout"
+    result.commandStderr `shouldBe` "stderr"
 
 withTempDir :: (FilePath -> IO a) -> IO a
 withTempDir action = do

--- a/packages/agent-core/test/Agent/Tools/MultiAgentsSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/MultiAgentsSpec.hs
@@ -26,7 +26,7 @@ import Test.Hspec
 spec :: Spec
 spec = describe "Agent.Tools.MultiAgents" do
     it "allows collaboration coordination without approval" do
-        registry <- newSubagentRegistry defaultSubagentConfig "/tmp"
+        registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
             (\_ _ _ _ -> pure $ Left LoopNoResponseId)
             (\_ _ -> pure ())
         let tools = multiAgentTools (rootContext registry Nothing)


### PR DESCRIPTION
## Summary

- remove all bare `async` calls from the Haskell codebase
- use structured `race` and `concurrently` for bounded concurrent work
- explicitly track, cancel, and join long-lived subagent worker threads
- close the worker launch/registration race during registry shutdown
- document the no-bare-`async` policy in `AGENTS.md`
- add regression coverage for worker teardown and background output draining

## Testing

- full `agent-core` test suite in GHCi: 134 examples, 0 failures
- `git diff --check`
- verified no bare `async` calls remain in `*.hs` files
