### PR TITLE
Fix provider fallback availability checks

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -12,7 +12,7 @@ module Agent.CLI
     ) where
 
 import Agent.CLI.Artifact (fencedCodeBlock, lastDiffBlock)
-import Agent.CLI.Auth (LoadedAuth(..), loadAuth)
+import Agent.CLI.Auth (LoadedAuth(..), loadAuth, probeLoadedAuth)
 import Agent.CLI.AgentViewport
     ( AgentEntry(..)
     , AgentTarget(..)
@@ -1929,7 +1929,7 @@ chooseAutomaticProviderTransition current unavailable0 sessionId pending apiErro
                     putTextLn stderr $ roleWarn color $
                         glyphWarn
                             <> providerSlug current
-                            <> " unavailable; switching to "
+                            <> " unavailable; trying this turn with "
                             <> providerSlug choice.modelProvider
                             <> "/"
                             <> choice.modelId
@@ -1969,14 +1969,21 @@ validateProviderTarget choice =
                 <> providerSlug choice.modelProvider
                 <> ": "
                 <> err
-        Right loaded
-            | loaded.loadedProvider /= choice.modelProvider ->
-                pure $ Left $
+        Right loaded ->
+            probeLoadedAuth loaded >>= \case
+                Left err -> pure $ Left $
                     "cannot switch to "
                         <> providerSlug choice.modelProvider
-                        <> ": auth resolved "
-                        <> providerSlug loaded.loadedProvider
-            | otherwise -> pure (Right ())
+                        <> ": credentials unavailable: "
+                        <> Text.pack (show err)
+                Right usable
+                    | usable.loadedProvider /= choice.modelProvider ->
+                        pure $ Left $
+                            "cannot switch to "
+                                <> providerSlug choice.modelProvider
+                                <> ": auth resolved "
+                                <> providerSlug usable.loadedProvider
+                    | otherwise -> pure (Right ())
 
 ensureTransitionSessionId
     :: Maybe (IORef (Either SessionCreate SessionHandle))

--- a/packages/agent-cli/src/Agent/CLI/Auth.hs
+++ b/packages/agent-cli/src/Agent/CLI/Auth.hs
@@ -5,6 +5,7 @@ module Agent.CLI.Auth
     , loadAuth
     , openAIOAuthClientId
     , openaiAuthStateFromJson
+    , probeLoadedAuth
     , reloadableFileCredentialProvider
     , xaiOAuthClientId
     ) where
@@ -85,6 +86,23 @@ loadAuth requested = runExceptT do
                 XAIProvider -> loadXai
                 OpenAIProvider -> loadOpenAi
                 OpenRouterProvider -> loadOpenRouter
+
+-- | Ask the token source whether it has a usable credential now without
+-- making a model request, preserving a successful checkout for later use.
+probeLoadedAuth :: LoadedAuth -> IO (Either ApiError LoadedAuth)
+probeLoadedAuth loaded = do
+    result <- getNextToken loaded.loadedTokenProvider Nothing
+    case result of
+        Left err -> pure (Left err)
+        Right credential
+            | credential.provider /= loaded.loadedProvider ->
+                pure $ Left $ ProviderError AuthenticationError
+                    "credential provider does not match loaded auth"
+                    Nothing
+            | otherwise -> do
+                tokenProvider <-
+                    seedTokenProvider loaded.loadedTokenProvider credential
+                pure $ Right loaded { loadedTokenProvider = tokenProvider }
 
 detectProvider :: Maybe Provider -> ExceptT Text IO Provider
 detectProvider (Just provider) = pure provider

--- a/packages/agent-cli/test/Agent/CLI/AuthSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/AuthSpec.hs
@@ -8,6 +8,7 @@ import Agent.Provider
     , Credential(..)
     , FailedCredential(..)
     , Provider(..)
+    , TokenProvider(..)
     , getNextToken
     )
 import Control.Exception.Safe (bracket)
@@ -35,6 +36,20 @@ spec = do
                                 "AGENT_BROKER_URL is set; also set AGENT_BROKER_TOKEN"
                         Right _ ->
                             expectationFailure "expected broker configuration failure"
+
+    describe "probeLoadedAuth" do
+        it "rejects auth whose accounts are currently cooling down" do
+            let retryAt = UTCTime (fromGregorian 2026 8 21) 3600
+                exhausted = LoadedAuth
+                    { loadedProvider = XAIProvider
+                    , loadedTokenProvider = TokenProvider \_ ->
+                        pure (Left (CredentialsExhausted retryAt))
+                    , loadedOpenAiPool = Nothing
+                    }
+            result <- probeLoadedAuth exhausted
+            case result of
+                Left err -> err `shouldBe` CredentialsExhausted retryAt
+                Right _ -> expectationFailure "expected exhausted auth"
 
     describe "openAIOAuthClientId" do
         it "uses the Codex public client id by default" do


### PR DESCRIPTION
## Summary
- preflight fallback token providers before rebuilding the session
- skip providers whose configured accounts are already known to be unavailable
- describe automatic transitions as trying the turn until the replacement succeeds
- add regression coverage for exhausted fallback credentials

## Validation
- `cabal repl agent-cli:test:agent-cli-test`, then `:main` — 366 examples, 0 failures
- live GHCi CLI smoke check in tmux
- `git diff --check`