### PR TITLE
Fix fullscreen TUI viewport height

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -679,7 +679,7 @@ drawHeader state =
         padLeftRight 2 $
             hBox
                 [ hLimitPercent 68 (txt left)
-                , fill ' '
+                , vLimit 1 (fill ' ')
                 , txt right
                 ]
   where


### PR DESCRIPTION
## Summary
- constrain the fullscreen header spacer to one terminal row
- prevent Brick from treating the header as vertically greedy
- let the conversation viewport consume all remaining terminal height

## Verification
- loaded `Agent.CLI.TUI.App` successfully in GHCi
- confirmed the header vertical size policy is `Fixed`
- smoke-tested the live TUI in tmux at 120×40 and 100×24
- ran `git diff --check`
