### PR TITLE
fix(cli): default OpenAI OAuth client id

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Auth.hs
+++ b/packages/agent-cli/src/Agent/CLI/Auth.hs
@@ -3,6 +3,7 @@ module Agent.CLI.Auth
     ( LoadedAuth(..)
     , grokCredentialFromAuthJson
     , loadAuth
+    , openAIOAuthClientId
     , openaiAuthStateFromJson
     , reloadableFileCredentialProvider
     ) where
@@ -46,6 +47,10 @@ import Data.Time.Clock (UTCTime, addUTCTime, getCurrentTime)
 import System.Directory.OsPath (doesFileExist, getHomeDirectory)
 import System.Environment (lookupEnv)
 import System.OsPath ((</>))
+
+openAIOAuthClientId :: Maybe Text -> Text
+openAIOAuthClientId =
+    fromMaybe "app_EMoamEEZ73f0CkXaXp7hrann"
 
 data LoadedAuth = LoadedAuth
     { loadedProvider :: !Provider
@@ -200,27 +205,24 @@ loadManagedOpenAI now metadata secret =
                     pure $ Left
                         "managed OpenAI OAuth credential contains invalid auth JSON"
                 Just state -> do
-                    clientId <- lookupNonEmpty "OPENAI_OAUTH_CLIENT_ID"
-                    let refresh stale = case clientId of
-                            Nothing ->
-                                pure $ Left $ ProviderError AuthenticationError
-                                    "OPENAI_OAUTH_CLIENT_ID is required to refresh ChatGPT OAuth"
-                                    Nothing
-                            Just oauthClientId ->
-                                OpenAI.refreshAccessTokenHTTP oauthClientId stale >>= \case
-                                    Left err -> pure (Left err)
-                                    Right newState -> do
-                                        stamped <- authStateToJson newState <$> getCurrentTime
-                                        let payload =
-                                                TextEncoding.decodeUtf8
-                                                    (LBS.toStrict (Aeson.encode stamped))
-                                        upsertManagedCredential
-                                            metadata
-                                            secret { secretPayload = payload }
-                                            >>= \case
-                                                Left err ->
-                                                    pure $ Left $ ConnectionError err
-                                                Right () -> pure (Right newState)
+                    clientId <-
+                        openAIOAuthClientId
+                            <$> lookupNonEmpty "OPENAI_OAUTH_CLIENT_ID"
+                    let refresh stale =
+                            OpenAI.refreshAccessTokenHTTP clientId stale >>= \case
+                                Left err -> pure (Left err)
+                                Right newState -> do
+                                    stamped <- authStateToJson newState <$> getCurrentTime
+                                    let payload =
+                                            TextEncoding.decodeUtf8
+                                                (LBS.toStrict (Aeson.encode stamped))
+                                    upsertManagedCredential
+                                        metadata
+                                        secret { secretPayload = payload }
+                                        >>= \case
+                                            Left err ->
+                                                pure $ Left $ ConnectionError err
+                                            Right () -> pure (Right newState)
                     pool <- OpenAI.newPool [state] refresh
                     tokenProvider <- OpenAICredential.poolTokenProvider pool
                     pure $ Right LoadedAuth
@@ -245,20 +247,17 @@ openAiPoolAuth
     -> OpenAI.AuthState
     -> IO (Either String LoadedAuth)
 openAiPoolAuth persistRefresh filePath state = do
-    clientId <- lookupNonEmpty "OPENAI_OAUTH_CLIENT_ID"
-    let refresh stale = case clientId of
-            Nothing -> pure $ Left $ ProviderError AuthenticationError
-                "OPENAI_OAUTH_CLIENT_ID is required to refresh ChatGPT OAuth"
-                Nothing
-            Just oauthClientId ->
-                OpenAI.refreshAccessTokenHTTP oauthClientId stale >>= \case
-                    Left err -> pure (Left err)
-                    Right newState
-                        | persistRefresh -> do
-                            stamped <- authStateToJson newState <$> getCurrentTime
-                            OpenAILogin.writeAuthFile filePath stamped
-                            pure (Right newState)
-                        | otherwise -> pure (Right newState)
+    clientId <-
+        openAIOAuthClientId <$> lookupNonEmpty "OPENAI_OAUTH_CLIENT_ID"
+    let refresh stale =
+            OpenAI.refreshAccessTokenHTTP clientId stale >>= \case
+                Left err -> pure (Left err)
+                Right newState
+                    | persistRefresh -> do
+                        stamped <- authStateToJson newState <$> getCurrentTime
+                        OpenAILogin.writeAuthFile filePath stamped
+                        pure (Right newState)
+                    | otherwise -> pure (Right newState)
     pool <- OpenAI.newPool [state] refresh
     tokenProvider <- OpenAICredential.poolTokenProvider pool
     pure $ Right LoadedAuth

--- a/packages/agent-cli/src/Agent/CLI/Login.hs
+++ b/packages/agent-cli/src/Agent/CLI/Login.hs
@@ -17,6 +17,7 @@ module Agent.CLI.Login
 
 import Agent.CLI.Auth
     ( grokCredentialFromAuthJson
+    , openAIOAuthClientId
     , openaiAuthStateFromJson
     )
 import Agent.CLI.CredentialStore
@@ -396,40 +397,37 @@ pickConnectProvider color =
         _ -> Right index
 
 connectOpenAI :: Bool -> IO ()
-connectOpenAI color =
-    lookupNonEmpty "OPENAI_OAUTH_CLIENT_ID" >>= \case
-        Nothing ->
-            printLoginMessage color False
-                "set OPENAI_OAUTH_CLIENT_ID before connecting a ChatGPT account"
-        Just clientId -> do
-            let options = OpenAILogin.defaultLoginOptions clientId
-            OpenAILogin.requestDeviceCode options >>= \case
+connectOpenAI color = do
+    clientId <-
+        openAIOAuthClientId <$> lookupNonEmpty "OPENAI_OAUTH_CLIENT_ID"
+    let options = OpenAILogin.defaultLoginOptions clientId
+    OpenAILogin.requestDeviceCode options >>= \case
+        Left err -> printLoginMessage color False err
+        Right device -> do
+            Text.hPutStrLn stderr $
+                roleMuted color "Open "
+                    <> rolePrompt color (Text.pack device.verificationUrl)
+            Text.hPutStrLn stderr $
+                roleMuted color "Enter code "
+                    <> rolePrompt color device.userCode
+            hFlush stderr
+            OpenAILogin.completeDeviceCodeLogin options device >>= \case
                 Left err -> printLoginMessage color False err
-                Right device -> do
-                    Text.hPutStrLn stderr $
-                        roleMuted color "Open "
-                            <> rolePrompt color (Text.pack device.verificationUrl)
-                    Text.hPutStrLn stderr $
-                        roleMuted color "Enter code "
-                            <> rolePrompt color device.userCode
-                    hFlush stderr
-                    OpenAILogin.completeDeviceCodeLogin options device >>= \case
-                        Left err -> printLoginMessage color False err
-                        Right authJson -> do
-                            now <- getCurrentTime
-                            case openaiAuthStateFromJson now (Aeson.encode authJson) of
-                                Nothing ->
-                                    printLoginMessage color False
-                                        "OpenAI login returned invalid account data"
-                                Just auth ->
-                                    storeConnectedCredential color
-                                        OpenAIProvider
-                                        auth.accountId
-                                        "ChatGPT"
-                                        ManagedSubscription
-                                        ManagedOpenAIAuthJson
-                                        (Text.decodeUtf8
-                                            (LBS.toStrict (Aeson.encode authJson)))
+                Right authJson -> do
+                    now <- getCurrentTime
+                    case openaiAuthStateFromJson now (Aeson.encode authJson) of
+                        Nothing ->
+                            printLoginMessage color False
+                                "OpenAI login returned invalid account data"
+                        Just auth ->
+                            storeConnectedCredential color
+                                OpenAIProvider
+                                auth.accountId
+                                "ChatGPT"
+                                ManagedSubscription
+                                ManagedOpenAIAuthJson
+                                (Text.decodeUtf8
+                                    (LBS.toStrict (Aeson.encode authJson)))
 
 connectXAI :: Bool -> IO ()
 connectXAI color =

--- a/packages/agent-cli/test/Agent/CLI/AuthSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/AuthSpec.hs
@@ -22,6 +22,15 @@ import Test.Hspec
 
 spec :: Spec
 spec = do
+    describe "openAIOAuthClientId" do
+        it "uses the Codex public client id by default" do
+            openAIOAuthClientId Nothing
+                `shouldBe` "app_EMoamEEZ73f0CkXaXp7hrann"
+
+        it "allows an application-specific override" do
+            openAIOAuthClientId (Just "custom-client")
+                `shouldBe` "custom-client"
+
     describe "openaiAuthStateFromJson" do
         it "reads the login file tokens object" do
             let encoded = Aeson.encode $ Aeson.object


### PR DESCRIPTION
## Summary
- use the public Codex OAuth client ID by default for ChatGPT device login
- retain `OPENAI_OAUTH_CLIENT_ID` as an optional application override
- use the same resolution for OAuth token refresh
- cover default and override behavior with focused tests

## Validation
- loaded `agent-cli` library and test modules in GHCi
- focused Hspec tests: 2 examples, 0 failures
- `git diff --check`
- tmux TTY smoke test with `OPENAI_OAUTH_CLIENT_ID` unset reached the OpenAI device-code prompt