### PR TITLE
Reduce REPL heap limit to 1 GiB

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,7 +94,7 @@ When changing the CLI UI (prompt, colors, chrome, keybindings, paste, approval p
 
 ### memory / RTS heap cap
 
-`nix develop` and the `repl` wrapper default `GHCRTS` to `-M8G -A64m` so the agent/GHCi process dies at an 8 GiB heap instead of OOMing the whole machine. The `agent-cli` executable is built with the same `-M8G -A64m` RTS defaults (overridable via `+RTS` because `-rtsopts` is enabled). Override when needed:
+`nix develop` and the `repl` wrapper default `GHCRTS` to `-M1G -A64m` so the agent/GHCi process dies at a 1 GiB heap instead of OOMing the whole machine. The `agent-cli` executable retains a separate `-M8G -A64m` RTS default (overridable via `+RTS` because `-rtsopts` is enabled). Override when needed:
 
 ```
 GHCRTS='-M16G -A64m' repl

--- a/flake.nix
+++ b/flake.nix
@@ -142,7 +142,7 @@
                     # Cap the agent/GHCi heap so a runaway session OOMs itself
                     # instead of the whole machine. Override with GHCRTS=...
                     if [ -z "''${GHCRTS:-}" ]; then
-                      export GHCRTS="-M8G -A64m"
+                      export GHCRTS="-M1G -A64m"
                     fi
                     cabal="${haskellPackages.cabal-install}/bin/cabal"
                     expect_bin="${pkgs.expect}/bin/expect"
@@ -211,7 +211,7 @@
                     # `repl` wrapper sets the same default if GHCRTS is unset.
                     shellHook = ''
                       if [ -z "''${GHCRTS:-}" ]; then
-                        export GHCRTS="-M8G -A64m"
+                        export GHCRTS="-M1G -A64m"
                       fi
                     '';
                 };


### PR DESCRIPTION
## Summary
- lower the default `GHCRTS` heap ceiling for the `repl` wrapper from 8 GiB to 1 GiB
- apply the same default in the Nix development shell so inherited settings stay consistent
- document that the packaged `agent-cli` executable retains its separate 8 GiB default

## Validation
- `nix-instantiate --parse flake.nix`
- `git diff --check`