### PR TITLE
refactor(core): simplify OpenAI skill metadata parsing

### DIFF
--- a/packages/agent-core/src/Agent/Skills.hs
+++ b/packages/agent-core/src/Agent/Skills.hs
@@ -19,16 +19,19 @@ module Agent.Skills
 
 import Agent.FileRetry (retryOnFileBusy)
 import Agent.OsPath (directoryChain, toText, unsafeToFilePath)
+import Control.Applicative ((<|>))
 import Control.Exception.Safe (displayException, tryAny)
 import Control.Monad (filterM, forM)
 import Data.Aeson
     ( FromJSON(..)
+    , Object
     , Value(..)
     , withObject
     , (.:)
     , (.:?)
     , (.!=)
     )
+import Data.Aeson.Key (Key)
 import System.OsPath (OsPath, unsafeEncodeUtf)
 import Data.Aeson.Types (Parser)
 import qualified Data.ByteString as BS
@@ -176,28 +179,22 @@ instance FromJSON OpenAiMetadata where
     parseJSON = withObject "agents/openai.yaml" \o -> do
         interface <- o .:? "interface"
         policy <- o .:? "policy"
-        shortDescription <- case interface of
-            Just (Object fields) -> fields .:? "short_description"
-            _ -> pure Nothing
-        displayName <- case interface of
-            Just (Object fields) -> fields .:? "display_name"
-            _ -> pure Nothing
-        defaultPrompt <- case interface of
-            Just (Object fields) -> fields .:? "default_prompt"
-            _ -> pure Nothing
-        argumentHint <- case interface of
-            Just (Object fields) -> fields .:? "argument_hint"
-            _ -> pure Nothing
-        allowImplicit <- case policy of
-            Just (Object fields) -> fields .:? "allow_implicit_invocation"
-            _ -> pure Nothing
-        pure OpenAiMetadata
-            { openAiDisplayName = displayName
-            , openAiShortDescription = shortDescription
-            , openAiDefaultPrompt = defaultPrompt
-            , openAiArgumentHint = argumentHint
-            , openAiAllowImplicit = allowImplicit
-            }
+        let interfaceFields = interface >>= valueObject
+            policyFields = policy >>= valueObject
+        OpenAiMetadata
+            <$> optionalField interfaceFields "display_name"
+            <*> optionalField interfaceFields "short_description"
+            <*> optionalField interfaceFields "default_prompt"
+            <*> optionalField interfaceFields "argument_hint"
+            <*> optionalField policyFields "allow_implicit_invocation"
+
+valueObject :: Value -> Maybe Object
+valueObject (Object fields) = Just fields
+valueObject _ = Nothing
+
+optionalField :: FromJSON a => Maybe Object -> Key -> Parser (Maybe a)
+optionalField fields key =
+    maybe (pure Nothing) (\object -> object .:? key) fields
 
 defaultSkillCatalogMaxChars :: Int
 defaultSkillCatalogMaxChars = 8000
@@ -605,9 +602,3 @@ neutralizeSkillTags :: Text -> Text
 neutralizeSkillTags =
     Text.replace "<SKILL_INSTRUCTIONS" "&lt;SKILL_INSTRUCTIONS"
         . Text.replace "</SKILL_INSTRUCTIONS" "&lt;/SKILL_INSTRUCTIONS"
-
-infixr 3 <|>
-(<|>) :: Maybe a -> Maybe a -> Maybe a
-(<|>) left right = case left of
-    Just value -> Just value
-    Nothing -> right

--- a/packages/agent-core/test/Agent/SkillsSpec.hs
+++ b/packages/agent-core/test/Agent/SkillsSpec.hs
@@ -40,14 +40,18 @@ spec = describe "Agent.Skills" do
                 skillDir = repo </> ".agents" </> "skills" </> "deploy"
             writeSkill skillDir "deploy" "Deploy the service"
                 [ "when-to-use: Use for production deploys"
-                , "argument-hint: <environment>"
                 , "user-invocable: false"
                 , "allowed-tools: shell_command, apply_patch"
                 ]
             createDirectoryIfMissing True (skillDir </> "agents")
             writeFile (skillDir </> "agents" </> "openai.yaml") $
                 unlines
-                    [ "policy:"
+                    [ "interface:"
+                    , "  display_name: Production deploy"
+                    , "  short_description: Deploy safely"
+                    , "  default_prompt: Deploy the service"
+                    , "  argument_hint: <environment>"
+                    , "policy:"
                     , "  allow_implicit_invocation: false"
                     ]
             catalog <- discoverSkills (options home repo repo)
@@ -55,6 +59,9 @@ spec = describe "Agent.Skills" do
                 [skill] -> do
                     skill.skillWhenToUse `shouldBe` Just "Use for production deploys"
                     skill.skillArgumentHint `shouldBe` Just "<environment>"
+                    skill.skillDisplayName `shouldBe` Just "Production deploy"
+                    skill.skillShortDescription `shouldBe` Just "Deploy safely"
+                    skill.skillDefaultPrompt `shouldBe` Just "Deploy the service"
                     skill.skillUserInvocable `shouldBe` False
                     skill.skillModelInvocable `shouldBe` False
                     skill.skillAllowedTools


### PR DESCRIPTION
## Summary

- normalize optional OpenAI skill metadata sections once
- parse nested interface and policy fields through one helper
- use the standard `Control.Applicative.<|>` implementation
- expand coverage for all supported interface metadata fields

## Testing

- `nix develop -c cabal repl agent-core:test:agent-core-test`
  - ran `hspec SkillsSpec.spec`
  - 9 examples, 0 failures
- `git diff --check`
