### PR TITLE
Keep fullscreen TUI responsive at scale

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -23,7 +23,7 @@ import Agent.CLI.AgentViewport
     , formatAgentStatus
     , pickAgentViewport
     , renderAgentViewportPanelFor
-    , responseItemLines
+    , responseItemPreviewLines
     )
 import Agent.CLI.SessionTitle
     ( invalidateSessionTitles
@@ -1245,45 +1245,74 @@ runSession options provider policy tools toolEnv planMode startup prompt pending
     previous <- newIORef initialPrevious
     titleTurnCount <- newIORef =<< sessionTitleTurnCountFromSlot persist
     selectedAgent <- newIORef AgentRoot
-    let loadAgentEntries = do
+    let loadAgentEntries includeSummaries = do
+            selected <- readIORef selectedAgent
             rootItems <- readIORef transcriptRef
             agents <- case multiCtx of
                 Nothing -> pure []
                 Just ctx -> listAgents ctx.multiRegistry Nothing
+            sessions <- readIORef subagentSessions
+            let previewCount target =
+                    if null agents
+                        then Nothing
+                        else if target == selected
+                            then Just 12
+                            else if includeSummaries
+                                then Just 0
+                                else Nothing
             let rootEntry = AgentEntry
                     { agentTarget = AgentRoot
                     , agentPath = "/root"
                     , agentStatus = "active"
-                    , agentTranscript = responseItemLines rootItems
+                    , agentTranscript = case previewCount AgentRoot of
+                        Nothing -> []
+                        Just count ->
+                            responseItemPreviewLines count rootItems
                     }
-            children <- mapM materializeChild agents
+            children <- mapM
+                (materializeChild previewCount sessions)
+                agents
             pure (rootEntry : children)
           where
-            materializeChild (path, agentId, status) = do
-                sessions <- readIORef subagentSessions
-                stored <- case Map.lookup agentId sessions of
-                    Nothing -> pure ["(" <> formatAgentStatus status <> ")"]
-                    Just session ->
-                        responseItemLines <$> readIORef session.subSessionTranscript
-                let transcript = stored <> case status of
-                        Completed (Just result)
-                            | not (Text.null (Text.strip result)) ->
-                                ["assistant: " <> Text.strip result]
-                        Errored message ->
-                            ["error: " <> Text.strip message]
-                        _ -> []
+            materializeChild previewCount sessions (path, agentId, status) = do
+                let target = AgentChild agentId
+                transcript <- case previewCount target of
+                    Nothing -> pure []
+                    Just count -> do
+                        stored <- case Map.lookup agentId sessions of
+                            Nothing ->
+                                pure ["(" <> formatAgentStatus status <> ")"]
+                            Just session ->
+                                responseItemPreviewLines count
+                                    <$> readIORef session.subSessionTranscript
+                        pure $
+                            compactAgentPreview count $
+                                stored <> case status of
+                                    Completed (Just result)
+                                        | not (Text.null (Text.strip result)) ->
+                                            ["assistant: " <> Text.strip result]
+                                    Errored message ->
+                                        ["error: " <> Text.strip message]
+                                    _ -> []
                 pure AgentEntry
-                    { agentTarget = AgentChild agentId
+                    { agentTarget = target
                     , agentPath = taskPathText path
                     , agentStatus = formatAgentStatus status
                     , agentTranscript = transcript
                     }
+            compactAgentPreview count rows
+                | length rows <= count = rows
+                | otherwise = case rows of
+                    [] -> []
+                    firstLine : _ ->
+                        firstLine
+                            : drop (max 0 (length rows - count)) rows
         agentViewport = AgentViewportEnv
             { viewportSelected = selectedAgent
-            , viewportEntries = loadAgentEntries
+            , viewportEntries = loadAgentEntries True
             }
     writeIORef startup.startupAgentSnapshot
-        ((,) <$> readIORef selectedAgent <*> loadAgentEntries)
+        ((,) <$> readIORef selectedAgent <*> loadAgentEntries False)
     writeIORef startup.startupAgentSelect (writeIORef selectedAgent)
     let sessionReset = do
             resetLiveConversation previous transcriptRef attachmentsRef planMode

--- a/packages/agent-cli/src/Agent/CLI/AgentViewport.hs
+++ b/packages/agent-cli/src/Agent/CLI/AgentViewport.hs
@@ -15,6 +15,7 @@ module Agent.CLI.AgentViewport
     , renderAgentViewportFrame
     , renderAgentViewportFrameFor
     , responseItemLines
+    , responseItemPreviewLines
     , selectAgentTarget
     , selectedAgentEntry
     ) where
@@ -266,48 +267,109 @@ pickAgentViewport color selected entries = do
                 _ -> Nothing
 
 responseItemLines :: [ResponseItem] -> [Text]
-responseItemLines = concatMap itemLines
+responseItemLines = concatMap responseItemLineList
+
+-- | Keep a compact agent preview: the first line for picker context plus
+-- only the most recent logical lines for the live pane. Earlier response
+-- items are traversed only as list spine once the tail is full; their message
+-- bodies are not split or copied.
+responseItemPreviewLines :: Int -> [ResponseItem] -> [Text]
+responseItemPreviewLines count items
+    | count <= 0 = maybe [] pure (responseItemFirstLine items)
+    | remaining > 0 = trailing
+    | otherwise = case responseItemFirstLine items of
+        Nothing -> trailing
+        Just firstLine -> case trailing of
+            trailingFirst : _
+                | trailingFirst == firstLine -> trailing
+            _ -> firstLine : trailing
   where
-    itemLines = \case
-        MessageItem message ->
-            labelled (roleLabel message.role) (messageText message.content)
-        FunctionCallItem call ->
-            ["tool: " <> call.name]
-        CustomToolCallItem call ->
-            ["tool: " <> call.name]
-        FunctionCallOutputItem _ -> ["tool: completed"]
-        CustomToolCallOutputItem _ -> ["tool: completed"]
-        _ -> []
+    (remaining, trailing) =
+        foldr collectTail (count, []) items
+    collectTail item result@(needed, kept)
+        | needed <= 0 = result
+        | otherwise =
+            let rows = responseItemLineList item
+                rowCount = length rows
+                selected = drop (max 0 (rowCount - needed)) rows
+            in (max 0 (needed - rowCount), selected <> kept)
 
-    roleLabel = \case
-        RoleUser -> "user: "
-        RoleAssistant -> "assistant: "
-        RoleSystem -> "system: "
-        RoleDeveloper -> "developer: "
-        RoleUnknown value -> value <> ": "
+responseItemFirstLine :: [ResponseItem] -> Maybe Text
+responseItemFirstLine = go
+  where
+    go [] = Nothing
+    go (item : rest) = case responseItemFirstItemLine item of
+        Just line -> Just line
+        Nothing -> go rest
 
-    messageText = \case
-        MessageContentText text -> text
-        MessageContentParts parts ->
-            Text.intercalate "\n" (concatMap contentText parts)
+responseItemFirstItemLine :: ResponseItem -> Maybe Text
+responseItemFirstItemLine = \case
+    MessageItem message ->
+        labelledFirst
+            (responseRoleLabel message.role)
+            (responseMessageText message.content)
+    FunctionCallItem call ->
+        Just ("tool: " <> call.name)
+    CustomToolCallItem call ->
+        Just ("tool: " <> call.name)
+    FunctionCallOutputItem _ -> Just "tool: completed"
+    CustomToolCallOutputItem _ -> Just "tool: completed"
+    _ -> Nothing
 
-    contentText = \case
-        InputTextPart{text} -> [text]
-        OutputTextPart{text} -> [text]
-        RefusalPart{refusal} -> [refusal]
-        ReasoningTextPart{text} -> [text]
-        SummaryTextPart{text} -> [text]
-        InputImagePart{} -> ["[image]"]
-        InputFilePart{filename} -> ["[file" <> maybe "" (" " <>) filename <> "]"]
-        InputAudioPart{} -> ["[audio]"]
-        UnknownContentPart{} -> []
+responseItemLineList :: ResponseItem -> [Text]
+responseItemLineList = \case
+    MessageItem message ->
+        labelled
+            (responseRoleLabel message.role)
+            (responseMessageText message.content)
+    FunctionCallItem call ->
+        ["tool: " <> call.name]
+    CustomToolCallItem call ->
+        ["tool: " <> call.name]
+    FunctionCallOutputItem _ -> ["tool: completed"]
+    CustomToolCallOutputItem _ -> ["tool: completed"]
+    _ -> []
 
-    labelled prefix raw =
-        case Text.lines (Text.strip raw) of
-            [] -> []
-            firstLine : rest ->
-                (prefix <> firstLine)
-                    : map (Text.replicate (Text.length prefix) " " <>) rest
+responseRoleLabel :: ResponseRole -> Text
+responseRoleLabel = \case
+    RoleUser -> "user: "
+    RoleAssistant -> "assistant: "
+    RoleSystem -> "system: "
+    RoleDeveloper -> "developer: "
+    RoleUnknown value -> value <> ": "
+
+responseMessageText :: MessageContent -> Text
+responseMessageText = \case
+    MessageContentText text -> text
+    MessageContentParts parts ->
+        Text.intercalate "\n" (concatMap responseContentText parts)
+
+responseContentText :: ResponseContentPart -> [Text]
+responseContentText = \case
+    InputTextPart{text} -> [text]
+    OutputTextPart{text} -> [text]
+    RefusalPart{refusal} -> [refusal]
+    ReasoningTextPart{text} -> [text]
+    SummaryTextPart{text} -> [text]
+    InputImagePart{} -> ["[image]"]
+    InputFilePart{filename} -> ["[file" <> maybe "" (" " <>) filename <> "]"]
+    InputAudioPart{} -> ["[audio]"]
+    UnknownContentPart{} -> []
+
+labelled :: Text -> Text -> [Text]
+labelled prefix raw =
+    case Text.lines (Text.strip raw) of
+        [] -> []
+        firstLine : rest ->
+            (prefix <> firstLine)
+                : map (Text.replicate (Text.length prefix) " " <>) rest
+
+labelledFirst :: Text -> Text -> Maybe Text
+labelledFirst prefix raw =
+    let stripped = Text.strip raw
+    in if Text.null stripped
+        then Nothing
+        else Just (prefix <> Text.takeWhile (/= '\n') stripped)
 
 findByTarget :: AgentTarget -> [AgentEntry] -> Maybe AgentEntry
 findByTarget target = go

--- a/packages/agent-cli/src/Agent/CLI/Input.hs
+++ b/packages/agent-cli/src/Agent/CLI/Input.hs
@@ -21,6 +21,7 @@ module Agent.CLI.Input
     , appendReplHistory
     , readReplHistory
     , replHistoryPath
+    , terminalCharWidth
     , terminalTextWidth
     , truncateDisplayText
     , visibleEditorText
@@ -301,6 +302,9 @@ data DisplayCell = DisplayCell
 
 terminalTextWidth :: Text -> Int
 terminalTextWidth = cellsWidth . displayCells
+
+terminalCharWidth :: Char -> Int
+terminalCharWidth = (.displayCellWidth) . displayCell
 
 displayCells :: Text -> [DisplayCell]
 displayCells = map displayCell . Text.unpack

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -47,14 +47,25 @@ import qualified Agent.CLI.TUI.Theme as Theme
 import qualified Agent.CLI.TUI.Bridge as Bridge
 import Agent.CLI.TUI.Markdown (markdownWidget)
 import Agent.CLI.UI.Model
+import Agent.Loop (LoopEvent(..))
 import Agent.ToolDispatch (ToolCall(..))
 import Brick
-import Brick.BChan (BChan, newBChan, writeBChan)
+import Brick.BChan
+    ( BChan
+    , newBChan
+    , writeBChan
+    , writeBChanNonBlocking
+    )
 import Brick.Widgets.Border (borderWithLabel)
 import Brick.Widgets.Border.Style (unicodeRounded)
 import Brick.Widgets.Center (centerLayer)
 import Control.Concurrent.Async (wait, waitCatch, withAsync)
 import Control.Concurrent (threadDelay)
+import Control.Concurrent.MVar
+    ( MVar
+    , newMVar
+    , withMVar
+    )
 import Control.Concurrent.STM
     ( STM
     , TMVar
@@ -76,7 +87,15 @@ import Control.Exception (AsyncException(UserInterrupt))
 import Data.ByteString (ByteString)
 import Data.Char (isControl)
 import Data.Foldable (toList)
-import Data.List (find, intersperse, sortOn)
+import Data.IORef
+    ( IORef
+    , atomicModifyIORef'
+    , newIORef
+    , readIORef
+    , writeIORef
+    )
+import Data.List (find, findIndex, intersperse, sortOn)
+import Data.Sequence (Seq)
 import qualified Data.Sequence as Seq
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -89,6 +108,7 @@ data Name
     = ConversationViewport
     | OverlayViewport
     | ConversationBlock !BlockId
+    | ConversationBlockCache !BlockId !Bool !Bool
     | ComposerArea
     | ComposerCursor
     | ComposerModel
@@ -100,6 +120,16 @@ data Name
     | OverlayCursor
     | AgentRow !AgentTarget
     deriving (Eq, Ord, Show)
+
+data DeltaKind
+    = DeltaText
+    | DeltaReasoning
+    deriving (Eq)
+
+data BufferedDelta = BufferedDelta
+    { bufferedKind :: !DeltaKind
+    , bufferedChunks :: !(Seq Text)
+    }
 
 data AppEvent
     = AppUi !UiEvent
@@ -141,6 +171,9 @@ data FullscreenRuntime = FullscreenRuntime
     , runtimeAgentSnapshot :: !(IO (AgentTarget, [AgentEntry]))
     , runtimeAgentSelect :: !(AgentTarget -> IO ())
     , runtimeFirstFrame :: !(IO ())
+    , runtimePendingDeltas :: !(IORef (Seq BufferedDelta))
+    , runtimeEventLock :: !(MVar ())
+    , runtimeRunning :: !(IORef Bool)
     , runtimeColor :: !Bool
     , runtimeInitial :: !UiState
     }
@@ -210,22 +243,94 @@ newFullscreenRuntime
     agentSelect
     firstFrame
     color
-    initial = FullscreenRuntime
-    <$> newBChan 512
-    <*> pure inputBuffer
-    <*> pure cancelAction
-    <*> pure ctrlCAction
-    <*> pure copyAction
-    <*> pure setWindowTitle
-    <*> pure nativeProgress
-    <*> pure agentSnapshot
-    <*> pure agentSelect
-    <*> pure firstFrame
-    <*> pure color
-    <*> pure initial
+    initial = do
+        events <- newBChan 512
+        pendingDeltas <- newIORef Seq.empty
+        eventLock <- newMVar ()
+        running <- newIORef False
+        pure FullscreenRuntime
+            { runtimeEvents = events
+            , runtimeInput = inputBuffer
+            , runtimeCancel = cancelAction
+            , runtimeCtrlC = ctrlCAction
+            , runtimeCopy = copyAction
+            , runtimeSetWindowTitle = setWindowTitle
+            , runtimeNativeProgress = nativeProgress
+            , runtimeAgentSnapshot = agentSnapshot
+            , runtimeAgentSelect = agentSelect
+            , runtimeFirstFrame = firstFrame
+            , runtimePendingDeltas = pendingDeltas
+            , runtimeEventLock = eventLock
+            , runtimeRunning = running
+            , runtimeColor = color
+            , runtimeInitial = initial
+            }
 
 emitUiEvent :: FullscreenRuntime -> UiEvent -> IO ()
-emitUiEvent runtime = writeBChan runtime.runtimeEvents . AppUi
+emitUiEvent runtime event =
+    case bufferedDelta event of
+        Just (kind, delta) ->
+            atomicModifyIORef' runtime.runtimePendingDeltas \pending ->
+                (appendBufferedDelta kind delta pending, ())
+        Nothing ->
+            withMVar runtime.runtimeEventLock \_ -> do
+                flushPendingDeltasUnlocked runtime
+                updateRuntimeRunning runtime event
+                writeBChan runtime.runtimeEvents (AppUi event)
+
+bufferedDelta :: UiEvent -> Maybe (DeltaKind, Text)
+bufferedDelta = \case
+    UiLoop (TextDelta delta) -> Just (DeltaText, delta)
+    UiLoop (ReasoningDelta delta) -> Just (DeltaReasoning, delta)
+    _ -> Nothing
+
+appendBufferedDelta
+    :: DeltaKind
+    -> Text
+    -> Seq BufferedDelta
+    -> Seq BufferedDelta
+appendBufferedDelta kind delta pending =
+    case Seq.viewr pending of
+        rest Seq.:> buffered
+            | buffered.bufferedKind == kind ->
+                rest Seq.|> buffered
+                    { bufferedChunks =
+                        buffered.bufferedChunks Seq.|> delta
+                    }
+        _ ->
+            pending Seq.|> BufferedDelta
+                { bufferedKind = kind
+                , bufferedChunks = Seq.singleton delta
+                }
+
+flushPendingUiEvents :: FullscreenRuntime -> IO ()
+flushPendingUiEvents runtime =
+    withMVar runtime.runtimeEventLock \_ ->
+        flushPendingDeltasUnlocked runtime
+
+flushPendingDeltasUnlocked :: FullscreenRuntime -> IO ()
+flushPendingDeltasUnlocked runtime = do
+    pending <- atomicModifyIORef' runtime.runtimePendingDeltas \buffered ->
+        (Seq.empty, buffered)
+    mapM_ emitBuffered pending
+  where
+    emitBuffered buffered =
+        writeBChan runtime.runtimeEvents $
+            AppUi $
+                UiLoop $
+                    case buffered.bufferedKind of
+                        DeltaText -> TextDelta body
+                        DeltaReasoning -> ReasoningDelta body
+      where
+        body = Text.concat (toList buffered.bufferedChunks)
+
+updateRuntimeRunning :: FullscreenRuntime -> UiEvent -> IO ()
+updateRuntimeRunning runtime = \case
+    UiLoop TurnStarted -> writeIORef runtime.runtimeRunning True
+    UiLoop TurnFinished{} -> writeIORef runtime.runtimeRunning False
+    UiTurnEnded _ -> writeIORef runtime.runtimeRunning False
+    UiSetAwaitingInput True -> writeIORef runtime.runtimeRunning False
+    _ -> pure ()
 
 setFullscreenWindowTitle :: FullscreenRuntime -> Text -> IO ()
 setFullscreenWindowTitle runtime =
@@ -368,39 +473,57 @@ runFullscreen runtime workerAction = do
             , appWorkerStopped = False
             }
     withAsync workerAction \worker ->
-        withAsync ticker \_ticker ->
-            withAsync
-                (void (waitCatch worker)
-                    >> writeBChan runtime.runtimeEvents AppStop)
-                \_notifier -> do
-                    finalState <-
-                        customMain
-                            initialVty
-                            buildVty
-                            (Just runtime.runtimeEvents)
-                            fullscreenApp
-                            initialState
-                        `finally` runtime.runtimeNativeProgress False
-                    when (not finalState.appWorkerStopped) $
-                        atomically $
-                            appendFullscreenInput runtime.runtimeInput FullscreenInput
-                                { fullscreenInputLine = ReplEof
-                                , fullscreenInputQueued = False
-                                , fullscreenInputDisplay = Nothing
-                                }
-                    wait worker
+        withAsync uiTicker \_uiTicker ->
+            withAsync (agentTicker (initialAgent, initialAgents)) \_agentTicker ->
+                withAsync
+                    (void (waitCatch worker)
+                        >> flushPendingUiEvents runtime
+                        >> writeBChan runtime.runtimeEvents AppStop)
+                    \_notifier -> do
+                        finalState <-
+                            customMain
+                                initialVty
+                                buildVty
+                                (Just runtime.runtimeEvents)
+                                fullscreenApp
+                                initialState
+                            `finally` runtime.runtimeNativeProgress False
+                        when (not finalState.appWorkerStopped) $
+                            atomically $
+                                appendFullscreenInput runtime.runtimeInput FullscreenInput
+                                    { fullscreenInputLine = ReplEof
+                                    , fullscreenInputQueued = False
+                                    , fullscreenInputDisplay = Nothing
+                                    }
+                        wait worker
   where
-    ticker = loop (0 :: Int)
-    loop tick = do
-        threadDelay 100000
-        writeBChan runtime.runtimeEvents (AppUi UiTick)
-        when (tick `mod` 5 == 0) do
-            tryAny runtime.runtimeAgentSnapshot >>= \case
-                Left _ -> pure ()
-                Right (selected, entries) ->
-                    writeBChan runtime.runtimeEvents
-                        (AppAgentSnapshot selected entries)
-        loop ((tick + 1) `mod` 10)
+    uiTicker = loop (0 :: Int)
+      where
+        loop tick = do
+            threadDelay 50000
+            flushPendingUiEvents runtime
+            running <- readIORef runtime.runtimeRunning
+            when (running && tick `mod` 2 == 0) $
+                void $
+                    writeBChanNonBlocking
+                        runtime.runtimeEvents
+                        (AppUi UiTick)
+            loop ((tick + 1) `mod` 20)
+
+    agentTicker previous = do
+        threadDelay 500000
+        next <- tryAny runtime.runtimeAgentSnapshot
+        previous' <- case next of
+            Left _ -> pure previous
+            Right snapshot
+                | snapshot == previous -> pure previous
+                | otherwise -> do
+                    written <-
+                        writeBChanNonBlocking
+                            runtime.runtimeEvents
+                            (uncurry AppAgentSnapshot snapshot)
+                    pure (if written then snapshot else previous)
+        agentTicker previous'
 
 handleChoiceKey :: V.Event -> EventM Name AppState ()
 handleChoiceKey = \case
@@ -707,7 +830,7 @@ drawAgentPane selected entries =
             borderWithLabel (txt " Agents ") $
                 padAll 1 $
                     vBox
-                        [ vBox (map drawEntry (zip [0 ..] ordered))
+                        [ vBox agentRows
                         , padTop (Pad 1) $
                             withAttr Theme.footerAttr $
                                 txtWrap
@@ -723,8 +846,19 @@ drawAgentPane selected entries =
     ordered = sortOn (.agentPath) entries
     selectedEntry =
         find ((== selected) . (.agentTarget)) ordered
-    drawEntry (index, entry) =
+    shownEntries = agentEntryWindow 12 selected ordered
+    hiddenCount = max 0 (length ordered - length shownEntries)
+    agentRows =
+        map drawEntry shownEntries
+            <> [ withAttr Theme.mutedAttr $
+                    txt ("  … " <> Text.pack (show hiddenCount) <> " more")
+               | hiddenCount > 0
+               ]
+    drawEntry entry =
         let
+            index =
+                maybe 0 id $
+                    findIndex ((== entry.agentTarget) . (.agentTarget)) ordered
             marker =
                 if entry.agentTarget == selected then "› " else "  "
             row =
@@ -745,6 +879,20 @@ drawAgentPane selected entries =
             in if null rows
                 then ["(no transcript)"]
                 else drop (max 0 (length rows - 12)) rows
+
+agentEntryWindow :: Int -> AgentTarget -> [AgentEntry] -> [AgentEntry]
+agentEntryWindow count selected entries
+    | count <= 0 = []
+    | length entries <= count = entries
+    | otherwise =
+        take count (drop start entries)
+  where
+    selectedIndex =
+        maybe 0 id $
+            findIndex ((== selected) . (.agentTarget)) entries
+    start =
+        max 0 $
+            min selectedIndex (length entries - count)
 
 drawHeader :: UiState -> Widget Name
 drawHeader state =
@@ -789,6 +937,7 @@ drawTranscript state
 drawBlock :: UiState -> UiBlock -> Widget Name
 drawBlock state block =
     let selected = state.uiSelectedBlock == Just block.blockId
+        highlighted = selected && state.uiFocus == FocusScrollback
         content = case block.blockKind of
             BlockUser ->
                 withAttr Theme.userAttr $
@@ -818,11 +967,25 @@ drawBlock state block =
             BlockError ->
                 withAttr Theme.errorAttr (txtWrap block.blockBody)
         framed =
-            if selected && state.uiFocus == FocusScrollback
+            if highlighted
                 then withAttr Theme.selectedAttr content
                 else content
-    in clickable (ConversationBlock block.blockId) $
-        padBottom (Pad 1) framed
+        rendered =
+            clickable (ConversationBlock block.blockId) $
+                padBottom (Pad 1) framed
+    in if cacheableBlock block
+        then cached
+            (ConversationBlockCache
+                block.blockId
+                highlighted
+                block.blockExpanded)
+            rendered
+        else rendered
+
+cacheableBlock :: UiBlock -> Bool
+cacheableBlock block =
+    block.blockState
+        `notElem` [BlockStreaming, BlockRunning]
 
 accentBlock :: AttrName -> Text -> Text -> Widget Name
 accentBlock accent title body =
@@ -1194,23 +1357,37 @@ handleEvent event = case event of
     AppEvent AppStop -> do
         modify' \state -> state { appWorkerStopped = True }
         halt
-    AppEvent (AppSetSkillCommands skills) ->
-        modify' \state -> state
-            { appSkillCommands = skills
-            , appSlashIndex = 0
-            , appSlashDismissed = False
-            }
-    AppEvent (AppAgentSnapshot selected entries) ->
-        modify' \state ->
-            state
-                { appAgentSelected =
-                    Bridge.normalizeAgentSelection selected entries
-                , appAgentEntries = entries
+    AppEvent (AppSetSkillCommands skills) -> do
+        state <- get
+        if state.appSkillCommands == skills
+            then continueWithoutRedraw
+            else modify' \current -> current
+                { appSkillCommands = skills
+                , appSlashIndex = 0
+                , appSlashDismissed = False
                 }
     AppEvent (AppSetWindowTitle title) -> do
         state <- get
         liftIO (state.appRuntime.runtimeSetWindowTitle title)
+    AppEvent (AppAgentSnapshot selected entries) -> do
+        state <- get
+        let normalized =
+                Bridge.normalizeAgentSelection selected entries
+        if state.appAgentSelected == normalized
+            && state.appAgentEntries == entries
+            then continueWithoutRedraw
+            else do
+                modify' \current ->
+                    current
+                        { appAgentSelected = normalized
+                        , appAgentEntries = entries
+                        }
+                when
+                    ((length state.appAgentEntries > 1)
+                        /= (length entries > 1))
+                    invalidateCache
     AppEvent (AppUi uiEvent) -> do
+        previous <- get
         modify' \state -> state
             { appUi = reduceUi uiEvent state.appUi
             , appSlashDismissed = case uiEvent of
@@ -1231,8 +1408,13 @@ handleEvent event = case event of
             Nothing -> pure ()
             Just active ->
                 liftIO (state.appRuntime.runtimeNativeProgress active)
+        case uiEvent of
+            UiConversationCleared -> invalidateCache
+            _ -> pure ()
         when (Bridge.eventFollows uiEvent && state.appUi.uiFollow) $
             vScrollToEnd (viewportScroll ConversationViewport)
+        when (uiEvent == UiTick && state.appUi == previous.appUi) $
+            continueWithoutRedraw
     AppEvent (AppAskPermission summary reply) ->
         modify' \state ->
             state
@@ -1346,6 +1528,8 @@ handleEvent event = case event of
                 { appHoveredControl = Nothing
                 , appPressedControl = Nothing
                 }
+    VtyEvent V.EvResize{} ->
+        invalidateCache
     VtyEvent vtyEvent -> do
         state <- get
         case (state.appTextPrompt, state.appChoice, state.appUi.uiPermission) of

--- a/packages/agent-cli/src/Agent/CLI/TUI/Markdown.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Markdown.hs
@@ -7,15 +7,17 @@ module Agent.CLI.TUI.Markdown
     , parseInline
     ) where
 
-import Agent.CLI.Input (terminalTextWidth)
+import Agent.CLI.Input (terminalCharWidth)
 import qualified Agent.CLI.TUI.Theme as Theme
 import Brick
 import qualified Brick.Types as B
 import Data.Char (isDigit, isSpace)
 import Data.List (transpose)
+import qualified Data.List as List
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Lazy as LazyText
+import qualified Data.Text.Lazy.Builder as Builder
 import qualified Graphics.Vty as V
 
 data InlineStyle
@@ -194,33 +196,47 @@ asumPrefix prefixes text = case prefixes of
         Nothing -> asumPrefix rest text
 
 parseInline :: Text -> [InlineSpan]
-parseInline = mergePlain . go Nothing
+parseInline = go Nothing []
   where
-    go _ text | Text.null text = []
-    go previous text
+    go _ plain text
+        | Text.null text = flushPlain plain []
+    go previous plain text
         | Just (body, rest) <- delimited "**" text =
-            InlineSpan InlineStrong body : go (lastChar body) rest
+            flushPlain plain $
+                InlineSpan InlineStrong body
+                    : go (lastChar body) [] rest
         | Just (body, rest) <- delimited "__" text =
-            InlineSpan InlineStrong body : go (lastChar body) rest
+            flushPlain plain $
+                InlineSpan InlineStrong body
+                    : go (lastChar body) [] rest
         | Just (body, rest) <- codeSpan text =
-            InlineSpan InlineCode body : go (lastChar body) rest
+            flushPlain plain $
+                InlineSpan InlineCode body
+                    : go (lastChar body) [] rest
         | Just (label, url, rest) <- linkSpan text =
-            InlineSpan InlineLink
-                (label
-                    <> if Text.null url || label == url
-                        then ""
-                        else " (" <> url <> ")")
-                : go (lastChar label) rest
+            flushPlain plain $
+                InlineSpan InlineLink
+                    (label
+                        <> if Text.null url || label == url
+                            then ""
+                            else " (" <> url <> ")")
+                    : go (lastChar label) [] rest
         | Just (body, rest) <- emphasis previous '*' text =
-            InlineSpan InlineEmphasis body : go (lastChar body) rest
+            flushPlain plain $
+                InlineSpan InlineEmphasis body
+                    : go (lastChar body) [] rest
         | Just (body, rest) <- emphasis previous '_' text =
-            InlineSpan InlineEmphasis body : go (lastChar body) rest
+            flushPlain plain $
+                InlineSpan InlineEmphasis body
+                    : go (lastChar body) [] rest
         | otherwise =
             case Text.uncons text of
-                Nothing -> []
+                Nothing -> flushPlain plain []
                 Just (character, rest) ->
-                    InlineSpan InlinePlain (Text.singleton character)
-                        : go (Just character) rest
+                    let (ordinary, remaining) =
+                            Text.span (not . inlineMarker) rest
+                        chunk = Text.cons character ordinary
+                    in go (lastChar chunk) (chunk : plain) remaining
 
     delimited marker text = do
         after <- Text.stripPrefix marker text
@@ -275,15 +291,13 @@ parseInline = mergePlain . go Nothing
     lastChar value =
         snd <$> Text.unsnoc value
 
-mergePlain :: [InlineSpan] -> [InlineSpan]
-mergePlain = foldr merge []
-  where
-    merge span_ (next : rest)
-        | span_.inlineStyle == next.inlineStyle =
-            InlineSpan span_.inlineStyle
-                (span_.inlineText <> next.inlineText)
-                : rest
-    merge span_ rest = span_ : rest
+    inlineMarker character =
+        character `elem` ("*_`[" :: String)
+
+    flushPlain [] rest = rest
+    flushPlain chunks rest =
+        InlineSpan InlinePlain (Text.concat (reverse chunks))
+            : rest
 
 inlinePlainText :: [InlineSpan] -> Text
 inlinePlainText = Text.concat . map (.inlineText)
@@ -320,32 +334,42 @@ styleAttr = \case
 wrapStyled :: Int -> [(V.Attr, Text)] -> [[(V.Attr, Text)]]
 wrapStyled width spans =
     finalize $
-        foldl addCell ([[]], 0) cells
+        List.foldl' addCell ([[]], 0) cells
   where
     cells =
-        [ (attr, Text.singleton character)
+        [ (attr, character)
         | (attr, text) <- spans
         , character <- Text.unpack text
         ]
     addCell (rows, used) (attr, cell)
-        | cell == "\n" = ([] : rows, 0)
+        | cell == '\n' = ([] : rows, 0)
         | used > 0
         , used + cellWidth > width =
-            ([(attr, cell)] : rows, cellWidth)
+            ([(attr, Builder.singleton cell)] : rows, cellWidth)
         | otherwise =
             case rows of
-                [] -> ([[(attr, cell)]], cellWidth)
+                [] ->
+                    ([[(attr, Builder.singleton cell)]], cellWidth)
                 row : rest ->
                     (appendCell attr cell row : rest, used + cellWidth)
       where
-        cellWidth = terminalTextWidth cell
+        cellWidth = terminalCharWidth cell
     appendCell attr cell row =
-        case reverse row of
+        case row of
             (previousAttr, previousText) : prior
                 | previousAttr == attr ->
-                    reverse
-                        ((previousAttr, previousText <> cell) : prior)
-            _ -> row <> [(attr, cell)]
+                    ( previousAttr
+                    , previousText <> Builder.singleton cell
+                    ) : prior
+            _ -> (attr, Builder.singleton cell) : row
     finalize (rows, _) =
-        let ordered = reverse rows
+        let ordered =
+                map
+                    (map
+                        (\(attr, text) ->
+                            ( attr
+                            , LazyText.toStrict (Builder.toLazyText text)
+                            ))
+                        . reverse)
+                    (reverse rows)
         in if null ordered then [[]] else ordered

--- a/packages/agent-cli/src/Agent/CLI/UI/Model.hs
+++ b/packages/agent-cli/src/Agent/CLI/UI/Model.hs
@@ -288,14 +288,13 @@ reduceUi event state = case event of
             }
     UiTurnEnded terminalState ->
         finalizeTurn terminalState state
-    UiTick ->
-        state
-            { uiFrame = (state.uiFrame + 1) `mod` 10
-            , uiElapsedTenths =
-                if state.uiRunning
-                    then state.uiElapsedTenths + 1
-                    else state.uiElapsedTenths
-            }
+    UiTick
+        | not state.uiRunning -> state
+        | otherwise ->
+            state
+                { uiFrame = (state.uiFrame + 1) `mod` 10
+                , uiElapsedTenths = state.uiElapsedTenths + 1
+                }
 
 reduceLoop :: LoopEvent -> UiState -> UiState
 reduceLoop event state = case event of

--- a/packages/agent-cli/test/Agent/CLI/AgentViewportSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/AgentViewportSpec.hs
@@ -2,7 +2,9 @@ module Agent.CLI.AgentViewportSpec (spec) where
 
 import Agent.CLI.AgentViewport
 import Agent.CLI.Picker (PickerKey(..))
+import Agent.Responses.Types
 import Agent.Subagents (SubagentId(..), SubagentStatus(..))
+import qualified Data.Aeson.KeyMap as KeyMap
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Test.Hspec
@@ -93,6 +95,26 @@ spec = do
                 ]
                 `shouldBe` ["pending", "running", "done", "error", "interrupted"]
 
+    describe "responseItemPreviewLines" do
+        it "keeps the first line and only the requested transcript tail" do
+            let items =
+                    [ messageItem RoleUser "request"
+                    , messageItem RoleAssistant "one\ntwo\nthree\nfour"
+                    ]
+            responseItemPreviewLines 2 items
+                `shouldBe`
+                    [ "user: request"
+                    , "           three"
+                    , "           four"
+                    ]
+
+        it "uses only the first line when no transcript tail is requested" do
+            responseItemPreviewLines 0
+                [ messageItem RoleUser "request"
+                , messageItem RoleAssistant "answer"
+                ]
+                `shouldBe` ["user: request"]
+
 rootEntry :: AgentEntry
 rootEntry =
     AgentEntry
@@ -110,6 +132,16 @@ child agentId path status =
         , agentStatus = status
         , agentTranscript = ["assistant: working"]
         }
+
+messageItem :: ResponseRole -> Text -> ResponseItem
+messageItem role text = MessageItem ResponseMessage
+    { messageId = Nothing
+    , content = MessageContentText text
+    , role
+    , status = Nothing
+    , phase = Nothing
+    , extraFields = KeyMap.empty
+    }
 
 rightState :: Either (Maybe AgentTarget) AgentViewportState -> IO AgentViewportState
 rightState result = case result of

--- a/packages/agent-cli/test/Agent/CLI/TUIMarkdownSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIMarkdownSpec.hs
@@ -1,6 +1,7 @@
 module Agent.CLI.TUIMarkdownSpec (spec) where
 
 import Agent.CLI.TUI.Markdown
+import qualified Data.Text as Text
 import Test.Hspec
 
 spec :: Spec
@@ -28,3 +29,8 @@ spec = describe "fullscreen Markdown inline parsing" do
     it "leaves unmatched delimiters visible" do
         inlinePlainText (parseInline "unfinished **bold")
             `shouldBe` "unfinished **bold"
+
+    it "keeps long unstyled input in one plain span" do
+        let input = Text.replicate 10000 "a"
+        parseInline input
+            `shouldBe` [InlineSpan InlinePlain input]

--- a/packages/agent-cli/test/Agent/CLI/UIModelSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/UIModelSpec.hs
@@ -81,6 +81,7 @@ spec = describe "fullscreen UI reducer" do
                     running
             after = reduceUi UiTick finished
         idle.uiElapsedTenths `shouldBe` 0
+        idle.uiFrame `shouldBe` 0
         running.uiElapsedTenths `shouldBe` 3
         after.uiElapsedTenths `shouldBe` 3
 


### PR DESCRIPTION
## Summary
- coalesce streaming text and reasoning deltas into 50 ms UI updates so model output cannot flood the bounded Brick event queue
- skip idle/no-op redraws and cache completed conversation blocks while preserving resize, selection, folding, and clear invalidation
- reduce live agent snapshots to metadata plus the selected transcript tail, avoid unchanged snapshots, and window large agent lists
- optimize fullscreen Markdown parsing and wrapping to avoid character-sized `Text` allocation and repeated strict-text concatenation
- avoid updating elapsed/spinner state while idle

## Validation
- `nix develop -c env GHCRTS= cabal test agent-cli-test --test-show-details=direct` (**438 examples, 0 failures**)
- `nix develop -c env GHCRTS='-M4G -A32m' cabal repl agent-cli:lib:agent-cli --repl-options='-e :quit'`
- tmux live TTY smoke test via `nix develop -c repl`: fullscreen startup rendered correctly, a model response streamed and completed, and the composer returned ready for input
- `git diff --check origin/master...HEAD`

## Context
This completes the work recovered from failed session `2026-08-21-b070ce19` / worktree `2026-08-21-af7e9c27`. The original implementation commit crashed while rebasing; its conflicts with the newer fast-first-frame and interactive agent-pane changes were resolved here.
