### PR TITLE
Polish fullscreen TUI interaction states

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -211,6 +211,10 @@ import Agent.CLI.UI.Model
     ( PromptState(..)
     , UiEvent(..)
     , UiState(..)
+    , infoNotice
+    , progressNotice
+    , successNotice
+    , warningNotice
     , initialUiState
     , reduceUi
     )
@@ -578,7 +582,8 @@ setStartupNotice fullscreen message =
     case fullscreen of
         Nothing -> pure ()
         Just runtime ->
-            emitUiEvent runtime (UiSetNotice (Just message))
+            emitUiEvent runtime
+                (UiSetNotice (Just (progressNotice message)))
 
 recordStartupTiming
     :: UTCTime
@@ -702,7 +707,8 @@ runAgent fullscreenInputs options transition = do
                 && options.optScreenMode /= ScreenMinimal
         initialFullscreenState =
             (reduceUi
-                (UiSetNotice (Just "Loading project…"))
+                (UiSetNotice
+                    (Just (progressNotice "Loading project…")))
                 (reduceUi
                     (UiSetRepository
                         ""
@@ -1623,7 +1629,8 @@ waitAndRetryPendingTurn env delay pending = do
                 <> " (Esc to cancel)"
     case env.sessionFullscreen of
         Just runtime ->
-            emitUiEvent runtime (UiSetNotice (Just waitMessage))
+            emitUiEvent runtime
+                (UiSetNotice (Just (warningNotice waitMessage)))
         Nothing -> do
             color <- resolveColor stderr
             putTextLn stderr $
@@ -1647,7 +1654,10 @@ waitAndRetryPendingTurn env delay pending = do
             case env.sessionFullscreen of
                 Just runtime ->
                     emitUiEvent runtime
-                        (UiSetNotice (Just "automatic retry cancelled"))
+                        (UiSetNotice
+                            (Just
+                                (infoNotice
+                                    "automatic retry cancelled")))
                 Nothing -> do
                     color <- resolveColor stderr
                     putTextLn stderr
@@ -1659,7 +1669,8 @@ waitAndRetryPendingTurn env delay pending = do
             case env.sessionFullscreen of
                 Just runtime ->
                     emitUiEvent runtime
-                        (UiSetNotice (Just "retrying turn"))
+                        (UiSetNotice
+                            (Just (successNotice "retrying turn")))
                 Nothing -> do
                     color <- resolveColor stderr
                     putTextLn stderr
@@ -2226,7 +2237,10 @@ replWithDraft env@SessionEnv
                     ReplBtw question -> do
                         color <- resolveColor stdout
                         fullscreenEvent
-                            (UiSetNotice (Just "btw · asking…"))
+                            (UiSetNotice
+                                (Just
+                                    (progressNotice
+                                        "btw · asking…")))
                         result <-
                             runBtwWithCancel
                                 (\cancel action ->

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -57,6 +57,7 @@ import Brick.BChan
     , writeBChan
     )
 import Brick.Widgets.Border (borderWithLabel)
+import qualified Brick.Widgets.Border as Border
 import Brick.Widgets.Border.Style (unicodeRounded)
 import Brick.Widgets.Center (centerLayer)
 import Control.Concurrent.Async (wait, waitCatch, withAsync)
@@ -247,7 +248,7 @@ newFullscreenRuntime
     initial = do
         events <- newBChan 512
         mailbox <- AppEventMailbox <$> newTVarIO Seq.empty
-        running <- newIORef False
+        running <- newIORef (uiNeedsTick initial)
         pure FullscreenRuntime
             { runtimeEvents = events
             , runtimeMailbox = mailbox
@@ -267,18 +268,8 @@ newFullscreenRuntime
             }
 
 emitUiEvent :: FullscreenRuntime -> UiEvent -> IO ()
-emitUiEvent runtime event = do
-    updateRuntimeRunning runtime event
+emitUiEvent runtime event =
     enqueueAppEvent runtime (AppUi event)
-
-updateRuntimeRunning :: FullscreenRuntime -> UiEvent -> IO ()
-updateRuntimeRunning runtime = \case
-    UiLoop TurnStarted -> writeIORef runtime.runtimeRunning True
-    UiLoop TurnFinished{} -> writeIORef runtime.runtimeRunning False
-    UiTurnEnded _ -> writeIORef runtime.runtimeRunning False
-    UiTurnRestarted -> writeIORef runtime.runtimeRunning False
-    UiSetAwaitingInput True -> writeIORef runtime.runtimeRunning False
-    _ -> pure ()
 
 setFullscreenWindowTitle :: FullscreenRuntime -> Text -> IO ()
 setFullscreenWindowTitle runtime =
@@ -655,7 +646,9 @@ handlePromptControlClick choice = do
                     { appUi =
                         reduceUi
                             (UiSetNotice
-                                (Just "Prompt settings can be changed when input is ready."))
+                                (Just
+                                    (warningNotice
+                                        "Prompt settings can be changed when input is ready.")))
                             current.appUi
                     }
 
@@ -700,7 +693,9 @@ handleEffortControlClick = do
                         { appUi =
                             reduceUi
                                 (UiSetNotice
-                                    (Just "Prompt settings cannot be changed right now."))
+                                    (Just
+                                        (warningNotice
+                                            "Prompt settings cannot be changed right now.")))
                                 current.appUi
                         }
 
@@ -889,15 +884,15 @@ drawApp state =
     case (state.appTextPrompt, state.appChoice, state.appUi.uiPermission) of
         (Just prompt, _, _) ->
             [ drawTextPrompt prompt
-            , drawMain state
+            , forceAttr Theme.dimAttr (drawMain state)
             ]
         (Nothing, Just choice, _) ->
             [ drawChoice state choice
-            , drawMain state
+            , forceAttr Theme.dimAttr (drawMain state)
             ]
         (Nothing, Nothing, Just permission) ->
             [ drawPermission permission
-            , drawMain state
+            , forceAttr Theme.dimAttr (drawMain state)
             ]
         (Nothing, Nothing, Nothing) -> [drawMain state]
 
@@ -910,6 +905,7 @@ drawMain state =
             , drawNotice state.appUi
             , drawQueuedInputs state.appUi
             , drawSlashMenu state
+            , drawFollowStatus state.appUi
             , drawComposer state
             , drawFooter state
             ]
@@ -1010,22 +1006,37 @@ drawHeader state =
             hBox
                 [ hLimitPercent 68 (txt left)
                 , vLimit 1 (fill ' ')
-                , txt right
+                , drawHeaderRight state
                 ]
   where
     left =
         (if Text.null state.uiBranch then "" else "git " <> state.uiBranch <> "  ")
             <> state.uiCwd
-    usage = formatTokenUsage state.uiPrompt.promptUsage
-    right =
+
+drawHeaderRight :: UiState -> Widget Name
+drawHeaderRight state =
+    hBox
+        [ withAttr activityAttr (txt activity)
+        , withAttr Theme.mutedAttr (txt elapsed)
+        , withAttr Theme.mutedAttr (txt usage)
+        ]
+  where
+    activityAttr
+        | state.uiRunning = Theme.thinkingAttr
+        | state.uiCompletionTicks > 0 = Theme.successAttr
+        | otherwise = Theme.mutedAttr
+    activity =
         (if state.uiRunning then spinnerFrame state.uiFrame <> " " else "")
             <> state.uiActivity
-            <> if state.uiRunning
-                then " · "
-                    <> formatElapsed
-                        (fromIntegral state.uiElapsedTenths / 10)
-                else ""
-            <> if Text.null usage then "" else " │ " <> usage
+    elapsed =
+        if state.uiRunning
+            then " · "
+                <> formatElapsed
+                    (fromIntegral state.uiElapsedTenths / 10)
+            else ""
+    formattedUsage = formatTokenUsage state.uiPrompt.promptUsage
+    usage =
+        if Text.null formattedUsage then "" else " │ " <> formattedUsage
 
 spinnerFrame :: Int -> Text
 spinnerFrame frame =
@@ -1057,19 +1068,19 @@ drawBlock state block =
                         (markdownWidget block.blockBody)
             BlockThinking ->
                 accentBlock Theme.thinkingAttr
-                    ("◆ " <> block.blockTitle)
+                    (blockStateGlyph state block <> block.blockTitle)
                     (visibleBody block)
             BlockTool ->
                 accentBlock (statusAttr block.blockState)
-                    ("◆ " <> block.blockTitle <> detailSuffix block)
+                    (blockStateGlyph state block <> block.blockTitle <> detailSuffix block)
                     (visibleBody block)
             BlockShell ->
                 accentBlock (statusAttr block.blockState)
-                    ("◆ " <> block.blockTitle <> detailSuffix block)
+                    (blockStateGlyph state block <> block.blockTitle <> detailSuffix block)
                     (visibleShellBody block)
             BlockEdit ->
                 accentBlock (statusAttr block.blockState)
-                    ("◆ " <> block.blockTitle <> detailSuffix block)
+                    (blockStateGlyph state block <> block.blockTitle <> detailSuffix block)
                     (visibleBody block)
             BlockSystem ->
                 withAttr Theme.mutedAttr (txtWrap block.blockBody)
@@ -1081,7 +1092,15 @@ drawBlock state block =
                 else content
         rendered =
             clickable (ConversationBlock block.blockId) $
-                padBottom (Pad 1) framed
+                padBottom (Pad 1) $
+                    hBox
+                        [ withAttr
+                            (if highlighted
+                                then Theme.borderActiveAttr
+                                else Theme.mutedAttr)
+                            (txt (if highlighted then "❯ " else "  "))
+                        , framed
+                        ]
     in if cacheableBlock block
         then cached
             (ConversationBlockCache
@@ -1095,6 +1114,15 @@ cacheableBlock :: UiBlock -> Bool
 cacheableBlock block =
     block.blockState
         `notElem` [BlockStreaming, BlockRunning]
+
+blockStateGlyph :: UiState -> UiBlock -> Text
+blockStateGlyph state block = case block.blockState of
+    BlockRunning -> spinnerFrame state.uiFrame <> " "
+    BlockStreaming -> spinnerFrame state.uiFrame <> " "
+    BlockComplete -> "✓ "
+    BlockFailed -> "✗ "
+    BlockDenied -> "⊘ "
+    BlockCancelled -> "⊘ "
 
 accentBlock :: AttrName -> Text -> Text -> Widget Name
 accentBlock accent title body =
@@ -1148,8 +1176,25 @@ drawNotice :: UiState -> Widget Name
 drawNotice state = case state.uiNotice of
     Nothing -> emptyWidget
     Just notice ->
-        withAttr Theme.footerAttr $
-            padLeftRight 2 (txtWrap notice)
+        let (attr, prefix) = noticePresentation state.uiFrame notice.noticeKind
+        in withAttr attr $
+            padLeftRight 2 (txtWrap (prefix <> notice.noticeText))
+
+noticePresentation :: Int -> NoticeKind -> (AttrName, Text)
+noticePresentation frame = \case
+    NoticeInfo -> (Theme.footerAttr, "• ")
+    NoticeSuccess -> (Theme.successAttr, "✓ ")
+    NoticeWarning -> (Theme.thinkingAttr, "⚠ ")
+    NoticeProgress -> (Theme.thinkingAttr, spinnerFrame frame <> " ")
+    NoticeError -> (Theme.errorAttr, "✗ ")
+
+drawFollowStatus :: UiState -> Widget Name
+drawFollowStatus state
+    | state.uiFollow = emptyWidget
+    | otherwise =
+        withAttr Theme.thinkingAttr $
+            padLeftRight 2 $
+                txt "↓ Live output paused · End to resume"
 
 drawQueuedInputs :: UiState -> Widget Name
 drawQueuedInputs state =
@@ -1218,7 +1263,6 @@ drawComposer appState =
     let focused = state.uiFocus == FocusComposer
         attr = if focused then Theme.borderActiveAttr else Theme.borderAttr
         mode = replModeLabel state.uiPrompt.promptMode
-        usage = formatTokenUsage state.uiPrompt.promptUsage
         leading =
             filter (not . Text.null)
                 [ if state.uiPrompt.promptAttachments > 0
@@ -1226,9 +1270,11 @@ drawComposer appState =
                         <> Text.pack
                             (show state.uiPrompt.promptAttachments)
                     else ""
-                , usage
                 , if Seq.null state.uiQueuedInputs
-                    then ""
+                    then
+                        if not state.uiAwaitingInput
+                            then "next message"
+                            else ""
                     else "queued "
                         <> Text.pack
                             (show (Seq.length state.uiQueuedInputs))
@@ -1238,7 +1284,10 @@ drawComposer appState =
             | otherwise =
                 [ clickable ComposerModel $
                     forceAttr
-                        (controlAttr appState ComposerModel)
+                        (controlAttr
+                            appState
+                            ComposerModel
+                            Theme.controlLinkAttr)
                         (txt state.uiPrompt.promptModel)
                 ]
         effortControl
@@ -1246,7 +1295,10 @@ drawComposer appState =
             | otherwise =
                 [ clickable ComposerEffort $
                     forceAttr
-                        (controlAttr appState ComposerEffort)
+                        (controlAttr
+                            appState
+                            ComposerEffort
+                            Theme.assistantAttr)
                         (txt (" (" <> state.uiPrompt.promptEffort <> ")"))
                 ]
         modelAndEffort = case modelControl <> effortControl of
@@ -1257,7 +1309,10 @@ drawComposer appState =
                 <> modelAndEffort
                 <> [ clickable ComposerMode $
                         forceAttr
-                            (controlAttr appState ComposerMode)
+                            (controlAttr
+                                appState
+                                ComposerMode
+                                (modeAttr mode))
                             (txt mode)
                    | not (Text.null mode)
                    ]
@@ -1269,23 +1324,26 @@ drawComposer appState =
         editor =
             padLeftRight 1 $
                 hBox
-                    [ withAttr Theme.assistantAttr (txt "❯ ")
-                    , renderDraft focused state
+                    [ withAttr
+                        (if focused then Theme.borderActiveAttr else Theme.mutedAttr)
+                        (txt "❯ ")
+                    , withAttr Theme.assistantAttr (renderDraft focused state)
                     , vLimit 1 (fill ' ')
                     ]
-    in clickable ComposerArea $
-        withAttr attr $
+        composer =
             withBorderStyle unicodeRounded $
                 borderWithLabel (withAttr Theme.footerAttr label) $
                     editor
+    in clickable ComposerArea $
+        overrideAttr Border.borderAttr attr composer
   where
     state = appState.appUi
 
-controlAttr :: AppState -> Name -> AttrName
-controlAttr state name =
+controlAttr :: AppState -> Name -> AttrName -> AttrName
+controlAttr state name fallback =
     case controlInteractionAttr state name of
         Just attr -> attr
-        Nothing -> Theme.controlLinkAttr
+        Nothing -> fallback
 
 controlInteractionAttr :: AppState -> Name -> Maybe AttrName
 controlInteractionAttr state name
@@ -1296,6 +1354,12 @@ controlInteractionAttr state name
         Just Theme.controlLinkHoverAttr
     | otherwise =
         Nothing
+
+modeAttr :: Text -> AttrName
+modeAttr mode = case Text.toLower mode of
+    "yolo" -> Theme.thinkingAttr
+    "plan" -> Theme.headingAttr
+    _ -> Theme.linkAttr
 
 renderDraft :: Bool -> UiState -> Widget Name
 renderDraft focused state =
@@ -1347,7 +1411,7 @@ drawPermission :: PermissionOverlay -> Widget Name
 drawPermission permission =
     centerLayer $
         hLimitPercent 78 $
-            withAttr Theme.borderActiveAttr $
+            overrideAttr Border.borderAttr Theme.borderActiveAttr $
                 withBorderStyle unicodeRounded $
                     borderWithLabel (txt " Permission ") $
                         padAll 1 $
@@ -1379,7 +1443,7 @@ drawChoice appState choice =
     centerLayer $
         hLimitPercent 82 $
             vLimitPercent 78 $
-                withAttr Theme.borderActiveAttr $
+                overrideAttr Border.borderAttr Theme.borderActiveAttr $
                     withBorderStyle unicodeRounded $
                         borderWithLabel
                             (txt (" " <> choice.choiceTitle <> " ")) $
@@ -1410,7 +1474,7 @@ drawTextPrompt prompt =
     centerLayer $
         hLimitPercent 82 $
             vLimitPercent 78 $
-                withAttr Theme.borderActiveAttr $
+                overrideAttr Border.borderAttr Theme.borderAttr $
                     withBorderStyle unicodeRounded $
                         borderWithLabel
                             (txt (" " <> prompt.textTitle <> " ")) $
@@ -1422,7 +1486,7 @@ drawTextPrompt prompt =
                                             vLimitPercent 60 $
                                                 viewport OverlayViewport Vertical $
                                                     markdownWidget prompt.textBody
-                                    , withAttr Theme.borderAttr $
+                                    , overrideAttr Border.borderAttr Theme.borderActiveAttr $
                                         withBorderStyle unicodeRounded $
                                             borderWithLabel (txt " Answer ") $
                                                 padLeftRight 1 $
@@ -1468,6 +1532,10 @@ handleUiEvents uiEvents = do
         (final, nativeProgress, shouldFollow, shouldInvalidate) =
             foldl' applyOne (initial, Nothing, False, False) uiEvents
     put final
+    liftIO $
+        writeIORef
+            final.appRuntime.runtimeRunning
+            (uiNeedsTick final.appUi)
     case nativeProgress of
         Nothing -> pure ()
         Just active ->
@@ -1735,7 +1803,9 @@ handleCtrlC = do
                     { appUi =
                         reduceUi
                             (UiSetNotice
-                                (Just "Interrupted; press Ctrl-C again to exit."))
+                                (Just
+                                    (warningNotice
+                                        "Interrupted; press Ctrl-C again to exit.")))
                             current.appUi
                     }
         WarnExit ->
@@ -1744,7 +1814,9 @@ handleCtrlC = do
                     { appUi =
                         reduceUi
                             (UiSetNotice
-                                (Just "Press Ctrl-C again to exit."))
+                                (Just
+                                    (warningNotice
+                                        "Press Ctrl-C again to exit.")))
                             current.appUi
                     }
         ForceExit ->
@@ -1867,8 +1939,10 @@ handleScrollbackKey = \case
                                 (UiSetNotice
                                     (Just
                                         (if copied
-                                            then "Copied selected block."
-                                            else "Terminal clipboard is unavailable.")))
+                                            then successNotice
+                                                "Copied selected block."
+                                            else warningNotice
+                                                "Terminal clipboard is unavailable.")))
                                 current.appUi
                         }
 
@@ -1912,7 +1986,9 @@ handleComposerKey event = do
         V.EvKey (V.KChar '\t') [] ->
             case slashMenu of
                 Just menu -> acceptSlash menu
-                Nothing -> modifyUi (UiFocusChanged FocusScrollback)
+                Nothing ->
+                    when (not (null (toList ui.uiBlocks))) $
+                        modifyUi (UiFocusChanged FocusScrollback)
         V.EvKey V.KEnter [V.MShift] ->
             insertText "\n"
         V.EvKey V.KEnter [] ->
@@ -2048,7 +2124,8 @@ handleComposerKey event = do
         if not state.appUi.uiAwaitingInput
             then do
                 liftIO state.appRuntime.runtimeCancel
-                modifyUi (UiSetNotice (Just "Cancelling…"))
+                modifyUi
+                    (UiSetNotice (Just (progressNotice "Cancelling…")))
             else
                 modifyUi (UiSetDraft "" 0)
 

--- a/packages/agent-cli/src/Agent/CLI/TUI/Theme.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Theme.hs
@@ -11,6 +11,7 @@ module Agent.CLI.TUI.Theme
     , controlLinkActiveAttr
     , controlLinkAttr
     , controlLinkHoverAttr
+    , dimAttr
     , emphasisAttr
     , headingAttr
     , inlineCodeAttr
@@ -33,7 +34,7 @@ import qualified Graphics.Vty as V
 baseAttr, headerAttr, footerAttr, mutedAttr :: AttrName
 userAttr, assistantAttr, thinkingAttr, toolAttr :: AttrName
 errorAttr, successAttr, selectedAttr, borderAttr, borderActiveAttr :: AttrName
-headingAttr, codeAttr, emphasisAttr, inlineCodeAttr, linkAttr, strongAttr :: AttrName
+headingAttr, codeAttr, dimAttr, emphasisAttr, inlineCodeAttr, linkAttr, strongAttr :: AttrName
 controlLinkAttr, controlLinkHoverAttr, controlLinkActiveAttr :: AttrName
 baseAttr = attrName "base"
 headerAttr = attrName "header"
@@ -50,6 +51,7 @@ borderAttr = attrName "border"
 borderActiveAttr = attrName "border-active"
 headingAttr = attrName "markdown-heading"
 codeAttr = attrName "markdown-code"
+dimAttr = attrName "dim"
 emphasisAttr = attrName "markdown-emphasis"
 inlineCodeAttr = attrName "markdown-inline-code"
 linkAttr = attrName "markdown-link"
@@ -111,6 +113,9 @@ solarizedDark =
         , (codeAttr, V.defAttr
             `V.withForeColor` rgb 42 161 152
             `V.withBackColor` rgb 7 54 66)
+        , (dimAttr, V.defAttr
+            `V.withForeColor` rgb 88 110 117
+            `V.withBackColor` rgb 0 43 54)
         , (emphasisAttr, V.defAttr
             `V.withForeColor` rgb 147 161 161
             `V.withBackColor` rgb 0 43 54
@@ -157,6 +162,7 @@ monochrome =
         , (borderActiveAttr, V.defAttr `V.withStyle` V.bold)
         , (headingAttr, V.defAttr `V.withStyle` V.bold)
         , (codeAttr, V.defAttr)
+        , (dimAttr, V.defAttr)
         , (emphasisAttr, V.defAttr `V.withStyle` V.italic)
         , (inlineCodeAttr, V.defAttr `V.withStyle` V.reverseVideo)
         , (linkAttr, V.defAttr `V.withStyle` V.underline)

--- a/packages/agent-cli/src/Agent/CLI/Turn.hs
+++ b/packages/agent-cli/src/Agent/CLI/Turn.hs
@@ -16,7 +16,11 @@ import Agent.CLI.ProviderTransition
 import Agent.CLI.TUI.App
     ( emitUiEvent
     )
-import Agent.CLI.UI.Model (BlockState(..), UiEvent(..))
+import Agent.CLI.UI.Model
+    ( BlockState(..)
+    , UiEvent(..)
+    , successNotice
+    )
 import Agent.CLI.Render
     ( RenderConfig(..)
     , clearThinking
@@ -318,7 +322,11 @@ runOneTurn env@SessionEnv
                     detail = elapsedDetail extra
                 case fullscreen of
                     Just runtime ->
-                        emitUiEvent runtime (UiSetNotice (Just detail))
+                        emitUiEvent runtime
+                            (UiSetNotice
+                                (Just
+                                    (successNotice
+                                        ("Finished · " <> detail))))
                     Nothing -> do
                         color <- resolveColor stderr
                         putTextLn stderr

--- a/packages/agent-cli/src/Agent/CLI/UI/Model.hs
+++ b/packages/agent-cli/src/Agent/CLI/UI/Model.hs
@@ -4,11 +4,15 @@ module Agent.CLI.UI.Model
     , BlockKind(..)
     , BlockState(..)
     , Focus(..)
+    , NoticeKind(..)
     , PermissionOverlay(..)
     , PromptState(..)
     , UiBlock(..)
     , UiEvent(..)
+    , UiNotice(..)
     , UiState(..)
+    , errorNotice
+    , infoNotice
     , initialUiState
     , deleteToLineStart
     , deleteToLineEnd
@@ -19,6 +23,10 @@ module Agent.CLI.UI.Model
     , moveWordRight
     , reduceUi
     , selectedBlockIndex
+    , progressNotice
+    , successNotice
+    , uiNeedsTick
+    , warningNotice
     ) where
 
 import Agent.CLI.ReplMode (ReplMode(..))
@@ -54,6 +62,21 @@ data BlockKind
     | BlockEdit
     | BlockSystem
     | BlockError
+    deriving (Eq, Show)
+
+data NoticeKind
+    = NoticeInfo
+    | NoticeSuccess
+    | NoticeWarning
+    | NoticeProgress
+    | NoticeError
+    deriving (Eq, Show)
+
+data UiNotice = UiNotice
+    { noticeKind :: !NoticeKind
+    , noticeText :: !Text
+    , noticeTransient :: !Bool
+    }
     deriving (Eq, Show)
 
 data BlockState
@@ -114,9 +137,11 @@ data UiState = UiState
     , uiBranch :: !Text
     , uiCwd :: !Text
     , uiPermission :: !(Maybe PermissionOverlay)
-    , uiNotice :: !(Maybe Text)
+    , uiNotice :: !(Maybe UiNotice)
+    , uiNoticeTicks :: !Int
     , uiFrame :: !Int
     , uiElapsedTenths :: !Int
+    , uiCompletionTicks :: !Int
     , uiTurnStartBlock :: !Int
     , uiToolCalls :: !(Map.Map Text ToolCall)
     }
@@ -133,7 +158,7 @@ data UiEvent
     | UiSetPromptEffort !Text
     | UiSetAwaitingInput !Bool
     | UiSetRepository !Text !Text
-    | UiSetNotice !(Maybe Text)
+    | UiSetNotice !(Maybe UiNotice)
     | UiMoveSelection !Int
     | UiSelectBlock !BlockId
     | UiToggleSelected
@@ -176,8 +201,10 @@ initialUiState = UiState
     , uiCwd = ""
     , uiPermission = Nothing
     , uiNotice = Nothing
+    , uiNoticeTicks = 0
     , uiFrame = 0
     , uiElapsedTenths = 0
+    , uiCompletionTicks = 0
     , uiTurnStartBlock = 0
     , uiToolCalls = Map.empty
     }
@@ -227,12 +254,15 @@ reduceUi event state = case event of
         (if awaiting then finalizeStreams state else state)
             { uiAwaitingInput = awaiting
             , uiRunning = if awaiting then False else state.uiRunning
-            , uiActivity = if awaiting then "Ready" else state.uiActivity
+            , uiActivity =
+                if awaiting && state.uiCompletionTicks == 0
+                    then "Ready"
+                    else state.uiActivity
             }
     UiSetRepository branch cwd ->
         state { uiBranch = branch, uiCwd = cwd }
     UiSetNotice notice ->
-        state { uiNotice = notice }
+        state { uiNotice = notice, uiNoticeTicks = 0 }
     UiMoveSelection delta ->
         moveSelection delta state
     UiSelectBlock ident ->
@@ -299,16 +329,49 @@ reduceUi event state = case event of
             { uiBlocks = Seq.take state.uiTurnStartBlock state.uiBlocks
             , uiRunning = False
             , uiActivity = "Restarting…"
-            , uiNotice = Just "Restarting current turn…"
+            , uiNotice =
+                Just (progressNotice "Restarting current turn…")
+            , uiNoticeTicks = 0
+            , uiCompletionTicks = 0
             , uiToolCalls = Map.empty
             }
-    UiTick
-        | not state.uiRunning -> state
-        | otherwise ->
-            state
-                { uiFrame = (state.uiFrame + 1) `mod` 10
-                , uiElapsedTenths = state.uiElapsedTenths + 1
-                }
+    UiTick ->
+        if not (uiNeedsTick state)
+            then state
+            else
+                let completionTicks =
+                        max 0 (state.uiCompletionTicks - 1)
+                    noticeTicks = state.uiNoticeTicks + 1
+                    notice
+                        | noticeTicks >= 30
+                        , maybe False (.noticeTransient) state.uiNotice =
+                            Nothing
+                        | otherwise = state.uiNotice
+                in state
+                    { uiFrame = (state.uiFrame + 1) `mod` 10
+                    , uiElapsedTenths =
+                        if state.uiRunning
+                            then state.uiElapsedTenths + 1
+                            else state.uiElapsedTenths
+                    , uiActivity =
+                        if state.uiCompletionTicks == 1
+                            then "Ready"
+                            else state.uiActivity
+                    , uiCompletionTicks = completionTicks
+                    , uiNotice = notice
+                    , uiNoticeTicks =
+                        if notice == Nothing then 0 else noticeTicks
+                    }
+
+uiNeedsTick :: UiState -> Bool
+uiNeedsTick state =
+    state.uiRunning
+        || state.uiCompletionTicks > 0
+        || maybe False noticeNeedsTick state.uiNotice
+  where
+    noticeNeedsTick notice =
+        notice.noticeTransient
+            || notice.noticeKind == NoticeProgress
 
 reduceLoop :: LoopEvent -> UiState -> UiState
 reduceLoop event state = case event of
@@ -319,6 +382,7 @@ reduceLoop event state = case event of
             , uiActivity = "Thinking…"
             , uiNotice = Nothing
             , uiElapsedTenths = 0
+            , uiCompletionTicks = 0
             , uiTurnStartBlock = Seq.length state.uiBlocks
             , uiToolCalls = Map.empty
             }
@@ -377,7 +441,9 @@ reduceLoop event state = case event of
             , uiActivity =
                 if continuing
                     then "Running tools…"
-                    else "Ready"
+                    else "Finished"
+            , uiCompletionTicks =
+                if continuing then 0 else 10
             }
 
 appendOrExtend
@@ -469,8 +535,32 @@ finalizeTurn terminalState state =
                         else block)
                 state.uiBlocks
         , uiRunning = False
-        , uiActivity = "Ready"
+        , uiActivity =
+            if terminalState == BlockComplete
+                then "Finished"
+                else "Ready"
+        , uiCompletionTicks =
+            if terminalState == BlockComplete then 10 else 0
         }
+
+infoNotice, successNotice, warningNotice, progressNotice, errorNotice
+    :: Text -> UiNotice
+infoNotice = transientNotice NoticeInfo
+successNotice = transientNotice NoticeSuccess
+warningNotice = transientNotice NoticeWarning
+errorNotice = transientNotice NoticeError
+progressNotice text = UiNotice
+    { noticeKind = NoticeProgress
+    , noticeText = text
+    , noticeTransient = False
+    }
+
+transientNotice :: NoticeKind -> Text -> UiNotice
+transientNotice kind text = UiNotice
+    { noticeKind = kind
+    , noticeText = text
+    , noticeTransient = True
+    }
 
 finalizeStreams :: UiState -> UiState
 finalizeStreams state =

--- a/packages/agent-cli/test/Agent/CLI/UIModelSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/UIModelSpec.hs
@@ -69,7 +69,9 @@ spec = describe "fullscreen UI reducer" do
         state.uiPrompt.promptEffort `shouldBe` "high"
         state.uiRunning `shouldBe` False
         state.uiActivity `shouldBe` "Restarting…"
-        state.uiNotice `shouldBe` Just "Restarting current turn…"
+        state.uiNotice
+            `shouldBe` Just
+                (progressNotice "Restarting current turn…")
 
     it "matches tool completion by call id" do
         let call = functionToolCall "c1" "run_terminal_cmd" "{\"command\":\"git status\"}"
@@ -178,6 +180,38 @@ spec = describe "fullscreen UI reducer" do
         idle.uiFrame `shouldBe` 0
         running.uiElapsedTenths `shouldBe` 3
         after.uiElapsedTenths `shouldBe` 3
+
+    it "briefly settles on Finished before returning to Ready" do
+        let finished =
+                apply
+                    [ UiLoop TurnStarted
+                    , UiLoop
+                        (TurnFinished
+                            (emptyTurnOutput "r1" [] Nothing))
+                    ]
+            awaiting = reduceUi (UiSetAwaitingInput True) finished
+            settled = iterate (reduceUi UiTick) awaiting !! 10
+        finished.uiActivity `shouldBe` "Finished"
+        finished.uiCompletionTicks `shouldBe` 10
+        awaiting.uiActivity `shouldBe` "Finished"
+        settled.uiActivity `shouldBe` "Ready"
+        settled.uiCompletionTicks `shouldBe` 0
+
+    it "expires transient notices but keeps progress notices visible" do
+        let transient =
+                reduceUi
+                    (UiSetNotice
+                        (Just (successNotice "Copied selected block.")))
+                    initialUiState
+            expired = iterate (reduceUi UiTick) transient !! 30
+            progress =
+                reduceUi
+                    (UiSetNotice (Just (progressNotice "Cancelling…")))
+                    initialUiState
+            stillProgress = iterate (reduceUi UiTick) progress !! 40
+        expired.uiNotice `shouldBe` Nothing
+        stillProgress.uiNotice
+            `shouldBe` Just (progressNotice "Cancelling…")
 
     it "shows a search-replace diff while the tool is running" do
         let call =
@@ -343,7 +377,8 @@ spec = describe "fullscreen UI reducer" do
         requestingTool.uiActivity `shouldBe` "Running tools…"
         afterTool.uiRunning `shouldBe` True
         finished.uiRunning `shouldBe` False
-        finished.uiActivity `shouldBe` "Ready"
+        finished.uiActivity `shouldBe` "Finished"
+        finished.uiCompletionTicks `shouldBe` 10
 
     it "deletes the previous word for command/option-backspace" do
         deleteWordBefore "hello brave world" 17


### PR DESCRIPTION
## Summary

- make the fullscreen composer use a real active focus ring while keeping draft text visually stable
- add explicit scrollback selection, paused-follow, queued-input, tool-progress, and completion states
- introduce typed semantic notices with transient and persistent lifetimes
- improve header hierarchy while preserving hover/pressed feedback for clickable composer metadata
- dim the underlying interface for modal overlays and focus the active modal control
- keep animation ticks demand-driven and compatible with batched fullscreen event delivery

## Validation

- recovered the crashed session implementation and final uncommitted regression assertion
- rebased onto the latest `master` and resolved overlaps with turn restarts, transcript caching, shell streaming, and batched TUI event delivery
- ran the full `agent-cli` test suite in the test REPL: 452 examples, 0 failures
- exercised the focused composer and model modal in a fresh tmux session after the final rebase
- the original session also exercised queued input, running tools, completion feedback, scrollback selection, and paused follow mode in tmux
