### PR TITLE
fix(cli): harden prompt composer behavior

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -1015,6 +1015,7 @@ replWithDraft env@SessionEnv
         planPending = planState == PlanPending
     params <- readIORef paramsRef
     policy <- readIORef policyRef
+    pendingAttachments <- readIORef attachmentsRef
     let idleMode = replModeFromState planState policy
     termCols <- fmap snd <$> getTerminalSize
     case agentViewport of
@@ -1050,6 +1051,10 @@ replWithDraft env@SessionEnv
         chromePrompt =
             beginBackground stdoutColor userBackground
                 <> modeTag
+                <> if null pendingAttachments
+                    then ""
+                    else roleMuted stdoutColor
+                        ("[📎 " <> Text.pack (show (length pendingAttachments)) <> "] ")
                 <> rolePrompt stdoutColor "λ "
                 <> if stdoutColor
                     then Text.pack clearFromCursorToLineEndCode
@@ -1092,7 +1097,7 @@ replWithDraft env@SessionEnv
                     let chip = formatPasteChip stripped
                     when (chip /= stripped) do
                         Text.putStrLn (roleMuted color chip)
-                case parseReplLine stripped of
+                case parseReplLine line of
                     ReplQuit -> pure RunQuit
                     ReplReload -> requestReload persist
                     ReplPrompt text -> do

--- a/packages/agent-cli/src/Agent/CLI/Command.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command.hs
@@ -121,13 +121,13 @@ parseReplLine raw =
             then ReplReload
             else case Text.uncons line of
                 Just ('/', _) -> parseSlash line
-                Just (':', _) -> parseColon line
-                _ -> ReplPrompt line
+                Just (':', _) -> parseColon raw
+                _ -> ReplPrompt raw
 
 parseColon :: Text -> ReplAction
-parseColon line
-    | isAlwaysApproveAlias (Text.drop 1 line) = ReplToggleAlwaysApprove
-    | otherwise = ReplPrompt line
+parseColon raw
+    | isAlwaysApproveAlias (Text.drop 1 (Text.strip raw)) = ReplToggleAlwaysApprove
+    | otherwise = ReplPrompt raw
 
 parseSlash :: Text -> ReplAction
 parseSlash line = case Text.words line of
@@ -379,14 +379,14 @@ slashMenuFor :: Text -> Int -> Maybe SlashMenu
 slashMenuFor text cursor
     | cursor < 1 || not (Text.isPrefixOf "/" text) = Nothing
     | otherwise =
-        let before = Text.take cursor text
-            (commandToken, commandRest) = Text.break isSpace before
-        in if Text.null commandRest
-            then commandMenu commandToken cursor
-            else argumentMenu commandToken before cursor
+        let commandToken = Text.takeWhile (not . isSpace) text
+            commandEnd = Text.length commandToken
+        in if cursor <= commandEnd
+            then commandMenu (Text.take cursor text) commandEnd
+            else argumentMenu commandToken commandEnd text cursor
 
 commandMenu :: Text -> Int -> Maybe SlashMenu
-commandMenu token cursor =
+commandMenu token replaceEnd =
     let query = Text.toLower (Text.drop 1 token)
         scored = mapMaybe (scoreCommand query) (zip [0 :: Int ..] slashCommands)
         ordered
@@ -408,7 +408,7 @@ commandMenu token cursor =
         then Nothing
         else Just SlashMenu
             { slashMenuReplaceStart = 0
-            , slashMenuReplaceEnd = cursor
+            , slashMenuReplaceEnd = replaceEnd
             , slashMenuSuggestions = rows
             }
 
@@ -426,12 +426,22 @@ scoreCommand query (order, command)
             (score, positions) : _ ->
                 Just (score, order, command, positions)
 
-argumentMenu :: Text -> Text -> Int -> Maybe SlashMenu
-argumentMenu commandToken before cursor = do
+argumentMenu :: Text -> Int -> Text -> Int -> Maybe SlashMenu
+argumentMenu commandToken commandEnd text cursor = do
     command <- lookupSlashCommand commandToken
-    let options = argCompletions command
+    let before = Text.take cursor text
         suffix = Text.takeWhileEnd (not . isSpace) before
         argStart = Text.length before - Text.length suffix
+        tokenEnd =
+            cursor
+                + Text.length
+                    (Text.takeWhile (not . isSpace) (Text.drop cursor text))
+        precedingArgs =
+            Text.words
+                (Text.take (argStart - commandEnd) (Text.drop commandEnd text))
+        options
+            | null precedingArgs = argCompletions command
+            | otherwise = []
         query = Text.toLower suffix
         ordered = sortOn (\(score, option, _) -> (Down score, option))
             [ (score, option, positions)
@@ -452,7 +462,7 @@ argumentMenu commandToken before cursor = do
         then Nothing
         else Just SlashMenu
             { slashMenuReplaceStart = argStart
-            , slashMenuReplaceEnd = cursor
+            , slashMenuReplaceEnd = tokenEnd
             , slashMenuSuggestions = rows
             }
 

--- a/packages/agent-cli/src/Agent/CLI/Input.hs
+++ b/packages/agent-cli/src/Agent/CLI/Input.hs
@@ -194,11 +194,15 @@ choiceMoveIndex len idx key
 -- 'noteIdleCtrlC' rather than the outer signal handler.
 readReplLine :: InterruptState -> Text -> IO ReplLine
 readReplLine interrupt prompt =
-    readReplLineWithInitial interrupt prompt ""
+    readReplLineConfigured False interrupt prompt ""
 
 -- | Like 'readReplLine', restoring @initial@ as the in-progress draft.
 readReplLineWithInitial :: InterruptState -> Text -> Text -> IO ReplLine
-readReplLineWithInitial interrupt prompt initial = do
+readReplLineWithInitial =
+    readReplLineConfigured True
+
+readReplLineConfigured :: Bool -> InterruptState -> Text -> Text -> IO ReplLine
+readReplLineConfigured slashEnabled interrupt prompt initial = do
     isTty <- hIsTerminalDevice stdin
     if isTty
         then do
@@ -206,11 +210,11 @@ readReplLineWithInitial interrupt prompt initial = do
             let path = replHistoryPath home
             ensureHistoryParent path
             classifyLine <$>
-                readInlineEditor interrupt path prompt initial
+                readInlineEditor slashEnabled interrupt path prompt initial
         else do
             Text.hPutStr stdout prompt
             hFlush stdout
-            fmap (maybe ReplEof (classifySubmitted . Text.strip)) readAnswerOnly
+            fmap (maybe ReplEof classifySubmitted) readRawLine
   where
     classifyLine = \case
         ReplText text -> classifySubmitted text
@@ -227,6 +231,7 @@ data EditorState = EditorState
     , editorHistoryDraft :: !Text
     , editorKillBuffer :: !Text
     , editorPasted :: !Bool
+    , editorSlashEnabled :: !Bool
     , editorSlashDismissed :: !Bool
     }
 
@@ -338,12 +343,13 @@ data EditorKey
 -- | First-party inline editor for the interactive TTY path. It owns the
 -- prompt redraw so slash suggestions can update after every keystroke.
 readInlineEditor
-    :: InterruptState
+    :: Bool
+    -> InterruptState
     -> FilePath
     -> Text
     -> Text
     -> IO ReplLine
-readInlineEditor interrupt historyPath prompt initial = do
+readInlineEditor slashEnabled interrupt historyPath prompt initial = do
     withBracketedPaste $
         withEditorRawStdin $
             bracket
@@ -360,6 +366,7 @@ readInlineEditor interrupt historyPath prompt initial = do
                             , editorHistoryDraft = initial
                             , editorKillBuffer = ""
                             , editorPasted = False
+                            , editorSlashEnabled = slashEnabled
                             , editorSlashDismissed = False
                             }
                     redrawEditor prompt state
@@ -390,16 +397,8 @@ readInlineEditor interrupt historyPath prompt initial = do
                     ContinuePrompt -> do
                         finishEditorLine prompt state
                         Text.putStrLn "^C"
-                        let cleared = state
-                                { editorText = ""
-                                , editorCursor = 0
-                                , editorSelected = 0
-                                , editorHistoryIndex = Nothing
-                                , editorHistoryDraft = ""
-                                , editorSlashDismissed = False
-                                }
-                        redrawEditor prompt cleared
-                        editorLoop history entries cleared
+                        redrawEditor prompt state
+                        editorLoop history entries state
                     QuitProcess -> do
                         finishEditorLine prompt state
                         pure ReplQuitInterrupt
@@ -487,6 +486,7 @@ menuHasRows = maybe False (not . null . (.slashMenuSuggestions))
 
 currentMenu :: EditorState -> Maybe SlashMenu
 currentMenu state
+    | not state.editorSlashEnabled = Nothing
     | state.editorSlashDismissed = Nothing
     | otherwise = slashMenuFor state.editorText state.editorCursor
 
@@ -1113,11 +1113,16 @@ withBracketedPaste action = do
         hFlush stdout
 
 readAnswerOnly :: IO (Maybe Text)
-readAnswerOnly = do
+readAnswerOnly = fmap (fmap Text.strip) readRawLine
+
+-- | Read one line without changing whitespace. Prompt payloads can contain
+-- indentation or trailing blank data; approval answers normalize separately.
+readRawLine :: IO (Maybe Text)
+readRawLine = do
     done <- isEOF
     if done
         then pure Nothing
-        else Just . Text.strip <$> Text.getLine
+        else Just <$> Text.getLine
 
 ensureHistoryParent :: FilePath -> IO ()
 ensureHistoryParent path = do

--- a/packages/agent-cli/src/Agent/CLI/Status.hs
+++ b/packages/agent-cli/src/Agent/CLI/Status.hs
@@ -6,6 +6,7 @@ module Agent.CLI.Status
     , formatTokenUsage
     ) where
 
+import Agent.CLI.Input (terminalTextWidth, truncateDisplayText)
 import Agent.CLI.Options (ApprovalPolicy(..))
 import Agent.CLI.Project (saveProjectAutoApprove)
 import Agent.CLI.ReplMode
@@ -41,14 +42,25 @@ formatReplStatusLine color width model effort mode usage =
     let left = "  " <> model <> " · " <> effort <> " · " <> replModeLabel mode
         right = formatTokenUsage usage
         padded = case width of
-            Just cols | cols > 0, not (Text.null right) ->
-                let gap = cols - Text.length left - Text.length right
-                in if gap > 0
-                    then left <> Text.replicate gap " " <> right
-                    else left <> "  " <> right
+            Just cols | cols > 0 ->
+                fitStatusLine cols left right
             _ | Text.null right -> left
             _ -> left <> "  " <> right
     in roleMuted color padded
+
+-- | Keep the status on one physical row so composer redraws never inherit a
+-- wrapped status line. Prefer interaction state over token totals.
+fitStatusLine :: Int -> Text -> Text -> Text
+fitStatusLine cols left right
+    | cols <= 0 = ""
+    | Text.null right = truncateDisplayText cols left
+    | leftWidth + 1 + rightWidth <= cols =
+        left <> Text.replicate (cols - leftWidth - rightWidth) " " <> right
+    | leftWidth <= cols = left
+    | otherwise = truncateDisplayText cols left
+  where
+    leftWidth = terminalTextWidth left
+    rightWidth = terminalTextWidth right
 
 -- | Apply a cycled idle mode: plan pending vs always-approve vs ask.
 -- Always-approve still persists to project settings, matching /always-approve.

--- a/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
@@ -23,6 +23,14 @@ spec = do
             parseReplLine "list the files" `shouldBe` ReplPrompt "list the files"
             parseReplLine ":status" `shouldBe` ReplPrompt ":status"
 
+        it "preserves ordinary prompt whitespace exactly" do
+            parseReplLine "  indented prompt  "
+                `shouldBe` ReplPrompt "  indented prompt  "
+            parseReplLine "\n    code\n"
+                `shouldBe` ReplPrompt "\n    code\n"
+            parseReplLine "  :status  "
+                `shouldBe` ReplPrompt "  :status  "
+
         it "shows the current effort with a bare /effort" do
             parseReplLine "/effort" `shouldBe` ReplShowEffort
             parseReplLine "  /Effort  " `shouldBe` ReplShowEffort
@@ -231,6 +239,19 @@ spec = do
             fmap (.slashMenuReplaceStart) menu `shouldBe` Just 8
             fmap (map (.slashSuggestionDisplay) . (.slashMenuSuggestions)) menu
                 `shouldBe` Just ["high", "xhigh"]
+
+        it "replaces the whole token when completing from the middle" do
+            fmap (\menu -> (menu.slashMenuReplaceStart, menu.slashMenuReplaceEnd))
+                (slashMenuFor "/mofoo" 3)
+                `shouldBe` Just (0, 6)
+            fmap (\menu -> (menu.slashMenuReplaceStart, menu.slashMenuReplaceEnd))
+                (slashMenuFor "/effort hi" 9)
+                `shouldBe` Just (8, 10)
+
+        it "does not offer single-argument completions in later slots" do
+            slashMenuFor "/effort high " 13 `shouldBe` Nothing
+            slashMenuFor "/help model " 12 `shouldBe` Nothing
+            slashMenuFor "/paste --send " 14 `shouldBe` Nothing
 
         it "renders /help with usage and summary" do
             let listing = Text.unpack (formatSlashHelp False Nothing)

--- a/packages/agent-cli/test/Agent/CLI/ReplStatusSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ReplStatusSpec.hs
@@ -7,6 +7,7 @@ import Agent.CLI
     , formatReplStatusLine
     , formatTokenUsage
     )
+import Agent.CLI.Input (terminalTextWidth)
 import Agent.CLI.Options (ApprovalPolicy(..))
 import Agent.CLI.Project (ProjectSettings(..), loadProjectSettings)
 import Agent.CLI.ReplMode
@@ -67,10 +68,22 @@ spec = do
                 TokenUsage { inputTokens = 1200, outputTokens = 340, cachedTokens = 0 }
                 `shouldBe` "  grok-4.6 · high · ask        1.2k in · 340 out"
 
-        it "keeps a two-space gap when the line would overflow" do
+        it "drops usage rather than wrapping when only the state fits" do
+            formatReplStatusLine False (Just 24) "grok-4.6" "high" ReplModeNormal
+                TokenUsage { inputTokens = 1200, outputTokens = 340, cachedTokens = 0 }
+                `shouldBe` "  grok-4.6 · high · ask"
+
+        it "truncates the state when a narrow pane cannot fit it" do
             formatReplStatusLine False (Just 20) "grok-4.6" "high" ReplModeNormal
                 TokenUsage { inputTokens = 1200, outputTokens = 340, cachedTokens = 0 }
-                `shouldBe` "  grok-4.6 · high · ask  1.2k in · 340 out"
+                `shouldBe` "  grok-4.6 · high ·…"
+
+        it "measures and truncates wide model names in terminal columns" do
+            let line =
+                    formatReplStatusLine False (Just 16) "模型模型" "high"
+                        ReplModeNormal emptyTokenUsage
+            terminalTextWidth line `shouldBe` 16
+            line `shouldBe` "  模型模型 · hi…"
 
     describe "cycleReplMode" do
         it "walks ask → plan → always-approve → ask" do


### PR DESCRIPTION
## Summary

- preserve exact prompt whitespace and retain drafts after the first idle Ctrl-C
- constrain slash completion to the main REPL, replace whole tokens, and stop suggesting single-value arguments in later slots
- keep queued attachments visible in the composer and prevent narrow status lines from wrapping

## Testing

- loaded `agent-cli` library and test modules in the multi-package GHCi REPL
- ran the complete `agent-cli` test suite: 296 examples, 0 failures
- exercised the composer in a 44-column tmux TTY, including Ctrl-C draft retention
