### PR TITLE
fix(cli): reduce image paste preview latency

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -226,3 +226,15 @@ test-suite agent-cli-test
                     , transformers
                     , unix
                     , vty >= 6.4 && < 7
+
+benchmark image-preview-latency-bench
+    import:           common-options
+    type:             exitcode-stdio-1.0
+    hs-source-dirs:   benchmark
+    main-is:          ImagePreviewLatency.hs
+    ghc-options:      -O2 -rtsopts
+    build-depends:    agent-cli
+                    , agent-core
+                    , base >= 4.17 && < 5
+                    , bytestring
+                    , JuicyPixels

--- a/packages/agent-cli/benchmark/ImagePreviewLatency.hs
+++ b/packages/agent-cli/benchmark/ImagePreviewLatency.hs
@@ -1,0 +1,170 @@
+module Main (main) where
+
+import Agent.CLI.TUI.ImagePreview
+    ( TuiImagePreview(..)
+    , imageDimensions
+    , prepareTuiImagePreview
+    )
+import Agent.Loop (ImageAttachment(..))
+import Codec.Picture
+    ( PixelRGB8(..)
+    , PixelRGBA8(..)
+    , convertRGBA8
+    , decodeImage
+    , encodePng
+    , generateImage
+    , imageHeight
+    , imageWidth
+    , pixelAt
+    )
+import Control.Exception (evaluate)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as LBS
+import Data.List (sort)
+import GHC.Clock (getMonotonicTimeNSec)
+import GHC.Stats
+    ( RTSStats(..)
+    , getRTSStats
+    , getRTSStatsEnabled
+    )
+import System.CPUTime (getCPUTime)
+import System.Environment (getArgs)
+import System.Mem (performMajorGC)
+
+data Sample = Sample
+    { sampleElapsedMillis :: !Double
+    , sampleCpuMillis :: !Double
+    , sampleAllocatedBytes :: !Word
+    }
+
+main :: IO ()
+main = do
+    (width, height, samples) <- parseArgs <$> getArgs
+    statsEnabled <- getRTSStatsEnabled
+    if not statsEnabled
+        then fail "run with +RTS -T"
+        else do
+            let source =
+                    generateImage
+                        (\x y ->
+                            PixelRGB8
+                                (fromIntegral (x * 31 + y * 17))
+                                (fromIntegral (x * 13 + y * 29))
+                                (fromIntegral (x * 7 + y * 37)))
+                        width
+                        height
+                encoded = LBS.toStrict (encodePng source)
+            BS.length encoded `seq`
+                putStrLn
+                    ("png="
+                        <> show width
+                        <> "x"
+                        <> show height
+                        <> " bytes="
+                        <> show (BS.length encoded)
+                        <> " samples="
+                        <> show samples)
+            benchmark "old-full-decode" samples oldDimensions encoded
+            benchmark "new-ansi-preview" samples newAnsiPreview encoded
+            benchmark "new-header-only" samples newDimensions encoded
+
+parseArgs :: [String] -> (Int, Int, Int)
+parseArgs = \case
+    [width, height, samples] ->
+        (read width, read height, read samples)
+    _ -> (3840, 2160, 7)
+
+benchmark
+    :: String
+    -> Int
+    -> (Int -> BS.ByteString -> Int)
+    -> BS.ByteString
+    -> IO ()
+benchmark label count action source = do
+    measured <- mapM (\nonce -> measure action nonce source) [1 .. max 1 count]
+    let elapsed = median (map (.sampleElapsedMillis) measured)
+        cpu = median (map (.sampleCpuMillis) measured)
+        allocated = median (map (.sampleAllocatedBytes) measured)
+    putStrLn
+        (label
+            <> " elapsed-ms="
+            <> show elapsed
+            <> " cpu-ms="
+            <> show cpu
+            <> " allocated-bytes="
+            <> show allocated)
+
+measure :: (Int -> BS.ByteString -> Int) -> Int -> BS.ByteString -> IO Sample
+measure action nonce source = do
+    let input = BS.copy source
+    BS.length input `seq` pure ()
+    performMajorGC
+    beforeStats <- getRTSStats
+    beforeCpu <- getCPUTime
+    beforeElapsed <- getMonotonicTimeNSec
+    checksum <- evaluate (action nonce input)
+    afterElapsed <- getMonotonicTimeNSec
+    afterCpu <- getCPUTime
+    afterStats <- getRTSStats
+    checksum `seq`
+        pure Sample
+            { sampleElapsedMillis =
+                fromIntegral (afterElapsed - beforeElapsed) / 1_000_000
+            , sampleCpuMillis =
+                fromIntegral (afterCpu - beforeCpu) / 1_000_000_000
+            , sampleAllocatedBytes =
+                fromIntegral
+                    (allocated_bytes afterStats - allocated_bytes beforeStats)
+            }
+
+{-# NOINLINE oldDimensions #-}
+oldDimensions :: Int -> BS.ByteString -> Int
+oldDimensions nonce bytes =
+    case decodeImage bytes of
+        Left err -> error err
+        Right dynamic ->
+            let image = convertRGBA8 dynamic
+                width = imageWidth image
+                height = imageHeight image
+                PixelRGBA8 red green blue alpha =
+                    pixelAt image (width - 1) (height - 1)
+            in width
+                + height
+                + fromIntegral red
+                + fromIntegral green
+                + fromIntegral blue
+                + fromIntegral alpha
+                + nonce
+
+{-# NOINLINE newDimensions #-}
+newDimensions :: Int -> BS.ByteString -> Int
+newDimensions nonce bytes =
+    case imageDimensions "image/png" bytes of
+        Left err -> error (show err)
+        Right (width, height) -> width + height + nonce
+
+{-# NOINLINE newAnsiPreview #-}
+newAnsiPreview :: Int -> BS.ByteString -> Int
+newAnsiPreview nonce bytes =
+    case prepareTuiImagePreview
+        ImageAttachment
+            { imageMime = "image/png"
+            , imageBytes = bytes
+            } of
+        Left err -> error (show err)
+        Right preview ->
+            let image = preview.previewSample
+                width = imageWidth image
+                height = imageHeight image
+                PixelRGB8 red green blue =
+                    pixelAt image (width - 1) (height - 1)
+            in width
+                + height
+                + fromIntegral red
+                + fromIntegral green
+                + fromIntegral blue
+                + nonce
+
+median :: Ord a => [a] -> a
+median values =
+    sort values !! (length values `div` 2)

--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -71,8 +71,10 @@ import Agent.CLI.Clipboard
     ( ClipboardContent(..)
     , formatImageSize
     , loadImagesFromPastedText
+    , nonEmptyClipboardImages
     , readClipboard
     , readClipboardImages
+    , readClipboardImagesImageFirst
     )
 import Agent.CLI.Command
 import Agent.CLI.Compaction
@@ -3146,6 +3148,7 @@ replWithDraft env@SessionEnv
                         (isNothing fullscreen)
                         images
                     syncFullscreenImagePreviews
+                    fullscreenEvent (UiSetNotice Nothing)
                     displayInfo message $
                         Text.putStrLn
                             (roleMuted stdoutColor
@@ -3168,6 +3171,26 @@ replWithDraft env@SessionEnv
                                         (roleMuted stdoutColor
                                             (glyphOk <> message))
             continueWith keptDraft
+        ReplClipboardPasteOrText keptDraft pastedDraft -> do
+            imagesResult <- readClipboardImagesImageFirst
+            case nonEmptyClipboardImages imagesResult of
+                Just images -> do
+                    message <- queueAttachedImages
+                        attachmentsRef
+                        previewIdRef
+                        stdoutColor
+                        (isNothing fullscreen)
+                        images
+                    syncFullscreenImagePreviews
+                    fullscreenEvent (UiSetNotice Nothing)
+                    displayInfo message $
+                        Text.putStrLn
+                            (roleMuted stdoutColor
+                                (glyphOk <> message))
+                    continueWith keptDraft
+                Nothing -> do
+                    fullscreenEvent (UiSetNotice Nothing)
+                    continueWith pastedDraft
         ReplChooseModel keptDraft ->
             chooseModel keptDraft (continueWith keptDraft)
         ReplChooseEffort keptDraft ->

--- a/packages/agent-cli/src/Agent/CLI/Clipboard.hs
+++ b/packages/agent-cli/src/Agent/CLI/Clipboard.hs
@@ -4,6 +4,7 @@ module Agent.CLI.Clipboard
     , readClipboard
     , readClipboardImage
     , readClipboardImages
+    , readClipboardImagesImageFirst
     , nonEmptyClipboardImages
     , loadImagesFromPastedText
     , formatImageSize
@@ -68,6 +69,27 @@ readClipboardImages = do
                 Right images@(_:_) -> pure (Right images)
                 Right [] -> pure (Left "no image found on the clipboard")
                 Left err -> pure (Left err)
+
+-- | Fast path for a terminal bracketed paste. Screenshots and copied browser
+-- images usually expose bitmap data directly; checking Finder file coercions
+-- first is especially expensive on macOS because AppleScript may spend close
+-- to a second attempting to turn the bitmap into a file list.
+readClipboardImagesImageFirst :: IO (Either Text [ImageAttachment])
+readClipboardImagesImageFirst = do
+    bitmap <- readClipboardImageBytes
+    case bitmap of
+        Right image -> pure (Right [image])
+        Left bitmapError -> do
+            paths <- readClipboardPaths
+            imagePaths <- filterM isImageFile paths
+            case imagePaths of
+                [] -> pure (Left bitmapError)
+                ps -> do
+                    loaded <- mapM readImageFile ps
+                    case sequence loaded of
+                        Right images@(_:_) -> pure (Right images)
+                        Right [] -> pure (Left bitmapError)
+                        Left err -> pure (Left err)
 
 -- | Prefer PNG; fall back to JPEG. Back-compat for one-image callers.
 readClipboardImage :: IO (Either Text ImageAttachment)

--- a/packages/agent-cli/src/Agent/CLI/Input.hs
+++ b/packages/agent-cli/src/Agent/CLI/Input.hs
@@ -130,6 +130,10 @@ data ReplLine
     | ReplPasted Text
     -- | Attach a native clipboard image while keeping the current draft.
     | ReplClipboardPaste !Text !(Maybe [ImageAttachment])
+    -- | Classify a bracketed paste off the UI thread. If the clipboard contains
+    -- an image, attach it and keep the original draft; otherwise restore the
+    -- supplied draft with the pasted terminal text inserted.
+    | ReplClipboardPasteOrText !Text !Text
     | ReplCycleMode Text
     -- ^ Shift+Tab: cycle idle mode and keep the current draft.
     | ReplChooseModel Text

--- a/packages/agent-cli/src/Agent/CLI/Plan.hs
+++ b/packages/agent-cli/src/Agent/CLI/Plan.hs
@@ -222,6 +222,10 @@ readChangeNotes interrupt color = do
             if Text.null (Text.strip text)
                 then readChangeNotes interrupt color
                 else pure (Text.strip text)
+        ReplClipboardPasteOrText _ text ->
+            if Text.null (Text.strip text)
+                then readChangeNotes interrupt color
+                else pure (Text.strip text)
         ReplCycleMode _ ->
             -- Shift+Tab is idle-prompt only; keep asking for notes.
             readChangeNotes interrupt color
@@ -259,6 +263,10 @@ askQuestion interrupt resolveColor question options = do
                                 then pure Nothing
                                 else pure (Just (Text.strip text))
                         ReplClipboardPaste text _ ->
+                            if Text.null (Text.strip text)
+                                then askQuestion interrupt resolveColor question []
+                                else pure (Just (Text.strip text))
+                        ReplClipboardPasteOrText _ text ->
                             if Text.null (Text.strip text)
                                 then askQuestion interrupt resolveColor question []
                                 else pure (Just (Text.strip text))

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -136,6 +136,7 @@ import Brick.Widgets.Border (borderWithLabel)
 import qualified Brick.Widgets.Border as Border
 import Brick.Widgets.Border.Style (unicodeRounded)
 import Brick.Widgets.Center (center, centerLayer, hCenter)
+import Codec.Picture (pixelAt)
 import Control.Concurrent.Async (wait, waitCatch, withAsync)
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.STM
@@ -347,8 +348,31 @@ setFullscreenImagePreviews
     :: FullscreenRuntime
     -> [ImageAttachment]
     -> IO ()
-setFullscreenImagePreviews runtime =
-    enqueueAppEvent runtime . AppSetImagePreviews
+setFullscreenImagePreviews runtime images = do
+    previous <- readIORef runtime.runtimeImagePreviews
+    prepared <-
+        if map fst previous == images
+            then pure previous
+            else do
+                let next =
+                        mapMaybe
+                            (\image ->
+                                case prepareTuiImagePreview image of
+                                    Left _ -> Nothing
+                                    Right preview -> Just (image, preview))
+                            images
+                -- ANSI previews force the sampled image during Brick drawing.
+                -- Build that sample here on the model worker instead of
+                -- stalling the Brick event/render thread.
+                unless runtime.runtimeNativeImagePreviews $
+                    mapM_
+                        (\(_, preview) ->
+                            void $
+                                pure $!
+                                    pixelAt preview.previewSample 0 0)
+                        next
+                pure next
+    enqueueAppEvent runtime (AppSetImagePreviews prepared)
 
 hasQueuedFullscreenInput :: FullscreenRuntime -> IO Bool
 hasQueuedFullscreenInput runtime =
@@ -3280,22 +3304,13 @@ handleEventInner event = case event of
                 , appSlashIndex = 0
                 , appSlashDismissed = False
                 }
-    AppEvent (AppSetImagePreviews images) ->
+    AppEvent (AppSetImagePreviews prepared) ->
         do
             state <- get
             previous <-
                 liftIO $
                     readIORef state.appRuntime.runtimeImagePreviews
-            let unchanged = map fst previous == images
-                prepared
-                    | unchanged = previous
-                    | otherwise =
-                        mapMaybe
-                            (\image ->
-                                case prepareTuiImagePreview image of
-                                    Left _ -> Nothing
-                                    Right preview -> Just (image, preview))
-                            images
+            let unchanged = map fst previous == map fst prepared
             liftIO do
                 when (not unchanged) do
                     writeIORef

--- a/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
@@ -26,10 +26,6 @@ module Agent.CLI.TUI.Composer
     , wrapDraft
     ) where
 
-import Agent.CLI.Clipboard
-    ( nonEmptyClipboardImages
-    , readClipboardImages
-    )
 import Agent.CLI.Command
     ( SlashMenu(..)
     , SlashSuggestion(..)
@@ -142,6 +138,7 @@ isPromptPrelude :: FullscreenInput -> Bool
 isPromptPrelude input =
     case input.fullscreenInputLine of
         ReplClipboardPaste _ _ -> True
+        ReplClipboardPasteOrText _ _ -> True
         _ -> False
 
 takeFullscreenInput
@@ -780,15 +777,15 @@ handleComposerKey
         V.EvKey (V.KChar character) [] ->
             insertText (Text.singleton character)
         V.EvPaste bytes -> do
-            images <- liftIO $
-                nonEmptyClipboardImages <$> readClipboardImages
-            case images of
-                Just attached ->
-                    submitRaw
-                        (ReplClipboardPaste ui.uiDraft (Just attached))
-                Nothing -> do
-                    insertText (decodePaste bytes)
-                    modify' \current -> current { appPasted = True }
+            let pasted = decodePaste bytes
+                before = Text.take ui.uiCursor ui.uiDraft
+                after = Text.drop ui.uiCursor ui.uiDraft
+                pastedDraft = before <> pasted <> after
+            modifyUi
+                (UiSetNotice
+                    (Just (progressNotice "Reading clipboard…")))
+            submitRaw
+                (ReplClipboardPasteOrText ui.uiDraft pastedDraft)
         _ -> pure ()
   where
     submitRaw replLine = do

--- a/packages/agent-cli/src/Agent/CLI/TUI/ImagePreview.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/ImagePreview.hs
@@ -5,6 +5,7 @@ module Agent.CLI.TUI.ImagePreview
     ( NativePreviewPlacement(..)
     , TuiImagePreview(..)
     , nativePreviewPlacements
+    , imageDimensions
     , prepareTuiImagePreview
     , previewCellSize
     , previewImageAt
@@ -15,11 +16,13 @@ import Agent.CLI.ImagePreview (kittyCompatibleAttachment)
 import Agent.Loop (ImageAttachment(..))
 import Brick (Widget, raw)
 import Codec.Picture
-    ( Image
+    ( DynamicImage(..)
+    , Image
     , PixelRGB8(..)
-    , PixelRGBA8
+    , PixelRGBA8(..)
     , convertRGBA8
     , decodeImage
+    , dynamicMap
     , generateImage
     , imageData
     , imageHeight
@@ -27,6 +30,7 @@ import Codec.Picture
     , pixelAt
     )
 import qualified Data.ByteString as BS
+import Data.Bits ((.|.), shiftL)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Vector.Storable as Vector
@@ -84,26 +88,155 @@ instance Show TuiImagePreview where
 
 prepareTuiImagePreview :: ImageAttachment -> Either Text TuiImagePreview
 prepareTuiImagePreview ImageAttachment{imageMime, imageBytes} = do
-    dynamic <- firstText (decodeImage imageBytes)
-    let image = convertRGBA8 dynamic
-        sourceWidth = imageWidth image
-        sourceHeight = imageHeight image
-        (targetWidth, targetHeight) =
-            previewSize sourceWidth sourceHeight
+    (sourceWidth, sourceHeight) <- imageDimensions imageMime imageBytes
+    let (targetWidth, targetHeight) =
+            previewSampleSize sourceWidth sourceHeight
     pure TuiImagePreview
         { previewMime = imageMime
         , previewBytes = BS.length imageBytes
         , previewSourceWidth = sourceWidth
         , previewSourceHeight = sourceHeight
         , previewSample =
-            generateImage
-                (\x y -> samplePixel image targetWidth targetHeight x y)
-                targetWidth
-                targetHeight
+            case decodeImage imageBytes of
+                Left _ ->
+                    generateImage
+                        (\_ _ -> previewBackground)
+                        1
+                        1
+                Right dynamic ->
+                    sampleDynamicImage
+                        dynamic
+                        targetWidth
+                        targetHeight
         , previewKittyAttachment =
             kittyCompatibleAttachment
                 (ImageAttachment{imageMime, imageBytes})
         }
+
+-- | Read common image dimensions without inflating the complete compressed
+-- image. macOS clipboard screenshots arrive as PNG, so native terminal
+-- previews can be placed after inspecting only the 24-byte PNG header.
+-- Formats without a cheap parser retain the full-decoder fallback.
+imageDimensions :: Text -> BS.ByteString -> Either Text (Int, Int)
+imageDimensions mime bytes
+    | normalized == "image/png" =
+        pngDimensions bytes
+    | normalized == "image/jpeg" || normalized == "image/jpg" =
+        jpegDimensions bytes
+    | otherwise = do
+        dynamic <- firstText (decodeImage bytes)
+        pure (dynamicWidth dynamic, dynamicHeight dynamic)
+  where
+    normalized = Text.toLower mime
+
+pngDimensions :: BS.ByteString -> Either Text (Int, Int)
+pngDimensions bytes
+    | BS.length bytes < 24 =
+        Left "invalid PNG header"
+    | BS.take 8 bytes /= pngSignature =
+        Left "invalid PNG signature"
+    | BS.take 4 (BS.drop 12 bytes) /= "IHDR" =
+        Left "PNG has no leading IHDR chunk"
+    | width <= 0 || height <= 0 =
+        Left "invalid PNG dimensions"
+    | otherwise =
+        Right (width, height)
+  where
+    width = word32beAt bytes 16
+    height = word32beAt bytes 20
+
+pngSignature :: BS.ByteString
+pngSignature = BS.pack [137, 80, 78, 71, 13, 10, 26, 10]
+
+jpegDimensions :: BS.ByteString -> Either Text (Int, Int)
+jpegDimensions bytes
+    | BS.length bytes < 4
+        || BS.index bytes 0 /= 0xff
+        || BS.index bytes 1 /= 0xd8 =
+        Left "invalid JPEG header"
+    | otherwise =
+        scan 2
+  where
+    size = BS.length bytes
+
+    scan offset
+        | offset + 1 >= size =
+            Left "JPEG dimensions not found"
+        | BS.index bytes offset /= 0xff =
+            scan (offset + 1)
+        | otherwise =
+            let markerOffset = skipFill (offset + 1)
+            in if markerOffset >= size
+                then Left "truncated JPEG marker"
+                else
+                    let marker = BS.index bytes markerOffset
+                        segment = markerOffset + 1
+                    in if isStartOfFrame marker
+                        then frameDimensions segment
+                        else if marker == 0xd9 || marker == 0xda
+                            then Left "JPEG dimensions not found"
+                            else if isStandaloneMarker marker
+                                then scan segment
+                                else
+                                    if segment + 1 >= size
+                                        then Left "truncated JPEG segment"
+                                        else
+                                            let segmentLength =
+                                                    word16beAt bytes segment
+                                            in if segmentLength < 2
+                                                then Left
+                                                    "invalid JPEG segment length"
+                                                else scan
+                                                    (segment + segmentLength)
+
+    skipFill offset
+        | offset < size && BS.index bytes offset == 0xff =
+            skipFill (offset + 1)
+        | otherwise = offset
+
+    frameDimensions segment
+        | segment + 6 >= size =
+            Left "truncated JPEG frame"
+        | word16beAt bytes segment < 7 =
+            Left "invalid JPEG frame"
+        | width <= 0 || height <= 0 =
+            Left "invalid JPEG dimensions"
+        | otherwise =
+            Right (width, height)
+      where
+        height = word16beAt bytes (segment + 3)
+        width = word16beAt bytes (segment + 5)
+
+isStartOfFrame :: Word8 -> Bool
+isStartOfFrame marker =
+    marker `elem`
+        [ 0xc0, 0xc1, 0xc2, 0xc3
+        , 0xc5, 0xc6, 0xc7
+        , 0xc9, 0xca, 0xcb
+        , 0xcd, 0xce, 0xcf
+        ]
+
+isStandaloneMarker :: Word8 -> Bool
+isStandaloneMarker marker =
+    marker == 0x01 || marker >= 0xd0 && marker <= 0xd8
+
+word16beAt :: BS.ByteString -> Int -> Int
+word16beAt bytes offset =
+    fromIntegral (BS.index bytes offset) `shiftL` 8
+        .|. fromIntegral (BS.index bytes (offset + 1))
+
+word32beAt :: BS.ByteString -> Int -> Int
+word32beAt bytes offset =
+    fromIntegral (BS.index bytes offset) `shiftL` 24
+        .|. fromIntegral (BS.index bytes (offset + 1)) `shiftL` 16
+        .|. fromIntegral (BS.index bytes (offset + 2)) `shiftL` 8
+        .|. fromIntegral (BS.index bytes (offset + 3))
+
+dynamicWidth :: DynamicImage -> Int
+dynamicWidth = dynamicMap imageWidth
+
+dynamicHeight :: DynamicImage -> Int
+dynamicHeight = dynamicMap imageHeight
 
 -- | Size the preview to the supplied terminal-cell bounds while preserving its
 -- aspect ratio. One terminal row represents two sampled pixel rows.
@@ -214,9 +347,9 @@ pixelAttr
                 (V.rgbColor topRed topGreen topBlue))
             (V.rgbColor bottomRed bottomGreen bottomBlue)
 
-previewSize :: Int -> Int -> (Int, Int)
-previewSize =
-    previewSizeWithin maxPreviewColumns maxPreviewPixelRows
+previewSampleSize :: Int -> Int -> (Int, Int)
+previewSampleSize =
+    previewSizeWithin maxPreviewSampleColumns maxPreviewSamplePixelRows
 
 previewSizeWithin :: Int -> Int -> Int -> Int -> (Int, Int)
 previewSizeWithin maxWidth maxHeight width height
@@ -233,15 +366,29 @@ previewSizeWithin maxWidth maxHeight width height
            , max 1 (floor (fromIntegral height * scale))
            )
 
-samplePixel
-    :: Image PixelRGBA8
+sampleDynamicImage
+    :: DynamicImage
     -> Int
     -> Int
-    -> Int
-    -> Int
-    -> PixelRGB8
-samplePixel image targetWidth targetHeight x y =
-    sampleRgbaBox image targetWidth targetHeight x y
+    -> Image PixelRGB8
+sampleDynamicImage dynamic targetWidth targetHeight =
+    case dynamic of
+        ImageRGB8 image ->
+            generateImage
+                (sampleRgbBox image targetWidth targetHeight)
+                targetWidth
+                targetHeight
+        ImageRGBA8 image ->
+            generateImage
+                (sampleRgbaBox image targetWidth targetHeight)
+                targetWidth
+                targetHeight
+        _ ->
+            let image = convertRGBA8 dynamic
+            in generateImage
+                (sampleRgbaBox image targetWidth targetHeight)
+                targetWidth
+                targetHeight
 
 sampleImageBox :: Image PixelRGB8 -> Int -> Int -> Int -> Int -> PixelRGB8
 sampleImageBox image targetWidth targetHeight =
@@ -377,6 +524,15 @@ maxPreviewColumns = 240
 -- Two sampled pixel rows fit in one terminal row via the upper-half block.
 maxPreviewPixelRows :: Int
 maxPreviewPixelRows = 160
+
+-- The ANSI source sample is deliberately smaller than the maximum layout.
+-- It may be upscaled in unusually large terminals, but keeping this bounded
+-- avoids hundreds of thousands of interpreted sampling operations on paste.
+maxPreviewSampleColumns :: Int
+maxPreviewSampleColumns = 96
+
+maxPreviewSamplePixelRows :: Int
+maxPreviewSamplePixelRows = 64
 
 -- Bound work per output pixel so large screenshots remain cheap in the
 -- interpreted development loop while still sampling throughout each source

--- a/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
@@ -94,7 +94,7 @@ data AppEvent
         !(TMVar (Maybe ResumeEntry))
     | forall a. AppSuspend !(IO a) !(TMVar (Either SomeException a))
     | AppSetSkillCommands ![SkillCommand]
-    | AppSetImagePreviews ![ImageAttachment]
+    | AppSetImagePreviews ![(ImageAttachment, TuiImagePreview)]
     | AppAgentSnapshot !AgentTarget ![AgentEntry]
     | AppSetWindowTitle !Text
     | AppSyntaxHighlighterLoaded !(Maybe SyntaxHighlighter)

--- a/packages/agent-cli/test/Agent/CLI/TUIComposerSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIComposerSpec.hs
@@ -58,11 +58,15 @@ spec = describe "fullscreen composer" do
             appendFullscreenInput
                 buffer
                 (input (ReplClipboardPaste "draft" Nothing))
+            appendFullscreenInput
+                buffer
+                (input (ReplClipboardPasteOrText "before" "before/path.png"))
             promoteFullscreenInput buffer (input (ReplText "urgent"))
         queued <- atomically (readFullscreenInputs buffer)
         map (.fullscreenInputLine) (toList queued)
             `shouldBe`
                 [ ReplClipboardPaste "draft" Nothing
+                , ReplClipboardPasteOrText "before" "before/path.png"
                 , ReplText "urgent"
                 , ReplText "queued"
                 ]

--- a/packages/agent-cli/test/Agent/CLI/TUIImagePreviewSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIImagePreviewSpec.hs
@@ -3,6 +3,7 @@ module Agent.CLI.TUIImagePreviewSpec (spec) where
 import Agent.CLI.TUI.ImagePreview
     ( NativePreviewPlacement(..)
     , TuiImagePreview(..)
+    , imageDimensions
     , nativePreviewPlacements
     , prepareTuiImagePreview
     , previewCellSize
@@ -19,10 +20,35 @@ import Codec.Picture
     , pixelAt
     )
 import qualified Data.ByteString.Lazy as LBS
+import qualified Data.ByteString as BS
 import Test.Hspec
 
 spec :: Spec
-spec =
+spec = do
+    describe "imageDimensions" do
+        it "reads PNG dimensions without decoding image data" do
+            let headerOnlyPng = BS.pack
+                    [ 137, 80, 78, 71, 13, 10, 26, 10
+                    , 0, 0, 0, 13
+                    , 73, 72, 68, 82
+                    , 0, 0, 6, 64
+                    , 0, 0, 3, 132
+                    ]
+            imageDimensions "image/png" headerOnlyPng
+                `shouldBe` Right (1600, 900)
+
+        it "reads JPEG dimensions from the first start-of-frame marker" do
+            let jpegHeader = BS.pack
+                    [ 0xff, 0xd8
+                    , 0xff, 0xc0
+                    , 0x00, 0x11
+                    , 0x08
+                    , 0x01, 0x2c
+                    , 0x02, 0x80
+                    ]
+            imageDimensions "image/jpeg" jpegHeader
+                `shouldBe` Right (640, 300)
+
     describe "prepareTuiImagePreview" do
         it "decodes and samples an image into bounded terminal cells" do
             let source =


### PR DESCRIPTION
## Summary

- move bracketed-paste clipboard classification off the Brick event thread and show immediate `Reading clipboard…` feedback
- prefer bitmap extraction for terminal image pastes on macOS, avoiding the expensive Finder file-list coercion for screenshots
- read PNG/JPEG dimensions from headers for native previews instead of fully decoding the image
- prepare ANSI preview samples before publishing the Brick event, avoid unnecessary RGB-to-RGBA conversion, and bound the retained fallback sample
- add an optimized old/new image preview latency benchmark

## Performance

Live GHCi/tmux smoke test with a 1600x900, 707 KB PNG:

- before: 3.49 s until preview
- after: 1.07 s until preview
- loading feedback visible within 150 ms

Optimized benchmark (`-O2`, median of 7, `+RTS -T`):

| Workload | Old full decode | New ANSI preview | Old allocation | New allocation |
| --- | ---: | ---: | ---: | ---: |
| 1920x1080 | 43.4 ms | 25.4 ms | 241 MB | 23 MB |
| 3840x2160 | 164.3 ms | 87.8 ms | 968 MB | 80 MB |

The native PNG header-only path measures below 0.001 ms with no measured allocation in this benchmark.

Benchmark command:

```sh
nix develop -c cabal build --offline agent-cli:bench:image-preview-latency-bench
bin=$(nix develop -c cabal list-bin agent-cli:bench:image-preview-latency-bench)
"$bin" 1920 1080 7 +RTS -T
"$bin" 3840 2160 7 +RTS -T
```

## Validation

- `nix develop -c cabal repl agent-cli:lib:agent-cli --repl-options='-fno-code'`
- `nix develop -c cabal test agent-cli:agent-cli-test` — 654 examples, 0 failures
- live tmux paste/preview smoke check
- `git diff --check`
