### PR TITLE
fix(cli): preserve pasted image aspect ratio

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/ImagePreview.hs
+++ b/packages/agent-cli/src/Agent/CLI/ImagePreview.hs
@@ -82,9 +82,15 @@ detectImagePreviewProtocol handle = do
 -- | Kitty graphics transmit-and-display. @f=100@ is PNG; Kitty has no JPEG
 -- format code (24/32 are raw RGB/RGBA). We always send 100 and let the
 -- terminal sniff, matching Grok Build's overlay path for PNG screenshots.
+--
+-- Only @r@ is specified for the placement. Per the Kitty graphics protocol,
+-- omitting @c@ makes the terminal derive the width from the source image and
+-- cell dimensions, preserving the original aspect ratio. Supplying both
+-- dimensions would stretch every image into the same cell rectangle.
+--
 -- Chunked at 4096 encoded bytes (Kitty's documented payload limit).
 kittyImageSequence :: Int -> Int -> Int -> Text -> ByteString -> Text
-kittyImageSequence imageId columns rows mime bytes =
+kittyImageSequence imageId _columns rows mime bytes =
     let fmt = kittyFormat mime
         chunks = chunkBytes 4096 (Base64.encode bytes)
         total = length chunks
@@ -94,9 +100,7 @@ kittyImageSequence imageId columns rows mime bytes =
                     | n == 0 =
                         ",f="
                             <> Text.pack (show fmt)
-                            <> ",t=d,c="
-                            <> Text.pack (show columns)
-                            <> ",r="
+                            <> ",t=d,r="
                             <> Text.pack (show rows)
                             <> ",C=1"
                     | otherwise = ""
@@ -111,8 +115,6 @@ kittyImageSequence imageId columns rows mime bytes =
         display =
             "\ESC_Ga=p,i="
                 <> Text.pack (show imageId)
-                <> ",c="
-                <> Text.pack (show columns)
                 <> ",r="
                 <> Text.pack (show rows)
                 <> ",C=1,q=2\ESC\\"

--- a/packages/agent-cli/test/Agent/CLI/ImagePreviewSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ImagePreviewSpec.hs
@@ -35,10 +35,11 @@ spec = do
             previewColumnsFor 30 `shouldBe` 12
 
     describe "kittyImageSequence" do
-        it "transmits PNG with f=100, then places the image" do
+        it "specifies only rows so Kitty preserves the source aspect ratio" do
             let seq_ = kittyImageSequence 7 20 6 "image/png" "png-bytes"
-            seq_ `shouldSatisfy` Text.isInfixOf "\ESC_Ga=t,q=2,i=7,f=100,t=d,c=20,r=6,C=1,m=0;"
-            seq_ `shouldSatisfy` Text.isInfixOf "\ESC_Ga=p,i=7,c=20,r=6,C=1,q=2\ESC\\"
+            seq_ `shouldSatisfy` Text.isInfixOf "\ESC_Ga=t,q=2,i=7,f=100,t=d,r=6,C=1,m=0;"
+            seq_ `shouldSatisfy` Text.isInfixOf "\ESC_Ga=p,i=7,r=6,C=1,q=2\ESC\\"
+            seq_ `shouldSatisfy` (not . Text.isInfixOf ",c=")
             -- payload is base64 of the raw bytes
             seq_ `shouldSatisfy` Text.isInfixOf "cG5nLWJ5dGVz"
 


### PR DESCRIPTION
## Summary

- stop forcing Kitty image previews into a fixed column-by-row rectangle
- let Kitty derive the preview width from the source image and terminal cell geometry
- keep the existing fixed row cap and iTerm2 `preserveAspectRatio=1` behavior
- add a regression assertion that Kitty preview sequences omit `c=`

## Verification

- focused `kittyImageSequence` tests in GHCi: 3 passed
- broader image preview tests in GHCi: 7 passed
- tmux real-TTY smoke test with an actual PNG
- confirmed the emitted Kitty transmit and placement headers specify only `r=` and contain no fixed `c=`
