### PR TITLE
feat(tui): highlight fenced code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ A universal coding-agent harness written in Haskell.
 ## Packages
 
 - `agent-cli` is the command-line entry point (`-p` for one-shot, otherwise a REPL).
+- `agent-syntax` provides renderer-independent syntax loading, language
+  resolution, tokenization, and semantic token classes.
+- `agent-tui` provides retained fullscreen presentation state, Markdown
+  rendering, themes, and terminal presentation of syntax spans.
 - `agent-core` provides provider-neutral credentials, common
   errors, tool dispatch, and transport utilities under the `Agent.*` namespace.
 - `agent-responses` provides the canonical Responses wire model, codecs, error
@@ -20,6 +24,9 @@ A universal coding-agent harness written in Haskell.
 ## Development
 
 All compiler and package dependencies come from the pinned Nix flake.
+The flake also fetches Skylighting's complete XML syntax-definition set and
+configures it for development, tests, and packaged `agent-cli` executables; the
+generated grammar data is not vendored in this repository.
 
 Each package has a checked-in `package.nix` generated with `cabal2nix` (no IFD).
 After changing a `.cabal` file, regenerate that package's Nix expression:
@@ -30,6 +37,8 @@ After changing a `.cabal` file, regenerate that package's Nix expression:
 (cd packages/agent-openai && cabal2nix . > package.nix)
 (cd packages/agent-xai && cabal2nix . > package.nix)
 (cd packages/agent-openrouter && cabal2nix . > package.nix)
+(cd packages/agent-syntax && cabal2nix . > package.nix)
+(cd packages/agent-tui && cabal2nix . > package.nix)
 (cd packages/agent-cli && cabal2nix . > package.nix)
 ```
 

--- a/cabal.project
+++ b/cabal.project
@@ -1,6 +1,7 @@
 packages:
     packages/agent-cli
     packages/agent-core
+    packages/agent-syntax
     packages/agent-tui
     packages/agent-responses
     packages/agent-openai

--- a/flake.lock
+++ b/flake.lock
@@ -53,7 +53,25 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "nix-filter": "nix-filter",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "skylighting": "skylighting"
+      }
+    },
+    "skylighting": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1785853199,
+        "narHash": "sha256-Ii7ky4AYyv89yliYSVMYDznP9yjx6bbHXVLMFHaFw/M=",
+        "owner": "jgm",
+        "repo": "skylighting",
+        "rev": "e432d65743ecef9475816b2cc074d34833837ced",
+        "type": "github"
+      },
+      "original": {
+        "owner": "jgm",
+        "repo": "skylighting",
+        "rev": "e432d65743ecef9475816b2cc074d34833837ced",
+        "type": "github"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -5,6 +5,10 @@
         nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
         flake-utils.url = "github:numtide/flake-utils";
         nix-filter.url = "github:numtide/nix-filter";
+        skylighting = {
+            url = "github:jgm/skylighting/e432d65743ecef9475816b2cc074d34833837ced";
+            flake = false;
+        };
     };
 
     outputs =
@@ -13,6 +17,7 @@
             nixpkgs,
             flake-utils,
             nix-filter,
+            skylighting,
             ...
         }:
         flake-utils.lib.eachDefaultSystem (
@@ -31,6 +36,17 @@
                         "LICENSE"
                         "README.md"
                         "UPSTREAM.md"
+                    ];
+                };
+
+                agentSyntaxSource = nix-filter.lib {
+                    root = ./packages/agent-syntax;
+                    include = [
+                        "src"
+                        "test"
+                        "agent-syntax.cabal"
+                        "LICENSE"
+                        "README.md"
                     ];
                 };
 
@@ -100,11 +116,46 @@
                     ];
                 };
 
+                skylightingSyntaxes = pkgs.runCommand "skylighting-syntaxes" { } ''
+                    mkdir -p "$out/share/skylighting/xml"
+                    cp ${skylighting}/skylighting-core/xml/*.xml \
+                        "$out/share/skylighting/xml/"
+
+                    mkdir -p "$out/share/doc/skylighting-syntaxes"
+                    cp ${skylighting}/skylighting-core/README.md \
+                        "$out/share/doc/skylighting-syntaxes/UPSTREAM_README.md"
+                    cat > "$out/share/doc/skylighting-syntaxes/NOTICE" <<'EOF'
+                    These unmodified KDE XML syntax definitions come from the
+                    pinned jgm/skylighting source. They are distributed under
+                    various licenses recorded in the individual XML files.
+                    See UPSTREAM_README.md for upstream provenance.
+                    EOF
+                '';
+                skylightingSyntaxDirectory =
+                    "${skylightingSyntaxes}/share/skylighting/xml";
+
                 haskellPackages = pkgs.haskellPackages.extend (
                     final: previous: {
                         vty-unix = pkgs.haskell.lib.appendPatch
                             previous.vty-unix
                             ./patches/vty-unix-all-motion.patch;
+                        skylighting-core = final.callCabal2nix
+                            "skylighting-core"
+                            "${skylighting}/skylighting-core"
+                            { };
+                        agent-syntax =
+                            (pkgs.haskell.lib.overrideSrc
+                                (final.callPackage ./packages/agent-syntax/package.nix { })
+                                {
+                                    src = agentSyntaxSource;
+                                }).overrideAttrs
+                                (old: {
+                                    preCheck =
+                                        (old.preCheck or "")
+                                        + ''
+                                            export AGENT_SYNTAX_DIR=${skylightingSyntaxDirectory}
+                                        '';
+                                });
                         agent-core = pkgs.haskell.lib.addTestToolDepends
                             (pkgs.haskell.lib.overrideSrc (final.callPackage ./packages/agent-core/package.nix { }) {
                                 src = agentCoreSource;
@@ -125,9 +176,19 @@
                         agent-openrouter = pkgs.haskell.lib.overrideSrc (final.callPackage ./packages/agent-openrouter/package.nix { }) {
                             src = agentOpenrouterSource;
                         };
-                        agent-tui = pkgs.haskell.lib.overrideSrc (final.callPackage ./packages/agent-tui/package.nix { }) {
-                            src = agentTuiSource;
-                        };
+                        agent-tui =
+                            (pkgs.haskell.lib.overrideSrc
+                                (final.callPackage ./packages/agent-tui/package.nix { })
+                                {
+                                    src = agentTuiSource;
+                                }).overrideAttrs
+                                (old: {
+                                    preCheck =
+                                        (old.preCheck or "")
+                                        + ''
+                                            export AGENT_SYNTAX_DIR=${skylightingSyntaxDirectory}
+                                        '';
+                                });
                         agent-cli = pkgs.haskell.lib.addTestToolDepends
                             (pkgs.haskell.lib.overrideSrc (final.callPackage ./packages/agent-cli/package.nix { }) {
                                 src = agentCliSource;
@@ -137,13 +198,27 @@
                 );
 
                 agentCorePackage = haskellPackages.agent-core;
+                agentSyntaxPackage = haskellPackages.agent-syntax;
                 agentResponsesPackage = haskellPackages.agent-responses;
                 agentOpenaiPackage = haskellPackages.agent-openai;
                 agentXaiPackage = haskellPackages.agent-xai;
                 agentOpenrouterPackage = haskellPackages.agent-openrouter;
                 agentTuiPackage = haskellPackages.agent-tui;
                 agentCliPackage = haskellPackages.agent-cli;
-                agentCliExecutable = pkgs.haskell.lib.justStaticExecutables agentCliPackage;
+                agentCliExecutable =
+                    (pkgs.haskell.lib.justStaticExecutables agentCliPackage).overrideAttrs
+                        (old: {
+                            nativeBuildInputs =
+                                (old.nativeBuildInputs or [ ])
+                                ++ [ pkgs.makeWrapper ];
+                            postInstall =
+                                (old.postInstall or "")
+                                + ''
+                                    wrapProgram "$out/bin/agent-cli" \
+                                        --set-default AGENT_SYNTAX_DIR \
+                                            "${skylightingSyntaxDirectory}"
+                                '';
+                        });
                 agentOpenaiExecutables = pkgs.haskell.lib.justStaticExecutables agentOpenaiPackage;
 
                 # Opens cabal repl on the agent-cli library and enters the
@@ -220,7 +295,9 @@
                 packages.default = agentCliExecutable;
                 packages.agent-cli = agentCliExecutable;
                 packages.agent-core = agentCorePackage;
+                packages.agent-syntax = agentSyntaxPackage;
                 packages.agent-tui = agentTuiPackage;
+                packages.skylighting-syntaxes = skylightingSyntaxes;
                 packages.agent-responses = agentResponsesPackage;
                 packages.agent-openai = agentOpenaiPackage;
                 packages.agent-xai = agentXaiPackage;
@@ -240,6 +317,7 @@
                     packages = packages: [
                         packages.agent-cli
                         packages.agent-core
+                        packages.agent-syntax
                         packages.agent-tui
                         packages.agent-responses
                         packages.agent-openai
@@ -247,6 +325,9 @@
                         packages.agent-openrouter
                     ];
                     withHoogle = false;
+                    shellHook = ''
+                        export AGENT_SYNTAX_DIR=${skylightingSyntaxDirectory}
+                    '';
                     nativeBuildInputs =
                         (with haskellPackages; [
                             cabal-install
@@ -262,6 +343,7 @@
                 checks = {
                     agent-cli = agentCliPackage;
                     agent-core = agentCorePackage;
+                    agent-syntax = agentSyntaxPackage;
                     agent-tui = agentTuiPackage;
                     agent-responses = agentResponsesPackage;
                     agent-openai = agentOpenaiPackage;

--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -91,6 +91,7 @@ library
                     , Agent.CLI.Usage
                     , Agent.CLI.Worktree
     build-depends:    agent-core >= 0.1 && < 0.2
+                    , agent-syntax >= 0.1 && < 0.2
                     , agent-tui >= 0.1 && < 0.2
                     , agent-openai >= 0.1 && < 0.2
                     , agent-openrouter >= 0.1 && < 0.2

--- a/packages/agent-cli/package.nix
+++ b/packages/agent-cli/package.nix
@@ -1,9 +1,9 @@
-{ mkDerivation, aeson, agent-core, agent-tui, agent-openai, agent-openrouter
-, agent-responses, agent-xai, ansi-terminal, async, base
-, base64-bytestring, brick, bytestring, colour, containers
-, directory, filepath, haskeline, hspec, JuicyPixels, lib, mtl, process
-, safe-exceptions, stm, text, time, transformers, unix, vty
-, vty-crossplatform
+{ mkDerivation, aeson, agent-core, agent-openai, agent-openrouter
+, agent-responses, agent-syntax, agent-tui, agent-xai
+, ansi-terminal, async, base, base64-bytestring, brick, bytestring
+, colour, containers, directory, filepath, haskeline, hspec
+, JuicyPixels, lib, mtl, process, safe-exceptions, stm, text, time
+, transformers, unix, vector, vty, vty-crossplatform
 }:
 mkDerivation {
   pname = "agent-cli";
@@ -12,17 +12,18 @@ mkDerivation {
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [
-    aeson agent-core agent-tui agent-openai agent-openrouter agent-responses
-    agent-xai ansi-terminal async base base64-bytestring brick
-    bytestring colour containers directory filepath haskeline JuicyPixels mtl
-    process safe-exceptions stm text time transformers unix vty
-    vty-crossplatform
+    aeson agent-core agent-openai agent-openrouter agent-responses
+    agent-syntax agent-tui agent-xai ansi-terminal async base
+    base64-bytestring brick bytestring colour containers directory
+    filepath haskeline JuicyPixels mtl process safe-exceptions stm text
+    time transformers unix vector vty vty-crossplatform
   ];
   executableHaskellDepends = [ base ];
   testHaskellDepends = [
-    aeson agent-core agent-tui agent-openai agent-responses agent-xai
-    ansi-terminal base bytestring colour containers directory filepath
-    haskeline hspec JuicyPixels process safe-exceptions text time unix vty
+    aeson agent-core agent-openai agent-responses agent-tui agent-xai
+    ansi-terminal base brick bytestring colour containers directory
+    filepath haskeline hspec JuicyPixels process safe-exceptions stm
+    text time transformers unix vty
   ];
   description = "Command-line interface for the universal agent harness";
   license = lib.meta.getLicenseFromSpdxId "BSD-3-Clause";

--- a/packages/agent-cli/src/Agent/CLI/Artifact.hs
+++ b/packages/agent-cli/src/Agent/CLI/Artifact.hs
@@ -5,40 +5,19 @@ module Agent.CLI.Artifact
     , lastDiffBlock
     ) where
 
+import qualified Agent.TUI.FencedCode as FencedCode
 import Data.Text (Text)
 import qualified Data.Text as Text
 
 -- | Markdown fenced blocks as @(language, body)@ pairs.
 fencedBlocks :: Text -> [(Text, Text)]
-fencedBlocks = go . Text.lines
-  where
-    go [] = []
-    go (line:rest) =
-        case fenceStart line of
-            Nothing -> go rest
-            Just (marker, language) ->
-                let (body, remaining) = break (isFenceEnd marker) rest
-                    after = case remaining of
-                        [] -> []
-                        (_:xs) -> xs
-                in (language, Text.unlines body) : go after
-
-    fenceStart line =
-        let stripped = Text.stripStart line
-            opening marker =
-                Just
-                    ( marker
-                    , Text.toLower (Text.strip (Text.drop 3 stripped))
-                    )
-        in if "```" `Text.isPrefixOf` stripped
-            then opening '`'
-            else if "~~~" `Text.isPrefixOf` stripped
-                then opening '~'
-                else Nothing
-
-    isFenceEnd marker line =
-        Text.replicate 3 (Text.singleton marker)
-            `Text.isPrefixOf` Text.stripStart line
+fencedBlocks input =
+    map
+        (\block ->
+            ( Text.toLower (Text.strip block.fencedInfo)
+            , block.fencedBody
+            ))
+        (FencedCode.fencedBlocks input)
 
 fencedCodeBlock :: Int -> Text -> Maybe Text
 fencedCodeBlock index text

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -69,7 +69,10 @@ import Agent.CLI.TUI.ImagePreview
     )
 import Agent.TUI.Markdown
     ( markdownWidget
-    , markdownWidgetWithCodeControls
+    , markdownWidgetWithSyntaxHighlighting
+    )
+import Agent.Syntax
+    ( loadSyntaxHighlighter
     )
 import qualified Agent.CLI.TUI.Scroll as Scroll
 import Agent.CLI.TUI.Types
@@ -165,6 +168,8 @@ newFullscreenRuntime
         imagePreviewIdBase <- allocateNativePreviewImageIdBase
         imagePreviewProtocol <- detectImagePreviewProtocol stdout
         imagePreviewInTmux <- isJust <$> lookupEnv "TMUX"
+        syntaxHighlighter <-
+            either (const Nothing) Just <$> loadSyntaxHighlighter
         pure FullscreenRuntime
             { runtimeEvents = events
             , runtimeMailbox = mailbox
@@ -187,6 +192,7 @@ newFullscreenRuntime
                 imagePreviewProtocol == PreviewKitty
                     && not imagePreviewInTmux
             , runtimeColor = color
+            , runtimeSyntaxHighlighter = syntaxHighlighter
             , runtimeInitial = initial
             }
 
@@ -1625,7 +1631,13 @@ drawBlock state block =
             BlockAssistant ->
                 padLeft (Pad 3) $
                     withAttr Theme.assistantAttr
-                        (markdownWidgetWithCodeControls
+                        (markdownWidgetWithSyntaxHighlighting
+                            state.appRuntime.runtimeSyntaxHighlighter
+                            (\codeIndex ->
+                                cached
+                                    (CodeBlockCache
+                                        block.blockId
+                                        codeIndex))
                             (codeBlockHeader state block.blockId)
                             block.blockBody)
             BlockThinking ->

--- a/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
@@ -23,6 +23,7 @@ import Agent.CLI.TUI.ImagePreview (TuiImagePreview)
 import qualified Agent.CLI.TUI.Scroll as Scroll
 import Agent.Loop (ImageAttachment)
 import Agent.TUI.Model (BlockId, UiEvent, UiState)
+import Agent.Syntax (SyntaxHighlighter)
 import Brick (Location)
 import Brick.BChan (BChan)
 import Control.Concurrent.STM (TMVar, TVar)
@@ -42,6 +43,7 @@ data Name
         !Bool
         !Bool
         !(Maybe (Int, Bool))
+    | CodeBlockCache !BlockId !Int
     | CodeCopy !BlockId !Int
     | ComposerArea
     | ComposerCursor
@@ -121,6 +123,7 @@ data FullscreenRuntime = FullscreenRuntime
     , runtimeImagePreviewIdBase :: !Int
     , runtimeNativeImagePreviews :: !Bool
     , runtimeColor :: !Bool
+    , runtimeSyntaxHighlighter :: !(Maybe SyntaxHighlighter)
     , runtimeInitial :: !UiState
     }
 

--- a/packages/agent-cli/test/Agent/CLI/AgentSessionsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/AgentSessionsSpec.hs
@@ -115,9 +115,10 @@ spec = describe "Agent.CLI.AgentSessions" do
                 second `shouldSatisfy` \case
                     Left err -> "already running" `Text.isInfixOf` err
                     Right _ -> False
-                threadDelay 500000
-                sessionProcessStatus manager handle.sessionMeta.metaId
-                    `shouldReturn` "completed"
+                waitForSessionStatus
+                    manager
+                    handle.sessionMeta.metaId
+                    "completed"
                 closeSessionProcessManager manager
 
     it "does not terminate background sessions when the manager closes" $
@@ -195,6 +196,23 @@ waitForFile path = go (50 :: Int)
         if exists
             then pure ()
             else threadDelay 20000 >> go (attempts - 1)
+
+waitForSessionStatus
+    :: SessionProcessManager
+    -> Text.Text
+    -> Text.Text
+    -> IO ()
+waitForSessionStatus manager sessionId expected = go (100 :: Int)
+  where
+    go attempts
+        | attempts <= 0 = do
+            actual <- sessionProcessStatus manager sessionId
+            actual `shouldBe` expected
+        | otherwise = do
+            actual <- sessionProcessStatus manager sessionId
+            if actual == expected
+                then pure ()
+                else threadDelay 20000 >> go (attempts - 1)
 
 shellQuote :: FilePath -> String
 shellQuote path = "'" <> concatMap escape path <> "'"

--- a/packages/agent-cli/test/Agent/CLI/ArtifactSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ArtifactSpec.hs
@@ -16,6 +16,37 @@ spec = do
             let text = "~~~bash\nprintf 'copy me\\n'\n~~~\n"
             fencedCodeBlock 1 text `shouldBe` Just "printf 'copy me\\n'\n"
 
+        it "matches marker type and requires a sufficiently long closer" do
+            let text =
+                    "````haskell\n"
+                        <> "```\n"
+                        <> "main = pure ()\n"
+                        <> "~~~\n"
+                        <> "`````\n"
+                        <> "~~~bash\n"
+                        <> "echo ok\n"
+                        <> "~~~\n"
+            fencedCodeBlock 1 text
+                `shouldBe` Just "```\nmain = pure ()\n~~~\n"
+            fencedCodeBlock 2 text `shouldBe` Just "echo ok\n"
+
+        it "includes unterminated fences with their exact body" do
+            fencedCodeBlock 1 "before\n```text\nno final newline"
+                `shouldBe` Just "no final newline"
+
+        it "numbers mixed fence types in source order" do
+            let text =
+                    "~~~a\none\n~~~\n"
+                        <> "````b\ntwo\n````\n"
+                        <> "```c\nthree\n```\n"
+            map (`fencedCodeBlock` text) [1, 2, 3, 4]
+                `shouldBe`
+                    [ Just "one\n"
+                    , Just "two\n"
+                    , Just "three\n"
+                    , Nothing
+                    ]
+
     describe "lastDiffBlock" do
         it "selects the last diff-like fence" do
             let text = "```diff\n-old\n+new\n```\n```patch\n-a\n+b\n```\n"

--- a/packages/agent-syntax/LICENSE
+++ b/packages/agent-syntax/LICENSE
@@ -1,0 +1,29 @@
+Copyright (c) 2026, digitally induced GmbH
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following disclaimer
+      in the documentation and/or other materials provided with the distribution.
+
+    * Neither the name of the author nor the names of other
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/packages/agent-syntax/README.md
+++ b/packages/agent-syntax/README.md
@@ -1,0 +1,17 @@
+# agent-syntax
+
+Renderer-independent syntax highlighting for the universal agent harness.
+
+The package owns:
+
+- loading KDE XML syntax definitions through Skylighting
+- Markdown fence language and file-extension resolution
+- bounded tokenization with exact source preservation
+- a stable semantic token-class model for renderers
+
+Syntax definitions are supplied at runtime through `AGENT_SYNTAX_DIR`. The
+repository's Nix flake fetches the pinned upstream definitions and configures
+the variable for tests, development shells, and packaged executables.
+
+Terminal colors, Brick attributes, Markdown layout, and widget caching remain
+in `agent-tui`.

--- a/packages/agent-syntax/agent-syntax.cabal
+++ b/packages/agent-syntax/agent-syntax.cabal
@@ -1,8 +1,9 @@
 cabal-version:      3.0
-name:               agent-tui
+name:               agent-syntax
 version:            0.1.0.0
-synopsis:           Retained terminal UI for the universal agent harness
-description:        Presentation state and Brick widgets for the agent terminal UI.
+synopsis:           Syntax highlighting for the universal agent harness
+description:        Renderer-independent syntax loading, language resolution,
+                    tokenization, and semantic token classes.
 license:            BSD-3-Clause
 license-file:       LICENSE
 author:             digitally induced GmbH
@@ -33,34 +34,20 @@ common common-options
 library
     import:           common-options
     hs-source-dirs:   src
-    exposed-modules:  Agent.TUI.FencedCode
-                    , Agent.TUI.Markdown
-                    , Agent.TUI.Model
-                    , Agent.TUI.Presentation
-                    , Agent.TUI.Theme
-    build-depends:    agent-core >= 0.1 && < 0.2
-                    , agent-syntax >= 0.1 && < 0.2
-                    , aeson >= 2.0 && < 3
-                    , base >= 4.17 && < 5
-                    , brick >= 2.9 && < 3
+    exposed-modules:  Agent.Syntax
+    build-depends:    base >= 4.17 && < 5
                     , containers >= 0.6 && < 0.8
+                    , filepath >= 1.4 && < 1.6
+                    , skylighting-core >= 0.14.7 && < 0.15
                     , text >= 2.0 && < 2.2
-                    , vty >= 6.4 && < 7
 
-test-suite agent-tui-test
+test-suite agent-syntax-test
     import:           common-options
     type:             exitcode-stdio-1.0
     hs-source-dirs:   test
     main-is:          Spec.hs
-    other-modules:    Agent.TUI.FencedCodeSpec
-                    , Agent.TUI.MarkdownSpec
-                    , Agent.TUI.ModelSpec
-                    , Agent.TUI.ThemeSpec
-    build-depends:    agent-tui
-                    , agent-core
-                    , agent-syntax
+    other-modules:    Agent.SyntaxSpec
+    build-depends:    agent-syntax
                     , base >= 4.17 && < 5
-                    , brick >= 2.9 && < 3
                     , hspec >= 2.11 && < 2.12
                     , text
-                    , vty

--- a/packages/agent-syntax/package.nix
+++ b/packages/agent-syntax/package.nix
@@ -1,0 +1,14 @@
+{ mkDerivation, base, containers, filepath, hspec, lib
+, skylighting-core, text
+}:
+mkDerivation {
+  pname = "agent-syntax";
+  version = "0.1.0.0";
+  src = ./.;
+  libraryHaskellDepends = [
+    base containers filepath skylighting-core text
+  ];
+  testHaskellDepends = [ base hspec text ];
+  description = "Syntax highlighting for the universal agent harness";
+  license = lib.meta.getLicenseFromSpdxId "BSD-3-Clause";
+}

--- a/packages/agent-syntax/src/Agent/Syntax.hs
+++ b/packages/agent-syntax/src/Agent/Syntax.hs
@@ -1,0 +1,276 @@
+-- | Renderer-independent syntax highlighting for fenced code blocks.
+--
+-- The public representation deliberately contains semantic token classes
+-- rather than colors so callers can choose their own presentation.
+module Agent.Syntax
+    ( HighlightedLine
+    , SyntaxClass(..)
+    , SyntaxHighlighter
+    , SyntaxSpan(..)
+    , highlightCode
+    , loadSyntaxHighlighter
+    , loadSyntaxHighlighterFrom
+    , resolveFenceLanguage
+    ) where
+
+import Data.Char (ord)
+import qualified Data.Map.Strict as Map
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Skylighting.Core
+    ( SyntaxMap
+    , TokenType(..)
+    , TokenizerConfig(..)
+    , loadValidSyntaxesFromDir
+    , lookupSyntax
+    , tokenize
+    )
+import System.Environment (lookupEnv)
+import System.FilePath (takeExtension, takeFileName)
+import System.IO.Error (tryIOError)
+
+-- | A small, stable set of semantic token classes.
+data SyntaxClass
+    = SyntaxNormal
+    | SyntaxKeyword
+    | SyntaxType
+    | SyntaxFunction
+    | SyntaxVariable
+    | SyntaxString
+    | SyntaxNumber
+    | SyntaxComment
+    | SyntaxOperator
+    | SyntaxAnnotation
+    | SyntaxPreprocessor
+    | SyntaxWarning
+    | SyntaxError
+    deriving (Bounded, Enum, Eq, Ord, Show)
+
+data SyntaxSpan = SyntaxSpan
+    { syntaxClass :: !SyntaxClass
+    , syntaxText :: !Text
+    }
+    deriving (Eq, Show)
+
+type HighlightedLine = [SyntaxSpan]
+
+newtype SyntaxHighlighter = SyntaxHighlighter SyntaxMap
+
+maxHighlightBytes :: Int
+maxHighlightBytes = 256 * 1024
+
+maxHighlightLines :: Int
+maxHighlightLines = 5000
+
+-- | Load the pinned syntax definitions supplied by the runtime environment.
+--
+-- Loading failure is represented as a value so syntax highlighting can always
+-- remain an optional enhancement.
+loadSyntaxHighlighter :: IO (Either Text SyntaxHighlighter)
+loadSyntaxHighlighter =
+    lookupEnv "AGENT_SYNTAX_DIR" >>= \case
+        Nothing ->
+            pure (Left "AGENT_SYNTAX_DIR is not configured")
+        Just syntaxDirectory ->
+            loadSyntaxHighlighterFrom syntaxDirectory
+
+loadSyntaxHighlighterFrom :: FilePath -> IO (Either Text SyntaxHighlighter)
+loadSyntaxHighlighterFrom syntaxDirectory = do
+    result <- tryIOError (loadValidSyntaxesFromDir syntaxDirectory)
+    pure case result of
+        Left exception ->
+            Left ("Could not load syntax definitions: " <> Text.pack (show exception))
+        Right (loadErrors, syntaxMap)
+            | not (Map.null loadErrors) ->
+                Left
+                    ( "Could not load syntax definitions: "
+                        <> Text.intercalate
+                            "; "
+                            [ Text.pack path <> ": " <> Text.pack message
+                            | (path, message) <- Map.toList loadErrors
+                            ]
+                    )
+            | Map.null syntaxMap ->
+                Left "No syntax definitions were installed"
+            | otherwise ->
+                Right (SyntaxHighlighter syntaxMap)
+
+-- | Highlight a fenced code block.
+--
+-- The first 'Text' is the complete fence info string. Unknown languages,
+-- explicit plain-text fences, oversized inputs, and tokenizer failures return
+-- 'Left'; callers should render those blocks with the ordinary code attribute.
+highlightCode
+    :: SyntaxHighlighter
+    -> Text
+    -> Text
+    -> Either Text [HighlightedLine]
+highlightCode (SyntaxHighlighter syntaxMap) fenceInfo source
+    | utf8Length source > maxHighlightBytes =
+        Left "Code block exceeds the syntax-highlighting byte limit"
+    | sourceLineCount source > maxHighlightLines =
+        Left "Code block exceeds the syntax-highlighting line limit"
+    | otherwise = do
+        language <-
+            maybe
+                (Left "Fence does not specify a highlighted language")
+                Right
+                (resolveFenceLanguage fenceInfo)
+        syntax <-
+            maybe
+                (Left ("Unknown syntax language: " <> language))
+                Right
+                (lookupSyntax language syntaxMap)
+        tokenLines <-
+            either (Left . Text.pack) Right $
+                tokenize
+                    TokenizerConfig
+                        { syntaxMap
+                        , traceOutput = False
+                        }
+                    syntax
+                    source
+        preserveSourceLines source (map (map tokenSpan) tokenLines)
+  where
+    tokenSpan (tokenType, tokenText) =
+        SyntaxSpan
+            { syntaxClass = syntaxClassForTokenType tokenType
+            , syntaxText = tokenText
+            }
+
+-- | Resolve a Markdown fence info string to the identifier used for syntax
+-- lookup. The result is normalized but is not guaranteed to name an installed
+-- syntax.
+resolveFenceLanguage :: Text -> Maybe Text
+resolveFenceLanguage info = do
+    firstToken <- case Text.words info of
+        token : _ -> Just token
+        [] -> Nothing
+    let normalized = Text.toLower (Text.strip firstToken)
+        candidate =
+            maybe normalized languageFromPath (lineRangePath normalized)
+        aliased = Map.findWithDefault candidate candidate languageAliases
+    if aliased `elem` plainTextAliases || Text.null aliased
+        then Nothing
+        else Just aliased
+
+lineRangePath :: Text -> Maybe Text
+lineRangePath value =
+    case Text.splitOn ":" value of
+        startLine : endLine : pathParts
+            | not (null pathParts)
+            , isDecimal startLine
+            , isDecimal endLine ->
+                Just (Text.intercalate ":" pathParts)
+        _ -> Nothing
+  where
+    isDecimal text =
+        not (Text.null text)
+            && Text.all (\character -> character >= '0' && character <= '9') text
+
+languageFromPath :: Text -> Text
+languageFromPath path =
+    let fileName = takeFileName (Text.unpack path)
+        extension = takeExtension fileName
+    in if null extension
+        then Text.toLower (Text.pack fileName)
+        else Text.toLower (Text.pack (drop 1 extension))
+
+plainTextAliases :: [Text]
+plainTextAliases =
+    [ "plain"
+    , "plaintext"
+    , "text"
+    , "txt"
+    ]
+
+languageAliases :: Map.Map Text Text
+languageAliases =
+    Map.fromList
+        [ ("c++", "cpp")
+        , ("cs", "csharp")
+        , ("docker", "dockerfile")
+        , ("hs", "haskell")
+        , ("js", "javascript")
+        , ("patch", "diff")
+        , ("py", "python")
+        , ("rs", "rust")
+        , ("sh", "bash")
+        , ("shell", "bash")
+        , ("ts", "typescript")
+        , ("tsx", "jsx")
+        , ("yml", "yaml")
+        ]
+
+-- | Map Skylighting's complete token vocabulary into the smaller semantic set
+-- exposed to renderers.
+syntaxClassForTokenType :: TokenType -> SyntaxClass
+syntaxClassForTokenType = \case
+    KeywordTok -> SyntaxKeyword
+    DataTypeTok -> SyntaxType
+    DecValTok -> SyntaxNumber
+    BaseNTok -> SyntaxNumber
+    FloatTok -> SyntaxNumber
+    ConstantTok -> SyntaxNumber
+    CharTok -> SyntaxString
+    SpecialCharTok -> SyntaxString
+    StringTok -> SyntaxString
+    VerbatimStringTok -> SyntaxString
+    SpecialStringTok -> SyntaxString
+    ImportTok -> SyntaxType
+    CommentTok -> SyntaxComment
+    DocumentationTok -> SyntaxComment
+    AnnotationTok -> SyntaxAnnotation
+    CommentVarTok -> SyntaxComment
+    OtherTok -> SyntaxNormal
+    FunctionTok -> SyntaxFunction
+    VariableTok -> SyntaxVariable
+    ControlFlowTok -> SyntaxKeyword
+    OperatorTok -> SyntaxOperator
+    BuiltInTok -> SyntaxFunction
+    ExtensionTok -> SyntaxType
+    PreprocessorTok -> SyntaxPreprocessor
+    AttributeTok -> SyntaxAnnotation
+    RegionMarkerTok -> SyntaxPreprocessor
+    InformationTok -> SyntaxWarning
+    WarningTok -> SyntaxWarning
+    AlertTok -> SyntaxError
+    ErrorTok -> SyntaxError
+    NormalTok -> SyntaxNormal
+
+preserveSourceLines
+    :: Text
+    -> [HighlightedLine]
+    -> Either Text [HighlightedLine]
+preserveSourceLines source highlightedLines =
+    let sourceLines = Text.splitOn "\n" source
+        highlightedTexts =
+            map (Text.concat . map (.syntaxText)) highlightedLines
+        tokenizedSourceLines = take (length highlightedTexts) sourceLines
+    in if length highlightedTexts > length sourceLines
+        || highlightedTexts /= tokenizedSourceLines
+        then Left "Syntax tokenizer did not preserve the original source text"
+        else
+            Right
+                ( highlightedLines
+                    <> replicate
+                        (length sourceLines - length highlightedLines)
+                        []
+                )
+
+sourceLineCount :: Text -> Int
+sourceLineCount source
+    | Text.null source = 1
+    | otherwise = Text.count "\n" source + 1
+
+utf8Length :: Text -> Int
+utf8Length = Text.foldl' (\total character -> total + utf8CharLength character) 0
+
+utf8CharLength :: Char -> Int
+utf8CharLength character
+    | code <= 0x7f = 1
+    | code <= 0x7ff = 2
+    | code <= 0xffff = 3
+    | otherwise = 4
+  where
+    code = ord character

--- a/packages/agent-syntax/test/Agent/SyntaxSpec.hs
+++ b/packages/agent-syntax/test/Agent/SyntaxSpec.hs
@@ -1,0 +1,129 @@
+module Agent.SyntaxSpec (spec) where
+
+import Agent.Syntax
+import Data.Either (isLeft)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import System.Environment (lookupEnv)
+import Test.Hspec
+
+spec :: Spec
+spec = describe "syntax highlighting" do
+    describe "fence language resolution" do
+        it "normalizes common aliases and case" do
+            resolveFenceLanguage "HS" `shouldBe` Just "haskell"
+            resolveFenceLanguage "py linenums" `shouldBe` Just "python"
+            resolveFenceLanguage "c++" `shouldBe` Just "cpp"
+            resolveFenceLanguage "PATCH" `shouldBe` Just "diff"
+
+        it "resolves Grok line-range file paths by extension" do
+            resolveFenceLanguage "12:40:src/Agent/TUI/Markdown.hs"
+                `shouldBe` Just "haskell"
+            resolveFenceLanguage "1:8:flake.nix"
+                `shouldBe` Just "nix"
+            resolveFenceLanguage "1:8:Dockerfile"
+                `shouldBe` Just "dockerfile"
+
+        it "keeps unknown languages available for a recoverable lookup failure" do
+            resolveFenceLanguage "made-up-language"
+                `shouldBe` Just "made-up-language"
+
+        it "treats plain text aliases as explicitly unhighlighted" do
+            map resolveFenceLanguage ["text", "txt", "plain", "plaintext"]
+                `shouldBe` replicate 4 Nothing
+
+    it "loads the packaged grammar set and highlights representative languages" do
+        highlighter <- requireHighlighter
+        mapM_
+            (\(language, source) ->
+                highlightCode highlighter language source
+                    `shouldSatisfy` either (const False) (not . null))
+            [ ("haskell", "main = putStrLn \"hello\"")
+            , ("bash", "printf '%s\\n' hello")
+            , ("c", "int main(void) { return 0; }")
+            , ("cpp", "auto answer = 42;")
+            , ("cs", "class Program { static void Main() {} }")
+            , ("css", "body { color: red; }")
+            , ("dockerfile", "FROM scratch")
+            , ("go", "package main\nfunc main() {}")
+            , ("html", "<main>Hello</main>")
+            , ("java", "class Main {}")
+            , ("python", "print(\"hello\")")
+            , ("javascript", "const answer = 42;")
+            , ("typescript", "const answer: number = 42;")
+            , ("json", "{\"answer\": 42}")
+            , ("kotlin", "fun main() = println(\"hello\")")
+            , ("lua", "local answer = 42")
+            , ("markdown", "# Hello")
+            , ("nix", "{ pkgs, ... }: pkgs.hello")
+            , ("rust", "fn main() { println!(\"hello\"); }")
+            , ("diff", "-before\n+after")
+            , ("sql", "select answer from results;")
+            , ("swift", "let answer = 42")
+            , ("toml", "answer = 42")
+            , ("xml", "<answer>42</answer>")
+            , ("yml", "answer: 42")
+            , ("zig", "pub fn main() void {}")
+            ]
+
+    it "preserves source text including Unicode, blank lines, and a trailing newline" do
+        highlighter <- requireHighlighter
+        let source = "{- λ\n\ncomment\n-}\nmain = putStrLn \"hello\"\n"
+        highlighted <- requireHighlight (highlightCode highlighter "haskell" source)
+        reconstruct highlighted `shouldBe` source
+
+    it "retains multiline lexer state across blank lines" do
+        highlighter <- requireHighlighter
+        highlighted <-
+            requireHighlight $
+                highlightCode
+                    highlighter
+                    "haskell"
+                    "{-\n\ninside comment\n-}\nmain = pure ()"
+        let lineInsideComment = highlighted !! 2
+        lineInsideComment `shouldSatisfy` (not . null)
+        map (.syntaxClass) lineInsideComment
+            `shouldSatisfy` all (== SyntaxComment)
+
+    it "returns recoverable failures for unknown and explicit plain languages" do
+        highlighter <- requireHighlighter
+        highlightCode highlighter "not-a-real-language" "hello"
+            `shouldSatisfy` isLeft
+        highlightCode highlighter "text" "hello"
+            `shouldSatisfy` isLeft
+
+    it "refuses blocks above the byte and line limits" do
+        highlighter <- requireHighlighter
+        highlightCode highlighter "haskell" (Text.replicate (256 * 1024 + 1) "a")
+            `shouldSatisfy` isLeft
+        highlightCode highlighter "haskell" (Text.replicate 5000 "\n")
+            `shouldSatisfy` isLeft
+
+requireHighlighter :: IO SyntaxHighlighter
+requireHighlighter = do
+    syntaxDirectory <- sourceSyntaxDirectory
+    loadSyntaxHighlighterFrom syntaxDirectory >>= \case
+        Left message -> expectationFailure (Text.unpack message) >> fail "unreachable"
+        Right highlighter -> pure highlighter
+
+sourceSyntaxDirectory :: IO FilePath
+sourceSyntaxDirectory =
+    lookupEnv "AGENT_SYNTAX_DIR" >>= \case
+        Nothing -> do
+            expectationFailure
+                "AGENT_SYNTAX_DIR is not set; run tests from nix develop"
+            fail "unreachable"
+        Just syntaxDirectory ->
+            pure syntaxDirectory
+
+requireHighlight
+    :: Either Text [HighlightedLine]
+    -> IO [HighlightedLine]
+requireHighlight = \case
+    Left message -> expectationFailure (Text.unpack message) >> fail "unreachable"
+    Right highlighted -> pure highlighted
+
+reconstruct :: [HighlightedLine] -> Text
+reconstruct =
+    Text.intercalate "\n"
+        . map (Text.concat . map (.syntaxText))

--- a/packages/agent-syntax/test/Spec.hs
+++ b/packages/agent-syntax/test/Spec.hs
@@ -1,0 +1,7 @@
+module Main (main) where
+
+import qualified Agent.SyntaxSpec as SyntaxSpec
+import Test.Hspec (hspec)
+
+main :: IO ()
+main = hspec SyntaxSpec.spec

--- a/packages/agent-tui/README.md
+++ b/packages/agent-tui/README.md
@@ -9,6 +9,8 @@ This package owns presentation state and reusable Brick/Vty rendering:
 - `Agent.TUI.Theme` — semantic Brick attributes and themes
 - `Agent.TUI.Presentation` — plain tool-call presentation helpers
 
+Renderer-independent syntax loading and tokenization live in `agent-syntax`.
+
 The CLI-specific runtime adapter remains in `agent-cli` as
 `Agent.CLI.TUI.App`. It coordinates clipboard access, command completion,
 permissions, interrupts, history, and agent selection while depending on this

--- a/packages/agent-tui/package.nix
+++ b/packages/agent-tui/package.nix
@@ -1,15 +1,15 @@
-{ mkDerivation, aeson, agent-core, base, brick, containers, hspec
-, lib, text, vty
+{ mkDerivation, aeson, agent-core, agent-syntax, base, brick
+, containers, hspec, lib, text, vty
 }:
 mkDerivation {
   pname = "agent-tui";
   version = "0.1.0.0";
   src = ./.;
   libraryHaskellDepends = [
-    aeson agent-core base brick containers text vty
+    aeson agent-core agent-syntax base brick containers text vty
   ];
   testHaskellDepends = [
-    agent-core base hspec text
+    agent-core agent-syntax base brick hspec text vty
   ];
   description = "Retained terminal UI for the universal agent harness";
   license = lib.meta.getLicenseFromSpdxId "BSD-3-Clause";

--- a/packages/agent-tui/src/Agent/TUI/FencedCode.hs
+++ b/packages/agent-tui/src/Agent/TUI/FencedCode.hs
@@ -1,0 +1,143 @@
+-- | Shared Markdown fenced-code parsing.
+--
+-- The fullscreen renderer and copy-code commands use this module so their
+-- block numbering and fence matching cannot drift apart.
+module Agent.TUI.FencedCode
+    ( FenceMarker(..)
+    , FencedBlock(..)
+    , FenceChunk(..)
+    , fenceOpener
+    , isFenceCloser
+    , fenceChunks
+    , fencedBlocks
+    ) where
+
+import Data.Char (isSpace)
+import Data.Text (Text)
+import qualified Data.Text as Text
+
+data FenceMarker = FenceMarker
+    { fenceCharacter :: !Char
+    , fenceLength :: !Int
+    }
+    deriving (Eq, Show)
+
+-- | Markdown source split into prose and fenced-code chunks in source order.
+-- Delimiter lines are represented by the metadata on 'FenceBlock', rather than
+-- repeated in the surrounding prose.
+data FenceChunk
+    = FenceText !Text
+    | FenceBlock !FencedBlock
+    deriving (Eq, Show)
+
+data FencedBlock = FencedBlock
+    { fencedIndex :: !Int
+    , fencedMarker :: !FenceMarker
+    , fencedInfo :: !Text
+    , fencedBody :: !Text
+    , fencedClosed :: !Bool
+    }
+    deriving (Eq, Show)
+
+-- | Parse a fence opener, allowing the zero-to-three leading spaces permitted
+-- by Markdown. Backtick fence info strings may not themselves contain a
+-- backtick.
+fenceOpener :: Text -> Maybe (FenceMarker, Text)
+fenceOpener line = do
+    stripped <- stripFenceIndent line
+    character <- Text.uncons stripped >>= \(first, _) ->
+        if first == '`' || first == '~'
+            then Just first
+            else Nothing
+    let
+        (markerText, suffix) = Text.span (== character) stripped
+        marker = FenceMarker character (Text.length markerText)
+        info = Text.strip suffix
+    if marker.fenceLength < 3
+        || (character == '`' && Text.any (== '`') info)
+        then Nothing
+        else Just (marker, info)
+
+-- | Whether a line closes a particular opener. A closer must use the same
+-- marker character, be at least as long, and contain only trailing whitespace.
+isFenceCloser :: FenceMarker -> Text -> Bool
+isFenceCloser marker line =
+    case stripFenceIndent line of
+        Nothing -> False
+        Just stripped ->
+            let (markerText, suffix) =
+                    Text.span (== marker.fenceCharacter) stripped
+            in Text.length markerText >= marker.fenceLength
+                && Text.all isSpace suffix
+
+-- | Split Markdown into prose and fenced blocks in source order. Unterminated
+-- blocks are included with 'fencedClosed' set to 'False'. Prose and body text
+-- retain their original line endings.
+fenceChunks :: Text -> [FenceChunk]
+fenceChunks = go 1 [] . sourceLines
+  where
+    go _ prose [] = proseChunk prose
+    go index prose (line : rest) =
+        case fenceOpener line.lineText of
+            Nothing -> go index (line : prose) rest
+            Just (marker, info) ->
+                let
+                    (bodyLines, closingAndRest) =
+                        break (isFenceCloser marker . (.lineText)) rest
+                    (closed, remaining) =
+                        case closingAndRest of
+                            [] -> (False, [])
+                            _closing : after -> (True, after)
+                    block = FencedBlock
+                        { fencedIndex = index
+                        , fencedMarker = marker
+                        , fencedInfo = info
+                        , fencedBody =
+                            foldMap
+                                (\bodyLine ->
+                                    bodyLine.lineText <> bodyLine.lineEnding)
+                                bodyLines
+                        , fencedClosed = closed
+                        }
+                in proseChunk prose
+                    <> [FenceBlock block]
+                    <> go (index + 1) [] remaining
+
+    proseChunk [] = []
+    proseChunk reversedLines =
+        [FenceText (foldMap sourceLineText (reverse reversedLines))]
+
+-- | Extract all fenced blocks in source order.
+fencedBlocks :: Text -> [FencedBlock]
+fencedBlocks =
+    foldr
+        (\chunk rest ->
+            case chunk of
+                FenceText _ -> rest
+                FenceBlock block -> block : rest)
+        []
+        . fenceChunks
+
+data SourceLine = SourceLine
+    { lineText :: !Text
+    , lineEnding :: !Text
+    }
+
+sourceLines :: Text -> [SourceLine]
+sourceLines input
+    | Text.null input = []
+    | otherwise =
+        let (line, suffix) = Text.breakOn "\n" input
+        in if Text.null suffix
+            then [SourceLine line ""]
+            else SourceLine line "\n" : sourceLines (Text.drop 1 suffix)
+
+sourceLineText :: SourceLine -> Text
+sourceLineText line = line.lineText <> line.lineEnding
+
+stripFenceIndent :: Text -> Maybe Text
+stripFenceIndent line =
+    let (spaces, stripped) = Text.span (== ' ') line
+    in if Text.length spaces <= 3
+        then Just stripped
+        else Nothing

--- a/packages/agent-tui/src/Agent/TUI/Markdown.hs
+++ b/packages/agent-tui/src/Agent/TUI/Markdown.hs
@@ -5,9 +5,21 @@ module Agent.TUI.Markdown
     , inlinePlainText
     , markdownWidget
     , markdownWidgetWithCodeControls
+    , markdownWidgetWithSyntaxHighlighting
     , parseInline
     ) where
 
+import Agent.TUI.FencedCode
+    ( FenceChunk(..)
+    , FencedBlock(..)
+    , fenceChunks
+    )
+import Agent.Syntax
+    ( HighlightedLine
+    , SyntaxHighlighter
+    , SyntaxSpan(..)
+    , highlightCode
+    )
 import qualified Agent.TUI.Theme as Theme
 import Brick
 import qualified Brick.Types as B
@@ -86,66 +98,147 @@ markdownWidgetWithCodeControls
     -> Text
     -> Widget n
 markdownWidgetWithCodeControls codeHeader input =
-    vBox (renderLines codeHeader 1 False (Text.lines input))
+    markdownWidgetWithSyntaxHighlighting
+        Nothing
+        (\_ widget -> widget)
+        codeHeader
+        input
+
+-- | Render Markdown with optional token-level highlighting for closed fenced
+-- code blocks. The cache callback receives the stable one-based fence index;
+-- callers can use it to retain completed code bodies while later prose
+-- continues streaming.
+markdownWidgetWithSyntaxHighlighting
+    :: Maybe SyntaxHighlighter
+    -> (Int -> Widget n -> Widget n)
+    -> (Int -> Text -> Widget n)
+    -> Text
+    -> Widget n
+markdownWidgetWithSyntaxHighlighting syntaxHighlighter cacheCode codeHeader input =
+    vBox $
+        concatMap
+            (renderChunk syntaxHighlighter cacheCode codeHeader)
+            (fenceChunks input)
+
+renderChunk
+    :: Maybe SyntaxHighlighter
+    -> (Int -> Widget n -> Widget n)
+    -> (Int -> Text -> Widget n)
+    -> FenceChunk
+    -> [Widget n]
+renderChunk _ _ _ (FenceText prose) =
+    renderLines (Text.lines prose)
+renderChunk syntaxHighlighter cacheCode codeHeader (FenceBlock block) =
+    [ codeHeader block.fencedIndex block.fencedInfo
+    , if block.fencedClosed
+        then cacheCode block.fencedIndex bodyWidget
+        else bodyWidget
+    ]
+  where
+    bodyWidget =
+        renderCodeBody
+            (if block.fencedClosed then syntaxHighlighter else Nothing)
+            block.fencedInfo
+            (codeBodyLines block.fencedBody)
 
 renderLines
-    :: (Int -> Text -> Widget n)
-    -> Int
-    -> Bool
-    -> [Text]
+    :: [Text]
     -> [Widget n]
-renderLines _ _ _ [] = []
-renderLines codeHeader codeIndex False lines_
+renderLines [] = []
+renderLines lines_
     | Just (table, rest) <- takeTable lines_ =
-        table : renderLines codeHeader codeIndex False rest
-renderLines codeHeader codeIndex inFence (line : rest)
-    | isFence line =
-        let language = Text.strip (Text.drop 3 (Text.stripStart line))
-        in if inFence
-            then renderLines codeHeader codeIndex False rest
-            else
-                codeHeader codeIndex language
-                    : renderLines codeHeader (codeIndex + 1) True rest
-    | inFence =
-        withAttr Theme.codeAttr
-            (padLeftRight 1 (txt line))
-            : renderLines codeHeader codeIndex True rest
+        table : renderLines rest
+renderLines (line : rest)
     | Just heading <- stripHeading line =
         withAttr Theme.headingAttr
             (padTop (Pad 1) (inlineWidget (parseInline heading)))
-            : renderLines codeHeader codeIndex False rest
+            : renderLines rest
     | Just item <- stripBullet line =
         hBox
             [ withAttr Theme.headingAttr (txt "• ")
             , inlineWidget (parseInline item)
             ]
-            : renderLines codeHeader codeIndex False rest
+            : renderLines rest
     | Just (number, item) <- stripOrdered line =
         hBox
             [ withAttr Theme.headingAttr (txt (number <> ". "))
             , inlineWidget (parseInline item)
             ]
-            : renderLines codeHeader codeIndex False rest
+            : renderLines rest
     | Just quote <- Text.stripPrefix "> " (Text.stripStart line) =
         hBox
             [ withAttr Theme.mutedAttr (txt "│ ")
             , withAttr Theme.mutedAttr (inlineWidget (parseInline quote))
             ]
-            : renderLines codeHeader codeIndex False rest
+            : renderLines rest
     | Text.null (Text.strip line) =
-        txt " " : renderLines codeHeader codeIndex False rest
+        txt " " : renderLines rest
     | isThematicBreak line =
         withAttr Theme.mutedAttr (vLimit 1 (fill '─'))
-            : renderLines codeHeader codeIndex False rest
+            : renderLines rest
     | otherwise =
         inlineWidget (parseInline line)
-            : renderLines codeHeader codeIndex False rest
+            : renderLines rest
 
-isFence :: Text -> Bool
-isFence line =
-    let stripped = Text.stripStart line
-    in "```" `Text.isPrefixOf` stripped
-        || "~~~" `Text.isPrefixOf` stripped
+codeBodyLines :: Text -> [Text]
+codeBodyLines body
+    | Text.null body = []
+    | Text.isSuffixOf "\n" body =
+        dropLast (Text.splitOn "\n" body)
+    | otherwise =
+        Text.splitOn "\n" body
+  where
+    dropLast = reverse . drop 1 . reverse
+
+renderCodeBody
+    :: Maybe SyntaxHighlighter
+    -> Text
+    -> [Text]
+    -> Widget n
+renderCodeBody syntaxHighlighter language bodyLines =
+    -- Keep tokenization inside the render action. Brick's 'cached' inspects a
+    -- widget's size policy before consulting its cache; returning a concrete
+    -- vBox here would therefore force tokenization on every streamed redraw.
+    B.Widget B.Fixed B.Fixed $
+        B.render (buildCodeBody syntaxHighlighter language bodyLines)
+
+buildCodeBody
+    :: Maybe SyntaxHighlighter
+    -> Text
+    -> [Text]
+    -> Widget n
+buildCodeBody syntaxHighlighter language bodyLines =
+    vBox $
+        case syntaxHighlighter >>= highlighted of
+            Just highlightedLines
+                | length highlightedLines == length bodyLines ->
+                    map renderHighlightedCodeLine highlightedLines
+            _ -> map renderFlatCodeLine bodyLines
+  where
+    highlighted highlighter =
+        either (const Nothing) Just $
+            highlightCode
+                highlighter
+                language
+                (Text.intercalate "\n" bodyLines)
+
+renderFlatCodeLine :: Text -> Widget n
+renderFlatCodeLine =
+    withAttr Theme.codeAttr . padLeftRight 1 . txt
+
+renderHighlightedCodeLine :: HighlightedLine -> Widget n
+renderHighlightedCodeLine spans =
+    withAttr Theme.codeAttr $
+        padLeftRight 1 $
+            case spans of
+                [] -> txt ""
+                _ ->
+                    hBox
+                        [ withAttr
+                            (Theme.syntaxClassAttr span_.syntaxClass)
+                            (txt span_.syntaxText)
+                        | span_ <- spans
+                        ]
 
 stripHeading :: Text -> Maybe Text
 stripHeading line =

--- a/packages/agent-tui/src/Agent/TUI/Theme.hs
+++ b/packages/agent-tui/src/Agent/TUI/Theme.hs
@@ -24,6 +24,20 @@ module Agent.TUI.Theme
     , selectedAttr
     , strongAttr
     , successAttr
+    , syntaxAnnotationAttr
+    , syntaxCommentAttr
+    , syntaxErrorAttr
+    , syntaxFunctionAttr
+    , syntaxKeywordAttr
+    , syntaxNormalAttr
+    , syntaxNumberAttr
+    , syntaxOperatorAttr
+    , syntaxPreprocessorAttr
+    , syntaxStringAttr
+    , syntaxTypeAttr
+    , syntaxVariableAttr
+    , syntaxWarningAttr
+    , syntaxClassAttr
     , thinkingAttr
     , toolAttr
     , userAttr
@@ -31,6 +45,7 @@ module Agent.TUI.Theme
     , solarizedDark
     ) where
 
+import Agent.Syntax (SyntaxClass(..))
 import Brick (AttrMap, AttrName, attrMap, attrName)
 import Data.Bits ((.|.))
 import qualified Graphics.Vty as V
@@ -41,6 +56,10 @@ errorAttr, successAttr, selectedAttr, borderAttr, borderActiveAttr :: AttrName
 headingAttr, codeAttr, dimAttr, emphasisAttr, inlineCodeAttr, linkAttr, strongAttr :: AttrName
 controlLinkAttr, controlLinkHoverAttr, controlLinkActiveAttr :: AttrName
 lambdaDimAttr, lambdaTrailAttr, lambdaGlowAttr, lambdaSparkAttr :: AttrName
+syntaxNormalAttr, syntaxKeywordAttr, syntaxTypeAttr, syntaxFunctionAttr :: AttrName
+syntaxVariableAttr, syntaxStringAttr, syntaxNumberAttr, syntaxCommentAttr :: AttrName
+syntaxOperatorAttr, syntaxAnnotationAttr, syntaxPreprocessorAttr :: AttrName
+syntaxWarningAttr, syntaxErrorAttr :: AttrName
 baseAttr = attrName "base"
 headerAttr = attrName "header"
 footerAttr = attrName "footer"
@@ -68,6 +87,35 @@ strongAttr = attrName "markdown-strong"
 controlLinkAttr = attrName "control-link"
 controlLinkHoverAttr = attrName "control-link-hover"
 controlLinkActiveAttr = attrName "control-link-active"
+syntaxNormalAttr = attrName "syntax-normal"
+syntaxKeywordAttr = attrName "syntax-keyword"
+syntaxTypeAttr = attrName "syntax-type"
+syntaxFunctionAttr = attrName "syntax-function"
+syntaxVariableAttr = attrName "syntax-variable"
+syntaxStringAttr = attrName "syntax-string"
+syntaxNumberAttr = attrName "syntax-number"
+syntaxCommentAttr = attrName "syntax-comment"
+syntaxOperatorAttr = attrName "syntax-operator"
+syntaxAnnotationAttr = attrName "syntax-annotation"
+syntaxPreprocessorAttr = attrName "syntax-preprocessor"
+syntaxWarningAttr = attrName "syntax-warning"
+syntaxErrorAttr = attrName "syntax-error"
+
+syntaxClassAttr :: SyntaxClass -> AttrName
+syntaxClassAttr = \case
+    SyntaxNormal -> syntaxNormalAttr
+    SyntaxKeyword -> syntaxKeywordAttr
+    SyntaxType -> syntaxTypeAttr
+    SyntaxFunction -> syntaxFunctionAttr
+    SyntaxVariable -> syntaxVariableAttr
+    SyntaxString -> syntaxStringAttr
+    SyntaxNumber -> syntaxNumberAttr
+    SyntaxComment -> syntaxCommentAttr
+    SyntaxOperator -> syntaxOperatorAttr
+    SyntaxAnnotation -> syntaxAnnotationAttr
+    SyntaxPreprocessor -> syntaxPreprocessorAttr
+    SyntaxWarning -> syntaxWarningAttr
+    SyntaxError -> syntaxErrorAttr
 
 solarizedDark :: AttrMap
 solarizedDark =
@@ -165,6 +213,22 @@ solarizedDark =
             `V.withForeColor` rgb 0 43 54
             `V.withBackColor` rgb 38 139 210
             `V.withStyle` V.bold)
+        , (syntaxNormalAttr, codeColor 42 161 152)
+        , (syntaxKeywordAttr, codeColor 211 54 130)
+        , (syntaxTypeAttr, codeColor 181 137 0)
+        , (syntaxFunctionAttr, codeColor 38 139 210)
+        , (syntaxVariableAttr, codeColor 42 161 152)
+        , (syntaxStringAttr, codeColor 42 161 152)
+        , (syntaxNumberAttr, codeColor 108 113 196)
+        , (syntaxCommentAttr,
+            codeColor 88 110 117 `V.withStyle` V.italic)
+        , (syntaxOperatorAttr, codeColor 203 75 22)
+        , (syntaxAnnotationAttr, codeColor 133 153 0)
+        , (syntaxPreprocessorAttr, codeColor 203 75 22)
+        , (syntaxWarningAttr,
+            codeColor 181 137 0 `V.withStyle` V.bold)
+        , (syntaxErrorAttr,
+            codeColor 220 50 47 `V.withStyle` V.bold)
         ]
 
 monochrome :: AttrMap
@@ -199,7 +263,27 @@ monochrome =
         , (controlLinkHoverAttr, V.defAttr
             `V.withStyle` (V.underline .|. V.bold))
         , (controlLinkActiveAttr, V.defAttr `V.withStyle` V.reverseVideo)
+        , (syntaxNormalAttr, V.defAttr)
+        , (syntaxKeywordAttr, V.defAttr `V.withStyle` V.bold)
+        , (syntaxTypeAttr, V.defAttr `V.withStyle` V.bold)
+        , (syntaxFunctionAttr, V.defAttr `V.withStyle` V.bold)
+        , (syntaxVariableAttr, V.defAttr)
+        , (syntaxStringAttr, V.defAttr)
+        , (syntaxNumberAttr, V.defAttr)
+        , (syntaxCommentAttr, V.defAttr `V.withStyle` V.italic)
+        , (syntaxOperatorAttr, V.defAttr)
+        , (syntaxAnnotationAttr, V.defAttr `V.withStyle` V.bold)
+        , (syntaxPreprocessorAttr, V.defAttr `V.withStyle` V.bold)
+        , (syntaxWarningAttr, V.defAttr `V.withStyle` V.bold)
+        , (syntaxErrorAttr, V.defAttr
+            `V.withStyle` (V.bold .|. V.reverseVideo))
         ]
+
+codeColor :: Int -> Int -> Int -> V.Attr
+codeColor r g b =
+    V.defAttr
+        `V.withForeColor` rgb r g b
+        `V.withBackColor` rgb 7 54 66
 
 rgb :: Int -> Int -> Int -> V.Color
 rgb r g b =

--- a/packages/agent-tui/test/Agent/TUI/FencedCodeSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/FencedCodeSpec.hs
@@ -1,0 +1,69 @@
+module Agent.TUI.FencedCodeSpec (spec) where
+
+import Agent.TUI.FencedCode
+import Test.Hspec
+
+spec :: Spec
+spec = describe "fencedBlocks" do
+    it "returns prose and fences in source order for rendering" do
+        let chunks =
+                fenceChunks
+                    "before\n```hs\none\n```\nbetween\n~~~sh\ntwo\n"
+        case chunks of
+            [ FenceText before
+                , FenceBlock first
+                , FenceText between
+                , FenceBlock second
+                ] -> do
+                    before `shouldBe` "before\n"
+                    first.fencedIndex `shouldBe` 1
+                    first.fencedBody `shouldBe` "one\n"
+                    first.fencedClosed `shouldBe` True
+                    between `shouldBe` "between\n"
+                    second.fencedIndex `shouldBe` 2
+                    second.fencedBody `shouldBe` "two\n"
+                    second.fencedClosed `shouldBe` False
+            _ -> expectationFailure ("unexpected chunks: " <> show chunks)
+
+    it "matches the opener character and accepts a longer closer" do
+        let blocks =
+                fencedBlocks
+                    "````haskell\n```\nmain = pure ()\n`````\n~~~sh\necho ok\n~~~\n"
+        map (.fencedInfo) blocks `shouldBe` ["haskell", "sh"]
+        map (.fencedBody) blocks
+            `shouldBe` ["```\nmain = pure ()\n", "echo ok\n"]
+        map (.fencedClosed) blocks `shouldBe` [True, True]
+        map (.fencedIndex) blocks `shouldBe` [1, 2]
+
+    it "does not close a fence with a different marker or a shorter run" do
+        case fencedBlocks "````\na\n~~~\nb\n```\nc\n" of
+            [block] -> do
+                block.fencedBody `shouldBe` "a\n~~~\nb\n```\nc\n"
+                block.fencedClosed `shouldBe` False
+            blocks ->
+                expectationFailure
+                    ("expected one block, got " <> show blocks)
+
+    it "allows up to three leading spaces but not four" do
+        let blocks =
+                fencedBlocks
+                    "    ```ignored\nx\n   ~~~ diff\n-old\n+new\n  ~~~   \n"
+        map (.fencedInfo) blocks `shouldBe` ["diff"]
+        map (.fencedBody) blocks `shouldBe` ["-old\n+new\n"]
+
+    it "preserves an unterminated body and its final newline state" do
+        case
+            ( fencedBlocks "```text\none"
+            , fencedBlocks "```text\none\n"
+            ) of
+            ([withoutNewline], [withNewline]) -> do
+                withoutNewline.fencedBody `shouldBe` "one"
+                withNewline.fencedBody `shouldBe` "one\n"
+                withoutNewline.fencedClosed `shouldBe` False
+                withNewline.fencedClosed `shouldBe` False
+            blocks ->
+                expectationFailure
+                    ("expected one block in each input, got " <> show blocks)
+
+    it "rejects backticks in a backtick fence info string" do
+        fenceOpener "```lang`bad" `shouldBe` Nothing

--- a/packages/agent-tui/test/Agent/TUI/MarkdownSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/MarkdownSpec.hs
@@ -1,8 +1,11 @@
 module Agent.TUI.MarkdownSpec (spec) where
 
 import Agent.TUI.Markdown
+import Agent.Syntax (loadSyntaxHighlighterFrom)
+import qualified Agent.TUI.Theme as Theme
 import Brick
-    ( ViewportType(..)
+    ( (<=>)
+    , ViewportType(..)
     , Widget
     , renderWidget
     , txt
@@ -10,6 +13,7 @@ import Brick
     )
 import Data.List (isInfixOf)
 import qualified Data.Text as Text
+import System.Environment (lookupEnv)
 import Test.Hspec
 
 spec :: Spec
@@ -54,6 +58,60 @@ spec = describe "fullscreen Markdown inline parsing" do
         rendered `shouldSatisfy` isInfixOf "1:bash"
         rendered `shouldSatisfy` isInfixOf "2:haskell"
 
+    it "caches closed fence bodies but leaves open streaming fences uncached" do
+        let render input =
+                let widget :: Widget ()
+                    widget =
+                        markdownWidgetWithSyntaxHighlighting
+                            Nothing
+                            (\index widget ->
+                                txt ("cached-" <> Text.pack (show index))
+                                    <=> widget)
+                            (\index language ->
+                                txt (Text.pack (show index) <> ":" <> language))
+                            input
+                in show (renderWidget Nothing [widget] (40, 12))
+            closed = render "```haskell\nmain = pure ()\n```"
+            open = render "```haskell\nmain = pure ()"
+        closed `shouldSatisfy` isInfixOf "cached-1"
+        open `shouldSatisfy` (not . isInfixOf "cached-1")
+
+    it "keeps shorter nested markers inside a longer fence" do
+        let widget :: Widget ()
+            widget =
+                markdownWidgetWithCodeControls
+                    (\index language ->
+                        txt (Text.pack (show index) <> ":" <> language))
+                    "````markdown\n```haskell\nmain = pure ()\n```\n````"
+            rendered = show (renderWidget Nothing [widget] (40, 12))
+        rendered `shouldSatisfy` isInfixOf "1:markdown"
+        rendered `shouldSatisfy` (not . isInfixOf "2:haskell")
+
+    it "applies semantic syntax attributes only after a fence closes" do
+        syntaxDirectory <- sourceSyntaxDirectory
+        loadSyntaxHighlighterFrom syntaxDirectory >>= \case
+            Left message -> expectationFailure (Text.unpack message)
+            Right highlighter -> do
+                let render input =
+                        let widget :: Widget ()
+                            widget =
+                                markdownWidgetWithSyntaxHighlighting
+                                    (Just highlighter)
+                                    (\_ body -> body)
+                                    (\_ _ -> txt "")
+                                    input
+                        in show $
+                            renderWidget
+                                (Just Theme.solarizedDark)
+                                [widget]
+                                (80, 8)
+                    closed =
+                        render "```haskell\nmain = putStrLn \"hello\"\n```"
+                    open =
+                        render "```haskell\nmain = putStrLn \"hello\""
+                closed `shouldSatisfy` isInfixOf "RGBColor 38 139 210"
+                open `shouldSatisfy` (not . isInfixOf "RGBColor 38 139 210")
+
     it "renders thematic breaks inside a vertical viewport" do
         let widget :: Widget ()
             widget =
@@ -61,3 +119,13 @@ spec = describe "fullscreen Markdown inline parsing" do
                     markdownWidget "---\n\n***\n\n___"
             rendered = show (renderWidget Nothing [widget] (40, 12))
         rendered `shouldSatisfy` (not . null)
+
+sourceSyntaxDirectory :: IO FilePath
+sourceSyntaxDirectory =
+    lookupEnv "AGENT_SYNTAX_DIR" >>= \case
+        Nothing -> do
+            expectationFailure
+                "AGENT_SYNTAX_DIR is not set; run tests from nix develop"
+            fail "unreachable"
+        Just syntaxDirectory ->
+            pure syntaxDirectory

--- a/packages/agent-tui/test/Agent/TUI/ThemeSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ThemeSpec.hs
@@ -1,0 +1,39 @@
+module Agent.TUI.ThemeSpec (spec) where
+
+import Agent.Syntax (SyntaxClass(..))
+import qualified Agent.TUI.Theme as Theme
+import Brick.AttrMap (attrMapLookup)
+import qualified Graphics.Vty as V
+import Test.Hspec
+
+spec :: Spec
+spec = describe "syntax theme attributes" do
+    it "keeps every Solarized syntax class on the code-block background" do
+        let codeBackground =
+                V.attrBackColor
+                    (attrMapLookup Theme.codeAttr Theme.solarizedDark)
+        map
+            ( V.attrBackColor
+                . (`attrMapLookup` Theme.solarizedDark)
+                . Theme.syntaxClassAttr
+            )
+            allSyntaxClasses
+            `shouldBe` replicate (length allSyntaxClasses) codeBackground
+
+    it "does not introduce colors in monochrome mode" do
+        map
+            ( \syntaxClass ->
+                let attr =
+                        attrMapLookup
+                            (Theme.syntaxClassAttr syntaxClass)
+                            Theme.monochrome
+                in (V.attrForeColor attr, V.attrBackColor attr)
+            )
+            allSyntaxClasses
+            `shouldBe`
+                replicate
+                    (length allSyntaxClasses)
+                    (V.Default, V.Default)
+
+allSyntaxClasses :: [SyntaxClass]
+allSyntaxClasses = [minBound .. maxBound]

--- a/packages/agent-tui/test/Spec.hs
+++ b/packages/agent-tui/test/Spec.hs
@@ -1,10 +1,14 @@
 module Main (main) where
 
+import qualified Agent.TUI.FencedCodeSpec as FencedCodeSpec
 import qualified Agent.TUI.MarkdownSpec as MarkdownSpec
 import qualified Agent.TUI.ModelSpec as ModelSpec
+import qualified Agent.TUI.ThemeSpec as ThemeSpec
 import Test.Hspec (hspec)
 
 main :: IO ()
 main = hspec do
+    FencedCodeSpec.spec
     MarkdownSpec.spec
     ModelSpec.spec
+    ThemeSpec.spec


### PR DESCRIPTION
## Summary

- add token-level syntax highlighting for closed fenced code blocks in the fullscreen Brick TUI
- introduce `agent-syntax`, a renderer-independent package for syntax loading, language resolution, bounded tokenization, and semantic token classes
- keep Brick rendering, widget caching, and Solarized/monochrome attributes in `agent-tui`
- share marker-aware fenced-code parsing with artifact copying and cache closed code widgets
- pin `jgm/skylighting` and build `skylighting-core` from that flake input
- fetch all 166 upstream XML syntax definitions into a separate `skylighting-syntaxes` Nix output instead of vendoring them in Git
- configure `AGENT_SYNTAX_DIR` for `agent-syntax` tests, `agent-tui` integration tests, `nix develop`, and packaged `agent-cli` executables
- preserve runtime grammar overrides through the packaged executable wrapper

This replaces #237. `master` was rewound to its pre-#237 commit so the large vendored XML commit is no longer in branch history.

## Package boundaries

```text
skylighting-core
       ↓
 agent-syntax
       ↓
  agent-tui
       ↓
  agent-cli
```

`Agent.Syntax` does not expose Skylighting token types. The TUI consumes only the stable semantic span model.

## Validation

- `agent-syntax`: 9 examples, 0 failures
- `agent-tui`: 39 examples, 0 failures
- `agent-cli`: 474 examples, 0 failures
- `nix build .#agent-syntax`
- `nix build .#agent-tui`
- `nix build .#agent-cli`
- `nix flake check --no-build`
- `nix develop` exports a valid `AGENT_SYNTAX_DIR`
- fetched syntax output contains 166 XML files and no non-XML grammar files
- packaged executable closure contains `skylighting-syntaxes`, not the full upstream source checkout
- tmux smoke: Haskell and Python fences rendered with semantic truecolor spans and Copy controls

## Licensing

The Nix output contains unmodified upstream KDE XML definitions. Their individual license headers are preserved, and the output includes an upstream provenance README plus a generated notice explaining that the definitions use various licenses.
