### PR TITLE
Fix transparent fullscreen image previews

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TUI/ImagePreview.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/ImagePreview.hs
@@ -10,7 +10,8 @@ import Brick (Widget, raw)
 import Codec.Picture
     ( Image
     , PixelRGB8(..)
-    , convertRGB8
+    , PixelRGBA8(..)
+    , convertRGBA8
     , decodeImage
     , imageHeight
     , imageWidth
@@ -19,6 +20,7 @@ import Codec.Picture
 import qualified Data.ByteString as BS
 import Data.Text (Text)
 import qualified Data.Text as Text
+import Data.Word (Word8)
 import qualified Graphics.Vty as V
 
 data PreviewCell = PreviewCell
@@ -41,7 +43,7 @@ data TuiImagePreview = TuiImagePreview
 prepareTuiImagePreview :: ImageAttachment -> Either Text TuiImagePreview
 prepareTuiImagePreview ImageAttachment{imageMime, imageBytes} = do
     dynamic <- firstText (decodeImage imageBytes)
-    let image = convertRGB8 dynamic
+    let image = convertRGBA8 dynamic
         sourceWidth = imageWidth image
         sourceHeight = imageHeight image
         (targetWidth, targetHeight) =
@@ -93,7 +95,7 @@ previewSize width height
            , max 1 (floor (fromIntegral height * scale))
            )
 
-sampleCells :: Image PixelRGB8 -> Int -> Int -> [[PreviewCell]]
+sampleCells :: Image PixelRGBA8 -> Int -> Int -> [[PreviewCell]]
 sampleCells image targetWidth targetHeight =
     [ [ PreviewCell
             { cellTop = samplePixel image targetWidth targetHeight x topY
@@ -107,14 +109,14 @@ sampleCells image targetWidth targetHeight =
     ]
 
 samplePixel
-    :: Image PixelRGB8
+    :: Image PixelRGBA8
     -> Int
     -> Int
     -> Int
     -> Int
     -> PixelRGB8
 samplePixel image targetWidth targetHeight x y =
-    pixelAt image sourceX sourceY
+    compositePixel previewBackground (pixelAt image sourceX sourceY)
   where
     sourceX =
         min (imageWidth image - 1)
@@ -122,6 +124,31 @@ samplePixel image targetWidth targetHeight x y =
     sourceY =
         min (imageHeight image - 1)
             (y * imageHeight image `div` targetHeight)
+
+-- Transparent PNG pixels can retain arbitrary RGB data. Dropping alpha with
+-- 'convertRGB8' exposes those hidden colours as bright smears, so composite
+-- onto the fullscreen canvas before rendering the sampled terminal cells.
+compositePixel :: PixelRGB8 -> PixelRGBA8 -> PixelRGB8
+compositePixel
+    (PixelRGB8 backgroundRed backgroundGreen backgroundBlue)
+    (PixelRGBA8 red green blue alpha) =
+        PixelRGB8
+            (blend red backgroundRed alpha)
+            (blend green backgroundGreen alpha)
+            (blend blue backgroundBlue alpha)
+
+blend :: Word8 -> Word8 -> Word8 -> Word8
+blend foreground background alpha =
+    fromIntegral $
+        ( fromIntegral foreground * alpha'
+            + fromIntegral background * (255 - alpha')
+            + 127
+        ) `div` 255
+  where
+    alpha' = fromIntegral alpha :: Int
+
+previewBackground :: PixelRGB8
+previewBackground = PixelRGB8 0 43 54
 
 maxPreviewColumns :: Int
 maxPreviewColumns = 24

--- a/packages/agent-cli/test/Agent/CLI/TUIImagePreviewSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIImagePreviewSpec.hs
@@ -5,7 +5,12 @@ import Agent.CLI.TUI.ImagePreview
     , prepareTuiImagePreview
     )
 import Agent.Loop (ImageAttachment(..))
-import Codec.Picture (PixelRGB8(..), encodePng, generateImage)
+import Codec.Picture
+    ( PixelRGB8(..)
+    , PixelRGBA8(..)
+    , encodePng
+    , generateImage
+    )
 import qualified Data.ByteString.Lazy as LBS
 import Test.Hspec
 
@@ -33,6 +38,34 @@ spec =
                     preview.previewSourceHeight `shouldBe` 2
                     length preview.previewCells `shouldBe` 1
                     map length preview.previewCells `shouldBe` [4]
+
+        it "composites alpha instead of exposing hidden transparent RGB" do
+            let transparentSource =
+                    generateImage
+                        (\x _ ->
+                            if x == 0
+                                then PixelRGBA8 255 0 255 0
+                                else PixelRGBA8 255 255 255 128)
+                        2
+                        1
+                compositedSource =
+                    generateImage
+                        (\x _ ->
+                            if x == 0
+                                then PixelRGB8 0 43 54
+                                else PixelRGB8 128 149 155)
+                        2
+                        1
+                attachment source = ImageAttachment
+                    { imageMime = "image/png"
+                    , imageBytes = LBS.toStrict (encodePng source)
+                    }
+                transparentPreview =
+                    prepareTuiImagePreview (attachment transparentSource)
+                compositedPreview =
+                    prepareTuiImagePreview (attachment compositedSource)
+            (.previewCells) <$> transparentPreview
+                `shouldBe` (.previewCells) <$> compositedPreview
 
         it "rejects invalid image bytes without crashing the TUI" do
             prepareTuiImagePreview


### PR DESCRIPTION
## Root cause

The retained fullscreen thumbnail path decoded pasted images with `convertRGB8`. For PNGs with transparency, that drops the alpha channel and exposes arbitrary RGB values stored behind transparent pixels. Those hidden colors rendered as the bright blurred strip in the reported screenshot.

The non-fullscreen terminal image protocol already preserved PNG alpha, so the regression was isolated to the recently added Brick/Vty preview path.

## Fix

- decode fullscreen thumbnails as RGBA
- composite every sampled pixel over the Solarized fullscreen background before rendering it as a terminal cell
- add regression coverage for fully transparent hidden RGB and partially transparent pixels

## Verification

- GHCi: `445 examples, 0 failures`
- live tmux TTY smoke test using a 48×24 fully transparent PNG with a hidden RGB gradient
  - image attached successfully through `/paste`
  - all preview cells rendered uniformly as the fullscreen background
  - no hidden gradient colors were emitted
