### PR TITLE
Restart running turn when reasoning effort changes

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -385,6 +385,7 @@ data StartupRuntime = StartupRuntime
     , startupStdoutTty :: !Bool
     , startupAgentSnapshot :: !(IORef (IO (AgentTarget, [AgentEntry])))
     , startupAgentSelect :: !(IORef (AgentTarget -> IO ()))
+    , startupRestartEffort :: !(IORef (Text -> IO ()))
     , startupStartedAt :: !UTCTime
     , startupTimings :: !(IORef [(Text, NominalDiffTime)])
     }
@@ -690,6 +691,7 @@ runAgent fullscreenInputs options transition = do
     useColor <- resolveColor stdout
     agentSnapshotRef <- newIORef (pure (AgentRoot, []))
     agentSelectRef <- newIORef (\_ -> pure ())
+    restartEffortActionRef <- newIORef (\_ -> pure ())
     queuedInputDisplays <- queuedFullscreenInputDisplays fullscreenInputs
     let initialTurns = maybe [] snd resumed
         fullscreenEnabled =
@@ -712,6 +714,7 @@ runAgent fullscreenInputs options transition = do
         then Just <$> newFullscreenRuntime
             fullscreenInputs
             (requestCancel toolEnv.toolCancel)
+            (\level -> readIORef restartEffortActionRef >>= ($ level))
             (noteFullscreenCtrlC interrupt)
             (copyTerminalClipboard terminal stdout)
             (setCliWindowTitle stdoutTty stdout)
@@ -738,6 +741,7 @@ runAgent fullscreenInputs options transition = do
             , startupStdoutTty = stdoutTty
             , startupAgentSnapshot = agentSnapshotRef
             , startupAgentSelect = agentSelectRef
+            , startupRestartEffort = restartEffortActionRef
             , startupStartedAt = startedAt
             , startupTimings = startupTimingsRef
             }
@@ -1241,6 +1245,7 @@ runSession options provider policy tools toolEnv planMode startup prompt pending
     lastAssistantRef <- newIORef Nothing
     modelRef <- newIORef =<< (currentModel <$> readIORef paramsRef)
     unavailableProvidersRef <- newIORef unavailableProviders
+    restartEffortRef <- newIORef Nothing
     ioLock <- newMVar ()
     previous <- newIORef initialPrevious
     titleTurnCount <- newIORef =<< sessionTitleTurnCountFromSlot persist
@@ -1421,6 +1426,7 @@ runSession options provider policy tools toolEnv planMode startup prompt pending
             , sessionAttachments = attachmentsRef
             , sessionPreviewId = previewIdRef
             , sessionInterrupt = interrupt
+            , sessionRestartEffort = restartEffortRef
             , sessionStoreRoot = storeRoot
             , sessionUsage = usageRef
             , sessionLastAssistant = lastAssistantRef
@@ -1434,6 +1440,10 @@ runSession options provider policy tools toolEnv planMode startup prompt pending
             , sessionOnPersisted = onPersisted
             , sessionReset = sessionReset
             }
+    writeIORef startup.startupRestartEffort \level -> do
+        setSessionEffort env level
+        writeIORef restartEffortRef (Just level)
+        requestCancel toolEnv.toolCancel
     let formatSkillWarning warning =
             "skill ignored: "
                 <> toText warning.skillWarningPath
@@ -1520,6 +1530,17 @@ finishTurnWithCooldownRetry allowCooldownRetry env exitAfter = \case
                     Nothing -> putTrailingNewline env.sessionPrinted
                     Just _ -> pure ()
                 continueAfterTurn env
+    TurnRestartRequested level pending -> do
+        setSessionEffort env level
+        writeIORef env.sessionPlanMode.planStateRef pending.pendingPlanState
+        case env.sessionFullscreen of
+            Just runtime ->
+                emitUiEvent runtime
+                    (UiSystemMessage
+                        ("restarting current turn with " <> level <> " effort"))
+            Nothing -> pure ()
+        result <- runOneTurn env pending.pendingPromptText pending.pendingInputs
+        finishTurnWithCooldownRetry allowCooldownRetry env exitAfter result
     TurnProviderUnavailable apiError pending ->
         let pending' = setPendingExitAfter exitAfter pending
         in requestAutomaticProviderFallback env apiError pending' >>= \case
@@ -1617,6 +1638,27 @@ reportProviderUnavailable apiError = do
     putTextLn stderr $ roleError color $
         "provider unavailable; no usable fallback provider account is available: "
             <> detail
+
+setSessionEffort :: SessionEnv -> Text -> IO ()
+setSessionEffort env level = do
+    modifyIORef' env.sessionParams (setReasoningEffort level)
+    case env.sessionFullscreen of
+        Just runtime ->
+            emitUiEvent runtime (UiSetPromptEffort level)
+        Nothing -> pure ()
+    case env.sessionPersist of
+        PersistenceDisabled -> pure ()
+        PersistenceEnabled slotRef -> do
+            slot <- readIORef slotRef
+            case slot of
+                PersistencePending pending ->
+                    writeIORef slotRef
+                        (PersistencePending pending { createEffort = level })
+                PersistenceActive handle -> do
+                    let meta = handle.sessionMeta { metaEffort = level }
+                    writeSessionMeta handle.sessionMetaPath meta
+                    writeIORef slotRef
+                        (PersistenceActive handle { sessionMeta = meta })
 
 repl :: SessionEnv -> IO RunResult
 repl env = replWithDraft env ""
@@ -2457,24 +2499,11 @@ replWithDraft env@SessionEnv
         Just runtime -> emitUiEvent runtime (UiErrorMessage message)
     setEffort level = do
         color <- resolveColor stdout
-        modifyIORef' paramsRef (setReasoningEffort level)
+        setSessionEffort env level
         displayInfo ("effort set to " <> level) $
             Text.putStrLn
                 (roleMuted color
                     (glyphOk <> "effort set to " <> level))
-        case persist of
-            PersistenceDisabled -> pure ()
-            PersistenceEnabled slotRef -> do
-                slot <- readIORef slotRef
-                case slot of
-                    PersistencePending pending ->
-                        writeIORef slotRef
-                            (PersistencePending pending { createEffort = level })
-                    PersistenceActive handle -> do
-                        let meta = handle.sessionMeta { metaEffort = level }
-                        writeSessionMeta handle.sessionMetaPath meta
-                        writeIORef slotRef
-                            (PersistenceActive handle { sessionMeta = meta })
     chooseEffort next = do
         params <- readIORef paramsRef
         effortChoice fullscreen (currentEffort params) >>= \case

--- a/packages/agent-cli/src/Agent/CLI/ProviderTransition.hs
+++ b/packages/agent-cli/src/Agent/CLI/ProviderTransition.hs
@@ -40,6 +40,7 @@ data ProviderTransition = ProviderTransition
 data TurnResult
     = TurnSucceeded
     | TurnFailed
+    | TurnRestartRequested !Text !PendingTurn
     | TurnProviderUnavailable !ApiError !PendingTurn
 
 -- | Rebuild provider-specific state without changing how the invocation was

--- a/packages/agent-cli/src/Agent/CLI/SessionEnv.hs
+++ b/packages/agent-cli/src/Agent/CLI/SessionEnv.hs
@@ -51,6 +51,7 @@ data SessionEnv = SessionEnv
     , sessionAttachments :: !(IORef [ImageAttachment])
     , sessionPreviewId :: !(IORef Int)
     , sessionInterrupt :: !InterruptState
+    , sessionRestartEffort :: !(IORef (Maybe Text))
     , sessionStoreRoot :: !(IORef (Maybe OsPath))
     , sessionUsage :: !(IORef TokenUsage)
     , sessionLastAssistant :: !(IORef (Maybe Text))

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -40,6 +40,7 @@ import Agent.CLI.Command
     , slashMenuForWithSkills
     )
 import Agent.CLI.Permission (PermissionChoice(..))
+import Agent.CLI.Options (reasoningEfforts)
 import Agent.CLI.ReplMode (replModeLabel)
 import Agent.CLI.Render (formatElapsed, summarizeToolCall)
 import Agent.CLI.Status (formatTokenUsage)
@@ -76,7 +77,8 @@ import Control.Exception (AsyncException(UserInterrupt))
 import Data.ByteString (ByteString)
 import Data.Char (isControl)
 import Data.Foldable (toList)
-import Data.List (find, intersperse, sortOn)
+import Data.List (elemIndex, find, intersperse, sortOn)
+import Data.Maybe (fromMaybe)
 import qualified Data.Sequence as Seq
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -134,6 +136,7 @@ data FullscreenRuntime = FullscreenRuntime
     { runtimeEvents :: !(BChan AppEvent)
     , runtimeInput :: !FullscreenInputBuffer
     , runtimeCancel :: !(IO ())
+    , runtimeRestartEffort :: !(Text -> IO ())
     , runtimeCtrlC :: !(IO CtrlCDecision)
     , runtimeCopy :: !(Text -> IO Bool)
     , runtimeSetWindowTitle :: !(Text -> IO ())
@@ -151,7 +154,7 @@ data AppState = AppState
     , appRuntime :: !FullscreenRuntime
     , appSlashIndex :: !Int
     , appChoice :: !(Maybe ChoiceOverlay)
-    , appChoiceReply :: !(Maybe (TMVar (Maybe Int)))
+    , appChoiceReply :: !(Maybe (Maybe Int -> IO ()))
     , appTextPrompt :: !(Maybe TextOverlay)
     , appTextReply :: !(Maybe (TMVar (Maybe Text)))
     , appSlashDismissed :: !Bool
@@ -189,6 +192,7 @@ newFullscreenInputBuffer =
 newFullscreenRuntime
     :: FullscreenInputBuffer
     -> IO ()
+    -> (Text -> IO ())
     -> IO CtrlCDecision
     -> (Text -> IO Bool)
     -> (Text -> IO ())
@@ -202,6 +206,7 @@ newFullscreenRuntime
 newFullscreenRuntime
     inputBuffer
     cancelAction
+    restartEffortAction
     ctrlCAction
     copyAction
     setWindowTitle
@@ -214,6 +219,7 @@ newFullscreenRuntime
     <$> newBChan 512
     <*> pure inputBuffer
     <*> pure cancelAction
+    <*> pure restartEffortAction
     <*> pure ctrlCAction
     <*> pure copyAction
     <*> pure setWindowTitle
@@ -471,6 +477,51 @@ handlePromptControlClick choice = do
                             current.appUi
                     }
 
+handleEffortControlClick :: EventM Name AppState ()
+handleEffortControlClick = do
+    state <- get
+    let ui = state.appUi
+        overlayOpen =
+            maybe False (const True) state.appTextPrompt
+                || maybe False (const True) state.appChoice
+                || maybe False (const True) ui.uiPermission
+    if ui.uiAwaitingInput
+        then handlePromptControlClick ReplChooseEffort
+        else if ui.uiRunning && not overlayOpen
+            then do
+                let efforts = reasoningEfforts
+                    current = ui.uiPrompt.promptEffort
+                    initial = fromMaybe 0 (elemIndex current efforts)
+                    choose = \case
+                        Just index
+                            | index >= 0
+                            , index < length efforts -> do
+                                let level = efforts !! index
+                                when (level /= current) $
+                                    state.appRuntime.runtimeRestartEffort level
+                        _ -> pure ()
+                modify' \currentState ->
+                    currentState
+                        { appChoice = Just ChoiceOverlay
+                            { choiceTitle = "Reasoning effort"
+                            , choiceBody =
+                                "Changing effort will restart the current turn."
+                            , choiceIndex = initial
+                            , choiceRows = [(effort, "") | effort <- efforts]
+                            }
+                        , appChoiceReply = Just choose
+                        }
+                vScrollToBeginning (viewportScroll OverlayViewport)
+            else
+                modify' \current ->
+                    current
+                        { appUi =
+                            reduceUi
+                                (UiSetNotice
+                                    (Just "Prompt settings cannot be changed right now."))
+                                current.appUi
+                        }
+
 confirmChoiceAt :: Int -> EventM Name AppState ()
 confirmChoiceAt index = do
     state <- get
@@ -517,7 +568,7 @@ activateControl = \case
     ComposerModel ->
         handlePromptControlClick ReplChooseModel
     ComposerEffort ->
-        handlePromptControlClick ReplChooseEffort
+        handleEffortControlClick
     ComposerMode ->
         handlePromptControlClick ReplCycleMode
     ChoiceRow index ->
@@ -539,11 +590,10 @@ resolveChoice confirmed = do
     case state.appChoiceReply of
         Nothing -> pure ()
         Just reply ->
-            liftIO $ atomically $
-                putTMVar reply $
-                    if confirmed
-                        then (.choiceIndex) <$> state.appChoice
-                        else Nothing
+            liftIO $ reply $
+                if confirmed
+                    then (.choiceIndex) <$> state.appChoice
+                    else Nothing
     modify' \current ->
         current
             { appChoice = Nothing
@@ -1249,7 +1299,7 @@ handleEvent event = case event of
                         max 0 (min (max 0 (length rows - 1)) initial)
                     , choiceRows = rows
                     }
-                , appChoiceReply = Just reply
+                , appChoiceReply = Just (atomically . putTMVar reply)
                 }
         vScrollToBeginning (viewportScroll OverlayViewport)
     AppEvent (AppAskText title body initial reply) -> do

--- a/packages/agent-cli/src/Agent/CLI/Turn.hs
+++ b/packages/agent-cli/src/Agent/CLI/Turn.hs
@@ -123,6 +123,7 @@ runOneTurn env@SessionEnv
   -- Clear the prior turn before publishing this flag to Ctrl-C / Esc.
   -- Resetting inside runLoopInputs could erase the one-shot Esc signal.
   resetCancel config.loopCancel
+  writeIORef env.sessionRestartEffort Nothing
   withTurnCancel interrupt config.loopCancel $
     (if isJust fullscreen
         then id
@@ -193,6 +194,9 @@ runOneTurn env@SessionEnv
             (restoreStartupContext >> abortSubagentTurn rootTurnId)
     clearThinking render
     finishedAt <- getCurrentTime
+    restartEffort <-
+        atomicModifyIORef' env.sessionRestartEffort \requested ->
+            (Nothing, requested)
     let elapsedDetail extra = case startedAt of
             Nothing -> extra
             Just t0 -> extra <> " · " <> formatElapsed (realToFrac (diffUTCTime finishedAt t0))
@@ -214,8 +218,23 @@ runOneTurn env@SessionEnv
                         }
                 handle' <- appendTurn handle turn
                 writeIORef slotRef (PersistenceActive handle')
-    case result of
-        Left cancelled@(LoopCancelled _) -> do
+    case (restartEffort, result) of
+        (Just level, _) -> do
+            restoreStartupContext
+            abortSubagentTurn rootTurnId
+            writeIORef transcriptRef beforeItems
+            planState <- readIORef planMode.planStateRef
+            case fullscreen of
+                Just runtime ->
+                    emitUiEvent runtime UiTurnRestarted
+                Nothing -> pure ()
+            pure $ TurnRestartRequested level PendingTurn
+                { pendingPromptText = promptText
+                , pendingInputs = inputs
+                , pendingExitAfter = False
+                , pendingPlanState = planState
+                }
+        (Nothing, Left cancelled@(LoopCancelled _)) -> do
             restoreStartupContext
             finishTerminal (isNothing fullscreen)
                 terminal wallStarted finishedAt 130 "Agent cancelled"
@@ -236,7 +255,7 @@ runOneTurn env@SessionEnv
                         (formatTurnStatus color "cancelled" (elapsedDetail model))
             persistIncomplete "cancelled"
             pure TurnSucceeded
-        Left err -> do
+        (Nothing, Left err) -> do
             restoreStartupContext
             abortSubagentTurn rootTurnId
             afterItems <- readIORef transcriptRef
@@ -281,7 +300,7 @@ runOneTurn env@SessionEnv
                                 (formatTurnStatus color "error" (elapsedDetail model))
                     persistIncomplete (Text.pack (show err))
                     pure TurnFailed
-        Right loopResult -> do
+        (Nothing, Right loopResult) -> do
             finishTerminal (isNothing fullscreen)
                 terminal wallStarted finishedAt 0 "Agent finished"
             finishSubagentTurn rootTurnId

--- a/packages/agent-cli/src/Agent/CLI/UI/Model.hs
+++ b/packages/agent-cli/src/Agent/CLI/UI/Model.hs
@@ -130,6 +130,7 @@ data UiEvent
     | UiQueuedInputStarted
     | UiSetDraft !Text !Int
     | UiSetPrompt !PromptState
+    | UiSetPromptEffort !Text
     | UiSetAwaitingInput !Bool
     | UiSetRepository !Text !Text
     | UiSetNotice !(Maybe Text)
@@ -147,6 +148,7 @@ data UiEvent
     | UiConversationCleared
     | UiSetFollow !Bool
     | UiTurnEnded !BlockState
+    | UiTurnRestarted
     | UiTick
     deriving (Eq, Show)
 
@@ -217,6 +219,10 @@ reduceUi event state = case event of
             }
     UiSetPrompt prompt ->
         state { uiPrompt = prompt }
+    UiSetPromptEffort effort ->
+        state
+            { uiPrompt = state.uiPrompt { promptEffort = effort }
+            }
     UiSetAwaitingInput awaiting ->
         (if awaiting then finalizeStreams state else state)
             { uiAwaitingInput = awaiting
@@ -288,6 +294,14 @@ reduceUi event state = case event of
             }
     UiTurnEnded terminalState ->
         finalizeTurn terminalState state
+    UiTurnRestarted ->
+        state
+            { uiBlocks = Seq.take state.uiTurnStartBlock state.uiBlocks
+            , uiRunning = False
+            , uiActivity = "Restarting…"
+            , uiNotice = Just "Restarting current turn…"
+            , uiToolCalls = Map.empty
+            }
     UiTick ->
         state
             { uiFrame = (state.uiFrame + 1) `mod` 10

--- a/packages/agent-cli/test/Agent/CLI/UIModelSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/UIModelSpec.hs
@@ -49,6 +49,28 @@ spec = describe "fullscreen UI reducer" do
         state.uiCursor `shouldBe` 20
         state.uiAwaitingInput `shouldBe` True
 
+    it "discards partial output and updates effort when restarting a turn" do
+        let initialPrompt =
+                initialUiState.uiPrompt
+                    { promptEffort = "low"
+                    }
+            state =
+                apply
+                    [ UiSetPrompt initialPrompt
+                    , UiUserSubmitted "try this"
+                    , UiLoop TurnStarted
+                    , UiLoop (ReasoningDelta "partial thought")
+                    , UiLoop (TextDelta "partial answer")
+                    , UiSetPromptEffort "high"
+                    , UiTurnRestarted
+                    ]
+            blocks = Foldable.toList state.uiBlocks
+        map (.blockBody) blocks `shouldBe` ["try this"]
+        state.uiPrompt.promptEffort `shouldBe` "high"
+        state.uiRunning `shouldBe` False
+        state.uiActivity `shouldBe` "Restarting…"
+        state.uiNotice `shouldBe` Just "Restarting current turn…"
+
     it "matches tool completion by call id" do
         let call = functionToolCall "c1" "run_terminal_cmd" "{\"command\":\"git status\"}"
             result = ToolCallResult


### PR DESCRIPTION
## Summary
- allow the fullscreen reasoning-effort control to open while a turn is running
- cancel and restart the current turn after selecting a different effort
- discard partial output from the interrupted attempt while preserving the original user message
- update and persist the selected effort immediately

## Testing
- `nix develop -c cabal repl agent-cli:lib:agent-cli --repl-options='-fno-code'`
- `env -u GHCRTS nix develop -c env -u GHCRTS cabal test agent-cli:test:agent-cli-test` (439 examples, 0 failures)
- live tmux smoke test changing a running turn from `high` to `xhigh`
- `git diff --check`
