### PR TITLE
fix(tui): render styled markdown links

### DIFF
--- a/packages/agent-tui/src/Agent/TUI/Markdown.hs
+++ b/packages/agent-tui/src/Agent/TUI/Markdown.hs
@@ -45,6 +45,8 @@ data InlineStyle
     | InlineEmphasis
     | InlineCode
     | InlineLink !Text
+    | InlineStrongLink !Text
+    | InlineEmphasisLink !Text
     deriving (Eq, Show)
 
 data InlineSpan = InlineSpan
@@ -609,12 +611,12 @@ parseInline = go Nothing []
     go previous plain text
         | Just (body, rest) <- delimited "**" text =
             flushPlain plain $
-                InlineSpan InlineStrong body
-                    : go (lastChar body) [] rest
+                strongSpans body
+                    <> go (lastChar body) [] rest
         | Just (body, rest) <- delimited "__" text =
             flushPlain plain $
-                InlineSpan InlineStrong body
-                    : go (lastChar body) [] rest
+                strongSpans body
+                    <> go (lastChar body) [] rest
         | Just (body, rest) <- codeSpan text =
             flushPlain plain $
                 InlineSpan InlineCode body
@@ -629,12 +631,12 @@ parseInline = go Nothing []
                     : go (lastChar label) [] rest
         | Just (body, rest) <- emphasis previous '*' text =
             flushPlain plain $
-                InlineSpan InlineEmphasis body
-                    : go (lastChar body) [] rest
+                emphasisSpans body
+                    <> go (lastChar body) [] rest
         | Just (body, rest) <- emphasis previous '_' text =
             flushPlain plain $
-                InlineSpan InlineEmphasis body
-                    : go (lastChar body) [] rest
+                emphasisSpans body
+                    <> go (lastChar body) [] rest
         | otherwise =
             case Text.uncons text of
                 Nothing -> flushPlain plain []
@@ -700,6 +702,28 @@ parseInline = go Nothing []
     inlineMarker character =
         character `elem` ("*_`[" :: String)
 
+    strongSpans = nestedLinkSpans InlineStrong InlineStrongLink
+
+    emphasisSpans = nestedLinkSpans InlineEmphasis InlineEmphasisLink
+
+    nestedLinkSpans plainStyle linkStyle body =
+        let spans = parseInline body
+        in if any isLinkSpan spans
+            then map (applyNestedStyle plainStyle linkStyle) spans
+            else [InlineSpan plainStyle body]
+
+    isLinkSpan InlineSpan{inlineStyle = InlineLink _} = True
+    isLinkSpan _ = False
+
+    applyNestedStyle plainStyle linkStyle span_ =
+        span_
+            { inlineStyle =
+                case span_.inlineStyle of
+                    InlinePlain -> plainStyle
+                    InlineLink url -> linkStyle url
+                    other -> other
+            }
+
     flushPlain [] rest = rest
     flushPlain chunks rest =
         InlineSpan InlinePlain (Text.concat (reverse chunks))
@@ -730,14 +754,22 @@ resolveInlineSpan
     -> InlineSpan
     -> B.RenderM n (V.Attr, Text)
 resolveInlineSpan plainAttr InlineSpan{inlineStyle, inlineText} = do
-    attr <-
+    baseAttr <-
         B.lookupAttrName $
             case inlineStyle of
                 InlinePlain -> plainAttr
                 _ -> styleAttr inlineStyle
+    let attr = case inlineStyle of
+            InlineStrongLink _ -> baseAttr `V.withStyle` V.bold
+            InlineEmphasisLink _ -> baseAttr `V.withStyle` V.italic
+            _ -> baseAttr
     pure
         ( case inlineStyle of
             InlineLink url
+                | not (Text.null url) -> attr `V.withURL` url
+            InlineStrongLink url
+                | not (Text.null url) -> attr `V.withURL` url
+            InlineEmphasisLink url
                 | not (Text.null url) -> attr `V.withURL` url
             _ -> attr
         , inlineText
@@ -750,6 +782,8 @@ styleAttr = \case
     InlineEmphasis -> Theme.emphasisAttr
     InlineCode -> Theme.inlineCodeAttr
     InlineLink _ -> Theme.linkAttr
+    InlineStrongLink _ -> Theme.linkAttr
+    InlineEmphasisLink _ -> Theme.linkAttr
 
 wrapStyled :: Int -> [(V.Attr, Text)] -> [[(V.Attr, Text)]]
 wrapStyled width spans =

--- a/packages/agent-tui/test/Agent/TUI/MarkdownSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/MarkdownSpec.hs
@@ -49,6 +49,31 @@ spec = describe "fullscreen Markdown rendering" do
         rendered `shouldSatisfy`
             isInfixOf "attrURL = SetTo \"https://example.com\""
 
+    it "parses links nested inside strong and emphasis spans" do
+        parseInline
+            "**[PR #316](https://example.com/316)** and *[docs](https://example.com)*"
+            `shouldBe`
+                [ InlineSpan
+                    (InlineStrongLink "https://example.com/316")
+                    "PR #316 (https://example.com/316)"
+                , InlineSpan InlinePlain " and "
+                , InlineSpan
+                    (InlineEmphasisLink "https://example.com")
+                    "docs (https://example.com)"
+                ]
+
+    it "renders a strong link with hyperlink metadata and bold styling" do
+        let widget :: Widget ()
+            widget =
+                markdownWidget
+                    "Merged **[PR #316](https://example.com/316)**."
+            spans = concat (renderSpanRows 80
+                "Merged **[PR #316](https://example.com/316)**.")
+            rendered = show (renderWidget Nothing [widget] (80, 3))
+        spans `shouldSatisfy`
+            any (hasUrlWithStyle "https://example.com/316" V.bold)
+        rendered `shouldSatisfy` (not . isInfixOf "[PR #316]")
+
     it "supports multi-backtick code and avoids snake_case emphasis" do
         let spans = parseInline "``a ` b`` and snake_case"
         inlinePlainText spans `shouldBe` "a ` b and snake_case"
@@ -495,6 +520,14 @@ hasUrl :: Text.Text -> SpanOp -> Bool
 hasUrl url = \case
     TextSpan{textSpanAttr} ->
         V.attrURL textSpanAttr == V.SetTo url
+    Skip _ -> False
+    RowEnd _ -> False
+
+hasUrlWithStyle :: Text.Text -> V.Style -> SpanOp -> Bool
+hasUrlWithStyle url style = \case
+    TextSpan{textSpanAttr} ->
+        V.attrURL textSpanAttr == V.SetTo url
+            && V.attrStyle textSpanAttr == V.SetTo style
     Skip _ -> False
     RowEnd _ -> False
 


### PR DESCRIPTION
## Summary

- parse links nested inside strong and emphasis spans in the fullscreen Markdown renderer
- preserve hyperlink metadata while applying the surrounding bold or italic style
- add regression coverage for the `**[label](url)**` form that previously displayed raw Markdown syntax

## Verification

- `nix develop -c cabal test --offline agent-tui-test` — 83 examples, 0 failures
- fullscreen tmux smoke check with `Merged **[PR #316](https://github.com/digitallyinduced/haskell-agent/pull/316)** into `master`.` — rendered without Markdown delimiters and retained OSC 8 hyperlink metadata