### PR TITLE
Retry persistent file operations on busy locks

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Auth.hs
+++ b/packages/agent-cli/src/Agent/CLI/Auth.hs
@@ -18,6 +18,7 @@ import Agent.CLI.CredentialStore
     , upsertManagedCredential
     )
 import Agent.Error (ApiError(..), ErrorType(..))
+import Agent.FileRetry (retryOnFileBusy)
 import qualified Agent.OpenAI.Auth as OpenAI
 import qualified Agent.OpenAI.Credential as OpenAICredential
 import qualified Agent.OpenAI.Login as OpenAILogin
@@ -177,7 +178,7 @@ loadOpenAi = do
             home </> fromFilePath ".codex" </> fromFilePath "auth.json"
     fileExists <- doesFileExist filePath
     fileBytes <- if fileExists
-        then Just <$> LBS.readFile (toFilePath filePath)
+        then Just <$> retryOnFileBusy (LBS.readFile (toFilePath filePath))
         else pure Nothing
     now <- getCurrentTime
     case managed of
@@ -369,7 +370,7 @@ loadGrokCredential = do
     fileExists <- doesFileExist filePath
     fileJson <- if fileExists
         then Just . TextEncoding.decodeUtf8 . LBS.toStrict
-            <$> LBS.readFile (toFilePath filePath)
+            <$> retryOnFileBusy (LBS.readFile (toFilePath filePath))
         else pure Nothing
     let token =
             (fromJson >>= grokCredentialFromAuthJson)

--- a/packages/agent-cli/src/Agent/CLI/CredentialStore.hs
+++ b/packages/agent-cli/src/Agent/CLI/CredentialStore.hs
@@ -13,6 +13,7 @@ module Agent.CLI.CredentialStore
     , upsertManagedCredential
     ) where
 
+import Agent.FileRetry (retryOnFileBusy, writeLazyFileAtomically)
 import Agent.OsPath (OsPath, fromFilePath, toFilePath, toText)
 import Agent.Provider (Provider(..), parseProvider, providerSlug)
 import Control.Exception.Safe (tryIO)
@@ -27,7 +28,6 @@ import System.Directory.OsPath
     ( createDirectoryIfMissing
     , doesFileExist
     , getHomeDirectory
-    , renameFile
     )
 import System.OsPath (takeDirectory, (</>))
 import System.Posix.Files (setFileMode)
@@ -273,7 +273,7 @@ decodeFileOrEmpty path empty = do
     exists <- doesFileExist path
     if not exists
         then pure (Right empty)
-        else tryIO (LBS.readFile (toFilePath path)) >>= \case
+        else tryIO (retryOnFileBusy (LBS.readFile (toFilePath path))) >>= \case
             Left exception ->
                 pure $ Left
                     ("could not read " <> toText path <> ": "
@@ -297,10 +297,7 @@ writePrivateJson path value =
     action = do
         createDirectoryIfMissing True (takeDirectory path)
         setFileMode (toFilePath (takeDirectory path)) 0o700
-        let temporary = path <> fromFilePath ".tmp"
-        LBS.writeFile (toFilePath temporary) (Aeson.encode value)
-        setFileMode (toFilePath temporary) 0o600
-        renameFile temporary path
+        writeLazyFileAtomically path 0o600 (Aeson.encode value)
 
 upsertBy :: Eq key => (value -> key) -> value -> [value] -> [value]
 upsertBy keyOf value values =

--- a/packages/agent-cli/src/Agent/CLI/Login.hs
+++ b/packages/agent-cli/src/Agent/CLI/Login.hs
@@ -43,6 +43,7 @@ import Agent.CLI.Style
     , roleSuccess
     , roleWarn
     )
+import Agent.FileRetry (retryOnFileBusy)
 import qualified Agent.OpenAI.Auth as OpenAI
 import qualified Agent.OpenAI.Login as OpenAILogin
 import Agent.OsPath (OsPath, fromFilePath, toFilePath, toText)
@@ -571,7 +572,7 @@ discoverOpenAIFile now path = do
     if not exists
         then pure Nothing
         else do
-            bytes <- LBS.readFile (toFilePath path)
+            bytes <- retryOnFileBusy (LBS.readFile (toFilePath path))
             pure $ do
                 auth <- openaiAuthStateFromJson now bytes
                 pure $ subscriptionAccount
@@ -602,7 +603,7 @@ discoverGrokFile path = do
         then pure Nothing
         else do
             raw <- Text.decodeUtf8 . LBS.toStrict
-                <$> LBS.readFile (toFilePath path)
+                <$> retryOnFileBusy (LBS.readFile (toFilePath path))
             pure $ do
                 token <- grokCredentialFromAuthJson raw
                 pure (grokAccount token (toText path)

--- a/packages/agent-cli/src/Agent/CLI/Project.hs
+++ b/packages/agent-cli/src/Agent/CLI/Project.hs
@@ -8,6 +8,7 @@ module Agent.CLI.Project
     , saveProjectAutoApprove
     ) where
 
+import Agent.FileRetry (retryOnFileBusy, writeLazyFileAtomically)
 import Agent.OsPath (OsPath, fromFilePath, toFilePath)
 import Control.Exception (try)
 import Data.Aeson (FromJSON(..), ToJSON(..), object, withObject, (.:?), (.=))
@@ -20,8 +21,6 @@ import System.Directory.OsPath
     ( canonicalizePath
     , createDirectoryIfMissing
     , doesFileExist
-    , removeFile
-    , renameFile
     )
 import System.Exit (ExitCode(..))
 import System.OsPath ((</>))
@@ -83,7 +82,7 @@ loadProjectSettings projectRoot = do
     if not exists
         then pure defaultProjectSettings
         else do
-            result <- try @IOError (LBS.readFile (toFilePath path))
+            result <- try @IOError (retryOnFileBusy (LBS.readFile (toFilePath path)))
             pure $ case result of
                 Left _ -> defaultProjectSettings
                 Right bytes ->
@@ -96,14 +95,10 @@ saveProjectAutoApprove :: OsPath -> Bool -> IO ()
 saveProjectAutoApprove projectRoot autoApprove = do
     let dir = projectRoot </> fromFilePath ".haskell-agent"
         path = projectSettingsPath projectRoot
-        tmp = path <> fromFilePath ".tmp"
         settings = defaultProjectSettings { settingsAutoApprove = autoApprove }
     createDirectoryIfMissing True dir
     _ <- try @IOError (setFileMode (toFilePath dir) 0o700)
-    LBS.writeFile (toFilePath tmp) (Aeson.encode settings)
-    setFileMode (toFilePath tmp) 0o600
-    renameOrReplace tmp path
-    setFileMode (toFilePath path) 0o600
+    writeLazyFileAtomically path 0o600 (Aeson.encode settings)
 
 gitToplevel :: OsPath -> IO (Maybe OsPath)
 gitToplevel dir = do
@@ -118,17 +113,6 @@ gitToplevel dir = do
             let trimmed = trim out
             in if null trimmed then Nothing else Just (fromFilePath trimmed)
         Right _ -> Nothing
-
-renameOrReplace :: OsPath -> OsPath -> IO ()
-renameOrReplace tmp path = do
-    result <- try @IOError (renameFile tmp path)
-    case result of
-        Right () -> pure ()
-        Left _ -> do
-            bytes <- LBS.readFile (toFilePath tmp)
-            LBS.writeFile (toFilePath path) bytes
-            _ <- try @IOError (removeFile tmp)
-            pure ()
 
 trim :: String -> String
 trim = dropWhileEnd isSpace . dropWhile isSpace

--- a/packages/agent-cli/src/Agent/CLI/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session.hs
@@ -21,6 +21,11 @@ module Agent.CLI.Session
     , sessionUsageFromTurns
     ) where
 
+import Agent.FileRetry
+    ( appendLazyFileRetryingOpen
+    , retryOnFileBusy
+    , writeLazyFileAtomically
+    )
 import Agent.Loop (TokenUsage(..))
 import Agent.OsPath (OsPath, fromFilePath, toFilePath)
 import Agent.OpenAI.Responses.Types (ResponseItem)
@@ -49,7 +54,6 @@ import System.Directory.OsPath
     , doesFileExist
     , listDirectory
     , removeFile
-    , renameFile
     )
 import System.OsPath ((</>))
 import System.Posix.Files (setFileMode)
@@ -72,8 +76,10 @@ writeDevResumePointer home sessionId = do
     let root = home </> fromFilePath ".haskell-agent"
         path = devResumePointerPath home
     ensurePrivateDir root
-    Text.writeFile (toFilePath path) (sessionId <> "\n")
-    setFileMode (toFilePath path) 0o600
+    writeLazyFileAtomically
+        path
+        0o600
+        (LBS.fromStrict (Text.encodeUtf8 (sessionId <> "\n")))
 
 readDevResumePointer :: OsPath -> IO (Maybe Text)
 readDevResumePointer home = do
@@ -82,7 +88,7 @@ readDevResumePointer home = do
     if not exists
         then pure Nothing
         else do
-            raw <- Text.strip <$> Text.readFile (toFilePath path)
+            raw <- Text.strip <$> retryOnFileBusy (Text.readFile (toFilePath path))
             pure (if Text.null raw then Nothing else Just raw)
 
 clearDevResumePointer :: OsPath -> IO ()
@@ -241,7 +247,7 @@ appendTurn :: SessionHandle -> SessionTurn -> IO SessionHandle
 appendTurn handle turn = do
     let path = handle.sessionTranscriptPath
     existed <- doesFileExist path
-    LBS.appendFile (toFilePath path) (Aeson.encode turn <> "\n")
+    appendLazyFileRetryingOpen path (Aeson.encode turn <> "\n")
     if existed then pure () else setFileMode (toFilePath path) 0o600
     now <- getCurrentTime
     let meta0 = handle.sessionMeta
@@ -268,7 +274,7 @@ appendTurnKeepTitle :: SessionHandle -> SessionTurn -> IO SessionHandle
 appendTurnKeepTitle handle turn = do
     let path = handle.sessionTranscriptPath
     existed <- doesFileExist path
-    LBS.appendFile (toFilePath path) (Aeson.encode turn <> "\n")
+    appendLazyFileRetryingOpen path (Aeson.encode turn <> "\n")
     if existed then pure () else setFileMode (toFilePath path) 0o600
     now <- getCurrentTime
     let meta0 = handle.sessionMeta
@@ -315,12 +321,8 @@ listSessions root = do
             pure (sortOn (Down . (.metaUpdatedAt)) (catMaybes metas))
 
 writeSessionMeta :: OsPath -> SessionMeta -> IO ()
-writeSessionMeta path meta = do
-    let tmp = path <> fromFilePath ".tmp"
-    LBS.writeFile (toFilePath tmp) (Aeson.encode meta)
-    setFileMode (toFilePath tmp) 0o600
-    renameOrReplace tmp path
-    setFileMode (toFilePath path) 0o600
+writeSessionMeta path meta =
+    writeLazyFileAtomically path 0o600 (Aeson.encode meta)
 
 sessionTitleFromPrompt :: Text -> Text
 sessionTitleFromPrompt prompt =
@@ -389,7 +391,7 @@ loadTranscript path = do
     if not exists
         then pure (Right [])
         else do
-            raw <- Text.readFile (toFilePath path)
+            raw <- retryOnFileBusy (Text.readFile (toFilePath path))
             let linesOf = filter (not . Text.null) (Text.lines raw)
             pure (mapM decodeTurnLine linesOf)
 
@@ -405,7 +407,7 @@ decodeFileEither path = do
     if not exists
         then pure (Left ("missing file: " <> toFilePath path))
         else do
-            bytes <- LBS.readFile (toFilePath path)
+            bytes <- retryOnFileBusy (LBS.readFile (toFilePath path))
             pure (case Aeson.eitherDecode' bytes of
                 Left err -> Left (toFilePath path <> ": " <> err)
                 Right value -> Right value)
@@ -420,14 +422,3 @@ readMetaQuiet root name = do
         Right (Right meta)
             | meta.metaVersion == sessionSchemaVersion -> Just meta
             | otherwise -> Nothing
-
-renameOrReplace :: OsPath -> OsPath -> IO ()
-renameOrReplace tmp path = do
-    result <- try @IOError (renameFile tmp path)
-    case result of
-        Right () -> pure ()
-        Left _ -> do
-            bytes <- LBS.readFile (toFilePath tmp)
-            LBS.writeFile (toFilePath path) bytes
-            _ <- try @IOError (removeFile tmp)
-            pure ()

--- a/packages/agent-cli/src/Agent/CLI/SubagentStore.hs
+++ b/packages/agent-cli/src/Agent/CLI/SubagentStore.hs
@@ -14,6 +14,7 @@ module Agent.CLI.SubagentStore
     , loadSubagentState
     ) where
 
+import Agent.FileRetry (retryOnFileBusy, writeLazyFileAtomically)
 import Agent.OsPath (OsPath, fromFilePath, toFilePath, toText)
 import Agent.OpenAI.Responses.Types (ResponseItem)
 import Agent.Subagents (SubagentId(..))
@@ -27,7 +28,6 @@ import qualified Data.Text as Text
 import System.Directory.OsPath
     ( createDirectoryIfMissing
     , doesFileExist
-    , renameFile
     )
 import System.OsPath ((</>))
 import System.Posix.Files (setFileMode)
@@ -94,21 +94,15 @@ saveSubagentState sessionDir agentId items previous agentType agentModel cwd =
         Right dir -> do
             let metaPath = dir </> fromFilePath "meta.json"
                 transcriptPath = dir </> fromFilePath "transcript.json"
-                metaTmp = metaPath <> fromFilePath ".tmp"
-                transcriptTmp = transcriptPath <> fromFilePath ".tmp"
             createDirectoryIfMissing True dir
             _ <- tryAny (setFileMode (toFilePath dir) 0o700)
-            LBS.writeFile (toFilePath metaTmp) $ Aeson.encode SubagentDiskMeta
+            writeLazyFileAtomically metaPath 0o600 $ Aeson.encode SubagentDiskMeta
                 { diskPreviousResponseId = previous
                 , diskAgentType = agentType
                 , diskAgentModel = agentModel
                 , diskCwd = cwd
                 }
-            _ <- tryAny (setFileMode (toFilePath metaTmp) 0o600)
-            LBS.writeFile (toFilePath transcriptTmp) (Aeson.encode items)
-            _ <- tryAny (setFileMode (toFilePath transcriptTmp) 0o600)
-            renameFile metaTmp metaPath
-            renameFile transcriptTmp transcriptPath
+            writeLazyFileAtomically transcriptPath 0o600 (Aeson.encode items)
             pure (Right ())
 
 loadSubagentState
@@ -139,7 +133,7 @@ loadSubagentState sessionDir agentId =
                             Right (Just (items, meta))
   where
     decodeFile path = do
-        raw <- LBS.readFile (toFilePath path)
+        raw <- retryOnFileBusy (LBS.readFile (toFilePath path))
         case Aeson.eitherDecode raw of
             Left err ->
                 pure $ Left $

--- a/packages/agent-core/agent-core.cabal
+++ b/packages/agent-core/agent-core.cabal
@@ -33,6 +33,7 @@ library
     import:           common-opts
     exposed-modules:  Agent.Cancel
                     , Agent.Error
+                    , Agent.FileRetry
                     , Agent.InterAgentMessage
                     , Agent.Provider
                     , Agent.Broker

--- a/packages/agent-core/src/Agent/FileRetry.hs
+++ b/packages/agent-core/src/Agent/FileRetry.hs
@@ -1,0 +1,75 @@
+-- | Retry filesystem operations that temporarily fail because another
+-- process or thread holds the GHC/macOS file lock.
+module Agent.FileRetry
+    ( appendLazyFileRetryingOpen
+    , retryOnFileBusy
+    , writeLazyFileAtomically
+    ) where
+
+import Agent.OsPath (OsPath, fromFilePath, toFilePath)
+import Control.Exception.Safe (bracket, bracketOnError, throwIO, tryIO)
+import Control.Retry
+    ( RetryPolicyM
+    , exponentialBackoff
+    , limitRetries
+    , retrying
+    )
+import qualified Data.ByteString.Lazy as LBS
+import System.Directory.OsPath (removeFile, renameFile)
+import System.IO
+    ( IOMode(AppendMode)
+    , hClose
+    , openBinaryFile
+    , openBinaryTempFile
+    )
+import System.IO.Error (isAlreadyInUseError)
+import System.OsPath (takeDirectory, takeFileName)
+import System.Posix.Files (setFileMode)
+import System.Posix.Types (FileMode)
+
+fileBusyRetryPolicy :: RetryPolicyM IO
+fileBusyRetryPolicy = exponentialBackoff 1000 <> limitRetries 5
+
+-- | Retry an 'IO' action after 1, 2, 4, 8, and 16 milliseconds when it
+-- fails with 'isAlreadyInUseError'. Other exceptions are rethrown immediately.
+retryOnFileBusy :: IO a -> IO a
+retryOnFileBusy action = do
+    result <- retrying fileBusyRetryPolicy shouldRetry (const (tryIO action))
+    either throwIO pure result
+  where
+    shouldRetry _ = pure . either isAlreadyInUseError (const False)
+
+-- | Append bytes while retrying only acquisition of the append handle.
+-- Once writing begins it is never replayed, so a partial write cannot be
+-- duplicated by the retry policy.
+appendLazyFileRetryingOpen :: OsPath -> LBS.ByteString -> IO ()
+appendLazyFileRetryingOpen path bytes =
+    bracket
+        (retryOnFileBusy (openBinaryFile (toFilePath path) AppendMode))
+        hClose
+        (`LBS.hPut` bytes)
+
+-- | Atomically replace a file using a unique temporary file in the same
+-- directory. Unique names prevent concurrent writers from renaming or
+-- deleting each other's temporary files.
+writeLazyFileAtomically
+    :: OsPath
+    -> FileMode
+    -> LBS.ByteString
+    -> IO ()
+writeLazyFileAtomically path mode bytes =
+    bracketOnError acquire cleanup \(temporary, handle) -> do
+        LBS.hPut handle bytes
+        hClose handle
+        setFileMode temporary mode
+        retryOnFileBusy (renameFile (fromFilePath temporary) path)
+  where
+    acquire =
+        retryOnFileBusy $
+            openBinaryTempFile
+                (toFilePath (takeDirectory path))
+                (toFilePath (takeFileName path) <> ".tmp")
+    cleanup (temporary, handle) = do
+        _ <- tryIO (hClose handle)
+        _ <- tryIO (removeFile (fromFilePath temporary))
+        pure ()

--- a/packages/agent-core/src/Agent/ProjectInstructions.hs
+++ b/packages/agent-core/src/Agent/ProjectInstructions.hs
@@ -18,6 +18,7 @@ module Agent.ProjectInstructions
     , globalAgentsHomeDir
     ) where
 
+import Agent.FileRetry (retryOnFileBusy)
 import Agent.Provider (Provider(..))
 import Agent.OsPath (OsPath, fromFilePath, toFilePath, toText)
 import Control.Exception.Safe (tryAny)
@@ -121,7 +122,7 @@ readAgentsFile path = do
     exists <- doesFileExist path
     if not exists
         then pure Nothing
-        else tryAny (Text.readFile (toFilePath path)) >>= \case
+        else tryAny (retryOnFileBusy (Text.readFile (toFilePath path))) >>= \case
             Left _ -> pure Nothing
             Right text ->
                 if Text.null (Text.strip text)

--- a/packages/agent-core/src/Agent/Tools/FileSystem.hs
+++ b/packages/agent-core/src/Agent/Tools/FileSystem.hs
@@ -8,15 +8,10 @@ module Agent.Tools.FileSystem
     , writeTextFile
     ) where
 
+import Agent.FileRetry (retryOnFileBusy)
 import Agent.OsPath (OsPath, fromFilePath, toFilePath, toText)
 import Agent.Tools.Types (ToolEnv(..))
-import Control.Exception.Safe (SomeException, throwIO, try, tryIO)
-import Control.Retry
-    ( RetryPolicyM
-    , exponentialBackoff
-    , limitRetries
-    , retrying
-    )
+import Control.Exception.Safe (SomeException, try)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.ByteString as BS
@@ -41,7 +36,6 @@ import System.OsPath
     , takeFileName
     , (</>)
     )
-import System.IO.Error (isAlreadyInUseError)
 
 -- | Resolve a model-supplied path against the tool cwd and reject anything
 -- that canonicalizes outside that tree, including via symlinks.
@@ -93,19 +87,9 @@ isInside root path
                 (first : _) | first == fromFilePath ".." -> False
                 _ -> True
 
-lockRetryPolicy :: RetryPolicyM IO
-lockRetryPolicy = exponentialBackoff 1000 <> limitRetries 5
-
-retryOnBusy :: IO a -> IO a
-retryOnBusy action = do
-    result <- retrying lockRetryPolicy shouldRetry (const (tryIO action))
-    either throwIO pure result
-  where
-    shouldRetry _ = pure . either isAlreadyInUseError (const False)
-
 readTextFile :: OsPath -> IO (Either Text Text)
 readTextFile path =
-    try @_ @SomeException (retryOnBusy (BS.readFile (toFilePath path))) >>= \case
+    try @_ @SomeException (retryOnFileBusy (BS.readFile (toFilePath path))) >>= \case
     Left err -> pure $ Left $ "Failed to read file: " <> Text.pack (show err)
     Right bytes
         | BS.elem 0 (BS.take 8192 bytes) ->
@@ -117,7 +101,7 @@ writeTextFile :: OsPath -> Text -> IO (Either Text ())
 writeTextFile path content = do
     createDirectoryIfMissing True (takeDirectory path)
     try @_ @SomeException
-        (retryOnBusy (BS.writeFile (toFilePath path) (encodeUtf8 content))) >>= \case
+        (retryOnFileBusy (BS.writeFile (toFilePath path) (encodeUtf8 content))) >>= \case
         Left err -> pure $ Left $ "Failed to write file: " <> Text.pack (show err)
         Right () -> pure (Right ())
 
@@ -130,7 +114,7 @@ deleteTextFile path =
 renameTextFile :: OsPath -> OsPath -> IO (Either Text ())
 renameTextFile from to = do
     createDirectoryIfMissing True (takeDirectory to)
-    try @_ @SomeException (renameFile from to) >>= \case
+    try @_ @SomeException (retryOnFileBusy (renameFile from to)) >>= \case
         Left err -> pure $ Left $ "Failed to move file: " <> Text.pack (show err)
         Right () -> pure (Right ())
 

--- a/packages/agent-core/src/Agent/Tools/PlanMode.hs
+++ b/packages/agent-core/src/Agent/Tools/PlanMode.hs
@@ -27,6 +27,7 @@ module Agent.Tools.PlanMode
     , askUserQuestionTool
     ) where
 
+import Agent.FileRetry (retryOnFileBusy)
 import Agent.OsPath (OsPath, fromFilePath, toFilePath, toText)
 import Agent.ToolArgs (objectArgs, optText, reqText)
 import Agent.ToolDSL
@@ -122,13 +123,14 @@ readPlanMarkdown env = do
     exists <- doesFileExist path
     if not exists
         then pure ""
-        else either (const "") id <$> tryAny (Text.readFile (toFilePath path))
+        else either (const "") id
+            <$> tryAny (retryOnFileBusy (Text.readFile (toFilePath path)))
 
 writePlanMarkdown :: PlanModeEnv -> Text -> IO (Either Text ())
 writePlanMarkdown env content = do
     path <- planFilePath env
     createDirectoryIfMissing True (takeDirectory path)
-    result <- tryAny (Text.writeFile (toFilePath path) content)
+    result <- tryAny (retryOnFileBusy (Text.writeFile (toFilePath path) content))
     pure $ case result of
         Left err -> Left ("failed to write plan file: " <> Text.pack (show err))
         Right () -> Right ()

--- a/packages/agent-core/test/Agent/ProjectInstructionsSpec.hs
+++ b/packages/agent-core/test/Agent/ProjectInstructionsSpec.hs
@@ -3,6 +3,7 @@ module Agent.ProjectInstructionsSpec (spec) where
 import Agent.ProjectInstructions
 import Agent.OsPath (fromFilePath)
 import Agent.Provider (Provider(..))
+import Control.Concurrent (forkIO, threadDelay)
 import Control.Exception.Safe (bracket)
 import qualified Data.Text as Text
 import System.Directory
@@ -11,6 +12,7 @@ import System.Directory
     , removeDirectoryRecursive
     )
 import System.FilePath ((</>))
+import System.IO (IOMode(AppendMode), hClose, openFile)
 import System.Posix.Temp (mkdtemp)
 import Test.Hspec
 
@@ -36,6 +38,9 @@ spec = describe "Agent.ProjectInstructions" do
                 writeFile (dir </> "AGENTS.override.md") "override\n"
                 loaded <- discoverProjectInstructions defaultDiscoverOptions (fromFilePath dir)
                 map (.instructionContent) loaded.loadedProject `shouldBe` ["override\n"]
+
+        it "waits for a transient lock instead of dropping instructions" do
+            withTempDir checkLockedInstructions
 
         it "loads a global home file before project files" do
             withTempDir \dir -> do
@@ -151,6 +156,18 @@ spec = describe "Agent.ProjectInstructions" do
                 `shouldBe` fromFilePath "/home/u/.grok"
             globalAgentsHomeDir OpenRouterProvider (fromFilePath "/home/u")
                 `shouldBe` fromFilePath "/home/u/.grok"
+
+checkLockedInstructions :: FilePath -> IO ()
+checkLockedInstructions dir = do
+    createDirectoryIfMissing True (dir </> ".git")
+    let path = dir </> "AGENTS.md"
+    writeFile path "locked rules\n"
+    handle <- openFile path AppendMode
+    _ <- forkIO do
+        threadDelay 5000
+        hClose handle
+    loaded <- discoverProjectInstructions defaultDiscoverOptions (fromFilePath dir)
+    map (.instructionContent) loaded.loadedProject `shouldBe` ["locked rules\n"]
 
 withTempDir :: (FilePath -> IO a) -> IO a
 withTempDir action = do

--- a/packages/agent-core/test/Agent/Tools/IOSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/IOSpec.hs
@@ -1,6 +1,11 @@
 module Agent.Tools.IOSpec (spec) where
 
 import Agent.Cancel (requestCancel)
+import Agent.FileRetry
+    ( appendLazyFileRetryingOpen
+    , retryOnFileBusy
+    , writeLazyFileAtomically
+    )
 import Agent.OsPath (fromFilePath)
 import Agent.Tools.IO
     ( CommandResult(..)
@@ -13,18 +18,48 @@ import Agent.Tools.IO
 import Agent.Tools.Types (ToolEnv(..), defaultToolEnv)
 import Control.Concurrent (forkIO, newEmptyMVar, putMVar, takeMVar, threadDelay)
 import Control.Concurrent.MVar (readMVar)
-import Control.Exception.Safe (bracket)
+import Control.Exception.Safe (bracket, tryIO)
 import Control.Monad (replicateM)
-import Data.Either (isLeft)
+import qualified Data.ByteString.Lazy.Char8 as LBS8
+import Data.Either (isLeft, isRight)
+import Data.IORef
+import Data.List (sort)
 import qualified Data.Text as Text
-import System.Directory (getTemporaryDirectory, removeDirectoryRecursive)
+import System.Directory (getTemporaryDirectory, listDirectory, removeDirectoryRecursive)
 import System.FilePath ((</>))
 import System.IO (IOMode(..), hClose, openFile)
+import System.IO.Error (alreadyInUseErrorType, mkIOError)
 import System.Posix.Temp (mkdtemp)
 import Test.Hspec
 
 spec :: Spec
 spec = describe "Agent.Tools.IO" do
+    it "retries only resource-busy IO exceptions" do
+        attempts <- newIORef (0 :: Int)
+        retryOnFileBusy do
+            attempt <- atomicModifyIORef' attempts \current ->
+                let next = current + 1
+                in (next, next)
+            if attempt < 3
+                then ioError (mkIOError alreadyInUseErrorType "busy" Nothing Nothing)
+                else pure ()
+        readIORef attempts `shouldReturn` 3
+
+    it "does not retry unrelated IO exceptions" do
+        attempts <- newIORef (0 :: Int)
+        result <- tryIO do
+            retryOnFileBusy do
+                modifyIORef' attempts (+ 1)
+                ioError (userError "not retryable") :: IO ()
+        result `shouldSatisfy` isLeft
+        readIORef attempts `shouldReturn` 1
+
+    it "atomically replaces a file from concurrent writers" do
+        withTempDir checkConcurrentAtomicWrites
+
+    it "appends each concurrent payload exactly once" do
+        withTempDir checkConcurrentAppends
+
     it "retries a write after a transient GHC file lock" do
         withTempDir \dir -> do
             let path = dir </> "held.txt"
@@ -93,6 +128,41 @@ checkBackgroundOutput dir = do
     result.commandExitCode `shouldBe` Just 0
     result.commandStdout `shouldBe` "stdout"
     result.commandStderr `shouldBe` "stderr"
+
+checkConcurrentAtomicWrites :: FilePath -> IO ()
+checkConcurrentAtomicWrites dir = do
+    let path = fromFilePath (dir </> "state.json")
+        payloads = map (LBS8.pack . show) [1 :: Int .. 16]
+    vars <- replicateM (length payloads) newEmptyMVar
+    mapM_ (startAtomicWrite path) (zip payloads vars)
+    results <- mapM takeMVar vars
+    results `shouldSatisfy` all isRight
+    final <- LBS8.readFile (dir </> "state.json")
+    final `shouldSatisfy` (`elem` payloads)
+    leftovers <- filter (Text.isInfixOf ".tmp" . Text.pack)
+        <$> listDirectory dir
+    leftovers `shouldBe` []
+
+startAtomicWrite path (payload, var) =
+    forkIO $
+        tryIO (writeLazyFileAtomically path 0o600 payload) >>= putMVar var
+
+checkConcurrentAppends :: FilePath -> IO ()
+checkConcurrentAppends dir = do
+    let file = dir </> "transcript.jsonl"
+        path = fromFilePath file
+        payloads = map (LBS8.pack . (<> "\n") . show) [1 :: Int .. 16]
+    writeFile file ""
+    vars <- replicateM (length payloads) newEmptyMVar
+    mapM_ (startAppend path) (zip payloads vars)
+    results <- mapM takeMVar vars
+    results `shouldSatisfy` all isRight
+    linesWritten <- sort . LBS8.lines <$> LBS8.readFile file
+    linesWritten `shouldBe` sort (map LBS8.init payloads)
+
+startAppend path (payload, var) =
+    forkIO $
+        tryIO (appendLazyFileRetryingOpen path payload) >>= putMVar var
 
 withTempDir :: (FilePath -> IO a) -> IO a
 withTempDir action = do

--- a/packages/agent-core/test/Spec.hs
+++ b/packages/agent-core/test/Spec.hs
@@ -17,6 +17,7 @@ import qualified Agent.Tools.Grok.TaskSpec as GrokTaskSpec
 import qualified Agent.Tools.GhciSpec as GhciSpec
 import qualified Agent.Tools.IOSpec as IOSpec
 import qualified Agent.Tools.MultiAgentsSpec as MultiAgentsSpec
+import qualified Agent.Tools.PlanModeSpec as PlanModeSpec
 import qualified Agent.Transport.WebSocketSpec as WebSocketSpec
 import Test.Hspec (hspec)
 
@@ -37,6 +38,7 @@ main = hspec do
     GhciSpec.spec
     IOSpec.spec
     MultiAgentsSpec.spec
+    PlanModeSpec.spec
     CodexToolsSpec.spec
     DangerousSpec.spec
     WebSocketSpec.spec

--- a/packages/agent-openai/src/Agent/OpenAI/Login.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Login.hs
@@ -9,9 +9,10 @@ module Agent.OpenAI.Login
     , writeAuthFile
     ) where
 
+import Agent.FileRetry (writeLazyFileAtomically)
 import Agent.Http.Url (trimTrailingSlash)
 import Agent.OpenAI.Auth (deriveAccountId)
-import Agent.OsPath (OsPath, fromFilePath, toFilePath)
+import Agent.OsPath (OsPath)
 import Control.Concurrent (threadDelay)
 import Control.Exception.Safe (tryAny)
 import Control.Monad (unless)
@@ -19,15 +20,13 @@ import qualified Data.Aeson as Aeson
 import Data.Aeson ((.=))
 import qualified Data.Aeson.KeyMap as KeyMap
 import qualified Data.Aeson.Key as Key
-import qualified Data.ByteString.Lazy as LBS
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import Data.Time.Clock (getCurrentTime)
 import Network.HTTP.Simple
-import System.Directory.OsPath (createDirectoryIfMissing, renameFile)
-import System.OsPath ((<.>), takeDirectory)
-import System.Posix.Files (setFileMode)
+import System.Directory.OsPath (createDirectoryIfMissing)
+import System.OsPath (takeDirectory)
 
 data LoginOptions = LoginOptions
     { issuer :: !String
@@ -150,10 +149,7 @@ pollOnce options deviceCode = do
 writeAuthFile :: OsPath -> Aeson.Value -> IO ()
 writeAuthFile path value = do
     createDirectoryIfMissing True (takeDirectory path)
-    let temporary = path <.> fromFilePath "tmp"
-    LBS.writeFile (toFilePath temporary) (Aeson.encode value)
-    setFileMode (toFilePath temporary) 0o600
-    renameFile temporary path
+    writeLazyFileAtomically path 0o600 (Aeson.encode value)
 
 safely :: IO a -> IO (Either Text a)
 safely action = tryAny action >>= \case


### PR DESCRIPTION
## Summary
- extract shared `Agent.FileRetry` helpers backed by `Control.Retry`
- retry transient resource-busy reads and file-handle acquisition across session, project, credential, auth, plan, tool, and project-instruction paths
- atomically replace persistent files through unique same-directory temp files so concurrent writers cannot collide on a fixed `.tmp` path
- retry only append-handle acquisition, avoiding replay of a partially written transcript entry
- restore the existing plan-mode spec to the core test runner

## Validation
- multi-package GHCi load: 123 modules
- `agent-core` suite in GHCi: 158 examples, 0 failures
- `agent-cli` suite in GHCi: 333 examples, 0 failures
- focused `Agent.OpenAI.Login` spec: 1 example, 0 failures
- `nix build --no-link .#agent-core .#agent-openai`
- `git diff --check`

## Note
A local `nix build .#agent-cli` reached and ran all CLI tests, but its remote Darwin builder lacked `osascript`; the platform-specific clipboard test failed before this branch's final refactor. The same full CLI suite passes locally in GHCi.
