### PR TITLE
fix(tools): parse integer arguments exactly

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/SubagentStore.hs
+++ b/packages/agent-cli/src/Agent/CLI/SubagentStore.hs
@@ -21,6 +21,7 @@ import Agent.OsPath (toText, unsafeToFilePath)
 import Agent.Responses.Types
 import Agent.Subagents (SubagentId(..), SubagentIdentity(..), SubagentStatus(..))
 import Agent.Subagents.TaskPath (taskPathText)
+import Agent.ToolArgs (readExactInt)
 import Control.Exception.Safe (tryAny)
 import Data.Aeson (FromJSON(..), ToJSON(..), object, withObject, (.:?), (.=))
 import qualified Data.Aeson as Aeson
@@ -30,7 +31,6 @@ import qualified Data.ByteString.Lazy as LBS
 import Data.Char (isAlphaNum)
 import Data.Text (Text)
 import qualified Data.Text as Text
-import Text.Read (readMaybe)
 import System.Directory.OsPath
     ( createDirectoryIfMissing
     , doesFileExist
@@ -135,7 +135,7 @@ forkSubagentTranscript forkTurns items =
     in case normalized of
         Just "none" -> []
         Just turns
-            | Just count <- readMaybe (Text.unpack turns)
+            | Just count <- readExactInt turns
             , count > 0 -> takeRecentTurns count completeItems
         _ -> completeItems
 

--- a/packages/agent-cli/test/Agent/CLI/SubagentStoreSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SubagentStoreSpec.hs
@@ -116,6 +116,8 @@ spec = describe "Agent.CLI.SubagentStore" do
         forkSubagentTranscript (Just "none") items `shouldBe` []
         forkSubagentTranscript (Just "1") items
             `shouldBe` drop 2 items
+        forkSubagentTranscript (Just "18446744073709551617") items
+            `shouldBe` items
 
 messageItem :: ResponseRole -> Text -> ResponseItem
 messageItem role text = MessageItem ResponseMessage

--- a/packages/agent-core/agent-core.cabal
+++ b/packages/agent-core/agent-core.cabal
@@ -96,6 +96,7 @@ library
                     , retry >= 0.9.3.1 && < 0.10
                     , resourcet
                     , safe-exceptions
+                    , scientific
                     , stm
                     , text
                     , time

--- a/packages/agent-core/package.nix
+++ b/packages/agent-core/package.nix
@@ -1,6 +1,6 @@
 { mkDerivation, aeson, async, base, bytestring, containers
 , directory, filepath, hspec, lib, process, resourcet, retry
-, safe-exceptions, stm, text, time, transformers, unix, vector
+, safe-exceptions, scientific, stm, text, time, transformers, unix, vector
 , websockets, yaml
 }:
 mkDerivation {
@@ -9,7 +9,7 @@ mkDerivation {
   src = ./.;
   libraryHaskellDepends = [
     aeson async base bytestring containers directory filepath process
-    resourcet retry safe-exceptions stm text time transformers unix
+    resourcet retry safe-exceptions scientific stm text time transformers unix
     vector websockets yaml
   ];
   testHaskellDepends = [

--- a/packages/agent-core/src/Agent/ToolArgs.hs
+++ b/packages/agent-core/src/Agent/ToolArgs.hs
@@ -12,6 +12,8 @@ module Agent.ToolArgs
     , reqTextList
     , optText
     , optInt
+    , optIntOrString
+    , readExactInt
     , optBool
     , intOr
     , optList
@@ -22,8 +24,10 @@ import Data.Aeson (FromJSON(..), Object, Value(..))
 import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KeyMap
 import Data.Aeson.Types (Parser)
+import Data.Scientific (Scientific, toBoundedInteger)
 import Data.Text (Text)
 import qualified Data.Text as Text
+import qualified Data.Text.Read as TextRead
 import qualified Data.Vector as Vector
 
 extractText :: Value -> Text -> Either Text Text
@@ -59,7 +63,7 @@ extractTextOr _ _ def = def
 extractIntOr :: Value -> Text -> Int -> Int
 extractIntOr (Object obj) key def =
     case KeyMap.lookup (Key.fromText key) obj of
-        Just (Number n) -> round n
+        Just (Number n) -> maybe def id (exactInt n)
         _ -> def
 extractIntOr _ _ def = def
 
@@ -73,7 +77,7 @@ extractMaybeText _ _ = Nothing
 extractMaybeInt :: Value -> Text -> Maybe Int
 extractMaybeInt (Object obj) key =
     case KeyMap.lookup (Key.fromText key) obj of
-        Just (Number n) -> Just (round n)
+        Just (Number n) -> exactInt n
         _ -> Nothing
 extractMaybeInt _ _ = Nothing
 
@@ -135,11 +139,38 @@ optText obj key = pure $ case look obj key of
     Just (String t) | not (Text.null t) -> Just t
     _ -> Nothing
 
--- | Optional integer (JSON number, rounded).
+-- | Optional exact, bounded integer. An absent or null field is 'Nothing';
+-- fractional, out-of-range, and wrongly typed values fail.
 optInt :: Object -> Text -> Parser (Maybe Int)
-optInt obj key = pure $ case look obj key of
-    Just (Number n) -> Just (round n)
-    _ -> Nothing
+optInt obj key = case look obj key of
+    Nothing -> pure Nothing
+    Just Null -> pure Nothing
+    Just (Number n) -> Just <$> parseExactInt key n
+    Just _ -> expectedInteger key
+
+-- | 'optInt' plus compatibility for integer strings emitted by some
+-- model tool surfaces. Strings are still required to be exact and in range.
+optIntOrString :: Object -> Text -> Parser (Maybe Int)
+optIntOrString obj key = case look obj key of
+    Nothing -> pure Nothing
+    Just Null -> pure Nothing
+    Just (Number n) -> Just <$> parseExactInt key n
+    Just (String value) ->
+        maybe (expectedInteger key) (pure . Just) (readExactInt value)
+    Just _ -> expectedInteger key
+
+-- | Read a signed decimal 'Int' without rounding or overflow. Leading and
+-- trailing whitespace is ignored; non-decimal syntax and trailing input fail.
+readExactInt :: Text -> Maybe Int
+readExactInt value = do
+    (integer, rest) <-
+        either (const Nothing) Just $
+            TextRead.signed TextRead.decimal (Text.strip value)
+    if Text.null rest
+        && integer >= toInteger (minBound :: Int)
+        && integer <= toInteger (maxBound :: Int)
+        then Just (fromInteger integer)
+        else Nothing
 
 -- | Optional boolean accepting stringy forms.
 optBool :: Object -> Text -> Parser (Maybe Bool)
@@ -154,11 +185,13 @@ optBool obj key = pure $ case look obj key of
             _       -> Nothing
     _ -> Nothing
 
--- | Integer with a default.
+-- | Exact, bounded integer with a default for an absent or null field.
 intOr :: Object -> Text -> Int -> Parser Int
-intOr obj key def = pure $ case look obj key of
-    Just (Number n) -> round n
-    _ -> def
+intOr obj key def = case look obj key of
+    Nothing -> pure def
+    Just Null -> pure def
+    Just (Number n) -> parseExactInt key n
+    Just _ -> expectedInteger key
 
 -- | Optional array field decoded element-wise via 'FromJSON'. Absent key
 -- means 'Nothing'; present-but-not-an-array fails with the supplied message.
@@ -180,3 +213,14 @@ stripAesonPrefix t
 
 failText :: Text -> Parser a
 failText = fail . Text.unpack
+
+exactInt :: Scientific -> Maybe Int
+exactInt = toBoundedInteger
+
+parseExactInt :: Text -> Scientific -> Parser Int
+parseExactInt key =
+    maybe (expectedInteger key) pure . exactInt
+
+expectedInteger :: Text -> Parser a
+expectedInteger key =
+    failText ("Expected integer for key: " <> key)

--- a/packages/agent-core/src/Agent/Tools/Codex.hs
+++ b/packages/agent-core/src/Agent/Tools/Codex.hs
@@ -11,7 +11,7 @@ module Agent.Tools.Codex
 import Agent.OsPath (fromText)
 import Agent.ToolArgs
     ( objectArgs
-    , optInt
+    , optIntOrString
     , optText
     , reqText
     )
@@ -44,9 +44,9 @@ import Agent.Tools.Types
     , jsonAppToolWithExecution
     )
 import Control.Applicative ((<|>))
-import Data.Aeson (FromJSON(..), Object, Value(..), withObject)
+import Data.Aeson (FromJSON(..), Value(..), withObject)
 import qualified Data.Aeson.KeyMap as KeyMap
-import Data.Aeson.Types (Parser, parseFail)
+import Data.Aeson.Types (parseFail)
 import Data.IORef
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
@@ -97,17 +97,7 @@ instance FromJSON ShellCommandArgs where
     parseJSON = objectArgs \object -> ShellCommandArgs
         <$> reqText object "command"
         <*> optText object "workdir"
-        <*> (optInt object "timeout_ms" <|> optionalIntString object "timeout_ms")
-
-optionalIntString :: Object -> Text -> Parser (Maybe Int)
-optionalIntString object key = do
-    value <- optText object key
-    pure (value >>= readInt)
-
-readInt :: Text -> Maybe Int
-readInt text = case reads (Text.unpack text) of
-    [(n, "")] -> Just n
-    _ -> Nothing
+        <*> optIntOrString object "timeout_ms"
 
 shellCommandTool :: ToolEnv -> AppTool
 shellCommandTool env = jsonTool "shell_command" shellDescription

--- a/packages/agent-core/src/Agent/Tools/Ghci/Tool.hs
+++ b/packages/agent-core/src/Agent/Tools/Ghci/Tool.hs
@@ -5,8 +5,7 @@ module Agent.Tools.Ghci.Tool
 
 import Agent.ToolArgs
     ( objectArgs
-    , optInt
-    , optText
+    , optIntOrString
     , reqText
     )
 import Agent.ToolDSL
@@ -28,7 +27,6 @@ import Agent.Tools.Types
     , ToolExecutionPolicy(..)
     , jsonAppToolWithExecution
     )
-import Control.Applicative ((<|>))
 import Data.Aeson (FromJSON(..), Object)
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Key as Key
@@ -52,16 +50,8 @@ instance FromJSON GhciArgs where
         <*> reqText object "description"
 
 optionalTimeout :: Object -> Parser (Maybe Int)
-optionalTimeout object = do
-    fromInt <- optInt object "timeout"
-    fromText <- optText object "timeout"
-    pure (fromInt <|> (fromText >>= readTimeout))
-
-readTimeout :: Text -> Maybe Int
-readTimeout text =
-    case reads (Text.unpack text) of
-        [(n, "")] -> Just n
-        _ -> Nothing
+optionalTimeout object =
+    optIntOrString object "timeout"
 
 runGhciTool :: GhciSession -> AppTool
 runGhciTool session =

--- a/packages/agent-core/src/Agent/Tools/Grok/Common.hs
+++ b/packages/agent-core/src/Agent/Tools/Grok/Common.hs
@@ -5,7 +5,7 @@ module Agent.Tools.Grok.Common
     , stripAnsi
     ) where
 
-import Agent.ToolArgs (optInt, optText)
+import Agent.ToolArgs (optIntOrString)
 import Agent.ToolDSL (PropertySchema)
 import Agent.ToolDispatch (ToolHandler)
 import Agent.OsPath (unsafeToFilePath)
@@ -15,7 +15,6 @@ import Agent.Tools.Types
     , ToolExecutionPolicy
     , jsonAppToolWithExecution
     )
-import Control.Applicative ((<|>))
 import Data.Aeson (Object)
 import Data.Aeson.Types (Parser)
 import Data.Text (Text)
@@ -47,16 +46,8 @@ isGitIgnored cwd path = findExecutable "git" >>= \case
         pure (code == ExitSuccess)
 
 optionalTimeout :: Object -> Parser (Maybe Int)
-optionalTimeout object = do
-    fromInt <- optInt object "timeout"
-    fromText <- optText object "timeout"
-    pure $ fromInt <|> (fromText >>= readTimeout)
-
-readTimeout :: Text -> Maybe Int
-readTimeout text =
-    case reads (Text.unpack text) of
-        [(n, "")] -> Just n
-        _ -> Nothing
+optionalTimeout object =
+    optIntOrString object "timeout"
 
 stripAnsi :: Text -> Text
 stripAnsi = Text.concat . go

--- a/packages/agent-core/src/Agent/Tools/MultiAgents.hs
+++ b/packages/agent-core/src/Agent/Tools/MultiAgents.hs
@@ -45,6 +45,7 @@ import Agent.ToolArgs
     ( objectArgs
     , optInt
     , optText
+    , readExactInt
     , reqText
     , reqTextList
     )
@@ -224,8 +225,8 @@ validForkTurns = \case
     Just turns ->
         let stripped = Text.toLower (Text.strip turns)
         in stripped `elem` ["none", "all", ""]
-            || case reads (Text.unpack stripped) of
-                [(turns :: Int, "")] -> turns > 0
+            || case readExactInt stripped of
+                Just count -> count > 0
                 _ -> False
 
 sanitizeOverride :: Maybe Text -> Maybe Text
@@ -259,7 +260,7 @@ instance FromJSON WaitAgentArgs where
 
 waitAgentTool :: MultiAgentContext -> AppTool
 waitAgentTool ctx = jsonTool "wait_agent" waitAgentDescription
-    [ PropertySchema "timeout_ms" PropertyNumber False $ Just
+    [ PropertySchema "timeout_ms" PropertyInteger False $ Just
         "Timeout in milliseconds. Defaults to 30000 ms."
     ]
     True

--- a/packages/agent-core/test/Agent/ToolArgsSpec.hs
+++ b/packages/agent-core/test/Agent/ToolArgsSpec.hs
@@ -1,10 +1,20 @@
 module Agent.ToolArgsSpec (spec) where
 
 import Agent.ToolArgs
+import Agent.Loop (defaultLoopDispatch)
+import Agent.ToolDispatch
+    ( ToolCallResult(..)
+    , dispatchToolCall
+    , functionToolCall
+    , typedTool
+    )
 import Data.Aeson ((.=))
 import qualified Data.Aeson as Aeson
 import Data.Aeson.Types (parseEither)
+import Data.ByteString (ByteString)
+import Data.IORef (newIORef, readIORef, writeIORef)
 import Data.Text (Text)
+import qualified Data.Text as Text
 import Test.Hspec
 
 spec :: Spec
@@ -26,6 +36,69 @@ spec = describe "ToolArgs" do
             `shouldBe`
                 Right (SearchArgs "invoice" 5 (Just False))
 
+    it "accepts only exact bounded JSON integers" do
+        decodeSearch "{\"query\":\"invoice\",\"limit\":5}"
+            `shouldBe` Right (SearchArgs "invoice" 5 Nothing)
+        decodeSearch "{\"query\":\"invoice\",\"limit\":5.0}"
+            `shouldBe` Right (SearchArgs "invoice" 5 Nothing)
+        decodeSearch "{\"query\":\"invoice\",\"limit\":1.9}"
+            `shouldBe` Left "Expected integer for key: limit"
+        decodeSearch "{\"query\":\"invoice\",\"limit\":1e100}"
+            `shouldBe` Left "Expected integer for key: limit"
+        decodeSearch "{\"query\":\"invoice\",\"limit\":-1e100}"
+            `shouldBe` Left "Expected integer for key: limit"
+        decodeSearch "{\"query\":\"invoice\",\"limit\":\"5\"}"
+            `shouldBe` Left "Expected integer for key: limit"
+
+    it "defaults integers only when absent or null" do
+        decodeSearch "{\"query\":\"invoice\"}"
+            `shouldBe` Right (SearchArgs "invoice" 10 Nothing)
+        decodeSearch "{\"query\":\"invoice\",\"limit\":null}"
+            `shouldBe` Right (SearchArgs "invoice" 10 Nothing)
+
+    it "keeps optional integers absent but rejects malformed values" do
+        parseOptionalInt (Aeson.object [])
+            `shouldBe` Right Nothing
+        parseOptionalInt (Aeson.object ["timeout" .= Aeson.Null])
+            `shouldBe` Right Nothing
+        parseOptionalInt (Aeson.object ["timeout" .= (250 :: Int)])
+            `shouldBe` Right (Just 250)
+        parseOptionalInt (Aeson.object ["timeout" .= (2.5 :: Double)])
+            `shouldBe` Left "Expected integer for key: timeout"
+        parseOptionalInt (Aeson.object ["timeout" .= ("250" :: Text)])
+            `shouldBe` Left "Expected integer for key: timeout"
+
+    it "accepts bounded integer strings only through the compatibility helper" do
+        parseOptionalIntString (Aeson.object ["timeout" .= (" 250 " :: Text)])
+            `shouldBe` Right (Just 250)
+        parseOptionalIntString (Aeson.object ["timeout" .= ("1.9" :: Text)])
+            `shouldBe` Left "Expected integer for key: timeout"
+        parseOptionalIntString (Aeson.object ["timeout" .= ("0x10" :: Text)])
+            `shouldBe` Left "Expected integer for key: timeout"
+        parseOptionalIntString
+            (Aeson.object ["timeout" .= ("999999999999999999999999999" :: Text)])
+            `shouldBe` Left "Expected integer for key: timeout"
+
+    it "keeps legacy pure extractors total on malformed integers" do
+        let fractional = jsonValue "{\"limit\":1.9}"
+            overflowing = jsonValue "{\"limit\":1e100}"
+        extractIntOr fractional "limit" 20 `shouldBe` 20
+        extractMaybeInt fractional "limit" `shouldBe` Nothing
+        extractIntOr overflowing "limit" 20 `shouldBe` 20
+        extractMaybeInt overflowing "limit" `shouldBe` Nothing
+
+    it "does not execute a handler when an integer argument is invalid" do
+        called <- newIORef False
+        result <- dispatchToolCall defaultLoopDispatch
+            [ typedTool "search" \(args :: SearchArgs) -> do
+                writeIORef called True
+                pure (Right args.query)
+            ]
+            (functionToolCall "call-1" "search"
+                "{\"query\":\"invoice\",\"limit\":1.9}")
+        result.output `shouldBe` "Error: Expected integer for key: limit"
+        readIORef called `shouldReturn` False
+
     it "keeps optList absent distinct from present empty" do
         parseEither (objectArgs $ \o -> optList @Text o "items" "items must be an array") (Aeson.object [])
             `shouldBe` Right Nothing
@@ -43,3 +116,29 @@ instance Aeson.FromJSON SearchArgs where
         <$> reqText o "query"
         <*> intOr o "limit" 10
         <*> optBool o "dry_run"
+
+decodeSearch :: ByteString -> Either Text SearchArgs
+decodeSearch bytes =
+    case Aeson.eitherDecodeStrict bytes of
+        Right value -> Right value
+        Left err -> Left (stripAesonPrefix (toText err))
+
+parseOptionalInt :: Aeson.Value -> Either Text (Maybe Int)
+parseOptionalInt =
+    firstText . parseEither (objectArgs $ \o -> optInt o "timeout")
+
+parseOptionalIntString :: Aeson.Value -> Either Text (Maybe Int)
+parseOptionalIntString =
+    firstText . parseEither (objectArgs $ \o -> optIntOrString o "timeout")
+
+firstText :: Either String a -> Either Text a
+firstText = either (Left . stripAesonPrefix . toText) Right
+
+toText :: String -> Text
+toText = Text.pack
+
+jsonValue :: ByteString -> Aeson.Value
+jsonValue bytes =
+    case Aeson.eitherDecodeStrict bytes of
+        Right value -> value
+        Left err -> error err

--- a/packages/agent-core/test/Agent/Tools/CodexSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/CodexSpec.hs
@@ -92,7 +92,7 @@ spec = describe "Agent.Tools.Codex" do
                 , "fork_turns"
                 ]
             map (.propertyType) (parameters "wait_agent") `shouldBe`
-                [PropertyNumber]
+                [PropertyInteger]
             case map (.propertyType) (parameters "spawn_agent") of
                 _ : PropertyRaw (Aeson.Object messageSchema) : _ ->
                     KeyMap.lookup "encrypted" messageSchema
@@ -271,7 +271,7 @@ spec = describe "Agent.Tools.Codex" do
             output `shouldSatisfy` Text.isInfixOf "Exit code: 0"
             output `shouldSatisfy` Text.isInfixOf "hi"
             timed <- runFn env "shell_command"
-                "{\"command\":\"sleep 5\",\"timeout_ms\":200}"
+                "{\"command\":\"sleep 5\",\"timeout_ms\":\"200\"}"
             timed `shouldSatisfy` Text.isInfixOf "timed out"
 
     it "stores an update_plan and rejects two in_progress steps" do

--- a/packages/agent-core/test/Agent/Tools/GhciSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/GhciSpec.hs
@@ -227,7 +227,7 @@ spec = describe "Agent.Tools.Ghci" do
             let handlers = appToolHandlers tools
             result <- dispatchToolCall defaultLoopDispatch handlers
                 (functionToolCall "c1" "run_ghci"
-                    "{\"expression\":\"3 + 4\",\"description\":\"add\"}")
+                    "{\"expression\":\"3 + 4\",\"timeout\":\"10000\",\"description\":\"add\"}")
             result.output `shouldSatisfy` Text.isInfixOf "class: pure"
             result.output `shouldSatisfy` Text.isInfixOf "7"
             let names = map (.appToolName) tools

--- a/packages/agent-core/test/Agent/Tools/GrokSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/GrokSpec.hs
@@ -183,7 +183,7 @@ spec = describe "Agent.Tools.Grok" do
     it "times out a long-running shell command" do
         withTempSession \(session, ghci) -> do
             output <- runTool session ghci "run_terminal_cmd"
-                "{\"command\":\"sleep 5\",\"timeout\":200,\"description\":\"timeout test\"}"
+                "{\"command\":\"sleep 5\",\"timeout\":\"200\",\"description\":\"timeout test\"}"
             output `shouldSatisfy` Text.isPrefixOf "exit: killed (timeout)"
 
     it "starts read_file from a negative offset" do

--- a/packages/agent-core/test/Agent/Tools/MultiAgentsSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/MultiAgentsSpec.hs
@@ -138,6 +138,24 @@ spec = describe "Agent.Tools.MultiAgents" do
         result.output `shouldSatisfy` Text.isInfixOf "positive integer"
         closeSubagentRegistry registry
 
+    it "rejects overflowing fork turns instead of wrapping them" do
+        registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
+            (\_ _ _ _ -> pure $ Left LoopNoResponseId)
+            (\_ _ -> pure ())
+        let call = ToolCall
+                { callId = "spawn-overflow"
+                , name = "collaboration.spawn_agent"
+                , arguments =
+                    "{\"task_name\":\"worker\",\"message\":\"task\",\
+                    \\"fork_turns\":\"18446744073709551617\"}"
+                , callKind = FunctionCallKind
+                , argumentsEncrypted = False
+                }
+        result <- dispatchToolCall defaultLoopDispatch
+            (appToolHandlers (multiAgentTools (rootContext registry Nothing))) call
+        result.output `shouldSatisfy` Text.isInfixOf "positive integer"
+        closeSubagentRegistry registry
+
     it "wait_agent excludes the calling child" do
         parentGate <- newTVarIO False
         registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")


### PR DESCRIPTION
## Summary
- reject fractional and out-of-range JSON tool integers instead of rounding or overflowing
- preserve bounded decimal-string compatibility for shell, GHCi, and Grok timeout arguments
- share exact integer parsing with `fork_turns` and persisted transcript slicing
- advertise `wait_agent.timeout_ms` as an integer while preserving absent/null defaults

## Validation
- `agent-core`: 257 examples, 0 failures
- `agent-cli`: 533 examples, 0 failures
- `nix build --no-link .#checks.aarch64-darwin.agent-core`
- `git diff --check origin/master...HEAD`