### PR TITLE
refactor(tui): simplify agent list formatting

### DIFF
--- a/packages/agent-tui/src/Agent/TUI/Presentation.hs
+++ b/packages/agent-tui/src/Agent/TUI/Presentation.hs
@@ -18,8 +18,8 @@ import Agent.ToolDispatch
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KeyMap
-import qualified Data.Foldable as Foldable
-import Data.Maybe (fromMaybe)
+import Data.Foldable (toList)
+import Data.Maybe (fromMaybe, mapMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
@@ -167,21 +167,17 @@ formatAgentList :: Text -> Maybe Text
 formatAgentList output = do
     Aeson.Object object <- Aeson.decodeStrict (TextEncoding.encodeUtf8 output)
     Aeson.Array agents <- KeyMap.lookup (Key.fromText "agents") object
-    let rows = foldr agentRow [] (Foldable.toList agents)
+    let rows = mapMaybe formatAgentRow (toList agents)
     pure $ case rows of
         [] -> "(no live agents)"
         _ -> Text.intercalate "\n" rows
-  where
-    agentRow value rest = case value of
-        Aeson.Object agent ->
-            case
-                ( jsonObjectText "agent_name" agent
-                , jsonObjectText "agent_status" agent
-                ) of
-                (Just name, Just status) -> (name <> " · " <> status) : rest
-                (Just name, Nothing) -> name : rest
-                _ -> rest
-        _ -> rest
+
+formatAgentRow :: Aeson.Value -> Maybe Text
+formatAgentRow (Aeson.Object agent) = do
+    name <- jsonObjectText "agent_name" agent
+    pure $ maybe name (\status -> name <> " · " <> status)
+        (jsonObjectText "agent_status" agent)
+formatAgentRow _ = Nothing
 
 jsonObjectText :: Text -> Aeson.Object -> Maybe Text
 jsonObjectText key object =

--- a/packages/agent-tui/test/Agent/TUI/PresentationSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/PresentationSpec.hs
@@ -41,8 +41,18 @@ spec = describe "tool presentation" do
         parsed.diffHiddenLines `shouldBe` 10
 
     it "formats structured collaboration output" do
-        formatToolOutput
-            (functionToolCall "agents" "collaboration.list_agents" "{}")
+        let call = functionToolCall
+                "agents" "collaboration.list_agents" "{}"
+        formatToolOutput call
             "{\"agents\":[{\"agent_name\":\"/root/reviewer\",\
             \\"agent_status\":\"running\"}]}"
             `shouldBe` "/root/reviewer · running"
+        formatToolOutput call
+            "{\"agents\":[\
+            \{\"agent_name\":\" /root/worker \",\"agent_status\":\" idle \"},\
+            \{\"agent_name\":\"/root/queued\"},\
+            \{\"agent_name\":\" \",\"agent_status\":\"running\"},42]}"
+            `shouldBe` "/root/worker · idle\n/root/queued"
+        formatToolOutput call
+            "{\"agents\":[{\"agent_status\":\"running\"},null]}"
+            `shouldBe` "(no live agents)"


### PR DESCRIPTION
## Summary

- replace manual agent-row accumulator threading with `mapMaybe`
- extract a direct formatter for individual collaboration-agent rows
- cover missing statuses, whitespace, malformed entries, and empty valid results

## Testing

- `nix develop -c cabal repl agent-tui:test:agent-tui-test`
  - ran `hspec PresentationSpec.spec`
  - 3 examples, 0 failures
- tmux TTY smoke test rendered:
  - `/root/worker · idle`
  - `/root/queued`
- `git diff --check`
