### PR TITLE
Skip approval prompts for collaboration tools

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Tools.hs
+++ b/packages/agent-cli/src/Agent/CLI/Tools.hs
@@ -9,6 +9,7 @@ import Agent.OpenAI.Responses.Types
 import Agent.OpenAI.ToolDSL (buildGrokTool, buildTool)
 import Agent.Provider (Provider(..))
 import Agent.ToolDSL (parametersObjectLoose)
+import Agent.ToolDispatch (canonicalToolName)
 import Agent.Tools.ApplyPatch (applyPatchGrammar)
 import Agent.Tools.MultiAgents (multiAgentNamespace, multiAgentToolNames)
 import Agent.Tools.Types (AppTool(..), AppToolKind(..))
@@ -20,7 +21,8 @@ import Data.List (find, partition)
 import Data.Text (Text)
 
 lookupAppTool :: Text -> [AppTool] -> Maybe AppTool
-lookupAppTool name = find (\tool -> tool.appToolName == name)
+lookupAppTool name =
+    find (\tool -> tool.appToolName == canonicalToolName name)
 
 -- | Built-in Responses @web_search@ tool, enabled for every provider by default.
 -- The host runs the search server-side; the agent loop never dispatches it.

--- a/packages/agent-cli/test/Agent/CLI/ApprovalSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ApprovalSpec.hs
@@ -27,6 +27,10 @@ spec = describe "childApprove" do
         childApprove DenyMutating [mutatingTool] mutatingCall
             `shouldReturn` Right False
 
+    it "recognizes namespaced collaboration tools as read-only" do
+        childApprove DenyMutating [namespacedReadOnlyTool] namespacedReadOnlyCall
+            `shouldReturn` Right True
+
     it "returns an in-band denial when a child would need to prompt" do
         result <- childApprove PromptMutating [mutatingTool] mutatingCall
         result `shouldSatisfy` \case
@@ -51,6 +55,10 @@ dynamicReadCall = functionToolCall "call-dynamic-read" "dynamic" "read"
 dynamicWriteCall :: ToolCall
 dynamicWriteCall = functionToolCall "call-dynamic-write" "dynamic" "write"
 
+namespacedReadOnlyCall :: ToolCall
+namespacedReadOnlyCall =
+    functionToolCall "call-list-agents" "collaboration.list_agents" "{}"
+
 readOnlyTool :: AppTool
 readOnlyTool = tool "read" True Nothing
 
@@ -59,6 +67,9 @@ mutatingTool = tool "write" False Nothing
 
 dynamicTool :: AppTool
 dynamicTool = tool "dynamic" False (Just (\call -> pure (call == dynamicReadCall)))
+
+namespacedReadOnlyTool :: AppTool
+namespacedReadOnlyTool = tool "list_agents" True Nothing
 
 tool :: Text -> Bool -> Maybe (ToolCall -> IO Bool) -> AppTool
 tool name readOnly classify = AppTool

--- a/packages/agent-core/src/Agent/ToolDispatch.hs
+++ b/packages/agent-core/src/Agent/ToolDispatch.hs
@@ -12,6 +12,7 @@ module Agent.ToolDispatch
     , functionToolCall
     , customToolCall
     , dispatchToolCall
+    , canonicalToolName
     , toolArgumentsValue
     , decodeToolArguments
     ) where
@@ -125,12 +126,12 @@ decodeToolArguments value =
 findHandler :: Text -> [ToolHandler] -> Maybe ToolHandler
 findHandler name handlers =
     find ((== name) . handlerName) handlers
-        <|> find ((== stripNamespace name) . handlerName) handlers
+        <|> find ((== canonicalToolName name) . handlerName) handlers
 
 -- | Codex namespaced tools may arrive as @collaboration.spawn_agent@ or
 -- legacy @multi_agent_v1.spawn_agent@ (and concatenated Display forms).
-stripNamespace :: Text -> Text
-stripNamespace name
+canonicalToolName :: Text -> Text
+canonicalToolName name
     | Just rest <- Text.stripPrefix "collaboration." name = rest
     | Just rest <- Text.stripPrefix "collaboration" name
     , rest `elem` multiAgentBareNames =

--- a/packages/agent-core/src/Agent/Tools/MultiAgents.hs
+++ b/packages/agent-core/src/Agent/Tools/MultiAgents.hs
@@ -153,7 +153,7 @@ spawnAgentTool ctx = jsonTool "spawn_agent" spawnAgentDescription
     , PropertySchema "fork_turns" PropertyString False $ Just
         "Optional number of turns to fork. Defaults to `all`. Use `none`, `all`, or a positive integer string such as `3` to fork only the most recent turns."
     ]
-    False
+    True
     (typedToolWithCall "spawn_agent" (runSpawn ctx))
 
 spawnAgentDescription :: Text
@@ -297,7 +297,7 @@ sendMessageTool ctx = jsonTool "send_message" sendMessageDescription
     , PropertySchema "message"
         (encryptedString "Message text to queue on the target agent.") True Nothing
     ]
-    False
+    True
     (typedToolWithCall "send_message" (runSendMessage ctx))
 
 sendMessageDescription :: Text
@@ -329,7 +329,7 @@ followupTaskTool ctx = jsonTool "followup_task" followupDescription
     , PropertySchema "message"
         (encryptedString "Message text to send to the target agent.") True Nothing
     ]
-    False
+    True
     (typedToolWithCall "followup_task" (runFollowup ctx))
 
 followupDescription :: Text
@@ -440,7 +440,7 @@ interruptAgentTool ctx = jsonTool "interrupt_agent" interruptDescription
     [ PropertySchema "target" PropertyString True $ Just
         "Agent id or canonical task name to interrupt (from spawn_agent)."
     ]
-    False
+    True
     (typedTool "interrupt_agent" (runInterrupt ctx))
 
 interruptDescription :: Text

--- a/packages/agent-core/test/Agent/Tools/MultiAgentsSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/MultiAgentsSpec.hs
@@ -16,7 +16,7 @@ import Agent.ToolDispatch
     , dispatchToolCall
     )
 import Agent.Tools.MultiAgents
-import Agent.Tools.Types (appToolHandlers)
+import Agent.Tools.Types (AppTool(..), appToolHandlers)
 import Control.Concurrent.STM
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -24,6 +24,22 @@ import Test.Hspec
 
 spec :: Spec
 spec = describe "Agent.Tools.MultiAgents" do
+    it "allows collaboration coordination without approval" do
+        registry <- newSubagentRegistry defaultSubagentConfig "/tmp"
+            (\_ _ _ _ -> pure $ Left LoopNoResponseId)
+            (\_ _ -> pure ())
+        let tools = multiAgentTools (rootContext registry Nothing)
+        map (\tool -> (tool.appToolName, tool.appToolReadOnly)) tools
+            `shouldBe`
+                [ ("spawn_agent", True)
+                , ("wait_agent", True)
+                , ("send_message", True)
+                , ("followup_task", True)
+                , ("list_agents", True)
+                , ("interrupt_agent", True)
+                ]
+        closeSubagentRegistry registry
+
     it "preserves encrypted spawn payloads" do
         spawned <- newEmptyTMVarIO
         registry <- newSubagentRegistry defaultSubagentConfig "/tmp"


### PR DESCRIPTION
## Summary
- treat subagent spawning, messaging, waiting, listing, follow-ups, and interruption as internal coordination that does not require approval
- canonicalize namespaced `collaboration.*` calls before approval lookup
- retain normal approval handling for external effects performed by agents, such as file writes and shell commands

## Validation
- GHCi: `Agent.CLI.ApprovalSpec` (5 examples)
- GHCi: `Agent.Tools.MultiAgentsSpec` (3 examples)
- GHCi: `Agent.ToolDispatchSpec` (6 examples)
- `git diff --check`
