### PR TITLE
Refactor duplicated agent infrastructure

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/AgentSessions.hs
+++ b/packages/agent-cli/src/Agent/CLI/AgentSessions.hs
@@ -28,12 +28,11 @@ import Agent.OsPath (fromText, unsafeToFilePath)
 import Agent.Provider (Provider, providerSlug)
 import Agent.ToolArgs (objectArgs, optInt, optText, reqText)
 import Agent.ToolDSL (PropertySchema(..), PropertyType(..))
-import Agent.ToolDispatch (ToolHandler, typedTool)
+import Agent.ToolDispatch (typedTool)
 import Agent.Tools.Types
     ( AppTool
-    , ApprovalRule(..)
     , ToolExecutionPolicy(..)
-    , jsonAppToolWithExecution
+    , jsonTool
     )
 import Control.Concurrent.MVar
     ( MVar
@@ -295,22 +294,6 @@ agentSessionTools env =
     , readAgentSessionTool env
     , sendAgentSessionMessageTool env
     ]
-
-jsonTool
-    :: Text
-    -> Text
-    -> [PropertySchema]
-    -> Bool
-    -> ToolExecutionPolicy
-    -> ToolHandler
-    -> AppTool
-jsonTool name description parameters readOnly execution handler =
-    jsonAppToolWithExecution
-        name description parameters approval execution handler
-  where
-    approval
-        | readOnly = AlwaysReadOnly
-        | otherwise = AlwaysPrompt
 
 data CreateAgentSessionArgs = CreateAgentSessionArgs
     { message :: Text

--- a/packages/agent-cli/src/Agent/CLI/AgentViewport.hs
+++ b/packages/agent-cli/src/Agent/CLI/AgentViewport.hs
@@ -31,10 +31,9 @@ import Agent.CLI.Render (summarizeToolCall)
 import Agent.CLI.Picker (PickerKey(..), runOverlay)
 import Agent.CLI.Style (roleMuted, rolePrompt, roleSuccess)
 import Agent.CLI.TextLayout
-    ( clampSelectionIndex
-    , fitTextCell
-    , selectionWindow
-    , transcriptPreviewRows
+    ( SplitPaneFrame(..)
+    , clampSelectionIndex
+    , renderSplitPaneFrame
     )
 import Agent.Responses.Types
 import Agent.Subagents (SubagentId(..), SubagentStatus(..))
@@ -240,59 +239,35 @@ renderAgentViewportFor
     -> AgentViewportState
     -> Text
 renderAgentViewportFor color bodyRows terminalCols footerText state =
-    Text.intercalate "\n" (header : headings : body <> [footer])
+    renderSplitPaneFrame SplitPaneFrame
+        { splitPaneMinColumns = 20
+        , splitPaneColumns = terminalCols
+        , splitPaneBodyRows = bodyRows
+        , splitPaneLeftMinWidth = 12
+        , splitPaneLeftMaxWidth = 38
+        , splitPaneDivider = " │ "
+        , splitPaneTitle = "agents"
+        , splitPaneHeaderDetail =
+            \count ->
+                Text.pack (show count)
+                    <> if count == 1 then " agent" else " agents"
+        , splitPaneLeftHeading = "hierarchy"
+        , splitPaneRightHeading =
+            \selected ->
+                "transcript"
+                    <> maybe "" (\entry -> " · " <> entry.agentPath) selected
+        , splitPaneItems = entries
+        , splitPaneSelectedIndex = state.viewportIndex
+        , splitPaneLeftLabel = agentEntryTreeLabel entries
+        , splitPaneTranscript = (.agentTranscript)
+        , splitPaneEmptyTranscript = "(no agents)"
+        , splitPaneFooter = footerText
+        , splitPanePromptStyle = rolePrompt color
+        , splitPaneMutedStyle = roleMuted color
+        , splitPaneSelectedStyle = roleSuccess color
+        }
   where
-    cols = max 20 terminalCols
-    divider = roleMuted color " │ "
-    leftWidth = max 12 (min 38 ((cols - 3) * 2 `div` 5))
-    rightWidth = max 1 (cols - leftWidth - 3)
     entries = state.viewportAll
-    n = length entries
-    idx = clampSelectionIndex n state.viewportIndex
-    shown = selectionWindow bodyRows idx entries
-    selected = selectedAgentEntry state
-    header =
-        rolePrompt color "agents"
-            <> roleMuted color
-                (fitTextCell (max 0 (cols - 6))
-                    (" · " <> Text.pack (show n)
-                        <> if n == 1 then " agent" else " agents"))
-    headings =
-        rolePrompt color (fitTextCell leftWidth "hierarchy")
-            <> divider
-            <> rolePrompt color
-                (fitTextCell rightWidth
-                    ("transcript"
-                        <> maybe "" (\entry -> " · " <> entry.agentPath) selected))
-    leftRows =
-        map
-            (\(absoluteIndex, entry) ->
-                let prefix = if absoluteIndex == idx then "› " else "  "
-                    text = fitTextCell leftWidth
-                        (prefix
-                            <> agentEntryTreeLabel
-                                entries absoluteIndex entry)
-                in if absoluteIndex == idx
-                    then roleSuccess color text
-                    else text)
-            shown
-            <> repeat (Text.replicate leftWidth " ")
-    rightRows = case selected of
-        Nothing ->
-            roleMuted color (fitTextCell rightWidth "(no agents)") : repeat ""
-        Just entry ->
-            let preview =
-                    transcriptPreviewRows
-                        rightWidth
-                        bodyRows
-                        entry.agentTranscript
-            in map (fitTextCell rightWidth) preview <> repeat ""
-    body =
-        take bodyRows $
-            zipWith (\left right -> left <> divider <> right) leftRows rightRows
-    footer =
-        roleMuted color $
-            fitTextCell cols footerText
 
 pickAgentViewport
     :: Bool

--- a/packages/agent-cli/src/Agent/CLI/Input.hs
+++ b/packages/agent-cli/src/Agent/CLI/Input.hs
@@ -53,6 +53,7 @@ import Agent.CLI.Terminal
     , stripAnsi
     )
 import Agent.Loop (ImageAttachment)
+import Agent.TUI.TextWidth (charCellWidth)
 import Control.Exception.Safe (bracket, bracket_, catchIO, throwIO, tryIO)
 import Control.Monad (unless, when)
 import Data.Bits ((.&.))
@@ -337,31 +338,7 @@ textColumns :: Text -> Int
 textColumns = sum . map charColumns . Text.unpack
 
 charColumns :: Char -> Int
-charColumns char
-    | category `elem` [NonSpacingMark, SpacingCombiningMark, EnclosingMark] = 0
-    | category `elem` [Control, Surrogate, NotAssigned] = 0
-    | isWideCharacter char = 2
-    | otherwise = 1
-  where
-    category = generalCategory char
-
-isWideCharacter :: Char -> Bool
-isWideCharacter char =
-    let code = ord char
-    in code >= 0x1100
-        && ( code <= 0x115f
-            || code == 0x2329
-            || code == 0x232a
-            || (code >= 0x2e80 && code <= 0xa4cf && code /= 0x303f)
-            || (code >= 0xac00 && code <= 0xd7a3)
-            || (code >= 0xf900 && code <= 0xfaff)
-            || (code >= 0xfe10 && code <= 0xfe19)
-            || (code >= 0xfe30 && code <= 0xfe6f)
-            || (code >= 0xff00 && code <= 0xff60)
-            || (code >= 0xffe0 && code <= 0xffe6)
-            || (code >= 0x1f300 && code <= 0x1faff)
-            || (code >= 0x20000 && code <= 0x3fffd)
-           )
+charColumns = charCellWidth
 
 cellsWidth :: [DisplayCell] -> Int
 cellsWidth = sum . map (.displayCellWidth)

--- a/packages/agent-cli/src/Agent/CLI/Render.hs
+++ b/packages/agent-cli/src/Agent/CLI/Render.hs
@@ -68,8 +68,16 @@ import Agent.CLI.Style
     , motionGlyphSet
     , style
     )
-import Agent.JsonText (jsonTextField, jsonTextFieldDefault)
 import Agent.Loop (LoopError(..), LoopEvent(..), TurnOutput(..))
+import Agent.TUI.Presentation
+    ( SearchReplaceAction(..)
+    , SearchReplaceDiff(..)
+    , SearchReplaceLine(..)
+    , formatToolOutput
+    , parseSearchReplaceDiff
+    , summarizeToolCall
+    , toolDetail
+    )
 import Agent.ToolDispatch
     ( ToolCall(..)
     , ToolCallResult(..)
@@ -79,16 +87,11 @@ import Control.Concurrent (ThreadId, forkIO, killThread, threadDelay)
 import Control.Concurrent.MVar (MVar, withMVar)
 import Control.Exception.Safe (tryIO)
 import Control.Monad (unless, void, when)
-import qualified Data.Aeson as Aeson
-import qualified Data.Aeson.Key as Key
-import qualified Data.Aeson.KeyMap as KeyMap
-import qualified Data.Foldable as Foldable
 import Data.IORef
 import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe, isJust)
 import Data.Text (Text)
 import qualified Data.Text as Text
-import qualified Data.Text.Encoding as TextEncoding
 import qualified Data.Text.IO as Text
 import Data.Time.Clock (UTCTime, diffUTCTime, getCurrentTime)
 import Data.Word (Word64)
@@ -527,12 +530,6 @@ putTextLn handle text = do
     Text.hPutStr handle (text <> "\n")
     hFlush handle
 
-summarizeToolCall :: ToolCall -> Text
-summarizeToolCall call =
-    let verb = toolVerb call.name
-        detail = toolDetail call
-    in if Text.null detail then verb else verb <> " " <> detail
-
 -- | Colored tool-start line for stderr chrome.
 --
 -- Known coding tools use English verbs (Read / Listed / $) instead of
@@ -599,11 +596,6 @@ toolChrome name = case canonicalToolName name of
     "ask_user_question" -> ToolChrome "Asked" ToolDetailMuted
     _ -> ToolChrome name ToolDetailMuted
 
-toolVerb :: Text -> Text
-toolVerb name = case toolChrome name of
-    ToolChromeShell -> "$"
-    ToolChrome verb _ -> verb
-
 formatToolBody :: Bool -> ToolCall -> Text
 formatToolBody color call = case canonicalToolName call.name of
     "search_replace" -> formatSearchReplaceDiff color call.arguments
@@ -612,29 +604,30 @@ formatToolBody color call = case canonicalToolName call.name of
 -- | Compact unified-diff preview for @search_replace@ arguments.
 formatSearchReplaceDiff :: Bool -> Text -> Text
 formatSearchReplaceDiff color arguments =
-    let path = jsonTextFieldDefault "file_path" arguments
-        oldText = jsonTextFieldDefault "old_string" arguments
-        newText = jsonTextFieldDefault "new_string" arguments
-        header = case (Text.null oldText, Text.null newText) of
-            (True, False) ->
-                roleMuted color "  create " <> renderToolPath color path
-            (False, True) ->
-                roleMuted color "  delete " <> renderToolPath color path
+    let SearchReplaceDiff { diffPath, diffAction, diffLines, diffHiddenLines } =
+            parseSearchReplaceDiff arguments
+        header = case diffAction of
+            Just SearchReplaceCreate ->
+                roleMuted color "  create " <> renderToolPath color diffPath
+            Just SearchReplaceDelete ->
+                roleMuted color "  delete " <> renderToolPath color diffPath
             _ -> ""
-        oldLines = Text.lines oldText
-        newLines = Text.lines newText
-        minus = map (\line -> style color [SetRGBColor Foreground solarizedRed] ("  -" <> line)) oldLines
-        plus = map (\line -> style color [SetRGBColor Foreground solarizedGreen] ("  +" <> line)) newLines
-        raw = minus <> plus
-        (shown, hidden)
-            | length raw <= 20 = (raw, 0)
-            | otherwise = (take 20 raw, length raw - 20)
+        shown = map paintLine diffLines
         more =
-            if hidden == 0
+            if diffHiddenLines == 0
                 then []
-                else [roleMuted color ("  … " <> Text.pack (show hidden) <> " more")]
+                else
+                    [ roleMuted color
+                        ("  … " <> Text.pack (show diffHiddenLines) <> " more")
+                    ]
         body = shown <> more
     in Text.intercalate "\n" (filter (not . Text.null) (header : body))
+  where
+    paintLine = \case
+        SearchReplaceRemoved line ->
+            style color [SetRGBColor Foreground solarizedRed] ("  -" <> line)
+        SearchReplaceAdded line ->
+            style color [SetRGBColor Foreground solarizedGreen] ("  +" <> line)
 
 renderToolPath :: Bool -> Text -> Text
 renderToolPath color path =
@@ -642,90 +635,6 @@ renderToolPath color path =
     in if "/" `Text.isPrefixOf` path
         then osc8Link color (fileUri (Text.unpack path)) styled
         else styled
-
-toolDetail :: ToolCall -> Text
-toolDetail call = case canonicalToolName call.name of
-    "read_file" -> jsonTextFieldDefault "target_file" call.arguments
-    "list_dir" -> jsonTextFieldDefault "target_directory" call.arguments
-    "search_replace" -> jsonTextFieldDefault "file_path" call.arguments
-    "grep" -> jsonTextFieldDefault "pattern" call.arguments
-    "run_terminal_cmd" -> firstLine (jsonTextFieldDefault "command" call.arguments)
-    "run_ghci" -> firstLine (jsonTextFieldDefault "expression" call.arguments)
-    "shell_command" -> firstLine (jsonTextFieldDefault "command" call.arguments)
-    "apply_patch" -> fromMaybe "patch" (firstPatchPath call.arguments)
-    "update_plan" -> "plan"
-    "enter_plan_mode" -> "enter"
-    "exit_plan_mode" -> "exit"
-    "ask_user_question" -> firstLine (jsonTextFieldDefault "question" call.arguments)
-    "spawn_agent" -> jsonTextFieldDefault "task_name" call.arguments
-    "send_message" -> jsonTextFieldDefault "target" call.arguments
-    "followup_task" -> jsonTextFieldDefault "target" call.arguments
-    "interrupt_agent" -> jsonTextFieldDefault "target" call.arguments
-    "list_agents" ->
-        maybe "" ("under " <>) (nonEmptyJsonText "path_prefix" call.arguments)
-    _ -> ""
-
--- | Turn structured collaboration results into compact terminal text. The
--- provider still receives the original JSON result; this is display-only.
-formatToolOutput :: ToolCall -> Text -> Text
-formatToolOutput call output = case canonicalToolName call.name of
-    "spawn_agent" ->
-        maybe output ("Agent: " <>) (nonEmptyJsonText "task_name" output)
-    "wait_agent" ->
-        fromMaybe output (nonEmptyJsonText "message" output)
-    "list_agents" ->
-        fromMaybe output (formatAgentList output)
-    "interrupt_agent" ->
-        maybe output ("Previous status: " <>)
-            (nonEmptyJsonText "previous_status" output)
-    _ -> output
-
-nonEmptyJsonText :: Text -> Text -> Maybe Text
-nonEmptyJsonText key input = jsonTextField key input >>= \value ->
-    let stripped = Text.strip value
-    in if Text.null stripped then Nothing else Just stripped
-
-formatAgentList :: Text -> Maybe Text
-formatAgentList output = do
-    Aeson.Object object <- Aeson.decodeStrict (TextEncoding.encodeUtf8 output)
-    Aeson.Array agents <- KeyMap.lookup (Key.fromText "agents") object
-    let rows = mapMaybeAgent (Foldable.toList agents)
-    pure $ case rows of
-        [] -> "(no live agents)"
-        _ -> Text.intercalate "\n" rows
-  where
-    mapMaybeAgent = foldr
-        (\value rest ->
-            case value of
-                Aeson.Object agent ->
-                    case
-                        ( jsonObjectText "agent_name" agent
-                        , jsonObjectText "agent_status" agent
-                        ) of
-                        (Just name, Just status) ->
-                            (name <> " · " <> status) : rest
-                        (Just name, Nothing) -> name : rest
-                        _ -> rest
-                _ -> rest)
-        []
-
-jsonObjectText :: Text -> Aeson.Object -> Maybe Text
-jsonObjectText key object =
-    case KeyMap.lookup (Key.fromText key) object of
-        Just (Aeson.String value)
-            | not (Text.null (Text.strip value)) -> Just (Text.strip value)
-        _ -> Nothing
-
-firstPatchPath :: Text -> Maybe Text
-firstPatchPath patch =
-    case
-        [ Text.drop (Text.length prefix) line
-        | line <- Text.lines patch
-        , prefix <- ["*** Add File: ", "*** Update File: ", "*** Delete File: "]
-        , prefix `Text.isPrefixOf` line
-        ] of
-        (path : _) | not (Text.null path) -> Just path
-        _ -> Nothing
 
 truncateToolOutput :: Text -> Text
 truncateToolOutput output =
@@ -744,9 +653,6 @@ truncateToolOutput output =
                 <> if rest > 0
                     then "\n" <> glyphToolAccent <> glyphToolOut <> "… " <> Text.pack (show rest) <> " more"
                     else ""
-
-firstLine :: Text -> Text
-firstLine = Text.takeWhile (/= '\n')
 
 formatLoopError :: LoopError -> Text
 formatLoopError = formatLoopErrorColored False

--- a/packages/agent-cli/src/Agent/CLI/Resume.hs
+++ b/packages/agent-cli/src/Agent/CLI/Resume.hs
@@ -40,10 +40,9 @@ import Agent.CLI.Session
     )
 import Agent.CLI.Style (roleMuted, rolePrompt, roleSuccess)
 import Agent.CLI.TextLayout
-    ( clampSelectionIndex
-    , fitTextCell
-    , selectionWindow
-    , transcriptPreviewRows
+    ( SplitPaneFrame(..)
+    , clampSelectionIndex
+    , renderSplitPaneFrame
     )
 import Agent.OsPath (toText)
 import Agent.Provider (providerSlug)
@@ -456,64 +455,37 @@ renderResumeFrame color = renderResumeFrameFor color 24 100
 -- tail of that selected session's transcript.
 renderResumeFrameFor :: Bool -> Int -> Int -> ResumeState -> Text
 renderResumeFrameFor color terminalRows terminalCols state =
-    Text.intercalate "\n" (header : headings : body <> [footer])
+    renderSplitPaneFrame SplitPaneFrame
+        { splitPaneMinColumns = 12
+        , splitPaneColumns = terminalCols
+        -- Leave the final terminal row unused. Redrawing a frame that exactly
+        -- fills the viewport would scroll its first line and duplicate the header.
+        , splitPaneBodyRows = max 1 (terminalRows - 4)
+        , splitPaneLeftMinWidth = 8
+        , splitPaneLeftMaxWidth = 34
+        , splitPaneDivider = " │ "
+        , splitPaneTitle = "resume"
+        , splitPaneHeaderDetail = const filterText
+        , splitPaneLeftHeading = "sessions"
+        , splitPaneRightHeading =
+            \selected ->
+                "transcript"
+                    <> maybe "" (\entry -> " · " <> entry.resumeTitle) selected
+        , splitPaneItems = visibleResume state
+        , splitPaneSelectedIndex = state.resumeIndex
+        , splitPaneLeftLabel = \_ entry -> entry.resumeTitle
+        , splitPaneTranscript = (.resumeTranscript)
+        , splitPaneEmptyTranscript = "(no sessions)"
+        , splitPaneFooter =
+            "↑↓/jk or scroll · click/enter resume · esc/q cancel · type to filter"
+        , splitPanePromptStyle = rolePrompt color
+        , splitPaneMutedStyle = roleMuted color
+        , splitPaneSelectedStyle = roleSuccess color
+        }
   where
-    cols = max 12 terminalCols
-    -- Leave the final terminal row unused. Redrawing a frame that exactly
-    -- fills the viewport would scroll its first line and duplicate the header.
-    bodyRows = max 1 (terminalRows - 4)
-    divider = roleMuted color " │ "
-    leftWidth = max 8 (min 34 ((cols - 3) * 2 `div` 5))
-    rightWidth = max 1 (cols - leftWidth - 3)
-    visible = visibleResume state
-    n = length visible
-    idx = clampSelectionIndex n state.resumeIndex
-    shown = selectionWindow bodyRows idx visible
-    selected = selectedResume state
     filterText
         | Text.null state.resumeFilter = "type to filter"
         | otherwise = "filter: " <> state.resumeFilter
-    header =
-        rolePrompt color "resume"
-            <> roleMuted color
-                (fitTextCell (max 0 (cols - 6)) (" · " <> filterText))
-    headings =
-        rolePrompt color (fitTextCell leftWidth "sessions")
-            <> divider
-            <> rolePrompt color
-                (fitTextCell rightWidth
-                    ("transcript"
-                        <> maybe "" (\entry -> " · " <> entry.resumeTitle) selected))
-    leftRows =
-        map
-            (\(absoluteIndex, entry) ->
-                let prefix = if absoluteIndex == idx then "› " else "  "
-                    text = fitTextCell leftWidth (prefix <> entry.resumeTitle)
-                in if absoluteIndex == idx
-                    then roleSuccess color text
-                    else text)
-            shown
-            <> repeat (Text.replicate leftWidth " ")
-    rightRows = case selected of
-        Nothing ->
-            roleMuted color (fitTextCell rightWidth "(no sessions)") : repeat ""
-        Just entry ->
-            let preview =
-                    transcriptPreviewRows
-                        rightWidth
-                        bodyRows
-                        entry.resumeTranscript
-            in map (fitTextCell rightWidth) preview <> repeat ""
-    body =
-        take bodyRows $
-            zipWith
-                (\left right -> left <> divider <> right)
-                leftRows
-                rightRows
-    footer =
-        roleMuted color $
-            fitTextCell cols
-                "↑↓/jk or scroll · click/enter resume · esc/q cancel · type to filter"
 
 transcriptLines :: [SessionTurn] -> [Text]
 transcriptLines = concatMap turnLines

--- a/packages/agent-cli/src/Agent/CLI/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session.hs
@@ -272,7 +272,20 @@ appendTurnWithMetaUpdate
     -> SessionTurn
     -> (SessionMeta -> SessionMeta)
     -> IO SessionHandle
-appendTurnWithMetaUpdate handle turn updateMeta = do
+appendTurnWithMetaUpdate handle turn updateMeta =
+    appendTurnWithMetaTransition handle turn
+        (updateMeta . applyTurnMetadata turn)
+
+-- | Append a transcript turn and persist one metadata transition. Timestamp
+-- and response-id updates are common to every kind of turn; the supplied
+-- transition controls whether title, usage, or caller-specific metadata is
+-- changed.
+appendTurnWithMetaTransition
+    :: SessionHandle
+    -> SessionTurn
+    -> (SessionMeta -> SessionMeta)
+    -> IO SessionHandle
+appendTurnWithMetaTransition handle turn transition = do
     let path = handle.sessionTranscriptPath
     existed <- doesFileExist path
     appendLazyFileRetryingOpen path (Aeson.encode turn <> "\n")
@@ -282,20 +295,25 @@ appendTurnWithMetaUpdate handle turn updateMeta = do
         meta = meta0
             { metaUpdatedAt = now
             , metaLastResponseId = turn.turnResponseId <|> meta0.metaLastResponseId
-            , metaTitle =
-                if meta0.metaTitle == "untitled" && not (Text.null turn.turnUserText)
-                    then sessionTitleFromPrompt turn.turnUserText
-                    else meta0.metaTitle
-            , metaInputTokens =
-                meta0.metaInputTokens + maybe 0 (.inputTokens) turn.turnUsage
-            , metaOutputTokens =
-                meta0.metaOutputTokens + maybe 0 (.outputTokens) turn.turnUsage
-            , metaCachedTokens =
-                meta0.metaCachedTokens + maybe 0 (.cachedTokens) turn.turnUsage
             }
-        finalMeta = updateMeta meta
+        finalMeta = transition meta
     writeSessionMeta handle.sessionMetaPath finalMeta
     pure handle { sessionMeta = finalMeta }
+
+applyTurnMetadata :: SessionTurn -> SessionMeta -> SessionMeta
+applyTurnMetadata turn meta =
+    meta
+        { metaTitle =
+            if meta.metaTitle == "untitled" && not (Text.null turn.turnUserText)
+                then sessionTitleFromPrompt turn.turnUserText
+                else meta.metaTitle
+        , metaInputTokens =
+            meta.metaInputTokens + maybe 0 (.inputTokens) turn.turnUsage
+        , metaOutputTokens =
+            meta.metaOutputTokens + maybe 0 (.outputTokens) turn.turnUsage
+        , metaCachedTokens =
+            meta.metaCachedTokens + maybe 0 (.cachedTokens) turn.turnUsage
+        }
 
 -- | Persist provider usage that is not represented by its own transcript
 -- turn, such as an inline compaction request. Session metadata is the
@@ -337,22 +355,11 @@ sessionTitleTurnCountFromSlot = \case
             PersistencePending _ -> pure 0
             PersistenceActive handle -> pure handle.sessionMeta.metaTitleUserTurns
 
--- | Like 'appendTurn', but never derives the session title from this turn.
--- Used for synthetic markers such as @/new@ and @/clear@.
+-- | Append a synthetic marker without deriving a title or aggregating usage.
+-- Used for markers such as @/new@ and @/clear@.
 appendTurnKeepTitle :: SessionHandle -> SessionTurn -> IO SessionHandle
-appendTurnKeepTitle handle turn = do
-    let path = handle.sessionTranscriptPath
-    existed <- doesFileExist path
-    appendLazyFileRetryingOpen path (Aeson.encode turn <> "\n")
-    if existed then pure () else setFileMode (unsafeToFilePath path) 0o600
-    now <- getCurrentTime
-    let meta0 = handle.sessionMeta
-        meta = meta0
-            { metaUpdatedAt = now
-            , metaLastResponseId = turn.turnResponseId <|> meta0.metaLastResponseId
-            }
-    writeSessionMeta handle.sessionMetaPath meta
-    pure handle { sessionMeta = meta }
+appendTurnKeepTitle handle turn =
+    appendTurnWithMetaTransition handle turn id
 
 
 loadSession :: OsPath -> Text -> IO (Either Text (SessionMeta, [SessionTurn]))

--- a/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
@@ -37,6 +37,8 @@ import Agent.InterAgentMessage
 import Agent.Loop
     ( Backend(..)
     , LoopConfig(..)
+    , LoopError
+    , LoopEvent
     , LoopResult(..)
     , TurnInput(..)
     , defaultLoopDispatch
@@ -97,7 +99,11 @@ import Agent.Tools.MultiAgents
     , MultiAgentContext(..)
     )
 import Agent.Tools.PlanMode (PlanModeEnv(..), PlanModeHooks)
-import Agent.Tools.Types (ToolEnv(..), defaultToolEnv)
+import Agent.Tools.Types
+    ( ToolEnv(..)
+    , ToolRegistry
+    , defaultToolEnv
+    )
 import Control.Exception.Safe (finally)
 import Data.IORef
 import Data.Map.Strict (Map)
@@ -124,6 +130,13 @@ data SubagentRuntime = SubagentRuntime
     , subagentSessions :: !(IORef (Map SubagentId SubagentSession))
     , subagentStoreRoot :: !SubagentStoreRoot
     , subagentTypes :: !GrokSubagentSpecs
+    }
+
+data PreparedChild = PreparedChild
+    { preparedParentParams :: !ResponseCreateParams
+    , preparedSession :: !SubagentSession
+    , preparedToolEnv :: !ToolEnv
+    , preparedMultiContext :: !MultiAgentContext
     }
 
 -- | Prefer an explicit store root; otherwise fall back to planMode's session dir.
@@ -319,57 +332,28 @@ runCodexSubagent
     -> RunSubagent
 runCodexSubagent runtime tokenProvider sendToRoot =
     \env previous prompt onEvent -> do
-        parentParams <- readIORef runtime.subagentParams
-        childEnv <- defaultToolEnv env.subCwd
-        childPath <-
-            fromMaybe taskPathRoot
-                <$> getTaskPath runtime.subagentRegistry env.subId
-        session <-
-            lookupOrCreateSubagentSession
-                runtime.subagentSessions
-                runtime.subagentStoreRoot
-                runtime.subagentTypes
-                env.subId
-        nestedForkSource <- newIORef (Just session.subSessionTranscript)
+        prepared <- prepareChild runtime env sendToRoot
         childModel <- lookupAgentModel runtime.subagentTypes env.subId
         childEffort <- lookupAgentReasoningEffort runtime.subagentTypes env.subId
-        let childToolEnv = childEnv { toolCancel = env.subCancel }
-            childCtx = MultiAgentContext
-                { multiRegistry = runtime.subagentRegistry
-                , multiSelfId = Just env.subId
-                , multiDepth = env.subDepth
-                , multiTaskPath = childPath
-                , multiRootTurnId = pure env.subRootTurnId
-                , multiResumeFromDisk = Nothing
-                , multiCreateWorktree = Nothing
-                , multiPrepareSpawn = Just
-                    (prepareCollaborationSpawn
-                        runtime.subagentSessions
-                        runtime.subagentStoreRoot
-                        runtime.subagentTypes
-                        nestedForkSource)
-                , multiSendToRoot = sendToRoot
-                }
         coding <-
             codingToolsFor
                 OpenAIProvider
-                childToolEnv
+                prepared.preparedToolEnv
                 (Just runtime.subagentPlanHooks)
-                (Just childCtx)
+                (Just prepared.preparedMultiContext)
         syncStoreRootFromPlan runtime.subagentStoreRoot coding.codingPlanMode
         flip finally coding.codingClose do
             today <- utctDay <$> getCurrentTime
-            let model = fromMaybe
-                    (fromMaybe (defaultModelFor OpenAIProvider) parentParams.model)
-                    childModel
-                inheritedEffort = case parentParams.reasoning of
-                    Just cfg -> fromMaybe (defaultEffortFor OpenAIProvider) cfg.effort
-                    Nothing -> defaultEffortFor OpenAIProvider
-                effort = fromMaybe inheritedEffort childEffort
+            let (model, effort) =
+                    resolveChildModelAndEffort
+                        OpenAIProvider
+                        prepared.preparedParentParams
+                        childModel
+                        childEffort
                 baseInstructions =
                     fromMaybe
                         (systemPrompt OpenAIProvider env.subCwd today True)
-                        parentParams.instructions
+                        prepared.preparedParentParams.instructions
                 instructions =
                     baseInstructions
                         <> "\n\nYou are a Codex subagent. Complete the assigned task and "
@@ -384,13 +368,14 @@ runCodexSubagent runtime tokenProvider sendToRoot =
             httpFallbackActive <- newIORef False
             let websocketBackend =
                     freshOpenAiBackend tokenProvider
-                        (readIORef childParamsRef) session.subSessionTranscript
+                        (readIORef childParamsRef)
+                        prepared.preparedSession.subSessionTranscript
                 httpBackend =
                     statelessResponsesBackend
                         (\request _onEvent ->
                             OpenAI.createCodexMessageWithProvider tokenProvider request)
                         (readIORef childParamsRef)
-                        session.subSessionTranscript
+                        prepared.preparedSession.subSessionTranscript
                 baseBackend =
                     openAiBackendWithTransportFallback
                         httpFallbackActive
@@ -402,37 +387,13 @@ runCodexSubagent runtime tokenProvider sendToRoot =
                             runtime.subagentOptions.optCompactThreshold
                             tokenProvider
                             (readIORef childParamsRef)
-                            session.subSessionTranscript
-                            session.subSessionContextTokens
+                            prepared.preparedSession.subSessionTranscript
+                            prepared.preparedSession.subSessionContextTokens
                             baseBackend
-                config = LoopConfig
-                    { loopBackend = backend
-                    , loopTools = toolRegistry
-                    , loopDispatch = defaultLoopDispatch
-                    , loopMaxTurns = runtime.subagentOptions.optMaxTurns
-                    , loopOnEvent = onEvent
-                    , loopApprove =
-                        \call ->
-                            childApprove runtime.subagentPolicy toolRegistry call
-                    , loopCancel = env.subCancel
-                    }
-            result <- runLoopInputs config previous [AgentMessage prompt]
-            case result of
-                Right loopResult ->
-                    setPreviousResponseId
-                        runtime.subagentRegistry
-                        env.subId
-                        loopResult.finalResponseId
-                Left _ ->
-                    modifyIORef' session.subSessionTranscript
-                        trimDanglingToolSuffix
-            persistSubagentSnapshot
-                runtime.subagentStoreRoot
-                runtime.subagentRegistry
-                runtime.subagentTypes
-                env.subId
-                session.subSessionTranscript
-            pure result
+            runPreparedChild
+                runtime env prepared.preparedSession toolRegistry backend onEvent
+                (\config ->
+                    runLoopInputs config previous [AgentMessage prompt])
 
 -- | Child XAI/OpenRouter agent: HTTP backend, filtered tools by subagent_type.
 runHttpSubagent
@@ -442,35 +403,7 @@ runHttpSubagent
     -> RunSubagent
 runHttpSubagent runtime provider mkBackend =
     \env previous prompt onEvent -> do
-        parentParams <- readIORef runtime.subagentParams
-        childEnv <- defaultToolEnv env.subCwd
-        childPath <-
-            fromMaybe taskPathRoot
-                <$> getTaskPath runtime.subagentRegistry env.subId
-        session <-
-            lookupOrCreateSubagentSession
-                runtime.subagentSessions
-                runtime.subagentStoreRoot
-                runtime.subagentTypes
-                env.subId
-        nestedForkSource <- newIORef (Just session.subSessionTranscript)
-        let childToolEnv = childEnv { toolCancel = env.subCancel }
-            childCtx = MultiAgentContext
-                { multiRegistry = runtime.subagentRegistry
-                , multiSelfId = Just env.subId
-                , multiDepth = env.subDepth
-                , multiTaskPath = childPath
-                , multiRootTurnId = pure env.subRootTurnId
-                , multiResumeFromDisk = Nothing
-                , multiCreateWorktree = Nothing
-                , multiPrepareSpawn = Just
-                    (prepareCollaborationSpawn
-                        runtime.subagentSessions
-                        runtime.subagentStoreRoot
-                        runtime.subagentTypes
-                        nestedForkSource)
-                , multiSendToRoot = Nothing
-                }
+        prepared <- prepareChild runtime env Nothing
         agentType <-
             fromMaybe defaultSubagentType
                 <$> lookupAgentType runtime.subagentTypes env.subId
@@ -480,18 +413,17 @@ runHttpSubagent runtime provider mkBackend =
         coding <-
             codingToolsFor
                 provider
-                childToolEnv
+                prepared.preparedToolEnv
                 (Just runtime.subagentPlanHooks)
-                (Just childCtx)
+                (Just prepared.preparedMultiContext)
         flip finally coding.codingClose do
             today <- utctDay <$> getCurrentTime
-            let model = fromMaybe
-                    (fromMaybe (defaultModelFor provider) parentParams.model)
-                    childModel
-                inheritedEffort = case parentParams.reasoning of
-                    Just cfg -> fromMaybe (defaultEffortFor provider) cfg.effort
-                    Nothing -> defaultEffortFor provider
-                effort = fromMaybe inheritedEffort childEffort
+            let (model, effort) =
+                    resolveChildModelAndEffort
+                        provider
+                        prepared.preparedParentParams
+                        childModel
+                        childEffort
                 baseInstructions = systemPrompt provider env.subCwd today True
                 instructions =
                     baseInstructions
@@ -504,35 +436,111 @@ runHttpSubagent runtime provider mkBackend =
             childParamsRef <- newIORef childParams
             let backend =
                     withConnectionRecovery $
-                        mkBackend childParamsRef session.subSessionTranscript
-                config = LoopConfig
-                    { loopBackend = backend
-                    , loopTools = toolRegistry
-                    , loopDispatch = defaultLoopDispatch
-                    , loopMaxTurns = runtime.subagentOptions.optMaxTurns
-                    , loopOnEvent = onEvent
-                    , loopApprove =
-                        \call ->
-                            childApprove runtime.subagentPolicy toolRegistry call
-                    , loopCancel = env.subCancel
-                    }
-            result <- runLoop config previous (interAgentMessagePayload prompt)
-            case result of
-                Right loopResult ->
-                    setPreviousResponseId
-                        runtime.subagentRegistry
-                        env.subId
-                        loopResult.finalResponseId
-                Left _ ->
-                    modifyIORef' session.subSessionTranscript
-                        trimDanglingToolSuffix
-            persistSubagentSnapshot
-                runtime.subagentStoreRoot
+                        mkBackend
+                            childParamsRef
+                            prepared.preparedSession.subSessionTranscript
+            runPreparedChild
+                runtime env prepared.preparedSession toolRegistry backend onEvent
+                (\config ->
+                    runLoop config previous (interAgentMessagePayload prompt))
+
+prepareChild
+    :: SubagentRuntime
+    -> SubagentSpawnEnv
+    -> Maybe (InterAgentMessage -> IO (Either Text Text))
+    -> IO PreparedChild
+prepareChild runtime env sendToRoot = do
+    parentParams <- readIORef runtime.subagentParams
+    childEnv <- defaultToolEnv env.subCwd
+    childPath <-
+        fromMaybe taskPathRoot
+            <$> getTaskPath runtime.subagentRegistry env.subId
+    session <-
+        lookupOrCreateSubagentSession
+            runtime.subagentSessions
+            runtime.subagentStoreRoot
+            runtime.subagentTypes
+            env.subId
+    nestedForkSource <- newIORef (Just session.subSessionTranscript)
+    let childToolEnv = childEnv { toolCancel = env.subCancel }
+        childCtx = MultiAgentContext
+            { multiRegistry = runtime.subagentRegistry
+            , multiSelfId = Just env.subId
+            , multiDepth = env.subDepth
+            , multiTaskPath = childPath
+            , multiRootTurnId = pure env.subRootTurnId
+            , multiResumeFromDisk = Nothing
+            , multiCreateWorktree = Nothing
+            , multiPrepareSpawn = Just
+                (prepareCollaborationSpawn
+                    runtime.subagentSessions
+                    runtime.subagentStoreRoot
+                    runtime.subagentTypes
+                    nestedForkSource)
+            , multiSendToRoot = sendToRoot
+            }
+    pure PreparedChild
+        { preparedParentParams = parentParams
+        , preparedSession = session
+        , preparedToolEnv = childToolEnv
+        , preparedMultiContext = childCtx
+        }
+
+resolveChildModelAndEffort
+    :: Provider
+    -> ResponseCreateParams
+    -> Maybe Text
+    -> Maybe Text
+    -> (Text, Text)
+resolveChildModelAndEffort provider parentParams childModel childEffort =
+    ( model
+    , fromMaybe inheritedEffort childEffort
+    )
+  where
+    model = fromMaybe
+        (fromMaybe (defaultModelFor provider) parentParams.model)
+        childModel
+    inheritedEffort = case parentParams.reasoning of
+        Just cfg -> fromMaybe (defaultEffortFor provider) cfg.effort
+        Nothing -> defaultEffortFor provider
+
+runPreparedChild
+    :: SubagentRuntime
+    -> SubagentSpawnEnv
+    -> SubagentSession
+    -> ToolRegistry
+    -> Backend
+    -> (LoopEvent -> IO ())
+    -> (LoopConfig -> IO (Either LoopError LoopResult))
+    -> IO (Either LoopError LoopResult)
+runPreparedChild runtime env session toolRegistry backend onEvent runChild = do
+    let config = LoopConfig
+            { loopBackend = backend
+            , loopTools = toolRegistry
+            , loopDispatch = defaultLoopDispatch
+            , loopMaxTurns = runtime.subagentOptions.optMaxTurns
+            , loopOnEvent = onEvent
+            , loopApprove =
+                \call ->
+                    childApprove runtime.subagentPolicy toolRegistry call
+            , loopCancel = env.subCancel
+            }
+    result <- runChild config
+    case result of
+        Right loopResult ->
+            setPreviousResponseId
                 runtime.subagentRegistry
-                runtime.subagentTypes
                 env.subId
-                session.subSessionTranscript
-            pure result
+                loopResult.finalResponseId
+        Left _ ->
+            modifyIORef' session.subSessionTranscript trimDanglingToolSuffix
+    persistSubagentSnapshot
+        runtime.subagentStoreRoot
+        runtime.subagentRegistry
+        runtime.subagentTypes
+        env.subId
+        session.subSessionTranscript
+    pure result
 
 grokSubagentSuffix :: Text -> SubagentId -> Text
 grokSubagentSuffix agentType agentId =

--- a/packages/agent-cli/src/Agent/CLI/TextLayout.hs
+++ b/packages/agent-cli/src/Agent/CLI/TextLayout.hs
@@ -1,13 +1,111 @@
 -- | Text layout helpers shared by fixed-size CLI overlays.
 module Agent.CLI.TextLayout
-    ( clampSelectionIndex
+    ( SplitPaneFrame(..)
+    , clampSelectionIndex
     , fitTextCell
+    , renderSplitPaneFrame
     , selectionWindow
     , transcriptPreviewRows
     ) where
 
 import Data.Text (Text)
 import qualified Data.Text as Text
+
+-- | Presentation inputs for a fixed-height, two-column selection overlay.
+--
+-- The renderer owns the shared layout, selection-window, padding, and
+-- transcript-tail behavior. Callers supply domain labels and styling.
+data SplitPaneFrame item = SplitPaneFrame
+    { splitPaneMinColumns :: !Int
+    , splitPaneColumns :: !Int
+    , splitPaneBodyRows :: !Int
+    , splitPaneLeftMinWidth :: !Int
+    , splitPaneLeftMaxWidth :: !Int
+    , splitPaneDivider :: !Text
+    , splitPaneTitle :: !Text
+    , splitPaneHeaderDetail :: !(Int -> Text)
+    , splitPaneLeftHeading :: !Text
+    , splitPaneRightHeading :: !(Maybe item -> Text)
+    , splitPaneItems :: ![item]
+    , splitPaneSelectedIndex :: !Int
+    , splitPaneLeftLabel :: !(Int -> item -> Text)
+    , splitPaneTranscript :: !(item -> [Text])
+    , splitPaneEmptyTranscript :: !Text
+    , splitPaneFooter :: !Text
+    , splitPanePromptStyle :: !(Text -> Text)
+    , splitPaneMutedStyle :: !(Text -> Text)
+    , splitPaneSelectedStyle :: !(Text -> Text)
+    }
+
+renderSplitPaneFrame :: SplitPaneFrame item -> Text
+renderSplitPaneFrame frame =
+    Text.intercalate "\n" (header : headings : body <> [footer])
+  where
+    cols = max frame.splitPaneMinColumns frame.splitPaneColumns
+    bodyRows = frame.splitPaneBodyRows
+    dividerWidth = Text.length frame.splitPaneDivider
+    divider = frame.splitPaneMutedStyle frame.splitPaneDivider
+    leftWidth =
+        max frame.splitPaneLeftMinWidth $
+            min frame.splitPaneLeftMaxWidth
+                ((cols - dividerWidth) * 2 `div` 5)
+    rightWidth = max 1 (cols - leftWidth - dividerWidth)
+    items = frame.splitPaneItems
+    itemCount = length items
+    selectedIndex =
+        clampSelectionIndex itemCount frame.splitPaneSelectedIndex
+    shown = selectionWindow bodyRows selectedIndex items
+    selected = atMay selectedIndex items
+    header =
+        frame.splitPanePromptStyle frame.splitPaneTitle
+            <> frame.splitPaneMutedStyle
+                (fitTextCell
+                    (max 0 (cols - Text.length frame.splitPaneTitle))
+                    (" · " <> frame.splitPaneHeaderDetail itemCount))
+    headings =
+        frame.splitPanePromptStyle
+            (fitTextCell leftWidth frame.splitPaneLeftHeading)
+            <> divider
+            <> frame.splitPanePromptStyle
+                (fitTextCell rightWidth
+                    (frame.splitPaneRightHeading selected))
+    leftRows =
+        map
+            (\(absoluteIndex, item) ->
+                let prefix =
+                        if absoluteIndex == selectedIndex then "› " else "  "
+                    text =
+                        fitTextCell leftWidth
+                            (prefix
+                                <> frame.splitPaneLeftLabel absoluteIndex item)
+                in if absoluteIndex == selectedIndex
+                    then frame.splitPaneSelectedStyle text
+                    else text)
+            shown
+            <> repeat (Text.replicate leftWidth " ")
+    rightRows = case selected of
+        Nothing ->
+            frame.splitPaneMutedStyle
+                (fitTextCell rightWidth frame.splitPaneEmptyTranscript)
+                : repeat ""
+        Just item ->
+            map (fitTextCell rightWidth)
+                (transcriptPreviewRows
+                    rightWidth bodyRows (frame.splitPaneTranscript item))
+                <> repeat ""
+    body =
+        take bodyRows $
+            zipWith (\left right -> left <> divider <> right) leftRows rightRows
+    footer =
+        frame.splitPaneMutedStyle $
+            fitTextCell cols frame.splitPaneFooter
+
+atMay :: Int -> [a] -> Maybe a
+atMay index values
+    | index < 0 = Nothing
+    | otherwise = case drop index values of
+        value : _ -> Just value
+        [] -> Nothing
 
 clampSelectionIndex :: Int -> Int -> Int
 clampSelectionIndex count index

--- a/packages/agent-cli/test/Agent/CLI/SessionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SessionSpec.hs
@@ -157,6 +157,38 @@ spec = describe "Agent.CLI.Session" do
                         meta `shouldBe` handle'.sessionMeta
                         turns `shouldBe` [turn]
 
+        it "keeps synthetic turns out of title and usage metadata" $
+            withTempDir "agent-sessions-" \root -> do
+                handle <- createSession (testCreate root)
+                let turn = SessionTurn
+                        { turnAt = fixedTime
+                        , turnUserText = "/clear"
+                        , turnAssistantText = Just "Started a new conversation."
+                        , turnError = Nothing
+                        , turnResponseId = Just "resp-marker"
+                        , turnItems = []
+                        , turnUsage = Just TokenUsage
+                            { inputTokens = 11
+                            , outputTokens = 5
+                            , cachedTokens = 3
+                            }
+                        }
+                handle' <- appendTurnKeepTitle handle turn
+
+                handle'.sessionMeta.metaTitle `shouldBe` "untitled"
+                handle'.sessionMeta.metaLastResponseId
+                    `shouldBe` Just "resp-marker"
+                handle'.sessionMeta.metaInputTokens `shouldBe` 0
+                handle'.sessionMeta.metaOutputTokens `shouldBe` 0
+                handle'.sessionMeta.metaCachedTokens `shouldBe` 0
+                modeOf handle.sessionTranscriptPath `shouldReturn` 0o600
+
+                loadSession root handle.sessionMeta.metaId >>= \case
+                    Left err -> expectationFailure (Text.unpack err)
+                    Right (meta, turns) -> do
+                        meta `shouldBe` handle'.sessionMeta
+                        turns `shouldBe` [turn]
+
         it "commits a compact marker with a cleared response id" $
             withTempDir "agent-sessions-" \root -> do
                 handle <- createSession (testCreate root)

--- a/packages/agent-cli/test/Agent/CLI/TextLayoutSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TextLayoutSpec.hs
@@ -1,6 +1,7 @@
 module Agent.CLI.TextLayoutSpec (spec) where
 
 import Agent.CLI.TextLayout
+import qualified Data.Text as Text
 import Test.Hspec
 
 spec :: Spec
@@ -52,3 +53,34 @@ spec = do
             fitTextCell 4 "abcde" `shouldBe` "abc…"
             fitTextCell 1 "ab" `shouldBe` "…"
             fitTextCell 0 "ab" `shouldBe` ""
+
+    describe "renderSplitPaneFrame" do
+        it "keeps the selected item visible and previews its transcript" do
+            let frame = renderSplitPaneFrame SplitPaneFrame
+                    { splitPaneMinColumns = 20
+                    , splitPaneColumns = 20
+                    , splitPaneBodyRows = 2
+                    , splitPaneLeftMinWidth = 6
+                    , splitPaneLeftMaxWidth = 6
+                    , splitPaneDivider = " │ "
+                    , splitPaneTitle = "pick"
+                    , splitPaneHeaderDetail =
+                        \count -> Text.pack (show count) <> " items"
+                    , splitPaneLeftHeading = "items"
+                    , splitPaneRightHeading =
+                        maybe "preview" ("preview " <>)
+                    , splitPaneItems = ["one", "two", "three"]
+                    , splitPaneSelectedIndex = 2
+                    , splitPaneLeftLabel = \_ item -> item
+                    , splitPaneTranscript = \item -> [item <> " transcript"]
+                    , splitPaneEmptyTranscript = "(none)"
+                    , splitPaneFooter = "keys"
+                    , splitPanePromptStyle = id
+                    , splitPaneMutedStyle = id
+                    , splitPaneSelectedStyle = ("selected:" <>)
+                    }
+            frame `shouldSatisfy` Text.isInfixOf "  two "
+            frame `shouldSatisfy` Text.isInfixOf "selected:› thr…"
+            frame `shouldSatisfy` Text.isInfixOf "three trans"
+            frame `shouldSatisfy` Text.isInfixOf "cript"
+            length (Text.lines frame) `shouldBe` 5

--- a/packages/agent-core/agent-core.cabal
+++ b/packages/agent-core/agent-core.cabal
@@ -37,7 +37,8 @@ common common-opts
 
 library
     import:           common-opts
-    exposed-modules:  Agent.Cancel
+    exposed-modules:  Agent.Auth.JWT
+                    , Agent.Cancel
                     , Agent.Error
                     , Agent.FileRetry
                     , Agent.InterAgentMessage
@@ -89,6 +90,7 @@ library
     build-depends:    base >= 4.14 && < 5
                     , aeson >= 2.0
                     , async
+                    , base64-bytestring
                     , bytestring
                     , containers
                     , crypton-connection
@@ -114,7 +116,8 @@ test-suite agent-core-test
     type:             exitcode-stdio-1.0
     hs-source-dirs:   test
     main-is:          Spec.hs
-    other-modules:    Agent.CancelSpec
+    other-modules:    Agent.Auth.JWTSpec
+                    , Agent.CancelSpec
                     , Agent.ErrorSpec
                     , Agent.Http.HeaderSpec
                     , Agent.LoopSpec
@@ -143,6 +146,7 @@ test-suite agent-core-test
                     , agent-core
                     , aeson
                     , async
+                    , base64-bytestring
                     , directory
                     , filepath
                     , containers

--- a/packages/agent-core/src/Agent/Auth/JWT.hs
+++ b/packages/agent-core/src/Agent/Auth/JWT.hs
@@ -1,0 +1,36 @@
+-- | Provider-neutral helpers for reading unverified JWT payloads.
+--
+-- These helpers decode claims for metadata such as account identity and token
+-- expiry. They do not verify signatures and must not be used for authorization.
+module Agent.Auth.JWT
+    ( decodeJwtPayload
+    ) where
+
+import Data.Aeson (FromJSON)
+import qualified Data.Aeson as Aeson
+import qualified "base64-bytestring" Data.ByteString.Base64 as Base64
+import qualified Data.ByteString.Lazy as LBS
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
+
+-- | Decode the JSON payload (the second dot-separated segment) of a JWT
+-- without verifying its signature.
+decodeJwtPayload :: FromJSON value => Text -> Maybe value
+decodeJwtPayload token = do
+    payload <- case Text.splitOn "." token of
+        (_header : encodedPayload : _) -> Just encodedPayload
+        _ -> Nothing
+    bytes <- either (const Nothing) Just $
+        Base64.decode (Text.encodeUtf8 (base64UrlToBase64 payload))
+    Aeson.decode (LBS.fromStrict bytes)
+
+base64UrlToBase64 :: Text -> Text
+base64UrlToBase64 input =
+    replaced <> Text.replicate paddingLength "="
+  where
+    replaced = Text.map replace input
+    replace '-' = '+'
+    replace '_' = '/'
+    replace character = character
+    paddingLength = (4 - Text.length replaced `mod` 4) `mod` 4

--- a/packages/agent-core/src/Agent/OsPath.hs
+++ b/packages/agent-core/src/Agent/OsPath.hs
@@ -3,7 +3,8 @@
 -- Import 'OsPath' and the standard encoding functions directly from
 -- "System.OsPath".
 module Agent.OsPath
-    ( fromText
+    ( directoryChain
+    , fromText
     , toText
     , unsafeToFilePath
     ) where
@@ -11,8 +12,24 @@ module Agent.OsPath
 import Control.Exception.Safe (impureThrow)
 import Data.Text (Text)
 import qualified Data.Text as Text
-import System.OsPath (OsPath, decodeUtf)
+import System.OsPath (OsPath, decodeUtf, takeDirectory)
 import qualified System.OsPath as OsPath
+
+-- | Directories from @root@ through @cwd@, inclusive.
+--
+-- If @cwd@ is not contained by @root@, return only @cwd@. Callers use this
+-- fallback to avoid discovering files from unrelated filesystem ancestors.
+-- Inputs are expected to be absolute and normalized by the caller.
+directoryChain :: OsPath -> OsPath -> [OsPath]
+directoryChain root cwd =
+    maybe [cwd] reverse (walk cwd)
+  where
+    walk dir
+        | dir == root = Just [dir]
+        | parent == dir = Nothing
+        | otherwise = (dir :) <$> walk parent
+      where
+        parent = takeDirectory dir
 
 -- | Pure UTF encoding for path values that originate as Unicode text.
 fromText :: Text -> OsPath

--- a/packages/agent-core/src/Agent/ProjectInstructions.hs
+++ b/packages/agent-core/src/Agent/ProjectInstructions.hs
@@ -20,7 +20,7 @@ module Agent.ProjectInstructions
 
 import Agent.FileRetry (retryOnFileBusy)
 import Agent.Provider (Provider(..))
-import Agent.OsPath (toText, unsafeToFilePath)
+import Agent.OsPath (directoryChain, toText, unsafeToFilePath)
 import Control.Exception.Safe (tryAny)
 import qualified Data.ByteString as BS
 import Data.Maybe (mapMaybe)
@@ -103,14 +103,6 @@ findProjectRoot markers start = go start
                 if parent == dir
                     then pure start
                     else go parent
-
-directoryChain :: OsPath -> OsPath -> [OsPath]
-directoryChain root cwd = reverse (go cwd)
-  where
-    go dir
-        | dir == root = [dir]
-        | takeDirectory dir == dir = [dir]
-        | otherwise = dir : go (takeDirectory dir)
 
 -- | Prefer @AGENTS.override.md@ over @AGENTS.md@ in a directory.
 readPreferredAgentsMd :: OsPath -> IO (Maybe InstructionFile)

--- a/packages/agent-core/src/Agent/Skills.hs
+++ b/packages/agent-core/src/Agent/Skills.hs
@@ -18,7 +18,7 @@ module Agent.Skills
     ) where
 
 import Agent.FileRetry (retryOnFileBusy)
-import Agent.OsPath (toText, unsafeToFilePath)
+import Agent.OsPath (directoryChain, toText, unsafeToFilePath)
 import Control.Exception.Safe (displayException, tryAny)
 import Control.Monad (filterM, forM)
 import Data.Aeson
@@ -224,7 +224,9 @@ skillRoots options = do
     projectRoot <- canonicalizePath (unsafeToFilePath options.skillsProjectRoot)
     cwd <- canonicalizePath (unsafeToFilePath options.skillsCwd)
     home <- canonicalizePath (unsafeToFilePath options.skillsHome)
-    let dirs = directoryChain projectRoot cwd
+    let dirs =
+            map unsafeToFilePath $
+                directoryChain (unsafeEncodeUtf projectRoot) (unsafeEncodeUtf cwd)
         projectRoots =
             [ ( RepositorySkill depth (dir == cwd)
               , origin
@@ -248,14 +250,6 @@ skillRoots options = do
         AgentSkills -> ".agents" </> "skills"
         GrokSkills -> ".grok" </> "skills"
         CodexSkills -> ".codex" </> "skills"
-
-directoryChain :: FilePath -> FilePath -> [FilePath]
-directoryChain root cwd = reverse (go cwd)
-  where
-    go dir
-        | dir == root = [dir]
-        | takeDirectory dir == dir = [cwd]
-        | otherwise = dir : go (takeDirectory dir)
 
 findSkillFiles :: Int -> FilePath -> IO [FilePath]
 findSkillFiles maxDepth root = go Set.empty 0 root

--- a/packages/agent-core/src/Agent/Tools.hs
+++ b/packages/agent-core/src/Agent/Tools.hs
@@ -12,6 +12,7 @@ module Agent.Tools
     , ToolRegistry
     , ToolEnv(..)
     , defaultToolEnv
+    , jsonTool
     , jsonAppTool
     , jsonAppToolWithExecution
     , freeformApplyPatchAppTool

--- a/packages/agent-core/src/Agent/Tools/Codex.hs
+++ b/packages/agent-core/src/Agent/Tools/Codex.hs
@@ -19,7 +19,7 @@ import Agent.ToolDSL
     ( PropertySchema(..)
     , PropertyType(..)
     )
-import Agent.ToolDispatch (ToolHandler, typedStreamingTool, typedTool)
+import Agent.ToolDispatch (typedStreamingTool, typedTool)
 import Agent.Tools.ApplyPatch (applyPatch)
 import Agent.Tools.Ghci (GhciSession, runGhciTool)
 import Agent.Tools.Dangerous (forbiddenRmRfReason, commandLooksLikeRmRf)
@@ -41,7 +41,7 @@ import Agent.Tools.Types
     , ToolExecutionPolicy(..)
     , ToolEnv(..)
     , freeformApplyPatchAppToolWithExecution
-    , jsonAppToolWithExecution
+    , jsonTool
     )
 import Control.Applicative ((<|>))
 import Data.Aeson (FromJSON(..), Value(..), withObject)
@@ -69,19 +69,6 @@ codexTools env ghci planMode multi = do
         , askUserQuestionTool planMode
         ]
         ++ maybe [] multiAgentTools multi
-
-jsonTool
-    :: Text
-    -> Text
-    -> [PropertySchema]
-    -> Bool
-    -> ToolExecutionPolicy
-    -> ToolHandler
-    -> AppTool
-jsonTool name description parameters readOnly execution =
-    jsonAppToolWithExecution name description parameters
-        (if readOnly then AlwaysReadOnly else AlwaysPrompt)
-        execution
 
 --------------------------------------------------------------------------------
 -- shell_command

--- a/packages/agent-core/src/Agent/Tools/Grok/Common.hs
+++ b/packages/agent-core/src/Agent/Tools/Grok/Common.hs
@@ -6,14 +6,9 @@ module Agent.Tools.Grok.Common
     ) where
 
 import Agent.ToolArgs (optIntOrString)
-import Agent.ToolDSL (PropertySchema)
-import Agent.ToolDispatch (ToolHandler)
 import Agent.OsPath (unsafeToFilePath)
 import Agent.Tools.Types
-    ( AppTool
-    , ApprovalRule(..)
-    , ToolExecutionPolicy
-    , jsonAppToolWithExecution
+    ( jsonTool
     )
 import Data.Aeson (Object)
 import Data.Aeson.Types (Parser)
@@ -23,19 +18,6 @@ import System.Directory (findExecutable)
 import System.Exit (ExitCode(..))
 import System.Process (readProcessWithExitCode)
 import System.OsPath (OsPath)
-
-jsonTool
-    :: Text
-    -> Text
-    -> [PropertySchema]
-    -> Bool
-    -> ToolExecutionPolicy
-    -> ToolHandler
-    -> AppTool
-jsonTool name description parameters readOnly execution =
-    jsonAppToolWithExecution name description parameters
-        (if readOnly then AlwaysReadOnly else AlwaysPrompt)
-        execution
 
 isGitIgnored :: OsPath -> OsPath -> IO Bool
 isGitIgnored cwd path = findExecutable "git" >>= \case

--- a/packages/agent-core/src/Agent/Tools/Grok/Shell.hs
+++ b/packages/agent-core/src/Agent/Tools/Grok/Shell.hs
@@ -27,6 +27,8 @@ import Agent.ResourceScope
 import Agent.Tools.IO
     ( CommandResult(..)
     , RunningCommand(..)
+    , combineCommandOutput
+    , formatCommandResult
     , resolveUnderCwd
     , runShellCommandStreaming
     , runningLiveOutput
@@ -42,7 +44,6 @@ import Control.Monad (void)
 import Data.IORef
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
@@ -183,15 +184,15 @@ readTaskOutput session taskId timeoutMs = do
                     (readMVar task.backgroundRunning.runningResult)
                 case raced of
                     Left () -> snapshotTask task
-                    Right result -> pure (formatExit result)
+                    Right result -> pure (formatCommandResult result)
 
 snapshotTask :: BackgroundTask -> IO Text
 snapshotTask task =
     tryReadMVar task.backgroundRunning.runningResult >>= \case
-        Just result -> pure (formatExit result)
+        Just result -> pure (formatCommandResult result)
         Nothing -> do
             (out, err) <- runningLiveOutput task.backgroundRunning
-            let body = combinePipes out err
+            let body = combineCommandOutput out err
             pure $ if Text.null body
                 then "still running"
                 else "still running\n" <> body
@@ -204,7 +205,7 @@ killTask session taskId = do
         Just task -> do
             releaseResource task.backgroundResource
             result <- readMVar task.backgroundRunning.runningResult
-            pure $ "killed " <> taskId <> "\n" <> formatExit result
+            pure $ "killed " <> taskId <> "\n" <> formatCommandResult result
 
 nextTaskId :: GrokSession -> IO Text
 nextTaskId session = atomicModifyIORef' session.grokNextId \n ->
@@ -265,20 +266,6 @@ removeIfExists path = do
     if exists
         then void $ tryAny (removeFile path)
         else pure ()
-
-formatExit :: CommandResult -> Text
-formatExit result
-    | result.commandCancelled = "exit: cancelled\n" <> body
-    | result.commandTimedOut = "exit: killed (timeout)\n" <> body
-    | otherwise = "exit: " <> Text.pack (show (fromMaybe 1 result.commandExitCode)) <> "\n" <> body
-  where
-    body = combinePipes result.commandStdout result.commandStderr
-
-combinePipes :: Text -> Text -> Text
-combinePipes out err
-    | Text.null err = out
-    | Text.null out = err
-    | otherwise = out <> "\n" <> err
 
 -- | True when a foreground command would background itself with @&@.
 hasUnwaitedBackgroundOp :: Text -> Bool

--- a/packages/agent-core/src/Agent/Tools/Grok/TaskControl.hs
+++ b/packages/agent-core/src/Agent/Tools/Grok/TaskControl.hs
@@ -10,6 +10,7 @@ import Agent.Subagents
     , getStatus
     , waitSubagents
     )
+import Agent.Subagents.Format (isFinalStatus)
 import Agent.ToolArgs (objectArgs, optInt, reqText, reqTextList)
 import Agent.ToolDSL (PropertySchema(..), PropertyType(..))
 import Agent.ToolDispatch (typedTool)
@@ -135,7 +136,7 @@ runOneTaskOutput session multi timeout taskId = case multi of
         pure TaskOutputEntry
             { taskOutputId = taskId
             , output = formatAgentWait taskId timedOut (Just status)
-            , terminal = isTerminalAgentStatus status
+            , terminal = isFinalStatus status
             }
     _ -> do
         text <- stripAnsi <$> readTaskOutput session taskId timeout
@@ -144,14 +145,6 @@ runOneTaskOutput session multi timeout taskId = case multi of
             , output = text
             , terminal = terminalCommandOutput text
             }
-
-isTerminalAgentStatus :: SubagentStatus -> Bool
-isTerminalAgentStatus = \case
-    Completed {} -> True
-    Errored {} -> True
-    Interrupted -> True
-    Closed -> True
-    _ -> False
 
 terminalCommandOutput :: Text -> Bool
 terminalCommandOutput text =

--- a/packages/agent-core/src/Agent/Tools/Grok/Terminal.hs
+++ b/packages/agent-core/src/Agent/Tools/Grok/Terminal.hs
@@ -11,7 +11,10 @@ import Agent.Tools.Grok.Shell
     , runForegroundStreaming
     , startBackground
     )
-import Agent.Tools.IO (CommandResult(..))
+import Agent.Tools.IO
+    ( combineCommandOutput
+    , formatCommandResult
+    )
 import Agent.Tools.Types
     ( AppTool
     , ToolExecutionPolicy(..)
@@ -76,22 +79,6 @@ runTerminal session emitOutput args
             session
             (Text.unpack args.command)
             timeoutMs
-            (\out err -> emitOutput (stripAnsi (combinePipes out err)))
-        let body = stripAnsi (combinedOutput result)
-        if result.commandCancelled
-            then pure $ Right $ "exit: cancelled\n" <> body
-            else if result.commandTimedOut
-                then pure $ Right $ "exit: killed (timeout)\n" <> body
-                else
-                    let code = fromMaybe 1 result.commandExitCode
-                    in pure $ Right $ "exit: " <> Text.pack (show code) <> "\n" <> body
-
-combinedOutput :: CommandResult -> Text
-combinedOutput result =
-    combinePipes result.commandStdout result.commandStderr
-
-combinePipes :: Text -> Text -> Text
-combinePipes out err
-    | Text.null err = out
-    | Text.null out = err
-    | otherwise = out <> "\n" <> err
+            (\out err ->
+                emitOutput (stripAnsi (combineCommandOutput out err)))
+        pure $ Right $ stripAnsi (formatCommandResult result)

--- a/packages/agent-core/src/Agent/Tools/IO.hs
+++ b/packages/agent-core/src/Agent/Tools/IO.hs
@@ -2,6 +2,9 @@
 module Agent.Tools.IO
     ( CommandResult(..)
     , RunningCommand(..)
+    , combineCommandOutput
+    , commandResultOutput
+    , formatCommandResult
     , resolveUnderCwd
     , readTextFile
     , writeTextFile
@@ -55,6 +58,7 @@ import Control.Exception.Safe
 import Control.Monad (unless, void, when)
 import Data.Either (isRight)
 import Data.IORef (IORef, atomicModifyIORef', newIORef, readIORef)
+import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.ByteString as BS
@@ -89,6 +93,33 @@ data CommandResult = CommandResult
     , commandTimedOut :: !Bool
     , commandCancelled :: !Bool
     } deriving (Eq, Show)
+
+-- | Combine captured stdout and stderr without introducing a blank line when
+-- either stream is empty.
+combineCommandOutput :: Text -> Text -> Text
+combineCommandOutput out err
+    | Text.null err = out
+    | Text.null out = err
+    | otherwise = out <> "\n" <> err
+
+-- | Combined captured output from a completed command.
+commandResultOutput :: CommandResult -> Text
+commandResultOutput result =
+    combineCommandOutput result.commandStdout result.commandStderr
+
+-- | Render the stable terminal-tool result format shared by foreground and
+-- background commands.
+formatCommandResult :: CommandResult -> Text
+formatCommandResult result
+    | result.commandCancelled = "exit: cancelled\n" <> body
+    | result.commandTimedOut = "exit: killed (timeout)\n" <> body
+    | otherwise =
+        "exit: "
+            <> Text.pack (show (fromMaybe 1 result.commandExitCode))
+            <> "\n"
+            <> body
+  where
+    body = commandResultOutput result
 
 data RunningCommand = RunningCommand
     { runningHandle :: !ProcessHandle

--- a/packages/agent-core/src/Agent/Tools/MultiAgents.hs
+++ b/packages/agent-core/src/Agent/Tools/MultiAgents.hs
@@ -53,12 +53,11 @@ import Agent.ToolDSL
     ( PropertySchema(..)
     , PropertyType(..)
     )
-import Agent.ToolDispatch (ToolCall(..), ToolHandler, typedTool, typedToolWithCall)
+import Agent.ToolDispatch (ToolCall(..), typedTool, typedToolWithCall)
 import Agent.Tools.Types
     ( AppTool
-    , ApprovalRule(..)
     , ToolExecutionPolicy(..)
-    , jsonAppToolWithExecution
+    , jsonTool
     )
 import Data.Aeson (FromJSON(..), Value(..), object, (.=))
 import qualified Data.Aeson as Aeson
@@ -125,19 +124,6 @@ multiAgentTools ctx =
     , listAgentsTool ctx
     , interruptAgentTool ctx
     ]
-
-jsonTool
-    :: Text
-    -> Text
-    -> [PropertySchema]
-    -> Bool
-    -> ToolExecutionPolicy
-    -> ToolHandler
-    -> AppTool
-jsonTool name description parameters readOnly execution =
-    jsonAppToolWithExecution name description parameters
-        (if readOnly then AlwaysReadOnly else AlwaysPrompt)
-        execution
 
 --------------------------------------------------------------------------------
 -- spawn_agent

--- a/packages/agent-core/src/Agent/Tools/PlanMode.hs
+++ b/packages/agent-core/src/Agent/Tools/PlanMode.hs
@@ -34,12 +34,11 @@ import Agent.ToolDSL
     ( PropertySchema(..)
     , PropertyType(..)
     )
-import Agent.ToolDispatch (ToolHandler, typedTool)
+import Agent.ToolDispatch (typedTool)
 import Agent.Tools.Types
     ( AppTool
-    , ApprovalRule(..)
     , ToolExecutionPolicy(..)
-    , jsonAppToolWithExecution
+    , jsonTool
     )
 import Control.Exception.Safe (tryAny)
 import Data.Aeson (FromJSON(..), withObject)
@@ -170,19 +169,6 @@ isPlanFileEditTarget planPath target =
 --------------------------------------------------------------------------------
 -- Grok-build tools
 --------------------------------------------------------------------------------
-
-jsonTool
-    :: Text
-    -> Text
-    -> [PropertySchema]
-    -> Bool
-    -> ToolExecutionPolicy
-    -> ToolHandler
-    -> AppTool
-jsonTool name description parameters readOnly execution =
-    jsonAppToolWithExecution name description parameters
-        (if readOnly then AlwaysReadOnly else AlwaysPrompt)
-        execution
 
 data EnterPlanArgs = EnterPlanArgs
     { explanation :: Maybe Text

--- a/packages/agent-core/src/Agent/Tools/Types.hs
+++ b/packages/agent-core/src/Agent/Tools/Types.hs
@@ -6,6 +6,7 @@ module Agent.Tools.Types
     , ToolRegistry
     , ToolEnv(..)
     , defaultToolEnv
+    , jsonTool
     , jsonAppTool
     , jsonAppToolWithExecution
     , freeformApplyPatchAppTool
@@ -91,6 +92,21 @@ defaultToolEnv cwd = do
         , toolStdoutCap = 100000
         , toolCancel = cancel
         }
+
+-- | Construct a JSON tool whose approval is selected from a simple read-only
+-- flag. This is the common convenience shape used by provider tool surfaces.
+jsonTool
+    :: Text
+    -> Text
+    -> [PropertySchema]
+    -> Bool
+    -> ToolExecutionPolicy
+    -> ToolHandler
+    -> AppTool
+jsonTool name description parameters readOnly execution =
+    jsonAppToolWithExecution name description parameters
+        (if readOnly then AlwaysReadOnly else AlwaysPrompt)
+        execution
 
 -- | Construct a JSON tool with the conservative turn-sequential default.
 jsonAppTool

--- a/packages/agent-core/test/Agent/Auth/JWTSpec.hs
+++ b/packages/agent-core/test/Agent/Auth/JWTSpec.hs
@@ -1,0 +1,49 @@
+module Agent.Auth.JWTSpec (spec) where
+
+import Agent.Auth.JWT (decodeJwtPayload)
+import qualified Data.Aeson as Aeson
+import qualified "base64-bytestring" Data.ByteString.Base64 as Base64
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as LBS
+import Data.Text (Text)
+import qualified Data.Text.Encoding as Text
+import Test.Hspec
+
+spec :: Spec
+spec = describe "decodeJwtPayload" do
+    it "decodes an unpadded base64url JSON payload" do
+        decodeJwtPayload (unsignedJwt (Aeson.object
+            [ "account_id" Aeson..= ("account-123" :: Text) ]))
+            `shouldBe`
+                Just (Aeson.object
+                    [ "account_id" Aeson..= ("account-123" :: Text) ])
+
+    it "supports typed payload decoding" do
+        decodeJwtPayload (unsignedJwt (Aeson.String "claims")) `shouldBe`
+            Just ("claims" :: Text)
+
+    it "rejects missing, malformed, or non-JSON payloads" do
+        (decodeJwtPayload "" :: Maybe Aeson.Value) `shouldBe` Nothing
+        (decodeJwtPayload "one-segment" :: Maybe Aeson.Value) `shouldBe` Nothing
+        (decodeJwtPayload "header.%%%.signature" :: Maybe Aeson.Value)
+            `shouldBe` Nothing
+        (decodeJwtPayload "header.bm90LWpzb24.signature" :: Maybe Aeson.Value)
+            `shouldBe` Nothing
+
+unsignedJwt :: Aeson.Value -> Text
+unsignedJwt payload =
+    "header." <> encodePayload payload <> ".signature"
+
+encodePayload :: Aeson.Value -> Text
+encodePayload =
+    Text.decodeUtf8
+        . BS.filter (/= padding)
+        . BS.map urlSafe
+        . Base64.encode
+        . LBS.toStrict
+        . Aeson.encode
+  where
+    padding = 0x3d
+    urlSafe 0x2b = 0x2d
+    urlSafe 0x2f = 0x5f
+    urlSafe byte = byte

--- a/packages/agent-core/test/Agent/OsPathSpec.hs
+++ b/packages/agent-core/test/Agent/OsPathSpec.hs
@@ -2,13 +2,30 @@
 
 module Agent.OsPathSpec (spec) where
 
-import Agent.OsPath (fromText, toText, unsafeToFilePath)
+import Agent.OsPath (directoryChain, fromText, toText, unsafeToFilePath)
 import qualified Data.Text as Text
 import System.OsPath (decodeUtf, pack, unsafeFromChar)
 import Test.Hspec
 
 spec :: Spec
 spec = describe "Agent.OsPath" do
+    describe "directoryChain" do
+        it "returns the root itself when root and cwd match" do
+            directoryChain (fromText "/repo") (fromText "/repo")
+                `shouldBe` [fromText "/repo"]
+
+        it "returns directories from root through a descendant cwd" do
+            directoryChain (fromText "/repo") (fromText "/repo/pkg/src")
+                `shouldBe`
+                    [ fromText "/repo"
+                    , fromText "/repo/pkg"
+                    , fromText "/repo/pkg/src"
+                    ]
+
+        it "falls back to cwd when cwd is outside root" do
+            directoryChain (fromText "/repo") (fromText "/other/pkg")
+                `shouldBe` [fromText "/other/pkg"]
+
     it "converts Text to and from a UTF path" do
         let text = "/tmp/日本語"
             path = fromText text

--- a/packages/agent-core/test/Agent/SubagentsSpec.hs
+++ b/packages/agent-core/test/Agent/SubagentsSpec.hs
@@ -77,6 +77,20 @@ fromFilePath = unsafeEncodeUtf
 
 spec :: Spec
 spec = describe "Agent.Subagents" do
+    describe "isFinalStatus" do
+        it "treats missing agents as final, matching waitSubagents" do
+            map isFinalStatus
+                [ Completed Nothing
+                , Errored "failed"
+                , Interrupted
+                , Closed
+                , NotFound
+                ]
+                `shouldBe` replicate 5 True
+
+        it "keeps pending and running agents non-final" do
+            map isFinalStatus [Pending, Running] `shouldBe` [False, False]
+
     it "spawns a child, waits for completion, and returns final text" do
         registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
             (\_ _ prompt _ -> pure $ Right LoopResult

--- a/packages/agent-core/test/Agent/Tools/IOSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/IOSpec.hs
@@ -10,6 +10,9 @@ import System.OsPath (unsafeEncodeUtf)
 import Agent.Tools.IO
     ( CommandResult(..)
     , RunningCommand(..)
+    , combineCommandOutput
+    , commandResultOutput
+    , formatCommandResult
     , readTextFile
     , resolveUnderCwd
     , runShellCommand
@@ -47,6 +50,46 @@ fromFilePath = unsafeEncodeUtf
 
 spec :: Spec
 spec = describe "Agent.Tools.IO" do
+    describe "command result formatting" do
+        it "combines stdout and stderr without redundant separators" do
+            combineCommandOutput "out" "" `shouldBe` "out"
+            combineCommandOutput "" "err" `shouldBe` "err"
+            combineCommandOutput "out" "err" `shouldBe` "out\nerr"
+
+        it "renders success, timeout, and cancellation consistently" do
+            let result = CommandResult
+                    { commandExitCode = Just 3
+                    , commandStdout = "out"
+                    , commandStderr = "err"
+                    , commandTimedOut = False
+                    , commandCancelled = False
+                    }
+            commandResultOutput result `shouldBe` "out\nerr"
+            formatCommandResult result `shouldBe` "exit: 3\nout\nerr"
+            formatCommandResult
+                result
+                    { commandExitCode = Nothing
+                    , commandTimedOut = True
+                    }
+                `shouldBe` "exit: killed (timeout)\nout\nerr"
+            formatCommandResult
+                result
+                    { commandExitCode = Nothing
+                    , commandTimedOut = True
+                    , commandCancelled = True
+                    }
+                `shouldBe` "exit: cancelled\nout\nerr"
+
+        it "defaults a missing ordinary exit code to one" do
+            formatCommandResult CommandResult
+                { commandExitCode = Nothing
+                , commandStdout = ""
+                , commandStderr = ""
+                , commandTimedOut = False
+                , commandCancelled = False
+                }
+                `shouldBe` "exit: 1\n"
+
     it "retries only resource-busy IO exceptions" do
         attempts <- newIORef (0 :: Int)
         retryOnFileBusy do

--- a/packages/agent-core/test/Spec.hs
+++ b/packages/agent-core/test/Spec.hs
@@ -1,5 +1,6 @@
 module Main (main) where
 
+import qualified Agent.Auth.JWTSpec as JWTSpec
 import qualified Agent.CancelSpec as CancelSpec
 import qualified Agent.ErrorSpec as ErrorSpec
 import qualified Agent.Http.HeaderSpec as HttpHeaderSpec
@@ -29,6 +30,7 @@ import Test.Hspec (hspec)
 
 main :: IO ()
 main = hspec do
+    JWTSpec.spec
     CancelSpec.spec
     ErrorSpec.spec
     HttpHeaderSpec.spec

--- a/packages/agent-openai/agent-openai.cabal
+++ b/packages/agent-openai/agent-openai.cabal
@@ -78,7 +78,6 @@ library
                     , network-uri
                     , websockets
                     , wuss
-                    , base64-bytestring
                     , retry >= 0.9.3.1 && < 0.10
                     , exceptions
                     , safe-exceptions

--- a/packages/agent-openai/src/Agent/OpenAI/Auth/JWT.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Auth/JWT.hs
@@ -6,15 +6,13 @@ module Agent.OpenAI.Auth.JWT
     , refreshMarginSeconds
     ) where
 
+import Agent.Auth.JWT (decodeJwtPayload)
 import Agent.OpenAI.Auth.Types (AuthState(..))
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KeyMap
-import qualified "base64-bytestring" Data.ByteString.Base64 as Base64
-import qualified Data.ByteString.Lazy as LBS
 import Data.Text (Text)
 import qualified Data.Text as Text
-import qualified Data.Text.Encoding as Text
 import Data.Time.Calendar (fromGregorian)
 import Data.Time.Clock (UTCTime(..), addUTCTime, diffUTCTime)
 
@@ -35,10 +33,7 @@ needsRefresh state now =
 -- | Parse the @exp@ claim from a JWT without signature verification.
 parseJwtExp :: Text -> Maybe UTCTime
 parseJwtExp token = do
-    payloadB64 <- Text.splitOn "." token !!? 1
-    payloadBytes <- either (const Nothing) Just
-        (Base64.decode (Text.encodeUtf8 (base64UrlToBase64 payloadB64)))
-    obj <- Aeson.decode (LBS.fromStrict payloadBytes)
+    obj <- decodeJwtPayload token
     expAt <- jsonIntMaybe obj "exp"
     let epoch = UTCTime (fromGregorian 1970 1 1) 0
     pure $ addUTCTime (fromIntegral expAt) epoch
@@ -61,26 +56,8 @@ deriveEmail token = do
 
 jwtClaims :: Text -> Maybe Aeson.Object
 jwtClaims token = do
-    payloadB64 <- Text.splitOn "." token !!? 1
-    payloadBytes <- either (const Nothing) Just
-        (Base64.decode (Text.encodeUtf8 (base64UrlToBase64 payloadB64)))
-    Aeson.Object claims <- Aeson.decode (LBS.fromStrict payloadBytes)
+    Aeson.Object claims <- decodeJwtPayload token
     pure claims
-
-base64UrlToBase64 :: Text -> Text
-base64UrlToBase64 text =
-    let replaced = Text.replace "-" "+" (Text.replace "_" "/" text)
-        padLen = (4 - Text.length replaced `mod` 4) `mod` 4
-    in replaced <> Text.replicate padLen "="
-
-(!!?) :: [a] -> Int -> Maybe a
-(!!?) xs index
-    | index < 0 = Nothing
-    | otherwise = go xs index
-  where
-    go [] _ = Nothing
-    go (x:_) 0 = Just x
-    go (_:rest) n = go rest (n - 1)
 
 jsonIntMaybe :: Aeson.Value -> Text -> Maybe Int
 jsonIntMaybe (Aeson.Object object) key =

--- a/packages/agent-openrouter/src/Agent/OpenRouter/Client.hs
+++ b/packages/agent-openrouter/src/Agent/OpenRouter/Client.hs
@@ -8,25 +8,18 @@ module Agent.OpenRouter.Client
     , retryTransientOpenRouterResultWithPolicy
     ) where
 
-import Agent.Http.Header (parseRetryAfterSeconds)
-import Agent.Http.Url (trimTrailingSlash)
 import Agent.Error
     ( ApiError(..)
     , ErrorType(..)
     , isInlineRetryableProviderError
     )
+import qualified Agent.Responses.HttpSSE as HttpSSE
 import Agent.Responses.Types
 import Agent.Provider (Credential(..), Provider(..))
 import Agent.OpenRouter.Error (classifyFailure)
 import Agent.OpenRouter.Options
 import Agent.OpenRouter.Request (buildRequest)
-import Agent.OpenRouter.Stream
-    ( buildResponse
-    , feedSseDecoder
-    , finishSseDecoder
-    , newSseDecoder
-    )
-import Control.Exception.Safe (tryAny)
+import Agent.OpenRouter.Stream (buildResponse)
 import Control.Retry
     ( RetryPolicyM
     , exponentialBackoff
@@ -34,19 +27,14 @@ import Control.Retry
     , retrying
     )
 import qualified Data.Aeson as Aeson
-import qualified Data.ByteString as BS
-import qualified Data.ByteString.Lazy as LBS
 import Data.IORef
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
-import qualified Data.Text.Encoding.Error as Text (lenientDecode)
-import qualified Network.HTTP.Client as HttpClient
-import qualified Network.HTTP.Client.TLS as HttpTls
 import Network.HTTP.Simple hiding (Response)
 import Network.HTTP.Types (HeaderName)
 
-type StreamEventCallback = ResponseStreamEvent -> IO ()
+type StreamEventCallback = HttpSSE.StreamEventCallback
 
 -- | Send one request using environment-derived client options.
 createResponse :: Credential -> ResponseCreateParams -> IO (Either ApiError Response)
@@ -91,82 +79,24 @@ createResponseWithEventsPolicy policy options credential request onEvent
     | otherwise =
         retryTransientOpenRouterResultWithPolicy policy performOnce onEvent
   where
-    performOnce emit =
-        tryAny (performRequest emit) >>= \case
-            Left exception -> pure $ Left $ ConnectionError
-                ("OpenRouter request failed: " <> Text.pack (show exception))
-            Right result -> pure result
+    performOnce =
+        HttpSSE.performResponsesHttpSse
+            HttpSSE.HttpSseConfig
+                { exceptionPrefix = "OpenRouter request failed"
+                , classifyFailure
+                , buildResponse
+                }
+            options.baseUrl
+            options.requestTimeoutSeconds
+            (Aeson.encode (buildRequest options request))
+            configureRequest
 
-    performRequest emit = do
-        httpRequest <- parseRequest ("POST " <> trimTrailingSlash options.baseUrl <> "/responses")
-        manager <- HttpTls.getGlobalManager
-        HttpClient.withResponse
-            ( setRequestBodyLBS (Aeson.encode (buildRequest options request))
-            $ setRequestHeader "Authorization"
-                ["Bearer " <> Text.encodeUtf8 credential.accessToken]
-            $ setRequestHeader "Content-Type" ["application/json"]
-            $ setRequestHeader "Accept" ["text/event-stream"]
-            $ setRequestHeader "User-Agent" ["haskell-agent"]
-            $ optionalHeader "HTTP-Referer" options.httpReferer
-            $ optionalHeader "X-Title" options.appTitle
-            $ withTimeout httpRequest
-            )
-            manager
-            (handleResponse emit)
-
-    withTimeout httpRequest = httpRequest
-        { HttpClient.responseTimeout =
-            HttpClient.responseTimeoutMicro (options.requestTimeoutSeconds * 1_000_000)
-        }
-
-    handleResponse emit response = do
-        let status = getResponseStatusCode response
-        if status >= 200 && status < 300
-            then consumeSse emit (HttpClient.responseBody response)
-            else do
-                body <- consumeBody (HttpClient.responseBody response)
-                let bodyText = Text.decodeUtf8With Text.lenientDecode
-                        (LBS.toStrict body)
-                pure $ Left $
-                    classifyFailure status
-                        (parseRetryAfterSeconds
-                            (getResponseHeader "Retry-After" response))
-                        bodyText
-
-    consumeSse emit body = go newSseDecoder []
-      where
-        go decoder reversedEvents = do
-            chunk <- HttpClient.brRead body
-            if BS.null chunk
-                then case finishSseDecoder decoder of
-                    Left err -> pure (Left err)
-                    Right trailing -> do
-                        mapM_ emit trailing
-                        pure $ buildResponse
-                            (reverse reversedEvents <> trailing)
-                else case feedSseDecoder decoder chunk of
-                    Left err -> pure (Left err)
-                    Right (nextDecoder, events) -> do
-                        mapM_ emit events
-                        let retained = filter retainForResponse events
-                        go nextDecoder (reverse retained <> reversedEvents)
-
-    consumeBody body = LBS.fromChunks <$> readChunks []
-      where
-        readChunks reversedChunks = do
-            chunk <- HttpClient.brRead body
-            if BS.null chunk
-                then pure (reverse reversedChunks)
-                else readChunks (chunk : reversedChunks)
-
-    retainForResponse = \case
-        ResponseOutputItemDoneEvent {} -> True
-        ResponseCompletedEvent {} -> True
-        ResponseIncompleteEvent {} -> True
-        ResponseErrorEvent {} -> True
-        ResponseNestedErrorEvent {} -> True
-        ResponseFailedEvent {} -> True
-        _ -> False
+    configureRequest =
+        setRequestHeader "Authorization"
+            ["Bearer " <> Text.encodeUtf8 credential.accessToken]
+            . setRequestHeader "User-Agent" ["haskell-agent"]
+            . optionalHeader "HTTP-Referer" options.httpReferer
+            . optionalHeader "X-Title" options.appTitle
 
 -- | Retry transient failures while replay is safe. The callback marker is
 -- written before user code runs, so callback exceptions are never retried.

--- a/packages/agent-openrouter/src/Agent/OpenRouter/Stream.hs
+++ b/packages/agent-openrouter/src/Agent/OpenRouter/Stream.hs
@@ -16,65 +16,20 @@ import Agent.Responses.SSE
     , newSseDecoder
     , parseSseEvents
     )
-import Agent.Responses.ResponseMerge (mergeCompletedResponseOutput)
+import Agent.Responses.StreamAssembly
+    ( StreamAssemblyConfig(..)
+    , buildStreamResponse
+    , failedResponseMessage
+    )
 import Agent.Responses.Types
 import Agent.OpenRouter.Error (classifyStreamError)
-import qualified Data.Aeson as Aeson
-import qualified Data.ByteString.Lazy as LBS
-import qualified Data.Maybe as Maybe
-import Data.Text (Text)
-import qualified Data.Text as Text
-import qualified Data.Text.Encoding as Text
-import qualified Data.Text.Encoding.Error as Text (lenientDecode)
 
 -- | Merge streamed output-item events into the terminal completed response.
 buildResponse :: [ResponseStreamEvent] -> Either ApiError Response
-buildResponse events = case lastMaybe terminalResponses of
-    Just terminal -> decodeMerged terminal
-    Nothing -> Left (Maybe.fromMaybe missingCompletion (firstFailure events))
-  where
-    terminalResponses = Maybe.mapMaybe terminalResponse events
-    doneItems =
-        [ Aeson.toJSON item
-        | ResponseOutputItemDoneEvent { item } <- events
-        ]
-
-    decodeMerged completed =
-        let merged = mergeCompletedResponseOutput doneItems (Aeson.toJSON completed)
-        in case Aeson.fromJSON merged of
-            Aeson.Success response -> Right response
-            Aeson.Error err -> Left $ JsonDecodeError
-                (Text.pack err)
-                (Text.take 2000 (Text.decodeUtf8With Text.lenientDecode
-                    (LBS.toStrict (Aeson.encode merged))))
-
-    missingCompletion = JsonDecodeError
+buildResponse = buildStreamResponse StreamAssemblyConfig
+    { missingCompletionMessage =
         "No terminal response event found in OpenRouter SSE stream"
-        (Text.take 2000 (Text.decodeUtf8With Text.lenientDecode
-            (LBS.toStrict (Aeson.encode events))))
-
-    terminalResponse = \case
-        ResponseCompletedEvent { response } -> Just response
-        ResponseIncompleteEvent { response } -> Just response
-        _ -> Nothing
-
-firstFailure :: [ResponseStreamEvent] -> Maybe ApiError
-firstFailure = Maybe.listToMaybe . Maybe.mapMaybe failure
-  where
-    failure = \case
-        ResponseErrorEvent { streamError } -> Just (classifyStreamError streamError)
-        ResponseNestedErrorEvent { streamError } -> Just (classifyStreamError streamError)
-        ResponseFailedEvent { response } -> Just (ConnectionError (failedResponseMessage response))
-        _ -> Nothing
-
-failedResponseMessage :: Response -> Text
-failedResponseMessage response = case response.error of
-    Just responseError -> responseError.message
-    Nothing -> case response.incompleteDetails of
-        Just details -> "response.failed: " <> details.reason
-        Nothing -> "response.failed (no details)"
-
-lastMaybe :: [value] -> Maybe value
-lastMaybe [] = Nothing
-lastMaybe [value] = Just value
-lastMaybe (_ : rest) = lastMaybe rest
+    , classifyStreamError
+    , classifyFailedResponse =
+        ConnectionError . failedResponseMessage
+    }

--- a/packages/agent-responses/agent-responses.cabal
+++ b/packages/agent-responses/agent-responses.cabal
@@ -46,8 +46,10 @@ library
     exposed-modules:  Agent.Responses.Types
                     , Agent.Responses.Codec
                     , Agent.Responses.Error
+                    , Agent.Responses.HttpSSE
                     , Agent.Responses.SSE
                     , Agent.Responses.ResponseMerge
+                    , Agent.Responses.StreamAssembly
                     , Agent.Responses.LoopBackend
     hs-source-dirs:   src
     build-depends:    base                  >= 4.14 && < 5
@@ -56,6 +58,10 @@ library
                     , base64-bytestring
                     , bytestring
                     , containers
+                    , http-client
+                    , http-client-tls
+                    , http-conduit
+                    , safe-exceptions
                     , scientific
                     , text
                     , vector
@@ -68,6 +74,7 @@ test-suite agent-responses-test
     other-modules:    Agent.Responses.LoopBackendSpec
                     , Agent.Responses.ResponseMergeSpec
                     , Agent.Responses.SSESpec
+                    , Agent.Responses.StreamAssemblySpec
     build-depends:    base >= 4.14 && < 5
                     , agent-core
                     , agent-responses

--- a/packages/agent-responses/package.nix
+++ b/packages/agent-responses/package.nix
@@ -1,5 +1,6 @@
 { mkDerivation, aeson, agent-core, base, base64-bytestring
-, bytestring, containers, hspec, lib, scientific, text, vector
+, bytestring, containers, hspec, http-client, http-client-tls
+, http-conduit, lib, safe-exceptions, scientific, text, vector
 }:
 mkDerivation {
   pname = "agent-responses";
@@ -7,7 +8,8 @@ mkDerivation {
   src = ./.;
   libraryHaskellDepends = [
     aeson agent-core base base64-bytestring bytestring containers
-    scientific text vector
+    http-client http-client-tls http-conduit safe-exceptions scientific
+    text vector
   ];
   testHaskellDepends = [ aeson agent-core base bytestring hspec text ];
   description = "Provider-neutral OpenAI Responses protocol types and adapters";

--- a/packages/agent-responses/src/Agent/Responses/HttpSSE.hs
+++ b/packages/agent-responses/src/Agent/Responses/HttpSSE.hs
@@ -1,0 +1,131 @@
+-- | Provider-neutral HTTP transport for streaming Responses endpoints.
+module Agent.Responses.HttpSSE
+    ( HttpSseConfig(..)
+    , StreamEventCallback
+    , performResponsesHttpSse
+    ) where
+
+import Agent.Error (ApiError(..))
+import Agent.Http.Header (parseRetryAfterSeconds)
+import Agent.Http.Url (trimTrailingSlash)
+import Agent.Responses.SSE
+    ( feedSseDecoder
+    , finishSseDecoder
+    , newSseDecoder
+    )
+import Agent.Responses.Types
+import Control.Exception.Safe (tryAny)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as LBS
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
+import qualified Data.Text.Encoding.Error as Text (lenientDecode)
+import qualified Network.HTTP.Client as HttpClient
+import qualified Network.HTTP.Client.TLS as HttpTls
+import Network.HTTP.Simple hiding (Response)
+
+type StreamEventCallback = ResponseStreamEvent -> IO ()
+
+-- | Provider-specific hooks around the shared Responses HTTP/SSE mechanics.
+data HttpSseConfig = HttpSseConfig
+    { exceptionPrefix :: !Text
+      -- ^ Prefix used when request setup, transport, or callback code throws.
+    , classifyFailure :: !(Int -> Maybe Int -> Text -> ApiError)
+      -- ^ Classify a non-success status, optional @Retry-After@, and body.
+    , buildResponse :: !([ResponseStreamEvent] -> Either ApiError Response)
+      -- ^ Assemble retained terminal events into the provider response.
+    }
+
+-- | POST one streaming Responses request and deliver decoded events in wire
+-- order. The request modifier supplies provider-specific authentication and
+-- metadata headers; this function owns timeout setup, connection management,
+-- failure-body collection, incremental SSE decoding, and response assembly.
+performResponsesHttpSse
+    :: HttpSseConfig
+    -> String
+    -> Int
+    -> LBS.ByteString
+    -> (Request -> Request)
+    -> StreamEventCallback
+    -> IO (Either ApiError Response)
+performResponsesHttpSse
+    HttpSseConfig{exceptionPrefix, classifyFailure, buildResponse}
+    baseUrl
+    timeoutSeconds
+    requestBody
+    configureRequest
+    emit =
+        tryAny performRequest >>= \case
+            Left exception -> pure $ Left $ ConnectionError
+                (exceptionPrefix <> ": " <> Text.pack (show exception))
+            Right result -> pure result
+  where
+    performRequest = do
+        baseRequest <- parseRequest
+            ("POST " <> trimTrailingSlash baseUrl <> "/responses")
+        manager <- HttpTls.getGlobalManager
+        HttpClient.withResponse
+            ( setRequestBodyLBS requestBody
+            $ configureRequest
+            $ setRequestHeader "Content-Type" ["application/json"]
+            $ setRequestHeader "Accept" ["text/event-stream"]
+            $ withTimeout baseRequest
+            )
+            manager
+            handleResponse
+
+    withTimeout request = request
+        { HttpClient.responseTimeout =
+            HttpClient.responseTimeoutMicro (timeoutSeconds * 1_000_000)
+        }
+
+    handleResponse response = do
+        let status = getResponseStatusCode response
+        if status >= 200 && status < 300
+            then consumeSse (HttpClient.responseBody response)
+            else do
+                body <- consumeBody (HttpClient.responseBody response)
+                let bodyText = Text.decodeUtf8With Text.lenientDecode
+                        (LBS.toStrict body)
+                pure $ Left $
+                    classifyFailure status
+                        (parseRetryAfterSeconds
+                            (getResponseHeader "Retry-After" response))
+                        bodyText
+
+    consumeSse body = go newSseDecoder []
+      where
+        go decoder reversedEvents = do
+            chunk <- HttpClient.brRead body
+            if BS.null chunk
+                then case finishSseDecoder decoder of
+                    Left err -> pure (Left err)
+                    Right trailing -> do
+                        mapM_ emit trailing
+                        pure $ buildResponse
+                            (reverse reversedEvents <> trailing)
+                else case feedSseDecoder decoder chunk of
+                    Left err -> pure (Left err)
+                    Right (nextDecoder, events) -> do
+                        mapM_ emit events
+                        let retained = filter retainForResponse events
+                        go nextDecoder (reverse retained <> reversedEvents)
+
+    consumeBody body = LBS.fromChunks <$> readChunks []
+      where
+        readChunks reversedChunks = do
+            chunk <- HttpClient.brRead body
+            if BS.null chunk
+                then pure (reverse reversedChunks)
+                else readChunks (chunk : reversedChunks)
+
+retainForResponse :: ResponseStreamEvent -> Bool
+retainForResponse = \case
+    ResponseOutputItemDoneEvent {} -> True
+    ResponseCompletedEvent {} -> True
+    ResponseIncompleteEvent {} -> True
+    ResponseErrorEvent {} -> True
+    ResponseNestedErrorEvent {} -> True
+    ResponseFailedEvent {} -> True
+    _ -> False

--- a/packages/agent-responses/src/Agent/Responses/StreamAssembly.hs
+++ b/packages/agent-responses/src/Agent/Responses/StreamAssembly.hs
@@ -1,0 +1,97 @@
+-- | Provider-neutral terminal response assembly for Responses SSE streams.
+module Agent.Responses.StreamAssembly
+    ( StreamAssemblyConfig(..)
+    , buildStreamResponse
+    , failedResponseMessage
+    ) where
+
+import Agent.Error (ApiError(..))
+import Agent.Responses.ResponseMerge (mergeCompletedResponseOutput)
+import Agent.Responses.Types
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString.Lazy as LBS
+import qualified Data.Maybe as Maybe
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as TextEncoding
+import qualified Data.Text.Encoding.Error as TextEncoding (lenientDecode)
+
+-- | Provider-specific failure classification around shared event assembly.
+data StreamAssemblyConfig = StreamAssemblyConfig
+    { missingCompletionMessage :: !Text
+      -- ^ Error message when no terminal response or stream failure is present.
+    , classifyStreamError :: !(ResponseStreamError -> ApiError)
+      -- ^ Classify top-level and nested stream error events.
+    , classifyFailedResponse :: !(Response -> ApiError)
+      -- ^ Classify a terminal @response.failed@ event.
+    }
+
+-- | Merge streamed output items into the last terminal response. If no
+-- completed or incomplete response is present, return the first typed stream
+-- failure, falling back to a decode error containing a bounded event preview.
+buildStreamResponse
+    :: StreamAssemblyConfig
+    -> [ResponseStreamEvent]
+    -> Either ApiError Response
+buildStreamResponse config events = case lastMaybe terminalResponses of
+    Just terminal -> decodeMerged terminal
+    Nothing -> Left (Maybe.fromMaybe missingCompletion (firstFailure config events))
+  where
+    terminalResponses = Maybe.mapMaybe terminalResponse events
+    doneItems =
+        [ Aeson.toJSON item
+        | ResponseOutputItemDoneEvent { item } <- events
+        ]
+
+    decodeMerged completed =
+        let merged = mergeCompletedResponseOutput doneItems (Aeson.toJSON completed)
+        in case Aeson.fromJSON merged of
+            Aeson.Success response -> Right response
+            Aeson.Error err -> Left $ JsonDecodeError
+                (Text.pack err)
+                (jsonPreview merged)
+
+    missingCompletion = JsonDecodeError
+        config.missingCompletionMessage
+        (jsonPreview events)
+
+firstFailure
+    :: StreamAssemblyConfig
+    -> [ResponseStreamEvent]
+    -> Maybe ApiError
+firstFailure config = Maybe.listToMaybe . Maybe.mapMaybe failure
+  where
+    failure = \case
+        ResponseErrorEvent { streamError } ->
+            Just (config.classifyStreamError streamError)
+        ResponseNestedErrorEvent { streamError } ->
+            Just (config.classifyStreamError streamError)
+        ResponseFailedEvent { response } ->
+            Just (config.classifyFailedResponse response)
+        _ -> Nothing
+
+terminalResponse :: ResponseStreamEvent -> Maybe Response
+terminalResponse = \case
+    ResponseCompletedEvent { response } -> Just response
+    ResponseIncompleteEvent { response } -> Just response
+    _ -> Nothing
+
+-- | Best available text from a failed terminal response.
+failedResponseMessage :: Response -> Text
+failedResponseMessage response = case response.error of
+    Just responseError -> responseError.message
+    Nothing -> case response.incompleteDetails of
+        Just details -> "response.failed: " <> details.reason
+        Nothing -> "response.failed (no details)"
+
+jsonPreview :: Aeson.ToJSON value => value -> Text
+jsonPreview =
+    Text.take 2000
+        . TextEncoding.decodeUtf8With TextEncoding.lenientDecode
+        . LBS.toStrict
+        . Aeson.encode
+
+lastMaybe :: [value] -> Maybe value
+lastMaybe [] = Nothing
+lastMaybe [value] = Just value
+lastMaybe (_ : rest) = lastMaybe rest

--- a/packages/agent-responses/test/Agent/Responses/StreamAssemblySpec.hs
+++ b/packages/agent-responses/test/Agent/Responses/StreamAssemblySpec.hs
@@ -1,0 +1,59 @@
+module Agent.Responses.StreamAssemblySpec (spec) where
+
+import Agent.Error (ApiError(..))
+import Agent.Responses.SSE (parseSseEvents)
+import Agent.Responses.StreamAssembly
+import Agent.Responses.Types
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Test.Hspec
+
+spec :: Spec
+spec = describe "buildStreamResponse" do
+    it "merges output_item.done events into the terminal response" do
+        events <- expectRight $ parseSseEvents $ Text.intercalate ""
+            [ sseBlock "response.output_item.done"
+                "{\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"type\":\"function_call\",\"call_id\":\"call-1\",\"name\":\"echo\",\"arguments\":\"{}\"}}"
+            , sseBlock "response.completed"
+                "{\"type\":\"response.completed\",\"response\":{\"id\":\"resp-1\",\"created_at\":0,\"model\":\"test\",\"status\":\"completed\",\"output\":[]}}"
+            ]
+        response <- expectRight (buildStreamResponse config events)
+        [name | FunctionCallItem FunctionCall { name } <- response.output]
+            `shouldBe` ["echo"]
+
+    it "uses provider classifiers when no terminal response is present" do
+        streamEvents <- expectRight $ parseSseEvents $ sseBlock "error"
+            "{\"type\":\"error\",\"error\":{\"message\":\"stream broke\"}}"
+        buildStreamResponse config streamEvents
+            `shouldBe` Left (ConnectionError "stream: stream broke")
+
+        failedEvents <- expectRight $ parseSseEvents $ sseBlock "response.failed"
+            "{\"type\":\"response.failed\",\"response\":{\"id\":\"resp-f\",\"created_at\":0,\"model\":\"test\",\"status\":\"failed\",\"incomplete_details\":{\"reason\":\"overloaded\"}}}"
+        buildStreamResponse config failedEvents
+            `shouldBe` Left (ConnectionError "failed: response.failed: overloaded")
+
+    it "uses the configured missing-completion message" do
+        case buildStreamResponse config [] of
+            Left (JsonDecodeError message _) ->
+                message `shouldBe` "custom missing completion"
+            other -> expectationFailure
+                ("expected missing-completion JsonDecodeError, got " <> show other)
+  where
+    config = StreamAssemblyConfig
+        { missingCompletionMessage = "custom missing completion"
+        , classifyStreamError =
+            \streamError -> ConnectionError ("stream: " <> streamError.message)
+        , classifyFailedResponse =
+            \response -> ConnectionError ("failed: " <> failedResponseMessage response)
+        }
+
+sseBlock :: Text -> Text -> Text
+sseBlock eventType dataText =
+    "event: " <> eventType <> "\ndata: " <> dataText <> "\n\n"
+
+expectRight :: Show error => Either error value -> IO value
+expectRight = \case
+    Left err ->
+        expectationFailure ("expected Right, got Left " <> show err)
+            >> fail "unreachable"
+    Right value -> pure value

--- a/packages/agent-responses/test/Spec.hs
+++ b/packages/agent-responses/test/Spec.hs
@@ -5,9 +5,11 @@ import Test.Hspec (hspec)
 import qualified Agent.Responses.LoopBackendSpec as LoopBackendSpec
 import qualified Agent.Responses.ResponseMergeSpec as ResponseMergeSpec
 import qualified Agent.Responses.SSESpec as SSESpec
+import qualified Agent.Responses.StreamAssemblySpec as StreamAssemblySpec
 
 main :: IO ()
 main = hspec do
     LoopBackendSpec.spec
     ResponseMergeSpec.spec
     SSESpec.spec
+    StreamAssemblySpec.spec

--- a/packages/agent-tui/agent-tui.cabal
+++ b/packages/agent-tui/agent-tui.cabal
@@ -40,6 +40,7 @@ library
                     , Agent.TUI.Motion
                     , Agent.TUI.Model
                     , Agent.TUI.Presentation
+                    , Agent.TUI.TextWidth
                     , Agent.TUI.Theme
     build-depends:    agent-core >= 0.1 && < 0.2
                     , agent-syntax >= 0.1 && < 0.2
@@ -59,7 +60,9 @@ test-suite agent-tui-test
                     , Agent.TUI.MarkdownSpec
                     , Agent.TUI.MotionSpec
                     , Agent.TUI.ModelSpec
+                    , Agent.TUI.PresentationSpec
                     , Agent.TUI.ThemeSpec
+                    , Agent.TUI.TextWidthSpec
     build-depends:    agent-tui
                     , agent-core
                     , agent-syntax

--- a/packages/agent-tui/src/Agent/TUI/Markdown.hs
+++ b/packages/agent-tui/src/Agent/TUI/Markdown.hs
@@ -20,15 +20,13 @@ import Agent.Syntax
     , SyntaxSpan(..)
     , highlightCode
     )
+import Agent.TUI.TextWidth (displayCharCellWidth)
 import qualified Agent.TUI.Theme as Theme
 import Brick
 import qualified Brick.Types as B
 import Data.Char
-    ( GeneralCategory(..)
-    , generalCategory
-    , isDigit
+    ( isDigit
     , isSpace
-    , ord
     )
 import Data.List (transpose)
 import qualified Data.List as List
@@ -39,36 +37,7 @@ import qualified Data.Text.Lazy.Builder as Builder
 import qualified Graphics.Vty as V
 
 terminalCharWidth :: Char -> Int
-terminalCharWidth char
-    | char == '\n' || char == '\r' || char == '\t' = 1
-    | code <= 0x1f || code == 0x7f = 1
-    | code >= 0x80 && code <= 0x9f = 1
-    | category == Format = 1
-    | category `elem` [NonSpacingMark, SpacingCombiningMark, EnclosingMark] = 0
-    | category `elem` [Control, Surrogate, NotAssigned] = 0
-    | isWideCharacter char = 2
-    | otherwise = 1
-  where
-    code = ord char
-    category = generalCategory char
-
-isWideCharacter :: Char -> Bool
-isWideCharacter char =
-    let code = ord char
-    in code >= 0x1100
-        && ( code <= 0x115f
-            || code == 0x2329
-            || code == 0x232a
-            || (code >= 0x2e80 && code <= 0xa4cf && code /= 0x303f)
-            || (code >= 0xac00 && code <= 0xd7a3)
-            || (code >= 0xf900 && code <= 0xfaff)
-            || (code >= 0xfe10 && code <= 0xfe19)
-            || (code >= 0xfe30 && code <= 0xfe6f)
-            || (code >= 0xff00 && code <= 0xff60)
-            || (code >= 0xffe0 && code <= 0xffe6)
-            || (code >= 0x1f300 && code <= 0x1faff)
-            || (code >= 0x20000 && code <= 0x3fffd)
-           )
+terminalCharWidth = displayCharCellWidth
 
 data InlineStyle
     = InlinePlain

--- a/packages/agent-tui/src/Agent/TUI/Presentation.hs
+++ b/packages/agent-tui/src/Agent/TUI/Presentation.hs
@@ -1,8 +1,13 @@
 -- | Presentation-neutral formatting shared by retained UI state.
 module Agent.TUI.Presentation
-    ( formatSearchReplaceDiff
+    ( SearchReplaceAction(..)
+    , SearchReplaceDiff(..)
+    , SearchReplaceLine(..)
+    , formatSearchReplaceDiff
     , formatToolOutput
+    , parseSearchReplaceDiff
     , summarizeToolCall
+    , toolDetail
     ) where
 
 import Agent.JsonText (jsonTextField, jsonTextFieldDefault)
@@ -25,25 +30,62 @@ summarizeToolCall call =
         detail = toolDetail call
     in if Text.null detail then verb else verb <> " " <> detail
 
-formatSearchReplaceDiff :: Text -> Text
-formatSearchReplaceDiff arguments =
+data SearchReplaceAction
+    = SearchReplaceCreate
+    | SearchReplaceDelete
+    deriving (Eq, Show)
+
+data SearchReplaceLine
+    = SearchReplaceRemoved !Text
+    | SearchReplaceAdded !Text
+    deriving (Eq, Show)
+
+data SearchReplaceDiff = SearchReplaceDiff
+    { diffPath :: !Text
+    , diffAction :: !(Maybe SearchReplaceAction)
+    , diffLines :: ![SearchReplaceLine]
+    , diffHiddenLines :: !Int
+    }
+    deriving (Eq, Show)
+
+parseSearchReplaceDiff :: Text -> SearchReplaceDiff
+parseSearchReplaceDiff arguments =
     let path = jsonTextFieldDefault "file_path" arguments
         oldText = jsonTextFieldDefault "old_string" arguments
         newText = jsonTextFieldDefault "new_string" arguments
-        header = case (Text.null oldText, Text.null newText) of
-            (True, False) -> "  create " <> path
-            (False, True) -> "  delete " <> path
-            _ -> ""
+        action = case (Text.null oldText, Text.null newText) of
+            (True, False) -> Just SearchReplaceCreate
+            (False, True) -> Just SearchReplaceDelete
+            _ -> Nothing
         raw =
-            map ("  -" <>) (Text.lines oldText)
-                <> map ("  +" <>) (Text.lines newText)
-        (shown, hidden)
-            | length raw <= 20 = (raw, 0)
-            | otherwise = (take 20 raw, length raw - 20)
+            map SearchReplaceRemoved (Text.lines oldText)
+                <> map SearchReplaceAdded (Text.lines newText)
+        shown = take 20 raw
+    in SearchReplaceDiff
+        { diffPath = path
+        , diffAction = action
+        , diffLines = shown
+        , diffHiddenLines = length raw - length shown
+        }
+
+formatSearchReplaceDiff :: Text -> Text
+formatSearchReplaceDiff arguments =
+    let SearchReplaceDiff { diffPath, diffAction, diffLines, diffHiddenLines } =
+            parseSearchReplaceDiff arguments
+        header = case diffAction of
+            Just SearchReplaceCreate -> "  create " <> diffPath
+            Just SearchReplaceDelete -> "  delete " <> diffPath
+            _ -> ""
+        shown = map formatLine diffLines
         more
-            | hidden == 0 = []
-            | otherwise = ["  … " <> Text.pack (show hidden) <> " more"]
+            | diffHiddenLines == 0 = []
+            | otherwise =
+                ["  … " <> Text.pack (show diffHiddenLines) <> " more"]
     in Text.intercalate "\n" (filter (not . Text.null) (header : shown <> more))
+  where
+    formatLine = \case
+        SearchReplaceRemoved line -> "  -" <> line
+        SearchReplaceAdded line -> "  +" <> line
 
 formatToolOutput :: ToolCall -> Text -> Text
 formatToolOutput call output = case canonicalToolName call.name of

--- a/packages/agent-tui/src/Agent/TUI/TextWidth.hs
+++ b/packages/agent-tui/src/Agent/TUI/TextWidth.hs
@@ -1,0 +1,57 @@
+-- | Terminal-cell width classification shared by line editors and renderers.
+module Agent.TUI.TextWidth
+    ( charCellWidth
+    , displayCharCellWidth
+    , isWideCharacter
+    ) where
+
+import Data.Char
+    ( GeneralCategory(..)
+    , generalCategory
+    , ord
+    )
+
+-- | Width of a Unicode character before any control-character visualization.
+--
+-- Combining marks occupy no additional cells. Control and unassigned
+-- characters are also zero-width; callers that render them as replacement
+-- glyphs should measure the replacement instead.
+charCellWidth :: Char -> Int
+charCellWidth char
+    | category `elem` [NonSpacingMark, SpacingCombiningMark, EnclosingMark] = 0
+    | category `elem` [Control, Surrogate, NotAssigned] = 0
+    | isWideCharacter char = 2
+    | otherwise = 1
+  where
+    category = generalCategory char
+
+-- | Width used when a renderer displays terminal controls as visible
+-- one-cell placeholders rather than treating them as zero-width input.
+displayCharCellWidth :: Char -> Int
+displayCharCellWidth char
+    | char == '\n' || char == '\r' || char == '\t' = 1
+    | code <= 0x1f || code == 0x7f = 1
+    | code >= 0x80 && code <= 0x9f = 1
+    | generalCategory char == Format = 1
+    | otherwise = charCellWidth char
+  where
+    code = ord char
+
+-- | Approximate the wide/full-width ranges used by terminal emulators.
+isWideCharacter :: Char -> Bool
+isWideCharacter char =
+    let code = ord char
+    in code >= 0x1100
+        && ( code <= 0x115f
+            || code == 0x2329
+            || code == 0x232a
+            || (code >= 0x2e80 && code <= 0xa4cf && code /= 0x303f)
+            || (code >= 0xac00 && code <= 0xd7a3)
+            || (code >= 0xf900 && code <= 0xfaff)
+            || (code >= 0xfe10 && code <= 0xfe19)
+            || (code >= 0xfe30 && code <= 0xfe6f)
+            || (code >= 0xff00 && code <= 0xff60)
+            || (code >= 0xffe0 && code <= 0xffe6)
+            || (code >= 0x1f300 && code <= 0x1faff)
+            || (code >= 0x20000 && code <= 0x3fffd)
+           )

--- a/packages/agent-tui/test/Agent/TUI/PresentationSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/PresentationSpec.hs
@@ -1,0 +1,45 @@
+module Agent.TUI.PresentationSpec (spec) where
+
+import Agent.TUI.Presentation
+import Agent.ToolDispatch
+    ( customToolCall
+    , functionToolCall
+    )
+import qualified Data.Text as Text
+import Test.Hspec
+
+spec :: Spec
+spec = describe "tool presentation" do
+    it "extracts tool details from function and custom calls" do
+        toolDetail
+            (functionToolCall "read" "read_file"
+                "{\"target_file\":\"src/Main.hs\"}")
+            `shouldBe` "src/Main.hs"
+        toolDetail
+            (customToolCall "patch" "apply_patch"
+                "*** Begin Patch\n*** Update File: src/Main.hs\n*** End Patch")
+            `shouldBe` "src/Main.hs"
+
+    it "parses and truncates search-replace diffs once for all renderers" do
+        let oldText = Text.intercalate "\\n"
+                ["old" <> Text.pack (show n) | n <- [1 :: Int .. 15]]
+            newText = Text.intercalate "\\n"
+                ["new" <> Text.pack (show n) | n <- [1 :: Int .. 15]]
+            arguments =
+                "{\"file_path\":\"src/Main.hs\",\"old_string\":\""
+                    <> oldText
+                    <> "\",\"new_string\":\""
+                    <> newText
+                    <> "\"}"
+            parsed = parseSearchReplaceDiff arguments
+        parsed.diffPath `shouldBe` "src/Main.hs"
+        parsed.diffAction `shouldBe` Nothing
+        length parsed.diffLines `shouldBe` 20
+        parsed.diffHiddenLines `shouldBe` 10
+
+    it "formats structured collaboration output" do
+        formatToolOutput
+            (functionToolCall "agents" "collaboration.list_agents" "{}")
+            "{\"agents\":[{\"agent_name\":\"/root/reviewer\",\
+            \\"agent_status\":\"running\"}]}"
+            `shouldBe` "/root/reviewer · running"

--- a/packages/agent-tui/test/Agent/TUI/TextWidthSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/TextWidthSpec.hs
@@ -1,0 +1,22 @@
+module Agent.TUI.TextWidthSpec (spec) where
+
+import Agent.TUI.TextWidth
+import Test.Hspec
+
+spec :: Spec
+spec = describe "terminal character width" do
+    it "classifies narrow, wide, and combining characters" do
+        charCellWidth 'a' `shouldBe` 1
+        charCellWidth '界' `shouldBe` 2
+        charCellWidth '🙂' `shouldBe` 2
+        charCellWidth '\x0301' `shouldBe` 0
+
+    it "keeps raw controls zero-width but display placeholders one cell wide" do
+        charCellWidth '\BEL' `shouldBe` 0
+        displayCharCellWidth '\BEL' `shouldBe` 1
+        displayCharCellWidth '\t' `shouldBe` 1
+
+    it "exposes the shared wide-character classification" do
+        isWideCharacter '界' `shouldBe` True
+        isWideCharacter '🙂' `shouldBe` True
+        isWideCharacter 'a' `shouldBe` False

--- a/packages/agent-tui/test/Spec.hs
+++ b/packages/agent-tui/test/Spec.hs
@@ -4,7 +4,9 @@ import qualified Agent.TUI.FencedCodeSpec as FencedCodeSpec
 import qualified Agent.TUI.MarkdownSpec as MarkdownSpec
 import qualified Agent.TUI.MotionSpec as MotionSpec
 import qualified Agent.TUI.ModelSpec as ModelSpec
+import qualified Agent.TUI.PresentationSpec as PresentationSpec
 import qualified Agent.TUI.ThemeSpec as ThemeSpec
+import qualified Agent.TUI.TextWidthSpec as TextWidthSpec
 import Test.Hspec (hspec)
 
 main :: IO ()
@@ -13,4 +15,6 @@ main = hspec do
     MarkdownSpec.spec
     MotionSpec.spec
     ModelSpec.spec
+    PresentationSpec.spec
     ThemeSpec.spec
+    TextWidthSpec.spec

--- a/packages/agent-xai/agent-xai.cabal
+++ b/packages/agent-xai/agent-xai.cabal
@@ -56,7 +56,6 @@ library
                     , http-client
                     , http-client-tls
                     , http-conduit
-                    , base64-bytestring
                     , retry >= 0.9.3.1 && < 0.10
                     , safe-exceptions
                     , scientific

--- a/packages/agent-xai/src/Agent/XAI/Auth.hs
+++ b/packages/agent-xai/src/Agent/XAI/Auth.hs
@@ -31,11 +31,11 @@ module Agent.XAI.Auth
 
 import Agent.Http.Url (trimTrailingSlash)
 import Agent.Error (ApiError(..), ErrorType(..))
+import Agent.Auth.JWT (decodeJwtPayload)
 import Control.Concurrent (threadDelay)
 import Control.Exception.Safe (tryAny)
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString as BS
-import qualified "base64-bytestring" Data.ByteString.Base64 as Base64
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Maybe as Maybe
 import Data.Text (Text)
@@ -251,7 +251,7 @@ parseTokens = decodeResponse "token response"
 -- namespaces accounts, it grants nothing.
 accountIdFromAccessToken :: Text -> Maybe Text
 accountIdFromAccessToken accessToken = do
-    payload <- decodeJwtPayload accessToken
+    payload <- decodeJwtPayload @JwtClaims accessToken
     payload.subject
         `orElse` payload.principalIdSnake
         `orElse` payload.principalIdCamel
@@ -262,7 +262,7 @@ accountIdFromAccessToken accessToken = do
 
 emailFromToken :: Text -> Maybe Text
 emailFromToken token = do
-    payload <- decodeJwtPayload token
+    payload <- decodeJwtPayload @JwtClaims token
     email <- payload.email
     let trimmed = Text.strip email
     if Text.null trimmed then Nothing else Just trimmed
@@ -280,25 +280,6 @@ instance Aeson.FromJSON JwtClaims where
         <*> object Aeson..:? "principal_id"
         <*> object Aeson..:? "principalId"
         <*> object Aeson..:? "email"
-
-decodeJwtPayload :: Text -> Maybe JwtClaims
-decodeJwtPayload token = do
-    payloadB64 <- case Text.splitOn "." token of
-        (_ : payload : _) -> Just payload
-        _ -> Nothing
-    let padded = base64UrlToBase64 payloadB64
-    payloadBytes <- either (const Nothing) Just (Base64.decode (Text.encodeUtf8 padded))
-    Aeson.decode (LBS.fromStrict payloadBytes)
-
-base64UrlToBase64 :: Text -> Text
-base64UrlToBase64 input = padded
-  where
-    replaced = Text.map replace input
-    replace '-' = '+'
-    replace '_' = '/'
-    replace c = c
-    padding = (4 - Text.length replaced `mod` 4) `mod` 4
-    padded = replaced <> Text.replicate padding "="
 
 --------------------------------------------------------------------------------
 -- Small helpers

--- a/packages/agent-xai/src/Agent/XAI/Client.hs
+++ b/packages/agent-xai/src/Agent/XAI/Client.hs
@@ -9,12 +9,11 @@ module Agent.XAI.Client
     , retryTransientXaiResultWithPolicy
     ) where
 
-import Agent.Http.Header (parseRetryAfterSeconds)
-import Agent.Http.Url (trimTrailingSlash)
 import Agent.Error
     ( ApiError(..)
     , ErrorType(..)
     )
+import qualified Agent.Responses.HttpSSE as HttpSSE
 import Agent.Responses.Types
 import Agent.Provider (Credential(..), Provider(..))
 import Agent.XAI.Error
@@ -24,13 +23,7 @@ import Agent.XAI.Error
     )
 import Agent.XAI.Options
 import Agent.XAI.Request (buildRequest)
-import Agent.XAI.Stream
-    ( buildResponse
-    , feedSseDecoder
-    , finishSseDecoder
-    , newSseDecoder
-    )
-import Control.Exception.Safe (tryAny)
+import Agent.XAI.Stream (buildResponse)
 import Control.Retry
     ( RetryPolicyM
     , constantDelay
@@ -38,17 +31,11 @@ import Control.Retry
     , retrying
     )
 import qualified Data.Aeson as Aeson
-import qualified Data.ByteString as BS
-import qualified Data.ByteString.Lazy as LBS
 import Data.IORef
-import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
-import qualified Data.Text.Encoding.Error as Text (lenientDecode)
-import qualified Network.HTTP.Client as HttpClient
-import qualified Network.HTTP.Client.TLS as HttpTls
 import Network.HTTP.Simple hiding (Response)
 
-type StreamEventCallback = ResponseStreamEvent -> IO ()
+type StreamEventCallback = HttpSSE.StreamEventCallback
 
 -- | Send one request using environment-derived client options.
 createResponse :: Credential -> ResponseCreateParams -> IO (Either ApiError Response)
@@ -126,84 +113,27 @@ createResponseWithMaybeEventsPolicy policy options credential request onEvent
     | otherwise =
         retryTransientXaiStreamWithPolicy policy performOnce onEvent
   where
-    performOnce emit =
-        tryAny (performRequest emit) >>= \case
-            Left exception -> pure $ Left $ ConnectionError
-                ("xAI request failed: " <> Text.pack (show exception))
-            Right result -> pure result
+    performOnce =
+        HttpSSE.performResponsesHttpSse
+            HttpSSE.HttpSseConfig
+                { exceptionPrefix = "xAI request failed"
+                , classifyFailure
+                , buildResponse
+                }
+            options.baseUrl
+            options.requestTimeoutSeconds
+            (Aeson.encode (buildRequest options request))
+            configureRequest
 
-    performRequest emit = do
-        httpRequest <- parseRequest ("POST " <> trimTrailingSlash options.baseUrl <> "/responses")
-        manager <- HttpTls.getGlobalManager
-        HttpClient.withResponse
-            ( setRequestBodyLBS (Aeson.encode (buildRequest options request))
-            $ setRequestHeader "Authorization"
-                ["Bearer " <> Text.encodeUtf8 credential.accessToken]
-            $ setRequestHeader "X-XAI-Token-Auth" ["xai-grok-cli"]
-            $ setRequestHeader "x-grok-client-version" [Text.encodeUtf8 options.clientVersion]
-            $ setRequestHeader "x-grok-client-identifier" ["grok-shell"]
-            $ setRequestHeader "x-grok-client-mode" ["interactive"]
-            $ setRequestHeader "Content-Type" ["application/json"]
-            $ setRequestHeader "Accept" ["text/event-stream"]
-            $ setRequestHeader "User-Agent" ["codex-hs"]
-            $ withTimeout httpRequest
-            )
-            manager
-            (handleResponse emit)
-
-    withTimeout httpRequest = httpRequest
-        { HttpClient.responseTimeout =
-            HttpClient.responseTimeoutMicro (options.requestTimeoutSeconds * 1_000_000)
-        }
-
-    handleResponse emit response = do
-        let status = getResponseStatusCode response
-        if status >= 200 && status < 300
-            then consumeSse emit (HttpClient.responseBody response)
-            else do
-                body <- consumeBody (HttpClient.responseBody response)
-                let bodyText = Text.decodeUtf8With Text.lenientDecode
-                        (LBS.toStrict body)
-                pure $ Left $
-                    classifyFailure status
-                        (parseRetryAfterSeconds
-                            (getResponseHeader "Retry-After" response))
-                        bodyText
-
-    consumeSse emit body = go newSseDecoder []
-      where
-        go decoder reversedEvents = do
-            chunk <- HttpClient.brRead body
-            if BS.null chunk
-                then case finishSseDecoder decoder of
-                    Left err -> pure (Left err)
-                    Right trailing -> do
-                        mapM_ emit trailing
-                        pure $ buildResponse
-                            (reverse reversedEvents <> trailing)
-                else case feedSseDecoder decoder chunk of
-                    Left err -> pure (Left err)
-                    Right (nextDecoder, events) -> do
-                        mapM_ emit events
-                        let retained = filter retainForResponse events
-                        go nextDecoder (reverse retained <> reversedEvents)
-
-    consumeBody body = LBS.fromChunks <$> readChunks []
-      where
-        readChunks reversedChunks = do
-            chunk <- HttpClient.brRead body
-            if BS.null chunk
-                then pure (reverse reversedChunks)
-                else readChunks (chunk : reversedChunks)
-
-    retainForResponse = \case
-        ResponseOutputItemDoneEvent {} -> True
-        ResponseCompletedEvent {} -> True
-        ResponseIncompleteEvent {} -> True
-        ResponseErrorEvent {} -> True
-        ResponseNestedErrorEvent {} -> True
-        ResponseFailedEvent {} -> True
-        _ -> False
+    configureRequest =
+        setRequestHeader "Authorization"
+            ["Bearer " <> Text.encodeUtf8 credential.accessToken]
+            . setRequestHeader "X-XAI-Token-Auth" ["xai-grok-cli"]
+            . setRequestHeader "x-grok-client-version"
+                [Text.encodeUtf8 options.clientVersion]
+            . setRequestHeader "x-grok-client-identifier" ["grok-shell"]
+            . setRequestHeader "x-grok-client-mode" ["interactive"]
+            . setRequestHeader "User-Agent" ["codex-hs"]
 
 -- | Retry transient failures while replay is safe. The callback marker is
 -- written before user code runs, so callback exceptions are never retried.

--- a/packages/agent-xai/src/Agent/XAI/Stream.hs
+++ b/packages/agent-xai/src/Agent/XAI/Stream.hs
@@ -10,7 +10,6 @@ module Agent.XAI.Stream
 
 import Agent.Error (ApiError(..), errorTypeFromText)
 import Agent.Responses.Error (mkOpenAIError)
-import Agent.Responses.ResponseMerge (mergeCompletedResponseOutput)
 import Agent.Responses.SSE
     ( SseDecoder
     , feedSseDecoder
@@ -18,55 +17,22 @@ import Agent.Responses.SSE
     , newSseDecoder
     , parseSseEvents
     )
+import Agent.Responses.StreamAssembly
+    ( StreamAssemblyConfig(..)
+    , buildStreamResponse
+    , failedResponseMessage
+    )
 import Agent.Responses.Types
 import Agent.XAI.Error (classifyStreamError)
-import qualified Data.Aeson as Aeson
-import qualified Data.ByteString.Lazy as LBS
-import qualified Data.Maybe as Maybe
-import Data.Text (Text)
-import qualified Data.Text as Text
-import qualified Data.Text.Encoding as Text
-import qualified Data.Text.Encoding.Error as Text (lenientDecode)
 
 -- | Merge streamed output-item events into the terminal completed response.
 buildResponse :: [ResponseStreamEvent] -> Either ApiError Response
-buildResponse events = case lastMaybe terminalResponses of
-    Just terminal -> decodeMerged terminal
-    Nothing -> Left (Maybe.fromMaybe missingCompletion (firstFailure events))
-  where
-    terminalResponses = Maybe.mapMaybe terminalResponse events
-    doneItems =
-        [ Aeson.toJSON item
-        | ResponseOutputItemDoneEvent { item } <- events
-        ]
-
-    decodeMerged completed =
-        let merged = mergeCompletedResponseOutput doneItems (Aeson.toJSON completed)
-        in case Aeson.fromJSON merged of
-            Aeson.Success response -> Right response
-            Aeson.Error err -> Left $ JsonDecodeError
-                (Text.pack err)
-                (Text.take 2000 (Text.decodeUtf8With Text.lenientDecode
-                    (LBS.toStrict (Aeson.encode merged))))
-
-    missingCompletion = JsonDecodeError
+buildResponse = buildStreamResponse StreamAssemblyConfig
+    { missingCompletionMessage =
         "No terminal response event found in xAI SSE stream"
-        (Text.take 2000 (Text.decodeUtf8With Text.lenientDecode
-            (LBS.toStrict (Aeson.encode events))))
-
-    terminalResponse = \case
-        ResponseCompletedEvent { response } -> Just response
-        ResponseIncompleteEvent { response } -> Just response
-        _ -> Nothing
-
-firstFailure :: [ResponseStreamEvent] -> Maybe ApiError
-firstFailure = Maybe.listToMaybe . Maybe.mapMaybe failure
-  where
-    failure = \case
-        ResponseErrorEvent { streamError } -> Just (classifyStreamError streamError)
-        ResponseNestedErrorEvent { streamError } -> Just (classifyStreamError streamError)
-        ResponseFailedEvent { response } -> Just (failedResponseError response)
-        _ -> Nothing
+    , classifyStreamError
+    , classifyFailedResponse = failedResponseError
+    }
 
 failedResponseError :: Response -> ApiError
 failedResponseError response = case response.error of
@@ -77,15 +43,3 @@ failedResponseError response = case response.error of
             (Just responseError.code)
             Nothing
     Nothing -> ConnectionError (failedResponseMessage response)
-
-failedResponseMessage :: Response -> Text
-failedResponseMessage response = case response.error of
-    Just responseError -> responseError.message
-    Nothing -> case response.incompleteDetails of
-        Just details -> "response.failed: " <> details.reason
-        Nothing -> "response.failed (no details)"
-
-lastMaybe :: [value] -> Maybe value
-lastMaybe [] = Nothing
-lastMaybe [value] = Just value
-lastMaybe (_ : rest) = lastMaybe rest


### PR DESCRIPTION
## Summary

- extract shared provider-neutral HTTP/SSE transport and terminal response assembly for OpenRouter and xAI
- centralize tool presentation, Unicode width handling, split-pane rendering, JWT decoding, command-result formatting, and JSON tool construction
- share child-subagent and session append scaffolding
- unify directory ancestry and terminal subagent status semantics
- add focused regression coverage for each shared abstraction

## Validation

- multi-package GHCi load: 158 modules
- `nix develop -c cabal test all --test-show-details=direct`
  - agent-core: 277 examples, 0 failures
  - agent-cli: 553 examples, 0 failures
  - agent-tui: 53 examples, 0 failures
  - agent-responses: 12 examples, 0 failures
  - agent-openai: 178 examples, 0 failures, 1 live test pending
  - agent-openrouter: 38 examples, 0 failures, 1 live test pending
  - agent-xai: 47 examples, 0 failures, 1 live test pending
  - agent-syntax: 9 examples, 0 failures
- live tmux smoke test of the fullscreen CLI and `/resume` overlay
- `git diff --check`
