### PR TITLE
fix(cli): default Grok OAuth client id

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Auth.hs
+++ b/packages/agent-cli/src/Agent/CLI/Auth.hs
@@ -6,6 +6,7 @@ module Agent.CLI.Auth
     , openAIOAuthClientId
     , openaiAuthStateFromJson
     , reloadableFileCredentialProvider
+    , xaiOAuthClientId
     ) where
 
 import Agent.Broker (BrokerOptions(..), newBrokerTokenProviderFor)
@@ -51,6 +52,10 @@ import System.OsPath ((</>))
 openAIOAuthClientId :: Maybe Text -> Text
 openAIOAuthClientId =
     fromMaybe "app_EMoamEEZ73f0CkXaXp7hrann"
+
+xaiOAuthClientId :: Maybe Text -> Text
+xaiOAuthClientId =
+    fromMaybe "b1a00492-073a-47ea-816f-4c329264a828"
 
 data LoadedAuth = LoadedAuth
     { loadedProvider :: !Provider

--- a/packages/agent-cli/src/Agent/CLI/Login.hs
+++ b/packages/agent-cli/src/Agent/CLI/Login.hs
@@ -19,6 +19,7 @@ import Agent.CLI.Auth
     ( grokCredentialFromAuthJson
     , openAIOAuthClientId
     , openaiAuthStateFromJson
+    , xaiOAuthClientId
     )
 import Agent.CLI.CredentialStore
     ( ManagedAuthKind(..)
@@ -430,43 +431,40 @@ connectOpenAI color = do
                                     (LBS.toStrict (Aeson.encode authJson)))
 
 connectXAI :: Bool -> IO ()
-connectXAI color =
-    lookupNonEmpty "XAI_OAUTH_CLIENT_ID" >>= \case
-        Nothing ->
-            printLoginMessage color False
-                "set XAI_OAUTH_CLIENT_ID before connecting a Grok account"
-        Just clientId -> do
-            let options = XAIAuth.defaultOAuthOptions clientId
-            XAIAuth.requestDeviceAuthorization options >>= \case
+connectXAI color = do
+    clientId <-
+        xaiOAuthClientId <$> lookupNonEmpty "XAI_OAUTH_CLIENT_ID"
+    let options = XAIAuth.defaultOAuthOptions clientId
+    XAIAuth.requestDeviceAuthorization options >>= \case
+        Left err -> printLoginMessage color False err
+        Right device -> do
+            Text.hPutStrLn stderr $
+                roleMuted color "Open "
+                    <> rolePrompt color device.verificationUrl
+            Text.hPutStrLn stderr $
+                roleMuted color "Enter code "
+                    <> rolePrompt color device.userCode
+            hFlush stderr
+            XAIAuth.completeDeviceAuthorization options device >>= \case
                 Left err -> printLoginMessage color False err
-                Right device -> do
-                    Text.hPutStrLn stderr $
-                        roleMuted color "Open "
-                            <> rolePrompt color device.verificationUrl
-                    Text.hPutStrLn stderr $
-                        roleMuted color "Enter code "
-                            <> rolePrompt color device.userCode
-                    hFlush stderr
-                    XAIAuth.completeDeviceAuthorization options device >>= \case
-                        Left err -> printLoginMessage color False err
-                        Right tokens -> do
-                            let accountId =
-                                    fromMaybe "grok"
-                                        (XAIAuth.accountIdFromAccessToken
-                                            tokens.accessToken)
-                                authJson = Aeson.object
-                                    [ "access_token" .= tokens.accessToken
-                                    , "refresh_token" .= tokens.refreshToken
-                                    , "id_token" .= tokens.idToken
-                                    ]
-                            storeConnectedCredential color
-                                XAIProvider
-                                accountId
-                                "Grok"
-                                ManagedSubscription
-                                ManagedGrokAuthJson
-                                (Text.decodeUtf8
-                                    (LBS.toStrict (Aeson.encode authJson)))
+                Right tokens -> do
+                    let accountId =
+                            fromMaybe "grok"
+                                (XAIAuth.accountIdFromAccessToken
+                                    tokens.accessToken)
+                        authJson = Aeson.object
+                            [ "access_token" .= tokens.accessToken
+                            , "refresh_token" .= tokens.refreshToken
+                            , "id_token" .= tokens.idToken
+                            ]
+                    storeConnectedCredential color
+                        XAIProvider
+                        accountId
+                        "Grok"
+                        ManagedSubscription
+                        ManagedGrokAuthJson
+                        (Text.decodeUtf8
+                            (LBS.toStrict (Aeson.encode authJson)))
 
 connectOpenRouter :: Bool -> IO ()
 connectOpenRouter color =

--- a/packages/agent-cli/test/Agent/CLI/AuthSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/AuthSpec.hs
@@ -31,6 +31,15 @@ spec = do
             openAIOAuthClientId (Just "custom-client")
                 `shouldBe` "custom-client"
 
+    describe "xaiOAuthClientId" do
+        it "uses the Grok CLI public client id by default" do
+            xaiOAuthClientId Nothing
+                `shouldBe` "b1a00492-073a-47ea-816f-4c329264a828"
+
+        it "allows an application-specific override" do
+            xaiOAuthClientId (Just "custom-client")
+                `shouldBe` "custom-client"
+
     describe "openaiAuthStateFromJson" do
         it "reads the login file tokens object" do
             let encoded = Aeson.encode $ Aeson.object


### PR DESCRIPTION
## Summary
- use the public Grok CLI OAuth client ID by default for device login
- retain `XAI_OAUTH_CLIENT_ID` as an optional application override
- cover default and override behavior with focused tests

## Validation
- loaded the `agent-cli` test suite in GHCi
- focused Hspec tests: 2 examples, 0 failures
- `git diff --check`
- tmux TTY smoke test with `XAI_OAUTH_CLIENT_ID` unset reached the xAI device-code prompt