### PR TITLE
fix(runtime): reduce default RTS memory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,17 +102,21 @@ When changing the CLI UI (prompt, colors, chrome, keybindings, paste, approval p
 ### memory / RTS heap cap
 
 `nix develop` does not impose a heap ceiling on every development command. The
-`repl` wrapper defaults `GHCRTS` to `-M8G -A64m`, which leaves enough room for
-the multi-package GHCi session while protecting the machine from an unbounded
-long-running agent. The compiled `agent-cli` executable has the same 8 GiB RTS
-default, overridable via `+RTS` because `-rtsopts` is enabled. Set `GHCRTS`
-explicitly to override the wrapper:
+`repl` wrapper defaults `GHCRTS` to `-M8G`, which protects the machine from an
+unbounded long-running GHCi/agent process while preserving the RTS allocation
+area default. The compiled `agent-cli` executable defaults to `-N4 -M8G`;
+four capabilities cover concurrent agent I/O without scaling nursery memory
+with every host core. Both defaults are overridable because `-rtsopts` is
+enabled. Set `GHCRTS` explicitly to override the wrapper:
 
 ```
-GHCRTS='-M16G -A64m' repl
-GHCRTS='-M4G -A32m' cabal repl agent-cli
-cabal run agent-cli -- +RTS -M16G -RTS
+GHCRTS='-M16G' repl
+GHCRTS='-M4G' cabal repl agent-cli
+cabal run agent-cli -- +RTS -N8 -M16G -RTS
 ```
+
+Avoid large `-A` defaults: the allocation area is per capability, so
+`-N14 -A64m` consumes roughly 896 MiB before meaningful application data.
 
 
 # haskell

--- a/flake.nix
+++ b/flake.nix
@@ -240,7 +240,7 @@
                     # Cap the long-running GHCi/agent process without forcing
                     # every command in nix develop to inherit the same limit.
                     if [ -z "''${GHCRTS:-}" ]; then
-                      export GHCRTS="-M8G -A64m"
+                      export GHCRTS="-M8G"
                     fi
                     cabal="${haskellPackages.cabal-install}/bin/cabal"
                     expect_bin="${pkgs.expect}/bin/expect"

--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -131,7 +131,10 @@ executable agent-cli
     import:           common-options
     hs-source-dirs:   app
     main-is:          Main.hs
-    ghc-options:      -threaded -rtsopts "-with-rtsopts=-N -M8G -A64m"
+    -- Keep the heap ceiling without multiplying a large allocation area by
+    -- every host core. Four capabilities cover the agent's concurrent I/O;
+    -- leave -A at the GHC RTS default.
+    ghc-options:      -threaded -rtsopts "-with-rtsopts=-N4 -M8G"
     build-depends:    agent-cli
                     , base >= 4.17 && < 5
 


### PR DESCRIPTION
## Summary

- change the packaged agent RTS defaults from `-N -M8G -A64m` to `-N4 -M8G`
- preserve the 8 GiB heap safety cap while returning to GHC's normal allocation-area size
- remove `-A64m` from the development `repl` wrapper
- document the per-capability allocation-area behavior

## Memory impact

On a 14-core Apple Silicon Mac:

| Workload | Before | After |
| --- | ---: | ---: |
| Trivial startup peak RSS | ~988 MB | 38.8 MB |
| Trivial RTS memory | 925 MiB | 21 MiB |
| Session listing peak RSS | ~1.02 GB | 49.1 MB |
| Initialized idle physical footprint | 942 MB | 38.7 MB |

A real one-turn request with the new defaults used 3.76 MiB maximum live heap and about 73 MB peak RSS.

The old baseline came from `-A64m` being applied per capability: `-N14 -A64m` creates roughly 896 MiB of allocation areas before meaningful application data.

## Validation

- `nix build .#agent-cli`
- 551 tests, 0 failures
- `nix flake check --no-build`
- production executable reports `Flag -with-rtsopts: -N4 -M8G`
- live tmux/TTY idle smoke test
- real OpenAI one-turn smoke test
- `git diff --check`
