### PR TITLE
refactor: scope agent resources with ResourceT

### DIFF
--- a/packages/agent-core/agent-core.cabal
+++ b/packages/agent-core/agent-core.cabal
@@ -42,6 +42,7 @@ library
                     , Agent.OsPath
                     , Agent.Http.Url
                     , Agent.ProjectInstructions
+                    , Agent.ResourceScope
                     , Agent.Subagents
                     , Agent.Subagents.Format
                     , Agent.Subagents.Registry
@@ -86,6 +87,7 @@ library
                     , http-conduit
                     , process
                     , retry >= 0.9.3.1 && < 0.10
+                    , resourcet
                     , safe-exceptions
                     , stm
                     , text
@@ -105,6 +107,7 @@ test-suite agent-core-test
                     , Agent.LoopSpec
                     , Agent.JsonTextSpec
                     , Agent.ProjectInstructionsSpec
+                    , Agent.ResourceScopeSpec
                     , Agent.SubagentsSpec
                     , Agent.Subagents.TaskPathSpec
                     , Agent.ToolArgsSpec

--- a/packages/agent-core/package.nix
+++ b/packages/agent-core/package.nix
@@ -1,6 +1,6 @@
 { mkDerivation, aeson, async, base, bytestring, containers
 , directory, filepath, hspec, http-conduit, lib, process
-, retry, safe-exceptions, stm, text, time, unix, vector, websockets
+, resourcet, retry, safe-exceptions, stm, text, time, unix, vector, websockets
 }:
 mkDerivation {
   pname = "agent-core";
@@ -8,7 +8,7 @@ mkDerivation {
   src = ./.;
   libraryHaskellDepends = [
     aeson async base bytestring containers directory filepath
-    http-conduit process retry safe-exceptions stm text time unix vector
+    http-conduit process resourcet retry safe-exceptions stm text time unix vector
     websockets
   ];
   testHaskellDepends = [

--- a/packages/agent-core/src/Agent/ResourceScope.hs
+++ b/packages/agent-core/src/Agent/ResourceScope.hs
@@ -1,0 +1,78 @@
+-- | Dynamically owned resources with explicit early release.
+--
+-- The public API stays in 'IO' so resource ownership does not force
+-- 'ResourceT' through the agent loop and provider interfaces.
+module Agent.ResourceScope
+    ( ResourceScope
+    , ResourceKey
+    , newResourceScope
+    , withResourceScope
+    , closeResourceScope
+    , allocateResource
+    , registerResource
+    , releaseResource
+    ) where
+
+import Control.Concurrent.MVar
+    ( MVar
+    , modifyMVar
+    , newMVar
+    , withMVar
+    )
+import Control.Exception.Safe (bracket, throwIO)
+import Control.Monad.Trans.Resource
+    ( InternalState
+    , ReleaseKey
+    , ResourceT
+    , allocate
+    , closeInternalState
+    , createInternalState
+    , register
+    , release
+    , runInternalState
+    )
+
+newtype ResourceScope = ResourceScope (MVar (Maybe InternalState))
+
+newtype ResourceKey = ResourceKey ReleaseKey
+
+newResourceScope :: IO ResourceScope
+newResourceScope = do
+    state <- createInternalState
+    ResourceScope <$> newMVar (Just state)
+
+withResourceScope :: (ResourceScope -> IO a) -> IO a
+withResourceScope = bracket newResourceScope closeResourceScope
+
+closeResourceScope :: ResourceScope -> IO ()
+closeResourceScope (ResourceScope stateVar) = do
+    state <- modifyMVar stateVar \current ->
+        pure (Nothing, current)
+    mapM_ closeInternalState state
+
+allocateResource
+    :: ResourceScope
+    -> IO a
+    -> (a -> IO ())
+    -> IO (ResourceKey, a)
+allocateResource scope acquire cleanup =
+    withOpenScope scope \state -> do
+        (key, value) <- runInScope state (allocate acquire cleanup)
+        pure (ResourceKey key, value)
+
+registerResource :: ResourceScope -> IO () -> IO ResourceKey
+registerResource scope cleanup =
+    withOpenScope scope \state ->
+        ResourceKey <$> runInScope state (register cleanup)
+
+releaseResource :: ResourceKey -> IO ()
+releaseResource (ResourceKey key) = release key
+
+runInScope :: InternalState -> ResourceT IO a -> IO a
+runInScope = flip runInternalState
+
+withOpenScope :: ResourceScope -> (InternalState -> IO a) -> IO a
+withOpenScope (ResourceScope stateVar) action =
+    withMVar stateVar \case
+        Nothing -> throwIO (userError "resource scope is closed")
+        Just state -> action state

--- a/packages/agent-core/src/Agent/Subagents/Registry.hs
+++ b/packages/agent-core/src/Agent/Subagents/Registry.hs
@@ -1,7 +1,7 @@
 -- | Nestable subagent registry.
 --
 -- Shared state (agent map, status, mailboxes, admission count) lives in STM.
--- IO is only used to allocate ids, start explicitly tracked child threads,
+-- IO is only used to allocate ids, start child 'Async' loops,
 -- and wait with timeouts via 'threadDelay'.
 module Agent.Subagents.Registry
     ( SubagentRegistry
@@ -44,7 +44,12 @@ module Agent.Subagents.Registry
     , listAgents
     ) where
 
-import Agent.Cancel (CancelFlag, newCancelFlag, requestCancel)
+import Agent.Cancel
+    ( CancelFlag
+    , newCancelFlag
+    , requestCancel
+    , resetCancel
+    )
 import Agent.InterAgentMessage
     ( InterAgentMessage(..)
     , InterAgentMessageContent
@@ -53,6 +58,14 @@ import Agent.InterAgentMessage
     )
 import Agent.Loop (LoopError(..), LoopEvent, LoopResult(..))
 import Agent.OsPath (OsPath)
+import Agent.ResourceScope
+    ( ResourceKey
+    , ResourceScope
+    , allocateResource
+    , closeResourceScope
+    , newResourceScope
+    , releaseResource
+    )
 import Agent.Subagents.Format (isFinalStatus)
 import Agent.Subagents.Types
     ( RunSubagent
@@ -64,13 +77,9 @@ import Agent.Subagents.Types
     , maxWaitTimeoutMs
     , minWaitTimeoutMs
     )
-import Control.Concurrent
-    ( ThreadId
-    , forkFinally
-    , killThread
-    , threadDelay
-    )
-import Control.Concurrent.Async (race)
+import Control.Concurrent (threadDelay)
+import Control.Concurrent.Async (Async, async, cancel, race, waitCatch)
+import Control.Concurrent.MVar (MVar, newMVar, withMVar)
 import Control.Concurrent.STM
 import Control.Exception.Safe (SomeException, finally, mask, onException, tryAny)
 import Data.IORef
@@ -102,7 +111,7 @@ data SubagentRecord = SubagentRecord
     , recordStatus :: !(TVar SubagentStatus)
     , recordCancel :: !CancelFlag
     , recordMailbox :: !(TQueue SubagentWork)
-    , recordWorker :: !(TVar (Maybe Worker))
+    , recordAsync :: !(TVar (Maybe (ResourceKey, Async ())))
     , recordRootTurnId :: !(TVar (Maybe RootTurnId))
       -- | Whether this agent currently occupies a concurrency slot.
     , recordSlotHeld :: !(TVar Bool)
@@ -117,11 +126,6 @@ data SubagentWork = SubagentWork
     , workMessage :: !InterAgentMessage
     }
 
-data Worker = Worker
-    { workerThreadId :: !(TMVar ThreadId)
-    , workerDone :: !(TMVar ())
-    }
-
 data SubagentRegistry = SubagentRegistry
     { registryAgents :: !(TVar (Map SubagentId SubagentRecord))
     , registryPaths :: !(TVar (Map TaskPath SubagentId))
@@ -134,6 +138,8 @@ data SubagentRegistry = SubagentRegistry
     , registryClosed :: !(TVar Bool)
     , registryNextRootTurnId :: !(TVar Word64)
     , registryAbortedRootTurns :: !(TVar (Set RootTurnId))
+    , registryLifecycle :: !(MVar ())
+    , registryResources :: !(IORef ResourceScope)
     }
 
 newSubagentRegistry
@@ -149,6 +155,8 @@ newSubagentRegistry config cwd run onEvent = do
     closed <- newTVarIO False
     nextRootTurnId <- newTVarIO 0
     abortedRootTurns <- newTVarIO Set.empty
+    lifecycle <- newMVar ()
+    resources <- newIORef =<< newResourceScope
     runRef <- newIORef run
     onCompleteRef <- newIORef (\_ _ -> pure ())
     pure SubagentRegistry
@@ -165,6 +173,8 @@ newSubagentRegistry config cwd run onEvent = do
         , registryClosed = closed
         , registryNextRootTurnId = nextRootTurnId
         , registryAbortedRootTurns = abortedRootTurns
+        , registryLifecycle = lifecycle
+        , registryResources = resources
         }
 
 setSubagentRunner :: SubagentRegistry -> RunSubagent -> IO ()
@@ -186,22 +196,32 @@ beginRootTurn registry = atomically do
     pure rootTurnId
 
 closeSubagentRegistry :: SubagentRegistry -> IO ()
-closeSubagentRegistry registry = do
+closeSubagentRegistry registry =
+    withMVar registry.registryLifecycle \_ ->
+        closeSubagentRegistryLocked registry
+
+closeSubagentRegistryLocked :: SubagentRegistry -> IO ()
+closeSubagentRegistryLocked registry = do
     records <- atomically do
         writeTVar registry.registryClosed True
         Map.elems <$> readTVar registry.registryAgents
     mapM_ (shutdownRecord registry) records
+    resources <- readIORef registry.registryResources
+    closeResourceScope resources
 
 -- | Shut down live children and reopen the registry for a fresh session.
 resetSubagentRegistry :: SubagentRegistry -> IO ()
-resetSubagentRegistry registry = do
-    closeSubagentRegistry registry
-    atomically do
-        writeTVar registry.registryAgents Map.empty
-        writeTVar registry.registryPaths Map.empty
-        writeTVar registry.registryLiveCount 0
-        writeTVar registry.registryAbortedRootTurns Set.empty
-        writeTVar registry.registryClosed False
+resetSubagentRegistry registry =
+    withMVar registry.registryLifecycle \_ -> do
+        closeSubagentRegistryLocked registry
+        resources <- newResourceScope
+        writeIORef registry.registryResources resources
+        atomically do
+            writeTVar registry.registryAgents Map.empty
+            writeTVar registry.registryPaths Map.empty
+            writeTVar registry.registryLiveCount 0
+            writeTVar registry.registryAbortedRootTurns Set.empty
+            writeTVar registry.registryClosed False
 
 spawnSubagent
     :: SubagentRegistry
@@ -348,7 +368,7 @@ spawnSubagentAtWithCwdPreparedForTurn
                 cancelFlag <- newCancelFlag
                 mailbox <- newTQueueIO
                 statusVar <- newTVarIO Pending
-                workerVar <- newTVarIO Nothing
+                asyncVar <- newTVarIO Nothing
                 rootTurnVar <- newTVarIO rootTurnId
                 slotHeld <- newTVarIO True
                 previousVar <- newTVarIO Nothing
@@ -360,14 +380,14 @@ spawnSubagentAtWithCwdPreparedForTurn
                         , recordStatus = statusVar
                         , recordCancel = cancelFlag
                         , recordMailbox = mailbox
-                        , recordWorker = workerVar
+                        , recordAsync = asyncVar
                         , recordRootTurnId = rootTurnVar
                         , recordSlotHeld = slotHeld
                         , recordPreviousResponseId = previousVar
                         , recordTaskPath = childPath
                         , recordCwd = childCwd
                         }
-                admitted <- atomically do
+                admitted <- withMVar registry.registryLifecycle \_ -> atomically do
                     closed <- readTVar registry.registryClosed
                     aborted <- isRootTurnAborted registry rootTurnId
                     if closed
@@ -375,22 +395,26 @@ spawnSubagentAtWithCwdPreparedForTurn
                         else if aborted
                             then pure (Left "Root turn was aborted.")
                         else do
-                            paths <- readTVar registry.registryPaths
-                            if Map.member childPath paths
-                                then pure $ Left $
-                                    "task path already in use: " <> taskPathText childPath
+                            parentOpen <- isParentOpenSTM registry parentId
+                            if not parentOpen
+                                then pure (Left "Parent subagent is closed or missing.")
                                 else do
-                                    live <- readTVar registry.registryLiveCount
-                                    if live >= cfg.maxConcurrent
+                                    paths <- readTVar registry.registryPaths
+                                    if Map.member childPath paths
                                         then pure $ Left $
-                                            "Concurrent subagent limit reached: "
-                                                <> Text.pack (show cfg.maxConcurrent)
-                                                <> " agents are already open. Close finished agents before spawning more."
+                                            "task path already in use: " <> taskPathText childPath
                                         else do
-                                            modifyTVar' registry.registryLiveCount (+ 1)
-                                            modifyTVar' registry.registryAgents (Map.insert agentId record)
-                                            modifyTVar' registry.registryPaths (Map.insert childPath agentId)
-                                            pure (Right ())
+                                            live <- readTVar registry.registryLiveCount
+                                            if live >= cfg.maxConcurrent
+                                                then pure $ Left $
+                                                    "Concurrent subagent limit reached: "
+                                                        <> Text.pack (show cfg.maxConcurrent)
+                                                        <> " agents are already open. Close finished agents before spawning more."
+                                                else do
+                                                    modifyTVar' registry.registryLiveCount (+ 1)
+                                                    modifyTVar' registry.registryAgents (Map.insert agentId record)
+                                                    modifyTVar' registry.registryPaths (Map.insert childPath agentId)
+                                                    pure (Right ())
                 case admitted of
                     Left err -> pure (Left err)
                     Right () -> mask \restore ->
@@ -418,14 +442,15 @@ spawnSubagentAtWithCwdPreparedForTurn
                 }
         started <-
             restore
-                (startRecordWorker registry record
-                    (runWorker registry record work))
+                (withMVar registry.registryLifecycle \_ ->
+                    startRecordWorker registry record work)
                 `onException` shutdownRecord registry record
-        if started
-            then pure (Right (agentId, childPath))
-            else do
+        case started of
+            Left err -> do
                 rollbackAdmission registry record
-                pure (Left "Subagent closed before its worker started.")
+                pure (Left err)
+            Right () ->
+                pure (Right (agentId, childPath))
 
 rollbackAdmission :: SubagentRegistry -> SubagentRecord -> IO ()
 rollbackAdmission registry record = atomically do
@@ -437,12 +462,23 @@ rollbackAdmission registry record = atomically do
         writeTVar record.recordSlotHeld False
         live <- readTVar registry.registryLiveCount
         writeTVar registry.registryLiveCount (max 0 (live - 1))
+    writeTVar record.recordStatus Closed
 
 deleteOwnedPath :: TaskPath -> SubagentId -> Map TaskPath SubagentId -> Map TaskPath SubagentId
 deleteOwnedPath key expected mappings =
     case Map.lookup key mappings of
         Just actual | actual == expected -> Map.delete key mappings
         _ -> mappings
+
+isParentOpenSTM :: SubagentRegistry -> Maybe SubagentId -> STM Bool
+isParentOpenSTM _ Nothing = pure True
+isParentOpenSTM registry (Just parentId) = do
+    agents <- readTVar registry.registryAgents
+    case Map.lookup parentId agents of
+        Nothing -> pure False
+        Just parent -> do
+            status <- readTVar parent.recordStatus
+            pure (status /= Closed && status /= NotFound)
 
 runWorker :: SubagentRegistry -> SubagentRecord -> SubagentWork -> IO ()
 runWorker registry record firstWork = do
@@ -480,86 +516,147 @@ runWorker registry record firstWork = do
                         writeTVar record.recordPreviousResponseId
                             (Just loopResult.finalResponseId)
                 _ -> pure ()
-            next <- atomically do
-                closed <- readTVar registry.registryClosed
-                current <- readTVar record.recordStatus
-                if closed || current == Closed
-                    then do
-                        writeTVar record.recordStatus Closed
-                        pure Nothing
-                    else do
-                        empty <- isEmptyTQueue record.recordMailbox
-                        if empty
-                            then do
-                                writeTVar record.recordStatus status
-                                pure Nothing
-                            else do
-                                nextWork <- readTQueue record.recordMailbox
-                                writeTVar record.recordRootTurnId nextWork.workRootTurnId
-                                writeTVar record.recordStatus Running
-                                pure (Just nextWork)
+            next <- atomically $ nextWorkerStep registry record
             case next of
-                -- Completed/errored/interrupted agents stay open and keep their
-                -- concurrency slot until close_agent, matching Codex v1.
-                Nothing -> notifyComplete registry record.recordId status
-                Just nextWork -> loop nextWork
+                WorkerClosed -> pure ()
+                WorkerMessage nextWork -> do
+                    resetCancel record.recordCancel
+                    loop nextWork
+                WorkerComplete -> do
+                    _ <- tryAny $
+                        notifyComplete
+                            registry record.recordId work.workRootTurnId status
+                    atomically (finishOrContinue record status) >>= \case
+                        Nothing -> pure ()
+                        Just nextWork -> do
+                            resetCancel record.recordCancel
+                            loop nextWork
     whenIO mayRun (loop firstWork)
 
--- | Record ownership before forking. The thread id is published immediately
--- afterward, so shutdown can safely race startup and still cancel and join.
 startRecordWorker
     :: SubagentRegistry
     -> SubagentRecord
-    -> IO ()
-    -> IO Bool
-startRecordWorker registry record action = mask \restore -> do
-    -- A completed turn publishes its status just before its worker exits.
-    -- Wait for that short tail before replacing the tracked worker.
+    -> SubagentWork
+    -> IO (Either Text ())
+startRecordWorker registry record work =
+    mask \_ -> do
+        canStart <- atomically do
+            closed <- readTVar registry.registryClosed
+            status <- readTVar record.recordStatus
+            aborted <- isRootTurnAborted registry work.workRootTurnId
+            agents <- readTVar registry.registryAgents
+            paths <- readTVar registry.registryPaths
+            current <- readTVar record.recordAsync
+            pure $
+                not closed
+                    && not aborted
+                    && status /= Closed
+                    && Map.member record.recordId agents
+                    && maybe True (== record.recordId)
+                        (Map.lookup record.recordTaskPath paths)
+                    && maybe True (const False) current
+        if not canStart
+            then pure (Left "Subagent closed before its worker started.")
+            else do
+                gate <- newEmptyTMVarIO
+                resources <- readIORef registry.registryResources
+                started <- tryAny $
+                    allocateResource resources
+                        (async do
+                            atomically (takeTMVar gate)
+                            runWorker registry record work)
+                        stopAsync
+                case started of
+                    Left (exception :: SomeException) ->
+                        pure (Left ("Failed to start subagent: " <> Text.pack (show exception)))
+                    Right worker -> do
+                        atomically do
+                            writeTVar record.recordAsync (Just worker)
+                            writeTVar record.recordRootTurnId work.workRootTurnId
+                            writeTVar record.recordStatus Running
+                            putTMVar gate ()
+                        pure (Right ())
+
+stopAsync :: Async () -> IO ()
+stopAsync worker = do
+    cancel worker
+    _ <- waitCatch worker
+    pure ()
+
+takeRecordWorker :: SubagentRecord -> IO (Maybe (ResourceKey, Async ()))
+takeRecordWorker record =
     atomically do
-        current <- readTVar record.recordWorker
-        case current of
-            Nothing -> pure ()
-            Just worker -> readTMVar worker.workerDone
-    threadIdVar <- newEmptyTMVarIO
-    done <- newEmptyTMVarIO
-    let worker = Worker
-            { workerThreadId = threadIdVar
-            , workerDone = done
-            }
-    started <- atomically do
-        closed <- readTVar registry.registryClosed
-        status <- readTVar record.recordStatus
-        rootTurnId <- readTVar record.recordRootTurnId
-        aborted <- isRootTurnAborted registry rootTurnId
-        current <- readTVar record.recordWorker
-        case current of
-            Just _ -> pure False
-            Nothing
-                | closed || aborted || status == Closed || status == Interrupted -> pure False
-                | otherwise -> do
-                    writeTVar record.recordWorker (Just worker)
-                    pure True
-    if started
+        current <- readTVar record.recordAsync
+        writeTVar record.recordAsync Nothing
+        pure current
+
+releaseRecordWorker :: SubagentRecord -> IO ()
+releaseRecordWorker record = do
+    worker <- takeRecordWorker record
+    mapM_ (releaseResource . fst) worker
+
+finishRecordWorker :: SubagentRecord -> IO ()
+finishRecordWorker record = do
+    worker <- takeRecordWorker record
+    mapM_
+        (\(key, child) -> do
+            _ <- waitCatch child
+            releaseResource key)
+        worker
+
+data WorkerStep
+    = WorkerClosed
+    | WorkerComplete
+    | WorkerMessage !SubagentWork
+
+nextWorkerStep
+    :: SubagentRegistry
+    -> SubagentRecord
+    -> STM WorkerStep
+nextWorkerStep registry record = do
+    closed <- readTVar registry.registryClosed
+    current <- readTVar record.recordStatus
+    if closed || current == Closed || current == Interrupted
         then do
-            tid <- forkFinally (restore action) (\_ -> finishWorker record worker)
-                `onException` finishWorker record worker
-            atomically $ putTMVar threadIdVar tid
-            pure True
-        else pure False
+            whenSTM closed (writeTVar record.recordStatus Closed)
+            pure WorkerClosed
+        else do
+            empty <- isEmptyTQueue record.recordMailbox
+            if empty
+                then pure WorkerComplete
+                else do
+                    work <- readTQueue record.recordMailbox
+                    writeTVar record.recordRootTurnId work.workRootTurnId
+                    writeTVar record.recordStatus Running
+                    pure (WorkerMessage work)
 
-finishWorker :: SubagentRecord -> Worker -> IO ()
-finishWorker record worker = atomically do
-    writeTVar record.recordWorker Nothing
-    putTMVar worker.workerDone ()
+finishOrContinue
+    :: SubagentRecord
+    -> SubagentStatus
+    -> STM (Maybe SubagentWork)
+finishOrContinue record status = do
+    current <- readTVar record.recordStatus
+    if current == Closed || current == Interrupted
+        then pure Nothing
+        else do
+            empty <- isEmptyTQueue record.recordMailbox
+            if empty
+                then do
+                    writeTVar record.recordStatus status
+                    pure Nothing
+                else do
+                    work <- readTQueue record.recordMailbox
+                    writeTVar record.recordRootTurnId work.workRootTurnId
+                    writeTVar record.recordStatus Running
+                    pure (Just work)
 
-stopWorker :: Worker -> IO ()
-stopWorker worker = do
-    threadId <- atomically $ readTMVar worker.workerThreadId
-    killThread threadId
-    atomically $ readTMVar worker.workerDone
-
-notifyComplete :: SubagentRegistry -> SubagentId -> SubagentStatus -> IO ()
-notifyComplete registry agentId status
+notifyComplete
+    :: SubagentRegistry
+    -> SubagentId
+    -> Maybe RootTurnId
+    -> SubagentStatus
+    -> IO ()
+notifyComplete registry agentId rootTurnId status
     | isFinalStatus status && status /= Closed && status /= NotFound = do
         shouldNotify <- atomically do
             closed <- readTVar registry.registryClosed
@@ -568,7 +665,13 @@ notifyComplete registry agentId status
                 Nothing -> pure False
                 Just record -> do
                     current <- readTVar record.recordStatus
-                    pure (not closed && current == status)
+                    owner <- readTVar record.recordRootTurnId
+                    aborted <- isRootTurnAborted registry rootTurnId
+                    pure $
+                        not closed
+                            && not aborted
+                            && current == Running
+                            && owner == rootTurnId
         whenIO shouldNotify do
             onComplete <- readIORef registry.registryOnCompleteRef
             onComplete agentId status
@@ -632,11 +735,6 @@ waitSubagents registry targets timeoutMs = do
         Left statuses -> pure (statuses, False)
         Right statuses -> pure (statuses, True)
 
-data SendKick
-    = KickNone
-    | KickStart
-    | KickFail !Text
-
 sendInput
     :: SubagentRegistry
     -> SubagentId
@@ -665,60 +763,66 @@ sendInputMessageForTurn
     -> InterAgentMessageContent
     -> Bool
     -> IO (Either Text Text)
-sendInputMessageForTurn registry rootTurnId senderPath agentId content interrupt = do
-    mrecord <- atomically $ Map.lookup agentId <$> readTVar registry.registryAgents
-    case mrecord of
-        Nothing -> pure (Left ("unknown agent id: " <> agentId.unSubagentId))
-        Just record -> do
-            status <- atomically $ readTVar record.recordStatus
-            case status of
-                Closed -> pure (Left "agent is closed")
-                NotFound -> pure (Left "agent not found")
-                _ -> do
-                    let work = SubagentWork
-                            { workRootTurnId = rootTurnId
-                            , workMessage = InterAgentMessage
-                                { messageAuthor = taskPathText senderPath
-                                , messageRecipient = taskPathText record.recordTaskPath
-                                , messageType = FollowUpMessage
-                                , messageContent = content
-                                }
+sendInputMessageForTurn registry rootTurnId senderPath agentId content interrupt =
+    withMVar registry.registryLifecycle \_ -> do
+        mrecord <- atomically $
+            Map.lookup agentId <$> readTVar registry.registryAgents
+        case mrecord of
+            Nothing -> pure (Left ("unknown agent id: " <> agentId.unSubagentId))
+            Just record -> do
+                status <- atomically $ readTVar record.recordStatus
+                let work = SubagentWork
+                        { workRootTurnId = rootTurnId
+                        , workMessage = InterAgentMessage
+                            { messageAuthor = taskPathText senderPath
+                            , messageRecipient = taskPathText record.recordTaskPath
+                            , messageType = FollowUpMessage
+                            , messageContent = content
                             }
-                    whenIO interrupt (requestCancel record.recordCancel)
-                    -- Admit before mutating status/mailbox so a failed resume
-                    -- does not leave the agent stuck in Running with no worker.
-                    kick <- atomically do
-                        aborted <- isRootTurnAborted registry rootTurnId
-                        current <- readTVar record.recordStatus
-                        if aborted
-                            then pure (KickFail "Root turn was aborted.")
-                            else case current of
-                                Running -> do
-                                    writeTQueue record.recordMailbox work
-                                    pure KickNone
-                                Pending -> do
-                                    writeTQueue record.recordMailbox work
-                                    pure KickNone
-                                _ -> do
-                                    admitted <- acquireSlot registry record
-                                    case admitted of
-                                        Left err -> pure (KickFail err)
-                                        Right () -> do
-                                            writeTQueue record.recordMailbox work
-                                            writeTVar record.recordRootTurnId rootTurnId
-                                            writeTVar record.recordStatus Running
-                                            pure KickStart
-                    case kick of
-                        KickFail err -> pure (Left err)
-                        KickNone -> pure (Right "queued")
-                        KickStart -> do
-                            started <-
-                                startRecordWorker registry record do
-                                    msg <- atomically $ readTQueue record.recordMailbox
-                                    runWorker registry record msg
-                            if started
-                                then pure (Right "queued")
-                                else pure (Left "agent was closed before its worker started")
+                        }
+                case status of
+                    Closed -> pure (Left "agent is closed")
+                    NotFound -> pure (Left "agent not found")
+                    Running -> queue record work
+                    Pending -> queue record work
+                    _ -> restart record work
+  where
+    queue
+        :: SubagentRecord
+        -> SubagentWork
+        -> IO (Either Text Text)
+    queue record work = do
+        whenIO interrupt (requestCancel record.recordCancel)
+        queued <- atomically do
+            aborted <- isRootTurnAborted registry rootTurnId
+            if aborted
+                then pure False
+                else writeTQueue record.recordMailbox work >> pure True
+        pure $ if queued
+            then Right "queued"
+            else Left "Root turn was aborted."
+
+    restart
+        :: SubagentRecord
+        -> SubagentWork
+        -> IO (Either Text Text)
+    restart record work = do
+        admitted <- atomically do
+            aborted <- isRootTurnAborted registry rootTurnId
+            if aborted
+                then pure (Left "Root turn was aborted.")
+                else acquireSlot registry record
+        case admitted of
+            Left err -> pure (Left err)
+            Right () -> do
+                resetCancel record.recordCancel
+                finishRecordWorker record
+                started <- startRecordWorker registry record work
+                case started of
+                    Left err -> do
+                        releaseSlot registry record
+                        pure (Left err)
+                    Right () -> pure (Right "queued")
 
 whenIO :: Bool -> IO () -> IO ()
 whenIO True action = action
@@ -728,17 +832,19 @@ closeSubagent
     :: SubagentRegistry
     -> SubagentId
     -> IO (Either Text SubagentStatus)
-closeSubagent registry agentId = do
-    mrecord <- atomically $ Map.lookup agentId <$> readTVar registry.registryAgents
-    case mrecord of
-        Nothing -> pure (Left ("unknown agent id: " <> agentId.unSubagentId))
-        Just record -> do
-            previous <- atomically $ readTVar record.recordStatus
-            toClose <- atomically do
-                agents <- readTVar registry.registryAgents
-                pure (record : descendants agents record.recordId)
-            mapM_ (shutdownRecord registry) toClose
-            pure (Right previous)
+closeSubagent registry agentId =
+    withMVar registry.registryLifecycle \_ -> do
+        mrecord <- atomically $
+            Map.lookup agentId <$> readTVar registry.registryAgents
+        case mrecord of
+            Nothing -> pure (Left ("unknown agent id: " <> agentId.unSubagentId))
+            Just record -> do
+                previous <- atomically $ readTVar record.recordStatus
+                toClose <- atomically do
+                    agents <- readTVar registry.registryAgents
+                    pure (record : descendants agents record.recordId)
+                mapM_ (shutdownRecord registry) toClose
+                pure (Right previous)
 
 descendants :: Map SubagentId SubagentRecord -> SubagentId -> [SubagentRecord]
 descendants agents parentId =
@@ -748,21 +854,18 @@ descendants agents parentId =
 shutdownRecord :: SubagentRegistry -> SubagentRecord -> IO ()
 shutdownRecord registry record = do
     requestCancel record.recordCancel
-    mworker <- atomically do
-        writeTVar record.recordStatus Closed
-        readTVar record.recordWorker
-    case mworker of
-        Nothing -> pure ()
-        Just worker -> stopWorker worker
+    atomically $ writeTVar record.recordStatus Closed
+    releaseRecordWorker record
     releaseSlot registry record
 
 abortRootTurn :: SubagentRegistry -> RootTurnId -> IO ()
-abortRootTurn registry rootTurnId = do
-    records <- atomically do
-        modifyTVar' registry.registryAbortedRootTurns (Set.insert rootTurnId)
-        agents <- Map.elems <$> readTVar registry.registryAgents
-        fmap concat $ mapM selectOwned agents
-    mapM_ (interruptRecordForTurn registry rootTurnId) records
+abortRootTurn registry rootTurnId =
+    withMVar registry.registryLifecycle \_ -> do
+        records <- atomically do
+            modifyTVar' registry.registryAbortedRootTurns (Set.insert rootTurnId)
+            agents <- Map.elems <$> readTVar registry.registryAgents
+            fmap concat $ mapM selectOwned agents
+        mapM_ (interruptRecordForTurn registry rootTurnId) records
   where
     selectOwned :: SubagentRecord -> STM [SubagentRecord]
     selectOwned record = do
@@ -782,16 +885,15 @@ interruptRecordForTurn registry rootTurnId record = do
         if owner == Just rootTurnId
             then do
                 writeTVar record.recordStatus Interrupted
-                worker <- readTVar record.recordWorker
+                worker <- readTVar record.recordAsync
+                writeTVar record.recordAsync Nothing
                 pure (Just worker)
             else pure Nothing
     case ownedWorker of
         Nothing -> pure ()
         Just mworker -> do
             requestCancel record.recordCancel
-            case mworker of
-                Nothing -> pure ()
-                Just worker -> stopWorker worker
+            mapM_ (releaseResource . fst) mworker
             atomically do
                 owner <- readTVar record.recordRootTurnId
                 whenSTM (owner == Just rootTurnId) $
@@ -817,16 +919,17 @@ isRootTurnAborted registry (Just rootTurnId) =
 -- during the transition so a descendant cannot publish a newly-created worker
 -- after the abort snapshot has been taken.
 interruptActiveSubagents :: SubagentRegistry -> IO ()
-interruptActiveSubagents registry = do
-    (wasClosed, records) <- atomically do
-        wasClosed <- readTVar registry.registryClosed
-        writeTVar registry.registryClosed True
-        agents <- Map.elems <$> readTVar registry.registryAgents
-        records <- filterMSTM isActiveRecord agents
-        pure (wasClosed, records)
-    mapM_ (interruptRecord registry) records
-        `finally`
-            atomically (writeTVar registry.registryClosed wasClosed)
+interruptActiveSubagents registry =
+    withMVar registry.registryLifecycle \_ -> do
+        (wasClosed, records) <- atomically do
+            wasClosed <- readTVar registry.registryClosed
+            writeTVar registry.registryClosed True
+            agents <- Map.elems <$> readTVar registry.registryAgents
+            records <- filterMSTM isActiveRecord agents
+            pure (wasClosed, records)
+        mapM_ (interruptRecord registry) records
+            `finally`
+                atomically (writeTVar registry.registryClosed wasClosed)
   where
     isActiveRecord :: SubagentRecord -> STM Bool
     isActiveRecord record = do
@@ -836,13 +939,11 @@ interruptActiveSubagents registry = do
 interruptRecord :: SubagentRegistry -> SubagentRecord -> IO ()
 interruptRecord registry record = do
     requestCancel record.recordCancel
-    mworker <- atomically do
+    atomically do
         writeTVar record.recordStatus Interrupted
         _ <- flushTQueue record.recordMailbox
-        readTVar record.recordWorker
-    case mworker of
-        Nothing -> pure ()
-        Just worker -> stopWorker worker
+        pure ()
+    releaseRecordWorker record
     atomically $ writeTVar record.recordStatus Interrupted
     releaseSlot registry record
 
@@ -878,65 +979,93 @@ restoreSubagentWithCwd
     -> Maybe Text
     -> Maybe Text
     -> IO (Either Text SubagentId)
-restoreSubagentWithCwd registry childCwd agentId parentId depth nickname previous = do
-    existing <- atomically $ Map.lookup agentId <$> readTVar registry.registryAgents
-    case existing of
-        Just record -> do
-            -- Same-process resume after close: reopen without consuming a slot.
-            atomically do
-                writeTVar record.recordStatus (Completed Nothing)
-                writeTVar record.recordPreviousResponseId previous
-                writeTVar record.recordWorker Nothing
-                writeTVar record.recordRootTurnId Nothing
-            pure (Right agentId)
-        Nothing -> do
-            cancelFlag <- newCancelFlag
-            mailbox <- newTQueueIO
-            statusVar <- newTVarIO (Completed Nothing)
-            workerVar <- newTVarIO Nothing
-            rootTurnVar <- newTVarIO Nothing
-            slotHeld <- newTVarIO False
-            previousVar <- newTVarIO previous
-            let record = SubagentRecord
-                    { recordId = agentId
-                    , recordParent = parentId
-                    , recordDepth = depth
-                    , recordNickname = nickname
-                    , recordStatus = statusVar
-                    , recordCancel = cancelFlag
-                    , recordMailbox = mailbox
-                    , recordWorker = workerVar
-                    , recordRootTurnId = rootTurnVar
-                    , recordSlotHeld = slotHeld
-                    , recordPreviousResponseId = previousVar
-                    , recordTaskPath = taskPathRoot
-                    , recordCwd = childCwd
-                    }
-            atomically do
-                closed <- readTVar registry.registryClosed
-                if closed
-                    then pure ()
-                    else modifyTVar' registry.registryAgents (Map.insert agentId record)
-            closed <- atomically $ readTVar registry.registryClosed
+restoreSubagentWithCwd registry childCwd agentId parentId depth nickname previous =
+    withMVar registry.registryLifecycle \_ -> do
+        closed <- atomically $ readTVar registry.registryClosed
+        if closed
+            then pure (Left "Subagent registry is closed.")
+            else do
+                existing <- atomically $
+                    Map.lookup agentId <$> readTVar registry.registryAgents
+                case existing of
+                    Just record -> restoreExisting record
+                    Nothing -> restoreMissing
+  where
+    restoreExisting record = do
+        status <- atomically $ readTVar record.recordStatus
+        case status of
+            Running -> pure (Left "cannot restore a running subagent")
+            Pending -> pure (Left "cannot restore a pending subagent")
+            NotFound -> pure (Left "cannot restore a missing subagent record")
+            _ -> do
+                finishRecordWorker record
+                releaseSlot registry record
+                resetCancel record.recordCancel
+                atomically do
+                    writeTVar record.recordStatus (Completed Nothing)
+                    writeTVar record.recordPreviousResponseId previous
+                    writeTVar record.recordRootTurnId Nothing
+                pure (Right agentId)
+
+    restoreMissing = do
+        cancelFlag <- newCancelFlag
+        mailbox <- newTQueueIO
+        statusVar <- newTVarIO (Completed Nothing)
+        asyncVar <- newTVarIO Nothing
+        rootTurnVar <- newTVarIO Nothing
+        slotHeld <- newTVarIO False
+        previousVar <- newTVarIO previous
+        let record = SubagentRecord
+                { recordId = agentId
+                , recordParent = parentId
+                , recordDepth = depth
+                , recordNickname = nickname
+                , recordStatus = statusVar
+                , recordCancel = cancelFlag
+                , recordMailbox = mailbox
+                , recordAsync = asyncVar
+                , recordRootTurnId = rootTurnVar
+                , recordSlotHeld = slotHeld
+                , recordPreviousResponseId = previousVar
+                , recordTaskPath = taskPathRoot
+                , recordCwd = childCwd
+                }
+        inserted <- atomically do
+            closed <- readTVar registry.registryClosed
             if closed
-                then pure (Left "Subagent registry is closed.")
-                else pure (Right agentId)
+                then pure False
+                else do
+                    modifyTVar' registry.registryAgents (Map.insert agentId record)
+                    pure True
+        pure $ if inserted
+            then Right agentId
+            else Left "Subagent registry is closed."
 
 resumeSubagent
     :: SubagentRegistry
     -> SubagentId
     -> IO (Either Text SubagentStatus)
-resumeSubagent registry agentId = do
-    mrecord <- atomically $ Map.lookup agentId <$> readTVar registry.registryAgents
-    case mrecord of
-        Nothing -> pure (Left ("unknown agent id: " <> agentId.unSubagentId))
-        Just record -> do
-            status <- atomically $ readTVar record.recordStatus
-            case status of
-                Closed -> do
-                    atomically $ writeTVar record.recordStatus (Completed Nothing)
-                    pure (Right (Completed Nothing))
-                other -> pure (Right other)
+resumeSubagent registry agentId =
+    withMVar registry.registryLifecycle \_ -> do
+        closed <- atomically $ readTVar registry.registryClosed
+        if closed
+            then pure (Left "Subagent registry is closed.")
+            else do
+                mrecord <- atomically $
+                    Map.lookup agentId <$> readTVar registry.registryAgents
+                case mrecord of
+                    Nothing ->
+                        pure (Left ("unknown agent id: " <> agentId.unSubagentId))
+                    Just record -> do
+                        status <- atomically $ readTVar record.recordStatus
+                        case status of
+                            Closed -> do
+                                resetCancel record.recordCancel
+                                atomically do
+                                    writeTVar record.recordStatus (Completed Nothing)
+                                    writeTVar record.recordRootTurnId Nothing
+                                pure (Right (Completed Nothing))
+                            other -> pure (Right other)
 
 getStatus :: SubagentRegistry -> SubagentId -> IO SubagentStatus
 getStatus registry agentId = atomically (readStatusSTM registry agentId)

--- a/packages/agent-core/src/Agent/Tools.hs
+++ b/packages/agent-core/src/Agent/Tools.hs
@@ -17,6 +17,11 @@ module Agent.Tools
     ) where
 
 import Agent.Provider (Provider(..))
+import Agent.ResourceScope
+    ( allocateResource
+    , closeResourceScope
+    , newResourceScope
+    )
 import Agent.Tools.Codex (codexTools)
 import Agent.Tools.Ghci (closeGhciSession, newGhciSession)
 import Agent.Tools.Grok (closeGrokSession, filterGrokToolsForType, grokTools, newGrokSession)
@@ -24,6 +29,7 @@ import Agent.Tools.Grok.Task (GrokSubagentSpecs)
 import Agent.Tools.MultiAgents (MultiAgentContext)
 import Agent.Tools.PlanMode (PlanModeEnv, PlanModeHooks, newPlanModeEnv)
 import Agent.Tools.Types
+import Control.Exception.Safe (onException)
 import Data.IORef
 import qualified Data.Map.Strict as Map
 import Data.Text (Text)
@@ -61,35 +67,39 @@ codingToolsForWithTypes
     -> GrokSubagentSpecs
     -> IO CodingTools
 codingToolsForWithTypes provider env hooks multi typesRef = do
-    plan <- newPlanModeEnv env.toolCwd hooks
-    case provider of
-        XAIProvider -> do
-            session <- newGrokSession env
-            ghci <- newGhciSession env
-            pure CodingTools
-                { codingAppTools = grokTools session ghci plan multi typesRef
-                , codingPlanMode = plan
-                , codingClose = closeGrokSession session >> closeGhciSession ghci
-                , codingAgentTypes = typesRef
-                }
-        OpenRouterProvider -> do
-            session <- newGrokSession env
-            ghci <- newGhciSession env
-            pure CodingTools
-                { codingAppTools = grokTools session ghci plan multi typesRef
-                , codingPlanMode = plan
-                , codingClose = closeGrokSession session >> closeGhciSession ghci
-                , codingAgentTypes = typesRef
-                }
-        OpenAIProvider -> do
-            ghci <- newGhciSession env
-            tools <- codexTools env ghci plan multi
-            pure CodingTools
-                { codingAppTools = tools
-                , codingPlanMode = plan
-                , codingClose = closeGhciSession ghci
-                , codingAgentTypes = typesRef
-                }
+    resources <- newResourceScope
+    flip onException (closeResourceScope resources) do
+        plan <- newPlanModeEnv env.toolCwd hooks
+        case provider of
+            XAIProvider ->
+                grokCodingTools resources plan
+            OpenRouterProvider ->
+                grokCodingTools resources plan
+            OpenAIProvider -> do
+                (_, ghci) <- allocateResource resources
+                    (newGhciSession env)
+                    closeGhciSession
+                tools <- codexTools env ghci plan multi
+                pure CodingTools
+                    { codingAppTools = tools
+                    , codingPlanMode = plan
+                    , codingClose = closeResourceScope resources
+                    , codingAgentTypes = typesRef
+                    }
+  where
+    grokCodingTools resources plan = do
+        (_, session) <- allocateResource resources
+            (newGrokSession env)
+            closeGrokSession
+        (_, ghci) <- allocateResource resources
+            (newGhciSession env)
+            closeGhciSession
+        pure CodingTools
+            { codingAppTools = grokTools session ghci plan multi typesRef
+            , codingPlanMode = plan
+            , codingClose = closeResourceScope resources
+            , codingAgentTypes = typesRef
+            }
 
 -- | Re-export for CLI child runners.
 filterChildGrokTools :: Text -> [AppTool] -> [AppTool]

--- a/packages/agent-core/src/Agent/Tools/Grok/Shell.hs
+++ b/packages/agent-core/src/Agent/Tools/Grok/Shell.hs
@@ -16,6 +16,14 @@ module Agent.Tools.Grok.Shell
     ) where
 
 import Agent.OsPath (OsPath, fromFilePath, fromText, toFilePath)
+import Agent.ResourceScope
+    ( ResourceKey
+    , ResourceScope
+    , allocateResource
+    , closeResourceScope
+    , newResourceScope
+    , releaseResource
+    )
 import Agent.Tools.IO
     ( CommandResult(..)
     , RunningCommand(..)
@@ -23,13 +31,14 @@ import Agent.Tools.IO
     , runShellCommand
     , runningLiveOutput
     , startShellCommand
+    , stopShellCommand
     )
 import Agent.Tools.Types (ToolEnv(..))
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async (race)
 import Control.Concurrent.MVar
-import Control.Exception (SomeException, try)
-import Control.Monad (forM_, void)
+import Control.Exception.Safe (mask, onException, throwIO, tryAny)
+import Control.Monad (void)
 import Data.IORef
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
@@ -37,12 +46,16 @@ import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
-import System.Directory.OsPath (doesDirectoryExist, getTemporaryDirectory, removeFile)
+import System.Directory.OsPath
+    ( doesDirectoryExist
+    , doesFileExist
+    , getTemporaryDirectory
+    , removeFile
+    )
 import System.IO (hClose)
 import System.OsPath ((<.>), (</>))
 import System.Posix.Files (ownerReadMode, ownerWriteMode, setFileMode, unionFileModes)
 import System.Posix.Temp (mkstemp)
-import System.Process (interruptProcessGroupOf)
 
 data PersistentShell = PersistentShell
     { shellCwd :: !OsPath
@@ -52,6 +65,7 @@ data PersistentShell = PersistentShell
 data BackgroundTask = BackgroundTask
     { backgroundId :: !Text
     , backgroundRunning :: !RunningCommand
+    , backgroundResource :: !ResourceKey
     }
 
 data GrokSession = GrokSession
@@ -59,43 +73,53 @@ data GrokSession = GrokSession
     , grokShell :: !(MVar PersistentShell)
     , grokTasks :: !(MVar (Map Text BackgroundTask))
     , grokNextId :: !(IORef Int)
+    , grokResources :: !ResourceScope
     }
 
 newGrokSession :: ToolEnv -> IO GrokSession
 newGrokSession env = do
-    tmp <- getTemporaryDirectory
-    (envFileRaw, handle) <-
-        mkstemp (toFilePath (tmp </> fromFilePath "agent-grok-env"))
-    let envFile = fromFilePath envFileRaw
-    hClose handle
-    setFileMode envFileRaw (unionFileModes ownerReadMode ownerWriteMode)
-    Text.writeFile envFileRaw ""
-    shell <- newMVar PersistentShell
-        { shellCwd = env.toolCwd
-        , shellEnvFile = envFile
-        }
-    tasks <- newMVar Map.empty
-    nextId <- newIORef 0
-    pure GrokSession
-        { grokEnv = env
-        , grokShell = shell
-        , grokTasks = tasks
-        , grokNextId = nextId
-        }
+    resources <- newResourceScope
+    flip onException (closeResourceScope resources) do
+        (_, envFile) <- allocateResource resources acquireEnvFile cleanupEnvFiles
+        shell <- newMVar PersistentShell
+            { shellCwd = env.toolCwd
+            , shellEnvFile = envFile
+            }
+        tasks <- newMVar Map.empty
+        nextId <- newIORef 0
+        pure GrokSession
+            { grokEnv = env
+            , grokShell = shell
+            , grokTasks = tasks
+            , grokNextId = nextId
+            , grokResources = resources
+            }
+  where
+    acquireEnvFile =
+        mask \restore -> do
+            tmp <- getTemporaryDirectory
+            (envFileRaw, handle) <- restore $
+                mkstemp (toFilePath (tmp </> fromFilePath "agent-grok-env"))
+            let envFile = fromFilePath envFileRaw
+            let rollback = do
+                    void $ tryAny (hClose handle)
+                    removeIfExists envFile
+            flip onException rollback do
+                hClose handle
+                setFileMode envFileRaw
+                    (unionFileModes ownerReadMode ownerWriteMode)
+                Text.writeFile envFileRaw ""
+                pure envFile
+    cleanupEnvFiles envFile = do
+        removeIfExists envFile
+        removeIfExists (envFile <.> fromFilePath "cwd")
 
 -- | Delete the env/cwd dump and interrupt leftover background tasks.
 -- Call this when the CLI/session ends, including after exceptions.
 closeGrokSession :: GrokSession -> IO ()
 closeGrokSession session = do
-    tasks <- modifyMVar session.grokTasks \current ->
-        pure (Map.empty, current)
-    forM_ (Map.elems tasks) \task ->
-        void $ try @SomeException
-            (interruptProcessGroupOf task.backgroundRunning.runningHandle)
-    shell <- readMVar session.grokShell
-    _ <- try @SomeException (removeFile shell.shellEnvFile)
-    _ <- try @SomeException (removeFile (cwdFile shell))
-    pure ()
+    modifyMVar_ session.grokTasks (const (pure Map.empty))
+    closeResourceScope session.grokResources
 
 runForeground :: GrokSession -> String -> Int -> IO CommandResult
 runForeground session command timeoutMs =
@@ -113,15 +137,24 @@ startBackground session command = do
     -- Background wrappers source cwd/env but must not write them back;
     -- a later foreground command owns the persistent session.
     let wrapped = bashWrap (wrapScript shell False (Text.unpack command))
-    startShellCommand session.grokEnv session.grokEnv.toolCwd wrapped >>= \case
-        Left err -> pure (Left err)
-        Right running -> do
+    started <- tryAny $
+        allocateResource session.grokResources
+            (startShellCommand session.grokEnv session.grokEnv.toolCwd wrapped
+                >>= either (throwIO . userError . Text.unpack) pure)
+            stopShellCommand
+    case started of
+        Left exception ->
+            pure (Left (Text.pack (show exception)))
+        Right (resource, running) -> do
             taskId <- nextTaskId session
-            modifyMVar_ session.grokTasks \tasks ->
-                pure $ Map.insert taskId BackgroundTask
+            let task = BackgroundTask
                     { backgroundId = taskId
                     , backgroundRunning = running
-                    } tasks
+                    , backgroundResource = resource
+                    }
+            modifyMVar_ session.grokTasks
+                (\tasks -> pure (Map.insert taskId task tasks))
+                `onException` releaseResource resource
             pure $ Right $
                 "Command moved to background.\n\
                 \task_id: " <> taskId <> "\n\
@@ -159,16 +192,9 @@ killTask session taskId = do
     case Map.lookup taskId tasks of
         Nothing -> pure $ "Unknown task_id: " <> taskId
         Just task -> do
-            _ <- try @SomeException
-                (interruptProcessGroupOf task.backgroundRunning.runningHandle)
-            raced <- race
-                (threadDelay 5000000)
-                (readMVar task.backgroundRunning.runningResult)
-            case raced of
-                Left () ->
-                    pure $ "kill signal sent to " <> taskId <> ", still running"
-                Right result ->
-                    pure $ "killed " <> taskId <> "\n" <> formatExit result
+            releaseResource task.backgroundResource
+            result <- readMVar task.backgroundRunning.runningResult
+            pure $ "killed " <> taskId <> "\n" <> formatExit result
 
 nextTaskId :: GrokSession -> IO Text
 nextTaskId session = atomicModifyIORef' session.grokNextId \n ->
@@ -202,7 +228,7 @@ cwdFile shell = shell.shellEnvFile <.> fromFilePath "cwd"
 
 refreshCwd :: ToolEnv -> PersistentShell -> IO PersistentShell
 refreshCwd env shell = do
-    contents <- try @SomeException (Text.readFile (toFilePath (cwdFile shell)))
+    contents <- tryAny (Text.readFile (toFilePath (cwdFile shell)))
     case contents of
         Left _ -> pure shell
         Right raw -> do
@@ -222,6 +248,13 @@ quoteString path = "'" <> concatMap escape path <> "'"
   where
     escape '\'' = "'\\''"
     escape c = [c]
+
+removeIfExists :: OsPath -> IO ()
+removeIfExists path = do
+    exists <- doesFileExist path
+    if exists
+        then void $ tryAny (removeFile path)
+        else pure ()
 
 formatExit :: CommandResult -> Text
 formatExit result

--- a/packages/agent-core/src/Agent/Tools/IO.hs
+++ b/packages/agent-core/src/Agent/Tools/IO.hs
@@ -10,6 +10,7 @@ module Agent.Tools.IO
     , listDirectoryEntries
     , runShellCommand
     , startShellCommand
+    , stopShellCommand
     , runningLiveOutput
     , truncateText
     ) where
@@ -25,12 +26,30 @@ import Agent.Tools.FileSystem
     , writeTextFile
     )
 import Agent.Tools.Types (ToolEnv(..))
-import Control.Concurrent (forkFinally, threadDelay)
+import Control.Concurrent (threadDelay)
 import Control.Monad (void)
-import Control.Concurrent.Async (concurrently, race)
-import Control.Concurrent.MVar (MVar, newEmptyMVar, putMVar)
+import Control.Concurrent.Async
+    ( Async
+    , async
+    , cancel
+    , concurrently
+    , race
+    , waitCatch
+    )
+import Control.Concurrent.MVar
+    ( MVar
+    , newEmptyMVar
+    , readMVar
+    , tryPutMVar
+    )
 import Control.Exception (evaluate)
-import Control.Exception.Safe (SomeException, try)
+import Control.Exception.Safe
+    ( SomeException
+    , finally
+    , mask
+    , onException
+    , try
+    )
 import Data.IORef (IORef, atomicModifyIORef', newIORef, readIORef)
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -46,6 +65,7 @@ import System.Process
     , createProcess
     , interruptProcessGroupOf
     , shell
+    , terminateProcess
     , waitForProcess
     )
 
@@ -63,6 +83,7 @@ data RunningCommand = RunningCommand
     , runningStdout :: !(IORef BS.ByteString)
     , runningStderr :: !(IORef BS.ByteString)
     , runningCap :: !Int
+    , runningSupervisor :: !(Async ())
     }
 
 -- | Bytes already drained from a still-running command, decoded and capped.
@@ -170,8 +191,8 @@ cancelledResult = CommandResult
     , commandCancelled = True
     }
 
--- | Start a command without waiting. The result is written to 'runningResult'
--- when the process exits. Use 'interruptProcessGroupOf' on 'runningHandle' to kill it.
+-- | Start a command without waiting. Call 'stopShellCommand' when its owner
+-- is closed or the task is explicitly killed.
 startShellCommand
     :: ToolEnv
     -> OsPath
@@ -185,46 +206,92 @@ startShellCommand env workdir command = do
             , std_err = CreatePipe
             , create_group = True
             }
-    try @_ @SomeException (createProcess spec) >>= \case
+    try @_ @SomeException
+        (acquireRunningCommand spec env.toolStdoutCap) >>= \case
         Left err -> pure $ Left $ "Failed to start command: " <> Text.pack (show err)
-        Right (Just hin, Just hout, Just herr, processHandle) -> do
-            hClose hin
-            resultVar <- newEmptyMVar
-            stdoutRef <- newIORef BS.empty
-            stderrRef <- newIORef BS.empty
-            _ <- forkFinally
-                (do
-                    ((outBytes, errBytes), code) <- concurrently
-                        (concurrently
-                            (drainHandle hout stdoutRef)
-                            (drainHandle herr stderrRef))
-                        (waitForProcess processHandle)
-                    pure CommandResult
-                        { commandExitCode = Just (exitCodeInt code)
-                        , commandStdout = truncateText env.toolStdoutCap
-                            (decodeUtf8With lenientDecode outBytes)
-                        , commandStderr = truncateText env.toolStdoutCap
-                            (decodeUtf8With lenientDecode errBytes)
-                        , commandTimedOut = False
-                        , commandCancelled = False
-                        })
-                (publishCommandResult resultVar)
-            pure $ Right RunningCommand
-                { runningHandle = processHandle
-                , runningResult = resultVar
-                , runningStdout = stdoutRef
-                , runningStderr = stderrRef
-                , runningCap = env.toolStdoutCap
-                }
+        Right running ->
+            pure (Right running)
+
+acquireRunningCommand :: CreateProcess -> Int -> IO RunningCommand
+acquireRunningCommand spec outputCap =
+    mask \restore ->
+    restore (createProcess spec) >>= \case
+        (Just hin, Just hout, Just herr, processHandle) -> do
+            let rollback = cleanupProcess processHandle [hin, hout, herr]
+            flip onException rollback do
+                hClose hin
+                resultVar <- newEmptyMVar
+                stdoutRef <- newIORef BS.empty
+                stderrRef <- newIORef BS.empty
+                supervisor <- async $
+                    (do
+                        result <- try @_ @SomeException do
+                            ((outBytes, errBytes), code) <- concurrently
+                                (concurrently
+                                    (drainHandle hout stdoutRef)
+                                    (drainHandle herr stderrRef))
+                                (waitForProcess processHandle)
+                            pure (outBytes, errBytes, code)
+                        void $ tryPutMVar resultVar $ case result of
+                            Left exception -> commandFailure exception
+                            Right (outBytes, errBytes, code) -> CommandResult
+                                { commandExitCode = Just (exitCodeInt code)
+                                , commandStdout = truncateText outputCap
+                                    (decodeUtf8With lenientDecode outBytes)
+                                , commandStderr = truncateText outputCap
+                                    (decodeUtf8With lenientDecode errBytes)
+                                , commandTimedOut = False
+                                , commandCancelled = False
+                                })
+                    `finally` do
+                        void $ tryPutMVar resultVar cancelledResult
+                        mapM_
+                            (\handle ->
+                                void $ try @_ @SomeException (hClose handle))
+                            [hout, herr]
+                pure RunningCommand
+                    { runningHandle = processHandle
+                    , runningResult = resultVar
+                    , runningStdout = stdoutRef
+                    , runningStderr = stderrRef
+                    , runningCap = outputCap
+                    , runningSupervisor = supervisor
+                    }
+        _ -> fail "Failed to capture command output"
+
+cleanupProcess :: ProcessHandle -> [Handle] -> IO ()
+cleanupProcess processHandle handles = do
+    void $ try @_ @SomeException (interruptProcessGroupOf processHandle)
+    void $ try @_ @SomeException (terminateProcess processHandle)
+    mapM_ (\handle -> void $ try @_ @SomeException (hClose handle)) handles
+    void $ try @_ @SomeException (waitForProcess processHandle)
+
+stopShellCommand :: RunningCommand -> IO ()
+stopShellCommand running = do
+    void $ try @_ @SomeException
+        (interruptProcessGroupOf running.runningHandle)
+    stopped <- race
+        (threadDelay 5000000)
+        (readMVar running.runningResult)
+    case stopped of
         Right _ ->
-            pure $ Left "Failed to capture command output"
+            void (waitCatch running.runningSupervisor)
+        Left () -> do
+            void $ try @_ @SomeException
+                (terminateProcess running.runningHandle)
+            stoppedAfterTerminate <- race
+                (threadDelay 1000000)
+                (readMVar running.runningResult)
+            case stoppedAfterTerminate of
+                Right _ ->
+                    void (waitCatch running.runningSupervisor)
+                Left () -> do
+                    cancel running.runningSupervisor
+                    void (waitCatch running.runningSupervisor)
+                    void $ tryPutMVar running.runningResult cancelledResult
 
-publishCommandResult :: MVar CommandResult -> Either SomeException CommandResult -> IO ()
-publishCommandResult resultVar result =
-    putMVar resultVar (either failedCommandResult id result)
-
-failedCommandResult :: SomeException -> CommandResult
-failedCommandResult exception = CommandResult
+commandFailure :: SomeException -> CommandResult
+commandFailure exception = CommandResult
     { commandExitCode = Just 127
     , commandStdout = ""
     , commandStderr = Text.pack (show exception)

--- a/packages/agent-core/test/Agent/ResourceScopeSpec.hs
+++ b/packages/agent-core/test/Agent/ResourceScopeSpec.hs
@@ -1,0 +1,34 @@
+module Agent.ResourceScopeSpec (spec) where
+
+import Agent.ResourceScope
+import Data.IORef
+import Test.Hspec
+
+spec :: Spec
+spec = describe "Agent.ResourceScope" do
+    it "releases resources in reverse acquisition order" do
+        released <- newIORef ([] :: [Int])
+        scope <- newResourceScope
+        _ <- registerResource scope (record released 1)
+        _ <- registerResource scope (record released 2)
+        closeResourceScope scope
+        readIORef released `shouldReturn` [2, 1]
+
+    it "supports explicit idempotent release" do
+        releases <- newIORef (0 :: Int)
+        scope <- newResourceScope
+        key <- registerResource scope $
+            atomicModifyIORef' releases \n -> (n + 1, ())
+        releaseResource key
+        releaseResource key
+        closeResourceScope scope
+        readIORef releases `shouldReturn` 1
+
+    it "can be closed more than once" do
+        scope <- newResourceScope
+        closeResourceScope scope
+        closeResourceScope scope
+
+record :: IORef [Int] -> Int -> IO ()
+record ref value =
+    atomicModifyIORef' ref \values -> (values <> [value], ())

--- a/packages/agent-core/test/Agent/SubagentsSpec.hs
+++ b/packages/agent-core/test/Agent/SubagentsSpec.hs
@@ -276,6 +276,31 @@ spec = describe "Agent.Subagents" do
         seen <- readIORef notices
         seen `shouldBe` [(agentId, Completed (Just "notify-me"))]
 
+    it "allows completion callbacks to queue a follow-up without deadlocking" do
+        prompts <- newIORef ([] :: [Text])
+        registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
+            (\_ _ prompt _ -> do
+                let payload = messagePayload prompt
+                atomicModifyIORef' prompts \seen -> (seen <> [payload], ())
+                pure $ Right LoopResult
+                    { finalResponseId = "response-" <> payload
+                    , finalText = Just payload
+                    , turnsUsed = 1
+                    , tokenUsage = emptyTokenUsage
+                    })
+            (\_ _ -> pure ())
+        setSubagentOnComplete registry \agentId -> \case
+            Completed (Just "first") -> do
+                _ <- sendInput registry agentId "second" False
+                pure ()
+            _ -> pure ()
+        Right agentId <- spawnSubagent registry Nothing 0 "first" Nothing
+        (statuses, timedOut) <- waitSubagents registry [agentId] 15000
+        timedOut `shouldBe` False
+        Map.lookup agentId statuses
+            `shouldBe` Just (Completed (Just "second"))
+        readIORef prompts `shouldReturn` ["first", "second"]
+
     it "cancels and joins a running worker when the registry closes" do
         started <- newEmptyTMVarIO
         cleanedUp <- newEmptyTMVarIO
@@ -326,6 +351,70 @@ spec = describe "Agent.Subagents" do
         status1 `shouldBe` Completed Nothing
         previous <- getPreviousResponseId registry agentId
         previous `shouldBe` Just "prev"
+        Right _ <- sendInput registry agentId "after-restore" False
+        (statuses, timedOut) <- waitSubagents registry [agentId] 15000
+        timedOut `shouldBe` False
+        Map.lookup agentId statuses
+            `shouldBe` Just (Completed (Just "after-restore"))
+
+    it "does not let sendInput resurrect a closed agent" do
+        registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
+            (\_ _ prompt _ -> pure $ Right LoopResult
+                { finalResponseId = "r"
+                , finalText = Just (messagePayload prompt)
+                , turnsUsed = 1
+                , tokenUsage = emptyTokenUsage
+                })
+            (\_ _ -> pure ())
+        Right agentId <- spawnSubagent registry Nothing 0 "first" Nothing
+        _ <- waitSubagents registry [agentId] 15000
+        _ <- closeSubagent registry agentId
+        sendInput registry agentId "should-not-run" False
+            `shouldReturn` Left "agent is closed"
+        getStatus registry agentId `shouldReturn` Closed
+
+    it "reset cancels old workers and reopens with a fresh resource scope" do
+        started <- newEmptyMVar
+        notices <- newIORef ([] :: [SubagentId])
+        registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
+            (\_ _ prompt _ ->
+                let payload = messagePayload prompt
+                in if payload == "old"
+                    then putMVar started () >> atomically retry
+                    else pure $ Right LoopResult
+                        { finalResponseId = "new"
+                        , finalText = Just payload
+                        , turnsUsed = 1
+                        , tokenUsage = emptyTokenUsage
+                        })
+            (\_ _ -> pure ())
+        setSubagentOnComplete registry \agentId _ ->
+            atomicModifyIORef' notices \ids -> (ids <> [agentId], ())
+        Right old <- spawnSubagent registry Nothing 0 "old" Nothing
+        takeMVar started
+        resetSubagentRegistry registry
+        getStatus registry old `shouldReturn` NotFound
+        readIORef notices `shouldReturn` []
+        Right fresh <- spawnSubagent registry Nothing 0 "fresh" Nothing
+        (statuses, timedOut) <- waitSubagents registry [fresh] 15000
+        timedOut `shouldBe` False
+        Map.lookup fresh statuses
+            `shouldBe` Just (Completed (Just "fresh"))
+
+    it "rejects spawning a descendant under a closed parent" do
+        registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
+            (\_ _ prompt _ -> pure $ Right LoopResult
+                { finalResponseId = "r"
+                , finalText = Just (messagePayload prompt)
+                , turnsUsed = 1
+                , tokenUsage = emptyTokenUsage
+                })
+            (\_ _ -> pure ())
+        Right parent <- spawnSubagent registry Nothing 0 "parent" Nothing
+        _ <- waitSubagents registry [parent] 15000
+        _ <- closeSubagent registry parent
+        result <- spawnSubagent registry (Just parent) 1 "child" Nothing
+        result `shouldBe` Left "Parent subagent is closed or missing."
 
     it "spawns at a task path and resolves relative targets" do
         registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
@@ -441,6 +530,34 @@ spec = describe "Agent.Subagents" do
         rejected <- spawnSubagentWithCwdForTurn registry (Just ownedTurn)
             (fromFilePath "/tmp") Nothing 0 "too-late" Nothing
         rejected `shouldBe` Left "Root turn was aborted."
+        closeSubagentRegistry registry
+
+    it "can restart an interrupted agent in a later root turn" do
+        started <- newEmptyTMVarIO
+        registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
+            (\_ _ prompt _ ->
+                if messagePayload prompt == "first"
+                    then atomically (putTMVar started ()) >> atomically retry
+                    else pure $ Right LoopResult
+                        { finalResponseId = "second"
+                        , finalText = Just (messagePayload prompt)
+                        , turnsUsed = 1
+                        , tokenUsage = emptyTokenUsage
+                        })
+            (\_ _ -> pure ())
+        firstTurn <- beginRootTurn registry
+        secondTurn <- beginRootTurn registry
+        Right agentId <- spawnSubagentWithCwdForTurn registry (Just firstTurn)
+            (fromFilePath "/tmp") Nothing 0 "first" Nothing
+        atomically $ takeTMVar started
+        abortRootTurn registry firstTurn
+        getStatus registry agentId `shouldReturn` Interrupted
+        Right _ <- sendInputMessageForTurn registry (Just secondTurn)
+            taskPathRoot agentId (plainInterAgentContent "second") False
+        (statuses, timedOut) <- waitSubagents registry [agentId] 15000
+        timedOut `shouldBe` False
+        Map.lookup agentId statuses
+            `shouldBe` Just (Completed (Just "second"))
         closeSubagentRegistry registry
 
     it "removes failed-turn follow-ups queued behind unrelated work" do

--- a/packages/agent-core/test/Agent/Tools/GrokSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/GrokSpec.hs
@@ -281,6 +281,16 @@ spec = describe "Agent.Tools.Grok" do
             closeGrokSession session
             doesFileExist (toFilePath shell.shellEnvFile) `shouldReturn` False
 
+    it "stops background commands when the session closes" do
+        withTempSession \(session, ghci) -> do
+            let escaped = toFilePath session.grokEnv.toolCwd </> "escaped"
+            started <- runTool session ghci "run_terminal_cmd"
+                "{\"command\":\"sleep 1; touch escaped\",\"description\":\"cleanup test\",\"background\":true}"
+            started `shouldSatisfy` Text.isInfixOf "task_id:"
+            closeGrokSession session
+            threadDelay 1500000
+            doesFileExist escaped `shouldReturn` False
+
     describe "hasUnwaitedBackgroundOp" do
         it "detects a trailing bare ampersand" do
             hasUnwaitedBackgroundOp "sleep 1 &" `shouldBe` True

--- a/packages/agent-core/test/Spec.hs
+++ b/packages/agent-core/test/Spec.hs
@@ -5,6 +5,7 @@ import qualified Agent.ErrorSpec as ErrorSpec
 import qualified Agent.JsonTextSpec as JsonTextSpec
 import qualified Agent.LoopSpec as LoopSpec
 import qualified Agent.ProjectInstructionsSpec as ProjectInstructionsSpec
+import qualified Agent.ResourceScopeSpec as ResourceScopeSpec
 import qualified Agent.SubagentsSpec as SubagentsSpec
 import qualified Agent.Subagents.TaskPathSpec as TaskPathSpec
 import qualified Agent.ToolArgsSpec as ToolArgsSpec
@@ -28,6 +29,7 @@ main = hspec do
     JsonTextSpec.spec
     LoopSpec.spec
     ProjectInstructionsSpec.spec
+    ResourceScopeSpec.spec
     SubagentsSpec.spec
     TaskPathSpec.spec
     ToolArgsSpec.spec


### PR DESCRIPTION
## Summary

- add an IO-facing `ResourceScope` backed by `ResourceT` without threading `MonadResource` through provider APIs
- scope coding tool sessions, Grok background processes, and subagent worker asyncs with explicit early release
- serialize subagent lifecycle transitions and fix worker publication, reset, close, resume, and descendant-admission races
- replace manually managed wait helper asyncs with structured `race`
- preserve latest OsPath and encrypted inter-agent message behavior

## Validation

- `agent-core` test suite in GHCi: 153 examples, 0 failures
- multi-package GHCi load: 120 modules loaded (`agent-cli`, `agent-core`, `agent-openai`, `agent-xai`, `agent-openrouter`)
- `git diff --check`