### PR TITLE
fix(tui): render markdown links as hyperlinks

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -321,6 +321,10 @@ runFullscreen runtime workerAction = do
                 V.setMode output V.BracketedPaste True
             when (V.supportsMode output V.Mouse) $
                 V.setMode output V.Mouse True
+            -- Vty deliberately leaves OSC 8 output disabled by default even
+            -- when rendered attributes contain URLs.
+            when (V.supportsMode output V.Hyperlink) $
+                V.setMode output V.Hyperlink True
             wrapNativePreviewVty runtime vty
     initialVty <- buildVty
     let

--- a/packages/agent-tui/src/Agent/TUI/Markdown.hs
+++ b/packages/agent-tui/src/Agent/TUI/Markdown.hs
@@ -63,7 +63,7 @@ data InlineStyle
     | InlineStrong
     | InlineEmphasis
     | InlineCode
-    | InlineLink
+    | InlineLink !Text
     deriving (Eq, Show)
 
 data InlineSpan = InlineSpan
@@ -271,7 +271,7 @@ parseInline = go Nothing []
                     : go (lastChar body) [] rest
         | Just (label, url, rest) <- linkSpan text =
             flushPlain plain $
-                InlineSpan InlineLink
+                InlineSpan (InlineLink url)
                     (label
                         <> if Text.null url || label == url
                             then ""
@@ -377,7 +377,13 @@ inlineWidget spans =
   where
     resolve InlineSpan{inlineStyle, inlineText} = do
         attr <- B.lookupAttrName (styleAttr inlineStyle)
-        pure (attr, inlineText)
+        pure
+            ( case inlineStyle of
+                InlineLink url
+                    | not (Text.null url) -> attr `V.withURL` url
+                _ -> attr
+            , inlineText
+            )
 
 styleAttr :: InlineStyle -> AttrName
 styleAttr = \case
@@ -385,7 +391,7 @@ styleAttr = \case
     InlineStrong -> Theme.strongAttr
     InlineEmphasis -> Theme.emphasisAttr
     InlineCode -> Theme.inlineCodeAttr
-    InlineLink -> Theme.linkAttr
+    InlineLink _ -> Theme.linkAttr
 
 wrapStyled :: Int -> [(V.Attr, Text)] -> [[(V.Attr, Text)]]
 wrapStyled width spans =

--- a/packages/agent-tui/test/Agent/TUI/MarkdownSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/MarkdownSpec.hs
@@ -25,9 +25,18 @@ spec = describe "fullscreen Markdown inline parsing" do
                 , InlineSpan InlinePlain ", "
                 , InlineSpan InlineCode "code"
                 , InlineSpan InlinePlain ", and "
-                , InlineSpan InlineLink "docs (https://example.com)"
+                , InlineSpan
+                    (InlineLink "https://example.com")
+                    "docs (https://example.com)"
                 , InlineSpan InlinePlain "."
                 ]
+
+    it "renders links with native terminal hyperlink metadata" do
+        let widget :: Widget ()
+            widget = markdownWidget "[docs](https://example.com)"
+            rendered = show (renderWidget Nothing [widget] (40, 3))
+        rendered `shouldSatisfy`
+            isInfixOf "attrURL = SetTo \"https://example.com\""
 
     it "supports multi-backtick code and avoids snake_case emphasis" do
         let spans = parseInline "``a ` b`` and snake_case"


### PR DESCRIPTION
## Summary

- preserve Markdown link destinations in fullscreen TUI inline spans
- attach Vty URL attributes to rendered link text
- enable Vty hyperlink mode so the TUI emits OSC 8 links
- add regression coverage for terminal hyperlink metadata

## Verification

- `nix develop -c cabal repl agent-tui:test:agent-tui-test` — 29 examples, 0 failures
- multi-package `agent-cli` + `agent-tui` GHCi load
- live agent smoke test in tmux; raw pane output contained OSC 8 sequences for `https://example.com`