### PR TITLE
fix(openai): serialize account token refreshes

### DIFF
--- a/packages/agent-openai/agent-openai.cabal
+++ b/packages/agent-openai/agent-openai.cabal
@@ -124,6 +124,7 @@ test-suite agent-openai-test
                     , agent-core
                     , agent-openai
                     , agent-responses
+                    , async
                     , hspec
                     , aeson
                     , retry >= 0.9.3.1 && < 0.10

--- a/packages/agent-openai/package.nix
+++ b/packages/agent-openai/package.nix
@@ -1,4 +1,4 @@
-{ mkDerivation, aeson, agent-core, agent-responses, base, base64-bytestring
+{ mkDerivation, aeson, agent-core, agent-responses, async, base, base64-bytestring
 , bytestring, case-insensitive, containers, directory, exceptions
 , filepath, hashable, HsOpenSSL, hspec, http-client
 , http-client-tls, http-conduit, http-streams, http-types
@@ -22,7 +22,7 @@ mkDerivation {
     agent-core base directory filepath text
   ];
   testHaskellDepends = [
-    aeson agent-core agent-responses base base64-bytestring bytestring case-insensitive
+    aeson agent-core agent-responses async base base64-bytestring bytestring case-insensitive
     directory filepath hspec http-types retry temporary text time unix
     vector wai warp websockets
   ];

--- a/packages/agent-openai/src/Agent/OpenAI/Auth.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Auth.hs
@@ -70,6 +70,7 @@ data AccountEntry = AccountEntry
     { entryAccountId     :: !Text
     , entryAuthRef       :: !(IORef AuthState)
     , entryCooldownUntil :: !(IORef (Maybe UTCTime))
+    , entryRefreshLock   :: !(MVar ())
     }
 
 -- | Optional source of newly available accounts. The callback receives every
@@ -199,10 +200,12 @@ mkEntry :: AuthState -> IO AccountEntry
 mkEntry state = do
     authRef <- newIORef state
     cooldownRef <- newIORef Nothing
+    refreshLock <- newMVar ()
     pure AccountEntry
         { entryAccountId = state.accountId
         , entryAuthRef = authRef
         , entryCooldownUntil = cooldownRef
+        , entryRefreshLock = refreshLock
         }
 
 --------------------------------------------------------------------------------
@@ -254,22 +257,46 @@ getAccessTokenWithDiscovery pool allowDiscovery = do
             picked <- pickAccount pool
             case picked of
                 Left earliest -> pure $ Left (CredentialsExhausted earliest)
-                Right entry -> do
-                    state <- readIORef entry.entryAuthRef
-                    now <- getCurrentTime
-                    if needsRefresh state now
-                        then do
-                            result <- pool.poolRefresh state
-                            case result of
-                                Right new -> do
-                                    writeIORef entry.entryAuthRef new
-                                    pure $ Right (new.accessToken, new.accountId)
-                                Left err
-                                    | isAuthError err -> do
-                                        reportAuthBroken pool state.accountId
-                                        go (attemptsLeft - 1)
-                                    | otherwise -> pure $ Left err
-                        else pure $ Right (state.accessToken, state.accountId)
+                Right entry ->
+                    currentAuthState pool entry >>= \case
+                        Right state ->
+                            pure $ Right (state.accessToken, state.accountId)
+                        Left err
+                            | isAuthError err -> do
+                                reportAuthBroken pool entry.entryAccountId
+                                go (attemptsLeft - 1)
+                            | otherwise -> pure $ Left err
+
+-- | Read a checkout state while serialized with every refresh for this
+-- account. Always taking the lock prevents an in-flight forced refresh from
+-- handing another caller the rejected token it is replacing. Re-checking
+-- expiry after acquiring it makes concurrent expiry-driven checkouts share
+-- the first successful refresh.
+currentAuthState
+    :: Pool
+    -> AccountEntry
+    -> IO (Either ApiError AuthState)
+currentAuthState pool entry =
+    withMVar entry.entryRefreshLock \_ -> do
+        state <- readIORef entry.entryAuthRef
+        now <- getCurrentTime
+        if needsRefresh state now
+            then refreshEntry pool entry state
+            else pure (Right state)
+
+-- | Invoke the refresh callback and commit its result. The caller must hold
+-- 'entryRefreshLock'.
+refreshEntry
+    :: Pool
+    -> AccountEntry
+    -> AuthState
+    -> IO (Either ApiError AuthState)
+refreshEntry pool entry state =
+    pool.poolRefresh state >>= \case
+        Right new -> do
+            writeIORef entry.entryAuthRef new
+            pure (Right new)
+        Left err -> pure (Left err)
 
 -- | Ask the dynamic source only for accounts this process has never seen.
 -- Broker outages do not replace a precise local 'CredentialsExhausted' reset time
@@ -454,8 +481,8 @@ snapshotAccounts pool = do
 -- | Force a refresh of the given account, regardless of JWT expiry. Useful
 -- for scheduled refresh jobs that rotate ahead of the natural expiry window.
 --
--- Invokes the pool's refresh callback — serialisation against concurrent
--- in-path refreshes is the callback's responsibility (e.g. via a Postgres
+-- Refreshes for the same account are serialized within this pool. The callback
+-- remains responsible for cross-process serialization (e.g. via a Postgres
 -- row-level lock). On success the new state is written back to the pool's
 -- in-memory cache.
 forceRefresh :: Pool -> Text -> IO (Either ApiError AuthState)
@@ -465,12 +492,9 @@ forceRefresh pool targetAccountId = do
         Nothing ->
             pure $ Left (ProviderError AuthenticationError
                 ("Agent.OpenAI.Auth.forceRefresh: unknown accountId " <> targetAccountId) Nothing)
-        Just entry -> do
+        Just entry -> withMVar entry.entryRefreshLock \_ -> do
             state <- readIORef entry.entryAuthRef
-            result <- pool.poolRefresh state
-            case result of
-                Right new -> writeIORef entry.entryAuthRef new >> pure (Right new)
-                Left err  -> pure (Left err)
+            refreshEntry pool entry state
 
 findEntry :: Pool -> Text -> IO (Maybe AccountEntry)
 findEntry pool targetAccountId = do

--- a/packages/agent-openai/test/Agent/OpenAI/AuthSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/AuthSpec.hs
@@ -2,6 +2,12 @@ module Agent.OpenAI.AuthSpec (spec) where
 
 import Agent.OpenAI.Auth
 import Agent.Error (ApiError(..), ErrorType(..))
+import Control.Concurrent.Async (wait, withAsync)
+import Control.Concurrent.MVar
+    ( newEmptyMVar
+    , putMVar
+    , takeMVar
+    )
 import qualified Data.Aeson as Aeson
 import Data.Aeson ((.=))
 import qualified "base64-bytestring" Data.ByteString.Base64 as B64
@@ -13,6 +19,7 @@ import Data.Text (Text)
 import qualified Data.Text.Encoding as Text
 import Data.Time.Calendar (fromGregorian)
 import Data.Time.Clock (UTCTime(..), addUTCTime, getCurrentTime)
+import System.Timeout (timeout)
 import Test.Hspec
 
 spec :: Spec
@@ -93,6 +100,45 @@ spec = do
             result <- getAccessToken pool
             result `shouldSatisfy` isRight
             readIORef callCounter `shouldReturn` 0
+
+        it "shares one successful refresh across concurrent expired checkouts" do
+            refreshCalls <- newIORef (0 :: Int)
+            firstRefreshStarted <- newEmptyMVar
+            laterRefreshStarted <- newEmptyMVar
+            releaseFirstRefresh <- newEmptyMVar
+            secondCheckoutStarted <- newEmptyMVar
+            let refreshed = (mkFreshAuth "acc")
+                    { refreshToken = "rotated-refresh" }
+                refresh _ = do
+                    callNumber <- atomicModifyIORef' refreshCalls \n ->
+                        let next = n + 1
+                        in (next, next)
+                    if callNumber == 1
+                        then do
+                            putMVar firstRefreshStarted ()
+                            takeMVar releaseFirstRefresh
+                        else putMVar laterRefreshStarted ()
+                    pure (Right refreshed)
+            pool <- newPool [mkExpiredAuth "acc"] refresh
+
+            withAsync (getAccessToken pool) \firstCheckout -> do
+                takeMVar firstRefreshStarted
+                withAsync
+                    (putMVar secondCheckoutStarted () >> getAccessToken pool)
+                    \secondCheckout -> do
+                        takeMVar secondCheckoutStarted
+                        overlappingRefresh <- timeout concurrencyProbeMicros
+                            (takeMVar laterRefreshStarted)
+                        putMVar releaseFirstRefresh ()
+                        firstResult <- wait firstCheckout
+                        secondResult <- wait secondCheckout
+
+                        overlappingRefresh `shouldBe` Nothing
+                        readIORef refreshCalls `shouldReturn` 1
+                        firstResult `shouldBe`
+                            Right (refreshed.accessToken, refreshed.accountId)
+                        secondResult `shouldBe`
+                            Right (refreshed.accessToken, refreshed.accountId)
 
         it "alternates between accounts on consecutive calls (round-robin)" $ do
             callCounter <- newIORef (0 :: Int)
@@ -248,6 +294,39 @@ spec = do
             mAfter <- readAccountState pool "acc"
             fmap (.refreshToken) mAfter `shouldBe` Just "rotated-refresh"
 
+        it "blocks checkouts until the forced replacement is committed" do
+            refreshStarted <- newEmptyMVar
+            releaseRefresh <- newEmptyMVar
+            checkoutStarted <- newEmptyMVar
+            let startState = mkFreshAuth "acc"
+                rotated = startState
+                    { accessToken = (mkFreshAuth "rotated").accessToken
+                    , refreshToken = "rotated-refresh"
+                    }
+                refresh _ = do
+                    putMVar refreshStarted ()
+                    takeMVar releaseRefresh
+                    pure (Right rotated)
+            pool <- newPool [startState] refresh
+
+            withAsync (forceRefresh pool "acc") \forcedRefresh -> do
+                takeMVar refreshStarted
+                withAsync
+                    (putMVar checkoutStarted () >> getAccessToken pool)
+                    \checkout -> do
+                        takeMVar checkoutStarted
+                        earlyCheckout <- timeout concurrencyProbeMicros
+                            (wait checkout)
+                        putMVar releaseRefresh ()
+                        forcedResult <- wait forcedRefresh
+                        checkoutResult <- wait checkout
+
+                        earlyCheckout `shouldBe` Nothing
+                        fmap (.accessToken) forcedResult
+                            `shouldBe` Right rotated.accessToken
+                        checkoutResult `shouldBe`
+                            Right (rotated.accessToken, rotated.accountId)
+
         it "returns Left with an AuthenticationError when the accountId is unknown" $ do
             pool <- newPool [mkFreshAuth "acc"] neverRefresh
             outcome <- forceRefresh pool "does-not-exist"
@@ -315,6 +394,9 @@ spec = do
 
 epoch :: UTCTime
 epoch = UTCTime (fromGregorian 1970 1 1) 0
+
+concurrencyProbeMicros :: Int
+concurrencyProbeMicros = 250_000
 
 -- | Build an 'AuthState' with a JWT whose exp is the year 2100 — well past
 -- the refresh-margin threshold, so 'needsRefresh' returns False.


### PR DESCRIPTION
## Summary

- add a per-account refresh lock to the OpenAI OAuth pool
- re-read auth state and re-check expiry while holding the lock
- coalesce concurrent expired-token checkouts onto one successful refresh
- serialize `forceRefresh` with normal checkouts so callers cannot receive the token being replaced
- keep cross-process refresh serialization as the callback's responsibility

## Tests

- added barrier-based concurrency coverage for concurrent expired-token checkouts
- added coverage proving checkouts wait for a forced replacement to be committed
- `nix develop -c cabal repl agent-openai:test:agent-openai-test --repl-options='-e main'` — 163 examples, 0 failures, 1 live test pending
- evaluated `.#checks.aarch64-darwin.agent-openai.drvPath` successfully
