### PR TITLE
fix(tui): quiet Solarized chrome

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
@@ -342,12 +342,6 @@ controlInteractionAttr state name
     | otherwise =
         Nothing
 
-modeAttr :: Text -> AttrName
-modeAttr mode = case Text.toLower mode of
-    "yolo" -> Theme.thinkingAttr
-    "plan" -> Theme.headingAttr
-    _ -> Theme.linkAttr
-
 renderDraft :: Bool -> Int -> UiState -> Widget Name
 renderDraft focused height state =
     Widget Greedy Fixed do
@@ -493,7 +487,7 @@ draftCursorLocation text cursor =
 drawComposerStatus :: AppState -> Widget Name
 drawComposerStatus state =
     hBox $
-        intersperse (txt " · ") $
+        intersperse (withAttr Theme.mutedAttr (txt " · ")) $
             modelAndEffort
                 <> [ modeControl
                    | not (Text.null mode)
@@ -515,7 +509,7 @@ drawComposerStatus state =
     effortControl =
         clickable ComposerEffort $
             forceAttr
-                (controlAttr state ComposerEffort Theme.assistantAttr)
+                (controlAttr state ComposerEffort Theme.controlLinkAttr)
                 (txt ("(" <> prompt.promptEffort <> ")"))
     modelAndEffort
         | Text.null prompt.promptModel = []
@@ -524,7 +518,7 @@ drawComposerStatus state =
     modeControl =
         clickable ComposerMode $
             forceAttr
-                (controlAttr state ComposerMode (modeAttr mode))
+                (controlAttr state ComposerMode Theme.controlLinkAttr)
                 (txt mode)
     accountControl =
         clickable ComposerAccount $

--- a/packages/agent-tui/src/Agent/TUI/Theme.hs
+++ b/packages/agent-tui/src/Agent/TUI/Theme.hs
@@ -174,11 +174,13 @@ solarizedDark =
         , (selectedAttr, V.defAttr
             `V.withForeColor` rgb 147 161 161
             `V.withBackColor` rgb 7 54 66)
+        -- Persistent UI chrome stays on Solarized's base ramp. Saturated
+        -- accents are reserved for semantic content and exceptional states.
         , (borderAttr, V.defAttr
             `V.withForeColor` rgb 88 110 117
             `V.withBackColor` rgb 0 43 54)
         , (borderActiveAttr, V.defAttr
-            `V.withForeColor` rgb 42 161 152
+            `V.withForeColor` rgb 101 123 131
             `V.withBackColor` rgb 0 43 54)
         , (headingAttr, V.defAttr
             `V.withForeColor` rgb 211 54 130
@@ -201,14 +203,14 @@ solarizedDark =
             `V.withForeColor` rgb 69 94 100
             `V.withBackColor` rgb 0 43 54)
         , (lambdaTrailAttr, V.defAttr
-            `V.withForeColor` rgb 38 139 210
+            `V.withForeColor` rgb 88 110 117
             `V.withBackColor` rgb 0 43 54)
         , (lambdaGlowAttr, V.defAttr
-            `V.withForeColor` rgb 42 161 152
+            `V.withForeColor` rgb 101 123 131
             `V.withBackColor` rgb 0 43 54
             `V.withStyle` V.bold)
         , (lambdaSparkAttr, V.defAttr
-            `V.withForeColor` rgb 211 54 130
+            `V.withForeColor` rgb 131 148 150
             `V.withBackColor` rgb 0 43 54
             `V.withStyle` V.bold)
         , (linkAttr, V.defAttr
@@ -220,15 +222,15 @@ solarizedDark =
             `V.withBackColor` rgb 0 43 54
             `V.withStyle` V.bold)
         , (controlLinkAttr, V.defAttr
-            `V.withForeColor` rgb 38 139 210
+            `V.withForeColor` rgb 101 123 131
             `V.withBackColor` rgb 0 43 54)
         , (controlLinkHoverAttr, V.defAttr
-            `V.withForeColor` rgb 42 161 152
+            `V.withForeColor` rgb 131 148 150
             `V.withBackColor` rgb 0 43 54
             `V.withStyle` V.underline)
         , (controlLinkActiveAttr, V.defAttr
-            `V.withForeColor` rgb 0 43 54
-            `V.withBackColor` rgb 38 139 210
+            `V.withForeColor` rgb 147 161 161
+            `V.withBackColor` rgb 7 54 66
             `V.withStyle` V.bold)
         , (syntaxNormalAttr, codeColor 42 161 152)
         , (syntaxKeywordAttr, codeColor 211 54 130)

--- a/packages/agent-tui/test/Agent/TUI/ThemeSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ThemeSpec.hs
@@ -2,38 +2,67 @@ module Agent.TUI.ThemeSpec (spec) where
 
 import Agent.Syntax (SyntaxClass(..))
 import qualified Agent.TUI.Theme as Theme
+import Brick (AttrName)
 import Brick.AttrMap (attrMapLookup)
 import qualified Graphics.Vty as V
 import Test.Hspec
 
 spec :: Spec
-spec = describe "syntax theme attributes" do
-    it "keeps every Solarized syntax class on the code-block background" do
-        let codeBackground =
-                V.attrBackColor
-                    (attrMapLookup Theme.codeAttr Theme.solarizedDark)
-        map
-            ( V.attrBackColor
-                . (`attrMapLookup` Theme.solarizedDark)
-                . Theme.syntaxClassAttr
-            )
-            allSyntaxClasses
-            `shouldBe` replicate (length allSyntaxClasses) codeBackground
+spec = do
+    describe "structural theme attributes" do
+        it "keeps active chrome and controls on the Solarized neutral ramp" do
+            map solarizedForeground
+                [ Theme.borderActiveAttr
+                , Theme.controlLinkAttr
+                , Theme.controlLinkHoverAttr
+                , Theme.controlLinkActiveAttr
+                , Theme.lambdaDimAttr
+                , Theme.lambdaTrailAttr
+                , Theme.lambdaGlowAttr
+                , Theme.lambdaSparkAttr
+                ]
+                `shouldBe`
+                    [ V.SetTo (V.RGBColor 101 123 131)
+                    , V.SetTo (V.RGBColor 101 123 131)
+                    , V.SetTo (V.RGBColor 131 148 150)
+                    , V.SetTo (V.RGBColor 147 161 161)
+                    , V.SetTo (V.RGBColor 69 94 100)
+                    , V.SetTo (V.RGBColor 88 110 117)
+                    , V.SetTo (V.RGBColor 101 123 131)
+                    , V.SetTo (V.RGBColor 131 148 150)
+                    ]
 
-    it "does not introduce colors in monochrome mode" do
-        map
-            ( \syntaxClass ->
-                let attr =
-                        attrMapLookup
-                            (Theme.syntaxClassAttr syntaxClass)
-                            Theme.monochrome
-                in (V.attrForeColor attr, V.attrBackColor attr)
-            )
-            allSyntaxClasses
-            `shouldBe`
-                replicate
-                    (length allSyntaxClasses)
-                    (V.Default, V.Default)
+    describe "syntax theme attributes" do
+        it "keeps every Solarized syntax class on the code-block background" do
+            let codeBackground =
+                    V.attrBackColor
+                        (attrMapLookup Theme.codeAttr Theme.solarizedDark)
+            map
+                ( V.attrBackColor
+                    . (`attrMapLookup` Theme.solarizedDark)
+                    . Theme.syntaxClassAttr
+                )
+                allSyntaxClasses
+                `shouldBe` replicate (length allSyntaxClasses) codeBackground
+
+        it "does not introduce colors in monochrome mode" do
+            map
+                ( \syntaxClass ->
+                    let attr =
+                            attrMapLookup
+                                (Theme.syntaxClassAttr syntaxClass)
+                                Theme.monochrome
+                    in (V.attrForeColor attr, V.attrBackColor attr)
+                )
+                allSyntaxClasses
+                `shouldBe`
+                    replicate
+                        (length allSyntaxClasses)
+                        (V.Default, V.Default)
+
+solarizedForeground :: AttrName -> V.MaybeDefault V.Color
+solarizedForeground =
+    V.attrForeColor . (`attrMapLookup` Theme.solarizedDark)
 
 allSyntaxClasses :: [SyntaxClass]
 allSyntaxClasses = [minBound .. maxBound]


### PR DESCRIPTION
## Summary

- move persistent TUI chrome and empty-state motion onto the Solarized base ramp
- give composer model, effort, mode, and account metadata one restrained control style
- reserve saturated accents for semantic content and add regression coverage for structural colors

## Testing

- `nix develop -c cabal repl agent-tui:test:agent-tui-test` (`:main`): 79 examples, 0 failures
- `nix develop -c cabal repl agent-cli:test:agent-cli-test` (`:main`): 611 examples, 0 failures
- full-screen tmux smoke test covering prompt typing and composer/scrollback focus transitions
