### PR TITLE
Fix immediate continuation after plan approval

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Plan.hs
+++ b/packages/agent-cli/src/Agent/CLI/Plan.hs
@@ -6,6 +6,7 @@ module Agent.CLI.Plan
     , stripProposedPlan
     , renderPlanMarkdown
     , parsePlanDecisionAnswer
+    , planDecisionFollowUp
     ) where
 
 import Agent.CLI.CancelWatch (withStdinPaused)
@@ -31,7 +32,11 @@ import Agent.CLI.Style
     , solarizedCyan
     , style
     )
-import Agent.Tools.PlanMode (PlanDecision(..), PlanModeHooks(..))
+import Agent.Tools.PlanMode
+    ( PlanDecision(..)
+    , PlanModeHooks(..)
+    , planApprovedContinuation
+    )
 import Control.Exception (AsyncException(UserInterrupt))
 import Control.Exception.Safe (throwIO)
 import Data.IORef (IORef)
@@ -195,6 +200,18 @@ parsePlanDecisionAnswer raw = case Text.toLower (Text.strip raw) of
     "n" -> Just PlanCancel
     "no" -> Just PlanCancel
     _ -> Nothing
+
+-- | Build the synthetic turn that follows a plan decision.
+-- Approval and requested changes continue immediately; cancellation stops.
+planDecisionFollowUp :: PlanDecision -> Maybe Text
+planDecisionFollowUp PlanApprove = Just planApprovedContinuation
+planDecisionFollowUp (PlanRequestChanges notes) =
+    Just $ Text.intercalate "\n"
+        [ "The user requested changes to the plan. Stay in plan mode and revise."
+        , "Feedback:"
+        , notes
+        ]
+planDecisionFollowUp PlanCancel = Nothing
 
 -- | Pull the first @\<proposed_plan\>…\</proposed_plan\>@ block (Codex).
 extractProposedPlan :: Text -> Maybe Text

--- a/packages/agent-cli/src/Agent/CLI/Turn.hs
+++ b/packages/agent-cli/src/Agent/CLI/Turn.hs
@@ -5,7 +5,7 @@ module Agent.CLI.Turn
 
 import Agent.CLI.CancelWatch (withEscCancel)
 import Agent.CLI.Interrupt (withTurnCancel)
-import Agent.CLI.Plan (extractProposedPlan)
+import Agent.CLI.Plan (extractProposedPlan, planDecisionFollowUp)
 import Agent.CLI.ProviderFallback (isProviderUnavailable)
 import Agent.CLI.ProviderTransition
     ( PendingTurn(..)
@@ -248,13 +248,10 @@ handleProposedPlan planMode = \case
                 case decision of
                     PlanApprove -> do
                         deactivatePlanMode planMode
-                        pure Nothing
+                        pure (planDecisionFollowUp decision)
                     PlanCancel -> do
                         deactivatePlanMode planMode
                         pure Nothing
-                    PlanRequestChanges notes ->
-                        pure $ Just $
-                            "The user requested changes to the plan. Stay in plan mode and revise.\n\
-                            \Feedback:\n"
-                                <> notes
+                    PlanRequestChanges _ ->
+                        pure (planDecisionFollowUp decision)
             _ -> pure Nothing

--- a/packages/agent-cli/test/Agent/CLI/PlanSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/PlanSpec.hs
@@ -42,3 +42,15 @@ spec = do
             parsePlanDecisionAnswer "q" `shouldBe` Just PlanCancel
             parsePlanDecisionAnswer "cancel" `shouldBe` Just PlanCancel
             parsePlanDecisionAnswer "maybe" `shouldBe` Nothing
+
+    describe "planDecisionFollowUp" do
+        it "continues immediately when the plan is approved" do
+            planDecisionFollowUp PlanApprove
+                `shouldSatisfy` maybe False (Text.isInfixOf "Begin implementing")
+
+        it "keeps revising when changes are requested" do
+            planDecisionFollowUp (PlanRequestChanges "cover retries")
+                `shouldSatisfy` maybe False (Text.isInfixOf "cover retries")
+
+        it "does not continue after cancellation" do
+            planDecisionFollowUp PlanCancel `shouldBe` Nothing

--- a/packages/agent-core/src/Agent/Tools/PlanMode.hs
+++ b/packages/agent-core/src/Agent/Tools/PlanMode.hs
@@ -19,6 +19,7 @@ module Agent.Tools.PlanMode
     , readPlanMarkdown
     , writePlanMarkdown
     , planModeReminder
+    , planApprovedContinuation
     , planModeBlockedEditMessage
     , isPlanFileEditTarget
     , enterPlanModeTool
@@ -144,6 +145,12 @@ planModeReminder path =
         , "When the plan is ready, call `exit_plan_mode` (Grok/OpenRouter) or end your turn with a complete `<proposed_plan>` … `</proposed_plan>` block (OpenAI/Codex) so the user can approve, request changes, or cancel."
         ]
 
+planApprovedContinuation :: Text
+planApprovedContinuation =
+    "The user approved the plan. Plan mode is now off. "
+        <> "Begin implementing the approved plan immediately. "
+        <> "Do not wait for another user message."
+
 planModeBlockedEditMessage :: OsPath -> Text
 planModeBlockedEditMessage path =
     "Rejected: file edits are not allowed in plan mode - the only editable file is the plan file ("
@@ -260,8 +267,7 @@ runExitPlanMode env args = do
             case decision of
                 PlanApprove -> do
                     deactivatePlanMode env
-                    pure $ Right
-                        "Your plan has been approved. You can now start coding."
+                    pure (Right planApprovedContinuation)
                 PlanRequestChanges notes ->
                     pure $ Right $
                         "The user requested changes to the plan. Stay in plan mode and revise plan.md.\n"


### PR DESCRIPTION
## Summary
- automatically start an implementation turn after approving a Codex proposed plan
- share a stronger post-approval continuation instruction with tool-based plan mode
- cover approve, revise, and cancel follow-up behavior

## Validation
- full agent-cli test suite in GHCi: 296 examples, 0 failures
- live tmux smoke test: approving a plan immediately produced the requested result without another user prompt
- git diff --check