### PR TITLE
fix(cli): retain cancelled turn context

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -186,6 +186,7 @@ test-suite agent-cli-test
                     , Agent.CLI.TimestampSpec
                     , Agent.CLI.TerminalSpec
                     , Agent.CLI.TextLayoutSpec
+                    , Agent.CLI.TurnSpec
                     , Agent.CLI.SessionSpec
                     , Agent.CLI.SessionTitleSpec
                     , Agent.CLI.SkillsSpec

--- a/packages/agent-cli/src/Agent/CLI/Turn.hs
+++ b/packages/agent-cli/src/Agent/CLI/Turn.hs
@@ -1,6 +1,7 @@
 -- | Execute one model turn and commit its observable session state.
 module Agent.CLI.Turn
     ( applyPendingSessionTitles
+    , retainTurnInputs
     , runOneTurn
     ) where
 
@@ -39,7 +40,6 @@ import Agent.CLI.Session
     , SessionTurn(..)
     , Persistence(..)
     , PersistenceState(..)
-    , appendTurn
     , appendTurnWithMetaUpdate
     , ensureSession
     , loadSession
@@ -77,6 +77,8 @@ import Agent.Loop
     , addTokenUsage
     , runLoopInputs
     )
+import Agent.Responses.LoopBackend (turnInputsToItems)
+import Agent.Responses.Types (ResponseItem)
 import Agent.Tools.PlanMode
     ( PlanDecision(..)
     , PlanModeEnv(..)
@@ -215,7 +217,7 @@ runOneTurn env@SessionEnv
     let elapsedDetail extra = case startedAt of
             Nothing -> extra
             Just t0 -> extra <> " · " <> formatElapsed (realToFrac (diffUTCTime finishedAt t0))
-        persistIncomplete errorText = case persist of
+        persistIncomplete retainedItems errorText = case persist of
             PersistenceDisabled -> pure ()
             PersistenceEnabled slotRef -> do
                 now <- getCurrentTime
@@ -228,10 +230,11 @@ runOneTurn env@SessionEnv
                         , turnAssistantText = Nothing
                         , turnError = Just errorText
                         , turnResponseId = Nothing
-                        , turnItems = []
+                        , turnItems = retainedItems
                         , turnUsage = Nothing
                         }
-                handle' <- appendTurn handle turn
+                handle' <- appendTurnWithMetaUpdate handle turn \meta ->
+                    meta { metaLastResponseId = Nothing }
                 writeIORef slotRef (PersistenceActive handle')
     case (restartEffort, result) of
         (Just level, _) -> do
@@ -250,11 +253,16 @@ runOneTurn env@SessionEnv
                 , pendingPlanState = planState
                 }
         (Nothing, Left cancelled@(LoopCancelled _)) -> do
-            restoreStartupContext
             finishTerminal (isNothing fullscreen)
                 terminal wallStarted finishedAt 130 "Agent cancelled"
             abortSubagentTurn rootTurnId
-            writeIORef transcriptRef beforeItems
+            -- turnInputs already contains any startup context consumed above.
+            -- Checkpoint it instead of restoring it separately, which would
+            -- duplicate the instructions on the next full-history request.
+            let (retainedTranscript, retainedItems) =
+                    retainTurnInputs beforeItems turnInputs
+            writeIORef transcriptRef retainedTranscript
+            writeIORef previous Nothing
             model <- readIORef render.renderModelRef
             case fullscreen of
                 Just runtime -> do
@@ -268,16 +276,16 @@ runOneTurn env@SessionEnv
                     putTextLn stderr (formatLoopErrorColored color cancelled)
                     putTextLn stderr
                         (formatTurnStatus color "cancelled" (elapsedDetail model))
-            persistIncomplete "cancelled"
+            persistIncomplete retainedItems "cancelled"
             pure TurnSucceeded
         (Nothing, Left err) -> do
-            restoreStartupContext
             abortSubagentTurn rootTurnId
             afterItems <- readIORef transcriptRef
             case err of
                 LoopTransport apiError
                     | length afterItems == length beforeItems
                     , isProviderUnavailable apiError -> do
+                        restoreStartupContext
                         case fullscreen of
                             Nothing -> pure ()
                             Just runtime ->
@@ -296,7 +304,10 @@ runOneTurn env@SessionEnv
                 _ -> do
                     finishTerminal (isNothing fullscreen)
                         terminal wallStarted finishedAt 1 "Agent turn failed"
-                    writeIORef transcriptRef beforeItems
+                    let (retainedTranscript, retainedItems) =
+                            retainTurnInputs beforeItems turnInputs
+                    writeIORef transcriptRef retainedTranscript
+                    writeIORef previous Nothing
                     model <- readIORef render.renderModelRef
                     case fullscreen of
                         Just runtime ->
@@ -314,7 +325,8 @@ runOneTurn env@SessionEnv
                                 (formatLoopErrorColoredAt color finishedAt err)
                             putTextLn stderr
                                 (formatTurnStatus color "error" (elapsedDetail model))
-                    persistIncomplete (formatLoopErrorPersistedAt finishedAt err)
+                    persistIncomplete retainedItems
+                        (formatLoopErrorPersistedAt finishedAt err)
                     pure TurnFailed
         (Nothing, Right loopResult) -> do
             finishTerminal (isNothing fullscreen)
@@ -403,6 +415,18 @@ isPendingPersistence :: PersistenceState -> Bool
 isPendingPersistence = \case
     PersistencePending _ -> True
     PersistenceActive _ -> False
+
+-- | Keep inputs from a cancelled or failed logical turn while discarding any
+-- partial assistant output, tool calls, and tool results produced after the
+-- turn began. Returning the retained suffix separately lets persistence store
+-- the same model-visible checkpoint used by the live transcript.
+retainTurnInputs
+    :: [ResponseItem]
+    -> [TurnInput]
+    -> ([ResponseItem], [ResponseItem])
+retainTurnInputs beforeItems turnInputs =
+    let retainedItems = turnInputsToItems turnInputs
+    in (beforeItems <> retainedItems, retainedItems)
 
 requestConversationTitle :: SessionEnv -> SessionHandle -> Int -> IO ()
 requestConversationTitle env handle milestone =

--- a/packages/agent-cli/src/Agent/CLI/Turn.hs
+++ b/packages/agent-cli/src/Agent/CLI/Turn.hs
@@ -1,7 +1,8 @@
 -- | Execute one model turn and commit its observable session state.
 module Agent.CLI.Turn
-    ( applyPendingSessionTitles
-    , retainTurnInputs
+    ( IncompleteTurnCheckpoint(..)
+    , applyPendingSessionTitles
+    , checkpointIncompleteTurn
     , runOneTurn
     ) where
 
@@ -259,10 +260,9 @@ runOneTurn env@SessionEnv
             -- turnInputs already contains any startup context consumed above.
             -- Checkpoint it instead of restoring it separately, which would
             -- duplicate the instructions on the next full-history request.
-            let (retainedTranscript, retainedItems) =
-                    retainTurnInputs beforeItems turnInputs
-            writeIORef transcriptRef retainedTranscript
-            writeIORef previous Nothing
+            let checkpoint = checkpointIncompleteTurn beforeItems turnInputs
+            writeIORef transcriptRef checkpoint.checkpointTranscript
+            writeIORef previous checkpoint.checkpointPreviousResponseId
             model <- readIORef render.renderModelRef
             case fullscreen of
                 Just runtime -> do
@@ -276,7 +276,7 @@ runOneTurn env@SessionEnv
                     putTextLn stderr (formatLoopErrorColored color cancelled)
                     putTextLn stderr
                         (formatTurnStatus color "cancelled" (elapsedDetail model))
-            persistIncomplete retainedItems "cancelled"
+            persistIncomplete checkpoint.checkpointTurnItems "cancelled"
             pure TurnSucceeded
         (Nothing, Left err) -> do
             abortSubagentTurn rootTurnId
@@ -304,10 +304,11 @@ runOneTurn env@SessionEnv
                 _ -> do
                     finishTerminal (isNothing fullscreen)
                         terminal wallStarted finishedAt 1 "Agent turn failed"
-                    let (retainedTranscript, retainedItems) =
-                            retainTurnInputs beforeItems turnInputs
-                    writeIORef transcriptRef retainedTranscript
-                    writeIORef previous Nothing
+                    let checkpoint =
+                            checkpointIncompleteTurn beforeItems turnInputs
+                    writeIORef transcriptRef checkpoint.checkpointTranscript
+                    writeIORef previous
+                        checkpoint.checkpointPreviousResponseId
                     model <- readIORef render.renderModelRef
                     case fullscreen of
                         Just runtime ->
@@ -325,7 +326,7 @@ runOneTurn env@SessionEnv
                                 (formatLoopErrorColoredAt color finishedAt err)
                             putTextLn stderr
                                 (formatTurnStatus color "error" (elapsedDetail model))
-                    persistIncomplete retainedItems
+                    persistIncomplete checkpoint.checkpointTurnItems
                         (formatLoopErrorPersistedAt finishedAt err)
                     pure TurnFailed
         (Nothing, Right loopResult) -> do
@@ -416,17 +417,27 @@ isPendingPersistence = \case
     PersistencePending _ -> True
     PersistenceActive _ -> False
 
--- | Keep inputs from a cancelled or failed logical turn while discarding any
--- partial assistant output, tool calls, and tool results produced after the
--- turn began. Returning the retained suffix separately lets persistence store
--- the same model-visible checkpoint used by the live transcript.
-retainTurnInputs
+-- | Pure state transition for a cancelled or failed logical turn. It preserves
+-- the exact model inputs while discarding partial assistant/tool state and
+-- invalidates the provider response chain so the next request replays the
+-- complete local transcript.
+data IncompleteTurnCheckpoint = IncompleteTurnCheckpoint
+    { checkpointTranscript :: ![ResponseItem]
+    , checkpointTurnItems :: ![ResponseItem]
+    , checkpointPreviousResponseId :: !(Maybe Text)
+    } deriving (Eq, Show)
+
+checkpointIncompleteTurn
     :: [ResponseItem]
     -> [TurnInput]
-    -> ([ResponseItem], [ResponseItem])
-retainTurnInputs beforeItems turnInputs =
+    -> IncompleteTurnCheckpoint
+checkpointIncompleteTurn beforeItems turnInputs =
     let retainedItems = turnInputsToItems turnInputs
-    in (beforeItems <> retainedItems, retainedItems)
+    in IncompleteTurnCheckpoint
+        { checkpointTranscript = beforeItems <> retainedItems
+        , checkpointTurnItems = retainedItems
+        , checkpointPreviousResponseId = Nothing
+        }
 
 requestConversationTitle :: SessionEnv -> SessionHandle -> Int -> IO ()
 requestConversationTitle env handle milestone =

--- a/packages/agent-cli/test/Agent/CLI/TurnSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TurnSpec.hs
@@ -1,6 +1,9 @@
 module Agent.CLI.TurnSpec (spec) where
 
-import Agent.CLI.Turn (retainTurnInputs)
+import Agent.CLI.Turn
+    ( IncompleteTurnCheckpoint(..)
+    , checkpointIncompleteTurn
+    )
 import Agent.Loop (TurnInput(..))
 import Agent.Responses.LoopBackend (turnInputsToItems)
 import Agent.Responses.Types
@@ -14,13 +17,17 @@ import qualified Data.Aeson.KeyMap as KeyMap
 import Test.Hspec
 
 spec :: Spec
-spec = describe "retainTurnInputs" do
-    it "keeps the exact turn inputs after existing history" do
+spec = describe "checkpointIncompleteTurn" do
+    it "describes the complete input-only checkpoint transition" do
         let history = turnInputsToItems [UserMessage "earlier"]
             inputs = [UserMessage "build failed [2026-08-23 13:10 CEST]"]
             retained = turnInputsToItems inputs
-        retainTurnInputs history inputs
-            `shouldBe` (history <> retained, retained)
+        checkpointIncompleteTurn history inputs `shouldBe`
+            IncompleteTurnCheckpoint
+                { checkpointTranscript = history <> retained
+                , checkpointTurnItems = retained
+                , checkpointPreviousResponseId = Nothing
+                }
 
     it "does not retain partial assistant or tool state" do
         let history = turnInputsToItems [UserMessage "earlier"]
@@ -41,6 +48,9 @@ spec = describe "retainTurnInputs" do
                     , extraFields = KeyMap.empty
                     }
             inputs = [UserMessage "fix the failure"]
-            (transcript, _) = retainTurnInputs history inputs
-        transcript `shouldNotContain` [partialAssistant]
-        transcript `shouldBe` history <> turnInputsToItems inputs
+            partialTranscript = history <> [partialAssistant]
+            checkpoint = checkpointIncompleteTurn history inputs
+        checkpoint.checkpointTranscript
+            `shouldNotBe` partialTranscript <> turnInputsToItems inputs
+        checkpoint.checkpointTranscript
+            `shouldBe` history <> turnInputsToItems inputs

--- a/packages/agent-cli/test/Agent/CLI/TurnSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TurnSpec.hs
@@ -1,0 +1,46 @@
+module Agent.CLI.TurnSpec (spec) where
+
+import Agent.CLI.Turn (retainTurnInputs)
+import Agent.Loop (TurnInput(..))
+import Agent.Responses.LoopBackend (turnInputsToItems)
+import Agent.Responses.Types
+    ( ResponseContentPart(..)
+    , ResponseItem(..)
+    , ResponseMessage(..)
+    , MessageContent(..)
+    , ResponseRole(..)
+    )
+import qualified Data.Aeson.KeyMap as KeyMap
+import Test.Hspec
+
+spec :: Spec
+spec = describe "retainTurnInputs" do
+    it "keeps the exact turn inputs after existing history" do
+        let history = turnInputsToItems [UserMessage "earlier"]
+            inputs = [UserMessage "build failed [2026-08-23 13:10 CEST]"]
+            retained = turnInputsToItems inputs
+        retainTurnInputs history inputs
+            `shouldBe` (history <> retained, retained)
+
+    it "does not retain partial assistant or tool state" do
+        let history = turnInputsToItems [UserMessage "earlier"]
+            partialAssistant =
+                MessageItem ResponseMessage
+                    { messageId = Just "partial"
+                    , content =
+                        MessageContentParts
+                            [ OutputTextPart
+                                "partial answer"
+                                Nothing
+                                Nothing
+                                KeyMap.empty
+                            ]
+                    , role = RoleAssistant
+                    , status = Nothing
+                    , phase = Nothing
+                    , extraFields = KeyMap.empty
+                    }
+            inputs = [UserMessage "fix the failure"]
+            (transcript, _) = retainTurnInputs history inputs
+        transcript `shouldNotContain` [partialAssistant]
+        transcript `shouldBe` history <> turnInputsToItems inputs

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -44,6 +44,7 @@ import qualified Agent.CLI.SkillsSpec as SkillsSpec
 import qualified Agent.CLI.SubagentStoreSpec as SubagentStoreSpec
 import qualified Agent.CLI.StyleSpec as StyleSpec
 import qualified Agent.CLI.TimestampSpec as TimestampSpec
+import qualified Agent.CLI.TurnSpec as TurnSpec
 import qualified Agent.CLI.TerminalSpec as TerminalSpec
 import qualified Agent.CLI.TextLayoutSpec as TextLayoutSpec
 import qualified Agent.CLI.ToolsSpec as ToolsSpec
@@ -95,6 +96,7 @@ main = hspec do
     ResumeSpec.spec
     StyleSpec.spec
     TimestampSpec.spec
+    TurnSpec.spec
     TerminalSpec.spec
     TextLayoutSpec.spec
     SessionSpec.spec


### PR DESCRIPTION
## Summary

- model cancelled/failed-turn recovery as a pure `IncompleteTurnCheckpoint` transition
- retain the exact stamped model inputs while discarding partial assistant output and tool state
- clear `previous_response_id` so the next request replays full local history
- persist the same input checkpoint so resumed sessions keep identical context
- avoid restoring startup instructions separately once they are part of the checkpoint
- add no new `IORef`s; `runOneTurn` only commits the pure checkpoint to existing session state

## Regression

Previously, a cancelled turn remained visible through `turnUserText` but was persisted with `turnItems = []` and removed from the live transcript. A follow-up such as “fix the error I mentioned earlier” therefore could not see the error.

## Tests

- `nix develop -c cabal repl agent-cli:test:agent-cli-test` → `:main` — 613 examples, 0 failures
- focused `checkpointIncompleteTurn` tests — 2 examples, 0 failures
