### PR TITLE
fix(resources): make scope close a cancellation-safe barrier

### DIFF
--- a/packages/agent-core/src/Agent/ResourceScope.hs
+++ b/packages/agent-core/src/Agent/ResourceScope.hs
@@ -12,13 +12,23 @@ module Agent.ResourceScope
     , releaseResource
     ) where
 
+import Control.Concurrent (ThreadId, forkIOWithUnmask, myThreadId)
 import Control.Concurrent.MVar
     ( MVar
     , modifyMVar
+    , newEmptyMVar
     , newMVar
+    , putMVar
+    , readMVar
     , withMVar
     )
-import Control.Exception.Safe (throwIO)
+import qualified Control.Exception as Exception
+import Control.Exception.Safe
+    ( SomeException
+    , mask
+    , throwIO
+    , uninterruptibleMask_
+    )
 import Control.Monad.Trans.Resource
     ( InternalState
     , ReleaseKey
@@ -31,20 +41,52 @@ import Control.Monad.Trans.Resource
     , runInternalState
     )
 
-newtype ResourceScope = ResourceScope (MVar (Maybe InternalState))
+type ScopeOutcome = Either SomeException ()
+
+data ResourceScopeState
+    = ScopeOpen !InternalState
+    -- A full completion cell is also the stable closed state.
+    | ScopeClosing !ThreadId !(MVar ScopeOutcome)
+
+newtype ResourceScope = ResourceScope (MVar ResourceScopeState)
+
+data CloseDecision
+    = CloseComplete !ScopeOutcome
+    | CloseWait !(MVar ScopeOutcome)
 
 newtype ResourceKey = ResourceKey ReleaseKey
 
 newResourceScope :: IO ResourceScope
 newResourceScope = do
     state <- createInternalState
-    ResourceScope <$> newMVar (Just state)
+    ResourceScope <$> newMVar (ScopeOpen state)
 
 closeResourceScope :: ResourceScope -> IO ()
-closeResourceScope (ResourceScope stateVar) = do
-    state <- modifyMVar stateVar \current ->
-        pure (Nothing, current)
-    mapM_ closeInternalState state
+closeResourceScope (ResourceScope stateVar) =
+    mask \restore -> do
+        caller <- myThreadId
+        decision <- modifyMVar stateVar \case
+            ScopeOpen state -> do
+                done <- newEmptyMVar
+                -- Cleanup belongs to the scope, not whichever close caller
+                -- happened to start it.
+                owner <- forkIOWithUnmask \unmask -> do
+                    result <- Exception.try @SomeException $
+                        unmask (closeInternalState state)
+                    uninterruptibleMask_ (putMVar done result)
+                pure
+                    ( ScopeClosing owner done
+                    , CloseWait done
+                    )
+            closing@(ScopeClosing owner done)
+                | caller == owner ->
+                    pure (closing, CloseComplete (Right ()))
+                | otherwise ->
+                    pure (closing, CloseWait done)
+        result <- case decision of
+            CloseComplete completed -> pure completed
+            CloseWait done -> restore (readMVar done)
+        either throwIO pure result
 
 allocateResource
     :: ResourceScope
@@ -70,5 +112,5 @@ runInScope = flip runInternalState
 withOpenScope :: ResourceScope -> (InternalState -> IO a) -> IO a
 withOpenScope (ResourceScope stateVar) action =
     withMVar stateVar \case
-        Nothing -> throwIO (userError "resource scope is closed")
-        Just state -> action state
+        ScopeOpen state -> action state
+        ScopeClosing{} -> throwIO (userError "resource scope is closed")

--- a/packages/agent-core/test/Agent/ResourceScopeSpec.hs
+++ b/packages/agent-core/test/Agent/ResourceScopeSpec.hs
@@ -1,7 +1,10 @@
 module Agent.ResourceScopeSpec (spec) where
 
 import Agent.ResourceScope
+import qualified Control.Concurrent.Async as Async
+import Control.Concurrent.MVar
 import Data.IORef
+import System.Timeout (timeout)
 import Test.Hspec
 
 spec :: Spec
@@ -29,6 +32,68 @@ spec = describe "Agent.ResourceScope" do
         closeResourceScope scope
         closeResourceScope scope
 
+    it "makes concurrent close callers wait for cleanup" do
+        cleanupStarted <- newEmptyMVar
+        finishCleanup <- newEmptyMVar
+        secondStarted <- newEmptyMVar
+        scope <- newResourceScope
+        _ <- registerResource scope $
+            putMVar cleanupStarted () >> takeMVar finishCleanup
+
+        Async.withAsync (closeResourceScope scope) \firstClose -> do
+            takeMVar cleanupStarted
+            Async.withAsync
+                (putMVar secondStarted () >> closeResourceScope scope)
+                \secondClose -> do
+                takeMVar secondStarted
+                premature <- timeout 1000000 (Async.wait secondClose)
+                putMVar finishCleanup ()
+                Async.wait firstClose
+                case premature of
+                    Nothing -> Async.wait secondClose
+                    Just () -> pure ()
+                premature `shouldBe` Nothing
+
+    it "continues cleanup when the initiating close caller is cancelled" do
+        cleanupStarted <- newEmptyMVar
+        finishCleanup <- newEmptyMVar
+        joiningStarted <- newEmptyMVar
+        releases <- newIORef (0 :: Int)
+        scope <- newResourceScope
+        _ <- registerResource scope do
+            putMVar cleanupStarted ()
+            takeMVar finishCleanup
+            increment releases
+
+        Async.withAsync (closeResourceScope scope) \firstClose -> do
+            takeMVar cleanupStarted
+            Async.cancel firstClose
+            Async.waitCatch firstClose >>= \case
+                Left _ -> pure ()
+                Right () ->
+                    expectationFailure "cancelled close returned successfully"
+            Async.withAsync
+                (putMVar joiningStarted () >> closeResourceScope scope)
+                \joiningClose -> do
+                takeMVar joiningStarted
+                premature <- timeout 1000000 (Async.wait joiningClose)
+                putMVar finishCleanup ()
+                case premature of
+                    Nothing -> Async.wait joiningClose
+                    Just () -> pure ()
+                premature `shouldBe` Nothing
+        readIORef releases `shouldReturn` 1
+
+    it "allows a cleanup action to close its own scope" do
+        scope <- newResourceScope
+        _ <- registerResource scope (closeResourceScope scope)
+        timeout 1000000 (closeResourceScope scope)
+            `shouldReturn` Just ()
+
 record :: IORef [Int] -> Int -> IO ()
 record ref value =
     atomicModifyIORef' ref \values -> (values <> [value], ())
+
+increment :: IORef Int -> IO ()
+increment ref =
+    atomicModifyIORef' ref \value -> (value + 1, ())


### PR DESCRIPTION
## Summary
- make concurrent `closeResourceScope` callers wait for the same cleanup result
- move `ResourceT` cleanup to a scope-owned worker so cancelling the initiating caller cannot interrupt or abandon cleanup
- allow a cleanup callback to close its own scope without joining itself
- keep the implementation to a two-state `MVar`; this intentionally does not add active-release tracking or the larger STM lifecycle machine

`releaseResource` remains ResourceT's exactly-once early release. Callers that need release-vs-close serialization should provide it at their own lifecycle boundary (the remaining Grok fix will do that).

## Tests
- `nix develop -c env -u GHCRTS cabal test agent-core:agent-core-test --test-options='--match=Agent.ResourceScope' --test-show-details=direct`
- `nix develop -c env -u GHCRTS cabal test all --test-show-details=failures`
