### PR TITLE
feat(cli): add fullscreen terminal interface

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -77,6 +77,10 @@ library
                     , Agent.CLI.Terminal
                     , Agent.CLI.Timestamp
                     , Agent.CLI.Tools
+                    , Agent.CLI.TUI.App
+                    , Agent.CLI.TUI.Markdown
+                    , Agent.CLI.TUI.Theme
+                    , Agent.CLI.UI.Model
                     , Agent.CLI.Turn
                     , Agent.CLI.Usage
                     , Agent.CLI.Worktree
@@ -90,12 +94,14 @@ library
                     , async
                     , base >= 4.17 && < 5
                     , base64-bytestring
+                    , brick >= 2.9 && < 3
                     , bytestring
                     , colour >= 2.3
                     , containers
                     , directory
                     , filepath
                     , haskeline >= 0.8 && < 0.9
+                    , mtl
                     , process >= 1.6.26
                     , safe-exceptions
                     , stm
@@ -103,6 +109,8 @@ library
                     , time
                     , transformers
                     , unix
+                    , vty >= 6.4 && < 7
+                    , vty-crossplatform >= 0.4 && < 0.5
 
 executable agent-cli
     import:           common-options
@@ -156,6 +164,7 @@ test-suite agent-cli-test
                     , Agent.CLI.SessionTitleSpec
                     , Agent.CLI.SubagentStoreSpec
                     , Agent.CLI.ToolsSpec
+                    , Agent.CLI.UIModelSpec
                     , Agent.CLI.UsageSpec
                     , Agent.CLI.WorktreeSpec
     build-depends:    agent-cli

--- a/packages/agent-cli/package.nix
+++ b/packages/agent-cli/package.nix
@@ -1,8 +1,8 @@
 { mkDerivation, aeson, agent-core, agent-openai, agent-openrouter
-, agent-responses, agent-xai, ansi-terminal, async, base, base64-bytestring
-, bytestring, colour, containers, directory, filepath, haskeline
-, hspec, lib, process, safe-exceptions, text, time, transformers
-, unix
+, agent-responses, agent-xai, ansi-terminal, async, base
+, base64-bytestring, brick, bytestring, colour, containers, directory
+, filepath, haskeline, hspec, lib, mtl, process, safe-exceptions, stm
+, text, time, transformers, unix, vty, vty-crossplatform
 }:
 mkDerivation {
   pname = "agent-cli";
@@ -12,9 +12,9 @@ mkDerivation {
   isExecutable = true;
   libraryHaskellDepends = [
     aeson agent-core agent-openai agent-openrouter agent-responses agent-xai
-    ansi-terminal async base base64-bytestring bytestring colour
-    containers directory filepath haskeline process safe-exceptions
-    text time transformers unix
+    ansi-terminal async base base64-bytestring brick bytestring colour
+    containers directory filepath haskeline mtl process safe-exceptions
+    stm text time transformers unix vty vty-crossplatform
   ];
   executableHaskellDepends = [ base ];
   testHaskellDepends = [

--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -1293,30 +1293,53 @@ waitAndRetryPendingTurn
     -> PendingTurn
     -> IO RunResult
 waitAndRetryPendingTurn env delay pending = do
-    color <- resolveColor stderr
-    putTextLn stderr $ roleWarn color $
-        glyphWarn
-            <> "provider credentials temporarily unavailable; retrying this turn in "
-            <> formatDuration delay
-            <> " (Esc to cancel)"
+    let waitMessage =
+            "provider credentials temporarily unavailable; retrying this turn in "
+                <> formatDuration delay
+                <> " (Esc to cancel)"
+    case env.sessionFullscreen of
+        Just runtime ->
+            emitUiEvent runtime (UiSetNotice (Just waitMessage))
+        Nothing -> do
+            color <- resolveColor stderr
+            putTextLn stderr $
+                roleWarn color (glyphWarn <> waitMessage)
     let cancel = env.sessionLoop.loopCancel
         -- Give the provider reset boundary a small margin so the automatic
         -- retry does not race a rounded server timestamp.
         waitMicros = max 1 (ceiling ((realToFrac delay + 0.25) * 1_000_000 :: Double))
+        waitForCancel =
+            isJust <$> timeout waitMicros (waitCancel cancel)
+        waitAction = case env.sessionFullscreen of
+            Just _ -> waitForCancel
+            Nothing ->
+                withEscCancel cancel env.sessionEscPaused waitForCancel
     resetCancel cancel
     cancelled <-
-        ( withTurnCancel env.sessionInterrupt cancel $
-            withEscCancel cancel env.sessionEscPaused $
-                isJust <$> timeout waitMicros (waitCancel cancel)
-        ) `finally` resetCancel cancel
+        (withTurnCancel env.sessionInterrupt cancel waitAction)
+            `finally` resetCancel cancel
     if cancelled
         then do
-            putTextLn stderr (roleMuted color "automatic retry cancelled")
+            case env.sessionFullscreen of
+                Just runtime ->
+                    emitUiEvent runtime
+                        (UiSetNotice (Just "automatic retry cancelled"))
+                Nothing -> do
+                    color <- resolveColor stderr
+                    putTextLn stderr
+                        (roleMuted color "automatic retry cancelled")
             if pending.pendingExitAfter
                 then pure RunQuit
                 else replWithDraft env pending.pendingPromptText
         else do
-            putTextLn stderr (roleMuted color (glyphOk <> "retrying turn"))
+            case env.sessionFullscreen of
+                Just runtime ->
+                    emitUiEvent runtime
+                        (UiSetNotice (Just "retrying turn"))
+                Nothing -> do
+                    color <- resolveColor stderr
+                    putTextLn stderr
+                        (roleMuted color (glyphOk <> "retrying turn"))
             runPendingTurnWithCooldownRetry False env pending
 
 reportProviderUnavailable :: ApiError -> IO ()
@@ -1981,7 +2004,9 @@ replWithDraft env@SessionEnv
                         legacy (runLoginManager color)
                         continue
                     ReplUsage -> do
-                        showAccountUsage provider tokenProvider openAiPool
+                        legacy
+                            (showAccountUsage
+                                provider tokenProvider openAiPool)
                         continue
                     ReplReloadAuth -> do
                         reloadAuth provider tokenProvider

--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -40,6 +40,7 @@ import Agent.CLI.AgentSessions
     )
 import Agent.CLI.Approval
     ( approveToolDecision
+    , approveToolDecisionWith
     , childApprove
     , toggleAlwaysApprove
     )
@@ -77,12 +78,17 @@ import Agent.CLI.Interrupt
     ( InterruptState
     , isWrappedUserInterrupt
     , newInterruptState
+    , noteFullscreenCtrlC
     , withCtrlCHandler
     , withTurnCancel
     )
 import Agent.CLI.Login (runLoginManager)
 import Agent.CLI.ModelPicker (pickModel)
-import Agent.CLI.Models (ModelOption(..))
+import Agent.CLI.Models
+    ( ModelOption(..)
+    , PickerState(..)
+    , initialPickerState
+    )
 import Agent.CLI.Notification
     ( AttentionRequest(InputRequested)
     , notifyAttention
@@ -162,6 +168,23 @@ import Agent.CLI.Terminal
     , withSynchronizedOutput
     )
 import Agent.CLI.Tools (schemasFromAppTools)
+import Agent.CLI.TUI.App
+    ( FullscreenRuntime
+    , emitUiEvent
+    , newFullscreenRuntime
+    , readFullscreenLine
+    , requestFullscreenPermission
+    , requestFullscreenChoice
+    , runFullscreen
+    , withFullscreenSuspended
+    )
+import Agent.CLI.UI.Model
+    ( PromptState(..)
+    , UiEvent(..)
+    , UiState
+    , initialUiState
+    , reduceUi
+    )
 import Agent.CLI.Turn (applyPendingSessionTitles, runOneTurn)
 import Agent.CLI.Usage
     ( AccountUsageLine(..)
@@ -174,7 +197,7 @@ import Agent.CLI.Worktree
     , removeWorktree
     , worktreeRoot
     )
-import Agent.Cancel (resetCancel, waitCancel)
+import Agent.Cancel (requestCancel, resetCancel, waitCancel)
 import Agent.Loop
 import Agent.Error (ApiError(..))
 import Agent.InterAgentMessage (InterAgentMessage, interAgentMessagePayload)
@@ -263,7 +286,7 @@ import Agent.Tools.MultiAgents
     )
 import Agent.Tools.PlanMode
     ( PlanModeEnv(..)
-    , PlanModeHooks
+    , PlanModeHooks(..)
     , PlanModeState(..)
     , activatePlanMode
     , deactivatePlanMode
@@ -316,11 +339,12 @@ import System.Directory.OsPath
     , setCurrentDirectory
     )
 import System.Environment (getArgs, getProgName, lookupEnv)
-import System.OsPath ((</>), takeDirectory)
+import System.OsPath ((</>), takeDirectory, takeFileName)
 import System.Console.ANSI (getTerminalSize)
 import System.Console.ANSI.Codes (clearFromCursorToLineEndCode)
-import System.Exit (die, exitFailure)
+import System.Exit (ExitCode(..), die, exitFailure)
 import System.IO (Handle, hFlush, hIsTerminalDevice, stderr, stdin, stdout)
+import System.Process (readProcessWithExitCode)
 import System.Timeout (timeout)
 
 -- | How the GHCi-driven agent REPL finished.
@@ -562,7 +586,10 @@ runAgent options transition = do
         putTextLn stderr (roleMuted color msg)
     -- Shared with Esc cancel and plan prompts so arrow-key pickers own stdin.
     escPaused <- newIORef False
-    let planHooks = cliPlanHooks interrupt escPaused (resolveColor stderr)
+    uiRuntimeRef <- newIORef Nothing
+    let basePlanHooks =
+            cliPlanHooks interrupt escPaused (resolveColor stderr)
+        planHooks = fullscreenAwarePlanHooks uiRuntimeRef basePlanHooks
         provider = loaded.loadedProvider
         model = fromMaybe
             (case transitionTarget of
@@ -682,6 +709,7 @@ runAgent options transition = do
             params = requestParams model instructions
                 (schemasFromAppTools provider tools) effort
             initialItems = maybe [] (foldSessionItems . snd) resumed
+            initialTurns = maybe [] snd resumed
             initialPrevious = case transition of
                 Just _ -> Nothing
                 Nothing -> resumed >>= \(meta, _) -> meta.metaLastResponseId
@@ -750,7 +778,7 @@ runAgent options transition = do
                                             privateTranscript
                                 activeBackend <-
                                     prepareTransitionBackend transition persist noticingBackend
-                                runSession options provider policy tools toolEnv planMode prompt pendingTurn unavailableProviders paramsRef transcriptRef
+                                runSession options provider policy tools toolEnv planMode uiRuntimeRef prompt pendingTurn unavailableProviders paramsRef transcriptRef initialTurns
                                     initialPrevious persist projectRoot home cwd (Just loaded.loadedTokenProvider) loaded.loadedOpenAiPool agentsContext escPaused interrupt
                                     multiCtx rootTurnRef subagentSessions pendingNotices subagentStoreRoot usageRef claimCurrentSession activeBackend btwBackend)
                             >>= \case
@@ -789,7 +817,7 @@ runAgent options transition = do
                                     (readIORef privateParams) privateTranscript
                         activeBackend <-
                             prepareTransitionBackend transition persist backend
-                        runSession options provider policy tools toolEnv planMode prompt pendingTurn unavailableProviders paramsRef transcriptRef
+                        runSession options provider policy tools toolEnv planMode uiRuntimeRef prompt pendingTurn unavailableProviders paramsRef transcriptRef initialTurns
                             initialPrevious persist projectRoot home cwd (Just loaded.loadedTokenProvider) loaded.loadedOpenAiPool agentsContext escPaused interrupt
                             multiCtx rootTurnRef subagentSessions pendingNotices subagentStoreRoot usageRef claimCurrentSession activeBackend btwBackend
                     OpenRouterProvider -> do
@@ -820,7 +848,7 @@ runAgent options transition = do
                                     (readIORef privateParams) privateTranscript
                         activeBackend <-
                             prepareTransitionBackend transition persist backend
-                        runSession options provider policy tools toolEnv planMode prompt pendingTurn unavailableProviders paramsRef transcriptRef
+                        runSession options provider policy tools toolEnv planMode uiRuntimeRef prompt pendingTurn unavailableProviders paramsRef transcriptRef initialTurns
                             initialPrevious persist projectRoot home cwd (Just loaded.loadedTokenProvider) loaded.loadedOpenAiPool agentsContext escPaused interrupt
                             multiCtx rootTurnRef subagentSessions pendingNotices subagentStoreRoot usageRef claimCurrentSession activeBackend btwBackend
 
@@ -931,11 +959,13 @@ runSession
     -> [AppTool]
     -> ToolEnv
     -> PlanModeEnv
+    -> IORef (Maybe FullscreenRuntime)
     -> Maybe Text
     -> Maybe PendingTurn
     -> [Provider]
     -> IORef ResponseCreateParams
     -> IORef [ResponseItem]
+    -> [SessionTurn]
     -> Maybe Text
     -> Persistence
     -> OsPath
@@ -956,7 +986,7 @@ runSession
     -> Backend
     -> BtwBackendFactory
     -> IO RunResult
-runSession options provider policy tools toolEnv planMode prompt pendingTurn unavailableProviders paramsRef transcriptRef initialPrevious persist projectRoot home cwd tokenProvider openAiPool agentsContext escPaused interrupt multiCtx rootTurnRef subagentSessions pendingNotices storeRoot usageRef onPersisted backend btwBackend =
+runSession options provider policy tools toolEnv planMode uiRuntimeRef prompt pendingTurn unavailableProviders paramsRef transcriptRef initialTurns initialPrevious persist projectRoot home cwd tokenProvider openAiPool agentsContext escPaused interrupt multiCtx rootTurnRef subagentSessions pendingNotices storeRoot usageRef onPersisted backend btwBackend =
   withSessionTitleManager btwBackend paramsRef \titleManager -> do
     toolRegistry <- requireToolRegistry tools
     printed <- newIORef False
@@ -1024,9 +1054,33 @@ runSession options provider policy tools toolEnv planMode prompt pendingTurn una
             writeIORef agentsContext fresh
     policyRef <- newIORef policy
     stderrTty <- hIsTerminalDevice stderr
+    stdinTty <- hIsTerminalDevice stdin
+    stdoutTty <- hIsTerminalDevice stdout
     terminal <- detectTerminalCapabilities stdout
     reportTerminalCwd terminal stdout (toFilePath cwd)
     useColor <- resolveColor stdout
+    branch <- detectGitBranch cwd
+    let fullscreenEnabled =
+            stdinTty
+                && stdoutTty
+                && not (isOneShot options)
+                && options.optScreenMode /= ScreenMinimal
+        initialFullscreenState =
+            reduceUi
+                (UiSetRepository
+                    branch
+                    (toText (takeFileName (takeDirectory cwd))
+                        <> "/"
+                        <> toText (takeFileName cwd)))
+                (hydrateUiHistory initialTurns)
+    fullscreen <- if fullscreenEnabled
+        then Just <$> newFullscreenRuntime
+            (requestCancel toolEnv.toolCancel)
+            (noteFullscreenCtrlC interrupt)
+            (copyTerminalClipboard terminal stdout)
+            initialFullscreenState
+        else pure Nothing
+    writeIORef uiRuntimeRef fullscreen
     -- Mirror plan session dir into the subagent store root for this session.
     let syncStore = do
             sessionDir <- readIORef planMode.planSessionDir
@@ -1056,17 +1110,40 @@ runSession options provider policy tools toolEnv planMode prompt pendingTurn una
             , renderNativeProgress =
                 stderrTty && terminal.terminalNativeProgress
             }
+        emitLoop event = case fullscreen of
+            Nothing -> renderEvent render event
+            Just runtime -> do
+                case event of
+                    TurnStarted -> do
+                        now <- getCurrentTime
+                        writeIORef startedAtRef (Just now)
+                        writeIORef activityRef "Thinking…"
+                    TextDelta _ -> writeIORef printed True
+                    ToolStarted _ ->
+                        writeIORef activityRef "Running tool…"
+                    _ -> pure ()
+                emitUiEvent runtime (UiLoop event)
         config = LoopConfig
             { loopBackend = backend
             , loopTools = toolRegistry
             , loopDispatch = defaultLoopDispatch
             , loopMaxTurns = options.optMaxTurns
-            , loopOnEvent = renderEvent render
+            , loopOnEvent = emitLoop
             , loopApprove = \call ->
                 withMVar ioLock \_ ->
-                    withStdinPaused escPaused $
-                        approveToolDecision
-                            policyRef allowedToolsRef toolRegistry planMode call
+                    case fullscreen of
+                        Nothing ->
+                            withStdinPaused escPaused $
+                                approveToolDecision
+                                    policyRef allowedToolsRef toolRegistry planMode call
+                        Just runtime ->
+                            approveToolDecisionWith
+                                (requestFullscreenPermission runtime)
+                                policyRef
+                                allowedToolsRef
+                                toolRegistry
+                                planMode
+                                call
             , loopCancel = toolEnv.toolCancel
             }
         beginSubagentTurn = do
@@ -1115,6 +1192,7 @@ runSession options provider policy tools toolEnv planMode prompt pendingTurn una
             , sessionUsage = usageRef
             , sessionLastAssistant = lastAssistantRef
             , sessionTerminal = terminal
+            , sessionFullscreen = fullscreen
             , sessionAgentViewport = Just agentViewport
             , sessionBeginSubagentTurn = beginSubagentTurn
             , sessionFinishSubagentTurn = finishSubagentTurn
@@ -1122,15 +1200,20 @@ runSession options provider policy tools toolEnv planMode prompt pendingTurn una
             , sessionOnPersisted = onPersisted
             , sessionReset = sessionReset
             }
-    result <- case pendingTurn of
-        Just pending ->
-            runPendingTurn env pending
-        Nothing -> case prompt of
-            Just text -> do
-                result <- runOneTurn env text [UserMessage text]
-                finishTurn env True result
-            Nothing ->
-                repl env
+    let sessionAction = case pendingTurn of
+            Just pending ->
+                runPendingTurn env pending
+            Nothing -> case prompt of
+                Just text -> do
+                    result <- runOneTurn env text [UserMessage text]
+                    finishTurn env True result
+                Nothing ->
+                    repl env
+    result <-
+        (case fullscreen of
+            Nothing -> sessionAction
+            Just runtime -> runFullscreen runtime sessionAction)
+            `finally` writeIORef uiRuntimeRef Nothing
     _ <- waitForSessionTitleResults 5000000 titleManager
     applyPendingSessionTitles env
     pure result
@@ -1145,6 +1228,10 @@ runPendingTurnWithCooldownRetry
     -> IO RunResult
 runPendingTurnWithCooldownRetry allowCooldownRetry env pending = do
     writeIORef env.sessionPlanMode.planStateRef pending.pendingPlanState
+    case env.sessionFullscreen of
+        Nothing -> pure ()
+        Just runtime ->
+            emitUiEvent runtime (UiUserSubmitted pending.pendingPromptText)
     result <- runOneTurn env pending.pendingPromptText pending.pendingInputs
     finishTurnWithCooldownRetry
         allowCooldownRetry env pending.pendingExitAfter result
@@ -1165,7 +1252,9 @@ finishTurnWithCooldownRetry
 finishTurnWithCooldownRetry allowCooldownRetry env exitAfter = \case
     TurnSucceeded -> do
         writeIORef env.sessionUnavailableProviders []
-        putTrailingNewline env.sessionPrinted
+        case env.sessionFullscreen of
+            Nothing -> putTrailingNewline env.sessionPrinted
+            Just _ -> pure ()
         if exitAfter
             then pure RunQuit
             else do
@@ -1175,7 +1264,9 @@ finishTurnWithCooldownRetry allowCooldownRetry env exitAfter = \case
         if exitAfter
             then exitFailure
             else do
-                putTrailingNewline env.sessionPrinted
+                case env.sessionFullscreen of
+                    Nothing -> putTrailingNewline env.sessionPrinted
+                    Just _ -> pure ()
                 notifyAttention stderr InputRequested
                 repl env
     TurnProviderUnavailable apiError pending ->
@@ -1271,11 +1362,10 @@ replWithDraft env@SessionEnv
     , sessionUsage = usageRef
     , sessionLastAssistant = lastAssistantRef
     , sessionTerminal = terminal
+    , sessionFullscreen = fullscreen
     , sessionAgentViewport = agentViewport
     , sessionReset = sessionReset
     } draft = do
-    when terminal.terminalSemanticPrompts $
-        emitTerminalSequence terminal stdout osc133PromptStart
     stdoutColor <- resolveColor stdout
     planState <- readIORef planMode.planStateRef
     let planActive = planState == PlanActive
@@ -1284,54 +1374,65 @@ replWithDraft env@SessionEnv
     policy <- readIORef policyRef
     pendingAttachments <- readIORef attachmentsRef
     let idleMode = replModeFromState planState policy
-    termCols <- fmap snd <$> getTerminalSize
-    case agentViewport of
-        Nothing -> pure ()
-        Just viewport -> do
-            entries <- viewport.viewportEntries
-            selected <- readIORef viewport.viewportSelected
-            let panel =
-                    renderAgentViewportPanelFor
-                        stdoutColor
-                        (fromMaybe 100 termCols)
-                        selected
-                        entries
-            when (not (Text.null panel)) (Text.putStrLn panel)
-    -- Status sits on the line above λ; the inline editor owns the prompt and
-    -- any live completion rows below it.
-    -- Token totals sit on the right of that line when the TTY width is known.
     usage <- readIORef usageRef
-    withSynchronizedOutput terminal stdout do
-        Text.putStrLn $ formatReplStatusLine stdoutColor termCols
-            (currentModel params)
-            (currentEffort params)
-            idleMode
-            usage
-        hFlush stdout
-    -- Solarized user wash under the prompt; the inline editor redraws it.
-    -- Ctrl+U keeps the familiar kill-to-start behavior.
-    let modeTag
-            | planActive = roleWarn stdoutColor "[plan] "
-            | planPending = roleMuted stdoutColor "[plan…] "
-            | idleMode == ReplModeAlwaysApprove =
-                roleSuccess stdoutColor "[yolo] "
-            | otherwise = ""
-        chromePrompt =
-            beginBackground stdoutColor userBackground
-                <> modeTag
-                <> if null pendingAttachments
-                    then ""
-                    else roleMuted stdoutColor
-                        ("[📎 " <> Text.pack (show (length pendingAttachments)) <> "] ")
-                <> rolePrompt stdoutColor "λ "
-                <> if stdoutColor
-                    then Text.pack clearFromCursorToLineEndCode
-                    else mempty
-    mline <- readReplLineWithInitial interrupt chromePrompt draft
-    when terminal.terminalSemanticPrompts $
-        emitTerminalSequence terminal stdout osc133PromptEnd
-    Text.putStr (endBackground stdoutColor)
-    hFlush stdout
+    mline <- case fullscreen of
+        Just runtime ->
+            readFullscreenLine runtime
+                PromptState
+                    { promptModel = currentModel params
+                    , promptEffort = currentEffort params
+                    , promptMode = idleMode
+                    , promptUsage = usage
+                    , promptAttachments = length pendingAttachments
+                    }
+                draft
+        Nothing -> do
+            when terminal.terminalSemanticPrompts $
+                emitTerminalSequence terminal stdout osc133PromptStart
+            termCols <- fmap snd <$> getTerminalSize
+            case agentViewport of
+                Nothing -> pure ()
+                Just viewport -> do
+                    entries <- viewport.viewportEntries
+                    selected <- readIORef viewport.viewportSelected
+                    let panel =
+                            renderAgentViewportPanelFor
+                                stdoutColor
+                                (fromMaybe 100 termCols)
+                                selected
+                                entries
+                    when (not (Text.null panel)) (Text.putStrLn panel)
+            -- Status sits on the line above λ in minimal mode.
+            withSynchronizedOutput terminal stdout do
+                Text.putStrLn $ formatReplStatusLine stdoutColor termCols
+                    (currentModel params)
+                    (currentEffort params)
+                    idleMode
+                    usage
+                hFlush stdout
+            let modeTag
+                    | planActive = roleWarn stdoutColor "[plan] "
+                    | planPending = roleMuted stdoutColor "[plan…] "
+                    | idleMode == ReplModeAlwaysApprove =
+                        roleSuccess stdoutColor "[yolo] "
+                    | otherwise = ""
+                chromePrompt =
+                    beginBackground stdoutColor userBackground
+                        <> modeTag
+                        <> if null pendingAttachments
+                            then ""
+                            else roleMuted stdoutColor
+                                ("[📎 " <> Text.pack (show (length pendingAttachments)) <> "] ")
+                        <> rolePrompt stdoutColor "λ "
+                        <> if stdoutColor
+                            then Text.pack clearFromCursorToLineEndCode
+                            else mempty
+            result <- readReplLineWithInitial interrupt chromePrompt draft
+            when terminal.terminalSemanticPrompts $
+                emitTerminalSequence terminal stdout osc133PromptEnd
+            Text.putStr (endBackground stdoutColor)
+            hFlush stdout
+            pure result
     case mline of
         ReplEof -> do
             putStrLn ""
@@ -1343,10 +1444,12 @@ replWithDraft env@SessionEnv
         ReplCycleMode keptDraft -> do
             let next = cycleReplInteraction planState policy
             applyReplMode planMode policyRef projectRoot next
-            -- The editor advanced a line; walk back over the previous status
-            -- + prompt so the next chrome replaces them.
-            putStr "\ESC[2A\r\ESC[J"
-            hFlush stdout
+            case fullscreen of
+                Just _ -> pure ()
+                Nothing -> do
+                    -- Minimal editor advanced a line; replace its old chrome.
+                    putStr "\ESC[2A\r\ESC[J"
+                    hFlush stdout
             continueWith keptDraft
         ReplClipboardPaste keptDraft -> do
             errColor <- resolveColor stderr
@@ -1436,6 +1539,8 @@ replWithDraft env@SessionEnv
                                         Text.putStrLn
                                             (roleMuted color (glyphOk <> "pasted " <> sizes))
                                         writeIORef printed False
+                                        fullscreenEvent
+                                            (UiUserSubmitted promptText)
                                         let turnInputs =
                                                 [ UserMultimodal
                                                     { userText = promptText
@@ -1451,20 +1556,29 @@ replWithDraft env@SessionEnv
                     ReplShowAttachments -> do
                         pending <- readIORef attachmentsRef
                         color <- resolveColor stdout
-                        if null pending
-                            then Text.putStrLn (roleMuted color (glyphSession <> "attachments: (none)"))
-                            else Text.putStrLn $ roleMuted color $
-                                glyphSession
-                                    <> "attachments: "
-                                    <> Text.intercalate ", "
-                                        [ img.imageMime <> " (" <> formatImageSize (BS.length img.imageBytes) <> ")"
-                                        | img <- pending
-                                        ]
+                        let message =
+                                if null pending
+                                    then "attachments: (none)"
+                                    else "attachments: "
+                                        <> Text.intercalate ", "
+                                            [ img.imageMime
+                                                <> " ("
+                                                <> formatImageSize
+                                                    (BS.length img.imageBytes)
+                                                <> ")"
+                                            | img <- pending
+                                            ]
+                        displayInfo message $
+                            Text.putStrLn
+                                (roleMuted color (glyphSession <> message))
                         continue
                     ReplClearAttachments -> do
                         writeIORef attachmentsRef []
                         color <- resolveColor stdout
-                        Text.putStrLn (roleMuted color (glyphOk <> "attachments cleared"))
+                        displayInfo "attachments cleared" $
+                            Text.putStrLn
+                                (roleMuted color
+                                    (glyphOk <> "attachments cleared"))
                         continue
                     ReplAgents -> do
                         case agentViewport of
@@ -1473,7 +1587,8 @@ replWithDraft env@SessionEnv
                                 entries <- viewport.viewportEntries
                                 selected <- readIORef viewport.viewportSelected
                                 color <- resolveColor stderr
-                                pickAgentViewport color selected entries >>= \case
+                                legacy
+                                    (pickAgentViewport color selected entries) >>= \case
                                     Nothing -> pure ()
                                     Just target ->
                                         writeIORef viewport.viewportSelected target
@@ -1509,19 +1624,25 @@ replWithDraft env@SessionEnv
                             sessionId
                         continue
                     ReplShowTerminal -> do
-                        Text.putStrLn
-                            (roleMuted color
-                                (formatTerminalCapabilities terminal))
+                        let message = formatTerminalCapabilities terminal
+                        displayInfo message $
+                            Text.putStrLn (roleMuted color message)
                         continue
                     ReplShowEffort -> do
                         color <- resolveColor stdout
                         params <- readIORef paramsRef
-                        Text.putStrLn (roleMuted color (glyphSession <> "effort: " <> currentEffort params))
+                        let message = "effort: " <> currentEffort params
+                        displayInfo message $
+                            Text.putStrLn
+                                (roleMuted color (glyphSession <> message))
                         continue
                     ReplSetEffort level -> do
                         color <- resolveColor stdout
                         modifyIORef' paramsRef (setReasoningEffort level)
-                        Text.putStrLn (roleMuted color (glyphOk <> "effort set to " <> level))
+                        displayInfo ("effort set to " <> level) $
+                            Text.putStrLn
+                                (roleMuted color
+                                    (glyphOk <> "effort set to " <> level))
                         case persist of
                             PersistenceDisabled -> pure ()
                             PersistenceEnabled slotRef -> do
@@ -1540,7 +1661,7 @@ replWithDraft env@SessionEnv
                         color <- resolveColor stderr
                         params <- readIORef paramsRef
                         let current = currentModel params
-                        pickModel color provider current >>= \case
+                        modelChoice fullscreen color provider current >>= \case
                             Nothing -> continue
                             Just choice
                                 | choice.modelProvider == provider
@@ -1580,6 +1701,9 @@ replWithDraft env@SessionEnv
                             Right outcome -> do
                                 writeIORef transcriptRef outcome.compactHistory
                                 writeIORef previous Nothing
+                                fullscreenEvent UiConversationCleared
+                                fullscreenEvent
+                                    (UiSystemMessage outcome.compactSummary)
                                 Text.hPutStrLn stderr $ roleMuted color $
                                     glyphSession
                                         <> "compacted "
@@ -1621,14 +1745,15 @@ replWithDraft env@SessionEnv
                         color <- resolveColor stdout
                         putTextLn stdout
                             (roleMuted color (glyphSession <> "btw · asking…"))
-                        result <- runBtwWithCancel
-                            (\cancel action ->
-                                withTurnCancel interrupt cancel $
-                                    withEscCancel cancel escPaused action)
-                            btwBackend
-                            paramsRef
-                            transcriptRef
-                            question
+                        result <- legacy $
+                            runBtwWithCancel
+                                (\cancel action ->
+                                    withTurnCancel interrupt cancel $
+                                        withEscCancel cancel escPaused action)
+                                btwBackend
+                                paramsRef
+                                transcriptRef
+                                question
                         case result of
                             Left err -> do
                                 errorColor <- resolveColor stderr
@@ -1638,11 +1763,12 @@ replWithDraft env@SessionEnv
                                 putTextLn stdout (renderAssistantText color answer)
                         continue
                     ReplResume maybeId -> do
-                        handleResume maybeId persist >>= \case
+                        legacy (handleResume maybeId persist) >>= \case
                             Nothing -> continue
                             Just result -> pure result
                     ReplClear -> do
                         sessionReset
+                        fullscreenEvent UiConversationCleared
                         color <- resolveColor stderr
                         case persist of
                             PersistenceDisabled ->
@@ -1686,6 +1812,7 @@ replWithDraft env@SessionEnv
                         continue
                     ReplNew -> do
                         sessionReset
+                        fullscreenEvent UiConversationCleared
                         color <- resolveColor stderr
                         case persist of
                             PersistenceDisabled -> do
@@ -1755,18 +1882,27 @@ replWithDraft env@SessionEnv
                         color <- resolveColor stdout
                         case persist of
                             PersistenceDisabled ->
-                                Text.putStrLn (roleMuted color "session: (not persisted)")
+                                displayInfo "session: (not persisted)" $
+                                    Text.putStrLn
+                                        (roleMuted color
+                                            "session: (not persisted)")
                             PersistenceEnabled slotRef -> do
                                 slot <- readIORef slotRef
                                 case slot of
                                     PersistencePending _ ->
-                                        Text.putStrLn
-                                            (roleMuted color
-                                                "session: (pending until first turn)")
+                                        displayInfo
+                                            "session: (pending until first turn)" $
+                                            Text.putStrLn
+                                                (roleMuted color
+                                                    "session: (pending until first turn)")
                                     PersistenceActive handle ->
-                                        Text.putStrLn
-                                            (roleMuted color
-                                                (glyphSession <> "session: " <> handle.sessionMeta.metaId))
+                                        let message =
+                                                "session: "
+                                                    <> handle.sessionMeta.metaId
+                                        in displayInfo message $
+                                            Text.putStrLn
+                                                (roleMuted color
+                                                    (glyphSession <> message))
                         continue
                     ReplRename title -> do
                         color <- resolveColor stderr
@@ -1842,7 +1978,7 @@ replWithDraft env@SessionEnv
                         continue
                     ReplLogin -> do
                         color <- resolveColor stderr
-                        runLoginManager color
+                        legacy (runLoginManager color)
                         continue
                     ReplUsage -> do
                         showAccountUsage provider tokenProvider openAiPool
@@ -1852,15 +1988,87 @@ replWithDraft env@SessionEnv
                         continue
                     ReplHelp maybeName -> do
                         color <- resolveColor stdout
-                        Text.putStrLn (formatSlashHelp color maybeName)
+                        displayInfo (formatSlashHelp False maybeName) $
+                            Text.putStrLn
+                                (formatSlashHelp color maybeName)
                         continue
                     ReplCommandError err -> do
                         color <- resolveColor stderr
-                        Text.hPutStrLn stderr (roleError color err)
+                        displayError err $
+                            Text.hPutStrLn stderr (roleError color err)
                         continue
     continue = continueWith ""
     continueWith keptDraft =
         replWithDraft env keptDraft
+    legacy action = case fullscreen of
+        Nothing -> action
+        Just runtime -> withFullscreenSuspended runtime action
+    fullscreenEvent event = case fullscreen of
+        Nothing -> pure ()
+        Just runtime -> emitUiEvent runtime event
+    displayInfo message minimalAction = case fullscreen of
+        Nothing -> minimalAction
+        Just runtime -> emitUiEvent runtime (UiSystemMessage message)
+    displayError message minimalAction = case fullscreen of
+        Nothing -> minimalAction
+        Just runtime -> emitUiEvent runtime (UiErrorMessage message)
+
+modelChoice
+    :: Maybe FullscreenRuntime
+    -> Bool
+    -> Provider
+    -> Text
+    -> IO (Maybe ModelOption)
+modelChoice fullscreen color provider current = case fullscreen of
+    Nothing -> pickModel color provider current
+    Just runtime -> do
+        let picker = initialPickerState provider current
+            options = picker.pickerAll
+            rows =
+                [ ( providerSlug option.modelProvider
+                        <> " · "
+                        <> option.modelId
+                  , fromMaybe "" option.modelLabel
+                  )
+                | option <- options
+                ]
+        requestFullscreenChoice
+            runtime
+            "Model"
+            picker.pickerIndex
+            rows
+            >>= \case
+                Just index
+                    | index >= 0
+                    , index < length options ->
+                        pure (Just (options !! index))
+                _ -> pure Nothing
+
+fullscreenAwarePlanHooks
+    :: IORef (Maybe FullscreenRuntime)
+    -> PlanModeHooks
+    -> PlanModeHooks
+fullscreenAwarePlanHooks runtimeRef hooks = PlanModeHooks
+    { planConfirmEnter = \reason ->
+        withCurrentFullscreen runtimeRef
+            (hooks.planConfirmEnter reason)
+    , planDecideExit = \planBody ->
+        withCurrentFullscreen runtimeRef
+            (hooks.planDecideExit planBody)
+    , planAskQuestion = \question options ->
+        withCurrentFullscreen runtimeRef
+            (hooks.planAskQuestion question options)
+    }
+
+withCurrentFullscreen
+    :: IORef (Maybe FullscreenRuntime)
+    -> IO a
+    -> IO a
+withCurrentFullscreen runtimeRef action = do
+    runtime <- readIORef runtimeRef
+    case runtime of
+        Nothing -> action
+        Just active -> withFullscreenSuspended active action
 
 showAccountUsage
     :: Provider
@@ -2226,7 +2434,12 @@ requestReload persist = do
             pure RunReload
 
 enterPlanFromSlash :: SessionEnv -> Maybe Text -> IO (Maybe ProviderTransition)
-enterPlanFromSlash env@SessionEnv{sessionPlanMode = planMode, sessionPersist = persist, sessionPrinted = printed} maybeDescription = do
+enterPlanFromSlash env@SessionEnv
+    { sessionPlanMode = planMode
+    , sessionPersist = persist
+    , sessionPrinted = printed
+    , sessionFullscreen = fullscreen
+    } maybeDescription = do
     discardStore <- newIORef Nothing
     color <- resolveColor stderr
     case persist of
@@ -2251,6 +2464,10 @@ enterPlanFromSlash env@SessionEnv{sessionPlanMode = planMode, sessionPersist = p
             putTextLn stderr
                 (roleMuted color (glyphSession <> "plan mode on (" <> toText path <> ")"))
             writeIORef printed False
+            case fullscreen of
+                Nothing -> pure ()
+                Just runtime ->
+                    emitUiEvent runtime (UiUserSubmitted description)
             let planEnv = env { sessionStoreRoot = discardStore }
                 inputs = [UserMessage description]
             result <- runOneTurn planEnv description inputs
@@ -2882,6 +3099,23 @@ resetLiveConversation previous transcriptRef attachmentsRef planMode = do
     writeIORef attachmentsRef []
     deactivatePlanMode planMode
 
+detectGitBranch :: OsPath -> IO Text
+detectGitBranch cwd = do
+    result <-
+        (try $
+            readProcessWithExitCode
+                "git"
+                ["-C", toFilePath cwd, "rev-parse", "--abbrev-ref", "HEAD"]
+                "")
+            :: IO (Either SomeException (ExitCode, String, String))
+    pure $ case result of
+        Right (ExitSuccess, output, _) ->
+            let branch = Text.strip (Text.pack output)
+            in if Text.null branch
+                then toText (takeFileName cwd)
+                else branch
+        _ -> toText (takeFileName cwd)
+
 -- | Apply compact turns as full transcript replacements when resuming.
 foldSessionItems :: [SessionTurn] -> [ResponseItem]
 foldSessionItems = go []
@@ -2893,6 +3127,36 @@ foldSessionItems = go []
             -- rebuilt history. Either way, turnItems replaces prior history.
             go turn.turnItems rest
         | otherwise = go (acc <> turn.turnItems) rest
+
+hydrateUiHistory :: [SessionTurn] -> UiState
+hydrateUiHistory = foldl addTurn initialUiState
+  where
+    addTurn state turn
+        | isTranscriptResetTurn turn.turnUserText =
+            addResetTurn state turn
+        | otherwise =
+            addRegularTurn state turn
+
+    addResetTurn state turn =
+        let cleared = reduceUi UiConversationCleared state
+        in case turn.turnAssistantText of
+            Nothing -> cleared
+            Just text -> reduceUi (UiSystemMessage text) cleared
+
+    addRegularTurn state turn =
+        let withUser =
+                if Text.null (Text.strip turn.turnUserText)
+                    then state
+                    else reduceUi
+                        (UiUserSubmitted turn.turnUserText)
+                        state
+            withAssistant = case turn.turnAssistantText of
+                Nothing -> withUser
+                Just text ->
+                    reduceUi (UiAssistantHistory text) withUser
+        in case turn.turnError of
+            Nothing -> withAssistant
+            Just err -> reduceUi (UiErrorMessage err) withAssistant
 
 -- | Codex requires @store = false@. Continuation still uses
 -- @previous_response_id@, with the local transcript available for recovery.

--- a/packages/agent-cli/src/Agent/CLI/Approval.hs
+++ b/packages/agent-cli/src/Agent/CLI/Approval.hs
@@ -1,6 +1,7 @@
 -- | Parent and child tool-approval policy for interactive CLI sessions.
 module Agent.CLI.Approval
     ( approveToolDecision
+    , approveToolDecisionWith
     , childApprove
     , toggleAlwaysApprove
     ) where
@@ -57,6 +58,25 @@ approveToolDecision
     -> ToolCall
     -> IO (Either Text Bool)
 approveToolDecision policyRef allowedToolsRef tools planMode call = do
+    approveToolDecisionWith
+        (\requested -> do
+            color <- resolveColor stderr
+            promptPermission color requested)
+        policyRef
+        allowedToolsRef
+        tools
+        planMode
+        call
+
+approveToolDecisionWith
+    :: (ToolCall -> IO (Maybe PermissionChoice))
+    -> IORef ApprovalPolicy
+    -> IORef (Set Text)
+    -> ToolRegistry
+    -> PlanModeEnv
+    -> ToolCall
+    -> IO (Either Text Bool)
+approveToolDecisionWith requestPermission policyRef allowedToolsRef tools planMode call = do
     policy <- readIORef policyRef
     planActive <- isPlanModeActive planMode
     planPath <- planFilePath planMode
@@ -94,7 +114,7 @@ approveToolDecision policyRef allowedToolsRef tools planMode call = do
                                         | readOnly -> pure (Right True)
                                         | otherwise -> do
                                             color <- resolveColor stderr
-                                            promptPermission color call >>= \case
+                                            requestPermission call >>= \case
                                                 Nothing -> pure (Right False)
                                                 Just PermissionAllowOnce ->
                                                     pure (Right True)

--- a/packages/agent-cli/src/Agent/CLI/Clipboard.hs
+++ b/packages/agent-cli/src/Agent/CLI/Clipboard.hs
@@ -9,7 +9,7 @@ module Agent.CLI.Clipboard
     ) where
 
 import Agent.Loop (ImageAttachment(..))
-import Control.Exception (SomeException, try)
+import Control.Exception.Safe (tryAny)
 import Control.Monad (filterM)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
@@ -179,35 +179,38 @@ readMacClipboardImage = do
 
 readMacClipboardPaths :: IO [FilePath]
 readMacClipboardPaths = do
-    (code, out, _) <- readProcessWithExitCode "osascript"
-        [ "-e"
-        , "try\n\
-          \  set theFiles to the clipboard as list\n\
-          \  set paths to {}\n\
-          \  repeat with f in theFiles\n\
-          \    try\n\
-          \      set end of paths to POSIX path of f\n\
-          \    end try\n\
-          \  end repeat\n\
-          \  set AppleScript's text item delimiters to linefeed\n\
-          \  return paths as text\n\
-          \on error\n\
-          \  try\n\
-          \    return POSIX path of (the clipboard as «class furl»)\n\
-          \  on error\n\
-          \    return \"\"\n\
-          \  end try\n\
-          \end try"
-        ]
-        ""
-    pure $ case code of
-        ExitSuccess -> filter (not . null) (lines out)
-        ExitFailure _ -> []
+    result <- tryAny $
+        readProcessWithExitCode "osascript"
+            [ "-e"
+            , "try\n\
+              \  set theFiles to the clipboard as list\n\
+              \  set paths to {}\n\
+              \  repeat with f in theFiles\n\
+              \    try\n\
+              \      set end of paths to POSIX path of f\n\
+              \    end try\n\
+              \  end repeat\n\
+              \  set AppleScript's text item delimiters to linefeed\n\
+              \  return paths as text\n\
+              \on error\n\
+              \  try\n\
+              \    return POSIX path of (the clipboard as «class furl»)\n\
+              \  on error\n\
+              \    return \"\"\n\
+              \  end try\n\
+              \end try"
+            ]
+            ""
+    pure $ case result of
+        Right (ExitSuccess, out, _) ->
+            filter (not . null) (lines out)
+        Right (ExitFailure _, _, _) -> []
+        Left _ -> []
 
 readMacClipboardClass :: String -> IO (Either Text ByteString)
 readMacClipboardClass typeClass = do
     tmpDir <- getTemporaryDirectory
-    result <- try @SomeException do
+    result <- tryAny do
         (path, handle) <- openBinaryTempFile tmpDir "agent-clipboard-.bin"
         hClose handle
         removeFile path
@@ -233,10 +236,10 @@ readMacClipboardClass typeClass = do
         case code of
             ExitSuccess -> do
                 bytes <- BS.readFile path
-                _ <- try @SomeException (removeFile path)
+                _ <- tryAny (removeFile path)
                 pure (Right bytes)
             ExitFailure _ -> do
-                _ <- try @SomeException (removeFile path)
+                _ <- tryAny (removeFile path)
                 pure (Left (clipboardErrorMessage typeClass err))
     case result of
         Left ex -> pure (Left (Text.pack (show ex)))
@@ -288,7 +291,7 @@ isImageExtension ext =
 
 readImageFile :: FilePath -> IO (Either Text ImageAttachment)
 readImageFile path = do
-    result <- try @SomeException (BS.readFile path)
+    result <- tryAny (BS.readFile path)
     pure $ case result of
         Left ex -> Left (Text.pack (show ex))
         Right bytes
@@ -310,7 +313,7 @@ mimeForPath path = case map toLower (takeExtension path) of
 
 runTextCmd :: FilePath -> [String] -> IO (Either Text Text)
 runTextCmd cmd args = do
-    result <- try @SomeException (readProcessWithExitCode cmd args "")
+    result <- tryAny (readProcessWithExitCode cmd args "")
     pure $ case result of
         Left ex -> Left (Text.pack (show ex))
         Right (ExitSuccess, out, _) -> Right (Text.pack out)
@@ -320,7 +323,7 @@ runTextCmd cmd args = do
 runBytesCmd :: FilePath -> [String] -> IO (Either Text ByteString)
 runBytesCmd cmd args = do
     tmpDir <- getTemporaryDirectory
-    result <- try @SomeException do
+    result <- tryAny do
         (path, handle) <- openBinaryTempFile tmpDir "agent-clipboard-.bin"
         hClose handle
         removeFile path
@@ -336,12 +339,12 @@ runBytesCmd cmd args = do
         case code of
             ExitSuccess -> do
                 bytes <- BS.readFile path
-                _ <- try @SomeException (removeFile path)
+                _ <- tryAny (removeFile path)
                 if BS.null bytes
                     then pure (Left "no image found on the clipboard")
                     else pure (Right bytes)
             ExitFailure _ -> do
-                _ <- try @SomeException (removeFile path)
+                _ <- tryAny (removeFile path)
                 pure (Left (Text.strip (Text.pack err)))
     case result of
         Left ex -> pure (Left (Text.pack (show ex)))

--- a/packages/agent-cli/src/Agent/CLI/Interrupt.hs
+++ b/packages/agent-cli/src/Agent/CLI/Interrupt.hs
@@ -12,6 +12,7 @@ module Agent.CLI.Interrupt
     , withTurnCancel
     , noteIdleCtrlC
     , isWrappedUserInterrupt
+    , noteFullscreenCtrlC
     ) where
 
 import Agent.Cancel (CancelFlag, isCancelled, requestCancel)
@@ -122,8 +123,31 @@ noteIdleCtrlC state = do
             writeIORef state.interruptLastWarn Nothing
             pure QuitProcess
         SoftCancel ->
-            -- Idle context never decides SoftCancel; keep the match total.
             pure ContinuePrompt
+
+-- | Apply the same double-Ctrl-C policy when a retained TUI owns stdin.
+-- The caller renders the returned decision in its own UI.
+noteFullscreenCtrlC :: InterruptState -> IO CtrlCDecision
+noteFullscreenCtrlC state = do
+    now <- getCurrentTime
+    mCancel <- readIORef state.interruptActiveCancel
+    withinWindow <- isWithinWarnWindow state now
+    context <- case mCancel of
+        Nothing -> pure Idle
+        Just cancel ->
+            TurnActive <$> isCancelled cancel
+    let decision = decideCtrlC context withinWindow
+    case decision of
+        SoftCancel -> do
+            case mCancel of
+                Just cancel -> requestCancel cancel
+                Nothing -> pure ()
+            writeIORef state.interruptLastWarn (Just now)
+        WarnExit ->
+            writeIORef state.interruptLastWarn (Just now)
+        ForceExit ->
+            writeIORef state.interruptLastWarn Nothing
+    pure decision
 
 onSigInt :: ThreadId -> InterruptState -> IO ()
 onSigInt mainTid state = do

--- a/packages/agent-cli/src/Agent/CLI/Options.hs
+++ b/packages/agent-cli/src/Agent/CLI/Options.hs
@@ -4,6 +4,7 @@ module Agent.CLI.Options
     , ApprovalPolicy(..)
     , CliOptions(..)
     , Command(..)
+    , ScreenMode(..)
     , defaultCliOptions
     , defaultEffortFor
     , isOneShot
@@ -28,6 +29,12 @@ data Command
     | ListSessions
     | ShowSession Text
     | RunAgent CliOptions
+    deriving (Eq, Show)
+
+data ScreenMode
+    = ScreenAuto
+    | ScreenFullscreen
+    | ScreenMinimal
     deriving (Eq, Show)
 
 data ApprovalPolicy
@@ -69,6 +76,7 @@ data CliOptions = CliOptions
     , optSaveSession :: !Bool
     , optAgentsMd :: !Bool
       -- ^ Discover and inject AGENTS.md at session start (default: True).
+    , optScreenMode :: !ScreenMode
     } deriving (Eq, Show)
 
 defaultCliOptions :: CliOptions
@@ -86,6 +94,7 @@ defaultCliOptions = CliOptions
     , optResume = Nothing
     , optSaveSession = False
     , optAgentsMd = True
+    , optScreenMode = ScreenAuto
     }
 
 -- | Provider default when @--effort@ is omitted. Grok runs at high effort.
@@ -173,6 +182,10 @@ parseOptions options = \case
         parseOptions options { optAgentsMd = True } rest
     "--no-agents-md" : rest ->
         parseOptions options { optAgentsMd = False } rest
+    "--fullscreen" : rest ->
+        parseOptions options { optScreenMode = ScreenFullscreen } rest
+    "--minimal" : rest ->
+        parseOptions options { optScreenMode = ScreenMinimal } rest
     flag : _
         | flag == "openai-base-url" ->
             Left "openai-base-url was removed; run agent-cli --help"
@@ -227,6 +240,8 @@ usage = unlines
     , "      --save-session      Persist a one-shot (-p) run as a session"
     , "      --agents-md         Discover and inject AGENTS.md (default)"
     , "      --no-agents-md      Skip AGENTS.md discovery"
+    , "      --fullscreen        Use the retained full-screen TUI"
+    , "      --minimal           Use terminal-native append-only rendering"
     , "      --yolo              Auto-approve every tool"
     , "      --no-yolo           Never auto-approve; deny mutating tools without a TTY"
     , "      --max-turns N       Stop after N model turns (default: 500)"

--- a/packages/agent-cli/src/Agent/CLI/SessionEnv.hs
+++ b/packages/agent-cli/src/Agent/CLI/SessionEnv.hs
@@ -11,6 +11,7 @@ import Agent.CLI.Render (RenderConfig)
 import Agent.CLI.Session (Persistence, SessionHandle)
 import Agent.CLI.SessionTitle (SessionTitleManager)
 import Agent.CLI.Terminal (TerminalCapabilities)
+import Agent.CLI.TUI.App (FullscreenRuntime)
 import Agent.Loop (ImageAttachment, LoopConfig, TokenUsage)
 import qualified Agent.OpenAI.Auth as OpenAI
 import Agent.Responses.Types (ResponseCreateParams, ResponseItem)
@@ -50,6 +51,7 @@ data SessionEnv = SessionEnv
     , sessionUsage :: !(IORef TokenUsage)
     , sessionLastAssistant :: !(IORef (Maybe Text))
     , sessionTerminal :: !TerminalCapabilities
+    , sessionFullscreen :: !(Maybe FullscreenRuntime)
     , sessionAgentViewport :: !(Maybe AgentViewportEnv)
     , sessionBeginSubagentTurn :: !(IO (Maybe RootTurnId))
     , sessionFinishSubagentTurn :: !(Maybe RootTurnId -> IO ())

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -1,0 +1,1118 @@
+-- | Retained fullscreen terminal application and its session bridge.
+module Agent.CLI.TUI.App
+    ( FullscreenRuntime
+    , emitUiEvent
+    , newFullscreenRuntime
+    , readFullscreenLine
+    , requestFullscreenPermission
+    , requestFullscreenChoice
+    , runFullscreen
+    , withFullscreenSuspended
+    ) where
+
+import Agent.CLI.Input (ReplLine(..), terminalTextWidth)
+import Agent.CLI.Interrupt (CtrlCDecision(..))
+import Agent.CLI.Command
+    ( ReplAction(..)
+    , SlashMenu(..)
+    , SlashSuggestion(..)
+    , parseReplLine
+    , slashMenuFor
+    )
+import Agent.CLI.Permission (PermissionChoice(..))
+import Agent.CLI.ReplMode (replModeLabel)
+import Agent.CLI.Render (summarizeToolCall)
+import Agent.CLI.Status (formatTokenUsage)
+import qualified Agent.CLI.TUI.Theme as Theme
+import Agent.CLI.TUI.Markdown (markdownWidget)
+import Agent.CLI.UI.Model
+import Agent.ToolDispatch (ToolCall(..))
+import Brick
+import Brick.BChan (BChan, newBChan, writeBChan)
+import Brick.Widgets.Border (borderWithLabel)
+import Brick.Widgets.Border.Style (unicodeRounded)
+import Brick.Widgets.Center (centerLayer)
+import Control.Concurrent.Async (wait, waitCatch, withAsync)
+import Control.Concurrent (threadDelay)
+import Control.Concurrent.STM
+    ( TMVar
+    , TQueue
+    , atomically
+    , newEmptyTMVarIO
+    , newTQueueIO
+    , putTMVar
+    , readTMVar
+    , readTQueue
+    , writeTQueue
+    )
+import Control.Monad (forever, void, when)
+import Control.Monad.IO.Class (liftIO)
+import Control.Monad.State.Strict (modify')
+import Control.Exception.Safe (SomeException, throwIO, tryAny)
+import Control.Exception (AsyncException(UserInterrupt))
+import Data.ByteString (ByteString)
+import Data.Char (isControl)
+import Data.Foldable (toList)
+import Data.List (find)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
+import Data.Text.Encoding.Error (lenientDecode)
+import qualified Graphics.Vty as V
+import qualified Graphics.Vty.CrossPlatform as Vty
+
+data Name
+    = ConversationViewport
+    | ComposerCursor
+    deriving (Eq, Ord, Show)
+
+data AppEvent
+    = AppUi !UiEvent
+    | AppAskPermission !Text !(TMVar (Maybe PermissionChoice))
+    | AppAskChoice
+        !Text
+        !Int
+        ![(Text, Text)]
+        !(TMVar (Maybe Int))
+    | forall a. AppSuspend !(IO a) !(TMVar (Either SomeException a))
+    | AppStop
+
+data FullscreenRuntime = FullscreenRuntime
+    { runtimeEvents :: !(BChan AppEvent)
+    , runtimeInput :: !(TQueue ReplLine)
+    , runtimeCancel :: !(IO ())
+    , runtimeCtrlC :: !(IO CtrlCDecision)
+    , runtimeCopy :: !(Text -> IO Bool)
+    , runtimeInitial :: !UiState
+    }
+
+data AppState = AppState
+    { appUi :: !UiState
+    , appPermissionReply :: !(Maybe (TMVar (Maybe PermissionChoice)))
+    , appRuntime :: !FullscreenRuntime
+    , appSlashIndex :: !Int
+    , appChoice :: !(Maybe ChoiceOverlay)
+    , appChoiceReply :: !(Maybe (TMVar (Maybe Int)))
+    , appSlashDismissed :: !Bool
+    , appPasted :: !Bool
+    }
+
+data ChoiceOverlay = ChoiceOverlay
+    { choiceTitle :: !Text
+    , choiceIndex :: !Int
+    , choiceRows :: ![(Text, Text)]
+    }
+
+newFullscreenRuntime
+    :: IO ()
+    -> IO CtrlCDecision
+    -> (Text -> IO Bool)
+    -> UiState
+    -> IO FullscreenRuntime
+newFullscreenRuntime cancelAction ctrlCAction copyAction initial = FullscreenRuntime
+    <$> newBChan 512
+    <*> newTQueueIO
+    <*> pure cancelAction
+    <*> pure ctrlCAction
+    <*> pure copyAction
+    <*> pure initial
+
+emitUiEvent :: FullscreenRuntime -> UiEvent -> IO ()
+emitUiEvent runtime = writeBChan runtime.runtimeEvents . AppUi
+
+readFullscreenLine
+    :: FullscreenRuntime
+    -> PromptState
+    -> Text
+    -> IO ReplLine
+readFullscreenLine runtime prompt initial = do
+    emitUiEvent runtime (UiSetPrompt prompt)
+    emitUiEvent runtime (UiSetDraft initial (Text.length initial))
+    emitUiEvent runtime (UiSetAwaitingInput True)
+    atomically (readTQueue runtime.runtimeInput)
+
+requestFullscreenPermission
+    :: FullscreenRuntime
+    -> ToolCall
+    -> IO (Maybe PermissionChoice)
+requestFullscreenPermission runtime call = do
+    reply <- newEmptyTMVarIO
+    let summary = summarizeToolCall call
+    writeBChan runtime.runtimeEvents (AppAskPermission summary reply)
+    atomically (readTMVar reply)
+
+requestFullscreenChoice
+    :: FullscreenRuntime
+    -> Text
+    -> Int
+    -> [(Text, Text)]
+    -> IO (Maybe Int)
+requestFullscreenChoice runtime title initial rows = do
+    reply <- newEmptyTMVarIO
+    writeBChan runtime.runtimeEvents
+        (AppAskChoice title initial rows reply)
+    atomically (readTMVar reply)
+
+withFullscreenSuspended :: FullscreenRuntime -> IO a -> IO a
+withFullscreenSuspended runtime action = do
+    reply <- newEmptyTMVarIO
+    writeBChan runtime.runtimeEvents (AppSuspend action reply)
+    atomically (readTMVar reply) >>= either throwIO pure
+
+runFullscreen :: FullscreenRuntime -> IO a -> IO a
+runFullscreen runtime workerAction = do
+    let vtyConfig =
+            V.defaultConfig
+                { V.configPreferredColorMode = Just V.FullColor
+                }
+        buildVty = Vty.mkVty vtyConfig
+    initialVty <- buildVty
+    let
+        initialState = AppState
+            { appUi = runtime.runtimeInitial
+            , appPermissionReply = Nothing
+            , appRuntime = runtime
+            , appSlashIndex = 0
+            , appChoice = Nothing
+            , appChoiceReply = Nothing
+            , appSlashDismissed = False
+            , appPasted = False
+            }
+    withAsync workerAction \worker ->
+        withAsync ticker \_ticker ->
+            withAsync
+                (void (waitCatch worker)
+                    >> writeBChan runtime.runtimeEvents AppStop)
+                \_notifier -> do
+                    void $ customMain
+                        initialVty
+                        buildVty
+                        (Just runtime.runtimeEvents)
+                        fullscreenApp
+                        initialState
+                    atomically $
+                        writeTQueue runtime.runtimeInput ReplEof
+                    wait worker
+  where
+    ticker = forever do
+        threadDelay 100000
+        writeBChan runtime.runtimeEvents (AppUi UiTick)
+
+handleChoiceKey :: V.Event -> EventM Name AppState ()
+handleChoiceKey = \case
+    V.EvKey V.KUp [] -> moveChoice (-1)
+    V.EvKey V.KDown [] -> moveChoice 1
+    V.EvKey V.KBackTab [] -> moveChoice (-1)
+    V.EvKey (V.KChar '\t') [] -> moveChoice 1
+    V.EvKey V.KEnter [] -> resolveChoice True
+    V.EvKey V.KEsc [] -> resolveChoice False
+    V.EvKey (V.KChar 'q') [] -> resolveChoice False
+    _ -> pure ()
+  where
+    moveChoice delta =
+        modify' \state ->
+            state
+                { appChoice =
+                    (\choice ->
+                        let count = length choice.choiceRows
+                        in if count == 0
+                            then choice
+                            else choice
+                                { choiceIndex =
+                                    (choice.choiceIndex + delta) `mod` count
+                                })
+                        <$> state.appChoice
+                }
+
+resolveChoice :: Bool -> EventM Name AppState ()
+resolveChoice confirmed = do
+    state <- get
+    case state.appChoiceReply of
+        Nothing -> pure ()
+        Just reply ->
+            liftIO $ atomically $
+                putTMVar reply $
+                    if confirmed
+                        then (.choiceIndex) <$> state.appChoice
+                        else Nothing
+    modify' \current ->
+        current
+            { appChoice = Nothing
+            , appChoiceReply = Nothing
+            }
+
+fullscreenApp :: App AppState AppEvent Name
+fullscreenApp = App
+    { appDraw = drawApp
+    , appChooseCursor = showFirstCursor
+    , appHandleEvent = handleEvent
+    , appStartEvent = vScrollToEnd (viewportScroll ConversationViewport)
+    , appAttrMap = const Theme.solarizedDark
+    }
+
+drawApp :: AppState -> [Widget Name]
+drawApp state =
+    case (state.appChoice, state.appUi.uiPermission) of
+        (Just choice, _) ->
+            [ drawChoice choice
+            , drawMain state
+            ]
+        (Nothing, Just permission) ->
+            [ drawPermission permission
+            , drawMain state
+            ]
+        (Nothing, Nothing) -> [drawMain state]
+
+drawMain :: AppState -> Widget Name
+drawMain state =
+    withAttr Theme.baseAttr $
+        vBox
+            [ drawHeader state.appUi
+            , padTop (Pad 1) $
+                withVScrollBars OnRight $
+                    viewport ConversationViewport Vertical $
+                        padLeftRight 2 (drawTranscript state.appUi)
+            , drawNotice state.appUi
+            , drawSlashMenu state
+            , drawComposer state.appUi
+            , drawFooter state
+            ]
+
+drawHeader :: UiState -> Widget Name
+drawHeader state =
+    withAttr Theme.headerAttr $
+        padLeftRight 2 $
+            hBox
+                [ hLimitPercent 68 (txt left)
+                , fill ' '
+                , txt right
+                ]
+  where
+    left =
+        (if Text.null state.uiBranch then "" else "git " <> state.uiBranch <> "  ")
+            <> state.uiCwd
+    usage = formatTokenUsage state.uiPrompt.promptUsage
+    right =
+        (if state.uiRunning then spinnerFrame state.uiFrame <> " " else "")
+            <> state.uiActivity
+            <> if Text.null usage then "" else " │ " <> usage
+
+spinnerFrame :: Int -> Text
+spinnerFrame frame =
+    ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
+        !! (frame `mod` 10)
+
+drawTranscript :: UiState -> Widget Name
+drawTranscript state
+    | null blocks =
+        withAttr Theme.mutedAttr $
+            padTop (Pad 2) $
+                txt "Start by describing what you want to build or change."
+    | otherwise =
+        vBox (map (drawBlock state) blocks)
+  where
+    blocks = toList state.uiBlocks
+
+drawBlock :: UiState -> UiBlock -> Widget Name
+drawBlock state block =
+    let selected = state.uiSelectedBlock == Just block.blockId
+        content = case block.blockKind of
+            BlockUser ->
+                withAttr Theme.userAttr $
+                    padAll 1 (txtWrap block.blockBody)
+            BlockAssistant ->
+                padLeft (Pad 3) $
+                    withAttr Theme.assistantAttr
+                        (markdownWidget block.blockBody)
+            BlockThinking ->
+                accentBlock Theme.thinkingAttr
+                    ("◆ " <> block.blockTitle)
+                    (visibleBody block)
+            BlockTool ->
+                accentBlock (statusAttr block.blockState)
+                    ("◆ " <> block.blockTitle <> detailSuffix block)
+                    (visibleBody block)
+            BlockShell ->
+                accentBlock (statusAttr block.blockState)
+                    ("◆ " <> block.blockTitle <> detailSuffix block)
+                    (visibleShellBody block)
+            BlockEdit ->
+                accentBlock (statusAttr block.blockState)
+                    ("◆ " <> block.blockTitle <> detailSuffix block)
+                    (visibleBody block)
+            BlockSystem ->
+                withAttr Theme.mutedAttr (txtWrap block.blockBody)
+            BlockError ->
+                withAttr Theme.errorAttr (txtWrap block.blockBody)
+        framed =
+            if selected && state.uiFocus == FocusScrollback
+                then withAttr Theme.selectedAttr content
+                else content
+    in padBottom (Pad 1) framed
+
+accentBlock :: AttrName -> Text -> Text -> Widget Name
+accentBlock accent title body =
+    hBox
+        [ withAttr accent (txt "❙")
+        , padLeft (Pad 2) $
+            vBox $
+                [withAttr accent (txt title)]
+                    <> if Text.null (Text.strip body)
+                        then []
+                        else [padTop (Pad 1) (txtWrap body)]
+        ]
+
+visibleBody :: UiBlock -> Text
+visibleBody block
+    | block.blockExpanded = block.blockBody
+    | otherwise =
+        let rows = Text.lines block.blockBody
+            shown = take 3 rows
+            hidden = length rows - length shown
+        in Text.unlines shown
+            <> if hidden > 0
+                then "… +" <> Text.pack (show hidden) <> " lines"
+                else ""
+
+visibleShellBody :: UiBlock -> Text
+visibleShellBody block
+    | block.blockExpanded = block.blockBody
+    | otherwise =
+        let rows = Text.lines block.blockBody
+            shown
+                | length rows <= 5 = rows
+                | otherwise = take 2 rows <> ["…"] <> drop (length rows - 3) rows
+        in Text.unlines shown
+
+detailSuffix :: UiBlock -> Text
+detailSuffix block
+    | Text.null (Text.strip block.blockDetail) = ""
+    | otherwise = "  " <> block.blockDetail
+
+statusAttr :: BlockState -> AttrName
+statusAttr state = case state of
+    BlockFailed -> Theme.errorAttr
+    BlockCancelled -> Theme.mutedAttr
+    BlockDenied -> Theme.errorAttr
+    BlockComplete -> Theme.successAttr
+    BlockRunning -> Theme.toolAttr
+    BlockStreaming -> Theme.thinkingAttr
+
+drawNotice :: UiState -> Widget Name
+drawNotice state = case state.uiNotice of
+    Nothing -> emptyWidget
+    Just notice ->
+        withAttr Theme.footerAttr $
+            padLeftRight 2 (txtWrap notice)
+
+drawSlashMenu :: AppState -> Widget Name
+drawSlashMenu state = case currentSlashMenu state of
+    Nothing -> emptyWidget
+    Just menu ->
+        let allSuggestions = menu.slashMenuSuggestions
+            count = length allSuggestions
+            selected
+                | count == 0 = 0
+                | otherwise = state.appSlashIndex `mod` count
+            start = max 0 (min selected (max 0 (count - 6)))
+            suggestions = take 6 (drop start allSuggestions)
+        in padLeftRight 2 $
+            withAttr Theme.borderAttr $
+                withBorderStyle unicodeRounded $
+                    borderWithLabel (txt " Commands ") $
+                        vBox $
+                            zipWith
+                                (drawSlashRow selected)
+                                [start ..]
+                                suggestions
+
+drawSlashRow :: Int -> Int -> SlashSuggestion -> Widget Name
+drawSlashRow selected index suggestion =
+    let prefix = if selected == index then "❯ " else "  "
+        row =
+            hBox
+                [ txt (prefix <> suggestion.slashSuggestionDisplay)
+                , vLimit 1 (fill ' ')
+                , withAttr Theme.mutedAttr
+                    (txt suggestion.slashSuggestionSummary)
+                ]
+    in if selected == index
+        then withAttr Theme.selectedAttr row
+        else row
+
+drawComposer :: UiState -> Widget Name
+drawComposer state =
+    let focused = state.uiFocus == FocusComposer
+        attr = if focused then Theme.borderActiveAttr else Theme.borderAttr
+        mode = replModeLabel state.uiPrompt.promptMode
+        usage = formatTokenUsage state.uiPrompt.promptUsage
+        status =
+            Text.intercalate " · " $
+                filter (not . Text.null)
+                    [ if state.uiPrompt.promptAttachments > 0
+                        then "📎 "
+                            <> Text.pack
+                                (show state.uiPrompt.promptAttachments)
+                        else ""
+                    , usage
+                    , state.uiPrompt.promptModel
+                        <> if Text.null state.uiPrompt.promptEffort
+                            then ""
+                            else " (" <> state.uiPrompt.promptEffort <> ")"
+                    , mode
+                    ]
+        label = if Text.null status then " " else " " <> status <> " "
+        editor =
+            padLeftRight 1 $
+                hBox
+                    [ withAttr Theme.assistantAttr (txt "❯ ")
+                    , renderDraft focused state
+                    , vLimit 1 (fill ' ')
+                    ]
+    in withAttr attr $
+        withBorderStyle unicodeRounded $
+            borderWithLabel (withAttr Theme.footerAttr (txt label)) $
+                editor
+
+renderDraft :: Bool -> UiState -> Widget Name
+renderDraft focused state =
+    let content =
+            if Text.null state.uiDraft
+                then withAttr Theme.mutedAttr (txt " ")
+                else txt state.uiDraft
+        (row, column) = draftCursorLocation state.uiDraft state.uiCursor
+    in if focused
+        then showCursor ComposerCursor (Location (column, row)) content
+        else content
+
+draftCursorLocation :: Text -> Int -> (Int, Int)
+draftCursorLocation text cursor =
+    let before = Text.take cursor text
+        rows = Text.splitOn "\n" before
+    in case reverse rows of
+        [] -> (0, 0)
+        lastRow : rest -> (length rest, terminalTextWidth lastRow)
+
+drawFooter :: AppState -> Widget Name
+drawFooter state =
+    withAttr Theme.footerAttr $
+        padLeftRight 2 $
+            txt footer
+  where
+    footer = case (state.appChoice, state.appUi.uiFocus) of
+        (Just _, _) ->
+            "↑↓ select  │  Enter choose  │  Esc cancel"
+        (Nothing, focus) ->
+                case focus of
+                    FocusPermission ->
+                        "↑↓ select  │  Enter choose  │  Esc deny"
+                    FocusScrollback ->
+                        "↑↓ blocks  │  ←→ fold  │  PgUp/PgDn scroll  │  Tab/Space prompt"
+                    FocusComposer
+                        | state.appUi.uiRunning ->
+                            "Esc/Ctrl+C cancel  │  Tab scrollback"
+                        | otherwise ->
+                            "Enter send  │  Shift+Enter newline  │  Shift+Tab mode  │  Tab scrollback"
+
+drawPermission :: PermissionOverlay -> Widget Name
+drawPermission permission =
+    centerLayer $
+        hLimitPercent 78 $
+            withAttr Theme.borderActiveAttr $
+                withBorderStyle unicodeRounded $
+                    borderWithLabel (txt " Permission ") $
+                        padAll 1 $
+                            vBox
+                                [ txtWrap ("Allow " <> permission.permissionSummary <> "?")
+                                , padTop (Pad 1) $
+                                    vBox $
+                                        zipWith
+                                            (permissionRow permission.permissionIndex)
+                                            [0 ..]
+                                            [ "Allow once"
+                                            , "Always allow this tool this session"
+                                            , "Deny"
+                                            ]
+                                ]
+
+permissionRow :: Int -> Int -> Text -> Widget Name
+permissionRow selected index label =
+    let prefix = if selected == index then "› " else "  "
+        widget = txt (prefix <> label)
+    in if selected == index
+        then withAttr Theme.selectedAttr widget
+        else widget
+
+drawChoice :: ChoiceOverlay -> Widget Name
+drawChoice choice =
+    centerLayer $
+        hLimitPercent 82 $
+            vLimitPercent 78 $
+                withAttr Theme.borderActiveAttr $
+                    withBorderStyle unicodeRounded $
+                        borderWithLabel
+                            (txt (" " <> choice.choiceTitle <> " ")) $
+                            padAll 1 $
+                                vBox $
+                                    zipWith
+                                        (choiceRow choice.choiceIndex)
+                                        [start ..]
+                                        rows
+  where
+    count = length choice.choiceRows
+    start =
+        max 0 (min choice.choiceIndex (max 0 (count - 14)))
+    rows = take 14 (drop start choice.choiceRows)
+
+choiceRow :: Int -> Int -> (Text, Text) -> Widget Name
+choiceRow selected index (label, detail) =
+    let prefix = if selected == index then "› " else "  "
+        row =
+            hBox
+                [ txt (prefix <> label)
+                , vLimit 1 (fill ' ')
+                , withAttr Theme.mutedAttr (txt detail)
+                ]
+    in if selected == index
+        then withAttr Theme.selectedAttr row
+        else row
+
+handleEvent :: BrickEvent Name AppEvent -> EventM Name AppState ()
+handleEvent event = case event of
+    AppEvent AppStop ->
+        halt
+    AppEvent (AppUi uiEvent) -> do
+        modify' \state -> state
+            { appUi = reduceUi uiEvent state.appUi
+            , appSlashDismissed = case uiEvent of
+                UiSetDraft _ _ -> False
+                _ -> state.appSlashDismissed
+            , appPasted = case uiEvent of
+                UiSetDraft _ _ -> False
+                _ -> state.appPasted
+            }
+        state <- get
+        when (eventFollows uiEvent && state.appUi.uiFollow) $
+            vScrollToEnd (viewportScroll ConversationViewport)
+    AppEvent (AppAskPermission summary reply) ->
+        modify' \state ->
+            state
+                { appUi = reduceUi (UiPermissionShown summary) state.appUi
+                , appPermissionReply = Just reply
+                }
+    AppEvent (AppAskChoice title initial rows reply) ->
+        modify' \state ->
+            state
+                { appChoice = Just ChoiceOverlay
+                    { choiceTitle = title
+                    , choiceIndex =
+                        max 0 (min (max 0 (length rows - 1)) initial)
+                    , choiceRows = rows
+                    }
+                , appChoiceReply = Just reply
+                }
+    AppEvent (AppSuspend action reply) -> do
+        state <- get
+        suspendAndResume do
+            result <- tryAny action
+            atomically (putTMVar reply result)
+            pure state
+    VtyEvent vtyEvent -> do
+        state <- get
+        case (state.appChoice, state.appUi.uiPermission) of
+            (Just _, _) -> handleChoiceKey vtyEvent
+            (Nothing, Just _) -> handlePermissionKey vtyEvent
+            (Nothing, Nothing) -> handleNormalKey vtyEvent
+    _ -> pure ()
+
+eventFollows :: UiEvent -> Bool
+eventFollows = \case
+    UiLoop _ -> True
+    UiUserSubmitted _ -> True
+    UiConversationCleared -> True
+    _ -> False
+
+handlePermissionKey :: V.Event -> EventM Name AppState ()
+handlePermissionKey = \case
+    V.EvKey V.KUp [] -> movePermission (-1)
+    V.EvKey V.KDown [] -> movePermission 1
+    V.EvKey V.KBackTab [] -> movePermission (-1)
+    V.EvKey (V.KChar '\t') [] -> movePermission 1
+    V.EvKey (V.KChar 'y') [] -> resolvePermission PermissionAllowOnce
+    V.EvKey (V.KChar 'a') [] -> resolvePermission PermissionAllowTool
+    V.EvKey (V.KChar 'n') [] -> resolvePermission PermissionDeny
+    V.EvKey V.KEsc [] -> resolvePermission PermissionDeny
+    V.EvKey (V.KChar 'c') modifiers
+        | V.MCtrl `elem` modifiers -> do
+            _ <- handleCtrlC
+            resolvePermission PermissionDeny
+    V.EvKey V.KEnter [] -> do
+        state <- get
+        let choice = case state.appUi.uiPermission of
+                Just permission -> case permission.permissionIndex of
+                    0 -> PermissionAllowOnce
+                    1 -> PermissionAllowTool
+                    _ -> PermissionDeny
+                Nothing -> PermissionDeny
+        resolvePermission choice
+    _ -> pure ()
+  where
+    movePermission delta =
+        modify' \state ->
+            state { appUi = reduceUi (UiPermissionMoved delta) state.appUi }
+
+resolvePermission
+    :: PermissionChoice
+    -> EventM Name AppState ()
+resolvePermission choice = do
+    state <- get
+    case state.appPermissionReply of
+        Nothing -> pure ()
+        Just reply ->
+            liftIO $ atomically (putTMVar reply (Just choice))
+    modify' \current ->
+        current
+            { appUi = reduceUi UiPermissionHidden current.appUi
+            , appPermissionReply = Nothing
+            }
+
+handleCtrlC :: EventM Name AppState CtrlCDecision
+handleCtrlC = do
+    state <- get
+    decision <- liftIO state.appRuntime.runtimeCtrlC
+    case decision of
+        SoftCancel ->
+            modify' \current ->
+                current
+                    { appUi =
+                        reduceUi
+                            (UiSetNotice
+                                (Just "Interrupted; press Ctrl-C again to exit."))
+                            current.appUi
+                    }
+        WarnExit ->
+            modify' \current ->
+                current
+                    { appUi =
+                        reduceUi
+                            (UiSetNotice
+                                (Just "Press Ctrl-C again to exit."))
+                            current.appUi
+                    }
+        ForceExit ->
+            liftIO (throwIO UserInterrupt)
+    pure decision
+
+handleNormalKey :: V.Event -> EventM Name AppState ()
+handleNormalKey event = do
+    state <- get
+    case state.appUi.uiFocus of
+        FocusScrollback -> handleScrollbackKey event
+        FocusComposer -> handleComposerKey event
+        FocusPermission -> pure ()
+
+handleScrollbackKey :: V.Event -> EventM Name AppState ()
+handleScrollbackKey = \case
+    V.EvKey V.KUp [] -> moveBlock (-1) >> vScrollBy scroll (-2)
+    V.EvKey V.KDown [] -> moveBlock 1 >> vScrollBy scroll 2
+    V.EvKey V.KPageUp [] -> leaveFollow >> vScrollPage scroll Up
+    V.EvKey V.KPageDown [] -> leaveFollow >> vScrollPage scroll Down
+    V.EvKey V.KHome [] -> leaveFollow >> vScrollToBeginning scroll
+    V.EvKey V.KEnd [] -> resumeFollow
+    V.EvKey (V.KChar 'g') [] -> leaveFollow >> vScrollToBeginning scroll
+    V.EvKey (V.KChar 'G') [] -> resumeFollow
+    V.EvKey V.KLeft [] -> toggle
+    V.EvKey V.KRight [] -> toggle
+    V.EvKey V.KEnter [] -> toggle
+    V.EvKey (V.KChar 'y') [] -> copySelected
+    V.EvKey (V.KChar ' ') [] -> focusComposer
+    V.EvKey (V.KChar '\t') [] -> focusComposer
+    V.EvKey V.KEsc [] -> focusComposer
+    _ -> pure ()
+  where
+    scroll = viewportScroll ConversationViewport
+    moveBlock delta =
+        modify' \state ->
+            state { appUi = reduceUi (UiMoveSelection delta) state.appUi }
+    toggle =
+        modify' \state ->
+            state { appUi = reduceUi UiToggleSelected state.appUi }
+    focusComposer =
+        modify' \state ->
+            state { appUi = reduceUi (UiFocusChanged FocusComposer) state.appUi }
+    leaveFollow =
+        modify' \state ->
+            state { appUi = reduceUi (UiSetFollow False) state.appUi }
+    resumeFollow = do
+        modify' \state ->
+            state { appUi = reduceUi (UiSetFollow True) state.appUi }
+        vScrollToEnd scroll
+    copySelected = do
+        state <- get
+        case state.appUi.uiSelectedBlock >>= selectedBlock state.appUi of
+            Nothing -> pure ()
+            Just block -> do
+                copied <- liftIO $
+                    state.appRuntime.runtimeCopy block.blockBody
+                modify' \current ->
+                    current
+                        { appUi =
+                            reduceUi
+                                (UiSetNotice
+                                    (Just
+                                        (if copied
+                                            then "Copied selected block."
+                                            else "Terminal clipboard is unavailable.")))
+                                current.appUi
+                        }
+
+handleComposerKey :: V.Event -> EventM Name AppState ()
+handleComposerKey event = do
+    state <- get
+    let ui = state.appUi
+        slashMenu = currentSlashMenu state
+    if not ui.uiAwaitingInput
+        && isDraftMutation event
+        && not (isCtrlDEof event ui.uiDraft)
+        then modifyUi
+            (UiSetNotice
+                (Just "Agent is busy; wait for the prompt or cancel the turn."))
+        else case event of
+        V.EvKey (V.KChar 'q') [V.MCtrl] ->
+            submitRaw ReplEof
+        V.EvKey (V.KChar 'd') [V.MCtrl]
+            | Text.null ui.uiDraft ->
+                submitRaw ReplEof
+        V.EvKey (V.KChar 'd') modifiers
+            | V.MCtrl `elem` modifiers ->
+                deleteAfter
+        V.EvKey (V.KChar 'c') [V.MCtrl] ->
+            void handleCtrlC
+        V.EvKey V.KEsc [] ->
+            case slashMenu of
+                Just _ ->
+                    modify' \current ->
+                        current { appSlashDismissed = True }
+                Nothing -> cancelOrClear
+        V.EvKey V.KBackTab []
+            | ui.uiAwaitingInput ->
+                submitRaw (ReplCycleMode ui.uiDraft)
+        V.EvKey V.KUp []
+            | Just menu <- slashMenu
+            , not (null menu.slashMenuSuggestions) ->
+                moveSlash (-1) (length menu.slashMenuSuggestions)
+        V.EvKey V.KDown []
+            | Just menu <- slashMenu
+            , not (null menu.slashMenuSuggestions) ->
+                moveSlash 1 (length menu.slashMenuSuggestions)
+        V.EvKey (V.KChar '\t') [] ->
+            case slashMenu of
+                Just menu -> acceptSlash menu
+                Nothing -> modifyUi (UiFocusChanged FocusScrollback)
+        V.EvKey V.KEnter [V.MShift] ->
+            insertText "\n"
+        V.EvKey V.KEnter [] ->
+            case slashMenu of
+                Just menu -> handleSlashEnter menu
+                Nothing
+                    | ui.uiAwaitingInput -> submitDraft
+                    | otherwise -> modifyUi
+                        (UiSetNotice
+                            (Just "Agent is running; press Esc or Ctrl+C to cancel."))
+        V.EvKey V.KBS [] ->
+            deleteBefore
+        V.EvKey V.KBS modifiers
+            | V.MMeta `elem` modifiers
+                || V.MAlt `elem` modifiers ->
+                deletePreviousWord
+        V.EvKey (V.KChar 'w') modifiers
+            | V.MCtrl `elem` modifiers ->
+                deletePreviousWord
+        V.EvKey (V.KChar 'u') modifiers
+            | V.MCtrl `elem` modifiers ->
+                deleteCurrentLine
+        V.EvKey (V.KChar 'k') modifiers
+            | V.MCtrl `elem` modifiers ->
+                deleteLineEnd
+        V.EvKey (V.KChar 'a') modifiers
+            | V.MCtrl `elem` modifiers ->
+                setCursor (lineStartCursor ui.uiDraft ui.uiCursor)
+        V.EvKey (V.KChar 'e') modifiers
+            | V.MCtrl `elem` modifiers ->
+                setCursor (lineEndCursor ui.uiDraft ui.uiCursor)
+        V.EvKey (V.KChar 'b') modifiers
+            | V.MCtrl `elem` modifiers ->
+                moveCursor (-1)
+        V.EvKey (V.KChar 'f') modifiers
+            | V.MCtrl `elem` modifiers ->
+                moveCursor 1
+        V.EvKey (V.KChar 'v') modifiers
+            | V.MCtrl `elem` modifiers ->
+                submitRaw (ReplClipboardPaste ui.uiDraft)
+        V.EvKey V.KDel [] ->
+            deleteAfter
+        V.EvKey V.KLeft modifiers
+            | V.MMeta `elem` modifiers
+                || V.MAlt `elem` modifiers ->
+                setCursor (moveWordLeft ui.uiDraft ui.uiCursor)
+        V.EvKey V.KRight modifiers
+            | V.MMeta `elem` modifiers
+                || V.MAlt `elem` modifiers ->
+                setCursor (moveWordRight ui.uiDraft ui.uiCursor)
+        V.EvKey V.KLeft [] ->
+            moveCursor (-1)
+        V.EvKey V.KRight [] ->
+            moveCursor 1
+        V.EvKey V.KHome [] ->
+            setCursor (lineStartCursor ui.uiDraft ui.uiCursor)
+        V.EvKey V.KEnd [] ->
+            setCursor (lineEndCursor ui.uiDraft ui.uiCursor)
+        V.EvKey V.KPageUp [] ->
+            vScrollPage (viewportScroll ConversationViewport) Up
+        V.EvKey V.KPageDown [] ->
+            vScrollPage (viewportScroll ConversationViewport) Down
+        V.EvKey (V.KChar character) [] ->
+            insertText (Text.singleton character)
+        V.EvPaste bytes -> do
+            insertText (decodePaste bytes)
+            modify' \current -> current { appPasted = True }
+        _ -> pure ()
+  where
+    submitRaw replLine = do
+        state <- get
+        liftIO $ atomically $
+            writeTQueue state.appRuntime.runtimeInput replLine
+        modify' \current ->
+            current
+                { appUi =
+                    reduceUi
+                        (UiSetAwaitingInput False)
+                        current.appUi
+                }
+
+    submitDraft = do
+        state <- get
+        let draft = state.appUi.uiDraft
+        if Text.null (Text.strip draft)
+            then pure ()
+            else do
+                liftIO $ atomically $
+                    writeTQueue state.appRuntime.runtimeInput $
+                        if state.appPasted
+                            then ReplPasted draft
+                            else ReplText draft
+                modify' \current ->
+                    current
+                        { appUi = if isLocalCommand draft
+                            then reduceUi
+                                (UiSetDraft "" 0)
+                                (reduceUi
+                                    (UiSetAwaitingInput False)
+                                    current.appUi)
+                            else reduceUi
+                                (UiUserSubmitted draft)
+                                current.appUi
+                        , appPasted = False
+                        }
+                vScrollToEnd (viewportScroll ConversationViewport)
+
+    cancelOrClear = do
+        state <- get
+        if state.appUi.uiRunning
+            then do
+                liftIO state.appRuntime.runtimeCancel
+                modifyUi (UiSetNotice (Just "Cancelling…"))
+            else
+                modifyUi (UiSetDraft "" 0)
+
+    insertText inserted = do
+        state <- get
+        let ui = state.appUi
+            before = Text.take ui.uiCursor ui.uiDraft
+            after = Text.drop ui.uiCursor ui.uiDraft
+        modifyUiResetSlash $
+            UiSetDraft
+                (before <> inserted <> after)
+                (ui.uiCursor + Text.length inserted)
+
+    deleteBefore = do
+        state <- get
+        let ui = state.appUi
+        when (ui.uiCursor > 0) do
+            let before = Text.take (ui.uiCursor - 1) ui.uiDraft
+                after = Text.drop ui.uiCursor ui.uiDraft
+            modifyUiResetSlash
+                (UiSetDraft (before <> after) (ui.uiCursor - 1))
+
+    deleteAfter = do
+        state <- get
+        let ui = state.appUi
+        when (ui.uiCursor < Text.length ui.uiDraft) do
+            let before = Text.take ui.uiCursor ui.uiDraft
+                after = Text.drop (ui.uiCursor + 1) ui.uiDraft
+            modifyUiResetSlash
+                (UiSetDraft (before <> after) ui.uiCursor)
+
+    deletePreviousWord = do
+        state <- get
+        let (next, cursor) =
+                deleteWordBefore state.appUi.uiDraft state.appUi.uiCursor
+        modifyUiResetSlash (UiSetDraft next cursor)
+
+    deleteLineEnd = do
+        state <- get
+        let (next, cursor) =
+                deleteToLineEnd state.appUi.uiDraft state.appUi.uiCursor
+        modifyUiResetSlash (UiSetDraft next cursor)
+
+    deleteCurrentLine = do
+        state <- get
+        let (next, cursor) =
+                deleteToLineStart state.appUi.uiDraft state.appUi.uiCursor
+        modifyUiResetSlash (UiSetDraft next cursor)
+
+    moveCursor delta = do
+        state <- get
+        setCursor (state.appUi.uiCursor + delta)
+
+    setCursor cursor =
+        modify' \current ->
+            current
+                { appUi =
+                    reduceUi
+                        (UiSetDraft current.appUi.uiDraft cursor)
+                        current.appUi
+                , appSlashIndex = 0
+                }
+
+    modifyUi uiEvent =
+        modify' \state ->
+            state { appUi = reduceUi uiEvent state.appUi }
+
+    modifyUiResetSlash uiEvent =
+        modify' \state ->
+            state
+                { appUi = reduceUi uiEvent state.appUi
+                , appSlashIndex = 0
+                , appSlashDismissed = False
+                }
+
+    moveSlash delta count =
+        modify' \current ->
+            current
+                { appSlashIndex =
+                    (current.appSlashIndex + delta) `mod` count
+                }
+
+    acceptSlash menu = do
+        current <- get
+        case selectedSlashSuggestion current menu of
+            Nothing -> pure ()
+            Just suggestion -> acceptSlashSuggestion menu suggestion
+
+    handleSlashEnter menu = do
+        current <- get
+        case selectedSlashSuggestion current menu of
+            Nothing -> submitDraft
+            Just suggestion
+                | Text.strip current.appUi.uiDraft
+                    == suggestion.slashSuggestionDisplay ->
+                        submitDraft
+                | suggestion.slashSuggestionTakesArguments ->
+                    acceptSlashSuggestion menu suggestion
+                | otherwise -> do
+                    let next = slashReplacement
+                            current.appUi.uiDraft
+                            menu
+                            suggestion
+                    liftIO $ atomically $
+                        writeTQueue
+                            current.appRuntime.runtimeInput
+                            (ReplText next)
+                    modify' \state ->
+                        state
+                            { appUi =
+                                reduceUi
+                                    (UiSetDraft "" 0)
+                                    (reduceUi
+                                        (UiSetAwaitingInput False)
+                                        state.appUi)
+                            , appSlashIndex = 0
+                            , appSlashDismissed = False
+                            , appPasted = False
+                            }
+
+    acceptSlashSuggestion menu suggestion = do
+        current <- get
+        let next = slashReplacement
+                current.appUi.uiDraft
+                menu
+                suggestion
+            cursor =
+                menu.slashMenuReplaceStart
+                    + Text.length suggestion.slashSuggestionReplacement
+        modifyUiResetSlash (UiSetDraft next cursor)
+
+decodePaste :: ByteString -> Text
+decodePaste =
+    Text.filter
+        (\character ->
+            character == '\n'
+                || character == '\t'
+                || not (isControl character))
+        . Text.decodeUtf8With lenientDecode
+
+isDraftMutation :: V.Event -> Bool
+isDraftMutation = \case
+    V.EvPaste _ -> True
+    V.EvKey V.KBS _ -> True
+    V.EvKey V.KDel _ -> True
+    V.EvKey V.KEnter modifiers -> V.MShift `elem` modifiers
+    V.EvKey (V.KChar character) modifiers
+        | V.MCtrl `elem` modifiers ->
+            character `elem` ['d', 'k', 'u', 'w']
+        | otherwise -> null modifiers
+    _ -> False
+
+isCtrlDEof :: V.Event -> Text -> Bool
+isCtrlDEof event draft = case event of
+    V.EvKey (V.KChar 'd') modifiers ->
+        V.MCtrl `elem` modifiers && Text.null draft
+    _ -> False
+
+currentSlashMenu :: AppState -> Maybe SlashMenu
+currentSlashMenu state
+    | state.appSlashDismissed = Nothing
+    | otherwise =
+        slashMenuFor state.appUi.uiDraft state.appUi.uiCursor
+
+selectedSlashSuggestion
+    :: AppState
+    -> SlashMenu
+    -> Maybe SlashSuggestion
+selectedSlashSuggestion state menu =
+    case menu.slashMenuSuggestions of
+        [] -> Nothing
+        suggestions ->
+            Just
+                (suggestions
+                    !! (state.appSlashIndex `mod` length suggestions))
+
+slashReplacement
+    :: Text
+    -> SlashMenu
+    -> SlashSuggestion
+    -> Text
+slashReplacement draft menu suggestion =
+    let before = Text.take menu.slashMenuReplaceStart draft
+        after = Text.drop menu.slashMenuReplaceEnd draft
+    in before <> suggestion.slashSuggestionReplacement <> after
+
+isLocalCommand :: Text -> Bool
+isLocalCommand draft = case parseReplLine draft of
+    ReplPrompt _ -> False
+    _ -> True
+
+selectedBlock :: UiState -> BlockId -> Maybe UiBlock
+selectedBlock state ident =
+    find ((== ident) . (.blockId)) (toList state.uiBlocks)

--- a/packages/agent-cli/src/Agent/CLI/TUI/Markdown.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Markdown.hs
@@ -1,0 +1,71 @@
+-- | Lightweight fullscreen Markdown block rendering.
+module Agent.CLI.TUI.Markdown
+    ( markdownWidget
+    ) where
+
+import qualified Agent.CLI.TUI.Theme as Theme
+import Brick
+import Data.Text (Text)
+import qualified Data.Text as Text
+
+markdownWidget :: Text -> Widget n
+markdownWidget input =
+    vBox (renderLines False (Text.lines input))
+
+renderLines :: Bool -> [Text] -> [Widget n]
+renderLines _ [] = []
+renderLines inFence (line : rest)
+    | isFence line =
+        renderLines (not inFence) rest
+    | inFence =
+        withAttr Theme.codeAttr
+            (padLeftRight 1 (txt line))
+            : renderLines True rest
+    | Just heading <- stripHeading line =
+        withAttr Theme.headingAttr
+            (padTop (Pad 1) (txtWrap heading))
+            : renderLines False rest
+    | Just item <- stripBullet line =
+        hBox
+            [ withAttr Theme.headingAttr (txt "• ")
+            , txtWrap item
+            ]
+            : renderLines False rest
+    | Just quote <- Text.stripPrefix "> " (Text.stripStart line) =
+        hBox
+            [ withAttr Theme.mutedAttr (txt "│ ")
+            , withAttr Theme.mutedAttr (txtWrap quote)
+            ]
+            : renderLines False rest
+    | Text.null (Text.strip line) =
+        txt " " : renderLines False rest
+    | otherwise =
+        txtWrap line : renderLines False rest
+
+isFence :: Text -> Bool
+isFence line =
+    let stripped = Text.stripStart line
+    in "```" `Text.isPrefixOf` stripped
+        || "~~~" `Text.isPrefixOf` stripped
+
+stripHeading :: Text -> Maybe Text
+stripHeading line =
+    let stripped = Text.stripStart line
+        (marks, rest) = Text.span (== '#') stripped
+    in if not (Text.null marks)
+        && Text.length marks <= 6
+        && Text.isPrefixOf " " rest
+        then Just (Text.strip rest)
+        else Nothing
+
+stripBullet :: Text -> Maybe Text
+stripBullet line =
+    let stripped = Text.stripStart line
+    in asumPrefix ["- ", "* ", "+ "] stripped
+
+asumPrefix :: [Text] -> Text -> Maybe Text
+asumPrefix prefixes text = case prefixes of
+    [] -> Nothing
+    prefix : rest -> case Text.stripPrefix prefix text of
+        Just value -> Just value
+        Nothing -> asumPrefix rest text

--- a/packages/agent-cli/src/Agent/CLI/TUI/Theme.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Theme.hs
@@ -1,0 +1,104 @@
+-- | Semantic attributes for the retained fullscreen interface.
+module Agent.CLI.TUI.Theme
+    ( assistantAttr
+    , baseAttr
+    , borderActiveAttr
+    , borderAttr
+    , errorAttr
+    , footerAttr
+    , headerAttr
+    , codeAttr
+    , headingAttr
+    , mutedAttr
+    , selectedAttr
+    , successAttr
+    , thinkingAttr
+    , toolAttr
+    , userAttr
+    , solarizedDark
+    ) where
+
+import Brick (AttrMap, AttrName, attrMap, attrName)
+import qualified Graphics.Vty as V
+
+baseAttr, headerAttr, footerAttr, mutedAttr :: AttrName
+userAttr, assistantAttr, thinkingAttr, toolAttr :: AttrName
+errorAttr, successAttr, selectedAttr, borderAttr, borderActiveAttr :: AttrName
+headingAttr, codeAttr :: AttrName
+baseAttr = attrName "base"
+headerAttr = attrName "header"
+footerAttr = attrName "footer"
+mutedAttr = attrName "muted"
+userAttr = attrName "user"
+assistantAttr = attrName "assistant"
+thinkingAttr = attrName "thinking"
+toolAttr = attrName "tool"
+errorAttr = attrName "error"
+successAttr = attrName "success"
+selectedAttr = attrName "selected"
+borderAttr = attrName "border"
+borderActiveAttr = attrName "border-active"
+headingAttr = attrName "markdown-heading"
+codeAttr = attrName "markdown-code"
+
+solarizedDark :: AttrMap
+solarizedDark =
+    attrMap
+        (V.defAttr
+            `V.withForeColor` rgb 131 148 150
+            `V.withBackColor` rgb 0 43 54)
+        [ (baseAttr, V.defAttr
+            `V.withForeColor` rgb 131 148 150
+            `V.withBackColor` rgb 0 43 54)
+        , (headerAttr, V.defAttr
+            `V.withForeColor` rgb 147 161 161
+            `V.withBackColor` rgb 0 43 54)
+        , (footerAttr, V.defAttr
+            `V.withForeColor` rgb 88 110 117
+            `V.withBackColor` rgb 0 43 54)
+        , (mutedAttr, V.defAttr
+            `V.withForeColor` rgb 88 110 117
+            `V.withBackColor` rgb 0 43 54)
+        , (userAttr, V.defAttr
+            `V.withForeColor` rgb 147 161 161
+            `V.withBackColor` rgb 7 54 66)
+        , (assistantAttr, V.defAttr
+            `V.withForeColor` rgb 131 148 150
+            `V.withBackColor` rgb 0 43 54)
+        , (thinkingAttr, V.defAttr
+            `V.withForeColor` rgb 181 137 0
+            `V.withBackColor` rgb 0 43 54)
+        , (toolAttr, V.defAttr
+            `V.withForeColor` rgb 42 161 152
+            `V.withBackColor` rgb 0 43 54)
+        , (errorAttr, V.defAttr
+            `V.withForeColor` rgb 220 50 47
+            `V.withBackColor` rgb 0 43 54
+            `V.withStyle` V.bold)
+        , (successAttr, V.defAttr
+            `V.withForeColor` rgb 133 153 0
+            `V.withBackColor` rgb 0 43 54)
+        , (selectedAttr, V.defAttr
+            `V.withForeColor` rgb 147 161 161
+            `V.withBackColor` rgb 7 54 66)
+        , (borderAttr, V.defAttr
+            `V.withForeColor` rgb 88 110 117
+            `V.withBackColor` rgb 0 43 54)
+        , (borderActiveAttr, V.defAttr
+            `V.withForeColor` rgb 42 161 152
+            `V.withBackColor` rgb 0 43 54)
+        , (headingAttr, V.defAttr
+            `V.withForeColor` rgb 211 54 130
+            `V.withBackColor` rgb 0 43 54
+            `V.withStyle` V.bold)
+        , (codeAttr, V.defAttr
+            `V.withForeColor` rgb 42 161 152
+            `V.withBackColor` rgb 7 54 66)
+        ]
+
+rgb :: Int -> Int -> Int -> V.Color
+rgb r g b =
+    V.RGBColor
+        (fromIntegral r)
+        (fromIntegral g)
+        (fromIntegral b)

--- a/packages/agent-cli/src/Agent/CLI/Turn.hs
+++ b/packages/agent-cli/src/Agent/CLI/Turn.hs
@@ -13,6 +13,12 @@ import Agent.CLI.ProviderTransition
     ( PendingTurn(..)
     , TurnResult(..)
     )
+import Agent.CLI.TUI.App
+    ( FullscreenRuntime
+    , emitUiEvent
+    , withFullscreenSuspended
+    )
+import Agent.CLI.UI.Model (BlockState(..), UiEvent(..))
 import Agent.CLI.Render
     ( RenderConfig(..)
     , clearThinking
@@ -87,7 +93,7 @@ import Data.IORef
     , readIORef
     , writeIORef
     )
-import Data.Maybe (isNothing)
+import Data.Maybe (isJust, isNothing)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Time.Clock (UTCTime, diffUTCTime, getCurrentTime)
@@ -110,16 +116,19 @@ runOneTurn env@SessionEnv
     , sessionUsage = usageRef
     , sessionLastAssistant = lastAssistantRef
     , sessionTerminal = terminal
+    , sessionFullscreen = fullscreen
     , sessionBeginSubagentTurn = beginSubagentTurn
     , sessionFinishSubagentTurn = finishSubagentTurn
     , sessionAbortSubagentTurn = abortSubagentTurn
     , sessionOnPersisted = onPersisted
-    } promptText inputs =
+    } promptText inputs = do
   -- Clear the prior turn before publishing this flag to Ctrl-C / Esc.
   -- Resetting inside runLoopInputs could erase the one-shot Esc signal.
-  resetCancel config.loopCancel >>
-  (withTurnCancel interrupt config.loopCancel
-    . withEscCancel config.loopCancel escPaused) do
+  resetCancel config.loopCancel
+  withTurnCancel interrupt config.loopCancel $
+    (if isJust fullscreen
+        then id
+        else withEscCancel config.loopCancel escPaused) do
     applyPendingSessionTitles env
     pending <- readIORef planMode.planStateRef
     when (pending == PlanPending) (activatePlanMode planMode)
@@ -133,10 +142,17 @@ runOneTurn env@SessionEnv
             writeIORef planMode.planSessionDir (Just handle.sessionDir)
             writeIORef storeRoot (Just handle.sessionDir)
             when created do
-                color <- resolveColor stderr
-                putTextLn stderr
-                    (roleMuted color
-                        (glyphSession <> "session: " <> handle.sessionMeta.metaId))
+                case fullscreen of
+                    Just runtime ->
+                        emitUiEvent runtime
+                            (UiSystemMessage
+                                ("session: " <> handle.sessionMeta.metaId))
+                    Nothing -> do
+                        color <- resolveColor stderr
+                        putTextLn stderr
+                            (roleMuted color
+                                (glyphSession <> "session: "
+                                    <> handle.sessionMeta.metaId))
             titleTurns <- readIORef env.sessionTitleTurnCount
             when
                 ( titleTurns == 0
@@ -205,10 +221,19 @@ runOneTurn env@SessionEnv
             finishTerminal terminal wallStarted finishedAt 130 "Agent cancelled"
             abortSubagentTurn rootTurnId
             writeIORef transcriptRef beforeItems
-            color <- resolveColor stderr
-            putTextLn stderr (formatLoopErrorColored color cancelled)
             model <- readIORef render.renderModelRef
-            putTextLn stderr (formatTurnStatus color "cancelled" (elapsedDetail model))
+            case fullscreen of
+                Just runtime -> do
+                    emitUiEvent runtime
+                        (UiTurnEnded BlockCancelled)
+                    emitUiEvent runtime
+                        (UiSystemMessage
+                            ("cancelled · " <> elapsedDetail model))
+                Nothing -> do
+                    color <- resolveColor stderr
+                    putTextLn stderr (formatLoopErrorColored color cancelled)
+                    putTextLn stderr
+                        (formatTurnStatus color "cancelled" (elapsedDetail model))
             persistIncomplete "cancelled"
             pure TurnSucceeded
         Left err -> do
@@ -219,6 +244,11 @@ runOneTurn env@SessionEnv
                 LoopTransport apiError
                     | length afterItems == length beforeItems
                     , isProviderUnavailable apiError -> do
+                        case fullscreen of
+                            Nothing -> pure ()
+                            Just runtime ->
+                                emitUiEvent runtime
+                                    (UiTurnEnded BlockFailed)
                         finishTerminal terminal wallStarted finishedAt 1
                             "Agent provider unavailable"
                         planState <- readIORef planMode.planStateRef
@@ -231,10 +261,22 @@ runOneTurn env@SessionEnv
                 _ -> do
                     finishTerminal terminal wallStarted finishedAt 1 "Agent turn failed"
                     writeIORef transcriptRef beforeItems
-                    color <- resolveColor stderr
-                    putTextLn stderr (formatLoopErrorColored color err)
                     model <- readIORef render.renderModelRef
-                    putTextLn stderr (formatTurnStatus color "error" (elapsedDetail model))
+                    case fullscreen of
+                        Just runtime ->
+                            do
+                                emitUiEvent runtime
+                                    (UiTurnEnded BlockFailed)
+                                emitUiEvent runtime
+                                    (UiErrorMessage
+                                        (Text.pack (show err)
+                                            <> "\n"
+                                            <> elapsedDetail model))
+                        Nothing -> do
+                            color <- resolveColor stderr
+                            putTextLn stderr (formatLoopErrorColored color err)
+                            putTextLn stderr
+                                (formatTurnStatus color "error" (elapsedDetail model))
                     persistIncomplete (Text.pack (show err))
                     pure TurnFailed
         Right loopResult -> do
@@ -243,7 +285,6 @@ runOneTurn env@SessionEnv
             writeIORef previous (Just loopResult.finalResponseId)
             modifyIORef' usageRef (`addTokenUsage` loopResult.tokenUsage)
             do
-                color <- resolveColor stderr
                 model <- readIORef render.renderModelRef
                 let turns = Text.pack (show loopResult.turnsUsed)
                     unit = if loopResult.turnsUsed == 1 then " turn" else " turns"
@@ -252,15 +293,22 @@ runOneTurn env@SessionEnv
                         if Text.null usageDetail
                             then model <> " · " <> turns <> unit
                             else model <> " · " <> turns <> unit <> " · " <> usageDetail
-                putTextLn stderr
-                    (formatTurnStatus color "ok" (elapsedDetail extra))
-            followUp <- handleProposedPlan planMode loopResult.finalText
+                    detail = elapsedDetail extra
+                case fullscreen of
+                    Just runtime ->
+                        emitUiEvent runtime (UiSetNotice (Just detail))
+                    Nothing -> do
+                        color <- resolveColor stderr
+                        putTextLn stderr
+                            (formatTurnStatus color "ok" detail)
+            followUp <- handleProposedPlan fullscreen planMode loopResult.finalText
             printedText <- readIORef printed
             let assistantText =
                     fmap stripBracketedTimestamps loopResult.finalText
             writeIORef lastAssistantRef assistantText
-            case (printedText, assistantText) of
-                (False, Just text) | not (Text.null (Text.strip text)) -> do
+            case (fullscreen, printedText, assistantText) of
+                (Just _, _, _) -> pure ()
+                (Nothing, False, Just text) | not (Text.null (Text.strip text)) -> do
                     useColor <- resolveColor stdout
                     putTextLn stdout (renderAssistantText useColor text)
                 _ -> pure ()
@@ -366,8 +414,12 @@ finishTerminal terminal started finished exitCode message = do
     when (exitCode /= 0 || seconds >= 10) $
         notifyTerminal terminal stdout message
 
-handleProposedPlan :: PlanModeEnv -> Maybe Text -> IO (Maybe Text)
-handleProposedPlan planMode = \case
+handleProposedPlan
+    :: Maybe FullscreenRuntime
+    -> PlanModeEnv
+    -> Maybe Text
+    -> IO (Maybe Text)
+handleProposedPlan fullscreen planMode = \case
     Nothing -> pure Nothing
     Just text -> do
         active <- isPlanModeActive planMode
@@ -375,7 +427,10 @@ handleProposedPlan planMode = \case
             (True, Just planBody) -> do
                 _ <- writePlanMarkdown planMode planBody
                 let PlanModeHooks{ planDecideExit = decideExit } = planMode.planHooks
-                decision <- decideExit planBody
+                decision <- case fullscreen of
+                    Nothing -> decideExit planBody
+                    Just runtime ->
+                        withFullscreenSuspended runtime (decideExit planBody)
                 case decision of
                     PlanApprove -> do
                         deactivatePlanMode planMode

--- a/packages/agent-cli/src/Agent/CLI/Turn.hs
+++ b/packages/agent-cli/src/Agent/CLI/Turn.hs
@@ -14,9 +14,7 @@ import Agent.CLI.ProviderTransition
     , TurnResult(..)
     )
 import Agent.CLI.TUI.App
-    ( FullscreenRuntime
-    , emitUiEvent
-    , withFullscreenSuspended
+    ( emitUiEvent
     )
 import Agent.CLI.UI.Model (BlockState(..), UiEvent(..))
 import Agent.CLI.Render
@@ -301,7 +299,7 @@ runOneTurn env@SessionEnv
                         color <- resolveColor stderr
                         putTextLn stderr
                             (formatTurnStatus color "ok" detail)
-            followUp <- handleProposedPlan fullscreen planMode loopResult.finalText
+            followUp <- handleProposedPlan planMode loopResult.finalText
             printedText <- readIORef printed
             let assistantText =
                     fmap stripBracketedTimestamps loopResult.finalText
@@ -415,11 +413,10 @@ finishTerminal terminal started finished exitCode message = do
         notifyTerminal terminal stdout message
 
 handleProposedPlan
-    :: Maybe FullscreenRuntime
-    -> PlanModeEnv
+    :: PlanModeEnv
     -> Maybe Text
     -> IO (Maybe Text)
-handleProposedPlan fullscreen planMode = \case
+handleProposedPlan planMode = \case
     Nothing -> pure Nothing
     Just text -> do
         active <- isPlanModeActive planMode
@@ -427,10 +424,7 @@ handleProposedPlan fullscreen planMode = \case
             (True, Just planBody) -> do
                 _ <- writePlanMarkdown planMode planBody
                 let PlanModeHooks{ planDecideExit = decideExit } = planMode.planHooks
-                decision <- case fullscreen of
-                    Nothing -> decideExit planBody
-                    Just runtime ->
-                        withFullscreenSuspended runtime (decideExit planBody)
+                decision <- decideExit planBody
                 case decision of
                     PlanApprove -> do
                         deactivatePlanMode planMode

--- a/packages/agent-cli/src/Agent/CLI/UI/Model.hs
+++ b/packages/agent-cli/src/Agent/CLI/UI/Model.hs
@@ -1,0 +1,534 @@
+-- | Renderer-independent state for the retained terminal UI.
+module Agent.CLI.UI.Model
+    ( BlockId(..)
+    , BlockKind(..)
+    , BlockState(..)
+    , Focus(..)
+    , PermissionOverlay(..)
+    , PromptState(..)
+    , UiBlock(..)
+    , UiEvent(..)
+    , UiState(..)
+    , initialUiState
+    , deleteToLineStart
+    , deleteToLineEnd
+    , deleteWordBefore
+    , lineEndCursor
+    , lineStartCursor
+    , moveWordLeft
+    , moveWordRight
+    , reduceUi
+    , selectedBlockIndex
+    ) where
+
+import Agent.CLI.ReplMode (ReplMode(..))
+import Agent.CLI.Render (summarizeToolCall)
+import Agent.Loop
+    ( LoopEvent(..)
+    , TokenUsage
+    , TurnOutput(..)
+    , emptyTokenUsage
+    )
+import Agent.ToolDispatch (ToolCall(..), ToolCallResult(..))
+import Data.Foldable (toList)
+import Data.Sequence (Seq)
+import qualified Data.Sequence as Seq
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Data.Char (isSpace)
+
+newtype BlockId = BlockId Int
+    deriving (Eq, Ord, Show)
+
+data BlockKind
+    = BlockUser
+    | BlockAssistant
+    | BlockThinking
+    | BlockTool
+    | BlockShell
+    | BlockEdit
+    | BlockSystem
+    | BlockError
+    deriving (Eq, Show)
+
+data BlockState
+    = BlockStreaming
+    | BlockRunning
+    | BlockComplete
+    | BlockFailed
+    | BlockCancelled
+    | BlockDenied
+    deriving (Eq, Show)
+
+data UiBlock = UiBlock
+    { blockId :: !BlockId
+    , blockKind :: !BlockKind
+    , blockTitle :: !Text
+    , blockBody :: !Text
+    , blockDetail :: !Text
+    , blockState :: !BlockState
+    , blockExpanded :: !Bool
+    , blockCallId :: !(Maybe Text)
+    }
+    deriving (Eq, Show)
+
+data Focus
+    = FocusComposer
+    | FocusScrollback
+    | FocusPermission
+    deriving (Eq, Show)
+
+data PermissionOverlay = PermissionOverlay
+    { permissionSummary :: !Text
+    , permissionIndex :: !Int
+    }
+    deriving (Eq, Show)
+
+data PromptState = PromptState
+    { promptModel :: !Text
+    , promptEffort :: !Text
+    , promptMode :: !ReplMode
+    , promptUsage :: !TokenUsage
+    , promptAttachments :: !Int
+    }
+    deriving (Eq, Show)
+
+data UiState = UiState
+    { uiBlocks :: !(Seq UiBlock)
+    , uiNextBlockId :: !Int
+    , uiDraft :: !Text
+    , uiCursor :: !Int
+    , uiFocus :: !Focus
+    , uiSelectedBlock :: !(Maybe BlockId)
+    , uiFollow :: !Bool
+    , uiRunning :: !Bool
+    , uiAwaitingInput :: !Bool
+    , uiActivity :: !Text
+    , uiPrompt :: !PromptState
+    , uiBranch :: !Text
+    , uiCwd :: !Text
+    , uiPermission :: !(Maybe PermissionOverlay)
+    , uiNotice :: !(Maybe Text)
+    , uiFrame :: !Int
+    , uiTurnStartBlock :: !Int
+    }
+    deriving (Eq, Show)
+
+data UiEvent
+    = UiLoop !LoopEvent
+    | UiUserSubmitted !Text
+    | UiSetDraft !Text !Int
+    | UiSetPrompt !PromptState
+    | UiSetAwaitingInput !Bool
+    | UiSetRepository !Text !Text
+    | UiSetNotice !(Maybe Text)
+    | UiMoveSelection !Int
+    | UiToggleSelected
+    | UiFocusChanged !Focus
+    | UiPermissionShown !Text
+    | UiPermissionMoved !Int
+    | UiPermissionHidden
+    | UiHistory !Text
+    | UiAssistantHistory !Text
+    | UiSystemMessage !Text
+    | UiErrorMessage !Text
+    | UiConversationCleared
+    | UiSetFollow !Bool
+    | UiTurnEnded !BlockState
+    | UiTick
+    deriving (Eq, Show)
+
+initialUiState :: UiState
+initialUiState = UiState
+    { uiBlocks = Seq.empty
+    , uiNextBlockId = 1
+    , uiDraft = ""
+    , uiCursor = 0
+    , uiFocus = FocusComposer
+    , uiSelectedBlock = Nothing
+    , uiFollow = True
+    , uiRunning = False
+    , uiAwaitingInput = False
+    , uiActivity = "Ready"
+    , uiPrompt = PromptState
+        { promptModel = ""
+        , promptEffort = ""
+        , promptMode = ReplModeNormal
+        , promptUsage = emptyTokenUsage
+        , promptAttachments = 0
+        }
+    , uiBranch = ""
+    , uiCwd = ""
+    , uiPermission = Nothing
+    , uiNotice = Nothing
+    , uiFrame = 0
+    , uiTurnStartBlock = 0
+    }
+
+reduceUi :: UiEvent -> UiState -> UiState
+reduceUi event state = case event of
+    UiLoop loopEvent -> reduceLoop loopEvent state
+    UiUserSubmitted text ->
+        appendBlock BlockUser "You" text "" BlockComplete Nothing
+            state
+                { uiDraft = ""
+                , uiCursor = 0
+                , uiAwaitingInput = False
+                , uiFollow = True
+                , uiNotice = Nothing
+                }
+    UiSetDraft text cursor ->
+        state
+            { uiDraft = text
+            , uiCursor = max 0 (min (Text.length text) cursor)
+            }
+    UiSetPrompt prompt ->
+        state { uiPrompt = prompt }
+    UiSetAwaitingInput awaiting ->
+        (if awaiting then finalizeStreams state else state)
+            { uiAwaitingInput = awaiting
+            , uiRunning = if awaiting then False else state.uiRunning
+            , uiActivity = if awaiting then "Ready" else state.uiActivity
+            }
+    UiSetRepository branch cwd ->
+        state { uiBranch = branch, uiCwd = cwd }
+    UiSetNotice notice ->
+        state { uiNotice = notice }
+    UiMoveSelection delta ->
+        moveSelection delta state
+    UiToggleSelected ->
+        toggleSelected state
+    UiFocusChanged focus ->
+        state { uiFocus = focus }
+    UiPermissionShown summary ->
+        state
+            { uiPermission = Just PermissionOverlay
+                { permissionSummary = summary
+                , permissionIndex = 0
+                }
+            , uiFocus = FocusPermission
+            }
+    UiPermissionMoved delta ->
+        state
+            { uiPermission =
+                (\permission ->
+                    permission
+                        { permissionIndex =
+                            (permission.permissionIndex + delta) `mod` 3
+                        })
+                    <$> state.uiPermission
+            }
+    UiPermissionHidden ->
+        state { uiPermission = Nothing, uiFocus = FocusComposer }
+    UiHistory history
+        | Text.null (Text.strip history) -> state
+        | otherwise ->
+            appendBlock BlockSystem "Previous conversation" history ""
+                BlockComplete Nothing state
+    UiAssistantHistory message
+        | Text.null (Text.strip message) -> state
+        | otherwise ->
+            appendBlock BlockAssistant "Assistant" message ""
+                BlockComplete Nothing state
+    UiSystemMessage message ->
+        appendBlock BlockSystem "System" message "" BlockComplete Nothing state
+    UiErrorMessage message ->
+        appendBlock BlockError "Error" message "" BlockFailed Nothing state
+    UiConversationCleared ->
+        state
+            { uiBlocks = Seq.empty
+            , uiSelectedBlock = Nothing
+            , uiNextBlockId = 1
+            , uiTurnStartBlock = 0
+            }
+    UiSetFollow follow ->
+        state { uiFollow = follow }
+    UiTurnEnded terminalState ->
+        finalizeTurn terminalState state
+    UiTick ->
+        state { uiFrame = (state.uiFrame + 1) `mod` 10 }
+
+reduceLoop :: LoopEvent -> UiState -> UiState
+reduceLoop event state = case event of
+    TurnStarted ->
+        state
+            { uiRunning = True
+            , uiAwaitingInput = False
+            , uiActivity = "Thinking…"
+            , uiNotice = Nothing
+            , uiTurnStartBlock = Seq.length state.uiBlocks
+            }
+    ReasoningDelta delta ->
+        appendOrExtend BlockThinking "Thought" delta BlockStreaming state
+            { uiActivity = "Thinking…" }
+    TextDelta delta ->
+        appendOrExtend BlockAssistant "Assistant" delta BlockStreaming state
+            { uiActivity = "Writing…" }
+    ActivityUpdated activity ->
+        state { uiActivity = activity }
+    ToolStarted call ->
+        let kind = toolBlockKind call.name
+        in appendBlock kind (summarizeToolCall call) "" ""
+            BlockRunning (Just call.callId)
+            state { uiActivity = summarizeToolCall call }
+    ToolFinished result ->
+        completeTool result state
+            { uiActivity = "Thinking…" }
+    TurnFinished output ->
+        let finalized = finalizeStreams state
+            withFallback = case output.assistantText of
+                Just text
+                    | not (Text.null (Text.strip text))
+                    , not
+                        (hasAssistantTextSince
+                            finalized.uiTurnStartBlock
+                            finalized) ->
+                        appendBlock BlockAssistant "Assistant" text ""
+                            BlockComplete Nothing finalized
+                _ -> finalized
+        in withFallback
+            { uiRunning = False
+            , uiActivity = "Ready"
+            }
+
+appendOrExtend
+    :: BlockKind
+    -> Text
+    -> Text
+    -> BlockState
+    -> UiState
+    -> UiState
+appendOrExtend kind title delta streamState state =
+    case Seq.viewr state.uiBlocks of
+        rest Seq.:> block
+            | block.blockKind == kind
+            , block.blockState == BlockStreaming ->
+                state
+                    { uiBlocks =
+                        rest Seq.|> block
+                            { blockBody = block.blockBody <> delta }
+                    }
+        _ ->
+            appendBlock kind title delta "" streamState Nothing state
+
+appendBlock
+    :: BlockKind
+    -> Text
+    -> Text
+    -> Text
+    -> BlockState
+    -> Maybe Text
+    -> UiState
+    -> UiState
+appendBlock kind title body detail blockState callId state =
+    let ident = BlockId state.uiNextBlockId
+        block = UiBlock
+            { blockId = ident
+            , blockKind = kind
+            , blockTitle = title
+            , blockBody = body
+            , blockDetail = detail
+            , blockState
+            , blockExpanded =
+                kind `elem` [BlockUser, BlockAssistant, BlockSystem, BlockError]
+            , blockCallId = callId
+            }
+    in state
+        { uiBlocks = state.uiBlocks Seq.|> block
+        , uiNextBlockId = state.uiNextBlockId + 1
+        , uiSelectedBlock = Just ident
+        }
+
+completeTool :: ToolCallResult -> UiState -> UiState
+completeTool result state =
+    state
+        { uiBlocks =
+            fmap
+                (\block ->
+                    if block.blockCallId == Just result.callId
+                        then block
+                            { blockBody = result.output
+                            , blockState = toolResultState result.output
+                            }
+                        else block)
+                state.uiBlocks
+        }
+
+finalizeTurn :: BlockState -> UiState -> UiState
+finalizeTurn terminalState state =
+    state
+        { uiBlocks =
+            Seq.mapWithIndex
+                (\index block ->
+                    if index >= state.uiTurnStartBlock
+                        && block.blockState
+                            `elem` [BlockStreaming, BlockRunning]
+                        then block { blockState = terminalState }
+                        else block)
+                state.uiBlocks
+        , uiRunning = False
+        , uiActivity = "Ready"
+        }
+
+finalizeStreams :: UiState -> UiState
+finalizeStreams state =
+    state
+        { uiBlocks =
+            fmap
+                (\block ->
+                    if block.blockState == BlockStreaming
+                        then block { blockState = BlockComplete }
+                        else block)
+                state.uiBlocks
+        }
+
+hasAssistantTextSince :: Int -> UiState -> Bool
+hasAssistantTextSince start =
+    any
+        (\block ->
+            block.blockKind == BlockAssistant
+                && not (Text.null (Text.strip block.blockBody)))
+        . toList
+        . Seq.drop start
+        . (.uiBlocks)
+
+moveSelection :: Int -> UiState -> UiState
+moveSelection delta state =
+    case toList state.uiBlocks of
+        [] -> state { uiSelectedBlock = Nothing }
+        blocks ->
+            let current = selectedBlockIndex state
+                next = max 0 (min (length blocks - 1) (current + delta))
+            in state
+                { uiSelectedBlock = Just (blocks !! next).blockId
+                , uiFollow = next == length blocks - 1
+                }
+
+selectedBlockIndex :: UiState -> Int
+selectedBlockIndex state =
+    case state.uiSelectedBlock of
+        Nothing -> max 0 (Seq.length state.uiBlocks - 1)
+        Just ident ->
+            case Seq.findIndexL ((== ident) . (.blockId)) state.uiBlocks of
+                Nothing -> max 0 (Seq.length state.uiBlocks - 1)
+                Just index -> index
+
+-- | Delete whitespace and the previous non-whitespace word before the cursor.
+deleteWordBefore :: Text -> Int -> (Text, Int)
+deleteWordBefore text cursor =
+    let cursor' = max 0 (min (Text.length text) cursor)
+        before = Text.take cursor' text
+        after = Text.drop cursor' text
+        reversed = Text.reverse before
+        withoutSpace = Text.dropWhile isSpace reversed
+        remaining = Text.dropWhile (not . isSpace) withoutSpace
+        kept = Text.reverse remaining
+        after'
+            | Text.isSuffixOf " " kept
+            , Text.isPrefixOf " " after =
+                Text.drop 1 after
+            | otherwise = after
+    in (kept <> after', Text.length kept)
+
+-- | Delete from the cursor to the beginning of its logical line.
+deleteToLineStart :: Text -> Int -> (Text, Int)
+deleteToLineStart text cursor =
+    let cursor' = max 0 (min (Text.length text) cursor)
+        before = Text.take cursor' text
+        after = Text.drop cursor' text
+        kept = case Text.breakOnEnd "\n" before of
+            ("", _) -> ""
+            (prefix, _) -> prefix
+    in (kept <> after, Text.length kept)
+
+-- | Delete from the cursor to the end of its logical line.
+deleteToLineEnd :: Text -> Int -> (Text, Int)
+deleteToLineEnd text cursor =
+    let cursor' = max 0 (min (Text.length text) cursor)
+        before = Text.take cursor' text
+        after = Text.drop cursor' text
+        keptAfter = case Text.break (== '\n') after of
+            (_, rest) -> rest
+    in (before <> keptAfter, cursor')
+
+lineStartCursor :: Text -> Int -> Int
+lineStartCursor text cursor =
+    let cursor' = max 0 (min (Text.length text) cursor)
+        before = Text.take cursor' text
+    in Text.length (fst (Text.breakOnEnd "\n" before))
+
+lineEndCursor :: Text -> Int -> Int
+lineEndCursor text cursor =
+    let cursor' = max 0 (min (Text.length text) cursor)
+        after = Text.drop cursor' text
+        (line, _) = Text.break (== '\n') after
+    in cursor' + Text.length line
+
+moveWordLeft :: Text -> Int -> Int
+moveWordLeft text cursor =
+    let cursor' = max 0 (min (Text.length text) cursor)
+        reversed = Text.reverse (Text.take cursor' text)
+        withoutSpace = Text.dropWhile isSpace reversed
+        remaining = Text.dropWhile (not . isSpace) withoutSpace
+    in Text.length remaining
+
+moveWordRight :: Text -> Int -> Int
+moveWordRight text cursor =
+    let cursor' = max 0 (min (Text.length text) cursor)
+        after = Text.drop cursor' text
+        withoutWord = Text.dropWhile (not . isSpace) after
+        remaining = Text.dropWhile isSpace withoutWord
+    in Text.length text - Text.length remaining
+
+toggleSelected :: UiState -> UiState
+toggleSelected state =
+    case state.uiSelectedBlock of
+        Nothing -> state
+        Just ident ->
+            state
+                { uiBlocks =
+                    fmap
+                        (\block ->
+                            if block.blockId == ident
+                                then block
+                                    { blockExpanded = not block.blockExpanded }
+                                else block)
+                        state.uiBlocks
+                }
+
+toolBlockKind :: Text -> BlockKind
+toolBlockKind name
+    | name `elem` ["run_terminal_cmd", "shell_command", "run_ghci"] =
+        BlockShell
+    | name `elem` ["search_replace", "apply_patch"] =
+        BlockEdit
+    | otherwise = BlockTool
+
+outputLooksFailed :: Text -> Bool
+outputLooksFailed output =
+    let lowered = Text.toLower (Text.strip output)
+    in "error:" `Text.isPrefixOf` lowered
+        || "exit: 1" `Text.isPrefixOf` lowered
+        || "exit: 2" `Text.isPrefixOf` lowered
+
+toolResultState :: Text -> BlockState
+toolResultState output
+    | "tool call rejected by user" `Text.isInfixOf` lowered =
+        BlockDenied
+    | "cancel" `Text.isInfixOf` lowered
+        && ("tool" `Text.isInfixOf` lowered
+            || "exit:" `Text.isPrefixOf` lowered) =
+        BlockCancelled
+    | outputLooksFailed output = BlockFailed
+    | Just code <- exitCodeFrom lowered
+    , code /= 0 = BlockFailed
+    | otherwise = BlockComplete
+  where
+    lowered = Text.toLower (Text.strip output)
+
+exitCodeFrom :: Text -> Maybe Int
+exitCodeFrom text = do
+    rest <- Text.stripPrefix "exit:" text
+    case reads (Text.unpack (Text.takeWhile (not . isSpace) (Text.strip rest))) of
+        [(code, "")] -> Just code
+        _ -> Nothing

--- a/packages/agent-cli/src/Agent/CLI/UI/Model.hs
+++ b/packages/agent-cli/src/Agent/CLI/UI/Model.hs
@@ -515,9 +515,7 @@ toolResultState :: Text -> BlockState
 toolResultState output
     | "tool call rejected by user" `Text.isInfixOf` lowered =
         BlockDenied
-    | "cancel" `Text.isInfixOf` lowered
-        && ("tool" `Text.isInfixOf` lowered
-            || "exit:" `Text.isPrefixOf` lowered) =
+    | structuredCancellation lowered =
         BlockCancelled
     | outputLooksFailed output = BlockFailed
     | Just code <- exitCodeFrom lowered
@@ -525,6 +523,17 @@ toolResultState output
     | otherwise = BlockComplete
   where
     lowered = Text.toLower (Text.strip output)
+
+structuredCancellation :: Text -> Bool
+structuredCancellation output =
+    let header = Text.strip (headLine output)
+    in header == "exit: cancelled"
+        || header == "error: command cancelled"
+        || header == "cancelled"
+        || "cancelled (" `Text.isPrefixOf` header
+
+headLine :: Text -> Text
+headLine = Text.takeWhile (/= '\n')
 
 exitCodeFrom :: Text -> Maybe Int
 exitCodeFrom text = do

--- a/packages/agent-cli/test/Agent/CLI/OptionsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/OptionsSpec.hs
@@ -106,6 +106,14 @@ spec = do
                     , optAgentsMd = True
                     })
 
+        it "parses fullscreen and minimal rendering modes" do
+            parseArgs ["--fullscreen"]
+                `shouldBe` Right (RunAgent defaultCliOptions
+                    { optScreenMode = ScreenFullscreen })
+            parseArgs ["--fullscreen", "--minimal"]
+                `shouldBe` Right (RunAgent defaultCliOptions
+                    { optScreenMode = ScreenMinimal })
+
     describe "resolveApprovalPolicy" do
         it "auto-approves one-shot scripts without a TTY" do
             resolveApprovalPolicy defaultCliOptions { optPrompt = Just "hi" } False False

--- a/packages/agent-cli/test/Agent/CLI/UIModelSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/UIModelSpec.hs
@@ -11,6 +11,7 @@ import Agent.ToolDispatch
     , functionToolCall
     )
 import qualified Data.Foldable as Foldable
+import Data.Text (Text)
 import Test.Hspec
 
 spec :: Spec
@@ -52,6 +53,16 @@ spec = describe "fullscreen UI reducer" do
                 block.blockBody `shouldBe` "exit: 0\nclean"
             _ -> expectationFailure "expected one completed tool block"
 
+    it "only marks structured cancellation results as cancelled" do
+        toolStateFor "exit: cancelled\npartial output"
+            `shouldBe` BlockCancelled
+        toolStateFor "Error: Command cancelled"
+            `shouldBe` BlockCancelled
+        toolStateFor "exit: 0\ncancellation complete"
+            `shouldBe` BlockComplete
+        toolStateFor "exit: 0\ncancelled work item"
+            `shouldBe` BlockComplete
+
     it "moves selection and toggles folding" do
         let initial =
                 apply
@@ -82,3 +93,26 @@ spec = describe "fullscreen UI reducer" do
 
 apply :: [UiEvent] -> UiState
 apply events = foldl (flip reduceUi) initialUiState events
+
+toolStateFor :: Text -> BlockState
+toolStateFor output =
+    let call =
+            functionToolCall
+                "cancel-test"
+                "run_terminal_cmd"
+                "{\"command\":\"echo test\"}"
+        result = ToolCallResult
+            { callId = "cancel-test"
+            , output
+            , callKind = FunctionCallKind
+            }
+        blocks = Foldable.toList $
+            (.uiBlocks) $
+                apply
+                    [ UiLoop TurnStarted
+                    , UiLoop (ToolStarted call)
+                    , UiLoop (ToolFinished result)
+                    ]
+    in case blocks of
+        [block] -> block.blockState
+        _ -> BlockFailed

--- a/packages/agent-cli/test/Agent/CLI/UIModelSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/UIModelSpec.hs
@@ -1,0 +1,84 @@
+module Agent.CLI.UIModelSpec (spec) where
+
+import Agent.CLI.UI.Model
+import Agent.Loop
+    ( LoopEvent(..)
+    , emptyTurnOutput
+    )
+import Agent.ToolDispatch
+    ( ToolCallResult(..)
+    , ToolCallKind(..)
+    , functionToolCall
+    )
+import qualified Data.Foldable as Foldable
+import Test.Hspec
+
+spec :: Spec
+spec = describe "fullscreen UI reducer" do
+    it "retains user, reasoning, and assistant blocks across a turn" do
+        let state =
+                apply
+                    [ UiUserSubmitted "hello"
+                    , UiLoop TurnStarted
+                    , UiLoop (ReasoningDelta "checking")
+                    , UiLoop (TextDelta "answer")
+                    , UiLoop (TurnFinished (emptyTurnOutput "r1" [] (Just "answer")))
+                    ]
+            blocks = Foldable.toList state.uiBlocks
+        map (.blockKind) blocks
+            `shouldBe` [BlockUser, BlockThinking, BlockAssistant]
+        map (.blockBody) blocks
+            `shouldBe` ["hello", "checking", "answer"]
+        state.uiRunning `shouldBe` False
+
+    it "matches tool completion by call id" do
+        let call = functionToolCall "c1" "run_terminal_cmd" "{\"command\":\"git status\"}"
+            result = ToolCallResult
+                { callId = "c1"
+                , output = "exit: 0\nclean"
+                , callKind = FunctionCallKind
+                }
+            state =
+                apply
+                    [ UiLoop TurnStarted
+                    , UiLoop (ToolStarted call)
+                    , UiLoop (ToolFinished result)
+                    ]
+            blocks = Foldable.toList state.uiBlocks
+        case blocks of
+            [block] -> do
+                block.blockKind `shouldBe` BlockShell
+                block.blockState `shouldBe` BlockComplete
+                block.blockBody `shouldBe` "exit: 0\nclean"
+            _ -> expectationFailure "expected one completed tool block"
+
+    it "moves selection and toggles folding" do
+        let initial =
+                apply
+                    [ UiUserSubmitted "one"
+                    , UiUserSubmitted "two"
+                    , UiMoveSelection (-1)
+                    ]
+            toggled = reduceUi UiToggleSelected initial
+            blocks = Foldable.toList toggled.uiBlocks
+        selectedBlockIndex initial `shouldBe` 0
+        case blocks of
+            block : _ -> block.blockExpanded `shouldBe` False
+            [] -> expectationFailure "expected selected blocks"
+
+    it "deletes the previous word for command/option-backspace" do
+        deleteWordBefore "hello brave world" 17
+            `shouldBe` ("hello brave ", 12)
+        deleteWordBefore "hello brave   " 14
+            `shouldBe` ("hello ", 6)
+        deleteWordBefore "one two three" 7
+            `shouldBe` ("one three", 4)
+
+    it "deletes to the start of the current line for ctrl-u" do
+        deleteToLineStart "first\nsecond line" 12
+            `shouldBe` ("first\n line", 6)
+        deleteToLineStart "single line" 6
+            `shouldBe` (" line", 0)
+
+apply :: [UiEvent] -> UiState
+apply events = foldl (flip reduceUi) initialUiState events

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -41,6 +41,7 @@ import qualified Agent.CLI.StyleSpec as StyleSpec
 import qualified Agent.CLI.TimestampSpec as TimestampSpec
 import qualified Agent.CLI.TerminalSpec as TerminalSpec
 import qualified Agent.CLI.ToolsSpec as ToolsSpec
+import qualified Agent.CLI.UIModelSpec as UIModelSpec
 import qualified Agent.CLI.UsageSpec as UsageSpec
 import qualified Agent.CLI.WorktreeSpec as WorktreeSpec
 
@@ -85,5 +86,6 @@ main = hspec do
     SessionTitleSpec.spec
     SubagentStoreSpec.spec
     ToolsSpec.spec
+    UIModelSpec.spec
     UsageSpec.spec
     WorktreeSpec.spec


### PR DESCRIPTION
## Summary

- add a retained fullscreen terminal interface with a Solarized Dark theme, repository header, scrollable transcript, and multiline composer
- render streaming assistant text, reasoning, tool execution, edits, status updates, permissions, and model selection as structured UI blocks and overlays
- add keyboard navigation, folding, slash completion, clipboard copy, modified-word deletion, resize handling, and reliable terminal restoration
- preserve the existing append-only interface through `--minimal` and keep non-interactive output unchanged
- harden clipboard probing when platform helpers are unavailable

## Testing

- `cabal repl agent-cli:test:agent-cli-test` — 374 examples, 0 failures
- `nix build .#agent-cli` — passed
- tmux smoke checks for fullscreen startup, streaming, permission denial, model selection, slash completion, resizing, modified Backspace, minimal mode, and terminal restoration