### PR TITLE
test(codex): avoid shell completion timing race

### DIFF
--- a/packages/agent-core/test/Agent/Tools/CodexSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/CodexSpec.hs
@@ -338,7 +338,7 @@ spec = describe "Agent.Tools.Codex" do
                 threadDelay 150000
                 finished <- runFnWith tools "write_stdin" $
                     "{\"session_id\":" <> Text.pack (show sessionId)
-                        <> ",\"chars\":\"late\",\"yield_time_ms\":10}"
+                        <> ",\"chars\":\"late\",\"yield_time_ms\":1000}"
                 finished `shouldSatisfy` Text.isInfixOf "Exit code: 0"
                 finished `shouldSatisfy` Text.isInfixOf "done"
 


### PR DESCRIPTION
## Summary

- allow the post-exit `write_stdin` regression test enough time to observe command completion
- avoid a load-dependent 10 ms scheduling race on the Nix CI builder
- leave the managed shell implementation and production behavior unchanged

## Validation

- focused regression test passed 100 consecutive runs
- `Agent.Tools.Codex`: 24 examples, 0 failures
- full `agent-core` suite with seed `1401698146`: 296 examples, 0 failures
- `git diff --check`
