### PR TITLE
refactor(cli): use findIndex for model selection

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Models.hs
+++ b/packages/agent-cli/src/Agent/CLI/Models.hs
@@ -15,7 +15,7 @@ module Agent.CLI.Models
 
 import Agent.CLI.Prompt (defaultModelFor)
 import Agent.Provider (Provider(..), providerSlug)
-import Data.List (find, nub)
+import Data.List (findIndex, nub)
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -108,8 +108,7 @@ initialPickerState provider current =
         allOpts = ensureCurrentInList provider current
             (concatMap modelsForProvider providerOrder)
         idx = fromMaybe 0 $
-            fmap fst $
-                find (\(_, opt) -> isCurrent provider current opt) (zip [0 ..] allOpts)
+            findIndex (isCurrent provider current) allOpts
     in PickerState
         { pickerProvider = provider
         , pickerCurrent = current


### PR DESCRIPTION
## Summary

- replace indexed zip/search plumbing with `Data.List.findIndex`
- preserve the current-model fallback behavior

## Testing

- `nix develop -c cabal repl agent-cli:test:agent-cli-test`
  - ran `hspec ModelsSpec.spec`
  - 16 examples, 0 failures
- tmux TTY smoke test opened the model picker with `gpt-5.6-terra` selected
- `git diff --check`
