### PR TITLE
Keep interactive prompts in fullscreen TUI

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -176,6 +176,8 @@ import Agent.CLI.TUI.App
     , readFullscreenLine
     , requestFullscreenPermission
     , requestFullscreenChoice
+    , requestFullscreenChoiceWithBody
+    , requestFullscreenText
     , runFullscreen
     , withFullscreenSuspended
     )
@@ -287,7 +289,8 @@ import Agent.Tools.MultiAgents
     , SubagentWorktree(..)
     )
 import Agent.Tools.PlanMode
-    ( PlanModeEnv(..)
+    ( PlanDecision(..)
+    , PlanModeEnv(..)
     , PlanModeHooks(..)
     , PlanModeState(..)
     , activatePlanMode
@@ -322,6 +325,7 @@ import qualified Data.ByteString as BS
 import Data.IORef
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
+import Data.List (findIndex)
 import Data.Maybe (fromMaybe, isJust)
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -1614,8 +1618,8 @@ replWithDraft env@SessionEnv
                                 entries <- viewport.viewportEntries
                                 selected <- readIORef viewport.viewportSelected
                                 color <- resolveColor stderr
-                                legacy
-                                    (pickAgentViewport color selected entries) >>= \case
+                                pickAgentChoice
+                                    fullscreen color selected entries >>= \case
                                     Nothing -> pure ()
                                     Just target ->
                                         writeIORef viewport.viewportSelected target
@@ -1769,10 +1773,11 @@ replWithDraft env@SessionEnv
                                 pure (RunSwitchProvider providerSwitch)
                             Nothing -> continue
                     ReplBtw question -> do
-                        color <- resolveColor stdout
-                        putTextLn stdout
-                            (roleMuted color (glyphSession <> "btw · asking…"))
-                        result <- legacy $
+                        displayInfo "btw · asking…" do
+                            color <- resolveColor stdout
+                            putTextLn stdout
+                                (roleMuted color (glyphSession <> "btw · asking…"))
+                        result <-
                             runBtwWithCancel
                                 (\cancel action ->
                                     withTurnCancel interrupt cancel $
@@ -1782,15 +1787,19 @@ replWithDraft env@SessionEnv
                                 transcriptRef
                                 question
                         case result of
-                            Left err -> do
-                                errorColor <- resolveColor stderr
-                                putTextLn stderr
-                                    (roleError errorColor (formatBtwError err))
+                            Left err ->
+                                displayError (formatBtwError err) do
+                                    errorColor <- resolveColor stderr
+                                    putTextLn stderr
+                                        (roleError errorColor (formatBtwError err))
                             Right answer ->
-                                putTextLn stdout (renderAssistantText color answer)
+                                displayInfo answer do
+                                    color <- resolveColor stdout
+                                    putTextLn stdout
+                                        (renderAssistantText color answer)
                         continue
                     ReplResume maybeId -> do
-                        legacy (handleResume maybeId persist) >>= \case
+                        handleResume fullscreen maybeId persist >>= \case
                             Nothing -> continue
                             Just result -> pure result
                     ReplClear -> do
@@ -2008,9 +2017,14 @@ replWithDraft env@SessionEnv
                         legacy (runLoginManager color)
                         continue
                     ReplUsage -> do
-                        legacy
-                            (showAccountUsage
-                                provider tokenProvider openAiPool)
+                        case fullscreen of
+                            Nothing ->
+                                showAccountUsage
+                                    provider tokenProvider openAiPool
+                            Just runtime ->
+                                accountUsageText
+                                    False provider tokenProvider openAiPool
+                                    >>= emitUiEvent runtime . UiSystemMessage
                         continue
                     ReplReloadAuth -> do
                         reloadAuth provider tokenProvider
@@ -2081,23 +2095,89 @@ fullscreenAwarePlanHooks runtimeRef hooks = PlanModeHooks
     { planConfirmEnter = \reason ->
         withCurrentFullscreen runtimeRef
             (hooks.planConfirmEnter reason)
+            \runtime ->
+                requestFullscreenChoiceWithBody
+                    runtime
+                    "Enter plan mode?"
+                    reason
+                    0
+                    [ ("Enter plan mode", "Explore and design before implementing")
+                    , ("Stay in normal mode", "Continue without entering plan mode")
+                    ]
+                    >>= pure . (== Just 0)
     , planDecideExit = \planBody ->
         withCurrentFullscreen runtimeRef
             (hooks.planDecideExit planBody)
+            \runtime ->
+                requestFullscreenChoiceWithBody
+                    runtime
+                    "Ready to implement this plan?"
+                    planBody
+                    0
+                    [ ("Approve and implement", "Leave plan mode and start implementation")
+                    , ("Request changes", "Send feedback and keep planning")
+                    , ("Cancel plan", "Leave plan mode without implementing")
+                    ]
+                    >>= \case
+                        Just 0 -> pure PlanApprove
+                        Just 1 ->
+                            requestFullscreenText
+                                runtime
+                                "Request changes"
+                                "What should be changed in the plan?"
+                                ""
+                                >>= pure
+                                    . PlanRequestChanges
+                                    . normalizePlanNotes
+                        _ -> pure PlanCancel
     , planAskQuestion = \question options ->
         withCurrentFullscreen runtimeRef
             (hooks.planAskQuestion question options)
+            \runtime -> case options of
+                [] ->
+                    requestFullscreenText
+                        runtime
+                        "Planning question"
+                        question
+                        ""
+                        >>= pure . nonBlank
+                choices ->
+                    requestFullscreenChoiceWithBody
+                        runtime
+                        "Planning question"
+                        question
+                        0
+                        [(choice, "") | choice <- choices]
+                        >>= pure . (>>= (`atMay` choices))
     }
 
 withCurrentFullscreen
     :: IORef (Maybe FullscreenRuntime)
     -> IO a
+    -> (FullscreenRuntime -> IO a)
     -> IO a
-withCurrentFullscreen runtimeRef action = do
+withCurrentFullscreen runtimeRef fallback fullscreenAction = do
     runtime <- readIORef runtimeRef
     case runtime of
-        Nothing -> action
-        Just active -> withFullscreenSuspended active action
+        Nothing -> fallback
+        Just active -> fullscreenAction active
+
+normalizePlanNotes :: Maybe Text -> Text
+normalizePlanNotes =
+    fromMaybe "(no notes)" . nonBlank
+
+nonBlank :: Maybe Text -> Maybe Text
+nonBlank =
+    (>>= \text ->
+        let stripped = Text.strip text
+        in if Text.null stripped then Nothing else Just stripped)
+
+atMay :: Int -> [a] -> Maybe a
+atMay index values
+    | index < 0 = Nothing
+    | otherwise = case drop index values of
+        value : _ -> Just value
+        [] -> Nothing
 
 showAccountUsage
     :: Provider
@@ -2106,6 +2186,16 @@ showAccountUsage
     -> IO ()
 showAccountUsage provider tokenProvider openAiPool = do
     color <- resolveColor stdout
+    accountUsageText color provider tokenProvider openAiPool
+        >>= Text.putStrLn
+
+accountUsageText
+    :: Bool
+    -> Provider
+    -> Maybe TokenProvider
+    -> Maybe OpenAI.Pool
+    -> IO Text
+accountUsageText color provider tokenProvider openAiPool = do
     now <- getCurrentTime
     case provider of
         OpenAIProvider ->
@@ -2113,19 +2203,19 @@ showAccountUsage provider tokenProvider openAiPool = do
                 Just pool -> do
                     snapshots <- OpenAI.snapshotAccounts pool
                     lines_ <- mapM fetchSnapshot snapshots
-                    Text.putStrLn (formatUsageReport color now lines_)
+                    pure (formatUsageReport color now lines_)
                 Nothing ->
                     case tokenProvider of
                         Just provider_ ->
                             getNextToken provider_ Nothing >>= \case
                                 Left err ->
-                                    Text.putStrLn
-                                        (roleError color
-                                            ("usage: " <> Text.pack (show err)))
+                                    pure $
+                                        roleError color
+                                            ("usage: " <> Text.pack (show err))
                                 Right credential -> do
                                     result <- fetchUsage
                                         credential.accessToken credential.accountId
-                                    Text.putStrLn $
+                                    pure $
                                         formatUsageReport color now
                                             [ AccountUsageLine
                                                 { usageAccountId = credential.accountId
@@ -2134,10 +2224,11 @@ showAccountUsage provider tokenProvider openAiPool = do
                                                 }
                                             ]
                         Nothing ->
-                            Text.putStrLn
-                                (roleMuted color "usage: no OpenAI credentials loaded")
+                            pure $
+                                roleMuted color
+                                    "usage: no OpenAI credentials loaded"
         _ ->
-            Text.putStrLn $
+            pure $
                 roleMuted color
                     "usage: ChatGPT Codex windows only (xAI/OpenRouter have no account usage API here)"
 
@@ -2642,10 +2733,11 @@ loadPrompt options = case (options.optPrompt, options.optPromptFile) of
     _ -> pure Nothing
 
 handleResume
-    :: Maybe Text
+    :: Maybe FullscreenRuntime
+    -> Maybe Text
     -> Persistence
     -> IO (Maybe RunResult)
-handleResume maybeId persist = do
+handleResume fullscreen maybeId persist = do
     color <- resolveColor stderr
     home <- getHomeDirectory
     let root = sessionsRoot home
@@ -2667,9 +2759,59 @@ handleResume maybeId persist = do
         Just sessionId -> resume sessionId
         Nothing -> do
             sessions <- listSessions root
-            pickResumeSession color root sessions >>= \case
+            pickResumeChoice fullscreen color root sessions >>= \case
                 Nothing -> pure Nothing
                 Just sessionId -> resume sessionId
+
+pickResumeChoice
+    :: Maybe FullscreenRuntime
+    -> Bool
+    -> OsPath
+    -> [SessionMeta]
+    -> IO (Maybe Text)
+pickResumeChoice fullscreen color root sessions = case fullscreen of
+    Nothing -> pickResumeSession color root sessions
+    Just runtime ->
+        requestFullscreenChoice
+            runtime
+            "Resume session"
+            0
+            [ ( meta.metaTitle
+              , providerSlug meta.metaProvider
+                    <> "/"
+                    <> meta.metaModel
+                    <> " · "
+                    <> toText meta.metaCwd
+              )
+            | meta <- sessions
+            ]
+            >>= pure . (>>= (`atMay` map (.metaId) sessions))
+
+pickAgentChoice
+    :: Maybe FullscreenRuntime
+    -> Bool
+    -> AgentTarget
+    -> [AgentEntry]
+    -> IO (Maybe AgentTarget)
+pickAgentChoice fullscreen color selected entries = case fullscreen of
+    Nothing -> pickAgentViewport color selected entries
+    Just runtime ->
+        requestFullscreenChoice
+            runtime
+            "Agents"
+            (fromMaybe 0
+                (findIndex ((== selected) . (.agentTarget)) entries))
+            [ ( entry.agentPath
+              , entry.agentStatus
+                    <> case entry.agentTranscript of
+                        first : _
+                            | not (Text.null (Text.strip first)) ->
+                                " · " <> Text.take 80 (Text.strip first)
+                        _ -> ""
+              )
+            | entry <- entries
+            ]
+            >>= pure . (>>= (`atMay` map (.agentTarget) entries))
 
 currentSessionId
     :: Persistence

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -6,6 +6,8 @@ module Agent.CLI.TUI.App
     , readFullscreenLine
     , requestFullscreenPermission
     , requestFullscreenChoice
+    , requestFullscreenChoiceWithBody
+    , requestFullscreenText
     , runFullscreen
     , withFullscreenSuspended
     ) where
@@ -63,7 +65,9 @@ import qualified Graphics.Vty.CrossPlatform as Vty
 
 data Name
     = ConversationViewport
+    | OverlayViewport
     | ComposerCursor
+    | OverlayCursor
     deriving (Eq, Ord, Show)
 
 data AppEvent
@@ -71,9 +75,15 @@ data AppEvent
     | AppAskPermission !Text !(TMVar (Maybe PermissionChoice))
     | AppAskChoice
         !Text
+        !Text
         !Int
         ![(Text, Text)]
         !(TMVar (Maybe Int))
+    | AppAskText
+        !Text
+        !Text
+        !Text
+        !(TMVar (Maybe Text))
     | forall a. AppSuspend !(IO a) !(TMVar (Either SomeException a))
     | AppStop
 
@@ -93,14 +103,24 @@ data AppState = AppState
     , appSlashIndex :: !Int
     , appChoice :: !(Maybe ChoiceOverlay)
     , appChoiceReply :: !(Maybe (TMVar (Maybe Int)))
+    , appTextPrompt :: !(Maybe TextOverlay)
+    , appTextReply :: !(Maybe (TMVar (Maybe Text)))
     , appSlashDismissed :: !Bool
     , appPasted :: !Bool
     }
 
 data ChoiceOverlay = ChoiceOverlay
     { choiceTitle :: !Text
+    , choiceBody :: !Text
     , choiceIndex :: !Int
     , choiceRows :: ![(Text, Text)]
+    }
+
+data TextOverlay = TextOverlay
+    { textTitle :: !Text
+    , textBody :: !Text
+    , textDraft :: !Text
+    , textCursor :: !Int
     }
 
 newFullscreenRuntime
@@ -148,9 +168,31 @@ requestFullscreenChoice
     -> [(Text, Text)]
     -> IO (Maybe Int)
 requestFullscreenChoice runtime title initial rows = do
+    requestFullscreenChoiceWithBody runtime title "" initial rows
+
+requestFullscreenChoiceWithBody
+    :: FullscreenRuntime
+    -> Text
+    -> Text
+    -> Int
+    -> [(Text, Text)]
+    -> IO (Maybe Int)
+requestFullscreenChoiceWithBody runtime title body initial rows = do
     reply <- newEmptyTMVarIO
     writeBChan runtime.runtimeEvents
-        (AppAskChoice title initial rows reply)
+        (AppAskChoice title body initial rows reply)
+    atomically (readTMVar reply)
+
+requestFullscreenText
+    :: FullscreenRuntime
+    -> Text
+    -> Text
+    -> Text
+    -> IO (Maybe Text)
+requestFullscreenText runtime title body initial = do
+    reply <- newEmptyTMVarIO
+    writeBChan runtime.runtimeEvents
+        (AppAskText title body initial reply)
     atomically (readTMVar reply)
 
 withFullscreenSuspended :: FullscreenRuntime -> IO a -> IO a
@@ -175,6 +217,8 @@ runFullscreen runtime workerAction = do
             , appSlashIndex = 0
             , appChoice = Nothing
             , appChoiceReply = Nothing
+            , appTextPrompt = Nothing
+            , appTextReply = Nothing
             , appSlashDismissed = False
             , appPasted = False
             }
@@ -204,6 +248,10 @@ handleChoiceKey = \case
     V.EvKey V.KDown [] -> moveChoice 1
     V.EvKey V.KBackTab [] -> moveChoice (-1)
     V.EvKey (V.KChar '\t') [] -> moveChoice 1
+    V.EvKey V.KPageUp [] ->
+        vScrollPage (viewportScroll OverlayViewport) Up
+    V.EvKey V.KPageDown [] ->
+        vScrollPage (viewportScroll OverlayViewport) Down
     V.EvKey V.KEnter [] -> resolveChoice True
     V.EvKey V.KEsc [] -> resolveChoice False
     V.EvKey (V.KChar 'q') [] -> resolveChoice False
@@ -241,6 +289,89 @@ resolveChoice confirmed = do
             , appChoiceReply = Nothing
             }
 
+handleTextPromptKey :: V.Event -> EventM Name AppState ()
+handleTextPromptKey = \case
+    V.EvKey V.KEsc [] -> resolveTextPrompt False
+    V.EvKey V.KEnter [] -> resolveTextPrompt True
+    V.EvKey V.KEnter [V.MShift] -> insert "\n"
+    V.EvKey V.KPageUp [] ->
+        vScrollPage (viewportScroll OverlayViewport) Up
+    V.EvKey V.KPageDown [] ->
+        vScrollPage (viewportScroll OverlayViewport) Down
+    V.EvKey V.KBS [] -> edit \draft cursor ->
+        if cursor <= 0
+            then (draft, cursor)
+            else
+                ( Text.take (cursor - 1) draft <> Text.drop cursor draft
+                , cursor - 1
+                )
+    V.EvKey V.KDel [] -> edit \draft cursor ->
+        if cursor >= Text.length draft
+            then (draft, cursor)
+            else
+                ( Text.take cursor draft <> Text.drop (cursor + 1) draft
+                , cursor
+                )
+    V.EvKey V.KLeft [] -> move (-1)
+    V.EvKey V.KRight [] -> move 1
+    V.EvKey V.KHome [] -> edit \draft cursor ->
+        (draft, lineStartCursor draft cursor)
+    V.EvKey V.KEnd [] -> edit \draft cursor ->
+        (draft, lineEndCursor draft cursor)
+    V.EvKey (V.KChar 'w') modifiers
+        | V.MCtrl `elem` modifiers ->
+            edit deleteWordBefore
+    V.EvKey (V.KChar 'u') modifiers
+        | V.MCtrl `elem` modifiers ->
+            edit deleteToLineStart
+    V.EvKey (V.KChar 'k') modifiers
+        | V.MCtrl `elem` modifiers ->
+            edit deleteToLineEnd
+    V.EvKey (V.KChar character) [] ->
+        insert (Text.singleton character)
+    V.EvPaste bytes ->
+        insert (decodePaste bytes)
+    _ -> pure ()
+  where
+    edit change =
+        modify' \state ->
+            state
+                { appTextPrompt =
+                    (\prompt ->
+                        let (draft, cursor) =
+                                change prompt.textDraft prompt.textCursor
+                        in prompt
+                            { textDraft = draft
+                            , textCursor =
+                                max 0 (min (Text.length draft) cursor)
+                            })
+                        <$> state.appTextPrompt
+                }
+    insert inserted =
+        edit \draft cursor ->
+            ( Text.take cursor draft <> inserted <> Text.drop cursor draft
+            , cursor + Text.length inserted
+            )
+    move delta =
+        edit \draft cursor -> (draft, cursor + delta)
+
+resolveTextPrompt :: Bool -> EventM Name AppState ()
+resolveTextPrompt confirmed = do
+    state <- get
+    case state.appTextReply of
+        Nothing -> pure ()
+        Just reply ->
+            liftIO $ atomically $
+                putTMVar reply $
+                    if confirmed
+                        then (.textDraft) <$> state.appTextPrompt
+                        else Nothing
+    modify' \current ->
+        current
+            { appTextPrompt = Nothing
+            , appTextReply = Nothing
+            }
+
 fullscreenApp :: App AppState AppEvent Name
 fullscreenApp = App
     { appDraw = drawApp
@@ -252,16 +383,20 @@ fullscreenApp = App
 
 drawApp :: AppState -> [Widget Name]
 drawApp state =
-    case (state.appChoice, state.appUi.uiPermission) of
-        (Just choice, _) ->
+    case (state.appTextPrompt, state.appChoice, state.appUi.uiPermission) of
+        (Just prompt, _, _) ->
+            [ drawTextPrompt prompt
+            , drawMain state
+            ]
+        (Nothing, Just choice, _) ->
             [ drawChoice choice
             , drawMain state
             ]
-        (Nothing, Just permission) ->
+        (Nothing, Nothing, Just permission) ->
             [ drawPermission permission
             , drawMain state
             ]
-        (Nothing, Nothing) -> [drawMain state]
+        (Nothing, Nothing, Nothing) -> [drawMain state]
 
 drawMain :: AppState -> Widget Name
 drawMain state =
@@ -499,10 +634,12 @@ drawFooter state =
         padLeftRight 2 $
             txt footer
   where
-    footer = case (state.appChoice, state.appUi.uiFocus) of
-        (Just _, _) ->
+    footer = case (state.appTextPrompt, state.appChoice, state.appUi.uiFocus) of
+        (Just _, _, _) ->
+            "Enter submit  │  Shift+Enter newline  │  PgUp/PgDn scroll  │  Esc cancel"
+        (Nothing, Just _, _) ->
             "↑↓ select  │  Enter choose  │  Esc cancel"
-        (Nothing, focus) ->
+        (Nothing, Nothing, focus) ->
                 case focus of
                     FocusPermission ->
                         "↑↓ select  │  Enter choose  │  Esc deny"
@@ -553,16 +690,61 @@ drawChoice choice =
                         borderWithLabel
                             (txt (" " <> choice.choiceTitle <> " ")) $
                             padAll 1 $
-                                vBox $
-                                    zipWith
-                                        (choiceRow choice.choiceIndex)
-                                        [start ..]
-                                        rows
+                                vBox
+                                    [ if Text.null (Text.strip choice.choiceBody)
+                                        then emptyWidget
+                                        else padBottom (Pad 1) $
+                                            vLimitPercent 65 $
+                                                viewport OverlayViewport Vertical $
+                                                    markdownWidget choice.choiceBody
+                                    , vBox $
+                                        zipWith
+                                            (choiceRow choice.choiceIndex)
+                                            [start ..]
+                                            rows
+                                    ]
   where
     count = length choice.choiceRows
     start =
         max 0 (min choice.choiceIndex (max 0 (count - 14)))
     rows = take 14 (drop start choice.choiceRows)
+
+drawTextPrompt :: TextOverlay -> Widget Name
+drawTextPrompt prompt =
+    centerLayer $
+        hLimitPercent 82 $
+            vLimitPercent 78 $
+                withAttr Theme.borderActiveAttr $
+                    withBorderStyle unicodeRounded $
+                        borderWithLabel
+                            (txt (" " <> prompt.textTitle <> " ")) $
+                            padAll 1 $
+                                vBox
+                                    [ if Text.null (Text.strip prompt.textBody)
+                                        then emptyWidget
+                                        else padBottom (Pad 1) $
+                                            vLimitPercent 60 $
+                                                viewport OverlayViewport Vertical $
+                                                    markdownWidget prompt.textBody
+                                    , withAttr Theme.borderAttr $
+                                        withBorderStyle unicodeRounded $
+                                            borderWithLabel (txt " Answer ") $
+                                                padLeftRight 1 $
+                                                    hBox
+                                                        [ renderTextDraft prompt
+                                                        , vLimit 1 (fill ' ')
+                                                        ]
+                                    ]
+
+renderTextDraft :: TextOverlay -> Widget Name
+renderTextDraft prompt =
+    let content =
+            if Text.null prompt.textDraft
+                then withAttr Theme.mutedAttr (txt " ")
+                else txt prompt.textDraft
+        (row, column) =
+            draftCursorLocation prompt.textDraft prompt.textCursor
+    in showCursor OverlayCursor (Location (column, row)) content
 
 choiceRow :: Int -> Int -> (Text, Text) -> Widget Name
 choiceRow selected index (label, detail) =
@@ -600,17 +782,31 @@ handleEvent event = case event of
                 { appUi = reduceUi (UiPermissionShown summary) state.appUi
                 , appPermissionReply = Just reply
                 }
-    AppEvent (AppAskChoice title initial rows reply) ->
+    AppEvent (AppAskChoice title body initial rows reply) -> do
         modify' \state ->
             state
                 { appChoice = Just ChoiceOverlay
                     { choiceTitle = title
+                    , choiceBody = body
                     , choiceIndex =
                         max 0 (min (max 0 (length rows - 1)) initial)
                     , choiceRows = rows
                     }
                 , appChoiceReply = Just reply
                 }
+        vScrollToBeginning (viewportScroll OverlayViewport)
+    AppEvent (AppAskText title body initial reply) -> do
+        modify' \state ->
+            state
+                { appTextPrompt = Just TextOverlay
+                    { textTitle = title
+                    , textBody = body
+                    , textDraft = initial
+                    , textCursor = Text.length initial
+                    }
+                , appTextReply = Just reply
+                }
+        vScrollToBeginning (viewportScroll OverlayViewport)
     AppEvent (AppSuspend action reply) -> do
         state <- get
         suspendAndResume do
@@ -619,10 +815,11 @@ handleEvent event = case event of
             pure state
     VtyEvent vtyEvent -> do
         state <- get
-        case (state.appChoice, state.appUi.uiPermission) of
-            (Just _, _) -> handleChoiceKey vtyEvent
-            (Nothing, Just _) -> handlePermissionKey vtyEvent
-            (Nothing, Nothing) -> handleNormalKey vtyEvent
+        case (state.appTextPrompt, state.appChoice, state.appUi.uiPermission) of
+            (Just _, _, _) -> handleTextPromptKey vtyEvent
+            (Nothing, Just _, _) -> handleChoiceKey vtyEvent
+            (Nothing, Nothing, Just _) -> handlePermissionKey vtyEvent
+            (Nothing, Nothing, Nothing) -> handleNormalKey vtyEvent
     _ -> pure ()
 
 eventFollows :: UiEvent -> Bool


### PR DESCRIPTION
## Summary
- add retained full-screen choice and text-input overlays
- keep model, agent, resume, and all plan-mode interactions inside the TUI
- render `/btw` and `/usage` results without suspending the full-screen application
- preserve legacy prompts for minimal/non-TTY sessions

## Validation
- `nix develop -c cabal repl agent-cli:lib:agent-cli --repl-options=-fno-code`
- `nix develop -c sh -c 'unset GHCRTS; cabal test agent-cli-test --test-show-details=direct'` (393 examples, 0 failures)
- tmux smoke checks for `/model`, `/agents`, plan approval, and free-text planning questions
- `git diff --check`