### PR TITLE
Resume agent turns after connectivity returns

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -45,6 +45,7 @@ library
                     , Agent.CLI.CancelWatch
                     , Agent.CLI.Clipboard
                     , Agent.CLI.Compaction
+                    , Agent.CLI.Connectivity
                     , Agent.CLI.Command
                     , Agent.CLI.CredentialStore
                     , Agent.CLI.ImagePreview
@@ -138,6 +139,7 @@ test-suite agent-cli-test
                     , Agent.CLI.ClipboardSpec
                     , Agent.CLI.CommandSpec
                     , Agent.CLI.CompactionSpec
+                    , Agent.CLI.ConnectivitySpec
                     , Agent.CLI.CredentialStoreSpec
                     , Agent.CLI.ImagePreviewSpec
                     , Agent.CLI.InputSpec

--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -66,6 +66,7 @@ import Agent.CLI.Compaction
     , autoCompactOpenAiBackend
     , runProviderCompact
     )
+import Agent.CLI.Connectivity (withConnectionRecovery)
 import Agent.CLI.ImagePreview
     ( detectImagePreviewProtocol
     , previewColumnsFor
@@ -1018,7 +1019,8 @@ runAgentInitialized options transition home root resumed cwd startup = do
                                             transcriptRef
                                             contextTokensRef
                                     noticingBackend =
-                                        withPendingInputs pendingNotices lockedBackend
+                                        withPendingInputs pendingNotices $
+                                            withConnectionRecovery lockedBackend
                                     btwBackend privateParams privateTranscript =
                                         freshOpenAiBackend
                                             loaded.loadedTokenProvider
@@ -1053,8 +1055,9 @@ runAgentInitialized options transition home root resumed cwd startup = do
                             Nothing -> pure ()
                         let backend =
                                 withPendingInputs pendingNotices $
-                                    xaiBackend xaiOptions loaded.loadedTokenProvider
-                                        (readIORef paramsRef) transcriptRef
+                                    withConnectionRecovery $
+                                        xaiBackend xaiOptions loaded.loadedTokenProvider
+                                            (readIORef paramsRef) transcriptRef
                             btwBackend privateParams privateTranscript =
                                 xaiBackend xaiOptions loaded.loadedTokenProvider
                                     (readIORef privateParams) privateTranscript
@@ -1077,8 +1080,9 @@ runAgentInitialized options transition home root resumed cwd startup = do
                             Nothing -> pure ()
                         let backend =
                                 withPendingInputs pendingNotices $
-                                    openRouterBackend openRouterOptions loaded.loadedTokenProvider
-                                        (readIORef paramsRef) transcriptRef
+                                    withConnectionRecovery $
+                                        openRouterBackend openRouterOptions loaded.loadedTokenProvider
+                                            (readIORef paramsRef) transcriptRef
                             btwBackend privateParams privateTranscript =
                                 openRouterBackend openRouterOptions loaded.loadedTokenProvider
                                     (readIORef privateParams) privateTranscript

--- a/packages/agent-cli/src/Agent/CLI/Connectivity.hs
+++ b/packages/agent-cli/src/Agent/CLI/Connectivity.hs
@@ -1,0 +1,82 @@
+-- | Keep a provider submission alive while the machine is offline.
+--
+-- Recovery wraps one 'Backend' submission rather than an entire agent turn.
+-- If a connection drops after tools have run, the loop can therefore retry
+-- the exact model continuation without executing those tools again.
+module Agent.CLI.Connectivity
+    ( reconnectDelayMicros
+    , withConnectionRecovery
+    , withConnectionRecoveryUsing
+    ) where
+
+import Agent.Error (ApiError(..))
+import Agent.Loop (Backend(..), LoopEvent(..))
+import Control.Concurrent (threadDelay)
+import Control.Monad (when)
+import Data.IORef (newIORef, readIORef, writeIORef)
+import Data.Text (Text)
+import qualified Data.Text as Text
+
+-- | Retry after 1s, 2s, 4s, 8s, then every 15s while offline.
+reconnectDelayMicros :: Int -> Int
+reconnectDelayMicros attempt =
+    case max 1 attempt of
+        1 -> 1_000_000
+        2 -> 2_000_000
+        3 -> 4_000_000
+        4 -> 8_000_000
+        _ -> 15_000_000
+
+-- | Automatically retry connection failures until the submission succeeds or
+-- its owner cancels it. 'runLoopInputs' races every backend submission against
+-- the session cancel flag, so the sleep and all retries remain scoped to the
+-- current turn.
+withConnectionRecovery :: Backend -> Backend
+withConnectionRecovery =
+    withConnectionRecoveryUsing
+        (threadDelay . reconnectDelayMicros)
+
+-- | Injectable variant used by tests.
+--
+-- Retrying stops once response text/reasoning has streamed. Replaying after
+-- visible output could duplicate it; those rare mid-stream failures continue
+-- through the existing error path instead.
+withConnectionRecoveryUsing
+    :: (Int -> IO ())
+    -> Backend
+    -> Backend
+withConnectionRecoveryUsing waitBeforeRetry (Backend submit) =
+    Backend \previous inputs onEvent ->
+        let go attempt = do
+                streamed <- newIORef False
+                result <- submit previous inputs \event -> do
+                    when (isStreamOutput event) (writeIORef streamed True)
+                    onEvent event
+                didStream <- readIORef streamed
+                case result of
+                    Left ConnectionError{}
+                        | not didStream -> do
+                            onEvent (ActivityUpdated (waitingMessage attempt))
+                            waitBeforeRetry attempt
+                            onEvent
+                                (ActivityUpdated
+                                    "Checking internet connection…")
+                            go (attempt + 1)
+                    _ -> pure result
+        in go 1
+
+isStreamOutput :: LoopEvent -> Bool
+isStreamOutput = \case
+    TextDelta _ -> True
+    ReasoningDelta _ -> True
+    _ -> False
+
+waitingMessage :: Int -> Text
+waitingMessage attempt =
+    "Connection lost; waiting for internet. Retrying automatically in "
+        <> formatDelay (reconnectDelayMicros attempt)
+        <> " (Esc or Ctrl-C to cancel)…"
+
+formatDelay :: Int -> Text
+formatDelay micros =
+    Text.pack (show ((micros + 999_999) `div` 1_000_000)) <> "s"

--- a/packages/agent-cli/test/Agent/CLI/ConnectivitySpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ConnectivitySpec.hs
@@ -1,0 +1,115 @@
+module Agent.CLI.ConnectivitySpec (spec) where
+
+import Agent.CLI.Connectivity
+    ( reconnectDelayMicros
+    , withConnectionRecoveryUsing
+    )
+import Agent.CLI.PendingInputs (withPendingInputs)
+import Agent.Error (ApiError(..))
+import Agent.Loop
+    ( Backend(..)
+    , LoopEvent(..)
+    , TurnInput(..)
+    , emptyTurnOutput
+    )
+import Data.IORef
+import Test.Hspec
+
+spec :: Spec
+spec = describe "withConnectionRecovery" do
+    it "retries the same submission until connectivity returns" do
+        attempts <- newIORef (0 :: Int)
+        waits <- newIORef []
+        seen <- newIORef []
+        events <- newIORef []
+        let backend = withConnectionRecoveryUsing
+                (\attempt -> modifyIORef' waits (<> [attempt]))
+                (Backend \previous inputs _ -> do
+                    modifyIORef' seen (<> [(previous, inputs)])
+                    attempt <- atomicModifyIORef' attempts \n -> (n + 1, n + 1)
+                    pure $
+                        if attempt < 3
+                            then Left (ConnectionError "offline")
+                            else Right (emptyTurnOutput "response" [] (Just "done")))
+            inputs = [UserMessage "continue"]
+        result <- backend.submitTurn (Just "previous") inputs
+            (\event -> modifyIORef' events (<> [event]))
+
+        result `shouldBe`
+            Right (emptyTurnOutput "response" [] (Just "done"))
+        readIORef waits `shouldReturn` [1, 2]
+        readIORef seen `shouldReturn`
+            [ (Just "previous", inputs)
+            , (Just "previous", inputs)
+            , (Just "previous", inputs)
+            ]
+        readIORef events `shouldReturn`
+            [ ActivityUpdated
+                "Connection lost; waiting for internet. Retrying automatically in 1s (Esc or Ctrl-C to cancel)…"
+            , ActivityUpdated "Checking internet connection…"
+            , ActivityUpdated
+                "Connection lost; waiting for internet. Retrying automatically in 2s (Esc or Ctrl-C to cancel)…"
+            , ActivityUpdated "Checking internet connection…"
+            ]
+
+    it "does not retry non-connection provider errors" do
+        waits <- newIORef []
+        let expected = HttpError 503 "unavailable"
+            backend = withConnectionRecoveryUsing
+                (\attempt -> modifyIORef' waits (<> [attempt]))
+                (Backend \_ _ _ -> pure (Left expected))
+        result <- backend.submitTurn Nothing [] (const (pure ()))
+        result `shouldBe` Left expected
+        readIORef waits `shouldReturn` []
+
+    it "does not replay a submission after visible output streamed" do
+        attempts <- newIORef (0 :: Int)
+        waits <- newIORef []
+        let backend = withConnectionRecoveryUsing
+                (\attempt -> modifyIORef' waits (<> [attempt]))
+                (Backend \_ _ onEvent -> do
+                    modifyIORef' attempts (+ 1)
+                    onEvent (TextDelta "partial")
+                    pure (Left (ConnectionError "dropped")))
+        result <- backend.submitTurn Nothing [] (const (pure ()))
+        result `shouldBe` Left (ConnectionError "dropped")
+        readIORef attempts `shouldReturn` 1
+        readIORef waits `shouldReturn` []
+
+    it "does not duplicate queued inputs across reconnect attempts" do
+        attempts <- newIORef (0 :: Int)
+        pending <- newIORef [UserMessage "queued"]
+        seen <- newIORef []
+        let backend =
+                withPendingInputs pending $
+                    withConnectionRecoveryUsing
+                        (const (pure ()))
+                        (Backend \_ inputs _ -> do
+                            modifyIORef' seen (<> [inputs])
+                            attempt <- atomicModifyIORef' attempts
+                                \n -> (n + 1, n + 1)
+                            pure $
+                                if attempt == 1
+                                    then Left (ConnectionError "offline")
+                                    else Right
+                                        (emptyTurnOutput
+                                            "response" [] (Just "done")))
+            expected = [UserMessage "queued", UserMessage "current"]
+        result <- backend.submitTurn Nothing [UserMessage "current"]
+            (const (pure ()))
+        result `shouldBe`
+            Right (emptyTurnOutput "response" [] (Just "done"))
+        readIORef seen `shouldReturn` [expected, expected]
+        readIORef pending `shouldReturn` []
+
+    it "backs off to a bounded polling interval" do
+        map reconnectDelayMicros [1 .. 7]
+            `shouldBe`
+                [ 1_000_000
+                , 2_000_000
+                , 4_000_000
+                , 8_000_000
+                , 15_000_000
+                , 15_000_000
+                , 15_000_000
+                ]

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -12,6 +12,7 @@ import qualified Agent.CLI.CancelWatchSpec as CancelWatchSpec
 import qualified Agent.CLI.ClipboardSpec as ClipboardSpec
 import qualified Agent.CLI.CommandSpec as CommandSpec
 import qualified Agent.CLI.CompactionSpec as CompactionSpec
+import qualified Agent.CLI.ConnectivitySpec as ConnectivitySpec
 import qualified Agent.CLI.CredentialStoreSpec as CredentialStoreSpec
 import qualified Agent.CLI.ImagePreviewSpec as ImagePreviewSpec
 import qualified Agent.CLI.InputSpec as InputSpec
@@ -60,6 +61,7 @@ main = hspec do
     ClipboardSpec.spec
     CommandSpec.spec
     CompactionSpec.spec
+    ConnectivitySpec.spec
     CredentialStoreSpec.spec
     ImagePreviewSpec.spec
     InputSpec.spec


### PR DESCRIPTION
## Summary

- retry connection failures automatically until the provider is reachable again
- resume the exact failed provider submission so completed tools are not executed twice
- surface reconnect status in minimal and fullscreen modes for OpenAI, xAI, and OpenRouter
- preserve queued inputs and stop replaying once visible output has streamed

## Behavior

Retries use a bounded 1s, 2s, 4s, 8s, then 15s polling interval. The existing turn cancellation scope keeps the retry loop structured and lets users stop it with Esc or Ctrl-C.

## Testing

- `printf 'main\n:q\n' | nix develop -c cabal repl agent-cli:test:agent-cli-test` — 439 examples, 0 failures
- live fullscreen TTY smoke test in tmux with a successful OpenAI provider turn
- `git diff --check`
