### PR TITLE
Suppress subagent completion notifications

### DIFF
--- a/docs/ghostty.md
+++ b/docs/ghostty.md
@@ -9,8 +9,7 @@ wrapped for tmux passthrough when `TMUX` is set.
 - Kitty graphics previews for pasted images.
 - OSC 7 working-directory reporting, including agent worktrees.
 - OSC 8 links for Markdown URLs and absolute tool file paths.
-- OSC 9 desktop notifications for long turns, failures, approvals, and
-  completed subagents.
+- OSC 9 desktop notifications for long turns, failures, and approvals.
 - OSC 9;4 native progress while the model is working.
 - OSC 52 clipboard commands:
   - `/copy` or `/copy-last`

--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -148,7 +148,6 @@ import Agent.CLI.Terminal
     , osc133PromptStart
     , reportTerminalCwd
     , resolveColor
-    , notifyTerminal
     , withSynchronizedOutput
     )
 import Agent.CLI.Tools (schemasFromAppTools)
@@ -588,9 +587,6 @@ runAgent options transition = do
             setSubagentOnComplete ctx.multiRegistry \agentId status -> do
                 atomicModifyIORef' pendingNotices \xs ->
                     (xs <> [UserMessage (formatCompletionNotice agentId status)], ())
-                terminal <- detectTerminalCapabilities stderr
-                notifyTerminal terminal stderr
-                    ("Subagent completed: " <> agentId.unSubagentId)
                 sessions <- readIORef subagentSessions
                 case Map.lookup agentId sessions of
                     Just session ->


### PR DESCRIPTION
## Summary
- stop emitting OSC 9 desktop notifications when a subagent completes
- keep subagent completion notices queued for the root agent
- update the Ghostty integration documentation

## Validation
- loaded `agent-cli:lib:agent-cli` in GHCi with `-fno-code`
- exercised the live CLI in a tmux TTY
- ran `git diff --check`