### PR TITLE
feat(agent): make model dialects first-class

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,11 @@ have to be.
   typed workspace. The harness distinguishes pure expressions from effectful
   actions, preserves bindings across calls, and recovers or restarts GHCi when
   interruption makes its state uncertain.
-- **One runtime without one generic tool dialect:** the harness owns the agent
-  loop and connects to providers directly, but OpenAI still receives
-  Codex-style tools while xAI receives the Grok Build tool surface.
+- **First-class model dialects:** providers own authentication, billing, and
+  transport, while dialects own the model-facing prompt, tool surface, schema
+  conventions, project-instruction formatting, and subagent protocol. This
+  keeps Codex-style and Grok Build behavior intact even when a transport such
+  as OpenRouter serves models from several families.
 - **Cross-provider state and billing policy:** provider transitions preserve
   the pending turn and durable session state. Credential failover understands
   account cooldowns and prevents automatic fallback from silently converting
@@ -212,6 +214,11 @@ The provider-neutral loop sees typed turns, tool calls, tool results, usage,
 and streamed events. Provider packages own wire formats, authentication,
 transport, and provider-specific continuation. Presentation consumes the same
 events through renderer-independent state.
+
+Model targets resolve independently to a provider transport and a model-facing
+dialect. OpenAI models use the Codex dialect, xAI models use the Grok Build
+dialect, and OpenRouter selects Codex, Grok Build, or a portable Responses
+dialect from the model family.
 
 ## Development
 

--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -129,7 +129,10 @@ import Agent.CLI.ModelPicker (pickModel)
 import Agent.CLI.Models
     ( ModelOption(..)
     , PickerState(..)
-    , initialPickerState
+    , initialPickerStateResolved
+    , modelTargetRequiresRebuild
+    , resolveModelOptionDialect
+    , resolvePersistedDialect
     )
 import Agent.CLI.Notification
     ( AttentionRequest(InputRequested)
@@ -151,7 +154,8 @@ import Agent.CLI.Progress
     , wrapOscForTmux
     )
 import Agent.CLI.Project
-    ( ProjectSettings(..)
+    ( ProjectModel(..)
+    , ProjectSettings(..)
     , loadProjectSettings
     , projectModelFor
     , projectModelProvider
@@ -296,11 +300,20 @@ import Agent.CLI.Worktree
 import Agent.Cancel (requestCancel, resetCancel, waitCancel)
 import Agent.Loop
 import Agent.Error (ApiError(..))
+import Agent.Dialect
+    ( Dialect
+    , DialectId
+    , dialectForId
+    , dialectId
+    , dialectIdForModel
+    , dialectSlug
+    , providerSupportsDialect
+    )
 import Agent.ProjectInstructions
     ( DiscoverOptions(..)
     , defaultDiscoverOptions
     , discoverProjectInstructions
-    , formatAgentsMdForProvider
+    , formatAgentsMdForDialect
     , globalAgentsHomeDir
     , loadedInstructionFiles
     )
@@ -386,7 +399,7 @@ import Agent.Tools.Types
     , defaultToolEnv
     )
 import Agent.OpenRouter.LoopBackend (openRouterBackend)
-import qualified Agent.OpenRouter.Options as OpenRouter
+import qualified Agent.OpenRouter as OpenRouter
 import Agent.OsPath (fromText, toText, unsafeToFilePath)
 import Agent.XAI.LoopBackend (xaiBackend)
 import qualified Agent.XAI.Options as XAI
@@ -1311,6 +1324,7 @@ runAgentInitializedWithLock
                                             }
                                     pure (Right label)
 
+    openRouterOptions <- OpenRouter.clientOptionsFromEnv
     markStartupStage startup "Loading tools…"
     let basePlanHooks =
             cliPlanHooks interrupt escPaused (resolveColor stderr)
@@ -1327,6 +1341,64 @@ runAgentInitializedWithLock
                                 (defaultModelFor provider)
                                 (projectModelFor provider projectSettings))
             options.optModel
+        transportModel = case provider of
+            OpenRouterProvider -> OpenRouter.mapModel openRouterOptions
+            _ -> id
+        inferredTarget = ModelOption
+            { modelProvider = provider
+            , modelId = model
+            , modelTransportId = transportModel model
+            , modelDialect =
+                dialectIdForModel provider (transportModel model)
+            , modelLabel = Nothing
+            }
+        persistedTarget = case fst <$> resumed of
+            Just meta ->
+                Just
+                    ( meta.metaDialect
+                    , meta.metaTransportModel
+                    )
+            Nothing -> do
+                remembered <- projectSettings.settingsLastModel
+                if remembered.projectModelProvider == provider
+                    then Just
+                        ( remembered.projectModelDialect
+                        , remembered.projectModelTransportName
+                        )
+                    else Nothing
+        resolvedPersistedTarget =
+            (\(storedDialect, storedTransportModel) ->
+                resolvePersistedDialect
+                    storedDialect
+                    storedTransportModel
+                    inferredTarget)
+                <$> persistedTarget
+        mappedTargetChanged =
+            maybe False snd resolvedPersistedTarget
+        dialectId = case transitionTarget of
+            Just target -> target.modelDialect
+            Nothing -> case options.optModel of
+                Just _ -> inferredTarget.modelDialect
+                Nothing
+                    | mappedTargetChanged -> inferredTarget.modelDialect
+                    | otherwise ->
+                        maybe
+                            inferredTarget.modelDialect
+                            fst
+                            resolvedPersistedTarget
+        dialect = dialectForId dialectId
+        resumeTargetChanged = case fst <$> resumed of
+            Just meta ->
+                provider /= meta.metaProvider
+                    || model /= meta.metaModel
+                    || mappedTargetChanged
+                    || dialectId /= meta.metaDialect
+            Nothing -> False
+        refreshDialectContext = case fst <$> resumed of
+            Just meta -> dialectId /= meta.metaDialect
+            Nothing -> False
+        legacySubagentTarget =
+            sessionLegacySubagentTarget . fst <$> resumed
         effort = fromMaybe
             (maybe (defaultEffortFor provider) (.metaEffort) (fst <$> resumed))
             options.optEffort
@@ -1335,7 +1407,12 @@ runAgentInitializedWithLock
     -- Provider transitions commit their selection separately: manual switches
     -- immediately, automatic fallbacks only after the replacement succeeds.
     when (isNothing transition) $
-        saveProjectModel projectRoot provider model
+        saveProjectModel
+            projectRoot
+            provider
+            model
+            inferredTarget.modelTransportId
+            dialectId
     sessionProcessManager <- newSessionProcessManager root
     activeSessionLock <- newIORef resumeLock
     persistSlotRef <- newIORef PersistenceDisabled
@@ -1360,7 +1437,16 @@ runAgentInitializedWithLock
             , multiTaskPath = taskPathRoot
             , multiRootTurnId = readIORef rootTurnRef
             , multiResumeFromDisk = Just
-                (restoreAgentFromDisk subagentStoreRoot registry subagentSessions agentTypesRef)
+                (restoreAgentFromDisk
+                    provider
+                    transportModel
+                    inferredTarget.modelTransportId
+                    dialectId
+                    legacySubagentTarget
+                    subagentStoreRoot
+                    registry
+                    subagentSessions
+                    agentTypesRef)
             , multiCreateWorktree = Just \source ->
                 createWorktree source (worktreeRoot home) >>= \case
                     Left err -> pure (Left err)
@@ -1373,11 +1459,18 @@ runAgentInitializedWithLock
                         }
             , multiPrepareSpawn = Just
                 (prepareCollaborationSpawn
+                    provider
+                    transportModel
+                    inferredTarget.modelTransportId
+                    dialectId
+                    legacySubagentTarget
                     subagentSessions subagentStoreRoot agentTypesRef
                     subagentForkSource)
             , multiSendToRoot = Just sendToRoot
             }
-    coding <- codingToolsForWithTypes provider toolEnv (Just planHooks) multiCtx agentTypesRef
+    coding <-
+        codingToolsForWithTypes
+            dialect toolEnv (Just planHooks) multiCtx agentTypesRef
     case multiCtx of
         Just ctx ->
             setSubagentOnComplete ctx.multiRegistry \agentId status -> do
@@ -1388,7 +1481,7 @@ runAgentInitializedWithLock
                     Just session ->
                         persistSubagentSnapshotWithStatus
                             subagentStoreRoot ctx.multiRegistry agentTypesRef
-                            agentId status session.subSessionTranscript
+                            agentId status session
                     Nothing -> pure ()
         Nothing -> pure ()
     let claimCurrentSession handle = do
@@ -1408,6 +1501,8 @@ runAgentInitializedWithLock
             { toolsRoot = root
             , toolsProvider = provider
             , toolsModel = model
+            , toolsTransportModel = inferredTarget.modelTransportId
+            , toolsDialect = dialectId
             , toolsCwd = cwd
             , toolsEffort = effort
             , toolsCurrentSessionId =
@@ -1437,14 +1532,17 @@ runAgentInitializedWithLock
             coding.codingClose
     flip finally closeAll do
         today <- utctDay <$> getCurrentTime
-        let instructions = systemPrompt provider cwd today (isOneShot options)
+        let instructions = systemPrompt dialect cwd today (isOneShot options)
             params = requestParams model instructions
-                (schemasFromAppTools provider tools) effort
+                (schemasFromAppTools dialect tools) effort
             initialItems = maybe [] (foldSessionItems . snd) resumed
             initialTurns = maybe [] snd resumed
             initialPrevious = case transition of
                 Just _ -> Nothing
-                Nothing -> resumed >>= \(meta, _) -> meta.metaLastResponseId
+                Nothing
+                    | resumeTargetChanged -> Nothing
+                    | otherwise ->
+                        resumed >>= \(meta, _) -> meta.metaLastResponseId
         paramsRef <- newIORef params
         let subagentRuntime = SubagentRuntime
                 { subagentOptions = options
@@ -1455,6 +1553,8 @@ runAgentInitializedWithLock
                 , subagentSessions = subagentSessions
                 , subagentStoreRoot = subagentStoreRoot
                 , subagentTypes = agentTypesRef
+                , subagentLegacyTarget = legacySubagentTarget
+                , subagentMapModel = transportModel
                 }
         transcriptRef <- newIORef initialItems
         contextTokensRef <- newIORef Nothing
@@ -1468,7 +1568,13 @@ runAgentInitializedWithLock
         markStartupStage startup "Loading instructions…"
         startupContext <-
             loadAgentsContext
-                fullscreen options provider home cwd initialItems initialPrevious
+                fullscreen
+                options
+                dialect
+                home
+                cwd
+                (if refreshDialectContext then [] else initialItems)
+                (if refreshDialectContext then Nothing else initialPrevious)
         -- Fullscreen sessions load skills after Brick has taken over the
         -- terminal, so filesystem discovery cannot delay the first frame.
         -- Minimal and one-shot sessions still initialize them synchronously
@@ -1478,7 +1584,9 @@ runAgentInitializedWithLock
 
         persist <-
             preparePersistence
-                fullscreen options root provider model cwd effort prompt resumed
+                fullscreen options root provider model
+                    inferredTarget.modelTransportId dialectId
+                    (isNothing transition) cwd effort prompt resumed
         writeIORef persistSlotRef persist
         usageRef <- newIORef $ case resumed of
             Just (meta, turns) -> sessionUsageFromTurns meta turns
@@ -1774,7 +1882,7 @@ runAgentInitializedWithLock
                                         projectRoot transition persist noticingBackend
                                 withAsync switchLoop \switchWorker -> do
                                     link switchWorker
-                                    runSession options provider policy tools toolEnv planMode startup prompt pendingTurn transitionDraft unavailableProviders startupUnavailable paramsRef transcriptRef initialTurns
+                                    runSession options provider dialect policy tools toolEnv planMode startup prompt pendingTurn transitionDraft unavailableProviders startupUnavailable paramsRef transcriptRef initialTurns
                                         previousRef persist projectRoot home cwd (Just tokenProvider) loaded.loadedOpenAiPool startupContext skillsRef skillInvocationsRef escPaused interrupt
                                         multiCtx rootTurnRef subagentSessions pendingNotices subagentStoreRoot usageRef activeAccountRef activeAccountIdRef activeSelectionRef resolveActiveAccountLabel selectAccount claimCurrentSession compactRunner activeBackend btwBackend)
                             >>= \case
@@ -1810,7 +1918,9 @@ runAgentInitializedWithLock
                                 setSubagentRunner ctx.multiRegistry $
                                     runHttpSubagent
                                         subagentRuntime
+                                        dialect
                                         XAIProvider
+                                        ctx.multiSendToRoot
                                         (\childParamsRef childTranscript ->
                                             xaiBackend xaiOptions tokenProvider
                                                 (readIORef childParamsRef) childTranscript)
@@ -1835,17 +1945,18 @@ runAgentInitializedWithLock
                         activeBackend <-
                             prepareTransitionBackend
                                 projectRoot transition persist backend
-                        runSession options provider policy tools toolEnv planMode startup prompt pendingTurn transitionDraft unavailableProviders startupUnavailable paramsRef transcriptRef initialTurns
+                        runSession options provider dialect policy tools toolEnv planMode startup prompt pendingTurn transitionDraft unavailableProviders startupUnavailable paramsRef transcriptRef initialTurns
                             previousRef persist projectRoot home cwd (Just tokenProvider) loaded.loadedOpenAiPool startupContext skillsRef skillInvocationsRef escPaused interrupt
                             multiCtx rootTurnRef subagentSessions pendingNotices subagentStoreRoot usageRef activeAccountRef activeAccountIdRef activeSelectionRef resolveActiveAccountLabel (Just selectHttpAccount) claimCurrentSession compactRunner activeBackend btwBackend
                     OpenRouterProvider -> do
-                        openRouterOptions <- OpenRouter.clientOptionsFromEnv
                         case multiCtx of
                             Just ctx ->
                                 setSubagentRunner ctx.multiRegistry $
                                     runHttpSubagent
                                         subagentRuntime
+                                        dialect
                                         OpenRouterProvider
+                                        ctx.multiSendToRoot
                                         (\childParamsRef childTranscript ->
                                             openRouterBackend openRouterOptions
                                                 tokenProvider
@@ -1871,7 +1982,7 @@ runAgentInitializedWithLock
                         activeBackend <-
                             prepareTransitionBackend
                                 projectRoot transition persist backend
-                        runSession options provider policy tools toolEnv planMode startup prompt pendingTurn transitionDraft unavailableProviders startupUnavailable paramsRef transcriptRef initialTurns
+                        runSession options provider dialect policy tools toolEnv planMode startup prompt pendingTurn transitionDraft unavailableProviders startupUnavailable paramsRef transcriptRef initialTurns
                             previousRef persist projectRoot home cwd (Just tokenProvider) loaded.loadedOpenAiPool startupContext skillsRef skillInvocationsRef escPaused interrupt
                             multiCtx rootTurnRef subagentSessions pendingNotices subagentStoreRoot usageRef activeAccountRef activeAccountIdRef activeSelectionRef resolveActiveAccountLabel (Just selectHttpAccount) claimCurrentSession compactRunner activeBackend btwBackend
           where
@@ -1903,23 +2014,67 @@ preparePersistence
     -> OsPath
     -> Provider
     -> Text
+    -> Text
+    -> DialectId
+    -> Bool
     -> OsPath
     -> Text
     -> Maybe Text
     -> Maybe (SessionMeta, [SessionTurn])
     -> IO Persistence
-preparePersistence fullscreen options root provider model cwd effort prompt resumed =
+preparePersistence
+        fullscreen options root provider model transportModel dialectId
+        retargetResumed cwd effort prompt resumed =
     case resumed of
         Just (meta, _) -> do
+            now <- getCurrentTime
+            let targetChanged =
+                    retargetResumed
+                        && ( provider /= meta.metaProvider
+                            || model /= meta.metaModel
+                            || maybe
+                                False
+                                (/= transportModel)
+                                meta.metaTransportModel
+                            || dialectId /= meta.metaDialect
+                           )
+                metadataChanged =
+                    retargetResumed
+                        && ( targetChanged
+                            || meta.metaTransportModel /= Just transportModel
+                            || isNothing meta.metaLegacySubagentTarget
+                           )
+                activeMeta
+                    | metadataChanged =
+                        meta
+                            { metaProvider = provider
+                            , metaModel = model
+                            , metaTransportModel = Just transportModel
+                            , metaDialect = dialectId
+                            , metaLegacySubagentTarget =
+                                Just (sessionLegacySubagentTarget meta)
+                            , metaLastResponseId =
+                                if targetChanged
+                                    then Nothing
+                                    else meta.metaLastResponseId
+                            , metaUpdatedAt = now
+                            }
+                    | otherwise = meta
             let handle = SessionHandle
-                    { sessionDir = root </> fromText meta.metaId
+                    { sessionDir = root </> fromText activeMeta.metaId
                     , sessionMetaPath =
-                        root </> fromText meta.metaId </> unsafeEncodeUtf "meta.json"
+                        root
+                            </> fromText activeMeta.metaId
+                            </> unsafeEncodeUtf "meta.json"
                     , sessionTranscriptPath =
-                        root </> fromText meta.metaId </> unsafeEncodeUtf "transcript.jsonl"
-                    , sessionMeta = meta
+                        root
+                            </> fromText activeMeta.metaId
+                            </> unsafeEncodeUtf "transcript.jsonl"
+                    , sessionMeta = activeMeta
                     }
-            let message = "session: " <> meta.metaId <> " (resumed)"
+            when metadataChanged $
+                writeSessionMeta handle.sessionMetaPath activeMeta
+            let message = "session: " <> activeMeta.metaId <> " (resumed)"
             case fullscreen of
                 Nothing -> do
                     color <- resolveColor stderr
@@ -1936,6 +2091,8 @@ preparePersistence fullscreen options root provider model cwd effort prompt resu
                     { createRoot = root
                     , createProvider = provider
                     , createModel = model
+                    , createTransportModel = transportModel
+                    , createDialect = dialectId
                     , createCwd = cwd
                     , createEffort = effort
                     , createTitleHint = sessionTitleFromPrompt <$> prompt
@@ -2006,6 +2163,7 @@ isJustCwd options = case options.optCwd of
 runSession
     :: CliOptions
     -> Provider
+    -> Dialect
     -> ApprovalPolicy
     -> [AppTool]
     -> ToolEnv
@@ -2047,7 +2205,7 @@ runSession
     -> Backend
     -> BtwBackendFactory
     -> IO RunResult
-runSession options provider policy tools toolEnv planMode startup prompt pendingTurn initialDraft unavailableProviders startupUnavailable paramsRef transcriptRef initialTurns previous persist projectRoot home cwd tokenProvider openAiPool startupContext skillsRef skillInvocationsRef escPaused interrupt multiCtx rootTurnRef subagentSessions pendingNotices storeRoot usageRef accountRef accountIdRef selectionRef accountLabel selectAccount onPersisted compactRunner backend btwBackend = do
+runSession options provider dialect policy tools toolEnv planMode startup prompt pendingTurn initialDraft unavailableProviders startupUnavailable paramsRef transcriptRef initialTurns previous persist projectRoot home cwd tokenProvider openAiPool startupContext skillsRef skillInvocationsRef escPaused interrupt multiCtx rootTurnRef subagentSessions pendingNotices storeRoot usageRef accountRef accountIdRef selectionRef accountLabel selectAccount onPersisted compactRunner backend btwBackend = do
   initialPrevious <- readIORef previous
   ioLock <- newMVar ()
   let fullscreen = startup.startupFullscreen
@@ -2212,7 +2370,7 @@ runSession options provider policy tools toolEnv planMode startup prompt pending
                 Just ctx -> resetSubagentRegistry ctx.multiRegistry
                 Nothing -> pure ()
             freshAgents <-
-                loadAgentsContext fullscreen options provider home cwd [] Nothing
+                loadAgentsContext fullscreen options dialect home cwd [] Nothing
             freshSkills <- loadSkillsCatalogQuiet options home projectRoot cwd
             omitted <- installSkillCatalogWithOmissions
                 reservedSlashNames True freshAgents
@@ -2379,6 +2537,7 @@ runSession options provider policy tools toolEnv planMode startup prompt pending
             , sessionCompact = compactRunner
             , sessionRender = render
             , sessionProvider = provider
+            , sessionDialect = dialect
             , sessionUnavailableProviders = unavailableProvidersRef
             , sessionStartupUnavailable = startupUnavailableRef
             , sessionPrevious = previous
@@ -2807,6 +2966,7 @@ replWithDraft env@SessionEnv
     , sessionCompact = compactRunner
     , sessionRender = render
     , sessionProvider = provider
+    , sessionDialect = dialect
     , sessionStartupUnavailable = startupUnavailableRef
     , sessionPrevious = previous
     , sessionPrinted = printed
@@ -3311,12 +3471,35 @@ replWithDraft env@SessionEnv
                         chooseModel "" continue
                     ReplSetModel name -> do
                         color <- resolveColor stdout
-                        message <- applyModelChange
-                            projectRoot provider name paramsRef render previous persist
-                        displayInfo message $
-                            Text.putStrLn
-                                (roleMuted color (glyphOk <> message))
-                        continue
+                        choice <-
+                            resolveModelOptionDialect ModelOption
+                                { modelProvider = provider
+                                , modelId = name
+                                , modelTransportId = name
+                                , modelDialect =
+                                    dialectIdForModel provider name
+                                , modelLabel = Nothing
+                                }
+                        if modelTargetRequiresRebuild
+                                provider (dialectId dialect) choice
+                            then
+                                requestModelTargetSwitch
+                                    fullscreen choice "" persist >>= \case
+                                    Left err -> do
+                                        displayError err $
+                                            Text.hPutStrLn stderr
+                                                (roleError color err)
+                                        continue
+                                    Right result -> pure result
+                            else do
+                                message <- applyModelChange
+                                    projectRoot provider name
+                                    choice.modelTransportId choice.modelDialect
+                                    paramsRef render previous persist
+                                displayInfo message $
+                                    Text.putStrLn
+                                        (roleMuted color (glyphOk <> message))
+                                continue
                     ReplToggleAlwaysApprove -> do
                         message <- toggleAlwaysApprove policyRef projectRoot
                         color <- resolveColor stderr
@@ -3498,6 +3681,12 @@ replWithDraft env@SessionEnv
                                                     takeDirectory handle.sessionDir
                                                 , createProvider = provider
                                                 , createModel = model
+                                                , createTransportModel =
+                                                    fromMaybe
+                                                        model
+                                                        handle.sessionMeta.metaTransportModel
+                                                , createDialect =
+                                                    (dialectId dialect)
                                                 , createCwd =
                                                     handle.sessionMeta.metaCwd
                                                 , createEffort = effort
@@ -3739,11 +3928,15 @@ replWithDraft env@SessionEnv
         color <- resolveColor stderr
         params <- readIORef paramsRef
         let current = currentModel params
-        modelChoice fullscreen color provider current >>= \case
+        modelChoice
+            fullscreen color provider current (dialectId dialect) >>= \case
             Nothing -> next
-            Just choice
-                | choice.modelProvider == provider
-                , choice.modelId == current -> do
+            Just rawChoice -> do
+                choice <- resolveModelOptionDialect rawChoice
+                if choice.modelProvider == provider
+                    && choice.modelId == current
+                    && choice.modelDialect == dialectId dialect
+                  then do
                     let message =
                             "model: "
                                 <> providerSlug provider
@@ -3754,16 +3947,21 @@ replWithDraft env@SessionEnv
                             (roleMuted color
                                 (glyphSession <> message))
                     next
-                | choice.modelProvider == provider -> do
+                  else if not
+                        (modelTargetRequiresRebuild
+                            provider (dialectId dialect) choice)
+                  then do
                     message <- applyModelChange
-                        projectRoot provider choice.modelId paramsRef render previous persist
+                        projectRoot provider choice.modelId
+                        choice.modelTransportId choice.modelDialect
+                        paramsRef render previous persist
                     displayInfo message $
                         Text.putStrLn
                             (roleMuted color
                                 (glyphOk <> message))
                     next
-                | otherwise ->
-                    requestModelProviderSwitch
+                  else
+                    requestModelTargetSwitch
                         fullscreen choice keptDraft persist >>= \case
                         Left err -> do
                             displayError err $
@@ -3908,6 +4106,7 @@ replWithDraft env@SessionEnv
                                     fullscreen
                                     provider
                                     (currentModel params)
+                                    (dialectId dialect)
                                     selectedProvider
                                     selectedSelectionId
                                     selectedAccountId
@@ -3957,16 +4156,20 @@ modelChoice
     -> Bool
     -> Provider
     -> Text
+    -> DialectId
     -> IO (Maybe ModelOption)
-modelChoice fullscreen color provider current = case fullscreen of
-    Nothing -> pickModel color provider current
+modelChoice fullscreen color provider current currentDialect = case fullscreen of
+    Nothing -> pickModel color provider current currentDialect
     Just runtime -> do
-        let picker = initialPickerState provider current
-            options = picker.pickerAll
+        picker <-
+            initialPickerStateResolved provider current currentDialect
+        let options = picker.pickerAll
             rows =
                 [ ( providerSlug option.modelProvider
                         <> " · "
                         <> option.modelId
+                        <> " · "
+                        <> dialectSlug option.modelDialect
                   , fromMaybe "" option.modelLabel
                   )
                 | option <- options
@@ -4285,15 +4488,19 @@ applyModelChange
     :: OsPath
     -> Provider
     -> Text
+    -> Text
+    -> DialectId
     -> IORef ResponseCreateParams
     -> RenderConfig
     -> IORef (Maybe Text)
     -> Persistence
     -> IO Text
-applyModelChange projectRoot provider name paramsRef render previous persist = do
+applyModelChange
+        projectRoot provider name transportModel dialectId
+        paramsRef render previous persist = do
     modifyIORef' paramsRef (setModel name)
     writeIORef render.renderModelRef name
-    saveProjectModel projectRoot provider name
+    saveProjectModel projectRoot provider name transportModel dialectId
     clearedChain <- case provider of
         OpenAIProvider ->
             atomicModifyIORef' previous \prev ->
@@ -4306,9 +4513,17 @@ applyModelChange projectRoot provider name paramsRef render previous persist = d
             case slot of
                 PersistencePending pending ->
                     writeIORef slotRef
-                        (PersistencePending pending { createModel = name })
+                        (PersistencePending pending
+                            { createModel = name
+                            , createTransportModel = transportModel
+                            , createDialect = dialectId
+                            })
                 PersistenceActive handle -> do
-                    let meta = handle.sessionMeta { metaModel = name }
+                    let meta = handle.sessionMeta
+                            { metaModel = name
+                            , metaTransportModel = Just transportModel
+                            , metaDialect = dialectId
+                            }
                     writeSessionMeta handle.sessionMetaPath meta
                     writeIORef slotRef
                         (PersistenceActive handle { sessionMeta = meta })
@@ -4319,13 +4534,13 @@ applyModelChange projectRoot provider name paramsRef render previous persist = d
                 then " (conversation continued locally)"
                 else ""
 
-requestModelProviderSwitch
+requestModelTargetSwitch
     :: Maybe FullscreenRuntime
     -> ModelOption
     -> Text
     -> Persistence
     -> IO (Either Text RunResult)
-requestModelProviderSwitch fullscreen choice draft persist =
+requestModelTargetSwitch fullscreen choice draft persist =
     prepareProviderTransition
         ManualTransition [] Nothing draft choice persist >>= \case
             Left err -> pure (Left err)
@@ -4349,6 +4564,7 @@ requestAccountProviderSwitch
     :: Maybe FullscreenRuntime
     -> Provider
     -> Text
+    -> DialectId
     -> Provider
     -> Text
     -> Text
@@ -4359,16 +4575,25 @@ requestAccountProviderSwitch
     fullscreen
     currentProvider
     currentModelId
+    currentDialect
     selectedProvider
     selectionId
     accountId
     draft
     persist = do
-        let choice =
+        currentTransportModel <-
+            persistenceTransportModel currentModelId persist
+        let rawChoice =
                 accountSwitchTarget
                     currentProvider
                     currentModelId
+                    currentTransportModel
+                    currentDialect
                     selectedProvider
+        choice <-
+            if currentProvider == selectedProvider
+                then pure rawChoice
+                else resolveModelOptionDialect rawChoice
         validateSelectedAccountTarget
             selectedProvider
             selectionId
@@ -4412,16 +4637,49 @@ requestAccountProviderSwitch
                                     ("switching to " <> modelMessage)
                     pure (Right (RunSwitchProvider transition))
 
-accountSwitchTarget :: Provider -> Text -> Provider -> ModelOption
-accountSwitchTarget currentProvider currentModelId selectedProvider =
-    ModelOption
-        { modelProvider = selectedProvider
-        , modelId =
+accountSwitchTarget
+    :: Provider
+    -> Text
+    -> Text
+    -> DialectId
+    -> Provider
+    -> ModelOption
+accountSwitchTarget
+        currentProvider currentModelId currentTransportModel currentDialect
+        selectedProvider =
+    let targetModel =
             if currentProvider == selectedProvider
                 then currentModelId
                 else defaultModelFor selectedProvider
+        targetDialect =
+            if currentProvider == selectedProvider
+                then currentDialect
+                else dialectIdForModel selectedProvider targetModel
+        targetTransportModel =
+            if currentProvider == selectedProvider
+                then currentTransportModel
+                else targetModel
+    in
+    ModelOption
+        { modelProvider = selectedProvider
+        , modelId = targetModel
+        , modelTransportId = targetTransportModel
+        , modelDialect = targetDialect
         , modelLabel = Nothing
         }
+
+persistenceTransportModel :: Text -> Persistence -> IO Text
+persistenceTransportModel fallback = \case
+    PersistenceDisabled -> pure fallback
+    PersistenceEnabled slotRef ->
+        readIORef slotRef >>= \case
+            PersistencePending pending ->
+                pure pending.createTransportModel
+            PersistenceActive handle ->
+                pure $
+                    fromMaybe
+                        fallback
+                        handle.sessionMeta.metaTransportModel
 
 validateSelectedAccountTarget
     :: Provider
@@ -4531,7 +4789,8 @@ chooseAutomaticProviderTransition
 
     tryCandidates unavailable = \case
         [] -> pure Nothing
-        choice : rest ->
+        rawChoice : rest -> do
+            choice <- resolveModelOptionDialect rawChoice
             validateAutomaticProviderTarget sourceBilling choice >>= \case
                 Left err -> do
                     let message =
@@ -4591,7 +4850,8 @@ chooseStartupProviderTransition
 
     tryCandidates unavailable = \case
         [] -> pure Nothing
-        choice : rest ->
+        rawChoice : rest -> do
+            choice <- resolveModelOptionDialect rawChoice
             validateAutomaticProviderTarget sourceBilling choice >>= \case
                 Left err -> do
                     let message =
@@ -4633,7 +4893,8 @@ prepareProviderTransition
     -> ModelOption
     -> Persistence
     -> IO (Either Text ProviderTransition)
-prepareProviderTransition cause unavailable pending draft choice persist =
+prepareProviderTransition cause unavailable pending draft rawChoice persist = do
+    choice <- resolveModelOptionDialect rawChoice
     validateProviderTarget choice >>= \case
         Left err -> pure (Left err)
         Right () -> do
@@ -4673,7 +4934,17 @@ validateAutomaticProviderTarget sourceBilling choice =
 
 loadValidatedProviderTarget :: ModelOption -> IO (Either Text LoadedAuth)
 loadValidatedProviderTarget choice =
-    loadAuth (Just choice.modelProvider) >>= \case
+    if not
+        (providerSupportsDialect
+            choice.modelProvider
+            choice.modelDialect)
+    then
+        pure $ Left $
+            "dialect "
+                <> dialectSlug choice.modelDialect
+                <> " is incompatible with provider "
+                <> providerSlug choice.modelProvider
+    else loadAuth (Just choice.modelProvider) >>= \case
         Left err -> pure $ Left $
             "cannot switch to "
                 <> providerSlug choice.modelProvider
@@ -4716,6 +4987,8 @@ commitProviderTransition projectRoot (Just transition) persist = do
         projectRoot
         transition.transitionTarget.modelProvider
         transition.transitionTarget.modelId
+        transition.transitionTarget.modelTransportId
+        transition.transitionTarget.modelDialect
     case persist of
         PersistenceDisabled -> pure ()
         PersistenceEnabled slotRef -> do
@@ -4725,12 +4998,22 @@ commitProviderTransition projectRoot (Just transition) persist = do
                     writeIORef slotRef $ PersistencePending pending
                         { createProvider = transition.transitionTarget.modelProvider
                         , createModel = transition.transitionTarget.modelId
+                        , createTransportModel =
+                            transition.transitionTarget.modelTransportId
+                        , createDialect = transition.transitionTarget.modelDialect
                         }
                 PersistenceActive handle -> do
                     now <- getCurrentTime
-                    let meta = handle.sessionMeta
+                    let previousMeta = handle.sessionMeta
+                        meta = previousMeta
                             { metaProvider = transition.transitionTarget.modelProvider
                             , metaModel = transition.transitionTarget.modelId
+                            , metaTransportModel =
+                                Just transition.transitionTarget.modelTransportId
+                            , metaDialect = transition.transitionTarget.modelDialect
+                            , metaLegacySubagentTarget =
+                                Just
+                                    (sessionLegacySubagentTarget previousMeta)
                             , metaLastResponseId = Nothing
                             , metaUpdatedAt = now
                             }
@@ -4903,24 +5186,24 @@ enterPlanFromSlash env@SessionEnv
 loadAgentsContext
     :: Maybe FullscreenRuntime
     -> CliOptions
-    -> Provider
+    -> Dialect
     -> OsPath
     -> OsPath
     -> [ResponseItem]
     -> Maybe Text
     -> IO (IORef (Maybe Text))
-loadAgentsContext fullscreen options provider home cwd initialItems initialPrevious
+loadAgentsContext fullscreen options dialect home cwd initialItems initialPrevious
     | not options.optAgentsMd = newIORef Nothing
     | not (null initialItems) || isJust initialPrevious = newIORef Nothing
     | otherwise = do
         let discoverOptions = DiscoverOptions
                 { discoverMaxBytes = defaultDiscoverOptions.discoverMaxBytes
-                , discoverGlobalDir = Just (globalAgentsHomeDir provider home)
+                , discoverGlobalDir = Just (globalAgentsHomeDir dialect home)
                 , discoverRootMarkers = defaultDiscoverOptions.discoverRootMarkers
                 }
         loaded <- discoverProjectInstructions discoverOptions cwd
         let files = loadedInstructionFiles loaded
-        case formatAgentsMdForProvider provider cwd loaded of
+        case formatAgentsMdForDialect dialect cwd loaded of
             Nothing -> newIORef Nothing
             Just text -> do
                 let message =

--- a/packages/agent-cli/src/Agent/CLI/AgentSessions.hs
+++ b/packages/agent-cli/src/Agent/CLI/AgentSessions.hs
@@ -27,7 +27,16 @@ import Agent.CLI.SessionLock
     ( sessionLockIsActive
     , sessionLockPath
     )
+import Agent.CLI.Models
+    ( ModelOption(..)
+    , resolveModelOptionDialect
+    )
 import Agent.OsPath (fromText, unsafeToFilePath)
+import Agent.Dialect
+    ( DialectId
+    , dialectIdForModel
+    , dialectSlug
+    )
 import Agent.Provider (Provider, providerSlug)
 import Agent.ToolArgs (objectArgs, optInt, optText, reqText)
 import Agent.ToolDSL (PropertySchema(..), PropertyType(..))
@@ -81,6 +90,8 @@ data AgentSessionToolsEnv = AgentSessionToolsEnv
     { toolsRoot :: !OsPath
     , toolsProvider :: !Provider
     , toolsModel :: !Text
+    , toolsTransportModel :: !Text
+    , toolsDialect :: !DialectId
     , toolsCwd :: !OsPath
     , toolsEffort :: !Text
     , toolsCurrentSessionId :: !(IO (Maybe Text))
@@ -349,13 +360,34 @@ runCreateAgentSession env args
     | maybe False ((> 100) . Text.length . Text.strip) args.title =
         pure (Left "create_agent_session title must be at most 100 characters")
     | otherwise = do
+        let model = fromMaybe env.toolsModel args.model
+        target <- case args.model of
+            Nothing ->
+                pure ModelOption
+                    { modelProvider = env.toolsProvider
+                    , modelId = model
+                    , modelTransportId = env.toolsTransportModel
+                    , modelDialect = env.toolsDialect
+                    , modelLabel = Nothing
+                    }
+            Just _ ->
+                resolveModelOptionDialect ModelOption
+                    { modelProvider = env.toolsProvider
+                    , modelId = model
+                    , modelTransportId = model
+                    , modelDialect =
+                        dialectIdForModel env.toolsProvider model
+                    , modelLabel = Nothing
+                    }
         let title = case Text.strip <$> args.title of
                 Just value | not (Text.null value) -> value
                 _ -> sessionTitleFromPrompt args.message
             spec = SessionCreate
                 { createRoot = env.toolsRoot
                 , createProvider = env.toolsProvider
-                , createModel = fromMaybe env.toolsModel args.model
+                , createModel = model
+                , createTransportModel = target.modelTransportId
+                , createDialect = target.modelDialect
                 , createCwd = env.toolsCwd
                 , createEffort = fromMaybe env.toolsEffort args.reasoningEffort
                 , createTitleHint = Just title
@@ -483,6 +515,7 @@ sessionJson meta status = object
     , "title" .= meta.metaTitle
     , "provider" .= providerSlug meta.metaProvider
     , "model" .= meta.metaModel
+    , "dialect" .= dialectSlug meta.metaDialect
     , "reasoning_effort" .= meta.metaEffort
     , "cwd" .= unsafeToFilePath meta.metaCwd
     , "created_at" .= meta.metaCreatedAt

--- a/packages/agent-cli/src/Agent/CLI/ModelPicker.hs
+++ b/packages/agent-cli/src/Agent/CLI/ModelPicker.hs
@@ -9,6 +9,7 @@ module Agent.CLI.ModelPicker
 import Agent.CLI.Models
 import Agent.CLI.Picker (PickerKey(..), runOverlay)
 import qualified Agent.CLI.Picker as Picker
+import Agent.Dialect (DialectId, dialectSlug)
 import Agent.CLI.Style
     ( glyphOk
     , roleMuted
@@ -39,25 +40,38 @@ toEvent = \case
 -- | Open the picker when stdin is a TTY; otherwise print the catalog.
 -- Returns the provider/model choice on confirm and @Nothing@ on cancel, EOF,
 -- or non-TTY input.
-pickModel :: Bool -> Provider -> Text -> IO (Maybe ModelOption)
-pickModel color provider current = do
+pickModel :: Bool -> Provider -> Text -> DialectId -> IO (Maybe ModelOption)
+pickModel color provider current currentDialect = do
     isTty <- hIsTerminalDevice stdin
+    state0 <- initialPickerStateResolved provider current currentDialect
     if not isTty
         then do
-            Text.hPutStrLn stderr (formatCatalogListing color provider current)
+            Text.hPutStrLn stderr
+                (formatCatalogListingState
+                    color provider current currentDialect state0)
             hFlush stderr
             pure Nothing
         else do
-            let state0 = initialPickerState provider current
             result <- runOverlay (renderPickerFrame color) step state0
             pure (join result)
   where
     step key state = applyPickerEvent (toEvent key) state
 
-formatCatalogListing :: Bool -> Provider -> Text -> Text
-formatCatalogListing color provider current =
-    let state = initialPickerState provider current
-        header =
+formatCatalogListing :: Bool -> Provider -> Text -> DialectId -> IO Text
+formatCatalogListing color provider current currentDialect = do
+    state <- initialPickerStateResolved provider current currentDialect
+    pure (formatCatalogListingState
+        color provider current currentDialect state)
+
+formatCatalogListingState
+    :: Bool
+    -> Provider
+    -> Text
+    -> DialectId
+    -> PickerState
+    -> Text
+formatCatalogListingState color provider current currentDialect state =
+    let header =
             roleMuted color
                 (glyphSessionLike
                     <> "model: "
@@ -69,7 +83,7 @@ formatCatalogListing color provider current =
             map
                 (\opt ->
                     let mark
-                            | isCurrent provider current opt =
+                            | isCurrent provider current currentDialect opt =
                                 roleSuccess color
                                     (glyphOk <> formatOptionName opt)
                             | otherwise =
@@ -105,7 +119,10 @@ renderPickerFrame color state =
             opts ->
                 zipWith
                     (\i opt -> renderRow color (i == idx)
-                        state.pickerProvider state.pickerCurrent opt)
+                        state.pickerProvider
+                        state.pickerCurrent
+                        state.pickerCurrentDialect
+                        opt)
                     [0 ..]
                     opts
         footer =
@@ -113,14 +130,22 @@ renderPickerFrame color state =
                 "↑↓/jk or scroll · click/enter · esc/q · type to filter"
     in Text.intercalate "\n" (header : filterLine : body <> [footer])
 
-renderRow :: Bool -> Bool -> Provider -> Text -> ModelOption -> Text
-renderRow color selected currentProvider current opt =
+renderRow
+    :: Bool
+    -> Bool
+    -> Provider
+    -> Text
+    -> DialectId
+    -> ModelOption
+    -> Text
+renderRow color selected currentProvider current currentDialect opt =
     let cursor = if selected then roleWarn color "› " else "  "
         name
             | selected = roleSuccess color (formatOptionName opt)
             | otherwise = roleMuted color (formatOptionName opt)
         currentMark
-            | isCurrent currentProvider current opt = roleSuccess color " ✓"
+            | isCurrent currentProvider current currentDialect opt =
+                roleSuccess color " ✓"
             | otherwise = ""
         label = case opt.modelLabel of
             Nothing -> ""
@@ -132,8 +157,15 @@ glyphSessionLike :: Text
 glyphSessionLike = "⧉ "
 
 formatOptionName :: ModelOption -> Text
-formatOptionName opt = providerSlug opt.modelProvider <> " · " <> opt.modelId
+formatOptionName opt =
+    providerSlug opt.modelProvider
+        <> " · "
+        <> opt.modelId
+        <> " · "
+        <> dialectSlug opt.modelDialect
 
-isCurrent :: Provider -> Text -> ModelOption -> Bool
-isCurrent provider current opt =
-    opt.modelProvider == provider && opt.modelId == current
+isCurrent :: Provider -> Text -> DialectId -> ModelOption -> Bool
+isCurrent provider current dialect opt =
+    opt.modelProvider == provider
+        && opt.modelId == current
+        && opt.modelDialect == dialect

--- a/packages/agent-cli/src/Agent/CLI/Models.hs
+++ b/packages/agent-cli/src/Agent/CLI/Models.hs
@@ -8,12 +8,22 @@ module Agent.CLI.Models
     , catalogModelIds
     , ensureCurrentInList
     , initialPickerState
+    , initialPickerStateResolved
     , visibleOptions
     , selectedOption
     , applyPickerEvent
+    , modelTargetRequiresRebuild
+    , resolvePersistedDialect
+    , resolveModelOptionDialect
     ) where
 
 import Agent.CLI.Prompt (defaultModelFor)
+import Agent.Dialect
+    ( DialectId(..)
+    , dialectIdForModel
+    )
+import qualified Agent.OpenRouter.Options as OpenRouter
+import qualified Agent.OpenRouter.Request as OpenRouter
 import Agent.Provider (Provider(..), providerSlug)
 import Data.List (findIndex, nub)
 import Data.Maybe (fromMaybe)
@@ -23,6 +33,8 @@ import qualified Data.Text as Text
 data ModelOption = ModelOption
     { modelProvider :: !Provider
     , modelId :: !Text
+    , modelTransportId :: !Text
+    , modelDialect :: !DialectId
     , modelLabel :: !(Maybe Text)
     }
     deriving (Eq, Show)
@@ -31,6 +43,7 @@ data ModelOption = ModelOption
 data PickerState = PickerState
     { pickerProvider :: !Provider
     , pickerCurrent :: !Text
+    , pickerCurrentDialect :: !DialectId
     , pickerAll :: ![ModelOption]
     , pickerFilter :: !Text
     , pickerIndex :: !Int
@@ -50,30 +63,33 @@ modelsForProvider :: Provider -> [ModelOption]
 modelsForProvider provider =
     let opts = case provider of
             XAIProvider ->
-                [ opt "grok-4.6" (Just "default")
-                , opt "grok-4.5" Nothing
-                , opt "grok-4.5-mini" (Just "faster")
-                , opt "grok-3" Nothing
+                [ opt "grok-4.6" GrokBuildDialect (Just "default")
+                , opt "grok-4.5" GrokBuildDialect Nothing
+                , opt "grok-4.5-mini" GrokBuildDialect (Just "faster")
+                , opt "grok-3" GrokBuildDialect Nothing
                 ]
             OpenAIProvider ->
-                [ opt "gpt-5.6-luna" (Just "default · fast")
-                , opt "gpt-5.6-terra" (Just "balanced")
-                , opt "gpt-5.6-sol" (Just "frontier")
+                [ opt "gpt-5.6-luna" CodexDialect (Just "default · fast")
+                , opt "gpt-5.6-terra" CodexDialect (Just "balanced")
+                , opt "gpt-5.6-sol" CodexDialect (Just "frontier")
                 ]
             OpenRouterProvider ->
-                [ opt "openai/gpt-5.1" (Just "default")
-                , opt "stealth/ox-alpha" (Just "free · coding · 1M context")
-                , opt "anthropic/claude-sonnet-4" Nothing
-                , opt "x-ai/grok-4" Nothing
-                , opt "google/gemini-2.5-pro" Nothing
+                [ opt "openai/gpt-5.1" CodexDialect (Just "default")
+                , opt "stealth/ox-alpha" GenericResponsesDialect
+                    (Just "free · coding · 1M context")
+                , opt "anthropic/claude-sonnet-4" GenericResponsesDialect Nothing
+                , opt "x-ai/grok-4" GrokBuildDialect Nothing
+                , opt "google/gemini-2.5-pro" GenericResponsesDialect Nothing
                 ]
         -- Keep the provider default first even if the table drifts.
         def = defaultModelFor provider
-    in ensureCurrentInList provider def opts
+    in ensureCurrentInList provider def (dialectIdForModel provider def) opts
   where
-    opt mid label = ModelOption
+    opt mid dialect label = ModelOption
         { modelProvider = provider
         , modelId = mid
+        , modelTransportId = mid
+        , modelDialect = dialect
         , modelLabel = label
         }
 
@@ -90,28 +106,67 @@ catalogModelIds =
     nub (map (\opt -> opt.modelId) modelCatalog)
 
 -- | Prepend @current@ when it is missing so the active model stays visible.
-ensureCurrentInList :: Provider -> Text -> [ModelOption] -> [ModelOption]
-ensureCurrentInList provider current options
+ensureCurrentInList
+    :: Provider
+    -> Text
+    -> DialectId
+    -> [ModelOption]
+    -> [ModelOption]
+ensureCurrentInList provider current currentDialect options
     | Text.null current || current == "(unset)" = options
-    | any (isCurrent provider current) options = options
+    | any (isCurrent provider current currentDialect) options = options
     | otherwise =
         ModelOption
             { modelProvider = provider
             , modelId = current
+            , modelTransportId = current
+            , modelDialect = currentDialect
             , modelLabel = Just "current"
             }
             : options
 
-initialPickerState :: Provider -> Text -> PickerState
-initialPickerState provider current =
-    let providerOrder = provider : filter (/= provider) allProviders
-        allOpts = ensureCurrentInList provider current
-            (concatMap modelsForProvider providerOrder)
+initialPickerState :: Provider -> Text -> DialectId -> PickerState
+initialPickerState provider current currentDialect =
+    pickerStateFromOptions
+        provider
+        current
+        currentDialect
+        (concatMap modelsForProvider providerOrder)
+  where
+    providerOrder = provider : filter (/= provider) allProviders
+
+-- | Resolve transport rewrites before displaying model dialects. This keeps
+-- OpenRouter picker labels and current-target identity aligned with the model
+-- that will actually be sent.
+initialPickerStateResolved
+    :: Provider
+    -> Text
+    -> DialectId
+    -> IO PickerState
+initialPickerStateResolved provider current currentDialect = do
+    resolved <- traverse resolveModelOptionDialect
+        (concatMap modelsForProvider providerOrder)
+    pure (pickerStateFromOptions provider current currentDialect resolved)
+  where
+    providerOrder = provider : filter (/= provider) allProviders
+
+pickerStateFromOptions
+    :: Provider
+    -> Text
+    -> DialectId
+    -> [ModelOption]
+    -> PickerState
+pickerStateFromOptions provider current currentDialect options =
+    let allOpts =
+            ensureCurrentInList provider current currentDialect options
         idx = fromMaybe 0 $
-            findIndex (isCurrent provider current) allOpts
+            findIndex
+                (isCurrent provider current currentDialect)
+                allOpts
     in PickerState
         { pickerProvider = provider
         , pickerCurrent = current
+        , pickerCurrentDialect = currentDialect
         , pickerAll = allOpts
         , pickerFilter = ""
         , pickerIndex = idx
@@ -159,6 +214,50 @@ applyPickerEvent event state = case event of
                 }
         | otherwise -> Right state
 
+-- | Changing providers or model-facing dialects requires rebuilding tools,
+-- prompts, and the transport backend. A model change within the current
+-- provider and dialect can update request parameters in place.
+modelTargetRequiresRebuild
+    :: Provider
+    -> DialectId
+    -> ModelOption
+    -> Bool
+modelTargetRequiresRebuild provider dialect option =
+    option.modelProvider /= provider
+        || option.modelDialect /= dialect
+
+-- | Keep an explicitly persisted dialect while the effective transport model
+-- is unchanged. When a recorded alias/default now resolves elsewhere, use the
+-- newly inferred dialect and report that the target changed. Legacy records
+-- without an effective model retain their old dialect for compatibility.
+resolvePersistedDialect
+    :: DialectId
+    -> Maybe Text
+    -> ModelOption
+    -> (DialectId, Bool)
+resolvePersistedDialect storedDialect storedTransportModel inferred =
+    case storedTransportModel of
+        Just previous
+            | previous /= inferred.modelTransportId ->
+                (inferred.modelDialect, True)
+        _ -> (storedDialect, False)
+
+-- | Resolve the dialect from the model that the provider transport will
+-- actually receive. OpenRouter may rewrite friendly aliases and exact model
+-- overrides before sending a request.
+resolveModelOptionDialect :: ModelOption -> IO ModelOption
+resolveModelOptionDialect option = do
+    transportedModel <- case option.modelProvider of
+        OpenRouterProvider -> do
+            options <- OpenRouter.clientOptionsFromEnv
+            pure (OpenRouter.mapModel options option.modelId)
+        _ -> pure option.modelId
+    pure option
+        { modelTransportId = transportedModel
+        , modelDialect =
+            dialectIdForModel option.modelProvider transportedModel
+        }
+
 move :: Int -> PickerState -> PickerState
 move delta state =
     let n = length (visibleOptions state)
@@ -188,6 +287,8 @@ isFilterChar c =
         || (c >= 'A' && c <= 'Z')
         || (c >= '0' && c <= '9')
 
-isCurrent :: Provider -> Text -> ModelOption -> Bool
-isCurrent provider current option =
-    option.modelProvider == provider && option.modelId == current
+isCurrent :: Provider -> Text -> DialectId -> ModelOption -> Bool
+isCurrent provider current dialect option =
+    option.modelProvider == provider
+        && option.modelId == current
+        && option.modelDialect == dialect

--- a/packages/agent-cli/src/Agent/CLI/Project.hs
+++ b/packages/agent-cli/src/Agent/CLI/Project.hs
@@ -4,6 +4,7 @@ module Agent.CLI.Project
     , ProjectSettings(..)
     , defaultProjectSettings
     , loadProjectSettings
+    , projectDialectFor
     , projectModelFor
     , projectModelProvider
     , projectSettingsPath
@@ -13,9 +14,17 @@ module Agent.CLI.Project
     ) where
 
 import Agent.FileRetry (retryOnFileBusy, writeLazyFileAtomically)
+import Agent.Dialect
+    ( DialectId
+    , dialectSlug
+    , legacyDialectIdForProvider
+    , parseDialect
+    , providerSupportsDialect
+    )
 import Agent.OsPath (unsafeToFilePath)
 import Agent.Provider (Provider, parseProvider, providerSlug)
 import Control.Exception.Safe (tryIO)
+import Control.Monad (unless)
 import Data.Aeson
     ( FromJSON(..)
     , ToJSON(..)
@@ -56,6 +65,8 @@ projectSettingsPath projectRoot =
 data ProjectModel = ProjectModel
     { projectModelProvider :: !Provider
     , projectModelName :: !Text
+    , projectModelTransportName :: !(Maybe Text)
+    , projectModelDialect :: !DialectId
     } deriving (Eq, Show)
 
 data ProjectSettings = ProjectSettings
@@ -75,6 +86,8 @@ instance ToJSON ProjectModel where
     toJSON model = object
         [ "provider" .= providerSlug model.projectModelProvider
         , "model" .= model.projectModelName
+        , "transportModel" .= model.projectModelTransportName
+        , "dialect" .= dialectSlug model.projectModelDialect
         ]
 
 instance FromJSON ProjectModel where
@@ -84,11 +97,27 @@ instance FromJSON ProjectModel where
             Just parsed -> pure parsed
             Nothing -> fail ("unknown provider: " <> Text.unpack providerText)
         model <- o .: "model"
+        transportModel <- o .:? "transportModel"
+        dialectText <- o .:? "dialect"
+        dialect <- case dialectText of
+            Nothing -> pure (legacyDialectIdForProvider provider)
+            Just text -> case parseDialect text of
+                Just parsed -> pure parsed
+                Nothing -> fail ("unknown dialect: " <> Text.unpack text)
+        unless (providerSupportsDialect provider dialect) $
+            fail
+                ( "dialect "
+                    <> Text.unpack (dialectSlug dialect)
+                    <> " is incompatible with provider "
+                    <> Text.unpack (providerSlug provider)
+                )
         if Text.null (Text.strip model)
             then fail "model must not be empty"
             else pure ProjectModel
                 { projectModelProvider = provider
                 , projectModelName = model
+                , projectModelTransportName = transportModel
+                , projectModelDialect = dialect
                 }
 
 instance ToJSON ProjectSettings where
@@ -146,13 +175,15 @@ saveProjectAutoApprove projectRoot autoApprove =
         settings { settingsAutoApprove = autoApprove }
 
 -- | Remember the most recently selected provider/model pair for this project.
-saveProjectModel :: OsPath -> Provider -> Text -> IO ()
-saveProjectModel projectRoot provider model =
+saveProjectModel :: OsPath -> Provider -> Text -> Text -> DialectId -> IO ()
+saveProjectModel projectRoot provider model transportModel dialect =
     updateProjectSettings projectRoot \settings ->
         settings
             { settingsLastModel = Just ProjectModel
                 { projectModelProvider = provider
                 , projectModelName = model
+                , projectModelTransportName = Just transportModel
+                , projectModelDialect = dialect
                 }
             }
 
@@ -166,6 +197,13 @@ projectModelFor provider settings = do
     remembered <- settings.settingsLastModel
     if remembered.projectModelProvider == provider
         then Just remembered.projectModelName
+        else Nothing
+
+projectDialectFor :: Provider -> ProjectSettings -> Maybe DialectId
+projectDialectFor provider settings = do
+    remembered <- settings.settingsLastModel
+    if remembered.projectModelProvider == provider
+        then Just remembered.projectModelDialect
         else Nothing
 
 updateProjectSettings

--- a/packages/agent-cli/src/Agent/CLI/Prompt.hs
+++ b/packages/agent-cli/src/Agent/CLI/Prompt.hs
@@ -1,13 +1,23 @@
--- | Provider-specific system prompt closed over by the transport backend.
+-- | Dialect-specific system prompt closed over by the transport backend.
 module Agent.CLI.Prompt
     ( defaultModelFor
     , systemPrompt
+    , systemPromptForTools
     ) where
 
 import Agent.CLI.Timestamp (timeContextGuidance)
+import Agent.Dialect
+    ( Dialect
+    , PromptStyle(..)
+    , dialectPromptStyle
+    )
 import Agent.OsPath (toText)
 import Agent.Provider (Provider(..))
-import Agent.Tools.Grok.Prompt (codingGrokPromptTools, grokSystemPrompt)
+import Agent.Tools.Grok.Prompt
+    ( codingGrokPromptTools
+    , grokSystemPrompt
+    , grokSystemPromptForTools
+    )
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Time.Calendar (Day)
@@ -21,14 +31,45 @@ defaultModelFor = \case
     OpenRouterProvider -> "openai/gpt-5.1"
 
 -- | @isNonInteractive@ is True for one-shot @-p@ (no human in the loop).
-systemPrompt :: Provider -> OsPath -> Day -> Bool -> Text
-systemPrompt provider cwd today isNonInteractive =
+systemPrompt :: Dialect -> OsPath -> Day -> Bool -> Text
+systemPrompt dialect cwd today isNonInteractive =
     base <> "\n\n" <> ghciGuidance <> "\n" <> timeContextGuidance
   where
-    base = case provider of
-        XAIProvider -> grokSystemPrompt codingGrokPromptTools cwd today isNonInteractive
-        OpenRouterProvider -> grokSystemPrompt codingGrokPromptTools cwd today isNonInteractive
-        OpenAIProvider -> codexSystemPrompt cwd today
+    base = case dialectPromptStyle dialect of
+        GrokBuildPromptStyle ->
+            grokSystemPrompt codingGrokPromptTools cwd today isNonInteractive
+        CodexPromptStyle -> codexSystemPrompt cwd today
+        GenericResponsesPromptStyle ->
+            genericSystemPrompt cwd today isNonInteractive
+
+-- | Render a child prompt against the final filtered application-tool set.
+-- @web_search@ is server-side and remains available independently.
+systemPromptForTools :: Dialect -> [Text] -> OsPath -> Day -> Bool -> Text
+systemPromptForTools dialect toolNames cwd today isNonInteractive =
+    Text.intercalate "\n\n" $
+        filter (not . Text.null)
+            [ base
+            , ghciGuidanceForTools available
+            , timeContextGuidance
+            ]
+  where
+    available = "web_search" : toolNames
+    base = case dialectPromptStyle dialect of
+        GrokBuildPromptStyle ->
+            grokSystemPromptForTools
+                codingGrokPromptTools
+                available
+                cwd
+                today
+                isNonInteractive
+        CodexPromptStyle ->
+            codexSystemPromptForTools available cwd today
+        GenericResponsesPromptStyle ->
+            genericSystemPromptForTools
+                available
+                cwd
+                today
+                isNonInteractive
 
 -- | Prefer GHCI as the general-purpose scripting environment.
 ghciGuidance :: Text
@@ -42,6 +83,31 @@ ghciGuidance =
         , "Prefer shell tools (run_terminal_cmd or shell_command) for OS commands, package installs, servers, and anything that is not Haskell evaluation."
         , "Drive GHCi with complete expressions; do not expect interactive human input."
         ]
+
+ghciGuidanceForTools :: [Text] -> Text
+ghciGuidanceForTools available
+    | "run_ghci" `notElem` available = ""
+    | otherwise =
+        Text.unlines $
+            [ "Prefer ghci for scripting."
+            , "When you need a short program, calculation, or one-off script, use the run_ghci tool rather than Python, Node, bash, or compiling a binary."
+            , "run_ghci keeps a persistent GHCi session: bindings and loaded modules stick across calls."
+            , "The session enables GHC2021 plus BlockArguments, OverloadedStrings, OverloadedRecordDot, DuplicateRecordFields, NoFieldSelectors, LambdaCase, and RecordWildCards."
+            , "Pure expressions do not need user approval; IO and side-effecting GHCi commands do."
+            ]
+                <> shellGuidance
+                <> [ "Drive GHCi with complete expressions; do not expect interactive human input."
+                   ]
+  where
+    shellNames =
+        filter (`elem` available) ["run_terminal_cmd", "shell_command"]
+    shellGuidance = case shellNames of
+        [] -> []
+        names ->
+            [ "Prefer shell tools ("
+                <> Text.intercalate " or " names
+                <> ") for OS commands, package installs, servers, and anything that is not Haskell evaluation."
+            ]
 
 codexSystemPrompt :: OsPath -> Day -> Text
 codexSystemPrompt cwd today =
@@ -72,3 +138,100 @@ codexSystemPrompt cwd today =
         , "mode ends. update_plan is not Plan Mode."
         , "Be concise. Do not mention tools this session does not register."
         ]
+
+codexSystemPromptForTools :: [Text] -> OsPath -> Day -> Text
+codexSystemPromptForTools available cwd today =
+    Text.unlines $
+        [ "You are a coding agent working in " <> toText cwd <> "."
+        , "Today's date is " <> formattedToday <> "."
+        , ""
+        , "Use the registered tools:"
+        ]
+            <> toolLine "shell_command"
+                "- Inspect the repo and run system commands with shell_command. Always set workdir."
+            <> toolLine "apply_patch"
+                "- Edit files with apply_patch. Never call applypatch or apply-patch."
+            <> toolLine "update_plan"
+                "- Track multi-step work with update_plan."
+            <> toolLine "run_ghci"
+                "- Evaluate Haskell with run_ghci."
+            <> toolLine "web_search"
+                "- Look up current public information with web_search."
+            <> planLines
+            <> ["Be concise. Do not mention tools this session does not register."]
+  where
+    formattedToday =
+        Text.pack (formatTime defaultTimeLocale "%Y-%m-%d" today)
+    toolLine name line
+        | name `elem` available = [line]
+        | otherwise = []
+    planLines =
+        toolLine "enter_plan_mode"
+            "- Enter Plan Mode with enter_plan_mode for genuinely ambiguous architectural work."
+            <> toolLine "ask_user_question"
+                "- Ask planning questions with ask_user_question."
+
+genericSystemPrompt :: OsPath -> Day -> Bool -> Text
+genericSystemPrompt cwd today isNonInteractive =
+    Text.unlines
+        [ identity
+        , "Today's date is " <> formattedToday <> "."
+        , ""
+        , "Use the registered tools to inspect and modify the workspace."
+        , "- Prefer read_file, grep, and list_dir for codebase exploration."
+        , "- Use search_replace for focused file edits."
+        , "- Use run_terminal_cmd for commands that require a shell."
+        , "- Use run_ghci for Haskell evaluation and short typed scripts."
+        , "- Use web_search for current public information."
+        , "- Use enter_plan_mode for genuinely ambiguous architectural work."
+        , "- Do not mention tools this session does not register."
+        , ""
+        , "Work directly in " <> toText cwd <> "."
+        , "Keep changes scoped to the request and report unverified work plainly."
+        ]
+  where
+    formattedToday =
+        Text.pack (formatTime defaultTimeLocale "%Y-%m-%d" today)
+    identity
+        | isNonInteractive =
+            "You are an autonomous coding agent. There is no human operator in this session."
+        | otherwise =
+            "You are an interactive coding agent helping the user complete software engineering work."
+
+genericSystemPromptForTools :: [Text] -> OsPath -> Day -> Bool -> Text
+genericSystemPromptForTools available cwd today isNonInteractive =
+    Text.unlines $
+        [ identity
+        , "Today's date is " <> formattedToday <> "."
+        , ""
+        , "Use the registered tools to work in the workspace."
+        ]
+            <> toolLine "read_file" "- Use read_file to inspect files."
+            <> toolLine "grep" "- Use grep to search file contents."
+            <> toolLine "list_dir" "- Use list_dir to list directories."
+            <> toolLine "search_replace"
+                "- Use search_replace for focused file edits."
+            <> toolLine "run_terminal_cmd"
+                "- Use run_terminal_cmd for commands that require a shell."
+            <> toolLine "run_ghci"
+                "- Use run_ghci for Haskell evaluation and short typed scripts."
+            <> toolLine "web_search"
+                "- Use web_search for current public information."
+            <> toolLine "enter_plan_mode"
+                "- Use enter_plan_mode for genuinely ambiguous architectural work."
+            <> [ "- Do not mention tools this session does not register."
+               , ""
+               , "Work directly in " <> toText cwd <> "."
+               , "Keep changes scoped to the request and report unverified work plainly."
+               ]
+  where
+    formattedToday =
+        Text.pack (formatTime defaultTimeLocale "%Y-%m-%d" today)
+    identity
+        | isNonInteractive =
+            "You are an autonomous coding agent. There is no human operator in this session."
+        | otherwise =
+            "You are an interactive coding agent helping the user complete software engineering work."
+    toolLine name line
+        | name `elem` available = [line]
+        | otherwise = []

--- a/packages/agent-cli/src/Agent/CLI/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session.hs
@@ -2,6 +2,7 @@
 module Agent.CLI.Session
     ( SessionHandle(..)
     , SessionMeta(..)
+    , LegacySubagentTarget(..)
     , SessionTurn(..)
     , SessionCreate(..)
     , Persistence(..)
@@ -24,6 +25,7 @@ module Agent.CLI.Session
     , setManualSessionTitle
     , resetSessionTitleToAuto
     , sessionConversationText
+    , sessionLegacySubagentTarget
     , sessionTitleTurnCountFromSlot
     , writeSessionMeta
     , ensureSession
@@ -41,6 +43,13 @@ import Agent.CLI.SessionLock
     , releaseSessionLock
     )
 import Agent.Loop (TokenUsage(..))
+import Agent.Dialect
+    ( DialectId
+    , dialectSlug
+    , legacyDialectIdForProvider
+    , parseDialect
+    , providerSupportsDialect
+    )
 import Agent.OsPath (toText, unsafeToFilePath)
 import Agent.Responses.Types (ResponseItem)
 import Agent.Provider (Provider(..), parseProvider, providerSlug)
@@ -59,7 +68,7 @@ import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy as LBS
 import Data.IORef
 import Data.List (sortOn)
-import Data.Maybe (catMaybes)
+import Data.Maybe (catMaybes, fromMaybe)
 import Data.Ord (Down(..))
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -95,6 +104,9 @@ data SessionMeta = SessionMeta
     , metaUpdatedAt :: !UTCTime
     , metaProvider :: !Provider
     , metaModel :: !Text
+    , metaTransportModel :: !(Maybe Text)
+    , metaDialect :: !DialectId
+    , metaLegacySubagentTarget :: !(Maybe LegacySubagentTarget)
     , metaCwd :: !OsPath
     , metaEffort :: !Text
     , metaTitle :: !Text
@@ -107,6 +119,50 @@ data SessionMeta = SessionMeta
     , metaCachedTokens :: !Int
     } deriving (Eq, Show)
 
+-- | Durable provenance for subagent transcripts written before child target
+-- metadata was persisted. Keeping this target separate from the mutable root
+-- target prevents a later reopen from treating stale legacy children as
+-- compatible merely because the root metadata has already been retargeted.
+data LegacySubagentTarget = LegacySubagentTarget
+    { legacyTargetProvider :: !Provider
+    , legacyTargetEffectiveModel :: !Text
+    , legacyTargetDialect :: !DialectId
+    } deriving (Eq, Show)
+
+instance ToJSON LegacySubagentTarget where
+    toJSON target = object
+        [ "provider" .= providerSlug target.legacyTargetProvider
+        , "effectiveModel" .= target.legacyTargetEffectiveModel
+        , "dialect" .= dialectSlug target.legacyTargetDialect
+        ]
+
+instance FromJSON LegacySubagentTarget where
+    parseJSON = withObject "LegacySubagentTarget" \o -> do
+        providerText <- o .: "provider"
+        provider <- case parseProvider providerText of
+            Just parsed -> pure parsed
+            Nothing ->
+                fail
+                    ("unknown legacy subagent provider: "
+                        <> Text.unpack providerText)
+        dialectText <- o .: "dialect"
+        dialect <- case parseDialect dialectText of
+            Just parsed -> pure parsed
+            Nothing ->
+                fail
+                    ("unknown legacy subagent dialect: "
+                        <> Text.unpack dialectText)
+        unless (providerSupportsDialect provider dialect) $
+            fail
+                ( "legacy subagent dialect "
+                    <> Text.unpack (dialectSlug dialect)
+                    <> " is incompatible with provider "
+                    <> Text.unpack (providerSlug provider)
+                )
+        LegacySubagentTarget provider
+            <$> o .: "effectiveModel"
+            <*> pure dialect
+
 instance ToJSON SessionMeta where
     toJSON meta = object
         [ "version" .= meta.metaVersion
@@ -115,6 +171,9 @@ instance ToJSON SessionMeta where
         , "updatedAt" .= meta.metaUpdatedAt
         , "provider" .= providerSlug meta.metaProvider
         , "model" .= meta.metaModel
+        , "transportModel" .= meta.metaTransportModel
+        , "dialect" .= dialectSlug meta.metaDialect
+        , "legacySubagentTarget" .= meta.metaLegacySubagentTarget
         , "cwd" .= unsafeToFilePath meta.metaCwd
         , "effort" .= meta.metaEffort
         , "title" .= meta.metaTitle
@@ -134,12 +193,29 @@ instance FromJSON SessionMeta where
         provider <- case parseProvider providerText of
             Just p -> pure p
             Nothing -> fail ("unknown provider: " <> Text.unpack providerText)
+        model <- o .: "model"
+        dialectText <- o .:? "dialect"
+        dialect <- case dialectText of
+            Nothing -> pure (legacyDialectIdForProvider provider)
+            Just text -> case parseDialect text of
+                Just parsed -> pure parsed
+                Nothing -> fail ("unknown dialect: " <> Text.unpack text)
+        unless (providerSupportsDialect provider dialect) $
+            fail
+                ( "dialect "
+                    <> Text.unpack (dialectSlug dialect)
+                    <> " is incompatible with provider "
+                    <> Text.unpack (providerSlug provider)
+                )
         SessionMeta version
             <$> o .: "id"
             <*> o .: "createdAt"
             <*> o .: "updatedAt"
             <*> pure provider
-            <*> o .: "model"
+            <*> pure model
+            <*> o .:? "transportModel"
+            <*> pure dialect
+            <*> o .:? "legacySubagentTarget"
             <*> (unsafeEncodeUtf <$> o .: "cwd")
             <*> o .: "effort"
             <*> o .: "title"
@@ -195,6 +271,8 @@ data SessionCreate = SessionCreate
     { createRoot :: !OsPath
     , createProvider :: !Provider
     , createModel :: !Text
+    , createTransportModel :: !Text
+    , createDialect :: !DialectId
     , createCwd :: !OsPath
     , createEffort :: !Text
     , createTitleHint :: !(Maybe Text)
@@ -235,6 +313,13 @@ createSession spec = do
             , metaUpdatedAt = now
             , metaProvider = spec.createProvider
             , metaModel = spec.createModel
+            , metaTransportModel = Just spec.createTransportModel
+            , metaDialect = spec.createDialect
+            , metaLegacySubagentTarget = Just LegacySubagentTarget
+                { legacyTargetProvider = spec.createProvider
+                , legacyTargetEffectiveModel = spec.createTransportModel
+                , legacyTargetDialect = spec.createDialect
+                }
             , metaCwd = spec.createCwd
             , metaEffort = spec.createEffort
             , metaTitle = title
@@ -338,6 +423,20 @@ addSessionUsage usage handle = do
             }
     writeSessionMeta handle.sessionMetaPath meta
     pure handle { sessionMeta = meta }
+
+-- | The original root target under which metadata-less child transcripts may
+-- have been created. Old session files derive it from their persisted root
+-- target; once written, it remains stable across root model/provider changes.
+sessionLegacySubagentTarget :: SessionMeta -> LegacySubagentTarget
+sessionLegacySubagentTarget meta =
+    fromMaybe
+        LegacySubagentTarget
+            { legacyTargetProvider = meta.metaProvider
+            , legacyTargetEffectiveModel =
+                fromMaybe meta.metaModel meta.metaTransportModel
+            , legacyTargetDialect = meta.metaDialect
+            }
+        meta.metaLegacySubagentTarget
 
 sessionConversationText :: [SessionTurn] -> Text
 sessionConversationText =

--- a/packages/agent-cli/src/Agent/CLI/SessionEnv.hs
+++ b/packages/agent-cli/src/Agent/CLI/SessionEnv.hs
@@ -13,6 +13,7 @@ import Agent.CLI.Session (Persistence, SessionHandle)
 import Agent.CLI.SessionTitle (SessionTitleManager)
 import Agent.CLI.Terminal (TerminalCapabilities)
 import Agent.CLI.TUI.App (FullscreenRuntime)
+import Agent.Dialect (Dialect)
 import Agent.Error (ApiError)
 import Agent.Loop (ImageAttachment, LoopConfig, TokenUsage)
 import qualified Agent.OpenAI.Auth as OpenAI
@@ -32,6 +33,7 @@ data SessionEnv = SessionEnv
     , sessionCompact :: !(Maybe Text -> IO (Either Text CompactOutcome))
     , sessionRender :: !RenderConfig
     , sessionProvider :: !Provider
+    , sessionDialect :: !Dialect
     , sessionUnavailableProviders :: !(IORef [Provider])
     , sessionStartupUnavailable :: !(IORef (Maybe (STM ApiError)))
     , sessionPrevious :: !(IORef (Maybe Text))

--- a/packages/agent-cli/src/Agent/CLI/SubagentStore.hs
+++ b/packages/agent-cli/src/Agent/CLI/SubagentStore.hs
@@ -16,8 +16,14 @@ module Agent.CLI.SubagentStore
     ) where
 
 import Agent.CLI.Btw (trimDanglingToolSuffix)
+import Agent.Dialect
+    ( DialectId
+    , dialectSlug
+    , parseDialect
+    )
 import Agent.FileRetry (retryOnFileBusy, writeLazyFileAtomically)
 import Agent.OsPath (toText, unsafeToFilePath)
+import Agent.Provider (Provider, parseProvider, providerSlug)
 import Agent.Responses.Types
 import Agent.Subagents (SubagentId(..), SubagentIdentity(..), SubagentStatus(..))
 import Agent.Subagents.TaskPath (taskPathText)
@@ -41,6 +47,9 @@ import System.Posix.Files (setFileMode)
 data SubagentDiskMeta = SubagentDiskMeta
     { diskPreviousResponseId :: !(Maybe Text)
     , diskStatus :: !(Maybe SubagentStatus)
+    , diskProvider :: !(Maybe Provider)
+    , diskEffectiveModel :: !(Maybe Text)
+    , diskDialect :: !(Maybe DialectId)
     , diskAgentType :: !(Maybe Text)
     , diskAgentModel :: !(Maybe Text)
     , diskReasoningEffort :: !(Maybe Text)
@@ -54,6 +63,9 @@ instance ToJSON SubagentDiskMeta where
     toJSON meta = object
         [ "previousResponseId" .= meta.diskPreviousResponseId
         , "status" .= fmap encodeDiskStatus meta.diskStatus
+        , "provider" .= fmap providerSlug meta.diskProvider
+        , "effectiveModel" .= meta.diskEffectiveModel
+        , "dialect" .= fmap dialectSlug meta.diskDialect
         , "agentType" .= meta.diskAgentType
         , "agentModel" .= meta.diskAgentModel
         , "reasoningEffort" .= meta.diskReasoningEffort
@@ -67,9 +79,16 @@ instance FromJSON SubagentDiskMeta where
     parseJSON = withObject "SubagentDiskMeta" \o -> do
         statusValue <- o .:? "status"
         diskStatus <- traverse decodeDiskStatus statusValue
+        providerText <- o .:? "provider"
+        diskProvider <- traverse parseDiskProvider providerText
+        dialectText <- o .:? "dialect"
+        diskDialect <- traverse parseDiskDialect dialectText
         SubagentDiskMeta
             <$> o .:? "previousResponseId"
             <*> pure diskStatus
+            <*> pure diskProvider
+            <*> o .:? "effectiveModel"
+            <*> pure diskDialect
             <*> o .:? "agentType"
             <*> o .:? "agentModel"
             <*> o .:? "reasoningEffort"
@@ -77,6 +96,18 @@ instance FromJSON SubagentDiskMeta where
             <*> o .:? "taskPath"
             <*> o .:? "parentId"
             <*> o .:? "depth"
+
+parseDiskDialect :: Text -> Parser DialectId
+parseDiskDialect text =
+    case parseDialect text of
+        Just dialect -> pure dialect
+        Nothing -> fail ("unknown persisted subagent dialect: " <> Text.unpack text)
+
+parseDiskProvider :: Text -> Parser Provider
+parseDiskProvider text =
+    case parseProvider text of
+        Just provider -> pure provider
+        Nothing -> fail ("unknown persisted subagent provider: " <> Text.unpack text)
 
 encodeDiskStatus :: SubagentStatus -> Aeson.Value
 encodeDiskStatus = \case
@@ -157,6 +188,9 @@ saveSubagentState
     -> [ResponseItem]
     -> Maybe Text
     -> SubagentStatus
+    -> Provider
+    -> Text
+    -> DialectId
     -> Maybe Text
     -> Maybe Text
     -> Maybe Text
@@ -164,7 +198,8 @@ saveSubagentState
     -> Maybe SubagentIdentity
     -> IO (Either Text ())
 saveSubagentState
-        sessionDir agentId items previous status agentType agentModel
+        sessionDir agentId items previous status provider effectiveModel dialect
+        agentType agentModel
         reasoningEffort cwd identity =
     case subagentStoreDir sessionDir agentId of
         Left err -> pure (Left err)
@@ -176,6 +211,9 @@ saveSubagentState
             writeLazyFileAtomically metaPath 0o600 $ Aeson.encode SubagentDiskMeta
                 { diskPreviousResponseId = previous
                 , diskStatus = Just status
+                , diskProvider = Just provider
+                , diskEffectiveModel = Just effectiveModel
+                , diskDialect = Just dialect
                 , diskAgentType = agentType
                 , diskAgentModel = agentModel
                 , diskReasoningEffort = reasoningEffort
@@ -205,7 +243,7 @@ loadSubagentState sessionDir agentId =
                     metaResult <- if hasMeta
                         then decodeFile metaPath
                         else pure (Right (SubagentDiskMeta
-                            Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing))
+                            Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing))
                     itemsResult <- if hasTranscript
                         then decodeFile transcriptPath
                         else pure (Right [])

--- a/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
@@ -10,6 +10,7 @@ module Agent.CLI.Subagents.Runtime
     , restoreAgentFromDisk
     , runCodexSubagent
     , runHttpSubagent
+    , validatePersistedSubagentTarget
     ) where
 
 import Agent.CLI.Approval (childApprove)
@@ -21,8 +22,13 @@ import Agent.CLI.Options
     , CliOptions(..)
     , defaultEffortFor
     )
-import Agent.CLI.Prompt (defaultModelFor, systemPrompt)
+import Agent.CLI.Prompt
+    ( defaultModelFor
+    , systemPrompt
+    , systemPromptForTools
+    )
 import Agent.CLI.Request (requestParams)
+import Agent.CLI.Session (LegacySubagentTarget(..))
 import Agent.CLI.SubagentStore
     ( SubagentDiskMeta(..)
     , forkSubagentTranscript
@@ -30,6 +36,18 @@ import Agent.CLI.SubagentStore
     , saveSubagentState
     )
 import Agent.CLI.Tools (requireToolRegistry, schemasFromAppTools)
+import Agent.Dialect
+    ( ChildAgentProtocol(..)
+    , Dialect
+    , DialectId
+    , codexDialect
+    , dialectChildAgentProtocol
+    , dialectForId
+    , dialectId
+    , dialectIdForModel
+    , dialectSlug
+    , providerSupportsDialect
+    )
 import Agent.InterAgentMessage
     ( InterAgentMessage
     , interAgentMessagePayload
@@ -37,7 +55,7 @@ import Agent.InterAgentMessage
 import Agent.Loop
     ( Backend(..)
     , LoopConfig(..)
-    , LoopError
+    , LoopError(..)
     , LoopEvent
     , LoopResult(..)
     , TurnInput(..)
@@ -53,7 +71,7 @@ import Agent.OpenAI.LoopBackend
     )
 import Agent.OpenAI.WebSocketClient (withCodexWsRetrying)
 import System.OsPath (OsPath)
-import Agent.Provider (Provider(..), TokenProvider)
+import Agent.Provider (Provider(..), TokenProvider, providerSlug)
 import Agent.Responses.Types
     ( ReasoningConfig(..)
     , ResponseCreateParams(..)
@@ -100,7 +118,8 @@ import Agent.Tools.MultiAgents
     )
 import Agent.Tools.PlanMode (PlanModeEnv(..), PlanModeHooks)
 import Agent.Tools.Types
-    ( ToolEnv(..)
+    ( AppTool(..)
+    , ToolEnv(..)
     , ToolRegistry
     , defaultToolEnv
     )
@@ -115,6 +134,9 @@ import Data.Time.Clock (getCurrentTime, utctDay)
 data SubagentSession = SubagentSession
     { subSessionTranscript :: !(IORef [ResponseItem])
     , subSessionContextTokens :: !(IORef (Maybe (Int, Int)))
+    , subSessionProvider :: !Provider
+    , subSessionEffectiveModel :: !Text
+    , subSessionDialect :: !DialectId
     }
 
 -- | Optional on-disk root for child transcripts (@sessionDir/agents/<id>@).
@@ -130,6 +152,8 @@ data SubagentRuntime = SubagentRuntime
     , subagentSessions :: !(IORef (Map SubagentId SubagentSession))
     , subagentStoreRoot :: !SubagentStoreRoot
     , subagentTypes :: !GrokSubagentSpecs
+    , subagentLegacyTarget :: !(Maybe LegacySubagentTarget)
+    , subagentMapModel :: !(Text -> Text)
     }
 
 data PreparedChild = PreparedChild
@@ -152,7 +176,12 @@ syncStoreRootFromPlan storeRootRef planMode = do
                 Nothing -> pure ()
 
 prepareCollaborationSpawn
-    :: IORef (Map SubagentId SubagentSession)
+    :: Provider
+    -> (Text -> Text)
+    -> Text
+    -> DialectId
+    -> Maybe LegacySubagentTarget
+    -> IORef (Map SubagentId SubagentSession)
     -> SubagentStoreRoot
     -> GrokSubagentSpecs
     -> IORef (Maybe (IORef [ResponseItem]))
@@ -160,6 +189,11 @@ prepareCollaborationSpawn
     -> CollaborationSpawnOptions
     -> IO ()
 prepareCollaborationSpawn
+        provider
+        mapModel
+        currentEffectiveModel
+        currentDialect
+        legacyTarget
         sessionsRef storeRootRef typesRef sourceRef agentId spawnOptions = do
     recordAgentSpec typesRef agentId GrokSubagentSpec
         { agentType = defaultSubagentType
@@ -167,9 +201,23 @@ prepareCollaborationSpawn
         , reasoningEffortOverride =
             spawnOptions.collaborationReasoningEffort
         }
+    let effectiveModel =
+            maybe currentEffectiveModel mapModel spawnOptions.collaborationModel
+        childDialect =
+            maybe
+                currentDialect
+                (dialectIdForModel provider . mapModel)
+                spawnOptions.collaborationModel
     session <-
         lookupOrCreateSubagentSession
-            sessionsRef storeRootRef typesRef agentId
+            sessionsRef
+            storeRootRef
+            typesRef
+            provider
+            legacyTarget
+            effectiveModel
+            childDialect
+            agentId
     source <- readIORef sourceRef
     sourceItems <- maybe (pure []) readIORef source
     writeIORef session.subSessionTranscript
@@ -180,12 +228,13 @@ persistSubagentSnapshot
     -> SubagentRegistry
     -> GrokSubagentSpecs
     -> SubagentId
-    -> IORef [ResponseItem]
+    -> SubagentSession
     -> IO ()
-persistSubagentSnapshot storeRootRef registry typesRef agentId transcriptRef = do
+persistSubagentSnapshot
+        storeRootRef registry typesRef agentId session = do
     status <- getStatus registry agentId
     persistSubagentSnapshotWithStatus
-        storeRootRef registry typesRef agentId status transcriptRef
+        storeRootRef registry typesRef agentId status session
 
 persistSubagentSnapshotWithStatus
     :: SubagentStoreRoot
@@ -193,15 +242,17 @@ persistSubagentSnapshotWithStatus
     -> GrokSubagentSpecs
     -> SubagentId
     -> SubagentStatus
-    -> IORef [ResponseItem]
+    -> SubagentSession
     -> IO ()
 persistSubagentSnapshotWithStatus
-        storeRootRef registry typesRef agentId status transcriptRef = do
+        storeRootRef registry typesRef agentId status session = do
     mroot <- readIORef storeRootRef
     case mroot of
         Nothing -> pure ()
         Just sessionDir -> do
-            items <- trimDanglingToolSuffix <$> readIORef transcriptRef
+            items <-
+                trimDanglingToolSuffix
+                    <$> readIORef session.subSessionTranscript
             previous <- getPreviousResponseId registry agentId
             agentType <- lookupAgentType typesRef agentId
             agentModel <- lookupAgentModel typesRef agentId
@@ -209,7 +260,10 @@ persistSubagentSnapshotWithStatus
             agentCwd <- getSubagentCwd registry agentId
             identity <- getSubagentIdentity registry agentId
             _ <- saveSubagentState
-                sessionDir agentId items previous status agentType agentModel
+                sessionDir agentId items previous status
+                session.subSessionProvider session.subSessionEffectiveModel
+                session.subSessionDialect
+                agentType agentModel
                 reasoningEffort agentCwd identity
             pure ()
 
@@ -223,20 +277,27 @@ flushAllSubagentSnapshots storeRootRef registry sessionsRef typesRef = do
     sessions <- readIORef sessionsRef
     mapM_
         (\(agentId, session) ->
-            persistSubagentSnapshot storeRootRef registry typesRef agentId
-                session.subSessionTranscript)
+            persistSubagentSnapshot
+                storeRootRef registry typesRef agentId session)
         (Map.toList sessions)
 
 -- | Rehydrate a closed/missing agent from @sessionDir/agents/<id>@ so
 -- 'resume_agent' / 'resume_from' can continue the prior transcript.
 restoreAgentFromDisk
-    :: SubagentStoreRoot
+    :: Provider
+    -> (Text -> Text)
+    -> Text
+    -> DialectId
+    -> Maybe LegacySubagentTarget
+    -> SubagentStoreRoot
     -> SubagentRegistry
     -> IORef (Map SubagentId SubagentSession)
     -> GrokSubagentSpecs
     -> SubagentId
     -> IO (Either Text ())
-restoreAgentFromDisk storeRootRef registry sessionsRef typesRef agentId = do
+restoreAgentFromDisk
+        provider mapModel parentEffectiveModel parentDialect legacyTarget
+        storeRootRef registry sessionsRef typesRef agentId = do
     status <- getStatus registry agentId
     case status of
         NotFound -> restore
@@ -255,29 +316,66 @@ restoreAgentFromDisk storeRootRef registry sessionsRef typesRef agentId = do
                         -- Same-process close with no disk yet: still reopen.
                         reopenInMemory Nothing Nothing
                     Right (Just (items, meta)) -> do
-                        result <- reopenPersisted meta
-                        case result of
+                        let expectedEffectiveModel =
+                                maybe
+                                    parentEffectiveModel
+                                    mapModel
+                                    meta.diskAgentModel
+                            expectedDialect =
+                                maybe
+                                    parentDialect
+                                    (dialectIdForModel provider . mapModel)
+                                    meta.diskAgentModel
+                        case validatePersistedSubagentTarget
+                                provider
+                                expectedEffectiveModel
+                                expectedDialect
+                                legacyTarget
+                                meta of
                             Left err -> pure (Left err)
-                            Right () -> do
-                                case meta.diskAgentType of
-                                    Just agentType ->
-                                        recordAgentSpec typesRef agentId GrokSubagentSpec
-                                            { agentType
-                                            , modelOverride = meta.diskAgentModel
-                                            , reasoningEffortOverride =
-                                                meta.diskReasoningEffort
-                                            }
-                                    Nothing -> pure ()
-                                transcript <- newIORef items
-                                contextTokens <- newIORef Nothing
-                                let session =
-                                        SubagentSession
-                                            { subSessionTranscript = transcript
-                                            , subSessionContextTokens = contextTokens
-                                            }
-                                atomicModifyIORef' sessionsRef \m ->
-                                    (Map.insert agentId session m, ())
-                                pure (Right ())
+                            Right (_, storedDialect)
+                                | not
+                                    (providerSupportsDialect
+                                        provider storedDialect) ->
+                                    pure $ Left $
+                                        unsupportedDialectMessage
+                                            provider agentId storedDialect
+                            Right (storedEffectiveModel, storedDialect) -> do
+                                result <- reopenPersisted meta
+                                case result of
+                                    Left err -> pure (Left err)
+                                    Right () -> do
+                                        case meta.diskAgentType of
+                                            Just agentType ->
+                                                recordAgentSpec
+                                                    typesRef
+                                                    agentId
+                                                    GrokSubagentSpec
+                                                        { agentType
+                                                        , modelOverride =
+                                                            meta.diskAgentModel
+                                                        , reasoningEffortOverride =
+                                                            meta.diskReasoningEffort
+                                                        }
+                                            Nothing -> pure ()
+                                        transcript <- newIORef items
+                                        contextTokens <- newIORef Nothing
+                                        let session =
+                                                SubagentSession
+                                                    { subSessionTranscript =
+                                                        transcript
+                                                    , subSessionContextTokens =
+                                                        contextTokens
+                                                    , subSessionProvider =
+                                                        provider
+                                                    , subSessionEffectiveModel =
+                                                        storedEffectiveModel
+                                                    , subSessionDialect =
+                                                        storedDialect
+                                                    }
+                                        atomicModifyIORef' sessionsRef \m ->
+                                            (Map.insert agentId session m, ())
+                                        pure (Right ())
     reopenPersisted meta =
         case meta.diskTaskPath of
             Nothing -> restoreAt taskPathRoot
@@ -332,124 +430,203 @@ runCodexSubagent
     -> RunSubagent
 runCodexSubagent runtime tokenProvider sendToRoot =
     \env previous prompt onEvent -> do
-        prepared <- prepareChild runtime env sendToRoot
         childModel <- lookupAgentModel runtime.subagentTypes env.subId
         childEffort <- lookupAgentReasoningEffort runtime.subagentTypes env.subId
-        coding <-
-            codingToolsFor
+        parentParams <- readIORef runtime.subagentParams
+        let (model, effort) =
+                resolveChildModelAndEffort
+                    OpenAIProvider
+                    parentParams
+                    childModel
+                    childEffort
+        prepared <-
+            prepareChild
+                runtime
                 OpenAIProvider
-                prepared.preparedToolEnv
-                (Just runtime.subagentPlanHooks)
-                (Just prepared.preparedMultiContext)
-        syncStoreRootFromPlan runtime.subagentStoreRoot coding.codingPlanMode
-        flip finally coding.codingClose do
-            today <- utctDay <$> getCurrentTime
-            let (model, effort) =
-                    resolveChildModelAndEffort
-                        OpenAIProvider
-                        prepared.preparedParentParams
-                        childModel
-                        childEffort
-                baseInstructions =
-                    fromMaybe
-                        (systemPrompt OpenAIProvider env.subCwd today True)
-                        prepared.preparedParentParams.instructions
-                instructions =
-                    baseInstructions
-                        <> "\n\nYou are a Codex subagent. Complete the assigned task and "
-                        <> "report results clearly. Your agent id is "
-                        <> env.subId.unSubagentId
-                        <> "."
-                tools = coding.codingAppTools
-                childParams = requestParams model instructions
-                    (schemasFromAppTools OpenAIProvider tools) effort
-            toolRegistry <- requireToolRegistry tools
-            childParamsRef <- newIORef childParams
-            httpFallbackActive <- newIORef False
-            let websocketBackend =
-                    freshOpenAiBackend tokenProvider
-                        (readIORef childParamsRef)
-                        prepared.preparedSession.subSessionTranscript
-                httpBackend =
-                    statelessResponsesBackend
-                        (\request _onEvent ->
-                            OpenAI.createCodexMessageWithProvider tokenProvider request)
-                        (readIORef childParamsRef)
-                        prepared.preparedSession.subSessionTranscript
-                baseBackend =
-                    openAiBackendWithTransportFallback
-                        httpFallbackActive
-                        websocketBackend
-                        httpBackend
-                backend =
-                    withConnectionRecovery $
-                        autoCompactOpenAiBackendWithThreshold
-                            runtime.subagentOptions.optCompactThreshold
-                            tokenProvider
-                            (readIORef childParamsRef)
-                            prepared.preparedSession.subSessionTranscript
-                            prepared.preparedSession.subSessionContextTokens
-                            baseBackend
-            runPreparedChild
-                runtime env prepared.preparedSession toolRegistry backend onEvent
-                (\config ->
-                    runLoopInputs config previous [AgentMessage prompt])
+                model
+                (dialectId codexDialect)
+                env
+                sendToRoot
+        case activeSubagentTargetError
+                OpenAIProvider model prepared.preparedSession of
+            Just err -> pure (Left (LoopUnexpected err))
+            Nothing -> do
+                coding <-
+                    codingToolsFor
+                        codexDialect
+                        prepared.preparedToolEnv
+                        (Just runtime.subagentPlanHooks)
+                        (Just prepared.preparedMultiContext)
+                syncStoreRootFromPlan
+                    runtime.subagentStoreRoot
+                    coding.codingPlanMode
+                flip finally coding.codingClose do
+                    today <- utctDay <$> getCurrentTime
+                    let baseInstructions =
+                            fromMaybe
+                                (systemPrompt
+                                    codexDialect env.subCwd today True)
+                                prepared.preparedParentParams.instructions
+                        instructions =
+                            baseInstructions
+                                <> "\n\nYou are a Codex subagent. Complete the assigned task and "
+                                <> "report results clearly. Your agent id is "
+                                <> env.subId.unSubagentId
+                                <> "."
+                        tools = coding.codingAppTools
+                        childParams = requestParams model instructions
+                            (schemasFromAppTools codexDialect tools) effort
+                    toolRegistry <- requireToolRegistry tools
+                    childParamsRef <- newIORef childParams
+                    httpFallbackActive <- newIORef False
+                    let websocketBackend =
+                            freshOpenAiBackend tokenProvider
+                                (readIORef childParamsRef)
+                                prepared.preparedSession.subSessionTranscript
+                        httpBackend =
+                            statelessResponsesBackend
+                                (\request _onEvent ->
+                                    OpenAI.createCodexMessageWithProvider
+                                        tokenProvider request)
+                                (readIORef childParamsRef)
+                                prepared.preparedSession.subSessionTranscript
+                        baseBackend =
+                            openAiBackendWithTransportFallback
+                                httpFallbackActive
+                                websocketBackend
+                                httpBackend
+                        backend =
+                            withConnectionRecovery $
+                                autoCompactOpenAiBackendWithThreshold
+                                    runtime.subagentOptions.optCompactThreshold
+                                    tokenProvider
+                                    (readIORef childParamsRef)
+                                    prepared.preparedSession.subSessionTranscript
+                                    prepared.preparedSession.subSessionContextTokens
+                                    baseBackend
+                    runPreparedChild
+                        runtime env prepared.preparedSession toolRegistry
+                        backend onEvent
+                        (\config ->
+                            runLoopInputs config previous [AgentMessage prompt])
 
 -- | Child XAI/OpenRouter agent: HTTP backend, filtered tools by subagent_type.
 runHttpSubagent
     :: SubagentRuntime
+    -> Dialect
     -> Provider
+    -> Maybe (InterAgentMessage -> IO (Either Text Text))
     -> (IORef ResponseCreateParams -> IORef [ResponseItem] -> Backend)
     -> RunSubagent
-runHttpSubagent runtime provider mkBackend =
+runHttpSubagent runtime dialect provider sendToRoot mkBackend =
     \env previous prompt onEvent -> do
-        prepared <- prepareChild runtime env Nothing
         agentType <-
             fromMaybe defaultSubagentType
                 <$> lookupAgentType runtime.subagentTypes env.subId
         childModel <- lookupAgentModel runtime.subagentTypes env.subId
         childEffort <-
             lookupAgentReasoningEffort runtime.subagentTypes env.subId
-        coding <-
-            codingToolsFor
+        parentParams <- readIORef runtime.subagentParams
+        let (model, effort) =
+                resolveChildModelAndEffort
+                    provider
+                    parentParams
+                    childModel
+                    childEffort
+            effectiveModel = runtime.subagentMapModel model
+        prepared <-
+            prepareChild
+                runtime
                 provider
-                prepared.preparedToolEnv
-                (Just runtime.subagentPlanHooks)
-                (Just prepared.preparedMultiContext)
-        flip finally coding.codingClose do
-            today <- utctDay <$> getCurrentTime
-            let (model, effort) =
-                    resolveChildModelAndEffort
-                        provider
-                        prepared.preparedParentParams
-                        childModel
-                        childEffort
-                baseInstructions = systemPrompt provider env.subCwd today True
-                instructions =
-                    baseInstructions
-                        <> "\n\n"
-                        <> grokSubagentSuffix agentType env.subId
-                tools = filterChildGrokTools agentType coding.codingAppTools
-                childParams = requestParams model instructions
-                    (schemasFromAppTools provider tools) effort
-            toolRegistry <- requireToolRegistry tools
-            childParamsRef <- newIORef childParams
-            let backend =
-                    withConnectionRecovery $
-                        mkBackend
-                            childParamsRef
-                            prepared.preparedSession.subSessionTranscript
-            runPreparedChild
-                runtime env prepared.preparedSession toolRegistry backend onEvent
-                (\config ->
-                    runLoop config previous (interAgentMessagePayload prompt))
+                effectiveModel
+                (maybe
+                    (dialectId dialect)
+                    (dialectIdForModel provider . runtime.subagentMapModel)
+                    childModel)
+                env
+                sendToRoot
+        case activeSubagentTargetError
+                provider effectiveModel prepared.preparedSession of
+            Just err -> pure (Left (LoopUnexpected err))
+            Nothing -> do
+                let childDialect =
+                        dialectForId
+                            prepared.preparedSession.subSessionDialect
+                coding <-
+                    codingToolsFor
+                        childDialect
+                        prepared.preparedToolEnv
+                        (Just runtime.subagentPlanHooks)
+                        (Just prepared.preparedMultiContext)
+                flip finally coding.codingClose do
+                    today <- utctDay <$> getCurrentTime
+                    let tools = case
+                                dialectChildAgentProtocol childDialect of
+                            CodexCollaborationProtocol ->
+                                coding.codingAppTools
+                            GrokTaskProtocol ->
+                                filterChildGrokTools
+                                    agentType coding.codingAppTools
+                            GenericTaskProtocol ->
+                                filterChildGrokTools
+                                    agentType coding.codingAppTools
+                        baseInstructions =
+                            case dialectChildAgentProtocol childDialect of
+                                CodexCollaborationProtocol ->
+                                    systemPrompt
+                                        childDialect env.subCwd today True
+                                GrokTaskProtocol ->
+                                    systemPromptForTools
+                                        childDialect
+                                        (map (.appToolName) tools)
+                                        env.subCwd
+                                        today
+                                        True
+                                GenericTaskProtocol ->
+                                    systemPromptForTools
+                                        childDialect
+                                        (map (.appToolName) tools)
+                                        env.subCwd
+                                        today
+                                        True
+                        instructions =
+                            baseInstructions
+                                <> "\n\n"
+                                <> case
+                                    dialectChildAgentProtocol childDialect of
+                                    CodexCollaborationProtocol ->
+                                        codexSubagentSuffix env.subId
+                                    GrokTaskProtocol ->
+                                        grokSubagentSuffix agentType env.subId
+                                    GenericTaskProtocol ->
+                                        genericSubagentSuffix agentType env.subId
+                        childParams = requestParams model instructions
+                            (schemasFromAppTools childDialect tools) effort
+                    toolRegistry <- requireToolRegistry tools
+                    childParamsRef <- newIORef childParams
+                    let backend =
+                            withConnectionRecovery $
+                                mkBackend
+                                    childParamsRef
+                                    prepared.preparedSession.subSessionTranscript
+                    runPreparedChild
+                        runtime env prepared.preparedSession toolRegistry
+                        backend onEvent
+                        (\config ->
+                            runLoop
+                                config
+                                previous
+                                (interAgentMessagePayload prompt))
 
 prepareChild
     :: SubagentRuntime
+    -> Provider
+    -> Text
+    -> DialectId
     -> SubagentSpawnEnv
     -> Maybe (InterAgentMessage -> IO (Either Text Text))
     -> IO PreparedChild
-prepareChild runtime env sendToRoot = do
+prepareChild runtime provider currentEffectiveModel currentDialect env sendToRoot = do
     parentParams <- readIORef runtime.subagentParams
     childEnv <- defaultToolEnv env.subCwd
     childPath <-
@@ -460,9 +637,14 @@ prepareChild runtime env sendToRoot = do
             runtime.subagentSessions
             runtime.subagentStoreRoot
             runtime.subagentTypes
+            provider
+            runtime.subagentLegacyTarget
+            currentEffectiveModel
+            currentDialect
             env.subId
     nestedForkSource <- newIORef (Just session.subSessionTranscript)
-    let childToolEnv = childEnv { toolCancel = env.subCancel }
+    let sessionDialect = dialectForId session.subSessionDialect
+        childToolEnv = childEnv { toolCancel = env.subCancel }
         childCtx = MultiAgentContext
             { multiRegistry = runtime.subagentRegistry
             , multiSelfId = Just env.subId
@@ -473,11 +655,27 @@ prepareChild runtime env sendToRoot = do
             , multiCreateWorktree = Nothing
             , multiPrepareSpawn = Just
                 (prepareCollaborationSpawn
+                    provider
+                    runtime.subagentMapModel
+                    session.subSessionEffectiveModel
+                    session.subSessionDialect
+                    (Just LegacySubagentTarget
+                        { legacyTargetProvider =
+                            session.subSessionProvider
+                        , legacyTargetEffectiveModel =
+                            session.subSessionEffectiveModel
+                        , legacyTargetDialect =
+                            session.subSessionDialect
+                        })
                     runtime.subagentSessions
                     runtime.subagentStoreRoot
                     runtime.subagentTypes
                     nestedForkSource)
-            , multiSendToRoot = sendToRoot
+            , multiSendToRoot =
+                case dialectChildAgentProtocol sessionDialect of
+                    CodexCollaborationProtocol -> sendToRoot
+                    GrokTaskProtocol -> Nothing
+                    GenericTaskProtocol -> Nothing
             }
     pure PreparedChild
         { preparedParentParams = parentParams
@@ -539,7 +737,7 @@ runPreparedChild runtime env session toolRegistry backend onEvent runChild = do
         runtime.subagentRegistry
         runtime.subagentTypes
         env.subId
-        session.subSessionTranscript
+        session
     pure result
 
 grokSubagentSuffix :: Text -> SubagentId -> Text
@@ -565,13 +763,49 @@ grokSubagentSuffix agentType agentId =
                 "\n\nStart broad and narrow down. Check multiple locations and naming conventions. \
                 \Never create documentation files unless explicitly requested."
 
+codexSubagentSuffix :: SubagentId -> Text
+codexSubagentSuffix agentId =
+    "You are a Codex subagent. Complete the assigned task and report results clearly. \
+    \Your agent id is "
+        <> agentId.unSubagentId
+        <> "."
+
+genericSubagentSuffix :: Text -> SubagentId -> Text
+genericSubagentSuffix agentType agentId =
+    "You are a focused subagent delegated a specific task.\n\
+    \Complete the assigned task directly and efficiently. Do not broaden scope beyond what was asked. \
+    \Report blocked or unverified work explicitly.\n\n\
+    \Subagent type: "
+        <> agentType
+        <> "\nAgent id: "
+        <> agentId.unSubagentId
+        <> case agentType of
+            "explore" ->
+                "\n\n=== READ-ONLY MODE ===\n\
+                \You have no file editing or command execution tools. Search broadly, narrow down, \
+                \and return absolute file paths and relevant findings."
+            "plan" ->
+                "\n\n=== READ-ONLY MODE ===\n\
+                \Do not create, modify, or delete implementation files. Explore the codebase, \
+                \consider trade-offs, and produce a concrete implementation strategy. End with \
+                \a Critical Files for Implementation section listing 3-5 files."
+            _ ->
+                "\n\nStart broad and narrow down. Check multiple locations and naming conventions. \
+                \Never create documentation files unless explicitly requested."
+
 lookupOrCreateSubagentSession
     :: IORef (Map SubagentId SubagentSession)
     -> SubagentStoreRoot
     -> GrokSubagentSpecs
+    -> Provider
+    -> Maybe LegacySubagentTarget
+    -> Text
+    -> DialectId
     -> SubagentId
     -> IO SubagentSession
-lookupOrCreateSubagentSession sessionsRef storeRootRef typesRef agentId = do
+lookupOrCreateSubagentSession
+        sessionsRef storeRootRef typesRef provider legacyTarget
+        currentEffectiveModel currentDialect agentId = do
     sessions <- readIORef sessionsRef
     case Map.lookup agentId sessions of
         Just session -> pure session
@@ -580,9 +814,18 @@ lookupOrCreateSubagentSession sessionsRef storeRootRef typesRef agentId = do
             loaded <- case mroot of
                 Just sessionDir -> loadSubagentState sessionDir agentId
                 Nothing -> pure (Right Nothing)
-            let (items, meta) = case loaded of
-                    Right (Just (xs, m)) -> (xs, Just m)
-                    _ -> ([], Nothing)
+            let (items, meta, sessionEffectiveModel, sessionDialect) = case loaded of
+                    Right (Just (xs, m))
+                        | Right (storedEffectiveModel, storedDialect) <-
+                            validatePersistedSubagentTarget
+                                provider
+                                currentEffectiveModel
+                                currentDialect
+                                legacyTarget
+                                m
+                        , providerSupportsDialect provider storedDialect ->
+                            (xs, Just m, storedEffectiveModel, storedDialect)
+                    _ -> ([], Nothing, currentEffectiveModel, currentDialect)
             transcript <- newIORef items
             contextTokens <- newIORef Nothing
             case meta >>= (.diskAgentType) of
@@ -597,6 +840,117 @@ lookupOrCreateSubagentSession sessionsRef storeRootRef typesRef agentId = do
             let session = SubagentSession
                     { subSessionTranscript = transcript
                     , subSessionContextTokens = contextTokens
+                    , subSessionProvider = provider
+                    , subSessionEffectiveModel = sessionEffectiveModel
+                    , subSessionDialect = sessionDialect
                     }
             atomicModifyIORef' sessionsRef \m -> (Map.insert agentId session m, ())
             pure session
+
+validatePersistedSubagentTarget
+    :: Provider
+    -> Text
+    -> DialectId
+    -> Maybe LegacySubagentTarget
+    -> SubagentDiskMeta
+    -> Either Text (Text, DialectId)
+validatePersistedSubagentTarget
+        provider expectedEffectiveModel expectedDialect legacyTarget meta = do
+    let legacyDialect =
+            legacyDialectForTarget
+                legacyTarget
+                provider
+                expectedEffectiveModel
+                expectedDialect
+    storedProvider <- case meta.diskProvider of
+        Just storedProvider -> Right storedProvider
+        Nothing
+            | Nothing <- legacyDialect ->
+                Left
+                    "cannot restore a legacy subagent without provider metadata \
+                    \after changing the session target; reopen the parent \
+                    \session under its original target first"
+        Nothing -> Right provider
+    storedEffectiveModel <- case meta.diskEffectiveModel of
+        Just stored -> Right stored
+        Nothing
+            | Just _ <- legacyDialect -> Right expectedEffectiveModel
+            | otherwise ->
+                Left
+                    "cannot restore a legacy subagent without effective model \
+                    \metadata after changing the session target; reopen the \
+                    \parent session under its original target first"
+    case subagentTargetError
+            provider expectedEffectiveModel storedProvider storedEffectiveModel of
+        Just err -> Left err
+        Nothing -> Right ()
+    storedDialect <- case meta.diskDialect of
+        Just stored -> Right stored
+        Nothing -> case legacyDialect of
+            Just legacy -> Right legacy
+            Nothing ->
+                Left
+                    "cannot restore a legacy subagent without dialect metadata \
+                    \after changing the session target; reopen the parent \
+                    \session under its original target first"
+    Right (storedEffectiveModel, storedDialect)
+
+legacyDialectForTarget
+    :: Maybe LegacySubagentTarget
+    -> Provider
+    -> Text
+    -> DialectId
+    -> Maybe DialectId
+legacyDialectForTarget target provider effectiveModel dialect = do
+    legacy <- target
+    if legacy.legacyTargetProvider == provider
+        && legacy.legacyTargetEffectiveModel == effectiveModel
+        && legacy.legacyTargetDialect == dialect
+        then Just dialect
+        else Nothing
+
+activeSubagentTargetError
+    :: Provider
+    -> Text
+    -> SubagentSession
+    -> Maybe Text
+activeSubagentTargetError provider effectiveModel session =
+    subagentTargetError
+        provider
+        effectiveModel
+        session.subSessionProvider
+        session.subSessionEffectiveModel
+
+subagentTargetError
+    :: Provider
+    -> Text
+    -> Provider
+    -> Text
+    -> Maybe Text
+subagentTargetError provider effectiveModel storedProvider storedEffectiveModel
+    | storedProvider /= provider =
+        Just
+            ( "cannot continue subagent created for the "
+                <> providerSlug storedProvider
+                <> " transport under "
+                <> providerSlug provider
+            )
+    | storedEffectiveModel /= effectiveModel =
+        Just
+            ( "cannot continue subagent after its effective model changed \
+                \from "
+                <> storedEffectiveModel
+                <> " to "
+                <> effectiveModel
+            )
+    | otherwise = Nothing
+
+unsupportedDialectMessage :: Provider -> SubagentId -> DialectId -> Text
+unsupportedDialectMessage provider agentId storedDialect =
+    "cannot restore subagent "
+        <> agentId.unSubagentId
+        <> ": dialect "
+        <> dialectSlug storedDialect
+        <> " is not supported by the current "
+        <> providerSlug provider
+        <> " transport"

--- a/packages/agent-cli/src/Agent/CLI/Tools.hs
+++ b/packages/agent-cli/src/Agent/CLI/Tools.hs
@@ -7,8 +7,14 @@ module Agent.CLI.Tools
     ) where
 
 import Agent.Responses.Types
+import Agent.Dialect
+    ( Dialect
+    , FunctionSchemaStyle(..)
+    , ToolLayout(..)
+    , dialectFunctionSchemaStyle
+    , dialectToolLayout
+    )
 import Agent.OpenAI.ToolDSL (buildGrokTool, buildTool)
-import Agent.Provider (Provider(..))
 import Agent.ToolDSL (PropertySchema, parametersObjectLoose)
 import Agent.ToolDispatch (canonicalToolName)
 import Agent.Tools.ApplyPatch (applyPatchGrammar)
@@ -43,27 +49,26 @@ webSearchTool = KnownResponseTool ToolWebSearch TaggedObject
     , fields = KeyMap.empty
     }
 
-schemasFromAppTools :: Provider -> [AppTool] -> [ResponseTool]
-schemasFromAppTools provider tools = case provider of
-    OpenAIProvider ->
+schemasFromAppTools :: Dialect -> [AppTool] -> [ResponseTool]
+schemasFromAppTools dialect tools = case dialectToolLayout dialect of
+    CollaborationNamespaceLayout ->
         let (multi, rest) = partition isMultiAgentTool tools
-            base = webSearchTool : map (schemaFromAppTool provider) rest
+            base = webSearchTool : map (schemaFromAppTool dialect) rest
         in if null multi
             then base
             else base ++ [multiAgentNamespaceTool multi]
-    _ ->
-        webSearchTool : map (schemaFromAppTool provider) tools
+    FlatToolLayout ->
+        webSearchTool : map (schemaFromAppTool dialect) tools
 
 isMultiAgentTool :: AppTool -> Bool
 isMultiAgentTool tool = tool.appToolName `elem` multiAgentToolNames
 
-schemaFromAppTool :: Provider -> AppTool -> ResponseTool
-schemaFromAppTool provider tool = case tool.appToolSchema of
+schemaFromAppTool :: Dialect -> AppTool -> ResponseTool
+schemaFromAppTool dialect tool = case tool.appToolSchema of
     JsonFunctionSchema parameters ->
-        let build = case provider of
-                XAIProvider -> buildGrokTool
-                OpenRouterProvider -> buildGrokTool
-                OpenAIProvider -> buildTool
+        let build = case dialectFunctionSchemaStyle dialect of
+                StrictFunctionSchemas -> buildTool
+                LooseFunctionSchemas -> buildGrokTool
         in build tool.appToolName tool.appToolDescription parameters
     FreeformApplyPatchSchema ->
         applyPatchCustomTool tool.appToolName tool.appToolDescription

--- a/packages/agent-cli/test/Agent/CLI/AgentSessionsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/AgentSessionsSpec.hs
@@ -4,6 +4,7 @@ import Agent.CLI.AgentSessions
 import Agent.CLI.Options (ApprovalPolicy(..))
 import Agent.CLI.Session
 import Agent.CLI.SessionLock
+import Agent.Dialect (DialectId(..))
 import Agent.Loop (defaultLoopDispatch)
 import System.OsPath (OsPath, decodeUtf, unsafeEncodeUtf)
 import Agent.Provider (Provider(..))
@@ -60,9 +61,30 @@ spec = describe "Agent.CLI.AgentSessions" do
             handle.sessionMeta.metaTitle `shouldBe` "worker"
             handle.sessionMeta.metaTitleIsManual `shouldBe` True
             handle.sessionMeta.metaModel `shouldBe` "model-2"
+            handle.sessionMeta.metaDialect `shouldBe` GrokBuildDialect
             handle.sessionMeta.metaEffort `shouldBe` "high"
             loadSession env.toolsRoot handle.sessionMeta.metaId
                 `shouldReturn` Right (handle.sessionMeta, [])
+
+    it "inherits the active dialect and resolves explicit model overrides" $
+        withTempEnv \env launched -> do
+            let openRouterEnv = env
+                    { toolsProvider = OpenRouterProvider
+                    , toolsModel = "openai/gpt-5.1"
+                    , toolsTransportModel = "openai/gpt-5.1"
+                    , toolsDialect = GrokBuildDialect
+                    }
+            _ <- runTool openRouterEnv "create_agent_session"
+                "{\"message\":\"inherit legacy dialect\"}"
+            _ <- runTool openRouterEnv "create_agent_session"
+                "{\"message\":\"use portable dialect\",\"model\":\"anthropic/claude-sonnet-4\"}"
+            [(inherited, _), (overridden, _)] <- readIORef launched
+            inherited.sessionMeta.metaModel `shouldBe` "openai/gpt-5.1"
+            inherited.sessionMeta.metaDialect `shouldBe` GrokBuildDialect
+            overridden.sessionMeta.metaModel
+                `shouldBe` "anthropic/claude-sonnet-4"
+            overridden.sessionMeta.metaDialect
+                `shouldBe` GenericResponsesDialect
 
     it "reads recent turns without exposing raw response items" $
         withTempEnv \env _ -> do
@@ -228,6 +250,8 @@ withTempEnv action =
                 { toolsRoot = root
                 , toolsProvider = XAIProvider
                 , toolsModel = "model-1"
+                , toolsTransportModel = "model-1"
+                , toolsDialect = GrokBuildDialect
                 , toolsCwd = fromFilePath "/tmp/work"
                 , toolsEffort = "low"
                 , toolsCurrentSessionId = pure Nothing
@@ -241,6 +265,8 @@ testCreate root = SessionCreate
     { createRoot = root
     , createProvider = XAIProvider
     , createModel = "model-1"
+    , createTransportModel = "model-1"
+    , createDialect = GrokBuildDialect
     , createCwd = fromFilePath "/tmp/work"
     , createEffort = "low"
     , createTitleHint = Just "test"

--- a/packages/agent-cli/test/Agent/CLI/ModelPickerSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ModelPickerSpec.hs
@@ -3,8 +3,11 @@ module Agent.CLI.ModelPickerSpec (spec) where
 import Agent.CLI.ModelPicker
 import Agent.CLI.Models
 import Agent.CLI.Prompt (defaultModelFor)
+import Agent.Dialect (DialectId(..))
 import Agent.Provider (Provider(..))
+import Control.Exception.Safe (bracket)
 import qualified Data.Text as Text
+import System.Environment (lookupEnv, setEnv, unsetEnv)
 import Test.Hspec
 
 spec :: Spec
@@ -30,7 +33,10 @@ spec = do
         it "mentions all providers, current model, and controls" do
             let frame =
                     renderPickerFrame False $
-                        initialPickerState XAIProvider (defaultModelFor XAIProvider)
+                        initialPickerState
+                            XAIProvider
+                            (defaultModelFor XAIProvider)
+                            GrokBuildDialect
             frame `shouldSatisfy` Text.isInfixOf "xai"
             frame `shouldSatisfy` Text.isInfixOf "openai"
             frame `shouldSatisfy` Text.isInfixOf "openrouter"
@@ -40,11 +46,40 @@ spec = do
 
     describe "formatCatalogListing" do
         it "lists the current model and entries from every provider" do
-            let listing =
-                    formatCatalogListing False OpenAIProvider "gpt-5.6-luna"
+            listing <-
+                formatCatalogListing
+                    False
+                    OpenAIProvider
+                    "gpt-5.6-luna"
+                    CodexDialect
             listing `shouldSatisfy` Text.isInfixOf "gpt-5.6-luna"
             listing `shouldSatisfy` Text.isInfixOf "gpt-5.6-terra"
             listing `shouldSatisfy` Text.isInfixOf "gpt-5.6-sol"
             listing `shouldSatisfy` Text.isInfixOf "openai"
             listing `shouldSatisfy` Text.isInfixOf "grok-4.6"
             listing `shouldSatisfy` Text.isInfixOf "openrouter"
+
+        it "shows the dialect of OpenRouter's mapped transport model" do
+            withEnv
+                "OPENROUTER_MODEL_MAP"
+                (Just "openai/gpt-5.1=x-ai/grok-4") do
+                    listing <-
+                        formatCatalogListing
+                            False
+                            OpenRouterProvider
+                            "openai/gpt-5.1"
+                            GrokBuildDialect
+                    listing `shouldSatisfy`
+                        Text.isInfixOf
+                            "openrouter · openai/gpt-5.1 · grok-build"
+
+withEnv :: String -> Maybe String -> IO a -> IO a
+withEnv name value action =
+    bracket (lookupEnv name) restore \_ -> set value >> action
+  where
+    set = \case
+        Nothing -> unsetEnv name
+        Just x -> setEnv name x
+    restore = \case
+        Nothing -> unsetEnv name
+        Just x -> setEnv name x

--- a/packages/agent-cli/test/Agent/CLI/ModelsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ModelsSpec.hs
@@ -2,10 +2,16 @@ module Agent.CLI.ModelsSpec (spec) where
 
 import Agent.CLI.Models
 import Agent.CLI.Prompt (defaultModelFor)
+import Agent.Dialect
+    ( DialectId(..)
+    , dialectIdForModel
+    )
 import Agent.Provider (Provider(..))
-import Data.List (nub)
+import Control.Exception.Safe (bracket)
+import Data.List (find, nub)
 import Data.Maybe (listToMaybe)
 import qualified Data.Text as Text
+import System.Environment (lookupEnv, setEnv, unsetEnv)
 import Test.Hspec
 
 firstId :: [ModelOption] -> Maybe Text.Text
@@ -43,38 +49,203 @@ spec = do
                 (modelsForProvider OpenAIProvider)
                 `shouldBe` True
 
+        it "assigns OpenRouter dialects by model family" do
+            let options = modelsForProvider OpenRouterProvider
+                dialectFor model =
+                    (.modelDialect) <$> find ((== model) . (.modelId)) options
+            dialectFor "openai/gpt-5.1" `shouldBe` Just CodexDialect
+            dialectFor "x-ai/grok-4" `shouldBe` Just GrokBuildDialect
+            dialectFor "anthropic/claude-sonnet-4"
+                `shouldBe` Just GenericResponsesDialect
+            dialectFor "google/gemini-2.5-pro"
+                `shouldBe` Just GenericResponsesDialect
+
+        it "keeps every catalog dialect consistent with model inference" do
+            all
+                (\option ->
+                    option.modelDialect
+                        == dialectIdForModel
+                            option.modelProvider
+                            option.modelId)
+                modelCatalog
+                `shouldBe` True
+
     describe "modelCatalog" do
         it "includes every provider" do
             nub (map (.modelProvider) modelCatalog)
                 `shouldMatchList`
                     [OpenAIProvider, XAIProvider, OpenRouterProvider]
 
+    describe "modelTargetRequiresRebuild" do
+        let sameDialect = ModelOption
+                { modelProvider = OpenRouterProvider
+                , modelId = "openai/gpt-5.2"
+                , modelTransportId = "openai/gpt-5.2"
+                , modelDialect = CodexDialect
+                , modelLabel = Nothing
+                }
+
+        it "updates a model in place within the current provider and dialect" do
+            modelTargetRequiresRebuild
+                OpenRouterProvider CodexDialect sameDialect
+                `shouldBe` False
+
+        it "rebuilds when only the dialect changes" do
+            modelTargetRequiresRebuild
+                OpenRouterProvider
+                GrokBuildDialect
+                sameDialect
+                `shouldBe` True
+
+        it "rebuilds when the provider changes" do
+            modelTargetRequiresRebuild
+                XAIProvider
+                CodexDialect
+                sameDialect
+                `shouldBe` True
+
+    describe "resolveModelOptionDialect" do
+        it "uses the final OpenRouter model after transport overrides" do
+            withEnv
+                "OPENROUTER_MODEL_MAP"
+                (Just "friendly=anthropic/claude-sonnet-4") do
+                    resolved <-
+                        resolveModelOptionDialect ModelOption
+                            { modelProvider = OpenRouterProvider
+                            , modelId = "friendly"
+                            , modelTransportId = "friendly"
+                            , modelDialect = CodexDialect
+                            , modelLabel = Nothing
+                            }
+                    resolved.modelDialect
+                        `shouldBe` GenericResponsesDialect
+                    resolved.modelTransportId
+                        `shouldBe` "anthropic/claude-sonnet-4"
+
+        it "keeps direct providers on their native dialect" do
+            resolved <-
+                resolveModelOptionDialect ModelOption
+                    { modelProvider = XAIProvider
+                    , modelId = "openai/gpt-5.1"
+                    , modelTransportId = "openai/gpt-5.1"
+                    , modelDialect = CodexDialect
+                    , modelLabel = Nothing
+                    }
+            resolved.modelDialect `shouldBe` GrokBuildDialect
+
+    describe "resolvePersistedDialect" do
+        let inferred = ModelOption
+                { modelProvider = OpenRouterProvider
+                , modelId = "friendly"
+                , modelTransportId = "x-ai/grok-4"
+                , modelDialect = GrokBuildDialect
+                , modelLabel = Nothing
+                }
+
+        it "retargets when a recorded OpenRouter mapping changes" do
+            resolvePersistedDialect
+                CodexDialect
+                (Just "openai/gpt-5.1")
+                inferred
+                `shouldBe` (GrokBuildDialect, True)
+
+        it "preserves an explicit dialect while the mapping is unchanged" do
+            resolvePersistedDialect
+                CodexDialect
+                (Just "x-ai/grok-4")
+                inferred
+                `shouldBe` (CodexDialect, False)
+
+        it "preserves legacy records without an effective model" do
+            resolvePersistedDialect
+                GrokBuildDialect
+                Nothing
+                inferred
+                `shouldBe` (GrokBuildDialect, False)
+
     describe "ensureCurrentInList" do
         it "prepends an unknown current model" do
             let base = modelsForProvider XAIProvider
-                opts = ensureCurrentInList XAIProvider "custom-model" base
+                opts =
+                    ensureCurrentInList
+                        XAIProvider
+                        "custom-model"
+                        GrokBuildDialect
+                        base
             firstId opts `shouldBe` Just "custom-model"
             fmap (.modelLabel) (listToMaybe opts) `shouldBe` Just (Just "current")
             fmap (.modelProvider) (listToMaybe opts) `shouldBe` Just XAIProvider
+            fmap (.modelDialect) (listToMaybe opts)
+                `shouldBe` Just GrokBuildDialect
 
         it "does not duplicate a known current model" do
             let base = modelsForProvider XAIProvider
                 def = defaultModelFor XAIProvider
-                opts = ensureCurrentInList XAIProvider def base
+                opts =
+                    ensureCurrentInList
+                        XAIProvider
+                        def
+                        GrokBuildDialect
+                        base
             length (filter (\opt -> opt.modelId == def) opts) `shouldBe` 1
 
+        it "preserves a legacy OpenRouter dialect for a known model" do
+            let model = "openai/gpt-5.1"
+                opts =
+                    ensureCurrentInList
+                        OpenRouterProvider
+                        model
+                        GrokBuildDialect
+                        (modelsForProvider OpenRouterProvider)
+            fmap (.modelDialect) (listToMaybe opts)
+                `shouldBe` Just GrokBuildDialect
+            length (filter ((== model) . (.modelId)) opts) `shouldBe` 2
+
         it "ignores unset placeholders" do
-            let option = ModelOption XAIProvider "a" Nothing
-            ensureCurrentInList XAIProvider "(unset)" [option]
+            let option =
+                    ModelOption
+                        XAIProvider
+                        "a"
+                        "a"
+                        GrokBuildDialect
+                        Nothing
+            ensureCurrentInList
+                XAIProvider
+                "(unset)"
+                GrokBuildDialect
+                [option]
                 `shouldBe` [option]
 
     describe "picker navigation" do
-        let state0 = initialPickerState XAIProvider (defaultModelFor XAIProvider)
+        let state0 =
+                initialPickerState
+                    XAIProvider
+                    (defaultModelFor XAIProvider)
+                    GrokBuildDialect
 
         it "starts on the current model" do
-            fmap (\option -> (option.modelProvider, option.modelId))
+            fmap
+                (\option ->
+                    ( option.modelProvider
+                    , option.modelId
+                    , option.modelDialect
+                    ))
                 (selectedOption state0)
-                `shouldBe` Just (XAIProvider, defaultModelFor XAIProvider)
+                `shouldBe`
+                    Just
+                        ( XAIProvider
+                        , defaultModelFor XAIProvider
+                        , GrokBuildDialect
+                        )
+
+        it "starts on a legacy dialect rather than the catalog replacement" do
+            let state =
+                    initialPickerState
+                        OpenRouterProvider
+                        "openai/gpt-5.1"
+                        GrokBuildDialect
+            fmap (.modelDialect) (selectedOption state)
+                `shouldBe` Just GrokBuildDialect
 
         it "shows models from every provider" do
             nub (map (.modelProvider) (visibleOptions state0))
@@ -100,6 +271,8 @@ spec = do
                 `shouldBe` Left (Just ModelOption
                     { modelProvider = XAIProvider
                     , modelId = defaultModelFor XAIProvider
+                    , modelTransportId = defaultModelFor XAIProvider
+                    , modelDialect = GrokBuildDialect
                     , modelLabel = Just "default"
                     })
 
@@ -135,3 +308,17 @@ spec = do
             visibleOptions typed `shouldSatisfy` (not . null)
             all ((== OpenRouterProvider) . (.modelProvider)) (visibleOptions typed)
                 `shouldBe` True
+
+withEnv :: String -> Maybe String -> IO a -> IO a
+withEnv name value action =
+    bracket
+        (do
+            previous <- lookupEnv name
+            set value
+            pure previous)
+        set
+        (const action)
+  where
+    set = \case
+        Just current -> setEnv name current
+        Nothing -> unsetEnv name

--- a/packages/agent-cli/test/Agent/CLI/ProjectSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ProjectSpec.hs
@@ -1,6 +1,7 @@
 module Agent.CLI.ProjectSpec (spec) where
 
 import Agent.CLI.Project
+import Agent.Dialect (DialectId(..))
 import Agent.Provider (Provider(..))
 import System.OsPath (OsPath, decodeUtf, unsafeEncodeUtf)
 import Control.Exception (bracket)
@@ -53,10 +54,11 @@ spec = describe "Agent.CLI.Project" do
                 settings' <- loadProjectSettings root
                 settings'.settingsAutoApprove `shouldBe` False
 
-        it "round-trips the last provider/model and preserves other settings" $
+        it "round-trips the last provider/model/dialect and preserves other settings" $
             withTempDir "agent-project-" \root -> do
                 saveProjectAutoApprove root True
-                saveProjectModel root OpenAIProvider "gpt-project"
+                saveProjectModel
+                    root OpenAIProvider "gpt-project" "gpt-project" CodexDialect
 
                 let path = projectSettingsPath root
                 modeOf path `shouldReturn` 0o600
@@ -65,11 +67,16 @@ spec = describe "Agent.CLI.Project" do
                 settings.settingsLastModel `shouldBe` Just ProjectModel
                     { projectModelProvider = OpenAIProvider
                     , projectModelName = "gpt-project"
+                    , projectModelTransportName = Just "gpt-project"
+                    , projectModelDialect = CodexDialect
                     }
                 projectModelProvider settings `shouldBe` Just OpenAIProvider
                 projectModelFor OpenAIProvider settings
                     `shouldBe` Just "gpt-project"
+                projectDialectFor OpenAIProvider settings
+                    `shouldBe` Just CodexDialect
                 projectModelFor XAIProvider settings `shouldBe` Nothing
+                projectDialectFor XAIProvider settings `shouldBe` Nothing
 
                 saveProjectAutoApprove root False
                 updated <- loadProjectSettings root
@@ -80,14 +87,36 @@ spec = describe "Agent.CLI.Project" do
         it "replaces the remembered provider/model without resetting approval" $
             withTempDir "agent-project-" \root -> do
                 saveProjectAutoApprove root True
-                saveProjectModel root OpenAIProvider "gpt-old"
-                saveProjectModel root XAIProvider "grok-new"
+                saveProjectModel
+                    root OpenAIProvider "gpt-old" "gpt-old" CodexDialect
+                saveProjectModel
+                    root XAIProvider "grok-new" "grok-new" GrokBuildDialect
 
                 settings <- loadProjectSettings root
                 settings.settingsAutoApprove `shouldBe` True
                 projectModelProvider settings `shouldBe` Just XAIProvider
                 projectModelFor XAIProvider settings `shouldBe` Just "grok-new"
+                projectDialectFor XAIProvider settings
+                    `shouldBe` Just GrokBuildDialect
                 projectModelFor OpenAIProvider settings `shouldBe` Nothing
+
+        it "loads legacy OpenRouter settings with the old Grok dialect" $
+            withTempDir "agent-project-" \root -> do
+                let dir = root </> fromFilePath ".haskell-agent"
+                    path = projectSettingsPath root
+                createDirectoryIfMissing True dir
+                LBS.writeFile
+                    (toFilePath path)
+                    "{\"version\":1,\"autoApprove\":true,\"lastModel\":{\"provider\":\"openrouter\",\"model\":\"openai/gpt-5.1\"}}"
+
+                settings <- loadProjectSettings root
+                settings.settingsAutoApprove `shouldBe` True
+                projectModelFor OpenRouterProvider settings
+                    `shouldBe` Just "openai/gpt-5.1"
+                projectDialectFor OpenRouterProvider settings
+                    `shouldBe` Just GrokBuildDialect
+                fmap (.projectModelTransportName) settings.settingsLastModel
+                    `shouldBe` Just Nothing
 
         it "loads legacy settings without a remembered model" $
             withTempDir "agent-project-" \root -> do
@@ -97,6 +126,32 @@ spec = describe "Agent.CLI.Project" do
                 LBS.writeFile
                     (toFilePath path)
                     "{\"version\":1,\"autoApprove\":true}"
+
+                settings <- loadProjectSettings root
+                settings.settingsAutoApprove `shouldBe` True
+                settings.settingsLastModel `shouldBe` Nothing
+
+        it "ignores an unknown remembered dialect without resetting approval" $
+            withTempDir "agent-project-" \root -> do
+                let dir = root </> fromFilePath ".haskell-agent"
+                    path = projectSettingsPath root
+                createDirectoryIfMissing True dir
+                LBS.writeFile
+                    (toFilePath path)
+                    "{\"version\":1,\"autoApprove\":true,\"lastModel\":{\"provider\":\"openrouter\",\"model\":\"openai/gpt-5.1\",\"dialect\":\"retired\"}}"
+
+                settings <- loadProjectSettings root
+                settings.settingsAutoApprove `shouldBe` True
+                settings.settingsLastModel `shouldBe` Nothing
+
+        it "ignores an incompatible remembered dialect" $
+            withTempDir "agent-project-" \root -> do
+                let dir = root </> fromFilePath ".haskell-agent"
+                    path = projectSettingsPath root
+                createDirectoryIfMissing True dir
+                LBS.writeFile
+                    (toFilePath path)
+                    "{\"version\":1,\"autoApprove\":true,\"lastModel\":{\"provider\":\"openai\",\"model\":\"gpt-5.6-luna\",\"dialect\":\"grok-build\"}}"
 
                 settings <- loadProjectSettings root
                 settings.settingsAutoApprove `shouldBe` True

--- a/packages/agent-cli/test/Agent/CLI/PromptSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/PromptSpec.hs
@@ -1,6 +1,11 @@
 module Agent.CLI.PromptSpec (spec) where
 
 import Agent.CLI.Prompt
+import Agent.Dialect
+    ( codexDialect
+    , genericResponsesDialect
+    , grokBuildDialect
+    )
 import System.OsPath (unsafeEncodeUtf)
 import Agent.Provider (Provider(..))
 import Data.Time.Calendar (fromGregorian)
@@ -13,8 +18,18 @@ spec :: Spec
 spec = describe "systemPrompt" do
     it "names grok-build tools for xAI and Codex tools for OpenAI" do
         let day = fromGregorian 2026 8 19
-            grok = systemPrompt XAIProvider (fromFilePath "/tmp/repo") day False
-            openai = systemPrompt OpenAIProvider (fromFilePath "/tmp/repo") day False
+            grok =
+                systemPrompt
+                    grokBuildDialect
+                    (fromFilePath "/tmp/repo")
+                    day
+                    False
+            openai =
+                systemPrompt
+                    codexDialect
+                    (fromFilePath "/tmp/repo")
+                    day
+                    False
         grok `shouldSatisfy` Text.isInfixOf "read_file"
         grok `shouldSatisfy` Text.isInfixOf "search_replace"
         grok `shouldSatisfy` Text.isInfixOf "run_terminal_cmd"
@@ -42,17 +57,61 @@ spec = describe "systemPrompt" do
         openai `shouldSatisfy` Text.isInfixOf "<proposed_plan>"
         grok `shouldSatisfy` Text.isInfixOf "2026-08-19"
         grok `shouldSatisfy` Text.isInfixOf "/tmp/repo"
-        let openrouter = systemPrompt OpenRouterProvider (fromFilePath "/tmp/repo") day False
-        openrouter `shouldSatisfy` Text.isInfixOf "read_file"
-        openrouter `shouldNotSatisfy` Text.isInfixOf "apply_patch"
+
+    it "uses a neutral identity for generic Responses models" do
+        let generic =
+                systemPrompt
+                    genericResponsesDialect
+                    (fromFilePath "/tmp/repo")
+                    (fromGregorian 2026 8 19)
+                    False
+        generic `shouldSatisfy` Text.isInfixOf "interactive coding agent"
+        generic `shouldSatisfy` Text.isInfixOf "read_file"
+        generic `shouldNotSatisfy` Text.isInfixOf "Grok released by xAI"
 
     it "uses the autonomous identity for one-shot Grok sessions" do
-        let grok = systemPrompt XAIProvider (fromFilePath "/tmp/repo") (fromGregorian 2026 8 19) True
+        let grok =
+                systemPrompt
+                    grokBuildDialect
+                    (fromFilePath "/tmp/repo")
+                    (fromGregorian 2026 8 19)
+                    True
         grok `shouldSatisfy` Text.isInfixOf "no human operator"
+
+    it "renders restricted Grok child prompts from the registered tools" do
+        let prompt =
+                systemPromptForTools
+                    grokBuildDialect
+                    ["read_file", "list_dir", "grep"]
+                    (fromFilePath "/tmp/repo")
+                    (fromGregorian 2026 8 19)
+                    True
+        prompt `shouldSatisfy` Text.isInfixOf "read_file"
+        prompt `shouldSatisfy` Text.isInfixOf "web_search"
+        prompt `shouldNotSatisfy` Text.isInfixOf "search_replace"
+        prompt `shouldNotSatisfy` Text.isInfixOf "run_terminal_cmd"
+        prompt `shouldNotSatisfy` Text.isInfixOf "run_ghci"
+        prompt `shouldNotSatisfy` Text.isInfixOf "<background_tasks>"
+        prompt `shouldNotSatisfy` Text.isInfixOf "<plan_mode>"
+
+    it "renders restricted generic child prompts without unavailable tools" do
+        let prompt =
+                systemPromptForTools
+                    genericResponsesDialect
+                    ["read_file", "list_dir", "grep"]
+                    (fromFilePath "/tmp/repo")
+                    (fromGregorian 2026 8 19)
+                    True
+        prompt `shouldSatisfy` Text.isInfixOf "read_file"
+        prompt `shouldSatisfy` Text.isInfixOf "web_search"
+        prompt `shouldNotSatisfy` Text.isInfixOf "search_replace"
+        prompt `shouldNotSatisfy` Text.isInfixOf "run_terminal_cmd"
+        prompt `shouldNotSatisfy` Text.isInfixOf "run_ghci"
+        prompt `shouldNotSatisfy` Text.isInfixOf "Prefer ghci for scripting"
 
     it "keeps OpenAI web-search references internal" do
         let openai =
-                systemPrompt OpenAIProvider
+                systemPrompt codexDialect
                     (fromFilePath "/tmp/repo")
                     (fromGregorian 2026 8 19)
                     False
@@ -62,8 +121,18 @@ spec = describe "systemPrompt" do
 
     it "tells grok and openai to prefer ghci for general-purpose scripting" do
         let day = fromGregorian 2026 8 19
-            grok = systemPrompt XAIProvider (fromFilePath "/tmp/repo") day False
-            openai = systemPrompt OpenAIProvider (fromFilePath "/tmp/repo") day False
+            grok =
+                systemPrompt
+                    grokBuildDialect
+                    (fromFilePath "/tmp/repo")
+                    day
+                    False
+            openai =
+                systemPrompt
+                    codexDialect
+                    (fromFilePath "/tmp/repo")
+                    day
+                    False
         grok `shouldSatisfy` Text.isInfixOf "Prefer ghci for scripting"
         grok `shouldSatisfy` Text.isInfixOf "Time context:"
         openai `shouldSatisfy` Text.isInfixOf "Time context:"

--- a/packages/agent-cli/test/Agent/CLI/ProviderTransitionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ProviderTransitionSpec.hs
@@ -3,6 +3,7 @@ module Agent.CLI.ProviderTransitionSpec (spec) where
 import Agent.CLI.Models (ModelOption(..))
 import Agent.CLI.Options (CliOptions(..), defaultCliOptions, isOneShot)
 import Agent.CLI.ProviderTransition
+import Agent.Dialect (DialectId(..))
 import Agent.Provider (BillingMode(..), Provider(..))
 import Agent.Tools.PlanMode (PlanModeState(..))
 import Data.Text (Text)
@@ -59,6 +60,8 @@ transition sessionId pending = ProviderTransition
     { transitionTarget = ModelOption
         { modelProvider = OpenAIProvider
         , modelId = "gpt-5.6-sol"
+        , modelTransportId = "gpt-5.6-sol"
+        , modelDialect = CodexDialect
         , modelLabel = Nothing
         }
     , transitionAccountSelectionId = Nothing

--- a/packages/agent-cli/test/Agent/CLI/ReplStatusSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ReplStatusSpec.hs
@@ -24,6 +24,7 @@ import Agent.CLI.ReplMode
     , cycleReplMode
     , replModeFromState
     )
+import Agent.Dialect (DialectId(..))
 import Agent.Loop (LoopEvent(..), TokenUsage(..), emptyTokenUsage)
 import Agent.Provider (Provider(..))
 import Agent.Responses.Types (defaultResponseCreateParams)
@@ -57,18 +58,37 @@ spec = do
                     accountSwitchTarget
                         OpenAIProvider
                         "gpt-5.6-sol"
+                        "gpt-5.6-sol"
+                        CodexDialect
                         XAIProvider
             target.modelProvider `shouldBe` XAIProvider
             target.modelId `shouldBe` "grok-4.6"
+            target.modelDialect `shouldBe` GrokBuildDialect
 
         it "keeps the current model when only the account backend restarts" do
             let target =
                     accountSwitchTarget
                         OpenAIProvider
                         "gpt-5.6-sol"
+                        "gpt-5.6-sol"
+                        CodexDialect
                         OpenAIProvider
             target.modelProvider `shouldBe` OpenAIProvider
             target.modelId `shouldBe` "gpt-5.6-sol"
+            target.modelDialect `shouldBe` CodexDialect
+
+        it "preserves a legacy OpenRouter dialect on an account restart" do
+            let target =
+                    accountSwitchTarget
+                        OpenRouterProvider
+                        "openai/gpt-5.1"
+                        "openai/gpt-5.1"
+                        GrokBuildDialect
+                        OpenRouterProvider
+            target.modelProvider `shouldBe` OpenRouterProvider
+            target.modelId `shouldBe` "openai/gpt-5.1"
+            target.modelTransportId `shouldBe` "openai/gpt-5.1"
+            target.modelDialect `shouldBe` GrokBuildDialect
 
     describe "devArgs" do
         it "starts fresh REPL sessions on gpt-5.6-sol in yolo mode" do

--- a/packages/agent-cli/test/Agent/CLI/ResumeSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ResumeSpec.hs
@@ -2,7 +2,12 @@ module Agent.CLI.ResumeSpec (spec) where
 
 import Agent.CLI.Picker (PickerKey(..))
 import Agent.CLI.Resume
-import Agent.CLI.Session (SessionMeta(..), SessionTurn(..))
+import Agent.CLI.Session
+    ( LegacySubagentTarget(..)
+    , SessionMeta(..)
+    , SessionTurn(..)
+    )
+import Agent.Dialect (DialectId(..))
 import System.OsPath (unsafeEncodeUtf)
 import Agent.Provider (Provider(..))
 import Data.Time.Clock (addUTCTime)
@@ -183,6 +188,13 @@ sampleMeta sid title =
         , metaUpdatedAt = posixSecondsToUTCTime 0
         , metaProvider = XAIProvider
         , metaModel = "grok-4.6"
+        , metaTransportModel = Just "grok-4.6"
+        , metaDialect = GrokBuildDialect
+        , metaLegacySubagentTarget = Just LegacySubagentTarget
+            { legacyTargetProvider = XAIProvider
+            , legacyTargetEffectiveModel = "grok-4.6"
+            , legacyTargetDialect = GrokBuildDialect
+            }
         , metaCwd = fromFilePath "/tmp/repo"
         , metaEffort = "high"
         , metaTitle = title

--- a/packages/agent-cli/test/Agent/CLI/SessionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SessionSpec.hs
@@ -2,6 +2,7 @@ module Agent.CLI.SessionSpec (spec) where
 
 import Agent.CLI.Session
 import Agent.CLI.SessionLock
+import Agent.Dialect (DialectId(..))
 import Agent.Loop (TokenUsage(..))
 import Agent.Responses.Types
 import System.OsPath (OsPath, decodeUtf, unsafeEncodeUtf)
@@ -9,6 +10,7 @@ import Agent.Provider (Provider(..))
 import Control.Exception (bracket)
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy as LBS
 import Data.IORef
 import qualified Data.Text as Text
 import Data.Time.Calendar (fromGregorian)
@@ -102,6 +104,13 @@ spec = describe "Agent.CLI.Session" do
                         meta.metaId `shouldBe` handle.sessionMeta.metaId
                         meta.metaProvider `shouldBe` XAIProvider
                         meta.metaModel `shouldBe` "grok-4"
+                        meta.metaDialect `shouldBe` GrokBuildDialect
+                        meta.metaLegacySubagentTarget
+                            `shouldBe` Just LegacySubagentTarget
+                                { legacyTargetProvider = XAIProvider
+                                , legacyTargetEffectiveModel = "grok-4"
+                                , legacyTargetDialect = GrokBuildDialect
+                                }
                         meta.metaCwd `shouldBe` fromFilePath "/tmp/work"
                         case turns of
                             [loadedTurn] -> do
@@ -293,6 +302,97 @@ spec = describe "Agent.CLI.Session" do
                             , cachedTokens = 42
                             }
 
+        it "round-trips an explicit OpenRouter dialect" $
+            withTempDir "agent-sessions-" \root -> do
+                handle <- createSession $
+                    (testCreate root)
+                        { createProvider = OpenRouterProvider
+                        , createModel = "openai/gpt-5.1"
+                        , createTransportModel = "openai/gpt-5.1"
+                        , createDialect = CodexDialect
+                        }
+                loadSession root handle.sessionMeta.metaId >>= \case
+                    Left err -> expectationFailure (Text.unpack err)
+                    Right (meta, _) -> do
+                        meta.metaDialect `shouldBe` CodexDialect
+                        meta.metaTransportModel
+                            `shouldBe` Just "openai/gpt-5.1"
+
+        it "decodes legacy OpenRouter metadata with the old Grok dialect" $
+            withTempDir "agent-sessions-" \root -> do
+                handle <- createSession $
+                    (testCreate root)
+                        { createProvider = OpenRouterProvider
+                        , createModel = "openai/gpt-5.1"
+                        , createTransportModel = "openai/gpt-5.1"
+                        , createDialect = CodexDialect
+                        }
+                rewriteMetaObject handle.sessionMetaPath $
+                    KeyMap.delete "legacySubagentTarget"
+                        . KeyMap.delete "transportModel"
+                        . KeyMap.delete "dialect"
+                loadSession root handle.sessionMeta.metaId >>= \case
+                    Left err -> expectationFailure (Text.unpack err)
+                    Right (meta, _) -> do
+                        meta.metaDialect `shouldBe` GrokBuildDialect
+                        meta.metaTransportModel `shouldBe` Nothing
+                        meta.metaLegacySubagentTarget `shouldBe` Nothing
+                        sessionLegacySubagentTarget meta
+                            `shouldBe` LegacySubagentTarget
+                                { legacyTargetProvider = OpenRouterProvider
+                                , legacyTargetEffectiveModel =
+                                    "openai/gpt-5.1"
+                                , legacyTargetDialect = GrokBuildDialect
+                                }
+
+        it "keeps legacy child provenance after the root target changes" $
+            withTempDir "agent-sessions-" \root -> do
+                handle <- createSession $
+                    (testCreate root)
+                        { createProvider = OpenRouterProvider
+                        , createModel = "openai/gpt-5.1"
+                        , createTransportModel = "openai/gpt-5.1"
+                        , createDialect = CodexDialect
+                        }
+                let legacyTarget =
+                        sessionLegacySubagentTarget handle.sessionMeta
+                    retargeted = handle.sessionMeta
+                        { metaModel = "x-ai/grok-4"
+                        , metaTransportModel = Just "x-ai/grok-4"
+                        , metaDialect = GrokBuildDialect
+                        , metaLegacySubagentTarget = Just legacyTarget
+                        }
+                writeSessionMeta handle.sessionMetaPath retargeted
+                loadSession root handle.sessionMeta.metaId >>= \case
+                    Left err -> expectationFailure (Text.unpack err)
+                    Right (meta, _) -> do
+                        meta.metaDialect `shouldBe` GrokBuildDialect
+                        sessionLegacySubagentTarget meta
+                            `shouldBe` legacyTarget
+
+        it "rejects an explicit unknown session dialect" $
+            withTempDir "agent-sessions-" \root -> do
+                handle <- createSession (testCreate root)
+                rewriteMetaObject handle.sessionMetaPath $
+                    KeyMap.insert "dialect" (Aeson.String "retired")
+                loadSession root handle.sessionMeta.metaId >>= \case
+                    Left err ->
+                        err `shouldSatisfy` Text.isInfixOf "unknown dialect"
+                    Right _ ->
+                        expectationFailure "expected dialect decode failure"
+
+        it "rejects a dialect incompatible with the persisted provider" $
+            withTempDir "agent-sessions-" \root -> do
+                handle <- createSession (testCreate root)
+                rewriteMetaObject handle.sessionMetaPath $
+                    KeyMap.insert "dialect" (Aeson.String "codex")
+                loadSession root handle.sessionMeta.metaId >>= \case
+                    Left err ->
+                        err `shouldSatisfy` Text.isInfixOf "incompatible"
+                    Right _ ->
+                        expectationFailure
+                            "expected provider/dialect compatibility failure"
+
         it "rejects unsupported schema versions" $
             withTempDir "agent-sessions-" \root -> do
                 handle <- createSession (testCreate root)
@@ -396,11 +496,29 @@ testCreate root = SessionCreate
     { createRoot = root
     , createProvider = XAIProvider
     , createModel = "grok-4"
+    , createTransportModel = "grok-4"
+    , createDialect = GrokBuildDialect
     , createCwd = fromFilePath "/tmp/work"
     , createEffort = "low"
     , createTitleHint = Nothing
     , createTitleIsManual = False
     }
+
+rewriteMetaObject
+    :: OsPath
+    -> (KeyMap.KeyMap Aeson.Value -> KeyMap.KeyMap Aeson.Value)
+    -> IO ()
+rewriteMetaObject path update = do
+    bytes <- LBS.readFile (toFilePath path)
+    case Aeson.eitherDecode' bytes of
+        Right (Aeson.Object object) ->
+            LBS.writeFile
+                (toFilePath path)
+                (Aeson.encode (Aeson.Object (update object)))
+        Right other ->
+            expectationFailure ("expected metadata object, got " <> show other)
+        Left err ->
+            expectationFailure ("failed to decode metadata: " <> err)
 
 fixedTime :: UTCTime
 fixedTime = UTCTime (fromGregorian 2026 8 19) (secondsToDiffTime 0)

--- a/packages/agent-cli/test/Agent/CLI/SubagentStoreSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SubagentStoreSpec.hs
@@ -1,6 +1,10 @@
 module Agent.CLI.SubagentStoreSpec (spec) where
 
 import Agent.CLI.SubagentStore
+import Agent.CLI.Subagents.Runtime (validatePersistedSubagentTarget)
+import Agent.CLI.Session (LegacySubagentTarget(..))
+import Agent.Dialect (DialectId(..))
+import Agent.Provider (Provider(..))
 import Agent.Responses.Types
 import System.OsPath (OsPath, decodeUtf, unsafeEncodeUtf)
 import Agent.Subagents
@@ -40,7 +44,8 @@ spec = describe "Agent.CLI.SubagentStore" do
             Right taskPath <- pure (parseTaskPath "/root/research/worker")
             let identity = SubagentIdentity (Just parentId) 2 taskPath
             saveSubagentState dir agentId [item] (Just "resp-1")
-                (Completed (Just "done")) (Just "explore")
+                (Completed (Just "done")) XAIProvider "grok-4.5-mini"
+                GrokBuildDialect (Just "explore")
                 (Just "grok-4.5-mini") (Just "high")
                 (Just (fromFilePath "/tmp/work"))
                 (Just identity)
@@ -51,6 +56,9 @@ spec = describe "Agent.CLI.SubagentStore" do
                     length items `shouldBe` 1
                     meta.diskPreviousResponseId `shouldBe` Just "resp-1"
                     meta.diskStatus `shouldBe` Just (Completed (Just "done"))
+                    meta.diskProvider `shouldBe` Just XAIProvider
+                    meta.diskEffectiveModel `shouldBe` Just "grok-4.5-mini"
+                    meta.diskDialect `shouldBe` Just GrokBuildDialect
                     meta.diskAgentType `shouldBe` Just "explore"
                     meta.diskAgentModel `shouldBe` Just "grok-4.5-mini"
                     meta.diskReasoningEffort `shouldBe` Just "high"
@@ -76,6 +84,7 @@ spec = describe "Agent.CLI.SubagentStore" do
         withTempDir \dir -> do
             let agentId = SubagentId "agent-legacy-1"
             saveSubagentState dir agentId [] (Just "legacy") Interrupted
+                XAIProvider "grok-4.6" GrokBuildDialect
                 Nothing Nothing Nothing Nothing Nothing
                 `shouldReturn` Right ()
             Right path <- pure (subagentStoreDir dir agentId)
@@ -89,12 +98,16 @@ spec = describe "Agent.CLI.SubagentStore" do
                     meta.diskParentId `shouldBe` Nothing
                     meta.diskDepth `shouldBe` Nothing
                     meta.diskStatus `shouldBe` Nothing
+                    meta.diskProvider `shouldBe` Nothing
+                    meta.diskEffectiveModel `shouldBe` Nothing
+                    meta.diskDialect `shouldBe` Nothing
                 other -> expectationFailure ("unexpected load: " <> show other)
 
     it "fails closed on corrupt transcript JSON" do
         withTempDir \dir -> do
             let agentId = SubagentId "agent-corrupt-1"
             saveSubagentState dir agentId [] (Just "r") Interrupted
+                OpenAIProvider "gpt-5.6-luna" CodexDialect
                 Nothing Nothing Nothing Nothing Nothing
                 `shouldReturn` Right ()
             Right path <- pure (subagentStoreDir dir agentId)
@@ -118,6 +131,94 @@ spec = describe "Agent.CLI.SubagentStore" do
             `shouldBe` drop 2 items
         forkSubagentTranscript (Just "18446744073709551617") items
             `shouldBe` items
+
+    describe "validatePersistedSubagentTarget" do
+        it "accepts a matching provider, effective model, and dialect" do
+            validatePersistedSubagentTarget
+                OpenRouterProvider
+                "openai/gpt-5.1"
+                CodexDialect
+                Nothing
+                persistedMeta
+                `shouldBe` Right ("openai/gpt-5.1", CodexDialect)
+
+        it "rejects an inherited child after the parent target changes" do
+            validatePersistedSubagentTarget
+                OpenRouterProvider
+                "anthropic/claude-sonnet-4"
+                GenericResponsesDialect
+                Nothing
+                persistedMeta
+                `shouldSatisfy` isLeft
+
+        it "rejects transport-specific child models after a provider change" do
+            validatePersistedSubagentTarget
+                OpenAIProvider
+                "openai/gpt-5.1"
+                CodexDialect
+                Nothing
+                persistedMeta
+                `shouldSatisfy` isLeft
+
+        it "accepts missing target metadata only in legacy-compatible sessions" do
+            validatePersistedSubagentTarget
+                OpenRouterProvider
+                "openai/gpt-5.1"
+                GrokBuildDialect
+                (Just legacyTarget)
+                legacyMeta
+                `shouldBe` Right ("openai/gpt-5.1", GrokBuildDialect)
+            validatePersistedSubagentTarget
+                OpenRouterProvider
+                "openai/gpt-5.1"
+                GrokBuildDialect
+                Nothing
+                legacyMeta
+                `shouldSatisfy` isLeft
+
+        it "rejects legacy metadata after a durable root target change" do
+            validatePersistedSubagentTarget
+                OpenRouterProvider
+                "anthropic/claude-sonnet-4"
+                GenericResponsesDialect
+                (Just legacyTarget)
+                legacyMeta
+                `shouldSatisfy` isLeft
+
+legacyTarget :: LegacySubagentTarget
+legacyTarget = LegacySubagentTarget
+    { legacyTargetProvider = OpenRouterProvider
+    , legacyTargetEffectiveModel = "openai/gpt-5.1"
+    , legacyTargetDialect = GrokBuildDialect
+    }
+
+persistedMeta :: SubagentDiskMeta
+persistedMeta = legacyMeta
+    { diskProvider = Just OpenRouterProvider
+    , diskEffectiveModel = Just "openai/gpt-5.1"
+    , diskDialect = Just CodexDialect
+    }
+
+legacyMeta :: SubagentDiskMeta
+legacyMeta = SubagentDiskMeta
+    { diskPreviousResponseId = Nothing
+    , diskStatus = Nothing
+    , diskProvider = Nothing
+    , diskEffectiveModel = Nothing
+    , diskDialect = Nothing
+    , diskAgentType = Nothing
+    , diskAgentModel = Nothing
+    , diskReasoningEffort = Nothing
+    , diskCwd = Nothing
+    , diskTaskPath = Nothing
+    , diskParentId = Nothing
+    , diskDepth = Nothing
+    }
+
+isLeft :: Either a b -> Bool
+isLeft = \case
+    Left _ -> True
+    Right _ -> False
 
 messageItem :: ResponseRole -> Text -> ResponseItem
 messageItem role text = MessageItem ResponseMessage

--- a/packages/agent-cli/test/Agent/CLI/ToolsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ToolsSpec.hs
@@ -1,9 +1,9 @@
 module Agent.CLI.ToolsSpec (spec) where
 
 import Agent.CLI.Tools
+import Agent.Dialect (codexDialect, grokBuildDialect)
 import Agent.Loop (LoopError(..))
 import Agent.Responses.Types
-import Agent.Provider (Provider(..))
 import Agent.Subagents
     ( closeSubagentRegistry
     , defaultSubagentConfig
@@ -34,21 +34,21 @@ import Test.Hspec
 spec :: Spec
 spec = describe "schemasFromAppTools" do
     it "enables built-in web_search ahead of app tools" do
-        case schemasFromAppTools OpenAIProvider [jsonTool] of
+        case schemasFromAppTools codexDialect [jsonTool] of
             KnownResponseTool ToolWebSearch tagged : _ -> do
                 tagged.tag `shouldBe` "web_search"
                 tagged.fields `shouldBe` KeyMap.empty
             other -> expectationFailure ("expected web_search first, got " <> show other)
 
     it "builds a strict function tool for OpenAI JSON tools" do
-        case schemasFromAppTools OpenAIProvider [jsonTool] of
+        case schemasFromAppTools codexDialect [jsonTool] of
             [_, FunctionToolValue tool] -> do
                 tool.name `shouldBe` "read_file"
                 tool.strict `shouldBe` Just True
             other -> expectationFailure ("expected function tool, got " <> show other)
 
     it "builds a loose grok-build function tool for xAI" do
-        case schemasFromAppTools XAIProvider [jsonTool] of
+        case schemasFromAppTools grokBuildDialect [jsonTool] of
             [_, FunctionToolValue tool] -> do
                 tool.name `shouldBe` "read_file"
                 tool.strict `shouldBe` Nothing
@@ -57,7 +57,7 @@ spec = describe "schemasFromAppTools" do
             other -> expectationFailure ("expected function tool, got " <> show other)
 
     it "registers apply_patch as a custom Lark tool" do
-        case schemasFromAppTools OpenAIProvider [patchTool] of
+        case schemasFromAppTools codexDialect [patchTool] of
             [_, KnownResponseTool ToolCustom tagged] -> do
                 tagged.tag `shouldBe` "custom"
                 KeyMap.lookup "name" tagged.fields
@@ -79,7 +79,7 @@ spec = describe "schemasFromAppTools" do
                 [ PropertySchema "message" PropertyString False Nothing ]
                 AlwaysPrompt
                 (noArgsTool "spawn_agent" (pure (Right "ok")))
-        case schemasFromAppTools OpenAIProvider [jsonTool, spawn] of
+        case schemasFromAppTools codexDialect [jsonTool, spawn] of
             [_, FunctionToolValue _, KnownResponseTool ToolNamespace tagged] -> do
                 tagged.tag `shouldBe` "namespace"
                 KeyMap.lookup "name" tagged.fields
@@ -91,7 +91,7 @@ spec = describe "schemasFromAppTools" do
                 [ PropertySchema "timeout_ms" PropertyNumber False Nothing ]
                 AlwaysReadOnly
                 (noArgsTool "wait_agent" (pure (Right "ok")))
-        case schemasFromAppTools OpenAIProvider [wait] of
+        case schemasFromAppTools codexDialect [wait] of
             [_, KnownResponseTool ToolNamespace tagged] ->
                 case KeyMap.lookup "tools" tagged.fields of
                     Just (Aeson.Array tools) -> case toList tools of
@@ -130,7 +130,7 @@ spec = describe "schemasFromAppTools" do
                         [ tagged
                         | KnownResponseTool ToolNamespace tagged <-
                             schemasFromAppTools
-                                OpenAIProvider
+                                codexDialect
                                 (multiAgentTools context)
                         ]
                 case namespaces of

--- a/packages/agent-core/README.md
+++ b/packages/agent-core/README.md
@@ -4,6 +4,9 @@ Provider-neutral infrastructure shared by the harness transports:
 
 - `Agent.Error` defines the common transport and provider error channel.
 - `Agent.Provider` owns credentials, account-failure feedback, and failover.
+- `Agent.Dialect` describes the model-facing prompt, tool surface, schema
+  convention, project-instruction format, and child-agent protocol separately
+  from provider transport.
 - `Agent.Loop` runs the provider-neutral tool-calling agent loop. Transport
   adapters live in `agent-openai` (`Agent.OpenAI.LoopBackend`), `agent-xai`
   (`Agent.XAI.LoopBackend`), and `agent-openrouter`
@@ -11,7 +14,8 @@ Provider-neutral infrastructure shared by the harness transports:
 - `Agent.ToolArgs` parses model-supplied JSON tool arguments.
 - `Agent.ToolDSL` owns JSON Schema fragments for function-tool parameters.
 - `Agent.ToolDispatch` decodes and runs provider-neutral application tools.
-- `Agent.Tools` / `Agent.Tools.Grok` register grok-build coding tools
+- `Agent.Tools` selects a dialect tool surface. `Agent.Tools.Grok` registers
+  grok-build coding tools
   (`read_file`, `grep`, `list_dir`, `search_replace`, `run_terminal_cmd`).
 - `Agent.Tools.Codex` registers Codex tools (`shell_command`, `apply_patch`,
   `update_plan`). `apply_patch` is the Codex freeform patch language.

--- a/packages/agent-core/agent-core.cabal
+++ b/packages/agent-core/agent-core.cabal
@@ -39,6 +39,7 @@ library
     import:           common-opts
     exposed-modules:  Agent.Auth.JWT
                     , Agent.Cancel
+                    , Agent.Dialect
                     , Agent.Error
                     , Agent.FileRetry
                     , Agent.InterAgentMessage
@@ -131,6 +132,7 @@ test-suite agent-core-test
     main-is:          Spec.hs
     other-modules:    Agent.Auth.JWTSpec
                     , Agent.CancelSpec
+                    , Agent.DialectSpec
                     , Agent.ErrorSpec
                     , Agent.Http.HeaderSpec
                     , Agent.LoopSpec

--- a/packages/agent-core/src/Agent/Dialect.hs
+++ b/packages/agent-core/src/Agent/Dialect.hs
@@ -1,0 +1,230 @@
+-- | The model-facing agent protocol, separate from provider transport.
+--
+-- A provider owns authentication, billing, endpoints, request projection, and
+-- streaming. A dialect owns the prompt and tool conventions a model sees.
+module Agent.Dialect
+    ( DialectId(..)
+    , Dialect
+    , dialectId
+    , dialectToolSurface
+    , dialectFunctionSchemaStyle
+    , dialectToolLayout
+    , dialectPromptStyle
+    , dialectProjectInstructionStyle
+    , dialectInstructionHomeStyle
+    , dialectChildAgentProtocol
+    , ToolSurface(..)
+    , FunctionSchemaStyle(..)
+    , ToolLayout(..)
+    , PromptStyle(..)
+    , ProjectInstructionStyle(..)
+    , InstructionHomeStyle(..)
+    , ChildAgentProtocol(..)
+    , codexDialect
+    , grokBuildDialect
+    , genericResponsesDialect
+    , dialectForId
+    , dialectIdForModel
+    , dialectForModel
+    , legacyDialectIdForProvider
+    , providerSupportsDialect
+    , dialectSlug
+    , parseDialect
+    ) where
+
+import Agent.Provider (Provider(..))
+import Data.Text (Text)
+import qualified Data.Text as Text
+
+-- | Stable identity persisted in session and project metadata.
+data DialectId
+    = CodexDialect
+    | GrokBuildDialect
+    | GenericResponsesDialect
+    deriving (Eq, Ord, Show)
+
+-- | Runtime tool implementation family.
+--
+-- The generic Responses dialect initially uses the portable Grok-style
+-- function tool surface without Grok's identity prompt.
+data ToolSurface
+    = CodexToolSurface
+    | GrokBuildToolSurface
+    deriving (Eq, Show)
+
+-- | JSON function-schema convention presented to the model.
+data FunctionSchemaStyle
+    = StrictFunctionSchemas
+    | LooseFunctionSchemas
+    deriving (Eq, Show)
+
+-- | Whether model-facing tools are flat or grouped into a namespace.
+data ToolLayout
+    = FlatToolLayout
+    | CollaborationNamespaceLayout
+    deriving (Eq, Show)
+
+-- | Base system-prompt family.
+data PromptStyle
+    = CodexPromptStyle
+    | GrokBuildPromptStyle
+    | GenericResponsesPromptStyle
+    deriving (Eq, Show)
+
+-- | How discovered project instructions are presented to the model.
+data ProjectInstructionStyle
+    = CodexProjectInstructions
+    | GrokProjectInstructions
+    deriving (Eq, Show)
+
+-- | Compatibility directory used for global project instructions.
+data InstructionHomeStyle
+    = CodexInstructionHome
+    | GrokInstructionHome
+    | HarnessInstructionHome
+    deriving (Eq, Show)
+
+-- | Model-facing child-agent tool and prompt protocol.
+data ChildAgentProtocol
+    = CodexCollaborationProtocol
+    | GrokTaskProtocol
+    | GenericTaskProtocol
+    deriving (Eq, Show)
+
+-- | Complete static selection of model-facing behavior.
+--
+-- Effectful tools are constructed later from 'dialectToolSurface'; they
+-- cannot be stored directly because they own shell, GHCi, plan-mode, and
+-- subagent resources.
+data Dialect = Dialect
+    { dialectId :: !DialectId
+    , dialectToolSurface :: !ToolSurface
+    , dialectFunctionSchemaStyle :: !FunctionSchemaStyle
+    , dialectToolLayout :: !ToolLayout
+    , dialectPromptStyle :: !PromptStyle
+    , dialectProjectInstructionStyle :: !ProjectInstructionStyle
+    , dialectInstructionHomeStyle :: !InstructionHomeStyle
+    , dialectChildAgentProtocol :: !ChildAgentProtocol
+    }
+    deriving (Eq, Show)
+
+dialectId :: Dialect -> DialectId
+dialectId Dialect{dialectId = value} = value
+
+dialectToolSurface :: Dialect -> ToolSurface
+dialectToolSurface Dialect{dialectToolSurface = value} = value
+
+dialectFunctionSchemaStyle :: Dialect -> FunctionSchemaStyle
+dialectFunctionSchemaStyle Dialect{dialectFunctionSchemaStyle = value} = value
+
+dialectToolLayout :: Dialect -> ToolLayout
+dialectToolLayout Dialect{dialectToolLayout = value} = value
+
+dialectPromptStyle :: Dialect -> PromptStyle
+dialectPromptStyle Dialect{dialectPromptStyle = value} = value
+
+dialectProjectInstructionStyle :: Dialect -> ProjectInstructionStyle
+dialectProjectInstructionStyle Dialect{dialectProjectInstructionStyle = value} =
+    value
+
+dialectInstructionHomeStyle :: Dialect -> InstructionHomeStyle
+dialectInstructionHomeStyle Dialect{dialectInstructionHomeStyle = value} = value
+
+dialectChildAgentProtocol :: Dialect -> ChildAgentProtocol
+dialectChildAgentProtocol Dialect{dialectChildAgentProtocol = value} = value
+
+codexDialect :: Dialect
+codexDialect = Dialect
+    { dialectId = CodexDialect
+    , dialectToolSurface = CodexToolSurface
+    , dialectFunctionSchemaStyle = StrictFunctionSchemas
+    , dialectToolLayout = CollaborationNamespaceLayout
+    , dialectPromptStyle = CodexPromptStyle
+    , dialectProjectInstructionStyle = CodexProjectInstructions
+    , dialectInstructionHomeStyle = CodexInstructionHome
+    , dialectChildAgentProtocol = CodexCollaborationProtocol
+    }
+
+grokBuildDialect :: Dialect
+grokBuildDialect = Dialect
+    { dialectId = GrokBuildDialect
+    , dialectToolSurface = GrokBuildToolSurface
+    , dialectFunctionSchemaStyle = LooseFunctionSchemas
+    , dialectToolLayout = FlatToolLayout
+    , dialectPromptStyle = GrokBuildPromptStyle
+    , dialectProjectInstructionStyle = GrokProjectInstructions
+    , dialectInstructionHomeStyle = GrokInstructionHome
+    , dialectChildAgentProtocol = GrokTaskProtocol
+    }
+
+genericResponsesDialect :: Dialect
+genericResponsesDialect = Dialect
+    { dialectId = GenericResponsesDialect
+    , dialectToolSurface = GrokBuildToolSurface
+    , dialectFunctionSchemaStyle = LooseFunctionSchemas
+    , dialectToolLayout = FlatToolLayout
+    , dialectPromptStyle = GenericResponsesPromptStyle
+    , dialectProjectInstructionStyle = GrokProjectInstructions
+    , dialectInstructionHomeStyle = HarnessInstructionHome
+    , dialectChildAgentProtocol = GenericTaskProtocol
+    }
+
+dialectForId :: DialectId -> Dialect
+dialectForId = \case
+    CodexDialect -> codexDialect
+    GrokBuildDialect -> grokBuildDialect
+    GenericResponsesDialect -> genericResponsesDialect
+
+-- | Resolve the default dialect for a provider/model target.
+--
+-- OpenRouter is a transport for several model families, so its dialect is
+-- selected from the model slug rather than from the provider alone.
+dialectIdForModel :: Provider -> Text -> DialectId
+dialectIdForModel provider model = case provider of
+    OpenAIProvider -> CodexDialect
+    XAIProvider -> GrokBuildDialect
+    OpenRouterProvider
+        | "x-ai/" `Text.isPrefixOf` normalized -> GrokBuildDialect
+        | "openai/" `Text.isPrefixOf` normalized -> CodexDialect
+        | otherwise -> GenericResponsesDialect
+  where
+    normalized = Text.toLower (Text.strip model)
+
+dialectForModel :: Provider -> Text -> Dialect
+dialectForModel provider =
+    dialectForId . dialectIdForModel provider
+
+-- | Dialect used before dialect identity was persisted explicitly.
+--
+-- OpenRouter historically always used the Grok Build surface, including for
+-- OpenAI-family model slugs. Legacy sessions must preserve that contract.
+legacyDialectIdForProvider :: Provider -> DialectId
+legacyDialectIdForProvider = \case
+    OpenAIProvider -> CodexDialect
+    XAIProvider -> GrokBuildDialect
+    OpenRouterProvider -> GrokBuildDialect
+
+-- | Whether a provider transport can carry a model-facing dialect.
+--
+-- Direct provider transports expose one native contract. OpenRouter can host
+-- models from all supported families, so the model target selects its dialect.
+providerSupportsDialect :: Provider -> DialectId -> Bool
+providerSupportsDialect provider dialect = case provider of
+    OpenAIProvider -> dialect == CodexDialect
+    XAIProvider -> dialect == GrokBuildDialect
+    OpenRouterProvider -> True
+
+dialectSlug :: DialectId -> Text
+dialectSlug = \case
+    CodexDialect -> "codex"
+    GrokBuildDialect -> "grok-build"
+    GenericResponsesDialect -> "generic-responses"
+
+parseDialect :: Text -> Maybe DialectId
+parseDialect raw = case Text.toLower (Text.strip raw) of
+    "codex" -> Just CodexDialect
+    "grok-build" -> Just GrokBuildDialect
+    "grok" -> Just GrokBuildDialect
+    "generic-responses" -> Just GenericResponsesDialect
+    "generic" -> Just GenericResponsesDialect
+    _ -> Nothing

--- a/packages/agent-core/src/Agent/ProjectInstructions.hs
+++ b/packages/agent-core/src/Agent/ProjectInstructions.hs
@@ -14,12 +14,18 @@ module Agent.ProjectInstructions
     , loadedInstructionFiles
     , formatCodexAgentsMd
     , formatGrokAgentsMd
-    , formatAgentsMdForProvider
+    , formatAgentsMdForDialect
     , globalAgentsHomeDir
     ) where
 
 import Agent.FileRetry (retryOnFileBusy)
-import Agent.Provider (Provider(..))
+import Agent.Dialect
+    ( Dialect
+    , InstructionHomeStyle(..)
+    , ProjectInstructionStyle(..)
+    , dialectInstructionHomeStyle
+    , dialectProjectInstructionStyle
+    )
 import Agent.OsPath (directoryChain, toText, unsafeToFilePath)
 import Control.Exception.Safe (tryAny)
 import qualified Data.ByteString as BS
@@ -68,12 +74,13 @@ defaultDiscoverOptions = DiscoverOptions
     , discoverRootMarkers = [unsafeEncodeUtf ".git"]
     }
 
--- | Provider-specific directory under the user home for global AGENTS.md.
-globalAgentsHomeDir :: Provider -> OsPath -> OsPath
-globalAgentsHomeDir provider home = case provider of
-    OpenAIProvider -> home </> unsafeEncodeUtf ".codex"
-    XAIProvider -> home </> unsafeEncodeUtf ".grok"
-    OpenRouterProvider -> home </> unsafeEncodeUtf ".grok"
+-- | Dialect compatibility directory under the user home for global AGENTS.md.
+globalAgentsHomeDir :: Dialect -> OsPath -> OsPath
+globalAgentsHomeDir dialect home =
+    home </> case dialectInstructionHomeStyle dialect of
+        CodexInstructionHome -> unsafeEncodeUtf ".codex"
+        GrokInstructionHome -> unsafeEncodeUtf ".grok"
+        HarnessInstructionHome -> unsafeEncodeUtf ".haskell-agent"
 
 -- | Load global + project AGENTS.md files for @cwd@. Empty / unreadable files
 -- are skipped. Project files are ordered root -> cwd.
@@ -151,11 +158,11 @@ applyByteBudget maxBytes loaded =
                             (BS.take remaining encoded)
                     in [file { instructionContent = truncated }]
 
-formatAgentsMdForProvider :: Provider -> OsPath -> LoadedAgentsMd -> Maybe Text
-formatAgentsMdForProvider provider cwd loaded = case provider of
-    OpenAIProvider -> formatCodexAgentsMd cwd loaded
-    XAIProvider -> formatGrokAgentsMd loaded
-    OpenRouterProvider -> formatGrokAgentsMd loaded
+formatAgentsMdForDialect :: Dialect -> OsPath -> LoadedAgentsMd -> Maybe Text
+formatAgentsMdForDialect dialect cwd loaded =
+    case dialectProjectInstructionStyle dialect of
+        CodexProjectInstructions -> formatCodexAgentsMd cwd loaded
+        GrokProjectInstructions -> formatGrokAgentsMd loaded
 
 -- | Codex-style contextual user fragment.
 formatCodexAgentsMd :: OsPath -> LoadedAgentsMd -> Maybe Text

--- a/packages/agent-core/src/Agent/Tools.hs
+++ b/packages/agent-core/src/Agent/Tools.hs
@@ -29,7 +29,11 @@ module Agent.Tools
     , filterChildGrokTools
     ) where
 
-import Agent.Provider (Provider(..))
+import Agent.Dialect
+    ( Dialect
+    , ToolSurface(..)
+    , dialectToolSurface
+    )
 import Agent.ResourceScope
     ( allocateResource
     , closeResourceScope
@@ -66,34 +70,32 @@ data CodingTools = CodingTools
 -- persistent cwd/environment shell state. 'codingClose' closes owned sessions;
 -- run it in 'finally'.
 codingToolsFor
-    :: Provider
+    :: Dialect
     -> ToolEnv
     -> Maybe PlanModeHooks
     -> Maybe MultiAgentContext
     -> IO CodingTools
-codingToolsFor provider env hooks multi = do
+codingToolsFor dialect env hooks multi = do
     typesRef <- newIORef Map.empty
-    codingToolsForWithTypes provider env hooks multi typesRef
+    codingToolsForWithTypes dialect env hooks multi typesRef
 
 -- | Same as 'codingToolsFor', but reuses an existing agent-type map so the
 -- host can wire resume-from-disk before tools are built.
 codingToolsForWithTypes
-    :: Provider
+    :: Dialect
     -> ToolEnv
     -> Maybe PlanModeHooks
     -> Maybe MultiAgentContext
     -> GrokSubagentSpecs
     -> IO CodingTools
-codingToolsForWithTypes provider env hooks multi typesRef = do
+codingToolsForWithTypes dialect env hooks multi typesRef = do
     resources <- newResourceScope
     flip onException (closeResourceScope resources) do
         plan <- newPlanModeEnv env.toolCwd hooks
-        case provider of
-            XAIProvider ->
+        case dialectToolSurface dialect of
+            GrokBuildToolSurface ->
                 grokCodingTools resources plan
-            OpenRouterProvider ->
-                grokCodingTools resources plan
-            OpenAIProvider -> do
+            CodexToolSurface -> do
                 (_, shellSession) <- allocateResource resources
                     (newCodexShellSession env)
                     closeCodexShellSession

--- a/packages/agent-core/src/Agent/Tools/Grok/Prompt.hs
+++ b/packages/agent-core/src/Agent/Tools/Grok/Prompt.hs
@@ -7,6 +7,7 @@ module Agent.Tools.Grok.Prompt
     ( GrokPromptTools(..)
     , codingGrokPromptTools
     , grokSystemPrompt
+    , grokSystemPromptForTools
     ) where
 
 import Agent.OsPath (toText)
@@ -57,6 +58,28 @@ grokSystemPrompt tools cwd today isNonInteractive =
         , formatting
         ]
 
+-- | Render the prompt against the tools actually registered for a child.
+-- Sections and individual instructions that require absent tools are omitted.
+grokSystemPromptForTools
+    :: GrokPromptTools
+    -> [Text]
+    -> OsPath
+    -> Day
+    -> Bool
+    -> Text
+grokSystemPromptForTools tools available cwd today isNonInteractive =
+    Text.intercalate "\n\n" $
+        filter (not . Text.null)
+            [ identity tools isNonInteractive
+            , environment cwd today
+            , workPolicy
+            , toolCallingForTools tools available
+            , backgroundTasksForTools tools available
+            , planModeForTools tools available
+            , communication
+            , formatting
+            ]
+
 identity :: GrokPromptTools -> Bool -> Text
 identity _ isNonInteractive =
     "You are Grok released by xAI. You are "
@@ -104,6 +127,32 @@ toolCalling tools =
     \- Do not mention tools this session does not register.\n\
     \</tool_calling>"
 
+toolCallingForTools :: GrokPromptTools -> [Text] -> Text
+toolCallingForTools tools available =
+    taggedSection "tool_calling" $
+        [ "- Use specialized tools instead of shell commands when possible."
+        ]
+            <> toolLine tools.grokRead
+                ("- Use `" <> tools.grokRead <> "` to read files.")
+            <> toolLine tools.grokEdit
+                ("- Use `" <> tools.grokEdit <> "` for focused file edits.")
+            <> toolLine tools.grokSearch
+                ("- Use `" <> tools.grokSearch <> "` to search file contents.")
+            <> toolLine tools.grokList
+                ("- Use `" <> tools.grokList <> "` to list directories.")
+            <> toolLine tools.grokExecute
+                ( "- Reserve `"
+                    <> tools.grokExecute
+                    <> "` for system commands and terminal operations."
+                )
+            <> toolLine "web_search"
+                "- Use `web_search` to look up current public information on the internet."
+            <> ["- Do not mention tools this session does not register."]
+  where
+    toolLine name line
+        | name `elem` available = [line]
+        | otherwise = []
+
 backgroundTasks :: GrokPromptTools -> Text
 backgroundTasks tools =
     "<background_tasks>\n\
@@ -118,6 +167,28 @@ backgroundTasks tools =
         <> "` to stop a background task.\n\
     \</background_tasks>"
 
+backgroundTasksForTools :: GrokPromptTools -> [Text] -> Text
+backgroundTasksForTools tools available
+    | null linesForTools = ""
+    | otherwise = taggedSection "background_tasks" linesForTools
+  where
+    linesForTools =
+        toolLine tools.grokExecute
+            ( "- Run long-lived commands as background commands in `"
+                <> tools.grokExecute
+                <> "` and continue independent work."
+            )
+            <> toolLine tools.grokGetOutput
+                ( "- Use `"
+                    <> tools.grokGetOutput
+                    <> "` for a snapshot or one bounded wait, not repeated polling."
+                )
+            <> toolLine tools.grokKill
+                ("- Use `" <> tools.grokKill <> "` to stop a background task.")
+    toolLine name line
+        | name `elem` available = [line]
+        | otherwise = []
+
 planMode :: GrokPromptTools -> Text
 planMode tools =
     "<plan_mode>\n\
@@ -131,6 +202,38 @@ planMode tools =
         <> tools.grokExitPlan
         <> "` so the user can approve, request changes, or cancel.\n\
     \</plan_mode>"
+
+planModeForTools :: GrokPromptTools -> [Text] -> Text
+planModeForTools tools available
+    | null linesForTools = ""
+    | otherwise = taggedSection "plan_mode" linesForTools
+  where
+    linesForTools =
+        toolLine tools.grokEnterPlan
+            ( "- For genuinely ambiguous architectural work, call `"
+                <> tools.grokEnterPlan
+                <> "` to request Plan Mode."
+            )
+            <> toolLine tools.grokAskUser
+                ( "- While planning, use `"
+                    <> tools.grokAskUser
+                    <> "` when clarification is required."
+                )
+            <> toolLine tools.grokExitPlan
+                ( "- When the plan is ready, call `"
+                    <> tools.grokExitPlan
+                    <> "` for user review."
+                )
+    toolLine name line
+        | name `elem` available = [line]
+        | otherwise = []
+
+taggedSection :: Text -> [Text] -> Text
+taggedSection tagName body =
+    Text.unlines $
+        ["<" <> tagName <> ">"]
+            <> body
+            <> ["</" <> tagName <> ">"]
 
 communication :: Text
 communication = Text.unlines

--- a/packages/agent-core/src/Agent/Tools/Grok/Task.hs
+++ b/packages/agent-core/src/Agent/Tools/Grok/Task.hs
@@ -310,41 +310,52 @@ resumeTask
     -> IO (Either Text Text)
 resumeTask ctx typesRef args resumeId = do
     let agentId = SubagentId resumeId
-    _ <- case ctx.multiResumeFromDisk of
+    restored <- case ctx.multiResumeFromDisk of
         Just restore -> restore agentId
         Nothing -> pure (Right ())
-    status <- getStatus ctx.multiRegistry agentId
-    case status of
-        NotFound -> pure (Left ("unknown subagent id: " <> resumeId))
-        Closed -> pure (Left "cannot resume a closed subagent; it must still be open (completed).")
-        Running -> pure (Left "cannot resume_from a running subagent; wait for it to finish first.")
-        Pending -> pure (Left "cannot resume_from a pending subagent; wait for it to finish first.")
-        _ -> do
-            mtype <- lookupAgentType typesRef agentId
-            case mtype of
-                Just prior
-                    | prior /= args.subagentType ->
-                        pure $ Left $
-                            "resume_from subagent_type mismatch: source is "
-                                <> prior
-                                <> ", requested "
-                                <> args.subagentType
+    case restored of
+        Left err -> pure (Left err)
+        Right () -> do
+            status <- getStatus ctx.multiRegistry agentId
+            case status of
+                NotFound -> pure (Left ("unknown subagent id: " <> resumeId))
+                Closed -> pure (Left "cannot resume a closed subagent; it must still be open (completed).")
+                Running -> pure (Left "cannot resume_from a running subagent; wait for it to finish first.")
+                Pending -> pure (Left "cannot resume_from a pending subagent; wait for it to finish first.")
                 _ -> do
-                    recordAgentType typesRef agentId args.subagentType
-                    rootTurnId <- ctx.multiRootTurnId
-                    sent <- sendInputMessageForTurn ctx.multiRegistry rootTurnId
-                        ctx.multiTaskPath agentId
-                        (plainInterAgentContent args.prompt) False
-                    case sent of
-                        Left err -> pure (Left err)
-                        Right _ ->
-                            if args.runInBackground
-                                then pure $ Right $ formatTaskStarted agentId args Nothing
-                                else do
-                                    (statuses, timedOut) <-
-                                        waitSubagents ctx.multiRegistry [agentId] defaultWaitTimeoutMs
-                                    pure $ Right $ formatTaskCompleted agentId args Nothing timedOut
-                                        (Map.lookup agentId statuses)
+                    mtype <- lookupAgentType typesRef agentId
+                    case mtype of
+                        Just prior
+                            | prior /= args.subagentType ->
+                                pure $ Left $
+                                    "resume_from subagent_type mismatch: source is "
+                                        <> prior
+                                        <> ", requested "
+                                        <> args.subagentType
+                        _ -> do
+                            recordAgentType typesRef agentId args.subagentType
+                            rootTurnId <- ctx.multiRootTurnId
+                            sent <- sendInputMessageForTurn ctx.multiRegistry rootTurnId
+                                ctx.multiTaskPath agentId
+                                (plainInterAgentContent args.prompt) False
+                            case sent of
+                                Left err -> pure (Left err)
+                                Right _ ->
+                                    if args.runInBackground
+                                        then pure $ Right $ formatTaskStarted agentId args Nothing
+                                        else do
+                                            (statuses, timedOut) <-
+                                                waitSubagents
+                                                    ctx.multiRegistry
+                                                    [agentId]
+                                                    defaultWaitTimeoutMs
+                                            pure $ Right $
+                                                formatTaskCompleted
+                                                    agentId
+                                                    args
+                                                    Nothing
+                                                    timedOut
+                                                    (Map.lookup agentId statuses)
 
 formatTaskStarted :: SubagentId -> TaskArgs -> Maybe OsPath -> Text
 formatTaskStarted agentId args worktreePath =

--- a/packages/agent-core/test/Agent/DialectSpec.hs
+++ b/packages/agent-core/test/Agent/DialectSpec.hs
@@ -1,0 +1,117 @@
+module Agent.DialectSpec (spec) where
+
+import Agent.Dialect
+import Agent.Provider (Provider(..))
+import Test.Hspec
+
+spec :: Spec
+spec = describe "Agent.Dialect" do
+    describe "dialect slugs" do
+        it "round-trips every persisted dialect identity" do
+            map (parseDialect . dialectSlug)
+                [CodexDialect, GrokBuildDialect, GenericResponsesDialect]
+                `shouldBe`
+                    map Just
+                        [CodexDialect, GrokBuildDialect, GenericResponsesDialect]
+
+        it "accepts compatibility aliases and normalized input" do
+            parseDialect " CODEX " `shouldBe` Just CodexDialect
+            parseDialect "grok" `shouldBe` Just GrokBuildDialect
+            parseDialect "generic" `shouldBe` Just GenericResponsesDialect
+            parseDialect "unknown" `shouldBe` Nothing
+
+    describe "model resolution" do
+        it "uses provider-native dialects for direct transports" do
+            dialectIdForModel OpenAIProvider "arbitrary-model"
+                `shouldBe` CodexDialect
+            dialectIdForModel XAIProvider "arbitrary-model"
+                `shouldBe` GrokBuildDialect
+
+        it "selects OpenRouter dialects from the model family" do
+            dialectIdForModel OpenRouterProvider "openai/gpt-5.1"
+                `shouldBe` CodexDialect
+            dialectIdForModel OpenRouterProvider " X-AI/GROK-4 "
+                `shouldBe` GrokBuildDialect
+            map (dialectIdForModel OpenRouterProvider)
+                [ "anthropic/claude-sonnet-4"
+                , "google/gemini-2.5-pro"
+                , "stealth/ox-alpha"
+                ]
+                `shouldBe` replicate 3 GenericResponsesDialect
+
+        it "resolves the executable profile from the same identity" do
+            dialectForModel OpenRouterProvider "x-ai/grok-4"
+                `shouldBe` dialectForId GrokBuildDialect
+            dialectForModel OpenRouterProvider "anthropic/claude-sonnet-4"
+                `shouldBe` dialectForId GenericResponsesDialect
+
+    describe "legacy provider mapping" do
+        it "preserves the dialect used before explicit persistence" do
+            legacyDialectIdForProvider OpenAIProvider `shouldBe` CodexDialect
+            legacyDialectIdForProvider XAIProvider `shouldBe` GrokBuildDialect
+            legacyDialectIdForProvider OpenRouterProvider
+                `shouldBe` GrokBuildDialect
+
+    describe "provider compatibility" do
+        it "keeps direct transports on their native dialect" do
+            providerSupportsDialect OpenAIProvider CodexDialect
+                `shouldBe` True
+            providerSupportsDialect OpenAIProvider GrokBuildDialect
+                `shouldBe` False
+            providerSupportsDialect XAIProvider GrokBuildDialect
+                `shouldBe` True
+            providerSupportsDialect XAIProvider GenericResponsesDialect
+                `shouldBe` False
+
+        it "allows OpenRouter to carry every supported model dialect" do
+            map (providerSupportsDialect OpenRouterProvider)
+                [CodexDialect, GrokBuildDialect, GenericResponsesDialect]
+                `shouldBe` replicate 3 True
+
+    describe "static profiles" do
+        it "defines the Codex model-facing contract" do
+            dialectProfile codexDialect `shouldBe`
+                ( CodexDialect
+                , CodexToolSurface
+                , StrictFunctionSchemas
+                , CollaborationNamespaceLayout
+                , CodexPromptStyle
+                , CodexProjectInstructions
+                , CodexInstructionHome
+                , CodexCollaborationProtocol
+                )
+
+        it "defines the Grok Build model-facing contract" do
+            dialectProfile grokBuildDialect `shouldBe`
+                ( GrokBuildDialect
+                , GrokBuildToolSurface
+                , LooseFunctionSchemas
+                , FlatToolLayout
+                , GrokBuildPromptStyle
+                , GrokProjectInstructions
+                , GrokInstructionHome
+                , GrokTaskProtocol
+                )
+
+        it "defines the portable generic Responses contract" do
+            dialectProfile genericResponsesDialect `shouldBe`
+                ( GenericResponsesDialect
+                , GrokBuildToolSurface
+                , LooseFunctionSchemas
+                , FlatToolLayout
+                , GenericResponsesPromptStyle
+                , GrokProjectInstructions
+                , HarnessInstructionHome
+                , GenericTaskProtocol
+                )
+
+dialectProfile dialect =
+    ( dialectId dialect
+    , dialectToolSurface dialect
+    , dialectFunctionSchemaStyle dialect
+    , dialectToolLayout dialect
+    , dialectPromptStyle dialect
+    , dialectProjectInstructionStyle dialect
+    , dialectInstructionHomeStyle dialect
+    , dialectChildAgentProtocol dialect
+    )

--- a/packages/agent-core/test/Agent/ProjectInstructionsSpec.hs
+++ b/packages/agent-core/test/Agent/ProjectInstructionsSpec.hs
@@ -1,8 +1,12 @@
 module Agent.ProjectInstructionsSpec (spec) where
 
+import Agent.Dialect
+    ( codexDialect
+    , genericResponsesDialect
+    , grokBuildDialect
+    )
 import Agent.ProjectInstructions
 import System.OsPath (unsafeEncodeUtf)
-import Agent.Provider (Provider(..))
 import Control.Concurrent (forkIO, threadDelay)
 import Control.Exception.Safe (bracket)
 import qualified Data.Text as Text
@@ -175,27 +179,27 @@ spec = describe "Agent.ProjectInstructions" do
                 Nothing ->
                     expectationFailure "expected rendered Grok instructions"
 
-    describe "formatAgentsMdForProvider" do
-        it "picks Codex formatting for OpenAI and Grok formatting otherwise" do
+    describe "formatAgentsMdForDialect" do
+        it "picks the instruction format declared by the dialect" do
             let loaded = LoadedAgentsMd
                     { loadedGlobal = Nothing
                     , loadedProject = [InstructionFile (fromFilePath "/repo/AGENTS.md") "x"]
                     }
-            formatAgentsMdForProvider OpenAIProvider (fromFilePath "/repo") loaded
+            formatAgentsMdForDialect codexDialect (fromFilePath "/repo") loaded
                 `shouldSatisfy` maybe False (Text.isPrefixOf "# AGENTS.md instructions")
-            formatAgentsMdForProvider XAIProvider (fromFilePath "/repo") loaded
+            formatAgentsMdForDialect grokBuildDialect (fromFilePath "/repo") loaded
                 `shouldSatisfy` maybe False (Text.isInfixOf "<system-reminder>")
-            formatAgentsMdForProvider OpenRouterProvider (fromFilePath "/repo") loaded
+            formatAgentsMdForDialect genericResponsesDialect (fromFilePath "/repo") loaded
                 `shouldSatisfy` maybe False (Text.isInfixOf "<system-reminder>")
 
     describe "globalAgentsHomeDir" do
-        it "uses ~/.codex for OpenAI and ~/.grok for the others" do
-            globalAgentsHomeDir OpenAIProvider (fromFilePath "/home/u")
+        it "uses the compatibility directory declared by the dialect" do
+            globalAgentsHomeDir codexDialect (fromFilePath "/home/u")
                 `shouldBe` fromFilePath "/home/u/.codex"
-            globalAgentsHomeDir XAIProvider (fromFilePath "/home/u")
+            globalAgentsHomeDir grokBuildDialect (fromFilePath "/home/u")
                 `shouldBe` fromFilePath "/home/u/.grok"
-            globalAgentsHomeDir OpenRouterProvider (fromFilePath "/home/u")
-                `shouldBe` fromFilePath "/home/u/.grok"
+            globalAgentsHomeDir genericResponsesDialect (fromFilePath "/home/u")
+                `shouldBe` fromFilePath "/home/u/.haskell-agent"
 
 checkLockedInstructions :: FilePath -> IO ()
 checkLockedInstructions dir = do

--- a/packages/agent-core/test/Agent/ToolDSLSpec.hs
+++ b/packages/agent-core/test/Agent/ToolDSLSpec.hs
@@ -60,6 +60,22 @@ spec = do
                     (fromGregorian 2026 8 20) True
             prompt `shouldSatisfy` Text.isInfixOf "no human operator"
 
+        it "omits sections and names for tools unavailable to a child" do
+            let prompt =
+                    grokSystemPromptForTools
+                        codingGrokPromptTools
+                        ["read_file", "list_dir", "grep", "web_search"]
+                        (fromFilePath "/tmp/repo")
+                        (fromGregorian 2026 8 20)
+                        True
+            prompt `shouldSatisfy` Text.isInfixOf "read_file"
+            prompt `shouldSatisfy` Text.isInfixOf "web_search"
+            prompt `shouldNotSatisfy` Text.isInfixOf "search_replace"
+            prompt `shouldNotSatisfy` Text.isInfixOf "run_terminal_cmd"
+            prompt `shouldNotSatisfy` Text.isInfixOf "get_task_output"
+            prompt `shouldNotSatisfy` Text.isInfixOf "<background_tasks>"
+            prompt `shouldNotSatisfy` Text.isInfixOf "<plan_mode>"
+
 propertyType :: Text -> Aeson.Object -> Maybe Aeson.Value
 propertyType name object = do
     Aeson.Object properties <- KeyMap.lookup "properties" object

--- a/packages/agent-core/test/Agent/Tools/CodexSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/CodexSpec.hs
@@ -1,11 +1,11 @@
 module Agent.Tools.CodexSpec (spec) where
 
+import Agent.Dialect (codexDialect)
 import Agent.Loop (LoopError(..), defaultLoopDispatch)
 import System.OsPath (decodeUtf, unsafeEncodeUtf)
 import Agent.Subagents (closeSubagentRegistry, defaultSubagentConfig, newSubagentRegistry)
 import Agent.Subagents.TaskPath (taskPathRoot)
 import Agent.Tools.MultiAgents (MultiAgentContext(..))
-import Agent.Provider (Provider(..))
 import Agent.ToolDispatch
     ( ToolCallResult(..)
     , customToolCall
@@ -53,7 +53,7 @@ spec = describe "Agent.Tools.Codex" do
     it "advertises Codex wire names and not Grok names" do
         withTempEnv \env -> do
             -- create a throwaway ghci for schema listing; codingToolsFor owns lifecycle
-            coding <- codingToolsFor OpenAIProvider env Nothing Nothing
+            coding <- codingToolsFor codexDialect env Nothing Nothing
             let names = map (.appToolName) coding.codingAppTools
             names `shouldBe`
                 [ "read_file"
@@ -88,7 +88,7 @@ spec = describe "Agent.Tools.Codex" do
                     , multiPrepareSpawn = Nothing
                     , multiSendToRoot = Nothing
                     }
-            coding <- codingToolsFor OpenAIProvider env Nothing (Just ctx)
+            coding <- codingToolsFor codexDialect env Nothing (Just ctx)
             let names = map (.appToolName) coding.codingAppTools
             names `shouldContain` ["spawn_agent", "wait_agent", "send_message", "followup_task", "list_agents", "interrupt_agent"]
             let parameters name =
@@ -429,7 +429,7 @@ spec = describe "Agent.Tools.Codex" do
     it "stops managed shell commands when coding tools close" do
         withTempEnv \env -> do
             let marker = toFilePath env.toolCwd </> "escaped"
-            coding <- codingToolsFor OpenAIProvider env Nothing Nothing
+            coding <- codingToolsFor codexDialect env Nothing Nothing
             started <- runFnWith coding.codingAppTools "shell_command" $
                 "{\"command\":\"sleep 0.3; printf done > "
                     <> Text.pack marker

--- a/packages/agent-core/test/Agent/Tools/GhciSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/GhciSpec.hs
@@ -1,9 +1,9 @@
 module Agent.Tools.GhciSpec (spec) where
 
 import Agent.Cancel (requestCancel, resetCancel)
+import Agent.Dialect (codexDialect)
 import Agent.Loop (defaultLoopDispatch)
 import System.OsPath (decodeUtf, unsafeEncodeUtf)
-import Agent.Provider (Provider(..))
 import Agent.ToolDispatch (ToolCallResult(..), dispatchToolCall, functionToolCall)
 import Agent.Tools (CodingTools(..), appToolHandlers, codingToolsFor, defaultToolEnv)
 import Agent.Tools.Ghci
@@ -235,7 +235,7 @@ spec = describe "Agent.Tools.Ghci" do
 
     it "is registered for OpenAI via codingToolsFor" do
         withTempEnv \env -> do
-            coding <- codingToolsFor OpenAIProvider env Nothing Nothing
+            coding <- codingToolsFor codexDialect env Nothing Nothing
             map (.appToolName) coding.codingAppTools `shouldContain` ["run_ghci"]
             coding.codingClose
 

--- a/packages/agent-core/test/Agent/Tools/Grok/TaskSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/Grok/TaskSpec.hs
@@ -81,6 +81,24 @@ spec = describe "Agent.Tools.Grok.Task" do
         lookupAgentReasoningEffort specsRef agentId
             `shouldReturn` Just "high"
 
+    it "propagates restore failures for resume_from" do
+        registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
+            (\_ _ _ _ -> pure $ Left LoopNoResponseId)
+            (\_ _ -> pure ())
+        typesRef <- newIORef Map.empty
+        let restore _ =
+                pure (Left "persisted subagent dialect is incompatible")
+            ctx = MultiAgentContext registry Nothing 0 taskPathRoot
+                (pure Nothing) (Just restore) Nothing Nothing Nothing
+            tool = taskTool (fromFilePath "/tmp") ctx typesRef
+        result <- dispatchToolCall defaultLoopDispatch [tool.appToolHandler]
+            (functionToolCall "c1" "task"
+                "{\"prompt\":\"continue\",\"description\":\"resume\",\
+                \\"resume_from\":\"agent-old\",\"subagent_type\":\"explore\"}")
+        result.output `shouldSatisfy`
+            Text.isInfixOf "persisted subagent dialect is incompatible"
+        closeSubagentRegistry registry
+
     it "filters explore tools to the Grok Build read-only set" do
         let tools =
                 [ fake "read_file"

--- a/packages/agent-core/test/Agent/Tools/GrokSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/GrokSpec.hs
@@ -1,8 +1,8 @@
 module Agent.Tools.GrokSpec (spec) where
 
+import Agent.Dialect (genericResponsesDialect, grokBuildDialect)
 import Agent.Loop (LoopError(..), defaultLoopDispatch)
 import System.OsPath (decodeUtf, unsafeEncodeUtf)
-import Agent.Provider (Provider(..))
 import Agent.Subagents (SubagentId, closeSubagentRegistry, defaultSubagentConfig, newSubagentRegistry)
 import Agent.ToolDispatch (ToolCallResult(..), dispatchToolCall, functionToolCall)
 import Agent.ToolDSL (PropertySchema(..))
@@ -69,12 +69,14 @@ spec = describe "Agent.Tools.Grok" do
                     ]
             map (map (.propertyName)) outputSchemas
                 `shouldBe` [["task_ids", "timeout_ms"]]
-            xai <- codingToolsFor XAIProvider session.grokEnv Nothing Nothing
-            openrouter <- codingToolsFor OpenRouterProvider session.grokEnv Nothing Nothing
+            grok <- codingToolsFor grokBuildDialect session.grokEnv Nothing Nothing
+            generic <-
+                codingToolsFor
+                    genericResponsesDialect session.grokEnv Nothing Nothing
             (do
-                map (.appToolName) xai.codingAppTools `shouldBe` names
-                map (.appToolName) openrouter.codingAppTools `shouldBe` names)
-                `finally` (xai.codingClose >> openrouter.codingClose)
+                map (.appToolName) grok.codingAppTools `shouldBe` names
+                map (.appToolName) generic.codingAppTools `shouldBe` names)
+                `finally` (grok.codingClose >> generic.codingClose)
 
 
     it "registers task when a multi-agent context is provided" do

--- a/packages/agent-core/test/Spec.hs
+++ b/packages/agent-core/test/Spec.hs
@@ -2,6 +2,7 @@ module Main (main) where
 
 import qualified Agent.Auth.JWTSpec as JWTSpec
 import qualified Agent.CancelSpec as CancelSpec
+import qualified Agent.DialectSpec as DialectSpec
 import qualified Agent.ErrorSpec as ErrorSpec
 import qualified Agent.Http.HeaderSpec as HttpHeaderSpec
 import qualified Agent.JsonTextSpec as JsonTextSpec
@@ -33,6 +34,7 @@ main :: IO ()
 main = hspec do
     JWTSpec.spec
     CancelSpec.spec
+    DialectSpec.spec
     ErrorSpec.spec
     HttpHeaderSpec.spec
     JsonTextSpec.spec

--- a/packages/agent-openrouter/test/Agent/OpenRouter/RequestSpec.hs
+++ b/packages/agent-openrouter/test/Agent/OpenRouter/RequestSpec.hs
@@ -62,6 +62,31 @@ spec = do
             Maybe.mapMaybe (KeyMap.lookup "external_web_access") toolObjects `shouldBe`
                 [Aeson.Bool True]
 
+        it "preserves Codex custom and namespace tools" do
+            let codexTools =
+                    [ KnownResponseTool ToolCustom TaggedObject
+                        { tag = "custom"
+                        , fields = KeyMap.singleton
+                            "name"
+                            (Aeson.String "apply_patch")
+                        }
+                    , KnownResponseTool ToolNamespace TaggedObject
+                        { tag = "namespace"
+                        , fields = KeyMap.singleton
+                            "name"
+                            (Aeson.String "collaboration")
+                        }
+                    ]
+                request = withTools (Just codexTools) sampleRequest
+            object <- expectObject
+                (requestValue defaultClientOptions request)
+            tools <- expectArray (KeyMap.lookup "tools" object)
+            toolObjects <- traverse expectObject tools
+            map (KeyMap.lookup "type") toolObjects `shouldBe`
+                [ Just (Aeson.String "custom")
+                , Just (Aeson.String "namespace")
+                ]
+
         it "uses the configured default when the request has no model" do
             let value = requestValue defaultClientOptions
                     (withModel Nothing sampleRequest)
@@ -179,6 +204,10 @@ sampleRequest = defaultResponseCreateParams
 withModel :: Maybe Text -> ResponseCreateParams -> ResponseCreateParams
 withModel nextModel ResponseCreateParams { model = _, .. } =
     ResponseCreateParams { model = nextModel, .. }
+
+withTools :: Maybe [ResponseTool] -> ResponseCreateParams -> ResponseCreateParams
+withTools nextTools ResponseCreateParams { tools = _, .. } =
+    ResponseCreateParams { tools = nextTools, .. }
 
 expectObject :: Aeson.Value -> IO Aeson.Object
 expectObject = \case


### PR DESCRIPTION
## Summary

- separate provider transport/auth concerns from a first-class model-facing `Dialect`
- add Codex, Grok Build, and Generic Responses dialect profiles covering prompts, tools, schemas, project instructions, and child-agent protocols
- resolve OpenRouter dialects from the effective transported model and show the resolved dialect in model pickers
- persist dialect and effective model targets across project, root-session, background-session, and subagent state
- rebuild model-facing runtime state when a model switch changes dialect
- preserve legacy OpenRouter behavior while durably preventing incompatible legacy subagent transcripts from being resumed after target changes
- render capability-aware prompts for restricted children while retaining the canonical Codex prompt for Codex children

## Validation

- `nix develop -c cabal test all --test-show-details=never`
- `nix develop -c cabal build exe:agent-cli`
- `git diff --check origin/master...HEAD`
- tmux smoke test of `/model`, including an OpenRouter model-map override resolving `openai/gpt-5.1` to the `grok-build` dialect
