### PR TITLE
Render fullscreen UI before startup initialization

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -8,6 +8,7 @@ module Agent.CLI
     , devMain
     , devMainResume
     , formatReplStatusLine
+    , formatStartupTimings
     , formatTokenUsage
     , run
     , withRestoredCurrentDirectory
@@ -308,7 +309,8 @@ import qualified Agent.XAI.Options as XAI
 import Control.Concurrent.MVar (MVar, newMVar, withMVar)
 import Control.Exception (AsyncException(UserInterrupt))
 import Control.Exception.Safe
-    ( SomeException
+    ( Exception
+    , SomeException
     , catchAny
     , catchAsync
     , finally
@@ -318,7 +320,7 @@ import Control.Exception.Safe
 import Control.Monad (when)
 import qualified Data.ByteString as BS
 import Data.IORef
-import Data.List (elemIndex, findIndex)
+import Data.List (elemIndex, findIndex, sortOn)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe, isJust, isNothing)
@@ -326,8 +328,10 @@ import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
 import qualified Data.Set as Set
+import Text.Printf (printf)
 import Data.Time.Clock
     ( NominalDiffTime
+    , UTCTime
     , diffUTCTime
     , getCurrentTime
     , utctDay
@@ -362,6 +366,28 @@ data RunResult
     | RunResumeSession Text
       -- ^ Persisted session id. Consumed after the current provider-specific
       -- backend shuts down before starting the selected session.
+
+data StartupRuntime = StartupRuntime
+    { startupToolEnv :: !ToolEnv
+    , startupInterrupt :: !InterruptState
+    , startupEscPaused :: !(IORef Bool)
+    , startupUiRuntimeRef :: !(IORef (Maybe FullscreenRuntime))
+    , startupFullscreen :: !(Maybe FullscreenRuntime)
+    , startupTerminal :: !TerminalCapabilities
+    , startupUseColor :: !Bool
+    , startupStderrTty :: !Bool
+    , startupStdinTty :: !Bool
+    , startupStdoutTty :: !Bool
+    , startupAgentSnapshot :: !(IORef (IO (AgentTarget, [AgentEntry])))
+    , startupAgentSelect :: !(IORef (AgentTarget -> IO ()))
+    , startupStartedAt :: !UTCTime
+    , startupTimings :: !(IORef [(Text, NominalDiffTime)])
+    }
+
+newtype StartupFailure = StartupFailure String
+    deriving (Show)
+
+instance Exception StartupFailure
 
 -- | GHCi @:cmd@ helper: on 'DevReload', reload modules and resume that exact
 -- session. Keeping the id in the generated GHCi command avoids a shared
@@ -535,8 +561,80 @@ printTurn turn = do
         _ -> pure ()
     putStrLn ""
 
+setStartupNotice :: Maybe FullscreenRuntime -> Text -> IO ()
+setStartupNotice fullscreen message =
+    case fullscreen of
+        Nothing -> pure ()
+        Just runtime ->
+            emitUiEvent runtime (UiSetNotice (Just message))
+
+recordStartupTiming
+    :: UTCTime
+    -> IORef [(Text, NominalDiffTime)]
+    -> Text
+    -> IO ()
+recordStartupTiming startedAt timingsRef label = do
+    elapsed <- (`diffUTCTime` startedAt) <$> getCurrentTime
+    atomicModifyIORef' timingsRef \timings ->
+        (timings <> [(label, elapsed)], ())
+
+markStartupStage :: StartupRuntime -> Text -> IO ()
+markStartupStage startup label = do
+    recordStartupTiming startup.startupStartedAt startup.startupTimings label
+    setStartupNotice startup.startupFullscreen label
+
+finishStartup :: StartupRuntime -> IO ()
+finishStartup startup = do
+    recordStartupTiming startup.startupStartedAt startup.startupTimings "ready"
+    case startup.startupFullscreen of
+        Nothing -> pure ()
+        Just runtime ->
+            emitUiEvent runtime (UiSetNotice Nothing)
+    lookupEnv "HASKELL_AGENT_STARTUP_TIMING" >>= \case
+        Just "1" -> do
+            message <- formatStartupTimings <$> readIORef startup.startupTimings
+            case startup.startupFullscreen of
+                Nothing -> putTextLn stderr message
+                Just runtime -> emitUiEvent runtime (UiSystemMessage message)
+        _ -> pure ()
+
+startupDie :: StartupRuntime -> String -> IO a
+startupDie startup message =
+    case startup.startupFullscreen of
+        Nothing -> die message
+        Just _ -> throwIO (StartupFailure message)
+
+formatStartupTimings :: [(Text, NominalDiffTime)] -> Text
+formatStartupTimings timings =
+    "startup: "
+        <> Text.intercalate " · "
+            [ label <> " " <> formatStartupDuration elapsed
+            | (label, elapsed) <- sortOn snd timings
+            ]
+
+formatStartupDuration :: NominalDiffTime -> Text
+formatStartupDuration elapsed
+    | elapsed < 1 =
+        Text.pack (show (round (elapsed * 1000) :: Int)) <> "ms"
+    | otherwise =
+        Text.pack (printf "%.2fs" (realToFrac elapsed :: Double))
+
+setStartupRepository :: Maybe FullscreenRuntime -> Text -> OsPath -> IO ()
+setStartupRepository fullscreen branch cwd =
+    case fullscreen of
+        Nothing -> pure ()
+        Just runtime ->
+            emitUiEvent runtime $
+                UiSetRepository
+                    branch
+                    (toText (takeFileName (takeDirectory cwd))
+                        <> "/"
+                        <> toText (takeFileName cwd))
+
 runAgent :: CliOptions -> Maybe ProviderTransition -> IO RunResult
 runAgent options transition = do
+    startedAt <- getCurrentTime
+    startupTimingsRef <- newIORef []
     home <- getHomeDirectory
     let root = sessionsRoot home
     resumed <- case options.optResume of
@@ -560,35 +658,6 @@ runAgent options transition = do
             | otherwise -> pure source
     setCurrentDirectory cwd
 
-    projectRoot <- resolveProjectRoot cwd
-    projectSettings <- loadProjectSettings projectRoot
-    isTty <- hIsTerminalDevice stdin
-    stdoutTty <- hIsTerminalDevice stdout
-    let transitionTarget = (.transitionTarget) <$> transition
-        pendingTurn = transition >>= (.transitionPendingTurn)
-        unavailableProviders =
-            maybe [] (.transitionUnavailableProviders) transition
-        requestedProvider = case transitionTarget of
-            Just target -> Just target.modelProvider
-            Nothing -> case resumed of
-                Just (meta, _) -> Just meta.metaProvider
-                Nothing -> options.optProvider
-    loaded <- loadAuth requestedProvider >>= either (die . Text.unpack) pure
-    case (transitionTarget, resumed) of
-        (Just target, _)
-            | loaded.loadedProvider /= target.modelProvider ->
-                die $ "provider transition requested "
-                    <> Text.unpack (providerSlug target.modelProvider)
-                    <> " but auth resolved "
-                    <> Text.unpack (providerSlug loaded.loadedProvider)
-        (Nothing, Just (meta, _))
-            | loaded.loadedProvider /= meta.metaProvider ->
-                die $ "session provider is "
-                    <> Text.unpack (providerSlug meta.metaProvider)
-                    <> " but auth resolved "
-                    <> Text.unpack (providerSlug loaded.loadedProvider)
-        _ -> pure ()
-
     toolEnv <- defaultToolEnv cwd
     interrupt <- newInterruptState \msg -> do
         -- Drop an in-place "Thinking…" status so the hint is its own line.
@@ -599,6 +668,122 @@ runAgent options transition = do
     -- Shared with Esc cancel and plan prompts so arrow-key pickers own stdin.
     escPaused <- newIORef False
     uiRuntimeRef <- newIORef Nothing
+    stderrTty <- hIsTerminalDevice stderr
+    stdinTty <- hIsTerminalDevice stdin
+    stdoutTty <- hIsTerminalDevice stdout
+    terminal <- detectTerminalCapabilities stdout
+    reportTerminalCwd terminal stdout (toFilePath cwd)
+    useColor <- resolveColor stdout
+    agentSnapshotRef <- newIORef (pure (AgentRoot, []))
+    agentSelectRef <- newIORef (\_ -> pure ())
+    let initialTurns = maybe [] snd resumed
+        fullscreenEnabled =
+            stdinTty
+                && stdoutTty
+                && not (isOneShot options)
+                && options.optScreenMode /= ScreenMinimal
+        initialFullscreenState =
+            reduceUi
+                (UiSetNotice (Just "Loading project…"))
+                (reduceUi
+                    (UiSetRepository
+                        ""
+                        (toText (takeFileName (takeDirectory cwd))
+                            <> "/"
+                            <> toText (takeFileName cwd)))
+                    (hydrateUiHistory initialTurns))
+    fullscreen <- if fullscreenEnabled
+        then Just <$> newFullscreenRuntime
+            (requestCancel toolEnv.toolCancel)
+            (noteFullscreenCtrlC interrupt)
+            (copyTerminalClipboard terminal stdout)
+            (\active ->
+                when terminal.terminalNativeProgress $
+                    setNativeProgress stderr active)
+            (readIORef agentSnapshotRef >>= id)
+            (\target -> readIORef agentSelectRef >>= ($ target))
+            (recordStartupTiming startedAt startupTimingsRef "first frame")
+            useColor
+            initialFullscreenState
+        else pure Nothing
+    writeIORef uiRuntimeRef fullscreen
+    let startup = StartupRuntime
+            { startupToolEnv = toolEnv
+            , startupInterrupt = interrupt
+            , startupEscPaused = escPaused
+            , startupUiRuntimeRef = uiRuntimeRef
+            , startupFullscreen = fullscreen
+            , startupTerminal = terminal
+            , startupUseColor = useColor
+            , startupStderrTty = stderrTty
+            , startupStdinTty = stdinTty
+            , startupStdoutTty = stdoutTty
+            , startupAgentSnapshot = agentSnapshotRef
+            , startupAgentSelect = agentSelectRef
+            , startupStartedAt = startedAt
+            , startupTimings = startupTimingsRef
+            }
+        action =
+            runAgentInitialized
+                options transition home root resumed cwd startup
+    outcome <-
+        try @_ @StartupFailure
+            (case fullscreen of
+                Nothing -> action
+                Just runtime -> runFullscreen runtime action)
+            `finally` writeIORef uiRuntimeRef Nothing
+    either (\(StartupFailure message) -> die message) pure outcome
+
+runAgentInitialized
+    :: CliOptions
+    -> Maybe ProviderTransition
+    -> OsPath
+    -> OsPath
+    -> Maybe (SessionMeta, [SessionTurn])
+    -> OsPath
+    -> StartupRuntime
+    -> IO RunResult
+runAgentInitialized options transition home root resumed cwd startup = do
+    let toolEnv = startup.startupToolEnv
+        interrupt = startup.startupInterrupt
+        escPaused = startup.startupEscPaused
+        uiRuntimeRef = startup.startupUiRuntimeRef
+        fullscreen = startup.startupFullscreen
+        isTty = startup.startupStdinTty
+        stdoutTty = startup.startupStdoutTty
+    projectRoot <- resolveProjectRoot cwd
+    projectSettings <- loadProjectSettings projectRoot
+    branch <- detectGitBranch cwd
+    setStartupRepository fullscreen branch cwd
+    markStartupStage startup "Loading credentials…"
+    let transitionTarget = (.transitionTarget) <$> transition
+        pendingTurn = transition >>= (.transitionPendingTurn)
+        unavailableProviders =
+            maybe [] (.transitionUnavailableProviders) transition
+        requestedProvider = case transitionTarget of
+            Just target -> Just target.modelProvider
+            Nothing -> case resumed of
+                Just (meta, _) -> Just meta.metaProvider
+                Nothing -> options.optProvider
+    loaded <-
+        loadAuth requestedProvider
+            >>= either (startupDie startup . Text.unpack) pure
+    case (transitionTarget, resumed) of
+        (Just target, _)
+            | loaded.loadedProvider /= target.modelProvider ->
+                startupDie startup $ "provider transition requested "
+                    <> Text.unpack (providerSlug target.modelProvider)
+                    <> " but auth resolved "
+                    <> Text.unpack (providerSlug loaded.loadedProvider)
+        (Nothing, Just (meta, _))
+            | loaded.loadedProvider /= meta.metaProvider ->
+                startupDie startup $ "session provider is "
+                    <> Text.unpack (providerSlug meta.metaProvider)
+                    <> " but auth resolved "
+                    <> Text.unpack (providerSlug loaded.loadedProvider)
+        _ -> pure ()
+
+    markStartupStage startup "Loading tools…"
     let basePlanHooks =
             cliPlanHooks interrupt escPaused (resolveColor stderr)
         planHooks = fullscreenAwarePlanHooks uiRuntimeRef basePlanHooks
@@ -744,7 +929,10 @@ runAgent options transition = do
                 Just (meta, _) -> Just meta.metaTitle
                 Nothing -> sessionTitleFromPrompt <$> prompt
         setCliWindowTitle stdoutTty stdout (cliWindowTitle cwd titleHint)
-        startupContext <- loadAgentsContext options provider home cwd initialItems initialPrevious
+        markStartupStage startup "Loading instructions…"
+        startupContext <-
+            loadAgentsContext
+                fullscreen options provider home cwd initialItems initialPrevious
         -- Fullscreen sessions load skills after Brick has taken over the
         -- terminal, so filesystem discovery cannot delay the first frame.
         -- Minimal and one-shot sessions still initialize them synchronously
@@ -752,7 +940,9 @@ runAgent options transition = do
         skillsRef <- newIORef (SkillCatalog [] [])
         skillInvocationsRef <- newIORef []
 
-        persist <- preparePersistence options root provider model cwd effort prompt resumed
+        persist <-
+            preparePersistence
+                fullscreen options root provider model cwd effort prompt resumed
         writeIORef persistSlotRef persist
         usageRef <- newIORef $ case resumed of
             Just (meta, turns) -> sessionUsageFromTurns meta turns
@@ -767,6 +957,7 @@ runAgent options transition = do
                     PersistencePending _ -> pure ()
             PersistenceDisabled -> pure ()
         progName <- getProgName
+        markStartupStage startup "Connecting to provider…"
         withCtrlCHandler interrupt $
             withInterruptResume progName persist RunQuit do
                 case provider of
@@ -801,7 +992,7 @@ runAgent options transition = do
                                             privateTranscript
                                 activeBackend <-
                                     prepareTransitionBackend transition persist noticingBackend
-                                runSession options provider policy tools toolEnv planMode uiRuntimeRef prompt pendingTurn unavailableProviders paramsRef transcriptRef initialTurns
+                                runSession options provider policy tools toolEnv planMode startup prompt pendingTurn unavailableProviders paramsRef transcriptRef initialTurns
                                     initialPrevious persist projectRoot home cwd (Just loaded.loadedTokenProvider) loaded.loadedOpenAiPool startupContext skillsRef skillInvocationsRef escPaused interrupt
                                     multiCtx rootTurnRef subagentSessions pendingNotices subagentStoreRoot usageRef claimCurrentSession activeBackend btwBackend)
                             >>= \case
@@ -810,7 +1001,9 @@ runAgent options transition = do
                                         Just active
                                             | active.transitionCause == AutomaticFallback ->
                                                 pure (RunProviderStartFailed err)
-                                        _ -> die ("openai auth: " <> show err)
+                                        _ ->
+                                            startupDie startup
+                                                ("openai auth: " <> show err)
                                 Right result -> pure result
                     XAIProvider -> do
                         xaiOptions <- XAI.clientOptionsFromEnv
@@ -833,7 +1026,7 @@ runAgent options transition = do
                                     (readIORef privateParams) privateTranscript
                         activeBackend <-
                             prepareTransitionBackend transition persist backend
-                        runSession options provider policy tools toolEnv planMode uiRuntimeRef prompt pendingTurn unavailableProviders paramsRef transcriptRef initialTurns
+                        runSession options provider policy tools toolEnv planMode startup prompt pendingTurn unavailableProviders paramsRef transcriptRef initialTurns
                             initialPrevious persist projectRoot home cwd (Just loaded.loadedTokenProvider) loaded.loadedOpenAiPool startupContext skillsRef skillInvocationsRef escPaused interrupt
                             multiCtx rootTurnRef subagentSessions pendingNotices subagentStoreRoot usageRef claimCurrentSession activeBackend btwBackend
                     OpenRouterProvider -> do
@@ -857,12 +1050,13 @@ runAgent options transition = do
                                     (readIORef privateParams) privateTranscript
                         activeBackend <-
                             prepareTransitionBackend transition persist backend
-                        runSession options provider policy tools toolEnv planMode uiRuntimeRef prompt pendingTurn unavailableProviders paramsRef transcriptRef initialTurns
+                        runSession options provider policy tools toolEnv planMode startup prompt pendingTurn unavailableProviders paramsRef transcriptRef initialTurns
                             initialPrevious persist projectRoot home cwd (Just loaded.loadedTokenProvider) loaded.loadedOpenAiPool startupContext skillsRef skillInvocationsRef escPaused interrupt
                             multiCtx rootTurnRef subagentSessions pendingNotices subagentStoreRoot usageRef claimCurrentSession activeBackend btwBackend
 
 preparePersistence
-    :: CliOptions
+    :: Maybe FullscreenRuntime
+    -> CliOptions
     -> OsPath
     -> Provider
     -> Text
@@ -871,7 +1065,7 @@ preparePersistence
     -> Maybe Text
     -> Maybe (SessionMeta, [SessionTurn])
     -> IO Persistence
-preparePersistence options root provider model cwd effort prompt resumed =
+preparePersistence fullscreen options root provider model cwd effort prompt resumed =
     case resumed of
         Just (meta, _) -> do
             let handle = SessionHandle
@@ -882,10 +1076,14 @@ preparePersistence options root provider model cwd effort prompt resumed =
                         root </> fromText meta.metaId </> fromFilePath "transcript.jsonl"
                     , sessionMeta = meta
                     }
-            color <- resolveColor stderr
-            putTextLn stderr
-                (roleMuted color
-                    (glyphSession <> "session: " <> meta.metaId <> " (resumed)"))
+            let message = "session: " <> meta.metaId <> " (resumed)"
+            case fullscreen of
+                Nothing -> do
+                    color <- resolveColor stderr
+                    putTextLn stderr
+                        (roleMuted color (glyphSession <> message))
+                Just runtime ->
+                    emitUiEvent runtime (UiSystemMessage message)
             newActivePersistence handle
         Nothing
             | shouldPersist options ->
@@ -964,7 +1162,7 @@ runSession
     -> [AppTool]
     -> ToolEnv
     -> PlanModeEnv
-    -> IORef (Maybe FullscreenRuntime)
+    -> StartupRuntime
     -> Maybe Text
     -> Maybe PendingTurn
     -> [Provider]
@@ -993,8 +1191,12 @@ runSession
     -> Backend
     -> BtwBackendFactory
     -> IO RunResult
-runSession options provider policy tools toolEnv planMode uiRuntimeRef prompt pendingTurn unavailableProviders paramsRef transcriptRef initialTurns initialPrevious persist projectRoot home cwd tokenProvider openAiPool startupContext skillsRef skillInvocationsRef escPaused interrupt multiCtx rootTurnRef subagentSessions pendingNotices storeRoot usageRef onPersisted backend btwBackend =
+runSession options provider policy tools toolEnv planMode startup prompt pendingTurn unavailableProviders paramsRef transcriptRef initialTurns initialPrevious persist projectRoot home cwd tokenProvider openAiPool startupContext skillsRef skillInvocationsRef escPaused interrupt multiCtx rootTurnRef subagentSessions pendingNotices storeRoot usageRef onPersisted backend btwBackend =
   withSessionTitleManager btwBackend paramsRef \titleManager -> do
+    let fullscreen = startup.startupFullscreen
+        terminal = startup.startupTerminal
+        useColor = startup.startupUseColor
+        stderrTty = startup.startupStderrTty
     toolRegistry <- requireToolRegistry tools
     printed <- newIORef False
     attachmentsRef <- newIORef []
@@ -1053,6 +1255,9 @@ runSession options provider policy tools toolEnv planMode uiRuntimeRef prompt pe
             { viewportSelected = selectedAgent
             , viewportEntries = loadAgentEntries
             }
+    writeIORef startup.startupAgentSnapshot
+        ((,) <$> readIORef selectedAgent <*> loadAgentEntries)
+    writeIORef startup.startupAgentSelect (writeIORef selectedAgent)
     let sessionReset = do
             resetLiveConversation previous transcriptRef attachmentsRef planMode
             writeIORef usageRef emptyTokenUsage
@@ -1064,7 +1269,7 @@ runSession options provider policy tools toolEnv planMode uiRuntimeRef prompt pe
                 Just ctx -> resetSubagentRegistry ctx.multiRegistry
                 Nothing -> pure ()
             freshAgents <-
-                loadAgentsContext options provider home cwd [] Nothing
+                loadAgentsContext fullscreen options provider home cwd [] Nothing
             freshSkills <- loadSkillsCatalog options home projectRoot cwd True
             installSkillCatalog
                 reservedSlashNames True freshAgents
@@ -1078,42 +1283,6 @@ runSession options provider policy tools toolEnv planMode uiRuntimeRef prompt pe
                 reservedSlashNames queueContext startupContext
                 skillsRef skillInvocationsRef refreshed
     policyRef <- newIORef policy
-    stderrTty <- hIsTerminalDevice stderr
-    stdinTty <- hIsTerminalDevice stdin
-    stdoutTty <- hIsTerminalDevice stdout
-    terminal <- detectTerminalCapabilities stdout
-    reportTerminalCwd terminal stdout (toFilePath cwd)
-    useColor <- resolveColor stdout
-    branch <- detectGitBranch cwd
-    let fullscreenEnabled =
-            stdinTty
-                && stdoutTty
-                && not (isOneShot options)
-                && options.optScreenMode /= ScreenMinimal
-        initialFullscreenState =
-            reduceUi
-                (UiSetNotice (Just "Starting…"))
-                (reduceUi
-                    (UiSetRepository
-                        branch
-                        (toText (takeFileName (takeDirectory cwd))
-                            <> "/"
-                            <> toText (takeFileName cwd)))
-                    (hydrateUiHistory initialTurns))
-    fullscreen <- if fullscreenEnabled
-        then Just <$> newFullscreenRuntime
-            (requestCancel toolEnv.toolCancel)
-            (noteFullscreenCtrlC interrupt)
-            (copyTerminalClipboard terminal stdout)
-            (\active ->
-                when terminal.terminalNativeProgress $
-                    setNativeProgress stderr active)
-            ((,) <$> readIORef selectedAgent <*> loadAgentEntries)
-            (writeIORef selectedAgent)
-            useColor
-            initialFullscreenState
-        else pure Nothing
-    writeIORef uiRuntimeRef fullscreen
     -- Mirror plan session dir into the subagent store root for this session.
     let syncStore = do
             sessionDir <- readIORef planMode.planSessionDir
@@ -1243,6 +1412,7 @@ runSession options provider policy tools toolEnv planMode uiRuntimeRef prompt pe
                 <> ": "
                 <> warning.skillWarningMessage
         initializeSkills = do
+            markStartupStage startup "Loading skills…"
             skills <- loadSkillsCatalog
                 options home projectRoot cwd (isNothing fullscreen)
             installSkillCatalog
@@ -1255,7 +1425,7 @@ runSession options provider policy tools toolEnv planMode uiRuntimeRef prompt pe
                     mapM_
                         (emitUiEvent runtime . UiSystemMessage . formatSkillWarning)
                         skills.catalogWarnings
-                    emitUiEvent runtime (UiSetNotice Nothing)
+            finishStartup startup
         sessionAction = do
             initializeSkills
             case pendingTurn of
@@ -1269,11 +1439,7 @@ runSession options provider policy tools toolEnv planMode uiRuntimeRef prompt pe
                         finishTurn env True result
                     Nothing ->
                         repl env
-    result <-
-        (case fullscreen of
-            Nothing -> sessionAction
-            Just runtime -> runFullscreen runtime sessionAction)
-            `finally` writeIORef uiRuntimeRef Nothing
+    result <- sessionAction
     _ <- waitForSessionTitleResults 5000000 titleManager
     applyPendingSessionTitles env
     pure result
@@ -2891,14 +3057,15 @@ enterPlanFromSlash env@SessionEnv
 -- | Discover AGENTS.md once for a fresh session. Resumed transcripts keep
 -- whatever instructions were already in history.
 loadAgentsContext
-    :: CliOptions
+    :: Maybe FullscreenRuntime
+    -> CliOptions
     -> Provider
     -> OsPath
     -> OsPath
     -> [ResponseItem]
     -> Maybe Text
     -> IO (IORef (Maybe Text))
-loadAgentsContext options provider home cwd initialItems initialPrevious
+loadAgentsContext fullscreen options provider home cwd initialItems initialPrevious
     | not options.optAgentsMd = newIORef Nothing
     | not (null initialItems) || isJust initialPrevious = newIORef Nothing
     | otherwise = do
@@ -2912,12 +3079,17 @@ loadAgentsContext options provider home cwd initialItems initialPrevious
         case formatAgentsMdForProvider provider cwd loaded of
             Nothing -> newIORef Nothing
             Just text -> do
-                color <- resolveColor stderr
-                putTextLn stderr
-                    (roleMuted color
-                        (glyphSession <> "agents.md: loaded "
+                let message =
+                        "agents.md: loaded "
                             <> Text.pack (show (length files))
-                            <> if length files == 1 then " file" else " files"))
+                            <> if length files == 1 then " file" else " files"
+                case fullscreen of
+                    Nothing -> do
+                        color <- resolveColor stderr
+                        putTextLn stderr
+                            (roleMuted color (glyphSession <> message))
+                    Just runtime ->
+                        emitUiEvent runtime (UiSystemMessage message)
                 newIORef (Just text)
 
 preparePromptSkillInputs

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -123,6 +123,7 @@ data FullscreenRuntime = FullscreenRuntime
     , runtimeNativeProgress :: !(Bool -> IO ())
     , runtimeAgentSnapshot :: !(IO (AgentTarget, [AgentEntry]))
     , runtimeAgentSelect :: !(AgentTarget -> IO ())
+    , runtimeFirstFrame :: !(IO ())
     , runtimeColor :: !Bool
     , runtimeInitial :: !UiState
     }
@@ -170,6 +171,7 @@ newFullscreenRuntime
     -> (Bool -> IO ())
     -> IO (AgentTarget, [AgentEntry])
     -> (AgentTarget -> IO ())
+    -> IO ()
     -> Bool
     -> UiState
     -> IO FullscreenRuntime
@@ -180,6 +182,7 @@ newFullscreenRuntime
     nativeProgress
     agentSnapshot
     agentSelect
+    firstFrame
     color
     initial = FullscreenRuntime
     <$> newBChan 512
@@ -190,6 +193,7 @@ newFullscreenRuntime
     <*> pure nativeProgress
     <*> pure agentSnapshot
     <*> pure agentSelect
+    <*> pure firstFrame
     <*> pure color
     <*> pure initial
 
@@ -573,7 +577,10 @@ fullscreenApp = App
     { appDraw = drawApp
     , appChooseCursor = showFirstCursor
     , appHandleEvent = handleEvent
-    , appStartEvent = vScrollToEnd (viewportScroll ConversationViewport)
+    , appStartEvent = do
+        state <- get
+        liftIO state.appRuntime.runtimeFirstFrame
+        vScrollToEnd (viewportScroll ConversationViewport)
     , appAttrMap = \state ->
         if state.appRuntime.runtimeColor
             then Theme.solarizedDark

--- a/packages/agent-cli/test/Agent/CLI/ReplStatusSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ReplStatusSpec.hs
@@ -7,6 +7,7 @@ import Agent.CLI
     , cycleReplInteraction
     , devArgs
     , formatReplStatusLine
+    , formatStartupTimings
     , formatTokenUsage
     , withRestoredCurrentDirectory
     )
@@ -118,6 +119,16 @@ spec = do
                         ReplModeNormal emptyTokenUsage
             terminalTextWidth line `shouldBe` 16
             line `shouldBe` "  模型模型 · hi…"
+
+    describe "formatStartupTimings" do
+        it "sorts cumulative startup markers and keeps subsecond precision" do
+            formatStartupTimings
+                [ ("ready", 1.25)
+                , ("first frame", 0.042)
+                , ("Loading tools…", 0.4)
+                ]
+                `shouldBe`
+                    "startup: first frame 42ms · Loading tools… 400ms · ready 1.25s"
 
     describe "cycleReplMode" do
         it "walks ask → plan → always-approve → ask" do


### PR DESCRIPTION
## Summary

- create and run the fullscreen TUI immediately after basic cwd and terminal setup
- perform project, credential, tool, instruction, provider, and skill initialization inside the scoped fullscreen worker
- show live startup stages while keeping the composer disabled until the session is ready
- preserve minimal and one-shot behavior, route startup messages safely through the TUI, and defer agent-browser callbacks until session state exists
- add opt-in cumulative startup timings with `HASKELL_AGENT_STARTUP_TIMING=1`, including a Brick first-frame marker

## Measured result

A tmux launch from the development REPL reported:

```text
first frame 12ms
credentials 30ms
tools 34ms
instructions 39ms
provider 42ms
skills 47ms
ready 59ms
```

## Validation

- rebased onto current `master`
- loaded and typechecked `agent-cli` in the Nix development shell
- ran the full `agent-cli` test suite in GHCi: 430 examples, 0 failures
- exercised fullscreen startup and timing output in tmux
- exercised the minimal rendering path in tmux
