### PR TITLE
Refactor file lock retries to use retry

### DIFF
--- a/packages/agent-core/agent-core.cabal
+++ b/packages/agent-core/agent-core.cabal
@@ -84,6 +84,7 @@ library
                     , filepath
                     , http-conduit
                     , process
+                    , retry >= 0.9.3.1 && < 0.10
                     , safe-exceptions
                     , stm
                     , text

--- a/packages/agent-core/package.nix
+++ b/packages/agent-core/package.nix
@@ -1,6 +1,6 @@
 { mkDerivation, aeson, async, base, bytestring, containers
 , directory, filepath, hspec, http-conduit, lib, process
-, safe-exceptions, stm, text, time, unix, vector, websockets
+, retry, safe-exceptions, stm, text, time, unix, vector, websockets
 }:
 mkDerivation {
   pname = "agent-core";
@@ -8,7 +8,7 @@ mkDerivation {
   src = ./.;
   libraryHaskellDepends = [
     aeson async base bytestring containers directory filepath
-    http-conduit process safe-exceptions stm text time unix vector
+    http-conduit process retry safe-exceptions stm text time unix vector
     websockets
   ];
   testHaskellDepends = [

--- a/packages/agent-core/src/Agent/Tools/FileSystem.hs
+++ b/packages/agent-core/src/Agent/Tools/FileSystem.hs
@@ -10,8 +10,13 @@ module Agent.Tools.FileSystem
 
 import Agent.OsPath (OsPath, fromFilePath, toFilePath, toText)
 import Agent.Tools.Types (ToolEnv(..))
-import Control.Concurrent (threadDelay)
-import Control.Exception.Safe (SomeException, catchIO, throwIO, try)
+import Control.Exception.Safe (SomeException, throwIO, try, tryIO)
+import Control.Retry
+    ( RetryPolicyM
+    , exponentialBackoff
+    , limitRetries
+    , retrying
+    )
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.ByteString as BS
@@ -88,18 +93,15 @@ isInside root path
                 (first : _) | first == fromFilePath ".." -> False
                 _ -> True
 
-lockRetryDelaysUs :: [Int]
-lockRetryDelaysUs = [1000, 2000, 4000, 8000, 16000]
+lockRetryPolicy :: RetryPolicyM IO
+lockRetryPolicy = exponentialBackoff 1000 <> limitRetries 5
 
 retryOnBusy :: IO a -> IO a
-retryOnBusy action = go lockRetryDelaysUs
+retryOnBusy action = do
+    result <- retrying lockRetryPolicy shouldRetry (const (tryIO action))
+    either throwIO pure result
   where
-    go [] = action
-    go (delayUs : rest) =
-        catchIO action \err ->
-            if isAlreadyInUseError err
-                then threadDelay delayUs >> go rest
-                else throwIO err
+    shouldRetry _ = pure . either isAlreadyInUseError (const False)
 
 readTextFile :: OsPath -> IO (Either Text Text)
 readTextFile path =

--- a/packages/agent-openai/agent-openai.cabal
+++ b/packages/agent-openai/agent-openai.cabal
@@ -75,7 +75,7 @@ library
                     , websockets
                     , wuss
                     , base64-bytestring
-                    , retry
+                    , retry >= 0.9.3.1 && < 0.10
                     , exceptions
                     , safe-exceptions
                     , containers
@@ -122,7 +122,7 @@ test-suite agent-openai-test
                     , agent-openai
                     , hspec
                     , aeson
-                    , retry
+                    , retry >= 0.9.3.1 && < 0.10
                     , text
                     , bytestring
                     , base64-bytestring

--- a/packages/agent-xai/agent-xai.cabal
+++ b/packages/agent-xai/agent-xai.cabal
@@ -50,7 +50,7 @@ library
                     , http-client
                     , http-conduit
                     , base64-bytestring
-                    , retry
+                    , retry >= 0.9.3.1 && < 0.10
                     , safe-exceptions
                     , scientific
                     , time
@@ -78,6 +78,6 @@ test-suite agent-xai-test
                     , base64-bytestring
                     , case-insensitive
                     , http-types
-                    , retry
+                    , retry >= 0.9.3.1 && < 0.10
                     , wai
                     , warp

--- a/packages/agent-xai/package.nix
+++ b/packages/agent-xai/package.nix
@@ -1,7 +1,7 @@
 { mkDerivation, aeson, agent-core, agent-openai, base
 , base64-bytestring, bytestring, case-insensitive, hspec
-, http-client, http-conduit, http-types, lib, safe-exceptions, text
-, wai, warp
+, http-client, http-conduit, http-types, lib, retry, safe-exceptions
+, scientific, text, time, wai, warp
 }:
 mkDerivation {
   pname = "agent-xai";
@@ -9,11 +9,11 @@ mkDerivation {
   src = ./.;
   libraryHaskellDepends = [
     aeson agent-core agent-openai base base64-bytestring bytestring
-    http-client http-conduit safe-exceptions text
+    http-client http-conduit retry safe-exceptions scientific text time
   ];
   testHaskellDepends = [
     aeson agent-core agent-openai base base64-bytestring bytestring
-    case-insensitive hspec http-types text wai warp
+    case-insensitive hspec http-types retry text wai warp
   ];
   description = "Haskell client for the xAI Grok subscription transport";
   license = lib.licenses.bsd3;


### PR DESCRIPTION
## Summary
- replace the hand-written file-lock retry loop with `Control.Retry.retrying`
- preserve the existing 1/2/4/8/16 ms exponential backoff and five-retry limit
- constrain direct `retry` dependencies to the 0.9.3.x API
- synchronize the affected Nix package dependencies

## Validation
- focused `Agent.Tools.IO` spec in GHCi: 6 examples, 0 failures
- multi-package OpenAI/xAI GHCi load
- `nix build --no-link .#agent-core .#agent-openai .#agent-xai`
- `git diff --check`
