### PR TITLE
Use System.OsPath conversions directly

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -314,7 +314,7 @@ import Agent.Tools.Types
     )
 import Agent.OpenRouter.LoopBackend (openRouterBackend)
 import qualified Agent.OpenRouter.Options as OpenRouter
-import Agent.OsPath (OsPath, fromFilePath, fromText, toFilePath, toText)
+import Agent.OsPath (fromText, toText)
 import Agent.XAI.LoopBackend (xaiBackend)
 import qualified Agent.XAI.Options as XAI
 import Control.Concurrent.MVar (MVar, newMVar, withMVar)
@@ -325,6 +325,7 @@ import Control.Exception.Safe
     , catchAny
     , catchAsync
     , finally
+    , impureThrow
     , throwIO
     , try
     )
@@ -355,7 +356,7 @@ import System.Directory.OsPath
     , setCurrentDirectory
     )
 import System.Environment (getArgs, getProgName, lookupEnv)
-import System.OsPath ((</>), takeDirectory, takeFileName)
+import System.OsPath (OsPath, decodeUtf, unsafeEncodeUtf, (</>), takeDirectory, takeFileName)
 import System.Console.ANSI (getTerminalSize)
 import System.Console.ANSI.Codes (clearFromCursorToLineEndCode)
 import System.Exit (ExitCode(..), die, exitFailure)
@@ -694,7 +695,7 @@ runAgent fullscreenInputs options transition = do
     stdinTty <- hIsTerminalDevice stdin
     stdoutTty <- hIsTerminalDevice stdout
     terminal <- detectTerminalCapabilities stdout
-    reportTerminalCwd terminal stdout (toFilePath cwd)
+    reportTerminalCwd terminal stdout (decodeUtfPath cwd)
     useColor <- resolveColor stdout
     agentSnapshotRef <- newIORef (pure (AgentRoot, []))
     agentSelectRef <- newIORef (\_ -> pure ())
@@ -893,8 +894,8 @@ runAgentInitialized options transition home root resumed cwd startup = do
             | managedAgentSession = pure ()
             | otherwise = do
                 let desired =
-                        toFilePath
-                            (handle.sessionDir </> fromFilePath ".agent-running")
+                        decodeUtfPath
+                            (handle.sessionDir </> unsafeEncodeUtf ".agent-running")
                 readIORef activeSessionLock >>= \case
                     Just current | current == desired -> pure ()
                     previous ->
@@ -1105,9 +1106,9 @@ preparePersistence fullscreen options root provider model cwd effort prompt resu
             let handle = SessionHandle
                     { sessionDir = root </> fromText meta.metaId
                     , sessionMetaPath =
-                        root </> fromText meta.metaId </> fromFilePath "meta.json"
+                        root </> fromText meta.metaId </> unsafeEncodeUtf "meta.json"
                     , sessionTranscriptPath =
-                        root </> fromText meta.metaId </> fromFilePath "transcript.jsonl"
+                        root </> fromText meta.metaId </> unsafeEncodeUtf "transcript.jsonl"
                     , sessionMeta = meta
                     }
             let message = "session: " <> meta.metaId <> " (resumed)"
@@ -3331,7 +3332,7 @@ putTrailingNewline printed = do
 loadPrompt :: CliOptions -> IO (Maybe Text)
 loadPrompt options = case (options.optPrompt, options.optPromptFile) of
     (Just text, _) -> pure (Just text)
-    (_, Just path) -> Just . Text.strip <$> Text.readFile (toFilePath path)
+    (_, Just path) -> Just . Text.strip <$> Text.readFile (decodeUtfPath path)
     _ -> pure Nothing
 
 handleResume
@@ -3465,7 +3466,7 @@ detectGitBranch cwd = do
         (try $
             readProcessWithExitCode
                 "git"
-                ["-C", toFilePath cwd, "rev-parse", "--abbrev-ref", "HEAD"]
+                ["-C", decodeUtfPath cwd, "rev-parse", "--abbrev-ref", "HEAD"]
                 "")
             :: IO (Either SomeException (ExitCode, String, String))
     pure $ case result of
@@ -3519,3 +3520,6 @@ hydrateUiHistory = foldl addTurn initialUiState
         in case turn.turnError of
             Nothing -> withAssistant
             Just err -> reduceUi (UiErrorMessage err) withAssistant
+
+decodeUtfPath :: OsPath -> FilePath
+decodeUtfPath = either impureThrow id . decodeUtf

--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -356,7 +356,7 @@ import System.Directory.OsPath
     , setCurrentDirectory
     )
 import System.Environment (getArgs, getProgName, lookupEnv)
-import System.OsPath (OsPath, decodeUtf, unsafeEncodeUtf, (</>), takeDirectory, takeFileName)
+import System.OsPath (OsPath, decodeFS, decodeUtf, unsafeEncodeUtf, (</>), takeDirectory, takeFileName)
 import System.Console.ANSI (getTerminalSize)
 import System.Console.ANSI.Codes (clearFromCursorToLineEndCode)
 import System.Exit (ExitCode(..), die, exitFailure)
@@ -695,7 +695,8 @@ runAgent fullscreenInputs options transition = do
     stdinTty <- hIsTerminalDevice stdin
     stdoutTty <- hIsTerminalDevice stdout
     terminal <- detectTerminalCapabilities stdout
-    reportTerminalCwd terminal stdout (decodeUtfPath cwd)
+    terminalCwd <- decodeFS cwd
+    reportTerminalCwd terminal stdout terminalCwd
     useColor <- resolveColor stdout
     agentSnapshotRef <- newIORef (pure (AgentRoot, []))
     agentSelectRef <- newIORef (\_ -> pure ())

--- a/packages/agent-cli/src/Agent/CLI/AgentSessions.hs
+++ b/packages/agent-cli/src/Agent/CLI/AgentSessions.hs
@@ -23,7 +23,7 @@ import Agent.CLI.Session
     , loadSession
     , sessionTitleFromPrompt
     )
-import Agent.OsPath (OsPath, fromFilePath, fromText, toFilePath)
+import Agent.OsPath (fromText)
 import Agent.Provider (Provider, providerSlug)
 import Agent.ToolArgs (objectArgs, optInt, optText, reqText)
 import Agent.ToolDSL (PropertySchema(..), PropertyType(..))
@@ -39,7 +39,7 @@ import Control.Concurrent.MVar
     , modifyMVar_
     , newMVar
     )
-import Control.Exception.Safe (SomeException, try)
+import Control.Exception.Safe (SomeException, impureThrow, try)
 import Control.Monad (forM_)
 import Data.Aeson (FromJSON(..), Value, object, (.=))
 import qualified Data.Aeson as Aeson
@@ -63,7 +63,7 @@ import System.Exit (ExitCode(..))
 import System.FilePath (takeFileName)
 import qualified System.FilePath as FilePath
 import System.IO (IOMode(AppendMode), hClose, openTempFile, withFile)
-import System.OsPath ((</>))
+import System.OsPath (OsPath, decodeUtf, unsafeEncodeUtf, (</>))
 import System.Posix.Files (setFileMode)
 import System.Process
     ( CreateProcess(..)
@@ -135,7 +135,7 @@ launchSessionTurn manager background policy handle message =
                     Right executable -> do
                         parentEnv <- getEnvironment
                         (promptPath, promptHandle) <- openTempFile
-                            (toFilePath handle.sessionDir) ".agent-prompt-"
+                            (decodeUtfPath handle.sessionDir) ".agent-prompt-"
                         TextIO.hPutStr promptHandle message
                         hClose promptHandle
                         setFileMode promptPath 0o600
@@ -144,7 +144,7 @@ launchSessionTurn manager background policy handle message =
                                     : filter
                                         ((/= "HASKELL_AGENT_MANAGED_SESSION") . fst)
                                         parentEnv
-                            logPath = toFilePath handle.sessionDir FilePath.</> "agent.log"
+                            logPath = decodeUtfPath handle.sessionDir FilePath.</> "agent.log"
                             approvalArgs = case policy of
                                 ApproveAll -> ["--yolo"]
                                 DenyMutating -> ["--no-yolo"]
@@ -172,7 +172,7 @@ launchSessionTurn manager background policy handle message =
                             withFile logPath AppendMode \logHandle ->
                                 setFileMode logPath 0o600 >>
                                 createProcess (proc "/bin/sh" args)
-                                    { cwd = Just (toFilePath handle.sessionMeta.metaCwd)
+                                    { cwd = Just (decodeUtfPath handle.sessionMeta.metaCwd)
                                     , std_in = NoStream
                                     , std_out = UseHandle logHandle
                                     , std_err = UseHandle logHandle
@@ -247,7 +247,7 @@ closeSessionProcessManager manager =
 
 acquireSessionLock :: SessionHandle -> IO (Either Text FilePath)
 acquireSessionLock handle = do
-    let lockPath = toFilePath handle.sessionDir FilePath.</> ".agent-running"
+    let lockPath = decodeUtfPath handle.sessionDir FilePath.</> ".agent-running"
     try @_ @SomeException (createDirectory lockPath) >>= \case
         Right () -> pure (Right lockPath)
         Left _ -> pure $ Left
@@ -265,7 +265,7 @@ removePrivateFile path = do
 
 sessionLockPath :: SessionProcessManager -> Text -> FilePath
 sessionLockPath manager sessionId =
-    toFilePath manager.managedRoot
+    decodeUtfPath manager.managedRoot
         FilePath.</> Text.unpack sessionId
         FilePath.</> ".agent-running"
 
@@ -462,9 +462,9 @@ sessionHandle root meta =
     let dir = root </> fromText meta.metaId
     in SessionHandle
         { sessionDir = dir
-        , sessionMetaPath = dir </> fromFilePath "meta.json"
+        , sessionMetaPath = dir </> unsafeEncodeUtf "meta.json"
         , sessionTranscriptPath =
-            dir </> fromFilePath "transcript.jsonl"
+            dir </> unsafeEncodeUtf "transcript.jsonl"
         , sessionMeta = meta
         }
 
@@ -481,7 +481,7 @@ sessionJson meta status = object
     , "provider" .= providerSlug meta.metaProvider
     , "model" .= meta.metaModel
     , "reasoning_effort" .= meta.metaEffort
-    , "cwd" .= toFilePath meta.metaCwd
+    , "cwd" .= decodeUtfPath meta.metaCwd
     , "created_at" .= meta.metaCreatedAt
     , "updated_at" .= meta.metaUpdatedAt
     ]
@@ -496,3 +496,6 @@ turnJson turn = object
 
 encodeJson :: Value -> Text
 encodeJson = TextEncoding.decodeUtf8 . LBS.toStrict . Aeson.encode
+
+decodeUtfPath :: OsPath -> FilePath
+decodeUtfPath = either impureThrow id . decodeUtf

--- a/packages/agent-cli/src/Agent/CLI/Approval.hs
+++ b/packages/agent-cli/src/Agent/CLI/Approval.hs
@@ -11,6 +11,7 @@ import Agent.CLI.Permission
     ( PermissionChoice(..)
     , promptPermission
     )
+import System.OsPath (OsPath)
 import Agent.CLI.Project (saveProjectAutoApprove)
 import Agent.CLI.Render (putTextLn)
 import Agent.CLI.Style
@@ -21,7 +22,7 @@ import Agent.CLI.Style
     )
 import Agent.CLI.Terminal (resolveColor)
 import Agent.JsonText (jsonTextFieldDefault)
-import Agent.OsPath (OsPath, fromText)
+import Agent.OsPath (fromText)
 import Agent.ToolDispatch (ToolCall(..))
 import Agent.Tools.Dangerous (shellCommandBlocked)
 import Agent.Tools.PlanMode

--- a/packages/agent-cli/src/Agent/CLI/Auth.hs
+++ b/packages/agent-cli/src/Agent/CLI/Auth.hs
@@ -31,7 +31,6 @@ import Agent.FileRetry (retryOnFileBusy)
 import qualified Agent.OpenAI.Auth as OpenAI
 import qualified Agent.OpenAI.Credential as OpenAICredential
 import qualified Agent.OpenAI.Login as OpenAILogin
-import Agent.OsPath (OsPath, fromFilePath, toFilePath)
 import Agent.Provider
     ( AccountFailure(..)
     , Credential(..)
@@ -45,7 +44,7 @@ import Agent.OpenRouter.Credential (credentialFromApiKey)
 import qualified Agent.XAI.Auth as XAIAuth
 import Control.Applicative ((<|>))
 import Control.Concurrent.MVar (MVar, newMVar, withMVar)
-import Control.Exception.Safe (bracket, bracket_)
+import Control.Exception.Safe (bracket, bracket_, impureThrow)
 import Control.Monad (when)
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Except
@@ -74,7 +73,7 @@ import System.Directory.OsPath
     , getHomeDirectory
     )
 import System.IO (SeekMode(AbsoluteSeek))
-import System.OsPath (takeDirectory, (</>))
+import System.OsPath (OsPath, decodeUtf, takeDirectory, unsafeEncodeUtf, (</>))
 import qualified System.OsPath as OsPath
 import System.Posix.Files (setFileMode)
 import System.Posix.IO
@@ -238,10 +237,10 @@ loadOpenAi = do
     fromEnvJson <- lift (lookupNonEmpty "CODEX_AUTH_JSON")
     home <- lift getHomeDirectory
     let filePath =
-            home </> fromFilePath ".codex" </> fromFilePath "auth.json"
+            home </> unsafeEncodeUtf ".codex" </> unsafeEncodeUtf "auth.json"
     fileExists <- lift (doesFileExist filePath)
     fileBytes <- if fileExists
-        then lift (Just <$> retryOnFileBusy (LBS.readFile (toFilePath filePath)))
+        then lift (Just <$> retryOnFileBusy (LBS.readFile (decodeUtfPath filePath)))
         else pure Nothing
     now <- lift getCurrentTime
     let (storeErrors, managed) = case managedResult of
@@ -422,7 +421,7 @@ openAiSourceLockPath source =
         OpenAiManagedOAuth managedId ->
             Just <$> managedRefreshLockPath managedId
         OpenAiAuthFile filePath ->
-            pure (Just (fromFilePath (toFilePath filePath <> ".refresh.lock")))
+            pure (Just (unsafeEncodeUtf (decodeUtfPath filePath <> ".refresh.lock")))
         _ ->
             pure Nothing
 
@@ -433,9 +432,9 @@ managedRefreshLockPath managedId = do
             "refresh-" <> Text.unpack (safeLockName managedId) <> ".lock"
     pure $
         home
-            </> fromFilePath ".haskell-agent"
-            </> fromFilePath "credentials"
-            </> fromFilePath fileName
+            </> unsafeEncodeUtf ".haskell-agent"
+            </> unsafeEncodeUtf "credentials"
+            </> unsafeEncodeUtf fileName
 
 safeLockName :: Text -> Text
 safeLockName = Text.map replace
@@ -449,7 +448,7 @@ safeLockName = Text.map replace
 withAdvisoryFileLock :: OsPath -> IO a -> IO a
 withAdvisoryFileLock path action = do
     createDirectoryIfMissing True (takeDirectory path)
-    setFileMode (toFilePath (takeDirectory path)) 0o700
+    setFileMode (decodeUtfPath (takeDirectory path)) 0o700
     bracket
         (openRefreshLock path)
         closeFd
@@ -458,7 +457,7 @@ withAdvisoryFileLock path action = do
 openRefreshLock :: OsPath -> IO Fd
 openRefreshLock path =
     openFd
-        (toFilePath path)
+        (decodeUtfPath path)
         ReadWrite
         defaultFileFlags { creat = Just 0o600, cloexec = True }
 
@@ -516,7 +515,7 @@ reloadOpenAiAccount source stale =
                 else do
                     now <- getCurrentTime
                     bytes <- retryOnFileBusy
-                        (LBS.readFile (toFilePath filePath))
+                        (LBS.readFile (decodeUtfPath filePath))
                     pure $ case openaiAuthStateFromJson now bytes of
                         Nothing ->
                             Left $ ProviderError AuthenticationError
@@ -640,11 +639,11 @@ loadExternalGrokCredential = do
     fromToken <- lookupNonEmpty "GROK_ACCESS_TOKEN"
     home <- getHomeDirectory
     let filePath =
-            home </> fromFilePath ".grok" </> fromFilePath "auth.json"
+            home </> unsafeEncodeUtf ".grok" </> unsafeEncodeUtf "auth.json"
     fileExists <- doesFileExist filePath
     fileJson <- if fileExists
         then Just . TextEncoding.decodeUtf8 . LBS.toStrict
-            <$> retryOnFileBusy (LBS.readFile (toFilePath filePath))
+            <$> retryOnFileBusy (LBS.readFile (decodeUtfPath filePath))
         else pure Nothing
     let token =
             (fromJson >>= grokCredentialFromAuthJson)
@@ -907,7 +906,7 @@ hasGrokAuth = do
     envToken <- lookupNonEmpty "GROK_ACCESS_TOKEN"
     home <- getHomeDirectory
     file <- doesFileExist
-        (home </> fromFilePath ".grok" </> fromFilePath "auth.json")
+        (home </> unsafeEncodeUtf ".grok" </> unsafeEncodeUtf "auth.json")
     managed <- hasManagedProvider XAIProvider
     pure (isJust envJson || isJust envToken || file || managed)
 
@@ -917,7 +916,7 @@ hasOpenAiAuth = do
     envToken <- lookupNonEmpty "CODEX_ACCESS_TOKEN"
     home <- getHomeDirectory
     file <- doesFileExist
-        (home </> fromFilePath ".codex" </> fromFilePath "auth.json")
+        (home </> unsafeEncodeUtf ".codex" </> unsafeEncodeUtf "auth.json")
     managed <- hasManagedProvider OpenAIProvider
     pure (isJust envJson || isJust envToken || file || managed)
 
@@ -1016,3 +1015,6 @@ noAuthHint :: Text
 noAuthHint =
     "no credentials found. Set GROK_ACCESS_TOKEN, CODEX_ACCESS_TOKEN, \
     \or OPENROUTER_API_KEY, or place auth at ~/.grok/auth.json / ~/.codex/auth.json."
+
+decodeUtfPath :: OsPath -> FilePath
+decodeUtfPath = either impureThrow id . decodeUtf

--- a/packages/agent-cli/src/Agent/CLI/CredentialStore.hs
+++ b/packages/agent-cli/src/Agent/CLI/CredentialStore.hs
@@ -17,10 +17,10 @@ module Agent.CLI.CredentialStore
     ) where
 
 import Agent.FileRetry (retryOnFileBusy, writeLazyFileAtomically)
-import Agent.OsPath (OsPath, fromFilePath, toFilePath, toText)
+import Agent.OsPath (toText)
 import Agent.Provider (Provider(..), parseProvider, providerSlug)
 import Control.Concurrent.MVar (MVar, newMVar, withMVar)
-import Control.Exception.Safe (bracket, bracket_, tryIO)
+import Control.Exception.Safe (bracket, bracket_, impureThrow, tryIO)
 import qualified Data.Aeson as Aeson
 import Data.Aeson ((.:), (.:?), (.=))
 import qualified Data.ByteString.Lazy as LBS
@@ -33,7 +33,7 @@ import System.Directory.OsPath
     , doesFileExist
     , getHomeDirectory
     )
-import System.OsPath (takeDirectory, (</>))
+import System.OsPath (OsPath, decodeUtf, takeDirectory, unsafeEncodeUtf, (</>))
 import System.IO (SeekMode(AbsoluteSeek))
 import System.Posix.Files (setFileMode)
 import System.Posix.IO
@@ -182,16 +182,16 @@ instance Aeson.FromJSON SecretsFile where
 managedCredentialsPath :: OsPath -> OsPath
 managedCredentialsPath home =
     home
-        </> fromFilePath ".haskell-agent"
-        </> fromFilePath "credentials"
-        </> fromFilePath "accounts.json"
+        </> unsafeEncodeUtf ".haskell-agent"
+        </> unsafeEncodeUtf "credentials"
+        </> unsafeEncodeUtf "accounts.json"
 
 managedSecretsPath :: OsPath -> OsPath
 managedSecretsPath home =
     home
-        </> fromFilePath ".haskell-agent"
-        </> fromFilePath "credentials"
-        </> fromFilePath "secrets.json"
+        </> unsafeEncodeUtf ".haskell-agent"
+        </> unsafeEncodeUtf "credentials"
+        </> unsafeEncodeUtf "secrets.json"
 
 -- | Serialize OAuth rotation across threads and harness processes. POSIX
 -- record locks are released automatically if a process exits.
@@ -204,14 +204,14 @@ withCredentialRefreshFileLockUnlocked :: IO value -> IO value
 withCredentialRefreshFileLockUnlocked action = do
     home <- getHomeDirectory
     let directory = takeDirectory (managedSecretsPath home)
-        lockPath = directory </> fromFilePath "refresh.lock"
+        lockPath = directory </> unsafeEncodeUtf "refresh.lock"
     createDirectoryIfMissing True directory
-    setFileMode (toFilePath directory) 0o700
+    setFileMode (decodeUtfPath directory) 0o700
     bracket
-        (openFd (toFilePath lockPath) ReadWrite lockFlags)
+        (openFd (decodeUtfPath lockPath) ReadWrite lockFlags)
         closeFd
         \fd -> do
-            setFileMode (toFilePath lockPath) 0o600
+            setFileMode (decodeUtfPath lockPath) 0o600
             waitToSetLock fd (WriteLock, AbsoluteSeek, 0, 0)
             action
   where
@@ -227,9 +227,9 @@ credentialRefreshThreadLock = unsafePerformIO (newMVar ())
 managedCredentialsLockPath :: OsPath -> OsPath
 managedCredentialsLockPath home =
     home
-        </> fromFilePath ".haskell-agent"
-        </> fromFilePath "credentials"
-        </> fromFilePath "store.lock"
+        </> unsafeEncodeUtf ".haskell-agent"
+        </> unsafeEncodeUtf "credentials"
+        </> unsafeEncodeUtf "store.lock"
 
 loadManagedCredentials
     :: IO (Either Text [(ManagedCredential, ManagedSecret)])
@@ -415,9 +415,9 @@ withCredentialStoreFileLock home action = do
             , cloexec = True
             }
     createDirectoryIfMissing True directoryPath
-    setFileMode (toFilePath directoryPath) 0o700
+    setFileMode (decodeUtfPath directoryPath) 0o700
     bracket
-        (openFd (toFilePath path) ReadWrite flags)
+        (openFd (decodeUtfPath path) ReadWrite flags)
         closeFd
         (\fd ->
             bracket_
@@ -434,7 +434,7 @@ decodeFileOrEmpty path empty = do
     exists <- doesFileExist path
     if not exists
         then pure (Right empty)
-        else tryIO (retryOnFileBusy (LBS.readFile (toFilePath path))) >>= \case
+        else tryIO (retryOnFileBusy (LBS.readFile (decodeUtfPath path))) >>= \case
             Left exception ->
                 pure $ Left
                     ("could not read " <> toText path <> ": "
@@ -457,9 +457,12 @@ writePrivateJson path value =
   where
     action = do
         createDirectoryIfMissing True (takeDirectory path)
-        setFileMode (toFilePath (takeDirectory path)) 0o700
+        setFileMode (decodeUtfPath (takeDirectory path)) 0o700
         writeLazyFileAtomically path 0o600 (Aeson.encode value)
 
 upsertBy :: Eq key => (value -> key) -> value -> [value] -> [value]
 upsertBy keyOf value values =
     value : filter ((/= keyOf value) . keyOf) values
+
+decodeUtfPath :: OsPath -> FilePath
+decodeUtfPath = either impureThrow id . decodeUtf

--- a/packages/agent-cli/src/Agent/CLI/Login.hs
+++ b/packages/agent-cli/src/Agent/CLI/Login.hs
@@ -53,7 +53,7 @@ import Agent.CLI.Style
 import Agent.FileRetry (retryOnFileBusy)
 import qualified Agent.OpenAI.Auth as OpenAI
 import qualified Agent.OpenAI.Login as OpenAILogin
-import Agent.OsPath (OsPath, fromFilePath, toFilePath, toText)
+import Agent.OsPath (toText)
 import qualified Agent.OpenAI.Usage as OpenAI
 import qualified Agent.OpenRouter.Usage as OpenRouter
 import Agent.Provider (Provider(..), providerSlug)
@@ -66,7 +66,7 @@ import Control.Concurrent.Async
     , withAsync
     )
 import Control.Concurrent.Chan (Chan, newChan, readChan, writeChan)
-import Control.Exception.Safe (bracket, tryAny)
+import Control.Exception.Safe (bracket, impureThrow, tryAny)
 import Control.Monad (join)
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy as LBS
@@ -80,7 +80,7 @@ import Data.Time.Clock (UTCTime, addUTCTime, getCurrentTime)
 import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
 import System.Directory.OsPath (doesFileExist, getHomeDirectory)
 import System.Environment (lookupEnv)
-import System.OsPath ((</>))
+import System.OsPath (OsPath, decodeUtf, unsafeEncodeUtf, (</>))
 import System.IO
     ( hFlush
     , hGetEcho
@@ -284,10 +284,10 @@ discoverLoginAccounts = do
     now <- getCurrentTime
     openaiEnv <- discoverOpenAIEnv
     openaiFile <- discoverOpenAIFile now
-        (home </> fromFilePath ".codex" </> fromFilePath "auth.json")
+        (home </> unsafeEncodeUtf ".codex" </> unsafeEncodeUtf "auth.json")
     grokEnv <- discoverGrokEnv
     grokFile <- discoverGrokFile
-        (home </> fromFilePath ".grok" </> fromFilePath "auth.json")
+        (home </> unsafeEncodeUtf ".grok" </> unsafeEncodeUtf "auth.json")
     openRouter <- discoverOpenRouter
     managed <- loadManagedCredentials
     let managedAccounts = case managed of
@@ -648,7 +648,7 @@ discoverOpenAIFile now path = do
     if not exists
         then pure Nothing
         else do
-            bytes <- retryOnFileBusy (LBS.readFile (toFilePath path))
+            bytes <- retryOnFileBusy (LBS.readFile (decodeUtfPath path))
             pure $ do
                 auth <- openaiAuthStateFromJson now bytes
                 pure $ subscriptionAccount
@@ -679,7 +679,7 @@ discoverGrokFile path = do
         then pure Nothing
         else do
             raw <- Text.decodeUtf8 . LBS.toStrict
-                <$> retryOnFileBusy (LBS.readFile (toFilePath path))
+                <$> retryOnFileBusy (LBS.readFile (decodeUtfPath path))
             pure $ do
                 token <- grokCredentialFromAuthJson raw
                 pure (grokAccount token (toText path)
@@ -945,3 +945,6 @@ lookupNonEmpty name = do
     pure case value of
         Just text | not (null text) -> Just (Text.pack text)
         _ -> Nothing
+
+decodeUtfPath :: OsPath -> FilePath
+decodeUtfPath = either impureThrow id . decodeUtf

--- a/packages/agent-cli/src/Agent/CLI/Options.hs
+++ b/packages/agent-cli/src/Agent/CLI/Options.hs
@@ -16,7 +16,7 @@ module Agent.CLI.Options
     , usage
     ) where
 
-import Agent.OsPath (OsPath, fromFilePath)
+import System.OsPath (OsPath, unsafeEncodeUtf)
 import Agent.Provider (Provider(..), parseProvider)
 import Data.Maybe (isJust)
 import Data.Text (Text)
@@ -158,7 +158,7 @@ parseOptions options = \case
     "--model" : value : rest ->
         parseOptions options { optModel = Just (Text.pack value) } rest
     "--cwd" : value : rest ->
-        parseOptions options { optCwd = Just (fromFilePath value) } rest
+        parseOptions options { optCwd = Just (unsafeEncodeUtf value) } rest
     "--worktree" : rest ->
         parseOptions options { optWorktree = True } rest
     "--yolo" : rest ->
@@ -176,7 +176,7 @@ parseOptions options = \case
     "--prompt" : value : rest ->
         parseOptions options { optPrompt = Just (Text.pack value) } rest
     "--prompt-file" : value : rest ->
-        parseOptions options { optPromptFile = Just (fromFilePath value) } rest
+        parseOptions options { optPromptFile = Just (unsafeEncodeUtf value) } rest
     "--resume" : value : rest ->
         parseOptions options { optResume = Just (Text.pack value) } rest
     "--save-session" : rest ->

--- a/packages/agent-cli/src/Agent/CLI/Project.hs
+++ b/packages/agent-cli/src/Agent/CLI/Project.hs
@@ -9,8 +9,8 @@ module Agent.CLI.Project
     ) where
 
 import Agent.FileRetry (retryOnFileBusy, writeLazyFileAtomically)
-import Agent.OsPath (OsPath, fromFilePath, toFilePath)
 import Control.Exception (try)
+import Control.Exception.Safe (impureThrow)
 import Data.Aeson (FromJSON(..), ToJSON(..), object, withObject, (.:?), (.=))
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy as LBS
@@ -23,7 +23,7 @@ import System.Directory.OsPath
     , doesFileExist
     )
 import System.Exit (ExitCode(..))
-import System.OsPath ((</>))
+import System.OsPath (OsPath, decodeUtf, unsafeEncodeUtf, (</>))
 import System.Posix.Files (setFileMode)
 import System.Process (CreateProcess(..), proc, readCreateProcessWithExitCode)
 
@@ -34,8 +34,8 @@ settingsSchemaVersion = 1
 projectSettingsPath :: OsPath -> OsPath
 projectSettingsPath projectRoot =
     projectRoot
-        </> fromFilePath ".haskell-agent"
-        </> fromFilePath "settings.json"
+        </> unsafeEncodeUtf ".haskell-agent"
+        </> unsafeEncodeUtf "settings.json"
 
 data ProjectSettings = ProjectSettings
     { settingsVersion :: !Int
@@ -82,7 +82,7 @@ loadProjectSettings projectRoot = do
     if not exists
         then pure defaultProjectSettings
         else do
-            result <- try @IOError (retryOnFileBusy (LBS.readFile (toFilePath path)))
+            result <- try @IOError (retryOnFileBusy (LBS.readFile (decodeUtfPath path)))
             pure $ case result of
                 Left _ -> defaultProjectSettings
                 Right bytes ->
@@ -93,11 +93,11 @@ loadProjectSettings projectRoot = do
 -- | Persist the project-wide auto-approve flag, creating @.haskell-agent@ as needed.
 saveProjectAutoApprove :: OsPath -> Bool -> IO ()
 saveProjectAutoApprove projectRoot autoApprove = do
-    let dir = projectRoot </> fromFilePath ".haskell-agent"
+    let dir = projectRoot </> unsafeEncodeUtf ".haskell-agent"
         path = projectSettingsPath projectRoot
         settings = defaultProjectSettings { settingsAutoApprove = autoApprove }
     createDirectoryIfMissing True dir
-    _ <- try @IOError (setFileMode (toFilePath dir) 0o700)
+    _ <- try @IOError (setFileMode (decodeUtfPath dir) 0o700)
     writeLazyFileAtomically path 0o600 (Aeson.encode settings)
 
 gitToplevel :: OsPath -> IO (Maybe OsPath)
@@ -105,14 +105,17 @@ gitToplevel dir = do
     result <- try @IOError $
         readCreateProcessWithExitCode
             (proc "git" ["rev-parse", "--show-toplevel"])
-                { cwd = Just (toFilePath dir) }
+                { cwd = Just (decodeUtfPath dir) }
             ""
     pure $ case result of
         Left _ -> Nothing
         Right (ExitSuccess, out, _) ->
             let trimmed = trim out
-            in if null trimmed then Nothing else Just (fromFilePath trimmed)
+            in if null trimmed then Nothing else Just (unsafeEncodeUtf trimmed)
         Right _ -> Nothing
 
 trim :: String -> String
 trim = dropWhileEnd isSpace . dropWhile isSpace
+
+decodeUtfPath :: OsPath -> FilePath
+decodeUtfPath = either impureThrow id . decodeUtf

--- a/packages/agent-cli/src/Agent/CLI/Prompt.hs
+++ b/packages/agent-cli/src/Agent/CLI/Prompt.hs
@@ -5,13 +5,14 @@ module Agent.CLI.Prompt
     ) where
 
 import Agent.CLI.Timestamp (timeContextGuidance)
-import Agent.OsPath (OsPath, toText)
+import Agent.OsPath (toText)
 import Agent.Provider (Provider(..))
 import Agent.Tools.Grok.Prompt (codingGrokPromptTools, grokSystemPrompt)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Time.Calendar (Day)
 import Data.Time.Format (defaultTimeLocale, formatTime)
+import System.OsPath (OsPath)
 
 defaultModelFor :: Provider -> Text
 defaultModelFor = \case

--- a/packages/agent-cli/src/Agent/CLI/Resume.hs
+++ b/packages/agent-cli/src/Agent/CLI/Resume.hs
@@ -19,7 +19,7 @@ import Agent.CLI.Session
     , loadSession
     )
 import Agent.CLI.Style (roleMuted, rolePrompt, roleSuccess)
-import Agent.OsPath (OsPath, toText)
+import Agent.OsPath (toText)
 import Agent.Provider (providerSlug)
 import Control.Monad (forM)
 import Data.Char (isAlphaNum)
@@ -28,7 +28,7 @@ import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
 import Data.Time.Format (defaultTimeLocale, formatTime)
 import System.Console.ANSI (getTerminalSize)
-import System.OsPath (takeFileName)
+import System.OsPath (OsPath, takeFileName)
 import System.IO (hFlush, hIsTerminalDevice, stderr, stdin)
 
 data ResumeEntry = ResumeEntry

--- a/packages/agent-cli/src/Agent/CLI/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session.hs
@@ -33,11 +33,11 @@ import Agent.FileRetry
     , writeLazyFileAtomically
     )
 import Agent.Loop (TokenUsage(..))
-import Agent.OsPath (OsPath, fromFilePath, toFilePath, toText)
+import Agent.OsPath (toText)
 import Agent.Responses.Types (ResponseItem)
 import Agent.Provider (Provider(..), parseProvider, providerSlug)
 import Control.Applicative ((<|>))
-import Control.Exception.Safe (tryIO)
+import Control.Exception.Safe (impureThrow, tryIO)
 import Control.Monad (unless)
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Except
@@ -68,7 +68,7 @@ import System.Directory.OsPath
     , doesFileExist
     , listDirectory
     )
-import System.OsPath ((</>))
+import System.OsPath (OsPath, decodeUtf, unsafeEncodeUtf, (</>))
 import System.Posix.Files (setFileMode)
 
 sessionSchemaVersion :: Int
@@ -77,7 +77,7 @@ sessionSchemaVersion = 1
 -- | @~/.haskell-agent/sessions@ given the user's home directory.
 sessionsRoot :: OsPath -> OsPath
 sessionsRoot home =
-    home </> fromFilePath ".haskell-agent" </> fromFilePath "sessions"
+    home </> unsafeEncodeUtf ".haskell-agent" </> unsafeEncodeUtf "sessions"
 
 data SessionMeta = SessionMeta
     { metaVersion :: !Int
@@ -106,7 +106,7 @@ instance ToJSON SessionMeta where
         , "updatedAt" .= meta.metaUpdatedAt
         , "provider" .= providerSlug meta.metaProvider
         , "model" .= meta.metaModel
-        , "cwd" .= toFilePath meta.metaCwd
+        , "cwd" .= decodeUtfPath meta.metaCwd
         , "effort" .= meta.metaEffort
         , "title" .= meta.metaTitle
         , "titleIsManual" .= meta.metaTitleIsManual
@@ -131,7 +131,7 @@ instance FromJSON SessionMeta where
             <*> o .: "updatedAt"
             <*> pure provider
             <*> o .: "model"
-            <*> (fromFilePath <$> o .: "cwd")
+            <*> (unsafeEncodeUtf <$> o .: "cwd")
             <*> o .: "effort"
             <*> o .: "title"
             <*> (o .:? "titleIsManual" .!= False)
@@ -239,8 +239,8 @@ createSession spec = do
             }
         handle = SessionHandle
             { sessionDir = dir
-            , sessionMetaPath = dir </> fromFilePath "meta.json"
-            , sessionTranscriptPath = dir </> fromFilePath "transcript.jsonl"
+            , sessionMetaPath = dir </> unsafeEncodeUtf "meta.json"
+            , sessionTranscriptPath = dir </> unsafeEncodeUtf "transcript.jsonl"
             , sessionMeta = meta
             }
     writeSessionMeta handle.sessionMetaPath meta
@@ -262,7 +262,7 @@ appendTurn handle turn = do
     let path = handle.sessionTranscriptPath
     existed <- doesFileExist path
     appendLazyFileRetryingOpen path (Aeson.encode turn <> "\n")
-    if existed then pure () else setFileMode (toFilePath path) 0o600
+    if existed then pure () else setFileMode (decodeUtfPath path) 0o600
     now <- getCurrentTime
     let meta0 = handle.sessionMeta
         meta = meta0
@@ -310,7 +310,7 @@ appendTurnKeepTitle handle turn = do
     let path = handle.sessionTranscriptPath
     existed <- doesFileExist path
     appendLazyFileRetryingOpen path (Aeson.encode turn <> "\n")
-    if existed then pure () else setFileMode (toFilePath path) 0o600
+    if existed then pure () else setFileMode (decodeUtfPath path) 0o600
     now <- getCurrentTime
     let meta0 = handle.sessionMeta
         meta = meta0
@@ -325,9 +325,9 @@ loadSession :: OsPath -> Text -> IO (Either Text (SessionMeta, [SessionTurn]))
 loadSession root sessionId = runExceptT do
     unless (isValidSessionId sessionId) $
         throwE "invalid session id"
-    let dir = root </> fromFilePath (Text.unpack sessionId)
-        metaPath = dir </> fromFilePath "meta.json"
-        transcriptPath = dir </> fromFilePath "transcript.jsonl"
+    let dir = root </> unsafeEncodeUtf (Text.unpack sessionId)
+        metaPath = dir </> unsafeEncodeUtf "meta.json"
+        transcriptPath = dir </> unsafeEncodeUtf "transcript.jsonl"
     exists <- lift (doesDirectoryExist dir)
     unless exists $
         throwE ("session not found: " <> sessionId)
@@ -441,12 +441,12 @@ allocateSessionDir root now = go (0 :: Int)
         | otherwise = do
             let hex = hex8 (start + fromIntegral attempt)
                 sessionId = Text.pack (day <> "-" <> hex)
-                dir = root </> fromFilePath (Text.unpack sessionId)
+                dir = root </> unsafeEncodeUtf (Text.unpack sessionId)
             result <- tryIO (createDirectory dir)
             case result of
                 Left _ -> go (attempt + 1)
                 Right () -> do
-                    setFileMode (toFilePath dir) 0o700
+                    setFileMode (decodeUtfPath dir) 0o700
                     pure (sessionId, dir)
 
 hex8 :: Integer -> String
@@ -457,7 +457,7 @@ hex8 n =
 ensurePrivateDir :: OsPath -> IO ()
 ensurePrivateDir path = do
     createDirectoryIfMissing True path
-    _ <- tryIO (setFileMode (toFilePath path) 0o700)
+    _ <- tryIO (setFileMode (decodeUtfPath path) 0o700)
     pure ()
 
 loadTranscript :: OsPath -> ExceptT Text IO [SessionTurn]
@@ -466,7 +466,7 @@ loadTranscript path = do
     if not exists
         then pure []
         else do
-            raw <- lift (retryOnFileBusy (Text.readFile (toFilePath path)))
+            raw <- lift (retryOnFileBusy (Text.readFile (decodeUtfPath path)))
             let linesOf = filter (not . Text.null) (Text.lines raw)
             except (mapM decodeTurnLine linesOf)
 
@@ -481,14 +481,14 @@ decodeFileEither path = do
     exists <- lift (doesFileExist path)
     unless exists $
         throwE ("missing file: " <> toText path)
-    bytes <- lift (retryOnFileBusy (LBS.readFile (toFilePath path)))
+    bytes <- lift (retryOnFileBusy (LBS.readFile (decodeUtfPath path)))
     case Aeson.eitherDecode' bytes of
         Left err -> throwE (toText path <> ": " <> Text.pack err)
         Right value -> pure value
 
 readMetaQuiet :: OsPath -> OsPath -> IO (Maybe SessionMeta)
 readMetaQuiet root name = do
-    let path = root </> name </> fromFilePath "meta.json"
+    let path = root </> name </> unsafeEncodeUtf "meta.json"
     result <- tryIO (runExceptT (decodeFileEither path))
     pure $ case result of
         Left _ -> Nothing
@@ -496,3 +496,6 @@ readMetaQuiet root name = do
         Right (Right meta)
             | meta.metaVersion == sessionSchemaVersion -> Just meta
             | otherwise -> Nothing
+
+decodeUtfPath :: OsPath -> FilePath
+decodeUtfPath = either impureThrow id . decodeUtf

--- a/packages/agent-cli/src/Agent/CLI/SessionEnv.hs
+++ b/packages/agent-cli/src/Agent/CLI/SessionEnv.hs
@@ -15,7 +15,7 @@ import Agent.CLI.TUI.App (FullscreenRuntime)
 import Agent.Loop (ImageAttachment, LoopConfig, TokenUsage)
 import qualified Agent.OpenAI.Auth as OpenAI
 import Agent.Responses.Types (ResponseCreateParams, ResponseItem)
-import Agent.OsPath (OsPath)
+import System.OsPath (OsPath)
 import Agent.Provider (Provider, TokenProvider)
 import Agent.Skills (SkillCatalog, SkillInvocation)
 import Agent.Subagents (RootTurnId)

--- a/packages/agent-cli/src/Agent/CLI/Skills.hs
+++ b/packages/agent-cli/src/Agent/CLI/Skills.hs
@@ -23,7 +23,7 @@ import Agent.CLI.Style
     )
 import Agent.CLI.Render (putTextLn)
 import Agent.CLI.Terminal (resolveColor)
-import Agent.OsPath (OsPath, toText)
+import Agent.OsPath (toText)
 import Agent.Skills
 import Control.Monad (when)
 import Data.IORef (IORef, modifyIORef', writeIORef)
@@ -31,6 +31,7 @@ import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import System.IO (stderr)
+import System.OsPath (OsPath)
 
 reservedSlashNames :: [Text]
 reservedSlashNames =

--- a/packages/agent-cli/src/Agent/CLI/Status.hs
+++ b/packages/agent-cli/src/Agent/CLI/Status.hs
@@ -17,7 +17,7 @@ import Agent.CLI.ReplMode
     )
 import Agent.CLI.Style (roleMuted)
 import Agent.Loop (TokenUsage(..), emptyTokenUsage)
-import Agent.OsPath (OsPath)
+import System.OsPath (OsPath)
 import Agent.Tools.PlanMode
     ( PlanModeEnv(..)
     , PlanModeState(..)

--- a/packages/agent-cli/src/Agent/CLI/Style.hs
+++ b/packages/agent-cli/src/Agent/CLI/Style.hs
@@ -50,7 +50,7 @@ module Agent.CLI.Style
     , setCliWindowTitle
     ) where
 
-import Agent.OsPath (OsPath, toText)
+import Agent.OsPath (toText)
 import Data.Colour (Colour)
 import Data.Colour.SRGB (RGB(..), sRGB24, toSRGB24)
 import Data.Text (Text)
@@ -67,7 +67,7 @@ import System.Console.ANSI.Codes
     , setSGRCode
     )
 import System.Environment (lookupEnv)
-import System.OsPath (takeFileName)
+import System.OsPath (OsPath, takeFileName)
 import System.IO (Handle)
 import System.IO.Unsafe (unsafePerformIO)
 

--- a/packages/agent-cli/src/Agent/CLI/SubagentStore.hs
+++ b/packages/agent-cli/src/Agent/CLI/SubagentStore.hs
@@ -17,11 +17,11 @@ module Agent.CLI.SubagentStore
 
 import Agent.CLI.Btw (trimDanglingToolSuffix)
 import Agent.FileRetry (retryOnFileBusy, writeLazyFileAtomically)
-import Agent.OsPath (OsPath, fromFilePath, toFilePath, toText)
+import Agent.OsPath (toText)
 import Agent.Responses.Types
 import Agent.Subagents (SubagentId(..), SubagentIdentity(..), SubagentStatus(..))
 import Agent.Subagents.TaskPath (taskPathText)
-import Control.Exception.Safe (tryAny)
+import Control.Exception.Safe (impureThrow, tryAny)
 import Data.Aeson (FromJSON(..), ToJSON(..), object, withObject, (.:?), (.=))
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.KeyMap as KeyMap
@@ -35,7 +35,7 @@ import System.Directory.OsPath
     ( createDirectoryIfMissing
     , doesFileExist
     )
-import System.OsPath ((</>))
+import System.OsPath (OsPath, decodeUtf, unsafeEncodeUtf, (</>))
 import System.Posix.Files (setFileMode)
 
 data SubagentDiskMeta = SubagentDiskMeta
@@ -57,7 +57,7 @@ instance ToJSON SubagentDiskMeta where
         , "agentType" .= meta.diskAgentType
         , "agentModel" .= meta.diskAgentModel
         , "reasoningEffort" .= meta.diskReasoningEffort
-        , "cwd" .= fmap toFilePath meta.diskCwd
+        , "cwd" .= fmap decodeUtfPath meta.diskCwd
         , "taskPath" .= meta.diskTaskPath
         , "parentId" .= meta.diskParentId
         , "depth" .= meta.diskDepth
@@ -73,7 +73,7 @@ instance FromJSON SubagentDiskMeta where
             <*> o .:? "agentType"
             <*> o .:? "agentModel"
             <*> o .:? "reasoningEffort"
-            <*> (fmap fromFilePath <$> o .:? "cwd")
+            <*> (fmap unsafeEncodeUtf <$> o .:? "cwd")
             <*> o .:? "taskPath"
             <*> o .:? "parentId"
             <*> o .:? "depth"
@@ -124,8 +124,8 @@ subagentStoreDir sessionDir agentId
     | otherwise =
         Right
             ( sessionDir
-                </> fromFilePath "agents"
-                </> fromFilePath (Text.unpack agentId.unSubagentId)
+                </> unsafeEncodeUtf "agents"
+                </> unsafeEncodeUtf (Text.unpack agentId.unSubagentId)
             )
 
 forkSubagentTranscript :: Maybe Text -> [ResponseItem] -> [ResponseItem]
@@ -169,10 +169,10 @@ saveSubagentState
     case subagentStoreDir sessionDir agentId of
         Left err -> pure (Left err)
         Right dir -> do
-            let metaPath = dir </> fromFilePath "meta.json"
-                transcriptPath = dir </> fromFilePath "transcript.json"
+            let metaPath = dir </> unsafeEncodeUtf "meta.json"
+                transcriptPath = dir </> unsafeEncodeUtf "transcript.json"
             createDirectoryIfMissing True dir
-            _ <- tryAny (setFileMode (toFilePath dir) 0o700)
+            _ <- tryAny (setFileMode (decodeUtfPath dir) 0o700)
             writeLazyFileAtomically metaPath 0o600 $ Aeson.encode SubagentDiskMeta
                 { diskPreviousResponseId = previous
                 , diskStatus = Just status
@@ -195,8 +195,8 @@ loadSubagentState sessionDir agentId =
     case subagentStoreDir sessionDir agentId of
         Left err -> pure (Left err)
         Right dir -> do
-            let metaPath = dir </> fromFilePath "meta.json"
-                transcriptPath = dir </> fromFilePath "transcript.json"
+            let metaPath = dir </> unsafeEncodeUtf "meta.json"
+                transcriptPath = dir </> unsafeEncodeUtf "transcript.json"
             hasMeta <- doesFileExist metaPath
             hasTranscript <- doesFileExist transcriptPath
             if not (hasMeta || hasTranscript)
@@ -216,7 +216,7 @@ loadSubagentState sessionDir agentId =
                             Right (Just (items, meta))
   where
     decodeFile path = do
-        raw <- retryOnFileBusy (LBS.readFile (toFilePath path))
+        raw <- retryOnFileBusy (LBS.readFile (decodeUtfPath path))
         case Aeson.eitherDecode raw of
             Left err ->
                 pure $ Left $
@@ -225,3 +225,6 @@ loadSubagentState sessionDir agentId =
                         <> ": "
                         <> Text.pack err
             Right value -> pure (Right value)
+
+decodeUtfPath :: OsPath -> FilePath
+decodeUtfPath = either impureThrow id . decodeUtf

--- a/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
@@ -44,7 +44,7 @@ import Agent.Loop
     )
 import Agent.OpenAI.LoopBackend (openAiBackend)
 import Agent.OpenAI.WebSocketClient (withCodexWsRetrying)
-import Agent.OsPath (OsPath)
+import System.OsPath (OsPath)
 import Agent.Provider (Provider(..), TokenProvider)
 import Agent.Responses.Types
     ( ReasoningConfig(..)

--- a/packages/agent-cli/src/Agent/CLI/Worktree.hs
+++ b/packages/agent-cli/src/Agent/CLI/Worktree.hs
@@ -7,8 +7,7 @@ module Agent.CLI.Worktree
     , worktreeRoot
     ) where
 
-import Agent.OsPath (OsPath, fromFilePath, toFilePath)
-import Control.Exception.Safe (mask, onException, tryAny)
+import Control.Exception.Safe (impureThrow, mask, onException, tryAny)
 import Control.Monad (void)
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Except
@@ -32,9 +31,12 @@ import System.Directory.OsPath
     )
 import System.Exit (ExitCode(..))
 import System.OsPath
-    ( equalFilePath
+    ( OsPath
+    , decodeUtf
+    , equalFilePath
     , splitDirectories
     , takeFileName
+    , unsafeEncodeUtf
     , (</>)
     )
 import System.Process (CreateProcess(..), proc, readCreateProcessWithExitCode)
@@ -42,7 +44,7 @@ import System.Process (CreateProcess(..), proc, readCreateProcessWithExitCode)
 -- | @~/.haskell-agent/worktrees@ given the user's home directory.
 worktreeRoot :: OsPath -> OsPath
 worktreeRoot home =
-    home </> fromFilePath ".haskell-agent" </> fromFilePath "worktrees"
+    home </> unsafeEncodeUtf ".haskell-agent" </> unsafeEncodeUtf "worktrees"
 
 -- | True when @path@ is @root@ or a subdirectory of it.
 -- Both paths should already be absolute (or otherwise comparable).
@@ -54,7 +56,7 @@ isUnderWorktreeRoot root path =
 -- | @root/repo/YYYY-MM-DD-\<hex8\>@.
 worktreePath :: OsPath -> OsPath -> Day -> String -> OsPath
 worktreePath root repoName day hex8 =
-    root </> repoName </> fromFilePath (formatDay day <> "-" <> hex8)
+    root </> repoName </> unsafeEncodeUtf (formatDay day <> "-" <> hex8)
 
 -- | Add a new worktree of @source@ under @root@. @root@ is injected so tests
 -- can use a temp directory instead of the real home.
@@ -73,9 +75,9 @@ removeWorktree :: OsPath -> OsPath -> IO (Either Text ())
 removeWorktree source path = runExceptT do
     repo <- gitToplevel source
     void $ ExceptT $
-        git repo ["worktree", "remove", "--force", toFilePath path]
+        git repo ["worktree", "remove", "--force", decodeUtfPath path]
     void $ ExceptT $
-        git repo ["branch", "-D", toFilePath (takeFileName path)]
+        git repo ["branch", "-D", decodeUtfPath (takeFileName path)]
 
 addUnique
     :: OsPath
@@ -95,7 +97,7 @@ addUnique repo root repoName day start attempt
             then addUnique repo root repoName day start (attempt + 1)
             else do
                 added <- lift $ mask \restore ->
-                    restore (git repo ["worktree", "add", toFilePath path])
+                    restore (git repo ["worktree", "add", decodeUtfPath path])
                         `onException` cleanupWorktreeCandidate repo path
                 case added of
                     Left err
@@ -112,10 +114,10 @@ cleanupWorktreeCandidate repo path = do
     if not exists
         then pure ()
         else do
-            _ <- git repo ["worktree", "remove", "--force", toFilePath path]
+            _ <- git repo ["worktree", "remove", "--force", decodeUtfPath path]
             _ <- tryAny (removePathForcibly path)
             _ <- git repo ["worktree", "prune"]
-            _ <- git repo ["branch", "-D", toFilePath (takeFileName path)]
+            _ <- git repo ["branch", "-D", decodeUtfPath (takeFileName path)]
             pure ()
 
 gitToplevel :: OsPath -> ExceptT Text IO OsPath
@@ -123,13 +125,13 @@ gitToplevel source = do
     path <- withExceptT
         (\err -> "--worktree requires a git repository (" <> Text.strip err <> ")")
         (ExceptT (git source ["rev-parse", "--show-toplevel"]))
-    pure (fromFilePath (Text.unpack (Text.strip path)))
+    pure (unsafeEncodeUtf (Text.unpack (Text.strip path)))
 
 git :: OsPath -> [String] -> IO (Either Text Text)
 git dir args = do
     (code, out, err) <-
         readCreateProcessWithExitCode
-            (proc "git" args) { cwd = Just (toFilePath dir) }
+            (proc "git" args) { cwd = Just (decodeUtfPath dir) }
             ""
     case code of
         ExitSuccess -> pure (Right (Text.pack out))
@@ -161,3 +163,6 @@ hex8 n =
 
 formatDay :: Day -> String
 formatDay = formatTime defaultTimeLocale "%Y-%m-%d"
+
+decodeUtfPath :: OsPath -> FilePath
+decodeUtfPath = either impureThrow id . decodeUtf

--- a/packages/agent-cli/test/Agent/CLI/AgentSessionsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/AgentSessionsSpec.hs
@@ -4,7 +4,7 @@ import Agent.CLI.AgentSessions
 import Agent.CLI.Options (ApprovalPolicy(..))
 import Agent.CLI.Session
 import Agent.Loop (defaultLoopDispatch)
-import Agent.OsPath (OsPath, fromFilePath, toFilePath)
+import System.OsPath (OsPath, decodeUtf, unsafeEncodeUtf)
 import Agent.Provider (Provider(..))
 import Agent.ToolDispatch
     ( ToolCallResult(..)
@@ -31,6 +31,9 @@ import Test.Hspec
 isReadOnly :: ApprovalRule -> Bool
 isReadOnly AlwaysReadOnly = True
 isReadOnly _ = False
+
+fromFilePath = unsafeEncodeUtf
+toFilePath path = either (error . show) id (decodeUtf path)
 
 spec :: Spec
 spec = describe "Agent.CLI.AgentSessions" do

--- a/packages/agent-cli/test/Agent/CLI/AuthSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/AuthSpec.hs
@@ -3,7 +3,7 @@ module Agent.CLI.AuthSpec (spec) where
 import Agent.CLI.Auth
 import Agent.CLI.CredentialStore
 import Agent.Error (ApiError(..), ErrorType(..))
-import Agent.OsPath (OsPath, fromFilePath, toFilePath)
+import System.OsPath (OsPath, decodeUtf, unsafeEncodeUtf)
 import Agent.OpenAI.Auth (AuthState(..))
 import qualified Agent.OpenAI.Auth as OpenAI
 import Agent.Provider
@@ -42,6 +42,9 @@ import System.Environment (lookupEnv, setEnv, unsetEnv)
 import System.FilePath ((</>))
 import System.IO (hClose, openTempFile)
 import Test.Hspec
+
+fromFilePath = unsafeEncodeUtf
+toFilePath path = either (error . show) id (decodeUtf path)
 
 spec :: Spec
 spec = do

--- a/packages/agent-cli/test/Agent/CLI/CredentialStoreSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CredentialStoreSpec.hs
@@ -1,7 +1,7 @@
 module Agent.CLI.CredentialStoreSpec (spec) where
 
 import Agent.CLI.CredentialStore
-import Agent.OsPath (OsPath, fromFilePath, toFilePath)
+import System.OsPath (OsPath, decodeUtf, unsafeEncodeUtf)
 import Agent.Provider (Provider(..))
 import Control.Exception.Safe (bracket)
 import qualified Data.ByteString.Lazy.Char8 as LBS
@@ -17,6 +17,9 @@ import System.Environment (lookupEnv, setEnv, unsetEnv)
 import System.IO (hClose, openTempFile)
 import System.Posix.Files (fileMode, getFileStatus)
 import Test.Hspec
+
+fromFilePath = unsafeEncodeUtf
+toFilePath path = either (error . show) id (decodeUtf path)
 
 spec :: Spec
 spec =

--- a/packages/agent-cli/test/Agent/CLI/OptionsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/OptionsSpec.hs
@@ -1,9 +1,11 @@
 module Agent.CLI.OptionsSpec (spec) where
 
 import Agent.CLI.Options
-import Agent.OsPath (fromFilePath)
+import System.OsPath (unsafeEncodeUtf)
 import Agent.Provider (Provider(..))
 import Test.Hspec
+
+fromFilePath = unsafeEncodeUtf
 
 spec :: Spec
 spec = do

--- a/packages/agent-cli/test/Agent/CLI/ProjectSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ProjectSpec.hs
@@ -1,7 +1,7 @@
 module Agent.CLI.ProjectSpec (spec) where
 
 import Agent.CLI.Project
-import Agent.OsPath (OsPath, fromFilePath, toFilePath)
+import System.OsPath (OsPath, decodeUtf, unsafeEncodeUtf)
 import Control.Exception (bracket)
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy as LBS
@@ -19,6 +19,9 @@ import System.Posix.Temp (mkdtemp)
 import System.Posix.Types (FileMode)
 import System.Process (CreateProcess(..), proc, readCreateProcessWithExitCode)
 import Test.Hspec
+
+fromFilePath = unsafeEncodeUtf
+toFilePath path = either (error . show) id (decodeUtf path)
 
 spec :: Spec
 spec = describe "Agent.CLI.Project" do

--- a/packages/agent-cli/test/Agent/CLI/PromptSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/PromptSpec.hs
@@ -1,11 +1,13 @@
 module Agent.CLI.PromptSpec (spec) where
 
 import Agent.CLI.Prompt
-import Agent.OsPath (fromFilePath)
+import System.OsPath (unsafeEncodeUtf)
 import Agent.Provider (Provider(..))
 import Data.Time.Calendar (fromGregorian)
 import qualified Data.Text as Text
 import Test.Hspec
+
+fromFilePath = unsafeEncodeUtf
 
 spec :: Spec
 spec = describe "systemPrompt" do

--- a/packages/agent-cli/test/Agent/CLI/ReplStatusSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ReplStatusSpec.hs
@@ -20,7 +20,7 @@ import Agent.CLI.ReplMode
     , replModeFromState
     )
 import Agent.Loop (TokenUsage(..), emptyTokenUsage)
-import Agent.OsPath (fromFilePath)
+import System.OsPath (unsafeEncodeUtf)
 import Agent.Tools.PlanMode (PlanModeEnv(..), PlanModeState(..), newPlanModeEnv)
 import Control.Exception.Safe (bracket, throwIO)
 import Data.IORef (newIORef, readIORef)
@@ -32,6 +32,8 @@ import System.Directory
     )
 import System.Posix.Temp (mkdtemp)
 import Test.Hspec
+
+fromFilePath = unsafeEncodeUtf
 
 spec :: Spec
 spec = do

--- a/packages/agent-cli/test/Agent/CLI/ResumeSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ResumeSpec.hs
@@ -3,11 +3,13 @@ module Agent.CLI.ResumeSpec (spec) where
 import Agent.CLI.Picker (PickerKey(..))
 import Agent.CLI.Resume
 import Agent.CLI.Session (SessionMeta(..), SessionTurn(..))
-import Agent.OsPath (fromFilePath)
+import System.OsPath (unsafeEncodeUtf)
 import Agent.Provider (Provider(..))
 import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
 import qualified Data.Text as Text
 import Test.Hspec
+
+fromFilePath = unsafeEncodeUtf
 
 spec :: Spec
 spec = do

--- a/packages/agent-cli/test/Agent/CLI/SessionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SessionSpec.hs
@@ -3,7 +3,7 @@ module Agent.CLI.SessionSpec (spec) where
 import Agent.CLI.Session
 import Agent.Loop (TokenUsage(..))
 import Agent.Responses.Types
-import Agent.OsPath (OsPath, fromFilePath, toFilePath)
+import System.OsPath (OsPath, decodeUtf, unsafeEncodeUtf)
 import Agent.Provider (Provider(..))
 import Control.Exception (bracket)
 import qualified Data.Aeson as Aeson
@@ -22,6 +22,9 @@ import qualified System.FilePath as FilePath
 import System.Posix.Files (fileMode, getFileStatus)
 import System.Posix.Temp (mkdtemp)
 import Test.Hspec
+
+fromFilePath = unsafeEncodeUtf
+toFilePath path = either (error . show) id (decodeUtf path)
 
 spec :: Spec
 spec = describe "Agent.CLI.Session" do

--- a/packages/agent-cli/test/Agent/CLI/SkillsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SkillsSpec.hs
@@ -3,11 +3,13 @@ module Agent.CLI.SkillsSpec (spec) where
 import Agent.CLI.Command (SkillCommand(..))
 import Agent.CLI.Options (CliOptions(..), defaultCliOptions)
 import Agent.CLI.Skills
-import Agent.OsPath (fromFilePath)
+import System.OsPath (unsafeEncodeUtf)
 import Agent.Skills
 import Data.IORef (newIORef, readIORef)
 import qualified Data.Text as Text
 import Test.Hspec
+
+fromFilePath = unsafeEncodeUtf
 
 spec :: Spec
 spec = describe "Agent.CLI.Skills" do

--- a/packages/agent-cli/test/Agent/CLI/StyleSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/StyleSpec.hs
@@ -1,9 +1,11 @@
 module Agent.CLI.StyleSpec (spec) where
 
 import Agent.CLI.Style
-import Agent.OsPath (fromFilePath)
+import System.OsPath (unsafeEncodeUtf)
 import qualified Data.Text as Text
 import Test.Hspec
+
+fromFilePath = unsafeEncodeUtf
 
 spec :: Spec
 spec = do

--- a/packages/agent-cli/test/Agent/CLI/SubagentStoreSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SubagentStoreSpec.hs
@@ -2,7 +2,7 @@ module Agent.CLI.SubagentStoreSpec (spec) where
 
 import Agent.CLI.SubagentStore
 import Agent.Responses.Types
-import Agent.OsPath (OsPath, fromFilePath, toFilePath)
+import System.OsPath (OsPath, decodeUtf, unsafeEncodeUtf)
 import Agent.Subagents
     ( SubagentId(..)
     , SubagentIdentity(..)
@@ -19,6 +19,9 @@ import qualified System.FilePath as FilePath
 import System.OsPath ((</>))
 import System.Posix.Temp (mkdtemp)
 import Test.Hspec
+
+fromFilePath = unsafeEncodeUtf
+toFilePath path = either (error . show) id (decodeUtf path)
 
 spec :: Spec
 spec = describe "Agent.CLI.SubagentStore" do

--- a/packages/agent-cli/test/Agent/CLI/WorktreeSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/WorktreeSpec.hs
@@ -1,7 +1,7 @@
 module Agent.CLI.WorktreeSpec (spec) where
 
 import Agent.CLI.Worktree
-import Agent.OsPath (OsPath, fromFilePath, toFilePath)
+import System.OsPath (OsPath, decodeUtf, unsafeEncodeUtf)
 import Control.Exception (bracket)
 import Data.List (dropWhileEnd, isInfixOf)
 import Data.Text (Text)
@@ -15,6 +15,9 @@ import System.OsPath (addTrailingPathSeparator, takeFileName, (</>))
 import System.Posix.Temp (mkdtemp)
 import System.Process (CreateProcess(..), proc, readCreateProcessWithExitCode)
 import Test.Hspec
+
+fromFilePath = unsafeEncodeUtf
+toFilePath path = either (error . show) id (decodeUtf path)
 
 spec :: Spec
 spec = describe "Agent.CLI.Worktree" do

--- a/packages/agent-core/agent-core.cabal
+++ b/packages/agent-core/agent-core.cabal
@@ -105,6 +105,7 @@ test-suite agent-core-test
     other-modules:    Agent.CancelSpec
                     , Agent.ErrorSpec
                     , Agent.LoopSpec
+                    , Agent.OsPathSpec
                     , Agent.JsonTextSpec
                     , Agent.ProjectInstructionsSpec
                     , Agent.ResourceScopeSpec

--- a/packages/agent-core/src/Agent/FileRetry.hs
+++ b/packages/agent-core/src/Agent/FileRetry.hs
@@ -6,8 +6,7 @@ module Agent.FileRetry
     , writeLazyFileAtomically
     ) where
 
-import Agent.OsPath (OsPath, fromFilePath, toFilePath)
-import Control.Exception.Safe (bracket, bracketOnError, throwIO, tryIO)
+import Control.Exception.Safe (bracket, bracketOnError, impureThrow, throwIO, tryIO)
 import Control.Retry
     ( RetryPolicyM
     , exponentialBackoff
@@ -23,7 +22,7 @@ import System.IO
     , openBinaryTempFile
     )
 import System.IO.Error (isAlreadyInUseError)
-import System.OsPath (takeDirectory, takeFileName)
+import System.OsPath (OsPath, decodeUtf, takeDirectory, takeFileName, unsafeEncodeUtf)
 import System.Posix.Files (setFileMode)
 import System.Posix.Types (FileMode)
 
@@ -45,7 +44,7 @@ retryOnFileBusy action = do
 appendLazyFileRetryingOpen :: OsPath -> LBS.ByteString -> IO ()
 appendLazyFileRetryingOpen path bytes =
     bracket
-        (retryOnFileBusy (openBinaryFile (toFilePath path) AppendMode))
+        (retryOnFileBusy (openBinaryFile (decodeUtfPath path) AppendMode))
         hClose
         (`LBS.hPut` bytes)
 
@@ -62,14 +61,17 @@ writeLazyFileAtomically path mode bytes =
         LBS.hPut handle bytes
         hClose handle
         setFileMode temporary mode
-        retryOnFileBusy (renameFile (fromFilePath temporary) path)
+        retryOnFileBusy (renameFile (unsafeEncodeUtf temporary) path)
   where
     acquire =
         retryOnFileBusy $
             openBinaryTempFile
-                (toFilePath (takeDirectory path))
-                (toFilePath (takeFileName path) <> ".tmp")
+                (decodeUtfPath (takeDirectory path))
+                (decodeUtfPath (takeFileName path) <> ".tmp")
     cleanup (temporary, handle) = do
         _ <- tryIO (hClose handle)
-        _ <- tryIO (removeFile (fromFilePath temporary))
+        _ <- tryIO (removeFile (unsafeEncodeUtf temporary))
         pure ()
+
+decodeUtfPath :: OsPath -> FilePath
+decodeUtfPath = either impureThrow id . decodeUtf

--- a/packages/agent-core/src/Agent/OsPath.hs
+++ b/packages/agent-core/src/Agent/OsPath.hs
@@ -1,13 +1,9 @@
--- | Common conversions at text-oriented API boundaries.
+-- | Conversions at 'Text'-oriented API boundaries.
 --
--- Filesystem-facing code should keep paths as 'OsPath'. Conversion back to
--- 'FilePath' is reserved for libraries such as @process@ that do not yet
--- expose an 'OsPath' API, and for human-readable output.
+-- Import 'OsPath' and the standard encoding functions directly from
+-- "System.OsPath".
 module Agent.OsPath
-    ( OsPath
-    , fromFilePath
-    , fromText
-    , toFilePath
+    ( fromText
     , toText
     ) where
 
@@ -16,15 +12,14 @@ import qualified Data.Text as Text
 import System.OsPath (OsPath)
 import qualified System.OsPath as OsPath
 
-fromFilePath :: FilePath -> OsPath
-fromFilePath = OsPath.unsafeEncodeUtf
-
+-- | Pure UTF encoding for path values that originate as Unicode text.
 fromText :: Text -> OsPath
-fromText = fromFilePath . Text.unpack
+fromText = OsPath.unsafeEncodeUtf . Text.unpack
 
-toFilePath :: OsPath -> FilePath
-toFilePath path =
-    either (const (show path)) id (OsPath.decodeUtf path)
-
+-- | Render a path for human-readable output.
+--
+-- An undecodable path is represented with its escaped 'Show' form. This
+-- fallback is suitable for diagnostics, never filesystem access.
 toText :: OsPath -> Text
-toText = Text.pack . toFilePath
+toText path =
+    either (const (Text.pack (show path))) Text.pack (OsPath.decodeUtf path)

--- a/packages/agent-core/src/Agent/ProjectInstructions.hs
+++ b/packages/agent-core/src/Agent/ProjectInstructions.hs
@@ -20,8 +20,8 @@ module Agent.ProjectInstructions
 
 import Agent.FileRetry (retryOnFileBusy)
 import Agent.Provider (Provider(..))
-import Agent.OsPath (OsPath, fromFilePath, toFilePath, toText)
-import Control.Exception.Safe (tryAny)
+import Agent.OsPath (toText)
+import Control.Exception.Safe (impureThrow, tryAny)
 import qualified Data.ByteString as BS
 import Data.Maybe (mapMaybe)
 import Data.Text (Text)
@@ -29,7 +29,7 @@ import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
 import qualified Data.Text.IO as Text
 import System.Directory.OsPath (doesFileExist, doesPathExist)
-import System.OsPath (takeDirectory, (</>))
+import System.OsPath (OsPath, decodeUtf, takeDirectory, unsafeEncodeUtf, (</>))
 
 -- | One loaded instruction file and its absolute path.
 data InstructionFile = InstructionFile
@@ -64,15 +64,15 @@ defaultDiscoverOptions :: DiscoverOptions
 defaultDiscoverOptions = DiscoverOptions
     { discoverMaxBytes = defaultProjectDocMaxBytes
     , discoverGlobalDir = Nothing
-    , discoverRootMarkers = [fromFilePath ".git"]
+    , discoverRootMarkers = [unsafeEncodeUtf ".git"]
     }
 
 -- | Provider-specific directory under the user home for global AGENTS.md.
 globalAgentsHomeDir :: Provider -> OsPath -> OsPath
 globalAgentsHomeDir provider home = case provider of
-    OpenAIProvider -> home </> fromFilePath ".codex"
-    XAIProvider -> home </> fromFilePath ".grok"
-    OpenRouterProvider -> home </> fromFilePath ".grok"
+    OpenAIProvider -> home </> unsafeEncodeUtf ".codex"
+    XAIProvider -> home </> unsafeEncodeUtf ".grok"
+    OpenRouterProvider -> home </> unsafeEncodeUtf ".grok"
 
 -- | Load global + project AGENTS.md files for @cwd@. Empty / unreadable files
 -- are skipped. Project files are ordered root -> cwd.
@@ -114,17 +114,17 @@ directoryChain root cwd = reverse (go cwd)
 -- | Prefer @AGENTS.override.md@ over @AGENTS.md@ in a directory.
 readPreferredAgentsMd :: OsPath -> IO (Maybe InstructionFile)
 readPreferredAgentsMd dir = do
-    override <- readAgentsFile (dir </> fromFilePath "AGENTS.override.md")
+    override <- readAgentsFile (dir </> unsafeEncodeUtf "AGENTS.override.md")
     case override of
         Just file -> pure (Just file)
-        Nothing -> readAgentsFile (dir </> fromFilePath "AGENTS.md")
+        Nothing -> readAgentsFile (dir </> unsafeEncodeUtf "AGENTS.md")
 
 readAgentsFile :: OsPath -> IO (Maybe InstructionFile)
 readAgentsFile path = do
     exists <- doesFileExist path
     if not exists
         then pure Nothing
-        else tryAny (retryOnFileBusy (Text.readFile (toFilePath path))) >>= \case
+        else tryAny (retryOnFileBusy (Text.readFile (decodeUtfPath path))) >>= \case
             Left _ -> pure Nothing
             Right text ->
                 if Text.null (Text.strip text)
@@ -235,3 +235,6 @@ neutralizeReminderTags =
         . Text.replace "</system-reminder" "&lt;/system-reminder"
         . Text.replace "<system_reminder" "&lt;system_reminder"
         . Text.replace "</system_reminder" "&lt;/system_reminder"
+
+decodeUtfPath :: OsPath -> FilePath
+decodeUtfPath = either impureThrow id . decodeUtf

--- a/packages/agent-core/src/Agent/Skills.hs
+++ b/packages/agent-core/src/Agent/Skills.hs
@@ -19,8 +19,8 @@ module Agent.Skills
     ) where
 
 import Agent.FileRetry (retryOnFileBusy)
-import Agent.OsPath (OsPath, fromFilePath, toFilePath, toText)
-import Control.Exception.Safe (tryAny)
+import Agent.OsPath (toText)
+import Control.Exception.Safe (impureThrow, tryAny)
 import Control.Monad (filterM, forM)
 import Data.Aeson
     ( FromJSON(..)
@@ -30,6 +30,7 @@ import Data.Aeson
     , (.:?)
     , (.!=)
     )
+import System.OsPath (OsPath, decodeUtf, unsafeEncodeUtf)
 import Data.Aeson.Types (Parser)
 import qualified Data.ByteString as BS
 import Data.Char (isAlphaNum)
@@ -221,9 +222,9 @@ discoverSkills options = do
 
 skillRoots :: SkillDiscoverOptions -> IO [(SkillScope, SkillOrigin, FilePath)]
 skillRoots options = do
-    projectRoot <- canonicalizePath (toFilePath options.skillsProjectRoot)
-    cwd <- canonicalizePath (toFilePath options.skillsCwd)
-    home <- canonicalizePath (toFilePath options.skillsHome)
+    projectRoot <- canonicalizePath (decodeUtfPath options.skillsProjectRoot)
+    cwd <- canonicalizePath (decodeUtfPath options.skillsCwd)
+    home <- canonicalizePath (decodeUtfPath options.skillsHome)
     let dirs = directoryChain projectRoot cwd
         projectRoots =
             [ ( RepositorySkill depth (dir == cwd)
@@ -330,15 +331,15 @@ loadSkill scope origin path = do
                                         , skillLicense = frontmatter.fmLicense
                                         , skillCompatibility = frontmatter.fmCompatibility
                                         , skillMetadata = frontmatter.fmMetadata
-                                        , skillPath = fromFilePath path
-                                        , skillDirectory = fromFilePath (takeDirectory path)
+                                        , skillPath = unsafeEncodeUtf path
+                                        , skillDirectory = unsafeEncodeUtf (takeDirectory path)
                                         , skillBody = Text.strip body
                                         , skillFileText = fileText
                                         , skillScope = scope
                                         , skillOrigin = origin
                                         }
   where
-    warning message = SkillWarning (fromFilePath path) message
+    warning message = SkillWarning (unsafeEncodeUtf path) message
 
 loadOpenAiMetadata :: FilePath -> IO (Maybe OpenAiMetadata)
 loadOpenAiMetadata dir = do
@@ -617,3 +618,6 @@ infixr 3 <|>
 (<|>) left right = case left of
     Just value -> Just value
     Nothing -> right
+
+decodeUtfPath :: OsPath -> FilePath
+decodeUtfPath = either impureThrow id . decodeUtf

--- a/packages/agent-core/src/Agent/Subagents/Registry.hs
+++ b/packages/agent-core/src/Agent/Subagents/Registry.hs
@@ -67,7 +67,7 @@ import Agent.InterAgentMessage
     , plainInterAgentContent
     )
 import Agent.Loop (LoopError(..), LoopEvent, LoopResult(..))
-import Agent.OsPath (OsPath)
+import System.OsPath (OsPath)
 import Agent.Subagents.Format (formatCompletionNotice, isFinalStatus)
 import Agent.Subagents.Types
     ( RunSubagent

--- a/packages/agent-core/src/Agent/Subagents/Types.hs
+++ b/packages/agent-core/src/Agent/Subagents/Types.hs
@@ -17,7 +17,7 @@ module Agent.Subagents.Types
 import Agent.Cancel (CancelFlag)
 import Agent.InterAgentMessage (InterAgentMessage)
 import Agent.Loop (LoopError, LoopEvent, LoopResult)
-import Agent.OsPath (OsPath)
+import System.OsPath (OsPath)
 import Agent.Subagents.TaskPath (TaskPath)
 import qualified Data.Aeson as Aeson
 import Data.Text (Text)

--- a/packages/agent-core/src/Agent/Tools/ApplyPatch.hs
+++ b/packages/agent-core/src/Agent/Tools/ApplyPatch.hs
@@ -10,7 +10,6 @@ module Agent.Tools.ApplyPatch
     , applyPatchGrammar
     ) where
 
-import Agent.OsPath (OsPath, fromFilePath)
 import Agent.Tools.IO
     ( deleteTextFile
     , readTextFile
@@ -30,6 +29,7 @@ import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import System.Directory.OsPath (doesFileExist)
+import System.OsPath (OsPath, unsafeEncodeUtf)
 
 
 -- | Lark grammar Codex registers for the freeform apply_patch tool.
@@ -228,7 +228,7 @@ applyHunks env hunks = go hunks [] [] []
 
 resolvePath :: ToolEnv -> FilePath -> ExceptT Text IO OsPath
 resolvePath env path =
-    ExceptT (resolveUnderCwd env (fromFilePath path))
+    ExceptT (resolveUnderCwd env (unsafeEncodeUtf path))
 
 applyChunks :: [UpdateChunk] -> [Text] -> Either Text [Text]
 applyChunks chunks start = foldl applyOne (Right start) chunks

--- a/packages/agent-core/src/Agent/Tools/FileSystem.hs
+++ b/packages/agent-core/src/Agent/Tools/FileSystem.hs
@@ -9,9 +9,9 @@ module Agent.Tools.FileSystem
     ) where
 
 import Agent.FileRetry (retryOnFileBusy)
-import Agent.OsPath (OsPath, fromFilePath, toFilePath, toText)
+import Agent.OsPath (toText)
 import Agent.Tools.Types (ToolEnv(..))
-import Control.Exception.Safe (SomeException, try, tryIO)
+import Control.Exception.Safe (SomeException, impureThrow, try, tryIO)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.ByteString as BS
@@ -28,12 +28,15 @@ import System.Directory.OsPath
     , renameFile
     )
 import System.OsPath
-    ( equalFilePath
+    ( OsPath
+    , decodeUtf
+    , equalFilePath
     , isAbsolute
     , makeRelative
     , splitDirectories
     , takeDirectory
     , takeFileName
+    , unsafeEncodeUtf
     , (</>)
     )
 import System.IO.Error (isDoesNotExistError)
@@ -85,12 +88,12 @@ isInside root path
         let relative = makeRelative root path
         in not (isAbsolute relative)
             && case splitDirectories relative of
-                (first : _) | first == fromFilePath ".." -> False
+                (first : _) | first == unsafeEncodeUtf ".." -> False
                 _ -> True
 
 readTextFile :: OsPath -> IO (Either Text Text)
 readTextFile path =
-    try @_ @SomeException (retryOnFileBusy (BS.readFile (toFilePath path))) >>= \case
+    try @_ @SomeException (retryOnFileBusy (BS.readFile (decodeUtfPath path))) >>= \case
     Left err -> pure $ Left $ "Failed to read file: " <> Text.pack (show err)
     Right bytes
         | BS.elem 0 (BS.take 8192 bytes) ->
@@ -102,7 +105,7 @@ writeTextFile :: OsPath -> Text -> IO (Either Text ())
 writeTextFile path content = do
     createDirectoryIfMissing True (takeDirectory path)
     try @_ @SomeException
-        (retryOnFileBusy (BS.writeFile (toFilePath path) (encodeUtf8 content))) >>= \case
+        (retryOnFileBusy (BS.writeFile (decodeUtfPath path) (encodeUtf8 content))) >>= \case
         Left err -> pure $ Left $ "Failed to write file: " <> Text.pack (show err)
         Right () -> pure (Right ())
 
@@ -127,3 +130,6 @@ listDirectoryEntries path = try @_ @SomeException (listDirectory path) >>= \case
     classify root name = do
         isDir <- doesDirectoryExist (root </> name)
         pure (name, isDir)
+
+decodeUtfPath :: OsPath -> FilePath
+decodeUtfPath = either impureThrow id . decodeUtf

--- a/packages/agent-core/src/Agent/Tools/Ghci/Runtime.hs
+++ b/packages/agent-core/src/Agent/Tools/Ghci/Runtime.hs
@@ -14,7 +14,6 @@ module Agent.Tools.Ghci.Runtime
     ) where
 
 import Agent.Cancel (CancelFlag, isCancelled, waitCancel)
-import Agent.OsPath (toFilePath)
 import Agent.Tools.Ghci.Classify
     ( GhciClass(..)
     , classifyGhciInput
@@ -51,6 +50,7 @@ import Control.Concurrent.STM
 import Control.Exception.Safe
     ( SomeException
     , finally
+    , impureThrow
     , mask
     , onException
     , try
@@ -85,6 +85,7 @@ import System.Process
     )
 import System.Posix.Signals (sigINT, signalProcessGroup)
 import System.Posix.Types (ProcessGroupID)
+import System.OsPath (OsPath, decodeUtf)
 
 data GhciOutcome
     = GhciCompleted
@@ -467,7 +468,7 @@ ghciArgs =
 spawnProcess :: ToolEnv -> IO (Either Text GhciProcess)
 spawnProcess env = do
     let spec = (proc "ghci" ghciArgs)
-            { cwd = Just (toFilePath env.toolCwd)
+            { cwd = Just (decodeUtfPath env.toolCwd)
             , std_in = CreatePipe
             , std_out = CreatePipe
             , std_err = CreatePipe
@@ -868,3 +869,6 @@ remainingMillis started budget = do
     now <- getMonotonicTimeNSec
     let elapsed = fromIntegral ((now - started) `div` 1000000)
     pure (max 0 (budget - elapsed))
+
+decodeUtfPath :: OsPath -> FilePath
+decodeUtfPath = either impureThrow id . decodeUtf

--- a/packages/agent-core/src/Agent/Tools/Grok/Common.hs
+++ b/packages/agent-core/src/Agent/Tools/Grok/Common.hs
@@ -5,7 +5,6 @@ module Agent.Tools.Grok.Common
     , stripAnsi
     ) where
 
-import Agent.OsPath (OsPath, toFilePath)
 import Agent.ToolArgs (optInt, optText)
 import Agent.ToolDSL (PropertySchema)
 import Agent.ToolDispatch (ToolHandler)
@@ -19,9 +18,11 @@ import Data.Aeson (Object)
 import Data.Aeson.Types (Parser)
 import Data.Text (Text)
 import qualified Data.Text as Text
+import Control.Exception.Safe (impureThrow)
 import System.Directory (findExecutable)
 import System.Exit (ExitCode(..))
 import System.Process (readProcessWithExitCode)
+import System.OsPath (OsPath, decodeUtf)
 
 jsonTool
     :: Text
@@ -39,7 +40,7 @@ isGitIgnored cwd path = findExecutable "git" >>= \case
     Nothing -> pure False
     Just git -> do
         (code, _, _) <- readProcessWithExitCode git
-            ["-C", toFilePath cwd, "check-ignore", "-q", "--", toFilePath path] ""
+            ["-C", decodeUtfPath cwd, "check-ignore", "-q", "--", decodeUtfPath path] ""
         pure (code == ExitSuccess)
 
 optionalTimeout :: Object -> Parser (Maybe Int)
@@ -70,3 +71,6 @@ stripAnsi = Text.concat . go
                     _ -> before : "\ESC" : go afterEsc
 
     isCsiFinal c = c >= '@' && c <= '~'
+
+decodeUtfPath :: OsPath -> FilePath
+decodeUtfPath = either impureThrow id . decodeUtf

--- a/packages/agent-core/src/Agent/Tools/Grok/Grep.hs
+++ b/packages/agent-core/src/Agent/Tools/Grok/Grep.hs
@@ -1,12 +1,13 @@
 module Agent.Tools.Grok.Grep (grepTool) where
 
-import Agent.OsPath (OsPath, fromText, toFilePath, toText)
+import Agent.OsPath (fromText, toText)
 import Agent.ToolArgs (objectArgs, optBool, optInt, optText, reqText)
 import Agent.ToolDSL (PropertySchema(..), PropertyType(..))
 import Agent.ToolDispatch (typedTool)
 import Agent.Tools.Grok.Common (jsonTool)
 import Agent.Tools.IO (resolveUnderCwd)
 import Agent.Tools.Types (AppTool, ToolEnv(..))
+import Control.Exception.Safe (impureThrow)
 import Data.Aeson (FromJSON(..))
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
@@ -14,6 +15,7 @@ import qualified Data.Text as Text
 import System.Directory (findExecutable)
 import System.Exit (ExitCode(..))
 import System.Process (readProcessWithExitCode)
+import System.OsPath (OsPath, decodeUtf)
 
 data GrepOutputMode = GrepContent | GrepFilesWithMatches | GrepCount
     deriving (Eq, Show)
@@ -127,7 +129,7 @@ runRipgrep rgPath path args = do
             , ["-i" | args.caseInsensitive]
             , maybe [] (\t -> ["--type", Text.unpack t]) args.fileType
             , if args.multiline then ["-U", "--multiline-dotall"] else []
-            , ["--regexp", Text.unpack args.pattern, "--", toFilePath path]
+            , ["--regexp", Text.unpack args.pattern, "--", decodeUtfPath path]
             ]
     (code, stdout, stderr) <- readProcessWithExitCode rgPath rgArgs ""
     let raw = Text.pack stdout
@@ -159,3 +161,6 @@ formatGrepCard cwd raw limit
             <> body
             <> footer
             <> "</workspace_result>"
+
+decodeUtfPath :: OsPath -> FilePath
+decodeUtfPath = either impureThrow id . decodeUtf

--- a/packages/agent-core/src/Agent/Tools/Grok/ListDir.hs
+++ b/packages/agent-core/src/Agent/Tools/Grok/ListDir.hs
@@ -1,6 +1,6 @@
 module Agent.Tools.Grok.ListDir (listDirTool) where
 
-import Agent.OsPath (OsPath, fromText, toText)
+import Agent.OsPath (fromText, toText)
 import Agent.ToolArgs (objectArgs, reqText)
 import Agent.ToolDSL (PropertySchema(..), PropertyType(..))
 import Agent.ToolDispatch (typedTool)
@@ -13,7 +13,7 @@ import qualified Data.Map.Strict as Map
 import Data.Text (Text)
 import qualified Data.Text as Text
 import System.Directory.OsPath (doesDirectoryExist, pathIsSymbolicLink)
-import System.OsPath (takeExtension, (</>))
+import System.OsPath (OsPath, takeExtension, (</>))
 
 newtype ListDirArgs = ListDirArgs { targetDirectory :: Text }
 

--- a/packages/agent-core/src/Agent/Tools/Grok/Prompt.hs
+++ b/packages/agent-core/src/Agent/Tools/Grok/Prompt.hs
@@ -9,12 +9,12 @@ module Agent.Tools.Grok.Prompt
     , grokSystemPrompt
     ) where
 
-import Agent.OsPath (OsPath, toText)
+import Agent.OsPath (toText)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Time.Calendar (Day)
 import Data.Time.Format (defaultTimeLocale, formatTime)
-import System.OsPath (dropTrailingPathSeparator)
+import System.OsPath (OsPath, dropTrailingPathSeparator)
 
 -- | Model-facing names for the grok-build tool kinds we currently advertise.
 data GrokPromptTools = GrokPromptTools

--- a/packages/agent-core/src/Agent/Tools/Grok/SearchReplace.hs
+++ b/packages/agent-core/src/Agent/Tools/Grok/SearchReplace.hs
@@ -1,6 +1,7 @@
 module Agent.Tools.Grok.SearchReplace (searchReplaceTool) where
 
-import Agent.OsPath (OsPath, fromText)
+import Agent.OsPath (fromText)
+import System.OsPath (OsPath)
 import Agent.ToolArgs (objectArgs, optBool, reqText)
 import Agent.ToolDSL (PropertySchema(..), PropertyType(..))
 import Agent.ToolDispatch (typedTool)

--- a/packages/agent-core/src/Agent/Tools/Grok/Shell.hs
+++ b/packages/agent-core/src/Agent/Tools/Grok/Shell.hs
@@ -16,7 +16,7 @@ module Agent.Tools.Grok.Shell
     , hasUnwaitedBackgroundOp
     ) where
 
-import Agent.OsPath (OsPath, fromFilePath, fromText, toFilePath)
+import Agent.OsPath (fromText)
 import Agent.ResourceScope
     ( ResourceKey
     , ResourceScope
@@ -38,7 +38,7 @@ import Agent.Tools.Types (ToolEnv(..))
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async (race)
 import Control.Concurrent.MVar
-import Control.Exception.Safe (mask, onException, throwIO, tryAny)
+import Control.Exception.Safe (impureThrow, mask, onException, throwIO, tryAny)
 import Control.Monad (void)
 import Data.IORef
 import Data.Map.Strict (Map)
@@ -54,7 +54,7 @@ import System.Directory.OsPath
     , removeFile
     )
 import System.IO (hClose)
-import System.OsPath ((<.>), (</>))
+import System.OsPath (OsPath, decodeUtf, unsafeEncodeUtf, (<.>), (</>))
 import System.Posix.Files (ownerReadMode, ownerWriteMode, setFileMode, unionFileModes)
 import System.Posix.Temp (mkstemp)
 
@@ -100,8 +100,8 @@ newGrokSession env = do
         mask \restore -> do
             tmp <- getTemporaryDirectory
             (envFileRaw, handle) <- restore $
-                mkstemp (toFilePath (tmp </> fromFilePath "agent-grok-env"))
-            let envFile = fromFilePath envFileRaw
+                mkstemp (decodeUtfPath (tmp </> unsafeEncodeUtf "agent-grok-env"))
+            let envFile = unsafeEncodeUtf envFileRaw
             let rollback = do
                     void $ tryAny (hClose handle)
                     removeIfExists envFile
@@ -113,7 +113,7 @@ newGrokSession env = do
                 pure envFile
     cleanupEnvFiles envFile = do
         removeIfExists envFile
-        removeIfExists (envFile <.> fromFilePath "cwd")
+        removeIfExists (envFile <.> unsafeEncodeUtf "cwd")
 
 -- | Delete the env/cwd dump and interrupt leftover background tasks.
 -- Call this when the CLI/session ends, including after exceptions.
@@ -239,11 +239,11 @@ wrapScript shell persist command =
         ]
 
 cwdFile :: PersistentShell -> OsPath
-cwdFile shell = shell.shellEnvFile <.> fromFilePath "cwd"
+cwdFile shell = shell.shellEnvFile <.> unsafeEncodeUtf "cwd"
 
 refreshCwd :: ToolEnv -> PersistentShell -> IO PersistentShell
 refreshCwd env shell = do
-    contents <- tryAny (Text.readFile (toFilePath (cwdFile shell)))
+    contents <- tryAny (Text.readFile (decodeUtfPath (cwdFile shell)))
     case contents of
         Left _ -> pure shell
         Right raw -> do
@@ -256,7 +256,7 @@ refreshCwd env shell = do
                     Right resolved -> pure shell { shellCwd = resolved }
 
 quote :: OsPath -> String
-quote = quoteString . toFilePath
+quote = quoteString . decodeUtfPath
 
 quoteString :: String -> String
 quoteString path = "'" <> concatMap escape path <> "'"
@@ -320,3 +320,6 @@ containsBareAmp text = go (' ' : Text.unpack text)
         | a `notElem` ("&<>|" :: String) && b `notElem` ("&>" :: String) = True
         | otherwise = go ('&' : b : rest)
     go (_ : rest) = go rest
+
+decodeUtfPath :: OsPath -> FilePath
+decodeUtfPath = either impureThrow id . decodeUtf

--- a/packages/agent-core/src/Agent/Tools/Grok/Task.hs
+++ b/packages/agent-core/src/Agent/Tools/Grok/Task.hs
@@ -20,7 +20,7 @@ module Agent.Tools.Grok.Task
     ) where
 
 import Agent.InterAgentMessage (plainInterAgentContent)
-import Agent.OsPath (OsPath, fromText, toText)
+import Agent.OsPath (fromText, toText)
 import Agent.Subagents
     ( SubagentId(..)
     , SubagentStatus(..)
@@ -59,7 +59,7 @@ import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import System.Directory.OsPath (doesDirectoryExist)
-import System.OsPath (isAbsolute, normalise, (</>))
+import System.OsPath (OsPath, isAbsolute, normalise, (</>))
 
 defaultSubagentType :: Text
 defaultSubagentType = "general-purpose"

--- a/packages/agent-core/src/Agent/Tools/IO.hs
+++ b/packages/agent-core/src/Agent/Tools/IO.hs
@@ -18,7 +18,6 @@ module Agent.Tools.IO
     ) where
 
 import Agent.Cancel (isCancelled, waitCancel)
-import Agent.OsPath (OsPath, toFilePath)
 import Agent.Tools.FileSystem
     ( deleteTextFile
     , listDirectoryEntries
@@ -27,6 +26,7 @@ import Agent.Tools.FileSystem
     , resolveUnderCwd
     , writeTextFile
     )
+import System.OsPath (OsPath, decodeUtf)
 import Agent.Tools.Types (ToolEnv(..))
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async
@@ -48,6 +48,7 @@ import Control.Concurrent.MVar
 import Control.Exception.Safe
     ( SomeException
     , finally
+    , impureThrow
     , mask
     , onException
     , try
@@ -139,7 +140,7 @@ runShellCommandStreaming
 runShellCommandStreaming env workdir command timeoutMs onSnapshot =
     mask \restore -> do
     let spec = (shell command)
-            { cwd = Just (toFilePath workdir)
+            { cwd = Just (decodeUtfPath workdir)
             , std_in = CreatePipe
             , std_out = CreatePipe
             , std_err = CreatePipe
@@ -263,7 +264,7 @@ startShellCommand
     -> IO (Either Text RunningCommand)
 startShellCommand env workdir command = do
     let spec = (shell command)
-            { cwd = Just (toFilePath workdir)
+            { cwd = Just (decodeUtfPath workdir)
             , std_in = CreatePipe
             , std_out = CreatePipe
             , std_err = CreatePipe
@@ -493,3 +494,6 @@ processGroupAlive groupId processHandle = do
         Just pid ->
             isRight <$> try @_ @SomeException
                 (signalProcessGroup nullSignal pid)
+
+decodeUtfPath :: OsPath -> FilePath
+decodeUtfPath = either impureThrow id . decodeUtf

--- a/packages/agent-core/src/Agent/Tools/MultiAgents.hs
+++ b/packages/agent-core/src/Agent/Tools/MultiAgents.hs
@@ -40,7 +40,7 @@ import Agent.InterAgentMessage
     , encryptedInterAgentContent
     , plainInterAgentContent
     )
-import Agent.OsPath (OsPath)
+import System.OsPath (OsPath)
 import Agent.ToolArgs
     ( objectArgs
     , optInt

--- a/packages/agent-core/src/Agent/Tools/PlanMode.hs
+++ b/packages/agent-core/src/Agent/Tools/PlanMode.hs
@@ -28,7 +28,7 @@ module Agent.Tools.PlanMode
     ) where
 
 import Agent.FileRetry (retryOnFileBusy)
-import Agent.OsPath (OsPath, fromFilePath, toFilePath, toText)
+import Agent.OsPath (toText)
 import Agent.ToolArgs (objectArgs, optText, reqText)
 import Agent.ToolDSL
     ( PropertySchema(..)
@@ -40,7 +40,7 @@ import Agent.Tools.Types
     , ApprovalRule(..)
     , jsonAppTool
     )
-import Control.Exception.Safe (tryAny)
+import Control.Exception.Safe (impureThrow, tryAny)
 import Data.Aeson (FromJSON(..), withObject)
 import Data.IORef
 import Data.Maybe (fromMaybe)
@@ -48,7 +48,7 @@ import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
 import System.Directory.OsPath (createDirectoryIfMissing, doesFileExist)
-import System.OsPath (equalFilePath, takeDirectory, (</>))
+import System.OsPath (OsPath, decodeUtf, equalFilePath, takeDirectory, unsafeEncodeUtf, (</>))
 
 data PlanModeState
     = PlanInactive
@@ -82,7 +82,7 @@ data PlanModeHooks = PlanModeHooks
     }
 
 planFileName :: OsPath
-planFileName = fromFilePath "plan.md"
+planFileName = unsafeEncodeUtf "plan.md"
 
 defaultHooks :: PlanModeHooks
 defaultHooks = PlanModeHooks
@@ -125,13 +125,13 @@ readPlanMarkdown env = do
     if not exists
         then pure ""
         else either (const "") id
-            <$> tryAny (retryOnFileBusy (Text.readFile (toFilePath path)))
+            <$> tryAny (retryOnFileBusy (Text.readFile (decodeUtfPath path)))
 
 writePlanMarkdown :: PlanModeEnv -> Text -> IO (Either Text ())
 writePlanMarkdown env content = do
     path <- planFilePath env
     createDirectoryIfMissing True (takeDirectory path)
-    result <- tryAny (retryOnFileBusy (Text.writeFile (toFilePath path) content))
+    result <- tryAny (retryOnFileBusy (Text.writeFile (decodeUtfPath path) content))
     pure $ case result of
         Left err -> Left ("failed to write plan file: " <> Text.pack (show err))
         Right () -> Right ()
@@ -316,3 +316,6 @@ parseOptions raw =
         [ Text.strip part
         | part <- Text.split (\c -> c == '\n' || c == ',') raw
         ]
+
+decodeUtfPath :: OsPath -> FilePath
+decodeUtfPath = either impureThrow id . decodeUtf

--- a/packages/agent-core/src/Agent/Tools/Types.hs
+++ b/packages/agent-core/src/Agent/Tools/Types.hs
@@ -17,7 +17,7 @@ module Agent.Tools.Types
     ) where
 
 import Agent.Cancel (CancelFlag, newCancelFlag)
-import Agent.OsPath (OsPath)
+import System.OsPath (OsPath)
 import Agent.ToolDSL (PropertySchema)
 import Agent.ToolDispatch
     ( ToolCall(..)

--- a/packages/agent-core/test/Agent/OsPathSpec.hs
+++ b/packages/agent-core/test/Agent/OsPathSpec.hs
@@ -4,8 +4,7 @@ module Agent.OsPathSpec (spec) where
 
 import Agent.OsPath (fromText, toText)
 import qualified Data.Text as Text
-import qualified System.OsString as OsString
-import System.OsPath (decodeUtf)
+import System.OsPath (decodeUtf, pack, unsafeFromChar)
 import Test.Hspec
 
 spec :: Spec
@@ -18,6 +17,6 @@ spec = describe "Agent.OsPath" do
 
 #ifndef mingw32_HOST_OS
     it "uses an escaped representation only for human-readable output" do
-        let path = OsString.singleton (OsString.unsafeFromChar '\xff')
+        let path = pack [unsafeFromChar '\xff']
         toText path `shouldBe` Text.pack (show path)
 #endif

--- a/packages/agent-core/test/Agent/OsPathSpec.hs
+++ b/packages/agent-core/test/Agent/OsPathSpec.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE CPP #-}
+
+module Agent.OsPathSpec (spec) where
+
+import Agent.OsPath (fromText, toText)
+import qualified Data.Text as Text
+import qualified System.OsString as OsString
+import System.OsPath (decodeUtf)
+import Test.Hspec
+
+spec :: Spec
+spec = describe "Agent.OsPath" do
+    it "converts Text to and from a UTF path" do
+        let text = "/tmp/日本語"
+            path = fromText text
+        decodeUtf path `shouldReturn` Text.unpack text
+        toText path `shouldBe` text
+
+#ifndef mingw32_HOST_OS
+    it "uses an escaped representation only for human-readable output" do
+        let path = OsString.singleton (OsString.unsafeFromChar '\xff')
+        toText path `shouldBe` Text.pack (show path)
+#endif

--- a/packages/agent-core/test/Agent/ProjectInstructionsSpec.hs
+++ b/packages/agent-core/test/Agent/ProjectInstructionsSpec.hs
@@ -1,7 +1,7 @@
 module Agent.ProjectInstructionsSpec (spec) where
 
 import Agent.ProjectInstructions
-import Agent.OsPath (fromFilePath)
+import System.OsPath (unsafeEncodeUtf)
 import Agent.Provider (Provider(..))
 import Control.Concurrent (forkIO, threadDelay)
 import Control.Exception.Safe (bracket)
@@ -15,6 +15,8 @@ import System.FilePath ((</>))
 import System.IO (IOMode(AppendMode), hClose, openFile)
 import System.Posix.Temp (mkdtemp)
 import Test.Hspec
+
+fromFilePath = unsafeEncodeUtf
 
 spec :: Spec
 spec = describe "Agent.ProjectInstructions" do

--- a/packages/agent-core/test/Agent/SkillsSpec.hs
+++ b/packages/agent-core/test/Agent/SkillsSpec.hs
@@ -1,6 +1,6 @@
 module Agent.SkillsSpec (spec) where
 
-import Agent.OsPath (fromFilePath)
+import System.OsPath (unsafeEncodeUtf)
 import Agent.Skills
 import Control.Exception.Safe (bracket)
 import qualified Data.Text as Text
@@ -13,6 +13,8 @@ import System.Directory
 import System.FilePath ((</>))
 import System.Posix.Temp (mkdtemp)
 import Test.Hspec
+
+fromFilePath = unsafeEncodeUtf
 
 spec :: Spec
 spec = describe "Agent.Skills" do

--- a/packages/agent-core/test/Agent/SubagentsSpec.hs
+++ b/packages/agent-core/test/Agent/SubagentsSpec.hs
@@ -3,7 +3,7 @@ module Agent.SubagentsSpec (spec) where
 import Agent.Cancel (isCancelled, waitCancel)
 import Agent.InterAgentMessage
 import Agent.Loop (LoopError(..), LoopResult(..), emptyTokenUsage)
-import Agent.OsPath (fromFilePath)
+import System.OsPath (unsafeEncodeUtf)
 import Agent.Subagents
 import Agent.Subagents.TaskPath
     ( TaskPath
@@ -72,6 +72,8 @@ runNestedRouting registry parentRelease childRelease childSpawned noticeSeen env
 blockingRunner started cleanedUp _ _ _ _ =
     (atomically (putTMVar started ()) >> atomically retry)
         `finally` atomically (putTMVar cleanedUp ())
+
+fromFilePath = unsafeEncodeUtf
 
 spec :: Spec
 spec = describe "Agent.Subagents" do

--- a/packages/agent-core/test/Agent/ToolDSLSpec.hs
+++ b/packages/agent-core/test/Agent/ToolDSLSpec.hs
@@ -1,6 +1,6 @@
 module Agent.ToolDSLSpec (spec) where
 
-import Agent.OsPath (fromFilePath)
+import System.OsPath (unsafeEncodeUtf)
 import Agent.ToolDSL
 import Agent.Tools.Grok.Prompt
 import qualified Data.Aeson as Aeson
@@ -10,6 +10,8 @@ import Data.Time.Calendar (fromGregorian)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Test.Hspec
+
+fromFilePath = unsafeEncodeUtf
 
 spec :: Spec
 spec = do

--- a/packages/agent-core/test/Agent/Tools/CodexSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/CodexSpec.hs
@@ -1,7 +1,7 @@
 module Agent.Tools.CodexSpec (spec) where
 
 import Agent.Loop (LoopError(..), defaultLoopDispatch)
-import Agent.OsPath (fromFilePath, toFilePath)
+import System.OsPath (decodeUtf, unsafeEncodeUtf)
 import Agent.Subagents (closeSubagentRegistry, defaultSubagentConfig, newSubagentRegistry)
 import Agent.Subagents.TaskPath (taskPathRoot)
 import Agent.Tools.MultiAgents (MultiAgentContext(..))
@@ -35,6 +35,9 @@ import System.Directory
 import System.FilePath (takeFileName, (</>))
 import System.Posix.Temp (mkdtemp)
 import Test.Hspec
+
+fromFilePath = unsafeEncodeUtf
+toFilePath path = either (error . show) id (decodeUtf path)
 
 spec :: Spec
 spec = describe "Agent.Tools.Codex" do

--- a/packages/agent-core/test/Agent/Tools/GhciSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/GhciSpec.hs
@@ -2,7 +2,7 @@ module Agent.Tools.GhciSpec (spec) where
 
 import Agent.Cancel (requestCancel, resetCancel)
 import Agent.Loop (defaultLoopDispatch)
-import Agent.OsPath (fromFilePath, toFilePath)
+import System.OsPath (decodeUtf, unsafeEncodeUtf)
 import Agent.Provider (Provider(..))
 import Agent.ToolDispatch (ToolCallResult(..), dispatchToolCall, functionToolCall)
 import Agent.Tools (CodingTools(..), appToolHandlers, codingToolsFor, defaultToolEnv)
@@ -36,6 +36,9 @@ import System.Posix.Temp (mkdtemp)
 import System.Posix.Types (ProcessID)
 import System.Timeout (timeout)
 import Test.Hspec
+
+fromFilePath = unsafeEncodeUtf
+toFilePath path = either (error . show) id (decodeUtf path)
 
 spec :: Spec
 spec = describe "Agent.Tools.Ghci" do

--- a/packages/agent-core/test/Agent/Tools/Grok/TaskSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/Grok/TaskSpec.hs
@@ -2,7 +2,7 @@ module Agent.Tools.Grok.TaskSpec (spec) where
 
 import Agent.Loop (LoopError(..), LoopResult(..), defaultLoopDispatch, emptyTokenUsage)
 import Agent.InterAgentMessage (interAgentMessagePayload)
-import Agent.OsPath (OsPath, fromFilePath)
+import System.OsPath (OsPath, unsafeEncodeUtf)
 import Agent.Subagents
 import Agent.ToolDispatch
     ( ToolCallResult(..)
@@ -24,6 +24,8 @@ import qualified Data.Map.Strict as Map
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Test.Hspec
+
+fromFilePath = unsafeEncodeUtf
 
 spec :: Spec
 spec = describe "Agent.Tools.Grok.Task" do

--- a/packages/agent-core/test/Agent/Tools/GrokSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/GrokSpec.hs
@@ -1,7 +1,7 @@
 module Agent.Tools.GrokSpec (spec) where
 
 import Agent.Loop (LoopError(..), defaultLoopDispatch)
-import Agent.OsPath (fromFilePath, toFilePath)
+import System.OsPath (decodeUtf, unsafeEncodeUtf)
 import Agent.Provider (Provider(..))
 import Agent.Subagents (SubagentId, closeSubagentRegistry, defaultSubagentConfig, newSubagentRegistry)
 import Agent.ToolDispatch (ToolCallResult(..), dispatchToolCall, functionToolCall)
@@ -36,6 +36,9 @@ import System.FilePath (takeDirectory, takeFileName, (</>))
 import System.Posix.Temp (mkdtemp)
 import System.Directory (removeDirectoryRecursive)
 import Test.Hspec
+
+fromFilePath = unsafeEncodeUtf
+toFilePath path = either (error . show) id (decodeUtf path)
 
 spec :: Spec
 spec = describe "Agent.Tools.Grok" do

--- a/packages/agent-core/test/Agent/Tools/IOSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/IOSpec.hs
@@ -6,7 +6,7 @@ import Agent.FileRetry
     , retryOnFileBusy
     , writeLazyFileAtomically
     )
-import Agent.OsPath (fromFilePath)
+import System.OsPath (unsafeEncodeUtf)
 import Agent.Tools.IO
     ( CommandResult(..)
     , RunningCommand(..)
@@ -42,6 +42,8 @@ import System.IO (IOMode(..), hClose, openFile)
 import System.IO.Error (alreadyInUseErrorType, mkIOError)
 import System.Posix.Temp (mkdtemp)
 import Test.Hspec
+
+fromFilePath = unsafeEncodeUtf
 
 spec :: Spec
 spec = describe "Agent.Tools.IO" do

--- a/packages/agent-core/test/Agent/Tools/MultiAgentsSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/MultiAgentsSpec.hs
@@ -7,7 +7,7 @@ import Agent.Loop
     , defaultLoopDispatch
     , emptyTokenUsage
     )
-import Agent.OsPath (fromFilePath)
+import System.OsPath (unsafeEncodeUtf)
 import Agent.Subagents
 import Agent.Subagents.TaskPath (joinTaskPath, taskPathRoot)
 import Agent.ToolDispatch
@@ -27,6 +27,8 @@ import Control.Monad (unless)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Test.Hspec
+
+fromFilePath = unsafeEncodeUtf
 
 spec :: Spec
 spec = describe "Agent.Tools.MultiAgents" do

--- a/packages/agent-core/test/Agent/Tools/PlanModeSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/PlanModeSpec.hs
@@ -1,6 +1,7 @@
 module Agent.Tools.PlanModeSpec (spec) where
 
-import Agent.OsPath (fromFilePath, toText)
+import Agent.OsPath (toText)
+import System.OsPath (unsafeEncodeUtf)
 import Agent.Tools.PlanMode
 import Agent.Tools.Types
     ( AppTool(..)
@@ -12,6 +13,8 @@ import System.Directory (getTemporaryDirectory, removeDirectoryRecursive)
 import System.FilePath ((</>))
 import System.Posix.Temp (mkdtemp)
 import Control.Exception.Safe (bracket)
+
+fromFilePath = unsafeEncodeUtf
 
 spec :: Spec
 spec = describe "Agent.Tools.PlanMode" do

--- a/packages/agent-core/test/Spec.hs
+++ b/packages/agent-core/test/Spec.hs
@@ -4,6 +4,7 @@ import qualified Agent.CancelSpec as CancelSpec
 import qualified Agent.ErrorSpec as ErrorSpec
 import qualified Agent.JsonTextSpec as JsonTextSpec
 import qualified Agent.LoopSpec as LoopSpec
+import qualified Agent.OsPathSpec as OsPathSpec
 import qualified Agent.ProjectInstructionsSpec as ProjectInstructionsSpec
 import qualified Agent.ResourceScopeSpec as ResourceScopeSpec
 import qualified Agent.SkillsSpec as SkillsSpec
@@ -29,6 +30,7 @@ main = hspec do
     ErrorSpec.spec
     JsonTextSpec.spec
     LoopSpec.spec
+    OsPathSpec.spec
     ProjectInstructionsSpec.spec
     ResourceScopeSpec.spec
     SkillsSpec.spec

--- a/packages/agent-openai/app/Login.hs
+++ b/packages/agent-openai/app/Login.hs
@@ -1,13 +1,13 @@
 module Main where
 
 import qualified Agent.OpenAI.Login as Login
-import Agent.OsPath (fromFilePath, toFilePath)
+import Control.Exception.Safe (impureThrow)
 import qualified Data.Text as Text
 import qualified Data.Text.IO as TextIO
 import System.Directory.OsPath (getHomeDirectory)
 import System.Environment (getArgs, lookupEnv)
 import System.Exit (die)
-import System.OsPath ((</>))
+import System.OsPath (OsPath, decodeUtf, unsafeEncodeUtf, (</>))
 
 main :: IO ()
 main = do
@@ -19,8 +19,8 @@ main = do
     let loginOptions = Login.defaultLoginOptions oauthClientId
     output <- case args of
         [] -> pure
-            (home </> fromFilePath ".codex" </> fromFilePath "auth.json")
-        ["--output", path] -> pure (fromFilePath path)
+            (home </> unsafeEncodeUtf ".codex" </> unsafeEncodeUtf "auth.json")
+        ["--output", path] -> pure (unsafeEncodeUtf path)
         _ -> die "usage: agent-openai-login [--output PATH]"
     requested <- Login.requestDeviceCode loginOptions
     deviceCode <- either (die . show) pure requested
@@ -32,4 +32,7 @@ main = do
     completed <- Login.completeDeviceCodeLogin loginOptions deviceCode
     auth <- either (die . show) pure completed
     Login.writeAuthFile output auth
-    putStrLn ("Login successful. Credentials written to " <> toFilePath output)
+    putStrLn ("Login successful. Credentials written to " <> decodeUtfPath output)
+
+decodeUtfPath :: OsPath -> FilePath
+decodeUtfPath = either impureThrow id . decodeUtf

--- a/packages/agent-openai/app/Login.hs
+++ b/packages/agent-openai/app/Login.hs
@@ -1,13 +1,12 @@
 module Main where
 
 import qualified Agent.OpenAI.Login as Login
-import Control.Exception.Safe (impureThrow)
 import qualified Data.Text as Text
 import qualified Data.Text.IO as TextIO
 import System.Directory.OsPath (getHomeDirectory)
 import System.Environment (getArgs, lookupEnv)
 import System.Exit (die)
-import System.OsPath (OsPath, decodeUtf, unsafeEncodeUtf, (</>))
+import System.OsPath (decodeFS, unsafeEncodeUtf, (</>))
 
 main :: IO ()
 main = do
@@ -32,7 +31,5 @@ main = do
     completed <- Login.completeDeviceCodeLogin loginOptions deviceCode
     auth <- either (die . show) pure completed
     Login.writeAuthFile output auth
-    putStrLn ("Login successful. Credentials written to " <> decodeUtfPath output)
-
-decodeUtfPath :: OsPath -> FilePath
-decodeUtfPath = either impureThrow id . decodeUtf
+    outputPath <- decodeFS output
+    putStrLn ("Login successful. Credentials written to " <> outputPath)

--- a/packages/agent-openai/src/Agent/OpenAI/Login.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Login.hs
@@ -12,7 +12,7 @@ module Agent.OpenAI.Login
 import Agent.FileRetry (writeLazyFileAtomically)
 import Agent.Http.Url (trimTrailingSlash)
 import Agent.OpenAI.Auth (deriveAccountId)
-import Agent.OsPath (OsPath)
+import System.OsPath (OsPath)
 import Control.Concurrent (threadDelay)
 import Control.Exception.Safe (tryAny)
 import Control.Monad (unless)

--- a/packages/agent-openai/test/Agent/OpenAI/LoginSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/LoginSpec.hs
@@ -1,13 +1,15 @@
 module Agent.OpenAI.LoginSpec (spec) where
 
 import Agent.OpenAI.Login (writeAuthFile)
-import Agent.OsPath (fromFilePath)
+import System.OsPath (unsafeEncodeUtf)
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy as LBS
 import System.FilePath ((</>))
 import System.IO.Temp (withSystemTempDirectory)
 import System.Posix.Files (fileMode, getFileStatus)
 import Test.Hspec
+
+fromFilePath = unsafeEncodeUtf
 
 spec :: Spec
 spec = describe "Agent.OpenAI.Login" do


### PR DESCRIPTION
## Summary

- narrow `Agent.OsPath` to the genuine `Text` adapters (`fromText` and `toText`)
- import `OsPath` and UTF conversion functions directly from `System.OsPath` at call sites
- remove the shared `fromFilePath` / `toFilePath` compatibility API and its unsafe `show` fallback for filesystem paths
- add coverage for UTF text conversion and diagnostic rendering of undecodable paths

## Testing

- agent-core test suite in GHCi: 231 examples, 0 failures
- agent-cli test suite in GHCi: 433 examples, 0 failures
- agent-openai test suite typechecks in GHCi
- `git diff --check`