### PR TITLE
fix(tui): keep fullscreen across provider switches

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -94,7 +94,8 @@ import Agent.CLI.ReplMode
     , replModeFromState
     )
 import Agent.CLI.Interrupt
-    ( InterruptState
+    ( CtrlCDecision(..)
+    , InterruptState
     , isWrappedUserInterrupt
     , newInterruptState
     , noteFullscreenCtrlC
@@ -218,6 +219,7 @@ import Agent.CLI.TUI.App
     , requestFullscreenChoiceWithBody
     , requestFullscreenText
     , runFullscreen
+    , setFullscreenSessionActions
     , setFullscreenImagePreviews
     , setFullscreenWindowTitle
     , withFullscreenSuspended
@@ -399,6 +401,16 @@ data RunResult
       -- ^ Persisted session id. Consumed after the current provider-specific
       -- backend shuts down before starting the selected session.
 
+data PreparedAgent = PreparedAgent
+    { preparedFullscreen :: !(Maybe FullscreenRuntime)
+    , preparedRun :: !(IO RunResult)
+    }
+
+data PendingTurnPresentation
+    = SubmitPendingTurn
+    | RestartPendingTurn
+    | ContinuePendingTurn
+
 data AgentStepCache = AgentStepCache
     { cachedTranscript :: !(StableName [ResponseItem])
     , cachedVariant :: !(Maybe SubagentStatus)
@@ -416,6 +428,7 @@ data StartupRuntime = StartupRuntime
     , startupStderrTty :: !Bool
     , startupStdinTty :: !Bool
     , startupStdoutTty :: !Bool
+    , startupFullscreenReused :: !Bool
     , startupAgentSnapshot :: !(IORef (IO (AgentTarget, [AgentEntry])))
     , startupAgentSelect :: !(IORef (AgentTarget -> IO ()))
     , startupRestartEffort :: !(IORef (Text -> IO ()))
@@ -542,13 +555,14 @@ runAgentWithRestarts options = do
                 case transition of
                     Just failed
                         | failed.transitionCause == AutomaticFallback ->
-                            continueAutomaticFallback failed apiError >>= \case
+                            continueAutomaticFallback
+                                Nothing failed apiError >>= \case
                                 Just next ->
                                     go fullscreenInputs
                                         (applyProviderTransition current next)
                                         (Just next)
                                 Nothing -> do
-                                    reportProviderUnavailable apiError
+                                    reportProviderUnavailable Nothing apiError
                                     pure DevQuit
                     _ -> pure DevQuit
             RunQuit -> pure DevQuit
@@ -696,6 +710,44 @@ runAgent
     -> Maybe ProviderTransition
     -> IO RunResult
 runAgent fullscreenInputs options transition = do
+    prepared <-
+        prepareAgentIteration fullscreenInputs Nothing options transition
+    let runPrepared = case prepared.preparedFullscreen of
+            Nothing -> prepared.preparedRun
+            Just runtime ->
+                runFullscreen runtime $
+                    runFullscreenRestartLoop
+                        fullscreenInputs
+                        runtime
+                        options
+                        transition
+                        prepared.preparedRun
+    outcome <- try @_ @StartupFailure runPrepared
+    result <- either (\(StartupFailure message) -> die message) pure outcome
+    case (prepared.preparedFullscreen, result) of
+        -- The retained screen has been restored before this persistent final
+        -- diagnostic is printed.
+        (Just _, RunProviderStartFailed apiError) -> do
+            reportProviderUnavailable Nothing apiError
+            pure RunQuit
+        _ -> pure result
+
+-- | Prepare one provider-specific backend. The outer Brick worker loops over
+-- these prepared actions while reusing @activeFullscreen@, so Vty stays in the
+-- alternate screen until the whole provider-restart chain finishes. Session
+-- resumes still return to 'runAgentWithRestarts' and start a fresh UI.
+prepareAgentIteration
+    :: FullscreenInputBuffer
+    -> Maybe FullscreenRuntime
+    -> CliOptions
+    -> Maybe ProviderTransition
+    -> IO PreparedAgent
+prepareAgentIteration fullscreenInputs activeFullscreen options transition = do
+    forM_ activeFullscreen resetFullscreenSessionActions
+    let failPreparation message =
+            case activeFullscreen of
+                Nothing -> die message
+                Just _ -> throwIO (StartupFailure message)
     startedAt <- getCurrentTime
     startupTimingsRef <- newIORef []
     home <- getHomeDirectory
@@ -704,7 +756,7 @@ runAgent fullscreenInputs options transition = do
         Nothing -> pure Nothing
         Just sessionId ->
             loadSession root sessionId >>= \case
-                Left err -> die (Text.unpack err)
+                Left err -> failPreparation (Text.unpack err)
                 Right loaded -> pure (Just loaded)
 
     source <- maybe getCurrentDirectory makeAbsolute options.optCwd
@@ -714,7 +766,8 @@ runAgent fullscreenInputs options transition = do
             | otherwise -> makeAbsolute meta.metaCwd
         Nothing
             | options.optWorktree -> do
-                createWorktree source (worktreeRoot home) >>= either (die . Text.unpack) \path -> do
+                createWorktree source (worktreeRoot home)
+                    >>= either (failPreparation . Text.unpack) \path -> do
                     color <- resolveColor stderr
                     putTextLn stderr (roleMuted color (glyphSession <> "worktree: " <> toText path))
                     pure path
@@ -760,23 +813,36 @@ runAgent fullscreenInputs options transition = do
                             <> toText (takeFileName cwd)))
                     (hydrateUiHistory initialTurns)))
                         { uiQueuedInputs = queuedInputDisplays }
-    fullscreen <- if fullscreenEnabled
-        then Just <$> newFullscreenRuntime
-            fullscreenInputs
+    fullscreen <- case activeFullscreen of
+        Just runtime -> pure (Just runtime)
+        Nothing
+            | fullscreenEnabled ->
+                Just <$> newFullscreenRuntime
+                    fullscreenInputs
+                    (requestCancel toolEnv.toolCancel)
+                    (\level ->
+                        readIORef restartEffortActionRef >>= ($ level))
+                    (noteFullscreenCtrlC interrupt)
+                    (copyTerminalClipboard terminal stdout)
+                    (setCliWindowTitle stdoutTty stdout)
+                    (\active ->
+                        when terminal.terminalNativeProgress $
+                            setNativeProgress stderr active)
+                    (readIORef agentSnapshotRef >>= id)
+                    (\target -> readIORef agentSelectRef >>= ($ target))
+                    (recordStartupTiming
+                        startedAt startupTimingsRef "first frame")
+                    useColor
+                    initialFullscreenState
+            | otherwise -> pure Nothing
+    forM_ fullscreen \runtime ->
+        setFullscreenSessionActions
+            runtime
             (requestCancel toolEnv.toolCancel)
             (\level -> readIORef restartEffortActionRef >>= ($ level))
             (noteFullscreenCtrlC interrupt)
-            (copyTerminalClipboard terminal stdout)
-            (setCliWindowTitle stdoutTty stdout)
-            (\active ->
-                when terminal.terminalNativeProgress $
-                    setNativeProgress stderr active)
             (readIORef agentSnapshotRef >>= id)
             (\target -> readIORef agentSelectRef >>= ($ target))
-            (recordStartupTiming startedAt startupTimingsRef "first frame")
-            useColor
-            initialFullscreenState
-        else pure Nothing
     writeIORef uiRuntimeRef fullscreen
     let startup = StartupRuntime
             { startupToolEnv = toolEnv
@@ -789,6 +855,7 @@ runAgent fullscreenInputs options transition = do
             , startupStderrTty = stderrTty
             , startupStdinTty = stdinTty
             , startupStdoutTty = stdoutTty
+            , startupFullscreenReused = isJust activeFullscreen
             , startupAgentSnapshot = agentSnapshotRef
             , startupAgentSelect = agentSelectRef
             , startupRestartEffort = restartEffortActionRef
@@ -798,13 +865,72 @@ runAgent fullscreenInputs options transition = do
         action =
             runAgentInitialized
                 options transition home root resumed cwd startup
-    outcome <-
-        try @_ @StartupFailure
-            (case fullscreen of
-                Nothing -> action
-                Just runtime -> runFullscreen runtime action)
-            `finally` writeIORef uiRuntimeRef Nothing
-    either (\(StartupFailure message) -> die message) pure outcome
+        cleanup = do
+            writeIORef uiRuntimeRef Nothing
+            forM_ fullscreen resetFullscreenSessionActions
+    pure PreparedAgent
+        { preparedFullscreen = fullscreen
+        , preparedRun = action `finally` cleanup
+        }
+
+resetFullscreenSessionActions :: FullscreenRuntime -> IO ()
+resetFullscreenSessionActions runtime =
+    setFullscreenSessionActions
+        runtime
+        (pure ())
+        (const (pure ()))
+        -- No session-local interrupt state is alive between providers. A
+        -- transition must remain escapable even if auth probing blocks.
+        (pure ForceExit)
+        (pure (AgentRoot, []))
+        (const (pure ()))
+
+runFullscreenRestartLoop
+    :: FullscreenInputBuffer
+    -> FullscreenRuntime
+    -> CliOptions
+    -> Maybe ProviderTransition
+    -> IO RunResult
+    -> IO RunResult
+runFullscreenRestartLoop
+    fullscreenInputs
+    runtime =
+        loop
+  where
+    loop options transition action =
+        -- The notifier in 'runFullscreen' watches this whole tail-recursive
+        -- chain, rather than stopping Brick after the first provider exits.
+        action >>= \case
+            RunSwitchProvider next -> do
+                let nextOptions = applyProviderTransition options next
+                prepared <- prepareAgentIteration
+                    fullscreenInputs
+                    (Just runtime)
+                    nextOptions
+                    (Just next)
+                loop nextOptions (Just next) prepared.preparedRun
+            RunProviderStartFailed apiError ->
+                case transition of
+                    Just failed
+                        | failed.transitionCause == AutomaticFallback ->
+                            continueAutomaticFallback
+                                (Just runtime) failed apiError >>= \case
+                                Just next -> do
+                                    let nextOptions =
+                                            applyProviderTransition options next
+                                    prepared <- prepareAgentIteration
+                                        fullscreenInputs
+                                        (Just runtime)
+                                        nextOptions
+                                        (Just next)
+                                    loop
+                                        nextOptions
+                                        (Just next)
+                                        prepared.preparedRun
+                                Nothing ->
+                                    pure (RunProviderStartFailed apiError)
+                    _ -> pure (RunProviderStartFailed apiError)
+            result -> pure result
 
 runAgentInitialized
     :: CliOptions
@@ -1663,7 +1789,12 @@ runSession options provider policy tools toolEnv planMode startup prompt pending
             initializeSkills
             case pendingTurn of
                 Just pending ->
-                    runPendingTurn env pending
+                    runPendingTurn
+                        (if startup.startupFullscreenReused
+                            then ContinuePendingTurn
+                            else SubmitPendingTurn)
+                        env
+                        pending
                 Nothing -> case prompt of
                     Just text -> do
                         inputs <- preparePromptSkillInputs env text [UserMessage text]
@@ -1677,20 +1808,33 @@ runSession options provider policy tools toolEnv planMode startup prompt pending
     applyPendingSessionTitles env
     pure result
 
-runPendingTurn :: SessionEnv -> PendingTurn -> IO RunResult
-runPendingTurn = runPendingTurnWithCooldownRetry True
-
-runPendingTurnWithCooldownRetry
-    :: Bool
+runPendingTurn
+    :: PendingTurnPresentation
     -> SessionEnv
     -> PendingTurn
     -> IO RunResult
-runPendingTurnWithCooldownRetry allowCooldownRetry env pending = do
+runPendingTurn presentation =
+    runPendingTurnWithCooldownRetry True presentation
+
+runPendingTurnWithCooldownRetry
+    :: Bool
+    -> PendingTurnPresentation
+    -> SessionEnv
+    -> PendingTurn
+    -> IO RunResult
+runPendingTurnWithCooldownRetry
+    allowCooldownRetry presentation env pending = do
     writeIORef env.sessionPlanMode.planStateRef pending.pendingPlanState
     case env.sessionFullscreen of
         Nothing -> pure ()
-        Just runtime ->
-            emitUiEvent runtime (UiUserSubmitted pending.pendingPromptText)
+        Just runtime -> case presentation of
+            SubmitPendingTurn ->
+                emitUiEvent runtime
+                    (UiUserSubmitted pending.pendingPromptText)
+            RestartPendingTurn ->
+                emitUiEvent runtime UiTurnRestarted
+            ContinuePendingTurn ->
+                pure ()
     result <- runOneTurn env pending.pendingPromptText pending.pendingInputs
     finishTurnWithCooldownRetry
         allowCooldownRetry env pending.pendingExitAfter result
@@ -1747,7 +1891,8 @@ finishTurnWithCooldownRetry allowCooldownRetry env exitAfter = \case
                     Just delay | allowCooldownRetry ->
                         waitAndRetryPendingTurn env delay pending'
                     _ -> do
-                        reportProviderUnavailable apiError
+                        reportProviderUnavailable
+                            env.sessionFullscreen apiError
                         if exitAfter
                             then exitFailure
                             else do
@@ -1821,15 +1966,24 @@ waitAndRetryPendingTurn env delay pending = do
                     color <- resolveColor stderr
                     putTextLn stderr
                         (roleMuted color (glyphOk <> "retrying turn"))
-            runPendingTurnWithCooldownRetry False env pending
+            runPendingTurnWithCooldownRetry
+                False RestartPendingTurn env pending
 
-reportProviderUnavailable :: ApiError -> IO ()
-reportProviderUnavailable apiError = do
-    color <- resolveColor stderr
+reportProviderUnavailable
+    :: Maybe FullscreenRuntime
+    -> ApiError
+    -> IO ()
+reportProviderUnavailable fullscreen apiError = do
     now <- getCurrentTime
-    putTextLn stderr $ roleError color $
-        "No usable fallback provider account is available.\n"
+    let message =
+            "No usable fallback provider account is available.\n"
             <> formatApiErrorAt now apiError
+    case fullscreen of
+        Nothing -> do
+            color <- resolveColor stderr
+            putTextLn stderr (roleError color message)
+        Just runtime ->
+            emitUiEvent runtime (UiErrorMessage message)
 
 setSessionEffort :: SessionEnv -> Text -> IO ()
 setSessionEffort env level = do
@@ -2768,7 +2922,8 @@ replWithDraft env@SessionEnv
                                 (glyphOk <> message))
                     next
                 | otherwise ->
-                    requestModelProviderSwitch choice keptDraft persist >>= \case
+                    requestModelProviderSwitch
+                        fullscreen choice keptDraft persist >>= \case
                         Left err -> do
                             displayError err $
                                 Text.hPutStrLn stderr
@@ -3041,23 +3196,29 @@ applyModelChange provider name paramsRef render previous persist = do
                 else ""
 
 requestModelProviderSwitch
-    :: ModelOption
+    :: Maybe FullscreenRuntime
+    -> ModelOption
     -> Text
     -> Persistence
     -> IO (Either Text RunResult)
-requestModelProviderSwitch choice draft persist =
+requestModelProviderSwitch fullscreen choice draft persist =
     prepareProviderTransition
         ManualTransition [] Nothing draft choice persist >>= \case
             Left err -> pure (Left err)
             Right transition -> do
                 color <- resolveColor stdout
-                Text.putStrLn $ roleMuted color $
-                    glyphOk
-                        <> "switching to "
-                        <> providerSlug choice.modelProvider
-                        <> "/"
-                        <> choice.modelId
-                        <> " (conversation continued locally)"
+                let message =
+                        "switching to "
+                            <> providerSlug choice.modelProvider
+                            <> "/"
+                            <> choice.modelId
+                            <> " (conversation continued locally)"
+                case fullscreen of
+                    Nothing ->
+                        Text.putStrLn
+                            (roleMuted color (glyphOk <> message))
+                    Just runtime ->
+                        emitUiEvent runtime (UiSystemMessage message)
                 pure (Right (RunSwitchProvider transition))
 
 requestAutomaticProviderFallback
@@ -3066,9 +3227,11 @@ requestAutomaticProviderFallback
     -> PendingTurn
     -> IO (Maybe ProviderTransition)
 requestAutomaticProviderFallback env apiError pending = do
+    forM_ env.sessionFullscreen \runtime ->
+        emitUiEvent runtime UiTurnRestarted
     sessionId <- ensureTransitionSessionId env.sessionPersist
     unavailable <- readIORef env.sessionUnavailableProviders
-    chooseAutomaticProviderTransition
+    chooseAutomaticProviderTransition env.sessionFullscreen
         env.sessionProvider
         unavailable
         sessionId
@@ -3076,14 +3239,15 @@ requestAutomaticProviderFallback env apiError pending = do
         apiError
 
 continueAutomaticFallback
-    :: ProviderTransition
+    :: Maybe FullscreenRuntime
+    -> ProviderTransition
     -> ApiError
     -> IO (Maybe ProviderTransition)
-continueAutomaticFallback failed apiError =
+continueAutomaticFallback fullscreen failed apiError =
     case failed.transitionPendingTurn of
         Nothing -> pure Nothing
         Just pending ->
-            chooseAutomaticProviderTransition
+            chooseAutomaticProviderTransition fullscreen
                 failed.transitionTarget.modelProvider
                 failed.transitionUnavailableProviders
                 failed.transitionSessionId
@@ -3091,13 +3255,15 @@ continueAutomaticFallback failed apiError =
                 apiError
 
 chooseAutomaticProviderTransition
-    :: Provider
+    :: Maybe FullscreenRuntime
+    -> Provider
     -> [Provider]
     -> Maybe Text
     -> PendingTurn
     -> ApiError
     -> IO (Maybe ProviderTransition)
-chooseAutomaticProviderTransition current unavailable0 sessionId pending apiError =
+chooseAutomaticProviderTransition
+    fullscreen current unavailable0 sessionId pending apiError =
     tryCandidates unavailable candidates
   where
     unavailable = markUnavailable current unavailable0
@@ -3108,24 +3274,34 @@ chooseAutomaticProviderTransition current unavailable0 sessionId pending apiErro
         choice : rest ->
             validateProviderTarget choice >>= \case
                 Left err -> do
-                    color <- resolveColor stderr
-                    putTextLn stderr $ roleMuted color $
-                        "skipping "
+                    let message =
+                            "skipping "
                             <> providerSlug choice.modelProvider
                             <> ": "
                             <> err
+                    case fullscreen of
+                        Nothing -> do
+                            color <- resolveColor stderr
+                            putTextLn stderr (roleMuted color message)
+                        Just runtime ->
+                            emitUiEvent runtime (UiSystemMessage message)
                     tryCandidates
                         (markUnavailable choice.modelProvider unavailable)
                         rest
                 Right () -> do
-                    color <- resolveColor stderr
-                    putTextLn stderr $ roleWarn color $
-                        glyphWarn
-                            <> providerSlug current
+                    let message =
+                            providerSlug current
                             <> " unavailable; trying this turn with "
                             <> providerSlug choice.modelProvider
                             <> "/"
                             <> choice.modelId
+                    case fullscreen of
+                        Nothing -> do
+                            color <- resolveColor stderr
+                            putTextLn stderr
+                                (roleWarn color (glyphWarn <> message))
+                        Just runtime ->
+                            emitUiEvent runtime (UiSystemMessage message)
                     pure $ Just ProviderTransition
                         { transitionTarget = choice
                         , transitionSessionId = sessionId
@@ -3348,7 +3524,7 @@ enterPlanFromSlash env@SessionEnv
                     requestAutomaticProviderFallback
                         planEnv apiError pending >>= \case
                             Nothing -> do
-                                reportProviderUnavailable apiError
+                                reportProviderUnavailable fullscreen apiError
                                 pure Nothing
                             Just providerTransition ->
                                 pure (Just providerTransition)

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -18,6 +18,7 @@ module Agent.CLI.TUI.App
     , requestFullscreenChoiceWithBody
     , requestFullscreenText
     , runFullscreen
+    , setFullscreenSessionActions
     , fullscreenVtyConfig
     , setFullscreenImagePreviews
     , setFullscreenWindowTitle
@@ -168,20 +169,34 @@ newFullscreenRuntime
         imagePreviewIdBase <- allocateNativePreviewImageIdBase
         imagePreviewProtocol <- detectImagePreviewProtocol stdout
         imagePreviewInTmux <- isJust <$> lookupEnv "TMUX"
+        sessionActions <- newIORef FullscreenSessionActions
+            { sessionCancel = cancelAction
+            , sessionRestartEffort = restartEffortAction
+            , sessionCtrlC = ctrlCAction
+            , sessionAgentSnapshot = agentSnapshot
+            , sessionAgentSelect = agentSelect
+            }
         syntaxHighlighter <-
             either (const Nothing) Just <$> loadSyntaxHighlighter
         pure FullscreenRuntime
             { runtimeEvents = events
             , runtimeMailbox = mailbox
             , runtimeInput = inputBuffer
-            , runtimeCancel = cancelAction
-            , runtimeRestartEffort = restartEffortAction
-            , runtimeCtrlC = ctrlCAction
+            , runtimeCancel =
+                readIORef sessionActions >>= (.sessionCancel)
+            , runtimeRestartEffort = \level ->
+                readIORef sessionActions >>= \actions ->
+                    actions.sessionRestartEffort level
+            , runtimeCtrlC =
+                readIORef sessionActions >>= (.sessionCtrlC)
             , runtimeCopy = copyAction
             , runtimeSetWindowTitle = setWindowTitle
             , runtimeNativeProgress = nativeProgress
-            , runtimeAgentSnapshot = agentSnapshot
-            , runtimeAgentSelect = agentSelect
+            , runtimeAgentSnapshot =
+                readIORef sessionActions >>= (.sessionAgentSnapshot)
+            , runtimeAgentSelect = \target ->
+                readIORef sessionActions >>= \actions ->
+                    actions.sessionAgentSelect target
             , runtimeFirstFrame = firstFrame
             , runtimeRunning = running
             , runtimeImagePreviews = imagePreviews
@@ -194,6 +209,30 @@ newFullscreenRuntime
             , runtimeColor = color
             , runtimeSyntaxHighlighter = syntaxHighlighter
             , runtimeInitial = initial
+            , runtimeSessionActions = sessionActions
+            }
+
+setFullscreenSessionActions
+    :: FullscreenRuntime
+    -> IO ()
+    -> (Text -> IO ())
+    -> IO CtrlCDecision
+    -> IO (AgentTarget, [AgentEntry])
+    -> (AgentTarget -> IO ())
+    -> IO ()
+setFullscreenSessionActions
+    runtime
+    cancelAction
+    restartEffortAction
+    ctrlCAction
+    agentSnapshot
+    agentSelect =
+        writeIORef runtime.runtimeSessionActions FullscreenSessionActions
+            { sessionCancel = cancelAction
+            , sessionRestartEffort = restartEffortAction
+            , sessionCtrlC = ctrlCAction
+            , sessionAgentSnapshot = agentSnapshot
+            , sessionAgentSelect = agentSelect
             }
 
 emitUiEvent :: FullscreenRuntime -> UiEvent -> IO ()

--- a/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
@@ -8,6 +8,7 @@ module Agent.CLI.TUI.Types
     , FullscreenInput(..)
     , FullscreenInputBuffer(..)
     , FullscreenRuntime(..)
+    , FullscreenSessionActions(..)
     , Name(..)
     , PendingAppEvent(..)
     , PendingUiEvent(..)
@@ -125,6 +126,18 @@ data FullscreenRuntime = FullscreenRuntime
     , runtimeColor :: !Bool
     , runtimeSyntaxHighlighter :: !(Maybe SyntaxHighlighter)
     , runtimeInitial :: !UiState
+    , runtimeSessionActions :: !(IORef FullscreenSessionActions)
+    }
+
+-- | Provider/session-scoped actions behind one long-lived terminal runtime.
+-- Replacing the record atomically prevents the retained UI from calling into
+-- resources belonging to a backend that has already shut down.
+data FullscreenSessionActions = FullscreenSessionActions
+    { sessionCancel :: !(IO ())
+    , sessionRestartEffort :: !(Text -> IO ())
+    , sessionCtrlC :: !(IO CtrlCDecision)
+    , sessionAgentSnapshot :: !(IO (AgentTarget, [AgentEntry]))
+    , sessionAgentSelect :: !(AgentTarget -> IO ())
     }
 
 data AppState = AppState

--- a/packages/agent-cli/test/Agent/CLI/TUIBridgeSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIBridgeSpec.hs
@@ -6,13 +6,16 @@ import Agent.CLI.TUI.App
     ( emitUiEvent
     , newFullscreenInputBuffer
     , newFullscreenRuntime
+    , setFullscreenSessionActions
     )
 import Agent.CLI.TUI.Bridge
+import Agent.CLI.TUI.Types (FullscreenRuntime(..))
 import Agent.TUI.Model
 import Agent.Loop (LoopEvent(..), emptyTurnOutput)
 import Agent.Subagents (SubagentId(..))
 import Agent.ToolDispatch (functionToolCall)
 import Control.Monad (replicateM_)
+import Data.IORef (modifyIORef', newIORef, readIORef)
 import System.Timeout (timeout)
 import qualified Graphics.Vty as V
 import Test.Hspec
@@ -104,6 +107,38 @@ spec = describe "fullscreen TUI bridge" do
                 emitUiEvent runtime (UiLoop (TextDelta "x"))
                 emitUiEvent runtime (UiLoop TurnStarted)
         completed `shouldBe` Just ()
+
+    it "rebinds provider-specific actions without replacing the runtime" do
+        calls <- newIORef ([] :: [String])
+        input <- newFullscreenInputBuffer
+        runtime <- newFullscreenRuntime
+            input
+            (modifyIORef' calls (<> ["old cancel"]))
+            (const (pure ()))
+            (pure WarnExit)
+            (const (pure True))
+            (const (pure ()))
+            (const (pure ()))
+            (pure (AgentRoot, []))
+            (const (pure ()))
+            (pure ())
+            False
+            initialUiState
+        runtime.runtimeCancel
+        setFullscreenSessionActions
+            runtime
+            (modifyIORef' calls (<> ["new cancel"]))
+            (const (modifyIORef' calls (<> ["new effort"])))
+            (pure SoftCancel)
+            (pure (AgentRoot, []))
+            (const (modifyIORef' calls (<> ["new agent"])))
+        runtime.runtimeCancel
+        runtime.runtimeRestartEffort "high"
+        runtime.runtimeAgentSelect AgentRoot
+        decision <- runtime.runtimeCtrlC
+        readIORef calls `shouldReturn`
+            ["old cancel", "new cancel", "new effort", "new agent"]
+        decision `shouldBe` SoftCancel
 
     it "moves through history and restores the original draft" do
         historyMove 1 ["new", "old"] Nothing "draft" ""


### PR DESCRIPTION
## Summary

- keep one Brick/Vty runtime alive while rebuilding provider-specific backends
- atomically rebind cancel, effort, Ctrl-C, and agent callbacks between provider sessions
- route model-switch and fallback status through the retained TUI instead of writing into the active screen
- preserve the visible turn correctly across automatic fallback and print terminal fallback errors after Vty restores

## Validation

- loaded `Agent.CLI` successfully in GHCi under `nix develop`
- ran the full `agent-cli` test suite in GHCi: 523 examples, 0 failures
- exercised an xAI → OpenAI model switch in tmux
  - during switch: one alternate-screen enter, zero exits
  - after quitting: one alternate-screen enter, one exit
