### PR TITLE
fix(auth): single-flight file credential reloads

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -202,6 +202,7 @@ test-suite agent-cli-test
                     , agent-xai
                     , aeson
                     , ansi-terminal
+                    , async
                     , base >= 4.17 && < 5
                     , brick >= 2.9 && < 3
                     , bytestring

--- a/packages/agent-cli/src/Agent/CLI/Auth.hs
+++ b/packages/agent-cli/src/Agent/CLI/Auth.hs
@@ -1145,6 +1145,7 @@ reloadableFileCredentialProvider
     -> IO TokenProvider
 reloadableFileCredentialProvider expectedProvider billing initial reload = do
     cache <- newIORef (Just initial)
+    cacheLock <- newMVar ()
     let loadFresh rejectedToken =
             reload >>= \case
                 Nothing ->
@@ -1163,19 +1164,42 @@ reloadableFileCredentialProvider expectedProvider billing initial reload = do
                     | otherwise -> do
                         writeIORef cache (Just credential)
                         pure (Right credential)
+        isExplicitReloadRequest rejected =
+            -- /reload-auth uses this otherwise-invalid credential as an
+            -- explicit cache invalidation request.
+            rejected.provider == expectedProvider
+                && Text.null rejected.accessToken
+                && Text.null rejected.accountId
+                && rejected.leaseId == Nothing
+        rejectsCachedCredential rejected credential =
+            rejected.provider == credential.provider
+                && rejected.accessToken == credential.accessToken
     pure $ tokenProvider billing \failed -> case failed of
-            Just FailedCredential { failure = AccountRateLimited { retryAfterSeconds } } -> do
-                now <- getCurrentTime
-                let seconds = max 1 (fromMaybe 60 retryAfterSeconds)
-                pure $ Left $ CredentialsExhausted
-                    (addUTCTime (fromIntegral seconds) now)
-            Just FailedCredential
-                { credential = rejected
-                , failure = AccountAuthenticationRejected
-                } -> do
-                writeIORef cache Nothing
-                loadFresh (Just rejected.accessToken)
-            Nothing ->
+        Just FailedCredential { failure = AccountRateLimited { retryAfterSeconds } } -> do
+            now <- getCurrentTime
+            let seconds = max 1 (fromMaybe 60 retryAfterSeconds)
+            pure $ Left $ CredentialsExhausted
+                (addUTCTime (fromIntegral seconds) now)
+        Just FailedCredential
+            { credential = rejected
+            , failure = AccountAuthenticationRejected
+            } ->
+            withMVar cacheLock \_ -> do
+                current <- readIORef cache
+                let forceReload = isExplicitReloadRequest rejected
+                case current of
+                    Just credential
+                        | not forceReload
+                        , not (rejectsCachedCredential rejected credential) ->
+                            pure (Right credential)
+                    _ -> do
+                        writeIORef cache Nothing
+                        loadFresh
+                            (if forceReload
+                                then Nothing
+                                else Just rejected.accessToken)
+        Nothing ->
+            withMVar cacheLock \_ ->
                 readIORef cache >>= \case
                     Just credential -> pure (Right credential)
                     Nothing -> loadFresh Nothing

--- a/packages/agent-cli/test/Agent/CLI/AuthSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/AuthSpec.hs
@@ -18,6 +18,8 @@ import Agent.Provider
     , tokenProviderBillingMode
     )
 import qualified Agent.XAI.Auth as XAIAuth
+import Control.Concurrent (threadDelay)
+import Control.Concurrent.Async (mapConcurrently)
 import Control.Exception.Safe (bracket)
 import Data.Aeson ((.=))
 import qualified Data.Aeson as Aeson
@@ -461,6 +463,51 @@ spec = do
             reloaded `shouldBe` Right freshGrok
             getNextToken provider Nothing `shouldReturn` Right freshGrok
             readIORef loads `shouldReturn` 1
+
+        it "does not reload for a delayed rejection of the replaced credential" do
+            loads <- newIORef (0 :: Int)
+            provider <- reloadableFileCredentialProvider
+                XAIProvider SubscriptionBilled staleGrok
+                (modifyIORef' loads (+ 1) >> pure (Just freshGrok))
+            let rejected = Just FailedCredential
+                    { credential = staleGrok
+                    , failure = AccountAuthenticationRejected
+                    }
+            getNextToken provider rejected `shouldReturn` Right freshGrok
+            getNextToken provider rejected `shouldReturn` Right freshGrok
+            readIORef loads `shouldReturn` 1
+
+        it "reloads a concurrently rejected credential only once" do
+            loads <- newIORef (0 :: Int)
+            provider <- reloadableFileCredentialProvider
+                XAIProvider SubscriptionBilled staleGrok do
+                atomicModifyIORef' loads \count -> (count + 1, ())
+                threadDelay 50000
+                pure (Just freshGrok)
+            let rejected = Just FailedCredential
+                    { credential = staleGrok
+                    , failure = AccountAuthenticationRejected
+                    }
+            results <- mapConcurrently
+                (const (getNextToken provider rejected))
+                ([1 .. 16] :: [Int])
+            results `shouldBe` replicate 16 (Right freshGrok)
+            readIORef loads `shouldReturn` 1
+
+        it "honors the explicit reload request sentinel" do
+            provider <- reloadableFileCredentialProvider
+                XAIProvider SubscriptionBilled staleGrok
+                (pure (Just freshGrok))
+            getNextToken provider (Just FailedCredential
+                { credential = Credential
+                    { accessToken = ""
+                    , accountId = ""
+                    , leaseId = Nothing
+                    , provider = XAIProvider
+                    }
+                , failure = AccountAuthenticationRejected
+                })
+                `shouldReturn` Right freshGrok
 
         it "rejects an unchanged reload after authentication failure" do
             provider <- reloadableFileCredentialProvider


### PR DESCRIPTION
## Summary

- serialize reloadable file-credential cache reads and refreshes
- reuse an already-rotated credential when a delayed rejection arrives for the old token
- preserve `/reload-auth` as an explicit forced reload

This is a focused replacement for the auth-cache portion of the earlier broad concurrency PR. It intentionally excludes unrelated OpenAI pool, process, ResourceT, TUI, and subagent lifecycle changes.

## Why

Concurrent requests can reject the same cached xAI/OpenRouter credential at nearly the same time. Previously each rejection cleared the cache and re-read the credential source. A delayed rejection could also discard a credential another request had already refreshed.

## Tests

```sh
nix develop -c env -u GHCRTS cabal test agent-cli:agent-cli-test \
  --test-options='--match=reloadableFileCredentialProvider' \
  --test-show-details=direct
```

6 examples, 0 failures.
