### PR TITLE
fix(cli): use advisory session locks

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -77,6 +77,7 @@ library
                     , Agent.CLI.Resume
                     , Agent.CLI.Session
                     , Agent.CLI.SessionEnv
+                    , Agent.CLI.SessionLock
                     , Agent.CLI.SessionTitle
                     , Agent.CLI.Skills
                     , Agent.CLI.Status
@@ -113,6 +114,7 @@ library
                     , colour >= 2.3
                     , containers
                     , directory
+                    , filelock
                     , filepath
                     , haskeline >= 0.8 && < 0.9
                     , JuicyPixels

--- a/packages/agent-cli/package.nix
+++ b/packages/agent-cli/package.nix
@@ -1,7 +1,7 @@
 { mkDerivation, aeson, agent-core, agent-openai, agent-openrouter
 , agent-responses, agent-syntax, agent-tui, agent-xai
 , ansi-terminal, async, base, base64-bytestring, brick, bytestring
-, colour, containers, directory, filepath, haskeline, hspec
+, colour, containers, directory, filelock, filepath, haskeline, hspec
 , JuicyPixels, lib, mtl, process, safe-exceptions, stm, text, time
 , transformers, unix, vector, vty, vty-crossplatform
 }:
@@ -14,7 +14,7 @@ mkDerivation {
   libraryHaskellDepends = [
     aeson agent-core agent-openai agent-openrouter agent-responses
     agent-syntax agent-tui agent-xai ansi-terminal async base
-    base64-bytestring brick bytestring colour containers directory
+    base64-bytestring brick bytestring colour containers directory filelock
     filepath haskeline JuicyPixels mtl process safe-exceptions stm text
     time transformers unix vector vty vty-crossplatform
   ];

--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -46,12 +46,11 @@ import Agent.CLI.SessionTitle
     )
 import Agent.CLI.AgentSessions
     ( AgentSessionToolsEnv(..)
-    , acquireSessionLock
     , agentSessionTools
     , closeSessionProcessManager
     , launchSessionTurn
     , newSessionProcessManager
-    , releaseSessionLock
+    , signalManagedSessionReady
     , sessionProcessStatus
     )
 import Agent.CLI.Approval
@@ -184,6 +183,13 @@ import Agent.CLI.Render
     )
 import Agent.CLI.Session
 import Agent.CLI.SessionEnv (SessionEnv(..))
+import Agent.CLI.SessionLock
+    ( SessionLock
+    , acquireSessionLock
+    , releaseSessionLock
+    , sessionLockFilePath
+    , sessionLockPath
+    )
 import Agent.CLI.Skills
     ( formatSkillsListing
     , installSkillCatalog
@@ -403,6 +409,7 @@ import Control.Exception.Safe
     , catchAsync
     , finally
     , mask_
+    , onException
     , throwIO
     , try
     )
@@ -427,7 +434,8 @@ import Data.Time.Clock
     )
 import Data.Time.Format (defaultTimeLocale, formatTime)
 import System.Directory.OsPath
-    ( getCurrentDirectory
+    ( doesDirectoryExist
+    , getCurrentDirectory
     , getHomeDirectory
     , makeAbsolute
     , setCurrentDirectory
@@ -836,10 +844,12 @@ prepareAgentIteration
     -> IO PreparedAgent
 prepareAgentIteration fullscreenInputs activeFullscreen options transition = do
     forM_ activeFullscreen resetFullscreenSessionActions
+    resumeLockRef <- newIORef (Nothing :: Maybe SessionLock)
     let failPreparation message =
-            case activeFullscreen of
-                Nothing -> die message
-                Just _ -> throwIO (StartupFailure message)
+            readIORef resumeLockRef >>= mapM_ releaseSessionLock >>
+                case activeFullscreen of
+                    Nothing -> die message
+                    Just _ -> throwIO (StartupFailure message)
     startedAt <- getCurrentTime
     startupTimingsRef <- newIORef []
     syntaxLoadDurationRef <- newIORef Nothing
@@ -847,10 +857,31 @@ prepareAgentIteration fullscreenInputs activeFullscreen options transition = do
     let root = sessionsRoot home
     resumed <- case options.optResume of
         Nothing -> pure Nothing
-        Just sessionId ->
-            loadSession root sessionId >>= \case
-                Left err -> failPreparation (Text.unpack err)
-                Right loaded -> pure (Just loaded)
+        Just sessionId -> do
+            dir <- either
+                (\err -> do
+                    signalManagedSessionReady (Left err)
+                    failPreparation (Text.unpack err))
+                pure
+                (sessionDirForId root sessionId)
+            exists <- doesDirectoryExist dir
+            when (not exists) do
+                let err = "session not found: " <> sessionId
+                signalManagedSessionReady (Left err)
+                failPreparation (Text.unpack err)
+            acquireSessionLock dir sessionId >>= \case
+                Left err -> do
+                    signalManagedSessionReady (Left err)
+                    failPreparation (Text.unpack err)
+                Right lock -> do
+                    writeIORef resumeLockRef (Just lock)
+                    loadSession root sessionId >>= \case
+                        Left err -> do
+                            signalManagedSessionReady (Left err)
+                            failPreparation (Text.unpack err)
+                        Right loaded -> do
+                            signalManagedSessionReady (Right ())
+                            pure (Just loaded)
 
     source <- maybe getCurrentDirectory makeAbsolute options.optCwd
     cwd <- case resumed of
@@ -961,9 +992,10 @@ prepareAgentIteration fullscreenInputs activeFullscreen options transition = do
             , startupTimings = startupTimingsRef
             , startupSyntaxLoadDuration = syntaxLoadDurationRef
             }
-        action =
+    resumeLock <- readIORef resumeLockRef
+    let action =
             runAgentInitialized
-                options transition home root resumed cwd startup
+                options transition home root resumed resumeLock cwd startup
         cleanup = do
             writeIORef uiRuntimeRef Nothing
             forM_ fullscreen resetFullscreenSessionActions
@@ -1037,10 +1069,27 @@ runAgentInitialized
     -> OsPath
     -> OsPath
     -> Maybe (SessionMeta, [SessionTurn])
+    -> Maybe SessionLock
     -> OsPath
     -> StartupRuntime
     -> IO RunResult
-runAgentInitialized options transition home root resumed cwd startup = do
+runAgentInitialized options transition home root resumed resumeLock cwd startup =
+    runAgentInitializedWithLock
+        options transition home root resumed resumeLock cwd startup
+        `onException` mapM_ releaseSessionLock resumeLock
+
+runAgentInitializedWithLock
+    :: CliOptions
+    -> Maybe ProviderTransition
+    -> OsPath
+    -> OsPath
+    -> Maybe (SessionMeta, [SessionTurn])
+    -> Maybe SessionLock
+    -> OsPath
+    -> StartupRuntime
+    -> IO RunResult
+runAgentInitializedWithLock
+        options transition home root resumed resumeLock cwd startup = do
     let toolEnv = startup.startupToolEnv
         interrupt = startup.startupInterrupt
         escPaused = startup.startupEscPaused
@@ -1274,8 +1323,7 @@ runAgentInitialized options transition home root resumed cwd startup = do
     when (isNothing transition) $
         saveProjectModel projectRoot provider model
     sessionProcessManager <- newSessionProcessManager root
-    managedAgentSession <- (== Just "1") <$> lookupEnv "HASKELL_AGENT_MANAGED_SESSION"
-    activeSessionLock <- newIORef (Nothing :: Maybe FilePath)
+    activeSessionLock <- newIORef resumeLock
     persistSlotRef <- newIORef PersistenceDisabled
     -- Per-subagent transcripts / previous ids, shared across send_input / task.
     subagentSessions <- newIORef Map.empty
@@ -1329,19 +1377,18 @@ runAgentInitialized options transition home root resumed cwd startup = do
                             agentId status session.subSessionTranscript
                     Nothing -> pure ()
         Nothing -> pure ()
-    let claimCurrentSession handle
-            | managedAgentSession = pure ()
-            | otherwise = do
-                let desired =
-                        unsafeToFilePath
-                            (handle.sessionDir </> unsafeEncodeUtf ".agent-running")
-                readIORef activeSessionLock >>= \case
-                    Just current | current == desired -> pure ()
-                    previous ->
-                        acquireSessionLock handle >>= \case
+    let claimCurrentSession handle = do
+            let desired = sessionLockPath handle.sessionDir
+            readIORef activeSessionLock >>= \case
+                Just current
+                    | sessionLockFilePath current == desired -> pure ()
+                previous ->
+                    acquireSessionLock
+                        handle.sessionDir
+                        handle.sessionMeta.metaId >>= \case
                             Left err -> throwIO (userError (Text.unpack err))
-                            Right lockPath -> do
-                                writeIORef activeSessionLock (Just lockPath)
+                            Right lock -> do
+                                writeIORef activeSessionLock (Just lock)
                                 mapM_ releaseSessionLock previous
         sessionToolsEnv = AgentSessionToolsEnv
             { toolsRoot = root

--- a/packages/agent-cli/src/Agent/CLI/AgentSessions.hs
+++ b/packages/agent-cli/src/Agent/CLI/AgentSessions.hs
@@ -5,11 +5,10 @@ module Agent.CLI.AgentSessions
     ( AgentSessionToolsEnv(..)
     , SessionProcessManager
     , agentSessionTools
-    , acquireSessionLock
     , closeSessionProcessManager
     , launchSessionTurn
     , newSessionProcessManager
-    , releaseSessionLock
+    , signalManagedSessionReady
     , sessionProcessStatus
     ) where
 
@@ -24,6 +23,10 @@ import Agent.CLI.Session
     , loadSession
     , sessionTitleFromPrompt
     )
+import Agent.CLI.SessionLock
+    ( sessionLockIsActive
+    , sessionLockPath
+    )
 import Agent.OsPath (fromText, unsafeToFilePath)
 import Agent.Provider (Provider, providerSlug)
 import Agent.ToolArgs (objectArgs, optInt, optText, reqText)
@@ -34,6 +37,7 @@ import Agent.Tools.Types
     , ToolExecutionPolicy(..)
     , jsonTool
     )
+import Control.Concurrent (threadDelay)
 import Control.Concurrent.MVar
     ( MVar
     , modifyMVar
@@ -52,15 +56,8 @@ import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
 import qualified Data.Text.IO as TextIO
-import Data.Time.Clock (diffUTCTime, getCurrentTime)
-import Text.Read (readMaybe)
 import System.Directory
-    ( createDirectory
-    , doesDirectoryExist
-    , doesFileExist
-    , findExecutable
-    , getModificationTime
-    , removeDirectory
+    ( findExecutable
     , removeFile
     )
 import System.Environment (getEnvironment, getExecutablePath, lookupEnv)
@@ -70,7 +67,6 @@ import qualified System.FilePath as FilePath
 import System.IO (IOMode(AppendMode), hClose, openTempFile, withFile)
 import System.OsPath (OsPath, unsafeEncodeUtf, (</>))
 import System.Posix.Files (setFileMode)
-import System.Posix.Signals (nullSignal, signalProcess)
 import System.Process
     ( CreateProcess(..)
     , ProcessHandle
@@ -93,10 +89,7 @@ data AgentSessionToolsEnv = AgentSessionToolsEnv
     }
 
 data ManagedSessionProcess = ManagedSessionProcess
-    { managedHandle :: !ProcessHandle
-    , managedLockPath :: !FilePath
-    , managedPromptPath :: !FilePath
-    }
+    { managedHandle :: !ProcessHandle }
 
 data SessionProcessManager = SessionProcessManager
     { managedRoot :: !OsPath
@@ -132,93 +125,92 @@ launchSessionTurn manager background policy handle message =
                 ( processes
                 , Left ("session " <> sessionId <> " is already running")
                 )
-            else acquireSessionLock handle >>= \case
+            else resolveAgentExecutable >>= \case
                 Left err -> pure (processes, Left err)
-                Right lockPath -> resolveAgentExecutable >>= \case
-                    Left err -> do
-                        releaseSessionLock lockPath
-                        pure (processes, Left err)
-                    Right executable -> do
-                        parentEnv <- getEnvironment
-                        (promptPath, promptHandle) <- openTempFile
-                            (unsafeToFilePath handle.sessionDir) ".agent-prompt-"
-                        TextIO.hPutStr promptHandle message
-                        hClose promptHandle
-                        setFileMode promptPath 0o600
-                        let childEnv =
-                                ("HASKELL_AGENT_MANAGED_SESSION", "1")
-                                    : filter
-                                        ((/= "HASKELL_AGENT_MANAGED_SESSION") . fst)
-                                        parentEnv
-                            logPath = unsafeToFilePath handle.sessionDir FilePath.</> "agent.log"
-                            approvalArgs = case policy of
-                                ApproveAll -> ["--yolo"]
-                                DenyMutating -> ["--no-yolo"]
-                                PromptMutating -> ["--no-yolo"]
-                            agentArgs =
-                                [ "--resume", Text.unpack sessionId
-                                , "--prompt-file", promptPath
-                                , "--save-session"
-                                ]
-                                    <> approvalArgs
-                            cleanupScript =
-                                "lock=$1; prompt=$2; shift 2; owner=\"$lock/pid\"; "
-                                    <> "cleanup() { rm -f \"$prompt\" \"$owner\"; rmdir \"$lock\" >/dev/null 2>&1 || true; }; "
-                                    <> "trap cleanup EXIT; "
-                                    <> "\"$@\" & child=$!; "
-                                    <> "printf '%s\\n' \"$child\" > \"$owner\"; "
-                                    <> "trap 'kill \"$child\" >/dev/null 2>&1 || true' HUP INT TERM; "
-                                    <> "wait \"$child\""
-                            args =
-                                [ "-c", cleanupScript
-                                , "agent-session-runner"
-                                , lockPath
-                                , promptPath
-                                , executable
-                                ]
-                                    <> agentArgs
-                        started <- try @_ @SomeException do
-                            withFile logPath AppendMode \logHandle ->
-                                setFileMode logPath 0o600 >>
-                                createProcess (proc "/bin/sh" args)
-                                    { cwd = Just (unsafeToFilePath handle.sessionMeta.metaCwd)
-                                    , std_in = NoStream
-                                    , std_out = UseHandle logHandle
-                                    , std_err = UseHandle logHandle
-                                    , create_group = True
-                                    , env = Just childEnv
-                                    }
-                        case started of
-                            Left err -> do
-                                removePrivateFile promptPath
-                                releaseSessionLock lockPath
-                                pure
-                                    ( processes
-                                    , Left
-                                        ("failed to start agent session: "
-                                            <> formatException err)
-                                    )
-                            Right (_, _, _, process)
-                                | background ->
-                                    pure
-                                        ( Map.insert sessionId ManagedSessionProcess
-                                            { managedHandle = process
-                                            , managedLockPath = lockPath
-                                            , managedPromptPath = promptPath
-                                            }
-                                            processes
-                                        , Right ("started session " <> sessionId)
-                                        )
-                                | otherwise -> do
-                                    exitCode <- waitForProcess process
-                                    removePrivateFile promptPath
-                                    pure (processes, case exitCode of
-                                        ExitSuccess ->
-                                            Right ("completed session " <> sessionId)
-                                        ExitFailure code ->
-                                            Left
-                                                ("session failed with exit code "
-                                                    <> Text.pack (show code)))
+                Right executable -> do
+                    parentEnv <- getEnvironment
+                    (promptPath, promptHandle) <- openTempFile
+                        (unsafeToFilePath handle.sessionDir) ".agent-prompt-"
+                    TextIO.hPutStr promptHandle message
+                    hClose promptHandle
+                    setFileMode promptPath 0o600
+                    (readyPath, readyHandle) <- openTempFile
+                        (unsafeToFilePath handle.sessionDir) ".agent-ready-"
+                    hClose readyHandle
+                    setFileMode readyPath 0o600
+                    let childEnv =
+                            (managedSessionReadyEnv, readyPath)
+                                : filter
+                                    ((/= managedSessionReadyEnv) . fst)
+                                    parentEnv
+                        logPath = unsafeToFilePath handle.sessionDir FilePath.</> "agent.log"
+                        approvalArgs = case policy of
+                            ApproveAll -> ["--yolo"]
+                            DenyMutating -> ["--no-yolo"]
+                            PromptMutating -> ["--no-yolo"]
+                        agentArgs =
+                            [ "--resume", Text.unpack sessionId
+                            , "--prompt-file", promptPath
+                            , "--save-session"
+                            ]
+                                <> approvalArgs
+                        cleanupScript =
+                            "prompt=$1; shift; "
+                                <> "cleanup() { rm -f \"$prompt\"; }; "
+                                <> "trap cleanup EXIT HUP INT TERM; "
+                                <> "\"$@\""
+                        args =
+                            [ "-c", cleanupScript
+                            , "agent-session-runner"
+                            , promptPath
+                            , executable
+                            ]
+                                <> agentArgs
+                    started <- try @_ @SomeException do
+                        withFile logPath AppendMode \logHandle ->
+                            setFileMode logPath 0o600 >>
+                            createProcess (proc "/bin/sh" args)
+                                { cwd = Just (unsafeToFilePath handle.sessionMeta.metaCwd)
+                                , std_in = NoStream
+                                , std_out = UseHandle logHandle
+                                , std_err = UseHandle logHandle
+                                , create_group = True
+                                , env = Just childEnv
+                                }
+                    case started of
+                        Left err -> do
+                            removePrivateFile promptPath
+                            removePrivateFile readyPath
+                            pure
+                                ( processes
+                                , Left
+                                    ("failed to start agent session: "
+                                        <> formatException err)
+                                )
+                        Right (_, _, _, process) -> do
+                            ready <- waitForManagedSessionReady process readyPath
+                            removePrivateFile readyPath
+                            case ready of
+                                Left err -> do
+                                    _ <- waitForProcess process
+                                    pure (processes, Left err)
+                                Right ()
+                                    | background ->
+                                        pure
+                                            ( Map.insert sessionId ManagedSessionProcess
+                                                { managedHandle = process }
+                                                processes
+                                            , Right ("started session " <> sessionId)
+                                            )
+                                    | otherwise -> do
+                                        exitCode <- waitForProcess process
+                                        pure (processes, case exitCode of
+                                            ExitSuccess ->
+                                                Right ("completed session " <> sessionId)
+                                            ExitFailure code ->
+                                                Left
+                                                    ("session failed with exit code "
+                                                        <> Text.pack (show code)))
 
 sessionProcessStatus :: SessionProcessManager -> Text -> IO Text
 sessionProcessStatus manager sessionId =
@@ -226,7 +218,9 @@ sessionProcessStatus manager sessionId =
         case Map.lookup sessionId processes of
             Nothing -> do
                 locked <- sessionLockIsActive
-                    (sessionLockPath manager sessionId)
+                    (sessionLockPath
+                        (manager.managedRoot
+                            </> unsafeEncodeUtf (Text.unpack sessionId)))
                 pure (processes, if locked then "running" else "idle")
             Just process ->
                 getProcessExitCode process.managedHandle >>= \case
@@ -242,8 +236,8 @@ sessionProcessStatus manager sessionId =
 closeSessionProcessManager :: SessionProcessManager -> IO ()
 closeSessionProcessManager manager =
     modifyMVar_ manager.managedProcesses \processes -> do
-        -- Running sessions intentionally outlive the caller. The child
-        -- wrapper owns prompt and lock cleanup.
+        -- Running sessions intentionally outlive the caller. The child owns
+        -- the advisory session lock; its wrapper owns prompt cleanup.
         forM_ (Map.elems processes) \process -> do
             getProcessExitCode process.managedHandle >>= \case
                 Just _ -> do
@@ -253,79 +247,41 @@ closeSessionProcessManager manager =
                 Nothing -> pure ()
         pure Map.empty
 
-acquireSessionLock :: SessionHandle -> IO (Either Text FilePath)
-acquireSessionLock handle = do
-    let lockPath = unsafeToFilePath handle.sessionDir FilePath.</> ".agent-running"
-    acquire lockPath >>= \case
-        True -> pure (Right lockPath)
-        False -> pure $ Left
-            ("session " <> handle.sessionMeta.metaId <> " is already running")
+signalManagedSessionReady :: Either Text () -> IO ()
+signalManagedSessionReady result =
+    lookupEnv managedSessionReadyEnv >>= \case
+        Nothing -> pure ()
+        Just path -> TextIO.writeFile path $ case result of
+            Right () -> "ready\n"
+            Left err -> "error\n" <> err
+
+waitForManagedSessionReady :: ProcessHandle -> FilePath -> IO (Either Text ())
+waitForManagedSessionReady process path = go
   where
-    acquire lockPath =
-        try @_ @SomeException (createDirectory lockPath) >>= \case
-            Right () -> pure True
-            Left _ ->
-                sessionLockIsActive lockPath >>= \case
-                    True -> pure False
-                    False ->
-                        try @_ @SomeException (createDirectory lockPath) >>= \case
-                            Right () -> pure True
-                            Left _ -> pure False
-
-releaseSessionLock :: FilePath -> IO ()
-releaseSessionLock lockPath = do
-    removePrivateFile (sessionLockOwnerPath lockPath)
-    _ <- try @_ @SomeException (removeDirectory lockPath)
-    pure ()
-
--- | Check whether a cross-process session lock still has a live owner.
--- New locks record the child agent PID. Empty legacy locks are kept briefly
--- to avoid racing a newly-created lock before its owner file is written, then
--- reclaimed so a hard-killed launcher cannot block a session forever.
-sessionLockIsActive :: FilePath -> IO Bool
-sessionLockIsActive lockPath =
-    doesDirectoryExist lockPath >>= \case
-        False -> pure False
-        True -> do
-            let ownerPath = sessionLockOwnerPath lockPath
-            doesFileExist ownerPath >>= \case
-                True ->
-                    try @_ @SomeException (readFile ownerPath) >>= \case
-                        Right contents
-                            | Just pid <- readMaybe contents ->
-                                processIsAlive pid >>= \case
-                                    True -> pure True
-                                    False ->
-                                        releaseSessionLock lockPath >> pure False
-                        _ -> legacyLockIsFresh lockPath
-                False -> legacyLockIsFresh lockPath
-  where
-    legacyLockIsFresh path = do
-        now <- getCurrentTime
-        modified <- getModificationTime path
-        if diffUTCTime now modified < 5
-            then pure True
-            else releaseSessionLock path >> pure False
-
-processIsAlive :: Int -> IO Bool
-processIsAlive pid =
-    try @_ @SomeException (signalProcess nullSignal (fromIntegral pid)) >>= \case
-        Right () -> pure True
-        Left _ -> pure False
-
-sessionLockOwnerPath :: FilePath -> FilePath
-sessionLockOwnerPath lockPath = lockPath FilePath.</> "pid"
+    go = do
+        contents <- try @_ @SomeException (TextIO.readFile path)
+        case contents of
+            Right "ready\n" -> pure (Right ())
+            Right text
+                | Just err <- Text.stripPrefix "error\n" text ->
+                    pure (Left err)
+            _ ->
+                getProcessExitCode process >>= \case
+                    Nothing -> threadDelay 10000 >> go
+                    Just ExitSuccess ->
+                        pure (Left "agent session exited before acquiring its lock")
+                    Just (ExitFailure code) ->
+                        pure $ Left
+                            ("agent session exited before acquiring its lock (exit code "
+                                <> Text.pack (show code) <> ")")
 
 removePrivateFile :: FilePath -> IO ()
 removePrivateFile path = do
     _ <- try @_ @SomeException (removeFile path)
     pure ()
 
-sessionLockPath :: SessionProcessManager -> Text -> FilePath
-sessionLockPath manager sessionId =
-    unsafeToFilePath manager.managedRoot
-        FilePath.</> Text.unpack sessionId
-        FilePath.</> ".agent-running"
+managedSessionReadyEnv :: String
+managedSessionReadyEnv = "HASKELL_AGENT_MANAGED_SESSION_READY"
 
 resolveAgentExecutable :: IO (Either Text FilePath)
 resolveAgentExecutable = do

--- a/packages/agent-cli/src/Agent/CLI/AgentSessions.hs
+++ b/packages/agent-cli/src/Agent/CLI/AgentSessions.hs
@@ -52,10 +52,14 @@ import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
 import qualified Data.Text.IO as TextIO
+import Data.Time.Clock (diffUTCTime, getCurrentTime)
+import Text.Read (readMaybe)
 import System.Directory
     ( createDirectory
     , doesDirectoryExist
+    , doesFileExist
     , findExecutable
+    , getModificationTime
     , removeDirectory
     , removeFile
     )
@@ -66,6 +70,7 @@ import qualified System.FilePath as FilePath
 import System.IO (IOMode(AppendMode), hClose, openTempFile, withFile)
 import System.OsPath (OsPath, unsafeEncodeUtf, (</>))
 import System.Posix.Files (setFileMode)
+import System.Posix.Signals (nullSignal, signalProcess)
 import System.Process
     ( CreateProcess(..)
     , ProcessHandle
@@ -157,10 +162,13 @@ launchSessionTurn manager background policy handle message =
                                 ]
                                     <> approvalArgs
                             cleanupScript =
-                                "lock=$1; prompt=$2; shift 2; "
-                                    <> "cleanup() { rm -f \"$prompt\"; rmdir \"$lock\" >/dev/null 2>&1 || true; }; "
-                                    <> "trap cleanup EXIT HUP INT TERM; "
-                                    <> "\"$@\""
+                                "lock=$1; prompt=$2; shift 2; owner=\"$lock/pid\"; "
+                                    <> "cleanup() { rm -f \"$prompt\" \"$owner\"; rmdir \"$lock\" >/dev/null 2>&1 || true; }; "
+                                    <> "trap cleanup EXIT; "
+                                    <> "\"$@\" & child=$!; "
+                                    <> "printf '%s\\n' \"$child\" > \"$owner\"; "
+                                    <> "trap 'kill \"$child\" >/dev/null 2>&1 || true' HUP INT TERM; "
+                                    <> "wait \"$child\""
                             args =
                                 [ "-c", cleanupScript
                                 , "agent-session-runner"
@@ -204,7 +212,6 @@ launchSessionTurn manager background policy handle message =
                                 | otherwise -> do
                                     exitCode <- waitForProcess process
                                     removePrivateFile promptPath
-                                    releaseSessionLock lockPath
                                     pure (processes, case exitCode of
                                         ExitSuccess ->
                                             Right ("completed session " <> sessionId)
@@ -218,7 +225,7 @@ sessionProcessStatus manager sessionId =
     modifyMVar manager.managedProcesses \processes ->
         case Map.lookup sessionId processes of
             Nothing -> do
-                locked <- doesDirectoryExist
+                locked <- sessionLockIsActive
                     (sessionLockPath manager sessionId)
                 pure (processes, if locked then "running" else "idle")
             Just process ->
@@ -249,15 +256,65 @@ closeSessionProcessManager manager =
 acquireSessionLock :: SessionHandle -> IO (Either Text FilePath)
 acquireSessionLock handle = do
     let lockPath = unsafeToFilePath handle.sessionDir FilePath.</> ".agent-running"
-    try @_ @SomeException (createDirectory lockPath) >>= \case
-        Right () -> pure (Right lockPath)
-        Left _ -> pure $ Left
+    acquire lockPath >>= \case
+        True -> pure (Right lockPath)
+        False -> pure $ Left
             ("session " <> handle.sessionMeta.metaId <> " is already running")
+  where
+    acquire lockPath =
+        try @_ @SomeException (createDirectory lockPath) >>= \case
+            Right () -> pure True
+            Left _ ->
+                sessionLockIsActive lockPath >>= \case
+                    True -> pure False
+                    False ->
+                        try @_ @SomeException (createDirectory lockPath) >>= \case
+                            Right () -> pure True
+                            Left _ -> pure False
 
 releaseSessionLock :: FilePath -> IO ()
 releaseSessionLock lockPath = do
+    removePrivateFile (sessionLockOwnerPath lockPath)
     _ <- try @_ @SomeException (removeDirectory lockPath)
     pure ()
+
+-- | Check whether a cross-process session lock still has a live owner.
+-- New locks record the child agent PID. Empty legacy locks are kept briefly
+-- to avoid racing a newly-created lock before its owner file is written, then
+-- reclaimed so a hard-killed launcher cannot block a session forever.
+sessionLockIsActive :: FilePath -> IO Bool
+sessionLockIsActive lockPath =
+    doesDirectoryExist lockPath >>= \case
+        False -> pure False
+        True -> do
+            let ownerPath = sessionLockOwnerPath lockPath
+            doesFileExist ownerPath >>= \case
+                True ->
+                    try @_ @SomeException (readFile ownerPath) >>= \case
+                        Right contents
+                            | Just pid <- readMaybe contents ->
+                                processIsAlive pid >>= \case
+                                    True -> pure True
+                                    False ->
+                                        releaseSessionLock lockPath >> pure False
+                        _ -> legacyLockIsFresh lockPath
+                False -> legacyLockIsFresh lockPath
+  where
+    legacyLockIsFresh path = do
+        now <- getCurrentTime
+        modified <- getModificationTime path
+        if diffUTCTime now modified < 5
+            then pure True
+            else releaseSessionLock path >> pure False
+
+processIsAlive :: Int -> IO Bool
+processIsAlive pid =
+    try @_ @SomeException (signalProcess nullSignal (fromIntegral pid)) >>= \case
+        Right () -> pure True
+        Left _ -> pure False
+
+sessionLockOwnerPath :: FilePath -> FilePath
+sessionLockOwnerPath lockPath = lockPath FilePath.</> "pid"
 
 removePrivateFile :: FilePath -> IO ()
 removePrivateFile path = do

--- a/packages/agent-cli/src/Agent/CLI/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session.hs
@@ -17,6 +17,7 @@ module Agent.CLI.Session
     , loadSession
     , isValidSessionId
     , listSessions
+    , sessionDirForId
     , sessionsRoot
     , sessionTitleFromPrompt
     , setGeneratedSessionTitle
@@ -35,13 +36,17 @@ import Agent.FileRetry
     , retryOnFileBusy
     , writeLazyFileAtomically
     )
+import Agent.CLI.SessionLock
+    ( acquireSessionLock
+    , releaseSessionLock
+    )
 import Agent.Loop (TokenUsage(..))
 import Agent.OsPath (toText, unsafeToFilePath)
 import Agent.Responses.Types (ResponseItem)
 import Agent.Provider (Provider(..), parseProvider, providerSlug)
 import Control.Applicative ((<|>))
-import Control.Exception.Safe (displayException, tryIO)
-import Control.Monad (unless, when)
+import Control.Exception.Safe (displayException, finally, tryIO)
+import Control.Monad (unless)
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Except
     ( ExceptT(..)
@@ -364,9 +369,8 @@ appendTurnKeepTitle handle turn =
 
 loadSession :: OsPath -> Text -> IO (Either Text (SessionMeta, [SessionTurn]))
 loadSession root sessionId = runExceptT do
-    unless (isValidSessionId sessionId) $
-        throwE "invalid session id"
-    let dir = root </> unsafeEncodeUtf (Text.unpack sessionId)
+    dir <- except (sessionDirForId root sessionId)
+    let
         metaPath = dir </> unsafeEncodeUtf "meta.json"
         transcriptPath = dir </> unsafeEncodeUtf "transcript.jsonl"
     exists <- lift (doesDirectoryExist dir)
@@ -389,17 +393,15 @@ loadSession root sessionId = runExceptT do
 
 deleteSession :: OsPath -> Text -> IO (Either Text ())
 deleteSession root sessionId = runExceptT do
-    unless (isValidSessionId sessionId) $
-        throwE "invalid session id"
-    let dir = root </> unsafeEncodeUtf (Text.unpack sessionId)
-        runningPath = dir </> unsafeEncodeUtf ".agent-running"
+    dir <- except (sessionDirForId root sessionId)
     exists <- lift (doesDirectoryExist dir)
     unless exists $
         throwE ("session not found: " <> sessionId)
-    running <- lift (doesDirectoryExist runningPath)
-    when running $
-        throwE "cannot delete a running session"
-    removed <- lift (tryIO (removePathForcibly dir))
+    lock <- lift (acquireSessionLock dir sessionId) >>= \case
+        Left _ -> throwE "cannot delete a running session"
+        Right lock -> pure lock
+    removed <- lift $
+        tryIO (removePathForcibly dir) `finally` releaseSessionLock lock
     case removed of
         Left err ->
             throwE ("could not delete session: " <> Text.pack (displayException err))
@@ -413,6 +415,12 @@ isValidSessionId sessionId =
         && sessionId /= "."
         && sessionId /= ".."
         && Text.all (\char -> char /= '/' && char /= '\\' && char /= '\NUL') sessionId
+
+sessionDirForId :: OsPath -> Text -> Either Text OsPath
+sessionDirForId root sessionId
+    | isValidSessionId sessionId =
+        Right (root </> unsafeEncodeUtf (Text.unpack sessionId))
+    | otherwise = Left "invalid session id"
 
 listSessions :: OsPath -> IO [SessionMeta]
 listSessions root = do

--- a/packages/agent-cli/src/Agent/CLI/SessionLock.hs
+++ b/packages/agent-cli/src/Agent/CLI/SessionLock.hs
@@ -1,0 +1,61 @@
+-- | Lifetime ownership for persisted sessions.
+--
+-- Lock files are permanent coordination points. The operating system releases
+-- the advisory lock when the owning process exits, including after a crash.
+module Agent.CLI.SessionLock
+    ( SessionLock
+    , acquireSessionLock
+    , releaseSessionLock
+    , sessionLockFilePath
+    , sessionLockIsActive
+    , sessionLockPath
+    ) where
+
+import Agent.CLI.Error (formatException)
+import Agent.OsPath (unsafeToFilePath)
+import Control.Exception.Safe (SomeException, try)
+import Data.Text (Text)
+import qualified System.FileLock as FileLock
+import qualified System.FilePath as FilePath
+import System.OsPath (OsPath)
+
+data SessionLock = SessionLock
+    { lockFilePath :: !FilePath
+    , sessionLockHandle :: !FileLock.FileLock
+    }
+
+sessionLockFilePath :: SessionLock -> FilePath
+sessionLockFilePath lock = lock.lockFilePath
+
+sessionLockPath :: OsPath -> FilePath
+sessionLockPath sessionDir =
+    unsafeToFilePath sessionDir FilePath.</> ".agent-running.lock"
+
+acquireSessionLock :: OsPath -> Text -> IO (Either Text SessionLock)
+acquireSessionLock sessionDir sessionId = do
+    let path = sessionLockPath sessionDir
+    try @_ @SomeException
+        (FileLock.tryLockFile path FileLock.Exclusive) >>= \case
+            Left err -> pure $ Left
+                ("failed to lock session " <> sessionId <> ": "
+                    <> formatException err)
+            Right Nothing -> pure $ Left
+                ("session " <> sessionId <> " is already running")
+            Right (Just lock) -> pure $ Right SessionLock
+                { lockFilePath = path
+                , sessionLockHandle = lock
+                }
+
+releaseSessionLock :: SessionLock -> IO ()
+releaseSessionLock lock = do
+    _ <- try @_ @SomeException
+        (FileLock.unlockFile lock.sessionLockHandle)
+    pure ()
+
+sessionLockIsActive :: FilePath -> IO Bool
+sessionLockIsActive path =
+    try @_ @SomeException
+        (FileLock.tryLockFile path FileLock.Exclusive) >>= \case
+            Left _ -> pure True
+            Right Nothing -> pure True
+            Right (Just lock) -> FileLock.unlockFile lock >> pure False

--- a/packages/agent-cli/test/Agent/CLI/AgentSessionsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/AgentSessionsSpec.hs
@@ -21,7 +21,12 @@ import Control.Exception.Safe (bracket)
 import Data.IORef
 import qualified Data.Text as Text
 import Data.Time.Calendar (fromGregorian)
-import Data.Time.Clock (UTCTime(..), secondsToDiffTime)
+import Data.Time.Clock
+    ( UTCTime(..)
+    , addUTCTime
+    , getCurrentTime
+    , secondsToDiffTime
+    )
 import qualified System.Directory as Directory
 import System.Environment (lookupEnv, setEnv, unsetEnv)
 import qualified System.FilePath as FilePath
@@ -120,6 +125,28 @@ spec = describe "Agent.CLI.AgentSessions" do
                     handle.sessionMeta.metaId
                     "completed"
                 closeSessionProcessManager manager
+
+    it "reclaims a stale session lock left by a crashed process" $
+        withTempDir "agent-session-runtime-" \root -> do
+            handle <- createSession (testCreateAt root root)
+            let lockPath =
+                    toFilePath handle.sessionDir FilePath.</> ".agent-running"
+                ownerPath = lockPath FilePath.</> "pid"
+            Directory.createDirectory lockPath
+            writeFile ownerPath "999999999\n"
+            acquireSessionLock handle `shouldReturn` Right lockPath
+            releaseSessionLock lockPath
+
+    it "reclaims an old empty legacy session lock" $
+        withTempDir "agent-session-runtime-" \root -> do
+            handle <- createSession (testCreateAt root root)
+            let lockPath =
+                    toFilePath handle.sessionDir FilePath.</> ".agent-running"
+            Directory.createDirectory lockPath
+            old <- addUTCTime (-10) <$> getCurrentTime
+            Directory.setModificationTime lockPath old
+            acquireSessionLock handle `shouldReturn` Right lockPath
+            releaseSessionLock lockPath
 
     it "does not terminate background sessions when the manager closes" $
         withTempDir "agent-session-runtime-" \root -> do

--- a/packages/agent-cli/test/Agent/CLI/AgentSessionsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/AgentSessionsSpec.hs
@@ -3,6 +3,7 @@ module Agent.CLI.AgentSessionsSpec (spec) where
 import Agent.CLI.AgentSessions
 import Agent.CLI.Options (ApprovalPolicy(..))
 import Agent.CLI.Session
+import Agent.CLI.SessionLock
 import Agent.Loop (defaultLoopDispatch)
 import System.OsPath (OsPath, decodeUtf, unsafeEncodeUtf)
 import Agent.Provider (Provider(..))
@@ -17,20 +18,17 @@ import Agent.Tools.Types
     , appToolHandlers
     )
 import Control.Concurrent (threadDelay)
-import Control.Exception.Safe (bracket)
+import Control.Exception.Safe (SomeException, bracket, finally, try)
 import Data.IORef
 import qualified Data.Text as Text
 import Data.Time.Calendar (fromGregorian)
-import Data.Time.Clock
-    ( UTCTime(..)
-    , addUTCTime
-    , getCurrentTime
-    , secondsToDiffTime
-    )
+import Data.Time.Clock (UTCTime(..), secondsToDiffTime)
 import qualified System.Directory as Directory
 import System.Environment (lookupEnv, setEnv, unsetEnv)
 import qualified System.FilePath as FilePath
 import System.Posix.Temp (mkdtemp)
+import System.Posix.Process (forkProcess, getProcessStatus)
+import System.Posix.Signals (sigKILL, signalProcess)
 import Test.Hspec
 
 isReadOnly :: ApprovalRule -> Bool
@@ -126,33 +124,83 @@ spec = describe "Agent.CLI.AgentSessions" do
                     "completed"
                 closeSessionProcessManager manager
 
-    it "reclaims a stale session lock left by a crashed process" $
-        withTempDir "agent-session-runtime-" \root -> do
+    it "keeps an advisory lock until its owner releases it" $
+        withTempDir "agent-session-lock-" \root -> do
             handle <- createSession (testCreateAt root root)
-            let lockPath =
-                    toFilePath handle.sessionDir FilePath.</> ".agent-running"
-                ownerPath = lockPath FilePath.</> "pid"
-            Directory.createDirectory lockPath
-            writeFile ownerPath "999999999\n"
-            acquireSessionLock handle `shouldReturn` Right lockPath
-            releaseSessionLock lockPath
+            acquireSessionLock
+                handle.sessionDir
+                handle.sessionMeta.metaId >>= \case
+                    Left err -> expectationFailure (Text.unpack err)
+                    Right lock -> do
+                        sessionLockIsActive (sessionLockPath handle.sessionDir)
+                            `shouldReturn` True
+                        threadDelay 5100000
+                        acquireSessionLock
+                            handle.sessionDir
+                            handle.sessionMeta.metaId >>= \case
+                                Left err ->
+                                    err `shouldSatisfy`
+                                        Text.isInfixOf "already running"
+                                Right other -> do
+                                    releaseSessionLock other
+                                    expectationFailure
+                                        "acquired an already-held session lock"
+                        releaseSessionLock lock
+                        Directory.doesFileExist
+                            (sessionLockPath handle.sessionDir)
+                            `shouldReturn` True
+                        sessionLockIsActive (sessionLockPath handle.sessionDir)
+                            `shouldReturn` False
 
-    it "reclaims an old empty legacy session lock" $
-        withTempDir "agent-session-runtime-" \root -> do
+    it "releases an advisory lock when its process crashes" $
+        withTempDir "agent-session-lock-crash-" \root -> do
             handle <- createSession (testCreateAt root root)
-            let lockPath =
-                    toFilePath handle.sessionDir FilePath.</> ".agent-running"
-            Directory.createDirectory lockPath
-            old <- addUTCTime (-10) <$> getCurrentTime
-            Directory.setModificationTime lockPath old
-            acquireSessionLock handle `shouldReturn` Right lockPath
-            releaseSessionLock lockPath
+            let marker = toFilePath root FilePath.</> "locked"
+            pid <- forkProcess do
+                acquireSessionLock
+                    handle.sessionDir
+                    handle.sessionMeta.metaId >>= \case
+                        Left _ -> pure ()
+                        Right _ -> do
+                            writeFile marker "locked"
+                            threadDelay 30000000
+            let stopChild = do
+                    _ <- try @_ @SomeException (signalProcess sigKILL pid)
+                    pure ()
+            flip finally stopChild do
+                waitForFile marker
+                acquireSessionLock
+                    handle.sessionDir
+                    handle.sessionMeta.metaId >>= \case
+                        Left err ->
+                            err `shouldSatisfy` Text.isInfixOf "already running"
+                        Right lock -> do
+                            releaseSessionLock lock
+                            expectationFailure "acquired the child process lock"
+                signalProcess sigKILL pid
+                _ <- getProcessStatus True False pid
+                reacquired <- acquireSessionLock
+                    handle.sessionDir
+                    handle.sessionMeta.metaId
+                case reacquired of
+                    Left err -> expectationFailure (Text.unpack err)
+                    Right lock -> releaseSessionLock lock
+
+    it "reports a managed child readiness failure" $
+        withTempDir "agent-session-runtime-" \root -> do
+            script <- writeFakeAgentError root "could not acquire lock"
+            withExecutableOverride script do
+                handle <- createSession (testCreateAt root root)
+                manager <- newSessionProcessManager root
+                launchSessionTurn manager True ApproveAll handle "one"
+                    `shouldReturn` Left "could not acquire lock"
+                closeSessionProcessManager manager
 
     it "does not terminate background sessions when the manager closes" $
         withTempDir "agent-session-runtime-" \root -> do
             let marker = toFilePath root FilePath.</> "finished"
             script <- writeFakeAgentBody root
-                ("#!/bin/sh\nsleep 0.2\nprintf done > " <> shellQuote marker <> "\n")
+                ("sleep 0.2\nprintf done > " <> shellQuote marker <> "\n")
             withExecutableOverride script do
                 handle <- createSession (testCreateAt root root)
                 manager <- newSessionProcessManager root
@@ -204,12 +252,25 @@ testCreateAt root cwd = (testCreate root) { createCwd = cwd }
 
 writeFakeAgent :: OsPath -> IO FilePath
 writeFakeAgent root = do
-    writeFakeAgentBody root "#!/bin/sh\nsleep 0.2\nexit 0\n"
+    writeFakeAgentBody root "sleep 0.2\nexit 0\n"
 
 writeFakeAgentBody :: OsPath -> String -> IO FilePath
 writeFakeAgentBody root body = do
     let path = toFilePath root FilePath.</> "fake-agent-cli"
-    writeFile path body
+    writeFile path $
+        "#!/bin/sh\nprintf 'ready\\n' > \"$HASKELL_AGENT_MANAGED_SESSION_READY\"\n"
+            <> body
+    permissions <- Directory.getPermissions path
+    Directory.setPermissions path permissions { Directory.executable = True }
+    pure path
+
+writeFakeAgentError :: OsPath -> String -> IO FilePath
+writeFakeAgentError root message = do
+    let path = toFilePath root FilePath.</> "fake-agent-cli-error"
+    writeFile path $
+        "#!/bin/sh\nprintf 'error\\n%s' "
+            <> shellQuote message
+            <> " > \"$HASKELL_AGENT_MANAGED_SESSION_READY\"\nexit 1\n"
     permissions <- Directory.getPermissions path
     Directory.setPermissions path permissions { Directory.executable = True }
     pure path

--- a/packages/agent-cli/test/Agent/CLI/SessionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SessionSpec.hs
@@ -1,6 +1,7 @@
 module Agent.CLI.SessionSpec (spec) where
 
 import Agent.CLI.Session
+import Agent.CLI.SessionLock
 import Agent.Loop (TokenUsage(..))
 import Agent.Responses.Types
 import System.OsPath (OsPath, decodeUtf, unsafeEncodeUtf)
@@ -325,6 +326,21 @@ spec = describe "Agent.CLI.Session" do
                 doesDirectoryExist handle.sessionDir `shouldReturn` False
                 deleteSession root "../outside"
                     `shouldReturn` Left "invalid session id"
+
+        it "does not delete a session while another process owns its lock" $
+            withTempDir "agent-sessions-" \root -> do
+                handle <- createSession (testCreate root)
+                acquireSessionLock
+                    handle.sessionDir
+                    handle.sessionMeta.metaId >>= \case
+                        Left err -> expectationFailure (Text.unpack err)
+                        Right lock -> do
+                            deleteSession root handle.sessionMeta.metaId
+                                `shouldReturn`
+                                    Left "cannot delete a running session"
+                            releaseSessionLock lock
+                            deleteSession root handle.sessionMeta.metaId
+                                `shouldReturn` Right ()
 
         it "rejects metadata whose id does not match its directory" $
             withTempDir "agent-sessions-" \root -> do


### PR DESCRIPTION
## Summary
- replace PID-directory ownership with an OS advisory lock held by the actual `agent-cli --resume` process for its full lifetime
- acquire the lock before loading session history, and make managed launchers wait for a child readiness/error handshake before reporting success
- keep lock files as permanent coordination points so crashes release ownership through the kernel without stale-file reclamation heuristics
- refuse deletion while the advisory lock is held and preserve background sessions when their launching manager exits

## Why
This follows the same core ownership model used by Codex: liveness is represented by a retained OS file-lock guard rather than inferred from a PID file or lock age. It removes PID-reuse, empty-lock grace-period, and cleanup race failure modes.

## Testing
- `nix develop path:/Users/marc/.haskell-agent/worktrees/haskell-agent/2026-08-22-aa5c6eb2 -c cabal test agent-cli-test --test-show-details=direct`
- 611 examples, 0 failures
- includes advisory-lock contention, lock persistence beyond the old grace period, process-crash release, readiness failure, and active-session deletion coverage
