### PR TITLE
Refactor compaction workflow with ExceptT

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -94,6 +94,7 @@ library
                     , safe-exceptions
                     , text >= 2.0 && < 2.2
                     , time
+                    , transformers
                     , unix
 
 executable agent-cli
@@ -115,6 +116,7 @@ test-suite agent-cli-test
                     , Agent.CLI.CancelWatchSpec
                     , Agent.CLI.ClipboardSpec
                     , Agent.CLI.CommandSpec
+                    , Agent.CLI.CompactionSpec
                     , Agent.CLI.CredentialStoreSpec
                     , Agent.CLI.ImagePreviewSpec
                     , Agent.CLI.InputSpec

--- a/packages/agent-cli/src/Agent/CLI/Compaction.hs
+++ b/packages/agent-cli/src/Agent/CLI/Compaction.hs
@@ -14,8 +14,6 @@ import Agent.OpenAI.Compaction
     , estimateItemsTokens
     , summarizationPrompt
     , userTextItem
-    , userTextItem
-    , userTextItem
     )
 import Agent.OpenAI.LoopBackend
     ( assistantTextFromResponse
@@ -32,6 +30,13 @@ import qualified Agent.OpenRouter.Client as OpenRouter
 import qualified Agent.OpenRouter.Options as OpenRouter
 import qualified Agent.XAI.Client as XAI
 import qualified Agent.XAI.Options as XAI
+import Control.Monad.Trans.Class (lift)
+import Control.Monad.Trans.Except
+    ( ExceptT(..)
+    , runExceptT
+    , throwE
+    , withExceptT
+    )
 import Data.IORef (IORef, readIORef)
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
@@ -51,17 +56,18 @@ runProviderCompact
     -> IORef [ResponseItem]
     -> Maybe Text
     -> IO (Either Text CompactOutcome)
-runProviderCompact provider tokenProvider paramsRef transcriptRef focus = do
-    params <- readIORef paramsRef
-    history <- readIORef transcriptRef
-    let before = estimateItemsTokens history
-    case provider of
-        OpenAIProvider ->
-            compactOpenAI tokenProvider params history before focus
-        XAIProvider ->
-            compactLocalXai tokenProvider params history before focus
-        OpenRouterProvider ->
-            compactLocalOpenRouter tokenProvider params history before focus
+runProviderCompact provider tokenProvider paramsRef transcriptRef focus =
+    runExceptT do
+        params <- lift (readIORef paramsRef)
+        history <- lift (readIORef transcriptRef)
+        let before = estimateItemsTokens history
+        case provider of
+            OpenAIProvider ->
+                compactOpenAI tokenProvider params history before focus
+            XAIProvider ->
+                compactLocalXai tokenProvider params history before focus
+            OpenRouterProvider ->
+                compactLocalOpenRouter tokenProvider params history before focus
 
 compactOpenAI
     :: Maybe TokenProvider
@@ -69,47 +75,41 @@ compactOpenAI
     -> [ResponseItem]
     -> Int
     -> Maybe Text
-    -> IO (Either Text CompactOutcome)
-compactOpenAI tokenProvider params history before focus =
-    case tokenProvider of
-        Nothing -> pure (Left "openai compact requires a token provider")
-        Just provider
-            | null history -> pure (Left "nothing to compact")
-            | otherwise -> do
-                let model = fromMaybe "gpt-5.6-luna" params.model
-                    focusedHistory = case focus of
-                        Just text | not (Text.null (Text.strip text)) ->
-                            history
-                                <> [ userTextItem
-                                        ( "Compaction focus from the user: "
-                                            <> Text.strip text
-                                        )
-                                   ]
-                        _ -> history
-                    request =
-                        CompactRequest
-                            { compactModel = model
-                            , compactInput = focusedHistory
-                            , compactInstructions = params.instructions
-                            , compactTools = params.tools
-                            , compactParallelToolCalls =
-                                fromMaybe True params.parallelToolCalls
-                            , compactReasoning = params.reasoning
-                            }
-                compactConversation provider request >>= \case
-                    Left err -> pure (Left (formatApiError err))
-                    Right items ->
-                        pure $
-                            Right
-                                CompactOutcome
-                                    { compactBeforeTokens = before
-                                    , compactAfterTokens = estimateItemsTokens items
-                                    , compactHistory = items
-                                    , compactSummary =
-                                        "remote compact returned "
-                                            <> Text.pack (show (length items))
-                                            <> " items"
-                                    }
+    -> ExceptT Text IO CompactOutcome
+compactOpenAI tokenProvider params history before focus = do
+    provider <- requireTokenProvider OpenAIProvider tokenProvider
+    requireHistory history
+    let model = fromMaybe "gpt-5.6-luna" params.model
+        focusedHistory = case focus of
+            Just text | not (Text.null (Text.strip text)) ->
+                history
+                    <> [ userTextItem
+                            ( "Compaction focus from the user: "
+                                <> Text.strip text
+                            )
+                       ]
+            _ -> history
+        request =
+            CompactRequest
+                { compactModel = model
+                , compactInput = focusedHistory
+                , compactInstructions = params.instructions
+                , compactTools = params.tools
+                , compactParallelToolCalls =
+                    fromMaybe True params.parallelToolCalls
+                , compactReasoning = params.reasoning
+                }
+    items <- withExceptT formatApiError $
+        ExceptT (compactConversation provider request)
+    pure CompactOutcome
+        { compactBeforeTokens = before
+        , compactAfterTokens = estimateItemsTokens items
+        , compactHistory = items
+        , compactSummary =
+            "remote compact returned "
+                <> Text.pack (show (length items))
+                <> " items"
+        }
 
 compactLocalXai
     :: Maybe TokenProvider
@@ -117,19 +117,17 @@ compactLocalXai
     -> [ResponseItem]
     -> Int
     -> Maybe Text
-    -> IO (Either Text CompactOutcome)
-compactLocalXai tokenProvider params history before focus =
-    case tokenProvider of
-        Nothing -> pure (Left "xai compact requires a token provider")
-        Just provider -> do
-            options <- XAI.clientOptionsFromEnv
-            summarizeLocal
-                (XAI.createResponseWith options)
-                provider
-                params
-                history
-                before
-                focus
+    -> ExceptT Text IO CompactOutcome
+compactLocalXai tokenProvider params history before focus = do
+    provider <- requireTokenProvider XAIProvider tokenProvider
+    options <- lift XAI.clientOptionsFromEnv
+    summarizeLocal
+        (XAI.createResponseWith options)
+        provider
+        params
+        history
+        before
+        focus
 
 compactLocalOpenRouter
     :: Maybe TokenProvider
@@ -137,19 +135,17 @@ compactLocalOpenRouter
     -> [ResponseItem]
     -> Int
     -> Maybe Text
-    -> IO (Either Text CompactOutcome)
-compactLocalOpenRouter tokenProvider params history before focus =
-    case tokenProvider of
-        Nothing -> pure (Left "openrouter compact requires a token provider")
-        Just provider -> do
-            options <- OpenRouter.clientOptionsFromEnv
-            summarizeLocal
-                (OpenRouter.createResponseWith options)
-                provider
-                params
-                history
-                before
-                focus
+    -> ExceptT Text IO CompactOutcome
+compactLocalOpenRouter tokenProvider params history before focus = do
+    provider <- requireTokenProvider OpenRouterProvider tokenProvider
+    options <- lift OpenRouter.clientOptionsFromEnv
+    summarizeLocal
+        (OpenRouter.createResponseWith options)
+        provider
+        params
+        history
+        before
+        focus
 
 summarizeLocal
     :: (Credential -> ResponseCreateParams -> IO (Either ApiError Response))
@@ -158,41 +154,53 @@ summarizeLocal
     -> [ResponseItem]
     -> Int
     -> Maybe Text
-    -> IO (Either Text CompactOutcome)
-summarizeLocal send provider params history before focus
-    | null history = pure (Left "nothing to compact")
-    | otherwise = do
-        let summaryPrompt = summarizationPrompt focus
-            ResponseCreateParams{..} = params
-            summaryParams =
-                ResponseCreateParams
-                    { tools = Nothing
-                    , parallelToolCalls = Just False
-                    , ..
-                    }
-            request =
-                withRequestInput
-                    summaryParams
-                    (history <> [userTextItem summaryPrompt])
-        result <- runWithTokenProvider provider \credential ->
-            send credential request
-        case result of
-            Left err -> pure (Left (formatApiError err))
-            Right response ->
-                case assistantTextFromResponse response of
-                    Nothing ->
-                        pure (Left "compaction produced no summary text")
-                    Just summary -> do
-                        let items =
-                                buildLocalCompactedHistory 6 history summary
-                        pure $
-                            Right
-                                CompactOutcome
-                                    { compactBeforeTokens = before
-                                    , compactAfterTokens = estimateItemsTokens items
-                                    , compactHistory = items
-                                    , compactSummary = summary
-                                    }
+    -> ExceptT Text IO CompactOutcome
+summarizeLocal send provider params history before focus = do
+    requireHistory history
+    let summaryPrompt = summarizationPrompt focus
+        ResponseCreateParams{..} = params
+        summaryParams =
+            ResponseCreateParams
+                { tools = Nothing
+                , parallelToolCalls = Just False
+                , ..
+                }
+        request =
+            withRequestInput
+                summaryParams
+                (history <> [userTextItem summaryPrompt])
+    response <- withExceptT formatApiError $
+        ExceptT $
+            runWithTokenProvider provider \credential ->
+                send credential request
+    summary <- case assistantTextFromResponse response of
+        Nothing -> throwE "compaction produced no summary text"
+        Just text -> pure text
+    let items = buildLocalCompactedHistory 6 history summary
+    pure CompactOutcome
+        { compactBeforeTokens = before
+        , compactAfterTokens = estimateItemsTokens items
+        , compactHistory = items
+        , compactSummary = summary
+        }
+
+requireTokenProvider
+    :: Provider
+    -> Maybe TokenProvider
+    -> ExceptT Text IO TokenProvider
+requireTokenProvider provider =
+    maybe (throwE (providerLabel provider <> " compact requires a token provider")) pure
+
+requireHistory :: [ResponseItem] -> ExceptT Text IO ()
+requireHistory history
+    | null history = throwE "nothing to compact"
+    | otherwise = pure ()
+
+providerLabel :: Provider -> Text
+providerLabel = \case
+    OpenAIProvider -> "openai"
+    XAIProvider -> "xai"
+    OpenRouterProvider -> "openrouter"
 
 formatApiError :: ApiError -> Text
 formatApiError err = Text.pack (show err)

--- a/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
@@ -1,0 +1,28 @@
+module Agent.CLI.CompactionSpec (spec) where
+
+import Agent.CLI.Compaction (runProviderCompact)
+import Agent.OpenAI.Responses.Types (defaultResponseCreateParams)
+import Agent.Provider (Provider(..), TokenProvider(..))
+import Data.IORef (newIORef)
+import Test.Hspec
+
+spec :: Spec
+spec =
+    describe "runProviderCompact" do
+        it "reports a provider-specific error when credentials are unavailable" do
+            params <- newIORef defaultResponseCreateParams
+            transcript <- newIORef []
+            runProviderCompact OpenAIProvider Nothing params transcript Nothing
+                `shouldReturn` Left "openai compact requires a token provider"
+            runProviderCompact XAIProvider Nothing params transcript Nothing
+                `shouldReturn` Left "xai compact requires a token provider"
+            runProviderCompact OpenRouterProvider Nothing params transcript Nothing
+                `shouldReturn` Left "openrouter compact requires a token provider"
+
+        it "short-circuits an empty transcript before using credentials" do
+            params <- newIORef defaultResponseCreateParams
+            transcript <- newIORef []
+            let provider = TokenProvider \_ ->
+                    error "empty compaction unexpectedly requested credentials"
+            runProviderCompact OpenAIProvider (Just provider) params transcript Nothing
+                `shouldReturn` Left "nothing to compact"

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -8,6 +8,7 @@ import qualified Agent.CLI.BtwSpec as BtwSpec
 import qualified Agent.CLI.CancelWatchSpec as CancelWatchSpec
 import qualified Agent.CLI.ClipboardSpec as ClipboardSpec
 import qualified Agent.CLI.CommandSpec as CommandSpec
+import qualified Agent.CLI.CompactionSpec as CompactionSpec
 import qualified Agent.CLI.CredentialStoreSpec as CredentialStoreSpec
 import qualified Agent.CLI.ImagePreviewSpec as ImagePreviewSpec
 import qualified Agent.CLI.InputSpec as InputSpec
@@ -44,6 +45,7 @@ main = hspec do
     CancelWatchSpec.spec
     ClipboardSpec.spec
     CommandSpec.spec
+    CompactionSpec.spec
     CredentialStoreSpec.spec
     ImagePreviewSpec.spec
     InputSpec.spec


### PR DESCRIPTION
## Summary

- use a local `ExceptT Text IO` workflow for provider compaction
- preserve the existing `IO (Either Text CompactOutcome)` public API
- centralize token-provider and empty-history validation
- add focused compaction short-circuit tests

## Testing

- loaded `Agent.CLI.Compaction` in the `agent-cli` GHCi session
- ran the full `agent-cli-test` suite in GHCi: **294 examples, 0 failures**
