### PR TITLE
perf(tui): load syntax highlighting asynchronously

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -432,6 +432,7 @@ data StartupRuntime = StartupRuntime
     , startupRestartEffort :: !(IORef (Text -> IO ()))
     , startupStartedAt :: !UTCTime
     , startupTimings :: !(IORef [(Text, NominalDiffTime)])
+    , startupSyntaxLoadDuration :: !(IORef (Maybe NominalDiffTime))
     }
 
 newtype StartupFailure = StartupFailure String
@@ -648,7 +649,17 @@ finishStartup startup = do
             emitUiEvent runtime (UiSetNotice Nothing)
     lookupEnv "HASKELL_AGENT_STARTUP_TIMING" >>= \case
         Just "1" -> do
-            message <- formatStartupTimings <$> readIORef startup.startupTimings
+            timings <- readIORef startup.startupTimings
+            syntaxLoadDuration <-
+                readIORef startup.startupSyntaxLoadDuration
+            let message =
+                    formatStartupTimings timings
+                        <> maybe
+                            ""
+                            (\duration ->
+                                " · syntax highlighting "
+                                    <> formatStartupDuration duration)
+                            syntaxLoadDuration
             case startup.startupFullscreen of
                 Nothing -> putTextLn stderr message
                 Just runtime -> emitUiEvent runtime (UiSystemMessage message)
@@ -709,6 +720,7 @@ runAgent
 runAgent fullscreenInputs options transition = do
     startedAt <- getCurrentTime
     startupTimingsRef <- newIORef []
+    syntaxLoadDurationRef <- newIORef Nothing
     home <- getHomeDirectory
     let root = sessionsRoot home
     resumed <- case options.optResume of
@@ -788,6 +800,7 @@ runAgent fullscreenInputs options transition = do
             (readIORef agentSnapshotRef >>= id)
             (\target -> readIORef agentSelectRef >>= ($ target))
             (recordStartupTiming startedAt startupTimingsRef "first frame")
+            (writeIORef syntaxLoadDurationRef . Just)
             options.optMotionMode
             useColor
             initialFullscreenState
@@ -809,6 +822,7 @@ runAgent fullscreenInputs options transition = do
             , startupRestartEffort = restartEffortActionRef
             , startupStartedAt = startedAt
             , startupTimings = startupTimingsRef
+            , startupSyntaxLoadDuration = syntaxLoadDurationRef
             }
         action =
             runAgentInitialized

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -16,6 +16,8 @@ module Agent.CLI.TUI.App
     , nextMotionSchedule
     , newFullscreenInputBuffer
     , newFullscreenRuntime
+    , newFullscreenRuntimeWithSyntaxLoader
+    , loadSyntaxHighlighterForRuntime
     , queuedFullscreenInputDisplays
     , readFullscreenLine
     , repositoryHeaderText
@@ -101,7 +103,8 @@ import Agent.TUI.Markdown
     , markdownWidgetWithSyntaxHighlighting
     )
 import Agent.Syntax
-    ( loadSyntaxHighlighter
+    ( SyntaxHighlighter
+    , loadSyntaxHighlighter
     )
 import qualified Agent.CLI.TUI.Scroll as Scroll
 import Agent.CLI.TUI.Types
@@ -166,7 +169,7 @@ import qualified Data.Sequence as Seq
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
-import Data.Time.Clock (UTCTime)
+import Data.Time.Clock (NominalDiffTime, UTCTime)
 import Data.Time.Clock.POSIX (getPOSIXTime)
 import Data.Time.Format (defaultTimeLocale, formatTime)
 import Data.Word (Word64)
@@ -191,11 +194,33 @@ newFullscreenRuntime
     -> IO (AgentTarget, [AgentEntry])
     -> (AgentTarget -> IO ())
     -> IO ()
+    -> (NominalDiffTime -> IO ())
     -> MotionMode
     -> Bool
     -> UiState
     -> IO FullscreenRuntime
-newFullscreenRuntime
+newFullscreenRuntime =
+    newFullscreenRuntimeWithSyntaxLoader loadSyntaxHighlighter
+
+newFullscreenRuntimeWithSyntaxLoader
+    :: IO (Either Text SyntaxHighlighter)
+    -> FullscreenInputBuffer
+    -> IO ()
+    -> (Text -> IO ())
+    -> IO CtrlCDecision
+    -> (Text -> IO Bool)
+    -> (Text -> IO ())
+    -> (Bool -> IO ())
+    -> IO (AgentTarget, [AgentEntry])
+    -> (AgentTarget -> IO ())
+    -> IO ()
+    -> (NominalDiffTime -> IO ())
+    -> MotionMode
+    -> Bool
+    -> UiState
+    -> IO FullscreenRuntime
+newFullscreenRuntimeWithSyntaxLoader
+    syntaxLoader
     inputBuffer
     cancelAction
     restartEffortAction
@@ -206,6 +231,7 @@ newFullscreenRuntime
     agentSnapshot
     agentSelect
     firstFrame
+    syntaxLoadFinished
     motionMode
     color
     initial = do
@@ -219,8 +245,6 @@ newFullscreenRuntime
         imagePreviewIdBase <- allocateNativePreviewImageIdBase
         imagePreviewProtocol <- detectImagePreviewProtocol stdout
         imagePreviewInTmux <- isJust <$> lookupEnv "TMUX"
-        syntaxHighlighter <-
-            either (const Nothing) Just <$> loadSyntaxHighlighter
         pure FullscreenRuntime
             { runtimeEvents = events
             , runtimeMailbox = mailbox
@@ -245,9 +269,28 @@ newFullscreenRuntime
                 imagePreviewProtocol == PreviewKitty
                     && not imagePreviewInTmux
             , runtimeColor = color
-            , runtimeSyntaxHighlighter = syntaxHighlighter
+            , runtimeLoadSyntaxHighlighter = syntaxLoader
+            , runtimeSyntaxLoadFinished = syntaxLoadFinished
             , runtimeInitial = initial
             }
+
+loadSyntaxHighlighterForRuntime :: FullscreenRuntime -> IO ()
+loadSyntaxHighlighterForRuntime runtime = do
+    startedAt <- getMonotonicTimeNSec
+    result <- tryAny runtime.runtimeLoadSyntaxHighlighter
+    finishedAt <- getMonotonicTimeNSec
+    let highlighter = case result of
+            Left _ -> Nothing
+            Right loaded -> either (const Nothing) Just loaded
+    enqueueAppEvent runtime (AppSyntaxHighlighterLoaded highlighter)
+    void $
+        tryAny $
+            runtime.runtimeSyntaxLoadFinished
+                (nanosecondsToNominalDiffTime (finishedAt - startedAt))
+
+nanosecondsToNominalDiffTime :: Word64 -> NominalDiffTime
+nanosecondsToNominalDiffTime nanoseconds =
+    realToFrac nanoseconds / 1_000_000_000
 
 emitUiEvent :: FullscreenRuntime -> UiEvent -> IO ()
 emitUiEvent runtime event =
@@ -435,6 +478,7 @@ runFullscreen runtime workerAction = do
             , appMotionScheduleReset = False
             , appClockNanos = initialClock
             , appNativeProgressKeepaliveBucket = 0
+            , appSyntaxHighlighter = Nothing
             }
         (initialDemand, initialDelay) =
             appMotionTiming initialState
@@ -447,27 +491,34 @@ runFullscreen runtime workerAction = do
             withAsync (agentTicker (initialAgent, initialAgents)) \_agentTicker ->
                 withAsync (eventPump runtime) \_eventPump ->
                     withAsync
-                        (void (waitCatch worker)
-                            >> enqueueAppEvent runtime AppStop)
-                        \_notifier -> do
-                            finalState <-
-                                customMain
-                                    initialVty
-                                    buildVty
-                                    (Just runtime.runtimeEvents)
-                                    fullscreenApp
-                                    initialState
-                                `finally` runtime.runtimeNativeProgress False
-                            when (not finalState.appWorkerStopped) $
-                                atomically $
-                                    Composer.appendFullscreenInput
-                                        runtime.runtimeInput
-                                        FullscreenInput
-                                            { fullscreenInputLine = ReplEof
-                                            , fullscreenInputQueued = False
-                                            , fullscreenInputDisplay = Nothing
-                                            }
-                            wait worker
+                        (loadSyntaxHighlighterForRuntime runtime)
+                        \_syntaxLoader ->
+                            withAsync
+                                (void (waitCatch worker)
+                                    >> enqueueAppEvent runtime AppStop)
+                                \_notifier -> do
+                                    finalState <-
+                                        customMain
+                                            initialVty
+                                            buildVty
+                                            (Just runtime.runtimeEvents)
+                                            fullscreenApp
+                                            initialState
+                                        `finally`
+                                            runtime.runtimeNativeProgress False
+                                    when (not finalState.appWorkerStopped) $
+                                        atomically $
+                                            Composer.appendFullscreenInput
+                                                runtime.runtimeInput
+                                                FullscreenInput
+                                                    { fullscreenInputLine =
+                                                        ReplEof
+                                                    , fullscreenInputQueued =
+                                                        False
+                                                    , fullscreenInputDisplay =
+                                                        Nothing
+                                                    }
+                                    wait worker
   where
     uiTicker = waitForDemand
       where
@@ -2151,7 +2202,7 @@ drawBlock state block =
                 padLeft (Pad 3) $
                     withAttr Theme.assistantAttr
                         (markdownWidgetWithSyntaxHighlighting
-                            state.appRuntime.runtimeSyntaxHighlighter
+                            state.appSyntaxHighlighter
                             (\codeIndex ->
                                 cached
                                     (CodeBlockCache
@@ -3019,6 +3070,13 @@ handleEventInner event = case event of
         state <- get
         liftIO (state.appRuntime.runtimeSetWindowTitle title)
         modify' \current -> current { appWindowTitle = Just title }
+    AppEvent (AppSyntaxHighlighterLoaded highlighter) ->
+        case highlighter of
+            Nothing -> pure ()
+            Just loaded -> do
+                modify' \current ->
+                    current { appSyntaxHighlighter = Just loaded }
+                invalidateCache
     AppEvent (AppAgentSnapshot selected entries) -> do
         state <- get
         let normalized =

--- a/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
@@ -36,6 +36,7 @@ import Data.List.NonEmpty (NonEmpty)
 import qualified Data.Map.Strict as Map
 import Data.Sequence (Seq)
 import Data.Text (Text)
+import Data.Time.Clock (NominalDiffTime)
 import Data.Word (Word64)
 
 data Name
@@ -92,6 +93,7 @@ data AppEvent
     | AppSetImagePreviews ![ImageAttachment]
     | AppAgentSnapshot !AgentTarget ![AgentEntry]
     | AppSetWindowTitle !Text
+    | AppSyntaxHighlighterLoaded !(Maybe SyntaxHighlighter)
     | AppConversationReflow
     | AppMotionTick
     | AppStop
@@ -139,7 +141,9 @@ data FullscreenRuntime = FullscreenRuntime
     , runtimeImagePreviewIdBase :: !Int
     , runtimeNativeImagePreviews :: !Bool
     , runtimeColor :: !Bool
-    , runtimeSyntaxHighlighter :: !(Maybe SyntaxHighlighter)
+    , runtimeLoadSyntaxHighlighter
+        :: !(IO (Either Text SyntaxHighlighter))
+    , runtimeSyntaxLoadFinished :: !(NominalDiffTime -> IO ())
     , runtimeInitial :: !UiState
     }
 
@@ -178,6 +182,7 @@ data AppState = AppState
     , appMotionScheduleReset :: !Bool
     , appClockNanos :: !Word64
     , appNativeProgressKeepaliveBucket :: !Int
+    , appSyntaxHighlighter :: !(Maybe SyntaxHighlighter)
     }
 
 data AgentHover = AgentHover

--- a/packages/agent-cli/test/Agent/CLI/TUIBridgeSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIBridgeSpec.hs
@@ -4,16 +4,28 @@ import Agent.CLI.AgentViewport (AgentEntry(..), AgentTarget(..))
 import Agent.CLI.Interrupt (CtrlCDecision(..))
 import Agent.CLI.TUI.App
     ( emitUiEvent
+    , loadSyntaxHighlighterForRuntime
     , newFullscreenInputBuffer
     , newFullscreenRuntime
+    , newFullscreenRuntimeWithSyntaxLoader
     )
 import Agent.CLI.TUI.Bridge
+import Agent.CLI.TUI.Types
+    ( AppEvent(..)
+    , AppEventMailbox(..)
+    , FullscreenRuntime(..)
+    , PendingAppEvent(..)
+    )
 import Agent.TUI.Model
 import Agent.Loop (LoopEvent(..), emptyTurnOutput)
 import Agent.Subagents (SubagentId(..))
 import Agent.ToolDispatch (functionToolCall)
 import Agent.TUI.Motion (MotionMode(..))
+import Control.Concurrent.STM (readTVarIO)
+import Control.Exception.Safe (throwString)
 import Control.Monad (replicateM_)
+import Data.Foldable (toList)
+import Data.IORef (newIORef, readIORef, writeIORef)
 import System.Timeout (timeout)
 import qualified Graphics.Vty as V
 import Test.Hspec
@@ -96,6 +108,7 @@ spec = describe "fullscreen TUI bridge" do
             (pure (AgentRoot, []))
             (const (pure ()))
             (pure ())
+            (const (throwString "syntax timing failed"))
             MotionFull
             False
             initialUiState
@@ -104,6 +117,53 @@ spec = describe "fullscreen TUI bridge" do
                 emitUiEvent runtime (UiLoop (TextDelta "x"))
                 emitUiEvent runtime (UiLoop TurnStarted)
         completed `shouldBe` Just ()
+
+    it "defers syntax loading until the runtime starts it" do
+        input <- newFullscreenInputBuffer
+        loaderCalled <- newIORef False
+        durationRef <- newIORef Nothing
+        runtime <- newFullscreenRuntimeWithSyntaxLoader
+            (writeIORef loaderCalled True >> pure (Left "unavailable"))
+            input
+            (pure ())
+            (const (pure ()))
+            (pure WarnExit)
+            (const (pure True))
+            (const (pure ()))
+            (const (pure ()))
+            (pure (AgentRoot, []))
+            (const (pure ()))
+            (pure ())
+            (writeIORef durationRef . Just)
+            MotionFull
+            False
+            initialUiState
+        readIORef loaderCalled `shouldReturn` False
+        loadSyntaxHighlighterForRuntime runtime
+        readIORef loaderCalled `shouldReturn` True
+        readIORef durationRef >>= (`shouldSatisfy` maybe False (>= 0))
+        hasPendingUnavailableSyntax runtime `shouldReturn` True
+
+    it "contains unexpected syntax loader and timing failures" do
+        input <- newFullscreenInputBuffer
+        runtime <- newFullscreenRuntimeWithSyntaxLoader
+            (throwString "syntax loader failed")
+            input
+            (pure ())
+            (const (pure ()))
+            (pure WarnExit)
+            (const (pure True))
+            (const (pure ()))
+            (const (pure ()))
+            (pure (AgentRoot, []))
+            (const (pure ()))
+            (pure ())
+            (const (pure ()))
+            MotionFull
+            False
+            initialUiState
+        loadSyntaxHighlighterForRuntime runtime
+        hasPendingUnavailableSyntax runtime `shouldReturn` True
 
     it "moves through history and restores the original draft" do
         historyMove 1 ["new", "old"] Nothing "draft" ""
@@ -133,3 +193,11 @@ spec = describe "fullscreen TUI bridge" do
             `shouldBe` AgentRoot
         reconcileAgentSelection [AgentRoot, other] other
             `shouldBe` other
+
+hasPendingUnavailableSyntax :: FullscreenRuntime -> IO Bool
+hasPendingUnavailableSyntax runtime = do
+    let AppEventMailbox pendingRef = runtime.runtimeMailbox
+    pending <- readTVarIO pendingRef
+    pure case toList pending of
+        [PendingEvent (AppSyntaxHighlighterLoaded Nothing)] -> True
+        _ -> False


### PR DESCRIPTION
## Summary

- return the fullscreen runtime without synchronously parsing syntax grammars
- load the syntax highlighter in a structured background task owned by the TUI lifecycle
- install the highlighter through the Brick event mailbox and invalidate cached conversation/code widgets
- keep flat rendering on load failures and contain unexpected loader/timing callback exceptions
- record syntax load duration for startup timing diagnostics

## Validation

- `nix develop -c cabal test agent-syntax-test agent-tui-test agent-cli-test --test-show-details=direct`
  - agent-syntax: 9 examples
  - agent-tui: 47 examples
  - agent-cli: 547 examples
- `nix build .#agent-cli`
- `nix flake check --no-build`
- tmux smoke with an injected 2-second loader delay: the first frame rendered the cached fence flat, then `putStrLn`, `Just`, and the numeric literal gained syntax colors after the completion event/cache invalidation
