### PR TITLE
fix(cli): implement fullscreen scrolling

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -73,6 +73,8 @@ import qualified Graphics.Vty.CrossPlatform as Vty
 data Name
     = ConversationViewport
     | OverlayViewport
+    | ConversationBlock !BlockId
+    | ComposerArea
     | ComposerCursor
     | OverlayCursor
     deriving (Eq, Ord, Show)
@@ -235,7 +237,12 @@ runFullscreen runtime workerAction = do
             V.defaultConfig
                 { V.configPreferredColorMode = Just V.FullColor
                 }
-        buildVty = Vty.mkVty vtyConfig
+        buildVty = do
+            vty <- Vty.mkVty vtyConfig
+            let output = V.outputIface vty
+            when (V.supportsMode output V.Mouse) $
+                V.setMode output V.Mouse True
+            pure vty
     initialVty <- buildVty
     let
         initialState = AppState
@@ -526,7 +533,12 @@ drawBlock state block =
             if selected && state.uiFocus == FocusScrollback
                 then withAttr Theme.selectedAttr content
                 else content
-    in padBottom (Pad 1) framed
+        visibleFramed =
+            if selected && state.uiFocus == FocusScrollback
+                then visibleRegion (Location (0, 0)) (1, 1) framed
+                else framed
+    in clickable (ConversationBlock block.blockId) $
+        padBottom (Pad 1) visibleFramed
 
 accentBlock :: AttrName -> Text -> Text -> Widget Name
 accentBlock accent title body =
@@ -647,10 +659,11 @@ drawComposer state =
                     , renderDraft focused state
                     , vLimit 1 (fill ' ')
                     ]
-    in withAttr attr $
-        withBorderStyle unicodeRounded $
-            borderWithLabel (withAttr Theme.footerAttr (txt label)) $
-                editor
+    in clickable ComposerArea $
+        withAttr attr $
+            withBorderStyle unicodeRounded $
+                borderWithLabel (withAttr Theme.footerAttr (txt label)) $
+                    editor
 
 renderDraft :: Bool -> UiState -> Widget Name
 renderDraft focused state =
@@ -687,12 +700,12 @@ drawFooter state =
                     FocusPermission ->
                         "↑↓ select  │  Enter choose  │  Esc deny"
                     FocusScrollback ->
-                        "↑↓ blocks  │  ←→ fold  │  PgUp/PgDn scroll  │  Tab/Space prompt"
+                        "↑↓ blocks  │  Ctrl+J/K lines  │  PgUp/PgDn pages  │  wheel scroll  │  Tab/Space prompt"
                     FocusComposer
                         | state.appUi.uiRunning ->
-                            "Esc/Ctrl+C cancel  │  Tab scrollback"
+                            "Esc/Ctrl+C cancel  │  PgUp/PgDn or wheel scroll  │  Tab scrollback"
                         | otherwise ->
-                            "Enter send  │  Shift+Enter newline  │  Shift+Tab mode  │  Tab scrollback"
+                            "Enter send  │  Shift+Enter newline  │  PgUp/PgDn or wheel scroll  │  Tab scrollback"
 
 drawPermission :: PermissionOverlay -> Widget Name
 drawPermission permission =
@@ -872,6 +885,11 @@ handleEvent event = case event of
             result <- tryAny action
             atomically (putTMVar reply result)
             pure state
+    MouseDown name button _ _ -> do
+        state <- get
+        case (state.appChoice, state.appUi.uiPermission) of
+            (Nothing, Nothing) -> handleMouseDown name button
+            _ -> pure ()
     VtyEvent vtyEvent -> do
         state <- get
         case (state.appTextPrompt, state.appChoice, state.appUi.uiPermission) of
@@ -976,18 +994,60 @@ handleCtrlC = do
 
 handleNormalKey :: V.Event -> EventM Name AppState ()
 handleNormalKey event = do
-    state <- get
-    case state.appUi.uiFocus of
-        FocusScrollback -> handleScrollbackKey event
-        FocusComposer -> handleComposerKey event
-        FocusPermission -> pure ()
+    case event of
+        V.EvMouseDown _ _ V.BScrollUp _ ->
+            scrollConversationBy (-mouseScrollLines)
+        V.EvMouseDown _ _ V.BScrollDown _ ->
+            scrollConversationBy mouseScrollLines
+        _ -> do
+            state <- get
+            case state.appUi.uiFocus of
+                FocusScrollback -> handleScrollbackKey event
+                FocusComposer -> handleComposerKey event
+                FocusPermission -> pure ()
+
+handleMouseDown :: Name -> V.Button -> EventM Name AppState ()
+handleMouseDown name button =
+    case button of
+        V.BScrollUp -> scrollConversationBy (-mouseScrollLines)
+        V.BScrollDown -> scrollConversationBy mouseScrollLines
+        V.BLeft -> case name of
+            ConversationBlock ident ->
+                modify' \state ->
+                    state
+                        { appUi =
+                            reduceUi
+                                (UiFocusChanged FocusScrollback)
+                                (reduceUi (UiSelectBlock ident) state.appUi)
+                        }
+            ComposerArea ->
+                modify' \state ->
+                    state
+                        { appUi =
+                            reduceUi
+                                (UiFocusChanged FocusComposer)
+                                state.appUi
+                        }
+            _ -> pure ()
+        _ -> pure ()
+
+mouseScrollLines :: Int
+mouseScrollLines = 3
 
 handleScrollbackKey :: V.Event -> EventM Name AppState ()
 handleScrollbackKey = \case
-    V.EvKey V.KUp [] -> moveBlock (-1) >> vScrollBy scroll (-2)
-    V.EvKey V.KDown [] -> moveBlock 1 >> vScrollBy scroll 2
-    V.EvKey V.KPageUp [] -> leaveFollow >> vScrollPage scroll Up
-    V.EvKey V.KPageDown [] -> leaveFollow >> vScrollPage scroll Down
+    V.EvKey V.KUp [] -> moveBlock (-1)
+    V.EvKey V.KDown [] -> moveBlock 1
+    V.EvKey V.KPageUp [] -> scrollConversationPage Up
+    V.EvKey V.KPageDown [] -> scrollConversationPage Down
+    V.EvKey (V.KChar 'k') modifiers
+        | V.MCtrl `elem` modifiers -> scrollConversationBy (-1)
+    V.EvKey (V.KChar 'j') modifiers
+        | V.MCtrl `elem` modifiers -> scrollConversationBy 1
+    V.EvKey (V.KChar 'u') modifiers
+        | V.MCtrl `elem` modifiers -> scrollConversationHalfPage Up
+    V.EvKey (V.KChar 'd') modifiers
+        | V.MCtrl `elem` modifiers -> scrollConversationHalfPage Down
     V.EvKey V.KHome [] -> leaveFollow >> vScrollToBeginning scroll
     V.EvKey V.KEnd [] -> resumeFollow
     V.EvKey (V.KChar 'g') [] -> leaveFollow >> vScrollToBeginning scroll
@@ -1149,9 +1209,9 @@ handleComposerKey event = do
         V.EvKey V.KEnd [] ->
             setCursor (lineEndCursor ui.uiDraft ui.uiCursor)
         V.EvKey V.KPageUp [] ->
-            vScrollPage (viewportScroll ConversationViewport) Up
+            scrollConversationPage Up
         V.EvKey V.KPageDown [] ->
-            vScrollPage (viewportScroll ConversationViewport) Down
+            scrollConversationPage Down
         V.EvKey (V.KChar character) [] ->
             insertText (Text.singleton character)
         V.EvPaste bytes -> do
@@ -1408,6 +1468,52 @@ handleComposerKey event = do
                 menu.slashMenuReplaceStart
                     + Text.length suggestion.slashSuggestionReplacement
         modifyUiResetSlash (UiSetDraft next cursor)
+
+scrollConversationPage :: Direction -> EventM Name AppState ()
+scrollConversationPage direction = do
+    height <- conversationViewportHeight
+    scrollConversationBy $
+        case direction of
+            Up -> negate height
+            Down -> height
+
+scrollConversationHalfPage :: Direction -> EventM Name AppState ()
+scrollConversationHalfPage direction = do
+    height <- conversationViewportHeight
+    let amount = max 1 (height `div` 2)
+    scrollConversationBy $
+        case direction of
+            Up -> negate amount
+            Down -> amount
+
+conversationViewportHeight :: EventM Name AppState Int
+conversationViewportHeight =
+    lookupViewport ConversationViewport >>= \case
+        Just (VP _ _ (_, height) _) -> pure (max 1 height)
+        Nothing -> pure 1
+
+scrollConversationBy :: Int -> EventM Name AppState ()
+scrollConversationBy amount
+    | amount == 0 = pure ()
+    | amount < 0 = do
+        setConversationFollow False
+        vScrollBy scroll amount
+    | otherwise =
+        lookupViewport ConversationViewport >>= \case
+            Just (VP _ top (_, height) (_, contentHeight))
+                | top + height + amount >= contentHeight -> do
+                    setConversationFollow True
+                    vScrollToEnd scroll
+            _ -> do
+                setConversationFollow False
+                vScrollBy scroll amount
+  where
+    scroll = viewportScroll ConversationViewport
+
+setConversationFollow :: Bool -> EventM Name AppState ()
+setConversationFollow follow =
+    modify' \state ->
+        state { appUi = reduceUi (UiSetFollow follow) state.appUi }
 
 decodePaste :: ByteString -> Text
 decodePaste =

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -533,12 +533,8 @@ drawBlock state block =
             if selected && state.uiFocus == FocusScrollback
                 then withAttr Theme.selectedAttr content
                 else content
-        visibleFramed =
-            if selected && state.uiFocus == FocusScrollback
-                then visibleRegion (Location (0, 0)) (1, 1) framed
-                else framed
     in clickable (ConversationBlock block.blockId) $
-        padBottom (Pad 1) visibleFramed
+        padBottom (Pad 1) framed
 
 accentBlock :: AttrName -> Text -> Text -> Widget Name
 accentBlock accent title body =
@@ -887,8 +883,11 @@ handleEvent event = case event of
             pure state
     MouseDown name button _ _ -> do
         state <- get
-        case (state.appChoice, state.appUi.uiPermission) of
-            (Nothing, Nothing) -> handleMouseDown name button
+        case ( state.appTextPrompt
+             , state.appChoice
+             , state.appUi.uiPermission
+             ) of
+            (Nothing, Nothing, Nothing) -> handleMouseDown name button
             _ -> pure ()
     VtyEvent vtyEvent -> do
         state <- get
@@ -1062,9 +1061,13 @@ handleScrollbackKey = \case
     _ -> pure ()
   where
     scroll = viewportScroll ConversationViewport
-    moveBlock delta =
+    moveBlock delta = do
         modify' \state ->
             state { appUi = reduceUi (UiMoveSelection delta) state.appUi }
+        state <- get
+        case state.appUi.uiSelectedBlock of
+            Just ident -> makeVisible (ConversationBlock ident)
+            Nothing -> pure ()
     toggle =
         modify' \state ->
             state { appUi = reduceUi UiToggleSelected state.appUi }

--- a/packages/agent-cli/src/Agent/CLI/UI/Model.hs
+++ b/packages/agent-cli/src/Agent/CLI/UI/Model.hs
@@ -130,6 +130,7 @@ data UiEvent
     | UiSetRepository !Text !Text
     | UiSetNotice !(Maybe Text)
     | UiMoveSelection !Int
+    | UiSelectBlock !BlockId
     | UiToggleSelected
     | UiFocusChanged !Focus
     | UiPermissionShown !Text
@@ -205,6 +206,8 @@ reduceUi event state = case event of
         state { uiNotice = notice }
     UiMoveSelection delta ->
         moveSelection delta state
+    UiSelectBlock ident ->
+        selectBlock ident state
     UiToggleSelected ->
         toggleSelected state
     UiFocusChanged focus ->
@@ -251,7 +254,15 @@ reduceUi event state = case event of
             , uiTurnStartBlock = 0
             }
     UiSetFollow follow ->
-        state { uiFollow = follow }
+        state
+            { uiFollow = follow
+            , uiSelectedBlock =
+                if follow
+                    then (.blockId) <$> Seq.lookup
+                        (Seq.length state.uiBlocks - 1)
+                        state.uiBlocks
+                    else state.uiSelectedBlock
+            }
     UiTurnEnded terminalState ->
         finalizeTurn terminalState state
     UiTick ->
@@ -434,6 +445,16 @@ moveSelection delta state =
             in state
                 { uiSelectedBlock = Just (blocks !! next).blockId
                 , uiFollow = next == length blocks - 1
+                }
+
+selectBlock :: BlockId -> UiState -> UiState
+selectBlock ident state =
+    case Seq.findIndexL ((== ident) . (.blockId)) state.uiBlocks of
+        Nothing -> state
+        Just index ->
+            state
+                { uiSelectedBlock = Just ident
+                , uiFollow = index == Seq.length state.uiBlocks - 1
                 }
 
 selectedBlockIndex :: UiState -> Int

--- a/packages/agent-cli/test/Agent/CLI/UIModelSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/UIModelSpec.hs
@@ -134,6 +134,32 @@ spec = describe "fullscreen UI reducer" do
             block : _ -> block.blockExpanded `shouldBe` False
             [] -> expectationFailure "expected selected blocks"
 
+    it "selects a clicked block and follows only at the tail" do
+        let populated =
+                apply
+                    [ UiUserSubmitted "one"
+                    , UiUserSubmitted "two"
+                    , UiUserSubmitted "three"
+                    ]
+            blocks = Foldable.toList populated.uiBlocks
+        case blocks of
+            first : _ : lastBlock : [] -> do
+                let firstSelected =
+                        reduceUi (UiSelectBlock first.blockId) populated
+                    lastSelected =
+                        reduceUi (UiSelectBlock lastBlock.blockId) firstSelected
+                firstSelected.uiSelectedBlock
+                    `shouldBe` Just first.blockId
+                firstSelected.uiFollow `shouldBe` False
+                lastSelected.uiSelectedBlock
+                    `shouldBe` Just lastBlock.blockId
+                lastSelected.uiFollow `shouldBe` True
+                let resumed = reduceUi (UiSetFollow True) firstSelected
+                resumed.uiSelectedBlock
+                    `shouldBe` Just lastBlock.blockId
+                resumed.uiFollow `shouldBe` True
+            _ -> expectationFailure "expected three blocks"
+
     it "deletes the previous word for command/option-backspace" do
         deleteWordBefore "hello brave world" 17
             `shouldBe` ("hello brave ", 12)


### PR DESCRIPTION
## Summary

- add Grok Build-style page, half-page, line, and mouse-wheel scrolling to the retained fullscreen TUI
- pause auto-follow during manual scrolling and resume it when returning to the transcript tail
- keep selected blocks visible and support click-to-select / click-to-focus interactions
- preserve composer focus and draft contents while scrolling with Page Up or Page Down

## Verification

- `nix develop -c cabal repl agent-cli:agent-cli-test` — 406 examples, 0 failures
- tmux TTY smoke test covering Page Up, mouse wheel, click-to-focus, and End-to-follow
