### PR TITLE
perf(subagents): evict settled transcripts

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -141,6 +141,20 @@ executable agent-cli
     build-depends:    agent-cli
                     , base >= 4.17 && < 5
 
+benchmark subagent-retention-bench
+    import:           common-options
+    type:             exitcode-stdio-1.0
+    hs-source-dirs:   benchmark
+    main-is:          SubagentRetention.hs
+    ghc-options:      -O2 -threaded -rtsopts "-with-rtsopts=-T"
+    build-depends:    agent-cli
+                    , agent-core
+                    , agent-responses
+                    , aeson
+                    , base >= 4.17 && < 5
+                    , containers
+                    , text
+
 test-suite agent-cli-test
     import:           common-options
     type:             exitcode-stdio-1.0
@@ -208,6 +222,7 @@ test-suite agent-cli-test
                     , agent-xai
                     , aeson
                     , ansi-terminal
+                    , async
                     , base >= 4.17 && < 5
                     , brick >= 2.9 && < 3
                     , bytestring

--- a/packages/agent-cli/benchmark/SubagentRetention.hs
+++ b/packages/agent-cli/benchmark/SubagentRetention.hs
@@ -1,0 +1,248 @@
+module Main (main) where
+
+import Agent.CLI.Subagents.Runtime (SubagentSession(..))
+import Agent.Dialect (DialectId(..))
+import Agent.Provider (Provider(..))
+import Agent.Responses.Types
+import Control.Concurrent.MVar (modifyMVar_, newMVar)
+import Control.Exception (evaluate)
+import Control.Monad (forM, forM_)
+import qualified Data.Aeson.KeyMap as KeyMap
+import Data.IORef
+import Data.List (sort)
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import Data.Text (Text)
+import qualified Data.Text as Text
+import GHC.Clock (getMonotonicTimeNSec)
+import GHC.Stats
+    ( GCDetails(..)
+    , RTSStats(..)
+    , getRTSStats
+    , getRTSStatsEnabled
+    )
+import System.CPUTime (getCPUTime)
+import System.Environment (getArgs)
+import System.Exit (die)
+import System.Mem (performGC)
+import Text.Printf (printf)
+
+data Workload
+    = Retained
+    | Evicted
+    deriving (Eq, Show)
+
+data Sample = Sample
+    { elapsedMillis :: !Double
+    , cpuMillis :: !Double
+    , allocatedBytes :: !Integer
+    , liveBytes :: !Integer
+    }
+
+main :: IO ()
+main = do
+    enabled <- getRTSStatsEnabled
+    if enabled
+        then pure ()
+        else die "RTS statistics are disabled; run with +RTS -T"
+    getArgs >>= \case
+        [] -> runMatrix
+        [workloadArg, agentCountArg, itemCountArg, payloadBytesArg, sampleCountArg] -> do
+            workload <- parseWorkload workloadArg
+            agentCount <- parsePositive "agent count" agentCountArg
+            itemCount <- parsePositive "items per agent" itemCountArg
+            payloadBytes <- parsePositive "payload bytes" payloadBytesArg
+            sampleCount <- parsePositive "sample count" sampleCountArg
+            samples <- forM [1 .. sampleCount] \sampleIndex ->
+                measure workload agentCount itemCount payloadBytes sampleIndex
+            let medianSample = median samples
+            printf
+                "%s,%d,%d,%d,%.3f,%.3f,%d,%d\n"
+                workloadArg
+                agentCount
+                itemCount
+                payloadBytes
+                medianSample.elapsedMillis
+                medianSample.cpuMillis
+                medianSample.allocatedBytes
+                medianSample.liveBytes
+        _ ->
+            die $
+                "usage: subagent-retention-bench WORKLOAD AGENTS ITEMS "
+                    <> "PAYLOAD_BYTES SAMPLES\n"
+                    <> "workloads: retained, evicted\n"
+                    <> "output: workload,agents,items,payload_bytes,"
+                    <> "elapsed_ms,cpu_ms,allocated_bytes,live_bytes"
+
+runMatrix :: IO ()
+runMatrix = do
+    putStrLn
+        "workload,agents,items,payload_bytes,elapsed_ms,cpu_ms,allocated_bytes,live_bytes"
+    forM_ [8, 32, 64] \agentCount ->
+        forM_ [Retained, Evicted] \workload -> do
+            -- Warm allocation and GC paths before collecting the five samples.
+            _ <- measure workload agentCount itemCount payloadBytes 0
+            samples <- forM [1 .. sampleCount] \sampleIndex ->
+                measure workload agentCount itemCount payloadBytes sampleIndex
+            printSample workload agentCount itemCount payloadBytes (median samples)
+  where
+    itemCount = 64
+    payloadBytes = 16 * 1024
+    sampleCount = 5
+
+parseWorkload :: String -> IO Workload
+parseWorkload = \case
+    "retained" -> pure Retained
+    "evicted" -> pure Evicted
+    other -> die ("unknown workload: " <> other)
+
+parsePositive :: String -> String -> IO Int
+parsePositive label raw =
+    case reads raw of
+        [(value, "")]
+            | value > 0 -> pure value
+        _ -> die ("invalid " <> label <> ": " <> raw)
+
+measure :: Workload -> Int -> Int -> Int -> Int -> IO Sample
+measure workload agentCount itemCount payloadBytes sampleIndex = do
+    performGC
+    beforeStats <- getRTSStats
+    beforeCpu <- getCPUTime
+    beforeElapsed <- getMonotonicTimeNSec
+    sessions <-
+        buildSessions agentCount itemCount payloadBytes sampleIndex
+    residentChecksum <- checksumSessions sessions
+    _ <- evaluate residentChecksum
+    case workload of
+        Retained -> pure ()
+        Evicted -> evictSessions sessions
+    performGC
+    afterStats <- getRTSStats
+    -- This future traversal keeps the stable session shells live through the
+    -- measured GC; retained mode also keeps every transcript payload live.
+    finalChecksum <- checksumSessions sessions
+    _ <- evaluate finalChecksum
+    afterElapsed <- getMonotonicTimeNSec
+    afterCpu <- getCPUTime
+    pure Sample
+        { elapsedMillis =
+            fromIntegral (afterElapsed - beforeElapsed) / 1.0e6
+        , cpuMillis =
+            fromIntegral (afterCpu - beforeCpu) / 1.0e9
+        , allocatedBytes =
+            fromIntegral
+                (afterStats.allocated_bytes - beforeStats.allocated_bytes)
+        , liveBytes =
+            fromIntegral afterStats.gc.gcdetails_live_bytes
+        }
+
+buildSessions :: Int -> Int -> Int -> Int -> IO (Map Int SubagentSession)
+buildSessions agentCount itemCount payloadBytes sampleIndex =
+    Map.fromList <$> forM [1 .. agentCount] \agentIndex -> do
+        let items =
+                [ messageItem
+                    (itemText sampleIndex agentIndex itemIndex payloadBytes)
+                | itemIndex <- [1 .. itemCount]
+                ]
+        transcript <- newIORef items
+        contextTokens <- newIORef (Just (itemCount, payloadBytes))
+        pinned <- newIORef False
+        hydrated <- newMVar True
+        pure
+            ( agentIndex
+            , SubagentSession
+                { subSessionTranscript = transcript
+                , subSessionContextTokens = contextTokens
+                , subSessionProvider = OpenAIProvider
+                , subSessionEffectiveModel = "gpt-5.6-luna"
+                , subSessionDialect = CodexDialect
+                , subSessionPinned = pinned
+                , subSessionHydrated = hydrated
+                }
+            )
+
+evictSessions :: Map Int SubagentSession -> IO ()
+evictSessions sessions =
+    forM_ (Map.elems sessions) \session ->
+        modifyMVar_ session.subSessionHydrated \_ -> do
+            writeIORef session.subSessionTranscript []
+            writeIORef session.subSessionContextTokens Nothing
+            pure False
+
+checksumSessions :: Map Int SubagentSession -> IO Int
+checksumSessions sessions =
+    foldMStrict 5381 (Map.toList sessions) \checksum (agentIndex, session) -> do
+        items <- readIORef session.subSessionTranscript
+        context <- readIORef session.subSessionContextTokens
+        pure $
+            foldl'
+                checksumItem
+                (checksum * 33 + agentIndex + maybe 0 (uncurry (+)) context)
+                items
+
+checksumItem :: Int -> ResponseItem -> Int
+checksumItem checksum = \case
+    MessageItem message ->
+        Text.foldl'
+            (\value character -> value * 33 + fromEnum character)
+            checksum
+            (messageText message.content)
+    _ -> checksum * 33 + 1
+
+messageText :: MessageContent -> Text
+messageText = \case
+    MessageContentText text -> text
+    MessageContentParts parts ->
+        Text.concat
+            [ text
+            | InputTextPart { text } <- parts
+            ]
+
+messageItem :: Text -> ResponseItem
+messageItem text = MessageItem ResponseMessage
+    { messageId = Nothing
+    , content = MessageContentText text
+    , role = RoleAssistant
+    , status = Nothing
+    , phase = Nothing
+    , extraFields = KeyMap.empty
+    }
+
+itemText :: Int -> Int -> Int -> Int -> Text
+itemText sampleIndex agentIndex itemIndex payloadBytes =
+    Text.pack
+        (show sampleIndex <> ":" <> show agentIndex <> ":" <> show itemIndex <> ":")
+        <> Text.replicate payloadBytes "x"
+
+foldMStrict :: b -> [a] -> (b -> a -> IO b) -> IO b
+foldMStrict initial values step = go initial values
+  where
+    go accumulator = \case
+        [] -> pure accumulator
+        value : rest -> do
+            next <- step accumulator value
+            next `seq` go next rest
+
+median :: [Sample] -> Sample
+median samples =
+    Sample
+        { elapsedMillis = middle (sort (map (.elapsedMillis) samples))
+        , cpuMillis = middle (sort (map (.cpuMillis) samples))
+        , allocatedBytes = middle (sort (map (.allocatedBytes) samples))
+        , liveBytes = middle (sort (map (.liveBytes) samples))
+        }
+  where
+    middle values = values !! (length values `div` 2)
+
+printSample :: Workload -> Int -> Int -> Int -> Sample -> IO ()
+printSample workload agentCount itemCount payloadBytes sample =
+    printf
+        "%s,%d,%d,%d,%.3f,%.3f,%d,%d\n"
+        (case workload of Retained -> "retained"; Evicted -> "evicted" :: String)
+        agentCount
+        itemCount
+        payloadBytes
+        sample.elapsedMillis
+        sample.cpuMillis
+        sample.allocatedBytes
+        sample.liveBytes

--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -216,7 +216,8 @@ import Agent.CLI.Subagents.Runtime
     , SubagentStoreRoot
     , flushAllSubagentSnapshots
     , freshOpenAiBackend
-    , persistSubagentSnapshotWithStatus
+    , lookupOrCreateSubagentSession
+    , persistAndEvictSubagentSessionWithStatus
     , prepareCollaborationSpawn
     , restoreAgentFromDisk
     , runCodexSubagent
@@ -371,13 +372,16 @@ import Agent.Subagents
     , resetSubagentRegistry
     , defaultSubagentConfig
     , formatCompletionNotice
+    , getStatus
     , interruptActiveSubagents
     , listAgents
     , newSubagentRegistry
     , setSubagentOnComplete
+    , setSubagentOnSettled
     , setSubagentRunner
     )
 import Agent.Tools (CodingTools(..), codingToolsForWithTypes)
+import Agent.Tools.Grok.Task (GrokSubagentSpecs)
 import Agent.Subagents.TaskPath (taskPathRoot, taskPathText)
 import Agent.TextBuffer (emptyTextBuffer)
 import Agent.Tools.MultiAgents
@@ -429,7 +433,7 @@ import Control.Exception.Safe
     , throwIO
     , try
     )
-import Control.Monad (forM_, when)
+import Control.Monad (forM_, void, when)
 import qualified Data.ByteString as BS
 import Data.IORef
 import Data.List (elemIndex, findIndex, sortOn)
@@ -1472,16 +1476,19 @@ runAgentInitializedWithLock
         codingToolsForWithTypes
             dialect toolEnv (Just planHooks) multiCtx agentTypesRef
     case multiCtx of
-        Just ctx ->
+        Just ctx -> do
             setSubagentOnComplete ctx.multiRegistry \agentId status -> do
                 atomicModifyIORef' pendingNotices \xs ->
                     (xs <> [UserMessage (formatCompletionNotice agentId status)], ())
+            setSubagentOnSettled ctx.multiRegistry \agentId status -> do
                 sessions <- readIORef subagentSessions
                 case Map.lookup agentId sessions of
-                    Just session ->
-                        persistSubagentSnapshotWithStatus
-                            subagentStoreRoot ctx.multiRegistry agentTypesRef
-                            agentId status session
+                    Just session -> do
+                        _ <-
+                            persistAndEvictSubagentSessionWithStatus
+                                subagentStoreRoot ctx.multiRegistry agentTypesRef
+                                agentId status session
+                        pure ()
                     Nothing -> pure ()
         Nothing -> pure ()
     let claimCurrentSession handle = do
@@ -1884,7 +1891,7 @@ runAgentInitializedWithLock
                                     link switchWorker
                                     runSession options provider dialect policy tools toolEnv planMode startup prompt pendingTurn transitionDraft unavailableProviders startupUnavailable paramsRef transcriptRef initialTurns
                                         previousRef persist projectRoot home cwd (Just tokenProvider) loaded.loadedOpenAiPool startupContext skillsRef skillInvocationsRef escPaused interrupt
-                                        multiCtx rootTurnRef subagentSessions pendingNotices subagentStoreRoot usageRef activeAccountRef activeAccountIdRef activeSelectionRef resolveActiveAccountLabel selectAccount claimCurrentSession compactRunner activeBackend btwBackend)
+                                        multiCtx rootTurnRef subagentSessions pendingNotices subagentStoreRoot agentTypesRef legacySubagentTarget usageRef activeAccountRef activeAccountIdRef activeSelectionRef resolveActiveAccountLabel selectAccount claimCurrentSession compactRunner activeBackend btwBackend)
                             >>= \case
                                 Left (CodexAuthFailed err) ->
                                     case transition of
@@ -1947,7 +1954,7 @@ runAgentInitializedWithLock
                                 projectRoot transition persist backend
                         runSession options provider dialect policy tools toolEnv planMode startup prompt pendingTurn transitionDraft unavailableProviders startupUnavailable paramsRef transcriptRef initialTurns
                             previousRef persist projectRoot home cwd (Just tokenProvider) loaded.loadedOpenAiPool startupContext skillsRef skillInvocationsRef escPaused interrupt
-                            multiCtx rootTurnRef subagentSessions pendingNotices subagentStoreRoot usageRef activeAccountRef activeAccountIdRef activeSelectionRef resolveActiveAccountLabel (Just selectHttpAccount) claimCurrentSession compactRunner activeBackend btwBackend
+                            multiCtx rootTurnRef subagentSessions pendingNotices subagentStoreRoot agentTypesRef legacySubagentTarget usageRef activeAccountRef activeAccountIdRef activeSelectionRef resolveActiveAccountLabel (Just selectHttpAccount) claimCurrentSession compactRunner activeBackend btwBackend
                     OpenRouterProvider -> do
                         case multiCtx of
                             Just ctx ->
@@ -1984,7 +1991,7 @@ runAgentInitializedWithLock
                                 projectRoot transition persist backend
                         runSession options provider dialect policy tools toolEnv planMode startup prompt pendingTurn transitionDraft unavailableProviders startupUnavailable paramsRef transcriptRef initialTurns
                             previousRef persist projectRoot home cwd (Just tokenProvider) loaded.loadedOpenAiPool startupContext skillsRef skillInvocationsRef escPaused interrupt
-                            multiCtx rootTurnRef subagentSessions pendingNotices subagentStoreRoot usageRef activeAccountRef activeAccountIdRef activeSelectionRef resolveActiveAccountLabel (Just selectHttpAccount) claimCurrentSession compactRunner activeBackend btwBackend
+                            multiCtx rootTurnRef subagentSessions pendingNotices subagentStoreRoot agentTypesRef legacySubagentTarget usageRef activeAccountRef activeAccountIdRef activeSelectionRef resolveActiveAccountLabel (Just selectHttpAccount) claimCurrentSession compactRunner activeBackend btwBackend
           where
             startupFailure err = do
                 now <- getCurrentTime
@@ -2194,6 +2201,8 @@ runSession
     -> IORef (Map SubagentId SubagentSession)
     -> IORef [TurnInput]
     -> SubagentStoreRoot
+    -> GrokSubagentSpecs
+    -> Maybe LegacySubagentTarget
     -> IORef TokenUsage
     -> IORef Text
     -> IORef Text
@@ -2205,7 +2214,7 @@ runSession
     -> Backend
     -> BtwBackendFactory
     -> IO RunResult
-runSession options provider dialect policy tools toolEnv planMode startup prompt pendingTurn initialDraft unavailableProviders startupUnavailable paramsRef transcriptRef initialTurns previous persist projectRoot home cwd tokenProvider openAiPool startupContext skillsRef skillInvocationsRef escPaused interrupt multiCtx rootTurnRef subagentSessions pendingNotices storeRoot usageRef accountRef accountIdRef selectionRef accountLabel selectAccount onPersisted compactRunner backend btwBackend = do
+runSession options provider dialect policy tools toolEnv planMode startup prompt pendingTurn initialDraft unavailableProviders startupUnavailable paramsRef transcriptRef initialTurns previous persist projectRoot home cwd tokenProvider openAiPool startupContext skillsRef skillInvocationsRef escPaused interrupt multiCtx rootTurnRef subagentSessions pendingNotices storeRoot agentTypes legacyTarget usageRef accountRef accountIdRef selectionRef accountLabel selectAccount onPersisted compactRunner backend btwBackend = do
   initialPrevious <- readIORef previous
   ioLock <- newMVar ()
   let fullscreen = startup.startupFullscreen
@@ -2351,13 +2360,60 @@ runSession options provider dialect policy tools toolEnv planMode startup prompt
                     , agentSteps = steps
                     , agentTranscript = transcript
                     }
+        hydrateSelectedAgent agentId = do
+            effectiveModel <- readIORef modelRef
+            lookupOrCreateSubagentSession
+                subagentSessions
+                storeRoot
+                agentTypes
+                provider
+                legacyTarget
+                effectiveModel
+                (dialectId dialect)
+                agentId
+        selectAgent target = do
+            previous <- readIORef selectedAgent
+            when (previous /= target) $
+                releaseSelectedAgent previous
+            case target of
+                AgentRoot -> pure ()
+                AgentChild agentId -> do
+                    session <-
+                        (Just <$>
+                            hydrateSelectedAgent agentId)
+                            `catchAny` \_ -> pure Nothing
+                    forM_ session \selectedSession -> do
+                        withMVar selectedSession.subSessionHydrated \_ ->
+                            writeIORef selectedSession.subSessionPinned True
+                        -- If settlement won the race before the pin was set,
+                        -- refill the same stable object now that it is pinned.
+                        void
+                            (hydrateSelectedAgent agentId)
+                            `catchAny` \_ -> pure ()
+            writeIORef selectedAgent target
+        releaseSelectedAgent = \case
+            AgentRoot -> pure ()
+            AgentChild agentId -> do
+                sessions <- readIORef subagentSessions
+                forM_ (Map.lookup agentId sessions) \session -> do
+                    withMVar session.subSessionHydrated \_ ->
+                        writeIORef session.subSessionPinned False
+                    case multiCtx of
+                        Nothing -> pure ()
+                        Just ctx -> do
+                            status <- getStatus ctx.multiRegistry agentId
+                            void $
+                                persistAndEvictSubagentSessionWithStatus
+                                    storeRoot ctx.multiRegistry agentTypes
+                                    agentId status session
         agentViewport = AgentViewportEnv
             { viewportSelected = selectedAgent
+            , viewportSelect = selectAgent
             , viewportEntries = snd <$> loadAgentSnapshot True
             }
     writeIORef startup.startupAgentSnapshot
         (loadAgentSnapshot False)
-    writeIORef startup.startupAgentSelect (writeIORef selectedAgent)
+    writeIORef startup.startupAgentSelect selectAgent
     let sessionReset = do
             resetLiveConversation previous transcriptRef attachmentsRef planMode
             writeIORef usageRef emptyTokenUsage
@@ -3412,7 +3468,7 @@ replWithDraft env@SessionEnv
                                     fullscreen color selected entries >>= \case
                                     Nothing -> pure ()
                                     Just target ->
-                                        writeIORef viewport.viewportSelected target
+                                        viewport.viewportSelect target
                                 continue
 
                     ReplCopyLast -> do

--- a/packages/agent-cli/src/Agent/CLI/AgentViewport.hs
+++ b/packages/agent-cli/src/Agent/CLI/AgentViewport.hs
@@ -101,6 +101,7 @@ agentStatusGlyph status = case Text.toLower status of
 
 data AgentViewportEnv = AgentViewportEnv
     { viewportSelected :: !(IORef AgentTarget)
+    , viewportSelect :: !(AgentTarget -> IO ())
     , viewportEntries :: !(IO [AgentEntry])
     }
 

--- a/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
@@ -5,6 +5,8 @@ module Agent.CLI.Subagents.Runtime
     , SubagentStoreRoot
     , flushAllSubagentSnapshots
     , freshOpenAiBackend
+    , lookupOrCreateSubagentSession
+    , persistAndEvictSubagentSessionWithStatus
     , persistSubagentSnapshotWithStatus
     , prepareCollaborationSpawn
     , restoreAgentFromDisk
@@ -123,12 +125,21 @@ import Agent.Tools.Types
     , ToolRegistry
     , defaultToolEnv
     )
-import Control.Exception.Safe (finally)
+import Control.Concurrent.MVar
+    ( MVar
+    , modifyMVar
+    , modifyMVar_
+    , newMVar
+    , withMVar
+    )
+import Control.Exception.Safe (finally, throwIO)
+import Control.Monad (unless, void, when)
 import Data.IORef
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
+import qualified Data.Text as Text
 import Data.Time.Clock (getCurrentTime, utctDay)
 
 data SubagentSession = SubagentSession
@@ -137,6 +148,8 @@ data SubagentSession = SubagentSession
     , subSessionProvider :: !Provider
     , subSessionEffectiveModel :: !Text
     , subSessionDialect :: !DialectId
+    , subSessionPinned :: !(IORef Bool)
+    , subSessionHydrated :: !(MVar Bool)
     }
 
 -- | Optional on-disk root for child transcripts (@sessionDir/agents/<id>@).
@@ -249,23 +262,80 @@ persistSubagentSnapshotWithStatus
     mroot <- readIORef storeRootRef
     case mroot of
         Nothing -> pure ()
-        Just sessionDir -> do
-            items <-
-                trimDanglingToolSuffix
-                    <$> readIORef session.subSessionTranscript
-            previous <- getPreviousResponseId registry agentId
-            agentType <- lookupAgentType typesRef agentId
-            agentModel <- lookupAgentModel typesRef agentId
-            reasoningEffort <- lookupAgentReasoningEffort typesRef agentId
-            agentCwd <- getSubagentCwd registry agentId
-            identity <- getSubagentIdentity registry agentId
-            _ <- saveSubagentState
-                sessionDir agentId items previous status
-                session.subSessionProvider session.subSessionEffectiveModel
-                session.subSessionDialect
-                agentType agentModel
-                reasoningEffort agentCwd identity
-            pure ()
+        Just sessionDir ->
+            void $
+                saveSubagentSnapshotWithStatus
+                    sessionDir registry typesRef agentId status session
+
+-- | Persist a final snapshot, then release its parsed transcript payload.
+--
+-- The stable 'SubagentSession' object stays installed so a concurrent follow-up
+-- cannot split history across two session objects. A failed or disabled save
+-- leaves the resident transcript untouched.
+persistAndEvictSubagentSessionWithStatus
+    :: SubagentStoreRoot
+    -> SubagentRegistry
+    -> GrokSubagentSpecs
+    -> SubagentId
+    -> SubagentStatus
+    -> SubagentSession
+    -> IO (Either Text Bool)
+persistAndEvictSubagentSessionWithStatus
+        storeRootRef registry typesRef agentId status session =
+    modifyMVar session.subSessionHydrated \hydrated ->
+        if not hydrated || not (evictableStatus status)
+            then pure (hydrated, Right False)
+            else readIORef storeRootRef >>= \case
+                Nothing -> pure (True, Right False)
+                Just sessionDir ->
+                    saveSubagentSnapshotWithStatus
+                        sessionDir registry typesRef agentId status session >>= \case
+                            Left err -> pure (True, Left err)
+                            Right () -> do
+                                pinned <- readIORef session.subSessionPinned
+                                if pinned
+                                    then pure (True, Right False)
+                                    else do
+                                        writeIORef session.subSessionTranscript []
+                                        writeIORef
+                                            session.subSessionContextTokens
+                                            Nothing
+                                        pure (False, Right True)
+  where
+    evictableStatus = \case
+        Completed{} -> True
+        Errored{} -> True
+        Interrupted -> True
+        Closed -> True
+        Pending -> False
+        Running -> False
+        NotFound -> False
+
+saveSubagentSnapshotWithStatus
+    :: OsPath
+    -> SubagentRegistry
+    -> GrokSubagentSpecs
+    -> SubagentId
+    -> SubagentStatus
+    -> SubagentSession
+    -> IO (Either Text ())
+saveSubagentSnapshotWithStatus
+        sessionDir registry typesRef agentId status session = do
+    items <-
+        trimDanglingToolSuffix
+            <$> readIORef session.subSessionTranscript
+    previous <- getPreviousResponseId registry agentId
+    agentType <- lookupAgentType typesRef agentId
+    agentModel <- lookupAgentModel typesRef agentId
+    reasoningEffort <- lookupAgentReasoningEffort typesRef agentId
+    agentCwd <- getSubagentCwd registry agentId
+    identity <- getSubagentIdentity registry agentId
+    saveSubagentState
+        sessionDir agentId items previous status
+        session.subSessionProvider session.subSessionEffectiveModel
+        session.subSessionDialect
+        agentType agentModel
+        reasoningEffort agentCwd identity
 
 flushAllSubagentSnapshots
     :: SubagentStoreRoot
@@ -277,8 +347,10 @@ flushAllSubagentSnapshots storeRootRef registry sessionsRef typesRef = do
     sessions <- readIORef sessionsRef
     mapM_
         (\(agentId, session) ->
-            persistSubagentSnapshot
-                storeRootRef registry typesRef agentId session)
+            withMVar session.subSessionHydrated \hydrated ->
+                when hydrated $
+                    persistSubagentSnapshot
+                        storeRootRef registry typesRef agentId session)
         (Map.toList sessions)
 
 -- | Rehydrate a closed/missing agent from @sessionDir/agents/<id>@ so
@@ -312,9 +384,17 @@ restoreAgentFromDisk
             Just sessionDir ->
                 loadSubagentState sessionDir agentId >>= \case
                     Left err -> pure (Left err)
-                    Right Nothing ->
+                    Right Nothing -> do
+                        session <-
+                            getOrInstallSubagentSession
+                                sessionsRef
+                                provider
+                                parentEffectiveModel
+                                parentDialect
+                                agentId
                         -- Same-process close with no disk yet: still reopen.
-                        reopenInMemory Nothing Nothing
+                        restoreSession session Nothing \_ ->
+                            reopenInMemory Nothing Nothing
                     Right (Just (items, meta)) -> do
                         let expectedEffectiveModel =
                                 maybe
@@ -341,41 +421,41 @@ restoreAgentFromDisk
                                         unsupportedDialectMessage
                                             provider agentId storedDialect
                             Right (storedEffectiveModel, storedDialect) -> do
-                                result <- reopenPersisted meta
-                                case result of
-                                    Left err -> pure (Left err)
-                                    Right () -> do
-                                        case meta.diskAgentType of
-                                            Just agentType ->
-                                                recordAgentSpec
-                                                    typesRef
-                                                    agentId
-                                                    GrokSubagentSpec
-                                                        { agentType
-                                                        , modelOverride =
-                                                            meta.diskAgentModel
-                                                        , reasoningEffortOverride =
-                                                            meta.diskReasoningEffort
-                                                        }
-                                            Nothing -> pure ()
-                                        transcript <- newIORef items
-                                        contextTokens <- newIORef Nothing
-                                        let session =
-                                                SubagentSession
-                                                    { subSessionTranscript =
-                                                        transcript
-                                                    , subSessionContextTokens =
-                                                        contextTokens
-                                                    , subSessionProvider =
-                                                        provider
-                                                    , subSessionEffectiveModel =
-                                                        storedEffectiveModel
-                                                    , subSessionDialect =
-                                                        storedDialect
-                                                    }
-                                        atomicModifyIORef' sessionsRef \m ->
-                                            (Map.insert agentId session m, ())
-                                        pure (Right ())
+                                session <-
+                                    getOrInstallSubagentSession
+                                        sessionsRef
+                                        provider
+                                        storedEffectiveModel
+                                        storedDialect
+                                        agentId
+                                restoreSession session (Just (items, meta)) \_ ->
+                                    reopenPersisted meta >>= \case
+                                        Left err -> pure (Left err)
+                                        Right () -> pure (Right ())
+    restoreSession session loaded reopen =
+        modifyMVar session.subSessionHydrated \hydrated -> do
+            currentStatus <- getStatus registry agentId
+            case currentStatus of
+                NotFound -> finish hydrated
+                Closed -> finish hydrated
+                _ -> do
+                    hydrated' <-
+                        ensureSubagentSessionHydratedLocked
+                            storeRootRef typesRef legacyTarget
+                            agentId session hydrated
+                    pure (hydrated', Right ())
+      where
+        finish hydrated =
+            reopen hydrated >>= \case
+                Left err -> pure (hydrated, Left err)
+                Right () -> do
+                    case loaded of
+                        Nothing -> pure ()
+                        Just (items, meta) -> do
+                            recordPersistedAgentSpec typesRef agentId meta
+                            unless hydrated $
+                                writeIORef session.subSessionTranscript items
+                    pure (True, Right ())
     reopenPersisted meta =
         case meta.diskTaskPath of
             Nothing -> restoreAt taskPathRoot
@@ -806,46 +886,102 @@ lookupOrCreateSubagentSession
 lookupOrCreateSubagentSession
         sessionsRef storeRootRef typesRef provider legacyTarget
         currentEffectiveModel currentDialect agentId = do
-    sessions <- readIORef sessionsRef
-    case Map.lookup agentId sessions of
-        Just session -> pure session
-        Nothing -> do
-            mroot <- readIORef storeRootRef
-            loaded <- case mroot of
-                Just sessionDir -> loadSubagentState sessionDir agentId
-                Nothing -> pure (Right Nothing)
-            let (items, meta, sessionEffectiveModel, sessionDialect) = case loaded of
-                    Right (Just (xs, m))
-                        | Right (storedEffectiveModel, storedDialect) <-
-                            validatePersistedSubagentTarget
-                                provider
-                                currentEffectiveModel
-                                currentDialect
-                                legacyTarget
-                                m
-                        , providerSupportsDialect provider storedDialect ->
-                            (xs, Just m, storedEffectiveModel, storedDialect)
-                    _ -> ([], Nothing, currentEffectiveModel, currentDialect)
-            transcript <- newIORef items
-            contextTokens <- newIORef Nothing
-            case meta >>= (.diskAgentType) of
-                Just agentType ->
-                    recordAgentSpec typesRef agentId GrokSubagentSpec
-                        { agentType
-                        , modelOverride = meta >>= (.diskAgentModel)
-                        , reasoningEffortOverride =
-                            meta >>= (.diskReasoningEffort)
-                        }
-                Nothing -> pure ()
-            let session = SubagentSession
-                    { subSessionTranscript = transcript
-                    , subSessionContextTokens = contextTokens
-                    , subSessionProvider = provider
-                    , subSessionEffectiveModel = sessionEffectiveModel
-                    , subSessionDialect = sessionDialect
-                    }
-            atomicModifyIORef' sessionsRef \m -> (Map.insert agentId session m, ())
-            pure session
+    session <-
+        getOrInstallSubagentSession
+            sessionsRef provider currentEffectiveModel currentDialect agentId
+    modifyMVar_ session.subSessionHydrated $
+        ensureSubagentSessionHydratedLocked
+            storeRootRef typesRef legacyTarget agentId session
+    pure session
+
+getOrInstallSubagentSession
+    :: IORef (Map SubagentId SubagentSession)
+    -> Provider
+    -> Text
+    -> DialectId
+    -> SubagentId
+    -> IO SubagentSession
+getOrInstallSubagentSession
+        sessionsRef provider effectiveModel dialect agentId = do
+    transcript <- newIORef []
+    contextTokens <- newIORef Nothing
+    pinned <- newIORef False
+    hydrated <- newMVar False
+    let candidate = SubagentSession
+            { subSessionTranscript = transcript
+            , subSessionContextTokens = contextTokens
+            , subSessionProvider = provider
+            , subSessionEffectiveModel = effectiveModel
+            , subSessionDialect = dialect
+            , subSessionPinned = pinned
+            , subSessionHydrated = hydrated
+            }
+    atomicModifyIORef' sessionsRef \sessions ->
+        case Map.lookup agentId sessions of
+            Just existing -> (sessions, existing)
+            Nothing -> (Map.insert agentId candidate sessions, candidate)
+
+ensureSubagentSessionHydratedLocked
+    :: SubagentStoreRoot
+    -> GrokSubagentSpecs
+    -> Maybe LegacySubagentTarget
+    -> SubagentId
+    -> SubagentSession
+    -> Bool
+    -> IO Bool
+ensureSubagentSessionHydratedLocked
+        storeRootRef typesRef legacyTarget agentId session hydrated
+    | hydrated = pure True
+    | otherwise = do
+        mroot <- readIORef storeRootRef
+        loaded <- case mroot of
+            Just sessionDir -> loadSubagentState sessionDir agentId
+            Nothing -> pure (Right Nothing)
+        case loaded of
+            Left err ->
+                throwIO (userError (Text.unpack err))
+            Right Nothing ->
+                pure ()
+            Right (Just (items, meta)) ->
+                case validatePersistedSubagentTarget
+                        session.subSessionProvider
+                        session.subSessionEffectiveModel
+                        session.subSessionDialect
+                        legacyTarget
+                        meta of
+                    Left err ->
+                        throwIO (userError (Text.unpack err))
+                    Right (_, storedDialect)
+                        | not
+                            (providerSupportsDialect
+                                session.subSessionProvider storedDialect) ->
+                            throwIO $
+                                userError $
+                                    Text.unpack $
+                                        unsupportedDialectMessage
+                                            session.subSessionProvider
+                                            agentId
+                                            storedDialect
+                    Right _ -> do
+                        writeIORef session.subSessionTranscript items
+                        writeIORef session.subSessionContextTokens Nothing
+                        recordPersistedAgentSpec typesRef agentId meta
+        pure True
+
+recordPersistedAgentSpec
+    :: GrokSubagentSpecs
+    -> SubagentId
+    -> SubagentDiskMeta
+    -> IO ()
+recordPersistedAgentSpec typesRef agentId meta =
+    case meta.diskAgentType of
+        Just agentType ->
+            recordAgentSpec typesRef agentId GrokSubagentSpec
+                { agentType
+                , modelOverride = meta.diskAgentModel
+                , reasoningEffortOverride = meta.diskReasoningEffort
+                }
+        Nothing -> pure ()
 
 validatePersistedSubagentTarget
     :: Provider

--- a/packages/agent-cli/test/Agent/CLI/SubagentStoreSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SubagentStoreSpec.hs
@@ -1,21 +1,41 @@
 module Agent.CLI.SubagentStoreSpec (spec) where
 
 import Agent.CLI.SubagentStore
-import Agent.CLI.Subagents.Runtime (validatePersistedSubagentTarget)
 import Agent.CLI.Session (LegacySubagentTarget(..))
 import Agent.Dialect (DialectId(..))
 import Agent.Provider (Provider(..))
+import Agent.CLI.Subagents.Runtime
+    ( SubagentSession(..)
+    , flushAllSubagentSnapshots
+    , lookupOrCreateSubagentSession
+    , persistAndEvictSubagentSessionWithStatus
+    , restoreAgentFromDisk
+    , validatePersistedSubagentTarget
+    )
 import Agent.Responses.Types
 import System.OsPath (OsPath, decodeUtf, unsafeEncodeUtf)
 import Agent.Subagents
     ( SubagentId(..)
     , SubagentIdentity(..)
     , SubagentStatus(..)
+    , closeSubagentRegistry
+    , defaultSubagentConfig
+    , newSubagentRegistry
     )
 import Agent.Subagents.TaskPath (parseTaskPath)
+import Control.Concurrent.Async (mapConcurrently, wait, withAsync)
+import Control.Concurrent.MVar
+    ( newEmptyMVar
+    , putMVar
+    , readMVar
+    , takeMVar
+    )
 import Control.Exception.Safe (bracket)
+import Control.Monad (forM_, replicateM_)
 import qualified Data.Aeson.KeyMap as KeyMap
 import qualified Data.ByteString.Lazy as LBS
+import Data.IORef
+import qualified Data.Map.Strict as Map
 import Data.Text (Text)
 import qualified System.Directory as Directory
 import System.Directory.OsPath (doesFileExist)
@@ -184,6 +204,217 @@ spec = describe "Agent.CLI.SubagentStore" do
                 (Just legacyTarget)
                 legacyMeta
                 `shouldSatisfy` isLeft
+    it "shares one session across concurrent disk hydration" do
+        withTempDir \dir -> do
+            let agentId = SubagentId "agent-concurrent-hydration"
+                persistedItems =
+                    replicate 20000 (messageItem RoleUser "persisted")
+                workerCount = 16
+            saveSubagentState dir agentId persistedItems Nothing
+                (Completed Nothing)
+                OpenAIProvider "gpt-5.6-luna" CodexDialect
+                Nothing Nothing Nothing Nothing Nothing
+                `shouldReturn` Right ()
+            sessionsRef <- newIORef Map.empty
+            storeRootRef <- newIORef (Just dir)
+            typesRef <- newIORef Map.empty
+            ready <- newEmptyMVar
+            start <- newEmptyMVar
+            let hydrate _ = do
+                    putMVar ready ()
+                    readMVar start
+                    lookupTestSession
+                        sessionsRef storeRootRef typesRef agentId
+            withAsync
+                (mapConcurrently hydrate [1 .. workerCount])
+                \workers -> do
+                    replicateM_ workerCount (takeMVar ready)
+                    putMVar start ()
+                    sessions <- wait workers
+                    case sessions of
+                        [] -> expectationFailure "expected hydrated sessions"
+                        first : _ -> do
+                            let marker = [messageItem RoleAssistant "shared"]
+                            writeIORef first.subSessionTranscript marker
+                            forM_ sessions \session ->
+                                readIORef session.subSessionTranscript
+                                    `shouldReturn` marker
+
+    it "keeps the installed session across concurrent registry restores" do
+        withTempDir \dir -> do
+            let agentId = SubagentId "agent-concurrent-restore"
+                persisted = [messageItem RoleUser "persisted"]
+                inMemory = [messageItem RoleAssistant "in-memory"]
+                workerCount = 8
+            saveSubagentState dir agentId persisted Nothing
+                (Completed Nothing)
+                OpenAIProvider "gpt-5.6-luna" CodexDialect
+                Nothing Nothing Nothing Nothing Nothing
+                `shouldReturn` Right ()
+            sessionsRef <- newIORef Map.empty
+            storeRootRef <- newIORef (Just dir)
+            typesRef <- newIORef Map.empty
+            installed <-
+                lookupTestSession
+                    sessionsRef storeRootRef typesRef agentId
+            writeIORef installed.subSessionTranscript inMemory
+            bracket
+                (newSubagentRegistry defaultSubagentConfig dir
+                    (\_ _ _ _ -> fail "unexpected subagent runner invocation")
+                    (\_ _ -> pure ()))
+                closeSubagentRegistry
+                \registry -> do
+                    ready <- newEmptyMVar
+                    start <- newEmptyMVar
+                    let restore _ = do
+                            putMVar ready ()
+                            readMVar start
+                            restoreTestAgent
+                                storeRootRef registry sessionsRef typesRef agentId
+                    withAsync
+                        (mapConcurrently restore [1 .. workerCount])
+                        \workers -> do
+                            replicateM_ workerCount (takeMVar ready)
+                            putMVar start ()
+                            wait workers
+                                `shouldReturn` replicate workerCount (Right ())
+                    sessions <- readIORef sessionsRef
+                    case Map.lookup agentId sessions of
+                        Nothing -> expectationFailure "expected restored session"
+                        Just current -> do
+                            readIORef current.subSessionTranscript
+                                `shouldReturn` inMemory
+                            let marker = [messageItem RoleAssistant "same-ref"]
+                            writeIORef current.subSessionTranscript marker
+                            readIORef installed.subSessionTranscript
+                                `shouldReturn` marker
+
+    it "evicts only after a successful save and rehydrates the same session" do
+        withTempDir \dir -> do
+            let agentId = SubagentId "agent-evict-rehydrate"
+                items =
+                    [ messageItem RoleUser "question"
+                    , messageItem RoleAssistant "answer"
+                    ]
+            sessionsRef <- newIORef Map.empty
+            storeRootRef <- newIORef (Just dir)
+            typesRef <- newIORef Map.empty
+            session <-
+                lookupTestSession
+                    sessionsRef storeRootRef typesRef agentId
+            writeIORef session.subSessionTranscript items
+            writeIORef session.subSessionContextTokens (Just (100, 200))
+            bracket
+                (newSubagentRegistry defaultSubagentConfig dir
+                    (\_ _ _ _ -> fail "unexpected subagent runner invocation")
+                    (\_ _ -> pure ()))
+                closeSubagentRegistry
+                \registry -> do
+                    writeIORef session.subSessionPinned True
+                    persistAndEvictSubagentSessionWithStatus
+                        storeRootRef registry typesRef agentId
+                        (Completed (Just "answer")) session
+                        `shouldReturn` Right False
+                    readIORef session.subSessionTranscript
+                        `shouldReturn` items
+                    readMVar session.subSessionHydrated `shouldReturn` True
+
+                    writeIORef session.subSessionPinned False
+                    persistAndEvictSubagentSessionWithStatus
+                        storeRootRef registry typesRef agentId
+                        (Completed (Just "answer")) session
+                        `shouldReturn` Right True
+                    readIORef session.subSessionTranscript `shouldReturn` []
+                    readIORef session.subSessionContextTokens
+                        `shouldReturn` Nothing
+                    readMVar session.subSessionHydrated `shouldReturn` False
+
+                    rehydrated <-
+                        lookupTestSession
+                            sessionsRef storeRootRef typesRef agentId
+                    readIORef rehydrated.subSessionTranscript
+                        `shouldReturn` items
+                    readMVar rehydrated.subSessionHydrated
+                        `shouldReturn` True
+                    writeIORef rehydrated.subSessionTranscript
+                        [messageItem RoleAssistant "poison"]
+                    persistAndEvictSubagentSessionWithStatus
+                        storeRootRef registry typesRef agentId
+                        (Completed (Just "answer")) rehydrated
+                        `shouldReturn` Right True
+                    writeIORef rehydrated.subSessionTranscript
+                        [messageItem RoleAssistant "must-not-flush"]
+                    flushAllSubagentSnapshots
+                        storeRootRef registry sessionsRef typesRef
+                    loadSubagentState dir agentId >>= \case
+                        Right (Just (stored, _)) ->
+                            stored `shouldBe`
+                                [messageItem RoleAssistant "poison"]
+                        other ->
+                            expectationFailure
+                                ("unexpected stored snapshot: " <> show other)
+
+    it "retains resident data when persistence is unavailable or fails" do
+        withTempDir \dir -> do
+            let validId = SubagentId "agent-no-store"
+                invalidId = SubagentId "../agent-invalid"
+                items = [messageItem RoleUser "keep-me"]
+            sessionsRef <- newIORef Map.empty
+            noStoreRef <- newIORef Nothing
+            failingStoreRef <- newIORef Nothing
+            typesRef <- newIORef Map.empty
+            bracket
+                (newSubagentRegistry defaultSubagentConfig dir
+                    (\_ _ _ _ -> fail "unexpected subagent runner invocation")
+                    (\_ _ -> pure ()))
+                closeSubagentRegistry
+                \registry -> do
+                    noStore <-
+                        lookupTestSession
+                            sessionsRef noStoreRef typesRef validId
+                    writeIORef noStore.subSessionTranscript items
+                    persistAndEvictSubagentSessionWithStatus
+                        noStoreRef registry typesRef validId Interrupted noStore
+                        `shouldReturn` Right False
+                    readIORef noStore.subSessionTranscript `shouldReturn` items
+                    readMVar noStore.subSessionHydrated `shouldReturn` True
+
+                    failed <-
+                        lookupTestSession
+                            sessionsRef failingStoreRef typesRef invalidId
+                    writeIORef failed.subSessionTranscript items
+                    writeIORef failingStoreRef (Just dir)
+                    persistAndEvictSubagentSessionWithStatus
+                        failingStoreRef registry typesRef invalidId Interrupted failed
+                        >>= (`shouldSatisfy` \case
+                            Left _ -> True
+                            Right _ -> False)
+                    readIORef failed.subSessionTranscript `shouldReturn` items
+                    readMVar failed.subSessionHydrated `shouldReturn` True
+
+lookupTestSession sessionsRef storeRootRef typesRef agentId =
+    lookupOrCreateSubagentSession
+        sessionsRef
+        storeRootRef
+        typesRef
+        OpenAIProvider
+        Nothing
+        "gpt-5.6-luna"
+        CodexDialect
+        agentId
+
+restoreTestAgent storeRootRef registry sessionsRef typesRef agentId =
+    restoreAgentFromDisk
+        OpenAIProvider
+        id
+        "gpt-5.6-luna"
+        CodexDialect
+        Nothing
+        storeRootRef
+        registry
+        sessionsRef
+        typesRef
+        agentId
 
 legacyTarget :: LegacySubagentTarget
 legacyTarget = LegacySubagentTarget

--- a/packages/agent-core/src/Agent/Subagents/Registry.hs
+++ b/packages/agent-core/src/Agent/Subagents/Registry.hs
@@ -10,6 +10,7 @@ module Agent.Subagents.Registry
     , newSubagentRegistry
     , setSubagentRunner
     , setSubagentOnComplete
+    , setSubagentOnSettled
     , beginRootTurn
     , abortRootTurn
     , closeSubagentRegistry
@@ -202,6 +203,7 @@ data SubagentRegistry = SubagentRegistry
     , registryRunRef :: !(IORef RunSubagent)
     , registryOnEvent :: !(SubagentId -> LoopEvent -> IO ())
     , registryOnCompleteRef :: !(IORef (SubagentId -> SubagentStatus -> IO ()))
+    , registryOnSettledRef :: !(IORef (SubagentId -> SubagentStatus -> IO ()))
     , registryCwd :: !OsPath
     , registryClosed :: !(TVar Bool)
     , registryNextRootTurnId :: !(TVar Word64)
@@ -228,6 +230,7 @@ newSubagentRegistry config cwd run onEvent = do
     lifecycle <- newMVar ()
     runRef <- newIORef run
     onCompleteRef <- newIORef (\_ _ -> pure ())
+    onSettledRef <- newIORef (\_ _ -> pure ())
     pure SubagentRegistry
         { registryAgents = agents
         , registryPaths = paths
@@ -241,6 +244,7 @@ newSubagentRegistry config cwd run onEvent = do
         , registryRunRef = runRef
         , registryOnEvent = onEvent
         , registryOnCompleteRef = onCompleteRef
+        , registryOnSettledRef = onSettledRef
         , registryCwd = cwd
         , registryClosed = closed
         , registryNextRootTurnId = nextRootTurnId
@@ -258,6 +262,18 @@ setSubagentOnComplete
     -> (SubagentId -> SubagentStatus -> IO ())
     -> IO ()
 setSubagentOnComplete registry = writeIORef registry.registryOnCompleteRef
+
+-- | Invoked synchronously after a child publishes a final turn status,
+-- including completions routed directly to another subagent, and before the
+-- child's supervisor can begin queued follow-up work. A first transition to
+-- 'Closed' is reported after the supervisor has stopped; that callback runs
+-- under the registry lifecycle lock and must not call lifecycle-mutating
+-- registry operations.
+setSubagentOnSettled
+    :: SubagentRegistry
+    -> (SubagentId -> SubagentStatus -> IO ())
+    -> IO ()
+setSubagentOnSettled registry = writeIORef registry.registryOnSettledRef
 
 beginRootTurn :: SubagentRegistry -> IO RootTurnId
 beginRootTurn registry = atomically do
@@ -647,6 +663,7 @@ runSupervisor registry record = awaitWork
                         notifyComplete
                             registry record.recordId work.workRootTurnId status
                     pure ()
+                notifySettled registry record.recordId status
                 atomically (finishSupervisorStep registry record status) >>= \case
                     SupervisorStop -> pure ()
                     SupervisorIdle -> awaitWork
@@ -884,6 +901,17 @@ notifyComplete registry agentId rootTurnId status
             onComplete agentId status
     | otherwise = pure ()
 
+notifySettled
+    :: SubagentRegistry
+    -> SubagentId
+    -> SubagentStatus
+    -> IO ()
+notifySettled registry agentId status
+    | isFinalStatus status && status /= NotFound = do
+        onSettled <- readIORef registry.registryOnSettledRef
+        void $ tryAny $ onSettled agentId status
+    | otherwise = pure ()
+
 releaseSlotSTM :: SubagentRegistry -> SubagentRecord -> STM ()
 releaseSlotSTM registry record = do
     phase <- readTVar record.recordPhase
@@ -1090,11 +1118,17 @@ descendants agents parentId =
 shutdownRecord :: SubagentRegistry -> SubagentRecord -> IO ()
 shutdownRecord registry record = do
     requestCancel record.recordCancel
-    atomically do
+    transitioned <- atomically do
+        phase <- readTVar record.recordPhase
         releaseSlotSTM registry record
         writeTVar record.recordPhase AgentClosed
         void $ flushTQueue record.recordMailbox
+        pure $ case phase of
+            AgentClosed -> False
+            _ -> True
     stopRecordSupervisor record
+    whenIO transitioned $
+        notifySettled registry record.recordId Closed
 
 abortRootTurn :: SubagentRegistry -> RootTurnId -> IO ()
 abortRootTurn registry rootTurnId =
@@ -1103,7 +1137,10 @@ abortRootTurn registry rootTurnId =
             modifyTVar' registry.registryAbortedRootTurns (Set.insert rootTurnId)
             agents <- Map.elems <$> readTVar registry.registryAgents
             fmap concat $ mapM selectOwned agents
-        mapM_ (interruptRecordForTurn registry rootTurnId) records
+        settled <- mapM (interruptRecordForTurn registry rootTurnId) records
+        mapM_
+            (\record -> notifySettled registry record.recordId Interrupted)
+            [record | (record, True) <- zip records settled]
   where
     selectOwned :: SubagentRecord -> STM [SubagentRecord]
     selectOwned record = do
@@ -1115,27 +1152,31 @@ abortRootTurn registry rootTurnId =
             , phaseStatus phase == Pending || phaseStatus phase == Running
             ]
 
-interruptRecordForTurn :: SubagentRegistry -> RootTurnId -> SubagentRecord -> IO ()
+interruptRecordForTurn :: SubagentRegistry -> RootTurnId -> SubagentRecord -> IO Bool
 interruptRecordForTurn registry rootTurnId record = do
-    waitForTurn <- atomically do
+    disposition <- atomically do
         phase <- readTVar record.recordPhase
         if phaseRootTurnId phase /= Just rootTurnId
-            then pure False
+            then pure InterruptUnchanged
             else case phase of
                 AgentPending{} -> do
                     releaseSlotSTM registry record
                     writeTVar record.recordPhase
                         (AgentIdle Interrupted (Just rootTurnId))
-                    pure False
+                    pure InterruptSettled
                 AgentRunning owner -> do
                     writeTVar record.recordPhase (AgentInterrupting owner)
-                    pure True
-                AgentInterrupting{} -> pure True
-                AgentIdle{} -> pure False
-                AgentClosed -> pure False
-    whenIO waitForTurn do
-        requestCancel record.recordCancel
-        atomically $ waitForReleasedSlot record
+                    pure InterruptWait
+                AgentInterrupting{} -> pure InterruptWait
+                AgentIdle{} -> pure InterruptUnchanged
+                AgentClosed -> pure InterruptUnchanged
+    case disposition of
+        InterruptUnchanged -> pure False
+        InterruptSettled -> pure True
+        InterruptWait -> do
+            requestCancel record.recordCancel
+            atomically $ waitForReleasedSlot record
+            pure True
 
 waitForReleasedSlot :: SubagentRecord -> STM ()
 waitForReleasedSlot record = do
@@ -1169,7 +1210,11 @@ interruptActiveSubagents registry =
             agents <- Map.elems <$> readTVar registry.registryAgents
             records <- filterMSTM isActiveRecord agents
             pure (wasClosed, records)
-        mapM_ (interruptRecord registry) records
+        (do
+            settled <- mapM (interruptRecord registry) records
+            mapM_
+                (\record -> notifySettled registry record.recordId Interrupted)
+                [record | (record, True) <- zip records settled])
             `finally`
                 atomically (writeTVar registry.registryClosed wasClosed)
   where
@@ -1178,26 +1223,36 @@ interruptActiveSubagents registry =
         status <- phaseStatus <$> readTVar record.recordPhase
         pure (status == Pending || status == Running)
 
-interruptRecord :: SubagentRegistry -> SubagentRecord -> IO ()
+interruptRecord :: SubagentRegistry -> SubagentRecord -> IO Bool
 interruptRecord registry record = do
-    waitForTurn <- atomically do
+    disposition <- atomically do
         phase <- readTVar record.recordPhase
         void $ flushTQueue record.recordMailbox
         case phase of
             AgentPending{} -> do
                 transitionToIdleSTM registry record Interrupted
-                pure False
+                pure InterruptSettled
             AgentRunning owner -> do
                 writeTVar record.recordPhase (AgentInterrupting owner)
-                pure True
-            AgentInterrupting{} -> pure True
-            AgentIdle _ owner -> do
-                writeTVar record.recordPhase (AgentIdle Interrupted owner)
-                pure False
-            AgentClosed -> pure False
-    whenIO waitForTurn do
-        requestCancel record.recordCancel
-        atomically $ waitForReleasedSlot record
+                pure InterruptWait
+            AgentInterrupting{} -> pure InterruptWait
+            -- The record may have completed after the active snapshot was
+            -- taken. Preserve that published final status rather than
+            -- replacing it with an administrative interruption.
+            AgentIdle{} -> pure InterruptUnchanged
+            AgentClosed -> pure InterruptUnchanged
+    case disposition of
+        InterruptUnchanged -> pure False
+        InterruptSettled -> pure True
+        InterruptWait -> do
+            requestCancel record.recordCancel
+            atomically $ waitForReleasedSlot record
+            pure True
+
+data InterruptDisposition
+    = InterruptUnchanged
+    | InterruptSettled
+    | InterruptWait
 
 filterMSTM :: (a -> STM Bool) -> [a] -> STM [a]
 filterMSTM predicate = fmap reverse . go []

--- a/packages/agent-core/test/Agent/SubagentsSpec.hs
+++ b/packages/agent-core/test/Agent/SubagentsSpec.hs
@@ -508,11 +508,14 @@ spec = describe "Agent.Subagents" do
         childSpawned <- newEmptyTMVarIO
         noticeSeen <- newEmptyTMVarIO
         rootNotices <- newIORef ([] :: [SubagentId])
+        settled <- newIORef ([] :: [(SubagentId, SubagentStatus)])
         registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
             (\_ _ _ _ -> pure (Left LoopNoResponseId))
             (\_ _ -> pure ())
         setSubagentOnComplete registry \agentId _ ->
             atomicModifyIORef' rootNotices \xs -> (xs <> [agentId], ())
+        setSubagentOnSettled registry \agentId status ->
+            atomicModifyIORef' settled \xs -> (xs <> [(agentId, status)], ())
         setSubagentRunner registry \env _ prompt _ ->
             runNestedRouting
                 registry parentRelease childRelease childSpawned noticeSeen
@@ -532,13 +535,20 @@ spec = describe "Agent.Subagents" do
         _ <- waitSubagents registry [parent] 15000
         notices <- readIORef rootNotices
         notices `shouldNotContain` [child]
+        readIORef settled `shouldReturn`
+            [ (child, Completed (Just "leaf-final"))
+            , (parent, Completed (Just "parent-final"))
+            ]
 
     it "allows completion callbacks to queue a follow-up without deadlocking" do
         prompts <- newIORef ([] :: [Text])
+        events <- newIORef ([] :: [Text])
         registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
             (\_ _ prompt _ -> do
                 let payload = messagePayload prompt
                 atomicModifyIORef' prompts \seen -> (seen <> [payload], ())
+                atomicModifyIORef' events \seen ->
+                    (seen <> ["run:" <> payload], ())
                 pure $ Right LoopResult
                     { finalResponseId = "response-" <> payload
                     , finalText = Just payload
@@ -551,23 +561,54 @@ spec = describe "Agent.Subagents" do
                 _ <- sendInput registry agentId "second" False
                 pure ()
             _ -> pure ()
+        setSubagentOnSettled registry \_ -> \case
+            Completed (Just payload) ->
+                atomicModifyIORef' events \seen ->
+                    (seen <> ["settled:" <> payload], ())
+            _ -> pure ()
         Right agentId <- spawnSubagent registry Nothing 0 "first" Nothing
         (statuses, timedOut) <- waitSubagents registry [agentId] 15000
         timedOut `shouldBe` False
         Map.lookup agentId statuses
             `shouldBe` Just (Completed (Just "second"))
         readIORef prompts `shouldReturn` ["first", "second"]
+        readIORef events `shouldReturn`
+            [ "run:first"
+            , "settled:first"
+            , "run:second"
+            , "settled:second"
+            ]
+
+    it "isolates settled callback failures from the supervisor" do
+        registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
+            (\_ _ prompt _ -> pure (completedResult (messagePayload prompt)))
+            (\_ _ -> pure ())
+        setSubagentOnSettled registry \_ _ ->
+            fail "settled callback failed"
+        Right agentId <- spawnSubagent registry Nothing 0 "first" Nothing
+        (first, firstTimedOut) <- waitSubagents registry [agentId] 15000
+        firstTimedOut `shouldBe` False
+        Map.lookup agentId first `shouldBe` Just (Completed (Just "first"))
+        Right _ <- sendInput registry agentId "second" False
+        (second, secondTimedOut) <- waitSubagents registry [agentId] 15000
+        secondTimedOut `shouldBe` False
+        Map.lookup agentId second `shouldBe` Just (Completed (Just "second"))
 
     it "cancels and joins a running supervisor when the registry closes" do
         started <- newEmptyTMVarIO
         cleanedUp <- newEmptyTMVarIO
+        settled <- newIORef ([] :: [(SubagentId, SubagentStatus)])
         registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
             (blockingRunner started cleanedUp)
             (\_ _ -> pure ())
-        Right _ <- spawnSubagent registry Nothing 0 "wait" Nothing
+        setSubagentOnSettled registry \agentId status -> do
+            atomically $ readTMVar cleanedUp
+            atomicModifyIORef' settled \xs -> (xs <> [(agentId, status)], ())
+        Right agentId <- spawnSubagent registry Nothing 0 "wait" Nothing
         atomically $ takeTMVar started
         closeSubagentRegistry registry
         atomically $ readTMVar cleanedUp
+        readIORef settled `shouldReturn` [(agentId, Closed)]
 
     it "restores a missing agent id into the registry" do
         registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
@@ -734,6 +775,7 @@ spec = describe "Agent.Subagents" do
         closeSubagentRegistry registry
 
     it "does not let sendInput resurrect a closed agent" do
+        settled <- newIORef ([] :: [SubagentStatus])
         registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
             (\_ _ prompt _ -> pure $ Right LoopResult
                 { finalResponseId = "r"
@@ -742,9 +784,15 @@ spec = describe "Agent.Subagents" do
                 , tokenUsage = emptyTokenUsage
                 })
             (\_ _ -> pure ())
+        setSubagentOnSettled registry \_ status ->
+            atomicModifyIORef' settled \statuses -> (statuses <> [status], ())
         Right agentId <- spawnSubagent registry Nothing 0 "first" Nothing
         _ <- waitSubagents registry [agentId] 15000
+        readIORef settled `shouldReturn` [Completed (Just "first")]
         _ <- closeSubagent registry agentId
+        readIORef settled `shouldReturn` [Completed (Just "first"), Closed]
+        _ <- closeSubagent registry agentId
+        readIORef settled `shouldReturn` [Completed (Just "first"), Closed]
         sendInput registry agentId "should-not-run" False
             `shouldReturn` Left "agent is closed"
         getStatus registry agentId `shouldReturn` Closed
@@ -868,6 +916,7 @@ spec = describe "Agent.Subagents" do
         started <- newEmptyTMVarIO
         blocker <- newEmptyTMVarIO
         notices <- newIORef ([] :: [(SubagentId, SubagentStatus)])
+        settled <- newIORef ([] :: [(SubagentId, SubagentStatus)])
         let config = defaultSubagentConfig { maxConcurrent = 1 }
         registry <- newSubagentRegistry config (fromFilePath "/tmp")
             (\_ _ _ _ -> do
@@ -882,6 +931,8 @@ spec = describe "Agent.Subagents" do
             (\_ _ -> pure ())
         setSubagentOnComplete registry \agentId status ->
             atomicModifyIORef' notices \xs -> (xs <> [(agentId, status)], ())
+        setSubagentOnSettled registry \agentId status ->
+            atomicModifyIORef' settled \xs -> (xs <> [(agentId, status)], ())
         Right active <- spawnSubagent registry Nothing 0 "active" Nothing
         atomically $ takeTMVar started
 
@@ -889,6 +940,7 @@ spec = describe "Agent.Subagents" do
 
         getStatus registry active `shouldReturn` Interrupted
         readIORef notices `shouldReturn` []
+        readIORef settled `shouldReturn` [(active, Interrupted)]
         replacement <- spawnSubagent registry Nothing 0 "replacement" Nothing
         replacement `shouldSatisfy` \case
             Right _ -> True
@@ -941,6 +993,7 @@ spec = describe "Agent.Subagents" do
 
     it "can restart an interrupted agent in a later root turn" do
         started <- newEmptyTMVarIO
+        settled <- newIORef ([] :: [SubagentStatus])
         registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
             (\_ _ prompt _ ->
                 if messagePayload prompt == "first"
@@ -952,6 +1005,8 @@ spec = describe "Agent.Subagents" do
                         , tokenUsage = emptyTokenUsage
                         })
             (\_ _ -> pure ())
+        setSubagentOnSettled registry \_ status ->
+            atomicModifyIORef' settled \statuses -> (statuses <> [status], ())
         firstTurn <- beginRootTurn registry
         secondTurn <- beginRootTurn registry
         Right agentId <- spawnSubagentWithCwdForTurn registry (Just firstTurn)
@@ -959,12 +1014,15 @@ spec = describe "Agent.Subagents" do
         atomically $ takeTMVar started
         abortRootTurn registry firstTurn
         getStatus registry agentId `shouldReturn` Interrupted
+        readIORef settled `shouldReturn` [Interrupted]
         Right _ <- sendInputMessageForTurn registry (Just secondTurn)
             taskPathRoot agentId (plainInterAgentContent "second") False
         (statuses, timedOut) <- waitSubagents registry [agentId] 15000
         timedOut `shouldBe` False
         Map.lookup agentId statuses
             `shouldBe` Just (Completed (Just "second"))
+        readIORef settled `shouldReturn`
+            [Interrupted, Completed (Just "second")]
         closeSubagentRegistry registry
 
     it "removes failed-turn follow-ups queued behind unrelated work" do


### PR DESCRIPTION
## Summary

- keep one stable, single-flight hydrated session object per subagent
- persist final subagent snapshots before clearing parsed transcripts and context-token caches
- rehydrate evicted sessions for follow-ups and explicit agent selection while keeping the selected transcript pinned
- add an all-agent settled hook covering nested completion, interruption, and close lifecycle paths
- skip evicted sessions during shutdown flush and retain resident data whenever persistence is unavailable or fails
- add a retained-versus-evicted RTS memory benchmark

This does not change RTS capabilities or the subagent concurrency limit.

## Benchmark

Built with `-O2`, RTS statistics enabled, one warm-up, and five measured samples. Each simulated agent retained approximately 1 MiB of transcript text.

| Agents | Retained live heap | Evicted live heap | Reduction |
| ---: | ---: | ---: | ---: |
| 8 | 8,525,736 bytes | 129,920 bytes | 98.48% |
| 32 | 34,032,624 bytes | 134,080 bytes | 99.61% |
| 64 | 67,936,480 bytes | 139,240 bytes | 99.80% |

A repeated seven-sample 32-agent run measured 33,962,288 bytes retained versus 63,728 bytes evicted, a 99.81% reduction. Construction allocation remained effectively unchanged, as expected.

```console
nix develop -c cabal build --offline agent-cli:bench:subagent-retention-bench
bin=$(nix develop -c cabal list-bin agent-cli:bench:subagent-retention-bench)
\"$bin\"
```

## Validation

- `nix develop -c cabal test --offline agent-core-test` — 297 examples, 0 failures
- `nix develop -c cabal test --offline agent-cli-test` — 615 examples, 0 failures
- concurrent hydration, restore, eviction, pinned selection, failed persistence, interruption, nested completion, and close behavior covered
- fullscreen tmux smoke test with `gpt-5.6-luna`, including the `/agents` picker