### PR TITLE
fix(cli): exit cleanly on confirmed Ctrl-C

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -58,6 +58,7 @@ import Agent.CLI.ReplMode
     )
 import Agent.CLI.Interrupt
     ( InterruptState
+    , isWrappedUserInterrupt
     , newInterruptState
     , withCtrlCHandler
     , withTurnCancel
@@ -246,7 +247,14 @@ import Agent.XAI.LoopBackend (xaiBackend)
 import qualified Agent.XAI.Options as XAI
 import Control.Concurrent.MVar (MVar, newMVar, withMVar)
 import Control.Exception (AsyncException(UserInterrupt))
-import Control.Exception.Safe (catchAsync, finally, throwIO, try)
+import Control.Exception.Safe
+    ( SomeException
+    , catchAny
+    , catchAsync
+    , finally
+    , throwIO
+    , try
+    )
 import Control.Monad (when)
 import qualified Data.Aeson.KeyMap as KeyMap
 import qualified Data.ByteString as BS
@@ -618,7 +626,7 @@ runAgent options transition = do
             Nothing -> pure ()
         progName <- getProgName
         withCtrlCHandler interrupt $
-            withInterruptResume progName persist do
+            withInterruptResume progName persist RunQuit do
                 case provider of
                     OpenAIProvider ->
                         try @_ @CodexAuthFailed
@@ -778,15 +786,29 @@ preparePersistence options root provider model cwd effort prompt resumed =
 withInterruptResume
     :: String
     -> Maybe (IORef (Either SessionCreate SessionHandle))
+    -> a
     -> IO a
     -> IO a
-withInterruptResume progName persist action =
-    action `catchAsync` \(e :: AsyncException) ->
+withInterruptResume progName persist interrupted action =
+    (action `catchAny` handleSyncException) `catchAsync` handleInterrupt
+  where
+    -- UserInterrupt can arrive asynchronously from the installed SIGINT
+    -- handler or wrapped as a synchronous exception by safe-exceptions when
+    -- the inline editor's double-Ctrl-C path calls throwIO.
+    handleInterrupt (e :: AsyncException) =
         case e of
-            UserInterrupt -> do
-                printResumeHint progName persist
-                throwIO e
+            UserInterrupt -> finishInterrupt
             _ -> throwIO e
+    handleSyncException (e :: SomeException)
+        | isWrappedUserInterrupt e = finishInterrupt
+        | otherwise = throwIO e
+    finishInterrupt = do
+        printResumeHint progName persist
+        -- The interrupt is the requested, graceful end of the CLI session.
+        -- Returning lets the surrounding brackets restore the SIGINT handler
+        -- and close tools without GHC's top-level exception handler printing
+        -- "user interrupt" and a backtrace.
+        pure interrupted
 
 printResumeHint
     :: String

--- a/packages/agent-cli/src/Agent/CLI/Interrupt.hs
+++ b/packages/agent-cli/src/Agent/CLI/Interrupt.hs
@@ -11,12 +11,23 @@ module Agent.CLI.Interrupt
     , withCtrlCHandler
     , withTurnCancel
     , noteIdleCtrlC
+    , isWrappedUserInterrupt
     ) where
 
 import Agent.Cancel (CancelFlag, isCancelled, requestCancel)
 import Control.Concurrent (ThreadId, myThreadId, throwTo)
-import Control.Exception (AsyncException(UserInterrupt))
-import Control.Exception.Safe (bracket, bracket_, catchIO)
+import Control.Exception
+    ( AsyncException(UserInterrupt)
+    , fromException
+    , toException
+    )
+import Control.Exception.Safe
+    ( SomeException
+    , SyncExceptionWrapper(..)
+    , bracket
+    , bracket_
+    , catchIO
+    )
 import Control.Monad (void)
 import Data.IORef (IORef, newIORef, readIORef, writeIORef)
 import Data.Text (Text)
@@ -149,3 +160,13 @@ notify :: InterruptState -> Text -> IO ()
 notify state msg =
     -- Best-effort: never let printing from the signal thread fail the handler.
     state.interruptOnMessage msg `catchIO` \_ -> pure ()
+
+-- | Recognize a 'UserInterrupt' thrown with safe-exceptions' 'throwIO'.
+isWrappedUserInterrupt :: SomeException -> Bool
+isWrappedUserInterrupt e =
+    case fromException e of
+        Just (SyncExceptionWrapper wrapped) ->
+            case fromException (toException wrapped) of
+                Just UserInterrupt -> True
+                _ -> False
+        Nothing -> False

--- a/packages/agent-cli/test/Agent/CLI/InterruptSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/InterruptSpec.hs
@@ -1,19 +1,29 @@
 module Agent.CLI.InterruptSpec (spec) where
 
 import Agent.CLI.Interrupt
+import Control.Exception (AsyncException(ThreadKilled, UserInterrupt))
+import Control.Exception.Safe (toSyncException)
 import Test.Hspec
 
 spec :: Spec
-spec = describe "decideCtrlC" do
-    it "warns on first idle Ctrl-C" do
-        decideCtrlC Idle False `shouldBe` WarnExit
+spec = do
+    describe "decideCtrlC" do
+        it "warns on first idle Ctrl-C" do
+            decideCtrlC Idle False `shouldBe` WarnExit
 
-    it "exits on second idle Ctrl-C within the window" do
-        decideCtrlC Idle True `shouldBe` ForceExit
+        it "exits on second idle Ctrl-C within the window" do
+            decideCtrlC Idle True `shouldBe` ForceExit
 
-    it "soft-cancels the first Ctrl-C during a turn" do
-        decideCtrlC (TurnActive False) False `shouldBe` SoftCancel
-        decideCtrlC (TurnActive False) True `shouldBe` SoftCancel
+        it "soft-cancels the first Ctrl-C during a turn" do
+            decideCtrlC (TurnActive False) False `shouldBe` SoftCancel
+            decideCtrlC (TurnActive False) True `shouldBe` SoftCancel
 
-    it "force-exits when Ctrl-C arrives after the turn is already cancelled" do
-        decideCtrlC (TurnActive True) False `shouldBe` ForceExit
+        it "force-exits when Ctrl-C arrives after the turn is already cancelled" do
+            decideCtrlC (TurnActive True) False `shouldBe` ForceExit
+
+    describe "isWrappedUserInterrupt" do
+        it "recognizes a synchronously wrapped UserInterrupt" do
+            isWrappedUserInterrupt (toSyncException UserInterrupt) `shouldBe` True
+
+        it "rejects other wrapped async exceptions" do
+            isWrappedUserInterrupt (toSyncException ThreadKilled) `shouldBe` False


### PR DESCRIPTION
## Summary

- handle both asynchronous SIGINT and `safe-exceptions`-wrapped `UserInterrupt` values
- return a normal `RunQuit` result after printing the resume hint instead of leaking an exception to GHC's top-level handler
- add coverage for recognizing wrapped user interrupts without matching other asynchronous exceptions

## Testing

- `env -u GHCRTS cabal test agent-cli-test` — 342 examples, 0 failures
- tmux TTY smoke test: rapid double Ctrl-C exits with status 0 and no `UserInterrupt` dump
- direct SIGINT smoke test: confirmed interrupt exits with status 0 and no exception dump
- `git diff --check`
