### PR TITLE
Harden collaboration and subagent lifecycle

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -41,6 +41,7 @@ import Agent.CLI.Btw
     ( BtwBackendFactory
     , formatBtwError
     , runBtwWithCancel
+    , trimDanglingToolSuffix
     )
 import Agent.CLI.CancelWatch (withEscCancel, withStdinPaused)
 import Agent.CLI.Clipboard
@@ -123,6 +124,7 @@ import Agent.CLI.Status
     )
 import Agent.CLI.SubagentStore
     ( SubagentDiskMeta(..)
+    , forkSubagentTranscript
     , loadSubagentState
     , saveSubagentState
     )
@@ -221,11 +223,12 @@ import Agent.Subagents
     , getSubagentCwd
     , getSubagentIdentity
     , getTaskPath
+    , interruptActiveSubagents
     , listAgents
     , newSubagentRegistry
     , restoreSubagent
-    , restoreSubagentAt
-    , restoreSubagentAtWithCwd
+    , restoreSubagentAtStatus
+    , restoreSubagentAtWithCwdStatus
     , restoreSubagentWithCwd
     , setPreviousResponseId
     , setSubagentOnComplete
@@ -242,11 +245,16 @@ import Agent.Tools.Grok.Task
     , GrokSubagentSpecs
     , defaultSubagentType
     , lookupAgentModel
+    , lookupAgentReasoningEffort
     , lookupAgentType
     , recordAgentSpec
     )
 import Agent.Subagents.TaskPath (parseTaskPath, taskPathRoot, taskPathText)
-import Agent.Tools.MultiAgents (MultiAgentContext(..), SubagentWorktree(..))
+import Agent.Tools.MultiAgents
+    ( CollaborationSpawnOptions(..)
+    , MultiAgentContext(..)
+    , SubagentWorktree(..)
+    )
 import Agent.Tools.PlanMode
     ( PlanModeEnv(..)
     , PlanModeHooks
@@ -568,6 +576,7 @@ runAgent options transition = do
     -- Per-subagent transcripts / previous ids, shared across send_input / task.
     subagentSessions <- newIORef Map.empty
     subagentStoreRoot <- newIORef Nothing
+    subagentForkSource <- newIORef (Nothing :: Maybe (IORef [ResponseItem]))
     pendingNotices <- newIORef ([] :: [TurnInput])
     registry <- newSubagentRegistry defaultSubagentConfig cwd
         (\_ _ _ _ -> pure $ Left LoopNoResponseId)
@@ -596,6 +605,10 @@ runAgent options transition = do
                                 Left err -> pure (Left err)
                                 Right () -> pure (Right ())
                         }
+            , multiPrepareSpawn = Just
+                (prepareCollaborationSpawn
+                    subagentSessions subagentStoreRoot agentTypesRef
+                    subagentForkSource)
             , multiSendToRoot = Just sendToRoot
             }
     coding <- codingToolsForWithTypes provider toolEnv (Just planHooks) multiCtx agentTypesRef
@@ -607,8 +620,9 @@ runAgent options transition = do
                 sessions <- readIORef subagentSessions
                 case Map.lookup agentId sessions of
                     Just session ->
-                        persistSubagentSnapshot subagentStoreRoot ctx.multiRegistry
-                            agentTypesRef agentId session.subSessionTranscript
+                        persistSubagentSnapshotWithStatus
+                            subagentStoreRoot ctx.multiRegistry agentTypesRef
+                            agentId status session.subSessionTranscript
                     Nothing -> pure ()
         Nothing -> pure ()
     let claimCurrentSession handle
@@ -644,9 +658,10 @@ runAgent options transition = do
         closeAll = do
             case multiCtx of
                 Just ctx -> do
-                    closeSubagentRegistry ctx.multiRegistry
+                    interruptActiveSubagents ctx.multiRegistry
                     flushAllSubagentSnapshots subagentStoreRoot ctx.multiRegistry
                         subagentSessions agentTypesRef
+                    closeSubagentRegistry ctx.multiRegistry
                 Nothing -> pure ()
             closeSessionProcessManager sessionProcessManager
             readIORef activeSessionLock >>= mapM_ releaseSessionLock
@@ -662,6 +677,7 @@ runAgent options transition = do
                 Nothing -> resumed >>= \(meta, _) -> meta.metaLastResponseId
         paramsRef <- newIORef params
         transcriptRef <- newIORef initialItems
+        writeIORef subagentForkSource (Just transcriptRef)
         prompt <- loadPrompt options
         let titleHint = case resumed of
                 Just (meta, _) -> Just meta.metaTitle
@@ -700,10 +716,7 @@ runAgent options transition = do
                                                 policy
                                                 planHooks
                                                 paramsRef
-                                                wsLock
                                                 loaded.loadedTokenProvider
-                                                wsHealthy
-                                                conn
                                                 ctx.multiRegistry
                                                 subagentSessions
                                                 subagentStoreRoot
@@ -2347,6 +2360,30 @@ syncStoreRootFromPlan storeRootRef planMode = do
                 Just dir -> writeIORef storeRootRef (Just dir)
                 Nothing -> pure ()
 
+prepareCollaborationSpawn
+    :: IORef (Map SubagentId SubagentSession)
+    -> SubagentStoreRoot
+    -> GrokSubagentSpecs
+    -> IORef (Maybe (IORef [ResponseItem]))
+    -> SubagentId
+    -> CollaborationSpawnOptions
+    -> IO ()
+prepareCollaborationSpawn
+        sessionsRef storeRootRef typesRef sourceRef agentId spawnOptions = do
+    recordAgentSpec typesRef agentId GrokSubagentSpec
+        { agentType = defaultSubagentType
+        , modelOverride = spawnOptions.collaborationModel
+        , reasoningEffortOverride =
+            spawnOptions.collaborationReasoningEffort
+        }
+    session <-
+        lookupOrCreateSubagentSession
+            sessionsRef storeRootRef typesRef agentId
+    source <- readIORef sourceRef
+    sourceItems <- maybe (pure []) readIORef source
+    writeIORef session.subSessionTranscript
+        (forkSubagentTranscript spawnOptions.collaborationForkTurns sourceItems)
+
 persistSubagentSnapshot
     :: SubagentStoreRoot
     -> SubagentRegistry
@@ -2355,18 +2392,34 @@ persistSubagentSnapshot
     -> IORef [ResponseItem]
     -> IO ()
 persistSubagentSnapshot storeRootRef registry typesRef agentId transcriptRef = do
+    status <- getStatus registry agentId
+    persistSubagentSnapshotWithStatus
+        storeRootRef registry typesRef agentId status transcriptRef
+
+persistSubagentSnapshotWithStatus
+    :: SubagentStoreRoot
+    -> SubagentRegistry
+    -> GrokSubagentSpecs
+    -> SubagentId
+    -> SubagentStatus
+    -> IORef [ResponseItem]
+    -> IO ()
+persistSubagentSnapshotWithStatus
+        storeRootRef registry typesRef agentId status transcriptRef = do
     mroot <- readIORef storeRootRef
     case mroot of
         Nothing -> pure ()
         Just sessionDir -> do
-            items <- readIORef transcriptRef
+            items <- trimDanglingToolSuffix <$> readIORef transcriptRef
             previous <- getPreviousResponseId registry agentId
             agentType <- lookupAgentType typesRef agentId
             agentModel <- lookupAgentModel typesRef agentId
+            reasoningEffort <- lookupAgentReasoningEffort typesRef agentId
             agentCwd <- getSubagentCwd registry agentId
             identity <- getSubagentIdentity registry agentId
             _ <- saveSubagentState
-                sessionDir agentId items previous agentType agentModel agentCwd identity
+                sessionDir agentId items previous status agentType agentModel
+                reasoningEffort agentCwd identity
             pure ()
 
 flushAllSubagentSnapshots
@@ -2420,6 +2473,8 @@ restoreAgentFromDisk storeRootRef registry sessionsRef typesRef agentId = do
                                         recordAgentSpec typesRef agentId GrokSubagentSpec
                                             { agentType
                                             , modelOverride = meta.diskAgentModel
+                                            , reasoningEffortOverride =
+                                                meta.diskReasoningEffort
                                             }
                                     Nothing -> pure ()
                                 transcript <- newIORef items
@@ -2432,24 +2487,26 @@ restoreAgentFromDisk storeRootRef registry sessionsRef typesRef agentId = do
                                 pure (Right ())
     reopenPersisted meta =
         case meta.diskTaskPath of
-            Nothing ->
-                reopenInMemory meta.diskPreviousResponseId meta.diskCwd
+            Nothing -> restoreAt taskPathRoot
             Just pathText ->
                 case parseTaskPath pathText of
                     Left err -> pure (Left err)
-                    Right taskPath -> do
-                        let restoreAt =
-                                case meta.diskCwd of
-                                    Just childCwd ->
-                                        restoreSubagentAtWithCwd
-                                            registry childCwd
-                                    Nothing ->
-                                        restoreSubagentAt registry
-                        restoreAt
-                            agentId meta.diskParentId taskPath
-                            (fromMaybe 1 meta.diskDepth)
-                            Nothing meta.diskPreviousResponseId
-                            >>= pure . fmap (const ())
+                    Right taskPath -> restoreAt taskPath
+      where
+        restoredStatus = fromMaybe (Completed Nothing) meta.diskStatus
+        restoreAt taskPath = do
+            let restore =
+                    case meta.diskCwd of
+                        Just childCwd ->
+                            restoreSubagentAtWithCwdStatus
+                                registry childCwd
+                        Nothing ->
+                            restoreSubagentAtStatus registry
+            restore
+                agentId meta.diskParentId taskPath
+                (fromMaybe 1 meta.diskDepth)
+                Nothing meta.diskPreviousResponseId restoredStatus
+                >>= pure . fmap (const ())
     reopenInMemory previous requestedCwd = do
         restored <- case requestedCwd of
             Just childCwd ->
@@ -2488,28 +2545,31 @@ freshOpenAiBackend provider getParams transcript = Backend \previous inputs onEv
     withCodexWsRetrying provider \conn _credential ->
         let Backend submit = openAiBackend conn getParams transcript
         in submit previous inputs onEvent
--- | Child Codex agent: per-agent transcript (retained across send_input), same
--- WS (locked), nested multi-agent tools.
+-- | Child Codex agent: per-agent transcript retained across follow-ups,
+-- independently scoped WebSocket requests, and nested multi-agent tools.
 runCodexSubagent
     :: CliOptions
     -> ApprovalPolicy
     -> PlanModeHooks
     -> IORef ResponseCreateParams
-    -> MVar ()
     -> TokenProvider
-    -> IORef Bool
-    -> CodexConn
     -> SubagentRegistry
     -> IORef (Map SubagentId SubagentSession)
     -> SubagentStoreRoot
     -> GrokSubagentSpecs
     -> Maybe (InterAgentMessage -> IO (Either Text Text))
     -> RunSubagent
-runCodexSubagent options policy planHooks paramsRef wsLock tokenProvider connectionHealthy conn registry sessionsRef storeRootRef typesRef sendToRoot =
+runCodexSubagent options policy planHooks paramsRef tokenProvider registry sessionsRef storeRootRef typesRef sendToRoot =
     \env previous prompt onEvent -> do
         parentParams <- readIORef paramsRef
         childEnv <- defaultToolEnv env.subCwd
         childPath <- fromMaybe taskPathRoot <$> getTaskPath registry env.subId
+        session <-
+            lookupOrCreateSubagentSession
+                sessionsRef storeRootRef typesRef env.subId
+        nestedForkSource <- newIORef (Just session.subSessionTranscript)
+        childModel <- lookupAgentModel typesRef env.subId
+        childEffort <- lookupAgentReasoningEffort typesRef env.subId
         -- Inherit soft-cancel from the registry-owned child flag.
         let childToolEnv = childEnv { toolCancel = env.subCancel }
             childCtx = MultiAgentContext
@@ -2520,20 +2580,25 @@ runCodexSubagent options policy planHooks paramsRef wsLock tokenProvider connect
                 , multiRootTurnId = pure env.subRootTurnId
                 , multiResumeFromDisk = Nothing
                 , multiCreateWorktree = Nothing
+                , multiPrepareSpawn = Just
+                    (prepareCollaborationSpawn
+                        sessionsRef storeRootRef typesRef nestedForkSource)
                 , multiSendToRoot = sendToRoot
                 }
         -- Child tools create their own PlanModeEnv; sync store root from parent
         -- params is handled by noteSessionDir on the parent path. If the parent
         -- already has a session dir in storeRootRef, we persist; otherwise skip.
-        session <- lookupOrCreateSubagentSession sessionsRef storeRootRef typesRef env.subId
         coding <- codingToolsFor OpenAIProvider childToolEnv (Just planHooks) (Just childCtx)
         syncStoreRootFromPlan storeRootRef coding.codingPlanMode
         flip finally coding.codingClose do
             today <- utctDay <$> getCurrentTime
-            let model = fromMaybe (defaultModelFor OpenAIProvider) parentParams.model
-                effort = case parentParams.reasoning of
+            let model = fromMaybe
+                    (fromMaybe (defaultModelFor OpenAIProvider) parentParams.model)
+                    childModel
+                inheritedEffort = case parentParams.reasoning of
                     Just cfg -> fromMaybe (defaultEffortFor OpenAIProvider) cfg.effort
                     Nothing -> defaultEffortFor OpenAIProvider
+                effort = fromMaybe inheritedEffort childEffort
                 baseInstructions =
                     fromMaybe
                         (systemPrompt OpenAIProvider env.subCwd today True)
@@ -2550,9 +2615,8 @@ runCodexSubagent options policy planHooks paramsRef wsLock tokenProvider connect
             toolRegistry <- requireToolRegistry tools
             childParamsRef <- newIORef childParams
             let backend =
-                    lockedOpenAiBackend wsLock tokenProvider connectionHealthy conn
-                        (readIORef childParamsRef)
-                        session.subSessionTranscript
+                    freshOpenAiBackend tokenProvider
+                        (readIORef childParamsRef) session.subSessionTranscript
                 config = LoopConfig
                     { loopBackend = backend
                     , loopTools = toolRegistry
@@ -2566,7 +2630,9 @@ runCodexSubagent options policy planHooks paramsRef wsLock tokenProvider connect
             case result of
                 Right loopResult ->
                     setPreviousResponseId registry env.subId loopResult.finalResponseId
-                Left _ -> pure ()
+                Left _ ->
+                    modifyIORef' session.subSessionTranscript
+                        trimDanglingToolSuffix
             persistSubagentSnapshot storeRootRef registry typesRef env.subId
                 session.subSessionTranscript
             pure result
@@ -2589,6 +2655,10 @@ runHttpSubagent options policy planHooks paramsRef provider mkBackend registry s
         parentParams <- readIORef paramsRef
         childEnv <- defaultToolEnv env.subCwd
         childPath <- fromMaybe taskPathRoot <$> getTaskPath registry env.subId
+        session <-
+            lookupOrCreateSubagentSession
+                sessionsRef storeRootRef typesRef env.subId
+        nestedForkSource <- newIORef (Just session.subSessionTranscript)
         let childToolEnv = childEnv { toolCancel = env.subCancel }
             childCtx = MultiAgentContext
                 { multiRegistry = registry
@@ -2598,20 +2668,24 @@ runHttpSubagent options policy planHooks paramsRef provider mkBackend registry s
                 , multiRootTurnId = pure env.subRootTurnId
                 , multiResumeFromDisk = Nothing
                 , multiCreateWorktree = Nothing
+                , multiPrepareSpawn = Just
+                    (prepareCollaborationSpawn
+                        sessionsRef storeRootRef typesRef nestedForkSource)
                 , multiSendToRoot = Nothing
                 }
-        session <- lookupOrCreateSubagentSession sessionsRef storeRootRef typesRef env.subId
         agentType <- fromMaybe defaultSubagentType <$> lookupAgentType typesRef env.subId
         childModel <- lookupAgentModel typesRef env.subId
+        childEffort <- lookupAgentReasoningEffort typesRef env.subId
         coding <- codingToolsFor provider childToolEnv (Just planHooks) (Just childCtx)
         flip finally coding.codingClose do
             today <- utctDay <$> getCurrentTime
             let model = fromMaybe
                     (fromMaybe (defaultModelFor provider) parentParams.model)
                     childModel
-                effort = case parentParams.reasoning of
+                inheritedEffort = case parentParams.reasoning of
                     Just cfg -> fromMaybe (defaultEffortFor provider) cfg.effort
                     Nothing -> defaultEffortFor provider
+                effort = fromMaybe inheritedEffort childEffort
                 baseInstructions = systemPrompt provider env.subCwd today True
                 instructions =
                     baseInstructions
@@ -2638,7 +2712,9 @@ runHttpSubagent options policy planHooks paramsRef provider mkBackend registry s
             case result of
                 Right loopResult ->
                     setPreviousResponseId registry env.subId loopResult.finalResponseId
-                Left _ -> pure ()
+                Left _ ->
+                    modifyIORef' session.subSessionTranscript
+                        trimDanglingToolSuffix
             persistSubagentSnapshot storeRootRef registry typesRef env.subId
                 session.subSessionTranscript
             pure result
@@ -2690,6 +2766,8 @@ lookupOrCreateSubagentSession sessionsRef storeRootRef typesRef agentId = do
                     recordAgentSpec typesRef agentId GrokSubagentSpec
                         { agentType
                         , modelOverride = meta >>= (.diskAgentModel)
+                        , reasoningEffortOverride =
+                            meta >>= (.diskReasoningEffort)
                         }
                 Nothing -> pure ()
             let session = SubagentSession { subSessionTranscript = transcript }

--- a/packages/agent-cli/src/Agent/CLI/SubagentStore.hs
+++ b/packages/agent-cli/src/Agent/CLI/SubagentStore.hs
@@ -10,22 +10,27 @@ module Agent.CLI.SubagentStore
     ( SubagentDiskMeta(..)
     , isValidSubagentStoreId
     , subagentStoreDir
+    , forkSubagentTranscript
     , saveSubagentState
     , loadSubagentState
     ) where
 
+import Agent.CLI.Btw (trimDanglingToolSuffix)
 import Agent.FileRetry (retryOnFileBusy, writeLazyFileAtomically)
 import Agent.OsPath (OsPath, fromFilePath, toFilePath, toText)
-import Agent.Responses.Types (ResponseItem)
-import Agent.Subagents (SubagentId(..), SubagentIdentity(..))
+import Agent.Responses.Types
+import Agent.Subagents (SubagentId(..), SubagentIdentity(..), SubagentStatus(..))
 import Agent.Subagents.TaskPath (taskPathText)
 import Control.Exception.Safe (tryAny)
 import Data.Aeson (FromJSON(..), ToJSON(..), object, withObject, (.:?), (.=))
 import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.KeyMap as KeyMap
+import Data.Aeson.Types (Parser)
 import qualified Data.ByteString.Lazy as LBS
 import Data.Char (isAlphaNum)
 import Data.Text (Text)
 import qualified Data.Text as Text
+import Text.Read (readMaybe)
 import System.Directory.OsPath
     ( createDirectoryIfMissing
     , doesFileExist
@@ -35,8 +40,10 @@ import System.Posix.Files (setFileMode)
 
 data SubagentDiskMeta = SubagentDiskMeta
     { diskPreviousResponseId :: !(Maybe Text)
+    , diskStatus :: !(Maybe SubagentStatus)
     , diskAgentType :: !(Maybe Text)
     , diskAgentModel :: !(Maybe Text)
+    , diskReasoningEffort :: !(Maybe Text)
     , diskCwd :: !(Maybe OsPath)
     , diskTaskPath :: !(Maybe Text)
     , diskParentId :: !(Maybe SubagentId)
@@ -46,8 +53,10 @@ data SubagentDiskMeta = SubagentDiskMeta
 instance ToJSON SubagentDiskMeta where
     toJSON meta = object
         [ "previousResponseId" .= meta.diskPreviousResponseId
+        , "status" .= fmap encodeDiskStatus meta.diskStatus
         , "agentType" .= meta.diskAgentType
         , "agentModel" .= meta.diskAgentModel
+        , "reasoningEffort" .= meta.diskReasoningEffort
         , "cwd" .= fmap toFilePath meta.diskCwd
         , "taskPath" .= meta.diskTaskPath
         , "parentId" .= meta.diskParentId
@@ -55,15 +64,45 @@ instance ToJSON SubagentDiskMeta where
         ]
 
 instance FromJSON SubagentDiskMeta where
-    parseJSON = withObject "SubagentDiskMeta" \o ->
+    parseJSON = withObject "SubagentDiskMeta" \o -> do
+        statusValue <- o .:? "status"
+        diskStatus <- traverse decodeDiskStatus statusValue
         SubagentDiskMeta
             <$> o .:? "previousResponseId"
+            <*> pure diskStatus
             <*> o .:? "agentType"
             <*> o .:? "agentModel"
+            <*> o .:? "reasoningEffort"
             <*> (fmap fromFilePath <$> o .:? "cwd")
             <*> o .:? "taskPath"
             <*> o .:? "parentId"
             <*> o .:? "depth"
+
+encodeDiskStatus :: SubagentStatus -> Aeson.Value
+encodeDiskStatus = \case
+    Pending -> Aeson.String "pending"
+    Running -> Aeson.String "running"
+    Interrupted -> Aeson.String "interrupted"
+    Closed -> Aeson.String "closed"
+    NotFound -> Aeson.String "not_found"
+    Completed finalText -> Aeson.object ["completed" .= finalText]
+    Errored err -> Aeson.object ["errored" .= err]
+
+decodeDiskStatus :: Aeson.Value -> Parser SubagentStatus
+decodeDiskStatus = \case
+    Aeson.String "pending" -> pure Pending
+    Aeson.String "pending_init" -> pure Pending
+    Aeson.String "running" -> pure Running
+    Aeson.String "interrupted" -> pure Interrupted
+    Aeson.String "closed" -> pure Closed
+    Aeson.String "shutdown" -> pure Closed
+    Aeson.String "not_found" -> pure NotFound
+    Aeson.Object object
+        | Just value <- KeyMap.lookup "completed" object ->
+            Completed <$> Aeson.parseJSON value
+        | Just value <- KeyMap.lookup "errored" object ->
+            Errored <$> Aeson.parseJSON value
+    value -> fail ("invalid persisted subagent status: " <> show value)
 
 -- | Generated ids look like @agent-<hex>-<n>@. Reject path separators and
 -- traversal so resume paths cannot escape @agents/@.
@@ -89,17 +128,44 @@ subagentStoreDir sessionDir agentId
                 </> fromFilePath (Text.unpack agentId.unSubagentId)
             )
 
+forkSubagentTranscript :: Maybe Text -> [ResponseItem] -> [ResponseItem]
+forkSubagentTranscript forkTurns items =
+    let completeItems = trimDanglingToolSuffix items
+        normalized = Text.toLower . Text.strip <$> forkTurns
+    in case normalized of
+        Just "none" -> []
+        Just turns
+            | Just count <- readMaybe (Text.unpack turns)
+            , count > 0 -> takeRecentTurns count completeItems
+        _ -> completeItems
+
+takeRecentTurns :: Int -> [ResponseItem] -> [ResponseItem]
+takeRecentTurns count items =
+    case drop (max 0 (length starts - count)) starts of
+        start : _ -> drop start items
+        [] -> items
+  where
+    starts =
+        [ index
+        | (index, MessageItem message) <- zip [0 :: Int ..] items
+        , message.role == RoleUser
+        ]
+
 saveSubagentState
     :: OsPath
     -> SubagentId
     -> [ResponseItem]
+    -> Maybe Text
+    -> SubagentStatus
     -> Maybe Text
     -> Maybe Text
     -> Maybe Text
     -> Maybe OsPath
     -> Maybe SubagentIdentity
     -> IO (Either Text ())
-saveSubagentState sessionDir agentId items previous agentType agentModel cwd identity =
+saveSubagentState
+        sessionDir agentId items previous status agentType agentModel
+        reasoningEffort cwd identity =
     case subagentStoreDir sessionDir agentId of
         Left err -> pure (Left err)
         Right dir -> do
@@ -109,8 +175,10 @@ saveSubagentState sessionDir agentId items previous agentType agentModel cwd ide
             _ <- tryAny (setFileMode (toFilePath dir) 0o700)
             writeLazyFileAtomically metaPath 0o600 $ Aeson.encode SubagentDiskMeta
                 { diskPreviousResponseId = previous
+                , diskStatus = Just status
                 , diskAgentType = agentType
                 , diskAgentModel = agentModel
+                , diskReasoningEffort = reasoningEffort
                 , diskCwd = cwd
                 , diskTaskPath = taskPathText . (.identityTaskPath) <$> identity
                 , diskParentId = identity >>= (.identityParent)
@@ -137,7 +205,7 @@ loadSubagentState sessionDir agentId =
                     metaResult <- if hasMeta
                         then decodeFile metaPath
                         else pure (Right (SubagentDiskMeta
-                            Nothing Nothing Nothing Nothing Nothing Nothing Nothing))
+                            Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing))
                     itemsResult <- if hasTranscript
                         then decodeFile transcriptPath
                         else pure (Right [])

--- a/packages/agent-cli/test/Agent/CLI/SubagentStoreSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SubagentStoreSpec.hs
@@ -3,11 +3,16 @@ module Agent.CLI.SubagentStoreSpec (spec) where
 import Agent.CLI.SubagentStore
 import Agent.Responses.Types
 import Agent.OsPath (OsPath, fromFilePath, toFilePath)
-import Agent.Subagents (SubagentId(..), SubagentIdentity(..))
+import Agent.Subagents
+    ( SubagentId(..)
+    , SubagentIdentity(..)
+    , SubagentStatus(..)
+    )
 import Agent.Subagents.TaskPath (parseTaskPath)
 import Control.Exception.Safe (bracket)
 import qualified Data.Aeson.KeyMap as KeyMap
 import qualified Data.ByteString.Lazy as LBS
+import Data.Text (Text)
 import qualified System.Directory as Directory
 import System.Directory.OsPath (doesFileExist)
 import qualified System.FilePath as FilePath
@@ -31,8 +36,10 @@ spec = describe "Agent.CLI.SubagentStore" do
                     }
             Right taskPath <- pure (parseTaskPath "/root/research/worker")
             let identity = SubagentIdentity (Just parentId) 2 taskPath
-            saveSubagentState dir agentId [item] (Just "resp-1") (Just "explore")
-                (Just "grok-4.5-mini") (Just (fromFilePath "/tmp/work"))
+            saveSubagentState dir agentId [item] (Just "resp-1")
+                (Completed (Just "done")) (Just "explore")
+                (Just "grok-4.5-mini") (Just "high")
+                (Just (fromFilePath "/tmp/work"))
                 (Just identity)
                 `shouldReturn` Right ()
             loaded <- loadSubagentState dir agentId
@@ -40,8 +47,10 @@ spec = describe "Agent.CLI.SubagentStore" do
                 Right (Just (items, meta)) -> do
                     length items `shouldBe` 1
                     meta.diskPreviousResponseId `shouldBe` Just "resp-1"
+                    meta.diskStatus `shouldBe` Just (Completed (Just "done"))
                     meta.diskAgentType `shouldBe` Just "explore"
                     meta.diskAgentModel `shouldBe` Just "grok-4.5-mini"
+                    meta.diskReasoningEffort `shouldBe` Just "high"
                     meta.diskCwd `shouldBe` Just (fromFilePath "/tmp/work")
                     meta.diskTaskPath `shouldBe` Just "/root/research/worker"
                     meta.diskParentId `shouldBe` Just parentId
@@ -63,7 +72,8 @@ spec = describe "Agent.CLI.SubagentStore" do
     it "loads legacy metadata without task topology" do
         withTempDir \dir -> do
             let agentId = SubagentId "agent-legacy-1"
-            saveSubagentState dir agentId [] (Just "legacy") Nothing Nothing Nothing Nothing
+            saveSubagentState dir agentId [] (Just "legacy") Interrupted
+                Nothing Nothing Nothing Nothing Nothing
                 `shouldReturn` Right ()
             Right path <- pure (subagentStoreDir dir agentId)
             LBS.writeFile
@@ -75,12 +85,14 @@ spec = describe "Agent.CLI.SubagentStore" do
                     meta.diskTaskPath `shouldBe` Nothing
                     meta.diskParentId `shouldBe` Nothing
                     meta.diskDepth `shouldBe` Nothing
+                    meta.diskStatus `shouldBe` Nothing
                 other -> expectationFailure ("unexpected load: " <> show other)
 
     it "fails closed on corrupt transcript JSON" do
         withTempDir \dir -> do
             let agentId = SubagentId "agent-corrupt-1"
-            saveSubagentState dir agentId [] (Just "r") Nothing Nothing Nothing Nothing
+            saveSubagentState dir agentId [] (Just "r") Interrupted
+                Nothing Nothing Nothing Nothing Nothing
                 `shouldReturn` Right ()
             Right path <- pure (subagentStoreDir dir agentId)
             LBS.writeFile
@@ -89,6 +101,28 @@ spec = describe "Agent.CLI.SubagentStore" do
             loadSubagentState dir agentId >>= \case
                 Left err -> err `shouldSatisfy` (not . null . show)
                 Right _ -> expectationFailure "expected decode failure"
+
+    it "forks all, none, or the requested number of recent turns" do
+        let items =
+                [ messageItem RoleUser "one"
+                , messageItem RoleAssistant "answer-one"
+                , messageItem RoleUser "two"
+                , messageItem RoleAssistant "answer-two"
+                ]
+        forkSubagentTranscript Nothing items `shouldBe` items
+        forkSubagentTranscript (Just "none") items `shouldBe` []
+        forkSubagentTranscript (Just "1") items
+            `shouldBe` drop 2 items
+
+messageItem :: ResponseRole -> Text -> ResponseItem
+messageItem role text = MessageItem ResponseMessage
+    { messageId = Nothing
+    , content = MessageContentText text
+    , role
+    , status = Nothing
+    , phase = Nothing
+    , extraFields = KeyMap.empty
+    }
 
 withTempDir :: (OsPath -> IO a) -> IO a
 withTempDir action = do

--- a/packages/agent-core/src/Agent/Subagents/Registry.hs
+++ b/packages/agent-core/src/Agent/Subagents/Registry.hs
@@ -20,11 +20,14 @@ module Agent.Subagents.Registry
     , spawnSubagentWithCwdPreparedForTurn
     , spawnSubagentAt
     , spawnSubagentAtForTurn
+    , spawnSubagentAtPreparedForTurn
     , spawnSubagentAtWithCwdPrepared
     , restoreSubagent
     , restoreSubagentAt
+    , restoreSubagentAtStatus
     , restoreSubagentWithCwd
     , restoreSubagentAtWithCwd
+    , restoreSubagentAtWithCwdStatus
     , waitSubagents
     , waitSubagentsFrom
     , waitAnyLive
@@ -118,7 +121,7 @@ data SubagentRecord = SubagentRecord
     , recordMailbox :: !(TQueue SubagentWork)
     , recordAsync :: !(TVar (Maybe (ResourceKey, Async ())))
     , recordRootTurnId :: !(TVar (Maybe RootTurnId))
-      -- | Whether this agent currently occupies a concurrency slot.
+      -- | Whether this agent currently occupies an active-worker slot.
     , recordSlotHeld :: !(TVar Bool)
       -- | Last successful response id for conversation continuity.
     , recordPreviousResponseId :: !(TVar (Maybe Text))
@@ -332,8 +335,22 @@ spawnSubagentAtForTurn
     -> Maybe Text
     -> IO (Either Text (SubagentId, TaskPath))
 spawnSubagentAtForTurn registry rootTurnId =
+    spawnSubagentAtPreparedForTurn registry rootTurnId (\_ -> pure ())
+
+spawnSubagentAtPreparedForTurn
+    :: SubagentRegistry
+    -> Maybe RootTurnId
+    -> (SubagentId -> IO ())
+    -> Maybe SubagentId
+    -> TaskPath
+    -> Int
+    -> Text
+    -> InterAgentMessageContent
+    -> Maybe Text
+    -> IO (Either Text (SubagentId, TaskPath))
+spawnSubagentAtPreparedForTurn registry rootTurnId beforeStart =
     spawnSubagentAtWithCwdPreparedForTurn
-        registry rootTurnId registry.registryCwd (\_ -> pure ())
+        registry rootTurnId registry.registryCwd beforeStart
 
 spawnSubagentAtWithCwdPrepared
     :: SubagentRegistry
@@ -426,7 +443,7 @@ spawnSubagentAtWithIdPreparedForTurn
                                                         "Concurrent subagent limit reached: "
                                                             <> Text.pack
                                                                 (show registry.registryConfig.maxConcurrent)
-                                                            <> " agents are already open. Close finished agents before spawning more."
+                                                            <> " agents are already active."
                                                     else do
                                                         let record = SubagentRecord
                                                                 { recordId = agentId
@@ -579,7 +596,7 @@ runWorker registry record firstWork = do
                             notifyComplete
                                 registry record.recordId work.workRootTurnId status
                         pure ()
-                    atomically (finishOrContinue record status) >>= \case
+                    atomically (finishOrContinue registry record status) >>= \case
                         Nothing -> pure ()
                         Just nextWork -> do
                             resetCancel record.recordCancel
@@ -739,10 +756,11 @@ nextWorkerStep registry record = do
                     pure (WorkerMessage work)
 
 finishOrContinue
-    :: SubagentRecord
+    :: SubagentRegistry
+    -> SubagentRecord
     -> SubagentStatus
     -> STM (Maybe SubagentWork)
-finishOrContinue record status = do
+finishOrContinue registry record status = do
     current <- readTVar record.recordStatus
     if current == Closed || current == Interrupted
         then pure Nothing
@@ -751,6 +769,7 @@ finishOrContinue record status = do
             if empty
                 then do
                     writeTVar record.recordStatus status
+                    releaseSlotSTM registry record
                     pure Nothing
                 else do
                     work <- readTQueue record.recordMailbox
@@ -786,7 +805,10 @@ notifyComplete registry agentId rootTurnId status
     | otherwise = pure ()
 
 releaseSlot :: SubagentRegistry -> SubagentRecord -> IO ()
-releaseSlot registry record = atomically do
+releaseSlot registry record = atomically (releaseSlotSTM registry record)
+
+releaseSlotSTM :: SubagentRegistry -> SubagentRecord -> STM ()
+releaseSlotSTM registry record = do
     held <- readTVar record.recordSlotHeld
     whenSTM held do
         writeTVar record.recordSlotHeld False
@@ -812,7 +834,7 @@ acquireSlot registry record = do
                         then pure $ Left $
                             "Concurrent subagent limit reached: "
                                 <> Text.pack (show registry.registryConfig.maxConcurrent)
-                                <> " agents are already open."
+                                <> " agents are already active."
                         else do
                             modifyTVar' registry.registryLiveCount (+ 1)
                             writeTVar record.recordSlotHeld True
@@ -1113,6 +1135,19 @@ restoreSubagentAt
 restoreSubagentAt registry =
     restoreSubagentAtWithCwd registry registry.registryCwd
 
+restoreSubagentAtStatus
+    :: SubagentRegistry
+    -> SubagentId
+    -> Maybe SubagentId
+    -> TaskPath
+    -> Int
+    -> Maybe Text
+    -> Maybe Text
+    -> SubagentStatus
+    -> IO (Either Text SubagentId)
+restoreSubagentAtStatus registry =
+    restoreSubagentAtWithCwdStatus registry registry.registryCwd
+
 restoreSubagentWithCwd
     :: SubagentRegistry
     -> OsPath
@@ -1125,7 +1160,8 @@ restoreSubagentWithCwd
 restoreSubagentWithCwd
         registry childCwd agentId parentId depth nickname previous =
     restoreSubagentResolvedWithCwd
-        registry childCwd agentId parentId nickname previous \agents ->
+        registry childCwd agentId parentId nickname previous
+        (Completed Nothing) \agents ->
             resolveParentSTM agents parentId taskPathRoot (max 0 (depth - 1))
                 >>= \case
                     Left err -> pure (Left err)
@@ -1147,8 +1183,25 @@ restoreSubagentAtWithCwd
     -> IO (Either Text SubagentId)
 restoreSubagentAtWithCwd
         registry childCwd agentId parentId taskPath depth nickname previous =
+    restoreSubagentAtWithCwdStatus
+        registry childCwd agentId parentId taskPath depth nickname previous
+        (Completed Nothing)
+
+restoreSubagentAtWithCwdStatus
+    :: SubagentRegistry
+    -> OsPath
+    -> SubagentId
+    -> Maybe SubagentId
+    -> TaskPath
+    -> Int
+    -> Maybe Text
+    -> Maybe Text
+    -> SubagentStatus
+    -> IO (Either Text SubagentId)
+restoreSubagentAtWithCwdStatus
+        registry childCwd agentId parentId taskPath depth nickname previous restoredStatus =
     restoreSubagentResolvedWithCwd
-        registry childCwd agentId parentId nickname previous
+        registry childCwd agentId parentId nickname previous restoredStatus
         (\_ -> pure (Right (taskPath, depth)))
 
 restoreSubagentResolvedWithCwd
@@ -1158,10 +1211,12 @@ restoreSubagentResolvedWithCwd
     -> Maybe SubagentId
     -> Maybe Text
     -> Maybe Text
+    -> SubagentStatus
     -> (Map SubagentId SubagentRecord -> STM (Either Text (TaskPath, Int)))
     -> IO (Either Text SubagentId)
 restoreSubagentResolvedWithCwd
-        registry childCwd agentId parentId nickname previous resolveIdentity = do
+        registry childCwd agentId parentId nickname previous
+        restoredStatus resolveIdentity = do
     result <-
         withMVar registry.registryLifecycle \_ -> do
             closed <- atomically $ readTVar registry.registryClosed
@@ -1179,6 +1234,12 @@ restoreSubagentResolvedWithCwd
             restoreSubagentIndex restored
             pure (Right restored)
   where
+    normalizedStatus = case restoredStatus of
+        Pending -> Interrupted
+        Running -> Interrupted
+        NotFound -> Interrupted
+        status -> status
+
     restoreExisting record = do
         status <- atomically $ readTVar record.recordStatus
         case status of
@@ -1190,7 +1251,7 @@ restoreSubagentResolvedWithCwd
                 releaseSlot registry record
                 resetCancel record.recordCancel
                 atomically do
-                    writeTVar record.recordStatus (Completed Nothing)
+                    writeTVar record.recordStatus normalizedStatus
                     writeTVar record.recordPreviousResponseId previous
                     writeTVar record.recordRootTurnId Nothing
                     modifyTVar' registry.registryPaths
@@ -1200,7 +1261,7 @@ restoreSubagentResolvedWithCwd
     restoreMissing = do
         cancelFlag <- newCancelFlag
         mailbox <- newTQueueIO
-        statusVar <- newTVarIO (Completed Nothing)
+        statusVar <- newTVarIO normalizedStatus
         asyncVar <- newTVarIO Nothing
         rootTurnVar <- newTVarIO Nothing
         slotHeld <- newTVarIO False

--- a/packages/agent-core/src/Agent/ToolDispatch.hs
+++ b/packages/agent-core/src/Agent/ToolDispatch.hs
@@ -21,8 +21,7 @@ module Agent.ToolDispatch
 
 import Agent.ToolArgs (stripAesonPrefix)
 import Control.Applicative ((<|>))
-import Control.Exception (SomeException)
-import qualified Control.Exception as Exception
+import Control.Exception.Safe (SomeException, tryAny)
 import Data.Aeson (FromJSON, Value(..))
 import qualified Data.Aeson as Aeson
 import Data.Aeson.Types (parseEither)
@@ -110,7 +109,7 @@ dispatchToolHandler config maybeHandler call = do
         runTool = case maybeHandler of
             Just handler -> runHandler call input handler
             Nothing -> pure (Left (config.toolDispatchUnknownTool callName))
-    result <- Exception.try @SomeException runTool
+    result <- tryAny runTool
     resultOutput <- case result of
         Right toolResult ->
             pure (config.toolDispatchFormatResult toolResult)

--- a/packages/agent-core/src/Agent/Tools/ApplyPatch.hs
+++ b/packages/agent-core/src/Agent/Tools/ApplyPatch.hs
@@ -71,7 +71,7 @@ data UpdateChunk = UpdateChunk
 parsePatch :: Text -> Either Text [Hunk]
 parsePatch raw = do
     let trimmed = Text.strip raw
-        ls = map Text.stripEnd (Text.lines trimmed)
+        ls = Text.lines trimmed
     case ls of
         [] -> Left "Invalid patch: empty"
         first : rest
@@ -135,9 +135,15 @@ parseChunks lines_
             (eof, remaining) = case afterBody of
                 (line : rest) | Text.strip line == "*** End of File" -> (True, rest)
                 _ -> (False, afterBody)
-        chunk <- buildChunk header body eof
-        (more, leftover) <- parseChunks remaining
-        Right (chunk : more, leftover)
+        case (header, body, eof, lines_) of
+            (Nothing, [], False, line : _) ->
+                Left $
+                    "Invalid update line; expected '@@', '+', '-', or space prefix: "
+                        <> Text.take 200 line
+            _ -> do
+                chunk <- buildChunk header body eof
+                (more, leftover) <- parseChunks remaining
+                Right (chunk : more, leftover)
 
 nextHunk :: [Text] -> Bool
 nextHunk (line : _) =

--- a/packages/agent-core/src/Agent/Tools/Grok/Task.hs
+++ b/packages/agent-core/src/Agent/Tools/Grok/Task.hs
@@ -16,6 +16,7 @@ module Agent.Tools.Grok.Task
     , recordAgentType
     , lookupAgentType
     , lookupAgentModel
+    , lookupAgentReasoningEffort
     ) where
 
 import Agent.InterAgentMessage (plainInterAgentContent)
@@ -66,6 +67,7 @@ knownSubagentTypes = ["general-purpose", "explore", "plan"]
 data GrokSubagentSpec = GrokSubagentSpec
     { agentType :: !Text
     , modelOverride :: !(Maybe Text)
+    , reasoningEffortOverride :: !(Maybe Text)
     } deriving (Eq, Show)
 
 type GrokSubagentSpecs = IORef (Map SubagentId GrokSubagentSpec)
@@ -196,6 +198,7 @@ spawnFresh childCwd worktree ctx typesRef args = mask \restore -> do
     let spec = GrokSubagentSpec
             { agentType = args.subagentType
             , modelOverride = args.model
+            , reasoningEffortOverride = Nothing
             }
         worktreePath = (.subagentWorktreePath) <$> worktree
     result <- restore
@@ -379,7 +382,10 @@ recordAgentType :: GrokSubagentSpecs -> SubagentId -> Text -> IO ()
 recordAgentType specsRef agentId agentType = do
     specs <- readIORef specsRef
     let model = maybe Nothing (\spec -> spec.modelOverride) (Map.lookup agentId specs)
-    recordAgentSpec specsRef agentId (GrokSubagentSpec agentType model)
+        effort =
+            maybe Nothing (\spec -> spec.reasoningEffortOverride)
+                (Map.lookup agentId specs)
+    recordAgentSpec specsRef agentId (GrokSubagentSpec agentType model effort)
 
 lookupAgentType :: GrokSubagentSpecs -> SubagentId -> IO (Maybe Text)
 lookupAgentType specsRef agentId = do
@@ -390,6 +396,11 @@ lookupAgentModel :: GrokSubagentSpecs -> SubagentId -> IO (Maybe Text)
 lookupAgentModel specsRef agentId = do
     specs <- readIORef specsRef
     pure (Map.lookup agentId specs >>= \spec -> spec.modelOverride)
+
+lookupAgentReasoningEffort :: GrokSubagentSpecs -> SubagentId -> IO (Maybe Text)
+lookupAgentReasoningEffort specsRef agentId = do
+    specs <- readIORef specsRef
+    pure (Map.lookup agentId specs >>= \spec -> spec.reasoningEffortOverride)
 
 -- | Restrict the child tool surface by subagent type.
 filterGrokToolsForType :: Text -> [AppTool] -> [AppTool]

--- a/packages/agent-core/src/Agent/Tools/MultiAgents.hs
+++ b/packages/agent-core/src/Agent/Tools/MultiAgents.hs
@@ -4,6 +4,7 @@
 -- @codex-rs/core/src/tools/handlers/multi_agents_spec.rs@ (v2).
 module Agent.Tools.MultiAgents
     ( MultiAgentContext(..)
+    , CollaborationSpawnOptions(..)
     , SubagentWorktree(..)
     , multiAgentTools
     , multiAgentNamespace
@@ -22,7 +23,7 @@ import Agent.Subagents
     , queueMessageFromForTurn
     , resolveAgentTarget
     , sendInputMessageForTurn
-    , spawnSubagentAtForTurn
+    , spawnSubagentAtPreparedForTurn
     , waitAnyLive
     , waitSubagentsFrom
     )
@@ -74,6 +75,12 @@ data SubagentWorktree = SubagentWorktree
     , subagentWorktreeCleanup :: !(IO (Either Text ()))
     }
 
+data CollaborationSpawnOptions = CollaborationSpawnOptions
+    { collaborationModel :: !(Maybe Text)
+    , collaborationReasoningEffort :: !(Maybe Text)
+    , collaborationForkTurns :: !(Maybe Text)
+    } deriving (Eq, Show)
+
 -- | Per-agent identity for nesting depth / parent linkage / task path.
 data MultiAgentContext = MultiAgentContext
     { multiRegistry :: !SubagentRegistry
@@ -86,6 +93,10 @@ data MultiAgentContext = MultiAgentContext
     , multiResumeFromDisk :: !(Maybe (SubagentId -> IO (Either Text ())))
       -- | Optional host hook for Grok-style isolated worktree children.
     , multiCreateWorktree :: !(Maybe (OsPath -> IO (Either Text SubagentWorktree)))
+      -- | Record model/effort overrides and seed the child transcript before
+      -- its worker starts.
+    , multiPrepareSpawn
+        :: !(Maybe (SubagentId -> CollaborationSpawnOptions -> IO ()))
       -- | Deliver a child message to the root agent's next model turn.
     , multiSendToRoot :: !(Maybe (InterAgentMessage -> IO (Either Text Text)))
     }
@@ -174,11 +185,20 @@ runSpawn ctx call args
     | not (validForkTurns args.forkTurns) =
         pure (Left "fork_turns must be none, all, or a positive integer string")
     | otherwise = do
-        _ <- pure (args.model, args.reasoningEffort, args.forkTurns)
         rootTurnId <- ctx.multiRootTurnId
-        result <- spawnSubagentAtForTurn
+        let spawnOptions = CollaborationSpawnOptions
+                { collaborationModel = sanitizeOverride args.model
+                , collaborationReasoningEffort =
+                    sanitizeOverride args.reasoningEffort
+                , collaborationForkTurns = normalizeForkTurns args.forkTurns
+                }
+            prepare agentId =
+                maybe (pure ()) (\hook -> hook agentId spawnOptions)
+                    ctx.multiPrepareSpawn
+        result <- spawnSubagentAtPreparedForTurn
             ctx.multiRegistry
             rootTurnId
+            prepare
             ctx.multiSelfId
             ctx.multiTaskPath
             ctx.multiDepth
@@ -199,7 +219,21 @@ validForkTurns = \case
     Just turns ->
         let stripped = Text.toLower (Text.strip turns)
         in stripped `elem` ["none", "all", ""]
-            || (not (Text.null stripped) && Text.all (\c -> c >= '0' && c <= '9') stripped)
+            || case reads (Text.unpack stripped) of
+                [(turns :: Int, "")] -> turns > 0
+                _ -> False
+
+sanitizeOverride :: Maybe Text -> Maybe Text
+sanitizeOverride value = value >>= \raw ->
+    let stripped = Text.strip raw
+    in if Text.null stripped then Nothing else Just stripped
+
+normalizeForkTurns :: Maybe Text -> Maybe Text
+normalizeForkTurns value =
+    case Text.toLower . Text.strip <$> value of
+        Nothing -> Just "all"
+        Just "" -> Just "all"
+        normalized -> normalized
 
 --------------------------------------------------------------------------------
 -- wait_agent

--- a/packages/agent-core/test/Agent/SubagentsSpec.hs
+++ b/packages/agent-core/test/Agent/SubagentsSpec.hs
@@ -153,7 +153,7 @@ spec = describe "Agent.Subagents" do
         result <- spawnSubagent registry (Just child) 1 "two" Nothing
         result `shouldBe` Left "Agent depth limit reached. Solve the task yourself."
 
-    it "enforces maxConcurrent until agents are closed" do
+    it "releases maxConcurrent capacity when agents finish" do
         gate <- newTVarIO False
         let config = defaultSubagentConfig { maxConcurrent = 1 }
         registry <- newSubagentRegistry config (fromFilePath "/tmp")
@@ -173,12 +173,7 @@ spec = describe "Agent.Subagents" do
             Right _ -> False
         atomically $ writeTVar gate True
         _ <- waitSubagents registry [first] 15000
-        third <- spawnSubagent registry Nothing 0 "c" Nothing
-        third `shouldSatisfy` \case
-            Left err -> "Concurrent subagent limit" `Text.isInfixOf` err
-            Right _ -> False
-        _ <- closeSubagent registry first
-        Right _ <- spawnSubagent registry Nothing 0 "d" Nothing
+        Right _ <- spawnSubagent registry Nothing 0 "c" Nothing
         pure ()
 
     it "supports nested spawn when depth is unlimited" do
@@ -341,7 +336,7 @@ spec = describe "Agent.Subagents" do
 
     it "does not leave Running when send_input admission fails" do
         gate <- newTVarIO False
-        let config = defaultSubagentConfig { maxConcurrent = 2 }
+        let config = defaultSubagentConfig { maxConcurrent = 1 }
         registry <- newSubagentRegistry config (fromFilePath "/tmp")
             (\_ _ prompt _ -> case messagePayload prompt of
                 "hold" -> do
@@ -362,18 +357,14 @@ spec = describe "Agent.Subagents" do
         Right idle <- spawnSubagent registry Nothing 0 "idle" Nothing
         _ <- waitSubagents registry [idle] 15000
         Right holder <- spawnSubagent registry Nothing 0 "hold" Nothing
-        -- Free idle's slot, soft-resume without a slot, then fill both slots.
-        _ <- closeSubagent registry idle
-        Right _ <- resumeSubagent registry idle
-        Right filler <- spawnSubagent registry Nothing 0 "filler" Nothing
-        _ <- waitSubagents registry [filler] 15000
-        -- holder + filler occupy both slots; idle is Completed without a slot.
+        -- The completed idle agent no longer owns a slot, while holder owns the
+        -- only active slot.
         result <- sendInput registry idle "follow-up" False
         result `shouldSatisfy` \case
             Left err -> "Concurrent subagent limit" `Text.isInfixOf` err
             Right _ -> False
         status <- getStatus registry idle
-        status `shouldBe` Completed Nothing
+        status `shouldBe` Completed (Just "idle")
         atomically $ writeTVar gate True
         _ <- waitSubagents registry [holder] 15000
         pure ()
@@ -524,7 +515,18 @@ spec = describe "Agent.Subagents" do
             `shouldReturn` Left "Subagent registry is closed."
         sendInput registry agentId "late" False
             `shouldReturn` Left "Subagent registry is closed."
-
+    it "restores persisted lifecycle status and marks abandoned work interrupted" do
+        registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
+            (\_ _ _ _ -> pure $ Left LoopNoResponseId)
+            (\_ _ -> pure ())
+        let interruptedId = SubagentId "agent-restored-running"
+            erroredId = SubagentId "agent-restored-error"
+        Right _ <- restoreSubagentAtStatus registry interruptedId Nothing
+            taskPathRoot 1 Nothing (Just "prev-running") Running
+        getStatus registry interruptedId `shouldReturn` Interrupted
+        Right _ <- restoreSubagentAtStatus registry erroredId Nothing
+            taskPathRoot 1 Nothing (Just "prev-error") (Errored "boom")
+        getStatus registry erroredId `shouldReturn` Errored "boom"
     it "reopens a closed agent via restoreSubagent" do
         registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
             (\_ _ prompt _ -> pure $ Right LoopResult

--- a/packages/agent-core/test/Agent/ToolDispatchSpec.hs
+++ b/packages/agent-core/test/Agent/ToolDispatchSpec.hs
@@ -59,6 +59,12 @@ spec = describe "dispatchToolCall" do
         result `shouldBe` functionResult "call-1" "EX explode"
         readIORef seen `shouldReturn` ["explode"]
 
+    it "does not turn asynchronous cancellation into tool output" do
+        dispatchToolCall testConfig
+            [noArgsTool "cancel" (Exception.throwIO Exception.ThreadKilled)]
+            (functionToolCall "call-1" "cancel" "{}")
+            `shouldThrow` (== Exception.ThreadKilled)
+
 testConfig :: ToolDispatchConfig
 testConfig = ToolDispatchConfig
     { toolDispatchUnknownTool = \name -> "unknown:" <> name

--- a/packages/agent-core/test/Agent/Tools/CodexSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/CodexSpec.hs
@@ -69,6 +69,7 @@ spec = describe "Agent.Tools.Codex" do
                     , multiRootTurnId = pure Nothing
                     , multiResumeFromDisk = Nothing
                     , multiCreateWorktree = Nothing
+                    , multiPrepareSpawn = Nothing
                     , multiSendToRoot = Nothing
                     }
             coding <- codingToolsFor OpenAIProvider env Nothing (Just ctx)
@@ -167,6 +168,51 @@ spec = describe "Agent.Tools.Codex" do
                 , "*** End Patch"
                 ]
             output `shouldSatisfy` Text.isInfixOf "Failed to find expected lines"
+
+    it "preserves unchanged blank lines in update hunks" do
+        withTempEnv \env -> do
+            Text.writeFile (toFilePath env.toolCwd </> "blank.txt")
+                "before\n\nold\nafter\n"
+            output <- runPatch env $ Text.unlines
+                [ "*** Begin Patch"
+                , "*** Update File: blank.txt"
+                , "@@"
+                , " before"
+                , " "
+                , "-old"
+                , "+new"
+                , " after"
+                , "*** End Patch"
+                ]
+            output `shouldSatisfy` Text.isInfixOf "M blank.txt"
+            Text.readFile (toFilePath env.toolCwd </> "blank.txt")
+                `shouldReturn` "before\n\nnew\nafter\n"
+
+    it "rejects malformed update lines without recursing forever" do
+        let parsed = parsePatch $ Text.unlines
+                [ "*** Begin Patch"
+                , "*** Update File: malformed.txt"
+                , "@@"
+                , " context"
+                , ""
+                , "-old"
+                , "+new"
+                , "*** End Patch"
+                ]
+        parsed `shouldSatisfy` \case
+            Left err -> "Invalid update line" `Text.isInfixOf` err
+            Right _ -> False
+
+    it "preserves trailing whitespace in added lines" do
+        withTempEnv \env -> do
+            _ <- runPatch env $ Text.unlines
+                [ "*** Begin Patch"
+                , "*** Add File: spaces.txt"
+                , "+hello  "
+                , "*** End Patch"
+                ]
+            Text.readFile (toFilePath env.toolCwd </> "spaces.txt")
+                `shouldReturn` "hello  \n"
 
     it "stops applying hunks after the first failure" do
         withTempEnv \env -> do

--- a/packages/agent-core/test/Agent/Tools/Grok/TaskSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/Grok/TaskSpec.hs
@@ -38,7 +38,7 @@ spec = describe "Agent.Tools.Grok.Task" do
             (\_ _ -> pure ())
         typesRef <- newIORef Map.empty
         let ctx = MultiAgentContext registry Nothing 0 taskPathRoot
-                (pure Nothing) Nothing Nothing Nothing
+                (pure Nothing) Nothing Nothing Nothing Nothing
             tool = taskTool (fromFilePath "/tmp") ctx typesRef
         result <- dispatchToolCall defaultLoopDispatch [tool.appToolHandler]
             (functionToolCall "c1" "task"
@@ -56,7 +56,7 @@ spec = describe "Agent.Tools.Grok.Task" do
             (observeSpec typesRef observed)
             (\_ _ -> pure ())
         let ctx = MultiAgentContext registry Nothing 0 taskPathRoot
-                (pure Nothing) Nothing Nothing Nothing
+                (pure Nothing) Nothing Nothing Nothing Nothing
             tool = taskTool (fromFilePath "/tmp") ctx typesRef
         _ <- dispatchToolCall defaultLoopDispatch [tool.appToolHandler]
             (functionToolCall "c1" "task" raceArgs)
@@ -91,7 +91,7 @@ spec = describe "Agent.Tools.Grok.Task" do
                 , subagentWorktreeCleanup = pure (Right ())
                 }
             ctx = MultiAgentContext registry Nothing 0 taskPathRoot (pure Nothing)
-                Nothing (Just createIsolated) Nothing
+                Nothing (Just createIsolated) Nothing Nothing
             tool = taskTool (fromFilePath "/tmp") ctx typesRef
         result <- dispatchToolCall defaultLoopDispatch [tool.appToolHandler]
             (functionToolCall "c1" "task"
@@ -104,7 +104,7 @@ spec = describe "Agent.Tools.Grok.Task" do
         registry <- closedRegistry
         typesRef <- newIORef Map.empty
         let ctx = MultiAgentContext registry Nothing 0 taskPathRoot
-                (pure Nothing) Nothing (Just (cleanupLease cleaned)) Nothing
+                (pure Nothing) Nothing (Just (cleanupLease cleaned)) Nothing Nothing
             tool = taskTool (fromFilePath "/tmp") ctx typesRef
         result <- dispatchToolCall defaultLoopDispatch [tool.appToolHandler]
             (functionToolCall "c1" "task" worktreeArgs)

--- a/packages/agent-core/test/Agent/Tools/GrokSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/GrokSpec.hs
@@ -81,7 +81,7 @@ spec = describe "Agent.Tools.Grok" do
                 (\_ _ -> pure ())
             typesRef <- newIORef Map.empty
             let ctx = MultiAgentContext registry Nothing 0 taskPathRoot
-                    (pure Nothing) Nothing Nothing Nothing
+                    (pure Nothing) Nothing Nothing Nothing Nothing
                 names = map (.appToolName) (grokTools session ghci plan (Just ctx) typesRef)
             names `shouldContain` ["task"]
             closeSubagentRegistry registry

--- a/packages/agent-core/test/Agent/Tools/MultiAgentsSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/MultiAgentsSpec.hs
@@ -70,6 +70,53 @@ spec = describe "Agent.Tools.MultiAgents" do
             EncryptedInterAgentContent "gAAAAA-task"
         closeSubagentRegistry registry
 
+    it "applies model, effort, and fork overrides before the worker starts" do
+        prepared <- newEmptyTMVarIO
+        registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
+            (\env _ _ _ -> pure (resultWithText env.subId.unSubagentId))
+            (\_ _ -> pure ())
+        let prepare _ options = atomically (putTMVar prepared options)
+            context = (rootContext registry Nothing)
+                { multiPrepareSpawn = Just prepare }
+            call = ToolCall
+                { callId = "spawn-options"
+                , name = "collaboration.spawn_agent"
+                , arguments =
+                    "{\"task_name\":\"worker\",\"message\":\"task\",\
+                    \\"model\":\"gpt-test\",\"reasoning_effort\":\"high\",\
+                    \\"fork_turns\":\"3\"}"
+                , callKind = FunctionCallKind
+                , argumentsEncrypted = False
+                }
+        result <- dispatchToolCall defaultLoopDispatch
+            (appToolHandlers (multiAgentTools context)) call
+        result.output `shouldSatisfy` Text.isInfixOf "/root/worker"
+        options <- atomically (takeTMVar prepared)
+        options `shouldBe` CollaborationSpawnOptions
+            { collaborationModel = Just "gpt-test"
+            , collaborationReasoningEffort = Just "high"
+            , collaborationForkTurns = Just "3"
+            }
+        closeSubagentRegistry registry
+
+    it "rejects zero fork turns" do
+        registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
+            (\_ _ _ _ -> pure $ Left LoopNoResponseId)
+            (\_ _ -> pure ())
+        let call = ToolCall
+                { callId = "spawn-zero"
+                , name = "collaboration.spawn_agent"
+                , arguments =
+                    "{\"task_name\":\"worker\",\"message\":\"task\",\
+                    \\"fork_turns\":\"0\"}"
+                , callKind = FunctionCallKind
+                , argumentsEncrypted = False
+                }
+        result <- dispatchToolCall defaultLoopDispatch
+            (appToolHandlers (multiAgentTools (rootContext registry Nothing))) call
+        result.output `shouldSatisfy` Text.isInfixOf "positive integer"
+        closeSubagentRegistry registry
+
     it "wait_agent excludes the calling child" do
         parentGate <- newTVarIO False
         registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
@@ -128,6 +175,7 @@ spec = describe "Agent.Tools.MultiAgents" do
                 , multiRootTurnId = pure Nothing
                 , multiResumeFromDisk = Nothing
                 , multiCreateWorktree = Nothing
+                , multiPrepareSpawn = Nothing
                 , multiSendToRoot = Just deliverRoot
                 }
         result <- dispatchToolCall defaultLoopDispatch
@@ -158,6 +206,7 @@ rootContext registry sendToRoot = MultiAgentContext
     , multiRootTurnId = pure Nothing
     , multiResumeFromDisk = Nothing
     , multiCreateWorktree = Nothing
+    , multiPrepareSpawn = Nothing
     , multiSendToRoot = sendToRoot
     }
 


### PR DESCRIPTION
## Summary

- make `apply_patch` preserve blank context lines and reject malformed update hunks without non-progressing recursion
- stop converting asynchronous cancellation into ordinary tool output
- release subagent concurrency slots when workers finish and persist accurate lifecycle status
- trim incomplete tool-call suffixes before retrying or persisting interrupted children
- implement collaboration `model`, `reasoning_effort`, and `fork_turns` overrides, including nested transcript forks
- run OpenAI child submissions on independently scoped WebSocket connections instead of serializing behind the root connection
- persist model/effort/topology metadata while remaining compatible with legacy snapshots

## Validation

- `agent-core`: 198 examples, 0 failures (GHCi)
- `agent-cli`: 369 examples, 0 failures (GHCi)
- `git diff --check`
