### PR TITLE
Harden TUI against width and control-character corruption

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -13,6 +13,7 @@ module Agent.CLI.TUI.App
     , emitUiEvent
     , hasQueuedFullscreenInput
     , motionDemandFor
+    , lambdaArtWidget
     , nativeProgressKeepaliveDue
     , nextMotionSchedule
     , newFullscreenInputBuffer
@@ -24,6 +25,7 @@ module Agent.CLI.TUI.App
     , readFullscreenLine
     , readFullscreenLineOr
     , repositoryHeaderText
+    , resumeSearchCursorColumn
     , onboardingVisibleRowIndices
     , requestFullscreenPermission
     , requestFullscreenChoice
@@ -47,6 +49,7 @@ import Agent.CLI.Artifact (fencedCodeBlock)
 import Agent.CLI.Input
     ( ReplLine(..)
     , readReplHistory
+    , terminalTextWidth
     , truncateDisplayText
     )
 import Agent.CLI.AgentViewport
@@ -101,6 +104,7 @@ import Agent.CLI.TUI.ImagePreview
     , TuiImagePreview(..)
     , nativePreviewPlacements
     , prepareTuiImagePreview
+    , previewCountForWidth
     , previewCellSize
     , renderTuiImagePreview
     )
@@ -1522,15 +1526,21 @@ drawImagePreviews native previews =
         context <- getContext
         let maxWidth = viewportPreviewSize context.availWidth
             maxHeight = viewportPreviewSize context.availHeight
-            gaps = max 0 (length previews - 1) * previewGap
+            visible =
+                drop
+                    (max
+                        0
+                        (length previews - previewCountForWidth maxWidth))
+                    previews
+            gaps = max 0 (length visible - 1) * previewGap
             previewWidth =
-                max 1 ((maxWidth - gaps) `div` max 1 (length previews))
+                max 1 ((maxWidth - gaps) `div` max 1 (length visible))
             previewHeight = max 1 (maxHeight - 1)
             content =
                 hBox $
                     intersperse
                         (hLimit previewGap (fill ' '))
-                        (map (drawPreview previewWidth previewHeight) previews)
+                        (map (drawPreview previewWidth previewHeight) visible)
         render $
             hLimit maxWidth $
                 vLimit maxHeight content
@@ -2167,7 +2177,12 @@ lambdaArtWidget frame =
                         ]
                     | y <- [0 .. canvasHeight - 1]
                     ]
-        pure B.emptyResult { B.image = rendered }
+            bounded =
+                V.crop
+                    (max 0 context.availWidth)
+                    (max 0 context.availHeight)
+                    rendered
+        pure B.emptyResult { B.image = bounded }
 
 lambdaComposition :: Int -> Int -> LambdaComposition
 lambdaComposition width height
@@ -2675,12 +2690,18 @@ resumeHeader browser =
             showCursor
                 ResumeSearchCursor
                 (Location
-                    (Text.length prefix + Text.length browser.resumeBrowserQuery, 0))
+                    (resumeSearchCursorColumn
+                        prefix
+                        browser.resumeBrowserQuery, 0))
                 (txt (prefix <> browser.resumeBrowserQuery <> " "))
         | Text.null browser.resumeBrowserQuery =
             withAttr Theme.mutedAttr (txt prefix)
         | otherwise =
             txt (prefix <> browser.resumeBrowserQuery)
+
+resumeSearchCursorColumn :: Text -> Text -> Int
+resumeSearchCursorColumn prefix query =
+    terminalTextWidth prefix + terminalTextWidth query
 
 resumeList :: ResumeBrowser -> Widget Name
 resumeList browser =

--- a/packages/agent-cli/src/Agent/CLI/TUI/ImagePreview.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/ImagePreview.hs
@@ -7,6 +7,7 @@ module Agent.CLI.TUI.ImagePreview
     , nativePreviewPlacements
     , imageDimensions
     , prepareTuiImagePreview
+    , previewCountForWidth
     , previewCellSize
     , previewImageAt
     , renderTuiImagePreview
@@ -257,7 +258,10 @@ nativePreviewPlacements
 nativePreviewPlacements imageIdBase terminalColumns terminalRows previews =
     zipWith place [imageIdBase ..] shownWithSizes
   where
-    shown = takeLast maxShownPreviews previews
+    shown =
+        takeLast
+            (previewCountForWidth maxWidth)
+            previews
     count = length shown
     maxWidth = viewportPreviewSize terminalColumns
     maxHeight = viewportPreviewSize terminalRows
@@ -542,6 +546,16 @@ maxBoxSamplesPerAxis = 3
 
 maxShownPreviews :: Int
 maxShownPreviews = 3
+
+-- | Number of previews that can fit with at least one column per image and
+-- the normal gap between them.
+previewCountForWidth :: Int -> Int
+previewCountForWidth availableWidth
+    | availableWidth <= 0 = 0
+    | otherwise =
+        min
+            maxShownPreviews
+            ((availableWidth + previewGap) `div` (1 + previewGap))
 
 previewGap :: Int
 previewGap = 2

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -12,10 +12,12 @@ import Agent.CLI.TUI.App
     , elapsedMillisSince
     , fullscreenVtyConfig
     , motionDemandFor
+    , lambdaArtWidget
     , nativeProgressKeepaliveDue
     , nextMotionSchedule
     , onboardingVisibleRowIndices
     , repositoryHeaderText
+    , resumeSearchCursorColumn
     , selectedAgentConversation
     , uiEventRestartsMotionSchedule
     )
@@ -142,6 +144,21 @@ spec = do
         it "still renders a path when git state is unavailable" do
             repositoryHeaderText "" "~/scratch"
                 `shouldBe` "~/scratch"
+
+    describe "bounded custom rendering" do
+        it "crops the empty-conversation art to tiny render contexts" do
+            let image =
+                    V.picImage $
+                        renderWidget Nothing [lambdaArtWidget 0] (5, 3)
+            V.imageWidth image `shouldSatisfy` (<= 5)
+            V.imageHeight image `shouldSatisfy` (<= 3)
+
+    describe "resume search cursor" do
+        it "uses terminal cells for wide and combining characters" do
+            resumeSearchCursorColumn "search: " "漢"
+                `shouldBe` 10
+            resumeSearchCursorColumn "search: " "e\x0301"
+                `shouldBe` 9
 
     describe "onboarding layout" do
         it "uses the complete 18-row surface when it fits" do

--- a/packages/agent-cli/test/Agent/CLI/TUIImagePreviewSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIImagePreviewSpec.hs
@@ -6,6 +6,7 @@ import Agent.CLI.TUI.ImagePreview
     , imageDimensions
     , nativePreviewPlacements
     , prepareTuiImagePreview
+    , previewCountForWidth
     , previewCellSize
     , previewImageAt
     )
@@ -113,6 +114,35 @@ spec = do
                         , nativePreviewAttachment = attachment
                         }
                     ]
+
+        it "keeps every native placement inside narrow terminal bounds" do
+            let attachment = ImageAttachment
+                    { imageMime = "image/png"
+                    , imageBytes = ""
+                    }
+                preview = TuiImagePreview
+                    { previewMime = "image/png"
+                    , previewBytes = 0
+                    , previewSourceWidth = 1
+                    , previewSourceHeight = 1
+                    , previewSample =
+                        error "native preview bounds forced the ANSI sample"
+                    , previewKittyAttachment = attachment
+                    }
+                previews = replicate 3 (attachment, preview)
+            previewCountForWidth 1 `shouldBe` 1
+            previewCountForWidth 4 `shouldBe` 2
+            previewCountForWidth 7 `shouldBe` 3
+            mapM_
+                (\columns ->
+                    nativePreviewPlacements 100 columns 10 previews
+                        `shouldSatisfy` all
+                            (\placement ->
+                                placement.nativePreviewColumn >= 0
+                                    && placement.nativePreviewColumn
+                                        + placement.nativePreviewColumns
+                                        <= columns))
+                [1 .. 12]
 
         it "preserves thin screenshot details while downsampling" do
             let source =

--- a/packages/agent-tui/src/Agent/TUI/Markdown.hs
+++ b/packages/agent-tui/src/Agent/TUI/Markdown.hs
@@ -19,7 +19,10 @@ import Agent.Syntax
     , SyntaxSpan(..)
     , highlightCode
     )
-import Agent.TUI.TextWidth (displayCharCellWidth)
+import Agent.TUI.TextWidth
+    ( displayCharCellWidth
+    , displayTerminalText
+    )
 import qualified Agent.TUI.Theme as Theme
 import Brick
 import qualified Brick.Types as B
@@ -183,7 +186,7 @@ renderCodeBody syntaxHighlighter language bodyLines =
                         traverse (traverse resolveSyntaxSpan) highlightedLines
                 _ ->
                     pure
-                        [ [(codeAttr, line)]
+                        [ [(codeAttr, displayTerminalText line)]
                         | line <- bodyLines
                         ]
         let availableWidth = max 1 context.availWidth
@@ -215,7 +218,7 @@ renderCodeBody syntaxHighlighter language bodyLines =
                 (Text.intercalate "\n" bodyLines)
     resolveSyntaxSpan span_ = do
         attr <- B.lookupAttrName (Theme.syntaxClassAttr span_.syntaxClass)
-        pure (attr, span_.syntaxText)
+        pure (attr, displayTerminalText span_.syntaxText)
 
 renderCodeRow
     :: V.Attr
@@ -792,14 +795,18 @@ resolveInlineSpan plainAttr InlineSpan{inlineStyle, inlineText} = do
     pure
         ( case inlineStyle of
             InlineLink url
-                | not (Text.null url) -> attr `V.withURL` url
+                | safeUrl url -> attr `V.withURL` url
             InlineStrongLink url
-                | not (Text.null url) -> attr `V.withURL` url
+                | safeUrl url -> attr `V.withURL` url
             InlineEmphasisLink url
-                | not (Text.null url) -> attr `V.withURL` url
+                | safeUrl url -> attr `V.withURL` url
             _ -> attr
-        , inlineText
+        , displayTerminalText inlineText
         )
+  where
+    safeUrl url =
+        not (Text.null url)
+            && displayTerminalText url == url
 
 styleAttr :: InlineStyle -> AttrName
 styleAttr = \case

--- a/packages/agent-tui/src/Agent/TUI/Markdown.hs
+++ b/packages/agent-tui/src/Agent/TUI/Markdown.hs
@@ -15,8 +15,7 @@ import Agent.TUI.FencedCode
     , fenceChunks
     )
 import Agent.Syntax
-    ( HighlightedLine
-    , SyntaxHighlighter
+    ( SyntaxHighlighter
     , SyntaxSpan(..)
     , highlightCode
     )
@@ -170,21 +169,43 @@ renderCodeBody syntaxHighlighter language bodyLines =
     -- Keep tokenization inside the render action. Brick's 'cached' inspects a
     -- widget's size policy before consulting its cache; returning a concrete
     -- vBox here would therefore force tokenization on every streamed redraw.
-    B.Widget B.Fixed B.Fixed $
-        B.render (buildCodeBody syntaxHighlighter language bodyLines)
-
-buildCodeBody
-    :: Maybe SyntaxHighlighter
-    -> Text
-    -> [Text]
-    -> Widget n
-buildCodeBody syntaxHighlighter language bodyLines =
-    vBox $
-        case syntaxHighlighter >>= highlighted of
-            Just highlightedLines
-                | length highlightedLines == length bodyLines ->
-                    map renderHighlightedCodeLine highlightedLines
-            _ -> map renderFlatCodeLine bodyLines
+    --
+    -- Code must also be bounded here rather than relying on the surrounding
+    -- vertical viewport. An over-wide Vty image can reach the terminal as one
+    -- physical line, where terminal-side wrapping corrupts subsequent rows.
+    B.Widget B.Greedy B.Fixed do
+        context <- B.getContext
+        codeAttr <- B.lookupAttrName Theme.codeAttr
+        styledLines <-
+            case syntaxHighlighter >>= highlighted of
+                Just highlightedLines
+                    | length highlightedLines == length bodyLines ->
+                        traverse (traverse resolveSyntaxSpan) highlightedLines
+                _ ->
+                    pure
+                        [ [(codeAttr, line)]
+                        | line <- bodyLines
+                        ]
+        let availableWidth = max 1 context.availWidth
+            horizontalPadding =
+                if availableWidth >= 3 then 1 else 0
+            contentWidth =
+                max 1 (availableWidth - 2 * horizontalPadding)
+            rows =
+                concatMap (wrapStyled contentWidth) styledLines
+            image =
+                V.vertCat
+                    [ renderCodeRow
+                        codeAttr
+                        horizontalPadding
+                        row
+                    | row <- rows
+                    ]
+            boundedImage
+                | V.imageWidth image > availableWidth =
+                    V.cropRight availableWidth image
+                | otherwise = image
+        pure B.emptyResult { B.image = boundedImage }
   where
     highlighted highlighter =
         either (const Nothing) Just $
@@ -192,24 +213,29 @@ buildCodeBody syntaxHighlighter language bodyLines =
                 highlighter
                 language
                 (Text.intercalate "\n" bodyLines)
+    resolveSyntaxSpan span_ = do
+        attr <- B.lookupAttrName (Theme.syntaxClassAttr span_.syntaxClass)
+        pure (attr, span_.syntaxText)
 
-renderFlatCodeLine :: Text -> Widget n
-renderFlatCodeLine =
-    withAttr Theme.codeAttr . padLeftRight 1 . txt
-
-renderHighlightedCodeLine :: HighlightedLine -> Widget n
-renderHighlightedCodeLine spans =
-    withAttr Theme.codeAttr $
-        padLeftRight 1 $
-            case spans of
-                [] -> txt ""
-                _ ->
-                    hBox
-                        [ withAttr
-                            (Theme.syntaxClassAttr span_.syntaxClass)
-                            (txt span_.syntaxText)
-                        | span_ <- spans
-                        ]
+renderCodeRow
+    :: V.Attr
+    -> Int
+    -> [(V.Attr, Text)]
+    -> V.Image
+renderCodeRow paddingAttr horizontalPadding fragments =
+    V.horizCat
+        [ blank
+        , V.horizCat
+            [ V.text attr (LazyText.fromStrict text)
+            | (attr, text) <- fragments
+            ]
+        , blank
+        ]
+  where
+    blank
+        | horizontalPadding <= 0 = V.emptyImage
+        | otherwise =
+            V.charFill paddingAttr ' ' horizontalPadding 1
 
 stripHeading :: Text -> Maybe Text
 stripHeading line =

--- a/packages/agent-tui/src/Agent/TUI/TextWidth.hs
+++ b/packages/agent-tui/src/Agent/TUI/TextWidth.hs
@@ -2,14 +2,19 @@
 module Agent.TUI.TextWidth
     ( charCellWidth
     , displayCharCellWidth
+    , displayTerminalChar
+    , displayTerminalText
     , isWideCharacter
     ) where
 
 import Data.Char
     ( GeneralCategory(..)
+    , chr
     , generalCategory
     , ord
     )
+import Data.Text (Text)
+import qualified Data.Text as Text
 
 -- | Width of a Unicode character before any control-character visualization.
 --
@@ -36,6 +41,27 @@ displayCharCellWidth char
     | otherwise = charCellWidth char
   where
     code = ord char
+
+-- | Replace terminal control characters with visible, inert glyphs.
+--
+-- Newlines remain structural so width-aware renderers can split on them.
+-- Every other replacement has the width reported by 'displayCharCellWidth'.
+displayTerminalChar :: Char -> Text
+displayTerminalChar char
+    | char == '\n' = "\n"
+    | char == '\r' = "↵"
+    | char == '\t' = "⇥"
+    | code >= 0 && code <= 0x1f =
+        Text.singleton (chr (0x2400 + code))
+    | code == 0x7f = "␡"
+    | code >= 0x80 && code <= 0x9f = "�"
+    | generalCategory char == Format = "�"
+    | otherwise = Text.singleton char
+  where
+    code = ord char
+
+displayTerminalText :: Text -> Text
+displayTerminalText = Text.concatMap displayTerminalChar
 
 -- | Approximate the wide/full-width ranges used by terminal emulators.
 isWideCharacter :: Char -> Bool

--- a/packages/agent-tui/test/Agent/TUI/MarkdownSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/MarkdownSpec.hs
@@ -13,6 +13,7 @@ import Brick
     , viewport
     )
 import Control.Monad (forM_)
+import Data.Char (isControl)
 import Data.Foldable (toList)
 import Data.List (findIndex, isInfixOf)
 import qualified Data.Text as Text
@@ -74,6 +75,13 @@ spec = describe "fullscreen Markdown rendering" do
             any (hasUrlWithStyle "https://example.com/316" V.bold)
         rendered `shouldSatisfy` (not . isInfixOf "[PR #316]")
 
+    it "does not attach terminal hyperlink metadata to unsafe URLs" do
+        let widget :: Widget ()
+            widget = markdownWidget "[docs](https://example.com/\ESC]8;;owned)"
+            rendered = show (renderWidget Nothing [widget] (80, 3))
+        rendered `shouldSatisfy`
+            (not . isInfixOf "attrURL = SetTo")
+
     it "supports multi-backtick code and avoids snake_case emphasis" do
         let spans = parseInline "``a ` b`` and snake_case"
         inlinePlainText spans `shouldBe` "a ` b and snake_case"
@@ -93,6 +101,15 @@ spec = describe "fullscreen Markdown rendering" do
             rows = renderRows 12 ("```\n" <> code <> "\n```")
         map rowDisplayWidth rows `shouldSatisfy` all (<= 12)
         Text.filter (/= ' ') (Text.concat rows) `shouldBe` code
+
+    it "renders terminal controls as inert visible glyphs" do
+        let unsafe = "\ESC]0;owned\BEL\t\r"
+            prose = Text.concat (renderRows 40 unsafe)
+            code = Text.concat (renderRows 40 ("```\n" <> unsafe <> "\n```"))
+        prose `shouldSatisfy` Text.isInfixOf "␛]0;owned␇⇥↵"
+        code `shouldSatisfy` Text.isInfixOf "␛]0;owned␇⇥↵"
+        prose `shouldSatisfy` not . Text.any isControl
+        code `shouldSatisfy` not . Text.any isControl
 
     it "renders numbered controls for fenced code block headers" do
         let widget :: Widget ()

--- a/packages/agent-tui/test/Agent/TUI/MarkdownSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/MarkdownSpec.hs
@@ -88,6 +88,12 @@ spec = describe "fullscreen Markdown rendering" do
         parseInline input
             `shouldBe` [InlineSpan InlinePlain input]
 
+    it "wraps long fenced-code lines inside the available terminal width" do
+        let code = Text.replicate 100 "a"
+            rows = renderRows 12 ("```\n" <> code <> "\n```")
+        map rowDisplayWidth rows `shouldSatisfy` all (<= 12)
+        Text.filter (/= ' ') (Text.concat rows) `shouldBe` code
+
     it "renders numbered controls for fenced code block headers" do
         let widget :: Widget ()
             widget =

--- a/packages/agent-tui/test/Agent/TUI/TextWidthSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/TextWidthSpec.hs
@@ -15,6 +15,8 @@ spec = describe "terminal character width" do
         charCellWidth '\BEL' `shouldBe` 0
         displayCharCellWidth '\BEL' `shouldBe` 1
         displayCharCellWidth '\t' `shouldBe` 1
+        displayTerminalText "\ESC]0;owned\BEL\t\r"
+            `shouldBe` "␛]0;owned␇⇥↵"
 
     it "exposes the shared wide-character classification" do
         isWideCharacter '界' `shouldBe` True


### PR DESCRIPTION
## Summary
- wrap fenced-code lines to the width Brick assigns the widget while preserving syntax highlighting
- render ESC, BEL, tabs, carriage returns, C1 controls, and format controls as inert visible glyphs
- reject unsafe OSC 8 hyperlink metadata
- crop the empty-state raw image to its actual render context
- keep native image preview placements inside narrow terminal bounds
- position the resume-search cursor using terminal-cell widths for wide and combining Unicode
- add regressions for all confirmed failures

## Verification
- `nix develop -c cabal test agent-tui-test` (84 examples, 0 failures)
- `nix develop -c cabal test agent-cli-test` (655 examples, 0 failures)
- live tmux fenced-code test at 100 columns with a 400-character line
- live tmux resize stress at 40x12, 16x7, and 8x4 without screen corruption

## Additional audit findings
Not included here because they need broader Unicode/parser work:
- Vty and modern terminals disagree about some emoji widths
- ZWJ grapheme clusters can wrap between code points
- very large unmatched backtick runs expose quadratic inline parsing