### PR TITLE
fix(tui): make turn cancellation reliable

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
@@ -1,8 +1,10 @@
 -- | Fullscreen prompt composer rendering, editing, and input buffering.
 module Agent.CLI.TUI.Composer
-    ( activateSlashAt
+    ( ComposerEscapeAction(..)
+    , activateSlashAt
     , appendFullscreenInput
     , applyComposerUiEvent
+    , composerEscapeAction
     , controlAttr
     , controlInteractionAttr
     , decodePaste
@@ -680,11 +682,16 @@ handleComposerKey
         V.EvKey (V.KChar 'c') [V.MCtrl] ->
             void handleCtrlC
         V.EvKey V.KEsc [] ->
-            case slashMenu of
-                Just _ ->
+            case composerEscapeAction
+                ui.uiAwaitingInput
+                (maybe False (const True) slashMenu) of
+                EscapeCancelTurn ->
+                    cancelOrClear
+                EscapeDismissSlashMenu ->
                     modify' \current ->
                         current { appSlashDismissed = True }
-                Nothing -> cancelOrClear
+                EscapeClearDraft ->
+                    cancelOrClear
         V.EvKey V.KBackTab []
             | ui.uiAwaitingInput ->
                 submitRaw (ReplCycleMode ui.uiDraft)
@@ -1090,6 +1097,20 @@ currentSlashMenu state
             state.appSkillCommands
             state.appUi.uiDraft
             state.appUi.uiCursor
+
+data ComposerEscapeAction
+    = EscapeCancelTurn
+    | EscapeDismissSlashMenu
+    | EscapeClearDraft
+    deriving (Eq, Show)
+
+-- | During a running turn Esc keeps its advertised cancellation meaning,
+-- even when the next-message draft happens to open the slash menu.
+composerEscapeAction :: Bool -> Bool -> ComposerEscapeAction
+composerEscapeAction awaitingInput hasSlashMenu
+    | not awaitingInput = EscapeCancelTurn
+    | hasSlashMenu = EscapeDismissSlashMenu
+    | otherwise = EscapeClearDraft
 
 selectedSlashSuggestion
     :: AppState

--- a/packages/agent-cli/test/Agent/CLI/TUIComposerSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIComposerSpec.hs
@@ -12,6 +12,16 @@ import Test.Hspec
 
 spec :: Spec
 spec = describe "fullscreen composer" do
+    it "cancels a running turn even when the slash menu is open" do
+        composerEscapeAction False True
+            `shouldBe` EscapeCancelTurn
+
+    it "dismisses slash completion or clears the draft while idle" do
+        composerEscapeAction True True
+            `shouldBe` EscapeDismissSlashMenu
+        composerEscapeAction True False
+            `shouldBe` EscapeClearDraft
+
     it "tracks the multiline cursor location" do
         draftCursorLocation "one\ntwo" 6 `shouldBe` (1, 2)
 

--- a/packages/agent-tui/src/Agent/TUI/Model.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model.hs
@@ -605,6 +605,14 @@ finalizeTurn terminalState state =
             if terminalState == BlockComplete
                 then completionStatusDurationMillis
                 else 0
+        , uiNotice = case state.uiNotice of
+            Just notice
+                | notice.noticeKind == NoticeProgress -> Nothing
+            other -> other
+        , uiNoticeElapsedMillis = case state.uiNotice of
+            Just notice
+                | notice.noticeKind == NoticeProgress -> 0
+            _ -> state.uiNoticeElapsedMillis
         }
 
 infoNotice, successNotice, warningNotice, progressNotice, errorNotice

--- a/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
@@ -73,6 +73,27 @@ spec = describe "fullscreen UI reducer" do
             `shouldBe` Just
                 (progressNotice "Restarting current turn…")
 
+    it "clears a cancellation progress notice when the turn ends" do
+        let state =
+                apply
+                    [ UiLoop TurnStarted
+                    , UiSetNotice (Just (progressNotice "Cancelling…"))
+                    , UiTurnEnded BlockCancelled
+                    ]
+        state.uiRunning `shouldBe` False
+        state.uiActivity `shouldBe` "Ready"
+        state.uiNotice `shouldBe` Nothing
+
+    it "preserves a transient notice when the turn ends" do
+        let notice = warningNotice "Connection recovered"
+            state =
+                apply
+                    [ UiLoop TurnStarted
+                    , UiSetNotice (Just notice)
+                    , UiTurnEnded BlockFailed
+                    ]
+        state.uiNotice `shouldBe` Just notice
+
     it "matches tool completion by call id" do
         let call = functionToolCall "c1" "run_terminal_cmd" "{\"command\":\"git status\"}"
             result = ToolCallResult


### PR DESCRIPTION
## Summary

- make Esc cancel an active fullscreen turn even when the next-message slash menu is open
- clear non-transient progress notices such as `Cancelling…` when a turn reaches a terminal state
- preserve idle Esc behavior and transient informational notices
- add regression coverage for both cancellation state transitions

## Reproduction

Tested in a real tmux TTY with OpenAI `gpt-5.6-luna`:

1. Start a turn that runs `sleep 60`.
2. Type `/` in the next-message composer to open slash completion.
3. Press Esc once.

Before this change, the first Esc only dismissed slash completion and a second Esc was needed. After cancellation completed, `Cancelling…` could also remain visible while the UI was already Ready.

After this change, one Esc cancels the command and turn, the UI returns to Ready, and the progress notice clears.

## Tests

- `nix develop -c cabal test --offline agent-tui:test:agent-tui-test agent-cli:test:agent-cli-test`
  - agent-tui: 81 examples, 0 failures
  - agent-cli: 613 examples, 0 failures
- final tmux smoke test with `gpt-5.6-luna`
- `git diff --check`
