### PR TITLE
Add copy buttons to fullscreen code blocks

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Artifact.hs
+++ b/packages/agent-cli/src/Agent/CLI/Artifact.hs
@@ -16,8 +16,8 @@ fencedBlocks = go . Text.lines
     go (line:rest) =
         case fenceStart line of
             Nothing -> go rest
-            Just language ->
-                let (body, remaining) = break isFenceEnd rest
+            Just (marker, language) ->
+                let (body, remaining) = break (isFenceEnd marker) rest
                     after = case remaining of
                         [] -> []
                         (_:xs) -> xs
@@ -25,11 +25,20 @@ fencedBlocks = go . Text.lines
 
     fenceStart line =
         let stripped = Text.stripStart line
+            opening marker =
+                Just
+                    ( marker
+                    , Text.toLower (Text.strip (Text.drop 3 stripped))
+                    )
         in if "```" `Text.isPrefixOf` stripped
-            then Just (Text.toLower (Text.strip (Text.drop 3 stripped)))
-            else Nothing
+            then opening '`'
+            else if "~~~" `Text.isPrefixOf` stripped
+                then opening '~'
+                else Nothing
 
-    isFenceEnd line = "```" `Text.isPrefixOf` Text.stripStart line
+    isFenceEnd marker line =
+        Text.replicate 3 (Text.singleton marker)
+            `Text.isPrefixOf` Text.stripStart line
 
 fencedCodeBlock :: Int -> Text -> Maybe Text
 fencedCodeBlock index text

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -21,6 +21,7 @@ import Agent.CLI.Clipboard
     ( nonEmptyClipboardImages
     , readClipboardImages
     )
+import Agent.CLI.Artifact (fencedCodeBlock)
 import Agent.CLI.Input
     ( ReplLine(..)
     , appendReplHistory
@@ -45,7 +46,10 @@ import Agent.CLI.Render (formatElapsed, summarizeToolCall)
 import Agent.CLI.Status (formatTokenUsage)
 import qualified Agent.TUI.Theme as Theme
 import qualified Agent.CLI.TUI.Bridge as Bridge
-import Agent.TUI.Markdown (markdownWidget)
+import Agent.TUI.Markdown
+    ( markdownWidget
+    , markdownWidgetWithCodeControls
+    )
 import qualified Agent.CLI.TUI.Scroll as Scroll
 import Agent.TUI.Model
 import Agent.Loop (LoopEvent(..))
@@ -106,7 +110,12 @@ data Name
     | ConversationReserve
     | OverlayViewport
     | ConversationBlock !BlockId
-    | ConversationBlockCache !BlockId !Bool !Bool
+    | ConversationBlockCache
+        !BlockId
+        !Bool
+        !Bool
+        !(Maybe (Int, Bool))
+    | CodeCopy !BlockId !Int
     | ComposerArea
     | ComposerCursor
     | ComposerModel
@@ -756,6 +765,8 @@ activateControl = \case
         handlePromptControlClick ReplCycleMode
     ChoiceRow index ->
         confirmChoiceAt index
+    CodeCopy blockId codeIndex ->
+        copyCodeBlock blockId codeIndex
     _ ->
         pure ()
 
@@ -765,7 +776,42 @@ isInteractiveControl = \case
     ComposerEffort -> True
     ComposerMode -> True
     ChoiceRow _ -> True
+    CodeCopy _ _ -> True
     _ -> False
+
+copyCodeBlock :: BlockId -> Int -> EventM Name AppState ()
+copyCodeBlock blockId codeIndex = do
+    state <- get
+    let code =
+            selectedBlock state.appUi blockId
+                >>= fencedCodeBlock codeIndex . (.blockBody)
+    case code of
+        Nothing ->
+            modify' \current ->
+                current
+                    { appUi =
+                        reduceUi
+                            (UiSetNotice
+                                (Just
+                                    (warningNotice
+                                        "Code block is no longer available.")))
+                            current.appUi
+                    }
+        Just payload -> do
+            copied <- liftIO (state.appRuntime.runtimeCopy payload)
+            modify' \current ->
+                current
+                    { appUi =
+                        reduceUi
+                            (UiSetNotice
+                                (Just
+                                    (if copied
+                                        then successNotice
+                                            "Copied code block."
+                                        else warningNotice
+                                            "Terminal clipboard is unavailable.")))
+                            current.appUi
+                    }
 
 resolveChoice :: Bool -> EventM Name AppState ()
 resolveChoice confirmed = do
@@ -919,10 +965,7 @@ drawWorkspace state =
         hBox $
             [ withVScrollBars OnRight $
                 viewport ConversationViewport Vertical $
-                    padLeftRight 2
-                        (drawTranscript
-                            state.appUi
-                            state.appConversationAnchor)
+                    padLeftRight 2 (drawTranscript state)
             ]
                 <> if length state.appAgentEntries <= 1
                     then []
@@ -1049,11 +1092,8 @@ spinnerFrame frame =
     ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
         !! (frame `mod` 10)
 
-drawTranscript
-    :: UiState
-    -> Maybe Scroll.ConversationAnchor
-    -> Widget Name
-drawTranscript state anchor
+drawTranscript :: AppState -> Widget Name
+drawTranscript state
     | null blocks =
         withAttr Theme.mutedAttr $
             padTop (Pad 2) $
@@ -1063,7 +1103,8 @@ drawTranscript state anchor
             [vBox (map (drawBlock state) blocks)]
                 <> conversationReserveWidgets anchor
   where
-    blocks = toList state.uiBlocks
+    blocks = toList state.appUi.uiBlocks
+    anchor = state.appConversationAnchor
 
 stickyPromptLayers :: AppState -> [Widget Name]
 stickyPromptLayers state =
@@ -1103,10 +1144,11 @@ conversationReserveWidgets = \case
             ]
     _ -> []
 
-drawBlock :: UiState -> UiBlock -> Widget Name
+drawBlock :: AppState -> UiBlock -> Widget Name
 drawBlock state block =
-    let selected = state.uiSelectedBlock == Just block.blockId
-        highlighted = selected && state.uiFocus == FocusScrollback
+    let ui = state.appUi
+        selected = ui.uiSelectedBlock == Just block.blockId
+        highlighted = selected && ui.uiFocus == FocusScrollback
         content = case block.blockKind of
             BlockUser ->
                 withAttr Theme.userAttr $
@@ -1114,22 +1156,24 @@ drawBlock state block =
             BlockAssistant ->
                 padLeft (Pad 3) $
                     withAttr Theme.assistantAttr
-                        (markdownWidget block.blockBody)
+                        (markdownWidgetWithCodeControls
+                            (codeBlockHeader state block.blockId)
+                            block.blockBody)
             BlockThinking ->
                 accentBlock Theme.thinkingAttr
-                    (blockStateGlyph state block <> block.blockTitle)
+                    (blockStateGlyph ui block <> block.blockTitle)
                     (visibleBody block)
             BlockTool ->
                 accentBlock (statusAttr block.blockState)
-                    (blockStateGlyph state block <> block.blockTitle <> detailSuffix block)
+                    (blockStateGlyph ui block <> block.blockTitle <> detailSuffix block)
                     (visibleBody block)
             BlockShell ->
                 accentBlock (statusAttr block.blockState)
-                    (blockStateGlyph state block <> block.blockTitle <> detailSuffix block)
+                    (blockStateGlyph ui block <> block.blockTitle <> detailSuffix block)
                     (visibleShellBody block)
             BlockEdit ->
                 accentBlock (statusAttr block.blockState)
-                    (blockStateGlyph state block <> block.blockTitle <> detailSuffix block)
+                    (blockStateGlyph ui block <> block.blockTitle <> detailSuffix block)
                     (visibleBody block)
             BlockSystem ->
                 withAttr Theme.mutedAttr (txtWrap block.blockBody)
@@ -1155,9 +1199,37 @@ drawBlock state block =
             (ConversationBlockCache
                 block.blockId
                 highlighted
-                block.blockExpanded)
+                block.blockExpanded
+                (codeCopyCacheState state block.blockId))
             rendered
         else rendered
+
+codeBlockHeader :: AppState -> BlockId -> Int -> Text -> Widget Name
+codeBlockHeader state blockId codeIndex language =
+    hBox
+        [ if Text.null language
+            then emptyWidget
+            else withAttr Theme.mutedAttr (txt language)
+        , vLimit 1 (fill ' ')
+        , clickable name $
+            withAttr
+                (controlAttr state name Theme.controlLinkAttr)
+                (txt " Copy ")
+        ]
+  where
+    name = CodeCopy blockId codeIndex
+
+codeCopyCacheState :: AppState -> BlockId -> Maybe (Int, Bool)
+codeCopyCacheState state blockId =
+    case state.appHoveredControl of
+        Just (CodeCopy hoveredBlock codeIndex)
+            | hoveredBlock == blockId ->
+                Just
+                    ( codeIndex
+                    , state.appPressedControl
+                        == Just (CodeCopy blockId codeIndex)
+                    )
+        _ -> Nothing
 
 cacheableBlock :: UiBlock -> Bool
 cacheableBlock block =
@@ -1775,6 +1847,8 @@ handleEvent event = case event of
                         handleControlMouseDown ComposerEffort
                     (ComposerMode, V.BLeft) ->
                         handleControlMouseDown ComposerMode
+                    (CodeCopy blockId codeIndex, V.BLeft) ->
+                        handleControlMouseDown (CodeCopy blockId codeIndex)
                     (SlashRow index, V.BLeft) ->
                         activateSlashAt index
                     (SlashRow _, V.BScrollUp) ->

--- a/packages/agent-cli/test/Agent/CLI/ArtifactSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ArtifactSpec.hs
@@ -12,6 +12,10 @@ spec = do
             fencedCodeBlock 2 text `shouldBe` Just "echo ok\n"
             fencedCodeBlock 3 text `shouldBe` Nothing
 
+        it "matches tilde fences shown by the fullscreen renderer" do
+            let text = "~~~bash\nprintf 'copy me\\n'\n~~~\n"
+            fencedCodeBlock 1 text `shouldBe` Just "printf 'copy me\\n'\n"
+
     describe "lastDiffBlock" do
         it "selects the last diff-like fence" do
             let text = "```diff\n-old\n+new\n```\n```patch\n-a\n+b\n```\n"

--- a/packages/agent-tui/agent-tui.cabal
+++ b/packages/agent-tui/agent-tui.cabal
@@ -54,5 +54,6 @@ test-suite agent-tui-test
     build-depends:    agent-tui
                     , agent-core
                     , base >= 4.17 && < 5
+                    , brick >= 2.9 && < 3
                     , hspec >= 2.11 && < 2.12
                     , text

--- a/packages/agent-tui/src/Agent/TUI/Markdown.hs
+++ b/packages/agent-tui/src/Agent/TUI/Markdown.hs
@@ -4,6 +4,7 @@ module Agent.TUI.Markdown
     , InlineStyle(..)
     , inlinePlainText
     , markdownWidget
+    , markdownWidgetWithCodeControls
     , parseInline
     ) where
 
@@ -72,55 +73,73 @@ data InlineSpan = InlineSpan
     deriving (Eq, Show)
 
 markdownWidget :: Text -> Widget n
-markdownWidget input =
-    vBox (renderLines False (Text.lines input))
+markdownWidget =
+    markdownWidgetWithCodeControls \_ language ->
+        if Text.null language
+            then emptyWidget
+            else withAttr Theme.mutedAttr (txt language)
 
-renderLines :: Bool -> [Text] -> [Widget n]
-renderLines _ [] = []
-renderLines False lines_
+-- | Render Markdown, allowing callers to add an interactive control to each
+-- fenced code block header. Code block indices are one-based.
+markdownWidgetWithCodeControls
+    :: (Int -> Text -> Widget n)
+    -> Text
+    -> Widget n
+markdownWidgetWithCodeControls codeHeader input =
+    vBox (renderLines codeHeader 1 False (Text.lines input))
+
+renderLines
+    :: (Int -> Text -> Widget n)
+    -> Int
+    -> Bool
+    -> [Text]
+    -> [Widget n]
+renderLines _ _ _ [] = []
+renderLines codeHeader codeIndex False lines_
     | Just (table, rest) <- takeTable lines_ =
-        table : renderLines False rest
-renderLines inFence (line : rest)
+        table : renderLines codeHeader codeIndex False rest
+renderLines codeHeader codeIndex inFence (line : rest)
     | isFence line =
         let language = Text.strip (Text.drop 3 (Text.stripStart line))
-            label
-                | inFence || Text.null language = []
-                | otherwise =
-                    [withAttr Theme.mutedAttr (txt language)]
-        in label <> renderLines (not inFence) rest
+        in if inFence
+            then renderLines codeHeader codeIndex False rest
+            else
+                codeHeader codeIndex language
+                    : renderLines codeHeader (codeIndex + 1) True rest
     | inFence =
         withAttr Theme.codeAttr
             (padLeftRight 1 (txt line))
-            : renderLines True rest
+            : renderLines codeHeader codeIndex True rest
     | Just heading <- stripHeading line =
         withAttr Theme.headingAttr
             (padTop (Pad 1) (inlineWidget (parseInline heading)))
-            : renderLines False rest
+            : renderLines codeHeader codeIndex False rest
     | Just item <- stripBullet line =
         hBox
             [ withAttr Theme.headingAttr (txt "• ")
             , inlineWidget (parseInline item)
             ]
-            : renderLines False rest
+            : renderLines codeHeader codeIndex False rest
     | Just (number, item) <- stripOrdered line =
         hBox
             [ withAttr Theme.headingAttr (txt (number <> ". "))
             , inlineWidget (parseInline item)
             ]
-            : renderLines False rest
+            : renderLines codeHeader codeIndex False rest
     | Just quote <- Text.stripPrefix "> " (Text.stripStart line) =
         hBox
             [ withAttr Theme.mutedAttr (txt "│ ")
             , withAttr Theme.mutedAttr (inlineWidget (parseInline quote))
             ]
-            : renderLines False rest
+            : renderLines codeHeader codeIndex False rest
     | Text.null (Text.strip line) =
-        txt " " : renderLines False rest
+        txt " " : renderLines codeHeader codeIndex False rest
     | isThematicBreak line =
         withAttr Theme.mutedAttr (fill '─')
-            : renderLines False rest
+            : renderLines codeHeader codeIndex False rest
     | otherwise =
-        inlineWidget (parseInline line) : renderLines False rest
+        inlineWidget (parseInline line)
+            : renderLines codeHeader codeIndex False rest
 
 isFence :: Text -> Bool
 isFence line =

--- a/packages/agent-tui/test/Agent/TUI/MarkdownSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/MarkdownSpec.hs
@@ -1,6 +1,8 @@
 module Agent.TUI.MarkdownSpec (spec) where
 
 import Agent.TUI.Markdown
+import Brick (Widget, renderWidget, txt)
+import Data.List (isInfixOf)
 import qualified Data.Text as Text
 import Test.Hspec
 
@@ -34,3 +36,14 @@ spec = describe "fullscreen Markdown inline parsing" do
         let input = Text.replicate 10000 "a"
         parseInline input
             `shouldBe` [InlineSpan InlinePlain input]
+
+    it "renders numbered controls for fenced code block headers" do
+        let widget :: Widget ()
+            widget =
+                markdownWidgetWithCodeControls
+                    (\index language ->
+                        txt (Text.pack (show index) <> ":" <> language))
+                    "```bash\none\n```\n\n~~~haskell\ntwo\n~~~"
+            rendered = show (renderWidget Nothing [widget] (40, 12))
+        rendered `shouldSatisfy` isInfixOf "1:bash"
+        rendered `shouldSatisfy` isInfixOf "2:haskell"


### PR DESCRIPTION
## Summary

- add a clickable Copy control to each fenced code block in the fullscreen transcript
- copy the selected fence body through the existing terminal clipboard integration
- support both backtick and tilde fences and show success/failure notices
- keep code-block control rendering reusable in the shared `agent-tui` markdown package

## Testing

- `nix develop -c cabal repl agent-tui:test:agent-tui-test` (`:main`): 27 examples, 0 failures
- `nix develop -c cabal repl agent-cli:test:agent-cli-test` (`:main`): 433 examples, 0 failures
- live tmux fullscreen smoke test: verified the Copy control renders, accepts a mouse click, and shows `Copied code block.`
