### PR TITLE
perf(cli): avoid quadratic streaming buffers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,16 +155,19 @@ CPU time and allocation across the requested sample count.
 Build and locate it with:
 
 ```
-nix develop -c cabal build agent-core:bench:streaming-text-bench
+nix develop -c cabal build --offline agent-core:bench:streaming-text-bench
 bin=$(nix develop -c cabal list-bin agent-core:bench:streaming-text-bench)
 ```
 
 Compare strict repeated append, chunked accumulation, removed-buffer overhead,
-and the fullscreen baseline with:
+the `text-builder` alternative, and the fullscreen baseline with:
 
 ```
 "$bin" old-accumulate       10000 16 7 +RTS -T
 "$bin" new-accumulate       10000 16 7 +RTS -T
+"$bin" old-io-ref           10000 16 7 +RTS -T
+"$bin" new-io-ref           10000 16 7 +RTS -T
+"$bin" text-builder-io-ref   10000 16 7 +RTS -T
 "$bin" no-duplicate-buffer  10000 16 7 +RTS -T
 "$bin" fullscreen-baseline  10000 16 7 +RTS -T
 ```
@@ -172,10 +175,12 @@ and the fullscreen baseline with:
 The positional arguments are workload, chunk count, ASCII bytes per chunk, and
 sample count. Run several chunk counts and sizes; the benchmark used for the
 streaming-buffer change covered 1,000, 2,000, 5,000, and 10,000 16-byte chunks,
-plus fixed-total-size cases with larger chunks. An attempted fullscreen
-chunk-buffer change was benchmarked separately and reverted because flattening
-the complete body for every Markdown render made it slower and allocated more
-than the strict-`Text` baseline.
+plus fixed-total-size cases with larger chunks. Alternative-buffer comparisons
+also covered 20,000, 50,000, and 100,000 chunks. The `*-io-ref` workloads model
+the actual renderer update path; keep those when evaluating alternative buffer
+implementations. An attempted fullscreen chunk-buffer change was benchmarked
+separately and reverted because flattening the complete body for every Markdown
+render made it slower and allocated more than the strict-`Text` baseline.
 
 # haskell
 - Prefer Control.Exception.Safe over Control.Exception

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,6 +118,64 @@ cabal run agent-cli -- +RTS -N8 -M16G -RTS
 Avoid large `-A` defaults: the allocation area is per capability, so
 `-N14 -A64m` consumes roughly 896 MiB before meaningful application data.
 
+# performance
+
+Performance improvements must be supported by a benchmark that proves the
+claimed improvement before opening a PR.
+
+- Benchmark the old and new implementations with equivalent, representative
+  workloads. Keep a baseline workload in the benchmark so future changes can
+  be compared against the behavior being replaced.
+- Use an optimized build rather than interpreted GHCi timings. Run benchmarks
+  inside `nix develop`, force the result so GHC cannot optimize the work away,
+  and enable RTS statistics when measuring allocation.
+- Measure both elapsed/CPU time and allocated bytes when the change is intended
+  to reduce allocation or GC pressure. A speedup that shifts work or allocation
+  to another stage is not sufficient.
+- Run multiple samples and report a robust aggregate such as the median. Test
+  multiple input sizes to distinguish constant/linear behavior from quadratic
+  behavior, and repeat at least one representative case to check measurement
+  stability.
+- Record the benchmark command, GHC/build settings, workload dimensions, and
+  before/after results in the PR. Keep the benchmark in the repository when it
+  is useful for detecting regressions.
+- If benchmarking shows that part of the proposed optimization regresses, do
+  not ship that part. Revert it or redesign it, and document the remaining
+  performance boundary.
+
+## streaming text benchmark
+
+The streaming allocation benchmark is
+`packages/agent-core/benchmark/StreamingText.hs`. It is built with `-O2` and
+uses `GHC.Stats` with `+RTS -T` to measure allocated bytes. It constructs input
+outside the measured interval, forces a checksum of the output to prevent
+dead-code elimination, performs a GC before each sample, and reports the median
+CPU time and allocation across the requested sample count.
+
+Build and locate it with:
+
+```
+nix develop -c cabal build agent-core:bench:streaming-text-bench
+bin=$(nix develop -c cabal list-bin agent-core:bench:streaming-text-bench)
+```
+
+Compare strict repeated append, chunked accumulation, removed-buffer overhead,
+and the fullscreen baseline with:
+
+```
+"$bin" old-accumulate       10000 16 7 +RTS -T
+"$bin" new-accumulate       10000 16 7 +RTS -T
+"$bin" no-duplicate-buffer  10000 16 7 +RTS -T
+"$bin" fullscreen-baseline  10000 16 7 +RTS -T
+```
+
+The positional arguments are workload, chunk count, ASCII bytes per chunk, and
+sample count. Run several chunk counts and sizes; the benchmark used for the
+streaming-buffer change covered 1,000, 2,000, 5,000, and 10,000 16-byte chunks,
+plus fixed-total-size cases with larger chunks. An attempted fullscreen
+chunk-buffer change was benchmarked separately and reverted because flattening
+the complete body for every Markdown render made it slower and allocated more
+than the strict-`Text` baseline.
 
 # haskell
 - Prefer Control.Exception.Safe over Control.Exception

--- a/flake.nix
+++ b/flake.nix
@@ -325,6 +325,10 @@
                         packages.agent-openrouter
                     ];
                     withHoogle = false;
+                    doBenchmark = true;
+                    extraDependencies = packages: {
+                        benchmarkHaskellDepends = [ packages.text-builder ];
+                    };
                     shellHook = ''
                         export AGENT_SYNTAX_DIR=${skylightingSyntaxDirectory}
                     '';

--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -334,6 +334,7 @@ import Agent.Subagents
     )
 import Agent.Tools (CodingTools(..), codingToolsForWithTypes)
 import Agent.Subagents.TaskPath (taskPathRoot, taskPathText)
+import Agent.TextBuffer (emptyTextBuffer)
 import Agent.Tools.MultiAgents
     ( MultiAgentContext(..)
     , SubagentWorktree(..)
@@ -1564,12 +1565,11 @@ runSession options provider policy tools toolEnv planMode startup prompt pending
     printed <- newIORef False
     attachmentsRef <- newIORef []
     previewIdRef <- newIORef (1 :: Int)
-    textBuffer <- newIORef ""
     markdownState <- newIORef emptyMarkdownStreamState
     liveActive <- newIORef False
     thinkingVisible <- newIORef False
     spinnerRef <- newIORef Nothing
-    reasoningBuffer <- newIORef ""
+    reasoningBuffer <- newIORef emptyTextBuffer
     activityRef <- newIORef "Thinking…"
     startedAtRef <- newIORef Nothing
     toolCallsRef <- newIORef Map.empty
@@ -1735,7 +1735,6 @@ runSession options provider policy tools toolEnv planMode startup prompt pending
             , renderReasoningBuffer = reasoningBuffer
             , renderColor = useColor
             , renderPrintedText = printed
-            , renderTextBuffer = textBuffer
             , renderMarkdownState = markdownState
             , renderLiveActive = liveActive
             , renderLock = ioLock

--- a/packages/agent-cli/src/Agent/CLI/Render.hs
+++ b/packages/agent-cli/src/Agent/CLI/Render.hs
@@ -75,6 +75,12 @@ import Agent.ToolDispatch
     , ToolCallResult(..)
     , canonicalToolName
     )
+import Agent.TextBuffer
+    ( TextBuffer
+    , appendTextBuffer
+    , emptyTextBuffer
+    , textBufferToText
+    )
 import Control.Concurrent (ThreadId, forkIO, killThread, threadDelay)
 import Control.Concurrent.MVar (MVar, withMVar)
 import Control.Exception.Safe (tryIO)
@@ -109,10 +115,9 @@ data RenderConfig = RenderConfig
     , renderThinkingVisible :: !(IORef Bool)
     , renderThinkingSpinner :: !(IORef (Maybe ThreadId))
     -- | Accumulated reasoning-summary text for the current model round.
-    , renderReasoningBuffer :: !(IORef Text)
+    , renderReasoningBuffer :: !(IORef TextBuffer)
     , renderColor :: !Bool
     , renderPrintedText :: !(IORef Bool)
-    , renderTextBuffer :: !(IORef Text)
     , renderMarkdownState :: !(IORef MarkdownStreamState)
     -- | True after assistant text has been streamed for the current round.
     , renderLiveActive :: !(IORef Bool)
@@ -149,7 +154,6 @@ renderEventUnlocked config = \case
         commitThinkingUnlocked config
         if config.renderColor
             then do
-                modifyIORef' config.renderTextBuffer (<> delta)
                 streamAssistantDelta config delta
             else do
                 writeIORef config.renderPrintedText True
@@ -166,10 +170,9 @@ renderEventUnlocked config = \case
                 then startThinkingSpinnerUnlocked config
                 else putTextLn config.renderStderr (roleMuted config.renderColor activity)
     TurnStarted -> do
-        writeIORef config.renderTextBuffer ""
         writeIORef config.renderMarkdownState emptyMarkdownStreamState
         writeIORef config.renderLiveActive False
-        writeIORef config.renderReasoningBuffer ""
+        writeIORef config.renderReasoningBuffer emptyTextBuffer
         writeIORef config.renderActivityRef "Thinking…"
         writeIORef config.renderToolCalls Map.empty
         now <- getCurrentTime
@@ -246,12 +249,11 @@ streamAssistantDelta config delta
             hFlush config.renderStdout
 
 -- | End-of-turn: keep live paint when deltas already drew; otherwise paint
--- once from the buffer or completed 'assistantText' (non-streaming backends).
+-- once from the pending fragment or completed 'assistantText'
+-- (non-streaming backends).
 -- Returns whether anything was written.
 finalizeAssistantBuffer :: RenderConfig -> Maybe Text -> IO Bool
 finalizeAssistantBuffer config assistantText = do
-    buffered <- readIORef config.renderTextBuffer
-    writeIORef config.renderTextBuffer ""
     (pending, context) <-
         atomicModifyIORef' config.renderMarkdownState \state ->
             (emptyMarkdownStreamState, (state.pending, state.context))
@@ -269,7 +271,7 @@ finalizeAssistantBuffer config assistantText = do
             pure True
         else do
             let raw
-                    | not (Text.null buffered) = buffered
+                    | not (Text.null pending) = pending
                     | otherwise = fromMaybe "" assistantText
             if Text.null raw
                 then pure False
@@ -399,14 +401,16 @@ appendReasoningUnlocked config delta
     | otherwise =
         -- Keep the one-line spinner while buffering. Repainting even a bounded
         -- multi-line preview can scroll old frames into terminal scrollback.
-        modifyIORef' config.renderReasoningBuffer (<> delta)
+        modifyIORef' config.renderReasoningBuffer
+            (appendTextBuffer delta)
 
 commitThinkingUnlocked :: RenderConfig -> IO ()
 commitThinkingUnlocked config = do
     stopThinkingSpinnerUnlocked config
     emitNativeProgress config False
-    buffered <- readIORef config.renderReasoningBuffer
-    writeIORef config.renderReasoningBuffer ""
+    buffered <- textBufferToText
+        <$> readIORef config.renderReasoningBuffer
+    writeIORef config.renderReasoningBuffer emptyTextBuffer
     if Text.null (Text.strip buffered)
         then pure ()
         else do

--- a/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
@@ -10,6 +10,10 @@ import Agent.ToolDispatch
     , customToolCall
     , functionToolCall
     )
+import Agent.TextBuffer
+    ( emptyTextBuffer
+    , textBufferToText
+    )
 import Agent.TUI.Motion (MotionMode(..), foregroundIndicator)
 import Control.Concurrent (forkIO)
 import Control.Concurrent.MVar (newEmptyMVar, newMVar, putMVar, takeMVar)
@@ -269,6 +273,25 @@ spec = do
                 body `shouldSatisfy` (not . Text.isInfixOf "\ESC7")
                 body `shouldSatisfy` (not . Text.isInfixOf "\ESC8")
 
+        it "accumulates many small reasoning deltas without losing order" do
+            withRenderConfig True False \config handle path -> do
+                let chunks = replicate 5000 "x"
+                mapM_ (renderEvent config . ReasoningDelta) chunks
+                buffered <- readIORef config.renderReasoningBuffer
+                textBufferToText buffered
+                    `shouldBe` Text.replicate 5000 "x"
+                renderEvent config (TurnFinished TurnOutput
+                    { responseId = "r1"
+                    , toolCalls = []
+                    , assistantText = Nothing
+                    , tokenUsage = emptyTokenUsage
+                    })
+                readIORef config.renderReasoningBuffer
+                    `shouldReturn` emptyTextBuffer
+                hClose handle
+                body <- Text.readFile path
+                body `shouldSatisfy` Text.isInfixOf "Thought for"
+
         it "commits the thinking block before the first tool" do
             withRenderConfig True False \config handle path -> do
                 renderEvent config TurnStarted
@@ -302,8 +325,6 @@ spec = do
                 renderEvent config (TextDelta "say **")
                 renderEvent config (TextDelta "hello")
                 renderEvent config (TextDelta "** there")
-                buffered <- readIORef config.renderTextBuffer
-                buffered `shouldBe` "say **hello** there"
                 live <- readIORef config.renderLiveActive
                 live `shouldBe` True
                 printed <- readIORef config.renderPrintedText
@@ -362,7 +383,6 @@ spec = do
                 body <- Text.readFile path
                 body `shouldSatisfy` Text.isInfixOf "src"
                 body `shouldSatisfy` Text.isInfixOf "\ESC["
-                readIORef config.renderTextBuffer `shouldReturn` ""
 
         it "paints assistantText on TurnFinished when no deltas arrived" do
             withRenderConfig False True \config handle path -> do
@@ -494,11 +514,10 @@ withRenderConfigNativeMode showThinking color native motionMode action = do
     printed <- newIORef False
     thinking <- newIORef False
     spinner <- newIORef Nothing
-    reasoningBuffer <- newIORef ""
+    reasoningBuffer <- newIORef emptyTextBuffer
     modelRef <- newIORef "test-model"
     activityRef <- newIORef "Thinking…"
     startedAt <- newIORef Nothing
-    textBuffer <- newIORef ""
     markdownState <- newIORef emptyMarkdownStreamState
     liveActive <- newIORef False
     toolCalls <- newIORef mempty
@@ -514,7 +533,6 @@ withRenderConfigNativeMode showThinking color native motionMode action = do
                 , renderReasoningBuffer = reasoningBuffer
                 , renderColor = color
                 , renderPrintedText = printed
-                , renderTextBuffer = textBuffer
                 , renderMarkdownState = markdownState
                 , renderLiveActive = liveActive
                 , renderLock = lock

--- a/packages/agent-core/agent-core.cabal
+++ b/packages/agent-core/agent-core.cabal
@@ -119,6 +119,7 @@ benchmark streaming-text-bench
     build-depends:    agent-core
                     , base >= 4.14 && < 5
                     , text
+                    , text-builder >= 1.0 && < 1.1
 
 test-suite agent-core-test
     import:           common-opts

--- a/packages/agent-core/agent-core.cabal
+++ b/packages/agent-core/agent-core.cabal
@@ -57,6 +57,7 @@ library
                     , Agent.Subagents.Registry
                     , Agent.Subagents.TaskPath
                     , Agent.Subagents.Types
+                    , Agent.TextBuffer
                     , Agent.ToolArgs
                     , Agent.ToolDSL
                     , Agent.ToolDispatch
@@ -109,6 +110,16 @@ library
                     , websockets
                     , yaml
 
+benchmark streaming-text-bench
+    import:           common-opts
+    type:             exitcode-stdio-1.0
+    hs-source-dirs:   benchmark
+    main-is:          StreamingText.hs
+    ghc-options:      -O2 -rtsopts
+    build-depends:    agent-core
+                    , base >= 4.14 && < 5
+                    , text
+
 test-suite agent-core-test
     import:           common-opts
     type:             exitcode-stdio-1.0
@@ -127,6 +138,7 @@ test-suite agent-core-test
                     , Agent.SkillsSpec
                     , Agent.SubagentsSpec
                     , Agent.Subagents.TaskPathSpec
+                    , Agent.TextBufferSpec
                     , Agent.ToolArgsSpec
                     , Agent.ToolDispatchSpec
                     , Agent.Tools.CodexSpec

--- a/packages/agent-core/benchmark/StreamingText.hs
+++ b/packages/agent-core/benchmark/StreamingText.hs
@@ -10,6 +10,11 @@ import Agent.TextBuffer
 import Control.Exception (evaluate)
 import Control.Monad (forM)
 import Data.Char (chr, ord)
+import Data.IORef
+    ( modifyIORef'
+    , newIORef
+    , readIORef
+    )
 import Data.List (sort)
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -22,11 +27,15 @@ import System.CPUTime (getCPUTime)
 import System.Environment (getArgs)
 import System.Exit (die)
 import System.Mem (performGC)
+import qualified TextBuilder
 import Text.Printf (printf)
 
 data Workload
     = OldAccumulate
     | NewAccumulate
+    | OldIORefAccumulate
+    | NewIORefAccumulate
+    | TextBuilderIORefAccumulate
     | NoDuplicateBuffer
     | FullscreenBaseline
     deriving (Eq, Show)
@@ -66,12 +75,16 @@ main = do
             die $
                 "usage: streaming-text-bench WORKLOAD CHUNKS CHUNK_SIZE SAMPLES\n"
                     <> "workloads: old-accumulate, new-accumulate, "
+                    <> "old-io-ref, new-io-ref, text-builder-io-ref, "
                     <> "no-duplicate-buffer, fullscreen-baseline"
 
 parseWorkload :: String -> IO Workload
 parseWorkload = \case
     "old-accumulate" -> pure OldAccumulate
     "new-accumulate" -> pure NewAccumulate
+    "old-io-ref" -> pure OldIORefAccumulate
+    "new-io-ref" -> pure NewIORefAccumulate
+    "text-builder-io-ref" -> pure TextBuilderIORefAccumulate
     "no-duplicate-buffer" -> pure NoDuplicateBuffer
     "fullscreen-baseline" -> pure FullscreenBaseline
     other -> die ("unknown workload: " <> other)
@@ -84,24 +97,46 @@ parsePositive label raw =
         _ -> die ("invalid " <> label <> ": " <> raw)
 
 runWorkload :: Workload -> [Text] -> IO Int
-runWorkload workload chunks =
-    evaluate $ case workload of
-        OldAccumulate ->
+runWorkload workload chunks = case workload of
+    OldAccumulate ->
+        evaluate $
             checksumText (foldl' (<>) "" chunks)
-        NewAccumulate ->
+    NewAccumulate ->
+        evaluate $
             checksumText $
                 textBufferToText $
                     foldl'
                         (flip appendTextBuffer)
                         emptyTextBuffer
                         chunks
-        NoDuplicateBuffer ->
+    OldIORefAccumulate -> do
+        bufferRef <- newIORef ""
+        mapM_
+            (\chunk -> modifyIORef' bufferRef (<> chunk))
+            chunks
+        checksumText <$> readIORef bufferRef
+    NewIORefAccumulate -> do
+        bufferRef <- newIORef emptyTextBuffer
+        mapM_
+            (\chunk ->
+                modifyIORef' bufferRef (appendTextBuffer chunk))
+            chunks
+        checksumText . textBufferToText <$> readIORef bufferRef
+    TextBuilderIORefAccumulate -> do
+        bufferRef <- newIORef mempty
+        mapM_
+            (\chunk ->
+                modifyIORef' bufferRef (<> TextBuilder.text chunk))
+            chunks
+        checksumText . TextBuilder.toText <$> readIORef bufferRef
+    NoDuplicateBuffer ->
+        evaluate $
             foldl'
                 (Text.foldl' checksumStep)
                 checksumSeed
                 chunks
-        FullscreenBaseline ->
-            oldFullscreen chunks
+    FullscreenBaseline ->
+        evaluate (oldFullscreen chunks)
 
 oldFullscreen :: [Text] -> Int
 oldFullscreen =

--- a/packages/agent-core/benchmark/StreamingText.hs
+++ b/packages/agent-core/benchmark/StreamingText.hs
@@ -1,0 +1,151 @@
+module Main (main) where
+
+import Agent.TextBuffer
+    ( appendTextBuffer
+    , emptyTextBuffer
+    , textBufferToText
+    )
+-- 'evaluate' is required to keep pure work inside the measured IO interval;
+-- safe-exceptions does not re-export it.
+import Control.Exception (evaluate)
+import Control.Monad (forM)
+import Data.Char (chr, ord)
+import Data.List (sort)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import GHC.Stats
+    ( RTSStats(..)
+    , getRTSStats
+    , getRTSStatsEnabled
+    )
+import System.CPUTime (getCPUTime)
+import System.Environment (getArgs)
+import System.Exit (die)
+import System.Mem (performGC)
+import Text.Printf (printf)
+
+data Workload
+    = OldAccumulate
+    | NewAccumulate
+    | NoDuplicateBuffer
+    | FullscreenBaseline
+    deriving (Eq, Show)
+
+data Sample = Sample
+    { elapsedMillis :: !Double
+    , allocatedBytes :: !Integer
+    }
+
+main :: IO ()
+main = do
+    enabled <- getRTSStatsEnabled
+    if not enabled
+        then die "RTS statistics are disabled; run with +RTS -T"
+        else pure ()
+    getArgs >>= \case
+        [workloadArg, chunkCountArg, chunkSizeArg, sampleCountArg] -> do
+            workload <- parseWorkload workloadArg
+            chunkCount <- parsePositive "chunk count" chunkCountArg
+            chunkSize <- parsePositive "chunk size" chunkSizeArg
+            sampleCount <- parsePositive "sample count" sampleCountArg
+            samples <- forM [1 .. sampleCount] \sampleIndex -> do
+                let character = chr (97 + sampleIndex `mod` 26)
+                    chunk = Text.replicate chunkSize (Text.singleton character)
+                    chunks = replicate chunkCount chunk
+                _ <- evaluate (length chunks + checksumText chunk)
+                measure (runWorkload workload chunks)
+            let medianSample = median samples
+            printf
+                "%s,%d,%d,%.3f,%d\n"
+                workloadArg
+                chunkCount
+                chunkSize
+                medianSample.elapsedMillis
+                medianSample.allocatedBytes
+        _ ->
+            die $
+                "usage: streaming-text-bench WORKLOAD CHUNKS CHUNK_SIZE SAMPLES\n"
+                    <> "workloads: old-accumulate, new-accumulate, "
+                    <> "no-duplicate-buffer, fullscreen-baseline"
+
+parseWorkload :: String -> IO Workload
+parseWorkload = \case
+    "old-accumulate" -> pure OldAccumulate
+    "new-accumulate" -> pure NewAccumulate
+    "no-duplicate-buffer" -> pure NoDuplicateBuffer
+    "fullscreen-baseline" -> pure FullscreenBaseline
+    other -> die ("unknown workload: " <> other)
+
+parsePositive :: String -> String -> IO Int
+parsePositive label raw =
+    case reads raw of
+        [(value, "")]
+            | value > 0 -> pure value
+        _ -> die ("invalid " <> label <> ": " <> raw)
+
+runWorkload :: Workload -> [Text] -> IO Int
+runWorkload workload chunks =
+    evaluate $ case workload of
+        OldAccumulate ->
+            checksumText (foldl' (<>) "" chunks)
+        NewAccumulate ->
+            checksumText $
+                textBufferToText $
+                    foldl'
+                        (flip appendTextBuffer)
+                        emptyTextBuffer
+                        chunks
+        NoDuplicateBuffer ->
+            foldl'
+                (Text.foldl' checksumStep)
+                checksumSeed
+                chunks
+        FullscreenBaseline ->
+            oldFullscreen chunks
+
+oldFullscreen :: [Text] -> Int
+oldFullscreen =
+    snd . foldl' step ("", 0)
+  where
+    step (buffer, checksum) chunk =
+        let buffer' = buffer <> chunk
+            checksum' = checksumText buffer'
+        in checksum' `seq` (buffer', checksum + checksum')
+
+checksumText :: Text -> Int
+checksumText =
+    Text.foldl' checksumStep checksumSeed
+
+checksumSeed :: Int
+checksumSeed = 5381
+
+checksumStep :: Int -> Char -> Int
+checksumStep checksum character =
+    checksum * 33 + ord character
+
+measure :: IO Int -> IO Sample
+measure action = do
+    performGC
+    beforeStats <- getRTSStats
+    beforeTime <- getCPUTime
+    result <- action
+    _ <- evaluate result
+    afterTime <- getCPUTime
+    performGC
+    afterStats <- getRTSStats
+    pure Sample
+        { elapsedMillis =
+            fromIntegral (afterTime - beforeTime) / 1.0e9
+        , allocatedBytes =
+            fromIntegral
+                (afterStats.allocated_bytes - beforeStats.allocated_bytes)
+        }
+
+median :: [Sample] -> Sample
+median samples =
+    Sample
+        { elapsedMillis = middle (sort (map (.elapsedMillis) samples))
+        , allocatedBytes = middle (sort (map (.allocatedBytes) samples))
+        }
+  where
+    middle values = values !! (length values `div` 2)

--- a/packages/agent-core/package.nix
+++ b/packages/agent-core/package.nix
@@ -1,7 +1,7 @@
 { mkDerivation, aeson, async, base, bytestring, containers
 , crypton-connection, directory, filepath, hspec, lib, process
 , resourcet, retry, safe-exceptions, scientific, stm, text, time
-, tls, transformers, unix, vector, websockets, yaml
+, text-builder, tls, transformers, unix, vector, websockets, yaml
 }:
 mkDerivation {
   pname = "agent-core";
@@ -12,6 +12,7 @@ mkDerivation {
     filepath process resourcet retry safe-exceptions scientific stm
     text time tls transformers unix vector websockets yaml
   ];
+  benchmarkHaskellDepends = [ base text text-builder ];
   testHaskellDepends = [
     aeson async base bytestring containers crypton-connection directory
     filepath hspec retry safe-exceptions stm text time tls unix

--- a/packages/agent-core/src/Agent/TextBuffer.hs
+++ b/packages/agent-core/src/Agent/TextBuffer.hs
@@ -2,6 +2,8 @@
 --
 -- Chunks are retained in reverse arrival order so appending does not copy the
 -- accumulated prefix. Convert to strict 'Text' only at an output boundary.
+-- The streaming benchmark also compares this representation with
+-- @text-builder@ under the same 'IORef' update pattern.
 module Agent.TextBuffer
     ( TextBuffer
     , appendTextBuffer

--- a/packages/agent-core/src/Agent/TextBuffer.hs
+++ b/packages/agent-core/src/Agent/TextBuffer.hs
@@ -1,0 +1,54 @@
+-- | Append-friendly text accumulation.
+--
+-- Chunks are retained in reverse arrival order so appending does not copy the
+-- accumulated prefix. Convert to strict 'Text' only at an output boundary.
+module Agent.TextBuffer
+    ( TextBuffer
+    , appendTextBuffer
+    , compactTextBuffer
+    , emptyTextBuffer
+    , textBufferFromText
+    , textBufferNull
+    , textBufferToText
+    ) where
+
+import Data.Text (Text)
+import qualified Data.Text as Text
+
+data TextBuffer = TextBuffer ![Text]
+
+instance Eq TextBuffer where
+    left == right = textBufferToText left == textBufferToText right
+
+instance Show TextBuffer where
+    showsPrec precedence = showsPrec precedence . textBufferToText
+
+emptyTextBuffer :: TextBuffer
+emptyTextBuffer = TextBuffer []
+
+textBufferFromText :: Text -> TextBuffer
+textBufferFromText text
+    | Text.null text = emptyTextBuffer
+    | otherwise = TextBuffer [text]
+
+appendTextBuffer :: Text -> TextBuffer -> TextBuffer
+appendTextBuffer chunk buffer
+    | Text.null chunk = buffer
+appendTextBuffer chunk (TextBuffer chunks) =
+    TextBuffer (chunk : chunks)
+
+textBufferToText :: TextBuffer -> Text
+textBufferToText (TextBuffer chunks) =
+    Text.concat (reverse chunks)
+
+textBufferNull :: TextBuffer -> Bool
+textBufferNull (TextBuffer chunks) =
+    null chunks
+
+-- | Collapse accumulated chunks after streaming completes.
+compactTextBuffer :: TextBuffer -> TextBuffer
+compactTextBuffer buffer@(TextBuffer chunks) =
+    case chunks of
+        [] -> buffer
+        [_] -> buffer
+        _ -> textBufferFromText (textBufferToText buffer)

--- a/packages/agent-core/test/Agent/TextBufferSpec.hs
+++ b/packages/agent-core/test/Agent/TextBufferSpec.hs
@@ -1,0 +1,26 @@
+module Agent.TextBufferSpec (spec) where
+
+import Agent.TextBuffer
+import qualified Data.Text as Text
+import Test.Hspec
+
+spec :: Spec
+spec = describe "TextBuffer" do
+    it "preserves the arrival order of many small chunks" do
+        let chunks = replicate 10000 "x"
+            buffered =
+                foldl'
+                    (flip appendTextBuffer)
+                    emptyTextBuffer
+                    chunks
+        textBufferToText buffered
+            `shouldBe` Text.replicate 10000 "x"
+
+    it "ignores empty chunks and compacts without changing content" do
+        let buffered =
+                appendTextBuffer "second" $
+                    appendTextBuffer "" $
+                        textBufferFromText "first "
+        textBufferNull buffered `shouldBe` False
+        compactTextBuffer buffered `shouldBe` textBufferFromText "first second"
+        textBufferNull (appendTextBuffer "" emptyTextBuffer) `shouldBe` True

--- a/packages/agent-core/test/Spec.hs
+++ b/packages/agent-core/test/Spec.hs
@@ -13,6 +13,7 @@ import qualified Agent.RetrySpec as RetrySpec
 import qualified Agent.SkillsSpec as SkillsSpec
 import qualified Agent.SubagentsSpec as SubagentsSpec
 import qualified Agent.Subagents.TaskPathSpec as TaskPathSpec
+import qualified Agent.TextBufferSpec as TextBufferSpec
 import qualified Agent.ToolArgsSpec as ToolArgsSpec
 import qualified Agent.ToolDispatchSpec as ToolDispatchSpec
 import qualified Agent.ToolDSLSpec as ToolDSLSpec
@@ -42,6 +43,7 @@ main = hspec do
     SkillsSpec.spec
     SubagentsSpec.spec
     TaskPathSpec.spec
+    TextBufferSpec.spec
     ToolArgsSpec.spec
     ToolDispatchSpec.spec
     ToolDSLSpec.spec


### PR DESCRIPTION
## Summary

- remove the redundant full assistant-response `Text` buffer from the minimal CLI renderer
- accumulate streamed reasoning in an append-friendly `TextBuffer` and flatten once when committing the thought block
- add high-chunk-count regression tests and an optimized RTS allocation benchmark
- compare the custom buffer directly with [`text-builder`](https://hackage.haskell.org/package/text-builder) under the renderer's actual `IORef` update pattern
- document in `AGENTS.md` that performance PRs require reproducible before/after benchmarks

The assistant fallback remains intact: if no Markdown prefix was emitted, `MarkdownStreamState.pending` contains the complete streamed response; otherwise only its pending suffix needs to be flushed.

## Benchmark methodology

Built with GHC 9.10.3. The benchmark component passes `-O2 -rtsopts`; the verbose GHC invocation was checked to contain `-O2`. The Nix dev shell includes benchmark dependencies and currently pins `text-builder-1.0.0.4`, so a clean offline Cabal build does not depend on a user package cache.

Each workload:

- constructs input outside the measured interval
- performs a major GC before the sample
- measures CPU time and `GHC.Stats.allocated_bytes` with `+RTS -T`
- forces an equivalent checksum of the final response inside the measured interval
- reports the median of multiple samples

The `*-io-ref` workloads use the same strict `modifyIORef'` update shape as the renderer. The comparison covered 1,000, 2,000, 5,000, 10,000, 20,000, 50,000, and 100,000 chunks, with repeated representative runs. The original benchmark also covered different chunk sizes and fixed-total-size inputs.

Reproducible build/run:

```sh
nix develop -c cabal build --offline agent-core:bench:streaming-text-bench
bin=$(nix develop -c cabal list-bin agent-core:bench:streaming-text-bench)

"$bin" old-accumulate       10000 16 15 +RTS -T
"$bin" new-accumulate       10000 16 15 +RTS -T
"$bin" old-io-ref           10000 16 15 +RTS -T
"$bin" new-io-ref           10000 16 15 +RTS -T
"$bin" text-builder-io-ref  10000 16 15 +RTS -T
"$bin" no-duplicate-buffer  10000 16 15 +RTS -T
"$bin" fullscreen-baseline  10000 16 15 +RTS -T
```

For a package-cache-independent verification, I also built in fresh `CABAL_DIR` and `--builddir` directories with `--offline`; Cabal selected the Nix-provided `text-builder-1.0.0.4`.

## Results

10,000 chunks × 16 ASCII bytes (160 KB final response):

| Workload | Median CPU time | Allocated bytes |
| --- | ---: | ---: |
| repeated strict `Text` append | 15.424 ms | 800,241,216 |
| chunk-list accumulation | 0.284 ms | 641,296 |
| original renderer `IORef Text` | 15.476 ms | 800,561,232 |
| custom `TextBuffer` renderer path | 0.291 ms | 801,312 |
| `text-builder` renderer path | 0.279 ms | 1,354,512 |
| assistant path without duplicate buffer | 0.198 ms | 1,248 |
| full-prefix-per-frame baseline | 904.157 ms | 800,241,216 |

At 10,000 chunks, `text-builder` was about 4% faster than the custom buffer, but allocated **69% more**. At 100,000 chunks:

| Buffer | Median CPU time | Allocated bytes |
| --- | ---: | ---: |
| custom `TextBuffer` | 3.904 ms | 8,001,312 |
| `text-builder` | 5.059 ms | 13,730,064 |

At that size, `text-builder` was about **30% slower** and allocated **72% more**. Since this change specifically targets allocation/GC pressure and the custom buffer scales better at high chunk counts, the production implementation remains the simple reversed chunk list. The `text-builder` workload stays in the benchmark so this decision remains measurable.

I also benchmarked a chunk-buffer conversion for fullscreen blocks. Because the current Markdown renderer still materializes and parses the complete body every frame, that version was slower and allocated more than the strict-`Text` baseline, so it was reverted. A real fullscreen fix requires incremental Markdown/layout state rather than moving the full-prefix materialization.

## Validation

- `agent-core` test suite: 268 examples, 0 failures
- `agent-cli` test suite: 567 examples, 0 failures
- clean offline optimized benchmark build against Nix-provided `text-builder-1.0.0.4`
- `nix build .#agent-core --no-link`
- `nix flake check --no-build`
- live fullscreen CLI streaming smoke-tested in tmux
- `git diff --check`
