### PR TITLE
fix: supervise repl subprocess group

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -131,6 +131,29 @@
                 # GHCi :cmd loop that reloads + resumes after agent :reload.
                 # expect waits for modules to load, then starts the agent
                 # (ghci scripts run before cabal loads the package).
+                agentReplExpect = pkgs.writeText "agent-repl.expect" ''
+                    set timeout -1
+                    set cabal $env(AGENT_REPL_CABAL)
+                    set script $env(AGENT_REPL_SCRIPT)
+                    set pgid_file $env(AGENT_REPL_PGID_FILE)
+
+                    set child_pid [spawn -noecho $cabal repl lib:agent-cli --repl-options=-ghci-script=$script]
+                    set pgid_handle [open $pgid_file w]
+                    puts $pgid_handle $child_pid
+                    close $pgid_handle
+                    expect {
+                      -re {Ok, [0-9]+ modules? loaded\.} {}
+                      eof {
+                        puts stderr "repl: cabal repl exited before modules loaded"
+                        exit 1
+                      }
+                    }
+                    send -- ":module +Agent.CLI\r"
+                    expect -re {ghci>}
+                    send -- ":cmd afterDev =<< devMain\r"
+                    interact
+                '';
+
                 agentRepl = pkgs.writeShellScriptBin "repl" ''
                     set -euo pipefail
                     root="$(${pkgs.git}/bin/git rev-parse --show-toplevel 2>/dev/null || pwd)"
@@ -146,25 +169,81 @@
                     fi
                     cabal="${haskellPackages.cabal-install}/bin/cabal"
                     expect_bin="${pkgs.expect}/bin/expect"
+                    kill_bin="${pkgs.coreutils}/bin/kill"
+                    sleep_bin="${pkgs.coreutils}/bin/sleep"
+                    stty_bin="${pkgs.coreutils}/bin/stty"
+                    rm_bin="${pkgs.coreutils}/bin/rm"
+                    rmdir_bin="${pkgs.coreutils}/bin/rmdir"
+                    state_dir="$(${pkgs.coreutils}/bin/mktemp -d "''${TMPDIR:-/tmp}/agent-repl.XXXXXX")"
+                    pgid_file="$state_dir/cabal-pgid"
+                    expect_pid=""
+                    tty_state=""
+
+                    if [ -t 0 ]; then
+                      tty_state="$("$stty_bin" -g < /dev/tty 2>/dev/null || true)"
+                    fi
+
+                    terminate_group() {
+                      local pgid="''${1:-}"
+                      case "$pgid" in
+                        ""|*[!0-9]*) return 0 ;;
+                      esac
+                      [ "$pgid" -gt 1 ] || return 0
+
+                      "$kill_bin" -TERM -- "-$pgid" 2>/dev/null || true
+                      for _ in {1..20}; do
+                        if ! "$kill_bin" -0 -- "-$pgid" 2>/dev/null; then
+                          return 0
+                        fi
+                        "$sleep_bin" 0.05
+                      done
+                      "$kill_bin" -KILL -- "-$pgid" 2>/dev/null || true
+                    }
+
+                    cleanup() {
+                      local status=$?
+                      local pgid=""
+                      trap - EXIT HUP INT TERM
+                      case "$expect_pid" in
+                        ""|*[!0-9]*) ;;
+                        *) "$kill_bin" -TERM "$expect_pid" 2>/dev/null || true ;;
+                      esac
+                      if [ -r "$pgid_file" ]; then
+                        IFS= read -r pgid < "$pgid_file" || true
+                        terminate_group "$pgid"
+                      fi
+                      case "$expect_pid" in
+                        ""|*[!0-9]*) ;;
+                        *)
+                          "$kill_bin" -KILL "$expect_pid" 2>/dev/null || true
+                          wait "$expect_pid" 2>/dev/null || true
+                          ;;
+                      esac
+                      if [ -n "$tty_state" ]; then
+                        "$stty_bin" "$tty_state" < /dev/tty 2>/dev/null || true
+                      fi
+                      "$rm_bin" -f "$pgid_file"
+                      "$rmdir_bin" "$state_dir" 2>/dev/null || true
+                      return "$status"
+                    }
+
+                    trap cleanup EXIT
+                    trap 'exit 129' HUP
+                    trap 'exit 130' INT
+                    trap 'exit 143' TERM
+
                     export AGENT_REPL_SCRIPT="$script"
                     export AGENT_REPL_CABAL="$cabal"
-                    exec "$expect_bin" -c '
-                      set timeout -1
-                      set cabal $env(AGENT_REPL_CABAL)
-                      set script $env(AGENT_REPL_SCRIPT)
-                      spawn -noecho $cabal repl lib:agent-cli --repl-options=-ghci-script=$script
-                      expect {
-                        -re {Ok, [0-9]+ modules? loaded\.} {}
-                        eof {
-                          puts stderr "repl: cabal repl exited before modules loaded"
-                          exit 1
-                        }
-                      }
-                      send -- ":module +Agent.CLI\r"
-                      expect -re {ghci>}
-                      send -- ":cmd afterDev =<< devMain\r"
-                      interact
-                    '
+                    export AGENT_REPL_PGID_FILE="$pgid_file"
+                    "$expect_bin" "${agentReplExpect}" <&0 &
+                    expect_pid=$!
+                    if wait "$expect_pid"; then
+                      status=0
+                    else
+                      status=$?
+                    fi
+                    expect_pid=""
+                    exit "$status"
                 '';
             in
             {


### PR DESCRIPTION
## Summary

- keep a small outer shell supervisor around the Expect-based development REPL
- record the Cabal PTY process group and terminate the complete group when Expect exits or the outer terminal sends HUP/INT/TERM
- escalate TERM to KILL, reap Expect, restore the terminal mode, and remove the temporary supervisor state

This is intentionally limited to the confirmed REPL/terminal orphaning bug.

## Validation

- `nix flake check --no-build`
- built the generated `repl` wrapper through `nix develop`
- launched the generated wrapper, sent SIGHUP to the supervisor, and verified that the Expect and Cabal process group had no live processes afterward
- `git diff --check`
