### PR TITLE
Show OpenAI account emails in login manager

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Login.hs
+++ b/packages/agent-cli/src/Agent/CLI/Login.hs
@@ -270,7 +270,8 @@ managedLoginAccount now (metadata, secret) =
         { loginManagedId = Just metadata.managedId
         , loginProvider = metadata.managedProvider
         , loginAccountId = metadata.managedAccountId
-        , loginLabel = metadata.managedLabel
+        , loginLabel = fromMaybe metadata.managedLabel
+            (openAIAccountEmail =<< openAIAuth)
         , loginBilling = case metadata.managedBilling of
             ManagedSubscription -> SubscriptionBilling Nothing
             ManagedApiCredits -> ApiCreditsBilling
@@ -282,11 +283,14 @@ managedLoginAccount now (metadata, secret) =
         , loginEnabled = metadata.managedEnabled
         }
   where
+    openAIAuth = case metadata.managedAuthKind of
+        ManagedOpenAIAuthJson ->
+            openaiAuthStateFromJson now
+                (LBS.fromStrict (Text.encodeUtf8 secret.secretPayload))
+        _ -> Nothing
     accessToken = fromMaybe "" case metadata.managedAuthKind of
         ManagedBearerToken -> Just secret.secretPayload
-        ManagedOpenAIAuthJson ->
-            (.accessToken) <$> openaiAuthStateFromJson now
-                (LBS.fromStrict (Text.encodeUtf8 secret.secretPayload))
+        ManagedOpenAIAuthJson -> (.accessToken) <$> openAIAuth
         ManagedGrokAuthJson ->
             grokCredentialFromAuthJson secret.secretPayload
 
@@ -425,7 +429,8 @@ connectOpenAI color = do
                             storeConnectedCredential color
                                 OpenAIProvider
                                 auth.accountId
-                                "ChatGPT"
+                                (fromMaybe "ChatGPT"
+                                    (openAIAccountEmail auth))
                                 ManagedSubscription
                                 ManagedOpenAIAuthJson
                                 (Text.decodeUtf8
@@ -562,8 +567,11 @@ discoverOpenAIEnv = do
                     explicitAccount
                         <|> (idToken >>= OpenAI.deriveAccountId)
                         <|> OpenAI.deriveAccountId accessToken
+            label = fromMaybe "ChatGPT" $
+                (idToken >>= OpenAI.deriveEmail)
+                    <|> OpenAI.deriveEmail accessToken
         pure $ subscriptionAccount
-            OpenAIProvider accountId "ChatGPT" "environment"
+            OpenAIProvider accountId label "environment"
             accessToken ManagedBearerToken accessToken
 
 discoverOpenAIFile :: UTCTime -> OsPath -> IO (Maybe LoginAccount)
@@ -578,7 +586,7 @@ discoverOpenAIFile now path = do
                 pure $ subscriptionAccount
                     OpenAIProvider
                     auth.accountId
-                    "ChatGPT"
+                    (fromMaybe "ChatGPT" (openAIAccountEmail auth))
                     (toText path)
                     auth.accessToken
                     ManagedOpenAIAuthJson
@@ -685,6 +693,11 @@ grokAccount token source authKind payload =
         token
         authKind
         payload
+
+openAIAccountEmail :: OpenAI.AuthState -> Maybe Text
+openAIAccountEmail auth =
+    (auth.idToken >>= OpenAI.deriveEmail)
+        <|> OpenAI.deriveEmail auth.accessToken
 
 refreshLoginAccount :: LoginAccount -> IO LoginAccount
 refreshLoginAccount account

--- a/packages/agent-cli/test/Agent/CLI/LoginSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/LoginSpec.hs
@@ -71,6 +71,12 @@ spec = do
             body `shouldSatisfy` Text.isInfixOf "API credits"
             body `shouldSatisfy` Text.isInfixOf "environment"
 
+        it "shows the OpenAI account email in the account label" do
+            let body = renderLoginFrame False $
+                    initialLoginState
+                        [openai { loginLabel = "person@example.com" }]
+            body `shouldSatisfy` Text.isInfixOf "person@example.com"
+
         it "does not render access tokens" do
             renderLoginFrame False (initialLoginState [openai])
                 `shouldSatisfy` (not . Text.isInfixOf "secret-openai")

--- a/packages/agent-openai/src/Agent/OpenAI/Auth.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Auth.hs
@@ -40,11 +40,13 @@ module Agent.OpenAI.Auth
     , parseJwtExp
     , needsRefresh
     , deriveAccountId
+    , deriveEmail
     ) where
 
 import Agent.Error (ApiError(..), ErrorType(..))
 import Agent.OpenAI.Auth.JWT
     ( deriveAccountId
+    , deriveEmail
     , needsRefresh
     , parseJwtExp
     )

--- a/packages/agent-openai/src/Agent/OpenAI/Auth/JWT.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Auth/JWT.hs
@@ -1,5 +1,6 @@
 module Agent.OpenAI.Auth.JWT
     ( deriveAccountId
+    , deriveEmail
     , needsRefresh
     , parseJwtExp
     , refreshMarginSeconds
@@ -42,13 +43,26 @@ parseJwtExp token = do
 -- | Derive the ChatGPT account id from an @id_token@ JWT.
 deriveAccountId :: Text -> Maybe Text
 deriveAccountId idTok = do
-    payloadB64 <- Text.splitOn "." idTok !!? 1
-    payloadBytes <- either (const Nothing) Just
-        (Base64.decode (Text.encodeUtf8 (base64UrlToBase64 payloadB64)))
-    Aeson.Object km <- Aeson.decode (LBS.fromStrict payloadBytes)
+    km <- jwtClaims idTok
     Aeson.Object authKm <- KeyMap.lookup "https://api.openai.com/auth" km
     Aeson.String accId <- KeyMap.lookup "chatgpt_account_id" authKm
     pure accId
+
+deriveEmail :: Text -> Maybe Text
+deriveEmail token = do
+    claims <- jwtClaims token
+    Aeson.String email <- KeyMap.lookup "email" claims
+    if Text.null (Text.strip email)
+        then Nothing
+        else Just email
+
+jwtClaims :: Text -> Maybe Aeson.Object
+jwtClaims token = do
+    payloadB64 <- Text.splitOn "." token !!? 1
+    payloadBytes <- either (const Nothing) Just
+        (Base64.decode (Text.encodeUtf8 (base64UrlToBase64 payloadB64)))
+    Aeson.Object claims <- Aeson.decode (LBS.fromStrict payloadBytes)
+    pure claims
 
 base64UrlToBase64 :: Text -> Text
 base64UrlToBase64 text =

--- a/packages/agent-openai/test/Agent/OpenAI/AuthSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/AuthSpec.hs
@@ -51,6 +51,17 @@ spec = do
             let idTok = mkJwt (Aeson.object [ "exp" .= (1_800_000_000 :: Int) ])
             deriveAccountId idTok `shouldBe` Nothing
 
+    describe "deriveEmail" $ do
+        it "extracts the standard email claim" $ do
+            let idTok = mkJwt $ Aeson.object
+                    [ "email" .= ("person@example.com" :: Text) ]
+            deriveEmail idTok `shouldBe` Just "person@example.com"
+
+        it "returns Nothing when the email claim is absent or empty" $ do
+            deriveEmail (mkJwt (Aeson.object [])) `shouldBe` Nothing
+            deriveEmail (mkJwt (Aeson.object ["email" .= ("" :: Text)]))
+                `shouldBe` Nothing
+
     describe "needsRefresh" $ do
         it "returns False for tokens with an exp far in the future" $ do
             let state = mkFreshAuth "acc"


### PR DESCRIPTION
## Summary
- extract the standard email claim from OpenAI OAuth JWTs
- show that email as the account label in `/login`
- apply the label to new, managed, file-based, and environment OpenAI credentials
- fall back to `ChatGPT` when the token has no email claim

## Validation
- OpenAI auth spec in GHCi: 29 examples, 0 failures
- CLI login spec in GHCi: 7 examples, 0 failures
- tmux smoke test of the live `/login` dashboard with multiple OpenAI accounts
