### PR TITLE
fix(cli): prevent duplicate arrow movement in pickers

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Picker.hs
+++ b/packages/agent-cli/src/Agent/CLI/Picker.hs
@@ -77,6 +77,8 @@ data MouseEvent
 
 decodePickerKey :: String -> Maybe PickerKey
 decodePickerKey = \case
+    sequence_
+        | kittyEvent sequence_ == Just kittyRelease -> Nothing
     "\n" -> Just PickerKeyConfirm
     "\r" -> Just PickerKeyConfirm
     "\ESC" -> Just PickerKeyCancel
@@ -151,6 +153,20 @@ kittyCodepoint sequence_ = do
     case reads (Text.unpack code) of
         [(n, "")] -> Just n
         _ -> Nothing
+
+-- | Kitty's keyboard protocol appends @:event@ to the modifier field when
+-- event reporting is enabled. Releases must not be interpreted as a second
+-- press; repeats remain navigable.
+kittyEvent :: String -> Maybe Int
+kittyEvent sequence_ = do
+    body <- stripPrefix "\ESC[" sequence_
+    (parameters, _) <- unsnoc body
+    modifierField <- listAt 1 (splitOnceOrSingleton ';' parameters)
+    eventField <- listAt 1 (splitOnceOrSingleton ':' modifierField)
+    readDecimal eventField
+
+kittyRelease :: Int
+kittyRelease = 3
 
 codepointKey :: Int -> Maybe PickerKey
 codepointKey = \case
@@ -386,6 +402,19 @@ splitOnce delimiter value =
     case break (== delimiter) value of
         (before, _ : after) -> Just (before, after)
         _ -> Nothing
+
+splitOnceOrSingleton :: Char -> String -> [String]
+splitOnceOrSingleton delimiter value =
+    case break (== delimiter) value of
+        (before, _ : after) -> [before, after]
+        _ -> [value]
+
+listAt :: Int -> [a] -> Maybe a
+listAt index values
+    | index < 0 = Nothing
+    | otherwise = case drop index values of
+        value : _ -> Just value
+        [] -> Nothing
 
 unsnoc :: [a] -> Maybe ([a], a)
 unsnoc [] = Nothing

--- a/packages/agent-cli/test/Agent/CLI/PickerSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/PickerSpec.hs
@@ -15,6 +15,12 @@ spec = do
             decodePickerKey "\ESC[1;2A" `shouldBe` Just PickerKeyUp
             decodePickerKey "\ESC[1;5B" `shouldBe` Just PickerKeyDown
 
+        it "ignores Kitty key releases instead of moving twice" do
+            decodePickerKey "\ESC[1;1:1A" `shouldBe` Just PickerKeyUp
+            decodePickerKey "\ESC[1;1:2B" `shouldBe` Just PickerKeyDown
+            decodePickerKey "\ESC[1;1:3A" `shouldBe` Nothing
+            decodePickerKey "\ESC[106;1:3u" `shouldBe` Nothing
+
     describe "decodeMouseEvent" do
         it "decodes SGR clicks, releases, and wheel events" do
             decodeMouseEvent "\ESC[<0;12;7M"


### PR DESCRIPTION
## Summary
- ignore Kitty keyboard release events in shared picker decoding
- keep press and repeat events working for arrow navigation
- add regression coverage for press, repeat, and release sequences

## Testing
- `cabal repl agent-cli:test:agent-cli-test`: `--match "decodePickerKey"` (6 examples)
- `cabal repl agent-cli:test:agent-cli-test`: `--match "plan exit picker"` (2 examples)
- tmux TTY smoke test: a Down-arrow press/release pair moved the plan picker exactly one row
- `git diff --check`
