### PR TITLE
Fix streaming for local compaction requests

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Compaction.hs
+++ b/packages/agent-cli/src/Agent/CLI/Compaction.hs
@@ -171,6 +171,9 @@ summarizeLocal send provider params history before focus = do
             ResponseCreateParams
                 { tools = Nothing
                 , parallelToolCalls = Just False
+                -- The ChatGPT Codex REST endpoint only accepts streaming
+                -- Responses requests, and this client decodes its SSE result.
+                , stream = Just True
                 , ..
                 }
         request =

--- a/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
@@ -54,7 +54,7 @@ spec = do
             result <- runExceptT $
                 compactOpenAIWith send
                     (Just provider)
-                    defaultResponseCreateParams
+                    defaultResponseCreateParams { stream = Just False }
                     history
                     100
                     Nothing
@@ -68,6 +68,7 @@ spec = do
             length seen `shouldBe` 1
             map (.tools) seen `shouldBe` [Nothing]
             map (.parallelToolCalls) seen `shouldBe` [Just False]
+            map (.stream) seen `shouldBe` [Just True]
 
     describe "autoCompactOpenAiBackendWith" do
         it "compacts before the next request at the Codex token limit" do


### PR DESCRIPTION
## Summary

- force local compaction summaries to use streaming Responses requests
- avoid the ChatGPT Codex REST rejection when session parameters leave `stream` unset or false
- add a regression assertion that compaction overrides `stream = false`

## Root cause

The ChatGPT Codex REST `/responses` endpoint requires `stream = true`. Local compaction reused the session's request parameters, where `stream` could be unset or false, causing automatic compaction to fail with `Stream must be set to true`.

## Test plan

- Loaded `agent-cli:test:agent-cli-test` in GHCi through `nix develop`
- Ran `Agent.CLI.CompactionSpec.spec`: 4 examples, 0 failures
- Ran the changed agent in a real tmux TTY, completed a live Codex turn, then ran `/compact` successfully: `compacted 2460 → 2742 tokens (3 items)`
- `git diff --check`
