### PR TITLE
refactor: simplify UTF-8 instruction truncation

### DIFF
--- a/packages/agent-core/src/Agent/ProjectInstructions.hs
+++ b/packages/agent-core/src/Agent/ProjectInstructions.hs
@@ -27,6 +27,7 @@ import Data.Maybe (mapMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
+import qualified Data.Text.Encoding.Error as TextEncodingError
 import qualified Data.Text.IO as Text
 import System.Directory.OsPath (doesFileExist, doesPathExist)
 import System.OsPath (takeDirectory, (</>))
@@ -149,24 +150,14 @@ applyByteBudget maxBytes loaded =
         | remaining <= 0 = []
         | otherwise =
             let content = file.instructionContent
-                size = BS.length (TextEncoding.encodeUtf8 content)
+                encoded = TextEncoding.encodeUtf8 content
+                size = BS.length encoded
             in if size <= remaining
                 then file : go (remaining - size) rest
-                else [file { instructionContent = takeUtf8Bytes remaining content }]
-
-takeUtf8Bytes :: Int -> Text -> Text
-takeUtf8Bytes budget = Text.pack . go budget . Text.unpack
-  where
-    go _ [] = []
-    go remaining (char : rest)
-        | width > remaining = []
-        | otherwise = char : go (remaining - width) rest
-      where
-        width
-            | char <= '\x7f' = 1
-            | char <= '\x7ff' = 2
-            | char <= '\xffff' = 3
-            | otherwise = 4
+                else
+                    let truncated = TextEncoding.decodeUtf8With TextEncodingError.ignore
+                            (BS.take remaining encoded)
+                    in [file { instructionContent = truncated }]
 
 formatAgentsMdForProvider :: Provider -> OsPath -> LoadedAgentsMd -> Maybe Text
 formatAgentsMdForProvider provider cwd loaded = case provider of

--- a/packages/agent-core/test/Agent/ProjectInstructionsSpec.hs
+++ b/packages/agent-core/test/Agent/ProjectInstructionsSpec.hs
@@ -77,9 +77,17 @@ spec = describe "Agent.ProjectInstructions" do
             withTempDir \dir -> do
                 createDirectoryIfMissing True (dir </> ".git")
                 writeFile (dir </> "AGENTS.md") "ééa"
+                let options = defaultDiscoverOptions { discoverMaxBytes = 3 }
+                loaded <- discoverProjectInstructions options (fromFilePath dir)
+                map (.instructionContent) loaded.loadedProject `shouldBe` ["é"]
+
+        it "drops an incomplete trailing UTF-8 code point" do
+            withTempDir \dir -> do
+                createDirectoryIfMissing True (dir </> ".git")
+                writeFile (dir </> "AGENTS.md") "a😀b"
                 let options = defaultDiscoverOptions { discoverMaxBytes = 4 }
                 loaded <- discoverProjectInstructions options (fromFilePath dir)
-                map (.instructionContent) loaded.loadedProject `shouldBe` ["éé"]
+                map (.instructionContent) loaded.loadedProject `shouldBe` ["a"]
 
         it "disables discovery when max bytes is zero" do
             withTempDir \dir -> do


### PR DESCRIPTION
## Summary

- retain the UTF-8 byte budget for project instructions
- replace the hand-written code-point width traversal with the standard `text` UTF-8 codec
- encode instruction content once, truncate the bytes, and drop only an incomplete trailing code point
- add regression coverage for byte budgets that split multibyte characters

## Testing

- `nix develop -c cabal repl agent-core:test:agent-core-test`
- `:main --match Agent.ProjectInstructions` — 15 examples, 0 failures
