### PR TITLE
feat: support Codex remote compaction v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ Without `-p` / `--prompt-file` the CLI starts a REPL. Credentials come from
 `CODEX_ACCESS_TOKEN` (OpenAI), or `OPENROUTER_API_KEY` (OpenRouter).
 `--provider` overrides auto-detection.
 
+OpenAI sessions compact automatically at the selected model's default context
+threshold. Pass `--compact-threshold N` to override it in estimated tokens, for
+example `--model gpt-5.6-luna --compact-threshold 120000`.
+
 Ghostty receives native progress, notifications, semantic turn boundaries,
 working-directory updates, inline images, synchronized picker redraws, and
 terminal clipboard support. See `docs/ghostty.md`; run `/terminal` inside the

--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -67,7 +67,7 @@ import Agent.CLI.Clipboard
 import Agent.CLI.Command
 import Agent.CLI.Compaction
     ( CompactOutcome(..)
-    , autoCompactOpenAiBackend
+    , autoCompactOpenAiBackendWithThreshold
     , runProviderCompact
     )
 import Agent.CLI.Connectivity (withConnectionRecovery)
@@ -1043,6 +1043,7 @@ runAgentInitialized options transition home root resumed cwd startup = do
                                     Nothing -> pure ()
                                 let lockedBackend =
                                         lockedOpenAiBackend
+                                            options.optCompactThreshold
                                             wsLock
                                             loaded.loadedTokenProvider
                                             wsHealthy
@@ -3538,7 +3539,8 @@ currentSessionId = \case
 -- | Serialize turns on the root OpenAI WebSocket connection because
 -- 'receiveWsResponse' is not multiplexed.
 lockedOpenAiBackend
-    :: MVar ()
+    :: Maybe Int
+    -> MVar ()
     -> TokenProvider
     -> IORef Bool
     -> CodexConn
@@ -3546,13 +3548,13 @@ lockedOpenAiBackend
     -> IORef [ResponseItem]
     -> IORef (Maybe (Int, Int))
     -> Backend
-lockedOpenAiBackend wsLock provider connectionHealthy conn getParams transcript
-        contextTokens =
+lockedOpenAiBackend compactThreshold wsLock provider connectionHealthy conn
+        getParams transcript contextTokens =
     let Backend submit =
             openAiBackendReconnecting provider connectionHealthy conn getParams transcript
         serialized = Backend \previous inputs onEvent ->
             withMVar wsLock \_ -> submit previous inputs onEvent
-    in autoCompactOpenAiBackend provider
+    in autoCompactOpenAiBackendWithThreshold compactThreshold provider
         getParams transcript contextTokens serialized
 
 -- | Drop live conversation state without touching persisted session files.

--- a/packages/agent-cli/src/Agent/CLI/Compaction.hs
+++ b/packages/agent-cli/src/Agent/CLI/Compaction.hs
@@ -3,7 +3,9 @@ module Agent.CLI.Compaction
     ( CompactOutcome(..)
     , codexAutoCompactTokenLimit
     , autoCompactOpenAiBackend
+    , autoCompactOpenAiBackendWithThreshold
     , autoCompactOpenAiBackendWith
+    , autoCompactOpenAiBackendWithApi
     , compactOpenAIWith
     , runProviderCompact
     ) where
@@ -19,13 +21,24 @@ import Agent.Loop
 import qualified Agent.OpenAI.Client as OpenAI
 import Agent.OpenAI.Compaction
     ( buildLocalCompactedHistory
-    , compactTranscriptAtLastCheckpoint
+    , buildRemoteCompactedHistory
+    , buildRemoteCompactionRequest
+    , extractRemoteCompactionItem
     , estimateItemsTokens
+    , remoteCompactionRetainedTokenBudget
     , summarizationPrompt
+    , trimRemoteCompactionHistoryToFit
     , userTextItem
+    )
+import Agent.OpenAI.ModelMetadata
+    ( codexAutoCompactTokenLimitFor
+    , codexEffectiveContextWindowFor
+    , defaultCodexAutoCompactTokenLimit
     )
 import Agent.Responses.LoopBackend
     ( assistantTextFromResponse
+    , toolResultToItem
+    , turnInputsToItems
     , withRequestInput
     )
 import Agent.Responses.Types
@@ -45,12 +58,14 @@ import Control.Monad.Trans.Except
     , throwE
     , withExceptT
     )
-import Data.IORef (IORef, newIORef, readIORef, writeIORef)
+import Control.Exception.Safe (onException)
+import Data.IORef (IORef, readIORef, writeIORef)
+import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
 
 codexAutoCompactTokenLimit :: Int
-codexAutoCompactTokenLimit = 244800
+codexAutoCompactTokenLimit = defaultCodexAutoCompactTokenLimit
 
 data CompactOutcome = CompactOutcome
     { compactBeforeTokens :: !Int
@@ -71,11 +86,9 @@ runProviderCompact provider tokenProvider paramsRef transcriptRef focus =
         params <- lift (readIORef paramsRef)
         history <- lift (readIORef transcriptRef)
         case provider of
-            OpenAIProvider -> do
-                let effectiveHistory =
-                        compactTranscriptAtLastCheckpoint history
-                compactOpenAI tokenProvider params effectiveHistory
-                    (estimateItemsTokens effectiveHistory) focus
+            OpenAIProvider ->
+                compactOpenAI tokenProvider params history
+                    (estimateItemsTokens history) focus
             XAIProvider ->
                 compactLocalXai tokenProvider params history
                     (estimateItemsTokens history) focus
@@ -91,7 +104,15 @@ compactOpenAI
     -> Maybe Text
     -> ExceptT Text IO CompactOutcome
 compactOpenAI =
-    compactOpenAIWith OpenAI.createCodexMessageWithProvider
+    compactOpenAIWith sendOpenAIRemoteCompaction
+
+sendOpenAIRemoteCompaction
+    :: TokenProvider
+    -> ResponseCreateParams
+    -> IO (Either ApiError Response)
+sendOpenAIRemoteCompaction =
+    OpenAI.createCodexMessageWithProviderWithOptions
+        OpenAI.remoteCompactionV2RequestOptions
 
 compactOpenAIWith
     :: (TokenProvider -> ResponseCreateParams -> IO (Either ApiError Response))
@@ -103,18 +124,70 @@ compactOpenAIWith
     -> ExceptT Text IO CompactOutcome
 compactOpenAIWith send tokenProvider params history before focus = do
     provider <- requireTokenProvider OpenAIProvider tokenProvider
-    -- The default OpenAI transport uses the ChatGPT Codex backend. Its normal
-    -- /responses endpoint is available, but /responses/compact returns 404.
-    -- Compact locally without first paying for a known-failing HTTP request.
-    -- Agent.OpenAI.CompactClient remains available to callers targeting an
-    -- API-compatible host that implements the remote compact endpoint.
-    summarizeLocal
-        send
-        provider
-        params
-        history
-        before
-        focus
+    if hasFocus focus
+        then summarizeLocal
+            send
+            provider
+            params
+            history
+            before
+            focus
+        else compactRemoteV2
+            send
+            provider
+            params
+            history
+            before
+
+compactRemoteV2
+    :: (TokenProvider -> ResponseCreateParams -> IO (Either ApiError Response))
+    -> TokenProvider
+    -> ResponseCreateParams
+    -> [ResponseItem]
+    -> Int
+    -> ExceptT Text IO CompactOutcome
+compactRemoteV2 send provider params history before =
+    do
+        requireHistory history
+        withExceptT formatApiError $
+            ExceptT (compactRemoteV2Api send provider params history before)
+
+compactRemoteV2Api
+    :: (TokenProvider -> ResponseCreateParams -> IO (Either ApiError Response))
+    -> TokenProvider
+    -> ResponseCreateParams
+    -> [ResponseItem]
+    -> Int
+    -> IO (Either ApiError CompactOutcome)
+compactRemoteV2Api send provider params history before =
+    runExceptT do
+        requireHistoryApi history
+        let requestHistory =
+                trimRemoteCompactionHistoryToFit
+                    (codexEffectiveContextWindowFor params.model)
+                    params.instructions
+                    history
+            request = buildRemoteCompactionRequest params requestHistory
+        response <- ExceptT (send provider request)
+        checkpoint <-
+            either
+                (throwE . protocolError)
+                pure
+                (extractRemoteCompactionItem response)
+        let items =
+                buildRemoteCompactedHistory
+                    remoteCompactionRetainedTokenBudget
+                    history
+                    checkpoint
+        pure CompactOutcome
+            { compactBeforeTokens = before
+            , compactAfterTokens = estimateItemsTokens items
+            , compactHistory = items
+            , compactSummary = "Context compacted remotely."
+            }
+  where
+    protocolError message =
+        ProviderError ApiErrorType message Nothing
 
 compactLocalXai
     :: Maybe TokenProvider
@@ -201,14 +274,42 @@ autoCompactOpenAiBackend
     -> IORef (Maybe (Int, Int))
     -> Backend
     -> Backend
-autoCompactOpenAiBackend tokenProvider getParams transcriptRef contextTokensRef
-        backend =
-    autoCompactOpenAiBackendWith compactAction transcriptRef contextTokensRef backend
+autoCompactOpenAiBackend =
+    autoCompactOpenAiBackendWithThreshold Nothing
+
+-- | Wrap an OpenAI backend with client-managed automatic compaction. A
+-- configured threshold overrides the current model's default.
+autoCompactOpenAiBackendWithThreshold
+    :: Maybe Int
+    -> TokenProvider
+    -> IO ResponseCreateParams
+    -> IORef [ResponseItem]
+    -> IORef (Maybe (Int, Int))
+    -> Backend
+    -> Backend
+autoCompactOpenAiBackendWithThreshold configuredThreshold tokenProvider
+        getParams transcriptRef contextTokensRef backend =
+    autoCompactOpenAiBackendWithLimit
+        getLimit
+        compactAction
+        transcriptRef
+        contextTokensRef
+        backend
   where
+    getLimit = do
+        params <- getParams
+        pure $ fromMaybe
+            (codexAutoCompactTokenLimitFor params.model)
+            configuredThreshold
     compactAction = do
-        paramsRef <- newIORef =<< getParams
-        runProviderCompact OpenAIProvider (Just tokenProvider)
-            paramsRef transcriptRef Nothing
+        params <- getParams
+        history <- readIORef transcriptRef
+        compactRemoteV2Api
+            sendOpenAIRemoteCompaction
+            tokenProvider
+            params
+            history
+            (estimateItemsTokens history)
 
 autoCompactOpenAiBackendWith
     :: IO (Either Text CompactOutcome)
@@ -216,35 +317,79 @@ autoCompactOpenAiBackendWith
     -> IORef (Maybe (Int, Int))
     -> Backend
     -> Backend
-autoCompactOpenAiBackendWith compactAction transcriptRef contextTokensRef
+autoCompactOpenAiBackendWith =
+    autoCompactOpenAiBackendWithApi
+        . fmap (either (Left . textCompactionError) Right)
+  where
+    textCompactionError message =
+        ProviderError ApiErrorType message Nothing
+
+autoCompactOpenAiBackendWithApi
+    :: IO (Either ApiError CompactOutcome)
+    -> IORef [ResponseItem]
+    -> IORef (Maybe (Int, Int))
+    -> Backend
+    -> Backend
+autoCompactOpenAiBackendWithApi =
+    autoCompactOpenAiBackendWithLimit
+        (pure codexAutoCompactTokenLimit)
+
+autoCompactOpenAiBackendWithLimit
+    :: IO Int
+    -> IO (Either ApiError CompactOutcome)
+    -> IORef [ResponseItem]
+    -> IORef (Maybe (Int, Int))
+    -> Backend
+    -> Backend
+autoCompactOpenAiBackendWithLimit getLimit compactAction transcriptRef contextTokensRef
         (Backend submit) =
     Backend \previous inputs onEvent -> do
         contextState <- readIORef contextTokensRef
-        historyLength <- length <$> readIORef transcriptRef
-        case contextState of
-            Just (tokens, observedLength)
-                | observedLength == historyLength
-                , tokens >= codexAutoCompactTokenLimit ->
-                    if any isCompletedTool inputs
-                        then submitAndTrack contextState previous inputs onEvent
-                        else compactThenSubmit contextState inputs onEvent
-            _ -> submitAndTrack contextState previous inputs onEvent
+        history <- readIORef transcriptRef
+        tokenLimit <- getLimit
+        let historyLength = length history
+            pendingItems = turnInputsToItems inputs
+            projectedTokens =
+                case contextState of
+                    Just (tokens, observedLength)
+                        | observedLength == historyLength ->
+                            tokens + estimateItemsTokens pendingItems
+                    _ ->
+                        estimateItemsTokens (history <> pendingItems)
+            shouldCompact =
+                not (null history)
+                    && projectedTokens >= tokenLimit
+        if shouldCompact
+            then if any isCompletedTool inputs
+                then compactToolContinuation contextState inputs onEvent
+                else compactThenSubmit contextState inputs onEvent
+            else submitAndTrack contextState previous inputs onEvent
   where
-    -- Tool results are appended by the wrapped backend as part of the next
-    -- request. Before that request, the transcript ends with the originating
-    -- calls and is therefore not valid input for a compaction request.
-    -- Defer compaction until the next non-tool continuation, by which point
-    -- the call/output pairs have been committed to the transcript.
     isCompletedTool = \case
         CompletedTool{} -> True
         _ -> False
+
+    -- Tool outputs must be part of the checkpoint, but the wrapped backend has
+    -- not committed them yet. Absorb them into history before compaction, then
+    -- resume from the new checkpoint without sending them a second time.
+    compactToolContinuation oldTokens inputs onEvent = do
+        oldHistory <- readIORef transcriptRef
+        let (toolItems, remainingInputs) = absorbCompletedTools inputs
+        writeIORef transcriptRef (oldHistory <> toolItems)
+        onEvent (ActivityUpdated "Compacting context…")
+        (compactAction `onException` writeIORef transcriptRef oldHistory) >>= \case
+            Left err -> do
+                writeIORef transcriptRef oldHistory
+                pure (Left (automaticCompactionError err))
+            Right outcome -> do
+                writeIORef transcriptRef outcome.compactHistory
+                submitAndTrack oldTokens Nothing remainingInputs onEvent
 
     compactThenSubmit oldTokens inputs onEvent = do
         onEvent (ActivityUpdated "Compacting context…")
         compactAction >>= \case
                 Left err ->
-                    pure $ Left $ ProviderError ApiErrorType
-                        ("automatic compaction failed: " <> err) Nothing
+                    pure (Left (automaticCompactionError err))
                 Right outcome -> do
                     writeIORef transcriptRef outcome.compactHistory
                     submitAndTrack oldTokens Nothing inputs onEvent
@@ -261,6 +406,25 @@ autoCompactOpenAiBackendWith compactAction transcriptRef contextTokensRef
                     )
         pure result
 
+    absorbCompletedTools =
+        foldr
+            (\input (toolItems, otherInputs) ->
+                case input of
+                    CompletedTool result ->
+                        (toolResultToItem result : toolItems, otherInputs)
+                    _ ->
+                        (toolItems, input : otherInputs))
+            ([], [])
+
+    automaticCompactionError = \case
+        ProviderError errorType message retryAfter ->
+            ProviderError errorType
+                ("automatic compaction failed: " <> message)
+                retryAfter
+        ConnectionError message ->
+            ConnectionError ("automatic compaction failed: " <> message)
+        err -> err
+
 requireTokenProvider
     :: Provider
     -> Maybe TokenProvider
@@ -273,11 +437,23 @@ requireHistory history
     | null history = throwE "nothing to compact"
     | otherwise = pure ()
 
+requireHistoryApi :: [ResponseItem] -> ExceptT ApiError IO ()
+requireHistoryApi history
+    | null history =
+        throwE $ ProviderError InvalidRequestError
+            "nothing to compact"
+            Nothing
+    | otherwise = pure ()
+
 providerLabel :: Provider -> Text
 providerLabel = \case
     OpenAIProvider -> "openai"
     XAIProvider -> "xai"
     OpenRouterProvider -> "openrouter"
+
+hasFocus :: Maybe Text -> Bool
+hasFocus =
+    maybe False (not . Text.null . Text.strip)
 
 formatApiError :: ApiError -> Text
 formatApiError err = Text.pack (show err)

--- a/packages/agent-cli/src/Agent/CLI/Options.hs
+++ b/packages/agent-cli/src/Agent/CLI/Options.hs
@@ -68,6 +68,8 @@ data CliOptions = CliOptions
     , optYolo :: !Bool
     , optNoYolo :: !Bool
     , optMaxTurns :: !Int
+    , optCompactThreshold :: !(Maybe Int)
+      -- ^ OpenAI automatic-compaction threshold in estimated context tokens.
     , optEffort :: !(Maybe Text)
       -- ^ 'Nothing' means use 'defaultEffortFor' once the provider is known.
     , optPrompt :: !(Maybe Text)
@@ -90,6 +92,7 @@ defaultCliOptions = CliOptions
     , optYolo = False
     , optNoYolo = False
     , optMaxTurns = 500
+    , optCompactThreshold = Nothing
     , optEffort = Nothing
     , optPrompt = Nothing
     , optPromptFile = Nothing
@@ -168,6 +171,9 @@ parseOptions options = \case
     "--max-turns" : value : rest -> do
         turns <- parseInt "--max-turns" value
         parseOptions options { optMaxTurns = turns } rest
+    "--compact-threshold" : value : rest -> do
+        threshold <- parseInt "--compact-threshold" value
+        parseOptions options { optCompactThreshold = Just threshold } rest
     "--effort" : value : rest -> do
         effort <- parseEffort (Text.pack value)
         parseOptions options { optEffort = Just effort } rest
@@ -254,6 +260,9 @@ usage = unlines
     , "      --yolo              Auto-approve every tool"
     , "      --no-yolo           Never auto-approve; deny mutating tools without a TTY"
     , "      --max-turns N       Stop after N model turns (default: 500)"
+    , "      --compact-threshold N"
+    , "                          OpenAI auto-compaction threshold in tokens"
+    , "                          (default: model-specific, currently 244800)"
     , "      --effort LEVEL      Reasoning effort: none, low, medium, high, xhigh, max"
     , "                          (default: high for xai/grok, medium otherwise)"
     , "      --version           Print the agent-cli version"

--- a/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
@@ -14,7 +14,7 @@ module Agent.CLI.Subagents.Runtime
 
 import Agent.CLI.Approval (childApprove)
 import Agent.CLI.Btw (trimDanglingToolSuffix)
-import Agent.CLI.Compaction (autoCompactOpenAiBackend)
+import Agent.CLI.Compaction (autoCompactOpenAiBackendWithThreshold)
 import Agent.CLI.Connectivity (withConnectionRecovery)
 import Agent.CLI.Options
     ( ApprovalPolicy
@@ -398,7 +398,9 @@ runCodexSubagent runtime tokenProvider sendToRoot =
                         httpBackend
                 backend =
                     withConnectionRecovery $
-                        autoCompactOpenAiBackend tokenProvider
+                        autoCompactOpenAiBackendWithThreshold
+                            runtime.subagentOptions.optCompactThreshold
+                            tokenProvider
                             (readIORef childParamsRef)
                             session.subSessionTranscript
                             session.subSessionContextTokens

--- a/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
@@ -3,13 +3,17 @@ module Agent.CLI.CompactionSpec (spec) where
 import Agent.CLI.Compaction
     ( CompactOutcome(..)
     , autoCompactOpenAiBackendWith
+    , autoCompactOpenAiBackendWithApi
+    , autoCompactOpenAiBackendWithThreshold
     , codexAutoCompactTokenLimit
     , compactOpenAIWith
     , runProviderCompact
     )
+import Agent.Error (ApiError(..), ErrorType(..))
 import Agent.Loop
 import Agent.OpenAI.Compaction
-    ( hasCompactionCheckpoint
+    ( compactionTriggerItem
+    , hasCompactionCheckpoint
     , userTextItem
     )
 import Agent.ToolDispatch
@@ -23,6 +27,7 @@ import Agent.Provider (Provider(..), TokenProvider(..))
 import Data.IORef
 import Control.Monad.Trans.Except (runExceptT)
 import Data.Text (Text)
+import qualified Data.Text as Text
 import Test.Hspec
 
 spec :: Spec
@@ -47,7 +52,47 @@ spec = do
                 `shouldReturn` Left "nothing to compact"
 
     describe "compactOpenAIWith" do
-        it "uses normal Responses summarization directly" do
+        it "uses remote compaction v2 on normal Responses" do
+            requests <- newIORef []
+            let provider = TokenProvider \_ ->
+                    error "remote compaction unexpectedly requested credentials"
+                send _ request = do
+                    modifyIORef' requests (<> [request])
+                    pure (Right remoteCompactionResponse)
+                history = [userTextItem "old context"]
+                params = defaultResponseCreateParams
+                    { instructions = Just "keep these instructions"
+                    , tools = Just []
+                    , stream = Just False
+                    }
+            result <- runExceptT $
+                compactOpenAIWith send
+                    (Just provider)
+                    params
+                    history
+                    100
+                    Nothing
+            case result of
+                Left err -> expectationFailure (show err)
+                Right outcome -> do
+                    outcome.compactSummary
+                        `shouldBe` "Context compacted remotely."
+                    outcome.compactHistory
+                        `shouldSatisfy` hasCompactionCheckpoint
+            seen <- readIORef requests
+            length seen `shouldBe` 1
+            map (.instructions) seen `shouldBe` [Just "keep these instructions"]
+            map (.tools) seen `shouldBe` [Just []]
+            map (.parallelToolCalls) seen `shouldBe` [Just True]
+            map (.previousResponseId) seen `shouldBe` [Nothing]
+            map (.store) seen `shouldBe` [Just False]
+            map (.stream) seen `shouldBe` [Just True]
+            map (.toolChoice) seen
+                `shouldBe` [Just (ToolChoiceMode ToolChoiceAuto)]
+            map requestItems seen
+                `shouldBe` [history <> [compactionTriggerItem]]
+
+        it "keeps focused manual compaction on local summarization" do
             requests <- newIORef []
             let provider = TokenProvider \_ ->
                     error "local summarization unexpectedly requested credentials"
@@ -58,10 +103,10 @@ spec = do
             result <- runExceptT $
                 compactOpenAIWith send
                     (Just provider)
-                    defaultResponseCreateParams { stream = Just False }
+                    defaultResponseCreateParams
                     history
                     100
-                    Nothing
+                    (Just "focus on auth")
             case result of
                 Left err -> expectationFailure (show err)
                 Right outcome -> do
@@ -69,12 +114,38 @@ spec = do
                     outcome.compactHistory
                         `shouldSatisfy` hasCompactionCheckpoint
             seen <- readIORef requests
-            length seen `shouldBe` 1
             map (.tools) seen `shouldBe` [Nothing]
             map (.parallelToolCalls) seen `shouldBe` [Just False]
             map (.stream) seen `shouldBe` [Just True]
 
     describe "autoCompactOpenAiBackendWith" do
+        it "compacts at a configured threshold below the model default" do
+            let history = [userTextItem "old"]
+                threshold = 20
+                tokenProvider = TokenProvider \_ ->
+                    pure (Left (ConnectionError "configured threshold fired"))
+                params =
+                    withModel
+                        (Just "gpt-5.6-luna")
+                        defaultResponseCreateParams
+                base = Backend \_ _ _ ->
+                    error "configured compaction threshold should run first"
+            transcript <- newIORef history
+            contextState <- newIORef
+                (Just (threshold, length history))
+            let backend =
+                    autoCompactOpenAiBackendWithThreshold
+                        (Just threshold)
+                        tokenProvider
+                        (pure params)
+                        transcript
+                        contextState
+                        base
+            backend.submitTurn Nothing [UserMessage "new"] (const (pure ()))
+                `shouldReturn`
+                    Left (ConnectionError
+                        "automatic compaction failed: configured threshold fired")
+
         it "compacts before the next request at the Codex token limit" do
             let oldHistory = [userTextItem "old"]
                 compactedHistory = [userTextItem "compacted"]
@@ -113,7 +184,7 @@ spec = do
             readIORef events `shouldReturn`
                 [ActivityUpdated "Compacting context…"]
 
-        it "defers compaction while completed tool outputs are still pending" do
+        it "compacts when a pending tool output crosses the limit" do
             let danglingCall = FunctionCallItem FunctionCall
                     { itemId = Nothing
                     , callId = "call-1"
@@ -123,19 +194,22 @@ spec = do
                     , extraFields = mempty
                     }
                 oldHistory = [userTextItem "run it", danglingCall]
+                toolOutputText = Text.replicate 400 "x"
                 toolResult = ToolCallResult
                     { callId = "call-1"
-                    , output = "done"
+                    , output = toolOutputText
                     , callKind = FunctionCallKind
                     }
             transcript <- newIORef oldHistory
             contextState <- newIORef
-                (Just (codexAutoCompactTokenLimit, length oldHistory))
+                (Just (codexAutoCompactTokenLimit - 10, length oldHistory))
             compactCalls <- newIORef (0 :: Int)
+            historyAtCompact <- newIORef []
             seenPrevious <- newIORef []
             seenInputs <- newIORef []
             let compactAction = do
                     modifyIORef' compactCalls (+ 1)
+                    readIORef transcript >>= writeIORef historyAtCompact
                     pure $ Right CompactOutcome
                         { compactBeforeTokens = codexAutoCompactTokenLimit
                         , compactAfterTokens = 10
@@ -157,12 +231,96 @@ spec = do
             result <- backend.submitTurn (Just "resp-tool") inputs
                 (const (pure ()))
             result `shouldSatisfy` either (const False) (const True)
-            readIORef compactCalls `shouldReturn` 0
-            readIORef seenPrevious `shouldReturn` [Just "resp-tool"]
-            readIORef seenInputs `shouldReturn` [inputs]
-            readIORef transcript `shouldReturn` oldHistory
+            readIORef compactCalls `shouldReturn` 1
+            compactInput <- readIORef historyAtCompact
+            compactInput `shouldSatisfy` \items ->
+                case reverse items of
+                    FunctionCallOutputItem output : _ ->
+                        output.callId == "call-1"
+                            && output.output == Aeson.String toolOutputText
+                    _ -> False
+            readIORef seenPrevious `shouldReturn` [Nothing]
+            readIORef seenInputs `shouldReturn` [[]]
+            readIORef transcript `shouldReturn` [userTextItem "compacted"]
             readIORef contextState `shouldReturn`
-                Just (25, length oldHistory)
+                Just (25, 1)
+
+        it "preserves typed provider failures from automatic compaction" do
+            let history = [userTextItem "old"]
+                compactError =
+                    ProviderError UsageLimitReached "quota exhausted" (Just 120)
+            transcript <- newIORef history
+            contextState <- newIORef
+                (Just (codexAutoCompactTokenLimit, length history))
+            let compactAction =
+                    pure (Left compactError)
+                base = Backend \_ _ _ ->
+                    error "failed compaction should not submit a model request"
+                backend = autoCompactOpenAiBackendWithApi compactAction
+                    transcript contextState base
+            backend.submitTurn Nothing [UserMessage "new"] (const (pure ()))
+                `shouldReturn`
+                    Left (ProviderError UsageLimitReached
+                        "automatic compaction failed: quota exhausted"
+                        (Just 120))
+
+        it "estimates resumed history when no provider token snapshot exists" do
+            let history =
+                    [ userTextItem
+                        (Text.replicate
+                            (codexAutoCompactTokenLimit * 4)
+                            "x")
+                    ]
+            transcript <- newIORef history
+            contextState <- newIORef Nothing
+            compactCalls <- newIORef (0 :: Int)
+            let compactAction = do
+                    modifyIORef' compactCalls (+ 1)
+                    pure $ Right CompactOutcome
+                        { compactBeforeTokens = codexAutoCompactTokenLimit
+                        , compactAfterTokens = 10
+                        , compactHistory = [userTextItem "compacted"]
+                        , compactSummary = "checkpoint"
+                        }
+                base = Backend \_ _ _ ->
+                    pure $ Right TurnOutput
+                        { responseId = "resp-new"
+                        , toolCalls = []
+                        , assistantText = Just "ok"
+                        , tokenUsage = TokenUsage 20 5 0
+                        }
+                backend = autoCompactOpenAiBackendWith compactAction
+                    transcript contextState base
+            result <- backend.submitTurn Nothing [UserMessage "new"]
+                (const (pure ()))
+            result `shouldSatisfy` either (const False) (const True)
+            readIORef compactCalls `shouldReturn` 1
+
+requestItems :: ResponseCreateParams -> [ResponseItem]
+requestItems request = case request.input of
+    Just (ResponseInputItems items) -> items
+    _ -> []
+
+remoteCompactionResponse :: Response
+remoteCompactionResponse =
+    case Aeson.fromJSON $ Aeson.object
+        [ "id" .= ("resp-compact" :: Text)
+        , "created_at" .= (0 :: Int)
+        , "status" .= ("completed" :: Text)
+        , "model" .= ("gpt-test" :: Text)
+        , "output" .=
+            [ Aeson.object
+                [ "type" .= ("compaction" :: Text)
+                , "encrypted_content" .= ("opaque" :: Text)
+                ]
+            ]
+        ] of
+        Aeson.Success response -> response
+        Aeson.Error err -> error err
+
+withModel :: Maybe Text -> ResponseCreateParams -> ResponseCreateParams
+withModel nextModel ResponseCreateParams { model = _, .. } =
+    ResponseCreateParams { model = nextModel, .. }
 
 summaryResponse :: Text -> Response
 summaryResponse summary =

--- a/packages/agent-cli/test/Agent/CLI/OptionsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/OptionsSpec.hs
@@ -23,6 +23,7 @@ spec = do
                 , "--cwd", "/tmp/work"
                 , "--yolo"
                 , "--max-turns", "3"
+                , "--compact-threshold", "1200"
                 , "--effort", "high"
                 , "-p", "hello"
                 ]
@@ -32,6 +33,7 @@ spec = do
                     , optCwd = Just (fromFilePath "/tmp/work")
                     , optYolo = True
                     , optMaxTurns = 3
+                    , optCompactThreshold = Just 1200
                     , optEffort = Just "high"
                     , optPrompt = Just "hello"
                     })
@@ -71,6 +73,11 @@ spec = do
 
         it "rejects using both -p and --prompt-file" do
             parseArgs ["-p", "a", "--prompt-file", "b"] `shouldSatisfy` isLeft
+
+        it "requires a positive compaction threshold" do
+            parseArgs ["--compact-threshold", "0"] `shouldSatisfy` isLeft
+            parseArgs ["--compact-threshold", "-1"] `shouldSatisfy` isLeft
+            parseArgs ["--compact-threshold", "nope"] `shouldSatisfy` isLeft
 
         it "opens the credential manager without starting an agent" do
             parseArgs ["login"] `shouldBe` Right Login

--- a/packages/agent-openai/agent-openai.cabal
+++ b/packages/agent-openai/agent-openai.cabal
@@ -52,6 +52,8 @@ library
                     , Agent.OpenAI.Login
                     , Agent.OpenAI.Usage
                     , Agent.OpenAI.Client
+                    , Agent.OpenAI.Features
+                    , Agent.OpenAI.ModelMetadata
                     , Agent.OpenAI.ResponseMerge
                     , Agent.OpenAI.WebSocketClient
                     , Agent.OpenAI.LoopBackend

--- a/packages/agent-openai/src/Agent/OpenAI/Client.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Client.hs
@@ -1,7 +1,12 @@
 module Agent.OpenAI.Client
-    ( createCodexMessage
+    ( CodexRequestOptions(..)
+    , defaultCodexRequestOptions
+    , remoteCompactionV2RequestOptions
+    , createCodexMessage
     , createCodexMessageWithProvider
+    , createCodexMessageWithProviderWithOptions
     , createCodexMessageWithProviderAt
+    , createCodexMessageWithProviderAtWithOptions
     , defaultCodexBaseUrl
     , retryTransientCodexResultWithPolicy
     ) where
@@ -10,6 +15,10 @@ import Agent.OpenAI.Auth (Pool)
 import Agent.OpenAI.Credential (poolTokenProvider)
 import Agent.Error
 import Agent.OpenAI.Error (classifyHttpFailure)
+import Agent.OpenAI.Features
+    ( betaFeaturesHeaderValue
+    , remoteCompactionV2Feature
+    )
 import Agent.OpenAI.Http (decodeCodexHttpBody)
 import Agent.Provider
     ( Credential(..)
@@ -18,7 +27,7 @@ import Agent.Provider
     , runWithTokenProvider
     )
 import qualified Agent.Responses.Types as OpenAI
-import Control.Monad (when)
+import Control.Monad (forM_, when)
 import qualified Control.Exception.Safe as Exception
 import Control.Monad.Catch (Handler(..))
 import Control.Retry
@@ -46,6 +55,21 @@ import Network.Http.Client
 -- request/SSE client without the ChatGPT broker.
 defaultCodexBaseUrl :: Text
 defaultCodexBaseUrl = "https://chatgpt.com/backend-api/codex"
+
+-- | Per-request Codex transport controls that are not part of the public
+-- Responses JSON schema.
+data CodexRequestOptions = CodexRequestOptions
+    { betaFeatures :: ![Text]
+    } deriving (Eq, Show)
+
+defaultCodexRequestOptions :: CodexRequestOptions
+defaultCodexRequestOptions = CodexRequestOptions
+    { betaFeatures = [remoteCompactionV2Feature]
+    }
+
+-- | Normal Responses transport options for the @compaction_trigger@ protocol.
+remoteCompactionV2RequestOptions :: CodexRequestOptions
+remoteCompactionV2RequestOptions = defaultCodexRequestOptions
 
 -- | Send a request to the Codex Responses API and parse the response.
 -- Serialises 'OpenAI.ResponseCreateParams' via its 'ToJSON' instance, POSTs to
@@ -75,7 +99,18 @@ createCodexMessageWithProvider
     -> OpenAI.ResponseCreateParams
     -> IO (Either ApiError OpenAI.Response)
 createCodexMessageWithProvider =
-    createCodexMessageWithProviderAt defaultCodexBaseUrl
+    createCodexMessageWithProviderWithOptions defaultCodexRequestOptions
+
+-- | Provider-based REST client with Codex-specific transport options.
+createCodexMessageWithProviderWithOptions
+    :: CodexRequestOptions
+    -> TokenProvider
+    -> OpenAI.ResponseCreateParams
+    -> IO (Either ApiError OpenAI.Response)
+createCodexMessageWithProviderWithOptions options =
+    createCodexMessageWithProviderAtWithOptions
+        options
+        defaultCodexBaseUrl
 
 -- | Like 'createCodexMessageWithProvider', but POST to
 -- @{baseUrl}/responses@ instead of the ChatGPT Codex backend.
@@ -89,7 +124,18 @@ createCodexMessageWithProviderAt
     -> TokenProvider
     -> OpenAI.ResponseCreateParams
     -> IO (Either ApiError OpenAI.Response)
-createCodexMessageWithProviderAt baseUrl provider request =
+createCodexMessageWithProviderAt =
+    createCodexMessageWithProviderAtWithOptions defaultCodexRequestOptions
+
+-- | Like 'createCodexMessageWithProviderAt', with additional Codex transport
+-- headers such as @x-codex-beta-features@.
+createCodexMessageWithProviderAtWithOptions
+    :: CodexRequestOptions
+    -> Text
+    -> TokenProvider
+    -> OpenAI.ResponseCreateParams
+    -> IO (Either ApiError OpenAI.Response)
+createCodexMessageWithProviderAtWithOptions options baseUrl provider request =
     runWithTokenProvider provider \credential ->
         case credential.provider of
             XAIProvider -> pure $ Left $ ProviderError ApiErrorType
@@ -101,7 +147,12 @@ createCodexMessageWithProviderAt baseUrl provider request =
             OpenAIProvider ->
                 retryTransientCodexResultWithPolicy transientResultPolicy $
                     recovering exceptionPolicy handlers $ \_status ->
-                        makeCodexRequest baseUrl credential.accessToken credential.accountId request
+                        makeCodexRequest
+                            options
+                            baseUrl
+                            credential.accessToken
+                            credential.accountId
+                            request
   where
     exceptionPolicy = exponentialBackoff 1_000_000 <> limitRetries 3
     transientResultPolicy = exponentialBackoff 5_000_000 <> limitRetries 3
@@ -124,8 +175,14 @@ retryTransientCodexResultWithPolicy policy request =
         Left apiError | isInlineRetryableProviderError apiError -> pure True
         _ -> pure False
 
-makeCodexRequest :: Text -> Text -> Text -> OpenAI.ResponseCreateParams -> IO (Either ApiError OpenAI.Response)
-makeCodexRequest baseUrl accessToken accountId request = do
+makeCodexRequest
+    :: CodexRequestOptions
+    -> Text
+    -> Text
+    -> Text
+    -> OpenAI.ResponseCreateParams
+    -> IO (Either ApiError OpenAI.Response)
+makeCodexRequest options baseUrl accessToken accountId request = do
     -- The ChatGPT Codex HTTP endpoint only serves Responses requests as SSE
     -- and rejects an omitted/false stream flag. WebSocket callers do not need
     -- this field, so enforce it at the HTTP transport boundary.
@@ -146,6 +203,10 @@ makeCodexRequest baseUrl accessToken accountId request = do
                                 -- OpenAI-compatible proxies (llm-router) do not.
                                 when (not (Text.null (Text.strip accountId))) $
                                     Network.Http.Client.setHeader "chatgpt-account-id" (Text.encodeUtf8 accountId)
+                                forM_ (betaFeaturesHeaderValue options.betaFeatures) \features ->
+                                    Network.Http.Client.setHeader
+                                        "x-codex-beta-features"
+                                        (Text.encodeUtf8 features)
                     sendRequest conn req (jsonBody requestBody)
                     receiveResponse conn responseHandler
 

--- a/packages/agent-openai/src/Agent/OpenAI/Compaction.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Compaction.hs
@@ -3,6 +3,12 @@
 module Agent.OpenAI.Compaction
     ( summaryPrefix
     , summarizationPrompt
+    , remoteCompactionRetainedTokenBudget
+    , compactionTriggerItem
+    , buildRemoteCompactionRequest
+    , trimRemoteCompactionHistoryToFit
+    , extractRemoteCompactionItem
+    , buildRemoteCompactedHistory
     , estimateTokens
     , estimateItemsTokens
     , collectRecentUserTexts
@@ -20,18 +26,382 @@ module Agent.OpenAI.Compaction
     , newSessionUserText
     ) where
 
+import Agent.Responses.LoopBackend (withRequestInput)
 import Agent.Responses.Types
 import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KeyMap
 import Data.Maybe (mapMaybe)
 import qualified Data.ByteString.Lazy as LBS
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
+import qualified Data.Vector as Vector
 
 -- | Marker prefix for compacted summary messages.
 summaryPrefix :: Text
 summaryPrefix = "Compacted conversation summary:"
+
+-- | Matches the retained-message budget used by Codex remote compaction v2.
+remoteCompactionRetainedTokenBudget :: Int
+remoteCompactionRetainedTokenBudget = 64_000
+
+maxRetainedAgentMessageTokens :: Int
+maxRetainedAgentMessageTokens = 10_000
+
+-- | The exact sentinel understood by the remote compaction v2 protocol.
+compactionTriggerItem :: ResponseItem
+compactionTriggerItem =
+    KnownResponseItem ItemCompactionTrigger TaggedObject
+        { tag = "compaction_trigger"
+        , fields = KeyMap.empty
+        }
+
+-- | Build a normal streaming Responses request whose final input item asks the
+-- model to emit an opaque compaction checkpoint.
+buildRemoteCompactionRequest
+    :: ResponseCreateParams
+    -> [ResponseItem]
+    -> ResponseCreateParams
+buildRemoteCompactionRequest params history =
+    case withRequestInput params (history <> [compactionTriggerItem]) of
+        ResponseCreateParams{..} ->
+            ResponseCreateParams
+                { parallelToolCalls = Just True
+                , previousResponseId = Nothing
+                , store = Just False
+                , stream = Just True
+                , toolChoice = Just (ToolChoiceMode ToolChoiceAuto)
+                , ..
+                }
+
+contextWindowTruncatedOutputMessage :: Text
+contextWindowTruncatedOutputMessage =
+    "Output exceeded the available model context and was truncated"
+
+-- | Codex rewrites only a contiguous suffix of tool outputs when the
+-- compaction request itself would exceed the model's usable context window.
+-- This keeps call/output pairing valid while making room for the trigger.
+trimRemoteCompactionHistoryToFit
+    :: Int
+    -> Maybe Text
+    -> [ResponseItem]
+    -> [ResponseItem]
+trimRemoteCompactionHistoryToFit contextWindow instructionText history =
+    go initialTokens (reverse history) []
+  where
+    initialTokens =
+        maybe 0 estimateTokens instructionText
+            + estimateItemsTokens history
+
+    go _ [] rewritten = rewritten
+    go tokens remaining rewritten
+        | tokens <= contextWindow =
+            reverse remaining <> rewritten
+    go tokens (item : remaining) rewritten =
+        case rewriteOversizedToolOutput item of
+            Nothing ->
+                reverse (item : remaining) <> rewritten
+            Just replacement ->
+                let nextTokens =
+                        tokens
+                            - estimateItemsTokens [item]
+                            + estimateItemsTokens [replacement]
+                in go nextTokens remaining (replacement : rewritten)
+
+rewriteOversizedToolOutput :: ResponseItem -> Maybe ResponseItem
+rewriteOversizedToolOutput = \case
+    FunctionCallOutputItem output ->
+        Just $ FunctionCallOutputItem FunctionCallOutput
+            { itemId = output.itemId
+            , callId = output.callId
+            , output = Aeson.String contextWindowTruncatedOutputMessage
+            , status = output.status
+            , extraFields = output.extraFields
+            }
+    CustomToolCallOutputItem output ->
+        Just $ CustomToolCallOutputItem CustomToolCallOutput
+            { itemId = output.itemId
+            , callId = output.callId
+            , name = output.name
+            , output = Aeson.String contextWindowTruncatedOutputMessage
+            , status = output.status
+            , extraFields = output.extraFields
+            }
+    KnownResponseItem ItemToolSearchOutput tagged ->
+        Just $ KnownResponseItem ItemToolSearchOutput TaggedObject
+            { tag = tagged.tag
+            , fields =
+                KeyMap.insert
+                    (Key.fromText "tools")
+                    (Aeson.Array Vector.empty)
+                    tagged.fields
+            }
+    _ -> Nothing
+
+-- | A successful v2 stream must complete and contain exactly one compaction
+-- output item. Other output item types are ignored, matching Codex.
+extractRemoteCompactionItem :: Response -> Either Text ResponseItem
+extractRemoteCompactionItem response
+    | response.status /= ResponseCompleted =
+        Left $
+            "remote compaction v2 expected response.completed, got "
+                <> Text.pack (show response.status)
+    | otherwise =
+        case
+            [ item
+            | item@(KnownResponseItem ItemCompaction _) <- response.output
+            ]
+        of
+            [item] -> Right item
+            items ->
+                Left $
+                    "remote compaction v2 expected exactly one compaction "
+                        <> "output item, got "
+                        <> Text.pack (show (length items))
+                        <> " from "
+                        <> Text.pack (show (length response.output))
+                        <> " output items"
+
+-- | Install the newest eligible user/inter-agent messages under the retained
+-- token budget, followed by the opaque checkpoint. Ordinary assistant output,
+-- reasoning, tool calls/results, old checkpoints, and generated system or
+-- developer messages are represented by the checkpoint and are discarded.
+buildRemoteCompactedHistory
+    :: Int
+    -> [ResponseItem]
+    -> ResponseItem
+    -> [ResponseItem]
+buildRemoteCompactedHistory budget history checkpoint =
+    truncateRetainedGroups budget
+        (filter (\group -> isRemoteRetainedItem group.retainedSource)
+            (retainedGroups history))
+        <> [checkpoint]
+
+data RetainedGroup = RetainedGroup
+    { retainedSource :: !ResponseItem
+    , retainedNotice :: !(Maybe ResponseItem)
+    }
+
+retainedGroups :: [ResponseItem] -> [RetainedGroup]
+retainedGroups = \case
+    [] -> []
+    source : notice : rest
+        | isImageResizeNotice notice ->
+            RetainedGroup source (Just notice) : retainedGroups rest
+    source : rest ->
+        RetainedGroup source Nothing : retainedGroups rest
+
+isImageResizeNotice :: ResponseItem -> Bool
+isImageResizeNotice = \case
+    MessageItem message
+        | message.role == RoleDeveloper ->
+            maybe False
+                (Text.isPrefixOf "<image_resize_notice>" . Text.stripStart)
+                (messageText message)
+    _ -> False
+
+-- The Haskell harness currently lacks Codex's per-item metadata sidecar, so
+-- recognize the contextual user wrappers it generates itself. Their contents
+-- are already represented by the opaque checkpoint and, where applicable,
+-- reinjected from current session state.
+isGeneratedContextUserText :: Text -> Bool
+isGeneratedContextUserText text =
+    any (`Text.isPrefixOf` Text.stripStart text)
+        [ "# AGENTS.md instructions for "
+        , "# Skill instructions: "
+        , "Plan mode is active. Do not make any edits or writes to the system except for the plan file."
+        , "The user approved the plan. Plan mode is now off."
+        , "<subagent_notification>"
+        ]
+
+isRemoteRetainedItem :: ResponseItem -> Bool
+isRemoteRetainedItem = \case
+    MessageItem message ->
+        message.role == RoleUser
+            && maybe True
+                (not . isGeneratedContextUserText)
+                (messageText message)
+    KnownResponseItem ItemAgentMessage tagged ->
+        not (isDiscardedAgentMessage tagged)
+            && itemTokenCount (KnownResponseItem ItemAgentMessage tagged)
+                <= maxRetainedAgentMessageTokens
+    _ -> False
+
+isDiscardedAgentMessage :: TaggedObject -> Bool
+isDiscardedAgentMessage tagged =
+    let author = taggedTextField "author" tagged
+        recipient = taggedTextField "recipient" tagged
+        firstText = taggedFirstContentText tagged
+        descendantProgress =
+            case (author, recipient, firstText) of
+                (Just author_, Just recipient_, Just text_) ->
+                    Text.isPrefixOf (recipient_ <> "/") author_
+                        && Text.isPrefixOf "Message Type: MESSAGE\n" text_
+                _ -> False
+        completion =
+            maybe False
+                (Text.isPrefixOf "Message Type: FINAL_ANSWER\n")
+                firstText
+    in descendantProgress || completion
+
+taggedTextField :: Text -> TaggedObject -> Maybe Text
+taggedTextField name tagged =
+    case KeyMap.lookup (Key.fromText name) tagged.fields of
+        Just (Aeson.String value) -> Just value
+        _ -> Nothing
+
+taggedFirstContentText :: TaggedObject -> Maybe Text
+taggedFirstContentText tagged = do
+    Aeson.Array content <-
+        KeyMap.lookup (Key.fromText "content") tagged.fields
+    first <- content Vector.!? 0
+    Aeson.Object object <- pure first
+    Aeson.String text <-
+        KeyMap.lookup (Key.fromText "text") object
+    pure text
+
+truncateRetainedGroups :: Int -> [RetainedGroup] -> [ResponseItem]
+truncateRetainedGroups maxTokens groups =
+    concatMap groupItems (go (max 0 maxTokens) (reverse groups) [])
+  where
+    go _ [] selected = selected
+    go 0 _ selected = selected
+    go remaining (group : rest) selected
+        | tokenCount <= remaining =
+            go (remaining - tokenCount) rest (group : selected)
+        | remaining > noticeTokens
+        , Just source <- truncateItemText
+            (remaining - noticeTokens)
+            group.retainedSource =
+                RetainedGroup source group.retainedNotice : selected
+        | otherwise =
+            go remaining rest selected
+      where
+        noticeTokens = maybe 0 itemTokenCount group.retainedNotice
+        tokenCount =
+            itemTokenCount group.retainedSource + noticeTokens
+
+groupItems :: RetainedGroup -> [ResponseItem]
+groupItems group =
+    group.retainedSource : maybe [] pure group.retainedNotice
+
+itemTokenCount :: ResponseItem -> Int
+itemTokenCount = \case
+    MessageItem message -> max 1 (messageTokenCount message)
+    item -> estimateItemsTokens [item]
+
+messageTokenCount :: ResponseMessage -> Int
+messageTokenCount message = case message.content of
+    MessageContentText text -> estimateTokens text
+    MessageContentParts parts ->
+        sum (map contentPartTokenCount parts)
+
+contentPartTokenCount :: ResponseContentPart -> Int
+contentPartTokenCount = \case
+    InputTextPart { text } -> estimateTokens text
+    OutputTextPart { text } -> estimateTokens text
+    RefusalPart { refusal } -> estimateTokens refusal
+    ReasoningTextPart { text } -> estimateTokens text
+    SummaryTextPart { text } -> estimateTokens text
+    _ -> 0
+
+truncateItemText :: Int -> ResponseItem -> Maybe ResponseItem
+truncateItemText budget = \case
+    MessageItem message ->
+        MessageItem <$> truncateMessageText budget message
+    _ -> Nothing
+
+truncateMessageText :: Int -> ResponseMessage -> Maybe ResponseMessage
+truncateMessageText budget message =
+    case message.content of
+        MessageContentText text ->
+            let truncated = takeTokenBudget budget text
+            in if Text.null truncated
+                then Nothing
+                else Just (replaceMessageContent
+                    message
+                    (MessageContentText truncated))
+        MessageContentParts parts ->
+            let truncated = truncateContentParts budget parts
+            in if null truncated
+                then Nothing
+                else Just (replaceMessageContent
+                    message
+                    (MessageContentParts truncated))
+
+replaceMessageContent :: ResponseMessage -> MessageContent -> ResponseMessage
+replaceMessageContent message nextContent =
+    ResponseMessage
+        { messageId = message.messageId
+        , content = nextContent
+        , role = message.role
+        , status = message.status
+        , phase = message.phase
+        , extraFields = message.extraFields
+        }
+
+truncateContentParts :: Int -> [ResponseContentPart] -> [ResponseContentPart]
+truncateContentParts initialBudget = go (max 0 initialBudget)
+  where
+    go _ [] = []
+    go remaining (part : rest) =
+        case truncateTextPart remaining part of
+            TextPartNonText ->
+                part : go remaining rest
+            TextPartDropped ->
+                go remaining rest
+            TextPartKept used truncated ->
+                truncated : go (remaining - used) rest
+
+data TruncatedTextPart
+    = TextPartNonText
+    | TextPartDropped
+    | TextPartKept !Int !ResponseContentPart
+
+truncateTextPart :: Int -> ResponseContentPart -> TruncatedTextPart
+truncateTextPart budget part =
+    case partText part of
+        Nothing -> TextPartNonText
+        Just text
+            | budget <= 0 -> TextPartDropped
+            | otherwise ->
+                let tokens = estimateTokens text
+                    used = min budget tokens
+                    truncated = replacePartText (takeTokenBudget used text) part
+                in if Text.null (partTextValue truncated)
+                    then TextPartDropped
+                    else TextPartKept used truncated
+
+partText :: ResponseContentPart -> Maybe Text
+partText = \case
+    InputTextPart { text } -> Just text
+    OutputTextPart { text } -> Just text
+    RefusalPart { refusal } -> Just refusal
+    ReasoningTextPart { text } -> Just text
+    SummaryTextPart { text } -> Just text
+    _ -> Nothing
+
+partTextValue :: ResponseContentPart -> Text
+partTextValue = maybe "" id . partText
+
+replacePartText :: Text -> ResponseContentPart -> ResponseContentPart
+replacePartText value = \case
+    InputTextPart { promptCacheBreakpoint, extraFields } ->
+        InputTextPart value promptCacheBreakpoint extraFields
+    OutputTextPart { annotations, logprobs, extraFields } ->
+        OutputTextPart value annotations logprobs extraFields
+    RefusalPart { extraFields } ->
+        RefusalPart value extraFields
+    ReasoningTextPart { extraFields } ->
+        ReasoningTextPart value extraFields
+    SummaryTextPart { extraFields } ->
+        SummaryTextPart value extraFields
+    part -> part
+
+takeTokenBudget :: Int -> Text -> Text
+takeTokenBudget tokens =
+    Text.take (max 0 tokens * 4)
 
 -- | User-visible / persisted marker for a compact turn.
 compactSessionUserText :: Maybe Text -> Text
@@ -134,6 +504,18 @@ buildLocalCompactedHistory keepRecent history summary =
     map userTextItem (collectRecentUserTexts keepRecent history)
         <> [assistantSummaryItem summary]
 
+-- | Legacy helper retained for API compatibility. Installed v2 snapshots must
+-- be replayed in full because they intentionally place retained messages
+-- before the checkpoint; new loop code therefore no longer calls this.
+compactTranscriptAtLastCheckpoint :: [ResponseItem] -> [ResponseItem]
+compactTranscriptAtLastCheckpoint items = go [] (reverse items)
+  where
+    go _ [] = items
+    go after (item : before) =
+        case item of
+            KnownResponseItem ItemCompaction _ -> item : after
+            _ -> go (item : after) before
+
 -- | Session turns that represent a compaction checkpoint.
 isCompactSessionTurn :: Text -> Bool
 isCompactSessionTurn text =
@@ -159,16 +541,6 @@ isTranscriptResetTurn text =
     isCompactSessionTurn text
         || isClearSessionTurn text
         || isNewSessionTurn text
-
--- | An opaque server compaction item replaces every item before it.
-compactTranscriptAtLastCheckpoint :: [ResponseItem] -> [ResponseItem]
-compactTranscriptAtLastCheckpoint items = go [] (reverse items)
-  where
-    go _ [] = items
-    go after (item : before) =
-        case item of
-            KnownResponseItem ItemCompaction _ -> item : after
-            _ -> go (item : after) before
 
 hasCompactionCheckpoint :: [ResponseItem] -> Bool
 hasCompactionCheckpoint = any \case

--- a/packages/agent-openai/src/Agent/OpenAI/Features.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Features.hs
@@ -1,0 +1,20 @@
+-- | Codex transport feature names shared by HTTP and WebSocket clients.
+module Agent.OpenAI.Features
+    ( remoteCompactionV2Feature
+    , betaFeaturesHeaderValue
+    ) where
+
+import Data.List (nub)
+import Data.Text (Text)
+import qualified Data.Text as Text
+
+-- | Enables the @compaction_trigger@ protocol on normal Responses requests.
+remoteCompactionV2Feature :: Text
+remoteCompactionV2Feature = "remote_compaction_v2"
+
+-- | Render a comma-separated @x-codex-beta-features@ value.
+betaFeaturesHeaderValue :: [Text] -> Maybe Text
+betaFeaturesHeaderValue features =
+    case nub (filter (not . Text.null) (map Text.strip features)) of
+        [] -> Nothing
+        values -> Just (Text.intercalate "," values)

--- a/packages/agent-openai/src/Agent/OpenAI/LoopBackend.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/LoopBackend.hs
@@ -24,7 +24,6 @@ import Agent.Error
     , isInlineRetryableProviderResponseError
     )
 import Agent.Loop (Backend(..), LoopEvent(..))
-import Agent.OpenAI.Compaction (compactTranscriptAtLastCheckpoint)
 import Agent.OpenAI.Error (isPreviousResponseIdError)
 import Agent.OpenAI.WebSocketClient
     ( CodexConn
@@ -218,8 +217,11 @@ openAiBackendWithRetryPolicy retryPolicy send getParams transcript =
         history <- readIORef transcript
         let newItems = turnInputsToItems inputs
             deltaRequest = withRequestInput baseParams newItems
-            replayHistory = compactTranscriptAtLastCheckpoint history
-            fullRequest = withRequestInput baseParams (replayHistory <> newItems)
+            -- Live and resumed transcripts already apply compaction snapshots
+            -- as full replacements. Remote v2 intentionally keeps retained
+            -- messages before its opaque checkpoint, so replay the complete
+            -- replacement instead of trimming that retained prefix.
+            fullRequest = withRequestInput baseParams (history <> newItems)
             emit event = mapM_ onLoopEvent (streamEventToLoopEvent event)
             (initialRequest, initialPrevious) =
                 case previousResponseId of

--- a/packages/agent-openai/src/Agent/OpenAI/ModelMetadata.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/ModelMetadata.hs
@@ -1,0 +1,51 @@
+-- | Minimal Codex model metadata used by transport-level context management.
+module Agent.OpenAI.ModelMetadata
+    ( CodexModelMetadata(..)
+    , codexModelMetadata
+    , codexAutoCompactTokenLimitFor
+    , codexEffectiveContextWindowFor
+    , defaultCodexAutoCompactTokenLimit
+    , defaultCodexEffectiveContextWindow
+    ) where
+
+import Data.Text (Text)
+
+data CodexModelMetadata = CodexModelMetadata
+    { modelContextWindow :: !Int
+    , modelEffectiveContextWindow :: !Int
+    , modelAutoCompactTokenLimit :: !Int
+    } deriving (Eq, Show)
+
+-- | The current Codex fallback model metadata uses a 272k context window and
+-- compacts at 90% of that window.
+defaultCodexAutoCompactTokenLimit :: Int
+defaultCodexAutoCompactTokenLimit = 244_800
+
+defaultCodexEffectiveContextWindow :: Int
+defaultCodexEffectiveContextWindow = 258_400
+
+codexModelMetadata :: Text -> Maybe CodexModelMetadata
+codexModelMetadata modelName
+    | modelName `elem`
+        [ "gpt-5.6-sol"
+        , "gpt-5.6-terra"
+        , "gpt-5.6-luna"
+        ] =
+        Just CodexModelMetadata
+            { modelContextWindow = 272_000
+            , modelEffectiveContextWindow = defaultCodexEffectiveContextWindow
+            , modelAutoCompactTokenLimit = defaultCodexAutoCompactTokenLimit
+            }
+    | otherwise = Nothing
+
+codexAutoCompactTokenLimitFor :: Maybe Text -> Int
+codexAutoCompactTokenLimitFor modelName =
+    maybe defaultCodexAutoCompactTokenLimit
+        (.modelAutoCompactTokenLimit)
+        (modelName >>= codexModelMetadata)
+
+codexEffectiveContextWindowFor :: Maybe Text -> Int
+codexEffectiveContextWindowFor modelName =
+    maybe defaultCodexEffectiveContextWindow
+        (.modelEffectiveContextWindow)
+        (modelName >>= codexModelMetadata)

--- a/packages/agent-openai/src/Agent/OpenAI/WebSocketClient.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/WebSocketClient.hs
@@ -10,6 +10,7 @@ module Agent.OpenAI.WebSocketClient
     , CodexWsOptions(..)
     , defaultCodexWsOptions
     , buildWsPayloadWithOptions
+    , buildCodexWsHeaders
     , StreamEventCallback
     , RawStreamEventCallback
     , CodexConn
@@ -20,6 +21,7 @@ import Agent.OpenAI.Auth (Pool)
 import Agent.OpenAI.Credential (poolTokenProvider)
 import Agent.Error
 import Agent.OpenAI.Error (isPreviousResponseIdError, mkOpenAIError)
+import Agent.OpenAI.Features (remoteCompactionV2Feature)
 import Agent.Responses.ResponseMerge (mergeCompletedResponseOutput)
 import qualified Agent.Responses.Codec as ResponsesCodec
 import qualified Agent.Transport.WebSocket as WebSocket
@@ -139,11 +141,7 @@ runConnectionAttempt credential _action
         Nothing
 runConnectionAttempt credential action = do
     result <- Exception.try @Exception.SomeException $ do
-        let headers =
-                [ ("Authorization", "Bearer " <> Text.encodeUtf8 credential.accessToken)
-                , ("chatgpt-account-id", Text.encodeUtf8 credential.accountId)
-                , ("OpenAI-Beta", "responses_websockets=2026-02-06")
-                ]
+        let headers = buildCodexWsHeaders credential
         WebSocket.retryTransientWsConnectWithPolicy
             WebSocket.transientWsConnectRetryPolicy
             \connected ->
@@ -165,6 +163,15 @@ runConnectionAttempt credential action = do
             | Just authErr <- WebSocket.wsHandshakeAuthFailure exception ->
                 pure (Left authErr)
             | otherwise -> Exception.throwIO exception
+
+-- | Pure handshake-header builder exported for transport contract tests.
+buildCodexWsHeaders :: Credential -> WS.Headers
+buildCodexWsHeaders credential =
+    [ ("Authorization", "Bearer " <> Text.encodeUtf8 credential.accessToken)
+    , ("chatgpt-account-id", Text.encodeUtf8 credential.accountId)
+    , ("OpenAI-Beta", "responses_websockets=2026-02-06")
+    , ("x-codex-beta-features", Text.encodeUtf8 remoteCompactionV2Feature)
+    ]
 
 -- | Wraps an 'ApiError' from 'getAccessToken' so it can propagate out of
 -- 'withCodexWs' as an exception. The agent-loop's failover layer unwraps it

--- a/packages/agent-openai/test/Agent/OpenAI/ClientSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/ClientSpec.hs
@@ -132,6 +132,8 @@ spec = do
             request.path `shouldBe` "/v1/responses"
             lookup "Authorization" request.headers `shouldBe` Just "Bearer router-key"
             lookup "chatgpt-account-id" request.headers `shouldBe` Nothing
+            lookup "x-codex-beta-features" request.headers
+                `shouldBe` Just "remote_compaction_v2"
             case request.body of
                 Aeson.Object object ->
                     KeyMap.lookup "stream" object `shouldBe` Just (Aeson.Bool True)
@@ -169,6 +171,34 @@ spec = do
                     (helloRequest "hi")
                 response <- expectRight result
                 extractAssistantText response `shouldBe` Just "from-sse"
+
+        it "advertises remote compaction v2 and merges its streamed output item" do
+            recorded <- newIORef []
+            let handler _request = pure sseCompactionCompleted
+            withMockResponses recorded handler \baseUrl -> do
+                result <- createCodexMessageWithProviderAtWithOptions
+                    remoteCompactionV2RequestOptions
+                    baseUrl
+                    (staticBearerProvider "router-key")
+                    (helloRequest "compact")
+                response <- expectRight result
+                case response.output of
+                    [KnownResponseItem ItemCompaction tagged] ->
+                        KeyMap.lookup "encrypted_content" tagged.fields
+                            `shouldBe` Just (Aeson.String "opaque")
+                    other ->
+                        expectationFailure
+                            ("expected one compaction output, got " <> show other)
+
+            [request] <- readIORef recorded
+            lookup "x-codex-beta-features" request.headers
+                `shouldBe` Just "remote_compaction_v2"
+            case request.body of
+                Aeson.Object object ->
+                    KeyMap.lookup "stream" object `shouldBe` Just (Aeson.Bool True)
+                other ->
+                    expectationFailure
+                        ("expected JSON request object, got " <> show other)
 
 responseWithStatus :: Text -> Maybe Aeson.Value -> Response
 responseWithStatus status errorValue = decodeResponse (Aeson.object
@@ -237,6 +267,38 @@ sseCompleted text =
         body = "event: response.completed\ndata: "
             <> Text.decodeUtf8 (LBS.toStrict (Aeson.encode payload))
             <> "\n\n"
+    in Wai.responseLBS HTTP.status200
+        [("Content-Type", "text/event-stream")]
+        (LBS.fromStrict (Text.encodeUtf8 body))
+
+sseCompactionCompleted :: Wai.Response
+sseCompactionCompleted =
+    let item = Aeson.object
+            [ "type" .= ("compaction" :: Text)
+            , "encrypted_content" .= ("opaque" :: Text)
+            ]
+        done = Aeson.object
+            [ "type" .= ("response.output_item.done" :: Text)
+            , "item" .= item
+            ]
+        completed = Aeson.object
+            [ "type" .= ("response.completed" :: Text)
+            , "response" .= Aeson.object
+                [ "id" .= ("resp-compact" :: Text)
+                , "created_at" .= (0 :: Int)
+                , "model" .= ("gpt-test" :: Text)
+                , "status" .= ("completed" :: Text)
+                , "output" .= ([] :: [Aeson.Value])
+                ]
+            ]
+        body = Text.concat
+            [ "event: response.output_item.done\ndata: "
+            , Text.decodeUtf8 (LBS.toStrict (Aeson.encode done))
+            , "\n\n"
+            , "event: response.completed\ndata: "
+            , Text.decodeUtf8 (LBS.toStrict (Aeson.encode completed))
+            , "\n\n"
+            ]
     in Wai.responseLBS HTTP.status200
         [("Content-Type", "text/event-stream")]
         (LBS.fromStrict (Text.encodeUtf8 body))

--- a/packages/agent-openai/test/Agent/OpenAI/CompactionSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/CompactionSpec.hs
@@ -3,15 +3,154 @@ module Agent.OpenAI.CompactionSpec (spec) where
 import Agent.Error (ApiError(..), ErrorType(..))
 import Agent.OpenAI.CompactClient
 import Agent.OpenAI.Compaction
+import Agent.OpenAI.ModelMetadata
 import qualified Data.Aeson as Aeson
+import Data.Aeson ((.=))
 import Agent.Provider
 import Agent.Responses.Types
 import qualified Data.Aeson.KeyMap as KeyMap
+import Data.Either (isLeft)
 import qualified Data.Text as Text
 import Test.Hspec
 
 spec :: Spec
 spec = do
+    describe "remote compaction v2" do
+        it "builds an exact final compaction trigger and preserves request controls" do
+            let reasoningConfig = ReasoningConfig
+                    { context = Nothing
+                    , effort = Just "high"
+                    , generateSummary = Nothing
+                    , reasoningMode = Nothing
+                    , summary = Nothing
+                    , extraFields = KeyMap.empty
+                    }
+                params = defaultResponseCreateParams
+                    { instructions = Just "instructions"
+                    , tools = Just []
+                    , reasoning = Just reasoningConfig
+                    , previousResponseId = Just "old-response"
+                    , parallelToolCalls = Just False
+                    , store = Just True
+                    , stream = Just False
+                    }
+                history = [user "hello"]
+                request = buildRemoteCompactionRequest params history
+            request.instructions `shouldBe` Just "instructions"
+            request.tools `shouldBe` Just []
+            request.reasoning `shouldBe` Just reasoningConfig
+            request.previousResponseId `shouldBe` Nothing
+            request.parallelToolCalls `shouldBe` Just True
+            request.store `shouldBe` Just False
+            request.stream `shouldBe` Just True
+            request.toolChoice `shouldBe` Just (ToolChoiceMode ToolChoiceAuto)
+            requestItems request `shouldBe` history <> [compactionTriggerItem]
+            Aeson.toJSON compactionTriggerItem
+                `shouldBe` Aeson.object ["type" .= ("compaction_trigger" :: Text.Text)]
+
+        it "accepts exactly one compaction item alongside unrelated output" do
+            let opaque = checkpoint "opaque"
+                response = completedResponse [assistant "ignored", opaque]
+            extractRemoteCompactionItem response `shouldBe` Right opaque
+
+        it "rejects zero or multiple compaction output items" do
+            extractRemoteCompactionItem (completedResponse [assistant "none"])
+                `shouldSatisfy` isLeft
+            extractRemoteCompactionItem
+                (completedResponse [checkpoint "one", checkpoint "two"])
+                `shouldSatisfy` isLeft
+
+        it "installs retained user messages before the opaque checkpoint" do
+            let opaque = checkpoint "opaque"
+                call = FunctionCallItem FunctionCall
+                    { itemId = Nothing
+                    , callId = "call-1"
+                    , name = "shell_command"
+                    , arguments = "{}"
+                    , status = Nothing
+                    , extraFields = KeyMap.empty
+                    }
+                history =
+                    [ user "old"
+                    , assistant "discard me"
+                    , call
+                    , user "recent"
+                    ]
+            buildRemoteCompactedHistory 64_000 history opaque
+                `shouldBe` [user "old", user "recent", opaque]
+
+        it "drops harness-generated user-role context wrappers" do
+            let opaque = checkpoint "opaque"
+                history =
+                    [ user "# AGENTS.md instructions for /tmp/project\n\n<INSTRUCTIONS>generated</INSTRUCTIONS>"
+                    , user "# Skill instructions: example\n\n<SKILL_INSTRUCTIONS>generated</SKILL_INSTRUCTIONS>"
+                    , user "<subagent_notification>\nstatus: completed\n</subagent_notification>"
+                    , user "real user request"
+                    ]
+            buildRemoteCompactedHistory 64_000 history opaque
+                `shouldBe` [user "real user request", opaque]
+
+        it "retains task agent messages but drops descendant progress and completions" do
+            let opaque = checkpoint "opaque"
+                task = agentMessage "root" "root/child"
+                    "Message Type: NEW_TASK\nPayload:\ndo it"
+                progress = agentMessage "root/child/grandchild" "root/child"
+                    "Message Type: MESSAGE\nPayload:\nworking"
+                completion = agentMessage "root/child" "root"
+                    "Message Type: FINAL_ANSWER\nPayload:\ndone"
+            buildRemoteCompactedHistory 64_000
+                [task, progress, completion]
+                opaque
+                `shouldBe` [task, opaque]
+
+        it "uses the retained budget newest-first and truncates the boundary user" do
+            let opaque = checkpoint "opaque"
+                old = Text.replicate 40 "o"
+                recent = "recent"
+                compacted =
+                    buildRemoteCompactedHistory 3
+                        [user old, user recent]
+                        opaque
+                retainedTexts =
+                    [ userOnly message
+                    | MessageItem message <- compacted
+                    , message.role == RoleUser
+                    ]
+            retainedTexts `shouldBe` [Text.take 8 old, recent]
+            last compacted `shouldBe` opaque
+
+        it "rewrites a trailing oversized tool output to fit the request window" do
+            let oversized = FunctionCallOutputItem FunctionCallOutput
+                    { itemId = Nothing
+                    , callId = "call-1"
+                    , output = Aeson.String (Text.replicate 10_000 "x")
+                    , status = Just ItemCompleted
+                    , extraFields = KeyMap.empty
+                    }
+                trimmed =
+                    trimRemoteCompactionHistoryToFit
+                        100
+                        Nothing
+                        [user "keep", oversized]
+            case reverse trimmed of
+                FunctionCallOutputItem output : _ ->
+                    output.output `shouldBe` Aeson.String
+                        "Output exceeded the available model context and was truncated"
+                other ->
+                    expectationFailure
+                        ("expected rewritten tool output, got " <> show other)
+
+    describe "Codex model metadata" do
+        it "derives the 90% auto-compaction limit for curated 272k models" do
+            codexModelMetadata "gpt-5.6-luna"
+                `shouldBe` Just CodexModelMetadata
+                    { modelContextWindow = 272_000
+                    , modelEffectiveContextWindow = 258_400
+                    , modelAutoCompactTokenLimit = 244_800
+                    }
+            codexAutoCompactTokenLimitFor (Just "gpt-5.6-sol")
+                `shouldBe` 244_800
+
     describe "buildLocalCompactedHistory" do
         it "keeps recent user texts and an assistant summary" do
             let history =
@@ -36,24 +175,18 @@ spec = do
             texts `shouldBe` ["keep me"]
 
     describe "compactTranscriptAtLastCheckpoint" do
-        it "preserves history without a checkpoint" do
-            let history = [user "one", assistant "two"]
-            compactTranscriptAtLastCheckpoint history `shouldBe` history
-
-        it "keeps the latest checkpoint and following items" do
+        it "retains its legacy raw-checkpoint behavior for API compatibility" do
             let first = checkpoint "first"
                 latest = checkpoint "latest"
-                history = [user "old", first, assistant "middle", latest, user "recent"]
+                history =
+                    [ user "old"
+                    , first
+                    , assistant "middle"
+                    , latest
+                    , user "recent"
+                    ]
             compactTranscriptAtLastCheckpoint history
                 `shouldBe` [latest, user "recent"]
-
-        it "does not treat a compaction trigger as a checkpoint" do
-            let trigger = KnownResponseItem ItemCompactionTrigger TaggedObject
-                    { tag = "compaction_trigger"
-                    , fields = KeyMap.empty
-                    }
-                history = [user "old", trigger, user "recent"]
-            compactTranscriptAtLastCheckpoint history `shouldBe` history
 
     describe "hasCompactionCheckpoint" do
         it "recognizes remote and local compaction snapshots" do
@@ -133,6 +266,34 @@ spec = do
         MessageContentParts (InputTextPart text _ _ : _) -> text
         MessageContentText text -> text
         _ -> ""
+    requestItems request = case request.input of
+        Just (ResponseInputItems items) -> items
+        _ -> []
+    completedResponse output =
+        case Aeson.fromJSON $ Aeson.object
+            [ "id" .= ("resp-compact" :: Text.Text)
+            , "created_at" .= (0 :: Int)
+            , "status" .= ("completed" :: Text.Text)
+            , "model" .= ("gpt-test" :: Text.Text)
+            , "output" .= output
+            ] of
+            Aeson.Success response -> response
+            Aeson.Error err -> error err
+    agentMessage :: Text.Text -> Text.Text -> Text.Text -> ResponseItem
+    agentMessage author recipient text =
+        KnownResponseItem ItemAgentMessage TaggedObject
+            { tag = "agent_message"
+            , fields = KeyMap.fromList
+                [ ("author", Aeson.String author)
+                , ("recipient", Aeson.String recipient)
+                , ("content", Aeson.toJSON
+                    [ Aeson.object
+                        [ "type" .= ("input_text" :: Text.Text)
+                        , "text" .= text
+                        ]
+                    ])
+                ]
+            }
     checkpoint name = KnownResponseItem ItemCompaction TaggedObject
         { tag = "compaction"
         , fields = KeyMap.fromList [("name", Aeson.String name)]

--- a/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
@@ -365,7 +365,7 @@ spec = do
                 , seed <> turnInputsToItems [UserMessage "new"]
                 ]
 
-        it "starts fresh replay at the latest automatic compaction checkpoint" do
+        it "replays retained messages before an automatic compaction checkpoint" do
             seen <- newIORef []
             let checkpoint = compactionItem "opaque"
                 history =
@@ -381,7 +381,8 @@ spec = do
             [(request, previous)] <- readIORef seen
             previous `shouldBe` Nothing
             inputItems request `shouldBe`
-                [checkpoint]
+                turnInputsToItems [UserMessage "old"]
+                    <> [checkpoint]
                     <> turnInputsToItems [UserMessage "recent"]
                     <> turnInputsToItems [UserMessage "new"]
 

--- a/packages/agent-openai/test/Agent/OpenAI/WebSocketClientSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/WebSocketClientSpec.hs
@@ -2,6 +2,7 @@ module Agent.OpenAI.WebSocketClientSpec (spec) where
 
 import Test.Hspec
 import Agent.Error
+import Agent.Provider (Credential(..), Provider(..))
 import Agent.Responses.Types
 import Agent.OpenAI.WebSocketClient
 import Control.Retry (constantDelay, limitRetries)
@@ -13,6 +14,17 @@ import Data.Text (Text)
 
 spec :: Spec
 spec = do
+  describe "buildCodexWsHeaders" do
+    it "advertises remote compaction v2 on the session handshake" do
+        let credential = Credential
+                { accessToken = "token"
+                , accountId = "account"
+                , leaseId = Nothing
+                , provider = OpenAIProvider
+                }
+        lookup "x-codex-beta-features" (buildCodexWsHeaders credential)
+            `shouldBe` Just "remote_compaction_v2"
+
   describe "buildWsPayloadWithOptions" do
     it "forces store=false for the Codex WebSocket contract" do
         let request = sampleRequest { store = Just True }


### PR DESCRIPTION
## Summary

- switch OpenAI compaction to Codex remote compaction v2 by appending an exact `compaction_trigger` to a normal streaming `/responses` request
- advertise `remote_compaction_v2` on REST requests and WebSocket handshakes, validate exactly one opaque checkpoint, and install upstream-style retained history
- replay complete installed compaction snapshots, account for pending inputs and resumed histories, preserve typed provider errors, and compact pending tool continuations safely
- add curated GPT-5.6 context metadata plus a positive `--compact-threshold N` override for root sessions and OpenAI subagents
- keep focused OpenAI compaction and non-OpenAI providers on local summarization

## Testing

- `nix develop -c env -u GHCRTS cabal test agent-openai:test:agent-openai-test agent-cli:test:agent-cli-test --test-show-details=direct`
  - OpenAI: 161 examples, 0 failures, 1 opt-in live test pending
  - CLI: 467 examples, 0 failures
- `git diff --check`
- live tmux smoke test with `gpt-5.6-luna` and `--compact-threshold 2000`
  - first completed turn reported 6.7k input tokens
  - following turn displayed `Compacting context…` and completed without an automatic-compaction error
  - persisted transcript contained an opaque `compaction` item
  - post-compaction prompt returned exactly `LUNA_COMPACT_OK`
