### PR TITLE
fix(cli): render pasted images with native terminal graphics

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -117,6 +117,7 @@ library
                     , time
                     , transformers
                     , unix
+                    , vector
                     , vty >= 6.4 && < 7
                     , vty-crossplatform >= 0.4 && < 0.5
 

--- a/packages/agent-cli/src/Agent/CLI/ImagePreview.hs
+++ b/packages/agent-cli/src/Agent/CLI/ImagePreview.hs
@@ -9,7 +9,11 @@ module Agent.CLI.ImagePreview
     , detectImagePreviewProtocol
     , parseImagePreviewProtocol
     , kittyImageSequence
+    , kittyPlacedImageSequence
+    , kittyDeleteImageSequence
+    , kittyCompatibleAttachment
     , itermImageSequence
+    , positionImagePayload
     , wrapTmuxPassthrough
     , imagePreviewPayload
     , previewRowsFor
@@ -18,9 +22,11 @@ module Agent.CLI.ImagePreview
     ) where
 
 import Agent.Loop (ImageAttachment(..))
+import Codec.Picture (convertRGBA8, decodeImage, encodePng)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Base64 as Base64
+import qualified Data.ByteString.Lazy as LBS
 import Data.Char (toLower)
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
@@ -79,9 +85,8 @@ detectImagePreviewProtocol handle = do
             mIterm <- lookupEnv "ITERM_SESSION_ID"
             pure (parseImagePreviewProtocol mTerm mProgram mKitty mIterm)
 
--- | Kitty graphics transmit-and-display. @f=100@ is PNG; Kitty has no JPEG
--- format code (24/32 are raw RGB/RGBA). We always send 100 and let the
--- terminal sniff, matching Grok Build's overlay path for PNG screenshots.
+-- | Kitty graphics transmit-and-display. @f=100@ is PNG; non-PNG clipboard
+-- formats are transcoded before this sequence is assembled.
 --
 -- Use the combined @a=T@ action rather than uploading with @a=t@ and creating
 -- a separate @a=p@ placement. Besides saving a round trip, this keeps PNG
@@ -95,31 +100,100 @@ detectImagePreviewProtocol handle = do
 -- Chunked at 4096 encoded bytes (Kitty's documented payload limit).
 kittyImageSequence :: Int -> Int -> Int -> Text -> ByteString -> Text
 kittyImageSequence imageId _columns rows mime bytes =
+    let compatible =
+            kittyCompatibleAttachment (ImageAttachment mime bytes)
+    in kittyTransmitSequence
+        imageId
+        Nothing
+        rows
+        compatible.imageMime
+        compatible.imageBytes
+
+-- | Kitty transmit-and-display sequence for a fullscreen placement with an
+-- explicit cell rectangle and placement id. Reusing the image/placement pair
+-- replaces the old placement without flicker.
+kittyPlacedImageSequence
+    :: Int
+    -> Int
+    -> Int
+    -> Int
+    -> Text
+    -> ByteString
+    -> Text
+kittyPlacedImageSequence imageId placementId columns rows mime bytes =
+    let compatible =
+            kittyCompatibleAttachment (ImageAttachment mime bytes)
+    in kittyTransmitSequence
+        imageId
+        (Just (placementId, columns))
+        rows
+        compatible.imageMime
+        compatible.imageBytes
+
+-- | Kitty accepts PNG or raw pixels, not JPEG/WebP/etc. Preserve PNG bytes
+-- unchanged and transcode other decodable clipboard formats once.
+kittyCompatibleAttachment :: ImageAttachment -> ImageAttachment
+kittyCompatibleAttachment attachment@ImageAttachment{imageMime, imageBytes}
+    | Text.toLower imageMime == "image/png" = attachment
+    | otherwise =
+        case decodeImage imageBytes of
+            Left _ -> attachment
+            Right image ->
+                ImageAttachment
+                    { imageMime = "image/png"
+                    , imageBytes =
+                        LBS.toStrict (encodePng (convertRGBA8 image))
+                    }
+
+kittyTransmitSequence
+    :: Int
+    -> Maybe (Int, Int)
+    -> Int
+    -> Text
+    -> ByteString
+    -> Text
+kittyTransmitSequence imageId placement rows mime bytes =
     let fmt = kittyFormat mime
         chunks = chunkBytes 4096 (Base64.encode bytes)
         total = length chunks
         transmit n chunk =
             let more = if n + 1 < total then 1 else 0 :: Int
-                action = if n == 0 then "T" else "t"
-                extras
+                controls
                     | n == 0 =
-                        ",f="
+                        "a=T,q=2,i="
+                            <> Text.pack (show imageId)
+                            <> ",f="
                             <> Text.pack (show fmt)
                             <> ",t=d,r="
                             <> Text.pack (show rows)
+                            <> case placement of
+                                Nothing -> ""
+                                Just (placementId, columns) ->
+                                    ",c="
+                                        <> Text.pack (show columns)
+                                        <> ",p="
+                                        <> Text.pack (show placementId)
+                                        <> ",z=1"
                             <> ",C=1"
-                    | otherwise = ""
-            in "\ESC_Ga="
-                <> action
-                <> ",q=2,i="
-                <> Text.pack (show imageId)
-                <> extras
+                    -- The protocol permits only m and optionally q after the
+                    -- first chunk. Repeating a/i makes larger images fail in
+                    -- stricter implementations.
+                    | otherwise = "q=2"
+            in "\ESC_G"
+                <> controls
                 <> ",m="
                 <> Text.pack (show more)
                 <> ";"
                 <> TextEncoding.decodeLatin1 chunk
                 <> "\ESC\\"
     in Text.concat (zipWith transmit [0 ..] chunks)
+
+-- | Delete one Kitty image and all of its placements, freeing its image data.
+kittyDeleteImageSequence :: Int -> Text
+kittyDeleteImageSequence imageId =
+    "\ESC_Ga=d,d=I,q=2,i="
+        <> Text.pack (show imageId)
+        <> "\ESC\\"
 
 kittyFormat :: Text -> Int
 kittyFormat _ = 100
@@ -135,6 +209,20 @@ itermImageSequence columns rows bytes =
         <> ";preserveAspectRatio=1:"
         <> TextEncoding.decodeLatin1 (Base64.encode bytes)
         <> "\BEL"
+
+-- | Draw a graphics payload at a zero-based terminal cell while preserving
+-- Vty's cursor position.
+positionImagePayload :: Int -> Int -> Text -> Text
+positionImagePayload row column payload
+    | Text.null payload = payload
+    | otherwise =
+        "\ESC7\ESC["
+            <> Text.pack (show (row + 1))
+            <> ";"
+            <> Text.pack (show (column + 1))
+            <> "H"
+            <> payload
+            <> "\ESC8"
 
 -- | tmux DCS passthrough so Kitty/iTerm sequences reach the outer emulator.
 -- @ST@ must be @ESC \\@ (not BEL) so tmux does not swallow the payload.

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -42,6 +42,13 @@ import Agent.CLI.AgentViewport
     , agentEntryTreeLabel
     )
 import Agent.CLI.Interrupt (CtrlCDecision(..))
+import Agent.CLI.ImagePreview
+    ( ImagePreviewProtocol(..)
+    , detectImagePreviewProtocol
+    , kittyDeleteImageSequence
+    , kittyPlacedImageSequence
+    , positionImagePayload
+    )
 import Agent.CLI.Command
     ( SkillCommand
     )
@@ -53,8 +60,11 @@ import qualified Agent.TUI.Theme as Theme
 import qualified Agent.CLI.TUI.Bridge as Bridge
 import qualified Agent.CLI.TUI.Composer as Composer
 import Agent.CLI.TUI.ImagePreview
-    ( TuiImagePreview(..)
+    ( NativePreviewPlacement(..)
+    , TuiImagePreview(..)
+    , nativePreviewPlacements
     , prepareTuiImagePreview
+    , previewCellSize
     , renderTuiImagePreview
     )
 import Agent.TUI.Markdown
@@ -64,7 +74,7 @@ import Agent.TUI.Markdown
 import qualified Agent.CLI.TUI.Scroll as Scroll
 import Agent.CLI.TUI.Types
 import Agent.TUI.Model
-import Agent.Loop (ImageAttachment, LoopEvent(..))
+import Agent.Loop (ImageAttachment(..), LoopEvent(..))
 import Agent.ToolDispatch (ToolCall(..))
 import Brick
 import qualified Brick.Types as B
@@ -96,19 +106,25 @@ import Control.Exception.Safe (finally, throwIO, tryAny)
 import Control.Exception (AsyncException(UserInterrupt))
 import Data.Foldable (toList)
 import Data.IORef
-    ( newIORef
+    ( modifyIORef'
+    , newIORef
     , readIORef
     , writeIORef
     )
 import Data.List (find, findIndex, intersperse, sortOn)
 import Data.List.NonEmpty (NonEmpty(..))
-import Data.Maybe (fromMaybe, mapMaybe)
+import Data.Maybe (fromMaybe, isJust, isNothing, mapMaybe)
 import Data.Sequence (Seq, ViewL(..), ViewR(..), (|>))
 import qualified Data.Sequence as Seq
 import Data.Text (Text)
 import qualified Data.Text as Text
+import qualified Data.Text.Encoding as TextEncoding
+import Data.Time.Clock.POSIX (getPOSIXTime)
 import qualified Graphics.Vty as V
 import qualified Graphics.Vty.CrossPlatform as Vty
+import System.Environment (lookupEnv)
+import System.IO (stdout)
+import System.Posix.Process (getProcessID)
 
 newFullscreenInputBuffer :: IO FullscreenInputBuffer
 newFullscreenInputBuffer = Composer.newFullscreenInputBuffer
@@ -143,6 +159,12 @@ newFullscreenRuntime
         events <- newBChan 512
         mailbox <- AppEventMailbox <$> newTVarIO Seq.empty
         running <- newIORef (uiNeedsTick initial)
+        imagePreviews <- newIORef []
+        imagePreviewRevision <- newIORef 0
+        imagePreviewVisible <- newIORef True
+        imagePreviewIdBase <- allocateNativePreviewImageIdBase
+        imagePreviewProtocol <- detectImagePreviewProtocol stdout
+        imagePreviewInTmux <- isJust <$> lookupEnv "TMUX"
         pure FullscreenRuntime
             { runtimeEvents = events
             , runtimeMailbox = mailbox
@@ -157,6 +179,13 @@ newFullscreenRuntime
             , runtimeAgentSelect = agentSelect
             , runtimeFirstFrame = firstFrame
             , runtimeRunning = running
+            , runtimeImagePreviews = imagePreviews
+            , runtimeImagePreviewRevision = imagePreviewRevision
+            , runtimeImagePreviewVisible = imagePreviewVisible
+            , runtimeImagePreviewIdBase = imagePreviewIdBase
+            , runtimeNativeImagePreviews =
+                imagePreviewProtocol == PreviewKitty
+                    && not imagePreviewInTmux
             , runtimeColor = color
             , runtimeInitial = initial
             }
@@ -292,7 +321,7 @@ runFullscreen runtime workerAction = do
                 V.setMode output V.BracketedPaste True
             when (V.supportsMode output V.Mouse) $
                 V.setMode output V.Mouse True
-            pure vty
+            wrapNativePreviewVty runtime vty
     initialVty <- buildVty
     let
         initialState = AppState
@@ -373,6 +402,96 @@ runFullscreen runtime workerAction = do
                         (uncurry AppAgentSnapshot snapshot)
                     pure snapshot
         agentTicker previous'
+
+wrapNativePreviewVty :: FullscreenRuntime -> V.Vty -> IO V.Vty
+wrapNativePreviewVty runtime vty
+    | not runtime.runtimeNativeImagePreviews = pure vty
+    | otherwise = do
+        rendered <- newIORef Nothing
+        let output = V.outputIface vty
+            deletePayload imageId =
+                kittyDeleteImageSequence imageId
+            placementPayload placement =
+                let attachment = placement.nativePreviewAttachment
+                    graphics =
+                        kittyPlacedImageSequence
+                            placement.nativePreviewImageId
+                            placement.nativePreviewImageId
+                            placement.nativePreviewColumns
+                            placement.nativePreviewRows
+                            attachment.imageMime
+                            attachment.imageBytes
+                in positionImagePayload
+                    placement.nativePreviewRow
+                    placement.nativePreviewColumn
+                    graphics
+            renderNative force = do
+                revision <- readIORef runtime.runtimeImagePreviewRevision
+                bounds@(terminalColumns, terminalRows) <-
+                    V.displayBounds output
+                previous <- readIORef rendered
+                let unchanged = case previous of
+                        Just (oldRevision, oldBounds, _) ->
+                            oldRevision == revision && oldBounds == bounds
+                        Nothing -> False
+                when (force || not unchanged) do
+                    visible <-
+                        readIORef runtime.runtimeImagePreviewVisible
+                    previews <-
+                        if visible
+                            then readIORef runtime.runtimeImagePreviews
+                            else pure []
+                    let placements =
+                            nativePreviewPlacements
+                                runtime.runtimeImagePreviewIdBase
+                                terminalColumns
+                                terminalRows
+                                previews
+                        oldImageIds = case previous of
+                            Just (_, _, imageIds) -> imageIds
+                            Nothing -> []
+                        payload =
+                            Text.concat
+                                ( map deletePayload oldImageIds
+                                    <> map placementPayload placements
+                                )
+                    when (not (Text.null payload)) $
+                        V.outputByteBuffer output
+                            (TextEncoding.encodeUtf8 payload)
+                    writeIORef rendered $
+                        Just
+                            ( revision
+                            , bounds
+                            , map (.nativePreviewImageId) placements
+                            )
+            clearNative = do
+                previous <- readIORef rendered
+                let imageIds = case previous of
+                        Just (_, _, ids) -> ids
+                        Nothing -> []
+                    payload = Text.concat (map deletePayload imageIds)
+                when (not (Text.null payload)) $
+                    V.outputByteBuffer output
+                        (TextEncoding.encodeUtf8 payload)
+                writeIORef rendered Nothing
+        pure vty
+            { V.update = \picture ->
+                V.update vty picture >> renderNative False
+            , V.refresh =
+                V.refresh vty >> renderNative True
+            , V.shutdown =
+                clearNative `finally` V.shutdown vty
+            }
+
+allocateNativePreviewImageIdBase :: IO Int
+allocateNativePreviewImageIdBase = do
+    micros <- floor . (* 1_000_000) <$> getPOSIXTime :: IO Integer
+    pid <- fromIntegral <$> getProcessID :: IO Integer
+    -- Kitty ids are terminal-global uint32s. Leave room for the other two
+    -- simultaneously displayed previews and vary the base per process/runtime.
+    let availableBases = 4_294_967_293 :: Integer
+    pure $
+        fromInteger ((micros * 65_537 + pid) `mod` availableBases) + 1
 
 -- | Move events from the producer-facing mailbox into Brick. UI updates are
 -- collected for one frame so a fast token stream causes at most one redraw
@@ -726,7 +845,9 @@ drawApp state =
     let mainLayers = stickyPromptLayers state <> [drawMain state]
         interactiveLayers =
             agentPopoverLayers state
-                <> imagePreviewLayers state.appImagePreviews
+                <> imagePreviewLayers
+                    state.appRuntime.runtimeNativeImagePreviews
+                    state.appImagePreviews
                 <> mainLayers
         dimmedMainLayers = map (forceAttr Theme.dimAttr) mainLayers
     in
@@ -753,17 +874,17 @@ drawMain state =
             , drawFooter state
             ]
 
-imagePreviewLayers :: [TuiImagePreview] -> [Widget Name]
-imagePreviewLayers previews =
+imagePreviewLayers :: Bool -> [TuiImagePreview] -> [Widget Name]
+imagePreviewLayers native previews =
     case takeLast 3 previews of
         [] -> []
-        shown -> [centerLayer (drawImagePreviews shown)]
+        shown -> [centerLayer (drawImagePreviews native shown)]
   where
     takeLast count values =
         drop (max 0 (length values - count)) values
 
-drawImagePreviews :: [TuiImagePreview] -> Widget Name
-drawImagePreviews previews =
+drawImagePreviews :: Bool -> [TuiImagePreview] -> Widget Name
+drawImagePreviews native previews =
     Widget Fixed Fixed do
         context <- getContext
         let maxWidth = viewportPreviewSize context.availWidth
@@ -787,7 +908,9 @@ drawImagePreviews previews =
         hLimit maxWidth $
             vBox
                 [ hCenter $
-                    renderTuiImagePreview maxWidth maxHeight preview
+                    if native
+                        then nativeImagePlaceholder maxWidth maxHeight preview
+                        else renderTuiImagePreview maxWidth maxHeight preview
                 , hCenter $
                     withAttr Theme.mutedAttr $
                         txt $
@@ -800,6 +923,13 @@ drawImagePreviews previews =
                                 <> " · "
                                 <> formatImageSize preview.previewBytes
                 ]
+
+    nativeImagePlaceholder maxWidth maxHeight preview =
+        let (width, height) =
+                previewCellSize maxWidth maxHeight preview
+        in hLimit width $
+            vLimit height $
+                fill ' '
 
 viewportPreviewSize :: Int -> Int
 viewportPreviewSize available =
@@ -1886,7 +2016,27 @@ applyUiEvent uiEvent state =
         state { appUi = reduceUi uiEvent state.appUi }
 
 handleEvent :: BrickEvent Name AppEvent -> EventM Name AppState ()
-handleEvent event = case event of
+handleEvent event = do
+    handleEventInner event
+    state <- get
+    let visible =
+            isNothing state.appTextPrompt
+                && isNothing state.appChoice
+                && isNothing state.appUi.uiPermission
+                && isNothing state.appAgentHover
+    liftIO do
+        previous <-
+            readIORef state.appRuntime.runtimeImagePreviewVisible
+        when (previous /= visible) do
+            writeIORef
+                state.appRuntime.runtimeImagePreviewVisible
+                visible
+            modifyIORef'
+                state.appRuntime.runtimeImagePreviewRevision
+                (+ 1)
+
+handleEventInner :: BrickEvent Name AppEvent -> EventM Name AppState ()
+handleEventInner event = case event of
     AppEvent AppStop -> do
         modify' \state -> state { appWorkerStopped = True }
         halt
@@ -1900,13 +2050,29 @@ handleEvent event = case event of
                 , appSlashDismissed = False
                 }
     AppEvent (AppSetImagePreviews images) ->
-        modify' \state ->
-            state
-                { appImagePreviews =
+        do
+            state <- get
+            let prepared =
                     mapMaybe
-                        (either (const Nothing) Just . prepareTuiImagePreview)
+                        (\image ->
+                            case prepareTuiImagePreview image of
+                                Left _ -> Nothing
+                                Right preview -> Just (image, preview))
                         images
-                }
+            liftIO do
+                previous <-
+                    readIORef state.appRuntime.runtimeImagePreviews
+                when (map fst previous /= map fst prepared) do
+                    writeIORef
+                        state.appRuntime.runtimeImagePreviews
+                        prepared
+                    modifyIORef'
+                        state.appRuntime.runtimeImagePreviewRevision
+                        (+ 1)
+            modify' \current ->
+                current
+                    { appImagePreviews = map snd prepared
+                    }
     AppEvent (AppSetWindowTitle title) -> do
         state <- get
         liftIO (state.appRuntime.runtimeSetWindowTitle title)

--- a/packages/agent-cli/src/Agent/CLI/TUI/ImagePreview.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/ImagePreview.hs
@@ -1,20 +1,27 @@
+{-# LANGUAGE BangPatterns #-}
+
 -- | True-colour image previews for the retained fullscreen interface.
 module Agent.CLI.TUI.ImagePreview
-    ( TuiImagePreview(..)
+    ( NativePreviewPlacement(..)
+    , TuiImagePreview(..)
+    , nativePreviewPlacements
     , prepareTuiImagePreview
     , previewCellSize
+    , previewImageAt
     , renderTuiImagePreview
     ) where
 
+import Agent.CLI.ImagePreview (kittyCompatibleAttachment)
 import Agent.Loop (ImageAttachment(..))
 import Brick (Widget, raw)
 import Codec.Picture
     ( Image
     , PixelRGB8(..)
-    , PixelRGBA8(..)
+    , PixelRGBA8
     , convertRGBA8
     , decodeImage
     , generateImage
+    , imageData
     , imageHeight
     , imageWidth
     , pixelAt
@@ -22,12 +29,23 @@ import Codec.Picture
 import qualified Data.ByteString as BS
 import Data.Text (Text)
 import qualified Data.Text as Text
+import qualified Data.Vector.Storable as Vector
 import Data.Word (Word8)
 import qualified Graphics.Vty as V
 
 data PreviewCell = PreviewCell
     { cellTop :: !PixelRGB8
     , cellBottom :: !PixelRGB8
+    }
+    deriving (Eq, Show)
+
+data NativePreviewPlacement = NativePreviewPlacement
+    { nativePreviewImageId :: !Int
+    , nativePreviewRow :: !Int
+    , nativePreviewColumn :: !Int
+    , nativePreviewColumns :: !Int
+    , nativePreviewRows :: !Int
+    , nativePreviewAttachment :: !ImageAttachment
     }
     deriving (Eq, Show)
 
@@ -39,6 +57,7 @@ data TuiImagePreview = TuiImagePreview
     , previewSourceWidth :: !Int
     , previewSourceHeight :: !Int
     , previewSample :: !(Image PixelRGB8)
+    , previewKittyAttachment :: !ImageAttachment
     }
     deriving (Eq)
 
@@ -77,19 +96,77 @@ prepareTuiImagePreview ImageAttachment{imageMime, imageBytes} = do
                 (\x y -> samplePixel image targetWidth targetHeight x y)
                 targetWidth
                 targetHeight
+        , previewKittyAttachment =
+            kittyCompatibleAttachment
+                (ImageAttachment{imageMime, imageBytes})
         }
 
 -- | Size the preview to the supplied terminal-cell bounds while preserving its
 -- aspect ratio. One terminal row represents two sampled pixel rows.
 previewCellSize :: Int -> Int -> TuiImagePreview -> (Int, Int)
 previewCellSize maxColumns maxRows preview =
-    let (pixelWidth, pixelHeight) =
-            previewSizeWithin
-                maxColumns
-                (max 1 maxRows * 2)
-                preview.previewSourceWidth
-                preview.previewSourceHeight
+    let (pixelWidth, pixelHeight) = previewPixelSize maxColumns maxRows preview
     in (pixelWidth, (pixelHeight + 1) `div` 2)
+
+-- | Match the centered Brick overlay layout with zero-based terminal-cell
+-- placements for Kitty graphics. The caption occupies the row immediately
+-- below each placement.
+nativePreviewPlacements
+    :: Int
+    -> Int
+    -> Int
+    -> [(ImageAttachment, TuiImagePreview)]
+    -> [NativePreviewPlacement]
+nativePreviewPlacements imageIdBase terminalColumns terminalRows previews =
+    zipWith place [imageIdBase ..] shownWithSizes
+  where
+    shown = takeLast maxShownPreviews previews
+    count = length shown
+    maxWidth = viewportPreviewSize terminalColumns
+    maxHeight = viewportPreviewSize terminalRows
+    gaps = max 0 (count - 1) * previewGap
+    segmentWidth = max 1 ((maxWidth - gaps) `div` max 1 count)
+    previewHeight = max 1 (maxHeight - 1)
+    sizes =
+        [ previewCellSize segmentWidth previewHeight preview
+        | (_, preview) <- shown
+        ]
+    contentWidth = segmentWidth * count + gaps
+    contentHeight =
+        case sizes of
+            [] -> 0
+            _ -> maximum (map snd sizes) + 1
+    contentColumn = max 0 ((terminalColumns - contentWidth) `div` 2)
+    contentRow = max 0 ((terminalRows - contentHeight) `div` 2)
+
+    place imageId ((_attachment, preview), (columns, rows), index) =
+        NativePreviewPlacement
+            { nativePreviewImageId = imageId
+            , nativePreviewRow = contentRow
+            , nativePreviewColumn =
+                contentColumn
+                    + index * (segmentWidth + previewGap)
+                    + max 0 ((segmentWidth - columns) `div` 2)
+            , nativePreviewColumns = columns
+            , nativePreviewRows = rows
+            , nativePreviewAttachment = preview.previewKittyAttachment
+            }
+
+    shownWithSizes =
+        zip3 shown sizes [0 ..]
+
+-- | Resample the bounded source preview for the current terminal area. Box
+-- filtering is important for screenshots: nearest-neighbour sampling can miss
+-- thin text and rules completely, leaving an almost blank rectangle.
+previewImageAt :: Int -> Int -> TuiImagePreview -> Image PixelRGB8
+previewImageAt maxColumns maxRows preview =
+    generateImage
+        (sampleImageBox preview.previewSample targetWidth targetHeight)
+        targetWidth
+        targetHeight
+  where
+    (targetWidth, targetHeight) =
+        previewPixelSize maxColumns maxRows preview
 
 renderTuiImagePreview :: Int -> Int -> TuiImagePreview -> Widget n
 renderTuiImagePreview maxColumns maxRows preview =
@@ -97,20 +174,26 @@ renderTuiImagePreview maxColumns maxRows preview =
         V.vertCat
             [ V.horizCat
                 [ renderCell PreviewCell
-                    { cellTop =
-                        samplePreviewPixel preview targetWidth targetHeight x topY
-                    , cellBottom =
-                        samplePreviewPixel preview targetWidth targetHeight x
-                            (min (targetHeight - 1) (topY + 1))
+                    { cellTop = pixelAt image x topY
+                    , cellBottom = pixelAt image x
+                        (min (targetHeight - 1) (topY + 1))
                     }
                 | x <- [0 .. targetWidth - 1]
                 ]
             | topY <- [0, 2 .. targetHeight - 1]
             ]
   where
-    (targetWidth, targetRows) =
-        previewCellSize maxColumns maxRows preview
-    targetHeight = max 1 (targetRows * 2)
+    image = previewImageAt maxColumns maxRows preview
+    targetWidth = imageWidth image
+    targetHeight = imageHeight image
+
+previewPixelSize :: Int -> Int -> TuiImagePreview -> (Int, Int)
+previewPixelSize maxColumns maxRows preview =
+    previewSizeWithin
+        (min (imageWidth preview.previewSample) (max 1 maxColumns))
+        (min (imageHeight preview.previewSample) (max 1 maxRows * 2))
+        preview.previewSourceWidth
+        preview.previewSourceHeight
 
 renderCell :: PreviewCell -> V.Image
 renderCell PreviewCell{cellTop, cellBottom} =
@@ -154,52 +237,130 @@ samplePixel
     -> Int
     -> PixelRGB8
 samplePixel image targetWidth targetHeight x y =
-    compositePixel previewBackground (pixelAt image sourceX sourceY)
-  where
-    sourceX =
-        min (imageWidth image - 1)
-            (x * imageWidth image `div` targetWidth)
-    sourceY =
-        min (imageHeight image - 1)
-            (y * imageHeight image `div` targetHeight)
+    sampleRgbaBox image targetWidth targetHeight x y
 
-samplePreviewPixel
-    :: TuiImagePreview
+sampleImageBox :: Image PixelRGB8 -> Int -> Int -> Int -> Int -> PixelRGB8
+sampleImageBox image targetWidth targetHeight =
+    sampleRgbBox image targetWidth targetHeight
+
+sampleRgbaBox
+    :: Image PixelRGBA8
     -> Int
     -> Int
     -> Int
     -> Int
     -> PixelRGB8
-samplePreviewPixel preview targetWidth targetHeight x y =
-    pixelAt sample sourceX sourceY
+sampleRgbaBox image targetWidth targetHeight x y =
+    finishAverage (goY 0 0 0 0 0)
   where
-    sample = preview.previewSample
-    sourceX =
-        min (imageWidth sample - 1)
-            (x * imageWidth sample `div` targetWidth)
-    sourceY =
-        min (imageHeight sample - 1)
-            (y * imageHeight sample `div` targetHeight)
+    sourceWidth = imageWidth image
+    sourceHeight = imageHeight image
+    pixels = imageData image
+    (startX, endX, startY, endY) =
+        boxBounds sourceWidth sourceHeight targetWidth targetHeight x y
+    sampleColumns = min maxBoxSamplesPerAxis (endX - startX)
+    sampleRows = min maxBoxSamplesPerAxis (endY - startY)
+    PixelRGB8 backgroundRed backgroundGreen backgroundBlue = previewBackground
 
--- Transparent PNG pixels can retain arbitrary RGB data. Dropping alpha with
--- 'convertRGB8' exposes those hidden colours as bright smears, so composite
--- onto the fullscreen canvas before rendering the sampled terminal cells.
-compositePixel :: PixelRGB8 -> PixelRGBA8 -> PixelRGB8
-compositePixel
-    (PixelRGB8 backgroundRed backgroundGreen backgroundBlue)
-    (PixelRGBA8 red green blue alpha) =
-        PixelRGB8
-            (blend red backgroundRed alpha)
-            (blend green backgroundGreen alpha)
-            (blend blue backgroundBlue alpha)
+    goY !sampleY !red !green !blue !count
+        | sampleY >= sampleRows = (red, green, blue, count)
+        | otherwise =
+            let sourceY = samplePosition startY endY sampleRows sampleY
+                (!red', !green', !blue', !count') =
+                    goX sourceY 0 red green blue count
+            in goY (sampleY + 1) red' green' blue' count'
 
-blend :: Word8 -> Word8 -> Word8 -> Word8
-blend foreground background alpha =
-    fromIntegral $
-        ( fromIntegral foreground * alpha'
-            + fromIntegral background * (255 - alpha')
-            + 127
-        ) `div` 255
+    goX !sourceY !sampleX !red !green !blue !count
+        | sampleX >= sampleColumns = (red, green, blue, count)
+        | otherwise =
+            let sourceX = samplePosition startX endX sampleColumns sampleX
+                base = (sourceY * sourceWidth + sourceX) * 4
+                pixelRed = Vector.unsafeIndex pixels base
+                pixelGreen = Vector.unsafeIndex pixels (base + 1)
+                pixelBlue = Vector.unsafeIndex pixels (base + 2)
+                alpha = Vector.unsafeIndex pixels (base + 3)
+            in goX
+                sourceY
+                (sampleX + 1)
+                (red + compositeChannel pixelRed backgroundRed alpha)
+                (green + compositeChannel pixelGreen backgroundGreen alpha)
+                (blue + compositeChannel pixelBlue backgroundBlue alpha)
+                (count + 1)
+
+sampleRgbBox
+    :: Image PixelRGB8
+    -> Int
+    -> Int
+    -> Int
+    -> Int
+    -> PixelRGB8
+sampleRgbBox image targetWidth targetHeight x y =
+    finishAverage (goY 0 0 0 0 0)
+  where
+    sourceWidth = imageWidth image
+    sourceHeight = imageHeight image
+    pixels = imageData image
+    (startX, endX, startY, endY) =
+        boxBounds sourceWidth sourceHeight targetWidth targetHeight x y
+    sampleColumns = min maxBoxSamplesPerAxis (endX - startX)
+    sampleRows = min maxBoxSamplesPerAxis (endY - startY)
+
+    goY !sampleY !red !green !blue !count
+        | sampleY >= sampleRows = (red, green, blue, count)
+        | otherwise =
+            let sourceY = samplePosition startY endY sampleRows sampleY
+                (!red', !green', !blue', !count') =
+                    goX sourceY 0 red green blue count
+            in goY (sampleY + 1) red' green' blue' count'
+
+    goX !sourceY !sampleX !red !green !blue !count
+        | sampleX >= sampleColumns = (red, green, blue, count)
+        | otherwise =
+            let sourceX = samplePosition startX endX sampleColumns sampleX
+                base = (sourceY * sourceWidth + sourceX) * 3
+            in goX
+                sourceY
+                (sampleX + 1)
+                (red + fromIntegral (Vector.unsafeIndex pixels base))
+                (green + fromIntegral (Vector.unsafeIndex pixels (base + 1)))
+                (blue + fromIntegral (Vector.unsafeIndex pixels (base + 2)))
+                (count + 1)
+
+boxBounds
+    :: Int
+    -> Int
+    -> Int
+    -> Int
+    -> Int
+    -> Int
+    -> (Int, Int, Int, Int)
+boxBounds sourceWidth sourceHeight targetWidth targetHeight x y =
+    ( startX
+    , max (startX + 1) ((x + 1) * sourceWidth `div` targetWidth)
+    , startY
+    , max (startY + 1) ((y + 1) * sourceHeight `div` targetHeight)
+    )
+  where
+    startX = x * sourceWidth `div` targetWidth
+    startY = y * sourceHeight `div` targetHeight
+
+samplePosition :: Int -> Int -> Int -> Int -> Int
+samplePosition start end count index =
+    start + ((2 * index + 1) * (end - start)) `div` (2 * count)
+
+finishAverage :: (Int, Int, Int, Int) -> PixelRGB8
+finishAverage (red, green, blue, count) =
+    PixelRGB8 (rounded red) (rounded green) (rounded blue)
+  where
+    rounded total =
+        fromIntegral ((total + count `div` 2) `div` count)
+
+compositeChannel :: Word8 -> Word8 -> Word8 -> Int
+compositeChannel foreground background alpha =
+    ( fromIntegral foreground * alpha'
+        + fromIntegral background * (255 - alpha')
+        + 127
+    ) `div` 255
   where
     alpha' = fromIntegral alpha :: Int
 
@@ -212,6 +373,26 @@ maxPreviewColumns = 240
 -- Two sampled pixel rows fit in one terminal row via the upper-half block.
 maxPreviewPixelRows :: Int
 maxPreviewPixelRows = 160
+
+-- Bound work per output pixel so large screenshots remain cheap in the
+-- interpreted development loop while still sampling throughout each source
+-- region instead of selecting one arbitrary pixel.
+maxBoxSamplesPerAxis :: Int
+maxBoxSamplesPerAxis = 3
+
+maxShownPreviews :: Int
+maxShownPreviews = 3
+
+previewGap :: Int
+previewGap = 2
+
+viewportPreviewSize :: Int -> Int
+viewportPreviewSize available =
+    max 1 (available * 3 `div` 5)
+
+takeLast :: Int -> [a] -> [a]
+takeLast count values =
+    drop (max 0 (length values - count)) values
 
 firstText :: Either String a -> Either Text a
 firstText = either (Left . Text.pack) Right

--- a/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
@@ -115,6 +115,11 @@ data FullscreenRuntime = FullscreenRuntime
     , runtimeAgentSelect :: !(AgentTarget -> IO ())
     , runtimeFirstFrame :: !(IO ())
     , runtimeRunning :: !(IORef Bool)
+    , runtimeImagePreviews :: !(IORef [(ImageAttachment, TuiImagePreview)])
+    , runtimeImagePreviewRevision :: !(IORef Int)
+    , runtimeImagePreviewVisible :: !(IORef Bool)
+    , runtimeImagePreviewIdBase :: !Int
+    , runtimeNativeImagePreviews :: !Bool
     , runtimeColor :: !Bool
     , runtimeInitial :: !UiState
     }

--- a/packages/agent-cli/test/Agent/CLI/ImagePreviewSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ImagePreviewSpec.hs
@@ -2,7 +2,13 @@ module Agent.CLI.ImagePreviewSpec (spec) where
 
 import Agent.CLI.ImagePreview
 import Agent.Loop (ImageAttachment(..))
+import Codec.Picture
+    ( PixelYCbCr8(..)
+    , encodeJpegAtQuality
+    , generateImage
+    )
 import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Text as Text
 import Test.Hspec
 
@@ -43,9 +49,16 @@ spec = do
             -- payload is base64 of the raw bytes
             seq_ `shouldSatisfy` Text.isInfixOf "cG5nLWJ5dGVz"
 
-        it "still uses f=100 for JPEG (Kitty has no JPEG format code)" do
-            let seq_ = kittyImageSequence 1 12 4 "image/jpeg" "jpg"
-            seq_ `shouldSatisfy` Text.isInfixOf ",f=100,"
+        it "transcodes JPEG attachments to PNG before transmission" do
+            let source = generateImage (\_ _ -> PixelYCbCr8 20 128 128) 4 3
+                jpeg =
+                    LBS.toStrict (encodeJpegAtQuality 90 source)
+                compatible =
+                    kittyCompatibleAttachment
+                        (ImageAttachment "image/jpeg" jpeg)
+            compatible.imageMime `shouldBe` "image/png"
+            BS.take 8 compatible.imageBytes
+                `shouldBe` "\137PNG\r\n\SUB\n"
 
         it "chunks payloads larger than 4096 encoded bytes" do
             let bytes = BS.replicate 4000 65 -- 'A'; base64 expands past 4096
@@ -53,7 +66,25 @@ spec = do
             Text.count ",m=1;" seq_ `shouldBe` 1
             seq_ `shouldSatisfy` Text.isInfixOf ",m=0;"
             Text.count "\ESC_Ga=T" seq_ `shouldBe` 1
-            Text.count "\ESC_Ga=t" seq_ `shouldBe` 1
+            Text.count "\ESC_Gq=2,m=0;" seq_ `shouldBe` 1
+            Text.count ",i=2," seq_ `shouldBe` 1
+
+    describe "kittyPlacedImageSequence" do
+        it "uses a stable placement id and explicit fullscreen cell rectangle" do
+            let seq_ =
+                    kittyPlacedImageSequence
+                        2000000001
+                        2000000001
+                        72
+                        19
+                        "image/png"
+                        "png-bytes"
+            seq_ `shouldSatisfy` Text.isInfixOf
+                "\ESC_Ga=T,q=2,i=2000000001,f=100,t=d,r=19,c=72,p=2000000001,z=1,C=1,m=0;"
+
+        it "deletes only the requested image and frees its data" do
+            kittyDeleteImageSequence 2000000001
+                `shouldBe` "\ESC_Ga=d,d=I,q=2,i=2000000001\ESC\\"
 
     describe "itermImageSequence" do
         it "emits OSC 1337 inline file with cell size" do
@@ -65,6 +96,11 @@ spec = do
         it "doubles ESC so tmux forwards the inner sequence" do
             wrapTmuxPassthrough "\ESC]1337;File=inline=1:\BEL"
                 `shouldBe` "\ESCPtmux;\ESC\ESC]1337;File=inline=1:\BEL\ESC\\"
+
+    describe "positionImagePayload" do
+        it "moves to a zero-based cell and restores Vty's cursor" do
+            positionImagePayload 4 9 "image"
+                `shouldBe` "\ESC7\ESC[5;10Himage\ESC8"
 
     describe "renderImagePreview" do
         let img = ImageAttachment "image/png" "png-bytes"

--- a/packages/agent-cli/test/Agent/CLI/TUIImagePreviewSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIImagePreviewSpec.hs
@@ -1,9 +1,12 @@
 module Agent.CLI.TUIImagePreviewSpec (spec) where
 
 import Agent.CLI.TUI.ImagePreview
-    ( TuiImagePreview(..)
+    ( NativePreviewPlacement(..)
+    , TuiImagePreview(..)
+    , nativePreviewPlacements
     , prepareTuiImagePreview
     , previewCellSize
+    , previewImageAt
     )
 import Agent.Loop (ImageAttachment(..))
 import Codec.Picture
@@ -11,6 +14,9 @@ import Codec.Picture
     , PixelRGBA8(..)
     , encodePng
     , generateImage
+    , imageHeight
+    , imageWidth
+    , pixelAt
     )
 import qualified Data.ByteString.Lazy as LBS
 import Test.Hspec
@@ -54,6 +60,56 @@ spec =
                 Right preview -> do
                     previewCellSize 72 23 preview `shouldBe` (72, 20)
                     previewCellSize 48 12 preview `shouldBe` (42, 12)
+
+        it "preserves thin screenshot details while downsampling" do
+            let source =
+                    generateImage
+                        (\x y ->
+                            if x `elem` [2, 3] || y `elem` [2, 3]
+                                then PixelRGB8 0 0 0
+                                else PixelRGB8 255 255 255)
+                        1604
+                        442
+                attachment = ImageAttachment
+                    { imageMime = "image/png"
+                    , imageBytes = LBS.toStrict (encodePng source)
+                    }
+            case prepareTuiImagePreview attachment of
+                Left err -> expectationFailure (show err)
+                Right preview -> do
+                    let image = previewImageAt 72 23 preview
+                    imageWidth image `shouldBe` 72
+                    imageHeight image `shouldBe` 19
+                    pixelAt image 0 0 `shouldNotBe` PixelRGB8 255 255 255
+
+        it "centers native Kitty placements over the fullscreen placeholder" do
+            let source =
+                    generateImage
+                        (\_ _ -> PixelRGB8 10 20 30)
+                        1604
+                        442
+                attachment = ImageAttachment
+                    { imageMime = "image/png"
+                    , imageBytes = LBS.toStrict (encodePng source)
+                    }
+            case prepareTuiImagePreview attachment of
+                Left err -> expectationFailure (show err)
+                Right preview ->
+                    nativePreviewPlacements
+                        2000000000
+                        120
+                        40
+                        [(attachment, preview)]
+                        `shouldBe`
+                            [ NativePreviewPlacement
+                                { nativePreviewImageId = 2000000000
+                                , nativePreviewRow = 14
+                                , nativePreviewColumn = 24
+                                , nativePreviewColumns = 72
+                                , nativePreviewRows = 10
+                                , nativePreviewAttachment = attachment
+                                }
+                            ]
 
         it "composites alpha instead of exposing hidden transparent RGB" do
             let transparentSource =


### PR DESCRIPTION
## Summary

- render fullscreen pasted-image previews through native Kitty graphics in Ghostty/Kitty/WezTerm instead of lossy half-block cells
- preserve the bounded resampled fallback for unsupported terminals and tmux
- fix Kitty chunk continuation framing and transcode non-PNG attachments before transmission
- keep native placements aligned across resize/refresh and clear them for modal overlays, attachment removal, and shutdown
- allocate terminal-global image IDs per runtime to avoid collisions

## Verification

- visually verified the original wide screenshot directly in Ghostty
- exercised placement, modal hide/restore, and deletion lifecycle
- `agent-cli-test`: 476 examples, 0 failures
