### PR TITLE
Fix development REPL worktree isolation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,7 +87,7 @@ When changing the CLI UI (prompt, colors, chrome, keybindings, paste, approval p
 
 - Exit the agent (`:q` or Ctrl-D) before `:r`; a live stdin/WebSocket session blocks GHCi.
 - `repl` / `devMain` creates a new worktree on first open when not already under `~/.haskell-agent/worktrees`. `:reload` resumes the same session (and cwd). Manual `run` still needs `withArgs ["--worktree"]` (or `--resume` / `--cwd`) if you want a worktree.
-- `run` calls `setCurrentDirectory`, so later runs in the same GHCi process inherit that cwd.
+- The development entry point restores GHCi's original cwd when the agent exits, so a later fresh run does not silently reuse the previous worktree.
 - `cabal repl agent-cli:exe:agent-cli` + `:main` looks convenient but only interprets `Main.hs` and does **not** reload library source changes.
 - Use `ghcid` for typecheck-on-save; keep `cabal repl` + `withArgs ... run` for running the live agent.
 - Prefer `repl` when you want automatic `:reload` + session resume instead of the manual `:q` / `:r` / `run` loop.

--- a/README.md
+++ b/README.md
@@ -49,9 +49,10 @@ From `nix develop`, `repl` opens `cabal repl lib:agent-cli` (via expect) and
 starts the agent with a GHCi `:cmd` loop. Development REPL sessions default to
 OpenAI `gpt-5.6-sol` with `--yolo`. On first open it also passes `--worktree`
 when the cwd is not already under `~/.haskell-agent/worktrees`. Inside the agent
-REPL, `:reload` writes `~/.haskell-agent/dev-resume`, returns to GHCi, reloads
-modules, and resumes the same session automatically. `:q` exits the agent back
-to `ghci>`.
+REPL, `:reload` returns to GHCi, reloads modules, and resumes the same session
+automatically through that REPL's GHCi continuation. Concurrent development
+REPLs therefore keep independent reload state. `:q` exits the agent back to
+`ghci>`.
 
 Without `-p` / `--prompt-file` the CLI starts a REPL. Credentials come from
 `~/.grok/auth.json` / `GROK_ACCESS_TOKEN` (xAI), `~/.codex/auth.json` /

--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -6,6 +6,7 @@ module Agent.CLI
     , cycleReplInteraction
     , devArgs
     , devMain
+    , devMainResume
     , formatReplStatusLine
     , formatTokenUsage
     , run
@@ -353,26 +354,30 @@ import System.Timeout (timeout)
 -- | How the GHCi-driven agent REPL finished.
 data DevResult
     = DevQuit
-    | DevReload
+    | DevReload Text
     deriving (Eq, Show)
 
 data RunResult
     = RunQuit
-    | RunReload
+    | RunReload Text
     | RunSwitchProvider ProviderTransition
     | RunProviderStartFailed ApiError
     | RunResumeSession Text
       -- ^ Persisted session id. Consumed after the current provider-specific
       -- backend shuts down before starting the selected session.
 
--- | GHCi @:cmd@ helper: on 'DevReload', reload modules and re-enter 'devMain'.
+-- | GHCi @:cmd@ helper: on 'DevReload', reload modules and resume that exact
+-- session. Keeping the id in the generated GHCi command avoids a shared
+-- cross-process resume pointer when several development REPLs are open.
 afterDev :: DevResult -> IO String
 afterDev = \case
     DevQuit -> pure ""
-    DevReload -> pure $ unlines
+    DevReload sessionId -> pure $ unlines
         [ ":reload"
         , ":module +Agent.CLI"
-        , ":cmd afterDev =<< devMain"
+        , ":cmd afterDev =<< devMainResume (Just "
+            <> show (Text.unpack sessionId)
+            <> ")"
         ]
 
 -- | Arguments used by the development @repl@ launcher.
@@ -392,14 +397,16 @@ devArgs resumeId underWorktree = case resumeId of
         ]
             <> ["--worktree" | not underWorktree]
 
--- | Start the agent from GHCi (@repl@). Resumes the session written by @:reload@.
--- On first open (no resume pointer), selects OpenAI/gpt-5.6-sol with yolo
--- enabled and passes @--worktree@ unless the cwd is already under
--- @~/.haskell-agent/worktrees@.
+-- | Start a fresh agent from GHCi (@repl@).
 devMain :: IO DevResult
-devMain = do
+devMain = devMainResume Nothing
+
+-- | Start or resume the GHCi-driven agent. 'afterDev' embeds the session id in
+-- the next @:cmd@ invocation, so concurrent REPLs cannot consume each other's
+-- reload state.
+devMainResume :: Maybe Text -> IO DevResult
+devMainResume resumeId = do
     home <- getHomeDirectory
-    resumeId <- readDevResumePointer home
     underWorktree <- case resumeId of
         Just _ -> pure True
         Nothing -> do
@@ -408,9 +415,7 @@ devMain = do
             pure (isUnderWorktreeRoot root cwd)
     let args = devArgs resumeId underWorktree
     case parseArgs args of
-        Left err -> do
-            clearDevResumePointer home
-            die err
+        Left err -> die err
         Right ShowHelp -> putStr usage >> pure DevQuit
         Right ShowVersion -> putStrLn "agent-cli 0.1.0.0" >> pure DevQuit
         Right Login -> do
@@ -422,8 +427,8 @@ devMain = do
         Right (RunAgent options) -> do
             result <- runAgentWithRestarts options
             case result of
-                DevQuit -> clearDevResumePointer home >> pure DevQuit
-                DevReload -> pure DevReload
+                DevQuit -> pure DevQuit
+                DevReload sessionId -> pure (DevReload sessionId)
 
 run :: IO ()
 run = do
@@ -441,16 +446,16 @@ run = do
             result <- runAgentWithRestarts options
             case result of
                 DevQuit -> pure ()
-                DevReload -> do
-                    home <- getHomeDirectory
-                    clearDevResumePointer home
+                DevReload _ ->
                     die ":reload is only available under `repl` (nix develop)"
 
 -- | Tear down and rebuild provider-specific auth, tools, prompt, and transport.
 -- Automatic transitions carry the exact failed turn in memory and commit
 -- persisted provider metadata only after the replacement backend succeeds.
 runAgentWithRestarts :: CliOptions -> IO DevResult
-runAgentWithRestarts options = go options Nothing
+runAgentWithRestarts options = do
+    originalCwd <- getCurrentDirectory
+    go options Nothing `finally` setCurrentDirectory originalCwd
   where
     go current transition =
         runAgent current transition >>= \case
@@ -481,7 +486,7 @@ runAgentWithRestarts options = go options Nothing
                                     pure DevQuit
                     _ -> pure DevQuit
             RunQuit -> pure DevQuit
-            RunReload -> pure DevReload
+            RunReload sessionId -> pure (DevReload sessionId)
 
 runListSessions :: IO ()
 runListSessions = do
@@ -2453,7 +2458,6 @@ requestReload
     :: Persistence
     -> IO RunResult
 requestReload persist = do
-    home <- getHomeDirectory
     color <- resolveColor stderr
     case persist of
         PersistenceDisabled -> do
@@ -2462,11 +2466,10 @@ requestReload persist = do
             pure RunQuit
         PersistenceEnabled slotRef -> do
             handle <- ensureSession slotRef
-            writeDevResumePointer home handle.sessionMeta.metaId
             putTextLn stderr
                 (roleMuted color
                     (glyphSession <> "reloading; session " <> handle.sessionMeta.metaId))
-            pure RunReload
+            pure (RunReload handle.sessionMeta.metaId)
 
 enterPlanFromSlash :: SessionEnv -> Maybe Text -> IO (Maybe ProviderTransition)
 enterPlanFromSlash env@SessionEnv

--- a/packages/agent-cli/src/Agent/CLI/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session.hs
@@ -23,10 +23,6 @@ module Agent.CLI.Session
     , sessionTitleTurnCountFromSlot
     , writeSessionMeta
     , ensureSession
-    , devResumePointerPath
-    , writeDevResumePointer
-    , readDevResumePointer
-    , clearDevResumePointer
     , resumeHint
     , sessionUsageFromTurns
     ) where
@@ -71,7 +67,6 @@ import System.Directory.OsPath
     , doesDirectoryExist
     , doesFileExist
     , listDirectory
-    , removeFile
     )
 import System.OsPath ((</>))
 import System.Posix.Files (setFileMode)
@@ -83,37 +78,6 @@ sessionSchemaVersion = 1
 sessionsRoot :: OsPath -> OsPath
 sessionsRoot home =
     home </> fromFilePath ".haskell-agent" </> fromFilePath "sessions"
-
--- | Pointer written before a GHCi @:reload@ so @devMain@ can resume.
-devResumePointerPath :: OsPath -> OsPath
-devResumePointerPath home =
-    home </> fromFilePath ".haskell-agent" </> fromFilePath "dev-resume"
-
-writeDevResumePointer :: OsPath -> Text -> IO ()
-writeDevResumePointer home sessionId = do
-    let root = home </> fromFilePath ".haskell-agent"
-        path = devResumePointerPath home
-    ensurePrivateDir root
-    writeLazyFileAtomically
-        path
-        0o600
-        (LBS.fromStrict (Text.encodeUtf8 (sessionId <> "\n")))
-
-readDevResumePointer :: OsPath -> IO (Maybe Text)
-readDevResumePointer home = do
-    let path = devResumePointerPath home
-    exists <- doesFileExist path
-    if not exists
-        then pure Nothing
-        else do
-            raw <- Text.strip <$> retryOnFileBusy (Text.readFile (toFilePath path))
-            pure (if Text.null raw then Nothing else Just raw)
-
-clearDevResumePointer :: OsPath -> IO ()
-clearDevResumePointer home = do
-    let path = devResumePointerPath home
-    _ <- tryIO (removeFile path)
-    pure ()
 
 data SessionMeta = SessionMeta
     { metaVersion :: !Int

--- a/packages/agent-cli/test/Agent/CLI/ReplStatusSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ReplStatusSpec.hs
@@ -1,7 +1,9 @@
 module Agent.CLI.ReplStatusSpec (spec) where
 
 import Agent.CLI
-    ( applyReplMode
+    ( DevResult(..)
+    , afterDev
+    , applyReplMode
     , cycleReplInteraction
     , devArgs
     , formatReplStatusLine
@@ -48,6 +50,15 @@ spec = do
                     [ "--yolo"
                     , "--resume", "2026-08-20-abcd1234"
                     ]
+
+        it "carries reload state in the GHCi continuation" do
+            afterDev (DevReload "2026-08-20-abcd1234")
+                `shouldReturn`
+                    unlines
+                        [ ":reload"
+                        , ":module +Agent.CLI"
+                        , ":cmd afterDev =<< devMainResume (Just \"2026-08-20-abcd1234\")"
+                        ]
 
     describe "formatReplStatusLine" do
         it "shows model, effort, and interaction mode" do

--- a/packages/agent-cli/test/Agent/CLI/SessionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SessionSpec.hs
@@ -30,17 +30,6 @@ spec = describe "Agent.CLI.Session" do
             sessionsRoot (fromFilePath "/home/marc")
                 `shouldBe` fromFilePath "/home/marc/.haskell-agent/sessions"
 
-    describe "dev resume pointer" do
-        it "round-trips and clears under ~/.haskell-agent/dev-resume" $
-            withTempDir "agent-home-" \home -> do
-                readDevResumePointer home `shouldReturn` Nothing
-                writeDevResumePointer home "2026-08-20-abcd1234"
-                modeOf (devResumePointerPath home) `shouldReturn` 0o600
-                readDevResumePointer home
-                    `shouldReturn` Just "2026-08-20-abcd1234"
-                clearDevResumePointer home
-                readDevResumePointer home `shouldReturn` Nothing
-
     describe "sessionTitleFromPrompt" do
         it "collapses whitespace and keeps the first ten words" do
             sessionTitleFromPrompt "  hello   world  " `shouldBe` "hello world"


### PR DESCRIPTION
## Summary

- carry `:reload` session identity in the originating GHCi continuation instead of the shared `~/.haskell-agent/dev-resume` file
- restore GHCi's original working directory when an agent run exits
- document the isolated reload behavior and add a regression test for the generated continuation

## Why

Multiple concurrent development REPLs shared one resume-pointer file. One REPL could consume or clear another REPL's session ID and resume into its worktree. The process-wide cwd also remained changed after returning to GHCi, allowing later fresh runs to inherit an old worktree.

## Verification

- `nix develop -c cabal repl agent-cli:lib:agent-cli` (49 modules loaded)
- full `agent-cli` test suite through GHCi: 405 examples, 0 failures
- tmux TTY smoke test: `:reload` resumed the same session and `:q` restored the original GHCi cwd
