### PR TITLE
Retry transient WebSocket handshakes

### DIFF
--- a/packages/agent-core/agent-core.cabal
+++ b/packages/agent-core/agent-core.cabal
@@ -131,6 +131,7 @@ test-suite agent-core-test
                     , filepath
                     , containers
                     , hspec
+                    , retry >= 0.9.3.1 && < 0.10
                     , safe-exceptions
                     , stm
                     , text

--- a/packages/agent-core/src/Agent/Transport/WebSocket.hs
+++ b/packages/agent-core/src/Agent/Transport/WebSocket.hs
@@ -11,7 +11,8 @@ module Agent.Transport.WebSocket
     , invalidateWebSocketRequest
     , sendWebSocketText
     , receiveWebSocketData
-    , transientWsRetryDelayMicros
+    , transientWsConnectRetryPolicy
+    , retryTransientWsConnectWithPolicy
     , transientWsConnectFailureLabel
     , transientWsMidRunFailureLabel
     , wsHandshakeAuthFailure
@@ -23,7 +24,14 @@ import Control.Concurrent.Async (withAsync)
 import Control.Concurrent.STM
 import qualified Control.Exception as Exception
 import qualified Control.Exception.Safe as Safe
+import Control.Retry
+    ( RetryPolicyM
+    , capDelay
+    , exponentialBackoff
+    , retrying
+    )
 import qualified Data.ByteString.Lazy as LBS
+import Data.IORef (newIORef, readIORef, writeIORef)
 import Data.Maybe (isJust)
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -409,10 +417,37 @@ isAsyncException :: Exception.SomeException -> Bool
 isAsyncException exception =
     isJust (Exception.fromException exception :: Maybe Exception.SomeAsyncException)
 
--- | Small fixed backoff before retrying a transient WebSocket connect /
--- handshake failure.
-transientWsRetryDelayMicros :: Int
-transientWsRetryDelayMicros = 3000000
+-- | Capped exponential backoff for transient WebSocket connection / handshake
+-- failures: 1s, 2s, 4s, 8s, then 15s until the connection succeeds or the
+-- caller cancels the operation.
+transientWsConnectRetryPolicy :: RetryPolicyM IO
+transientWsConnectRetryPolicy =
+    capDelay 15000000 (exponentialBackoff 1000000)
+
+-- | Retry transient WebSocket connection / handshake failures until the
+-- connection callback begins. Once the callback has started, retrying the
+-- enclosing action could replay visible effects from an active session, so
+-- every exception is propagated unchanged.
+--
+-- The policy is injectable so tests can retry without sleeping.
+retryTransientWsConnectWithPolicy
+    :: RetryPolicyM IO
+    -> (IO () -> IO value)
+    -> IO value
+retryTransientWsConnectWithPolicy policy connect = do
+    callbackStarted <- newIORef False
+    result <- retrying policy (shouldRetry callbackStarted) \_retryStatus -> do
+        writeIORef callbackStarted False
+        Safe.tryAny (connect (writeIORef callbackStarted True))
+    either Exception.throwIO pure result
+  where
+    shouldRetry callbackStarted _retryStatus = \case
+        Left exception -> do
+            started <- readIORef callbackStarted
+            pure $
+                not started
+                    && isJust (transientWsConnectFailureLabel exception)
+        Right _ -> pure False
 
 -- | Classify transient failures that happen before a WebSocket session is
 -- established.

--- a/packages/agent-core/test/Agent/Transport/WebSocketSpec.hs
+++ b/packages/agent-core/test/Agent/Transport/WebSocketSpec.hs
@@ -15,9 +15,19 @@ import Control.Concurrent
     , writeChan
     )
 import Control.Exception (SomeException, finally, throwIO, toException)
+import qualified Control.Exception.Safe as Safe
+import Control.Retry
+    ( RetryPolicyM
+    , applyPolicy
+    , constantDelay
+    , defaultRetryStatus
+    , limitRetries
+    , rsPreviousDelay
+    )
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BS8
 import qualified Data.ByteString.Lazy as LBS
+import Data.IORef
 import qualified Network.WebSockets as WS
 import qualified Network.WebSockets.Stream as WSStream
 import System.Timeout (timeout)
@@ -28,6 +38,18 @@ spec = describe "Agent.Transport.WebSocket" do
     it "classifies websocket connection timeouts" do
         transientWsConnectFailureLabel (toException WS.ConnectionTimeout :: SomeException)
             `shouldBe` Just "WebSocket handshake timed out"
+
+    it "backs off transient handshake retries exponentially with a cap" do
+        retryPolicyDelays 7 transientWsConnectRetryPolicy
+            `shouldReturn`
+                [ 1000000
+                , 2000000
+                , 4000000
+                , 8000000
+                , 15000000
+                , 15000000
+                , 15000000
+                ]
 
     it "classifies websocket parse errors during a run" do
         transientWsMidRunFailureLabel (toException (WS.ParseException "not enough bytes") :: SomeException)
@@ -43,6 +65,52 @@ spec = describe "Agent.Transport.WebSocket" do
         wsHandshakeAuthFailureStatus exception `shouldBe` Just 401
         wsHandshakeAuthFailure exception
             `shouldBe` Just (HttpError 401 "WebSocket handshake returned HTTP 401")
+
+    it "retries a transient handshake failure before the connection callback" do
+        attempts <- newIORef (0 :: Int)
+        let exception = transientHandshakeException 503
+        result <- retryTransientWsConnectWithPolicy
+            (constantDelay 0 <> limitRetries 3)
+            \connected -> do
+                attempt <- atomicModifyIORef' attempts \n -> (n + 1, n + 1)
+                if attempt == 1
+                    then throwIO exception
+                    else connected >> pure ("connected" :: String)
+
+        result `shouldBe` "connected"
+        readIORef attempts `shouldReturn` 2
+
+    it "does not retry after the connection callback has started" do
+        attempts <- newIORef (0 :: Int)
+        result <- Safe.tryAny $
+            retryTransientWsConnectWithPolicy
+                (constantDelay 0 <> limitRetries 3)
+                \connected -> do
+                    modifyIORef' attempts (+ 1)
+                    connected
+                    throwIO (transientHandshakeException 503)
+
+        case result of
+            Left exception ->
+                transientWsConnectFailureLabel exception
+                    `shouldBe` Just "WebSocket handshake returned HTTP 503"
+            Right () -> expectationFailure "expected the callback exception to escape"
+        readIORef attempts `shouldReturn` 1
+
+    it "does not retry a non-transient handshake rejection" do
+        attempts <- newIORef (0 :: Int)
+        result <- Safe.tryAny $
+            retryTransientWsConnectWithPolicy
+                (constantDelay 0 <> limitRetries 3)
+                \_connected -> do
+                    modifyIORef' attempts (+ 1)
+                    throwIO (transientHandshakeException 401)
+
+        case result of
+            Left exception ->
+                wsHandshakeAuthFailureStatus exception `shouldBe` Just 401
+            Right () -> expectationFailure "expected the handshake rejection to escape"
+        readIORef attempts `shouldReturn` 1
 
     it "handles server pings while delivering application data" do
         withConnectionPair \client server -> do
@@ -104,6 +172,28 @@ spec = describe "Agent.Transport.WebSocket" do
                     `shouldReturn` Left
                         (ConnectionError
                             "WebSocket session invalidated: response consumer interrupted")
+
+transientHandshakeException :: Int -> SomeException
+transientHandshakeException status =
+    toException $ WS.MalformedResponse responseHead "Wrong response status"
+  where
+    responseHead = WS.ResponseHead
+        { WS.responseCode = status
+        , WS.responseMessage = BS8.pack "Service Unavailable"
+        , WS.responseHeaders = []
+        }
+
+retryPolicyDelays :: Int -> RetryPolicyM IO -> IO [Int]
+retryPolicyDelays count policy = go count defaultRetryStatus
+  where
+    go remaining retryStatus
+        | remaining <= 0 = pure []
+        | otherwise =
+            applyPolicy policy retryStatus >>= \case
+                Nothing -> pure []
+                Just nextStatus -> do
+                    rest <- go (remaining - 1) nextStatus
+                    pure (maybe 0 id nextStatus.rsPreviousDelay : rest)
 
 -- WebSocket session fixtures.
 testSessionReuse :: WS.Connection -> WS.Connection -> IO ()

--- a/packages/agent-openai/src/Agent/OpenAI/WebSocketClient.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/WebSocketClient.hs
@@ -144,11 +144,21 @@ runConnectionAttempt credential action = do
                 , ("chatgpt-account-id", Text.encodeUtf8 credential.accountId)
                 , ("OpenAI-Beta", "responses_websockets=2026-02-06")
                 ]
-        Wuss.runSecureClientWith wsHost 443 wsPath WS.defaultConnectionOptions headers $ \conn ->
-            WebSocket.withWebSocketSession
-                WebSocket.defaultWebSocketSessionOptions
-                conn
-                (\session -> action (CodexWsConn session) credential)
+        WebSocket.retryTransientWsConnectWithPolicy
+            WebSocket.transientWsConnectRetryPolicy
+            \connected ->
+                Wuss.runSecureClientWith
+                    wsHost
+                    443
+                    wsPath
+                    WS.defaultConnectionOptions
+                    headers
+                    \conn -> do
+                        connected
+                        WebSocket.withWebSocketSession
+                            WebSocket.defaultWebSocketSessionOptions
+                            conn
+                            (\session -> action (CodexWsConn session) credential)
     case result of
         Right value -> pure value
         Left exception


### PR DESCRIPTION
## Summary
- retry transient WebSocket connection and handshake failures before the session callback starts
- use `Control.Retry` with capped exponential backoff (1s, 2s, 4s, 8s, then 15s)
- preserve authentication failover and avoid replaying exceptions after a session becomes active

## Testing
- loaded `agent-core:test:agent-core-test` in GHCi and ran `Agent.Transport.WebSocketSpec` (12 examples, 0 failures)
- loaded `agent-core` and `agent-openai` together in the multi-package GHCi session
- `git diff --check`