### PR TITLE
Retry transient Codex streaming errors

### DIFF
--- a/packages/agent-openai/src/Agent/OpenAI/LoopBackend.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/LoopBackend.hs
@@ -6,6 +6,7 @@ module Agent.OpenAI.LoopBackend
     ( openAiBackend
     , openAiBackendReconnecting
     , openAiBackendWith
+    , openAiBackendWithRetryPolicy
     , openAiBackendWithConnectionRecovery
     , turnInputsToItems
     , responseToTurnOutput
@@ -15,7 +16,10 @@ module Agent.OpenAI.LoopBackend
     , withRequestInput
     ) where
 
-import Agent.Error (ApiError(..))
+import Agent.Error
+    ( ApiError(..)
+    , isInlineRetryableProviderResponseError
+    )
 import Agent.InterAgentMessage
     ( InterAgentMessage(..)
     , InterAgentMessageContent(..)
@@ -45,6 +49,12 @@ import Agent.ToolDispatch
     , ToolCallResult(..)
     )
 import Control.Applicative ((<|>))
+import Control.Retry
+    ( RetryPolicyM
+    , exponentialBackoff
+    , limitRetries
+    , retrying
+    )
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KeyMap
@@ -142,33 +152,68 @@ openAiBackendWith
     -> IO ResponseCreateParams
     -> IORef [ResponseItem]
     -> Backend
-openAiBackendWith send getParams transcript = Backend \previousResponseId inputs onEvent -> do
-    baseParams <- getParams
-    history <- readIORef transcript
-    let newItems = turnInputsToItems inputs
-        deltaRequest = withRequestInput baseParams newItems
-        fullRequest = withRequestInput baseParams (history <> newItems)
-        emit event = mapM_ onEvent (streamEventToLoopEvent event)
-        -- After compaction (or any cleared chain), previousResponseId is Nothing
-        -- but local history is the compacted transcript — send it as a fresh chain.
-        (initialRequest, initialPrevious) =
-            case previousResponseId of
-                Nothing | not (null history) -> (fullRequest, Nothing)
-                _ -> (deltaRequest, previousResponseId)
-    result <- send initialRequest initialPrevious emit
-    recovered <- case result of
-        Left err
-            | isPreviousResponseIdError err && not (null history) ->
-                -- Server forgot the chain; replay the local transcript as a
-                -- fresh turn so resumed sessions keep working.
-                send fullRequest Nothing emit
-            | otherwise -> pure (Left err)
-        Right response -> pure (Right response)
-    case recovered of
-        Left err -> pure (Left err)
-        Right response -> do
-            writeIORef transcript (history <> newItems <> response.output)
-            pure (Right (responseToTurnOutput response))
+openAiBackendWith =
+    openAiBackendWithRetryPolicy transientStreamingResultPolicy
+
+-- | Streaming retries are replay-safe only until the loop has observed output.
+-- Server error events themselves are not loop-visible, so transient Codex
+-- failures can wait and retry without printing an error or duplicating output.
+openAiBackendWithRetryPolicy
+    :: RetryPolicyM IO
+    -> (ResponseCreateParams
+        -> Maybe Text
+        -> (ResponseStreamEvent -> IO ())
+        -> IO (Either ApiError Response))
+    -> IO ResponseCreateParams
+    -> IORef [ResponseItem]
+    -> Backend
+openAiBackendWithRetryPolicy retryPolicy send getParams transcript =
+    Backend \previousResponseId inputs onEvent -> do
+        baseParams <- getParams
+        history <- readIORef transcript
+        let newItems = turnInputsToItems inputs
+            deltaRequest = withRequestInput baseParams newItems
+            fullRequest = withRequestInput baseParams (history <> newItems)
+            emit event = mapM_ onEvent (streamEventToLoopEvent event)
+            -- After compaction (or any cleared chain), previousResponseId is Nothing
+            -- but local history is the compacted transcript — send it as a fresh chain.
+            (initialRequest, initialPrevious) =
+                case previousResponseId of
+                    Nothing | not (null history) -> (fullRequest, Nothing)
+                    _ -> (deltaRequest, previousResponseId)
+        result <- sendRetrying initialRequest initialPrevious emit
+        recovered <- case result of
+            Left err
+                | isPreviousResponseIdError err && not (null history) ->
+                    -- Server forgot the chain; replay the local transcript as a
+                    -- fresh turn so resumed sessions keep working.
+                    sendRetrying fullRequest Nothing emit
+                | otherwise -> pure (Left err)
+            Right response -> pure (Right response)
+        case recovered of
+            Left err -> pure (Left err)
+            Right response -> do
+                writeIORef transcript (history <> newItems <> response.output)
+                pure (Right (responseToTurnOutput response))
+  where
+    sendRetrying request previousResponseId onEvent = do
+        emittedLoopEvent <- newIORef False
+        retrying retryPolicy (shouldRetry emittedLoopEvent) \_status ->
+            send request previousResponseId \event -> do
+                if isJust (streamEventToLoopEvent event)
+                    then writeIORef emittedLoopEvent True
+                    else pure ()
+                onEvent event
+
+    shouldRetry emittedLoopEvent _retryStatus = \case
+        Left apiError
+            | isInlineRetryableProviderResponseError apiError ->
+                not <$> readIORef emittedLoopEvent
+        _ -> pure False
+
+transientStreamingResultPolicy :: RetryPolicyM IO
+transientStreamingResultPolicy =
+    exponentialBackoff 5_000_000 <> limitRetries 3
 
 -- | 'input' is also a field on 'CustomToolCall', so a record update is
 -- ambiguous. Rebuild from the constructor instead.

--- a/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
@@ -6,6 +6,7 @@ import Agent.Loop
 import Agent.OpenAI.LoopBackend
 import Agent.OpenAI.Responses.Types
 import Agent.ToolDispatch
+import Control.Retry (constantDelay, limitRetries)
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KeyMap
@@ -243,6 +244,48 @@ spec = do
                 , seed <> turnInputsToItems [UserMessage "new"]
                 ]
 
+        it "retries transient Codex server errors before visible output" do
+            attempts <- newIORef (0 :: Int)
+            transcript <- newIORef []
+            let serverError = ProviderError ApiErrorType
+                    "An error occurred while processing your request. (code: server_error)"
+                    Nothing
+                send _request _previous _onEvent = do
+                    modifyIORef' attempts (+ 1)
+                    attempt <- readIORef attempts
+                    pure if attempt < 3
+                        then Left serverError
+                        else Right (testResponse "resp-retried" [assistantItem "ok"])
+                backend = openAiBackendWithRetryPolicy
+                    (constantDelay 0 <> limitRetries 3)
+                    send
+                    (pure baseParams)
+                    transcript
+            result <- backend.submitTurn Nothing [UserMessage "one"] (const (pure ()))
+            result `shouldBe` Right (emptyTurnOutput "resp-retried" [] (Just "ok"))
+            readIORef attempts `shouldReturn` 3
+
+        it "does not retry after visible output was streamed" do
+            attempts <- newIORef (0 :: Int)
+            transcript <- newIORef []
+            events <- newIORef []
+            let serverError = ProviderError ApiErrorType "server error" Nothing
+                send _request _previous onEvent = do
+                    modifyIORef' attempts (+ 1)
+                    onEvent (deltaEvent EventOutputTextDelta "partial")
+                    pure (Left serverError)
+                backend = openAiBackendWithRetryPolicy
+                    (constantDelay 0 <> limitRetries 3)
+                    send
+                    (pure baseParams)
+                    transcript
+            result <- backend.submitTurn Nothing [UserMessage "one"]
+                (modifyIORef' events . (:))
+            result `shouldBe` Left serverError
+            readIORef attempts `shouldReturn` 1
+            observedEvents <- readIORef events
+            reverse observedEvents `shouldBe` [TextDelta "partial"]
+
     describe "openAiBackendWithConnectionRecovery" do
         it "replays on a fresh connection when the reusable socket dies before output" do
             currentCalls <- newIORef (0 :: Int)
@@ -291,7 +334,7 @@ spec = do
             healthy <- newIORef True
             transcript <- newIORef []
             let sendCurrent _request _previous _onEvent =
-                    pure $ Left $ ProviderError OverloadedError "busy" Nothing
+                    pure $ Left $ ProviderError InvalidRequestError "bad request" Nothing
                 sendFresh _request _previous _onEvent = do
                     modifyIORef' freshCalls (+ 1)
                     pure $ Right (testResponse "resp-fresh" [assistantItem "ok"])
@@ -299,7 +342,7 @@ spec = do
                     healthy sendCurrent sendFresh (pure baseParams) transcript
             result <- providerErrorBackend.submitTurn Nothing
                 [UserMessage "one"] (const (pure ()))
-            result `shouldBe` Left (ProviderError OverloadedError "busy" Nothing)
+            result `shouldBe` Left (ProviderError InvalidRequestError "bad request" Nothing)
             readIORef healthy `shouldReturn` True
             readIORef freshCalls `shouldReturn` 0
 


### PR DESCRIPTION
## Summary

- retry transient Codex provider errors from the streaming agent loop
- use 5s, 10s, and 20s backoff with a three-retry limit
- stop retrying once user-visible output has streamed to avoid duplicate partial responses
- preserve existing connection replacement and credential failover behavior

## Testing

- `nix develop -c cabal repl agent-openai:test:agent-openai-test`
- ran `main` in GHCi: 132 examples, 0 failures, 1 expected pending live functional test