### PR TITLE
Reject incomplete patterns and record construction

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -27,8 +27,10 @@ common common-options
     ghc-options:      -Wall
                       -Wcompat
                       -Widentities
+                      -Werror=incomplete-patterns
+                      -Werror=incomplete-uni-patterns
+                      -Werror=missing-fields
                       -Wincomplete-record-updates
-                      -Wincomplete-uni-patterns
                       -Wpartial-fields
                       -Wno-name-shadowing
 

--- a/packages/agent-core/agent-core.cabal
+++ b/packages/agent-core/agent-core.cabal
@@ -27,7 +27,13 @@ common common-opts
                       , TypeApplications
                       , ScopedTypeVariables
                       , PackageImports
-    ghc-options:      -Wall -Wno-unused-do-bind -Wno-name-shadowing -Wno-missing-signatures
+    ghc-options:      -Wall
+                      -Werror=incomplete-patterns
+                      -Werror=incomplete-uni-patterns
+                      -Werror=missing-fields
+                      -Wno-unused-do-bind
+                      -Wno-name-shadowing
+                      -Wno-missing-signatures
 
 library
     import:           common-opts

--- a/packages/agent-openai/agent-openai.cabal
+++ b/packages/agent-openai/agent-openai.cabal
@@ -36,7 +36,13 @@ common common-opts
                       , FlexibleContexts
                       , TupleSections
                       , PackageImports
-    ghc-options:      -Wall -Wno-unused-do-bind -Wno-name-shadowing -Wno-missing-signatures
+    ghc-options:      -Wall
+                      -Werror=incomplete-patterns
+                      -Werror=incomplete-uni-patterns
+                      -Werror=missing-fields
+                      -Wno-unused-do-bind
+                      -Wno-name-shadowing
+                      -Wno-missing-signatures
 
 library
     import:           common-opts

--- a/packages/agent-openrouter/agent-openrouter.cabal
+++ b/packages/agent-openrouter/agent-openrouter.cabal
@@ -28,7 +28,13 @@ common common-opts
                       , TypeApplications
                       , ScopedTypeVariables
                       , PackageImports
-    ghc-options:      -Wall -Wno-unused-do-bind -Wno-name-shadowing -Wno-missing-signatures
+    ghc-options:      -Wall
+                      -Werror=incomplete-patterns
+                      -Werror=incomplete-uni-patterns
+                      -Werror=missing-fields
+                      -Wno-unused-do-bind
+                      -Wno-name-shadowing
+                      -Wno-missing-signatures
 
 library
     import:           common-opts

--- a/packages/agent-responses/agent-responses.cabal
+++ b/packages/agent-responses/agent-responses.cabal
@@ -33,7 +33,13 @@ common common-opts
                       , FlexibleContexts
                       , TupleSections
                       , PackageImports
-    ghc-options:      -Wall -Wno-unused-do-bind -Wno-name-shadowing -Wno-missing-signatures
+    ghc-options:      -Wall
+                      -Werror=incomplete-patterns
+                      -Werror=incomplete-uni-patterns
+                      -Werror=missing-fields
+                      -Wno-unused-do-bind
+                      -Wno-name-shadowing
+                      -Wno-missing-signatures
 
 library
     import:           common-opts

--- a/packages/agent-tui/agent-tui.cabal
+++ b/packages/agent-tui/agent-tui.cabal
@@ -24,8 +24,10 @@ common common-options
     ghc-options:      -Wall
                       -Wcompat
                       -Widentities
+                      -Werror=incomplete-patterns
+                      -Werror=incomplete-uni-patterns
+                      -Werror=missing-fields
                       -Wincomplete-record-updates
-                      -Wincomplete-uni-patterns
                       -Wpartial-fields
                       -Wno-name-shadowing
 

--- a/packages/agent-xai/agent-xai.cabal
+++ b/packages/agent-xai/agent-xai.cabal
@@ -27,7 +27,13 @@ common common-opts
                       , TypeApplications
                       , ScopedTypeVariables
                       , PackageImports
-    ghc-options:      -Wall -Wno-unused-do-bind -Wno-name-shadowing -Wno-missing-signatures
+    ghc-options:      -Wall
+                      -Werror=incomplete-patterns
+                      -Werror=incomplete-uni-patterns
+                      -Werror=missing-fields
+                      -Wno-unused-do-bind
+                      -Wno-name-shadowing
+                      -Wno-missing-signatures
 
 library
     import:           common-opts


### PR DESCRIPTION
## Summary

- treat incomplete function and `case` patterns as compiler errors
- treat refutable unary pattern bindings as compiler errors
- reject record construction that omits fields
- apply the targeted warning policy to every package and component

## Verification

- loaded all seven libraries in the Nix multi-package Cabal REPL with GHC 9.10.3 (`Ok, 146 modules loaded.`)
- `git diff --check`