### PR TITLE
fix(grok): snapshot background task environments

### DIFF
--- a/packages/agent-core/src/Agent/Tools/Grok/Shell.hs
+++ b/packages/agent-core/src/Agent/Tools/Grok/Shell.hs
@@ -39,8 +39,9 @@ import Agent.Tools.Types (ToolEnv(..))
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async (race)
 import Control.Concurrent.MVar
-import Control.Exception.Safe (mask, onException, throwIO, tryAny)
+import Control.Exception.Safe (finally, mask, onException, throwIO, tryAny)
 import Control.Monad (void)
+import qualified Data.ByteString as BS
 import Data.IORef
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
@@ -81,7 +82,9 @@ newGrokSession :: ToolEnv -> IO GrokSession
 newGrokSession env = do
     resources <- newResourceScope
     flip onException (closeResourceScope resources) do
-        (_, envFile) <- allocateResource resources acquireEnvFile cleanupEnvFiles
+        (_, envFile) <- allocateResource resources
+            (acquirePrivateFile "agent-grok-env")
+            cleanupEnvFiles
         shell <- newMVar PersistentShell
             { shellCwd = env.toolCwd
             , shellEnvFile = envFile
@@ -95,25 +98,6 @@ newGrokSession env = do
             , grokNextId = nextId
             , grokResources = resources
             }
-  where
-    acquireEnvFile =
-        mask \restore -> do
-            tmp <- getTemporaryDirectory
-            (envFileRaw, handle) <- restore $
-                mkstemp (unsafeToFilePath (tmp </> unsafeEncodeUtf "agent-grok-env"))
-            let envFile = unsafeEncodeUtf envFileRaw
-            let rollback = do
-                    void $ tryAny (hClose handle)
-                    removeIfExists envFile
-            flip onException rollback do
-                hClose handle
-                setFileMode envFileRaw
-                    (unionFileModes ownerReadMode ownerWriteMode)
-                Text.writeFile envFileRaw ""
-                pure envFile
-    cleanupEnvFiles envFile = do
-        removeIfExists envFile
-        removeIfExists (envFile <.> unsafeEncodeUtf "cwd")
 
 -- | Delete the env/cwd dump and interrupt leftover background tasks.
 -- Call this when the CLI/session ends, including after exceptions.
@@ -144,19 +128,14 @@ runForegroundStreaming session command timeoutMs onSnapshot =
 
 startBackground :: GrokSession -> Text -> IO (Either Text Text)
 startBackground session command = do
-    shell <- readMVar session.grokShell
-    -- Background wrappers source cwd/env but must not write them back;
-    -- a later foreground command owns the persistent session.
-    let wrapped = bashWrap (wrapScript shell False (Text.unpack command))
-    started <- tryAny $
+    started <- tryAny $ withMVar session.grokShell \shell ->
         allocateResource session.grokResources
-            (startShellCommand session.grokEnv session.grokEnv.toolCwd wrapped
-                >>= either (throwIO . userError . Text.unpack) pure)
-            stopShellCommand
+            (acquireBackground shell)
+            cleanupBackground
     case started of
         Left exception ->
             pure (Left (Text.pack (show exception)))
-        Right (resource, running) -> do
+        Right (resource, (running, _snapshotFile)) -> do
             taskId <- nextTaskId session
             let task = BackgroundTask
                     { backgroundId = taskId
@@ -170,6 +149,33 @@ startBackground session command = do
                 "Command moved to background.\n\
                 \task_id: " <> taskId <> "\n\
                 \Use get_task_output to read output. Do not poll in a loop."
+  where
+    -- The child may not source its environment until after
+    -- startShellCommand returns. Give it an immutable snapshot so a later
+    -- foreground command cannot change what this task observes.
+    acquireBackground shell =
+        mask \restore -> do
+            snapshotFile <- acquirePrivateFile "agent-grok-env-bg"
+            let cleanupSnapshot = cleanupEnvFiles snapshotFile
+            flip onException cleanupSnapshot do
+                restore $
+                    BS.readFile (unsafeToFilePath shell.shellEnvFile)
+                        >>= BS.writeFile (unsafeToFilePath snapshotFile)
+                let snapshotShell = shell { shellEnvFile = snapshotFile }
+                    wrapped =
+                        bashWrap
+                            (wrapScript snapshotShell False (Text.unpack command))
+                running <-
+                    startShellCommand
+                        session.grokEnv
+                        session.grokEnv.toolCwd
+                        wrapped
+                    >>= either (throwIO . userError . Text.unpack) pure
+                pure (running, snapshotFile)
+
+    cleanupBackground (running, snapshotFile) =
+        stopShellCommand running
+            `finally` cleanupEnvFiles snapshotFile
 
 readTaskOutput :: GrokSession -> Text -> Maybe Int -> IO Text
 readTaskOutput session taskId timeoutMs = do
@@ -266,6 +272,28 @@ removeIfExists path = do
     if exists
         then void $ tryAny (removeFile path)
         else pure ()
+
+acquirePrivateFile :: String -> IO OsPath
+acquirePrivateFile template =
+    mask \_ -> do
+        tmp <- getTemporaryDirectory
+        (pathRaw, handle) <-
+            mkstemp (unsafeToFilePath (tmp </> unsafeEncodeUtf template))
+        let path = unsafeEncodeUtf pathRaw
+            rollback = do
+                void $ tryAny (hClose handle)
+                removeIfExists path
+        flip onException rollback do
+            hClose handle
+            setFileMode pathRaw
+                (unionFileModes ownerReadMode ownerWriteMode)
+            Text.writeFile pathRaw ""
+            pure path
+
+cleanupEnvFiles :: OsPath -> IO ()
+cleanupEnvFiles envFile = do
+    removeIfExists envFile
+    removeIfExists (envFile <.> unsafeEncodeUtf "cwd")
 
 -- | True when a foreground command would background itself with @&@.
 hasUnwaitedBackgroundOp :: Text -> Bool

--- a/packages/agent-core/test/Agent/Tools/GrokSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/GrokSpec.hs
@@ -11,7 +11,13 @@ import Agent.Tools.Types (jsonToolParameters)
 import Agent.Tools.Grok (closeGrokSession, grokTools, newGrokSession)
 import Agent.Tools.Grok.Task (GrokSubagentSpec)
 import Agent.Tools.Ghci (GhciSession, closeGhciSession, newGhciSession)
-import Agent.Tools.Grok.Shell (GrokSession(..), PersistentShell(..), hasUnwaitedBackgroundOp)
+import Agent.Tools.Grok.Shell
+    ( GrokSession(..)
+    , PersistentShell(..)
+    , hasUnwaitedBackgroundOp
+    , readTaskOutput
+    , startBackground
+    )
 import Agent.Subagents.TaskPath (taskPathRoot)
 import Agent.Tools.MultiAgents (MultiAgentContext(..))
 import Agent.Tools.PlanMode (PlanModeEnv, activatePlanMode, newPlanModeEnv)
@@ -22,7 +28,7 @@ import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe)
 import Control.Concurrent.MVar (readMVar)
-import Control.Exception (bracket, finally)
+import Control.Exception (bracket, bracket_, finally)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
@@ -30,9 +36,12 @@ import System.Directory
     ( createDirectoryIfMissing
     , createDirectoryLink
     , doesFileExist
+    , findExecutable
     , getTemporaryDirectory
     )
 import System.FilePath (takeDirectory, takeFileName, (</>))
+import System.Environment (lookupEnv, setEnv, unsetEnv)
+import System.Posix.Files (setFileMode)
 import System.Posix.Temp (mkdtemp)
 import System.Directory (removeDirectoryRecursive)
 import Test.Hspec
@@ -244,6 +253,44 @@ spec = describe "Agent.Tools.Grok" do
                 "{\"command\":\"echo $GROK_SESSION_VAR\",\"description\":\"show env\"}"
             envOut `shouldSatisfy` Text.isInfixOf "persisted"
 
+    it "captures background environment at launch" do
+        withTempSession \(session, ghci) -> do
+            _ <- runTool session ghci "run_terminal_cmd"
+                "{\"command\":\"export GROK_SESSION_VAR=before\",\"description\":\"seed env\"}"
+            let cwd = toFilePath session.grokEnv.toolCwd
+                shimDir = cwd </> "shim-bin"
+                shimPath = shimDir </> "bash"
+                claimPath = cwd </> "bash-shim-claim"
+                startedPath = cwd </> "bash-shim-started"
+                releasePath = cwd </> "bash-shim-release"
+                observedPath = cwd </> "background-env"
+            bashPath <- requireExecutable "bash"
+            createDirectoryIfMissing True shimDir
+            writeFile shimPath $ unlines
+                [ "#!/bin/sh"
+                , "if mkdir " <> shellQuote claimPath <> " 2>/dev/null; then"
+                , "  touch " <> shellQuote startedPath
+                , "  while [ ! -e " <> shellQuote releasePath
+                    <> " ]; do sleep 0.01; done"
+                , "fi"
+                , "exec " <> shellQuote bashPath <> " \"$@\""
+                ]
+            setFileMode shimPath 0o700
+
+            withPathPrefix shimDir do
+                started <- startBackground session
+                    "printf '%s' \"$GROK_SESSION_VAR\" > background-env"
+                started `shouldSatisfy` either (const False) (Text.isInfixOf "task_id:")
+                let taskId = either (const "") taskIdFrom started
+                waitForFile startedPath
+                foreground <- runTool session ghci "run_terminal_cmd"
+                    "{\"command\":\"export GROK_SESSION_VAR=after\",\"description\":\"update env\"}"
+                    `finally` writeFile releasePath ""
+                foreground `shouldSatisfy` Text.isPrefixOf "exit: 0"
+                finished <- readTaskOutput session taskId (Just 5000)
+                finished `shouldSatisfy` Text.isPrefixOf "exit: 0"
+                Text.readFile observedPath `shouldReturn` "before"
+
     it "rejects an un-waited & in a foreground command" do
         withTempSession \(session, ghci) -> do
             output <- runTool session ghci "run_terminal_cmd"
@@ -362,11 +409,33 @@ waitForFile path = go (20 :: Int)
             True -> pure ()
             False -> threadDelay 50000 >> go (n - 1)
 
+requireExecutable :: String -> IO FilePath
+requireExecutable name =
+    findExecutable name >>= \case
+        Just path -> pure path
+        Nothing -> do
+            expectationFailure ("could not find executable: " <> name)
+            pure name
+
 taskIdFrom :: Text -> Text
 taskIdFrom output =
     case [tid | line <- Text.lines output, Just tid <- [Text.stripPrefix "task_id: " line]] of
         (tid : _) -> tid
         [] -> error ("missing task_id in:\n" <> Text.unpack output)
+
+withPathPrefix :: FilePath -> IO a -> IO a
+withPathPrefix prefix action = do
+    previous <- lookupEnv "PATH"
+    bracket_
+        (setEnv "PATH" (prefix <> maybe "" (":" <>) previous))
+        (maybe (unsetEnv "PATH") (setEnv "PATH") previous)
+        action
+
+shellQuote :: FilePath -> String
+shellQuote path = "'" <> concatMap escape path <> "'"
+  where
+    escape '\'' = "'\\''"
+    escape c = [c]
 
 withTempSession :: ((GrokSession, GhciSession) -> IO a) -> IO a
 withTempSession action = do


### PR DESCRIPTION
## Summary
- copy the persistent shell environment into a private 0600 file for each background task
- keep the shell lock only through snapshot creation and process start, so later foreground commands cannot change what the task observes
- tie the snapshot file to the task's existing ResourceScope cleanup
- copy bytes verbatim rather than decoding the Bash `export -p` dump

This is intentionally independent from the remaining Grok lifecycle fix and adds no session state machine.

## Tests
- deterministic delayed-Bash regression proving a background task sees the environment from launch time, not a later foreground update
- `nix develop -c env -u GHCRTS cabal test agent-core:agent-core-test --test-options='--match=Agent.Tools.Grok' --test-show-details=direct`
- `nix develop -c env -u GHCRTS cabal test all --test-show-details=failures`
