### PR TITLE
Fix Markdown breaks in conversation viewport

### DIFF
--- a/packages/agent-tui/src/Agent/TUI/Markdown.hs
+++ b/packages/agent-tui/src/Agent/TUI/Markdown.hs
@@ -135,7 +135,7 @@ renderLines codeHeader codeIndex inFence (line : rest)
     | Text.null (Text.strip line) =
         txt " " : renderLines codeHeader codeIndex False rest
     | isThematicBreak line =
-        withAttr Theme.mutedAttr (fill '─')
+        withAttr Theme.mutedAttr (vLimit 1 (fill '─'))
             : renderLines codeHeader codeIndex False rest
     | otherwise =
         inlineWidget (parseInline line)

--- a/packages/agent-tui/test/Agent/TUI/MarkdownSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/MarkdownSpec.hs
@@ -1,7 +1,13 @@
 module Agent.TUI.MarkdownSpec (spec) where
 
 import Agent.TUI.Markdown
-import Brick (Widget, renderWidget, txt)
+import Brick
+    ( ViewportType(..)
+    , Widget
+    , renderWidget
+    , txt
+    , viewport
+    )
 import Data.List (isInfixOf)
 import qualified Data.Text as Text
 import Test.Hspec
@@ -47,3 +53,11 @@ spec = describe "fullscreen Markdown inline parsing" do
             rendered = show (renderWidget Nothing [widget] (40, 12))
         rendered `shouldSatisfy` isInfixOf "1:bash"
         rendered `shouldSatisfy` isInfixOf "2:haskell"
+
+    it "renders thematic breaks inside a vertical viewport" do
+        let widget :: Widget ()
+            widget =
+                viewport () Vertical $
+                    markdownWidget "---\n\n***\n\n___"
+            rendered = show (renderWidget Nothing [widget] (40, 12))
+        rendered `shouldSatisfy` (not . null)


### PR DESCRIPTION
## Summary
- constrain Markdown thematic breaks to a single row
- prevent greedy-height widgets from entering the vertical conversation viewport
- add a regression test covering `---`, `***`, and `___` inside a Brick viewport

## Verification
- `nix develop -c cabal repl agent-tui:test:agent-tui-test` followed by `:main` (28 examples, 0 failures)
- live tmux smoke test: resumed session `2026-08-20-0ea578fc`, which contains Markdown thematic breaks, and confirmed the fullscreen TUI rendered without the viewport exception