### PR TITLE
Refactor session loading with Text and ExceptT

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -436,7 +436,7 @@ runShowSession :: Text -> IO ()
 runShowSession sessionId = do
     home <- getHomeDirectory
     loadSession (sessionsRoot home) sessionId >>= \case
-        Left err -> die err
+        Left err -> die (Text.unpack err)
         Right (meta, turns) -> do
             printSessionSummary meta
             putStrLn ""
@@ -475,7 +475,7 @@ runAgent options transition = do
         Nothing -> pure Nothing
         Just sessionId ->
             loadSession root sessionId >>= \case
-                Left err -> die err
+                Left err -> die (Text.unpack err)
                 Right loaded -> pure (Just loaded)
 
     source <- maybe getCurrentDirectory makeAbsolute options.optCwd
@@ -2210,7 +2210,7 @@ handleResume maybeId persist = do
                 else
                     loadSession root sessionId >>= \case
                         Left err -> do
-                            Text.hPutStrLn stderr (roleError color (Text.pack err))
+                            Text.hPutStrLn stderr (roleError color err)
                             pure Nothing
                         Right _ -> pure (Just (RunResumeSession sessionId))
     case maybeId of

--- a/packages/agent-cli/src/Agent/CLI/AgentSessions.hs
+++ b/packages/agent-cli/src/Agent/CLI/AgentSessions.hs
@@ -405,7 +405,7 @@ runReadAgentSession
     -> IO (Either Text Text)
 runReadAgentSession env args =
     loadSession env.toolsRoot args.sessionId >>= \case
-        Left err -> pure (Left (Text.pack err))
+        Left err -> pure (Left err)
         Right (meta, turns) -> do
             status <- env.toolsSessionStatus args.sessionId
             let limit = min 100 (max 1 (fromMaybe 20 args.limit))
@@ -449,7 +449,7 @@ runSendAgentSessionMessage env args
         if current == Just args.sessionId
             then pure (Left "cannot message the current agent session")
             else loadSession env.toolsRoot args.sessionId >>= \case
-                Left err -> pure (Left (Text.pack err))
+                Left err -> pure (Left err)
                 Right (meta, _) -> do
                     env.toolsLaunchTurn (sessionHandle env.toolsRoot meta) args.message
                         >>= \case

--- a/packages/agent-cli/src/Agent/CLI/Resume.hs
+++ b/packages/agent-cli/src/Agent/CLI/Resume.hs
@@ -296,7 +296,7 @@ loadRecentSessions root metas =
                             { turnAt = meta.metaUpdatedAt
                             , turnUserText = ""
                             , turnAssistantText =
-                                Just ("Transcript unavailable: " <> Text.pack err)
+                                Just ("Transcript unavailable: " <> err)
                             , turnError = Nothing
                             , turnResponseId = Nothing
                             , turnItems = []

--- a/packages/agent-cli/src/Agent/CLI/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session.hs
@@ -28,11 +28,19 @@ import Agent.FileRetry
     , writeLazyFileAtomically
     )
 import Agent.Loop (TokenUsage(..))
-import Agent.OsPath (OsPath, fromFilePath, toFilePath)
+import Agent.OsPath (OsPath, fromFilePath, toFilePath, toText)
 import Agent.OpenAI.Responses.Types (ResponseItem)
 import Agent.Provider (Provider(..), parseProvider, providerSlug)
 import Control.Applicative ((<|>))
-import Control.Exception (try)
+import Control.Exception.Safe (tryIO)
+import Control.Monad (unless)
+import Control.Monad.Trans.Class (lift)
+import Control.Monad.Trans.Except
+    ( ExceptT(..)
+    , except
+    , runExceptT
+    , throwE
+    )
 import Data.Aeson (FromJSON(..), ToJSON(..), object, withObject, (.:), (.:?), (.!=), (.=))
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy as LBS
@@ -95,7 +103,7 @@ readDevResumePointer home = do
 clearDevResumePointer :: OsPath -> IO ()
 clearDevResumePointer home = do
     let path = devResumePointerPath home
-    _ <- try @IOError (removeFile path)
+    _ <- tryIO (removeFile path)
     pure ()
 
 data SessionMeta = SessionMeta
@@ -287,36 +295,30 @@ appendTurnKeepTitle handle turn = do
     pure handle { sessionMeta = meta }
 
 
-loadSession :: OsPath -> Text -> IO (Either String (SessionMeta, [SessionTurn]))
-loadSession root sessionId
-    | not (isValidSessionId sessionId) =
-        pure (Left "invalid session id")
-    | otherwise = do
-        let dir = root </> fromFilePath (Text.unpack sessionId)
-            metaPath = dir </> fromFilePath "meta.json"
-            transcriptPath = dir </> fromFilePath "transcript.jsonl"
-        exists <- doesDirectoryExist dir
-        if not exists
-            then pure (Left ("session not found: " <> Text.unpack sessionId))
-            else do
-                metaResult <- decodeFileEither metaPath
-                case metaResult of
-                    Left err -> pure (Left err)
-                    Right meta
-                        | not (isValidSessionId meta.metaId) ->
-                            pure (Left "invalid session id in metadata")
-                        | meta.metaId /= sessionId ->
-                            pure (Left "session id does not match directory")
-                        | meta.metaVersion /= sessionSchemaVersion ->
-                            pure $ Left $
-                                "unsupported session schema version "
-                                    <> show meta.metaVersion
-                                    <> " (expected "
-                                    <> show sessionSchemaVersion
-                                    <> ")"
-                        | otherwise -> do
-                            turnsResult <- loadTranscript transcriptPath
-                            pure ((meta,) <$> turnsResult)
+loadSession :: OsPath -> Text -> IO (Either Text (SessionMeta, [SessionTurn]))
+loadSession root sessionId = runExceptT do
+    unless (isValidSessionId sessionId) $
+        throwE "invalid session id"
+    let dir = root </> fromFilePath (Text.unpack sessionId)
+        metaPath = dir </> fromFilePath "meta.json"
+        transcriptPath = dir </> fromFilePath "transcript.jsonl"
+    exists <- lift (doesDirectoryExist dir)
+    unless exists $
+        throwE ("session not found: " <> sessionId)
+    meta <- decodeFileEither metaPath
+    unless (isValidSessionId meta.metaId) $
+        throwE "invalid session id in metadata"
+    unless (meta.metaId == sessionId) $
+        throwE "session id does not match directory"
+    unless (meta.metaVersion == sessionSchemaVersion) $
+        throwE $
+            "unsupported session schema version "
+                <> Text.pack (show meta.metaVersion)
+                <> " (expected "
+                <> Text.pack (show sessionSchemaVersion)
+                <> ")"
+    turns <- loadTranscript transcriptPath
+    pure (meta, turns)
 
 -- | Session ids are single path components. Keep this deliberately broader
 -- than the current date-plus-hex allocator so older ids remain resumable.
@@ -384,7 +386,7 @@ allocateSessionDir root now = go (0 :: Int)
             let hex = hex8 (start + fromIntegral attempt)
                 sessionId = Text.pack (day <> "-" <> hex)
                 dir = root </> fromFilePath (Text.unpack sessionId)
-            result <- try @IOError (createDirectory dir)
+            result <- tryIO (createDirectory dir)
             case result of
                 Left _ -> go (attempt + 1)
                 Right () -> do
@@ -399,40 +401,39 @@ hex8 n =
 ensurePrivateDir :: OsPath -> IO ()
 ensurePrivateDir path = do
     createDirectoryIfMissing True path
-    _ <- try @IOError (setFileMode (toFilePath path) 0o700)
+    _ <- tryIO (setFileMode (toFilePath path) 0o700)
     pure ()
 
-loadTranscript :: OsPath -> IO (Either String [SessionTurn])
+loadTranscript :: OsPath -> ExceptT Text IO [SessionTurn]
 loadTranscript path = do
-    exists <- doesFileExist path
+    exists <- lift (doesFileExist path)
     if not exists
-        then pure (Right [])
+        then pure []
         else do
-            raw <- retryOnFileBusy (Text.readFile (toFilePath path))
+            raw <- lift (retryOnFileBusy (Text.readFile (toFilePath path)))
             let linesOf = filter (not . Text.null) (Text.lines raw)
-            pure (mapM decodeTurnLine linesOf)
+            except (mapM decodeTurnLine linesOf)
 
-decodeTurnLine :: Text -> Either String SessionTurn
+decodeTurnLine :: Text -> Either Text SessionTurn
 decodeTurnLine line =
     case Aeson.eitherDecodeStrict' (Text.encodeUtf8 line) of
-        Left err -> Left ("invalid transcript line: " <> err)
+        Left err -> Left ("invalid transcript line: " <> Text.pack err)
         Right turn -> Right turn
 
-decodeFileEither :: FromJSON a => OsPath -> IO (Either String a)
+decodeFileEither :: FromJSON a => OsPath -> ExceptT Text IO a
 decodeFileEither path = do
-    exists <- doesFileExist path
-    if not exists
-        then pure (Left ("missing file: " <> toFilePath path))
-        else do
-            bytes <- retryOnFileBusy (LBS.readFile (toFilePath path))
-            pure (case Aeson.eitherDecode' bytes of
-                Left err -> Left (toFilePath path <> ": " <> err)
-                Right value -> Right value)
+    exists <- lift (doesFileExist path)
+    unless exists $
+        throwE ("missing file: " <> toText path)
+    bytes <- lift (retryOnFileBusy (LBS.readFile (toFilePath path)))
+    case Aeson.eitherDecode' bytes of
+        Left err -> throwE (toText path <> ": " <> Text.pack err)
+        Right value -> pure value
 
 readMetaQuiet :: OsPath -> OsPath -> IO (Maybe SessionMeta)
 readMetaQuiet root name = do
     let path = root </> name </> fromFilePath "meta.json"
-    result <- try @IOError (decodeFileEither path)
+    result <- tryIO (runExceptT (decodeFileEither path))
     pure $ case result of
         Left _ -> Nothing
         Right (Left _) -> Nothing

--- a/packages/agent-cli/test/Agent/CLI/SessionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SessionSpec.hs
@@ -101,7 +101,7 @@ spec = describe "Agent.CLI.Session" do
 
                 loaded <- loadSession root handle.sessionMeta.metaId
                 case loaded of
-                    Left err -> expectationFailure err
+                    Left err -> expectationFailure (Text.unpack err)
                     Right (meta, turns) -> do
                         meta.metaId `shouldBe` handle.sessionMeta.metaId
                         meta.metaProvider `shouldBe` XAIProvider
@@ -135,7 +135,9 @@ spec = describe "Agent.CLI.Session" do
                 writeSessionMeta handle.sessionMetaPath bad
                 loadSession root handle.sessionMeta.metaId
                     >>= \case
-                        Left err -> err `shouldContain` "unsupported session schema"
+                        Left err ->
+                            err `shouldSatisfy`
+                                Text.isInfixOf "unsupported session schema"
                         Right _ -> expectationFailure "expected schema failure"
 
         it "rejects session ids that escape the sessions root" $
@@ -145,6 +147,38 @@ spec = describe "Agent.CLI.Session" do
                 isValidSessionId "nested/id" `shouldBe` False
                 loadSession root "../outside"
                     `shouldReturn` Left "invalid session id"
+
+        it "reports a missing session with a Text error" $
+            withTempDir "agent-sessions-" \root ->
+                loadSession root "missing-session"
+                    `shouldReturn` Left "session not found: missing-session"
+
+        it "rejects metadata whose id does not match its directory" $
+            withTempDir "agent-sessions-" \root -> do
+                handle <- createSession (testCreate root)
+                writeSessionMeta handle.sessionMetaPath
+                    handle.sessionMeta { metaId = "different-session" }
+                loadSession root handle.sessionMeta.metaId
+                    `shouldReturn` Left "session id does not match directory"
+
+        it "reports malformed metadata and transcript lines as Text" $
+            withTempDir "agent-sessions-" \root -> do
+                badMeta <- createSession (testCreate root)
+                writeFile (toFilePath badMeta.sessionMetaPath) "{not-json"
+                loadSession root badMeta.sessionMeta.metaId >>= \case
+                    Left err ->
+                        err `shouldSatisfy` Text.isInfixOf "meta.json"
+                    Right _ -> expectationFailure "expected metadata decode failure"
+
+                badTranscript <- createSession (testCreate root)
+                writeFile
+                    (toFilePath badTranscript.sessionTranscriptPath)
+                    "{not-json}\n"
+                loadSession root badTranscript.sessionMeta.metaId >>= \case
+                    Left err ->
+                        err `shouldSatisfy`
+                            Text.isInfixOf "invalid transcript line"
+                    Right _ -> expectationFailure "expected transcript decode failure"
 
         it "creates a pending session only when ensureSession runs" $
             withTempDir "agent-sessions-" \root -> do


### PR DESCRIPTION
## Summary

- migrate `loadSession` and internal persistence errors from `String` to `Text`
- refactor metadata/transcript loading and validation to use `ExceptT Text IO`
- format persisted paths through `toText` and remove redundant caller conversions
- use `Control.Exception.Safe.tryIO` for touched filesystem exception handling
- add coverage for missing sessions, mismatched metadata ids, malformed metadata, and malformed transcript lines

## Validation

- targeted Session suite: 12 examples, 0 failures
- full `agent-cli` GHCi suite: 361 examples, 0 failures
- `git diff --check`