### PR TITLE
Raise development GHCi heap cap to 2 GiB

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,7 +97,7 @@ When changing the CLI UI (prompt, colors, chrome, keybindings, paste, approval p
 
 ### memory / RTS heap cap
 
-`nix develop` and the `repl` wrapper default `GHCRTS` to `-M1G -A64m` so the agent/GHCi process dies at a 1 GiB heap instead of OOMing the whole machine. The `agent-cli` executable retains a separate `-M8G -A64m` RTS default (overridable via `+RTS` because `-rtsopts` is enabled). Override when needed:
+`nix develop` and the `repl` wrapper default `GHCRTS` to `-M2G -A64m` so the agent/GHCi process dies at a 2 GiB heap instead of OOMing the whole machine. The `agent-cli` executable retains a separate `-M8G -A64m` RTS default (overridable via `+RTS` because `-rtsopts` is enabled). Override when needed:
 
 ```
 GHCRTS='-M16G -A64m' repl

--- a/flake.nix
+++ b/flake.nix
@@ -160,7 +160,7 @@
                     # Cap the agent/GHCi heap so a runaway session OOMs itself
                     # instead of the whole machine. Override with GHCRTS=...
                     if [ -z "''${GHCRTS:-}" ]; then
-                      export GHCRTS="-M1G -A64m"
+                      export GHCRTS="-M2G -A64m"
                     fi
                     cabal="${haskellPackages.cabal-install}/bin/cabal"
                     expect_bin="${pkgs.expect}/bin/expect"
@@ -231,7 +231,7 @@
                     # `repl` wrapper sets the same default if GHCRTS is unset.
                     shellHook = ''
                       if [ -z "''${GHCRTS:-}" ]; then
-                        export GHCRTS="-M1G -A64m"
+                        export GHCRTS="-M2G -A64m"
                       fi
                     '';
                 };


### PR DESCRIPTION
## Summary

- raise the `nix develop` default `GHCRTS` ceiling from 1 GiB to 2 GiB
- apply the same default to the `repl` wrapper
- update the development documentation

## Verification

- loaded the full multi-package GHCi session under the inherited `-M2G -A64m` default
- evaluated `putStrLn "MULTI_PACKAGE_REPL_OK"` successfully
- process exited with status 0 and no heap overflow
- `git diff --check` passes