### PR TITLE
Fix orphaned subagents after failed root turns

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -170,6 +170,7 @@ import Agent.Subagents
     , SubagentSpawnEnv(..)
     , SubagentStatus(..)
     , closeSubagentRegistry
+    , interruptActiveSubagents
     , resetSubagentRegistry
     , defaultSubagentConfig
     , formatCompletionNotice
@@ -932,6 +933,9 @@ runSession options provider policy tools toolEnv planMode prompt pendingTurn una
             , sessionStoreRoot = storeRoot
             , sessionUsage = usageRef
             , sessionAgentViewport = Just agentViewport
+            , sessionAbortSubagents = case multiCtx of
+                Just ctx -> interruptActiveSubagents ctx.multiRegistry
+                Nothing -> pure ()
             , sessionReset = sessionReset
             }
     case pendingTurn of

--- a/packages/agent-cli/src/Agent/CLI/SessionEnv.hs
+++ b/packages/agent-cli/src/Agent/CLI/SessionEnv.hs
@@ -41,5 +41,6 @@ data SessionEnv = SessionEnv
     , sessionStoreRoot :: !(IORef (Maybe OsPath))
     , sessionUsage :: !(IORef TokenUsage)
     , sessionAgentViewport :: !(Maybe AgentViewportEnv)
+    , sessionAbortSubagents :: !(IO ())
     , sessionReset :: !(IO ())
     }

--- a/packages/agent-cli/src/Agent/CLI/Turn.hs
+++ b/packages/agent-cli/src/Agent/CLI/Turn.hs
@@ -84,6 +84,7 @@ runOneTurn env@SessionEnv
     , sessionInterrupt = interrupt
     , sessionStoreRoot = storeRoot
     , sessionUsage = usageRef
+    , sessionAbortSubagents = abortSubagents
     } promptText inputs =
   withTurnCancel interrupt config.loopCancel $
   withEscCancel config.loopCancel escPaused do
@@ -147,6 +148,7 @@ runOneTurn env@SessionEnv
                 writeIORef slotRef (Right handle')
     case result of
         Left cancelled@(LoopCancelled _) -> do
+            abortSubagents
             writeIORef transcriptRef beforeItems
             color <- resolveColor stderr
             putTextLn stderr (formatLoopErrorColored color cancelled)
@@ -155,6 +157,7 @@ runOneTurn env@SessionEnv
             persistIncomplete "cancelled"
             pure TurnSucceeded
         Left err -> do
+            abortSubagents
             afterItems <- readIORef transcriptRef
             case err of
                 LoopTransport apiError

--- a/packages/agent-core/src/Agent/Subagents/Registry.hs
+++ b/packages/agent-core/src/Agent/Subagents/Registry.hs
@@ -9,6 +9,7 @@ module Agent.Subagents.Registry
     , setSubagentRunner
     , setSubagentOnComplete
     , closeSubagentRegistry
+    , interruptActiveSubagents
     , resetSubagentRegistry
     , spawnSubagent
     , spawnSubagentWithCwd
@@ -61,7 +62,7 @@ import Control.Concurrent
     )
 import Control.Concurrent.Async (race)
 import Control.Concurrent.STM
-import Control.Exception.Safe (SomeException, mask, onException, tryAny)
+import Control.Exception.Safe (SomeException, finally, mask, onException, tryAny)
 import Data.IORef
 import Data.Maybe (fromMaybe)
 import Data.Map.Strict (Map)
@@ -409,8 +410,17 @@ stopWorker worker = do
 notifyComplete :: SubagentRegistry -> SubagentId -> SubagentStatus -> IO ()
 notifyComplete registry agentId status
     | isFinalStatus status && status /= Closed && status /= NotFound = do
-        onComplete <- readIORef registry.registryOnCompleteRef
-        onComplete agentId status
+        shouldNotify <- atomically do
+            closed <- readTVar registry.registryClosed
+            agents <- readTVar registry.registryAgents
+            case Map.lookup agentId agents of
+                Nothing -> pure False
+                Just record -> do
+                    current <- readTVar record.recordStatus
+                    pure (not closed && current == status)
+        whenIO shouldNotify do
+            onComplete <- readIORef registry.registryOnCompleteRef
+            onComplete agentId status
     | otherwise = pure ()
 
 releaseSlot :: SubagentRegistry -> SubagentRecord -> IO ()
@@ -576,6 +586,48 @@ shutdownRecord registry record = do
         Nothing -> pure ()
         Just worker -> stopWorker worker
     releaseSlot registry record
+
+-- | Stop every currently pending/running child while keeping completed agent
+-- records and the registry available for later turns. The registry is closed
+-- during the transition so a descendant cannot publish a newly-created worker
+-- after the abort snapshot has been taken.
+interruptActiveSubagents :: SubagentRegistry -> IO ()
+interruptActiveSubagents registry = do
+    (wasClosed, records) <- atomically do
+        wasClosed <- readTVar registry.registryClosed
+        writeTVar registry.registryClosed True
+        agents <- Map.elems <$> readTVar registry.registryAgents
+        records <- filterMSTM isActiveRecord agents
+        pure (wasClosed, records)
+    mapM_ (interruptRecord registry) records
+        `finally`
+            atomically (writeTVar registry.registryClosed wasClosed)
+  where
+    isActiveRecord :: SubagentRecord -> STM Bool
+    isActiveRecord record = do
+        status <- readTVar record.recordStatus
+        pure (status == Pending || status == Running)
+
+interruptRecord :: SubagentRegistry -> SubagentRecord -> IO ()
+interruptRecord registry record = do
+    requestCancel record.recordCancel
+    mworker <- atomically do
+        writeTVar record.recordStatus Interrupted
+        _ <- flushTQueue record.recordMailbox
+        readTVar record.recordWorker
+    case mworker of
+        Nothing -> pure ()
+        Just worker -> stopWorker worker
+    atomically $ writeTVar record.recordStatus Interrupted
+    releaseSlot registry record
+
+filterMSTM :: (a -> STM Bool) -> [a] -> STM [a]
+filterMSTM predicate = fmap reverse . go []
+  where
+    go kept [] = pure kept
+    go kept (value : rest) = do
+        include <- predicate value
+        go (if include then value : kept else kept) rest
 
 -- | Re-admit a previously persisted agent that is not currently in the
 -- in-memory map (e.g. after close, or across a process restart within the

--- a/packages/agent-core/test/Agent/SubagentsSpec.hs
+++ b/packages/agent-core/test/Agent/SubagentsSpec.hs
@@ -316,3 +316,34 @@ spec = describe "Agent.Subagents" do
         after `shouldBe` before
         status <- getStatus registry agentId
         status `shouldBe` Completed (Just "one")
+
+    it "interrupts active descendants and keeps the registry reusable" do
+        started <- newEmptyTMVarIO
+        blocker <- newEmptyTMVarIO
+        notices <- newIORef ([] :: [(SubagentId, SubagentStatus)])
+        let config = defaultSubagentConfig { maxConcurrent = 1 }
+        registry <- newSubagentRegistry config (fromFilePath "/tmp")
+            (\_ _ _ _ -> do
+                atomically $ putTMVar started ()
+                atomically $ takeTMVar blocker
+                pure $ Right LoopResult
+                    { finalResponseId = "late"
+                    , finalText = Just "late"
+                    , turnsUsed = 1
+                    , tokenUsage = emptyTokenUsage
+                    })
+            (\_ _ -> pure ())
+        setSubagentOnComplete registry \agentId status ->
+            atomicModifyIORef' notices \xs -> (xs <> [(agentId, status)], ())
+        Right active <- spawnSubagent registry Nothing 0 "active" Nothing
+        atomically $ takeTMVar started
+
+        interruptActiveSubagents registry
+
+        getStatus registry active `shouldReturn` Interrupted
+        readIORef notices `shouldReturn` []
+        replacement <- spawnSubagent registry Nothing 0 "replacement" Nothing
+        replacement `shouldSatisfy` \case
+            Right _ -> True
+            Left _ -> False
+        closeSubagentRegistry registry


### PR DESCRIPTION
## Summary

- abort pending/running subagents when a root turn is cancelled or fails
- temporarily close the registry during abort so descendants cannot start new workers
- clear aborted follow-up mailboxes and suppress late completion notices
- preserve completed agent records, release concurrency slots, and reopen the registry for later turns
- integrate with the tracked worker lifecycle added on master

## Context

A root turn could dispatch follow-up work and then fail with a transport error such as `previous_response_not_found`. The failed turn rolled back its transcript, but descendants remained alive and could continue modifying the worktree after the user had already seen the failure.

This PR adds the immediate safety boundary: failed/cancelled root turns synchronously stop all currently active session descendants before returning to the REPL or transitioning providers.

Precise per-turn generation ownership remains a follow-up; this safety barrier intentionally prefers stopping unrelated active session descendants over allowing invisible post-failure mutations.

## Tests

- `cabal repl agent-core:test:agent-core-test`, then `:main`: 148 examples, 0 failures
- `cabal repl agent-cli:lib:agent-cli`: all 41 modules loaded
