### PR TITLE
fix(subagents): single-flight session hydration

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -202,6 +202,7 @@ test-suite agent-cli-test
                     , agent-xai
                     , aeson
                     , ansi-terminal
+                    , async
                     , base >= 4.17 && < 5
                     , brick >= 2.9 && < 3
                     , bytestring

--- a/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
@@ -5,6 +5,7 @@ module Agent.CLI.Subagents.Runtime
     , SubagentStoreRoot
     , flushAllSubagentSnapshots
     , freshOpenAiBackend
+    , lookupOrCreateSubagentSession
     , persistSubagentSnapshotWithStatus
     , prepareCollaborationSpawn
     , restoreAgentFromDisk
@@ -104,7 +105,15 @@ import Agent.Tools.Types
     , ToolRegistry
     , defaultToolEnv
     )
+import Control.Concurrent.MVar
+    ( MVar
+    , modifyMVar
+    , modifyMVar_
+    , newMVar
+    , readMVar
+    )
 import Control.Exception.Safe (finally)
+import Control.Monad (unless, when)
 import Data.IORef
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
@@ -115,6 +124,7 @@ import Data.Time.Clock (getCurrentTime, utctDay)
 data SubagentSession = SubagentSession
     { subSessionTranscript :: !(IORef [ResponseItem])
     , subSessionContextTokens :: !(IORef (Maybe (Int, Int)))
+    , subSessionHydrated :: !(MVar Bool)
     }
 
 -- | Optional on-disk root for child transcripts (@sessionDir/agents/<id>@).
@@ -222,9 +232,11 @@ flushAllSubagentSnapshots
 flushAllSubagentSnapshots storeRootRef registry sessionsRef typesRef = do
     sessions <- readIORef sessionsRef
     mapM_
-        (\(agentId, session) ->
-            persistSubagentSnapshot storeRootRef registry typesRef agentId
-                session.subSessionTranscript)
+        (\(agentId, session) -> do
+            hydrated <- readMVar session.subSessionHydrated
+            when hydrated $
+                persistSubagentSnapshot storeRootRef registry typesRef agentId
+                    session.subSessionTranscript)
         (Map.toList sessions)
 
 -- | Rehydrate a closed/missing agent from @sessionDir/agents/<id>@ so
@@ -244,40 +256,42 @@ restoreAgentFromDisk storeRootRef registry sessionsRef typesRef agentId = do
         _ -> pure (Right ())
   where
     restore = do
+        session <- getOrInstallSubagentSession sessionsRef agentId
+        modifyMVar session.subSessionHydrated \hydrated -> do
+            currentStatus <- getStatus registry agentId
+            case currentStatus of
+                NotFound -> restoreLocked session hydrated
+                Closed -> restoreLocked session hydrated
+                _ -> do
+                    hydrated' <-
+                        ensureSubagentSessionHydratedLocked
+                            storeRootRef typesRef agentId session hydrated
+                    pure (hydrated', Right ())
+    restoreLocked session hydrated = do
         mroot <- readIORef storeRootRef
         case mroot of
             Nothing ->
-                pure (Left "no session directory; cannot restore subagent from disk")
+                pure
+                    ( hydrated
+                    , Left "no session directory; cannot restore subagent from disk"
+                    )
             Just sessionDir ->
                 loadSubagentState sessionDir agentId >>= \case
-                    Left err -> pure (Left err)
+                    Left err -> pure (hydrated, Left err)
                     Right Nothing ->
                         -- Same-process close with no disk yet: still reopen.
-                        reopenInMemory Nothing Nothing
+                        reopenInMemory Nothing Nothing >>= \case
+                            Left err -> pure (hydrated, Left err)
+                            Right () -> pure (True, Right ())
                     Right (Just (items, meta)) -> do
                         result <- reopenPersisted meta
                         case result of
-                            Left err -> pure (Left err)
+                            Left err -> pure (hydrated, Left err)
                             Right () -> do
-                                case meta.diskAgentType of
-                                    Just agentType ->
-                                        recordAgentSpec typesRef agentId GrokSubagentSpec
-                                            { agentType
-                                            , modelOverride = meta.diskAgentModel
-                                            , reasoningEffortOverride =
-                                                meta.diskReasoningEffort
-                                            }
-                                    Nothing -> pure ()
-                                transcript <- newIORef items
-                                contextTokens <- newIORef Nothing
-                                let session =
-                                        SubagentSession
-                                            { subSessionTranscript = transcript
-                                            , subSessionContextTokens = contextTokens
-                                            }
-                                atomicModifyIORef' sessionsRef \m ->
-                                    (Map.insert agentId session m, ())
-                                pure (Right ())
+                                recordPersistedAgentSpec typesRef agentId meta
+                                unless hydrated $
+                                    writeIORef session.subSessionTranscript items
+                                pure (True, Right ())
     reopenPersisted meta =
         case meta.diskTaskPath of
             Nothing -> restoreAt taskPathRoot
@@ -572,31 +586,63 @@ lookupOrCreateSubagentSession
     -> SubagentId
     -> IO SubagentSession
 lookupOrCreateSubagentSession sessionsRef storeRootRef typesRef agentId = do
-    sessions <- readIORef sessionsRef
-    case Map.lookup agentId sessions of
-        Just session -> pure session
-        Nothing -> do
-            mroot <- readIORef storeRootRef
-            loaded <- case mroot of
-                Just sessionDir -> loadSubagentState sessionDir agentId
-                Nothing -> pure (Right Nothing)
-            let (items, meta) = case loaded of
-                    Right (Just (xs, m)) -> (xs, Just m)
-                    _ -> ([], Nothing)
-            transcript <- newIORef items
-            contextTokens <- newIORef Nothing
-            case meta >>= (.diskAgentType) of
-                Just agentType ->
-                    recordAgentSpec typesRef agentId GrokSubagentSpec
-                        { agentType
-                        , modelOverride = meta >>= (.diskAgentModel)
-                        , reasoningEffortOverride =
-                            meta >>= (.diskReasoningEffort)
-                        }
-                Nothing -> pure ()
-            let session = SubagentSession
-                    { subSessionTranscript = transcript
-                    , subSessionContextTokens = contextTokens
-                    }
-            atomicModifyIORef' sessionsRef \m -> (Map.insert agentId session m, ())
-            pure session
+    session <- getOrInstallSubagentSession sessionsRef agentId
+    modifyMVar_ session.subSessionHydrated $
+        ensureSubagentSessionHydratedLocked
+            storeRootRef typesRef agentId session
+    pure session
+
+getOrInstallSubagentSession
+    :: IORef (Map SubagentId SubagentSession)
+    -> SubagentId
+    -> IO SubagentSession
+getOrInstallSubagentSession sessionsRef agentId = do
+    transcript <- newIORef []
+    contextTokens <- newIORef Nothing
+    hydrated <- newMVar False
+    let candidate = SubagentSession
+            { subSessionTranscript = transcript
+            , subSessionContextTokens = contextTokens
+            , subSessionHydrated = hydrated
+            }
+    atomicModifyIORef' sessionsRef \sessions ->
+        case Map.lookup agentId sessions of
+            Just existing -> (sessions, existing)
+            Nothing -> (Map.insert agentId candidate sessions, candidate)
+
+ensureSubagentSessionHydratedLocked
+    :: SubagentStoreRoot
+    -> GrokSubagentSpecs
+    -> SubagentId
+    -> SubagentSession
+    -> Bool
+    -> IO Bool
+ensureSubagentSessionHydratedLocked
+        storeRootRef typesRef agentId session hydrated
+    | hydrated = pure True
+    | otherwise = do
+        mroot <- readIORef storeRootRef
+        loaded <- case mroot of
+            Just sessionDir -> loadSubagentState sessionDir agentId
+            Nothing -> pure (Right Nothing)
+        case loaded of
+            Right (Just (items, meta)) -> do
+                writeIORef session.subSessionTranscript items
+                recordPersistedAgentSpec typesRef agentId meta
+            _ -> pure ()
+        pure True
+
+recordPersistedAgentSpec
+    :: GrokSubagentSpecs
+    -> SubagentId
+    -> SubagentDiskMeta
+    -> IO ()
+recordPersistedAgentSpec typesRef agentId meta =
+    case meta.diskAgentType of
+        Just agentType ->
+            recordAgentSpec typesRef agentId GrokSubagentSpec
+                { agentType
+                , modelOverride = meta.diskAgentModel
+                , reasoningEffortOverride = meta.diskReasoningEffort
+                }
+        Nothing -> pure ()

--- a/packages/agent-cli/test/Agent/CLI/SubagentStoreSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SubagentStoreSpec.hs
@@ -1,17 +1,35 @@
 module Agent.CLI.SubagentStoreSpec (spec) where
 
 import Agent.CLI.SubagentStore
+import Agent.CLI.Subagents.Runtime
+    ( SubagentSession(..)
+    , lookupOrCreateSubagentSession
+    , restoreAgentFromDisk
+    )
 import Agent.Responses.Types
 import System.OsPath (OsPath, decodeUtf, unsafeEncodeUtf)
 import Agent.Subagents
     ( SubagentId(..)
     , SubagentIdentity(..)
     , SubagentStatus(..)
+    , closeSubagentRegistry
+    , defaultSubagentConfig
+    , newSubagentRegistry
     )
 import Agent.Subagents.TaskPath (parseTaskPath)
+import Control.Concurrent.Async (mapConcurrently, wait, withAsync)
+import Control.Concurrent.MVar
+    ( newEmptyMVar
+    , putMVar
+    , readMVar
+    , takeMVar
+    )
 import Control.Exception.Safe (bracket)
+import Control.Monad (forM_, replicateM_)
 import qualified Data.Aeson.KeyMap as KeyMap
 import qualified Data.ByteString.Lazy as LBS
+import Data.IORef
+import qualified Data.Map.Strict as Map
 import Data.Text (Text)
 import qualified System.Directory as Directory
 import System.Directory.OsPath (doesFileExist)
@@ -118,6 +136,87 @@ spec = describe "Agent.CLI.SubagentStore" do
             `shouldBe` drop 2 items
         forkSubagentTranscript (Just "18446744073709551617") items
             `shouldBe` items
+
+    it "shares one session across concurrent disk hydration" do
+        withTempDir \dir -> do
+            let agentId = SubagentId "agent-concurrent-hydration"
+                persistedItems =
+                    replicate 20000 (messageItem RoleUser "persisted")
+                workerCount = 16
+            saveSubagentState dir agentId persistedItems Nothing
+                (Completed Nothing) Nothing Nothing Nothing Nothing Nothing
+                `shouldReturn` Right ()
+            sessionsRef <- newIORef Map.empty
+            storeRootRef <- newIORef (Just dir)
+            typesRef <- newIORef Map.empty
+            ready <- newEmptyMVar
+            start <- newEmptyMVar
+            let hydrate _ = do
+                    putMVar ready ()
+                    readMVar start
+                    lookupOrCreateSubagentSession
+                        sessionsRef storeRootRef typesRef agentId
+            withAsync
+                (mapConcurrently hydrate [1 .. workerCount])
+                \workers -> do
+                    replicateM_ workerCount (takeMVar ready)
+                    putMVar start ()
+                    sessions <- wait workers
+                    case sessions of
+                        [] -> expectationFailure "expected hydrated sessions"
+                        first : _ -> do
+                            let marker = [messageItem RoleAssistant "shared"]
+                            writeIORef first.subSessionTranscript marker
+                            forM_ sessions \session ->
+                                readIORef session.subSessionTranscript
+                                    `shouldReturn` marker
+
+    it "keeps the installed session across concurrent registry restores" do
+        withTempDir \dir -> do
+            let agentId = SubagentId "agent-concurrent-restore"
+                persisted = [messageItem RoleUser "persisted"]
+                inMemory = [messageItem RoleAssistant "in-memory"]
+                workerCount = 8
+            saveSubagentState dir agentId persisted Nothing
+                (Completed Nothing) Nothing Nothing Nothing Nothing Nothing
+                `shouldReturn` Right ()
+            sessionsRef <- newIORef Map.empty
+            storeRootRef <- newIORef (Just dir)
+            typesRef <- newIORef Map.empty
+            installed <-
+                lookupOrCreateSubagentSession
+                    sessionsRef storeRootRef typesRef agentId
+            writeIORef installed.subSessionTranscript inMemory
+            bracket
+                (newSubagentRegistry defaultSubagentConfig dir
+                    (\_ _ _ _ -> fail "unexpected subagent runner invocation")
+                    (\_ _ -> pure ()))
+                closeSubagentRegistry
+                \registry -> do
+                    ready <- newEmptyMVar
+                    start <- newEmptyMVar
+                    let restore _ = do
+                            putMVar ready ()
+                            readMVar start
+                            restoreAgentFromDisk
+                                storeRootRef registry sessionsRef typesRef agentId
+                    withAsync
+                        (mapConcurrently restore [1 .. workerCount])
+                        \workers -> do
+                            replicateM_ workerCount (takeMVar ready)
+                            putMVar start ()
+                            wait workers
+                                `shouldReturn` replicate workerCount (Right ())
+                    sessions <- readIORef sessionsRef
+                    case Map.lookup agentId sessions of
+                        Nothing -> expectationFailure "expected restored session"
+                        Just current -> do
+                            readIORef current.subSessionTranscript
+                                `shouldReturn` inMemory
+                            let marker = [messageItem RoleAssistant "same-ref"]
+                            writeIORef current.subSessionTranscript marker
+                            readIORef installed.subSessionTranscript
+                                `shouldReturn` marker
 
 messageItem :: ResponseRole -> Text -> ResponseItem
 messageItem role text = MessageItem ResponseMessage


### PR DESCRIPTION
## Summary

- atomically install one in-memory session object per persisted subagent
- serialize disk hydration and registry restoration through that session
- avoid flushing a published session before its initial hydration completes

This is a focused replacement for the persisted-subagent portion of the earlier broad concurrency PR. It excludes lease ownership, process cleanup, ResourceT, stdin, modal, and provider-auth changes.

## Why

Concurrent callers could each miss the session map, hydrate separate transcripts, and overwrite one another in the map. Concurrent registry restores could likewise replace the installed in-memory transcript with a freshly allocated one.

The session map now chooses one candidate atomically, and a per-session hydration lock makes all callers share its transcript and initialization result.

## Tests

```sh
nix develop -c env -u GHCRTS cabal test agent-cli:agent-cli-test \
  --test-options='--match=Agent.CLI.SubagentStore' \
  --test-show-details=direct
```

7 examples, 0 failures, run after rebasing onto current `master`.
