### PR TITLE
refactor(core): share typed tool decoding

### DIFF
--- a/packages/agent-core/src/Agent/ToolDispatch.hs
+++ b/packages/agent-core/src/Agent/ToolDispatch.hs
@@ -213,17 +213,16 @@ runHandler
     -> ToolHandler
     -> IO (Either Text Text)
 runHandler emitOutput call value = \case
-    TypedTool _ run ->
-        case decodeToolArguments value of
-            Right args -> run args
-            Left err -> pure (Left err)
-    TypedToolWithCall _ run ->
-        case decodeToolArguments value of
-            Right args -> run call args
-            Left err -> pure (Left err)
-    TypedStreamingTool _ run ->
-        case decodeToolArguments value of
-            Right args -> run emitOutput args
-            Left err -> pure (Left err)
+    TypedTool _ run -> decodeAndRun value run
+    TypedToolWithCall _ run -> decodeAndRun value (run call)
+    TypedStreamingTool _ run -> decodeAndRun value (run emitOutput)
     NoArgsTool _ run ->
         run
+
+decodeAndRun
+    :: FromJSON args
+    => Value
+    -> (args -> IO (Either Text Text))
+    -> IO (Either Text Text)
+decodeAndRun value run =
+    either (pure . Left) run (decodeToolArguments value)

--- a/packages/agent-core/test/Agent/ToolDispatchSpec.hs
+++ b/packages/agent-core/test/Agent/ToolDispatchSpec.hs
@@ -44,6 +44,14 @@ spec = describe "dispatchToolCall" do
             (functionToolCall "call-1" "echo" "{\"message\":\"hello\"}")
         result `shouldBe` functionResult "call-1" "echo:hello"
 
+    it "passes the originating call to call-aware typed handlers" do
+        result <- dispatchToolCall testConfig
+            [ typedToolWithCall "echo" \call (EchoArgs message) ->
+                pure (Right (call.callId <> ":" <> message))
+            ]
+            (functionToolCall "call-1" "echo" "{\"message\":\"hello\"}")
+        result `shouldBe` functionResult "call-1" "call-1:hello"
+
     it "turns typed decode failures into formatted tool output" do
         result <- dispatchToolCall testConfig
             [ typedTool "echo" \(EchoArgs message) ->


### PR DESCRIPTION
## Summary

- factor typed tool argument decoding and error propagation into one helper
- reuse it for regular, call-aware, and streaming typed handlers
- add direct coverage for call-aware typed handler dispatch

## Testing

- `nix develop -c cabal repl agent-core:test:agent-core-test`
  - ran `hspec (ToolDispatchSpec.spec >> ToolArgsSpec.spec)`
  - 24 examples, 0 failures
- `git diff --check`
