### PR TITLE
Refactor shared CLI text layout helpers

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -79,6 +79,7 @@ library
                     , Agent.CLI.Subagents.Runtime
                     , Agent.CLI.Style
                     , Agent.CLI.Terminal
+                    , Agent.CLI.TextLayout
                     , Agent.CLI.Timestamp
                     , Agent.CLI.Tools
                     , Agent.CLI.TUI.App
@@ -171,6 +172,7 @@ test-suite agent-cli-test
                     , Agent.CLI.StyleSpec
                     , Agent.CLI.TimestampSpec
                     , Agent.CLI.TerminalSpec
+                    , Agent.CLI.TextLayoutSpec
                     , Agent.CLI.SessionSpec
                     , Agent.CLI.SessionTitleSpec
                     , Agent.CLI.SkillsSpec

--- a/packages/agent-cli/src/Agent/CLI/AgentViewport.hs
+++ b/packages/agent-cli/src/Agent/CLI/AgentViewport.hs
@@ -29,6 +29,12 @@ module Agent.CLI.AgentViewport
 import Agent.CLI.Render (summarizeToolCall)
 import Agent.CLI.Picker (PickerKey(..), runOverlay)
 import Agent.CLI.Style (roleMuted, rolePrompt, roleSuccess)
+import Agent.CLI.TextLayout
+    ( clampSelectionIndex
+    , fitTextCell
+    , selectionWindow
+    , transcriptPreviewRows
+    )
 import Agent.Responses.Types
 import Agent.Subagents (SubagentId(..), SubagentStatus(..))
 import Agent.ToolDispatch (customToolCall, functionToolCall)
@@ -117,7 +123,10 @@ initialAgentViewportState selected entries =
 selectedAgentEntry :: AgentViewportState -> Maybe AgentEntry
 selectedAgentEntry state = case state.viewportAll of
     [] -> Nothing
-    entries -> Just (entries !! clamp (length entries) state.viewportIndex)
+    entries ->
+        Just
+            (entries
+                !! clampSelectionIndex (length entries) state.viewportIndex)
 
 refreshAgentViewportState
     :: [AgentEntry]
@@ -154,7 +163,7 @@ applyAgentViewportKey key state = case key of
             then current { viewportIndex = 0 }
             else current
                 { viewportIndex =
-                    (clamp n current.viewportIndex + delta) `mod` n
+                    (clampSelectionIndex n current.viewportIndex + delta) `mod` n
                 }
 
 renderAgentTree :: Bool -> AgentTarget -> [AgentEntry] -> Text
@@ -238,27 +247,27 @@ renderAgentViewportFor color bodyRows terminalCols footerText state =
     rightWidth = max 1 (cols - leftWidth - 3)
     entries = state.viewportAll
     n = length entries
-    idx = clamp n state.viewportIndex
-    shown = entryWindow bodyRows idx entries
+    idx = clampSelectionIndex n state.viewportIndex
+    shown = selectionWindow bodyRows idx entries
     selected = selectedAgentEntry state
     header =
         rolePrompt color "agents"
             <> roleMuted color
-                (fitCell (max 0 (cols - 6))
+                (fitTextCell (max 0 (cols - 6))
                     (" · " <> Text.pack (show n)
                         <> if n == 1 then " agent" else " agents"))
     headings =
-        rolePrompt color (fitCell leftWidth "hierarchy")
+        rolePrompt color (fitTextCell leftWidth "hierarchy")
             <> divider
             <> rolePrompt color
-                (fitCell rightWidth
+                (fitTextCell rightWidth
                     ("transcript"
                         <> maybe "" (\entry -> " · " <> entry.agentPath) selected))
     leftRows =
         map
             (\(absoluteIndex, entry) ->
                 let prefix = if absoluteIndex == idx then "› " else "  "
-                    text = fitCell leftWidth
+                    text = fitTextCell leftWidth
                         (prefix
                             <> agentEntryTreeLabel
                                 entries absoluteIndex entry)
@@ -268,16 +277,21 @@ renderAgentViewportFor color bodyRows terminalCols footerText state =
             shown
             <> repeat (Text.replicate leftWidth " ")
     rightRows = case selected of
-        Nothing -> roleMuted color (fitCell rightWidth "(no agents)") : repeat ""
+        Nothing ->
+            roleMuted color (fitTextCell rightWidth "(no agents)") : repeat ""
         Just entry ->
-            let preview = previewRows rightWidth bodyRows entry.agentTranscript
-            in map (fitCell rightWidth) preview <> repeat ""
+            let preview =
+                    transcriptPreviewRows
+                        rightWidth
+                        bodyRows
+                        entry.agentTranscript
+            in map (fitTextCell rightWidth) preview <> repeat ""
     body =
         take bodyRows $
             zipWith (\left right -> left <> divider <> right) leftRows rightRows
     footer =
         roleMuted color $
-            fitCell cols footerText
+            fitTextCell cols footerText
 
 pickAgentViewport
     :: Bool
@@ -659,49 +673,3 @@ pathSegments path =
     case filter (not . Text.null) (Text.splitOn "/" path) of
         "root" : rest -> rest
         parts -> parts
-
-entryWindow :: Int -> Int -> [a] -> [(Int, a)]
-entryWindow count selected xs =
-    let total = length xs
-        start = max 0 (min selected (total - count))
-    in zip [start ..] (take count (drop start xs))
-
-previewRows :: Int -> Int -> [Text] -> [Text]
-previewRows width count logicalLines =
-    let wrapped = concatMap (hardWrap width) logicalLines
-        rows
-            | null wrapped = ["(empty transcript)"]
-            | otherwise = wrapped
-    in drop (max 0 (length rows - count)) rows
-
-hardWrap :: Int -> Text -> [Text]
-hardWrap width raw
-    | Text.null raw = [""]
-    | otherwise = go raw
-  where
-    width' = max 1 width
-    go text
-        | Text.null text = []
-        | otherwise =
-            let (line, rest) = Text.splitAt width' text
-            in line : go rest
-
-fitCell :: Int -> Text -> Text
-fitCell width raw
-    | width <= 0 = ""
-    | Text.length clean <= width =
-        clean <> Text.replicate (width - Text.length clean) " "
-    | width == 1 = "…"
-    | otherwise = Text.take (width - 1) clean <> "…"
-  where
-    clean =
-        Text.map
-            (\c -> if c == '\t' || c == '\r' || c == '\n' then ' ' else c)
-            raw
-
-clamp :: Int -> Int -> Int
-clamp n i
-    | n <= 0 = 0
-    | i < 0 = 0
-    | i >= n = n - 1
-    | otherwise = i

--- a/packages/agent-cli/src/Agent/CLI/Input.hs
+++ b/packages/agent-cli/src/Agent/CLI/Input.hs
@@ -50,6 +50,7 @@ import Agent.CLI.Terminal
     , kittyKeyboardDisambiguatePush
     , kittyKeyboardPop
     , shiftEnterCsiBodies
+    , stripAnsi
     )
 import Agent.Loop (ImageAttachment)
 import Control.Exception.Safe (bracket, bracket_, catchIO, throwIO, tryIO)
@@ -1093,18 +1094,6 @@ truncateDisplayText width text
 visibleWidth :: Text -> Int
 visibleWidth = terminalTextWidth . stripAnsi
 
-stripAnsi :: Text -> Text
-stripAnsi = Text.pack . goNormal . Text.unpack
-  where
-    goNormal = \case
-        [] -> []
-        '\ESC' : '[' : rest -> goCsi rest
-        char : rest -> char : goNormal rest
-    goCsi = \case
-        [] -> []
-        char : rest
-            | char >= '@' && char <= '~' -> goNormal rest
-            | otherwise -> goCsi rest
 -- | Read a one-shot approval answer. The question is always written to
 -- stderr (matching the historical behavior) so redirected stdout does
 -- not swallow the prompt. Does not touch REPL history.

--- a/packages/agent-cli/src/Agent/CLI/Picker.hs
+++ b/packages/agent-cli/src/Agent/CLI/Picker.hs
@@ -18,6 +18,7 @@ import Agent.CLI.Terminal
     , emitTerminalSequence
     , kittyKeyboardPop
     , kittyKeyboardPush
+    , stripAnsi
     , withSynchronizedOutput
     )
 import Control.Concurrent.Async (race)
@@ -377,19 +378,6 @@ selectableRows frame = do
             '›' : ' ' : _ -> True
             ' ' : ' ' : c : _ -> c /= ' '
             _ -> False
-
-stripAnsi :: Text -> Text
-stripAnsi = Text.pack . goNormal . Text.unpack
-  where
-    goNormal = \case
-        [] -> []
-        '\ESC' : '[' : rest -> goCsi rest
-        char : rest -> char : goNormal rest
-    goCsi = \case
-        [] -> []
-        char : rest
-            | char >= '@' && char <= '~' -> goNormal rest
-            | otherwise -> goCsi rest
 
 stripPrefix :: String -> String -> Maybe String
 stripPrefix prefix value

--- a/packages/agent-cli/src/Agent/CLI/Resume.hs
+++ b/packages/agent-cli/src/Agent/CLI/Resume.hs
@@ -19,6 +19,12 @@ import Agent.CLI.Session
     , loadSession
     )
 import Agent.CLI.Style (roleMuted, rolePrompt, roleSuccess)
+import Agent.CLI.TextLayout
+    ( clampSelectionIndex
+    , fitTextCell
+    , selectionWindow
+    , transcriptPreviewRows
+    )
 import Agent.OsPath (toText)
 import Agent.Provider (providerSlug)
 import Control.Monad (forM)
@@ -89,7 +95,7 @@ selectedResume state =
     case visibleResume state of
         [] -> Nothing
         opts ->
-            let i = clamp (length opts) state.resumeIndex
+            let i = clampSelectionIndex (length opts) state.resumeIndex
             in Just (opts !! i)
 
 applyResumeKey :: PickerKey -> ResumeState -> Either (Maybe ResumeEntry) ResumeState
@@ -116,18 +122,20 @@ move delta state =
     let n = length (visibleResume state)
     in if n == 0
         then state { resumeIndex = 0 }
-        else state { resumeIndex = (clamp n state.resumeIndex + delta) `mod` n }
+        else
+            state
+                { resumeIndex =
+                    (clampSelectionIndex n state.resumeIndex + delta) `mod` n
+                }
 
 clampSel :: ResumeState -> ResumeState
 clampSel state =
-    state { resumeIndex = clamp (length (visibleResume state)) state.resumeIndex }
-
-clamp :: Int -> Int -> Int
-clamp n i
-    | n <= 0 = 0
-    | i < 0 = 0
-    | i >= n = n - 1
-    | otherwise = i
+    state
+        { resumeIndex =
+            clampSelectionIndex
+                (length (visibleResume state))
+                state.resumeIndex
+        }
 
 isFilterChar :: Char -> Bool
 isFilterChar c =
@@ -153,8 +161,8 @@ renderResumeFrameFor color terminalRows terminalCols state =
     rightWidth = max 1 (cols - leftWidth - 3)
     visible = visibleResume state
     n = length visible
-    idx = clamp n state.resumeIndex
-    shown = sessionWindow bodyRows idx visible
+    idx = clampSelectionIndex n state.resumeIndex
+    shown = selectionWindow bodyRows idx visible
     selected = selectedResume state
     filterText
         | Text.null state.resumeFilter = "type to filter"
@@ -162,29 +170,34 @@ renderResumeFrameFor color terminalRows terminalCols state =
     header =
         rolePrompt color "resume"
             <> roleMuted color
-                (fitCell (max 0 (cols - 6)) (" · " <> filterText))
+                (fitTextCell (max 0 (cols - 6)) (" · " <> filterText))
     headings =
-        rolePrompt color (fitCell leftWidth "sessions")
+        rolePrompt color (fitTextCell leftWidth "sessions")
             <> divider
             <> rolePrompt color
-                (fitCell rightWidth
+                (fitTextCell rightWidth
                     ("transcript"
                         <> maybe "" (\entry -> " · " <> entry.resumeTitle) selected))
     leftRows =
         map
             (\(absoluteIndex, entry) ->
                 let prefix = if absoluteIndex == idx then "› " else "  "
-                    text = fitCell leftWidth (prefix <> entry.resumeTitle)
+                    text = fitTextCell leftWidth (prefix <> entry.resumeTitle)
                 in if absoluteIndex == idx
                     then roleSuccess color text
                     else text)
             shown
             <> repeat (Text.replicate leftWidth " ")
     rightRows = case selected of
-        Nothing -> roleMuted color (fitCell rightWidth "(no sessions)") : repeat ""
+        Nothing ->
+            roleMuted color (fitTextCell rightWidth "(no sessions)") : repeat ""
         Just entry ->
-            let preview = previewRows rightWidth bodyRows entry.resumeTranscript
-            in map (fitCell rightWidth) preview <> repeat ""
+            let preview =
+                    transcriptPreviewRows
+                        rightWidth
+                        bodyRows
+                        entry.resumeTranscript
+            in map (fitTextCell rightWidth) preview <> repeat ""
     body =
         take bodyRows $
             zipWith
@@ -193,44 +206,8 @@ renderResumeFrameFor color terminalRows terminalCols state =
                 rightRows
     footer =
         roleMuted color $
-            fitCell cols
+            fitTextCell cols
                 "↑↓/jk or scroll · click/enter resume · esc/q cancel · type to filter"
-
-sessionWindow :: Int -> Int -> [a] -> [(Int, a)]
-sessionWindow count selected xs =
-    let total = length xs
-        start = max 0 (min selected (total - count))
-    in zip [start ..] (take count (drop start xs))
-
-previewRows :: Int -> Int -> [Text] -> [Text]
-previewRows width count logicalLines =
-    let wrapped = concatMap (hardWrap width) logicalLines
-        rows
-            | null wrapped = ["(empty transcript)"]
-            | otherwise = wrapped
-    in drop (max 0 (length rows - count)) rows
-
-hardWrap :: Int -> Text -> [Text]
-hardWrap width raw
-    | Text.null raw = [""]
-    | otherwise = go raw
-  where
-    width' = max 1 width
-    go text
-        | Text.null text = []
-        | otherwise =
-            let (line, rest) = Text.splitAt width' text
-            in line : go rest
-
-fitCell :: Int -> Text -> Text
-fitCell width raw
-    | width <= 0 = ""
-    | Text.length clean <= width =
-        clean <> Text.replicate (width - Text.length clean) " "
-    | width == 1 = "…"
-    | otherwise = Text.take (width - 1) clean <> "…"
-  where
-    clean = Text.map (\c -> if c == '\t' || c == '\r' || c == '\n' then ' ' else c) raw
 
 transcriptLines :: [SessionTurn] -> [Text]
 transcriptLines = concatMap turnLines

--- a/packages/agent-cli/src/Agent/CLI/Terminal.hs
+++ b/packages/agent-cli/src/Agent/CLI/Terminal.hs
@@ -15,6 +15,7 @@ module Agent.CLI.Terminal
     , osc133CommandFinished
     , synchronizedOutputBegin
     , synchronizedOutputEnd
+    , stripAnsi
     , shiftEnterCsiBodies
     , kittyKeyboardDisambiguatePush
     , kittyKeyboardPush
@@ -132,6 +133,20 @@ resolveColor handle = do
     isTty <- hIsTerminalDevice handle
     noColor <- lookupEnv "NO_COLOR"
     pure (isTty && maybe True (const False) noColor)
+
+-- | Remove ANSI CSI escape sequences from terminal text.
+stripAnsi :: Text -> Text
+stripAnsi = Text.pack . goNormal . Text.unpack
+  where
+    goNormal = \case
+        [] -> []
+        '\ESC' : '[' : rest -> goCsi rest
+        char : rest -> char : goNormal rest
+    goCsi = \case
+        [] -> []
+        char : rest
+            | char >= '@' && char <= '~' -> goNormal rest
+            | otherwise -> goCsi rest
 
 osc7WorkingDirectory :: FilePath -> Text
 osc7WorkingDirectory path =

--- a/packages/agent-cli/src/Agent/CLI/TextLayout.hs
+++ b/packages/agent-cli/src/Agent/CLI/TextLayout.hs
@@ -1,0 +1,56 @@
+-- | Text layout helpers shared by fixed-size CLI overlays.
+module Agent.CLI.TextLayout
+    ( clampSelectionIndex
+    , fitTextCell
+    , selectionWindow
+    , transcriptPreviewRows
+    ) where
+
+import Data.Text (Text)
+import qualified Data.Text as Text
+
+clampSelectionIndex :: Int -> Int -> Int
+clampSelectionIndex count index
+    | count <= 0 = 0
+    | index < 0 = 0
+    | index >= count = count - 1
+    | otherwise = index
+
+selectionWindow :: Int -> Int -> [a] -> [(Int, a)]
+selectionWindow count selected values =
+    let total = length values
+        start = max 0 (min selected (total - count))
+    in zip [start ..] (take count (drop start values))
+
+transcriptPreviewRows :: Int -> Int -> [Text] -> [Text]
+transcriptPreviewRows width count logicalLines =
+    let wrapped = concatMap (hardWrapText width) logicalLines
+        rows
+            | null wrapped = ["(empty transcript)"]
+            | otherwise = wrapped
+    in drop (max 0 (length rows - count)) rows
+
+hardWrapText :: Int -> Text -> [Text]
+hardWrapText width raw
+    | Text.null raw = [""]
+    | otherwise = go raw
+  where
+    width' = max 1 width
+    go text
+        | Text.null text = []
+        | otherwise =
+            let (line, rest) = Text.splitAt width' text
+            in line : go rest
+
+fitTextCell :: Int -> Text -> Text
+fitTextCell width raw
+    | width <= 0 = ""
+    | Text.length clean <= width =
+        clean <> Text.replicate (width - Text.length clean) " "
+    | width == 1 = "…"
+    | otherwise = Text.take (width - 1) clean <> "…"
+  where
+    clean =
+        Text.map
+            (\c -> if c == '\t' || c == '\r' || c == '\n' then ' ' else c)
+            raw

--- a/packages/agent-cli/test/Agent/CLI/TerminalSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TerminalSpec.hs
@@ -34,3 +34,15 @@ spec = do
         it "exposes Kitty keyboard push/pop sequences" do
             Text.null kittyKeyboardPush `shouldBe` False
             Text.null kittyKeyboardPop `shouldBe` False
+
+    describe "stripAnsi" do
+        it "leaves plain text unchanged" do
+            stripAnsi "selected" `shouldBe` "selected"
+
+        it "removes multiple complete CSI sequences" do
+            stripAnsi "\ESC[1;36mselected\ESC[0m plain \ESC[2mdim\ESC[0m"
+                `shouldBe` "selected plain dim"
+
+        it "drops an incomplete trailing CSI sequence" do
+            stripAnsi "ready\ESC[38;5"
+                `shouldBe` "ready"

--- a/packages/agent-cli/test/Agent/CLI/TextLayoutSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TextLayoutSpec.hs
@@ -1,0 +1,54 @@
+module Agent.CLI.TextLayoutSpec (spec) where
+
+import Agent.CLI.TextLayout
+import Test.Hspec
+
+spec :: Spec
+spec = do
+    describe "clampSelectionIndex" do
+        it "clamps selection to the available values" do
+            clampSelectionIndex 3 (-1) `shouldBe` 0
+            clampSelectionIndex 3 1 `shouldBe` 1
+            clampSelectionIndex 3 4 `shouldBe` 2
+            clampSelectionIndex 0 4 `shouldBe` 0
+
+    describe "selectionWindow" do
+        it "keeps selections at the start, middle, and end visible" do
+            let values = ["a", "b", "c", "d"] :: [String]
+            selectionWindow 2 0 values
+                `shouldBe` [(0, "a"), (1, "b")]
+            selectionWindow 2 2 values
+                `shouldBe` [(2, "c"), (3, "d")]
+            selectionWindow 2 3 values
+                `shouldBe` [(2, "c"), (3, "d")]
+
+        it "handles oversized and empty windows" do
+            selectionWindow 5 1 (["a", "b"] :: [String])
+                `shouldBe` [(0, "a"), (1, "b")]
+            selectionWindow 2 0 ([] :: [String])
+                `shouldBe` []
+
+    describe "transcriptPreviewRows" do
+        it "wraps logical lines and returns the requested tail" do
+            transcriptPreviewRows 3 2 ["abcd", "ef"]
+                `shouldBe` ["d", "ef"]
+
+        it "renders an empty transcript placeholder" do
+            transcriptPreviewRows 20 2 []
+                `shouldBe` ["(empty transcript)"]
+
+        it "preserves blank lines and clamps non-positive widths" do
+            transcriptPreviewRows 0 3 ["", "ab"]
+                `shouldBe` ["", "a", "b"]
+
+        it "returns no rows when none are requested" do
+            transcriptPreviewRows 20 0 ["text"]
+                `shouldBe` []
+
+    describe "fitTextCell" do
+        it "pads, sanitizes, and truncates cell text" do
+            fitTextCell 4 "ab" `shouldBe` "ab  "
+            fitTextCell 4 "a\nb" `shouldBe` "a b "
+            fitTextCell 4 "abcde" `shouldBe` "abc…"
+            fitTextCell 1 "ab" `shouldBe` "…"
+            fitTextCell 0 "ab" `shouldBe` ""

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -43,6 +43,7 @@ import qualified Agent.CLI.SubagentStoreSpec as SubagentStoreSpec
 import qualified Agent.CLI.StyleSpec as StyleSpec
 import qualified Agent.CLI.TimestampSpec as TimestampSpec
 import qualified Agent.CLI.TerminalSpec as TerminalSpec
+import qualified Agent.CLI.TextLayoutSpec as TextLayoutSpec
 import qualified Agent.CLI.ToolsSpec as ToolsSpec
 import qualified Agent.CLI.TUIAppSpec as TUIAppSpec
 import qualified Agent.CLI.TUIBridgeSpec as TUIBridgeSpec
@@ -91,6 +92,7 @@ main = hspec do
     StyleSpec.spec
     TimestampSpec.spec
     TerminalSpec.spec
+    TextLayoutSpec.spec
     SessionSpec.spec
     SessionTitleSpec.spec
     SkillsSpec.spec


### PR DESCRIPTION
## Summary

- extract the duplicated resume and agent viewport layout logic into `Agent.CLI.TextLayout`
- share ANSI CSI stripping between the input editor and picker through `Agent.CLI.Terminal`
- add focused coverage for layout boundaries and ANSI stripping

## Testing

- `nix develop --no-write-lock-file -c cabal test agent-cli-test --test-show-details=direct` (487 examples, 0 failures)
- loaded the `agent-cli` library in GHCi
- exercised the minimal-mode `/resume` overlay in tmux, including selection movement and Escape cancellation
