### PR TITLE
fix(cli): restore fullscreen native progress

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -98,7 +98,8 @@ import Agent.CLI.PendingInputs (withPendingInputs)
 import Agent.CLI.Resume (pickResumeSession)
 import Agent.CLI.Plan (cliPlanHooks)
 import Agent.CLI.Progress
-    ( osc9ProgressRemove
+    ( osc9ProgressIndeterminate
+    , osc9ProgressRemove
     , wrapOscForTmux
     )
 import Agent.CLI.Project
@@ -1078,6 +1079,9 @@ runSession options provider policy tools toolEnv planMode uiRuntimeRef prompt pe
             (requestCancel toolEnv.toolCancel)
             (noteFullscreenCtrlC interrupt)
             (copyTerminalClipboard terminal stdout)
+            (\active ->
+                when terminal.terminalNativeProgress $
+                    setNativeProgress stderr active)
             initialFullscreenState
         else pure Nothing
     writeIORef uiRuntimeRef fullscreen
@@ -2544,11 +2548,18 @@ loadAgentsContext options provider home cwd initialItems initialPrevious
 -- | Drop Ghostty / Windows Terminal native progress (OSC 9;4) on stderr.
 -- Safe when the bar was never shown; unknown terminals ignore the sequence.
 clearNativeProgress :: Handle -> IO ()
-clearNativeProgress handle = do
+clearNativeProgress handle =
+    setNativeProgress handle False
+
+setNativeProgress :: Handle -> Bool -> IO ()
+setNativeProgress handle active = do
     tty <- hIsTerminalDevice handle
     when tty do
         inTmux <- isJust <$> lookupEnv "TMUX"
-        Text.hPutStr handle (wrapOscForTmux inTmux osc9ProgressRemove)
+        let sequence_
+                | active = osc9ProgressIndeterminate
+                | otherwise = osc9ProgressRemove
+        Text.hPutStr handle (wrapOscForTmux inTmux sequence_)
         hFlush handle
 
 -- | Queue clipboard / Finder-paste images and draw an in-terminal thumbnail

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -26,6 +26,7 @@ import Agent.CLI.Status (formatTokenUsage)
 import qualified Agent.CLI.TUI.Theme as Theme
 import Agent.CLI.TUI.Markdown (markdownWidget)
 import Agent.CLI.UI.Model
+import Agent.Loop (LoopEvent(..))
 import Agent.ToolDispatch (ToolCall(..))
 import Brick
 import Brick.BChan (BChan, newBChan, writeBChan)
@@ -48,7 +49,7 @@ import Control.Concurrent.STM
 import Control.Monad (forever, void, when)
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.State.Strict (modify')
-import Control.Exception.Safe (SomeException, throwIO, tryAny)
+import Control.Exception.Safe (SomeException, finally, throwIO, tryAny)
 import Control.Exception (AsyncException(UserInterrupt))
 import Data.ByteString (ByteString)
 import Data.Char (isControl)
@@ -83,6 +84,7 @@ data FullscreenRuntime = FullscreenRuntime
     , runtimeCancel :: !(IO ())
     , runtimeCtrlC :: !(IO CtrlCDecision)
     , runtimeCopy :: !(Text -> IO Bool)
+    , runtimeNativeProgress :: !(Bool -> IO ())
     , runtimeInitial :: !UiState
     }
 
@@ -107,14 +109,21 @@ newFullscreenRuntime
     :: IO ()
     -> IO CtrlCDecision
     -> (Text -> IO Bool)
+    -> (Bool -> IO ())
     -> UiState
     -> IO FullscreenRuntime
-newFullscreenRuntime cancelAction ctrlCAction copyAction initial = FullscreenRuntime
+newFullscreenRuntime
+    cancelAction
+    ctrlCAction
+    copyAction
+    nativeProgress
+    initial = FullscreenRuntime
     <$> newBChan 512
     <*> newTQueueIO
     <*> pure cancelAction
     <*> pure ctrlCAction
     <*> pure copyAction
+    <*> pure nativeProgress
     <*> pure initial
 
 emitUiEvent :: FullscreenRuntime -> UiEvent -> IO ()
@@ -184,12 +193,14 @@ runFullscreen runtime workerAction = do
                 (void (waitCatch worker)
                     >> writeBChan runtime.runtimeEvents AppStop)
                 \_notifier -> do
-                    void $ customMain
-                        initialVty
-                        buildVty
-                        (Just runtime.runtimeEvents)
-                        fullscreenApp
-                        initialState
+                    void
+                        (customMain
+                            initialVty
+                            buildVty
+                            (Just runtime.runtimeEvents)
+                            fullscreenApp
+                            initialState)
+                        `finally` runtime.runtimeNativeProgress False
                     atomically $
                         writeTQueue runtime.runtimeInput ReplEof
                     wait worker
@@ -592,6 +603,10 @@ handleEvent event = case event of
                 _ -> state.appPasted
             }
         state <- get
+        case nativeProgressSignal uiEvent state.appUi of
+            Nothing -> pure ()
+            Just active ->
+                liftIO (state.appRuntime.runtimeNativeProgress active)
         when (eventFollows uiEvent && state.appUi.uiFollow) $
             vScrollToEnd (viewportScroll ConversationViewport)
     AppEvent (AppAskPermission summary reply) ->
@@ -631,6 +646,18 @@ eventFollows = \case
     UiUserSubmitted _ -> True
     UiConversationCleared -> True
     _ -> False
+
+nativeProgressSignal :: UiEvent -> UiState -> Maybe Bool
+nativeProgressSignal event state = case event of
+    UiLoop TurnStarted -> Just True
+    UiLoop (TurnFinished _) -> Just False
+    UiTurnEnded _ -> Just False
+    UiSetAwaitingInput True -> Just False
+    UiTick
+        | state.uiRunning
+        , state.uiFrame == 0 ->
+            Just True
+    _ -> Nothing
 
 handlePermissionKey :: V.Event -> EventM Name AppState ()
 handlePermissionKey = \case


### PR DESCRIPTION
## Summary

- restore Ghostty/Windows Terminal OSC 9;4 progress signaling in the fullscreen TUI
- refresh the indeterminate signal while a turn remains active
- clear native progress on completion, cancellation, prompt return, and TUI shutdown
- preserve tmux passthrough behavior

## Validation

- loaded `agent-cli:lib:agent-cli` successfully in GHCi under `nix develop`
- ran targeted progress specs in the test-suite GHCi: 2 examples, 0 failures
- exercised the fullscreen UI in tmux with a 12-second live turn and confirmed repeated wrapped OSC 9;4 indeterminate signals followed by removal signals
- `git diff --check`
