### PR TITLE
Add Thinking Machines models to selector

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Models.hs
+++ b/packages/agent-cli/src/Agent/CLI/Models.hs
@@ -62,6 +62,8 @@ modelsForProvider provider =
                 ]
             OpenRouterProvider ->
                 [ opt "openai/gpt-5.1" (Just "default")
+                , opt "thinkingmachines/inkling:free" (Just "free")
+                , opt "thinkingmachines/inkling-small:free" (Just "free · faster")
                 , opt "anthropic/claude-sonnet-4" Nothing
                 , opt "x-ai/grok-4" Nothing
                 , opt "google/gemini-2.5-pro" Nothing

--- a/packages/agent-cli/test/Agent/CLI/ModelsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ModelsSpec.hs
@@ -26,6 +26,14 @@ spec = do
         it "lists the gpt-5.6 series for OpenAI" do
             let ids = map (.modelId) (modelsForProvider OpenAIProvider)
             ids `shouldBe` ["gpt-5.6-luna", "gpt-5.6-terra", "gpt-5.6-sol"]
+
+        it "lists Thinking Machines models for OpenRouter" do
+            let ids = map (.modelId) (modelsForProvider OpenRouterProvider)
+            ids `shouldContain`
+                [ "thinkingmachines/inkling:free"
+                , "thinkingmachines/inkling-small:free"
+                ]
+
         it "lists several options per provider" do
             length (modelsForProvider XAIProvider) `shouldSatisfy` (>= 2)
             length (modelsForProvider OpenAIProvider) `shouldSatisfy` (>= 2)


### PR DESCRIPTION
## Summary
- add Thinking Machines Inkling to the OpenRouter model selector
- add the faster Inkling Small variant
- cover both OpenRouter model IDs in the model catalog tests

## Testing
- `nix develop -c cabal repl agent-cli:test:agent-cli-test` (`:main`): 433 examples, 0 failures
- verified both entries render in the fullscreen model picker in tmux
- `git diff --check`
