### PR TITLE
fix: bound and reap shell subprocesses

### DIFF
--- a/packages/agent-core/src/Agent/Tools/Ghci/Runtime.hs
+++ b/packages/agent-core/src/Agent/Tools/Ghci/Runtime.hs
@@ -21,26 +21,41 @@ import Agent.Tools.Ghci.Classify
     , defaultGhciExtensions
     , typeLooksEffectful
     )
+import Agent.Tools.IO (terminateProcessGroup)
 import Agent.Tools.Types (ToolEnv(..))
 import Control.Concurrent (threadDelay)
-import Control.Concurrent.Async (Async, async, cancel, race)
+import Control.Concurrent.Async
+    ( Async
+    , asyncWithUnmask
+    , cancel
+    , race
+    , waitCatch
+    )
 import Control.Concurrent.MVar
 import Control.Concurrent.STM
     ( STM
-    , TChan
+    , TBQueue
+    , TMVar
     , atomically
-    , newTChanIO
-    , readTChan
-    , tryReadTChan
-    , writeTChan
+    , isFullTBQueue
+    , newEmptyTMVarIO
+    , newTBQueueIO
+    , orElse
+    , readTBQueue
+    , readTMVar
+    , retry
+    , tryReadTBQueue
+    , tryPutTMVar
+    , writeTBQueue
     )
 import Control.Exception.Safe
     ( SomeException
     , finally
+    , mask
     , onException
     , try
     )
-import Control.Monad (unless, void)
+import Control.Monad (void)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import Data.IORef
@@ -67,9 +82,9 @@ import System.Process
     , getProcessExitCode
     , interruptProcessGroupOf
     , proc
-    , terminateProcess
     )
-import System.Posix.Signals (sigKILL, signalProcessGroup)
+import System.Posix.Signals (sigINT, signalProcessGroup)
+import System.Posix.Types (ProcessGroupID)
 
 data GhciOutcome
     = GhciCompleted
@@ -105,7 +120,10 @@ data GhciProcess = GhciProcess
     , ghciStdoutHandle :: !Handle
     , ghciStderrHandle :: !Handle
     , ghciHandle :: !ProcessHandle
-    , ghciEvents :: !(TChan GhciEvent)
+    , ghciGroupId :: !(Maybe ProcessGroupID)
+    , ghciEvents :: !(TBQueue GhciEvent)
+    , ghciStdoutClosed :: !(TMVar ())
+    , ghciStderrClosed :: !(TMVar ())
     , ghciStdoutDrain :: !(Async ())
     , ghciStderrDrain :: !(Async ())
     }
@@ -204,11 +222,10 @@ evalRawGhci session expression requestedTimeout = do
     cancelled <- isCancelled session.ghciEnv.toolCancel
     if cancelled
         then pure $ emptyResult GhciCancelled GhciEffectful "GHCi evaluation cancelled."
-        else ensureProcess session >>= \case
+        else prepareProcess session >>= \case
             Left err ->
                 pure $ emptyResult GhciProcessFailed GhciEffectful err
-            Right process -> do
-                flushEvents process
+            Right (process, restartedBefore) -> do
                 marker <- nextMarker session
                 sent <- try @_ @SomeException do
                     sendGhciInput process expression
@@ -218,7 +235,9 @@ evalRawGhci session expression requestedTimeout = do
                         restarted <- restartProcess session
                         pure $ (emptyResult GhciProcessFailed GhciEffectful
                             ("Failed to send input to GHCi: " <> Text.pack (show err)))
-                                { ghciRestarted = restarted }
+                                { ghciRestarted =
+                                    restartedBefore || restarted
+                                }
                     Right () -> do
                         awaited <- awaitMarker
                             (Just session.ghciEnv.toolCancel)
@@ -226,46 +245,88 @@ evalRawGhci session expression requestedTimeout = do
                             process
                             marker
                             timeoutMs
-                        finishAwaited session process awaited
+                        finishAwaited
+                            session process restartedBefore awaited
+
+prepareProcess :: GhciSession -> IO (Either Text (GhciProcess, Bool))
+prepareProcess session = do
+    ensured <- ensureProcess session
+    case ensured of
+        Left err -> pure (Left err)
+        Right process -> do
+            flushed <- flushEvents process
+            if flushed
+                then pure (Right (process, False))
+                else do
+                    restarted <- restartProcess session
+                    if not restarted
+                        then pure (Left staleOutputError)
+                        else do
+                            ensuredAgain <- ensureProcess session
+                            pure (markRestarted <$> ensuredAgain)
+  where
+    markRestarted process = (process, True)
+    staleOutputError =
+        "GHCi produced excessive stale output and could not be restarted."
 
 finishAwaited
     :: GhciSession
     -> GhciProcess
+    -> Bool
     -> Awaited
     -> IO GhciResult
-finishAwaited session process awaited =
+finishAwaited session process restartedBefore awaited =
     case awaited.awaitReason of
-        AwaitMarkers -> pure $ capturedResult GhciCompleted awaited.awaitOutput False
+        AwaitMarkers ->
+            pure $ capturedResult
+                GhciCompleted awaited.awaitOutput restartedBefore
         AwaitTimeout -> recover GhciTimedOut
         AwaitCancellation -> recover GhciCancelled
         AwaitProcessExit -> do
             restarted <- restartProcess session
-            pure $ (capturedResult GhciProcessFailed awaited.awaitOutput restarted)
+            pure $ (capturedResult GhciProcessFailed awaited.awaitOutput
+                (restartedBefore || restarted))
                 { ghciOk = False }
   where
     recover outcome = do
-        void $ try @_ @SomeException
-            (interruptProcessGroupOf process.ghciHandle)
-        recovered <- recoverAfterInterrupt session process
+        interruptGhciProcess process
+        recovered <-
+            if awaited.awaitOutput.capturedTruncated
+                then pure False
+                else recoverAfterInterrupt session process
         restarted <- if recovered
             then pure False
             else restartProcess session
-        pure $ (capturedResult outcome awaited.awaitOutput restarted)
+        pure $ (capturedResult outcome awaited.awaitOutput
+            (restartedBefore || restarted))
             { ghciOk = False }
 
 recoverAfterInterrupt :: GhciSession -> GhciProcess -> IO Bool
 recoverAfterInterrupt session process = do
-    flushEvents process
-    marker <- nextMarker session
-    sent <- try @_ @SomeException do
-        sendLine process ":type ()"
-        sendMarker process marker
-    case sent of
-        Left _ -> pure False
-        Right () -> do
-            awaited <- awaitMarker Nothing
-                session.ghciEnv.toolStdoutCap process marker 5000
-            pure (awaited.awaitReason == AwaitMarkers)
+    flushed <- flushEvents process
+    if not flushed
+        then pure False
+        else do
+            marker <- nextMarker session
+            sent <- try @_ @SomeException do
+                sendLine process ":type ()"
+                sendMarker process marker
+            case sent of
+                Left _ -> pure False
+                Right () -> do
+                    awaited <- awaitMarker Nothing
+                        session.ghciEnv.toolStdoutCap process marker 5000
+                    pure (awaited.awaitReason == AwaitMarkers)
+
+interruptGhciProcess :: GhciProcess -> IO ()
+interruptGhciProcess process =
+    case process.ghciGroupId of
+        Just groupId ->
+            void $ try @_ @SomeException
+                (signalProcessGroup sigINT groupId)
+        Nothing ->
+            void $ try @_ @SomeException
+                (interruptProcessGroupOf process.ghciHandle)
 
 capturedResult :: GhciOutcome -> CapturedOutput -> Bool -> GhciResult
 capturedResult outcome captured restarted =
@@ -338,33 +399,47 @@ ensureProcess session =
                     startProcess session
 
 startProcess :: GhciSession -> IO (Either Text GhciProcess)
-startProcess session =
+startProcess session = mask \restore ->
     spawnProcess session.ghciEnv >>= \case
         Left err -> pure (Left err)
-        Right process -> do
-            flushEvents process
-            marker <- nextMarker session
-            sent <- try @_ @SomeException (sendMarker process marker)
-            case sent of
-                Left err -> do
-                    shutdownProcess process
-                    pure $ Left
-                        ("Failed to initialize GHCi: " <> Text.pack (show err))
-                Right () -> do
-                    awaited <- awaitMarker Nothing
-                        session.ghciEnv.toolStdoutCap process marker 5000
-                    if awaited.awaitReason == AwaitMarkers
-                        && not (isGhciError awaited.awaitOutput.capturedStderr)
-                        then do
-                            writeIORef session.ghciState (GhciRunning process)
-                            pure (Right process)
-                        else do
-                            shutdownProcess process
-                            pure $ Left $
-                                "GHCi failed its startup handshake.\n"
-                                    <> combineOutput
-                                        awaited.awaitOutput.capturedStdout
-                                        awaited.awaitOutput.capturedStderr
+        Right process ->
+            restore (initialize process)
+                `onException` shutdownProcess process
+  where
+    initialize process = do
+        flushed <- flushEvents process
+        if not flushed
+            then do
+                shutdownProcess process
+                pure $ Left
+                    "GHCi produced excessive output during startup."
+            else do
+                marker <- nextMarker session
+                sent <- try @_ @SomeException (sendMarker process marker)
+                case sent of
+                    Left err -> do
+                        shutdownProcess process
+                        pure $ Left
+                            ("Failed to initialize GHCi: "
+                                <> Text.pack (show err))
+                    Right () -> do
+                        awaited <- awaitMarker Nothing
+                            session.ghciEnv.toolStdoutCap process marker 5000
+                        if awaited.awaitReason == AwaitMarkers
+                            && not
+                                (isGhciError
+                                    awaited.awaitOutput.capturedStderr)
+                            then do
+                                writeIORef session.ghciState
+                                    (GhciRunning process)
+                                pure (Right process)
+                            else do
+                                shutdownProcess process
+                                pure $ Left $
+                                    "GHCi failed its startup handshake.\n"
+                                        <> combineOutput
+                                            awaited.awaitOutput.capturedStdout
+                                            awaited.awaitOutput.capturedStderr
 
 restartProcess :: GhciSession -> IO Bool
 restartProcess session = do
@@ -398,33 +473,69 @@ spawnProcess env = do
             , std_err = CreatePipe
             , create_group = True
             }
-    try @_ @SomeException (createProcess spec) >>= \case
+    spawned <- try @_ @SomeException $ mask \restore -> do
+        created@(_, _, _, handle) <- createProcess spec
+        groupId <- getPid handle
+            `onException` cleanupSpawn Nothing created []
+        case created of
+            (Just hin, Just hout, Just herr, _) -> do
+                let cleanup drains =
+                        cleanupSpawn groupId created drains
+                mapM_ prepareHandle [hin, hout, herr]
+                    `onException` cleanup []
+                (events, stdoutClosed, stderrClosed) <-
+                    (do
+                        queue <- newTBQueueIO
+                            (fromIntegral ghciEventQueueCapacity)
+                        outClosed <- newEmptyTMVarIO
+                        errClosed <- newEmptyTMVarIO
+                        pure (queue, outClosed, errClosed))
+                        `onException` cleanup []
+                stdoutDrain <-
+                    asyncWithUnmask
+                        (\unmask ->
+                            unmask (drainHandle
+                                GhciStdout hout events stdoutClosed))
+                        `onException` cleanup []
+                stderrDrain <-
+                    asyncWithUnmask
+                        (\unmask ->
+                            unmask (drainHandle
+                                GhciStderr herr events stderrClosed))
+                        `onException` cleanup [stdoutDrain]
+                let process = GhciProcess
+                        { ghciStdin = hin
+                        , ghciStdoutHandle = hout
+                        , ghciStderrHandle = herr
+                        , ghciHandle = handle
+                        , ghciGroupId = groupId
+                        , ghciEvents = events
+                        , ghciStdoutClosed = stdoutClosed
+                        , ghciStderrClosed = stderrClosed
+                        , ghciStdoutDrain = stdoutDrain
+                        , ghciStderrDrain = stderrDrain
+                        }
+                restore (pure (Just process))
+                    `onException` shutdownProcess process
+            _ -> do
+                cleanupSpawn groupId created []
+                pure Nothing
+    case spawned of
         Left err ->
             pure $ Left ("Failed to start GHCi: " <> Text.pack (show err))
-        Right (Just hin, Just hout, Just herr, handle) -> do
-            let closeCreated = do
-                    mapM_ (void . try @_ @SomeException . hClose)
-                        [hin, hout, herr]
-                    void $ try @_ @SomeException (terminateProcess handle)
-            (do
-                mapM_ prepareHandle [hin, hout, herr]
-                events <- newTChanIO
-                stdoutDrain <- async
-                    (drainHandle GhciStdout hout events)
-                stderrDrain <- async
-                    (drainHandle GhciStderr herr events)
-                pure $ Right GhciProcess
-                    { ghciStdin = hin
-                    , ghciStdoutHandle = hout
-                    , ghciStderrHandle = herr
-                    , ghciHandle = handle
-                    , ghciEvents = events
-                    , ghciStdoutDrain = stdoutDrain
-                    , ghciStderrDrain = stderrDrain
-                    })
-                `onException` closeCreated
-        Right _ ->
-            pure (Left "Failed to create GHCi pipes.")
+        Right Nothing -> pure (Left "Failed to create GHCi pipes.")
+        Right (Just process) -> pure (Right process)
+
+cleanupSpawn
+    :: Maybe ProcessGroupID
+    -> (Maybe Handle, Maybe Handle, Maybe Handle, ProcessHandle)
+    -> [Async ()]
+    -> IO ()
+cleanupSpawn groupId (hin, hout, herr, handle) drains = do
+    terminateProcessGroup groupId handle
+    mapM_ (mapM_ (void . try @_ @SomeException . hClose))
+        [hin, hout, herr]
+    stopDrains drains
 
 prepareHandle :: Handle -> IO ()
 prepareHandle handle = do
@@ -434,23 +545,19 @@ prepareHandle handle = do
 shutdownProcess :: GhciProcess -> IO ()
 shutdownProcess process = do
     void $ try @_ @SomeException (sendLine process ":quit")
-    exited <- waitForExit process.ghciHandle 200
-    unless exited do
-        void $ try @_ @SomeException
-            (interruptProcessGroupOf process.ghciHandle)
-        void $ try @_ @SomeException (terminateProcess process.ghciHandle)
-        terminated <- waitForExit process.ghciHandle 1000
-        unless terminated do
-            getPid process.ghciHandle >>= mapM_ \pid ->
-                void $ try @_ @SomeException (signalProcessGroup sigKILL pid)
-            void $ waitForExit process.ghciHandle 1000
+    void $ waitForExit process.ghciHandle 200
+    terminateProcessGroup process.ghciGroupId process.ghciHandle
     mapM_ (void . try @_ @SomeException . hClose)
         [ process.ghciStdin
         , process.ghciStdoutHandle
         , process.ghciStderrHandle
         ]
-    cancel process.ghciStdoutDrain
-    cancel process.ghciStderrDrain
+    stopDrains [process.ghciStdoutDrain, process.ghciStderrDrain]
+
+stopDrains :: [Async ()] -> IO ()
+stopDrains drains = do
+    mapM_ (void . try @_ @SomeException . cancel) drains
+    mapM_ (void . waitCatch) drains
 
 waitForExit :: ProcessHandle -> Int -> IO Bool
 waitForExit handle timeoutMs = go (max 1 timeoutMs)
@@ -512,11 +619,18 @@ sendLine process text = do
     BS.hPut process.ghciStdin (encodeUtf8 (text <> "\n"))
     hFlush process.ghciStdin
 
-flushEvents :: GhciProcess -> IO ()
+-- | Drop one bounded queue snapshot. If the queue was full, a drain thread
+-- may already be blocked with more stale output, so the caller must restart.
+flushEvents :: GhciProcess -> IO Bool
 flushEvents process =
-    atomically (tryReadTChan process.ghciEvents) >>= \case
-        Nothing -> pure ()
-        Just _ -> flushEvents process
+    atomically do
+        wasFull <- isFullTBQueue process.ghciEvents
+        let go =
+                tryReadTBQueue process.ghciEvents >>= \case
+                    Nothing -> pure ()
+                    Just _ -> go
+        go
+        pure (not wasFull)
 
 data AwaitReason
     = AwaitMarkers
@@ -594,7 +708,6 @@ awaitMarker cancelFlag cap process marker requestedTimeout = do
                             Left () -> pure AwaitCancellation
                             Right (Left ()) -> pure AwaitTimeout
                             Right (Right completed) -> pure completed
-    drainAvailable stateRef cap (encodeUtf8 marker) process
     captured <- renderCapture cap <$> readIORef stateRef
     pure Awaited
         { awaitReason = reason
@@ -610,7 +723,8 @@ collectEvents
 collectEvents stateRef cap marker process = go
   where
     go = do
-        event <- atomically (readTChanCompat process.ghciEvents)
+        current <- readIORef stateRef
+        event <- atomically (readGhciEvent process current)
         state <- atomicModifyIORef' stateRef \current ->
             let updated = applyEvent cap marker event current
             in (updated, updated)
@@ -622,24 +736,23 @@ collectEvents stateRef cap marker process = go
                 then pure AwaitProcessExit
                 else go
 
--- Kept as a helper so the blocking operation is visually distinct from
--- non-blocking queue drains.
-readTChanCompat :: TChan a -> STM a
-readTChanCompat = readTChan
-
-drainAvailable
-    :: IORef CaptureState
-    -> Int
-    -> ByteString
-    -> GhciProcess
-    -> IO ()
-drainAvailable stateRef cap marker process =
-    atomically (tryReadTChan process.ghciEvents) >>= \case
-        Nothing -> pure ()
-        Just event -> do
-            atomicModifyIORef' stateRef \current ->
-                (applyEvent cap marker event current, ())
-            drainAvailable stateRef cap marker process
+readGhciEvent :: GhciProcess -> CaptureState -> STM GhciEvent
+readGhciEvent process state =
+    readTBQueue process.ghciEvents
+        `orElse` closedEvent
+            GhciStdout
+            state.stdoutCapture.streamClosed
+            process.ghciStdoutClosed
+        `orElse` closedEvent
+            GhciStderr
+            state.stderrCapture.streamClosed
+            process.ghciStderrClosed
+  where
+    closedEvent stream alreadyClosed closed
+        | alreadyClosed = retry
+        | otherwise = do
+            readTMVar closed
+            pure (GhciStreamClosed stream)
 
 applyEvent :: Int -> ByteString -> GhciEvent -> CaptureState -> CaptureState
 applyEvent cap marker event state =
@@ -727,16 +840,24 @@ renderStream cap capture =
                     <> " bytes]"
     in (decoded <> suffix, dropped)
 
-drainHandle :: GhciStream -> Handle -> TChan GhciEvent -> IO ()
-drainHandle stream handle events =
-    go `finally` atomically (writeTChan events (GhciStreamClosed stream))
+ghciEventQueueCapacity :: Int
+ghciEventQueueCapacity = 64
+
+drainHandle
+    :: GhciStream
+    -> Handle
+    -> TBQueue GhciEvent
+    -> TMVar ()
+    -> IO ()
+drainHandle stream handle events closed =
+    go `finally` atomically (void (tryPutTMVar closed ()))
   where
     go = do
         chunk <- BS.hGetSome handle 4096
         if BS.null chunk
             then pure ()
             else do
-                atomically (writeTChan events (GhciChunk stream chunk))
+                atomically (writeTBQueue events (GhciChunk stream chunk))
                 go
 
 normalizeTimeout :: Int -> Int

--- a/packages/agent-core/src/Agent/Tools/IO.hs
+++ b/packages/agent-core/src/Agent/Tools/IO.hs
@@ -11,6 +11,7 @@ module Agent.Tools.IO
     , runShellCommand
     , startShellCommand
     , stopShellCommand
+    , terminateProcessGroup
     , runningLiveOutput
     , truncateText
     ) where
@@ -27,10 +28,9 @@ import Agent.Tools.FileSystem
     )
 import Agent.Tools.Types (ToolEnv(..))
 import Control.Concurrent (threadDelay)
-import Control.Monad (void)
 import Control.Concurrent.Async
     ( Async
-    , async
+    , asyncWithUnmask
     , cancel
     , concurrently
     , race
@@ -40,9 +40,9 @@ import Control.Concurrent.MVar
     ( MVar
     , newEmptyMVar
     , readMVar
+    , tryReadMVar
     , tryPutMVar
     )
-import Control.Exception (evaluate)
 import Control.Exception.Safe
     ( SomeException
     , finally
@@ -50,6 +50,8 @@ import Control.Exception.Safe
     , onException
     , try
     )
+import Control.Monad (unless, void)
+import Data.Either (isRight)
 import Data.IORef (IORef, atomicModifyIORef', newIORef, readIORef)
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -58,12 +60,21 @@ import Data.Text.Encoding (decodeUtf8With)
 import Data.Text.Encoding.Error (lenientDecode)
 import System.Exit (ExitCode(..))
 import System.IO (Handle, hClose)
+import System.Posix.Signals
+    ( nullSignal
+    , sigINT
+    , sigKILL
+    , sigTERM
+    , signalProcessGroup
+    )
+import System.Posix.Types (ProcessGroupID)
 import System.Process
     ( CreateProcess(..)
     , ProcessHandle
     , StdStream(..)
     , createProcess
-    , interruptProcessGroupOf
+    , getPid
+    , getProcessExitCode
     , shell
     , terminateProcess
     , waitForProcess
@@ -79,21 +90,28 @@ data CommandResult = CommandResult
 
 data RunningCommand = RunningCommand
     { runningHandle :: !ProcessHandle
+    , runningGroupId :: !(Maybe ProcessGroupID)
     , runningResult :: !(MVar CommandResult)
-    , runningStdout :: !(IORef BS.ByteString)
-    , runningStderr :: !(IORef BS.ByteString)
-    , runningCap :: !Int
+    , runningStdout :: !(IORef CapturedBytes)
+    , runningStderr :: !(IORef CapturedBytes)
+    , runningStdoutHandle :: !Handle
+    , runningStderrHandle :: !Handle
     , runningSupervisor :: !(Async ())
+    }
+
+data CapturedBytes = CapturedBytes
+    { capturedBytes :: !BS.ByteString
+    , capturedDropped :: !Int
     }
 
 -- | Bytes already drained from a still-running command, decoded and capped.
 runningLiveOutput :: RunningCommand -> IO (Text, Text)
 runningLiveOutput running = do
-    outBytes <- readIORef running.runningStdout
-    errBytes <- readIORef running.runningStderr
+    out <- readIORef running.runningStdout
+    err <- readIORef running.runningStderr
     pure
-        ( truncateText running.runningCap (decodeUtf8With lenientDecode outBytes)
-        , truncateText running.runningCap (decodeUtf8With lenientDecode errBytes)
+        ( renderCapturedBytes out
+        , renderCapturedBytes err
         )
 
 -- | Run a shell command in @workdir@, killing the process group on timeout.
@@ -103,7 +121,7 @@ runShellCommand
     -> String
     -> Int
     -> IO CommandResult
-runShellCommand env workdir command timeoutMs = do
+runShellCommand env workdir command timeoutMs = mask \restore -> do
     let spec = (shell command)
             { cwd = Just (toFilePath workdir)
             , std_in = CreatePipe
@@ -120,17 +138,23 @@ runShellCommand env workdir command timeoutMs = do
             , commandCancelled = False
             }
         Right (Just hin, Just hout, Just herr, processHandle) -> do
-            hClose hin
+            groupId <- getPid processHandle
+            let closePipes =
+                    mapM_ (void . try @_ @SomeException . hClose) [hin, hout, herr]
+                stopCommand = do
+                    terminateProcessGroup groupId processHandle
+                    closePipes
+            hClose hin `onException` stopCommand
+            outRef <- newIORef emptyCapturedBytes
+            errRef <- newIORef emptyCapturedBytes
             let collect = do
                     -- Drain stdout and stderr concurrently so a child that
                     -- fills one pipe cannot deadlock the other.
-                    (outBytes, errBytes) <- concurrently
-                        (strictGetContents hout)
-                        (strictGetContents herr)
+                    (out, err) <- concurrently
+                        (drainHandle env.toolStdoutCap hout outRef)
+                        (drainHandle env.toolStdoutCap herr errRef)
                     code <- waitForProcess processHandle
-                    pure (outBytes, errBytes, code)
-                killGroup = void $ try @_ @SomeException
-                    (interruptProcessGroupOf processHandle)
+                    pure (out, err, code)
                 -- Prefer cancel over timeout when both fire: race cancel
                 -- against (timeout `race` collect).
                 waitStop = do
@@ -138,37 +162,41 @@ runShellCommand env workdir command timeoutMs = do
                     pure $ case timed of
                         Left () -> StopTimeout
                         Right triple -> StopDone triple
-            already <- isCancelled env.toolCancel
-            if already
-                then do
-                    killGroup
-                    pure cancelledResult
-                else do
-                    stopped <- race (waitCancel env.toolCancel) waitStop
-                    case stopped of
-                        Left () -> do
-                            killGroup
-                            pure cancelledResult
-                        Right StopTimeout -> do
-                            killGroup
-                            pure CommandResult
-                                { commandExitCode = Nothing
-                                , commandStdout = ""
-                                , commandStderr = ""
-                                , commandTimedOut = True
-                                , commandCancelled = False
-                                }
-                        Right (StopDone (outBytes, errBytes, code)) ->
-                            pure CommandResult
-                                { commandExitCode = Just (exitCodeInt code)
-                                , commandStdout = truncateText env.toolStdoutCap
-                                    (decodeUtf8With lenientDecode outBytes)
-                                , commandStderr = truncateText env.toolStdoutCap
-                                    (decodeUtf8With lenientDecode errBytes)
-                                , commandTimedOut = False
-                                , commandCancelled = False
-                                }
-        Right _ ->
+            restore (do
+                already <- isCancelled env.toolCancel
+                if already
+                    then do
+                        stopCommand
+                        pure cancelledResult
+                    else do
+                        stopped <- race (waitCancel env.toolCancel) waitStop
+                        case stopped of
+                            Left () -> do
+                                stopCommand
+                                pure cancelledResult
+                            Right StopTimeout -> do
+                                stopCommand
+                                pure CommandResult
+                                    { commandExitCode = Nothing
+                                    , commandStdout = ""
+                                    , commandStderr = ""
+                                    , commandTimedOut = True
+                                    , commandCancelled = False
+                                    }
+                            Right (StopDone (out, err, code)) -> do
+                                closePipes
+                                pure CommandResult
+                                    { commandExitCode = Just (exitCodeInt code)
+                                    , commandStdout = renderCapturedBytes out
+                                    , commandStderr = renderCapturedBytes err
+                                    , commandTimedOut = False
+                                    , commandCancelled = False
+                                    })
+                `onException` stopCommand
+        Right (hin, hout, herr, processHandle) -> do
+            groupId <- getPid processHandle
+            terminateProcessGroup groupId processHandle
+            closeOptionalPipes [hin, hout, herr]
             pure CommandResult
                 { commandExitCode = Just 127
                 , commandStdout = ""
@@ -180,7 +208,7 @@ runShellCommand env workdir command timeoutMs = do
 -- | Outcomes of racing timeout against completion (cancel is the other race arm).
 data ShellStop
     = StopTimeout
-    | StopDone (BS.ByteString, BS.ByteString, ExitCode)
+    | StopDone (CapturedBytes, CapturedBytes, ExitCode)
 
 cancelledResult :: CommandResult
 cancelledResult = CommandResult
@@ -209,89 +237,96 @@ startShellCommand env workdir command = do
     try @_ @SomeException
         (acquireRunningCommand spec env.toolStdoutCap) >>= \case
         Left err -> pure $ Left $ "Failed to start command: " <> Text.pack (show err)
-        Right running ->
-            pure (Right running)
+        Right running -> pure (Right running)
 
 acquireRunningCommand :: CreateProcess -> Int -> IO RunningCommand
-acquireRunningCommand spec outputCap =
-    mask \restore ->
-    restore (createProcess spec) >>= \case
-        (Just hin, Just hout, Just herr, processHandle) -> do
-            let rollback = cleanupProcess processHandle [hin, hout, herr]
-            flip onException rollback do
-                hClose hin
-                resultVar <- newEmptyMVar
-                stdoutRef <- newIORef BS.empty
-                stderrRef <- newIORef BS.empty
-                supervisor <- async $
-                    (do
-                        result <- try @_ @SomeException do
-                            ((outBytes, errBytes), code) <- concurrently
-                                (concurrently
-                                    (drainHandle hout stdoutRef)
-                                    (drainHandle herr stderrRef))
-                                (waitForProcess processHandle)
-                            pure (outBytes, errBytes, code)
-                        void $ tryPutMVar resultVar $ case result of
-                            Left exception -> commandFailure exception
-                            Right (outBytes, errBytes, code) -> CommandResult
+acquireRunningCommand spec outputCap = mask \restore -> do
+    created@(_, _, _, processHandle) <- createProcess spec
+    groupId <- getPid processHandle
+    case created of
+        (Just hin, Just hout, Just herr, _) -> do
+            let closePipes =
+                    mapM_ (void . try @_ @SomeException . hClose) [hin, hout, herr]
+                stopCreated = do
+                    terminateProcessGroup groupId processHandle
+                    closePipes
+            hClose hin `onException` stopCreated
+            resultVar <- newEmptyMVar
+            stdoutRef <- newIORef emptyCapturedBytes
+            stderrRef <- newIORef emptyCapturedBytes
+            supervisor <- asyncWithUnmask \unmask ->
+                (do
+                    result <- try @_ @SomeException $ unmask do
+                        ((out, err), code) <- concurrently
+                            (concurrently
+                                (drainHandle outputCap hout stdoutRef)
+                                (drainHandle outputCap herr stderrRef))
+                            (waitForProcessPolling processHandle)
+                        pure (out, err, code)
+                    commandResult <- case result of
+                        Left exception -> do
+                            terminateProcessGroup groupId processHandle
+                            pure (failedCommandResult exception)
+                        Right (out, err, code) ->
+                            pure CommandResult
                                 { commandExitCode = Just (exitCodeInt code)
-                                , commandStdout = truncateText outputCap
-                                    (decodeUtf8With lenientDecode outBytes)
-                                , commandStderr = truncateText outputCap
-                                    (decodeUtf8With lenientDecode errBytes)
+                                , commandStdout = renderCapturedBytes out
+                                , commandStderr = renderCapturedBytes err
                                 , commandTimedOut = False
                                 , commandCancelled = False
-                                })
-                    `finally` do
-                        void $ tryPutMVar resultVar cancelledResult
-                        mapM_
-                            (\handle ->
-                                void $ try @_ @SomeException (hClose handle))
-                            [hout, herr]
-                pure RunningCommand
+                                }
+                    void $ tryPutMVar resultVar commandResult)
+                `finally` do
+                    void $ tryPutMVar resultVar cancelledResult
+                    mapM_ (void . try @_ @SomeException . hClose) [hout, herr]
+            let running = RunningCommand
                     { runningHandle = processHandle
+                    , runningGroupId = groupId
                     , runningResult = resultVar
                     , runningStdout = stdoutRef
                     , runningStderr = stderrRef
-                    , runningCap = outputCap
+                    , runningStdoutHandle = hout
+                    , runningStderrHandle = herr
                     , runningSupervisor = supervisor
                     }
-        _ -> fail "Failed to capture command output"
-
-cleanupProcess :: ProcessHandle -> [Handle] -> IO ()
-cleanupProcess processHandle handles = do
-    void $ try @_ @SomeException (interruptProcessGroupOf processHandle)
-    void $ try @_ @SomeException (terminateProcess processHandle)
-    mapM_ (\handle -> void $ try @_ @SomeException (hClose handle)) handles
-    void $ try @_ @SomeException (waitForProcess processHandle)
+            restore (pure running) `onException` stopShellCommand running
+        (hin, hout, herr, _) -> do
+            terminateProcessGroup groupId processHandle
+            closeOptionalPipes [hin, hout, herr]
+            fail "Failed to capture command output"
 
 stopShellCommand :: RunningCommand -> IO ()
 stopShellCommand running = do
-    void $ try @_ @SomeException
-        (interruptProcessGroupOf running.runningHandle)
-    stopped <- race
-        (threadDelay 5000000)
-        (readMVar running.runningResult)
-    case stopped of
-        Right _ ->
+    finished <- tryReadMVar running.runningResult
+    case finished of
+        Just _ ->
             void (waitCatch running.runningSupervisor)
-        Left () -> do
-            void $ try @_ @SomeException
-                (terminateProcess running.runningHandle)
-            stoppedAfterTerminate <- race
+        Nothing -> do
+            terminateProcessGroup running.runningGroupId running.runningHandle
+            joined <- race
                 (threadDelay 1000000)
                 (readMVar running.runningResult)
-            case stoppedAfterTerminate of
+            case joined of
                 Right _ ->
                     void (waitCatch running.runningSupervisor)
                 Left () -> do
+                    closeRunningPipes running
                     cancel running.runningSupervisor
                     void (waitCatch running.runningSupervisor)
                     void $ tryPutMVar running.runningResult cancelledResult
+    closeRunningPipes running
 
-commandFailure :: SomeException -> CommandResult
-commandFailure exception = CommandResult
+closeRunningPipes :: RunningCommand -> IO ()
+closeRunningPipes running =
+    mapM_ (void . try @_ @SomeException . hClose)
+        [running.runningStdoutHandle, running.runningStderrHandle]
+
+closeOptionalPipes :: [Maybe Handle] -> IO ()
+closeOptionalPipes =
+    mapM_ (mapM_ (void . try @_ @SomeException . hClose))
+
+failedCommandResult :: SomeException -> CommandResult
+failedCommandResult exception = CommandResult
     { commandExitCode = Just 127
     , commandStdout = ""
     , commandStderr = Text.pack (show exception)
@@ -299,23 +334,56 @@ commandFailure exception = CommandResult
     , commandCancelled = False
     }
 
-strictGetContents :: Handle -> IO BS.ByteString
-strictGetContents handle = do
-    bytes <- BS.hGetContents handle
-    _ <- evaluate (BS.length bytes)
-    pure bytes
-
 -- | Read the handle in chunks so a live snapshot can see output before EOF.
-drainHandle :: Handle -> IORef BS.ByteString -> IO BS.ByteString
-drainHandle handle ref = go
+drainHandle :: Int -> Handle -> IORef CapturedBytes -> IO CapturedBytes
+drainHandle cap handle ref = go
   where
     go = do
         chunk <- BS.hGetSome handle 8192
         if BS.null chunk
             then readIORef ref
             else do
-                atomicModifyIORef' ref \soFar -> (soFar <> chunk, ())
+                atomicModifyIORef' ref \soFar ->
+                    (appendCapturedBytes cap chunk soFar, ())
                 go
+
+emptyCapturedBytes :: CapturedBytes
+emptyCapturedBytes = CapturedBytes
+    { capturedBytes = BS.empty
+    , capturedDropped = 0
+    }
+
+appendCapturedBytes :: Int -> BS.ByteString -> CapturedBytes -> CapturedBytes
+appendCapturedBytes cap chunk captured
+    | BS.null chunk = captured
+    | cap <= 0 =
+        captured { capturedBytes = captured.capturedBytes <> chunk }
+    | otherwise =
+        let remaining = max 0 (cap - BS.length captured.capturedBytes)
+            kept = BS.take remaining chunk
+        in CapturedBytes
+            { capturedBytes = captured.capturedBytes <> kept
+            , capturedDropped =
+                captured.capturedDropped + BS.length chunk - BS.length kept
+            }
+
+renderCapturedBytes :: CapturedBytes -> Text
+renderCapturedBytes captured =
+    decodeUtf8With lenientDecode captured.capturedBytes
+        <> if captured.capturedDropped <= 0
+            then ""
+            else
+                "\n...[truncated "
+                    <> Text.pack (show captured.capturedDropped)
+                    <> " bytes]"
+
+waitForProcessPolling :: ProcessHandle -> IO ExitCode
+waitForProcessPolling processHandle =
+    getProcessExitCode processHandle >>= \case
+        Just code -> pure code
+        Nothing -> do
+            threadDelay 10000
+            waitForProcessPolling processHandle
 
 exitCodeInt :: ExitCode -> Int
 exitCodeInt = \case
@@ -331,3 +399,62 @@ truncateText cap text
             <> "\n...[truncated "
             <> Text.pack (show (Text.length text - cap))
             <> " chars]"
+
+terminateProcessGroup
+    :: Maybe ProcessGroupID
+    -> ProcessHandle
+    -> IO ()
+terminateProcessGroup groupId processHandle = do
+    alive <- processGroupAlive groupId processHandle
+    whenAlive alive do
+        signalGroup sigINT
+        interrupted <- waitForProcessGroupExit groupId processHandle 250
+        unless interrupted do
+            signalGroup sigTERM
+            void $ try @_ @SomeException (terminateProcess processHandle)
+            terminated <- waitForProcessGroupExit groupId processHandle 750
+            unless terminated do
+                signalGroup sigKILL
+                void $ try @_ @SomeException (terminateProcess processHandle)
+                void $ waitForProcessGroupExit groupId processHandle 1000
+  where
+    whenAlive True action = action
+    whenAlive False _ = pure ()
+
+    signalGroup signal =
+        case groupId of
+            Just pid ->
+                void $ try @_ @SomeException (signalProcessGroup signal pid)
+            Nothing ->
+                void $ try @_ @SomeException (terminateProcess processHandle)
+
+waitForProcessGroupExit
+    :: Maybe ProcessGroupID
+    -> ProcessHandle
+    -> Int
+    -> IO Bool
+waitForProcessGroupExit groupId processHandle timeoutMs =
+    go (max 0 timeoutMs)
+  where
+    go remaining = do
+        alive <- processGroupAlive groupId processHandle
+        if not alive
+            then pure True
+            else if remaining <= 0
+                then pure False
+                else do
+                    let delayMs = min 10 remaining
+                    threadDelay (delayMs * 1000)
+                    go (remaining - delayMs)
+
+processGroupAlive
+    :: Maybe ProcessGroupID
+    -> ProcessHandle
+    -> IO Bool
+processGroupAlive groupId processHandle = do
+    processExit <- getProcessExitCode processHandle
+    case groupId of
+        Nothing -> pure (case processExit of Nothing -> True; Just _ -> False)
+        Just pid ->
+            isRight <$> try @_ @SomeException
+                (signalProcessGroup nullSignal pid)

--- a/packages/agent-core/test/Agent/Tools/GhciSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/GhciSpec.hs
@@ -24,13 +24,17 @@ import Agent.Tools.PlanMode (newPlanModeEnv)
 import Agent.Tools.Types (AppTool(..), ToolEnv(..))
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async (wait, withAsync)
-import Control.Exception.Safe (bracket)
+import Control.Exception.Safe (SomeException, bracket, try)
+import Data.Either (isRight)
 import Data.IORef
 import qualified Data.Map.Strict as Map
 import qualified Data.Text as Text
 import System.Directory (getTemporaryDirectory, removeDirectoryRecursive)
 import System.FilePath ((</>))
+import System.Posix.Signals (nullSignal, signalProcess)
 import System.Posix.Temp (mkdtemp)
+import System.Posix.Types (ProcessID)
+import System.Timeout (timeout)
 import Test.Hspec
 
 spec :: Spec
@@ -127,13 +131,31 @@ spec = describe "Agent.Tools.Ghci" do
             recovered.ghciOk `shouldBe` True
             recovered.ghciOutput `shouldSatisfy` Text.isInfixOf "4"
 
+    it "returns promptly when timed-out output fills the event queue" do
+        withTempEnv \baseEnv -> do
+            let env = baseEnv { toolStdoutCap = 64 }
+            bracket (newGhciSession env) closeGhciSession \ghci -> do
+                warmup <- evalGhci ghci "()" 10000
+                warmup.ghciOk `shouldBe` True
+                completed <- timeout 5000000
+                    (evalGhci ghci infiniteOutput 300)
+                timed <- requireCompleted "timed-out output" completed
+                timed.ghciOutcome `shouldBe` GhciTimedOut
+                timed.ghciTruncated `shouldBe` True
+                recovered <- evalGhci ghci "2 + 2" 10000
+                recovered.ghciOk `shouldBe` True
+                recovered.ghciOutput `shouldSatisfy` Text.isInfixOf "4"
+
     it "honors cancellation and recovers the persistent process" do
         withTempEnv \env ->
             bracket (newGhciSession env) closeGhciSession \ghci -> do
-                withAsync (evalGhci ghci "last [1..]" 10000) \running -> do
+                warmup <- evalGhci ghci "()" 10000
+                warmup.ghciOk `shouldBe` True
+                withAsync (evalGhci ghci infiniteOutput 10000) \running -> do
                     threadDelay 100000
                     requestCancel env.toolCancel
-                    cancelled <- wait running
+                    completed <- timeout 5000000 (wait running)
+                    cancelled <- requireCompleted "cancelled output" completed
                     cancelled.ghciOutcome `shouldBe` GhciCancelled
                 resetCancel env.toolCancel
                 recovered <- evalGhci ghci "2 + 3" 10000
@@ -176,6 +198,18 @@ spec = describe "Agent.Tools.Ghci" do
             recovered.ghciOk `shouldBe` True
             recovered.ghciOutput `shouldSatisfy` Text.isInfixOf "42"
 
+    it "kills the old process group after the GHCi leader exits" do
+        withTempEnv \env -> do
+            let pidFile = toFilePath env.toolCwd </> "background.pid"
+            bracket (newGhciSession env) closeGhciSession \ghci -> do
+                spawned <- evalGhci ghci (backgroundCommand pidFile) 10000
+                spawned.ghciOk `shouldBe` True
+                childPid <- read <$> readFile pidFile
+                processAlive childPid `shouldReturn` True
+                exited <- evalGhci ghci ":quit" 10000
+                exited.ghciOutcome `shouldBe` GhciProcessFailed
+                waitForProcessDeath childPid
+
     it "is terminal and idempotent after close" do
         withTempEnv \env -> do
             ghci <- newGhciSession env
@@ -201,6 +235,43 @@ spec = describe "Agent.Tools.Ghci" do
             coding <- codingToolsFor OpenAIProvider env Nothing Nothing
             map (.appToolName) coding.codingAppTools `shouldContain` ["run_ghci"]
             coding.codingClose
+
+infiniteOutput :: Text.Text
+infiniteOutput =
+    "let loop = putStrLn (replicate 4096 'x') >> loop in loop"
+
+backgroundCommand :: FilePath -> Text.Text
+backgroundCommand pidFile =
+    ":! (trap '' INT TERM; while :; do sleep 1; done) "
+        <> "</dev/null >/dev/null 2>&1 & echo $! > "
+        <> Text.pack (show pidFile)
+
+requireCompleted :: String -> Maybe a -> IO a
+requireCompleted label = \case
+    Just value -> pure value
+    Nothing -> do
+        expectationFailure (label <> " did not finish promptly")
+        fail label
+
+waitForProcessDeath :: ProcessID -> IO ()
+waitForProcessDeath pid = go (200 :: Int)
+  where
+    go remaining = do
+        alive <- processAlive pid
+        if not alive
+            then pure ()
+            else retry remaining
+
+    retry remaining
+        | remaining <= 0 =
+            expectationFailure ("process remained alive: " <> show pid)
+        | otherwise = do
+            threadDelay 10000
+            go (remaining - 1)
+
+processAlive :: ProcessID -> IO Bool
+processAlive pid =
+    isRight <$> try @_ @SomeException (signalProcess nullSignal pid)
 
 withTempEnv :: (ToolEnv -> IO a) -> IO a
 withTempEnv action =

--- a/packages/agent-core/test/Agent/Tools/IOSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/IOSpec.hs
@@ -13,7 +13,9 @@ import Agent.Tools.IO
     , readTextFile
     , resolveUnderCwd
     , runShellCommand
+    , runningLiveOutput
     , startShellCommand
+    , stopShellCommand
     , writeTextFile
     )
 import Agent.Tools.Types (ToolEnv(..), defaultToolEnv)
@@ -152,8 +154,42 @@ spec = describe "Agent.Tools.IO" do
             commandCancelled `shouldBe` True
             commandTimedOut `shouldBe` False
 
+    it "force-kills a process group on timeout" do
+        withTempDir checkTimeoutKillsProcessGroup
+
+    it "caps foreground output" do
+        withTempDir checkForegroundOutputCap
+
     it "collects both output streams from a background shell command" do
         withTempDir checkBackgroundOutput
+
+    it "caps live and final background output" do
+        withTempDir checkBackgroundOutputCap
+
+checkTimeoutKillsProcessGroup dir = do
+    let osDir = fromFilePath dir
+        heartbeatFile = dir </> "heartbeat"
+        command =
+            "trap '' INT TERM; "
+                <> "(trap '' INT TERM; i=0; while :; do "
+                <> "i=$((i + 1)); printf '%s' \"$i\" > "
+                <> show heartbeatFile
+                <> "; sleep 0.02; done) & wait"
+    env <- defaultToolEnv osDir
+    result <- runShellCommand env osDir command 200
+    result.commandTimedOut `shouldBe` True
+    threadDelay 200000
+    before <- readFile heartbeatFile
+    threadDelay 200000
+    readFile heartbeatFile `shouldReturn` before
+
+checkForegroundOutputCap dir = do
+    let osDir = fromFilePath dir
+    base <- defaultToolEnv osDir
+    let env = base { toolStdoutCap = 64 }
+    result <- runShellCommand env osDir "yes x | head -c 262144" 5000
+    Text.length result.commandStdout `shouldSatisfy` (< 128)
+    result.commandStdout `shouldSatisfy` Text.isInfixOf "[truncated"
 
 checkBackgroundOutput dir = do
     let osDir = fromFilePath dir
@@ -164,6 +200,22 @@ checkBackgroundOutput dir = do
     result.commandExitCode `shouldBe` Just 0
     result.commandStdout `shouldBe` "stdout"
     result.commandStderr `shouldBe` "stderr"
+
+checkBackgroundOutputCap dir = do
+    let osDir = fromFilePath dir
+    base <- defaultToolEnv osDir
+    let env = base { toolStdoutCap = 64 }
+    Right running <-
+        startShellCommand env osDir
+            "yes x | head -c 262144; sleep 30"
+    threadDelay 200000
+    (liveOut, _) <- runningLiveOutput running
+    Text.length liveOut `shouldSatisfy` (< 128)
+    liveOut `shouldSatisfy` Text.isInfixOf "[truncated"
+    stopShellCommand running
+    result <- readMVar running.runningResult
+    Text.length result.commandStdout `shouldSatisfy` (< 128)
+    result.commandStdout `shouldSatisfy` Text.isInfixOf "[truncated"
 
 checkConcurrentAtomicWrites :: FilePath -> IO ()
 checkConcurrentAtomicWrites dir = do


### PR DESCRIPTION
## Summary

- stream foreground and background stdout/stderr into bounded capture buffers while continuing to drain both pipes
- cache the spawned process-group id and escalate shutdown through INT, TERM, and KILL
- close pipes, reap the process leader, and join the tracked background supervisor during resource release
- avoid blocking a non-threaded runtime by polling background process completion instead of waiting in a blocking worker

This PR is limited to the shared shell-process helper and its regression tests.

## Validation

- `env -u GHCRTS cabal test agent-core-test --test-show-details=direct` — 216 examples, 0 failures
- regression tests cover forced process-group shutdown plus bounded foreground, live background, and final background output
- `git diff --check`
