### PR TITLE
Render provider errors as actionable user-facing messages

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -48,6 +48,8 @@ library
                     , Agent.CLI.Connectivity
                     , Agent.CLI.Command
                     , Agent.CLI.CredentialStore
+                    , Agent.CLI.Duration
+                    , Agent.CLI.Error
                     , Agent.CLI.ImagePreview
                     , Agent.CLI.Input
                     , Agent.CLI.Interrupt
@@ -145,6 +147,7 @@ test-suite agent-cli-test
                     , Agent.CLI.CompactionSpec
                     , Agent.CLI.ConnectivitySpec
                     , Agent.CLI.CredentialStoreSpec
+                    , Agent.CLI.ErrorSpec
                     , Agent.CLI.ImagePreviewSpec
                     , Agent.CLI.InputSpec
                     , Agent.CLI.InterruptSpec

--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -71,6 +71,10 @@ import Agent.CLI.Compaction
     , runProviderCompact
     )
 import Agent.CLI.Connectivity (withConnectionRecovery)
+import Agent.CLI.Error
+    ( formatApiErrorAt
+    , formatApiErrorInlineAt
+    )
 import Agent.CLI.ImagePreview
     ( detectImagePreviewProtocol
     , previewColumnsFor
@@ -1070,9 +1074,11 @@ runAgentInitialized options transition home root resumed cwd startup = do
                                         Just active
                                             | active.transitionCause == AutomaticFallback ->
                                                 pure (RunProviderStartFailed err)
-                                        _ ->
+                                        _ -> do
+                                            now <- getCurrentTime
                                             startupDie startup
-                                                ("openai auth: " <> show err)
+                                                (Text.unpack
+                                                    (formatApiErrorAt now err))
                                 Right result -> pure result
                     XAIProvider -> do
                         xaiOptions <- XAI.clientOptionsFromEnv
@@ -1767,17 +1773,9 @@ reportProviderUnavailable :: ApiError -> IO ()
 reportProviderUnavailable apiError = do
     color <- resolveColor stderr
     now <- getCurrentTime
-    let detail = case apiError of
-            CredentialsExhausted{retryAt} ->
-                let delay = max 0 (diffUTCTime retryAt now)
-                in "all configured accounts are temporarily unavailable"
-                    <> if delay == 0
-                        then "; retry now"
-                        else "; retry in " <> formatDuration delay
-            _ -> Text.pack (show apiError)
     putTextLn stderr $ roleError color $
-        "provider unavailable; no usable fallback provider account is available: "
-            <> detail
+        "No usable fallback provider account is available.\n"
+            <> formatApiErrorAt now apiError
 
 setSessionEffort :: SessionEnv -> Text -> IO ()
 setSessionEffort env level = do
@@ -2905,7 +2903,8 @@ accountUsageText color provider tokenProvider openAiPool = do
                                 Left err ->
                                     pure $
                                         roleError color
-                                            ("usage: " <> Text.pack (show err))
+                                            ("usage: "
+                                                <> formatApiErrorInlineAt now err)
                                 Right credential -> do
                                     result <- fetchUsage
                                         credential.accessToken credential.accountId
@@ -3099,11 +3098,13 @@ validateProviderTarget choice =
                 <> err
         Right loaded ->
             probeLoadedAuth loaded >>= \case
-                Left err -> pure $ Left $
-                    "cannot switch to "
-                        <> providerSlug choice.modelProvider
-                        <> ": credentials unavailable: "
-                        <> Text.pack (show err)
+                Left err -> do
+                    now <- getCurrentTime
+                    pure $ Left $
+                        "cannot switch to "
+                            <> providerSlug choice.modelProvider
+                            <> ": "
+                            <> formatApiErrorInlineAt now err
                 Right usable
                     | usable.loadedProvider /= choice.modelProvider ->
                         pure $ Left $
@@ -3202,9 +3203,10 @@ reloadAuth provider = \case
                 }
             , failure = AccountAuthenticationRejected
             }) >>= \case
-            Left err ->
+            Left err -> do
+                now <- getCurrentTime
                 pure $ Left $
-                    "reload-auth failed: " <> Text.pack (show err)
+                    "reload-auth failed: " <> formatApiErrorInlineAt now err
             Right credential ->
                 pure $ Right $
                     "auth reloaded ("

--- a/packages/agent-cli/src/Agent/CLI/AgentSessions.hs
+++ b/packages/agent-cli/src/Agent/CLI/AgentSessions.hs
@@ -14,6 +14,7 @@ module Agent.CLI.AgentSessions
     ) where
 
 import Agent.CLI.Options (ApprovalPolicy(..))
+import Agent.CLI.Error (formatException)
 import Agent.CLI.Session
     ( SessionCreate(..)
     , SessionHandle(..)
@@ -187,7 +188,7 @@ launchSessionTurn manager background policy handle message =
                                     ( processes
                                     , Left
                                         ("failed to start agent session: "
-                                            <> Text.pack (show err))
+                                            <> formatException err)
                                     )
                             Right (_, _, _, process)
                                 | background ->

--- a/packages/agent-cli/src/Agent/CLI/Auth.hs
+++ b/packages/agent-cli/src/Agent/CLI/Auth.hs
@@ -26,7 +26,7 @@ import Agent.CLI.CredentialStore
     , withCredentialRefreshFileLock
     , updateManagedCredentialSecret
     )
-import Agent.Error (ApiError(..), ErrorType(..))
+import Agent.Error (ApiError(..))
 import Agent.FileRetry (retryOnFileBusy)
 import qualified Agent.OpenAI.Auth as OpenAI
 import qualified Agent.OpenAI.Credential as OpenAICredential
@@ -38,6 +38,7 @@ import Agent.Provider
     , Provider(..)
     , TokenProvider(..)
     , getNextToken
+    , providerSlug
     , seedTokenProvider
     )
 import Agent.OpenRouter.Credential (credentialFromApiKey)
@@ -142,9 +143,8 @@ probeLoadedAuth loaded = do
         Left err -> pure (Left err)
         Right credential
             | credential.provider /= loaded.loadedProvider ->
-                pure $ Left $ ProviderError AuthenticationError
+                pure $ Left $ CredentialError
                     "credential provider does not match loaded auth"
-                    Nothing
             | otherwise -> do
                 tokenProvider <-
                     seedTokenProvider loaded.loadedTokenProvider credential
@@ -412,19 +412,17 @@ refreshOpenAiAccount lock clientId accountSources stale =
             ((== stale.accountId) . (.accountId) . (.openAiState))
             accounts of
             Nothing ->
-                pure $ Left $ ProviderError AuthenticationError
+                pure $ Left $ CredentialError
                     ("OpenAI refresh source is unavailable for account "
                         <> stale.accountId)
-                    Nothing
             Just account ->
                 withOpenAiSourceLock account.openAiSource do
                     reloadOpenAiAccount account.openAiSource stale >>= \case
                         Left err -> pure (Left err)
                         Right current
                             | current.accountId /= stale.accountId ->
-                                pure $ Left $ ProviderError AuthenticationError
+                                pure $ Left $ CredentialError
                                     "OpenAI auth source changed account identity"
-                                    Nothing
                             | openAiAuthStateChanged stale current ->
                                 pure (Right current)
                             | otherwise ->
@@ -432,9 +430,8 @@ refreshOpenAiAccount lock clientId accountSources stale =
                                     Left err -> pure (Left err)
                                     Right newState
                                         | newState.accountId /= stale.accountId ->
-                                            pure $ Left $ ProviderError AuthenticationError
+                                            pure $ Left $ CredentialError
                                                 "OpenAI refresh changed account identity"
-                                                Nothing
                                         | otherwise ->
                                             persistRefreshedOpenAiAccount
                                                 account.openAiSource newState
@@ -518,16 +515,14 @@ reloadOpenAiAccount source stale =
                         ((== managedId) . (.managedId) . fst)
                         credentials of
                         Nothing ->
-                            pure $ Left $ ProviderError AuthenticationError
+                            pure $ Left $ CredentialError
                                 ("managed OpenAI credential " <> managedId
                                     <> " no longer exists")
-                                Nothing
                         Just (metadata, secret)
                             | not metadata.managedEnabled ->
-                                pure $ Left $ ProviderError AuthenticationError
+                                pure $ Left $ CredentialError
                                     ("managed OpenAI credential " <> managedId
                                         <> " is disabled")
-                                    Nothing
                             | otherwise -> do
                                 now <- getCurrentTime
                                 pure $ case openaiAuthStateFromJson now
@@ -535,27 +530,24 @@ reloadOpenAiAccount source stale =
                                         (TextEncoding.encodeUtf8
                                             secret.secretPayload)) of
                                     Nothing ->
-                                        Left $ ProviderError AuthenticationError
+                                        Left $ CredentialError
                                             ("managed OpenAI credential "
                                                 <> managedId
                                                 <> " contains invalid auth JSON")
-                                            Nothing
                                     Just current -> Right current
         OpenAiAuthFile filePath -> do
             exists <- doesFileExist filePath
             if not exists
-                then pure $ Left $ ProviderError AuthenticationError
+                then pure $ Left $ CredentialError
                     "OpenAI auth file no longer exists"
-                    Nothing
                 else do
                     now <- getCurrentTime
                     bytes <- retryOnFileBusy
                         (LBS.readFile (unsafeToFilePath filePath))
                     pure $ case openaiAuthStateFromJson now bytes of
                         Nothing ->
-                            Left $ ProviderError AuthenticationError
+                            Left $ CredentialError
                                 "OpenAI auth file contains invalid auth JSON"
-                                Nothing
                         Just current -> Right current
         OpenAiEnvironmentOAuth ->
             pure (Right stale)
@@ -566,10 +558,9 @@ reloadOpenAiAccount source stale =
 
 staticRefreshError :: Text -> IO (Either ApiError OpenAI.AuthState)
 staticRefreshError accountId =
-    pure $ Left $ ProviderError AuthenticationError
+    pure $ Left $ CredentialError
         ("OpenAI account " <> accountId
             <> " uses a static bearer token that cannot be refreshed")
-        Nothing
 
 persistRefreshedOpenAiAccount
     :: OpenAiCredentialSource
@@ -809,9 +800,8 @@ refreshManagedGrok metadata _secret stateRef refresh state =
                 now <- getCurrentTime
                 case grokAuthStateFromJson now latestSecret.secretPayload of
                     Nothing ->
-                        pure $ Left $ ProviderError AuthenticationError
+                        pure $ Left $ CredentialError
                             "managed Grok OAuth credential became invalid during refresh"
-                            Nothing
                     Just current
                         | grokStateChanged state current -> do
                             writeIORef stateRef current
@@ -839,9 +829,8 @@ refreshCurrentGrok
 refreshCurrentGrok metadata secret stateRef refresh state =
     case state.grokRefreshToken of
         Nothing ->
-            pure $ Left $ ProviderError AuthenticationError
+            pure $ Left $ CredentialError
                 "managed Grok OAuth credential has no refresh token; reconnect the account"
-                Nothing
         Just refreshToken ->
             refresh refreshToken >>= \case
                 Left err -> pure (Left err)
@@ -978,21 +967,18 @@ reloadableFileCredentialProvider expectedProvider initial reload = do
     let loadFresh rejectedToken =
             reload >>= \case
                 Nothing ->
-                    pure $ Left $ ProviderError AuthenticationError
+                    pure $ Left $ CredentialError
                         "no credentials found while reloading auth"
-                        Nothing
                 Just credential
                     | credential.provider /= expectedProvider ->
-                        pure $ Left $ ProviderError AuthenticationError
+                        pure $ Left $ CredentialError
                             ("reloaded auth resolved "
-                                <> Text.pack (show credential.provider)
+                                <> providerSlug credential.provider
                                 <> " but this session expects "
-                                <> Text.pack (show expectedProvider))
-                            Nothing
+                                <> providerSlug expectedProvider)
                     | rejectedToken == Just credential.accessToken ->
-                        pure $ Left $ ProviderError AuthenticationError
+                        pure $ Left $ CredentialError
                             "reloaded credential is unchanged; refresh ~/.grok/auth.json or OPENROUTER_API_KEY and retry"
-                            Nothing
                     | otherwise -> do
                         writeIORef cache (Just credential)
                         pure (Right credential)
@@ -1027,9 +1013,8 @@ staticCredentialProvider credential = TokenProvider \failed ->
         Just FailedCredential
             { failure = AccountAuthenticationRejected
             } ->
-                pure $ Left $ ProviderError AuthenticationError
+                pure $ Left $ CredentialError
                     "static credential was rejected"
-                    Nothing
 
 lookupNonEmpty :: String -> IO (Maybe Text)
 lookupNonEmpty name = do

--- a/packages/agent-cli/src/Agent/CLI/Btw.hs
+++ b/packages/agent-cli/src/Agent/CLI/Btw.hs
@@ -9,6 +9,7 @@ module Agent.CLI.Btw
     ) where
 
 import Agent.Cancel (CancelFlag, newCancelFlag, waitCancel)
+import Agent.CLI.Error (formatApiErrorInline)
 import Agent.Error (ApiError)
 import Agent.Loop (Backend(..), TurnInput(..), TurnOutput(..))
 import Agent.Responses.Types
@@ -150,7 +151,8 @@ classifyTurn turn
 
 formatBtwError :: BtwError -> Text
 formatBtwError = \case
-    BtwTransport err -> "side question failed: " <> Text.pack (show err)
+    BtwTransport err ->
+        "side question failed: " <> formatApiErrorInline err
     BtwCancelled -> "side question cancelled"
     BtwEmptyResponse -> "side question returned an empty response"
     BtwUnexpectedToolCall ->

--- a/packages/agent-cli/src/Agent/CLI/Clipboard.hs
+++ b/packages/agent-cli/src/Agent/CLI/Clipboard.hs
@@ -9,6 +9,7 @@ module Agent.CLI.Clipboard
     , formatImageSize
     ) where
 
+import Agent.CLI.Error (formatException)
 import Agent.Loop (ImageAttachment(..))
 import Control.Exception.Safe (tryAny)
 import Control.Monad (filterM)
@@ -253,7 +254,7 @@ readMacClipboardClass typeClass = do
                 _ <- tryAny (removeFile path)
                 pure (Left (clipboardErrorMessage typeClass err))
     case result of
-        Left ex -> pure (Left (Text.pack (show ex)))
+        Left ex -> pure (Left (formatException ex))
         Right value -> pure value
 
 --------------------------------------------------------------------------------
@@ -304,7 +305,7 @@ readImageFile :: FilePath -> IO (Either Text ImageAttachment)
 readImageFile path = do
     result <- tryAny (BS.readFile path)
     pure $ case result of
-        Left ex -> Left (Text.pack (show ex))
+        Left ex -> Left (formatException ex)
         Right bytes
             | BS.null bytes -> Left ("empty image file: " <> Text.pack path)
             | otherwise ->
@@ -326,7 +327,7 @@ runTextCmd :: FilePath -> [String] -> IO (Either Text Text)
 runTextCmd cmd args = do
     result <- tryAny (readProcessWithExitCode cmd args "")
     pure $ case result of
-        Left ex -> Left (Text.pack (show ex))
+        Left ex -> Left (formatException ex)
         Right (ExitSuccess, out, _) -> Right (Text.pack out)
         Right (ExitFailure _, _, err) ->
             Left (Text.strip (Text.pack err))
@@ -358,7 +359,7 @@ runBytesCmd cmd args = do
                 _ <- tryAny (removeFile path)
                 pure (Left (Text.strip (Text.pack err)))
     case result of
-        Left ex -> pure (Left (Text.pack (show ex)))
+        Left ex -> pure (Left (formatException ex))
         Right value -> pure value
 
 shellQuote :: String -> String

--- a/packages/agent-cli/src/Agent/CLI/Compaction.hs
+++ b/packages/agent-cli/src/Agent/CLI/Compaction.hs
@@ -10,6 +10,7 @@ module Agent.CLI.Compaction
     , runProviderCompact
     ) where
 
+import Agent.CLI.Error (formatApiError)
 import Agent.Error (ApiError(..), ErrorType(..))
 import Agent.Loop
     ( Backend(..)
@@ -423,6 +424,8 @@ autoCompactOpenAiBackendWithLimit getLimit compactAction transcriptRef contextTo
                 retryAfter
         ConnectionError message ->
             ConnectionError ("automatic compaction failed: " <> message)
+        CredentialError message ->
+            CredentialError ("automatic compaction failed: " <> message)
         err -> err
 
 requireTokenProvider
@@ -454,6 +457,3 @@ providerLabel = \case
 hasFocus :: Maybe Text -> Bool
 hasFocus =
     maybe False (not . Text.null . Text.strip)
-
-formatApiError :: ApiError -> Text
-formatApiError err = Text.pack (show err)

--- a/packages/agent-cli/src/Agent/CLI/CredentialStore.hs
+++ b/packages/agent-cli/src/Agent/CLI/CredentialStore.hs
@@ -16,6 +16,7 @@ module Agent.CLI.CredentialStore
     , withCredentialRefreshFileLock
     ) where
 
+import Agent.CLI.Error (formatException)
 import Agent.FileRetry (retryOnFileBusy, writeLazyFileAtomically)
 import Agent.OsPath (toText, unsafeToFilePath)
 import Agent.Provider (Provider(..), parseProvider, providerSlug)
@@ -438,7 +439,7 @@ decodeFileOrEmpty path empty = do
             Left exception ->
                 pure $ Left
                     ("could not read " <> toText path <> ": "
-                        <> Text.pack (show exception))
+                        <> formatException exception)
             Right bytes -> pure case Aeson.eitherDecode bytes of
                 Left err ->
                     Left
@@ -452,7 +453,7 @@ writePrivateJson path value =
         Left exception ->
             pure $ Left
                 ("could not write " <> toText path <> ": "
-                    <> Text.pack (show exception))
+                    <> formatException exception)
         Right () -> pure (Right ())
   where
     action = do

--- a/packages/agent-cli/src/Agent/CLI/Duration.hs
+++ b/packages/agent-cli/src/Agent/CLI/Duration.hs
@@ -1,0 +1,24 @@
+-- | Compact human-readable durations used by CLI status and error messages.
+module Agent.CLI.Duration
+    ( formatDuration
+    ) where
+
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Data.Time.Clock (NominalDiffTime)
+
+formatDuration :: NominalDiffTime -> Text
+formatDuration delta =
+    let seconds = max 0 (round delta :: Int)
+        hours = seconds `div` 3600
+        minutes = (seconds `mod` 3600) `div` 60
+    in if hours >= 24
+        then Text.pack (show (hours `div` 24))
+            <> "d "
+            <> Text.pack (show (hours `mod` 24))
+            <> "h"
+        else if hours > 0
+            then Text.pack (show hours) <> "h " <> Text.pack (show minutes) <> "m"
+            else if minutes > 0
+                then Text.pack (show minutes) <> "m"
+                else Text.pack (show seconds) <> "s"

--- a/packages/agent-cli/src/Agent/CLI/Error.hs
+++ b/packages/agent-cli/src/Agent/CLI/Error.hs
@@ -1,0 +1,441 @@
+-- | User-facing rendering for provider-independent API errors.
+--
+-- Keep this module free of terminal styling so every CLI surface—turns,
+-- startup, slash commands, dashboards, and persisted sessions—can reuse the
+-- same wording without exposing Haskell constructors or raw provider bodies.
+module Agent.CLI.Error
+    ( formatApiError
+    , formatApiErrorAt
+    , formatApiErrorInline
+    , formatApiErrorInlineAt
+    , formatApiErrorPersistedAt
+    , formatException
+    ) where
+
+import Agent.CLI.Duration (formatDuration)
+import Agent.Error
+    ( ApiError(..)
+    , ErrorType(..)
+    )
+import Control.Exception.Safe (Exception, displayException)
+import Data.Char (isControl)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Data.Time.Clock (UTCTime, addUTCTime, diffUTCTime)
+import Data.Time.Clock.POSIX
+    ( posixSecondsToUTCTime
+    , utcTimeToPOSIXSeconds
+    )
+import Data.Time.Format (defaultTimeLocale, formatTime)
+
+formatApiError :: ApiError -> Text
+formatApiError = formatApiErrorWith Nothing RelativeRetry
+
+formatApiErrorAt :: UTCTime -> ApiError -> Text
+formatApiErrorAt now = formatApiErrorWith (Just now) RelativeRetry
+
+formatApiErrorPersistedAt :: UTCTime -> ApiError -> Text
+formatApiErrorPersistedAt now =
+    formatApiErrorWith Nothing (AbsoluteRetryFrom now)
+
+formatApiErrorInline :: ApiError -> Text
+formatApiErrorInline = inline . formatApiError
+
+formatApiErrorInlineAt :: UTCTime -> ApiError -> Text
+formatApiErrorInlineAt now = inline . formatApiErrorAt now
+
+formatErrorDetail :: Text -> Text
+formatErrorDetail =
+    boundText maxExceptionLength
+        . cleanText
+
+formatException :: Exception exception => exception -> Text
+formatException =
+    formatErrorDetail
+        . Text.pack
+        . displayException
+
+data RetryPresentation
+    = RelativeRetry
+    | AbsoluteRetryFrom !UTCTime
+
+formatApiErrorWith
+    :: Maybe UTCTime
+    -> RetryPresentation
+    -> ApiError
+    -> Text
+formatApiErrorWith maybeNow retryPresentation = \case
+    HttpError{statusCode} ->
+        formatHttpError statusCode
+    JsonDecodeError{} ->
+        message
+            "Provider returned an unreadable response."
+            []
+            ["Retry the message. If this continues, report the issue."]
+    ProviderError{errorType, message = providerMessage, retryAfter} ->
+        formatProviderError
+            retryPresentation errorType providerMessage retryAfter
+    CredentialError{credentialMessage} ->
+        message
+            "Authentication failed."
+            (trustedDetails credentialMessage)
+            [ "Run /login or agent-cli login to reconnect "
+                <> "the provider account."
+            ]
+    ConnectionError{exception} ->
+        let details = failureDetails exception
+            action
+                | null details =
+                    "Retry. If this continues, check your connection "
+                        <> "and provider configuration."
+                | otherwise = "Review the details and retry."
+        in message
+            "The operation could not be completed."
+            details
+            [action]
+    CredentialsExhausted{retryAt} ->
+        message
+            "Provider unavailable."
+            []
+            [ "All accounts for this provider are temporarily unavailable."
+            , credentialsRetryGuidance maybeNow retryAt
+                <> ", or choose another provider with /model."
+            ]
+
+formatProviderError
+    :: RetryPresentation
+    -> ErrorType
+    -> Text
+    -> Maybe Int
+    -> Text
+formatProviderError retryPresentation errorType providerMessage retryAfter =
+    case errorType of
+        InvalidRequestError ->
+            message
+                "Provider rejected the request."
+                (providerDetails providerMessage)
+                ["Review the prompt or attachments and retry."]
+        AuthenticationError ->
+            message
+                "Authentication failed."
+                []
+                [ "Run /login or agent-cli login to reconnect "
+                    <> "the provider account."
+                ]
+        PermissionError ->
+            message
+                "This account cannot use the requested model or feature."
+                []
+                ["Choose another model with /model or reconnect with /login."]
+        NotFoundError ->
+            message
+                "The requested model or provider resource was not found."
+                (providerDetails providerMessage)
+                ["Check the selected model with /model and retry."]
+        PreviousResponseNotFound ->
+            message
+                "The provider no longer has this conversation state."
+                []
+                ["Retry the message so the conversation can be resent."]
+        ContextWindowExceeded ->
+            message
+                "This conversation is too long for the selected model."
+                []
+                ["Run /compact or start a new conversation with /new."]
+        InvalidImageError ->
+            message
+                "The provider could not process an attached image."
+                (providerDetails providerMessage)
+                ["Remove it or attach a PNG or JPEG and retry."]
+        RateLimitError ->
+            message
+                "Rate limit reached."
+                []
+                [retryOr retryPresentation retryAfter
+                    "Wait a moment and retry, or choose another provider with /model."]
+        UsageLimitReached ->
+            message
+                "Usage limit reached for this account."
+                []
+                [retryOr retryPresentation retryAfter
+                    "Check /usage or choose another provider with /model."]
+        UsageBalanceExhausted ->
+            message
+                "This account's usage balance is exhausted."
+                []
+                [retryOr retryPresentation retryAfter
+                    "Check /usage or choose another provider with /model."]
+        QuotaExceeded ->
+            message
+                "This account has no remaining quota."
+                []
+                ["Check provider billing or choose another provider with /model."]
+        UsageNotIncluded ->
+            message
+                "This account's plan does not include the requested model or feature."
+                []
+                ["Choose another model with /model or reconnect with /login."]
+        ApiErrorType ->
+            message
+                "The provider returned an internal error."
+                (providerDetails providerMessage)
+                [retryOr retryPresentation retryAfter "Retry the message."]
+        OverloadedError ->
+            message
+                "The provider is temporarily overloaded."
+                []
+                [retryOr retryPresentation retryAfter
+                    "Retry shortly or choose another provider with /model."]
+        ServiceUnavailableError ->
+            message
+                "The provider is temporarily unavailable."
+                []
+                [retryOr retryPresentation retryAfter
+                    "Retry shortly or choose another provider with /model."]
+        BillingError ->
+            message
+                "Provider billing or credits are unavailable."
+                []
+                ["Check provider billing or choose another provider with /model."]
+        ClientUpdateRequired ->
+            message
+                "The provider requires a newer client version."
+                []
+                ["Update haskell-agent and retry."]
+        PayloadTooLargeError ->
+            message
+                "The request is too large."
+                []
+                ["Remove large attachments or run /compact, then retry."]
+        WebSocketConnectionLimitReached ->
+            message
+                "This account has too many active provider connections."
+                []
+                ["Close another agent session or retry in a moment."]
+        CyberPolicyError ->
+            message
+                "The provider blocked this request under its safety policy."
+                (providerDetails providerMessage)
+                ["Revise the request and try again."]
+        MisalignmentPolicyViolation ->
+            message
+                "The provider blocked this request under its safety policy."
+                (providerDetails providerMessage)
+                ["Revise the request and try again."]
+        UnknownErrorType value ->
+            message
+                ("Provider error (" <> safeErrorType value <> ").")
+                (providerDetails providerMessage)
+                [retryOr retryPresentation retryAfter
+                    "Retry the message or choose another provider with /model."]
+
+formatHttpError :: Int -> Text
+formatHttpError status =
+    case status of
+        400 ->
+            rejected
+        401 ->
+            auth
+        402 ->
+            billing
+        403 ->
+            permission
+        404 ->
+            notFound
+        408 ->
+            timedOut
+        409 ->
+            retryable
+        413 ->
+            tooLarge
+        422 ->
+            rejected
+        425 ->
+            retryable
+        426 ->
+            updateRequired
+        429 ->
+            rateLimited
+        _
+            | status >= 500 ->
+                message
+                    ("Provider temporarily unavailable (HTTP "
+                        <> Text.pack (show status)
+                        <> ").")
+                    []
+                    ["Retry shortly or choose another provider with /model."]
+            | otherwise ->
+                message
+                    ("Request failed (HTTP " <> Text.pack (show status) <> ").")
+                    []
+                    ["Retry the message or choose another provider with /model."]
+  where
+    rejected =
+        message
+            "Provider rejected the request."
+            []
+            ["Review the prompt or attachments and retry."]
+    auth =
+        message
+            "Authentication failed."
+            []
+            [ "Run /login or agent-cli login to reconnect "
+                <> "the provider account."
+            ]
+    billing =
+        message
+            "Provider billing or credits are unavailable."
+            []
+            ["Check provider billing or choose another provider with /model."]
+    permission =
+        message
+            "This account cannot use the requested model or feature."
+            []
+            ["Choose another model with /model or reconnect with /login."]
+    notFound =
+        message
+            "The requested model or provider resource was not found."
+            []
+            ["Check the selected model with /model and retry."]
+    timedOut =
+        message
+            "The provider request timed out."
+            []
+            ["Retry the message."]
+    retryable =
+        message
+            "The provider could not accept the request yet."
+            []
+            ["Retry the message."]
+    tooLarge =
+        message
+            "The request is too large."
+            []
+            ["Remove large attachments or run /compact, then retry."]
+    updateRequired =
+        message
+            "The provider requires a newer client version."
+            []
+            ["Update haskell-agent and retry."]
+    rateLimited =
+        message
+            "Rate limit reached."
+            []
+            ["Wait a moment and retry, or choose another provider with /model."]
+
+credentialsRetryGuidance :: Maybe UTCTime -> UTCTime -> Text
+credentialsRetryGuidance maybeNow retryAt =
+    case maybeNow of
+        Just now
+            | retryAt <= now -> "Try again now"
+            | otherwise ->
+                "Try again in " <> formatDuration (diffUTCTime retryAt now)
+        Nothing ->
+            "Try again after "
+                <> formatUtcRetryTime retryAt
+
+retryOr :: RetryPresentation -> Maybe Int -> Text -> Text
+retryOr retryPresentation retryAfter fallback =
+    case retryAfter of
+        Just seconds
+            | seconds <= 0 -> "Try again now."
+            | otherwise -> case retryPresentation of
+                RelativeRetry ->
+                    "Try again in "
+                        <> formatDuration (fromIntegral seconds)
+                        <> "."
+                AbsoluteRetryFrom now ->
+                    "Try again after "
+                        <> formatUtcRetryTime
+                            (addUTCTime (fromIntegral seconds) now)
+                        <> "."
+        Nothing -> fallback
+
+providerDetails :: Text -> [Text]
+providerDetails raw =
+    case boundedDetail raw of
+        Nothing -> []
+        Just detail -> ["Provider details: " <> detail]
+
+failureDetails :: Text -> [Text]
+failureDetails raw =
+    case boundedDetail raw of
+        Nothing -> []
+        Just detail
+            | looksLikeExceptionDump detail -> []
+            | otherwise -> ["Details: " <> detail]
+
+trustedDetails :: Text -> [Text]
+trustedDetails raw =
+    case boundedDetail raw of
+        Nothing -> []
+        Just detail -> ["Details: " <> detail]
+
+boundedDetail :: Text -> Maybe Text
+boundedDetail raw
+    | Text.null cleaned = Nothing
+    | looksStructured cleaned = Nothing
+    | otherwise = Just (boundText maxDetailLength cleaned)
+  where
+    cleaned = cleanText raw
+
+maxDetailLength :: Int
+maxDetailLength = 200
+
+maxExceptionLength :: Int
+maxExceptionLength = 240
+
+boundText :: Int -> Text -> Text
+boundText limit value
+    | Text.length value <= limit = value
+    | otherwise = Text.take (limit - 1) value <> "…"
+
+cleanText :: Text -> Text
+cleanText =
+    Text.unwords
+        . Text.words
+        . Text.map (\character -> if isControl character then ' ' else character)
+        . Text.strip
+
+safeErrorType :: Text -> Text
+safeErrorType raw =
+    let cleaned = cleanText raw
+    in if Text.null cleaned
+        then "unknown"
+        else boundText 80 cleaned
+
+looksStructured :: Text -> Bool
+looksStructured value =
+    any (`Text.isPrefixOf` Text.stripStart value) ["{", "[", "<"]
+
+looksLikeExceptionDump :: Text -> Bool
+looksLikeExceptionDump value =
+    any (`Text.isInfixOf` value)
+        [ "HttpExceptionRequest"
+        , "ConnectionFailure"
+        , "InvalidUrlException"
+        , "SomeException"
+        , "TlsException"
+        , "HandshakeFailed"
+        , "Network.Socket."
+        , "WebSocket error (no type):"
+        ]
+
+formatUtcRetryTime :: UTCTime -> Text
+formatUtcRetryTime retryAt =
+    let wholeSeconds =
+            ceiling (utcTimeToPOSIXSeconds retryAt) :: Integer
+        rounded = posixSecondsToUTCTime (fromInteger wholeSeconds)
+    in Text.pack
+        (formatTime defaultTimeLocale "%Y-%m-%d %H:%M:%S UTC" rounded)
+
+message :: Text -> [Text] -> [Text] -> Text
+message title details actions =
+    Text.intercalate "\n" (title : details <> actions)
+
+inline :: Text -> Text
+inline =
+    Text.intercalate " "
+        . filter (not . Text.null)
+        . map Text.strip
+        . Text.lines

--- a/packages/agent-cli/src/Agent/CLI/Login.hs
+++ b/packages/agent-cli/src/Agent/CLI/Login.hs
@@ -35,6 +35,10 @@ import Agent.CLI.CredentialStore
     , setManagedCredentialEnabled
     , upsertManagedCredential
     )
+import Agent.CLI.Error
+    ( formatApiErrorInlineAt
+    , formatException
+    )
 import Agent.CLI.Input (readApprovalLine)
 import Agent.CLI.Picker
     ( PickerKey(..)
@@ -260,7 +264,8 @@ refreshSelectedAccounts updates indices accounts =
                 Left err ->
                     pure account
                         { loginUsage =
-                            UsageUnavailable (Text.pack (show err))
+                            UsageUnavailable
+                                ("usage check failed: " <> formatException err)
                         }
                 Right result -> pure result
             writeChan updates (index, refreshed)
@@ -765,10 +770,12 @@ refreshLoginAccount account
                     }
                 else OpenAI.fetchUsage
                     account.loginAccessToken account.loginAccountId >>= \case
-                        Left err ->
+                        Left err -> do
+                            now <- getCurrentTime
                             pure account
                                 { loginUsage =
-                                    UsageUnavailable (Text.pack (show err))
+                                    UsageUnavailable
+                                        (formatApiErrorInlineAt now err)
                                 }
                         Right snapshot ->
                             pure account
@@ -782,7 +789,8 @@ refreshLoginAccount account
         XAIProvider ->
             XAI.fetchGrokUsage account.loginAccessToken >>= \case
                 Left err ->
-                    pure account { loginUsage = UsageUnavailable err }
+                    pure account
+                        { loginUsage = UsageUnavailable err }
                 Right snapshot ->
                     pure account
                         { loginUsage =
@@ -803,7 +811,8 @@ refreshLoginAccount account
         OpenRouterProvider ->
             OpenRouter.fetchOpenRouterUsage account.loginAccessToken >>= \case
                 Left err ->
-                    pure account { loginUsage = UsageUnavailable err }
+                    pure account
+                        { loginUsage = UsageUnavailable err }
                 Right snapshot ->
                     pure account
                         { loginLabel =

--- a/packages/agent-cli/src/Agent/CLI/ProviderFallback.hs
+++ b/packages/agent-cli/src/Agent/CLI/ProviderFallback.hs
@@ -90,5 +90,6 @@ isProviderUnavailable err
     | otherwise = case err of
         HttpError status _ -> status == 401 || status == 403
         ProviderError AuthenticationError _ _ -> True
+        CredentialError{} -> True
         ProviderError PermissionError _ _ -> True
         _ -> False

--- a/packages/agent-cli/src/Agent/CLI/Render.hs
+++ b/packages/agent-cli/src/Agent/CLI/Render.hs
@@ -8,7 +8,10 @@ module Agent.CLI.Render
     , formatActivityLine
     , formatElapsed
     , formatLoopError
+    , formatLoopErrorAt
     , formatLoopErrorColored
+    , formatLoopErrorColoredAt
+    , formatLoopErrorPersistedAt
     , formatSearchReplaceDiff
     , formatThinkingBlock
     , formatToolOutput
@@ -34,6 +37,11 @@ import Agent.CLI.Progress
     , wrapOscForTmux
     )
 import Agent.CLI.Terminal (fileUri)
+import Agent.CLI.Error
+    ( formatApiError
+    , formatApiErrorAt
+    , formatApiErrorPersistedAt
+    )
 import Agent.CLI.Style
     ( agentBackground
     , glyphCancel
@@ -714,15 +722,48 @@ firstLine = Text.takeWhile (/= '\n')
 formatLoopError :: LoopError -> Text
 formatLoopError = formatLoopErrorColored False
 
+-- | Format a loop error relative to the time it is shown.
+formatLoopErrorAt :: UTCTime -> LoopError -> Text
+formatLoopErrorAt = formatLoopErrorColoredAt False
+
 -- | Like 'formatLoopError', with optional ANSI styling for TTY stderr.
 formatLoopErrorColored :: Bool -> LoopError -> Text
-formatLoopErrorColored color = \case
+formatLoopErrorColored color =
+    formatLoopErrorColoredMaybeAt color Nothing
+
+-- | Like 'formatLoopErrorAt', with optional ANSI styling for TTY stderr.
+formatLoopErrorColoredAt :: Bool -> UTCTime -> LoopError -> Text
+formatLoopErrorColoredAt color now =
+    formatLoopErrorColoredMaybeAt color (Just now)
+
+-- | Stable, unstyled text for session persistence. Retry timestamps stay
+-- absolute so resumed sessions never show stale relative guidance.
+formatLoopErrorPersistedAt :: UTCTime -> LoopError -> Text
+formatLoopErrorPersistedAt now = \case
+    LoopTransport err -> formatApiErrorPersistedAt now err
+    LoopMaxTurns turn ->
+        "Stopped: maximum turns reached."
+            <> maybe "" ("\n" <>) turn.assistantText
+    LoopNoResponseId ->
+        "Provider returned an incomplete response.\nRetry the message."
+    LoopCancelled _ ->
+        "Cancelled."
+
+formatLoopErrorColoredMaybeAt :: Bool -> Maybe UTCTime -> LoopError -> Text
+formatLoopErrorColoredMaybeAt color maybeNow = \case
     LoopTransport err ->
-        roleError color (glyphErr <> "transport error: " <> Text.pack (show err))
+        roleError color $
+            glyphErr
+                <> case maybeNow of
+                    Nothing -> formatApiError err
+                    Just now -> formatApiErrorAt now err
     LoopMaxTurns turn ->
         roleError color (glyphErr <> "stopped: max turns reached")
             <> maybe "" (\text -> "\n" <> text) turn.assistantText
     LoopNoResponseId ->
-        roleError color (glyphErr <> "transport error: response had no id")
+        roleError color
+            (glyphErr
+                <> "Provider returned an incomplete response.\n"
+                <> "Retry the message.")
     LoopCancelled _ ->
         roleMuted color (glyphCancel <> "cancelled")

--- a/packages/agent-cli/src/Agent/CLI/Turn.hs
+++ b/packages/agent-cli/src/Agent/CLI/Turn.hs
@@ -25,7 +25,10 @@ import Agent.CLI.Render
     ( RenderConfig(..)
     , clearThinking
     , formatElapsed
+    , formatLoopErrorAt
     , formatLoopErrorColored
+    , formatLoopErrorColoredAt
+    , formatLoopErrorPersistedAt
     , formatTurnStatus
     , putTextLn
     , renderAssistantText
@@ -294,15 +297,16 @@ runOneTurn env@SessionEnv
                                     (UiTurnEnded BlockFailed)
                                 emitUiEvent runtime
                                     (UiErrorMessage
-                                        (Text.pack (show err)
+                                        (formatLoopErrorAt finishedAt err
                                             <> "\n"
                                             <> elapsedDetail model))
                         Nothing -> do
                             color <- resolveColor stderr
-                            putTextLn stderr (formatLoopErrorColored color err)
+                            putTextLn stderr
+                                (formatLoopErrorColoredAt color finishedAt err)
                             putTextLn stderr
                                 (formatTurnStatus color "error" (elapsedDetail model))
-                    persistIncomplete (Text.pack (show err))
+                    persistIncomplete (formatLoopErrorPersistedAt finishedAt err)
                     pure TurnFailed
         (Nothing, Right loopResult) -> do
             finishTerminal (isNothing fullscreen)

--- a/packages/agent-cli/src/Agent/CLI/Usage.hs
+++ b/packages/agent-cli/src/Agent/CLI/Usage.hs
@@ -8,13 +8,15 @@ module Agent.CLI.Usage
     , shortAccountId
     ) where
 
+import Agent.CLI.Duration (formatDuration)
+import Agent.CLI.Error (formatApiErrorInlineAt)
 import Agent.CLI.Style (roleMuted, roleSuccess, roleWarn)
 import Agent.Error (ApiError)
 import Agent.OpenAI.Usage (UsageLimit(..), UsageSnapshot(..), UsageWindow(..))
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Time.Calendar (fromGregorian)
-import Data.Time.Clock (NominalDiffTime, UTCTime(..), addUTCTime, diffUTCTime)
+import Data.Time.Clock (UTCTime(..), addUTCTime, diffUTCTime)
 import Data.Time.Format (defaultTimeLocale, formatTime)
 
 data AccountUsageLine = AccountUsageLine
@@ -43,7 +45,10 @@ formatAccountUsage color now line =
                 | otherwise -> Nothing
             Nothing -> Nothing
         body = case line.usageResult of
-            Left err -> [roleWarn color ("fetch failed: " <> Text.pack (show err))]
+            Left err ->
+                [ roleWarn color
+                    ("couldn't load usage: " <> formatApiErrorInlineAt now err)
+                ]
             Right snapshot ->
                 let plan = roleMuted color ("plan " <> snapshot.planType)
                     windows = case snapshot.rateLimit of
@@ -103,19 +108,6 @@ maybeToList = \case
 formatSeconds :: Int -> Text
 formatSeconds total =
     formatDuration (fromIntegral (max 0 total))
-
-formatDuration :: NominalDiffTime -> Text
-formatDuration delta =
-    let seconds = max 0 (round delta :: Int)
-        hours = seconds `div` 3600
-        minutes = (seconds `mod` 3600) `div` 60
-    in if hours >= 24
-        then Text.pack (show (hours `div` 24)) <> "d " <> Text.pack (show (hours `mod` 24)) <> "h"
-        else if hours > 0
-            then Text.pack (show hours) <> "h " <> Text.pack (show minutes) <> "m"
-            else if minutes > 0
-                then Text.pack (show minutes) <> "m"
-                else Text.pack (show seconds) <> "s"
 
 formatClock :: UTCTime -> Text
 formatClock = Text.pack . formatTime defaultTimeLocale "%Y-%m-%d %H:%M"

--- a/packages/agent-cli/test/Agent/CLI/AuthSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/AuthSpec.hs
@@ -2,7 +2,7 @@ module Agent.CLI.AuthSpec (spec) where
 
 import Agent.CLI.Auth
 import Agent.CLI.CredentialStore
-import Agent.Error (ApiError(..), ErrorType(..))
+import Agent.Error (ApiError(..))
 import System.OsPath (OsPath, decodeUtf, unsafeEncodeUtf)
 import Agent.OpenAI.Auth (AuthState(..))
 import qualified Agent.OpenAI.Auth as OpenAI
@@ -282,10 +282,10 @@ spec = do
                 , failure = AccountAuthenticationRejected
                 })
             case result of
-                Left (ProviderError AuthenticationError message _) ->
+                Left (CredentialError message) ->
                     Text.unpack message `shouldContain`
                         "reloaded credential is unchanged"
-                other -> expectationFailure ("expected AuthenticationError, got " <> show other)
+                other -> expectationFailure ("expected CredentialError, got " <> show other)
 
 openAiManagedPoolTest :: OsPath -> IO ()
 openAiManagedPoolTest _ =

--- a/packages/agent-cli/test/Agent/CLI/BtwSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/BtwSpec.hs
@@ -124,6 +124,18 @@ spec = do
                 empty params transcript "why?"
                 `shouldReturn` Left BtwEmptyResponse
 
+    describe "formatBtwError" do
+        it "uses the shared provider error rendering" do
+            let rendered =
+                    formatBtwError
+                        (BtwTransport (ConnectionError "socket closed"))
+            rendered `shouldSatisfy`
+                Text.isInfixOf "operation could not be completed"
+            rendered `shouldSatisfy`
+                Text.isInfixOf "socket closed"
+            rendered `shouldNotSatisfy`
+                Text.isInfixOf "ConnectionError"
+
 userItem :: Text.Text -> ResponseItem
 userItem text = MessageItem ResponseMessage
     { messageId = Nothing

--- a/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
@@ -118,6 +118,33 @@ spec = do
             map (.parallelToolCalls) seen `shouldBe` [Just False]
             map (.stream) seen `shouldBe` [Just True]
 
+        it "returns friendly provider errors from manual compaction" do
+            let provider = TokenProvider \_ ->
+                    error "compaction unexpectedly requested credentials"
+                send _ _ =
+                    pure $ Left $
+                        ProviderError UsageLimitReached
+                            "quota exhausted"
+                            (Just 120)
+                history = [userTextItem "old context"]
+            result <- runExceptT $
+                compactOpenAIWith send
+                    (Just provider)
+                    defaultResponseCreateParams
+                    history
+                    100
+                    Nothing
+            case result of
+                Left err -> do
+                    err `shouldSatisfy`
+                        Text.isInfixOf "Usage limit reached"
+                    err `shouldSatisfy`
+                        Text.isInfixOf "Try again in 2m"
+                    err `shouldNotSatisfy`
+                        Text.isInfixOf "ProviderError"
+                Right _ ->
+                    expectationFailure "expected compaction to fail"
+
     describe "autoCompactOpenAiBackendWith" do
         it "compacts at a configured threshold below the model default" do
             let history = [userTextItem "old"]

--- a/packages/agent-cli/test/Agent/CLI/ErrorSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ErrorSpec.hs
@@ -1,0 +1,234 @@
+module Agent.CLI.ErrorSpec (spec) where
+
+import Agent.CLI.Error
+import Agent.Error (ApiError(..), ErrorType(..))
+import Control.Monad (forM_)
+import qualified Data.Text as Text
+import Data.Time.Calendar (fromGregorian)
+import Data.Time.Clock (UTCTime(..), addUTCTime)
+import Test.Hspec
+
+spec :: Spec
+spec = do
+    describe "formatApiErrorAt" do
+        it "renders every API error without exposing Haskell constructors" do
+            forM_ sampleErrors \apiError -> do
+                let rendered = formatApiErrorAt epoch apiError
+                rendered `shouldNotSatisfy` Text.null
+                Text.length rendered `shouldSatisfy` (<= 600)
+                forM_ internalNames \name ->
+                    rendered `shouldNotSatisfy` Text.isInfixOf name
+
+        it "does not expose raw HTTP or decode response bodies" do
+            formatApiErrorAt epoch
+                (HttpError 502 "TOP_SECRET_HTTP_BODY")
+                `shouldNotSatisfy` Text.isInfixOf "TOP_SECRET_HTTP_BODY"
+            let decoded =
+                    formatApiErrorAt epoch
+                        (JsonDecodeError
+                            "unexpected token"
+                            "TOP_SECRET_RAW_PROVIDER_RESPONSE")
+            decoded `shouldNotSatisfy`
+                Text.isInfixOf "TOP_SECRET_RAW_PROVIDER_RESPONSE"
+            decoded `shouldSatisfy`
+                Text.isInfixOf "unreadable response"
+            formatApiErrorAt epoch
+                (ProviderError AuthenticationError
+                    "TOP_SECRET_AUTH_RESPONSE"
+                    Nothing)
+                `shouldNotSatisfy`
+                    Text.isInfixOf "TOP_SECRET_AUTH_RESPONSE"
+
+        it "keeps connection failures neutral and preserves safe details" do
+            let rendered =
+                    formatApiErrorAt epoch
+                        (ConnectionError
+                            "automatic compaction failed: credential store is locked")
+            rendered `shouldSatisfy`
+                Text.isInfixOf "operation could not be completed"
+            rendered `shouldSatisfy`
+                Text.isInfixOf "credential store is locked"
+            rendered `shouldNotSatisfy`
+                Text.isInfixOf "internet connection"
+
+        it "suppresses structured and internal connection dumps" do
+            formatApiErrorAt epoch
+                (ConnectionError "{\"secret\":\"raw body\"}")
+                `shouldNotSatisfy` Text.isInfixOf "secret"
+            formatApiErrorAt epoch
+                (ConnectionError
+                    "xAI request failed: HttpExceptionRequest Request {host = \"secret.example\"}")
+                `shouldNotSatisfy` Text.isInfixOf "HttpExceptionRequest"
+            formatApiErrorAt epoch
+                (ConnectionError
+                    "WebSocket error (no type): {\"secret\":\"raw event\"}")
+                `shouldNotSatisfy` Text.isInfixOf "secret"
+            formatApiErrorAt epoch
+                (ConnectionError "{\"secret\":\"raw body\"}")
+                `shouldSatisfy`
+                    Text.isInfixOf "check your connection and provider configuration"
+
+        it "preserves trusted local authentication recovery details" do
+            let rendered =
+                    formatApiErrorAt epoch
+                        (CredentialError
+                            "reloaded credential is unchanged; refresh ~/.grok/auth.json or OPENROUTER_API_KEY and retry")
+            rendered `shouldSatisfy`
+                Text.isInfixOf "~/.grok/auth.json"
+            rendered `shouldSatisfy`
+                Text.isInfixOf "OPENROUTER_API_KEY"
+
+        it "provides actions for common provider failures" do
+            formatApiErrorAt epoch
+                (ProviderError AuthenticationError "bad token" Nothing)
+                `shouldSatisfy` Text.isInfixOf "/login"
+            let context =
+                    formatApiErrorAt epoch
+                        (ProviderError ContextWindowExceeded "too long" Nothing)
+            context `shouldSatisfy` Text.isInfixOf "/compact"
+            context `shouldSatisfy` Text.isInfixOf "/new"
+            formatApiErrorAt epoch
+                (ProviderError InvalidImageError "invalid image" Nothing)
+                `shouldSatisfy` Text.isInfixOf "PNG or JPEG"
+            formatApiErrorAt epoch
+                (ProviderError PayloadTooLargeError "large" Nothing)
+                `shouldSatisfy` Text.isInfixOf "/compact"
+            formatApiErrorAt epoch
+                (ProviderError ClientUpdateRequired "old client" Nothing)
+                `shouldSatisfy` Text.isInfixOf "Update haskell-agent"
+            formatApiErrorAt epoch
+                (ProviderError WebSocketConnectionLimitReached "busy" Nothing)
+                `shouldSatisfy` Text.isInfixOf "Close another agent session"
+
+        it "formats provider retry intervals and credential reset times" do
+            formatApiErrorAt epoch
+                (ProviderError RateLimitError "slow down" (Just 121))
+                `shouldSatisfy` Text.isInfixOf "Try again in 2m"
+            formatApiErrorAt epoch
+                (CredentialsExhausted
+                    (addUTCTime (5 * 86400 + 21 * 3600) epoch))
+                `shouldSatisfy` Text.isInfixOf "Try again in 5d 21h"
+            formatApiError
+                (CredentialsExhausted
+                    (addUTCTime (5 * 86400 + 21 * 3600) epoch))
+                `shouldSatisfy`
+                    Text.isInfixOf "2026-08-27 21:00:00 UTC"
+            formatApiError
+                (CredentialsExhausted (addUTCTime 37.4 epoch))
+                `shouldSatisfy`
+                    Text.isInfixOf "2026-08-22 00:00:38 UTC"
+            formatApiErrorAt epoch
+                (CredentialsExhausted epoch)
+                `shouldSatisfy` Text.isInfixOf "Try again now"
+            formatApiErrorAt epoch
+                (ProviderError RateLimitError "slow down" (Just 0))
+                `shouldSatisfy` Text.isInfixOf "Try again now"
+
+        it "bounds and sanitizes provider detail text" do
+            let rendered =
+                    formatApiErrorAt epoch
+                        (ProviderError InvalidRequestError
+                            (Text.replicate 400 "x")
+                            Nothing)
+            rendered `shouldSatisfy` Text.isInfixOf "…"
+            Text.length rendered `shouldSatisfy` (<= 400)
+            formatApiErrorAt epoch
+                (ProviderError InvalidRequestError
+                    "{\"secret\":\"raw body\"}"
+                    Nothing)
+                `shouldNotSatisfy` Text.isInfixOf "secret"
+            formatApiErrorAt epoch
+                (ProviderError InvalidRequestError
+                    "bad\ESC[31m request"
+                    Nothing)
+                `shouldNotSatisfy` Text.isInfixOf "\ESC"
+
+    describe "formatApiErrorInlineAt" do
+        it "flattens the shared rendering for compact command surfaces" do
+            let rendered =
+                    formatApiErrorInlineAt epoch
+                        (ProviderError AuthenticationError "bad token" Nothing)
+            rendered `shouldNotSatisfy` Text.isInfixOf "\n"
+            rendered `shouldSatisfy` Text.isInfixOf "/login"
+
+    describe "formatException" do
+        it "normalizes and bounds exception details" do
+            let rendered =
+                    formatException
+                        (userError ("failed\n" <> replicate 400 'x'))
+            rendered `shouldNotSatisfy` Text.isInfixOf "\n"
+            Text.length rendered `shouldSatisfy` (<= 240)
+            rendered `shouldSatisfy` Text.isSuffixOf "…"
+
+sampleErrors :: [ApiError]
+sampleErrors =
+    [ HttpError 502 "raw body"
+    , JsonDecodeError "bad JSON" "raw body"
+    , CredentialError "credential file is invalid"
+    , ConnectionError "socket closed"
+    , CredentialsExhausted (addUTCTime 60 epoch)
+    ]
+        <> [ ProviderError errorType "provider detail" (Just 60)
+           | errorType <- allErrorTypes
+           ]
+
+allErrorTypes :: [ErrorType]
+allErrorTypes =
+    [ InvalidRequestError
+    , AuthenticationError
+    , PermissionError
+    , NotFoundError
+    , PreviousResponseNotFound
+    , ContextWindowExceeded
+    , InvalidImageError
+    , RateLimitError
+    , UsageLimitReached
+    , UsageBalanceExhausted
+    , QuotaExceeded
+    , UsageNotIncluded
+    , ApiErrorType
+    , OverloadedError
+    , ServiceUnavailableError
+    , BillingError
+    , ClientUpdateRequired
+    , PayloadTooLargeError
+    , WebSocketConnectionLimitReached
+    , CyberPolicyError
+    , MisalignmentPolicyViolation
+    , UnknownErrorType "future_error"
+    ]
+
+internalNames :: [Text.Text]
+internalNames =
+    [ "HttpError"
+    , "JsonDecodeError"
+    , "ProviderError"
+    , "CredentialError"
+    , "ConnectionError"
+    , "CredentialsExhausted"
+    , "InvalidRequestError"
+    , "AuthenticationError"
+    , "PermissionError"
+    , "NotFoundError"
+    , "PreviousResponseNotFound"
+    , "ContextWindowExceeded"
+    , "InvalidImageError"
+    , "RateLimitError"
+    , "UsageLimitReached"
+    , "UsageBalanceExhausted"
+    , "QuotaExceeded"
+    , "UsageNotIncluded"
+    , "ApiErrorType"
+    , "OverloadedError"
+    , "ServiceUnavailableError"
+    , "BillingError"
+    , "ClientUpdateRequired"
+    , "PayloadTooLargeError"
+    , "WebSocketConnectionLimitReached"
+    , "CyberPolicyError"
+    , "MisalignmentPolicyViolation"
+    , "UnknownErrorType"
+    ]
+
+epoch :: UTCTime
+epoch = UTCTime (fromGregorian 2026 8 22) 0

--- a/packages/agent-cli/test/Agent/CLI/ProviderFallbackSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ProviderFallbackSpec.hs
@@ -67,6 +67,10 @@ spec = do
                 (fallbackCandidates [XAIProvider] OpenAIProvider
                     (ProviderError AuthenticationError "rejected" Nothing))
                 `shouldBe` [OpenRouterProvider]
+            map (.modelProvider)
+                (fallbackCandidates [XAIProvider] OpenAIProvider
+                    (CredentialError "credential file is invalid"))
+                `shouldBe` [OpenRouterProvider]
 
     describe "automaticCooldownRetryDelay" do
         let now = UTCTime (fromGregorian 2026 8 21) 0

--- a/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
@@ -1,6 +1,7 @@
 module Agent.CLI.RenderSpec (spec) where
 
 import Agent.CLI.Render
+import Agent.Error (ApiError(..), ErrorType(..))
 import Agent.Loop (LoopError(..), LoopEvent(..), TurnOutput(..), emptyTokenUsage)
 import Agent.ToolDispatch
     ( ToolCallKind(..)
@@ -14,6 +15,8 @@ import Control.Exception (finally)
 import Data.IORef (newIORef, readIORef)
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
+import Data.Time.Calendar (fromGregorian)
+import Data.Time.Clock (UTCTime(..), addUTCTime)
 import System.Directory (getTemporaryDirectory, removeFile)
 import System.IO (BufferMode(..), Handle, hClose, hSetBuffering, openTempFile)
 import Test.Hspec
@@ -134,6 +137,64 @@ spec = do
                 , tokenUsage = emptyTokenUsage
                 })
                 `shouldSatisfy` (/= "")
+
+        it "renders exhausted credentials as actionable user-facing text" do
+            let now = UTCTime (fromGregorian 2026 8 22) 0
+                retryAt = addUTCTime (5 * 86400 + 21 * 3600) now
+                rendered =
+                    formatLoopErrorAt now
+                        (LoopTransport (CredentialsExhausted retryAt))
+            rendered `shouldSatisfy`
+                Text.isInfixOf
+                    "All accounts for this provider are temporarily unavailable"
+            rendered `shouldSatisfy` Text.isInfixOf "Try again in 5d 21h"
+            rendered `shouldSatisfy`
+                Text.isInfixOf "choose another provider with /model"
+            rendered `shouldNotSatisfy`
+                Text.isInfixOf "CredentialsExhausted"
+
+        it "persists absolute retry guidance without UI chrome" do
+            let retryAt =
+                    addUTCTime (5 * 86400 + 21 * 3600)
+                        (UTCTime (fromGregorian 2026 8 22) 0)
+                rendered =
+                    formatLoopErrorPersistedAt
+                        (UTCTime (fromGregorian 2026 8 22) 0)
+                        (LoopTransport (CredentialsExhausted retryAt))
+            rendered `shouldSatisfy`
+                Text.isInfixOf "2026-08-27 21:00:00 UTC"
+            rendered `shouldNotSatisfy` Text.isInfixOf "Try again in"
+            rendered `shouldNotSatisfy` Text.isPrefixOf "✗"
+
+        it "persists provider retry intervals as absolute timestamps" do
+            let rendered =
+                    formatLoopErrorPersistedAt
+                        (UTCTime (fromGregorian 2026 8 22) 0)
+                        (LoopTransport
+                            (ProviderError RateLimitError
+                                "slow down"
+                                (Just 120)))
+            rendered `shouldSatisfy`
+                Text.isInfixOf "2026-08-22 00:02:00 UTC"
+            rendered `shouldNotSatisfy` Text.isInfixOf "Try again in"
+
+        it "renders typed provider errors without constructor syntax" do
+            let rendered =
+                    formatLoopError
+                        (LoopTransport
+                            (ProviderError ContextWindowExceeded
+                                "context too long"
+                                Nothing))
+            rendered `shouldSatisfy`
+                Text.isInfixOf "conversation is too long"
+            rendered `shouldSatisfy` Text.isInfixOf "/compact"
+            rendered `shouldNotSatisfy`
+                Text.isInfixOf "ProviderError"
+
+        it "explains an incomplete provider response" do
+            formatLoopError LoopNoResponseId
+                `shouldSatisfy`
+                    Text.isInfixOf "Provider returned an incomplete response"
 
     describe "renderEvent" do
         it "keeps concurrent tool lines intact" do

--- a/packages/agent-cli/test/Agent/CLI/UsageSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/UsageSpec.hs
@@ -1,6 +1,7 @@
 module Agent.CLI.UsageSpec (spec) where
 
 import Agent.CLI.Usage
+import Agent.Error (ApiError(..), ErrorType(..))
 import Agent.OpenAI.Usage
 import qualified Data.Text as Text
 import Data.Time.Calendar (fromGregorian)
@@ -34,6 +35,23 @@ spec = do
             rendered `shouldSatisfy` ("5h  69% reserve" `Text.isInfixOf`)
             rendered `shouldSatisfy` ("7d  28% reserve" `Text.isInfixOf`)
             rendered `shouldSatisfy` ("lasts until reset" `Text.isInfixOf`)
+
+        it "uses friendly provider errors when usage cannot be loaded" do
+            let line = AccountUsageLine
+                    { usageAccountId = "acc-123"
+                    , usageCooldownUntil = Nothing
+                    , usageResult =
+                        Left
+                            (ProviderError AuthenticationError
+                                "expired token"
+                                Nothing)
+                    }
+                rendered = formatAccountUsage False epoch line
+            rendered `shouldSatisfy`
+                Text.isInfixOf "Authentication failed"
+            rendered `shouldSatisfy` Text.isInfixOf "/login"
+            rendered `shouldNotSatisfy`
+                Text.isInfixOf "ProviderError"
 
     describe "formatUsageReport" do
         it "explains an empty pool" do

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -14,6 +14,7 @@ import qualified Agent.CLI.CommandSpec as CommandSpec
 import qualified Agent.CLI.CompactionSpec as CompactionSpec
 import qualified Agent.CLI.ConnectivitySpec as ConnectivitySpec
 import qualified Agent.CLI.CredentialStoreSpec as CredentialStoreSpec
+import qualified Agent.CLI.ErrorSpec as ErrorSpec
 import qualified Agent.CLI.ImagePreviewSpec as ImagePreviewSpec
 import qualified Agent.CLI.InputSpec as InputSpec
 import qualified Agent.CLI.InterruptSpec as InterruptSpec
@@ -66,6 +67,7 @@ main = hspec do
     CompactionSpec.spec
     ConnectivitySpec.spec
     CredentialStoreSpec.spec
+    ErrorSpec.spec
     ImagePreviewSpec.spec
     InputSpec.spec
     InterruptSpec.spec

--- a/packages/agent-core/src/Agent/Error.hs
+++ b/packages/agent-core/src/Agent/Error.hs
@@ -127,6 +127,7 @@ data ApiError
         , message :: !Text
         , retryAfter :: !(Maybe Int)
         }
+    | CredentialError { credentialMessage :: !Text }
     | ConnectionError { exception :: !Text }
     | CredentialsExhausted { retryAt :: !UTCTime }
     deriving (Eq, Show)

--- a/packages/agent-core/src/Agent/Provider.hs
+++ b/packages/agent-core/src/Agent/Provider.hs
@@ -134,6 +134,7 @@ accountFailureFromApiError err = case err of
     HttpError 401 _ -> authenticationRejected
     HttpError 403 _ -> authenticationRejected
     ProviderError AuthenticationError _ _ -> authenticationRejected
+    CredentialError{} -> authenticationRejected
     _ -> Nothing
   where
     rateLimited = Just $ AccountRateLimited (apiErrorRetryAfter err)

--- a/packages/agent-core/src/Agent/Skills.hs
+++ b/packages/agent-core/src/Agent/Skills.hs
@@ -19,7 +19,7 @@ module Agent.Skills
 
 import Agent.FileRetry (retryOnFileBusy)
 import Agent.OsPath (toText, unsafeToFilePath)
-import Control.Exception.Safe (tryAny)
+import Control.Exception.Safe (displayException, tryAny)
 import Control.Monad (filterM, forM)
 import Data.Aeson
     ( FromJSON(..)
@@ -44,7 +44,7 @@ import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import qualified Data.Text.IO as Text
-import Data.Yaml (decodeEither')
+import Data.Yaml (decodeEither', prettyPrintParseException)
 import System.Directory
     ( canonicalizePath
     , doesDirectoryExist
@@ -290,13 +290,17 @@ loadSkill
 loadSkill scope origin path = do
     result <- tryAny (retryOnFileBusy (Text.readFile path))
     case result of
-        Left err -> pure $ Left (warning (Text.pack (show err)))
+        Left err ->
+            pure $ Left (warning (Text.pack (displayException err)))
         Right fileText ->
             case splitFrontmatter fileText of
                 Left err -> pure (Left (warning err))
                 Right (yamlText, body) ->
                     case decodeEither' (Text.encodeUtf8 yamlText) of
-                        Left err -> pure $ Left (warning (Text.pack (show err)))
+                        Left err ->
+                            pure $ Left
+                                (warning
+                                    (Text.pack (prettyPrintParseException err)))
                         Right frontmatter ->
                             case validateFrontmatter path frontmatter of
                                 Left err -> pure (Left (warning err))

--- a/packages/agent-openai/src/Agent/OpenAI/Auth.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Auth.hs
@@ -421,6 +421,7 @@ isAuthError :: ApiError -> Bool
 isAuthError (HttpError 401 _) = True
 isAuthError (HttpError 403 _) = True
 isAuthError (ProviderError AuthenticationError _ _) = True
+isAuthError CredentialError{} = True
 isAuthError _ = False
 
 setCooldown :: Pool -> Text -> UTCTime -> IO ()

--- a/packages/agent-openai/test/Agent/OpenAI/AuthSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/AuthSpec.hs
@@ -205,6 +205,26 @@ spec = do
                     accountIdOf result `shouldBe` second
                 _ -> expectationFailure ("expected two refresh attempts, got " <> show tried)
 
+        it "fails over when the selected account has a local credential error" $ do
+            attempts <- newIORef ([] :: [Text])
+            let states = [ mkExpiredAuth "acc-broken", mkExpiredAuth "acc-ok" ]
+                refresh state = do
+                    previous <- readIORef attempts
+                    modifyIORef' attempts (<> [state.accountId])
+                    if null previous
+                        then pure $ Left
+                            (CredentialError "credential source is unavailable")
+                        else pure $ Right state
+            pool <- newPool states refresh
+            result <- getAccessToken pool
+            tried <- readIORef attempts
+            case tried of
+                [first, second] -> do
+                    first `shouldNotBe` second
+                    accountIdOf result `shouldBe` second
+                _ -> expectationFailure
+                    ("expected two refresh attempts, got " <> show tried)
+
     describe "reportRateLimit" $ do
         it "skips rate-limited accounts on subsequent picks" $ do
             callCounter <- newIORef (0 :: Int)

--- a/packages/agent-openai/test/Agent/OpenAI/CredentialSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/CredentialSpec.hs
@@ -46,6 +46,9 @@ spec = do
         it "classifies authentication failures but not connection errors" do
             accountFailureFromApiError (HttpError 401 "rejected")
                 `shouldBe` Just AccountAuthenticationRejected
+            accountFailureFromApiError
+                (CredentialError "credential file is invalid")
+                `shouldBe` Just AccountAuthenticationRejected
             accountFailureFromApiError (ConnectionError "offline")
                 `shouldBe` Nothing
 

--- a/packages/agent-openrouter/src/Agent/OpenRouter/Usage.hs
+++ b/packages/agent-openrouter/src/Agent/OpenRouter/Usage.hs
@@ -69,8 +69,8 @@ decodeKeyInfo
     -> Either Text
         (Maybe Text, Maybe Scientific, Maybe Scientific, Maybe Scientific, Maybe Bool)
 decodeKeyInfo body = case Aeson.eitherDecode body of
-    Left detail ->
-        Left ("OpenRouter key response could not be decoded: " <> Text.pack detail)
+    Left _ ->
+        Left "OpenRouter returned an unreadable key-usage response."
     Right KeyInfo{label, usage, limit, limitRemaining, freeTier} ->
         Right (label, usage, limit, limitRemaining, freeTier)
 
@@ -78,10 +78,8 @@ decodeCredits
     :: LBS.ByteString
     -> Either Text (Maybe Scientific, Maybe Scientific)
 decodeCredits body = case Aeson.eitherDecode body of
-    Left detail ->
-        Left
-            ("OpenRouter credits response could not be decoded: "
-                <> Text.pack detail)
+    Left _ ->
+        Left "OpenRouter returned an unreadable credits response."
     Right Credits{credits, used} -> Right (credits, used)
 
 fetchOpenRouterUsage :: Text -> IO (Either Text OpenRouterUsage)
@@ -113,10 +111,9 @@ fetchOpenRouterUsage apiKey = do
                     (HttpClient.responseTimeoutMicro (30 * 1_000_000))
                     request
         pure case result of
-            Left exception ->
+            Left _ ->
                 Left
-                    ("OpenRouter usage request failed: "
-                        <> Text.pack (show exception))
+                    "Could not load OpenRouter usage. Check your connection and retry."
             Right response
                 | let status = getResponseStatusCode response
                 , status >= 200

--- a/packages/agent-openrouter/test/Agent/OpenRouter/UsageSpec.hs
+++ b/packages/agent-openrouter/test/Agent/OpenRouter/UsageSpec.hs
@@ -14,8 +14,18 @@ spec = do
                 `shouldBe` Right
                     (Just "agent", Just 12.5, Just 50, Just 37.5, Just False)
 
+        it "hides parser internals for unreadable responses" do
+            decodeKeyInfo "not json"
+                `shouldBe`
+                    Left "OpenRouter returned an unreadable key-usage response."
+
     describe "decodeCredits" do
         it "decodes total credits and usage" do
             decodeCredits (LBS.pack
                 "{\"data\":{\"total_credits\":100,\"total_usage\":25.25}}")
                 `shouldBe` Right (Just 100, Just 25.25)
+
+        it "hides parser internals for unreadable responses" do
+            decodeCredits "not json"
+                `shouldBe`
+                    Left "OpenRouter returned an unreadable credits response."

--- a/packages/agent-responses/src/Agent/Responses/Error.hs
+++ b/packages/agent-responses/src/Agent/Responses/Error.hs
@@ -251,6 +251,7 @@ isPreviousResponseIdError = \case
         mentionsPreviousResponse (Text.pack (show errorType))
             || mentionsPreviousResponse message
     ConnectionError message -> mentionsPreviousResponse message
+    CredentialError{} -> False
     HttpError _ body -> mentionsPreviousResponse body
     JsonDecodeError message body ->
         mentionsPreviousResponse message || mentionsPreviousResponse body

--- a/packages/agent-xai/src/Agent/XAI/Usage.hs
+++ b/packages/agent-xai/src/Agent/XAI/Usage.hs
@@ -50,16 +50,16 @@ instance Aeson.FromJSON GrokUsageSnapshot where
 
 decodeGrokUsage :: LBS.ByteString -> Either Text GrokUsageSnapshot
 decodeGrokUsage body = case Aeson.eitherDecode body of
-    Left detail ->
-        Left ("Grok billing response could not be decoded: " <> Text.pack detail)
+    Left _ ->
+        Left "Grok returned an unreadable usage response."
     Right snapshot -> Right snapshot
 
 fetchGrokUsage :: Text -> IO (Either Text GrokUsageSnapshot)
 fetchGrokUsage accessToken =
     tryAny requestUsage >>= \case
-        Left exception ->
+        Left _ ->
             pure $ Left
-                ("Grok billing request failed: " <> Text.pack (show exception))
+                "Could not load Grok usage. Check your connection and retry."
         Right response -> do
             let status = getResponseStatusCode response
             pure $

--- a/packages/agent-xai/test/Agent/XAI/UsageSpec.hs
+++ b/packages/agent-xai/test/Agent/XAI/UsageSpec.hs
@@ -24,3 +24,7 @@ spec =
                     \\"currentPeriod\":{\"start\":\"2026-08-20T00:00:00Z\",\
                     \\"end\":\"2026-08-21T00:00:00Z\"}}}"
             fmap (.usedPercent) (decodeGrokUsage body) `shouldBe` Right 100
+
+        it "hides parser internals for unreadable responses" do
+            decodeGrokUsage "not json"
+                `shouldBe` Left "Grok returned an unreadable usage response."


### PR DESCRIPTION
## Summary

- add a centralized, exhaustive formatter for API, credential, connection, quota, and provider failures
- route turns, persisted sessions, startup, fallback, `/btw`, `/compact`, `/usage`, `/login`, `/reload-auth`, and provider switching through the shared renderer
- suppress raw response bodies, structured WebSocket payloads, exception dumps, terminal controls, and Haskell constructor syntax
- preserve trusted local credential recovery details with a distinct `CredentialError` while retaining account failover behavior
- render live retry guidance relatively and persisted retry guidance as safe absolute timestamps
- make xAI/OpenRouter usage failures and skill-loading warnings readable without parser or HTTP-client internals

## Validation

- `agent-cli-test`: 489 examples, 0 failures
- `agent-core-test`: 241 examples, 0 failures
- `agent-responses-test`: 3 examples, 0 failures
- `agent-openai-test`: 167 examples, 0 failures, 1 pending live test
- `agent-xai-test`: 42 examples, 0 failures, 1 pending live test
- `agent-openrouter-test`: 38 examples, 0 failures, 1 pending live test
- exercised the fullscreen application and representative colored/persisted error states in tmux
- `git diff --check`
