### PR TITLE
feat(cli): show active account in prompt status

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -16,7 +16,11 @@ module Agent.CLI
     ) where
 
 import Agent.CLI.Artifact (fencedCodeBlock, lastDiffBlock)
-import Agent.CLI.Auth (LoadedAuth(..), loadAuth, probeLoadedAuth)
+import Agent.CLI.Auth
+    ( LoadedAuth(..)
+    , loadAuth
+    , probeLoadedAuth
+    )
 import Agent.CLI.AgentViewport
     ( AgentEntry(..)
     , AgentStep
@@ -302,7 +306,7 @@ import Agent.Provider
     , Credential(..)
     , FailedCredential(..)
     , Provider(..)
-    , TokenProvider
+    , TokenProvider(..)
     , getNextToken
     , providerSlug
     )
@@ -879,6 +883,12 @@ runAgentInitialized options transition home root resumed cwd startup = do
                     <> " but auth resolved "
                     <> Text.unpack (providerSlug loaded.loadedProvider)
         _ -> pure ()
+    activeAccountRef <- newIORef ""
+    let tokenProvider =
+            trackCredentialAccount
+                activeAccountRef
+                loaded.loadedAccountLabel
+                loaded.loadedTokenProvider
 
     markStartupStage startup "Loading tools…"
     let basePlanHooks =
@@ -1081,7 +1091,7 @@ runAgentInitialized options transition home root resumed cwd startup = do
                 case provider of
                     OpenAIProvider ->
                         try @_ @CodexAuthFailed
-                            (withCodexWsWithProvider loaded.loadedTokenProvider \conn credential -> do
+                            (withCodexWsWithProvider tokenProvider \conn credential -> do
                                 wsLock <- newMVar ()
                                 wsHealthy <- newIORef True
                                 case multiCtx of
@@ -1096,7 +1106,7 @@ runAgentInitialized options transition home root resumed cwd startup = do
                                         lockedOpenAiSession
                                             options.optCompactThreshold
                                             wsLock
-                                            loaded.loadedTokenProvider
+                                            tokenProvider
                                             credential
                                             wsHealthy
                                             conn
@@ -1109,7 +1119,7 @@ runAgentInitialized options transition home root resumed cwd startup = do
                                             lockedBackend
                                     btwBackend privateParams privateTranscript =
                                         freshOpenAiBackend
-                                            loaded.loadedTokenProvider
+                                            tokenProvider
                                             (readIORef privateParams)
                                             privateTranscript
                                     compactRunner focus =
@@ -1122,7 +1132,7 @@ runAgentInitialized options transition home root resumed cwd startup = do
                                                     (Just compactSender)
                                                     recordCompactionUsage
                                                     provider
-                                                    (Just loaded.loadedTokenProvider)
+                                                    (Just tokenProvider)
                                                     paramsRef
                                                     transcriptRef)
                                                 focus
@@ -1130,8 +1140,8 @@ runAgentInitialized options transition home root resumed cwd startup = do
                                     prepareTransitionBackend
                                         projectRoot transition persist noticingBackend
                                 runSession options provider policy tools toolEnv planMode startup prompt pendingTurn transitionDraft unavailableProviders paramsRef transcriptRef initialTurns
-                                    previousRef persist projectRoot home cwd (Just loaded.loadedTokenProvider) loaded.loadedOpenAiPool startupContext skillsRef skillInvocationsRef escPaused interrupt
-                                    multiCtx rootTurnRef subagentSessions pendingNotices subagentStoreRoot usageRef claimCurrentSession compactRunner activeBackend btwBackend)
+                                    previousRef persist projectRoot home cwd (Just tokenProvider) loaded.loadedOpenAiPool startupContext skillsRef skillInvocationsRef escPaused interrupt
+                                    multiCtx rootTurnRef subagentSessions pendingNotices subagentStoreRoot usageRef activeAccountRef claimCurrentSession compactRunner activeBackend btwBackend)
                             >>= \case
                                 Left (CodexAuthFailed err) ->
                                     case transition of
@@ -1153,16 +1163,17 @@ runAgentInitialized options transition home root resumed cwd startup = do
                                         subagentRuntime
                                         XAIProvider
                                         (\childParamsRef childTranscript ->
-                                            xaiBackend xaiOptions loaded.loadedTokenProvider
+                                            xaiBackend xaiOptions
+                                                loaded.loadedTokenProvider
                                                 (readIORef childParamsRef) childTranscript)
                             Nothing -> pure ()
                         let backend =
                                 withPendingInputs pendingNotices $
                                     withConnectionRecovery $
-                                        xaiBackend xaiOptions loaded.loadedTokenProvider
+                                        xaiBackend xaiOptions tokenProvider
                                             (readIORef paramsRef) transcriptRef
                             btwBackend privateParams privateTranscript =
-                                xaiBackend xaiOptions loaded.loadedTokenProvider
+                                xaiBackend xaiOptions tokenProvider
                                     (readIORef privateParams) privateTranscript
                             compactRunner =
                                 installCompactOutcome previousRef transcriptRef Nothing $
@@ -1170,15 +1181,15 @@ runAgentInitialized options transition home root resumed cwd startup = do
                                         Nothing
                                         recordCompactionUsage
                                         provider
-                                        (Just loaded.loadedTokenProvider)
+                                        (Just tokenProvider)
                                         paramsRef
                                         transcriptRef
                         activeBackend <-
                             prepareTransitionBackend
                                 projectRoot transition persist backend
                         runSession options provider policy tools toolEnv planMode startup prompt pendingTurn transitionDraft unavailableProviders paramsRef transcriptRef initialTurns
-                            previousRef persist projectRoot home cwd (Just loaded.loadedTokenProvider) loaded.loadedOpenAiPool startupContext skillsRef skillInvocationsRef escPaused interrupt
-                            multiCtx rootTurnRef subagentSessions pendingNotices subagentStoreRoot usageRef claimCurrentSession compactRunner activeBackend btwBackend
+                            previousRef persist projectRoot home cwd (Just tokenProvider) loaded.loadedOpenAiPool startupContext skillsRef skillInvocationsRef escPaused interrupt
+                            multiCtx rootTurnRef subagentSessions pendingNotices subagentStoreRoot usageRef activeAccountRef claimCurrentSession compactRunner activeBackend btwBackend
                     OpenRouterProvider -> do
                         openRouterOptions <- OpenRouter.clientOptionsFromEnv
                         case multiCtx of
@@ -1188,16 +1199,17 @@ runAgentInitialized options transition home root resumed cwd startup = do
                                         subagentRuntime
                                         OpenRouterProvider
                                         (\childParamsRef childTranscript ->
-                                            openRouterBackend openRouterOptions loaded.loadedTokenProvider
+                                            openRouterBackend openRouterOptions
+                                                loaded.loadedTokenProvider
                                                 (readIORef childParamsRef) childTranscript)
                             Nothing -> pure ()
                         let backend =
                                 withPendingInputs pendingNotices $
                                     withConnectionRecovery $
-                                        openRouterBackend openRouterOptions loaded.loadedTokenProvider
+                                        openRouterBackend openRouterOptions tokenProvider
                                             (readIORef paramsRef) transcriptRef
                             btwBackend privateParams privateTranscript =
-                                openRouterBackend openRouterOptions loaded.loadedTokenProvider
+                                openRouterBackend openRouterOptions tokenProvider
                                     (readIORef privateParams) privateTranscript
                             compactRunner =
                                 installCompactOutcome previousRef transcriptRef Nothing $
@@ -1205,15 +1217,28 @@ runAgentInitialized options transition home root resumed cwd startup = do
                                         Nothing
                                         recordCompactionUsage
                                         provider
-                                        (Just loaded.loadedTokenProvider)
+                                        (Just tokenProvider)
                                         paramsRef
                                         transcriptRef
                         activeBackend <-
                             prepareTransitionBackend
                                 projectRoot transition persist backend
                         runSession options provider policy tools toolEnv planMode startup prompt pendingTurn transitionDraft unavailableProviders paramsRef transcriptRef initialTurns
-                            previousRef persist projectRoot home cwd (Just loaded.loadedTokenProvider) loaded.loadedOpenAiPool startupContext skillsRef skillInvocationsRef escPaused interrupt
-                            multiCtx rootTurnRef subagentSessions pendingNotices subagentStoreRoot usageRef claimCurrentSession compactRunner activeBackend btwBackend
+                            previousRef persist projectRoot home cwd (Just tokenProvider) loaded.loadedOpenAiPool startupContext skillsRef skillInvocationsRef escPaused interrupt
+                            multiCtx rootTurnRef subagentSessions pendingNotices subagentStoreRoot usageRef activeAccountRef claimCurrentSession compactRunner activeBackend btwBackend
+
+trackCredentialAccount
+    :: IORef Text
+    -> (Credential -> IO Text)
+    -> TokenProvider
+    -> TokenProvider
+trackCredentialAccount accountRef resolveLabel provider =
+    TokenProvider \failed ->
+        getNextToken provider failed >>= \case
+            Left err -> pure (Left err)
+            Right credential -> do
+                resolveLabel credential >>= writeIORef accountRef
+                pure (Right credential)
 
 preparePersistence
     :: Maybe FullscreenRuntime
@@ -1349,12 +1374,13 @@ runSession
     -> IORef [TurnInput]
     -> SubagentStoreRoot
     -> IORef TokenUsage
+    -> IORef Text
     -> (SessionHandle -> IO ())
     -> (Maybe Text -> IO (Either Text CompactOutcome))
     -> Backend
     -> BtwBackendFactory
     -> IO RunResult
-runSession options provider policy tools toolEnv planMode startup prompt pendingTurn initialDraft unavailableProviders paramsRef transcriptRef initialTurns previous persist projectRoot home cwd tokenProvider openAiPool startupContext skillsRef skillInvocationsRef escPaused interrupt multiCtx rootTurnRef subagentSessions pendingNotices storeRoot usageRef onPersisted compactRunner backend btwBackend = do
+runSession options provider policy tools toolEnv planMode startup prompt pendingTurn initialDraft unavailableProviders paramsRef transcriptRef initialTurns previous persist projectRoot home cwd tokenProvider openAiPool startupContext skillsRef skillInvocationsRef escPaused interrupt multiCtx rootTurnRef subagentSessions pendingNotices storeRoot usageRef accountRef onPersisted compactRunner backend btwBackend = do
   initialPrevious <- readIORef previous
   ioLock <- newMVar ()
   let fullscreen = startup.startupFullscreen
@@ -1660,6 +1686,7 @@ runSession options provider policy tools toolEnv planMode startup prompt pending
             , sessionRestartEffort = restartEffortRef
             , sessionStoreRoot = storeRoot
             , sessionUsage = usageRef
+            , sessionAccount = accountRef
             , sessionLastAssistant = lastAssistantRef
             , sessionTerminal = terminal
             , sessionFullscreen = fullscreen
@@ -1917,6 +1944,7 @@ replWithDraft env@SessionEnv
     , sessionEscPaused = escPaused
     , sessionStoreRoot = storeRoot
     , sessionUsage = usageRef
+    , sessionAccount = accountRef
     , sessionLastAssistant = lastAssistantRef
     , sessionTerminal = terminal
     , sessionFullscreen = fullscreen
@@ -1938,6 +1966,7 @@ replWithDraft env@SessionEnv
     pendingAttachments <- readIORef attachmentsRef
     let idleMode = replModeFromState planState policy
     usage <- readIORef usageRef
+    account <- readIORef accountRef
     mline <- case fullscreen of
         Just runtime -> do
             setFullscreenImagePreviews runtime pendingAttachments
@@ -1946,6 +1975,7 @@ replWithDraft env@SessionEnv
                     { promptModel = currentModel params
                     , promptEffort = currentEffort params
                     , promptMode = replModeLabel idleMode
+                    , promptAccount = account
                     , promptUsage = usage
                     , promptAttachments = length pendingAttachments
                     }
@@ -1975,6 +2005,7 @@ replWithDraft env@SessionEnv
                     (currentModel params)
                     (currentEffort params)
                     idleMode
+                    account
                     usage
                 hFlush stdout
             let modeTag

--- a/packages/agent-cli/src/Agent/CLI/Auth.hs
+++ b/packages/agent-cli/src/Agent/CLI/Auth.hs
@@ -2,6 +2,7 @@
 module Agent.CLI.Auth
     ( LoadedAuth(..)
     , GrokAuthState(..)
+    , credentialAccountLabel
     , grokCredentialFromAuthJson
     , grokAuthStateFromJson
     , grokAuthStateToJson
@@ -108,9 +109,47 @@ xaiOAuthClientId =
 data LoadedAuth = LoadedAuth
     { loadedProvider :: !Provider
     , loadedTokenProvider :: !TokenProvider
+    , loadedAccountLabel :: !(Credential -> IO Text)
     -- | Live OpenAI OAuth pool, when authentication uses one.
     , loadedOpenAiPool :: !(Maybe OpenAI.Pool)
     }
+
+-- | Human-readable identity for the credential most recently selected by a
+-- provider. Prefer an email claim, then fall back to a compact account id.
+credentialAccountLabel :: Credential -> Text
+credentialAccountLabel credential = case credential.provider of
+    OpenAIProvider ->
+        fromMaybe (fallback "ChatGPT") $
+            OpenAI.deriveEmail credential.accessToken
+    XAIProvider ->
+        fromMaybe (fallback "Grok") $
+            XAIAuth.emailFromToken credential.accessToken
+    OpenRouterProvider ->
+        fallback "OpenRouter"
+  where
+    accountId = Text.strip credential.accountId
+    fallback providerName
+        | Text.null accountId = providerName
+        | Text.length accountId <= 12 = accountId
+        | otherwise = Text.take 8 accountId <> "…"
+
+credentialAccountLabelWith :: Text -> Credential -> Text
+credentialAccountLabelWith preferred credential =
+    fromMaybe (credentialAccountLabel credential) $
+        credentialEmail credential <|> nonEmptyText preferred
+
+credentialEmail :: Credential -> Maybe Text
+credentialEmail credential = case credential.provider of
+    OpenAIProvider -> OpenAI.deriveEmail credential.accessToken
+    XAIProvider -> XAIAuth.emailFromToken credential.accessToken
+    OpenRouterProvider -> Nothing
+
+nonEmptyText :: Text -> Maybe Text
+nonEmptyText value
+    | Text.null trimmed = Nothing
+    | otherwise = Just trimmed
+  where
+    trimmed = Text.strip value
 
 data GrokAuthState = GrokAuthState
     { grokAccessToken :: !Text, grokRefreshToken :: !(Maybe Text)
@@ -188,6 +227,8 @@ loadXai = do
                 pure LoadedAuth
                     { loadedProvider = XAIProvider
                     , loadedTokenProvider = provider
+                    , loadedAccountLabel =
+                        pure . credentialAccountLabelWith metadata.managedLabel
                     , loadedOpenAiPool = Nothing
                     }
         Just (metadata, secret) ->
@@ -200,6 +241,8 @@ loadXai = do
                         , leaseId = Nothing
                         , provider = XAIProvider
                         }
+                , loadedAccountLabel =
+                    pure . credentialAccountLabelWith metadata.managedLabel
                 , loadedOpenAiPool = Nothing
                 }
         Nothing -> do
@@ -212,28 +255,45 @@ loadXai = do
                     pure LoadedAuth
                         { loadedProvider = XAIProvider
                         , loadedTokenProvider = provider
+                        , loadedAccountLabel = pure . credentialAccountLabel
                         , loadedOpenAiPool = Nothing
                         }
 
-loadOpenRouterKey :: IO (Maybe Text)
-loadOpenRouterKey = do
+loadOpenRouterCredential :: IO (Maybe (Credential, Text))
+loadOpenRouterCredential = do
     managed <- loadManagedCredential OpenRouterProvider
     case managed of
-        Just (_, secret) -> pure (Just secret.secretPayload)
-        Nothing -> lookupNonEmpty "OPENROUTER_API_KEY"
+        Just (metadata, secret) ->
+            pure $ Just
+                ( (credentialFromApiKey secret.secretPayload)
+                    { accountId = metadata.managedAccountId }
+                , metadata.managedLabel
+                )
+        Nothing ->
+            fmap (\key -> (credentialFromApiKey key, "")) <$>
+                lookupNonEmpty "OPENROUTER_API_KEY"
 
 loadOpenRouter :: ExceptT Text IO LoadedAuth
 loadOpenRouter = do
-    key <- lift loadOpenRouterKey
-    case key of
+    loadedCredential <- lift loadOpenRouterCredential
+    case loadedCredential of
         Nothing -> throwE noAuthHint
-        Just apiKey -> do
-            let initial = credentialFromApiKey apiKey
-            provider <- lift $ reloadableFileCredentialProvider OpenRouterProvider initial
-                (fmap (fmap credentialFromApiKey) loadOpenRouterKey)
+        Just (initial, initialLabel) -> do
+            provider <- lift $ reloadableFileCredentialProvider
+                OpenRouterProvider initial
+                (fmap (fmap fst) loadOpenRouterCredential)
             pure LoadedAuth
                 { loadedProvider = OpenRouterProvider
                 , loadedTokenProvider = provider
+                , loadedAccountLabel = \credential -> do
+                    current <- loadOpenRouterCredential
+                    let label = case current of
+                            Just (currentCredential, currentLabel)
+                                | currentCredential.accountId
+                                    == credential.accountId ->
+                                        currentLabel
+                            _ -> initialLabel
+                    pure (credentialAccountLabelWith label credential)
                 , loadedOpenAiPool = Nothing
                 }
 
@@ -259,6 +319,16 @@ loadOpenAi = do
     pure LoadedAuth
         { loadedProvider = OpenAIProvider
         , loadedTokenProvider = tokenProvider
+        , loadedAccountLabel = \credential -> do
+            currentAccounts <- readIORef accountSources
+            pure $ maybe
+                (credentialAccountLabel credential)
+                (.openAiLabel)
+                (find
+                    ((== credential.accountId)
+                        . (.accountId)
+                        . (.openAiState))
+                    currentAccounts)
         , loadedOpenAiPool = Just pool
         }
 
@@ -294,15 +364,21 @@ loadOpenAiAccounts = do
             partitionEithers (map (managedOpenAiAccount now) enabledManaged)
         managedAccountIds =
             map ((.accountId) . (.openAiState)) managedAccounts
-        envJsonAccount =
-            OpenAiAccount
-                <$> (fromEnvJson >>= openaiAuthStateFromJson now
-                    . LBS.fromStrict . TextEncoding.encodeUtf8)
-                <*> pure OpenAiEnvironmentOAuth
-        fileAccount =
-            OpenAiAccount
-                <$> (fileBytes >>= openaiAuthStateFromJson now)
-                <*> pure (OpenAiAuthFile filePath)
+        envJsonAccount = do
+            state <- fromEnvJson >>= openaiAuthStateFromJson now
+                . LBS.fromStrict . TextEncoding.encodeUtf8
+            pure OpenAiAccount
+                { openAiState = state
+                , openAiSource = OpenAiEnvironmentOAuth
+                , openAiLabel = openAiStateLabel "ChatGPT" state
+                }
+        fileAccount = do
+            state <- fileBytes >>= openaiAuthStateFromJson now
+            pure OpenAiAccount
+                { openAiState = state
+                , openAiSource = OpenAiAuthFile filePath
+                , openAiLabel = openAiStateLabel "ChatGPT" state
+                }
         externalAccounts =
             filter
                 (\account ->
@@ -342,6 +418,7 @@ data OpenAiCredentialSource
 data OpenAiAccount = OpenAiAccount
     { openAiState :: !OpenAI.AuthState
     , openAiSource :: !OpenAiCredentialSource
+    , openAiLabel :: !Text
     }
 
 managedOpenAiAccount
@@ -369,12 +446,22 @@ managedOpenAiAccount now (metadata, secret) =
                             { openAiState = state
                             , openAiSource =
                                 OpenAiManagedOAuth metadata.managedId
+                            , openAiLabel =
+                                openAiStateLabel metadata.managedLabel state
                             }
         _ ->
             Right OpenAiAccount
                 { openAiState = staticOpenAiState
                     now metadata.managedAccountId secret.secretPayload
                 , openAiSource = OpenAiManagedBearer
+                , openAiLabel = fromMaybe
+                    (credentialAccountLabel Credential
+                        { accessToken = secret.secretPayload
+                        , accountId = metadata.managedAccountId
+                        , leaseId = Nothing
+                        , provider = OpenAIProvider
+                        })
+                    (nonEmptyText metadata.managedLabel)
                 }
 
 openAiStaticAccount :: UTCTime -> Text -> IO OpenAiAccount
@@ -383,7 +470,29 @@ openAiStaticAccount now token = do
     pure OpenAiAccount
         { openAiState = staticOpenAiState now accountId token
         , openAiSource = OpenAiEnvironmentBearer
+        , openAiLabel =
+            credentialAccountLabel Credential
+                { accessToken = token
+                , accountId
+                , leaseId = Nothing
+                , provider = OpenAIProvider
+                }
         }
+
+openAiStateLabel :: Text -> OpenAI.AuthState -> Text
+openAiStateLabel preferred state =
+    fromMaybe fallback $
+        (state.idToken >>= OpenAI.deriveEmail)
+            <|> OpenAI.deriveEmail state.accessToken
+            <|> nonEmptyText preferred
+  where
+    fallback =
+        credentialAccountLabel Credential
+            { accessToken = state.accessToken
+            , accountId = state.accountId
+            , leaseId = Nothing
+            , provider = OpenAIProvider
+            }
 
 staticOpenAiState :: UTCTime -> Text -> Text -> OpenAI.AuthState
 staticOpenAiState now accountId accessToken =

--- a/packages/agent-cli/src/Agent/CLI/SessionEnv.hs
+++ b/packages/agent-cli/src/Agent/CLI/SessionEnv.hs
@@ -56,6 +56,7 @@ data SessionEnv = SessionEnv
     , sessionRestartEffort :: !(IORef (Maybe Text))
     , sessionStoreRoot :: !(IORef (Maybe OsPath))
     , sessionUsage :: !(IORef TokenUsage)
+    , sessionAccount :: !(IORef Text)
     , sessionLastAssistant :: !(IORef (Maybe Text))
     , sessionTerminal :: !TerminalCapabilities
     , sessionFullscreen :: !(Maybe FullscreenRuntime)

--- a/packages/agent-cli/src/Agent/CLI/Status.hs
+++ b/packages/agent-cli/src/Agent/CLI/Status.hs
@@ -28,18 +28,21 @@ import Data.IORef (IORef, readIORef, writeIORef)
 import Data.Text (Text)
 import qualified Data.Text as Text
 
--- | Idle prompt chrome: model, reasoning effort, interaction mode on the
--- left; session token totals right-aligned when the TTY width is known.
+-- | Idle prompt chrome: model, reasoning effort, interaction mode, and active
+-- account on the left; session token totals right-aligned when possible.
 formatReplStatusLine
     :: Bool
     -> Maybe Int
     -> Text
     -> Text
     -> ReplMode
+    -> Text
     -> TokenUsage
     -> Text
-formatReplStatusLine color width model effort mode usage =
-    let left = "  " <> model <> " · " <> effort <> " · " <> replModeLabel mode
+formatReplStatusLine color width model effort mode account usage =
+    let left =
+            "  " <> Text.intercalate " · " (filter (not . Text.null)
+                [model, effort, replModeLabel mode, account])
         right = formatTokenUsage usage
         padded = case width of
             Just cols | cols > 0 ->

--- a/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
@@ -346,9 +346,13 @@ drawComposerStatus state =
                 <> [ modeControl
                    | not (Text.null mode)
                    ]
+                <> [ withAttr Theme.mutedAttr (txt account)
+                   | not (Text.null account)
+                   ]
   where
     prompt = state.appUi.uiPrompt
     mode = prompt.promptMode
+    account = prompt.promptAccount
     modelControl =
         clickable ComposerModel $
             forceAttr

--- a/packages/agent-cli/test/Agent/CLI/AuthSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/AuthSpec.hs
@@ -55,12 +55,45 @@ spec = do
                     { loadedProvider = XAIProvider
                     , loadedTokenProvider = TokenProvider \_ ->
                         pure (Left (CredentialsExhausted retryAt))
+                    , loadedAccountLabel = pure . credentialAccountLabel
                     , loadedOpenAiPool = Nothing
                     }
             result <- probeLoadedAuth exhausted
             case result of
                 Left err -> err `shouldBe` CredentialsExhausted retryAt
                 Right _ -> expectationFailure "expected exhausted auth"
+
+    describe "credentialAccountLabel" do
+        it "prefers an email claim over the provider account id" do
+            let token =
+                    "e30.eyJlbWFpbCI6InBlcnNvbkBleGFtcGxlLmNvbSJ9."
+            credentialAccountLabel
+                Credential
+                    { accessToken = token
+                    , accountId = "acc-1234567890"
+                    , leaseId = Nothing
+                    , provider = OpenAIProvider
+                    }
+                `shouldBe` "person@example.com"
+
+        it "shortens opaque account ids and names key-only providers" do
+            credentialAccountLabel staleGrok `shouldBe` "acc-stale"
+            credentialAccountLabel
+                Credential
+                    { accessToken = "key"
+                    , accountId = "account-1234567890"
+                    , leaseId = Nothing
+                    , provider = OpenRouterProvider
+                    }
+                `shouldBe` "account-…"
+            credentialAccountLabel
+                Credential
+                    { accessToken = "key"
+                    , accountId = ""
+                    , leaseId = Nothing
+                    , provider = OpenRouterProvider
+                    }
+                `shouldBe` "OpenRouter"
 
     describe "OpenAI account pools" do
         it "loads every enabled managed account into one pool" $
@@ -73,6 +106,8 @@ spec = do
             withTempHome openAiDeduplicationTest
         it "does not let a disabled managed source shadow ~/.codex" $
             withTempHome openAiDisabledSourceTest
+        it "uses the login email as the active account label" $
+            withTempHome openAiAccountLabelTest
 
     describe "openAIOAuthClientId" do
         it "uses the Codex public client id by default" do
@@ -353,6 +388,37 @@ openAiDisabledSourceTest home =
         pool <- expectOpenAiPool loaded
         snapshots <- OpenAI.snapshotAccounts pool
         map ((.accessToken) . (.snapshotAuth)) snapshots `shouldBe` ["file-token"]
+
+openAiAccountLabelTest :: OsPath -> IO ()
+openAiAccountLabelTest home =
+    withCleanOpenAiEnv do
+        let codexDirectory = toFilePath home </> ".codex"
+            accessToken :: Text
+            accessToken = "e30.eyJleHAiOjQxMDI0NDQ4MDB9."
+            idToken :: Text
+            idToken =
+                "e30.eyJlbWFpbCI6InBlcnNvbkBleGFtcGxlLmNvbSJ9."
+        createDirectoryIfMissing True codexDirectory
+        LBS.writeFile
+            (codexDirectory </> "auth.json")
+            (Aeson.encode $ Aeson.object
+                [ "tokens" .= Aeson.object
+                    [ "access_token" .= accessToken
+                    , "refresh_token" .= ("refresh" :: Text)
+                    , "account_id" .= ("acc-email" :: Text)
+                    , "id_token" .= idToken
+                    ]
+                ])
+        loadAuth (Just OpenAIProvider) >>= \case
+            Left err -> expectationFailure (Text.unpack err)
+            Right loaded ->
+                getNextToken loaded.loadedTokenProvider Nothing >>= \case
+                    Left err ->
+                        expectationFailure
+                            ("expected credential, got " <> show err)
+                    Right credential ->
+                        loaded.loadedAccountLabel credential
+                            `shouldReturn` "person@example.com"
 
 expectOpenAiPool :: Either Text LoadedAuth -> IO OpenAI.Pool
 expectOpenAiPool = \case

--- a/packages/agent-cli/test/Agent/CLI/ReplStatusSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ReplStatusSpec.hs
@@ -88,38 +88,41 @@ spec = do
                 getCurrentDirectory `shouldReturn` original
 
     describe "formatReplStatusLine" do
-        it "shows model, effort, and interaction mode" do
-            formatReplStatusLine False Nothing "grok-4.6" "high" ReplModeNormal emptyTokenUsage
-                `shouldBe` "  grok-4.6 · high · ask"
-            formatReplStatusLine False Nothing "gpt-5.1-codex" "medium" ReplModeAlwaysApprove emptyTokenUsage
+        it "shows model, effort, interaction mode, and active account" do
+            formatReplStatusLine False Nothing "grok-4.6" "high"
+                ReplModeNormal "person@example.com" emptyTokenUsage
+                `shouldBe` "  grok-4.6 · high · ask · person@example.com"
+            formatReplStatusLine False Nothing "gpt-5.1-codex" "medium"
+                ReplModeAlwaysApprove "" emptyTokenUsage
                 `shouldBe` "  gpt-5.1-codex · medium · yolo"
-            formatReplStatusLine False Nothing "gpt-5.1" "low" ReplModePlan emptyTokenUsage
+            formatReplStatusLine False Nothing "gpt-5.1" "low"
+                ReplModePlan "" emptyTokenUsage
                 `shouldBe` "  gpt-5.1 · low · plan"
 
         it "appends session usage when no width is known" do
-            formatReplStatusLine False Nothing "grok-4.6" "high" ReplModeNormal
+            formatReplStatusLine False Nothing "grok-4.6" "high" ReplModeNormal ""
                 TokenUsage { inputTokens = 1200, outputTokens = 340, cachedTokens = 0 }
                 `shouldBe` "  grok-4.6 · high · ask  1.2k in · 340 out"
 
         it "right-aligns session usage when the TTY is wide enough" do
-            formatReplStatusLine False (Just 48) "grok-4.6" "high" ReplModeNormal
+            formatReplStatusLine False (Just 48) "grok-4.6" "high" ReplModeNormal ""
                 TokenUsage { inputTokens = 1200, outputTokens = 340, cachedTokens = 0 }
                 `shouldBe` "  grok-4.6 · high · ask        1.2k in · 340 out"
 
         it "drops usage rather than wrapping when only the state fits" do
-            formatReplStatusLine False (Just 24) "grok-4.6" "high" ReplModeNormal
+            formatReplStatusLine False (Just 24) "grok-4.6" "high" ReplModeNormal ""
                 TokenUsage { inputTokens = 1200, outputTokens = 340, cachedTokens = 0 }
                 `shouldBe` "  grok-4.6 · high · ask"
 
         it "truncates the state when a narrow pane cannot fit it" do
-            formatReplStatusLine False (Just 20) "grok-4.6" "high" ReplModeNormal
+            formatReplStatusLine False (Just 20) "grok-4.6" "high" ReplModeNormal ""
                 TokenUsage { inputTokens = 1200, outputTokens = 340, cachedTokens = 0 }
                 `shouldBe` "  grok-4.6 · high ·…"
 
         it "measures and truncates wide model names in terminal columns" do
             let line =
                     formatReplStatusLine False (Just 16) "模型模型" "high"
-                        ReplModeNormal emptyTokenUsage
+                        ReplModeNormal "" emptyTokenUsage
             terminalTextWidth line `shouldBe` 16
             line `shouldBe` "  模型模型 · hi…"
 

--- a/packages/agent-tui/src/Agent/TUI/Model.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model.hs
@@ -122,6 +122,7 @@ data PromptState = PromptState
     { promptModel :: !Text
     , promptEffort :: !Text
     , promptMode :: !Text
+    , promptAccount :: !Text
     , promptUsage :: !TokenUsage
     , promptAttachments :: !Int
     }
@@ -199,6 +200,7 @@ initialUiState = UiState
         { promptModel = ""
         , promptEffort = ""
         , promptMode = "ask"
+        , promptAccount = ""
         , promptUsage = emptyTokenUsage
         , promptAttachments = 0
         }


### PR DESCRIPTION
## Summary

- track the credential most recently selected for the root session, including account failover
- show its email, configured label, shortened account ID, or provider fallback next to model, reasoning effort, and mode
- render the account in both the fullscreen composer border and minimal CLI status line
- keep subagent credential activity from changing the root session account indicator

## Testing

- `nix develop -c cabal repl agent-cli:test:agent-cli-test`, then `:main` — 548 examples, 0 failures
- `nix develop -c cabal repl agent-tui:test:agent-tui-test`, then `:main` — 47 examples, 0 failures
- live tmux smoke test confirmed the account label renders at the far right of the fullscreen composer border
