### PR TITLE
Document Nix quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 A universal coding-agent harness written in Haskell.
 
+## Quick start
+
+With [Nix](https://nixos.org/download/) installed, run the agent directly from
+GitHub:
+
+```console
+nix run github:digitallyinduced/haskell-agent
+```
+
 ## Packages
 
 - `agent-cli` is the command-line entry point (`-p` for one-shot, otherwise a REPL).


### PR DESCRIPTION
## Summary

- add a prominent quick-start section to the README
- document the one-line `nix run github:digitallyinduced/haskell-agent` command
- link to the Nix installer

## Testing

- launched the exact command in a fresh tmux session
- confirmed the interactive agent TUI opened successfully
- exited cleanly with Ctrl-D