### PR TITLE
Fix image-only prompt submission

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -91,6 +91,7 @@ import Agent.CLI.Input
     ( ReplLine(..)
     , formatPasteChip
     , readReplLineWithSkills
+    , submissionPromptText
     )
 import Agent.CLI.ReplMode
     ( ReplMode(..)
@@ -2282,16 +2283,17 @@ replWithDraft env@SessionEnv
             submitLine skillCommands skillInvocations
                 continue stdoutColor False line
   where
-    submitLine skillCommands skillInvocations continue color pasted line =
-        let stripped = Text.strip line
-        in if Text.null stripped
-            then continue
-            else do
+    submitLine skillCommands skillInvocations continue color pasted line = do
+        attachmentCount <- length <$> readIORef attachmentsRef
+        case submissionPromptText attachmentCount line of
+            Nothing -> continue
+            Just promptLine -> do
+                let stripped = Text.strip promptLine
                 when pasted do
                     let chip = formatPasteChip stripped
                     when (chip /= stripped && isNothing fullscreen) do
                         Text.putStrLn (roleMuted color chip)
-                case parseReplLineWithSkills skillCommands line of
+                case parseReplLineWithSkills skillCommands promptLine of
                     ReplQuit -> pure RunQuit
                     ReplReload -> requestReload persist
                     ReplPrompt text -> do

--- a/packages/agent-cli/src/Agent/CLI/Input.hs
+++ b/packages/agent-cli/src/Agent/CLI/Input.hs
@@ -19,6 +19,7 @@ module Agent.CLI.Input
     , isClipboardPasteCsiBody
     , isClipboardPasteKey
     , isShiftEnterCsiBody
+    , submissionPromptText
     , appendReplHistory
     , readReplHistory
     , replHistoryPath
@@ -136,6 +137,15 @@ data ReplLine
     -- ^ Fullscreen status click: open the effort selector and keep the draft.
     | ReplQuitInterrupt
     deriving (Eq, Show)
+
+-- | Keep empty composers inert unless they have queued image attachments.
+-- Providers expect a non-empty text part alongside image parts, so image-only
+-- submissions receive a small synthetic prompt.
+submissionPromptText :: Int -> Text -> Maybe Text
+submissionPromptText attachmentCount text
+    | not (Text.null (Text.strip text)) = Just text
+    | attachmentCount > 0 = Just "The user attached an image."
+    | otherwise = Nothing
 
 -- | Strip terminal bracketed-paste wrappers (raw @CSI 200~@ / @CSI 201~@,
 -- or the printable sentinels used by older history/input versions) and decide

--- a/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
@@ -36,6 +36,7 @@ import Agent.CLI.Input
     ( ReplLine(..)
     , appendReplHistory
     , displayEditorText
+    , submissionPromptText
     , terminalCharWidth
     , terminalTextWidth
     )
@@ -777,9 +778,11 @@ handleComposerKey
     submitDraft = do
         state <- get
         let draft = state.appUi.uiDraft
-        if Text.null (Text.strip draft)
-            then pure ()
-            else submitText state draft state.appPasted
+            attachmentCount =
+                state.appUi.uiPrompt.promptAttachments
+        case submissionPromptText attachmentCount draft of
+            Nothing -> pure ()
+            Just text -> submitText state text state.appPasted
 
     submitText state text pasted = do
         liftIO (appendReplHistory text)

--- a/packages/agent-cli/test/Agent/CLI/InputSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/InputSpec.hs
@@ -13,6 +13,7 @@ import Agent.CLI.Input
     , isShiftEnterCsiBody
     , parseChoiceKey
     , replHistoryPath
+    , submissionPromptText
     , terminalTextWidth
     , truncateDisplayText
     , visibleEditorText
@@ -78,6 +79,21 @@ spec = do
         it "treats a 4-line burst as a paste" do
             let burst = Text.unlines ["one", "two", "three", "four"]
             classifyPastedText burst `shouldBe` (burst, True)
+
+    describe "submissionPromptText" do
+        it "keeps an empty composer inert without attachments" do
+            submissionPromptText 0 "" `shouldBe` Nothing
+            submissionPromptText 0 " \n " `shouldBe` Nothing
+
+        it "supplies fallback text for an image-only submission" do
+            submissionPromptText 1 ""
+                `shouldBe` Just "The user attached an image."
+            submissionPromptText 2 " \n "
+                `shouldBe` Just "The user attached an image."
+
+        it "preserves user text exactly when attachments are present" do
+            submissionPromptText 1 "  describe this  "
+                `shouldBe` Just "  describe this  "
 
     describe "formatPasteChip" do
         it "keeps short pastes inline and chips long ones" do


### PR DESCRIPTION
## Summary
- allow an empty composer to submit when image attachments are queued
- add the fallback prompt `The user attached an image.` for image-only turns
- apply the same normalization in fullscreen and inline REPL submission paths
- preserve the existing no-op behavior for empty input without attachments

## Testing
- `nix develop -c cabal repl agent-cli:test:agent-cli-test`
  - `:main --match submissionPromptText` (3 examples, 0 failures)
- live tmux smoke test: attached a PNG, pressed Enter with an empty fullscreen composer, and verified the image-only turn was submitted and received a model response
