### PR TITLE
feat(cli): add animated lambda empty state

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -3537,7 +3537,7 @@ hydrateUiHistory = foldl addTurn initialUiState
         let cleared = reduceUi UiConversationCleared state
         in case turn.turnAssistantText of
             Nothing -> cleared
-            Just text -> reduceUi (UiSystemMessage text) cleared
+            Just text -> reduceUi (UiHistory text) cleared
 
     addRegularTurn state turn =
         let withUser =

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -64,6 +64,7 @@ import Agent.TUI.Model
 import Agent.Loop (ImageAttachment, LoopEvent(..))
 import Agent.ToolDispatch (ToolCall(..))
 import Brick
+import qualified Brick.Types as B
 import Brick.BChan
     ( BChan
     , newBChan
@@ -72,7 +73,7 @@ import Brick.BChan
 import Brick.Widgets.Border (borderWithLabel)
 import qualified Brick.Widgets.Border as Border
 import Brick.Widgets.Border.Style (unicodeRounded)
-import Brick.Widgets.Center (centerLayer)
+import Brick.Widgets.Center (center, centerLayer)
 import Control.Concurrent.Async (wait, waitCatch, withAsync)
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.STM
@@ -488,8 +489,11 @@ runFullscreen runtime workerAction = do
       where
         loop tick = do
             threadDelay 50000
-            running <- readIORef runtime.runtimeRunning
-            when (running && tick `mod` 2 == 0) $
+            needsTick <- readIORef runtime.runtimeRunning
+            -- Model ticks remain at 10 Hz for elapsed time, completion
+            -- settling, and notice expiry. The empty-state renderer samples
+            -- every second frame for a calmer 5 FPS animation.
+            when (needsTick && tick `mod` 2 == 0) $
                 enqueueAppEvent runtime (AppUi UiTick)
             loop ((tick + 1) `mod` 20)
 
@@ -1023,10 +1027,7 @@ drawWorkspace :: AppState -> Widget Name
 drawWorkspace state =
     padTop (Pad 1) $
         hBox $
-            [ withVScrollBars OnRight $
-                viewport ConversationViewport Vertical $
-                    padLeftRight 2 (drawTranscript state)
-            ]
+            [ drawConversationPane state ]
                 <> if length state.appAgentEntries <= 1
                     then []
                     else
@@ -1036,6 +1037,19 @@ drawWorkspace state =
                                     state.appAgentSelected
                                     state.appAgentEntries
                         ]
+
+drawConversationPane :: AppState -> Widget Name
+drawConversationPane state
+    | conversationIsEmpty state.appUi =
+        padLeftRight 2 $
+            vBox
+                [ drawTranscript state
+                , drawEmptyConversation (state.appUi.uiFrame `div` 2)
+                ]
+    | otherwise =
+        withVScrollBars OnRight $
+            viewport ConversationViewport Vertical $
+                padLeftRight 2 (drawTranscript state)
 
 drawAgentPane :: AgentTarget -> [AgentEntry] -> Widget Name
 drawAgentPane selected entries =
@@ -1153,15 +1167,10 @@ spinnerFrame frame =
         !! (frame `mod` 10)
 
 drawTranscript :: AppState -> Widget Name
-drawTranscript state
-    | null blocks =
-        withAttr Theme.mutedAttr $
-            padTop (Pad 2) $
-                txt "Start by describing what you want to build or change."
-    | otherwise =
-        vBox $
-            [vBox (map (drawBlock state) blocks)]
-                <> conversationReserveWidgets anchor
+drawTranscript state =
+    vBox $
+        [vBox (map (drawBlock state) blocks)]
+            <> conversationReserveWidgets anchor
   where
     blocks = toList state.appUi.uiBlocks
     anchor = state.appConversationAnchor
@@ -1203,6 +1212,263 @@ conversationReserveWidgets = \case
                 vLimit anchor.anchorReserveRows (fill ' ')
             ]
     _ -> []
+
+drawEmptyConversation :: Int -> Widget Name
+drawEmptyConversation frame =
+    center (lambdaArtWidget frame)
+
+data LambdaComposition = LambdaComposition
+    { lambdaUpperHeight :: !Int
+    , lambdaLowerHeight :: !Int
+    , lambdaStrokeWidth :: !Int
+    , lambdaMarginX :: !Int
+    , lambdaMarginY :: !Int
+    , lambdaHasOrbit :: !Bool
+    }
+
+data LambdaPalette = LambdaPalette
+    { lambdaDim :: !V.Attr
+    , lambdaTrail :: !V.Attr
+    , lambdaGlow :: !V.Attr
+    , lambdaSpark :: !V.Attr
+    }
+
+lambdaArtWidget :: Int -> Widget Name
+lambdaArtWidget frame =
+    B.Widget B.Fixed B.Fixed do
+        context <- B.getContext
+        dimAttr <- B.lookupAttrName Theme.lambdaDimAttr
+        trailAttr <- B.lookupAttrName Theme.lambdaTrailAttr
+        glowAttr <- B.lookupAttrName Theme.lambdaGlowAttr
+        sparkAttr <- B.lookupAttrName Theme.lambdaSparkAttr
+        let
+            composition =
+                lambdaComposition context.availWidth context.availHeight
+            palette = LambdaPalette
+                { lambdaDim = dimAttr
+                , lambdaTrail = trailAttr
+                , lambdaGlow = glowAttr
+                , lambdaSpark = sparkAttr
+                }
+            rows =
+                buildSolidLambdaRows
+                    composition.lambdaUpperHeight
+                    composition.lambdaLowerHeight
+                    composition.lambdaStrokeWidth
+            logoWidth = maximum (0 : map length rows)
+            canvasWidth = logoWidth + 2 * composition.lambdaMarginX
+            canvasHeight = length rows + 2 * composition.lambdaMarginY
+            particles =
+                lambdaOrbitParticles
+                    palette
+                    frame
+                    canvasWidth
+                    canvasHeight
+                    composition.lambdaHasOrbit
+            rendered =
+                V.vertCat
+                    [ V.horizCat
+                        [ renderLambdaCell
+                            palette
+                            frame
+                            composition
+                            rows
+                            particles
+                            x
+                            y
+                        | x <- [0 .. canvasWidth - 1]
+                        ]
+                    | y <- [0 .. canvasHeight - 1]
+                    ]
+        pure B.emptyResult { B.image = rendered }
+
+lambdaComposition :: Int -> Int -> LambdaComposition
+lambdaComposition width height
+    | width >= 42
+    , height >= 21 =
+        LambdaComposition
+            { lambdaUpperHeight = 8
+            , lambdaLowerHeight = 11
+            , lambdaStrokeWidth = 3
+            , lambdaMarginX = 8
+            , lambdaMarginY = 1
+            , lambdaHasOrbit = True
+            }
+    | width >= 24
+    , height >= 14 =
+        LambdaComposition
+            { lambdaUpperHeight = 5
+            , lambdaLowerHeight = 7
+            , lambdaStrokeWidth = 2
+            , lambdaMarginX = 4
+            , lambdaMarginY = 1
+            , lambdaHasOrbit = True
+            }
+    | otherwise =
+        LambdaComposition
+            { lambdaUpperHeight = 3
+            , lambdaLowerHeight = 4
+            , lambdaStrokeWidth = 2
+            , lambdaMarginX = 0
+            , lambdaMarginY = 0
+            , lambdaHasOrbit = False
+            }
+
+buildSolidLambdaRows :: Int -> Int -> Int -> [String]
+buildSolidLambdaRows upperHeight lowerHeight strokeWidth =
+    map row [0 .. totalHeight - 1]
+  where
+    totalHeight = upperHeight + lowerHeight
+    mainStart =
+        max 0 (strokeWidth + lowerHeight - 1 - upperHeight)
+    width = mainColumn (totalHeight - 1) + strokeWidth
+    row rowIndex =
+        map (cell rowIndex) [0 .. width - 1]
+    cell rowIndex column
+        | rowIndex >= upperHeight
+        , column >= branchColumn rowIndex
+        , column < branchColumn rowIndex + strokeWidth =
+            '/'
+        | column >= mainColumn rowIndex
+        , column < mainColumn rowIndex + strokeWidth =
+            '\\'
+        | otherwise = ' '
+      where
+        branchColumn index =
+            mainStart
+                + upperHeight
+                - strokeWidth
+                - (index - upperHeight)
+    mainColumn index =
+        mainStart + index
+
+renderLambdaCell
+    :: LambdaPalette
+    -> Int
+    -> LambdaComposition
+    -> [String]
+    -> [((Int, Int), Char, V.Attr)]
+    -> Int
+    -> Int
+    -> V.Image
+renderLambdaCell palette frame composition rows particles x y =
+    case lambdaLogoChar rows composition.lambdaMarginX
+        composition.lambdaMarginY x y of
+        ' ' ->
+            case find
+                (\(position, _, _) -> position == (x, y))
+                particles of
+                Just (_, character, attr) ->
+                    V.char attr character
+                Nothing ->
+                    V.char palette.lambdaDim ' '
+        character ->
+            let
+                localX = x - composition.lambdaMarginX
+                localY = y - composition.lambdaMarginY
+                (attr, animatedCharacter) =
+                    animatedLambdaStroke
+                        palette
+                        frame
+                        localX
+                        localY
+                        character
+            in V.char attr animatedCharacter
+
+lambdaLogoChar :: [String] -> Int -> Int -> Int -> Int -> Char
+lambdaLogoChar rows marginX marginY x y
+    | localX < 0 || localY < 0 = ' '
+    | otherwise =
+        case drop localY rows of
+            row : _ ->
+                case drop localX row of
+                    character : _ -> character
+                    [] -> ' '
+            [] -> ' '
+  where
+    localX = x - marginX
+    localY = y - marginY
+
+animatedLambdaStroke
+    :: LambdaPalette
+    -> Int
+    -> Int
+    -> Int
+    -> Char
+    -> (V.Attr, Char)
+animatedLambdaStroke palette frame x y character
+    | distance == 0 =
+        (palette.lambdaSpark, energizedStroke character)
+    | distance <= 2 =
+        (palette.lambdaGlow, character)
+    | distance <= 5 =
+        (palette.lambdaTrail, character)
+    | otherwise =
+        (palette.lambdaDim, character)
+  where
+    period = 36
+    phase = frame `mod` period
+    oppositePhase = (phase + period `div` 2) `mod` period
+    cellPhase = (y * 5 + x * 3) `mod` period
+    distance =
+        min
+            (circularDistance period phase cellPhase)
+            (circularDistance period oppositePhase cellPhase)
+
+energizedStroke :: Char -> Char
+energizedStroke = \case
+    '_' -> '='
+    _ -> '*'
+
+circularDistance :: Int -> Int -> Int -> Int
+circularDistance period left right =
+    let direct = abs (left - right)
+    in min direct (period - direct)
+
+lambdaOrbitParticles
+    :: LambdaPalette
+    -> Int
+    -> Int
+    -> Int
+    -> Bool
+    -> [((Int, Int), Char, V.Attr)]
+lambdaOrbitParticles _ _ _ _ False = []
+lambdaOrbitParticles palette frame width height True =
+    [ (position, character, attr)
+    | (offset, (character, attr)) <- zip offsets particleStyles
+    , Just position <- [cyclicAt path (frame + offset)]
+    ]
+  where
+    path = lambdaOrbitPath width height
+    pathLength = length path
+    offsets =
+        [ 0
+        , pathLength `div` 3
+        , 2 * pathLength `div` 3
+        ]
+    particleStyles =
+        [ ('*', palette.lambdaSpark)
+        , ('+', palette.lambdaGlow)
+        , ('.', palette.lambdaTrail)
+        ]
+
+lambdaOrbitPath :: Int -> Int -> [(Int, Int)]
+lambdaOrbitPath width height =
+    top <> right <> bottom <> left
+  where
+    horizontal = [2, 4 .. width - 3]
+    vertical = [2, 4 .. height - 3]
+    top = [(x, 0) | x <- horizontal]
+    right = [(width - 1, y) | y <- vertical]
+    bottom = [(x, height - 1) | x <- reverse horizontal]
+    left = [(0, y) | y <- reverse vertical]
+
+cyclicAt :: [a] -> Int -> Maybe a
+cyclicAt [] _ = Nothing
+cyclicAt values index =
+    case drop (index `mod` length values) values of
+        value : _ -> Just value
+        [] -> Nothing
 
 drawBlock :: AppState -> UiBlock -> Widget Name
 drawBlock state block =

--- a/packages/agent-cli/src/Agent/CLI/TUI/Bridge.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Bridge.hs
@@ -47,7 +47,7 @@ nativeProgressSignal event state = case event of
     UiSetAwaitingInput True -> Just False
     UiTick
         | state.uiRunning
-        , state.uiFrame == 0 ->
+        , state.uiFrame `mod` 10 == 0 ->
             Just True
     _ -> Nothing
 

--- a/packages/agent-cli/test/Agent/CLI/TUIBridgeSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIBridgeSpec.hs
@@ -26,7 +26,7 @@ spec = describe "fullscreen TUI bridge" do
 
     it "starts, refreshes, and clears native terminal progress" do
         let running = reduceUi (UiLoop TurnStarted) initialUiState
-            refresh = running { uiFrame = 0 }
+            refresh = running { uiFrame = 10 }
             toolCall =
                 functionToolCall
                     "tool-1"

--- a/packages/agent-tui/src/Agent/TUI/Model.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model.hs
@@ -14,6 +14,7 @@ module Agent.TUI.Model
     , errorNotice
     , infoNotice
     , initialUiState
+    , conversationIsEmpty
     , deleteToLineStart
     , deleteToLineEnd
     , deleteWordBefore
@@ -209,6 +210,16 @@ initialUiState = UiState
     , uiToolCalls = Map.empty
     }
 
+-- | Status-only blocks can appear before the first user turn, but the
+-- conversation is still empty from the user's perspective.
+conversationIsEmpty :: UiState -> Bool
+conversationIsEmpty state =
+    all isStartupStatus (toList state.uiBlocks)
+  where
+    isStartupStatus block =
+        block.blockKind == BlockSystem
+            && block.blockTitle == "System"
+
 reduceUi :: UiEvent -> UiState -> UiState
 reduceUi event state = case event of
     UiLoop loopEvent -> reduceLoop loopEvent state
@@ -358,7 +369,7 @@ reduceUi event state = case event of
                             Nothing
                         | otherwise = state.uiNotice
                 in state
-                    { uiFrame = (state.uiFrame + 1) `mod` 10
+                    { uiFrame = nextUiFrame state.uiFrame
                     , uiElapsedTenths =
                         if state.uiRunning
                             then state.uiElapsedTenths + 1
@@ -377,11 +388,16 @@ uiNeedsTick :: UiState -> Bool
 uiNeedsTick state =
     state.uiRunning
         || state.uiCompletionTicks > 0
+        || conversationIsEmpty state
         || maybe False noticeNeedsTick state.uiNotice
   where
     noticeNeedsTick notice =
         notice.noticeTransient
             || notice.noticeKind == NoticeProgress
+
+nextUiFrame :: Int -> Int
+nextUiFrame frame =
+    (frame + 1) `mod` 120
 
 reduceLoop :: LoopEvent -> UiState -> UiState
 reduceLoop event state = case event of

--- a/packages/agent-tui/src/Agent/TUI/Theme.hs
+++ b/packages/agent-tui/src/Agent/TUI/Theme.hs
@@ -15,6 +15,10 @@ module Agent.TUI.Theme
     , emphasisAttr
     , headingAttr
     , inlineCodeAttr
+    , lambdaDimAttr
+    , lambdaGlowAttr
+    , lambdaSparkAttr
+    , lambdaTrailAttr
     , linkAttr
     , mutedAttr
     , selectedAttr
@@ -36,6 +40,7 @@ userAttr, assistantAttr, thinkingAttr, toolAttr :: AttrName
 errorAttr, successAttr, selectedAttr, borderAttr, borderActiveAttr :: AttrName
 headingAttr, codeAttr, dimAttr, emphasisAttr, inlineCodeAttr, linkAttr, strongAttr :: AttrName
 controlLinkAttr, controlLinkHoverAttr, controlLinkActiveAttr :: AttrName
+lambdaDimAttr, lambdaTrailAttr, lambdaGlowAttr, lambdaSparkAttr :: AttrName
 baseAttr = attrName "base"
 headerAttr = attrName "header"
 footerAttr = attrName "footer"
@@ -54,6 +59,10 @@ codeAttr = attrName "markdown-code"
 dimAttr = attrName "dim"
 emphasisAttr = attrName "markdown-emphasis"
 inlineCodeAttr = attrName "markdown-inline-code"
+lambdaDimAttr = attrName "lambda-dim"
+lambdaTrailAttr = attrName "lambda-trail"
+lambdaGlowAttr = attrName "lambda-glow"
+lambdaSparkAttr = attrName "lambda-spark"
 linkAttr = attrName "markdown-link"
 strongAttr = attrName "markdown-strong"
 controlLinkAttr = attrName "control-link"
@@ -123,6 +132,20 @@ solarizedDark =
         , (inlineCodeAttr, V.defAttr
             `V.withForeColor` rgb 42 161 152
             `V.withBackColor` rgb 7 54 66)
+        , (lambdaDimAttr, V.defAttr
+            `V.withForeColor` rgb 69 94 100
+            `V.withBackColor` rgb 0 43 54)
+        , (lambdaTrailAttr, V.defAttr
+            `V.withForeColor` rgb 38 139 210
+            `V.withBackColor` rgb 0 43 54)
+        , (lambdaGlowAttr, V.defAttr
+            `V.withForeColor` rgb 42 161 152
+            `V.withBackColor` rgb 0 43 54
+            `V.withStyle` V.bold)
+        , (lambdaSparkAttr, V.defAttr
+            `V.withForeColor` rgb 211 54 130
+            `V.withBackColor` rgb 0 43 54
+            `V.withStyle` V.bold)
         , (linkAttr, V.defAttr
             `V.withForeColor` rgb 38 139 210
             `V.withBackColor` rgb 0 43 54
@@ -165,6 +188,11 @@ monochrome =
         , (dimAttr, V.defAttr)
         , (emphasisAttr, V.defAttr `V.withStyle` V.italic)
         , (inlineCodeAttr, V.defAttr `V.withStyle` V.reverseVideo)
+        , (lambdaDimAttr, V.defAttr)
+        , (lambdaTrailAttr, V.defAttr `V.withStyle` V.bold)
+        , (lambdaGlowAttr, V.defAttr `V.withStyle` V.bold)
+        , (lambdaSparkAttr, V.defAttr
+            `V.withStyle` (V.bold .|. V.reverseVideo))
         , (linkAttr, V.defAttr `V.withStyle` V.underline)
         , (strongAttr, V.defAttr `V.withStyle` V.bold)
         , (controlLinkAttr, V.defAttr `V.withStyle` V.underline)

--- a/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
@@ -166,8 +166,15 @@ spec = describe "fullscreen UI reducer" do
                 block.blockBody `shouldBe` "live output"
             _ -> expectationFailure "expected one running tool block"
 
-    it "tracks elapsed tenths only while a turn is running" do
-        let idle = apply [UiTick, UiTick]
+    it "animates an empty conversation without advancing elapsed time" do
+        let emptyIdle = apply [UiSystemMessage "startup status", UiTick, UiTick]
+            wrapped =
+                apply (UiSystemMessage "startup status" : replicate 120 UiTick)
+            nonEmptyIdle =
+                reduceUi UiTick $
+                    reduceUi (UiUserSubmitted "hello") initialUiState
+            compactedHistory =
+                reduceUi (UiHistory "compacted summary") initialUiState
             running = apply [UiLoop TurnStarted, UiTick, UiTick, UiTick]
             finished =
                 reduceUi
@@ -176,8 +183,13 @@ spec = describe "fullscreen UI reducer" do
                             (emptyTurnOutput "r1" [] Nothing)))
                     running
             after = reduceUi UiTick finished
-        idle.uiElapsedTenths `shouldBe` 0
-        idle.uiFrame `shouldBe` 0
+        emptyIdle.uiElapsedTenths `shouldBe` 0
+        emptyIdle.uiFrame `shouldBe` 2
+        wrapped.uiFrame `shouldBe` 0
+        conversationIsEmpty emptyIdle `shouldBe` True
+        conversationIsEmpty nonEmptyIdle `shouldBe` False
+        conversationIsEmpty compactedHistory `shouldBe` False
+        nonEmptyIdle.uiFrame `shouldBe` 0
         running.uiElapsedTenths `shouldBe` 3
         after.uiElapsedTenths `shouldBe` 3
 


### PR DESCRIPTION
## Summary
- recover the animated empty-conversation lambda work from crashed session `2026-08-21-0c3d92f4`
- render a responsive lowercase lambda with animated shimmer and orbiting particles
- keep startup status messages compatible with the empty state while preserving compacted/resumed history
- retain 10 Hz model ticks while presenting the idle artwork at 5 FPS

## Validation
- `agent-tui-test`: 28 examples, 0 failures
- focused fullscreen TUI bridge/scrolling tests: 15 examples, 0 failures
- live tmux smoke test at 120×40, 80×24, and 80×16
- independent post-rebase review: no remaining findings
