### PR TITLE
feat(cli): add first-start credential onboarding

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -18,6 +18,7 @@ module Agent.CLI
 import Agent.CLI.Artifact (fencedCodeBlock, lastDiffBlock)
 import Agent.CLI.Auth
     ( LoadedAuth(..)
+    , authErrorNeedsOnboarding
     , loadAuth
     , preferredOpenAiTokenProvider
     , probeLoadedAuth
@@ -236,6 +237,7 @@ import Agent.CLI.TUI.App
     , requestFullscreenPermission
     , requestFullscreenChoice
     , requestFullscreenChoiceWithBody
+    , requestFullscreenOnboarding
     , requestFullscreenResume
     , requestFullscreenText
     , runFullscreen
@@ -488,6 +490,11 @@ newtype StartupFailure = StartupFailure String
     deriving (Show)
 
 instance Exception StartupFailure
+
+data StartupCancelled = StartupCancelled
+    deriving (Show)
+
+instance Exception StartupCancelled
 
 -- | GHCi @:cmd@ helper: on 'DevReload', reload modules and resume that exact
 -- session. Keeping the id in the generated GHCi command avoids a shared
@@ -780,8 +787,11 @@ runAgent fullscreenInputs options transition = do
                         options
                         transition
                         prepared.preparedRun
-    outcome <- try @_ @StartupFailure runPrepared
-    result <- either (\(StartupFailure message) -> die message) pure outcome
+    outcome <- try @_ @StartupCancelled (try @_ @StartupFailure runPrepared)
+    result <- case outcome of
+        Left StartupCancelled -> pure RunQuit
+        Right startupOutcome ->
+            either (\(StartupFailure message) -> die message) pure startupOutcome
     case (prepared.preparedFullscreen, result) of
         -- The retained screen has been restored before this persistent final
         -- diagnostic is printed.
@@ -1038,9 +1048,7 @@ runAgentInitialized options transition home root resumed cwd startup = do
                         | isNothing options.optModel ->
                             projectModelProvider projectSettings
                         | otherwise -> Nothing
-    loaded <-
-        loadAuth requestedProvider
-            >>= either (startupDie startup . Text.unpack) pure
+    loaded <- loadStartupAuth startup transition requestedProvider
     case (transitionTarget, resumed) of
         (Just target, _)
             | loaded.loadedProvider /= target.modelProvider ->
@@ -2134,6 +2142,63 @@ runSession options provider policy tools toolEnv planMode startup prompt pending
     _ <- waitForSessionTitleResults 5000000 titleManager
     applyPendingSessionTitles env
     pure result
+
+loadStartupAuth
+    :: StartupRuntime
+    -> Maybe ProviderTransition
+    -> Maybe Provider
+    -> IO LoadedAuth
+loadStartupAuth startup transition requestedProvider =
+    loadAuth requestedProvider >>= \case
+        Right loaded -> pure loaded
+        Left err
+            | isNothing transition
+            , authErrorNeedsOnboarding err
+            , Just runtime <- startup.startupFullscreen ->
+                runCredentialOnboarding startup runtime >>= \provider ->
+                    loadAuth (Just provider)
+                        >>= either (startupDie startup . Text.unpack) pure
+            | otherwise ->
+                startupDie startup (Text.unpack err)
+
+runCredentialOnboarding
+    :: StartupRuntime
+    -> FullscreenRuntime
+    -> IO Provider
+runCredentialOnboarding startup runtime = do
+    markStartupStage startup "Choose how to connect…"
+    loop
+  where
+    choices =
+        [ ( OpenAIProvider
+          , ("Sign in with ChatGPT", "Use an OpenAI subscription")
+          )
+        , ( XAIProvider
+          , ("Sign in with Grok", "Use an xAI subscription")
+          )
+        , ( OpenRouterProvider
+          , ("Add an OpenRouter API key", "Use API credits")
+          )
+        ]
+    loop =
+        requestFullscreenOnboarding
+            runtime
+            "Welcome to haskell-agent"
+            "haskell-agent can access AI models with a subscription or API key."
+            (map snd choices)
+            >>= \case
+                Nothing -> throwIO StartupCancelled
+                Just index ->
+                    case atMay index choices of
+                        Nothing -> loop
+                        Just (provider, _) -> do
+                            connected <-
+                                withFullscreenSuspended runtime $
+                                    resolveColor stderr >>= \color ->
+                                        connectProviderAccount color provider
+                            case connected of
+                                Nothing -> loop
+                                Just _ -> pure provider
 
 runPendingTurn
     :: PendingTurnPresentation

--- a/packages/agent-cli/src/Agent/CLI/Auth.hs
+++ b/packages/agent-cli/src/Agent/CLI/Auth.hs
@@ -1,6 +1,7 @@
 -- | Load ChatGPT, Grok, or OpenRouter credentials for the CLI process.
 module Agent.CLI.Auth
     ( LoadedAuth(..)
+    , authErrorNeedsOnboarding
     , GrokAuthState(..)
     , credentialAccountLabel
     , grokCredentialFromAuthJson
@@ -1216,3 +1217,8 @@ noAuthHint :: Text
 noAuthHint =
     "no credentials found. Set GROK_ACCESS_TOKEN, CODEX_ACCESS_TOKEN, \
     \or OPENROUTER_API_KEY, or place auth at ~/.grok/auth.json / ~/.codex/auth.json."
+
+authErrorNeedsOnboarding :: Text -> Bool
+authErrorNeedsOnboarding message =
+    message == noAuthHint
+        || "no valid OpenAI credentials found:" `Text.isPrefixOf` message

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -21,9 +21,11 @@ module Agent.CLI.TUI.App
     , queuedFullscreenInputDisplays
     , readFullscreenLine
     , repositoryHeaderText
+    , onboardingVisibleRowIndices
     , requestFullscreenPermission
     , requestFullscreenChoice
     , requestFullscreenChoiceWithBody
+    , requestFullscreenOnboarding
     , requestFullscreenResume
     , requestFullscreenText
     , runFullscreen
@@ -161,7 +163,7 @@ import Data.IORef
     , readIORef
     , writeIORef
     )
-import Data.List (find, findIndex, intersperse, sortOn)
+import Data.List (find, findIndex, intersperse, nub, sort, sortOn)
 import Data.List.NonEmpty (NonEmpty(..))
 import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe, isJust, isNothing, mapMaybe)
@@ -426,7 +428,19 @@ requestFullscreenChoiceWithBody
 requestFullscreenChoiceWithBody runtime title body initial rows = do
     reply <- newEmptyTMVarIO
     enqueueAppEvent runtime
-        (AppAskChoice title body initial rows reply)
+        (AppAskChoice ChoiceDialog title body initial rows reply)
+    atomically (readTMVar reply)
+
+requestFullscreenOnboarding
+    :: FullscreenRuntime
+    -> Text
+    -> Text
+    -> [(Text, Text)]
+    -> IO (Maybe Int)
+requestFullscreenOnboarding runtime title body rows = do
+    reply <- newEmptyTMVarIO
+    enqueueAppEvent runtime
+        (AppAskChoice ChoiceOnboarding title body 0 rows reply)
     atomically (readTMVar reply)
 
 requestFullscreenResume
@@ -2669,7 +2683,12 @@ resumeFooter browser =
                     )
 
 drawChoice :: AppState -> ChoiceOverlay -> Widget Name
-drawChoice appState choice =
+drawChoice appState choice = case choice.choicePresentation of
+    ChoiceDialog -> drawDialogChoice appState choice
+    ChoiceOnboarding -> drawOnboardingChoice appState choice
+
+drawDialogChoice :: AppState -> ChoiceOverlay -> Widget Name
+drawDialogChoice appState choice =
     centerLayer $
         hLimitPercent 82 $
             vLimitPercent 78 $
@@ -2698,6 +2717,110 @@ drawChoice appState choice =
     start =
         max 0 (min choice.choiceIndex (max 0 (count - 14)))
     rows = take 14 (drop start choice.choiceRows)
+
+drawOnboardingChoice :: AppState -> ChoiceOverlay -> Widget Name
+drawOnboardingChoice appState choice =
+    Widget Greedy Greedy do
+        context <- getContext
+        render $
+            withAttr Theme.baseAttr $
+                padRight Max $
+                    padBottom Max $
+                        padLeft (Pad 3) $
+                            vBox
+                                [ onboardingRow context.availWidth sourceIndex
+                                | sourceIndex <-
+                                    onboardingVisibleRowIndices
+                                        context.availHeight
+                                        choice.choiceIndex
+                                        (length choice.choiceRows)
+                                ]
+  where
+    choiceStart = 8
+    choiceEnd = choiceStart + length choice.choiceRows
+    onboardingRow width sourceIndex
+        | sourceIndex >= choiceStart
+        , sourceIndex < choiceEnd =
+            case drop (sourceIndex - choiceStart) choice.choiceRows of
+                row : _ ->
+                    onboardingChoiceRow
+                        appState
+                        width
+                        choice.choiceIndex
+                        (sourceIndex - choiceStart)
+                        row
+                [] -> emptyWidget
+        | otherwise =
+            vLimit 1 $
+                case sourceIndex of
+                    0 -> withAttr Theme.headingAttr (txt choice.choiceTitle)
+                    2 -> txtWrap choice.choiceBody
+                    3 ->
+                        withAttr Theme.mutedAttr $
+                            txt "Choose a sign-in option below, or add your own API key."
+                    5 ->
+                        withAttr Theme.mutedAttr $
+                            txt "You can change this anytime with /login."
+                    7 -> withAttr Theme.strongAttr (txt "Get started")
+                    12 ->
+                        withAttr Theme.mutedAttr $
+                            txt "Credentials are stored locally on this computer."
+                    15 ->
+                        withAttr Theme.mutedAttr $
+                            txt "Esc to exit · Explore all commands with /help"
+                    _ -> txt " "
+
+onboardingChoiceRow
+    :: AppState
+    -> Int
+    -> Int
+    -> Int
+    -> (Text, Text)
+    -> Widget Name
+onboardingChoiceRow appState width selected index (label, detail) =
+    clickable name interactive
+  where
+    prefix = if selected == index then "› " else "  "
+    name = ChoiceRow index
+    showDetail = width >= 72 && not (Text.null detail)
+    row =
+        vLimit 1 $
+            if showDetail
+                then hBox
+                    [ hLimit 36 $
+                        padRight Max (txt (prefix <> label))
+                    , withAttr Theme.mutedAttr (txt detail)
+                    ]
+                else txt (prefix <> label)
+    styled =
+        if selected == index
+            then withAttr Theme.selectedAttr row
+            else row
+    interactive = case Composer.controlInteractionAttr appState name of
+        Nothing -> styled
+        Just attr -> forceAttr attr row
+
+-- | Project the 18-row onboarding surface into a short terminal while keeping
+-- the selected action and all setup paths visible before explanatory copy.
+onboardingVisibleRowIndices :: Int -> Int -> Int -> [Int]
+onboardingVisibleRowIndices availableHeight selected choiceCount
+    | availableHeight <= 0 = []
+    | availableHeight >= onboardingRowCount =
+        [0 .. onboardingRowCount - 1]
+    | otherwise =
+        sort $
+            take availableHeight $
+                nub $
+                    [ choiceStart + clampedSelected
+                    , choiceStart + max 0 (choiceCount - 1)
+                    ]
+                        <> [choiceStart .. choiceStart + choiceCount - 1]
+                        <> [7, 12, 15, 5, 0, 2, 3, 1, 4, 6, 13, 14, 16, 17]
+  where
+    onboardingRowCount = 18
+    choiceStart = 8
+    clampedSelected =
+        max 0 (min (max 0 (choiceCount - 1)) selected)
 
 waitingOverlayLabel :: AppState -> Text -> Widget Name
 waitingOverlayLabel state label =
@@ -3173,13 +3296,14 @@ handleEventInner event = case event of
                     { appPermissionReply = Just reply
                     , appAgentHover = Nothing
                     }
-    AppEvent (AppAskChoice title body initial rows reply) -> do
+    AppEvent (AppAskChoice presentation title body initial rows reply) -> do
         state <- get
         liftIO (state.appRuntime.runtimeNativeProgress False)
         modify' \state ->
             state
                 { appChoice = Just ChoiceOverlay
-                    { choiceTitle = title
+                    { choicePresentation = presentation
+                    , choiceTitle = title
                     , choiceBody = body
                     , choiceIndex =
                         max 0 (min (max 0 (length rows - 1)) initial)

--- a/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
@@ -576,7 +576,8 @@ handleEffortControlClick applyUiEvent = do
                 modify' \currentState ->
                     currentState
                         { appChoice = Just ChoiceOverlay
-                            { choiceTitle = "Reasoning effort"
+                            { choicePresentation = ChoiceDialog
+                            , choiceTitle = "Reasoning effort"
                             , choiceBody =
                                 "Changing effort will restart the current turn."
                             , choiceIndex = initial

--- a/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
@@ -4,6 +4,7 @@ module Agent.CLI.TUI.Types
     , AppEventMailbox(..)
     , AppState(..)
     , AgentHover(..)
+    , ChoicePresentation(..)
     , ChoiceOverlay(..)
     , FullscreenInput(..)
     , FullscreenInputBuffer(..)
@@ -75,6 +76,7 @@ data AppEvent
     | AppUiBatch !(NonEmpty UiEvent)
     | AppAskPermission !Text !(TMVar (Maybe PermissionChoice))
     | AppAskChoice
+        !ChoicePresentation
         !Text
         !Text
         !Int
@@ -206,8 +208,14 @@ data AgentHover = AgentHover
     , agentHoverPaneWidth :: !Int
     }
 
+data ChoicePresentation
+    = ChoiceDialog
+    | ChoiceOnboarding
+    deriving (Eq, Show)
+
 data ChoiceOverlay = ChoiceOverlay
-    { choiceTitle :: !Text
+    { choicePresentation :: !ChoicePresentation
+    , choiceTitle :: !Text
     , choiceBody :: !Text
     , choiceIndex :: !Int
     , choiceRows :: ![(Text, Text)]

--- a/packages/agent-cli/test/Agent/CLI/AuthSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/AuthSpec.hs
@@ -51,6 +51,17 @@ toFilePath path = either (error . show) id (decodeUtf path)
 
 spec :: Spec
 spec = do
+    describe "authErrorNeedsOnboarding" do
+        it "recognizes missing and invalid first-start credentials" do
+            authErrorNeedsOnboarding
+                "no credentials found. Set GROK_ACCESS_TOKEN, CODEX_ACCESS_TOKEN, or OPENROUTER_API_KEY, or place auth at ~/.grok/auth.json / ~/.codex/auth.json."
+                `shouldBe` True
+            authErrorNeedsOnboarding
+                "no valid OpenAI credentials found: invalid auth JSON"
+                `shouldBe` True
+            authErrorNeedsOnboarding "credential store is unreadable"
+                `shouldBe` False
+
     describe "probeLoadedAuth" do
         it "rejects auth whose accounts are currently cooling down" do
             let retryAt = UTCTime (fromGregorian 2026 8 21) 3600

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -13,6 +13,7 @@ import Agent.CLI.TUI.App
     , motionDemandFor
     , nativeProgressKeepaliveDue
     , nextMotionSchedule
+    , onboardingVisibleRowIndices
     , repositoryHeaderText
     , uiEventRestartsMotionSchedule
     )
@@ -64,6 +65,19 @@ spec = do
         it "still renders a path when git state is unavailable" do
             repositoryHeaderText "" "~/scratch"
                 `shouldBe` "~/scratch"
+
+    describe "onboarding layout" do
+        it "uses the complete 18-row surface when it fits" do
+            onboardingVisibleRowIndices 18 0 3
+                `shouldBe` [0 .. 17]
+
+        it "keeps every setup path in a short terminal" do
+            onboardingVisibleRowIndices 3 1 3
+                `shouldBe` [8, 9, 10]
+
+        it "keeps the selected setup path when only one row fits" do
+            onboardingVisibleRowIndices 1 1 3
+                `shouldBe` [9]
 
     describe "Agents pane layout" do
         it "hides below the responsive breakpoint and without children" do


### PR DESCRIPTION
## Summary

- show an fx-inspired fullscreen onboarding page when no usable provider credential is configured
- connect the onboarding choices to the existing ChatGPT, Grok, and OpenRouter authentication flows
- keep setup actions visible on short terminals and preserve normal choice-dialog behavior elsewhere
- return to onboarding after a cancelled provider flow and exit cleanly with Escape

## Testing

- `nix develop -c cabal repl agent-cli:lib:agent-cli` — 58 modules loaded
- `nix develop -c cabal repl agent-cli:test:agent-cli-test`, then `:main` — 580 examples, 0 failures
- tmux smoke tests at 100x30 and 60x10
- verified wrapped keyboard navigation, OpenRouter key prompt routing, cancelled setup recovery, and Escape exit
