### PR TITLE
fix(ghci): discard asynchronously interrupted processes

### DIFF
--- a/packages/agent-core/src/Agent/Tools/Ghci/Runtime.hs
+++ b/packages/agent-core/src/Agent/Tools/Ghci/Runtime.hs
@@ -131,6 +131,8 @@ data GhciProcess = GhciProcess
 data GhciSessionState
     = GhciNotStarted
     | GhciRunning !GhciProcess
+    | GhciTainted !GhciProcess
+    | GhciClosing !GhciProcess
     | GhciClosed
 
 data GhciSession = GhciSession
@@ -161,13 +163,21 @@ newGhciSession env = do
 closeGhciSession :: GhciSession -> IO ()
 closeGhciSession session =
     withGhciLock session do
-        current <- atomicModifyIORef' session.ghciState \state ->
-            (GhciClosed, state)
         writeIORef session.ghciClassificationCache Nothing
-        case current of
-            GhciRunning process -> shutdownProcess process
-            GhciNotStarted -> pure ()
+        readIORef session.ghciState >>= \case
+            GhciRunning process -> closeProcess process
+            GhciTainted process -> closeProcess process
+            GhciClosing process -> closeProcess process
+            GhciNotStarted ->
+                writeIORef session.ghciState GhciClosed
             GhciClosed -> pure ()
+  where
+    closeProcess process = do
+        -- Retain ownership if shutdown is interrupted so a later close can
+        -- retry instead of forgetting a live process.
+        writeIORef session.ghciState (GhciClosing process)
+        shutdownProcess process
+        writeIORef session.ghciState GhciClosed
 
 -- | Evaluate @expression@ in the persistent GHCi, classifying side effects first.
 -- The timeout is an overall budget for classification and execution.
@@ -217,36 +227,65 @@ classifyGhciLocked session expression timeoutMs =
                         else pure GhciPure
 
 evalRawGhci :: GhciSession -> Text -> Int -> IO GhciResult
-evalRawGhci session expression requestedTimeout = do
-    let timeoutMs = normalizeTimeout requestedTimeout
-    cancelled <- isCancelled session.ghciEnv.toolCancel
-    if cancelled
-        then pure $ emptyResult GhciCancelled GhciEffectful "GHCi evaluation cancelled."
-        else prepareProcess session >>= \case
-            Left err ->
-                pure $ emptyResult GhciProcessFailed GhciEffectful err
-            Right (process, restartedBefore) -> do
-                marker <- nextMarker session
-                sent <- try @_ @SomeException do
-                    sendGhciInput process expression
-                    sendMarker process marker
-                case sent of
-                    Left err -> do
-                        restarted <- restartProcess session
-                        pure $ (emptyResult GhciProcessFailed GhciEffectful
-                            ("Failed to send input to GHCi: " <> Text.pack (show err)))
-                                { ghciRestarted =
-                                    restartedBefore || restarted
-                                }
-                    Right () -> do
-                        awaited <- awaitMarker
-                            (Just session.ghciEnv.toolCancel)
-                            session.ghciEnv.toolStdoutCap
-                            process
-                            marker
-                            timeoutMs
-                        finishAwaited
-                            session process restartedBefore awaited
+evalRawGhci session expression requestedTimeout =
+    run `onException` taintCurrentProcess session
+  where
+    run = do
+        let timeoutMs = normalizeTimeout requestedTimeout
+        cancelled <- isCancelled session.ghciEnv.toolCancel
+        if cancelled
+            then pure $ emptyResult GhciCancelled GhciEffectful
+                "GHCi evaluation cancelled."
+            else prepareProcess session >>= \case
+                Left err ->
+                    pure $ emptyResult GhciProcessFailed GhciEffectful err
+                Right (process, restartedBefore) -> do
+                    marker <- nextMarker session
+                    sent <- try @_ @SomeException do
+                        sendGhciInput process expression
+                        sendMarker process marker
+                    case sent of
+                        Left err -> do
+                            restarted <- restartProcess session
+                            pure $ (emptyResult GhciProcessFailed GhciEffectful
+                                ("Failed to send input to GHCi: "
+                                    <> Text.pack (show err)))
+                                        { ghciRestarted =
+                                            restartedBefore || restarted
+                                        }
+                        Right () -> do
+                            awaited <- awaitMarker
+                                (Just session.ghciEnv.toolCancel)
+                                session.ghciEnv.toolStdoutCap
+                                process
+                                marker
+                                timeoutMs
+                            finishAwaited
+                                session process restartedBefore awaited
+
+-- Never reuse a process after a request exits exceptionally. The exception may
+-- arrive after input was written but before its output marker was observed.
+taintCurrentProcess :: GhciSession -> IO ()
+taintCurrentProcess session = do
+    writeIORef session.ghciClassificationCache Nothing
+    process <- atomicModifyIORef' session.ghciState \case
+        GhciRunning current ->
+            (GhciTainted current, Just current)
+        GhciTainted current ->
+            (GhciTainted current, Just current)
+        GhciClosing current ->
+            (GhciClosing current, Nothing)
+        GhciNotStarted ->
+            (GhciNotStarted, Nothing)
+        GhciClosed ->
+            (GhciClosed, Nothing)
+    case process of
+        Nothing -> pure ()
+        Just current ->
+            try @_ @SomeException (shutdownProcess current) >>= \case
+                Left _ -> pure ()
+                Right () ->
+                    writeIORef session.ghciState GhciNotStarted
 
 prepareProcess :: GhciSession -> IO (Either Text (GhciProcess, Bool))
 prepareProcess session = do
@@ -388,15 +427,26 @@ ensureProcess :: GhciSession -> IO (Either Text GhciProcess)
 ensureProcess session =
     readIORef session.ghciState >>= \case
         GhciClosed -> pure (Left "GHCi session is closed.")
+        GhciClosing{} -> pure (Left "GHCi session is closed.")
         GhciNotStarted -> startProcess session
+        GhciTainted process ->
+            restartTaintedProcess session process
         GhciRunning process -> do
             exited <- getProcessExitCode process.ghciHandle
             case exited of
                 Nothing -> pure (Right process)
                 Just _ -> do
-                    shutdownProcess process
-                    writeIORef session.ghciState GhciNotStarted
-                    startProcess session
+                    writeIORef session.ghciState (GhciTainted process)
+                    restartTaintedProcess session process
+
+restartTaintedProcess
+    :: GhciSession
+    -> GhciProcess
+    -> IO (Either Text GhciProcess)
+restartTaintedProcess session process = do
+    shutdownProcess process
+    writeIORef session.ghciState GhciNotStarted
+    startProcess session
 
 startProcess :: GhciSession -> IO (Either Text GhciProcess)
 startProcess session = mask \restore ->
@@ -442,19 +492,26 @@ startProcess session = mask \restore ->
                                             awaited.awaitOutput.capturedStderr
 
 restartProcess :: GhciSession -> IO Bool
-restartProcess session = do
-    current <- atomicModifyIORef' session.ghciState \state ->
-        (case state of
-            GhciClosed -> GhciClosed
-            _ -> GhciNotStarted, state)
-    case current of
-        GhciRunning process -> shutdownProcess process
-        GhciNotStarted -> pure ()
-        GhciClosed -> pure ()
-    writeIORef session.ghciClassificationCache Nothing
-    case current of
+restartProcess session =
+    readIORef session.ghciState >>= \case
         GhciClosed -> pure False
-        _ -> either (const False) (const True) <$> startProcess session
+        GhciClosing{} -> pure False
+        GhciNotStarted -> start
+        GhciRunning process -> do
+            writeIORef session.ghciState (GhciTainted process)
+            restart process
+        GhciTainted process ->
+            restart process
+  where
+    start = do
+        writeIORef session.ghciClassificationCache Nothing
+        either (const False) (const True) <$> startProcess session
+
+    restart process = do
+        writeIORef session.ghciClassificationCache Nothing
+        shutdownProcess process
+        writeIORef session.ghciState GhciNotStarted
+        either (const False) (const True) <$> startProcess session
 
 ghciArgs :: [String]
 ghciArgs =

--- a/packages/agent-core/test/Agent/Tools/GhciSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/GhciSpec.hs
@@ -23,13 +23,17 @@ import Agent.Tools.Grok (closeGrokSession, grokTools, newGrokSession)
 import Agent.Tools.PlanMode (newPlanModeEnv)
 import Agent.Tools.Types (AppTool(..), ToolEnv(..))
 import Control.Concurrent (threadDelay)
-import Control.Concurrent.Async (wait, withAsync)
+import Control.Concurrent.Async (cancel, poll, wait, withAsync)
 import Control.Exception.Safe (SomeException, bracket, try)
 import Data.Either (isRight)
 import Data.IORef
 import qualified Data.Map.Strict as Map
 import qualified Data.Text as Text
-import System.Directory (getTemporaryDirectory, removeDirectoryRecursive)
+import System.Directory
+    ( doesFileExist
+    , getTemporaryDirectory
+    , removeDirectoryRecursive
+    )
 import System.FilePath ((</>))
 import System.Posix.Signals (nullSignal, signalProcess)
 import System.Posix.Temp (mkdtemp)
@@ -165,6 +169,24 @@ spec = describe "Agent.Tools.Ghci" do
                 recovered.ghciOk `shouldBe` True
                 recovered.ghciOutput `shouldSatisfy` Text.isInfixOf "5"
 
+    it "discards a sent request after asynchronous cancellation" do
+        withTempEnv \env -> do
+            let pidFile = toFilePath env.toolCwd </> "cancelled.pid"
+            bracket (newGhciSession env) closeGhciSession \ghci -> do
+                withAsync
+                    (evalGhci ghci (delayedOutputCommand pidFile) 10000)
+                    \running -> do
+                        waitForFile pidFile
+                        childPid <- read <$> readFile pidFile
+                        completed <- timeout 5000000 (cancel running)
+                        _ <- requireCompleted
+                            "asynchronous GHCi cancellation" completed
+                        waitForProcessDeath childPid
+                recovered <- evalGhci ghci "\"NEW\"" 10000
+                recovered.ghciOk `shouldBe` True
+                recovered.ghciOutput `shouldSatisfy` Text.isInfixOf "NEW"
+                recovered.ghciOutput `shouldNotSatisfy` Text.isInfixOf "OLD"
+
     it "caps retained output and reports truncation" do
         withTempEnv \baseEnv -> do
             let env = baseEnv { toolStdoutCap = 32 }
@@ -222,6 +244,30 @@ spec = describe "Agent.Tools.Ghci" do
             result.ghciOutcome `shouldBe` GhciProcessFailed
             result.ghciOutput `shouldSatisfy` Text.isInfixOf "closed"
 
+    it "does not reopen after close is asynchronously interrupted" do
+        withTempEnv \env -> do
+            let pidFile = toFilePath env.toolCwd </> "closing-child.pid"
+            bracket (newGhciSession env) closeGhciSession \ghci -> do
+                spawned <- evalGhci ghci (backgroundCommand pidFile) 10000
+                spawned.ghciOk `shouldBe` True
+                childPid <- read <$> readFile pidFile
+                withAsync (closeGhciSession ghci) \closing -> do
+                    -- The child ignores INT/TERM, keeping group shutdown in
+                    -- its bounded wait after the close state is published.
+                    threadDelay 100000
+                    poll closing >>= \case
+                        Nothing -> pure ()
+                        Just result ->
+                            expectationFailure
+                                ("close finished before cancellation: "
+                                    <> show result)
+                    cancel closing
+                result <- evalGhci ghci "1 + 1" 10000
+                result.ghciOutcome `shouldBe` GhciProcessFailed
+                result.ghciOutput `shouldSatisfy` Text.isInfixOf "closed"
+                closeGhciSession ghci
+                waitForProcessDeath childPid
+
     it "exposes run_ghci through grokTools dispatch" do
         withTempTools \tools -> do
             let handlers = appToolHandlers tools
@@ -249,6 +295,12 @@ backgroundCommand pidFile =
         <> "</dev/null >/dev/null 2>&1 & echo $! > "
         <> Text.pack (show pidFile)
 
+delayedOutputCommand :: FilePath -> Text.Text
+delayedOutputCommand pidFile =
+    ":! sh -c 'echo $$ > "
+        <> Text.pack pidFile
+        <> "; sleep 30; printf OLD'"
+
 requireCompleted :: String -> Maybe a -> IO a
 requireCompleted label = \case
     Just value -> pure value
@@ -275,6 +327,17 @@ waitForProcessDeath pid = go (200 :: Int)
 processAlive :: ProcessID -> IO Bool
 processAlive pid =
     isRight <$> try @_ @SomeException (signalProcess nullSignal pid)
+
+waitForFile :: FilePath -> IO ()
+waitForFile path = go (500 :: Int)
+  where
+    go remaining = do
+        exists <- doesFileExist path
+        if exists
+            then pure ()
+            else if remaining <= 0
+                then expectationFailure ("file was not created: " <> path)
+                else threadDelay 10000 >> go (remaining - 1)
 
 withTempEnv :: (ToolEnv -> IO a) -> IO a
 withTempEnv action =


### PR DESCRIPTION
## Summary

- mark a GHCi process tainted when an evaluation exits exceptionally
- retain process ownership until shutdown succeeds, so later calls retry cleanup instead of reusing or forgetting it
- keep an asynchronously interrupted close terminal rather than reopening the session

This is a focused replacement for the GHCi ownership portion of the earlier broad concurrency PR. It has no ResourceT, Grok, CLI process-manager, auth, stdin, or modal changes.

## Why

An async exception can arrive after an expression has been written to the persistent GHCi process but before its completion marker is observed. Reusing that process lets delayed output from the cancelled request appear in the next result. The old close/restart transitions also published `NotStarted`/`Closed` before shutdown completed, losing ownership if cleanup was interrupted.

## Tests

```sh
nix develop -c env -u GHCRTS cabal test agent-core:agent-core-test \
  --test-options='--match=Agent.Tools.Ghci' \
  --test-show-details=direct
```

22 examples, 0 failures, run after rebasing onto current `master`.

The two asynchronous lifecycle regressions also passed three consecutive focused runs.
