### PR TITLE
fix(loop): schedule tool calls by execution policy

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/AgentSessions.hs
+++ b/packages/agent-cli/src/Agent/CLI/AgentSessions.hs
@@ -31,7 +31,8 @@ import Agent.ToolDispatch (ToolHandler, typedTool)
 import Agent.Tools.Types
     ( AppTool
     , ApprovalRule(..)
-    , jsonAppTool
+    , ToolExecutionPolicy(..)
+    , jsonAppToolWithExecution
     )
 import Control.Concurrent.MVar
     ( MVar
@@ -299,10 +300,12 @@ jsonTool
     -> Text
     -> [PropertySchema]
     -> Bool
+    -> ToolExecutionPolicy
     -> ToolHandler
     -> AppTool
-jsonTool name description parameters readOnly handler =
-    jsonAppTool name description parameters approval handler
+jsonTool name description parameters readOnly execution handler =
+    jsonAppToolWithExecution
+        name description parameters approval execution handler
   where
     approval
         | readOnly = AlwaysReadOnly
@@ -336,6 +339,7 @@ createAgentSessionTool env = jsonTool
         "Optional reasoning-effort override. Defaults to the current session effort."
     ]
     False
+    TurnSequential
     (typedTool "create_agent_session" (runCreateAgentSession env))
 
 runCreateAgentSession
@@ -393,6 +397,7 @@ readAgentSessionTool env = jsonTool
         "Maximum number of most recent turns to return. Defaults to 20; maximum 100."
     ]
     True
+    ParallelSafe
     (typedTool "read_agent_session" (runReadAgentSession env))
 
 runReadAgentSession
@@ -431,6 +436,7 @@ sendAgentSessionMessageTool env = jsonTool
         "Message or follow-up task for the target session."
     ]
     False
+    TurnSequential
     (typedTool "send_agent_session_message" (runSendAgentSessionMessage env))
 
 runSendAgentSessionMessage

--- a/packages/agent-cli/test/Agent/CLI/ApprovalSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ApprovalSpec.hs
@@ -76,7 +76,9 @@ namespacedReadOnlyTool = tool "list_agents" AlwaysReadOnly
 
 tool :: Text -> ApprovalRule -> AppTool
 tool name approval =
-    jsonAppTool name "" [] approval (noArgsTool name (pure (Right "ok")))
+    jsonAppTool
+        name "" [] approval
+        (noArgsTool name (pure (Right "ok")))
 
 registry :: [AppTool] -> ToolRegistry
 registry = either (error . Text.unpack) id . mkToolRegistry

--- a/packages/agent-cli/test/Agent/CLI/ToolsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ToolsSpec.hs
@@ -105,7 +105,8 @@ jsonTool = jsonAppTool "read_file" "Read a file."
 
 patchTool :: AppTool
 patchTool =
-    freeformApplyPatchAppTool "apply_patch" "Apply a patch." AlwaysPrompt
+    freeformApplyPatchAppTool
+        "apply_patch" "Apply a patch." AlwaysPrompt
         (noArgsTool "apply_patch" (pure (Right "ok")))
 
 required_ :: FunctionTool -> Maybe Aeson.Value

--- a/packages/agent-core/src/Agent/Loop.hs
+++ b/packages/agent-core/src/Agent/Loop.hs
@@ -30,7 +30,12 @@ import Agent.ToolDispatch
     , ToolCallResult(..)
     , ToolDispatchConfig(..)
     )
-import Agent.Tools.Types (ToolRegistry, dispatchRegisteredToolCall)
+import Agent.Tools.Types
+    ( ToolExecutionPolicy(..)
+    , ToolRegistry
+    , dispatchRegisteredToolCall
+    , toolExecutionPolicyFor
+    )
 import Control.Concurrent.Async (mapConcurrently, race)
 import Control.Concurrent.MVar (newMVar, withMVar)
 import Control.Exception (SomeException)
@@ -206,8 +211,9 @@ runLoopInputs
     -> [TurnInput]
     -> IO (Either LoopError LoopResult)
 runLoopInputs config0 previousResponseId firstInputs = do
-    -- Tools run with mapConcurrently. Serialize onEvent so a printer
-    -- (hPutStrLn on String is not atomic) cannot interleave characters.
+    -- Parallel-safe tool batches run with mapConcurrently. Serialize onEvent
+    -- so a printer (hPutStrLn on String is not atomic) cannot interleave
+    -- characters.
     eventLock <- newMVar ()
     let config = config0
             { loopOnEvent = \event ->
@@ -255,7 +261,7 @@ runLoopInputs config0 previousResponseId firstInputs = do
                                                     , tokenUsage = usageAcc'
                                                     }
                                                 else do
-                                                    results <- mapConcurrently (runOne config) turn.toolCalls
+                                                    results <- runToolCalls config turn.toolCalls
                                                     cancelledAfter <- isCancelled config.loopCancel
                                                     if cancelledAfter
                                                         then pure (Left (LoopCancelled results))
@@ -263,24 +269,78 @@ runLoopInputs config0 previousResponseId firstInputs = do
                                                             (map CompletedTool results) (Just turn) usageAcc'
     go previousResponseId 0 firstInputs Nothing emptyTokenUsage
 
+-- | Preserve model order around stateful tools while retaining concurrency
+-- for maximal consecutive runs of explicitly parallel-safe calls.
+runToolCalls :: LoopConfig -> [ToolCall] -> IO [ToolCallResult]
+runToolCalls config = go
+  where
+    go [] = pure []
+    go calls@(call : rest) =
+        case toolExecutionPolicyFor config.loopTools call of
+            ParallelSafe -> do
+                let (batch, remaining) =
+                        span
+                            ((== ParallelSafe)
+                                . toolExecutionPolicyFor config.loopTools)
+                            calls
+                prepared <- traverse (prepareToolCall config) batch
+                batchResults <-
+                    mapConcurrently (runPreparedToolCall config) prepared
+                continue batchResults remaining
+            TurnSequential -> do
+                result <- runOne config call
+                continue [result] rest
+
+    continue completed remaining = do
+        cancelled <- isCancelled config.loopCancel
+        if cancelled
+            then pure completed
+            else (completed <>) <$> go remaining
+
+data ToolApproval
+    = ToolApprovalDenied !Text
+    | ToolApprovalRejected
+    | ToolApprovalGranted
+
+data PreparedToolCall =
+    PreparedToolCall !ToolCall !ToolApproval
+
 runOne :: LoopConfig -> ToolCall -> IO ToolCallResult
-runOne config call = do
+runOne config call =
+    prepareToolCall config call >>= runPreparedToolCall config
+
+-- | Approval may touch interactive or otherwise order-sensitive state, so it
+-- is prepared serially even when the resulting handlers may run concurrently.
+prepareToolCall :: LoopConfig -> ToolCall -> IO PreparedToolCall
+prepareToolCall config call = do
+    approval <- config.loopApprove call
+    pure (PreparedToolCall call (normalizeApproval approval))
+  where
+    normalizeApproval = \case
+        Left denial -> ToolApprovalDenied denial
+        Right False -> ToolApprovalRejected
+        Right True -> ToolApprovalGranted
+
+runPreparedToolCall
+    :: LoopConfig
+    -> PreparedToolCall
+    -> IO ToolCallResult
+runPreparedToolCall config (PreparedToolCall call approval) = do
     config.loopOnEvent (ToolStarted call)
-    approved <- config.loopApprove call
-    result <- case approved of
-        Left denial ->
+    result <- case approval of
+        ToolApprovalDenied denial ->
             pure ToolCallResult
                 { callId = call.callId
                 , output = denial
                 , callKind = call.callKind
                 }
-        Right False ->
+        ToolApprovalRejected ->
             pure ToolCallResult
                 { callId = call.callId
                 , output = "Tool call rejected by user."
                 , callKind = call.callKind
                 }
-        Right True ->
+        ToolApprovalGranted ->
             dispatchRegisteredToolCall
                 config.loopDispatch
                     { toolDispatchOnOutput = \progressCall output ->

--- a/packages/agent-core/src/Agent/Tools.hs
+++ b/packages/agent-core/src/Agent/Tools.hs
@@ -8,14 +8,18 @@ module Agent.Tools
     ( AppTool(..)
     , ToolSchema(..)
     , ApprovalRule(..)
+    , ToolExecutionPolicy(..)
     , ToolRegistry
     , ToolEnv(..)
     , defaultToolEnv
     , jsonAppTool
+    , jsonAppToolWithExecution
     , freeformApplyPatchAppTool
+    , freeformApplyPatchAppToolWithExecution
     , mkToolRegistry
     , toolRegistryTools
     , lookupRegisteredTool
+    , toolExecutionPolicyFor
     , dispatchRegisteredToolCall
     , appToolHandlers
     , CodingTools(..)

--- a/packages/agent-core/src/Agent/Tools/Codex.hs
+++ b/packages/agent-core/src/Agent/Tools/Codex.hs
@@ -38,9 +38,10 @@ import Agent.Tools.PlanMode
 import Agent.Tools.Types
     ( AppTool
     , ApprovalRule(..)
+    , ToolExecutionPolicy(..)
     , ToolEnv(..)
-    , freeformApplyPatchAppTool
-    , jsonAppTool
+    , freeformApplyPatchAppToolWithExecution
+    , jsonAppToolWithExecution
     )
 import Control.Applicative ((<|>))
 import Data.Aeson (FromJSON(..), Object, Value(..), withObject)
@@ -74,11 +75,13 @@ jsonTool
     -> Text
     -> [PropertySchema]
     -> Bool
+    -> ToolExecutionPolicy
     -> ToolHandler
     -> AppTool
-jsonTool name description parameters readOnly =
-    jsonAppTool name description parameters
+jsonTool name description parameters readOnly execution =
+    jsonAppToolWithExecution name description parameters
         (if readOnly then AlwaysReadOnly else AlwaysPrompt)
+        execution
 
 --------------------------------------------------------------------------------
 -- shell_command
@@ -116,6 +119,7 @@ shellCommandTool env = jsonTool "shell_command" shellDescription
         "Maximum command runtime. Defaults to 10000 ms."
     ]
     False
+    TurnSequential
     (typedStreamingTool "shell_command" (runShell env))
 
 shellDescription :: Text
@@ -179,7 +183,8 @@ instance FromJSON ApplyPatchArgs where
 
 applyPatchTool :: ToolEnv -> AppTool
 applyPatchTool env =
-    freeformApplyPatchAppTool "apply_patch" applyPatchDescription AlwaysPrompt
+    freeformApplyPatchAppToolWithExecution
+        "apply_patch" applyPatchDescription AlwaysPrompt TurnSequential
         (typedTool "apply_patch" (runApplyPatch env))
 
 applyPatchDescription :: Text
@@ -238,6 +243,7 @@ updatePlanTool planMode planRef = jsonTool "update_plan" updatePlanDescription
         ])) True $ Just "The list of steps"
     ]
     True
+    TurnSequential
     (typedTool "update_plan" (runUpdatePlan planMode planRef))
 
 updatePlanDescription :: Text

--- a/packages/agent-core/src/Agent/Tools/Ghci/Tool.hs
+++ b/packages/agent-core/src/Agent/Tools/Ghci/Tool.hs
@@ -25,7 +25,8 @@ import Agent.Tools.Ghci.Runtime
 import Agent.Tools.Types
     ( AppTool
     , ApprovalRule(..)
-    , jsonAppTool
+    , ToolExecutionPolicy(..)
+    , jsonAppToolWithExecution
     )
 import Control.Applicative ((<|>))
 import Data.Aeson (FromJSON(..), Object)
@@ -64,7 +65,7 @@ readTimeout text =
 
 runGhciTool :: GhciSession -> AppTool
 runGhciTool session =
-    jsonAppTool "run_ghci" ghciDescription
+    jsonAppToolWithExecution "run_ghci" ghciDescription
         [ PropertySchema "expression" PropertyString True $ Just
             "Haskell expression, statement, or GHCi :command to evaluate."
         , PropertySchema "timeout" PropertyInteger False $ Just
@@ -73,6 +74,7 @@ runGhciTool session =
             "One sentence explanation as to why this evaluation is needed."
         ]
         (ClassifyReadOnly (isGhciReadOnlyCall session))
+        TurnSequential
         (typedTool "run_ghci" (runGhci session))
 
 ghciDescription :: Text

--- a/packages/agent-core/src/Agent/Tools/Grok/Common.hs
+++ b/packages/agent-core/src/Agent/Tools/Grok/Common.hs
@@ -12,7 +12,8 @@ import Agent.OsPath (unsafeToFilePath)
 import Agent.Tools.Types
     ( AppTool
     , ApprovalRule(..)
-    , jsonAppTool
+    , ToolExecutionPolicy
+    , jsonAppToolWithExecution
     )
 import Control.Applicative ((<|>))
 import Data.Aeson (Object)
@@ -29,11 +30,13 @@ jsonTool
     -> Text
     -> [PropertySchema]
     -> Bool
+    -> ToolExecutionPolicy
     -> ToolHandler
     -> AppTool
-jsonTool name description parameters readOnly =
-    jsonAppTool name description parameters
+jsonTool name description parameters readOnly execution =
+    jsonAppToolWithExecution name description parameters
         (if readOnly then AlwaysReadOnly else AlwaysPrompt)
+        execution
 
 isGitIgnored :: OsPath -> OsPath -> IO Bool
 isGitIgnored cwd path = findExecutable "git" >>= \case

--- a/packages/agent-core/src/Agent/Tools/Grok/Grep.hs
+++ b/packages/agent-core/src/Agent/Tools/Grok/Grep.hs
@@ -6,7 +6,11 @@ import Agent.ToolDSL (PropertySchema(..), PropertyType(..))
 import Agent.ToolDispatch (typedTool)
 import Agent.Tools.Grok.Common (jsonTool)
 import Agent.Tools.IO (resolveUnderCwd)
-import Agent.Tools.Types (AppTool, ToolEnv(..))
+import Agent.Tools.Types
+    ( AppTool
+    , ToolEnv(..)
+    , ToolExecutionPolicy(..)
+    )
 import Data.Aeson (FromJSON(..))
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
@@ -81,6 +85,7 @@ grepTool env = jsonTool "grep" grepDescription
         "content (default), files_with_matches, or count."
     ]
     True
+    ParallelSafe
     (typedTool "grep" (runGrep env))
 
 grepDescription :: Text

--- a/packages/agent-core/src/Agent/Tools/Grok/ListDir.hs
+++ b/packages/agent-core/src/Agent/Tools/Grok/ListDir.hs
@@ -6,7 +6,11 @@ import Agent.ToolDSL (PropertySchema(..), PropertyType(..))
 import Agent.ToolDispatch (typedTool)
 import Agent.Tools.Grok.Common (isGitIgnored, jsonTool)
 import Agent.Tools.IO (listDirectoryEntries, resolveUnderCwd)
-import Agent.Tools.Types (AppTool, ToolEnv(..))
+import Agent.Tools.Types
+    ( AppTool
+    , ToolEnv(..)
+    , ToolExecutionPolicy(..)
+    )
 import Data.Aeson (FromJSON(..))
 import Data.List (sortOn)
 import qualified Data.Map.Strict as Map
@@ -26,6 +30,7 @@ listDirTool env = jsonTool "list_dir" listDirDescription
         "Path to directory to list contents of, relative to the workspace root or absolute."
     ]
     True
+    ParallelSafe
     (typedTool "list_dir" (runListDir env))
 
 listDirDescription :: Text

--- a/packages/agent-core/src/Agent/Tools/Grok/ReadFile.hs
+++ b/packages/agent-core/src/Agent/Tools/Grok/ReadFile.hs
@@ -6,7 +6,11 @@ import Agent.ToolDSL (PropertySchema(..), PropertyType(..))
 import Agent.ToolDispatch (typedTool)
 import Agent.Tools.Grok.Common (jsonTool)
 import Agent.Tools.IO (readTextFile, resolveUnderCwd)
-import Agent.Tools.Types (AppTool, ToolEnv)
+import Agent.Tools.Types
+    ( AppTool
+    , ToolEnv
+    , ToolExecutionPolicy(..)
+    )
 import Data.Aeson (FromJSON(..))
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
@@ -43,6 +47,7 @@ readFileTool env = jsonTool "read_file" readFileDescription
         "Output format for PDF files. 'image' (default) renders pages as images. 'text' extracts text content. Ignored for non-PDF files."
     ]
     True
+    ParallelSafe
     (typedTool "read_file" (runReadFile env))
 
 readFileDescription :: Text

--- a/packages/agent-core/src/Agent/Tools/Grok/SearchReplace.hs
+++ b/packages/agent-core/src/Agent/Tools/Grok/SearchReplace.hs
@@ -15,7 +15,11 @@ import Agent.Tools.PlanMode
     , planFilePath
     , planModeBlockedEditMessage
     )
-import Agent.Tools.Types (AppTool, ToolEnv(..))
+import Agent.Tools.Types
+    ( AppTool
+    , ToolEnv(..)
+    , ToolExecutionPolicy(..)
+    )
 import Control.Monad (unless, when)
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Except
@@ -57,6 +61,7 @@ searchReplaceTool env planMode = jsonTool "search_replace" searchReplaceDescript
         "Replace all occurrences of old_string (default false)"
     ]
     False
+    TurnSequential
     (typedTool "search_replace" (runSearchReplace env planMode))
 
 searchReplaceDescription :: Text

--- a/packages/agent-core/src/Agent/Tools/Grok/Task.hs
+++ b/packages/agent-core/src/Agent/Tools/Grok/Task.hs
@@ -46,7 +46,8 @@ import Agent.Tools.MultiAgents (MultiAgentContext(..), SubagentWorktree(..))
 import Agent.Tools.Types
     ( AppTool(..)
     , ApprovalRule(..)
-    , jsonAppTool
+    , ToolExecutionPolicy(..)
+    , jsonAppToolWithExecution
     )
 import Control.Concurrent.MVar (modifyMVar, newMVar)
 import Control.Exception.Safe (mask, onException)
@@ -121,7 +122,7 @@ sanitizeOptional value = value >>= \raw ->
 
 taskTool :: OsPath -> MultiAgentContext -> GrokSubagentSpecs -> AppTool
 taskTool baseCwd ctx specsRef =
-    jsonAppTool "task" taskDescription
+    jsonAppToolWithExecution "task" taskDescription
         [ PropertySchema "prompt" PropertyString True $ Just
             "The full task prompt for the subagent to execute."
         , PropertySchema "description" PropertyString True $ Just
@@ -140,6 +141,7 @@ taskTool baseCwd ctx specsRef =
             "Isolation mode: \"none\" (default) or \"worktree\". Worktree mode prevents child edits from affecting the parent workspace until explicitly applied."
         ]
         AlwaysPrompt
+        TurnSequential
         (typedTool "task" (runTask baseCwd ctx specsRef))
 
 taskDescription :: Text

--- a/packages/agent-core/src/Agent/Tools/Grok/TaskControl.hs
+++ b/packages/agent-core/src/Agent/Tools/Grok/TaskControl.hs
@@ -21,7 +21,10 @@ import Agent.Tools.Grok.Shell
     )
 import Agent.Tools.Grok.Task (isSubagentIdText)
 import Agent.Tools.MultiAgents (MultiAgentContext(..))
-import Agent.Tools.Types (AppTool)
+import Agent.Tools.Types
+    ( AppTool
+    , ToolExecutionPolicy(..)
+    )
 import Control.Applicative ((<|>))
 import Control.Concurrent.Async (mapConcurrently)
 import Data.Aeson (FromJSON(..))
@@ -56,6 +59,7 @@ getTaskOutputTool session multi = jsonTool "get_task_output" getTaskOutputDescri
         "Max wait time in milliseconds, up to 600000. A positive value waits for completion; omit or pass 0 for a non-blocking status snapshot."
     ]
     True
+    TurnSequential
     (typedTool "get_task_output" (runGetTaskOutput session multi))
 
 getTaskOutputDescription :: Text
@@ -201,6 +205,7 @@ killTaskTool session multi = jsonTool "kill_task" killTaskDescription
         "The task id from a background run_terminal_cmd or the subagent_id from task."
     ]
     False
+    TurnSequential
     (typedTool "kill_task" (runKillTask session multi))
 
 killTaskDescription :: Text

--- a/packages/agent-core/src/Agent/Tools/Grok/Terminal.hs
+++ b/packages/agent-core/src/Agent/Tools/Grok/Terminal.hs
@@ -12,7 +12,10 @@ import Agent.Tools.Grok.Shell
     , startBackground
     )
 import Agent.Tools.IO (CommandResult(..))
-import Agent.Tools.Types (AppTool)
+import Agent.Tools.Types
+    ( AppTool
+    , ToolExecutionPolicy(..)
+    )
 import Data.Aeson (FromJSON(..))
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
@@ -44,6 +47,7 @@ runTerminalCmdTool session = jsonTool "run_terminal_cmd" terminalDescription
         "Set to true for long-running commands that should run in the background (e.g., dev servers, long builds). Returns a task id immediately while the command keeps running in the background; you are notified on completion, so do not poll or sleep-wait for it."
     ]
     False
+    TurnSequential
     (typedStreamingTool "run_terminal_cmd" (runTerminal session))
 
 terminalDescription :: Text

--- a/packages/agent-core/src/Agent/Tools/MultiAgents.hs
+++ b/packages/agent-core/src/Agent/Tools/MultiAgents.hs
@@ -56,7 +56,8 @@ import Agent.ToolDispatch (ToolCall(..), ToolHandler, typedTool, typedToolWithCa
 import Agent.Tools.Types
     ( AppTool
     , ApprovalRule(..)
-    , jsonAppTool
+    , ToolExecutionPolicy(..)
+    , jsonAppToolWithExecution
     )
 import Data.Aeson (FromJSON(..), Value(..), object, (.=))
 import qualified Data.Aeson as Aeson
@@ -129,11 +130,13 @@ jsonTool
     -> Text
     -> [PropertySchema]
     -> Bool
+    -> ToolExecutionPolicy
     -> ToolHandler
     -> AppTool
-jsonTool name description parameters readOnly =
-    jsonAppTool name description parameters
+jsonTool name description parameters readOnly execution =
+    jsonAppToolWithExecution name description parameters
         (if readOnly then AlwaysReadOnly else AlwaysPrompt)
+        execution
 
 --------------------------------------------------------------------------------
 -- spawn_agent
@@ -169,6 +172,7 @@ spawnAgentTool ctx = jsonTool "spawn_agent" spawnAgentDescription
         "Optional number of turns to fork. Defaults to `all`. Use `none`, `all`, or a positive integer string such as `3` to fork only the most recent turns."
     ]
     True
+    TurnSequential
     (typedToolWithCall "spawn_agent" (runSpawn ctx))
 
 spawnAgentDescription :: Text
@@ -259,6 +263,7 @@ waitAgentTool ctx = jsonTool "wait_agent" waitAgentDescription
         "Timeout in milliseconds. Defaults to 30000 ms."
     ]
     True
+    TurnSequential
     (typedTool "wait_agent" (runWait ctx))
 
 waitAgentDescription :: Text
@@ -342,6 +347,7 @@ sendMessageTool ctx = jsonTool "send_message" sendMessageDescription
         (encryptedString "Message text to queue on the target agent.") True Nothing
     ]
     True
+    TurnSequential
     (typedToolWithCall "send_message" (runSendMessage ctx))
 
 sendMessageDescription :: Text
@@ -382,6 +388,7 @@ followupTaskTool ctx = jsonTool "followup_task" followupDescription
         (encryptedString "Message text to send to the target agent.") True Nothing
     ]
     True
+    TurnSequential
     (typedToolWithCall "followup_task" (runFollowup ctx))
 
 followupDescription :: Text
@@ -466,6 +473,7 @@ listAgentsTool ctx = jsonTool "list_agents" listAgentsDescription
         "Task-path prefix filter without a trailing slash. Omit to list all live agents."
     ]
     True
+    ParallelSafe
     (typedTool "list_agents" (runListAgents ctx))
 
 listAgentsDescription :: Text
@@ -501,6 +509,7 @@ interruptAgentTool ctx = jsonTool "interrupt_agent" interruptDescription
         "Agent id or canonical task name to interrupt (from spawn_agent)."
     ]
     True
+    TurnSequential
     (typedTool "interrupt_agent" (runInterrupt ctx))
 
 interruptDescription :: Text

--- a/packages/agent-core/src/Agent/Tools/PlanMode.hs
+++ b/packages/agent-core/src/Agent/Tools/PlanMode.hs
@@ -38,7 +38,8 @@ import Agent.ToolDispatch (ToolHandler, typedTool)
 import Agent.Tools.Types
     ( AppTool
     , ApprovalRule(..)
-    , jsonAppTool
+    , ToolExecutionPolicy(..)
+    , jsonAppToolWithExecution
     )
 import Control.Exception.Safe (tryAny)
 import Data.Aeson (FromJSON(..), withObject)
@@ -175,11 +176,13 @@ jsonTool
     -> Text
     -> [PropertySchema]
     -> Bool
+    -> ToolExecutionPolicy
     -> ToolHandler
     -> AppTool
-jsonTool name description parameters readOnly =
-    jsonAppTool name description parameters
+jsonTool name description parameters readOnly execution =
+    jsonAppToolWithExecution name description parameters
         (if readOnly then AlwaysReadOnly else AlwaysPrompt)
+        execution
 
 data EnterPlanArgs = EnterPlanArgs
     { explanation :: Maybe Text
@@ -197,6 +200,7 @@ enterPlanModeTool env = jsonTool "enter_plan_mode" enterPlanDescription
     -- The tool performs its own explicit user confirmation through
     -- planConfirmEnter, so it must not also trigger generic tool approval.
     True
+    TurnSequential
     (typedTool "enter_plan_mode" (runEnterPlanMode env))
 
 enterPlanDescription :: Text
@@ -237,6 +241,7 @@ exitPlanModeTool env = jsonTool "exit_plan_mode" exitPlanDescription
         "Optional short summary shown with the plan approval prompt."
     ]
     False
+    TurnSequential
     (typedTool "exit_plan_mode" (runExitPlanMode env))
 
 exitPlanDescription :: Text
@@ -295,6 +300,7 @@ askUserQuestionTool env = jsonTool "ask_user_question" askUserDescription
         "Optional newline- or comma-separated choices."
     ]
     True
+    TurnSequential
     (typedTool "ask_user_question" (runAskUserQuestion env))
 
 askUserDescription :: Text

--- a/packages/agent-core/src/Agent/Tools/Types.hs
+++ b/packages/agent-core/src/Agent/Tools/Types.hs
@@ -2,14 +2,18 @@ module Agent.Tools.Types
     ( AppTool(..)
     , ToolSchema(..)
     , ApprovalRule(..)
+    , ToolExecutionPolicy(..)
     , ToolRegistry
     , ToolEnv(..)
     , defaultToolEnv
     , jsonAppTool
+    , jsonAppToolWithExecution
     , freeformApplyPatchAppTool
+    , freeformApplyPatchAppToolWithExecution
     , mkToolRegistry
     , toolRegistryTools
     , lookupRegisteredTool
+    , toolExecutionPolicyFor
     , dispatchRegisteredToolCall
     , jsonToolParameters
     , appToolHandlers
@@ -17,7 +21,6 @@ module Agent.Tools.Types
     ) where
 
 import Agent.Cancel (CancelFlag, newCancelFlag)
-import System.OsPath (OsPath)
 import Agent.ToolDSL (PropertySchema)
 import Agent.ToolDispatch
     ( ToolCall(..)
@@ -32,7 +35,7 @@ import Control.Monad (foldM)
 import qualified Data.Map.Strict as Map
 import Data.Text (Text)
 import qualified Data.Text as Text
-import System.OsPath (dropTrailingPathSeparator)
+import System.OsPath (OsPath, dropTrailingPathSeparator)
 
 -- | Provider-facing schema. The sum prevents freeform tools from carrying
 -- meaningless JSON parameters.
@@ -47,12 +50,23 @@ data ApprovalRule
     | AlwaysPrompt
     | ClassifyReadOnly !(ToolCall -> IO Bool)
 
+-- | Whether a tool handler may overlap other handlers emitted in the same
+-- model turn. Approval callbacks are always evaluated serially in call order.
+--
+-- This policy is intentionally turn-local: it does not coordinate separate
+-- loops or background work that outlives a handler.
+data ToolExecutionPolicy
+    = ParallelSafe
+    | TurnSequential
+    deriving (Eq, Show)
+
 data AppTool = AppTool
     { appToolName :: !Text
     , appToolDescription :: !Text
     , appToolSchema :: !ToolSchema
     , appToolHandler :: !ToolHandler
     , appToolApproval :: !ApprovalRule
+    , appToolExecution :: !ToolExecutionPolicy
     }
 
 -- | Registration order is retained for stable provider schemas while lookup is
@@ -78,6 +92,7 @@ defaultToolEnv cwd = do
         , toolCancel = cancel
         }
 
+-- | Construct a JSON tool with the conservative turn-sequential default.
 jsonAppTool
     :: Text
     -> Text
@@ -85,26 +100,54 @@ jsonAppTool
     -> ApprovalRule
     -> ToolHandler
     -> AppTool
-jsonAppTool name description parameters approval handler = AppTool
+jsonAppTool name description parameters approval =
+    jsonAppToolWithExecution
+        name description parameters approval TurnSequential
+
+jsonAppToolWithExecution
+    :: Text
+    -> Text
+    -> [PropertySchema]
+    -> ApprovalRule
+    -> ToolExecutionPolicy
+    -> ToolHandler
+    -> AppTool
+jsonAppToolWithExecution
+        name description parameters approval execution handler = AppTool
     { appToolName = name
     , appToolDescription = description
     , appToolSchema = JsonFunctionSchema parameters
     , appToolHandler = handler
     , appToolApproval = approval
+    , appToolExecution = execution
     }
 
+-- | Construct a freeform tool with the conservative turn-sequential default.
 freeformApplyPatchAppTool
     :: Text
     -> Text
     -> ApprovalRule
     -> ToolHandler
     -> AppTool
-freeformApplyPatchAppTool name description approval handler = AppTool
+freeformApplyPatchAppTool name description approval =
+    freeformApplyPatchAppToolWithExecution
+        name description approval TurnSequential
+
+freeformApplyPatchAppToolWithExecution
+    :: Text
+    -> Text
+    -> ApprovalRule
+    -> ToolExecutionPolicy
+    -> ToolHandler
+    -> AppTool
+freeformApplyPatchAppToolWithExecution
+        name description approval execution handler = AppTool
     { appToolName = name
     , appToolDescription = description
     , appToolSchema = FreeformApplyPatchSchema
     , appToolHandler = handler
     , appToolApproval = approval
+    , appToolExecution = execution
     }
 
 mkToolRegistry :: [AppTool] -> Either Text ToolRegistry
@@ -137,6 +180,13 @@ toolRegistryTools = (.registryTools)
 lookupRegisteredTool :: Text -> ToolRegistry -> Maybe AppTool
 lookupRegisteredTool name registry =
     Map.lookup (canonicalToolName name) registry.registryByName
+
+-- | Unknown tools are conservative barriers. Their dispatch will still
+-- produce the normal unknown-tool result, but never overlap known work.
+toolExecutionPolicyFor :: ToolRegistry -> ToolCall -> ToolExecutionPolicy
+toolExecutionPolicyFor registry call =
+    maybe TurnSequential (\tool -> tool.appToolExecution)
+        (lookupRegisteredTool call.name registry)
 
 dispatchRegisteredToolCall
     :: ToolDispatchConfig

--- a/packages/agent-core/test/Agent/LoopSpec.hs
+++ b/packages/agent-core/test/Agent/LoopSpec.hs
@@ -7,16 +7,26 @@ import Agent.ToolArgs (objectArgs, reqText)
 import Agent.ToolDispatch
 import Agent.Tools.Types
     ( ApprovalRule(..)
+    , ToolExecutionPolicy(..)
     , ToolRegistry
-    , jsonAppTool
+    , jsonAppToolWithExecution
     , mkToolRegistry
+    , toolExecutionPolicyFor
     )
 import Control.Concurrent (forkIO, threadDelay)
-import Control.Concurrent.MVar (newEmptyMVar, putMVar, takeMVar)
+import Control.Concurrent.Async (wait, withAsync)
+import Control.Concurrent.MVar
+    ( newEmptyMVar
+    , putMVar
+    , readMVar
+    , takeMVar
+    , tryReadMVar
+    )
 import Data.Aeson (FromJSON(..))
 import Data.IORef
 import Data.Text (Text)
 import qualified Data.Text as Text
+import System.Timeout (timeout)
 import Test.Hspec
 
 spec :: Spec
@@ -118,18 +128,17 @@ spec = describe "runLoop" do
             }
         readIORef maxInFlight `shouldReturn` 1
 
-    it "dispatches parallel tool calls" do
-        inFlight <- newIORef (0 :: Int)
-        maxInFlight <- newIORef (0 :: Int)
-        let bump = do
-                now <- atomicModifyIORef' inFlight \n -> (n + 1, n + 1)
-                atomicModifyIORef' maxInFlight \seen -> (max seen now, ())
-                threadDelay 80000
-                atomicModifyIORef' inFlight \n -> (n - 1, ())
+    it "dispatches consecutive parallel-safe tool calls concurrently" do
+        firstStarted <- newEmptyMVar
+        secondStarted <- newEmptyMVar
+        release <- newEmptyMVar
+        let blocked started = do
+                putMVar started ()
+                readMVar release
                 pure (Right "ok")
             handlers =
-                [ noArgsTool "a" bump
-                , noArgsTool "b" bump
+                [ noArgsTool "a" (blocked firstStarted)
+                , noArgsTool "b" (blocked secondStarted)
                 ]
         submissions <- newIORef []
         backend <- scriptedBackend submissions
@@ -141,14 +150,177 @@ spec = describe "runLoop" do
             , Right $ emptyTurnOutput "resp-2" [] (Just "ok")
             ]
         config0 <- testConfig backend
-        result <- runLoop config0 { loopTools = registryFromHandlers handlers } Nothing "go"
-        result `shouldBe` Right LoopResult
-            { finalResponseId = "resp-2"
-            , finalText = Just "ok"
-            , turnsUsed = 2
-            , tokenUsage = emptyTokenUsage
-            }
-        readIORef maxInFlight `shouldReturn` 2
+        withAsync
+            (runLoop
+                config0 { loopTools = registryFromHandlers handlers }
+                Nothing
+                "go")
+            \running -> do
+                bothStarted <- timeout concurrencyProbeMicros do
+                    takeMVar firstStarted
+                    takeMVar secondStarted
+                bothStarted `shouldBe` Just ()
+                putMVar release ()
+                wait running `shouldReturn` Right LoopResult
+                    { finalResponseId = "resp-2"
+                    , finalText = Just "ok"
+                    , turnsUsed = 2
+                    , tokenUsage = emptyTokenUsage
+                    }
+
+    it "preserves order between consecutive turn-sequential calls" do
+        firstStarted <- newEmptyMVar
+        secondStarted <- newEmptyMVar
+        releaseFirst <- newEmptyMVar
+        let first = do
+                putMVar firstStarted ()
+                takeMVar releaseFirst
+                pure (Right "first")
+            second = putMVar secondStarted () >> pure (Right "second")
+            tools =
+                [ (TurnSequential, noArgsTool "first" first)
+                , (TurnSequential, noArgsTool "second" second)
+                ]
+        submissions <- newIORef []
+        backend <- scriptedBackend submissions
+            [ Right $ emptyTurnOutput "resp-1"
+                [ functionToolCall "c1" "first" "{}"
+                , functionToolCall "c2" "second" "{}"
+                ]
+                Nothing
+            , Right $ emptyTurnOutput "resp-2" [] (Just "ok")
+            ]
+        config0 <- testConfig backend
+        withAsync
+            (runLoop
+                config0 { loopTools = registryFromPolicies tools }
+                Nothing
+                "go")
+            \running -> do
+                timeout concurrencyProbeMicros (takeMVar firstStarted)
+                    `shouldReturn` Just ()
+                tryReadMVar secondStarted `shouldReturn` Nothing
+                putMVar releaseFirst ()
+                timeout concurrencyProbeMicros (takeMVar secondStarted)
+                    `shouldReturn` Just ()
+                wait running `shouldReturn` Right LoopResult
+                    { finalResponseId = "resp-2"
+                    , finalText = Just "ok"
+                    , turnsUsed = 2
+                    , tokenUsage = emptyTokenUsage
+                    }
+
+    it "evaluates approvals serially before parallel-safe handlers" do
+        firstApprovalStarted <- newEmptyMVar
+        secondApprovalStarted <- newEmptyMVar
+        releaseFirstApproval <- newEmptyMVar
+        submissions <- newIORef []
+        backend <- scriptedBackend submissions
+            [ Right $ emptyTurnOutput "resp-1"
+                [ functionToolCall "c1" "a" "{}"
+                , functionToolCall "c2" "b" "{}"
+                ]
+                Nothing
+            , Right $ emptyTurnOutput "resp-2" [] (Just "ok")
+            ]
+        config0 <- testConfig backend
+        let approve :: ToolCall -> IO (Either Text Bool)
+            approve call
+                | call.name == "a" = do
+                    putMVar firstApprovalStarted ()
+                    takeMVar releaseFirstApproval
+                    pure (Right True)
+                | otherwise =
+                    putMVar secondApprovalStarted () >> pure (Right True)
+            handlers =
+                [ noArgsTool "a" (pure (Right "a"))
+                , noArgsTool "b" (pure (Right "b"))
+                ]
+            config = config0
+                { loopTools = registryFromHandlers handlers
+                , loopApprove = approve
+                }
+        withAsync (runLoop config Nothing "go") \running -> do
+            timeout concurrencyProbeMicros (takeMVar firstApprovalStarted)
+                `shouldReturn` Just ()
+            tryReadMVar secondApprovalStarted `shouldReturn` Nothing
+            putMVar releaseFirstApproval ()
+            timeout concurrencyProbeMicros (takeMVar secondApprovalStarted)
+                `shouldReturn` Just ()
+            wait running `shouldReturn` Right LoopResult
+                { finalResponseId = "resp-2"
+                , finalText = Just "ok"
+                , turnsUsed = 2
+                , tokenUsage = emptyTokenUsage
+                }
+
+    it "keeps sequential calls as barriers around parallel-safe batches" do
+        firstSafeStarted <- newEmptyMVar
+        secondSafeStarted <- newEmptyMVar
+        sequentialStarted <- newEmptyMVar
+        finalSafeStarted <- newEmptyMVar
+        releaseSafe <- newEmptyMVar
+        releaseSequential <- newEmptyMVar
+        let blockedSafe started = do
+                putMVar started ()
+                readMVar releaseSafe
+                pure (Right "safe")
+            sequential = do
+                putMVar sequentialStarted ()
+                takeMVar releaseSequential
+                pure (Right "sequential")
+            finalSafe = putMVar finalSafeStarted () >> pure (Right "final")
+            tools =
+                [ (ParallelSafe, noArgsTool "safe-a" (blockedSafe firstSafeStarted))
+                , (ParallelSafe, noArgsTool "safe-b" (blockedSafe secondSafeStarted))
+                , (TurnSequential, noArgsTool "sequential" sequential)
+                , (ParallelSafe, noArgsTool "safe-c" finalSafe)
+                ]
+        submissions <- newIORef []
+        backend <- scriptedBackend submissions
+            [ Right $ emptyTurnOutput "resp-1"
+                [ functionToolCall "c1" "safe-a" "{}"
+                , functionToolCall "c2" "safe-b" "{}"
+                , functionToolCall "c3" "sequential" "{}"
+                , functionToolCall "c4" "safe-c" "{}"
+                ]
+                Nothing
+            , Right $ emptyTurnOutput "resp-2" [] (Just "ok")
+            ]
+        config0 <- testConfig backend
+        withAsync
+            (runLoop
+                config0 { loopTools = registryFromPolicies tools }
+                Nothing
+                "go")
+            \running -> do
+                safeBatchStarted <- timeout concurrencyProbeMicros do
+                    takeMVar firstSafeStarted
+                    takeMVar secondSafeStarted
+                safeBatchStarted `shouldBe` Just ()
+                tryReadMVar sequentialStarted `shouldReturn` Nothing
+                tryReadMVar finalSafeStarted `shouldReturn` Nothing
+
+                putMVar releaseSafe ()
+                timeout concurrencyProbeMicros (takeMVar sequentialStarted)
+                    `shouldReturn` Just ()
+                tryReadMVar finalSafeStarted `shouldReturn` Nothing
+
+                putMVar releaseSequential ()
+                timeout concurrencyProbeMicros (takeMVar finalSafeStarted)
+                    `shouldReturn` Just ()
+                wait running `shouldReturn` Right LoopResult
+                    { finalResponseId = "resp-2"
+                    , finalText = Just "ok"
+                    , turnsUsed = 2
+                    , tokenUsage = emptyTokenUsage
+                    }
+
+    it "treats unknown tools as sequential" do
+        toolExecutionPolicyFor
+            (registryFromHandlers [noArgsTool "known" (pure (Right "ok"))])
+            (functionToolCall "c1" "unknown" "{}")
+            `shouldBe` TurnSequential
 
     it "returns a denial as tool output when approval is refused" do
         submissions <- newIORef []
@@ -379,11 +551,24 @@ testConfig backend = do
         }
 
 registryFromHandlers :: [ToolHandler] -> ToolRegistry
-registryFromHandlers handlers =
+registryFromHandlers =
+    registryFromPolicies . map (\handler -> (ParallelSafe, handler))
+
+registryFromPolicies :: [(ToolExecutionPolicy, ToolHandler)] -> ToolRegistry
+registryFromPolicies tools =
     either (error . Text.unpack) id $ mkToolRegistry
-        [ jsonAppTool (handlerName handler) "" [] AlwaysReadOnly handler
-        | handler <- handlers
+        [ jsonAppToolWithExecution
+            (handlerName handler)
+            ""
+            []
+            AlwaysReadOnly
+            execution
+            handler
+        | (execution, handler) <- tools
         ]
+
+concurrencyProbeMicros :: Int
+concurrencyProbeMicros = 5000000
 
 data EchoArgs = EchoArgs { message :: Text }
 

--- a/packages/agent-core/test/Agent/Tools/Grok/TaskSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/Grok/TaskSpec.hs
@@ -16,6 +16,7 @@ import Agent.Tools.MultiAgents (MultiAgentContext(..), SubagentWorktree(..))
 import Agent.Tools.Types
     ( AppTool(..)
     , ApprovalRule(..)
+    , ToolExecutionPolicy(..)
     , ToolSchema(..)
     )
 import Control.Concurrent.MVar
@@ -126,6 +127,7 @@ fake name = AppTool
     , appToolSchema = JsonFunctionSchema []
     , appToolHandler = noArgsTool name (pure (Right "ok"))
     , appToolApproval = AlwaysReadOnly
+    , appToolExecution = ParallelSafe
     }
 
 raceArgs :: Text


### PR DESCRIPTION
## Summary
- add explicit `ParallelSafe` / `TurnSequential` execution metadata to registered tools
- run only consecutive parallel-safe handlers concurrently while preserving model order around turn-sequential barriers
- evaluate approval callbacks serially before launching a parallel handler batch
- classify built-in tools conservatively and keep legacy constructors defaulting to turn-sequential execution
- add deterministic MVar-based tests for concurrency, barriers, approval ordering, sequential ordering, and unknown-tool fallback

## Scope
This policy coordinates handlers within one model turn. It intentionally does not claim to serialize separate agent loops or background work that outlives a handler.

## Validation
- `nix develop -c cabal test agent-core:agent-core-test agent-cli:agent-cli-test`
  - agent-core: 245 examples, 0 failures
  - agent-cli: 471 examples, 0 failures
