### PR TITLE
Fallback when remote compaction is unavailable

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Compaction.hs
+++ b/packages/agent-cli/src/Agent/CLI/Compaction.hs
@@ -304,8 +304,7 @@ shouldFallbackFromRemoteCompact = \case
             || (status >= 500 && status < 600)
     ProviderError errorType _ _ ->
         errorType `elem`
-            [ InvalidRequestError
-            , NotFoundError
+            [ NotFoundError
             , PreviousResponseNotFound
             , ApiErrorType
             , OverloadedError

--- a/packages/agent-cli/src/Agent/CLI/Compaction.hs
+++ b/packages/agent-cli/src/Agent/CLI/Compaction.hs
@@ -5,6 +5,7 @@ module Agent.CLI.Compaction
     , autoCompactOpenAiBackend
     , autoCompactOpenAiBackendWith
     , runProviderCompact
+    , shouldFallbackFromRemoteCompact
     ) where
 
 import Agent.Error (ApiError(..), ErrorType(..))
@@ -18,6 +19,7 @@ import Agent.OpenAI.CompactClient
     ( CompactRequest(..)
     , compactConversation
     )
+import qualified Agent.OpenAI.Client as OpenAI
 import Agent.OpenAI.Compaction
     ( buildLocalCompactedHistory
     , compactTranscriptAtLastCheckpoint
@@ -31,8 +33,7 @@ import Agent.Responses.LoopBackend
     )
 import Agent.Responses.Types
 import Agent.Provider
-    ( Credential
-    , Provider(..)
+    ( Provider(..)
     , TokenProvider
     , runWithTokenProvider
     )
@@ -116,17 +117,30 @@ compactOpenAI tokenProvider params history before focus = do
                     fromMaybe True params.parallelToolCalls
                 , compactReasoning = params.reasoning
                 }
-    items <- withExceptT formatApiError $
-        ExceptT (compactConversation provider request)
-    pure CompactOutcome
-        { compactBeforeTokens = before
-        , compactAfterTokens = estimateItemsTokens items
-        , compactHistory = items
-        , compactSummary =
-            "remote compact returned "
-                <> Text.pack (show (length items))
-                <> " items"
-        }
+    remoteResult <- lift (compactConversation provider request)
+    case remoteResult of
+        Right items ->
+            pure CompactOutcome
+                { compactBeforeTokens = before
+                , compactAfterTokens = estimateItemsTokens items
+                , compactHistory = items
+                , compactSummary =
+                    "remote compact returned "
+                        <> Text.pack (show (length items))
+                        <> " items"
+                }
+        Left remoteError
+            | shouldFallbackFromRemoteCompact remoteError ->
+                withExceptT (formatFallbackError remoteError) $
+                    summarizeLocal
+                        OpenAI.createCodexMessageWithProvider
+                        provider
+                        params
+                        history
+                        before
+                        focus
+            | otherwise ->
+                throwE (formatApiError remoteError)
 
 compactLocalXai
     :: Maybe TokenProvider
@@ -139,7 +153,9 @@ compactLocalXai tokenProvider params history before focus = do
     provider <- requireTokenProvider XAIProvider tokenProvider
     options <- lift XAI.clientOptionsFromEnv
     summarizeLocal
-        (XAI.createResponseWith options)
+        (\tokens request ->
+            runWithTokenProvider tokens \credential ->
+                XAI.createResponseWith options credential request)
         provider
         params
         history
@@ -157,7 +173,9 @@ compactLocalOpenRouter tokenProvider params history before focus = do
     provider <- requireTokenProvider OpenRouterProvider tokenProvider
     options <- lift OpenRouter.clientOptionsFromEnv
     summarizeLocal
-        (OpenRouter.createResponseWith options)
+        (\tokens request ->
+            runWithTokenProvider tokens \credential ->
+                OpenRouter.createResponseWith options credential request)
         provider
         params
         history
@@ -165,7 +183,7 @@ compactLocalOpenRouter tokenProvider params history before focus = do
         focus
 
 summarizeLocal
-    :: (Credential -> ResponseCreateParams -> IO (Either ApiError Response))
+    :: (TokenProvider -> ResponseCreateParams -> IO (Either ApiError Response))
     -> TokenProvider
     -> ResponseCreateParams
     -> [ResponseItem]
@@ -187,9 +205,7 @@ summarizeLocal send provider params history before focus = do
                 summaryParams
                 (history <> [userTextItem summaryPrompt])
     response <- withExceptT formatApiError $
-        ExceptT $
-            runWithTokenProvider provider \credential ->
-                send credential request
+        ExceptT (send provider request)
     summary <- case assistantTextFromResponse response of
         Nothing -> throwE "compaction produced no summary text"
         Just text -> pure text
@@ -274,6 +290,37 @@ providerLabel = \case
     OpenAIProvider -> "openai"
     XAIProvider -> "xai"
     OpenRouterProvider -> "openrouter"
+
+-- | The remote compact endpoint can be unavailable or reject payloads/models
+-- that the normal Responses endpoint accepts. Fall back locally for those
+-- endpoint-specific failures, but preserve terminal account, policy, quota,
+-- and context-window failures.
+shouldFallbackFromRemoteCompact :: ApiError -> Bool
+shouldFallbackFromRemoteCompact = \case
+    ConnectionError{} -> True
+    JsonDecodeError{} -> True
+    HttpError status _ ->
+        status `elem` [400, 404, 408, 409, 413, 422, 425]
+            || (status >= 500 && status < 600)
+    ProviderError errorType _ _ ->
+        errorType `elem`
+            [ InvalidRequestError
+            , NotFoundError
+            , PreviousResponseNotFound
+            , ApiErrorType
+            , OverloadedError
+            , ServiceUnavailableError
+            , PayloadTooLargeError
+            , WebSocketConnectionLimitReached
+            ]
+    CredentialsExhausted{} -> False
+
+formatFallbackError :: ApiError -> Text -> Text
+formatFallbackError remoteError localError =
+    "remote compact failed: "
+        <> formatApiError remoteError
+        <> "; local fallback failed: "
+        <> localError
 
 formatApiError :: ApiError -> Text
 formatApiError err = Text.pack (show err)

--- a/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
@@ -5,7 +5,9 @@ import Agent.CLI.Compaction
     , autoCompactOpenAiBackendWith
     , codexAutoCompactTokenLimit
     , runProviderCompact
+    , shouldFallbackFromRemoteCompact
     )
+import Agent.Error (ApiError(..), ErrorType(..))
 import Agent.Loop
 import Agent.OpenAI.Compaction (userTextItem)
 import Agent.Responses.Types (defaultResponseCreateParams)
@@ -33,6 +35,26 @@ spec = do
                     error "empty compaction unexpectedly requested credentials"
             runProviderCompact OpenAIProvider (Just provider) params transcript Nothing
                 `shouldReturn` Left "nothing to compact"
+
+    describe "shouldFallbackFromRemoteCompact" do
+        it "falls back when the remote compact endpoint returns Not Found" do
+            shouldFallbackFromRemoteCompact
+                (ProviderError NotFoundError "Not Found" Nothing)
+                `shouldBe` True
+            shouldFallbackFromRemoteCompact
+                (HttpError 404 "{\"detail\":\"Not Found\"}")
+                `shouldBe` True
+
+        it "does not mask account, quota, or context-window failures" do
+            shouldFallbackFromRemoteCompact
+                (ProviderError AuthenticationError "expired" Nothing)
+                `shouldBe` False
+            shouldFallbackFromRemoteCompact
+                (ProviderError UsageLimitReached "limit" Nothing)
+                `shouldBe` False
+            shouldFallbackFromRemoteCompact
+                (ProviderError ContextWindowExceeded "too long" Nothing)
+                `shouldBe` False
 
     describe "autoCompactOpenAiBackendWith" do
         it "compacts before the next request at the Codex token limit" do

--- a/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
@@ -50,6 +50,9 @@ spec = do
                 (ProviderError AuthenticationError "expired" Nothing)
                 `shouldBe` False
             shouldFallbackFromRemoteCompact
+                (ProviderError InvalidRequestError "bio_policy" Nothing)
+                `shouldBe` False
+            shouldFallbackFromRemoteCompact
                 (ProviderError UsageLimitReached "limit" Nothing)
                 `shouldBe` False
             shouldFallbackFromRemoteCompact

--- a/packages/agent-openai/src/Agent/OpenAI/Compaction.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Compaction.hs
@@ -168,4 +168,9 @@ compactTranscriptAtLastCheckpoint items = go [] (reverse items)
 hasCompactionCheckpoint :: [ResponseItem] -> Bool
 hasCompactionCheckpoint = any \case
     KnownResponseItem ItemCompaction _ -> True
+    MessageItem message
+        | message.role == RoleAssistant ->
+            maybe False
+                (Text.isPrefixOf summaryPrefix . Text.stripStart)
+                (messageText message)
     _ -> False

--- a/packages/agent-openai/test/Agent/OpenAI/CompactionSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/CompactionSpec.hs
@@ -54,6 +54,15 @@ spec = do
                 history = [user "old", trigger, user "recent"]
             compactTranscriptAtLastCheckpoint history `shouldBe` history
 
+    describe "hasCompactionCheckpoint" do
+        it "recognizes remote and local compaction snapshots" do
+            hasCompactionCheckpoint [checkpoint "remote"] `shouldBe` True
+            hasCompactionCheckpoint
+                (buildLocalCompactedHistory 1 [user "old"] "local summary")
+                `shouldBe` True
+            hasCompactionCheckpoint [assistant "ordinary response"]
+                `shouldBe` False
+
     describe "isCompactSessionTurn" do
         it "recognizes compact markers" do
             isCompactSessionTurn "/compact" `shouldBe` True


### PR DESCRIPTION
## Summary
- fall back to local OpenAI summarization when the remote `/responses/compact` endpoint is unavailable or rejects an otherwise supported request
- keep authentication, quota, policy, and context-window errors terminal
- include both errors when remote compaction and its local fallback fail
- cover the observed 404 and non-fallback error categories

## Testing
- loaded the full `agent-cli` library and test module graph in GHCi
- ran `Agent.CLI.CompactionSpec`: 5 examples, 0 failures
- `git diff --check`