### PR TITLE
fix(io): serialize streaming snapshots

### DIFF
--- a/packages/agent-core/src/Agent/Tools/IO.hs
+++ b/packages/agent-core/src/Agent/Tools/IO.hs
@@ -166,14 +166,19 @@ runShellCommandStreaming env workdir command timeoutMs onSnapshot =
             lastSnapshotRef <- newIORef Nothing
             let collect = do
                     -- Drain stdout and stderr concurrently so a child that
-                    -- fills one pipe cannot deadlock the other.
-                    withAsync sampleSnapshots \_sampler -> do
+                    -- fills one pipe cannot deadlock the other. Leave the
+                    -- sampler's structured scope before the final emission:
+                    -- this cancels and joins it, so an older periodic
+                    -- snapshot cannot overtake the authoritative final one
+                    -- and callbacks are never invoked concurrently.
+                    (out, err) <- withAsync sampleSnapshots \_sampler -> do
                         (out, err) <- concurrently
                             (drainHandle env.toolStdoutCap hout stdoutRef)
                             (drainHandle env.toolStdoutCap herr stderrRef)
-                        code <- waitForProcess processHandle
-                        emitSnapshot
-                        pure (out, err, code)
+                        pure (out, err)
+                    code <- waitForProcess processHandle
+                    emitSnapshot
+                    pure (out, err, code)
                 sampleSnapshots = do
                     threadDelay 100000
                     emitSnapshot

--- a/packages/agent-core/test/Agent/Tools/IOSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/IOSpec.hs
@@ -22,7 +22,7 @@ import Agent.Tools.IO
 import Agent.Tools.Types (ToolEnv(..), defaultToolEnv)
 import Control.Concurrent (forkIO, newEmptyMVar, putMVar, takeMVar, threadDelay)
 import Control.Concurrent.MVar (readMVar)
-import Control.Exception.Safe (bracket, tryIO)
+import Control.Exception.Safe (bracket, bracket_, tryIO)
 import Control.Monad (replicateM)
 import qualified Data.ByteString.Lazy.Char8 as LBS8
 import Data.Either (isLeft, isRight)
@@ -183,6 +183,31 @@ spec = describe "Agent.Tools.IO" do
             finalSnapshots <- readIORef snapshots
             finalSnapshots `shouldSatisfy`
                 any (Text.isInfixOf "firstsecond")
+
+    it "does not overlap periodic and final snapshot callbacks" do
+        withTempDir \dir -> do
+            let osDir = fromFilePath dir
+            env <- defaultToolEnv osDir
+            active <- newIORef (0 :: Int)
+            peak <- newIORef (0 :: Int)
+            let callback _ _ =
+                    bracket_
+                        (do
+                            next <- atomicModifyIORef' active \current ->
+                                let next = current + 1
+                                in (next, next)
+                            atomicModifyIORef' peak \highest ->
+                                (max highest next, ()))
+                        (atomicModifyIORef' active \current ->
+                            (current - 1, ()))
+                        (threadDelay 300000)
+            _ <- runShellCommandStreaming
+                env
+                osDir
+                "printf first; sleep 0.15; printf second"
+                5000
+                callback
+            readIORef peak `shouldReturn` 1
 
     it "force-kills a process group on timeout" do
         withTempDir checkTimeoutKillsProcessGroup


### PR DESCRIPTION
## Summary
- stop and join the periodic shell-output sampler before publishing final output
- keep streaming callbacks ordered and prevent periodic/final callbacks from running concurrently
- add a regression that blocks callbacks long enough to expose overlap

This is the first focused replacement extracted from the previous broad concurrency-hardening change. The complete original implementation remains preserved on `2026-08-22-a453c1ac-full` while the remaining fixes are split and simplified independently.

## Testing
- `nix develop -c env -u GHCRTS cabal test agent-core-test --test-options='--match=Agent.Tools.IO' --test-show-details=direct`
- 17 examples, 0 failures
