### PR TITLE
fix(agent): contain unexpected synchronous exceptions

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Render.hs
+++ b/packages/agent-cli/src/Agent/CLI/Render.hs
@@ -686,6 +686,8 @@ formatLoopErrorPersistedAt now = \case
             <> maybe "" ("\n" <>) turn.assistantText
     LoopNoResponseId ->
         "Provider returned an incomplete response.\nRetry the message."
+    LoopUnexpected message ->
+        "Unexpected agent error: " <> message <> "\nRetry the message."
     LoopCancelled _ ->
         "Cancelled."
 
@@ -705,5 +707,11 @@ formatLoopErrorColoredMaybeAt color maybeNow = \case
             (glyphErr
                 <> "Provider returned an incomplete response.\n"
                 <> "Retry the message.")
+    LoopUnexpected message ->
+        roleError color
+            (glyphErr
+                <> "Unexpected agent error: "
+                <> message
+                <> "\nRetry the message.")
     LoopCancelled _ ->
         roleMuted color (glyphCancel <> "cancelled")

--- a/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
@@ -204,6 +204,15 @@ spec = do
                 `shouldSatisfy`
                     Text.isInfixOf "Provider returned an incomplete response"
 
+        it "renders unexpected synchronous exceptions as retryable turn errors" do
+            let rendered =
+                    formatLoopError
+                        (LoopUnexpected "user error (disk failed)")
+            rendered `shouldSatisfy`
+                Text.isInfixOf
+                    "Unexpected agent error: user error (disk failed)"
+            rendered `shouldSatisfy` Text.isInfixOf "Retry the message."
+
     describe "renderEvent" do
         it "keeps concurrent tool lines intact" do
             withRenderConfig False False \config handle path -> do

--- a/packages/agent-core/src/Agent/Loop.hs
+++ b/packages/agent-core/src/Agent/Loop.hs
@@ -38,7 +38,7 @@ import Agent.Tools.Types
     )
 import Control.Concurrent.Async (mapConcurrently, race)
 import Control.Concurrent.MVar (newMVar, withMVar)
-import Control.Exception (SomeException)
+import Control.Exception.Safe (SomeException, displayException, tryAny)
 import Data.Aeson (FromJSON(..), ToJSON(..), object, withObject, (.:), (.:?), (.!=), (.=))
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as ByteString
@@ -173,6 +173,10 @@ data LoopError
     = LoopTransport ApiError
     | LoopMaxTurns TurnOutput
     | LoopNoResponseId
+    -- | An unexpected synchronous exception escaped a backend, approval
+    -- callback, event sink, or other loop-owned IO action. Keeping it in-band
+    -- lets interactive callers fail this turn without terminating the agent.
+    | LoopUnexpected Text
     -- | Soft-cancel after tools ran. Carries the completed tool results for
     -- callers that retain the in-progress turn; callers may instead roll the
     -- whole turn back to its last committed response boundary.
@@ -210,7 +214,26 @@ runLoopInputs
     -> Maybe Text
     -> [TurnInput]
     -> IO (Either LoopError LoopResult)
-runLoopInputs config0 previousResponseId firstInputs = do
+runLoopInputs config previousResponseId firstInputs =
+    tryAny (runLoopInputsUnsafe config previousResponseId firstInputs) >>= \case
+        Left exception ->
+            pure (Left (LoopUnexpected (exceptionSummary exception)))
+        Right result ->
+            pure result
+
+exceptionSummary :: SomeException -> Text
+exceptionSummary =
+    fst
+        . Text.breakOn "\nHasCallStack backtrace:"
+        . Text.pack
+        . displayException
+
+runLoopInputsUnsafe
+    :: LoopConfig
+    -> Maybe Text
+    -> [TurnInput]
+    -> IO (Either LoopError LoopResult)
+runLoopInputsUnsafe config0 previousResponseId firstInputs = do
     -- Parallel-safe tool batches run with mapConcurrently. Serialize onEvent
     -- so a printer (hPutStrLn on String is not atomic) cannot interleave
     -- characters.

--- a/packages/agent-core/src/Agent/ToolDispatch.hs
+++ b/packages/agent-core/src/Agent/ToolDispatch.hs
@@ -144,7 +144,10 @@ dispatchToolHandler config maybeHandler call = do
         Right toolResult ->
             pure (config.toolDispatchFormatResult toolResult)
         Left exception -> do
-            config.toolDispatchOnException callName exception
+            -- Diagnostics must not replace the original tool failure with a
+            -- second exception. 'tryAny' still lets asynchronous cancellation
+            -- propagate.
+            _ <- tryAny (config.toolDispatchOnException callName exception)
             pure (config.toolDispatchFormatException callName exception)
     pure ToolCallResult
         { callId = call.callId

--- a/packages/agent-core/test/Agent/LoopSpec.hs
+++ b/packages/agent-core/test/Agent/LoopSpec.hs
@@ -22,6 +22,7 @@ import Control.Concurrent.MVar
     , takeMVar
     , tryReadMVar
     )
+import qualified Control.Exception as Exception
 import Data.Aeson (FromJSON(..))
 import Data.IORef
 import Data.Text (Text)
@@ -386,6 +387,35 @@ spec = describe "runLoop" do
         config <- testConfig backend
         result <- runLoop config Nothing "hello"
         result `shouldBe` Left (LoopTransport (ConnectionError "down"))
+
+    it "turns synchronous backend exceptions into a failed turn" do
+        config <- testConfig $ Backend \_prev _inputs _onEvent ->
+            Exception.throwIO (userError "backend exploded")
+        result <- runLoop config Nothing "hello"
+        result `shouldBe`
+            Left (LoopUnexpected "user error (backend exploded)")
+
+    it "turns synchronous approval exceptions into a failed turn" do
+        submissions <- newIORef []
+        backend <- scriptedBackend submissions
+            [ Right $ emptyTurnOutput "resp-1"
+                [functionToolCall "c1" "echo" "{\"message\":\"hi\"}"]
+                Nothing
+            ]
+        config0 <- testConfig backend
+        let config = config0
+                { loopApprove = \_ ->
+                    Exception.throwIO (userError "approval exploded")
+                }
+        result <- runLoop config Nothing "hello"
+        result `shouldBe`
+            Left (LoopUnexpected "user error (approval exploded)")
+
+    it "does not turn asynchronous backend cancellation into a failed turn" do
+        config <- testConfig $ Backend \_prev _inputs _onEvent ->
+            Exception.throwIO Exception.ThreadKilled
+        runLoop config Nothing "hello"
+            `shouldThrow` (== Exception.ThreadKilled)
 
     it "emits TurnStarted and TurnFinished around each backend submit" do
         events <- newIORef []

--- a/packages/agent-core/test/Agent/ToolDispatchSpec.hs
+++ b/packages/agent-core/test/Agent/ToolDispatchSpec.hs
@@ -93,6 +93,16 @@ spec = describe "dispatchToolCall" do
         result `shouldBe` functionResult "call-1" "EX explode"
         readIORef seen `shouldReturn` ["explode"]
 
+    it "does not let a synchronous exception hook replace the tool failure" do
+        let config = testConfig
+                { toolDispatchOnException = \_ _ ->
+                    Exception.throwIO (userError "logging failed")
+                }
+        result <- dispatchToolCall config
+            [noArgsTool "explode" (Exception.throwIO (userError "boom"))]
+            (functionToolCall "call-1" "explode" "{}")
+        result `shouldBe` functionResult "call-1" "EX explode"
+
     it "does not turn asynchronous cancellation into tool output" do
         dispatchToolCall testConfig
             [noArgsTool "cancel" (Exception.throwIO Exception.ThreadKilled)]


### PR DESCRIPTION
## Summary
- convert unexpected synchronous exceptions from loop-owned IO into an in-band failed-turn result
- keep asynchronous cancellation exceptions propagating normally
- make tool exception diagnostics best-effort and render retry guidance in the CLI

## Tests
- `nix develop -c cabal test agent-core-test agent-cli-test --test-show-details=direct`
  - agent-core: 296 examples, 0 failures
  - agent-cli: 607 examples, 0 failures