### PR TITLE
fix(cli): resize fullscreen TUI with terminal

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -168,13 +168,39 @@
                     fi
                     cabal="${haskellPackages.cabal-install}/bin/cabal"
                     expect_bin="${pkgs.expect}/bin/expect"
+                    stty_bin="${pkgs.coreutils}/bin/stty"
                     export AGENT_REPL_SCRIPT="$script"
                     export AGENT_REPL_CABAL="$cabal"
+                    export AGENT_REPL_STTY="$stty_bin"
                     exec "$expect_bin" -c '
                       set timeout -1
                       set cabal $env(AGENT_REPL_CABAL)
                       set script $env(AGENT_REPL_SCRIPT)
+                      set external_stty $env(AGENT_REPL_STTY)
                       spawn -noecho $cabal repl lib:agent-cli --repl-options=-ghci-script=$script
+                      # Expect gives Cabal/GHCi its own PTY. Keep that PTY in
+                      # sync so Vty receives resize events with current bounds.
+                      proc sync_spawn_size {} {
+                        global external_stty spawn_out
+                        if {![info exists spawn_out(slave,name)]} {
+                          return
+                        }
+                        if {[catch {
+                          exec $external_stty --file=/dev/tty size
+                        } size]} {
+                          return
+                        }
+                        if {[scan $size "%d %d" rows columns] != 2
+                            || $rows <= 0
+                            || $columns <= 0} {
+                          return
+                        }
+                        catch {
+                          exec $external_stty --file=$spawn_out(slave,name) rows $rows columns $columns
+                        }
+                      }
+                      trap sync_spawn_size SIGWINCH
+                      sync_spawn_size
                       expect {
                         -re {Ok, [0-9]+ modules? loaded\.} {}
                         eof {

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -2498,6 +2498,7 @@ handleEvent event = case event of
     VtyEvent V.EvResize{} -> do
         clearAgentHover
         invalidateCache
+        queueConversationReflow
     VtyEvent vtyEvent -> do
         clearAgentHover
         state <- get
@@ -2593,8 +2594,6 @@ handleNormalKey event
         handleComposerKey event
     | otherwise = do
         case event of
-            V.EvResize _ _ ->
-                queueConversationReflow
             V.EvMouseDown _ _ V.BScrollUp _ ->
                 scrollConversationBy (-mouseScrollLines)
             V.EvMouseDown _ _ V.BScrollDown _ ->

--- a/packages/agent-cli/test/Agent/CLI/TUIScrollSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIScrollSpec.hs
@@ -26,6 +26,21 @@ spec = describe "fullscreen conversation scrolling" do
         grown.anchorViewportTop `shouldBe` 40
         grown.anchorPhase `shouldBe` ConversationFillingPage
 
+    it "recomputes the reserve when the terminal height changes" do
+        let initial = startConversationAnchor (BlockId 7) "question" 40
+            (pinned, _) =
+                reflowConversationAnchor True 40 20 45 initial
+            (taller, tallerAction) =
+                reflowConversationAnchor True 40 30 45 pinned
+            (shorter, shorterAction) =
+                reflowConversationAnchor True 40 10 45 taller
+        taller.anchorReserveRows `shouldBe` 25
+        taller.anchorViewportTop `shouldBe` 40
+        tallerAction `shouldBe` ScrollConversationToEnd
+        shorter.anchorReserveRows `shouldBe` 5
+        shorter.anchorViewportTop `shouldBe` 40
+        shorterAction `shouldBe` ScrollConversationToEnd
+
     it "switches permanently to tail following after the page overflows" do
         let initial = startConversationAnchor (BlockId 7) "question" 40
             (pinned, _) =


### PR DESCRIPTION
## Summary
- propagate terminal resize dimensions through the repl launcher nested Expect PTY
- invalidate width-dependent caches and reflow anchored conversations on Vty resize events
- cover conversation reserve recomputation when viewport height changes

## Testing
- agent-cli test suite in Cabal REPL: 456 examples, 0 failures
- nix-instantiate --parse flake.nix
- git diff --check
- live tmux smoke with generated nix develop -c repl: resized 90x26 to 64x19, verified outer and child PTYs both became 64x19, and confirmed the header/composer remained visible
