### PR TITLE
perf(xai): stream Responses events incrementally

### DIFF
--- a/packages/agent-openrouter/src/Agent/OpenRouter/Stream.hs
+++ b/packages/agent-openrouter/src/Agent/OpenRouter/Stream.hs
@@ -9,130 +9,23 @@ module Agent.OpenRouter.Stream
     ) where
 
 import Agent.Error (ApiError(..))
+import Agent.Responses.SSE
+    ( SseDecoder
+    , feedSseDecoder
+    , finishSseDecoder
+    , newSseDecoder
+    , parseSseEvents
+    )
 import Agent.Responses.ResponseMerge (mergeCompletedResponseOutput)
-import qualified Agent.Responses.Codec as ResponsesCodec
 import Agent.Responses.Types
 import Agent.OpenRouter.Error (classifyStreamError)
 import qualified Data.Aeson as Aeson
-import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Maybe as Maybe
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import qualified Data.Text.Encoding.Error as Text (lenientDecode)
-import Data.Word (Word8)
-
--- | Incremental SSE decoder. Only bytes belonging to the current incomplete
--- event block are retained between HTTP chunks.
-newtype SseDecoder = SseDecoder BS.ByteString
-
-newSseDecoder :: SseDecoder
-newSseDecoder = SseDecoder BS.empty
-
--- | Feed an arbitrary HTTP body chunk. Completed events are returned in wire
--- order as soon as their terminating blank line arrives.
-feedSseDecoder
-    :: SseDecoder
-    -> BS.ByteString
-    -> Either ApiError (SseDecoder, [ResponseStreamEvent])
-feedSseDecoder (SseDecoder buffered) chunk =
-    decodeAvailable [] (buffered <> chunk)
-  where
-    decodeAvailable events bytes = case takeBlock bytes of
-        Nothing -> Right (SseDecoder bytes, reverse events)
-        Just (block, rest) -> do
-            decoded <- parseBlockBytes block
-            decodeAvailable (maybe events (: events) decoded) rest
-
--- | Finish an SSE stream, accepting a final event without a trailing blank
--- line.
-finishSseDecoder :: SseDecoder -> Either ApiError [ResponseStreamEvent]
-finishSseDecoder (SseDecoder buffered)
-    | BS.null (BS.dropWhile isSseWhitespace buffered) = Right []
-    | otherwise = maybe [] pure <$> parseBlockBytes buffered
-
--- | Decode a complete SSE body into the canonical typed Responses event union.
-parseSseEvents :: Text -> Either ApiError [ResponseStreamEvent]
-parseSseEvents sseText = do
-    (decoder, events) <- feedSseDecoder newSseDecoder (Text.encodeUtf8 sseText)
-    trailing <- finishSseDecoder decoder
-    pure (events <> trailing)
-
-parseBlockBytes :: BS.ByteString -> Either ApiError (Maybe ResponseStreamEvent)
-parseBlockBytes bytes = case Text.decodeUtf8' bytes of
-    Left err -> Left $ JsonDecodeError
-        ("Invalid UTF-8 in OpenRouter SSE event: " <> Text.pack (show err))
-        (Text.take 2000 (Text.decodeUtf8With Text.lenientDecode bytes))
-    Right block -> parseBlock (Text.replace "\r\n" "\n" block)
-
-parseBlock :: Text -> Either ApiError (Maybe ResponseStreamEvent)
-parseBlock block
-    | Text.null dataText = Right Nothing
-    | Text.strip dataText == "[DONE]" = Right Nothing
-    | otherwise = Just <$> decodeEvent eventType dataText
-  where
-    blockLines = Text.lines block
-    eventType = Maybe.listToMaybe
-        [ Text.strip (Text.drop 6 line)
-        | line <- blockLines
-        , "event:" `Text.isPrefixOf` line
-        ]
-    dataText = Text.intercalate "\n"
-        [ stripOptionalSpace (Text.drop 5 line)
-        | line <- blockLines
-        , "data:" `Text.isPrefixOf` line
-        ]
-
-    stripOptionalSpace line = Maybe.fromMaybe line (Text.stripPrefix " " line)
-
-decodeEvent :: Maybe Text -> Text -> Either ApiError ResponseStreamEvent
-decodeEvent eventType dataText = do
-    value <- case Aeson.eitherDecodeStrict' (Text.encodeUtf8 dataText) of
-        Left err -> Left (decodeError (Text.pack err) dataText)
-        Right value -> Right value
-    let decoded = case eventType of
-            Just suppliedType ->
-                ResponsesCodec.decodeResponseStreamEventWithType suppliedType value
-            Nothing -> case ResponsesCodec.decodeResponseStreamEventValue value of
-                Aeson.Success event -> Right event
-                Aeson.Error err -> Left err
-    case decoded of
-        Left err -> Left (decodeError (Text.pack err) dataText)
-        Right event -> Right event
-  where
-    decodeError message body = JsonDecodeError message (Text.take 2000 body)
-
-takeBlock :: BS.ByteString -> Maybe (BS.ByteString, BS.ByteString)
-takeBlock bytes = do
-    (offset, delimiterLength) <- earliestDelimiter bytes
-    pure
-        ( BS.take offset bytes
-        , BS.drop (offset + delimiterLength) bytes
-        )
-
-earliestDelimiter :: BS.ByteString -> Maybe (Int, Int)
-earliestDelimiter bytes = case
-    ( findSubstring "\n\n" bytes
-    , findSubstring "\r\n\r\n" bytes
-    ) of
-        (Nothing, Nothing) -> Nothing
-        (Just offset, Nothing) -> Just (offset, 2)
-        (Nothing, Just offset) -> Just (offset, 4)
-        (Just lfOffset, Just crlfOffset)
-            | lfOffset <= crlfOffset -> Just (lfOffset, 2)
-            | otherwise -> Just (crlfOffset, 4)
-
-findSubstring :: BS.ByteString -> BS.ByteString -> Maybe Int
-findSubstring needle haystack
-    | BS.null needle = Just 0
-    | otherwise =
-        let (prefix, suffix) = BS.breakSubstring needle haystack
-        in if BS.null suffix then Nothing else Just (BS.length prefix)
-
-isSseWhitespace :: Word8 -> Bool
-isSseWhitespace byte =
-    byte == 0x20 || byte == 0x09 || byte == 0x0a || byte == 0x0d
 
 -- | Merge streamed output-item events into the terminal completed response.
 buildResponse :: [ResponseStreamEvent] -> Either ApiError Response

--- a/packages/agent-responses/README.md
+++ b/packages/agent-responses/README.md
@@ -4,5 +4,6 @@ Provider-neutral protocol support for Responses-compatible model transports.
 
 - canonical request, response, item, tool, and streaming-event types
 - JSON codecs
+- bounded incremental SSE framing shared by provider transports
 - streamed response merging
 - loop adapters for stateless Responses transports

--- a/packages/agent-responses/agent-responses.cabal
+++ b/packages/agent-responses/agent-responses.cabal
@@ -46,6 +46,7 @@ library
     exposed-modules:  Agent.Responses.Types
                     , Agent.Responses.Codec
                     , Agent.Responses.Error
+                    , Agent.Responses.SSE
                     , Agent.Responses.ResponseMerge
                     , Agent.Responses.LoopBackend
     hs-source-dirs:   src
@@ -66,9 +67,11 @@ test-suite agent-responses-test
     main-is:          Spec.hs
     other-modules:    Agent.Responses.LoopBackendSpec
                     , Agent.Responses.ResponseMergeSpec
+                    , Agent.Responses.SSESpec
     build-depends:    base >= 4.14 && < 5
                     , agent-core
                     , agent-responses
                     , aeson >= 2.0
+                    , bytestring
                     , hspec
                     , text

--- a/packages/agent-responses/package.nix
+++ b/packages/agent-responses/package.nix
@@ -9,7 +9,7 @@ mkDerivation {
     aeson agent-core base base64-bytestring bytestring containers
     scientific text vector
   ];
-  testHaskellDepends = [ aeson agent-core base hspec text ];
+  testHaskellDepends = [ aeson agent-core base bytestring hspec text ];
   description = "Provider-neutral OpenAI Responses protocol types and adapters";
   license = lib.licenses.bsd3;
 }

--- a/packages/agent-responses/src/Agent/Responses/SSE.hs
+++ b/packages/agent-responses/src/Agent/Responses/SSE.hs
@@ -1,0 +1,209 @@
+-- | Incremental decoding for provider-neutral Responses SSE events.
+module Agent.Responses.SSE
+    ( SseDecoder
+    , newSseDecoder
+    , feedSseDecoder
+    , finishSseDecoder
+    , parseSseEvents
+    ) where
+
+import Agent.Error (ApiError(..))
+import qualified Agent.Responses.Codec as ResponsesCodec
+import Agent.Responses.Types (ResponseStreamEvent)
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString as BS
+import qualified Data.Maybe as Maybe
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
+import qualified Data.Text.Encoding.Error as Text (lenientDecode)
+import Data.Word (Word8)
+
+-- | Incremental SSE decoder. Incomplete lines and event blocks stay chunked
+-- until their terminating blank line arrives, avoiding repeated copies and
+-- rescans when one large event spans many HTTP chunks.
+data SseDecoder = SseDecoder
+    { decoderLineChunksRev :: ![BS.ByteString]
+    , decoderBlockLinesRev :: ![BS.ByteString]
+    , decoderEventBytes :: !Int
+    }
+
+newSseDecoder :: SseDecoder
+newSseDecoder = SseDecoder
+    { decoderLineChunksRev = []
+    , decoderBlockLinesRev = []
+    , decoderEventBytes = 0
+    }
+
+-- | Feed an arbitrary HTTP body chunk. Completed events are returned in wire
+-- order as soon as their terminating blank line arrives.
+feedSseDecoder
+    :: SseDecoder
+    -> BS.ByteString
+    -> Either ApiError (SseDecoder, [ResponseStreamEvent])
+feedSseDecoder decoder chunk =
+    decodeAvailable decoder chunk []
+  where
+    decodeAvailable current bytes events
+        | BS.null bytes = Right (current, reverse events)
+        | otherwise =
+            let (linePart, restWithNewline) = BS.break (== lineFeed) bytes
+            in if BS.null restWithNewline
+                then do
+                    next <- appendLinePart current linePart
+                    Right (next, reverse events)
+                else do
+                    withPart <- appendLinePart current linePart
+                    withNewline <- addEventBytes 1 withPart
+                    let line = completeLine withNewline
+                        afterLine = withNewline { decoderLineChunksRev = [] }
+                    (next, decoded) <- consumeLine afterLine line
+                    decodeAvailable
+                        next
+                        (BS.tail restWithNewline)
+                        (maybe events (: events) decoded)
+
+-- | Finish an SSE stream, accepting a final event without a trailing blank
+-- line.
+finishSseDecoder :: SseDecoder -> Either ApiError [ResponseStreamEvent]
+finishSseDecoder decoder = do
+    (afterLine, lineEvent) <-
+        if null decoder.decoderLineChunksRev
+            then Right (decoder, Nothing)
+            else
+                let line = completeLine decoder
+                    withoutLine = decoder { decoderLineChunksRev = [] }
+                in consumeLine withoutLine line
+    blockEvent <- parseBlockLines (reverse afterLine.decoderBlockLinesRev)
+    pure (Maybe.catMaybes [lineEvent, blockEvent])
+
+-- | Decode a complete SSE body into the canonical typed Responses event union.
+parseSseEvents :: Text -> Either ApiError [ResponseStreamEvent]
+parseSseEvents sseText = do
+    (decoder, events) <- feedSseDecoder newSseDecoder (Text.encodeUtf8 sseText)
+    trailing <- finishSseDecoder decoder
+    pure (events <> trailing)
+
+appendLinePart :: SseDecoder -> BS.ByteString -> Either ApiError SseDecoder
+appendLinePart decoder chunk
+    | BS.null chunk = Right decoder
+    | otherwise = do
+        withBytes <- addEventBytes (BS.length chunk) decoder
+        pure withBytes
+            { decoderLineChunksRev =
+                chunk : withBytes.decoderLineChunksRev
+            }
+
+addEventBytes :: Int -> SseDecoder -> Either ApiError SseDecoder
+addEventBytes amount decoder
+    | amount <= maxSseEventBytes - decoder.decoderEventBytes =
+        Right decoder
+            { decoderEventBytes = decoder.decoderEventBytes + amount }
+    | otherwise = Left $ JsonDecodeError
+        ( "Responses SSE event exceeds "
+            <> Text.pack (show maxSseEventBytes)
+            <> " bytes"
+        )
+        (decoderPreview decoder)
+
+completeLine :: SseDecoder -> BS.ByteString
+completeLine =
+    dropTrailingCarriageReturn
+        . BS.concat
+        . reverse
+        . (.decoderLineChunksRev)
+
+consumeLine
+    :: SseDecoder
+    -> BS.ByteString
+    -> Either ApiError (SseDecoder, Maybe ResponseStreamEvent)
+consumeLine decoder line
+    | BS.null line = do
+        decoded <- parseBlockLines (reverse decoder.decoderBlockLinesRev)
+        pure (newSseDecoder, decoded)
+    | otherwise =
+        Right
+            ( decoder
+                { decoderBlockLinesRev =
+                    line : decoder.decoderBlockLinesRev
+                }
+            , Nothing
+            )
+
+parseBlockLines :: [BS.ByteString] -> Either ApiError (Maybe ResponseStreamEvent)
+parseBlockLines [] = Right Nothing
+parseBlockLines lines = parseBlockBytes (BS.intercalate "\n" lines)
+
+parseBlockBytes :: BS.ByteString -> Either ApiError (Maybe ResponseStreamEvent)
+parseBlockBytes bytes = case Text.decodeUtf8' bytes of
+    Left err -> Left $ JsonDecodeError
+        ("Invalid UTF-8 in Responses SSE event: " <> Text.pack (show err))
+        (Text.take 2000 (Text.decodeUtf8With Text.lenientDecode bytes))
+    Right block -> parseBlock (Text.replace "\r\n" "\n" block)
+
+parseBlock :: Text -> Either ApiError (Maybe ResponseStreamEvent)
+parseBlock block
+    | Text.null dataText = Right Nothing
+    | Text.strip dataText == "[DONE]" = Right Nothing
+    | otherwise = Just <$> decodeEvent eventType dataText
+  where
+    blockLines = Text.lines block
+    eventType = Maybe.listToMaybe
+        [ Text.strip (Text.drop 6 line)
+        | line <- blockLines
+        , "event:" `Text.isPrefixOf` line
+        ]
+    dataText = Text.intercalate "\n"
+        [ stripOptionalSpace (Text.drop 5 line)
+        | line <- blockLines
+        , "data:" `Text.isPrefixOf` line
+        ]
+
+    stripOptionalSpace line = Maybe.fromMaybe line (Text.stripPrefix " " line)
+
+decodeEvent :: Maybe Text -> Text -> Either ApiError ResponseStreamEvent
+decodeEvent eventType dataText = do
+    value <- case Aeson.eitherDecodeStrict' (Text.encodeUtf8 dataText) of
+        Left err -> Left (decodeError (Text.pack err) dataText)
+        Right value -> Right value
+    let decoded = case eventType of
+            Just suppliedType ->
+                ResponsesCodec.decodeResponseStreamEventWithType suppliedType value
+            Nothing -> case ResponsesCodec.decodeResponseStreamEventValue value of
+                Aeson.Success event -> Right event
+                Aeson.Error err -> Left err
+    case decoded of
+        Left err -> Left (decodeError (Text.pack err) dataText)
+        Right event -> Right event
+  where
+    decodeError message body = JsonDecodeError message (Text.take 2000 body)
+
+dropTrailingCarriageReturn :: BS.ByteString -> BS.ByteString
+dropTrailingCarriageReturn bytes = case BS.unsnoc bytes of
+    Just (prefix, byte) | byte == carriageReturn -> prefix
+    _ -> bytes
+
+decoderPreview :: SseDecoder -> Text
+decoderPreview decoder =
+    Text.decodeUtf8With Text.lenientDecode $
+        BS.concat $
+            takeByteChunks 2000 $
+                reverse decoder.decoderBlockLinesRev
+                    <> reverse decoder.decoderLineChunksRev
+
+takeByteChunks :: Int -> [BS.ByteString] -> [BS.ByteString]
+takeByteChunks remaining _
+    | remaining <= 0 = []
+takeByteChunks _ [] = []
+takeByteChunks remaining (chunk : rest) =
+    let kept = BS.take remaining chunk
+    in kept : takeByteChunks (remaining - BS.length kept) rest
+
+lineFeed :: Word8
+lineFeed = 0x0a
+
+carriageReturn :: Word8
+carriageReturn = 0x0d
+
+maxSseEventBytes :: Int
+maxSseEventBytes = 64 * 1024 * 1024

--- a/packages/agent-responses/test/Agent/Responses/SSESpec.hs
+++ b/packages/agent-responses/test/Agent/Responses/SSESpec.hs
@@ -1,0 +1,100 @@
+module Agent.Responses.SSESpec (spec) where
+
+import Agent.Error (ApiError(..))
+import Agent.Responses.SSE
+import Agent.Responses.Types
+import qualified Data.ByteString as BS
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
+import Test.Hspec
+
+spec :: Spec
+spec = describe "Responses SSE decoder" do
+    it "decodes arbitrary HTTP chunk boundaries, including split UTF-8" do
+        mapM_ checkSplit [0 .. BS.length splitBytes]
+
+    it "decodes a stream fed one byte at a time" do
+        events <- decodeChunks (map BS.singleton (BS.unpack splitBytes))
+        eventTypes events
+            `shouldBe` [EventOutputItemDone, EventResponseCompleted]
+
+    it "accepts CRLF, multiline data, comments, and a final unterminated event" do
+        events <- expectRight $ parseSseEvents $ Text.intercalate ""
+            [ ": keepalive\r\n\r\n"
+            , "event: response.output_item.done\r\n"
+            , "data: {\"type\":\"response.output_item.done\",\r\n"
+            , "data: \"output_index\":0,\"item\":{\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"héllo\"}]}}\r\n\r\n"
+            , "data: [DONE]\r\n\r\n"
+            , Text.dropEnd 2 completedBlock
+            ]
+        eventTypes events
+            `shouldBe` [EventOutputItemDone, EventResponseCompleted]
+
+    it "reads the event type from data and ignores blocks without data" do
+        events <- expectRight $ parseSseEvents $
+            "event: ping\nid: 1\n\n"
+                <> "data: " <> completedJson <> "\n\n"
+        eventTypes events `shouldBe` [EventResponseCompleted]
+
+    it "rejects invalid UTF-8 only after a complete event block arrives" do
+        (decoder, events) <- expectRight $
+            feedSseDecoder newSseDecoder "data: \xc3"
+        events `shouldBe` []
+        case feedSseDecoder decoder "\x28\n\n" of
+            Left JsonDecodeError{} -> pure ()
+            Left other -> expectationFailure
+                ("expected invalid UTF-8 error, got " <> show other)
+            Right _ -> expectationFailure "expected invalid UTF-8 error"
+
+checkSplit :: Int -> IO ()
+checkSplit offset = do
+    let (first, second) = BS.splitAt offset splitBytes
+    events <- decodeChunks [first, second]
+    eventTypes events
+        `shouldBe` [EventOutputItemDone, EventResponseCompleted]
+
+decodeChunks :: [BS.ByteString] -> IO [ResponseStreamEvent]
+decodeChunks chunks = do
+    (decoder, reversedEvents) <- foldl step (pure (newSseDecoder, [])) chunks
+    trailing <- expectRight (finishSseDecoder decoder)
+    pure (reverse reversedEvents <> trailing)
+  where
+    step accumulated chunk = do
+        (decoder, reversedEvents) <- accumulated
+        (nextDecoder, events) <- expectRight (feedSseDecoder decoder chunk)
+        pure (nextDecoder, reverse events <> reversedEvents)
+
+eventTypes :: [ResponseStreamEvent] -> [StreamEventType]
+eventTypes = map responseStreamEventType
+
+splitBytes :: BS.ByteString
+splitBytes = Text.encodeUtf8 (itemBlock <> completedBlock)
+
+itemBlock :: Text
+itemBlock = sseBlock "response.output_item.done" itemJson
+
+itemJson :: Text
+itemJson =
+    "{\"type\":\"response.output_item.done\",\"output_index\":0,\
+    \\"item\":{\"type\":\"message\",\"role\":\"assistant\",\"content\":\
+    \[{\"type\":\"output_text\",\"text\":\"héllo\"}]}}"
+
+completedBlock :: Text
+completedBlock = sseBlock "response.completed" completedJson
+
+completedJson :: Text
+completedJson =
+    "{\"type\":\"response.completed\",\"response\":{\"id\":\"resp-final\",\
+    \\"created_at\":0,\"model\":\"test-model\",\"status\":\"completed\"}}"
+
+sseBlock :: Text -> Text -> Text
+sseBlock eventType dataText =
+    "event: " <> eventType <> "\ndata: " <> dataText <> "\n\n"
+
+expectRight :: Show error => Either error value -> IO value
+expectRight = \case
+    Left err ->
+        expectationFailure ("expected Right, got Left " <> show err)
+            >> fail "unreachable"
+    Right value -> pure value

--- a/packages/agent-responses/test/Spec.hs
+++ b/packages/agent-responses/test/Spec.hs
@@ -4,8 +4,10 @@ import Test.Hspec (hspec)
 
 import qualified Agent.Responses.LoopBackendSpec as LoopBackendSpec
 import qualified Agent.Responses.ResponseMergeSpec as ResponseMergeSpec
+import qualified Agent.Responses.SSESpec as SSESpec
 
 main :: IO ()
 main = hspec do
     LoopBackendSpec.spec
     ResponseMergeSpec.spec
+    SSESpec.spec

--- a/packages/agent-xai/README.md
+++ b/packages/agent-xai/README.md
@@ -4,8 +4,9 @@ xAI-specific transport package for the agent harness.
 
 - Projects canonical `ResponseCreateParams` values into the Grok subscription
   proxy dialect while keeping the request typed.
-- Decodes SSE into the canonical typed `ResponseStreamEvent` union and assembles
-  the terminal `Response`.
+- Decodes SSE incrementally into the canonical typed `ResponseStreamEvent`
+  union, delivers callbacks while the response is still arriving, and
+  assembles the terminal `Response` without retaining every stream event.
 - Implements xAI device authorization, token refresh, and account-id derivation.
 
 `Agent.XAI.LoopBackend` implements the provider-neutral `Backend` used by
@@ -14,8 +15,9 @@ local item list and resends it on each turn.
 
 The package contains no agent loop, context trimming, or credential failover.
 Those concerns belong to the harness around the provider client. The HTTP
-client does retry short-lived capacity / overload failures (30s delay, a few
-attempts) before returning them to the loop.
+client retries short-lived capacity / overload failures (30s delay, a few
+attempts) before returning them to the loop. Event-producing calls retry only
+before the first callback, so already-visible output is never replayed.
 
 OAuth login options require the application's public client id at runtime;
 `agent-xai` does not embed one in its source.

--- a/packages/agent-xai/agent-xai.cabal
+++ b/packages/agent-xai/agent-xai.cabal
@@ -54,6 +54,7 @@ library
                     , bytestring
                     , aeson                 >= 2.0
                     , http-client
+                    , http-client-tls
                     , http-conduit
                     , base64-bytestring
                     , retry >= 0.9.3.1 && < 0.10
@@ -76,6 +77,7 @@ test-suite agent-xai-test
                     , agent-core
                     , agent-responses
                     , agent-xai
+                    , async
                     , hspec
                     , aeson
                     , text
@@ -84,5 +86,6 @@ test-suite agent-xai-test
                     , case-insensitive
                     , http-types
                     , retry >= 0.9.3.1 && < 0.10
+                    , safe-exceptions
                     , wai
                     , warp

--- a/packages/agent-xai/package.nix
+++ b/packages/agent-xai/package.nix
@@ -1,6 +1,6 @@
-{ mkDerivation, aeson, agent-core, agent-responses, base
+{ mkDerivation, aeson, agent-core, agent-responses, async, base
 , base64-bytestring, bytestring, case-insensitive, hspec
-, http-client, http-conduit, http-types, lib, retry, safe-exceptions
+, http-client, http-client-tls, http-conduit, http-types, lib, retry, safe-exceptions
 , scientific, text, time, wai, warp
 }:
 mkDerivation {
@@ -9,11 +9,11 @@ mkDerivation {
   src = ./.;
   libraryHaskellDepends = [
     aeson agent-core agent-responses base base64-bytestring bytestring
-    http-client http-conduit retry safe-exceptions scientific text time
+    http-client http-client-tls http-conduit retry safe-exceptions scientific text time
   ];
   testHaskellDepends = [
-    aeson agent-core agent-responses base base64-bytestring bytestring
-    case-insensitive hspec http-types retry text wai warp
+    aeson agent-core agent-responses async base base64-bytestring bytestring
+    case-insensitive hspec http-types retry safe-exceptions text wai warp
   ];
   description = "Haskell client for the xAI Grok subscription transport";
   license = lib.licenses.bsd3;

--- a/packages/agent-xai/src/Agent/XAI/Client.hs
+++ b/packages/agent-xai/src/Agent/XAI/Client.hs
@@ -3,6 +3,7 @@ module Agent.XAI.Client
     ( StreamEventCallback
     , createResponse
     , createResponseWith
+    , createResponseWithPolicy
     , createResponseWithEvents
     , createResponseWithEventsPolicy
     , retryTransientXaiResultWithPolicy
@@ -23,7 +24,12 @@ import Agent.XAI.Error
     )
 import Agent.XAI.Options
 import Agent.XAI.Request (buildRequest)
-import Agent.XAI.Stream (buildResponse, parseSseEvents)
+import Agent.XAI.Stream
+    ( buildResponse
+    , feedSseDecoder
+    , finishSseDecoder
+    , newSseDecoder
+    )
 import Control.Exception.Safe (tryAny)
 import Control.Retry
     ( RetryPolicyM
@@ -32,11 +38,14 @@ import Control.Retry
     , retrying
     )
 import qualified Data.Aeson as Aeson
+import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
+import Data.IORef
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import qualified Data.Text.Encoding.Error as Text (lenientDecode)
 import qualified Network.HTTP.Client as HttpClient
+import qualified Network.HTTP.Client.TLS as HttpTls
 import Network.HTTP.Simple hiding (Response)
 
 type StreamEventCallback = ResponseStreamEvent -> IO ()
@@ -53,14 +62,30 @@ createResponseWith
     -> Credential
     -> ResponseCreateParams
     -> IO (Either ApiError Response)
-createResponseWith options credential request =
-    createResponseWithEvents options credential request (const (pure ()))
+createResponseWith =
+    createResponseWithPolicy defaultTransientPolicy
 
--- | Send one request and deliver every decoded typed Responses event before
--- returning the assembled terminal response. The current HTTP backend buffers
--- the response body, so callbacks run in wire order after the body completes.
--- Transient capacity / overload failures wait 30s and retry a few times before
--- surfacing to the loop.
+-- | Like 'createResponseWith', with an injectable retry policy for tests.
+-- Because this path exposes no stream callbacks, retrying a stream-level
+-- capacity failure cannot replay caller-visible output.
+createResponseWithPolicy
+    :: RetryPolicyM IO
+    -> ClientOptions
+    -> Credential
+    -> ResponseCreateParams
+    -> IO (Either ApiError Response)
+createResponseWithPolicy policy options credential request =
+    createResponseWithMaybeEventsPolicy
+        policy
+        options
+        credential
+        request
+        Nothing
+
+-- | Send one request and deliver decoded typed Responses events incrementally
+-- in wire order before returning the assembled terminal response. Transient
+-- capacity / overload failures wait 30s and retry a few times only before the
+-- first callback, so callers never observe replayed output.
 createResponseWithEvents
     :: ClientOptions
     -> Credential
@@ -69,9 +94,6 @@ createResponseWithEvents
     -> IO (Either ApiError Response)
 createResponseWithEvents options credential request onEvent =
     createResponseWithEventsPolicy defaultTransientPolicy options credential request onEvent
-  where
-    defaultTransientPolicy =
-        constantDelay (capacityRetryAfterSeconds * 1_000_000) <> limitRetries 3
 
 -- | Same as 'createResponseWithEvents', with an injectable retry policy so
 -- tests can use a zero delay without waiting on the production 30s backoff.
@@ -82,23 +104,39 @@ createResponseWithEventsPolicy
     -> ResponseCreateParams
     -> StreamEventCallback
     -> IO (Either ApiError Response)
-createResponseWithEventsPolicy policy options credential request onEvent
+createResponseWithEventsPolicy policy options credential request onEvent =
+    createResponseWithMaybeEventsPolicy
+        policy
+        options
+        credential
+        request
+        (Just onEvent)
+
+createResponseWithMaybeEventsPolicy
+    :: RetryPolicyM IO
+    -> ClientOptions
+    -> Credential
+    -> ResponseCreateParams
+    -> Maybe StreamEventCallback
+    -> IO (Either ApiError Response)
+createResponseWithMaybeEventsPolicy policy options credential request onEvent
     | credential.provider /= XAIProvider = pure $ Left $ ProviderError ApiErrorType
         "agent-xai requires an xAI credential"
         Nothing
     | otherwise =
-        retryTransientXaiResultWithPolicy policy performOnce
+        retryTransientXaiStreamWithPolicy policy performOnce onEvent
   where
-    performOnce =
-        tryAny performRequest >>= \case
+    performOnce emit =
+        tryAny (performRequest emit) >>= \case
             Left exception -> pure $ Left $ ConnectionError
                 ("xAI request failed: " <> Text.pack (show exception))
-            Right response -> handleResponse response
+            Right result -> pure result
 
-    performRequest = do
+    performRequest emit = do
         httpRequest <- parseRequest ("POST " <> trimTrailingSlash options.baseUrl <> "/responses")
-        httpLBS
-            $ setRequestBodyLBS (Aeson.encode (buildRequest options request))
+        manager <- HttpTls.getGlobalManager
+        HttpClient.withResponse
+            ( setRequestBodyLBS (Aeson.encode (buildRequest options request))
             $ setRequestHeader "Authorization"
                 ["Bearer " <> Text.encodeUtf8 credential.accessToken]
             $ setRequestHeader "X-XAI-Token-Auth" ["xai-grok-cli"]
@@ -109,26 +147,93 @@ createResponseWithEventsPolicy policy options credential request onEvent
             $ setRequestHeader "Accept" ["text/event-stream"]
             $ setRequestHeader "User-Agent" ["codex-hs"]
             $ withTimeout httpRequest
+            )
+            manager
+            (handleResponse emit)
 
     withTimeout httpRequest = httpRequest
         { HttpClient.responseTimeout =
             HttpClient.responseTimeoutMicro (options.requestTimeoutSeconds * 1_000_000)
         }
 
-    handleResponse response = do
+    handleResponse emit response = do
         let status = getResponseStatusCode response
-            bodyText = Text.decodeUtf8With Text.lenientDecode
-                (LBS.toStrict (getResponseBody response))
         if status >= 200 && status < 300
-            then case parseSseEvents bodyText of
-                Left err -> pure (Left err)
-                Right events -> do
-                    mapM_ onEvent events
-                    pure (buildResponse events)
-            else pure $ Left $ classifyFailure status
-                (parseRetryAfterSeconds
-                    (getResponseHeader "Retry-After" response))
-                bodyText
+            then consumeSse emit (HttpClient.responseBody response)
+            else do
+                body <- consumeBody (HttpClient.responseBody response)
+                let bodyText = Text.decodeUtf8With Text.lenientDecode
+                        (LBS.toStrict body)
+                pure $ Left $
+                    classifyFailure status
+                        (parseRetryAfterSeconds
+                            (getResponseHeader "Retry-After" response))
+                        bodyText
+
+    consumeSse emit body = go newSseDecoder []
+      where
+        go decoder reversedEvents = do
+            chunk <- HttpClient.brRead body
+            if BS.null chunk
+                then case finishSseDecoder decoder of
+                    Left err -> pure (Left err)
+                    Right trailing -> do
+                        mapM_ emit trailing
+                        pure $ buildResponse
+                            (reverse reversedEvents <> trailing)
+                else case feedSseDecoder decoder chunk of
+                    Left err -> pure (Left err)
+                    Right (nextDecoder, events) -> do
+                        mapM_ emit events
+                        let retained = filter retainForResponse events
+                        go nextDecoder (reverse retained <> reversedEvents)
+
+    consumeBody body = LBS.fromChunks <$> readChunks []
+      where
+        readChunks reversedChunks = do
+            chunk <- HttpClient.brRead body
+            if BS.null chunk
+                then pure (reverse reversedChunks)
+                else readChunks (chunk : reversedChunks)
+
+    retainForResponse = \case
+        ResponseOutputItemDoneEvent {} -> True
+        ResponseCompletedEvent {} -> True
+        ResponseIncompleteEvent {} -> True
+        ResponseErrorEvent {} -> True
+        ResponseNestedErrorEvent {} -> True
+        ResponseFailedEvent {} -> True
+        _ -> False
+
+-- | Retry transient failures while replay is safe. The callback marker is
+-- written before user code runs, so callback exceptions are never retried.
+retryTransientXaiStreamWithPolicy
+    :: RetryPolicyM IO
+    -> ((event -> IO ()) -> IO (Either ApiError value))
+    -> Maybe (event -> IO ())
+    -> IO (Either ApiError value)
+retryTransientXaiStreamWithPolicy policy request onEvent =
+    snd <$> retrying policy shouldRetry runAttempt
+  where
+    runAttempt _status = do
+        emitted <- newIORef False
+        result <- request \event -> case onEvent of
+            Nothing -> pure ()
+            Just callback -> do
+                writeIORef emitted True
+                callback event
+        didEmit <- readIORef emitted
+        pure (didEmit, result)
+
+    shouldRetry _status (emitted, result) = pure $
+        not emitted
+            && case result of
+                Left apiError -> isCapacityRetryable apiError
+                Right _ -> False
+
+defaultTransientPolicy :: RetryPolicyM IO
+defaultTransientPolicy =
+    constantDelay (capacityRetryAfterSeconds * 1_000_000) <> limitRetries 3
 
 -- | Retry capacity / overload pressure and short-lived 5xx failures. Generic
 -- connection drops and quota errors are left to the caller. Production uses a

--- a/packages/agent-xai/src/Agent/XAI/Stream.hs
+++ b/packages/agent-xai/src/Agent/XAI/Stream.hs
@@ -1,13 +1,23 @@
 -- | Typed decoding and terminal-response assembly for xAI Responses SSE.
 module Agent.XAI.Stream
-    ( parseSseEvents
+    ( SseDecoder
+    , newSseDecoder
+    , feedSseDecoder
+    , finishSseDecoder
+    , parseSseEvents
     , buildResponse
     ) where
 
 import Agent.Error (ApiError(..), errorTypeFromText)
 import Agent.Responses.Error (mkOpenAIError)
 import Agent.Responses.ResponseMerge (mergeCompletedResponseOutput)
-import qualified Agent.Responses.Codec as ResponsesCodec
+import Agent.Responses.SSE
+    ( SseDecoder
+    , feedSseDecoder
+    , finishSseDecoder
+    , newSseDecoder
+    , parseSseEvents
+    )
 import Agent.Responses.Types
 import Agent.XAI.Error (classifyStreamError)
 import qualified Data.Aeson as Aeson
@@ -17,48 +27,6 @@ import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import qualified Data.Text.Encoding.Error as Text (lenientDecode)
-
--- | Decode an SSE body into the canonical typed Responses event union.
--- The discriminator may be supplied by the SSE @event:@ line, by the JSON
--- @type@ member, or by both when they agree.
-parseSseEvents :: Text -> Either ApiError [ResponseStreamEvent]
-parseSseEvents sseText = Maybe.catMaybes <$> traverse parseBlock blocks
-  where
-    normalized = Text.replace "\r\n" "\n" sseText
-    blocks = filter (not . Text.null . Text.strip) (Text.splitOn "\n\n" normalized)
-
-    parseBlock block
-        | Text.null dataText = Right Nothing
-        | Text.strip dataText == "[DONE]" = Right Nothing
-        | otherwise = Just <$> decodeEvent eventType dataText
-      where
-        blockLines = Text.lines block
-        eventType = Maybe.listToMaybe
-            [ Text.strip (Text.drop 6 line)
-            | line <- blockLines
-            , "event:" `Text.isPrefixOf` line
-            ]
-        dataText = Text.intercalate "\n"
-            [ Text.strip (Text.drop 5 line)
-            | line <- blockLines
-            , "data:" `Text.isPrefixOf` line
-            ]
-
-    decodeEvent eventType dataText = do
-        value <- case Aeson.eitherDecodeStrict' (Text.encodeUtf8 dataText) of
-            Left err -> Left (decodeError (Text.pack err) dataText)
-            Right value -> Right value
-        let decoded = case eventType of
-                Just suppliedType ->
-                    ResponsesCodec.decodeResponseStreamEventWithType suppliedType value
-                Nothing -> case ResponsesCodec.decodeResponseStreamEventValue value of
-                    Aeson.Success event -> Right event
-                    Aeson.Error err -> Left err
-        case decoded of
-            Left err -> Left (decodeError (Text.pack err) dataText)
-            Right event -> Right event
-
-    decodeError message body = JsonDecodeError message (Text.take 2000 body)
 
 -- | Merge streamed output-item events into the terminal completed response.
 buildResponse :: [ResponseStreamEvent] -> Either ApiError Response

--- a/packages/agent-xai/test/Agent/XAI/ClientSpec.hs
+++ b/packages/agent-xai/test/Agent/XAI/ClientSpec.hs
@@ -6,9 +6,14 @@ import Agent.XAI.Client
 import Agent.XAI.Options
 import Agent.Provider (Credential(..), Provider(..))
 import Agent.Responses.Types
+import Control.Concurrent.Async (cancel, withAsync)
+import Control.Concurrent.MVar
+import Control.Exception.Safe (finally)
+import Control.Monad (void, when)
 import Control.Retry (constantDelay, limitRetries)
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Builder as Builder
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.CaseInsensitive as CI
 import Data.IORef
@@ -18,6 +23,7 @@ import qualified Data.Text.Encoding as Text
 import qualified Network.HTTP.Types as HTTP
 import qualified Network.Wai as Wai
 import qualified Network.Wai.Handler.Warp as Warp
+import System.Timeout (timeout)
 import Test.Hspec
 
 spec :: Spec
@@ -43,6 +49,40 @@ spec = do
             requestModel request `shouldBe` Just "grok-4.6"
             -- instructions travel as the leading system item
             (inputRoles <$> requestBodyObject request) `shouldBe` Just ["system", "user"]
+
+        it "streams callbacks before the response completes" do
+            recorded <- newIORef []
+            callbackSeen <- newEmptyMVar
+            serverSawCallback <- newIORef False
+            let handler _ = pure $
+                    streamingResponse callbackSeen serverSawCallback
+            withMockGrok recorded handler \options -> do
+                result <- createResponseWithEvents options
+                    (xaiCredential "token-a")
+                    (helloRequest "hi")
+                    (recordOutputItem callbackSeen)
+                response <- expectRight result
+                response.responseId `shouldBe` "resp-stream"
+            readIORef serverSawCallback `shouldReturn` True
+
+        it "propagates cancellation promptly while a streamed response remains open" do
+            recorded <- newIORef []
+            callbackSeen <- newEmptyMVar
+            serverRelease <- newEmptyMVar
+            let handler _ = pure $
+                    cancellableStreamingResponse callbackSeen serverRelease
+            withMockGrok recorded handler \options ->
+                flip finally (void (tryPutMVar serverRelease ())) $
+                    withAsync
+                        (createResponseWithEvents options
+                            (xaiCredential "token-a")
+                            (helloRequest "hi")
+                            (recordOutputItem callbackSeen))
+                        \worker -> do
+                            seen <- timeout 2_000_000 (readMVar callbackSeen)
+                            seen `shouldBe` Just ()
+                            stopped <- timeout 2_000_000 (cancel worker)
+                            stopped `shouldBe` Just ()
 
     describe "retry boundaries" do
         it "reports a terminal stream failure after one request" do
@@ -70,25 +110,15 @@ spec = do
             requests <- readIORef recorded
             length requests `shouldBe` 1
 
-        it "retries capacity stream errors before returning success" do
+        it "retries a transient HTTP failure before streaming starts" do
             recorded <- newIORef []
             attempts <- newIORef (0 :: Int)
-            let capacityMessage :: Text
-                capacityMessage =
-                    "The model is currently at capacity due to high demand. \
-                    \Please try again in a few minutes, or use a higher service \
-                    \tier for priority processing"
-                handler _request = do
+            let handler _request = do
                     n <- atomicModifyIORef' attempts \i -> (i + 1, i + 1)
                     pure $ if n == 1
-                        then sseResponse
-                            [ sseEvent "error" $ Aeson.object
-                                [ "type" Aeson..= ("error" :: Text)
-                                , "error" Aeson..= Aeson.object
-                                    [ "message" Aeson..= capacityMessage
-                                    ]
-                                ]
-                            ]
+                        then Wai.responseLBS HTTP.status503
+                            [("Content-Type", "text/plain")]
+                            "temporarily unavailable"
                         else sseResponse
                             [ outputItemDone (assistantMessage "hello after capacity")
                             , completedEvent "resp-retry" []
@@ -105,6 +135,93 @@ spec = do
 
             requests <- readIORef recorded
             length requests `shouldBe` 2
+
+        it "retries capacity stream errors when callbacks are disabled" do
+            recorded <- newIORef []
+            attempts <- newIORef (0 :: Int)
+            let capacityMessage :: Text
+                capacityMessage =
+                    "The model is currently at capacity due to high demand. \
+                    \Please try again in a few minutes, or use a higher service \
+                    \tier for priority processing"
+                handler _request = do
+                    attempt <- atomicModifyIORef' attempts \current ->
+                        let next = current + 1
+                        in (next, next)
+                    pure $ if attempt == 1
+                        then sseResponse
+                            [ sseEvent "error" $ Aeson.object
+                                [ "type" Aeson..= ("error" :: Text)
+                                , "error" Aeson..= Aeson.object
+                                    [ "message" Aeson..= capacityMessage
+                                    ]
+                                ]
+                            ]
+                        else sseResponse
+                            [ outputItemDone (assistantMessage "after retry")
+                            , completedEvent "resp-stream-retry" []
+                            ]
+            withMockGrok recorded handler \options -> do
+                result <- createResponseWithPolicy
+                    (constantDelay 0 <> limitRetries 3)
+                    options
+                    (xaiCredential "token-a")
+                    (helloRequest "hi")
+                response <- expectRight result
+                response.responseId `shouldBe` "resp-stream-retry"
+            length <$> readIORef recorded `shouldReturn` 2
+
+        it "does not retry a capacity stream error after a callback" do
+            recorded <- newIORef []
+            callbacks <- newIORef (0 :: Int)
+            let capacityMessage :: Text
+                capacityMessage =
+                    "The model is currently at capacity due to high demand"
+                handler _request = pure $ sseResponse
+                    [ sseEvent "error" $ Aeson.object
+                        [ "type" Aeson..= ("error" :: Text)
+                        , "error" Aeson..= Aeson.object
+                            [ "message" Aeson..= capacityMessage
+                            ]
+                        ]
+                    ]
+            withMockGrok recorded handler \options -> do
+                result <- createResponseWithEventsPolicy
+                    (constantDelay 0 <> limitRetries 3)
+                    options
+                    (xaiCredential "token-a")
+                    (helloRequest "hi")
+                    (const (modifyIORef' callbacks (+ 1)))
+                result `shouldBe`
+                    Left
+                        (ProviderError
+                            OverloadedError
+                            capacityMessage
+                            (Just 30))
+            length <$> readIORef recorded `shouldReturn` 1
+            readIORef callbacks `shouldReturn` 1
+
+        it "does not retry when the stream callback throws" do
+            recorded <- newIORef []
+            callbacks <- newIORef (0 :: Int)
+            let handler _request = pure $ sseResponse
+                    [ outputItemDone (assistantMessage "hello")
+                    , completedEvent "resp-callback" []
+                    ]
+            withMockGrok recorded handler \options -> do
+                result <- createResponseWithEventsPolicy
+                    (constantDelay 0 <> limitRetries 3)
+                    options
+                    (xaiCredential "token-a")
+                    (helloRequest "hi")
+                    (\_ -> modifyIORef' callbacks (+ 1)
+                        >> ioError (userError "callback failed"))
+                case result of
+                    Left ConnectionError{} -> pure ()
+                    other -> expectationFailure
+                        ("expected callback ConnectionError, got " <> show other)
+            length <$> readIORef recorded `shouldReturn` 1
+            readIORef callbacks `shouldReturn` 1
 
         it "retries capacity Left values under a zero-delay policy" do
             let capacity = ProviderError OverloadedError
@@ -172,6 +289,37 @@ sseResponse :: [Text] -> Wai.Response
 sseResponse events = Wai.responseLBS HTTP.status200
     [("Content-Type", "text/event-stream")]
     (LBS.fromStrict (Text.encodeUtf8 (Text.concat events)))
+
+recordOutputItem :: MVar () -> ResponseStreamEvent -> IO ()
+recordOutputItem callbackSeen event =
+    when (responseStreamEventType event == EventOutputItemDone) do
+        tryPutMVar callbackSeen ()
+        pure ()
+
+streamingResponse :: MVar () -> IORef Bool -> Wai.Response
+streamingResponse callbackSeen serverSawCallback =
+    Wai.responseStream HTTP.status200
+        [("Content-Type", "text/event-stream")]
+        \write flush -> do
+            writeSse write (outputItemDone (assistantMessage "hello"))
+            flush
+            seen <- timeout 2_000_000 (readMVar callbackSeen)
+            writeIORef serverSawCallback (maybe False (const True) seen)
+            writeSse write (completedEvent "resp-stream" [])
+            flush
+
+cancellableStreamingResponse :: MVar () -> MVar () -> Wai.Response
+cancellableStreamingResponse callbackSeen serverRelease =
+    Wai.responseStream HTTP.status200
+        [("Content-Type", "text/event-stream")]
+        \write flush -> do
+            writeSse write (outputItemDone (assistantMessage "hello"))
+            flush
+            readMVar callbackSeen
+            readMVar serverRelease
+
+writeSse :: (Builder.Builder -> IO ()) -> Text -> IO ()
+writeSse write = write . Builder.byteString . Text.encodeUtf8
 
 outputItemDone :: Aeson.Value -> Text
 outputItemDone item = sseEvent "response.output_item.done" $ Aeson.object


### PR DESCRIPTION
## Summary

- stream xAI Responses SSE chunks through `withResponse`/`brRead` instead of buffering the complete body
- deliver typed callbacks as soon as complete SSE frames arrive while retaining only terminal/error and `output_item.done` state
- extract the existing OpenRouter decoder into a shared `Agent.Responses.SSE` module
- keep incomplete frames chunked, cap them at 64 MiB, and support LF/CRLF, multiline data, split UTF-8, `[DONE]`, and unterminated final frames
- stop event-producing retries after the first callback to prevent output replay, while preserving stream-error retries for the no-callback API
- propagate async cancellation through the bracketed HTTP response scope

## Validation

- `agent-responses`: 8 examples, 0 failures
- `agent-xai`: 46 examples, 0 failures, 1 live test pending without credentials
- `agent-openrouter`: 36 examples, 0 failures, 1 live test pending without credentials
- loaded all 96 affected `agent-cli`, `agent-responses`, `agent-openrouter`, `agent-openai`, and `agent-xai` library modules together in GHCi
- `git diff --check`
