### PR TITLE
feat(tui): add semantic motion system

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,12 @@ OpenAI sessions compact automatically at the selected model's default context
 threshold. Pass `--compact-threshold N` to override it in estimated tokens, for
 example `--model gpt-5.6-luna --compact-threshold 120000`.
 
+Terminal animation is controlled independently of color with
+`--motion full|reduced|off`. `reduced` keeps stable semantic glyphs with
+coarser elapsed-time updates; `off` removes cosmetic animation and retains only
+one-second semantic timer refreshes. Terminal-native indeterminate progress is
+also disabled outside full-motion mode.
+
 Ghostty receives native progress, notifications, semantic turn boundaries,
 working-directory updates, inline images, synchronized picker redraws, and
 terminal clipboard support. See `docs/ghostty.md`; run `/terminal` inside the

--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -234,6 +234,7 @@ import Agent.TUI.Model
     , initialUiState
     , reduceUi
     )
+import Agent.TUI.Motion (nativeProgressAnimationEnabled)
 import Agent.CLI.Turn (applyPendingSessionTitles, runOneTurn)
 import Agent.CLI.Usage
     ( AccountUsageLine(..)
@@ -769,11 +770,15 @@ runAgent fullscreenInputs options transition = do
             (copyTerminalClipboard terminal stdout)
             (setCliWindowTitle stdoutTty stdout)
             (\active ->
-                when terminal.terminalNativeProgress $
+                when
+                    (terminal.terminalNativeProgress
+                        && nativeProgressAnimationEnabled
+                            options.optMotionMode) $
                     setNativeProgress stderr active)
             (readIORef agentSnapshotRef >>= id)
             (\target -> readIORef agentSelectRef >>= ($ target))
             (recordStartupTiming startedAt startupTimingsRef "first frame")
+            options.optMotionMode
             useColor
             initialFullscreenState
         else pure Nothing
@@ -1537,7 +1542,11 @@ runSession options provider policy tools toolEnv planMode startup prompt pending
             -- Gate on the same TTY check as the in-pane spinner so pipes
             -- and redirected stderr stay clean.
             , renderNativeProgress =
-                stderrTty && terminal.terminalNativeProgress
+                stderrTty
+                    && terminal.terminalNativeProgress
+                    && nativeProgressAnimationEnabled
+                        options.optMotionMode
+            , renderMotionMode = options.optMotionMode
             }
         emitLoop event = case fullscreen of
             Nothing -> renderEvent render event
@@ -1977,7 +1986,14 @@ replWithDraft env@SessionEnv
             let next = cycleReplInteraction planState policy
             applyReplMode planMode policyRef projectRoot next
             case fullscreen of
-                Just _ -> pure ()
+                Just runtime ->
+                    emitUiEvent runtime $
+                        UiSetNotice $
+                            Just $
+                                infoNotice
+                                    ("Switched to "
+                                        <> replModeLabel next
+                                        <> " mode.")
                 Nothing -> do
                     -- Minimal editor advanced a line; replace its old chrome.
                     putStr "\ESC[2A\r\ESC[J"

--- a/packages/agent-cli/src/Agent/CLI/AgentViewport.hs
+++ b/packages/agent-cli/src/Agent/CLI/AgentViewport.hs
@@ -8,6 +8,7 @@ module Agent.CLI.AgentViewport
     , AgentViewportState(..)
     , agentDisplayName
     , agentEntryTreeLabel
+    , agentEntryTreeLabelWithGlyph
     , agentStatusGlyph
     , agentStepsForStatus
     , applyAgentViewportKey
@@ -627,10 +628,23 @@ findByTarget target = go
 
 agentEntryTreeLabel :: [AgentEntry] -> Int -> AgentEntry -> Text
 agentEntryTreeLabel entries index entry =
+    agentEntryTreeLabelWithGlyph
+        (agentStatusGlyph entry.agentStatus)
+        entries
+        index
+        entry
+
+agentEntryTreeLabelWithGlyph
+    :: Text
+    -> [AgentEntry]
+    -> Int
+    -> AgentEntry
+    -> Text
+agentEntryTreeLabelWithGlyph glyph entries index entry =
     treePrefix entries index entry.agentPath
         <> agentDisplayName entry.agentPath
         <> "  "
-        <> agentStatusGlyph entry.agentStatus
+        <> glyph
         <> " "
         <> entry.agentStatus
 

--- a/packages/agent-cli/src/Agent/CLI/Options.hs
+++ b/packages/agent-cli/src/Agent/CLI/Options.hs
@@ -18,6 +18,7 @@ module Agent.CLI.Options
 
 import System.OsPath (OsPath, unsafeEncodeUtf)
 import Agent.Provider (Provider(..), parseProvider)
+import Agent.TUI.Motion (MotionMode(..))
 import Data.Maybe (isJust)
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -81,6 +82,7 @@ data CliOptions = CliOptions
     , optSkills :: !Bool
       -- ^ Discover and expose filesystem skills (default: True).
     , optScreenMode :: !ScreenMode
+    , optMotionMode :: !MotionMode
     } deriving (Eq, Show)
 
 defaultCliOptions :: CliOptions
@@ -101,6 +103,7 @@ defaultCliOptions = CliOptions
     , optAgentsMd = True
     , optSkills = True
     , optScreenMode = ScreenAuto
+    , optMotionMode = MotionFull
     }
 
 -- | Provider default when @--effort@ is omitted. Grok runs at high effort.
@@ -199,6 +202,9 @@ parseOptions options = \case
         parseOptions options { optScreenMode = ScreenFullscreen } rest
     "--minimal" : rest ->
         parseOptions options { optScreenMode = ScreenMinimal } rest
+    "--motion" : value : rest -> do
+        motion <- parseMotionMode value
+        parseOptions options { optMotionMode = motion } rest
     flag : _
         | flag == "openai-base-url" ->
             Left "openai-base-url was removed; run agent-cli --help"
@@ -221,6 +227,13 @@ parseInt :: String -> String -> Either String Int
 parseInt flag value = case reads value of
     [(n, "")] | n >= 1 -> Right n
     _ -> Left (flag <> " expects a positive integer, got " <> value)
+
+parseMotionMode :: String -> Either String MotionMode
+parseMotionMode raw = case Text.toLower (Text.pack raw) of
+    "full" -> Right MotionFull
+    "reduced" -> Right MotionReduced
+    "off" -> Right MotionOff
+    _ -> Left ("--motion expects full, reduced, or off (got " <> raw <> ")")
 
 reasoningEfforts :: [Text]
 reasoningEfforts = ["none", "low", "medium", "high", "xhigh", "max"]
@@ -257,6 +270,7 @@ usage = unlines
     , "      --no-skills         Disable skill discovery and invocation"
     , "      --fullscreen        Use the retained full-screen TUI"
     , "      --minimal           Use terminal-native append-only rendering"
+    , "      --motion MODE       Animation policy: full, reduced, or off"
     , "      --yolo              Auto-approve every tool"
     , "      --no-yolo           Never auto-approve; deny mutating tools without a TTY"
     , "      --max-turns N       Stop after N model turns (default: 500)"

--- a/packages/agent-cli/src/Agent/CLI/Render.hs
+++ b/packages/agent-cli/src/Agent/CLI/Render.hs
@@ -65,7 +65,7 @@ import Agent.CLI.Style
     , roleToolPath
     , solarizedGreen
     , solarizedRed
-    , spinnerFrames
+    , motionGlyphSet
     , style
     )
 import Agent.JsonText (jsonTextField, jsonTextFieldDefault)
@@ -91,6 +91,15 @@ import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
 import qualified Data.Text.IO as Text
 import Data.Time.Clock (UTCTime, diffUTCTime, getCurrentTime)
+import Data.Word (Word64)
+import GHC.Clock (getMonotonicTimeNSec)
+import Agent.TUI.Motion
+    ( MotionDemand(..)
+    , MotionMode
+    , foregroundIndicator
+    , motionIntervalMicros
+    , nativeProgressAnimationEnabled
+    )
 import System.Console.ANSI (ConsoleLayer(..), SGR(..))
 import System.Environment (lookupEnv)
 import System.IO (Handle, hFlush)
@@ -115,6 +124,7 @@ data RenderConfig = RenderConfig
     , renderStartedAt :: !(IORef (Maybe UTCTime))
     , renderToolCalls :: !(IORef (Map.Map Text ToolCall))
     , renderNativeProgress :: !Bool -- ^ Ghostty / WT OSC 9;4; off in tests
+    , renderMotionMode :: !MotionMode
     }
 
 data MarkdownStreamState = MarkdownStreamState
@@ -151,7 +161,7 @@ renderEventUnlocked config = \case
         writeIORef config.renderActivityRef activity
         visible <- readIORef config.renderThinkingVisible
         if visible
-            then paintThinkingFrame config 0
+            then paintThinkingFrame config
             else if config.renderShowThinking
                 then startThinkingSpinnerUnlocked config
                 else putTextLn config.renderStderr (roleMuted config.renderColor activity)
@@ -185,7 +195,7 @@ renderEventUnlocked config = \case
         when config.renderShowThinking do
             visible <- readIORef config.renderThinkingVisible
             if visible
-                then paintThinkingFrame config 0
+                then paintThinkingFrame config
                 else startThinkingSpinnerUnlocked config
     -- The append-only renderer cannot safely repaint accumulated snapshots
     -- without duplicating output in terminal scrollback. The retained TUI
@@ -288,11 +298,12 @@ startThinkingSpinnerUnlocked config
         emitNativeProgress config True
         visible <- readIORef config.renderThinkingVisible
         if visible
-            then paintThinkingFrame config 0
+            then paintThinkingFrame config
             else do
                 writeIORef config.renderThinkingVisible True
-                paintThinkingFrame config 0
-                tid <- forkIO (spinnerLoop config 0)
+                paintThinkingFrame config
+                started <- getMonotonicTimeNSec
+                tid <- forkIO (spinnerLoop config started 0)
                 writeIORef config.renderThinkingSpinner (Just tid)
 
 -- | Stop the spinner and erase its in-place status line. Does not commit a
@@ -314,7 +325,9 @@ stopThinkingSpinnerUnlocked config = do
 -- Harmless no-op on terminals that do not implement OSC 9;4.
 emitNativeProgress :: RenderConfig -> Bool -> IO ()
 emitNativeProgress config active
-    | not config.renderNativeProgress = pure ()
+    | not config.renderNativeProgress
+        || not (nativeProgressAnimationEnabled config.renderMotionMode) =
+        pure ()
     | otherwise = do
         inTmux <- isJust <$> lookupEnv "TMUX"
         let seq_ =
@@ -324,27 +337,39 @@ emitNativeProgress config active
             Text.hPutStr config.renderStderr seq_
             hFlush config.renderStderr
 
-spinnerLoop :: RenderConfig -> Int -> IO ()
-spinnerLoop config frame = do
-    threadDelay 80000
+spinnerLoop :: RenderConfig -> Word64 -> Int -> IO ()
+spinnerLoop config startedAt lastKeepaliveBucket = do
+    threadDelay
+        (motionIntervalMicros config.renderMotionMode MotionFast)
     visible <- readIORef config.renderThinkingVisible
     when visible do
-        let frames = spinnerFrames
-            next = (frame + 1) `mod` length frames
+        now <- getMonotonicTimeNSec
+        let elapsedMillis =
+                fromIntegral ((now - startedAt) `div` 1000000)
+            keepaliveBucket = elapsedMillis `div` 5000
         withMVar config.renderLock \_ -> do
             still <- readIORef config.renderThinkingVisible
             when still do
                 -- Ghostty hides OSC 9;4 after ~15s without an update.
-                when (next == 0) (emitNativeProgress config True)
-                paintThinkingFrame config next
-        spinnerLoop config next
+                when (keepaliveBucket > lastKeepaliveBucket) $
+                    emitNativeProgress config True
+                paintThinkingFrameAt config (monotonicMillis now)
+        spinnerLoop config startedAt keepaliveBucket
 
-paintThinkingFrame :: RenderConfig -> Int -> IO ()
-paintThinkingFrame config frame = do
+paintThinkingFrame :: RenderConfig -> IO ()
+paintThinkingFrame config = do
+    now <- getMonotonicTimeNSec
+    paintThinkingFrameAt config (monotonicMillis now)
+
+paintThinkingFrameAt :: RenderConfig -> Int -> IO ()
+paintThinkingFrameAt config motionMillis = do
     activity <- readIORef config.renderActivityRef
     elapsed <- thinkingElapsed config
-    let frames = spinnerFrames
-        glyph = frames !! (frame `mod` length frames)
+    let glyph =
+            foregroundIndicator
+                motionGlyphSet
+                config.renderMotionMode
+                motionMillis
         line =
             formatActivityLine
                 config.renderColor
@@ -354,6 +379,10 @@ paintThinkingFrame config frame = do
     void $ tryIO do
         Text.hPutStr config.renderStderr ("\r\ESC[K" <> line)
         hFlush config.renderStderr
+
+monotonicMillis :: Word64 -> Int
+monotonicMillis now =
+    fromIntegral (now `div` 1000000)
 
 thinkingElapsed :: RenderConfig -> IO Double
 thinkingElapsed config = do

--- a/packages/agent-cli/src/Agent/CLI/Style.hs
+++ b/packages/agent-cli/src/Agent/CLI/Style.hs
@@ -32,6 +32,7 @@ module Agent.CLI.Style
     , glyphCancel
     , glyphSession
     , glyphThink
+    , motionGlyphSet
     , spinnerFrames
     , ColorLevel(..)
     , detectColorLevel
@@ -50,6 +51,10 @@ module Agent.CLI.Style
     , setCliWindowTitle
     ) where
 
+import Agent.TUI.Motion
+    ( MotionGlyphSet(..)
+    , foregroundSpinnerFrames
+    )
 import Data.Colour (Colour)
 import Data.Colour.SRGB (RGB(..), sRGB24, toSRGB24)
 import Data.Text (Text)
@@ -244,11 +249,12 @@ glyphSession = pickGlyph "⧉ " "# "
 glyphThink = pickGlyph "◆ " "* "
 
 spinnerFrames :: [Text]
-spinnerFrames
-    | supportsUnicodeChrome =
-        ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
-    | otherwise =
-        ["|", "/", "-", "\\"]
+spinnerFrames = foregroundSpinnerFrames motionGlyphSet
+
+motionGlyphSet :: MotionGlyphSet
+motionGlyphSet
+    | supportsUnicodeChrome = MotionUnicode
+    | otherwise = MotionAscii
 
 data ColorLevel = ColorNone | ColorBasic | Color256 | ColorTrue
     deriving (Eq, Ord, Show)

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -2,12 +2,18 @@
 module Agent.CLI.TUI.App
     ( FullscreenInputBuffer
     , FullscreenRuntime
+    , advanceCompletionFlashes
     , agentEntryWindow
     , agentPaneEntryLimit
     , agentPaneVisible
+    , completionFlashTransitions
     , conversationScrollbarRenderer
+    , elapsedMillisSince
     , emitUiEvent
     , hasQueuedFullscreenInput
+    , motionDemandFor
+    , nativeProgressKeepaliveDue
+    , nextMotionSchedule
     , newFullscreenInputBuffer
     , newFullscreenRuntime
     , queuedFullscreenInputDisplays
@@ -21,6 +27,7 @@ module Agent.CLI.TUI.App
     , fullscreenVtyConfig
     , setFullscreenImagePreviews
     , setFullscreenWindowTitle
+    , uiEventRestartsMotionSchedule
     , withFullscreenSuspended
     ) where
 
@@ -39,7 +46,8 @@ import Agent.CLI.AgentViewport
     , AgentStepState(..)
     , AgentTarget(..)
     , agentDisplayName
-    , agentEntryTreeLabel
+    , agentEntryTreeLabelWithGlyph
+    , agentStatusGlyph
     )
 import Agent.CLI.Interrupt (CtrlCDecision(..))
 import Agent.CLI.ImagePreview
@@ -54,6 +62,7 @@ import Agent.CLI.Command
     )
 import Agent.CLI.Permission (PermissionChoice(..))
 import Agent.CLI.Render (formatElapsed, summarizeToolCall)
+import Agent.CLI.Style (motionGlyphSet)
 import Agent.CLI.Status (formatTokenUsage)
 import Agent.CLI.Terminal (shiftEnterCsiBodies)
 import qualified Agent.TUI.Theme as Theme
@@ -77,6 +86,16 @@ import Agent.Syntax
 import qualified Agent.CLI.TUI.Scroll as Scroll
 import Agent.CLI.TUI.Types
 import Agent.TUI.Model
+import Agent.TUI.Motion
+    ( MotionDemand(..)
+    , MotionMode(..)
+    , backgroundIndicator
+    , completionFlashDurationMillis
+    , foregroundIndicator
+    , motionDelayMicros
+    , quietIndicator
+    , waitingIndicator
+    )
 import Agent.Loop (ImageAttachment(..), LoopEvent(..))
 import Agent.ToolDispatch (ToolCall(..))
 import Brick
@@ -94,11 +113,14 @@ import Control.Concurrent (threadDelay)
 import Control.Concurrent.STM
     ( STM
     , atomically
+    , check
     , newEmptyTMVarIO
     , newTVarIO
+    , orElse
     , putTMVar
     , readTVar
     , readTMVar
+    , registerDelay
     , retry
     , writeTVar
     )
@@ -116,6 +138,7 @@ import Data.IORef
     )
 import Data.List (find, findIndex, intersperse, sortOn)
 import Data.List.NonEmpty (NonEmpty(..))
+import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe, isJust, isNothing, mapMaybe)
 import Data.Sequence (Seq, ViewL(..), ViewR(..), (|>))
 import qualified Data.Sequence as Seq
@@ -123,6 +146,8 @@ import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
 import Data.Time.Clock.POSIX (getPOSIXTime)
+import Data.Word (Word64)
+import GHC.Clock (getMonotonicTimeNSec)
 import qualified Graphics.Vty as V
 import qualified Graphics.Vty.CrossPlatform as Vty
 import System.Environment (lookupEnv)
@@ -143,6 +168,7 @@ newFullscreenRuntime
     -> IO (AgentTarget, [AgentEntry])
     -> (AgentTarget -> IO ())
     -> IO ()
+    -> MotionMode
     -> Bool
     -> UiState
     -> IO FullscreenRuntime
@@ -157,11 +183,13 @@ newFullscreenRuntime
     agentSnapshot
     agentSelect
     firstFrame
+    motionMode
     color
     initial = do
         events <- newBChan 512
         mailbox <- AppEventMailbox <$> newTVarIO Seq.empty
-        running <- newIORef (uiNeedsTick initial)
+        motionSchedule <- newTVarIO (MotionNone, 1000000, 0)
+        motionTickQueued <- newTVarIO False
         imagePreviews <- newIORef []
         imagePreviewRevision <- newIORef 0
         imagePreviewVisible <- newIORef True
@@ -183,7 +211,9 @@ newFullscreenRuntime
             , runtimeAgentSnapshot = agentSnapshot
             , runtimeAgentSelect = agentSelect
             , runtimeFirstFrame = firstFrame
-            , runtimeRunning = running
+            , runtimeMotionSchedule = motionSchedule
+            , runtimeMotionTickQueued = motionTickQueued
+            , runtimeMotionMode = motionMode
             , runtimeImagePreviews = imagePreviews
             , runtimeImagePreviewRevision = imagePreviewRevision
             , runtimeImagePreviewVisible = imagePreviewVisible
@@ -316,6 +346,7 @@ runFullscreen :: FullscreenRuntime -> IO a -> IO a
 runFullscreen runtime workerAction = do
     history <- readReplHistory
     (initialAgent, initialAgents) <- runtime.runtimeAgentSnapshot
+    initialClock <- getMonotonicTimeNSec
     let buildVty = do
             vty <- Vty.mkVty fullscreenVtyConfig
             let output = V.outputIface vty
@@ -360,7 +391,18 @@ runFullscreen runtime workerAction = do
             , appConversationAnchor = Nothing
             , appConversationReflowQueued = False
             , appWindowTitle = Nothing
+            , appMotionElapsedMillis = 0
+            , appCompletionFlashes = Map.empty
+            , appMotionScheduleReset = False
+            , appClockNanos = initialClock
+            , appNativeProgressKeepaliveBucket = 0
             }
+        (initialDemand, initialDelay) =
+            appMotionTiming initialState
+    atomically $
+        writeTVar
+            runtime.runtimeMotionSchedule
+            (initialDemand, initialDelay, 0)
     withAsync workerAction \worker ->
         withAsync uiTicker \_uiTicker ->
             withAsync (agentTicker (initialAgent, initialAgents)) \_agentTicker ->
@@ -388,17 +430,39 @@ runFullscreen runtime workerAction = do
                                             }
                             wait worker
   where
-    uiTicker = loop (0 :: Int)
+    uiTicker = waitForDemand
       where
-        loop tick = do
-            threadDelay 50000
-            needsTick <- readIORef runtime.runtimeRunning
-            -- Model ticks remain at 10 Hz for elapsed time, completion
-            -- settling, and notice expiry. The empty-state renderer samples
-            -- every second frame for a calmer 5 FPS animation.
-            when (needsTick && tick `mod` 2 == 0) $
-                enqueueAppEvent runtime (AppUi UiTick)
-            loop ((tick + 1) `mod` 20)
+        waitForDemand = do
+            (demand, delayMicros, generation) <- atomically do
+                schedule@(current, _, _) <-
+                    readTVar runtime.runtimeMotionSchedule
+                if current == MotionNone then retry else pure schedule
+            tickActive demand delayMicros generation
+
+        tickActive demand delayMicros generation = do
+            timer <- registerDelay delayMicros
+            outcome <- atomically $
+                (do
+                    current <-
+                        readTVar runtime.runtimeMotionSchedule
+                    check (current /= (demand, delayMicros, generation))
+                    pure (Left current))
+                    `orElse`
+                (do
+                    ready <- readTVar timer
+                    check ready
+                    Right
+                        <$> readTVar runtime.runtimeMotionSchedule)
+            case outcome of
+                Left (MotionNone, _, _) ->
+                    waitForDemand
+                Left (active, nextDelay, nextGeneration) ->
+                    tickActive active nextDelay nextGeneration
+                Right (MotionNone, _, _) ->
+                    waitForDemand
+                Right (active, nextDelay, nextGeneration) -> do
+                    enqueueMotionTick runtime
+                    tickActive active nextDelay nextGeneration
 
     agentTicker previous = do
         threadDelay 500000
@@ -532,12 +596,144 @@ uiFrameDelayMicros = 16000
 uiFrameBatchLimit :: Int
 uiFrameBatchLimit = 256
 
+motionDemandFor
+    :: MotionMode
+    -> Bool
+    -- ^ A permission, question, or approval is waiting on the user.
+    -> Bool
+    -- ^ Background child-agent work remains.
+    -> Bool
+    -- ^ At least one completed block is still flashing.
+    -> UiState
+    -> MotionDemand
+motionDemandFor mode waitingForUser backgroundActive completionFlashing ui =
+    case mode of
+        MotionFull ->
+            maximum
+                [ semanticDemand
+                , if not waitingForUser && ui.uiRunning
+                    then MotionFast
+                    else MotionNone
+                , if waitingForUser
+                    then MotionSlow
+                    else MotionNone
+                , if not waitingForUser && progressNoticeActive ui
+                    then MotionFast
+                    else MotionNone
+                , if completionFlashing
+                    then MotionFast
+                    else MotionNone
+                , if backgroundActive
+                    || conversationIsEmpty ui
+                    then MotionSlow
+                    else MotionNone
+                ]
+        MotionReduced ->
+            maximum
+                [ semanticDemand
+                , if completionFlashing
+                    then MotionSlow
+                    else MotionNone
+                ]
+        MotionOff ->
+            semanticDemand
+  where
+    semanticDemand =
+        if uiNeedsTick ui then MotionSlow else MotionNone
+
+appMotionDemand :: AppState -> MotionDemand
+appMotionDemand state =
+    motionDemandFor
+        state.appRuntime.runtimeMotionMode
+        (userActionPending state)
+        (hasBackgroundActivity state.appAgentEntries)
+        (not (Map.null state.appCompletionFlashes))
+        state.appUi
+
+appMotionTiming :: AppState -> (MotionDemand, Int)
+appMotionTiming state =
+    ( demand
+    , motionDelayMicros
+        state.appRuntime.runtimeMotionMode
+        demand
+        (appNextDeadlineMillis state)
+    )
+  where
+    demand = appMotionDemand state
+
+appNextDeadlineMillis :: AppState -> Maybe Int
+appNextDeadlineMillis state =
+    minimumMaybe $
+        maybeToList (uiNextDeadlineMillis state.appUi)
+            <> Map.elems state.appCompletionFlashes
+  where
+    maybeToList = maybe [] pure
+    minimumMaybe [] = Nothing
+    minimumMaybe values = Just (minimum values)
+
+userActionPending :: AppState -> Bool
+userActionPending state =
+    isJust state.appTextPrompt
+        || isJust state.appChoice
+        || isJust state.appUi.uiPermission
+
+progressNoticeActive :: UiState -> Bool
+progressNoticeActive ui =
+    maybe False ((== NoticeProgress) . (.noticeKind)) ui.uiNotice
+
+hasBackgroundActivity :: [AgentEntry] -> Bool
+hasBackgroundActivity =
+    any isBackgroundAgentActive
+
+isBackgroundAgentActive :: AgentEntry -> Bool
+isBackgroundAgentActive entry =
+    entry.agentTarget /= AgentRoot
+        && Text.toLower entry.agentStatus `elem` ["pending", "running"]
+
+completionFlashTransitions :: UiState -> UiState -> [BlockId]
+completionFlashTransitions previous next =
+    [ block.blockId
+    | block <- toList next.uiBlocks
+    , Just oldBlock <- [Map.lookup block.blockId previousById]
+    , blockWasLive oldBlock.blockState
+    , block.blockState == BlockComplete
+    , block.blockKind
+        `elem` [BlockThinking, BlockTool, BlockShell, BlockEdit]
+    ]
+  where
+    previousById =
+        Map.fromList
+            [ (block.blockId, block)
+            | block <- toList previous.uiBlocks
+            ]
+    blockWasLive blockState =
+        blockState `elem` [BlockRunning, BlockStreaming]
+
+advanceCompletionFlashes
+    :: Int
+    -> Map.Map BlockId Int
+    -> Map.Map BlockId Int
+advanceCompletionFlashes rawElapsedMillis =
+    Map.mapMaybe \remaining ->
+        let next = remaining - max 0 rawElapsedMillis
+        in if next <= 0 then Nothing else Just next
+
 enqueueAppEvent :: FullscreenRuntime -> AppEvent -> IO ()
 enqueueAppEvent runtime event =
     atomically do
         let AppEventMailbox pendingRef = runtime.runtimeMailbox
         pending <- readTVar pendingRef
         writeTVar pendingRef (appendAppEvent event pending)
+
+enqueueMotionTick :: FullscreenRuntime -> IO ()
+enqueueMotionTick runtime =
+    atomically do
+        queued <- readTVar runtime.runtimeMotionTickQueued
+        unless queued do
+            writeTVar runtime.runtimeMotionTickQueued True
+            let AppEventMailbox pendingRef = runtime.runtimeMailbox
+            pending <- readTVar pendingRef
+            writeTVar pendingRef (appendAppEvent AppMotionTick pending)
 
 appendAppEvent :: AppEvent -> Seq PendingAppEvent -> Seq PendingAppEvent
 appendAppEvent event pending = case event of
@@ -577,6 +773,13 @@ appendExactAppEvent
     :: AppEvent
     -> Seq PendingAppEvent
     -> Seq PendingAppEvent
+appendExactAppEvent AppMotionTick pending
+    | any isPendingMotionTick pending =
+        pending
+  where
+    isPendingMotionTick = \case
+        PendingEvent AppMotionTick -> True
+        _ -> False
 appendExactAppEvent event pending =
     case (Seq.viewr pending, event) of
         ( rest :> PendingEvent (AppAgentSnapshot _ _)
@@ -677,11 +880,15 @@ confirmChoiceAt index = do
 activateControl :: Name -> EventM Name AppState ()
 activateControl = \case
     ComposerModel ->
-        Composer.handlePromptControlClick ReplChooseModel
+        Composer.handlePromptControlClick
+            applyLocalUiEventWith
+            ReplChooseModel
     ComposerEffort ->
-        Composer.handleEffortControlClick
+        Composer.handleEffortControlClick applyLocalUiEventWith
     ComposerMode ->
-        Composer.handlePromptControlClick ReplCycleMode
+        Composer.handlePromptControlClick
+            applyLocalUiEventWith
+            ReplCycleMode
     ChoiceRow index ->
         confirmChoiceAt index
     CodeCopy blockId codeIndex ->
@@ -706,31 +913,20 @@ copyCodeBlock blockId codeIndex = do
                 >>= fencedCodeBlock codeIndex . (.blockBody)
     case code of
         Nothing ->
-            modify' \current ->
-                current
-                    { appUi =
-                        reduceUi
-                            (UiSetNotice
-                                (Just
-                                    (warningNotice
-                                        "Code block is no longer available.")))
-                            current.appUi
-                    }
+            applyLocalUiEvent $
+                UiSetNotice $
+                    Just $
+                        warningNotice
+                            "Code block is no longer available."
         Just payload -> do
             copied <- liftIO (state.appRuntime.runtimeCopy payload)
-            modify' \current ->
-                current
-                    { appUi =
-                        reduceUi
-                            (UiSetNotice
-                                (Just
-                                    (if copied
-                                        then successNotice
-                                            "Copied code block."
-                                        else warningNotice
-                                            "Terminal clipboard is unavailable.")))
-                            current.appUi
-                    }
+            applyLocalUiEvent $
+                UiSetNotice $
+                    Just $
+                        if copied
+                            then successNotice "Copied code block."
+                            else warningNotice
+                                "Terminal clipboard is unavailable."
 
 resolveChoice :: Bool -> EventM Name AppState ()
 resolveChoice confirmed = do
@@ -747,6 +943,7 @@ resolveChoice confirmed = do
             { appChoice = Nothing
             , appChoiceReply = Nothing
             }
+    resumeNativeProgressIfRunning
 
 handleTextPromptKey :: V.Event -> EventM Name AppState ()
 handleTextPromptKey = \case
@@ -834,6 +1031,7 @@ resolveTextPrompt confirmed = do
             { appTextPrompt = Nothing
             , appTextReply = Nothing
             }
+    resumeNativeProgressIfRunning
 
 fullscreenApp :: App AppState AppEvent Name
 fullscreenApp = App
@@ -863,20 +1061,20 @@ drawApp state =
     in
     case (state.appTextPrompt, state.appChoice, state.appUi.uiPermission) of
         (Just prompt, _, _) ->
-            drawTextPrompt prompt : dimmedMainLayers
+            drawTextPrompt state prompt : dimmedMainLayers
         (Nothing, Just choice, _) ->
             drawChoice state choice : dimmedMainLayers
         (Nothing, Nothing, Just permission) ->
-            drawPermission permission : dimmedMainLayers
+            drawPermission state permission : dimmedMainLayers
         (Nothing, Nothing, Nothing) -> interactiveLayers
 
 drawMain :: AppState -> Widget Name
 drawMain state =
     withAttr Theme.baseAttr $
         vBox
-            [ drawHeader state.appUi
+            [ drawHeader state
             , drawWorkspace state
-            , drawNotice state.appUi
+            , drawNotice state
             , Composer.drawQueuedInputs state.appUi
             , Composer.drawSlashMenu state
             , drawFollowStatus state.appUi
@@ -964,6 +1162,7 @@ drawWorkspace state =
                                     hLimit agentPaneWidth $
                                         padLeft (Pad 1) $
                                             drawAgentPane
+                                                state
                                                 (agentPaneEntryLimit
                                                     context.availHeight)
                                                 state.appAgentSelected
@@ -978,7 +1177,7 @@ drawConversationPane state
         padLeftRight 2 $
             vBox
                 [ drawTranscript state
-                , drawEmptyConversation (state.appUi.uiFrame `div` 2)
+                , drawEmptyConversation state
                 ]
     | otherwise =
         withVScrollBarRenderer conversationScrollbarRenderer $
@@ -1025,12 +1224,13 @@ agentPaneEntryLimit availableHeight =
     max 1 (min 12 (availableHeight - 9))
 
 drawAgentPane
-    :: Int
+    :: AppState
+    -> Int
     -> AgentTarget
     -> Maybe AgentTarget
     -> [AgentEntry]
     -> Widget Name
-drawAgentPane entryLimit selected hovered entries =
+drawAgentPane state entryLimit selected hovered entries =
     clickable AgentPane $
         withAttr Theme.borderAttr $
             withBorderStyle unicodeRounded $
@@ -1078,8 +1278,22 @@ drawAgentPane entryLimit selected hovered entries =
                     findIndex ((== entry.agentTarget) . (.agentTarget)) ordered
             marker =
                 if entry.agentTarget == selected then "› " else "  "
+            statusGlyph
+                | isBackgroundAgentActive entry =
+                    quietIndicator
+                        motionGlyphSet
+                        state.appRuntime.runtimeMotionMode
+                        state.appMotionElapsedMillis
+                | otherwise =
+                    agentStatusGlyph entry.agentStatus
             row = hBox
-                [ txt (marker <> agentEntryTreeLabel ordered index entry)
+                [ txt
+                    (marker
+                        <> agentEntryTreeLabelWithGlyph
+                            statusGlyph
+                            ordered
+                            index
+                            entry)
                 , fill ' '
                 ]
             styled =
@@ -1100,7 +1314,7 @@ agentPopoverLayers state =
                 ((== hover.agentHoverTarget) . (.agentTarget))
                 state.appAgentEntries of
                 Nothing -> []
-                Just entry -> [positionAgentPopover hover entry]
+                Just entry -> [positionAgentPopover state hover entry]
 
 agentPopoverPreferredWidth :: Int
 agentPopoverPreferredWidth = 40
@@ -1114,8 +1328,8 @@ agentPopoverHeight = 9
 agentPopoverGap :: Int
 agentPopoverGap = 1
 
-positionAgentPopover :: AgentHover -> AgentEntry -> Widget Name
-positionAgentPopover hover entry =
+positionAgentPopover :: AppState -> AgentHover -> AgentEntry -> Widget Name
+positionAgentPopover state hover entry =
     Widget Fixed Fixed do
         context <- getContext
         let screenWidth = max 0 context.availWidth
@@ -1148,10 +1362,10 @@ positionAgentPopover hover entry =
             else
                 render $
                     translateBy (Location (x, y)) $
-                        drawAgentPopover placeLeft width height entry
+                        drawAgentPopover state placeLeft width height entry
 
-drawAgentPopover :: Bool -> Int -> Int -> AgentEntry -> Widget Name
-drawAgentPopover placeLeft width height entry =
+drawAgentPopover :: AppState -> Bool -> Int -> Int -> AgentEntry -> Widget Name
+drawAgentPopover state placeLeft width height entry =
     clickable (AgentPopover entry.agentTarget) surface
   where
     surface
@@ -1180,6 +1394,7 @@ drawAgentPopover placeLeft width height entry =
                                             (vLimit 1 (fill ' '))
                                             (map
                                                 (drawAgentStep
+                                                    state
                                                     (max 1 (width - 4)))
                                                 steps)
                                             <> [fill ' ']
@@ -1195,13 +1410,13 @@ drawAgentPopover placeLeft width height entry =
                 ]
             recent -> recent
 
-drawAgentStep :: Int -> AgentStep -> Widget Name
-drawAgentStep width step =
+drawAgentStep :: AppState -> Int -> AgentStep -> Widget Name
+drawAgentStep state width step =
     vLimit 2 $
         vBox
             [ hBox
                 [ withAttr (agentStepAttr step.agentStepState) $
-                    txt (agentStepGlyph step.agentStepState)
+                    txt (agentStepGlyph state step.agentStepState)
                 , txt " "
                 , withAttr Theme.assistantAttr $
                     txt
@@ -1219,9 +1434,13 @@ drawAgentStep width step =
                                 step.agentStepDetail))
             ]
 
-agentStepGlyph :: AgentStepState -> Text
-agentStepGlyph = \case
-    AgentStepRunning -> "●"
+agentStepGlyph :: AppState -> AgentStepState -> Text
+agentStepGlyph state = \case
+    AgentStepRunning ->
+        quietIndicator
+            motionGlyphSet
+            state.appRuntime.runtimeMotionMode
+            state.appMotionElapsedMillis
     AgentStepCompleted -> "✓"
     AgentStepFailed -> "✕"
     AgentStepInfo -> "◆"
@@ -1263,12 +1482,12 @@ agentEntryWindow count selected entries
                 (selectedIndex - count `div` 2)
                 (length entries - count)
 
-drawHeader :: UiState -> Widget Name
+drawHeader :: AppState -> Widget Name
 drawHeader state =
     withAttr Theme.headerAttr $
         padLeftRight 2 $
             hBox
-                [ hLimitPercent 68 (drawRepositoryHeader state)
+                [ hLimitPercent 68 (drawRepositoryHeader state.appUi)
                 , vLimit 1 (fill ' ')
                 , drawHeaderRight state
                 ]
@@ -1289,35 +1508,66 @@ repositoryHeaderText branch cwd =
     Text.intercalate "  " $
         filter (not . Text.null) [branch, cwd]
 
-drawHeaderRight :: UiState -> Widget Name
+drawHeaderRight :: AppState -> Widget Name
 drawHeaderRight state =
     hBox
-        [ withAttr activityAttr (txt activity)
+        [ activityWidget
         , withAttr Theme.mutedAttr (txt elapsed)
         , withAttr Theme.mutedAttr (txt usage)
         ]
   where
+    ui = state.appUi
+    waiting = userActionPending state
+    background = hasBackgroundActivity state.appAgentEntries
+    mode = state.appRuntime.runtimeMotionMode
+    motionMillis = state.appMotionElapsedMillis
+    activityWidget
+        | waiting =
+            hBox
+                [ withAttr (waitingIndicatorAttr state) $
+                    txt (waitingIndicator motionGlyphSet mode motionMillis)
+                , withAttr Theme.thinkingAttr (txt " Waiting for you")
+                ]
+        | otherwise =
+            withAttr activityAttr (txt activity)
     activityAttr
-        | state.uiRunning = Theme.thinkingAttr
-        | state.uiCompletionTicks > 0 = Theme.successAttr
+        | ui.uiRunning = Theme.thinkingAttr
+        | ui.uiCompletionRemainingMillis > 0 = Theme.successAttr
+        | background = Theme.toolAttr
         | otherwise = Theme.mutedAttr
-    activity =
-        (if state.uiRunning then spinnerFrame state.uiFrame <> " " else "")
-            <> state.uiActivity
+    activity
+        | ui.uiRunning =
+            foregroundIndicator motionGlyphSet mode motionMillis
+                <> " "
+                <> ui.uiActivity
+        | ui.uiCompletionRemainingMillis > 0 =
+            ui.uiActivity
+        | background =
+            backgroundIndicator motionGlyphSet mode motionMillis
+                <> " Background work"
+        | otherwise =
+            ui.uiActivity
     elapsed =
-        if state.uiRunning
+        if ui.uiRunning
             then " · "
                 <> formatElapsed
-                    (fromIntegral state.uiElapsedTenths / 10)
+                    (fromIntegral ui.uiElapsedMillis / 1000)
             else ""
-    formattedUsage = formatTokenUsage state.uiPrompt.promptUsage
+    formattedUsage = formatTokenUsage ui.uiPrompt.promptUsage
     usage =
         if Text.null formattedUsage then "" else " │ " <> formattedUsage
 
-spinnerFrame :: Int -> Text
-spinnerFrame frame =
-    ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
-        !! (frame `mod` 10)
+waitingIndicatorAttr :: AppState -> AttrName
+waitingIndicatorAttr state =
+    case waitingIndicator
+        motionGlyphSet
+        state.appRuntime.runtimeMotionMode
+        state.appMotionElapsedMillis of
+        "◇" -> Theme.waitingDimAttr
+        "." -> Theme.waitingDimAttr
+        "◈" -> Theme.waitingMidAttr
+        "*" -> Theme.waitingMidAttr
+        _ -> Theme.thinkingAttr
 
 drawTranscript :: AppState -> Widget Name
 drawTranscript state =
@@ -1366,9 +1616,16 @@ conversationReserveWidgets = \case
             ]
     _ -> []
 
-drawEmptyConversation :: Int -> Widget Name
-drawEmptyConversation frame =
+drawEmptyConversation :: AppState -> Widget Name
+drawEmptyConversation state =
     center (lambdaArtWidget frame)
+  where
+    frame
+        | userActionPending state = 0
+        | otherwise = case state.appRuntime.runtimeMotionMode of
+            MotionFull -> state.appMotionElapsedMillis `div` 160
+            MotionReduced -> 0
+            MotionOff -> 0
 
 data LambdaComposition = LambdaComposition
     { lambdaUpperHeight :: !Int
@@ -1645,20 +1902,20 @@ drawBlock state block =
                             (codeBlockHeader state block.blockId)
                             block.blockBody)
             BlockThinking ->
-                accentBlock Theme.thinkingAttr
-                    (blockStateGlyph ui block <> block.blockTitle)
+                accentBlock (thinkingBlockAttr state block)
+                    (blockStateGlyph state block <> block.blockTitle)
                     (visibleBody block)
             BlockTool ->
-                accentBlock (statusAttr block.blockState)
-                    (blockStateGlyph ui block <> block.blockTitle <> detailSuffix block)
+                accentBlock (statusAttr state block)
+                    (blockStateGlyph state block <> block.blockTitle <> detailSuffix block)
                     (visibleBody block)
             BlockShell ->
-                accentBlock (statusAttr block.blockState)
-                    (blockStateGlyph ui block <> block.blockTitle <> detailSuffix block)
+                accentBlock (statusAttr state block)
+                    (blockStateGlyph state block <> block.blockTitle <> detailSuffix block)
                     (visibleShellBody block)
             BlockEdit ->
-                accentBlock (statusAttr block.blockState)
-                    (blockStateGlyph ui block <> block.blockTitle <> detailSuffix block)
+                accentBlock (statusAttr state block)
+                    (blockStateGlyph state block <> block.blockTitle <> detailSuffix block)
                     (visibleBody block)
             BlockSystem ->
                 withAttr Theme.mutedAttr (txtWrap block.blockBody)
@@ -1679,7 +1936,7 @@ drawBlock state block =
                             (txt (if highlighted then "❯ " else "  "))
                         , framed
                         ]
-    in if cacheableBlock block
+    in if cacheableBlock state block
         then cached
             (ConversationBlockCache
                 block.blockId
@@ -1716,19 +1973,34 @@ codeCopyCacheState state blockId =
                     )
         _ -> Nothing
 
-cacheableBlock :: UiBlock -> Bool
-cacheableBlock block =
+cacheableBlock :: AppState -> UiBlock -> Bool
+cacheableBlock state block =
     block.blockState
         `notElem` [BlockStreaming, BlockRunning]
+        && not (blockFlashing state block)
 
-blockStateGlyph :: UiState -> UiBlock -> Text
+blockStateGlyph :: AppState -> UiBlock -> Text
 blockStateGlyph state block = case block.blockState of
-    BlockRunning -> spinnerFrame state.uiFrame <> " "
-    BlockStreaming -> spinnerFrame state.uiFrame <> " "
+    BlockRunning -> liveGlyph
+    BlockStreaming -> liveGlyph
     BlockComplete -> "✓ "
     BlockFailed -> "✗ "
     BlockDenied -> "⊘ "
     BlockCancelled -> "⊘ "
+  where
+    liveGlyph
+        | userActionPending state =
+            waitingIndicator
+                motionGlyphSet
+                MotionOff
+                state.appMotionElapsedMillis
+                <> " "
+        | otherwise =
+            foregroundIndicator
+                motionGlyphSet
+                state.appRuntime.runtimeMotionMode
+                state.appMotionElapsedMillis
+                <> " "
 
 accentBlock :: AttrName -> Text -> Text -> Widget Name
 accentBlock accent title body =
@@ -1769,29 +2041,54 @@ detailSuffix block
     | Text.null (Text.strip block.blockDetail) = ""
     | otherwise = "  " <> block.blockDetail
 
-statusAttr :: BlockState -> AttrName
-statusAttr state = case state of
-    BlockFailed -> Theme.errorAttr
-    BlockCancelled -> Theme.mutedAttr
-    BlockDenied -> Theme.errorAttr
-    BlockComplete -> Theme.successAttr
-    BlockRunning -> Theme.toolAttr
-    BlockStreaming -> Theme.thinkingAttr
+statusAttr :: AppState -> UiBlock -> AttrName
+statusAttr state block
+    | blockFlashing state block
+    , block.blockState == BlockComplete =
+        Theme.completionFlashAttr
+    | otherwise = case block.blockState of
+        BlockFailed -> Theme.errorAttr
+        BlockCancelled -> Theme.mutedAttr
+        BlockDenied -> Theme.errorAttr
+        BlockComplete -> Theme.successAttr
+        BlockRunning -> Theme.toolAttr
+        BlockStreaming -> Theme.thinkingAttr
 
-drawNotice :: UiState -> Widget Name
-drawNotice state = case state.uiNotice of
+thinkingBlockAttr :: AppState -> UiBlock -> AttrName
+thinkingBlockAttr state block
+    | blockFlashing state block
+    , block.blockState == BlockComplete =
+        Theme.completionFlashAttr
+    | otherwise =
+        Theme.thinkingAttr
+
+blockFlashing :: AppState -> UiBlock -> Bool
+blockFlashing state block =
+    Map.member block.blockId state.appCompletionFlashes
+
+drawNotice :: AppState -> Widget Name
+drawNotice state = case state.appUi.uiNotice of
     Nothing -> emptyWidget
     Just notice ->
-        let (attr, prefix) = noticePresentation state.uiFrame notice.noticeKind
+        let (attr, prefix) = noticePresentation state notice.noticeKind
         in withAttr attr $
             padLeftRight 2 (txtWrap (prefix <> notice.noticeText))
 
-noticePresentation :: Int -> NoticeKind -> (AttrName, Text)
-noticePresentation frame = \case
+noticePresentation :: AppState -> NoticeKind -> (AttrName, Text)
+noticePresentation state = \case
     NoticeInfo -> (Theme.footerAttr, "• ")
     NoticeSuccess -> (Theme.successAttr, "✓ ")
     NoticeWarning -> (Theme.thinkingAttr, "⚠ ")
-    NoticeProgress -> (Theme.thinkingAttr, spinnerFrame frame <> " ")
+    NoticeProgress ->
+        ( Theme.thinkingAttr
+        , foregroundIndicator
+            motionGlyphSet
+            (if userActionPending state
+                then MotionOff
+                else state.appRuntime.runtimeMotionMode)
+            state.appMotionElapsedMillis
+            <> " "
+        )
     NoticeError -> (Theme.errorAttr, "✗ ")
 
 drawFollowStatus :: UiState -> Widget Name
@@ -1825,13 +2122,14 @@ drawFooter state =
                         | otherwise ->
                             "Enter send  │  Shift+Enter newline  │  PgUp/PgDn or wheel scroll  │  Tab scrollback"
 
-drawPermission :: PermissionOverlay -> Widget Name
-drawPermission permission =
+drawPermission :: AppState -> PermissionOverlay -> Widget Name
+drawPermission state permission =
     centerLayer $
         hLimitPercent 78 $
             overrideAttr Border.borderAttr Theme.borderActiveAttr $
                 withBorderStyle unicodeRounded $
-                    borderWithLabel (txt " Permission ") $
+                    borderWithLabel
+                        (waitingOverlayLabel state "Permission") $
                         padAll 1 $
                             vBox
                                 [ txtWrap ("Allow " <> permission.permissionSummary <> "?")
@@ -1864,7 +2162,7 @@ drawChoice appState choice =
                 overrideAttr Border.borderAttr Theme.borderActiveAttr $
                     withBorderStyle unicodeRounded $
                         borderWithLabel
-                            (txt (" " <> choice.choiceTitle <> " ")) $
+                            (waitingOverlayLabel appState choice.choiceTitle) $
                             padAll 1 $
                                 vBox
                                     [ if Text.null (Text.strip choice.choiceBody)
@@ -1887,15 +2185,28 @@ drawChoice appState choice =
         max 0 (min choice.choiceIndex (max 0 (count - 14)))
     rows = take 14 (drop start choice.choiceRows)
 
-drawTextPrompt :: TextOverlay -> Widget Name
-drawTextPrompt prompt =
+waitingOverlayLabel :: AppState -> Text -> Widget Name
+waitingOverlayLabel state label =
+    hBox
+        [ txt " "
+        , withAttr (waitingIndicatorAttr state) $
+            txt
+                (waitingIndicator
+                    motionGlyphSet
+                    state.appRuntime.runtimeMotionMode
+                    state.appMotionElapsedMillis)
+        , txt (" " <> label <> " ")
+        ]
+
+drawTextPrompt :: AppState -> TextOverlay -> Widget Name
+drawTextPrompt state prompt =
     centerLayer $
         hLimitPercent 82 $
             vLimitPercent 78 $
                 overrideAttr Border.borderAttr Theme.borderAttr $
                     withBorderStyle unicodeRounded $
                         borderWithLabel
-                            (txt (" " <> prompt.textTitle <> " ")) $
+                            (waitingOverlayLabel state prompt.textTitle) $
                             padAll 1 $
                                 vBox
                                     [ if Text.null (Text.strip prompt.textBody)
@@ -1957,10 +2268,6 @@ handleUiEvents uiEvents = do
                 (initial, Nothing, False, False)
                 uiEvents
     put final
-    liftIO $
-        writeIORef
-            final.appRuntime.runtimeRunning
-            (uiNeedsTick final.appUi)
     case nativeProgress of
         Nothing -> pure ()
         Just active ->
@@ -1974,13 +2281,6 @@ handleUiEvents uiEvents = do
                 queueConversationReflow
             Nothing ->
                 vScrollToEnd (viewportScroll ConversationViewport)
-    -- An idle tick is the only batch that can leave the presentation
-    -- unchanged. Avoid comparing complete 'UiState' values here: that walks
-    -- the full conversation, including large streamed block bodies, on every
-    -- animation tick.
-    when
-        (all (== UiTick) uiEvents && not (uiNeedsTick initial.appUi))
-        continueWithoutRedraw
   where
     applyOne
         renderedContentHeight
@@ -1994,7 +2294,10 @@ handleUiEvents uiEvents = do
                             uiEvent
                             state
                 progress =
-                    case Bridge.nativeProgressSignal uiEvent next.appUi of
+                    case Bridge.nativeProgressSignal
+                        (userActionPending next)
+                        uiEvent
+                        next.appUi of
                         Nothing -> previousProgress
                         signal -> signal
                 follows =
@@ -2028,11 +2331,173 @@ applyConversationUiEvent renderedContentHeight uiEvent state =
 
 applyUiEvent :: UiEvent -> AppState -> AppState
 applyUiEvent uiEvent state =
-    Composer.applyComposerUiEvent uiEvent $
-        state { appUi = reduceUi uiEvent state.appUi }
+    let
+        previousUi = state.appUi
+        nextUi = reduceUi uiEvent previousUi
+        retainedFlashes =
+            case uiEvent of
+                UiConversationCleared ->
+                    Map.empty
+                UiTurnRestarted ->
+                    retainExistingFlashes
+                        nextUi
+                        state.appCompletionFlashes
+                _ ->
+                    state.appCompletionFlashes
+        transitionIds
+            | uiEventCanCompleteBlocks uiEvent =
+                completionFlashTransitions previousUi nextUi
+            | otherwise =
+                []
+        newFlashes =
+            if state.appRuntime.runtimeMotionMode == MotionOff
+                then Map.empty
+                else Map.fromList
+                    [ (blockId, completionFlashDurationMillis)
+                    | blockId <- transitionIds
+                    ]
+        restartSchedule =
+            uiEventRestartsMotionSchedule
+                uiEvent
+                previousUi
+                nextUi
+                newFlashes
+        nextState =
+            state
+                { appUi = nextUi
+                , appCompletionFlashes =
+                    Map.union newFlashes retainedFlashes
+                , appMotionScheduleReset =
+                    state.appMotionScheduleReset || restartSchedule
+                , appNativeProgressKeepaliveBucket =
+                    if nextUi.uiElapsedMillis < previousUi.uiElapsedMillis
+                        then 0
+                        else state.appNativeProgressKeepaliveBucket
+                }
+    in Composer.applyComposerUiEvent uiEvent nextState
+
+retainExistingFlashes
+    :: UiState
+    -> Map.Map BlockId Int
+    -> Map.Map BlockId Int
+retainExistingFlashes ui =
+    Map.filterWithKey
+        (\blockId _ ->
+            any ((== blockId) . (.blockId))
+                (toList ui.uiBlocks))
+
+uiEventCanCompleteBlocks :: UiEvent -> Bool
+uiEventCanCompleteBlocks = \case
+    UiLoop (ToolFinished _) -> True
+    UiLoop (TurnFinished _) -> True
+    UiSetAwaitingInput True -> True
+    UiTurnEnded _ -> True
+    _ -> False
+
+uiEventRestartsMotionSchedule
+    :: UiEvent
+    -> UiState
+    -> UiState
+    -> Map.Map BlockId Int
+    -> Bool
+uiEventRestartsMotionSchedule event previous next newFlashes =
+    explicitReset
+        || (previous.uiCompletionRemainingMillis == 0
+            && next.uiCompletionRemainingMillis > 0)
+        || not (Map.null newFlashes)
+  where
+    explicitReset = case event of
+        UiLoop TurnStarted -> True
+        UiSetNotice (Just _) -> True
+        UiInputPromoted _ -> True
+        UiTurnRestarted -> True
+        _ -> False
+
+nextMotionSchedule
+    :: Bool
+    -> MotionDemand
+    -> Int
+    -> (MotionDemand, Int, Int)
+    -> (MotionDemand, Int, Int)
+nextMotionSchedule
+    resetSchedule
+    demand
+    delayMicros
+    current@(currentDemand, currentDelay, generation)
+    | resetSchedule
+        || currentDemand /= demand
+        || currentDelay /= delayMicros =
+        (demand, delayMicros, generation + 1)
+    | otherwise =
+        current
+
+elapsedMillisSince :: Word64 -> Word64 -> (Int, Word64)
+elapsedMillisSince previous now
+    | now <= previous =
+        (0, previous)
+    | otherwise =
+        let elapsedMillis = (now - previous) `div` 1000000
+        in
+        ( fromIntegral elapsedMillis
+        , previous + elapsedMillis * 1000000
+        )
+
+advanceAppTime :: Word64 -> AppState -> AppState
+advanceAppTime now state =
+    let
+        (elapsedMillis, nextClock) =
+            elapsedMillisSince state.appClockNanos now
+    in state
+        { appUi = advanceUiTime elapsedMillis state.appUi
+        , appMotionElapsedMillis =
+            state.appMotionElapsedMillis + elapsedMillis
+        , appCompletionFlashes =
+            advanceCompletionFlashes
+                elapsedMillis
+                state.appCompletionFlashes
+        , appClockNanos = nextClock
+        }
+
+advanceAppClockNow :: EventM Name AppState ()
+advanceAppClockNow = do
+    now <- liftIO getMonotonicTimeNSec
+    modify' (advanceAppTime now)
+
+applyLocalUiEvent :: UiEvent -> EventM Name AppState ()
+applyLocalUiEvent event =
+    applyLocalUiEventWith event id
+
+applyLocalUiEventWith
+    :: UiEvent
+    -> (AppState -> AppState)
+    -> EventM Name AppState ()
+applyLocalUiEventWith event update = do
+    advanceAppClockNow
+    modify' (update . applyUiEvent event)
+
+nativeProgressKeepaliveDue :: Bool -> Int -> UiState -> Bool
+nativeProgressKeepaliveDue blocked previousBucket ui =
+    not blocked
+        && ui.uiRunning
+        && ui.uiElapsedMillis `div` 5000 > previousBucket
+
+refreshNativeProgressKeepalive :: EventM Name AppState ()
+refreshNativeProgressKeepalive = do
+    state <- get
+    let bucket = state.appUi.uiElapsedMillis `div` 5000
+    when
+        (nativeProgressKeepaliveDue
+            (userActionPending state)
+            state.appNativeProgressKeepaliveBucket
+            state.appUi) do
+        liftIO (state.appRuntime.runtimeNativeProgress True)
+        modify' \current ->
+            current { appNativeProgressKeepaliveBucket = bucket }
 
 handleEvent :: BrickEvent Name AppEvent -> EventM Name AppState ()
 handleEvent event = do
+    advanceAppClockNow
+    when (isMotionTick event) refreshNativeProgressKeepalive
     handleEventInner event
     state <- get
     let visible =
@@ -2050,16 +2515,53 @@ handleEvent event = do
             modifyIORef'
                 state.appRuntime.runtimeImagePreviewRevision
                 (+ 1)
+    syncMotionDemand
+  where
+    isMotionTick = \case
+        AppEvent AppMotionTick -> True
+        _ -> False
+
+syncMotionDemand :: EventM Name AppState ()
+syncMotionDemand = do
+    advanceAppClockNow
+    state <- get
+    let
+        (demand, delayMicros) = appMotionTiming state
+        resetSchedule = state.appMotionScheduleReset
+    liftIO $
+        atomically do
+            current <-
+                readTVar state.appRuntime.runtimeMotionSchedule
+            let next =
+                    nextMotionSchedule
+                        resetSchedule
+                        demand
+                        delayMicros
+                        current
+            when (next /= current) $
+                writeTVar
+                    state.appRuntime.runtimeMotionSchedule
+                    next
+    modify' \current ->
+        current
+            { appMotionScheduleReset = False }
 
 handleEventInner :: BrickEvent Name AppEvent -> EventM Name AppState ()
 handleEventInner event = case event of
+    AppEvent AppMotionTick -> do
+        state <- get
+        liftIO $
+            atomically $
+                writeTVar
+                    state.appRuntime.runtimeMotionTickQueued
+                    False
     AppEvent AppStop -> do
         modify' \state -> state { appWorkerStopped = True }
         halt
     AppEvent (AppSetSkillCommands skills) -> do
         state <- get
         if state.appSkillCommands == skills
-            then continueWithoutRedraw
+            then pure ()
             else modify' \current -> current
                 { appSkillCommands = skills
                 , appSlashIndex = 0
@@ -2103,7 +2605,7 @@ handleEventInner event = case event of
                 Bridge.normalizeAgentSelection selected entries
         if state.appAgentSelected == normalized
             && state.appAgentEntries == entries
-            then continueWithoutRedraw
+            then pure ()
             else do
                 modify' \current ->
                     current
@@ -2139,14 +2641,19 @@ handleEventInner event = case event of
         modify' \state ->
             state { appConversationReflowQueued = False }
         reflowConversation
-    AppEvent (AppAskPermission summary reply) ->
-        modify' \state ->
-            state
-                { appUi = reduceUi (UiPermissionShown summary) state.appUi
-                , appPermissionReply = Just reply
-                , appAgentHover = Nothing
-                }
+    AppEvent (AppAskPermission summary reply) -> do
+        state <- get
+        liftIO (state.appRuntime.runtimeNativeProgress False)
+        applyLocalUiEventWith
+            (UiPermissionShown summary)
+            \current ->
+                current
+                    { appPermissionReply = Just reply
+                    , appAgentHover = Nothing
+                    }
     AppEvent (AppAskChoice title body initial rows reply) -> do
+        state <- get
+        liftIO (state.appRuntime.runtimeNativeProgress False)
         modify' \state ->
             state
                 { appChoice = Just ChoiceOverlay
@@ -2161,6 +2668,8 @@ handleEventInner event = case event of
                 }
         vScrollToBeginning (viewportScroll OverlayViewport)
     AppEvent (AppAskText title body initial reply) -> do
+        state <- get
+        liftIO (state.appRuntime.runtimeNativeProgress False)
         modify' \state ->
             state
                 { appTextPrompt = Just TextOverlay
@@ -2213,16 +2722,19 @@ handleEventInner event = case event of
                             (CodeCopy blockId codeIndex)
                     (SlashRow index, V.BLeft) ->
                         Composer.activateSlashAt
+                            applyLocalUiEventWith
                             handleCtrlC
                             scrollConversationPage
                             index
                     (SlashRow _, V.BScrollUp) ->
                         Composer.handleComposerKey
+                            applyLocalUiEventWith
                             handleCtrlC
                             scrollConversationPage
                             (V.EvKey V.KUp [])
                     (SlashRow _, V.BScrollDown) ->
                         Composer.handleComposerKey
+                            applyLocalUiEventWith
                             handleCtrlC
                             scrollConversationPage
                             (V.EvKey V.KDown [])
@@ -2331,8 +2843,7 @@ handlePermissionKey = \case
     _ -> pure ()
   where
     movePermission delta =
-        modify' \state ->
-            state { appUi = reduceUi (UiPermissionMoved delta) state.appUi }
+        applyLocalUiEvent (UiPermissionMoved delta)
 
 permissionChoiceAt :: Int -> PermissionChoice
 permissionChoiceAt = \case
@@ -2349,11 +2860,22 @@ resolvePermission choice = do
         Nothing -> pure ()
         Just reply ->
             liftIO $ atomically (putTMVar reply (Just choice))
-    modify' \current ->
-        current
-            { appUi = reduceUi UiPermissionHidden current.appUi
-            , appPermissionReply = Nothing
-            }
+    applyLocalUiEventWith UiPermissionHidden \current ->
+        current { appPermissionReply = Nothing }
+    resumeNativeProgressIfRunning
+
+resumeNativeProgressIfRunning :: EventM Name AppState ()
+resumeNativeProgressIfRunning = do
+    state <- get
+    when
+        (state.appUi.uiRunning
+            && not (userActionPending state)) do
+        liftIO (state.appRuntime.runtimeNativeProgress True)
+        modify' \current ->
+            current
+                { appNativeProgressKeepaliveBucket =
+                    current.appUi.uiElapsedMillis `div` 5000
+                }
 
 handleCtrlC :: EventM Name AppState CtrlCDecision
 handleCtrlC = do
@@ -2361,27 +2883,17 @@ handleCtrlC = do
     decision <- liftIO state.appRuntime.runtimeCtrlC
     case decision of
         SoftCancel ->
-            modify' \current ->
-                current
-                    { appUi =
-                        reduceUi
-                            (UiSetNotice
-                                (Just
-                                    (warningNotice
-                                        "Interrupted; press Ctrl-C again to exit.")))
-                            current.appUi
-                    }
+            applyLocalUiEvent $
+                UiSetNotice $
+                    Just $
+                        warningNotice
+                            "Interrupted; press Ctrl-C again to exit."
         WarnExit ->
-            modify' \current ->
-                current
-                    { appUi =
-                        reduceUi
-                            (UiSetNotice
-                                (Just
-                                    (warningNotice
-                                        "Press Ctrl-C again to exit.")))
-                            current.appUi
-                    }
+            applyLocalUiEvent $
+                UiSetNotice $
+                    Just $
+                        warningNotice
+                            "Press Ctrl-C again to exit."
         ForceExit ->
             liftIO (throwIO UserInterrupt)
     pure decision
@@ -2390,6 +2902,7 @@ handleNormalKey :: V.Event -> EventM Name AppState ()
 handleNormalKey event
     | Bridge.isSendNowKey event =
         Composer.handleComposerKey
+            applyLocalUiEventWith
             handleCtrlC
             scrollConversationPage
             event
@@ -2405,6 +2918,7 @@ handleNormalKey event
                     FocusScrollback -> handleScrollbackKey event
                     FocusComposer ->
                         Composer.handleComposerKey
+                            applyLocalUiEventWith
                             handleCtrlC
                             scrollConversationPage
                             event
@@ -2474,21 +2988,11 @@ handleMouseDown name button =
         V.BScrollDown -> scrollConversationBy mouseScrollLines
         V.BLeft -> case name of
             ConversationBlock ident ->
-                modify' \state ->
-                    state
-                        { appUi =
-                            reduceUi
-                                (UiFocusChanged FocusScrollback)
-                                (reduceUi (UiSelectBlock ident) state.appUi)
-                        }
+                applyLocalUiEventWith
+                    (UiSelectBlock ident)
+                    (applyUiEvent (UiFocusChanged FocusScrollback))
             ComposerArea ->
-                modify' \state ->
-                    state
-                        { appUi =
-                            reduceUi
-                                (UiFocusChanged FocusComposer)
-                                state.appUi
-                        }
+                applyLocalUiEvent (UiFocusChanged FocusComposer)
             _ -> pure ()
         _ -> pure ()
 
@@ -2530,8 +3034,7 @@ handleScrollbackKey = \case
   where
     scroll = viewportScroll ConversationViewport
     moveBlock delta = do
-        modify' \state ->
-            state { appUi = reduceUi (UiMoveSelection delta) state.appUi }
+        applyLocalUiEvent (UiMoveSelection delta)
         state <- get
         case state.appUi.uiSelectedBlock of
             Just ident -> do
@@ -2539,20 +3042,16 @@ handleScrollbackKey = \case
                 queueConversationReflow
             Nothing -> pure ()
     toggle = do
-        modify' \state ->
-            state { appUi = reduceUi UiToggleSelected state.appUi }
+        applyLocalUiEvent UiToggleSelected
         queueConversationReflow
     focusComposer =
-        modify' \state ->
-            state { appUi = reduceUi (UiFocusChanged FocusComposer) state.appUi }
+        applyLocalUiEvent (UiFocusChanged FocusComposer)
     leaveFollow =
-        modify' \state ->
-            state { appUi = reduceUi (UiSetFollow False) state.appUi }
+        applyLocalUiEvent (UiSetFollow False)
     resumeFollow = do
-        modify' \state ->
+        applyLocalUiEventWith (UiSetFollow True) \state ->
             state
-                { appUi = reduceUi (UiSetFollow True) state.appUi
-                , appConversationAnchor =
+                { appConversationAnchor =
                     Scroll.followConversationTail
                         <$> state.appConversationAnchor
                 }
@@ -2565,19 +3064,14 @@ handleScrollbackKey = \case
             Just block -> do
                 copied <- liftIO $
                     state.appRuntime.runtimeCopy block.blockBody
-                modify' \current ->
-                    current
-                        { appUi =
-                            reduceUi
-                                (UiSetNotice
-                                    (Just
-                                        (if copied
-                                            then successNotice
-                                                "Copied selected block."
-                                            else warningNotice
-                                                "Terminal clipboard is unavailable.")))
-                                current.appUi
-                        }
+                applyLocalUiEvent $
+                    UiSetNotice $
+                        Just $
+                            if copied
+                                then successNotice
+                                    "Copied selected block."
+                                else warningNotice
+                                    "Terminal clipboard is unavailable."
 
 scrollConversationPage :: Direction -> EventM Name AppState ()
 scrollConversationPage direction = do
@@ -2625,8 +3119,7 @@ scrollConversationBy amount
 
 setConversationFollow :: Bool -> EventM Name AppState ()
 setConversationFollow follow =
-    modify' \state ->
-        state { appUi = reduceUi (UiSetFollow follow) state.appUi }
+    applyLocalUiEvent (UiSetFollow follow)
 
 conversationUnpaddedContentHeight :: EventM Name AppState Int
 conversationUnpaddedContentHeight =

--- a/packages/agent-cli/src/Agent/CLI/TUI/Bridge.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Bridge.hs
@@ -35,22 +35,18 @@ mergeUiEvents older newer = case (older, newer) of
         Just (UiLoop (ReasoningDelta (left <> right)))
     (UiLoop (ActivityUpdated _), UiLoop (ActivityUpdated latest)) ->
         Just (UiLoop (ActivityUpdated latest))
-    (UiTick, UiTick) ->
-        Just UiTick
     _ ->
         Nothing
 
-nativeProgressSignal :: UiEvent -> UiState -> Maybe Bool
-nativeProgressSignal event state = case event of
-    UiLoop TurnStarted -> Just True
-    UiLoop (TurnFinished _) -> Just state.uiRunning
-    UiTurnEnded _ -> Just False
-    UiSetAwaitingInput True -> Just False
-    UiTick
-        | state.uiRunning
-        , state.uiFrame `mod` 10 == 0 ->
-            Just True
-    _ -> Nothing
+nativeProgressSignal :: Bool -> UiEvent -> UiState -> Maybe Bool
+nativeProgressSignal blocked event state
+    | blocked = Nothing
+    | otherwise = case event of
+        UiLoop TurnStarted -> Just True
+        UiLoop (TurnFinished _) -> Just state.uiRunning
+        UiTurnEnded _ -> Just False
+        UiSetAwaitingInput True -> Just False
+        _ -> Nothing
 
 historyMove
     :: Int

--- a/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
@@ -70,6 +70,11 @@ import qualified Data.Text.Encoding as Text
 import Data.Text.Encoding.Error (lenientDecode)
 import qualified Graphics.Vty as V
 
+type ApplyLocalUiEvent =
+    UiEvent
+    -> (AppState -> AppState)
+    -> EventM Name AppState ()
+
 newFullscreenInputBuffer :: IO FullscreenInputBuffer
 newFullscreenInputBuffer =
     FullscreenInputBuffer <$> newTVarIO Seq.empty
@@ -365,9 +370,10 @@ drawComposerStatus state =
                 (txt mode)
 
 handlePromptControlClick
-    :: (Text -> ReplLine)
+    :: ApplyLocalUiEvent
+    -> (Text -> ReplLine)
     -> EventM Name AppState ()
-handlePromptControlClick choice = do
+handlePromptControlClick applyUiEvent choice = do
     state <- get
     let ui = state.appUi
         overlayOpen =
@@ -382,27 +388,19 @@ handlePromptControlClick choice = do
                     , fullscreenInputQueued = False
                     , fullscreenInputDisplay = Nothing
                     }
-            modify' \current ->
-                current
-                    { appUi =
-                        reduceUi
-                            (UiSetAwaitingInput False)
-                            current.appUi
-                    }
+            applyUiEvent (UiSetAwaitingInput False) id
         else
-            modify' \current ->
-                current
-                    { appUi =
-                        reduceUi
-                            (UiSetNotice
-                                (Just
-                                    (warningNotice
-                                        "Prompt settings can be changed when input is ready.")))
-                            current.appUi
-                    }
+            applyUiEvent
+                (UiSetNotice
+                    (Just
+                        (warningNotice
+                            "Prompt settings can be changed when input is ready.")))
+                id
 
-handleEffortControlClick :: EventM Name AppState ()
-handleEffortControlClick = do
+handleEffortControlClick
+    :: ApplyLocalUiEvent
+    -> EventM Name AppState ()
+handleEffortControlClick applyUiEvent = do
     state <- get
     let ui = state.appUi
         overlayOpen =
@@ -410,7 +408,7 @@ handleEffortControlClick = do
                 || maybe False (const True) state.appChoice
                 || maybe False (const True) ui.uiPermission
     if ui.uiAwaitingInput
-        then handlePromptControlClick ReplChooseEffort
+        then handlePromptControlClick applyUiEvent ReplChooseEffort
         else if ui.uiRunning && not overlayOpen
             then do
                 let efforts = reasoningEfforts
@@ -437,16 +435,12 @@ handleEffortControlClick = do
                         }
                 vScrollToBeginning (viewportScroll OverlayViewport)
             else
-                modify' \current ->
-                    current
-                        { appUi =
-                            reduceUi
-                                (UiSetNotice
-                                    (Just
-                                        (warningNotice
-                                            "Prompt settings cannot be changed right now.")))
-                                current.appUi
-                        }
+                applyUiEvent
+                    (UiSetNotice
+                        (Just
+                            (warningNotice
+                                "Prompt settings cannot be changed right now.")))
+                    id
 
 handleControlMouseDown :: Name -> EventM Name AppState ()
 handleControlMouseDown name =
@@ -474,11 +468,16 @@ handleControlMouseUp name action = do
     when activate action
 
 activateSlashAt
-    :: EventM Name AppState CtrlCDecision
+    :: ApplyLocalUiEvent
+    -> EventM Name AppState CtrlCDecision
     -> (Direction -> EventM Name AppState ())
     -> Int
     -> EventM Name AppState ()
-activateSlashAt handleCtrlC scrollConversationPage index = do
+activateSlashAt
+    applyUiEvent
+    handleCtrlC
+    scrollConversationPage
+    index = do
     state <- get
     case currentSlashMenu state of
         Just menu
@@ -487,6 +486,7 @@ activateSlashAt handleCtrlC scrollConversationPage index = do
                 modify' \current ->
                     current { appSlashIndex = index }
                 handleComposerKey
+                    applyUiEvent
                     handleCtrlC
                     scrollConversationPage
                     (V.EvKey V.KEnter [])
@@ -495,11 +495,16 @@ activateSlashAt handleCtrlC scrollConversationPage index = do
 -- | Handle one composer key. The host supplies Ctrl-C policy and conversation
 -- page scrolling because those actions also affect non-composer UI state.
 handleComposerKey
-    :: EventM Name AppState CtrlCDecision
+    :: ApplyLocalUiEvent
+    -> EventM Name AppState CtrlCDecision
     -> (Direction -> EventM Name AppState ())
     -> V.Event
     -> EventM Name AppState ()
-handleComposerKey handleCtrlC scrollConversationPage event = do
+handleComposerKey
+    applyUiEvent
+    handleCtrlC
+    scrollConversationPage
+    event = do
     state <- get
     let ui = state.appUi
         slashMenu = currentSlashMenu state
@@ -682,37 +687,37 @@ handleComposerKey handleCtrlC scrollConversationPage event = do
                                 , fullscreenInputQueued = True
                                 , fullscreenInputDisplay = Just draft
                                 }
-                    modify' \current ->
-                        current
-                            { appUi =
-                                reduceUi (UiInputPromoted draft) current.appUi
-                            , appPasted = False
-                            , appHistory = draft : current.appHistory
-                            , appHistoryIndex = Nothing
-                            , appHistoryDraft = ""
-                            , appSlashIndex = 0
-                            , appSlashDismissed = False
-                            }
+                    applyUiEvent
+                        (UiInputPromoted draft)
+                        \current ->
+                            current
+                                { appPasted = False
+                                , appHistory = draft : current.appHistory
+                                , appHistoryIndex = Nothing
+                                , appHistoryDraft = ""
+                                , appSlashIndex = 0
+                                , appSlashDismissed = False
+                                }
                     liftIO state.appRuntime.runtimeCancel
                     vScrollToEnd (viewportScroll ConversationViewport)
 
     enqueueInput state replLine display clearDraft = do
         let queued = not state.appUi.uiAwaitingInput
-        modify' \current ->
-            current
-                { appUi =
-                    if queued
-                        then case display of
-                            Just text -> reduceUi (UiInputQueued text) current.appUi
-                            Nothing -> current.appUi
-                        else reduceUi
-                            (if clearDraft
-                                then UiDraftSubmitted
-                                else UiSetAwaitingInput False)
-                            current.appUi
-                , appSlashIndex = 0
-                , appSlashDismissed = False
-                }
+            event =
+                if queued
+                    then UiInputQueued <$> display
+                    else Just
+                        (if clearDraft
+                            then UiDraftSubmitted
+                            else UiSetAwaitingInput False)
+            update current =
+                current
+                    { appSlashIndex = 0
+                    , appSlashDismissed = False
+                    }
+        case event of
+            Nothing -> modify' update
+            Just uiEvent -> applyUiEvent uiEvent update
         liftIO $ atomically $
             appendFullscreenInput state.appRuntime.runtimeInput FullscreenInput
                 { fullscreenInputLine = replLine
@@ -798,24 +803,18 @@ handleComposerKey handleCtrlC scrollConversationPage event = do
         setCursor (state.appUi.uiCursor + delta)
 
     setCursor cursor =
-        modify' \current ->
-            current
-                { appUi =
-                    reduceUi
-                        (UiSetDraft current.appUi.uiDraft cursor)
-                        current.appUi
-                , appSlashIndex = 0
-                }
+        get >>= \current ->
+            applyUiEvent
+                (UiSetDraft current.appUi.uiDraft cursor)
+                \state -> state { appSlashIndex = 0 }
 
     modifyUi uiEvent =
-        modify' \state ->
-            state { appUi = reduceUi uiEvent state.appUi }
+        applyUiEvent uiEvent id
 
     modifyUiResetSlash uiEvent =
-        modify' \state ->
+        applyUiEvent uiEvent \state ->
             state
-                { appUi = reduceUi uiEvent state.appUi
-                , appSlashIndex = 0
+                { appSlashIndex = 0
                 , appSlashDismissed = False
                 , appHistoryIndex = Nothing
                 , appHistoryDraft =
@@ -825,10 +824,9 @@ handleComposerKey handleCtrlC scrollConversationPage event = do
                 }
 
     modifyUiWithKill killed uiEvent =
-        modify' \state ->
+        applyUiEvent uiEvent \state ->
             state
-                { appUi = reduceUi uiEvent state.appUi
-                , appSlashIndex = 0
+                { appSlashIndex = 0
                 , appSlashDismissed = False
                 , appKillBuffer = killed
                 , appHistoryIndex = Nothing
@@ -847,17 +845,15 @@ handleComposerKey handleCtrlC scrollConversationPage event = do
                     state.appHistoryIndex
                     state.appUi.uiDraft
                     state.appHistoryDraft
-        modify' \currentState ->
-            currentState
-                { appUi =
-                    reduceUi
-                        (UiSetDraft text (Text.length text))
-                        currentState.appUi
-                , appHistoryIndex = index
-                , appHistoryDraft = draft
-                , appSlashIndex = 0
-                , appSlashDismissed = False
-                }
+        applyUiEvent
+            (UiSetDraft text (Text.length text))
+            \currentState ->
+                currentState
+                    { appHistoryIndex = index
+                    , appHistoryDraft = draft
+                    , appSlashIndex = 0
+                    , appSlashDismissed = False
+                    }
 
     moveSlash delta count =
         modify' \current ->

--- a/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
@@ -24,14 +24,17 @@ import qualified Agent.CLI.TUI.Scroll as Scroll
 import Agent.Loop (ImageAttachment)
 import Agent.TUI.Model (BlockId, UiEvent, UiState)
 import Agent.Syntax (SyntaxHighlighter)
+import Agent.TUI.Motion (MotionDemand, MotionMode)
 import Brick (Location)
 import Brick.BChan (BChan)
 import Control.Concurrent.STM (TMVar, TVar)
 import Control.Exception.Safe (SomeException)
 import Data.IORef (IORef)
 import Data.List.NonEmpty (NonEmpty)
+import qualified Data.Map.Strict as Map
 import Data.Sequence (Seq)
 import Data.Text (Text)
+import Data.Word (Word64)
 
 data Name
     = ConversationViewport
@@ -80,6 +83,7 @@ data AppEvent
     | AppAgentSnapshot !AgentTarget ![AgentEntry]
     | AppSetWindowTitle !Text
     | AppConversationReflow
+    | AppMotionTick
     | AppStop
 
 data PendingAppEvent
@@ -116,7 +120,9 @@ data FullscreenRuntime = FullscreenRuntime
     , runtimeAgentSnapshot :: !(IO (AgentTarget, [AgentEntry]))
     , runtimeAgentSelect :: !(AgentTarget -> IO ())
     , runtimeFirstFrame :: !(IO ())
-    , runtimeRunning :: !(IORef Bool)
+    , runtimeMotionSchedule :: !(TVar (MotionDemand, Int, Int))
+    , runtimeMotionTickQueued :: !(TVar Bool)
+    , runtimeMotionMode :: !MotionMode
     , runtimeImagePreviews :: !(IORef [(ImageAttachment, TuiImagePreview)])
     , runtimeImagePreviewRevision :: !(IORef Int)
     , runtimeImagePreviewVisible :: !(IORef Bool)
@@ -153,6 +159,11 @@ data AppState = AppState
     , appConversationAnchor :: !(Maybe Scroll.ConversationAnchor)
     , appConversationReflowQueued :: !Bool
     , appWindowTitle :: !(Maybe Text)
+    , appMotionElapsedMillis :: !Int
+    , appCompletionFlashes :: !(Map.Map BlockId Int)
+    , appMotionScheduleReset :: !Bool
+    , appClockNanos :: !Word64
+    , appNativeProgressKeepaliveBucket :: !Int
     }
 
 data AgentHover = AgentHover

--- a/packages/agent-cli/test/Agent/CLI/OptionsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/OptionsSpec.hs
@@ -3,6 +3,7 @@ module Agent.CLI.OptionsSpec (spec) where
 import Agent.CLI.Options
 import System.OsPath (unsafeEncodeUtf)
 import Agent.Provider (Provider(..))
+import Agent.TUI.Motion (MotionMode(..))
 import Test.Hspec
 
 fromFilePath = unsafeEncodeUtf
@@ -122,6 +123,18 @@ spec = do
             parseArgs ["--fullscreen", "--minimal"]
                 `shouldBe` Right (RunAgent defaultCliOptions
                     { optScreenMode = ScreenMinimal })
+
+        it "parses full, reduced, and disabled motion policies" do
+            parseArgs ["--motion", "full"]
+                `shouldBe` Right (RunAgent defaultCliOptions
+                    { optMotionMode = MotionFull })
+            parseArgs ["--motion", "REDUCED"]
+                `shouldBe` Right (RunAgent defaultCliOptions
+                    { optMotionMode = MotionReduced })
+            parseArgs ["--motion", "off"]
+                `shouldBe` Right (RunAgent defaultCliOptions
+                    { optMotionMode = MotionOff })
+            parseArgs ["--motion", "fast"] `shouldSatisfy` isLeft
 
         it "parses --skills and --no-skills" do
             parseArgs ["--no-skills", "-p", "hi"]

--- a/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
@@ -1,6 +1,7 @@
 module Agent.CLI.RenderSpec (spec) where
 
 import Agent.CLI.Render
+import Agent.CLI.Style (motionGlyphSet)
 import Agent.Error (ApiError(..), ErrorType(..))
 import Agent.Loop (LoopError(..), LoopEvent(..), TurnOutput(..), emptyTokenUsage)
 import Agent.ToolDispatch
@@ -9,6 +10,7 @@ import Agent.ToolDispatch
     , customToolCall
     , functionToolCall
     )
+import Agent.TUI.Motion (MotionMode(..), foregroundIndicator)
 import Control.Concurrent (forkIO)
 import Control.Concurrent.MVar (newEmptyMVar, newMVar, putMVar, takeMVar)
 import Control.Exception (finally)
@@ -409,6 +411,28 @@ spec = do
                 body `shouldSatisfy` containsOsc9 3
                 body `shouldSatisfy` containsOsc9 0
 
+        it "keeps reduced and off thinking static without native animation" do
+            mapM_
+                (\mode ->
+                    withRenderConfigNativeMode
+                        True
+                        False
+                        True
+                        mode
+                        \config handle path -> do
+                            renderEvent config TurnStarted
+                            hClose handle
+                            body <- Text.readFile path
+                            body `shouldSatisfy`
+                                Text.isInfixOf
+                                    (foregroundIndicator
+                                        motionGlyphSet
+                                        mode
+                                        0
+                                        <> " Thinking…")
+                            body `shouldSatisfy` (not . containsOsc9 3))
+                [MotionReduced, MotionOff]
+
     describe "formatThinkingBlock" do
         it "headers a live preview and a finished duration" do
             formatThinkingBlock False True 1.2 "secret plan"
@@ -452,7 +476,21 @@ withRenderConfigNative
     -> Bool
     -> (RenderConfig -> Handle -> FilePath -> IO ())
     -> IO ()
-withRenderConfigNative showThinking color native action = do
+withRenderConfigNative showThinking color native =
+    withRenderConfigNativeMode
+        showThinking
+        color
+        native
+        MotionFull
+
+withRenderConfigNativeMode
+    :: Bool
+    -> Bool
+    -> Bool
+    -> MotionMode
+    -> (RenderConfig -> Handle -> FilePath -> IO ())
+    -> IO ()
+withRenderConfigNativeMode showThinking color native motionMode action = do
     printed <- newIORef False
     thinking <- newIORef False
     spinner <- newIORef Nothing
@@ -487,6 +525,7 @@ withRenderConfigNative showThinking color native action = do
                 , renderStartedAt = startedAt
                 , renderToolCalls = toolCalls
                 , renderNativeProgress = native
+                , renderMotionMode = motionMode
                 }
         action config handle path
         clearThinking config

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -2,13 +2,21 @@ module Agent.CLI.TUIAppSpec (spec) where
 
 import Agent.CLI.AgentViewport (AgentEntry(..), AgentTarget(..))
 import Agent.CLI.TUI.App
-    ( agentEntryWindow
+    ( advanceCompletionFlashes
+    , agentEntryWindow
     , agentPaneEntryLimit
     , agentPaneVisible
+    , completionFlashTransitions
     , conversationScrollbarRenderer
+    , elapsedMillisSince
     , fullscreenVtyConfig
+    , motionDemandFor
+    , nativeProgressKeepaliveDue
+    , nextMotionSchedule
     , repositoryHeaderText
+    , uiEventRestartsMotionSchedule
     )
+import Agent.Loop (LoopEvent(..), emptyTurnOutput)
 import Brick
     ( VScrollbarRenderer(..)
     , hLimit
@@ -16,6 +24,14 @@ import Brick
     , vLimit
     )
 import Agent.Subagents (SubagentId(..))
+import Agent.ToolDispatch
+    ( ToolCallKind(..)
+    , ToolCallResult(..)
+    , functionToolCall
+    )
+import Agent.TUI.Model
+import Agent.TUI.Motion
+import qualified Data.Map.Strict as Map
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Graphics.Vty as V
@@ -101,6 +117,219 @@ spec = do
             renderCell
                 (conversationScrollbarRenderer @()).renderVScrollbar
                 `shouldBe` V.char V.defAttr '┃'
+
+    describe "motion demand" do
+        it "distinguishes foreground, waiting, background, and static modes" do
+            let idle =
+                    reduceUi
+                        (UiUserSubmitted "done")
+                        initialUiState
+                running =
+                    reduceUi (UiLoop TurnStarted) idle
+            motionDemandFor MotionFull False False False running
+                `shouldBe` MotionFast
+            motionDemandFor MotionFull True False False running
+                `shouldBe` MotionSlow
+            motionDemandFor MotionFull False True False idle
+                `shouldBe` MotionSlow
+            motionDemandFor MotionFull False False False idle
+                `shouldBe` MotionNone
+            motionDemandFor MotionFull False False False initialUiState
+                `shouldBe` MotionSlow
+            motionDemandFor MotionReduced False False False initialUiState
+                `shouldBe` MotionNone
+            motionDemandFor MotionReduced False False False running
+                `shouldBe` MotionSlow
+            motionDemandFor MotionOff False False False running
+                `shouldBe` MotionSlow
+
+        it "bumps the scheduler generation on demand or timer boundaries" do
+            nextMotionSchedule
+                False
+                MotionSlow
+                160000
+                (MotionSlow, 160000, 4)
+                `shouldBe` (MotionSlow, 160000, 4)
+            nextMotionSchedule
+                True
+                MotionSlow
+                160000
+                (MotionSlow, 160000, 4)
+                `shouldBe` (MotionSlow, 160000, 5)
+            nextMotionSchedule
+                False
+                MotionFast
+                80000
+                (MotionSlow, 160000, 4)
+                `shouldBe` (MotionFast, 80000, 5)
+            nextMotionSchedule
+                False
+                MotionSlow
+                400000
+                (MotionSlow, 500000, 4)
+                `shouldBe` (MotionSlow, 400000, 5)
+
+        it "retains sub-millisecond time across clock samples" do
+            elapsedMillisSince 1000000 1499999
+                `shouldBe` (0, 1000000)
+            elapsedMillisSince 1234567 3234999
+                `shouldBe` (2, 3234567)
+            elapsedMillisSince 4000000 3000000
+                `shouldBe` (0, 4000000)
+
+        it "restarts cadence when turn, notice, and promoted-input timers start" do
+            let idle =
+                    reduceUi
+                        (UiUserSubmitted "done")
+                        initialUiState
+                turnStarted =
+                    reduceUi (UiLoop TurnStarted) idle
+                turnFinished =
+                    reduceUi
+                        (UiLoop
+                            (TurnFinished
+                                (emptyTurnOutput
+                                    "response-1"
+                                    []
+                                    Nothing)))
+                        turnStarted
+                notice =
+                    reduceUi
+                        (UiSetNotice
+                            (Just (successNotice "saved")))
+                        idle
+                promoted =
+                    reduceUi (UiInputPromoted "urgent") turnStarted
+            uiEventRestartsMotionSchedule
+                (UiLoop TurnStarted)
+                idle
+                turnStarted
+                Map.empty
+                `shouldBe` True
+            uiEventRestartsMotionSchedule
+                (UiLoop
+                    (TurnFinished
+                        (emptyTurnOutput "response-1" [] Nothing)))
+                turnStarted
+                turnFinished
+                Map.empty
+                `shouldBe` True
+            uiEventRestartsMotionSchedule
+                (UiSetNotice (Just (successNotice "saved")))
+                idle
+                notice
+                Map.empty
+                `shouldBe` True
+            uiEventRestartsMotionSchedule
+                (UiInputPromoted "urgent")
+                turnStarted
+                promoted
+                Map.empty
+                `shouldBe` True
+            uiEventRestartsMotionSchedule
+                (UiLoop (ActivityUpdated "still working"))
+                turnStarted
+                (reduceUi
+                    (UiLoop (ActivityUpdated "still working"))
+                    turnStarted)
+                Map.empty
+                `shouldBe` False
+
+        it "refreshes native progress only after each five-second bucket" do
+            let running =
+                    advanceUiTime 5000 $
+                        reduceUi (UiLoop TurnStarted) initialUiState
+            nativeProgressKeepaliveDue False 0 running
+                `shouldBe` True
+            nativeProgressKeepaliveDue False 1 running
+                `shouldBe` False
+            nativeProgressKeepaliveDue True 0 running
+                `shouldBe` False
+
+        it "self-schedules completion flashes but disables them in off mode" do
+            let idle =
+                    reduceUi
+                        (UiUserSubmitted "done")
+                        initialUiState
+            motionDemandFor MotionFull False False True idle
+                `shouldBe` MotionFast
+            motionDemandFor MotionReduced False False True idle
+                `shouldBe` MotionSlow
+            motionDemandFor MotionOff False False True idle
+                `shouldBe` MotionNone
+
+    describe "completion flashes" do
+        it "detects only live-to-terminal block transitions" do
+            let call =
+                    functionToolCall
+                        "tool-1"
+                        "run_terminal_cmd"
+                        "{\"command\":\"true\"}"
+                running =
+                    reduceUi
+                        (UiLoop (ToolStarted call))
+                        (reduceUi (UiLoop TurnStarted) initialUiState)
+                completed =
+                    reduceUi
+                        (UiLoop
+                            (ToolFinished
+                                ToolCallResult
+                                    { callId = "tool-1"
+                                    , output = "exit: 0"
+                                    , callKind = FunctionCallKind
+                                    }))
+                        running
+            completionFlashTransitions running completed
+                `shouldBe` [BlockId 1]
+            completionFlashTransitions completed completed
+                `shouldBe` []
+
+        it "ignores assistant streams and unsuccessful terminal states" do
+            let assistantRunning =
+                    reduceUi
+                        (UiLoop (TextDelta "answer"))
+                        (reduceUi (UiLoop TurnStarted) initialUiState)
+                assistantComplete =
+                    reduceUi
+                        (UiLoop
+                            (TurnFinished
+                                (emptyTurnOutput
+                                    "response-1"
+                                    []
+                                    (Just "answer"))))
+                        assistantRunning
+                call =
+                    functionToolCall
+                        "tool-2"
+                        "run_terminal_cmd"
+                        "{\"command\":\"false\"}"
+                toolRunning =
+                    reduceUi
+                        (UiLoop (ToolStarted call))
+                        (reduceUi (UiLoop TurnStarted) initialUiState)
+                toolFailed =
+                    reduceUi
+                        (UiLoop
+                            (ToolFinished
+                                ToolCallResult
+                                    { callId = "tool-2"
+                                    , output = "Error: failed"
+                                    , callKind = FunctionCallKind
+                                    }))
+                        toolRunning
+            completionFlashTransitions
+                assistantRunning
+                assistantComplete
+                `shouldBe` []
+            completionFlashTransitions toolRunning toolFailed
+                `shouldBe` []
+
+        it "expires completion flashes from elapsed milliseconds" do
+            let active = Map.singleton (BlockId 7) 400
+            advanceCompletionFlashes 399 active
+                `shouldBe` Map.singleton (BlockId 7) 1
+            advanceCompletionFlashes 400 active
+                `shouldBe` Map.empty
 
 rootEntry :: AgentEntry
 rootEntry = AgentEntry

--- a/packages/agent-cli/test/Agent/CLI/TUIBridgeSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIBridgeSpec.hs
@@ -12,6 +12,7 @@ import Agent.TUI.Model
 import Agent.Loop (LoopEvent(..), emptyTurnOutput)
 import Agent.Subagents (SubagentId(..))
 import Agent.ToolDispatch (functionToolCall)
+import Agent.TUI.Motion (MotionMode(..))
 import Control.Monad (replicateM_)
 import System.Timeout (timeout)
 import qualified Graphics.Vty as V
@@ -24,9 +25,8 @@ spec = describe "fullscreen TUI bridge" do
         eventFollows (UiErrorMessage "failed") `shouldBe` True
         eventFollows (UiSetDraft "draft" 5) `shouldBe` False
 
-    it "starts, refreshes, and clears native terminal progress" do
+    it "starts and clears native terminal progress" do
         let running = reduceUi (UiLoop TurnStarted) initialUiState
-            refresh = running { uiFrame = 10 }
             toolCall =
                 functionToolCall
                     "tool-1"
@@ -44,19 +44,19 @@ spec = describe "fullscreen TUI bridge" do
                         (TurnFinished
                             (emptyTurnOutput "r2" [] Nothing)))
                     running
-        nativeProgressSignal (UiLoop TurnStarted) running
-            `shouldBe` Just True
-        nativeProgressSignal UiTick refresh
+        nativeProgressSignal False (UiLoop TurnStarted) running
             `shouldBe` Just True
         nativeProgressSignal
+            False
             (UiLoop (TurnFinished (emptyTurnOutput "r1" [] Nothing)))
             finished
             `shouldBe` Just False
         nativeProgressSignal
+            False
             (UiLoop (TurnFinished (emptyTurnOutput "r1" [toolCall] Nothing)))
             continuing
             `shouldBe` Just True
-        nativeProgressSignal (UiTurnEnded BlockCancelled) running
+        nativeProgressSignal False (UiTurnEnded BlockCancelled) running
             `shouldBe` Just False
 
     it "coalesces adjacent streaming updates without merging boundaries" do
@@ -72,7 +72,6 @@ spec = describe "fullscreen TUI bridge" do
             (UiLoop (ActivityUpdated "connecting"))
             (UiLoop (ActivityUpdated "streaming"))
             `shouldBe` Just (UiLoop (ActivityUpdated "streaming"))
-        mergeUiEvents UiTick UiTick `shouldBe` Just UiTick
         mergeUiEvents
             (UiLoop (TextDelta "answer"))
             (UiLoop
@@ -97,6 +96,7 @@ spec = describe "fullscreen TUI bridge" do
             (pure (AgentRoot, []))
             (const (pure ()))
             (pure ())
+            MotionFull
             False
             initialUiState
         completed <- timeout 2000000 $

--- a/packages/agent-tui/agent-tui.cabal
+++ b/packages/agent-tui/agent-tui.cabal
@@ -37,6 +37,7 @@ library
     hs-source-dirs:   src
     exposed-modules:  Agent.TUI.FencedCode
                     , Agent.TUI.Markdown
+                    , Agent.TUI.Motion
                     , Agent.TUI.Model
                     , Agent.TUI.Presentation
                     , Agent.TUI.Theme
@@ -56,6 +57,7 @@ test-suite agent-tui-test
     main-is:          Spec.hs
     other-modules:    Agent.TUI.FencedCodeSpec
                     , Agent.TUI.MarkdownSpec
+                    , Agent.TUI.MotionSpec
                     , Agent.TUI.ModelSpec
                     , Agent.TUI.ThemeSpec
     build-depends:    agent-tui

--- a/packages/agent-tui/src/Agent/TUI/Model.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model.hs
@@ -26,14 +26,20 @@ module Agent.TUI.Model
     , selectedBlockIndex
     , progressNotice
     , successNotice
+    , uiNextDeadlineMillis
     , uiNeedsTick
     , warningNotice
+    , advanceUiTime
     ) where
 
 import Agent.TUI.Presentation
     ( formatSearchReplaceDiff
     , formatToolOutput
     , summarizeToolCall
+    )
+import Agent.TUI.Motion
+    ( completionStatusDurationMillis
+    , transientNoticeDurationMillis
     )
 import Agent.Loop
     ( LoopEvent(..)
@@ -138,10 +144,9 @@ data UiState = UiState
     , uiCwd :: !Text
     , uiPermission :: !(Maybe PermissionOverlay)
     , uiNotice :: !(Maybe UiNotice)
-    , uiNoticeTicks :: !Int
-    , uiFrame :: !Int
-    , uiElapsedTenths :: !Int
-    , uiCompletionTicks :: !Int
+    , uiNoticeElapsedMillis :: !Int
+    , uiElapsedMillis :: !Int
+    , uiCompletionRemainingMillis :: !Int
     , uiTurnStartBlock :: !Int
     , uiToolCalls :: !(Map.Map Text ToolCall)
     }
@@ -175,7 +180,6 @@ data UiEvent
     | UiSetFollow !Bool
     | UiTurnEnded !BlockState
     | UiTurnRestarted
-    | UiTick
     deriving (Eq, Show)
 
 initialUiState :: UiState
@@ -202,10 +206,9 @@ initialUiState = UiState
     , uiCwd = ""
     , uiPermission = Nothing
     , uiNotice = Nothing
-    , uiNoticeTicks = 0
-    , uiFrame = 0
-    , uiElapsedTenths = 0
-    , uiCompletionTicks = 0
+    , uiNoticeElapsedMillis = 0
+    , uiElapsedMillis = 0
+    , uiCompletionRemainingMillis = 0
     , uiTurnStartBlock = 0
     , uiToolCalls = Map.empty
     }
@@ -229,6 +232,7 @@ reduceUi event state = case event of
                 { uiAwaitingInput = False
                 , uiFollow = True
                 , uiNotice = Nothing
+                , uiNoticeElapsedMillis = 0
                 }
     UiDraftSubmitted ->
         state
@@ -236,6 +240,7 @@ reduceUi event state = case event of
             , uiCursor = 0
             , uiAwaitingInput = False
             , uiNotice = Nothing
+            , uiNoticeElapsedMillis = 0
             }
     UiInputQueued text ->
         state
@@ -243,6 +248,7 @@ reduceUi event state = case event of
             , uiCursor = 0
             , uiQueuedInputs = state.uiQueuedInputs Seq.|> text
             , uiNotice = Nothing
+            , uiNoticeElapsedMillis = 0
             }
     UiInputPromoted text ->
         state
@@ -253,12 +259,14 @@ reduceUi event state = case event of
                 Just $
                     warningNotice
                         "Cancelling the current turn; sending this prompt next…"
+            , uiNoticeElapsedMillis = 0
             }
     UiQueuedInputStarted ->
         state
             { uiQueuedInputs = Seq.drop 1 state.uiQueuedInputs
             , uiAwaitingInput = False
             , uiNotice = Nothing
+            , uiNoticeElapsedMillis = 0
             }
     UiSetDraft text cursor ->
         state
@@ -276,14 +284,14 @@ reduceUi event state = case event of
             { uiAwaitingInput = awaiting
             , uiRunning = if awaiting then False else state.uiRunning
             , uiActivity =
-                if awaiting && state.uiCompletionTicks == 0
+                if awaiting && state.uiCompletionRemainingMillis == 0
                     then "Ready"
                     else state.uiActivity
             }
     UiSetRepository branch cwd ->
         state { uiBranch = branch, uiCwd = cwd }
     UiSetNotice notice ->
-        state { uiNotice = notice, uiNoticeTicks = 0 }
+        state { uiNotice = notice, uiNoticeElapsedMillis = 0 }
     UiMoveSelection delta ->
         moveSelection delta state
     UiSelectBlock ident ->
@@ -352,52 +360,75 @@ reduceUi event state = case event of
             , uiActivity = "Restarting…"
             , uiNotice =
                 Just (progressNotice "Restarting current turn…")
-            , uiNoticeTicks = 0
-            , uiCompletionTicks = 0
+            , uiNoticeElapsedMillis = 0
+            , uiCompletionRemainingMillis = 0
             , uiToolCalls = Map.empty
             }
-    UiTick ->
-        if not (uiNeedsTick state)
-            then state
-            else
-                let completionTicks =
-                        max 0 (state.uiCompletionTicks - 1)
-                    noticeTicks = state.uiNoticeTicks + 1
-                    notice
-                        | noticeTicks >= 30
-                        , maybe False (.noticeTransient) state.uiNotice =
-                            Nothing
-                        | otherwise = state.uiNotice
-                in state
-                    { uiFrame = nextUiFrame state.uiFrame
-                    , uiElapsedTenths =
-                        if state.uiRunning
-                            then state.uiElapsedTenths + 1
-                            else state.uiElapsedTenths
-                    , uiActivity =
-                        if state.uiCompletionTicks == 1
-                            then "Ready"
-                            else state.uiActivity
-                    , uiCompletionTicks = completionTicks
-                    , uiNotice = notice
-                    , uiNoticeTicks =
-                        if notice == Nothing then 0 else noticeTicks
-                    }
+
+advanceUiTime :: Int -> UiState -> UiState
+advanceUiTime rawElapsedMillis state =
+    let
+        elapsedMillis = max 0 rawElapsedMillis
+        completionRemainingMillis =
+            max 0
+                (state.uiCompletionRemainingMillis - elapsedMillis)
+        noticeElapsedMillis =
+            case state.uiNotice of
+                Just notice
+                    | notice.noticeTransient ->
+                        state.uiNoticeElapsedMillis + elapsedMillis
+                _ ->
+                    0
+        notice
+            | noticeElapsedMillis >= transientNoticeDurationMillis
+            , maybe False (.noticeTransient) state.uiNotice =
+                Nothing
+            | otherwise = state.uiNotice
+    in state
+        { uiElapsedMillis =
+            if state.uiRunning
+                then state.uiElapsedMillis + elapsedMillis
+                else state.uiElapsedMillis
+        , uiActivity =
+            if state.uiCompletionRemainingMillis > 0
+                && completionRemainingMillis == 0
+                then "Ready"
+                else state.uiActivity
+        , uiCompletionRemainingMillis = completionRemainingMillis
+        , uiNotice = notice
+        , uiNoticeElapsedMillis =
+            if notice == Nothing then 0 else noticeElapsedMillis
+        }
 
 uiNeedsTick :: UiState -> Bool
 uiNeedsTick state =
     state.uiRunning
-        || state.uiCompletionTicks > 0
-        || conversationIsEmpty state
+        || state.uiCompletionRemainingMillis > 0
         || maybe False noticeNeedsTick state.uiNotice
   where
     noticeNeedsTick notice =
         notice.noticeTransient
-            || notice.noticeKind == NoticeProgress
 
-nextUiFrame :: Int -> Int
-nextUiFrame frame =
-    (frame + 1) `mod` 120
+uiNextDeadlineMillis :: UiState -> Maybe Int
+uiNextDeadlineMillis state =
+    minimumMaybe $
+        completionDeadline <> noticeDeadline
+  where
+    completionDeadline =
+        [state.uiCompletionRemainingMillis
+        | state.uiCompletionRemainingMillis > 0]
+    noticeDeadline =
+        case state.uiNotice of
+            Just notice
+                | notice.noticeTransient ->
+                    [ max 0
+                        (transientNoticeDurationMillis
+                            - state.uiNoticeElapsedMillis)
+                    ]
+            _ ->
+                []
+    minimumMaybe [] = Nothing
+    minimumMaybe values = Just (minimum values)
 
 reduceLoop :: LoopEvent -> UiState -> UiState
 reduceLoop event state = case event of
@@ -407,8 +438,9 @@ reduceLoop event state = case event of
             , uiAwaitingInput = False
             , uiActivity = "Thinking…"
             , uiNotice = Nothing
-            , uiElapsedTenths = 0
-            , uiCompletionTicks = 0
+            , uiNoticeElapsedMillis = 0
+            , uiElapsedMillis = 0
+            , uiCompletionRemainingMillis = 0
             , uiTurnStartBlock = Seq.length state.uiBlocks
             , uiToolCalls = Map.empty
             }
@@ -468,8 +500,8 @@ reduceLoop event state = case event of
                 if continuing
                     then "Running tools…"
                     else "Finished"
-            , uiCompletionTicks =
-                if continuing then 0 else 10
+            , uiCompletionRemainingMillis =
+                if continuing then 0 else completionStatusDurationMillis
             }
 
 appendOrExtend
@@ -565,8 +597,10 @@ finalizeTurn terminalState state =
             if terminalState == BlockComplete
                 then "Finished"
                 else "Ready"
-        , uiCompletionTicks =
-            if terminalState == BlockComplete then 10 else 0
+        , uiCompletionRemainingMillis =
+            if terminalState == BlockComplete
+                then completionStatusDurationMillis
+                else 0
         }
 
 infoNotice, successNotice, warningNotice, progressNotice, errorNotice

--- a/packages/agent-tui/src/Agent/TUI/Motion.hs
+++ b/packages/agent-tui/src/Agent/TUI/Motion.hs
@@ -1,0 +1,238 @@
+-- | Shared, renderer-independent motion vocabulary for terminal UIs.
+--
+-- Animation phases are derived from elapsed milliseconds rather than a
+-- renderer-specific tick count. This keeps visual cadence and semantic
+-- lifetimes stable when the scheduler changes frequency.
+module Agent.TUI.Motion
+    ( MotionDemand(..)
+    , MotionGlyphSet(..)
+    , MotionMode(..)
+    , backgroundIndicator
+    , backgroundPulseFrames
+    , completionFlashDurationMillis
+    , completionStatusDurationMillis
+    , foregroundIndicator
+    , foregroundSpinnerFrames
+    , motionFrameAt
+    , motionDelayMicros
+    , motionIntervalMicros
+    , nativeProgressAnimationEnabled
+    , quietIndicator
+    , quietSpinnerFrames
+    , transientNoticeDurationMillis
+    , waitingIndicator
+    , waitingPulseFrames
+    ) where
+
+import Data.Text (Text)
+import Data.List.NonEmpty (NonEmpty(..))
+import qualified Data.List.NonEmpty as NonEmpty
+
+-- | User-selected animation policy.
+data MotionMode
+    = MotionFull
+    | MotionReduced
+    | MotionOff
+    deriving (Eq, Ord, Show)
+
+-- | The fastest visible or semantic clock currently required by the UI.
+data MotionDemand
+    = MotionNone
+    | MotionSlow
+    | MotionFast
+    deriving (Eq, Ord, Show)
+
+data MotionGlyphSet
+    = MotionUnicode
+    | MotionAscii
+    deriving (Eq, Ord, Show)
+
+foregroundSpinnerFrames :: MotionGlyphSet -> [Text]
+foregroundSpinnerFrames =
+    NonEmpty.toList . foregroundSpinnerFamily
+
+foregroundSpinnerFamily :: MotionGlyphSet -> NonEmpty Text
+foregroundSpinnerFamily = \case
+    MotionUnicode ->
+        "⠋" :| ["⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧"]
+    MotionAscii ->
+        "|" :| ["/", "-", "\\"]
+
+quietSpinnerFrames :: MotionGlyphSet -> [Text]
+quietSpinnerFrames =
+    NonEmpty.toList . quietSpinnerFamily
+
+quietSpinnerFamily :: MotionGlyphSet -> NonEmpty Text
+quietSpinnerFamily = \case
+    MotionUnicode ->
+        "⋅" :| [":", "⸬", "⁙"]
+    MotionAscii ->
+        "." :| [":", "*", ":"]
+
+backgroundPulseFrames :: MotionGlyphSet -> [Text]
+backgroundPulseFrames =
+    NonEmpty.toList . backgroundPulseFamily
+
+backgroundPulseFamily :: MotionGlyphSet -> NonEmpty Text
+backgroundPulseFamily = \case
+    MotionUnicode ->
+        "○" :| ["◎", "◉", "◎"]
+    MotionAscii ->
+        "o" :| ["O", "@", "O"]
+
+-- | The intermediate shapes make the pulse legible in monochrome terminals;
+-- colour renderers can additionally vary brightness.
+waitingPulseFrames :: MotionGlyphSet -> [Text]
+waitingPulseFrames =
+    NonEmpty.toList . waitingPulseFamily
+
+waitingPulseFamily :: MotionGlyphSet -> NonEmpty Text
+waitingPulseFamily = \case
+    MotionUnicode ->
+        "◇" :| ["◈", "◆", "◈"]
+    MotionAscii ->
+        "." :| ["*", "#", "*"]
+
+foregroundIndicator
+    :: MotionGlyphSet
+    -> MotionMode
+    -> Int
+    -> Text
+foregroundIndicator glyphs mode elapsedMillis = case mode of
+    MotionFull ->
+        motionFrameAt
+            foregroundFrameDurationMillis
+            elapsedMillis
+            (foregroundSpinnerFamily glyphs)
+    MotionReduced ->
+        staticForeground glyphs
+    MotionOff ->
+        staticForeground glyphs
+
+quietIndicator
+    :: MotionGlyphSet
+    -> MotionMode
+    -> Int
+    -> Text
+quietIndicator glyphs mode elapsedMillis = case mode of
+    MotionFull ->
+        motionFrameAt
+            quietFrameDurationMillis
+            elapsedMillis
+            (quietSpinnerFamily glyphs)
+    MotionReduced ->
+        staticQuiet glyphs
+    MotionOff ->
+        staticQuiet glyphs
+
+backgroundIndicator
+    :: MotionGlyphSet
+    -> MotionMode
+    -> Int
+    -> Text
+backgroundIndicator glyphs mode elapsedMillis = case mode of
+    MotionFull ->
+        motionFrameAt
+            backgroundFrameDurationMillis
+            elapsedMillis
+            (backgroundPulseFamily glyphs)
+    MotionReduced ->
+        staticBackground glyphs
+    MotionOff ->
+        staticBackground glyphs
+
+waitingIndicator
+    :: MotionGlyphSet
+    -> MotionMode
+    -> Int
+    -> Text
+waitingIndicator glyphs mode elapsedMillis = case mode of
+    MotionFull ->
+        motionFrameAt
+            waitingFrameDurationMillis
+            elapsedMillis
+            (waitingPulseFamily glyphs)
+    MotionReduced ->
+        staticWaiting glyphs
+    MotionOff ->
+        staticWaiting glyphs
+
+motionFrameAt :: Int -> Int -> NonEmpty a -> a
+motionFrameAt frameDurationMillis elapsedMillis frames =
+    NonEmpty.toList frames
+        !! ((max 0 elapsedMillis `div` max 1 frameDurationMillis)
+            `mod` NonEmpty.length frames)
+
+-- | Scheduler cadence. Full motion deliberately stays below 30 FPS until the
+-- Brick/Vty cursor-blink path has been audited at that rate.
+motionIntervalMicros :: MotionMode -> MotionDemand -> Int
+motionIntervalMicros mode demand = case (mode, demand) of
+    (_, MotionNone) -> 1000000
+    (MotionFull, MotionSlow) -> 160000
+    (MotionFull, MotionFast) -> 80000
+    (MotionReduced, _) -> 500000
+    (MotionOff, _) -> 1000000
+
+-- | Wake no later than the next semantic deadline, even when accessibility
+-- policy caps cosmetic animation at a slower cadence.
+motionDelayMicros
+    :: MotionMode
+    -> MotionDemand
+    -> Maybe Int
+    -- ^ Milliseconds until the earliest semantic deadline.
+    -> Int
+motionDelayMicros mode demand deadlineMillis =
+    case deadlineMillis of
+        Nothing ->
+            cadence
+        Just remaining ->
+            min cadence (max 1 remaining * 1000)
+  where
+    cadence = motionIntervalMicros mode demand
+
+nativeProgressAnimationEnabled :: MotionMode -> Bool
+nativeProgressAnimationEnabled = \case
+    MotionFull -> True
+    MotionReduced -> False
+    MotionOff -> False
+
+completionFlashDurationMillis :: Int
+completionFlashDurationMillis = 400
+
+completionStatusDurationMillis :: Int
+completionStatusDurationMillis = 1000
+
+transientNoticeDurationMillis :: Int
+transientNoticeDurationMillis = 3000
+
+foregroundFrameDurationMillis :: Int
+foregroundFrameDurationMillis = 160
+
+quietFrameDurationMillis :: Int
+quietFrameDurationMillis = 160
+
+backgroundFrameDurationMillis :: Int
+backgroundFrameDurationMillis = 320
+
+waitingFrameDurationMillis :: Int
+waitingFrameDurationMillis = 320
+
+staticForeground :: MotionGlyphSet -> Text
+staticForeground = \case
+    MotionUnicode -> "●"
+    MotionAscii -> "*"
+
+staticQuiet :: MotionGlyphSet -> Text
+staticQuiet = \case
+    MotionUnicode -> "·"
+    MotionAscii -> "."
+
+staticBackground :: MotionGlyphSet -> Text
+staticBackground = \case
+    MotionUnicode -> "○"
+    MotionAscii -> "o"
+
+staticWaiting :: MotionGlyphSet -> Text
+staticWaiting = \case
+    MotionUnicode -> "◆"
+    MotionAscii -> "!"

--- a/packages/agent-tui/src/Agent/TUI/Theme.hs
+++ b/packages/agent-tui/src/Agent/TUI/Theme.hs
@@ -41,6 +41,9 @@ module Agent.TUI.Theme
     , thinkingAttr
     , toolAttr
     , userAttr
+    , waitingDimAttr
+    , waitingMidAttr
+    , completionFlashAttr
     , monochrome
     , solarizedDark
     ) where
@@ -60,6 +63,7 @@ syntaxNormalAttr, syntaxKeywordAttr, syntaxTypeAttr, syntaxFunctionAttr :: AttrN
 syntaxVariableAttr, syntaxStringAttr, syntaxNumberAttr, syntaxCommentAttr :: AttrName
 syntaxOperatorAttr, syntaxAnnotationAttr, syntaxPreprocessorAttr :: AttrName
 syntaxWarningAttr, syntaxErrorAttr :: AttrName
+waitingDimAttr, waitingMidAttr, completionFlashAttr :: AttrName
 baseAttr = attrName "base"
 headerAttr = attrName "header"
 footerAttr = attrName "footer"
@@ -116,6 +120,9 @@ syntaxClassAttr = \case
     SyntaxPreprocessor -> syntaxPreprocessorAttr
     SyntaxWarning -> syntaxWarningAttr
     SyntaxError -> syntaxErrorAttr
+waitingDimAttr = attrName "waiting-dim"
+waitingMidAttr = attrName "waiting-mid"
+completionFlashAttr = attrName "completion-flash"
 
 solarizedDark :: AttrMap
 solarizedDark =
@@ -144,6 +151,12 @@ solarizedDark =
         , (thinkingAttr, V.defAttr
             `V.withForeColor` rgb 181 137 0
             `V.withBackColor` rgb 0 43 54)
+        , (waitingDimAttr, V.defAttr
+            `V.withForeColor` rgb 101 83 0
+            `V.withBackColor` rgb 0 43 54)
+        , (waitingMidAttr, V.defAttr
+            `V.withForeColor` rgb 150 112 0
+            `V.withBackColor` rgb 0 43 54)
         , (toolAttr, V.defAttr
             `V.withForeColor` rgb 42 161 152
             `V.withBackColor` rgb 0 43 54)
@@ -154,6 +167,10 @@ solarizedDark =
         , (successAttr, V.defAttr
             `V.withForeColor` rgb 133 153 0
             `V.withBackColor` rgb 0 43 54)
+        , (completionFlashAttr, V.defAttr
+            `V.withForeColor` rgb 181 196 0
+            `V.withBackColor` rgb 0 43 54
+            `V.withStyle` V.bold)
         , (selectedAttr, V.defAttr
             `V.withForeColor` rgb 147 161 161
             `V.withBackColor` rgb 7 54 66)
@@ -241,9 +258,12 @@ monochrome =
         , (userAttr, V.defAttr `V.withStyle` V.bold)
         , (assistantAttr, V.defAttr)
         , (thinkingAttr, V.defAttr)
+        , (waitingDimAttr, V.defAttr)
+        , (waitingMidAttr, V.defAttr)
         , (toolAttr, V.defAttr)
         , (errorAttr, V.defAttr `V.withStyle` V.bold)
         , (successAttr, V.defAttr)
+        , (completionFlashAttr, V.defAttr `V.withStyle` V.bold)
         , (selectedAttr, V.defAttr `V.withStyle` V.reverseVideo)
         , (borderAttr, V.defAttr)
         , (borderActiveAttr, V.defAttr `V.withStyle` V.bold)

--- a/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
@@ -166,32 +166,35 @@ spec = describe "fullscreen UI reducer" do
                 block.blockBody `shouldBe` "live output"
             _ -> expectationFailure "expected one running tool block"
 
-    it "animates an empty conversation without advancing elapsed time" do
-        let emptyIdle = apply [UiSystemMessage "startup status", UiTick, UiTick]
-            wrapped =
-                apply (UiSystemMessage "startup status" : replicate 120 UiTick)
+    it "uses elapsed milliseconds without advancing idle turn time" do
+        let emptyIdle =
+                advanceUiTime 67 $
+                    advanceUiTime 33 $
+                        apply [UiSystemMessage "startup status"]
             nonEmptyIdle =
-                reduceUi UiTick $
+                advanceUiTime 100 $
                     reduceUi (UiUserSubmitted "hello") initialUiState
             compactedHistory =
                 reduceUi (UiHistory "compacted summary") initialUiState
-            running = apply [UiLoop TurnStarted, UiTick, UiTick, UiTick]
+            running =
+                advanceUiTime 100 $
+                    advanceUiTime 67 $
+                        advanceUiTime 33 $
+                            apply [UiLoop TurnStarted]
             finished =
                 reduceUi
                     (UiLoop
                         (TurnFinished
                             (emptyTurnOutput "r1" [] Nothing)))
                     running
-            after = reduceUi UiTick finished
-        emptyIdle.uiElapsedTenths `shouldBe` 0
-        emptyIdle.uiFrame `shouldBe` 2
-        wrapped.uiFrame `shouldBe` 0
+            after = advanceUiTime 100 finished
+        emptyIdle.uiElapsedMillis `shouldBe` 0
         conversationIsEmpty emptyIdle `shouldBe` True
         conversationIsEmpty nonEmptyIdle `shouldBe` False
         conversationIsEmpty compactedHistory `shouldBe` False
-        nonEmptyIdle.uiFrame `shouldBe` 0
-        running.uiElapsedTenths `shouldBe` 3
-        after.uiElapsedTenths `shouldBe` 3
+        nonEmptyIdle.uiElapsedMillis `shouldBe` 0
+        running.uiElapsedMillis `shouldBe` 200
+        after.uiElapsedMillis `shouldBe` 200
 
     it "briefly settles on Finished before returning to Ready" do
         let finished =
@@ -202,12 +205,14 @@ spec = describe "fullscreen UI reducer" do
                             (emptyTurnOutput "r1" [] Nothing))
                     ]
             awaiting = reduceUi (UiSetAwaitingInput True) finished
-            settled = iterate (reduceUi UiTick) awaiting !! 10
+            almostSettled = advanceUiTime 999 awaiting
+            settled = advanceUiTime 1 almostSettled
         finished.uiActivity `shouldBe` "Finished"
-        finished.uiCompletionTicks `shouldBe` 10
+        finished.uiCompletionRemainingMillis `shouldBe` 1000
         awaiting.uiActivity `shouldBe` "Finished"
+        almostSettled.uiActivity `shouldBe` "Finished"
         settled.uiActivity `shouldBe` "Ready"
-        settled.uiCompletionTicks `shouldBe` 0
+        settled.uiCompletionRemainingMillis `shouldBe` 0
 
     it "expires transient notices but keeps progress notices visible" do
         let transient =
@@ -215,15 +220,37 @@ spec = describe "fullscreen UI reducer" do
                     (UiSetNotice
                         (Just (successNotice "Copied selected block.")))
                     initialUiState
-            expired = iterate (reduceUi UiTick) transient !! 30
+            visible = advanceUiTime 2999 transient
+            expired = advanceUiTime 1 visible
             progress =
                 reduceUi
                     (UiSetNotice (Just (progressNotice "Cancelling…")))
                     initialUiState
-            stillProgress = iterate (reduceUi UiTick) progress !! 40
+            stillProgress = advanceUiTime 40000 progress
+        visible.uiNotice
+            `shouldBe` Just (successNotice "Copied selected block.")
+        uiNextDeadlineMillis transient `shouldBe` Just 3000
+        uiNextDeadlineMillis visible `shouldBe` Just 1
         expired.uiNotice `shouldBe` Nothing
         stillProgress.uiNotice
             `shouldBe` Just (progressNotice "Cancelling…")
+        stillProgress.uiNoticeElapsedMillis `shouldBe` 0
+        uiNextDeadlineMillis stillProgress `shouldBe` Nothing
+
+    it "does not let replacement notices inherit elapsed time" do
+        let almostExpired =
+                advanceUiTime 2999 $
+                    reduceUi
+                        (UiSetNotice (Just (successNotice "Saved.")))
+                        initialUiState
+            replaced = reduceUi (UiInputPromoted "send next") almostExpired
+            stillVisible = advanceUiTime 1 replaced
+        replaced.uiNoticeElapsedMillis `shouldBe` 0
+        stillVisible.uiNotice
+            `shouldBe`
+                Just
+                    (warningNotice
+                        "Cancelling the current turn; sending this prompt next…")
 
     it "shows a search-replace diff while the tool is running" do
         let call =
@@ -408,7 +435,7 @@ spec = describe "fullscreen UI reducer" do
         afterTool.uiRunning `shouldBe` True
         finished.uiRunning `shouldBe` False
         finished.uiActivity `shouldBe` "Finished"
-        finished.uiCompletionTicks `shouldBe` 10
+        finished.uiCompletionRemainingMillis `shouldBe` 1000
 
     it "deletes the previous word for command/option-backspace" do
         deleteWordBefore "hello brave world" 17

--- a/packages/agent-tui/test/Agent/TUI/MotionSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/MotionSpec.hs
@@ -1,0 +1,102 @@
+module Agent.TUI.MotionSpec (spec) where
+
+import Agent.TUI.Motion
+import qualified Data.Text as Text
+import qualified Graphics.Vty as V
+import Test.Hspec
+
+spec :: Spec
+spec = describe "terminal motion vocabulary" do
+    it "keeps every animation frame exactly one terminal cell wide" do
+        let families glyphs =
+                [ foregroundSpinnerFrames glyphs
+                , quietSpinnerFrames glyphs
+                , backgroundPulseFrames glyphs
+                , waitingPulseFrames glyphs
+                ]
+        mapM_
+            (\frame -> do
+                V.safeWcswidth (Text.unpack frame) `shouldBe` 1
+                let image = V.text' V.defAttr frame
+                V.imageWidth image `shouldBe` 1
+                V.imageHeight image `shouldBe` 1)
+            (concat (concatMap families [MotionUnicode, MotionAscii]))
+
+    it "keeps reduced and off indicators static" do
+        let samples indicator mode =
+                [ indicator MotionUnicode mode elapsed
+                | elapsed <- [0, 80, 320, 1000, 10000]
+                ]
+        samples foregroundIndicator MotionReduced
+            `shouldSatisfy` allEqual
+        samples foregroundIndicator MotionOff
+            `shouldSatisfy` allEqual
+        samples quietIndicator MotionReduced
+            `shouldSatisfy` allEqual
+        samples backgroundIndicator MotionOff
+            `shouldSatisfy` allEqual
+        samples waitingIndicator MotionReduced
+            `shouldSatisfy` allEqual
+
+    it "advances and wraps every full-motion frame family" do
+        mapM_
+            (\glyphs -> do
+                cyclesThrough
+                    foregroundIndicator
+                    glyphs
+                    160
+                    (foregroundSpinnerFrames glyphs)
+                cyclesThrough
+                    quietIndicator
+                    glyphs
+                    160
+                    (quietSpinnerFrames glyphs)
+                cyclesThrough
+                    backgroundIndicator
+                    glyphs
+                    320
+                    (backgroundPulseFrames glyphs)
+                cyclesThrough
+                    waitingIndicator
+                    glyphs
+                    320
+                    (waitingPulseFrames glyphs))
+            [MotionUnicode, MotionAscii]
+
+    it "uses fast cadence only when full motion is enabled" do
+        motionIntervalMicros MotionFull MotionFast
+            `shouldSatisfy`
+                (< motionIntervalMicros MotionFull MotionSlow)
+        motionIntervalMicros MotionReduced MotionFast
+            `shouldBe` motionIntervalMicros MotionReduced MotionSlow
+        motionIntervalMicros MotionOff MotionFast
+            `shouldBe` motionIntervalMicros MotionOff MotionSlow
+
+    it "wakes at semantic deadlines before a reduced-motion cadence" do
+        motionDelayMicros MotionReduced MotionSlow Nothing
+            `shouldBe` 500000
+        motionDelayMicros MotionReduced MotionSlow (Just 400)
+            `shouldBe` 400000
+        motionDelayMicros MotionOff MotionSlow (Just 250)
+            `shouldBe` 250000
+
+    it "disables terminal-native animation outside full motion" do
+        nativeProgressAnimationEnabled MotionFull `shouldBe` True
+        nativeProgressAnimationEnabled MotionReduced `shouldBe` False
+        nativeProgressAnimationEnabled MotionOff `shouldBe` False
+
+allEqual :: Eq a => [a] -> Bool
+allEqual [] = True
+allEqual (first : rest) = all (== first) rest
+
+cyclesThrough
+    :: (MotionGlyphSet -> MotionMode -> Int -> Text.Text)
+    -> MotionGlyphSet
+    -> Int
+    -> [Text.Text]
+    -> Expectation
+cyclesThrough indicator glyphs frameMillis frames =
+    [ indicator glyphs MotionFull (index * frameMillis)
+    | index <- [0 .. length frames]
+    ]
+        `shouldBe` (frames <> take 1 frames)

--- a/packages/agent-tui/test/Spec.hs
+++ b/packages/agent-tui/test/Spec.hs
@@ -2,6 +2,7 @@ module Main (main) where
 
 import qualified Agent.TUI.FencedCodeSpec as FencedCodeSpec
 import qualified Agent.TUI.MarkdownSpec as MarkdownSpec
+import qualified Agent.TUI.MotionSpec as MotionSpec
 import qualified Agent.TUI.ModelSpec as ModelSpec
 import qualified Agent.TUI.ThemeSpec as ThemeSpec
 import Test.Hspec (hspec)
@@ -10,5 +11,6 @@ main :: IO ()
 main = hspec do
     FencedCodeSpec.spec
     MarkdownSpec.spec
+    MotionSpec.spec
     ModelSpec.spec
     ThemeSpec.spec


### PR DESCRIPTION
## Summary

- add a shared semantic motion model with `full`, `reduced`, and `off` policies
- animate foreground work, user-waiting states, background tasks, and completion transitions in both fullscreen and minimal renderers
- drive fullscreen motion from monotonic, demand-based scheduling rather than a permanent redraw loop
- preserve timer correctness across composer-local events and native terminal progress
- expose motion controls independently from color and terminal capabilities

## Testing

- `nix develop --command cabal test agent-tui:agent-tui-test agent-cli:agent-cli-test -j1 --test-show-details=never` (501 CLI examples and 46 TUI examples)
- `nix flake check --no-build --option eval-cache false`
- `git diff --check origin/master...HEAD`
- tmux/Vty synthetic smoke covering active thinking, waiting-for-user motion, tool completion, and turn completion
