### PR TITLE
refactor: share provider transport plumbing

### DIFF
--- a/packages/agent-core/agent-core.cabal
+++ b/packages/agent-core/agent-core.cabal
@@ -36,9 +36,11 @@ library
                     , Agent.FileRetry
                     , Agent.InterAgentMessage
                     , Agent.Provider
+                    , Agent.Provider.Options
                     , Agent.Loop
                     , Agent.JsonText
                     , Agent.OsPath
+                    , Agent.Http.Header
                     , Agent.Http.Url
                     , Agent.ProjectInstructions
                     , Agent.ResourceScope
@@ -104,10 +106,12 @@ test-suite agent-core-test
     main-is:          Spec.hs
     other-modules:    Agent.CancelSpec
                     , Agent.ErrorSpec
+                    , Agent.Http.HeaderSpec
                     , Agent.LoopSpec
                     , Agent.OsPathSpec
                     , Agent.JsonTextSpec
                     , Agent.ProjectInstructionsSpec
+                    , Agent.Provider.OptionsSpec
                     , Agent.ResourceScopeSpec
                     , Agent.SkillsSpec
                     , Agent.SubagentsSpec

--- a/packages/agent-core/src/Agent/Http/Header.hs
+++ b/packages/agent-core/src/Agent/Http/Header.hs
@@ -1,0 +1,18 @@
+-- | Small HTTP header parsers shared by provider clients.
+module Agent.Http.Header
+    ( parseRetryAfterSeconds
+    ) where
+
+import Data.ByteString (ByteString)
+import qualified Data.ByteString.Char8 as BS8
+
+-- | Parse the first integer @Retry-After@ header value.
+--
+-- HTTP-date values and malformed integers are left unhandled. A zero or
+-- negative delay is clamped to one second so retry loops always yield.
+parseRetryAfterSeconds :: [ByteString] -> Maybe Int
+parseRetryAfterSeconds = \case
+    value : _ -> case reads (BS8.unpack value) of
+        [(seconds, "")] -> Just (max 1 seconds)
+        _ -> Nothing
+    [] -> Nothing

--- a/packages/agent-core/src/Agent/Provider/Options.hs
+++ b/packages/agent-core/src/Agent/Provider/Options.hs
@@ -1,0 +1,46 @@
+-- | Small environment and model-mapping helpers shared by provider clients.
+module Agent.Provider.Options
+    ( lookupNonEmptyEnv
+    , lookupIntEnv
+    , parseModelOverrides
+    ) where
+
+import qualified Data.Maybe as Maybe
+import Data.Text (Text)
+import qualified Data.Text as Text
+import System.Environment (lookupEnv)
+
+-- | Read an environment variable, treating only the empty string as absent.
+lookupNonEmptyEnv :: String -> IO (Maybe String)
+lookupNonEmptyEnv name = nonEmpty <$> lookupEnv name
+  where
+    nonEmpty (Just value) | not (null value) = Just value
+    nonEmpty _ = Nothing
+
+-- | Read an integer environment variable. Invalid or empty values are absent.
+lookupIntEnv :: String -> IO (Maybe Int)
+lookupIntEnv name = do
+    value <- lookupNonEmptyEnv name
+    pure (value >>= parseInt)
+
+-- | Parse an integer only when the entire input is consumed.
+parseInt :: String -> Maybe Int
+parseInt value = case reads value of
+    [(number, "")] -> Just number
+    _ -> Nothing
+
+-- | Parse comma-separated exact model mappings in @source=target@ form.
+--
+-- Whitespace around each side is ignored. Empty or malformed entries are
+-- skipped so one bad override does not discard the remaining valid entries.
+parseModelOverrides :: Text -> [(Text, Text)]
+parseModelOverrides raw =
+    Maybe.mapMaybe parseEntry (Text.splitOn "," raw)
+  where
+    parseEntry entry = case Text.breakOn "=" entry of
+        (source, target)
+            | not (Text.null (Text.strip source))
+            , Just stripped <- Text.stripPrefix "=" target
+            , not (Text.null (Text.strip stripped)) ->
+                Just (Text.strip source, Text.strip stripped)
+        _ -> Nothing

--- a/packages/agent-core/test/Agent/Http/HeaderSpec.hs
+++ b/packages/agent-core/test/Agent/Http/HeaderSpec.hs
@@ -1,0 +1,19 @@
+module Agent.Http.HeaderSpec (spec) where
+
+import Agent.Http.Header (parseRetryAfterSeconds)
+import Test.Hspec
+
+spec :: Spec
+spec = describe "parseRetryAfterSeconds" do
+    it "parses the first integer header value" do
+        parseRetryAfterSeconds ["42"] `shouldBe` Just 42
+        parseRetryAfterSeconds ["7", "9"] `shouldBe` Just 7
+
+    it "clamps non-positive delays to one second" do
+        parseRetryAfterSeconds ["0"] `shouldBe` Just 1
+        parseRetryAfterSeconds ["-4"] `shouldBe` Just 1
+
+    it "rejects absent, malformed, and HTTP-date values" do
+        parseRetryAfterSeconds [] `shouldBe` Nothing
+        parseRetryAfterSeconds ["42s"] `shouldBe` Nothing
+        parseRetryAfterSeconds ["Sat, 22 Aug 2026 16:43:00 GMT"] `shouldBe` Nothing

--- a/packages/agent-core/test/Agent/Provider/OptionsSpec.hs
+++ b/packages/agent-core/test/Agent/Provider/OptionsSpec.hs
@@ -1,0 +1,46 @@
+module Agent.Provider.OptionsSpec (spec) where
+
+import Agent.Provider.Options
+import Control.Exception.Safe (bracket)
+import System.Environment (lookupEnv, setEnv, unsetEnv)
+import Test.Hspec
+
+spec :: Spec
+spec = describe "Agent.Provider.Options" do
+    describe "parseModelOverrides" do
+        it "parses valid entries, trims whitespace, and skips malformed ones" do
+            parseModelOverrides "local = remote,broken,=missing,also=,x=y=z"
+                `shouldBe`
+                    [ ("local", "remote")
+                    , ("x", "y=z")
+                    ]
+
+    describe "environment lookup" do
+        it "distinguishes empty, invalid, and valid values" $
+            withEnvironment "AGENT_PROVIDER_OPTIONS_SPEC" do
+                unsetEnv "AGENT_PROVIDER_OPTIONS_SPEC"
+                lookupNonEmptyEnv "AGENT_PROVIDER_OPTIONS_SPEC"
+                    `shouldReturn` Nothing
+
+                setEnv "AGENT_PROVIDER_OPTIONS_SPEC" ""
+                lookupNonEmptyEnv "AGENT_PROVIDER_OPTIONS_SPEC"
+                    `shouldReturn` Nothing
+
+                setEnv "AGENT_PROVIDER_OPTIONS_SPEC" "  "
+                lookupNonEmptyEnv "AGENT_PROVIDER_OPTIONS_SPEC"
+                    `shouldReturn` Just "  "
+
+                setEnv "AGENT_PROVIDER_OPTIONS_SPEC" "42s"
+                lookupIntEnv "AGENT_PROVIDER_OPTIONS_SPEC"
+                    `shouldReturn` Nothing
+
+                setEnv "AGENT_PROVIDER_OPTIONS_SPEC" "42"
+                lookupIntEnv "AGENT_PROVIDER_OPTIONS_SPEC"
+                    `shouldReturn` Just 42
+
+withEnvironment :: String -> IO a -> IO a
+withEnvironment name =
+    bracket (lookupEnv name) restore . const
+  where
+    restore Nothing = unsetEnv name
+    restore (Just value) = setEnv name value

--- a/packages/agent-core/test/Spec.hs
+++ b/packages/agent-core/test/Spec.hs
@@ -2,10 +2,12 @@ module Main (main) where
 
 import qualified Agent.CancelSpec as CancelSpec
 import qualified Agent.ErrorSpec as ErrorSpec
+import qualified Agent.Http.HeaderSpec as HttpHeaderSpec
 import qualified Agent.JsonTextSpec as JsonTextSpec
 import qualified Agent.LoopSpec as LoopSpec
 import qualified Agent.OsPathSpec as OsPathSpec
 import qualified Agent.ProjectInstructionsSpec as ProjectInstructionsSpec
+import qualified Agent.Provider.OptionsSpec as ProviderOptionsSpec
 import qualified Agent.ResourceScopeSpec as ResourceScopeSpec
 import qualified Agent.SkillsSpec as SkillsSpec
 import qualified Agent.SubagentsSpec as SubagentsSpec
@@ -28,10 +30,12 @@ main :: IO ()
 main = hspec do
     CancelSpec.spec
     ErrorSpec.spec
+    HttpHeaderSpec.spec
     JsonTextSpec.spec
     LoopSpec.spec
     OsPathSpec.spec
     ProjectInstructionsSpec.spec
+    ProviderOptionsSpec.spec
     ResourceScopeSpec.spec
     SkillsSpec.spec
     SubagentsSpec.spec

--- a/packages/agent-openrouter/src/Agent/OpenRouter/Client.hs
+++ b/packages/agent-openrouter/src/Agent/OpenRouter/Client.hs
@@ -8,6 +8,7 @@ module Agent.OpenRouter.Client
     , retryTransientOpenRouterResultWithPolicy
     ) where
 
+import Agent.Http.Header (parseRetryAfterSeconds)
 import Agent.Http.Url (trimTrailingSlash)
 import Agent.Error
     ( ApiError(..)
@@ -34,7 +35,6 @@ import Control.Retry
     )
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString as BS
-import qualified Data.ByteString.Char8 as BS8
 import qualified Data.ByteString.Lazy as LBS
 import Data.IORef
 import Data.Text (Text)
@@ -128,7 +128,10 @@ createResponseWithEventsPolicy policy options credential request onEvent
                 let bodyText = Text.decodeUtf8With Text.lenientDecode
                         (LBS.toStrict body)
                 pure $ Left $
-                    classifyFailure status (retryAfterSeconds response) bodyText
+                    classifyFailure status
+                        (parseRetryAfterSeconds
+                            (getResponseHeader "Retry-After" response))
+                        bodyText
 
     consumeSse emit body = go newSseDecoder []
       where
@@ -164,12 +167,6 @@ createResponseWithEventsPolicy policy options credential request onEvent
         ResponseNestedErrorEvent {} -> True
         ResponseFailedEvent {} -> True
         _ -> False
-
-    retryAfterSeconds response = case getResponseHeader "Retry-After" response of
-        (value : _) -> case reads (BS8.unpack value) of
-            [(seconds, "")] -> Just (max 1 seconds)
-            _ -> Nothing
-        [] -> Nothing
 
 -- | Retry transient failures while replay is safe. The callback marker is
 -- written before user code runs, so callback exceptions are never retried.

--- a/packages/agent-openrouter/src/Agent/OpenRouter/LoopBackend.hs
+++ b/packages/agent-openrouter/src/Agent/OpenRouter/LoopBackend.hs
@@ -12,12 +12,12 @@ module Agent.OpenRouter.LoopBackend
 
 import Agent.Error (ApiError)
 import Agent.Loop (Backend)
-import Agent.Responses.LoopBackend (statelessResponsesBackend)
-import Agent.Responses.Types
-import Agent.Provider
-    ( TokenProvider
-    , runWithTokenProvider
+import Agent.Responses.LoopBackend
+    ( statelessResponsesBackend
+    , tokenProviderStatelessResponsesBackend
     )
+import Agent.Responses.Types
+import Agent.Provider (TokenProvider)
 import Agent.OpenRouter.Client (createResponseWithEvents)
 import Agent.OpenRouter.Options (ClientOptions)
 import Data.IORef
@@ -34,9 +34,8 @@ openRouterBackend
     -> IORef [ResponseItem]
     -> Backend
 openRouterBackend options provider =
-    openRouterBackendWith \params onEvent ->
-        runWithTokenProvider provider \credential ->
-            createResponseWithEvents options credential params onEvent
+    tokenProviderStatelessResponsesBackend provider
+        (createResponseWithEvents options)
 
 -- | Same mapping as 'openRouterBackend', with an injectable transport for tests.
 openRouterBackendWith

--- a/packages/agent-openrouter/src/Agent/OpenRouter/Options.hs
+++ b/packages/agent-openrouter/src/Agent/OpenRouter/Options.hs
@@ -5,10 +5,14 @@ module Agent.OpenRouter.Options
     , clientOptionsFromEnv
     ) where
 
+import Agent.Provider.Options
+    ( lookupIntEnv
+    , lookupNonEmptyEnv
+    , parseModelOverrides
+    )
 import qualified Data.Maybe as Maybe
 import Data.Text (Text)
 import qualified Data.Text as Text
-import System.Environment (lookupEnv)
 
 data ClientOptions = ClientOptions
     { baseUrl :: !String
@@ -38,36 +42,18 @@ defaultClientOptions = ClientOptions
 -- | Load optional transport overrides from the environment.
 clientOptionsFromEnv :: IO ClientOptions
 clientOptionsFromEnv = do
-    baseUrl <- lookupEnv "OPENROUTER_BASE_URL"
-    modelMap <- lookupEnv "OPENROUTER_MODEL_MAP"
-    defaultModel <- lookupEnv "OPENROUTER_DEFAULT_MODEL"
-    timeoutSeconds <- lookupEnv "OPENROUTER_TIMEOUT_SECONDS"
-    httpReferer <- lookupEnv "OPENROUTER_HTTP_REFERER"
-    appTitle <- lookupEnv "OPENROUTER_APP_TITLE"
+    baseUrl <- lookupNonEmptyEnv "OPENROUTER_BASE_URL"
+    modelMap <- lookupNonEmptyEnv "OPENROUTER_MODEL_MAP"
+    defaultModel <- lookupNonEmptyEnv "OPENROUTER_DEFAULT_MODEL"
+    timeoutSeconds <- lookupIntEnv "OPENROUTER_TIMEOUT_SECONDS"
+    httpReferer <- lookupNonEmptyEnv "OPENROUTER_HTTP_REFERER"
+    appTitle <- lookupNonEmptyEnv "OPENROUTER_APP_TITLE"
     pure ClientOptions
-        { baseUrl = Maybe.fromMaybe defaultClientOptions.baseUrl (nonEmpty baseUrl)
-        , modelOverrides = maybe [] (parseModelMap . Text.pack) (nonEmpty modelMap)
-        , defaultModel = maybe defaultClientOptions.defaultModel Text.pack (nonEmpty defaultModel)
+        { baseUrl = Maybe.fromMaybe defaultClientOptions.baseUrl baseUrl
+        , modelOverrides = maybe [] (parseModelOverrides . Text.pack) modelMap
+        , defaultModel = maybe defaultClientOptions.defaultModel Text.pack defaultModel
         , requestTimeoutSeconds = Maybe.fromMaybe defaultClientOptions.requestTimeoutSeconds
-            (nonEmpty timeoutSeconds >>= readMaybeInt)
-        , httpReferer = Text.pack <$> nonEmpty httpReferer
-        , appTitle = Text.pack <$> nonEmpty appTitle
+            timeoutSeconds
+        , httpReferer = Text.pack <$> httpReferer
+        , appTitle = Text.pack <$> appTitle
         }
-  where
-    nonEmpty (Just value) | not (null value) = Just value
-    nonEmpty _ = Nothing
-
-    readMaybeInt value = case reads value of
-        [(number, "")] -> Just number
-        _ -> Nothing
-
-parseModelMap :: Text -> [(Text, Text)]
-parseModelMap raw = Maybe.mapMaybe parseEntry (Text.splitOn "," raw)
-  where
-    parseEntry entry = case Text.breakOn "=" entry of
-        (source, target)
-            | not (Text.null (Text.strip source))
-            , Just stripped <- Text.stripPrefix "=" target
-            , not (Text.null (Text.strip stripped)) ->
-                Just (Text.strip source, Text.strip stripped)
-        _ -> Nothing

--- a/packages/agent-responses/agent-responses.cabal
+++ b/packages/agent-responses/agent-responses.cabal
@@ -58,8 +58,10 @@ test-suite agent-responses-test
     type:             exitcode-stdio-1.0
     hs-source-dirs:   test
     main-is:          Spec.hs
-    other-modules:    Agent.Responses.ResponseMergeSpec
+    other-modules:    Agent.Responses.LoopBackendSpec
+                    , Agent.Responses.ResponseMergeSpec
     build-depends:    base >= 4.14 && < 5
+                    , agent-core
                     , agent-responses
                     , aeson >= 2.0
                     , hspec

--- a/packages/agent-responses/package.nix
+++ b/packages/agent-responses/package.nix
@@ -9,7 +9,7 @@ mkDerivation {
     aeson agent-core base base64-bytestring bytestring containers
     scientific text vector
   ];
-  testHaskellDepends = [ aeson base hspec text ];
+  testHaskellDepends = [ aeson agent-core base hspec text ];
   description = "Provider-neutral OpenAI Responses protocol types and adapters";
   license = lib.licenses.bsd3;
 }

--- a/packages/agent-responses/src/Agent/Responses/LoopBackend.hs
+++ b/packages/agent-responses/src/Agent/Responses/LoopBackend.hs
@@ -1,6 +1,7 @@
 -- | Provider-neutral loop adapters for Responses-compatible transports.
 module Agent.Responses.LoopBackend
     ( statelessResponsesBackend
+    , tokenProviderStatelessResponsesBackend
     , turnInputsToItems
     , responseToTurnOutput
     , streamEventToLoopEvent
@@ -24,6 +25,11 @@ import Agent.Loop
     , TurnInput(..)
     , TurnOutput(..)
     , emptyTokenUsage
+    )
+import Agent.Provider
+    ( Credential
+    , TokenProvider
+    , runWithTokenProvider
     )
 import Agent.Responses.Types
 import Agent.ToolDispatch
@@ -65,6 +71,24 @@ statelessResponsesBackend send getParams transcript =
             Right response -> do
                 writeIORef transcript (requestItems <> response.output)
                 pure (Right (responseToTurnOutput response))
+
+-- | Adapt a credentialed stateless Responses transport to the loop.
+--
+-- Credential acquisition and account failover are shared across providers;
+-- the transport remains responsible only for one request with one credential.
+tokenProviderStatelessResponsesBackend
+    :: TokenProvider
+    -> (Credential
+        -> ResponseCreateParams
+        -> (ResponseStreamEvent -> IO ())
+        -> IO (Either ApiError Response))
+    -> IO ResponseCreateParams
+    -> IORef [ResponseItem]
+    -> Backend
+tokenProviderStatelessResponsesBackend provider send =
+    statelessResponsesBackend \params onEvent ->
+        runWithTokenProvider provider \credential ->
+            send credential params onEvent
 
 -- | 'input' is also a field on 'CustomToolCall', so a record update is
 -- ambiguous. Rebuild from the constructor instead.

--- a/packages/agent-responses/test/Agent/Responses/LoopBackendSpec.hs
+++ b/packages/agent-responses/test/Agent/Responses/LoopBackendSpec.hs
@@ -1,0 +1,49 @@
+module Agent.Responses.LoopBackendSpec (spec) where
+
+import Agent.Error (ApiError(..), ErrorType(..))
+import Agent.Loop (Backend(..), TurnInput(..))
+import Agent.Provider
+    ( Credential(..)
+    , FailedCredential(..)
+    , Provider(..)
+    , TokenProvider(..)
+    )
+import Agent.Responses.LoopBackend (tokenProviderStatelessResponsesBackend)
+import Agent.Responses.Types (defaultResponseCreateParams)
+import Data.IORef
+import qualified Data.Text as Text
+import Test.Hspec
+
+spec :: Spec
+spec = describe "tokenProviderStatelessResponsesBackend" do
+    it "reacquires a credential after an authentication rejection" do
+        attempts <- newIORef []
+        transcript <- newIORef []
+        let first = credential "first"
+            second = credential "second"
+            provider = TokenProvider \failed -> pure $ Right $ case failed of
+                Nothing -> first
+                Just FailedCredential{} -> second
+            send current _params _onEvent = do
+                modifyIORef' attempts (<> [current])
+                pure $ Left $
+                    if current == first
+                        then ProviderError AuthenticationError "rejected" Nothing
+                        else ConnectionError "stopped after failover"
+            backend =
+                tokenProviderStatelessResponsesBackend provider send
+                    (pure defaultResponseCreateParams)
+                    transcript
+
+        result <- backend.submitTurn Nothing [UserMessage "hello"] (const (pure ()))
+
+        result `shouldBe` Left (ConnectionError "stopped after failover")
+        readIORef attempts `shouldReturn` [first, second]
+
+credential :: String -> Credential
+credential label = Credential
+    { accessToken = "token-" <> Text.pack label
+    , accountId = Text.pack label
+    , leaseId = Nothing
+    , provider = OpenRouterProvider
+    }

--- a/packages/agent-responses/test/Spec.hs
+++ b/packages/agent-responses/test/Spec.hs
@@ -2,7 +2,10 @@ module Main (main) where
 
 import Test.Hspec (hspec)
 
+import qualified Agent.Responses.LoopBackendSpec as LoopBackendSpec
 import qualified Agent.Responses.ResponseMergeSpec as ResponseMergeSpec
 
 main :: IO ()
-main = hspec ResponseMergeSpec.spec
+main = hspec do
+    LoopBackendSpec.spec
+    ResponseMergeSpec.spec

--- a/packages/agent-xai/src/Agent/XAI/Client.hs
+++ b/packages/agent-xai/src/Agent/XAI/Client.hs
@@ -8,6 +8,7 @@ module Agent.XAI.Client
     , retryTransientXaiResultWithPolicy
     ) where
 
+import Agent.Http.Header (parseRetryAfterSeconds)
 import Agent.Http.Url (trimTrailingSlash)
 import Agent.Error
     ( ApiError(..)
@@ -31,7 +32,6 @@ import Control.Retry
     , retrying
     )
 import qualified Data.Aeson as Aeson
-import qualified Data.ByteString.Char8 as BS8
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
@@ -125,13 +125,10 @@ createResponseWithEventsPolicy policy options credential request onEvent
                 Right events -> do
                     mapM_ onEvent events
                     pure (buildResponse events)
-            else pure $ Left $ classifyFailure status (retryAfterSeconds response) bodyText
-
-    retryAfterSeconds response = case getResponseHeader "Retry-After" response of
-        (value : _) -> case reads (BS8.unpack value) of
-            [(seconds, "")] -> Just (max 1 seconds)
-            _ -> Nothing
-        [] -> Nothing
+            else pure $ Left $ classifyFailure status
+                (parseRetryAfterSeconds
+                    (getResponseHeader "Retry-After" response))
+                bodyText
 
 -- | Retry capacity / overload pressure and short-lived 5xx failures. Generic
 -- connection drops and quota errors are left to the caller. Production uses a

--- a/packages/agent-xai/src/Agent/XAI/LoopBackend.hs
+++ b/packages/agent-xai/src/Agent/XAI/LoopBackend.hs
@@ -12,12 +12,12 @@ module Agent.XAI.LoopBackend
 
 import Agent.Error (ApiError)
 import Agent.Loop (Backend)
-import Agent.Responses.LoopBackend (statelessResponsesBackend)
-import Agent.Responses.Types
-import Agent.Provider
-    ( TokenProvider
-    , runWithTokenProvider
+import Agent.Responses.LoopBackend
+    ( statelessResponsesBackend
+    , tokenProviderStatelessResponsesBackend
     )
+import Agent.Responses.Types
+import Agent.Provider (TokenProvider)
 import Agent.XAI.Client (createResponseWithEvents)
 import Agent.XAI.Options (ClientOptions)
 import Data.IORef
@@ -34,9 +34,8 @@ xaiBackend
     -> IORef [ResponseItem]
     -> Backend
 xaiBackend options provider =
-    xaiBackendWith \params onEvent ->
-        runWithTokenProvider provider \credential ->
-            createResponseWithEvents options credential params onEvent
+    tokenProviderStatelessResponsesBackend provider
+        (createResponseWithEvents options)
 
 -- | Same mapping as 'xaiBackend', with an injectable transport for tests.
 xaiBackendWith

--- a/packages/agent-xai/src/Agent/XAI/Options.hs
+++ b/packages/agent-xai/src/Agent/XAI/Options.hs
@@ -5,10 +5,14 @@ module Agent.XAI.Options
     , clientOptionsFromEnv
     ) where
 
+import Agent.Provider.Options
+    ( lookupIntEnv
+    , lookupNonEmptyEnv
+    , parseModelOverrides
+    )
 import qualified Data.Maybe as Maybe
 import Data.Text (Text)
 import qualified Data.Text as Text
-import System.Environment (lookupEnv)
 
 data ClientOptions = ClientOptions
     { baseUrl :: !String
@@ -35,34 +39,16 @@ defaultClientOptions = ClientOptions
 -- | Load optional transport overrides from the environment.
 clientOptionsFromEnv :: IO ClientOptions
 clientOptionsFromEnv = do
-    baseUrl <- lookupEnv "XAI_GROK_BASE_URL"
-    modelMap <- lookupEnv "XAI_GROK_MODEL_MAP"
-    defaultModel <- lookupEnv "XAI_GROK_DEFAULT_MODEL"
-    timeoutSeconds <- lookupEnv "XAI_GROK_TIMEOUT_SECONDS"
-    clientVersion <- lookupEnv "XAI_GROK_CLIENT_VERSION"
+    baseUrl <- lookupNonEmptyEnv "XAI_GROK_BASE_URL"
+    modelMap <- lookupNonEmptyEnv "XAI_GROK_MODEL_MAP"
+    defaultModel <- lookupNonEmptyEnv "XAI_GROK_DEFAULT_MODEL"
+    timeoutSeconds <- lookupIntEnv "XAI_GROK_TIMEOUT_SECONDS"
+    clientVersion <- lookupNonEmptyEnv "XAI_GROK_CLIENT_VERSION"
     pure ClientOptions
-        { baseUrl = Maybe.fromMaybe defaultClientOptions.baseUrl (nonEmpty baseUrl)
-        , modelOverrides = maybe [] (parseModelMap . Text.pack) (nonEmpty modelMap)
-        , defaultModel = maybe defaultClientOptions.defaultModel Text.pack (nonEmpty defaultModel)
+        { baseUrl = Maybe.fromMaybe defaultClientOptions.baseUrl baseUrl
+        , modelOverrides = maybe [] (parseModelOverrides . Text.pack) modelMap
+        , defaultModel = maybe defaultClientOptions.defaultModel Text.pack defaultModel
         , requestTimeoutSeconds = Maybe.fromMaybe defaultClientOptions.requestTimeoutSeconds
-            (nonEmpty timeoutSeconds >>= readMaybeInt)
-        , clientVersion = maybe defaultClientOptions.clientVersion Text.pack (nonEmpty clientVersion)
+            timeoutSeconds
+        , clientVersion = maybe defaultClientOptions.clientVersion Text.pack clientVersion
         }
-  where
-    nonEmpty (Just value) | not (null value) = Just value
-    nonEmpty _ = Nothing
-
-    readMaybeInt value = case reads value of
-        [(number, "")] -> Just number
-        _ -> Nothing
-
-parseModelMap :: Text -> [(Text, Text)]
-parseModelMap raw = Maybe.mapMaybe parseEntry (Text.splitOn "," raw)
-  where
-    parseEntry entry = case Text.breakOn "=" entry of
-        (source, target)
-            | not (Text.null (Text.strip source))
-            , Just stripped <- Text.stripPrefix "=" target
-            , not (Text.null (Text.strip stripped)) ->
-                Just (Text.strip source, Text.strip stripped)
-        _ -> Nothing


### PR DESCRIPTION
## Summary

- extract shared provider option parsing for non-empty environment values, integer timeouts, and model overrides
- add a shared stateless Responses backend adapter that composes token-provider failover with provider transports
- centralize integer `Retry-After` parsing without adding HTTP client dependencies to shared packages
- keep provider-specific request execution, streaming, timeout, and retry policies local

## Validation

- multi-package GHCi load for `agent-core`, `agent-responses`, `agent-openrouter`, and `agent-xai`
- `agent-core`: 246 examples, 0 failures
- `agent-responses`: 4 examples, 0 failures
- `agent-openrouter`: 36 examples, 0 failures, 1 live test pending
- `agent-xai`: 41 examples, 0 failures, 1 live test pending
- `git diff --check`
