### PR TITLE
fix(tools): restore wait_agent reserved schema

### DIFF
--- a/packages/agent-cli/test/Agent/CLI/ToolsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ToolsSpec.hs
@@ -1,23 +1,34 @@
 module Agent.CLI.ToolsSpec (spec) where
 
 import Agent.CLI.Tools
+import Agent.Loop (LoopError(..))
 import Agent.Responses.Types
 import Agent.Provider (Provider(..))
+import Agent.Subagents
+    ( SubagentRegistry
+    , closeSubagentRegistry
+    , defaultSubagentConfig
+    , newSubagentRegistry
+    )
+import Agent.Subagents.TaskPath (taskPathRoot)
 import Agent.ToolDispatch (noArgsTool)
 import Agent.ToolDSL (PropertySchema(..), PropertyType(..))
 import Agent.Tools.ApplyPatch (applyPatchGrammar)
+import Agent.Tools.MultiAgents (MultiAgentContext(..), multiAgentTools)
 import Agent.Tools.Types
-    ( AppTool
+    ( AppTool(..)
     , ApprovalRule(..)
     , freeformApplyPatchAppTool
     , jsonAppTool
     )
+import Control.Exception.Safe (bracket)
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KeyMap
 import Data.Foldable (toList)
 import Data.Text (Text)
 import qualified Data.Text as Text
+import System.OsPath (unsafeEncodeUtf)
 import Test.Hspec
 
 spec :: Spec
@@ -75,25 +86,44 @@ spec = describe "schemasFromAppTools" do
                     `shouldBe` Just (Aeson.String "collaboration")
             other -> expectationFailure ("expected namespace tool, got " <> show other)
 
-    it "omits an empty required list from reserved collaboration schemas" do
-        let wait = jsonAppTool "wait_agent" "Wait."
-                [ PropertySchema "timeout_ms" PropertyNumber False Nothing ]
-                AlwaysReadOnly
-                (noArgsTool "wait_agent" (pure (Right "ok")))
-        case schemasFromAppTools OpenAIProvider [wait] of
-            [_, KnownResponseTool ToolNamespace tagged] ->
-                case KeyMap.lookup "tools" tagged.fields of
-                    Just (Aeson.Array tools) -> case toList tools of
-                        [Aeson.Object tool] -> do
-                            Just (Aeson.Object parameters) <-
-                                pure (KeyMap.lookup "parameters" tool)
-                            KeyMap.lookup "required" parameters `shouldBe` Nothing
+    it "preserves the configured schema for the reserved wait_agent tool" do
+        bracket newRegistry closeSubagentRegistry \registry -> do
+            let context = MultiAgentContext
+                    { multiRegistry = registry
+                    , multiSelfId = Nothing
+                    , multiDepth = 0
+                    , multiTaskPath = taskPathRoot
+                    , multiRootTurnId = pure Nothing
+                    , multiResumeFromDisk = Nothing
+                    , multiCreateWorktree = Nothing
+                    , multiPrepareSpawn = Nothing
+                    , multiSendToRoot = Nothing
+                    }
+                wait =
+                    filter
+                        (\tool -> tool.appToolName == ("wait_agent" :: Text))
+                        (multiAgentTools context)
+            case schemasFromAppTools OpenAIProvider wait of
+                [_, KnownResponseTool ToolNamespace tagged] ->
+                    case KeyMap.lookup "tools" tagged.fields of
+                        Just (Aeson.Array tools) -> case toList tools of
+                            [Aeson.Object tool] -> do
+                                Just (Aeson.Object parameters) <-
+                                    pure (KeyMap.lookup "parameters" tool)
+                                KeyMap.lookup "required" parameters
+                                    `shouldBe` Nothing
+                                Just (Aeson.Object properties) <-
+                                    pure (KeyMap.lookup "properties" parameters)
+                                Just (Aeson.Object timeout) <-
+                                    pure (KeyMap.lookup "timeout_ms" properties)
+                                KeyMap.lookup "type" timeout
+                                    `shouldBe` Just (Aeson.String "number")
+                            other -> expectationFailure
+                                ("expected one nested tool, got " <> show other)
                         other -> expectationFailure
-                            ("expected one nested tool, got " <> show other)
-                    other -> expectationFailure
-                        ("expected namespace tools, got " <> show other)
-            other -> expectationFailure
-                ("expected collaboration namespace, got " <> show other)
+                            ("expected namespace tools, got " <> show other)
+                other -> expectationFailure
+                    ("expected collaboration namespace, got " <> show other)
 
 jsonTool :: AppTool
 jsonTool = jsonAppTool "read_file" "Read a file."
@@ -120,3 +150,10 @@ offsetType tool = do
     Aeson.Object properties <- KeyMap.lookup "properties" parameters
     Aeson.Object offset <- KeyMap.lookup (Key.fromText "offset") properties
     KeyMap.lookup "type" offset
+
+newRegistry :: IO SubagentRegistry
+newRegistry = newSubagentRegistry
+    defaultSubagentConfig
+    (unsafeEncodeUtf "/tmp")
+    (\_ _ _ _ -> pure $ Left LoopNoResponseId)
+    (\_ _ -> pure ())

--- a/packages/agent-core/src/Agent/Tools/MultiAgents.hs
+++ b/packages/agent-core/src/Agent/Tools/MultiAgents.hs
@@ -260,7 +260,7 @@ instance FromJSON WaitAgentArgs where
 
 waitAgentTool :: MultiAgentContext -> AppTool
 waitAgentTool ctx = jsonTool "wait_agent" waitAgentDescription
-    [ PropertySchema "timeout_ms" PropertyInteger False $ Just
+    [ PropertySchema "timeout_ms" PropertyNumber False $ Just
         "Timeout in milliseconds. Defaults to 30000 ms."
     ]
     True

--- a/packages/agent-core/test/Agent/Tools/CodexSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/CodexSpec.hs
@@ -92,7 +92,7 @@ spec = describe "Agent.Tools.Codex" do
                 , "fork_turns"
                 ]
             map (.propertyType) (parameters "wait_agent") `shouldBe`
-                [PropertyInteger]
+                [PropertyNumber]
             case map (.propertyType) (parameters "spawn_agent") of
                 _ : PropertyRaw (Aeson.Object messageSchema) : _ ->
                     KeyMap.lookup "encrypted" messageSchema


### PR DESCRIPTION
## Summary

- restore `collaboration.wait_agent.timeout_ms` to the provider-required JSON Schema type `number`
- retain exact integer decoding through `optInt` at runtime
- replace the synthetic reserved-schema test with coverage that serializes the real production `multiAgentTools` registry

## Root cause

Commit `62c807c` tightened integer argument parsing but also changed the provider-facing reserved schema from `number` to `integer`. OpenAI and xAI reject the entire request when a reserved collaboration schema differs from their configured contract.

## Verification

- agent-core test suite: 266 examples, 0 failures
- agent-cli test suite: 545 examples, 0 failures
- `nix flake check --no-write-lock-file --print-build-logs`
