### PR TITLE
Reuse active OpenAI session for compaction

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -67,8 +67,10 @@ import Agent.CLI.Clipboard
 import Agent.CLI.Command
 import Agent.CLI.Compaction
     ( CompactOutcome(..)
-    , autoCompactOpenAiBackendWithThreshold
-    , runProviderCompact
+    , OpenAiCompactionSender
+    , autoCompactOpenAiBackendWithSender
+    , installCompactOutcome
+    , runProviderCompactWith
     )
 import Agent.CLI.Connectivity (withConnectionRecovery)
 import Agent.CLI.ImagePreview
@@ -268,7 +270,11 @@ import Agent.OpenAI.Compaction
     , newSessionUserText
     )
 import qualified Agent.OpenAI.Auth as OpenAI
-import Agent.OpenAI.LoopBackend (openAiBackendReconnecting)
+import Agent.OpenAI.LoopBackend
+    ( openAiAuxiliaryResponseSenderReconnecting
+    , openAiBackendWith
+    , openAiResponseSenderReconnecting
+    )
 import Agent.Responses.Types
 import Agent.OpenAI.Usage (fetchUsage)
 import Agent.OpenAI.WebSocketClient
@@ -334,6 +340,7 @@ import Control.Exception.Safe
     , catchAny
     , catchAsync
     , finally
+    , mask_
     , throwIO
     , try
     )
@@ -989,6 +996,7 @@ runAgentInitialized options transition home root resumed cwd startup = do
                 }
         transcriptRef <- newIORef initialItems
         contextTokensRef <- newIORef Nothing
+        previousRef <- newIORef initialPrevious
         writeIORef subagentForkSource (Just transcriptRef)
         prompt <- loadPrompt options
         let titleHint = case resumed of
@@ -1013,6 +1021,17 @@ runAgentInitialized options transition home root resumed cwd startup = do
         usageRef <- newIORef $ case resumed of
             Just (meta, turns) -> sessionUsageFromTurns meta turns
             Nothing -> emptyTokenUsage
+        let recordCompactionUsage usage =
+                when (usage /= emptyTokenUsage) $
+                    mask_ do
+                        case persist of
+                            PersistenceDisabled -> pure ()
+                            PersistenceEnabled slotRef -> do
+                                handle <- ensureSession slotRef
+                                claimCurrentSession handle
+                                updated <- addSessionUsage usage handle
+                                writeIORef slotRef (PersistenceActive updated)
+                        modifyIORef' usageRef (`addTokenUsage` usage)
         case persist of
             PersistenceEnabled slotRef -> do
                 slot <- readIORef slotRef
@@ -1040,8 +1059,8 @@ runAgentInitialized options transition home root resumed cwd startup = do
                                                 loaded.loadedTokenProvider
                                                 ctx.multiSendToRoot
                                     Nothing -> pure ()
-                                let lockedBackend =
-                                        lockedOpenAiBackend
+                                let (compactSender, lockedBackend) =
+                                        lockedOpenAiSession
                                             options.optCompactThreshold
                                             wsLock
                                             loaded.loadedTokenProvider
@@ -1051,19 +1070,34 @@ runAgentInitialized options transition home root resumed cwd startup = do
                                             (readIORef paramsRef)
                                             transcriptRef
                                             contextTokensRef
+                                            recordCompactionUsage
                                     noticingBackend =
-                                        withPendingInputs pendingNotices $
-                                            withConnectionRecovery lockedBackend
+                                        withPendingInputs pendingNotices
+                                            lockedBackend
                                     btwBackend privateParams privateTranscript =
                                         freshOpenAiBackend
                                             loaded.loadedTokenProvider
                                             (readIORef privateParams)
                                             privateTranscript
+                                    compactRunner focus =
+                                        withMVar wsLock \_ ->
+                                            installCompactOutcome
+                                                previousRef
+                                                transcriptRef
+                                                (Just contextTokensRef)
+                                                (runProviderCompactWith
+                                                    (Just compactSender)
+                                                    recordCompactionUsage
+                                                    provider
+                                                    (Just loaded.loadedTokenProvider)
+                                                    paramsRef
+                                                    transcriptRef)
+                                                focus
                                 activeBackend <-
                                     prepareTransitionBackend transition persist noticingBackend
                                 runSession options provider policy tools toolEnv planMode startup prompt pendingTurn transitionDraft unavailableProviders paramsRef transcriptRef initialTurns
-                                    initialPrevious persist projectRoot home cwd (Just loaded.loadedTokenProvider) loaded.loadedOpenAiPool startupContext skillsRef skillInvocationsRef escPaused interrupt
-                                    multiCtx rootTurnRef subagentSessions pendingNotices subagentStoreRoot usageRef claimCurrentSession activeBackend btwBackend)
+                                    previousRef persist projectRoot home cwd (Just loaded.loadedTokenProvider) loaded.loadedOpenAiPool startupContext skillsRef skillInvocationsRef escPaused interrupt
+                                    multiCtx rootTurnRef subagentSessions pendingNotices subagentStoreRoot usageRef claimCurrentSession compactRunner activeBackend btwBackend)
                             >>= \case
                                 Left (CodexAuthFailed err) ->
                                     case transition of
@@ -1094,11 +1128,20 @@ runAgentInitialized options transition home root resumed cwd startup = do
                             btwBackend privateParams privateTranscript =
                                 xaiBackend xaiOptions loaded.loadedTokenProvider
                                     (readIORef privateParams) privateTranscript
+                            compactRunner =
+                                installCompactOutcome previousRef transcriptRef Nothing $
+                                    runProviderCompactWith
+                                        Nothing
+                                        recordCompactionUsage
+                                        provider
+                                        (Just loaded.loadedTokenProvider)
+                                        paramsRef
+                                        transcriptRef
                         activeBackend <-
                             prepareTransitionBackend transition persist backend
                         runSession options provider policy tools toolEnv planMode startup prompt pendingTurn transitionDraft unavailableProviders paramsRef transcriptRef initialTurns
-                            initialPrevious persist projectRoot home cwd (Just loaded.loadedTokenProvider) loaded.loadedOpenAiPool startupContext skillsRef skillInvocationsRef escPaused interrupt
-                            multiCtx rootTurnRef subagentSessions pendingNotices subagentStoreRoot usageRef claimCurrentSession activeBackend btwBackend
+                            previousRef persist projectRoot home cwd (Just loaded.loadedTokenProvider) loaded.loadedOpenAiPool startupContext skillsRef skillInvocationsRef escPaused interrupt
+                            multiCtx rootTurnRef subagentSessions pendingNotices subagentStoreRoot usageRef claimCurrentSession compactRunner activeBackend btwBackend
                     OpenRouterProvider -> do
                         openRouterOptions <- OpenRouter.clientOptionsFromEnv
                         case multiCtx of
@@ -1119,11 +1162,20 @@ runAgentInitialized options transition home root resumed cwd startup = do
                             btwBackend privateParams privateTranscript =
                                 openRouterBackend openRouterOptions loaded.loadedTokenProvider
                                     (readIORef privateParams) privateTranscript
+                            compactRunner =
+                                installCompactOutcome previousRef transcriptRef Nothing $
+                                    runProviderCompactWith
+                                        Nothing
+                                        recordCompactionUsage
+                                        provider
+                                        (Just loaded.loadedTokenProvider)
+                                        paramsRef
+                                        transcriptRef
                         activeBackend <-
                             prepareTransitionBackend transition persist backend
                         runSession options provider policy tools toolEnv planMode startup prompt pendingTurn transitionDraft unavailableProviders paramsRef transcriptRef initialTurns
-                            initialPrevious persist projectRoot home cwd (Just loaded.loadedTokenProvider) loaded.loadedOpenAiPool startupContext skillsRef skillInvocationsRef escPaused interrupt
-                            multiCtx rootTurnRef subagentSessions pendingNotices subagentStoreRoot usageRef claimCurrentSession activeBackend btwBackend
+                            previousRef persist projectRoot home cwd (Just loaded.loadedTokenProvider) loaded.loadedOpenAiPool startupContext skillsRef skillInvocationsRef escPaused interrupt
+                            multiCtx rootTurnRef subagentSessions pendingNotices subagentStoreRoot usageRef claimCurrentSession compactRunner activeBackend btwBackend
 
 preparePersistence
     :: Maybe FullscreenRuntime
@@ -1241,7 +1293,7 @@ runSession
     -> IORef ResponseCreateParams
     -> IORef [ResponseItem]
     -> [SessionTurn]
-    -> Maybe Text
+    -> IORef (Maybe Text)
     -> Persistence
     -> OsPath
     -> OsPath
@@ -1260,10 +1312,12 @@ runSession
     -> SubagentStoreRoot
     -> IORef TokenUsage
     -> (SessionHandle -> IO ())
+    -> (Maybe Text -> IO (Either Text CompactOutcome))
     -> Backend
     -> BtwBackendFactory
     -> IO RunResult
-runSession options provider policy tools toolEnv planMode startup prompt pendingTurn initialDraft unavailableProviders paramsRef transcriptRef initialTurns initialPrevious persist projectRoot home cwd tokenProvider openAiPool startupContext skillsRef skillInvocationsRef escPaused interrupt multiCtx rootTurnRef subagentSessions pendingNotices storeRoot usageRef onPersisted backend btwBackend = do
+runSession options provider policy tools toolEnv planMode startup prompt pendingTurn initialDraft unavailableProviders paramsRef transcriptRef initialTurns previous persist projectRoot home cwd tokenProvider openAiPool startupContext skillsRef skillInvocationsRef escPaused interrupt multiCtx rootTurnRef subagentSessions pendingNotices storeRoot usageRef onPersisted compactRunner backend btwBackend = do
+  initialPrevious <- readIORef previous
   ioLock <- newMVar ()
   let fullscreen = startup.startupFullscreen
       terminal = startup.startupTerminal
@@ -1306,7 +1360,6 @@ runSession options provider policy tools toolEnv planMode startup prompt pending
     modelRef <- newIORef =<< (currentModel <$> readIORef paramsRef)
     unavailableProvidersRef <- newIORef unavailableProviders
     restartEffortRef <- newIORef Nothing
-    previous <- newIORef initialPrevious
     titleTurnCount <- newIORef =<< sessionTitleTurnCountFromSlot persist
     selectedAgent <- newIORef AgentRoot
     agentStepCache <- newIORef (Map.empty :: Map AgentTarget AgentStepCache)
@@ -1536,6 +1589,7 @@ runSession options provider policy tools toolEnv planMode startup prompt pending
         env = SessionEnv
             { sessionLoop = config
             , sessionBtwBackend = btwBackend
+            , sessionCompact = compactRunner
             , sessionRender = render
             , sessionProvider = provider
             , sessionUnavailableProviders = unavailableProvidersRef
@@ -1806,6 +1860,7 @@ repl env = replWithDraft env ""
 replWithDraft :: SessionEnv -> Text -> IO RunResult
 replWithDraft env@SessionEnv
     { sessionBtwBackend = btwBackend
+    , sessionCompact = compactRunner
     , sessionRender = render
     , sessionProvider = provider
     , sessionPrevious = previous
@@ -2274,16 +2329,13 @@ replWithDraft env@SessionEnv
                         color <- resolveColor stderr
                         result <-
                             withReplActivity "Compacting context…" $
-                                runProviderCompact provider tokenProvider
-                                    paramsRef transcriptRef focus
+                                compactRunner focus
                         case result of
                             Left err -> do
                                 displayError err $
                                     Text.hPutStrLn stderr (roleError color err)
                                 continue
                             Right outcome -> do
-                                writeIORef transcriptRef outcome.compactHistory
-                                writeIORef previous Nothing
                                 fullscreenEvent UiConversationCleared
                                 fullscreenEvent
                                     (UiSystemMessage outcome.compactSummary)
@@ -2314,16 +2366,19 @@ replWithDraft env@SessionEnv
                                                 , turnError = Nothing
                                                 , turnResponseId = Nothing
                                                 , turnItems = outcome.compactHistory
+                                                -- Compaction response usage is
+                                                -- recorded immediately by
+                                                -- compactRunner, including
+                                                -- response-level failures.
                                                 , turnUsage = Nothing
                                                 }
-                                        handle' <- appendTurn handle turn
-                                        let meta = handle'.sessionMeta
-                                                { metaLastResponseId = Nothing
-                                                , metaUpdatedAt = now
-                                                }
-                                        writeSessionMeta handle'.sessionMetaPath meta
+                                        handle' <-
+                                            appendTurnWithMetaUpdate handle turn
+                                                \meta -> meta
+                                                    { metaLastResponseId = Nothing
+                                                    }
                                         writeIORef slotRef
-                                            (PersistenceActive handle'{sessionMeta = meta})
+                                            (PersistenceActive handle')
                                 continue
                     ReplPlan maybeDescription ->
                         enterPlanFromSlash env maybeDescription >>= \case
@@ -3541,9 +3596,12 @@ currentSessionId = \case
             PersistencePending _ -> Nothing
             PersistenceActive handle -> Just handle.sessionMeta.metaId
 
--- | Serialize turns on the root OpenAI WebSocket connection because
--- 'receiveWsResponse' is not multiplexed.
-lockedOpenAiBackend
+-- | Build a root OpenAI backend plus an unlocked sender for manual compaction.
+-- Callers hold the same lock around the entire manual compact/install
+-- transition. A normal logical turn holds it across automatic compaction and
+-- its continuation because the active WebSocket is not multiplexed and
+-- transcript mutation must not interleave between those two requests.
+lockedOpenAiSession
     :: Maybe Int
     -> MVar ()
     -> TokenProvider
@@ -3553,16 +3611,41 @@ lockedOpenAiBackend
     -> IO ResponseCreateParams
     -> IORef [ResponseItem]
     -> IORef (Maybe (Int, Int))
-    -> Backend
-lockedOpenAiBackend compactThreshold wsLock provider credential connectionHealthy
-        conn getParams transcript contextTokens =
-    let Backend submit =
-            openAiBackendReconnecting
-                provider credential connectionHealthy conn getParams transcript
-        serialized = Backend \previous inputs onEvent ->
-            withMVar wsLock \_ -> submit previous inputs onEvent
-    in autoCompactOpenAiBackendWithThreshold compactThreshold provider
-        getParams transcript contextTokens serialized
+    -> (TokenUsage -> IO ())
+    -> (OpenAiCompactionSender, Backend)
+lockedOpenAiSession compactThreshold wsLock provider credential
+        connectionHealthy conn getParams transcript contextTokens
+        recordCompactionUsage =
+    let sendResponse =
+            openAiResponseSenderReconnecting
+                provider
+                credential
+                connectionHealthy
+                conn
+        sendAuxiliary =
+            openAiAuxiliaryResponseSenderReconnecting
+                provider
+                credential
+                connectionHealthy
+                conn
+        baseBackend =
+            withConnectionRecovery $
+                openAiBackendWith sendResponse getParams transcript
+        compactSender request =
+            sendAuxiliary request Nothing (const (pure ()))
+        compactingBackend =
+            autoCompactOpenAiBackendWithSender
+                compactThreshold
+                compactSender
+                recordCompactionUsage
+                getParams
+                transcript
+                contextTokens
+                baseBackend
+        serializedBackend = Backend \previous inputs onEvent ->
+            withMVar wsLock \_ ->
+                compactingBackend.submitTurn previous inputs onEvent
+    in (compactSender, serializedBackend)
 
 -- | Drop live conversation state without touching persisted session files.
 resetLiveConversation

--- a/packages/agent-cli/src/Agent/CLI/Compaction.hs
+++ b/packages/agent-cli/src/Agent/CLI/Compaction.hs
@@ -1,13 +1,17 @@
 -- | Run provider compaction and rewrite the local transcript.
 module Agent.CLI.Compaction
     ( CompactOutcome(..)
+    , OpenAiCompactionSender
     , codexAutoCompactTokenLimit
     , autoCompactOpenAiBackend
     , autoCompactOpenAiBackendWithThreshold
+    , autoCompactOpenAiBackendWithSender
     , autoCompactOpenAiBackendWith
     , autoCompactOpenAiBackendWithApi
     , compactOpenAIWith
+    , installCompactOutcome
     , runProviderCompact
+    , runProviderCompactWith
     ) where
 
 import Agent.Error (ApiError(..), ErrorType(..))
@@ -17,6 +21,7 @@ import Agent.Loop
     , TokenUsage(..)
     , TurnInput(..)
     , TurnOutput(..)
+    , emptyTokenUsage
     )
 import qualified Agent.OpenAI.Client as OpenAI
 import Agent.OpenAI.Compaction
@@ -37,6 +42,7 @@ import Agent.OpenAI.ModelMetadata
     )
 import Agent.Responses.LoopBackend
     ( assistantTextFromResponse
+    , responseTokenUsage
     , toolResultToItem
     , turnInputsToItems
     , withRequestInput
@@ -53,12 +59,11 @@ import qualified Agent.XAI.Client as XAI
 import qualified Agent.XAI.Options as XAI
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Except
-    ( ExceptT(..)
-    , runExceptT
+    ( ExceptT
     , throwE
-    , withExceptT
     )
-import Control.Exception.Safe (onException)
+import Control.Exception.Safe (mask, onException)
+import Control.Monad (when)
 import Data.IORef (IORef, readIORef, writeIORef)
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
@@ -74,6 +79,14 @@ data CompactOutcome = CompactOutcome
     , compactSummary :: !Text
     } deriving (Eq, Show)
 
+type OpenAiCompactionSender =
+    ResponseCreateParams -> IO (Either ApiError Response)
+
+data CompactAttempt error = CompactAttempt
+    { compactAttemptUsage :: !TokenUsage
+    , compactAttemptResult :: !(Either error CompactOutcome)
+    }
+
 runProviderCompact
     :: Provider
     -> Maybe TokenProvider
@@ -81,30 +94,157 @@ runProviderCompact
     -> IORef [ResponseItem]
     -> Maybe Text
     -> IO (Either Text CompactOutcome)
-runProviderCompact provider tokenProvider paramsRef transcriptRef focus =
-    runExceptT do
-        params <- lift (readIORef paramsRef)
-        history <- lift (readIORef transcriptRef)
-        case provider of
-            OpenAIProvider ->
-                compactOpenAI tokenProvider params history
-                    (estimateItemsTokens history) focus
-            XAIProvider ->
-                compactLocalXai tokenProvider params history
-                    (estimateItemsTokens history) focus
-            OpenRouterProvider ->
-                compactLocalOpenRouter tokenProvider params history
-                    (estimateItemsTokens history) focus
+runProviderCompact =
+    runProviderCompactWith Nothing (const (pure ()))
 
-compactOpenAI
-    :: Maybe TokenProvider
-    -> ResponseCreateParams
-    -> [ResponseItem]
-    -> Int
+-- | Run manual compaction, optionally routing OpenAI through the active model
+-- session. Provider-reported compaction usage is recorded as soon as a
+-- completed response arrives, including protocol-invalid responses.
+runProviderCompactWith
+    :: Maybe OpenAiCompactionSender
+    -> (TokenUsage -> IO ())
+    -> Provider
+    -> Maybe TokenProvider
+    -> IORef ResponseCreateParams
+    -> IORef [ResponseItem]
     -> Maybe Text
-    -> ExceptT Text IO CompactOutcome
-compactOpenAI =
-    compactOpenAIWith sendOpenAIRemoteCompaction
+    -> IO (Either Text CompactOutcome)
+runProviderCompactWith openAiSender recordUsage provider tokenProvider
+        paramsRef transcriptRef focus = do
+    params <- readIORef paramsRef
+    history <- readIORef transcriptRef
+    attempt <- runAttemptAndRecord recordUsage $ case provider of
+        OpenAIProvider ->
+            case openAiSender of
+                Just sender ->
+                    compactTextAttempt sender params history focus
+                Nothing ->
+                    case tokenProvider of
+                        Nothing ->
+                            pure (compactTextFailure
+                                "openai compact requires a token provider")
+                        Just tokens ->
+                            compactTextAttempt
+                                (sendOpenAIRemoteCompaction tokens)
+                                params
+                                history
+                                focus
+        XAIProvider ->
+            case tokenProvider of
+                Nothing ->
+                    pure (compactTextFailure
+                        "xai compact requires a token provider")
+                Just tokens -> do
+                    options <- XAI.clientOptionsFromEnv
+                    summarizeTextAttempt
+                        (\request ->
+                            runWithTokenProvider tokens \credential ->
+                                XAI.createResponseWith options credential request)
+                        params
+                        history
+                        focus
+        OpenRouterProvider ->
+            case tokenProvider of
+                Nothing ->
+                    pure (compactTextFailure
+                        "openrouter compact requires a token provider")
+                Just tokens -> do
+                    options <- OpenRouter.clientOptionsFromEnv
+                    summarizeTextAttempt
+                        (\request ->
+                            runWithTokenProvider tokens \credential ->
+                                OpenRouter.createResponseWith
+                                    options credential request)
+                        params
+                        history
+                        focus
+    pure attempt.compactAttemptResult
+  where
+    compactTextAttempt sender params history focus
+        | null history = pure (compactTextFailure "nothing to compact")
+        | otherwise =
+            mapCompactAttemptError formatApiError
+                <$> compactOpenAIAttempt
+                    sender
+                    params
+                    history
+                    (estimateItemsTokens history)
+                    focus
+
+    summarizeTextAttempt sender params history focus
+        | null history = pure (compactTextFailure "nothing to compact")
+        | otherwise =
+            mapCompactAttemptError formatApiError
+                <$> summarizeLocalAttempt
+                    sender
+                    params
+                    history
+                    (estimateItemsTokens history)
+                    focus
+
+compactTextFailure :: Text -> CompactAttempt Text
+compactTextFailure message =
+    CompactAttempt emptyTokenUsage (Left message)
+
+mapCompactAttemptError
+    :: (source -> target)
+    -> CompactAttempt source
+    -> CompactAttempt target
+mapCompactAttemptError f attempt =
+    CompactAttempt
+        { compactAttemptUsage = attempt.compactAttemptUsage
+        , compactAttemptResult =
+            either (Left . f) Right attempt.compactAttemptResult
+        }
+
+recordAttemptUsage
+    :: (TokenUsage -> IO ())
+    -> CompactAttempt error
+    -> IO ()
+recordAttemptUsage recordUsage attempt =
+    when (attempt.compactAttemptUsage /= emptyTokenUsage) $
+        recordUsage attempt.compactAttemptUsage
+
+-- Keep the model request cancellable, but once it returns a completed response
+-- close the ordinary asynchronous-exception window before entering the usage
+-- recorder.
+runAttemptAndRecord
+    :: (TokenUsage -> IO ())
+    -> IO (CompactAttempt error)
+    -> IO (CompactAttempt error)
+runAttemptAndRecord recordUsage action =
+    mask \restore -> do
+        attempt <- restore action
+        recordAttemptUsage recordUsage attempt
+        pure attempt
+
+-- | Install a successful manual compaction as one masked local state change.
+-- Clearing the server continuation id together with replacing the transcript
+-- prevents the next request from pairing compacted local history with the
+-- pre-compaction response chain.
+installCompactOutcome
+    :: IORef (Maybe Text)
+    -> IORef [ResponseItem]
+    -> Maybe (IORef (Maybe (Int, Int)))
+    -> (Maybe Text -> IO (Either Text CompactOutcome))
+    -> Maybe Text
+    -> IO (Either Text CompactOutcome)
+installCompactOutcome previous transcript contextTokens runCompact focus =
+    mask \restore -> do
+        result <- restore (runCompact focus)
+        case result of
+            Left _ -> pure ()
+            Right outcome -> do
+                writeIORef previous Nothing
+                writeIORef transcript outcome.compactHistory
+                case contextTokens of
+                    Nothing -> pure ()
+                    Just ref ->
+                        writeIORef ref $ Just
+                            ( outcome.compactAfterTokens
+                            , length outcome.compactHistory
+                            )
+        pure result
 
 sendOpenAIRemoteCompaction
     :: TokenProvider
@@ -124,148 +264,125 @@ compactOpenAIWith
     -> ExceptT Text IO CompactOutcome
 compactOpenAIWith send tokenProvider params history before focus = do
     provider <- requireTokenProvider OpenAIProvider tokenProvider
-    if hasFocus focus
-        then summarizeLocal
-            send
-            provider
+    requireHistory history
+    attempt <- lift $
+        compactOpenAIAttempt
+            (send provider)
             params
             history
             before
             focus
-        else compactRemoteV2
-            send
-            provider
-            params
-            history
-            before
+    either (throwE . formatApiError) pure attempt.compactAttemptResult
 
-compactRemoteV2
-    :: (TokenProvider -> ResponseCreateParams -> IO (Either ApiError Response))
-    -> TokenProvider
+compactOpenAIAttempt
+    :: OpenAiCompactionSender
     -> ResponseCreateParams
     -> [ResponseItem]
     -> Int
-    -> ExceptT Text IO CompactOutcome
-compactRemoteV2 send provider params history before =
-    do
-        requireHistory history
-        withExceptT formatApiError $
-            ExceptT (compactRemoteV2Api send provider params history before)
+    -> Maybe Text
+    -> IO (CompactAttempt ApiError)
+compactOpenAIAttempt send params history before focus
+    | hasFocus focus =
+        summarizeLocalAttempt send params history before focus
+    | otherwise =
+        compactRemoteV2Attempt send params history before
 
-compactRemoteV2Api
-    :: (TokenProvider -> ResponseCreateParams -> IO (Either ApiError Response))
-    -> TokenProvider
+compactRemoteV2Attempt
+    :: OpenAiCompactionSender
     -> ResponseCreateParams
     -> [ResponseItem]
     -> Int
-    -> IO (Either ApiError CompactOutcome)
-compactRemoteV2Api send provider params history before =
-    runExceptT do
-        requireHistoryApi history
+    -> IO (CompactAttempt ApiError)
+compactRemoteV2Attempt send params history before
+    | null history =
+        pure $ CompactAttempt emptyTokenUsage $
+            Left (ProviderError InvalidRequestError "nothing to compact" Nothing)
+    | otherwise = do
         let requestHistory =
                 trimRemoteCompactionHistoryToFit
                     (codexEffectiveContextWindowFor params.model)
                     params.instructions
                     history
             request = buildRemoteCompactionRequest params requestHistory
-        response <- ExceptT (send provider request)
-        checkpoint <-
-            either
-                (throwE . protocolError)
-                pure
-                (extractRemoteCompactionItem response)
-        let items =
-                buildRemoteCompactedHistory
-                    remoteCompactionRetainedTokenBudget
-                    history
-                    checkpoint
-        pure CompactOutcome
-            { compactBeforeTokens = before
-            , compactAfterTokens = estimateItemsTokens items
-            , compactHistory = items
-            , compactSummary = "Context compacted remotely."
-            }
+        send request >>= \case
+            Left err ->
+                pure (CompactAttempt emptyTokenUsage (Left err))
+            Right response ->
+                pure CompactAttempt
+                    { compactAttemptUsage = responseTokenUsage response
+                    , compactAttemptResult = do
+                        checkpoint <-
+                            either
+                                (Left . protocolError)
+                                Right
+                                (extractRemoteCompactionItem response)
+                        let items =
+                                buildRemoteCompactedHistory
+                                    remoteCompactionRetainedTokenBudget
+                                    history
+                                    checkpoint
+                        Right CompactOutcome
+                            { compactBeforeTokens = before
+                            , compactAfterTokens = estimateItemsTokens items
+                            , compactHistory = items
+                            , compactSummary = "Context compacted remotely."
+                            }
+                    }
   where
     protocolError message =
         ProviderError ApiErrorType message Nothing
 
-compactLocalXai
-    :: Maybe TokenProvider
+summarizeLocalAttempt
+    :: OpenAiCompactionSender
     -> ResponseCreateParams
     -> [ResponseItem]
     -> Int
     -> Maybe Text
-    -> ExceptT Text IO CompactOutcome
-compactLocalXai tokenProvider params history before focus = do
-    provider <- requireTokenProvider XAIProvider tokenProvider
-    options <- lift XAI.clientOptionsFromEnv
-    summarizeLocal
-        (\tokens request ->
-            runWithTokenProvider tokens \credential ->
-                XAI.createResponseWith options credential request)
-        provider
-        params
-        history
-        before
-        focus
-
-compactLocalOpenRouter
-    :: Maybe TokenProvider
-    -> ResponseCreateParams
-    -> [ResponseItem]
-    -> Int
-    -> Maybe Text
-    -> ExceptT Text IO CompactOutcome
-compactLocalOpenRouter tokenProvider params history before focus = do
-    provider <- requireTokenProvider OpenRouterProvider tokenProvider
-    options <- lift OpenRouter.clientOptionsFromEnv
-    summarizeLocal
-        (\tokens request ->
-            runWithTokenProvider tokens \credential ->
-                OpenRouter.createResponseWith options credential request)
-        provider
-        params
-        history
-        before
-        focus
-
-summarizeLocal
-    :: (TokenProvider -> ResponseCreateParams -> IO (Either ApiError Response))
-    -> TokenProvider
-    -> ResponseCreateParams
-    -> [ResponseItem]
-    -> Int
-    -> Maybe Text
-    -> ExceptT Text IO CompactOutcome
-summarizeLocal send provider params history before focus = do
-    requireHistory history
-    let summaryPrompt = summarizationPrompt focus
-        ResponseCreateParams{..} = params
-        summaryParams =
-            ResponseCreateParams
-                { tools = Nothing
-                , parallelToolCalls = Just False
-                -- The ChatGPT Codex REST endpoint only accepts streaming
-                -- Responses requests, and this client decodes its SSE result.
-                , stream = Just True
-                , ..
-                }
-        request =
-            withRequestInput
-                summaryParams
-                (history <> [userTextItem summaryPrompt])
-    response <- withExceptT formatApiError $
-        ExceptT (send provider request)
-    summary <- case assistantTextFromResponse response of
-        Nothing -> throwE "compaction produced no summary text"
-        Just text -> pure text
-    let items = buildLocalCompactedHistory 6 history summary
-    pure CompactOutcome
-        { compactBeforeTokens = before
-        , compactAfterTokens = estimateItemsTokens items
-        , compactHistory = items
-        , compactSummary = summary
-        }
+    -> IO (CompactAttempt ApiError)
+summarizeLocalAttempt send params history before focus
+    | null history =
+        pure $ CompactAttempt emptyTokenUsage $
+            Left (ProviderError InvalidRequestError "nothing to compact" Nothing)
+    | otherwise = do
+        let summaryPrompt = summarizationPrompt focus
+            ResponseCreateParams{..} = params
+            summaryParams =
+                ResponseCreateParams
+                    { tools = Nothing
+                    , parallelToolCalls = Just False
+                    -- The ChatGPT Codex REST endpoint only accepts streaming
+                    -- Responses requests, and this client decodes its SSE result.
+                    , stream = Just True
+                    , ..
+                    }
+            request =
+                withRequestInput
+                    summaryParams
+                    (history <> [userTextItem summaryPrompt])
+        send request >>= \case
+            Left err ->
+                pure (CompactAttempt emptyTokenUsage (Left err))
+            Right response ->
+                pure CompactAttempt
+                    { compactAttemptUsage = responseTokenUsage response
+                    , compactAttemptResult =
+                        case assistantTextFromResponse response of
+                            Nothing ->
+                                Left (ProviderError ApiErrorType
+                                    "compaction produced no summary text"
+                                    Nothing)
+                            Just summary ->
+                                let items =
+                                        buildLocalCompactedHistory
+                                            6 history summary
+                                in Right CompactOutcome
+                                    { compactBeforeTokens = before
+                                    , compactAfterTokens =
+                                        estimateItemsTokens items
+                                    , compactHistory = items
+                                    , compactSummary = summary
+                                    }
+                    }
 
 autoCompactOpenAiBackend
     :: TokenProvider
@@ -289,9 +406,33 @@ autoCompactOpenAiBackendWithThreshold
     -> Backend
 autoCompactOpenAiBackendWithThreshold configuredThreshold tokenProvider
         getParams transcriptRef contextTokensRef backend =
+    autoCompactOpenAiBackendWithSender
+        configuredThreshold
+        (sendOpenAIRemoteCompaction tokenProvider)
+        (const (pure ()))
+        getParams
+        transcriptRef
+        contextTokensRef
+        backend
+
+-- | Automatic compaction with an injected Responses sender and an immediate
+-- usage recorder. The root CLI uses this to share its active WebSocket session
+-- and persist billable compaction usage even if the following turn fails.
+autoCompactOpenAiBackendWithSender
+    :: Maybe Int
+    -> OpenAiCompactionSender
+    -> (TokenUsage -> IO ())
+    -> IO ResponseCreateParams
+    -> IORef [ResponseItem]
+    -> IORef (Maybe (Int, Int))
+    -> Backend
+    -> Backend
+autoCompactOpenAiBackendWithSender configuredThreshold send recordUsage
+        getParams transcriptRef contextTokensRef backend =
     autoCompactOpenAiBackendWithLimit
         getLimit
         compactAction
+        recordUsage
         transcriptRef
         contextTokensRef
         backend
@@ -304,9 +445,8 @@ autoCompactOpenAiBackendWithThreshold configuredThreshold tokenProvider
     compactAction = do
         params <- getParams
         history <- readIORef transcriptRef
-        compactRemoteV2Api
-            sendOpenAIRemoteCompaction
-            tokenProvider
+        compactRemoteV2Attempt
+            send
             params
             history
             (estimateItemsTokens history)
@@ -330,18 +470,22 @@ autoCompactOpenAiBackendWithApi
     -> IORef (Maybe (Int, Int))
     -> Backend
     -> Backend
-autoCompactOpenAiBackendWithApi =
+autoCompactOpenAiBackendWithApi compactAction =
     autoCompactOpenAiBackendWithLimit
         (pure codexAutoCompactTokenLimit)
+        (CompactAttempt emptyTokenUsage <$> compactAction)
+        (const (pure ()))
 
 autoCompactOpenAiBackendWithLimit
     :: IO Int
-    -> IO (Either ApiError CompactOutcome)
+    -> IO (CompactAttempt ApiError)
+    -> (TokenUsage -> IO ())
     -> IORef [ResponseItem]
     -> IORef (Maybe (Int, Int))
     -> Backend
     -> Backend
-autoCompactOpenAiBackendWithLimit getLimit compactAction transcriptRef contextTokensRef
+autoCompactOpenAiBackendWithLimit getLimit compactAction recordUsage
+        transcriptRef contextTokensRef
         (Backend submit) =
     Backend \previous inputs onEvent -> do
         contextState <- readIORef contextTokensRef
@@ -365,6 +509,10 @@ autoCompactOpenAiBackendWithLimit getLimit compactAction transcriptRef contextTo
                 else compactThenSubmit contextState inputs onEvent
             else submitAndTrack contextState previous inputs onEvent
   where
+    runCompaction =
+        (.compactAttemptResult)
+            <$> runAttemptAndRecord recordUsage compactAction
+
     isCompletedTool = \case
         CompletedTool{} -> True
         _ -> False
@@ -373,38 +521,77 @@ autoCompactOpenAiBackendWithLimit getLimit compactAction transcriptRef contextTo
     -- not committed them yet. Absorb them into history before compaction, then
     -- resume from the new checkpoint without sending them a second time.
     compactToolContinuation oldTokens inputs onEvent = do
-        oldHistory <- readIORef transcriptRef
-        let (toolItems, remainingInputs) = absorbCompletedTools inputs
-        writeIORef transcriptRef (oldHistory <> toolItems)
-        onEvent (ActivityUpdated "Compacting context…")
-        (compactAction `onException` writeIORef transcriptRef oldHistory) >>= \case
-            Left err -> do
-                writeIORef transcriptRef oldHistory
-                pure (Left (automaticCompactionError err))
-            Right outcome -> do
-                writeIORef transcriptRef outcome.compactHistory
-                submitAndTrack oldTokens Nothing remainingInputs onEvent
+        mask \restore -> do
+            oldHistory <- readIORef transcriptRef
+            let (toolItems, remainingInputs) = absorbCompletedTools inputs
+                rollback = do
+                    writeIORef transcriptRef oldHistory
+                    writeIORef contextTokensRef oldTokens
+            writeIORef transcriptRef (oldHistory <> toolItems)
+            (do
+                onEvent (ActivityUpdated "Compacting context…")
+                restore runCompaction >>= \case
+                    Left err -> do
+                        rollback
+                        pure (Left (automaticCompactionError err))
+                    Right outcome ->
+                        installSubmitAndTrack
+                            restore
+                            rollback
+                            outcome
+                            remainingInputs
+                            onEvent
+                ) `onException` rollback
 
     compactThenSubmit oldTokens inputs onEvent = do
+        oldHistory <- readIORef transcriptRef
         onEvent (ActivityUpdated "Compacting context…")
-        compactAction >>= \case
+        runCompaction >>= \case
                 Left err ->
                     pure (Left (automaticCompactionError err))
-                Right outcome -> do
-                    writeIORef transcriptRef outcome.compactHistory
-                    submitAndTrack oldTokens Nothing inputs onEvent
+                Right outcome ->
+                    mask \restore -> do
+                        let rollback = do
+                                writeIORef transcriptRef oldHistory
+                                writeIORef contextTokensRef oldTokens
+                        installSubmitAndTrack
+                            restore
+                            rollback
+                            outcome
+                            inputs
+                            onEvent
+                            `onException` rollback
+
+    installCompactedHistory outcome = do
+        let history = outcome.compactHistory
+            contextState =
+                Just (outcome.compactAfterTokens, length history)
+        writeIORef transcriptRef history
+        writeIORef contextTokensRef contextState
+
+    installSubmitAndTrack restore rollback outcome inputs onEvent = do
+        installCompactedHistory outcome
+        result <- restore (submit Nothing inputs onEvent)
+        case result of
+            Left _ -> rollback
+            Right output -> trackSuccessfulOutput output
+        pure result
 
     submitAndTrack oldTokens previous inputs onEvent = do
-        result <- submit previous inputs onEvent
+        result <-
+            submit previous inputs onEvent
+                `onException` writeIORef contextTokensRef oldTokens
         case result of
             Left _ -> writeIORef contextTokensRef oldTokens
-            Right output -> do
-                historyLength <- length <$> readIORef transcriptRef
-                writeIORef contextTokensRef $ Just
-                    ( output.tokenUsage.inputTokens + output.tokenUsage.outputTokens
-                    , historyLength
-                    )
+            Right output -> trackSuccessfulOutput output
         pure result
+
+    trackSuccessfulOutput output = do
+        historyLength <- length <$> readIORef transcriptRef
+        writeIORef contextTokensRef $ Just
+            ( output.tokenUsage.inputTokens + output.tokenUsage.outputTokens
+            , historyLength
+            )
 
     absorbCompletedTools =
         foldr
@@ -435,14 +622,6 @@ requireTokenProvider provider =
 requireHistory :: [ResponseItem] -> ExceptT Text IO ()
 requireHistory history
     | null history = throwE "nothing to compact"
-    | otherwise = pure ()
-
-requireHistoryApi :: [ResponseItem] -> ExceptT ApiError IO ()
-requireHistoryApi history
-    | null history =
-        throwE $ ProviderError InvalidRequestError
-            "nothing to compact"
-            Nothing
     | otherwise = pure ()
 
 providerLabel :: Provider -> Text

--- a/packages/agent-cli/src/Agent/CLI/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session.hs
@@ -12,6 +12,7 @@ module Agent.CLI.Session
     , appendTurn
     , appendTurnWithMetaUpdate
     , appendTurnKeepTitle
+    , addSessionUsage
     , loadSession
     , isValidSessionId
     , listSessions
@@ -293,6 +294,25 @@ appendTurnWithMetaUpdate handle turn updateMeta = do
         finalMeta = updateMeta meta
     writeSessionMeta handle.sessionMetaPath finalMeta
     pure handle { sessionMeta = finalMeta }
+
+-- | Persist provider usage that is not represented by its own transcript
+-- turn, such as an inline compaction request. Session metadata is the
+-- authoritative aggregate used when resuming.
+addSessionUsage :: TokenUsage -> SessionHandle -> IO SessionHandle
+addSessionUsage usage handle = do
+    now <- getCurrentTime
+    let meta0 = handle.sessionMeta
+        meta = meta0
+            { metaUpdatedAt = now
+            , metaInputTokens =
+                meta0.metaInputTokens + usage.inputTokens
+            , metaOutputTokens =
+                meta0.metaOutputTokens + usage.outputTokens
+            , metaCachedTokens =
+                meta0.metaCachedTokens + usage.cachedTokens
+            }
+    writeSessionMeta handle.sessionMetaPath meta
+    pure handle { sessionMeta = meta }
 
 sessionConversationText :: [SessionTurn] -> Text
 sessionConversationText =

--- a/packages/agent-cli/src/Agent/CLI/SessionEnv.hs
+++ b/packages/agent-cli/src/Agent/CLI/SessionEnv.hs
@@ -6,6 +6,7 @@ module Agent.CLI.SessionEnv
 import Agent.CLI.Interrupt (InterruptState)
 import Agent.CLI.AgentViewport (AgentViewportEnv)
 import Agent.CLI.Btw (BtwBackendFactory)
+import Agent.CLI.Compaction (CompactOutcome)
 import Agent.CLI.Options (ApprovalPolicy)
 import Agent.CLI.Render (RenderConfig)
 import Agent.CLI.Session (Persistence, SessionHandle)
@@ -26,6 +27,7 @@ import Data.Text (Text)
 data SessionEnv = SessionEnv
     { sessionLoop :: !LoopConfig
     , sessionBtwBackend :: !BtwBackendFactory
+    , sessionCompact :: !(Maybe Text -> IO (Either Text CompactOutcome))
     , sessionRender :: !RenderConfig
     , sessionProvider :: !Provider
     , sessionUnavailableProviders :: !(IORef [Provider])

--- a/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
@@ -4,11 +4,15 @@ import Agent.CLI.Compaction
     ( CompactOutcome(..)
     , autoCompactOpenAiBackendWith
     , autoCompactOpenAiBackendWithApi
+    , autoCompactOpenAiBackendWithSender
     , autoCompactOpenAiBackendWithThreshold
     , codexAutoCompactTokenLimit
     , compactOpenAIWith
+    , installCompactOutcome
     , runProviderCompact
+    , runProviderCompactWith
     )
+import Agent.CLI.Connectivity (withConnectionRecoveryUsing)
 import Agent.Error (ApiError(..), ErrorType(..))
 import Agent.Loop
 import Agent.OpenAI.Compaction
@@ -24,6 +28,13 @@ import Agent.Responses.Types
 import qualified Data.Aeson as Aeson
 import Data.Aeson ((.=))
 import Agent.Provider (Provider(..), TokenProvider(..))
+import Control.Exception
+    ( AsyncException(..)
+    , MaskingState(..)
+    , getMaskingState
+    , throwIO
+    , try
+    )
 import Data.IORef
 import Control.Monad.Trans.Except (runExceptT)
 import Data.Text (Text)
@@ -50,6 +61,154 @@ spec = do
                     error "empty compaction unexpectedly requested credentials"
             runProviderCompact OpenAIProvider (Just provider) params transcript Nothing
                 `shouldReturn` Left "nothing to compact"
+
+        it "uses an injected OpenAI sender and records its response usage" do
+            params <- newIORef defaultResponseCreateParams
+            let history = [userTextItem "old context"]
+            transcript <- newIORef history
+            requests <- newIORef []
+            recordedUsage <- newIORef []
+            let sender request = do
+                    modifyIORef' requests (<> [request])
+                    pure (Right remoteCompactionResponse)
+                record usage =
+                    modifyIORef' recordedUsage (<> [usage])
+            result <-
+                runProviderCompactWith
+                    (Just sender)
+                    record
+                    OpenAIProvider
+                    Nothing
+                    params
+                    transcript
+                    Nothing
+            result `shouldSatisfy` either (const False) (const True)
+            map requestItems <$> readIORef requests
+                `shouldReturn` [history <> [compactionTriggerItem]]
+            readIORef recordedUsage `shouldReturn` [compactionUsage]
+
+        it "records completed-response usage with asynchronous exceptions masked" do
+            params <- newIORef defaultResponseCreateParams
+            transcript <- newIORef [userTextItem "old context"]
+            senderMasking <- newIORef MaskedUninterruptible
+            recorderMasking <- newIORef Unmasked
+            result <-
+                runProviderCompactWith
+                    (Just \_ -> do
+                        getMaskingState >>= writeIORef senderMasking
+                        pure (Right remoteCompactionResponse))
+                    (\_ -> getMaskingState >>= writeIORef recorderMasking)
+                    OpenAIProvider
+                    Nothing
+                    params
+                    transcript
+                    Nothing
+            result `shouldSatisfy` either (const False) (const True)
+            readIORef senderMasking `shouldReturn` Unmasked
+            readIORef recorderMasking `shouldReturn` MaskedInterruptible
+
+        it "records local-summary response usage when summary text is missing" do
+            params <- newIORef defaultResponseCreateParams
+            transcript <- newIORef [userTextItem "old context"]
+            recordedUsage <- newIORef []
+            result <-
+                runProviderCompactWith
+                    (Just \_ -> pure (Right responseWithoutCompaction))
+                    (\usage -> modifyIORef' recordedUsage (<> [usage]))
+                    OpenAIProvider
+                    Nothing
+                    params
+                    transcript
+                    (Just "focus")
+            result `shouldSatisfy` \case
+                Left message ->
+                    "compaction produced no summary text"
+                        `Text.isInfixOf` message
+                Right _ -> False
+            readIORef recordedUsage `shouldReturn` [compactionUsage]
+
+        it "does not record usage for a transport failure" do
+            params <- newIORef defaultResponseCreateParams
+            transcript <- newIORef [userTextItem "old context"]
+            recordedUsage <- newIORef []
+            result <-
+                runProviderCompactWith
+                    (Just \_ -> pure (Left (ConnectionError "offline")))
+                    (\usage -> modifyIORef' recordedUsage (<> [usage]))
+                    OpenAIProvider
+                    Nothing
+                    params
+                    transcript
+                    Nothing
+            result `shouldSatisfy` \case
+                Left message -> "offline" `Text.isInfixOf` message
+                Right _ -> False
+            readIORef recordedUsage `shouldReturn` []
+
+        it "records completed-response usage even when the checkpoint is invalid" do
+            params <- newIORef defaultResponseCreateParams
+            transcript <- newIORef [userTextItem "old context"]
+            recordedUsage <- newIORef []
+            result <-
+                runProviderCompactWith
+                    (Just \_ -> pure (Right responseWithoutCompaction))
+                    (\usage -> modifyIORef' recordedUsage (<> [usage]))
+                    OpenAIProvider
+                    Nothing
+                    params
+                    transcript
+                    Nothing
+            result `shouldSatisfy` \case
+                Left message ->
+                    "expected exactly one compaction" `Text.isInfixOf` message
+                Right _ -> False
+            readIORef recordedUsage `shouldReturn` [compactionUsage]
+
+    describe "installCompactOutcome" do
+        it "clears the previous response id with transcript and token state" do
+            previous <- newIORef (Just "resp-old")
+            transcript <- newIORef [userTextItem "old context"]
+            contextState <- newIORef (Just (100, 1))
+            actionMasking <- newIORef MaskedUninterruptible
+            let compactedHistory = [userTextItem "compacted context"]
+                outcome = CompactOutcome
+                    { compactBeforeTokens = 100
+                    , compactAfterTokens = 12
+                    , compactHistory = compactedHistory
+                    , compactSummary = "checkpoint"
+                    }
+                compactAction _ = do
+                    getMaskingState >>= writeIORef actionMasking
+                    pure (Right outcome)
+            installCompactOutcome
+                previous
+                transcript
+                (Just contextState)
+                compactAction
+                Nothing
+                `shouldReturn` Right outcome
+            readIORef actionMasking `shouldReturn` Unmasked
+            readIORef previous `shouldReturn` Nothing
+            readIORef transcript `shouldReturn` compactedHistory
+            readIORef contextState `shouldReturn`
+                Just (outcome.compactAfterTokens, length compactedHistory)
+
+        it "leaves live state unchanged when compaction fails" do
+            let oldHistory = [userTextItem "old context"]
+                oldContextState = Just (100, length oldHistory)
+            previous <- newIORef (Just "resp-old")
+            transcript <- newIORef oldHistory
+            contextState <- newIORef oldContextState
+            installCompactOutcome
+                previous
+                transcript
+                (Just contextState)
+                (const (pure (Left "failed")))
+                Nothing
+                `shouldReturn` Left "failed"
+            readIORef previous `shouldReturn` Just "resp-old"
+            readIORef transcript `shouldReturn` oldHistory
+            readIORef contextState `shouldReturn` oldContextState
 
     describe "compactOpenAIWith" do
         it "uses remote compaction v2 on normal Responses" do
@@ -184,6 +343,117 @@ spec = do
             readIORef events `shouldReturn`
                 [ActivityUpdated "Compacting context…"]
 
+        it "records active-session compaction usage before a failed continuation" do
+            let history = [userTextItem "old"]
+                threshold = 20
+                oldContextState = Just (threshold - 2, length history)
+            transcript <- newIORef history
+            contextState <- newIORef oldContextState
+            requests <- newIORef []
+            recordedUsage <- newIORef []
+            let sender request = do
+                    modifyIORef' requests (<> [request])
+                    pure (Right remoteCompactionResponse)
+                base = Backend \_ _ _ ->
+                    pure (Left (ConnectionError "continuation failed"))
+                backend =
+                    autoCompactOpenAiBackendWithSender
+                        (Just threshold)
+                        sender
+                        (\usage -> modifyIORef' recordedUsage (<> [usage]))
+                        (pure defaultResponseCreateParams)
+                        transcript
+                        contextState
+                        base
+            backend.submitTurn Nothing [UserMessage "new"] (const (pure ()))
+                `shouldReturn` Left (ConnectionError "continuation failed")
+            map requestItems <$> readIORef requests
+                `shouldReturn` [history <> [compactionTriggerItem]]
+            readIORef recordedUsage `shouldReturn` [compactionUsage]
+            readIORef transcript `shouldReturn` history
+            readIORef contextState `shouldReturn` oldContextState
+
+        it "rolls back compacted state when the continuation is cancelled" do
+            let history = [userTextItem "old"]
+                threshold = 20
+                oldContextState = Just (threshold, length history)
+            transcript <- newIORef history
+            contextState <- newIORef oldContextState
+            continuationMasking <- newIORef MaskedUninterruptible
+            let sender _request =
+                    pure (Right remoteCompactionResponse)
+                base = Backend \_ _ _ -> do
+                    getMaskingState >>= writeIORef continuationMasking
+                    throwIO UserInterrupt
+                backend =
+                    autoCompactOpenAiBackendWithSender
+                        (Just threshold)
+                        sender
+                        (const (pure ()))
+                        (pure defaultResponseCreateParams)
+                        transcript
+                        contextState
+                        base
+                submit =
+                    backend.submitTurn Nothing
+                        [UserMessage "new"]
+                        (const (pure ()))
+            result <- try submit
+                :: IO (Either AsyncException (Either ApiError TurnOutput))
+            result `shouldBe` Left UserInterrupt
+            readIORef continuationMasking `shouldReturn` Unmasked
+            readIORef transcript `shouldReturn` history
+            readIORef contextState `shouldReturn` oldContextState
+
+        it "does not rerun compaction while its continuation reconnects" do
+            let history = [userTextItem "old"]
+                threshold = 20
+            transcript <- newIORef history
+            contextState <- newIORef
+                (Just (threshold, length history))
+            compactCalls <- newIORef (0 :: Int)
+            continuationCalls <- newIORef (0 :: Int)
+            recordedUsage <- newIORef []
+            waits <- newIORef []
+            seenPrevious <- newIORef []
+            let sender _request = do
+                    modifyIORef' compactCalls (+ 1)
+                    pure (Right remoteCompactionResponse)
+                continuation = Backend \previous _inputs _onEvent -> do
+                    modifyIORef' seenPrevious (<> [previous])
+                    attempt <- atomicModifyIORef' continuationCalls
+                        \n -> (n + 1, n + 1)
+                    pure $
+                        if attempt == 1
+                            then Left (ConnectionError "offline")
+                            else Right TurnOutput
+                                { responseId = "resp-new"
+                                , toolCalls = []
+                                , assistantText = Just "ok"
+                                , tokenUsage = TokenUsage 20 5 0
+                                }
+                reconnectingContinuation =
+                    withConnectionRecoveryUsing
+                        (\attempt -> modifyIORef' waits (<> [attempt]))
+                        continuation
+                backend =
+                    autoCompactOpenAiBackendWithSender
+                        (Just threshold)
+                        sender
+                        (\usage -> modifyIORef' recordedUsage (<> [usage]))
+                        (pure defaultResponseCreateParams)
+                        transcript
+                        contextState
+                        reconnectingContinuation
+            result <- backend.submitTurn (Just "resp-old")
+                [UserMessage "new"] (const (pure ()))
+            result `shouldSatisfy` either (const False) (const True)
+            readIORef compactCalls `shouldReturn` 1
+            readIORef continuationCalls `shouldReturn` 2
+            readIORef waits `shouldReturn` [1]
+            readIORef seenPrevious `shouldReturn` [Nothing, Nothing]
+            readIORef recordedUsage `shouldReturn` [compactionUsage]
+
         it "compacts when a pending tool output crosses the limit" do
             let danglingCall = FunctionCallItem FunctionCall
                     { itemId = Nothing
@@ -204,18 +474,14 @@ spec = do
             contextState <- newIORef
                 (Just (codexAutoCompactTokenLimit - 10, length oldHistory))
             compactCalls <- newIORef (0 :: Int)
+            recordedUsage <- newIORef []
             historyAtCompact <- newIORef []
             seenPrevious <- newIORef []
             seenInputs <- newIORef []
-            let compactAction = do
+            let sender _request = do
                     modifyIORef' compactCalls (+ 1)
                     readIORef transcript >>= writeIORef historyAtCompact
-                    pure $ Right CompactOutcome
-                        { compactBeforeTokens = codexAutoCompactTokenLimit
-                        , compactAfterTokens = 10
-                        , compactHistory = [userTextItem "compacted"]
-                        , compactSummary = "checkpoint"
-                        }
+                    pure (Right remoteCompactionResponse)
                 base = Backend \previous inputs _ -> do
                     modifyIORef' seenPrevious (<> [previous])
                     modifyIORef' seenInputs (<> [inputs])
@@ -225,8 +491,15 @@ spec = do
                         , assistantText = Just "ok"
                         , tokenUsage = TokenUsage 20 5 0
                         }
-                backend = autoCompactOpenAiBackendWith compactAction
-                    transcript contextState base
+                backend =
+                    autoCompactOpenAiBackendWithSender
+                        (Just codexAutoCompactTokenLimit)
+                        sender
+                        (\usage -> modifyIORef' recordedUsage (<> [usage]))
+                        (pure defaultResponseCreateParams)
+                        transcript
+                        contextState
+                        base
                 inputs = [CompletedTool toolResult]
             result <- backend.submitTurn (Just "resp-tool") inputs
                 (const (pure ()))
@@ -241,9 +514,11 @@ spec = do
                     _ -> False
             readIORef seenPrevious `shouldReturn` [Nothing]
             readIORef seenInputs `shouldReturn` [[]]
-            readIORef transcript `shouldReturn` [userTextItem "compacted"]
+            compacted <- readIORef transcript
+            compacted `shouldSatisfy` hasCompactionCheckpoint
             readIORef contextState `shouldReturn`
-                Just (25, 1)
+                Just (25, length compacted)
+            readIORef recordedUsage `shouldReturn` [compactionUsage]
 
         it "preserves typed provider failures from automatic compaction" do
             let history = [userTextItem "old"]
@@ -303,20 +578,44 @@ requestItems request = case request.input of
 
 remoteCompactionResponse :: Response
 remoteCompactionResponse =
+    responseWithOutput
+        [ Aeson.object
+            [ "type" .= ("compaction" :: Text)
+            , "encrypted_content" .= ("opaque" :: Text)
+            ]
+        ]
+
+responseWithoutCompaction :: Response
+responseWithoutCompaction =
+    responseWithOutput []
+
+responseWithOutput :: [Aeson.Value] -> Response
+responseWithOutput output =
     case Aeson.fromJSON $ Aeson.object
         [ "id" .= ("resp-compact" :: Text)
         , "created_at" .= (0 :: Int)
         , "status" .= ("completed" :: Text)
         , "model" .= ("gpt-test" :: Text)
-        , "output" .=
-            [ Aeson.object
-                [ "type" .= ("compaction" :: Text)
-                , "encrypted_content" .= ("opaque" :: Text)
+        , "output" .= output
+        , "usage" .= Aeson.object
+            [ "input_tokens" .= compactionUsage.inputTokens
+            , "output_tokens" .= compactionUsage.outputTokens
+            , "total_tokens" .=
+                (compactionUsage.inputTokens + compactionUsage.outputTokens)
+            , "input_tokens_details" .= Aeson.object
+                [ "cached_tokens" .= compactionUsage.cachedTokens
                 ]
             ]
         ] of
         Aeson.Success response -> response
         Aeson.Error err -> error err
+
+compactionUsage :: TokenUsage
+compactionUsage = TokenUsage
+    { inputTokens = 80
+    , outputTokens = 6
+    , cachedTokens = 40
+    }
 
 withModel :: Maybe Text -> ResponseCreateParams -> ResponseCreateParams
 withModel nextModel ResponseCreateParams { model = _, .. } =

--- a/packages/agent-cli/test/Agent/CLI/SessionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SessionSpec.hs
@@ -157,6 +157,109 @@ spec = describe "Agent.CLI.Session" do
                         meta `shouldBe` handle'.sessionMeta
                         turns `shouldBe` [turn]
 
+        it "commits a compact marker with a cleared response id" $
+            withTempDir "agent-sessions-" \root -> do
+                handle <- createSession (testCreate root)
+                let completedTurn = SessionTurn
+                        { turnAt = fixedTime
+                        , turnUserText = "before compact"
+                        , turnAssistantText = Just "done"
+                        , turnError = Nothing
+                        , turnResponseId = Just "resp-old"
+                        , turnItems = []
+                        , turnUsage = Nothing
+                        }
+                    compactTurn = SessionTurn
+                        { turnAt = fixedTime
+                        , turnUserText = "/compact"
+                        , turnAssistantText =
+                            Just "Context compacted remotely."
+                        , turnError = Nothing
+                        , turnResponseId = Nothing
+                        , turnItems = []
+                        , turnUsage = Nothing
+                        }
+                withResponse <- appendTurn handle completedTurn
+                final <-
+                    appendTurnWithMetaUpdate withResponse compactTurn
+                        \meta -> meta { metaLastResponseId = Nothing }
+
+                final.sessionMeta.metaLastResponseId `shouldBe` Nothing
+                loadSession root final.sessionMeta.metaId >>= \case
+                    Left err -> expectationFailure (Text.unpack err)
+                    Right (meta, turns) -> do
+                        meta.metaLastResponseId `shouldBe` Nothing
+                        turns `shouldBe` [completedTurn, compactTurn]
+
+        it "adds auxiliary usage without appending a transcript turn" $
+            withTempDir "agent-sessions-" \root -> do
+                handle <- createSession (testCreate root)
+                updated <- addSessionUsage TokenUsage
+                    { inputTokens = 90
+                    , outputTokens = 7
+                    , cachedTokens = 40
+                    }
+                    handle
+                updated.sessionMeta.metaInputTokens `shouldBe` 90
+                updated.sessionMeta.metaOutputTokens `shouldBe` 7
+                updated.sessionMeta.metaCachedTokens `shouldBe` 40
+                doesFileExist updated.sessionTranscriptPath
+                    `shouldReturn` False
+
+                loadSession root updated.sessionMeta.metaId >>= \case
+                    Left err -> expectationFailure (Text.unpack err)
+                    Right (meta, turns) -> do
+                        turns `shouldBe` []
+                        sessionUsageFromTurns meta turns `shouldBe` TokenUsage
+                            { inputTokens = 90
+                            , outputTokens = 7
+                            , cachedTokens = 40
+                            }
+
+        it "combines auxiliary and turn usage exactly once on resume" $
+            withTempDir "agent-sessions-" \root -> do
+                handle <- createSession (testCreate root)
+                withCompaction <- addSessionUsage TokenUsage
+                    { inputTokens = 90
+                    , outputTokens = 7
+                    , cachedTokens = 40
+                    }
+                    handle
+                let compactTurn = SessionTurn
+                        { turnAt = fixedTime
+                        , turnUserText = "/compact"
+                        , turnAssistantText = Just "Context compacted remotely."
+                        , turnError = Nothing
+                        , turnResponseId = Nothing
+                        , turnItems = []
+                        , turnUsage = Nothing
+                        }
+                    normalTurn = SessionTurn
+                        { turnAt = fixedTime
+                        , turnUserText = "continue"
+                        , turnAssistantText = Just "done"
+                        , turnError = Nothing
+                        , turnResponseId = Just "resp-next"
+                        , turnItems = []
+                        , turnUsage = Just TokenUsage
+                            { inputTokens = 10
+                            , outputTokens = 4
+                            , cachedTokens = 2
+                            }
+                        }
+                withMarker <- appendTurn withCompaction compactTurn
+                final <- appendTurn withMarker normalTurn
+
+                loadSession root final.sessionMeta.metaId >>= \case
+                    Left err -> expectationFailure (Text.unpack err)
+                    Right (meta, turns) -> do
+                        turns `shouldBe` [compactTurn, normalTurn]
+                        sessionUsageFromTurns meta turns `shouldBe` TokenUsage
+                            { inputTokens = 100
+                            , outputTokens = 11
+                            , cachedTokens = 42
+                            }
+
         it "rejects unsupported schema versions" $
             withTempDir "agent-sessions-" \root -> do
                 handle <- createSession (testCreate root)

--- a/packages/agent-openai/src/Agent/OpenAI/LoopBackend.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/LoopBackend.hs
@@ -5,6 +5,12 @@
 module Agent.OpenAI.LoopBackend
     ( openAiBackend
     , openAiBackendReconnecting
+    , openAiAuxiliaryResponseSenderReconnecting
+    , openAiAuxiliaryResponseSenderWithConnectionRecovery
+    , openAiResponseSenderReconnecting
+    , openAiResponseSenderWithConnectionRecoveryWhen
+    , openAiResponseSenderWithConnectionRecovery
+    , openAiResponseSenderWithRetryPolicy
     , openAiBackendWith
     , openAiBackendWithRetryPolicy
     , openAiBackendWithConnectionRecovery
@@ -12,6 +18,7 @@ module Agent.OpenAI.LoopBackend
     , statelessResponsesBackend
     , turnInputsToItems
     , responseToTurnOutput
+    , responseTokenUsage
     , streamEventToLoopEvent
     , assistantTextFromResponse
     , toolResultToItem
@@ -21,6 +28,7 @@ module Agent.OpenAI.LoopBackend
 import Agent.Error
     ( ApiError(..)
     , ErrorType(..)
+    , isInlineRetryableProviderError
     , isInlineRetryableProviderResponseError
     )
 import Agent.Loop (Backend(..), LoopEvent(..))
@@ -40,6 +48,7 @@ import Agent.Provider
 import Agent.Responses.LoopBackend
     ( assistantTextFromResponse
     , responseToTurnOutput
+    , responseTokenUsage
     , statelessResponsesBackend
     , streamEventToLoopEvent
     , toolResultToItem
@@ -89,7 +98,76 @@ openAiBackendReconnecting
     -> IORef [ResponseItem]
     -> Backend
 openAiBackendReconnecting provider currentCredential connectionHealthy conn =
-    openAiBackendWithConnectionRecovery connectionHealthy sendCurrent sendFresh
+    openAiBackendWith
+        (openAiResponseSenderReconnecting
+            provider
+            currentCredential
+            connectionHealthy
+            conn)
+
+-- | Send a Responses request through the active Codex WebSocket while it is
+-- healthy, with the same replay-safe fresh-connection recovery used by the
+-- normal model backend. Callers can reuse this for auxiliary model requests
+-- such as remote compaction without opening a separate REST session/account.
+openAiResponseSenderReconnecting
+    :: TokenProvider
+    -> Credential
+    -> IORef Bool
+    -> CodexConn
+    -> ResponseCreateParams
+    -> Maybe Text
+    -> (ResponseStreamEvent -> IO ())
+    -> IO (Either ApiError Response)
+openAiResponseSenderReconnecting =
+    openAiResponseSenderReconnectingWhen
+        (isJust . streamEventToLoopEvent)
+        markLoopReplayUnsafe
+
+-- | Auxiliary Responses requests are not rendered to the loop, so their
+-- replay boundary also includes completed output items such as an opaque
+-- compaction checkpoint. Replaying after one of those items arrived could
+-- bill the request twice even though no text delta was visible.
+openAiAuxiliaryResponseSenderReconnecting
+    :: TokenProvider
+    -> Credential
+    -> IORef Bool
+    -> CodexConn
+    -> ResponseCreateParams
+    -> Maybe Text
+    -> (ResponseStreamEvent -> IO ())
+    -> IO (Either ApiError Response)
+openAiAuxiliaryResponseSenderReconnecting provider currentCredential
+        connectionHealthy conn =
+    openAiResponseSenderWithRetryPolicy
+        transientStreamingResultPolicy
+        auxiliaryOutputObserved
+        (openAiResponseSenderReconnectingWhen
+            auxiliaryOutputObserved
+            markAuxiliaryReplayUnsafe
+            provider
+            currentCredential
+            connectionHealthy
+            conn)
+
+openAiResponseSenderReconnectingWhen
+    :: (ResponseStreamEvent -> Bool)
+    -> (ApiError -> ApiError)
+    -> TokenProvider
+    -> Credential
+    -> IORef Bool
+    -> CodexConn
+    -> ResponseCreateParams
+    -> Maybe Text
+    -> (ResponseStreamEvent -> IO ())
+    -> IO (Either ApiError Response)
+openAiResponseSenderReconnectingWhen observed markObservedFailure provider
+        currentCredential connectionHealthy conn =
+    openAiResponseSenderWithConnectionRecoveryUsing
+        observed
+        markObservedFailure
+        connectionHealthy
+        sendCurrent
+        sendFresh
   where
     sendCurrent request previousResponseId onEvent =
         sendWsRequestWithEvents conn request previousResponseId onEvent
@@ -106,7 +184,19 @@ openAiBackendReconnecting provider currentCredential connectionHealthy conn =
                 withCodexWsRetrying provider
                     (sendOnFresh request previousResponseId onEvent)
     sendOnFresh request previousResponseId onEvent freshConn _credential =
-        sendWsRequestWithEvents freshConn request previousResponseId onEvent
+        do
+            emittedOutput <- newIORef False
+            result <-
+                sendWsRequestWithEvents freshConn request previousResponseId
+                    \event -> do
+                        if observed event
+                            then writeIORef emittedOutput True
+                            else pure ()
+                        onEvent event
+            emitted <- readIORef emittedOutput
+            pure $ case result of
+                Left err | emitted -> Left (markObservedFailure err)
+                _ -> result
 
 -- | Injectable connection recovery used by the reconnecting backend.
 openAiBackendWithConnectionRecovery
@@ -124,13 +214,101 @@ openAiBackendWithConnectionRecovery
     -> IORef [ResponseItem]
     -> Backend
 openAiBackendWithConnectionRecovery connectionHealthy sendCurrent sendFresh =
-    openAiBackendWith sendWithRecovery
+    openAiBackendWith $
+        openAiResponseSenderWithConnectionRecovery
+            connectionHealthy
+            sendCurrent
+            sendFresh
+
+openAiResponseSenderWithConnectionRecovery
+    :: IORef Bool
+    -> (ResponseCreateParams
+        -> Maybe Text
+        -> (ResponseStreamEvent -> IO ())
+        -> IO (Either ApiError Response))
+    -> (Maybe ApiError
+        -> ResponseCreateParams
+        -> Maybe Text
+        -> (ResponseStreamEvent -> IO ())
+        -> IO (Either ApiError Response))
+    -> ResponseCreateParams
+    -> Maybe Text
+    -> (ResponseStreamEvent -> IO ())
+    -> IO (Either ApiError Response)
+openAiResponseSenderWithConnectionRecovery =
+    openAiResponseSenderWithConnectionRecoveryUsing
+        (isJust . streamEventToLoopEvent)
+        markLoopReplayUnsafe
+
+openAiAuxiliaryResponseSenderWithConnectionRecovery
+    :: IORef Bool
+    -> (ResponseCreateParams
+        -> Maybe Text
+        -> (ResponseStreamEvent -> IO ())
+        -> IO (Either ApiError Response))
+    -> (Maybe ApiError
+        -> ResponseCreateParams
+        -> Maybe Text
+        -> (ResponseStreamEvent -> IO ())
+        -> IO (Either ApiError Response))
+    -> ResponseCreateParams
+    -> Maybe Text
+    -> (ResponseStreamEvent -> IO ())
+    -> IO (Either ApiError Response)
+openAiAuxiliaryResponseSenderWithConnectionRecovery =
+    openAiResponseSenderWithConnectionRecoveryUsing
+        auxiliaryOutputObserved
+        markAuxiliaryReplayUnsafe
+
+-- | Connection recovery with an explicit definition of when a request has
+-- produced enough output that replaying it is no longer safe.
+openAiResponseSenderWithConnectionRecoveryWhen
+    :: (ResponseStreamEvent -> Bool)
+    -> IORef Bool
+    -> (ResponseCreateParams
+        -> Maybe Text
+        -> (ResponseStreamEvent -> IO ())
+        -> IO (Either ApiError Response))
+    -> (Maybe ApiError
+        -> ResponseCreateParams
+        -> Maybe Text
+        -> (ResponseStreamEvent -> IO ())
+        -> IO (Either ApiError Response))
+    -> ResponseCreateParams
+    -> Maybe Text
+    -> (ResponseStreamEvent -> IO ())
+    -> IO (Either ApiError Response)
+openAiResponseSenderWithConnectionRecoveryWhen observed =
+    openAiResponseSenderWithConnectionRecoveryUsing
+        observed
+        markLoopReplayUnsafe
+
+openAiResponseSenderWithConnectionRecoveryUsing
+    :: (ResponseStreamEvent -> Bool)
+    -> (ApiError -> ApiError)
+    -> IORef Bool
+    -> (ResponseCreateParams
+        -> Maybe Text
+        -> (ResponseStreamEvent -> IO ())
+        -> IO (Either ApiError Response))
+    -> (Maybe ApiError
+        -> ResponseCreateParams
+        -> Maybe Text
+        -> (ResponseStreamEvent -> IO ())
+        -> IO (Either ApiError Response))
+    -> ResponseCreateParams
+    -> Maybe Text
+    -> (ResponseStreamEvent -> IO ())
+    -> IO (Either ApiError Response)
+openAiResponseSenderWithConnectionRecoveryUsing observed markObservedFailure
+        connectionHealthy sendCurrent sendFresh =
+    sendWithRecovery
   where
     sendWithRecovery request previousResponseId onEvent = do
         healthy <- readIORef connectionHealthy
         if healthy
             then tryCurrent request previousResponseId onEvent
-            else sendFresh Nothing request previousResponseId onEvent
+            else sendFreshTracked Nothing request previousResponseId onEvent
 
     tryCurrent request previousResponseId onEvent = do
         emittedLoopEvent <- newIORef False
@@ -138,17 +316,36 @@ openAiBackendWithConnectionRecovery connectionHealthy sendCurrent sendFresh =
             (trackOutput emittedLoopEvent onEvent)
             `onException` writeIORef connectionHealthy False
         case result of
-            Left err
-                | isDeadConnectionOrAccount err -> do
-                    writeIORef connectionHealthy False
-                    emitted <- readIORef emittedLoopEvent
-                    if emitted
-                        then pure result
-                        else sendFresh (Just err) request previousResponseId onEvent
+            Left err -> do
+                let deadConnectionOrAccount =
+                        isDeadConnectionOrAccount err
+                if deadConnectionOrAccount
+                    then writeIORef connectionHealthy False
+                    else pure ()
+                emitted <- readIORef emittedLoopEvent
+                if emitted
+                    then pure (Left (markObservedFailure err))
+                    else if deadConnectionOrAccount
+                        then sendFreshTracked
+                            (Just err)
+                            request
+                            previousResponseId
+                            onEvent
+                        else pure result
             _ -> pure result
 
+    sendFreshTracked previousFailure request previousResponseId onEvent = do
+        emittedOutput <- newIORef False
+        result <-
+            sendFresh previousFailure request previousResponseId
+                (trackOutput emittedOutput onEvent)
+        emitted <- readIORef emittedOutput
+        pure $ case result of
+            Left err | emitted -> Left (markObservedFailure err)
+            _ -> result
+
     trackOutput emittedLoopEvent onEvent event = do
-        if isJust (streamEventToLoopEvent event)
+        if observed event
             then writeIORef emittedLoopEvent True
             else pure ()
         onEvent event
@@ -157,6 +354,80 @@ openAiBackendWithConnectionRecovery connectionHealthy sendCurrent sendFresh =
         ConnectionError {} -> True
         ProviderError WebSocketConnectionLimitReached _ _ -> True
         err -> isJust (accountFailureFromApiError err)
+
+-- | Retry transient provider responses only while a request has produced no
+-- output that would make replay unsafe.
+openAiResponseSenderWithRetryPolicy
+    :: RetryPolicyM IO
+    -> (ResponseStreamEvent -> Bool)
+    -> (ResponseCreateParams
+        -> Maybe Text
+        -> (ResponseStreamEvent -> IO ())
+        -> IO (Either ApiError Response))
+    -> ResponseCreateParams
+    -> Maybe Text
+    -> (ResponseStreamEvent -> IO ())
+    -> IO (Either ApiError Response)
+openAiResponseSenderWithRetryPolicy retryPolicy observed send
+        request previousResponseId onEvent = do
+    emittedOutput <- newIORef False
+    go emittedOutput defaultRetryStatus
+  where
+    go emittedOutput retryStatus = do
+        result <- send request previousResponseId \event -> do
+            if observed event
+                then writeIORef emittedOutput True
+                else pure ()
+            onEvent event
+        emitted <- readIORef emittedOutput
+        case result of
+            Left apiError
+                | not emitted
+                , isInlineRetryableProviderError apiError ->
+                    applyPolicy retryPolicy retryStatus >>= \case
+                        Nothing -> pure result
+                        Just nextStatus -> do
+                            threadDelay
+                                (fromMaybe 0 nextStatus.rsPreviousDelay)
+                            go emittedOutput nextStatus
+            _ -> pure result
+
+auxiliaryOutputObserved :: ResponseStreamEvent -> Bool
+auxiliaryOutputObserved = \case
+    ResponseCompletedEvent{} -> True
+    ResponseFailedEvent{response} -> not (null response.output)
+    ResponseIncompleteEvent{} -> True
+    ResponseOutputItemAddedEvent{} -> True
+    ResponseOutputItemDoneEvent{} -> True
+    event -> isJust (streamEventToLoopEvent event)
+
+markLoopReplayUnsafe :: ApiError -> ApiError
+markLoopReplayUnsafe err
+    | isJust (accountFailureFromApiError err) =
+        replayUnsafeError "model output" err
+    | otherwise = err
+
+markAuxiliaryReplayUnsafe :: ApiError -> ApiError
+markAuxiliaryReplayUnsafe =
+    replayUnsafeError "auxiliary response output"
+
+replayUnsafeError :: Text -> ApiError -> ApiError
+replayUnsafeError outputLabel err =
+    if isReplayUnsafeError err
+        then err
+        else ProviderError (UnknownErrorType "replay_unsafe")
+            ( "provider failed after "
+                <> outputLabel
+                <> "; refusing to replay: "
+                <> Text.pack (show err)
+            )
+            Nothing
+
+isReplayUnsafeError :: ApiError -> Bool
+isReplayUnsafeError = \case
+    ProviderError (UnknownErrorType errorType) _ _ ->
+        errorType == "replay_unsafe"
+    _ -> False
 
 -- | Prefer a WebSocket backend, then switch this agent session permanently to
 -- a fallback transport when the socket dies before exposing model output.

--- a/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
@@ -1,6 +1,10 @@
 module Agent.OpenAI.LoopBackendSpec (spec) where
 
-import Agent.Error (ApiError(..), ErrorType(..))
+import Agent.Error
+    ( ApiError(..)
+    , ErrorType(..)
+    , isInlineRetryableProviderError
+    )
 import Agent.InterAgentMessage
 import Agent.Loop
 import Agent.OpenAI.LoopBackend
@@ -12,6 +16,7 @@ import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KeyMap
 import Data.IORef
 import Data.Text (Text)
+import qualified Data.Text as Text
 import Test.Hspec
 
 spec :: Spec
@@ -442,6 +447,197 @@ spec = do
             reverse observedEvents `shouldBe` [TextDelta "partial"]
 
     describe "openAiBackendWithConnectionRecovery" do
+        it "keeps auxiliary requests on the healthy reusable connection" do
+            currentCalls <- newIORef (0 :: Int)
+            freshCalls <- newIORef (0 :: Int)
+            healthy <- newIORef True
+            let response = testResponse "resp-current" [assistantItem "ok"]
+                sendCurrent _request _previous _onEvent = do
+                    modifyIORef' currentCalls (+ 1)
+                    pure (Right response)
+                sendFresh _failure _request _previous _onEvent = do
+                    modifyIORef' freshCalls (+ 1)
+                    pure (Right (testResponse "resp-fresh" [assistantItem "no"]))
+                sender =
+                    openAiAuxiliaryResponseSenderWithConnectionRecovery
+                        healthy
+                        sendCurrent
+                        sendFresh
+            sender baseParams Nothing (const (pure ()))
+                `shouldReturn` Right response
+            readIORef healthy `shouldReturn` True
+            readIORef currentCalls `shouldReturn` 1
+            readIORef freshCalls `shouldReturn` 0
+
+        it "exposes the same current/fresh recovery to auxiliary requests" do
+            currentCalls <- newIORef (0 :: Int)
+            freshCalls <- newIORef (0 :: Int)
+            failures <- newIORef []
+            healthy <- newIORef True
+            let connectionFailure = ConnectionError "socket closed"
+            let sendCurrent _request _previous _onEvent = do
+                    modifyIORef' currentCalls (+ 1)
+                    pure (Left connectionFailure)
+                sendFresh failure _request _previous _onEvent = do
+                    modifyIORef' freshCalls (+ 1)
+                    modifyIORef' failures (<> [failure])
+                    pure $ Right (testResponse "resp-fresh" [assistantItem "ok"])
+                sender =
+                    openAiAuxiliaryResponseSenderWithConnectionRecovery
+                        healthy
+                        sendCurrent
+                        sendFresh
+            first <- sender baseParams Nothing (const (pure ()))
+            second <- sender baseParams Nothing (const (pure ()))
+            first `shouldBe`
+                Right (testResponse "resp-fresh" [assistantItem "ok"])
+            second `shouldBe`
+                Right (testResponse "resp-fresh" [assistantItem "ok"])
+            readIORef healthy `shouldReturn` False
+            readIORef currentCalls `shouldReturn` 1
+            readIORef freshCalls `shouldReturn` 2
+            readIORef failures `shouldReturn`
+                [Just connectionFailure, Nothing]
+
+        it "does not replay auxiliary requests after an output item arrived" do
+            freshCalls <- newIORef (0 :: Int)
+            healthy <- newIORef True
+            let connectionFailure = ConnectionError "socket closed"
+                outputEvent = ResponseOutputItemDoneEvent
+                    { item = assistantItem "partial"
+                    , outputIndex = 0
+                    , sequenceNumber = Nothing
+                    , eventExtraFields = KeyMap.empty
+                    }
+                sendCurrent _request _previous onEvent = do
+                    onEvent outputEvent
+                    pure (Left connectionFailure)
+                sendFresh _failure _request _previous _onEvent = do
+                    modifyIORef' freshCalls (+ 1)
+                    pure $ Right (testResponse "resp-fresh" [assistantItem "ok"])
+                sender =
+                    openAiAuxiliaryResponseSenderWithConnectionRecovery
+                        healthy
+                        sendCurrent
+                        sendFresh
+            sender baseParams Nothing (const (pure ()))
+                `shouldReturn` Left
+                    (replayUnsafeAuxiliaryFailure connectionFailure)
+            readIORef healthy `shouldReturn` False
+            readIORef freshCalls `shouldReturn` 0
+
+        it "does not replay after a terminal auxiliary response arrived" do
+            freshCalls <- newIORef (0 :: Int)
+            healthy <- newIORef True
+            let connectionFailure = ConnectionError "decode failed"
+                completedEvent = ResponseCompletedEvent
+                    { response =
+                        testResponse "resp-completed" [assistantItem "done"]
+                    , sequenceNumber = Nothing
+                    , eventExtraFields = KeyMap.empty
+                    }
+                sendCurrent _request _previous onEvent = do
+                    onEvent completedEvent
+                    pure (Left connectionFailure)
+                sendFresh _failure _request _previous _onEvent = do
+                    modifyIORef' freshCalls (+ 1)
+                    pure $ Right
+                        (testResponse "resp-fresh" [assistantItem "duplicate"])
+                sender =
+                    openAiAuxiliaryResponseSenderWithConnectionRecovery
+                        healthy
+                        sendCurrent
+                        sendFresh
+            sender baseParams Nothing (const (pure ()))
+                `shouldReturn` Left
+                    (replayUnsafeAuxiliaryFailure connectionFailure)
+            readIORef freshCalls `shouldReturn` 0
+
+        it "does not replay a failed auxiliary response with partial output" do
+            freshCalls <- newIORef (0 :: Int)
+            healthy <- newIORef True
+            let connectionFailure = ConnectionError "failed response"
+                failedEvent = ResponseFailedEvent
+                    { response =
+                        testResponse "resp-failed" [assistantItem "partial"]
+                    , sequenceNumber = Nothing
+                    , eventExtraFields = KeyMap.empty
+                    }
+                sendCurrent _request _previous onEvent = do
+                    onEvent failedEvent
+                    pure (Left connectionFailure)
+                sendFresh _failure _request _previous _onEvent = do
+                    modifyIORef' freshCalls (+ 1)
+                    pure $ Right
+                        (testResponse "resp-fresh" [assistantItem "duplicate"])
+                sender =
+                    openAiAuxiliaryResponseSenderWithConnectionRecovery
+                        healthy
+                        sendCurrent
+                        sendFresh
+            sender baseParams Nothing (const (pure ()))
+                `shouldReturn` Left
+                    (replayUnsafeAuxiliaryFailure connectionFailure)
+            readIORef freshCalls `shouldReturn` 0
+
+        it "marks output from an initially fresh auxiliary connection as replay-unsafe" do
+            currentCalls <- newIORef (0 :: Int)
+            freshCalls <- newIORef (0 :: Int)
+            healthy <- newIORef False
+            let connectionFailure = ConnectionError "fresh socket closed"
+                outputEvent = ResponseOutputItemDoneEvent
+                    { item = assistantItem "partial"
+                    , outputIndex = 0
+                    , sequenceNumber = Nothing
+                    , eventExtraFields = KeyMap.empty
+                    }
+                sendCurrent _request _previous _onEvent = do
+                    modifyIORef' currentCalls (+ 1)
+                    pure (Left (ConnectionError "unexpected current request"))
+                sendFresh _failure _request _previous onEvent = do
+                    modifyIORef' freshCalls (+ 1)
+                    onEvent outputEvent
+                    pure (Left connectionFailure)
+                sender =
+                    openAiAuxiliaryResponseSenderWithConnectionRecovery
+                        healthy
+                        sendCurrent
+                        sendFresh
+            sender baseParams Nothing (const (pure ()))
+                `shouldReturn` Left
+                    (replayUnsafeAuxiliaryFailure connectionFailure)
+            readIORef currentCalls `shouldReturn` 0
+            readIORef freshCalls `shouldReturn` 1
+
+        it "marks fresh auxiliary output after a pre-output current failure" do
+            freshCalls <- newIORef (0 :: Int)
+            healthy <- newIORef True
+            let currentFailure = ConnectionError "current socket closed"
+                freshFailure = ConnectionError "fresh socket closed"
+                outputEvent = ResponseOutputItemDoneEvent
+                    { item = assistantItem "partial"
+                    , outputIndex = 0
+                    , sequenceNumber = Nothing
+                    , eventExtraFields = KeyMap.empty
+                    }
+                sendCurrent _request _previous _onEvent =
+                    pure (Left currentFailure)
+                sendFresh failure _request _previous onEvent = do
+                    failure `shouldBe` Just currentFailure
+                    modifyIORef' freshCalls (+ 1)
+                    onEvent outputEvent
+                    pure (Left freshFailure)
+                sender =
+                    openAiAuxiliaryResponseSenderWithConnectionRecovery
+                        healthy
+                        sendCurrent
+                        sendFresh
+            sender baseParams Nothing (const (pure ()))
+                `shouldReturn` Left
+                    (replayUnsafeAuxiliaryFailure freshFailure)
+            readIORef healthy `shouldReturn` False
+            readIORef freshCalls `shouldReturn` 1
+
         it "replays on a fresh connection when the reusable socket dies before output" do
             currentCalls <- newIORef (0 :: Int)
             freshCalls <- newIORef (0 :: Int)
@@ -573,6 +769,45 @@ spec = do
                         <> turnInputsToItems [UserMessage "new"]
                   , Nothing
                   )
+                ]
+
+    describe "openAiResponseSenderWithRetryPolicy" do
+        it "retries a pre-output fresh connection failure" $
+            shouldRetryFreshAuxiliaryFailure
+                (ConnectionError "fresh socket closed")
+
+        it "retries a pre-output fresh websocket-limit failure" $
+            shouldRetryFreshAuxiliaryFailure
+                (ProviderError WebSocketConnectionLimitReached
+                    "too many websocket connections"
+                    Nothing)
+
+        it "returns the final pre-output failure after exhausting retries" do
+            attempts <- newIORef (0 :: Int)
+            let failure = ConnectionError "still offline"
+                send _request _previous _onEvent = do
+                    modifyIORef' attempts (+ 1)
+                    pure (Left failure)
+                sender =
+                    openAiResponseSenderWithRetryPolicy
+                        (constantDelay 0 <> limitRetries 1)
+                        isAuxiliaryOutputEvent
+                        send
+            sender baseParams Nothing (const (pure ()))
+                `shouldReturn` Left failure
+            readIORef attempts `shouldReturn` 2
+
+        it "marks every post-output auxiliary failure as non-retryable" do
+            mapM_ shouldMarkPostOutputAuxiliaryFailure
+                [ ConnectionError "socket closed"
+                , ProviderError WebSocketConnectionLimitReached
+                    "too many websocket connections"
+                    Nothing
+                , ProviderError OverloadedError "busy" Nothing
+                , ProviderError ServiceUnavailableError "unavailable" Nothing
+                , ProviderError ApiErrorType "server error" Nothing
+                , ProviderError UsageLimitReached "usage exhausted" (Just 120)
+                , HttpError 503 "unavailable"
                 ]
 
     describe "openAiBackendWithTransportFallback" do
@@ -818,3 +1053,82 @@ inputItems :: ResponseCreateParams -> [ResponseItem]
 inputItems request = case request.input of
     Just (ResponseInputItems items) -> items
     _ -> []
+
+shouldRetryFreshAuxiliaryFailure :: ApiError -> Expectation
+shouldRetryFreshAuxiliaryFailure initialFailure = do
+    healthy <- newIORef False
+    currentCalls <- newIORef (0 :: Int)
+    freshCalls <- newIORef (0 :: Int)
+    let response = testResponse "resp-retried" [assistantItem "ok"]
+        sendCurrent _request _previous _onEvent = do
+            modifyIORef' currentCalls (+ 1)
+            pure (Left (ConnectionError "unexpected reusable request"))
+        sendFresh _failure _request _previous _onEvent = do
+            attempt <- atomicModifyIORef' freshCalls \count ->
+                let next = count + 1
+                in (next, next)
+            pure $
+                if attempt == 1
+                    then Left initialFailure
+                    else Right response
+        reconnecting =
+            openAiAuxiliaryResponseSenderWithConnectionRecovery
+                healthy
+                sendCurrent
+                sendFresh
+        sender =
+            openAiResponseSenderWithRetryPolicy
+                (constantDelay 0 <> limitRetries 1)
+                isAuxiliaryOutputEvent
+                reconnecting
+    sender baseParams Nothing (const (pure ()))
+        `shouldReturn` Right response
+    readIORef currentCalls `shouldReturn` 0
+    readIORef freshCalls `shouldReturn` 2
+
+shouldMarkPostOutputAuxiliaryFailure :: ApiError -> Expectation
+shouldMarkPostOutputAuxiliaryFailure failure = do
+    healthy <- newIORef True
+    currentCalls <- newIORef (0 :: Int)
+    freshCalls <- newIORef (0 :: Int)
+    let outputEvent = ResponseOutputItemDoneEvent
+            { item = assistantItem "partial"
+            , outputIndex = 0
+            , sequenceNumber = Nothing
+            , eventExtraFields = KeyMap.empty
+            }
+        sendCurrent _request _previous onEvent = do
+            modifyIORef' currentCalls (+ 1)
+            onEvent outputEvent
+            pure (Left failure)
+        sendFresh _failure _request _previous _onEvent = do
+            modifyIORef' freshCalls (+ 1)
+            pure $ Right (testResponse "resp-fresh" [assistantItem "duplicate"])
+        sender =
+            openAiAuxiliaryResponseSenderWithConnectionRecovery
+                healthy
+                sendCurrent
+                sendFresh
+        expected = replayUnsafeAuxiliaryFailure failure
+    sender baseParams Nothing (const (pure ()))
+        `shouldReturn` Left expected
+    isInlineRetryableProviderError expected `shouldBe` False
+    readIORef currentCalls `shouldReturn` 1
+    readIORef freshCalls `shouldReturn` 0
+
+isAuxiliaryOutputEvent :: ResponseStreamEvent -> Bool
+isAuxiliaryOutputEvent = \case
+    ResponseCompletedEvent{} -> True
+    ResponseFailedEvent{response} -> not (null response.output)
+    ResponseIncompleteEvent{} -> True
+    ResponseOutputItemAddedEvent{} -> True
+    ResponseOutputItemDoneEvent{} -> True
+    _ -> False
+
+replayUnsafeAuxiliaryFailure :: ApiError -> ApiError
+replayUnsafeAuxiliaryFailure failure =
+    ProviderError (UnknownErrorType "replay_unsafe")
+        ( "provider failed after auxiliary response output; refusing to replay: "
+            <> Text.pack (show failure)
+        )
+        Nothing

--- a/packages/agent-responses/src/Agent/Responses/LoopBackend.hs
+++ b/packages/agent-responses/src/Agent/Responses/LoopBackend.hs
@@ -4,6 +4,7 @@ module Agent.Responses.LoopBackend
     , tokenProviderStatelessResponsesBackend
     , turnInputsToItems
     , responseToTurnOutput
+    , responseTokenUsage
     , streamEventToLoopEvent
     , assistantTextFromResponse
     , toolResultToItem
@@ -230,8 +231,12 @@ responseToTurnOutput response = TurnOutput
     { responseId = response.responseId
     , toolCalls = mapMaybe responseItemToToolCall response.output
     , assistantText = assistantTextFromResponse response
-    , tokenUsage = tokenUsageFromResponse response.usage
+    , tokenUsage = responseTokenUsage response
     }
+
+responseTokenUsage :: Response -> TokenUsage
+responseTokenUsage response =
+    tokenUsageFromResponse response.usage
 
 tokenUsageFromResponse :: Maybe ResponseUsage -> TokenUsage
 tokenUsageFromResponse = maybe emptyTokenUsage \usage ->


### PR DESCRIPTION
## Summary
- route manual and automatic OpenAI compaction through the active WebSocket session
- keep replay-safe recovery and retry semantics across current and replacement credentials
- record compaction usage separately in session metadata and restore context state safely

## Tests
- `cabal test agent-responses-test agent-openai-test agent-cli-test --test-show-details=never`
- `cabal build all`
- tmux smoke with GPT-5.6 Luna and `--compact-threshold 2000`
  - automatic compaction displayed `Compacting context…`, persisted a checkpoint, and returned `AUTO_COMPACT_OK`
  - manual `/compact` succeeded (`447 → 442 tokens`), cleared persisted `lastResponseId`, and recorded auxiliary usage without a synthetic turn charge
  - a post-compaction turn returned `MANUAL_ACTIVE_OK`
