### PR TITLE
fix(security): redact sensitive Show output

### DIFF
--- a/packages/agent-core/src/Agent/InterAgentMessage.hs
+++ b/packages/agent-core/src/Agent/InterAgentMessage.hs
@@ -27,14 +27,29 @@ data InterAgentMessageType
 data InterAgentMessageContent
     = PlainInterAgentContent !Text
     | EncryptedInterAgentContent !Text
-    deriving (Eq, Show)
+    deriving (Eq)
+
+instance Show InterAgentMessageContent where
+    show = \case
+        PlainInterAgentContent text ->
+            "PlainInterAgentContent " <> show text
+        EncryptedInterAgentContent _ ->
+            "EncryptedInterAgentContent <redacted>"
 
 data InterAgentMessage = InterAgentMessage
     { messageAuthor :: !Text
     , messageRecipient :: !Text
     , messageType :: !InterAgentMessageType
     , messageContent :: !InterAgentMessageContent
-    } deriving (Eq, Show)
+    } deriving (Eq)
+
+instance Show InterAgentMessage where
+    show message =
+        "InterAgentMessage { messageAuthor = " <> show message.messageAuthor
+            <> ", messageRecipient = " <> show message.messageRecipient
+            <> ", messageType = " <> show message.messageType
+            <> ", messageContent = " <> show message.messageContent
+            <> " }"
 
 plainInterAgentContent :: Text -> InterAgentMessageContent
 plainInterAgentContent = PlainInterAgentContent

--- a/packages/agent-core/src/Agent/Loop.hs
+++ b/packages/agent-core/src/Agent/Loop.hs
@@ -36,6 +36,7 @@ import Control.Concurrent.MVar (newMVar, withMVar)
 import Control.Exception (SomeException)
 import Data.Aeson (FromJSON(..), ToJSON(..), object, withObject, (.:), (.:?), (.!=), (.=))
 import Data.ByteString (ByteString)
+import qualified Data.ByteString as ByteString
 import Data.Text (Text)
 import qualified Data.Text as Text
 
@@ -43,7 +44,14 @@ import qualified Data.Text as Text
 data ImageAttachment = ImageAttachment
     { imageMime :: !Text
     , imageBytes :: !ByteString
-    } deriving (Eq, Show)
+    } deriving (Eq)
+
+instance Show ImageAttachment where
+    show image =
+        "ImageAttachment { imageMime = " <> show image.imageMime
+            <> ", imageBytes = <redacted>"
+            <> ", imageByteLength = " <> show (ByteString.length image.imageBytes)
+            <> " }"
 
 data TurnInput
     = UserMessage Text

--- a/packages/agent-core/src/Agent/ToolDispatch.hs
+++ b/packages/agent-core/src/Agent/ToolDispatch.hs
@@ -45,7 +45,20 @@ data ToolCall = ToolCall
     , arguments :: !Text
     , callKind :: !ToolCallKind
     , argumentsEncrypted :: !Bool
-    } deriving (Eq, Show)
+    } deriving (Eq)
+
+instance Show ToolCall where
+    show call =
+        "ToolCall { callId = " <> show call.callId
+            <> ", name = " <> show call.name
+            <> ", arguments = " <> shownArguments
+            <> ", callKind = " <> show call.callKind
+            <> ", argumentsEncrypted = " <> show call.argumentsEncrypted
+            <> " }"
+      where
+        shownArguments
+            | call.argumentsEncrypted = "<redacted>"
+            | otherwise = show call.arguments
 
 -- | Provider-neutral result ready for a transport adapter to encode.
 data ToolCallResult = ToolCallResult

--- a/packages/agent-core/test/Agent/LoopSpec.hs
+++ b/packages/agent-core/test/Agent/LoopSpec.hs
@@ -21,6 +21,14 @@ import Test.Hspec
 
 spec :: Spec
 spec = describe "runLoop" do
+    it "shows image metadata without exposing attachment bytes" do
+        let image = ImageAttachment "image/png" "secret-image-bytes"
+            rendered = show image
+        rendered `shouldContain` "image/png"
+        rendered `shouldContain` "imageByteLength = 18"
+        rendered `shouldContain` "<redacted>"
+        rendered `shouldNotContain` "secret-image-bytes"
+
     it "combines TokenUsage component-wise" do
         TokenUsage 10 4 6 <> TokenUsage 3 2 1
             `shouldBe` TokenUsage 13 6 7

--- a/packages/agent-core/test/Agent/ToolDispatchSpec.hs
+++ b/packages/agent-core/test/Agent/ToolDispatchSpec.hs
@@ -18,6 +18,24 @@ instance FromJSON EchoArgs where
 
 spec :: Spec
 spec = describe "dispatchToolCall" do
+    it "keeps plaintext tool arguments useful in Show output" do
+        let rendered =
+                show (functionToolCall "call-visible" "echo" "{\"message\":\"hello\"}")
+        rendered `shouldContain` "call-visible"
+        rendered `shouldContain` "echo"
+        rendered `shouldContain` "message"
+        rendered `shouldContain` "hello"
+
+    it "redacts encrypted tool arguments from Show output" do
+        let secret = "encrypted-tool-argument"
+            call = (functionToolCall "call-secret" "collaboration.spawn_agent" secret)
+                { argumentsEncrypted = True }
+            rendered = show call
+        rendered `shouldContain` "call-secret"
+        rendered `shouldContain` "collaboration.spawn_agent"
+        rendered `shouldContain` "<redacted>"
+        rendered `shouldNotContain` "encrypted-tool-argument"
+
     it "decodes typed tool arguments before running the handler" do
         result <- dispatchToolCall testConfig
             [ typedTool "echo" \(EchoArgs message) ->

--- a/packages/agent-core/test/Agent/Tools/MultiAgentsSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/MultiAgentsSpec.hs
@@ -32,6 +32,25 @@ fromFilePath = unsafeEncodeUtf
 
 spec :: Spec
 spec = describe "Agent.Tools.MultiAgents" do
+    it "keeps plaintext inter-agent content useful in Show output" do
+        let rendered = show (PlainInterAgentContent "visible task")
+        rendered `shouldContain` "PlainInterAgentContent"
+        rendered `shouldContain` "visible task"
+
+    it "redacts encrypted inter-agent content from Show output" do
+        let secret = "gAAAAA-secret-ciphertext"
+            message = InterAgentMessage
+                { messageAuthor = "/root"
+                , messageRecipient = "/root/worker"
+                , messageType = NewTaskMessage
+                , messageContent = EncryptedInterAgentContent secret
+                }
+            rendered = show message
+        rendered `shouldContain` "/root/worker"
+        rendered `shouldContain` "NewTaskMessage"
+        rendered `shouldContain` "<redacted>"
+        rendered `shouldNotContain` "gAAAAA-secret-ciphertext"
+
     it "allows collaboration coordination without approval" do
         registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
             (\_ _ _ _ -> pure $ Left LoopNoResponseId)

--- a/packages/agent-openai/src/Agent/OpenAI/Auth/Types.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Auth/Types.hs
@@ -10,4 +10,14 @@ data AuthState = AuthState
     , accountId    :: !Text
     , idToken      :: !(Maybe Text)
     , lastRefresh  :: !UTCTime
-    } deriving (Show)
+    }
+
+-- Keep bearer, refresh, and identity tokens out of logs and test failures.
+instance Show AuthState where
+    show state =
+        "AuthState { accessToken = <redacted>, refreshToken = <redacted>"
+            <> ", accountId = " <> show state.accountId
+            <> ", idToken = "
+            <> maybe "Nothing" (const "Just <redacted>") state.idToken
+            <> ", lastRefresh = " <> show state.lastRefresh
+            <> " }"

--- a/packages/agent-openai/src/Agent/OpenAI/Login.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Login.hs
@@ -46,7 +46,16 @@ data DeviceCode = DeviceCode
     , userCode :: !Text
     , deviceAuthId :: !Text
     , pollIntervalSeconds :: !Int
-    } deriving (Eq, Show)
+    } deriving (Eq)
+
+-- Device authorization values grant access while the login flow is pending.
+-- In particular, verification URLs may embed the user code.
+instance Show DeviceCode where
+    show code =
+        "DeviceCode { verificationUrl = <redacted>, userCode = <redacted>"
+            <> ", deviceAuthId = <redacted>"
+            <> ", pollIntervalSeconds = " <> show code.pollIntervalSeconds
+            <> " }"
 
 data Tokens = Tokens
     { idToken :: !Text

--- a/packages/agent-openai/test/Agent/OpenAI/AuthSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/AuthSpec.hs
@@ -17,6 +17,40 @@ import Test.Hspec
 
 spec :: Spec
 spec = do
+    describe "Show" do
+        it "redacts every token while retaining account metadata" do
+            let auth = AuthState
+                    { accessToken = "access-secret"
+                    , refreshToken = "refresh-secret"
+                    , accountId = "acc-visible"
+                    , idToken = Just "identity-secret"
+                    , lastRefresh = epoch
+                    }
+                rendered = show auth
+            rendered `shouldContain` "acc-visible"
+            rendered `shouldContain` show epoch
+            rendered `shouldNotContain` "access-secret"
+            rendered `shouldNotContain` "refresh-secret"
+            rendered `shouldNotContain` "identity-secret"
+
+        it "keeps AccountSnapshot token-safe through its Show instance" do
+            let auth = AuthState
+                    { accessToken = "snapshot-access-secret"
+                    , refreshToken = "snapshot-refresh-secret"
+                    , accountId = "snapshot-account"
+                    , idToken = Just "snapshot-id-secret"
+                    , lastRefresh = epoch
+                    }
+                snapshot = AccountSnapshot
+                    { snapshotAuth = auth
+                    , snapshotCooldownUntil = Just epoch
+                    }
+                rendered = show snapshot
+            rendered `shouldContain` "snapshot-account"
+            rendered `shouldNotContain` "snapshot-access-secret"
+            rendered `shouldNotContain` "snapshot-refresh-secret"
+            rendered `shouldNotContain` "snapshot-id-secret"
+
     describe "parseJwtExp" $ do
         it "parses exp claim from a well-formed JWT" $ do
             let expSeconds = 4_102_444_800 :: Int  -- 2100-01-01 00:00:00 UTC

--- a/packages/agent-openai/test/Agent/OpenAI/LoginSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/LoginSpec.hs
@@ -1,6 +1,6 @@
 module Agent.OpenAI.LoginSpec (spec) where
 
-import Agent.OpenAI.Login (writeAuthFile)
+import Agent.OpenAI.Login (DeviceCode(..), writeAuthFile)
 import System.OsPath (unsafeEncodeUtf)
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy as LBS
@@ -13,6 +13,20 @@ fromFilePath = unsafeEncodeUtf
 
 spec :: Spec
 spec = describe "Agent.OpenAI.Login" do
+    it "redacts device authorization credentials from Show output" do
+        let code = DeviceCode
+                { verificationUrl =
+                    "https://auth.example/device?user_code=USER-SECRET"
+                , userCode = "USER-SECRET"
+                , deviceAuthId = "DEVICE-AUTH-SECRET"
+                , pollIntervalSeconds = 7
+                }
+            rendered = show code
+        rendered `shouldContain` "pollIntervalSeconds = 7"
+        rendered `shouldNotContain` "USER-SECRET"
+        rendered `shouldNotContain` "DEVICE-AUTH-SECRET"
+        rendered `shouldNotContain` "https://auth.example"
+
     it "writes auth JSON with owner-only permissions" $
         withSystemTempDirectory "codex-hs-login" \directory -> do
             let path = directory </> "nested" </> "auth.json"

--- a/packages/agent-openai/test/Agent/OpenAI/ResponsesSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/ResponsesSpec.hs
@@ -6,6 +6,7 @@ import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KeyMap
 import qualified Data.ByteString.Lazy as LBS
 import Data.Text (Text)
+import qualified Data.Text as T
 import qualified Data.Text.Encoding as Text
 import Test.Hspec
 
@@ -61,6 +62,29 @@ spec = do
                 `shouldSatisfy` isLeft
 
     describe "canonical Responses items and tools" do
+        it "redacts encrypted reasoning content from Show output" do
+            let secret = "encrypted-reasoning-secret"
+                item = Responses.ReasoningItem
+                    { itemId = Just "reasoning_1"
+                    , summary =
+                        [ Responses.ReasoningSummaryPart
+                            { partType = "summary_text"
+                            , text = Just "safe summary"
+                            , extraFields = mempty
+                            }
+                        ]
+                    , content = Nothing
+                    , encryptedContent = Just secret
+                    , status = Just Responses.ItemCompleted
+                    , extraFields = KeyMap.singleton "safe_extension" (Aeson.String "visible")
+                    }
+                rendered = show item
+            rendered `shouldNotContain` T.unpack secret
+            rendered `shouldContain` "encryptedContent = Just <redacted>"
+            rendered `shouldContain` "reasoning_1"
+            rendered `shouldContain` "safe_extension"
+            rendered `shouldContain` "ItemCompleted"
+
         it "builds strict function tools in the canonical tool union" do
             case buildTool "lookup" "Look something up"
                     [PropertySchema "query" PropertyString True Nothing] of

--- a/packages/agent-responses/src/Agent/Responses/Types.hs
+++ b/packages/agent-responses/src/Agent/Responses/Types.hs
@@ -784,7 +784,20 @@ data ReasoningItem = ReasoningItem
     , encryptedContent :: !(Maybe Text)
     , status           :: !(Maybe ItemStatus)
     , extraFields      :: !Aeson.Object
-    } deriving stock (Eq, Show)
+    } deriving stock (Eq)
+
+-- Keep opaque encrypted reasoning payloads out of logs while retaining enough
+-- structure to diagnose response-shape and lifecycle issues.
+instance Show ReasoningItem where
+    show item =
+        "ReasoningItem { itemId = " <> show item.itemId
+            <> ", summary = " <> show item.summary
+            <> ", content = " <> show item.content
+            <> ", encryptedContent = "
+            <> maybe "Nothing" (const "Just <redacted>") item.encryptedContent
+            <> ", status = " <> show item.status
+            <> ", extraFields = " <> show item.extraFields
+            <> " }"
 
 instance ToJSON ReasoningItem where
     toJSON ReasoningItem { itemId, summary, content, encryptedContent, status, extraFields } = objectWith extraFields

--- a/packages/agent-xai/src/Agent/XAI/Auth.hs
+++ b/packages/agent-xai/src/Agent/XAI/Auth.hs
@@ -82,7 +82,18 @@ data DeviceAuthorization = DeviceAuthorization
     , verificationUrl :: !Text
     , pollIntervalSeconds :: !Int
     , expiresInSeconds :: !(Maybe Int)
-    } deriving (Eq, Show)
+    } deriving (Eq)
+
+-- Device and user codes are temporary credentials, and the preferred
+-- verification URL may carry the user code in its query string.
+instance Show DeviceAuthorization where
+    show authorization =
+        "DeviceAuthorization { deviceCode = <redacted>, userCode = <redacted>"
+            <> ", verificationUrl = <redacted>"
+            <> ", pollIntervalSeconds = "
+            <> show authorization.pollIntervalSeconds
+            <> ", expiresInSeconds = " <> show authorization.expiresInSeconds
+            <> " }"
 
 instance Aeson.FromJSON DeviceAuthorization where
     parseJSON = Aeson.withObject "DeviceAuthorization" \object -> do

--- a/packages/agent-xai/test/Agent/XAI/AuthSpec.hs
+++ b/packages/agent-xai/test/Agent/XAI/AuthSpec.hs
@@ -18,6 +18,23 @@ import Test.Hspec
 
 spec :: Spec
 spec = do
+    describe "DeviceAuthorization Show" do
+        it "redacts codes and code-bearing verification URLs" do
+            let authorization = DeviceAuthorization
+                    { deviceCode = "device-secret"
+                    , userCode = "USER-SECRET"
+                    , verificationUrl =
+                        "https://accounts.example/activate?code=USER-SECRET"
+                    , pollIntervalSeconds = 7
+                    , expiresInSeconds = Just 600
+                    }
+                rendered = show authorization
+            rendered `shouldContain` "pollIntervalSeconds = 7"
+            rendered `shouldContain` "expiresInSeconds = Just 600"
+            rendered `shouldNotContain` "device-secret"
+            rendered `shouldNotContain` "USER-SECRET"
+            rendered `shouldNotContain` "https://accounts.example"
+
     describe "requestDeviceAuthorization" do
         it "posts the configured client id and scopes, and prefers the complete verification URL" do
             recorded <- newIORef []


### PR DESCRIPTION
## Summary

- redact bearer, refresh, identity, device, and encrypted reasoning/message payloads from `Show`
- preserve useful non-secret metadata for debugging
- report image attachment MIME type and byte length without rendering raw bytes
- add regression coverage across core, OpenAI, Responses, and xAI packages

## Tests

- `nix develop -c cabal repl agent-core:test:agent-core-test --repl-options='-e main'` — 241 examples, 0 failures
- `nix develop -c cabal repl agent-openai:test:agent-openai-test --repl-options='-e main'` — 165 examples, 0 failures, 1 live test pending
- `nix develop -c cabal repl agent-xai:test:agent-xai-test --repl-options='-e main'` — 41 examples, 0 failures, 1 live test pending
