### PR TITLE
fix(cli): show account picker for HTTP providers

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -19,8 +19,10 @@ import Agent.CLI.Artifact (fencedCodeBlock, lastDiffBlock)
 import Agent.CLI.Auth
     ( LoadedAuth(..)
     , loadAuth
+    , loadAuthForAccount
     , preferredOpenAiTokenProvider
     , probeLoadedAuth
+    , probeLoadedAuthCredential
     )
 import Agent.CLI.AgentViewport
     ( AgentEntry(..)
@@ -109,7 +111,15 @@ import Agent.CLI.Interrupt
     , withTurnCancel
     )
 import Agent.CLI.Login
-    ( connectProviderAccount
+    ( AccountBilling(..)
+    , AccountUsage(..)
+    , LoginAccount(..)
+    , UsageState(..)
+    , UsageWindow(..)
+    , connectProviderAccount
+    , discoverSelectableLoginAccounts
+    , loginAccountSelectionId
+    , refreshLoginAccount
     , runLoginManager
     )
 import Agent.CLI.ModelPicker (pickModel)
@@ -314,7 +324,7 @@ import Agent.OpenAI.WebSocketClient
     )
 import Agent.Provider
     ( AccountFailure(..)
-    , BillingMode
+    , BillingMode(..)
     , Credential(..)
     , FailedCredential(..)
     , Provider(..)
@@ -324,6 +334,7 @@ import Agent.Provider
     , tokenProvider
     , tokenProviderBillingMode
     )
+import qualified Agent.Provider as Provider
 import Agent.Subagents
     ( RootTurnId
     , SubagentId(..)
@@ -369,9 +380,11 @@ import Control.Concurrent.Async (link, mapConcurrently, withAsync)
 import Control.Concurrent.Chan (Chan, newChan, readChan, writeChan)
 import Control.Concurrent.MVar
     ( MVar
+    , modifyMVar_
     , newEmptyMVar
     , newMVar
     , putMVar
+    , readMVar
     , takeMVar
     , tryPutMVar
     , withMVar
@@ -393,7 +406,7 @@ import Data.IORef
 import Data.List (elemIndex, findIndex, sortOn)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import Data.Maybe (fromMaybe, isJust, isNothing)
+import Data.Maybe (fromMaybe, isJust, isNothing, listToMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
@@ -449,8 +462,15 @@ data PendingTurnPresentation
     | ContinuePendingTurn
 
 data AccountPickerOption
-    = AccountPickerAccount !Text !Text !Text
+    = AccountPickerAccount !Text !Text !Text !Text
     | AccountPickerConnect
+
+data ActiveHttpAuth = ActiveHttpAuth
+    { activeHttpGeneration :: !Int
+    , activeHttpProvider :: !TokenProvider
+    , activeHttpResolveLabel :: !(Credential -> IO Text)
+    , activeHttpAccountId :: !Text
+    }
 
 data OpenAiPersistentConnection
     = OpenAiPersistentConnection !Credential !(IORef Bool) !CodexConn
@@ -1067,6 +1087,7 @@ runAgentInitialized options transition home root resumed cwd startup = do
         _ -> pure ()
     activeAccountRef <- newIORef ""
     activeAccountIdRef <- newIORef ""
+    activeSelectionRef <- newIORef ""
     preferredOpenAiAccountRef <- newIORef Nothing
     let selectableTokenProvider =
             case loaded.loadedOpenAiPool of
@@ -1077,12 +1098,143 @@ runAgentInitialized options transition home root resumed cwd startup = do
                         loaded.loadedTokenProvider
                 Nothing ->
                     loaded.loadedTokenProvider
+    initialHttp <- case loaded.loadedProvider of
+        OpenAIProvider ->
+            pure
+                ( selectableTokenProvider
+                , loaded.loadedAccountLabel
+                , ""
+                )
+        _ ->
+            probeLoadedAuthCredential loaded >>= \case
+                Right (credential, usable) -> do
+                    label <- usable.loadedAccountLabel credential
+                    writeIORef activeAccountRef label
+                    writeIORef activeAccountIdRef credential.accountId
+                    let selectionId =
+                            fromMaybe
+                                credential.accountId
+                                usable.loadedSelectionId
+                    writeIORef activeSelectionRef selectionId
+                    pure
+                        ( usable.loadedTokenProvider
+                        , usable.loadedAccountLabel
+                        , credential.accountId
+                        )
+                Left _ -> do
+                    let fallback = case loaded.loadedProvider of
+                            XAIProvider -> "Grok"
+                            OpenRouterProvider -> "OpenRouter"
+                        selectionId = fromMaybe "" loaded.loadedSelectionId
+                    writeIORef activeAccountRef fallback
+                    writeIORef activeSelectionRef selectionId
+                    pure
+                        ( selectableTokenProvider
+                        , loaded.loadedAccountLabel
+                        , ""
+                        )
+    let
+        ( initialHttpProvider
+            , initialHttpResolver
+            , initialHttpAccountId
+            ) = initialHttp
+    activeHttpAuth <- newMVar ActiveHttpAuth
+        { activeHttpGeneration = 0
+        , activeHttpProvider = initialHttpProvider
+        , activeHttpResolveLabel = initialHttpResolver
+        , activeHttpAccountId = initialHttpAccountId
+        }
+    let switchableTokenProvider =
+            Provider.tokenProvider
+                (tokenProviderBillingMode selectableTokenProvider)
+                \failed -> do
+                    snapshot <- readMVar activeHttpAuth
+                    let routedFailure = case failed of
+                            Just reported
+                                | reported.credential.accountId
+                                    == snapshot.activeHttpAccountId ->
+                                    Just reported
+                            _ -> Nothing
+                    getNextToken
+                        snapshot.activeHttpProvider
+                        routedFailure
+                        >>= \case
+                            Left err -> pure (Left err)
+                            Right credential -> do
+                                label <-
+                                    snapshot.activeHttpResolveLabel credential
+                                modifyMVar_ activeHttpAuth \current ->
+                                    if current.activeHttpGeneration
+                                        == snapshot.activeHttpGeneration
+                                        then do
+                                            writeIORef
+                                                activeAccountIdRef
+                                                credential.accountId
+                                            writeIORef activeAccountRef label
+                                            pure current
+                                                { activeHttpAccountId =
+                                                    credential.accountId
+                                                }
+                                        else pure current
+                                pure (Right credential)
+        resolveActiveAccountLabel credential =
+            case loaded.loadedProvider of
+                OpenAIProvider ->
+                    loaded.loadedAccountLabel credential
+                _ -> do
+                    active <- readMVar activeHttpAuth
+                    active.activeHttpResolveLabel credential
         tokenProvider =
-            trackCredentialAccount
-                activeAccountRef
-                activeAccountIdRef
-                loaded.loadedAccountLabel
-                selectableTokenProvider
+            case loaded.loadedProvider of
+                OpenAIProvider ->
+                    trackCredentialAccount
+                        activeAccountRef
+                        activeAccountIdRef
+                        activeSelectionRef
+                        resolveActiveAccountLabel
+                        selectableTokenProvider
+                _ -> switchableTokenProvider
+        selectHttpAccount selectedSelectionId =
+            loadAuthForAccount loaded.loadedProvider selectedSelectionId
+                >>= \case
+                    Left err ->
+                        pure (Left (CredentialError err))
+                    Right selected
+                        | tokenProviderBillingMode
+                            selected.loadedTokenProvider
+                            /= tokenProviderBillingMode
+                                selectableTokenProvider ->
+                            pure $ Left $ CredentialError
+                                "selected account uses a different billing mode"
+                        | otherwise ->
+                            probeLoadedAuthCredential selected >>= \case
+                                Left err -> pure (Left err)
+                                Right (credential, usable) -> do
+                                    label <-
+                                        usable.loadedAccountLabel credential
+                                    let selectionId =
+                                            fromMaybe
+                                                selectedSelectionId
+                                                usable.loadedSelectionId
+                                    modifyMVar_ activeHttpAuth \current -> do
+                                        writeIORef
+                                            activeAccountIdRef
+                                            credential.accountId
+                                        writeIORef
+                                            activeSelectionRef
+                                            selectionId
+                                        writeIORef activeAccountRef label
+                                        pure ActiveHttpAuth
+                                            { activeHttpGeneration =
+                                                current.activeHttpGeneration + 1
+                                            , activeHttpProvider =
+                                                usable.loadedTokenProvider
+                                            , activeHttpResolveLabel =
+                                                usable.loadedAccountLabel
+                                            , activeHttpAccountId =
+                                                credential.accountId
+                                            }
+                                    pure (Right label)
 
     markStartupStage startup "Loading tools…"
     let basePlanHooks =
@@ -1359,7 +1511,7 @@ runAgentInitialized options transition home root resumed cwd startup = do
                                                             newHealthy <-
                                                                 newIORef True
                                                             label <-
-                                                                loaded.loadedAccountLabel
+                                                                resolveActiveAccountLabel
                                                                     newCredential
                                                             writeIORef
                                                                 activeConnectionRef $
@@ -1369,6 +1521,9 @@ runAgentInitialized options transition home root resumed cwd startup = do
                                                                     newConn
                                                             writeIORef
                                                                 activeAccountIdRef
+                                                                newCredential.accountId
+                                                            writeIORef
+                                                                activeSelectionRef
                                                                 newCredential.accountId
                                                             writeIORef
                                                                 activeAccountRef
@@ -1523,7 +1678,7 @@ runAgentInitialized options transition home root resumed cwd startup = do
                                     link switchWorker
                                     runSession options provider policy tools toolEnv planMode startup prompt pendingTurn transitionDraft unavailableProviders paramsRef transcriptRef initialTurns
                                         previousRef persist projectRoot home cwd (Just tokenProvider) loaded.loadedOpenAiPool startupContext skillsRef skillInvocationsRef escPaused interrupt
-                                        multiCtx rootTurnRef subagentSessions pendingNotices subagentStoreRoot usageRef activeAccountRef activeAccountIdRef loaded.loadedAccountLabel selectAccount claimCurrentSession compactRunner activeBackend btwBackend)
+                                        multiCtx rootTurnRef subagentSessions pendingNotices subagentStoreRoot usageRef activeAccountRef activeAccountIdRef activeSelectionRef resolveActiveAccountLabel selectAccount claimCurrentSession compactRunner activeBackend btwBackend)
                             >>= \case
                                 Left (CodexAuthFailed err) ->
                                     case transition of
@@ -1545,8 +1700,7 @@ runAgentInitialized options transition home root resumed cwd startup = do
                                         subagentRuntime
                                         XAIProvider
                                         (\childParamsRef childTranscript ->
-                                            xaiBackend xaiOptions
-                                                loaded.loadedTokenProvider
+                                            xaiBackend xaiOptions tokenProvider
                                                 (readIORef childParamsRef) childTranscript)
                             Nothing -> pure ()
                         let backend =
@@ -1571,7 +1725,7 @@ runAgentInitialized options transition home root resumed cwd startup = do
                                 projectRoot transition persist backend
                         runSession options provider policy tools toolEnv planMode startup prompt pendingTurn transitionDraft unavailableProviders paramsRef transcriptRef initialTurns
                             previousRef persist projectRoot home cwd (Just tokenProvider) loaded.loadedOpenAiPool startupContext skillsRef skillInvocationsRef escPaused interrupt
-                            multiCtx rootTurnRef subagentSessions pendingNotices subagentStoreRoot usageRef activeAccountRef activeAccountIdRef loaded.loadedAccountLabel Nothing claimCurrentSession compactRunner activeBackend btwBackend
+                            multiCtx rootTurnRef subagentSessions pendingNotices subagentStoreRoot usageRef activeAccountRef activeAccountIdRef activeSelectionRef resolveActiveAccountLabel (Just selectHttpAccount) claimCurrentSession compactRunner activeBackend btwBackend
                     OpenRouterProvider -> do
                         openRouterOptions <- OpenRouter.clientOptionsFromEnv
                         case multiCtx of
@@ -1582,7 +1736,7 @@ runAgentInitialized options transition home root resumed cwd startup = do
                                         OpenRouterProvider
                                         (\childParamsRef childTranscript ->
                                             openRouterBackend openRouterOptions
-                                                loaded.loadedTokenProvider
+                                                tokenProvider
                                                 (readIORef childParamsRef) childTranscript)
                             Nothing -> pure ()
                         let backend =
@@ -1607,20 +1761,22 @@ runAgentInitialized options transition home root resumed cwd startup = do
                                 projectRoot transition persist backend
                         runSession options provider policy tools toolEnv planMode startup prompt pendingTurn transitionDraft unavailableProviders paramsRef transcriptRef initialTurns
                             previousRef persist projectRoot home cwd (Just tokenProvider) loaded.loadedOpenAiPool startupContext skillsRef skillInvocationsRef escPaused interrupt
-                            multiCtx rootTurnRef subagentSessions pendingNotices subagentStoreRoot usageRef activeAccountRef activeAccountIdRef loaded.loadedAccountLabel Nothing claimCurrentSession compactRunner activeBackend btwBackend
+                            multiCtx rootTurnRef subagentSessions pendingNotices subagentStoreRoot usageRef activeAccountRef activeAccountIdRef activeSelectionRef resolveActiveAccountLabel (Just selectHttpAccount) claimCurrentSession compactRunner activeBackend btwBackend
 
 trackCredentialAccount
     :: IORef Text
     -> IORef Text
+    -> IORef Text
     -> (Credential -> IO Text)
     -> TokenProvider
     -> TokenProvider
-trackCredentialAccount accountRef accountIdRef resolveLabel provider =
+trackCredentialAccount accountRef accountIdRef selectionRef resolveLabel provider =
     tokenProvider (tokenProviderBillingMode provider) \failed ->
         getNextToken provider failed >>= \case
             Left err -> pure (Left err)
             Right credential -> do
                 writeIORef accountIdRef credential.accountId
+                writeIORef selectionRef credential.accountId
                 resolveLabel credential >>= writeIORef accountRef
                 pure (Right credential)
 
@@ -1760,6 +1916,7 @@ runSession
     -> IORef TokenUsage
     -> IORef Text
     -> IORef Text
+    -> IORef Text
     -> (Credential -> IO Text)
     -> Maybe (Text -> IO (Either ApiError Text))
     -> (SessionHandle -> IO ())
@@ -1767,7 +1924,7 @@ runSession
     -> Backend
     -> BtwBackendFactory
     -> IO RunResult
-runSession options provider policy tools toolEnv planMode startup prompt pendingTurn initialDraft unavailableProviders paramsRef transcriptRef initialTurns previous persist projectRoot home cwd tokenProvider openAiPool startupContext skillsRef skillInvocationsRef escPaused interrupt multiCtx rootTurnRef subagentSessions pendingNotices storeRoot usageRef accountRef accountIdRef accountLabel selectAccount onPersisted compactRunner backend btwBackend = do
+runSession options provider policy tools toolEnv planMode startup prompt pendingTurn initialDraft unavailableProviders paramsRef transcriptRef initialTurns previous persist projectRoot home cwd tokenProvider openAiPool startupContext skillsRef skillInvocationsRef escPaused interrupt multiCtx rootTurnRef subagentSessions pendingNotices storeRoot usageRef accountRef accountIdRef selectionRef accountLabel selectAccount onPersisted compactRunner backend btwBackend = do
   initialPrevious <- readIORef previous
   ioLock <- newMVar ()
   let fullscreen = startup.startupFullscreen
@@ -2075,6 +2232,7 @@ runSession options provider policy tools toolEnv planMode startup prompt pending
             , sessionUsage = usageRef
             , sessionAccount = accountRef
             , sessionAccountId = accountIdRef
+            , sessionAccountSelectionId = selectionRef
             , sessionAccountLabel = accountLabel
             , sessionSelectAccount = selectAccount
             , sessionLastAssistant = lastAssistantRef
@@ -2363,7 +2521,7 @@ replWithDraft env@SessionEnv
     , sessionStoreRoot = storeRoot
     , sessionUsage = usageRef
     , sessionAccount = accountRef
-    , sessionAccountId = accountIdRef
+    , sessionAccountSelectionId = selectionRef
     , sessionAccountLabel = accountLabel
     , sessionSelectAccount = selectAccount
     , sessionLastAssistant = lastAssistantRef
@@ -3276,75 +3434,107 @@ replWithDraft env@SessionEnv
                             next
                         Right result -> pure result
     chooseAccount _keptDraft next =
-        case (fullscreen, openAiPool) of
-            (Just runtime, Just pool) -> do
-                currentAccountId <- readIORef accountIdRef
+        case (fullscreen, selectAccount) of
+            (Just runtime, Just select) -> do
+                currentSelectionId <- readIORef selectionRef
                 options <- withReplActivity
                     "Loading account usage…"
-                    (loadAccountPickerOptions accountLabel pool)
+                    (case openAiPool of
+                        Just pool ->
+                            loadAccountPickerOptions accountLabel pool
+                        Nothing -> case tokenProvider of
+                            Just active ->
+                                loadProviderAccountPickerOptions
+                                    provider
+                                    (tokenProviderBillingMode active)
+                                    currentSelectionId
+                            Nothing ->
+                                pure [AccountPickerConnect])
                 let initial =
                         fromMaybe 0 $
                             findIndex
-                                (accountPickerMatches currentAccountId)
+                                (accountPickerMatches currentSelectionId)
                                 options
                 requestFullscreenChoiceWithBody
                     runtime
                     "Account"
-                    "Choose the ChatGPT subscription account for future requests."
+                    ("Choose the "
+                        <> providerSlug provider
+                        <> " account for future requests.")
                     initial
-                    (map (accountPickerRow currentAccountId) options)
+                    (map (accountPickerRow currentSelectionId) options)
                     >>= \case
                         Just index
                             | Just option <- atMay index options ->
                                 case option of
                                     AccountPickerAccount
-                                        selectedId
+                                        selectedSelectionId
+                                        _
                                         selectedLabel
                                         _
-                                            | selectedId == currentAccountId ->
+                                            | selectedSelectionId
+                                                == currentSelectionId ->
                                                 displayInfo
                                                     ("account: " <> selectedLabel)
                                                     (pure ())
                                                     >> next
                                             | otherwise ->
                                                 chooseSelectedAccount
-                                                    selectedId
+                                                    selectedSelectionId
                                     AccountPickerConnect -> do
                                         color <- resolveColor stderr
                                         connected <-
                                             withFullscreenSuspended runtime $
                                                 connectProviderAccount
                                                     color
-                                                    OpenAIProvider
+                                                    provider
                                         case connected of
                                             Nothing -> next
-                                            Just selectedId ->
-                                                chooseSelectedAccount
-                                                    selectedId
+                                            Just selectedAccountId -> do
+                                                refreshed <-
+                                                    loadProviderAccountPickerOptions
+                                                        provider
+                                                        (maybe
+                                                            SubscriptionBilled
+                                                            tokenProviderBillingMode
+                                                            tokenProvider)
+                                                        currentSelectionId
+                                                let connectedSelection =
+                                                        [ selectionId
+                                                        | AccountPickerAccount
+                                                            selectionId
+                                                            accountId
+                                                            _
+                                                            _ <- refreshed
+                                                        , accountId
+                                                            == selectedAccountId
+                                                        ]
+                                                chooseSelectedAccount $
+                                                    fromMaybe
+                                                        selectedAccountId
+                                                        (listToMaybe
+                                                            connectedSelection)
                         _ -> next
               where
                 chooseSelectedAccount selectedId =
-                    case selectAccount of
-                        Nothing -> next
-                        Just select -> do
-                            select selectedId >>= \case
-                                Left err -> do
-                                    now <- getCurrentTime
-                                    let message =
-                                            "could not select account: "
-                                                <> formatApiErrorInlineAt
-                                                    now
-                                                    err
-                                    displayError message (pure ())
-                                    next
-                                Right label -> do
-                                    displayInfo
-                                        ("account switched to " <> label)
-                                        (pure ())
-                                    next
+                    select selectedId >>= \case
+                        Left err -> do
+                            now <- getCurrentTime
+                            let message =
+                                    "could not select account: "
+                                        <> formatApiErrorInlineAt
+                                            now
+                                            err
+                            displayError message (pure ())
+                            next
+                        Right label -> do
+                            displayInfo
+                                ("account switched to " <> label)
+                                (pure ())
+                            next
             _ -> do
                 displayError
-                    "Account switching is only available for ChatGPT subscription accounts."
+                    "Account switching is unavailable for this session."
                     (pure ())
                 next
     copyCommand label missing payload = case payload of
@@ -3444,28 +3634,93 @@ loadAccountPickerOptions resolveLabel pool = do
         pure $
             AccountPickerAccount
                 auth.accountId
+                auth.accountId
                 label
                 (formatUsageSummary
                     now
                     snapshot.snapshotCooldownUntil
                     usage)
 
+loadProviderAccountPickerOptions
+    :: Provider
+    -> BillingMode
+    -> Text
+    -> IO [AccountPickerOption]
+loadProviderAccountPickerOptions provider billing _currentSelectionId = do
+    discovered <- discoverSelectableLoginAccounts
+    refreshed <-
+        mapConcurrently refreshLoginAccount
+            [ account
+            | account <- discovered
+            , account.loginProvider == provider
+            , accountBillingMode provider account.loginBilling == billing
+            ]
+    now <- getCurrentTime
+    pure $
+        [ AccountPickerAccount
+            (loginAccountSelectionId account)
+            account.loginAccountId
+            account.loginLabel
+            (formatLoginUsageSummary provider now account)
+        | account <- refreshed
+        ]
+            <> [AccountPickerConnect]
+
+accountBillingMode :: Provider -> AccountBilling -> BillingMode
+accountBillingMode provider = case provider of
+    OpenRouterProvider -> const ApiBilled
+    _ -> \case
+        SubscriptionBilling _ -> SubscriptionBilled
+        ApiCreditsBilling -> ApiBilled
+
+formatLoginUsageSummary :: Provider -> UTCTime -> LoginAccount -> Text
+formatLoginUsageSummary provider now account =
+    Text.intercalate " · " $
+        billing <> case account.loginUsage of
+            UsageNotChecked -> []
+            UsageUnavailable _ -> ["usage unavailable"]
+            UsageAvailable usage ->
+                maybeToList usage.usagePlan
+                    <> map summarizeWindow usage.usageWindows
+                    <> maybeToList
+                        (("credits " <>) <$> usage.creditsRemaining)
+                    <> maybeToList
+                        (("used " <>) <$> usage.creditsUsed)
+  where
+    billing = case accountBillingMode provider account.loginBilling of
+        ApiBilled -> ["API credits"]
+        SubscriptionBilled -> case account.loginBilling of
+            SubscriptionBilling plan ->
+                maybe ["subscription"] (\value -> ["subscription", value]) plan
+            ApiCreditsBilling -> ["subscription"]
+    summarizeWindow window =
+        window.windowName
+            <> " "
+            <> Text.pack (show (max 0 (100 - window.usedPercent)))
+            <> "% left"
+            <> if window.resetsAt > now
+                then " · resets "
+                    <> formatDuration (diffUTCTime window.resetsAt now)
+                else ""
+    maybeToList = maybe [] pure
+
 accountPickerMatches :: Text -> AccountPickerOption -> Bool
-accountPickerMatches currentAccountId = \case
-    AccountPickerAccount accountPickerId _ _ ->
-        accountPickerId == currentAccountId
+accountPickerMatches currentSelectionId = \case
+    AccountPickerAccount selectionId _ _ _ ->
+        selectionId == currentSelectionId
     AccountPickerConnect -> False
 
 accountPickerRow
     :: Text
     -> AccountPickerOption
     -> (Text, Text)
-accountPickerRow currentAccountId = \case
+accountPickerRow currentSelectionId = \case
     AccountPickerAccount
-        accountPickerId
+        selectionId
+        _
         accountPickerLabel
         accountPickerUsage ->
-            ( (if accountPickerId == currentAccountId then "✓ " else "")
+            ( (if selectionId == currentSelectionId then "✓ " else "")
                 <> accountPickerLabel
             , accountPickerUsage
             )
@@ -3953,28 +4208,31 @@ reloadAuth provider = \case
                 <> "restart after refreshing ~/.codex/auth.json "
                 <> "(OAuth pools already rotate on handshake failure)"
     Just tokenProvider ->
-        -- Force a disk/env re-read by pretending the cached credential was
-        -- rejected for authentication; the reloadable provider clears its cache.
-        getNextToken tokenProvider (Just FailedCredential
-            { credential = Credential
-                { accessToken = ""
-                , accountId = ""
-                , leaseId = Nothing
-                , provider
-                }
-            , failure = AccountAuthenticationRejected
-            }) >>= \case
+        -- Force a disk/env re-read by rejecting the credential that is
+        -- actually active. Switchable providers intentionally ignore failures
+        -- from older accounts, so a fabricated empty account id is insufficient.
+        getNextToken tokenProvider Nothing >>= \case
             Left err -> do
                 now <- getCurrentTime
                 pure $ Left $
                     "reload-auth failed: " <> formatApiErrorInlineAt now err
-            Right credential ->
-                pure $ Right $
-                    "auth reloaded ("
-                        <> providerSlug provider
-                        <> " account "
-                        <> credential.accountId
-                        <> ")"
+            Right current ->
+                getNextToken tokenProvider (Just FailedCredential
+                    { credential = current
+                    , failure = AccountAuthenticationRejected
+                    }) >>= \case
+                    Left err -> do
+                        now <- getCurrentTime
+                        pure $ Left $
+                            "reload-auth failed: "
+                                <> formatApiErrorInlineAt now err
+                    Right credential ->
+                        pure $ Right $
+                            "auth reloaded ("
+                                <> providerSlug provider
+                                <> " account "
+                                <> credential.accountId
+                                <> ")"
 
 
 requestReload

--- a/packages/agent-cli/src/Agent/CLI/Auth.hs
+++ b/packages/agent-cli/src/Agent/CLI/Auth.hs
@@ -7,13 +7,17 @@ module Agent.CLI.Auth
     , grokAuthStateFromJson
     , grokAuthStateToJson
     , grokEmailFromAuthJson
+    , externalAuthSelectionId
     , loadAuth
+    , loadAuthForAccount
+    , managedAuthSelectionId
     , managedGrokTokenProvider
     , openAIOAuthClientId
     , openAiAuthStateChanged
     , openaiAuthStateFromJson
     , preferredOpenAiTokenProvider
     , probeLoadedAuth
+    , probeLoadedAuthCredential
     , reloadableFileCredentialProvider
     , staticCredentialProvider
     , xaiOAuthClientId
@@ -47,7 +51,7 @@ import Agent.Provider
     , tokenProviderBillingMode
     )
 import Agent.OpenRouter.Credential (credentialFromApiKey)
-import Agent.OsPath (unsafeToFilePath)
+import Agent.OsPath (toText, unsafeToFilePath)
 import qualified Agent.XAI.Auth as XAIAuth
 import Control.Applicative ((<|>))
 import Control.Concurrent.MVar (MVar, newMVar, withMVar)
@@ -114,9 +118,18 @@ data LoadedAuth = LoadedAuth
     { loadedProvider :: !Provider
     , loadedTokenProvider :: !TokenProvider
     , loadedAccountLabel :: !(Credential -> IO Text)
+    -- | Stable credential-source key used by the account picker.
+    , loadedSelectionId :: !(Maybe Text)
     -- | Live OpenAI OAuth pool, when authentication uses one.
     , loadedOpenAiPool :: !(Maybe OpenAI.Pool)
     }
+
+managedAuthSelectionId :: Text -> Text
+managedAuthSelectionId managedId = "managed:" <> managedId
+
+externalAuthSelectionId :: Provider -> Text -> Text
+externalAuthSelectionId provider source =
+    "external:" <> providerSlug provider <> ":" <> source
 
 -- | Human-readable identity for the credential most recently selected by a
 -- provider. Prefer an email claim, then fall back to a compact account id.
@@ -173,14 +186,32 @@ loadAuth :: Maybe Provider -> IO (Either Text LoadedAuth)
 loadAuth requested = runExceptT do
     provider <- detectProvider requested
     case provider of
-        XAIProvider -> loadXai
+        XAIProvider -> loadXai Nothing
         OpenAIProvider -> loadOpenAi
-        OpenRouterProvider -> loadOpenRouter
+        OpenRouterProvider -> loadOpenRouter Nothing
+
+-- | Load one specific account for providers whose HTTP backends can swap
+-- token sources without reconnecting a long-lived transport.
+loadAuthForAccount :: Provider -> Text -> IO (Either Text LoadedAuth)
+loadAuthForAccount provider selectionId = runExceptT case provider of
+    XAIProvider -> loadXai (Just selectionId)
+    OpenRouterProvider -> loadOpenRouter (Just selectionId)
+    OpenAIProvider ->
+        throwE "OpenAI account selection is handled by the live account pool"
 
 -- | Ask the token source whether it has a usable credential now without
 -- making a model request, preserving a successful checkout for later use.
 probeLoadedAuth :: LoadedAuth -> IO (Either ApiError LoadedAuth)
-probeLoadedAuth loaded = do
+probeLoadedAuth loaded =
+    fmap snd <$> probeLoadedAuthCredential loaded
+
+-- | Validate the current token source and preserve the checked credential for
+-- the next real request. Returning the credential lets the UI show the active
+-- account before an HTTP backend performs its first checkout.
+probeLoadedAuthCredential
+    :: LoadedAuth
+    -> IO (Either ApiError (Credential, LoadedAuth))
+probeLoadedAuthCredential loaded = do
     result <- getNextToken loaded.loadedTokenProvider Nothing
     case result of
         Left err -> pure (Left err)
@@ -191,7 +222,10 @@ probeLoadedAuth loaded = do
             | otherwise -> do
                 tokenProvider <-
                     seedTokenProvider loaded.loadedTokenProvider credential
-                pure $ Right loaded { loadedTokenProvider = tokenProvider }
+                pure $ Right
+                    ( credential
+                    , loaded { loadedTokenProvider = tokenProvider }
+                    )
 
 -- | Pin normal checkouts to one OpenAI pool account until that credential is
 -- reported as failed. A failure for the selected credential clears the pin
@@ -254,9 +288,9 @@ detectProvider Nothing = do
                 then pure OpenRouterProvider
                 else throwE noAuthHint
 
-loadXai :: ExceptT Text IO LoadedAuth
-loadXai = do
-    managed <- lift (loadManagedCredential XAIProvider)
+loadXai :: Maybe Text -> ExceptT Text IO LoadedAuth
+loadXai requestedSelectionId = do
+    managed <- lift (loadManagedCredential XAIProvider requestedSelectionId)
     case managed of
         Just (metadata, secret)
             | metadata.managedAuthKind == ManagedGrokAuthJson -> do
@@ -280,6 +314,8 @@ loadXai = do
                     , loadedTokenProvider = provider
                     , loadedAccountLabel =
                         pure . credentialAccountLabelWith metadata.managedLabel
+                    , loadedSelectionId =
+                        Just (managedAuthSelectionId metadata.managedId)
                     , loadedOpenAiPool = Nothing
                     }
         Just (metadata, secret) ->
@@ -294,62 +330,102 @@ loadXai = do
                         }
                 , loadedAccountLabel =
                     pure . credentialAccountLabelWith metadata.managedLabel
+                , loadedSelectionId =
+                    Just (managedAuthSelectionId metadata.managedId)
                 , loadedOpenAiPool = Nothing
                 }
         Nothing -> do
-            credential <- lift loadExternalGrokCredential
-            case credential of
-                Nothing -> throwE noAuthHint
-                Just loaded -> do
+            selected <- lift $
+                selectExternalCredential
+                    requestedSelectionId
+                    <$> loadExternalGrokCredentials
+            case selected of
+                Nothing ->
+                    throwE $
+                        maybe noAuthHint
+                            (const
+                                (accountNotFound
+                                    XAIProvider requestedSelectionId))
+                            requestedSelectionId
+                Just (selectionId, loaded) -> do
                     provider <- lift $ reloadableFileCredentialProvider
                         XAIProvider
                         SubscriptionBilled
                         loaded
-                        loadExternalGrokCredential
+                        (fmap snd
+                            . selectExternalCredential (Just selectionId)
+                            <$> loadExternalGrokCredentials)
                     pure LoadedAuth
                         { loadedProvider = XAIProvider
                         , loadedTokenProvider = provider
                         , loadedAccountLabel = pure . credentialAccountLabel
+                        , loadedSelectionId = Just selectionId
                         , loadedOpenAiPool = Nothing
                         }
 
-loadOpenRouterCredential :: IO (Maybe (Credential, Text))
-loadOpenRouterCredential = do
-    managed <- loadManagedCredential OpenRouterProvider
+loadOpenRouterCredential
+    :: Maybe Text
+    -> IO (Maybe (Text, Credential, Text))
+loadOpenRouterCredential requestedSelectionId = do
+    managed <- loadManagedCredential OpenRouterProvider requestedSelectionId
     case managed of
         Just (metadata, secret) ->
             pure $ Just
-                ( (credentialFromApiKey secret.secretPayload)
+                ( managedAuthSelectionId metadata.managedId
+                , (credentialFromApiKey secret.secretPayload)
                     { accountId = metadata.managedAccountId }
                 , metadata.managedLabel
                 )
-        Nothing ->
-            fmap (\key -> (credentialFromApiKey key, "")) <$>
-                lookupNonEmpty "OPENROUTER_API_KEY"
+        Nothing -> do
+            external <- fmap
+                (\key ->
+                    ( externalAuthSelectionId
+                        OpenRouterProvider
+                        "environment"
+                    , (credentialFromApiKey key)
+                        { accountId = "openrouter" }
+                    , ""
+                    ))
+                <$> lookupNonEmpty "OPENROUTER_API_KEY"
+            pure $ external >>= \candidate@(selectionId, credential, _) ->
+                if matchesSelection
+                    requestedSelectionId
+                    selectionId
+                    credential
+                    then Just candidate
+                    else Nothing
 
-loadOpenRouter :: ExceptT Text IO LoadedAuth
-loadOpenRouter = do
-    loadedCredential <- lift loadOpenRouterCredential
+loadOpenRouter :: Maybe Text -> ExceptT Text IO LoadedAuth
+loadOpenRouter requestedSelectionId = do
+    loadedCredential <- lift (loadOpenRouterCredential requestedSelectionId)
     case loadedCredential of
-        Nothing -> throwE noAuthHint
-        Just (initial, initialLabel) -> do
+        Nothing ->
+            throwE $
+                maybe noAuthHint
+                    (const
+                        (accountNotFound
+                            OpenRouterProvider requestedSelectionId))
+                    requestedSelectionId
+        Just (selectionId, initial, initialLabel) -> do
             provider <- lift $ reloadableFileCredentialProvider
                 OpenRouterProvider
                 ApiBilled
                 initial
-                (fmap (fmap fst) loadOpenRouterCredential)
+                (fmap (\(_, credential, _) -> credential)
+                    <$> loadOpenRouterCredential (Just selectionId))
             pure LoadedAuth
                 { loadedProvider = OpenRouterProvider
                 , loadedTokenProvider = provider
                 , loadedAccountLabel = \credential -> do
-                    current <- loadOpenRouterCredential
+                    current <- loadOpenRouterCredential (Just selectionId)
                     let label = case current of
-                            Just (currentCredential, currentLabel)
+                            Just (_, currentCredential, currentLabel)
                                 | currentCredential.accountId
                                     == credential.accountId ->
                                         currentLabel
                             _ -> initialLabel
                     pure (credentialAccountLabelWith label credential)
+                , loadedSelectionId = Just selectionId
                 , loadedOpenAiPool = Nothing
                 }
 
@@ -392,6 +468,7 @@ loadOpenAi = do
                         . (.accountId)
                         . (.openAiState))
                     currentAccounts)
+        , loadedSelectionId = Nothing
         , loadedOpenAiPool = Just pool
         }
 
@@ -769,8 +846,9 @@ persistRefreshedOpenAiAccount source newState = do
 
 loadManagedCredential
     :: Provider
+    -> Maybe Text
     -> IO (Maybe (ManagedCredential, ManagedSecret))
-loadManagedCredential provider =
+loadManagedCredential provider requestedSelectionId =
     loadManagedCredentials >>= \case
         Left _ -> pure Nothing
         Right credentials ->
@@ -779,7 +857,17 @@ loadManagedCredential provider =
                 | (metadata, secret) <- credentials
                 , metadata.managedEnabled
                 , metadata.managedProvider == provider
+                , matchesManagedSelection requestedSelectionId metadata
                 ]
+
+matchesManagedSelection :: Maybe Text -> ManagedCredential -> Bool
+matchesManagedSelection requested metadata =
+    case requested of
+        Nothing -> True
+        Just selectionId ->
+            case Text.stripPrefix "managed:" selectionId of
+                Just managedId -> metadata.managedId == managedId
+                Nothing -> metadata.managedAccountId == selectionId
 
 loadManagedCredentialById
     :: Text
@@ -839,8 +927,8 @@ authStateToJson state now = Aeson.object
         ]
     ]
 
-loadExternalGrokCredential :: IO (Maybe Credential)
-loadExternalGrokCredential = do
+loadExternalGrokCredentials :: IO [(Text, Credential)]
+loadExternalGrokCredentials = do
     fromJson <- lookupNonEmpty "GROK_AUTH_JSON"
     fromToken <- lookupNonEmpty "GROK_ACCESS_TOKEN"
     home <- getHomeDirectory
@@ -851,11 +939,15 @@ loadExternalGrokCredential = do
         then Just . TextEncoding.decodeUtf8 . LBS.toStrict
             <$> retryOnFileBusy (LBS.readFile (unsafeToFilePath filePath))
         else pure Nothing
-    let token =
-            (fromJson >>= grokCredentialFromAuthJson)
-                <|> fromToken
-                <|> (fileJson >>= grokCredentialFromAuthJson)
-    pure (fmap grokCredential token)
+    let environmentToken =
+            (fromJson >>= grokCredentialFromAuthJson) <|> fromToken
+        sourceCredential source token =
+            (externalAuthSelectionId XAIProvider source, grokCredential token)
+    pure $ catMaybes
+        [ sourceCredential "environment" <$> environmentToken
+        , sourceCredential (toText filePath)
+            <$> (fileJson >>= grokCredentialFromAuthJson)
+        ]
 
 grokCredentialFromAuthJson :: Text -> Maybe Text
 grokCredentialFromAuthJson raw =
@@ -1132,7 +1224,30 @@ hasOpenRouterAuth = do
 
 hasManagedProvider :: Provider -> IO Bool
 hasManagedProvider provider =
-    isJust <$> loadManagedCredential provider
+    isJust <$> loadManagedCredential provider Nothing
+
+matchesSelection :: Maybe Text -> Text -> Credential -> Bool
+matchesSelection requested selectionId credential =
+    maybe True
+        (\requestedId ->
+            requestedId == selectionId
+                || requestedId == credential.accountId)
+        requested
+
+selectExternalCredential
+    :: Maybe Text
+    -> [(Text, Credential)]
+    -> Maybe (Text, Credential)
+selectExternalCredential requested =
+    find (\(selectionId, credential) ->
+        matchesSelection requested selectionId credential)
+
+accountNotFound :: Provider -> Maybe Text -> Text
+accountNotFound provider requested =
+    "no enabled "
+        <> providerSlug provider
+        <> " credential found for account "
+        <> fromMaybe "(unknown)" requested
 
 -- | Cache one credential and only re-read disk/env after the provider rejects
 -- it for authentication. Rate-limit failures stay exhausted rather than

--- a/packages/agent-cli/src/Agent/CLI/Login.hs
+++ b/packages/agent-cli/src/Agent/CLI/Login.hs
@@ -10,17 +10,22 @@ module Agent.CLI.Login
     , applyLoginKey
     , connectProviderAccount
     , discoverLoginAccounts
+    , discoverSelectableLoginAccounts
     , formatLoginAccounts
     , initialLoginState
+    , loginAccountSelectionId
+    , refreshLoginAccount
     , renderLoginFrame
     , runLoginManager
     ) where
 
 import Agent.CLI.Auth
     ( GrokAuthState(..)
+    , externalAuthSelectionId
     , grokAuthStateToJson
     , grokCredentialFromAuthJson
     , grokEmailFromAuthJson
+    , managedAuthSelectionId
     , openAIOAuthClientId
     , openaiAuthStateFromJson
     , xaiOAuthClientId
@@ -285,6 +290,35 @@ replaceAt index replacement accounts =
 
 discoverLoginAccounts :: IO [LoginAccount]
 discoverLoginAccounts = do
+    accounts <- discoverLoginAccountSources
+    pure (nubBy sameAccount accounts)
+  where
+    sameAccount left right =
+        left.loginProvider == right.loginProvider
+            && left.loginAccountId == right.loginAccountId
+
+-- | Accounts that can be selected in a live session. Unlike the login
+-- dashboard, disabled managed entries do not shadow usable external sources,
+-- and distinct managed credentials remain separately addressable.
+discoverSelectableLoginAccounts :: IO [LoginAccount]
+discoverSelectableLoginAccounts = do
+    accounts <- filter (.loginEnabled) <$> discoverLoginAccountSources
+    pure (nubBy sameSelection accounts)
+  where
+    sameSelection left right =
+        loginAccountSelectionId left == loginAccountSelectionId right
+
+loginAccountSelectionId :: LoginAccount -> Text
+loginAccountSelectionId account =
+    case account.loginManagedId of
+        Just managedId -> managedAuthSelectionId managedId
+        Nothing ->
+            externalAuthSelectionId
+                account.loginProvider
+                account.loginSource
+
+discoverLoginAccountSources :: IO [LoginAccount]
+discoverLoginAccountSources = do
     home <- getHomeDirectory
     now <- getCurrentTime
     openaiEnv <- discoverOpenAIEnv
@@ -298,7 +332,7 @@ discoverLoginAccounts = do
     let managedAccounts = case managed of
             Left _ -> []
             Right entries -> map (managedLoginAccount now) entries
-    pure $ nubBy sameAccount $
+    pure $
         managedAccounts
             <> catMaybes
                 [ openaiEnv
@@ -307,10 +341,6 @@ discoverLoginAccounts = do
                 , grokFile
                 , openRouter
                 ]
-  where
-    sameAccount left right =
-        left.loginProvider == right.loginProvider
-            && left.loginAccountId == right.loginAccountId
 
 managedLoginAccount
     :: UTCTime

--- a/packages/agent-cli/src/Agent/CLI/SessionEnv.hs
+++ b/packages/agent-cli/src/Agent/CLI/SessionEnv.hs
@@ -59,6 +59,7 @@ data SessionEnv = SessionEnv
     , sessionUsage :: !(IORef TokenUsage)
     , sessionAccount :: !(IORef Text)
     , sessionAccountId :: !(IORef Text)
+    , sessionAccountSelectionId :: !(IORef Text)
     , sessionAccountLabel :: !(Credential -> IO Text)
     , sessionSelectAccount
         :: !(Maybe (Text -> IO (Either ApiError Text)))

--- a/packages/agent-cli/test/Agent/CLI/AuthSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/AuthSpec.hs
@@ -2,6 +2,7 @@ module Agent.CLI.AuthSpec (spec) where
 
 import Agent.CLI.Auth
 import Agent.CLI.CredentialStore
+import qualified Agent.CLI.Login as Login
 import Agent.Error (ApiError(..))
 import System.OsPath (OsPath, decodeUtf, unsafeEncodeUtf)
 import Agent.OpenAI.Auth (AuthState(..))
@@ -59,12 +60,261 @@ spec = do
                     , loadedTokenProvider = tokenProvider SubscriptionBilled \_ ->
                         pure (Left (CredentialsExhausted retryAt))
                     , loadedAccountLabel = pure . credentialAccountLabel
+                    , loadedSelectionId = Nothing
                     , loadedOpenAiPool = Nothing
                     }
             result <- probeLoadedAuth exhausted
             case result of
                 Left err -> err `shouldBe` CredentialsExhausted retryAt
                 Right _ -> expectationFailure "expected exhausted auth"
+
+        it "returns and seeds the credential used for the account display" do
+            calls <- newIORef (0 :: Int)
+            let first = Credential "first" "account-first" Nothing XAIProvider
+                second = Credential "second" "account-second" Nothing XAIProvider
+                loaded = LoadedAuth
+                    { loadedProvider = XAIProvider
+                    , loadedTokenProvider =
+                        tokenProvider SubscriptionBilled \_ -> do
+                            call <- atomicModifyIORef' calls \count ->
+                                (count + 1, count)
+                            pure (Right (if call == 0 then first else second))
+                    , loadedAccountLabel = pure . (.accountId)
+                    , loadedSelectionId = Nothing
+                    , loadedOpenAiPool = Nothing
+                    }
+            probeLoadedAuthCredential loaded >>= \case
+                Left err ->
+                    expectationFailure
+                        ("expected usable credential, got " <> show err)
+                Right (credential, usable) -> do
+                    credential `shouldBe` first
+                    getNextToken usable.loadedTokenProvider Nothing
+                        `shouldReturn` Right first
+                    getNextToken usable.loadedTokenProvider Nothing
+                        `shouldReturn` Right second
+
+    describe "loadAuthForAccount" do
+        it "loads the selected managed Grok account" $
+            withTempHome \_ ->
+                withEnv "GROK_AUTH_JSON" Nothing $
+                withEnv "GROK_ACCESS_TOKEN" Nothing do
+                    storeManagedAccount
+                        SubscriptionBilled
+                        XAIProvider
+                        "grok-a"
+                        "account-a"
+                        "first@example.com"
+                        True
+                        "token-a"
+                    storeManagedAccount
+                        SubscriptionBilled
+                        XAIProvider
+                        "grok-b"
+                        "account-b"
+                        "second@example.com"
+                        True
+                        "token-b"
+                    loadAuthForAccount XAIProvider "account-b" >>= \case
+                        Left err -> expectationFailure (Text.unpack err)
+                        Right loaded -> do
+                            (fmap
+                                (fmap (.accountId))
+                                (getNextToken
+                                    loaded.loadedTokenProvider
+                                    Nothing))
+                                `shouldReturn` Right "account-b"
+                            getNextToken loaded.loadedTokenProvider Nothing
+                                >>= \case
+                                    Left err ->
+                                        expectationFailure (show err)
+                                    Right credential ->
+                                        loaded.loadedAccountLabel credential
+                                            `shouldReturn`
+                                                "second@example.com"
+
+        it "loads the selected managed OpenRouter account" $
+            withTempHome \_ ->
+                withEnv "OPENROUTER_API_KEY" Nothing do
+                    storeManagedAccount
+                        ApiBilled
+                        OpenRouterProvider
+                        "router-a"
+                        "account-a"
+                        "OpenRouter A"
+                        True
+                        "key-a"
+                    storeManagedAccount
+                        ApiBilled
+                        OpenRouterProvider
+                        "router-b"
+                        "account-b"
+                        "OpenRouter B"
+                        True
+                        "key-b"
+                    loadAuthForAccount
+                        OpenRouterProvider
+                        "account-b"
+                        >>= \case
+                            Left err ->
+                                expectationFailure (Text.unpack err)
+                            Right loaded ->
+                                getNextToken
+                                    loaded.loadedTokenProvider
+                                    Nothing
+                                    >>= \case
+                                        Left err ->
+                                            expectationFailure (show err)
+                                        Right credential -> do
+                                            credential.accountId
+                                                `shouldBe` "account-b"
+                                            loaded.loadedAccountLabel credential
+                                                `shouldReturn`
+                                                    "OpenRouter B"
+
+        it "selects duplicate OpenRouter account labels by managed id" $
+            withTempHome \_ ->
+                withEnv "OPENROUTER_API_KEY" Nothing do
+                    storeManagedAccount
+                        ApiBilled
+                        OpenRouterProvider
+                        "router-a"
+                        "shared-label"
+                        "OpenRouter A"
+                        True
+                        "key-a"
+                    storeManagedAccount
+                        ApiBilled
+                        OpenRouterProvider
+                        "router-b"
+                        "shared-label"
+                        "OpenRouter B"
+                        True
+                        "key-b"
+                    loadAuthForAccount
+                        OpenRouterProvider
+                        (managedAuthSelectionId "router-b")
+                        >>= \case
+                            Left err ->
+                                expectationFailure (Text.unpack err)
+                            Right loaded -> do
+                                loaded.loadedSelectionId
+                                    `shouldBe`
+                                        Just
+                                            (managedAuthSelectionId
+                                                "router-b")
+                                getNextToken
+                                    loaded.loadedTokenProvider
+                                    Nothing
+                                    >>= \case
+                                        Left err ->
+                                            expectationFailure (show err)
+                                        Right credential ->
+                                            credential.accessToken
+                                                `shouldBe` "key-b"
+
+        it "loads a Grok auth file even when a different env source exists" $
+            withTempHome \home ->
+                withEnv "GROK_AUTH_JSON" Nothing $
+                withEnv "GROK_ACCESS_TOKEN" (Just "env-token") do
+                    let grokDirectory = toFilePath home </> ".grok"
+                        authPath = grokDirectory </> "auth.json"
+                        selectionId =
+                            externalAuthSelectionId
+                                XAIProvider
+                                (Text.pack authPath)
+                    createDirectoryIfMissing True grokDirectory
+                    LBS.writeFile authPath $
+                        Aeson.encode $
+                            Aeson.object
+                                [ "access_token" .= ("file-token" :: Text)
+                                ]
+                    loadAuthForAccount XAIProvider selectionId >>= \case
+                        Left err ->
+                            expectationFailure (Text.unpack err)
+                        Right loaded -> do
+                            loaded.loadedSelectionId
+                                `shouldBe` Just selectionId
+                            getNextToken
+                                loaded.loadedTokenProvider
+                                Nothing
+                                >>= \case
+                                    Left err ->
+                                        expectationFailure (show err)
+                                    Right credential ->
+                                        credential.accessToken
+                                            `shouldBe` "file-token"
+
+        it "rejects an unknown or disabled managed account" $
+            withTempHome \_ ->
+                withEnv "GROK_AUTH_JSON" Nothing $
+                withEnv "GROK_ACCESS_TOKEN" Nothing do
+                    storeManagedAccount
+                        SubscriptionBilled
+                        XAIProvider
+                        "grok-disabled"
+                        "account-disabled"
+                        "Disabled"
+                        False
+                        "token-disabled"
+                    loadAuthForAccount
+                        XAIProvider
+                        "account-disabled"
+                        >>= \case
+                            Left err ->
+                                err `shouldBe`
+                                    "no enabled xai credential found for account account-disabled"
+                            Right _ ->
+                                expectationFailure
+                                    "expected disabled account selection to fail"
+
+        it "uses the same stable id for an OpenRouter environment account" $
+            withTempHome \_ ->
+                withEnv "OPENROUTER_API_KEY" (Just "openrouter-key") do
+                    let selectionId =
+                            externalAuthSelectionId
+                                OpenRouterProvider
+                                "environment"
+                    loadAuthForAccount
+                        OpenRouterProvider
+                        selectionId
+                        >>= \case
+                            Left err ->
+                                expectationFailure (Text.unpack err)
+                            Right loaded -> do
+                                loaded.loadedSelectionId
+                                    `shouldBe` Just selectionId
+                                (fmap
+                                    (fmap (.accountId))
+                                    (getNextToken
+                                        loaded.loadedTokenProvider
+                                        Nothing))
+                                    `shouldReturn` Right "openrouter"
+
+    describe "discoverSelectableLoginAccounts" do
+        it "does not let a disabled managed account shadow an external source" $
+            withTempHome \_ ->
+                withCleanGrokEnv $
+                withEnv "GROK_ACCESS_TOKEN" (Just "external-token") do
+                    storeManagedAccount
+                        SubscriptionBilled
+                        XAIProvider
+                        "disabled-grok"
+                        "grok"
+                        "Disabled"
+                        False
+                        "disabled-token"
+                    accounts <- Login.discoverSelectableLoginAccounts
+                    let grokAccounts =
+                            filter
+                                ((== XAIProvider) . (.loginProvider))
+                                accounts
+                    map Login.loginAccountSelectionId grokAccounts
+                        `shouldBe`
+                            [ externalAuthSelectionId
+                                XAIProvider
+                                "environment"
+                            ]
 
     describe "credentialAccountLabel" do
         it "prefers an email claim over the provider account id" do
@@ -629,6 +879,36 @@ storeOpenAiAccountWithBilling billing credentialId accountId enabled token =
         (openAiMetadata billing credentialId accountId enabled)
         (ManagedSecret credentialId (authJson accountId token))
         `shouldReturn` Right ()
+
+storeManagedAccount
+    :: BillingMode
+    -> Provider
+    -> Text
+    -> Text
+    -> Text
+    -> Bool
+    -> Text
+    -> IO ()
+storeManagedAccount
+    billing
+    provider
+    credentialId
+    accountId
+    label
+    enabled
+    token =
+        upsertManagedCredential
+            ManagedCredential
+                { managedId = credentialId
+                , managedProvider = provider
+                , managedAccountId = accountId
+                , managedLabel = label
+                , managedBilling = billing
+                , managedAuthKind = ManagedBearerToken
+                , managedEnabled = enabled
+                }
+            (ManagedSecret credentialId token)
+            `shouldReturn` Right ()
 
 openAiMetadata
     :: BillingMode


### PR DESCRIPTION
## Summary
- show the active account selector immediately for Grok/xAI and OpenRouter sessions
- support live account switching for HTTP providers with stable credential-source IDs
- prevent stale background requests from reverting or poisoning a newly selected account
- preserve `/reload-auth` behavior and handle managed, environment, and file credential sources consistently

## Validation
- `nix develop -c cabal repl agent-cli:test:agent-cli-test` — 584 examples, 0 failures
- fullscreen tmux smoke test: Grok account displayed before the first request
- fullscreen tmux smoke test: OpenRouter account displayed and the account picker opened from the footer
