### PR TITLE
Fix Shift+Enter rendering raw escape sequences

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -169,6 +169,7 @@ test-suite agent-cli-test
                     , Agent.CLI.SkillsSpec
                     , Agent.CLI.SubagentStoreSpec
                     , Agent.CLI.ToolsSpec
+                    , Agent.CLI.TUIAppSpec
                     , Agent.CLI.TUIBridgeSpec
                     , Agent.CLI.TUIScrollSpec
                     , Agent.CLI.UsageSpec

--- a/packages/agent-cli/src/Agent/CLI/Input.hs
+++ b/packages/agent-cli/src/Agent/CLI/Input.hs
@@ -18,6 +18,7 @@ module Agent.CLI.Input
     , formatPasteChip
     , isClipboardPasteCsiBody
     , isClipboardPasteKey
+    , isShiftEnterCsiBody
     , appendReplHistory
     , readReplHistory
     , replHistoryPath
@@ -48,6 +49,7 @@ import Agent.CLI.Terminal
     , emitTerminalSequence
     , kittyKeyboardDisambiguatePush
     , kittyKeyboardPop
+    , shiftEnterCsiBodies
     )
 import Agent.Loop (ImageAttachment)
 import Control.Exception.Safe (bracket, bracket_, catchIO, throwIO, tryIO)
@@ -790,6 +792,9 @@ isClipboardPasteCsiBody body =
                         || hasModifier kittySuper kittyModifiers)
         _ -> False
 
+isShiftEnterCsiBody :: String -> Bool
+isShiftEnterCsiBody body = body `elem` shiftEnterCsiBodies
+
 readEscapeKey :: IO EditorKey
 readEscapeKey = do
     ready <- hWaitForInput stdin 25
@@ -823,6 +828,7 @@ readCsiKey =
     readCsiBody >>= \case
         Left err -> pure (EditorInputError err)
         Right body
+            | isShiftEnterCsiBody body -> pure (EditorChar '\n')
             | Just key <- decodeKittyEditorKey body -> pure key
             | otherwise -> case body of
                 "A" -> pure EditorUp

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -13,6 +13,7 @@ module Agent.CLI.TUI.App
     , requestFullscreenChoiceWithBody
     , requestFullscreenText
     , runFullscreen
+    , fullscreenVtyConfig
     , setFullscreenWindowTitle
     , withFullscreenSuspended
     ) where
@@ -44,6 +45,7 @@ import Agent.CLI.Permission (PermissionChoice(..))
 import Agent.CLI.Options (reasoningEfforts)
 import Agent.CLI.Render (formatElapsed, summarizeToolCall)
 import Agent.CLI.Status (formatTokenUsage)
+import Agent.CLI.Terminal (shiftEnterCsiBodies)
 import qualified Agent.TUI.Theme as Theme
 import qualified Agent.CLI.TUI.Bridge as Bridge
 import Agent.TUI.Markdown
@@ -330,6 +332,22 @@ readFullscreenLine runtime skills prompt initial = do
                 Nothing -> UiSetAwaitingInput False
     pure input.fullscreenInputLine
 
+-- | Fullscreen Vty configuration, including enhanced-keyboard encodings that
+-- are not present in the default terminfo input table. Without these entries,
+-- Vty emits the payload of Shift+Enter sequences as printable characters.
+fullscreenVtyConfig :: V.VtyUserConfig
+fullscreenVtyConfig =
+    V.defaultConfig
+        { V.configPreferredColorMode = Just V.FullColor
+        , V.configInputMap =
+            [ ( Nothing
+              , "\ESC[" <> body
+              , V.EvKey V.KEnter [V.MShift]
+              )
+            | body <- shiftEnterCsiBodies
+            ]
+        }
+
 requestFullscreenPermission
     :: FullscreenRuntime
     -> ToolCall
@@ -384,12 +402,8 @@ runFullscreen :: FullscreenRuntime -> IO a -> IO a
 runFullscreen runtime workerAction = do
     history <- readReplHistory
     (initialAgent, initialAgents) <- runtime.runtimeAgentSnapshot
-    let vtyConfig =
-            V.defaultConfig
-                { V.configPreferredColorMode = Just V.FullColor
-                }
-        buildVty = do
-            vty <- Vty.mkVty vtyConfig
+    let buildVty = do
+            vty <- Vty.mkVty fullscreenVtyConfig
             let output = V.outputIface vty
             -- Without this mode terminals paste image clipboard fallbacks
             -- (paths, URLs, or other text representations) as ordinary key

--- a/packages/agent-cli/src/Agent/CLI/Terminal.hs
+++ b/packages/agent-cli/src/Agent/CLI/Terminal.hs
@@ -15,6 +15,7 @@ module Agent.CLI.Terminal
     , osc133CommandFinished
     , synchronizedOutputBegin
     , synchronizedOutputEnd
+    , shiftEnterCsiBodies
     , kittyKeyboardDisambiguatePush
     , kittyKeyboardPush
     , kittyKeyboardPop
@@ -164,6 +165,17 @@ osc133CommandFinished exitCode =
 synchronizedOutputBegin, synchronizedOutputEnd :: Text
 synchronizedOutputBegin = "\ESC[?2026h"
 synchronizedOutputEnd = "\ESC[?2026l"
+
+-- | CSI bodies used by enhanced-keyboard protocols for Shift+Enter.
+--
+-- Xterm's modifyOtherKeys protocol uses @CSI 27;2;13~@, while Kitty's
+-- keyboard protocol (also implemented by Ghostty and WezTerm) uses
+-- @CSI 13;2u@.
+shiftEnterCsiBodies :: [String]
+shiftEnterCsiBodies =
+    [ "27;2;13~"
+    , "13;2u"
+    ]
 
 -- | Push only Kitty's unambiguous-key flag. This is enough for an inline
 -- editor to receive modified keys such as Cmd+V without also receiving key

--- a/packages/agent-cli/test/Agent/CLI/InputSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/InputSpec.hs
@@ -10,6 +10,7 @@ import Agent.CLI.Input
     , formatPasteChip
     , isClipboardPasteCsiBody
     , isClipboardPasteKey
+    , isShiftEnterCsiBody
     , parseChoiceKey
     , replHistoryPath
     , terminalTextWidth
@@ -129,3 +130,9 @@ spec = do
             isClipboardPasteCsiBody "99;9u" `shouldBe` False
             isClipboardPasteCsiBody "118;9:3u" `shouldBe` False
             isClipboardPasteCsiBody "not-a-key" `shouldBe` False
+
+    describe "Shift+Enter" do
+        it "recognizes xterm modifyOtherKeys and Kitty CSI-u encodings" do
+            isShiftEnterCsiBody "27;2;13~" `shouldBe` True
+            isShiftEnterCsiBody "13;2u" `shouldBe` True
+            isShiftEnterCsiBody "13u" `shouldBe` False

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -1,0 +1,21 @@
+module Agent.CLI.TUIAppSpec (spec) where
+
+import Agent.CLI.TUI.App (fullscreenVtyConfig)
+import qualified Graphics.Vty as V
+import Test.Hspec
+
+spec :: Spec
+spec =
+    describe "fullscreenVtyConfig" do
+        it "maps enhanced-keyboard Shift+Enter sequences before Vty decodes them" do
+            V.configInputMap fullscreenVtyConfig
+                `shouldMatchList`
+                    [ ( Nothing
+                      , "\ESC[27;2;13~"
+                      , V.EvKey V.KEnter [V.MShift]
+                      )
+                    , ( Nothing
+                      , "\ESC[13;2u"
+                      , V.EvKey V.KEnter [V.MShift]
+                      )
+                    ]

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -43,6 +43,7 @@ import qualified Agent.CLI.StyleSpec as StyleSpec
 import qualified Agent.CLI.TimestampSpec as TimestampSpec
 import qualified Agent.CLI.TerminalSpec as TerminalSpec
 import qualified Agent.CLI.ToolsSpec as ToolsSpec
+import qualified Agent.CLI.TUIAppSpec as TUIAppSpec
 import qualified Agent.CLI.TUIBridgeSpec as TUIBridgeSpec
 import qualified Agent.CLI.TUIScrollSpec as TUIScrollSpec
 import qualified Agent.CLI.UsageSpec as UsageSpec
@@ -91,6 +92,7 @@ main = hspec do
     SkillsSpec.spec
     SubagentStoreSpec.spec
     ToolsSpec.spec
+    TUIAppSpec.spec
     TUIBridgeSpec.spec
     TUIScrollSpec.spec
     UsageSpec.spec


### PR DESCRIPTION
## Summary

- map xterm `modifyOtherKeys` and Kitty CSI-u Shift+Enter sequences in the fullscreen Vty configuration
- recognize the same sequences in the inline prompt editor
- add regression coverage for both input paths

## Testing

- `nix develop -c cabal repl agent-cli:test:agent-cli-test`, then `:main` — 436 examples, 0 failures
- live tmux smoke test injecting `ESC [27;2;13~` — inserted a newline between `alpha` and `beta` without rendering escape bytes
