### PR TITLE
Decouple fullscreen UI rendering from agent events

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -55,18 +55,12 @@ import Brick.BChan
     ( BChan
     , newBChan
     , writeBChan
-    , writeBChanNonBlocking
     )
 import Brick.Widgets.Border (borderWithLabel)
 import Brick.Widgets.Border.Style (unicodeRounded)
 import Brick.Widgets.Center (centerLayer)
 import Control.Concurrent.Async (wait, waitCatch, withAsync)
 import Control.Concurrent (threadDelay)
-import Control.Concurrent.MVar
-    ( MVar
-    , newMVar
-    , withMVar
-    )
 import Control.Concurrent.STM
     ( STM
     , TMVar
@@ -90,14 +84,14 @@ import Data.Char (isControl)
 import Data.Foldable (toList)
 import Data.IORef
     ( IORef
-    , atomicModifyIORef'
     , newIORef
     , readIORef
     , writeIORef
     )
 import Data.List (elemIndex, find, findIndex, intersperse, sortOn)
+import Data.List.NonEmpty (NonEmpty(..))
 import Data.Maybe (fromMaybe)
-import Data.Sequence (Seq)
+import Data.Sequence (Seq, ViewL(..), ViewR(..), (|>))
 import qualified Data.Sequence as Seq
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -123,18 +117,9 @@ data Name
     | AgentRow !AgentTarget
     deriving (Eq, Ord, Show)
 
-data DeltaKind
-    = DeltaText
-    | DeltaReasoning
-    deriving (Eq)
-
-data BufferedDelta = BufferedDelta
-    { bufferedKind :: !DeltaKind
-    , bufferedChunks :: !(Seq Text)
-    }
-
 data AppEvent
     = AppUi !UiEvent
+    | AppUiBatch !(NonEmpty UiEvent)
     | AppAskPermission !Text !(TMVar (Maybe PermissionChoice))
     | AppAskChoice
         !Text
@@ -153,6 +138,18 @@ data AppEvent
     | AppSetWindowTitle !Text
     | AppStop
 
+data PendingAppEvent
+    = PendingEvent !AppEvent
+    | PendingUi !PendingUiEvent
+
+data PendingUiEvent
+    = PendingExactUi !UiEvent
+    | PendingTextDeltas !(Seq Text)
+    | PendingReasoningDeltas !(Seq Text)
+
+newtype AppEventMailbox =
+    AppEventMailbox (TVar (Seq PendingAppEvent))
+
 data FullscreenInput = FullscreenInput
     { fullscreenInputLine :: !ReplLine
     , fullscreenInputQueued :: !Bool
@@ -164,6 +161,7 @@ newtype FullscreenInputBuffer =
 
 data FullscreenRuntime = FullscreenRuntime
     { runtimeEvents :: !(BChan AppEvent)
+    , runtimeMailbox :: !AppEventMailbox
     , runtimeInput :: !FullscreenInputBuffer
     , runtimeCancel :: !(IO ())
     , runtimeRestartEffort :: !(Text -> IO ())
@@ -174,8 +172,6 @@ data FullscreenRuntime = FullscreenRuntime
     , runtimeAgentSnapshot :: !(IO (AgentTarget, [AgentEntry]))
     , runtimeAgentSelect :: !(AgentTarget -> IO ())
     , runtimeFirstFrame :: !(IO ())
-    , runtimePendingDeltas :: !(IORef (Seq BufferedDelta))
-    , runtimeEventLock :: !(MVar ())
     , runtimeRunning :: !(IORef Bool)
     , runtimeColor :: !Bool
     , runtimeInitial :: !UiState
@@ -250,11 +246,11 @@ newFullscreenRuntime
     color
     initial = do
         events <- newBChan 512
-        pendingDeltas <- newIORef Seq.empty
-        eventLock <- newMVar ()
+        mailbox <- AppEventMailbox <$> newTVarIO Seq.empty
         running <- newIORef False
         pure FullscreenRuntime
             { runtimeEvents = events
+            , runtimeMailbox = mailbox
             , runtimeInput = inputBuffer
             , runtimeCancel = cancelAction
             , runtimeRestartEffort = restartEffortAction
@@ -265,70 +261,15 @@ newFullscreenRuntime
             , runtimeAgentSnapshot = agentSnapshot
             , runtimeAgentSelect = agentSelect
             , runtimeFirstFrame = firstFrame
-            , runtimePendingDeltas = pendingDeltas
-            , runtimeEventLock = eventLock
             , runtimeRunning = running
             , runtimeColor = color
             , runtimeInitial = initial
             }
 
 emitUiEvent :: FullscreenRuntime -> UiEvent -> IO ()
-emitUiEvent runtime event =
-    case bufferedDelta event of
-        Just (kind, delta) ->
-            atomicModifyIORef' runtime.runtimePendingDeltas \pending ->
-                (appendBufferedDelta kind delta pending, ())
-        Nothing ->
-            withMVar runtime.runtimeEventLock \_ -> do
-                flushPendingDeltasUnlocked runtime
-                updateRuntimeRunning runtime event
-                writeBChan runtime.runtimeEvents (AppUi event)
-
-bufferedDelta :: UiEvent -> Maybe (DeltaKind, Text)
-bufferedDelta = \case
-    UiLoop (TextDelta delta) -> Just (DeltaText, delta)
-    UiLoop (ReasoningDelta delta) -> Just (DeltaReasoning, delta)
-    _ -> Nothing
-
-appendBufferedDelta
-    :: DeltaKind
-    -> Text
-    -> Seq BufferedDelta
-    -> Seq BufferedDelta
-appendBufferedDelta kind delta pending =
-    case Seq.viewr pending of
-        rest Seq.:> buffered
-            | buffered.bufferedKind == kind ->
-                rest Seq.|> buffered
-                    { bufferedChunks =
-                        buffered.bufferedChunks Seq.|> delta
-                    }
-        _ ->
-            pending Seq.|> BufferedDelta
-                { bufferedKind = kind
-                , bufferedChunks = Seq.singleton delta
-                }
-
-flushPendingUiEvents :: FullscreenRuntime -> IO ()
-flushPendingUiEvents runtime =
-    withMVar runtime.runtimeEventLock \_ ->
-        flushPendingDeltasUnlocked runtime
-
-flushPendingDeltasUnlocked :: FullscreenRuntime -> IO ()
-flushPendingDeltasUnlocked runtime = do
-    pending <- atomicModifyIORef' runtime.runtimePendingDeltas \buffered ->
-        (Seq.empty, buffered)
-    mapM_ emitBuffered pending
-  where
-    emitBuffered buffered =
-        writeBChan runtime.runtimeEvents $
-            AppUi $
-                UiLoop $
-                    case buffered.bufferedKind of
-                        DeltaText -> TextDelta body
-                        DeltaReasoning -> ReasoningDelta body
-      where
-        body = Text.concat (toList buffered.bufferedChunks)
+emitUiEvent runtime event = do
+    updateRuntimeRunning runtime event
+    enqueueAppEvent runtime (AppUi event)
 
 updateRuntimeRunning :: FullscreenRuntime -> UiEvent -> IO ()
 updateRuntimeRunning runtime = \case
@@ -341,7 +282,7 @@ updateRuntimeRunning runtime = \case
 
 setFullscreenWindowTitle :: FullscreenRuntime -> Text -> IO ()
 setFullscreenWindowTitle runtime =
-    writeBChan runtime.runtimeEvents . AppSetWindowTitle
+    enqueueAppEvent runtime . AppSetWindowTitle
 
 hasQueuedFullscreenInput :: FullscreenRuntime -> IO Bool
 hasQueuedFullscreenInput runtime =
@@ -369,7 +310,7 @@ readFullscreenLine
     -> Text
     -> IO ReplLine
 readFullscreenLine runtime skills prompt initial = do
-    writeBChan runtime.runtimeEvents (AppSetSkillCommands skills)
+    enqueueAppEvent runtime (AppSetSkillCommands skills)
     emitUiEvent runtime (UiSetPrompt prompt)
     -- Keep anything the user started typing while the previous turn was
     -- running. Non-empty explicit drafts (for example after cycling mode or
@@ -392,7 +333,7 @@ requestFullscreenPermission
 requestFullscreenPermission runtime call = do
     reply <- newEmptyTMVarIO
     let summary = summarizeToolCall call
-    writeBChan runtime.runtimeEvents (AppAskPermission summary reply)
+    enqueueAppEvent runtime (AppAskPermission summary reply)
     atomically (readTMVar reply)
 
 requestFullscreenChoice
@@ -413,7 +354,7 @@ requestFullscreenChoiceWithBody
     -> IO (Maybe Int)
 requestFullscreenChoiceWithBody runtime title body initial rows = do
     reply <- newEmptyTMVarIO
-    writeBChan runtime.runtimeEvents
+    enqueueAppEvent runtime
         (AppAskChoice title body initial rows reply)
     atomically (readTMVar reply)
 
@@ -425,14 +366,14 @@ requestFullscreenText
     -> IO (Maybe Text)
 requestFullscreenText runtime title body initial = do
     reply <- newEmptyTMVarIO
-    writeBChan runtime.runtimeEvents
+    enqueueAppEvent runtime
         (AppAskText title body initial reply)
     atomically (readTMVar reply)
 
 withFullscreenSuspended :: FullscreenRuntime -> IO a -> IO a
 withFullscreenSuspended runtime action = do
     reply <- newEmptyTMVarIO
-    writeBChan runtime.runtimeEvents (AppSuspend action reply)
+    enqueueAppEvent runtime (AppSuspend action reply)
     atomically (readTMVar reply) >>= either throwIO pure
 
 runFullscreen :: FullscreenRuntime -> IO a -> IO a
@@ -482,39 +423,37 @@ runFullscreen runtime workerAction = do
     withAsync workerAction \worker ->
         withAsync uiTicker \_uiTicker ->
             withAsync (agentTicker (initialAgent, initialAgents)) \_agentTicker ->
-                withAsync
-                    (void (waitCatch worker)
-                        >> flushPendingUiEvents runtime
-                        >> writeBChan runtime.runtimeEvents AppStop)
-                    \_notifier -> do
-                        finalState <-
-                            customMain
-                                initialVty
-                                buildVty
-                                (Just runtime.runtimeEvents)
-                                fullscreenApp
-                                initialState
-                            `finally` runtime.runtimeNativeProgress False
-                        when (not finalState.appWorkerStopped) $
-                            atomically $
-                                appendFullscreenInput runtime.runtimeInput FullscreenInput
-                                    { fullscreenInputLine = ReplEof
-                                    , fullscreenInputQueued = False
-                                    , fullscreenInputDisplay = Nothing
-                                    }
-                        wait worker
+                withAsync (eventPump runtime) \_eventPump ->
+                    withAsync
+                        (void (waitCatch worker)
+                            >> enqueueAppEvent runtime AppStop)
+                        \_notifier -> do
+                            finalState <-
+                                customMain
+                                    initialVty
+                                    buildVty
+                                    (Just runtime.runtimeEvents)
+                                    fullscreenApp
+                                    initialState
+                                `finally` runtime.runtimeNativeProgress False
+                            when (not finalState.appWorkerStopped) $
+                                atomically $
+                                    appendFullscreenInput
+                                        runtime.runtimeInput
+                                        FullscreenInput
+                                            { fullscreenInputLine = ReplEof
+                                            , fullscreenInputQueued = False
+                                            , fullscreenInputDisplay = Nothing
+                                            }
+                            wait worker
   where
     uiTicker = loop (0 :: Int)
       where
         loop tick = do
             threadDelay 50000
-            flushPendingUiEvents runtime
             running <- readIORef runtime.runtimeRunning
             when (running && tick `mod` 2 == 0) $
-                void $
-                    writeBChanNonBlocking
-                        runtime.runtimeEvents
-                        (AppUi UiTick)
+                enqueueAppEvent runtime (AppUi UiTick)
             loop ((tick + 1) `mod` 20)
 
     agentTicker previous = do
@@ -525,12 +464,131 @@ runFullscreen runtime workerAction = do
             Right snapshot
                 | snapshot == previous -> pure previous
                 | otherwise -> do
-                    written <-
-                        writeBChanNonBlocking
-                            runtime.runtimeEvents
-                            (uncurry AppAgentSnapshot snapshot)
-                    pure (if written then snapshot else previous)
+                    enqueueAppEvent runtime
+                        (uncurry AppAgentSnapshot snapshot)
+                    pure snapshot
         agentTicker previous'
+
+-- | Move events from the producer-facing mailbox into Brick. UI updates are
+-- collected for one frame so a fast token stream causes at most one redraw
+-- every ~16 ms. Blocking on Brick's bounded channel only blocks this pump,
+-- never the model/tool worker publishing into the mailbox.
+eventPump :: FullscreenRuntime -> IO ()
+eventPump runtime = loop
+  where
+    loop = do
+        pending <- atomically (takePendingAppEvent runtime.runtimeMailbox)
+        delivered <- case pending of
+            PendingUi first -> do
+                threadDelay uiFrameDelayMicros
+                rest <- atomically $
+                    takePendingUiEventPrefix
+                        (uiFrameBatchLimit - 1)
+                        runtime.runtimeMailbox
+                pure (AppUiBatch
+                    (pendingUiEvent first :| map pendingUiEvent rest))
+            PendingEvent event ->
+                pure event
+        writeBChan runtime.runtimeEvents delivered
+        loop
+
+uiFrameDelayMicros :: Int
+uiFrameDelayMicros = 16000
+
+uiFrameBatchLimit :: Int
+uiFrameBatchLimit = 256
+
+enqueueAppEvent :: FullscreenRuntime -> AppEvent -> IO ()
+enqueueAppEvent runtime event =
+    atomically do
+        let AppEventMailbox pendingRef = runtime.runtimeMailbox
+        pending <- readTVar pendingRef
+        writeTVar pendingRef (appendAppEvent event pending)
+
+appendAppEvent :: AppEvent -> Seq PendingAppEvent -> Seq PendingAppEvent
+appendAppEvent event pending = case event of
+    AppUi (UiLoop (TextDelta delta)) ->
+        case Seq.viewr pending of
+            rest :> PendingUi (PendingTextDeltas deltas) ->
+                rest |> PendingUi (PendingTextDeltas (deltas |> delta))
+            _ ->
+                pending |> PendingUi
+                    (PendingTextDeltas (Seq.singleton delta))
+    AppUi (UiLoop (ReasoningDelta delta)) ->
+        case Seq.viewr pending of
+            rest :> PendingUi (PendingReasoningDeltas deltas) ->
+                rest |> PendingUi
+                    (PendingReasoningDeltas (deltas |> delta))
+            _ ->
+                pending |> PendingUi
+                    (PendingReasoningDeltas (Seq.singleton delta))
+    AppUi uiEvent ->
+        appendExactUiEvent uiEvent pending
+    _ ->
+        appendExactAppEvent event pending
+
+appendExactUiEvent
+    :: UiEvent
+    -> Seq PendingAppEvent
+    -> Seq PendingAppEvent
+appendExactUiEvent event pending =
+    case Seq.viewr pending of
+        rest :> PendingUi (PendingExactUi previous)
+            | Just merged <- Bridge.mergeUiEvents previous event ->
+                rest |> PendingUi (PendingExactUi merged)
+        _ ->
+            pending |> PendingUi (PendingExactUi event)
+
+appendExactAppEvent
+    :: AppEvent
+    -> Seq PendingAppEvent
+    -> Seq PendingAppEvent
+appendExactAppEvent event pending =
+    case (Seq.viewr pending, event) of
+        ( rest :> PendingEvent (AppAgentSnapshot _ _)
+            , AppAgentSnapshot selected entries
+            ) ->
+                rest |> PendingEvent (AppAgentSnapshot selected entries)
+        (rest :> PendingEvent (AppSetWindowTitle _), AppSetWindowTitle title) ->
+            rest |> PendingEvent (AppSetWindowTitle title)
+        _ ->
+            pending |> PendingEvent event
+
+takePendingAppEvent :: AppEventMailbox -> STM PendingAppEvent
+takePendingAppEvent (AppEventMailbox pendingRef) = do
+    pending <- readTVar pendingRef
+    case Seq.viewl pending of
+        EmptyL -> retry
+        event :< rest -> do
+            writeTVar pendingRef rest
+            pure event
+
+takePendingUiEventPrefix
+    :: Int
+    -> AppEventMailbox
+    -> STM [PendingUiEvent]
+takePendingUiEventPrefix limit (AppEventMailbox pendingRef) = do
+    pending <- readTVar pendingRef
+    let (events, rest) = go limit [] pending
+    writeTVar pendingRef rest
+    pure events
+  where
+    go remaining acc pending
+        | remaining <= 0 = (reverse acc, pending)
+        | otherwise =
+            case Seq.viewl pending of
+                PendingUi event :< rest ->
+                    go (remaining - 1) (event : acc) rest
+                _ ->
+                    (reverse acc, pending)
+
+pendingUiEvent :: PendingUiEvent -> UiEvent
+pendingUiEvent = \case
+    PendingExactUi event -> event
+    PendingTextDeltas deltas ->
+        UiLoop (TextDelta (Text.concat (toList deltas)))
+    PendingReasoningDeltas deltas ->
+        UiLoop (ReasoningDelta (Text.concat (toList deltas)))
 
 handleChoiceKey :: V.Event -> EventM Name AppState ()
 handleChoiceKey = \case
@@ -1403,6 +1461,59 @@ choiceRow appState selected index (label, detail) =
             Just attr -> forceAttr attr row
     in clickable name interactive
 
+handleUiEvents :: NonEmpty UiEvent -> EventM Name AppState ()
+handleUiEvents uiEvents = do
+    initial <- get
+    let
+        (final, nativeProgress, shouldFollow, shouldInvalidate) =
+            foldl' applyOne (initial, Nothing, False, False) uiEvents
+    put final
+    case nativeProgress of
+        Nothing -> pure ()
+        Just active ->
+            liftIO (final.appRuntime.runtimeNativeProgress active)
+    when shouldInvalidate invalidateCache
+    when shouldFollow $
+        vScrollToEnd (viewportScroll ConversationViewport)
+    when
+        (all (== UiTick) uiEvents && final.appUi == initial.appUi)
+        continueWithoutRedraw
+  where
+    applyOne
+        (state, previousProgress, followed, invalidated)
+        uiEvent =
+            let
+                next = applyUiEvent uiEvent state
+                progress =
+                    case Bridge.nativeProgressSignal uiEvent next.appUi of
+                        Nothing -> previousProgress
+                        signal -> signal
+                follows =
+                    followed
+                        || (Bridge.eventFollows uiEvent
+                            && next.appUi.uiFollow)
+                invalidates =
+                    invalidated || uiEvent == UiConversationCleared
+            in (next, progress, follows, invalidates)
+
+applyUiEvent :: UiEvent -> AppState -> AppState
+applyUiEvent uiEvent state =
+    state
+        { appUi = reduceUi uiEvent state.appUi
+        , appSlashDismissed = case uiEvent of
+            UiSetDraft _ _ -> False
+            _ -> state.appSlashDismissed
+        , appPasted = case uiEvent of
+            UiSetDraft _ _ -> False
+            _ -> state.appPasted
+        , appHistoryIndex = case uiEvent of
+            UiSetDraft _ _ -> Nothing
+            _ -> state.appHistoryIndex
+        , appHistoryDraft = case uiEvent of
+            UiSetDraft text _ -> text
+            _ -> state.appHistoryDraft
+        }
+
 handleEvent :: BrickEvent Name AppEvent -> EventM Name AppState ()
 handleEvent event = case event of
     AppEvent AppStop -> do
@@ -1437,35 +1548,10 @@ handleEvent event = case event of
                     ((length state.appAgentEntries > 1)
                         /= (length entries > 1))
                     invalidateCache
-    AppEvent (AppUi uiEvent) -> do
-        previous <- get
-        modify' \state -> state
-            { appUi = reduceUi uiEvent state.appUi
-            , appSlashDismissed = case uiEvent of
-                UiSetDraft _ _ -> False
-                _ -> state.appSlashDismissed
-            , appPasted = case uiEvent of
-                UiSetDraft _ _ -> False
-                _ -> state.appPasted
-            , appHistoryIndex = case uiEvent of
-                UiSetDraft _ _ -> Nothing
-                _ -> state.appHistoryIndex
-            , appHistoryDraft = case uiEvent of
-                UiSetDraft text _ -> text
-                _ -> state.appHistoryDraft
-            }
-        state <- get
-        case Bridge.nativeProgressSignal uiEvent state.appUi of
-            Nothing -> pure ()
-            Just active ->
-                liftIO (state.appRuntime.runtimeNativeProgress active)
-        case uiEvent of
-            UiConversationCleared -> invalidateCache
-            _ -> pure ()
-        when (Bridge.eventFollows uiEvent && state.appUi.uiFollow) $
-            vScrollToEnd (viewportScroll ConversationViewport)
-        when (uiEvent == UiTick && state.appUi == previous.appUi) $
-            continueWithoutRedraw
+    AppEvent (AppUi uiEvent) ->
+        handleUiEvents (uiEvent :| [])
+    AppEvent (AppUiBatch uiEvents) ->
+        handleUiEvents uiEvents
     AppEvent (AppAskPermission summary reply) ->
         modify' \state ->
             state

--- a/packages/agent-cli/src/Agent/CLI/TUI/Bridge.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Bridge.hs
@@ -2,6 +2,7 @@
 module Agent.CLI.TUI.Bridge
     ( eventFollows
     , historyMove
+    , mergeUiEvents
     , nativeProgressSignal
     , normalizeAgentSelection
     ) where
@@ -20,6 +21,21 @@ eventFollows = \case
     UiErrorMessage _ -> True
     UiConversationCleared -> True
     _ -> False
+
+-- | Merge adjacent high-frequency updates before they reach Brick. Structural
+-- events deliberately return 'Nothing' so turn/tool ordering remains exact.
+mergeUiEvents :: UiEvent -> UiEvent -> Maybe UiEvent
+mergeUiEvents older newer = case (older, newer) of
+    (UiLoop (TextDelta left), UiLoop (TextDelta right)) ->
+        Just (UiLoop (TextDelta (left <> right)))
+    (UiLoop (ReasoningDelta left), UiLoop (ReasoningDelta right)) ->
+        Just (UiLoop (ReasoningDelta (left <> right)))
+    (UiLoop (ActivityUpdated _), UiLoop (ActivityUpdated latest)) ->
+        Just (UiLoop (ActivityUpdated latest))
+    (UiTick, UiTick) ->
+        Just UiTick
+    _ ->
+        Nothing
 
 nativeProgressSignal :: UiEvent -> UiState -> Maybe Bool
 nativeProgressSignal event state = case event of

--- a/packages/agent-cli/test/Agent/CLI/TUIBridgeSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIBridgeSpec.hs
@@ -1,11 +1,19 @@
 module Agent.CLI.TUIBridgeSpec (spec) where
 
 import Agent.CLI.AgentViewport (AgentEntry(..), AgentTarget(..))
+import Agent.CLI.Interrupt (CtrlCDecision(..))
+import Agent.CLI.TUI.App
+    ( emitUiEvent
+    , newFullscreenInputBuffer
+    , newFullscreenRuntime
+    )
 import Agent.CLI.TUI.Bridge
 import Agent.CLI.UI.Model
 import Agent.Loop (LoopEvent(..), emptyTurnOutput)
 import Agent.Subagents (SubagentId(..))
 import Agent.ToolDispatch (functionToolCall)
+import Control.Monad (replicateM_)
+import System.Timeout (timeout)
 import Test.Hspec
 
 spec :: Spec
@@ -49,6 +57,52 @@ spec = describe "fullscreen TUI bridge" do
             `shouldBe` Just True
         nativeProgressSignal (UiTurnEnded BlockCancelled) running
             `shouldBe` Just False
+
+    it "coalesces adjacent streaming updates without merging boundaries" do
+        mergeUiEvents
+            (UiLoop (TextDelta "hel"))
+            (UiLoop (TextDelta "lo"))
+            `shouldBe` Just (UiLoop (TextDelta "hello"))
+        mergeUiEvents
+            (UiLoop (ReasoningDelta "look "))
+            (UiLoop (ReasoningDelta "here"))
+            `shouldBe` Just (UiLoop (ReasoningDelta "look here"))
+        mergeUiEvents
+            (UiLoop (ActivityUpdated "connecting"))
+            (UiLoop (ActivityUpdated "streaming"))
+            `shouldBe` Just (UiLoop (ActivityUpdated "streaming"))
+        mergeUiEvents UiTick UiTick `shouldBe` Just UiTick
+        mergeUiEvents
+            (UiLoop (TextDelta "answer"))
+            (UiLoop
+                (ToolStarted
+                    (functionToolCall "tool-1" "read_file" "{}")))
+            `shouldBe` Nothing
+        mergeUiEvents
+            (UiLoop (ReasoningDelta "thought"))
+            (UiLoop (TextDelta "answer"))
+            `shouldBe` Nothing
+
+    it "does not block producers when Brick is not draining events" do
+        input <- newFullscreenInputBuffer
+        runtime <- newFullscreenRuntime
+            input
+            (pure ())
+            (const (pure ()))
+            (pure WarnExit)
+            (const (pure True))
+            (const (pure ()))
+            (const (pure ()))
+            (pure (AgentRoot, []))
+            (const (pure ()))
+            (pure ())
+            False
+            initialUiState
+        completed <- timeout 2000000 $
+            replicateM_ 2000 do
+                emitUiEvent runtime (UiLoop (TextDelta "x"))
+                emitUiEvent runtime (UiLoop TurnStarted)
+        completed `shouldBe` Just ()
 
     it "moves through history and restores the original draft" do
         historyMove 1 ["new", "old"] Nothing "draft" ""


### PR DESCRIPTION
## Summary

- route fullscreen UI events through a producer-facing STM mailbox so model and tool workers do not block on Brick's bounded event channel
- coalesce streaming text, reasoning, activity, and tick updates and deliver UI changes in frame-sized batches at roughly 60 FPS
- preserve ordering for turn, tool, permission, suspension, and shutdown events with a scoped event pump
- add regression coverage for coalescing boundaries and publishing while Brick is not draining

## Testing

- loaded `agent-cli:lib:agent-cli` successfully in GHCi
- ran the full `agent-cli` test suite in GHCi after rebasing onto current `master`: 446 examples, 0 failures
- exercised the rebased fullscreen UI in tmux and verified a live 40-line streamed response rendered and completed correctly
