### PR TITLE
Fix model footer after provider fallback

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -3,6 +3,7 @@ module Agent.CLI
     ( DevResult(..)
     , afterDev
     , applyReplMode
+    , buildPromptState
     , cycleReplInteraction
     , devArgs
     , devMain
@@ -2152,6 +2153,7 @@ runPendingTurnWithCooldownRetry
 runPendingTurnWithCooldownRetry
     allowCooldownRetry presentation env pending = do
     writeIORef env.sessionPlanMode.planStateRef pending.pendingPlanState
+    syncFullscreenPrompt env
     case env.sessionFullscreen of
         Nothing -> pure ()
         Just runtime -> case presentation of
@@ -2165,6 +2167,49 @@ runPendingTurnWithCooldownRetry
     result <- runOneTurn env pending.pendingPromptText pending.pendingInputs
     finishTurnWithCooldownRetry
         allowCooldownRetry env pending.pendingExitAfter result
+
+-- | A retained fullscreen runtime survives provider rebuilds. Publish the new
+-- session's prompt metadata before replaying a pending turn so the composer
+-- does not keep showing the exhausted provider while its replacement runs.
+syncFullscreenPrompt :: SessionEnv -> IO ()
+syncFullscreenPrompt env =
+    forM_ env.sessionFullscreen \runtime -> do
+        planState <- readIORef env.sessionPlanMode.planStateRef
+        params <- readIORef env.sessionParams
+        policy <- readIORef env.sessionPolicy
+        account <- readIORef env.sessionAccount
+        usage <- readIORef env.sessionUsage
+        attachments <- readIORef env.sessionAttachments
+        emitUiEvent runtime $ UiSetPrompt $
+            buildPromptState
+                params
+                planState
+                policy
+                account
+                (isJust env.sessionSelectAccount)
+                usage
+                (length attachments)
+
+buildPromptState
+    :: ResponseCreateParams
+    -> PlanModeState
+    -> ApprovalPolicy
+    -> Text
+    -> Bool
+    -> TokenUsage
+    -> Int
+    -> PromptState
+buildPromptState params planState policy account accountSelectable usage attachments =
+    PromptState
+        { promptModel = currentModel params
+        , promptEffort = currentEffort params
+        , promptMode =
+            replModeLabel (replModeFromState planState policy)
+        , promptAccount = account
+        , promptAccountSelectable = accountSelectable
+        , promptUsage = usage
+        , promptAttachments = attachments
+        }
 
 finishTurn
     :: SessionEnv
@@ -2392,15 +2437,14 @@ replWithDraft env@SessionEnv
         Just runtime -> do
             setFullscreenImagePreviews runtime pendingAttachments
             readFullscreenLine runtime skillCommands
-                PromptState
-                    { promptModel = currentModel params
-                    , promptEffort = currentEffort params
-                    , promptMode = replModeLabel idleMode
-                    , promptAccount = account
-                    , promptAccountSelectable = isJust selectAccount
-                    , promptUsage = usage
-                    , promptAttachments = length pendingAttachments
-                    }
+                (buildPromptState
+                    params
+                    planState
+                    policy
+                    account
+                    (isJust selectAccount)
+                    usage
+                    (length pendingAttachments))
                 draft
         Nothing -> withMVar render.renderLock \_ -> do
             -- The inline editor redraws its ANSI frame with several writes.

--- a/packages/agent-cli/test/Agent/CLI/ReplStatusSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ReplStatusSpec.hs
@@ -4,6 +4,7 @@ import Agent.CLI
     ( DevResult(..)
     , afterDev
     , applyReplMode
+    , buildPromptState
     , cycleReplInteraction
     , devArgs
     , formatReplStatusLine
@@ -12,6 +13,7 @@ import Agent.CLI
     , formatTokenUsage
     , withRestoredCurrentDirectory
     )
+import Agent.CLI.Command (setModel, setReasoningEffort)
 import Agent.CLI.Input (terminalTextWidth)
 import Agent.CLI.Options (ApprovalPolicy(..))
 import Agent.CLI.Project (ProjectSettings(..), loadProjectSettings)
@@ -20,8 +22,16 @@ import Agent.CLI.ReplMode
     , cycleReplMode
     , replModeFromState
     )
-import Agent.Loop (TokenUsage(..), emptyTokenUsage)
+import Agent.Loop (LoopEvent(..), TokenUsage(..), emptyTokenUsage)
+import Agent.Responses.Types (defaultResponseCreateParams)
 import System.OsPath (unsafeEncodeUtf)
+import Agent.TUI.Model
+    ( PromptState(..)
+    , UiEvent(..)
+    , UiState(..)
+    , initialUiState
+    , reduceUi
+    )
 import Agent.Tools.PlanMode (PlanModeEnv(..), PlanModeState(..), newPlanModeEnv)
 import Control.Exception.Safe (bracket, throwIO)
 import Data.IORef (newIORef, readIORef)
@@ -125,6 +135,35 @@ spec = do
                         ReplModeNormal "" emptyTokenUsage
             terminalTextWidth line `shouldBe` 16
             line `shouldBe` "  模型模型 · hi…"
+
+    describe "buildPromptState" do
+        it "replaces stale Grok metadata before a fallback turn starts" do
+            let stalePrompt =
+                    initialUiState.uiPrompt
+                        { promptModel = "grok-4.6"
+                        , promptEffort = "high"
+                        , promptAccount = "grok@example.com"
+                        }
+                openAiParams =
+                    setReasoningEffort "medium" $
+                        setModel "gpt-5.6-sol" defaultResponseCreateParams
+                replacement =
+                    buildPromptState
+                        openAiParams
+                        PlanInactive
+                        PromptMutating
+                        "openai@example.com"
+                        True
+                        emptyTokenUsage
+                        0
+                running =
+                    reduceUi (UiLoop TurnStarted) $
+                        reduceUi (UiSetPrompt replacement) $
+                            reduceUi UiTurnRestarted $
+                                reduceUi (UiSetPrompt stalePrompt) initialUiState
+            running.uiPrompt.promptModel `shouldBe` "gpt-5.6-sol"
+            running.uiPrompt.promptEffort `shouldBe` "medium"
+            running.uiPrompt.promptAccount `shouldBe` "openai@example.com"
 
     describe "formatStartupTimings" do
         it "sorts cumulative startup markers and keeps subsecond precision" do


### PR DESCRIPTION
## Summary
- refresh the retained fullscreen prompt state before replaying a turn after automatic provider fallback
- update model, effort, account, mode, usage, and attachment metadata atomically
- share prompt-state construction with the normal fullscreen prompt path
- add regression coverage for replacing stale Grok metadata with OpenAI metadata

## Testing
- `nix develop -c cabal repl agent-cli:test:agent-cli-test`
  - `:main --match "fallback"` (10 examples, 0 failures)
  - `:main --match "applyProviderTransition"` (3 examples, 0 failures)
- tmux smoke test: started on exhausted `grok-4.6`, submitted a prompt, observed automatic fallback to OpenAI, and confirmed the footer displayed `gpt-5.6-sol` while the replacement turn was actively thinking
