### PR TITLE
fix(cli): keep fullscreen output inside TUI

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -55,8 +55,9 @@ import Agent.CLI.AgentSessions
     , sessionProcessStatus
     )
 import Agent.CLI.Approval
-    ( approveToolDecision
-    , approveToolDecisionWith
+    ( ApprovalNotice(..)
+    , approveToolDecision
+    , approveToolDecisionWithReporter
     , toggleAlwaysApprove
     )
 import Agent.CLI.Btw
@@ -186,8 +187,8 @@ import Agent.CLI.Session
 import Agent.CLI.SessionEnv (SessionEnv(..))
 import Agent.CLI.Skills
     ( formatSkillsListing
-    , installSkillCatalog
-    , loadSkillsCatalog
+    , installSkillCatalogWithOmissions
+    , loadSkillsCatalogQuiet
     , reservedSlashNames
     , skillInvocationCommand
     )
@@ -869,15 +870,20 @@ prepareAgentIteration fullscreenInputs activeFullscreen options transition = do
     setCurrentDirectory cwd
 
     toolEnv <- defaultToolEnv cwd
+    uiRuntimeRef <- newIORef Nothing
     interrupt <- newInterruptState \msg -> do
-        -- Drop an in-place "Thinking…" status so the hint is its own line.
-        Text.hPutStr stderr "\r\ESC[K"
-        clearNativeProgress stderr
-        color <- resolveColor stderr
-        putTextLn stderr (roleMuted color msg)
+        readIORef uiRuntimeRef >>= \case
+            Just runtime ->
+                emitUiEvent runtime
+                    (UiSetNotice (Just (warningNotice msg)))
+            Nothing -> do
+                -- Drop an in-place "Thinking…" status so the hint is its own line.
+                Text.hPutStr stderr "\r\ESC[K"
+                clearNativeProgress stderr
+                color <- resolveColor stderr
+                putTextLn stderr (roleMuted color msg)
     -- Shared with Esc cancel and plan prompts so arrow-key pickers own stdin.
     escPaused <- newIORef False
-    uiRuntimeRef <- newIORef Nothing
     stderrTty <- hIsTerminalDevice stderr
     stdinTty <- hIsTerminalDevice stdin
     stdoutTty <- hIsTerminalDevice stdout
@@ -1446,7 +1452,7 @@ runAgentInitialized options transition home root resumed cwd startup = do
         progName <- getProgName
         markStartupStage startup "Connecting to provider…"
         withCtrlCHandler interrupt $
-            withInterruptResume progName persist RunQuit do
+            withInterruptResume fullscreen progName persist RunQuit do
                 let shouldProbeAtStartup =
                         isJust fullscreen
                             && isNothing transition
@@ -1885,12 +1891,13 @@ preparePersistence fullscreen options root provider model cwd effort prompt resu
 
 -- | On Ctrl-C, print a copy-pasteable --resume line when a session exists.
 withInterruptResume
-    :: String
+    :: Maybe FullscreenRuntime
+    -> String
     -> Persistence
     -> a
     -> IO a
     -> IO a
-withInterruptResume progName persist interrupted action =
+withInterruptResume fullscreen progName persist interrupted action =
     (action `catchAny` handleSyncException) `catchAsync` handleInterrupt
   where
     -- UserInterrupt can arrive asynchronously from the installed SIGINT
@@ -1904,7 +1911,11 @@ withInterruptResume progName persist interrupted action =
         | isWrappedUserInterrupt e = finishInterrupt
         | otherwise = throwIO e
     finishInterrupt = do
-        printResumeHint progName persist
+        case fullscreen of
+            Nothing -> printResumeHint progName persist
+            Just runtime ->
+                withFullscreenSuspended runtime
+                    (printResumeHint progName persist)
         -- The interrupt is the requested, graceful end of the CLI session.
         -- Returning lets the surrounding brackets restore the SIGINT handler
         -- and close tools without GHC's top-level exception handler printing
@@ -2156,18 +2167,72 @@ runSession options provider policy tools toolEnv planMode startup prompt pending
                 Nothing -> pure ()
             freshAgents <-
                 loadAgentsContext fullscreen options provider home cwd [] Nothing
-            freshSkills <- loadSkillsCatalog options home projectRoot cwd True
-            installSkillCatalog
+            freshSkills <- loadSkillsCatalogQuiet options home projectRoot cwd
+            omitted <- installSkillCatalogWithOmissions
                 reservedSlashNames True freshAgents
                 skillsRef skillInvocationsRef freshSkills
+            reportSkillCatalog True freshSkills omitted
             fresh <- readIORef freshAgents
             writeIORef startupContext fresh
         refreshSkills queueContext = do
-            refreshed <- loadSkillsCatalog
-                options home projectRoot cwd queueContext
-            installSkillCatalog
+            refreshed <- loadSkillsCatalogQuiet
+                options home projectRoot cwd
+            omitted <- installSkillCatalogWithOmissions
                 reservedSlashNames queueContext startupContext
                 skillsRef skillInvocationsRef refreshed
+            when queueContext $
+                reportSkillCatalog True refreshed omitted
+        formatSkillWarning warning =
+            "skill ignored: "
+                <> toText warning.skillWarningPath
+                <> ": "
+                <> warning.skillWarningMessage
+        formatSkillOmission omitted =
+            "skills: "
+                <> Text.pack (show omitted)
+                <> " omitted from model context due to the catalog budget"
+        reportSkillCatalog includeSummary catalog omitted =
+            case fullscreen of
+                Nothing -> do
+                    color <- resolveColor stderr
+                    when includeSummary do
+                        let count = length catalog.catalogSkills
+                        putTextLn stderr $
+                            roleMuted color
+                                (glyphSession
+                                    <> "skills: loaded "
+                                    <> Text.pack (show count)
+                                    <> if count == 1
+                                        then " skill"
+                                        else " skills")
+                    mapM_
+                        (putTextLn stderr
+                            . roleWarn color
+                            . (glyphWarn <>)
+                            . formatSkillWarning)
+                        catalog.catalogWarnings
+                    when (omitted > 0) $
+                        putTextLn stderr $
+                            roleWarn color
+                                (glyphWarn <> formatSkillOmission omitted)
+                Just runtime -> do
+                    when includeSummary do
+                        let count = length catalog.catalogSkills
+                        emitUiEvent runtime $
+                            UiSystemMessage
+                                ("skills: loaded "
+                                    <> Text.pack (show count)
+                                    <> if count == 1
+                                        then " skill"
+                                        else " skills")
+                    mapM_
+                        (emitUiEvent runtime
+                            . UiSystemMessage
+                            . formatSkillWarning)
+                        catalog.catalogWarnings
+                    when (omitted > 0) $
+                        emitUiEvent runtime
+                            (UiSystemMessage (formatSkillOmission omitted))
     policyRef <- newIORef policy
     -- Mirror plan session dir into the subagent store root for this session.
     let syncStore = do
@@ -2229,8 +2294,15 @@ runSession options provider policy tools toolEnv planMode startup prompt pending
                                 approveToolDecision
                                     policyRef allowedToolsRef toolRegistry planMode call
                         Just runtime ->
-                            approveToolDecisionWith
+                            approveToolDecisionWithReporter
                                 (requestFullscreenPermission runtime)
+                                (\case
+                                    ApprovalWarning _ -> pure ()
+                                    ApprovalSuccess message ->
+                                        emitUiEvent runtime
+                                            (UiSetNotice
+                                                (Just
+                                                    (successNotice message))))
                                 policyRef
                                 allowedToolsRef
                                 toolRegistry
@@ -2308,25 +2380,15 @@ runSession options provider policy tools toolEnv planMode startup prompt pending
         setSessionEffort env level
         writeIORef restartEffortRef (Just level)
         requestCancel toolEnv.toolCancel
-    let formatSkillWarning warning =
-            "skill ignored: "
-                <> toText warning.skillWarningPath
-                <> ": "
-                <> warning.skillWarningMessage
-        initializeSkills = do
+    let initializeSkills = do
             markStartupStage startup "Loading skills…"
-            skills <- loadSkillsCatalog
-                options home projectRoot cwd (isNothing fullscreen)
-            installSkillCatalog
+            skills <- loadSkillsCatalogQuiet
+                options home projectRoot cwd
+            omitted <- installSkillCatalogWithOmissions
                 reservedSlashNames
                 (null initialTurns && not (isJust initialPrevious))
                 startupContext skillsRef skillInvocationsRef skills
-            case fullscreen of
-                Nothing -> pure ()
-                Just runtime -> do
-                    mapM_
-                        (emitUiEvent runtime . UiSystemMessage . formatSkillWarning)
-                        skills.catalogWarnings
+            reportSkillCatalog (isNothing fullscreen) skills omitted
             finishStartup startup
         sessionAction = do
             initializeSkills
@@ -2804,7 +2866,8 @@ replWithDraft env@SessionEnv
   where
     handleReplLine skillCommands skillInvocations stdoutColor planState policy = \case
         ReplEof -> do
-            putStrLn ""
+            when (isNothing fullscreen) $
+                putStrLn ""
             pure RunQuit
         ReplQuitInterrupt ->
             -- Confirmed double Ctrl-C: rethrow so withInterruptResume prints
@@ -2883,7 +2946,7 @@ replWithDraft env@SessionEnv
                         Text.putStrLn (roleMuted color chip)
                 case parseReplLineWithSkills skillCommands promptLine of
                     ReplQuit -> pure RunQuit
-                    ReplReload -> requestReload persist
+                    ReplReload -> requestReload fullscreen persist
                     ReplPrompt text -> do
                         -- Native Cmd+V of a Finder image often pastes a path
                         -- rather than bitmap bytes. Treat a prompt that is
@@ -4492,20 +4555,31 @@ reloadAuth provider = \case
 
 
 requestReload
-    :: Persistence
+    :: Maybe FullscreenRuntime
+    -> Persistence
     -> IO RunResult
-requestReload persist = do
+requestReload fullscreen persist = do
     color <- resolveColor stderr
+    let reportInfo message =
+            case fullscreen of
+                Nothing ->
+                    putTextLn stderr
+                        (roleMuted color (glyphSession <> message))
+                Just runtime ->
+                    emitUiEvent runtime (UiSystemMessage message)
+        reportError message =
+            case fullscreen of
+                Nothing ->
+                    putTextLn stderr (roleError color message)
+                Just runtime ->
+                    emitUiEvent runtime (UiErrorMessage message)
     case persist of
         PersistenceDisabled -> do
-            putTextLn stderr
-                (roleError color ":reload needs a persisted REPL session")
+            reportError ":reload needs a persisted REPL session"
             pure RunQuit
         PersistenceEnabled slotRef -> do
             handle <- ensureSession slotRef
-            putTextLn stderr
-                (roleMuted color
-                    (glyphSession <> "reloading; session " <> handle.sessionMeta.metaId))
+            reportInfo ("reloading; session " <> handle.sessionMeta.metaId)
             pure (RunReload handle.sessionMeta.metaId)
 
 enterPlanFromSlash :: SessionEnv -> Maybe Text -> IO (Maybe ProviderTransition)
@@ -4559,7 +4633,8 @@ enterPlanFromSlash env@SessionEnv
                             Just providerTransition ->
                                 pure (Just providerTransition)
                 _ -> do
-                    putTrailingNewline printed
+                    when (isNothing fullscreen) $
+                        putTrailingNewline printed
                     pure Nothing
 
 -- | Discover AGENTS.md once for a fresh session. Resumed transcripts keep
@@ -4729,19 +4804,30 @@ handleResume
 handleResume fullscreen maybeId persist = do
     color <- resolveColor stderr
     home <- getHomeDirectory
-    let root = sessionsRoot home
+    let reportInfo message =
+            case fullscreen of
+                Nothing ->
+                    Text.hPutStrLn stderr
+                        (roleMuted color (glyphSession <> message))
+                Just runtime ->
+                    emitUiEvent runtime (UiSystemMessage message)
+        reportError message =
+            case fullscreen of
+                Nothing ->
+                    Text.hPutStrLn stderr (roleError color message)
+                Just runtime ->
+                    emitUiEvent runtime (UiErrorMessage message)
+        root = sessionsRoot home
         resume sessionId = do
             currentId <- currentSessionId persist
             if Just sessionId == currentId
                 then do
-                    Text.hPutStrLn stderr
-                        (roleMuted color
-                            (glyphSession <> "already on session " <> sessionId))
+                    reportInfo ("already on session " <> sessionId)
                     pure Nothing
                 else
                     loadSession root sessionId >>= \case
                         Left err -> do
-                            Text.hPutStrLn stderr (roleError color err)
+                            reportError err
                             pure Nothing
                         Right _ -> pure (Just (RunResumeSession sessionId))
     case maybeId of

--- a/packages/agent-cli/src/Agent/CLI/Approval.hs
+++ b/packages/agent-cli/src/Agent/CLI/Approval.hs
@@ -1,7 +1,9 @@
 -- | Parent and child tool-approval policy for interactive CLI sessions.
 module Agent.CLI.Approval
-    ( approveToolDecision
+    ( ApprovalNotice(..)
+    , approveToolDecision
     , approveToolDecisionWith
+    , approveToolDecisionWithReporter
     , childApprove
     , toggleAlwaysApprove
     ) where
@@ -49,6 +51,11 @@ import Data.Text (Text)
 import qualified Data.Text as Text
 import System.IO (stderr)
 
+data ApprovalNotice
+    = ApprovalWarning !Text
+    | ApprovalSuccess !Text
+    deriving (Eq, Show)
+
 approveToolDecision
     :: IORef ApprovalPolicy
     -> IORef (Set Text)
@@ -75,15 +82,32 @@ approveToolDecisionWith
     -> PlanModeEnv
     -> ToolCall
     -> IO (Either Text Bool)
-approveToolDecisionWith requestPermission policyRef allowedToolsRef tools planMode call = do
+approveToolDecisionWith requestPermission =
+    approveToolDecisionWithReporter requestPermission \case
+        ApprovalWarning message -> do
+            color <- resolveColor stderr
+            putTextLn stderr (roleWarn color message)
+        ApprovalSuccess message -> do
+            color <- resolveColor stderr
+            putTextLn stderr (roleSuccess color message)
+
+approveToolDecisionWithReporter
+    :: (ToolCall -> IO (Maybe PermissionChoice))
+    -> (ApprovalNotice -> IO ())
+    -> IORef ApprovalPolicy
+    -> IORef (Set Text)
+    -> ToolRegistry
+    -> PlanModeEnv
+    -> ToolCall
+    -> IO (Either Text Bool)
+approveToolDecisionWithReporter requestPermission report policyRef allowedToolsRef tools planMode call = do
     policy <- readIORef policyRef
     planActive <- isPlanModeActive planMode
     planPath <- planFilePath planMode
     -- Hard deny for catastrophic shell deletes, even under ApproveAll / yolo.
     case shellCommandBlocked call.name call.arguments of
         Just msg -> do
-            color <- resolveColor stderr
-            putTextLn stderr (roleWarn color (glyphWarn <> msg))
+            report (ApprovalWarning (glyphWarn <> msg))
             pure (Left msg)
         Nothing -> do
             -- Plan mode: reject mutating file edits except plan.md (even under yolo).
@@ -92,8 +116,7 @@ approveToolDecisionWith requestPermission policyRef allowedToolsRef tools planMo
             if planModeBlocksCall planActive planPath call
                 then do
                     let msg = planModeBlockedEditMessage planPath
-                    color <- resolveColor stderr
-                    putTextLn stderr (roleWarn color msg)
+                    report (ApprovalWarning msg)
                     pure (Left msg)
                 else do
                     readOnly <- case lookupRegisteredTool call.name tools of
@@ -112,7 +135,6 @@ approveToolDecisionWith requestPermission policyRef allowedToolsRef tools planMo
                                     PromptMutating
                                         | readOnly -> pure (Right True)
                                         | otherwise -> do
-                                            color <- resolveColor stderr
                                             requestPermission call >>= \case
                                                 Nothing -> pure (Right False)
                                                 Just PermissionAllowOnce ->
@@ -120,12 +142,12 @@ approveToolDecisionWith requestPermission policyRef allowedToolsRef tools planMo
                                                 Just PermissionAllowTool -> do
                                                     modifyIORef' allowedToolsRef
                                                         (Set.insert call.name)
-                                                    putTextLn stderr
-                                                        (roleSuccess color
+                                                    report $
+                                                        ApprovalSuccess
                                                             (glyphOk
                                                                 <> "always allow "
                                                                 <> call.name
-                                                                <> " this session"))
+                                                                <> " this session")
                                                     pure (Right True)
                                                 Just PermissionDeny ->
                                                     pure (Right False)

--- a/packages/agent-cli/src/Agent/CLI/Skills.hs
+++ b/packages/agent-cli/src/Agent/CLI/Skills.hs
@@ -2,8 +2,11 @@
 module Agent.CLI.Skills
     ( formatSkillsListing
     , installSkillCatalog
+    , installSkillCatalogWithOmissions
     , loadSkillsCatalog
+    , loadSkillsCatalogQuiet
     , queueSkillCatalogContext
+    , queueSkillCatalogContextWithOmissions
     , reservedSlashNames
     , skillInvocationCommand
     ) where
@@ -14,6 +17,7 @@ import Agent.CLI.Command
     , slashCommands
     )
 import Agent.CLI.Options (CliOptions(..))
+import Agent.CLI.Render (putTextLn)
 import Agent.CLI.Style
     ( glyphSession
     , glyphWarn
@@ -21,11 +25,10 @@ import Agent.CLI.Style
     , rolePrompt
     , roleWarn
     )
-import Agent.CLI.Render (putTextLn)
 import Agent.CLI.Terminal (resolveColor)
 import Agent.OsPath (toText)
 import Agent.Skills
-import Control.Monad (when)
+import Control.Monad (void, when)
 import Data.IORef (IORef, modifyIORef', writeIORef)
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
@@ -49,12 +52,7 @@ loadSkillsCatalog
 loadSkillsCatalog options home projectRoot cwd report
     | not options.optSkills = pure (SkillCatalog [] [])
     | otherwise = do
-        catalog <- discoverSkills SkillDiscoverOptions
-            { skillsHome = home
-            , skillsProjectRoot = projectRoot
-            , skillsCwd = cwd
-            , skillsMaxDepth = 6
-            }
+        catalog <- loadSkillsCatalogQuiet options home projectRoot cwd
         when report do
             color <- resolveColor stderr
             let count = length catalog.catalogSkills
@@ -67,6 +65,22 @@ loadSkillsCatalog options home projectRoot cwd report
             mapM_ (reportSkillWarning color) catalog.catalogWarnings
         pure catalog
 
+loadSkillsCatalogQuiet
+    :: CliOptions
+    -> OsPath
+    -> OsPath
+    -> OsPath
+    -> IO SkillCatalog
+loadSkillsCatalogQuiet options home projectRoot cwd
+    | not options.optSkills = pure (SkillCatalog [] [])
+    | otherwise =
+        discoverSkills SkillDiscoverOptions
+            { skillsHome = home
+            , skillsProjectRoot = projectRoot
+            , skillsCwd = cwd
+            , skillsMaxDepth = 6
+            }
+
 reportSkillWarning :: Bool -> SkillWarning -> IO ()
 reportSkillWarning color warning =
     putTextLn stderr $
@@ -78,22 +92,30 @@ reportSkillWarning color warning =
                 <> warning.skillWarningMessage)
 
 queueSkillCatalogContext :: IORef (Maybe Text) -> SkillCatalog -> IO ()
-queueSkillCatalogContext contextRef catalog =
+queueSkillCatalogContext contextRef catalog = do
+    omitted <- queueSkillCatalogContextWithOmissions contextRef catalog
+    when (omitted > 0) do
+        color <- resolveColor stderr
+        putTextLn stderr $
+            roleWarn color
+                (glyphWarn
+                    <> "skills: "
+                    <> Text.pack (show omitted)
+                    <> " omitted from model context due to the catalog budget")
+
+queueSkillCatalogContextWithOmissions
+    :: IORef (Maybe Text)
+    -> SkillCatalog
+    -> IO Int
+queueSkillCatalogContextWithOmissions contextRef catalog =
     case formatSkillCatalogContext defaultSkillCatalogMaxChars catalog of
-        (Nothing, _) -> pure ()
+        (Nothing, omitted) -> pure omitted
         (Just text, omitted) -> do
             modifyIORef' contextRef \current ->
                 Just $ case current of
                     Nothing -> text
                     Just existing -> existing <> "\n\n" <> text
-            when (omitted > 0) do
-                color <- resolveColor stderr
-                putTextLn stderr $
-                    roleWarn color
-                        (glyphWarn
-                            <> "skills: "
-                            <> Text.pack (show omitted)
-                            <> " omitted from model context due to the catalog budget")
+            pure omitted
 
 -- | Publish a freshly discovered catalog to all session consumers. Keeping
 -- this transition in one helper lets fullscreen startup begin with empty refs
@@ -107,10 +129,29 @@ installSkillCatalog
     -> SkillCatalog
     -> IO ()
 installSkillCatalog reservedNames queueContext contextRef catalogRef invocationsRef catalog = do
+    void $
+        installSkillCatalogWithOmissions
+            reservedNames
+            queueContext
+            contextRef
+            catalogRef
+            invocationsRef
+            catalog
+
+installSkillCatalogWithOmissions
+    :: [Text]
+    -> Bool
+    -> IORef (Maybe Text)
+    -> IORef SkillCatalog
+    -> IORef [SkillInvocation]
+    -> SkillCatalog
+    -> IO Int
+installSkillCatalogWithOmissions reservedNames queueContext contextRef catalogRef invocationsRef catalog = do
     writeIORef catalogRef catalog
     writeIORef invocationsRef (buildSkillInvocations reservedNames catalog)
-    when queueContext $
-        queueSkillCatalogContext contextRef catalog
+    if queueContext
+        then queueSkillCatalogContextWithOmissions contextRef catalog
+        else pure 0
 
 skillInvocationCommand :: SkillInvocation -> SkillCommand
 skillInvocationCommand invocation =

--- a/packages/agent-cli/test/Agent/CLI/ApprovalSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ApprovalSpec.hs
@@ -1,7 +1,12 @@
 module Agent.CLI.ApprovalSpec (spec) where
 
-import Agent.CLI.Approval (childApprove)
+import Agent.CLI.Approval
+    ( ApprovalNotice(..)
+    , approveToolDecisionWithReporter
+    , childApprove
+    )
 import Agent.CLI.Options (ApprovalPolicy(..))
+import Agent.CLI.Permission (PermissionChoice(..))
 import Agent.ToolDispatch
     ( ToolCall
     , functionToolCall
@@ -14,37 +19,134 @@ import Agent.Tools.Types
     , jsonAppTool
     , mkToolRegistry
     )
+import Agent.Tools.PlanMode
+    ( activatePlanMode
+    , newPlanModeEnv
+    )
+import Data.IORef
+    ( modifyIORef'
+    , newIORef
+    , readIORef
+    )
+import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as Text
+import System.OsPath (unsafeEncodeUtf)
 import Test.Hspec
 
 spec :: Spec
-spec = describe "childApprove" do
-    it "allows every known tool under ApproveAll" do
-        childApprove ApproveAll (registry [mutatingTool]) mutatingCall
-            `shouldReturn` Right True
+spec = do
+    describe "approveToolDecisionWith" do
+        it "reports plan-mode denials without requiring terminal output" do
+            policy <- newIORef ApproveAll
+            allowed <- newIORef Set.empty
+            plan <- newPlanModeEnv (unsafeEncodeUtf "/tmp/approval-test") Nothing
+            activatePlanMode plan
+            notices <- newIORef []
+            permissionRequests <- newIORef (0 :: Int)
+            let call = functionToolCall "call-patch" "apply_patch" "{}"
 
-    it "allows only read-only tools under DenyMutating" do
-        childApprove DenyMutating (registry [readOnlyTool]) readOnlyCall
-            `shouldReturn` Right True
-        childApprove DenyMutating (registry [mutatingTool]) mutatingCall
-            `shouldReturn` Right False
+            result <- approveToolDecisionWithReporter
+                (\_ -> modifyIORef' permissionRequests (+ 1)
+                    >> pure (Just PermissionAllowOnce))
+                (\notice -> modifyIORef' notices (<> [notice]))
+                policy
+                allowed
+                (registry [])
+                plan
+                call
 
-    it "recognizes namespaced collaboration tools as read-only" do
-        childApprove DenyMutating (registry [namespacedReadOnlyTool]) namespacedReadOnlyCall
-            `shouldReturn` Right True
+            result `shouldSatisfy` \case
+                Left message ->
+                    "file edits are not allowed in plan mode"
+                        `Text.isInfixOf` message
+                Right _ -> False
+            readIORef permissionRequests `shouldReturn` 0
+            readIORef notices `shouldReturn`
+                [ApprovalWarning
+                    "Rejected: file edits are not allowed in plan mode - \
+                    \the only editable file is the plan file \
+                    \(/tmp/approval-test/plan.md)."]
 
-    it "returns an in-band denial when a child would need to prompt" do
-        result <- childApprove PromptMutating (registry [mutatingTool]) mutatingCall
-        result `shouldSatisfy` \case
-            Left message -> "cannot prompt for approval" `Text.isInfixOf` message
-            Right _ -> False
+        it "reports dangerous shell denials through the callback" do
+            policy <- newIORef ApproveAll
+            allowed <- newIORef Set.empty
+            plan <- newPlanModeEnv (unsafeEncodeUtf "/tmp/approval-test") Nothing
+            notices <- newIORef []
+            let call =
+                    functionToolCall
+                        "call-shell"
+                        "shell_command"
+                        "{\"command\":\"rm -rf /\"}"
 
-    it "honors per-call read-only classifiers" do
-        childApprove DenyMutating (registry [dynamicTool]) dynamicReadCall
-            `shouldReturn` Right True
-        childApprove DenyMutating (registry [dynamicTool]) dynamicWriteCall
-            `shouldReturn` Right False
+            result <- approveToolDecisionWithReporter
+                (\_ -> pure (Just PermissionAllowOnce))
+                (\notice -> modifyIORef' notices (<> [notice]))
+                policy
+                allowed
+                (registry [])
+                plan
+                call
+
+            result `shouldSatisfy` either (const True) (const False)
+            recorded <- readIORef notices
+            recorded `shouldSatisfy` \case
+                [ApprovalWarning message] ->
+                    "blocked dangerous shell command"
+                        `Text.isInfixOf` Text.toLower message
+                _ -> False
+
+        it "reports remembered tool approval through the callback" do
+            policy <- newIORef PromptMutating
+            allowed <- newIORef Set.empty
+            plan <- newPlanModeEnv (unsafeEncodeUtf "/tmp/approval-test") Nothing
+            notices <- newIORef []
+            permissionRequests <- newIORef (0 :: Int)
+            let request _ = do
+                    modifyIORef' permissionRequests (+ 1)
+                    pure (Just PermissionAllowTool)
+                report notice = modifyIORef' notices (<> [notice])
+
+            approveToolDecisionWithReporter
+                request report policy allowed
+                (registry [mutatingTool]) plan mutatingCall
+                `shouldReturn` Right True
+            approveToolDecisionWithReporter
+                request report policy allowed
+                (registry [mutatingTool]) plan mutatingCall
+                `shouldReturn` Right True
+
+            readIORef permissionRequests `shouldReturn` 1
+            readIORef notices `shouldReturn`
+                [ApprovalSuccess "✓ always allow write this session"]
+            readIORef allowed `shouldReturn` Set.singleton "write"
+
+    describe "childApprove" do
+        it "allows every known tool under ApproveAll" do
+            childApprove ApproveAll (registry [mutatingTool]) mutatingCall
+                `shouldReturn` Right True
+
+        it "allows only read-only tools under DenyMutating" do
+            childApprove DenyMutating (registry [readOnlyTool]) readOnlyCall
+                `shouldReturn` Right True
+            childApprove DenyMutating (registry [mutatingTool]) mutatingCall
+                `shouldReturn` Right False
+
+        it "recognizes namespaced collaboration tools as read-only" do
+            childApprove DenyMutating (registry [namespacedReadOnlyTool]) namespacedReadOnlyCall
+                `shouldReturn` Right True
+
+        it "returns an in-band denial when a child would need to prompt" do
+            result <- childApprove PromptMutating (registry [mutatingTool]) mutatingCall
+            result `shouldSatisfy` \case
+                Left message -> "cannot prompt for approval" `Text.isInfixOf` message
+                Right _ -> False
+
+        it "honors per-call read-only classifiers" do
+            childApprove DenyMutating (registry [dynamicTool]) dynamicReadCall
+                `shouldReturn` Right True
+            childApprove DenyMutating (registry [dynamicTool]) dynamicWriteCall
+                `shouldReturn` Right False
 
 readOnlyCall :: ToolCall
 readOnlyCall = functionToolCall "call-read" "read" "{}"

--- a/packages/agent-cli/test/Agent/CLI/SkillsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SkillsSpec.hs
@@ -24,7 +24,9 @@ spec = describe "Agent.CLI.Skills" do
 
     it "queues skill metadata after existing startup context" do
         context <- newIORef (Just "agents")
-        queueSkillCatalogContext context (SkillCatalog [fakeSkill] [])
+        _ <- queueSkillCatalogContextWithOmissions
+            context
+            (SkillCatalog [fakeSkill] [])
         readIORef context >>= \case
             Nothing -> expectationFailure "expected startup context"
             Just text -> do
@@ -45,7 +47,7 @@ spec = describe "Agent.CLI.Skills" do
         catalogRef <- newIORef (SkillCatalog [] [])
         invocationsRef <- newIORef []
         let catalog = SkillCatalog [fakeSkill] []
-        installSkillCatalog
+        _ <- installSkillCatalogWithOmissions
             ["help"] True context catalogRef invocationsRef catalog
         readIORef catalogRef `shouldReturn` catalog
         readIORef invocationsRef `shouldReturn`


### PR DESCRIPTION
## Summary
- route approval warnings and notices through the fullscreen UI instead of writing to the terminal behind Brick
- audit and fix analogous direct-output paths for skills, resume/reload errors, plan-mode diagnostics, EOF, and SIGINT handling
- preserve the existing exported approval and skills APIs while adding quiet/reporter variants for fullscreen callers
- add regression coverage for plan-mode and dangerous-command rejections, allow-tool notices, and skill omission reporting

## Testing
- `nix develop -c cabal repl agent-cli:test:agent-cli-test` → `main` (603 examples, 0 failures)
- live fullscreen tmux smoke test: plan-mode `apply_patch` rejection rendered in its tool block without modifying the composer
- live fullscreen smoke tests for `/resume` errors and `/skills reload`
- external SIGINT smoke test: warning rendered above an empty composer