### PR TITLE
Fix auto-compaction during tool continuations

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Compaction.hs
+++ b/packages/agent-cli/src/Agent/CLI/Compaction.hs
@@ -13,6 +13,7 @@ import Agent.Loop
     ( Backend(..)
     , LoopEvent(..)
     , TokenUsage(..)
+    , TurnInput(..)
     , TurnOutput(..)
     )
 import qualified Agent.OpenAI.Client as OpenAI
@@ -224,9 +225,20 @@ autoCompactOpenAiBackendWith compactAction transcriptRef contextTokensRef
             Just (tokens, observedLength)
                 | observedLength == historyLength
                 , tokens >= codexAutoCompactTokenLimit ->
-                    compactThenSubmit contextState inputs onEvent
+                    if any isCompletedTool inputs
+                        then submitAndTrack contextState previous inputs onEvent
+                        else compactThenSubmit contextState inputs onEvent
             _ -> submitAndTrack contextState previous inputs onEvent
   where
+    -- Tool results are appended by the wrapped backend as part of the next
+    -- request. Before that request, the transcript ends with the originating
+    -- calls and is therefore not valid input for a compaction request.
+    -- Defer compaction until the next non-tool continuation, by which point
+    -- the call/output pairs have been committed to the transcript.
+    isCompletedTool = \case
+        CompletedTool{} -> True
+        _ -> False
+
     compactThenSubmit oldTokens inputs onEvent = do
         onEvent (ActivityUpdated "Compacting context…")
         compactAction >>= \case

--- a/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
@@ -12,6 +12,10 @@ import Agent.OpenAI.Compaction
     ( hasCompactionCheckpoint
     , userTextItem
     )
+import Agent.ToolDispatch
+    ( ToolCallKind(..)
+    , ToolCallResult(..)
+    )
 import Agent.Responses.Types
 import qualified Data.Aeson as Aeson
 import Data.Aeson ((.=))
@@ -108,6 +112,57 @@ spec = do
                 Just (25, length compactedHistory)
             readIORef events `shouldReturn`
                 [ActivityUpdated "Compacting context…"]
+
+        it "defers compaction while completed tool outputs are still pending" do
+            let danglingCall = FunctionCallItem FunctionCall
+                    { itemId = Nothing
+                    , callId = "call-1"
+                    , name = "shell_command"
+                    , arguments = "{}"
+                    , status = Nothing
+                    , extraFields = mempty
+                    }
+                oldHistory = [userTextItem "run it", danglingCall]
+                toolResult = ToolCallResult
+                    { callId = "call-1"
+                    , output = "done"
+                    , callKind = FunctionCallKind
+                    }
+            transcript <- newIORef oldHistory
+            contextState <- newIORef
+                (Just (codexAutoCompactTokenLimit, length oldHistory))
+            compactCalls <- newIORef (0 :: Int)
+            seenPrevious <- newIORef []
+            seenInputs <- newIORef []
+            let compactAction = do
+                    modifyIORef' compactCalls (+ 1)
+                    pure $ Right CompactOutcome
+                        { compactBeforeTokens = codexAutoCompactTokenLimit
+                        , compactAfterTokens = 10
+                        , compactHistory = [userTextItem "compacted"]
+                        , compactSummary = "checkpoint"
+                        }
+                base = Backend \previous inputs _ -> do
+                    modifyIORef' seenPrevious (<> [previous])
+                    modifyIORef' seenInputs (<> [inputs])
+                    pure $ Right TurnOutput
+                        { responseId = "resp-new"
+                        , toolCalls = []
+                        , assistantText = Just "ok"
+                        , tokenUsage = TokenUsage 20 5 0
+                        }
+                backend = autoCompactOpenAiBackendWith compactAction
+                    transcript contextState base
+                inputs = [CompletedTool toolResult]
+            result <- backend.submitTurn (Just "resp-tool") inputs
+                (const (pure ()))
+            result `shouldSatisfy` either (const False) (const True)
+            readIORef compactCalls `shouldReturn` 0
+            readIORef seenPrevious `shouldReturn` [Just "resp-tool"]
+            readIORef seenInputs `shouldReturn` [inputs]
+            readIORef transcript `shouldReturn` oldHistory
+            readIORef contextState `shouldReturn`
+                Just (25, length oldHistory)
 
 summaryResponse :: Text -> Response
 summaryResponse summary =


### PR DESCRIPTION
## Summary

- defer automatic context compaction while a `CompletedTool` continuation is pending
- allow the wrapped backend to commit the tool call/output pair before compaction
- add a regression test for compaction at the token threshold with a dangling function call

## Root cause

The auto-compaction wrapper ran before submitting internal tool-result continuations. At that point the transcript contained the model's `function_call`, while the matching `function_call_output` still existed only in the pending `CompletedTool` input. Sending that transcript to the summarization request caused the provider to reject it with `No tool output found for function call ...`.

## Testing

- loaded the `agent-cli` test suite in GHCi
- ran `Agent.CLI.CompactionSpec.spec`
- 5 examples, 0 failures
- `git diff --check`
