### PR TITLE
fix(tui): render fenced code nested in lists

### DIFF
--- a/packages/agent-cli/test/Agent/CLI/ArtifactSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ArtifactSpec.hs
@@ -47,6 +47,14 @@ spec = do
                     , Nothing
                     ]
 
+        it "copies deindented fenced code nested under a list item" do
+            let text =
+                    "- Changed from:\n\
+                    \    ```text\n\
+                    \    -N -M8G -A64m\n\
+                    \    ```\n"
+            fencedCodeBlock 1 text `shouldBe` Just "-N -M8G -A64m\n"
+
     describe "lastDiffBlock" do
         it "selects the last diff-like fence" do
             let text = "```diff\n-old\n+new\n```\n```patch\n-a\n+b\n```\n"

--- a/packages/agent-tui/src/Agent/TUI/FencedCode.hs
+++ b/packages/agent-tui/src/Agent/TUI/FencedCode.hs
@@ -12,6 +12,7 @@ module Agent.TUI.FencedCode
     , fencedBlocks
     ) where
 
+import Control.Applicative ((<|>))
 import Data.Char (isSpace)
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -44,7 +45,7 @@ data FencedBlock = FencedBlock
 -- backtick.
 fenceOpener :: Text -> Maybe (FenceMarker, Text)
 fenceOpener line = do
-    stripped <- stripFenceIndent line
+    (_, stripped) <- stripFenceIndent line
     character <- Text.uncons stripped >>= \(first, _) ->
         if first == '`' || first == '~'
             then Just first
@@ -64,7 +65,7 @@ isFenceCloser :: FenceMarker -> Text -> Bool
 isFenceCloser marker line =
     case stripFenceIndent line of
         Nothing -> False
-        Just stripped ->
+        Just (_, stripped) ->
             let (markerText, suffix) =
                     Text.span (== marker.fenceCharacter) stripped
             in Text.length markerText >= marker.fenceLength
@@ -74,38 +75,163 @@ isFenceCloser marker line =
 -- blocks are included with 'fencedClosed' set to 'False'. Prose and body text
 -- retain their original line endings.
 fenceChunks :: Text -> [FenceChunk]
-fenceChunks = go 1 [] . sourceLines
+fenceChunks = go 1 [] [] . sourceLines
   where
-    go _ prose [] = proseChunk prose
-    go index prose (line : rest) =
-        case fenceOpener line.lineText of
-            Nothing -> go index (line : prose) rest
-            Just (marker, info) ->
+    go _ prose _ [] = proseChunk prose
+    go index prose previous (line : rest) =
+        case fenceOpenerInContext previous line.lineText of
+            Nothing -> go index (line : prose) (line : previous) rest
+            Just opener ->
                 let
                     (bodyLines, closingAndRest) =
-                        break (isFenceCloser marker . (.lineText)) rest
-                    (closed, remaining) =
+                        break
+                            (isContextualFenceCloser opener . (.lineText))
+                            rest
+                    (closed, closingLine, remaining) =
                         case closingAndRest of
-                            [] -> (False, [])
-                            _closing : after -> (True, after)
+                            [] -> (False, [], [])
+                            closing : after -> (True, [closing], after)
                     block = FencedBlock
                         { fencedIndex = index
-                        , fencedMarker = marker
-                        , fencedInfo = info
+                        , fencedMarker = opener.openMarker
+                        , fencedInfo = opener.openInfo
                         , fencedBody =
                             foldMap
                                 (\bodyLine ->
-                                    bodyLine.lineText <> bodyLine.lineEnding)
+                                    stripBodyIndent
+                                        opener.openIndent
+                                        bodyLine.lineText
+                                        <> bodyLine.lineEnding)
                                 bodyLines
                         , fencedClosed = closed
                         }
+                    consumed = line : bodyLines <> closingLine
                 in proseChunk prose
                     <> [FenceBlock block]
-                    <> go (index + 1) [] remaining
+                    <> go
+                        (index + 1)
+                        []
+                        (reverse consumed <> previous)
+                        remaining
 
     proseChunk [] = []
     proseChunk reversedLines =
         [FenceText (foldMap sourceLineText (reverse reversedLines))]
+
+data ContextualFence = ContextualFence
+    { openMarker :: !FenceMarker
+    , openInfo :: !Text
+    , openContainerIndent :: !Int
+    , openIndent :: !Int
+    }
+
+fenceOpenerInContext :: [SourceLine] -> Text -> Maybe ContextualFence
+fenceOpenerInContext previous line =
+    if not (startsWithFenceMarker line)
+        then Nothing
+        else
+            let lineIndent = leadingSpaceCount line
+            in (do
+                    containerIndent <-
+                        listContainerIndent lineIndent previous
+                    contextualFence containerIndent line)
+                <|> contextualFence 0 line
+
+contextualFence :: Int -> Text -> Maybe ContextualFence
+contextualFence containerIndent line = do
+    insideContainer <- dropSpaceIndent containerIndent line
+    (fenceIndent, stripped) <- stripFenceIndent insideContainer
+    (marker, info) <- fenceOpener stripped
+    pure ContextualFence
+        { openMarker = marker
+        , openInfo = info
+        , openContainerIndent = containerIndent
+        , openIndent = containerIndent + fenceIndent
+        }
+
+isContextualFenceCloser :: ContextualFence -> Text -> Bool
+isContextualFenceCloser opener line =
+    maybe False
+        (isFenceCloser opener.openMarker)
+        (dropSpaceIndent opener.openContainerIndent line)
+
+-- | Find the nearest surrounding list item whose continuation indentation
+-- contains the prospective fence. Intervening non-blank lines must remain
+-- within that item, which prevents an old list from making an unrelated
+-- top-level four-space-indented line look like a fence.
+listContainerIndent :: Int -> [SourceLine] -> Maybe Int
+listContainerIndent lineIndent = go maxBound
+  where
+    go _ [] = Nothing
+    go minimumIndent (line : rest)
+        | Text.null (Text.strip line.lineText) =
+            go minimumIndent rest
+        | Just contentIndent <- listItemContentIndent line.lineText
+        , contentIndent <= lineIndent
+        , contentIndent <= minimumIndent =
+            Just contentIndent
+        | otherwise =
+            let minimumIndent' =
+                    min minimumIndent (leadingSpaceCount line.lineText)
+            in if minimumIndent' == 0
+                then Nothing
+                else go minimumIndent' rest
+
+listItemContentIndent :: Text -> Maybe Int
+listItemContentIndent line =
+    bulletIndent <|> orderedIndent
+  where
+    leading = leadingSpaceCount line
+    stripped = Text.drop leading line
+    bulletIndent = do
+        (marker, afterMarker) <- Text.uncons stripped
+        if marker `elem` ['-', '+', '*']
+            then contentIndentAfterMarker leading 1 afterMarker
+            else Nothing
+    orderedIndent = do
+        let (digits, afterDigits) = Text.span isAsciiDigit stripped
+        if Text.null digits || Text.length digits > 9
+            then Nothing
+            else do
+                (marker, afterMarker) <- Text.uncons afterDigits
+                if marker == '.' || marker == ')'
+                    then
+                        contentIndentAfterMarker
+                            leading
+                            (Text.length digits + 1)
+                            afterMarker
+                    else Nothing
+
+contentIndentAfterMarker :: Int -> Int -> Text -> Maybe Int
+contentIndentAfterMarker leading markerWidth afterMarker =
+    let spaces = leadingSpaceCount afterMarker
+    in if spaces >= 1 && spaces <= 4
+        then Just (leading + markerWidth + spaces)
+        else Nothing
+
+isAsciiDigit :: Char -> Bool
+isAsciiDigit character = character >= '0' && character <= '9'
+
+leadingSpaceCount :: Text -> Int
+leadingSpaceCount = Text.length . Text.takeWhile (== ' ')
+
+startsWithFenceMarker :: Text -> Bool
+startsWithFenceMarker line =
+    case Text.uncons (Text.dropWhile (== ' ') line) of
+        Just (marker, _) -> marker == '`' || marker == '~'
+        Nothing -> False
+
+dropSpaceIndent :: Int -> Text -> Maybe Text
+dropSpaceIndent count line =
+    let (spaces, _) = Text.span (== ' ') line
+    in if Text.length spaces >= count
+        then Just (Text.drop count line)
+        else Nothing
+
+stripBodyIndent :: Int -> Text -> Text
+stripBodyIndent count line =
+    let available = leadingSpaceCount line
+    in Text.drop (min count available) line
 
 -- | Extract all fenced blocks in source order.
 fencedBlocks :: Text -> [FencedBlock]
@@ -135,9 +261,9 @@ sourceLines input
 sourceLineText :: SourceLine -> Text
 sourceLineText line = line.lineText <> line.lineEnding
 
-stripFenceIndent :: Text -> Maybe Text
+stripFenceIndent :: Text -> Maybe (Int, Text)
 stripFenceIndent line =
     let (spaces, stripped) = Text.span (== ' ') line
     in if Text.length spaces <= 3
-        then Just stripped
+        then Just (Text.length spaces, stripped)
         else Nothing

--- a/packages/agent-tui/test/Agent/TUI/FencedCodeSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/FencedCodeSpec.hs
@@ -51,6 +51,49 @@ spec = describe "fencedBlocks" do
         map (.fencedInfo) blocks `shouldBe` ["diff"]
         map (.fencedBody) blocks `shouldBe` ["-old\n+new\n"]
 
+    it "recognizes and deindents fences nested under a list item" do
+        let blocks =
+                fencedBlocks
+                    "- Changed embedded RTS defaults from:\n\
+                    \    ```text\n\
+                    \    -N -M8G -A64m\n\
+                    \    ```\n\
+                    \\n\
+                    \    to:\n\
+                    \    ```text\n\
+                    \    -N4 -M8G\n\
+                    \    ```\n"
+        map (.fencedInfo) blocks `shouldBe` ["text", "text"]
+        map (.fencedBody) blocks
+            `shouldBe` ["-N -M8G -A64m\n", "-N4 -M8G\n"]
+        map (.fencedClosed) blocks `shouldBe` [True, True]
+
+    it "recognizes fences nested under ordered and nested list items" do
+        let ordered =
+                fencedBlocks
+                    "10. item\n    ```hs\n    main = pure ()\n    ```\n"
+            nested =
+                fencedBlocks
+                    "- outer\n  - inner\n      ```hs\n      main = pure ()\n      ```\n"
+        map (.fencedBody) ordered `shouldBe` ["main = pure ()\n"]
+        map (.fencedBody) nested `shouldBe` ["main = pure ()\n"]
+
+    it "does not reuse a list container after dedented prose" do
+        fencedBlocks
+            "- item\noutside\n    ```text\n    not a fence\n    ```\n"
+            `shouldBe` []
+
+    it "requires nested fence closers to remain inside the list container" do
+        let check source = case fencedBlocks source of
+                [block] -> do
+                    block.fencedBody `shouldBe` "one\n```\ntwo\n"
+                    block.fencedClosed `shouldBe` True
+                blocks ->
+                    expectationFailure
+                        ("expected one nested block, got " <> show blocks)
+        check "- item\n    ```text\n    one\n```\n    two\n    ```\n"
+        check "- item\n  ```text\n  one\n```\n  two\n  ```\n"
+
     it "preserves an unterminated body and its final newline state" do
         case
             ( fencedBlocks "```text\none"

--- a/packages/agent-tui/test/Agent/TUI/MarkdownSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/MarkdownSpec.hs
@@ -67,6 +67,21 @@ spec = describe "fullscreen Markdown inline parsing" do
         rendered `shouldSatisfy` isInfixOf "1:bash"
         rendered `shouldSatisfy` isInfixOf "2:haskell"
 
+    it "renders a four-space fence nested under a list as a code block" do
+        let widget :: Widget ()
+            widget =
+                markdownWidgetWithCodeControls
+                    (\index language ->
+                        txt (Text.pack (show index) <> ":" <> language))
+                    "- Changed from:\n\
+                    \    ```text\n\
+                    \    -N -M8G -A64m\n\
+                    \    ```"
+            rendered = show (renderWidget Nothing [widget] (40, 8))
+        rendered `shouldSatisfy` isInfixOf "1:text"
+        rendered `shouldSatisfy` isInfixOf "-N -M8G -A64m"
+        rendered `shouldSatisfy` (not . isInfixOf "```text")
+
     it "caches closed fence bodies but leaves open streaming fences uncached" do
         let render input =
                 let widget :: Widget ()


### PR DESCRIPTION
## Summary

- recognize fenced code blocks relative to surrounding unordered, ordered, and nested list indentation
- require closing fences to stay within the same list container and deindent rendered/copied code bodies
- preserve the existing rule that unrelated top-level four-space-indented fences are not treated as fenced blocks
- add regression coverage for parsing, fullscreen rendering, and code copying

## Testing

- `printf ':main\n:q\n' | nix develop -c cabal repl agent-tui:test:agent-tui-test` — 52 examples, 0 failures
- `printf ':main --match fencedCodeBlock\n:q\n' | nix develop -c cabal repl agent-cli:test:agent-cli-test` — 6 examples, 0 failures
- live fullscreen-agent tmux smoke check after `:reload`: the four-space list-nested `text` fence rendered with code-block chrome and the Copy control, without visible fence markers
