### PR TITLE
Show fullscreen UI before loading skills

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -137,8 +137,8 @@ import Agent.CLI.Session
 import Agent.CLI.SessionEnv (SessionEnv(..))
 import Agent.CLI.Skills
     ( formatSkillsListing
+    , installSkillCatalog
     , loadSkillsCatalog
-    , queueSkillCatalogContext
     , reservedSlashNames
     , skillInvocationCommand
     )
@@ -234,7 +234,7 @@ import Agent.Skills
     ( Skill(..)
     , SkillCatalog(..)
     , SkillInvocation(..)
-    , buildSkillInvocations
+    , SkillWarning(..)
     , formatSkillActivation
     , resolveSkillInvocation
     , resolveSkillMentions
@@ -744,12 +744,12 @@ runAgent options transition = do
                 Nothing -> sessionTitleFromPrompt <$> prompt
         setCliWindowTitle stdoutTty stdout (cliWindowTitle cwd titleHint)
         startupContext <- loadAgentsContext options provider home cwd initialItems initialPrevious
-        skills <- loadSkillsCatalog options home projectRoot cwd True
-        skillsRef <- newIORef skills
-        skillInvocationsRef <- newIORef
-            (buildSkillInvocations reservedSlashNames skills)
-        when (null initialItems && not (isJust initialPrevious)) $
-            queueSkillCatalogContext startupContext skills
+        -- Fullscreen sessions load skills after Brick has taken over the
+        -- terminal, so filesystem discovery cannot delay the first frame.
+        -- Minimal and one-shot sessions still initialize them synchronously
+        -- before their first prompt/turn below.
+        skillsRef <- newIORef (SkillCatalog [] [])
+        skillInvocationsRef <- newIORef []
 
         persist <- preparePersistence options root provider model cwd effort prompt resumed
         writeIORef persistSlotRef persist
@@ -1058,20 +1058,17 @@ runSession options provider policy tools toolEnv planMode uiRuntimeRef prompt pe
             freshAgents <-
                 loadAgentsContext options provider home cwd [] Nothing
             freshSkills <- loadSkillsCatalog options home projectRoot cwd True
-            writeIORef skillsRef freshSkills
-            writeIORef skillInvocationsRef
-                (buildSkillInvocations reservedSlashNames freshSkills)
-            queueSkillCatalogContext freshAgents freshSkills
+            installSkillCatalog
+                reservedSlashNames True freshAgents
+                skillsRef skillInvocationsRef freshSkills
             fresh <- readIORef freshAgents
             writeIORef startupContext fresh
         refreshSkills queueContext = do
             refreshed <- loadSkillsCatalog
                 options home projectRoot cwd queueContext
-            writeIORef skillsRef refreshed
-            writeIORef skillInvocationsRef
-                (buildSkillInvocations reservedSlashNames refreshed)
-            when queueContext $
-                queueSkillCatalogContext startupContext refreshed
+            installSkillCatalog
+                reservedSlashNames queueContext startupContext
+                skillsRef skillInvocationsRef refreshed
     policyRef <- newIORef policy
     stderrTty <- hIsTerminalDevice stderr
     stdinTty <- hIsTerminalDevice stdin
@@ -1087,12 +1084,14 @@ runSession options provider policy tools toolEnv planMode uiRuntimeRef prompt pe
                 && options.optScreenMode /= ScreenMinimal
         initialFullscreenState =
             reduceUi
-                (UiSetRepository
-                    branch
-                    (toText (takeFileName (takeDirectory cwd))
-                        <> "/"
-                        <> toText (takeFileName cwd)))
-                (hydrateUiHistory initialTurns)
+                (UiSetNotice (Just "Starting…"))
+                (reduceUi
+                    (UiSetRepository
+                        branch
+                        (toText (takeFileName (takeDirectory cwd))
+                            <> "/"
+                            <> toText (takeFileName cwd)))
+                    (hydrateUiHistory initialTurns))
     fullscreen <- if fullscreenEnabled
         then Just <$> newFullscreenRuntime
             (requestCancel toolEnv.toolCancel)
@@ -1228,17 +1227,38 @@ runSession options provider policy tools toolEnv planMode uiRuntimeRef prompt pe
             , sessionOnPersisted = onPersisted
             , sessionReset = sessionReset
             }
-    let sessionAction = case pendingTurn of
-            Just pending ->
-                runPendingTurn env pending
-            Nothing -> case prompt of
-                Just text -> do
-                    inputs <- preparePromptSkillInputs env text [UserMessage text]
-                        >>= either (die . Text.unpack) pure
-                    result <- runOneTurn env text inputs
-                    finishTurn env True result
-                Nothing ->
-                    repl env
+    let formatSkillWarning warning =
+            "skill ignored: "
+                <> toText warning.skillWarningPath
+                <> ": "
+                <> warning.skillWarningMessage
+        initializeSkills = do
+            skills <- loadSkillsCatalog
+                options home projectRoot cwd (isNothing fullscreen)
+            installSkillCatalog
+                reservedSlashNames
+                (null initialTurns && not (isJust initialPrevious))
+                startupContext skillsRef skillInvocationsRef skills
+            case fullscreen of
+                Nothing -> pure ()
+                Just runtime -> do
+                    mapM_
+                        (emitUiEvent runtime . UiSystemMessage . formatSkillWarning)
+                        skills.catalogWarnings
+                    emitUiEvent runtime (UiSetNotice Nothing)
+        sessionAction = do
+            initializeSkills
+            case pendingTurn of
+                Just pending ->
+                    runPendingTurn env pending
+                Nothing -> case prompt of
+                    Just text -> do
+                        inputs <- preparePromptSkillInputs env text [UserMessage text]
+                            >>= either (die . Text.unpack) pure
+                        result <- runOneTurn env text inputs
+                        finishTurn env True result
+                    Nothing ->
+                        repl env
     result <-
         (case fullscreen of
             Nothing -> sessionAction

--- a/packages/agent-cli/src/Agent/CLI/Skills.hs
+++ b/packages/agent-cli/src/Agent/CLI/Skills.hs
@@ -1,6 +1,7 @@
 -- | CLI presentation and lifecycle helpers for filesystem Agent Skills.
 module Agent.CLI.Skills
     ( formatSkillsListing
+    , installSkillCatalog
     , loadSkillsCatalog
     , queueSkillCatalogContext
     , reservedSlashNames
@@ -25,7 +26,7 @@ import Agent.CLI.Terminal (resolveColor)
 import Agent.OsPath (OsPath, toText)
 import Agent.Skills
 import Control.Monad (when)
-import Data.IORef (IORef, modifyIORef')
+import Data.IORef (IORef, modifyIORef', writeIORef)
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -92,6 +93,23 @@ queueSkillCatalogContext contextRef catalog =
                             <> "skills: "
                             <> Text.pack (show omitted)
                             <> " omitted from model context due to the catalog budget")
+
+-- | Publish a freshly discovered catalog to all session consumers. Keeping
+-- this transition in one helper lets fullscreen startup begin with empty refs
+-- and install the complete catalog once background discovery finishes.
+installSkillCatalog
+    :: [Text]
+    -> Bool
+    -> IORef (Maybe Text)
+    -> IORef SkillCatalog
+    -> IORef [SkillInvocation]
+    -> SkillCatalog
+    -> IO ()
+installSkillCatalog reservedNames queueContext contextRef catalogRef invocationsRef catalog = do
+    writeIORef catalogRef catalog
+    writeIORef invocationsRef (buildSkillInvocations reservedNames catalog)
+    when queueContext $
+        queueSkillCatalogContext contextRef catalog
 
 skillInvocationCommand :: SkillInvocation -> SkillCommand
 skillInvocationCommand invocation =

--- a/packages/agent-cli/test/Agent/CLI/SkillsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SkillsSpec.hs
@@ -38,6 +38,21 @@ spec = describe "Agent.CLI.Skills" do
             , skillCommandSource = "user · agents"
             }
 
+    it "installs a deferred catalog, invocations, and startup context together" do
+        context <- newIORef (Just "agents")
+        catalogRef <- newIORef (SkillCatalog [] [])
+        invocationsRef <- newIORef []
+        let catalog = SkillCatalog [fakeSkill] []
+        installSkillCatalog
+            ["help"] True context catalogRef invocationsRef catalog
+        readIORef catalogRef `shouldReturn` catalog
+        readIORef invocationsRef `shouldReturn`
+            [SkillInvocation "deploy" fakeSkill True]
+        readIORef context >>= \case
+            Nothing -> expectationFailure "expected startup context"
+            Just text ->
+                text `shouldSatisfy` Text.isPrefixOf "agents\n\n## Skills"
+
 fakeSkill :: Skill
 fakeSkill = Skill
     { skillName = "deploy"


### PR DESCRIPTION
## Summary

- initialize fullscreen sessions with an empty skill catalog so filesystem discovery no longer blocks the first TUI frame
- show a temporary `Starting…` notice, then install discovered skills before accepting the first prompt
- route skill discovery warnings through fullscreen UI events and centralize catalog/invocation/context publication

## Validation

- loaded and typechecked `agent-cli` in the Nix development shell
- ran the full `agent-cli` test suite in GHCi: 421 examples, 0 failures
- exercised the live fullscreen agent in tmux and verified the prompt renders cleanly and `/skills` is populated after startup
