### PR TITLE
Preflight provider availability while composing

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -70,6 +70,7 @@ library
                     , Agent.CLI.Prompt
                     , Agent.CLI.Request
                     , Agent.CLI.ProviderFallback
+                    , Agent.CLI.ProviderAvailability
                     , Agent.CLI.ProviderTransition
                     , Agent.CLI.Render
                     , Agent.CLI.ReplMode
@@ -173,6 +174,7 @@ test-suite agent-cli-test
                     , Agent.CLI.ProgressSpec
                     , Agent.CLI.PromptSpec
                     , Agent.CLI.ProviderFallbackSpec
+                    , Agent.CLI.ProviderAvailabilitySpec
                     , Agent.CLI.ProviderTransitionSpec
                     , Agent.CLI.RequestSpec
                     , Agent.CLI.RenderSpec
@@ -198,6 +200,7 @@ test-suite agent-cli-test
                     , agent-core
                     , agent-tui
                     , agent-openai
+                    , agent-openrouter
                     , agent-responses
                     , agent-xai
                     , aeson

--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -19,7 +19,6 @@ import Agent.CLI.Artifact (fencedCodeBlock, lastDiffBlock)
 import Agent.CLI.Auth
     ( LoadedAuth(..)
     , loadAuth
-    , probeLoadedAuth
     )
 import Agent.CLI.AgentViewport
     ( AgentEntry(..)
@@ -146,7 +145,9 @@ import Agent.CLI.ProviderFallback
     ( allowsAutomaticBillingFallback
     , automaticCooldownRetryDelay
     , fallbackCandidates
+    , isProviderUnavailable
     )
+import Agent.CLI.ProviderAvailability (probeLoadedAvailability)
 import Agent.CLI.ProviderTransition
     ( PendingTurn(..)
     , ProviderTransition(..)
@@ -228,6 +229,7 @@ import Agent.CLI.TUI.App
     , newFullscreenRuntime
     , queuedFullscreenInputDisplays
     , readFullscreenLine
+    , readFullscreenLineOr
     , requestFullscreenPermission
     , requestFullscreenChoice
     , requestFullscreenChoiceWithBody
@@ -306,7 +308,7 @@ import Agent.OpenAI.WebSocketClient
     )
 import Agent.Provider
     ( AccountFailure(..)
-    , BillingMode
+    , BillingMode(..)
     , Credential(..)
     , FailedCredential(..)
     , Provider(..)
@@ -358,6 +360,8 @@ import Agent.OsPath (fromText, toText, unsafeToFilePath)
 import Agent.XAI.LoopBackend (xaiBackend)
 import qualified Agent.XAI.Options as XAI
 import Control.Concurrent.MVar (MVar, newMVar, withMVar)
+import Control.Concurrent.Async (waitSTM, withAsync)
+import Control.Concurrent.STM (STM, retry)
 import Control.Exception (AsyncException(UserInterrupt))
 import Control.Exception.Safe
     ( Exception
@@ -1242,7 +1246,32 @@ runAgentInitialized options transition home root resumed cwd startup = do
         markStartupStage startup "Connecting to provider…"
         withCtrlCHandler interrupt $
             withInterruptResume progName persist RunQuit do
-                case provider of
+                let shouldProbeAtStartup =
+                        isJust fullscreen
+                            && isNothing transition
+                            && isNothing resumed
+                            && isNothing options.optProvider
+                            && isNothing options.optModel
+                            && isNothing prompt
+                    withStartupAvailability action
+                        | shouldProbeAtStartup =
+                            withAsync
+                                (probeLoadedAvailability
+                                    loaded
+                                        { loadedTokenProvider =
+                                            tokenProvider
+                                        })
+                                \availability -> do
+                                    let startupUnavailable =
+                                            waitSTM availability >>= \case
+                                                Left err
+                                                    | isProviderUnavailable err ->
+                                                        pure err
+                                                _ -> retry
+                                    action (Just startupUnavailable)
+                        | otherwise = action Nothing
+                withStartupAvailability \startupUnavailable ->
+                    case provider of
                     OpenAIProvider ->
                         try @_ @CodexAuthFailed
                             (withCodexWsWithProvider tokenProvider \conn credential -> do
@@ -1293,7 +1322,7 @@ runAgentInitialized options transition home root resumed cwd startup = do
                                 activeBackend <-
                                     prepareTransitionBackend
                                         projectRoot transition persist noticingBackend
-                                runSession options provider policy tools toolEnv planMode startup prompt pendingTurn transitionDraft unavailableProviders paramsRef transcriptRef initialTurns
+                                runSession options provider policy tools toolEnv planMode startup prompt pendingTurn transitionDraft unavailableProviders startupUnavailable paramsRef transcriptRef initialTurns
                                     previousRef persist projectRoot home cwd (Just tokenProvider) loaded.loadedOpenAiPool startupContext skillsRef skillInvocationsRef escPaused interrupt
                                     multiCtx rootTurnRef subagentSessions pendingNotices subagentStoreRoot usageRef activeAccountRef claimCurrentSession compactRunner activeBackend btwBackend)
                             >>= \case
@@ -1302,11 +1331,25 @@ runAgentInitialized options transition home root resumed cwd startup = do
                                         Just active
                                             | active.transitionCause == AutomaticFallback ->
                                                 pure (RunProviderStartFailed err)
+                                        _
+                                            | shouldProbeAtStartup
+                                            , isProviderUnavailable err ->
+                                                chooseStartupProviderTransition
+                                                    fullscreen
+                                                    (tokenProviderBillingMode
+                                                        tokenProvider)
+                                                    provider
+                                                    unavailableProviders
+                                                    Nothing
+                                                    err >>= \case
+                                                        Just next ->
+                                                            pure
+                                                                (RunSwitchProvider
+                                                                    next)
+                                                        Nothing ->
+                                                            startupFailure err
                                         _ -> do
-                                            now <- getCurrentTime
-                                            startupDie startup
-                                                (Text.unpack
-                                                    (formatApiErrorAt now err))
+                                            startupFailure err
                                 Right result -> pure result
                     XAIProvider -> do
                         xaiOptions <- XAI.clientOptionsFromEnv
@@ -1341,7 +1384,7 @@ runAgentInitialized options transition home root resumed cwd startup = do
                         activeBackend <-
                             prepareTransitionBackend
                                 projectRoot transition persist backend
-                        runSession options provider policy tools toolEnv planMode startup prompt pendingTurn transitionDraft unavailableProviders paramsRef transcriptRef initialTurns
+                        runSession options provider policy tools toolEnv planMode startup prompt pendingTurn transitionDraft unavailableProviders startupUnavailable paramsRef transcriptRef initialTurns
                             previousRef persist projectRoot home cwd (Just tokenProvider) loaded.loadedOpenAiPool startupContext skillsRef skillInvocationsRef escPaused interrupt
                             multiCtx rootTurnRef subagentSessions pendingNotices subagentStoreRoot usageRef activeAccountRef claimCurrentSession compactRunner activeBackend btwBackend
                     OpenRouterProvider -> do
@@ -1377,9 +1420,14 @@ runAgentInitialized options transition home root resumed cwd startup = do
                         activeBackend <-
                             prepareTransitionBackend
                                 projectRoot transition persist backend
-                        runSession options provider policy tools toolEnv planMode startup prompt pendingTurn transitionDraft unavailableProviders paramsRef transcriptRef initialTurns
+                        runSession options provider policy tools toolEnv planMode startup prompt pendingTurn transitionDraft unavailableProviders startupUnavailable paramsRef transcriptRef initialTurns
                             previousRef persist projectRoot home cwd (Just tokenProvider) loaded.loadedOpenAiPool startupContext skillsRef skillInvocationsRef escPaused interrupt
                             multiCtx rootTurnRef subagentSessions pendingNotices subagentStoreRoot usageRef activeAccountRef claimCurrentSession compactRunner activeBackend btwBackend
+          where
+            startupFailure err = do
+                now <- getCurrentTime
+                startupDie startup
+                    (Text.unpack (formatApiErrorAt now err))
 
 trackCredentialAccount
     :: IORef Text
@@ -1507,6 +1555,7 @@ runSession
     -> Maybe PendingTurn
     -> Text
     -> [Provider]
+    -> Maybe (STM ApiError)
     -> IORef ResponseCreateParams
     -> IORef [ResponseItem]
     -> [SessionTurn]
@@ -1534,7 +1583,7 @@ runSession
     -> Backend
     -> BtwBackendFactory
     -> IO RunResult
-runSession options provider policy tools toolEnv planMode startup prompt pendingTurn initialDraft unavailableProviders paramsRef transcriptRef initialTurns previous persist projectRoot home cwd tokenProvider openAiPool startupContext skillsRef skillInvocationsRef escPaused interrupt multiCtx rootTurnRef subagentSessions pendingNotices storeRoot usageRef accountRef onPersisted compactRunner backend btwBackend = do
+runSession options provider policy tools toolEnv planMode startup prompt pendingTurn initialDraft unavailableProviders startupUnavailable paramsRef transcriptRef initialTurns previous persist projectRoot home cwd tokenProvider openAiPool startupContext skillsRef skillInvocationsRef escPaused interrupt multiCtx rootTurnRef subagentSessions pendingNotices storeRoot usageRef accountRef onPersisted compactRunner backend btwBackend = do
   initialPrevious <- readIORef previous
   ioLock <- newMVar ()
   let fullscreen = startup.startupFullscreen
@@ -1577,6 +1626,7 @@ runSession options provider policy tools toolEnv planMode startup prompt pending
     lastAssistantRef <- newIORef Nothing
     modelRef <- newIORef =<< (currentModel <$> readIORef paramsRef)
     unavailableProvidersRef <- newIORef unavailableProviders
+    startupUnavailableRef <- newIORef startupUnavailable
     restartEffortRef <- newIORef Nothing
     titleTurnCount <- newIORef =<< sessionTitleTurnCountFromSlot persist
     selectedAgent <- newIORef AgentRoot
@@ -1815,6 +1865,7 @@ runSession options provider policy tools toolEnv planMode startup prompt pending
             , sessionRender = render
             , sessionProvider = provider
             , sessionUnavailableProviders = unavailableProvidersRef
+            , sessionStartupUnavailable = startupUnavailableRef
             , sessionPrevious = previous
             , sessionPrinted = printed
             , sessionParams = paramsRef
@@ -2106,6 +2157,7 @@ replWithDraft env@SessionEnv
     , sessionCompact = compactRunner
     , sessionRender = render
     , sessionProvider = provider
+    , sessionStartupUnavailable = startupUnavailableRef
     , sessionPrevious = previous
     , sessionPrinted = printed
     , sessionParams = paramsRef
@@ -2149,11 +2201,11 @@ replWithDraft env@SessionEnv
     let idleMode = replModeFromState planState policy
     usage <- readIORef usageRef
     account <- readIORef accountRef
-    mline <- case fullscreen of
+    mlineResult <- case fullscreen of
         Just runtime -> do
             setFullscreenImagePreviews runtime pendingAttachments
-            readFullscreenLine runtime skillCommands
-                PromptState
+            let promptState =
+                    PromptState
                     { promptModel = currentModel params
                     , promptEffort = currentEffort params
                     , promptMode = replModeLabel idleMode
@@ -2161,8 +2213,15 @@ replWithDraft env@SessionEnv
                     , promptUsage = usage
                     , promptAttachments = length pendingAttachments
                     }
-                draft
-        Nothing -> withMVar render.renderLock \_ -> do
+            readIORef startupUnavailableRef >>= \case
+                Nothing ->
+                    Right
+                        <$> readFullscreenLine
+                            runtime skillCommands promptState draft
+                Just unavailable ->
+                    readFullscreenLineOr
+                        runtime skillCommands promptState draft unavailable
+        Nothing -> Right <$> withMVar render.renderLock \_ -> do
             -- The inline editor redraws its ANSI frame with several writes.
             -- Keep the renderer out for the complete prompt lifetime so a
             -- late tool event cannot be spliced into the composer row.
@@ -2214,7 +2273,31 @@ replWithDraft env@SessionEnv
             Text.putStr (endBackground stdoutColor)
             hFlush stdout
             pure result
-    case mline of
+    case mlineResult of
+        Left apiError -> do
+            -- The startup check is one-shot. If no fallback account is usable,
+            -- leave request-time error handling in charge of later submits.
+            writeIORef startupUnavailableRef Nothing
+            requestStartupProviderFallback env apiError >>= \case
+                Just providerTransition ->
+                    pure (RunSwitchProvider providerTransition)
+                Nothing -> do
+                    reportProviderUnavailable fullscreen apiError
+                    replWithDraft env ""
+        Right mline -> do
+            -- Any user action wins the startup race. In particular, a prompt
+            -- already submitted while the preflight was running proceeds on
+            -- the selected provider and leaves request-time fallback in charge.
+            writeIORef startupUnavailableRef Nothing
+            handleReplLine
+                skillCommands
+                skillInvocations
+                stdoutColor
+                planState
+                policy
+                mline
+  where
+    handleReplLine skillCommands skillInvocations stdoutColor planState policy = \case
         ReplEof -> do
             putStrLn ""
             pure RunQuit
@@ -2281,7 +2364,6 @@ replWithDraft env@SessionEnv
         ReplText line ->
             submitLine skillCommands skillInvocations
                 continue stdoutColor False line
-  where
     submitLine skillCommands skillInvocations continue color pasted line =
         let stripped = Text.strip line
         in if Text.null stripped
@@ -3347,6 +3429,23 @@ requestAutomaticProviderFallback env apiError pending = do
                 pending
                 apiError
 
+requestStartupProviderFallback
+    :: SessionEnv
+    -> ApiError
+    -> IO (Maybe ProviderTransition)
+requestStartupProviderFallback env apiError = do
+    unavailable <- readIORef env.sessionUnavailableProviders
+    case env.sessionTokenProvider of
+        Nothing -> pure Nothing
+        Just tokenProvider ->
+            chooseStartupProviderTransition
+                env.sessionFullscreen
+                (tokenProviderBillingMode tokenProvider)
+                env.sessionProvider
+                unavailable
+                Nothing
+                apiError
+
 continueAutomaticFallback
     :: Maybe FullscreenRuntime
     -> ProviderTransition
@@ -3426,6 +3525,55 @@ chooseAutomaticProviderTransition
                         , transitionAutomaticBilling = Just sourceBilling
                         }
 
+chooseStartupProviderTransition
+    :: Maybe FullscreenRuntime
+    -> BillingMode
+    -> Provider
+    -> [Provider]
+    -> Maybe Text
+    -> ApiError
+    -> IO (Maybe ProviderTransition)
+chooseStartupProviderTransition
+    fullscreen sourceBilling current unavailable0 sessionId apiError =
+    tryCandidates unavailable candidates
+  where
+    unavailable = markUnavailable current unavailable0
+    candidates = fallbackCandidates unavailable0 current apiError
+
+    tryCandidates unavailable = \case
+        [] -> pure Nothing
+        choice : rest ->
+            validateAutomaticProviderTarget sourceBilling choice >>= \case
+                Left err -> do
+                    let message =
+                            "skipping "
+                            <> providerSlug choice.modelProvider
+                            <> ": "
+                            <> err
+                    forM_ fullscreen \runtime ->
+                        emitUiEvent runtime (UiSystemMessage message)
+                    tryCandidates
+                        (markUnavailable choice.modelProvider unavailable)
+                        rest
+                Right () -> do
+                    let message =
+                            providerSlug current
+                            <> " account unavailable; switched to "
+                            <> providerSlug choice.modelProvider
+                            <> "/"
+                            <> choice.modelId
+                    forM_ fullscreen \runtime ->
+                        emitUiEvent runtime (UiSystemMessage message)
+                    pure $ Just ProviderTransition
+                        { transitionTarget = choice
+                        , transitionSessionId = sessionId
+                        , transitionPendingTurn = Nothing
+                        , transitionDraft = ""
+                        , transitionUnavailableProviders = unavailable
+                        , transitionCause = AutomaticFallback
+                        , transitionAutomaticBilling = Just sourceBilling
+                        }
+
 prepareProviderTransition
     :: TransitionCause
     -> [Provider]
@@ -3479,7 +3627,7 @@ loadValidatedProviderTarget choice =
                 <> ": "
                 <> err
         Right loaded ->
-            probeLoadedAuth loaded >>= \case
+            probeLoadedAvailability loaded >>= \case
                 Left err -> do
                     now <- getCurrentTime
                     pure $ Left $
@@ -3545,7 +3693,8 @@ prepareTransitionBackend
     -> IO Backend
 prepareTransitionBackend _ Nothing _ backend = pure backend
 prepareTransitionBackend projectRoot (Just transition) persist backend
-    | transition.transitionCause == ManualTransition = do
+    | transition.transitionCause == ManualTransition
+        || isNothing transition.transitionPendingTurn = do
         commitProviderTransition projectRoot (Just transition) persist
         pure backend
     | otherwise = do

--- a/packages/agent-cli/src/Agent/CLI/ProviderAvailability.hs
+++ b/packages/agent-cli/src/Agent/CLI/ProviderAvailability.hs
@@ -1,0 +1,155 @@
+-- | Non-authoritative provider account availability checks.
+--
+-- Usage endpoints are useful for avoiding a predictably failed first turn,
+-- but they are not the request path's source of truth. Network or decoding
+-- failures therefore leave the credential usable; only a successful response
+-- that definitively reports exhaustion rejects it.
+module Agent.CLI.ProviderAvailability
+    ( openAiUsageFailure
+    , openRouterUsageFailure
+    , probeLoadedAvailability
+    , probeLoadedAvailabilityWith
+    , xaiUsageFailure
+    ) where
+
+import Agent.CLI.Auth (LoadedAuth(..))
+import Agent.Error (ApiError(..), ErrorType(..))
+import qualified Agent.OpenAI.Usage as OpenAI
+import qualified Agent.OpenRouter.Usage as OpenRouter
+import Agent.Provider
+    ( BillingMode(..)
+    , Credential(..)
+    , Provider(..)
+    , runWithTokenProvider
+    , seedTokenProvider
+    , tokenProviderBillingMode
+    )
+import qualified Agent.XAI.Usage as XAI
+import Data.Maybe (catMaybes)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Data.Time.Clock (UTCTime, diffUTCTime, getCurrentTime)
+
+-- | Check the current account through the provider's available usage API and
+-- preserve the successful credential checkout for later validation callers.
+probeLoadedAvailability :: LoadedAuth -> IO (Either ApiError LoadedAuth)
+probeLoadedAvailability loaded =
+    probeLoadedAvailabilityWith checkCredential loaded
+  where
+    billing = tokenProviderBillingMode loaded.loadedTokenProvider
+    checkCredential credential = case credential.provider of
+        XAIProvider
+            | billing == SubscriptionBilled ->
+                XAI.fetchGrokUsage credential.accessToken >>= \case
+                    Left _ -> pure Nothing
+                    Right snapshot -> do
+                        now <- getCurrentTime
+                        pure (xaiUsageFailure now snapshot)
+        OpenAIProvider
+            | billing == SubscriptionBilled
+            , not (nullAccountId credential.accountId) ->
+                OpenAI.fetchUsage
+                    credential.accessToken credential.accountId >>= \case
+                        Left err
+                            | isDefinitiveUsageFailure err ->
+                                pure (Just err)
+                            | otherwise -> pure Nothing
+                        Right snapshot -> do
+                            now <- getCurrentTime
+                            pure (openAiUsageFailure now snapshot)
+        OpenRouterProvider ->
+            OpenRouter.fetchOpenRouterUsage credential.accessToken >>= \case
+                Left _ -> pure Nothing
+                Right snapshot -> pure (openRouterUsageFailure snapshot)
+        _ -> pure Nothing
+
+-- | Injectable core used by tests. Returning 'Nothing' means the credential
+-- is usable or the remote check was inconclusive. A returned provider error is
+-- fed through the normal account-failover machinery before the final result.
+probeLoadedAvailabilityWith
+    :: (Credential -> IO (Maybe ApiError))
+    -> LoadedAuth
+    -> IO (Either ApiError LoadedAuth)
+probeLoadedAvailabilityWith check loaded = do
+    result <-
+        runWithTokenProvider loaded.loadedTokenProvider \credential ->
+            check credential >>= \case
+                Nothing -> pure (Right credential)
+                Just err -> pure (Left err)
+    case result of
+        Left err -> pure (Left err)
+        Right credential -> do
+            provider <-
+                seedTokenProvider loaded.loadedTokenProvider credential
+            pure $ Right loaded { loadedTokenProvider = provider }
+
+xaiUsageFailure
+    :: UTCTime
+    -> XAI.GrokUsageSnapshot
+    -> Maybe ApiError
+xaiUsageFailure now snapshot
+    | snapshot.usedPercent < 100 = Nothing
+    | otherwise =
+        Just $
+            ProviderError
+                UsageLimitReached
+                "Grok usage is exhausted for the current billing period."
+                (Just (retrySecondsUntil now snapshot.resetsAt))
+
+openAiUsageFailure
+    :: UTCTime
+    -> OpenAI.UsageSnapshot
+    -> Maybe ApiError
+openAiUsageFailure _ snapshot =
+    case snapshot.rateLimit of
+        Just limit
+            | not limit.allowed || limit.limitReached ->
+                Just $
+                    ProviderError
+                        UsageLimitReached
+                        "Codex usage is exhausted for the current account."
+                        (minimumPositive
+                            (map (.resetAfterSeconds)
+                                (catMaybes
+                                    [ limit.primaryWindow
+                                    , limit.secondaryWindow
+                                    ])))
+        _ -> Nothing
+
+openRouterUsageFailure
+    :: OpenRouter.OpenRouterUsage
+    -> Maybe ApiError
+openRouterUsageFailure snapshot
+    | maybe False (<= 0) snapshot.keyLimitRemaining =
+        exhausted
+    | otherwise = case (snapshot.keyLimit, snapshot.keyUsage) of
+        (Just limit, Just used)
+            | used >= limit -> exhausted
+        _ -> Nothing
+  where
+    exhausted =
+        Just $
+            ProviderError
+                BillingError
+                "OpenRouter key usage limit is exhausted."
+                Nothing
+
+retrySecondsUntil :: UTCTime -> UTCTime -> Int
+retrySecondsUntil now resetAt =
+    max 1 (ceiling (diffUTCTime resetAt now))
+
+minimumPositive :: [Int] -> Maybe Int
+minimumPositive values =
+    case filter (> 0) values of
+        [] -> Nothing
+        positive -> Just (minimum positive)
+
+nullAccountId :: Text -> Bool
+nullAccountId = Text.null . Text.strip
+
+isDefinitiveUsageFailure :: ApiError -> Bool
+isDefinitiveUsageFailure = \case
+    ProviderError AuthenticationError _ _ -> True
+    ProviderError PermissionError _ _ -> True
+    CredentialError{} -> True
+    _ -> False

--- a/packages/agent-cli/src/Agent/CLI/ProviderFallback.hs
+++ b/packages/agent-cli/src/Agent/CLI/ProviderFallback.hs
@@ -89,6 +89,10 @@ isUsageExhausted :: ApiError -> Bool
 isUsageExhausted = \case
     CredentialsExhausted{} -> True
     ProviderError UsageLimitReached _ _ -> True
+    ProviderError UsageBalanceExhausted _ _ -> True
+    ProviderError QuotaExceeded _ _ -> True
+    ProviderError UsageNotIncluded _ _ -> True
+    ProviderError BillingError _ _ -> True
     _ -> False
 
 -- | Failures for which rebuilding the same provider cannot make progress.

--- a/packages/agent-cli/src/Agent/CLI/SessionEnv.hs
+++ b/packages/agent-cli/src/Agent/CLI/SessionEnv.hs
@@ -13,6 +13,7 @@ import Agent.CLI.Session (Persistence, SessionHandle)
 import Agent.CLI.SessionTitle (SessionTitleManager)
 import Agent.CLI.Terminal (TerminalCapabilities)
 import Agent.CLI.TUI.App (FullscreenRuntime)
+import Agent.Error (ApiError)
 import Agent.Loop (ImageAttachment, LoopConfig, TokenUsage)
 import qualified Agent.OpenAI.Auth as OpenAI
 import Agent.Responses.Types (ResponseCreateParams, ResponseItem)
@@ -23,6 +24,7 @@ import Agent.Subagents (RootTurnId)
 import Agent.Tools.PlanMode (PlanModeEnv)
 import Data.IORef (IORef)
 import Data.Text (Text)
+import Control.Concurrent.STM (STM)
 
 data SessionEnv = SessionEnv
     { sessionLoop :: !LoopConfig
@@ -31,6 +33,7 @@ data SessionEnv = SessionEnv
     , sessionRender :: !RenderConfig
     , sessionProvider :: !Provider
     , sessionUnavailableProviders :: !(IORef [Provider])
+    , sessionStartupUnavailable :: !(IORef (Maybe (STM ApiError)))
     , sessionPrevious :: !(IORef (Maybe Text))
     , sessionPrinted :: !(IORef Bool)
     , sessionParams :: !(IORef ResponseCreateParams)

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -20,6 +20,7 @@ module Agent.CLI.TUI.App
     , loadSyntaxHighlighterForRuntime
     , queuedFullscreenInputDisplays
     , readFullscreenLine
+    , readFullscreenLineOr
     , repositoryHeaderText
     , requestFullscreenPermission
     , requestFullscreenChoice
@@ -365,6 +366,23 @@ readFullscreenLine
     -> Text
     -> IO ReplLine
 readFullscreenLine runtime skills prompt initial = do
+    result <- readFullscreenLineOr runtime skills prompt initial retry
+    case result of
+        Left impossible -> pure impossible
+        Right line -> pure line
+
+-- | Wait for either user input or a session-level wakeup. The input branch is
+-- deliberately left-biased: once Enter has queued a prompt, provider startup
+-- fallback must let that prompt run instead of consuming and losing it during
+-- a backend restart.
+readFullscreenLineOr
+    :: FullscreenRuntime
+    -> [SkillCommand]
+    -> PromptState
+    -> Text
+    -> STM wake
+    -> IO (Either wake ReplLine)
+readFullscreenLineOr runtime skills prompt initial wake = do
     enqueueAppEvent runtime (AppSetSkillCommands skills)
     emitUiEvent runtime (UiSetPrompt prompt)
     -- Keep anything the user started typing while the previous turn was
@@ -373,13 +391,17 @@ readFullscreenLine runtime skills prompt initial = do
     when (not (Text.null initial)) $
         emitUiEvent runtime (UiSetDraft initial (Text.length initial))
     emitUiEvent runtime (UiSetAwaitingInput True)
-    input <- atomically (Composer.takeFullscreenInput runtime.runtimeInput)
-    when input.fullscreenInputQueued $
-        emitUiEvent runtime $
-            case input.fullscreenInputDisplay of
-                Just _ -> UiQueuedInputStarted
-                Nothing -> UiSetAwaitingInput False
-    pure input.fullscreenInputLine
+    result <- atomically $
+        Composer.takeFullscreenInputOr runtime.runtimeInput wake
+    case result of
+        Left signal -> pure (Left signal)
+        Right input -> do
+            when input.fullscreenInputQueued $
+                emitUiEvent runtime $
+                    case input.fullscreenInputDisplay of
+                        Just _ -> UiQueuedInputStarted
+                        Nothing -> UiSetAwaitingInput False
+            pure (Right input.fullscreenInputLine)
 
 -- | Fullscreen Vty configuration, including enhanced-keyboard encodings that
 -- are not present in the default terminfo input table. Without these entries,

--- a/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
@@ -20,6 +20,7 @@ module Agent.CLI.TUI.Composer
     , queuedFullscreenInputDisplays
     , readFullscreenInputs
     , takeFullscreenInput
+    , takeFullscreenInputOr
     , wrapDraft
     ) where
 
@@ -55,6 +56,7 @@ import Control.Concurrent.STM
     , newTVarIO
     , readTVar
     , retry
+    , orElse
     , writeTVar
     )
 import Control.Monad (void, when)
@@ -150,6 +152,16 @@ takeFullscreenInput (FullscreenInputBuffer inputs) = do
         input :< rest -> do
             writeTVar inputs rest
             pure input
+
+-- | Prefer a prompt that has already been queued over a simultaneous
+-- session-level wakeup, so provider restarts cannot consume and lose Enter.
+takeFullscreenInputOr
+    :: FullscreenInputBuffer
+    -> STM wake
+    -> STM (Either wake FullscreenInput)
+takeFullscreenInputOr inputBuffer wake =
+    (Right <$> takeFullscreenInput inputBuffer)
+        `orElse` (Left <$> wake)
 
 drawSlashMenu :: AppState -> Widget Name
 drawSlashMenu state = case currentSlashMenu state of

--- a/packages/agent-cli/test/Agent/CLI/ProviderAvailabilitySpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ProviderAvailabilitySpec.hs
@@ -1,0 +1,155 @@
+module Agent.CLI.ProviderAvailabilitySpec (spec) where
+
+import Agent.CLI.Auth (LoadedAuth(..), staticCredentialProvider)
+import Agent.CLI.ProviderAvailability
+    ( openAiUsageFailure
+    , openRouterUsageFailure
+    , probeLoadedAvailabilityWith
+    , xaiUsageFailure
+    )
+import Agent.Error (ApiError(..), ErrorType(..))
+import qualified Agent.OpenAI.Usage as OpenAI
+import qualified Agent.OpenRouter.Usage as OpenRouter
+import Agent.Provider
+    ( BillingMode(..)
+    , Credential(..)
+    , Provider(..)
+    , getNextToken
+    )
+import qualified Agent.XAI.Usage as XAI
+import Data.Time.Calendar (fromGregorian)
+import Data.Time.Clock (UTCTime(..), addUTCTime)
+import Test.Hspec
+
+spec :: Spec
+spec = do
+    describe "provider usage availability" do
+        let now = UTCTime (fromGregorian 2026 8 22) 0
+
+        it "classifies exhausted Grok usage with its reset delay" do
+            xaiUsageFailure now XAI.GrokUsageSnapshot
+                { usedPercent = 100
+                , windowSeconds = 3600
+                , resetsAt = addUTCTime 90 now
+                }
+                `shouldBe`
+                    Just
+                        (ProviderError
+                            UsageLimitReached
+                            "Grok usage is exhausted for the current billing period."
+                            (Just 90))
+
+        it "leaves Grok credentials usable below the limit" do
+            xaiUsageFailure now XAI.GrokUsageSnapshot
+                { usedPercent = 99
+                , windowSeconds = 3600
+                , resetsAt = addUTCTime 90 now
+                }
+                `shouldBe` Nothing
+
+        it "classifies a rejected Codex usage window" do
+            openAiUsageFailure now OpenAI.UsageSnapshot
+                { planType = "plus"
+                , rateLimit = Just OpenAI.UsageLimit
+                    { allowed = False
+                    , limitReached = True
+                    , primaryWindow = Just OpenAI.UsageWindow
+                        { usedPercent = 100
+                        , limitWindowSeconds = 18000
+                        , resetAfterSeconds = 75
+                        , resetAt = 0
+                        }
+                    , secondaryWindow = Nothing
+                    }
+                , additionalRateLimits = []
+                }
+                `shouldBe`
+                    Just
+                        (ProviderError
+                            UsageLimitReached
+                            "Codex usage is exhausted for the current account."
+                            (Just 75))
+
+        it "classifies an exhausted OpenRouter key limit" do
+            openRouterUsageFailure OpenRouter.OpenRouterUsage
+                { keyLabel = Just "coding"
+                , keyUsage = Just 10
+                , keyLimit = Just 10
+                , keyLimitRemaining = Just 0
+                , isFreeTier = Just False
+                , totalCredits = Just 50
+                , totalUsage = Just 10
+                }
+                `shouldBe`
+                    Just
+                        (ProviderError
+                            BillingError
+                            "OpenRouter key usage limit is exhausted."
+                            Nothing)
+
+        it "does not treat a zero credit balance as total OpenRouter unavailability" do
+            openRouterUsageFailure OpenRouter.OpenRouterUsage
+                { keyLabel = Nothing
+                , keyUsage = Nothing
+                , keyLimit = Nothing
+                , keyLimitRemaining = Nothing
+                , isFreeTier = Just True
+                , totalCredits = Just 0
+                , totalUsage = Just 0
+                }
+                `shouldBe` Nothing
+
+    describe "probeLoadedAvailabilityWith" do
+        it "preserves the checked credential for the backend" do
+            let credential = Credential
+                    { accessToken = "token"
+                    , accountId = "account"
+                    , leaseId = Nothing
+                    , provider = XAIProvider
+                    }
+                loaded = LoadedAuth
+                    { loadedProvider = XAIProvider
+                    , loadedTokenProvider =
+                        staticCredentialProvider SubscriptionBilled credential
+                    , loadedAccountLabel = const (pure "account")
+                    , loadedOpenAiPool = Nothing
+                    }
+            probeLoadedAvailabilityWith (const (pure Nothing)) loaded >>= \case
+                Left err ->
+                    expectationFailure
+                        ("availability probe unexpectedly failed: " <> show err)
+                Right usable ->
+                    getNextToken usable.loadedTokenProvider Nothing
+                        `shouldReturn` Right credential
+
+        it "feeds definitive exhaustion through account failover" do
+            let credential = Credential
+                    { accessToken = "token"
+                    , accountId = "account"
+                    , leaseId = Nothing
+                    , provider = XAIProvider
+                    }
+                loaded = LoadedAuth
+                    { loadedProvider = XAIProvider
+                    , loadedTokenProvider =
+                        staticCredentialProvider SubscriptionBilled credential
+                    , loadedAccountLabel = const (pure "account")
+                    , loadedOpenAiPool = Nothing
+                    }
+            result <- probeLoadedAvailabilityWith
+                (const
+                    (pure
+                        (Just
+                            (ProviderError
+                                UsageLimitReached
+                                "exhausted"
+                                (Just 60)))))
+                loaded
+            case result of
+                Left CredentialsExhausted{} -> pure ()
+                Left err ->
+                    expectationFailure
+                        ("expected credential exhaustion, got " <> show err)
+                Right _ ->
+                    expectationFailure
+                        "expected credential exhaustion, got usable auth"

--- a/packages/agent-cli/test/Agent/CLI/ProviderFallbackSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ProviderFallbackSpec.hs
@@ -74,6 +74,16 @@ spec = do
                 (ProviderError UsageLimitReached "quota exhausted" (Just 3600))
                 `shouldSatisfy` (not . null)
 
+        it "accepts other definitive account and billing exhaustion errors" do
+            map
+                (not . null . fallbackCandidates [] XAIProvider)
+                [ ProviderError UsageBalanceExhausted "balance exhausted" Nothing
+                , ProviderError QuotaExceeded "quota exhausted" Nothing
+                , ProviderError UsageNotIncluded "not included" Nothing
+                , ProviderError BillingError "billing unavailable" Nothing
+                ]
+                `shouldBe` replicate 4 True
+
         it "does not switch for transient capacity failures" do
             fallbackCandidates [] XAIProvider
                 (ProviderError OverloadedError "busy" (Just 30))

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -39,6 +39,23 @@ import Test.Hspec
 
 spec :: Spec
 spec = do
+    describe "prompt model refresh" do
+        it "preserves the live draft and cursor across a provider restart" do
+            let before =
+                    reduceUi
+                        (UiSetDraft "half typed prompt" 7)
+                        initialUiState
+                after =
+                    reduceUi
+                        (UiSetPrompt
+                            before.uiPrompt
+                                { promptModel = "gpt-5.6-sol"
+                                })
+                        before
+            after.uiDraft `shouldBe` "half typed prompt"
+            after.uiCursor `shouldBe` 7
+            after.uiPrompt.promptModel `shouldBe` "gpt-5.6-sol"
+
     describe "fullscreenVtyConfig" do
         it "maps enhanced-keyboard Shift+Enter sequences before Vty decodes them" do
             V.configInputMap fullscreenVtyConfig

--- a/packages/agent-cli/test/Agent/CLI/TUIComposerSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIComposerSpec.hs
@@ -7,6 +7,7 @@ import Control.Concurrent.STM (atomically)
 import qualified Data.ByteString as ByteString
 import Data.Foldable (toList)
 import qualified Data.Sequence as Seq
+import Data.Text (Text)
 import Test.Hspec
 
 spec :: Spec
@@ -71,6 +72,17 @@ spec = describe "fullscreen composer" do
                 }
         queuedFullscreenInputDisplays buffer
             `shouldReturn` Seq.singleton "queued"
+
+    it "prefers an already-submitted prompt over a simultaneous wakeup" do
+        buffer <- newFullscreenInputBuffer
+        atomically $
+            appendFullscreenInput buffer (input (ReplText "submitted"))
+        result <- atomically $
+            takeFullscreenInputOr
+                buffer
+                (pure ("provider unavailable" :: Text))
+        fmap (.fullscreenInputLine) result
+            `shouldBe` Right (ReplText "submitted")
   where
     input replLine = FullscreenInput
         { fullscreenInputLine = replLine

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -32,6 +32,7 @@ import qualified Agent.CLI.ProgressSpec as ProgressSpec
 import qualified Agent.CLI.ProjectSpec as ProjectSpec
 import qualified Agent.CLI.PromptSpec as PromptSpec
 import qualified Agent.CLI.ProviderFallbackSpec as ProviderFallbackSpec
+import qualified Agent.CLI.ProviderAvailabilitySpec as ProviderAvailabilitySpec
 import qualified Agent.CLI.ProviderTransitionSpec as ProviderTransitionSpec
 import qualified Agent.CLI.RequestSpec as RequestSpec
 import qualified Agent.CLI.RenderSpec as RenderSpec
@@ -86,6 +87,7 @@ main = hspec do
     ProjectSpec.spec
     PromptSpec.spec
     ProviderFallbackSpec.spec
+    ProviderAvailabilitySpec.spec
     ProviderTransitionSpec.spec
     RequestSpec.spec
     RenderSpec.spec


### PR DESCRIPTION
## Summary

- run a scoped startup availability preflight for automatically selected OpenAI, xAI, and OpenRouter providers
- switch to the best billing-compatible fallback before the first prompt is submitted when the selected account is definitively unavailable
- keep the fullscreen composer draft intact while rebuilding the provider backend and updating the displayed model/account
- treat usage endpoint connectivity or decoding failures as inconclusive, leaving request-time fallback as the source of truth
- recognize additional terminal quota/billing errors as eligible for cross-provider fallback

## Behavior

The preflight only applies to fresh fullscreen sessions using the automatically selected provider/model. Explicit provider/model choices, resumed sessions, one-shot prompts, and minimal mode are not silently overridden.

If user input is already queued, it wins the startup race and proceeds normally; request-time fallback handles any failure. Automatic idle transitions are persisted after the replacement provider has been validated.

## Testing

- `nix develop -c cabal repl agent-cli:lib:agent-cli --repl-options='-fno-code'`
- `nix develop -c cabal test agent-cli-test --test-show-details=direct` — 576 examples, 0 failures
- fullscreen tmux smoke test confirmed the selected model/account updates while a live composer draft remains intact
