### PR TITLE
Show Grok account emails in login manager

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Auth.hs
+++ b/packages/agent-cli/src/Agent/CLI/Auth.hs
@@ -2,6 +2,7 @@
 module Agent.CLI.Auth
     ( LoadedAuth(..)
     , grokCredentialFromAuthJson
+    , grokEmailFromAuthJson
     , loadAuth
     , openAIOAuthClientId
     , openaiAuthStateFromJson
@@ -34,7 +35,7 @@ import Agent.Provider
     , seedTokenProvider
     )
 import Agent.OpenRouter.Credential (credentialFromApiKey)
-import Agent.XAI.Auth (accountIdFromAccessToken)
+import Agent.XAI.Auth (accountIdFromAccessToken, emailFromToken)
 import Control.Applicative ((<|>))
 import Control.Monad (when)
 import Control.Monad.Trans.Class (lift)
@@ -419,6 +420,26 @@ grokCredentialFromAuthJson raw = do
             , Just token <- [entryToken nested]
             ]
     firstNestedToken _ = Nothing
+
+grokEmailFromAuthJson :: Text -> Maybe Text
+grokEmailFromAuthJson raw = do
+    value <- Aeson.decodeStrict (TextEncoding.encodeUtf8 raw)
+    entryEmail value <|> firstNestedEmail value
+  where
+    entryEmail (Aeson.Object object) =
+        textField "email" object
+            <|> (textField "id_token" object >>= emailFromToken)
+            <|> (textField "access_token" object >>= emailFromToken)
+            <|> (textField "key" object >>= emailFromToken)
+    entryEmail _ = Nothing
+
+    firstNestedEmail (Aeson.Object object) =
+        listToMaybe
+            [ email
+            | nested <- KeyMap.elems object
+            , Just email <- [entryEmail nested]
+            ]
+    firstNestedEmail _ = Nothing
 
 grokCredential :: Text -> Credential
 grokCredential token = Credential

--- a/packages/agent-cli/src/Agent/CLI/Login.hs
+++ b/packages/agent-cli/src/Agent/CLI/Login.hs
@@ -17,6 +17,7 @@ module Agent.CLI.Login
 
 import Agent.CLI.Auth
     ( grokCredentialFromAuthJson
+    , grokEmailFromAuthJson
     , openAIOAuthClientId
     , openaiAuthStateFromJson
     , xaiOAuthClientId
@@ -316,8 +317,7 @@ managedLoginAccount now (metadata, secret) =
         { loginManagedId = Just metadata.managedId
         , loginProvider = metadata.managedProvider
         , loginAccountId = metadata.managedAccountId
-        , loginLabel = fromMaybe metadata.managedLabel
-            (openAIAccountEmail =<< openAIAuth)
+        , loginLabel = fromMaybe metadata.managedLabel managedAccountEmail
         , loginBilling = case metadata.managedBilling of
             ManagedSubscription -> SubscriptionBilling Nothing
             ManagedApiCredits -> ApiCreditsBilling
@@ -329,6 +329,15 @@ managedLoginAccount now (metadata, secret) =
         , loginEnabled = metadata.managedEnabled
         }
   where
+    managedAccountEmail = case metadata.managedProvider of
+        OpenAIProvider -> openAIAccountEmail =<< openAIAuth
+        XAIProvider -> case metadata.managedAuthKind of
+            ManagedGrokAuthJson ->
+                grokEmailFromAuthJson secret.secretPayload
+            ManagedBearerToken ->
+                XAIAuth.emailFromToken secret.secretPayload
+            ManagedOpenAIAuthJson -> Nothing
+        OpenRouterProvider -> Nothing
     openAIAuth = case metadata.managedAuthKind of
         ManagedOpenAIAuthJson ->
             openaiAuthStateFromJson now
@@ -504,6 +513,9 @@ connectXAI color = do
                             fromMaybe "grok"
                                 (XAIAuth.accountIdFromAccessToken
                                     tokens.accessToken)
+                        label = fromMaybe "Grok" $
+                            (tokens.idToken >>= XAIAuth.emailFromToken)
+                                <|> XAIAuth.emailFromToken tokens.accessToken
                         authJson = Aeson.object
                             [ "access_token" .= tokens.accessToken
                             , "refresh_token" .= tokens.refreshToken
@@ -512,7 +524,7 @@ connectXAI color = do
                     storeConnectedCredential color
                         XAIProvider
                         accountId
-                        "Grok"
+                        label
                         ManagedSubscription
                         ManagedGrokAuthJson
                         (Text.decodeUtf8
@@ -734,7 +746,9 @@ grokAccount token source authKind payload =
     subscriptionAccount
         XAIProvider
         (fromMaybe "grok" (XAIAuth.accountIdFromAccessToken token))
-        "Grok"
+        (fromMaybe "Grok"
+            (grokEmailFromAuthJson payload
+                <|> XAIAuth.emailFromToken token))
         source
         token
         authKind

--- a/packages/agent-cli/test/Agent/CLI/AuthSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/AuthSpec.hs
@@ -100,6 +100,17 @@ spec = do
                 "{\"issuer::client\":{\"access_token\":\"nested-tok\"}}"
                 `shouldBe` Just "nested-tok"
 
+    describe "grokEmailFromAuthJson" do
+        it "reads profile emails and nested id-token claims" do
+            let token =
+                    "e30.eyJlbWFpbCI6InBlcnNvbkBleGFtcGxlLmNvbSJ9."
+            grokEmailFromAuthJson
+                "{\"issuer::client\":{\"email\":\"profile@example.com\"}}"
+                `shouldBe` Just "profile@example.com"
+            grokEmailFromAuthJson
+                ("{\"issuer::client\":{\"id_token\":\"" <> token <> "\"}}")
+                `shouldBe` Just "person@example.com"
+
     describe "reloadableFileCredentialProvider" do
         it "returns the cached credential without reloading" do
             loads <- newIORef (0 :: Int)

--- a/packages/agent-cli/test/Agent/CLI/LoginSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/LoginSpec.hs
@@ -77,6 +77,12 @@ spec = do
                         [openai { loginLabel = "person@example.com" }]
             body `shouldSatisfy` Text.isInfixOf "person@example.com"
 
+        it "shows the Grok account email in the account label" do
+            let body = renderLoginFrame False $
+                    initialLoginState
+                        [grok { loginLabel = "person@example.com" }]
+            body `shouldSatisfy` Text.isInfixOf "person@example.com"
+
         it "does not render access tokens" do
             renderLoginFrame False (initialLoginState [openai])
                 `shouldSatisfy` (not . Text.isInfixOf "secret-openai")

--- a/packages/agent-xai/src/Agent/XAI/Auth.hs
+++ b/packages/agent-xai/src/Agent/XAI/Auth.hs
@@ -26,6 +26,7 @@ module Agent.XAI.Auth
     , completeDeviceAuthorization
     , refreshAccessToken
     , accountIdFromAccessToken
+    , emailFromToken
     ) where
 
 import Agent.Http.Url (trimTrailingSlash)
@@ -248,10 +249,18 @@ accountIdFromAccessToken accessToken = do
     orElse Nothing b = b
     orElse _ b = b
 
+emailFromToken :: Text -> Maybe Text
+emailFromToken token = do
+    payload <- decodeJwtPayload token
+    email <- payload.email
+    let trimmed = Text.strip email
+    if Text.null trimmed then Nothing else Just trimmed
+
 data JwtClaims = JwtClaims
     { subject :: !(Maybe Text)
     , principalIdSnake :: !(Maybe Text)
     , principalIdCamel :: !(Maybe Text)
+    , email :: !(Maybe Text)
     }
 
 instance Aeson.FromJSON JwtClaims where
@@ -259,6 +268,7 @@ instance Aeson.FromJSON JwtClaims where
         <$> object Aeson..:? "sub"
         <*> object Aeson..:? "principal_id"
         <*> object Aeson..:? "principalId"
+        <*> object Aeson..:? "email"
 
 decodeJwtPayload :: Text -> Maybe JwtClaims
 decodeJwtPayload token = do

--- a/packages/agent-xai/test/Agent/XAI/AuthSpec.hs
+++ b/packages/agent-xai/test/Agent/XAI/AuthSpec.hs
@@ -151,6 +151,14 @@ spec = do
                 `shouldBe` Just "principal-9"
             accountIdFromAccessToken "not-a-jwt" `shouldBe` Nothing
 
+    describe "emailFromToken" do
+        it "extracts and trims the standard email claim" do
+            emailFromToken (unsignedJwt (Aeson.object
+                [ "email" Aeson..= (" person@example.com " :: Text) ]))
+                `shouldBe` Just "person@example.com"
+            emailFromToken (unsignedJwt (Aeson.object []))
+                `shouldBe` Nothing
+
 --------------------------------------------------------------------------------
 -- Mock auth server
 --------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- read Grok account emails from auth profile metadata and JWT claims
- show the email as the account label in `/login`
- apply it to new, managed, file-based, and environment Grok credentials
- fall back to `Grok` when no email is available

## Validation
- xAI auth spec in GHCi: 10 examples, 0 failures
- CLI auth + login specs in GHCi: 22 examples, 0 failures
- tmux smoke test confirmed the Grok email appears in the live credential dashboard
