### PR TITLE
fix(cli): keep automatic fallback within billing mode

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -143,7 +143,8 @@ import Agent.CLI.Project
 import Agent.CLI.Prompt (defaultModelFor, systemPrompt)
 import Agent.CLI.Request (requestParams)
 import Agent.CLI.ProviderFallback
-    ( automaticCooldownRetryDelay
+    ( allowsAutomaticBillingFallback
+    , automaticCooldownRetryDelay
     , fallbackCandidates
     )
 import Agent.CLI.ProviderTransition
@@ -305,12 +306,15 @@ import Agent.OpenAI.WebSocketClient
     )
 import Agent.Provider
     ( AccountFailure(..)
+    , BillingMode
     , Credential(..)
     , FailedCredential(..)
     , Provider(..)
-    , TokenProvider(..)
+    , TokenProvider
     , getNextToken
     , providerSlug
+    , tokenProvider
+    , tokenProviderBillingMode
     )
 import Agent.Subagents
     ( RootTurnId
@@ -1023,6 +1027,16 @@ runAgentInitialized options transition home root resumed cwd startup = do
                     <> " but auth resolved "
                     <> Text.unpack (providerSlug loaded.loadedProvider)
         _ -> pure ()
+    case transition >>= (.transitionAutomaticBilling) of
+        Just sourceBilling
+            | not
+                (allowsAutomaticBillingFallback
+                    sourceBilling
+                    (tokenProviderBillingMode loaded.loadedTokenProvider)) ->
+                startupDie startup
+                    "automatic provider fallback would cross from subscription \
+                    \billing to API-credit billing"
+        _ -> pure ()
     activeAccountRef <- newIORef ""
     let tokenProvider =
             trackCredentialAccount
@@ -1373,7 +1387,7 @@ trackCredentialAccount
     -> TokenProvider
     -> TokenProvider
 trackCredentialAccount accountRef resolveLabel provider =
-    TokenProvider \failed ->
+    tokenProvider (tokenProviderBillingMode provider) \failed ->
         getNextToken provider failed >>= \case
             Left err -> pure (Left err)
             Right credential -> do
@@ -3321,12 +3335,17 @@ requestAutomaticProviderFallback env apiError pending = do
         emitUiEvent runtime UiTurnRestarted
     sessionId <- ensureTransitionSessionId env.sessionPersist
     unavailable <- readIORef env.sessionUnavailableProviders
-    chooseAutomaticProviderTransition env.sessionFullscreen
-        env.sessionProvider
-        unavailable
-        sessionId
-        pending
-        apiError
+    case env.sessionTokenProvider of
+        Nothing -> pure Nothing
+        Just tokenProvider ->
+            chooseAutomaticProviderTransition
+                env.sessionFullscreen
+                (tokenProviderBillingMode tokenProvider)
+                env.sessionProvider
+                unavailable
+                sessionId
+                pending
+                apiError
 
 continueAutomaticFallback
     :: Maybe FullscreenRuntime
@@ -3334,18 +3353,23 @@ continueAutomaticFallback
     -> ApiError
     -> IO (Maybe ProviderTransition)
 continueAutomaticFallback fullscreen failed apiError =
-    case failed.transitionPendingTurn of
-        Nothing -> pure Nothing
-        Just pending ->
-            chooseAutomaticProviderTransition fullscreen
+    case ( failed.transitionAutomaticBilling
+         , failed.transitionPendingTurn
+         ) of
+        (Just billing, Just pending) ->
+            chooseAutomaticProviderTransition
+                fullscreen
+                billing
                 failed.transitionTarget.modelProvider
                 failed.transitionUnavailableProviders
                 failed.transitionSessionId
                 pending
                 apiError
+        _ -> pure Nothing
 
 chooseAutomaticProviderTransition
     :: Maybe FullscreenRuntime
+    -> BillingMode
     -> Provider
     -> [Provider]
     -> Maybe Text
@@ -3353,7 +3377,7 @@ chooseAutomaticProviderTransition
     -> ApiError
     -> IO (Maybe ProviderTransition)
 chooseAutomaticProviderTransition
-    fullscreen current unavailable0 sessionId pending apiError =
+    fullscreen sourceBilling current unavailable0 sessionId pending apiError =
     tryCandidates unavailable candidates
   where
     unavailable = markUnavailable current unavailable0
@@ -3362,7 +3386,7 @@ chooseAutomaticProviderTransition
     tryCandidates unavailable = \case
         [] -> pure Nothing
         choice : rest ->
-            validateProviderTarget choice >>= \case
+            validateAutomaticProviderTarget sourceBilling choice >>= \case
                 Left err -> do
                     let message =
                             "skipping "
@@ -3399,6 +3423,7 @@ chooseAutomaticProviderTransition
                         , transitionDraft = ""
                         , transitionUnavailableProviders = unavailable
                         , transitionCause = AutomaticFallback
+                        , transitionAutomaticBilling = Just sourceBilling
                         }
 
 prepareProviderTransition
@@ -3421,10 +3446,32 @@ prepareProviderTransition cause unavailable pending draft choice persist =
                 , transitionDraft = draft
                 , transitionUnavailableProviders = unavailable
                 , transitionCause = cause
+                , transitionAutomaticBilling = Nothing
                 }
 
 validateProviderTarget :: ModelOption -> IO (Either Text ())
 validateProviderTarget choice =
+    fmap (() <$) (loadValidatedProviderTarget choice)
+
+validateAutomaticProviderTarget
+    :: BillingMode
+    -> ModelOption
+    -> IO (Either Text ())
+validateAutomaticProviderTarget sourceBilling choice =
+    loadValidatedProviderTarget choice >>= \case
+        Left err -> pure (Left err)
+        Right loaded
+            | allowsAutomaticBillingFallback
+                sourceBilling
+                (tokenProviderBillingMode loaded.loadedTokenProvider) ->
+                    pure (Right ())
+            | otherwise ->
+                pure $ Left
+                    "automatic fallback from subscription billing to API \
+                    \credits is disabled"
+
+loadValidatedProviderTarget :: ModelOption -> IO (Either Text LoadedAuth)
+loadValidatedProviderTarget choice =
     loadAuth (Just choice.modelProvider) >>= \case
         Left err -> pure $ Left $
             "cannot switch to "
@@ -3447,7 +3494,7 @@ validateProviderTarget choice =
                                 <> providerSlug choice.modelProvider
                                 <> ": auth resolved "
                                 <> providerSlug usable.loadedProvider
-                    | otherwise -> pure (Right ())
+                    | otherwise -> pure (Right usable)
 
 ensureTransitionSessionId
     :: Persistence

--- a/packages/agent-cli/src/Agent/CLI/Auth.hs
+++ b/packages/agent-cli/src/Agent/CLI/Auth.hs
@@ -34,13 +34,15 @@ import qualified Agent.OpenAI.Credential as OpenAICredential
 import qualified Agent.OpenAI.Login as OpenAILogin
 import Agent.Provider
     ( AccountFailure(..)
+    , BillingMode(..)
     , Credential(..)
     , FailedCredential(..)
     , Provider(..)
-    , TokenProvider(..)
+    , TokenProvider
     , getNextToken
     , providerSlug
     , seedTokenProvider
+    , tokenProvider
     )
 import Agent.OpenRouter.Credential (credentialFromApiKey)
 import Agent.OsPath (unsafeToFilePath)
@@ -235,7 +237,7 @@ loadXai = do
             pure LoadedAuth
                 { loadedProvider = XAIProvider
                 , loadedTokenProvider =
-                    staticCredentialProvider Credential
+                    staticCredentialProvider metadata.managedBilling Credential
                         { accessToken = secret.secretPayload
                         , accountId = metadata.managedAccountId
                         , leaseId = Nothing
@@ -251,7 +253,10 @@ loadXai = do
                 Nothing -> throwE noAuthHint
                 Just loaded -> do
                     provider <- lift $ reloadableFileCredentialProvider
-                        XAIProvider loaded loadExternalGrokCredential
+                        XAIProvider
+                        SubscriptionBilled
+                        loaded
+                        loadExternalGrokCredential
                     pure LoadedAuth
                         { loadedProvider = XAIProvider
                         , loadedTokenProvider = provider
@@ -280,7 +285,9 @@ loadOpenRouter = do
         Nothing -> throwE noAuthHint
         Just (initial, initialLabel) -> do
             provider <- lift $ reloadableFileCredentialProvider
-                OpenRouterProvider initial
+                OpenRouterProvider
+                ApiBilled
+                initial
                 (fmap (fmap fst) loadOpenRouterCredential)
             pure LoadedAuth
                 { loadedProvider = OpenRouterProvider
@@ -309,13 +316,20 @@ loadOpenAi = do
     clientId <-
         lift $
             openAIOAuthClientId <$> lookupNonEmpty "OPENAI_OAUTH_CLIENT_ID"
+    let billing =
+            if any ((== SubscriptionBilled) . (.openAiBilling)) accounts
+                then SubscriptionBilled
+                else ApiBilled
+        activeAccounts =
+            filter ((== billing) . (.openAiBilling)) accounts
     refreshLock <- lift (newMVar ())
-    accountSources <- lift (newIORef accounts)
+    accountSources <- lift (newIORef activeAccounts)
     pool <- lift $ OpenAI.newDiscoveringPool
-        (map (.openAiState) accounts)
+        (map (.openAiState) activeAccounts)
         (refreshOpenAiAccount refreshLock clientId accountSources)
-        (discoverOpenAiAccounts accountSources)
-    tokenProvider <- lift (OpenAICredential.poolTokenProvider pool)
+        (discoverOpenAiAccounts billing accountSources)
+    tokenProvider <- lift
+        (OpenAICredential.poolTokenProviderWithBilling billing pool)
     pure LoadedAuth
         { loadedProvider = OpenAIProvider
         , loadedTokenProvider = tokenProvider
@@ -371,6 +385,7 @@ loadOpenAiAccounts = do
                 { openAiState = state
                 , openAiSource = OpenAiEnvironmentOAuth
                 , openAiLabel = openAiStateLabel "ChatGPT" state
+                , openAiBilling = SubscriptionBilled
                 }
         fileAccount = do
             state <- fileBytes >>= openaiAuthStateFromJson now
@@ -378,6 +393,7 @@ loadOpenAiAccounts = do
                 { openAiState = state
                 , openAiSource = OpenAiAuthFile filePath
                 , openAiLabel = openAiStateLabel "ChatGPT" state
+                , openAiBilling = SubscriptionBilled
                 }
         externalAccounts =
             filter
@@ -389,15 +405,17 @@ loadOpenAiAccounts = do
     pure (storeErrors <> managedErrors, accounts)
 
 discoverOpenAiAccounts
-    :: IORef [OpenAiAccount]
+    :: BillingMode
+    -> IORef [OpenAiAccount]
     -> [Text]
     -> IO (Either ApiError [OpenAI.AuthState])
-discoverOpenAiAccounts accountSources knownAccountIds = do
+discoverOpenAiAccounts billing accountSources knownAccountIds = do
     (errors, accounts) <- loadOpenAiAccounts
     let additional =
             filter
                 (\account ->
-                    account.openAiState.accountId `notElem` knownAccountIds)
+                    account.openAiBilling == billing
+                        && account.openAiState.accountId `notElem` knownAccountIds)
                 accounts
     if null additional
         then pure $ case errors of
@@ -419,6 +437,7 @@ data OpenAiAccount = OpenAiAccount
     { openAiState :: !OpenAI.AuthState
     , openAiSource :: !OpenAiCredentialSource
     , openAiLabel :: !Text
+    , openAiBilling :: !BillingMode
     }
 
 managedOpenAiAccount
@@ -448,6 +467,7 @@ managedOpenAiAccount now (metadata, secret) =
                                 OpenAiManagedOAuth metadata.managedId
                             , openAiLabel =
                                 openAiStateLabel metadata.managedLabel state
+                            , openAiBilling = metadata.managedBilling
                             }
         _ ->
             Right OpenAiAccount
@@ -462,6 +482,7 @@ managedOpenAiAccount now (metadata, secret) =
                         , provider = OpenAIProvider
                         })
                     (nonEmptyText metadata.managedLabel)
+                , openAiBilling = metadata.managedBilling
                 }
 
 openAiStaticAccount :: UTCTime -> Text -> IO OpenAiAccount
@@ -477,6 +498,7 @@ openAiStaticAccount now token = do
                 , leaseId = Nothing
                 , provider = OpenAIProvider
                 }
+        , openAiBilling = SubscriptionBilled
         }
 
 openAiStateLabel :: Text -> OpenAI.AuthState -> Text
@@ -859,7 +881,7 @@ managedGrokTokenProvider
 managedGrokTokenProvider metadata secret initial refresh = do
     stateRef <- newIORef initial
     refreshLock <- newMVar ()
-    pure $ TokenProvider \failed ->
+    pure $ tokenProvider metadata.managedBilling \failed ->
         withMVar refreshLock \_ ->
             managedGrokCredential metadata secret stateRef refresh failed
 
@@ -1068,10 +1090,11 @@ hasManagedProvider provider =
 -- spinning on the same key.
 reloadableFileCredentialProvider
     :: Provider
+    -> BillingMode
     -> Credential
     -> IO (Maybe Credential)
     -> IO TokenProvider
-reloadableFileCredentialProvider expectedProvider initial reload = do
+reloadableFileCredentialProvider expectedProvider billing initial reload = do
     cache <- newIORef (Just initial)
     let loadFresh rejectedToken =
             reload >>= \case
@@ -1091,26 +1114,26 @@ reloadableFileCredentialProvider expectedProvider initial reload = do
                     | otherwise -> do
                         writeIORef cache (Just credential)
                         pure (Right credential)
-    pure $ TokenProvider \failed -> case failed of
-        Just FailedCredential { failure = AccountRateLimited { retryAfterSeconds } } -> do
-            now <- getCurrentTime
-            let seconds = max 1 (fromMaybe 60 retryAfterSeconds)
-            pure $ Left $ CredentialsExhausted
-                (addUTCTime (fromIntegral seconds) now)
-        Just FailedCredential
-            { credential = rejected
-            , failure = AccountAuthenticationRejected
-            } -> do
-            writeIORef cache Nothing
-            loadFresh (Just rejected.accessToken)
-        Nothing ->
-            readIORef cache >>= \case
-                Just credential -> pure (Right credential)
-                Nothing -> loadFresh Nothing
+    pure $ tokenProvider billing \failed -> case failed of
+            Just FailedCredential { failure = AccountRateLimited { retryAfterSeconds } } -> do
+                now <- getCurrentTime
+                let seconds = max 1 (fromMaybe 60 retryAfterSeconds)
+                pure $ Left $ CredentialsExhausted
+                    (addUTCTime (fromIntegral seconds) now)
+            Just FailedCredential
+                { credential = rejected
+                , failure = AccountAuthenticationRejected
+                } -> do
+                writeIORef cache Nothing
+                loadFresh (Just rejected.accessToken)
+            Nothing ->
+                readIORef cache >>= \case
+                    Just credential -> pure (Right credential)
+                    Nothing -> loadFresh Nothing
 
-staticCredentialProvider :: Credential -> TokenProvider
-staticCredentialProvider credential = TokenProvider \failed ->
-    case failed of
+staticCredentialProvider :: BillingMode -> Credential -> TokenProvider
+staticCredentialProvider billing credential =
+    tokenProvider billing \failed -> case failed of
         Nothing -> pure (Right credential)
         Just FailedCredential
             { failure = AccountRateLimited { retryAfterSeconds }

--- a/packages/agent-cli/src/Agent/CLI/CredentialStore.hs
+++ b/packages/agent-cli/src/Agent/CLI/CredentialStore.hs
@@ -1,7 +1,6 @@
 -- | Restricted-file credential store used by the interactive login manager.
 module Agent.CLI.CredentialStore
     ( ManagedAuthKind(..)
-    , ManagedBilling(..)
     , ManagedCredential(..)
     , ManagedSecret(..)
     , deleteManagedCredential
@@ -19,7 +18,12 @@ module Agent.CLI.CredentialStore
 import Agent.CLI.Error (formatException)
 import Agent.FileRetry (retryOnFileBusy, writeLazyFileAtomically)
 import Agent.OsPath (toText, unsafeToFilePath)
-import Agent.Provider (Provider(..), parseProvider, providerSlug)
+import Agent.Provider
+    ( BillingMode
+    , Provider(..)
+    , parseProvider
+    , providerSlug
+    )
 import Control.Concurrent.MVar (MVar, newMVar, withMVar)
 import Control.Exception.Safe (bracket, bracket_, tryIO)
 import qualified Data.Aeson as Aeson
@@ -55,17 +59,12 @@ data ManagedAuthKind
     | ManagedGrokAuthJson
     deriving (Eq, Show)
 
-data ManagedBilling
-    = ManagedSubscription
-    | ManagedApiCredits
-    deriving (Eq, Show)
-
 data ManagedCredential = ManagedCredential
     { managedId :: !Text
     , managedProvider :: !Provider
     , managedAccountId :: !Text
     , managedLabel :: !Text
-    , managedBilling :: !ManagedBilling
+    , managedBilling :: !BillingMode
     , managedAuthKind :: !ManagedAuthKind
     , managedEnabled :: !Bool
     }
@@ -95,17 +94,6 @@ instance Aeson.FromJSON ManagedAuthKind where
         "openai_oauth" -> pure ManagedOpenAIAuthJson
         "grok_oauth" -> pure ManagedGrokAuthJson
         other -> fail ("unknown managed auth kind: " <> Text.unpack other)
-
-instance Aeson.ToJSON ManagedBilling where
-    toJSON = Aeson.String . \case
-        ManagedSubscription -> "subscription"
-        ManagedApiCredits -> "api_credits"
-
-instance Aeson.FromJSON ManagedBilling where
-    parseJSON = Aeson.withText "ManagedBilling" \case
-        "subscription" -> pure ManagedSubscription
-        "api_credits" -> pure ManagedApiCredits
-        other -> fail ("unknown managed billing kind: " <> Text.unpack other)
 
 instance Aeson.ToJSON ManagedCredential where
     toJSON credential = Aeson.object

--- a/packages/agent-cli/src/Agent/CLI/Login.hs
+++ b/packages/agent-cli/src/Agent/CLI/Login.hs
@@ -26,7 +26,6 @@ import Agent.CLI.Auth
     )
 import Agent.CLI.CredentialStore
     ( ManagedAuthKind(..)
-    , ManagedBilling(..)
     , ManagedCredential(..)
     , ManagedSecret(..)
     , deleteManagedCredential
@@ -60,7 +59,7 @@ import qualified Agent.OpenAI.Login as OpenAILogin
 import Agent.OsPath (toText, unsafeToFilePath)
 import qualified Agent.OpenAI.Usage as OpenAI
 import qualified Agent.OpenRouter.Usage as OpenRouter
-import Agent.Provider (Provider(..), providerSlug)
+import Agent.Provider (BillingMode(..), Provider(..), providerSlug)
 import qualified Agent.XAI.Auth as XAIAuth
 import qualified Agent.XAI.Usage as XAI
 import Control.Applicative ((<|>))
@@ -323,8 +322,8 @@ managedLoginAccount now (metadata, secret) =
         , loginAccountId = metadata.managedAccountId
         , loginLabel = fromMaybe metadata.managedLabel managedAccountEmail
         , loginBilling = case metadata.managedBilling of
-            ManagedSubscription -> SubscriptionBilling Nothing
-            ManagedApiCredits -> ApiCreditsBilling
+            SubscriptionBilled -> SubscriptionBilling Nothing
+            ApiBilled -> ApiCreditsBilling
         , loginSource = "managed"
         , loginUsage = UsageNotChecked
         , loginAccessToken = accessToken
@@ -411,8 +410,8 @@ importAt color index accounts =
                             , managedAccountId = account.loginAccountId
                             , managedLabel = account.loginLabel
                             , managedBilling = case account.loginBilling of
-                                SubscriptionBilling _ -> ManagedSubscription
-                                ApiCreditsBilling -> ManagedApiCredits
+                                SubscriptionBilling _ -> SubscriptionBilled
+                                ApiCreditsBilling -> ApiBilled
                             , managedAuthKind = account.loginAuthKind
                             , managedEnabled = True
                             }
@@ -490,7 +489,7 @@ connectOpenAI color = do
                                 auth.accountId
                                 (fromMaybe "ChatGPT"
                                     (openAIAccountEmail auth))
-                                ManagedSubscription
+                                SubscriptionBilled
                                 ManagedOpenAIAuthJson
                                 (Text.decodeUtf8
                                     (LBS.toStrict (Aeson.encode authJson)))
@@ -540,7 +539,7 @@ connectXAI color = do
                             XAIProvider
                             accountId
                             label
-                            ManagedSubscription
+                            SubscriptionBilled
                             ManagedGrokAuthJson
                             (Text.decodeUtf8
                                 (LBS.toStrict (Aeson.encode authJson)))
@@ -563,7 +562,7 @@ connectOpenRouter color =
                         OpenRouterProvider
                         accountId
                         label
-                        ManagedApiCredits
+                        ApiBilled
                         ManagedBearerToken
                         apiKey
 
@@ -572,7 +571,7 @@ storeConnectedCredential
     -> Provider
     -> Text
     -> Text
-    -> ManagedBilling
+    -> BillingMode
     -> ManagedAuthKind
     -> Text
     -> IO ()

--- a/packages/agent-cli/src/Agent/CLI/ProviderFallback.hs
+++ b/packages/agent-cli/src/Agent/CLI/ProviderFallback.hs
@@ -1,6 +1,7 @@
 -- | Automatic cross-provider fallback policy.
 module Agent.CLI.ProviderFallback
-    ( automaticCooldownRetryDelay
+    ( allowsAutomaticBillingFallback
+    , automaticCooldownRetryDelay
     , fallbackCandidates
     , isProviderUnavailable
     , isUsageExhausted
@@ -9,7 +10,7 @@ module Agent.CLI.ProviderFallback
 
 import Agent.CLI.Models (ModelOption(..), modelCatalog)
 import Agent.Error (ApiError(..), ErrorType(..))
-import Agent.Provider (Provider(..))
+import Agent.Provider (BillingMode(..), Provider(..))
 import Data.List (nubBy, sortOn)
 import Data.Time.Clock (NominalDiffTime, UTCTime, diffUTCTime)
 
@@ -18,6 +19,16 @@ import Data.Time.Clock (NominalDiffTime, UTCTime, diffUTCTime)
 -- making the CLI appear hung.
 maxAutomaticCooldownWait :: NominalDiffTime
 maxAutomaticCooldownWait = 120
+
+-- | Automatic fallback may use another subscription account, but must never
+-- turn subscription exhaustion into API-credit spending. Manual provider
+-- changes remain unrestricted because the user explicitly chose them.
+allowsAutomaticBillingFallback
+    :: BillingMode
+    -> BillingMode
+    -> Bool
+allowsAutomaticBillingFallback source target =
+    source /= SubscriptionBilled || target /= ApiBilled
 
 automaticCooldownRetryDelay
     :: UTCTime

--- a/packages/agent-cli/src/Agent/CLI/ProviderTransition.hs
+++ b/packages/agent-cli/src/Agent/CLI/ProviderTransition.hs
@@ -13,7 +13,7 @@ import Agent.CLI.Models (ModelOption(..))
 import Agent.CLI.Options (CliOptions(..))
 import Agent.Error (ApiError)
 import Agent.Loop (TurnInput)
-import Agent.Provider (Provider)
+import Agent.Provider (BillingMode, Provider)
 import Agent.Tools.PlanMode (PlanModeState)
 import Control.Applicative ((<|>))
 import Data.Text (Text)
@@ -37,6 +37,10 @@ data ProviderTransition = ProviderTransition
     , transitionDraft :: !Text
     , transitionUnavailableProviders :: ![Provider]
     , transitionCause :: !TransitionCause
+    -- | Billing class of the session that initiated an automatic fallback.
+    -- Preserved across failed replacement providers so the whole chain obeys
+    -- the original billing boundary. Manual transitions use 'Nothing'.
+    , transitionAutomaticBilling :: !(Maybe BillingMode)
     }
 
 data TurnResult

--- a/packages/agent-cli/test/Agent/CLI/AuthSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/AuthSpec.hs
@@ -8,11 +8,14 @@ import Agent.OpenAI.Auth (AuthState(..))
 import qualified Agent.OpenAI.Auth as OpenAI
 import Agent.Provider
     ( AccountFailure(..)
+    , BillingMode(..)
     , Credential(..)
     , FailedCredential(..)
     , Provider(..)
-    , TokenProvider(..)
+    , TokenProvider
     , getNextToken
+    , tokenProvider
+    , tokenProviderBillingMode
     )
 import qualified Agent.XAI.Auth as XAIAuth
 import Control.Exception.Safe (bracket)
@@ -53,7 +56,7 @@ spec = do
             let retryAt = UTCTime (fromGregorian 2026 8 21) 3600
                 exhausted = LoadedAuth
                     { loadedProvider = XAIProvider
-                    , loadedTokenProvider = TokenProvider \_ ->
+                    , loadedTokenProvider = tokenProvider SubscriptionBilled \_ ->
                         pure (Left (CredentialsExhausted retryAt))
                     , loadedAccountLabel = pure . credentialAccountLabel
                     , loadedOpenAiPool = Nothing
@@ -98,6 +101,10 @@ spec = do
     describe "OpenAI account pools" do
         it "loads every enabled managed account into one pool" $
             withTempHome openAiManagedPoolTest
+        it "does not mix subscription and API-credit accounts" $
+            withTempHome openAiBillingPoolTest
+        it "uses API billing when only API-credit accounts exist" $
+            withTempHome openAiApiBillingPoolTest
         it "discovers an account connected after the session started" $
             withTempHome openAiManagedPoolDiscoveryTest
         it "combines distinct managed and ~/.codex accounts" $
@@ -108,6 +115,69 @@ spec = do
             withTempHome openAiDisabledSourceTest
         it "uses the login email as the active account label" $
             withTempHome openAiAccountLabelTest
+
+    describe "loaded billing" do
+        it "classifies an OpenRouter API key as API-credit billed" $
+            withTempHome \_ ->
+                withEnv "OPENROUTER_API_KEY" (Just "openrouter-key") do
+                    loadAuth (Just OpenRouterProvider) >>= \case
+                        Left err -> expectationFailure (Text.unpack err)
+                        Right loaded ->
+                            tokenProviderBillingMode loaded.loadedTokenProvider
+                                `shouldBe` ApiBilled
+
+        it "does not trust managed metadata to make OpenRouter subscription billed" $
+            withTempHome \_ -> do
+                upsertManagedCredential
+                    ManagedCredential
+                        { managedId = "openrouter"
+                        , managedProvider = OpenRouterProvider
+                        , managedAccountId = "openrouter"
+                        , managedLabel = "OpenRouter"
+                        , managedBilling = SubscriptionBilled
+                        , managedAuthKind = ManagedBearerToken
+                        , managedEnabled = True
+                        }
+                    (ManagedSecret "openrouter" "openrouter-key")
+                    `shouldReturn` Right ()
+                loadAuth (Just OpenRouterProvider) >>= \case
+                    Left err -> expectationFailure (Text.unpack err)
+                    Right loaded ->
+                        tokenProviderBillingMode loaded.loadedTokenProvider
+                            `shouldBe` ApiBilled
+
+        it "classifies an external Grok access token as subscription billed" $
+            withTempHome \_ ->
+                withCleanGrokEnv $
+                    withEnv "GROK_ACCESS_TOKEN" (Just "grok-token") do
+                        loadAuth (Just XAIProvider) >>= \case
+                            Left err -> expectationFailure (Text.unpack err)
+                            Right loaded ->
+                                tokenProviderBillingMode
+                                    loaded.loadedTokenProvider
+                                    `shouldBe` SubscriptionBilled
+
+        it "uses stored billing for a managed XAI bearer token" $
+            withTempHome \_ ->
+                withCleanGrokEnv do
+                    upsertManagedCredential
+                        ManagedCredential
+                            { managedId = "xai-api"
+                            , managedProvider = XAIProvider
+                            , managedAccountId = "xai-api"
+                            , managedLabel = "xAI API"
+                            , managedBilling = ApiBilled
+                            , managedAuthKind = ManagedBearerToken
+                            , managedEnabled = True
+                            }
+                        (ManagedSecret "xai-api" "xai-api-key")
+                        `shouldReturn` Right ()
+                    loadAuth (Just XAIProvider) >>= \case
+                        Left err -> expectationFailure (Text.unpack err)
+                        Right loaded ->
+                            tokenProviderBillingMode
+                                loaded.loadedTokenProvider
+                                `shouldBe` ApiBilled
 
     describe "openAIOAuthClientId" do
         it "uses the Codex public client id by default" do
@@ -264,7 +334,7 @@ spec = do
         it "preserves rate-limit cooldowns for managed bearer tokens" do
             before <- getCurrentTime
             result <- getNextToken
-                (staticCredentialProvider staleGrok)
+                (staticCredentialProvider SubscriptionBilled staleGrok)
                 (Just
                     (FailedCredential staleGrok
                         (AccountRateLimited (Just 7))))
@@ -289,7 +359,8 @@ spec = do
     describe "reloadableFileCredentialProvider" do
         it "returns the cached credential without reloading" do
             loads <- newIORef (0 :: Int)
-            provider <- reloadableFileCredentialProvider XAIProvider staleGrok
+            provider <- reloadableFileCredentialProvider
+                XAIProvider SubscriptionBilled staleGrok
                 (modifyIORef' loads (+ 1) >> pure (Just freshGrok))
             first <- getNextToken provider Nothing
             second <- getNextToken provider Nothing
@@ -299,7 +370,8 @@ spec = do
 
         it "reloads after an authentication rejection" do
             loads <- newIORef (0 :: Int)
-            provider <- reloadableFileCredentialProvider XAIProvider staleGrok
+            provider <- reloadableFileCredentialProvider
+                XAIProvider SubscriptionBilled staleGrok
                 (modifyIORef' loads (+ 1) >> pure (Just freshGrok))
             reloaded <- getNextToken provider (Just FailedCredential
                 { credential = staleGrok
@@ -310,7 +382,8 @@ spec = do
             readIORef loads `shouldReturn` 1
 
         it "rejects an unchanged reload after authentication failure" do
-            provider <- reloadableFileCredentialProvider XAIProvider staleGrok
+            provider <- reloadableFileCredentialProvider
+                XAIProvider SubscriptionBilled staleGrok
                 (pure (Just staleGrok))
             result <- getNextToken provider (Just FailedCredential
                 { credential = staleGrok
@@ -329,8 +402,31 @@ openAiManagedPoolTest _ =
         storeOpenAiAccount "managed-b" "acc-b" True "token-b"
         storeOpenAiAccount "managed-disabled" "acc-disabled" False "token-disabled"
         loaded <- loadAuth (Just OpenAIProvider)
+        expectLoadedBilling loaded `shouldReturn` SubscriptionBilled
         pool <- expectOpenAiPool loaded
         OpenAI.allAccountIds pool `shouldReturn` ["acc-b", "acc-a"]
+
+openAiBillingPoolTest :: OsPath -> IO ()
+openAiBillingPoolTest _ =
+    withCleanOpenAiEnv do
+        storeOpenAiAccount "subscription" "acc-subscription" True
+            "subscription-token"
+        storeOpenAiAccountWithBilling
+            ApiBilled "api" "acc-api" True "api-token"
+        loaded <- loadAuth (Just OpenAIProvider)
+        expectLoadedBilling loaded `shouldReturn` SubscriptionBilled
+        pool <- expectOpenAiPool loaded
+        OpenAI.allAccountIds pool `shouldReturn` ["acc-subscription"]
+
+openAiApiBillingPoolTest :: OsPath -> IO ()
+openAiApiBillingPoolTest _ =
+    withCleanOpenAiEnv do
+        storeOpenAiAccountWithBilling
+            ApiBilled "api" "acc-api" True "api-token"
+        loaded <- loadAuth (Just OpenAIProvider)
+        expectLoadedBilling loaded `shouldReturn` ApiBilled
+        pool <- expectOpenAiPool loaded
+        OpenAI.allAccountIds pool `shouldReturn` ["acc-api"]
 
 openAiManagedPoolDiscoveryTest :: OsPath -> IO ()
 openAiManagedPoolDiscoveryTest _ =
@@ -428,20 +524,43 @@ expectOpenAiPool = \case
             >> fail "missing pool"
         Just pool -> pure pool
 
+expectLoadedBilling :: Either Text LoadedAuth -> IO BillingMode
+expectLoadedBilling = \case
+    Left err -> expectationFailure (Text.unpack err)
+        >> fail "missing loaded auth"
+    Right loaded ->
+        pure (tokenProviderBillingMode loaded.loadedTokenProvider)
+
 storeOpenAiAccount :: Text -> Text -> Bool -> Text -> IO ()
 storeOpenAiAccount credentialId accountId enabled token =
+    storeOpenAiAccountWithBilling
+        SubscriptionBilled credentialId accountId enabled token
+
+storeOpenAiAccountWithBilling
+    :: BillingMode
+    -> Text
+    -> Text
+    -> Bool
+    -> Text
+    -> IO ()
+storeOpenAiAccountWithBilling billing credentialId accountId enabled token =
     upsertManagedCredential
-        (openAiMetadata credentialId accountId enabled)
+        (openAiMetadata billing credentialId accountId enabled)
         (ManagedSecret credentialId (authJson accountId token))
         `shouldReturn` Right ()
 
-openAiMetadata :: Text -> Text -> Bool -> ManagedCredential
-openAiMetadata credentialId accountId enabled = ManagedCredential
+openAiMetadata
+    :: BillingMode
+    -> Text
+    -> Text
+    -> Bool
+    -> ManagedCredential
+openAiMetadata billing credentialId accountId enabled = ManagedCredential
     { managedId = credentialId
     , managedProvider = OpenAIProvider
     , managedAccountId = accountId
     , managedLabel = "ChatGPT"
-    , managedBilling = ManagedSubscription
+    , managedBilling = billing
     , managedAuthKind = ManagedOpenAIAuthJson
     , managedEnabled = enabled
     }
@@ -489,7 +608,7 @@ freshGrok = Credential
 managedGrokMetadata :: ManagedCredential
 managedGrokMetadata =
     ManagedCredential "grok-test" XAIProvider "account" "Grok"
-        ManagedSubscription ManagedGrokAuthJson True
+        SubscriptionBilled ManagedGrokAuthJson True
 
 managedGrokSecretFor :: GrokAuthState -> ManagedSecret
 managedGrokSecretFor state =
@@ -561,6 +680,16 @@ withCleanOpenAiEnv action =
         , "CODEX_ACCOUNT_ID"
         , "CODEX_ID_TOKEN"
         , "OPENAI_OAUTH_CLIENT_ID"
+        ]
+
+withCleanGrokEnv :: IO a -> IO a
+withCleanGrokEnv action =
+    foldr
+        (\name next -> withEnv name Nothing next)
+        action
+        [ "GROK_AUTH_JSON"
+        , "GROK_ACCESS_TOKEN"
+        , "XAI_OAUTH_CLIENT_ID"
         ]
 
 withTempHome :: (OsPath -> IO a) -> IO a

--- a/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
@@ -27,7 +27,11 @@ import Agent.ToolDispatch
 import Agent.Responses.Types
 import qualified Data.Aeson as Aeson
 import Data.Aeson ((.=))
-import Agent.Provider (Provider(..), TokenProvider(..))
+import Agent.Provider
+    ( BillingMode(..)
+    , Provider(..)
+    , tokenProvider
+    )
 import Control.Exception
     ( AsyncException(..)
     , MaskingState(..)
@@ -57,7 +61,7 @@ spec = do
         it "short-circuits an empty transcript before using credentials" do
             params <- newIORef defaultResponseCreateParams
             transcript <- newIORef []
-            let provider = TokenProvider \_ ->
+            let provider = tokenProvider SubscriptionBilled \_ ->
                     error "empty compaction unexpectedly requested credentials"
             runProviderCompact OpenAIProvider (Just provider) params transcript Nothing
                 `shouldReturn` Left "nothing to compact"
@@ -213,7 +217,7 @@ spec = do
     describe "compactOpenAIWith" do
         it "uses remote compaction v2 on normal Responses" do
             requests <- newIORef []
-            let provider = TokenProvider \_ ->
+            let provider = tokenProvider SubscriptionBilled \_ ->
                     error "remote compaction unexpectedly requested credentials"
                 send _ request = do
                     modifyIORef' requests (<> [request])
@@ -253,7 +257,7 @@ spec = do
 
         it "keeps focused manual compaction on local summarization" do
             requests <- newIORef []
-            let provider = TokenProvider \_ ->
+            let provider = tokenProvider SubscriptionBilled \_ ->
                     error "local summarization unexpectedly requested credentials"
                 send _ request = do
                     modifyIORef' requests (<> [request])
@@ -278,7 +282,7 @@ spec = do
             map (.stream) seen `shouldBe` [Just True]
 
         it "returns friendly provider errors from manual compaction" do
-            let provider = TokenProvider \_ ->
+            let provider = tokenProvider SubscriptionBilled \_ ->
                     error "compaction unexpectedly requested credentials"
                 send _ _ =
                     pure $ Left $
@@ -308,7 +312,7 @@ spec = do
         it "compacts at a configured threshold below the model default" do
             let history = [userTextItem "old"]
                 threshold = 20
-                tokenProvider = TokenProvider \_ ->
+                tokens = tokenProvider SubscriptionBilled \_ ->
                     pure (Left (ConnectionError "configured threshold fired"))
                 params =
                     withModel
@@ -322,7 +326,7 @@ spec = do
             let backend =
                     autoCompactOpenAiBackendWithThreshold
                         (Just threshold)
-                        tokenProvider
+                        tokens
                         (pure params)
                         transcript
                         contextState

--- a/packages/agent-cli/test/Agent/CLI/CredentialStoreSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CredentialStoreSpec.hs
@@ -2,7 +2,7 @@ module Agent.CLI.CredentialStoreSpec (spec) where
 
 import Agent.CLI.CredentialStore
 import System.OsPath (OsPath, decodeUtf, unsafeEncodeUtf)
-import Agent.Provider (Provider(..))
+import Agent.Provider (BillingMode(..), Provider(..))
 import Control.Exception.Safe (bracket)
 import qualified Data.ByteString.Lazy.Char8 as LBS
 import Data.Bits ((.&.))
@@ -89,7 +89,7 @@ account = ManagedCredential
     , managedProvider = OpenRouterProvider
     , managedAccountId = "account"
     , managedLabel = "Test"
-    , managedBilling = ManagedApiCredits
+    , managedBilling = ApiBilled
     , managedAuthKind = ManagedBearerToken
     , managedEnabled = True
     }

--- a/packages/agent-cli/test/Agent/CLI/ProviderFallbackSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ProviderFallbackSpec.hs
@@ -2,12 +2,13 @@ module Agent.CLI.ProviderFallbackSpec (spec) where
 
 import Agent.CLI.Models (ModelOption(..))
 import Agent.CLI.ProviderFallback
-    ( automaticCooldownRetryDelay
+    ( allowsAutomaticBillingFallback
+    , automaticCooldownRetryDelay
     , fallbackCandidates
     , rankedModels
     )
 import Agent.Error (ApiError(..), ErrorType(..))
-import Agent.Provider (Provider(..))
+import Agent.Provider (BillingMode(..), Provider(..))
 import Data.List (elemIndex)
 import Data.Time.Calendar (fromGregorian)
 import Data.Time.Clock (UTCTime(..), addUTCTime)
@@ -15,6 +16,22 @@ import Test.Hspec
 
 spec :: Spec
 spec = do
+    describe "allowsAutomaticBillingFallback" do
+        it "blocks subscription-to-API-credit fallback" do
+            allowsAutomaticBillingFallback
+                SubscriptionBilled ApiBilled
+                `shouldBe` False
+
+        it "allows fallback between subscription accounts" do
+            allowsAutomaticBillingFallback
+                SubscriptionBilled SubscriptionBilled
+                `shouldBe` True
+
+        it "does not restrict a session already using API credits" do
+            allowsAutomaticBillingFallback
+                ApiBilled ApiBilled
+                `shouldBe` True
+
     describe "rankedModels" do
         it "prefers sol over luna" do
             let ids = map (.modelId) rankedModels

--- a/packages/agent-cli/test/Agent/CLI/ProviderTransitionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ProviderTransitionSpec.hs
@@ -3,7 +3,7 @@ module Agent.CLI.ProviderTransitionSpec (spec) where
 import Agent.CLI.Models (ModelOption(..))
 import Agent.CLI.Options (CliOptions(..), defaultCliOptions, isOneShot)
 import Agent.CLI.ProviderTransition
-import Agent.Provider (Provider(..))
+import Agent.Provider (BillingMode(..), Provider(..))
 import Agent.Tools.PlanMode (PlanModeState(..))
 import Data.Text (Text)
 import Test.Hspec
@@ -66,4 +66,5 @@ transition sessionId pending = ProviderTransition
     , transitionDraft = ""
     , transitionUnavailableProviders = [XAIProvider]
     , transitionCause = AutomaticFallback
+    , transitionAutomaticBilling = Just SubscriptionBilled
     }

--- a/packages/agent-core/src/Agent/Provider.hs
+++ b/packages/agent-core/src/Agent/Provider.hs
@@ -1,6 +1,9 @@
 -- | Provider-neutral credential acquisition and account failover.
 module Agent.Provider
-    ( TokenProvider(..)
+    ( BillingMode(..)
+    , TokenProvider
+    , tokenProviderBillingMode
+    , tokenProvider
     , Credential(..)
     , Provider(..)
     , providerSlug
@@ -19,6 +22,7 @@ import Agent.Error
     , ErrorType(..)
     , apiErrorRetryAfter
     )
+import qualified Data.Aeson as Aeson
 import Data.IORef
 import Data.Text (Text)
 
@@ -46,6 +50,27 @@ data Credential = Credential
     }
     deriving (Eq)
 
+-- | How requests made with a credential source are billed.
+--
+-- A 'TokenProvider' must only issue credentials with its declared mode. This
+-- lets callers enforce spending boundaries without knowing provider-specific
+-- authentication details.
+data BillingMode
+    = SubscriptionBilled
+    | ApiBilled
+    deriving (Eq, Show)
+
+instance Aeson.ToJSON BillingMode where
+    toJSON = Aeson.String . \case
+        SubscriptionBilled -> "subscription"
+        ApiBilled -> "api_credits"
+
+instance Aeson.FromJSON BillingMode where
+    parseJSON = Aeson.withText "BillingMode" \case
+        "subscription" -> pure SubscriptionBilled
+        "api_credits" -> pure ApiBilled
+        other -> fail ("unknown billing mode: " <> show other)
+
 instance Show Credential where
     show credential = "Credential { accountId = "
         <> show credential.accountId
@@ -67,11 +92,22 @@ data FailedCredential = FailedCredential
     }
     deriving (Eq, Show)
 
-newtype TokenProvider = TokenProvider
-    { runGetNextToken
+data TokenProvider = TokenProvider
+    { providerBillingMode :: !BillingMode
+    , runGetNextToken
         :: Maybe FailedCredential
         -> IO (Either ApiError Credential)
     }
+
+tokenProvider
+    :: BillingMode
+    -> (Maybe FailedCredential -> IO (Either ApiError Credential))
+    -> TokenProvider
+tokenProvider = TokenProvider
+
+tokenProviderBillingMode :: TokenProvider -> BillingMode
+tokenProviderBillingMode TokenProvider{providerBillingMode} =
+    providerBillingMode
 
 getNextToken
     :: TokenProvider
@@ -82,11 +118,15 @@ getNextToken provider = provider.runGetNextToken
 seedTokenProvider :: TokenProvider -> Credential -> IO TokenProvider
 seedTokenProvider provider credential = do
     seed <- newIORef (Just credential)
-    pure $ TokenProvider \failed -> case failed of
-        Just reportedFailure -> getNextToken provider (Just reportedFailure)
-        Nothing -> atomicModifyIORef' seed (\current -> (Nothing, current)) >>= \case
-            Just firstCredential -> pure (Right firstCredential)
-            Nothing -> getNextToken provider Nothing
+    pure TokenProvider
+        { providerBillingMode = tokenProviderBillingMode provider
+        , runGetNextToken = \failed -> case failed of
+            Just reportedFailure -> getNextToken provider (Just reportedFailure)
+            Nothing -> atomicModifyIORef'
+                seed (\current -> (Nothing, current)) >>= \case
+                    Just firstCredential -> pure (Right firstCredential)
+                    Nothing -> getNextToken provider Nothing
+        }
 
 runWithTokenProvider
     :: TokenProvider

--- a/packages/agent-openai/src/Agent/OpenAI/Credential.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Credential.hs
@@ -2,6 +2,7 @@
 -- static Responses API bearer token.
 module Agent.OpenAI.Credential
     ( poolTokenProvider
+    , poolTokenProviderWithBilling
     , staticBearerProvider
     ) where
 
@@ -16,10 +17,12 @@ import qualified Data.Text as Text
 import Data.Time.Clock (UTCTime, addUTCTime, diffUTCTime, getCurrentTime)
 
 poolTokenProvider :: Auth.Pool -> IO TokenProvider
-poolTokenProvider pool = do
+poolTokenProvider = poolTokenProviderWithBilling SubscriptionBilled
+
+poolTokenProviderWithBilling :: BillingMode -> Auth.Pool -> IO TokenProvider
+poolTokenProviderWithBilling billing pool = do
     authRecoveryAttempts <- newIORef Map.empty
-    pure $ TokenProvider \failed ->
-        case failed of
+    pure $ tokenProvider billing \failed -> case failed of
             Nothing -> acquireFromPool pool
             Just FailedCredential { credential, failure } ->
                 case failure of
@@ -79,8 +82,7 @@ takeAuthRecoverySlot attempts accountId = do
 -- | A single OpenAI-compatible API bearer token with no OAuth refresh or
 -- account failover.
 staticBearerProvider :: Text -> TokenProvider
-staticBearerProvider apiKey = TokenProvider \failed ->
-    case failed of
+staticBearerProvider apiKey = tokenProvider ApiBilled \failed -> case failed of
         Nothing ->
             pure $ Right Credential
                 { accessToken = apiKey

--- a/packages/agent-openai/test/Agent/OpenAI/ClientSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/ClientSpec.hs
@@ -151,7 +151,9 @@ spec = do
                     , provider = OpenAIProvider
                     }
             withMockResponses recorded handler \baseUrl -> do
-                provider <- pure $ TokenProvider \_ -> pure (Right credential)
+                provider <- pure $
+                    tokenProvider SubscriptionBilled \_ ->
+                        pure (Right credential)
                 _ <- expectRight =<< createCodexMessageWithProviderAt
                     baseUrl
                     provider

--- a/packages/agent-openai/test/Agent/OpenAI/CompactionSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/CompactionSpec.hs
@@ -214,7 +214,8 @@ spec = do
 
     describe "compactConversationAt" do
         it "rejects non-OpenAI credentials before making a request" do
-            let provider = TokenProvider \_ -> pure $ Right Credential
+            let provider = tokenProvider SubscriptionBilled \_ ->
+                    pure $ Right Credential
                     { accessToken = "xai-secret"
                     , accountId = "account"
                     , leaseId = Nothing

--- a/packages/agent-openai/test/Agent/OpenAI/CredentialSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/CredentialSpec.hs
@@ -55,7 +55,7 @@ spec = do
     describe "runWithTokenProvider" do
         it "shares account failover orchestration across transports" do
             reportedFailures <- newIORef ([] :: [Maybe FailedCredential])
-            let provider = TokenProvider \reported -> do
+            let provider = tokenProvider SubscriptionBilled \reported -> do
                     modifyIORef' reportedFailures (<> [reported])
                     pure $ Right $ case reported of
                         Nothing -> credentialFor "acc-a"
@@ -73,7 +73,7 @@ spec = do
 
         it "does not poison credentials after transport failures" do
             acquisitions <- newIORef (0 :: Int)
-            let provider = TokenProvider \_ -> do
+            let provider = tokenProvider SubscriptionBilled \_ -> do
                     modifyIORef' acquisitions (+ 1)
                     pure $ Right (credentialFor "acc-a")
             result <- runWithTokenProvider provider \_ ->
@@ -87,7 +87,7 @@ spec = do
             let exhausted = credentialFor "acc-exhausted"
                 initialFailure =
                     failed exhausted (AccountRateLimited (Just 120))
-                provider = TokenProvider \reported -> do
+                provider = tokenProvider SubscriptionBilled \reported -> do
                     modifyIORef' reportedFailures (<> [reported])
                     pure $ Right (credentialFor "acc-healthy")
 
@@ -100,13 +100,14 @@ spec = do
     describe "seedTokenProvider" do
         it "uses an acquired replacement exactly once before delegating" do
             acquisitions <- newIORef (0 :: Int)
-            let underlying = TokenProvider \_ -> do
+            let underlying = tokenProvider SubscriptionBilled \_ -> do
                     call <- atomicModifyIORef' acquisitions (\n -> (n + 1, n + 1))
                     pure $ Right (credentialFor ("underlying-" <> showText call))
                 replacement = (credentialFor "replacement")
                     { leaseId = Just "replacement-lease" }
             seeded <- seedTokenProvider underlying replacement
 
+            tokenProviderBillingMode seeded `shouldBe` SubscriptionBilled
             first <- getNextToken seeded Nothing
             second <- getNextToken seeded Nothing
 
@@ -116,7 +117,7 @@ spec = do
 
         it "forwards failure feedback without consuming the seed" do
             reported <- newIORef ([] :: [Maybe FailedCredential])
-            let underlying = TokenProvider \failure -> do
+            let underlying = tokenProvider SubscriptionBilled \failure -> do
                     modifyIORef' reported (<> [failure])
                     pure $ Right (credentialFor "after-feedback")
                 replacement = (credentialFor "replacement")
@@ -135,6 +136,7 @@ spec = do
         it "acquires a credential without exposing local pool details" do
             provider <- localProvider ["acc-a"] (pure . Right)
 
+            tokenProviderBillingMode provider `shouldBe` SubscriptionBilled
             result <- getNextToken provider Nothing
 
             fmap (.accountId) result `shouldBe` Right "acc-a"
@@ -205,7 +207,9 @@ spec = do
 
     describe "staticBearerProvider" do
         it "returns the same bearer without an account id" do
-            result <- getNextToken (staticBearerProvider "router-key") Nothing
+            let provider = staticBearerProvider "router-key"
+            tokenProviderBillingMode provider `shouldBe` ApiBilled
+            result <- getNextToken provider Nothing
 
             case result of
                 Right credential -> do

--- a/packages/agent-openrouter/src/Agent/OpenRouter/Credential.hs
+++ b/packages/agent-openrouter/src/Agent/OpenRouter/Credential.hs
@@ -15,8 +15,7 @@ import System.Environment (lookupEnv)
 
 -- | A single OpenRouter API key with no OAuth refresh or account failover.
 staticApiKeyProvider :: Text -> TokenProvider
-staticApiKeyProvider apiKey = TokenProvider \failed ->
-    case failed of
+staticApiKeyProvider apiKey = tokenProvider ApiBilled \failed -> case failed of
         Nothing ->
             pure $ Right (credentialFromApiKey apiKey)
         Just FailedCredential { failure = AccountRateLimited { retryAfterSeconds } } -> do

--- a/packages/agent-openrouter/test/Agent/OpenRouter/CredentialSpec.hs
+++ b/packages/agent-openrouter/test/Agent/OpenRouter/CredentialSpec.hs
@@ -9,7 +9,9 @@ import Test.Hspec
 spec :: Spec
 spec = describe "staticApiKeyProvider" do
     it "returns the same bearer without an account id" do
-        result <- getNextToken (staticApiKeyProvider "or-key") Nothing
+        let provider = staticApiKeyProvider "or-key"
+        tokenProviderBillingMode provider `shouldBe` ApiBilled
+        result <- getNextToken provider Nothing
         case result of
             Right credential -> do
                 credential.accessToken `shouldBe` "or-key"

--- a/packages/agent-responses/test/Agent/Responses/LoopBackendSpec.hs
+++ b/packages/agent-responses/test/Agent/Responses/LoopBackendSpec.hs
@@ -4,9 +4,10 @@ import Agent.Error (ApiError(..), ErrorType(..))
 import Agent.Loop (Backend(..), TurnInput(..))
 import Agent.Provider
     ( Credential(..)
+    , BillingMode(..)
     , FailedCredential(..)
     , Provider(..)
-    , TokenProvider(..)
+    , tokenProvider
     )
 import Agent.Responses.LoopBackend (tokenProviderStatelessResponsesBackend)
 import Agent.Responses.Types (defaultResponseCreateParams)
@@ -21,7 +22,8 @@ spec = describe "tokenProviderStatelessResponsesBackend" do
         transcript <- newIORef []
         let first = credential "first"
             second = credential "second"
-            provider = TokenProvider \failed -> pure $ Right $ case failed of
+            provider = tokenProvider SubscriptionBilled \failed ->
+                pure $ Right $ case failed of
                 Nothing -> first
                 Just FailedCredential{} -> second
             send current _params _onEvent = do


### PR DESCRIPTION
## Summary

- make billing mode an explicit property of the core, opaque `TokenProvider`, so every credential source declares whether it is subscription- or API-billed
- partition OpenAI account pools by billing mode, prefer subscription accounts, and keep pool discovery within the selected mode
- classify OpenRouter as API-billed regardless of stored metadata, while preserving the correct modes for OpenAI and XAI credential sources
- prevent automatic fallback from a subscription-backed session to an API-billed provider, including chained retries and an auth reload recheck; explicit manual switching remains unrestricted

## Tests

- loaded all affected libraries in GHCi: 153 modules
- `agent-core`: 266 examples, 0 failures
- `agent-responses`: 9 examples, 0 failures
- `agent-openai`: 178 examples, 0 failures, 1 pending
- `agent-openrouter`: 38 examples, 0 failures, 1 pending
- `agent-xai`: 47 examples, 0 failures, 1 pending
- `agent-cli`: 561 examples, 0 failures
- `nix flake check`
