### PR TITLE
fix(cli): serialize output with the composer

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -1375,7 +1375,10 @@ replWithDraft env@SessionEnv
                     , promptAttachments = length pendingAttachments
                     }
                 draft
-        Nothing -> do
+        Nothing -> withMVar render.renderLock \_ -> do
+            -- The inline editor redraws its ANSI frame with several writes.
+            -- Keep the renderer out for the complete prompt lifetime so a
+            -- late tool event cannot be spliced into the composer row.
             when terminal.terminalSemanticPrompts $
                 emitTerminalSequence terminal stdout osc133PromptStart
             termCols <- fmap snd <$> getTerminalSize


### PR DESCRIPTION
## Summary

- hold the CLI render lock for the complete minimal-mode prompt lifetime
- prevent late tool or streamed output from interleaving with multi-write ANSI composer redraws
- keep prompt start/end terminal sequences inside the same serialized section

## Validation

- loaded `agent-cli:lib:agent-cli` successfully with `nix develop -c cabal repl`
- exercised minimal-mode editing, command submission, redraw, and exit in a real tmux TTY
- `git diff --check`