### PR TITLE
fix(cli): recover subagent connection failures

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
@@ -15,6 +15,7 @@ module Agent.CLI.Subagents.Runtime
 import Agent.CLI.Approval (childApprove)
 import Agent.CLI.Btw (trimDanglingToolSuffix)
 import Agent.CLI.Compaction (autoCompactOpenAiBackend)
+import Agent.CLI.Connectivity (withConnectionRecovery)
 import Agent.CLI.Options
     ( ApprovalPolicy
     , CliOptions(..)
@@ -379,11 +380,12 @@ runCodexSubagent runtime tokenProvider sendToRoot =
                     freshOpenAiBackend tokenProvider
                         (readIORef childParamsRef) session.subSessionTranscript
                 backend =
-                    autoCompactOpenAiBackend tokenProvider
-                        (readIORef childParamsRef)
-                        session.subSessionTranscript
-                        session.subSessionContextTokens
-                        baseBackend
+                    withConnectionRecovery $
+                        autoCompactOpenAiBackend tokenProvider
+                            (readIORef childParamsRef)
+                            session.subSessionTranscript
+                            session.subSessionContextTokens
+                            baseBackend
                 config = LoopConfig
                     { loopBackend = backend
                     , loopTools = toolRegistry
@@ -481,7 +483,9 @@ runHttpSubagent runtime provider mkBackend =
                     (schemasFromAppTools provider tools) effort
             toolRegistry <- requireToolRegistry tools
             childParamsRef <- newIORef childParams
-            let backend = mkBackend childParamsRef session.subSessionTranscript
+            let backend =
+                    withConnectionRecovery $
+                        mkBackend childParamsRef session.subSessionTranscript
                 config = LoopConfig
                     { loopBackend = backend
                     , loopTools = toolRegistry

--- a/packages/agent-cli/test/Agent/CLI/ConnectivitySpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ConnectivitySpec.hs
@@ -62,6 +62,23 @@ spec = describe "withConnectionRecovery" do
         result `shouldBe` Left expected
         readIORef waits `shouldReturn` []
 
+    it "recovers from a WebSocket frame parse disconnect" do
+        attempts <- newIORef (0 :: Int)
+        let backend = withConnectionRecoveryUsing
+                (const (pure ()))
+                (Backend \_ _ _ -> do
+                    attempt <- atomicModifyIORef' attempts \n -> (n + 1, n + 1)
+                    pure $
+                        if attempt == 1
+                            then Left $ ConnectionError
+                                "WebSocket receive error: ParseException \"not enough bytes\""
+                            else Right
+                                (emptyTurnOutput "response" [] (Just "done")))
+        result <- backend.submitTurn Nothing [] (const (pure ()))
+        result `shouldBe`
+            Right (emptyTurnOutput "response" [] (Just "done"))
+        readIORef attempts `shouldReturn` 2
+
     it "does not replay a submission after visible output streamed" do
         attempts <- newIORef (0 :: Int)
         waits <- newIORef []


### PR DESCRIPTION
## Summary

- apply automatic connection recovery to Codex subagent submissions
- apply the same recovery to XAI and OpenRouter subagent submissions
- cover the observed WebSocket `ParseException "not enough bytes"` disconnect

Retries remain replay-safe: recovery stops once visible text or reasoning has streamed.

## Testing

- `nix develop -c cabal test agent-cli-test --test-show-details=direct`
- 446 examples, 0 failures