### PR TITLE
fix(tui): switch conversation when selecting subagent

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -35,6 +35,7 @@ import Agent.CLI.AgentViewport
     , formatAgentStatus
     , pickAgentViewport
     , renderAgentViewportPanelFor
+    , responseItemLines
     , responseItemPreviewLines
     , responseItemStepPreviews
     )
@@ -2084,14 +2085,19 @@ runSession options provider policy tools toolEnv planMode startup prompt pending
                                 current
                     in (reconciled, reconciled)
             sessions <- readIORef subagentSessions
-            let previewCount target =
-                    if null agents
-                        then Nothing
-                        else if target == selected
-                            then Just 12
-                            else if includeSummaries
-                                then Just 0
-                                else Nothing
+            let transcriptLines target items
+                    | null agents = []
+                    | target == selected = case target of
+                        AgentRoot ->
+                            responseItemPreviewLines 12 items
+                        AgentChild _
+                            | includeSummaries ->
+                                responseItemPreviewLines 12 items
+                            | otherwise ->
+                                responseItemLines items
+                    | includeSummaries =
+                        responseItemPreviewLines 0 items
+                    | otherwise = []
             rootSteps <-
                 if null agents
                     then pure []
@@ -2105,17 +2111,15 @@ runSession options provider policy tools toolEnv planMode startup prompt pending
                     , agentPath = "/root"
                     , agentStatus = "active"
                     , agentSteps = rootSteps
-                    , agentTranscript = case previewCount AgentRoot of
-                        Nothing -> []
-                        Just count ->
-                            responseItemPreviewLines count rootItems
+                    , agentTranscript =
+                        transcriptLines AgentRoot rootItems
                     }
             children <- mapM
-                (materializeChild previewCount sessions)
+                (materializeChild transcriptLines sessions)
                 agents
             pure (selected, rootEntry : children)
           where
-            materializeChild previewCount sessions (path, agentId, status) = do
+            materializeChild transcriptLines sessions (path, agentId, status) = do
                 let target = AgentChild agentId
                 items <- case Map.lookup agentId sessions of
                     Nothing -> pure []
@@ -2125,20 +2129,16 @@ runSession options provider policy tools toolEnv planMode startup prompt pending
                     (Just status)
                     items
                     (agentStepsForStatus 2 status)
-                let transcript = case previewCount target of
-                        Nothing -> []
-                        Just count ->
-                            compactAgentPreview count $
-                                (if null items
-                                    then ["(" <> formatAgentStatus status <> ")"]
-                                    else responseItemPreviewLines count items)
-                                    <> case status of
-                                        Completed (Just result)
-                                            | not (Text.null (Text.strip result)) ->
-                                                ["assistant: " <> Text.strip result]
-                                        Errored message ->
-                                            ["error: " <> Text.strip message]
-                                        _ -> []
+                let transcript =
+                        transcriptLines target items
+                            <> case status of
+                                Completed (Just result)
+                                    | null items
+                                    , not (Text.null (Text.strip result)) ->
+                                        ["assistant: " <> Text.strip result]
+                                Errored message ->
+                                    ["error: " <> Text.strip message]
+                                _ -> []
                 pure AgentEntry
                     { agentTarget = target
                     , agentPath = taskPathText path
@@ -2146,13 +2146,6 @@ runSession options provider policy tools toolEnv planMode startup prompt pending
                     , agentSteps = steps
                     , agentTranscript = transcript
                     }
-            compactAgentPreview count rows
-                | length rows <= count = rows
-                | otherwise = case rows of
-                    [] -> []
-                    firstLine : _ ->
-                        firstLine
-                            : drop (max 0 (length rows - count)) rows
         agentViewport = AgentViewportEnv
             { viewportSelected = selectedAgent
             , viewportEntries = snd <$> loadAgentSnapshot True

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -17,6 +17,7 @@ module Agent.CLI.TUI.App
     , newFullscreenInputBuffer
     , newFullscreenRuntime
     , newFullscreenRuntimeWithSyntaxLoader
+    , selectedAgentConversation
     , loadSyntaxHighlighterForRuntime
     , queuedFullscreenInputDisplays
     , readFullscreenLine
@@ -1561,18 +1562,75 @@ drawWorkspace state =
                                 ]
 
 drawConversationPane :: AppState -> Widget Name
-drawConversationPane state
-    | conversationIsEmpty state.appUi =
-        padLeftRight 2 $
-            vBox
-                [ drawTranscript state
-                , drawEmptyConversation state
-                ]
-    | otherwise =
-        withVScrollBarRenderer conversationScrollbarRenderer $
-            withVScrollBars OnRight $
-                viewport ConversationViewport Vertical $
-                    padLeftRight 2 (drawTranscript state)
+drawConversationPane state =
+    case selectedChildEntry state of
+        Just entry ->
+            withVScrollBarRenderer conversationScrollbarRenderer $
+                withVScrollBars OnRight $
+                    viewport ConversationViewport Vertical $
+                        padLeftRight 2 (drawAgentConversation entry)
+        Nothing
+            | conversationIsEmpty state.appUi ->
+                padLeftRight 2 $
+                    vBox
+                        [ drawTranscript state
+                        , drawEmptyConversation state
+                        ]
+            | otherwise ->
+                withVScrollBarRenderer conversationScrollbarRenderer $
+                    withVScrollBars OnRight $
+                        viewport ConversationViewport Vertical $
+                            padLeftRight 2 (drawTranscript state)
+
+selectedChildEntry :: AppState -> Maybe AgentEntry
+selectedChildEntry state =
+    selectedAgentConversation
+        state.appAgentSelected
+        state.appAgentEntries
+
+selectedAgentConversation
+    :: AgentTarget
+    -> [AgentEntry]
+    -> Maybe AgentEntry
+selectedAgentConversation selected entries = case selected of
+    AgentRoot -> Nothing
+    target ->
+        find ((== target) . (.agentTarget)) entries
+
+drawAgentConversation :: AgentEntry -> Widget Name
+drawAgentConversation entry =
+    vBox
+        [ withAttr Theme.headingAttr $
+            txt ("Viewing " <> entry.agentPath)
+        , withAttr Theme.mutedAttr $
+            txt
+                (entry.agentStatus
+                    <> " · input is sent to /root")
+        , padTop (Pad 1) $
+            case entry.agentTranscript of
+                [] ->
+                    withAttr Theme.mutedAttr $
+                        txt "(no transcript yet)"
+                rows ->
+                    vBox (map drawAgentTranscriptLine rows)
+        ]
+
+drawAgentTranscriptLine :: Text -> Widget Name
+drawAgentTranscriptLine line =
+    padBottom (Pad 1) $
+        case Text.breakOn ": " line of
+            ("user", body) ->
+                withAttr Theme.userAttr $
+                    padAll 1 (txtWrap (Text.drop 2 body))
+            ("assistant", body) ->
+                padLeft (Pad 3) $
+                    withAttr Theme.assistantAttr $
+                        txtWrap (Text.drop 2 body)
+            ("error", body) ->
+                withAttr Theme.errorAttr $
+                    txtWrap (Text.drop 2 body)
+            _ ->
+                withAttr Theme.mutedAttr (txtWrap line)
 
 -- Brick's default scrollbar uses a full block for the thumb and a blank
 -- space for the trough. During rapid viewport reflow, some terminals can
@@ -1608,9 +1666,9 @@ agentPaneVisible width height entries =
 
 agentPaneEntryLimit :: Int -> Int
 agentPaneEntryLimit availableHeight =
-    -- Reserve the outer top pad, six pane chrome rows (border, padding,
-    -- footer), and two possible truncation indicators above and below.
-    max 1 (min 12 (availableHeight - 9))
+    -- Reserve the outer top pad, four pane chrome rows (border and padding),
+    -- and two possible truncation indicators above and below.
+    max 1 (min 12 (availableHeight - 7))
 
 drawAgentPane
     :: AppState
@@ -1629,12 +1687,7 @@ drawAgentPane state entryLimit selected hovered entries =
                             <> Text.pack (show childCount)
                             <> " ")) $
                     padAll 1 $
-                        vBox
-                            [ vBox agentRows
-                            , padTop (Pad 1) $
-                                withAttr Theme.footerAttr $
-                                    txt "hover preview · /agents switch"
-                            ]
+                        vBox agentRows
   where
     ordered = sortOn (.agentPath) entries
     childCount =
@@ -1969,8 +2022,8 @@ drawTranscript state =
 
 stickyPromptLayers :: AppState -> [Widget Name]
 stickyPromptLayers state =
-    case state.appConversationAnchor of
-        Just anchor
+    case (state.appAgentSelected, state.appConversationAnchor) of
+        (AgentRoot, Just anchor)
             | Scroll.conversationAnchorSticky anchor ->
                 [ translateBy (Location (0, 2)) $
                     hLimitPercent conversationWidth $

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -15,6 +15,7 @@ import Agent.CLI.TUI.App
     , nextMotionSchedule
     , onboardingVisibleRowIndices
     , repositoryHeaderText
+    , selectedAgentConversation
     , uiEventRestartsMotionSchedule
     )
 import Agent.Loop (LoopEvent(..), emptyTurnOutput)
@@ -131,9 +132,20 @@ spec = do
                 indicatorRows =
                     fromEnum (above > 0) + fromEnum (below > 0)
                 renderedRows =
-                    length shown + indicatorRows + 7
-            entryLimit `shouldBe` 6
+                    length shown + indicatorRows + 5
+            entryLimit `shouldBe` 8
             renderedRows `shouldSatisfy` (<= availableHeight)
+
+        it "uses a clicked child as the conversation view and root as the main view" do
+            let child =
+                    (childEntry 1)
+                        { agentTranscript =
+                            ["user: investigate", "assistant: finished"]
+                        }
+            selectedAgentConversation child.agentTarget [rootEntry, child]
+                `shouldBe` Just child
+            selectedAgentConversation AgentRoot [rootEntry, child]
+                `shouldBe` Nothing
 
     describe "conversation scrollbar" do
         it "uses a visible trough that repaints old thumb cells" do


### PR DESCRIPTION
## Summary
- switch the main conversation pane to the selected subagent when its row is clicked
- load the selected child's full transcript while retaining compact agent summaries elsewhere
- keep root-only sticky prompt UI out of the subagent view
- remove the agents-pane help footer and use the reclaimed height for more rows

## Testing
- `nix develop -c cabal repl agent-cli:lib:agent-cli --offline` and loaded `Agent.CLI` plus `Agent.CLI.TUI.App`
- focused `Agent.CLI.TUIAppSpec`: 21 examples, 0 failures
- live 140x42 tmux smoke test: spawned a child agent and confirmed an SGR mouse click switched the main pane to `/root/smoke_test`
- `git diff --check`
