### PR TITLE
perf(cli): reduce transcript and session overhead

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -3589,20 +3589,21 @@ detectGitBranch cwd = do
 
 -- | Apply compact turns as full transcript replacements when resuming.
 foldSessionItems :: [SessionTurn] -> [ResponseItem]
-foldSessionItems = go []
+foldSessionItems =
+    concat . reverse . foldl' addTurn []
   where
-    go acc [] = acc
-    go acc (turn:rest)
+    addTurn chunks turn
         | isTranscriptResetTurn turn.turnUserText =
             -- /clear and /new store an empty snapshot; /compact stores the
             -- rebuilt history. Either way, turnItems replaces prior history.
-            go turn.turnItems rest
+            [turn.turnItems]
         | hasCompactionCheckpoint turn.turnItems =
-            go turn.turnItems rest
-        | otherwise = go (acc <> turn.turnItems) rest
+            [turn.turnItems]
+        | otherwise =
+            turn.turnItems : chunks
 
 hydrateUiHistory :: [SessionTurn] -> UiState
-hydrateUiHistory = foldl addTurn initialUiState
+hydrateUiHistory = foldl' addTurn initialUiState
   where
     addTurn state turn
         | isTranscriptResetTurn turn.turnUserText =

--- a/packages/agent-cli/src/Agent/CLI/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session.hs
@@ -10,6 +10,7 @@ module Agent.CLI.Session
     , newActivePersistence
     , createSession
     , appendTurn
+    , appendTurnWithMetaUpdate
     , appendTurnKeepTitle
     , loadSession
     , isValidSessionId
@@ -258,7 +259,17 @@ ensureSession slotRef = do
             pure handle
 
 appendTurn :: SessionHandle -> SessionTurn -> IO SessionHandle
-appendTurn handle turn = do
+appendTurn handle turn =
+    appendTurnWithMetaUpdate handle turn id
+
+-- | Append one transcript turn, then apply an additional metadata transition
+-- before the append's single metadata write.
+appendTurnWithMetaUpdate
+    :: SessionHandle
+    -> SessionTurn
+    -> (SessionMeta -> SessionMeta)
+    -> IO SessionHandle
+appendTurnWithMetaUpdate handle turn updateMeta = do
     let path = handle.sessionTranscriptPath
     existed <- doesFileExist path
     appendLazyFileRetryingOpen path (Aeson.encode turn <> "\n")
@@ -279,8 +290,9 @@ appendTurn handle turn = do
             , metaCachedTokens =
                 meta0.metaCachedTokens + maybe 0 (.cachedTokens) turn.turnUsage
             }
-    writeSessionMeta handle.sessionMetaPath meta
-    pure handle { sessionMeta = meta }
+        finalMeta = updateMeta meta
+    writeSessionMeta handle.sessionMetaPath finalMeta
+    pure handle { sessionMeta = finalMeta }
 
 sessionConversationText :: [SessionTurn] -> Text
 sessionConversationText =

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -1827,8 +1827,12 @@ handleUiEvents uiEvents = do
                 queueConversationReflow
             Nothing ->
                 vScrollToEnd (viewportScroll ConversationViewport)
+    -- An idle tick is the only batch that can leave the presentation
+    -- unchanged. Avoid comparing complete 'UiState' values here: that walks
+    -- the full conversation, including large streamed block bodies, on every
+    -- animation tick.
     when
-        (all (== UiTick) uiEvents && final.appUi == initial.appUi)
+        (all (== UiTick) uiEvents && not (uiNeedsTick initial.appUi))
         continueWithoutRedraw
   where
     applyOne

--- a/packages/agent-cli/src/Agent/CLI/Turn.hs
+++ b/packages/agent-cli/src/Agent/CLI/Turn.hs
@@ -37,11 +37,11 @@ import Agent.CLI.Session
     , Persistence(..)
     , PersistenceState(..)
     , appendTurn
+    , appendTurnWithMetaUpdate
     , ensureSession
     , loadSession
     , sessionConversationText
     , setGeneratedSessionTitle
-    , writeSessionMeta
     )
 import Agent.CLI.SessionEnv (SessionEnv(..))
 import Agent.CLI.SessionTitle
@@ -363,13 +363,11 @@ runOneTurn env@SessionEnv
                             , turnItems = newItems
                             , turnUsage = Just loopResult.tokenUsage
                             }
-                    handle' <- appendTurn handle turn
-                    titleTurns <- atomicModifyIORef' env.sessionTitleTurnCount \n ->
-                        let next = n + 1 in (next, next)
-                    let countedMeta = handle'.sessionMeta
-                            { metaTitleUserTurns = titleTurns }
-                        countedHandle = handle' { sessionMeta = countedMeta }
-                    writeSessionMeta countedHandle.sessionMetaPath countedMeta
+                    titleTurns <- (+ 1) <$> readIORef env.sessionTitleTurnCount
+                    countedHandle <- appendTurnWithMetaUpdate handle turn \meta ->
+                        meta { metaTitleUserTurns = titleTurns }
+                    writeIORef env.sessionTitleTurnCount titleTurns
+                    let countedMeta = countedHandle.sessionMeta
                     writeIORef slotRef (PersistenceActive countedHandle)
                     when
                         ( titleTurns `elem` [3, 6]

--- a/packages/agent-cli/test/Agent/CLI/SessionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SessionSpec.hs
@@ -123,6 +123,40 @@ spec = describe "Agent.CLI.Session" do
                 listed <- listSessions root
                 map (.metaId) listed `shouldBe` [handle.sessionMeta.metaId]
 
+        it "combines append metadata and a caller transition in one result" $
+            withTempDir "agent-sessions-" \root -> do
+                handle <- createSession (testCreate root)
+                let turn = SessionTurn
+                        { turnAt = fixedTime
+                        , turnUserText = "count this turn"
+                        , turnAssistantText = Just "done"
+                        , turnError = Nothing
+                        , turnResponseId = Just "resp-counted"
+                        , turnItems = []
+                        , turnUsage = Just TokenUsage
+                            { inputTokens = 7
+                            , outputTokens = 3
+                            , cachedTokens = 1
+                            }
+                        }
+                handle' <- appendTurnWithMetaUpdate handle turn \meta ->
+                    meta { metaTitleUserTurns = 1 }
+
+                handle'.sessionMeta.metaTitle `shouldBe` "count this turn"
+                handle'.sessionMeta.metaLastResponseId
+                    `shouldBe` Just "resp-counted"
+                handle'.sessionMeta.metaInputTokens `shouldBe` 7
+                handle'.sessionMeta.metaOutputTokens `shouldBe` 3
+                handle'.sessionMeta.metaCachedTokens `shouldBe` 1
+                handle'.sessionMeta.metaTitleUserTurns `shouldBe` 1
+
+                loaded <- loadSession root handle.sessionMeta.metaId
+                case loaded of
+                    Left err -> expectationFailure (Text.unpack err)
+                    Right (meta, turns) -> do
+                        meta `shouldBe` handle'.sessionMeta
+                        turns `shouldBe` [turn]
+
         it "rejects unsupported schema versions" $
             withTempDir "agent-sessions-" \root -> do
                 handle <- createSession (testCreate root)


### PR DESCRIPTION
## Summary

- avoid comparing the complete TUI transcript on idle animation ticks
- reconstruct resumed response items in linear time and hydrate UI history strictly
- combine successful-turn metadata updates into the existing metadata write
- add coverage for composing caller metadata updates with turn-derived metadata

## Validation

- loaded all 55 `agent-cli` library modules and all 50 CLI test modules in GHCi
- ran focused `Agent.CLI.Session` and `Agent.CLI.SessionTitle` tests: 17 examples, 0 failures
- smoke-tested the fullscreen UI in a real tmux TTY and confirmed it reached the Ready prompt
- `git diff --check`
