### PR TITLE
fix(openai): handle response.done terminals

### DIFF
--- a/packages/agent-openai/src/Agent/OpenAI/LoopBackend.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/LoopBackend.hs
@@ -395,6 +395,7 @@ openAiResponseSenderWithRetryPolicy retryPolicy observed send
 auxiliaryOutputObserved :: ResponseStreamEvent -> Bool
 auxiliaryOutputObserved = \case
     ResponseCompletedEvent{} -> True
+    ResponseDoneEvent{} -> True
     ResponseFailedEvent{response} -> not (null response.output)
     ResponseIncompleteEvent{} -> True
     ResponseOutputItemAddedEvent{} -> True

--- a/packages/agent-openai/src/Agent/OpenAI/WebSocketClient.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/WebSocketClient.hs
@@ -26,6 +26,7 @@ import Agent.Error
 import Agent.OpenAI.Error (isPreviousResponseIdError, mkOpenAIError)
 import Agent.OpenAI.Features (remoteCompactionV2Feature)
 import Agent.Responses.ResponseMerge (mergeCompletedResponseOutput)
+import Agent.Responses.StreamAssembly (assembleDoneResponse)
 import qualified Agent.Responses.Codec as ResponsesCodec
 import qualified Agent.Transport.WebSocket as WebSocket
 import Agent.Provider
@@ -369,15 +370,16 @@ buildWsPayloadWithOptions options request previousResponseId =
 
 -- | Receive typed WebSocket events until the response is complete.
 -- Accumulates output items from 'ResponseOutputItemDoneEvent' values and
--- returns the response carried by 'ResponseCompletedEvent'.
+-- returns the response carried by a terminal response event.
 receiveWsResponse :: WebSocket.WebSocketRequest -> StreamEventCallback -> IO (Either ApiError Response)
 receiveWsResponse cc onEvent = do
     itemsRef <- newIORef ([] :: [Aeson.Value])
+    lifecycleResponseRef <- newIORef (Nothing :: Maybe Response)
     framesRef <- newIORef (0 :: Int)
     bytesRef <- newIORef (0 :: Int64)
-    loop itemsRef framesRef bytesRef
+    loop itemsRef lifecycleResponseRef framesRef bytesRef
   where
-    loop itemsRef framesRef bytesRef = do
+    loop itemsRef lifecycleResponseRef framesRef bytesRef = do
         msgResult <- WebSocket.receiveWebSocketData cc
         case msgResult of
             Left e -> do
@@ -407,13 +409,36 @@ receiveWsResponse cc onEvent = do
 
                             ResponseOutputItemDoneEvent { item } -> do
                                 modifyIORef' itemsRef (Aeson.toJSON item :)
-                                loop itemsRef framesRef bytesRef
+                                loop itemsRef lifecycleResponseRef framesRef bytesRef
+
+                            ResponseCreatedEvent { response } -> do
+                                writeIORef lifecycleResponseRef (Just response)
+                                loop itemsRef lifecycleResponseRef framesRef bytesRef
+
+                            ResponseInProgressEvent { response } -> do
+                                writeIORef lifecycleResponseRef (Just response)
+                                loop itemsRef lifecycleResponseRef framesRef bytesRef
+
+                            ResponseQueuedEvent { response } -> do
+                                writeIORef lifecycleResponseRef (Just response)
+                                loop itemsRef lifecycleResponseRef framesRef bytesRef
 
                             ResponseCompletedEvent { response } -> do
                                 items <- reverse <$> readIORef itemsRef
                                 logStreamStats "completed" itemsRef framesRef bytesRef
                                 WebSocket.completeWebSocketRequest cc
                                 parseCompletedResponse items (Aeson.toJSON response)
+
+                            ResponseDoneEvent { responseValue } -> do
+                                items <- reverse <$> readIORef itemsRef
+                                lifecycleResponse <- readIORef lifecycleResponseRef
+                                logStreamStats "done" itemsRef framesRef bytesRef
+                                WebSocket.completeWebSocketRequest cc
+                                pure $
+                                    assembleDoneResponse
+                                        lifecycleResponse
+                                        items
+                                        responseValue
 
                             ResponseIncompleteEvent { response } -> do
                                 items <- reverse <$> readIORef itemsRef
@@ -426,9 +451,9 @@ receiveWsResponse cc onEvent = do
                                 WebSocket.completeWebSocketRequest cc
                                 pure $ Left (failedResponseError response)
 
-                            -- Ignore other event variants (created, added,
-                            -- content deltas, and future event types).
-                            _ -> loop itemsRef framesRef bytesRef
+                            -- Ignore other event variants (added, content
+                            -- deltas, and future event types).
+                            _ -> loop itemsRef lifecycleResponseRef framesRef bytesRef
 
     recordFrame :: IORef Int -> IORef Int64 -> LBS.ByteString -> IO ()
     recordFrame framesRef bytesRef msgBytes = do

--- a/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
@@ -198,6 +198,19 @@ spec = do
             streamEventToLoopEvent (deltaEvent EventReasoningSummaryTextDelta "sum")
                 `shouldBe` Just (ReasoningDelta "sum")
 
+        it "surfaces unknown provider events as visible activity warnings" do
+            streamEventToLoopEvent
+                (OtherResponseStreamEvent
+                    { otherEventType =
+                        StreamEventUnknown "response.future.done"
+                    , sequenceNumber = Just 42
+                    , eventExtraFields = KeyMap.empty
+                    })
+                `shouldBe`
+                    Just
+                        (ActivityUpdated
+                            "Warning: unsupported provider event response.future.done")
+
         it "ignores empty deltas and unrelated events" do
             streamEventToLoopEvent (deltaEvent EventOutputTextDelta "")
                 `shouldBe` Nothing

--- a/packages/agent-openai/test/Agent/OpenAI/ResponsesSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/ResponsesSpec.hs
@@ -130,6 +130,26 @@ spec = do
                 Aeson.Success other -> expectationFailure ("unexpected event: " <> show other)
                 Aeson.Error err -> expectationFailure err
 
+        it "decodes the Codex WebSocket response.done terminal event losslessly" do
+            let original = Aeson.object
+                    [ "type" .= ("response.done" :: Text)
+                    , "sequence_number" .= (5 :: Int)
+                    , "response" .= Aeson.object
+                        [ "id" .= ("resp_done" :: Text)
+                        , "usage" .= Aeson.Null
+                        ]
+                    , "future_event_field" .= True
+                    ]
+            case Aeson.fromJSON original :: Aeson.Result Responses.ResponseStreamEvent of
+                Aeson.Success event@Responses.ResponseDoneEvent { responseValue } -> do
+                    field "id" responseValue `shouldBe`
+                        Just (Aeson.String "resp_done")
+                    Responses.responseStreamEventType event
+                        `shouldBe` Responses.EventResponseDone
+                    Aeson.toJSON event `shouldBe` original
+                Aeson.Success other -> expectationFailure ("unexpected event: " <> show other)
+                Aeson.Error err -> expectationFailure err
+
         it "decodes response incomplete into its typed terminal constructor" do
             let original = Aeson.object
                     [ "type" .= ("response.incomplete" :: Text)
@@ -333,6 +353,12 @@ assertKnownEvent eventName = do
 
 requiredEventFields :: Text -> [(Key.Key, Aeson.Value)]
 requiredEventFields eventName
+    | eventName == "response.done" =
+        [ ("response", Aeson.object
+            [ "id" .= ("resp_done" :: Text)
+            , "usage" .= Aeson.Null
+            ])
+        ]
     | eventName `elem`
         [ "response.created"
         , "response.in_progress"
@@ -373,7 +399,7 @@ isLeft (Right _) = False
 
 documentedStreamEventTypes :: [Text]
 documentedStreamEventTypes =
-    [ "response.created", "response.in_progress", "response.completed"
+    [ "response.created", "response.in_progress", "response.completed", "response.done"
     , "response.failed", "response.incomplete", "response.output_item.added"
     , "response.output_item.done", "response.content_part.added", "response.content_part.done"
     , "response.output_text.delta", "response.output_text.done", "response.refusal.delta"

--- a/packages/agent-responses/src/Agent/Responses/HttpSSE.hs
+++ b/packages/agent-responses/src/Agent/Responses/HttpSSE.hs
@@ -122,8 +122,12 @@ performResponsesHttpSse
 
 retainForResponse :: ResponseStreamEvent -> Bool
 retainForResponse = \case
+    ResponseCreatedEvent {} -> True
+    ResponseInProgressEvent {} -> True
+    ResponseQueuedEvent {} -> True
     ResponseOutputItemDoneEvent {} -> True
     ResponseCompletedEvent {} -> True
+    ResponseDoneEvent {} -> True
     ResponseIncompleteEvent {} -> True
     ResponseErrorEvent {} -> True
     ResponseNestedErrorEvent {} -> True

--- a/packages/agent-responses/src/Agent/Responses/LoopBackend.hs
+++ b/packages/agent-responses/src/Agent/Responses/LoopBackend.hs
@@ -304,6 +304,11 @@ assistantTextFromResponse response = case
 
 streamEventToLoopEvent :: ResponseStreamEvent -> Maybe LoopEvent
 streamEventToLoopEvent = \case
+    OtherResponseStreamEvent
+        { otherEventType = StreamEventUnknown eventType } ->
+            Just
+                (ActivityUpdated
+                    ("Warning: unsupported provider event " <> eventType))
     OtherResponseStreamEvent { otherEventType, eventExtraFields } ->
         case extraDeltaText eventExtraFields of
             Just text -> case otherEventType of

--- a/packages/agent-responses/src/Agent/Responses/ResponseMerge.hs
+++ b/packages/agent-responses/src/Agent/Responses/ResponseMerge.hs
@@ -1,5 +1,6 @@
 module Agent.Responses.ResponseMerge
     ( mergeCompletedResponseOutput
+    , mergeDoneResponse
     ) where
 
 import qualified Data.Aeson as Aeson
@@ -25,6 +26,34 @@ mergeCompletedResponseOutput streamedItems responseVal =
                     mergedItems = mergeOutputItems finalItems streamedItems
                 in Aeson.Object (KeyMap.insert "output" (Aeson.Array (Vector.fromList mergedItems)) robj)
         _ -> responseVal
+
+-- | Reconstruct the terminal response carried by the Codex WebSocket
+-- @response.done@ event. That event can contain only a partial response
+-- object, so overlay it on the latest lifecycle response, normalize a missing
+-- final status to @completed@, and attach streamed output items.
+mergeDoneResponse
+    :: Maybe Aeson.Value
+    -> [Aeson.Value]
+    -> Aeson.Value
+    -> Aeson.Value
+mergeDoneResponse baseResponse streamedItems doneResponse =
+    mergeCompletedResponseOutput streamedItems withTerminalStatus
+  where
+    mergedResponse = case (baseResponse, doneResponse) of
+        (Just (Aeson.Object baseObject), Aeson.Object doneObject) ->
+            Aeson.Object $
+                KeyMap.foldrWithKey
+                    KeyMap.insert
+                    baseObject
+                    doneObject
+        (_, value) -> value
+
+    withTerminalStatus = case (doneResponse, mergedResponse) of
+        (Aeson.Object doneObject, Aeson.Object mergedObject)
+            | not (KeyMap.member "status" doneObject) ->
+                Aeson.Object
+                    (KeyMap.insert "status" (Aeson.String "completed") mergedObject)
+        _ -> mergedResponse
 
 mergeOutputItems :: [Aeson.Value] -> [Aeson.Value] -> [Aeson.Value]
 mergeOutputItems finalItems streamedItems =

--- a/packages/agent-responses/src/Agent/Responses/StreamAssembly.hs
+++ b/packages/agent-responses/src/Agent/Responses/StreamAssembly.hs
@@ -1,12 +1,16 @@
 -- | Provider-neutral terminal response assembly for Responses SSE streams.
 module Agent.Responses.StreamAssembly
     ( StreamAssemblyConfig(..)
+    , assembleDoneResponse
     , buildStreamResponse
     , failedResponseMessage
     ) where
 
 import Agent.Error (ApiError(..))
-import Agent.Responses.ResponseMerge (mergeCompletedResponseOutput)
+import Agent.Responses.ResponseMerge
+    ( mergeCompletedResponseOutput
+    , mergeDoneResponse
+    )
 import Agent.Responses.Types
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy as LBS
@@ -33,11 +37,17 @@ buildStreamResponse
     :: StreamAssemblyConfig
     -> [ResponseStreamEvent]
     -> Either ApiError Response
-buildStreamResponse config events = case lastMaybe terminalResponses of
-    Just terminal -> decodeMerged terminal
+buildStreamResponse config events = case lastMaybe terminalEvents of
+    Just ResponseCompletedEvent { response } -> decodeMerged response
+    Just ResponseIncompleteEvent { response } -> decodeMerged response
+    Just ResponseDoneEvent { responseValue } ->
+        assembleDoneResponse latestLifecycleResponse doneItems responseValue
+    Just _ -> Left missingCompletion
     Nothing -> Left (Maybe.fromMaybe missingCompletion (firstFailure config events))
   where
-    terminalResponses = Maybe.mapMaybe terminalResponse events
+    terminalEvents = filter isTerminalEvent events
+    latestLifecycleResponse =
+        lastMaybe (Maybe.mapMaybe lifecycleResponse events)
     doneItems =
         [ Aeson.toJSON item
         | ResponseOutputItemDoneEvent { item } <- events
@@ -55,6 +65,22 @@ buildStreamResponse config events = case lastMaybe terminalResponses of
         config.missingCompletionMessage
         (jsonPreview events)
 
+assembleDoneResponse
+    :: Maybe Response
+    -> [Aeson.Value]
+    -> Aeson.Value
+    -> Either ApiError Response
+assembleDoneResponse baseResponse doneItems doneResponse =
+    let merged = mergeDoneResponse
+            (Aeson.toJSON <$> baseResponse)
+            doneItems
+            doneResponse
+    in case Aeson.fromJSON merged of
+        Aeson.Success response -> Right response
+        Aeson.Error err -> Left $ JsonDecodeError
+            (Text.pack err)
+            (jsonPreview merged)
+
 firstFailure
     :: StreamAssemblyConfig
     -> [ResponseStreamEvent]
@@ -70,10 +96,18 @@ firstFailure config = Maybe.listToMaybe . Maybe.mapMaybe failure
             Just (config.classifyFailedResponse response)
         _ -> Nothing
 
-terminalResponse :: ResponseStreamEvent -> Maybe Response
-terminalResponse = \case
-    ResponseCompletedEvent { response } -> Just response
-    ResponseIncompleteEvent { response } -> Just response
+isTerminalEvent :: ResponseStreamEvent -> Bool
+isTerminalEvent = \case
+    ResponseCompletedEvent{} -> True
+    ResponseDoneEvent{} -> True
+    ResponseIncompleteEvent{} -> True
+    _ -> False
+
+lifecycleResponse :: ResponseStreamEvent -> Maybe Response
+lifecycleResponse = \case
+    ResponseCreatedEvent { response } -> Just response
+    ResponseInProgressEvent { response } -> Just response
+    ResponseQueuedEvent { response } -> Just response
     _ -> Nothing
 
 -- | Best available text from a failed terminal response.

--- a/packages/agent-responses/src/Agent/Responses/Types.hs
+++ b/packages/agent-responses/src/Agent/Responses/Types.hs
@@ -1399,6 +1399,7 @@ data StreamEventType
     = EventResponseCreated
     | EventResponseInProgress
     | EventResponseCompleted
+    | EventResponseDone
     | EventResponseFailed
     | EventResponseIncomplete
     | EventOutputItemAdded
@@ -1462,6 +1463,7 @@ streamEventTypeText = \case
     EventResponseCreated -> "response.created"
     EventResponseInProgress -> "response.in_progress"
     EventResponseCompleted -> "response.completed"
+    EventResponseDone -> "response.done"
     EventResponseFailed -> "response.failed"
     EventResponseIncomplete -> "response.incomplete"
     EventOutputItemAdded -> "response.output_item.added"
@@ -1524,6 +1526,7 @@ parseStreamEventType value = case value of
     "response.created" -> EventResponseCreated
     "response.in_progress" -> EventResponseInProgress
     "response.completed" -> EventResponseCompleted
+    "response.done" -> EventResponseDone
     "response.failed" -> EventResponseFailed
     "response.incomplete" -> EventResponseIncomplete
     "response.output_item.added" -> EventOutputItemAdded
@@ -1632,6 +1635,11 @@ data ResponseStreamEvent
         , sequenceNumber   :: !(Maybe Int)
         , eventExtraFields :: !Aeson.Object
         }
+    | ResponseDoneEvent
+        { responseValue    :: !Aeson.Value
+        , sequenceNumber   :: !(Maybe Int)
+        , eventExtraFields :: !Aeson.Object
+        }
     | ResponseFailedEvent
         { response         :: !Response
         , sequenceNumber   :: !(Maybe Int)
@@ -1681,6 +1689,7 @@ responseStreamEventType = \case
     ResponseCreatedEvent{} -> EventResponseCreated
     ResponseInProgressEvent{} -> EventResponseInProgress
     ResponseCompletedEvent{} -> EventResponseCompleted
+    ResponseDoneEvent{} -> EventResponseDone
     ResponseFailedEvent{} -> EventResponseFailed
     ResponseIncompleteEvent{} -> EventResponseIncomplete
     ResponseQueuedEvent{} -> EventResponseQueued
@@ -1701,6 +1710,12 @@ instance ToJSON ResponseStreamEvent where
             lifecycleEvent "response.in_progress" response sequenceNumber eventExtraFields
         ResponseCompletedEvent { response, sequenceNumber, eventExtraFields } ->
             lifecycleEvent "response.completed" response sequenceNumber eventExtraFields
+        ResponseDoneEvent { responseValue, sequenceNumber, eventExtraFields } ->
+            objectWith eventExtraFields
+                [ Just (field "type" ("response.done" :: Text))
+                , optionalField "sequence_number" sequenceNumber
+                , Just (field "response" responseValue)
+                ]
         ResponseFailedEvent { response, sequenceNumber, eventExtraFields } ->
             lifecycleEvent "response.failed" response sequenceNumber eventExtraFields
         ResponseIncompleteEvent { response, sequenceNumber, eventExtraFields } ->
@@ -1754,6 +1769,10 @@ instance FromJSON ResponseStreamEvent where
             EventResponseCreated -> lifecycle ResponseCreatedEvent sequenceNumber o
             EventResponseInProgress -> lifecycle ResponseInProgressEvent sequenceNumber o
             EventResponseCompleted -> lifecycle ResponseCompletedEvent sequenceNumber o
+            EventResponseDone -> ResponseDoneEvent
+                <$> o .: "response"
+                <*> pure sequenceNumber
+                <*> pure (without ["type", "sequence_number", "response"] o)
             EventResponseFailed -> lifecycle ResponseFailedEvent sequenceNumber o
             EventResponseIncomplete -> lifecycle ResponseIncompleteEvent sequenceNumber o
             EventResponseQueued -> lifecycle ResponseQueuedEvent sequenceNumber o

--- a/packages/agent-responses/test/Agent/Responses/StreamAssemblySpec.hs
+++ b/packages/agent-responses/test/Agent/Responses/StreamAssemblySpec.hs
@@ -21,6 +21,22 @@ spec = describe "buildStreamResponse" do
         [name | FunctionCallItem FunctionCall { name } <- response.output]
             `shouldBe` ["echo"]
 
+    it "assembles a partial response.done after a function call" do
+        events <- expectRight $ parseSseEvents $ Text.intercalate ""
+            [ sseBlock "response.created"
+                "{\"type\":\"response.created\",\"response\":{\"id\":\"resp-done\",\"created_at\":0,\"model\":\"test\",\"status\":\"in_progress\",\"output\":[]}}"
+            , sseBlock "response.output_item.done"
+                "{\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"type\":\"function_call\",\"call_id\":\"call-done\",\"name\":\"shell_command\",\"arguments\":\"{\\\"command\\\":\\\"echo done\\\"}\"}}"
+            , sseBlock "response.done"
+                "{\"type\":\"response.done\",\"response\":{\"usage\":{\"input_tokens\":10,\"output_tokens\":2,\"total_tokens\":12}}}"
+            ]
+        response <- expectRight (buildStreamResponse config events)
+        response.responseId `shouldBe` "resp-done"
+        response.status `shouldBe` ResponseCompleted
+        fmap (.totalTokens) response.usage `shouldBe` Just 12
+        [name | FunctionCallItem FunctionCall { name } <- response.output]
+            `shouldBe` ["shell_command"]
+
     it "uses provider classifiers when no terminal response is present" do
         streamEvents <- expectRight $ parseSseEvents $ sseBlock "error"
             "{\"type\":\"error\",\"error\":{\"message\":\"stream broke\"}}"


### PR DESCRIPTION
## Summary

- decode Codex WebSocket `response.done` as a typed terminal event instead of an unknown event
- assemble its partial response payload with the latest lifecycle response and streamed output items
- terminate reusable WebSocket requests on `response.done` and retain the event in shared SSE assembly
- surface future unknown event discriminators as visible warning activity instead of silently ignoring them
- add codec, function-call, and unknown-event regression coverage

## Root cause

The WebSocket endpoint can finish a tool-call response with `response.done`. We classified that discriminator as unknown, so the receive loop ignored it and waited indefinitely even though the provider had already sent the terminal response.

Known stream frames that are intentionally unused remain quiet. Only genuinely unknown event types now produce a warning such as `Warning: unsupported provider event response.future.done`.

## Tests

- `nix develop -c cabal test --offline agent-responses:agent-responses-test agent-openai:agent-openai-test`
- `nix develop -c cabal test --offline agent-openai:agent-openai-test`
- `nix develop -c cabal build all --offline`
