### PR TITLE
Refactor CLI subagent runtime out of Agent.CLI

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -63,6 +63,7 @@ library
                     , Agent.CLI.Progress
                     , Agent.CLI.Project
                     , Agent.CLI.Prompt
+                    , Agent.CLI.Request
                     , Agent.CLI.ProviderFallback
                     , Agent.CLI.ProviderTransition
                     , Agent.CLI.Render
@@ -73,6 +74,7 @@ library
                     , Agent.CLI.SessionTitle
                     , Agent.CLI.Status
                     , Agent.CLI.SubagentStore
+                    , Agent.CLI.Subagents.Runtime
                     , Agent.CLI.Style
                     , Agent.CLI.Terminal
                     , Agent.CLI.Timestamp
@@ -146,6 +148,7 @@ test-suite agent-cli-test
                     , Agent.CLI.PromptSpec
                     , Agent.CLI.ProviderFallbackSpec
                     , Agent.CLI.ProviderTransitionSpec
+                    , Agent.CLI.RequestSpec
                     , Agent.CLI.RenderSpec
                     , Agent.CLI.ReplStatusSpec
                     , Agent.CLI.ResumeSpec

--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -40,14 +40,12 @@ import Agent.CLI.AgentSessions
     )
 import Agent.CLI.Approval
     ( approveToolDecision
-    , childApprove
     , toggleAlwaysApprove
     )
 import Agent.CLI.Btw
     ( BtwBackendFactory
     , formatBtwError
     , runBtwWithCancel
-    , trimDanglingToolSuffix
     )
 import Agent.CLI.CancelWatch (withEscCancel, withStdinPaused)
 import Agent.CLI.Clipboard
@@ -101,6 +99,7 @@ import Agent.CLI.Project
     , resolveProjectRoot
     )
 import Agent.CLI.Prompt (defaultModelFor, systemPrompt)
+import Agent.CLI.Request (requestParams)
 import Agent.CLI.ProviderFallback
     ( automaticCooldownRetryDelay
     , fallbackCandidates
@@ -128,11 +127,17 @@ import Agent.CLI.Status
     , formatReplStatusLine
     , formatTokenUsage
     )
-import Agent.CLI.SubagentStore
-    ( SubagentDiskMeta(..)
-    , forkSubagentTranscript
-    , loadSubagentState
-    , saveSubagentState
+import Agent.CLI.Subagents.Runtime
+    ( SubagentRuntime(..)
+    , SubagentSession(..)
+    , SubagentStoreRoot
+    , flushAllSubagentSnapshots
+    , freshOpenAiBackend
+    , persistSubagentSnapshotWithStatus
+    , prepareCollaborationSpawn
+    , restoreAgentFromDisk
+    , runCodexSubagent
+    , runHttpSubagent
     )
 import Agent.CLI.Style
     ( beginBackground
@@ -161,7 +166,7 @@ import Agent.CLI.Terminal
     , resolveColor
     , withSynchronizedOutput
     )
-import Agent.CLI.Tools (schemasFromAppTools)
+import Agent.CLI.Tools (requireToolRegistry, schemasFromAppTools)
 import Agent.CLI.Turn (applyPendingSessionTitles, runOneTurn)
 import Agent.CLI.Usage
     ( AccountUsageLine(..)
@@ -177,7 +182,6 @@ import Agent.CLI.Worktree
 import Agent.Cancel (resetCancel, waitCancel)
 import Agent.Loop
 import Agent.Error (ApiError(..))
-import Agent.InterAgentMessage (InterAgentMessage, interAgentMessagePayload)
 import Agent.ProjectInstructions
     ( DiscoverOptions(..)
     , defaultDiscoverOptions
@@ -193,13 +197,12 @@ import Agent.OpenAI.Compaction
     , newSessionUserText
     )
 import qualified Agent.OpenAI.Auth as OpenAI
-import Agent.OpenAI.LoopBackend (openAiBackend, openAiBackendReconnecting)
+import Agent.OpenAI.LoopBackend (openAiBackendReconnecting)
 import Agent.Responses.Types
 import Agent.OpenAI.Usage (fetchUsage)
 import Agent.OpenAI.WebSocketClient
     ( CodexAuthFailed(..)
     , CodexConn
-    , withCodexWsRetrying
     , withCodexWsWithProvider
     )
 import Agent.Provider
@@ -212,69 +215,37 @@ import Agent.Provider
     , providerSlug
     )
 import Agent.Subagents
-    ( RunSubagent
-    , RootTurnId
+    ( RootTurnId
     , SubagentId(..)
-    , SubagentRegistry
-    , SubagentSpawnEnv(..)
-    , SubagentStatus(..)
     , abortRootTurn
     , beginRootTurn
     , closeSubagentRegistry
     , resetSubagentRegistry
     , defaultSubagentConfig
     , formatCompletionNotice
-    , getPreviousResponseId
-    , getStatus
-    , getSubagentCwd
-    , getSubagentIdentity
-    , getTaskPath
     , interruptActiveSubagents
     , listAgents
     , newSubagentRegistry
-    , restoreSubagent
-    , restoreSubagentAtStatus
-    , restoreSubagentAtWithCwdStatus
-    , restoreSubagentWithCwd
-    , setPreviousResponseId
     , setSubagentOnComplete
     , setSubagentRunner
     )
-import Agent.Tools
-    ( CodingTools(..)
-    , codingToolsFor
-    , codingToolsForWithTypes
-    , filterChildGrokTools
-    )
-import Agent.Tools.Grok.Task
-    ( GrokSubagentSpec(..)
-    , GrokSubagentSpecs
-    , defaultSubagentType
-    , lookupAgentModel
-    , lookupAgentReasoningEffort
-    , lookupAgentType
-    , recordAgentSpec
-    )
-import Agent.Subagents.TaskPath (parseTaskPath, taskPathRoot, taskPathText)
+import Agent.Tools (CodingTools(..), codingToolsForWithTypes)
+import Agent.Subagents.TaskPath (taskPathRoot, taskPathText)
 import Agent.Tools.MultiAgents
-    ( CollaborationSpawnOptions(..)
-    , MultiAgentContext(..)
+    ( MultiAgentContext(..)
     , SubagentWorktree(..)
     )
 import Agent.Tools.PlanMode
     ( PlanModeEnv(..)
-    , PlanModeHooks
     , PlanModeState(..)
     , activatePlanMode
     , deactivatePlanMode
     , planFilePath
     )
 import Agent.Tools.Types
-    ( AppTool(..)
+    ( AppTool
     , ToolEnv(..)
-    , ToolRegistry
     , defaultToolEnv
-    , mkToolRegistry
     )
 import Agent.OpenRouter.LoopBackend (openRouterBackend)
 import qualified Agent.OpenRouter.Options as OpenRouter
@@ -292,7 +263,6 @@ import Control.Exception.Safe
     , try
     )
 import Control.Monad (when)
-import qualified Data.Aeson.KeyMap as KeyMap
 import qualified Data.ByteString as BS
 import Data.IORef
 import Data.Map.Strict (Map)
@@ -686,6 +656,16 @@ runAgent options transition = do
                 Just _ -> Nothing
                 Nothing -> resumed >>= \(meta, _) -> meta.metaLastResponseId
         paramsRef <- newIORef params
+        let subagentRuntime = SubagentRuntime
+                { subagentOptions = options
+                , subagentPolicy = policy
+                , subagentPlanHooks = planHooks
+                , subagentParams = paramsRef
+                , subagentRegistry = registry
+                , subagentSessions = subagentSessions
+                , subagentStoreRoot = subagentStoreRoot
+                , subagentTypes = agentTypesRef
+                }
         transcriptRef <- newIORef initialItems
         writeIORef subagentForkSource (Just transcriptRef)
         prompt <- loadPrompt options
@@ -722,15 +702,8 @@ runAgent options transition = do
                                     Just ctx ->
                                         setSubagentRunner ctx.multiRegistry $
                                             runCodexSubagent
-                                                options
-                                                policy
-                                                planHooks
-                                                paramsRef
+                                                subagentRuntime
                                                 loaded.loadedTokenProvider
-                                                ctx.multiRegistry
-                                                subagentSessions
-                                                subagentStoreRoot
-                                                agentTypesRef
                                                 ctx.multiSendToRoot
                                     Nothing -> pure ()
                                 let lockedBackend =
@@ -767,18 +740,11 @@ runAgent options transition = do
                             Just ctx ->
                                 setSubagentRunner ctx.multiRegistry $
                                     runHttpSubagent
-                                        options
-                                        policy
-                                        planHooks
-                                        paramsRef
+                                        subagentRuntime
                                         XAIProvider
                                         (\childParamsRef childTranscript ->
                                             xaiBackend xaiOptions loaded.loadedTokenProvider
                                                 (readIORef childParamsRef) childTranscript)
-                                        ctx.multiRegistry
-                                        subagentSessions
-                                        agentTypesRef
-                                        subagentStoreRoot
                             Nothing -> pure ()
                         let backend =
                                 withPendingInputs pendingNotices $
@@ -798,18 +764,11 @@ runAgent options transition = do
                             Just ctx ->
                                 setSubagentRunner ctx.multiRegistry $
                                     runHttpSubagent
-                                        options
-                                        policy
-                                        planHooks
-                                        paramsRef
+                                        subagentRuntime
                                         OpenRouterProvider
                                         (\childParamsRef childTranscript ->
                                             openRouterBackend openRouterOptions loaded.loadedTokenProvider
                                                 (readIORef childParamsRef) childTranscript)
-                                        ctx.multiRegistry
-                                        subagentSessions
-                                        agentTypesRef
-                                        subagentStoreRoot
                             Nothing -> pure ()
                         let backend =
                                 withPendingInputs pendingNotices $
@@ -913,10 +872,6 @@ printResumeHint progName = \case
 
 shouldPersist :: CliOptions -> Bool
 shouldPersist options = not (isOneShot options) || options.optSaveSession
-
-requireToolRegistry :: [AppTool] -> IO ToolRegistry
-requireToolRegistry tools =
-    either (ioError . userError . Text.unpack) pure (mkToolRegistry tools)
 
 isJustCwd :: CliOptions -> Bool
 isJustCwd options = case options.optCwd of
@@ -2436,183 +2391,6 @@ currentSessionId = \case
             PersistencePending _ -> Nothing
             PersistenceActive handle -> Just handle.sessionMeta.metaId
 
-data SubagentSession = SubagentSession
-    { subSessionTranscript :: !(IORef [ResponseItem])
-    }
-
--- | Optional on-disk root for child transcripts (@sessionDir/agents/<id>@).
-type SubagentStoreRoot = IORef (Maybe OsPath)
-
--- | Prefer an explicit store root; otherwise fall back to planMode's session dir.
-syncStoreRootFromPlan :: SubagentStoreRoot -> PlanModeEnv -> IO ()
-syncStoreRootFromPlan storeRootRef planMode = do
-    mroot <- readIORef storeRootRef
-    case mroot of
-        Just _ -> pure ()
-        Nothing -> do
-            sessionDir <- readIORef planMode.planSessionDir
-            case sessionDir of
-                Just dir -> writeIORef storeRootRef (Just dir)
-                Nothing -> pure ()
-
-prepareCollaborationSpawn
-    :: IORef (Map SubagentId SubagentSession)
-    -> SubagentStoreRoot
-    -> GrokSubagentSpecs
-    -> IORef (Maybe (IORef [ResponseItem]))
-    -> SubagentId
-    -> CollaborationSpawnOptions
-    -> IO ()
-prepareCollaborationSpawn
-        sessionsRef storeRootRef typesRef sourceRef agentId spawnOptions = do
-    recordAgentSpec typesRef agentId GrokSubagentSpec
-        { agentType = defaultSubagentType
-        , modelOverride = spawnOptions.collaborationModel
-        , reasoningEffortOverride =
-            spawnOptions.collaborationReasoningEffort
-        }
-    session <-
-        lookupOrCreateSubagentSession
-            sessionsRef storeRootRef typesRef agentId
-    source <- readIORef sourceRef
-    sourceItems <- maybe (pure []) readIORef source
-    writeIORef session.subSessionTranscript
-        (forkSubagentTranscript spawnOptions.collaborationForkTurns sourceItems)
-
-persistSubagentSnapshot
-    :: SubagentStoreRoot
-    -> SubagentRegistry
-    -> GrokSubagentSpecs
-    -> SubagentId
-    -> IORef [ResponseItem]
-    -> IO ()
-persistSubagentSnapshot storeRootRef registry typesRef agentId transcriptRef = do
-    status <- getStatus registry agentId
-    persistSubagentSnapshotWithStatus
-        storeRootRef registry typesRef agentId status transcriptRef
-
-persistSubagentSnapshotWithStatus
-    :: SubagentStoreRoot
-    -> SubagentRegistry
-    -> GrokSubagentSpecs
-    -> SubagentId
-    -> SubagentStatus
-    -> IORef [ResponseItem]
-    -> IO ()
-persistSubagentSnapshotWithStatus
-        storeRootRef registry typesRef agentId status transcriptRef = do
-    mroot <- readIORef storeRootRef
-    case mroot of
-        Nothing -> pure ()
-        Just sessionDir -> do
-            items <- trimDanglingToolSuffix <$> readIORef transcriptRef
-            previous <- getPreviousResponseId registry agentId
-            agentType <- lookupAgentType typesRef agentId
-            agentModel <- lookupAgentModel typesRef agentId
-            reasoningEffort <- lookupAgentReasoningEffort typesRef agentId
-            agentCwd <- getSubagentCwd registry agentId
-            identity <- getSubagentIdentity registry agentId
-            _ <- saveSubagentState
-                sessionDir agentId items previous status agentType agentModel
-                reasoningEffort agentCwd identity
-            pure ()
-
-flushAllSubagentSnapshots
-    :: SubagentStoreRoot
-    -> SubagentRegistry
-    -> IORef (Map SubagentId SubagentSession)
-    -> GrokSubagentSpecs
-    -> IO ()
-flushAllSubagentSnapshots storeRootRef registry sessionsRef typesRef = do
-    sessions <- readIORef sessionsRef
-    mapM_
-        (\(agentId, session) ->
-            persistSubagentSnapshot storeRootRef registry typesRef agentId
-                session.subSessionTranscript)
-        (Map.toList sessions)
-
--- | Rehydrate a closed/missing agent from @sessionDir/agents/<id>@ so
--- 'resume_agent' / 'resume_from' can continue the prior transcript.
-restoreAgentFromDisk
-    :: SubagentStoreRoot
-    -> SubagentRegistry
-    -> IORef (Map SubagentId SubagentSession)
-    -> GrokSubagentSpecs
-    -> SubagentId
-    -> IO (Either Text ())
-restoreAgentFromDisk storeRootRef registry sessionsRef typesRef agentId = do
-    status <- getStatus registry agentId
-    case status of
-        NotFound -> restore
-        Closed -> restore
-        _ -> pure (Right ())
-  where
-    restore = do
-        mroot <- readIORef storeRootRef
-        case mroot of
-            Nothing ->
-                pure (Left "no session directory; cannot restore subagent from disk")
-            Just sessionDir ->
-                loadSubagentState sessionDir agentId >>= \case
-                    Left err -> pure (Left err)
-                    Right Nothing ->
-                        -- Same-process close with no disk yet: still reopen.
-                        reopenInMemory Nothing Nothing
-                    Right (Just (items, meta)) -> do
-                        result <- reopenPersisted meta
-                        case result of
-                            Left err -> pure (Left err)
-                            Right () -> do
-                                case meta.diskAgentType of
-                                    Just agentType ->
-                                        recordAgentSpec typesRef agentId GrokSubagentSpec
-                                            { agentType
-                                            , modelOverride = meta.diskAgentModel
-                                            , reasoningEffortOverride =
-                                                meta.diskReasoningEffort
-                                            }
-                                    Nothing -> pure ()
-                                transcript <- newIORef items
-                                let session =
-                                        SubagentSession
-                                            { subSessionTranscript = transcript
-                                            }
-                                atomicModifyIORef' sessionsRef \m ->
-                                    (Map.insert agentId session m, ())
-                                pure (Right ())
-    reopenPersisted meta =
-        case meta.diskTaskPath of
-            Nothing -> restoreAt taskPathRoot
-            Just pathText ->
-                case parseTaskPath pathText of
-                    Left err -> pure (Left err)
-                    Right taskPath -> restoreAt taskPath
-      where
-        restoredStatus = fromMaybe (Completed Nothing) meta.diskStatus
-        restoreAt taskPath = do
-            let restore =
-                    case meta.diskCwd of
-                        Just childCwd ->
-                            restoreSubagentAtWithCwdStatus
-                                registry childCwd
-                        Nothing ->
-                            restoreSubagentAtStatus registry
-            restore
-                agentId meta.diskParentId taskPath
-                (fromMaybe 1 meta.diskDepth)
-                Nothing meta.diskPreviousResponseId restoredStatus
-                >>= pure . fmap (const ())
-    reopenInMemory previous requestedCwd = do
-        restored <- case requestedCwd of
-            Just childCwd ->
-                restoreSubagentWithCwd
-                    registry childCwd agentId Nothing 1 Nothing previous
-            Nothing ->
-                restoreSubagent registry agentId Nothing 1 Nothing previous
-        pure $ case restored of
-            Left err -> Left err
-            Right _ -> Right ()
-
 -- | Serialize OpenAI WebSocket turns: parent and children share one connection,
 -- and 'receiveWsResponse' is not multiplexed.
 lockedOpenAiBackend
@@ -2628,246 +2406,6 @@ lockedOpenAiBackend wsLock provider connectionHealthy conn getParams transcript 
             openAiBackendReconnecting provider connectionHealthy conn getParams transcript
     in Backend \previous inputs onEvent ->
         withMVar wsLock \_ -> submit previous inputs onEvent
-
--- | Use a disposable WebSocket for side questions so cancellation cannot
--- leave abandoned response frames queued on the main conversation connection.
-freshOpenAiBackend
-    :: TokenProvider
-    -> IO ResponseCreateParams
-    -> IORef [ResponseItem]
-    -> Backend
-freshOpenAiBackend provider getParams transcript = Backend \previous inputs onEvent ->
-    withCodexWsRetrying provider \conn _credential ->
-        let Backend submit = openAiBackend conn getParams transcript
-        in submit previous inputs onEvent
--- | Child Codex agent: per-agent transcript retained across follow-ups,
--- independently scoped WebSocket requests, and nested multi-agent tools.
-runCodexSubagent
-    :: CliOptions
-    -> ApprovalPolicy
-    -> PlanModeHooks
-    -> IORef ResponseCreateParams
-    -> TokenProvider
-    -> SubagentRegistry
-    -> IORef (Map SubagentId SubagentSession)
-    -> SubagentStoreRoot
-    -> GrokSubagentSpecs
-    -> Maybe (InterAgentMessage -> IO (Either Text Text))
-    -> RunSubagent
-runCodexSubagent options policy planHooks paramsRef tokenProvider registry sessionsRef storeRootRef typesRef sendToRoot =
-    \env previous prompt onEvent -> do
-        parentParams <- readIORef paramsRef
-        childEnv <- defaultToolEnv env.subCwd
-        childPath <- fromMaybe taskPathRoot <$> getTaskPath registry env.subId
-        session <-
-            lookupOrCreateSubagentSession
-                sessionsRef storeRootRef typesRef env.subId
-        nestedForkSource <- newIORef (Just session.subSessionTranscript)
-        childModel <- lookupAgentModel typesRef env.subId
-        childEffort <- lookupAgentReasoningEffort typesRef env.subId
-        -- Inherit soft-cancel from the registry-owned child flag.
-        let childToolEnv = childEnv { toolCancel = env.subCancel }
-            childCtx = MultiAgentContext
-                { multiRegistry = registry
-                , multiSelfId = Just env.subId
-                , multiDepth = env.subDepth
-                , multiTaskPath = childPath
-                , multiRootTurnId = pure env.subRootTurnId
-                , multiResumeFromDisk = Nothing
-                , multiCreateWorktree = Nothing
-                , multiPrepareSpawn = Just
-                    (prepareCollaborationSpawn
-                        sessionsRef storeRootRef typesRef nestedForkSource)
-                , multiSendToRoot = sendToRoot
-                }
-        -- Child tools create their own PlanModeEnv; sync store root from parent
-        -- params is handled by noteSessionDir on the parent path. If the parent
-        -- already has a session dir in storeRootRef, we persist; otherwise skip.
-        coding <- codingToolsFor OpenAIProvider childToolEnv (Just planHooks) (Just childCtx)
-        syncStoreRootFromPlan storeRootRef coding.codingPlanMode
-        flip finally coding.codingClose do
-            today <- utctDay <$> getCurrentTime
-            let model = fromMaybe
-                    (fromMaybe (defaultModelFor OpenAIProvider) parentParams.model)
-                    childModel
-                inheritedEffort = case parentParams.reasoning of
-                    Just cfg -> fromMaybe (defaultEffortFor OpenAIProvider) cfg.effort
-                    Nothing -> defaultEffortFor OpenAIProvider
-                effort = fromMaybe inheritedEffort childEffort
-                baseInstructions =
-                    fromMaybe
-                        (systemPrompt OpenAIProvider env.subCwd today True)
-                        parentParams.instructions
-                instructions =
-                    baseInstructions
-                        <> "\n\nYou are a Codex subagent. Complete the assigned task and "
-                        <> "report results clearly. Your agent id is "
-                        <> env.subId.unSubagentId
-                        <> "."
-                tools = coding.codingAppTools
-                childParams = requestParams model instructions
-                    (schemasFromAppTools OpenAIProvider tools) effort
-            toolRegistry <- requireToolRegistry tools
-            childParamsRef <- newIORef childParams
-            let backend =
-                    freshOpenAiBackend tokenProvider
-                        (readIORef childParamsRef) session.subSessionTranscript
-                config = LoopConfig
-                    { loopBackend = backend
-                    , loopTools = toolRegistry
-                    , loopDispatch = defaultLoopDispatch
-                    , loopMaxTurns = options.optMaxTurns
-                    , loopOnEvent = onEvent
-                    , loopApprove = \call -> childApprove policy toolRegistry call
-                    , loopCancel = env.subCancel
-                    }
-            result <- runLoopInputs config previous [AgentMessage prompt]
-            case result of
-                Right loopResult ->
-                    setPreviousResponseId registry env.subId loopResult.finalResponseId
-                Left _ ->
-                    modifyIORef' session.subSessionTranscript
-                        trimDanglingToolSuffix
-            persistSubagentSnapshot storeRootRef registry typesRef env.subId
-                session.subSessionTranscript
-            pure result
-
--- | Child XAI/OpenRouter agent: HTTP backend, filtered tools by subagent_type.
-runHttpSubagent
-    :: CliOptions
-    -> ApprovalPolicy
-    -> PlanModeHooks
-    -> IORef ResponseCreateParams
-    -> Provider
-    -> (IORef ResponseCreateParams -> IORef [ResponseItem] -> Backend)
-    -> SubagentRegistry
-    -> IORef (Map SubagentId SubagentSession)
-    -> GrokSubagentSpecs
-    -> SubagentStoreRoot
-    -> RunSubagent
-runHttpSubagent options policy planHooks paramsRef provider mkBackend registry sessionsRef typesRef storeRootRef =
-    \env previous prompt onEvent -> do
-        parentParams <- readIORef paramsRef
-        childEnv <- defaultToolEnv env.subCwd
-        childPath <- fromMaybe taskPathRoot <$> getTaskPath registry env.subId
-        session <-
-            lookupOrCreateSubagentSession
-                sessionsRef storeRootRef typesRef env.subId
-        nestedForkSource <- newIORef (Just session.subSessionTranscript)
-        let childToolEnv = childEnv { toolCancel = env.subCancel }
-            childCtx = MultiAgentContext
-                { multiRegistry = registry
-                , multiSelfId = Just env.subId
-                , multiDepth = env.subDepth
-                , multiTaskPath = childPath
-                , multiRootTurnId = pure env.subRootTurnId
-                , multiResumeFromDisk = Nothing
-                , multiCreateWorktree = Nothing
-                , multiPrepareSpawn = Just
-                    (prepareCollaborationSpawn
-                        sessionsRef storeRootRef typesRef nestedForkSource)
-                , multiSendToRoot = Nothing
-                }
-        agentType <- fromMaybe defaultSubagentType <$> lookupAgentType typesRef env.subId
-        childModel <- lookupAgentModel typesRef env.subId
-        childEffort <- lookupAgentReasoningEffort typesRef env.subId
-        coding <- codingToolsFor provider childToolEnv (Just planHooks) (Just childCtx)
-        flip finally coding.codingClose do
-            today <- utctDay <$> getCurrentTime
-            let model = fromMaybe
-                    (fromMaybe (defaultModelFor provider) parentParams.model)
-                    childModel
-                inheritedEffort = case parentParams.reasoning of
-                    Just cfg -> fromMaybe (defaultEffortFor provider) cfg.effort
-                    Nothing -> defaultEffortFor provider
-                effort = fromMaybe inheritedEffort childEffort
-                baseInstructions = systemPrompt provider env.subCwd today True
-                instructions =
-                    baseInstructions
-                        <> "\n\n"
-                        <> grokSubagentSuffix agentType env.subId
-                tools = filterChildGrokTools agentType coding.codingAppTools
-                childParams = requestParams model instructions
-                    (schemasFromAppTools provider tools) effort
-            toolRegistry <- requireToolRegistry tools
-            childParamsRef <- newIORef childParams
-            let backend = mkBackend childParamsRef session.subSessionTranscript
-                config = LoopConfig
-                    { loopBackend = backend
-                    , loopTools = toolRegistry
-                    , loopDispatch = defaultLoopDispatch
-                    , loopMaxTurns = options.optMaxTurns
-                    , loopOnEvent = onEvent
-                    , loopApprove = \call -> childApprove policy toolRegistry call
-                    , loopCancel = env.subCancel
-                    }
-            -- XAI/OpenRouter ignore previous_response_id and replay local
-            -- transcripts; still pass previous for API symmetry.
-            result <- runLoop config previous (interAgentMessagePayload prompt)
-            case result of
-                Right loopResult ->
-                    setPreviousResponseId registry env.subId loopResult.finalResponseId
-                Left _ ->
-                    modifyIORef' session.subSessionTranscript
-                        trimDanglingToolSuffix
-            persistSubagentSnapshot storeRootRef registry typesRef env.subId
-                session.subSessionTranscript
-            pure result
-
-grokSubagentSuffix :: Text -> SubagentId -> Text
-grokSubagentSuffix agentType agentId =
-    "You are a Grok Build subagent — a focused worker delegated a specific task.\n\
-    \Complete the assigned task directly and efficiently. Do not broaden scope beyond what was asked. \
-    \Report blocked or unverified work explicitly.\n\n\
-    \Subagent type: "
-        <> agentType
-        <> "\nAgent id: "
-        <> agentId.unSubagentId
-        <> case agentType of
-            "explore" ->
-                "\n\n=== READ-ONLY MODE ===\n\
-                \You have no file editing or command execution tools. Search broadly, narrow down, \
-                \and return absolute file paths and relevant findings."
-            "plan" ->
-                "\n\n=== READ-ONLY MODE ===\n\
-                \Do not create, modify, or delete implementation files. Explore the codebase, \
-                \consider trade-offs, and produce a concrete implementation strategy. End with \
-                \a Critical Files for Implementation section listing 3-5 files."
-            _ ->
-                "\n\nStart broad and narrow down. Check multiple locations and naming conventions. \
-                \Never create documentation files unless explicitly requested."
-
-lookupOrCreateSubagentSession
-    :: IORef (Map SubagentId SubagentSession)
-    -> SubagentStoreRoot
-    -> GrokSubagentSpecs
-    -> SubagentId
-    -> IO SubagentSession
-lookupOrCreateSubagentSession sessionsRef storeRootRef typesRef agentId = do
-    sessions <- readIORef sessionsRef
-    case Map.lookup agentId sessions of
-        Just session -> pure session
-        Nothing -> do
-            mroot <- readIORef storeRootRef
-            loaded <- case mroot of
-                Just sessionDir -> loadSubagentState sessionDir agentId
-                Nothing -> pure (Right Nothing)
-            let (items, meta) = case loaded of
-                    Right (Just (xs, m)) -> (xs, Just m)
-                    _ -> ([], Nothing)
-            transcript <- newIORef items
-            case meta >>= (.diskAgentType) of
-                Just agentType ->
-                    recordAgentSpec typesRef agentId GrokSubagentSpec
-                        { agentType
-                        , modelOverride = meta >>= (.diskAgentModel)
-                        , reasoningEffortOverride =
-                            meta >>= (.diskReasoningEffort)
-                        }
-                Nothing -> pure ()
-            let session = SubagentSession { subSessionTranscript = transcript }
-            atomicModifyIORef' sessionsRef \m -> (Map.insert agentId session m, ())
-            pure session
 
 -- | Drop live conversation state without touching persisted session files.
 resetLiveConversation
@@ -2893,30 +2431,3 @@ foldSessionItems = go []
             -- rebuilt history. Either way, turnItems replaces prior history.
             go turn.turnItems rest
         | otherwise = go (acc <> turn.turnItems) rest
-
--- | Codex requires @store = false@. Continuation still uses
--- @previous_response_id@, with the local transcript available for recovery.
-requestParams
-    :: Text
-    -> Text
-    -> [ResponseTool]
-    -> Text
-    -> ResponseCreateParams
-requestParams modelName instructionText toolSchemas effort =
-    case defaultResponseCreateParams of
-        ResponseCreateParams{..} ->
-            ResponseCreateParams
-                { model = Just modelName
-                , instructions = Just instructionText
-                , tools = Just toolSchemas
-                , reasoning = Just ReasoningConfig
-                    { context = Nothing
-                    , effort = Just effort
-                    , generateSummary = Nothing
-                    , reasoningMode = Nothing
-                    , summary = Nothing
-                    , extraFields = KeyMap.empty
-                    }
-                , store = Just False
-                , ..
-                }

--- a/packages/agent-cli/src/Agent/CLI/Request.hs
+++ b/packages/agent-cli/src/Agent/CLI/Request.hs
@@ -1,0 +1,35 @@
+-- | Construction of provider-neutral Responses requests.
+module Agent.CLI.Request
+    ( requestParams
+    ) where
+
+import Agent.Responses.Types
+import qualified Data.Aeson.KeyMap as KeyMap
+import Data.Text (Text)
+
+-- | Codex requires @store = false@. Continuation still uses
+-- @previous_response_id@, with the local transcript available for recovery.
+requestParams
+    :: Text
+    -> Text
+    -> [ResponseTool]
+    -> Text
+    -> ResponseCreateParams
+requestParams modelName instructionText toolSchemas effort =
+    case defaultResponseCreateParams of
+        ResponseCreateParams{..} ->
+            ResponseCreateParams
+                { model = Just modelName
+                , instructions = Just instructionText
+                , tools = Just toolSchemas
+                , reasoning = Just ReasoningConfig
+                    { context = Nothing
+                    , effort = Just effort
+                    , generateSummary = Nothing
+                    , reasoningMode = Nothing
+                    , summary = Nothing
+                    , extraFields = KeyMap.empty
+                    }
+                , store = Just False
+                , ..
+                }

--- a/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
@@ -1,0 +1,557 @@
+-- | CLI-owned runtime state and provider adapters for child agents.
+module Agent.CLI.Subagents.Runtime
+    ( SubagentRuntime(..)
+    , SubagentSession(..)
+    , SubagentStoreRoot
+    , flushAllSubagentSnapshots
+    , freshOpenAiBackend
+    , persistSubagentSnapshotWithStatus
+    , prepareCollaborationSpawn
+    , restoreAgentFromDisk
+    , runCodexSubagent
+    , runHttpSubagent
+    ) where
+
+import Agent.CLI.Approval (childApprove)
+import Agent.CLI.Btw (trimDanglingToolSuffix)
+import Agent.CLI.Options
+    ( ApprovalPolicy
+    , CliOptions(..)
+    , defaultEffortFor
+    )
+import Agent.CLI.Prompt (defaultModelFor, systemPrompt)
+import Agent.CLI.Request (requestParams)
+import Agent.CLI.SubagentStore
+    ( SubagentDiskMeta(..)
+    , forkSubagentTranscript
+    , loadSubagentState
+    , saveSubagentState
+    )
+import Agent.CLI.Tools (requireToolRegistry, schemasFromAppTools)
+import Agent.InterAgentMessage
+    ( InterAgentMessage
+    , interAgentMessagePayload
+    )
+import Agent.Loop
+    ( Backend(..)
+    , LoopConfig(..)
+    , LoopResult(..)
+    , TurnInput(..)
+    , defaultLoopDispatch
+    , runLoop
+    , runLoopInputs
+    )
+import Agent.OpenAI.LoopBackend (openAiBackend)
+import Agent.OpenAI.WebSocketClient (withCodexWsRetrying)
+import Agent.OsPath (OsPath)
+import Agent.Provider (Provider(..), TokenProvider)
+import Agent.Responses.Types
+    ( ReasoningConfig(..)
+    , ResponseCreateParams(..)
+    , ResponseItem
+    )
+import Agent.Subagents
+    ( RunSubagent
+    , SubagentId(..)
+    , SubagentRegistry
+    , SubagentSpawnEnv(..)
+    , SubagentStatus(..)
+    , getPreviousResponseId
+    , getStatus
+    , getSubagentCwd
+    , getSubagentIdentity
+    , getTaskPath
+    , restoreSubagent
+    , restoreSubagentAtStatus
+    , restoreSubagentAtWithCwdStatus
+    , restoreSubagentWithCwd
+    , setPreviousResponseId
+    )
+import Agent.Subagents.TaskPath
+    ( parseTaskPath
+    , taskPathRoot
+    )
+import Agent.Tools
+    ( CodingTools(..)
+    , codingToolsFor
+    , filterChildGrokTools
+    )
+import Agent.Tools.Grok.Task
+    ( GrokSubagentSpec(..)
+    , GrokSubagentSpecs
+    , defaultSubagentType
+    , lookupAgentModel
+    , lookupAgentReasoningEffort
+    , lookupAgentType
+    , recordAgentSpec
+    )
+import Agent.Tools.MultiAgents
+    ( CollaborationSpawnOptions(..)
+    , MultiAgentContext(..)
+    )
+import Agent.Tools.PlanMode (PlanModeEnv(..), PlanModeHooks)
+import Agent.Tools.Types (ToolEnv(..), defaultToolEnv)
+import Control.Exception.Safe (finally)
+import Data.IORef
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import Data.Maybe (fromMaybe)
+import Data.Text (Text)
+import Data.Time.Clock (getCurrentTime, utctDay)
+
+data SubagentSession = SubagentSession
+    { subSessionTranscript :: !(IORef [ResponseItem])
+    }
+
+-- | Optional on-disk root for child transcripts (@sessionDir/agents/<id>@).
+type SubagentStoreRoot = IORef (Maybe OsPath)
+
+-- | Provider-neutral dependencies shared by all child-agent backends.
+data SubagentRuntime = SubagentRuntime
+    { subagentOptions :: !CliOptions
+    , subagentPolicy :: !ApprovalPolicy
+    , subagentPlanHooks :: !PlanModeHooks
+    , subagentParams :: !(IORef ResponseCreateParams)
+    , subagentRegistry :: !SubagentRegistry
+    , subagentSessions :: !(IORef (Map SubagentId SubagentSession))
+    , subagentStoreRoot :: !SubagentStoreRoot
+    , subagentTypes :: !GrokSubagentSpecs
+    }
+
+-- | Prefer an explicit store root; otherwise fall back to planMode's session dir.
+syncStoreRootFromPlan :: SubagentStoreRoot -> PlanModeEnv -> IO ()
+syncStoreRootFromPlan storeRootRef planMode = do
+    mroot <- readIORef storeRootRef
+    case mroot of
+        Just _ -> pure ()
+        Nothing -> do
+            sessionDir <- readIORef planMode.planSessionDir
+            case sessionDir of
+                Just dir -> writeIORef storeRootRef (Just dir)
+                Nothing -> pure ()
+
+prepareCollaborationSpawn
+    :: IORef (Map SubagentId SubagentSession)
+    -> SubagentStoreRoot
+    -> GrokSubagentSpecs
+    -> IORef (Maybe (IORef [ResponseItem]))
+    -> SubagentId
+    -> CollaborationSpawnOptions
+    -> IO ()
+prepareCollaborationSpawn
+        sessionsRef storeRootRef typesRef sourceRef agentId spawnOptions = do
+    recordAgentSpec typesRef agentId GrokSubagentSpec
+        { agentType = defaultSubagentType
+        , modelOverride = spawnOptions.collaborationModel
+        , reasoningEffortOverride =
+            spawnOptions.collaborationReasoningEffort
+        }
+    session <-
+        lookupOrCreateSubagentSession
+            sessionsRef storeRootRef typesRef agentId
+    source <- readIORef sourceRef
+    sourceItems <- maybe (pure []) readIORef source
+    writeIORef session.subSessionTranscript
+        (forkSubagentTranscript spawnOptions.collaborationForkTurns sourceItems)
+
+persistSubagentSnapshot
+    :: SubagentStoreRoot
+    -> SubagentRegistry
+    -> GrokSubagentSpecs
+    -> SubagentId
+    -> IORef [ResponseItem]
+    -> IO ()
+persistSubagentSnapshot storeRootRef registry typesRef agentId transcriptRef = do
+    status <- getStatus registry agentId
+    persistSubagentSnapshotWithStatus
+        storeRootRef registry typesRef agentId status transcriptRef
+
+persistSubagentSnapshotWithStatus
+    :: SubagentStoreRoot
+    -> SubagentRegistry
+    -> GrokSubagentSpecs
+    -> SubagentId
+    -> SubagentStatus
+    -> IORef [ResponseItem]
+    -> IO ()
+persistSubagentSnapshotWithStatus
+        storeRootRef registry typesRef agentId status transcriptRef = do
+    mroot <- readIORef storeRootRef
+    case mroot of
+        Nothing -> pure ()
+        Just sessionDir -> do
+            items <- trimDanglingToolSuffix <$> readIORef transcriptRef
+            previous <- getPreviousResponseId registry agentId
+            agentType <- lookupAgentType typesRef agentId
+            agentModel <- lookupAgentModel typesRef agentId
+            reasoningEffort <- lookupAgentReasoningEffort typesRef agentId
+            agentCwd <- getSubagentCwd registry agentId
+            identity <- getSubagentIdentity registry agentId
+            _ <- saveSubagentState
+                sessionDir agentId items previous status agentType agentModel
+                reasoningEffort agentCwd identity
+            pure ()
+
+flushAllSubagentSnapshots
+    :: SubagentStoreRoot
+    -> SubagentRegistry
+    -> IORef (Map SubagentId SubagentSession)
+    -> GrokSubagentSpecs
+    -> IO ()
+flushAllSubagentSnapshots storeRootRef registry sessionsRef typesRef = do
+    sessions <- readIORef sessionsRef
+    mapM_
+        (\(agentId, session) ->
+            persistSubagentSnapshot storeRootRef registry typesRef agentId
+                session.subSessionTranscript)
+        (Map.toList sessions)
+
+-- | Rehydrate a closed/missing agent from @sessionDir/agents/<id>@ so
+-- 'resume_agent' / 'resume_from' can continue the prior transcript.
+restoreAgentFromDisk
+    :: SubagentStoreRoot
+    -> SubagentRegistry
+    -> IORef (Map SubagentId SubagentSession)
+    -> GrokSubagentSpecs
+    -> SubagentId
+    -> IO (Either Text ())
+restoreAgentFromDisk storeRootRef registry sessionsRef typesRef agentId = do
+    status <- getStatus registry agentId
+    case status of
+        NotFound -> restore
+        Closed -> restore
+        _ -> pure (Right ())
+  where
+    restore = do
+        mroot <- readIORef storeRootRef
+        case mroot of
+            Nothing ->
+                pure (Left "no session directory; cannot restore subagent from disk")
+            Just sessionDir ->
+                loadSubagentState sessionDir agentId >>= \case
+                    Left err -> pure (Left err)
+                    Right Nothing ->
+                        -- Same-process close with no disk yet: still reopen.
+                        reopenInMemory Nothing Nothing
+                    Right (Just (items, meta)) -> do
+                        result <- reopenPersisted meta
+                        case result of
+                            Left err -> pure (Left err)
+                            Right () -> do
+                                case meta.diskAgentType of
+                                    Just agentType ->
+                                        recordAgentSpec typesRef agentId GrokSubagentSpec
+                                            { agentType
+                                            , modelOverride = meta.diskAgentModel
+                                            , reasoningEffortOverride =
+                                                meta.diskReasoningEffort
+                                            }
+                                    Nothing -> pure ()
+                                transcript <- newIORef items
+                                let session =
+                                        SubagentSession
+                                            { subSessionTranscript = transcript
+                                            }
+                                atomicModifyIORef' sessionsRef \m ->
+                                    (Map.insert agentId session m, ())
+                                pure (Right ())
+    reopenPersisted meta =
+        case meta.diskTaskPath of
+            Nothing -> restoreAt taskPathRoot
+            Just pathText ->
+                case parseTaskPath pathText of
+                    Left err -> pure (Left err)
+                    Right taskPath -> restoreAt taskPath
+      where
+        restoredStatus = fromMaybe (Completed Nothing) meta.diskStatus
+        restoreAt taskPath = do
+            let restore =
+                    case meta.diskCwd of
+                        Just childCwd ->
+                            restoreSubagentAtWithCwdStatus
+                                registry childCwd
+                        Nothing ->
+                            restoreSubagentAtStatus registry
+            restore
+                agentId meta.diskParentId taskPath
+                (fromMaybe 1 meta.diskDepth)
+                Nothing meta.diskPreviousResponseId restoredStatus
+                >>= pure . fmap (const ())
+    reopenInMemory previous requestedCwd = do
+        restored <- case requestedCwd of
+            Just childCwd ->
+                restoreSubagentWithCwd
+                    registry childCwd agentId Nothing 1 Nothing previous
+            Nothing ->
+                restoreSubagent registry agentId Nothing 1 Nothing previous
+        pure $ case restored of
+            Left err -> Left err
+            Right _ -> Right ()
+
+-- | Use a disposable WebSocket for side questions so cancellation cannot
+-- leave abandoned response frames queued on the main conversation connection.
+freshOpenAiBackend
+    :: TokenProvider
+    -> IO ResponseCreateParams
+    -> IORef [ResponseItem]
+    -> Backend
+freshOpenAiBackend provider getParams transcript = Backend \previous inputs onEvent ->
+    withCodexWsRetrying provider \conn _credential ->
+        let Backend submit = openAiBackend conn getParams transcript
+        in submit previous inputs onEvent
+
+-- | Child Codex agent: per-agent transcript retained across follow-ups,
+-- independently scoped WebSocket requests, and nested multi-agent tools.
+runCodexSubagent
+    :: SubagentRuntime
+    -> TokenProvider
+    -> Maybe (InterAgentMessage -> IO (Either Text Text))
+    -> RunSubagent
+runCodexSubagent runtime tokenProvider sendToRoot =
+    \env previous prompt onEvent -> do
+        parentParams <- readIORef runtime.subagentParams
+        childEnv <- defaultToolEnv env.subCwd
+        childPath <-
+            fromMaybe taskPathRoot
+                <$> getTaskPath runtime.subagentRegistry env.subId
+        session <-
+            lookupOrCreateSubagentSession
+                runtime.subagentSessions
+                runtime.subagentStoreRoot
+                runtime.subagentTypes
+                env.subId
+        nestedForkSource <- newIORef (Just session.subSessionTranscript)
+        childModel <- lookupAgentModel runtime.subagentTypes env.subId
+        childEffort <- lookupAgentReasoningEffort runtime.subagentTypes env.subId
+        let childToolEnv = childEnv { toolCancel = env.subCancel }
+            childCtx = MultiAgentContext
+                { multiRegistry = runtime.subagentRegistry
+                , multiSelfId = Just env.subId
+                , multiDepth = env.subDepth
+                , multiTaskPath = childPath
+                , multiRootTurnId = pure env.subRootTurnId
+                , multiResumeFromDisk = Nothing
+                , multiCreateWorktree = Nothing
+                , multiPrepareSpawn = Just
+                    (prepareCollaborationSpawn
+                        runtime.subagentSessions
+                        runtime.subagentStoreRoot
+                        runtime.subagentTypes
+                        nestedForkSource)
+                , multiSendToRoot = sendToRoot
+                }
+        coding <-
+            codingToolsFor
+                OpenAIProvider
+                childToolEnv
+                (Just runtime.subagentPlanHooks)
+                (Just childCtx)
+        syncStoreRootFromPlan runtime.subagentStoreRoot coding.codingPlanMode
+        flip finally coding.codingClose do
+            today <- utctDay <$> getCurrentTime
+            let model = fromMaybe
+                    (fromMaybe (defaultModelFor OpenAIProvider) parentParams.model)
+                    childModel
+                inheritedEffort = case parentParams.reasoning of
+                    Just cfg -> fromMaybe (defaultEffortFor OpenAIProvider) cfg.effort
+                    Nothing -> defaultEffortFor OpenAIProvider
+                effort = fromMaybe inheritedEffort childEffort
+                baseInstructions =
+                    fromMaybe
+                        (systemPrompt OpenAIProvider env.subCwd today True)
+                        parentParams.instructions
+                instructions =
+                    baseInstructions
+                        <> "\n\nYou are a Codex subagent. Complete the assigned task and "
+                        <> "report results clearly. Your agent id is "
+                        <> env.subId.unSubagentId
+                        <> "."
+                tools = coding.codingAppTools
+                childParams = requestParams model instructions
+                    (schemasFromAppTools OpenAIProvider tools) effort
+            toolRegistry <- requireToolRegistry tools
+            childParamsRef <- newIORef childParams
+            let backend =
+                    freshOpenAiBackend tokenProvider
+                        (readIORef childParamsRef) session.subSessionTranscript
+                config = LoopConfig
+                    { loopBackend = backend
+                    , loopTools = toolRegistry
+                    , loopDispatch = defaultLoopDispatch
+                    , loopMaxTurns = runtime.subagentOptions.optMaxTurns
+                    , loopOnEvent = onEvent
+                    , loopApprove =
+                        \call ->
+                            childApprove runtime.subagentPolicy toolRegistry call
+                    , loopCancel = env.subCancel
+                    }
+            result <- runLoopInputs config previous [AgentMessage prompt]
+            case result of
+                Right loopResult ->
+                    setPreviousResponseId
+                        runtime.subagentRegistry
+                        env.subId
+                        loopResult.finalResponseId
+                Left _ ->
+                    modifyIORef' session.subSessionTranscript
+                        trimDanglingToolSuffix
+            persistSubagentSnapshot
+                runtime.subagentStoreRoot
+                runtime.subagentRegistry
+                runtime.subagentTypes
+                env.subId
+                session.subSessionTranscript
+            pure result
+
+-- | Child XAI/OpenRouter agent: HTTP backend, filtered tools by subagent_type.
+runHttpSubagent
+    :: SubagentRuntime
+    -> Provider
+    -> (IORef ResponseCreateParams -> IORef [ResponseItem] -> Backend)
+    -> RunSubagent
+runHttpSubagent runtime provider mkBackend =
+    \env previous prompt onEvent -> do
+        parentParams <- readIORef runtime.subagentParams
+        childEnv <- defaultToolEnv env.subCwd
+        childPath <-
+            fromMaybe taskPathRoot
+                <$> getTaskPath runtime.subagentRegistry env.subId
+        session <-
+            lookupOrCreateSubagentSession
+                runtime.subagentSessions
+                runtime.subagentStoreRoot
+                runtime.subagentTypes
+                env.subId
+        nestedForkSource <- newIORef (Just session.subSessionTranscript)
+        let childToolEnv = childEnv { toolCancel = env.subCancel }
+            childCtx = MultiAgentContext
+                { multiRegistry = runtime.subagentRegistry
+                , multiSelfId = Just env.subId
+                , multiDepth = env.subDepth
+                , multiTaskPath = childPath
+                , multiRootTurnId = pure env.subRootTurnId
+                , multiResumeFromDisk = Nothing
+                , multiCreateWorktree = Nothing
+                , multiPrepareSpawn = Just
+                    (prepareCollaborationSpawn
+                        runtime.subagentSessions
+                        runtime.subagentStoreRoot
+                        runtime.subagentTypes
+                        nestedForkSource)
+                , multiSendToRoot = Nothing
+                }
+        agentType <-
+            fromMaybe defaultSubagentType
+                <$> lookupAgentType runtime.subagentTypes env.subId
+        childModel <- lookupAgentModel runtime.subagentTypes env.subId
+        childEffort <-
+            lookupAgentReasoningEffort runtime.subagentTypes env.subId
+        coding <-
+            codingToolsFor
+                provider
+                childToolEnv
+                (Just runtime.subagentPlanHooks)
+                (Just childCtx)
+        flip finally coding.codingClose do
+            today <- utctDay <$> getCurrentTime
+            let model = fromMaybe
+                    (fromMaybe (defaultModelFor provider) parentParams.model)
+                    childModel
+                inheritedEffort = case parentParams.reasoning of
+                    Just cfg -> fromMaybe (defaultEffortFor provider) cfg.effort
+                    Nothing -> defaultEffortFor provider
+                effort = fromMaybe inheritedEffort childEffort
+                baseInstructions = systemPrompt provider env.subCwd today True
+                instructions =
+                    baseInstructions
+                        <> "\n\n"
+                        <> grokSubagentSuffix agentType env.subId
+                tools = filterChildGrokTools agentType coding.codingAppTools
+                childParams = requestParams model instructions
+                    (schemasFromAppTools provider tools) effort
+            toolRegistry <- requireToolRegistry tools
+            childParamsRef <- newIORef childParams
+            let backend = mkBackend childParamsRef session.subSessionTranscript
+                config = LoopConfig
+                    { loopBackend = backend
+                    , loopTools = toolRegistry
+                    , loopDispatch = defaultLoopDispatch
+                    , loopMaxTurns = runtime.subagentOptions.optMaxTurns
+                    , loopOnEvent = onEvent
+                    , loopApprove =
+                        \call ->
+                            childApprove runtime.subagentPolicy toolRegistry call
+                    , loopCancel = env.subCancel
+                    }
+            result <- runLoop config previous (interAgentMessagePayload prompt)
+            case result of
+                Right loopResult ->
+                    setPreviousResponseId
+                        runtime.subagentRegistry
+                        env.subId
+                        loopResult.finalResponseId
+                Left _ ->
+                    modifyIORef' session.subSessionTranscript
+                        trimDanglingToolSuffix
+            persistSubagentSnapshot
+                runtime.subagentStoreRoot
+                runtime.subagentRegistry
+                runtime.subagentTypes
+                env.subId
+                session.subSessionTranscript
+            pure result
+
+grokSubagentSuffix :: Text -> SubagentId -> Text
+grokSubagentSuffix agentType agentId =
+    "You are a Grok Build subagent — a focused worker delegated a specific task.\n\
+    \Complete the assigned task directly and efficiently. Do not broaden scope beyond what was asked. \
+    \Report blocked or unverified work explicitly.\n\n\
+    \Subagent type: "
+        <> agentType
+        <> "\nAgent id: "
+        <> agentId.unSubagentId
+        <> case agentType of
+            "explore" ->
+                "\n\n=== READ-ONLY MODE ===\n\
+                \You have no file editing or command execution tools. Search broadly, narrow down, \
+                \and return absolute file paths and relevant findings."
+            "plan" ->
+                "\n\n=== READ-ONLY MODE ===\n\
+                \Do not create, modify, or delete implementation files. Explore the codebase, \
+                \consider trade-offs, and produce a concrete implementation strategy. End with \
+                \a Critical Files for Implementation section listing 3-5 files."
+            _ ->
+                "\n\nStart broad and narrow down. Check multiple locations and naming conventions. \
+                \Never create documentation files unless explicitly requested."
+
+lookupOrCreateSubagentSession
+    :: IORef (Map SubagentId SubagentSession)
+    -> SubagentStoreRoot
+    -> GrokSubagentSpecs
+    -> SubagentId
+    -> IO SubagentSession
+lookupOrCreateSubagentSession sessionsRef storeRootRef typesRef agentId = do
+    sessions <- readIORef sessionsRef
+    case Map.lookup agentId sessions of
+        Just session -> pure session
+        Nothing -> do
+            mroot <- readIORef storeRootRef
+            loaded <- case mroot of
+                Just sessionDir -> loadSubagentState sessionDir agentId
+                Nothing -> pure (Right Nothing)
+            let (items, meta) = case loaded of
+                    Right (Just (xs, m)) -> (xs, Just m)
+                    _ -> ([], Nothing)
+            transcript <- newIORef items
+            case meta >>= (.diskAgentType) of
+                Just agentType ->
+                    recordAgentSpec typesRef agentId GrokSubagentSpec
+                        { agentType
+                        , modelOverride = meta >>= (.diskAgentModel)
+                        , reasoningEffortOverride =
+                            meta >>= (.diskReasoningEffort)
+                        }
+                Nothing -> pure ()
+            let session = SubagentSession { subSessionTranscript = transcript }
+            atomicModifyIORef' sessionsRef \m -> (Map.insert agentId session m, ())
+            pure session

--- a/packages/agent-cli/src/Agent/CLI/Tools.hs
+++ b/packages/agent-cli/src/Agent/CLI/Tools.hs
@@ -1,6 +1,7 @@
 -- | Convert registered AppTools into Responses tool schemas.
 module Agent.CLI.Tools
-    ( lookupAppTool
+    ( requireToolRegistry
+    , lookupAppTool
     , schemasFromAppTools
     , webSearchTool
     ) where
@@ -15,6 +16,8 @@ import Agent.Tools.MultiAgents (multiAgentNamespace, multiAgentToolNames)
 import Agent.Tools.Types
     ( AppTool(..)
     , ToolSchema(..)
+    , ToolRegistry
+    , mkToolRegistry
     )
 import qualified Data.Aeson as Aeson
 import Data.Aeson ((.=))
@@ -22,6 +25,11 @@ import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KeyMap
 import Data.List (find, partition)
 import Data.Text (Text)
+import qualified Data.Text as Text
+
+requireToolRegistry :: [AppTool] -> IO ToolRegistry
+requireToolRegistry tools =
+    either (ioError . userError . Text.unpack) pure (mkToolRegistry tools)
 
 lookupAppTool :: Text -> [AppTool] -> Maybe AppTool
 lookupAppTool name =

--- a/packages/agent-cli/test/Agent/CLI/RequestSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RequestSpec.hs
@@ -1,0 +1,30 @@
+module Agent.CLI.RequestSpec (spec) where
+
+import Agent.CLI.Request (requestParams)
+import Agent.CLI.Tools (webSearchTool)
+import Agent.Responses.Types
+import qualified Data.Aeson.KeyMap as KeyMap
+import Test.Hspec
+
+spec :: Spec
+spec = describe "requestParams" do
+    it "constructs a non-storing request with model, instructions, tools, and effort" do
+        let params =
+                requestParams
+                    "test-model"
+                    "test instructions"
+                    [webSearchTool]
+                    "high"
+        params.model `shouldBe` Just "test-model"
+        params.instructions `shouldBe` Just "test instructions"
+        params.tools `shouldBe` Just [webSearchTool]
+        params.store `shouldBe` Just False
+        case params.reasoning of
+            Nothing -> expectationFailure "expected reasoning configuration"
+            Just reasoning -> do
+                reasoning.effort `shouldBe` Just "high"
+                reasoning.context `shouldBe` Nothing
+                reasoning.generateSummary `shouldBe` Nothing
+                reasoning.reasoningMode `shouldBe` Nothing
+                reasoning.summary `shouldBe` Nothing
+                reasoning.extraFields `shouldBe` KeyMap.empty

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -31,6 +31,7 @@ import qualified Agent.CLI.ProjectSpec as ProjectSpec
 import qualified Agent.CLI.PromptSpec as PromptSpec
 import qualified Agent.CLI.ProviderFallbackSpec as ProviderFallbackSpec
 import qualified Agent.CLI.ProviderTransitionSpec as ProviderTransitionSpec
+import qualified Agent.CLI.RequestSpec as RequestSpec
 import qualified Agent.CLI.RenderSpec as RenderSpec
 import qualified Agent.CLI.ReplStatusSpec as ReplStatusSpec
 import qualified Agent.CLI.ResumeSpec as ResumeSpec
@@ -75,6 +76,7 @@ main = hspec do
     PromptSpec.spec
     ProviderFallbackSpec.spec
     ProviderTransitionSpec.spec
+    RequestSpec.spec
     RenderSpec.spec
     ReplStatusSpec.spec
     ResumeSpec.spec


### PR DESCRIPTION
## Summary

- extract child-agent orchestration, persistence, restore, and provider adapters into `Agent.CLI.Subagents.Runtime`
- group shared child-agent dependencies in `SubagentRuntime` instead of passing long positional argument lists
- move provider-neutral Responses request construction into `Agent.CLI.Request`
- move tool-registry validation into `Agent.CLI.Tools`
- add regression coverage for request construction

This removes roughly 500 lines of subagent implementation from `Agent.CLI` while preserving the existing entry-point API and runtime behavior.

## Validation

- six-package multi-library GHCi load: 133 modules loaded
- `agent-cli` library GHCi load: 47 modules loaded
- `agent-cli` tests: 386 examples, 0 failures
- live tmux smoke test: OpenAI runtime initialized, AGENTS.md loaded, prompt and slash-command UI rendered
- `git diff --check`
