### PR TITLE
Fix automatic REPL launcher after TUI extraction

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,10 @@ When changing the CLI UI (prompt, colors, chrome, keybindings, paste, approval p
 - `repl` / `devMain` creates a new worktree on first open when not already under `~/.haskell-agent/worktrees`. `:reload` resumes the same session (and cwd). Manual `run` still needs `withArgs ["--worktree"]` (or `--resume` / `--cwd`) if you want a worktree.
 - The development entry point restores GHCi's original cwd when the agent exits, so a later fresh run does not silently reuse the previous worktree.
 - `cabal repl agent-cli:exe:agent-cli` + `:main` looks convenient but only interprets `Main.hs` and does **not** reload library source changes.
+- Keep the automatic `repl` launcher single-component. With GHC 9.10,
+  Cabal's multi-home-unit mode does not support the GHCi `:module` and `:cmd`
+  commands that its automatic reload/resume loop uses. Use the manual
+  multi-package workflow above when editing dependency packages.
 - Use `ghcid` for typecheck-on-save; keep `cabal repl` + `withArgs ... run` for running the live agent.
 - Prefer `repl` when you want automatic `:reload` + session resume instead of the manual `:q` / `:r` / `run` loop.
 

--- a/flake.nix
+++ b/flake.nix
@@ -147,6 +147,10 @@
 
                 # Opens cabal repl on the agent-cli library and enters the
                 # GHCi :cmd loop that reloads + resumes after agent :reload.
+                # Keep this single-component: GHC 9.10 multi-home-unit mode
+                # does not support the :module or :cmd commands used below.
+                # Use the documented manual multi-package REPL when editing
+                # agent-tui or another dependency alongside agent-cli.
                 # expect waits for modules to load, then starts the agent
                 # (ghci scripts run before cabal loads the package).
                 agentRepl = pkgs.writeShellScriptBin "repl" ''
@@ -170,7 +174,7 @@
                       set timeout -1
                       set cabal $env(AGENT_REPL_CABAL)
                       set script $env(AGENT_REPL_SCRIPT)
-                      spawn -noecho $cabal repl lib:agent-cli lib:agent-tui --repl-options=-ghci-script=$script
+                      spawn -noecho $cabal repl lib:agent-cli --repl-options=-ghci-script=$script
                       expect {
                         -re {Ok, [0-9]+ modules? loaded\.} {}
                         eof {


### PR DESCRIPTION
## Summary

- keep the automatic `repl` launcher on the single `agent-cli` component
- avoid GHC 9.10 multi-home-unit mode, where the launcher's `:module` and `:cmd` commands are unsupported
- document that dependency changes should use the manual multi-package REPL workflow

## Verification

- reproduced the failure with `lib:agent-cli lib:agent-tui` under GHC 9.10.3
- confirmed single-component GHCi accepts the `:module` / `:cmd` continuation
- live tmux smoke test: `repl` reached the fullscreen agent prompt without the multi-mode error
- live tmux reload test: `:reload` recompiled the 51 loaded modules and resumed the same development session
- `git diff --check`
