### PR TITLE
Retry brief provider credential failures

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -158,6 +158,7 @@ import Agent.CLI.Tools (schemasFromAppTools)
 import Agent.CLI.Turn (runOneTurn)
 import Agent.CLI.Usage
     ( AccountUsageLine(..)
+    , formatDuration
     , formatUsageReport
     )
 import Agent.CLI.Worktree
@@ -1139,16 +1140,15 @@ finishTurnWithCooldownRetry allowCooldownRetry env exitAfter = \case
                 notifyAttention stderr InputRequested
                 repl env
     TurnProviderUnavailable apiError pending ->
-        requestAutomaticProviderFallback
-            env apiError (setPendingExitAfter exitAfter pending) >>= \case
+        let pending' = setPendingExitAfter exitAfter pending
+        in requestAutomaticProviderFallback env apiError pending' >>= \case
             Just providerTransition ->
                 pure (RunSwitchProvider providerTransition)
             Nothing -> do
                 now <- getCurrentTime
                 case automaticCooldownRetryDelay now apiError of
                     Just delay | allowCooldownRetry ->
-                        waitAndRetryPendingTurn
-                            env delay (setPendingExitAfter exitAfter pending)
+                        waitAndRetryPendingTurn env delay pending'
                     _ -> do
                         reportProviderUnavailable apiError
                         if exitAfter
@@ -1164,11 +1164,10 @@ waitAndRetryPendingTurn
     -> IO RunResult
 waitAndRetryPendingTurn env delay pending = do
     color <- resolveColor stderr
-    let seconds = max 0 (ceiling delay :: Int)
     putTextLn stderr $ roleWarn color $
         glyphWarn
             <> "provider credentials temporarily unavailable; retrying this turn in "
-            <> formatRetryDelay seconds
+            <> formatDuration delay
             <> " (Esc to cancel)"
     let cancel = env.sessionLoop.loopCancel
         -- Give the provider reset boundary a small margin so the automatic
@@ -1190,29 +1189,17 @@ waitAndRetryPendingTurn env delay pending = do
             putTextLn stderr (roleMuted color (glyphOk <> "retrying turn"))
             runPendingTurnWithCooldownRetry False env pending
 
-formatRetryDelay :: Int -> Text
-formatRetryDelay totalSeconds
-    | totalSeconds < 60 =
-        Text.pack (show totalSeconds) <> "s"
-    | otherwise =
-        let (minutes, seconds) = totalSeconds `divMod` 60
-        in Text.pack (show minutes)
-            <> "m"
-            <> if seconds == 0
-                then ""
-                else " " <> Text.pack (show seconds) <> "s"
-
 reportProviderUnavailable :: ApiError -> IO ()
 reportProviderUnavailable apiError = do
     color <- resolveColor stderr
     now <- getCurrentTime
     let detail = case apiError of
             CredentialsExhausted{retryAt} ->
-                let seconds = max 0 (ceiling (diffUTCTime retryAt now) :: Int)
+                let delay = max 0 (diffUTCTime retryAt now)
                 in "all configured accounts are temporarily unavailable"
-                    <> if seconds == 0
+                    <> if delay == 0
                         then "; retry now"
-                        else "; retry in " <> formatRetryDelay seconds
+                        else "; retry in " <> formatDuration delay
             _ -> Text.pack (show apiError)
     putTextLn stderr $ roleError color $
         "provider unavailable; no usable fallback provider account is available: "

--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -94,7 +94,10 @@ import Agent.CLI.Project
     , resolveProjectRoot
     )
 import Agent.CLI.Prompt (defaultModelFor, systemPrompt)
-import Agent.CLI.ProviderFallback (fallbackCandidates)
+import Agent.CLI.ProviderFallback
+    ( automaticCooldownRetryDelay
+    , fallbackCandidates
+    )
 import Agent.CLI.ProviderTransition
     ( PendingTurn(..)
     , ProviderTransition(..)
@@ -163,8 +166,9 @@ import Agent.CLI.Worktree
     , removeWorktree
     , worktreeRoot
     )
+import Agent.Cancel (resetCancel, waitCancel)
 import Agent.Loop
-import Agent.Error (ApiError)
+import Agent.Error (ApiError(..))
 import Agent.InterAgentMessage (InterAgentMessage, interAgentMessagePayload)
 import Agent.ProjectInstructions
     ( DiscoverOptions(..)
@@ -276,7 +280,12 @@ import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
 import qualified Data.Set as Set
-import Data.Time.Clock (getCurrentTime, utctDay)
+import Data.Time.Clock
+    ( NominalDiffTime
+    , diffUTCTime
+    , getCurrentTime
+    , utctDay
+    )
 import Data.Time.Format (defaultTimeLocale, formatTime)
 import System.Directory.OsPath
     ( getCurrentDirectory
@@ -290,6 +299,7 @@ import System.Console.ANSI (getTerminalSize)
 import System.Console.ANSI.Codes (clearFromCursorToLineEndCode)
 import System.Exit (die, exitFailure)
 import System.IO (Handle, hFlush, hIsTerminalDevice, stderr, stdin, stdout)
+import System.Timeout (timeout)
 
 -- | How the GHCi-driven agent REPL finished.
 data DevResult
@@ -417,7 +427,9 @@ runAgentWithRestarts options = go options Nothing
                             continueAutomaticFallback failed apiError >>= \case
                                 Just next ->
                                     go (applyProviderTransition current next) (Just next)
-                                Nothing -> pure DevQuit
+                                Nothing -> do
+                                    reportProviderUnavailable apiError
+                                    pure DevQuit
                     _ -> pure DevQuit
             RunQuit -> pure DevQuit
             RunReload -> pure DevReload
@@ -1084,17 +1096,33 @@ runSession options provider policy tools toolEnv planMode prompt pendingTurn una
                 repl env
 
 runPendingTurn :: SessionEnv -> PendingTurn -> IO RunResult
-runPendingTurn env pending = do
+runPendingTurn = runPendingTurnWithCooldownRetry True
+
+runPendingTurnWithCooldownRetry
+    :: Bool
+    -> SessionEnv
+    -> PendingTurn
+    -> IO RunResult
+runPendingTurnWithCooldownRetry allowCooldownRetry env pending = do
     writeIORef env.sessionPlanMode.planStateRef pending.pendingPlanState
     result <- runOneTurn env pending.pendingPromptText pending.pendingInputs
-    finishTurn env pending.pendingExitAfter result
+    finishTurnWithCooldownRetry
+        allowCooldownRetry env pending.pendingExitAfter result
 
 finishTurn
     :: SessionEnv
     -> Bool
     -> TurnResult
     -> IO RunResult
-finishTurn env exitAfter = \case
+finishTurn = finishTurnWithCooldownRetry True
+
+finishTurnWithCooldownRetry
+    :: Bool
+    -> SessionEnv
+    -> Bool
+    -> TurnResult
+    -> IO RunResult
+finishTurnWithCooldownRetry allowCooldownRetry env exitAfter = \case
     TurnSucceeded -> do
         writeIORef env.sessionUnavailableProviders []
         putTrailingNewline env.sessionPrinted
@@ -1115,12 +1143,80 @@ finishTurn env exitAfter = \case
             env apiError (setPendingExitAfter exitAfter pending) >>= \case
             Just providerTransition ->
                 pure (RunSwitchProvider providerTransition)
-            Nothing ->
-                if exitAfter
-                    then exitFailure
-                    else do
-                        notifyAttention stderr InputRequested
-                        repl env
+            Nothing -> do
+                now <- getCurrentTime
+                case automaticCooldownRetryDelay now apiError of
+                    Just delay | allowCooldownRetry ->
+                        waitAndRetryPendingTurn
+                            env delay (setPendingExitAfter exitAfter pending)
+                    _ -> do
+                        reportProviderUnavailable apiError
+                        if exitAfter
+                            then exitFailure
+                            else do
+                                notifyAttention stderr InputRequested
+                                replWithDraft env pending.pendingPromptText
+
+waitAndRetryPendingTurn
+    :: SessionEnv
+    -> NominalDiffTime
+    -> PendingTurn
+    -> IO RunResult
+waitAndRetryPendingTurn env delay pending = do
+    color <- resolveColor stderr
+    let seconds = max 0 (ceiling delay :: Int)
+    putTextLn stderr $ roleWarn color $
+        glyphWarn
+            <> "provider credentials temporarily unavailable; retrying this turn in "
+            <> formatRetryDelay seconds
+            <> " (Esc to cancel)"
+    let cancel = env.sessionLoop.loopCancel
+        -- Give the provider reset boundary a small margin so the automatic
+        -- retry does not race a rounded server timestamp.
+        waitMicros = max 1 (ceiling ((realToFrac delay + 0.25) * 1_000_000 :: Double))
+    resetCancel cancel
+    cancelled <-
+        ( withTurnCancel env.sessionInterrupt cancel $
+            withEscCancel cancel env.sessionEscPaused $
+                isJust <$> timeout waitMicros (waitCancel cancel)
+        ) `finally` resetCancel cancel
+    if cancelled
+        then do
+            putTextLn stderr (roleMuted color "automatic retry cancelled")
+            if pending.pendingExitAfter
+                then pure RunQuit
+                else replWithDraft env pending.pendingPromptText
+        else do
+            putTextLn stderr (roleMuted color (glyphOk <> "retrying turn"))
+            runPendingTurnWithCooldownRetry False env pending
+
+formatRetryDelay :: Int -> Text
+formatRetryDelay totalSeconds
+    | totalSeconds < 60 =
+        Text.pack (show totalSeconds) <> "s"
+    | otherwise =
+        let (minutes, seconds) = totalSeconds `divMod` 60
+        in Text.pack (show minutes)
+            <> "m"
+            <> if seconds == 0
+                then ""
+                else " " <> Text.pack (show seconds) <> "s"
+
+reportProviderUnavailable :: ApiError -> IO ()
+reportProviderUnavailable apiError = do
+    color <- resolveColor stderr
+    now <- getCurrentTime
+    let detail = case apiError of
+            CredentialsExhausted{retryAt} ->
+                let seconds = max 0 (ceiling (diffUTCTime retryAt now) :: Int)
+                in "all configured accounts are temporarily unavailable"
+                    <> if seconds == 0
+                        then "; retry now"
+                        else "; retry in " <> formatRetryDelay seconds
+            _ -> Text.pack (show apiError)
+    putTextLn stderr $ roleError color $
+        "provider unavailable; no usable fallback provider account is available: "
+            <> detail
 
 repl :: SessionEnv -> IO RunResult
 repl env = replWithDraft env ""
@@ -1829,12 +1925,7 @@ chooseAutomaticProviderTransition current unavailable0 sessionId pending apiErro
     candidates = fallbackCandidates unavailable0 current apiError
 
     tryCandidates unavailable = \case
-        [] -> do
-            color <- resolveColor stderr
-            putTextLn stderr $ roleError color $
-                "provider unavailable; no other configured provider account is available: "
-                    <> Text.pack (show apiError)
-            pure Nothing
+        [] -> pure Nothing
         choice : rest ->
             validateProviderTarget choice >>= \case
                 Left err -> do
@@ -2057,7 +2148,9 @@ enterPlanFromSlash env@SessionEnv{sessionPlanMode = planMode, sessionPersist = p
                 TurnProviderUnavailable apiError pending ->
                     requestAutomaticProviderFallback
                         planEnv apiError pending >>= \case
-                            Nothing -> pure Nothing
+                            Nothing -> do
+                                reportProviderUnavailable apiError
+                                pure Nothing
                             Just providerTransition ->
                                 pure (Just providerTransition)
                 _ -> do

--- a/packages/agent-cli/src/Agent/CLI/ProviderFallback.hs
+++ b/packages/agent-cli/src/Agent/CLI/ProviderFallback.hs
@@ -4,7 +4,6 @@ module Agent.CLI.ProviderFallback
     , fallbackCandidates
     , isProviderUnavailable
     , isUsageExhausted
-    , maxAutomaticCooldownWait
     , rankedModels
     ) where
 

--- a/packages/agent-cli/src/Agent/CLI/ProviderFallback.hs
+++ b/packages/agent-cli/src/Agent/CLI/ProviderFallback.hs
@@ -1,8 +1,10 @@
 -- | Automatic cross-provider fallback policy.
 module Agent.CLI.ProviderFallback
-    ( fallbackCandidates
+    ( automaticCooldownRetryDelay
+    , fallbackCandidates
     , isProviderUnavailable
     , isUsageExhausted
+    , maxAutomaticCooldownWait
     , rankedModels
     ) where
 
@@ -10,6 +12,25 @@ import Agent.CLI.Models (ModelOption(..), modelCatalog)
 import Agent.Error (ApiError(..), ErrorType(..))
 import Agent.Provider (Provider(..))
 import Data.List (nubBy, sortOn)
+import Data.Time.Clock (NominalDiffTime, UTCTime, diffUTCTime)
+
+-- | Keep brief provider cooldowns invisible to the user when no fallback
+-- account is available. Longer waits return control to the prompt instead of
+-- making the CLI appear hung.
+maxAutomaticCooldownWait :: NominalDiffTime
+maxAutomaticCooldownWait = 120
+
+automaticCooldownRetryDelay
+    :: UTCTime
+    -> ApiError
+    -> Maybe NominalDiffTime
+automaticCooldownRetryDelay now = \case
+    CredentialsExhausted{retryAt} ->
+        let delay = max 0 (diffUTCTime retryAt now)
+        in if delay <= maxAutomaticCooldownWait
+            then Just delay
+            else Nothing
+    _ -> Nothing
 
 -- | Curated models ordered from strongest to weakest for automatic selection.
 --

--- a/packages/agent-cli/src/Agent/CLI/Usage.hs
+++ b/packages/agent-cli/src/Agent/CLI/Usage.hs
@@ -2,6 +2,7 @@
 module Agent.CLI.Usage
     ( AccountUsageLine(..)
     , formatAccountUsage
+    , formatDuration
     , formatUsageReport
     , formatUsageWindow
     , shortAccountId

--- a/packages/agent-cli/test/Agent/CLI/ProviderFallbackSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ProviderFallbackSpec.hs
@@ -2,14 +2,15 @@ module Agent.CLI.ProviderFallbackSpec (spec) where
 
 import Agent.CLI.Models (ModelOption(..))
 import Agent.CLI.ProviderFallback
-    ( fallbackCandidates
+    ( automaticCooldownRetryDelay
+    , fallbackCandidates
     , rankedModels
     )
 import Agent.Error (ApiError(..), ErrorType(..))
 import Agent.Provider (Provider(..))
 import Data.List (elemIndex)
 import Data.Time.Calendar (fromGregorian)
-import Data.Time.Clock (UTCTime(..))
+import Data.Time.Clock (UTCTime(..), addUTCTime)
 import Test.Hspec
 
 spec :: Spec
@@ -66,6 +67,29 @@ spec = do
                 (fallbackCandidates [XAIProvider] OpenAIProvider
                     (ProviderError AuthenticationError "rejected" Nothing))
                 `shouldBe` [OpenRouterProvider]
+
+    describe "automaticCooldownRetryDelay" do
+        let now = UTCTime (fromGregorian 2026 8 21) 0
+
+        it "waits through a brief credential cooldown" do
+            automaticCooldownRetryDelay now
+                (CredentialsExhausted (addUTCTime 60 now))
+                `shouldBe` Just 60
+
+        it "retries immediately when the reset time has just passed" do
+            automaticCooldownRetryDelay now
+                (CredentialsExhausted (addUTCTime (-1) now))
+                `shouldBe` Just 0
+
+        it "returns control for a long cooldown" do
+            automaticCooldownRetryDelay now
+                (CredentialsExhausted (addUTCTime 121 now))
+                `shouldBe` Nothing
+
+        it "does not retry authentication failures as cooldowns" do
+            automaticCooldownRetryDelay now
+                (ProviderError AuthenticationError "expired" Nothing)
+                `shouldBe` Nothing
 
 safeHead :: [a] -> Maybe a
 safeHead = \case

--- a/packages/agent-openai/src/Agent/OpenAI/Auth.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Auth.hs
@@ -107,11 +107,11 @@ data Pool = Pool
 rateLimitCooldownSeconds :: Int
 rateLimitCooldownSeconds = 60
 
--- | Cooldown duration when an account returns 401/403 from Agent.OpenAI. Long
--- enough to let a scheduled refresh job rotate the token, short enough that
--- a transient 403 doesn't permanently black-hole the account.
+-- | Cooldown duration when an account returns 401/403 from Agent.OpenAI.
+-- Authentication recovery already forces an immediate refresh; if that still
+-- fails, retry soon instead of black-holing the only configured account.
 authBrokenCooldownSeconds :: Int
-authBrokenCooldownSeconds = 30 * 60
+authBrokenCooldownSeconds = 60
 
 --------------------------------------------------------------------------------
 -- Construction

--- a/packages/agent-openai/src/Agent/OpenAI/Auth.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Auth.hs
@@ -21,6 +21,7 @@ module Agent.OpenAI.Auth
     , reportRateLimit
     , reportAuthBroken
     , refreshAfterAuthFailure
+    , authFailureRetrySeconds
 
       -- * Inspection and manual refresh
     , allAccountIds
@@ -107,11 +108,11 @@ data Pool = Pool
 rateLimitCooldownSeconds :: Int
 rateLimitCooldownSeconds = 60
 
--- | Cooldown duration when an account returns 401/403 from Agent.OpenAI.
+-- | Retry window when an account returns 401/403 from Agent.OpenAI.
 -- Authentication recovery already forces an immediate refresh; if that still
 -- fails, retry soon instead of black-holing the only configured account.
-authBrokenCooldownSeconds :: Int
-authBrokenCooldownSeconds = 60
+authFailureRetrySeconds :: Int
+authFailureRetrySeconds = 60
 
 --------------------------------------------------------------------------------
 -- Construction
@@ -361,11 +362,11 @@ reportRateLimit pool limitedAccountId retryAfter = do
 
 -- | Mark the account with the given OpenAI @accountId@ as auth-broken
 -- (401/403 from Codex). Uses the same cooldown mechanism as
--- 'reportRateLimit' with 'authBrokenCooldownSeconds'.
+-- 'reportRateLimit' with 'authFailureRetrySeconds'.
 reportAuthBroken :: Pool -> Text -> IO ()
 reportAuthBroken pool brokenAccountId = do
     now <- getCurrentTime
-    let until_ = addUTCTime (fromIntegral authBrokenCooldownSeconds) now
+    let until_ = addUTCTime (fromIntegral authFailureRetrySeconds) now
     setCooldown pool brokenAccountId until_
 
 -- | Force-rotate an access token that Codex has rejected with HTTP 401/403,

--- a/packages/agent-openai/src/Agent/OpenAI/Credential.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Credential.hs
@@ -38,9 +38,6 @@ poolTokenProvider pool = do
                                 Auth.reportAuthBroken pool credential.accountId
                                 acquireFromPool pool
 
-authRecoveryGuardSeconds :: Int
-authRecoveryGuardSeconds = 60
-
 takeAuthRecoverySlot
     :: IORef (Map.Map Text UTCTime)
     -> Text
@@ -50,11 +47,11 @@ takeAuthRecoverySlot attempts accountId = do
     atomicModifyIORef' attempts \current ->
         let recent = case Map.lookup accountId current of
                 Just attemptedAt -> diffUTCTime now attemptedAt
-                    < fromIntegral authRecoveryGuardSeconds
+                    < fromIntegral Auth.authFailureRetrySeconds
                 Nothing -> False
             pruned = Map.filter
                 (\attemptedAt -> diffUTCTime now attemptedAt
-                    < fromIntegral authRecoveryGuardSeconds)
+                    < fromIntegral Auth.authFailureRetrySeconds)
                 current
         in if recent
             then (pruned, False)

--- a/packages/agent-openai/src/Agent/OpenAI/Credential.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Credential.hs
@@ -39,7 +39,7 @@ poolTokenProvider pool = do
                                 acquireFromPool pool
 
 authRecoveryGuardSeconds :: Int
-authRecoveryGuardSeconds = 5 * 60
+authRecoveryGuardSeconds = 60
 
 takeAuthRecoverySlot
     :: IORef (Map.Map Text UTCTime)

--- a/packages/agent-openai/test/Agent/OpenAI/AuthSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/AuthSpec.hs
@@ -188,6 +188,20 @@ spec = do
             ids <- mapM (const (accountIdOf <$> getAccessToken pool)) [1 .. 3 :: Int]
             ids `shouldSatisfy` all (== "acc-b")
 
+        it "retries an auth-broken account after about one minute" $ do
+            now <- getCurrentTime
+            pool <- newPool [mkFreshAuth "only-account"] neverRefresh
+            reportAuthBroken pool "only-account"
+
+            result <- getAccessToken pool
+
+            case result of
+                Left CredentialsExhausted{retryAt} -> do
+                    retryAt `shouldSatisfy` (> addUTCTime 50 now)
+                    retryAt `shouldSatisfy` (< addUTCTime 70 now)
+                other -> expectationFailure
+                    ("expected CredentialsExhausted, got " <> show other)
+
     describe "forceRefresh" $ do
         it "invokes the refresh callback and caches the returned state" $ do
             callCounter <- newIORef (0 :: Int)


### PR DESCRIPTION
## Summary

- automatically wait and retry a pending turn once when all provider credentials have a reset within two minutes
- reduce OpenAI authentication-rejection cooldowns and refresh guards from 30/5 minutes to one minute
- keep cross-provider fallback ahead of the cooldown wait and allow Esc to cancel
- preserve the original prompt when retry cannot proceed, and replace raw `CredentialsExhausted` output with actionable status text
- add policy coverage for brief, elapsed, long, non-cooldown, and auth-broken retry windows

## Validation

- `nix develop -c cabal repl agent-cli:lib:agent-cli`
- agent-cli test suite in GHCi: 359 examples, 0 failures
- agent-openai test suite in GHCi: 133 examples, 0 failures, 1 pending live test
- live CLI smoke check in tmux
