### PR TITLE
fix(subagents): release prepared leases on cancelled startup

### DIFF
--- a/packages/agent-core/src/Agent/Subagents/Registry.hs
+++ b/packages/agent-core/src/Agent/Subagents/Registry.hs
@@ -536,22 +536,33 @@ spawnSubagentAtWithIdPreparedForTurn
                         rollbackAdmission registry record
                         pure $ Left $
                             "Failed to prepare subagent: " <> Text.pack (show exc)
-                    Right lease ->
-                        startPrepared restore record lease)
+                    Right lease -> do
+                        leaseSettled <- newTVarIO False
+                        startPrepared restore record lease leaseSettled)
                 `onException` rollbackAdmission registry record
   where
-    startPrepared restore record lease = do
+    startPrepared restore record lease leaseSettled = do
         started <-
             restore
                 (withMVar registry.registryLifecycle \_ ->
-                    startRecordSupervisor registry record lease)
-                `onException` shutdownRecord registry record
+                    startRecordSupervisorWithHandoff
+                        registry record lease
+                        (writeTVar leaseSettled True))
+                `onException`
+                    (shutdownRecord registry record
+                        `finally` releaseIfUnsettled leaseSettled lease)
         case started of
             Left err -> do
                 rollbackAdmission registry record
                 pure (Left err)
             Right () ->
                 pure (Right (agentId, record.recordTaskPath))
+
+    releaseIfUnsettled leaseSettled lease = do
+        settled <- atomically (readTVar leaseSettled)
+        if settled
+            then pure ()
+            else releaseSubagentLease lease
 
 resolveParentSTM
     :: Map SubagentId SubagentRecord
@@ -729,6 +740,15 @@ startRecordSupervisor
     -> SubagentLease
     -> IO (Either Text ())
 startRecordSupervisor registry record lease =
+    startRecordSupervisorWithHandoff registry record lease (pure ())
+
+startRecordSupervisorWithHandoff
+    :: SubagentRegistry
+    -> SubagentRecord
+    -> SubagentLease
+    -> STM ()
+    -> IO (Either Text ())
+startRecordSupervisorWithHandoff registry record lease settleLease =
     mask \restore -> do
         canStart <- atomically do
             closed <- readTVar registry.registryClosed
@@ -747,6 +767,7 @@ startRecordSupervisor registry record lease =
                     && maybe True (const False) current
         if not canStart
             then do
+                atomically settleLease
                 releaseSubagentLease lease
                 pure (Left "Subagent closed before its supervisor started.")
             else do
@@ -755,10 +776,13 @@ startRecordSupervisor registry record lease =
                     supervisorAction ready
                 case started of
                     Left (exception :: SomeException) -> do
+                        atomically settleLease
                         releaseSubagentLease lease
                         pure (Left ("Failed to start subagent: " <> Text.pack (show exception)))
                     Right supervisor -> do
-                        atomically $ writeTVar record.recordAsync (Just supervisor)
+                        atomically do
+                            writeTVar record.recordAsync (Just supervisor)
+                            settleLease
                         ownership <- restore (atomically (takeTMVar ready))
                             `onException` stopRecordSupervisor record
                         case ownership of

--- a/packages/agent-core/test/Agent/SubagentsSpec.hs
+++ b/packages/agent-core/test/Agent/SubagentsSpec.hs
@@ -15,14 +15,15 @@ import Control.Concurrent (threadDelay)
 import qualified Control.Concurrent.Async as Async
 import Control.Concurrent.MVar
 import Control.Concurrent.STM
-import Control.Exception.Safe (finally)
+import Control.Exception.Safe (finally, uninterruptibleMask_)
 import Control.Monad (unless)
 import Data.IORef
-import Data.Maybe (fromMaybe)
+import Data.Maybe (fromMaybe, isNothing)
 import qualified Data.Map.Strict as Map
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Read as TextRead
+import GHC.Conc (BlockReason(..), ThreadStatus(..), threadStatus)
 import System.Timeout (timeout)
 import Test.Hspec
 
@@ -129,6 +130,32 @@ spec = describe "Agent.Subagents" do
         readIORef releases `shouldReturn` 1
         readIORef ran `shouldReturn` False
 
+    it "does not retry a prepared lease release that throws" do
+        entered <- newEmptyMVar
+        release <- newEmptyMVar
+        releases <- newIORef (0 :: Int)
+        ran <- newIORef False
+        registry <- shutdownRaceRegistry ran
+        spawning <- Async.async $
+            spawnSubagentWithCwdPrepared registry (fromFilePath "/tmp")
+                (\_ -> do
+                    putMVar entered ()
+                    takeMVar release
+                    pure $ subagentLease do
+                        atomicModifyIORef' releases \n -> (n + 1, ())
+                        fail "cleanup failed")
+                Nothing 0 "task" Nothing
+        takeMVar entered
+        closeSubagentRegistry registry
+        putMVar release ()
+        Async.waitCatch spawning >>= \case
+            Left _ -> pure ()
+            Right result ->
+                expectationFailure
+                    ("expected cleanup failure, got " <> show result)
+        readIORef releases `shouldReturn` 1
+        readIORef ran `shouldReturn` False
+
     it "rolls back prepared admission when spawning is cancelled" do
         entered <- newEmptyMVar
         release <- newEmptyMVar
@@ -142,6 +169,44 @@ spec = describe "Agent.Subagents" do
         Async.cancel spawning
         _ <- Async.waitCatch spawning
         Right _ <- spawnSubagent registry Nothing 0 "next" Nothing
+        closeSubagentRegistry registry
+
+    it "releases a prepared lease when cancellation wins before supervisor ownership" do
+        preparationEntered <- newEmptyMVar
+        finishPreparation <- newEmptyMVar
+        firstCleanupStarted <- newEmptyMVar
+        finishFirstCleanup <- newEmptyMVar
+        leaseReleases <- newIORef (0 :: Int)
+        registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
+            (\_ _ prompt _ -> pure (completedResult (messagePayload prompt)))
+            (\_ _ -> pure ())
+        Right first <- spawnSubagentWithCwdPrepared registry (fromFilePath "/tmp")
+            (\_ -> pure $ subagentLease $
+                uninterruptibleMask_ $
+                    putMVar firstCleanupStarted () >> takeMVar finishFirstCleanup)
+            Nothing 0 "first" Nothing
+
+        Async.withAsync
+            (spawnSubagentWithCwdPrepared registry (fromFilePath "/tmp")
+                (\_ -> do
+                    putMVar preparationEntered ()
+                    takeMVar finishPreparation
+                    pure $ subagentLease $
+                        atomicModifyIORef' leaseReleases \n -> (n + 1, ()))
+                Nothing 0 "cancelled-after-preparation" Nothing)
+            \spawning -> do
+                takeMVar preparationEntered
+                Async.withAsync (closeSubagent registry first) \closing -> do
+                    takeMVar firstCleanupStarted
+                    closingStatus <- Async.poll closing
+                    closingStatus `shouldSatisfy` isNothing
+                    putMVar finishPreparation ()
+                    waitForMVarBlock "spawn" spawning
+                    Async.cancel spawning
+                    _ <- Async.waitCatch spawning
+                    putMVar finishFirstCleanup ()
+                    _ <- Async.wait closing
+                    readIORef leaseReleases `shouldReturn` 1
         closeSubagentRegistry registry
 
     it "releases pending capacity exactly once when an agent closes during preparation" do
@@ -996,6 +1061,19 @@ shutdownRaceRegistry ran =
 blockPreparation :: MVar () -> MVar () -> SubagentId -> IO SubagentLease
 blockPreparation entered release _ =
     putMVar entered () >> takeMVar release >> pure mempty
+
+waitForMVarBlock :: String -> Async.Async a -> IO ()
+waitForMVarBlock label running = go (1000 :: Int)
+  where
+    go 0 = expectationFailure (label <> " thread did not block on an MVar")
+    go attempts =
+        threadStatus (Async.asyncThreadId running) >>= \case
+            ThreadBlocked BlockedOnMVar -> pure ()
+            ThreadFinished ->
+                expectationFailure (label <> " thread finished before cancellation")
+            ThreadDied ->
+                expectationFailure (label <> " thread died before cancellation")
+            _ -> threadDelay 1000 >> go (attempts - 1)
 
 spawnPreparedAt
     :: SubagentRegistry


### PR DESCRIPTION
## Summary

- close the cancellation gap after subagent preparation but before supervisor ownership
- atomically settle lease ownership with supervisor publication or failure-path cleanup
- release a prepared lease exactly once when cancellation wins before that handoff

This is a focused replacement for one ownership bug from the earlier broad concurrency PR. It intentionally omits the unrelated supervisor-handle state-machine change because that change did not have a dedicated regression.

## Why

A prepared subagent can acquire resources and then block waiting for the registry lifecycle lock. If that spawning thread is cancelled before the supervisor takes ownership, the admission record is rolled back but the prepared lease was previously leaked.

The fix uses one settlement bit. It flips in the same transaction that publishes the supervisor handle, or immediately before a failure path begins cleanup. Rollback can therefore distinguish “still mine to release” from “already transferred or released” without detached workers, uninterruptible waits, or duplicate finalization.

## Tests

```sh
nix develop -c env -u GHCRTS cabal test agent-core:agent-core-test \
  --test-options='--match=Agent.Subagents' \
  --test-show-details=direct
```

47 examples, 0 failures. Coverage includes cancellation before supervisor ownership and a release action that mutates state before throwing, proving cleanup is not retried.
