### PR TITLE
fix(auth): pool all available OpenAI accounts

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Auth.hs
+++ b/packages/agent-cli/src/Agent/CLI/Auth.hs
@@ -5,6 +5,7 @@ module Agent.CLI.Auth
     , grokEmailFromAuthJson
     , loadAuth
     , openAIOAuthClientId
+    , openAiAuthStateChanged
     , openaiAuthStateFromJson
     , probeLoadedAuth
     , reloadableFileCredentialProvider
@@ -17,7 +18,7 @@ import Agent.CLI.CredentialStore
     , ManagedCredential(..)
     , ManagedSecret(..)
     , loadManagedCredentials
-    , upsertManagedCredential
+    , updateManagedCredentialSecret
     )
 import Agent.Error (ApiError(..), ErrorType(..))
 import Agent.FileRetry (retryOnFileBusy)
@@ -36,7 +37,9 @@ import Agent.Provider
     )
 import Agent.OpenRouter.Credential (credentialFromApiKey)
 import Agent.XAI.Auth (accountIdFromAccessToken, emailFromToken)
+import Control.Concurrent.MVar (MVar, newMVar, withMVar)
 import Control.Applicative ((<|>))
+import Control.Exception.Safe (bracket, bracket_)
 import Control.Monad (when)
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Except
@@ -50,15 +53,35 @@ import Data.Aeson ((.=))
 import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KeyMap
 import qualified Data.ByteString.Lazy as LBS
+import Data.Either (partitionEithers)
+import Data.Function (on)
 import Data.IORef (newIORef, readIORef, writeIORef)
-import Data.Maybe (fromMaybe, isJust, listToMaybe)
+import Data.List (find, nubBy)
+import Data.Maybe (catMaybes, fromMaybe, isJust, listToMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
 import Data.Time.Clock (UTCTime, addUTCTime, getCurrentTime)
-import System.Directory.OsPath (doesFileExist, getHomeDirectory)
-import System.OsPath ((</>))
+import System.Directory.OsPath
+    ( createDirectoryIfMissing
+    , doesFileExist
+    , getHomeDirectory
+    )
+import System.IO (SeekMode(AbsoluteSeek))
+import System.OsPath (takeDirectory, (</>))
 import qualified System.OsPath as OsPath
+import System.Posix.Files (setFileMode)
+import System.Posix.IO
+    ( LockRequest(Unlock, WriteLock)
+    , OpenFileFlags(..)
+    , OpenMode(ReadWrite)
+    , closeFd
+    , defaultFileFlags
+    , openFd
+    , setLock
+    , waitToSetLock
+    )
+import System.Posix.Types (Fd)
 import qualified System.Process.Environment.OsString as Environment
 
 openAIOAuthClientId :: Maybe Text -> Text
@@ -195,7 +218,7 @@ loadOpenRouter = do
 
 loadOpenAi :: ExceptT Text IO LoadedAuth
 loadOpenAi = do
-    managed <- lift (loadManagedCredential OpenAIProvider)
+    managedResult <- lift loadManagedCredentials
     fromEnvToken <- lift (lookupNonEmpty "CODEX_ACCESS_TOKEN")
     fromEnvJson <- lift (lookupNonEmpty "CODEX_AUTH_JSON")
     home <- lift getHomeDirectory
@@ -206,105 +229,323 @@ loadOpenAi = do
         then lift (Just <$> retryOnFileBusy (LBS.readFile (toFilePath filePath)))
         else pure Nothing
     now <- lift getCurrentTime
-    case managed of
-        Just (metadata, secret) ->
-            loadManagedOpenAI now metadata secret
-        Nothing ->
-            case fromEnvToken of
-                Just token -> do
-                    accountId <- lift (openaiAccountIdForToken token)
-                    pure LoadedAuth
-                        { loadedProvider = OpenAIProvider
-                        , loadedTokenProvider = staticCredentialProvider Credential
-                            { accessToken = token
-                            , accountId
-                            , leaseId = Nothing
-                            , provider = OpenAIProvider
-                            }
-                        , loadedOpenAiPool = Nothing
-                        }
-                Nothing -> case envOrFileState now fromEnvJson fileBytes of
-                    Nothing -> throwE noAuthHint
-                    Just state ->
-                        openAiPoolAuth fileExists filePath state
-
-loadManagedOpenAI
-    :: UTCTime
-    -> ManagedCredential
-    -> ManagedSecret
-    -> ExceptT Text IO LoadedAuth
-loadManagedOpenAI now metadata secret =
-    case metadata.managedAuthKind of
-        ManagedOpenAIAuthJson ->
-            case openaiAuthStateFromJson now
-                (LBS.fromStrict (TextEncoding.encodeUtf8 secret.secretPayload)) of
-                Nothing ->
-                    throwE "managed OpenAI OAuth credential contains invalid auth JSON"
-                Just state -> do
-                    clientId <-
-                        lift $
-                            openAIOAuthClientId
-                                <$> lookupNonEmpty "OPENAI_OAUTH_CLIENT_ID"
-                    let refresh stale =
-                            OpenAI.refreshAccessTokenHTTP clientId stale >>= \case
-                                Left err -> pure (Left err)
-                                Right newState -> do
-                                    stamped <- authStateToJson newState <$> getCurrentTime
-                                    let payload =
-                                            TextEncoding.decodeUtf8
-                                                (LBS.toStrict (Aeson.encode stamped))
-                                    upsertManagedCredential
-                                        metadata
-                                        secret { secretPayload = payload }
-                                        >>= \case
-                                            Left err ->
-                                                pure $ Left $ ConnectionError err
-                                            Right () -> pure (Right newState)
-                    pool <- lift (OpenAI.newPool [state] refresh)
-                    tokenProvider <- lift (OpenAICredential.poolTokenProvider pool)
-                    pure LoadedAuth
-                        { loadedProvider = OpenAIProvider
-                        , loadedTokenProvider = tokenProvider
-                        , loadedOpenAiPool = Just pool
-                        }
-        _ ->
-            pure LoadedAuth
-                { loadedProvider = OpenAIProvider
-                , loadedTokenProvider =
-                    staticCredentialProvider Credential
-                        { accessToken = secret.secretPayload
-                        , accountId = metadata.managedAccountId
-                        , leaseId = Nothing
-                        , provider = OpenAIProvider
-                        }
-                , loadedOpenAiPool = Nothing
-                }
-
-openAiPoolAuth
-    :: Bool
-    -> OsPath
-    -> OpenAI.AuthState
-    -> ExceptT Text IO LoadedAuth
-openAiPoolAuth persistRefresh filePath state = do
+    let (storeErrors, managed) = case managedResult of
+            Left err -> ([err], [])
+            Right credentials ->
+                ( []
+                , [ credential
+                  | credential@(metadata, _) <- credentials
+                  , metadata.managedProvider == OpenAIProvider
+                  ]
+                )
+    envTokenAccount <- lift $ traverse (openAiStaticAccount now) fromEnvToken
+    let enabledManaged =
+            [ credential
+            | credential@(metadata, _) <- managed
+            , metadata.managedEnabled
+            ]
+        (managedErrors, managedAccounts) =
+            partitionEithers (map (managedOpenAiAccount now) enabledManaged)
+        managedAccountIds =
+            map ((.accountId) . (.openAiState)) managedAccounts
+        envJsonAccount =
+            OpenAiAccount
+                <$> (fromEnvJson >>= openaiAuthStateFromJson now
+                    . LBS.fromStrict . TextEncoding.encodeUtf8)
+                <*> pure OpenAiEnvironmentOAuth
+        fileAccount =
+            OpenAiAccount
+                <$> (fileBytes >>= openaiAuthStateFromJson now)
+                <*> pure (OpenAiAuthFile filePath)
+        externalAccounts =
+            filter
+                (\account ->
+                    account.openAiState.accountId `notElem` managedAccountIds)
+                (catMaybes [envTokenAccount, envJsonAccount, fileAccount])
+        accounts = deduplicateOpenAiAccounts
+            (managedAccounts <> externalAccounts)
+    when (null accounts) $
+        throwE $ case storeErrors <> managedErrors of
+            [] -> noAuthHint
+            errors ->
+                "no valid OpenAI credentials found: "
+                    <> Text.intercalate "; " errors
     clientId <-
         lift $
             openAIOAuthClientId <$> lookupNonEmpty "OPENAI_OAUTH_CLIENT_ID"
-    let refresh stale =
-            OpenAI.refreshAccessTokenHTTP clientId stale >>= \case
-                Left err -> pure (Left err)
-                Right newState
-                    | persistRefresh -> do
-                        stamped <- authStateToJson newState <$> getCurrentTime
-                        OpenAILogin.writeAuthFile filePath stamped
-                        pure (Right newState)
-                    | otherwise -> pure (Right newState)
-    pool <- lift (OpenAI.newPool [state] refresh)
+    refreshLock <- lift (newMVar ())
+    pool <- lift $ OpenAI.newPool
+        (map (.openAiState) accounts)
+        (refreshOpenAiAccount refreshLock clientId accounts)
     tokenProvider <- lift (OpenAICredential.poolTokenProvider pool)
     pure LoadedAuth
         { loadedProvider = OpenAIProvider
         , loadedTokenProvider = tokenProvider
         , loadedOpenAiPool = Just pool
         }
+
+data OpenAiCredentialSource
+    = OpenAiManagedOAuth !Text
+    | OpenAiManagedBearer
+    | OpenAiEnvironmentOAuth
+    | OpenAiEnvironmentBearer
+    | OpenAiAuthFile !OsPath
+
+data OpenAiAccount = OpenAiAccount
+    { openAiState :: !OpenAI.AuthState
+    , openAiSource :: !OpenAiCredentialSource
+    }
+
+managedOpenAiAccount
+    :: UTCTime
+    -> (ManagedCredential, ManagedSecret)
+    -> Either Text OpenAiAccount
+managedOpenAiAccount now (metadata, secret) =
+    case metadata.managedAuthKind of
+        ManagedOpenAIAuthJson ->
+            case openaiAuthStateFromJson now
+                (LBS.fromStrict (TextEncoding.encodeUtf8 secret.secretPayload)) of
+                Nothing ->
+                    Left $
+                        "managed OpenAI OAuth credential "
+                            <> metadata.managedId
+                            <> " contains invalid auth JSON"
+                Just state
+                    | state.accountId /= metadata.managedAccountId ->
+                        Left $
+                            "managed OpenAI credential "
+                                <> metadata.managedId
+                                <> " account id does not match its auth payload"
+                    | otherwise ->
+                        Right OpenAiAccount
+                            { openAiState = state
+                            , openAiSource =
+                                OpenAiManagedOAuth metadata.managedId
+                            }
+        _ ->
+            Right OpenAiAccount
+                { openAiState = staticOpenAiState
+                    now metadata.managedAccountId secret.secretPayload
+                , openAiSource = OpenAiManagedBearer
+                }
+
+openAiStaticAccount :: UTCTime -> Text -> IO OpenAiAccount
+openAiStaticAccount now token = do
+    accountId <- openaiAccountIdForToken token
+    pure OpenAiAccount
+        { openAiState = staticOpenAiState now accountId token
+        , openAiSource = OpenAiEnvironmentBearer
+        }
+
+staticOpenAiState :: UTCTime -> Text -> Text -> OpenAI.AuthState
+staticOpenAiState now accountId accessToken =
+    OpenAI.AuthState
+        { accessToken
+        , refreshToken = ""
+        , accountId
+        , idToken = Nothing
+        , lastRefresh = now
+        }
+
+deduplicateOpenAiAccounts :: [OpenAiAccount] -> [OpenAiAccount]
+deduplicateOpenAiAccounts =
+    nubBy ((==) `on` ((.accountId) . (.openAiState)))
+
+refreshOpenAiAccount
+    :: MVar ()
+    -> Text
+    -> [OpenAiAccount]
+    -> OpenAI.AuthState
+    -> IO (Either ApiError OpenAI.AuthState)
+refreshOpenAiAccount lock clientId accounts stale =
+    withMVar lock \_ ->
+        case find
+            ((== stale.accountId) . (.accountId) . (.openAiState))
+            accounts of
+            Nothing ->
+                pure $ Left $ ProviderError AuthenticationError
+                    ("OpenAI refresh source is unavailable for account "
+                        <> stale.accountId)
+                    Nothing
+            Just account ->
+                withOpenAiSourceLock account.openAiSource do
+                    reloadOpenAiAccount account.openAiSource stale >>= \case
+                        Left err -> pure (Left err)
+                        Right current
+                            | current.accountId /= stale.accountId ->
+                                pure $ Left $ ProviderError AuthenticationError
+                                    "OpenAI auth source changed account identity"
+                                    Nothing
+                            | openAiAuthStateChanged stale current ->
+                                pure (Right current)
+                            | otherwise ->
+                                OpenAI.refreshAccessTokenHTTP clientId current >>= \case
+                                    Left err -> pure (Left err)
+                                    Right newState
+                                        | newState.accountId /= stale.accountId ->
+                                            pure $ Left $ ProviderError AuthenticationError
+                                                "OpenAI refresh changed account identity"
+                                                Nothing
+                                        | otherwise ->
+                                            persistRefreshedOpenAiAccount
+                                                account.openAiSource newState
+
+openAiAuthStateChanged :: OpenAI.AuthState -> OpenAI.AuthState -> Bool
+openAiAuthStateChanged stale current =
+    current.accessToken /= stale.accessToken
+        || current.refreshToken /= stale.refreshToken
+
+withOpenAiSourceLock :: OpenAiCredentialSource -> IO a -> IO a
+withOpenAiSourceLock source action =
+    openAiSourceLockPath source >>= \case
+        Nothing -> action
+        Just path -> withAdvisoryFileLock path action
+
+openAiSourceLockPath :: OpenAiCredentialSource -> IO (Maybe OsPath)
+openAiSourceLockPath source =
+    case source of
+        OpenAiManagedOAuth managedId ->
+            Just <$> managedRefreshLockPath managedId
+        OpenAiAuthFile filePath ->
+            pure (Just (fromFilePath (toFilePath filePath <> ".refresh.lock")))
+        _ ->
+            pure Nothing
+
+managedRefreshLockPath :: Text -> IO OsPath
+managedRefreshLockPath managedId = do
+    home <- getHomeDirectory
+    let fileName =
+            "refresh-" <> Text.unpack (safeLockName managedId) <> ".lock"
+    pure $
+        home
+            </> fromFilePath ".haskell-agent"
+            </> fromFilePath "credentials"
+            </> fromFilePath fileName
+
+safeLockName :: Text -> Text
+safeLockName = Text.map replace
+  where
+    replace character
+        | Text.any (== character) allowed = character
+        | otherwise = '-'
+    allowed =
+        "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_"
+
+withAdvisoryFileLock :: OsPath -> IO a -> IO a
+withAdvisoryFileLock path action = do
+    createDirectoryIfMissing True (takeDirectory path)
+    setFileMode (toFilePath (takeDirectory path)) 0o700
+    bracket
+        (openRefreshLock path)
+        closeFd
+        (\fd -> bracket_ (lockRefreshFd fd) (unlockRefreshFd fd) action)
+
+openRefreshLock :: OsPath -> IO Fd
+openRefreshLock path =
+    openFd
+        (toFilePath path)
+        ReadWrite
+        defaultFileFlags { creat = Just 0o600, cloexec = True }
+
+lockRefreshFd :: Fd -> IO ()
+lockRefreshFd fd =
+    waitToSetLock fd (WriteLock, AbsoluteSeek, 0, 0)
+
+unlockRefreshFd :: Fd -> IO ()
+unlockRefreshFd fd =
+    setLock fd (Unlock, AbsoluteSeek, 0, 0)
+
+reloadOpenAiAccount
+    :: OpenAiCredentialSource
+    -> OpenAI.AuthState
+    -> IO (Either ApiError OpenAI.AuthState)
+reloadOpenAiAccount source stale =
+    case source of
+        OpenAiManagedOAuth managedId ->
+            loadManagedCredentials >>= \case
+                Left err -> pure (Left (ConnectionError err))
+                Right credentials ->
+                    case find
+                        ((== managedId) . (.managedId) . fst)
+                        credentials of
+                        Nothing ->
+                            pure $ Left $ ProviderError AuthenticationError
+                                ("managed OpenAI credential " <> managedId
+                                    <> " no longer exists")
+                                Nothing
+                        Just (metadata, secret)
+                            | not metadata.managedEnabled ->
+                                pure $ Left $ ProviderError AuthenticationError
+                                    ("managed OpenAI credential " <> managedId
+                                        <> " is disabled")
+                                    Nothing
+                            | otherwise -> do
+                                now <- getCurrentTime
+                                pure $ case openaiAuthStateFromJson now
+                                    (LBS.fromStrict
+                                        (TextEncoding.encodeUtf8
+                                            secret.secretPayload)) of
+                                    Nothing ->
+                                        Left $ ProviderError AuthenticationError
+                                            ("managed OpenAI credential "
+                                                <> managedId
+                                                <> " contains invalid auth JSON")
+                                            Nothing
+                                    Just current -> Right current
+        OpenAiAuthFile filePath -> do
+            exists <- doesFileExist filePath
+            if not exists
+                then pure $ Left $ ProviderError AuthenticationError
+                    "OpenAI auth file no longer exists"
+                    Nothing
+                else do
+                    now <- getCurrentTime
+                    bytes <- retryOnFileBusy
+                        (LBS.readFile (toFilePath filePath))
+                    pure $ case openaiAuthStateFromJson now bytes of
+                        Nothing ->
+                            Left $ ProviderError AuthenticationError
+                                "OpenAI auth file contains invalid auth JSON"
+                                Nothing
+                        Just current -> Right current
+        OpenAiEnvironmentOAuth ->
+            pure (Right stale)
+        OpenAiManagedBearer ->
+            staticRefreshError stale.accountId
+        OpenAiEnvironmentBearer ->
+            staticRefreshError stale.accountId
+
+staticRefreshError :: Text -> IO (Either ApiError OpenAI.AuthState)
+staticRefreshError accountId =
+    pure $ Left $ ProviderError AuthenticationError
+        ("OpenAI account " <> accountId
+            <> " uses a static bearer token that cannot be refreshed")
+        Nothing
+
+persistRefreshedOpenAiAccount
+    :: OpenAiCredentialSource
+    -> OpenAI.AuthState
+    -> IO (Either ApiError OpenAI.AuthState)
+persistRefreshedOpenAiAccount source newState = do
+    stamped <- authStateToJson newState <$> getCurrentTime
+    case source of
+        OpenAiManagedOAuth managedId -> do
+            let payload =
+                    TextEncoding.decodeUtf8
+                        (LBS.toStrict (Aeson.encode stamped))
+            updateManagedCredentialSecret managedId payload
+                >>= \case
+                    Left err -> pure $ Left $ ConnectionError err
+                    Right () -> pure (Right newState)
+        OpenAiAuthFile filePath ->
+            OpenAILogin.writeAuthFile filePath stamped
+                >> pure (Right newState)
+        OpenAiEnvironmentOAuth ->
+            pure (Right newState)
+        OpenAiManagedBearer ->
+            staticRefreshError newState.accountId
+        OpenAiEnvironmentBearer ->
+            staticRefreshError newState.accountId
 
 loadManagedCredential
     :: Provider
@@ -335,15 +576,6 @@ managedBearerCredential metadata secret =
         , leaseId = Nothing
         , provider = metadata.managedProvider
         }) <$> token
-
-envOrFileState
-    :: UTCTime
-    -> Maybe Text
-    -> Maybe LBS.ByteString
-    -> Maybe OpenAI.AuthState
-envOrFileState now fromEnvJson fileBytes =
-    (fromEnvJson >>= openaiAuthStateFromJson now . LBS.fromStrict . TextEncoding.encodeUtf8)
-        <|> (fileBytes >>= openaiAuthStateFromJson now)
 
 openaiAuthStateFromJson :: UTCTime -> LBS.ByteString -> Maybe OpenAI.AuthState
 openaiAuthStateFromJson now bytes = do
@@ -535,14 +767,6 @@ reloadableFileCredentialProvider expectedProvider initial reload = do
             readIORef cache >>= \case
                 Just credential -> pure (Right credential)
                 Nothing -> loadFresh Nothing
-
-staticCredentialProvider :: Credential -> TokenProvider
-staticCredentialProvider credential = TokenProvider \failed ->
-    case failed of
-        Nothing -> pure (Right credential)
-        Just _ -> pure $ Left $ ProviderError AuthenticationError
-            "static credential was rejected"
-            Nothing
 
 lookupNonEmpty :: String -> IO (Maybe Text)
 lookupNonEmpty name = do

--- a/packages/agent-cli/src/Agent/CLI/CredentialStore.hs
+++ b/packages/agent-cli/src/Agent/CLI/CredentialStore.hs
@@ -10,13 +10,15 @@ module Agent.CLI.CredentialStore
     , managedSecretsPath
     , newManagedCredentialId
     , setManagedCredentialEnabled
+    , updateManagedCredentialSecret
     , upsertManagedCredential
     ) where
 
 import Agent.FileRetry (retryOnFileBusy, writeLazyFileAtomically)
 import Agent.OsPath (OsPath, fromFilePath, toFilePath, toText)
 import Agent.Provider (Provider(..), parseProvider, providerSlug)
-import Control.Exception.Safe (tryIO)
+import Control.Concurrent.MVar (MVar, newMVar, withMVar)
+import Control.Exception.Safe (bracket, bracket_, tryIO)
 import qualified Data.Aeson as Aeson
 import Data.Aeson ((.:), (.:?), (.=))
 import qualified Data.ByteString.Lazy as LBS
@@ -30,6 +32,18 @@ import System.Directory.OsPath
     , getHomeDirectory
     )
 import System.OsPath (takeDirectory, (</>))
+import System.IO (SeekMode(AbsoluteSeek))
+import System.IO.Unsafe (unsafePerformIO)
+import System.Posix.IO
+    ( LockRequest(Unlock, WriteLock)
+    , OpenFileFlags(..)
+    , OpenMode(ReadWrite)
+    , closeFd
+    , defaultFileFlags
+    , openFd
+    , setLock
+    , waitToSetLock
+    )
 import System.Posix.Files (setFileMode)
 
 data ManagedAuthKind
@@ -177,10 +191,23 @@ managedSecretsPath home =
         </> fromFilePath "credentials"
         </> fromFilePath "secrets.json"
 
+managedCredentialsLockPath :: OsPath -> OsPath
+managedCredentialsLockPath home =
+    home
+        </> fromFilePath ".haskell-agent"
+        </> fromFilePath "credentials"
+        </> fromFilePath "store.lock"
+
 loadManagedCredentials
     :: IO (Either Text [(ManagedCredential, ManagedSecret)])
 loadManagedCredentials = do
     home <- getHomeDirectory
+    withCredentialStoreLock home (loadManagedCredentialsUnlocked home)
+
+loadManagedCredentialsUnlocked
+    :: OsPath
+    -> IO (Either Text [(ManagedCredential, ManagedSecret)])
+loadManagedCredentialsUnlocked home = do
     metadataResult <- decodeFileOrEmpty
         (managedCredentialsPath home)
         (MetadataFile 1 [])
@@ -206,10 +233,14 @@ upsertManagedCredential
     :: ManagedCredential
     -> ManagedSecret
     -> IO (Either Text ())
-upsertManagedCredential credential secret = mutateStore \accounts secrets ->
-    ( upsertBy (.managedId) credential accounts
-    , upsertBy (.secretManagedId) secret secrets
-    )
+upsertManagedCredential credential secret
+    | credential.managedId /= secret.secretManagedId =
+        pure $ Left "managed credential metadata and secret ids do not match"
+    | otherwise =
+        mutateStore \accounts secrets ->
+            ( upsertBy (.managedId) credential accounts
+            , upsertBy (.secretManagedId) secret secrets
+            )
 
 setManagedCredentialEnabled :: Text -> Bool -> IO (Either Text ())
 setManagedCredentialEnabled credentialId enabled =
@@ -222,6 +253,23 @@ setManagedCredentialEnabled credentialId enabled =
             accounts
         , secrets
         )
+
+updateManagedCredentialSecret :: Text -> Text -> IO (Either Text ())
+updateManagedCredentialSecret credentialId payload =
+    mutateStoreChecked \accounts secrets ->
+        if any ((== credentialId) . (.secretManagedId)) secrets
+            then Right
+                ( accounts
+                , map updateSecret secrets
+                )
+            else Left
+                ("managed credential secret " <> credentialId
+                    <> " no longer exists")
+  where
+    updateSecret secret
+        | secret.secretManagedId == credentialId =
+            secret { secretPayload = payload }
+        | otherwise = secret
 
 deleteManagedCredential :: Text -> IO (Either Text ())
 deleteManagedCredential credentialId =
@@ -250,23 +298,66 @@ newManagedCredentialId provider accountId = do
 mutateStore
     :: ([ManagedCredential] -> [ManagedSecret] -> ([ManagedCredential], [ManagedSecret]))
     -> IO (Either Text ())
-mutateStore update = do
+mutateStore update =
+    mutateStoreChecked \accounts secrets ->
+        Right (update accounts secrets)
+
+mutateStoreChecked
+    :: ( [ManagedCredential]
+        -> [ManagedSecret]
+        -> Either Text ([ManagedCredential], [ManagedSecret])
+       )
+    -> IO (Either Text ())
+mutateStoreChecked update = do
     home <- getHomeDirectory
-    loaded <- loadManagedCredentials
-    case loaded of
-        Left err -> pure (Left err)
-        Right entries -> do
-            let (accounts, secrets) = unzip entries
-                (accounts', secrets') = update accounts secrets
-            writeResult <- writePrivateJson
-                (managedCredentialsPath home)
-                (MetadataFile 1 accounts')
-            case writeResult of
-                Left err -> pure (Left err)
-                Right () ->
-                    writePrivateJson
-                        (managedSecretsPath home)
-                        (SecretsFile 1 secrets')
+    withCredentialStoreLock home do
+        loaded <- loadManagedCredentialsUnlocked home
+        case loaded of
+            Left err -> pure (Left err)
+            Right entries -> do
+                let (accounts, secrets) = unzip entries
+                case update accounts secrets of
+                    Left err -> pure (Left err)
+                    Right (accounts', secrets') -> do
+                        writeResult <- writePrivateJson
+                            (managedCredentialsPath home)
+                            (MetadataFile 1 accounts')
+                        case writeResult of
+                            Left err -> pure (Left err)
+                            Right () ->
+                                writePrivateJson
+                                    (managedSecretsPath home)
+                                    (SecretsFile 1 secrets')
+
+withCredentialStoreLock :: OsPath -> IO a -> IO a
+withCredentialStoreLock home action =
+    withMVar credentialStoreProcessLock \_ ->
+        withCredentialStoreFileLock home action
+
+withCredentialStoreFileLock :: OsPath -> IO a -> IO a
+withCredentialStoreFileLock home action = do
+    let path = managedCredentialsLockPath home
+        directoryPath = takeDirectory path
+        lock = (WriteLock, AbsoluteSeek, 0, 0)
+        unlock = (Unlock, AbsoluteSeek, 0, 0)
+        flags = defaultFileFlags
+            { creat = Just 0o600
+            , cloexec = True
+            }
+    createDirectoryIfMissing True directoryPath
+    setFileMode (toFilePath directoryPath) 0o700
+    bracket
+        (openFd (toFilePath path) ReadWrite flags)
+        closeFd
+        (\fd ->
+            bracket_
+                (waitToSetLock fd lock)
+                (setLock fd unlock)
+                action)
+
+credentialStoreProcessLock :: MVar ()
+credentialStoreProcessLock = unsafePerformIO (newMVar ())
+{-# NOINLINE credentialStoreProcessLock #-}
 
 decodeFileOrEmpty :: Aeson.FromJSON value => OsPath -> value -> IO (Either Text value)
 decodeFileOrEmpty path empty = do

--- a/packages/agent-cli/test/Agent/CLI/AuthSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/AuthSpec.hs
@@ -1,8 +1,11 @@
 module Agent.CLI.AuthSpec (spec) where
 
 import Agent.CLI.Auth
+import Agent.CLI.CredentialStore
 import Agent.Error (ApiError(..), ErrorType(..))
+import Agent.OsPath (OsPath, fromFilePath, toFilePath)
 import Agent.OpenAI.Auth (AuthState(..))
+import qualified Agent.OpenAI.Auth as OpenAI
 import Agent.Provider
     ( AccountFailure(..)
     , Credential(..)
@@ -14,13 +17,24 @@ import Agent.Provider
 import Control.Exception.Safe (bracket)
 import Data.Aeson ((.=))
 import qualified Data.Aeson as Aeson
+import qualified Data.ByteString.Lazy as LBS
 import Data.IORef
 import Data.Maybe (isNothing)
 import Data.Text (Text)
 import qualified Data.Text as Text
+import qualified Data.Text.Encoding as TextEncoding
 import Data.Time.Calendar (fromGregorian)
 import Data.Time.Clock (UTCTime(..))
+import System.Directory
+    ( createDirectory
+    , createDirectoryIfMissing
+    , getTemporaryDirectory
+    , removeFile
+    , removePathForcibly
+    )
 import System.Environment (lookupEnv, setEnv, unsetEnv)
+import System.FilePath ((</>))
+import System.IO (hClose, openTempFile)
 import Test.Hspec
 
 spec :: Spec
@@ -50,6 +64,16 @@ spec = do
             case result of
                 Left err -> err `shouldBe` CredentialsExhausted retryAt
                 Right _ -> expectationFailure "expected exhausted auth"
+
+    describe "OpenAI account pools" do
+        it "loads every enabled managed account into one pool" $
+            withTempHome openAiManagedPoolTest
+        it "combines distinct managed and ~/.codex accounts" $
+            withTempHome openAiManagedAndFilePoolTest
+        it "deduplicates duplicate accounts with managed precedence" $
+            withTempHome openAiDeduplicationTest
+        it "does not let a disabled managed source shadow ~/.codex" $
+            withTempHome openAiDisabledSourceTest
 
     describe "openAIOAuthClientId" do
         it "uses the Codex public client id by default" do
@@ -91,6 +115,16 @@ spec = do
         it "rejects objects without an access token" do
             openaiAuthStateFromJson epoch (Aeson.encode (Aeson.object []))
                 `shouldSatisfy` isNothing
+
+    describe "openAiAuthStateChanged" do
+        it "detects access-token rotation without refresh-token rotation" do
+            openAiAuthStateChanged
+                (testAuthState "old-access" "same-refresh")
+                (testAuthState "new-access" "same-refresh")
+                `shouldBe` True
+        it "does not report an unchanged state" do
+            let state = testAuthState "access" "refresh"
+            openAiAuthStateChanged state state `shouldBe` False
 
     describe "grokCredentialFromAuthJson" do
         it "accepts a plain access_token object or a nested grok CLI map" do
@@ -147,6 +181,96 @@ spec = do
                         "reloaded credential is unchanged"
                 other -> expectationFailure ("expected AuthenticationError, got " <> show other)
 
+openAiManagedPoolTest :: OsPath -> IO ()
+openAiManagedPoolTest _ =
+    withCleanOpenAiEnv do
+        storeOpenAiAccount "managed-a" "acc-a" True "token-a"
+        storeOpenAiAccount "managed-b" "acc-b" True "token-b"
+        storeOpenAiAccount "managed-disabled" "acc-disabled" False "token-disabled"
+        loaded <- loadAuth (Just OpenAIProvider)
+        pool <- expectOpenAiPool loaded
+        OpenAI.allAccountIds pool `shouldReturn` ["acc-b", "acc-a"]
+
+openAiManagedAndFilePoolTest :: OsPath -> IO ()
+openAiManagedAndFilePoolTest home =
+    withCleanOpenAiEnv do
+        storeOpenAiAccount "managed-a" "acc-a" True "token-a"
+        writeCodexAuthFile home "acc-file" "token-file"
+        loaded <- loadAuth (Just OpenAIProvider)
+        pool <- expectOpenAiPool loaded
+        OpenAI.allAccountIds pool `shouldReturn` ["acc-a", "acc-file"]
+
+openAiDeduplicationTest :: OsPath -> IO ()
+openAiDeduplicationTest home =
+    withCleanOpenAiEnv do
+        storeOpenAiAccount "managed-a" "acc-a" True "managed-token"
+        writeCodexAuthFile home "acc-a" "file-token"
+        loaded <- loadAuth (Just OpenAIProvider)
+        pool <- expectOpenAiPool loaded
+        snapshots <- OpenAI.snapshotAccounts pool
+        map ((.accountId) . (.snapshotAuth)) snapshots `shouldBe` ["acc-a"]
+        map ((.accessToken) . (.snapshotAuth)) snapshots `shouldBe` ["managed-token"]
+
+openAiDisabledSourceTest :: OsPath -> IO ()
+openAiDisabledSourceTest home =
+    withCleanOpenAiEnv do
+        storeOpenAiAccount "managed-file" "acc-file" False "disabled-token"
+        writeCodexAuthFile home "acc-file" "file-token"
+        loaded <- loadAuth (Just OpenAIProvider)
+        pool <- expectOpenAiPool loaded
+        snapshots <- OpenAI.snapshotAccounts pool
+        map ((.accessToken) . (.snapshotAuth)) snapshots `shouldBe` ["file-token"]
+
+expectOpenAiPool :: Either Text LoadedAuth -> IO OpenAI.Pool
+expectOpenAiPool = \case
+    Left err -> expectationFailure (Text.unpack err) >> fail "missing pool"
+    Right loaded -> case loaded.loadedOpenAiPool of
+        Nothing -> expectationFailure "expected OpenAI account pool"
+            >> fail "missing pool"
+        Just pool -> pure pool
+
+storeOpenAiAccount :: Text -> Text -> Bool -> Text -> IO ()
+storeOpenAiAccount credentialId accountId enabled token =
+    upsertManagedCredential
+        (openAiMetadata credentialId accountId enabled)
+        (ManagedSecret credentialId (authJson accountId token))
+        `shouldReturn` Right ()
+
+openAiMetadata :: Text -> Text -> Bool -> ManagedCredential
+openAiMetadata credentialId accountId enabled = ManagedCredential
+    { managedId = credentialId
+    , managedProvider = OpenAIProvider
+    , managedAccountId = accountId
+    , managedLabel = "ChatGPT"
+    , managedBilling = ManagedSubscription
+    , managedAuthKind = ManagedOpenAIAuthJson
+    , managedEnabled = enabled
+    }
+
+writeCodexAuthFile :: OsPath -> Text -> Text -> IO ()
+writeCodexAuthFile home accountId token = do
+    let codexDirectory = toFilePath home </> ".codex"
+    createDirectoryIfMissing True codexDirectory
+    LBS.writeFile
+        (codexDirectory </> "auth.json")
+        (Aeson.encode (authValue accountId token))
+
+authJson :: Text -> Text -> Text
+authJson accountId token =
+    TextEncoding.decodeUtf8 (LBS.toStrict (Aeson.encode (authValue accountId token)))
+
+authValue :: Text -> Text -> Aeson.Value
+authValue accountId token = Aeson.object
+    [ "tokens" .= tokenObject accountId token
+    ]
+
+tokenObject :: Text -> Text -> Aeson.Value
+tokenObject accountId token = Aeson.object
+    [ "access_token" .= token
+    , "refresh_token" .= ("refresh-" <> accountId)
+    , "account_id" .= accountId
+    ]
+
 staleGrok :: Credential
 staleGrok = Credential
     { accessToken = "stale"
@@ -162,6 +286,10 @@ freshGrok = Credential
     , leaseId = Nothing
     , provider = XAIProvider
     }
+
+testAuthState :: Text -> Text -> AuthState
+testAuthState access refresh =
+    AuthState access refresh "acc-test" Nothing epoch
 
 epoch :: UTCTime
 epoch = UTCTime (fromGregorian 2026 1 1) 0
@@ -179,3 +307,30 @@ withEnv name value action =
     set = \case
         Just current -> setEnv name current
         Nothing -> unsetEnv name
+
+withCleanOpenAiEnv :: IO a -> IO a
+withCleanOpenAiEnv action =
+    foldr
+        (\name next -> withEnv name Nothing next)
+        action
+        [ "AGENT_BROKER_URL"
+        , "AGENT_BROKER_TOKEN"
+        , "CODEX_ACCESS_TOKEN"
+        , "CODEX_AUTH_JSON"
+        , "CODEX_ACCOUNT_ID"
+        , "CODEX_ID_TOKEN"
+        , "OPENAI_OAUTH_CLIENT_ID"
+        ]
+
+withTempHome :: (OsPath -> IO a) -> IO a
+withTempHome action =
+    bracket create removePathForcibly \home ->
+        withEnv "HOME" (Just home) (action (fromFilePath home))
+  where
+    create = do
+        temporary <- getTemporaryDirectory
+        (path, handle) <- openTempFile temporary "agent-auth"
+        hClose handle
+        removeFile path
+        createDirectory path
+        pure path

--- a/packages/agent-cli/test/Agent/CLI/CredentialStoreSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CredentialStoreSpec.hs
@@ -51,6 +51,35 @@ spec =
                     `shouldReturn` Right ()
                 loadManagedCredentials `shouldReturn` Right []
 
+        it "updates one secret without replacing sibling accounts" $
+            withTempHome \_ -> do
+                let sibling = account
+                        { managedId = "openrouter-sibling"
+                        , managedAccountId = "sibling"
+                        }
+                    siblingSecret = ManagedSecret
+                        { secretManagedId = sibling.managedId
+                        , secretPayload = "sibling-secret"
+                        }
+                upsertManagedCredential account secret `shouldReturn` Right ()
+                upsertManagedCredential sibling siblingSecret
+                    `shouldReturn` Right ()
+                updateManagedCredentialSecret account.managedId "rotated-secret"
+                    `shouldReturn` Right ()
+                loaded <- loadManagedCredentials
+                loaded `shouldBe` Right
+                    [ (sibling, siblingSecret)
+                    , (account, secret { secretPayload = "rotated-secret" })
+                    ]
+
+        it "rejects mismatched metadata and secret ids" $
+            withTempHome \_ ->
+                upsertManagedCredential
+                    account
+                    secret { secretManagedId = "different-id" }
+                    `shouldReturn` Left
+                        "managed credential metadata and secret ids do not match"
+
 account :: ManagedCredential
 account = ManagedCredential
     { managedId = "openrouter-test"

--- a/packages/agent-openai/src/Agent/OpenAI/Auth/JWT.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Auth/JWT.hs
@@ -25,9 +25,12 @@ refreshMarginSeconds = 10 * 60
 -- | Refresh only when the access-token JWT is about to expire.
 needsRefresh :: AuthState -> UTCTime -> Bool
 needsRefresh state now =
-    case parseJwtExp state.accessToken of
-        Nothing    -> True
-        Just expAt -> diffUTCTime expAt now < fromIntegral refreshMarginSeconds
+    if Text.null state.refreshToken
+        then False
+        else case parseJwtExp state.accessToken of
+            Nothing    -> True
+            Just expAt ->
+                diffUTCTime expAt now < fromIntegral refreshMarginSeconds
 
 -- | Parse the @exp@ claim from a JWT without signature verification.
 parseJwtExp :: Text -> Maybe UTCTime

--- a/packages/agent-openai/src/Agent/OpenAI/Credential.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Credential.hs
@@ -12,6 +12,7 @@ import Data.IORef
 import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
+import qualified Data.Text as Text
 import Data.Time.Clock (UTCTime, addUTCTime, diffUTCTime, getCurrentTime)
 
 poolTokenProvider :: Auth.Pool -> IO TokenProvider
@@ -27,16 +28,34 @@ poolTokenProvider pool = do
                             (max 1 <$> retryAfterSeconds)
                         acquireFromPool pool
                     AccountAuthenticationRejected -> do
-                        shouldRefresh <- takeAuthRecoverySlot
-                            authRecoveryAttempts
-                            credential.accountId
-                        if shouldRefresh
-                            then Auth.refreshAfterAuthFailure pool credential.accountId >>= \case
-                                Right state -> pure $ Right $ credentialFromAuthState state
-                                Left _ -> acquireFromPool pool
+                        state <- Auth.readAccountState pool credential.accountId
+                        if maybe False (Text.null . (.refreshToken)) state
+                            then rejectStaticCredential pool credential.accountId
                             else do
-                                Auth.reportAuthBroken pool credential.accountId
-                                acquireFromPool pool
+                                shouldRefresh <- takeAuthRecoverySlot
+                                    authRecoveryAttempts
+                                    credential.accountId
+                                if shouldRefresh
+                                    then Auth.refreshAfterAuthFailure pool credential.accountId >>= \case
+                                        Right refreshed ->
+                                            pure $ Right $
+                                                credentialFromAuthState refreshed
+                                        Left _ -> acquireFromPool pool
+                                    else do
+                                        Auth.reportAuthBroken pool credential.accountId
+                                        acquireFromPool pool
+
+rejectStaticCredential :: Auth.Pool -> Text -> IO (Either ApiError Credential)
+rejectStaticCredential pool accountId = do
+    accountIds <- Auth.allAccountIds pool
+    Auth.reportAuthBroken pool accountId
+    acquireFromPool pool >>= \case
+        Left CredentialsExhausted{}
+            | accountIds == [accountId] ->
+                pure $ Left $ ProviderError AuthenticationError
+                    "static bearer token was rejected"
+                    Nothing
+        result -> pure result
 
 takeAuthRecoverySlot
     :: IORef (Map.Map Text UTCTime)

--- a/packages/agent-openai/test/Agent/OpenAI/AuthSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/AuthSpec.hs
@@ -78,6 +78,14 @@ spec = do
             now <- getCurrentTime
             needsRefresh state now `shouldBe` True
 
+        it "does not refresh static bearer credentials" $ do
+            let state = (mkFreshAuth "acc")
+                    { accessToken = "not-a-jwt"
+                    , refreshToken = ""
+                    }
+            now <- getCurrentTime
+            needsRefresh state now `shouldBe` False
+
     describe "newPool + getAccessToken" $ do
         it "dispenses fresh tokens without calling the refresh callback" $ do
             callCounter <- newIORef (0 :: Int)

--- a/packages/agent-openai/test/Agent/OpenAI/CredentialSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/CredentialSpec.hs
@@ -185,6 +185,10 @@ spec = do
                 other -> expectationFailure ("expected CredentialsExhausted, got " <> show other)
             readIORef refreshCalls `shouldReturn` 1
 
+    describe "pooled static bearer credentials" do
+        it "report rejection as an authentication error" staticPoolAuthenticationTest
+        it "preserves another account's cooldown" staticPoolCooldownTest
+
     describe "staticBearerProvider" do
         it "returns the same bearer without an account id" do
             result <- getNextToken (staticBearerProvider "router-key") Nothing
@@ -290,6 +294,49 @@ spec = do
             recovered <- expectCredential =<< getNextToken provider Nothing
 
             recovered.accountId `shouldBe` "acc-a"
+
+staticPoolAuthenticationTest :: IO ()
+staticPoolAuthenticationTest = do
+    state <- freshAuth "acc-static"
+    pool <- newPool
+        [ state
+            { accessToken = "static-token"
+            , refreshToken = ""
+            }
+        ]
+        unexpectedRefresh
+    provider <- poolTokenProvider pool
+    initial <- expectCredential =<< getNextToken provider Nothing
+    rejected <- getNextToken provider
+        (failed initial AccountAuthenticationRejected)
+    case rejected of
+        Left (ProviderError AuthenticationError _ _) -> pure ()
+        other -> expectationFailure
+            ("expected AuthenticationError, got " <> show other)
+  where
+    unexpectedRefresh _ =
+        expectationFailure "static token must not refresh"
+            >> pure (Left (ConnectionError "unexpected refresh"))
+
+staticPoolCooldownTest :: IO ()
+staticPoolCooldownTest = do
+    staticState <- freshAuth "acc-static"
+    oauthState <- freshAuth "acc-oauth"
+    pool <- newPool
+        [ staticState { accessToken = "static-token", refreshToken = "" }
+        , oauthState
+        ]
+        (pure . Right)
+    Auth.reportRateLimit pool "acc-oauth" (Just 90)
+    provider <- poolTokenProvider pool
+    initial <- expectCredential =<< getNextToken provider Nothing
+    initial.accountId `shouldBe` "acc-static"
+    rejected <- getNextToken provider
+        (failed initial AccountAuthenticationRejected)
+    case rejected of
+        Left CredentialsExhausted{} -> pure ()
+        other -> expectationFailure
+            ("expected CredentialsExhausted, got " <> show other)
 
 localProvider
     :: [Text]


### PR DESCRIPTION
## Summary

- load every enabled managed OpenAI account into one account pool
- combine managed, environment, and `~/.codex/auth.json` sources without provider-wide shadowing
- deduplicate matching account IDs while preserving distinct fallback accounts
- route OAuth refresh persistence back to the correct managed or file source
- serialize credential-store mutations and token refreshes across threads and processes
- preserve static bearer authentication and mixed-pool cooldown semantics

## Motivation

On `office-builder`, the first enabled managed ChatGPT account had exhausted its weekly quota, while another usable account existed in `~/.codex/auth.json`. The previous loader selected only the first enabled managed credential and ignored all other OpenAI sources, causing an unnecessary cross-provider fallback.

After this change, an exhausted account is cooled down and the OpenAI token provider immediately tries another available OpenAI account before falling back to another provider.

## Safety

- validates managed metadata against the auth payload account ID
- detects refreshes performed by another worker through either access-token or refresh-token changes
- rejects account identity changes during refresh
- protects managed credential reads/writes with process and POSIX advisory locks
- protects each persisted OAuth source across reload/refresh/persist
- updates only the selected managed secret and preserves sibling metadata/accounts

## Tests

- `nix develop -c env GHCRTS= cabal test agent-openai-test agent-cli-test`
  - 148 OpenAI examples passed, 1 live functional example pending
  - 401 CLI examples passed
- live `repl` startup exercised in tmux after rebasing onto current `origin/master`
