### PR TITLE
Refresh login usage asynchronously

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Login.hs
+++ b/packages/agent-cli/src/Agent/CLI/Login.hs
@@ -33,7 +33,11 @@ import Agent.CLI.CredentialStore
     , upsertManagedCredential
     )
 import Agent.CLI.Input (readApprovalLine)
-import Agent.CLI.Picker (PickerKey(..), runOverlay)
+import Agent.CLI.Picker
+    ( PickerKey(..)
+    , runOverlay
+    , runOverlayWithUpdates
+    )
 import Agent.CLI.Style
     ( glyphErr
     , glyphOk
@@ -53,7 +57,13 @@ import Agent.Provider (Provider(..), providerSlug)
 import qualified Agent.XAI.Auth as XAIAuth
 import qualified Agent.XAI.Usage as XAI
 import Control.Applicative ((<|>))
-import Control.Exception.Safe (bracket)
+import Control.Concurrent.Async
+    ( mapConcurrently
+    , mapConcurrently_
+    , withAsync
+    )
+import Control.Concurrent.Chan (Chan, newChan, readChan, writeChan)
+import Control.Exception.Safe (bracket, tryAny)
 import Control.Monad (join)
 import qualified Data.Aeson as Aeson
 import Data.Aeson ((.=))
@@ -195,40 +205,76 @@ runLoginManager color = do
     tty <- hIsTerminalDevice stdin
     if not tty
         then do
-            Text.hPutStrLn stderr (formatLoginAccounts color accounts)
+            refreshed <- mapConcurrently refreshLoginAccount accounts
+            Text.hPutStrLn stderr (formatLoginAccounts color refreshed)
             hFlush stderr
-        else loop (initialLoginState accounts)
+        else loop [0 .. length accounts - 1] (initialLoginState accounts)
   where
-    loop state =
-        runOverlay (renderLoginFrame color) applyLoginKey state >>= \case
+    loop refreshIndices state = do
+        updates <- newChan
+        result <- withAsync
+            (refreshSelectedAccounts updates refreshIndices state.loginAccounts)
+            \_ ->
+                runOverlayWithUpdates
+                    (renderLoginFrame color)
+                    applyLoginKey
+                    (readChan updates)
+                    applyRefreshedAccount
+                    state
+        case result of
             Nothing -> pure ()
-            Just LoginClose -> pure ()
-            Just (LoginRefresh index) -> do
-                accounts <- refreshAt index state.loginAccounts
-                loop state
-                    { loginAccounts = accounts
-                    , loginIndex = index
-                    }
-            Just LoginAdd -> do
+            Just (LoginClose, _) -> pure ()
+            Just (LoginRefresh index, state') ->
+                loop [index] state'
+            Just (LoginAdd, _) -> do
                 connectAccount color
-                discoverLoginAccounts >>= loop . initialLoginState
-            Just (LoginToggle index) -> do
-                toggleAt color index state.loginAccounts
-                discoverLoginAccounts >>= loop . initialLoginState
-            Just (LoginDelete index) -> do
-                deleteAt color index state.loginAccounts
-                discoverLoginAccounts >>= loop . initialLoginState
-            Just (LoginImport index) -> do
-                importAt color index state.loginAccounts
-                discoverLoginAccounts >>= loop . initialLoginState
+                rediscover
+            Just (LoginToggle index, state') -> do
+                toggleAt color index state'.loginAccounts
+                rediscover
+            Just (LoginDelete index, state') -> do
+                deleteAt color index state'.loginAccounts
+                rediscover
+            Just (LoginImport index, state') -> do
+                importAt color index state'.loginAccounts
+                rediscover
+      where
+        rediscover = do
+            accounts <- discoverLoginAccounts
+            loop [0 .. length accounts - 1] (initialLoginState accounts)
 
-refreshAt :: Int -> [LoginAccount] -> IO [LoginAccount]
-refreshAt index accounts =
+refreshSelectedAccounts
+    :: Chan (Int, LoginAccount)
+    -> [Int]
+    -> [LoginAccount]
+    -> IO ()
+refreshSelectedAccounts updates indices accounts =
+    mapConcurrently_ refreshOne indices
+  where
+    refreshOne index = case accountAt index accounts of
+        Nothing -> pure ()
+        Just account -> do
+            refreshed <- tryAny (refreshLoginAccount account) >>= \case
+                Left err ->
+                    pure account
+                        { loginUsage =
+                            UsageUnavailable (Text.pack (show err))
+                        }
+                Right result -> pure result
+            writeChan updates (index, refreshed)
+
+applyRefreshedAccount
+    :: (Int, LoginAccount)
+    -> LoginState
+    -> LoginState
+applyRefreshedAccount (index, refreshed) state =
+    state { loginAccounts = replaceAt index refreshed state.loginAccounts }
+
+replaceAt :: Int -> account -> [account] -> [account]
+replaceAt index replacement accounts =
     case splitAt index accounts of
-        (before, account : after) -> do
-            refreshed <- refreshLoginAccount account
-            pure (before <> (refreshed : after))
-        _ -> pure accounts
+        (before, _ : after) -> before <> (replacement : after)
+        _ -> accounts
 
 discoverLoginAccounts :: IO [LoginAccount]
 discoverLoginAccounts = do
@@ -688,7 +734,13 @@ grokAccount token source authKind payload =
 
 refreshLoginAccount :: LoginAccount -> IO LoginAccount
 refreshLoginAccount account
-    | Text.null account.loginAccessToken = pure account
+    | Text.null account.loginAccessToken = pure case account.loginUsage of
+        UsageNotChecked ->
+            account
+                { loginUsage =
+                    UsageUnavailable "access token is unavailable"
+                }
+        _ -> account
     | otherwise = case account.loginProvider of
         OpenAIProvider ->
             if account.loginAccountId == "openai-env"
@@ -833,8 +885,9 @@ renderAccount color selected index account =
     health
         | not account.loginEnabled = roleWarn color "○ "
         | otherwise = case account.loginUsage of
+            UsageNotChecked -> roleMuted color "◌ "
             UsageUnavailable _ -> roleError color glyphErr
-            _ -> roleSuccess color glyphOk
+            UsageAvailable _ -> roleSuccess color glyphOk
     provider = rolePrompt color (providerSlug account.loginProvider)
     label = roleMuted color account.loginLabel
     billing = roleMuted color case account.loginBilling of
@@ -849,7 +902,7 @@ renderAccount color selected index account =
         | otherwise = Text.take 24 account.loginAccountId
     usageLines = case account.loginUsage of
         UsageNotChecked ->
-            ["    " <> roleMuted color "usage not checked"]
+            ["    " <> roleMuted color "checking usage…"]
         UsageUnavailable err ->
             ["    " <> roleError color ("usage unavailable · " <> Text.take 100 err)]
         UsageAvailable usage ->

--- a/packages/agent-cli/src/Agent/CLI/Picker.hs
+++ b/packages/agent-cli/src/Agent/CLI/Picker.hs
@@ -8,6 +8,7 @@ module Agent.CLI.Picker
     , decodeMouseEvent
     , mouseKeysForFrame
     , runOverlay
+    , runOverlayWithUpdates
     , withRawTty
     ) where
 
@@ -19,6 +20,7 @@ import Agent.CLI.Terminal
     , kittyKeyboardPush
     , withSynchronizedOutput
     )
+import Control.Concurrent.Async (race)
 import Control.Exception.Safe (bracket, throwIO, tryIO)
 import Control.Monad (when)
 import Data.Char (isDigit)
@@ -168,7 +170,27 @@ safeLast xs = Just (last xs)
 
 -- | Draw @render@, then feed keys through @step@ until it returns @Left@.
 runOverlay :: (state -> Text) -> (PickerKey -> state -> Either result state) -> state -> IO (Maybe result)
-runOverlay render step state0 =
+runOverlay render step state =
+    fmap (fmap fst) (runOverlayInternal render step Nothing state)
+
+-- | Like 'runOverlay', but also redraw when an external update arrives.
+runOverlayWithUpdates
+    :: (state -> Text)
+    -> (PickerKey -> state -> Either result state)
+    -> IO update
+    -> (update -> state -> state)
+    -> state
+    -> IO (Maybe (result, state))
+runOverlayWithUpdates render step awaitUpdate applyUpdate =
+    runOverlayInternal render step (Just (awaitUpdate, applyUpdate))
+
+runOverlayInternal
+    :: (state -> Text)
+    -> (PickerKey -> state -> Either result state)
+    -> Maybe (IO update, update -> state -> state)
+    -> state
+    -> IO (Maybe (result, state))
+runOverlayInternal render step updates state0 =
     withRawTty do
         terminal <- detectTerminalCapabilities stderr
         let frame0 = render state0
@@ -178,23 +200,35 @@ runOverlay render step state0 =
         loop terminal stderr state0 lines0 frame0 top0
   where
     loop terminal h state drawnLines frame top = do
-        minput <- readPickerInput
-        case minput of
-            Nothing -> do
+        event <- case updates of
+            Nothing -> Left <$> readPickerInput
+            Just (awaitUpdate, _) -> race readPickerInput awaitUpdate
+        case event of
+            Left Nothing -> do
                 withSynchronizedOutput terminal h (clearDrawn h drawnLines)
                 pure Nothing
-            Just raw ->
+            Left (Just raw) ->
                 let keys = case decodeMouseEvent raw of
                         Just mouse -> mouseKeysForFrame top frame mouse
                         Nothing -> maybe [] pure (decodePickerKey raw)
                 in applyKeys terminal h state drawnLines frame top keys
+            Right update -> case updates of
+                Nothing -> loop terminal h state drawnLines frame top
+                Just (_, applyUpdate) -> do
+                    let state' = applyUpdate update state
+                        frame' = render state'
+                        n = frameLineCount frame'
+                    withSynchronizedOutput terminal h
+                        (redraw h drawnLines frame')
+                    top' <- frameTop h n
+                    loop terminal h state' n frame' top'
 
     applyKeys terminal h state drawnLines frame top = \case
         [] -> loop terminal h state drawnLines frame top
         key : keys -> case step key state of
             Left result -> do
                 withSynchronizedOutput terminal h (clearDrawn h drawnLines)
-                pure (Just result)
+                pure (Just (result, state))
             Right state'
                 | null keys -> do
                     let frame' = render state'

--- a/packages/agent-cli/test/Agent/CLI/LoginSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/LoginSpec.hs
@@ -75,6 +75,10 @@ spec = do
             renderLoginFrame False (initialLoginState [openai])
                 `shouldSatisfy` (not . Text.isInfixOf "secret-openai")
 
+        it "shows unchecked usage as an in-progress refresh" do
+            renderLoginFrame False (initialLoginState [openai])
+                `shouldSatisfy` Text.isInfixOf "checking usage"
+
 openai :: LoginAccount
 openai = LoginAccount
     { loginManagedId = Nothing


### PR DESCRIPTION
## Summary
- render the `/login` credential dashboard immediately with a loading state
- fetch account usage concurrently and redraw each account as its result arrives
- add reusable external-update support to the shared TTY overlay
- surface missing tokens and unexpected refresh failures as unavailable usage

## Verification
- `cabal repl agent-cli:lib:agent-cli --repl-options='-e :quit'`
- `GHCRTS='' cabal test agent-cli-test --test-options='--match Picker'`
- `GHCRTS='' cabal test agent-cli-test --test-options='--match Login'`
- tmux TTY smoke test: confirmed immediate `checking usage…` render followed by incremental OpenAI/Grok usage updates
