### PR TITLE
fix(cli): render markdown in streamed responses

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -93,6 +93,7 @@ import Agent.CLI.ProviderTransition
     )
 import Agent.CLI.Render
     ( RenderConfig(..)
+    , emptyMarkdownStreamState
     , putTextLn
     , renderAssistantText
     , renderEvent
@@ -811,8 +812,7 @@ runSession options provider policy tools toolEnv planMode prompt pendingTurn una
     attachmentsRef <- newIORef []
     previewIdRef <- newIORef (1 :: Int)
     textBuffer <- newIORef ""
-    markdownBuffer <- newIORef ""
-    markdownContext <- newIORef Nothing
+    markdownState <- newIORef emptyMarkdownStreamState
     liveActive <- newIORef False
     thinkingVisible <- newIORef False
     spinnerRef <- newIORef Nothing
@@ -886,8 +886,7 @@ runSession options provider policy tools toolEnv planMode prompt pendingTurn una
             , renderColor = useColor
             , renderPrintedText = printed
             , renderTextBuffer = textBuffer
-            , renderMarkdownBuffer = markdownBuffer
-            , renderMarkdownContext = markdownContext
+            , renderMarkdownState = markdownState
             , renderLiveActive = liveActive
             , renderLock = ioLock
             , renderStdout = stdout

--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -811,6 +811,8 @@ runSession options provider policy tools toolEnv planMode prompt pendingTurn una
     attachmentsRef <- newIORef []
     previewIdRef <- newIORef (1 :: Int)
     textBuffer <- newIORef ""
+    markdownBuffer <- newIORef ""
+    markdownContext <- newIORef Nothing
     liveActive <- newIORef False
     thinkingVisible <- newIORef False
     spinnerRef <- newIORef Nothing
@@ -884,6 +886,8 @@ runSession options provider policy tools toolEnv planMode prompt pendingTurn una
             , renderColor = useColor
             , renderPrintedText = printed
             , renderTextBuffer = textBuffer
+            , renderMarkdownBuffer = markdownBuffer
+            , renderMarkdownContext = markdownContext
             , renderLiveActive = liveActive
             , renderLock = ioLock
             , renderStdout = stdout

--- a/packages/agent-cli/src/Agent/CLI/Markdown.hs
+++ b/packages/agent-cli/src/Agent/CLI/Markdown.hs
@@ -1,6 +1,8 @@
 -- | Turn CommonMark-ish assistant text into ANSI-styled terminal output.
 module Agent.CLI.Markdown
     ( renderMarkdown
+    , renderMarkdownFragment
+    , splitMarkdownFragment
     ) where
 
 import Agent.CLI.Style
@@ -272,7 +274,14 @@ styleTableRow isHeader widths cells =
     in bar <> Text.intercalate bar (take (length widths) parts) <> bar
 
 styleInline :: Text -> Text
-styleInline = Text.concat . go Nothing
+styleInline = renderMarkdownFragment True Nothing
+
+-- | Render an inline markdown fragment whose first character may continue
+-- prose emitted by an earlier streaming chunk.
+renderMarkdownFragment :: Bool -> Maybe Char -> Text -> Text
+renderMarkdownFragment color prevChar text
+    | not color = text
+    | otherwise = Text.concat (go prevChar (Text.filter (/= '\ESC') text))
   where
     go :: Maybe Char -> Text -> [Text]
     go prev t
@@ -316,6 +325,76 @@ styleInline = Text.concat . go Nothing
         , SetUnderlining SingleUnderline
         ]
     urlStyle = [fg solarizedBase01]
+
+-- | Split an inline markdown stream into a prefix that can be rendered without
+-- future input and a suffix beginning at a possibly incomplete construct.
+--
+-- This lets the TUI remain append-only while holding delimiters such as @**@
+-- until their closing delimiter arrives. A newline makes an unmatched inline
+-- construct literal because the renderer does not span inline markup across
+-- lines.
+splitMarkdownFragment :: Maybe Char -> Text -> (Text, Text, Maybe Char)
+splitMarkdownFragment initialPrev = go initialPrev []
+  where
+    go prev chunks t
+        | Text.null t = (Text.concat (reverse chunks), "", prev)
+        | Just (code, rest) <- takeInlineCode t =
+            consume (lastChar code) rest
+        | Just (_linkText, _url, rest) <- takeLink t =
+            consume (Just ')') rest
+        | Just (inner, rest) <- takeEmphasis prev "**" t =
+            consume (lastChar inner) rest
+        | Just (inner, rest) <- takeEmphasis prev "__" t =
+            consume (lastChar inner) rest
+        | Just (inner, rest) <- takeEmphasis prev "*" t =
+            consume (lastChar inner) rest
+        | Just (inner, rest) <- takeEmphasis prev "_" t =
+            consume (lastChar inner) rest
+        | shouldWait prev t =
+            (Text.concat (reverse chunks), t, prev)
+        | otherwise =
+            let (plain, rest) = Text.break (`elem` ['`', '[', '*', '_']) t
+            in if Text.null plain
+                then
+                    let literal = Text.take 1 t
+                    in go (lastChar literal) (literal : chunks) (Text.drop 1 t)
+                else go (lastChar plain) (plain : chunks) rest
+      where
+        consume nextPrev rest =
+            let consumedLength = Text.length t - Text.length rest
+                consumed = Text.take consumedLength t
+            in go nextPrev (consumed : chunks) rest
+
+    shouldWait prev t
+        | Text.any (== '\n') t = False
+        | Text.isPrefixOf "`" t = True
+        | Text.isPrefixOf "[" t = incompleteLink t
+        | Text.isPrefixOf "**" t = potentialEmphasis prev "**" t
+        | Text.isPrefixOf "__" t = potentialEmphasis prev "__" t
+        | Text.isPrefixOf "*" t = potentialEmphasis prev "*" t
+        | Text.isPrefixOf "_" t = potentialEmphasis prev "_" t
+        | otherwise = False
+
+    incompleteLink t =
+        case Text.breakOn "]" (Text.drop 1 t) of
+            (_, rest) | Text.null rest -> True
+            (_, rest) ->
+                let afterBracket = Text.drop 1 rest
+                in Text.null afterBracket
+                    || (Text.isPrefixOf "(" afterBracket
+                        && not (")" `Text.isInfixOf` Text.drop 1 afterBracket))
+
+    potentialEmphasis prev delim t =
+        let after = Text.drop (Text.length delim) t
+        in case Text.uncons after of
+            Nothing -> True
+            Just (first, _)
+                | isSpace first -> False
+                | delim == "_" || delim == "__" ->
+                    maybe True (not . isWordChar) prev
+                | otherwise -> True
+
+    lastChar value = snd <$> Text.unsnoc value
 
 takeInlineCode :: Text -> Maybe (Text, Text)
 takeInlineCode t =

--- a/packages/agent-cli/src/Agent/CLI/Render.hs
+++ b/packages/agent-cli/src/Agent/CLI/Render.hs
@@ -21,7 +21,11 @@ module Agent.CLI.Render
     , wrapThinkingLines
     ) where
 
-import Agent.CLI.Markdown (renderMarkdown)
+import Agent.CLI.Markdown
+    ( renderMarkdown
+    , renderMarkdownFragment
+    , splitMarkdownFragment
+    )
 import Agent.CLI.Progress
     ( osc9ProgressIndeterminate
     , osc9ProgressRemove
@@ -78,6 +82,10 @@ data RenderConfig = RenderConfig
     , renderColor :: !Bool
     , renderPrintedText :: !(IORef Bool)
     , renderTextBuffer :: !(IORef Text)
+    -- | Unemitted suffix beginning at a possibly incomplete inline construct.
+    , renderMarkdownBuffer :: !(IORef Text)
+    -- | Last visible source character emitted before 'renderMarkdownBuffer'.
+    , renderMarkdownContext :: !(IORef (Maybe Char))
     -- | True after assistant text has been streamed for the current round.
     , renderLiveActive :: !(IORef Bool)
     , renderLock :: !(MVar ())
@@ -113,6 +121,8 @@ renderEventUnlocked config = \case
         appendReasoningUnlocked config delta
     TurnStarted -> do
         writeIORef config.renderTextBuffer ""
+        writeIORef config.renderMarkdownBuffer ""
+        writeIORef config.renderMarkdownContext Nothing
         writeIORef config.renderLiveActive False
         writeIORef config.renderReasoningBuffer ""
         writeIORef config.renderActivityRef "Thinking…"
@@ -150,23 +160,33 @@ renderAssistantText :: Bool -> Text -> Text
 renderAssistantText color text =
     paintBackgroundLines color agentBackground (renderMarkdown color text)
 
--- | Stream assistant text append-only.
+-- | Stream assistant text append-only while buffering incomplete inline
+-- markdown constructs. Once a closing delimiter arrives, the whole construct
+-- is emitted with styling and neither delimiter reaches the terminal.
 --
 -- Repainting the full accumulated response with DECSC/DECRC looks correct
 -- inside the current viewport, but once a repaint scrolls the terminal the
 -- previous frame has already entered scrollback and cannot be erased. Long
--- responses therefore appeared there many times. Markdown styling that needs
--- future context is reserved for non-streaming responses.
+-- responses therefore appeared there many times.
 streamAssistantDelta :: RenderConfig -> Text -> IO ()
 streamAssistantDelta config delta
     | Text.null delta = pure ()
     | otherwise = do
         let safe = Text.filter (/= '\ESC') delta
-        writeIORef config.renderPrintedText True
-        writeIORef config.renderLiveActive True
-        Text.hPutStr config.renderStdout
-            (paintBackgroundLines True agentBackground safe)
-        hFlush config.renderStdout
+        pending <- readIORef config.renderMarkdownBuffer
+        context <- readIORef config.renderMarkdownContext
+        let (ready, pending', nextContext) =
+                splitMarkdownFragment context (pending <> safe)
+        writeIORef config.renderMarkdownBuffer pending'
+        unless (Text.null ready) do
+            writeIORef config.renderPrintedText True
+            writeIORef config.renderLiveActive True
+            writeIORef config.renderMarkdownContext nextContext
+            Text.hPutStr config.renderStdout
+                ( paintBackgroundLines True agentBackground
+                    (renderMarkdownFragment True context ready)
+                )
+            hFlush config.renderStdout
 
 -- | End-of-turn: keep live paint when deltas already drew; otherwise paint
 -- once from the buffer or completed 'assistantText' (non-streaming backends).
@@ -175,11 +195,21 @@ finalizeAssistantBuffer :: RenderConfig -> Maybe Text -> IO Bool
 finalizeAssistantBuffer config assistantText = do
     buffered <- readIORef config.renderTextBuffer
     writeIORef config.renderTextBuffer ""
+    pending <- readIORef config.renderMarkdownBuffer
+    writeIORef config.renderMarkdownBuffer ""
+    context <- readIORef config.renderMarkdownContext
+    writeIORef config.renderMarkdownContext Nothing
     live <- readIORef config.renderLiveActive
     writeIORef config.renderLiveActive False
     if live
         then do
             writeIORef config.renderPrintedText True
+            unless (Text.null pending) do
+                Text.hPutStr config.renderStdout
+                    ( paintBackgroundLines True agentBackground
+                        (renderMarkdownFragment True context pending)
+                    )
+                hFlush config.renderStdout
             pure True
         else do
             let raw

--- a/packages/agent-cli/src/Agent/CLI/Render.hs
+++ b/packages/agent-cli/src/Agent/CLI/Render.hs
@@ -1,8 +1,10 @@
 -- | Stream renderer and mutating-tool approval prompts.
 module Agent.CLI.Render
-    ( RenderConfig(..)
+    ( MarkdownStreamState
+    , RenderConfig(..)
     , clearThinking
     , commitThinking
+    , emptyMarkdownStreamState
     , formatActivityLine
     , formatElapsed
     , formatLoopError
@@ -82,10 +84,7 @@ data RenderConfig = RenderConfig
     , renderColor :: !Bool
     , renderPrintedText :: !(IORef Bool)
     , renderTextBuffer :: !(IORef Text)
-    -- | Unemitted suffix beginning at a possibly incomplete inline construct.
-    , renderMarkdownBuffer :: !(IORef Text)
-    -- | Last visible source character emitted before 'renderMarkdownBuffer'.
-    , renderMarkdownContext :: !(IORef (Maybe Char))
+    , renderMarkdownState :: !(IORef MarkdownStreamState)
     -- | True after assistant text has been streamed for the current round.
     , renderLiveActive :: !(IORef Bool)
     , renderLock :: !(MVar ())
@@ -96,6 +95,14 @@ data RenderConfig = RenderConfig
     , renderStartedAt :: !(IORef (Maybe UTCTime))
     , renderNativeProgress :: !Bool -- ^ Ghostty / WT OSC 9;4; off in tests
     }
+
+data MarkdownStreamState = MarkdownStreamState
+    { pending :: !Text
+    , context :: !(Maybe Char)
+    }
+
+emptyMarkdownStreamState :: MarkdownStreamState
+emptyMarkdownStreamState = MarkdownStreamState "" Nothing
 
 -- | Grok-build @max_thoughts_width@: wrap reasoning display at this column.
 thinkingMaxWidth :: Int
@@ -121,8 +128,7 @@ renderEventUnlocked config = \case
         appendReasoningUnlocked config delta
     TurnStarted -> do
         writeIORef config.renderTextBuffer ""
-        writeIORef config.renderMarkdownBuffer ""
-        writeIORef config.renderMarkdownContext Nothing
+        writeIORef config.renderMarkdownState emptyMarkdownStreamState
         writeIORef config.renderLiveActive False
         writeIORef config.renderReasoningBuffer ""
         writeIORef config.renderActivityRef "Thinking…"
@@ -173,15 +179,15 @@ streamAssistantDelta config delta
     | Text.null delta = pure ()
     | otherwise = do
         let safe = Text.filter (/= '\ESC') delta
-        pending <- readIORef config.renderMarkdownBuffer
-        context <- readIORef config.renderMarkdownContext
-        let (ready, pending', nextContext) =
-                splitMarkdownFragment context (pending <> safe)
-        writeIORef config.renderMarkdownBuffer pending'
+        (ready, context) <-
+            atomicModifyIORef' config.renderMarkdownState \state ->
+                let (ready, pending', nextContext) =
+                        splitMarkdownFragment state.context (state.pending <> safe)
+                    state' = MarkdownStreamState pending' nextContext
+                in (state', (ready, state.context))
         unless (Text.null ready) do
             writeIORef config.renderPrintedText True
             writeIORef config.renderLiveActive True
-            writeIORef config.renderMarkdownContext nextContext
             Text.hPutStr config.renderStdout
                 ( paintBackgroundLines True agentBackground
                     (renderMarkdownFragment True context ready)
@@ -195,10 +201,9 @@ finalizeAssistantBuffer :: RenderConfig -> Maybe Text -> IO Bool
 finalizeAssistantBuffer config assistantText = do
     buffered <- readIORef config.renderTextBuffer
     writeIORef config.renderTextBuffer ""
-    pending <- readIORef config.renderMarkdownBuffer
-    writeIORef config.renderMarkdownBuffer ""
-    context <- readIORef config.renderMarkdownContext
-    writeIORef config.renderMarkdownContext Nothing
+    (pending, context) <-
+        atomicModifyIORef' config.renderMarkdownState \state ->
+            (emptyMarkdownStreamState, (state.pending, state.context))
     live <- readIORef config.renderLiveActive
     writeIORef config.renderLiveActive False
     if live

--- a/packages/agent-cli/test/Agent/CLI/MarkdownSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/MarkdownSpec.hs
@@ -1,6 +1,10 @@
 module Agent.CLI.MarkdownSpec (spec) where
 
-import Agent.CLI.Markdown (renderMarkdown)
+import Agent.CLI.Markdown
+    ( renderMarkdown
+    , renderMarkdownFragment
+    , splitMarkdownFragment
+    )
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Test.Hspec
@@ -138,3 +142,42 @@ spec = do
             let out = renderMarkdown True "see `file.txt` now"
             -- Nested Reset must re-open Solarized base03 so line painting sticks.
             out `shouldSatisfy` Text.isInfixOf "\ESC[0;48;2;0;43;54m"
+
+    describe "splitMarkdownFragment" do
+        it "holds a bold span until its closing delimiter arrives" do
+            let (ready1, pending1, context1) =
+                    splitMarkdownFragment Nothing "say **"
+                (ready2, pending2, context2) =
+                    splitMarkdownFragment context1 (pending1 <> "hello")
+                (ready3, pending3, _context3) =
+                    splitMarkdownFragment context2 (pending2 <> "** there")
+                out = renderMarkdownFragment True context2 ready3
+            ready1 `shouldBe` "say "
+            pending1 `shouldBe` "**"
+            ready2 `shouldBe` ""
+            pending2 `shouldBe` "**hello"
+            pending3 `shouldBe` ""
+            stripAnsi out `shouldBe` "hello there"
+
+        it "handles a bold delimiter split one star at a time" do
+            let (ready1, pending1, context1) =
+                    splitMarkdownFragment Nothing "*"
+                (ready2, pending2, context2) =
+                    splitMarkdownFragment context1 (pending1 <> "*a*")
+                (ready3, pending3, _context3) =
+                    splitMarkdownFragment context2 (pending2 <> "*")
+            ready1 `shouldBe` ""
+            ready2 `shouldBe` ""
+            pending3 `shouldBe` ""
+            stripAnsi (renderMarkdownFragment True context2 ready3)
+                `shouldBe` "a"
+
+        it "does not turn a chunked snake_case identifier into emphasis" do
+            let (ready1, pending1, context1) =
+                    splitMarkdownFragment Nothing "snake"
+                (ready2, pending2, _context2) =
+                    splitMarkdownFragment context1 (pending1 <> "_case_name")
+            pending2 `shouldBe` ""
+            renderMarkdownFragment True Nothing ready1
+                <> renderMarkdownFragment True context1 ready2
+                `shouldBe` "snake_case_name"

--- a/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
@@ -185,11 +185,13 @@ spec = do
                 body `shouldSatisfy` (not . Text.isInfixOf "secret plan")
                 body `shouldSatisfy` (not . Text.isInfixOf "Thought for")
 
-        it "streams TextDelta append-only in color mode" do
+        it "styles inline markdown while streaming append-only in color mode" do
             withRenderConfig False True \config handle path -> do
-                renderEvent config (TextDelta "see `file.txt`")
+                renderEvent config (TextDelta "say **")
+                renderEvent config (TextDelta "hello")
+                renderEvent config (TextDelta "** there")
                 buffered <- readIORef config.renderTextBuffer
-                buffered `shouldBe` "see `file.txt`"
+                buffered `shouldBe` "say **hello** there"
                 live <- readIORef config.renderLiveActive
                 live `shouldBe` True
                 printed <- readIORef config.renderPrintedText
@@ -202,24 +204,37 @@ spec = do
                     })
                 hClose handle
                 body <- Text.readFile path
-                body `shouldSatisfy` Text.isInfixOf "file.txt"
+                body `shouldSatisfy` Text.isInfixOf "hello"
                 body `shouldSatisfy` Text.isInfixOf "\ESC["
                 body `shouldSatisfy` Text.isInfixOf "\ESC[48;2;0;43;54m"
-                body `shouldSatisfy` Text.isInfixOf "`file.txt`"
+                body `shouldSatisfy` (not . Text.isInfixOf "**")
                 readIORef config.renderLiveActive `shouldReturn` False
 
         it "does not repaint earlier content across deltas" do
             withRenderConfig False True \config handle path -> do
-                renderEvent config (TextDelta "see `fi")
-                renderEvent config (TextDelta "le.txt`")
+                renderEvent config (TextDelta "first ")
+                renderEvent config (TextDelta "second")
                 hClose handle
                 body <- Text.readFile path
-                body `shouldSatisfy` Text.isInfixOf "see `fi"
-                body `shouldSatisfy` Text.isInfixOf "le.txt`"
-                Text.count "see " body `shouldBe` 1
+                body `shouldSatisfy` Text.isInfixOf "first "
+                body `shouldSatisfy` Text.isInfixOf "second"
+                Text.count "first " body `shouldBe` 1
                 body `shouldSatisfy` Text.isInfixOf "\ESC["
                 body `shouldSatisfy` (not . Text.isInfixOf "\ESC7")
                 body `shouldSatisfy` (not . Text.isInfixOf "\ESC8")
+
+        it "flushes an unmatched inline delimiter literally at turn end" do
+            withRenderConfig False True \config handle path -> do
+                renderEvent config (TextDelta "say **unfinished")
+                renderEvent config (TurnFinished TurnOutput
+                    { responseId = "r1"
+                    , toolCalls = []
+                    , assistantText = Nothing
+                    , tokenUsage = emptyTokenUsage
+                    })
+                hClose handle
+                body <- Text.readFile path
+                body `shouldSatisfy` Text.isInfixOf "**unfinished"
 
         it "flushes pre-tool assistant prose before tool lines" do
             withRenderConfig False True \config handle path -> do
@@ -345,6 +360,8 @@ withRenderConfigNative showThinking color native action = do
     activityRef <- newIORef "Thinking…"
     startedAt <- newIORef Nothing
     textBuffer <- newIORef ""
+    markdownBuffer <- newIORef ""
+    markdownContext <- newIORef Nothing
     liveActive <- newIORef False
     lock <- newMVar ()
     tmp <- getTemporaryDirectory
@@ -359,6 +376,8 @@ withRenderConfigNative showThinking color native action = do
                 , renderColor = color
                 , renderPrintedText = printed
                 , renderTextBuffer = textBuffer
+                , renderMarkdownBuffer = markdownBuffer
+                , renderMarkdownContext = markdownContext
                 , renderLiveActive = liveActive
                 , renderLock = lock
                 , renderStdout = handle

--- a/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
@@ -360,8 +360,7 @@ withRenderConfigNative showThinking color native action = do
     activityRef <- newIORef "Thinking…"
     startedAt <- newIORef Nothing
     textBuffer <- newIORef ""
-    markdownBuffer <- newIORef ""
-    markdownContext <- newIORef Nothing
+    markdownState <- newIORef emptyMarkdownStreamState
     liveActive <- newIORef False
     lock <- newMVar ()
     tmp <- getTemporaryDirectory
@@ -376,8 +375,7 @@ withRenderConfigNative showThinking color native action = do
                 , renderColor = color
                 , renderPrintedText = printed
                 , renderTextBuffer = textBuffer
-                , renderMarkdownBuffer = markdownBuffer
-                , renderMarkdownContext = markdownContext
+                , renderMarkdownState = markdownState
                 , renderLiveActive = liveActive
                 , renderLock = lock
                 , renderStdout = handle


### PR DESCRIPTION
## Summary

- render inline Markdown while assistant text streams instead of writing raw delimiters
- buffer incomplete emphasis, code, and link constructs across token boundaries
- preserve append-only terminal output to avoid duplicate scrollback
- flush unmatched delimiters literally and reset Markdown state between turns

## Verification

- `nix develop -c cabal repl agent-cli:test:agent-cli-test` → 312 examples, 0 failures
- loaded the full `agent-cli` library in the Cabal REPL
- exercised the live agent in tmux; `**bold** and \`code\`` rendered with ANSI styling and without visible delimiters or cursor repaint sequences
