### PR TITLE
feat(cli): add /worktree command

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -480,6 +480,9 @@ data RunResult
     | RunResumeSession Text
       -- ^ Persisted session id. Consumed after the current provider-specific
       -- backend shuts down before starting the selected session.
+    | RunSwitchWorktree OsPath Provider Text Text
+      -- ^ Fresh worktree path. Starts a new session after the current backend
+      -- and fullscreen UI have shut down, retaining provider, model, and effort.
 
 data PreparedAgent = PreparedAgent
     { preparedFullscreen :: !(Maybe FullscreenRuntime)
@@ -654,6 +657,19 @@ runAgentWithRestarts options = do
                         , optPrompt = Nothing
                         , optPromptFile = Nothing
                         , optResume = Just sessionId
+                        }
+                    Nothing
+            RunSwitchWorktree path provider model effort ->
+                go fullscreenInputs
+                    current
+                        { optProvider = Just provider
+                        , optModel = Just model
+                        , optCwd = Just path
+                        , optWorktree = False
+                        , optEffort = Just effort
+                        , optPrompt = Nothing
+                        , optPromptFile = Nothing
+                        , optResume = Nothing
                         }
                     Nothing
             RunSwitchProvider next ->
@@ -3752,6 +3768,29 @@ replWithDraft env@SessionEnv
                                                 (roleMuted color
                                                     (glyphSession <> message))
                         continue
+                    ReplWorktree -> do
+                        result <- withReplActivity "Creating worktree…" $
+                            createWorktree cwd (worktreeRoot env.sessionHome)
+                        case result of
+                            Left err -> do
+                                color <- resolveColor stderr
+                                displayError err $
+                                    putTextLn stderr (roleError color err)
+                                continue
+                            Right path -> do
+                                color <- resolveColor stderr
+                                params <- readIORef paramsRef
+                                let message = "worktree: " <> toText path
+                                displayInfo message $
+                                    putTextLn stderr
+                                        (roleMuted color
+                                            (glyphSession <> message))
+                                pure
+                                    (RunSwitchWorktree
+                                        path
+                                        provider
+                                        (currentModel params)
+                                        (currentEffort params))
                     ReplRename title -> do
                         color <- resolveColor stderr
                         case persist of

--- a/packages/agent-cli/src/Agent/CLI/Command.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command.hs
@@ -48,6 +48,7 @@ data ReplAction
     | ReplBtw Text
     -- ^ Ask an isolated one-shot question over the current context.
     | ReplShowSession
+    | ReplWorktree
     | ReplRename Text
     | ReplRenameAuto
     | ReplLogin
@@ -105,6 +106,7 @@ slashCommands =
     , cmd "plan" [] "/plan [description]" "Enter plan mode (or Shift+Tab)" True
     , cmd "btw" [] "/btw <QUESTION>" "Ask a side question without changing the conversation" True
     , cmd "session" [] "/session" "Print the current session id" False
+    , cmd "worktree" [] "/worktree" "Start a fresh session in a new git worktree" False
     , cmd "rename" ["title"] "/rename <TITLE>|--auto" "Rename the current session, or restore automatic titles" True
     , cmd "login" ["accounts"] "/login" "Manage provider credentials and usage" False
     , cmd "resume" [] "/resume [ID]" "Pick a session to resume, or resume ID" True
@@ -191,6 +193,10 @@ parseSlash skills line = case Text.words line of
                 if null args
                     then ReplShowSession
                     else ReplCommandError "usage: /session"
+            "worktree" ->
+                if null args
+                    then ReplWorktree
+                    else ReplCommandError "usage: /worktree"
             "rename" ->
                 let title = Text.strip (Text.drop (Text.length command) line)
                 in if title == "--auto"

--- a/packages/agent-cli/src/Agent/CLI/Worktree.hs
+++ b/packages/agent-cli/src/Agent/CLI/Worktree.hs
@@ -35,6 +35,7 @@ import System.OsPath
     ( OsPath
     , equalFilePath
     , splitDirectories
+    , takeDirectory
     , takeFileName
     , unsafeEncodeUtf
     , (</>)
@@ -63,9 +64,9 @@ worktreePath root repoName day hex8 =
 createWorktree :: OsPath -> OsPath -> IO (Either Text OsPath)
 createWorktree source root = runExceptT do
     repo <- gitToplevel source
+    repoName <- gitRepositoryName repo
     now <- lift getCurrentTime
-    let repoName = takeFileName repo
-        day = utctDay now
+    let day = utctDay now
         start = posixMicros now
     lift (createDirectoryIfMissing True (root </> repoName))
     addUnique repo root repoName day start 0
@@ -126,6 +127,16 @@ gitToplevel source = do
         (\err -> "--worktree requires a git repository (" <> Text.strip err <> ")")
         (ExceptT (git source ["rev-parse", "--show-toplevel"]))
     pure (unsafeEncodeUtf (Text.unpack (Text.strip path)))
+
+gitRepositoryName :: OsPath -> ExceptT Text IO OsPath
+gitRepositoryName repo = do
+    commonDir <- ExceptT $
+        git repo ["rev-parse", "--path-format=absolute", "--git-common-dir"]
+    let path = unsafeEncodeUtf (Text.unpack (Text.strip commonDir))
+    pure $
+        if takeFileName path == unsafeEncodeUtf ".git"
+            then takeFileName (takeDirectory path)
+            else takeFileName path
 
 git :: OsPath -> [String] -> IO (Either Text Text)
 git dir args = do

--- a/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
@@ -60,6 +60,12 @@ spec = do
             parseReplLine "/session now"
                 `shouldBe` ReplCommandError "usage: /session"
 
+        it "starts a fresh session in a new worktree" do
+            parseReplLine "/worktree" `shouldBe` ReplWorktree
+            parseReplLine "  /Worktree  " `shouldBe` ReplWorktree
+            parseReplLine "/worktree now"
+                `shouldBe` ReplCommandError "usage: /worktree"
+
         it "renames sessions or restores automatic titles" do
             parseReplLine "/rename Fix auth races"
                 `shouldBe` ReplRename "Fix auth races"
@@ -202,6 +208,7 @@ spec = do
                     , "plan"
                     , "btw"
                     , "session"
+                    , "worktree"
                     , "rename"
                     , "login"
                     , "resume"
@@ -299,6 +306,7 @@ spec = do
             listing `shouldSatisfy` ("/btw <QUESTION>" `isInfixOf`)
             listing `shouldSatisfy` ("/agents" `isInfixOf`)
             listing `shouldSatisfy` ("/usage" `isInfixOf`)
+            listing `shouldSatisfy` ("/worktree" `isInfixOf`)
             Text.unpack (formatSlashHelp False (Just "effort"))
                 `shouldSatisfy`
                     ("/effort [none|low|medium|high|xhigh|max]" `isInfixOf`)

--- a/packages/agent-cli/test/Agent/CLI/WorktreeSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/WorktreeSpec.hs
@@ -86,6 +86,14 @@ spec = describe "Agent.CLI.Worktree" do
                 doesDirectoryExist first `shouldReturn` True
                 doesDirectoryExist second `shouldReturn` True
 
+        it "keeps linked worktrees grouped under the original repository name" $
+            withTempGitRepo \repo ->
+            withTempDir "agent-home-" \home -> do
+                first <- expectRight =<< createWorktree repo (worktreeRoot home)
+                second <- expectRight =<< createWorktree first (worktreeRoot home)
+                let parent = worktreeRoot home </> takeFileName repo
+                isUnderWorktreeRoot parent second `shouldBe` True
+
         it "removes the worktree and its generated branch" $
             withTempGitRepo \repo ->
             withTempDir "agent-home-" \home -> do


### PR DESCRIPTION
## Summary

- add `/worktree` to slash-command parsing, help, completion, and the live command menu
- create a fresh Git worktree and restart into a fresh session there
- preserve the active provider, model, reasoning effort, and approval settings across the restart
- derive the repository directory from Git's common directory so repeated worktree creation remains grouped under the original repository name

## Validation

- loaded `agent-cli:lib:agent-cli` successfully in GHCi
- ran focused worktree/parser specs: 10 examples, 0 failures
- exercised `/worktree` in a real tmux TTY session
  - command appeared in the live slash menu
  - worktree was created under `~/.haskell-agent/worktrees/haskell-agent/...`
  - the restarted session retained `gpt-5.6-sol` with low effort
- `git diff --check`
