### PR TITLE
fix(openai): fail over exhausted resumed sessions

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -1030,7 +1030,7 @@ runAgentInitialized options transition home root resumed cwd startup = do
                 case provider of
                     OpenAIProvider ->
                         try @_ @CodexAuthFailed
-                            (withCodexWsWithProvider loaded.loadedTokenProvider \conn _credential -> do
+                            (withCodexWsWithProvider loaded.loadedTokenProvider \conn credential -> do
                                 wsLock <- newMVar ()
                                 wsHealthy <- newIORef True
                                 case multiCtx of
@@ -1045,6 +1045,7 @@ runAgentInitialized options transition home root resumed cwd startup = do
                                         lockedOpenAiBackend
                                             wsLock
                                             loaded.loadedTokenProvider
+                                            credential
                                             wsHealthy
                                             conn
                                             (readIORef paramsRef)
@@ -3540,16 +3541,18 @@ currentSessionId = \case
 lockedOpenAiBackend
     :: MVar ()
     -> TokenProvider
+    -> Credential
     -> IORef Bool
     -> CodexConn
     -> IO ResponseCreateParams
     -> IORef [ResponseItem]
     -> IORef (Maybe (Int, Int))
     -> Backend
-lockedOpenAiBackend wsLock provider connectionHealthy conn getParams transcript
+lockedOpenAiBackend wsLock provider credential connectionHealthy conn getParams transcript
         contextTokens =
     let Backend submit =
-            openAiBackendReconnecting provider connectionHealthy conn getParams transcript
+            openAiBackendReconnecting
+                provider credential connectionHealthy conn getParams transcript
         serialized = Backend \previous inputs onEvent ->
             withMVar wsLock \_ -> submit previous inputs onEvent
     in autoCompactOpenAiBackend provider

--- a/packages/agent-core/src/Agent/Provider.hs
+++ b/packages/agent-core/src/Agent/Provider.hs
@@ -9,6 +9,7 @@ module Agent.Provider
     , AccountFailure(..)
     , getNextToken
     , runWithTokenProvider
+    , runWithTokenProviderAfter
     , seedTokenProvider
     , accountFailureFromApiError
     ) where
@@ -91,8 +92,21 @@ runWithTokenProvider
     :: TokenProvider
     -> (Credential -> IO (Either ApiError a))
     -> IO (Either ApiError a)
-runWithTokenProvider provider action =
-    go maxProviderFailoverAttempts Nothing
+runWithTokenProvider provider =
+    runWithTokenProviderAfter provider Nothing
+
+-- | Run an action after reporting a credential that already failed outside
+-- this invocation. This is used when a long-lived transport (for example a
+-- resumed session WebSocket) encounters an in-band account failure: the
+-- replacement checkout must cool down that exact account before selecting
+-- another credential.
+runWithTokenProviderAfter
+    :: TokenProvider
+    -> Maybe FailedCredential
+    -> (Credential -> IO (Either ApiError a))
+    -> IO (Either ApiError a)
+runWithTokenProviderAfter provider initialFailure action =
+    go maxProviderFailoverAttempts initialFailure
   where
     go attemptsLeft failed
         | attemptsLeft <= 0 = pure $ Left $ ConnectionError

--- a/packages/agent-openai/src/Agent/OpenAI/LoopBackend.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/LoopBackend.hs
@@ -30,8 +30,14 @@ import Agent.OpenAI.WebSocketClient
     ( CodexConn
     , sendWsRequestWithEvents
     , withCodexWsRetrying
+    , withCodexWsRetryingAfter
     )
-import Agent.Provider (TokenProvider, accountFailureFromApiError)
+import Agent.Provider
+    ( Credential
+    , FailedCredential(..)
+    , TokenProvider
+    , accountFailureFromApiError
+    )
 import Agent.Responses.LoopBackend
     ( assistantTextFromResponse
     , responseToTurnOutput
@@ -77,19 +83,29 @@ openAiBackend conn =
 -- | Reuse the session WebSocket while it is healthy, reconnecting after it dies.
 openAiBackendReconnecting
     :: TokenProvider
+    -> Credential
     -> IORef Bool
     -> CodexConn
     -> IO ResponseCreateParams
     -> IORef [ResponseItem]
     -> Backend
-openAiBackendReconnecting provider connectionHealthy conn =
+openAiBackendReconnecting provider currentCredential connectionHealthy conn =
     openAiBackendWithConnectionRecovery connectionHealthy sendCurrent sendFresh
   where
     sendCurrent request previousResponseId onEvent =
         sendWsRequestWithEvents conn request previousResponseId onEvent
-    sendFresh request previousResponseId onEvent =
-        withCodexWsRetrying provider
-            (sendOnFresh request previousResponseId onEvent)
+    sendFresh previousFailure request previousResponseId onEvent =
+        case previousFailure >>= accountFailureFromApiError of
+            Just failure ->
+                withCodexWsRetryingAfter provider
+                    FailedCredential
+                        { credential = currentCredential
+                        , failure
+                        }
+                    (sendOnFresh request previousResponseId onEvent)
+            Nothing ->
+                withCodexWsRetrying provider
+                    (sendOnFresh request previousResponseId onEvent)
     sendOnFresh request previousResponseId onEvent freshConn _credential =
         sendWsRequestWithEvents freshConn request previousResponseId onEvent
 
@@ -100,7 +116,8 @@ openAiBackendWithConnectionRecovery
         -> Maybe Text
         -> (ResponseStreamEvent -> IO ())
         -> IO (Either ApiError Response))
-    -> (ResponseCreateParams
+    -> (Maybe ApiError
+        -> ResponseCreateParams
         -> Maybe Text
         -> (ResponseStreamEvent -> IO ())
         -> IO (Either ApiError Response))
@@ -114,7 +131,7 @@ openAiBackendWithConnectionRecovery connectionHealthy sendCurrent sendFresh =
         healthy <- readIORef connectionHealthy
         if healthy
             then tryCurrent request previousResponseId onEvent
-            else sendFresh request previousResponseId onEvent
+            else sendFresh Nothing request previousResponseId onEvent
 
     tryCurrent request previousResponseId onEvent = do
         emittedLoopEvent <- newIORef False
@@ -128,7 +145,7 @@ openAiBackendWithConnectionRecovery connectionHealthy sendCurrent sendFresh =
                     emitted <- readIORef emittedLoopEvent
                     if emitted
                         then pure result
-                        else sendFresh request previousResponseId onEvent
+                        else sendFresh (Just err) request previousResponseId onEvent
             _ -> pure result
 
     trackOutput emittedLoopEvent onEvent event = do

--- a/packages/agent-openai/src/Agent/OpenAI/WebSocketClient.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/WebSocketClient.hs
@@ -2,6 +2,7 @@ module Agent.OpenAI.WebSocketClient
     ( withCodexWs
     , withCodexWsWithProvider
     , withCodexWsRetrying
+    , withCodexWsRetryingAfter
     , sendWsRequest
     , sendWsRequestWithOptions
     , sendWsRequestWithEvents
@@ -25,9 +26,11 @@ import qualified Agent.Responses.Codec as ResponsesCodec
 import qualified Agent.Transport.WebSocket as WebSocket
 import Agent.Provider
     ( Credential(..)
+    , FailedCredential
     , Provider(..)
     , TokenProvider
     , runWithTokenProvider
+    , runWithTokenProviderAfter
     )
 import Agent.Responses.Types
 import Control.Retry
@@ -124,6 +127,18 @@ withCodexWsRetrying
     -> IO (Either ApiError a)
 withCodexWsRetrying provider action =
     runWithTokenProvider provider \credential ->
+        runConnectionAttempt credential action
+
+-- | Like 'withCodexWsRetrying', but first reports a credential that failed on
+-- an already-open connection. This ensures an exhausted resumed-session
+-- account is cooled down before a replacement WebSocket credential is chosen.
+withCodexWsRetryingAfter
+    :: TokenProvider
+    -> FailedCredential
+    -> (CodexConn -> Credential -> IO (Either ApiError a))
+    -> IO (Either ApiError a)
+withCodexWsRetryingAfter provider failed action =
+    runWithTokenProviderAfter provider (Just failed) \credential ->
         runConnectionAttempt credential action
 
 runConnectionAttempt

--- a/packages/agent-openai/test/Agent/OpenAI/CredentialSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/CredentialSpec.hs
@@ -79,6 +79,21 @@ spec = do
             result `shouldBe` Left (ConnectionError "offline")
             readIORef acquisitions `shouldReturn` 1
 
+        it "reports an already-failed connection before choosing a replacement" do
+            reportedFailures <- newIORef ([] :: [Maybe FailedCredential])
+            let exhausted = credentialFor "acc-exhausted"
+                initialFailure =
+                    failed exhausted (AccountRateLimited (Just 120))
+                provider = TokenProvider \reported -> do
+                    modifyIORef' reportedFailures (<> [reported])
+                    pure $ Right (credentialFor "acc-healthy")
+
+            result <- runWithTokenProviderAfter provider initialFailure
+                (pure . Right . (.accountId))
+
+            result `shouldBe` Right "acc-healthy"
+            readIORef reportedFailures `shouldReturn` [initialFailure]
+
     describe "seedTokenProvider" do
         it "uses an acquired replacement exactly once before delegating" do
             acquisitions <- newIORef (0 :: Int)

--- a/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
@@ -449,7 +449,7 @@ spec = do
             let sendCurrent _request _previous _onEvent = do
                     modifyIORef' currentCalls (+ 1)
                     pure $ Left $ ConnectionError "socket closed"
-                sendFresh _request _previous _onEvent = do
+                sendFresh _failure _request _previous _onEvent = do
                     modifyIORef' freshCalls (+ 1)
                     pure $ Right (testResponse "resp-fresh" [assistantItem "ok"])
                 backend = openAiBackendWithConnectionRecovery
@@ -471,7 +471,7 @@ spec = do
             let sendCurrent _request _previous onEvent = do
                     onEvent (deltaEvent EventOutputTextDelta "partial")
                     pure $ Left $ ConnectionError "socket closed"
-                sendFresh _request _previous _onEvent = do
+                sendFresh _failure _request _previous _onEvent = do
                     modifyIORef' freshCalls (+ 1)
                     pure $ Right (testResponse "resp-fresh" [assistantItem "ok"])
                 streamingBackend = openAiBackendWithConnectionRecovery
@@ -489,7 +489,7 @@ spec = do
             transcript <- newIORef []
             let sendCurrent _request _previous _onEvent =
                     pure $ Left $ ProviderError InvalidRequestError "bad request" Nothing
-                sendFresh _request _previous _onEvent = do
+                sendFresh _failure _request _previous _onEvent = do
                     modifyIORef' freshCalls (+ 1)
                     pure $ Right (testResponse "resp-fresh" [assistantItem "ok"])
                 providerErrorBackend = openAiBackendWithConnectionRecovery
@@ -509,7 +509,7 @@ spec = do
                     modifyIORef' currentCalls (+ 1)
                     pure $ Left $ ProviderError WebSocketConnectionLimitReached
                         "too many websocket connections" Nothing
-                sendFresh _request _previous _onEvent = do
+                sendFresh _failure _request _previous _onEvent = do
                     modifyIORef' freshCalls (+ 1)
                     pure $ Right (testResponse "resp-fresh" [assistantItem "ok"])
                 backend = openAiBackendWithConnectionRecovery
@@ -528,7 +528,7 @@ spec = do
             let sendCurrent _request _previous _onEvent =
                     pure $ Left $ ProviderError UsageLimitReached
                         "usage limit reached" (Just 120)
-                sendFresh _request _previous _onEvent = do
+                sendFresh _failure _request _previous _onEvent = do
                     modifyIORef' freshCalls (+ 1)
                     pure $ Right (testResponse "resp-fresh" [assistantItem "ok"])
                 backend = openAiBackendWithConnectionRecovery
@@ -538,6 +538,41 @@ spec = do
             result `shouldBe` Right (emptyTurnOutput "resp-fresh" [] (Just "ok"))
             readIORef healthy `shouldReturn` False
             readIORef freshCalls `shouldReturn` 1
+
+        it "reports the exhausted reusable connection before replaying on a fresh account" do
+            healthy <- newIORef True
+            transcript <- newIORef (turnInputsToItems [UserMessage "old"])
+            failures <- newIORef []
+            seen <- newIORef []
+            let exhausted = ProviderError UsageLimitReached
+                    "usage limit reached" (Just 120)
+                sendCurrent _request _previous _onEvent =
+                    pure (Left exhausted)
+                sendFresh failure request previous _onEvent = do
+                    modifyIORef' failures (<> [failure])
+                    modifyIORef' seen (<> [(inputItems request, previous)])
+                    case previous of
+                        Just _ ->
+                            pure $ Left $ ProviderError PreviousResponseNotFound
+                                "previous_response_id belongs to another account"
+                                Nothing
+                        Nothing ->
+                            pure $ Right $
+                                testResponse "resp-fresh" [assistantItem "ok"]
+                backend = openAiBackendWithConnectionRecovery
+                    healthy sendCurrent sendFresh (pure baseParams) transcript
+            result <- backend.submitTurn (Just "resp-old")
+                [UserMessage "new"] (const (pure ()))
+            result `shouldBe`
+                Right (emptyTurnOutput "resp-fresh" [] (Just "ok"))
+            readIORef failures `shouldReturn` [Just exhausted, Nothing]
+            readIORef seen `shouldReturn`
+                [ (turnInputsToItems [UserMessage "new"], Just "resp-old")
+                , ( turnInputsToItems [UserMessage "old"]
+                        <> turnInputsToItems [UserMessage "new"]
+                  , Nothing
+                  )
+                ]
 
     describe "openAiBackendWithTransportFallback" do
         it "switches permanently to fallback after a pre-output connection error" do


### PR DESCRIPTION
## Summary

- report quota failures from an existing resumed-session WebSocket back to the credential pool
- cool down the exhausted OpenAI account before acquiring a replacement account
- replay the persisted transcript when the previous response belongs to the original account
- add regression coverage for failure-aware account replacement and cross-account resume replay

## Testing

- multi-package GHCi loaded all 145 modules
- `cabal test agent-openai-test` (154 examples, 0 failures, 1 pending live credential test)
- `git diff --check`