### PR TITLE
Suppress terminal notifications for cancelled turns

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -2812,6 +2812,13 @@ finishTurnWithCooldownRetry allowCooldownRetry env exitAfter = \case
         if exitAfter
             then pure RunQuit
             else continueAfterTurn env
+    TurnCancelled -> do
+        case env.sessionFullscreen of
+            Nothing -> putTrailingNewline env.sessionPrinted
+            Just _ -> pure ()
+        if exitAfter
+            then pure RunQuit
+            else repl env
     TurnFailed ->
         if exitAfter
             then exitFailure

--- a/packages/agent-cli/src/Agent/CLI/ProviderTransition.hs
+++ b/packages/agent-cli/src/Agent/CLI/ProviderTransition.hs
@@ -49,6 +49,7 @@ data ProviderTransition = ProviderTransition
 
 data TurnResult
     = TurnSucceeded
+    | TurnCancelled
     | TurnFailed
     | TurnRestartRequested !Text !PendingTurn
     | TurnProviderUnavailable !ApiError !PendingTurn

--- a/packages/agent-cli/src/Agent/CLI/Turn.hs
+++ b/packages/agent-cli/src/Agent/CLI/Turn.hs
@@ -267,7 +267,7 @@ runOneTurn env@SessionEnv
         (Nothing, Left cancelled@(LoopCancelled _)) -> do
             restorePlanStateAfterIncomplete planMode initialPlanState
             finishTerminal (isNothing fullscreen)
-                terminal wallStarted finishedAt 130 "Agent cancelled"
+                terminal wallStarted finishedAt 130 Nothing
             abortSubagentTurn rootTurnId
             -- turnInputs already contains any startup context consumed above.
             -- Checkpoint it instead of restoring it separately, which would
@@ -289,7 +289,7 @@ runOneTurn env@SessionEnv
                     putTextLn stderr
                         (formatTurnStatus color "cancelled" (elapsedDetail model))
             persistIncomplete checkpoint.checkpointTurnItems "cancelled"
-            pure TurnSucceeded
+            pure TurnCancelled
         (Nothing, Left err) -> do
             abortSubagentTurn rootTurnId
             afterItems <- readIORef transcriptRef
@@ -305,7 +305,7 @@ runOneTurn env@SessionEnv
                                     (UiTurnEnded BlockFailed)
                         finishTerminal (isNothing fullscreen)
                             terminal wallStarted finishedAt 1
-                            "Agent provider unavailable"
+                            (Just "Agent provider unavailable")
                         planState <- readIORef planMode.planStateRef
                         pure $ TurnProviderUnavailable apiError PendingTurn
                             { pendingPromptText = promptText
@@ -316,7 +316,8 @@ runOneTurn env@SessionEnv
                 _ -> do
                     restorePlanStateAfterIncomplete planMode initialPlanState
                     finishTerminal (isNothing fullscreen)
-                        terminal wallStarted finishedAt 1 "Agent turn failed"
+                        terminal wallStarted finishedAt 1
+                        (Just "Agent turn failed")
                     let checkpoint =
                             checkpointIncompleteTurn beforeItems turnInputs
                     writeIORef transcriptRef checkpoint.checkpointTranscript
@@ -344,7 +345,7 @@ runOneTurn env@SessionEnv
                     pure TurnFailed
         (Nothing, Right loopResult) -> do
             finishTerminal (isNothing fullscreen)
-                terminal wallStarted finishedAt 0 "Agent finished"
+                terminal wallStarted finishedAt 0 (Just "Agent finished")
             finishSubagentTurn rootTurnId
             writeIORef previous (Just loopResult.finalResponseId)
             modifyIORef' usageRef (`addTokenUsage` loopResult.tokenUsage)
@@ -504,15 +505,18 @@ finishTerminal
     -> UTCTime
     -> UTCTime
     -> Int
-    -> Text
+    -> Maybe Text
     -> IO ()
-finishTerminal semanticPrompts terminal started finished exitCode message = do
+finishTerminal semanticPrompts terminal started finished exitCode notification = do
     when (semanticPrompts && terminal.terminalSemanticPrompts) $
         emitTerminalSequence terminal stdout
             (osc133CommandFinished (Just exitCode))
     let seconds = realToFrac (diffUTCTime finished started) :: Double
-    when (exitCode /= 0 || seconds >= 10) $
-        notifyTerminal terminal stdout message
+    case notification of
+        Just message
+            | exitCode /= 0 || seconds >= 10 ->
+                notifyTerminal terminal stdout message
+        _ -> pure ()
 
 handleProposedPlan
     :: PlanModeEnv


### PR DESCRIPTION
## Summary
- represent cancelled turns separately from successful turns
- keep semantic command completion while suppressing the cancellation OSC 9 notification
- return to the prompt after cancellation without emitting the normal input-requested notification

## Verification
- agent-cli library typechecked in GHCi with `--repl-options=-fno-code`
- agent-cli test suite passed in GHCi: 652 examples, 0 failures
- live tmux cancellation smoke test; raw pane output contained no OSC 9 sequence