### PR TITLE
refactor(core): share instruction content filtering

### DIFF
--- a/packages/agent-core/src/Agent/ProjectInstructions.hs
+++ b/packages/agent-core/src/Agent/ProjectInstructions.hs
@@ -171,22 +171,25 @@ formatCodexAgentsMd cwd loaded =
                 , "\n</INSTRUCTIONS>"
                 ]
   where
-    bodies = case (loaded.loadedGlobal >>= stripFile, mapMaybe stripFile loaded.loadedProject) of
+    bodies = case
+        ( loaded.loadedGlobal >>= nonEmptyInstructionContent
+        , mapMaybe nonEmptyInstructionContent loaded.loadedProject
+        ) of
         (Nothing, []) -> Nothing
         (Nothing, project) -> Just (Text.intercalate "\n\n" project)
         (Just global, []) -> Just global
         (Just global, project) ->
             Just $ global <> "\n\n--- project-doc ---\n\n" <> Text.intercalate "\n\n" project
 
-stripFile :: InstructionFile -> Maybe Text
-stripFile file =
+nonEmptyInstructionContent :: InstructionFile -> Maybe Text
+nonEmptyInstructionContent file =
     let text = file.instructionContent
     in if Text.null (Text.strip text) then Nothing else Just text
 
 -- | Grok-style system-reminder block with per-file provenance.
 formatGrokAgentsMd :: LoadedAgentsMd -> Maybe Text
 formatGrokAgentsMd loaded =
-    case filter nonempty (loadedInstructionFiles loaded) of
+    case mapMaybe withContent (loadedInstructionFiles loaded) of
         [] -> Nothing
         kept ->
             Just $ Text.concat $
@@ -201,14 +204,14 @@ formatGrokAgentsMd loaded =
                 , "\n</system-reminder>"
                 ]
   where
-    nonempty :: InstructionFile -> Bool
-    nonempty file = not (Text.null (Text.strip file.instructionContent))
-    renderFile :: InstructionFile -> [Text]
-    renderFile file =
+    withContent file =
+        (\content -> (file, content)) <$> nonEmptyInstructionContent file
+    renderFile :: (InstructionFile, Text) -> [Text]
+    renderFile (file, content) =
         [ "\n## From: "
         , neutralizeReminderTags (toText file.instructionPath)
         , "\n"
-        , neutralizeReminderTags file.instructionContent
+        , neutralizeReminderTags content
         , "\n"
         ]
 

--- a/packages/agent-core/test/Agent/ProjectInstructionsSpec.hs
+++ b/packages/agent-core/test/Agent/ProjectInstructionsSpec.hs
@@ -145,6 +145,22 @@ spec = describe "Agent.ProjectInstructions" do
                 Nothing ->
                     expectationFailure "expected rendered Grok instructions"
 
+        it "shares whitespace-only filtering with Codex formatting" do
+            let loaded = LoadedAgentsMd
+                    { loadedGlobal = Just
+                        (InstructionFile
+                            (fromFilePath "/home/.codex/AGENTS.md")
+                            " \n\t")
+                    , loadedProject =
+                        [ InstructionFile
+                            (fromFilePath "/repo/AGENTS.md")
+                            "\n  "
+                        ]
+                    }
+            formatCodexAgentsMd (fromFilePath "/repo") loaded
+                `shouldBe` Nothing
+            formatGrokAgentsMd loaded `shouldBe` Nothing
+
         it "neutralizes forged reminder tags in file content" do
             let loaded = LoadedAgentsMd
                     { loadedGlobal = Nothing


### PR DESCRIPTION
## Summary

- centralize whitespace-only instruction content filtering
- reuse the same rule for Codex and Grok formatting
- preserve original unstripped content and Grok file provenance
- add direct coverage for manually constructed whitespace-only files

## Testing

- `nix develop -c cabal repl agent-core:test:agent-core-test`
  - ran `hspec ProjectInstructionsSpec.spec`
  - 16 examples, 0 failures
- `git diff --check`
