### PR TITLE
fix(transport): contain and retry connection failures

### DIFF
--- a/packages/agent-core/agent-core.cabal
+++ b/packages/agent-core/agent-core.cabal
@@ -44,6 +44,7 @@ library
                     , Agent.Http.Url
                     , Agent.ProjectInstructions
                     , Agent.ResourceScope
+                    , Agent.Retry
                     , Agent.Skills
                     , Agent.Subagents
                     , Agent.Subagents.Format
@@ -84,6 +85,7 @@ library
                     , async
                     , bytestring
                     , containers
+                    , crypton-connection
                     , directory
                     , filepath
                     , process
@@ -114,6 +116,7 @@ test-suite agent-core-test
                     , Agent.ProjectInstructionsSpec
                     , Agent.Provider.OptionsSpec
                     , Agent.ResourceScopeSpec
+                    , Agent.RetrySpec
                     , Agent.SkillsSpec
                     , Agent.SubagentsSpec
                     , Agent.Subagents.TaskPathSpec
@@ -144,6 +147,7 @@ test-suite agent-core-test
                     , time
                     , tls
                     , bytestring
+                    , crypton-connection
                     , unix
                     , websockets
                     , yaml

--- a/packages/agent-core/agent-core.cabal
+++ b/packages/agent-core/agent-core.cabal
@@ -93,6 +93,7 @@ library
                     , stm
                     , text
                     , time
+                    , tls
                     , transformers
                     , unix
                     , vector
@@ -141,6 +142,7 @@ test-suite agent-core-test
                     , stm
                     , text
                     , time
+                    , tls
                     , bytestring
                     , unix
                     , websockets

--- a/packages/agent-core/package.nix
+++ b/packages/agent-core/package.nix
@@ -1,20 +1,21 @@
 { mkDerivation, aeson, async, base, bytestring, containers
-, directory, filepath, hspec, lib, process, resourcet, retry
-, safe-exceptions, stm, text, time, transformers, unix, vector
-, websockets, yaml
+, crypton-connection, directory, filepath, hspec, lib, process
+, resourcet, retry, safe-exceptions, stm, text, time, tls
+, transformers, unix, vector, websockets, yaml
 }:
 mkDerivation {
   pname = "agent-core";
   version = "0.1.0.0";
   src = ./.;
   libraryHaskellDepends = [
-    aeson async base bytestring containers directory filepath process
-    resourcet retry safe-exceptions stm text time transformers unix
-    vector websockets yaml
+    aeson async base bytestring containers crypton-connection directory
+    filepath process resourcet retry safe-exceptions stm text time tls
+    transformers unix vector websockets yaml
   ];
   testHaskellDepends = [
-    aeson async base bytestring containers directory filepath hspec
-    safe-exceptions stm text time unix websockets yaml
+    aeson async base bytestring containers crypton-connection directory
+    filepath hspec retry safe-exceptions stm text time tls unix
+    websockets yaml
   ];
   description = "Provider-neutral infrastructure for the agent harness";
   license = lib.meta.getLicenseFromSpdxId "BSD-3-Clause";

--- a/packages/agent-core/src/Agent/Retry.hs
+++ b/packages/agent-core/src/Agent/Retry.hs
@@ -1,0 +1,61 @@
+module Agent.Retry
+    ( ExceptionRetry(..)
+    , handleSyncExceptions
+    , retryingBeforeCommit
+    ) where
+
+import qualified Control.Exception.Safe as Safe
+import Control.Retry (RetryPolicyM, retrying)
+import Data.IORef (newIORef, readIORef, writeIORef)
+
+-- | How a synchronous exception raised before an operation commits should be
+-- represented. Both constructors return the error as data; only
+-- 'RetryException' asks the supplied retry policy for another attempt.
+data ExceptionRetry error
+    = RetryException !error
+    | StopException !error
+    deriving (Eq, Show)
+
+-- | Normalize any synchronous exception from an action into its ordinary
+-- error channel. Asynchronous cancellation remains an exception.
+handleSyncExceptions
+    :: (Safe.SomeException -> error)
+    -> IO (Either error value)
+    -> IO (Either error value)
+handleSyncExceptions classify action =
+    Safe.tryAny action >>= \case
+        Left exception -> pure (Left (classify exception))
+        Right result -> pure result
+
+-- | Retry synchronous exceptions only until the action crosses its explicit
+-- commit boundary.
+--
+-- Exceptions raised before @markCommitted@ are normalized with @classify@ and
+-- returned as ordinary errors when the policy stops. Exceptions raised after
+-- the boundary are rethrown unchanged because replaying the action could
+-- duplicate externally visible effects. 'Safe.tryAny' intentionally leaves
+-- asynchronous cancellation alone.
+retryingBeforeCommit
+    :: RetryPolicyM IO
+    -> (Safe.SomeException -> ExceptionRetry error)
+    -> ((IO () -> IO (Either error value)))
+    -> IO (Either error value)
+retryingBeforeCommit policy classify action = do
+    committedRef <- newIORef False
+    outcome <- retrying policy shouldRetry \_retryStatus -> do
+        writeIORef committedRef False
+        Safe.tryAny (action (writeIORef committedRef True)) >>= \case
+            Right result -> pure (Right result)
+            Left exception -> do
+                committed <- readIORef committedRef
+                if committed
+                    then Safe.throwIO exception
+                    else pure (Left (classify exception))
+    pure $ case outcome of
+        Right result -> result
+        Left (RetryException err) -> Left err
+        Left (StopException err) -> Left err
+  where
+    shouldRetry _retryStatus = \case
+        Left RetryException{} -> pure True
+        _ -> pure False

--- a/packages/agent-core/src/Agent/Transport/WebSocket.hs
+++ b/packages/agent-core/src/Agent/Transport/WebSocket.hs
@@ -20,6 +20,10 @@ module Agent.Transport.WebSocket
     ) where
 
 import Agent.Error (ApiError(..))
+import Agent.Retry
+    ( ExceptionRetry(..)
+    , retryingBeforeCommit
+    )
 import Control.Concurrent.Async (withAsync)
 import Control.Concurrent.STM
 import qualified Control.Exception as Exception
@@ -28,10 +32,8 @@ import Control.Retry
     ( RetryPolicyM
     , capDelay
     , exponentialBackoff
-    , retrying
     )
 import qualified Data.ByteString.Lazy as LBS
-import Data.IORef (newIORef, readIORef, writeIORef)
 import Data.Maybe (isJust)
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -39,6 +41,7 @@ import qualified Data.Text.Encoding as Text
 import qualified Data.Text.Encoding.Error as Text (lenientDecode)
 import Data.Word (Word64)
 import GHC.IO.Exception (IOErrorType(ResourceVanished))
+import qualified Network.Connection as Connection
 import qualified Network.TLS as TLS
 import qualified Network.WebSockets as WS
 import System.IO.Error (ioeGetErrorType)
@@ -425,51 +428,93 @@ transientWsConnectRetryPolicy :: RetryPolicyM IO
 transientWsConnectRetryPolicy =
     capDelay 15000000 (exponentialBackoff 1000000)
 
--- | Retry transient WebSocket connection / handshake failures until the
+-- | Normalize and retry WebSocket connection / handshake failures until the
 -- connection callback begins. Once the callback has started, retrying the
 -- enclosing action could replay visible effects from an active session, so
--- every exception is propagated unchanged.
+-- later exceptions are propagated unchanged.
 --
 -- The policy is injectable so tests can retry without sleeping.
 retryTransientWsConnectWithPolicy
     :: RetryPolicyM IO
-    -> (IO () -> IO value)
-    -> IO value
-retryTransientWsConnectWithPolicy policy connect = do
-    callbackStarted <- newIORef False
-    result <- retrying policy (shouldRetry callbackStarted) \_retryStatus -> do
-        writeIORef callbackStarted False
-        Safe.tryAny (connect (writeIORef callbackStarted True))
-    either Exception.throwIO pure result
-  where
-    shouldRetry callbackStarted _retryStatus = \case
-        Left exception -> do
-            started <- readIORef callbackStarted
-            pure $
-                not started
-                    && isJust (transientWsConnectFailureLabel exception)
-        Right _ -> pure False
+    -> (IO () -> IO (Either ApiError value))
+    -> IO (Either ApiError value)
+retryTransientWsConnectWithPolicy policy =
+    retryingBeforeCommit policy wsConnectExceptionRetry
 
 -- | Classify transient failures that happen before a WebSocket session is
 -- established.
 transientWsConnectFailureLabel :: Exception.SomeException -> Maybe Text
-transientWsConnectFailureLabel exception = case Exception.fromException exception of
-    Just WS.ConnectionTimeout ->
-        Just "WebSocket handshake timed out"
-    Just (WS.MalformedResponse responseHead _reason)
-        | WS.responseCode responseHead `elem` retryableHandshakeStatusCodes ->
-            Just ("WebSocket handshake returned HTTP " <> showText (WS.responseCode responseHead))
-    _
-        | Just (TLS.HandshakeFailed (TLS.Error_Misc message)) <-
-            Exception.fromException exception
-        , isTransientNetworkErrorText (Text.pack message) ->
-            Just ("TLS handshake failed: " <> Text.pack message)
-        | Just (ioException :: IOError) <- Exception.fromException exception
-        , isTransientIOError ioException ->
-            Just ("WebSocket connect IO error: " <> showText ioException)
-        | otherwise -> Nothing
+transientWsConnectFailureLabel exception =
+    case wsConnectExceptionRetry exception of
+        RetryException (ConnectionError message) -> Just message
+        RetryException (HttpError _ message) -> Just message
+        _ -> Nothing
+
+wsConnectExceptionRetry
+    :: Exception.SomeException
+    -> ExceptionRetry ApiError
+wsConnectExceptionRetry exception
+    | Just authError <- wsHandshakeAuthFailure exception =
+        StopException authError
+    | Just (WS.MalformedResponse responseHead _reason) <-
+        Exception.fromException exception =
+            let status = WS.responseCode responseHead
+                apiError = HttpError status
+                    ("WebSocket handshake returned HTTP " <> showText status)
+            in if status `elem` retryableHandshakeStatusCodes
+                then RetryException apiError
+                else StopException apiError
+    | Just WS.ConnectionTimeout <- Exception.fromException exception =
+        retryConnection "WebSocket handshake timed out"
+    | Just (Connection.HostNotResolved host) <-
+        Exception.fromException exception =
+            retryConnection
+                ("WebSocket host could not be resolved: " <> Text.pack host)
+    | Just (Connection.HostCannotConnect host failures) <-
+        Exception.fromException exception =
+            retryConnection
+                ("WebSocket host could not be reached: "
+                    <> Text.pack host
+                    <> formatNestedFailures failures)
+    | Just tlsException <- Exception.fromException exception =
+        classifyTlsException tlsException
+    | Just (ioException :: IOError) <- Exception.fromException exception =
+        retryConnection ("WebSocket connect IO error: " <> showText ioException)
+    | otherwise =
+        StopException $ ConnectionError
+            ("WebSocket connection failed: " <> showText exception)
   where
     retryableHandshakeStatusCodes = [408, 425, 429, 500, 502, 503, 504]
+    retryConnection = RetryException . ConnectionError
+    formatNestedFailures [] = ""
+    formatNestedFailures failures = " (" <> showText failures <> ")"
+
+classifyTlsException :: TLS.TLSException -> ExceptionRetry ApiError
+classifyTlsException tlsException =
+    let message = tlsExceptionMessage tlsException
+        transient = RetryException (ConnectionError message)
+        permanent = StopException (ConnectionError message)
+    in case tlsException of
+        TLS.HandshakeFailed TLS.Error_EOF -> transient
+        TLS.HandshakeFailed TLS.Error_TCP_Terminate -> transient
+        TLS.HandshakeFailed (TLS.Error_Misc detail)
+            | isTransientNetworkErrorText (Text.pack detail) -> transient
+        TLS.Terminated _ _ TLS.Error_EOF -> transient
+        TLS.Terminated _ _ TLS.Error_TCP_Terminate -> transient
+        TLS.Terminated _ _ (TLS.Error_Misc detail)
+            | isTransientNetworkErrorText (Text.pack detail) -> transient
+        _ -> permanent
+
+tlsExceptionMessage :: TLS.TLSException -> Text
+tlsExceptionMessage = \case
+    TLS.HandshakeFailed (TLS.Error_Misc detail) ->
+        "TLS handshake failed: " <> Text.pack detail
+    TLS.HandshakeFailed TLS.Error_EOF ->
+        "TLS handshake failed: unexpected EOF"
+    TLS.HandshakeFailed TLS.Error_TCP_Terminate ->
+        "TLS handshake failed: TCP connection terminated"
+    tlsException ->
+        "TLS handshake failed: " <> showText tlsException
 
 -- | Extract an authentication status from a rejected WebSocket handshake.
 wsHandshakeAuthFailureStatus :: Exception.SomeException -> Maybe Int

--- a/packages/agent-core/src/Agent/Transport/WebSocket.hs
+++ b/packages/agent-core/src/Agent/Transport/WebSocket.hs
@@ -39,6 +39,7 @@ import qualified Data.Text.Encoding as Text
 import qualified Data.Text.Encoding.Error as Text (lenientDecode)
 import Data.Word (Word64)
 import GHC.IO.Exception (IOErrorType(ResourceVanished))
+import qualified Network.TLS as TLS
 import qualified Network.WebSockets as WS
 import System.IO.Error (ioeGetErrorType)
 
@@ -458,7 +459,15 @@ transientWsConnectFailureLabel exception = case Exception.fromException exceptio
     Just (WS.MalformedResponse responseHead _reason)
         | WS.responseCode responseHead `elem` retryableHandshakeStatusCodes ->
             Just ("WebSocket handshake returned HTTP " <> showText (WS.responseCode responseHead))
-    _ -> Nothing
+    _
+        | Just (TLS.HandshakeFailed (TLS.Error_Misc message)) <-
+            Exception.fromException exception
+        , isTransientNetworkErrorText (Text.pack message) ->
+            Just ("TLS handshake failed: " <> Text.pack message)
+        | Just (ioException :: IOError) <- Exception.fromException exception
+        , isTransientIOError ioException ->
+            Just ("WebSocket connect IO error: " <> showText ioException)
+        | otherwise -> Nothing
   where
     retryableHandshakeStatusCodes = [408, 425, 429, 500, 502, 503, 504]
 
@@ -490,20 +499,21 @@ transientWsMidRunFailureLabel exception
     , isTransientIOError ioException =
         Just ("WebSocket IO error: " <> showText ioException)
     | otherwise = Nothing
-  where
-    isTransientIOError :: IOError -> Bool
-    isTransientIOError ioException =
-        ioeGetErrorType ioException == ResourceVanished || matchesTransientMessage
-      where
-        matchesTransientMessage =
-            any (`Text.isInfixOf` message)
-                [ "connection reset"
-                , "broken pipe"
-                , "connection refused"
-                , "network is unreachable"
-                , "timed out"
-                ]
-        message = Text.toLower (showText ioException)
+
+isTransientIOError :: IOError -> Bool
+isTransientIOError ioException =
+    ioeGetErrorType ioException == ResourceVanished
+        || isTransientNetworkErrorText (showText ioException)
+
+isTransientNetworkErrorText :: Text -> Bool
+isTransientNetworkErrorText message =
+    any (`Text.isInfixOf` Text.toLower message)
+        [ "connection reset"
+        , "broken pipe"
+        , "connection refused"
+        , "network is unreachable"
+        , "timed out"
+        ]
 
 showText :: Show value => value -> Text
 showText = Text.pack . show

--- a/packages/agent-core/test/Agent/RetrySpec.hs
+++ b/packages/agent-core/test/Agent/RetrySpec.hs
@@ -1,0 +1,56 @@
+module Agent.RetrySpec (spec) where
+
+import Agent.Retry
+import Control.Exception.Safe (SomeException, tryAny)
+import Control.Retry (constantDelay, limitRetries)
+import Data.IORef
+import Test.Hspec
+
+spec :: Spec
+spec = describe "retryingBeforeCommit" do
+    it "normalizes synchronous exceptions into the action error channel" do
+        result <- handleSyncExceptions
+            (const "normalized")
+            (ioError (userError "socket failed"))
+
+        result `shouldBe` (Left "normalized" :: Either String ())
+
+    it "returns the last normalized exception after retries are exhausted" do
+        attempts <- newIORef (0 :: Int)
+        result <- retryingBeforeCommit
+            (constantDelay 0 <> limitRetries 2)
+            (const (RetryException "offline"))
+            \_markCommitted -> do
+                modifyIORef' attempts (+ 1)
+                ioError (userError "socket failed")
+
+        result `shouldBe` (Left "offline" :: Either String ())
+        readIORef attempts `shouldReturn` 3
+
+    it "does not retry a stopped exception" do
+        attempts <- newIORef (0 :: Int)
+        result <- retryingBeforeCommit
+            (constantDelay 0 <> limitRetries 2)
+            (const (StopException "invalid configuration"))
+            \_markCommitted -> do
+                modifyIORef' attempts (+ 1)
+                ioError (userError "invalid")
+
+        result `shouldBe` (Left "invalid configuration" :: Either String ())
+        readIORef attempts `shouldReturn` 1
+
+    it "rethrows exceptions raised after the commit boundary" do
+        attempts <- newIORef (0 :: Int)
+        result <-
+            (tryAny $
+                retryingBeforeCommit
+                    (constantDelay 0 <> limitRetries 2)
+                    (const (RetryException "should not be used"))
+                    \markCommitted -> do
+                        modifyIORef' attempts (+ 1)
+                        markCommitted
+                        ioError (userError "callback failed"))
+                :: IO (Either SomeException (Either String ()))
+
+        result `shouldSatisfy` either (const True) (const False)
+        readIORef attempts `shouldReturn` 1

--- a/packages/agent-core/test/Agent/Transport/WebSocketSpec.hs
+++ b/packages/agent-core/test/Agent/Transport/WebSocketSpec.hs
@@ -28,6 +28,7 @@ import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BS8
 import qualified Data.ByteString.Lazy as LBS
 import Data.IORef
+import qualified Network.TLS as TLS
 import qualified Network.WebSockets as WS
 import qualified Network.WebSockets.Stream as WSStream
 import System.Timeout (timeout)
@@ -38,6 +39,19 @@ spec = describe "Agent.Transport.WebSocket" do
     it "classifies websocket connection timeouts" do
         transientWsConnectFailureLabel (toException WS.ConnectionTimeout :: SomeException)
             `shouldBe` Just "WebSocket handshake timed out"
+
+    it "classifies connection resets wrapped by the TLS handshake" do
+        let exception = TLS.HandshakeFailed $ TLS.Error_Misc
+                "Network.Socket.recvBuf: resource vanished (Connection reset by peer)"
+        transientWsConnectFailureLabel (toException exception :: SomeException)
+            `shouldBe` Just
+                "TLS handshake failed: Network.Socket.recvBuf: resource vanished (Connection reset by peer)"
+
+    it "does not classify permanent TLS handshake failures as transient" do
+        let exception = TLS.HandshakeFailed $ TLS.Error_Certificate
+                "certificate validation failed"
+        transientWsConnectFailureLabel (toException exception :: SomeException)
+            `shouldBe` Nothing
 
     it "backs off transient handshake retries exponentially with a cap" do
         retryPolicyDelays 7 transientWsConnectRetryPolicy
@@ -68,7 +82,8 @@ spec = describe "Agent.Transport.WebSocket" do
 
     it "retries a transient handshake failure before the connection callback" do
         attempts <- newIORef (0 :: Int)
-        let exception = transientHandshakeException 503
+        let exception = TLS.HandshakeFailed $ TLS.Error_Misc
+                "Network.Socket.recvBuf: resource vanished (Connection reset by peer)"
         result <- retryTransientWsConnectWithPolicy
             (constantDelay 0 <> limitRetries 3)
             \connected -> do

--- a/packages/agent-core/test/Agent/Transport/WebSocketSpec.hs
+++ b/packages/agent-core/test/Agent/Transport/WebSocketSpec.hs
@@ -14,7 +14,7 @@ import Control.Concurrent
     , takeMVar
     , writeChan
     )
-import Control.Exception (SomeException, finally, throwIO, toException)
+import Control.Exception (Exception, SomeException, finally, throwIO, toException)
 import qualified Control.Exception.Safe as Safe
 import Control.Retry
     ( RetryPolicyM
@@ -28,11 +28,17 @@ import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BS8
 import qualified Data.ByteString.Lazy as LBS
 import Data.IORef
+import qualified Network.Connection as Connection
 import qualified Network.TLS as TLS
 import qualified Network.WebSockets as WS
 import qualified Network.WebSockets.Stream as WSStream
 import System.Timeout (timeout)
 import Test.Hspec
+
+data UnexpectedConnectFailure = UnexpectedConnectFailure
+    deriving (Show)
+
+instance Exception UnexpectedConnectFailure
 
 spec :: Spec
 spec = describe "Agent.Transport.WebSocket" do
@@ -52,6 +58,24 @@ spec = describe "Agent.Transport.WebSocket" do
                 "certificate validation failed"
         transientWsConnectFailureLabel (toException exception :: SomeException)
             `shouldBe` Nothing
+
+    it "classifies typed TLS disconnects and connection wrappers as transient" do
+        transientWsConnectFailureLabel
+            (toException (TLS.HandshakeFailed TLS.Error_EOF) :: SomeException)
+            `shouldBe` Just "TLS handshake failed: unexpected EOF"
+        transientWsConnectFailureLabel
+            (toException (TLS.HandshakeFailed TLS.Error_TCP_Terminate) :: SomeException)
+            `shouldBe` Just "TLS handshake failed: TCP connection terminated"
+        transientWsConnectFailureLabel
+            (toException (Connection.HostNotResolved "chatgpt.com") :: SomeException)
+            `shouldBe` Just
+                "WebSocket host could not be resolved: chatgpt.com"
+        transientWsConnectFailureLabel
+            (toException
+                (Connection.HostCannotConnect "chatgpt.com" [])
+                :: SomeException)
+            `shouldBe` Just
+                "WebSocket host could not be reached: chatgpt.com"
 
     it "backs off transient handshake retries exponentially with a cap" do
         retryPolicyDelays 7 transientWsConnectRetryPolicy
@@ -90,9 +114,9 @@ spec = describe "Agent.Transport.WebSocket" do
                 attempt <- atomicModifyIORef' attempts \n -> (n + 1, n + 1)
                 if attempt == 1
                     then throwIO exception
-                    else connected >> pure ("connected" :: String)
+                    else connected >> pure (Right ("connected" :: String))
 
-        result `shouldBe` "connected"
+        result `shouldBe` Right "connected"
         readIORef attempts `shouldReturn` 2
 
     it "does not retry after the connection callback has started" do
@@ -109,22 +133,51 @@ spec = describe "Agent.Transport.WebSocket" do
             Left exception ->
                 transientWsConnectFailureLabel exception
                     `shouldBe` Just "WebSocket handshake returned HTTP 503"
-            Right () -> expectationFailure "expected the callback exception to escape"
+            Right (_ :: Either ApiError ()) ->
+                expectationFailure "expected the callback exception to escape"
         readIORef attempts `shouldReturn` 1
 
-    it "does not retry a non-transient handshake rejection" do
+    it "returns a non-transient handshake rejection as data" do
         attempts <- newIORef (0 :: Int)
-        result <- Safe.tryAny $
-            retryTransientWsConnectWithPolicy
-                (constantDelay 0 <> limitRetries 3)
-                \_connected -> do
-                    modifyIORef' attempts (+ 1)
-                    throwIO (transientHandshakeException 401)
+        result <- retryTransientWsConnectWithPolicy
+            (constantDelay 0 <> limitRetries 3)
+            \_connected -> do
+                modifyIORef' attempts (+ 1)
+                throwIO (transientHandshakeException 401)
 
-        case result of
-            Left exception ->
-                wsHandshakeAuthFailureStatus exception `shouldBe` Just 401
-            Right () -> expectationFailure "expected the handshake rejection to escape"
+        result `shouldBe`
+            (Left (HttpError 401 "WebSocket handshake returned HTTP 401")
+                :: Either ApiError ())
+        readIORef attempts `shouldReturn` 1
+
+    it "returns permanent TLS failures as data without retrying" do
+        attempts <- newIORef (0 :: Int)
+        result <- retryTransientWsConnectWithPolicy
+            (constantDelay 0 <> limitRetries 3)
+            \_connected -> do
+                modifyIORef' attempts (+ 1)
+                throwIO
+                    (TLS.HandshakeFailed
+                        (TLS.Error_Certificate "certificate validation failed"))
+
+        result `shouldBe`
+            (Left (ConnectionError
+                "TLS handshake failed: HandshakeFailed (Error_Certificate \"certificate validation failed\")")
+                :: Either ApiError ())
+        readIORef attempts `shouldReturn` 1
+
+    it "contains unknown synchronous failures before the callback" do
+        attempts <- newIORef (0 :: Int)
+        result <- retryTransientWsConnectWithPolicy
+            (constantDelay 0 <> limitRetries 3)
+            \_connected -> do
+                modifyIORef' attempts (+ 1)
+                throwIO UnexpectedConnectFailure
+
+        result `shouldBe`
+            (Left (ConnectionError
+                "WebSocket connection failed: UnexpectedConnectFailure")
+                :: Either ApiError ())
         readIORef attempts `shouldReturn` 1
 
     it "handles server pings while delivering application data" do

--- a/packages/agent-core/test/Spec.hs
+++ b/packages/agent-core/test/Spec.hs
@@ -9,6 +9,7 @@ import qualified Agent.OsPathSpec as OsPathSpec
 import qualified Agent.ProjectInstructionsSpec as ProjectInstructionsSpec
 import qualified Agent.Provider.OptionsSpec as ProviderOptionsSpec
 import qualified Agent.ResourceScopeSpec as ResourceScopeSpec
+import qualified Agent.RetrySpec as RetrySpec
 import qualified Agent.SkillsSpec as SkillsSpec
 import qualified Agent.SubagentsSpec as SubagentsSpec
 import qualified Agent.Subagents.TaskPathSpec as TaskPathSpec
@@ -37,6 +38,7 @@ main = hspec do
     ProjectInstructionsSpec.spec
     ProviderOptionsSpec.spec
     ResourceScopeSpec.spec
+    RetrySpec.spec
     SkillsSpec.spec
     SubagentsSpec.spec
     TaskPathSpec.spec

--- a/packages/agent-openai/src/Agent/OpenAI/Auth/Refresh.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Auth/Refresh.hs
@@ -13,6 +13,7 @@ import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
+import qualified Data.Text.Encoding.Error as Text (lenientDecode)
 import Data.Time.Clock (getCurrentTime)
 import Network.HTTP.Simple
     ( getResponseBody
@@ -49,7 +50,7 @@ refreshAccessTokenHTTP oauthClientId state = do
                 then pure $ Left $ ProviderError AuthenticationError
                     ("Codex token refresh failed with HTTP "
                         <> Text.pack (show status) <> ": "
-                        <> Text.decodeUtf8
+                        <> Text.decodeUtf8With Text.lenientDecode
                             (LBS.toStrict (LBS.take 500 (getResponseBody response))))
                     Nothing
                 else case Aeson.eitherDecode (getResponseBody response) of

--- a/packages/agent-openai/src/Agent/OpenAI/Client.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Client.hs
@@ -26,15 +26,13 @@ import Agent.Provider
     , TokenProvider
     , runWithTokenProvider
     )
+import Agent.Retry (handleSyncExceptions)
 import qualified Agent.Responses.Types as OpenAI
 import Control.Monad (forM_, when)
-import qualified Control.Exception.Safe as Exception
-import Control.Monad.Catch (Handler(..))
 import Control.Retry
     ( RetryPolicyM
     , exponentialBackoff
     , limitRetries
-    , recovering
     , retrying
     )
 import qualified Data.Aeson as Aeson
@@ -42,6 +40,7 @@ import qualified Data.ByteString as BS
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
+import qualified Data.Text.Encoding.Error as Text (lenientDecode)
 import qualified Network.URI as URI
 
 import OpenSSL
@@ -146,7 +145,11 @@ createCodexMessageWithProviderAtWithOptions options baseUrl provider request =
                 Nothing
             OpenAIProvider ->
                 retryTransientCodexResultWithPolicy transientResultPolicy $
-                    recovering exceptionPolicy handlers $ \_status ->
+                    handleSyncExceptions
+                        (ConnectionError
+                            . ("Codex request failed: " <>)
+                            . Text.pack
+                            . show) $
                         makeCodexRequest
                             options
                             baseUrl
@@ -154,13 +157,7 @@ createCodexMessageWithProviderAtWithOptions options baseUrl provider request =
                             credential.accountId
                             request
   where
-    exceptionPolicy = exponentialBackoff 1_000_000 <> limitRetries 3
     transientResultPolicy = exponentialBackoff 5_000_000 <> limitRetries 3
-    handlers = [\_status -> Handler handleException]
-    handleException :: Exception.SomeException -> IO Bool
-    handleException e
-        | Exception.isSyncException e = pure True
-        | otherwise = Exception.throwIO e
 
 -- | Retry short-lived provider and transport failures. Quota and rate-limit
 -- errors remain excluded by 'isInlineRetryableProviderError'.
@@ -214,7 +211,7 @@ responseHandler :: Response -> Streams.InputStream BS.ByteString -> IO (Either A
 responseHandler response stream = do
     let status = getStatusCode response
     bytes <- Streams.fold mappend mempty stream
-    let bodyText = Text.decodeUtf8 bytes
+    let bodyText = Text.decodeUtf8With Text.lenientDecode bytes
     if status >= 200 && status < 300
         then pure (decodeCodexHttpBody bodyText)
         else pure $ Left (classifyHttpFailure status bodyText)

--- a/packages/agent-openai/src/Agent/OpenAI/WebSocketClient.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/WebSocketClient.hs
@@ -155,29 +155,22 @@ runConnectionAttempt credential _action
         "OpenRouter credentials must be used through agent-openrouter"
         Nothing
 runConnectionAttempt credential action = do
-    result <- Exception.try @Exception.SomeException $ do
-        let headers = buildCodexWsHeaders credential
-        WebSocket.retryTransientWsConnectWithPolicy
-            WebSocket.transientWsConnectRetryPolicy
-            \connected ->
-                Wuss.runSecureClientWith
-                    wsHost
-                    443
-                    wsPath
-                    WS.defaultConnectionOptions
-                    headers
-                    \conn -> do
-                        connected
-                        WebSocket.withWebSocketSession
-                            WebSocket.defaultWebSocketSessionOptions
-                            conn
-                            (\session -> action (CodexWsConn session) credential)
-    case result of
-        Right value -> pure value
-        Left exception
-            | Just authErr <- WebSocket.wsHandshakeAuthFailure exception ->
-                pure (Left authErr)
-            | otherwise -> Exception.throwIO exception
+    let headers = buildCodexWsHeaders credential
+    WebSocket.retryTransientWsConnectWithPolicy
+        WebSocket.transientWsConnectRetryPolicy
+        \connected ->
+            Wuss.runSecureClientWith
+                wsHost
+                443
+                wsPath
+                WS.defaultConnectionOptions
+                headers
+                \conn -> do
+                    connected
+                    WebSocket.withWebSocketSession
+                        WebSocket.defaultWebSocketSessionOptions
+                        conn
+                        (\session -> action (CodexWsConn session) credential)
 
 -- | Pure handshake-header builder exported for transport contract tests.
 buildCodexWsHeaders :: Credential -> WS.Headers


### PR DESCRIPTION
## Summary

- add a shared `retryingBeforeCommit` boundary built on `Control.Retry`
- normalize synchronous failures before the commit/callback boundary into typed errors
- preserve exceptions after commit so requests with visible effects are never replayed
- retry typed DNS/connect failures from `crypton-connection`
- retry transient TLS EOF, TCP termination, reset, timeout, and retryable HTTP handshake failures
- return permanent and unknown pre-callback failures as controlled `ApiError` values instead of crashing GHCi
- normalize OpenAI REST transport exceptions before result retry and decode error bodies leniently

## Safety model

- pre-callback connection failures may retry according to policy
- non-transient pre-callback failures return as data without retrying
- post-callback exceptions are rethrown because replay may duplicate visible output or side effects
- asynchronous cancellation remains untouched

## Testing

- `agent-core` test suite in GHCi: 258 examples, 0 failures
- WebSocket transport group after final changes: 17 examples, 0 failures
- `agent-openai` test suite in GHCi: 178 examples, 0 failures, 1 live-test pending
- multi-package GHCi load for `agent-cli`, `agent-core`, and `agent-openai`: 151 modules loaded
