### PR TITLE
Show progress while compacting context

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -133,6 +133,7 @@ import Agent.CLI.ProviderTransition
     )
 import Agent.CLI.Render
     ( RenderConfig(..)
+    , clearThinking
     , emptyMarkdownStreamState
     , putTextLn
     , renderAssistantText
@@ -2195,7 +2196,10 @@ replWithDraft env@SessionEnv
                         continue
                     ReplCompact focus -> do
                         color <- resolveColor stderr
-                        result <- runProviderCompact provider tokenProvider paramsRef transcriptRef focus
+                        result <-
+                            withReplActivity "Compacting context…" $
+                                runProviderCompact provider tokenProvider
+                                    paramsRef transcriptRef focus
                         case result of
                             Left err -> do
                                 displayError err $
@@ -2570,6 +2574,17 @@ replWithDraft env@SessionEnv
     displayError message minimalAction = case fullscreen of
         Nothing -> minimalAction
         Just runtime -> emitUiEvent runtime (UiErrorMessage message)
+    withReplActivity message action = do
+        case fullscreen of
+            Nothing ->
+                renderEvent render (ActivityUpdated message)
+            Just runtime ->
+                emitUiEvent runtime
+                    (UiSetNotice (Just (progressNotice message)))
+        action `finally`
+            case fullscreen of
+                Nothing -> clearThinking render
+                Just runtime -> emitUiEvent runtime (UiSetNotice Nothing)
     setEffort level = do
         color <- resolveColor stdout
         setSessionEffort env level


### PR DESCRIPTION
## Summary
- show an animated `Compacting context…` indicator for manual `/compact`
- use the existing live activity spinner in minimal CLI mode
- use a progress notice in fullscreen mode
- always clear the indicator after success, failure, or interruption

## Verification
- loaded `Agent.CLI` and its 53 modules in GHCi
- `nix develop -c env -u GHCRTS cabal test agent-cli:test:agent-cli-test` (445 examples, 0 failures)
- exercised `/compact` in the live fullscreen agent under tmux and confirmed the indicator appears and clears after completion
- `git diff --check`
