### PR TITLE
fix: harden turn cancellation edge cases

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/CancelWatch.hs
+++ b/packages/agent-cli/src/Agent/CLI/CancelWatch.hs
@@ -1,6 +1,7 @@
 -- | Watch stdin for a bare Esc during an agent turn and soft-cancel.
 module Agent.CLI.CancelWatch
-    ( withEscCancel
+    ( drainEscapeContinuation
+    , withEscCancel
     , withStdinPaused
     , isBareEscape
     ) where
@@ -153,12 +154,20 @@ escLoop cancel paused stopped = go
                                                         then requestCancel cancel
                                                         else do
                                                             c2 <- hGetChar stdin
-                                                            case c2 of
-                                                                '[' -> drainCsi stdin >> go
-                                                                'O' -> do
-                                                                    _ <- hGetChar stdin
-                                                                    go
-                                                                _ -> go
+                                                            drainEscapeContinuation stdin c2
+                                                            go
+
+-- | Consume the remainder of an escape sequence without ever waiting
+-- indefinitely for a fragmented terminal input. SS3 sequences normally have
+-- one byte after @ESC O@, but terminals, tmux, or a truncated paste may omit
+-- it while the writer remains open.
+drainEscapeContinuation :: Handle -> Char -> IO ()
+drainEscapeContinuation h = \case
+    '[' -> drainCsi h
+    'O' -> do
+        ready <- hWaitForInput h 50
+        when ready (void (hGetChar h))
+    _ -> pure ()
 
 drainCsi :: Handle -> IO ()
 drainCsi h = go

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -8,6 +8,7 @@ module Agent.CLI.TUI.App
     , agentPaneVisible
     , completionFlashTransitions
     , conversationScrollbarRenderer
+    , choiceClosesOnUiTransition
     , elapsedMillisSince
     , emitUiEvent
     , hasQueuedFullscreenInput
@@ -1222,6 +1223,11 @@ handleChoiceKey = \case
     V.EvKey V.KEnter [] -> resolveChoice True
     V.EvKey V.KEsc [] -> resolveChoice False
     V.EvKey (V.KChar 'q') [] -> resolveChoice False
+    V.EvKey (V.KChar 'c') modifiers
+        | V.MCtrl `elem` modifiers -> do
+            state <- get
+            _ <- handleCtrlC
+            when state.appUi.uiRunning (resolveChoice False)
     _ -> pure ()
   where
     moveChoice delta =
@@ -1334,6 +1340,11 @@ resolveChoice confirmed = do
 handleTextPromptKey :: V.Event -> EventM Name AppState ()
 handleTextPromptKey = \case
     V.EvKey V.KEsc [] -> resolveTextPrompt False
+    V.EvKey (V.KChar 'c') modifiers
+        | V.MCtrl `elem` modifiers -> do
+            state <- get
+            _ <- handleCtrlC
+            when state.appUi.uiRunning (resolveTextPrompt False)
     V.EvKey V.KEnter [] -> resolveTextPrompt True
     V.EvKey V.KEnter [V.MShift] -> insert "\n"
     V.EvKey V.KPageUp [] ->
@@ -2549,9 +2560,13 @@ drawFooter state =
   where
     footer = case (state.appTextPrompt, state.appChoice, state.appUi.uiFocus) of
         (Just _, _, _) ->
-            "Enter submit  │  Shift+Enter newline  │  PgUp/PgDn scroll  │  Esc cancel"
+            if state.appUi.uiRunning
+                then "Enter submit  │  Shift+Enter newline  │  PgUp/PgDn scroll  │  Esc close  │  Ctrl+C cancel turn"
+                else "Enter submit  │  Shift+Enter newline  │  PgUp/PgDn scroll  │  Esc cancel"
         (Nothing, Just _, _) ->
-            "↑↓ select  │  Enter choose  │  Esc cancel"
+            if state.appUi.uiRunning
+                then "↑↓ select  │  Enter choose  │  Esc close  │  Ctrl+C cancel turn"
+                else "↑↓ select  │  Enter choose  │  Esc cancel"
         (Nothing, Nothing, focus) ->
                 case focus of
                     FocusPermission ->
@@ -3074,7 +3089,7 @@ applyUiEvent uiEvent state =
                 previousUi
                 nextUi
                 newFlashes
-        nextState =
+        nextState0 =
             state
                 { appUi = nextUi
                 , appCompletionFlashes =
@@ -3086,7 +3101,32 @@ applyUiEvent uiEvent state =
                         then 0
                         else state.appNativeProgressKeepaliveBucket
                 }
+        nextState =
+            case state.appChoice of
+                Just choice
+                    | choiceClosesOnUiTransition
+                        previousUi
+                        nextUi
+                        choice ->
+                        nextState0
+                            { appChoice = Nothing
+                            , appChoiceReply = Nothing
+                            }
+                _ -> nextState0
     in Composer.applyComposerUiEvent uiEvent nextState
+
+-- | Turn-scoped choices, such as the live effort selector, become invalid
+-- when their turn stops running. Ordinary idle dialogs remain open, and a
+-- model round that continues into tools keeps the selector visible.
+choiceClosesOnUiTransition
+    :: UiState
+    -> UiState
+    -> ChoiceOverlay
+    -> Bool
+choiceClosesOnUiTransition previous next choice =
+    choice.choiceCloseOnTurnEnd
+        && previous.uiRunning
+        && not next.uiRunning
 
 retainExistingFlashes
     :: UiState
@@ -3383,6 +3423,7 @@ handleEventInner event = case event of
                     , choiceIndex =
                         max 0 (min (max 0 (length rows - 1)) initial)
                     , choiceRows = rows
+                    , choiceCloseOnTurnEnd = False
                     }
                 , appChoiceReply = Just (atomically . putTMVar reply)
                 , appAgentHover = Nothing

--- a/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
@@ -590,6 +590,7 @@ handleEffortControlClick applyUiEvent = do
                                 "Changing effort will restart the current turn."
                             , choiceIndex = initial
                             , choiceRows = [(effort, "") | effort <- efforts]
+                            , choiceCloseOnTurnEnd = True
                             }
                         , appChoiceReply = Just choose
                         }

--- a/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
@@ -219,6 +219,7 @@ data ChoiceOverlay = ChoiceOverlay
     , choiceBody :: !Text
     , choiceIndex :: !Int
     , choiceRows :: ![(Text, Text)]
+    , choiceCloseOnTurnEnd :: !Bool
     }
 
 data ResumeOverlay = ResumeOverlay

--- a/packages/agent-cli/test/Agent/CLI/CancelWatchSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CancelWatchSpec.hs
@@ -1,14 +1,29 @@
 module Agent.CLI.CancelWatchSpec (spec) where
 
-import Agent.CLI.CancelWatch (isBareEscape)
+import Agent.CLI.CancelWatch (drainEscapeContinuation, isBareEscape)
+import System.IO (hClose)
+import System.Posix.IO (createPipe, fdToHandle)
+import System.Timeout (timeout)
 import Test.Hspec
 
 spec :: Spec
-spec = describe "isBareEscape" do
-    it "accepts a lone ESC" do
-        isBareEscape "\ESC" `shouldBe` True
+spec = do
+    describe "isBareEscape" do
+        it "accepts a lone ESC" do
+            isBareEscape "\ESC" `shouldBe` True
 
-    it "rejects CSI / empty / other" do
-        isBareEscape "\ESC[" `shouldBe` False
-        isBareEscape "" `shouldBe` False
-        isBareEscape "a" `shouldBe` False
+        it "rejects CSI / empty / other" do
+            isBareEscape "\ESC[" `shouldBe` False
+            isBareEscape "" `shouldBe` False
+            isBareEscape "a" `shouldBe` False
+
+    describe "drainEscapeContinuation" do
+        it "does not block forever on an incomplete SS3 sequence" do
+            (readFd, writeFd) <- createPipe
+            readHandle <- fdToHandle readFd
+            writeHandle <- fdToHandle writeFd
+            result <- timeout 500000 $
+                drainEscapeContinuation readHandle 'O'
+            hClose readHandle
+            hClose writeHandle
+            result `shouldBe` Just ()

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -8,6 +8,7 @@ import Agent.CLI.TUI.App
     , agentPaneVisible
     , completionFlashTransitions
     , conversationScrollbarRenderer
+    , choiceClosesOnUiTransition
     , elapsedMillisSince
     , fullscreenVtyConfig
     , motionDemandFor
@@ -17,6 +18,10 @@ import Agent.CLI.TUI.App
     , repositoryHeaderText
     , selectedAgentConversation
     , uiEventRestartsMotionSchedule
+    )
+import Agent.CLI.TUI.Types
+    ( ChoiceOverlay(..)
+    , ChoicePresentation(..)
     )
 import Agent.Loop (LoopEvent(..), emptyTurnOutput)
 import Brick
@@ -41,6 +46,60 @@ import Test.Hspec
 
 spec :: Spec
 spec = do
+    describe "choice overlay lifecycle" do
+        it "closes a running-turn choice on success or cancellation" do
+            let running =
+                    reduceUi (UiLoop TurnStarted) initialUiState
+                finished =
+                    reduceUi
+                        (UiLoop
+                            (TurnFinished
+                                (emptyTurnOutput
+                                    "response-1"
+                                    []
+                                    Nothing)))
+                        running
+                cancelled =
+                    reduceUi (UiTurnEnded BlockCancelled) running
+            choiceClosesOnUiTransition
+                running
+                finished
+                (choiceOverlay True)
+                `shouldBe` True
+            choiceClosesOnUiTransition
+                running
+                cancelled
+                (choiceOverlay True)
+                `shouldBe` True
+
+        it "preserves ordinary choices and continuing tool rounds" do
+            let running =
+                    reduceUi (UiLoop TurnStarted) initialUiState
+                call =
+                    functionToolCall
+                        "tool-1"
+                        "shell_command"
+                        "{\"command\":\"true\"}"
+                continuing =
+                    reduceUi
+                        (UiLoop
+                            (TurnFinished
+                                (emptyTurnOutput
+                                    "response-1"
+                                    [call]
+                                    Nothing)))
+                        running
+            choiceClosesOnUiTransition
+                running
+                (reduceUi (UiTurnEnded BlockCancelled) running)
+                (choiceOverlay False)
+                `shouldBe` False
+            choiceClosesOnUiTransition
+                running
+                continuing
+                (choiceOverlay True)
+                `shouldBe` False
+
     describe "prompt model refresh" do
         it "preserves the live draft and cursor across a provider restart" do
             let before =
@@ -373,6 +432,16 @@ spec = do
                 `shouldBe` Map.singleton (BlockId 7) 1
             advanceCompletionFlashes 400 active
                 `shouldBe` Map.empty
+
+choiceOverlay :: Bool -> ChoiceOverlay
+choiceOverlay closeOnTurnEnd = ChoiceOverlay
+    { choicePresentation = ChoiceDialog
+    , choiceTitle = "choice"
+    , choiceBody = ""
+    , choiceIndex = 0
+    , choiceRows = [("one", "")]
+    , choiceCloseOnTurnEnd = closeOnTurnEnd
+    }
 
 rootEntry :: AgentEntry
 rootEntry = AgentEntry

--- a/packages/agent-core/src/Agent/Loop.hs
+++ b/packages/agent-core/src/Agent/Loop.hs
@@ -42,6 +42,7 @@ import Control.Exception.Safe (SomeException, displayException, tryAny)
 import Data.Aeson (FromJSON(..), ToJSON(..), object, withObject, (.:), (.:?), (.!=), (.=))
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as ByteString
+import Data.Maybe (catMaybes, maybeToList)
 import Data.Text (Text)
 import qualified Data.Text as Text
 
@@ -306,13 +307,16 @@ runToolCalls config = go
                             ((== ParallelSafe)
                                 . toolExecutionPolicyFor config.loopTools)
                             calls
-                prepared <- traverse (prepareToolCall config) batch
+                prepared <- prepareToolCalls config batch
                 batchResults <-
-                    mapConcurrently (runPreparedToolCall config) prepared
+                    catMaybes
+                        <$> mapConcurrently
+                            (runPreparedToolCall config)
+                            prepared
                 continue batchResults remaining
             TurnSequential -> do
                 result <- runOne config call
-                continue [result] rest
+                continue (maybeToList result) rest
 
     continue completed remaining = do
         cancelled <- isCancelled config.loopCancel
@@ -328,7 +332,20 @@ data ToolApproval
 data PreparedToolCall =
     PreparedToolCall !ToolCall !ToolApproval
 
-runOne :: LoopConfig -> ToolCall -> IO ToolCallResult
+prepareToolCalls :: LoopConfig -> [ToolCall] -> IO [PreparedToolCall]
+prepareToolCalls _ [] = pure []
+prepareToolCalls config (call : rest) = do
+    cancelled <- isCancelled config.loopCancel
+    if cancelled
+        then pure []
+        else do
+            prepared <- prepareToolCall config call
+            cancelledAfter <- isCancelled config.loopCancel
+            if cancelledAfter
+                then pure []
+                else (prepared :) <$> prepareToolCalls config rest
+
+runOne :: LoopConfig -> ToolCall -> IO (Maybe ToolCallResult)
 runOne config call =
     prepareToolCall config call >>= runPreparedToolCall config
 
@@ -347,31 +364,35 @@ prepareToolCall config call = do
 runPreparedToolCall
     :: LoopConfig
     -> PreparedToolCall
-    -> IO ToolCallResult
+    -> IO (Maybe ToolCallResult)
 runPreparedToolCall config (PreparedToolCall call approval) = do
-    config.loopOnEvent (ToolStarted call)
-    result <- case approval of
-        ToolApprovalDenied denial ->
-            pure ToolCallResult
-                { callId = call.callId
-                , output = denial
-                , callKind = call.callKind
-                }
-        ToolApprovalRejected ->
-            pure ToolCallResult
-                { callId = call.callId
-                , output = "Tool call rejected by user."
-                , callKind = call.callKind
-                }
-        ToolApprovalGranted ->
-            dispatchRegisteredToolCall
-                config.loopDispatch
-                    { toolDispatchOnOutput = \progressCall output ->
-                        config.loopDispatch.toolDispatchOnOutput progressCall output
-                            >> config.loopOnEvent
-                                (ToolOutputUpdated progressCall.callId output)
-                    }
-                config.loopTools
-                call
-    config.loopOnEvent (ToolFinished result)
-    pure result
+    cancelled <- isCancelled config.loopCancel
+    if cancelled
+        then pure Nothing
+        else do
+            config.loopOnEvent (ToolStarted call)
+            result <- case approval of
+                ToolApprovalDenied denial ->
+                    pure ToolCallResult
+                        { callId = call.callId
+                        , output = denial
+                        , callKind = call.callKind
+                        }
+                ToolApprovalRejected ->
+                    pure ToolCallResult
+                        { callId = call.callId
+                        , output = "Tool call rejected by user."
+                        , callKind = call.callKind
+                        }
+                ToolApprovalGranted ->
+                    dispatchRegisteredToolCall
+                        config.loopDispatch
+                            { toolDispatchOnOutput = \progressCall output ->
+                                config.loopDispatch.toolDispatchOnOutput progressCall output
+                                    >> config.loopOnEvent
+                                        (ToolOutputUpdated progressCall.callId output)
+                            }
+                        config.loopTools
+                        call
+            config.loopOnEvent (ToolFinished result)
+            pure (Just result)

--- a/packages/agent-core/test/Agent/LoopSpec.hs
+++ b/packages/agent-core/test/Agent/LoopSpec.hs
@@ -511,6 +511,56 @@ spec = describe "runLoop" do
                 results `shouldNotBe` []
             other -> expectationFailure ("expected LoopCancelled, got " <> show other)
 
+    it "does not render a rejected tool when approval cancels the turn" do
+        events <- newIORef []
+        submissions <- newIORef []
+        backend <- scriptedBackend submissions
+            [ Right $ emptyTurnOutput "resp-1"
+                [functionToolCall "c1" "echo" "{\"message\":\"hi\"}"]
+                Nothing
+            ]
+        config0 <- testConfig backend
+        let cancel = case config0 of
+                LoopConfig{loopCancel = c} -> c
+            config = config0
+                { loopApprove = \_ -> do
+                    requestCancel cancel
+                    pure (Right False)
+                , loopOnEvent = \event -> modifyIORef' events (event :)
+                }
+        result <- runLoop config Nothing "go"
+        result `shouldBe` Left (LoopCancelled [])
+        seen <- reverse <$> readIORef events
+        seen `shouldBe`
+            [ TurnStarted
+            , TurnFinished $ emptyTurnOutput "resp-1"
+                [functionToolCall "c1" "echo" "{\"message\":\"hi\"}"]
+                Nothing
+            ]
+
+    it "stops preparing a parallel batch after approval cancels" do
+        approvals <- newIORef ([] :: [Text])
+        submissions <- newIORef []
+        backend <- scriptedBackend submissions
+            [ Right $ emptyTurnOutput "resp-1"
+                [ functionToolCall "c1" "echo" "{\"message\":\"one\"}"
+                , functionToolCall "c2" "echo" "{\"message\":\"two\"}"
+                ]
+                Nothing
+            ]
+        config0 <- testConfig backend
+        let cancel = case config0 of
+                LoopConfig{loopCancel = c} -> c
+            config = config0
+                { loopApprove = \call -> do
+                    modifyIORef' approvals (<> [call.callId])
+                    requestCancel cancel
+                    pure (Right False)
+                }
+        result <- runLoop config Nothing "go"
+        result `shouldBe` Left (LoopCancelled [])
+        readIORef approvals `shouldReturn` ["c1"]
+
     it "returns LoopCancelled when cancel arrives during submitTurn" do
         started <- newEmptyMVar
         config0 <- testConfig $ Backend \_prev _inputs _onEvent -> do


### PR DESCRIPTION
## Summary

- bound incomplete SS3 escape-sequence reads so minimal-mode turn cleanup cannot deadlock on `ESC O`
- let Ctrl-C cancel an active turn while a fullscreen choice or text overlay owns keyboard input
- close the live reasoning-effort selector when its turn stops, while preserving idle dialogs and tool-continuation rounds
- stop tool approval/preparation promptly when cancellation lands, without rendering cancelled calls as user-rejected tools

## tmux reproductions

Verified in real 120x36 tmux TTYs with OpenAI `gpt-5.6-luna`.

### Fullscreen effort overlay

1. Start a foreground `sleep` tool call.
2. Click `(medium)` in the composer status to open the live effort selector.
3. Press Ctrl-C.

The command and turn now cancel and the selector closes. The footer also distinguishes `Esc close` from `Ctrl+C cancel turn` while the turn is active.

Also verified that leaving the selector open while the command and model finish normally now returns to the ordinary Ready composer instead of retaining a stale overlay.

### Minimal-mode SS3 cleanup

Previously, sending an incomplete `ESC O` sequence during a turn left the watcher blocked on an unbounded third-byte read. Even after the command and model completed, cleanup waited forever until another byte arrived. The SS3 continuation read is now bounded.

### Approval cancellation

Cancellation during approval no longer emits a rejected tool block, and preparation of a parallel-safe batch stops before prompting for later calls.

## Tests

- `nix develop -c cabal test --offline agent-core:test:agent-core-test agent-cli:test:agent-cli-test`
  - agent-core: 299 examples, 0 failures
  - agent-cli: 618 examples, 0 failures
- real tmux smoke tests with `gpt-5.6-luna`
- `git diff --check`
