### PR TITLE
feat(core): add managed background shell sessions

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Render.hs
+++ b/packages/agent-cli/src/Agent/CLI/Render.hs
@@ -584,6 +584,7 @@ toolChrome name = case canonicalToolName name of
     "apply_patch" -> ToolChrome "Edited" ToolDetailPath
     "run_terminal_cmd" -> ToolChromeShell
     "shell_command" -> ToolChromeShell
+    "write_stdin" -> ToolChrome "Continued" ToolDetailMuted
     "run_ghci" -> ToolChromeShell
     "get_task_output" -> ToolChrome "Read" ToolDetailMuted
     "kill_task" -> ToolChrome "Killed" ToolDetailMuted

--- a/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
@@ -35,6 +35,8 @@ spec = do
                 `shouldBe` "Read src/A.hs"
             summarizeToolCall (functionToolCall "c2" "shell_command" "{\"command\":\"ls -l\"}")
                 `shouldBe` "$ ls -l"
+            summarizeToolCall (functionToolCall "c2b" "write_stdin" "{\"session_id\":7}")
+                `shouldBe` "Continued session 7"
             summarizeToolCall (functionToolCall "c3" "run_terminal_cmd" "{\"command\":\"git status\"}")
                 `shouldBe` "$ git status"
             summarizeToolCall (functionToolCall "c3b" "run_ghci" "{\"expression\":\"1 + 1\"}")

--- a/packages/agent-core/agent-core.cabal
+++ b/packages/agent-core/agent-core.cabal
@@ -65,6 +65,7 @@ library
                     , Agent.Tools
                     , Agent.Tools.ApplyPatch
                     , Agent.Tools.Codex
+                    , Agent.Tools.Codex.Shell
                     , Agent.Tools.Dangerous
                     , Agent.Tools.FileSystem
                     , Agent.Tools.Grok

--- a/packages/agent-core/src/Agent/ToolArgs.hs
+++ b/packages/agent-core/src/Agent/ToolArgs.hs
@@ -10,6 +10,7 @@ module Agent.ToolArgs
     , objectArgsLenient
     , reqText
     , reqTextList
+    , reqInt
     , optText
     , optInt
     , optIntOrString
@@ -131,6 +132,14 @@ reqTextList obj key =
             one _ = failText ("Expected string entries in array for key: " <> key)
         Just (String t) -> pure [t]
         Just _ -> failText ("Expected array for key: " <> key)
+        Nothing -> failText ("Missing parameter: " <> key)
+
+-- | Required exact, bounded integer.
+reqInt :: Object -> Text -> Parser Int
+reqInt obj key =
+    case look obj key of
+        Just (Number n) -> parseExactInt key n
+        Just _ -> expectedInteger key
         Nothing -> failText ("Missing parameter: " <> key)
 
 -- | Optional string; an empty string counts as absent.

--- a/packages/agent-core/src/Agent/Tools.hs
+++ b/packages/agent-core/src/Agent/Tools.hs
@@ -36,6 +36,10 @@ import Agent.ResourceScope
     , newResourceScope
     )
 import Agent.Tools.Codex (codexTools)
+import Agent.Tools.Codex.Shell
+    ( closeCodexShellSession
+    , newCodexShellSession
+    )
 import Agent.Tools.Ghci (closeGhciSession, newGhciSession)
 import Agent.Tools.Grok (closeGrokSession, filterGrokToolsForType, grokTools, newGrokSession)
 import Agent.Tools.Grok.Task (GrokSubagentSpecs)
@@ -58,8 +62,9 @@ data CodingTools = CodingTools
 
 -- | Tools advertised for a model vendor. Surfaces are never mixed.
 -- Every provider gets a persistent GHCi session for 'run_ghci'.
--- Grok/OpenRouter also keep a persistent shell session. 'codingClose'
--- closes owned sessions; run it in 'finally'.
+-- OpenAI keeps managed long-running shell processes. Grok/OpenRouter also keep
+-- persistent cwd/environment shell state. 'codingClose' closes owned sessions;
+-- run it in 'finally'.
 codingToolsFor
     :: Provider
     -> ToolEnv
@@ -89,10 +94,13 @@ codingToolsForWithTypes provider env hooks multi typesRef = do
             OpenRouterProvider ->
                 grokCodingTools resources plan
             OpenAIProvider -> do
+                (_, shellSession) <- allocateResource resources
+                    (newCodexShellSession env)
+                    closeCodexShellSession
                 (_, ghci) <- allocateResource resources
                     (newGhciSession env)
                     closeGhciSession
-                tools <- codexTools env ghci plan multi
+                tools <- codexTools env shellSession ghci plan multi
                 pure CodingTools
                     { codingAppTools = tools
                     , codingPlanMode = plan

--- a/packages/agent-core/src/Agent/Tools/Codex.hs
+++ b/packages/agent-core/src/Agent/Tools/Codex.hs
@@ -10,17 +10,30 @@ module Agent.Tools.Codex
 
 import Agent.OsPath (fromText)
 import Agent.ToolArgs
-    ( objectArgs
+    ( extractMaybeText
+    , objectArgs
     , optIntOrString
     , optText
+    , reqInt
     , reqText
     )
 import Agent.ToolDSL
     ( PropertySchema(..)
     , PropertyType(..)
     )
-import Agent.ToolDispatch (typedStreamingTool, typedTool)
+import Agent.ToolDispatch
+    ( ToolCall(..)
+    , toolArgumentsValue
+    , typedStreamingTool
+    , typedTool
+    )
 import Agent.Tools.ApplyPatch (applyPatch)
+import Agent.Tools.Codex.Shell
+    ( CodexShellResult(..)
+    , CodexShellSession
+    , continueCodexShellCommand
+    , startCodexShellCommand
+    )
 import Agent.Tools.Ghci (GhciSession, runGhciTool)
 import Agent.Tools.Dangerous (forbiddenRmRfReason, commandLooksLikeRmRf)
 import Agent.Tools.IO
@@ -41,6 +54,7 @@ import Agent.Tools.Types
     , ToolExecutionPolicy(..)
     , ToolEnv(..)
     , freeformApplyPatchAppToolWithExecution
+    , jsonAppToolWithExecution
     , jsonTool
     )
 import Control.Applicative ((<|>))
@@ -54,14 +68,16 @@ import qualified Data.Text as Text
 
 codexTools
     :: ToolEnv
+    -> CodexShellSession
     -> GhciSession
     -> PlanModeEnv
     -> Maybe MultiAgentContext
     -> IO [AppTool]
-codexTools env ghci planMode multi = do
+codexTools env shellSession ghci planMode multi = do
     planRef <- newIORef []
     pure $
-        [ shellCommandTool env
+        [ shellCommandTool env shellSession
+        , writeStdinTool shellSession
         , applyPatchTool env
         , updatePlanTool planMode planRef
         , runGhciTool ghci
@@ -78,6 +94,7 @@ data ShellCommandArgs = ShellCommandArgs
     { command :: Text
     , workdir :: Maybe Text
     , timeoutMs :: Maybe Int
+    , yieldTimeMs :: Maybe Int
     }
 
 instance FromJSON ShellCommandArgs where
@@ -85,59 +102,139 @@ instance FromJSON ShellCommandArgs where
         <$> reqText object "command"
         <*> optText object "workdir"
         <*> optIntOrString object "timeout_ms"
+        <*> optIntOrString object "yield_time_ms"
 
-shellCommandTool :: ToolEnv -> AppTool
-shellCommandTool env = jsonTool "shell_command" shellDescription
+shellCommandTool :: ToolEnv -> CodexShellSession -> AppTool
+shellCommandTool env session = jsonTool "shell_command" shellDescription
     [ PropertySchema "command" PropertyString True $ Just
         "Shell script to run in the user's default shell."
     , PropertySchema "workdir" PropertyString False $ Just
         "Working directory for the command. Defaults to the turn cwd."
     , PropertySchema "timeout_ms" PropertyInteger False $ Just
-        "Maximum command runtime. Defaults to 10000 ms."
+        "Maximum foreground command runtime. Defaults to 10000 ms. Mutually exclusive with yield_time_ms."
+    , PropertySchema "yield_time_ms" PropertyInteger False $ Just
+        "Return a session_id if the command is still running after this many milliseconds. Mutually exclusive with timeout_ms."
     ]
     False
     TurnSequential
-    (typedStreamingTool "shell_command" (runShell env))
+    (typedStreamingTool "shell_command" (runShell env session))
 
 shellDescription :: Text
 shellDescription =
     "Runs a shell command and returns its output.\n\
-    \- Always set the `workdir` param when using the shell_command function. Do not use `cd` unless absolutely necessary."
+    \- Always set the `workdir` param when using the shell_command function. Do not use `cd` unless absolutely necessary.\n\
+    \- For a long-running command, set `yield_time_ms`; if it is still running, use `write_stdin` with the returned session_id to poll or send input."
 
 runShell
     :: ToolEnv
+    -> CodexShellSession
     -> (Text -> IO ())
     -> ShellCommandArgs
     -> IO (Either Text Text)
-runShell env emitOutput args
+runShell env session emitOutput args
     | commandLooksLikeRmRf args.command =
         pure (Left (forbiddenRmRfReason args.command))
+    | args.timeoutMs /= Nothing && args.yieldTimeMs /= Nothing =
+        pure (Left "timeout_ms and yield_time_ms are mutually exclusive")
     | otherwise = do
-        let timeoutMs = min 300000 (max 1 (fromMaybe 10000 args.timeoutMs))
         workdir <- case args.workdir of
             Nothing -> pure (Right env.toolCwd)
             Just dir -> resolveUnderCwd env (fromText dir)
         case workdir of
             Left err -> pure (Left err)
-            Right dir -> do
-                result <- runShellCommandStreaming
-                    env
-                    dir
-                    (Text.unpack args.command)
-                    timeoutMs
-                    (\out err -> emitOutput (commandBody out err))
-                if result.commandCancelled
-                    then pure $ Left "Error: Command cancelled"
-                    else if result.commandTimedOut
-                    then pure $ Left $
-                        "Error: Command timed out after " <> Text.pack (show timeoutMs) <> "ms"
-                    else
-                        let code = fromMaybe 1 result.commandExitCode
-                            body = commandBody
-                                result.commandStdout
-                                result.commandStderr
-                        in pure $ Right $
-                            "Exit code: " <> Text.pack (show code) <> "\n" <> body
+            Right dir -> case args.yieldTimeMs of
+                Just requestedYield -> do
+                    let yieldMs = clampMs requestedYield
+                    startCodexShellCommand
+                        session
+                        dir
+                        (Text.unpack args.command)
+                        yieldMs
+                        (\out err -> emitOutput (commandBody out err))
+                        >>= pure . fmap renderShellResult
+                Nothing -> do
+                    let timeoutMs = clampMs (fromMaybe 10000 args.timeoutMs)
+                    result <- runShellCommandStreaming
+                        env
+                        dir
+                        (Text.unpack args.command)
+                        timeoutMs
+                        (\out err -> emitOutput (commandBody out err))
+                    if result.commandCancelled
+                        then pure $ Left "Error: Command cancelled"
+                        else if result.commandTimedOut
+                        then pure $ Left $
+                            "Error: Command timed out after " <> Text.pack (show timeoutMs) <> "ms"
+                        else pure $ Right $ renderFinished result
+
+data WriteStdinArgs = WriteStdinArgs
+    { sessionId :: Int
+    , chars :: Maybe Text
+    , yieldTimeMs :: Maybe Int
+    }
+
+instance FromJSON WriteStdinArgs where
+    parseJSON = objectArgs \object -> WriteStdinArgs
+        <$> reqInt object "session_id"
+        <*> optText object "chars"
+        <*> optIntOrString object "yield_time_ms"
+
+writeStdinTool :: CodexShellSession -> AppTool
+writeStdinTool session =
+    jsonAppToolWithExecution "write_stdin" writeStdinDescription
+        [ PropertySchema "session_id" PropertyInteger True $ Just
+            "Identifier returned by shell_command for a running command."
+        , PropertySchema "chars" PropertyString False $ Just
+            "Text to write to stdin. Omit or use an empty string to poll without writing. Use \\u0003 to interrupt."
+        , PropertySchema "yield_time_ms" PropertyInteger False $ Just
+            "Wait before returning output. Defaults to 5000 ms; maximum 300000 ms."
+        ]
+        (ClassifyReadOnly writeStdinIsReadOnly)
+        TurnSequential
+        (typedTool "write_stdin" (runWriteStdin session))
+
+writeStdinDescription :: Text
+writeStdinDescription =
+    "Writes text to or polls an existing shell_command session and returns newly produced output."
+
+writeStdinIsReadOnly :: ToolCall -> IO Bool
+writeStdinIsReadOnly call =
+    pure $ maybe True Text.null $
+        extractMaybeText (toolArgumentsValue call.arguments) "chars"
+
+runWriteStdin
+    :: CodexShellSession
+    -> WriteStdinArgs
+    -> IO (Either Text Text)
+runWriteStdin session args = do
+    let yieldMs = clampMs (fromMaybe 5000 args.yieldTimeMs)
+    fmap renderShellResult <$> continueCodexShellCommand
+        session
+        args.sessionId
+        (fromMaybe "" args.chars)
+        yieldMs
+
+clampMs :: Int -> Int
+clampMs = min 300000 . max 1
+
+renderShellResult :: CodexShellResult -> Text
+renderShellResult = \case
+    CodexShellFinished result -> renderFinished result
+    CodexShellRunning sessionId out err ->
+        "Process still running.\n\
+        \session_id: " <> Text.pack (show sessionId) <> "\n"
+            <> commandBody out err
+
+renderFinished :: CommandResult -> Text
+renderFinished result =
+    let body = commandBody result.commandStdout result.commandStderr
+    in if result.commandCancelled
+        then "Error: Command cancelled\n" <> body
+        else if result.commandTimedOut
+            then "Error: Command timed out\n" <> body
+            else
+                let code = fromMaybe 1 result.commandExitCode
+                in "Exit code: " <> Text.pack (show code) <> "\n" <> body
 
 commandBody :: Text -> Text -> Text
 commandBody out err

--- a/packages/agent-core/src/Agent/Tools/Codex/Shell.hs
+++ b/packages/agent-core/src/Agent/Tools/Codex/Shell.hs
@@ -1,0 +1,320 @@
+-- | Managed shell processes for the OpenAI/Codex tool surface.
+--
+-- Each command still starts in a fresh shell. Commands that outlive their
+-- initial yield can be retained under a numeric session id and later polled or
+-- written to with @write_stdin@.
+module Agent.Tools.Codex.Shell
+    ( CodexShellSession
+    , CodexShellResult(..)
+    , newCodexShellSession
+    , closeCodexShellSession
+    , startCodexShellCommand
+    , continueCodexShellCommand
+    ) where
+
+import Agent.Cancel (waitCancel)
+import Agent.Tools.IO
+    ( CommandResult(..)
+    , RunningCommand(..)
+    , RunningOutputCursor
+    , initialRunningOutputCursor
+    , interruptShellCommand
+    , runningLiveOutput
+    , runningOutputSince
+    , startShellCommandWithInput
+    , stopShellCommand
+    , writeShellCommandInput
+    )
+import Agent.Tools.Types (ToolEnv(..))
+import Control.Concurrent (threadDelay)
+import Control.Concurrent.Async (mapConcurrently_, race, withAsync)
+import Control.Concurrent.MVar
+    ( MVar
+    , modifyMVar
+    , newMVar
+    , readMVar
+    , tryReadMVar
+    , withMVar
+    )
+import Control.Exception.Safe (SomeException, mask, onException, try)
+import Control.Monad (void, when)
+import Data.IORef (IORef, atomicModifyIORef', newIORef, readIORef, writeIORef)
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import Data.Text (Text)
+import qualified Data.Text as Text
+import System.OsPath (OsPath)
+
+data CodexShellResult
+    = CodexShellFinished !CommandResult
+    | CodexShellRunning
+        { codexShellSessionId :: !Int
+        , codexShellStdout :: !Text
+        , codexShellStderr :: !Text
+        }
+
+data ManagedCommand = ManagedCommand
+    { managedRunning :: !RunningCommand
+    , managedLock :: !(MVar ())
+    , managedCursor :: !(IORef RunningOutputCursor)
+    }
+
+data SessionStore = SessionStore
+    { storeCommands :: !(Map Int ManagedCommand)
+    }
+
+data CodexShellSession = CodexShellSession
+    { sessionEnv :: !ToolEnv
+    , sessionCommands :: !(MVar (Maybe SessionStore))
+    , sessionNextId :: !(IORef Int)
+    }
+
+maxManagedCommands :: Int
+maxManagedCommands = 64
+
+newCodexShellSession :: ToolEnv -> IO CodexShellSession
+newCodexShellSession env = do
+    commands <- newMVar $ Just SessionStore
+        { storeCommands = Map.empty }
+    nextId <- newIORef 0
+    pure CodexShellSession
+        { sessionEnv = env
+        , sessionCommands = commands
+        , sessionNextId = nextId
+        }
+
+-- | Stop and join every retained command. Closing is idempotent.
+closeCodexShellSession :: CodexShellSession -> IO ()
+closeCodexShellSession session = do
+    commands <- modifyMVar session.sessionCommands \case
+        Nothing -> pure (Nothing, [])
+        Just current -> pure (Nothing, Map.elems current.storeCommands)
+    mapConcurrently_
+        (\task ->
+            void $ try @_ @SomeException $
+                stopShellCommand task.managedRunning)
+        commands
+
+-- | Start a fresh shell command and wait up to the requested yield. If the
+-- command is still alive it remains owned by the session and is returned under
+-- a numeric id.
+startCodexShellCommand
+    :: CodexShellSession
+    -> OsPath
+    -> String
+    -> Int
+    -> (Text -> Text -> IO ())
+    -> IO (Either Text CodexShellResult)
+startCodexShellCommand session workdir command yieldMs onSnapshot =
+    mask \restore -> do
+        startManagedCommand session workdir command >>= \case
+            Left err -> pure (Left err)
+            Right (commandId, task) ->
+                restore
+                    (waitForInitialYield
+                        session commandId task yieldMs onSnapshot)
+                    `onException` do
+                        removeCommand session commandId
+                        stopShellCommand task.managedRunning
+
+continueCodexShellCommand
+    :: CodexShellSession
+    -> Int
+    -> Text
+    -> Int
+    -> IO (Either Text CodexShellResult)
+continueCodexShellCommand session commandId input yieldMs = do
+    lookupCommand session commandId >>= \case
+        Nothing -> pure (Left (unknownSession commandId))
+        Just task ->
+            withMVar task.managedLock \() -> do
+                current <- lookupCommand session commandId
+                case current of
+                    Nothing -> pure (Left (unknownSession commandId))
+                    Just _ -> do
+                        tryReadMVar task.managedRunning.runningResult >>= \case
+                            Just result ->
+                                finishCommand session commandId task result
+                            Nothing -> do
+                                inputResult <-
+                                    if Text.null input
+                                        then pure (Right ())
+                                        else if input == "\ETX"
+                                            then interruptShellCommand task.managedRunning
+                                                >> pure (Right ())
+                                            else writeShellCommandInput
+                                                task.managedRunning
+                                                input
+                                case inputResult of
+                                    Right () ->
+                                        waitForContinuation
+                                            session commandId task yieldMs
+                                    Left err ->
+                                        tryReadMVar
+                                            task.managedRunning.runningResult
+                                                >>= \case
+                                                    Just result ->
+                                                        finishCommand
+                                                            session
+                                                            commandId
+                                                            task
+                                                            result
+                                                    Nothing -> pure (Left err)
+
+waitForInitialYield
+    :: CodexShellSession
+    -> Int
+    -> ManagedCommand
+    -> Int
+    -> (Text -> Text -> IO ())
+    -> IO (Either Text CodexShellResult)
+waitForInitialYield session commandId task yieldMs onSnapshot =
+    withAsync sampleSnapshots \_sampler -> do
+        stopped <- race
+            (waitCancel session.sessionEnv.toolCancel)
+            (race
+                (threadDelay (max 1 yieldMs * 1000))
+                (readMVar task.managedRunning.runningResult))
+        case stopped of
+            Left () ->
+                removeCommand session commandId
+                    >> stopShellCommand task.managedRunning
+                    >> pure (Left "Error: Command cancelled")
+            Right (Left ()) ->
+                runningResult commandId task
+            Right (Right result) ->
+                finishCommand session commandId task result
+  where
+    sampleSnapshots = go Nothing
+    go previous = do
+        threadDelay 100000
+        snapshot <- runningLiveOutput task.managedRunning
+        when (Just snapshot /= previous && snapshot /= ("", "")) $
+            uncurry onSnapshot snapshot
+        go (Just snapshot)
+
+waitForContinuation
+    :: CodexShellSession
+    -> Int
+    -> ManagedCommand
+    -> Int
+    -> IO (Either Text CodexShellResult)
+waitForContinuation session commandId task yieldMs = do
+    stopped <- race
+        (waitCancel session.sessionEnv.toolCancel)
+        (race
+            (threadDelay (max 1 yieldMs * 1000))
+            (readMVar task.managedRunning.runningResult))
+    case stopped of
+        Left () ->
+            pure $ Left $
+                "Error: Poll cancelled; session "
+                    <> Text.pack (show commandId)
+                    <> " is still running"
+        Right (Left ()) ->
+            runningResult commandId task
+        Right (Right result) ->
+            finishCommand session commandId task result
+
+finishCommand
+    :: CodexShellSession
+    -> Int
+    -> ManagedCommand
+    -> CommandResult
+    -> IO (Either Text CodexShellResult)
+finishCommand session commandId task result = do
+    (out, err) <- takeRunningOutput task
+    removeCommand session commandId
+    stopShellCommand task.managedRunning
+    pure $ Right $ CodexShellFinished result
+        { commandStdout = out
+        , commandStderr = err
+        }
+
+runningResult :: Int -> ManagedCommand -> IO (Either Text CodexShellResult)
+runningResult commandId task = do
+    (out, err) <- takeRunningOutput task
+    pure $ Right CodexShellRunning
+        { codexShellSessionId = commandId
+        , codexShellStdout = out
+        , codexShellStderr = err
+        }
+
+takeRunningOutput :: ManagedCommand -> IO (Text, Text)
+takeRunningOutput task = do
+    cursor <- readIORef task.managedCursor
+    (output, nextCursor) <- runningOutputSince task.managedRunning cursor
+    writeIORef task.managedCursor nextCursor
+    pure output
+
+nextCommandId :: CodexShellSession -> IO Int
+nextCommandId session =
+    atomicModifyIORef' session.sessionNextId \current ->
+        let next = current + 1
+        in (next, next)
+
+startManagedCommand
+    :: CodexShellSession
+    -> OsPath
+    -> String
+    -> IO (Either Text (Int, ManagedCommand))
+startManagedCommand session workdir command =
+    modifyMVar session.sessionCommands \case
+        Nothing ->
+            pure
+                ( Nothing
+                , Left "Cannot start command: managed shell session is closed."
+                )
+        Just store
+            | Map.size store.storeCommands >= maxManagedCommands ->
+                pure
+                    ( Just store
+                    , Left "Cannot start command: managed shell session is full."
+                    )
+            | otherwise ->
+                startShellCommandWithInput
+                    session.sessionEnv
+                    workdir
+                    command >>= \case
+                        Left err -> pure (Just store, Left err)
+                        Right running -> do
+                            prepared <-
+                                (do
+                                    commandId <- nextCommandId session
+                                    task <- ManagedCommand running
+                                        <$> newMVar ()
+                                        <*> newIORef initialRunningOutputCursor
+                                    pure (commandId, task))
+                                    `onException` stopShellCommand running
+                            let (commandId, task) = prepared
+                            pure
+                                ( Just store
+                                    { storeCommands =
+                                        Map.insert
+                                            commandId
+                                            task
+                                            store.storeCommands
+                                    }
+                                , Right (commandId, task)
+                                )
+
+lookupCommand :: CodexShellSession -> Int -> IO (Maybe ManagedCommand)
+lookupCommand session commandId =
+    withMVar session.sessionCommands \case
+        Nothing -> pure Nothing
+        Just store -> pure (Map.lookup commandId store.storeCommands)
+
+removeCommand :: CodexShellSession -> Int -> IO ()
+removeCommand session commandId =
+    modifyMVar session.sessionCommands \case
+        Nothing -> pure (Nothing, ())
+        Just store ->
+            pure
+                ( Just store
+                    { storeCommands = Map.delete commandId store.storeCommands }
+                , ()
+                )
+
+unknownSession :: Int -> Text
+unknownSession commandId =
+    "Unknown session_id: " <> Text.pack (show commandId)

--- a/packages/agent-core/src/Agent/Tools/IO.hs
+++ b/packages/agent-core/src/Agent/Tools/IO.hs
@@ -14,9 +14,15 @@ module Agent.Tools.IO
     , runShellCommand
     , runShellCommandStreaming
     , startShellCommand
+    , startShellCommandWithInput
+    , writeShellCommandInput
+    , interruptShellCommand
     , stopShellCommand
     , terminateProcessGroup
+    , RunningOutputCursor
+    , initialRunningOutputCursor
     , runningLiveOutput
+    , runningOutputSince
     ) where
 
 import Agent.Cancel (isCancelled, waitCancel)
@@ -43,7 +49,9 @@ import Control.Concurrent.Async
     )
 import Control.Concurrent.MVar
     ( MVar
+    , modifyMVar
     , newEmptyMVar
+    , newMVar
     , readMVar
     , tryReadMVar
     , tryPutMVar
@@ -63,9 +71,10 @@ import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.ByteString as BS
 import Data.Text.Encoding (decodeUtf8With)
+import qualified Data.Text.Encoding as TextEncoding
 import Data.Text.Encoding.Error (lenientDecode)
 import System.Exit (ExitCode(..))
-import System.IO (Handle, hClose)
+import System.IO (Handle, hClose, hFlush)
 import System.Posix.Signals
     ( nullSignal
     , sigINT
@@ -125,8 +134,11 @@ data RunningCommand = RunningCommand
     { runningHandle :: !ProcessHandle
     , runningGroupId :: !(Maybe ProcessGroupID)
     , runningResult :: !(MVar CommandResult)
+    , runningStdin :: !(MVar (Maybe Handle))
     , runningStdout :: !(IORef CapturedBytes)
     , runningStderr :: !(IORef CapturedBytes)
+    , runningStdoutRecent :: !(IORef RecentBytes)
+    , runningStderrRecent :: !(IORef RecentBytes)
     , runningStdoutHandle :: !Handle
     , runningStderrHandle :: !Handle
     , runningSupervisor :: !(Async ())
@@ -137,6 +149,19 @@ data CapturedBytes = CapturedBytes
     , capturedDropped :: !Int
     }
 
+data RecentBytes = RecentBytes
+    { recentBytes :: !BS.ByteString
+    , recentDropped :: !Int
+    }
+
+data RunningOutputCursor = RunningOutputCursor
+    { cursorStdoutBytes :: !Int
+    , cursorStderrBytes :: !Int
+    }
+
+initialRunningOutputCursor :: RunningOutputCursor
+initialRunningOutputCursor = RunningOutputCursor 0 0
+
 -- | Bytes already drained from a still-running command, decoded and capped.
 runningLiveOutput :: RunningCommand -> IO (Text, Text)
 runningLiveOutput running = do
@@ -145,6 +170,24 @@ runningLiveOutput running = do
     pure
         ( renderCapturedBytes out
         , renderCapturedBytes err
+        )
+
+-- | Return output produced after a prior cursor. The capture is a bounded tail,
+-- so a slow reader may receive a truncation marker followed by the newest data.
+runningOutputSince
+    :: RunningCommand
+    -> RunningOutputCursor
+    -> IO ((Text, Text), RunningOutputCursor)
+runningOutputSince running cursor = do
+    out <- readIORef running.runningStdoutRecent
+    err <- readIORef running.runningStderrRecent
+    let (outText, outCursor) =
+            renderRecentBytesSince cursor.cursorStdoutBytes out
+        (errText, errCursor) =
+            renderRecentBytesSince cursor.cursorStderrBytes err
+    pure
+        ( (outText, errText)
+        , RunningOutputCursor outCursor errCursor
         )
 
 -- | Run a shell command in @workdir@, killing the process group on timeout.
@@ -200,8 +243,8 @@ runShellCommandStreaming env workdir command timeoutMs onSnapshot =
                     -- fills one pipe cannot deadlock the other.
                     withAsync sampleSnapshots \_sampler -> do
                         (out, err) <- concurrently
-                            (drainHandle env.toolStdoutCap hout stdoutRef)
-                            (drainHandle env.toolStdoutCap herr stderrRef)
+                            (drainHandle env.toolStdoutCap hout stdoutRef Nothing)
+                            (drainHandle env.toolStdoutCap herr stderrRef Nothing)
                         code <- waitForProcess processHandle
                         emitSnapshot
                         pure (out, err, code)
@@ -292,7 +335,25 @@ startShellCommand
     -> OsPath
     -> String
     -> IO (Either Text RunningCommand)
-startShellCommand env workdir command = do
+startShellCommand = startShellCommandWithStdin False
+
+-- | Start a command without waiting and retain stdin for later writes.
+-- Call 'stopShellCommand' when its owner is closed or the task is explicitly
+-- killed.
+startShellCommandWithInput
+    :: ToolEnv
+    -> OsPath
+    -> String
+    -> IO (Either Text RunningCommand)
+startShellCommandWithInput = startShellCommandWithStdin True
+
+startShellCommandWithStdin
+    :: Bool
+    -> ToolEnv
+    -> OsPath
+    -> String
+    -> IO (Either Text RunningCommand)
+startShellCommandWithStdin keepStdin env workdir command = do
     let spec = (shell command)
             { cwd = Just (unsafeToFilePath workdir)
             , std_in = CreatePipe
@@ -301,37 +362,49 @@ startShellCommand env workdir command = do
             , create_group = True
             }
     try @_ @SomeException
-        (acquireRunningCommand spec env.toolStdoutCap) >>= \case
+        (acquireRunningCommand spec env.toolStdoutCap keepStdin) >>= \case
         Left err -> pure $ Left $ "Failed to start command: " <> Text.pack (show err)
         Right running -> pure (Right running)
 
-acquireRunningCommand :: CreateProcess -> Int -> IO RunningCommand
-acquireRunningCommand spec outputCap = mask \restore -> do
+acquireRunningCommand :: CreateProcess -> Int -> Bool -> IO RunningCommand
+acquireRunningCommand spec outputCap keepStdin = mask \restore -> do
     created@(_, _, _, processHandle) <- createProcess spec
     groupId <- getPid processHandle
     case created of
         (Just hin, Just hout, Just herr, _) -> do
+            stdinVar <- newMVar (if keepStdin then Just hin else Nothing)
             let closePipes =
                     mapM_ (void . try @_ @SomeException . hClose) [hin, hout, herr]
                 stopCreated = do
                     terminateProcessGroup groupId processHandle
                     closePipes
-            hClose hin `onException` stopCreated
+            unless keepStdin $
+                hClose hin `onException` stopCreated
             resultVar <- newEmptyMVar
             stdoutRef <- newIORef emptyCapturedBytes
             stderrRef <- newIORef emptyCapturedBytes
+            stdoutRecentRef <- newIORef emptyRecentBytes
+            stderrRecentRef <- newIORef emptyRecentBytes
             supervisor <- asyncWithUnmask \unmask ->
                 (do
                     result <- try @_ @SomeException $ unmask do
                         ((out, err), code) <- concurrently
                             (concurrently
-                                (drainHandle outputCap hout stdoutRef)
-                                (drainHandle outputCap herr stderrRef))
+                                (drainHandle
+                                    outputCap hout stdoutRef (Just stdoutRecentRef))
+                                (drainHandle
+                                    outputCap herr stderrRef (Just stderrRecentRef)))
                             (waitForProcessPolling processHandle)
                         pure (out, err, code)
                     commandResult <- case result of
                         Left exception -> do
                             terminateProcessGroup groupId processHandle
+                            let diagnostic =
+                                    TextEncoding.encodeUtf8 (Text.pack (show exception))
+                            atomicModifyIORef' stderrRef \soFar ->
+                                (appendCapturedBytes outputCap diagnostic soFar, ())
+                            atomicModifyIORef' stderrRecentRef \soFar ->
+                                (appendRecentBytes outputCap diagnostic soFar, ())
                             pure (failedCommandResult exception)
                         Right (out, err, code) ->
                             pure CommandResult
@@ -344,13 +417,17 @@ acquireRunningCommand spec outputCap = mask \restore -> do
                     void $ tryPutMVar resultVar commandResult)
                 `finally` do
                     void $ tryPutMVar resultVar cancelledResult
+                    closeRunningStdinVar stdinVar
                     mapM_ (void . try @_ @SomeException . hClose) [hout, herr]
             let running = RunningCommand
                     { runningHandle = processHandle
                     , runningGroupId = groupId
                     , runningResult = resultVar
+                    , runningStdin = stdinVar
                     , runningStdout = stdoutRef
                     , runningStderr = stderrRef
+                    , runningStdoutRecent = stdoutRecentRef
+                    , runningStderrRecent = stderrRecentRef
                     , runningStdoutHandle = hout
                     , runningStderrHandle = herr
                     , runningSupervisor = supervisor
@@ -361,8 +438,37 @@ acquireRunningCommand spec outputCap = mask \restore -> do
             closeOptionalPipes [hin, hout, herr]
             fail "Failed to capture command output"
 
+-- | Write input to a running command. The command must have been started with
+-- 'startShellCommandWithInput'.
+writeShellCommandInput :: RunningCommand -> Text -> IO (Either Text ())
+writeShellCommandInput running input =
+    modifyMVar running.runningStdin \case
+        Nothing ->
+            pure (Nothing, Left "stdin is closed")
+        Just handle ->
+            try @_ @SomeException
+                (BS.hPut handle (TextEncoding.encodeUtf8 input) >> hFlush handle) >>= \case
+                    Left exception -> do
+                        void $ try @_ @SomeException (hClose handle)
+                        pure
+                            ( Nothing
+                            , Left ("Failed to write stdin: " <> Text.pack (show exception))
+                            )
+                    Right () ->
+                        pure (Just handle, Right ())
+
+-- | Send an interrupt to the command's process group.
+interruptShellCommand :: RunningCommand -> IO ()
+interruptShellCommand running =
+    case running.runningGroupId of
+        Nothing ->
+            void $ try @_ @SomeException (terminateProcess running.runningHandle)
+        Just groupId ->
+            void $ try @_ @SomeException (signalProcessGroup sigINT groupId)
+
 stopShellCommand :: RunningCommand -> IO ()
 stopShellCommand running = do
+    closeRunningStdin running
     finished <- tryReadMVar running.runningResult
     case finished of
         Just _ ->
@@ -387,6 +493,15 @@ closeRunningPipes running =
     mapM_ (void . try @_ @SomeException . hClose)
         [running.runningStdoutHandle, running.runningStderrHandle]
 
+closeRunningStdin :: RunningCommand -> IO ()
+closeRunningStdin = closeRunningStdinVar . (.runningStdin)
+
+closeRunningStdinVar :: MVar (Maybe Handle) -> IO ()
+closeRunningStdinVar stdinVar =
+    modifyMVar stdinVar \current -> do
+        mapM_ (void . try @_ @SomeException . hClose) current
+        pure (Nothing, ())
+
 closeOptionalPipes :: [Maybe Handle] -> IO ()
 closeOptionalPipes =
     mapM_ (mapM_ (void . try @_ @SomeException . hClose))
@@ -401,8 +516,13 @@ failedCommandResult exception = CommandResult
     }
 
 -- | Read the handle in chunks so a live snapshot can see output before EOF.
-drainHandle :: Int -> Handle -> IORef CapturedBytes -> IO CapturedBytes
-drainHandle cap handle ref = go
+drainHandle
+    :: Int
+    -> Handle
+    -> IORef CapturedBytes
+    -> Maybe (IORef RecentBytes)
+    -> IO CapturedBytes
+drainHandle cap handle ref recentRef = go
   where
     go = do
         chunk <- BS.hGetSome handle 8192
@@ -411,12 +531,23 @@ drainHandle cap handle ref = go
             else do
                 atomicModifyIORef' ref \soFar ->
                     (appendCapturedBytes cap chunk soFar, ())
+                mapM_
+                    (\recent ->
+                        atomicModifyIORef' recent \soFar ->
+                            (appendRecentBytes cap chunk soFar, ()))
+                    recentRef
                 go
 
 emptyCapturedBytes :: CapturedBytes
 emptyCapturedBytes = CapturedBytes
     { capturedBytes = BS.empty
     , capturedDropped = 0
+    }
+
+emptyRecentBytes :: RecentBytes
+emptyRecentBytes = RecentBytes
+    { recentBytes = BS.empty
+    , recentDropped = 0
     }
 
 appendCapturedBytes :: Int -> BS.ByteString -> CapturedBytes -> CapturedBytes
@@ -442,6 +573,39 @@ renderCapturedBytes captured =
                 "\n...[truncated "
                     <> Text.pack (show captured.capturedDropped)
                     <> " bytes]"
+
+appendRecentBytes :: Int -> BS.ByteString -> RecentBytes -> RecentBytes
+appendRecentBytes cap chunk recent
+    | BS.null chunk = recent
+    | cap <= 0 =
+        recent { recentBytes = recent.recentBytes <> chunk }
+    | otherwise =
+        let combined = recent.recentBytes <> chunk
+            overflow = max 0 (BS.length combined - cap)
+        in RecentBytes
+            { recentBytes = BS.drop overflow combined
+            , recentDropped = recent.recentDropped + overflow
+            }
+
+renderRecentBytesSince :: Int -> RecentBytes -> (Text, Int)
+renderRecentBytesSince cursor recent =
+    let retainedFrom = recent.recentDropped
+        total = retainedFrom + BS.length recent.recentBytes
+        missed = max 0 (retainedFrom - cursor)
+        offset = max 0 (min (BS.length recent.recentBytes) (cursor - retainedFrom))
+        bytes = BS.drop offset recent.recentBytes
+    in
+        ( truncationMarker missed <> decodeUtf8With lenientDecode bytes
+        , total
+        )
+
+truncationMarker :: Int -> Text
+truncationMarker dropped
+    | dropped <= 0 = ""
+    | otherwise =
+        "...[truncated "
+            <> Text.pack (show dropped)
+            <> " bytes]\n"
 
 waitForProcessPolling :: ProcessHandle -> IO ExitCode
 waitForProcessPolling processHandle =

--- a/packages/agent-core/test/Agent/ToolArgsSpec.hs
+++ b/packages/agent-core/test/Agent/ToolArgsSpec.hs
@@ -50,6 +50,14 @@ spec = describe "ToolArgs" do
         decodeSearch "{\"query\":\"invoice\",\"limit\":\"5\"}"
             `shouldBe` Left "Expected integer for key: limit"
 
+    it "parses required exact integers" do
+        parseRequiredInt (Aeson.object ["session_id" .= (42 :: Int)])
+            `shouldBe` Right 42
+        parseRequiredInt (Aeson.object [])
+            `shouldBe` Left "Missing parameter: session_id"
+        parseRequiredInt (Aeson.object ["session_id" .= (1.5 :: Double)])
+            `shouldBe` Left "Expected integer for key: session_id"
+
     it "defaults integers only when absent or null" do
         decodeSearch "{\"query\":\"invoice\"}"
             `shouldBe` Right (SearchArgs "invoice" 10 Nothing)
@@ -130,6 +138,10 @@ parseOptionalInt =
 parseOptionalIntString :: Aeson.Value -> Either Text (Maybe Int)
 parseOptionalIntString =
     firstText . parseEither (objectArgs $ \o -> optIntOrString o "timeout")
+
+parseRequiredInt :: Aeson.Value -> Either Text Int
+parseRequiredInt =
+    firstText . parseEither (objectArgs $ \o -> reqInt o "session_id")
 
 firstText :: Either String a -> Either Text a
 firstText = either (Left . stripAesonPrefix . toText) Right

--- a/packages/agent-core/test/Agent/Tools/CodexSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/CodexSpec.hs
@@ -14,12 +14,17 @@ import Agent.ToolDispatch
     )
 import Agent.ToolDSL (PropertySchema(..), PropertyType(..))
 import Agent.Tools (CodingTools(..), appToolHandlers, codingToolsFor, defaultToolEnv)
-import Agent.Tools.Types (jsonToolParameters)
+import Agent.Tools.Types (jsonToolParameters, toolAllowsWithoutPrompt)
 import Agent.Tools.ApplyPatch (applyPatch, parsePatch)
 import Agent.Tools.Codex (codexTools)
+import Agent.Tools.Codex.Shell
+    ( closeCodexShellSession
+    , newCodexShellSession
+    )
 import Agent.Tools.Ghci (closeGhciSession, newGhciSession)
 import Agent.Tools.PlanMode (isPlanModeActive, newPlanModeEnv)
 import Agent.Tools.Types (AppTool(..), ToolEnv(..))
+import Control.Concurrent (threadDelay)
 import Control.Exception.Safe (bracket, finally)
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.KeyMap as KeyMap
@@ -48,6 +53,7 @@ spec = describe "Agent.Tools.Codex" do
             let names = map (.appToolName) coding.codingAppTools
             names `shouldBe`
                 [ "shell_command"
+                , "write_stdin"
                 , "apply_patch"
                 , "update_plan"
                 , "run_ghci"
@@ -105,15 +111,16 @@ spec = describe "Agent.Tools.Codex" do
     it "lets the OpenAI agent enter plan mode proactively" do
         withTempEnv \env -> do
             ghci <- newGhciSession env
+            shell <- newCodexShellSession env
             plan <- newPlanModeEnv env.toolCwd Nothing
-            tools <- codexTools env ghci plan Nothing
+            tools <- codexTools env shell ghci plan Nothing
             (do
                 result <- dispatchToolCall defaultLoopDispatch (appToolHandlers tools)
                     (functionToolCall "call-enter-plan" "enter_plan_mode"
                         "{\"explanation\":\"The user requested a design plan.\"}")
                 result.output `shouldSatisfy` Text.isInfixOf "entered plan mode"
                 isPlanModeActive plan `shouldReturn` True)
-                `finally` closeGhciSession ghci
+                `finally` (closeGhciSession ghci >> closeCodexShellSession shell)
 
     it "adds, updates, and deletes files via apply_patch" do
         withTempEnv \env -> do
@@ -274,6 +281,133 @@ spec = describe "Agent.Tools.Codex" do
                 "{\"command\":\"sleep 5\",\"timeout_ms\":\"200\"}"
             timed `shouldSatisfy` Text.isInfixOf "timed out"
 
+    it "rejects timeout_ms together with yield_time_ms" do
+        withTempEnv \env -> do
+            output <- runFn env "shell_command"
+                "{\"command\":\"sleep 1\",\"timeout_ms\":100,\"yield_time_ms\":10}"
+            output `shouldSatisfy`
+                Text.isInfixOf "timeout_ms and yield_time_ms are mutually exclusive"
+
+    it "only treats write_stdin polling as read-only" do
+        withTempEnv \env ->
+            withCodexTools env \tools -> do
+                let tool =
+                        fromMaybe (error "missing write_stdin") $
+                            findTool "write_stdin" tools
+                toolAllowsWithoutPrompt tool
+                    (functionToolCall "poll" "write_stdin" "{\"session_id\":1}")
+                    `shouldReturn` True
+                toolAllowsWithoutPrompt tool
+                    (functionToolCall "write" "write_stdin"
+                        "{\"session_id\":1,\"chars\":\"hello\\n\"}")
+                    `shouldReturn` False
+
+    it "yields a long-running shell_command and polls it to completion" do
+        withTempEnv \env ->
+            withCodexTools env \tools -> do
+                started <- runFnWith tools "shell_command"
+                    "{\"command\":\"printf first; sleep 0.2; printf second\",\"workdir\":\".\",\"yield_time_ms\":20}"
+                started `shouldSatisfy` Text.isInfixOf "Process still running"
+                started `shouldSatisfy` Text.isInfixOf "first"
+                let sessionId = sessionIdFrom started
+                finished <- runFnWith tools "write_stdin" $
+                    "{\"session_id\":" <> Text.pack (show sessionId)
+                        <> ",\"yield_time_ms\":1000}"
+                finished `shouldSatisfy` Text.isInfixOf "Exit code: 0"
+                finished `shouldSatisfy` Text.isInfixOf "second"
+                finished `shouldNotSatisfy` Text.isInfixOf "firstsecond"
+
+    it "writes stdin to a managed shell_command" do
+        withTempEnv \env ->
+            withCodexTools env \tools -> do
+                started <- runFnWith tools "shell_command"
+                    "{\"command\":\"IFS= read -r line; printf 'got:%s' \\\"$line\\\"\",\"workdir\":\".\",\"yield_time_ms\":20}"
+                let sessionId = sessionIdFrom started
+                finished <- runFnWith tools "write_stdin" $
+                    "{\"session_id\":" <> Text.pack (show sessionId)
+                        <> ",\"chars\":\"hello\\n\",\"yield_time_ms\":1000}"
+                finished `shouldSatisfy` Text.isInfixOf "Exit code: 0"
+                finished `shouldSatisfy` Text.isInfixOf "got:hello"
+
+    it "returns completed output when stdin is written after process exit" do
+        withTempEnv \env ->
+            withCodexTools env \tools -> do
+                started <- runFnWith tools "shell_command"
+                    "{\"command\":\"sleep 0.05; printf done\",\"workdir\":\".\",\"yield_time_ms\":10}"
+                let sessionId = sessionIdFrom started
+                threadDelay 150000
+                finished <- runFnWith tools "write_stdin" $
+                    "{\"session_id\":" <> Text.pack (show sessionId)
+                        <> ",\"chars\":\"late\",\"yield_time_ms\":10}"
+                finished `shouldSatisfy` Text.isInfixOf "Exit code: 0"
+                finished `shouldSatisfy` Text.isInfixOf "done"
+
+    it "keeps completed sessions available until they are polled" do
+        withTempEnv \env ->
+            withCodexTools env \tools -> do
+                first <- runFnWith tools "shell_command"
+                    "{\"command\":\"sleep 0.05; printf first\",\"workdir\":\".\",\"yield_time_ms\":10}"
+                let firstId = sessionIdFrom first
+                threadDelay 150000
+                _ <- runFnWith tools "shell_command"
+                    "{\"command\":\"sleep 1\",\"workdir\":\".\",\"yield_time_ms\":10}"
+                finished <- runFnWith tools "write_stdin" $
+                    "{\"session_id\":" <> Text.pack (show firstId)
+                        <> ",\"yield_time_ms\":10}"
+                finished `shouldSatisfy` Text.isInfixOf "Exit code: 0"
+                finished `shouldSatisfy` Text.isInfixOf "first"
+
+    it "returns new output even after the capture cap has rolled forward" do
+        withTempEnv \base -> do
+            let env = base { toolStdoutCap = 64 }
+            withCodexTools env \tools -> do
+                started <- runFnWith tools "shell_command"
+                    "{\"command\":\"yes x | head -c 4096; sleep 0.1; printf LATE; sleep 0.5\",\"workdir\":\".\",\"yield_time_ms\":50}"
+                let sessionId = sessionIdFrom started
+                threadDelay 200000
+                polled <- runFnWith tools "write_stdin" $
+                    "{\"session_id\":" <> Text.pack (show sessionId)
+                        <> ",\"yield_time_ms\":1}"
+                polled `shouldSatisfy` Text.isInfixOf "LATE"
+
+    it "rejects a command before spawning when the session is full" do
+        withTempEnv \env ->
+            withCodexTools env \tools -> do
+                mapM_
+                    (\_ -> do
+                        started <- runFnWith tools "shell_command"
+                            "{\"command\":\"sleep 5\",\"workdir\":\".\",\"yield_time_ms\":1}"
+                        started `shouldSatisfy` Text.isInfixOf "session_id:")
+                    [1 :: Int .. 64]
+                let marker = toFilePath env.toolCwd </> "over-cap"
+                rejected <- runFnWith tools "shell_command" $
+                    "{\"command\":\"printf bad > "
+                        <> Text.pack marker
+                        <> "\",\"workdir\":\".\",\"yield_time_ms\":1}"
+                rejected `shouldSatisfy` Text.isInfixOf "session is full"
+                threadDelay 100000
+                doesFileExist marker `shouldReturn` False
+
+    it "rejects unknown managed shell sessions" do
+        withTempEnv \env ->
+            withCodexTools env \tools -> do
+                output <- runFnWith tools "write_stdin"
+                    "{\"session_id\":999,\"yield_time_ms\":1}"
+                output `shouldSatisfy` Text.isInfixOf "Unknown session_id: 999"
+
+    it "stops managed shell commands when coding tools close" do
+        withTempEnv \env -> do
+            let marker = toFilePath env.toolCwd </> "escaped"
+            coding <- codingToolsFor OpenAIProvider env Nothing Nothing
+            started <- runFnWith coding.codingAppTools "shell_command" $
+                "{\"command\":\"sleep 0.3; printf done > "
+                    <> Text.pack marker
+                    <> "\",\"workdir\":\".\",\"yield_time_ms\":20}"
+            started `shouldSatisfy` Text.isInfixOf "session_id:"
+            coding.codingClose
+            threadDelay 500000
+            doesFileExist marker `shouldReturn` False
+
     it "stores an update_plan and rejects two in_progress steps" do
         withTempEnv \env -> do
             ok <- runFn env "update_plan"
@@ -296,16 +430,43 @@ runPatch env patch = withCodexTools env \tools -> do
 
 runFn :: ToolEnv -> Text -> Text -> IO Text
 runFn env name arguments = withCodexTools env \tools -> do
+    runFnWith tools name arguments
+
+runFnWith :: [AppTool] -> Text -> Text -> IO Text
+runFnWith tools name arguments = do
     result <- dispatchToolCall defaultLoopDispatch (appToolHandlers tools)
         (functionToolCall "call-1" name arguments)
     pure result.output
 
 withCodexTools :: ToolEnv -> ([AppTool] -> IO a) -> IO a
 withCodexTools env action = do
+    shell <- newCodexShellSession env
     ghci <- newGhciSession env
     plan <- newPlanModeEnv env.toolCwd Nothing
-    tools <- codexTools env ghci plan Nothing
-    action tools `finally` closeGhciSession ghci
+    tools <- codexTools env shell ghci plan Nothing
+    action tools
+        `finally` (closeGhciSession ghci >> closeCodexShellSession shell)
+
+sessionIdFrom :: Text -> Int
+sessionIdFrom output =
+    case
+        [ Text.strip rest
+        | line <- Text.lines output
+        , Just rest <- [Text.stripPrefix "session_id:" line]
+        ] of
+        value : _ -> case reads (Text.unpack value) of
+            [(sessionId, "")] -> sessionId
+            _ -> error ("invalid session_id: " <> Text.unpack value)
+        [] -> error ("missing session_id in: " <> Text.unpack output)
+
+findTool :: Text -> [AppTool] -> Maybe AppTool
+findTool name = go
+  where
+    go :: [AppTool] -> Maybe AppTool
+    go [] = Nothing
+    go (tool : tools)
+        | tool.appToolName == name = Just tool
+        | otherwise = go tools
 
 withTempEnv :: (ToolEnv -> IO a) -> IO a
 withTempEnv action = do

--- a/packages/agent-core/test/Agent/Tools/IOSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/IOSpec.hs
@@ -19,7 +19,9 @@ import Agent.Tools.IO
     , runShellCommandStreaming
     , runningLiveOutput
     , startShellCommand
+    , startShellCommandWithInput
     , stopShellCommand
+    , writeShellCommandInput
     , writeTextFile
     )
 import Agent.Tools.Types (ToolEnv(..), defaultToolEnv)
@@ -235,6 +237,25 @@ spec = describe "Agent.Tools.IO" do
 
     it "collects both output streams from a background shell command" do
         withTempDir checkBackgroundOutput
+
+    it "keeps ordinary background-command stdin closed" do
+        withTempDir \dir -> do
+            let osDir = fromFilePath dir
+            env <- defaultToolEnv osDir
+            Right running <- startShellCommand env osDir
+                "if IFS= read -r line; then printf unexpected; else printf eof; fi"
+            result <- readMVar running.runningResult
+            result.commandStdout `shouldBe` "eof"
+
+    it "writes to retained background-command stdin" do
+        withTempDir \dir -> do
+            let osDir = fromFilePath dir
+            env <- defaultToolEnv osDir
+            Right running <- startShellCommandWithInput env osDir
+                "IFS= read -r line; printf 'got:%s' \"$line\""
+            writeShellCommandInput running "hello\n" `shouldReturn` Right ()
+            result <- readMVar running.runningResult
+            result.commandStdout `shouldBe` "got:hello"
 
     it "caps live and final background output" do
         withTempDir checkBackgroundOutputCap

--- a/packages/agent-tui/src/Agent/TUI/Model.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model.hs
@@ -764,7 +764,7 @@ toggleSelected state =
 
 toolBlockKind :: Text -> BlockKind
 toolBlockKind name
-    | name `elem` ["run_terminal_cmd", "shell_command", "run_ghci"] =
+    | name `elem` ["run_terminal_cmd", "shell_command", "write_stdin", "run_ghci"] =
         BlockShell
     | name `elem` ["search_replace", "apply_patch"] =
         BlockEdit

--- a/packages/agent-tui/src/Agent/TUI/Presentation.hs
+++ b/packages/agent-tui/src/Agent/TUI/Presentation.hs
@@ -109,6 +109,7 @@ toolVerb name = case canonicalToolName name of
     "apply_patch" -> "Edited"
     "run_terminal_cmd" -> "$"
     "shell_command" -> "$"
+    "write_stdin" -> "Continued"
     "run_ghci" -> "$"
     "get_task_output" -> "Read"
     "kill_task" -> "Killed"
@@ -134,6 +135,8 @@ toolDetail call = case canonicalToolName call.name of
     "run_terminal_cmd" -> firstLine (jsonTextFieldDefault "command" call.arguments)
     "run_ghci" -> firstLine (jsonTextFieldDefault "expression" call.arguments)
     "shell_command" -> firstLine (jsonTextFieldDefault "command" call.arguments)
+    "write_stdin" ->
+        maybe "" ("session " <>) (jsonIntField "session_id" call.arguments)
     "apply_patch" -> fromMaybe "patch" (firstPatchPath call.arguments)
     "update_plan" -> "plan"
     "enter_plan_mode" -> "enter"
@@ -151,6 +154,14 @@ nonEmptyJsonText :: Text -> Text -> Maybe Text
 nonEmptyJsonText key input = jsonTextField key input >>= \value ->
     let stripped = Text.strip value
     in if Text.null stripped then Nothing else Just stripped
+
+jsonIntField :: Text -> Text -> Maybe Text
+jsonIntField key input = do
+    Aeson.Object object <- Aeson.decodeStrict (TextEncoding.encodeUtf8 input)
+    field <- KeyMap.lookup (Key.fromText key) object
+    case Aeson.fromJSON field :: Aeson.Result Int of
+        Aeson.Success value -> pure (Text.pack (show value))
+        Aeson.Error _ -> Nothing
 
 formatAgentList :: Text -> Maybe Text
 formatAgentList output = do

--- a/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
@@ -94,6 +94,16 @@ spec = describe "fullscreen UI reducer" do
                 block.blockBody `shouldBe` "exit: 0\nclean"
             _ -> expectationFailure "expected one completed tool block"
 
+    it "renders write_stdin as a shell block" do
+        let call = functionToolCall "c1" "write_stdin" "{\"session_id\":3}"
+            state = apply [UiLoop TurnStarted, UiLoop (ToolStarted call)]
+            blocks = Foldable.toList state.uiBlocks
+        case blocks of
+            [block] -> do
+                block.blockKind `shouldBe` BlockShell
+                block.blockTitle `shouldBe` "Continued session 3"
+            _ -> expectationFailure "expected one running shell block"
+
     it "applies tool output snapshots only to the matching running block" do
         let first = functionToolCall "c1" "run_terminal_cmd" "{\"command\":\"first\"}"
             second = functionToolCall "c2" "run_terminal_cmd" "{\"command\":\"second\"}"

--- a/packages/agent-tui/test/Agent/TUI/PresentationSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/PresentationSpec.hs
@@ -19,6 +19,9 @@ spec = describe "tool presentation" do
             (customToolCall "patch" "apply_patch"
                 "*** Begin Patch\n*** Update File: src/Main.hs\n*** End Patch")
             `shouldBe` "src/Main.hs"
+        summarizeToolCall
+            (functionToolCall "continue" "write_stdin" "{\"session_id\":12}")
+            `shouldBe` "Continued session 12"
 
     it "parses and truncates search-replace diffs once for all renderers" do
         let oldText = Text.intercalate "\\n"


### PR DESCRIPTION
## Summary

- add Codex-style managed background processes to `shell_command` via `yield_time_ms`
- add `write_stdin` for polling, stdin writes, and process-group interrupts
- retain newly produced output with bounded cursor-based capture and clean up all sessions with `codingClose`
- preserve foreground `timeout_ms` behavior and require approval for non-empty stdin writes
- render continuation calls as `Continued session N` in the CLI/TUI

Each `shell_command` still starts a fresh shell; yielded processes persist by session ID and use pipes rather than a PTY.

## Testing

- agent-core GHCi suite: 292 examples, 0 failures
- agent-tui GHCi suite: 78 examples, 0 failures
- multi-package GHCi load completed successfully
- live tmux smoke test: yielded `first`, polled `Continued session 1`, then completed with `second`
- `git diff --check`
