### PR TITLE
test(cli): cover REPL cwd restoration

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -10,6 +10,7 @@ module Agent.CLI
     , formatReplStatusLine
     , formatTokenUsage
     , run
+    , withRestoredCurrentDirectory
     ) where
 
 import Agent.CLI.Artifact (fencedCodeBlock, lastDiffBlock)
@@ -448,9 +449,8 @@ run = do
 -- Automatic transitions carry the exact failed turn in memory and commit
 -- persisted provider metadata only after the replacement backend succeeds.
 runAgentWithRestarts :: CliOptions -> IO DevResult
-runAgentWithRestarts options = do
-    originalCwd <- getCurrentDirectory
-    go options Nothing `finally` setCurrentDirectory originalCwd
+runAgentWithRestarts options =
+    withRestoredCurrentDirectory (go options Nothing)
   where
     go current transition =
         runAgent current transition >>= \case
@@ -482,6 +482,14 @@ runAgentWithRestarts options = do
                     _ -> pure DevQuit
             RunQuit -> pure DevQuit
             RunReload sessionId -> pure (DevReload sessionId)
+
+-- | Restore the process cwd after an action succeeds or throws. Cabal gives
+-- GHCi relative source paths, so returning from an agent session in its cwd
+-- would make the following @:reload@ lose local modules.
+withRestoredCurrentDirectory :: IO a -> IO a
+withRestoredCurrentDirectory action = do
+    originalCwd <- getCurrentDirectory
+    action `finally` setCurrentDirectory originalCwd
 
 runListSessions :: IO ()
 runListSessions = do

--- a/packages/agent-cli/test/Agent/CLI/ReplStatusSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ReplStatusSpec.hs
@@ -8,6 +8,7 @@ import Agent.CLI
     , devArgs
     , formatReplStatusLine
     , formatTokenUsage
+    , withRestoredCurrentDirectory
     )
 import Agent.CLI.Input (terminalTextWidth)
 import Agent.CLI.Options (ApprovalPolicy(..))
@@ -20,9 +21,14 @@ import Agent.CLI.ReplMode
 import Agent.Loop (TokenUsage(..), emptyTokenUsage)
 import Agent.OsPath (fromFilePath)
 import Agent.Tools.PlanMode (PlanModeEnv(..), PlanModeState(..), newPlanModeEnv)
-import Control.Exception (bracket)
+import Control.Exception.Safe (bracket, throwIO)
 import Data.IORef (newIORef, readIORef)
-import System.Directory (getTemporaryDirectory, removeDirectoryRecursive)
+import System.Directory
+    ( getCurrentDirectory
+    , getTemporaryDirectory
+    , removeDirectoryRecursive
+    , setCurrentDirectory
+    )
 import System.Posix.Temp (mkdtemp)
 import Test.Hspec
 
@@ -59,6 +65,23 @@ spec = do
                         , ":module +Agent.CLI"
                         , ":cmd afterDev =<< devMainResume (Just \"2026-08-20-abcd1234\")"
                         ]
+
+    describe "withRestoredCurrentDirectory" do
+        it "restores the GHCi cwd after normal completion" do
+            original <- getCurrentDirectory
+            withTempDir "agent-repl-cwd-" \temporary -> do
+                withRestoredCurrentDirectory (setCurrentDirectory temporary)
+                getCurrentDirectory `shouldReturn` original
+
+        it "restores the GHCi cwd after an exception" do
+            original <- getCurrentDirectory
+            withTempDir "agent-repl-cwd-" \temporary -> do
+                let failAfterChangingDirectory = do
+                        setCurrentDirectory temporary
+                        throwIO (userError "boom")
+                withRestoredCurrentDirectory failAfterChangingDirectory
+                    `shouldThrow` anyIOException
+                getCurrentDirectory `shouldReturn` original
 
     describe "formatReplStatusLine" do
         it "shows model, effort, and interaction mode" do


### PR DESCRIPTION
## Summary

- factor process cwd restoration into a named, testable helper
- document why restoring the cwd is required for Cabal/GHCi relative source paths
- cover both normal completion and exceptional exits

The runtime restoration itself landed in #163 while this change was being rebased; this PR adds focused regression coverage for the missing-module failure.

## Testing

- `nix develop -c cabal repl agent-cli:test:agent-cli-test --repl-options=-ignore-dot-ghci`
- `:main --match withRestoredCurrentDirectory` — 2 examples, 0 failures
- live tmux smoke test with a resumed session rooted at `/tmp`: agent `:reload` reported `Ok, 49 modules reloaded.` and resumed the same session without missing-module errors
