### PR TITLE
style(cli): round user message corners

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -1049,8 +1049,7 @@ drawBlock state block =
         highlighted = selected && state.uiFocus == FocusScrollback
         content = case block.blockKind of
             BlockUser ->
-                withAttr Theme.userAttr $
-                    padAll 1 (txtWrap block.blockBody)
+                roundedFill Theme.userAttr (txtWrap block.blockBody)
             BlockAssistant ->
                 padLeft (Pad 3) $
                     withAttr Theme.assistantAttr
@@ -1090,6 +1089,14 @@ drawBlock state block =
                 block.blockExpanded)
             rendered
         else rendered
+
+roundedFill :: AttrName -> Widget Name -> Widget Name
+roundedFill attr body =
+    vBox
+        [ padLeftRight 1 (withAttr attr (vLimit 1 (fill ' ')))
+        , withAttr attr (padLeftRight 1 body)
+        , padLeftRight 1 (withAttr attr (vLimit 1 (fill ' ')))
+        ]
 
 cacheableBlock :: UiBlock -> Bool
 cacheableBlock block =

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -56,7 +56,8 @@ import Brick.BChan
     , newBChan
     , writeBChan
     )
-import Brick.Widgets.Border (borderWithLabel)
+import Brick.Widgets.Border (border, borderWithLabel)
+import qualified Brick.Widgets.Border as Border
 import Brick.Widgets.Border.Style (unicodeRounded)
 import Brick.Widgets.Center (centerLayer)
 import Control.Concurrent.Async (wait, waitCatch, withAsync)
@@ -1055,7 +1056,7 @@ drawBlock color state block =
                 if color
                     then roundedFill
                         Theme.userAttr
-                        Theme.userCornerAttr
+                        Theme.userBorderAttr
                         (txtWrap block.blockBody)
                     else
                         withAttr Theme.userAttr $
@@ -1101,20 +1102,11 @@ drawBlock color state block =
         else rendered
 
 roundedFill :: AttrName -> AttrName -> Widget Name -> Widget Name
-roundedFill fillAttr cornerAttr body =
-    vBox
-        [ roundedRow '▗' '▖'
-        , withAttr fillAttr (padLeftRight 1 body)
-        , roundedRow '▝' '▘'
-        ]
-  where
-    roundedRow left right =
-        vLimit 1 $
-            hBox
-                [ withAttr cornerAttr (txt (Text.singleton left))
-                , withAttr fillAttr (fill ' ')
-                , withAttr cornerAttr (txt (Text.singleton right))
-                ]
+roundedFill fillAttr userBorderAttr body =
+    overrideAttr Border.borderAttr userBorderAttr $
+        withBorderStyle unicodeRounded $
+            border $
+                withAttr fillAttr (padLeftRight 1 body)
 
 cacheableBlock :: UiBlock -> Bool
 cacheableBlock block =

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -920,7 +920,10 @@ drawWorkspace state =
         hBox $
             [ withVScrollBars OnRight $
                 viewport ConversationViewport Vertical $
-                    padLeftRight 2 (drawTranscript state.appUi)
+                    padLeftRight 2 $
+                        drawTranscript
+                            state.appRuntime.runtimeColor
+                            state.appUi
             ]
                 <> if length state.appAgentEntries <= 1
                     then []
@@ -1032,24 +1035,31 @@ spinnerFrame frame =
     ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
         !! (frame `mod` 10)
 
-drawTranscript :: UiState -> Widget Name
-drawTranscript state
+drawTranscript :: Bool -> UiState -> Widget Name
+drawTranscript color state
     | null blocks =
         withAttr Theme.mutedAttr $
             padTop (Pad 2) $
                 txt "Start by describing what you want to build or change."
     | otherwise =
-        vBox (map (drawBlock state) blocks)
+        vBox (map (drawBlock color state) blocks)
   where
     blocks = toList state.uiBlocks
 
-drawBlock :: UiState -> UiBlock -> Widget Name
-drawBlock state block =
+drawBlock :: Bool -> UiState -> UiBlock -> Widget Name
+drawBlock color state block =
     let selected = state.uiSelectedBlock == Just block.blockId
         highlighted = selected && state.uiFocus == FocusScrollback
         content = case block.blockKind of
             BlockUser ->
-                roundedFill Theme.userAttr (txtWrap block.blockBody)
+                if color
+                    then roundedFill
+                        Theme.userAttr
+                        Theme.userCornerAttr
+                        (txtWrap block.blockBody)
+                    else
+                        withAttr Theme.userAttr $
+                            padAll 1 (txtWrap block.blockBody)
             BlockAssistant ->
                 padLeft (Pad 3) $
                     withAttr Theme.assistantAttr
@@ -1090,13 +1100,21 @@ drawBlock state block =
             rendered
         else rendered
 
-roundedFill :: AttrName -> Widget Name -> Widget Name
-roundedFill attr body =
+roundedFill :: AttrName -> AttrName -> Widget Name -> Widget Name
+roundedFill fillAttr cornerAttr body =
     vBox
-        [ padLeftRight 1 (withAttr attr (vLimit 1 (fill ' ')))
-        , withAttr attr (padLeftRight 1 body)
-        , padLeftRight 1 (withAttr attr (vLimit 1 (fill ' ')))
+        [ roundedRow '▗' '▖'
+        , withAttr fillAttr (padLeftRight 1 body)
+        , roundedRow '▝' '▘'
         ]
+  where
+    roundedRow left right =
+        vLimit 1 $
+            hBox
+                [ withAttr cornerAttr (txt (Text.singleton left))
+                , withAttr fillAttr (fill ' ')
+                , withAttr cornerAttr (txt (Text.singleton right))
+                ]
 
 cacheableBlock :: UiBlock -> Bool
 cacheableBlock block =

--- a/packages/agent-cli/src/Agent/CLI/TUI/Theme.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Theme.hs
@@ -22,6 +22,7 @@ module Agent.CLI.TUI.Theme
     , thinkingAttr
     , toolAttr
     , userAttr
+    , userCornerAttr
     , monochrome
     , solarizedDark
     ) where
@@ -31,7 +32,7 @@ import Data.Bits ((.|.))
 import qualified Graphics.Vty as V
 
 baseAttr, headerAttr, footerAttr, mutedAttr :: AttrName
-userAttr, assistantAttr, thinkingAttr, toolAttr :: AttrName
+userAttr, userCornerAttr, assistantAttr, thinkingAttr, toolAttr :: AttrName
 errorAttr, successAttr, selectedAttr, borderAttr, borderActiveAttr :: AttrName
 headingAttr, codeAttr, emphasisAttr, inlineCodeAttr, linkAttr, strongAttr :: AttrName
 controlLinkAttr, controlLinkHoverAttr, controlLinkActiveAttr :: AttrName
@@ -40,6 +41,7 @@ headerAttr = attrName "header"
 footerAttr = attrName "footer"
 mutedAttr = attrName "muted"
 userAttr = attrName "user"
+userCornerAttr = attrName "user-corner"
 assistantAttr = attrName "assistant"
 thinkingAttr = attrName "thinking"
 toolAttr = attrName "tool"
@@ -79,6 +81,9 @@ solarizedDark =
         , (userAttr, V.defAttr
             `V.withForeColor` rgb 147 161 161
             `V.withBackColor` rgb 7 54 66)
+        , (userCornerAttr, V.defAttr
+            `V.withForeColor` rgb 7 54 66
+            `V.withBackColor` rgb 0 43 54)
         , (assistantAttr, V.defAttr
             `V.withForeColor` rgb 131 148 150
             `V.withBackColor` rgb 0 43 54)
@@ -147,6 +152,7 @@ monochrome =
         , (footerAttr, V.defAttr)
         , (mutedAttr, V.defAttr)
         , (userAttr, V.defAttr `V.withStyle` V.bold)
+        , (userCornerAttr, V.defAttr)
         , (assistantAttr, V.defAttr)
         , (thinkingAttr, V.defAttr)
         , (toolAttr, V.defAttr)

--- a/packages/agent-cli/src/Agent/CLI/TUI/Theme.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Theme.hs
@@ -22,7 +22,7 @@ module Agent.CLI.TUI.Theme
     , thinkingAttr
     , toolAttr
     , userAttr
-    , userCornerAttr
+    , userBorderAttr
     , monochrome
     , solarizedDark
     ) where
@@ -32,7 +32,7 @@ import Data.Bits ((.|.))
 import qualified Graphics.Vty as V
 
 baseAttr, headerAttr, footerAttr, mutedAttr :: AttrName
-userAttr, userCornerAttr, assistantAttr, thinkingAttr, toolAttr :: AttrName
+userAttr, userBorderAttr, assistantAttr, thinkingAttr, toolAttr :: AttrName
 errorAttr, successAttr, selectedAttr, borderAttr, borderActiveAttr :: AttrName
 headingAttr, codeAttr, emphasisAttr, inlineCodeAttr, linkAttr, strongAttr :: AttrName
 controlLinkAttr, controlLinkHoverAttr, controlLinkActiveAttr :: AttrName
@@ -41,7 +41,7 @@ headerAttr = attrName "header"
 footerAttr = attrName "footer"
 mutedAttr = attrName "muted"
 userAttr = attrName "user"
-userCornerAttr = attrName "user-corner"
+userBorderAttr = attrName "user-border"
 assistantAttr = attrName "assistant"
 thinkingAttr = attrName "thinking"
 toolAttr = attrName "tool"
@@ -81,7 +81,7 @@ solarizedDark =
         , (userAttr, V.defAttr
             `V.withForeColor` rgb 147 161 161
             `V.withBackColor` rgb 7 54 66)
-        , (userCornerAttr, V.defAttr
+        , (userBorderAttr, V.defAttr
             `V.withForeColor` rgb 7 54 66
             `V.withBackColor` rgb 0 43 54)
         , (assistantAttr, V.defAttr
@@ -152,7 +152,7 @@ monochrome =
         , (footerAttr, V.defAttr)
         , (mutedAttr, V.defAttr)
         , (userAttr, V.defAttr `V.withStyle` V.bold)
-        , (userCornerAttr, V.defAttr)
+        , (userBorderAttr, V.defAttr)
         , (assistantAttr, V.defAttr)
         , (thinkingAttr, V.defAttr)
         , (toolAttr, V.defAttr)


### PR DESCRIPTION
## Summary
- render filled user-message blocks with smooth rounded box-drawing corners (`╭`, `╮`, `╰`, `╯`)
- color the rounded outline to merge with the message fill
- preserve the existing message wrapping, selection behavior, and monochrome fallback

## Verification
- loaded `agent-cli:lib:agent-cli` successfully in GHCi via `nix develop`
- exercised the fullscreen CLI in tmux and confirmed the smooth rounded outline and filled interior render correctly
- `git diff --check`