### PR TITLE
Refine repository header

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -8,6 +8,7 @@ module Agent.CLI
     , devMain
     , devMainResume
     , formatReplStatusLine
+    , formatRepositoryPath
     , formatStartupTimings
     , formatTokenUsage
     , run
@@ -652,17 +653,31 @@ formatStartupDuration elapsed
     | otherwise =
         Text.pack (printf "%.2fs" (realToFrac elapsed :: Double))
 
-setStartupRepository :: Maybe FullscreenRuntime -> Text -> OsPath -> IO ()
-setStartupRepository fullscreen branch cwd =
+setStartupRepository
+    :: Maybe FullscreenRuntime
+    -> OsPath
+    -> Text
+    -> OsPath
+    -> IO ()
+setStartupRepository fullscreen home branch cwd =
     case fullscreen of
         Nothing -> pure ()
         Just runtime ->
             emitUiEvent runtime $
                 UiSetRepository
                     branch
-                    (toText (takeFileName (takeDirectory cwd))
-                        <> "/"
-                        <> toText (takeFileName cwd))
+                    (formatRepositoryPath home cwd)
+
+formatRepositoryPath :: OsPath -> OsPath -> Text
+formatRepositoryPath home cwd
+    | cwdText == homeText = "~"
+    | homePrefix `Text.isPrefixOf` cwdText =
+        "~/" <> Text.drop (Text.length homePrefix) cwdText
+    | otherwise = cwdText
+  where
+    homeText = Text.dropWhileEnd (== '/') (toText home)
+    homePrefix = homeText <> "/"
+    cwdText = toText cwd
 
 runAgent
     :: FullscreenInputBuffer
@@ -803,7 +818,7 @@ runAgentInitialized options transition home root resumed cwd startup = do
     projectRoot <- resolveProjectRoot cwd
     projectSettings <- loadProjectSettings projectRoot
     branch <- detectGitBranch cwd
-    setStartupRepository fullscreen branch cwd
+    setStartupRepository fullscreen home branch cwd
     markStartupStage startup "Loading credentials…"
     let transitionTarget = (.transitionTarget) <$> transition
         pendingTurn = transition >>= (.transitionPendingTurn)
@@ -3564,9 +3579,9 @@ detectGitBranch cwd = do
         Right (ExitSuccess, output, _) ->
             let branch = Text.strip (Text.pack output)
             in if Text.null branch
-                then toText (takeFileName cwd)
-                else branch
-        _ -> toText (takeFileName cwd)
+                then ""
+                else if branch == "HEAD" then "detached" else branch
+        _ -> ""
 
 -- | Apply compact turns as full transcript replacements when resuming.
 foldSessionItems :: [SessionTurn] -> [ResponseItem]

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -11,6 +11,7 @@ module Agent.CLI.TUI.App
     , newFullscreenRuntime
     , queuedFullscreenInputDisplays
     , readFullscreenLine
+    , repositoryHeaderText
     , requestFullscreenPermission
     , requestFullscreenChoice
     , requestFullscreenChoiceWithBody
@@ -1348,14 +1349,26 @@ drawHeader state =
     withAttr Theme.headerAttr $
         padLeftRight 2 $
             hBox
-                [ hLimitPercent 68 (txt left)
+                [ hLimitPercent 68 (drawRepositoryHeader state)
                 , vLimit 1 (fill ' ')
                 , drawHeaderRight state
                 ]
-  where
-    left =
-        (if Text.null state.uiBranch then "" else "git " <> state.uiBranch <> "  ")
-            <> state.uiCwd
+
+drawRepositoryHeader :: UiState -> Widget Name
+drawRepositoryHeader state
+    | Text.null state.uiBranch =
+        withAttr Theme.mutedAttr (txt state.uiCwd)
+    | otherwise =
+        hBox
+            [ txt "\xE0A0 "
+            , withAttr Theme.mutedAttr $
+                txt (repositoryHeaderText state.uiBranch state.uiCwd)
+            ]
+
+repositoryHeaderText :: Text -> Text -> Text
+repositoryHeaderText branch cwd =
+    Text.intercalate "  " $
+        filter (not . Text.null) [branch, cwd]
 
 drawHeaderRight :: UiState -> Widget Name
 drawHeaderRight state =

--- a/packages/agent-cli/test/Agent/CLI/ReplStatusSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ReplStatusSpec.hs
@@ -7,6 +7,7 @@ import Agent.CLI
     , cycleReplInteraction
     , devArgs
     , formatReplStatusLine
+    , formatRepositoryPath
     , formatStartupTimings
     , formatTokenUsage
     , withRestoredCurrentDirectory
@@ -129,6 +130,19 @@ spec = do
                 ]
                 `shouldBe`
                     "startup: first frame 42ms · Loading tools… 400ms · ready 1.25s"
+
+    describe "formatRepositoryPath" do
+        it "abbreviates paths below the home directory" do
+            formatRepositoryPath
+                (fromFilePath "/Users/marc")
+                (fromFilePath "/Users/marc/src/haskell-agent")
+                `shouldBe` "~/src/haskell-agent"
+
+        it "keeps paths outside the home directory absolute" do
+            formatRepositoryPath
+                (fromFilePath "/Users/marc")
+                (fromFilePath "/tmp/haskell-agent")
+                `shouldBe` "/tmp/haskell-agent"
 
     describe "cycleReplMode" do
         it "walks ask → plan → always-approve → ask" do

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -6,6 +6,7 @@ import Agent.CLI.TUI.App
     , agentPaneEntryLimit
     , agentPaneVisible
     , fullscreenVtyConfig
+    , repositoryHeaderText
     )
 import Agent.Subagents (SubagentId(..))
 import Data.Text (Text)
@@ -28,6 +29,18 @@ spec = do
                       , V.EvKey V.KEnter [V.MShift]
                       )
                     ]
+
+    describe "repositoryHeaderText" do
+        it "puts the git state before the full checkout path" do
+            repositoryHeaderText
+                "detached"
+                "~/digitallyinduced/haskell-agent"
+                `shouldBe`
+                    "detached  ~/digitallyinduced/haskell-agent"
+
+        it "still renders a path when git state is unavailable" do
+            repositoryHeaderText "" "~/scratch"
+                `shouldBe` "~/scratch"
 
     describe "Agents pane layout" do
         it "hides below the responsive breakpoint and without children" do


### PR DESCRIPTION
## Summary
- render repository state with a compact branch glyph and muted checkout details
- show home-relative checkout paths and label detached HEAD explicitly
- avoid showing misleading branch information outside git repositories

## Testing
- loaded the agent CLI library and test suite in GHCi
- ran focused `repositoryHeaderText` and `formatRepositoryPath` specs
- smoke-tested the fullscreen CLI in tmux