### PR TITLE
Scope the development heap cap to the REPL wrapper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,7 +97,12 @@ When changing the CLI UI (prompt, colors, chrome, keybindings, paste, approval p
 
 ### memory / RTS heap cap
 
-`nix develop` and the `repl` wrapper default `GHCRTS` to `-M2G -A64m` so the agent/GHCi process dies at a 2 GiB heap instead of OOMing the whole machine. The `agent-cli` executable retains a separate `-M8G -A64m` RTS default (overridable via `+RTS` because `-rtsopts` is enabled). Override when needed:
+`nix develop` does not impose a heap ceiling on every development command. The
+`repl` wrapper defaults `GHCRTS` to `-M8G -A64m`, which leaves enough room for
+the multi-package GHCi session while protecting the machine from an unbounded
+long-running agent. The compiled `agent-cli` executable has the same 8 GiB RTS
+default, overridable via `+RTS` because `-rtsopts` is enabled. Set `GHCRTS`
+explicitly to override the wrapper:
 
 ```
 GHCRTS='-M16G -A64m' repl

--- a/flake.nix
+++ b/flake.nix
@@ -157,10 +157,10 @@
                       echo "repl: missing $script" >&2
                       exit 1
                     fi
-                    # Cap the agent/GHCi heap so a runaway session OOMs itself
-                    # instead of the whole machine. Override with GHCRTS=...
+                    # Cap the long-running GHCi/agent process without forcing
+                    # every command in nix develop to inherit the same limit.
                     if [ -z "''${GHCRTS:-}" ]; then
-                      export GHCRTS="-M2G -A64m"
+                      export GHCRTS="-M8G -A64m"
                     fi
                     cabal="${haskellPackages.cabal-install}/bin/cabal"
                     expect_bin="${pkgs.expect}/bin/expect"
@@ -226,14 +226,6 @@
                             ripgrep
                         ])
                         ++ [ agentRepl ];
-                    # Default RTS heap ceiling for GHCi / agent runs started from
-                    # this shell (including `cabal repl` and `cabal run`). The
-                    # `repl` wrapper sets the same default if GHCRTS is unset.
-                    shellHook = ''
-                      if [ -z "''${GHCRTS:-}" ]; then
-                        export GHCRTS="-M2G -A64m"
-                      fi
-                    '';
                 };
 
                 checks = {


### PR DESCRIPTION
## Summary

- stop exporting `GHCRTS` from the general `nix develop` shell
- retain an 8 GiB safety ceiling for the dedicated `repl` wrapper
- leave the compiled `agent-cli` executable's existing 8 GiB cap unchanged
- document how to override the wrapper cap explicitly

## Verification

- confirmed `GHCRTS` is unset in a fresh `nix develop` shell
- confirmed the generated `repl` wrapper defaults to `-M8G -A64m`
- loaded the `agent-cli` and `agent-tui` multi-home GHCi session under the 8 GiB cap
- evaluated `putStrLn "MULTI_HOME_REPL_8G_OK"` successfully
- `git diff --check` passes