### PR TITLE
feat(cli): add live agent activity previews

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -18,12 +18,15 @@ import Agent.CLI.Artifact (fencedCodeBlock, lastDiffBlock)
 import Agent.CLI.Auth (LoadedAuth(..), loadAuth, probeLoadedAuth)
 import Agent.CLI.AgentViewport
     ( AgentEntry(..)
+    , AgentStep
     , AgentTarget(..)
     , AgentViewportEnv(..)
+    , agentStepsForStatus
     , formatAgentStatus
     , pickAgentViewport
     , renderAgentViewportPanelFor
     , responseItemPreviewLines
+    , responseItemStepPreviews
     )
 import Agent.CLI.SessionTitle
     ( SessionTitleResult(..)
@@ -212,6 +215,7 @@ import Agent.CLI.TUI.App
     , setFullscreenWindowTitle
     , withFullscreenSuspended
     )
+import qualified Agent.CLI.TUI.Bridge as TuiBridge
 import Agent.TUI.Model
     ( PromptState(..)
     , UiEvent(..)
@@ -364,6 +368,7 @@ import System.Console.ANSI (getTerminalSize)
 import System.Console.ANSI.Codes (clearFromCursorToLineEndCode)
 import System.Exit (ExitCode(..), die, exitFailure)
 import System.IO (Handle, hFlush, hIsTerminalDevice, stderr, stdin, stdout)
+import System.Mem.StableName (StableName, makeStableName)
 import System.Process (readProcessWithExitCode)
 import System.Timeout (timeout)
 
@@ -381,6 +386,12 @@ data RunResult
     | RunResumeSession Text
       -- ^ Persisted session id. Consumed after the current provider-specific
       -- backend shuts down before starting the selected session.
+
+data AgentStepCache = AgentStepCache
+    { cachedTranscript :: !(StableName [ResponseItem])
+    , cachedVariant :: !(Maybe SubagentStatus)
+    , cachedSteps :: ![AgentStep]
+    }
 
 data StartupRuntime = StartupRuntime
     { startupToolEnv :: !ToolEnv
@@ -1280,12 +1291,44 @@ runSession options provider policy tools toolEnv planMode startup prompt pending
     previous <- newIORef initialPrevious
     titleTurnCount <- newIORef =<< sessionTitleTurnCountFromSlot persist
     selectedAgent <- newIORef AgentRoot
-    let loadAgentEntries includeSummaries = do
-            selected <- readIORef selectedAgent
+    agentStepCache <- newIORef (Map.empty :: Map AgentTarget AgentStepCache)
+    let cachedAgentSteps target variant items build = do
+            transcriptName <- makeStableName items
+            cache <- readIORef agentStepCache
+            case Map.lookup target cache of
+                Just cached
+                    | cached.cachedTranscript == transcriptName
+                    , cached.cachedVariant == variant ->
+                        pure cached.cachedSteps
+                _ -> do
+                    let steps = build items
+                    atomicModifyIORef' agentStepCache \current ->
+                        ( Map.insert target (AgentStepCache
+                            { cachedTranscript = transcriptName
+                            , cachedVariant = variant
+                            , cachedSteps = steps
+                            })
+                            current
+                        , ()
+                        )
+                    pure steps
+        loadAgentSnapshot includeSummaries = do
             rootItems <- readIORef transcriptRef
             agents <- case multiCtx of
                 Nothing -> pure []
                 Just ctx -> listAgents ctx.multiRegistry Nothing
+            let availableTargets =
+                    AgentRoot
+                        : [ AgentChild agentId
+                          | (_, agentId, _) <- agents
+                          ]
+            selected <-
+                atomicModifyIORef' selectedAgent \current ->
+                    let reconciled =
+                            TuiBridge.reconcileAgentSelection
+                                availableTargets
+                                current
+                    in (reconciled, reconciled)
             sessions <- readIORef subagentSessions
             let previewCount target =
                     if null agents
@@ -1295,10 +1338,19 @@ runSession options provider policy tools toolEnv planMode startup prompt pending
                             else if includeSummaries
                                 then Just 0
                                 else Nothing
+            rootSteps <-
+                if null agents
+                    then pure []
+                    else cachedAgentSteps
+                        AgentRoot
+                        Nothing
+                        rootItems
+                        (responseItemStepPreviews 2)
             let rootEntry = AgentEntry
                     { agentTarget = AgentRoot
                     , agentPath = "/root"
                     , agentStatus = "active"
+                    , agentSteps = rootSteps
                     , agentTranscript = case previewCount AgentRoot of
                         Nothing -> []
                         Just count ->
@@ -1307,32 +1359,37 @@ runSession options provider policy tools toolEnv planMode startup prompt pending
             children <- mapM
                 (materializeChild previewCount sessions)
                 agents
-            pure (rootEntry : children)
+            pure (selected, rootEntry : children)
           where
             materializeChild previewCount sessions (path, agentId, status) = do
                 let target = AgentChild agentId
-                transcript <- case previewCount target of
+                items <- case Map.lookup agentId sessions of
                     Nothing -> pure []
-                    Just count -> do
-                        stored <- case Map.lookup agentId sessions of
-                            Nothing ->
-                                pure ["(" <> formatAgentStatus status <> ")"]
-                            Just session ->
-                                responseItemPreviewLines count
-                                    <$> readIORef session.subSessionTranscript
-                        pure $
+                    Just session -> readIORef session.subSessionTranscript
+                steps <- cachedAgentSteps
+                    target
+                    (Just status)
+                    items
+                    (agentStepsForStatus 2 status)
+                let transcript = case previewCount target of
+                        Nothing -> []
+                        Just count ->
                             compactAgentPreview count $
-                                stored <> case status of
-                                    Completed (Just result)
-                                        | not (Text.null (Text.strip result)) ->
-                                            ["assistant: " <> Text.strip result]
-                                    Errored message ->
-                                        ["error: " <> Text.strip message]
-                                    _ -> []
+                                (if null items
+                                    then ["(" <> formatAgentStatus status <> ")"]
+                                    else responseItemPreviewLines count items)
+                                    <> case status of
+                                        Completed (Just result)
+                                            | not (Text.null (Text.strip result)) ->
+                                                ["assistant: " <> Text.strip result]
+                                        Errored message ->
+                                            ["error: " <> Text.strip message]
+                                        _ -> []
                 pure AgentEntry
                     { agentTarget = target
                     , agentPath = taskPathText path
                     , agentStatus = formatAgentStatus status
+                    , agentSteps = steps
                     , agentTranscript = transcript
                     }
             compactAgentPreview count rows
@@ -1344,10 +1401,10 @@ runSession options provider policy tools toolEnv planMode startup prompt pending
                             : drop (max 0 (length rows - count)) rows
         agentViewport = AgentViewportEnv
             { viewportSelected = selectedAgent
-            , viewportEntries = loadAgentEntries True
+            , viewportEntries = snd <$> loadAgentSnapshot True
             }
     writeIORef startup.startupAgentSnapshot
-        ((,) <$> readIORef selectedAgent <*> loadAgentEntries False)
+        (loadAgentSnapshot False)
     writeIORef startup.startupAgentSelect (writeIORef selectedAgent)
     let sessionReset = do
             resetLiveConversation previous transcriptRef attachmentsRef planMode
@@ -1356,6 +1413,7 @@ runSession options provider policy tools toolEnv planMode startup prompt pending
             writeIORef pendingNotices []
             writeIORef subagentSessions Map.empty
             writeIORef selectedAgent AgentRoot
+            writeIORef agentStepCache Map.empty
             case multiCtx of
                 Just ctx -> resetSubagentRegistry ctx.multiRegistry
                 Nothing -> pure ()

--- a/packages/agent-cli/src/Agent/CLI/AgentViewport.hs
+++ b/packages/agent-cli/src/Agent/CLI/AgentViewport.hs
@@ -1,10 +1,15 @@
 -- | Finder-style agent tree and transcript preview.
 module Agent.CLI.AgentViewport
     ( AgentEntry(..)
+    , AgentStep(..)
+    , AgentStepState(..)
     , AgentTarget(..)
     , AgentViewportEnv(..)
     , AgentViewportState(..)
+    , agentDisplayName
     , agentEntryTreeLabel
+    , agentStatusGlyph
+    , agentStepsForStatus
     , applyAgentViewportKey
     , formatAgentStatus
     , initialAgentViewportState
@@ -16,16 +21,21 @@ module Agent.CLI.AgentViewport
     , renderAgentViewportFrameFor
     , responseItemLines
     , responseItemPreviewLines
+    , responseItemStepPreviews
     , selectAgentTarget
     , selectedAgentEntry
     ) where
 
+import Agent.CLI.Render (summarizeToolCall)
 import Agent.CLI.Picker (PickerKey(..), runOverlay)
 import Agent.CLI.Style (roleMuted, rolePrompt, roleSuccess)
 import Agent.Responses.Types
 import Agent.Subagents (SubagentId(..), SubagentStatus(..))
+import Agent.ToolDispatch (customToolCall, functionToolCall)
 import Data.IORef (IORef)
 import Data.List (findIndex, sortOn)
+import qualified Data.Map.Strict as Map
+import Data.Maybe (listToMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
@@ -37,10 +47,25 @@ data AgentTarget
     | AgentChild !SubagentId
     deriving (Eq, Ord, Show)
 
+data AgentStepState
+    = AgentStepRunning
+    | AgentStepCompleted
+    | AgentStepFailed
+    | AgentStepInfo
+    deriving (Eq, Show)
+
+data AgentStep = AgentStep
+    { agentStepState :: !AgentStepState
+    , agentStepTitle :: !Text
+    , agentStepDetail :: !(Maybe Text)
+    }
+    deriving (Eq, Show)
+
 data AgentEntry = AgentEntry
     { agentTarget :: !AgentTarget
     , agentPath :: !Text
     , agentStatus :: !Text
+    , agentSteps :: ![AgentStep]
     , agentTranscript :: ![Text]
     }
     deriving (Eq, Show)
@@ -54,6 +79,19 @@ formatAgentStatus status = case status of
     Interrupted -> "interrupted"
     Closed -> "closed"
     NotFound -> "missing"
+
+agentStatusGlyph :: Text -> Text
+agentStatusGlyph status = case Text.toLower status of
+    "active" -> "●"
+    "running" -> "●"
+    "ready" -> "○"
+    "pending" -> "○"
+    "done" -> "✓"
+    "error" -> "✕"
+    "interrupted" -> "■"
+    "closed" -> "×"
+    "missing" -> "?"
+    _ -> "·"
 
 data AgentViewportEnv = AgentViewportEnv
     { viewportSelected :: !(IORef AgentTarget)
@@ -294,6 +332,200 @@ responseItemPreviewLines count items
                 selected = drop (max 0 (rowCount - needed)) rows
             in (max 0 (needed - rowCount), selected <> kept)
 
+-- | Return the latest meaningful agent actions, newest first. Tool outputs are
+-- folded into their originating calls so the preview shows one semantic step
+-- instead of adjacent @tool: name@ / @tool: completed@ rows.
+responseItemStepPreviews :: Int -> [ResponseItem] -> [AgentStep]
+responseItemStepPreviews count items
+    | count <= 0 = []
+    | otherwise = go count Map.empty (reverse items)
+  where
+    go _ _ [] = []
+    go remaining completed (item : rest)
+        | remaining <= 0 = []
+        | otherwise = case item of
+            FunctionCallOutputItem output ->
+                go remaining
+                    (rememberNewestOutput output.callId
+                        (outputStepState output.status)
+                        completed)
+                    rest
+            CustomToolCallOutputItem output ->
+                go remaining
+                    (rememberNewestOutput output.callId
+                        (outputStepState output.status)
+                        completed)
+                    rest
+            FunctionCallItem call ->
+                let state =
+                        Map.findWithDefault
+                            (callStepState call.status)
+                            call.callId
+                            completed
+                    step =
+                        AgentStep
+                            { agentStepState = state
+                            , agentStepTitle =
+                                summarizeToolCall
+                                    (functionToolCall
+                                        call.callId
+                                        call.name
+                                        call.arguments)
+                            , agentStepDetail = stepStateDetail state
+                            }
+                in step
+                    : go (remaining - 1)
+                        (Map.delete call.callId completed)
+                        rest
+            CustomToolCallItem call ->
+                let state =
+                        Map.findWithDefault
+                            (callStepState call.status)
+                            call.callId
+                            completed
+                    step =
+                        AgentStep
+                            { agentStepState = state
+                            , agentStepTitle =
+                                summarizeToolCall
+                                    (customToolCall
+                                        call.callId
+                                        call.name
+                                        call.input)
+                            , agentStepDetail = stepStateDetail state
+                            }
+                in step
+                    : go (remaining - 1)
+                        (Map.delete call.callId completed)
+                        rest
+            MessageItem message
+                | message.role == RoleAssistant ->
+                    case textStep
+                        (messageStepState message.status)
+                        (responseMessageText message.content) of
+                        Nothing -> go remaining completed rest
+                        Just step ->
+                            step : go (remaining - 1) completed rest
+            _ -> go remaining completed rest
+
+    -- We traverse newest-to-oldest. Keep the first output state seen for a
+    -- call so an older partial update cannot overwrite its final status.
+    rememberNewestOutput callId state =
+        Map.insertWith (\_ newest -> newest) callId state
+
+callStepState :: Maybe ItemStatus -> AgentStepState
+callStepState = \case
+    Just ItemIncomplete -> AgentStepFailed
+    Just (ItemStatusUnknown status)
+        | Text.toLower status `elem` ["failed", "error", "cancelled"] ->
+            AgentStepFailed
+    -- A completed call item means the model finished emitting the call, not
+    -- that the tool finished executing. The matching output item settles it.
+    _ -> AgentStepRunning
+
+outputStepState :: Maybe ItemStatus -> AgentStepState
+outputStepState = \case
+    Just ItemCompleted -> AgentStepCompleted
+    Just ItemIncomplete -> AgentStepFailed
+    Just (ItemStatusUnknown status)
+        | Text.toLower status `elem` ["failed", "error", "cancelled"] ->
+            AgentStepFailed
+    _ -> AgentStepInfo
+
+stepStateDetail :: AgentStepState -> Maybe Text
+stepStateDetail = \case
+    AgentStepInfo -> Just "finished"
+    _ -> Nothing
+
+messageStepState :: Maybe ItemStatus -> AgentStepState
+messageStepState = \case
+    Just ItemInProgress -> AgentStepRunning
+    Just ItemIncomplete -> AgentStepFailed
+    Just (ItemStatusUnknown status)
+        | Text.toLower status `elem` ["failed", "error", "cancelled"] ->
+            AgentStepFailed
+    _ -> AgentStepCompleted
+
+agentStepsForStatus
+    :: Int
+    -> SubagentStatus
+    -> [ResponseItem]
+    -> [AgentStep]
+agentStepsForStatus count status items
+    | count <= 0 = []
+    | otherwise = take count $ case status of
+        Pending ->
+            AgentStep AgentStepRunning "Waiting to start" Nothing : settled
+        Running
+            | any ((== AgentStepRunning) . (.agentStepState)) recent ->
+                recent
+            | otherwise ->
+                AgentStep AgentStepRunning "Working…" Nothing : recent
+        Completed result ->
+            maybe
+                (fallback
+                    (AgentStep AgentStepCompleted "Finished" Nothing)
+                    settled)
+                (\raw ->
+                    maybe settled (`prependDistinct` settled)
+                        (textStep AgentStepCompleted raw))
+                (nonEmptyText =<< result)
+        Errored message ->
+            AgentStep
+                { agentStepState = AgentStepFailed
+                , agentStepTitle = "Agent failed"
+                , agentStepDetail = nonEmptyText message
+                }
+                : settled
+        Interrupted ->
+            AgentStep AgentStepFailed "Agent interrupted" Nothing : settled
+        Closed ->
+            fallback
+                (AgentStep AgentStepCompleted "Agent closed" Nothing)
+                settled
+        NotFound ->
+            AgentStep AgentStepFailed "Agent unavailable" Nothing : settled
+  where
+    recent = responseItemStepPreviews count items
+    settled = map settleStep recent
+
+    settleStep step
+        | step.agentStepState == AgentStepRunning =
+            step { agentStepState = AgentStepCompleted }
+        | otherwise = step
+
+    fallback step [] = [step]
+    fallback _ steps = steps
+
+prependDistinct :: AgentStep -> [AgentStep] -> [AgentStep]
+prependDistinct step steps =
+    case steps of
+        current : _
+            | normalizedStepTitle current == normalizedStepTitle step -> steps
+        _ -> step : steps
+
+normalizedStepTitle :: AgentStep -> Text
+normalizedStepTitle =
+    Text.toCaseFold . Text.unwords . Text.words . (.agentStepTitle)
+
+textStep :: AgentStepState -> Text -> Maybe AgentStep
+textStep state raw = do
+    title <- listToMaybe lines_
+    pure AgentStep
+        { agentStepState = state
+        , agentStepTitle = title
+        , agentStepDetail = listToMaybe (drop 1 lines_)
+        }
+  where
+    lines_ =
+        filter (not . Text.null) $
+            map (Text.unwords . Text.words) (Text.lines (Text.strip raw))
+
+nonEmptyText :: Text -> Maybe Text
+nonEmptyText raw =
+    let compact = Text.unwords (Text.words raw)
+    in if Text.null compact then Nothing else Just compact
+
 responseItemFirstLine :: [ResponseItem] -> Maybe Text
 responseItemFirstLine = go
   where
@@ -382,12 +614,14 @@ findByTarget target = go
 agentEntryTreeLabel :: [AgentEntry] -> Int -> AgentEntry -> Text
 agentEntryTreeLabel entries index entry =
     treePrefix entries index entry.agentPath
-        <> pathName entry.agentPath
+        <> agentDisplayName entry.agentPath
         <> "  "
+        <> agentStatusGlyph entry.agentStatus
+        <> " "
         <> entry.agentStatus
 
-pathName :: Text -> Text
-pathName path =
+agentDisplayName :: Text -> Text
+agentDisplayName path =
     case reverse (filter (not . Text.null) (Text.splitOn "/" path)) of
         name : _ -> name
         [] -> "root"

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -2,6 +2,9 @@
 module Agent.CLI.TUI.App
     ( FullscreenInputBuffer
     , FullscreenRuntime
+    , agentEntryWindow
+    , agentPaneEntryLimit
+    , agentPaneVisible
     , emitUiEvent
     , hasQueuedFullscreenInput
     , newFullscreenInputBuffer
@@ -30,10 +33,14 @@ import Agent.CLI.Input
     , appendReplHistory
     , readReplHistory
     , terminalTextWidth
+    , truncateDisplayText
     )
 import Agent.CLI.AgentViewport
     ( AgentEntry(..)
+    , AgentStep(..)
+    , AgentStepState(..)
     , AgentTarget(..)
+    , agentDisplayName
     , agentEntryTreeLabel
     )
 import Agent.CLI.Interrupt (CtrlCDecision(..))
@@ -135,7 +142,9 @@ data Name
     | PermissionRow !Int
     | SlashRow !Int
     | OverlayCursor
+    | AgentPane
     | AgentRow !AgentTarget
+    | AgentPopover !AgentTarget
     deriving (Eq, Ord, Show)
 
 data AppEvent
@@ -219,11 +228,19 @@ data AppState = AppState
     , appImagePreviews :: ![TuiImagePreview]
     , appAgentSelected :: !AgentTarget
     , appAgentEntries :: ![AgentEntry]
+    , appAgentHover :: !(Maybe AgentHover)
     , appHoveredControl :: !(Maybe Name)
     , appPressedControl :: !(Maybe Name)
     , appWorkerStopped :: !Bool
     , appConversationAnchor :: !(Maybe Scroll.ConversationAnchor)
     , appConversationReflowQueued :: !Bool
+    }
+
+data AgentHover = AgentHover
+    { agentHoverTarget :: !AgentTarget
+    , agentHoverUpperLeft :: !Location
+    , agentHoverPaneUpperLeft :: !Location
+    , agentHoverPaneWidth :: !Int
     }
 
 data ChoiceOverlay = ChoiceOverlay
@@ -452,6 +469,7 @@ runFullscreen runtime workerAction = do
             , appImagePreviews = []
             , appAgentSelected = initialAgent
             , appAgentEntries = initialAgents
+            , appAgentHover = Nothing
             , appHoveredControl = Nothing
             , appPressedControl = Nothing
             , appWorkerStopped = False
@@ -969,6 +987,7 @@ fullscreenApp = App
 drawApp :: AppState -> [Widget Name]
 drawApp state =
     let mainLayers = stickyPromptLayers state <> [drawMain state]
+        interactiveLayers = agentPopoverLayers state <> mainLayers
         dimmedMainLayers = map (forceAttr Theme.dimAttr) mainLayers
     in
     case (state.appTextPrompt, state.appChoice, state.appUi.uiPermission) of
@@ -978,7 +997,7 @@ drawApp state =
             drawChoice state choice : dimmedMainLayers
         (Nothing, Nothing, Just permission) ->
             drawPermission permission : dimmedMainLayers
-        (Nothing, Nothing, Nothing) -> mainLayers
+        (Nothing, Nothing, Nothing) -> interactiveLayers
 
 drawMain :: AppState -> Widget Name
 drawMain state =
@@ -1025,18 +1044,30 @@ drawImagePreviews previews =
 
 drawWorkspace :: AppState -> Widget Name
 drawWorkspace state =
-    padTop (Pad 1) $
-        hBox $
-            [ drawConversationPane state ]
-                <> if length state.appAgentEntries <= 1
-                    then []
-                    else
-                        [ hLimit 42 $
-                            padLeft (Pad 1) $
-                                drawAgentPane
-                                    state.appAgentSelected
-                                    state.appAgentEntries
-                        ]
+    Widget Greedy Greedy do
+        context <- getContext
+        render $
+            padTop (Pad 1) $
+                hBox $
+                    [drawConversationPane state]
+                        <> if not
+                            (agentPaneVisible
+                                context.availWidth
+                                context.availHeight
+                                state.appAgentEntries)
+                            then []
+                            else
+                                [ hLimitPercent 40 $
+                                    hLimit agentPaneWidth $
+                                        padLeft (Pad 1) $
+                                            drawAgentPane
+                                                (agentPaneEntryLimit
+                                                    context.availHeight)
+                                                state.appAgentSelected
+                                                ((.agentHoverTarget)
+                                                    <$> state.appAgentHover)
+                                                state.appAgentEntries
+                                ]
 
 drawConversationPane :: AppState -> Widget Name
 drawConversationPane state
@@ -1051,37 +1082,74 @@ drawConversationPane state
             viewport ConversationViewport Vertical $
                 padLeftRight 2 (drawTranscript state)
 
-drawAgentPane :: AgentTarget -> [AgentEntry] -> Widget Name
-drawAgentPane selected entries =
-    withAttr Theme.borderAttr $
-        withBorderStyle unicodeRounded $
-            borderWithLabel (txt " Agents ") $
-                padAll 1 $
-                    vBox
-                        [ vBox agentRows
-                        , padTop (Pad 1) $
-                            withAttr Theme.footerAttr $
-                                txtWrap
-                                    ("viewing "
-                                        <> maybe "/root" (.agentPath)
-                                            selectedEntry
-                                        <> " · /agents to switch")
-                        , padTop (Pad 1) $
-                            withAttr Theme.assistantAttr $
-                                vBox (map txtWrap transcript)
-                        ]
+agentPaneWidth :: Int
+agentPaneWidth = 42
+
+agentPaneMinScreenWidth :: Int
+agentPaneMinScreenWidth = 72
+
+agentPaneMinAvailableHeight :: Int
+agentPaneMinAvailableHeight = 10
+
+agentPaneVisible :: Int -> Int -> [AgentEntry] -> Bool
+agentPaneVisible width height entries =
+    width >= agentPaneMinScreenWidth
+        && height >= agentPaneMinAvailableHeight
+        && length entries > 1
+
+agentPaneEntryLimit :: Int -> Int
+agentPaneEntryLimit availableHeight =
+    -- Reserve the outer top pad, six pane chrome rows (border, padding,
+    -- footer), and two possible truncation indicators above and below.
+    max 1 (min 12 (availableHeight - 9))
+
+drawAgentPane
+    :: Int
+    -> AgentTarget
+    -> Maybe AgentTarget
+    -> [AgentEntry]
+    -> Widget Name
+drawAgentPane entryLimit selected hovered entries =
+    clickable AgentPane $
+        withAttr Theme.borderAttr $
+            withBorderStyle unicodeRounded $
+                borderWithLabel
+                    (txt
+                        (" Agents · "
+                            <> Text.pack (show childCount)
+                            <> " ")) $
+                    padAll 1 $
+                        vBox
+                            [ vBox agentRows
+                            , padTop (Pad 1) $
+                                withAttr Theme.footerAttr $
+                                    txt "hover preview · /agents switch"
+                            ]
   where
     ordered = sortOn (.agentPath) entries
-    selectedEntry =
-        find ((== selected) . (.agentTarget)) ordered
-    shownEntries = agentEntryWindow 12 selected ordered
-    hiddenCount = max 0 (length ordered - length shownEntries)
+    childCount =
+        length
+            [ ()
+            | entry <- ordered
+            , entry.agentTarget /= AgentRoot
+            ]
+    (hiddenBefore, shownEntries, hiddenAfter) =
+        agentEntryWindow entryLimit selected ordered
     agentRows =
-        map drawEntry shownEntries
-            <> [ withAttr Theme.mutedAttr $
-                    txt ("  … " <> Text.pack (show hiddenCount) <> " more")
-               | hiddenCount > 0
+        [ drawHidden hiddenBefore "above"
+        | hiddenBefore > 0
+        ]
+            <> map drawEntry shownEntries
+            <> [ drawHidden hiddenAfter "below"
+               | hiddenAfter > 0
                ]
+    drawHidden count direction =
+        withAttr Theme.mutedAttr $
+            txt
+                ("  … "
+                    <> Text.pack (show count)
+                    <> " "
+                    <> direction)
     drawEntry entry =
         let
             index =
@@ -1089,38 +1157,190 @@ drawAgentPane selected entries =
                     findIndex ((== entry.agentTarget) . (.agentTarget)) ordered
             marker =
                 if entry.agentTarget == selected then "› " else "  "
-            row =
-                txt
-                    (marker
-                        <> agentEntryTreeLabel ordered index entry)
+            row = hBox
+                [ txt (marker <> agentEntryTreeLabel ordered index entry)
+                , fill ' '
+                ]
             styled =
-                if entry.agentTarget == selected
-                    then withAttr Theme.successAttr row
-                    else row
-        in clickable (AgentRow entry.agentTarget) styled
-    transcript = case selectedEntry of
-        Nothing -> ["(agent unavailable)"]
-        Just entry ->
-            let rows =
-                    filter (not . Text.null . Text.strip)
-                        entry.agentTranscript
-            in if null rows
-                then ["(no transcript)"]
-                else drop (max 0 (length rows - 12)) rows
+                if hovered == Just entry.agentTarget
+                    then withAttr Theme.controlLinkHoverAttr row
+                    else if entry.agentTarget == selected
+                        then withAttr Theme.successAttr row
+                        else row
+        in clickable (AgentRow entry.agentTarget) (vLimit 1 styled)
 
-agentEntryWindow :: Int -> AgentTarget -> [AgentEntry] -> [AgentEntry]
+agentPopoverLayers :: AppState -> [Widget Name]
+agentPopoverLayers state =
+    case (length state.appAgentEntries > 1, state.appAgentHover) of
+        (False, _) -> []
+        (_, Nothing) -> []
+        (True, Just hover) ->
+            case find
+                ((== hover.agentHoverTarget) . (.agentTarget))
+                state.appAgentEntries of
+                Nothing -> []
+                Just entry -> [positionAgentPopover hover entry]
+
+agentPopoverPreferredWidth :: Int
+agentPopoverPreferredWidth = 40
+
+agentPopoverMinWidth :: Int
+agentPopoverMinWidth = 24
+
+agentPopoverHeight :: Int
+agentPopoverHeight = 9
+
+agentPopoverGap :: Int
+agentPopoverGap = 1
+
+positionAgentPopover :: AgentHover -> AgentEntry -> Widget Name
+positionAgentPopover hover entry =
+    Widget Fixed Fixed do
+        context <- getContext
+        let screenWidth = max 0 context.availWidth
+            screenHeight = max 0 context.availHeight
+            Location (_, anchorY) = hover.agentHoverUpperLeft
+            Location (paneX, _) = hover.agentHoverPaneUpperLeft
+            paneRight = paneX + max 1 hover.agentHoverPaneWidth
+            leftAvailable = max 0 (paneX - agentPopoverGap)
+            rightAvailable =
+                max 0 (screenWidth - paneRight - agentPopoverGap)
+            placeLeft =
+                leftAvailable >= agentPopoverMinWidth
+                    || leftAvailable >= rightAvailable
+            available =
+                if placeLeft then leftAvailable else rightAvailable
+            width = min agentPopoverPreferredWidth available
+            height = min agentPopoverHeight screenHeight
+            x
+                | placeLeft =
+                    max 0 (paneX - agentPopoverGap - width)
+                | otherwise =
+                    min
+                        (max 0 (screenWidth - width - agentPopoverGap))
+                        paneRight
+            y = max 0 (min anchorY (screenHeight - height))
+        if screenWidth < agentPaneMinScreenWidth
+            || width < agentPopoverMinWidth
+            || height < 5
+            then render emptyWidget
+            else
+                render $
+                    translateBy (Location (x, y)) $
+                        drawAgentPopover placeLeft width height entry
+
+drawAgentPopover :: Bool -> Int -> Int -> AgentEntry -> Widget Name
+drawAgentPopover placeLeft width height entry =
+    clickable (AgentPopover entry.agentTarget) surface
+  where
+    surface
+        | placeLeft = hBox [popover, bridge]
+        | otherwise = hBox [bridge, popover]
+    bridge =
+        hLimit agentPopoverGap $
+            vLimit height (fill ' ')
+    popover =
+        hLimit width $
+            vLimit height $
+                withAttr Theme.baseAttr $
+                    overrideAttr Border.borderAttr Theme.borderActiveAttr $
+                        withBorderStyle unicodeRounded $
+                            borderWithLabel
+                                (withAttr Theme.headingAttr $
+                                    txt
+                                        (" "
+                                            <> truncateDisplayText
+                                                (max 1 (width - 6))
+                                                (agentDisplayName entry.agentPath)
+                                            <> " ")) $
+                                padAll 1 $
+                                    vBox
+                                        ( intersperse
+                                            (vLimit 1 (fill ' '))
+                                            (map
+                                                (drawAgentStep
+                                                    (max 1 (width - 4)))
+                                                steps)
+                                            <> [fill ' ']
+                                        )
+    steps =
+        case take 2 entry.agentSteps of
+            [] ->
+                [ AgentStep
+                    { agentStepState = AgentStepInfo
+                    , agentStepTitle = "No recent activity"
+                    , agentStepDetail = Just entry.agentStatus
+                    }
+                ]
+            recent -> recent
+
+drawAgentStep :: Int -> AgentStep -> Widget Name
+drawAgentStep width step =
+    vLimit 2 $
+        vBox
+            [ hBox
+                [ withAttr (agentStepAttr step.agentStepState) $
+                    txt (agentStepGlyph step.agentStepState)
+                , txt " "
+                , withAttr Theme.assistantAttr $
+                    txt
+                        (truncateDisplayText
+                            (max 1 (width - 2))
+                            step.agentStepTitle)
+                ]
+            , padLeft (Pad 2) $
+                withAttr Theme.mutedAttr $
+                    txt
+                        (truncateDisplayText
+                            (max 1 (width - 2))
+                            (fromMaybe
+                                (agentStepStateLabel step.agentStepState)
+                                step.agentStepDetail))
+            ]
+
+agentStepGlyph :: AgentStepState -> Text
+agentStepGlyph = \case
+    AgentStepRunning -> "●"
+    AgentStepCompleted -> "✓"
+    AgentStepFailed -> "✕"
+    AgentStepInfo -> "◆"
+
+agentStepStateLabel :: AgentStepState -> Text
+agentStepStateLabel = \case
+    AgentStepRunning -> "running"
+    AgentStepCompleted -> "completed"
+    AgentStepFailed -> "failed"
+    AgentStepInfo -> "recent activity"
+
+agentStepAttr :: AgentStepState -> AttrName
+agentStepAttr = \case
+    AgentStepRunning -> Theme.thinkingAttr
+    AgentStepCompleted -> Theme.successAttr
+    AgentStepFailed -> Theme.errorAttr
+    AgentStepInfo -> Theme.toolAttr
+
+agentEntryWindow
+    :: Int
+    -> AgentTarget
+    -> [AgentEntry]
+    -> (Int, [AgentEntry], Int)
 agentEntryWindow count selected entries
-    | count <= 0 = []
-    | length entries <= count = entries
+    | count <= 0 = (0, [], length entries)
+    | length entries <= count = (0, entries, 0)
     | otherwise =
-        take count (drop start entries)
+        ( start
+        , take count (drop start entries)
+        , length entries - start - count
+        )
   where
     selectedIndex =
         maybe 0 id $
             findIndex ((== selected) . (.agentTarget)) entries
     start =
         max 0 $
-            min selectedIndex (length entries - count)
+            min
+                (selectedIndex - count `div` 2)
+                (length entries - count)
 
 drawHeader :: UiState -> Widget Name
 drawHeader state =
@@ -2106,6 +2326,21 @@ handleEvent event = case event of
                     current
                         { appAgentSelected = normalized
                         , appAgentEntries = entries
+                        , appAgentHover =
+                            if normalized /= current.appAgentSelected
+                                || length entries <= 1
+                                || agentLayoutTargets entries
+                                    /= agentLayoutTargets
+                                        current.appAgentEntries
+                                then Nothing
+                                else
+                                    current.appAgentHover >>= \hover ->
+                                        if any
+                                            ((== hover.agentHoverTarget)
+                                                . (.agentTarget))
+                                            entries
+                                            then Just hover
+                                            else Nothing
                         }
                 when
                     ((length state.appAgentEntries > 1)
@@ -2124,6 +2359,7 @@ handleEvent event = case event of
             state
                 { appUi = reduceUi (UiPermissionShown summary) state.appUi
                 , appPermissionReply = Just reply
+                , appAgentHover = Nothing
                 }
     AppEvent (AppAskChoice title body initial rows reply) -> do
         modify' \state ->
@@ -2136,6 +2372,7 @@ handleEvent event = case event of
                     , choiceRows = rows
                     }
                 , appChoiceReply = Just (atomically . putTMVar reply)
+                , appAgentHover = Nothing
                 }
         vScrollToBeginning (viewportScroll OverlayViewport)
     AppEvent (AppAskText title body initial reply) -> do
@@ -2148,6 +2385,7 @@ handleEvent event = case event of
                     , textCursor = Text.length initial
                     }
                 , appTextReply = Just reply
+                , appAgentHover = Nothing
                 }
         vScrollToBeginning (viewportScroll OverlayViewport)
     AppEvent (AppSuspend action reply) -> do
@@ -2155,8 +2393,9 @@ handleEvent event = case event of
         suspendAndResume do
             result <- tryAny action
             atomically (putTMVar reply result)
-            pure state
+            pure state { appAgentHover = Nothing }
     MouseDown name button _ _ -> do
+        unless (isAgentHoverSurface name) clearAgentHover
         state <- get
         case ( state.appTextPrompt
              , state.appChoice
@@ -2190,6 +2429,13 @@ handleEvent event = case event of
                     (SlashRow _, V.BScrollDown) ->
                         handleComposerKey (V.EvKey V.KDown [])
                     (AgentRow target, V.BLeft) -> do
+                        clearAgentHover
+                        liftIO
+                            (state.appRuntime.runtimeAgentSelect target)
+                        modify' \current ->
+                            current { appAgentSelected = target }
+                    (AgentPopover target, V.BLeft) -> do
+                        keepAgentHover target
                         liftIO
                             (state.appRuntime.runtimeAgentSelect target)
                         modify' \current ->
@@ -2219,29 +2465,41 @@ handleEvent event = case event of
                     _ -> pure ()
     -- The patched vty-unix backend represents no-button pointer motion as
     -- MouseUp Nothing so Brick can route it through clickable extents.
+    MouseUp (AgentRow target) Nothing _ ->
+        rememberAgentHover target
+    MouseUp (AgentPopover target) Nothing _ ->
+        keepAgentHover target
+    MouseUp AgentPane Nothing _ ->
+        pure ()
     MouseUp name button _
         | isInteractiveControl name
-        , button == Just V.BLeft || button == Nothing ->
+        , button == Just V.BLeft || button == Nothing -> do
+            clearAgentHover
             handleControlMouseUp name (activateControl name)
     MouseUp _ Nothing _ ->
         modify' \state ->
             state
                 { appHoveredControl = Nothing
+                , appAgentHover = Nothing
                 }
     VtyEvent (V.EvMouseDown _ _ V.BLeft _) ->
         modify' \state ->
             state
                 { appHoveredControl = Nothing
+                , appAgentHover = Nothing
                 }
     VtyEvent (V.EvMouseUp _ _ _) ->
         modify' \state ->
             state
                 { appHoveredControl = Nothing
                 , appPressedControl = Nothing
+                , appAgentHover = Nothing
                 }
-    VtyEvent V.EvResize{} ->
+    VtyEvent V.EvResize{} -> do
+        clearAgentHover
         invalidateCache
     VtyEvent vtyEvent -> do
+        clearAgentHover
         state <- get
         case (state.appTextPrompt, state.appChoice, state.appUi.uiPermission) of
             (Just _, _, _) -> handleTextPromptKey vtyEvent
@@ -2359,6 +2617,63 @@ activateSlashAt index = do
                     current { appSlashIndex = index }
                 handleComposerKey (V.EvKey V.KEnter [])
         _ -> pure ()
+
+rememberAgentHover :: AgentTarget -> EventM Name AppState ()
+rememberAgentHover target = do
+    rowExtent <- lookupExtent (AgentRow target)
+    paneExtent <- lookupExtent AgentPane
+    case rowExtent of
+        Nothing -> pure ()
+        Just extent ->
+            let Location (rowX, rowY) = extent.extentUpperLeft
+                fallbackPaneUpperLeft =
+                    Location (max 0 (rowX - 2), max 0 (rowY - 2))
+                fallbackPaneWidth = extentWidth extent + 4
+            in
+            modify' \state ->
+                state
+                    { appAgentHover =
+                        Just AgentHover
+                            { agentHoverTarget = target
+                            , agentHoverUpperLeft = extent.extentUpperLeft
+                            , agentHoverPaneUpperLeft =
+                                maybe
+                                    fallbackPaneUpperLeft
+                                    (.extentUpperLeft)
+                                    paneExtent
+                            , agentHoverPaneWidth =
+                                maybe
+                                    fallbackPaneWidth
+                                    extentWidth
+                                    paneExtent
+                            }
+                    }
+  where
+    extentWidth extent = fst extent.extentSize
+
+keepAgentHover :: AgentTarget -> EventM Name AppState ()
+keepAgentHover target = do
+    state <- get
+    case state.appAgentHover of
+        Just hover
+            | hover.agentHoverTarget == target -> pure ()
+        _ -> rememberAgentHover target
+
+clearAgentHover :: EventM Name AppState ()
+clearAgentHover =
+    modify' \state ->
+        state { appAgentHover = Nothing }
+
+isAgentHoverSurface :: Name -> Bool
+isAgentHoverSurface = \case
+    AgentPane -> True
+    AgentRow _ -> True
+    AgentPopover _ -> True
+    _ -> False
+
+agentLayoutTargets :: [AgentEntry] -> [AgentTarget]
+agentLayoutTargets =
+    map (.agentTarget) . sortOn (.agentPath)
 
 handleMouseDown :: Name -> V.Button -> EventM Name AppState ()
 handleMouseDown name button =

--- a/packages/agent-cli/src/Agent/CLI/TUI/Bridge.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Bridge.hs
@@ -6,6 +6,7 @@ module Agent.CLI.TUI.Bridge
     , mergeUiEvents
     , nativeProgressSignal
     , normalizeAgentSelection
+    , reconcileAgentSelection
     ) where
 
 import Agent.CLI.AgentViewport (AgentEntry(..), AgentTarget(..))
@@ -88,4 +89,13 @@ normalizeAgentSelection
     -> AgentTarget
 normalizeAgentSelection selected entries
     | any ((== selected) . (.agentTarget)) entries = selected
+    | otherwise = AgentRoot
+
+-- | Normalize the current shared selection against an available target set.
+reconcileAgentSelection
+    :: [AgentTarget]
+    -> AgentTarget
+    -> AgentTarget
+reconcileAgentSelection available current
+    | current `elem` available = current
     | otherwise = AgentRoot

--- a/packages/agent-cli/test/Agent/CLI/AgentViewportSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/AgentViewportSpec.hs
@@ -4,6 +4,7 @@ import Agent.CLI.AgentViewport
 import Agent.CLI.Picker (PickerKey(..))
 import Agent.Responses.Types
 import Agent.Subagents (SubagentId(..), SubagentStatus(..))
+import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.KeyMap as KeyMap
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -26,10 +27,10 @@ spec = do
                 `shouldBe`
                     Text.intercalate "\n"
                         [ "agents"
-                        , "  ▾ root  active"
-                        , "  ├─ alpha  running"
-                        , "› │  └─ gamma  done"
-                        , "  └─ beta  running"
+                        , "  ▾ root  ● active"
+                        , "  ├─ alpha  ● running"
+                        , "› │  └─ gamma  ✓ done"
+                        , "  └─ beta  ● running"
                         , "  viewing /root/alpha/gamma · /agents to switch"
                         ]
 
@@ -115,12 +116,122 @@ spec = do
                 ]
                 `shouldBe` ["user: request"]
 
+    describe "responseItemStepPreviews" do
+        it "coalesces tool calls with their outputs and returns newest first" do
+            let steps =
+                    responseItemStepPreviews 2
+                        [ messageItem RoleUser "fix it"
+                        , functionCallItem
+                            "call-1"
+                            "shell_command"
+                            "{\"command\":\"cabal test\"}"
+                            Nothing
+                        , functionOutputItem
+                            "call-1"
+                            (Just ItemCompleted)
+                        , messageItem
+                            RoleAssistant
+                            "Updated the retry policy\nFocused tests pass"
+                        ]
+            case steps of
+                [latest, tool] -> do
+                    map (.agentStepState) steps
+                        `shouldBe` [AgentStepCompleted, AgentStepCompleted]
+                    latest.agentStepTitle
+                        `shouldBe` "Updated the retry policy"
+                    latest.agentStepDetail
+                        `shouldBe` Just "Focused tests pass"
+                    tool.agentStepTitle
+                        `shouldSatisfy` Text.isInfixOf "cabal test"
+                _ -> expectationFailure
+                    ("expected exactly two semantic steps, got " <> show steps)
+
+        it "keeps a call running until its matching output arrives" do
+            let preview status =
+                    responseItemStepPreviews 1
+                        [ functionCallItem
+                            "call-1"
+                            "shell_command"
+                            "{\"command\":\"sleep 5\"}"
+                            (Just status)
+                        ]
+            map
+                (map (.agentStepState) . preview)
+                [ItemInProgress, ItemCompleted]
+                `shouldBe`
+                    [ [AgentStepRunning]
+                    , [AgentStepRunning]
+                    ]
+
+        it "treats production tool outputs without status as neutral" do
+            responseItemStepPreviews 1
+                [ functionCallItem
+                    "call-1"
+                    "shell_command"
+                    "{\"command\":\"false\"}"
+                    (Just ItemCompleted)
+                , functionOutputItem "call-1" Nothing
+                ]
+                `shouldSatisfy`
+                    \case
+                        [step] ->
+                            step.agentStepState == AgentStepInfo
+                                && step.agentStepDetail == Just "finished"
+                        _ -> False
+
+        it "keeps the newest status when a call has multiple outputs" do
+            responseItemStepPreviews 1
+                [ functionCallItem
+                    "call-1"
+                    "shell_command"
+                    "{\"command\":\"cabal test\"}"
+                    (Just ItemCompleted)
+                , functionOutputItem
+                    "call-1"
+                    (Just ItemIncomplete)
+                , functionOutputItem
+                    "call-1"
+                    (Just ItemCompleted)
+                ]
+                `shouldSatisfy`
+                    \case
+                        [step] ->
+                            step.agentStepState == AgentStepCompleted
+                        _ -> False
+
+        it "adds live and terminal lifecycle steps for subagents" do
+            agentStepsForStatus 2 Running []
+                `shouldBe`
+                    [AgentStep AgentStepRunning "Working…" Nothing]
+            agentStepsForStatus 2 Running
+                [ functionCallItem
+                    "call-1"
+                    "shell_command"
+                    "{\"command\":\"sleep 5\"}"
+                    (Just ItemCompleted)
+                ]
+                `shouldSatisfy`
+                    \case
+                        step : _ ->
+                            step.agentStepState == AgentStepRunning
+                                && "sleep 5"
+                                    `Text.isInfixOf` step.agentStepTitle
+                        _ -> False
+            agentStepsForStatus 2 (Errored "websocket disconnected") []
+                `shouldBe`
+                    [ AgentStep
+                        AgentStepFailed
+                        "Agent failed"
+                        (Just "websocket disconnected")
+                    ]
+
 rootEntry :: AgentEntry
 rootEntry =
     AgentEntry
         { agentTarget = AgentRoot
         , agentPath = "/root"
         , agentStatus = "active"
+        , agentSteps = []
         , agentTranscript = ["user: hello", "assistant: ready"]
         }
 
@@ -130,6 +241,7 @@ child agentId path status =
         { agentTarget = AgentChild (SubagentId agentId)
         , agentPath = path
         , agentStatus = status
+        , agentSteps = []
         , agentTranscript = ["assistant: working"]
         }
 
@@ -142,6 +254,32 @@ messageItem role text = MessageItem ResponseMessage
     , phase = Nothing
     , extraFields = KeyMap.empty
     }
+
+functionCallItem
+    :: Text
+    -> Text
+    -> Text
+    -> Maybe ItemStatus
+    -> ResponseItem
+functionCallItem callId name arguments status =
+    FunctionCallItem FunctionCall
+        { itemId = Nothing
+        , callId
+        , name
+        , arguments
+        , status
+        , extraFields = KeyMap.empty
+        }
+
+functionOutputItem :: Text -> Maybe ItemStatus -> ResponseItem
+functionOutputItem callId status =
+    FunctionCallOutputItem FunctionCallOutput
+        { itemId = Nothing
+        , callId
+        , output = Aeson.String "ok"
+        , status
+        , extraFields = KeyMap.empty
+        }
 
 rightState :: Either (Maybe AgentTarget) AgentViewportState -> IO AgentViewportState
 rightState result = case result of

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -1,11 +1,20 @@
 module Agent.CLI.TUIAppSpec (spec) where
 
-import Agent.CLI.TUI.App (fullscreenVtyConfig)
+import Agent.CLI.AgentViewport (AgentEntry(..), AgentTarget(..))
+import Agent.CLI.TUI.App
+    ( agentEntryWindow
+    , agentPaneEntryLimit
+    , agentPaneVisible
+    , fullscreenVtyConfig
+    )
+import Agent.Subagents (SubagentId(..))
+import Data.Text (Text)
+import qualified Data.Text as Text
 import qualified Graphics.Vty as V
 import Test.Hspec
 
 spec :: Spec
-spec =
+spec = do
     describe "fullscreenVtyConfig" do
         it "maps enhanced-keyboard Shift+Enter sequences before Vty decodes them" do
             V.configInputMap fullscreenVtyConfig
@@ -19,3 +28,63 @@ spec =
                       , V.EvKey V.KEnter [V.MShift]
                       )
                     ]
+
+    describe "Agents pane layout" do
+        it "hides below the responsive breakpoint and without children" do
+            agentPaneVisible 71 20 [rootEntry, childEntry 1]
+                `shouldBe` False
+            agentPaneVisible 72 20 [rootEntry, childEntry 1]
+                `shouldBe` True
+            agentPaneVisible 120 9 [rootEntry, childEntry 1]
+                `shouldBe` False
+            agentPaneVisible 120 20 [rootEntry]
+                `shouldBe` False
+
+        it "centers the selected row and reports hidden rows on both sides" do
+            let entries = rootEntry : map childEntry [1 .. 6]
+                selected = AgentChild (SubagentId "agent-4")
+                (above, shown, below) =
+                    agentEntryWindow 3 selected entries
+            above `shouldBe` 3
+            map (.agentTarget) shown
+                `shouldBe`
+                    [ AgentChild (SubagentId "agent-3")
+                    , selected
+                    , AgentChild (SubagentId "agent-5")
+                    ]
+            below `shouldBe` 1
+
+        it "reserves height for truncation indicators and pane chrome" do
+            let availableHeight = 15
+                entries = rootEntry : map childEntry [1 .. 20]
+                selected = AgentChild (SubagentId "agent-10")
+                entryLimit = agentPaneEntryLimit availableHeight
+                (above, shown, below) =
+                    agentEntryWindow entryLimit selected entries
+                indicatorRows =
+                    fromEnum (above > 0) + fromEnum (below > 0)
+                renderedRows =
+                    length shown + indicatorRows + 7
+            entryLimit `shouldBe` 6
+            renderedRows `shouldSatisfy` (<= availableHeight)
+
+rootEntry :: AgentEntry
+rootEntry = AgentEntry
+    { agentTarget = AgentRoot
+    , agentPath = "/root"
+    , agentStatus = "active"
+    , agentSteps = []
+    , agentTranscript = []
+    }
+
+childEntry :: Int -> AgentEntry
+childEntry index = AgentEntry
+    { agentTarget = AgentChild (SubagentId name)
+    , agentPath = "/root/" <> name
+    , agentStatus = "running"
+    , agentSteps = []
+    , agentTranscript = []
+    }
+  where
+    name :: Text
+    name = "agent-" <> Text.pack (show index)

--- a/packages/agent-cli/test/Agent/CLI/TUIBridgeSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIBridgeSpec.hs
@@ -123,6 +123,13 @@ spec = describe "fullscreen TUI bridge" do
 
     it "falls back to root when the selected agent disappears" do
         let child = AgentChild (SubagentId "child")
-            root = AgentEntry AgentRoot "/root" "active" []
+            other = AgentChild (SubagentId "other")
+            root = AgentEntry AgentRoot "/root" "active" [] []
         normalizeAgentSelection child [root] `shouldBe` AgentRoot
         normalizeAgentSelection AgentRoot [root] `shouldBe` AgentRoot
+        reconcileAgentSelection [AgentRoot] child
+            `shouldBe` AgentRoot
+        reconcileAgentSelection [AgentRoot] AgentRoot
+            `shouldBe` AgentRoot
+        reconcileAgentSelection [AgentRoot, other] other
+            `shouldBe` other


### PR DESCRIPTION
## Summary

- turn the fullscreen Agents pane into a compact live hierarchy with status glyphs and accurate above/below truncation markers
- add mouse-hover activity popovers for root and subagents, including semantic assistant/tool steps and running/completed/error states
- keep snapshot polling scalable with StableName-backed activity caching and atomically normalize selections when agents disappear
- make the pane responsive to narrow and short terminals, and clear stale hover state across clicks, overlays, resize, layout changes, and session reset
- treat status-less tool outputs as neutral finished activity instead of false success

## Tests

- `nix develop -c cabal repl agent-cli:test:agent-cli-test` → `455 examples, 0 failures`
- live tmux smoke test with a real subagent:
  - running and completed hover previews
  - mouse leave and click-to-select behavior
  - `/agents` overlay interaction
  - 140x40, 80x15, and 70x25 layouts
  - pane/popover removal after `/clear`
