### PR TITLE
fix(cli): keep terminal title aligned with session

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -2526,6 +2526,9 @@ replWithDraft env@SessionEnv
                                             { createTitleHint = Just title
                                             , createTitleIsManual = True
                                             })
+                                        setWindowTitle
+                                            (cliWindowTitle pending.createCwd
+                                                (Just title))
                                         let message = "session title: " <> title
                                         displayInfo message $
                                             putTextLn stderr
@@ -2564,6 +2567,8 @@ replWithDraft env@SessionEnv
                                             { createTitleHint = Nothing
                                             , createTitleIsManual = False
                                             })
+                                        setWindowTitle
+                                            (cliWindowTitle pending.createCwd Nothing)
                                         displayInfo
                                             "automatic session titles enabled" $
                                             putTextLn stderr

--- a/packages/agent-cli/src/Agent/CLI/Style.hs
+++ b/packages/agent-cli/src/Agent/CLI/Style.hs
@@ -50,7 +50,6 @@ module Agent.CLI.Style
     , setCliWindowTitle
     ) where
 
-import Agent.OsPath (toText)
 import Data.Colour (Colour)
 import Data.Colour.SRGB (RGB(..), sRGB24, toSRGB24)
 import Data.Text (Text)
@@ -67,7 +66,7 @@ import System.Console.ANSI.Codes
     , setSGRCode
     )
 import System.Environment (lookupEnv)
-import System.OsPath (OsPath, takeFileName)
+import System.OsPath (OsPath)
 import System.IO (Handle)
 import System.IO.Unsafe (unsafePerformIO)
 
@@ -304,14 +303,14 @@ osc8Link color url label
     | otherwise =
         "\ESC]8;;" <> url <> "\ESC\\" <> label <> "\ESC]8;;\ESC\\"
 
--- | Window title: session name when known, otherwise the working directory.
+-- | Window title: session name when known, otherwise a stable placeholder.
 cliWindowTitle :: OsPath -> Maybe Text -> Text
-cliWindowTitle cwd sessionTitle =
+cliWindowTitle _cwd sessionTitle =
     case sessionTitle of
         Just title
             | not (Text.null title)
             , title /= "untitled" -> title
-        _ -> toText (takeFileName cwd)
+        _ -> "New session"
 
 -- | Set the terminal window title when @tty@ is 'True'; no-op otherwise.
 setCliWindowTitle :: Bool -> Handle -> Text -> IO ()

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -320,6 +320,7 @@ runFullscreen runtime workerAction = do
             , appWorkerStopped = False
             , appConversationAnchor = Nothing
             , appConversationReflowQueued = False
+            , appWindowTitle = Nothing
             }
     withAsync workerAction \worker ->
         withAsync uiTicker \_uiTicker ->
@@ -1909,6 +1910,7 @@ handleEvent event = case event of
     AppEvent (AppSetWindowTitle title) -> do
         state <- get
         liftIO (state.appRuntime.runtimeSetWindowTitle title)
+        modify' \current -> current { appWindowTitle = Just title }
     AppEvent (AppAgentSnapshot selected entries) -> do
         state <- get
         let normalized =
@@ -1989,6 +1991,9 @@ handleEvent event = case event of
         state <- get
         suspendAndResume do
             result <- tryAny action
+            mapM_
+                (setFullscreenWindowTitle state.appRuntime)
+                state.appWindowTitle
             atomically (putTMVar reply result)
             pure state { appAgentHover = Nothing }
     MouseDown name button _ _ -> do

--- a/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
@@ -144,6 +144,7 @@ data AppState = AppState
     , appWorkerStopped :: !Bool
     , appConversationAnchor :: !(Maybe Scroll.ConversationAnchor)
     , appConversationReflowQueued :: !Bool
+    , appWindowTitle :: !(Maybe Text)
     }
 
 data AgentHover = AgentHover

--- a/packages/agent-cli/src/Agent/CLI/Turn.hs
+++ b/packages/agent-cli/src/Agent/CLI/Turn.hs
@@ -41,6 +41,7 @@ import Agent.CLI.Session
     , ensureSession
     , loadSession
     , sessionConversationText
+    , sessionTitleFromPrompt
     , setGeneratedSessionTitle
     )
 import Agent.CLI.SessionEnv (SessionEnv(..))
@@ -144,6 +145,13 @@ runOneTurn env@SessionEnv
             onPersisted handle
             writeIORef planMode.planSessionDir (Just handle.sessionDir)
             writeIORef storeRoot (Just handle.sessionDir)
+            when
+                ( handle.sessionMeta.metaTitle == "untitled"
+                    && not (Text.null (Text.strip promptText))
+                )
+                (setWindowTitle
+                    (cliWindowTitle handle.sessionMeta.metaCwd
+                        (Just (sessionTitleFromPrompt promptText))))
             when created do
                 case fullscreen of
                     Just runtime ->

--- a/packages/agent-cli/test/Agent/CLI/StyleSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/StyleSpec.hs
@@ -62,9 +62,9 @@ spec = do
             spinnerFrames `shouldSatisfy` (not . null)
 
     describe "cliWindowTitle" do
-        it "uses the cwd basename when no session title is set" do
+        it "uses a stable placeholder when no session title is set" do
             cliWindowTitle (fromFilePath "/tmp/haskell-agent") Nothing
-                `shouldBe` "haskell-agent"
+                `shouldBe` "New session"
 
         it "prefers a real session title over cwd" do
             cliWindowTitle (fromFilePath "/tmp/haskell-agent") (Just "fix the title")
@@ -72,4 +72,4 @@ spec = do
 
         it "ignores untitled placeholders" do
             cliWindowTitle (fromFilePath "/tmp/haskell-agent") (Just "untitled")
-                `shouldBe` "haskell-agent"
+                `shouldBe` "New session"


### PR DESCRIPTION
## Summary

- use a stable `New session` title instead of the worktree directory before a session is named
- apply prompt-derived and manual titles immediately
- remember and restore the fullscreen title after terminal suspension
- preserve persisted titles when resuming sessions

## Verification

- multi-package GHCi typecheck: 144 modules loaded
- `GHCRTS= nix develop -c cabal test agent-cli:test:agent-cli-test --test-options="--match cliWindowTitle"`
- live tmux TTY smoke test confirmed `New session`, manual rename, and automatic-title reset