### PR TITLE
Fix continuation after local compaction

### DIFF
--- a/packages/agent-openai/src/Agent/OpenAI/Compaction.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Compaction.hs
@@ -90,7 +90,11 @@ messageText message = case message.content of
     MessageContentParts parts ->
         let texts =
                 [ text
-                | InputTextPart { text } <- parts
+                | part <- parts
+                , text <- case part of
+                    InputTextPart { text } -> [text]
+                    OutputTextPart { text } -> [text]
+                    _ -> []
                 ]
         in case texts of
             [] -> Nothing
@@ -112,8 +116,9 @@ assistantSummaryItem summary =
         { messageId = Nothing
         , content =
             MessageContentParts
-                [ InputTextPart
+                [ OutputTextPart
                     (summaryPrefix <> "\n" <> Text.strip summary)
+                    Nothing
                     Nothing
                     KeyMap.empty
                 ]

--- a/packages/agent-openai/test/Agent/OpenAI/CompactionSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/CompactionSpec.hs
@@ -24,6 +24,7 @@ spec = do
                 compacted = buildLocalCompactedHistory 2 history "did stuff"
             length compacted `shouldBe` 3
             compacted `shouldSatisfy` any isSummary
+            compacted `shouldSatisfy` any isWireValidAssistantSummary
             -- newest users retained
             let texts = [userOnly m | MessageItem m <- compacted, m.role == RoleUser]
             texts `shouldBe` ["two", "three"]
@@ -118,10 +119,16 @@ spec = do
     isSummary (MessageItem m) =
         m.role == RoleAssistant
             && case m.content of
-                MessageContentParts (InputTextPart text _ _ : _) ->
+                MessageContentParts (OutputTextPart text _ _ _ : _) ->
                     Text.isPrefixOf summaryPrefix text
                 _ -> False
     isSummary _ = False
+    isWireValidAssistantSummary (MessageItem m) =
+        m.role == RoleAssistant
+            && case m.content of
+                MessageContentParts [OutputTextPart {}] -> True
+                _ -> False
+    isWireValidAssistantSummary _ = False
     userOnly m = case m.content of
         MessageContentParts (InputTextPart text _ _ : _) -> text
         MessageContentText text -> text

--- a/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
@@ -16,6 +16,34 @@ import Test.Hspec
 
 spec :: Spec
 spec = do
+    describe "withRequestInput" do
+        it "repairs legacy assistant input_text from compacted sessions" do
+            let legacySummary = MessageItem ResponseMessage
+                    { messageId = Nothing
+                    , content = MessageContentParts
+                        [InputTextPart "Compacted conversation summary:\nold" Nothing KeyMap.empty]
+                    , role = RoleAssistant
+                    , status = Nothing
+                    , phase = Nothing
+                    , extraFields = KeyMap.empty
+                    }
+                request = withRequestInput baseParams [legacySummary]
+            inputItems request `shouldBe`
+                [ MessageItem ResponseMessage
+                    { messageId = Nothing
+                    , content = MessageContentParts
+                        [OutputTextPart
+                            "Compacted conversation summary:\nold"
+                            Nothing
+                            Nothing
+                            KeyMap.empty]
+                    , role = RoleAssistant
+                    , status = Nothing
+                    , phase = Nothing
+                    , extraFields = KeyMap.empty
+                    }
+                ]
+
     describe "turnInputsToItems" do
         it "encodes a user message as RoleUser input_text" do
             case turnInputsToItems [UserMessage "hello"] of

--- a/packages/agent-responses/src/Agent/Responses/LoopBackend.hs
+++ b/packages/agent-responses/src/Agent/Responses/LoopBackend.hs
@@ -70,7 +70,44 @@ statelessResponsesBackend send getParams transcript =
 -- ambiguous. Rebuild from the constructor instead.
 withRequestInput :: ResponseCreateParams -> [ResponseItem] -> ResponseCreateParams
 withRequestInput ResponseCreateParams{..} items =
-    ResponseCreateParams { input = Just (ResponseInputItems items), .. }
+    ResponseCreateParams
+        { input = Just (ResponseInputItems (map normalizeRequestItem items))
+        , ..
+        }
+
+-- Older local compaction snapshots accidentally persisted assistant summaries
+-- as input_text. Responses input accepts assistant history, but its content
+-- parts must use output_text (or refusal). Repair those snapshots at the wire
+-- boundary so resumed sessions recover without rewriting their session files.
+normalizeRequestItem :: ResponseItem -> ResponseItem
+normalizeRequestItem = \case
+    MessageItem message
+        | message.role == RoleAssistant ->
+            MessageItem ResponseMessage
+                { messageId = message.messageId
+                , content = case message.content of
+                    MessageContentText text ->
+                        MessageContentParts
+                            [OutputTextPart text Nothing Nothing KeyMap.empty]
+                    MessageContentParts parts ->
+                        MessageContentParts (map normalizeAssistantPart parts)
+                , role = message.role
+                , status = message.status
+                , phase = message.phase
+                , extraFields = message.extraFields
+                }
+    item -> item
+
+normalizeAssistantPart :: ResponseContentPart -> ResponseContentPart
+normalizeAssistantPart = \case
+    InputTextPart { text, extraFields } ->
+        OutputTextPart
+            { text
+            , annotations = Nothing
+            , logprobs = Nothing
+            , extraFields
+            }
+    part -> part
 
 turnInputsToItems :: [TurnInput] -> [ResponseItem]
 turnInputsToItems = map turnInputToItem


### PR DESCRIPTION
## Summary

- encode locally generated assistant compaction summaries as `output_text`
- recognize both legacy `input_text` and corrected `output_text` summaries when detecting checkpoints
- repair already-persisted malformed assistant history at the Responses request boundary
- add regression coverage for new and legacy compact snapshots

## Root cause

Local compaction persisted its assistant summary with an `input_text` content part. When the next turn replayed that snapshot, the Responses API rejected it because assistant message content only accepts `output_text` or `refusal`.

## Verification

- OpenAI test suite in GHCi: 147 examples, 0 failures, 1 credential-gated pending test
- resumed a real persisted malformed compact session in tmux
- sent a new turn through `gpt-5.6-sol` and received `SMOKE-RECOVERED`
- `git diff --check`
