### PR TITLE
Fix Esc to cancel active turns immediately

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Turn.hs
+++ b/packages/agent-cli/src/Agent/CLI/Turn.hs
@@ -3,6 +3,7 @@ module Agent.CLI.Turn
     ( runOneTurn
     ) where
 
+import Agent.Cancel (resetCancel)
 import Agent.CLI.CancelWatch (withEscCancel)
 import Agent.CLI.Interrupt (withTurnCancel)
 import Agent.CLI.Plan (extractProposedPlan, planDecisionFollowUp)
@@ -99,8 +100,11 @@ runOneTurn env@SessionEnv
     , sessionAbortSubagentTurn = abortSubagentTurn
     , sessionOnPersisted = onPersisted
     } promptText inputs =
-  withTurnCancel interrupt config.loopCancel $
-  withEscCancel config.loopCancel escPaused do
+  -- Clear the prior turn before publishing this flag to Ctrl-C / Esc.
+  -- Resetting inside runLoopInputs could erase the one-shot Esc signal.
+  resetCancel config.loopCancel >>
+  (withTurnCancel interrupt config.loopCancel
+    . withEscCancel config.loopCancel escPaused) do
     pending <- readIORef planMode.planStateRef
     when (pending == PlanPending) (activatePlanMode planMode)
     -- Create the session directory before tools run so first-turn subagents

--- a/packages/agent-core/src/Agent/Loop.hs
+++ b/packages/agent-core/src/Agent/Loop.hs
@@ -22,7 +22,7 @@ module Agent.Loop
     , runLoopInputs
     ) where
 
-import Agent.Cancel (CancelFlag, isCancelled, resetCancel, waitCancel)
+import Agent.Cancel (CancelFlag, isCancelled, waitCancel)
 import Agent.Error (ApiError)
 import Agent.InterAgentMessage (InterAgentMessage)
 import Agent.ToolDispatch
@@ -136,8 +136,9 @@ data LoopConfig = LoopConfig
     -- | 'Left' denies with that tool-output message; 'Right True' runs the
     -- tool; 'Right False' uses the usual user-rejection string.
     , loopApprove :: !(ToolCall -> IO (Either Text Bool))
-      -- | Soft-cancel latch. When set, the loop stops after the current tool
-      -- batch instead of asking the model for another step.
+      -- | Soft-cancel latch. The caller owns resetting it before publishing
+      -- the turn to input/interrupt handlers. When set, the loop stops after
+      -- the current tool batch instead of asking the model for another step.
     , loopCancel :: !CancelFlag
     }
 
@@ -192,7 +193,6 @@ runLoopInputs config0 previousResponseId firstInputs = do
     -- Tools run with mapConcurrently. Serialize onEvent so a printer
     -- (hPutStrLn on String is not atomic) cannot interleave characters.
     eventLock <- newMVar ()
-    resetCancel config0.loopCancel
     let config = config0
             { loopOnEvent = \event ->
                 withMVar eventLock \_ -> config0.loopOnEvent event

--- a/packages/agent-core/src/Agent/Transport/WebSocket.hs
+++ b/packages/agent-core/src/Agent/Transport/WebSocket.hs
@@ -5,6 +5,8 @@ module Agent.Transport.WebSocket
     , WebSocketSessionOptions(..)
     , defaultWebSocketSessionOptions
     , withWebSocketSession
+    , withWebSocketRequest
+    , invalidateWebSocketSession
     , sendWebSocketText
     , receiveWebSocketData
     , transientWsRetryDelayMicros
@@ -18,6 +20,8 @@ import Agent.Error (ApiError(..))
 import Control.Concurrent.Async (withAsync)
 import Control.Concurrent.STM
 import qualified Control.Exception as Exception
+import Control.Exception.Safe (onException)
+import Control.Monad (unless)
 import qualified Data.ByteString.Lazy as LBS
 import Data.Maybe (isJust)
 import Data.Text (Text)
@@ -34,6 +38,7 @@ data WebSocketSession = WebSocketSession
     { sessionOut :: !(TQueue OutCommand)
     , sessionIn :: !(TBQueue (Either ApiError LBS.ByteString))
     , sessionClosed :: !(TVar Bool)
+    , sessionPoisoned :: !(TVar (Maybe ApiError))
     }
 
 -- | Transport-level settings for a reusable WebSocket session.
@@ -53,6 +58,7 @@ defaultWebSocketSessionOptions = WebSocketSessionOptions
 data OutCommand
     = SendText !LBS.ByteString !(TMVar (Either ApiError ()))
     | SendControl !WS.Message
+    | CloseSession !LBS.ByteString
 
 -- | Run an action with a reusable WebSocket session.
 --
@@ -69,12 +75,14 @@ withWebSocketSession options connection action =
         outbound <- newTQueueIO
         inbound <- newTBQueueIO (fromIntegral (max 1 options.inboundFrameCapacity))
         closed <- newTVarIO False
+        poisoned <- newTVarIO Nothing
         let session = WebSocketSession
                 { sessionOut = outbound
                 , sessionIn = inbound
                 , sessionClosed = closed
+                , sessionPoisoned = poisoned
                 }
-        withAsync (readerLoop connection inbound outbound closed) \_ ->
+        withAsync (readerLoop connection inbound outbound closed poisoned) \_ ->
             withAsync (writerLoop connection outbound closed) \_ ->
                 action session
   where
@@ -82,19 +90,48 @@ withWebSocketSession options connection action =
         Just seconds | seconds > 0 -> WS.withPingThread connection seconds (pure ()) inner
         _ -> inner
 
+-- | Poison the reusable connection if a response consumer is interrupted.
+-- Once interrupted, its remaining frames cannot be assigned safely to a
+-- later request.
+withWebSocketRequest :: WebSocketSession -> IO value -> IO value
+withWebSocketRequest session action =
+    action `onException`
+        invalidateWebSocketSession session "response consumer interrupted"
+
+-- | Mark a response boundary as lost and asynchronously close the socket.
+invalidateWebSocketSession :: WebSocketSession -> Text -> IO ()
+invalidateWebSocketSession session reason = atomically do
+    current <- readTVar session.sessionPoisoned
+    case current of
+        Just _ -> pure ()
+        Nothing -> do
+            let apiError = ConnectionError
+                    ("WebSocket session invalidated: " <> reason)
+            writeTVar session.sessionPoisoned (Just apiError)
+            writeTVar session.sessionClosed True
+            writeTQueue session.sessionOut
+                (CloseSession (LBS.fromStrict (Text.encodeUtf8 reason)))
+
 -- | Send one text frame through the session's serialized writer.
 sendWebSocketText :: WebSocketSession -> LBS.ByteString -> IO (Either ApiError ())
 sendWebSocketText session bytes = do
     reply <- newEmptyTMVarIO
     queued <- atomically do
+        poisoned <- readTVar session.sessionPoisoned
         closed <- readTVar session.sessionClosed
-        if closed
-            then pure False
-            else writeTQueue session.sessionOut (SendText bytes reply) >> pure True
-    if not queued
-        then pure (Left connectionClosedError)
-        else atomically $
+        case poisoned of
+            Just apiError -> pure (Left apiError)
+            Nothing
+                | closed -> pure (Left connectionClosedError)
+                | otherwise -> do
+                    writeTQueue session.sessionOut (SendText bytes reply)
+                    pure (Right ())
+    case queued of
+        Left apiError -> pure (Left apiError)
+        Right () -> atomically $
             takeTMVar reply
+            `orElse`
+            poisonedSession session
             `orElse`
             (do
                 closed <- readTVar session.sessionClosed
@@ -104,13 +141,24 @@ sendWebSocketText session bytes = do
 -- | Receive the next application data frame. Control frames are handled by
 -- the session pump and are never exposed to callers.
 receiveWebSocketData :: WebSocketSession -> IO (Either ApiError LBS.ByteString)
-receiveWebSocketData session = atomically $
-    readTBQueue session.sessionIn
-    `orElse`
-    (do
-        closed <- readTVar session.sessionClosed
-        check closed
-        pure (Left connectionClosedError))
+receiveWebSocketData session = atomically do
+    poisoned <- readTVar session.sessionPoisoned
+    case poisoned of
+        Just apiError -> pure (Left apiError)
+        Nothing ->
+            readTBQueue session.sessionIn
+            `orElse`
+            (do
+                closed <- readTVar session.sessionClosed
+                check closed
+                pure (Left connectionClosedError))
+
+poisonedSession :: WebSocketSession -> STM (Either ApiError value)
+poisonedSession session = do
+    poisoned <- readTVar session.sessionPoisoned
+    case poisoned of
+        Just apiError -> pure (Left apiError)
+        Nothing -> retry
 
 connectionClosedError :: ApiError
 connectionClosedError = ConnectionError "WebSocket connection closed"
@@ -120,8 +168,9 @@ readerLoop
     -> TBQueue (Either ApiError LBS.ByteString)
     -> TQueue OutCommand
     -> TVar Bool
+    -> TVar (Maybe ApiError)
     -> IO ()
-readerLoop connection inbound outbound closed = loop
+readerLoop connection inbound outbound closed poisoned = loop
   where
     loop = do
         result <- Exception.try @Exception.SomeException (WS.receive connection)
@@ -134,8 +183,11 @@ readerLoop connection inbound outbound closed = loop
                 let bytes = case message of
                         WS.Text value _ -> value
                         WS.Binary value -> value
-                atomically (writeTBQueue inbound (Right bytes))
-                loop
+                stopped <- atomically do
+                    readTVar poisoned >>= \case
+                        Just _ -> pure True
+                        Nothing -> writeTBQueue inbound (Right bytes) >> pure False
+                unless stopped loop
             Right (WS.ControlMessage (WS.Ping payload)) -> do
                 atomically (writeTQueue outbound
                     (SendControl (WS.ControlMessage (WS.Pong payload))))
@@ -148,7 +200,12 @@ readerLoop connection inbound outbound closed = loop
 
     terminate reason = atomically do
         writeTVar closed True
-        writeTBQueue inbound (Left (ConnectionError reason))
+        readTVar poisoned >>= \case
+            Just _ -> pure ()
+            Nothing -> do
+                full <- isFullTBQueue inbound
+                unless full $
+                    writeTBQueue inbound (Left (ConnectionError reason))
 
 writerLoop
     :: WS.Connection
@@ -160,6 +217,13 @@ writerLoop connection outbound closed = loop
     loop = do
         command <- atomically (readTQueue outbound)
         case command of
+            CloseSession reason -> do
+                result <- Exception.try @Exception.SomeException
+                    (WS.sendClose connection reason)
+                case result of
+                    Left exception | isAsyncException exception ->
+                        Exception.throwIO exception
+                    _ -> pure ()
             SendControl message -> do
                 result <- Exception.try @Exception.SomeException (WS.send connection message)
                 case result of

--- a/packages/agent-core/test/Agent/LoopSpec.hs
+++ b/packages/agent-core/test/Agent/LoopSpec.hs
@@ -273,6 +273,16 @@ spec = describe "runLoop" do
         result <- runLoop config0 Nothing "go"
         result `shouldBe` Left (LoopCancelled [])
 
+    it "does not clear a cancel requested before the loop starts" do
+        submissions <- newIORef []
+        backend <- scriptedBackend submissions
+            [Right (emptyTurnOutput "resp-too-late" [] (Just "too late"))]
+        config <- testConfig backend
+        requestCancel config.loopCancel
+        result <- runLoop config Nothing "go"
+        result `shouldBe` Left (LoopCancelled [])
+        readIORef submissions `shouldReturn` []
+
     it "sums token usage across model steps in one user turn" do
         submissions <- newIORef []
         backend <- scriptedBackend submissions

--- a/packages/agent-core/test/Agent/Transport/WebSocketSpec.hs
+++ b/packages/agent-core/test/Agent/Transport/WebSocketSpec.hs
@@ -2,7 +2,18 @@ module Agent.Transport.WebSocketSpec (spec) where
 
 import Agent.Error (ApiError(..))
 import Agent.Transport.WebSocket
-import Control.Concurrent (Chan, forkFinally, newChan, newEmptyMVar, putMVar, readChan, takeMVar, writeChan)
+import Control.Concurrent
+    ( Chan
+    , MVar
+    , forkFinally
+    , killThread
+    , newChan
+    , newEmptyMVar
+    , putMVar
+    , readChan
+    , takeMVar
+    , writeChan
+    )
 import Control.Exception (SomeException, finally, throwIO, toException)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BS8
@@ -68,6 +79,9 @@ spec = describe "Agent.Transport.WebSocket" do
                     Left exception -> expectationFailure (show exception)
                     Right bytes -> bytes `shouldBe` "request-data"
 
+    it "poisons a cancelled request instead of exposing queued frames" do
+        withConnectionPair cancelledRequestIsolated
+
 testSessionOptions :: WebSocketSessionOptions
 testSessionOptions = defaultWebSocketSessionOptions
     { clientPingIntervalSeconds = Nothing
@@ -111,3 +125,42 @@ requireWithin message action = do
     case result of
         Just value -> pure value
         Nothing -> expectationFailure message >> fail message
+
+cancelledRequestIsolated :: WS.Connection -> WS.Connection -> IO ()
+cancelledRequestIsolated client server = do
+    firstReceived <- newEmptyMVar
+    never <- newEmptyMVar
+    finished <- newEmptyMVar
+    withWebSocketSession testSessionOptions client \session -> do
+        worker <- forkFinally
+            (cancelledRequest session firstReceived never)
+            (putMVar finished)
+        request <- WS.receiveData server :: IO LBS.ByteString
+        request `shouldBe` "request-data"
+        WS.sendTextData server ("first-frame" :: LBS.ByteString)
+        takeMVar firstReceived `shouldReturn` Right "first-frame"
+        WS.sendTextData server ("stale-frame" :: LBS.ByteString)
+        killThread worker
+        result <- requireWithin
+            "timed out waiting for cancelled request"
+            (takeMVar finished)
+        case result of
+            Left _ -> pure ()
+            Right () -> expectationFailure "cancelled request completed normally"
+        receiveWebSocketData session
+            `shouldReturn` Left
+                (ConnectionError
+                    "WebSocket session invalidated: response consumer interrupted")
+
+cancelledRequest
+    :: WebSocketSession
+    -> MVar (Either ApiError LBS.ByteString)
+    -> MVar ()
+    -> IO ()
+cancelledRequest session firstReceived never =
+    withWebSocketRequest session do
+        sendWebSocketText session "request-data"
+            `shouldReturn` Right ()
+        first <- receiveWebSocketData session
+        putMVar firstReceived first
+        takeMVar never

--- a/packages/agent-openai/src/Agent/OpenAI/WebSocketClient.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/WebSocketClient.hs
@@ -284,10 +284,11 @@ sendWsRequestWithEventsAndOptions options cc request previousResponseId onEvent 
     sendOverWs session = do
         let wsPayload = buildWsPayloadWithOptions options request previousResponseId
             encoded = Aeson.encode wsPayload
-        sendRes <- WebSocket.sendWebSocketText session encoded
-        case sendRes of
-            Left apiError -> pure (Left apiError)
-            Right () -> receiveWsResponse session onEvent
+        WebSocket.withWebSocketRequest session do
+            sendRes <- WebSocket.sendWebSocketText session encoded
+            case sendRes of
+                Left apiError -> pure (Left apiError)
+                Right () -> receiveWsResponse session onEvent
 
 -- | Pure WebSocket envelope builder, exported for payload contract tests.
 -- All fields are flattened at the top level (not nested inside "response").
@@ -336,6 +337,8 @@ receiveWsResponse cc onEvent = do
                     Left err -> do
                         let msgPreview = Text.decodeUtf8With Text.lenientDecode (LBS.toStrict msgBytes)
                         logStreamStats "json_decode_error" itemsRef framesRef bytesRef
+                        WebSocket.invalidateWebSocketSession cc
+                            "received a malformed response frame"
                         pure $ Left (JsonDecodeError (Text.pack err) (Text.take 500 msgPreview))
                     Right event -> do
                         onEvent event


### PR DESCRIPTION
## Summary

- reset the per-turn cancel latch before publishing it to the Esc/Ctrl-C handlers, so an immediate Esc cannot be erased during turn startup
- poison and close interrupted OpenAI Responses WebSockets so abandoned reasoning frames cannot leak into the next request
- reconnect transparently after an interrupted response and add regressions for pre-latched cancellation and queued stale frames

## Testing

- `nix develop -c env GHCRTS= cabal test agent-core-test --test-option=--match=runLoop`
- `nix develop -c env GHCRTS= cabal test agent-core-test --test-option=--match=WebSocket`
- `nix develop -c env GHCRTS= cabal test agent-openai-test --test-option=--match=WebSocket`
- `nix develop -c env GHCRTS= cabal test agent-cli-test --test-option=--match=Cancel`
- tmux smoke test: Esc during active reasoning returned immediately; the next request reconnected and returned its own response rather than the abandoned response