### PR TITLE
Use persistent supervisors for subagent resources

### DIFF
--- a/packages/agent-core/src/Agent/Subagents/Registry.hs
+++ b/packages/agent-core/src/Agent/Subagents/Registry.hs
@@ -5,6 +5,8 @@
 -- and wait with timeouts via 'threadDelay'.
 module Agent.Subagents.Registry
     ( SubagentRegistry
+    , SubagentLease
+    , subagentLease
     , newSubagentRegistry
     , setSubagentRunner
     , setSubagentOnComplete
@@ -56,6 +58,7 @@ import Agent.Cancel
     , newCancelFlag
     , requestCancel
     , resetCancel
+    , waitCancel
     )
 import Agent.InterAgentMessage
     ( InterAgentMessage(..)
@@ -65,14 +68,6 @@ import Agent.InterAgentMessage
     )
 import Agent.Loop (LoopError(..), LoopEvent, LoopResult(..))
 import Agent.OsPath (OsPath)
-import Agent.ResourceScope
-    ( ResourceKey
-    , ResourceScope
-    , allocateResource
-    , closeResourceScope
-    , newResourceScope
-    , releaseResource
-    )
 import Agent.Subagents.Format (formatCompletionNotice, isFinalStatus)
 import Agent.Subagents.Types
     ( RunSubagent
@@ -89,10 +84,24 @@ import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async (Async, async, cancel, race, waitCatch)
 import Control.Concurrent.MVar (MVar, newMVar, withMVar)
 import Control.Concurrent.STM
-import Control.Exception.Safe (SomeException, finally, mask, onException, tryAny)
+import Control.Exception.Safe
+    ( SomeException
+    , catchAny
+    , finally
+    , mask
+    , onException
+    , throwIO
+    , tryAny
+    )
+import Control.Monad (void)
+import Control.Monad.IO.Class (liftIO)
+import Control.Monad.Trans.Resource (runResourceT)
+import Data.Acquire (Acquire, allocateAcquire, mkAcquire, withAcquire)
 import Data.IORef
+import Data.List (sortOn)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
+import Data.Ord (Down(..))
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Text (Text)
@@ -119,9 +128,10 @@ data SubagentRecord = SubagentRecord
     , recordStatus :: !(TVar SubagentStatus)
     , recordCancel :: !CancelFlag
     , recordMailbox :: !(TQueue SubagentWork)
-    , recordAsync :: !(TVar (Maybe (ResourceKey, Async ())))
+    , recordWake :: !(TMVar ())
+    , recordAsync :: !(TVar (Maybe (Async ())))
     , recordRootTurnId :: !(TVar (Maybe RootTurnId))
-      -- | Whether this agent currently occupies an active-worker slot.
+      -- | Whether this agent currently occupies an active-turn slot.
     , recordSlotHeld :: !(TVar Bool)
       -- | Last successful response id for conversation continuity.
     , recordPreviousResponseId :: !(TVar (Maybe Text))
@@ -134,6 +144,22 @@ data SubagentWork = SubagentWork
     { workRootTurnId :: !(Maybe RootTurnId)
     , workMessage :: !InterAgentMessage
     }
+
+-- | Resources acquired while preparing an agent and transferred to its
+-- supervisor. They remain alive across turns and are released in reverse order
+-- when the supervisor exits.
+newtype SubagentLease = SubagentLease (Acquire ())
+
+instance Semigroup SubagentLease where
+    SubagentLease left <> SubagentLease right = SubagentLease (left *> right)
+
+instance Monoid SubagentLease where
+    mempty = SubagentLease (pure ())
+
+-- | Attach an already-acquired resource to the lifetime of a subagent.
+subagentLease :: IO () -> SubagentLease
+subagentLease cleanup =
+    SubagentLease (mkAcquire (pure ()) (const cleanup))
 
 data SubagentRegistry = SubagentRegistry
     { registryAgents :: !(TVar (Map SubagentId SubagentRecord))
@@ -151,7 +177,6 @@ data SubagentRegistry = SubagentRegistry
     , registryNextRootTurnId :: !(TVar Word64)
     , registryAbortedRootTurns :: !(TVar (Set RootTurnId))
     , registryLifecycle :: !(MVar ())
-    , registryResources :: !(IORef ResourceScope)
     }
 
 newSubagentRegistry
@@ -171,7 +196,6 @@ newSubagentRegistry config cwd run onEvent = do
     nextRootTurnId <- newTVarIO 0
     abortedRootTurns <- newTVarIO Set.empty
     lifecycle <- newMVar ()
-    resources <- newIORef =<< newResourceScope
     runRef <- newIORef run
     onCompleteRef <- newIORef (\_ _ -> pure ())
     pure SubagentRegistry
@@ -192,7 +216,6 @@ newSubagentRegistry config cwd run onEvent = do
         , registryNextRootTurnId = nextRootTurnId
         , registryAbortedRootTurns = abortedRootTurns
         , registryLifecycle = lifecycle
-        , registryResources = resources
         }
 
 setSubagentRunner :: SubagentRegistry -> RunSubagent -> IO ()
@@ -223,17 +246,14 @@ closeSubagentRegistryLocked registry = do
     records <- atomically do
         writeTVar registry.registryClosed True
         Map.elems <$> readTVar registry.registryAgents
-    mapM_ (shutdownRecord registry) records
-    resources <- readIORef registry.registryResources
-    closeResourceScope resources
+    mapM_ (shutdownRecord registry) $
+        sortOn (Down . (.recordDepth)) records
 
 -- | Shut down live children and reopen the registry for a fresh session.
 resetSubagentRegistry :: SubagentRegistry -> IO ()
 resetSubagentRegistry registry =
     withMVar registry.registryLifecycle \_ -> do
         closeSubagentRegistryLocked registry
-        resources <- newResourceScope
-        writeIORef registry.registryResources resources
         atomically do
             writeTVar registry.registryAgents Map.empty
             writeTVar registry.registryPaths Map.empty
@@ -276,13 +296,13 @@ spawnSubagentWithCwdForTurn
     -> IO (Either Text SubagentId)
 spawnSubagentWithCwdForTurn registry rootTurnId childCwd =
     spawnSubagentWithCwdPreparedForTurn
-        registry rootTurnId childCwd (\_ -> pure ())
+        registry rootTurnId childCwd (\_ -> pure mempty)
 
--- | Run host preparation after admission but before the worker starts.
+-- | Run host preparation after admission but before the supervisor starts.
 spawnSubagentWithCwdPrepared
     :: SubagentRegistry
     -> OsPath
-    -> (SubagentId -> IO ())
+    -> (SubagentId -> IO SubagentLease)
     -> Maybe SubagentId
     -> Int
     -> Text
@@ -295,7 +315,7 @@ spawnSubagentWithCwdPreparedForTurn
     :: SubagentRegistry
     -> Maybe RootTurnId
     -> OsPath
-    -> (SubagentId -> IO ())
+    -> (SubagentId -> IO SubagentLease)
     -> Maybe SubagentId
     -> Int
     -> Text
@@ -335,12 +355,12 @@ spawnSubagentAtForTurn
     -> Maybe Text
     -> IO (Either Text (SubagentId, TaskPath))
 spawnSubagentAtForTurn registry rootTurnId =
-    spawnSubagentAtPreparedForTurn registry rootTurnId (\_ -> pure ())
+    spawnSubagentAtPreparedForTurn registry rootTurnId (\_ -> pure mempty)
 
 spawnSubagentAtPreparedForTurn
     :: SubagentRegistry
     -> Maybe RootTurnId
-    -> (SubagentId -> IO ())
+    -> (SubagentId -> IO SubagentLease)
     -> Maybe SubagentId
     -> TaskPath
     -> Int
@@ -355,7 +375,7 @@ spawnSubagentAtPreparedForTurn registry rootTurnId beforeStart =
 spawnSubagentAtWithCwdPrepared
     :: SubagentRegistry
     -> OsPath
-    -> (SubagentId -> IO ())
+    -> (SubagentId -> IO SubagentLease)
     -> Maybe SubagentId
     -> TaskPath
     -> Int
@@ -370,7 +390,7 @@ spawnSubagentAtWithCwdPreparedForTurn
     :: SubagentRegistry
     -> Maybe RootTurnId
     -> OsPath
-    -> (SubagentId -> IO ())
+    -> (SubagentId -> IO SubagentLease)
     -> Maybe SubagentId
     -> TaskPath
     -> Int
@@ -390,7 +410,7 @@ spawnSubagentAtWithIdPreparedForTurn
     :: SubagentRegistry
     -> Maybe RootTurnId
     -> OsPath
-    -> (SubagentId -> IO ())
+    -> (SubagentId -> IO SubagentLease)
     -> SubagentId
     -> Maybe SubagentId
     -> TaskPath
@@ -404,6 +424,7 @@ spawnSubagentAtWithIdPreparedForTurn
         parentId requestedParentPath requestedParentDepth taskName content nickname = do
     cancelFlag <- newCancelFlag
     mailbox <- newTQueueIO
+    wakeVar <- newEmptyTMVarIO
     statusVar <- newTVarIO Pending
     asyncVar <- newTVarIO Nothing
     rootTurnVar <- newTVarIO rootTurnId
@@ -453,6 +474,7 @@ spawnSubagentAtWithIdPreparedForTurn
                                                                 , recordStatus = statusVar
                                                                 , recordCancel = cancelFlag
                                                                 , recordMailbox = mailbox
+                                                                , recordWake = wakeVar
                                                                 , recordAsync = asyncVar
                                                                 , recordRootTurnId = rootTurnVar
                                                                 , recordSlotHeld = slotHeld
@@ -478,11 +500,11 @@ spawnSubagentAtWithIdPreparedForTurn
                         rollbackAdmission registry record
                         pure $ Left $
                             "Failed to prepare subagent: " <> Text.pack (show exc)
-                    Right () ->
-                        startPrepared restore parentPath record)
+                    Right lease ->
+                        startPrepared restore parentPath record lease)
                 `onException` rollbackAdmission registry record
   where
-    startPrepared restore parentPath record = do
+    startPrepared restore parentPath record lease = do
         let work = SubagentWork
                 { workRootTurnId = rootTurnId
                 , workMessage = InterAgentMessage
@@ -495,7 +517,7 @@ spawnSubagentAtWithIdPreparedForTurn
         started <-
             restore
                 (withMVar registry.registryLifecycle \_ ->
-                    startRecordWorker registry record work)
+                    startRecordSupervisor registry record lease (Just work))
                 `onException` shutdownRecord registry record
         case started of
             Left err -> do
@@ -529,16 +551,18 @@ taskNameForAgentId agentId =
     "a" <> Text.filter (/= '-') agentId.unSubagentId
 
 rollbackAdmission :: SubagentRegistry -> SubagentRecord -> IO ()
-rollbackAdmission registry record = atomically do
-    modifyTVar' registry.registryAgents (Map.delete record.recordId)
-    modifyTVar' registry.registryPaths $
-        deleteOwnedPath record.recordTaskPath record.recordId
-    held <- readTVar record.recordSlotHeld
-    whenSTM held do
-        writeTVar record.recordSlotHeld False
-        live <- readTVar registry.registryLiveCount
-        writeTVar registry.registryLiveCount (max 0 (live - 1))
-    writeTVar record.recordStatus Closed
+rollbackAdmission registry record = do
+    atomically do
+        modifyTVar' registry.registryAgents (Map.delete record.recordId)
+        modifyTVar' registry.registryPaths $
+            deleteOwnedPath record.recordTaskPath record.recordId
+        held <- readTVar record.recordSlotHeld
+        whenSTM held do
+            writeTVar record.recordSlotHeld False
+            live <- readTVar registry.registryLiveCount
+            writeTVar registry.registryLiveCount (max 0 (live - 1))
+        writeTVar record.recordStatus Closed
+    stopRecordSupervisor record
 
 deleteOwnedPath :: TaskPath -> SubagentId -> Map TaskPath SubagentId -> Map TaskPath SubagentId
 deleteOwnedPath key expected mappings =
@@ -546,62 +570,83 @@ deleteOwnedPath key expected mappings =
         Just actual | actual == expected -> Map.delete key mappings
         _ -> mappings
 
-runWorker :: SubagentRegistry -> SubagentRecord -> SubagentWork -> IO ()
-runWorker registry record firstWork = do
-    mayRun <- atomically do
-        closed <- readTVar registry.registryClosed
-        current <- readTVar record.recordStatus
-        if closed || current == Closed || current == Interrupted
-            then pure False
-            else do
-                writeTVar record.recordStatus Running
-                pure True
-    let onEvent = registry.registryOnEvent record.recordId
-        loop work = do
-            atomically $ writeTVar record.recordRootTurnId work.workRootTurnId
-            let env = SubagentSpawnEnv
-                    { subId = record.recordId
-                    , subDepth = record.recordDepth
-                    , subParentId = record.recordParent
-                    , subCwd = record.recordCwd
-                    , subCancel = record.recordCancel
-                    , subRootTurnId = work.workRootTurnId
-                    }
-            previous <- atomically $ readTVar record.recordPreviousResponseId
-            run <- readIORef registry.registryRunRef
-            result <- tryAny (run env previous work.workMessage onEvent)
-            let status = case result of
-                    Left (exc :: SomeException) ->
-                        Errored (Text.pack (show exc))
-                    Right (Left LoopCancelled{}) -> Interrupted
-                    Right (Left err) -> Errored (Text.pack (show err))
-                    Right (Right loopResult) -> Completed loopResult.finalText
-            case result of
-                Right (Right loopResult) ->
-                    atomically $
-                        writeTVar record.recordPreviousResponseId
-                            (Just loopResult.finalResponseId)
-                _ -> pure ()
-            next <- atomically $ nextWorkerStep registry record
-            case next of
-                WorkerClosed -> pure ()
-                WorkerMessage nextWork -> do
-                    resetCancel record.recordCancel
-                    loop nextWork
-                WorkerComplete -> do
-                    notifyRoot <- atomically $
-                        publishCompletionSTM registry record status
-                    whenIO notifyRoot do
-                        _ <- tryAny $
-                            notifyComplete
-                                registry record.recordId work.workRootTurnId status
-                        pure ()
-                    atomically (finishOrContinue registry record status) >>= \case
-                        Nothing -> pure ()
-                        Just nextWork -> do
-                            resetCancel record.recordCancel
-                            loop nextWork
-    whenIO mayRun (loop firstWork)
+runSupervisor :: SubagentRegistry -> SubagentRecord -> IO ()
+runSupervisor registry record = awaitWork
+  where
+    awaitWork =
+        atomically (takeStartedWork record) >>= \case
+            Nothing -> pure ()
+            Just work -> do
+                resetCancel record.recordCancel
+                runWork work
+
+    runWork work = do
+        let onEvent = registry.registryOnEvent record.recordId
+            env = SubagentSpawnEnv
+                { subId = record.recordId
+                , subDepth = record.recordDepth
+                , subParentId = record.recordParent
+                , subCwd = record.recordCwd
+                , subCancel = record.recordCancel
+                , subRootTurnId = work.workRootTurnId
+                }
+        previous <- atomically $ readTVar record.recordPreviousResponseId
+        run <- readIORef registry.registryRunRef
+        raced <- race
+            (waitCancel record.recordCancel)
+            (tryAny (run env previous work.workMessage onEvent))
+        let result = case raced of
+                Left () -> Right (Left (LoopCancelled []))
+                Right completed -> completed
+            status = case result of
+                Left (exc :: SomeException) ->
+                    Errored (Text.pack (show exc))
+                Right (Left LoopCancelled{}) -> Interrupted
+                Right (Left err) -> Errored (Text.pack (show err))
+                Right (Right loopResult) -> Completed loopResult.finalText
+        case result of
+            Right (Right loopResult) ->
+                atomically $
+                    writeTVar record.recordPreviousResponseId
+                        (Just loopResult.finalResponseId)
+            _ -> pure ()
+        atomically (nextSupervisorStep registry record) >>= \case
+            SupervisorStop -> pure ()
+            SupervisorIdle -> awaitWork
+            SupervisorMessage nextWork -> do
+                resetCancel record.recordCancel
+                runWork nextWork
+            SupervisorComplete -> do
+                notifyRoot <- atomically $
+                    publishCompletionSTM registry record status
+                whenIO notifyRoot do
+                    _ <- tryAny $
+                        notifyComplete
+                            registry record.recordId work.workRootTurnId status
+                    pure ()
+                atomically (finishSupervisorStep registry record status) >>= \case
+                    SupervisorStop -> pure ()
+                    SupervisorIdle -> awaitWork
+                    SupervisorMessage nextWork -> do
+                        resetCancel record.recordCancel
+                        runWork nextWork
+                    SupervisorComplete -> pure ()
+
+takeStartedWork
+    :: SubagentRecord
+    -> STM (Maybe SubagentWork)
+takeStartedWork record = do
+    readTVar record.recordStatus >>= \case
+        Closed -> pure Nothing
+        _ -> do
+            takeTMVar record.recordWake
+            readTVar record.recordStatus >>= \case
+                Closed -> pure Nothing
+                _ -> do
+                    work <- readTQueue record.recordMailbox
+                    writeTVar record.recordRootTurnId work.workRootTurnId
+                    writeTVar record.recordStatus Running
+                    pure (Just work)
 
 publishCompletionSTM :: SubagentRegistry -> SubagentRecord -> SubagentStatus -> STM Bool
 publishCompletionSTM registry record status = do
@@ -658,17 +703,20 @@ completionMessage child parent status =
         QueuedMessage
         (plainInterAgentContent (formatCompletionNotice child.recordId status))
 
-startRecordWorker
+startRecordSupervisor
     :: SubagentRegistry
     -> SubagentRecord
-    -> SubagentWork
+    -> SubagentLease
+    -> Maybe SubagentWork
     -> IO (Either Text ())
-startRecordWorker registry record work =
-    mask \_ -> do
+startRecordSupervisor registry record lease initialWork =
+    mask \restore -> do
         canStart <- atomically do
             closed <- readTVar registry.registryClosed
             status <- readTVar record.recordStatus
-            aborted <- isRootTurnAborted registry work.workRootTurnId
+            aborted <- case initialWork of
+                Nothing -> pure False
+                Just work -> isRootTurnAborted registry work.workRootTurnId
             agents <- readTVar registry.registryAgents
             paths <- readTVar registry.registryPaths
             current <- readTVar record.recordAsync
@@ -681,101 +729,115 @@ startRecordWorker registry record work =
                         (Map.lookup record.recordTaskPath paths)
                     && maybe True (const False) current
         if not canStart
-            then pure (Left "Subagent closed before its worker started.")
+            then do
+                releaseSubagentLease lease
+                pure (Left "Subagent closed before its supervisor started.")
             else do
-                gate <- newEmptyTMVarIO
-                resources <- readIORef registry.registryResources
-                started <- tryAny $
-                    allocateResource resources
-                        (async do
-                            atomically (takeTMVar gate)
-                            runWorker registry record work)
-                        stopAsync
+                ready <- newEmptyTMVarIO
+                started <- tryAny $ async $
+                    supervisorAction ready
                 case started of
-                    Left (exception :: SomeException) ->
+                    Left (exception :: SomeException) -> do
+                        releaseSubagentLease lease
                         pure (Left ("Failed to start subagent: " <> Text.pack (show exception)))
-                    Right worker -> do
-                        atomically do
-                            writeTVar record.recordAsync (Just worker)
-                            writeTVar record.recordRootTurnId work.workRootTurnId
-                            writeTVar record.recordStatus Running
-                            putTMVar gate ()
-                        pure (Right ())
+                    Right supervisor -> do
+                        atomically $ writeTVar record.recordAsync (Just supervisor)
+                        ownership <- restore (atomically (takeTMVar ready))
+                            `onException` stopRecordSupervisor record
+                        case ownership of
+                            Left err -> do
+                                stopRecordSupervisor record
+                                pure (Left err)
+                            Right () -> do
+                                atomically $
+                                    mapM_ (scheduleIdleWork record) initialWork
+                                pure (Right ())
+  where
+    supervisorAction ready =
+        mask \restoreSupervisor ->
+            (runResourceT do
+                case lease of
+                    SubagentLease acquire -> void (allocateAcquire acquire)
+                liftIO $ atomically $ putTMVar ready (Right ())
+                liftIO $ restoreSupervisor (runSupervisor registry record))
+            `catchAny` \exception -> do
+                atomically $ void $ tryPutTMVar ready $ Left $
+                    "Failed to start subagent: " <> Text.pack (show exception)
+                throwIO exception
+
+releaseSubagentLease :: SubagentLease -> IO ()
+releaseSubagentLease (SubagentLease acquire) =
+    withAcquire acquire (const (pure ()))
 
 stopAsync :: Async () -> IO ()
-stopAsync worker = do
-    cancel worker
-    _ <- waitCatch worker
+stopAsync supervisor = do
+    cancel supervisor
+    _ <- waitCatch supervisor
     pure ()
 
-takeRecordWorker :: SubagentRecord -> IO (Maybe (ResourceKey, Async ()))
-takeRecordWorker record =
+takeRecordSupervisor :: SubagentRecord -> IO (Maybe (Async ()))
+takeRecordSupervisor record =
     atomically do
         current <- readTVar record.recordAsync
         writeTVar record.recordAsync Nothing
         pure current
 
-releaseRecordWorker :: SubagentRecord -> IO ()
-releaseRecordWorker record = do
-    worker <- takeRecordWorker record
-    mapM_ (releaseResource . fst) worker
+stopRecordSupervisor :: SubagentRecord -> IO ()
+stopRecordSupervisor record = do
+    supervisor <- takeRecordSupervisor record
+    mapM_ stopAsync supervisor
 
-finishRecordWorker :: SubagentRecord -> IO ()
-finishRecordWorker record = do
-    worker <- takeRecordWorker record
-    mapM_
-        (\(key, child) -> do
-            _ <- waitCatch child
-            releaseResource key)
-        worker
+data SupervisorStep
+    = SupervisorStop
+    | SupervisorIdle
+    | SupervisorComplete
+    | SupervisorMessage !SubagentWork
 
-data WorkerStep
-    = WorkerClosed
-    | WorkerComplete
-    | WorkerMessage !SubagentWork
-
-nextWorkerStep
+nextSupervisorStep
     :: SubagentRegistry
     -> SubagentRecord
-    -> STM WorkerStep
-nextWorkerStep registry record = do
-    closed <- readTVar registry.registryClosed
-    current <- readTVar record.recordStatus
-    if closed || current == Closed || current == Interrupted
-        then do
-            whenSTM closed (writeTVar record.recordStatus Closed)
-            pure WorkerClosed
-        else do
-            empty <- isEmptyTQueue record.recordMailbox
-            if empty
-                then pure WorkerComplete
-                else do
-                    work <- readTQueue record.recordMailbox
-                    writeTVar record.recordRootTurnId work.workRootTurnId
-                    writeTVar record.recordStatus Running
-                    pure (WorkerMessage work)
+    -> STM SupervisorStep
+nextSupervisorStep registry record = do
+    supervisorStep registry record (pure SupervisorComplete)
 
-finishOrContinue
+finishSupervisorStep
     :: SubagentRegistry
     -> SubagentRecord
     -> SubagentStatus
-    -> STM (Maybe SubagentWork)
-finishOrContinue registry record status = do
-    current <- readTVar record.recordStatus
-    if current == Closed || current == Interrupted
-        then pure Nothing
-        else do
-            empty <- isEmptyTQueue record.recordMailbox
-            if empty
-                then do
-                    writeTVar record.recordStatus status
-                    releaseSlotSTM registry record
-                    pure Nothing
-                else do
-                    work <- readTQueue record.recordMailbox
+    -> STM SupervisorStep
+finishSupervisorStep registry record status = do
+    supervisorStep registry record do
+        writeTVar record.recordStatus status
+        releaseSlotSTM registry record
+        pure SupervisorIdle
+
+supervisorStep
+    :: SubagentRegistry
+    -> SubagentRecord
+    -> STM SupervisorStep
+    -> STM SupervisorStep
+supervisorStep registry record onIdle =
+    readTVar record.recordStatus >>= \case
+        Closed -> release SupervisorStop
+        Interrupted -> release SupervisorIdle
+        _ ->
+            tryReadTQueue record.recordMailbox >>= \case
+                Nothing -> onIdle
+                Just work -> do
                     writeTVar record.recordRootTurnId work.workRootTurnId
                     writeTVar record.recordStatus Running
-                    pure (Just work)
+                    pure (SupervisorMessage work)
+  where
+    release step = do
+        releaseSlotSTM registry record
+        pure step
+
+scheduleIdleWork :: SubagentRecord -> SubagentWork -> STM ()
+scheduleIdleWork record work = do
+    unGetTQueue record.recordMailbox work
+    writeTVar record.recordRootTurnId work.workRootTurnId
+    writeTVar record.recordStatus Pending
+    putTMVar record.recordWake ()
 
 notifyComplete
     :: SubagentRegistry
@@ -945,12 +1007,12 @@ sendInputMessageForTurn registry rootTurnId senderPath agentId content interrupt
         -> SubagentWork
         -> IO (Either Text Text)
     queue record work = do
-        whenIO interrupt (requestCancel record.recordCancel)
         queued <- atomically do
             aborted <- isRootTurnAborted registry rootTurnId
             if aborted
                 then pure False
                 else writeTQueue record.recordMailbox work >> pure True
+        whenIO (queued && interrupt) (requestCancel record.recordCancel)
         pure $ if queued
             then Right "queued"
             else Left "Root turn was aborted."
@@ -960,22 +1022,25 @@ sendInputMessageForTurn registry rootTurnId senderPath agentId content interrupt
         -> SubagentWork
         -> IO (Either Text Text)
     restart record work = do
+        resetCancel record.recordCancel
         admitted <- atomically do
             aborted <- isRootTurnAborted registry rootTurnId
             if aborted
                 then pure (Left "Root turn was aborted.")
-                else acquireSlot registry record
+                else acquireSlot registry record >>= \case
+                    Left err -> pure (Left err)
+                    Right () -> do
+                        sleeping <- isEmptyTMVar record.recordWake
+                        if sleeping
+                            then do
+                                scheduleIdleWork record work
+                                pure (Right ())
+                            else do
+                                releaseSlotSTM registry record
+                                pure (Left "Subagent already has pending work.")
         case admitted of
             Left err -> pure (Left err)
-            Right () -> do
-                resetCancel record.recordCancel
-                finishRecordWorker record
-                started <- startRecordWorker registry record work
-                case started of
-                    Left err -> do
-                        releaseSlot registry record
-                        pure (Left err)
-                    Right () -> pure (Right "queued")
+            Right () -> pure (Right "queued")
 
 whenIO :: Bool -> IO () -> IO ()
 whenIO True action = action
@@ -995,20 +1060,25 @@ closeSubagent registry agentId =
                 previous <- atomically $ readTVar record.recordStatus
                 toClose <- atomically do
                     agents <- readTVar registry.registryAgents
-                    pure (record : descendants agents record.recordId)
+                    pure (descendants agents record.recordId <> [record])
                 mapM_ (shutdownRecord registry) toClose
                 pure (Right previous)
 
 descendants :: Map SubagentId SubagentRecord -> SubagentId -> [SubagentRecord]
 descendants agents parentId =
     let kids = [r | r <- Map.elems agents, r.recordParent == Just parentId]
-    in kids <> concatMap (\kid -> descendants agents kid.recordId) kids
+    in concatMap
+        (\kid -> descendants agents kid.recordId <> [kid])
+        kids
 
 shutdownRecord :: SubagentRegistry -> SubagentRecord -> IO ()
 shutdownRecord registry record = do
     requestCancel record.recordCancel
-    atomically $ writeTVar record.recordStatus Closed
-    releaseRecordWorker record
+    atomically do
+        writeTVar record.recordStatus Closed
+        void $ tryTakeTMVar record.recordWake
+        void $ flushTQueue record.recordMailbox
+    stopRecordSupervisor record
     releaseSlot registry record
 
 abortRootTurn :: SubagentRegistry -> RootTurnId -> IO ()
@@ -1033,25 +1103,32 @@ abortRootTurn registry rootTurnId =
 
 interruptRecordForTurn :: SubagentRegistry -> RootTurnId -> SubagentRecord -> IO ()
 interruptRecordForTurn registry rootTurnId record = do
-    ownedWorker <- atomically do
+    waitForTurn <- atomically do
         owner <- readTVar record.recordRootTurnId
         if owner == Just rootTurnId
             then do
+                status <- readTVar record.recordStatus
                 writeTVar record.recordStatus Interrupted
-                worker <- readTVar record.recordAsync
-                writeTVar record.recordAsync Nothing
-                pure (Just worker)
-            else pure Nothing
-    case ownedWorker of
-        Nothing -> pure ()
-        Just mworker -> do
-            requestCancel record.recordCancel
-            mapM_ (releaseResource . fst) mworker
-            atomically do
-                owner <- readTVar record.recordRootTurnId
-                whenSTM (owner == Just rootTurnId) $
-                    writeTVar record.recordStatus Interrupted
-            releaseSlot registry record
+                case status of
+                    Pending -> do
+                        void $ tryTakeTMVar record.recordWake
+                        releaseSlotSTM registry record
+                        pure False
+                    Running -> pure True
+                    _ -> pure False
+            else pure False
+    whenIO waitForTurn do
+        requestCancel record.recordCancel
+        atomically $ waitForReleasedSlot record
+    atomically do
+        owner <- readTVar record.recordRootTurnId
+        whenSTM (owner == Just rootTurnId) $
+            writeTVar record.recordStatus Interrupted
+
+waitForReleasedSlot :: SubagentRecord -> STM ()
+waitForReleasedSlot record = do
+    held <- readTVar record.recordSlotHeld
+    whenSTM held retry
 
 discardQueuedWork :: RootTurnId -> TQueue SubagentWork -> STM ()
 discardQueuedWork rootTurnId mailbox = do
@@ -1069,7 +1146,7 @@ isRootTurnAborted registry (Just rootTurnId) =
 
 -- | Stop every currently pending/running child while keeping completed agent
 -- records and the registry available for later turns. The registry is closed
--- during the transition so a descendant cannot publish a newly-created worker
+-- during the transition so a descendant cannot publish newly-started work
 -- after the abort snapshot has been taken.
 interruptActiveSubagents :: SubagentRegistry -> IO ()
 interruptActiveSubagents registry =
@@ -1091,14 +1168,21 @@ interruptActiveSubagents registry =
 
 interruptRecord :: SubagentRegistry -> SubagentRecord -> IO ()
 interruptRecord registry record = do
-    requestCancel record.recordCancel
-    atomically do
+    waitForTurn <- atomically do
+        status <- readTVar record.recordStatus
         writeTVar record.recordStatus Interrupted
-        _ <- flushTQueue record.recordMailbox
-        pure ()
-    releaseRecordWorker record
+        void $ flushTQueue record.recordMailbox
+        case status of
+            Pending -> do
+                void $ tryTakeTMVar record.recordWake
+                releaseSlotSTM registry record
+                pure False
+            Running -> pure True
+            _ -> pure False
+    whenIO waitForTurn do
+        requestCancel record.recordCancel
+        atomically $ waitForReleasedSlot record
     atomically $ writeTVar record.recordStatus Interrupted
-    releaseSlot registry record
 
 filterMSTM :: (a -> STM Bool) -> [a] -> STM [a]
 filterMSTM predicate = fmap reverse . go []
@@ -1110,7 +1194,7 @@ filterMSTM predicate = fmap reverse . go []
 
 -- | Re-admit a previously persisted agent that is not currently in the
 -- in-memory map (e.g. after close, or across a process restart within the
--- same session directory). Does not start a worker; callers follow with
+-- same session directory). Starts an idle supervisor; callers follow with
 -- 'sendInput'. Does not consume a concurrency slot until the next turn.
 restoreSubagent
     :: SubagentRegistry
@@ -1247,7 +1331,6 @@ restoreSubagentResolvedWithCwd
             Pending -> pure (Left "cannot restore a pending subagent")
             NotFound -> pure (Left "cannot restore a missing subagent record")
             _ -> do
-                finishRecordWorker record
                 releaseSlot registry record
                 resetCancel record.recordCancel
                 atomically do
@@ -1256,18 +1339,26 @@ restoreSubagentResolvedWithCwd
                     writeTVar record.recordRootTurnId Nothing
                     modifyTVar' registry.registryPaths
                         (Map.insert record.recordTaskPath agentId)
-                pure (Right agentId)
+                restarted <- if status == Closed
+                    then startRecordSupervisor registry record mempty Nothing
+                    else pure (Right ())
+                case restarted of
+                    Left err -> do
+                        atomically $ writeTVar record.recordStatus Closed
+                        pure (Left err)
+                    Right () -> pure (Right agentId)
 
     restoreMissing = do
         cancelFlag <- newCancelFlag
         mailbox <- newTQueueIO
+        wakeVar <- newEmptyTMVarIO
         statusVar <- newTVarIO normalizedStatus
         asyncVar <- newTVarIO Nothing
         rootTurnVar <- newTVarIO Nothing
         slotHeld <- newTVarIO False
         previousVar <- newTVarIO previous
         lastUpdateVar <- newTVarIO Nothing
-        atomically do
+        restored <- atomically do
             closed <- readTVar registry.registryClosed
             if closed
                 then pure (Left "Subagent registry is closed.")
@@ -1292,6 +1383,7 @@ restoreSubagentResolvedWithCwd
                                             , recordStatus = statusVar
                                             , recordCancel = cancelFlag
                                             , recordMailbox = mailbox
+                                            , recordWake = wakeVar
                                             , recordAsync = asyncVar
                                             , recordRootTurnId = rootTurnVar
                                             , recordSlotHeld = slotHeld
@@ -1305,7 +1397,15 @@ restoreSubagentResolvedWithCwd
                                     whenSTM (resolvedPath /= taskPathRoot) $
                                         writeTVar registry.registryPaths
                                             (Map.insert resolvedPath agentId paths)
-                                    pure (Right agentId)
+                                    pure (Right record)
+        case restored of
+            Left err -> pure (Left err)
+            Right record ->
+                startRecordSupervisor registry record mempty Nothing >>= \case
+                    Left err -> do
+                        rollbackAdmission registry record
+                        pure (Left err)
+                    Right () -> pure (Right agentId)
 
 resumeSubagent
     :: SubagentRegistry
@@ -1330,7 +1430,12 @@ resumeSubagent registry agentId =
                                 atomically do
                                     writeTVar record.recordStatus (Completed Nothing)
                                     writeTVar record.recordRootTurnId Nothing
-                                pure (Right (Completed Nothing))
+                                startRecordSupervisor registry record mempty Nothing >>= \case
+                                    Left err -> do
+                                        atomically $ writeTVar record.recordStatus Closed
+                                        pure (Left err)
+                                    Right () ->
+                                        pure (Right (Completed Nothing))
                             other -> pure (Right other)
 
 getStatus :: SubagentRegistry -> SubagentId -> IO SubagentStatus

--- a/packages/agent-core/src/Agent/Tools/Grok/Task.hs
+++ b/packages/agent-core/src/Agent/Tools/Grok/Task.hs
@@ -28,6 +28,7 @@ import Agent.Subagents
     , getStatus
     , sendInputMessageForTurn
     , spawnSubagentWithCwdPreparedForTurn
+    , subagentLease
     , waitSubagents
     )
 import Agent.ToolArgs
@@ -47,7 +48,9 @@ import Agent.Tools.Types
     , ApprovalRule(..)
     , jsonAppTool
     )
+import Control.Concurrent.MVar (modifyMVar, newMVar)
 import Control.Exception.Safe (mask, onException)
+import Control.Monad (void)
 import Data.Aeson (FromJSON(..))
 import Data.IORef
 import Data.Map.Strict (Map)
@@ -194,26 +197,33 @@ spawnFresh
     -> TaskArgs
     -> IO (Either Text Text)
 spawnFresh childCwd worktree ctx typesRef args = mask \restore -> do
+    ownedWorktree <- traverse makeIdempotentWorktree worktree
     rootTurnId <- ctx.multiRootTurnId
     let spec = GrokSubagentSpec
             { agentType = args.subagentType
             , modelOverride = args.model
             , reasoningEffortOverride = Nothing
             }
-        worktreePath = (.subagentWorktreePath) <$> worktree
+        worktreePath = (.subagentWorktreePath) <$> ownedWorktree
+        prepare agentId = do
+            recordAgentSpec typesRef agentId spec
+            pure $ case ownedWorktree of
+                Nothing -> mempty
+                Just lease ->
+                    subagentLease (void lease.subagentWorktreeCleanup)
     result <- restore
         (spawnSubagentWithCwdPreparedForTurn
             ctx.multiRegistry
             rootTurnId
             childCwd
-            (\agentId -> recordAgentSpec typesRef agentId spec)
+            prepare
             ctx.multiSelfId
             ctx.multiDepth
             args.prompt
             (Just args.description))
-        `onException` cleanupWorktreeQuietly worktree
+        `onException` cleanupWorktreeQuietly ownedWorktree
     case result of
-        Left err -> cleanupFailedWorktree worktree err
+        Left err -> cleanupFailedWorktree ownedWorktree err
         Right agentId -> restore do
             if args.runInBackground
                 then pure $ Right $ formatTaskStarted agentId args worktreePath
@@ -222,6 +232,16 @@ spawnFresh childCwd worktree ctx typesRef args = mask \restore -> do
                         waitSubagents ctx.multiRegistry [agentId] defaultWaitTimeoutMs
                     pure $ Right $ formatTaskCompleted agentId args worktreePath timedOut
                         (Map.lookup agentId statuses)
+
+makeIdempotentWorktree :: SubagentWorktree -> IO SubagentWorktree
+makeIdempotentWorktree worktree = do
+    resultVar <- newMVar Nothing
+    let cleanup = modifyMVar resultVar \case
+            Just result -> pure (Just result, result)
+            Nothing -> do
+                result <- worktree.subagentWorktreeCleanup
+                pure (Just result, result)
+    pure worktree { subagentWorktreeCleanup = cleanup }
 
 cleanupWorktreeQuietly :: Maybe SubagentWorktree -> IO ()
 cleanupWorktreeQuietly Nothing = pure ()

--- a/packages/agent-core/src/Agent/Tools/MultiAgents.hs
+++ b/packages/agent-core/src/Agent/Tools/MultiAgents.hs
@@ -195,6 +195,7 @@ runSpawn ctx call args
             prepare agentId =
                 maybe (pure ()) (\hook -> hook agentId spawnOptions)
                     ctx.multiPrepareSpawn
+                    >> pure mempty
         result <- spawnSubagentAtPreparedForTurn
             ctx.multiRegistry
             rootTurnId

--- a/packages/agent-core/test/Agent/SubagentsSpec.hs
+++ b/packages/agent-core/test/Agent/SubagentsSpec.hs
@@ -1,6 +1,6 @@
 module Agent.SubagentsSpec (spec) where
 
-import Agent.Cancel (isCancelled)
+import Agent.Cancel (isCancelled, waitCancel)
 import Agent.InterAgentMessage
 import Agent.Loop (LoopError(..), LoopResult(..), emptyTokenUsage)
 import Agent.OsPath (fromFilePath)
@@ -89,7 +89,7 @@ spec = describe "Agent.Subagents" do
         timedOut `shouldBe` False
         Map.lookup agentId statuses `shouldBe` Just (Completed (Just "done:hello"))
 
-    it "does not launch a prepared worker after registry shutdown" do
+    it "does not launch a prepared supervisor after registry shutdown" do
         entered <- newEmptyMVar
         release <- newEmptyMVar
         ran <- newIORef False
@@ -102,7 +102,29 @@ spec = describe "Agent.Subagents" do
         closeSubagentRegistry registry
         putMVar release ()
         Async.wait spawning `shouldReturn`
-            Left "Subagent closed before its worker started."
+            Left "Subagent closed before its supervisor started."
+        readIORef ran `shouldReturn` False
+
+    it "releases a prepared lease when the supervisor cannot start" do
+        entered <- newEmptyMVar
+        release <- newEmptyMVar
+        releases <- newIORef (0 :: Int)
+        ran <- newIORef False
+        registry <- shutdownRaceRegistry ran
+        spawning <- Async.async $
+            spawnSubagentWithCwdPrepared registry (fromFilePath "/tmp")
+                (\_ -> do
+                    putMVar entered ()
+                    takeMVar release
+                    pure $ subagentLease $
+                        atomicModifyIORef' releases \n -> (n + 1, ()))
+                Nothing 0 "task" Nothing
+        takeMVar entered
+        closeSubagentRegistry registry
+        putMVar release ()
+        Async.wait spawning `shouldReturn`
+            Left "Subagent closed before its supervisor started."
+        readIORef releases `shouldReturn` 1
         readIORef ran `shouldReturn` False
 
     it "rolls back prepared admission when spawning is cancelled" do
@@ -334,6 +356,29 @@ spec = describe "Agent.Subagents" do
         history <- readIORef seen
         history `shouldBe` [Nothing, Just "resp-one"]
 
+    it "does not lose a follow-up that interrupts the active turn" do
+        started <- newEmptyTMVarIO
+        seen <- newIORef ([] :: [Text])
+        registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
+            (\env _ prompt _ -> do
+                let payload = messagePayload prompt
+                atomicModifyIORef' seen \xs -> (xs <> [payload], ())
+                if payload == "first"
+                    then do
+                        atomically $ putTMVar started ()
+                        waitCancel env.subCancel
+                        pure (Left (LoopCancelled []))
+                    else pure (completedResult payload))
+            (\_ _ -> pure ())
+        Right agentId <- spawnSubagent registry Nothing 0 "first" Nothing
+        atomically $ takeTMVar started
+        Right _ <- sendInput registry agentId "second" True
+        (statuses, timedOut) <- waitSubagents registry [agentId] 15000
+        timedOut `shouldBe` False
+        Map.lookup agentId statuses `shouldBe` Just (Completed (Just "second"))
+        readIORef seen `shouldReturn` ["first", "second"]
+        closeSubagentRegistry registry
+
     it "does not leave Running when send_input admission fails" do
         gate <- newTVarIO False
         let config = defaultSubagentConfig { maxConcurrent = 1 }
@@ -442,7 +487,7 @@ spec = describe "Agent.Subagents" do
             `shouldBe` Just (Completed (Just "second"))
         readIORef prompts `shouldReturn` ["first", "second"]
 
-    it "cancels and joins a running worker when the registry closes" do
+    it "cancels and joins a running supervisor when the registry closes" do
         started <- newEmptyTMVarIO
         cleanedUp <- newEmptyTMVarIO
         registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
@@ -552,6 +597,71 @@ spec = describe "Agent.Subagents" do
         Map.lookup agentId statuses
             `shouldBe` Just (Completed (Just "after-restore"))
 
+    it "keeps subagent-owned resources across completion and releases them on close" do
+        releases <- newIORef (0 :: Int)
+        registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
+            (\_ _ prompt _ -> pure (completedResult (messagePayload prompt)))
+            (\_ _ -> pure ())
+        Right agentId <- spawnSubagentWithCwdPrepared registry (fromFilePath "/tmp")
+            (\_ -> pure $ subagentLease $
+                atomicModifyIORef' releases \n -> (n + 1, ()))
+            Nothing 0 "first" Nothing
+        _ <- waitSubagents registry [agentId] 15000
+        readIORef releases `shouldReturn` 0
+        Right _ <- sendInput registry agentId "second" False
+        _ <- waitSubagents registry [agentId] 15000
+        readIORef releases `shouldReturn` 0
+        _ <- closeSubagent registry agentId
+        readIORef releases `shouldReturn` 1
+        closeSubagentRegistry registry
+        readIORef releases `shouldReturn` 1
+
+    it "releases open subagent-owned resources when the registry closes" do
+        released <- newIORef False
+        registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
+            (\_ _ prompt _ -> pure (completedResult (messagePayload prompt)))
+            (\_ _ -> pure ())
+        Right _ <- spawnSubagentWithCwdPrepared registry (fromFilePath "/tmp")
+            (\_ -> pure $ subagentLease (writeIORef released True))
+            Nothing 0 "first" Nothing
+        closeSubagentRegistry registry
+        readIORef released `shouldReturn` True
+
+    it "releases composed subagent leases in reverse acquisition order" do
+        released <- newIORef ([] :: [Int])
+        registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
+            (\_ _ prompt _ -> pure (completedResult (messagePayload prompt)))
+            (\_ _ -> pure ())
+        Right agentId <- spawnSubagentWithCwdPrepared registry (fromFilePath "/tmp")
+            (\_ -> pure $
+                subagentLease
+                    (atomicModifyIORef' released \xs -> (xs <> [1], ()))
+                    <> subagentLease
+                        (atomicModifyIORef' released \xs -> (xs <> [2], ())))
+            Nothing 0 "first" Nothing
+        _ <- closeSubagent registry agentId
+        readIORef released `shouldReturn` [2, 1]
+        closeSubagentRegistry registry
+
+    it "releases nested subagent resources before their parent's resources" do
+        released <- newIORef ([] :: [Text])
+        registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
+            (\_ _ prompt _ -> pure (completedResult (messagePayload prompt)))
+            (\_ _ -> pure ())
+        Right parent <- spawnSubagentWithCwdPrepared registry (fromFilePath "/tmp")
+            (\_ -> pure $ subagentLease $
+                atomicModifyIORef' released \xs -> (xs <> ["parent"], ()))
+            Nothing 0 "parent" Nothing
+        _ <- waitSubagents registry [parent] 15000
+        Right child <- spawnSubagentWithCwdPrepared registry (fromFilePath "/tmp")
+            (\_ -> pure $ subagentLease $
+                atomicModifyIORef' released \xs -> (xs <> ["child"], ()))
+            (Just parent) 1 "child" Nothing
+        _ <- waitSubagents registry [child] 15000
+        _ <- closeSubagent registry parent
+        readIORef released `shouldReturn` ["child", "parent"]
+        closeSubagentRegistry registry
+
     it "does not let sendInput resurrect a closed agent" do
         registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
             (\_ _ prompt _ -> pure $ Right LoopResult
@@ -568,7 +678,7 @@ spec = describe "Agent.Subagents" do
             `shouldReturn` Left "agent is closed"
         getStatus registry agentId `shouldReturn` Closed
 
-    it "reset cancels old workers and reopens with a fresh resource scope" do
+    it "reset cancels old supervisors and reopens the registry" do
         started <- newEmptyMVar
         notices <- newIORef ([] :: [SubagentId])
         registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
@@ -826,9 +936,9 @@ shutdownRaceRegistry ran =
         (\_ _ _ _ -> writeIORef ran True >> pure (Left LoopNoResponseId))
         (\_ _ -> pure ())
 
-blockPreparation :: MVar () -> MVar () -> SubagentId -> IO ()
+blockPreparation :: MVar () -> MVar () -> SubagentId -> IO SubagentLease
 blockPreparation entered release _ =
-    putMVar entered () >> takeMVar release
+    putMVar entered () >> takeMVar release >> pure mempty
 
 spawnPreparedAt
     :: SubagentRegistry

--- a/packages/agent-core/test/Agent/Tools/Grok/TaskSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/Grok/TaskSpec.hs
@@ -49,7 +49,7 @@ spec = describe "Agent.Tools.Grok.Task" do
         map (\entry -> entry.modelOverride) specs `shouldBe` [Just "grok-4.5-mini"]
         closeSubagentRegistry registry
 
-    it "records overrides before the child worker starts" do
+    it "records overrides before the child supervisor starts" do
         typesRef <- newIORef Map.empty
         observed <- newEmptyMVar
         registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
@@ -81,22 +81,28 @@ spec = describe "Agent.Tools.Grok.Task" do
             names = map (.appToolName) (filterGrokToolsForType "general-purpose" tools)
         names `shouldBe` ["read_file"]
 
-    it "uses the host worktree hook for isolated children" do
+    it "keeps an isolated worktree until its child is closed" do
+        cleaned <- newIORef False
         registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
             (\_ _ _ _ -> pure $ Left LoopNoResponseId)
             (\_ _ -> pure ())
         typesRef <- newIORef Map.empty
-        let createIsolated _ = pure $ Right SubagentWorktree
-                { subagentWorktreePath = fromFilePath "/tmp"
-                , subagentWorktreeCleanup = pure (Right ())
-                }
+        let createIsolated = cleanupLease cleaned
             ctx = MultiAgentContext registry Nothing 0 taskPathRoot (pure Nothing)
                 Nothing (Just createIsolated) Nothing Nothing
             tool = taskTool (fromFilePath "/tmp") ctx typesRef
         result <- dispatchToolCall defaultLoopDispatch [tool.appToolHandler]
             (functionToolCall "c1" "task"
                 "{\"prompt\":\"x\",\"description\":\"y\",\"isolation\":\"worktree\"}")
-        result.output `shouldSatisfy` Text.isInfixOf "worktree_path: /tmp"
+        result.output `shouldSatisfy` Text.isInfixOf "worktree_path: /tmp/isolate"
+        agents <- listAgents registry Nothing
+        case agents of
+            [(_, agentId, _)] -> do
+                _ <- waitSubagents registry [agentId] 15000
+                readIORef cleaned `shouldReturn` False
+                _ <- closeSubagent registry agentId
+                readIORef cleaned `shouldReturn` True
+            _ -> expectationFailure "expected exactly one isolated child"
         closeSubagentRegistry registry
 
     it "cleans up worktrees after failed registry admission" do

--- a/packages/agent-core/test/Agent/Tools/MultiAgentsSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/MultiAgentsSpec.hs
@@ -70,7 +70,7 @@ spec = describe "Agent.Tools.MultiAgents" do
             EncryptedInterAgentContent "gAAAAA-task"
         closeSubagentRegistry registry
 
-    it "applies model, effort, and fork overrides before the worker starts" do
+    it "applies model, effort, and fork overrides before the supervisor starts" do
         prepared <- newEmptyTMVarIO
         registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
             (\env _ _ _ -> pure (resultWithText env.subId.unSubagentId))


### PR DESCRIPTION
## Summary

- keep one mailbox-driven supervisor alive for each open subagent instead of recreating worker threads and escaped resource scopes per turn
- run each supervisor inside a lexical `ResourceT`, with composable `SubagentLease` acquisitions for agent-lifetime resources
- wake idle supervisors for follow-up turns while preserving passive queued messages and active-turn concurrency limits
- attach isolated Grok worktrees to the supervisor lifetime so they survive follow-ups and clean up on agent, parent, or registry closure
- start fresh idle supervisors when persisted agents are restored

## Why

The previous version modeled hierarchy with mutable `ResourceScope` handles stored in each record. This revision keeps `ResourceT` lexical: an agent's supervisor is the lifetime, and its resources unwind naturally when that supervisor exits.

## Testing

- `nix develop -c env GHCRTS= cabal test agent-core:test:agent-core-test --test-show-details=direct`
- 224 examples, 0 failures
- `git diff --check origin/master...HEAD`
