### PR TITLE
Fix collaboration tools with omitted arguments

### DIFF
--- a/packages/agent-core/src/Agent/Tools/MultiAgents.hs
+++ b/packages/agent-core/src/Agent/Tools/MultiAgents.hs
@@ -43,6 +43,7 @@ import Agent.InterAgentMessage
 import System.OsPath (OsPath)
 import Agent.ToolArgs
     ( objectArgs
+    , objectArgsLenient
     , optInt
     , optText
     , readExactInt
@@ -237,7 +238,7 @@ data WaitAgentArgs = WaitAgentArgs
     }
 
 instance FromJSON WaitAgentArgs where
-    parseJSON = objectArgs \object_ -> do
+    parseJSON = objectArgsLenient \object_ -> do
         targets <- case KeyMap.lookup (Key.fromText "targets") object_ of
             Nothing -> pure Nothing
             Just _ -> Just <$> reqTextList object_ "targets"
@@ -451,7 +452,7 @@ data ListAgentsArgs = ListAgentsArgs
     }
 
 instance FromJSON ListAgentsArgs where
-    parseJSON = objectArgs \object_ -> ListAgentsArgs
+    parseJSON = objectArgsLenient \object_ -> ListAgentsArgs
         <$> optText object_ "path_prefix"
 
 listAgentsTool :: MultiAgentContext -> AppTool

--- a/packages/agent-core/test/Agent/Tools/MultiAgentsSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/MultiAgentsSpec.hs
@@ -185,6 +185,27 @@ spec = describe "Agent.Tools.MultiAgents" do
         atomically (writeTVar parentGate True)
         closeSubagentRegistry registry
 
+    it "accepts non-object input for optional-only collaboration tools" do
+        registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
+            (\_ _ _ _ -> pure (resultWithText "child"))
+            (\_ _ -> pure ())
+        Right _ <-
+            spawnSubagentAt registry Nothing taskPathRoot 0 "child"
+                (plainInterAgentContent "child") Nothing
+        let handlers =
+                appToolHandlers (multiAgentTools (rootContext registry Nothing))
+        listed <- dispatchToolCall defaultLoopDispatch handlers
+            (ToolCall "list-empty" "collaboration.list_agents" ""
+                FunctionCallKind False)
+        listed.output `shouldNotSatisfy`
+            Text.isInfixOf "Expected object input"
+        waited <- dispatchToolCall defaultLoopDispatch handlers
+            (ToolCall "wait-array" "collaboration.wait_agent" "[]"
+                FunctionCallKind False)
+        waited.output `shouldNotSatisfy`
+            Text.isInfixOf "Expected object input"
+        closeSubagentRegistry registry
+
     it "propagates restore failures from message tools" do
         registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
             (\_ _ _ _ -> pure (Left LoopNoResponseId))


### PR DESCRIPTION
## Summary
- parse `wait_agent` and `list_agents` arguments leniently because every field is optional
- treat empty or non-object model input as an empty argument object for these tools
- add a regression test covering empty-string and array arguments

## Root cause
The collaboration tools used the strict `objectArgs` decoder despite having only optional fields. When a provider emitted a valid non-object value (or an empty argument string preserved as text), decoding failed before the handler ran with `Expected object input`.

## Testing
- `nix develop -c cabal test --offline agent-core:test:agent-core-test --test-show-details=direct` (297 examples, 0 failures)
- `nix develop -c cabal test --offline agent-core:test:agent-core-test --test-options='--match Agent.Tools.MultiAgents' --test-show-details=direct` after rebasing (11 examples, 0 failures)