### PR TITLE
fix(cli): humanize collaboration tool rendering

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -1005,6 +1005,7 @@ runSession options provider policy tools toolEnv planMode uiRuntimeRef prompt pe
     reasoningBuffer <- newIORef ""
     activityRef <- newIORef "Thinking…"
     startedAtRef <- newIORef Nothing
+    toolCallsRef <- newIORef Map.empty
     allowedToolsRef <- newIORef Set.empty
     lastAssistantRef <- newIORef Nothing
     modelRef <- newIORef =<< (currentModel <$> readIORef paramsRef)
@@ -1112,6 +1113,7 @@ runSession options provider policy tools toolEnv planMode uiRuntimeRef prompt pe
             , renderModelRef = modelRef
             , renderActivityRef = activityRef
             , renderStartedAt = startedAtRef
+            , renderToolCalls = toolCallsRef
             -- OSC 9;4 is ignored by terminals that do not implement it.
             -- Gate on the same TTY check as the in-pane spinner so pipes
             -- and redirected stderr stay clean.

--- a/packages/agent-cli/src/Agent/CLI/Render.hs
+++ b/packages/agent-cli/src/Agent/CLI/Render.hs
@@ -11,6 +11,7 @@ module Agent.CLI.Render
     , formatLoopErrorColored
     , formatSearchReplaceDiff
     , formatThinkingBlock
+    , formatToolOutput
     , formatToolStarted
     , formatTurnStatus
     , putTextLn
@@ -60,17 +61,27 @@ import Agent.CLI.Style
     , spinnerFrames
     , style
     )
-import Agent.JsonText (jsonTextFieldDefault)
+import Agent.JsonText (jsonTextField, jsonTextFieldDefault)
 import Agent.Loop (LoopError(..), LoopEvent(..), TurnOutput(..))
-import Agent.ToolDispatch (ToolCall(..), ToolCallResult(..))
+import Agent.ToolDispatch
+    ( ToolCall(..)
+    , ToolCallResult(..)
+    , canonicalToolName
+    )
 import Control.Concurrent (ThreadId, forkIO, killThread, threadDelay)
 import Control.Concurrent.MVar (MVar, withMVar)
 import Control.Exception.Safe (tryIO)
 import Control.Monad (unless, void, when)
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.Foldable as Foldable
 import Data.IORef
+import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe, isJust)
 import Data.Text (Text)
 import qualified Data.Text as Text
+import qualified Data.Text.Encoding as TextEncoding
 import qualified Data.Text.IO as Text
 import Data.Time.Clock (UTCTime, diffUTCTime, getCurrentTime)
 import System.Console.ANSI (ConsoleLayer(..), SGR(..))
@@ -95,6 +106,7 @@ data RenderConfig = RenderConfig
     , renderModelRef :: !(IORef Text)
     , renderActivityRef :: !(IORef Text)
     , renderStartedAt :: !(IORef (Maybe UTCTime))
+    , renderToolCalls :: !(IORef (Map.Map Text ToolCall))
     , renderNativeProgress :: !Bool -- ^ Ghostty / WT OSC 9;4; off in tests
     }
 
@@ -142,6 +154,7 @@ renderEventUnlocked config = \case
         writeIORef config.renderLiveActive False
         writeIORef config.renderReasoningBuffer ""
         writeIORef config.renderActivityRef "Thinking…"
+        writeIORef config.renderToolCalls Map.empty
         now <- getCurrentTime
         writeIORef config.renderStartedAt (Just now)
         startThinkingSpinnerUnlocked config
@@ -156,6 +169,7 @@ renderEventUnlocked config = \case
                 putTextLn config.renderStdout ""
     ToolStarted call -> do
         commitThinkingUnlocked config
+        modifyIORef' config.renderToolCalls (Map.insert call.callId call)
         writeIORef config.renderActivityRef (summarizeToolCall call)
         putTextLn config.renderStderr (formatToolStarted config.renderColor call)
         let extra = formatToolBody config.renderColor call
@@ -166,9 +180,14 @@ renderEventUnlocked config = \case
             if visible
                 then paintThinkingFrame config 0
                 else startThinkingSpinnerUnlocked config
-    ToolFinished result ->
+    ToolFinished result -> do
+        calls <- readIORef config.renderToolCalls
+        modifyIORef' config.renderToolCalls (Map.delete result.callId)
+        let output = maybe result.output
+                (`formatToolOutput` result.output)
+                (Map.lookup result.callId calls)
         putTextLn config.renderStderr
-            (roleToolOutput config.renderColor (truncateToolOutput result.output))
+            (roleToolOutput config.renderColor (truncateToolOutput output))
 
 -- | Style assistant markdown when color is enabled; otherwise return plain text.
 -- Color mode also paints each line with 'agentBackground'.
@@ -562,7 +581,7 @@ data ToolDetailKind
     | ToolDetailCommand
 
 toolChrome :: Text -> ToolChrome
-toolChrome = \case
+toolChrome name = case canonicalToolName name of
     "read_file" -> ToolChrome "Read" ToolDetailPath
     "list_dir" -> ToolChrome "Listed" ToolDetailPath
     "grep" -> ToolChrome "Searched" ToolDetailMuted
@@ -574,17 +593,17 @@ toolChrome = \case
     "get_task_output" -> ToolChrome "Read" ToolDetailMuted
     "kill_task" -> ToolChrome "Killed" ToolDetailMuted
     "task" -> ToolChrome "Ran" ToolDetailMuted
-    "spawn_agent" -> ToolChrome "Spawned" ToolDetailMuted
-    "wait_agent" -> ToolChrome "Waited" ToolDetailMuted
-    "send_message" -> ToolChrome "Sent" ToolDetailMuted
-    "followup_task" -> ToolChrome "Followed up" ToolDetailMuted
-    "list_agents" -> ToolChrome "Listed" ToolDetailMuted
+    "spawn_agent" -> ToolChrome "Spawned agent" ToolDetailMuted
+    "wait_agent" -> ToolChrome "Waited for agent updates" ToolDetailMuted
+    "send_message" -> ToolChrome "Sent message to" ToolDetailMuted
+    "followup_task" -> ToolChrome "Followed up with" ToolDetailMuted
+    "list_agents" -> ToolChrome "Listed agents" ToolDetailMuted
     "interrupt_agent" -> ToolChrome "Interrupted" ToolDetailMuted
     "update_plan" -> ToolChrome "Updated" ToolDetailMuted
     "enter_plan_mode" -> ToolChrome "Entered" ToolDetailMuted
     "exit_plan_mode" -> ToolChrome "Exited" ToolDetailMuted
     "ask_user_question" -> ToolChrome "Asked" ToolDetailMuted
-    name -> ToolChrome name ToolDetailMuted
+    _ -> ToolChrome name ToolDetailMuted
 
 toolVerb :: Text -> Text
 toolVerb name = case toolChrome name of
@@ -592,7 +611,7 @@ toolVerb name = case toolChrome name of
     ToolChrome verb _ -> verb
 
 formatToolBody :: Bool -> ToolCall -> Text
-formatToolBody color call = case call.name of
+formatToolBody color call = case canonicalToolName call.name of
     "search_replace" -> formatSearchReplaceDiff color call.arguments
     _ -> ""
 
@@ -631,7 +650,7 @@ renderToolPath color path =
         else styled
 
 toolDetail :: ToolCall -> Text
-toolDetail call = case call.name of
+toolDetail call = case canonicalToolName call.name of
     "read_file" -> jsonTextFieldDefault "target_file" call.arguments
     "list_dir" -> jsonTextFieldDefault "target_directory" call.arguments
     "search_replace" -> jsonTextFieldDefault "file_path" call.arguments
@@ -644,7 +663,64 @@ toolDetail call = case call.name of
     "enter_plan_mode" -> "enter"
     "exit_plan_mode" -> "exit"
     "ask_user_question" -> firstLine (jsonTextFieldDefault "question" call.arguments)
+    "spawn_agent" -> jsonTextFieldDefault "task_name" call.arguments
+    "send_message" -> jsonTextFieldDefault "target" call.arguments
+    "followup_task" -> jsonTextFieldDefault "target" call.arguments
+    "interrupt_agent" -> jsonTextFieldDefault "target" call.arguments
+    "list_agents" ->
+        maybe "" ("under " <>) (nonEmptyJsonText "path_prefix" call.arguments)
     _ -> ""
+
+-- | Turn structured collaboration results into compact terminal text. The
+-- provider still receives the original JSON result; this is display-only.
+formatToolOutput :: ToolCall -> Text -> Text
+formatToolOutput call output = case canonicalToolName call.name of
+    "spawn_agent" ->
+        maybe output ("Agent: " <>) (nonEmptyJsonText "task_name" output)
+    "wait_agent" ->
+        fromMaybe output (nonEmptyJsonText "message" output)
+    "list_agents" ->
+        fromMaybe output (formatAgentList output)
+    "interrupt_agent" ->
+        maybe output ("Previous status: " <>)
+            (nonEmptyJsonText "previous_status" output)
+    _ -> output
+
+nonEmptyJsonText :: Text -> Text -> Maybe Text
+nonEmptyJsonText key input = jsonTextField key input >>= \value ->
+    let stripped = Text.strip value
+    in if Text.null stripped then Nothing else Just stripped
+
+formatAgentList :: Text -> Maybe Text
+formatAgentList output = do
+    Aeson.Object object <- Aeson.decodeStrict (TextEncoding.encodeUtf8 output)
+    Aeson.Array agents <- KeyMap.lookup (Key.fromText "agents") object
+    let rows = mapMaybeAgent (Foldable.toList agents)
+    pure $ case rows of
+        [] -> "(no live agents)"
+        _ -> Text.intercalate "\n" rows
+  where
+    mapMaybeAgent = foldr
+        (\value rest ->
+            case value of
+                Aeson.Object agent ->
+                    case
+                        ( jsonObjectText "agent_name" agent
+                        , jsonObjectText "agent_status" agent
+                        ) of
+                        (Just name, Just status) ->
+                            (name <> " · " <> status) : rest
+                        (Just name, Nothing) -> name : rest
+                        _ -> rest
+                _ -> rest)
+        []
+
+jsonObjectText :: Text -> Aeson.Object -> Maybe Text
+jsonObjectText key object =
+    case KeyMap.lookup (Key.fromText key) object of
+        Just (Aeson.String value)
+            | not (Text.null (Text.strip value)) -> Just (Text.strip value)
+        _ -> Nothing
 
 firstPatchPath :: Text -> Maybe Text
 firstPatchPath patch =

--- a/packages/agent-cli/src/Agent/CLI/UI/Model.hs
+++ b/packages/agent-cli/src/Agent/CLI/UI/Model.hs
@@ -22,7 +22,7 @@ module Agent.CLI.UI.Model
     ) where
 
 import Agent.CLI.ReplMode (ReplMode(..))
-import Agent.CLI.Render (summarizeToolCall)
+import Agent.CLI.Render (formatToolOutput, summarizeToolCall)
 import Agent.Loop
     ( LoopEvent(..)
     , TokenUsage
@@ -31,6 +31,7 @@ import Agent.Loop
     )
 import Agent.ToolDispatch (ToolCall(..), ToolCallResult(..))
 import Data.Foldable (toList)
+import qualified Data.Map.Strict as Map
 import Data.Sequence (Seq)
 import qualified Data.Sequence as Seq
 import Data.Text (Text)
@@ -111,6 +112,7 @@ data UiState = UiState
     , uiNotice :: !(Maybe Text)
     , uiFrame :: !Int
     , uiTurnStartBlock :: !Int
+    , uiToolCalls :: !(Map.Map Text ToolCall)
     }
     deriving (Eq, Show)
 
@@ -163,6 +165,7 @@ initialUiState = UiState
     , uiNotice = Nothing
     , uiFrame = 0
     , uiTurnStartBlock = 0
+    , uiToolCalls = Map.empty
     }
 
 reduceUi :: UiEvent -> UiState -> UiState
@@ -257,6 +260,7 @@ reduceLoop event state = case event of
             , uiActivity = "Thinking…"
             , uiNotice = Nothing
             , uiTurnStartBlock = Seq.length state.uiBlocks
+            , uiToolCalls = Map.empty
             }
     ReasoningDelta delta ->
         appendOrExtend BlockThinking "Thought" delta BlockStreaming state
@@ -270,10 +274,20 @@ reduceLoop event state = case event of
         let kind = toolBlockKind call.name
         in appendBlock kind (summarizeToolCall call) "" ""
             BlockRunning (Just call.callId)
-            state { uiActivity = summarizeToolCall call }
+            state
+                { uiActivity = summarizeToolCall call
+                , uiToolCalls = Map.insert call.callId call state.uiToolCalls
+                }
     ToolFinished result ->
-        completeTool result state
-            { uiActivity = "Thinking…" }
+        let displayed = case Map.lookup result.callId state.uiToolCalls of
+                Nothing -> result
+                Just call ->
+                    result
+                        { output = formatToolOutput call result.output }
+        in completeTool displayed state
+            { uiActivity = "Thinking…"
+            , uiToolCalls = Map.delete result.callId state.uiToolCalls
+            }
     TurnFinished output ->
         let finalized = finalizeStreams state
             withFallback = case output.assistantText of

--- a/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
@@ -40,6 +40,20 @@ spec = do
             summarizeToolCall (customToolCall "c4" "apply_patch" patch)
                 `shouldBe` "Edited src/Foo.hs"
 
+        it "renders namespaced collaboration tools with useful details" do
+            summarizeToolCall
+                (functionToolCall "c5" "collaboration.spawn_agent"
+                    "{\"task_name\":\"reviewer\",\"message\":\"review this\"}")
+                `shouldBe` "Spawned agent reviewer"
+            summarizeToolCall
+                (functionToolCall "c6" "collaboration.send_message"
+                    "{\"target\":\"reviewer\",\"message\":\"status?\"}")
+                `shouldBe` "Sent message to reviewer"
+            summarizeToolCall
+                (functionToolCall "c7" "collaboration.wait_agent"
+                    "{\"timeout_ms\":30000}")
+                `shouldBe` "Waited for agent updates"
+
     describe "truncateToolOutput" do
         it "keeps the first line and marks empty output" do
             truncateToolOutput "Exit code: 0\nhello"
@@ -50,6 +64,26 @@ spec = do
         it "caps long multi-line output" do
             let out = Text.unlines (map (Text.pack . show) [1 :: Int .. 12])
             truncateToolOutput out `shouldSatisfy` Text.isInfixOf "… 4 more"
+
+    describe "formatToolOutput" do
+        it "renders structured collaboration results as readable text" do
+            let spawn = functionToolCall "c1" "collaboration.spawn_agent" "{}"
+                wait = functionToolCall "c2" "collaboration.wait_agent" "{}"
+                agents = functionToolCall "c3" "collaboration.list_agents" "{}"
+            formatToolOutput spawn
+                "{\"nickname\":null,\"task_name\":\"/root/reviewer\"}"
+                `shouldBe` "Agent: /root/reviewer"
+            formatToolOutput wait
+                "{\"message\":\"agent updates: reviewer=completed\",\"timed_out\":false}"
+                `shouldBe` "agent updates: reviewer=completed"
+            formatToolOutput agents
+                "{\"agents\":[{\"agent_name\":\"/root/reviewer\",\
+                \\"agent_id\":\"agent-1\",\"agent_status\":\"running\"}]}"
+                `shouldBe` "/root/reviewer · running"
+
+        it "falls back to the original output when JSON is malformed" do
+            let call = functionToolCall "c1" "collaboration.spawn_agent" "{}"
+            formatToolOutput call "not json" `shouldBe` "not json"
 
     describe "formatElapsed" do
         it "formats seconds and minutes" do
@@ -377,6 +411,7 @@ withRenderConfigNative showThinking color native action = do
     textBuffer <- newIORef ""
     markdownState <- newIORef emptyMarkdownStreamState
     liveActive <- newIORef False
+    toolCalls <- newIORef mempty
     lock <- newMVar ()
     tmp <- getTemporaryDirectory
     (path, handle) <- openTempFile tmp "agent-render-spec"
@@ -398,6 +433,7 @@ withRenderConfigNative showThinking color native action = do
                 , renderModelRef = modelRef
                 , renderActivityRef = activityRef
                 , renderStartedAt = startedAt
+                , renderToolCalls = toolCalls
                 , renderNativeProgress = native
                 }
         action config handle path

--- a/packages/agent-cli/test/Agent/CLI/UIModelSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/UIModelSpec.hs
@@ -53,6 +53,28 @@ spec = describe "fullscreen UI reducer" do
                 block.blockBody `shouldBe` "exit: 0\nclean"
             _ -> expectationFailure "expected one completed tool block"
 
+    it "formats collaboration result JSON for display" do
+        let call =
+                functionToolCall
+                    "c1"
+                    "collaboration.spawn_agent"
+                    "{\"task_name\":\"reviewer\",\"message\":\"review\"}"
+            result = ToolCallResult
+                { callId = "c1"
+                , output = "{\"task_name\":\"/root/reviewer\",\"nickname\":null}"
+                , callKind = FunctionCallKind
+                }
+            blocks = Foldable.toList $ (.uiBlocks) $ apply
+                [ UiLoop TurnStarted
+                , UiLoop (ToolStarted call)
+                , UiLoop (ToolFinished result)
+                ]
+        case blocks of
+            [block] -> do
+                block.blockTitle `shouldBe` "Spawned agent reviewer"
+                block.blockBody `shouldBe` "Agent: /root/reviewer"
+            _ -> expectationFailure "expected one collaboration tool block"
+
     it "only marks structured cancellation results as cancelled" do
         toolStateFor "exit: cancelled\npartial output"
             `shouldBe` BlockCancelled

--- a/packages/agent-core/src/Agent/ToolDispatch.hs
+++ b/packages/agent-core/src/Agent/ToolDispatch.hs
@@ -11,6 +11,7 @@ module Agent.ToolDispatch
     , noArgsTool
     , functionToolCall
     , customToolCall
+    , canonicalToolName
     , dispatchToolCall
     , dispatchToolHandler
     , canonicalToolName


### PR DESCRIPTION
## Summary
- normalize namespaced collaboration tool names before choosing CLI labels
- show useful collaboration call details such as task names and message targets
- render structured collaboration results as readable text in both linear and fullscreen UIs while preserving the original provider output

## Testing
- loaded `agent-cli:test:agent-cli-test` in the Nix GHCi environment
- `Agent.CLI.RenderSpec`: 34 examples, 0 failures
- `Agent.CLI.UIModelSpec`: 7 examples, 0 failures
- tmux smoke test: `collaboration.list_agents` rendered as `Listed agents` with `(no live agents)` rather than raw JSON