### PR TITLE
Persist the last model used per project

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -124,7 +124,10 @@ import Agent.CLI.Progress
 import Agent.CLI.Project
     ( ProjectSettings(..)
     , loadProjectSettings
+    , projectModelFor
+    , projectModelProvider
     , resolveProjectRoot
+    , saveProjectModel
     )
 import Agent.CLI.Prompt (defaultModelFor, systemPrompt)
 import Agent.CLI.Request (requestParams)
@@ -846,7 +849,12 @@ runAgentInitialized options transition home root resumed cwd startup = do
             Just target -> Just target.modelProvider
             Nothing -> case resumed of
                 Just (meta, _) -> Just meta.metaProvider
-                Nothing -> options.optProvider
+                Nothing -> case options.optProvider of
+                    Just requested -> Just requested
+                    Nothing
+                        | isNothing options.optModel ->
+                            projectModelProvider projectSettings
+                        | otherwise -> Nothing
     loaded <-
         loadAuth requestedProvider
             >>= either (startupDie startup . Text.unpack) pure
@@ -874,13 +882,22 @@ runAgentInitialized options transition home root resumed cwd startup = do
             (case transitionTarget of
                 Just target -> target.modelId
                 Nothing ->
-                    maybe (defaultModelFor provider) (.metaModel) (fst <$> resumed))
+                    case fst <$> resumed of
+                        Just meta -> meta.metaModel
+                        Nothing ->
+                            fromMaybe
+                                (defaultModelFor provider)
+                                (projectModelFor provider projectSettings))
             options.optModel
         effort = fromMaybe
             (maybe (defaultEffortFor provider) (.metaEffort) (fst <$> resumed))
             options.optEffort
         policy = resolveApprovalPolicy options isTty
             projectSettings.settingsAutoApprove
+    -- Provider transitions commit their selection separately: manual switches
+    -- immediately, automatic fallbacks only after the replacement succeeds.
+    when (isNothing transition) $
+        saveProjectModel projectRoot provider model
     sessionProcessManager <- newSessionProcessManager root
     managedAgentSession <- (== Just "1") <$> lookupEnv "HASKELL_AGENT_MANAGED_SESSION"
     activeSessionLock <- newIORef (Nothing :: Maybe FilePath)
@@ -1103,7 +1120,8 @@ runAgentInitialized options transition home root resumed cwd startup = do
                                                     transcriptRef)
                                                 focus
                                 activeBackend <-
-                                    prepareTransitionBackend transition persist noticingBackend
+                                    prepareTransitionBackend
+                                        projectRoot transition persist noticingBackend
                                 runSession options provider policy tools toolEnv planMode startup prompt pendingTurn transitionDraft unavailableProviders paramsRef transcriptRef initialTurns
                                     previousRef persist projectRoot home cwd (Just loaded.loadedTokenProvider) loaded.loadedOpenAiPool startupContext skillsRef skillInvocationsRef escPaused interrupt
                                     multiCtx rootTurnRef subagentSessions pendingNotices subagentStoreRoot usageRef claimCurrentSession compactRunner activeBackend btwBackend)
@@ -1149,7 +1167,8 @@ runAgentInitialized options transition home root resumed cwd startup = do
                                         paramsRef
                                         transcriptRef
                         activeBackend <-
-                            prepareTransitionBackend transition persist backend
+                            prepareTransitionBackend
+                                projectRoot transition persist backend
                         runSession options provider policy tools toolEnv planMode startup prompt pendingTurn transitionDraft unavailableProviders paramsRef transcriptRef initialTurns
                             previousRef persist projectRoot home cwd (Just loaded.loadedTokenProvider) loaded.loadedOpenAiPool startupContext skillsRef skillInvocationsRef escPaused interrupt
                             multiCtx rootTurnRef subagentSessions pendingNotices subagentStoreRoot usageRef claimCurrentSession compactRunner activeBackend btwBackend
@@ -1183,7 +1202,8 @@ runAgentInitialized options transition home root resumed cwd startup = do
                                         paramsRef
                                         transcriptRef
                         activeBackend <-
-                            prepareTransitionBackend transition persist backend
+                            prepareTransitionBackend
+                                projectRoot transition persist backend
                         runSession options provider policy tools toolEnv planMode startup prompt pendingTurn transitionDraft unavailableProviders paramsRef transcriptRef initialTurns
                             previousRef persist projectRoot home cwd (Just loaded.loadedTokenProvider) loaded.loadedOpenAiPool startupContext skillsRef skillInvocationsRef escPaused interrupt
                             multiCtx rootTurnRef subagentSessions pendingNotices subagentStoreRoot usageRef claimCurrentSession compactRunner activeBackend btwBackend
@@ -2333,7 +2353,7 @@ replWithDraft env@SessionEnv
                     ReplSetModel name -> do
                         color <- resolveColor stdout
                         message <- applyModelChange
-                            provider name paramsRef render previous persist
+                            projectRoot provider name paramsRef render previous persist
                         displayInfo message $
                             Text.putStrLn
                                 (roleMuted color (glyphOk <> message))
@@ -2777,7 +2797,7 @@ replWithDraft env@SessionEnv
                     next
                 | choice.modelProvider == provider -> do
                     message <- applyModelChange
-                        provider choice.modelId paramsRef render previous persist
+                        projectRoot provider choice.modelId paramsRef render previous persist
                     displayInfo message $
                         Text.putStrLn
                             (roleMuted color
@@ -3021,16 +3041,18 @@ fetchSnapshot snapshot = do
         , usageResult = result
         }
 applyModelChange
-    :: Provider
+    :: OsPath
+    -> Provider
     -> Text
     -> IORef ResponseCreateParams
     -> RenderConfig
     -> IORef (Maybe Text)
     -> Persistence
     -> IO Text
-applyModelChange provider name paramsRef render previous persist = do
+applyModelChange projectRoot provider name paramsRef render previous persist = do
     modifyIORef' paramsRef (setModel name)
     writeIORef render.renderModelRef name
+    saveProjectModel projectRoot provider name
     clearedChain <- case provider of
         OpenAIProvider ->
             atomicModifyIORef' previous \prev ->
@@ -3208,51 +3230,63 @@ ensureTransitionSessionId (PersistenceEnabled slotRef) = do
     pure (Just handle.sessionMeta.metaId)
 
 commitProviderTransition
-    :: Maybe ProviderTransition
+    :: OsPath
+    -> Maybe ProviderTransition
     -> Persistence
     -> IO ()
-commitProviderTransition Nothing _ = pure ()
-commitProviderTransition _ PersistenceDisabled = pure ()
-commitProviderTransition (Just transition) (PersistenceEnabled slotRef) = do
-    slot <- readIORef slotRef
-    case slot of
-        PersistencePending pending ->
-            writeIORef slotRef $ PersistencePending pending
-                { createProvider = transition.transitionTarget.modelProvider
-                , createModel = transition.transitionTarget.modelId
-                }
-        PersistenceActive handle -> do
-            now <- getCurrentTime
-            let meta = handle.sessionMeta
-                    { metaProvider = transition.transitionTarget.modelProvider
-                    , metaModel = transition.transitionTarget.modelId
-                    , metaLastResponseId = Nothing
-                    , metaUpdatedAt = now
-                    }
-            writeSessionMeta handle.sessionMetaPath meta
-            writeIORef slotRef (PersistenceActive handle { sessionMeta = meta })
+commitProviderTransition _ Nothing _ = pure ()
+commitProviderTransition projectRoot (Just transition) persist = do
+    saveProjectModel
+        projectRoot
+        transition.transitionTarget.modelProvider
+        transition.transitionTarget.modelId
+    case persist of
+        PersistenceDisabled -> pure ()
+        PersistenceEnabled slotRef -> do
+            slot <- readIORef slotRef
+            case slot of
+                PersistencePending pending ->
+                    writeIORef slotRef $ PersistencePending pending
+                        { createProvider = transition.transitionTarget.modelProvider
+                        , createModel = transition.transitionTarget.modelId
+                        }
+                PersistenceActive handle -> do
+                    now <- getCurrentTime
+                    let meta = handle.sessionMeta
+                            { metaProvider = transition.transitionTarget.modelProvider
+                            , metaModel = transition.transitionTarget.modelId
+                            , metaLastResponseId = Nothing
+                            , metaUpdatedAt = now
+                            }
+                    writeSessionMeta handle.sessionMetaPath meta
+                    writeIORef slotRef
+                        (PersistenceActive handle { sessionMeta = meta })
 
 prepareTransitionBackend
-    :: Maybe ProviderTransition
+    :: OsPath
+    -> Maybe ProviderTransition
     -> Persistence
     -> Backend
     -> IO Backend
-prepareTransitionBackend Nothing _ backend = pure backend
-prepareTransitionBackend (Just transition) persist backend
+prepareTransitionBackend _ Nothing _ backend = pure backend
+prepareTransitionBackend projectRoot (Just transition) persist backend
     | transition.transitionCause == ManualTransition = do
-        commitProviderTransition (Just transition) persist
+        commitProviderTransition projectRoot (Just transition) persist
         pure backend
     | otherwise = do
         committed <- newIORef False
-        pure $ commitBackendOnSuccess committed transition persist backend
+        pure $
+            commitBackendOnSuccess
+                projectRoot committed transition persist backend
 
 commitBackendOnSuccess
-    :: IORef Bool
+    :: OsPath
+    -> IORef Bool
     -> ProviderTransition
     -> Persistence
     -> Backend
     -> Backend
-commitBackendOnSuccess committed transition persist (Backend submit) =
+commitBackendOnSuccess projectRoot committed transition persist (Backend submit) =
     Backend \previous inputs onEvent -> do
         result <- submit previous inputs onEvent
         case result of
@@ -3260,7 +3294,7 @@ commitBackendOnSuccess committed transition persist (Backend submit) =
                 shouldCommit <- atomicModifyIORef' committed \done ->
                     (True, not done)
                 when shouldCommit $
-                    commitProviderTransition (Just transition) persist
+                    commitProviderTransition projectRoot (Just transition) persist
             Left _ -> pure ()
         pure result
 

--- a/packages/agent-cli/src/Agent/CLI/Options.hs
+++ b/packages/agent-cli/src/Agent/CLI/Options.hs
@@ -259,7 +259,7 @@ usage = unlines
     , "  -p, --prompt TEXT       Run one prompt and exit"
     , "      --prompt-file FILE  Read the one-shot prompt from a file"
     , "      --provider NAME     openai, xai, or openrouter (default: detect from auth)"
-    , "      --model NAME        Override the provider default model"
+    , "      --model NAME        Override the project's saved/default model"
     , "      --cwd DIR           Working directory for tools (default: current)"
     , "      --worktree          Create a new git worktree under ~/.haskell-agent/worktrees"
     , "      --resume ID         Resume a persisted session from ~/.haskell-agent/sessions"

--- a/packages/agent-cli/src/Agent/CLI/Project.hs
+++ b/packages/agent-cli/src/Agent/CLI/Project.hs
@@ -1,22 +1,38 @@
 -- | Project-scoped settings under @<project>/.haskell-agent/settings.json@.
 module Agent.CLI.Project
-    ( ProjectSettings(..)
+    ( ProjectModel(..)
+    , ProjectSettings(..)
     , defaultProjectSettings
     , loadProjectSettings
+    , projectModelFor
+    , projectModelProvider
     , projectSettingsPath
     , resolveProjectRoot
     , saveProjectAutoApprove
+    , saveProjectModel
     ) where
 
 import Agent.FileRetry (retryOnFileBusy, writeLazyFileAtomically)
 import Agent.OsPath (unsafeToFilePath)
-import Control.Exception (try)
-import Data.Aeson (FromJSON(..), ToJSON(..), object, withObject, (.:?), (.=))
+import Agent.Provider (Provider, parseProvider, providerSlug)
+import Control.Exception.Safe (tryIO)
+import Data.Aeson
+    ( FromJSON(..)
+    , ToJSON(..)
+    , object
+    , withObject
+    , (.:)
+    , (.:?)
+    , (.=)
+    )
 import qualified Data.Aeson as Aeson
+import Data.Aeson.Types (parseMaybe)
 import qualified Data.ByteString.Lazy as LBS
 import Data.Char (isSpace)
 import Data.List (dropWhileEnd)
 import Data.Maybe (fromMaybe)
+import Data.Text (Text)
+import qualified Data.Text as Text
 import System.Directory.OsPath
     ( canonicalizePath
     , createDirectoryIfMissing
@@ -37,30 +53,63 @@ projectSettingsPath projectRoot =
         </> unsafeEncodeUtf ".haskell-agent"
         </> unsafeEncodeUtf "settings.json"
 
+data ProjectModel = ProjectModel
+    { projectModelProvider :: !Provider
+    , projectModelName :: !Text
+    } deriving (Eq, Show)
+
 data ProjectSettings = ProjectSettings
     { settingsVersion :: !Int
     , settingsAutoApprove :: !Bool
+    , settingsLastModel :: !(Maybe ProjectModel)
     } deriving (Eq, Show)
 
 defaultProjectSettings :: ProjectSettings
 defaultProjectSettings = ProjectSettings
     { settingsVersion = settingsSchemaVersion
     , settingsAutoApprove = False
+    , settingsLastModel = Nothing
     }
+
+instance ToJSON ProjectModel where
+    toJSON model = object
+        [ "provider" .= providerSlug model.projectModelProvider
+        , "model" .= model.projectModelName
+        ]
+
+instance FromJSON ProjectModel where
+    parseJSON = withObject "ProjectModel" \o -> do
+        providerText <- o .: "provider"
+        provider <- case parseProvider providerText of
+            Just parsed -> pure parsed
+            Nothing -> fail ("unknown provider: " <> Text.unpack providerText)
+        model <- o .: "model"
+        if Text.null (Text.strip model)
+            then fail "model must not be empty"
+            else pure ProjectModel
+                { projectModelProvider = provider
+                , projectModelName = model
+                }
 
 instance ToJSON ProjectSettings where
     toJSON settings = object
         [ "version" .= settings.settingsVersion
         , "autoApprove" .= settings.settingsAutoApprove
+        , "lastModel" .= settings.settingsLastModel
         ]
 
 instance FromJSON ProjectSettings where
     parseJSON = withObject "ProjectSettings" \o -> do
         version <- fromMaybe settingsSchemaVersion <$> o .:? "version"
         autoApprove <- fromMaybe False <$> o .:? "autoApprove"
+        lastModelValue <- o .:? "lastModel"
         pure ProjectSettings
             { settingsVersion = version
             , settingsAutoApprove = autoApprove
+            -- A malformed or obsolete model selection should not discard
+            -- unrelated project settings such as auto-approve.
+            , settingsLastModel =
+                lastModelValue >>= parseMaybe parseJSON
             }
 
 -- | Settings root for the checkout that contains @cwd@.
@@ -82,7 +131,7 @@ loadProjectSettings projectRoot = do
     if not exists
         then pure defaultProjectSettings
         else do
-            result <- try @IOError (retryOnFileBusy (LBS.readFile (unsafeToFilePath path)))
+            result <- tryIO (retryOnFileBusy (LBS.readFile (unsafeToFilePath path)))
             pure $ case result of
                 Left _ -> defaultProjectSettings
                 Right bytes ->
@@ -92,17 +141,48 @@ loadProjectSettings projectRoot = do
 
 -- | Persist the project-wide auto-approve flag, creating @.haskell-agent@ as needed.
 saveProjectAutoApprove :: OsPath -> Bool -> IO ()
-saveProjectAutoApprove projectRoot autoApprove = do
+saveProjectAutoApprove projectRoot autoApprove =
+    updateProjectSettings projectRoot \settings ->
+        settings { settingsAutoApprove = autoApprove }
+
+-- | Remember the most recently selected provider/model pair for this project.
+saveProjectModel :: OsPath -> Provider -> Text -> IO ()
+saveProjectModel projectRoot provider model =
+    updateProjectSettings projectRoot \settings ->
+        settings
+            { settingsLastModel = Just ProjectModel
+                { projectModelProvider = provider
+                , projectModelName = model
+                }
+            }
+
+projectModelProvider :: ProjectSettings -> Maybe Provider
+projectModelProvider settings =
+    (.projectModelProvider) <$> settings.settingsLastModel
+
+-- | Return the remembered model only when it belongs to the active provider.
+projectModelFor :: Provider -> ProjectSettings -> Maybe Text
+projectModelFor provider settings = do
+    remembered <- settings.settingsLastModel
+    if remembered.projectModelProvider == provider
+        then Just remembered.projectModelName
+        else Nothing
+
+updateProjectSettings
+    :: OsPath
+    -> (ProjectSettings -> ProjectSettings)
+    -> IO ()
+updateProjectSettings projectRoot update = do
     let dir = projectRoot </> unsafeEncodeUtf ".haskell-agent"
         path = projectSettingsPath projectRoot
-        settings = defaultProjectSettings { settingsAutoApprove = autoApprove }
+    settings <- update <$> loadProjectSettings projectRoot
     createDirectoryIfMissing True dir
-    _ <- try @IOError (setFileMode (unsafeToFilePath dir) 0o700)
+    _ <- tryIO (setFileMode (unsafeToFilePath dir) 0o700)
     writeLazyFileAtomically path 0o600 (Aeson.encode settings)
 
 gitToplevel :: OsPath -> IO (Maybe OsPath)
 gitToplevel dir = do
-    result <- try @IOError $
+    result <- tryIO $
         readCreateProcessWithExitCode
             (proc "git" ["rev-parse", "--show-toplevel"])
                 { cwd = Just (unsafeToFilePath dir) }

--- a/packages/agent-cli/test/Agent/CLI/ProjectSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ProjectSpec.hs
@@ -1,6 +1,7 @@
 module Agent.CLI.ProjectSpec (spec) where
 
 import Agent.CLI.Project
+import Agent.Provider (Provider(..))
 import System.OsPath (OsPath, decodeUtf, unsafeEncodeUtf)
 import Control.Exception (bracket)
 import qualified Data.Aeson as Aeson
@@ -51,6 +52,68 @@ spec = describe "Agent.CLI.Project" do
                 saveProjectAutoApprove root False
                 settings' <- loadProjectSettings root
                 settings'.settingsAutoApprove `shouldBe` False
+
+        it "round-trips the last provider/model and preserves other settings" $
+            withTempDir "agent-project-" \root -> do
+                saveProjectAutoApprove root True
+                saveProjectModel root OpenAIProvider "gpt-project"
+
+                let path = projectSettingsPath root
+                modeOf path `shouldReturn` 0o600
+                settings <- loadProjectSettings root
+                settings.settingsAutoApprove `shouldBe` True
+                settings.settingsLastModel `shouldBe` Just ProjectModel
+                    { projectModelProvider = OpenAIProvider
+                    , projectModelName = "gpt-project"
+                    }
+                projectModelProvider settings `shouldBe` Just OpenAIProvider
+                projectModelFor OpenAIProvider settings
+                    `shouldBe` Just "gpt-project"
+                projectModelFor XAIProvider settings `shouldBe` Nothing
+
+                saveProjectAutoApprove root False
+                updated <- loadProjectSettings root
+                updated.settingsAutoApprove `shouldBe` False
+                projectModelFor OpenAIProvider updated
+                    `shouldBe` Just "gpt-project"
+
+        it "replaces the remembered provider/model without resetting approval" $
+            withTempDir "agent-project-" \root -> do
+                saveProjectAutoApprove root True
+                saveProjectModel root OpenAIProvider "gpt-old"
+                saveProjectModel root XAIProvider "grok-new"
+
+                settings <- loadProjectSettings root
+                settings.settingsAutoApprove `shouldBe` True
+                projectModelProvider settings `shouldBe` Just XAIProvider
+                projectModelFor XAIProvider settings `shouldBe` Just "grok-new"
+                projectModelFor OpenAIProvider settings `shouldBe` Nothing
+
+        it "loads legacy settings without a remembered model" $
+            withTempDir "agent-project-" \root -> do
+                let dir = root </> fromFilePath ".haskell-agent"
+                    path = projectSettingsPath root
+                createDirectoryIfMissing True dir
+                LBS.writeFile
+                    (toFilePath path)
+                    "{\"version\":1,\"autoApprove\":true}"
+
+                settings <- loadProjectSettings root
+                settings.settingsAutoApprove `shouldBe` True
+                settings.settingsLastModel `shouldBe` Nothing
+
+        it "ignores only a malformed remembered model" $
+            withTempDir "agent-project-" \root -> do
+                let dir = root </> fromFilePath ".haskell-agent"
+                    path = projectSettingsPath root
+                createDirectoryIfMissing True dir
+                LBS.writeFile
+                    (toFilePath path)
+                    "{\"version\":1,\"autoApprove\":true,\"lastModel\":{\"provider\":\"retired\",\"model\":\"old\"}}"
+
+                settings <- loadProjectSettings root
+                settings.settingsAutoApprove `shouldBe` True
+                settings.settingsLastModel `shouldBe` Nothing
 
         it "ignores corrupt settings files" $
             withTempDir "agent-project-" \root -> do


### PR DESCRIPTION
## Summary
- persist the last selected provider and model in project settings
- reuse the project model when no explicit model is supplied
- update the saved selection after model changes and successful provider transitions
- preserve existing auto-approve settings and tolerate legacy or malformed model data

## Testing
- `printf ":main\n:q\n" | nix develop -c cabal repl agent-cli-test`
- 537 examples, 0 failures