### PR TITLE
feat(cli): persist and surface fullscreen prompt queue

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -190,21 +190,26 @@ import Agent.CLI.Terminal
     )
 import Agent.CLI.Tools (requireToolRegistry, schemasFromAppTools)
 import Agent.CLI.TUI.App
-    ( FullscreenRuntime
+    ( FullscreenInputBuffer
+    , FullscreenRuntime
     , emitUiEvent
+    , hasQueuedFullscreenInput
+    , newFullscreenInputBuffer
     , newFullscreenRuntime
+    , queuedFullscreenInputDisplays
     , readFullscreenLine
     , requestFullscreenPermission
     , requestFullscreenChoice
     , requestFullscreenChoiceWithBody
     , requestFullscreenText
     , runFullscreen
+    , setFullscreenWindowTitle
     , withFullscreenSuspended
     )
 import Agent.CLI.UI.Model
     ( PromptState(..)
     , UiEvent(..)
-    , UiState
+    , UiState(..)
     , initialUiState
     , reduceUi
     )
@@ -476,13 +481,14 @@ run = do
 -- Automatic transitions carry the exact failed turn in memory and commit
 -- persisted provider metadata only after the replacement backend succeeds.
 runAgentWithRestarts :: CliOptions -> IO DevResult
-runAgentWithRestarts options =
-    withRestoredCurrentDirectory (go options Nothing)
+runAgentWithRestarts options = do
+    fullscreenInputs <- newFullscreenInputBuffer
+    withRestoredCurrentDirectory (go fullscreenInputs options Nothing)
   where
-    go current transition =
-        runAgent current transition >>= \case
+    go fullscreenInputs current transition =
+        runAgent fullscreenInputs current transition >>= \case
             RunResumeSession sessionId ->
-                go
+                go fullscreenInputs
                     current
                         { optProvider = Nothing
                         , optModel = Nothing
@@ -495,14 +501,18 @@ runAgentWithRestarts options =
                         }
                     Nothing
             RunSwitchProvider next ->
-                go (applyProviderTransition current next) (Just next)
+                go fullscreenInputs
+                    (applyProviderTransition current next)
+                    (Just next)
             RunProviderStartFailed apiError ->
                 case transition of
                     Just failed
                         | failed.transitionCause == AutomaticFallback ->
                             continueAutomaticFallback failed apiError >>= \case
                                 Just next ->
-                                    go (applyProviderTransition current next) (Just next)
+                                    go fullscreenInputs
+                                        (applyProviderTransition current next)
+                                        (Just next)
                                 Nothing -> do
                                     reportProviderUnavailable apiError
                                     pure DevQuit
@@ -631,8 +641,12 @@ setStartupRepository fullscreen branch cwd =
                         <> "/"
                         <> toText (takeFileName cwd))
 
-runAgent :: CliOptions -> Maybe ProviderTransition -> IO RunResult
-runAgent options transition = do
+runAgent
+    :: FullscreenInputBuffer
+    -> CliOptions
+    -> Maybe ProviderTransition
+    -> IO RunResult
+runAgent fullscreenInputs options transition = do
     startedAt <- getCurrentTime
     startupTimingsRef <- newIORef []
     home <- getHomeDirectory
@@ -676,6 +690,7 @@ runAgent options transition = do
     useColor <- resolveColor stdout
     agentSnapshotRef <- newIORef (pure (AgentRoot, []))
     agentSelectRef <- newIORef (\_ -> pure ())
+    queuedInputDisplays <- queuedFullscreenInputDisplays fullscreenInputs
     let initialTurns = maybe [] snd resumed
         fullscreenEnabled =
             stdinTty
@@ -683,7 +698,7 @@ runAgent options transition = do
                 && not (isOneShot options)
                 && options.optScreenMode /= ScreenMinimal
         initialFullscreenState =
-            reduceUi
+            (reduceUi
                 (UiSetNotice (Just "Loading project…"))
                 (reduceUi
                     (UiSetRepository
@@ -691,12 +706,15 @@ runAgent options transition = do
                         (toText (takeFileName (takeDirectory cwd))
                             <> "/"
                             <> toText (takeFileName cwd)))
-                    (hydrateUiHistory initialTurns))
+                    (hydrateUiHistory initialTurns)))
+                        { uiQueuedInputs = queuedInputDisplays }
     fullscreen <- if fullscreenEnabled
         then Just <$> newFullscreenRuntime
+            fullscreenInputs
             (requestCancel toolEnv.toolCancel)
             (noteFullscreenCtrlC interrupt)
             (copyTerminalClipboard terminal stdout)
+            (setCliWindowTitle stdoutTty stdout)
             (\active ->
                 when terminal.terminalNativeProgress $
                     setNativeProgress stderr active)
@@ -751,6 +769,10 @@ runAgentInitialized options transition home root resumed cwd startup = do
         fullscreen = startup.startupFullscreen
         isTty = startup.startupStdinTty
         stdoutTty = startup.startupStdoutTty
+        setWindowTitle title =
+            case fullscreen of
+                Just runtime -> setFullscreenWindowTitle runtime title
+                Nothing -> setCliWindowTitle stdoutTty stdout title
     projectRoot <- resolveProjectRoot cwd
     projectSettings <- loadProjectSettings projectRoot
     branch <- detectGitBranch cwd
@@ -928,7 +950,7 @@ runAgentInitialized options transition home root resumed cwd startup = do
         let titleHint = case resumed of
                 Just (meta, _) -> Just meta.metaTitle
                 Nothing -> sessionTitleFromPrompt <$> prompt
-        setCliWindowTitle stdoutTty stdout (cliWindowTitle cwd titleHint)
+        setWindowTitle (cliWindowTitle cwd titleHint)
         markStartupStage startup "Loading instructions…"
         startupContext <-
             loadAgentsContext
@@ -1197,6 +1219,11 @@ runSession options provider policy tools toolEnv planMode startup prompt pending
         terminal = startup.startupTerminal
         useColor = startup.startupUseColor
         stderrTty = startup.startupStderrTty
+        stdoutTty = startup.startupStdoutTty
+        setWindowTitle title =
+            case fullscreen of
+                Just runtime -> setFullscreenWindowTitle runtime title
+                Nothing -> setCliWindowTitle stdoutTty stdout title
     toolRegistry <- requireToolRegistry tools
     printed <- newIORef False
     attachmentsRef <- newIORef []
@@ -1399,6 +1426,7 @@ runSession options provider policy tools toolEnv planMode startup prompt pending
             , sessionLastAssistant = lastAssistantRef
             , sessionTerminal = terminal
             , sessionFullscreen = fullscreen
+            , sessionSetWindowTitle = setWindowTitle
             , sessionAgentViewport = Just agentViewport
             , sessionBeginSubagentTurn = beginSubagentTurn
             , sessionFinishSubagentTurn = finishSubagentTurn
@@ -1483,9 +1511,7 @@ finishTurnWithCooldownRetry allowCooldownRetry env exitAfter = \case
             Just _ -> pure ()
         if exitAfter
             then pure RunQuit
-            else do
-                notifyAttention stderr InputRequested
-                repl env
+            else continueAfterTurn env
     TurnFailed ->
         if exitAfter
             then exitFailure
@@ -1493,8 +1519,7 @@ finishTurnWithCooldownRetry allowCooldownRetry env exitAfter = \case
                 case env.sessionFullscreen of
                     Nothing -> putTrailingNewline env.sessionPrinted
                     Just _ -> pure ()
-                notifyAttention stderr InputRequested
-                repl env
+                continueAfterTurn env
     TurnProviderUnavailable apiError pending ->
         let pending' = setPendingExitAfter exitAfter pending
         in requestAutomaticProviderFallback env apiError pending' >>= \case
@@ -1512,6 +1537,15 @@ finishTurnWithCooldownRetry allowCooldownRetry env exitAfter = \case
                             else do
                                 notifyAttention stderr InputRequested
                                 replWithDraft env pending.pendingPromptText
+
+continueAfterTurn :: SessionEnv -> IO RunResult
+continueAfterTurn env = do
+    queued <- case env.sessionFullscreen of
+        Nothing -> pure False
+        Just runtime -> hasQueuedFullscreenInput runtime
+    when (not queued) $
+        notifyAttention stderr InputRequested
+    repl env
 
 waitAndRetryPendingTurn
     :: SessionEnv
@@ -1615,6 +1649,7 @@ replWithDraft env@SessionEnv
     , sessionLastAssistant = lastAssistantRef
     , sessionTerminal = terminal
     , sessionFullscreen = fullscreen
+    , sessionSetWindowTitle = setWindowTitle
     , sessionAgentViewport = agentViewport
     , sessionReset = sessionReset
     } draft = do
@@ -1803,6 +1838,7 @@ replWithDraft env@SessionEnv
                                                 (roleError color err)
                                         continue
                                     Right skillInputs -> do
+                                        fullscreenEvent (UiUserSubmitted text)
                                         result <- runOneTurn env text skillInputs
                                         finishTurn env False result
                     ReplInvokeSkill invocationName arguments ->
@@ -2244,8 +2280,7 @@ replWithDraft env@SessionEnv
                                 writeIORef planMode.planSessionDir
                                     (Just handle'.sessionDir)
                                 writeIORef storeRoot (Just handle'.sessionDir)
-                                tty <- hIsTerminalDevice stdout
-                                setCliWindowTitle tty stdout
+                                setWindowTitle
                                     (cliWindowTitle meta.metaCwd
                                         (Just meta.metaTitle))
                                 let message = "new session: " <> meta.metaId
@@ -2307,8 +2342,7 @@ replWithDraft env@SessionEnv
                                             handle.sessionMeta.metaId
                                         updated <- setManualSessionTitle title handle
                                         writeIORef slotRef (PersistenceActive updated)
-                                        tty <- hIsTerminalDevice stdout
-                                        setCliWindowTitle tty stdout
+                                        setWindowTitle
                                             (cliWindowTitle updated.sessionMeta.metaCwd
                                                 (Just updated.sessionMeta.metaTitle))
                                         let message =

--- a/packages/agent-cli/src/Agent/CLI/Options.hs
+++ b/packages/agent-cli/src/Agent/CLI/Options.hs
@@ -264,6 +264,8 @@ usage = unlines
     , "reasoning effort. /model (alias /m) opens the model picker; /model NAME"
     , "sets it. /help [NAME] lists slash commands. Tab completes / commands."
     , "Shift+Tab cycles idle mode: ask (normal) → plan → always-approve → ask."
+    , "In fullscreen mode the composer stays editable during a turn; Enter queues"
+    , "the draft as the next input, and queued inputs run in submission order."
     , "/compact [FOCUS] summarizes history (OpenAI remote compact;"
     , "xAI/OpenRouter local summary) to free context."
     , "/plan [description] enters plan mode (read-only except plan.md);"

--- a/packages/agent-cli/src/Agent/CLI/SessionEnv.hs
+++ b/packages/agent-cli/src/Agent/CLI/SessionEnv.hs
@@ -56,6 +56,7 @@ data SessionEnv = SessionEnv
     , sessionLastAssistant :: !(IORef (Maybe Text))
     , sessionTerminal :: !TerminalCapabilities
     , sessionFullscreen :: !(Maybe FullscreenRuntime)
+    , sessionSetWindowTitle :: !(Text -> IO ())
     , sessionAgentViewport :: !(Maybe AgentViewportEnv)
     , sessionBeginSubagentTurn :: !(IO (Maybe RootTurnId))
     , sessionFinishSubagentTurn :: !(Maybe RootTurnId -> IO ())

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -1,14 +1,19 @@
 -- | Retained fullscreen terminal application and its session bridge.
 module Agent.CLI.TUI.App
-    ( FullscreenRuntime
+    ( FullscreenInputBuffer
+    , FullscreenRuntime
     , emitUiEvent
+    , hasQueuedFullscreenInput
+    , newFullscreenInputBuffer
     , newFullscreenRuntime
+    , queuedFullscreenInputDisplays
     , readFullscreenLine
     , requestFullscreenPermission
     , requestFullscreenChoice
     , requestFullscreenChoiceWithBody
     , requestFullscreenText
     , runFullscreen
+    , setFullscreenWindowTitle
     , withFullscreenSuspended
     ) where
 
@@ -29,11 +34,9 @@ import Agent.CLI.AgentViewport
     )
 import Agent.CLI.Interrupt (CtrlCDecision(..))
 import Agent.CLI.Command
-    ( ReplAction(..)
-    , SkillCommand
+    ( SkillCommand
     , SlashMenu(..)
     , SlashSuggestion(..)
-    , parseReplLineWithSkills
     , slashMenuForWithSkills
     )
 import Agent.CLI.Permission (PermissionChoice(..))
@@ -53,15 +56,17 @@ import Brick.Widgets.Center (centerLayer)
 import Control.Concurrent.Async (wait, waitCatch, withAsync)
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.STM
-    ( TMVar
-    , TQueue
+    ( STM
+    , TMVar
+    , TVar
     , atomically
     , newEmptyTMVarIO
-    , newTQueueIO
+    , newTVarIO
     , putTMVar
+    , readTVar
     , readTMVar
-    , readTQueue
-    , writeTQueue
+    , retry
+    , writeTVar
     )
 import Control.Monad (void, when)
 import Control.Monad.IO.Class (liftIO)
@@ -72,6 +77,7 @@ import Data.ByteString (ByteString)
 import Data.Char (isControl)
 import Data.Foldable (toList)
 import Data.List (find, intersperse, sortOn)
+import qualified Data.Sequence as Seq
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
@@ -112,14 +118,25 @@ data AppEvent
     | forall a. AppSuspend !(IO a) !(TMVar (Either SomeException a))
     | AppSetSkillCommands ![SkillCommand]
     | AppAgentSnapshot !AgentTarget ![AgentEntry]
+    | AppSetWindowTitle !Text
     | AppStop
+
+data FullscreenInput = FullscreenInput
+    { fullscreenInputLine :: !ReplLine
+    , fullscreenInputQueued :: !Bool
+    , fullscreenInputDisplay :: !(Maybe Text)
+    }
+
+newtype FullscreenInputBuffer =
+    FullscreenInputBuffer (TVar (Seq.Seq FullscreenInput))
 
 data FullscreenRuntime = FullscreenRuntime
     { runtimeEvents :: !(BChan AppEvent)
-    , runtimeInput :: !(TQueue ReplLine)
+    , runtimeInput :: !FullscreenInputBuffer
     , runtimeCancel :: !(IO ())
     , runtimeCtrlC :: !(IO CtrlCDecision)
     , runtimeCopy :: !(Text -> IO Bool)
+    , runtimeSetWindowTitle :: !(Text -> IO ())
     , runtimeNativeProgress :: !(Bool -> IO ())
     , runtimeAgentSnapshot :: !(IO (AgentTarget, [AgentEntry]))
     , runtimeAgentSelect :: !(AgentTarget -> IO ())
@@ -148,6 +165,7 @@ data AppState = AppState
     , appAgentEntries :: ![AgentEntry]
     , appHoveredControl :: !(Maybe Name)
     , appPressedControl :: !(Maybe Name)
+    , appWorkerStopped :: !Bool
     }
 
 data ChoiceOverlay = ChoiceOverlay
@@ -164,10 +182,16 @@ data TextOverlay = TextOverlay
     , textCursor :: !Int
     }
 
+newFullscreenInputBuffer :: IO FullscreenInputBuffer
+newFullscreenInputBuffer =
+    FullscreenInputBuffer <$> newTVarIO Seq.empty
+
 newFullscreenRuntime
-    :: IO ()
+    :: FullscreenInputBuffer
+    -> IO ()
     -> IO CtrlCDecision
     -> (Text -> IO Bool)
+    -> (Text -> IO ())
     -> (Bool -> IO ())
     -> IO (AgentTarget, [AgentEntry])
     -> (AgentTarget -> IO ())
@@ -176,9 +200,11 @@ newFullscreenRuntime
     -> UiState
     -> IO FullscreenRuntime
 newFullscreenRuntime
+    inputBuffer
     cancelAction
     ctrlCAction
     copyAction
+    setWindowTitle
     nativeProgress
     agentSnapshot
     agentSelect
@@ -186,10 +212,11 @@ newFullscreenRuntime
     color
     initial = FullscreenRuntime
     <$> newBChan 512
-    <*> newTQueueIO
+    <*> pure inputBuffer
     <*> pure cancelAction
     <*> pure ctrlCAction
     <*> pure copyAction
+    <*> pure setWindowTitle
     <*> pure nativeProgress
     <*> pure agentSnapshot
     <*> pure agentSelect
@@ -199,6 +226,29 @@ newFullscreenRuntime
 
 emitUiEvent :: FullscreenRuntime -> UiEvent -> IO ()
 emitUiEvent runtime = writeBChan runtime.runtimeEvents . AppUi
+
+setFullscreenWindowTitle :: FullscreenRuntime -> Text -> IO ()
+setFullscreenWindowTitle runtime =
+    writeBChan runtime.runtimeEvents . AppSetWindowTitle
+
+hasQueuedFullscreenInput :: FullscreenRuntime -> IO Bool
+hasQueuedFullscreenInput runtime =
+    atomically do
+        queued <- readFullscreenInputs runtime.runtimeInput
+        pure (not (Seq.null queued))
+
+queuedFullscreenInputDisplays
+    :: FullscreenInputBuffer
+    -> IO (Seq.Seq Text)
+queuedFullscreenInputDisplays inputBuffer =
+    atomically do
+        queued <- readFullscreenInputs inputBuffer
+        pure $ foldMap
+            (\input ->
+                if input.fullscreenInputQueued
+                    then maybe Seq.empty Seq.singleton input.fullscreenInputDisplay
+                    else Seq.empty)
+            queued
 
 readFullscreenLine
     :: FullscreenRuntime
@@ -215,7 +265,13 @@ readFullscreenLine runtime skills prompt initial = do
     when (not (Text.null initial)) $
         emitUiEvent runtime (UiSetDraft initial (Text.length initial))
     emitUiEvent runtime (UiSetAwaitingInput True)
-    atomically (readTQueue runtime.runtimeInput)
+    input <- atomically (takeFullscreenInput runtime.runtimeInput)
+    when input.fullscreenInputQueued $
+        emitUiEvent runtime $
+            case input.fullscreenInputDisplay of
+                Just _ -> UiQueuedInputStarted
+                Nothing -> UiSetAwaitingInput False
+    pure input.fullscreenInputLine
 
 requestFullscreenPermission
     :: FullscreenRuntime
@@ -309,6 +365,7 @@ runFullscreen runtime workerAction = do
             , appAgentEntries = initialAgents
             , appHoveredControl = Nothing
             , appPressedControl = Nothing
+            , appWorkerStopped = False
             }
     withAsync workerAction \worker ->
         withAsync ticker \_ticker ->
@@ -316,16 +373,21 @@ runFullscreen runtime workerAction = do
                 (void (waitCatch worker)
                     >> writeBChan runtime.runtimeEvents AppStop)
                 \_notifier -> do
-                    void
-                        (customMain
+                    finalState <-
+                        customMain
                             initialVty
                             buildVty
                             (Just runtime.runtimeEvents)
                             fullscreenApp
-                            initialState)
+                            initialState
                         `finally` runtime.runtimeNativeProgress False
-                    atomically $
-                        writeTQueue runtime.runtimeInput ReplEof
+                    when (not finalState.appWorkerStopped) $
+                        atomically $
+                            appendFullscreenInput runtime.runtimeInput FullscreenInput
+                                { fullscreenInputLine = ReplEof
+                                , fullscreenInputQueued = False
+                                , fullscreenInputDisplay = Nothing
+                                }
                     wait worker
   where
     ticker = loop (0 :: Int)
@@ -387,8 +449,11 @@ handlePromptControlClick choice = do
     if ui.uiAwaitingInput && not overlayOpen
         then do
             liftIO $ atomically $
-                writeTQueue state.appRuntime.runtimeInput
-                    (choice ui.uiDraft)
+                appendFullscreenInput state.appRuntime.runtimeInput FullscreenInput
+                    { fullscreenInputLine = choice ui.uiDraft
+                    , fullscreenInputQueued = False
+                    , fullscreenInputDisplay = Nothing
+                    }
             modify' \current ->
                 current
                     { appUi =
@@ -611,6 +676,7 @@ drawMain state =
             [ drawHeader state.appUi
             , drawWorkspace state
             , drawNotice state.appUi
+            , drawQueuedInputs state.appUi
             , drawSlashMenu state
             , drawComposer state
             , drawFooter state
@@ -813,6 +879,31 @@ drawNotice state = case state.uiNotice of
         withAttr Theme.footerAttr $
             padLeftRight 2 (txtWrap notice)
 
+drawQueuedInputs :: UiState -> Widget Name
+drawQueuedInputs state =
+    case toList state.uiQueuedInputs of
+        [] -> emptyWidget
+        next : _ ->
+            padLeftRight 2 $
+                vLimit 1 $
+                    hBox
+                        [ withAttr Theme.toolAttr (txt "◇ ")
+                        , withAttr Theme.footerAttr
+                            (txt
+                                ("queued "
+                                    <> Text.pack
+                                        (show (Seq.length state.uiQueuedInputs))
+                                    <> " · "))
+                        , withAttr Theme.mutedAttr (txt (queuePreview next))
+                        ]
+
+queuePreview :: Text -> Text
+queuePreview text =
+    let oneLine = Text.unwords (Text.words text)
+    in if Text.length oneLine > 100
+        then Text.take 99 oneLine <> "…"
+        else oneLine
+
 drawSlashMenu :: AppState -> Widget Name
 drawSlashMenu state = case currentSlashMenu state of
     Nothing -> emptyWidget
@@ -864,6 +955,11 @@ drawComposer appState =
                             (show state.uiPrompt.promptAttachments)
                     else ""
                 , usage
+                , if Seq.null state.uiQueuedInputs
+                    then ""
+                    else "queued "
+                        <> Text.pack
+                            (show (Seq.length state.uiQueuedInputs))
                 ]
         modelControl
             | Text.null state.uiPrompt.promptModel = []
@@ -933,7 +1029,11 @@ renderDraft :: Bool -> UiState -> Widget Name
 renderDraft focused state =
     let content =
             if Text.null state.uiDraft
-                then withAttr Theme.mutedAttr (txt " ")
+                then withAttr Theme.mutedAttr $
+                    txt
+                        (if not state.uiAwaitingInput
+                            then "Type a follow-up…"
+                            else " ")
                 else txt state.uiDraft
         (row, column) = draftCursorLocation state.uiDraft state.uiCursor
     in if focused
@@ -1091,7 +1191,8 @@ choiceRow appState selected index (label, detail) =
 
 handleEvent :: BrickEvent Name AppEvent -> EventM Name AppState ()
 handleEvent event = case event of
-    AppEvent AppStop ->
+    AppEvent AppStop -> do
+        modify' \state -> state { appWorkerStopped = True }
         halt
     AppEvent (AppSetSkillCommands skills) ->
         modify' \state -> state
@@ -1106,6 +1207,9 @@ handleEvent event = case event of
                     Bridge.normalizeAgentSelection selected entries
                 , appAgentEntries = entries
                 }
+    AppEvent (AppSetWindowTitle title) -> do
+        state <- get
+        liftIO (state.appRuntime.runtimeSetWindowTitle title)
     AppEvent (AppUi uiEvent) -> do
         modify' \state -> state
             { appUi = reduceUi uiEvent state.appUi
@@ -1569,56 +1673,54 @@ handleComposerKey event = do
   where
     submitRaw replLine = do
         state <- get
-        liftIO $ atomically $
-            writeTQueue state.appRuntime.runtimeInput replLine
-        modify' \current ->
-            current
-                { appUi =
-                    reduceUi
-                        (UiSetAwaitingInput False)
-                        current.appUi
-                }
+        enqueueInput state replLine Nothing False
 
     submitDraft = do
         state <- get
         let draft = state.appUi.uiDraft
-            queued = not state.appUi.uiAwaitingInput
         if Text.null (Text.strip draft)
             then pure ()
-            else do
-                liftIO (appendReplHistory draft)
-                liftIO $ atomically $
-                    writeTQueue state.appRuntime.runtimeInput $
-                        if state.appPasted
-                            then ReplPasted draft
-                            else ReplText draft
-                modify' \current ->
-                    current
-                        { appUi =
-                            let submitted =
-                                    if isLocalCommand
-                                        state.appSkillCommands
-                                        draft
-                                        then reduceUi
-                                            (UiSetDraft "" 0)
-                                            (reduceUi
-                                                (UiSetAwaitingInput False)
-                                                current.appUi)
-                                        else reduceUi
-                                            (UiUserSubmitted draft)
-                                            current.appUi
-                            in if queued
-                                then reduceUi
-                                    (UiSetNotice
-                                        (Just "Queued for the next turn."))
-                                    submitted
-                                else submitted
-                        , appPasted = False
-                        , appHistory = draft : current.appHistory
-                        , appHistoryIndex = Nothing
-                        , appHistoryDraft = ""
-                        }
-                vScrollToEnd (viewportScroll ConversationViewport)
+            else submitText state draft state.appPasted
+
+    submitText state text pasted = do
+        liftIO (appendReplHistory text)
+        enqueueInput
+            state
+            (if pasted then ReplPasted text else ReplText text)
+            (Just text)
+            True
+        modify' \current ->
+            current
+                { appPasted = False
+                , appHistory = text : current.appHistory
+                , appHistoryIndex = Nothing
+                , appHistoryDraft = ""
+                }
+        vScrollToEnd (viewportScroll ConversationViewport)
+
+    enqueueInput state replLine display clearDraft = do
+        let queued = not state.appUi.uiAwaitingInput
+        modify' \current ->
+            current
+                { appUi =
+                    if queued
+                        then case display of
+                            Just text -> reduceUi (UiInputQueued text) current.appUi
+                            Nothing -> current.appUi
+                        else reduceUi
+                            (if clearDraft
+                                then UiDraftSubmitted
+                                else UiSetAwaitingInput False)
+                            current.appUi
+                , appSlashIndex = 0
+                , appSlashDismissed = False
+                }
+        liftIO $ atomically $
+            appendFullscreenInput state.appRuntime.runtimeInput FullscreenInput
+                { fullscreenInputLine = replLine
+                , fullscreenInputQueued = queued
+                , fullscreenInputDisplay = display
+                }
 
     cancelOrClear = do
         state <- get
@@ -1786,22 +1888,7 @@ handleComposerKey event = do
                             current.appUi.uiDraft
                             menu
                             suggestion
-                    liftIO $ atomically $
-                        writeTQueue
-                            current.appRuntime.runtimeInput
-                            (ReplText next)
-                    modify' \state ->
-                        state
-                            { appUi =
-                                reduceUi
-                                    (UiSetDraft "" 0)
-                                    (reduceUi
-                                        (UiSetAwaitingInput False)
-                                        state.appUi)
-                            , appSlashIndex = 0
-                            , appSlashDismissed = False
-                            , appPasted = False
-                            }
+                    submitText current next False
 
     acceptSlashSuggestion menu suggestion = do
         current <- get
@@ -1900,11 +1987,31 @@ slashReplacement draft menu suggestion =
         after = Text.drop menu.slashMenuReplaceEnd draft
     in before <> suggestion.slashSuggestionReplacement <> after
 
-isLocalCommand :: [SkillCommand] -> Text -> Bool
-isLocalCommand skills draft = case parseReplLineWithSkills skills draft of
-    ReplPrompt _ -> False
-    _ -> True
-
 selectedBlock :: UiState -> BlockId -> Maybe UiBlock
 selectedBlock state ident =
     find ((== ident) . (.blockId)) (toList state.uiBlocks)
+
+readFullscreenInputs
+    :: FullscreenInputBuffer
+    -> STM (Seq.Seq FullscreenInput)
+readFullscreenInputs (FullscreenInputBuffer inputs) =
+    readTVar inputs
+
+appendFullscreenInput
+    :: FullscreenInputBuffer
+    -> FullscreenInput
+    -> STM ()
+appendFullscreenInput (FullscreenInputBuffer inputs) input = do
+    queued <- readTVar inputs
+    writeTVar inputs (queued Seq.|> input)
+
+takeFullscreenInput
+    :: FullscreenInputBuffer
+    -> STM FullscreenInput
+takeFullscreenInput (FullscreenInputBuffer inputs) = do
+    queued <- readTVar inputs
+    case Seq.viewl queued of
+        Seq.EmptyL -> retry
+        input Seq.:< rest -> do
+            writeTVar inputs rest
+            pure input

--- a/packages/agent-cli/src/Agent/CLI/TUI/Bridge.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Bridge.hs
@@ -24,7 +24,7 @@ eventFollows = \case
 nativeProgressSignal :: UiEvent -> UiState -> Maybe Bool
 nativeProgressSignal event state = case event of
     UiLoop TurnStarted -> Just True
-    UiLoop (TurnFinished _) -> Just False
+    UiLoop (TurnFinished _) -> Just state.uiRunning
     UiTurnEnded _ -> Just False
     UiSetAwaitingInput True -> Just False
     UiTick

--- a/packages/agent-cli/src/Agent/CLI/Turn.hs
+++ b/packages/agent-cli/src/Agent/CLI/Turn.hs
@@ -51,7 +51,6 @@ import Agent.CLI.Style
     ( cliWindowTitle
     , glyphSession
     , roleMuted
-    , setCliWindowTitle
     )
 import Agent.CLI.Terminal
     ( TerminalCapabilities(..)
@@ -95,7 +94,7 @@ import Data.Maybe (isJust, isNothing)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Time.Clock (UTCTime, diffUTCTime, getCurrentTime)
-import System.IO (hIsTerminalDevice, stderr, stdout)
+import System.IO (stderr, stdout)
 import qualified System.OsPath
 
 runOneTurn :: SessionEnv -> Text -> [TurnInput] -> IO TurnResult
@@ -115,6 +114,7 @@ runOneTurn env@SessionEnv
     , sessionLastAssistant = lastAssistantRef
     , sessionTerminal = terminal
     , sessionFullscreen = fullscreen
+    , sessionSetWindowTitle = setWindowTitle
     , sessionBeginSubagentTurn = beginSubagentTurn
     , sessionFinishSubagentTurn = finishSubagentTurn
     , sessionAbortSubagentTurn = abortSubagentTurn
@@ -352,8 +352,7 @@ runOneTurn env@SessionEnv
                         )
                         (requestConversationTitle env countedHandle titleTurns)
                     when (countedMeta.metaTitle /= handle.sessionMeta.metaTitle) do
-                        tty <- hIsTerminalDevice stdout
-                        setCliWindowTitle tty stdout
+                        setWindowTitle
                             (cliWindowTitle countedMeta.metaCwd
                                 (Just countedMeta.metaTitle))
                     applyPendingSessionTitles env
@@ -400,8 +399,7 @@ applyPendingSessionTitles env =
                                 resultTitle
                                 handle
                             writeIORef slotRef (PersistenceActive updated)
-                            tty <- hIsTerminalDevice stdout
-                            setCliWindowTitle tty stdout
+                            env.sessionSetWindowTitle
                                 (cliWindowTitle updated.sessionMeta.metaCwd
                                     (Just updated.sessionMeta.metaTitle))
 

--- a/packages/agent-cli/src/Agent/CLI/UI/Model.hs
+++ b/packages/agent-cli/src/Agent/CLI/UI/Model.hs
@@ -103,6 +103,7 @@ data UiState = UiState
     , uiNextBlockId :: !Int
     , uiDraft :: !Text
     , uiCursor :: !Int
+    , uiQueuedInputs :: !(Seq Text)
     , uiFocus :: !Focus
     , uiSelectedBlock :: !(Maybe BlockId)
     , uiFollow :: !Bool
@@ -124,6 +125,9 @@ data UiState = UiState
 data UiEvent
     = UiLoop !LoopEvent
     | UiUserSubmitted !Text
+    | UiDraftSubmitted
+    | UiInputQueued !Text
+    | UiQueuedInputStarted
     | UiSetDraft !Text !Int
     | UiSetPrompt !PromptState
     | UiSetAwaitingInput !Bool
@@ -152,6 +156,7 @@ initialUiState = UiState
     , uiNextBlockId = 1
     , uiDraft = ""
     , uiCursor = 0
+    , uiQueuedInputs = Seq.empty
     , uiFocus = FocusComposer
     , uiSelectedBlock = Nothing
     , uiFollow = True
@@ -181,12 +186,30 @@ reduceUi event state = case event of
     UiUserSubmitted text ->
         appendBlock BlockUser "You" text "" BlockComplete Nothing
             state
-                { uiDraft = ""
-                , uiCursor = 0
-                , uiAwaitingInput = False
+                { uiAwaitingInput = False
                 , uiFollow = True
                 , uiNotice = Nothing
                 }
+    UiDraftSubmitted ->
+        state
+            { uiDraft = ""
+            , uiCursor = 0
+            , uiAwaitingInput = False
+            , uiNotice = Nothing
+            }
+    UiInputQueued text ->
+        state
+            { uiDraft = ""
+            , uiCursor = 0
+            , uiQueuedInputs = state.uiQueuedInputs Seq.|> text
+            , uiNotice = Nothing
+            }
+    UiQueuedInputStarted ->
+        state
+            { uiQueuedInputs = Seq.drop 1 state.uiQueuedInputs
+            , uiAwaitingInput = False
+            , uiNotice = Nothing
+            }
     UiSetDraft text cursor ->
         state
             { uiDraft = text
@@ -304,7 +327,9 @@ reduceLoop event state = case event of
         in appendBlock kind (summarizeToolCall call) body ""
             BlockRunning (Just call.callId)
             state
-                { uiActivity = summarizeToolCall call
+                { uiRunning = True
+                , uiAwaitingInput = False
+                , uiActivity = summarizeToolCall call
                 , uiToolCalls = Map.insert call.callId call state.uiToolCalls
                 }
     ToolFinished result ->
@@ -314,11 +339,14 @@ reduceLoop event state = case event of
                     result
                         { output = formatToolOutput call result.output }
         in completeTool displayed state
-            { uiActivity = "Thinking…"
+            { uiRunning = True
+            , uiAwaitingInput = False
+            , uiActivity = "Thinking…"
             , uiToolCalls = Map.delete result.callId state.uiToolCalls
             }
     TurnFinished output ->
         let finalized = finalizeStreams state
+            continuing = not (null output.toolCalls)
             withFallback = case output.assistantText of
                 Just text
                     | not (Text.null (Text.strip text))
@@ -330,8 +358,11 @@ reduceLoop event state = case event of
                             BlockComplete Nothing finalized
                 _ -> finalized
         in withFallback
-            { uiRunning = False
-            , uiActivity = "Ready"
+            { uiRunning = continuing
+            , uiActivity =
+                if continuing
+                    then "Running tools…"
+                    else "Ready"
             }
 
 appendOrExtend

--- a/packages/agent-cli/test/Agent/CLI/TUIBridgeSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIBridgeSpec.hs
@@ -5,6 +5,7 @@ import Agent.CLI.TUI.Bridge
 import Agent.CLI.UI.Model
 import Agent.Loop (LoopEvent(..), emptyTurnOutput)
 import Agent.Subagents (SubagentId(..))
+import Agent.ToolDispatch (functionToolCall)
 import Test.Hspec
 
 spec :: Spec
@@ -17,14 +18,35 @@ spec = describe "fullscreen TUI bridge" do
     it "starts, refreshes, and clears native terminal progress" do
         let running = reduceUi (UiLoop TurnStarted) initialUiState
             refresh = running { uiFrame = 0 }
+            toolCall =
+                functionToolCall
+                    "tool-1"
+                    "run_terminal_cmd"
+                    "{\"command\":\"sleep 1\"}"
+            continuing =
+                reduceUi
+                    (UiLoop
+                        (TurnFinished
+                            (emptyTurnOutput "r1" [toolCall] Nothing)))
+                    running
+            finished =
+                reduceUi
+                    (UiLoop
+                        (TurnFinished
+                            (emptyTurnOutput "r2" [] Nothing)))
+                    running
         nativeProgressSignal (UiLoop TurnStarted) running
             `shouldBe` Just True
         nativeProgressSignal UiTick refresh
             `shouldBe` Just True
         nativeProgressSignal
             (UiLoop (TurnFinished (emptyTurnOutput "r1" [] Nothing)))
-            running
+            finished
             `shouldBe` Just False
+        nativeProgressSignal
+            (UiLoop (TurnFinished (emptyTurnOutput "r1" [toolCall] Nothing)))
+            continuing
+            `shouldBe` Just True
         nativeProgressSignal (UiTurnEnded BlockCancelled) running
             `shouldBe` Just False
 

--- a/packages/agent-cli/test/Agent/CLI/UIModelSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/UIModelSpec.hs
@@ -176,6 +176,80 @@ spec = describe "fullscreen UI reducer" do
                 resumed.uiFollow `shouldBe` True
             _ -> expectationFailure "expected three blocks"
 
+    it "queues follow-ups in order and preserves the draft typed behind them" do
+        let afterFirstStarted =
+                apply
+                    [ UiLoop TurnStarted
+                    , UiSetDraft "first follow-up" 15
+                    , UiInputQueued "first follow-up"
+                    , UiSetDraft "second follow-up" 16
+                    , UiInputQueued "second follow-up"
+                    , UiSetDraft "draft for later" 15
+                    , UiQueuedInputStarted
+                    , UiUserSubmitted "first follow-up"
+                    ]
+            afterSecondStarted =
+                reduceUi
+                    (UiUserSubmitted "second follow-up")
+                    (reduceUi UiQueuedInputStarted afterFirstStarted)
+        Foldable.toList afterFirstStarted.uiQueuedInputs
+            `shouldBe` ["second follow-up"]
+        afterFirstStarted.uiDraft `shouldBe` "draft for later"
+        afterFirstStarted.uiCursor `shouldBe` 15
+        map (.blockBody) (Foldable.toList afterFirstStarted.uiBlocks)
+            `shouldBe` ["first follow-up"]
+        Foldable.toList afterSecondStarted.uiQueuedInputs `shouldBe` []
+        afterSecondStarted.uiDraft `shouldBe` "draft for later"
+        map (.blockBody) (Foldable.toList afterSecondStarted.uiBlocks)
+            `shouldBe` ["first follow-up", "second follow-up"]
+
+    it "clears only the draft that was submitted immediately" do
+        let state =
+                apply
+                    [ UiSetAwaitingInput True
+                    , UiSetDraft "send this" 9
+                    , UiDraftSubmitted
+                    , UiUserSubmitted "send this"
+                    ]
+        state.uiDraft `shouldBe` ""
+        state.uiCursor `shouldBe` 0
+        state.uiAwaitingInput `shouldBe` False
+
+    it "stays busy between a model tool request and the next model round" do
+        let call =
+                functionToolCall
+                    "busy-tool"
+                    "run_terminal_cmd"
+                    "{\"command\":\"sleep 1\"}"
+            requestingTool =
+                apply
+                    [ UiLoop TurnStarted
+                    , UiLoop
+                        (TurnFinished
+                            (emptyTurnOutput "r1" [call] Nothing))
+                    ]
+            afterTool =
+                reduceUi
+                    (UiLoop
+                        (ToolFinished
+                            (ToolCallResult
+                                { callId = "busy-tool"
+                                , output = "exit: 0"
+                                , callKind = FunctionCallKind
+                                })))
+                    (reduceUi (UiLoop (ToolStarted call)) requestingTool)
+            finished =
+                reduceUi
+                    (UiLoop
+                        (TurnFinished
+                            (emptyTurnOutput "r2" [] (Just "done"))))
+                    (reduceUi (UiLoop TurnStarted) afterTool)
+        requestingTool.uiRunning `shouldBe` True
+        requestingTool.uiActivity `shouldBe` "Running tools…"
+        afterTool.uiRunning `shouldBe` True
+        finished.uiRunning `shouldBe` False
+        finished.uiActivity `shouldBe` "Ready"
+
     it "deletes the previous word for command/option-backspace" do
         deleteWordBefore "hello brave world" 17
             `shouldBe` ("hello brave ", 12)


### PR DESCRIPTION
## Summary

- keep the fullscreen composer editable while an agent turn is active
- enqueue submitted follow-ups in FIFO order and drain them automatically after the current turn
- show the queued count and next prompt preview while preserving drafts typed behind queued inputs
- keep queued inputs across provider/runtime restarts and keep native progress active across tool rounds
- route session-title updates through the retained TUI event loop

## Testing

- `nix develop -c cabal repl agent-cli:test:agent-cli-test --repl-options=-v0`, then `main`
  - 438 examples, 0 failures
- real tmux smoke test at 120x36
  - started a turn that ran `sleep 3` and returned `QUEUE_FIRST_RESULT`
  - submitted `QUEUE_SECOND_RESULT` while the first turn was active
  - observed `queued 1` plus the queue preview
  - verified the queued prompt ran automatically after the first turn and returned in FIFO order
