### PR TITLE
Simplify fullscreen sequence access

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
@@ -67,7 +67,6 @@ import Control.Monad.IO.Class (liftIO)
 import Control.Monad.State.Strict (modify')
 import Data.ByteString (ByteString)
 import Data.Char (isControl)
-import Data.Foldable (toList)
 import Data.List (elemIndex, intersperse)
 import Data.Maybe (fromMaybe)
 import Data.Sequence (Seq, ViewL(..), ViewR(..))
@@ -205,9 +204,9 @@ drawSlashRow selected index suggestion =
 
 drawQueuedInputs :: UiState -> Widget Name
 drawQueuedInputs state =
-    case toList state.uiQueuedInputs of
-        [] -> emptyWidget
-        next : _ ->
+    case Seq.viewl state.uiQueuedInputs of
+        EmptyL -> emptyWidget
+        next :< _ ->
             padLeftRight 2 $
                 vLimit 1 $
                     hBox
@@ -711,7 +710,7 @@ handleComposerKey
             case slashMenu of
                 Just menu -> acceptSlash menu
                 Nothing ->
-                    when (not (null (toList ui.uiBlocks))) $
+                    when (not (Seq.null ui.uiBlocks)) $
                         modifyUi (UiFocusChanged FocusScrollback)
         V.EvKey V.KEnter [V.MShift] ->
             insertText "\n"

--- a/packages/agent-tui/src/Agent/TUI/Model.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model.hs
@@ -48,7 +48,6 @@ import Agent.Loop
     , emptyTokenUsage
     )
 import Agent.ToolDispatch (ToolCall(..), ToolCallResult(..))
-import Data.Foldable (toList)
 import qualified Data.Map.Strict as Map
 import Data.Sequence (Seq)
 import qualified Data.Sequence as Seq
@@ -221,7 +220,7 @@ initialUiState = UiState
 -- conversation is still empty from the user's perspective.
 conversationIsEmpty :: UiState -> Bool
 conversationIsEmpty state =
-    all isStartupStatus (toList state.uiBlocks)
+    all isStartupStatus state.uiBlocks
   where
     isStartupStatus block =
         block.blockKind == BlockSystem
@@ -652,21 +651,22 @@ hasAssistantTextSince start =
         (\block ->
             block.blockKind == BlockAssistant
                 && not (Text.null (Text.strip block.blockBody)))
-        . toList
         . Seq.drop start
         . (.uiBlocks)
 
 moveSelection :: Int -> UiState -> UiState
 moveSelection delta state =
-    case toList state.uiBlocks of
-        [] -> state { uiSelectedBlock = Nothing }
-        blocks ->
-            let current = selectedBlockIndex state
-                next = max 0 (min (length blocks - 1) (current + delta))
-            in state
-                { uiSelectedBlock = Just (blocks !! next).blockId
-                , uiFollow = next == length blocks - 1
+    case Seq.lookup next blocks of
+        Nothing -> state { uiSelectedBlock = Nothing }
+        Just block ->
+            state
+                { uiSelectedBlock = Just block.blockId
+                , uiFollow = next == lastIndex
                 }
+  where
+    blocks = state.uiBlocks
+    lastIndex = Seq.length blocks - 1
+    next = max 0 (min lastIndex (selectedBlockIndex state + delta))
 
 selectBlock :: BlockId -> UiState -> UiState
 selectBlock ident state =


### PR DESCRIPTION
## Summary
- traverse retained UI sequences directly instead of converting them to lists
- use safe `Seq.lookup` for block selection and `Seq.viewl` for queued-input rendering
- use `Seq.null` for the fullscreen Tab focus check

## Validation
- `nix develop -c cabal test agent-tui-test agent-cli-test --test-show-details=direct`
  - agent-tui-test: 81 examples, 0 failures
  - agent-cli-test: 621 examples, 0 failures
- `nix develop -c cabal build agent-tui agent-cli`
- `git diff --check`
- live tmux fullscreen smoke check, including Tab switching to scrollback