### PR TITLE
refactor(core): share boolean argument parsing

### DIFF
--- a/packages/agent-core/src/Agent/ToolArgs.hs
+++ b/packages/agent-core/src/Agent/ToolArgs.hs
@@ -86,16 +86,7 @@ extractMaybeInt _ _ = Nothing
 -- emit ("true"/"false"/"1"/"0", case-insensitive, whitespace-tolerant).
 extractMaybeBool :: Value -> Text -> Maybe Bool
 extractMaybeBool (Object obj) key =
-    case KeyMap.lookup (Key.fromText key) obj of
-        Just (Bool b) -> Just b
-        Just (String t) ->
-            case Text.toLower (Text.strip t) of
-                "true"  -> Just True
-                "false" -> Just False
-                "1"     -> Just True
-                "0"     -> Just False
-                _       -> Nothing
-        _ -> Nothing
+    KeyMap.lookup (Key.fromText key) obj >>= boolValue
 extractMaybeBool _ _ = Nothing
 
 look :: Object -> Text -> Maybe Value
@@ -183,16 +174,7 @@ readExactInt value = do
 
 -- | Optional boolean accepting stringy forms.
 optBool :: Object -> Text -> Parser (Maybe Bool)
-optBool obj key = pure $ case look obj key of
-    Just (Bool b) -> Just b
-    Just (String t) ->
-        case Text.toLower (Text.strip t) of
-            "true"  -> Just True
-            "false" -> Just False
-            "1"     -> Just True
-            "0"     -> Just False
-            _       -> Nothing
-    _ -> Nothing
+optBool obj key = pure (look obj key >>= boolValue)
 
 -- | Exact, bounded integer with a default for an absent or null field.
 intOr :: Object -> Text -> Int -> Parser Int
@@ -225,6 +207,17 @@ failText = fail . Text.unpack
 
 exactInt :: Scientific -> Maybe Int
 exactInt = toBoundedInteger
+
+boolValue :: Value -> Maybe Bool
+boolValue = \case
+    Bool value -> Just value
+    String value -> case Text.toLower (Text.strip value) of
+        "true" -> Just True
+        "false" -> Just False
+        "1" -> Just True
+        "0" -> Just False
+        _ -> Nothing
+    _ -> Nothing
 
 parseExactInt :: Text -> Scientific -> Parser Int
 parseExactInt key =

--- a/packages/agent-core/test/Agent/ToolArgsSpec.hs
+++ b/packages/agent-core/test/Agent/ToolArgsSpec.hs
@@ -8,6 +8,7 @@ import Agent.ToolDispatch
     , functionToolCall
     , typedTool
     )
+import Control.Monad (forM_)
 import Data.Aeson ((.=))
 import qualified Data.Aeson as Aeson
 import Data.Aeson.Types (parseEither)
@@ -27,9 +28,27 @@ spec = describe "ToolArgs" do
         extractTextList (Aeson.object ["ids" .= ("abc" :: Text)]) "ids"
             `shouldBe` Right ["abc"]
 
-    it "accepts string booleans" do
-        extractMaybeBool (Aeson.object ["flag" .= ("true" :: Text)]) "flag"
-            `shouldBe` Just True
+    it "keeps legacy and typed boolean parsing aligned" do
+        let cases :: [(Aeson.Value, Maybe Bool)]
+            cases =
+                [ (Aeson.Bool True, Just True)
+                , (Aeson.Bool False, Just False)
+                , (Aeson.String " TRUE ", Just True)
+                , (Aeson.String "false", Just False)
+                , (Aeson.String "1", Just True)
+                , (Aeson.String "0", Just False)
+                , (Aeson.String "yes", Nothing)
+                , (Aeson.Null, Nothing)
+                , (Aeson.toJSON (1 :: Int), Nothing)
+                ]
+        forM_ cases \(value, expected) -> do
+            let input = Aeson.object ["flag" .= value]
+            extractMaybeBool input "flag" `shouldBe` expected
+            parseEither (objectArgs $ \o -> optBool o "flag") input
+                `shouldBe` Right expected
+        extractMaybeBool (Aeson.object []) "flag" `shouldBe` Nothing
+        parseEither (objectArgs $ \o -> optBool o "flag") (Aeson.object [])
+            `shouldBe` Right Nothing
 
     it "backs typed FromJSON records" do
         Aeson.eitherDecode "{\"query\":\"invoice\",\"limit\":5,\"dry_run\":\"false\"}"


### PR DESCRIPTION
## Summary

- centralize permissive boolean value parsing in `Agent.ToolArgs`
- reuse the same policy for legacy extraction and typed argument parsing
- add table-driven equivalence coverage for accepted and rejected forms

## Testing

- `nix develop -c cabal repl agent-core:test:agent-core-test`
  - ran `hspec ToolArgsSpec.spec`
  - 12 examples, 0 failures
- `git diff --check`
