### PR TITLE
Skip unsupported Codex remote compaction

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -196,5 +196,6 @@ test-suite agent-cli-test
                     , safe-exceptions
                     , text
                     , time
+                    , transformers
                     , unix
                     , vty >= 6.4 && < 7

--- a/packages/agent-cli/src/Agent/CLI/Compaction.hs
+++ b/packages/agent-cli/src/Agent/CLI/Compaction.hs
@@ -4,8 +4,8 @@ module Agent.CLI.Compaction
     , codexAutoCompactTokenLimit
     , autoCompactOpenAiBackend
     , autoCompactOpenAiBackendWith
+    , compactOpenAIWith
     , runProviderCompact
-    , shouldFallbackFromRemoteCompact
     ) where
 
 import Agent.Error (ApiError(..), ErrorType(..))
@@ -14,10 +14,6 @@ import Agent.Loop
     , LoopEvent(..)
     , TokenUsage(..)
     , TurnOutput(..)
-    )
-import Agent.OpenAI.CompactClient
-    ( CompactRequest(..)
-    , compactConversation
     )
 import qualified Agent.OpenAI.Client as OpenAI
 import Agent.OpenAI.Compaction
@@ -49,7 +45,6 @@ import Control.Monad.Trans.Except
     , withExceptT
     )
 import Data.IORef (IORef, newIORef, readIORef, writeIORef)
-import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
 
@@ -94,53 +89,31 @@ compactOpenAI
     -> Int
     -> Maybe Text
     -> ExceptT Text IO CompactOutcome
-compactOpenAI tokenProvider params history before focus = do
+compactOpenAI =
+    compactOpenAIWith OpenAI.createCodexMessageWithProvider
+
+compactOpenAIWith
+    :: (TokenProvider -> ResponseCreateParams -> IO (Either ApiError Response))
+    -> Maybe TokenProvider
+    -> ResponseCreateParams
+    -> [ResponseItem]
+    -> Int
+    -> Maybe Text
+    -> ExceptT Text IO CompactOutcome
+compactOpenAIWith send tokenProvider params history before focus = do
     provider <- requireTokenProvider OpenAIProvider tokenProvider
-    requireHistory history
-    let model = fromMaybe "gpt-5.6-luna" params.model
-        focusedHistory = case focus of
-            Just text | not (Text.null (Text.strip text)) ->
-                history
-                    <> [ userTextItem
-                            ( "Compaction focus from the user: "
-                                <> Text.strip text
-                            )
-                       ]
-            _ -> history
-        request =
-            CompactRequest
-                { compactModel = model
-                , compactInput = focusedHistory
-                , compactInstructions = params.instructions
-                , compactTools = params.tools
-                , compactParallelToolCalls =
-                    fromMaybe True params.parallelToolCalls
-                , compactReasoning = params.reasoning
-                }
-    remoteResult <- lift (compactConversation provider request)
-    case remoteResult of
-        Right items ->
-            pure CompactOutcome
-                { compactBeforeTokens = before
-                , compactAfterTokens = estimateItemsTokens items
-                , compactHistory = items
-                , compactSummary =
-                    "remote compact returned "
-                        <> Text.pack (show (length items))
-                        <> " items"
-                }
-        Left remoteError
-            | shouldFallbackFromRemoteCompact remoteError ->
-                withExceptT (formatFallbackError remoteError) $
-                    summarizeLocal
-                        OpenAI.createCodexMessageWithProvider
-                        provider
-                        params
-                        history
-                        before
-                        focus
-            | otherwise ->
-                throwE (formatApiError remoteError)
+    -- The default OpenAI transport uses the ChatGPT Codex backend. Its normal
+    -- /responses endpoint is available, but /responses/compact returns 404.
+    -- Compact locally without first paying for a known-failing HTTP request.
+    -- Agent.OpenAI.CompactClient remains available to callers targeting an
+    -- API-compatible host that implements the remote compact endpoint.
+    summarizeLocal
+        send
+        provider
+        params
+        history
+        before
+        focus
 
 compactLocalXai
     :: Maybe TokenProvider
@@ -290,36 +263,6 @@ providerLabel = \case
     OpenAIProvider -> "openai"
     XAIProvider -> "xai"
     OpenRouterProvider -> "openrouter"
-
--- | The remote compact endpoint can be unavailable or reject payloads/models
--- that the normal Responses endpoint accepts. Fall back locally for those
--- endpoint-specific failures, but preserve terminal account, policy, quota,
--- and context-window failures.
-shouldFallbackFromRemoteCompact :: ApiError -> Bool
-shouldFallbackFromRemoteCompact = \case
-    ConnectionError{} -> True
-    JsonDecodeError{} -> True
-    HttpError status _ ->
-        status `elem` [400, 404, 408, 409, 413, 422, 425]
-            || (status >= 500 && status < 600)
-    ProviderError errorType _ _ ->
-        errorType `elem`
-            [ NotFoundError
-            , PreviousResponseNotFound
-            , ApiErrorType
-            , OverloadedError
-            , ServiceUnavailableError
-            , PayloadTooLargeError
-            , WebSocketConnectionLimitReached
-            ]
-    CredentialsExhausted{} -> False
-
-formatFallbackError :: ApiError -> Text -> Text
-formatFallbackError remoteError localError =
-    "remote compact failed: "
-        <> formatApiError remoteError
-        <> "; local fallback failed: "
-        <> localError
 
 formatApiError :: ApiError -> Text
 formatApiError err = Text.pack (show err)

--- a/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
@@ -4,15 +4,21 @@ import Agent.CLI.Compaction
     ( CompactOutcome(..)
     , autoCompactOpenAiBackendWith
     , codexAutoCompactTokenLimit
+    , compactOpenAIWith
     , runProviderCompact
-    , shouldFallbackFromRemoteCompact
     )
-import Agent.Error (ApiError(..), ErrorType(..))
 import Agent.Loop
-import Agent.OpenAI.Compaction (userTextItem)
-import Agent.Responses.Types (defaultResponseCreateParams)
+import Agent.OpenAI.Compaction
+    ( hasCompactionCheckpoint
+    , userTextItem
+    )
+import Agent.Responses.Types
+import qualified Data.Aeson as Aeson
+import Data.Aeson ((.=))
 import Agent.Provider (Provider(..), TokenProvider(..))
 import Data.IORef
+import Control.Monad.Trans.Except (runExceptT)
+import Data.Text (Text)
 import Test.Hspec
 
 spec :: Spec
@@ -36,28 +42,32 @@ spec = do
             runProviderCompact OpenAIProvider (Just provider) params transcript Nothing
                 `shouldReturn` Left "nothing to compact"
 
-    describe "shouldFallbackFromRemoteCompact" do
-        it "falls back when the remote compact endpoint returns Not Found" do
-            shouldFallbackFromRemoteCompact
-                (ProviderError NotFoundError "Not Found" Nothing)
-                `shouldBe` True
-            shouldFallbackFromRemoteCompact
-                (HttpError 404 "{\"detail\":\"Not Found\"}")
-                `shouldBe` True
-
-        it "does not mask account, quota, or context-window failures" do
-            shouldFallbackFromRemoteCompact
-                (ProviderError AuthenticationError "expired" Nothing)
-                `shouldBe` False
-            shouldFallbackFromRemoteCompact
-                (ProviderError InvalidRequestError "bio_policy" Nothing)
-                `shouldBe` False
-            shouldFallbackFromRemoteCompact
-                (ProviderError UsageLimitReached "limit" Nothing)
-                `shouldBe` False
-            shouldFallbackFromRemoteCompact
-                (ProviderError ContextWindowExceeded "too long" Nothing)
-                `shouldBe` False
+    describe "compactOpenAIWith" do
+        it "uses normal Responses summarization directly" do
+            requests <- newIORef []
+            let provider = TokenProvider \_ ->
+                    error "local summarization unexpectedly requested credentials"
+                send _ request = do
+                    modifyIORef' requests (<> [request])
+                    pure (Right (summaryResponse "local summary"))
+                history = [userTextItem "old context"]
+            result <- runExceptT $
+                compactOpenAIWith send
+                    (Just provider)
+                    defaultResponseCreateParams
+                    history
+                    100
+                    Nothing
+            case result of
+                Left err -> expectationFailure (show err)
+                Right outcome -> do
+                    outcome.compactSummary `shouldBe` "local summary"
+                    outcome.compactHistory
+                        `shouldSatisfy` hasCompactionCheckpoint
+            seen <- readIORef requests
+            length seen `shouldBe` 1
+            map (.tools) seen `shouldBe` [Nothing]
+            map (.parallelToolCalls) seen `shouldBe` [Just False]
 
     describe "autoCompactOpenAiBackendWith" do
         it "compacts before the next request at the Codex token limit" do
@@ -97,3 +107,26 @@ spec = do
                 Just (25, length compactedHistory)
             readIORef events `shouldReturn`
                 [ActivityUpdated "Compacting context…"]
+
+summaryResponse :: Text -> Response
+summaryResponse summary =
+    case Aeson.fromJSON $ Aeson.object
+        [ "id" .= ("resp-summary" :: Text)
+        , "created_at" .= (0 :: Int)
+        , "status" .= ("completed" :: Text)
+        , "model" .= ("gpt-test" :: Text)
+        , "output" .=
+            [ Aeson.object
+                [ "type" .= ("message" :: Text)
+                , "role" .= ("assistant" :: Text)
+                , "content" .=
+                    [ Aeson.object
+                        [ "type" .= ("output_text" :: Text)
+                        , "text" .= summary
+                        ]
+                    ]
+                ]
+            ]
+        ] of
+        Aeson.Success response -> response
+        Aeson.Error err -> error err


### PR DESCRIPTION
## Summary
- compact OpenAI ChatGPT/Codex sessions directly through the normal Responses summarization path
- stop probing the unsupported ChatGPT backend `/responses/compact` route before every compaction
- keep the standalone remote compact client available for API-compatible hosts that implement the endpoint
- replace fallback-classifier tests with a regression test for direct local summarization

## Validation
- `git diff --check`
- loaded and ran `agent-cli:test:agent-cli-test` in GHCi: 443 examples, 0 failures