### PR TITLE
fix(cli): prevent scrollbar thumb trails

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -188,6 +188,7 @@ test-suite agent-cli-test
                     , aeson
                     , ansi-terminal
                     , base >= 4.17 && < 5
+                    , brick >= 2.9 && < 3
                     , bytestring
                     , colour
                     , containers

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -5,6 +5,7 @@ module Agent.CLI.TUI.App
     , agentEntryWindow
     , agentPaneEntryLimit
     , agentPaneVisible
+    , conversationScrollbarRenderer
     , emitUiEvent
     , hasQueuedFullscreenInput
     , newFullscreenInputBuffer
@@ -1079,9 +1080,27 @@ drawConversationPane state
                 , drawEmptyConversation (state.appUi.uiFrame `div` 2)
                 ]
     | otherwise =
-        withVScrollBars OnRight $
-            viewport ConversationViewport Vertical $
-                padLeftRight 2 (drawTranscript state)
+        withVScrollBarRenderer conversationScrollbarRenderer $
+            withVScrollBars OnRight $
+                viewport ConversationViewport Vertical $
+                    padLeftRight 2 (drawTranscript state)
+
+-- Brick's default scrollbar uses a full block for the thumb and a blank
+-- space for the trough. During rapid viewport reflow, some terminals can
+-- leave the old full-block cells behind because the replacement trough is
+-- visually identical to the surrounding background. A visible one-column
+-- trough makes every old thumb position get explicitly repainted.
+conversationScrollbarRenderer :: VScrollbarRenderer n
+conversationScrollbarRenderer =
+    VScrollbarRenderer
+        { renderVScrollbar =
+            withAttr Theme.mutedAttr (fill '┃')
+        , renderVScrollbarTrough =
+            withAttr Theme.borderAttr (fill '│')
+        , renderVScrollbarHandleBefore = emptyWidget
+        , renderVScrollbarHandleAfter = emptyWidget
+        , scrollbarWidthAllocation = 1
+        }
 
 agentPaneWidth :: Int
 agentPaneWidth = 42
@@ -2379,7 +2398,9 @@ handleEvent event = case event of
                 when
                     ((length state.appAgentEntries > 1)
                         /= (length entries > 1))
-                    invalidateCache
+                    do
+                        invalidateCache
+                        queueConversationReflow
     AppEvent (AppUi uiEvent) ->
         handleUiEvents (uiEvent :| [])
     AppEvent (AppUiBatch uiEvents) ->

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -5,7 +5,14 @@ import Agent.CLI.TUI.App
     ( agentEntryWindow
     , agentPaneEntryLimit
     , agentPaneVisible
+    , conversationScrollbarRenderer
     , fullscreenVtyConfig
+    )
+import Brick
+    ( VScrollbarRenderer(..)
+    , hLimit
+    , renderWidget
+    , vLimit
     )
 import Agent.Subagents (SubagentId(..))
 import Data.Text (Text)
@@ -67,6 +74,20 @@ spec = do
                     length shown + indicatorRows + 7
             entryLimit `shouldBe` 6
             renderedRows `shouldSatisfy` (<= availableHeight)
+
+    describe "conversation scrollbar" do
+        it "uses a visible trough that repaints old thumb cells" do
+            let renderCell widget =
+                    V.picImage $
+                        renderWidget Nothing
+                            [hLimit 1 (vLimit 1 widget)]
+                            (1, 1)
+            renderCell
+                (conversationScrollbarRenderer @()).renderVScrollbarTrough
+                `shouldBe` V.char V.defAttr '│'
+            renderCell
+                (conversationScrollbarRenderer @()).renderVScrollbar
+                `shouldBe` V.char V.defAttr '┃'
 
 rootEntry :: AgentEntry
 rootEntry = AgentEntry


### PR DESCRIPTION
## Summary

- replace Brick's blank scrollbar trough with a visible one-column track so old thumb cells are explicitly repainted
- queue conversation reflow when the Agents pane appears or disappears and changes the viewport width
- add a focused renderer regression test

## Root cause

Brick's default vertical scrollbar uses a full-block thumb and a blank-space trough. During rapid streaming and viewport reflow, some terminal/Vty paths could retain prior thumb cells instead of erasing them, leaving detached blocks at old thumb positions. A width change caused by the Agents pane could also move the scrollbar and leave a trail in the previous column.

## Verification

- targeted GHCi/Hspec run: 5 examples, 0 failures
- `git diff --check`
- live tmux smoke test with streaming shell output, Agents pane appearance, scrollback navigation, and repeated 82/90/120-column resizing
