### PR TITLE
refactor(core): centralize Grok agent spec lookup

### DIFF
--- a/packages/agent-core/src/Agent/Tools/Grok/Task.hs
+++ b/packages/agent-core/src/Agent/Tools/Grok/Task.hs
@@ -403,26 +403,30 @@ recordAgentSpec specsRef agentId spec =
 recordAgentType :: GrokSubagentSpecs -> SubagentId -> Text -> IO ()
 recordAgentType specsRef agentId agentType = do
     specs <- readIORef specsRef
-    let model = maybe Nothing (\spec -> spec.modelOverride) (Map.lookup agentId specs)
-        effort =
-            maybe Nothing (\spec -> spec.reasoningEffortOverride)
-                (Map.lookup agentId specs)
+    let existing = Map.lookup agentId specs
+        model = existing >>= \spec -> spec.modelOverride
+        effort = existing >>= \spec -> spec.reasoningEffortOverride
     recordAgentSpec specsRef agentId (GrokSubagentSpec agentType model effort)
 
 lookupAgentType :: GrokSubagentSpecs -> SubagentId -> IO (Maybe Text)
-lookupAgentType specsRef agentId = do
-    specs <- readIORef specsRef
-    pure ((\spec -> spec.agentType) <$> Map.lookup agentId specs)
+lookupAgentType specsRef agentId =
+    fmap (\spec -> spec.agentType) <$> lookupAgentSpec specsRef agentId
 
 lookupAgentModel :: GrokSubagentSpecs -> SubagentId -> IO (Maybe Text)
-lookupAgentModel specsRef agentId = do
-    specs <- readIORef specsRef
-    pure (Map.lookup agentId specs >>= \spec -> spec.modelOverride)
+lookupAgentModel specsRef agentId =
+    (>>= \spec -> spec.modelOverride) <$> lookupAgentSpec specsRef agentId
 
 lookupAgentReasoningEffort :: GrokSubagentSpecs -> SubagentId -> IO (Maybe Text)
-lookupAgentReasoningEffort specsRef agentId = do
-    specs <- readIORef specsRef
-    pure (Map.lookup agentId specs >>= \spec -> spec.reasoningEffortOverride)
+lookupAgentReasoningEffort specsRef agentId =
+    (>>= \spec -> spec.reasoningEffortOverride)
+        <$> lookupAgentSpec specsRef agentId
+
+lookupAgentSpec
+    :: GrokSubagentSpecs
+    -> SubagentId
+    -> IO (Maybe GrokSubagentSpec)
+lookupAgentSpec specsRef agentId =
+    Map.lookup agentId <$> readIORef specsRef
 
 -- | Restrict the child tool surface by subagent type.
 filterGrokToolsForType :: Text -> [AppTool] -> [AppTool]

--- a/packages/agent-core/test/Agent/Tools/Grok/TaskSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/Grok/TaskSpec.hs
@@ -66,6 +66,21 @@ spec = describe "Agent.Tools.Grok.Task" do
         takeMVar observed `shouldReturn` (Just "explore", Just "grok-4.5-mini")
         closeSubagentRegistry registry
 
+    it "updates an agent type without discarding its overrides" do
+        specsRef <- newIORef Map.empty
+        let agentId = SubagentId "agent-1"
+        recordAgentSpec specsRef agentId GrokSubagentSpec
+            { agentType = "explore"
+            , modelOverride = Just "grok-4.5-mini"
+            , reasoningEffortOverride = Just "high"
+            }
+        recordAgentType specsRef agentId "plan"
+        lookupAgentType specsRef agentId `shouldReturn` Just "plan"
+        lookupAgentModel specsRef agentId
+            `shouldReturn` Just "grok-4.5-mini"
+        lookupAgentReasoningEffort specsRef agentId
+            `shouldReturn` Just "high"
+
     it "filters explore tools to the Grok Build read-only set" do
         let tools =
                 [ fake "read_file"


### PR DESCRIPTION
## Summary

- centralize Grok subagent spec lookup behind one helper
- avoid repeated map lookups when updating an agent type
- preserve model and reasoning-effort overrides when changing type

## Testing

- `nix develop -c cabal repl agent-core:test:agent-core-test`
  - ran `hspec TaskSpec.spec`
  - 7 examples, 0 failures
- `git diff --check`
