### PR TITLE
fix(cli): preserve alpha in pasted image previews

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/ImagePreview.hs
+++ b/packages/agent-cli/src/Agent/CLI/ImagePreview.hs
@@ -83,6 +83,10 @@ detectImagePreviewProtocol handle = do
 -- format code (24/32 are raw RGB/RGBA). We always send 100 and let the
 -- terminal sniff, matching Grok Build's overlay path for PNG screenshots.
 --
+-- Use the combined @a=T@ action rather than uploading with @a=t@ and creating
+-- a separate @a=p@ placement. Besides saving a round trip, this keeps PNG
+-- alpha on the terminal's normal transmit-and-display path (notably Ghostty).
+--
 -- Only @r@ is specified for the placement. Per the Kitty graphics protocol,
 -- omitting @c@ makes the terminal derive the width from the source image and
 -- cell dimensions, preserving the original aspect ratio. Supplying both
@@ -96,6 +100,7 @@ kittyImageSequence imageId _columns rows mime bytes =
         total = length chunks
         transmit n chunk =
             let more = if n + 1 < total then 1 else 0 :: Int
+                action = if n == 0 then "T" else "t"
                 extras
                     | n == 0 =
                         ",f="
@@ -104,7 +109,9 @@ kittyImageSequence imageId _columns rows mime bytes =
                             <> Text.pack (show rows)
                             <> ",C=1"
                     | otherwise = ""
-            in "\ESC_Ga=t,q=2,i="
+            in "\ESC_Ga="
+                <> action
+                <> ",q=2,i="
                 <> Text.pack (show imageId)
                 <> extras
                 <> ",m="
@@ -112,13 +119,7 @@ kittyImageSequence imageId _columns rows mime bytes =
                 <> ";"
                 <> TextEncoding.decodeLatin1 chunk
                 <> "\ESC\\"
-        display =
-            "\ESC_Ga=p,i="
-                <> Text.pack (show imageId)
-                <> ",r="
-                <> Text.pack (show rows)
-                <> ",C=1,q=2\ESC\\"
-    in Text.concat (zipWith transmit [0 ..] chunks) <> display
+    in Text.concat (zipWith transmit [0 ..] chunks)
 
 kittyFormat :: Text -> Int
 kittyFormat _ = 100

--- a/packages/agent-cli/test/Agent/CLI/ImagePreviewSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ImagePreviewSpec.hs
@@ -35,10 +35,10 @@ spec = do
             previewColumnsFor 30 `shouldBe` 12
 
     describe "kittyImageSequence" do
-        it "specifies only rows so Kitty preserves the source aspect ratio" do
+        it "transmits and displays in one action while preserving source aspect ratio" do
             let seq_ = kittyImageSequence 7 20 6 "image/png" "png-bytes"
-            seq_ `shouldSatisfy` Text.isInfixOf "\ESC_Ga=t,q=2,i=7,f=100,t=d,r=6,C=1,m=0;"
-            seq_ `shouldSatisfy` Text.isInfixOf "\ESC_Ga=p,i=7,r=6,C=1,q=2\ESC\\"
+            seq_ `shouldSatisfy` Text.isInfixOf "\ESC_Ga=T,q=2,i=7,f=100,t=d,r=6,C=1,m=0;"
+            seq_ `shouldSatisfy` (not . Text.isInfixOf "\ESC_Ga=p")
             seq_ `shouldSatisfy` (not . Text.isInfixOf ",c=")
             -- payload is base64 of the raw bytes
             seq_ `shouldSatisfy` Text.isInfixOf "cG5nLWJ5dGVz"
@@ -52,6 +52,8 @@ spec = do
                 seq_ = kittyImageSequence 2 10 4 "image/png" bytes
             Text.count ",m=1;" seq_ `shouldBe` 1
             seq_ `shouldSatisfy` Text.isInfixOf ",m=0;"
+            Text.count "\ESC_Ga=T" seq_ `shouldBe` 1
+            Text.count "\ESC_Ga=t" seq_ `shouldBe` 1
 
     describe "itermImageSequence" do
         it "emits OSC 1337 inline file with cell size" do
@@ -75,7 +77,7 @@ spec = do
             case renderImagePreview PreviewKitty False muted 20 6 3 [img] of
                 Nothing -> expectationFailure "expected a preview block"
                 Just block -> do
-                    block `shouldSatisfy` Text.isInfixOf "\ESC_Ga=t,q=2,i=3"
+                    block `shouldSatisfy` Text.isInfixOf "\ESC_Ga=T,q=2,i=3"
                     block `shouldSatisfy` Text.isInfixOf "image/png (9 B)"
                     -- six blank lines (rows=6) sit between the bitmap and the caption
                     block `shouldSatisfy` Text.isInfixOf (Text.replicate 6 "\n")
@@ -85,7 +87,7 @@ spec = do
                 Nothing -> expectationFailure "expected a preview block"
                 Just block -> do
                     block `shouldSatisfy` Text.isPrefixOf "\ESCPtmux;"
-                    block `shouldSatisfy` Text.isInfixOf "\ESC\ESC_Ga=t"
+                    block `shouldSatisfy` Text.isInfixOf "\ESC\ESC_Ga=T"
 
         it "falls back to a caption without graphics" do
             case renderImagePreview PreviewUnsupported False muted 20 6 1 [img] of


### PR DESCRIPTION
## Summary

- use Kitty's combined `a=T` transmit-and-display action for pasted image previews
- avoid the separate `a=p` placement path that can composite transparent PNG pixels incorrectly in Ghostty
- retain `a=t` for continuation chunks and cover the sequence with regression tests

## Testing

- `nix develop -c env GHCRTS= cabal test agent-cli-test`
- focused image preview tests after rebasing onto current `master`
- live tmux smoke test with a known transparent RGBA PNG pasted via Ctrl+V
