### PR TITLE
Make the fullscreen subagent pane interactive

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -1110,6 +1110,7 @@ runSession options provider policy tools toolEnv planMode uiRuntimeRef prompt pe
                 when terminal.terminalNativeProgress $
                     setNativeProgress stderr active)
             ((,) <$> readIORef selectedAgent <*> loadAgentEntries)
+            (writeIORef selectedAgent)
             useColor
             initialFullscreenState
         else pure Nothing

--- a/packages/agent-cli/src/Agent/CLI/AgentViewport.hs
+++ b/packages/agent-cli/src/Agent/CLI/AgentViewport.hs
@@ -4,15 +4,19 @@ module Agent.CLI.AgentViewport
     , AgentTarget(..)
     , AgentViewportEnv(..)
     , AgentViewportState(..)
+    , agentEntryTreeLabel
     , applyAgentViewportKey
     , formatAgentStatus
     , initialAgentViewportState
     , pickAgentViewport
+    , refreshAgentViewportState
     , renderAgentTree
     , renderAgentViewportPanelFor
     , renderAgentViewportFrame
     , renderAgentViewportFrameFor
     , responseItemLines
+    , selectAgentTarget
+    , selectedAgentEntry
     ) where
 
 import Agent.CLI.Picker (PickerKey(..), runOverlay)
@@ -71,10 +75,28 @@ initialAgentViewportState selected entries =
   where
     ordered = sortOn (.agentPath) entries
 
-selectedEntry :: AgentViewportState -> Maybe AgentEntry
-selectedEntry state = case state.viewportAll of
+selectedAgentEntry :: AgentViewportState -> Maybe AgentEntry
+selectedAgentEntry state = case state.viewportAll of
     [] -> Nothing
     entries -> Just (entries !! clamp (length entries) state.viewportIndex)
+
+refreshAgentViewportState
+    :: [AgentEntry]
+    -> AgentViewportState
+    -> AgentViewportState
+refreshAgentViewportState entries state =
+    initialAgentViewportState selected entries
+  where
+    selected =
+        maybe AgentRoot (.agentTarget) (selectedAgentEntry state)
+
+selectAgentTarget :: AgentTarget -> AgentViewportState -> AgentViewportState
+selectAgentTarget target state =
+    state
+        { viewportIndex =
+            maybe state.viewportIndex id
+                (findIndex ((== target) . (.agentTarget)) state.viewportAll)
+        }
 
 applyAgentViewportKey
     :: PickerKey
@@ -82,7 +104,7 @@ applyAgentViewportKey
     -> Either (Maybe AgentTarget) AgentViewportState
 applyAgentViewportKey key state = case key of
     PickerKeyCancel -> Left Nothing
-    PickerKeyConfirm -> Left ((.agentTarget) <$> selectedEntry state)
+    PickerKeyConfirm -> Left ((.agentTarget) <$> selectedAgentEntry state)
     PickerKeyUp -> Right (move (-1) state)
     PickerKeyDown -> Right (move 1 state)
     _ -> Right state
@@ -118,13 +140,9 @@ renderAgentTree color selected entries
     renderEntry (index, entry) =
         let isSelected = entry.agentTarget == effectiveSelected
             marker = if isSelected then "› " else "  "
-            branch = treePrefix ordered index entry.agentPath
             line =
                 marker
-                    <> branch
-                    <> pathName entry.agentPath
-                    <> "  "
-                    <> entry.agentStatus
+                    <> agentEntryTreeLabel ordered index entry
         in if isSelected then roleSuccess color line else line
 
 renderAgentViewportFrame :: Bool -> AgentViewportState -> Text
@@ -163,7 +181,7 @@ renderAgentViewportPanelFor color terminalCols selected entries
   where
     state = initialAgentViewportState selected entries
     selectedPath =
-        maybe "/root" (.agentPath) (selectedEntry state)
+        maybe "/root" (.agentPath) (selectedAgentEntry state)
 
 renderAgentViewportFor
     :: Bool
@@ -183,7 +201,7 @@ renderAgentViewportFor color bodyRows terminalCols footerText state =
     n = length entries
     idx = clamp n state.viewportIndex
     shown = entryWindow bodyRows idx entries
-    selected = selectedEntry state
+    selected = selectedAgentEntry state
     header =
         rolePrompt color "agents"
             <> roleMuted color
@@ -201,10 +219,10 @@ renderAgentViewportFor color bodyRows terminalCols footerText state =
         map
             (\(absoluteIndex, entry) ->
                 let prefix = if absoluteIndex == idx then "› " else "  "
-                    branch = treePrefix entries absoluteIndex entry.agentPath
                     text = fitCell leftWidth
-                        (prefix <> branch <> pathName entry.agentPath
-                            <> "  " <> entry.agentStatus)
+                        (prefix
+                            <> agentEntryTreeLabel
+                                entries absoluteIndex entry)
                 in if absoluteIndex == idx
                     then roleSuccess color text
                     else text)
@@ -298,6 +316,13 @@ findByTarget target = go
     go (entry : rest)
         | entry.agentTarget == target = Just entry
         | otherwise = go rest
+
+agentEntryTreeLabel :: [AgentEntry] -> Int -> AgentEntry -> Text
+agentEntryTreeLabel entries index entry =
+    treePrefix entries index entry.agentPath
+        <> pathName entry.agentPath
+        <> "  "
+        <> entry.agentStatus
 
 pathName :: Text -> Text
 pathName path =

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -22,7 +22,11 @@ import Agent.CLI.Input
     , readReplHistory
     , terminalTextWidth
     )
-import Agent.CLI.AgentViewport (AgentEntry(..), AgentTarget(..))
+import Agent.CLI.AgentViewport
+    ( AgentEntry(..)
+    , AgentTarget(..)
+    , agentEntryTreeLabel
+    )
 import Agent.CLI.Interrupt (CtrlCDecision(..))
 import Agent.CLI.Command
     ( ReplAction(..)
@@ -67,7 +71,7 @@ import Control.Exception (AsyncException(UserInterrupt))
 import Data.ByteString (ByteString)
 import Data.Char (isControl)
 import Data.Foldable (toList)
-import Data.List (find, intersperse)
+import Data.List (find, intersperse, sortOn)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
@@ -86,6 +90,7 @@ data Name
     | ComposerMode
     | ChoiceRow !Int
     | OverlayCursor
+    | AgentRow !AgentTarget
     deriving (Eq, Ord, Show)
 
 data AppEvent
@@ -115,6 +120,7 @@ data FullscreenRuntime = FullscreenRuntime
     , runtimeCopy :: !(Text -> IO Bool)
     , runtimeNativeProgress :: !(Bool -> IO ())
     , runtimeAgentSnapshot :: !(IO (AgentTarget, [AgentEntry]))
+    , runtimeAgentSelect :: !(AgentTarget -> IO ())
     , runtimeColor :: !Bool
     , runtimeInitial :: !UiState
     }
@@ -159,6 +165,7 @@ newFullscreenRuntime
     -> (Text -> IO Bool)
     -> (Bool -> IO ())
     -> IO (AgentTarget, [AgentEntry])
+    -> (AgentTarget -> IO ())
     -> Bool
     -> UiState
     -> IO FullscreenRuntime
@@ -168,6 +175,7 @@ newFullscreenRuntime
     copyAction
     nativeProgress
     agentSnapshot
+    agentSelect
     color
     initial = FullscreenRuntime
     <$> newBChan 512
@@ -177,6 +185,7 @@ newFullscreenRuntime
     <*> pure copyAction
     <*> pure nativeProgress
     <*> pure agentSnapshot
+    <*> pure agentSelect
     <*> pure color
     <*> pure initial
 
@@ -565,7 +574,7 @@ drawAgentPane selected entries =
             borderWithLabel (txt " Agents ") $
                 padAll 1 $
                     vBox
-                        [ vBox (map drawEntry entries)
+                        [ vBox (map drawEntry (zip [0 ..] ordered))
                         , padTop (Pad 1) $
                             withAttr Theme.footerAttr $
                                 txtWrap
@@ -578,21 +587,22 @@ drawAgentPane selected entries =
                                 vBox (map txtWrap transcript)
                         ]
   where
+    ordered = sortOn (.agentPath) entries
     selectedEntry =
-        find ((== selected) . (.agentTarget)) entries
-    drawEntry entry =
+        find ((== selected) . (.agentTarget)) ordered
+    drawEntry (index, entry) =
         let
             marker =
                 if entry.agentTarget == selected then "› " else "  "
             row =
-                txtWrap
+                txt
                     (marker
-                        <> entry.agentPath
-                        <> "  "
-                        <> entry.agentStatus)
-        in if entry.agentTarget == selected
-            then withAttr Theme.successAttr row
-            else row
+                        <> agentEntryTreeLabel ordered index entry)
+            styled =
+                if entry.agentTarget == selected
+                    then withAttr Theme.successAttr row
+                    else row
+        in clickable (AgentRow entry.agentTarget) styled
     transcript = case selectedEntry of
         Nothing -> ["(agent unavailable)"]
         Just entry ->
@@ -1066,6 +1076,11 @@ handleEvent event = case event of
                         handlePromptControlClick ReplChooseEffort
                     (ComposerMode, V.BLeft) ->
                         handlePromptControlClick ReplCycleMode
+                    (AgentRow target, V.BLeft) -> do
+                        liftIO
+                            (state.appRuntime.runtimeAgentSelect target)
+                        modify' \current ->
+                            current { appAgentSelected = target }
                     _ -> handleMouseDown name button
             (Nothing, Just _, _) ->
                 case (name, button) of

--- a/packages/agent-cli/test/Agent/CLI/AgentViewportSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/AgentViewportSpec.hs
@@ -52,6 +52,23 @@ spec = do
             applyAgentViewportKey PickerKeyCancel moved
                 `shouldBe` Left Nothing
 
+        it "selects clicked targets and preserves them across live refreshes" do
+            let selected =
+                    selectAgentTarget
+                        (AgentChild (SubagentId "alpha"))
+                        state
+                refreshed =
+                    refreshAgentViewportState
+                        [ rootEntry
+                        , child "alpha" "/root/alpha" "done"
+                        , child "gamma" "/root/alpha/gamma" "running"
+                        ]
+                        selected
+            (.agentTarget) <$> selectedAgentEntry refreshed
+                `shouldBe` Just (AgentChild (SubagentId "alpha"))
+            (.agentStatus) <$> selectedAgentEntry refreshed
+                `shouldBe` Just "done"
+
         it "renders hierarchy and transcript panes" do
             let frame = renderAgentViewportFrameFor False 10 70 state
             frame `shouldSatisfy` Text.isInfixOf "hierarchy"


### PR DESCRIPTION
## Summary
- render the fullscreen agents pane as a nested Finder-style hierarchy
- make every agent row clickable and immediately switch the displayed transcript
- persist the selected agent through the shared session viewport state
- preserve selection when live agent snapshots refresh

## Validation
- GHCi: full `agent-cli` test suite, 428 examples passing
- tmux TTY smoke test: verified nested hierarchy rendering and mouse selection updates the child transcript
