### PR TITLE
Show Codex retry status in the CLI

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Render.hs
+++ b/packages/agent-cli/src/Agent/CLI/Render.hs
@@ -128,6 +128,14 @@ renderEventUnlocked config = \case
                 hFlush config.renderStdout
     ReasoningDelta delta ->
         appendReasoningUnlocked config delta
+    ActivityUpdated activity -> do
+        writeIORef config.renderActivityRef activity
+        visible <- readIORef config.renderThinkingVisible
+        if visible
+            then paintThinkingFrame config 0
+            else if config.renderShowThinking
+                then startThinkingSpinnerUnlocked config
+                else putTextLn config.renderStderr (roleMuted config.renderColor activity)
     TurnStarted -> do
         writeIORef config.renderTextBuffer ""
         writeIORef config.renderMarkdownState emptyMarkdownStreamState

--- a/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
@@ -139,6 +139,21 @@ spec = do
                 body `shouldSatisfy` (Text.isInfixOf "Thinking…")
                 body `shouldSatisfy` ("◆ Listed ." `Text.isInfixOf`)
 
+        it "shows retry activity on the live thinking status" do
+            withRenderConfig True False \config handle path -> do
+                renderEvent config TurnStarted
+                renderEvent config
+                    (ActivityUpdated
+                        "Codex server error; retrying in 5s (attempt 1)…")
+                activity <- readIORef config.renderActivityRef
+                activity `shouldBe`
+                    "Codex server error; retrying in 5s (attempt 1)…"
+                hClose handle
+                body <- Text.readFile path
+                body `shouldSatisfy`
+                    Text.isInfixOf
+                        "Codex server error; retrying in 5s (attempt 1)…"
+
         it "buffers reasoning summaries and commits one thinking block" do
             withRenderConfig True False \config handle path -> do
                 renderEvent config TurnStarted

--- a/packages/agent-core/src/Agent/Loop.hs
+++ b/packages/agent-core/src/Agent/Loop.hs
@@ -119,6 +119,8 @@ newtype Backend = Backend
 data LoopEvent
     = TextDelta Text
     | ReasoningDelta Text
+    -- | Ephemeral transport/tool activity for the live CLI status line.
+    | ActivityUpdated Text
     | TurnStarted
     | TurnFinished TurnOutput
     | ToolStarted ToolCall

--- a/packages/agent-openai/src/Agent/OpenAI/LoopBackend.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/LoopBackend.hs
@@ -18,6 +18,7 @@ module Agent.OpenAI.LoopBackend
 
 import Agent.Error
     ( ApiError(..)
+    , ErrorType(..)
     , isInlineRetryableProviderResponseError
     )
 import Agent.InterAgentMessage
@@ -51,10 +52,14 @@ import Agent.ToolDispatch
 import Control.Applicative ((<|>))
 import Control.Retry
     ( RetryPolicyM
+    , applyPolicy
+    , defaultRetryStatus
     , exponentialBackoff
     , limitRetries
-    , retrying
+    , rsIterNumber
+    , rsPreviousDelay
     )
+import Control.Concurrent (threadDelay)
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KeyMap
@@ -168,26 +173,26 @@ openAiBackendWithRetryPolicy
     -> IORef [ResponseItem]
     -> Backend
 openAiBackendWithRetryPolicy retryPolicy send getParams transcript =
-    Backend \previousResponseId inputs onEvent -> do
+    Backend \previousResponseId inputs onLoopEvent -> do
         baseParams <- getParams
         history <- readIORef transcript
         let newItems = turnInputsToItems inputs
             deltaRequest = withRequestInput baseParams newItems
             fullRequest = withRequestInput baseParams (history <> newItems)
-            emit event = mapM_ onEvent (streamEventToLoopEvent event)
+            emit event = mapM_ onLoopEvent (streamEventToLoopEvent event)
             -- After compaction (or any cleared chain), previousResponseId is Nothing
             -- but local history is the compacted transcript — send it as a fresh chain.
             (initialRequest, initialPrevious) =
                 case previousResponseId of
                     Nothing | not (null history) -> (fullRequest, Nothing)
                     _ -> (deltaRequest, previousResponseId)
-        result <- sendRetrying initialRequest initialPrevious emit
+        result <- sendRetrying onLoopEvent initialRequest initialPrevious emit
         recovered <- case result of
             Left err
                 | isPreviousResponseIdError err && not (null history) ->
                     -- Server forgot the chain; replay the local transcript as a
                     -- fresh turn so resumed sessions keep working.
-                    sendRetrying fullRequest Nothing emit
+                    sendRetrying onLoopEvent fullRequest Nothing emit
                 | otherwise -> pure (Left err)
             Right response -> pure (Right response)
         case recovered of
@@ -196,24 +201,59 @@ openAiBackendWithRetryPolicy retryPolicy send getParams transcript =
                 writeIORef transcript (history <> newItems <> response.output)
                 pure (Right (responseToTurnOutput response))
   where
-    sendRetrying request previousResponseId onEvent = do
+    sendRetrying onLoopEvent request previousResponseId onStreamEvent = do
         emittedLoopEvent <- newIORef False
-        retrying retryPolicy (shouldRetry emittedLoopEvent) \_status ->
-            send request previousResponseId \event -> do
+        go emittedLoopEvent defaultRetryStatus
+      where
+        go emittedLoopEvent retryStatus = do
+            result <- send request previousResponseId \event -> do
                 if isJust (streamEventToLoopEvent event)
                     then writeIORef emittedLoopEvent True
                     else pure ()
-                onEvent event
-
-    shouldRetry emittedLoopEvent _retryStatus = \case
-        Left apiError
-            | isInlineRetryableProviderResponseError apiError ->
-                not <$> readIORef emittedLoopEvent
-        _ -> pure False
+                onStreamEvent event
+            emitted <- readIORef emittedLoopEvent
+            case result of
+                Left apiError
+                    | not emitted
+                    , isInlineRetryableProviderResponseError apiError ->
+                        applyPolicy retryPolicy retryStatus >>= \case
+                            Nothing -> pure result
+                            Just nextStatus -> do
+                                let delayMicros =
+                                        fromMaybe 0 nextStatus.rsPreviousDelay
+                                    attempt = nextStatus.rsIterNumber
+                                onLoopEvent $ ActivityUpdated $
+                                    formatRetryScheduled apiError attempt delayMicros
+                                threadDelay delayMicros
+                                onLoopEvent $ ActivityUpdated $
+                                    "Retrying Codex request (attempt "
+                                        <> Text.pack (show attempt) <> ")…"
+                                go emittedLoopEvent nextStatus
+                _ -> pure result
 
 transientStreamingResultPolicy :: RetryPolicyM IO
 transientStreamingResultPolicy =
     exponentialBackoff 5_000_000 <> limitRetries 3
+
+formatRetryScheduled :: ApiError -> Int -> Int -> Text
+formatRetryScheduled apiError attempt delayMicros =
+    retryReason apiError
+        <> "; retrying in "
+        <> Text.pack (show delaySeconds)
+        <> "s (attempt "
+        <> Text.pack (show attempt)
+        <> ")…"
+  where
+    delaySeconds
+        | delayMicros <= 0 = 0
+        | otherwise = (delayMicros + 999_999) `div` 1_000_000
+
+    retryReason = \case
+        ProviderError OverloadedError _ _ -> "Codex is overloaded"
+        ProviderError ServiceUnavailableError _ _ -> "Codex is unavailable"
+        ProviderError WebSocketConnectionLimitReached _ _ ->
+            "Codex connection limit reached"
+        _ -> "Codex server error"
 
 -- | 'input' is also a field on 'CustomToolCall', so a record update is
 -- ambiguous. Rebuild from the constructor instead.

--- a/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
@@ -247,6 +247,7 @@ spec = do
         it "retries transient Codex server errors before visible output" do
             attempts <- newIORef (0 :: Int)
             transcript <- newIORef []
+            events <- newIORef []
             let serverError = ProviderError ApiErrorType
                     "An error occurred while processing your request. (code: server_error)"
                     Nothing
@@ -261,9 +262,21 @@ spec = do
                     send
                     (pure baseParams)
                     transcript
-            result <- backend.submitTurn Nothing [UserMessage "one"] (const (pure ()))
+            result <- backend.submitTurn Nothing [UserMessage "one"]
+                (modifyIORef' events . (:))
             result `shouldBe` Right (emptyTurnOutput "resp-retried" [] (Just "ok"))
             readIORef attempts `shouldReturn` 3
+            observedEvents <- reverse <$> readIORef events
+            observedEvents `shouldBe`
+                [ ActivityUpdated
+                    "Codex server error; retrying in 0s (attempt 1)…"
+                , ActivityUpdated
+                    "Retrying Codex request (attempt 1)…"
+                , ActivityUpdated
+                    "Codex server error; retrying in 0s (attempt 2)…"
+                , ActivityUpdated
+                    "Retrying Codex request (attempt 2)…"
+                ]
 
         it "does not retry after visible output was streamed" do
             attempts <- newIORef (0 :: Int)


### PR DESCRIPTION
## Summary

- add ephemeral activity events for live backend status updates
- show Codex retry delays and attempt numbers in the existing CLI spinner
- replace the status text when the delayed retry starts
- keep retry notices out of assistant text and persisted transcripts

## Testing

- OpenAI Hspec suite in GHCi: 132 examples, 0 failures, 1 expected pending live test
- CLI Hspec suite in GHCi: 356 examples, 0 failures
- tmux smoke check: live CLI started, rendered an OpenAI turn, and returned cleanly