### PR TITLE
fix(cli): reduce pasted image preview latency

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -1939,6 +1939,7 @@ replWithDraft env@SessionEnv
                         stdoutColor
                         (isNothing fullscreen)
                         images
+                    syncFullscreenImagePreviews
                     displayInfo message $
                         Text.putStrLn
                             (roleMuted stdoutColor
@@ -1954,7 +1955,8 @@ replWithDraft env@SessionEnv
                                 displayError err do
                                     errColor <- resolveColor stderr
                                     Text.hPutStrLn stderr (roleError errColor err)
-                            Right message ->
+                            Right message -> do
+                                syncFullscreenImagePreviews
                                 displayInfo message $
                                     Text.putStrLn
                                         (roleMuted stdoutColor
@@ -1997,6 +1999,7 @@ replWithDraft env@SessionEnv
                                     color
                                     (isNothing fullscreen)
                                     images
+                                syncFullscreenImagePreviews
                                 displayInfo message $
                                     Text.putStrLn
                                         (roleMuted color
@@ -2103,6 +2106,7 @@ replWithDraft env@SessionEnv
                                             color
                                             (isNothing fullscreen)
                                             [image]
+                                        syncFullscreenImagePreviews
                                         displayInfo attachMessage $
                                             Text.putStrLn
                                                 (roleMuted color
@@ -2154,6 +2158,7 @@ replWithDraft env@SessionEnv
                                             color
                                             (isNothing fullscreen)
                                             images
+                                        syncFullscreenImagePreviews
                                         displayInfo message $
                                             Text.putStrLn
                                                 (roleMuted color
@@ -2649,6 +2654,10 @@ replWithDraft env@SessionEnv
     fullscreenEvent event = case fullscreen of
         Nothing -> pure ()
         Just runtime -> emitUiEvent runtime event
+    syncFullscreenImagePreviews =
+        forM_ fullscreen \runtime ->
+            readIORef attachmentsRef
+                >>= setFullscreenImagePreviews runtime
     displayInfo message minimalAction = case fullscreen of
         Nothing -> minimalAction
         Just runtime -> emitUiEvent runtime (UiSystemMessage message)

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -2052,17 +2052,21 @@ handleEventInner event = case event of
     AppEvent (AppSetImagePreviews images) ->
         do
             state <- get
-            let prepared =
-                    mapMaybe
-                        (\image ->
-                            case prepareTuiImagePreview image of
-                                Left _ -> Nothing
-                                Right preview -> Just (image, preview))
-                        images
-            liftIO do
-                previous <-
+            previous <-
+                liftIO $
                     readIORef state.appRuntime.runtimeImagePreviews
-                when (map fst previous /= map fst prepared) do
+            let unchanged = map fst previous == images
+                prepared
+                    | unchanged = previous
+                    | otherwise =
+                        mapMaybe
+                            (\image ->
+                                case prepareTuiImagePreview image of
+                                    Left _ -> Nothing
+                                    Right preview -> Just (image, preview))
+                            images
+            liftIO do
+                when (not unchanged) do
                     writeIORef
                         state.appRuntime.runtimeImagePreviews
                         prepared

--- a/packages/agent-cli/src/Agent/CLI/TUI/ImagePreview.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/ImagePreview.hs
@@ -56,7 +56,11 @@ data TuiImagePreview = TuiImagePreview
     , previewBytes :: !Int
     , previewSourceWidth :: !Int
     , previewSourceHeight :: !Int
-    , previewSample :: !(Image PixelRGB8)
+    -- Keep the ANSI fallback sample lazy. Native Kitty previews only need the
+    -- source dimensions and encoded attachment, and eagerly resampling a large
+    -- screenshot here can stall the Brick event thread for over a second in
+    -- the interpreted development loop.
+    , previewSample :: Image PixelRGB8
     , previewKittyAttachment :: !ImageAttachment
     }
     deriving (Eq)
@@ -190,8 +194,8 @@ renderTuiImagePreview maxColumns maxRows preview =
 previewPixelSize :: Int -> Int -> TuiImagePreview -> (Int, Int)
 previewPixelSize maxColumns maxRows preview =
     previewSizeWithin
-        (min (imageWidth preview.previewSample) (max 1 maxColumns))
-        (min (imageHeight preview.previewSample) (max 1 maxRows * 2))
+        (min maxPreviewColumns (max 1 maxColumns))
+        (min maxPreviewPixelRows (max 1 maxRows * 2))
         preview.previewSourceWidth
         preview.previewSourceHeight
 

--- a/packages/agent-cli/test/Agent/CLI/TUIImagePreviewSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIImagePreviewSpec.hs
@@ -61,6 +61,33 @@ spec =
                     previewCellSize 72 23 preview `shouldBe` (72, 20)
                     previewCellSize 48 12 preview `shouldBe` (42, 12)
 
+        it "does not force the ANSI sample when sizing native previews" do
+            let attachment = ImageAttachment
+                    { imageMime = "image/png"
+                    , imageBytes = ""
+                    }
+                preview = TuiImagePreview
+                    { previewMime = "image/png"
+                    , previewBytes = 0
+                    , previewSourceWidth = 1600
+                    , previewSourceHeight = 900
+                    , previewSample =
+                        error "native preview sizing forced the ANSI sample"
+                    , previewKittyAttachment = attachment
+                    }
+            previewCellSize 72 23 preview `shouldBe` (72, 20)
+            nativePreviewPlacements 100 120 40 [(attachment, preview)]
+                `shouldBe`
+                    [ NativePreviewPlacement
+                        { nativePreviewImageId = 100
+                        , nativePreviewRow = 9
+                        , nativePreviewColumn = 24
+                        , nativePreviewColumns = 72
+                        , nativePreviewRows = 20
+                        , nativePreviewAttachment = attachment
+                        }
+                    ]
+
         it "preserves thin screenshot details while downsampling" do
             let source =
                     generateImage


### PR DESCRIPTION
## Summary

- keep the ANSI fallback sample lazy so native Kitty/Ghostty previews do not synchronously build an unused box-filtered thumbnail
- publish fullscreen image previews immediately after attachments are queued instead of waiting for the next REPL iteration
- reuse prepared previews when the queued attachments have not changed
- add a regression test proving native preview sizing does not force the ANSI sample

## Performance

For a representative 1600×900 PNG in the interpreted development REPL, the native preview preparation path dropped from roughly 1.6 seconds to roughly 0.02 seconds. Clipboard extraction and full-image terminal transfer can still contribute latency for large images.

## Validation

- focused `Agent.CLI.TUIImagePreviewSpec`: 7 examples, 0 failures
- reloaded all 55 `agent-cli` modules successfully in the project GHCi
- exercised image attachment and preview in a live tmux TTY smoke test
