### PR TITLE
Fix fullscreen Markdown table layout

### DIFF
--- a/packages/agent-tui/src/Agent/TUI/Markdown.hs
+++ b/packages/agent-tui/src/Agent/TUI/Markdown.hs
@@ -29,6 +29,7 @@ import Data.Char
     , isSpace
     )
 import qualified Data.List as List
+import Data.Maybe (fromMaybe, isJust, mapMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Lazy as LazyText
@@ -244,20 +245,28 @@ isThematicBreak line =
 
 takeTable :: [Text] -> Maybe (Widget n, [Text])
 takeTable (rawHeader : separator : rest)
-    | isTableRow rawHeader
-    , isSeparatorRow separator =
+    | Just headerCells <- splitTableRow rawHeader
+    , Just separatorCells <- splitTableRow separator
+    , length separatorCells == length headerCells
+    , all isSeparatorCell separatorCells =
         let
             (body, after) = span isTableRow rest
-            rows = map splitRow (rawHeader : body)
+            rows = headerCells : mapMaybe splitTableRow body
         in Just (tableWidget rows, after)
 takeTable _ = Nothing
+
+isSeparatorCell :: Text -> Bool
+isSeparatorCell cell =
+    Text.any (== '-') cell
+        && Text.null
+            (Text.filter (`notElem` ['-', ':', ' ']) cell)
 
 -- | Render a table against the width Brick actually gives it. Natural column
 -- widths are only preferences: short columns keep their size while verbose
 -- columns share the remaining space and wrap inside it.
 tableWidget :: [[Text]] -> Widget n
 tableWidget [] = emptyWidget
-tableWidget rows =
+tableWidget rows@(headerCells : _) =
     B.Widget B.Greedy B.Fixed do
         context <- B.getContext
         borderAttr <- B.lookupAttrName Theme.mutedAttr
@@ -276,16 +285,22 @@ tableWidget rows =
                         cells)
                 (zip [0 :: Int ..] normalizedRows)
         let availableWidth = max 1 context.availWidth
+            gridMinimumWidth =
+                columnCount + 1 + sum minimumWidths
+            paddedGridMinimumWidth =
+                gridMinimumWidth + 2 * columnCount
+            gridFits = availableWidth >= gridMinimumWidth
             horizontalPadding =
-                if availableWidth >= 4 * columnCount + 1
+                if availableWidth >= paddedGridMinimumWidth
                     then 1
                     else 0
             chromeWidth =
                 columnCount + 1
                     + 2 * horizontalPadding * columnCount
-            contentBudget =
-                max columnCount (availableWidth - chromeWidth)
-            widths = fitColumnWidths contentBudget naturalWidths
+            contentBudget = max 0 (availableWidth - chromeWidth)
+            widths =
+                fitColumnWidths
+                    contentBudget minimumWidths naturalWidths
             top = tableRule borderAttr horizontalPadding '┌' '┬' '┐' widths
             divider =
                 tableRule borderAttr horizontalPadding '├' '┼' '┤' widths
@@ -303,14 +318,17 @@ tableWidget rows =
                                     borderAttr bodyAttr horizontalPadding widths)
                                 body
             image =
-                V.vertCat (top : renderedRows <> [bottom])
+                if gridFits
+                    then V.vertCat (top : renderedRows <> [bottom])
+                    else compactTableImage
+                        availableWidth borderAttr styledRows
             boundedImage
                 | V.imageWidth image > availableWidth =
                     V.cropRight availableWidth image
                 | otherwise = image
         pure B.emptyResult { B.image = boundedImage }
   where
-    columnCount = maximum (0 : map length rows)
+    columnCount = length headerCells
     normalizedRows =
         [ take columnCount (cells <> repeat "")
         | cells <- rows
@@ -324,6 +342,15 @@ tableWidget rows =
                   ])
         | columnIndex <- [0 .. columnCount - 1]
         ]
+    minimumWidths =
+        [ maximum
+            (1
+                : [ cellMinimumWidth cell
+                  | row <- normalizedRows
+                  , cell <- take 1 (drop columnIndex row)
+                  ])
+        | columnIndex <- [0 .. columnCount - 1]
+        ]
 
 cellDisplayWidth :: Text -> Int
 cellDisplayWidth =
@@ -331,18 +358,30 @@ cellDisplayWidth =
         . inlinePlainText
         . parseInline
 
+cellMinimumWidth :: Text -> Int
+cellMinimumWidth =
+    maximum
+        . (1 :)
+        . map terminalCharWidth
+        . Text.unpack
+        . inlinePlainText
+        . parseInline
+
 -- | Fairly distribute a fixed content budget. Each column starts at one cell;
 -- columns that reach their natural width drop out while the longer columns
 -- continue growing.
-fitColumnWidths :: Int -> [Int] -> [Int]
-fitColumnWidths budget naturalWidths
-    | null naturalWidths = []
+fitColumnWidths :: Int -> [Int] -> [Int] -> [Int]
+fitColumnWidths budget minimumWidths naturalWidths
+    | null preferred = []
     | sum preferred <= budget = preferred
     | otherwise =
-        grow (replicate (length preferred) 1)
-            (max 0 (budget - length preferred))
+        grow minimum (max 0 (budget - sum minimum))
   where
-    preferred = map (max 1) naturalWidths
+    minimum = map (max 1) minimumWidths
+    preferred =
+        zipWith max
+            (minimum <> repeat 1)
+            (map (max 1) naturalWidths)
 
     grow widths remaining
         | remaining <= 0 = widths
@@ -359,6 +398,29 @@ fitColumnWidths budget naturalWidths
             (remaining - 1, current + 1)
         | otherwise =
             (remaining, current)
+
+compactTableImage
+    :: Int
+    -> V.Attr
+    -> [[[(V.Attr, Text)]]]
+    -> V.Image
+compactTableImage width borderAttr rows =
+    V.vertCat $
+        concat
+            [ map renderStyledLine $
+                wrapStyledWords width $
+                    List.intercalate
+                        [(borderAttr, " │ ")]
+                        cells
+            | cells <- rows
+            ]
+
+renderStyledLine :: [(V.Attr, Text)] -> V.Image
+renderStyledLine fragments =
+    V.horizCat
+        [ V.text attr (LazyText.fromStrict text)
+        | (attr, text) <- fragments
+        ]
 
 tableRule
     :: V.Attr
@@ -423,7 +485,7 @@ renderTableCell paddingAttr horizontalPadding width fragments =
     V.horizCat
         [ blank horizontalPadding
         , content
-        , blank (max 0 (width - V.imageWidth content))
+        , blank (max 0 (width - fragmentsDisplayWidth fragments))
         , blank horizontalPadding
         ]
   where
@@ -436,27 +498,101 @@ renderTableCell paddingAttr horizontalPadding width fragments =
         | count <= 0 = V.emptyImage
         | otherwise = V.charFill paddingAttr ' ' count 1
 
+fragmentsDisplayWidth :: [(V.Attr, Text)] -> Int
+fragmentsDisplayWidth =
+    sum
+        . map
+            (Text.foldl'
+                (\width character -> width + terminalCharWidth character)
+                0
+                . snd)
+
 isTableRow :: Text -> Bool
-isTableRow line =
-    let stripped = Text.strip line
-    in Text.isPrefixOf "|" stripped && Text.count "|" stripped >= 2
+isTableRow = isJust . splitTableRow
 
-isSeparatorRow :: Text -> Bool
-isSeparatorRow line =
-    isTableRow line && all isSeparatorCell (splitRow line)
+-- | Split a pipe row on actual column delimiters. Escaped pipes and pipes
+-- inside matching backtick spans remain part of their cell.
+splitTableRow :: Text -> Maybe [Text]
+splitTableRow raw =
+    let stripped = Text.strip raw
+        content = fromMaybe stripped (Text.stripPrefix "|" stripped)
+        (cells, delimiterCount) = scan Nothing [] [] 0 False
+            (Text.unpack content)
+    in if delimiterCount >= 1
+        then Just cells
+        else Nothing
   where
-    isSeparatorCell cell =
-        Text.any (== '-') cell
-            && Text.null
-                (Text.filter (`notElem` ['-', ':', ' ']) cell)
+    scan
+        :: Maybe Int
+        -> String
+        -> [Text]
+        -> Int
+        -> Bool
+        -> String
+        -> ([Text], Int)
+    scan _ current cells delimiterCount trailingDelimiter [] =
+        let allCells =
+                reverse
+                    (finishCell current : cells)
+            withoutOuterBorder
+                | trailingDelimiter = dropLast allCells
+                | otherwise = allCells
+        in (withoutOuterBorder, delimiterCount)
+    scan codeRun current cells delimiterCount _ ('\\' : rest) =
+        let (slashes, afterSlashes) = span (== '\\') rest
+            slashCount = 1 + length slashes
+            literalSlashes = replicate
+                (if startsWithPipe afterSlashes
+                    then slashCount `div` 2
+                    else slashCount)
+                '\\'
+            current' = literalSlashes <> current
+        in case afterSlashes of
+            '|' : afterPipe
+                | odd slashCount ->
+                    scan codeRun ('|' : current') cells
+                        delimiterCount False afterPipe
+                | codeRun == Nothing ->
+                    splitCell codeRun current' cells
+                        delimiterCount afterPipe
+            _ ->
+                scan codeRun current' cells
+                    delimiterCount False afterSlashes
+    scan codeRun current cells delimiterCount _ ('`' : rest) =
+        let (ticks, afterTicks) = span (== '`') rest
+            tickCount = 1 + length ticks
+            marker = replicate tickCount '`'
+            nextCodeRun = case codeRun of
+                Just openCount
+                    | tickCount >= openCount -> Nothing
+                Just openCount -> Just openCount
+                Nothing
+                    | hasClosingRun tickCount afterTicks ->
+                        Just tickCount
+                Nothing -> Nothing
+        in scan nextCodeRun (marker <> current) cells
+            delimiterCount False afterTicks
+    scan Nothing current cells delimiterCount _ ('|' : rest) =
+        splitCell Nothing current cells delimiterCount rest
+    scan codeRun current cells delimiterCount _ (character : rest) =
+        scan codeRun (character : current) cells
+            delimiterCount False rest
 
-splitRow :: Text -> [Text]
-splitRow =
-    map Text.strip
-        . Text.splitOn "|"
-        . Text.dropWhileEnd (== '|')
-        . Text.dropWhile (== '|')
-        . Text.strip
+    splitCell codeRun current cells delimiterCount rest =
+        scan codeRun [] (finishCell current : cells)
+            (delimiterCount + 1) True rest
+
+    finishCell = Text.strip . Text.pack . reverse
+
+    startsWithPipe ('|' : _) = True
+    startsWithPipe _ = False
+
+    hasClosingRun count =
+        Text.isInfixOf (Text.replicate count "`") . Text.pack
+
+    dropLast values = case reverse values of
+        _ : rest -> reverse rest
+        [] -> []
 
 asumPrefix :: [Text] -> Text -> Maybe Text
 asumPrefix prefixes text = case prefixes of

--- a/packages/agent-tui/src/Agent/TUI/Markdown.hs
+++ b/packages/agent-tui/src/Agent/TUI/Markdown.hs
@@ -28,7 +28,6 @@ import Data.Char
     ( isDigit
     , isSpace
     )
-import Data.List (transpose)
 import qualified Data.List as List
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -250,39 +249,192 @@ takeTable (rawHeader : separator : rest)
         let
             (body, after) = span isTableRow rest
             rows = map splitRow (rawHeader : body)
-            headerCells = splitRow rawHeader
-            widths = map (maximum . (0 :) . map Text.length) (transpose rows)
-            renderRow headerRow cells =
-                hBox $
-                    [withAttr Theme.mutedAttr (txt "│")]
-                        <> concat
-                            [ [ padLeftRight 1 $
-                                    (if headerRow
-                                        then withAttr Theme.headingAttr
-                                        else id)
-                                    (hLimit width
-                                        (inlineWidget (parseInline cell)))
-                              , withAttr Theme.mutedAttr (txt "│")
-                              ]
-                            | (width, cell) <- zip widths
-                                (cells <> repeat "")
-                            ]
-            divider =
-                withAttr Theme.mutedAttr $
-                    txt $
-                        "├"
-                            <> Text.intercalate "┼"
-                                [ Text.replicate (width + 2) "─"
-                                | width <- widths
-                                ]
-                            <> "┤"
-        in Just
-            (vBox
-                (renderRow True headerCells
-                    : divider
-                    : map (renderRow False) (drop 1 rows))
-            , after)
+        in Just (tableWidget rows, after)
 takeTable _ = Nothing
+
+-- | Render a table against the width Brick actually gives it. Natural column
+-- widths are only preferences: short columns keep their size while verbose
+-- columns share the remaining space and wrap inside it.
+tableWidget :: [[Text]] -> Widget n
+tableWidget [] = emptyWidget
+tableWidget rows =
+    B.Widget B.Greedy B.Fixed do
+        context <- B.getContext
+        borderAttr <- B.lookupAttrName Theme.mutedAttr
+        headerAttr <- B.lookupAttrName Theme.headingAttr
+        bodyAttr <- B.lookupAttrName Theme.assistantAttr
+        styledRows <-
+            traverse
+                (\(rowIndex, cells) ->
+                    traverse
+                        (traverse
+                            (resolveInlineSpan
+                                (if rowIndex == 0
+                                    then Theme.headingAttr
+                                    else Theme.assistantAttr))
+                            . parseInline)
+                        cells)
+                (zip [0 :: Int ..] normalizedRows)
+        let availableWidth = max 1 context.availWidth
+            horizontalPadding =
+                if availableWidth >= 4 * columnCount + 1
+                    then 1
+                    else 0
+            chromeWidth =
+                columnCount + 1
+                    + 2 * horizontalPadding * columnCount
+            contentBudget =
+                max columnCount (availableWidth - chromeWidth)
+            widths = fitColumnWidths contentBudget naturalWidths
+            top = tableRule borderAttr horizontalPadding '┌' '┬' '┐' widths
+            divider =
+                tableRule borderAttr horizontalPadding '├' '┼' '┤' widths
+            bottom =
+                tableRule borderAttr horizontalPadding '└' '┴' '┘' widths
+            renderedRows =
+                case styledRows of
+                    [] -> []
+                    header : body ->
+                        renderTableRow
+                            borderAttr headerAttr horizontalPadding widths header
+                            : divider
+                            : map
+                                (renderTableRow
+                                    borderAttr bodyAttr horizontalPadding widths)
+                                body
+            image =
+                V.vertCat (top : renderedRows <> [bottom])
+            boundedImage
+                | V.imageWidth image > availableWidth =
+                    V.cropRight availableWidth image
+                | otherwise = image
+        pure B.emptyResult { B.image = boundedImage }
+  where
+    columnCount = maximum (0 : map length rows)
+    normalizedRows =
+        [ take columnCount (cells <> repeat "")
+        | cells <- rows
+        ]
+    naturalWidths =
+        [ maximum
+            (1
+                : [ cellDisplayWidth cell
+                  | row <- normalizedRows
+                  , cell <- take 1 (drop columnIndex row)
+                  ])
+        | columnIndex <- [0 .. columnCount - 1]
+        ]
+
+cellDisplayWidth :: Text -> Int
+cellDisplayWidth =
+    Text.foldl' (\width char -> width + terminalCharWidth char) 0
+        . inlinePlainText
+        . parseInline
+
+-- | Fairly distribute a fixed content budget. Each column starts at one cell;
+-- columns that reach their natural width drop out while the longer columns
+-- continue growing.
+fitColumnWidths :: Int -> [Int] -> [Int]
+fitColumnWidths budget naturalWidths
+    | null naturalWidths = []
+    | sum preferred <= budget = preferred
+    | otherwise =
+        grow (replicate (length preferred) 1)
+            (max 0 (budget - length preferred))
+  where
+    preferred = map (max 1) naturalWidths
+
+    grow widths remaining
+        | remaining <= 0 = widths
+        | otherwise =
+            let (remaining', widths') =
+                    List.mapAccumL grant remaining (zip preferred widths)
+            in if remaining' == remaining
+                then widths
+                else grow widths' remaining'
+
+    grant remaining (wanted, current)
+        | remaining > 0
+        , current < wanted =
+            (remaining - 1, current + 1)
+        | otherwise =
+            (remaining, current)
+
+tableRule
+    :: V.Attr
+    -> Int
+    -> Char
+    -> Char
+    -> Char
+    -> [Int]
+    -> V.Image
+tableRule attr horizontalPadding left middle right widths =
+    V.text' attr $
+        Text.singleton left
+            <> Text.intercalate
+                (Text.singleton middle)
+                [ Text.replicate
+                    (width + 2 * horizontalPadding)
+                    "─"
+                | width <- widths
+                ]
+            <> Text.singleton right
+
+renderTableRow
+    :: V.Attr
+    -> V.Attr
+    -> Int
+    -> [Int]
+    -> [[(V.Attr, Text)]]
+    -> V.Image
+renderTableRow borderAttr paddingAttr horizontalPadding widths cells =
+    V.vertCat
+        [ V.horizCat $
+            V.char borderAttr '│'
+                : concat
+                    [ [ renderTableCell
+                            paddingAttr horizontalPadding width fragments
+                      , V.char borderAttr '│'
+                      ]
+                    | (width, fragments) <- zip widths rowFragments
+                    ]
+        | rowFragments <- physicalRows
+        ]
+  where
+    wrappedCells =
+        zipWith
+            (\width spans -> wrapStyledWords (max 1 width) spans)
+            widths
+            (cells <> repeat [])
+    rowHeight = maximum (1 : map length wrappedCells)
+    physicalRows =
+        List.transpose
+            [ take rowHeight (wrapped <> repeat [])
+            | wrapped <- wrappedCells
+            ]
+
+renderTableCell
+    :: V.Attr
+    -> Int
+    -> Int
+    -> [(V.Attr, Text)]
+    -> V.Image
+renderTableCell paddingAttr horizontalPadding width fragments =
+    V.horizCat
+        [ blank horizontalPadding
+        , content
+        , blank (max 0 (width - V.imageWidth content))
+        , blank horizontalPadding
+        ]
+  where
+    content =
+        V.horizCat
+            [ V.text attr (LazyText.fromStrict text)
+            | (attr, text) <- fragments
+            ]
+    blank count
+        | count <= 0 = V.emptyImage
+        | otherwise = V.charFill paddingAttr ' ' count 1
 
 isTableRow :: Text -> Bool
 isTableRow line =
@@ -424,7 +576,7 @@ inlineWidget :: [InlineSpan] -> Widget n
 inlineWidget spans =
     B.Widget B.Greedy B.Fixed do
         context <- B.getContext
-        styled <- traverse resolve spans
+        styled <- traverse (resolveInlineSpan Theme.assistantAttr) spans
         let width = max 1 context.availWidth
             rows = wrapStyled width styled
             rendered =
@@ -436,16 +588,24 @@ inlineWidget spans =
                     | row <- rows
                     ]
         pure B.emptyResult { B.image = rendered }
-  where
-    resolve InlineSpan{inlineStyle, inlineText} = do
-        attr <- B.lookupAttrName (styleAttr inlineStyle)
-        pure
-            ( case inlineStyle of
-                InlineLink url
-                    | not (Text.null url) -> attr `V.withURL` url
-                _ -> attr
-            , inlineText
-            )
+
+resolveInlineSpan
+    :: AttrName
+    -> InlineSpan
+    -> B.RenderM n (V.Attr, Text)
+resolveInlineSpan plainAttr InlineSpan{inlineStyle, inlineText} = do
+    attr <-
+        B.lookupAttrName $
+            case inlineStyle of
+                InlinePlain -> plainAttr
+                _ -> styleAttr inlineStyle
+    pure
+        ( case inlineStyle of
+            InlineLink url
+                | not (Text.null url) -> attr `V.withURL` url
+            _ -> attr
+        , inlineText
+        )
 
 styleAttr :: InlineStyle -> AttrName
 styleAttr = \case
@@ -497,3 +657,69 @@ wrapStyled width spans =
                         . reverse)
                     (reverse rows)
         in if null ordered then [[]] else ordered
+
+-- | Table cells prefer word boundaries, but still hard-wrap an individual
+-- token that is wider than its column.
+wrapStyledWords :: Int -> [(V.Attr, Text)] -> [[(V.Attr, Text)]]
+wrapStyledWords width spans =
+    map groupCells (wrapCells cells)
+  where
+    width' = max 1 width
+    cells =
+        [ (attr, character)
+        | (attr, text) <- spans
+        , character <- Text.unpack text
+        ]
+
+    wrapCells [] = [[]]
+    wrapCells remaining =
+        let (fitting, overflow) = takeFitting remaining
+        in case overflow of
+            [] -> [dropTrailingSpace fitting]
+            _ ->
+                case lastSpaceIndex fitting of
+                    Just index
+                        | index > 0 ->
+                            let (line, carried) = splitAt index fitting
+                                next =
+                                    dropWhile (isSpace . snd)
+                                        (carried <> overflow)
+                            in dropTrailingSpace line : wrapCells next
+                    _ -> fitting : wrapCells overflow
+
+    takeFitting = go 0 []
+      where
+        go _ taken [] = (reverse taken, [])
+        go used taken allCells@((attr, character) : rest)
+            | used > 0
+            , used + cellWidth > width' =
+                (reverse taken, allCells)
+            | otherwise =
+                go (used + cellWidth) ((attr, character) : taken) rest
+          where
+            cellWidth = terminalCharWidth character
+
+    lastSpaceIndex =
+        List.foldl'
+            (\found (index, (_, character)) ->
+                if isSpace character then Just index else found)
+            Nothing
+            . zip [0 :: Int ..]
+
+    dropTrailingSpace =
+        reverse . dropWhile (isSpace . snd) . reverse
+
+    groupCells =
+        map
+            (\(attr, text) ->
+                (attr, LazyText.toStrict (Builder.toLazyText text)))
+            . reverse
+            . List.foldl' appendCell []
+
+    appendCell grouped (attr, character) =
+        case grouped of
+            (previousAttr, previousText) : rest
+                | previousAttr == attr ->
+                    (previousAttr, previousText <> Builder.singleton character)
+                        : rest
+            _ -> (attr, Builder.singleton character) : grouped

--- a/packages/agent-tui/test/Agent/TUI/MarkdownSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/MarkdownSpec.hs
@@ -42,6 +42,19 @@ spec = describe "fullscreen Markdown inline parsing" do
         rendered `shouldSatisfy`
             isInfixOf "attrURL = SetTo \"https://example.com\""
 
+    it "wraps long table cells instead of clipping later columns" do
+        let widget :: Widget ()
+            widget =
+                markdownWidget $
+                    Text.unlines
+                        [ "| Product | Description | Difference |"
+                        , "| --- | --- | --- |"
+                        , "| Codex | short description | 0123456789ABCDEFVISIBLE |"
+                        ]
+            rendered = show (renderWidget Nothing [widget] (48, 20))
+        rendered `shouldSatisfy` isInfixOf "VISIBLE"
+        rendered `shouldSatisfy` isInfixOf "description"
+
     it "supports multi-backtick code and avoids snake_case emphasis" do
         let spans = parseInline "``a ` b`` and snake_case"
         inlinePlainText spans `shouldBe` "a ` b and snake_case"

--- a/packages/agent-tui/test/Agent/TUI/MarkdownSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/MarkdownSpec.hs
@@ -2,6 +2,7 @@ module Agent.TUI.MarkdownSpec (spec) where
 
 import Agent.TUI.Markdown
 import Agent.Syntax (loadSyntaxHighlighterFrom)
+import Agent.TUI.TextWidth (displayCharCellWidth)
 import qualified Agent.TUI.Theme as Theme
 import Brick
     ( (<=>)
@@ -11,13 +12,19 @@ import Brick
     , txt
     , viewport
     )
-import Data.List (isInfixOf)
+import Control.Monad (forM_)
+import Data.Foldable (toList)
+import Data.List (findIndex, isInfixOf)
 import qualified Data.Text as Text
+import qualified Data.Text.Lazy as LazyText
+import qualified Graphics.Vty as V
+import Graphics.Vty.PictureToSpans (displayOpsForPic)
+import Graphics.Vty.Span (SpanOp(..))
 import System.Environment (lookupEnv)
 import Test.Hspec
 
 spec :: Spec
-spec = describe "fullscreen Markdown inline parsing" do
+spec = describe "fullscreen Markdown rendering" do
     it "parses strong, emphasis, code, and links" do
         parseInline
             "Use **bold**, *italics*, `code`, and [docs](https://example.com)."
@@ -41,19 +48,6 @@ spec = describe "fullscreen Markdown inline parsing" do
             rendered = show (renderWidget Nothing [widget] (40, 3))
         rendered `shouldSatisfy`
             isInfixOf "attrURL = SetTo \"https://example.com\""
-
-    it "wraps long table cells instead of clipping later columns" do
-        let widget :: Widget ()
-            widget =
-                markdownWidget $
-                    Text.unlines
-                        [ "| Product | Description | Difference |"
-                        , "| --- | --- | --- |"
-                        , "| Codex | short description | 0123456789ABCDEFVISIBLE |"
-                        ]
-            rendered = show (renderWidget Nothing [widget] (48, 20))
-        rendered `shouldSatisfy` isInfixOf "VISIBLE"
-        rendered `shouldSatisfy` isInfixOf "description"
 
     it "supports multi-backtick code and avoids snake_case emphasis" do
         let spans = parseInline "``a ` b`` and snake_case"
@@ -157,6 +151,285 @@ spec = describe "fullscreen Markdown inline parsing" do
             rendered = show (renderWidget Nothing [widget] (40, 12))
         rendered `shouldSatisfy` (not . null)
 
+    describe "tables" do
+        it "renders a naturally sized table with aligned box geometry" do
+            renderRows 80
+                "| A | BB |\n| --- | --- |\n| x | yy |"
+                `shouldBe`
+                    [ "┌───┬────┐"
+                    , "│ A │ BB │"
+                    , "├───┼────┤"
+                    , "│ x │ yy │"
+                    , "└───┴────┘"
+                    ]
+
+        it "wraps constrained cells without clipping or losing borders" do
+            let rows =
+                    renderRows 48 $
+                        Text.unlines
+                            [ "| Product | Description | Difference |"
+                            , "| --- | --- | --- |"
+                            , "| Codex | short description | 0123456789ABCDEFVISIBLE |"
+                            ]
+                bodyRows =
+                    filter (Text.isPrefixOf "│") rows
+            map rowDisplayWidth rows
+                `shouldBe` replicate (length rows) 48
+            map (characterColumns '│') bodyRows
+                `shouldSatisfy` allEqual
+            Text.unlines rows `shouldSatisfy` Text.isInfixOf "VISIBLE"
+            Text.unlines rows `shouldSatisfy` Text.isInfixOf "description"
+
+        it "keeps short columns natural and splits remaining width fairly" do
+            let longLeft = Text.replicate 50 "l"
+                longRight = Text.replicate 50 "r"
+                rows =
+                    renderRows 40 $
+                        Text.unlines
+                            [ "| X | Left | Right |"
+                            , "| --- | --- | --- |"
+                            , "| x | " <> longLeft <> " | " <> longRight <> " |"
+                            ]
+            case rows of
+                top : _ -> do
+                    let junctions = characterColumns '┬' top
+                    rowDisplayWidth top `shouldBe` 40
+                    case junctions of
+                        [first, second] -> do
+                            first `shouldBe` 4
+                            let leftWidth = second - first - 3
+                                rightWidth =
+                                    rowDisplayWidth top - second - 4
+                            abs (leftWidth - rightWidth) `shouldSatisfy` (<= 1)
+                        _ -> expectationFailure
+                            ("expected two junctions, got " <> show junctions)
+                [] -> expectationFailure "expected a rendered table"
+
+        it "reflows the same table when the viewport is resized" do
+            let input =
+                    Text.unlines
+                        [ "| A | B |"
+                        , "| --- | --- |"
+                        , "| x | a verbose cell ending in TAILMARK |"
+                        ]
+                narrow = renderRows 24 input
+                wide = renderRows 80 input
+            Text.unlines narrow `shouldSatisfy` Text.isInfixOf "TAILMARK"
+            Text.unlines wide `shouldSatisfy` Text.isInfixOf "TAILMARK"
+            length narrow `shouldSatisfy` (> length wide)
+            map rowDisplayWidth narrow `shouldSatisfy` all (<= 24)
+            map rowDisplayWidth wide `shouldSatisfy` all (<= 80)
+
+        it "uses a compact fallback below the minimum grid width" do
+            let input =
+                    "| A | B | C |\n| --- | --- | --- |\n| x | y | z |"
+                compact = renderRows 6 input
+                grid = renderRows 7 input
+                compactText = Text.unlines compact
+            compactText `shouldSatisfy` (not . Text.isInfixOf "┌")
+            mapM_ (\value ->
+                compactText `shouldSatisfy` Text.isInfixOf value)
+                ["A", "B", "C", "x", "y", "z"]
+            expectFirstRow grid (shouldSatisfyText (Text.isPrefixOf "┌"))
+            map rowDisplayWidth grid
+                `shouldBe` replicate (length grid) 7
+
+        it "preserves every ASCII column down to a one-cell viewport" do
+            let input =
+                    "| A | B | C |\n| --- | --- | --- |\n| x | y | z |"
+            forM_ [1 .. 6] \width -> do
+                let rows = renderRows width input
+                    plain = Text.unlines rows
+                map rowDisplayWidth rows `shouldSatisfy` all (<= width)
+                mapM_ (\value ->
+                    plain `shouldSatisfy` Text.isInfixOf value)
+                    ["A", "B", "C", "x", "y", "z"]
+
+        it "switches cell padding only when the padded grid fits" do
+            let input =
+                    "| A | B |\n| --- | --- |\n| x | y |"
+                compactGrid = renderRows 8 input
+                paddedGrid = renderRows 9 input
+            expectFirstRow compactGrid
+                (`shouldBe` "┌─┬─┐")
+            expectFirstRow paddedGrid
+                (`shouldBe` "┌───┬───┐")
+
+        it "accounts for wide glyphs when choosing grid or compact layout" do
+            let input =
+                    "| A | B |\n| --- | --- |\n| 漢 | z |"
+                compact = renderRows 5 input
+                grid = renderRows 6 input
+            Text.unlines compact `shouldSatisfy` Text.isInfixOf "漢"
+            Text.unlines compact `shouldSatisfy` Text.isInfixOf "z"
+            expectFirstRow compact
+                (shouldSatisfyText (not . Text.isPrefixOf "┌"))
+            expectFirstRow grid
+                (shouldSatisfyText (Text.isPrefixOf "┌"))
+            map rowDisplayWidth grid
+                `shouldBe` replicate (length grid) 6
+
+        it "preserves styled text and hyperlink metadata while wrapping" do
+            let url = "https://example.com"
+                input =
+                    "| Kind | Value |\n\
+                    \| --- | --- |\n\
+                    \| styled | **bold** *emphasis* `code` [docs](https://example.com) |"
+                rows = renderRows 30 input
+                plain = Text.concat rows
+                spans = concat (renderSpanRows 30 input)
+            plain `shouldSatisfy` Text.isInfixOf "bold"
+            plain `shouldSatisfy` Text.isInfixOf "emphasis"
+            plain `shouldSatisfy` Text.isInfixOf "code"
+            plain `shouldSatisfy` Text.isInfixOf "docs"
+            plain `shouldSatisfy` (not . Text.isInfixOf "**")
+            plain `shouldSatisfy` (not . Text.isInfixOf "`code`")
+            spans `shouldSatisfy` any (hasUrl url)
+
+        it "preserves multiple records and links in compact layout" do
+            let url = "https://example.com"
+                input =
+                    "| A | B |\n\
+                    \| --- | --- |\n\
+                    \| first | [one](https://example.com) |\n\
+                    \| second | two |"
+                rows = renderRows 4 input
+                plain = Text.concat rows
+                spans = concat (renderSpanRows 4 input)
+            expectFirstRow rows
+                (shouldSatisfyText (not . Text.isPrefixOf "┌"))
+            mapM_ (\value ->
+                plain `shouldSatisfy` Text.isInfixOf value)
+                ["first", "one", "second", "two"]
+            spans `shouldSatisfy` any (hasUrl url)
+
+        it "aligns CJK, emoji, and combining-mark cells by display width" do
+            let input =
+                    "| Kind | Value |\n\
+                    \| --- | --- |\n\
+                    \| wide | 漢字🙂 |\n\
+                    \| combining | é |"
+                rows = renderRows 80 input
+                plain = Text.unlines rows
+            plain `shouldSatisfy` Text.isInfixOf "漢字🙂"
+            plain `shouldSatisfy` Text.isInfixOf "é"
+            map rowDisplayWidth rows
+                `shouldSatisfy` allEqual
+
+        it "keeps escaped and code-span pipes inside their cells" do
+            let input =
+                    "| Kind | Value |\n\
+                    \| --- | --- |\n\
+                    \| escaped | a \\| b |\n\
+                    \| code | `c|d` |\n\
+                    \| multi | ``e|f`` |"
+                rows = renderRows 80 input
+                plain = Text.unlines rows
+                bodyRows = filter (Text.isPrefixOf "│") (drop 2 rows)
+            plain `shouldSatisfy` Text.isInfixOf "a | b"
+            plain `shouldSatisfy` Text.isInfixOf "c|d"
+            plain `shouldSatisfy` Text.isInfixOf "e|f"
+            plain `shouldSatisfy` (not . Text.isInfixOf "`")
+            map (characterColumns '│') bodyRows
+                `shouldSatisfy` allEqual
+
+        it "handles odd and even backslash runs before pipes" do
+            let oddEscaped =
+                    renderRows 80
+                        "| A | B |\n\
+                        \| --- | --- |\n\
+                        \| odd | left \\| right |"
+                evenDelimiter =
+                    renderRows 80
+                        "| A | B |\n\
+                        \| --- | --- |\n\
+                        \| even | left \\\\| TRUNCATED |"
+                oddText = Text.unlines oddEscaped
+                evenText = Text.unlines evenDelimiter
+            oddText `shouldSatisfy` Text.isInfixOf "left | right"
+            evenText `shouldSatisfy` Text.isInfixOf "left \\"
+            evenText `shouldSatisfy` (not . Text.isInfixOf "TRUNCATED")
+
+        it "treats unmatched backticks as text without hiding delimiters" do
+            let rows =
+                    renderRows 80 $
+                        "| A | B |\n\
+                        \| --- | --- |\n\
+                        \| unmatched `tick | tail |"
+                plain = Text.unlines rows
+            plain `shouldSatisfy` Text.isInfixOf "unmatched `tick"
+            plain `shouldSatisfy` Text.isInfixOf "tail"
+            map rowDisplayWidth rows `shouldSatisfy` allEqual
+
+        it "preserves empty cells and normalizes body rows to the header" do
+            let rows =
+                    renderRows 80 $
+                        "| A | B |\n\
+                        \| --- | --- |\n\
+                        \|| value |\n\
+                        \| x ||\n\
+                        \| one | two | EXTRA |"
+                plain = Text.unlines rows
+                bodyRows = filter (Text.isPrefixOf "│") (drop 2 rows)
+            plain `shouldSatisfy` Text.isInfixOf "value"
+            plain `shouldSatisfy` Text.isInfixOf "one"
+            plain `shouldSatisfy` Text.isInfixOf "two"
+            plain `shouldSatisfy` (not . Text.isInfixOf "EXTRA")
+            map (characterColumns '│') bodyRows
+                `shouldSatisfy` allEqual
+
+        it "accepts alignment markers and rejects malformed separators" do
+            let aligned =
+                    renderRows 80
+                        "| A | B | C |\n| :--- | ---: | :---: |\n| x | y | z |"
+                malformed =
+                    renderRows 80
+                        "| A | B |\n| ---x | --- |\n| x | y |"
+            expectFirstRow aligned
+                (shouldSatisfyText (Text.isPrefixOf "┌"))
+            Text.unlines malformed `shouldSatisfy`
+                (not . Text.isInfixOf "┌")
+            Text.unlines malformed `shouldSatisfy`
+                Text.isInfixOf "---x"
+
+        it "accepts tables without optional outer pipes" do
+            let rows =
+                    renderRows 80
+                        "A | B\n--- | ---\nx | y"
+                plain = Text.unlines rows
+            expectFirstRow rows
+                (shouldSatisfyText (Text.isPrefixOf "┌"))
+            plain `shouldSatisfy` Text.isInfixOf "x"
+            plain `shouldSatisfy` Text.isInfixOf "y"
+
+        it "rejects separator column-count mismatches and false pipe rows" do
+            let mismatched =
+                    renderRows 80
+                        "| A | B |\n| --- | --- | --- |\n| x | y |"
+                escapedOnly =
+                    renderRows 80
+                        "| a \\| b\n| --- |\n| value |"
+            Text.unlines mismatched `shouldSatisfy`
+                (not . Text.isInfixOf "┌")
+            Text.unlines escapedOnly `shouldSatisfy`
+                (not . Text.isInfixOf "┌")
+
+        it "renders a header-only table and leaves following prose outside it" do
+            let headerOnly =
+                    renderRows 80
+                        "| A | B |\n| --- | --- |"
+                withProse =
+                    renderRows 80
+                        "| A | B |\n| --- | --- |\n| x | y |\nafter table"
+                bottomIndex = findIndex (Text.isPrefixOf "└") withProse
+                proseIndex = findIndex (Text.isInfixOf "after table") withProse
+            length headerOnly `shouldBe` 4
+            case (bottomIndex, proseIndex) of
+                (Just bottom, Just prose) ->
+                    prose `shouldSatisfy` (> bottom)
+                _ -> expectationFailure
+                    "expected both the table bottom and following prose"
+
 sourceSyntaxDirectory :: IO FilePath
 sourceSyntaxDirectory =
     lookupEnv "AGENT_SYNTAX_DIR" >>= \case
@@ -166,3 +439,74 @@ sourceSyntaxDirectory =
             fail "unreachable"
         Just syntaxDirectory ->
             pure syntaxDirectory
+
+renderRows :: Int -> Text.Text -> [Text.Text]
+renderRows width =
+    map spanRowText . renderSpanRows width
+
+renderSpanRows :: Int -> Text.Text -> [[SpanOp]]
+renderSpanRows width input =
+    reverse $
+        dropWhile (Text.null . Text.strip . spanRowText) $
+            reverse rows
+  where
+    region = (width, 200)
+    widget :: Widget ()
+    widget = markdownWidget input
+    rows =
+        map toList $
+            toList $
+                displayOpsForPic
+                    (renderWidget Nothing [widget] region)
+                    region
+
+spanRowText :: [SpanOp] -> Text.Text
+spanRowText =
+    Text.dropWhileEnd (== ' ')
+        . Text.concat
+        . map \case
+            TextSpan{textSpanText} ->
+                LazyText.toStrict textSpanText
+            Skip count -> Text.replicate count " "
+            RowEnd count -> Text.replicate count " "
+
+rowDisplayWidth :: Text.Text -> Int
+rowDisplayWidth =
+    Text.foldl'
+        (\width character -> width + displayCharCellWidth character)
+        0
+
+characterColumns :: Char -> Text.Text -> [Int]
+characterColumns target = go 0 . Text.unpack
+  where
+    go _ [] = []
+    go column (character : rest) =
+        let following =
+                go (column + displayCharCellWidth character) rest
+        in if character == target
+            then column : following
+            else following
+
+allEqual :: Eq a => [a] -> Bool
+allEqual [] = True
+allEqual (first : rest) = all (== first) rest
+
+hasUrl :: Text.Text -> SpanOp -> Bool
+hasUrl url = \case
+    TextSpan{textSpanAttr} ->
+        V.attrURL textSpanAttr == V.SetTo url
+    Skip _ -> False
+    RowEnd _ -> False
+
+expectFirstRow :: [Text.Text] -> (Text.Text -> Expectation) -> Expectation
+expectFirstRow rows assertion =
+    case rows of
+        first : _ -> assertion first
+        [] -> expectationFailure "expected at least one rendered row"
+
+shouldSatisfyText
+    :: (Text.Text -> Bool)
+    -> Text.Text
+    -> Expectation
+shouldSatisfyText predicate value =
+    value `shouldSatisfy` predicate


### PR DESCRIPTION
## Summary

- size fullscreen Markdown tables against Brick's available viewport width
- preserve naturally short columns while fairly sharing remaining width between verbose columns
- wrap styled cell content at word boundaries and keep borders aligned across continuation lines
- measure rendered terminal-cell widths for Markdown, links, CJK, emoji, and combining characters
- fall back to a compact wrapped layout when the viewport cannot fit a horizontal grid
- preserve escaped pipes and pipes inside single- or multi-backtick code spans
- support optional outer pipes, empty cells, and header-defined body normalization
- add complete top/bottom borders and exact Vty-output regression coverage

## Table coverage

The fullscreen table tests now cover:

- natural and constrained geometry, border alignment, and fair width allocation
- viewport resizing, padding thresholds, and widths down to one terminal cell
- compact fallback with multiple rows and hyperlink metadata
- word wrapping, long tokens, inline styles, CJK, emoji, and combining marks
- escaped pipes, code-span pipes, unmatched backticks, and backslash parity
- missing/extra/empty cells, alignment markers, malformed separators, optional outer pipes, header-only tables, and following prose

## Validation

- `nix develop -c cabal repl agent-tui:test:agent-tui-test` — 77 examples, 0 failures
- live fullscreen agent smoke-tested in tmux at 100 columns and after resizing to 44 columns
- live table included escaped pipes, inline-code pipes, Unicode, and verbose wrapped content
