### PR TITLE
Retry OpenRouter requests before streaming

### DIFF
--- a/packages/agent-openrouter/README.md
+++ b/packages/agent-openrouter/README.md
@@ -9,15 +9,18 @@ OpenRouter transport package for the agent harness.
 - Decodes SSE incrementally into the canonical typed `ResponseStreamEvent`
   union, delivers callbacks while the response is still arriving, and
   assembles the terminal `Response`.
+- Retries transient connection and provider failures with 1s/2s/4s
+  exponential backoff, but only before the first stream callback. Once any
+  callback runs, failures return directly so output is never replayed.
 - Authenticates with a static OpenRouter API key.
 
 `Agent.OpenRouter.LoopBackend` implements the provider-neutral `Backend`
 used by `Agent.Loop`. Because the host does not store transcripts, the
 adapter keeps a local item list and resends it on each turn.
 
-The package contains no agent loop, context trimming, retry policy, or
-credential failover. Those concerns belong to the harness around the
-provider client.
+The package contains no agent loop, context trimming, or credential failover.
+Those concerns belong to the harness around the provider client. The transport
+owns only the bounded replay-safe retry policy described above.
 
 ```haskell
 import Agent.OpenAI.Responses.Types

--- a/packages/agent-openrouter/agent-openrouter.cabal
+++ b/packages/agent-openrouter/agent-openrouter.cabal
@@ -52,6 +52,7 @@ library
                     , http-client-tls
                     , http-conduit
                     , http-types
+                    , retry >= 0.9.3.1 && < 0.10
                     , safe-exceptions
                     , scientific
                     , time
@@ -80,5 +81,6 @@ test-suite agent-openrouter-test
                     , time
                     , case-insensitive
                     , http-types
+                    , retry >= 0.9.3.1 && < 0.10
                     , wai
                     , warp

--- a/packages/agent-openrouter/package.nix
+++ b/packages/agent-openrouter/package.nix
@@ -1,6 +1,6 @@
 { mkDerivation, aeson, agent-core, agent-openai, base, bytestring
 , case-insensitive, hspec, http-client, http-client-tls, http-conduit, http-types
-, lib, safe-exceptions, text, time, wai, warp
+, lib, retry, safe-exceptions, scientific, text, time, wai, warp
 }:
 mkDerivation {
   pname = "agent-openrouter";
@@ -8,11 +8,11 @@ mkDerivation {
   src = ./.;
   libraryHaskellDepends = [
     aeson agent-core agent-openai base bytestring http-client http-client-tls
-    http-conduit http-types safe-exceptions text time
+    http-conduit http-types retry safe-exceptions scientific text time
   ];
   testHaskellDepends = [
     aeson agent-core agent-openai base bytestring case-insensitive
-    hspec http-types text time wai warp
+    hspec http-types retry text time wai warp
   ];
   description = "Haskell client for the OpenRouter Responses transport";
   license = lib.licenses.bsd3;

--- a/packages/agent-openrouter/src/Agent/OpenRouter/Client.hs
+++ b/packages/agent-openrouter/src/Agent/OpenRouter/Client.hs
@@ -4,10 +4,16 @@ module Agent.OpenRouter.Client
     , createResponse
     , createResponseWith
     , createResponseWithEvents
+    , createResponseWithEventsPolicy
+    , retryTransientOpenRouterResultWithPolicy
     ) where
 
 import Agent.Http.Url (trimTrailingSlash)
-import Agent.Error (ApiError(..), ErrorType(..))
+import Agent.Error
+    ( ApiError(..)
+    , ErrorType(..)
+    , isInlineRetryableProviderError
+    )
 import Agent.OpenAI.Responses.Types
 import Agent.Provider (Credential(..), Provider(..))
 import Agent.OpenRouter.Error (classifyFailure)
@@ -20,10 +26,17 @@ import Agent.OpenRouter.Stream
     , newSseDecoder
     )
 import Control.Exception.Safe (tryAny)
+import Control.Retry
+    ( RetryPolicyM
+    , exponentialBackoff
+    , limitRetries
+    , retrying
+    )
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BS8
 import qualified Data.ByteString.Lazy as LBS
+import Data.IORef
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
@@ -58,16 +71,33 @@ createResponseWithEvents
     -> ResponseCreateParams
     -> StreamEventCallback
     -> IO (Either ApiError Response)
-createResponseWithEvents options credential request onEvent
+createResponseWithEvents =
+    createResponseWithEventsPolicy transientResultPolicy
+
+-- | Like 'createResponseWithEvents', with an injectable retry policy for
+-- deterministic tests. Transient failures retry only before the first stream
+-- callback, so callers never observe replayed output.
+createResponseWithEventsPolicy
+    :: RetryPolicyM IO
+    -> ClientOptions
+    -> Credential
+    -> ResponseCreateParams
+    -> StreamEventCallback
+    -> IO (Either ApiError Response)
+createResponseWithEventsPolicy policy options credential request onEvent
     | credential.provider /= OpenRouterProvider = pure $ Left $ ProviderError ApiErrorType
         "agent-openrouter requires an OpenRouter credential"
         Nothing
-    | otherwise = tryAny performRequest >>= \case
-        Left exception -> pure $ Left $ ConnectionError
-            ("OpenRouter request failed: " <> Text.pack (show exception))
-        Right result -> pure result
+    | otherwise =
+        retryTransientOpenRouterResultWithPolicy policy performOnce onEvent
   where
-    performRequest = do
+    performOnce emit =
+        tryAny (performRequest emit) >>= \case
+            Left exception -> pure $ Left $ ConnectionError
+                ("OpenRouter request failed: " <> Text.pack (show exception))
+            Right result -> pure result
+
+    performRequest emit = do
         httpRequest <- parseRequest ("POST " <> trimTrailingSlash options.baseUrl <> "/responses")
         manager <- HttpTls.getGlobalManager
         HttpClient.withResponse
@@ -82,17 +112,17 @@ createResponseWithEvents options credential request onEvent
             $ withTimeout httpRequest
             )
             manager
-            handleResponse
+            (handleResponse emit)
 
     withTimeout httpRequest = httpRequest
         { HttpClient.responseTimeout =
             HttpClient.responseTimeoutMicro (options.requestTimeoutSeconds * 1_000_000)
         }
 
-    handleResponse response = do
+    handleResponse emit response = do
         let status = getResponseStatusCode response
         if status >= 200 && status < 300
-            then consumeSse (HttpClient.responseBody response)
+            then consumeSse emit (HttpClient.responseBody response)
             else do
                 body <- consumeBody (HttpClient.responseBody response)
                 let bodyText = Text.decodeUtf8With Text.lenientDecode
@@ -100,7 +130,7 @@ createResponseWithEvents options credential request onEvent
                 pure $ Left $
                     classifyFailure status (retryAfterSeconds response) bodyText
 
-    consumeSse body = go newSseDecoder []
+    consumeSse emit body = go newSseDecoder []
       where
         go decoder reversedEvents = do
             chunk <- HttpClient.brRead body
@@ -108,13 +138,13 @@ createResponseWithEvents options credential request onEvent
                 then case finishSseDecoder decoder of
                     Left err -> pure (Left err)
                     Right trailing -> do
-                        mapM_ onEvent trailing
+                        mapM_ emit trailing
                         pure $ buildResponse
                             (reverse reversedEvents <> trailing)
                 else case feedSseDecoder decoder chunk of
                     Left err -> pure (Left err)
                     Right (nextDecoder, events) -> do
-                        mapM_ onEvent events
+                        mapM_ emit events
                         let retained = filter retainForResponse events
                         go nextDecoder (reverse retained <> reversedEvents)
 
@@ -139,6 +169,33 @@ createResponseWithEvents options credential request onEvent
             [(seconds, "")] -> Just (max 1 seconds)
             _ -> Nothing
         [] -> Nothing
+
+-- | Retry transient failures while replay is safe. The callback marker is
+-- written before user code runs, so callback exceptions are never retried.
+retryTransientOpenRouterResultWithPolicy
+    :: RetryPolicyM IO
+    -> ((event -> IO ()) -> IO (Either ApiError value))
+    -> (event -> IO ())
+    -> IO (Either ApiError value)
+retryTransientOpenRouterResultWithPolicy policy request onEvent =
+    snd <$> retrying policy shouldRetry runAttempt
+  where
+    runAttempt _status = do
+        emitted <- newIORef False
+        result <- request \event -> do
+            writeIORef emitted True
+            onEvent event
+        didEmit <- readIORef emitted
+        pure (didEmit, result)
+
+    shouldRetry _status (emitted, result) = pure $
+        not emitted
+            && case result of
+                Left apiError -> isInlineRetryableProviderError apiError
+                Right _ -> False
+
+transientResultPolicy :: RetryPolicyM IO
+transientResultPolicy = exponentialBackoff 1_000_000 <> limitRetries 3
 
 optionalHeader :: HeaderName -> Maybe Text -> Request -> Request
 optionalHeader name value request = case nonEmptyText value of

--- a/packages/agent-openrouter/src/Agent/OpenRouter/Error.hs
+++ b/packages/agent-openrouter/src/Agent/OpenRouter/Error.hs
@@ -34,6 +34,13 @@ classifyFailure status retryAfterHeader body =
             | isOpenRouterSpecificCode envelope.envelopeCode ->
                 fromOpenRouterEnvelope envelope
         _ -> case decodeOpenAIError body of
+            Right (ProviderError ApiErrorType message retryAfter)
+                | isPermanentClientStatus status ->
+                    ProviderError
+                        (errorTypeFromOpenRouter status
+                            (openRouterEnvelope >>= \envelope -> envelope.envelopeCode))
+                        message
+                        (retryAfter `orElse` retryAfterHeader)
             Right (ProviderError errType message retryAfter) ->
                 ProviderError errType message (retryAfter `orElse` retryAfterHeader)
             Right other -> other
@@ -96,7 +103,14 @@ errorTypeFromOpenRouter status code = case Text.toLower <$> code of
         402 -> BillingError
         404 -> NotFoundError
         429 -> RateLimitError
+        _ | status >= 400 && status < 500 -> InvalidRequestError
         _ -> ApiErrorType
+
+isPermanentClientStatus :: Int -> Bool
+isPermanentClientStatus status =
+    status >= 400
+        && status < 500
+        && status `notElem` [408, 409, 425, 429]
 
 isOpenRouterSpecificCode :: Maybe Text -> Bool
 isOpenRouterSpecificCode code =

--- a/packages/agent-openrouter/test/Agent/OpenRouter/ClientSpec.hs
+++ b/packages/agent-openrouter/test/Agent/OpenRouter/ClientSpec.hs
@@ -8,6 +8,7 @@ import Agent.Provider (Credential(..), Provider(..))
 import Agent.OpenAI.Responses.Types
 import Control.Concurrent.MVar
 import Control.Monad (when)
+import Control.Retry (constantDelay, limitRetries)
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Builder as Builder
 import qualified Data.Aeson.KeyMap as KeyMap
@@ -85,6 +86,32 @@ spec = do
             readIORef recorded `shouldReturn` []
 
     describe "retry boundaries" do
+        it "retries a transient HTTP failure before streaming starts" do
+            recorded <- newIORef []
+            attempts <- newIORef (0 :: Int)
+            let handler _request = do
+                    attempt <- atomicModifyIORef' attempts \current ->
+                        let next = current + 1
+                        in (next, next)
+                    pure $ if attempt == 1
+                        then Wai.responseLBS HTTP.status503
+                            [("Content-Type", "text/plain")]
+                            "temporarily unavailable"
+                        else sseResponse
+                            [ outputItemDone (assistantMessage "after retry")
+                            , completedEvent "resp-retry" []
+                            ]
+            withMockOpenRouter recorded handler \options -> do
+                result <- createResponseWithEventsPolicy
+                    (constantDelay 0 <> limitRetries 3)
+                    options
+                    (openRouterCredential "token-a")
+                    (helloRequest "hi")
+                    (const (pure ()))
+                response <- expectRight result
+                response.responseId `shouldBe` "resp-retry"
+            length <$> readIORef recorded `shouldReturn` 2
+
         it "reports a terminal stream failure after one request" do
             recorded <- newIORef []
             let handler _request = pure $ sseResponse
@@ -111,6 +138,42 @@ spec = do
 
             requests <- readIORef recorded
             length requests `shouldBe` 1
+
+        it "does not retry a transient failure after a callback" do
+            attempts <- newIORef (0 :: Int)
+            callbacks <- newIORef (0 :: Int)
+            let overload =
+                    ProviderError OverloadedError "temporarily overloaded" Nothing
+                request emit = do
+                    modifyIORef' attempts (+ 1)
+                    emit ()
+                    pure (Left overload :: Either ApiError Text)
+            result <- retryTransientOpenRouterResultWithPolicy
+                (constantDelay 0 <> limitRetries 3)
+                request
+                (const (modifyIORef' callbacks (+ 1)))
+            result `shouldBe` Left overload
+            readIORef attempts `shouldReturn` 1
+            readIORef callbacks `shouldReturn` 1
+
+        it "does not retry when the stream callback throws" do
+            checkThrowingCallback
+
+        it "does not retry quota errors before streaming starts" do
+            attempts <- newIORef (0 :: Int)
+            let quota = ProviderError UsageLimitReached "quota" (Just 3600)
+                request _emit = do
+                    modifyIORef' attempts (+ 1)
+                    pure (Left quota :: Either ApiError Text)
+            result <- retryTransientOpenRouterResultWithPolicy
+                (constantDelay 0 <> limitRetries 3)
+                request
+                (const (pure ()))
+            result `shouldBe` Left quota
+            readIORef attempts `shouldReturn` 1
+
+        it "does not retry an unknown-code permanent client error" do
+            checkPermanentClientError
 
         it "classifies an OpenRouter 401 envelope as authentication rejected" do
             recorded <- newIORef []
@@ -258,6 +321,54 @@ expectRight :: Show e => Either e a -> IO a
 expectRight = \case
     Left err -> expectationFailure ("expected Right, got Left " <> show err) >> fail "unreachable"
     Right value -> pure value
+
+checkPermanentClientError :: IO ()
+checkPermanentClientError = do
+    recorded <- newIORef []
+    withMockOpenRouter recorded permanentClientErrorResponse \options -> do
+        result <- createResponseWithEventsPolicy
+            (constantDelay 0 <> limitRetries 3)
+            options
+            (openRouterCredential "token-a")
+            (helloRequest "hi")
+            (const (pure ()))
+        case result of
+            Left (ProviderError InvalidRequestError _ _) -> pure ()
+            other -> expectationFailure
+                ("expected InvalidRequestError, got " <> show other)
+    length <$> readIORef recorded `shouldReturn` 1
+
+checkThrowingCallback :: IO ()
+checkThrowingCallback = do
+    recorded <- newIORef []
+    callbacks <- newIORef (0 :: Int)
+    withMockOpenRouter recorded throwingCallbackResponse \options -> do
+        result <- createResponseWithEventsPolicy
+            (constantDelay 0 <> limitRetries 3)
+            options
+            (openRouterCredential "token-a")
+            (helloRequest "hi")
+            (throwingCallback callbacks)
+        case result of
+            Left ConnectionError{} -> pure ()
+            other -> expectationFailure
+                ("expected callback ConnectionError, got " <> show other)
+    length <$> readIORef recorded `shouldReturn` 1
+    readIORef callbacks `shouldReturn` 1
+
+permanentClientErrorResponse _request = pure $
+    Wai.responseLBS (HTTP.mkStatus 422 "Unprocessable Entity")
+        [("Content-Type", "application/json")]
+        "{\"error\":{\"code\":\"vendor_validation_failed\",\"message\":\"bad request\"}}"
+
+throwingCallbackResponse _request = pure $ sseResponse
+    [ outputItemDone (assistantMessage "hello")
+    , completedEvent "resp-callback" []
+    ]
+
+throwingCallback callbacks _event =
+    modifyIORef' callbacks (+ 1)
+        >> ioError (userError "callback failed")
 
 recordOutputItem :: MVar () -> ResponseStreamEvent -> IO ()
 recordOutputItem callbackSeen event =


### PR DESCRIPTION
## Summary
- add bounded OpenRouter retries with 1s/2s/4s exponential backoff
- retry connection, overload, service-unavailable, and transient HTTP failures only before the first stream callback
- mark attempts replay-unsafe before invoking callback code, including when the callback throws
- keep quota, rate-limit, authentication, and permanent client errors out of inline retries
- preserve permanent 4xx classification for unknown OpenRouter error codes
- document the transport-owned retry boundary

## Validation
- `agent-openrouter` suite in GHCi: 38 examples, 0 failures, 1 live test pending
- `nix build --no-link .#agent-openrouter`
- `git diff --check`
