### PR TITLE
Fix fullscreen composer link hitboxes

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -1371,20 +1371,20 @@ drawComposer appState =
                 else hBox
                     (txt " " : intersperse (txt " · ") labelWidgets <> [txt " "])
         editor =
-            padLeftRight 1 $
-                hBox
-                    [ withAttr
-                        (if focused then Theme.borderActiveAttr else Theme.mutedAttr)
-                        (txt "❯ ")
-                    , withAttr Theme.assistantAttr (renderDraft focused state)
-                    , vLimit 1 (fill ' ')
-                    ]
+            clickable ComposerArea $
+                padLeftRight 1 $
+                    hBox
+                        [ withAttr
+                            (if focused then Theme.borderActiveAttr else Theme.mutedAttr)
+                            (txt "❯ ")
+                        , withAttr Theme.assistantAttr (renderDraft focused state)
+                        , vLimit 1 (fill ' ')
+                        ]
         composer =
             withBorderStyle unicodeRounded $
                 borderWithLabel (withAttr Theme.footerAttr label) $
                     editor
-    in clickable ComposerArea $
-        overrideAttr Border.borderAttr attr composer
+    in overrideAttr Border.borderAttr attr composer
   where
     state = appState.appUi
 
@@ -1815,6 +1815,11 @@ handleEvent event = case event of
         | isInteractiveControl name
         , button == Just V.BLeft || button == Nothing ->
             handleControlMouseUp name (activateControl name)
+    MouseUp _ Nothing _ ->
+        modify' \state ->
+            state
+                { appHoveredControl = Nothing
+                }
     VtyEvent (V.EvMouseDown _ _ V.BLeft _) ->
         modify' \state ->
             state


### PR DESCRIPTION
## Summary
- restrict the fullscreen composer-area hitbox to the editor body instead of the bordered status row
- clear stale control hover when pointer motion lands on a non-control region
- keep the model, effort, and mode controls independently clickable

## Validation
- loaded `Agent.CLI.TUI.App` in the Nix `cabal repl` environment
- exercised the live fullscreen UI in tmux
- confirmed hovering the effort control highlights only its text and moving left clears the hover immediately
- confirmed the model selector remains clickable
- `git diff --check`