### PR TITLE
feat(cli): replace Inkling with Ox Alpha

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Models.hs
+++ b/packages/agent-cli/src/Agent/CLI/Models.hs
@@ -62,8 +62,7 @@ modelsForProvider provider =
                 ]
             OpenRouterProvider ->
                 [ opt "openai/gpt-5.1" (Just "default")
-                , opt "thinkingmachines/inkling:free" (Just "free")
-                , opt "thinkingmachines/inkling-small:free" (Just "free · faster")
+                , opt "stealth/ox-alpha" (Just "free · coding · 1M context")
                 , opt "anthropic/claude-sonnet-4" Nothing
                 , opt "x-ai/grok-4" Nothing
                 , opt "google/gemini-2.5-pro" Nothing

--- a/packages/agent-cli/test/Agent/CLI/ModelsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ModelsSpec.hs
@@ -27,12 +27,11 @@ spec = do
             let ids = map (.modelId) (modelsForProvider OpenAIProvider)
             ids `shouldBe` ["gpt-5.6-luna", "gpt-5.6-terra", "gpt-5.6-sol"]
 
-        it "lists Thinking Machines models for OpenRouter" do
+        it "lists Ox Alpha instead of Thinking Machines models for OpenRouter" do
             let ids = map (.modelId) (modelsForProvider OpenRouterProvider)
-            ids `shouldContain`
-                [ "thinkingmachines/inkling:free"
-                , "thinkingmachines/inkling-small:free"
-                ]
+            ids `shouldContain` ["stealth/ox-alpha"]
+            ids `shouldSatisfy`
+                all (not . Text.isPrefixOf "thinkingmachines/")
 
         it "lists several options per provider" do
             length (modelsForProvider XAIProvider) `shouldSatisfy` (>= 2)


### PR DESCRIPTION
## Summary

- remove the restricted Thinking Machines Inkling models from the curated OpenRouter catalog
- add [`stealth/ox-alpha`](https://openrouter.ai/stealth/ox-alpha) as a free coding model with a 1M-token context label
- cover the replacement and assert that Thinking Machines slugs are no longer curated

The OpenRouter default remains `openai/gpt-5.1`; this only changes the curated picker and completion catalog.

## Validation

- `nix develop --command cabal test agent-cli-test --test-options='--match modelsForProvider'` — 5 passed\n- `nix develop --command cabal test agent-cli-test` — 509 passed\n- live OpenRouter text request with `stealth/ox-alpha` returned `OX_ALPHA_OK`\n- live `read_file` tool call returned `OX_ALPHA_TOOL_OK`\n- tmux model-picker smoke test showed Ox Alpha and no Inkling entries