### PR TITLE
feat(cli): add live agents pane and rich Markdown

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -81,6 +81,7 @@ library
                     , Agent.CLI.Timestamp
                     , Agent.CLI.Tools
                     , Agent.CLI.TUI.App
+                    , Agent.CLI.TUI.Bridge
                     , Agent.CLI.TUI.Markdown
                     , Agent.CLI.TUI.Theme
                     , Agent.CLI.UI.Model
@@ -169,6 +170,8 @@ test-suite agent-cli-test
                     , Agent.CLI.SkillsSpec
                     , Agent.CLI.SubagentStoreSpec
                     , Agent.CLI.ToolsSpec
+                    , Agent.CLI.TUIBridgeSpec
+                    , Agent.CLI.TUIMarkdownSpec
                     , Agent.CLI.UIModelSpec
                     , Agent.CLI.UsageSpec
                     , Agent.CLI.WorktreeSpec

--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -266,6 +266,7 @@ import Agent.Provider
 import Agent.Subagents
     ( RootTurnId
     , SubagentId(..)
+    , SubagentStatus(..)
     , abortRootTurn
     , beginRootTurn
     , closeSubagentRegistry
@@ -1023,10 +1024,17 @@ runSession options provider policy tools toolEnv planMode uiRuntimeRef prompt pe
           where
             materializeChild (path, agentId, status) = do
                 sessions <- readIORef subagentSessions
-                transcript <- case Map.lookup agentId sessions of
+                stored <- case Map.lookup agentId sessions of
                     Nothing -> pure ["(" <> formatAgentStatus status <> ")"]
                     Just session ->
                         responseItemLines <$> readIORef session.subSessionTranscript
+                let transcript = stored <> case status of
+                        Completed (Just result)
+                            | not (Text.null (Text.strip result)) ->
+                                ["assistant: " <> Text.strip result]
+                        Errored message ->
+                            ["error: " <> Text.strip message]
+                        _ -> []
                 pure AgentEntry
                     { agentTarget = AgentChild agentId
                     , agentPath = taskPathText path
@@ -1093,6 +1101,7 @@ runSession options provider policy tools toolEnv planMode uiRuntimeRef prompt pe
             (\active ->
                 when terminal.terminalNativeProgress $
                     setNativeProgress stderr active)
+            ((,) <$> readIORef selectedAgent <*> loadAgentEntries)
             useColor
             initialFullscreenState
         else pure Nothing
@@ -1756,24 +1765,8 @@ replWithDraft env@SessionEnv
                                 pickAgentChoice
                                     fullscreen color selected entries >>= \case
                                     Nothing -> pure ()
-                                    Just target -> do
+                                    Just target ->
                                         writeIORef viewport.viewportSelected target
-                                        case
-                                            [ entry
-                                            | entry <- entries
-                                            , entry.agentTarget == target
-                                            ] of
-                                            entry : _ ->
-                                                fullscreenEvent $
-                                                    UiSystemMessage $
-                                                        "agent "
-                                                            <> entry.agentPath
-                                                            <> " · "
-                                                            <> entry.agentStatus
-                                                            <> "\n"
-                                                            <> Text.unlines
-                                                                entry.agentTranscript
-                                            [] -> pure ()
                                 continue
 
                     ReplCopyLast -> do

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -18,6 +18,7 @@ import Agent.CLI.Input
     , readReplHistory
     , terminalTextWidth
     )
+import Agent.CLI.AgentViewport (AgentEntry(..), AgentTarget(..))
 import Agent.CLI.Interrupt (CtrlCDecision(..))
 import Agent.CLI.Command
     ( ReplAction(..)
@@ -32,9 +33,9 @@ import Agent.CLI.ReplMode (replModeLabel)
 import Agent.CLI.Render (formatElapsed, summarizeToolCall)
 import Agent.CLI.Status (formatTokenUsage)
 import qualified Agent.CLI.TUI.Theme as Theme
+import qualified Agent.CLI.TUI.Bridge as Bridge
 import Agent.CLI.TUI.Markdown (markdownWidget)
 import Agent.CLI.UI.Model
-import Agent.Loop (LoopEvent(..))
 import Agent.ToolDispatch (ToolCall(..))
 import Brick
 import Brick.BChan (BChan, newBChan, writeBChan)
@@ -54,7 +55,7 @@ import Control.Concurrent.STM
     , readTQueue
     , writeTQueue
     )
-import Control.Monad (forever, void, when)
+import Control.Monad (void, when)
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.State.Strict (modify')
 import Control.Exception.Safe (SomeException, finally, throwIO, tryAny)
@@ -97,6 +98,7 @@ data AppEvent
         !(TMVar (Maybe Text))
     | forall a. AppSuspend !(IO a) !(TMVar (Either SomeException a))
     | AppSetSkillCommands ![SkillCommand]
+    | AppAgentSnapshot !AgentTarget ![AgentEntry]
     | AppStop
 
 data FullscreenRuntime = FullscreenRuntime
@@ -106,6 +108,7 @@ data FullscreenRuntime = FullscreenRuntime
     , runtimeCtrlC :: !(IO CtrlCDecision)
     , runtimeCopy :: !(Text -> IO Bool)
     , runtimeNativeProgress :: !(Bool -> IO ())
+    , runtimeAgentSnapshot :: !(IO (AgentTarget, [AgentEntry]))
     , runtimeColor :: !Bool
     , runtimeInitial :: !UiState
     }
@@ -126,6 +129,8 @@ data AppState = AppState
     , appHistoryDraft :: !Text
     , appKillBuffer :: !Text
     , appSkillCommands :: ![SkillCommand]
+    , appAgentSelected :: !AgentTarget
+    , appAgentEntries :: ![AgentEntry]
     }
 
 data ChoiceOverlay = ChoiceOverlay
@@ -147,6 +152,7 @@ newFullscreenRuntime
     -> IO CtrlCDecision
     -> (Text -> IO Bool)
     -> (Bool -> IO ())
+    -> IO (AgentTarget, [AgentEntry])
     -> Bool
     -> UiState
     -> IO FullscreenRuntime
@@ -155,6 +161,7 @@ newFullscreenRuntime
     ctrlCAction
     copyAction
     nativeProgress
+    agentSnapshot
     color
     initial = FullscreenRuntime
     <$> newBChan 512
@@ -163,6 +170,7 @@ newFullscreenRuntime
     <*> pure ctrlCAction
     <*> pure copyAction
     <*> pure nativeProgress
+    <*> pure agentSnapshot
     <*> pure color
     <*> pure initial
 
@@ -235,6 +243,7 @@ withFullscreenSuspended runtime action = do
 runFullscreen :: FullscreenRuntime -> IO a -> IO a
 runFullscreen runtime workerAction = do
     history <- readReplHistory
+    (initialAgent, initialAgents) <- runtime.runtimeAgentSnapshot
     let vtyConfig =
             V.defaultConfig
                 { V.configPreferredColorMode = Just V.FullColor
@@ -263,6 +272,8 @@ runFullscreen runtime workerAction = do
             , appHistoryDraft = ""
             , appKillBuffer = ""
             , appSkillCommands = []
+            , appAgentSelected = initialAgent
+            , appAgentEntries = initialAgents
             }
     withAsync workerAction \worker ->
         withAsync ticker \_ticker ->
@@ -282,9 +293,17 @@ runFullscreen runtime workerAction = do
                         writeTQueue runtime.runtimeInput ReplEof
                     wait worker
   where
-    ticker = forever do
+    ticker = loop (0 :: Int)
+    loop tick = do
         threadDelay 100000
         writeBChan runtime.runtimeEvents (AppUi UiTick)
+        when (tick `mod` 5 == 0) do
+            tryAny runtime.runtimeAgentSnapshot >>= \case
+                Left _ -> pure ()
+                Right (selected, entries) ->
+                    writeBChan runtime.runtimeEvents
+                        (AppAgentSnapshot selected entries)
+        loop ((tick + 1) `mod` 10)
 
 handleChoiceKey :: V.Event -> EventM Name AppState ()
 handleChoiceKey = \case
@@ -482,15 +501,75 @@ drawMain state =
     withAttr Theme.baseAttr $
         vBox
             [ drawHeader state.appUi
-            , padTop (Pad 1) $
-                withVScrollBars OnRight $
-                    viewport ConversationViewport Vertical $
-                        padLeftRight 2 (drawTranscript state.appUi)
+            , drawWorkspace state
             , drawNotice state.appUi
             , drawSlashMenu state
             , drawComposer state.appUi
             , drawFooter state
             ]
+
+drawWorkspace :: AppState -> Widget Name
+drawWorkspace state =
+    padTop (Pad 1) $
+        hBox $
+            [ withVScrollBars OnRight $
+                viewport ConversationViewport Vertical $
+                    padLeftRight 2 (drawTranscript state.appUi)
+            ]
+                <> if length state.appAgentEntries <= 1
+                    then []
+                    else
+                        [ hLimit 42 $
+                            padLeft (Pad 1) $
+                                drawAgentPane
+                                    state.appAgentSelected
+                                    state.appAgentEntries
+                        ]
+
+drawAgentPane :: AgentTarget -> [AgentEntry] -> Widget Name
+drawAgentPane selected entries =
+    withAttr Theme.borderAttr $
+        withBorderStyle unicodeRounded $
+            borderWithLabel (txt " Agents ") $
+                padAll 1 $
+                    vBox
+                        [ vBox (map drawEntry entries)
+                        , padTop (Pad 1) $
+                            withAttr Theme.footerAttr $
+                                txtWrap
+                                    ("viewing "
+                                        <> maybe "/root" (.agentPath)
+                                            selectedEntry
+                                        <> " · /agents to switch")
+                        , padTop (Pad 1) $
+                            withAttr Theme.assistantAttr $
+                                vBox (map txtWrap transcript)
+                        ]
+  where
+    selectedEntry =
+        find ((== selected) . (.agentTarget)) entries
+    drawEntry entry =
+        let
+            marker =
+                if entry.agentTarget == selected then "› " else "  "
+            row =
+                txtWrap
+                    (marker
+                        <> entry.agentPath
+                        <> "  "
+                        <> entry.agentStatus)
+        in if entry.agentTarget == selected
+            then withAttr Theme.successAttr row
+            else row
+    transcript = case selectedEntry of
+        Nothing -> ["(agent unavailable)"]
+        Just entry ->
+            let rows =
+                    filter (not . Text.null . Text.strip)
+                        entry.agentTranscript
+            in if null rows
+                then ["(no transcript)"]
+                else drop (max 0 (length rows - 12)) rows
 
 drawHeader :: UiState -> Widget Name
 drawHeader state =
@@ -872,6 +951,13 @@ handleEvent event = case event of
             , appSlashIndex = 0
             , appSlashDismissed = False
             }
+    AppEvent (AppAgentSnapshot selected entries) ->
+        modify' \state ->
+            state
+                { appAgentSelected =
+                    Bridge.normalizeAgentSelection selected entries
+                , appAgentEntries = entries
+                }
     AppEvent (AppUi uiEvent) -> do
         modify' \state -> state
             { appUi = reduceUi uiEvent state.appUi
@@ -889,11 +975,11 @@ handleEvent event = case event of
                 _ -> state.appHistoryDraft
             }
         state <- get
-        case nativeProgressSignal uiEvent state.appUi of
+        case Bridge.nativeProgressSignal uiEvent state.appUi of
             Nothing -> pure ()
             Just active ->
                 liftIO (state.appRuntime.runtimeNativeProgress active)
-        when (eventFollows uiEvent && state.appUi.uiFollow) $
+        when (Bridge.eventFollows uiEvent && state.appUi.uiFollow) $
             vScrollToEnd (viewportScroll ConversationViewport)
     AppEvent (AppAskPermission summary reply) ->
         modify' \state ->
@@ -954,28 +1040,6 @@ handleEvent event = case event of
             (Nothing, Nothing, Just _) -> handlePermissionKey vtyEvent
             (Nothing, Nothing, Nothing) -> handleNormalKey vtyEvent
     _ -> pure ()
-
-eventFollows :: UiEvent -> Bool
-eventFollows = \case
-    UiLoop _ -> True
-    UiUserSubmitted _ -> True
-    UiAssistantHistory _ -> True
-    UiSystemMessage _ -> True
-    UiErrorMessage _ -> True
-    UiConversationCleared -> True
-    _ -> False
-
-nativeProgressSignal :: UiEvent -> UiState -> Maybe Bool
-nativeProgressSignal event state = case event of
-    UiLoop TurnStarted -> Just True
-    UiLoop (TurnFinished _) -> Just False
-    UiTurnEnded _ -> Just False
-    UiSetAwaitingInput True -> Just False
-    UiTick
-        | state.uiRunning
-        , state.uiFrame == 0 ->
-            Just True
-    _ -> Nothing
 
 handlePermissionKey :: V.Event -> EventM Name AppState ()
 handlePermissionKey = \case
@@ -1440,38 +1504,24 @@ handleComposerKey event = do
 
     moveHistory delta = do
         state <- get
-        let entries = state.appHistory
-            current = maybe (-1) id state.appHistoryIndex
-            next = current + delta
-        if null entries
-            then pure ()
-            else if next < 0
-                then modify' \currentState ->
-                    currentState
-                        { appUi =
-                            reduceUi
-                                (UiSetDraft
-                                    currentState.appHistoryDraft
-                                    (Text.length currentState.appHistoryDraft))
-                                currentState.appUi
-                        , appHistoryIndex = Nothing
-                        }
-                else when (next < length entries) do
-                    let text = entries !! next
-                        draft = case state.appHistoryIndex of
-                            Nothing -> state.appUi.uiDraft
-                            Just _ -> state.appHistoryDraft
-                    modify' \currentState ->
-                        currentState
-                            { appUi =
-                                reduceUi
-                                    (UiSetDraft text (Text.length text))
-                                    currentState.appUi
-                            , appHistoryIndex = Just next
-                            , appHistoryDraft = draft
-                            , appSlashIndex = 0
-                            , appSlashDismissed = False
-                            }
+        let (text, index, draft) =
+                Bridge.historyMove
+                    delta
+                    state.appHistory
+                    state.appHistoryIndex
+                    state.appUi.uiDraft
+                    state.appHistoryDraft
+        modify' \currentState ->
+            currentState
+                { appUi =
+                    reduceUi
+                        (UiSetDraft text (Text.length text))
+                        currentState.appUi
+                , appHistoryIndex = index
+                , appHistoryDraft = draft
+                , appSlashIndex = 0
+                , appSlashDismissed = False
+                }
 
     moveSlash delta count =
         modify' \current ->

--- a/packages/agent-cli/src/Agent/CLI/TUI/Bridge.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Bridge.hs
@@ -1,0 +1,64 @@
+-- | Pure fullscreen bridge decisions used by the Brick runtime.
+module Agent.CLI.TUI.Bridge
+    ( eventFollows
+    , historyMove
+    , nativeProgressSignal
+    , normalizeAgentSelection
+    ) where
+
+import Agent.CLI.AgentViewport (AgentEntry(..), AgentTarget(..))
+import Agent.CLI.UI.Model (UiEvent(..), UiState(..))
+import Agent.Loop (LoopEvent(..))
+import Data.Text (Text)
+
+eventFollows :: UiEvent -> Bool
+eventFollows = \case
+    UiLoop _ -> True
+    UiUserSubmitted _ -> True
+    UiAssistantHistory _ -> True
+    UiSystemMessage _ -> True
+    UiErrorMessage _ -> True
+    UiConversationCleared -> True
+    _ -> False
+
+nativeProgressSignal :: UiEvent -> UiState -> Maybe Bool
+nativeProgressSignal event state = case event of
+    UiLoop TurnStarted -> Just True
+    UiLoop (TurnFinished _) -> Just False
+    UiTurnEnded _ -> Just False
+    UiSetAwaitingInput True -> Just False
+    UiTick
+        | state.uiRunning
+        , state.uiFrame == 0 ->
+            Just True
+    _ -> Nothing
+
+historyMove
+    :: Int
+    -> [Text]
+    -> Maybe Int
+    -> Text
+    -> Text
+    -> (Text, Maybe Int, Text)
+historyMove delta entries currentIndex currentText savedDraft
+    | null entries = (currentText, currentIndex, savedDraft)
+    | next < 0 = (savedDraft, Nothing, savedDraft)
+    | next >= length entries = (currentText, currentIndex, savedDraft)
+    | otherwise =
+        let
+            text = entries !! next
+            draft = case currentIndex of
+                Nothing -> currentText
+                Just _ -> savedDraft
+        in (text, Just next, draft)
+  where
+    current = maybe (-1) id currentIndex
+    next = current + delta
+
+normalizeAgentSelection
+    :: AgentTarget
+    -> [AgentEntry]
+    -> AgentTarget
+normalizeAgentSelection selected entries
+    | any ((== selected) . (.agentTarget)) entries = selected
+    | otherwise = AgentRoot

--- a/packages/agent-cli/src/Agent/CLI/TUI/Markdown.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Markdown.hs
@@ -1,14 +1,36 @@
 -- | Lightweight fullscreen Markdown block rendering.
 module Agent.CLI.TUI.Markdown
-    ( markdownWidget
+    ( InlineSpan(..)
+    , InlineStyle(..)
+    , inlinePlainText
+    , markdownWidget
+    , parseInline
     ) where
 
+import Agent.CLI.Input (terminalTextWidth)
 import qualified Agent.CLI.TUI.Theme as Theme
 import Brick
+import qualified Brick.Types as B
 import Data.Char (isDigit, isSpace)
 import Data.List (transpose)
 import Data.Text (Text)
 import qualified Data.Text as Text
+import qualified Data.Text.Lazy as LazyText
+import qualified Graphics.Vty as V
+
+data InlineStyle
+    = InlinePlain
+    | InlineStrong
+    | InlineEmphasis
+    | InlineCode
+    | InlineLink
+    deriving (Eq, Show)
+
+data InlineSpan = InlineSpan
+    { inlineStyle :: !InlineStyle
+    , inlineText :: !Text
+    }
+    deriving (Eq, Show)
 
 markdownWidget :: Text -> Widget n
 markdownWidget input =
@@ -33,24 +55,24 @@ renderLines inFence (line : rest)
             : renderLines True rest
     | Just heading <- stripHeading line =
         withAttr Theme.headingAttr
-            (padTop (Pad 1) (txtWrap heading))
+            (padTop (Pad 1) (inlineWidget (parseInline heading)))
             : renderLines False rest
     | Just item <- stripBullet line =
         hBox
             [ withAttr Theme.headingAttr (txt "• ")
-            , txtWrap item
+            , inlineWidget (parseInline item)
             ]
             : renderLines False rest
     | Just (number, item) <- stripOrdered line =
         hBox
             [ withAttr Theme.headingAttr (txt (number <> ". "))
-            , txtWrap item
+            , inlineWidget (parseInline item)
             ]
             : renderLines False rest
     | Just quote <- Text.stripPrefix "> " (Text.stripStart line) =
         hBox
             [ withAttr Theme.mutedAttr (txt "│ ")
-            , withAttr Theme.mutedAttr (txtWrap quote)
+            , withAttr Theme.mutedAttr (inlineWidget (parseInline quote))
             ]
             : renderLines False rest
     | Text.null (Text.strip line) =
@@ -59,7 +81,7 @@ renderLines inFence (line : rest)
         withAttr Theme.mutedAttr (fill '─')
             : renderLines False rest
     | otherwise =
-        txtWrap line : renderLines False rest
+        inlineWidget (parseInline line) : renderLines False rest
 
 isFence :: Text -> Bool
 isFence line =
@@ -118,7 +140,8 @@ takeTable (rawHeader : separator : rest)
                                     (if headerRow
                                         then withAttr Theme.headingAttr
                                         else id)
-                                    (hLimit width (txt cell))
+                                    (hLimit width
+                                        (inlineWidget (parseInline cell)))
                               , withAttr Theme.mutedAttr (txt "│")
                               ]
                             | (width, cell) <- zip widths
@@ -169,3 +192,160 @@ asumPrefix prefixes text = case prefixes of
     prefix : rest -> case Text.stripPrefix prefix text of
         Just value -> Just value
         Nothing -> asumPrefix rest text
+
+parseInline :: Text -> [InlineSpan]
+parseInline = mergePlain . go Nothing
+  where
+    go _ text | Text.null text = []
+    go previous text
+        | Just (body, rest) <- delimited "**" text =
+            InlineSpan InlineStrong body : go (lastChar body) rest
+        | Just (body, rest) <- delimited "__" text =
+            InlineSpan InlineStrong body : go (lastChar body) rest
+        | Just (body, rest) <- codeSpan text =
+            InlineSpan InlineCode body : go (lastChar body) rest
+        | Just (label, url, rest) <- linkSpan text =
+            InlineSpan InlineLink
+                (label
+                    <> if Text.null url || label == url
+                        then ""
+                        else " (" <> url <> ")")
+                : go (lastChar label) rest
+        | Just (body, rest) <- emphasis previous '*' text =
+            InlineSpan InlineEmphasis body : go (lastChar body) rest
+        | Just (body, rest) <- emphasis previous '_' text =
+            InlineSpan InlineEmphasis body : go (lastChar body) rest
+        | otherwise =
+            case Text.uncons text of
+                Nothing -> []
+                Just (character, rest) ->
+                    InlineSpan InlinePlain (Text.singleton character)
+                        : go (Just character) rest
+
+    delimited marker text = do
+        after <- Text.stripPrefix marker text
+        let (body, closing) = Text.breakOn marker after
+        if Text.null body || Text.null closing
+            then Nothing
+            else Just (body, Text.drop (Text.length marker) closing)
+
+    codeSpan text = do
+        let (ticks, after) = Text.span (== '`') text
+        if Text.null ticks
+            then Nothing
+            else
+                let (body, closing) = Text.breakOn ticks after
+                in if Text.null closing
+                    then Nothing
+                    else Just
+                        ( body
+                        , Text.drop (Text.length ticks) closing
+                        )
+
+    linkSpan text = do
+        afterOpen <- Text.stripPrefix "[" text
+        let (label, afterLabel) = Text.breakOn "](" afterOpen
+        afterUrl <- Text.stripPrefix "](" afterLabel
+        let (url, closing) = Text.breakOn ")" afterUrl
+        if Text.null label || Text.null closing
+            then Nothing
+            else Just (label, url, Text.drop 1 closing)
+
+    emphasis previous marker text = do
+        after <- Text.stripPrefix (Text.singleton marker) text
+        let (body, closing) =
+                Text.breakOn (Text.singleton marker) after
+            openingBoundary =
+                maybe True (\character -> isSpace character
+                    || character `elem` ("([{\"'" :: String)) previous
+            closingRest = Text.drop 1 closing
+            closingBoundary = case Text.uncons closingRest of
+                Nothing -> True
+                Just (character, _) ->
+                    isSpace character
+                        || character `elem` (".,;:!?)]}\"'" :: String)
+        if Text.null body
+            || Text.null closing
+            || Text.any isSpace (Text.take 1 body)
+            || not openingBoundary
+            || not closingBoundary
+            then Nothing
+            else Just (body, closingRest)
+
+    lastChar value =
+        snd <$> Text.unsnoc value
+
+mergePlain :: [InlineSpan] -> [InlineSpan]
+mergePlain = foldr merge []
+  where
+    merge span_ (next : rest)
+        | span_.inlineStyle == next.inlineStyle =
+            InlineSpan span_.inlineStyle
+                (span_.inlineText <> next.inlineText)
+                : rest
+    merge span_ rest = span_ : rest
+
+inlinePlainText :: [InlineSpan] -> Text
+inlinePlainText = Text.concat . map (.inlineText)
+
+inlineWidget :: [InlineSpan] -> Widget n
+inlineWidget spans =
+    B.Widget B.Greedy B.Fixed do
+        context <- B.getContext
+        styled <- traverse resolve spans
+        let width = max 1 context.availWidth
+            rows = wrapStyled width styled
+            rendered =
+                V.vertCat
+                    [ V.horizCat
+                        [ V.text attr (LazyText.fromStrict text)
+                        | (attr, text) <- row
+                        ]
+                    | row <- rows
+                    ]
+        pure B.emptyResult { B.image = rendered }
+  where
+    resolve InlineSpan{inlineStyle, inlineText} = do
+        attr <- B.lookupAttrName (styleAttr inlineStyle)
+        pure (attr, inlineText)
+
+styleAttr :: InlineStyle -> AttrName
+styleAttr = \case
+    InlinePlain -> Theme.assistantAttr
+    InlineStrong -> Theme.strongAttr
+    InlineEmphasis -> Theme.emphasisAttr
+    InlineCode -> Theme.inlineCodeAttr
+    InlineLink -> Theme.linkAttr
+
+wrapStyled :: Int -> [(V.Attr, Text)] -> [[(V.Attr, Text)]]
+wrapStyled width spans =
+    finalize $
+        foldl addCell ([[]], 0) cells
+  where
+    cells =
+        [ (attr, Text.singleton character)
+        | (attr, text) <- spans
+        , character <- Text.unpack text
+        ]
+    addCell (rows, used) (attr, cell)
+        | cell == "\n" = ([] : rows, 0)
+        | used > 0
+        , used + cellWidth > width =
+            ([(attr, cell)] : rows, cellWidth)
+        | otherwise =
+            case rows of
+                [] -> ([[(attr, cell)]], cellWidth)
+                row : rest ->
+                    (appendCell attr cell row : rest, used + cellWidth)
+      where
+        cellWidth = terminalTextWidth cell
+    appendCell attr cell row =
+        case reverse row of
+            (previousAttr, previousText) : prior
+                | previousAttr == attr ->
+                    reverse
+                        ((previousAttr, previousText <> cell) : prior)
+            _ -> row <> [(attr, cell)]
+    finalize (rows, _) =
+        let ordered = reverse rows
+        in if null ordered then [[]] else ordered

--- a/packages/agent-cli/src/Agent/CLI/TUI/Theme.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Theme.hs
@@ -8,9 +8,13 @@ module Agent.CLI.TUI.Theme
     , footerAttr
     , headerAttr
     , codeAttr
+    , emphasisAttr
     , headingAttr
+    , inlineCodeAttr
+    , linkAttr
     , mutedAttr
     , selectedAttr
+    , strongAttr
     , successAttr
     , thinkingAttr
     , toolAttr
@@ -25,7 +29,7 @@ import qualified Graphics.Vty as V
 baseAttr, headerAttr, footerAttr, mutedAttr :: AttrName
 userAttr, assistantAttr, thinkingAttr, toolAttr :: AttrName
 errorAttr, successAttr, selectedAttr, borderAttr, borderActiveAttr :: AttrName
-headingAttr, codeAttr :: AttrName
+headingAttr, codeAttr, emphasisAttr, inlineCodeAttr, linkAttr, strongAttr :: AttrName
 baseAttr = attrName "base"
 headerAttr = attrName "header"
 footerAttr = attrName "footer"
@@ -41,6 +45,10 @@ borderAttr = attrName "border"
 borderActiveAttr = attrName "border-active"
 headingAttr = attrName "markdown-heading"
 codeAttr = attrName "markdown-code"
+emphasisAttr = attrName "markdown-emphasis"
+inlineCodeAttr = attrName "markdown-inline-code"
+linkAttr = attrName "markdown-link"
+strongAttr = attrName "markdown-strong"
 
 solarizedDark :: AttrMap
 solarizedDark =
@@ -95,6 +103,21 @@ solarizedDark =
         , (codeAttr, V.defAttr
             `V.withForeColor` rgb 42 161 152
             `V.withBackColor` rgb 7 54 66)
+        , (emphasisAttr, V.defAttr
+            `V.withForeColor` rgb 147 161 161
+            `V.withBackColor` rgb 0 43 54
+            `V.withStyle` V.italic)
+        , (inlineCodeAttr, V.defAttr
+            `V.withForeColor` rgb 42 161 152
+            `V.withBackColor` rgb 7 54 66)
+        , (linkAttr, V.defAttr
+            `V.withForeColor` rgb 38 139 210
+            `V.withBackColor` rgb 0 43 54
+            `V.withStyle` V.underline)
+        , (strongAttr, V.defAttr
+            `V.withForeColor` rgb 147 161 161
+            `V.withBackColor` rgb 0 43 54
+            `V.withStyle` V.bold)
         ]
 
 monochrome :: AttrMap
@@ -115,6 +138,10 @@ monochrome =
         , (borderActiveAttr, V.defAttr `V.withStyle` V.bold)
         , (headingAttr, V.defAttr `V.withStyle` V.bold)
         , (codeAttr, V.defAttr)
+        , (emphasisAttr, V.defAttr `V.withStyle` V.italic)
+        , (inlineCodeAttr, V.defAttr `V.withStyle` V.reverseVideo)
+        , (linkAttr, V.defAttr `V.withStyle` V.underline)
+        , (strongAttr, V.defAttr `V.withStyle` V.bold)
         ]
 
 rgb :: Int -> Int -> Int -> V.Color

--- a/packages/agent-cli/test/Agent/CLI/TUIBridgeSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIBridgeSpec.hs
@@ -1,0 +1,43 @@
+module Agent.CLI.TUIBridgeSpec (spec) where
+
+import Agent.CLI.AgentViewport (AgentEntry(..), AgentTarget(..))
+import Agent.CLI.TUI.Bridge
+import Agent.CLI.UI.Model
+import Agent.Loop (LoopEvent(..), emptyTurnOutput)
+import Agent.Subagents (SubagentId(..))
+import Test.Hspec
+
+spec :: Spec
+spec = describe "fullscreen TUI bridge" do
+    it "follows retained output events but not draft-only events" do
+        eventFollows (UiSystemMessage "copied") `shouldBe` True
+        eventFollows (UiErrorMessage "failed") `shouldBe` True
+        eventFollows (UiSetDraft "draft" 5) `shouldBe` False
+
+    it "starts, refreshes, and clears native terminal progress" do
+        let running = reduceUi (UiLoop TurnStarted) initialUiState
+            refresh = running { uiFrame = 0 }
+        nativeProgressSignal (UiLoop TurnStarted) running
+            `shouldBe` Just True
+        nativeProgressSignal UiTick refresh
+            `shouldBe` Just True
+        nativeProgressSignal
+            (UiLoop (TurnFinished (emptyTurnOutput "r1" [] Nothing)))
+            running
+            `shouldBe` Just False
+        nativeProgressSignal (UiTurnEnded BlockCancelled) running
+            `shouldBe` Just False
+
+    it "moves through history and restores the original draft" do
+        historyMove 1 ["new", "old"] Nothing "draft" ""
+            `shouldBe` ("new", Just 0, "draft")
+        historyMove 1 ["new", "old"] (Just 0) "new" "draft"
+            `shouldBe` ("old", Just 1, "draft")
+        historyMove (-1) ["new", "old"] (Just 0) "new" "draft"
+            `shouldBe` ("draft", Nothing, "draft")
+
+    it "falls back to root when the selected agent disappears" do
+        let child = AgentChild (SubagentId "child")
+            root = AgentEntry AgentRoot "/root" "active" []
+        normalizeAgentSelection child [root] `shouldBe` AgentRoot
+        normalizeAgentSelection AgentRoot [root] `shouldBe` AgentRoot

--- a/packages/agent-cli/test/Agent/CLI/TUIMarkdownSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIMarkdownSpec.hs
@@ -1,0 +1,30 @@
+module Agent.CLI.TUIMarkdownSpec (spec) where
+
+import Agent.CLI.TUI.Markdown
+import Test.Hspec
+
+spec :: Spec
+spec = describe "fullscreen Markdown inline parsing" do
+    it "parses strong, emphasis, code, and links" do
+        parseInline
+            "Use **bold**, *italics*, `code`, and [docs](https://example.com)."
+            `shouldBe`
+                [ InlineSpan InlinePlain "Use "
+                , InlineSpan InlineStrong "bold"
+                , InlineSpan InlinePlain ", "
+                , InlineSpan InlineEmphasis "italics"
+                , InlineSpan InlinePlain ", "
+                , InlineSpan InlineCode "code"
+                , InlineSpan InlinePlain ", and "
+                , InlineSpan InlineLink "docs (https://example.com)"
+                , InlineSpan InlinePlain "."
+                ]
+
+    it "supports multi-backtick code and avoids snake_case emphasis" do
+        let spans = parseInline "``a ` b`` and snake_case"
+        inlinePlainText spans `shouldBe` "a ` b and snake_case"
+        spans `shouldContain` [InlineSpan InlineCode "a ` b"]
+
+    it "leaves unmatched delimiters visible" do
+        inlinePlainText (parseInline "unfinished **bold")
+            `shouldBe` "unfinished **bold"

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -43,6 +43,8 @@ import qualified Agent.CLI.StyleSpec as StyleSpec
 import qualified Agent.CLI.TimestampSpec as TimestampSpec
 import qualified Agent.CLI.TerminalSpec as TerminalSpec
 import qualified Agent.CLI.ToolsSpec as ToolsSpec
+import qualified Agent.CLI.TUIBridgeSpec as TUIBridgeSpec
+import qualified Agent.CLI.TUIMarkdownSpec as TUIMarkdownSpec
 import qualified Agent.CLI.UIModelSpec as UIModelSpec
 import qualified Agent.CLI.UsageSpec as UsageSpec
 import qualified Agent.CLI.WorktreeSpec as WorktreeSpec
@@ -90,6 +92,8 @@ main = hspec do
     SkillsSpec.spec
     SubagentStoreSpec.spec
     ToolsSpec.spec
+    TUIBridgeSpec.spec
+    TUIMarkdownSpec.spec
     UIModelSpec.spec
     UsageSpec.spec
     WorktreeSpec.spec


### PR DESCRIPTION
## Summary

- add a persistent fullscreen agents pane that appears when child agents exist
- poll agent state while the TUI runs so status and transcript content update live
- keep `/agents` selection synchronized with the persistent pane
- append completed/error results to agent transcript previews
- render inline Markdown with native Brick/Vty attributes:
  - strong emphasis
  - italics
  - inline code
  - links with visible URLs
  - multi-backtick code spans
- extract pure fullscreen bridge decisions for regression testing
- cover retained-output follow behavior, native-progress lifecycle, history navigation, and disappearing agent selection

## Validation

- loaded `agent-cli:lib:agent-cli` successfully in GHCi under `nix develop`
- ran the complete `agent-cli` test suite in GHCi: **423 examples, 0 failures**
- live tmux smoke test confirmed:
  - the agents pane appears after spawning a child
  - child status updates from running to done
  - `/agents` switches the persistent selected pane
  - bold, italic, inline-code, and link styling render without Markdown markers
- `git diff --check`
