### PR TITLE
feat(cli): enlarge pasted image previews

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -82,7 +82,7 @@ import Brick.Widgets.Border (borderWithLabel)
 import qualified Brick.Widgets.Border as Border
 import Brick.Widgets.Border.Style (unicodeRounded)
 import qualified Brick.Widgets.Border.Style as BorderStyle
-import Brick.Widgets.Center (center, centerLayer)
+import Brick.Widgets.Center (center, centerLayer, hCenter)
 import Control.Concurrent.Async (wait, waitCatch, withAsync)
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.STM
@@ -989,7 +989,10 @@ fullscreenApp = App
 drawApp :: AppState -> [Widget Name]
 drawApp state =
     let mainLayers = stickyPromptLayers state <> [drawMain state]
-        interactiveLayers = agentPopoverLayers state <> mainLayers
+        interactiveLayers =
+            agentPopoverLayers state
+                <> imagePreviewLayers state.appImagePreviews
+                <> mainLayers
         dimmedMainLayers = map (forceAttr Theme.dimAttr) mainLayers
     in
     case (state.appTextPrompt, state.appChoice, state.appUi.uiPermission) of
@@ -1008,7 +1011,6 @@ drawMain state =
             [ drawHeader state.appUi
             , drawWorkspace state
             , drawNotice state.appUi
-            , drawImagePreviews state.appImagePreviews
             , drawQueuedInputs state.appUi
             , drawSlashMenu state
             , drawFollowStatus state.appUi
@@ -1016,33 +1018,57 @@ drawMain state =
             , drawFooter state
             ]
 
-drawImagePreviews :: [TuiImagePreview] -> Widget Name
-drawImagePreviews previews =
+imagePreviewLayers :: [TuiImagePreview] -> [Widget Name]
+imagePreviewLayers previews =
     case takeLast 3 previews of
-        [] -> emptyWidget
-        shown ->
-            padLeftRight 2 $
-                padBottom (Pad 1) $
-                    hBox $
-                        intersperse (padLeft (Pad 2) emptyWidget)
-                            (map drawPreview shown)
+        [] -> []
+        shown -> [centerLayer (drawImagePreviews shown)]
   where
-    drawPreview preview =
-        vBox
-            [ renderTuiImagePreview preview
-            , withAttr Theme.mutedAttr $
-                txt $
-                    "🖼 "
-                        <> preview.previewMime
-                        <> " · "
-                        <> Text.pack (show preview.previewSourceWidth)
-                        <> "×"
-                        <> Text.pack (show preview.previewSourceHeight)
-                        <> " · "
-                        <> formatImageSize preview.previewBytes
-            ]
     takeLast count values =
         drop (max 0 (length values - count)) values
+
+drawImagePreviews :: [TuiImagePreview] -> Widget Name
+drawImagePreviews previews =
+    Widget Fixed Fixed do
+        context <- getContext
+        let maxWidth = viewportPreviewSize context.availWidth
+            maxHeight = viewportPreviewSize context.availHeight
+            gaps = max 0 (length previews - 1) * previewGap
+            previewWidth =
+                max 1 ((maxWidth - gaps) `div` max 1 (length previews))
+            previewHeight = max 1 (maxHeight - 1)
+            content =
+                hBox $
+                    intersperse
+                        (hLimit previewGap (fill ' '))
+                        (map (drawPreview previewWidth previewHeight) previews)
+        render $
+            hLimit maxWidth $
+                vLimit maxHeight content
+  where
+    previewGap = 2
+
+    drawPreview maxWidth maxHeight preview =
+        hLimit maxWidth $
+            vBox
+                [ hCenter $
+                    renderTuiImagePreview maxWidth maxHeight preview
+                , hCenter $
+                    withAttr Theme.mutedAttr $
+                        txt $
+                            "🖼 "
+                                <> preview.previewMime
+                                <> " · "
+                                <> Text.pack (show preview.previewSourceWidth)
+                                <> "×"
+                                <> Text.pack (show preview.previewSourceHeight)
+                                <> " · "
+                                <> formatImageSize preview.previewBytes
+                ]
+
+viewportPreviewSize :: Int -> Int
+viewportPreviewSize available =
+    max 1 (available * 3 `div` 5)
 
 drawWorkspace :: AppState -> Widget Name
 drawWorkspace state =

--- a/packages/agent-cli/src/Agent/CLI/TUI/ImagePreview.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/ImagePreview.hs
@@ -1,7 +1,8 @@
--- | Small true-colour thumbnails for the retained fullscreen interface.
+-- | True-colour image previews for the retained fullscreen interface.
 module Agent.CLI.TUI.ImagePreview
     ( TuiImagePreview(..)
     , prepareTuiImagePreview
+    , previewCellSize
     , renderTuiImagePreview
     ) where
 
@@ -13,6 +14,7 @@ import Codec.Picture
     , PixelRGBA8(..)
     , convertRGBA8
     , decodeImage
+    , generateImage
     , imageHeight
     , imageWidth
     , pixelAt
@@ -29,16 +31,33 @@ data PreviewCell = PreviewCell
     }
     deriving (Eq, Show)
 
--- | A bounded, terminal-cell representation. Keeping only sampled pixels
--- avoids retaining another full decoded copy of a large screenshot.
+-- | A bounded RGB sample. It is large enough to fill a typical terminal while
+-- avoiding retention of another full decoded copy of a large screenshot.
 data TuiImagePreview = TuiImagePreview
     { previewMime :: !Text
     , previewBytes :: !Int
     , previewSourceWidth :: !Int
     , previewSourceHeight :: !Int
-    , previewCells :: ![[PreviewCell]]
+    , previewSample :: !(Image PixelRGB8)
     }
-    deriving (Eq, Show)
+    deriving (Eq)
+
+instance Show TuiImagePreview where
+    show preview =
+        "TuiImagePreview { previewMime = "
+            <> show preview.previewMime
+            <> ", previewBytes = "
+            <> show preview.previewBytes
+            <> ", previewSourceWidth = "
+            <> show preview.previewSourceWidth
+            <> ", previewSourceHeight = "
+            <> show preview.previewSourceHeight
+            <> ", previewSampleSize = "
+            <> show
+                ( imageWidth preview.previewSample
+                , imageHeight preview.previewSample
+                )
+            <> " }"
 
 prepareTuiImagePreview :: ImageAttachment -> Either Text TuiImagePreview
 prepareTuiImagePreview ImageAttachment{imageMime, imageBytes} = do
@@ -53,17 +72,45 @@ prepareTuiImagePreview ImageAttachment{imageMime, imageBytes} = do
         , previewBytes = BS.length imageBytes
         , previewSourceWidth = sourceWidth
         , previewSourceHeight = sourceHeight
-        , previewCells =
-            sampleCells image targetWidth targetHeight
+        , previewSample =
+            generateImage
+                (\x y -> samplePixel image targetWidth targetHeight x y)
+                targetWidth
+                targetHeight
         }
 
-renderTuiImagePreview :: TuiImagePreview -> Widget n
-renderTuiImagePreview preview =
+-- | Size the preview to the supplied terminal-cell bounds while preserving its
+-- aspect ratio. One terminal row represents two sampled pixel rows.
+previewCellSize :: Int -> Int -> TuiImagePreview -> (Int, Int)
+previewCellSize maxColumns maxRows preview =
+    let (pixelWidth, pixelHeight) =
+            previewSizeWithin
+                maxColumns
+                (max 1 maxRows * 2)
+                preview.previewSourceWidth
+                preview.previewSourceHeight
+    in (pixelWidth, (pixelHeight + 1) `div` 2)
+
+renderTuiImagePreview :: Int -> Int -> TuiImagePreview -> Widget n
+renderTuiImagePreview maxColumns maxRows preview =
     raw $
         V.vertCat
-            [ V.horizCat (map renderCell row)
-            | row <- preview.previewCells
+            [ V.horizCat
+                [ renderCell PreviewCell
+                    { cellTop =
+                        samplePreviewPixel preview targetWidth targetHeight x topY
+                    , cellBottom =
+                        samplePreviewPixel preview targetWidth targetHeight x
+                            (min (targetHeight - 1) (topY + 1))
+                    }
+                | x <- [0 .. targetWidth - 1]
+                ]
+            | topY <- [0, 2 .. targetHeight - 1]
             ]
+  where
+    (targetWidth, targetRows) =
+        previewCellSize maxColumns maxRows preview
+    targetHeight = max 1 (targetRows * 2)
 
 renderCell :: PreviewCell -> V.Image
 renderCell PreviewCell{cellTop, cellBottom} =
@@ -81,32 +128,23 @@ pixelAttr
             (V.rgbColor bottomRed bottomGreen bottomBlue)
 
 previewSize :: Int -> Int -> (Int, Int)
-previewSize width height
+previewSize =
+    previewSizeWithin maxPreviewColumns maxPreviewPixelRows
+
+previewSizeWithin :: Int -> Int -> Int -> Int -> (Int, Int)
+previewSizeWithin maxWidth maxHeight width height
     | width <= 0 || height <= 0 = (1, 1)
     | otherwise =
         let scale :: Double
             scale =
                 minimum
                     [ 1
-                    , fromIntegral maxPreviewColumns / fromIntegral width
-                    , fromIntegral maxPreviewPixelRows / fromIntegral height
+                    , fromIntegral (max 1 maxWidth) / fromIntegral width
+                    , fromIntegral (max 1 maxHeight) / fromIntegral height
                     ]
         in ( max 1 (floor (fromIntegral width * scale))
            , max 1 (floor (fromIntegral height * scale))
            )
-
-sampleCells :: Image PixelRGBA8 -> Int -> Int -> [[PreviewCell]]
-sampleCells image targetWidth targetHeight =
-    [ [ PreviewCell
-            { cellTop = samplePixel image targetWidth targetHeight x topY
-            , cellBottom =
-                samplePixel image targetWidth targetHeight x
-                    (min (targetHeight - 1) (topY + 1))
-            }
-      | x <- [0 .. targetWidth - 1]
-      ]
-    | topY <- [0, 2 .. targetHeight - 1]
-    ]
 
 samplePixel
     :: Image PixelRGBA8
@@ -124,6 +162,24 @@ samplePixel image targetWidth targetHeight x y =
     sourceY =
         min (imageHeight image - 1)
             (y * imageHeight image `div` targetHeight)
+
+samplePreviewPixel
+    :: TuiImagePreview
+    -> Int
+    -> Int
+    -> Int
+    -> Int
+    -> PixelRGB8
+samplePreviewPixel preview targetWidth targetHeight x y =
+    pixelAt sample sourceX sourceY
+  where
+    sample = preview.previewSample
+    sourceX =
+        min (imageWidth sample - 1)
+            (x * imageWidth sample `div` targetWidth)
+    sourceY =
+        min (imageHeight sample - 1)
+            (y * imageHeight sample `div` targetHeight)
 
 -- Transparent PNG pixels can retain arbitrary RGB data. Dropping alpha with
 -- 'convertRGB8' exposes those hidden colours as bright smears, so composite
@@ -151,11 +207,11 @@ previewBackground :: PixelRGB8
 previewBackground = PixelRGB8 0 43 54
 
 maxPreviewColumns :: Int
-maxPreviewColumns = 24
+maxPreviewColumns = 240
 
 -- Two sampled pixel rows fit in one terminal row via the upper-half block.
 maxPreviewPixelRows :: Int
-maxPreviewPixelRows = 12
+maxPreviewPixelRows = 160
 
 firstText :: Either String a -> Either Text a
 firstText = either (Left . Text.pack) Right

--- a/packages/agent-cli/test/Agent/CLI/TUIImagePreviewSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIImagePreviewSpec.hs
@@ -3,6 +3,7 @@ module Agent.CLI.TUIImagePreviewSpec (spec) where
 import Agent.CLI.TUI.ImagePreview
     ( TuiImagePreview(..)
     , prepareTuiImagePreview
+    , previewCellSize
     )
 import Agent.Loop (ImageAttachment(..))
 import Codec.Picture
@@ -36,8 +37,23 @@ spec =
                 Right preview -> do
                     preview.previewSourceWidth `shouldBe` 4
                     preview.previewSourceHeight `shouldBe` 2
-                    length preview.previewCells `shouldBe` 1
-                    map length preview.previewCells `shouldBe` [4]
+                    previewCellSize 80 24 preview `shouldBe` (4, 1)
+
+        it "uses the available preview area while preserving aspect ratio" do
+            let source =
+                    generateImage
+                        (\_ _ -> PixelRGB8 10 20 30)
+                        1600
+                        900
+                attachment = ImageAttachment
+                    { imageMime = "image/png"
+                    , imageBytes = LBS.toStrict (encodePng source)
+                    }
+            case prepareTuiImagePreview attachment of
+                Left err -> expectationFailure (show err)
+                Right preview -> do
+                    previewCellSize 72 23 preview `shouldBe` (72, 20)
+                    previewCellSize 48 12 preview `shouldBe` (42, 12)
 
         it "composites alpha instead of exposing hidden transparent RGB" do
             let transparentSource =
@@ -64,8 +80,12 @@ spec =
                     prepareTuiImagePreview (attachment transparentSource)
                 compositedPreview =
                     prepareTuiImagePreview (attachment compositedSource)
-            (.previewCells) <$> transparentPreview
-                `shouldBe` (.previewCells) <$> compositedPreview
+            case (transparentPreview, compositedPreview) of
+                (Right transparent, Right composited) ->
+                    transparent.previewSample == composited.previewSample
+                        `shouldBe` True
+                (Left err, _) -> expectationFailure (show err)
+                (_, Left err) -> expectationFailure (show err)
 
         it "rejects invalid image bytes without crashing the TUI" do
             prepareTuiImagePreview


### PR DESCRIPTION
## Summary

- render queued pasted-image previews as centered fullscreen overlays
- size previews to at most 60% of the terminal viewport while preserving aspect ratio
- retain a larger bounded RGB sample so expanded previews remain detailed
- keep support for up to three queued image previews side by side

## Validation

- `env -u GHCRTS nix develop -c cabal test agent-cli-test` (461 examples, 0 failures)
- live tmux smoke test at 120×40 with an 800×450 pasted PNG; preview rendered centered at 72 columns and the composer remained usable
