### PR TITLE
Notify when the agent requests plan mode

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Notification.hs
+++ b/packages/agent-cli/src/Agent/CLI/Notification.hs
@@ -21,6 +21,7 @@ import System.IO (Handle, hFlush, hIsTerminalDevice)
 data AttentionRequest
     = InputRequested
     | PermissionRequested
+    | PlanModeRequested
     deriving (Eq, Show)
 
 attentionNotificationSequence :: AttentionRequest -> Text
@@ -31,6 +32,7 @@ notificationTitle :: AttentionRequest -> Text
 notificationTitle = \case
     InputRequested -> "Haskell Agent: input requested"
     PermissionRequested -> "Haskell Agent: permission required"
+    PlanModeRequested -> "Haskell Agent: plan mode requested"
 
 -- | Notify only when the destination is a TTY, keeping pipes and redirected
 -- stderr free of terminal control sequences. Notification failures must never

--- a/packages/agent-cli/src/Agent/CLI/Plan.hs
+++ b/packages/agent-cli/src/Agent/CLI/Plan.hs
@@ -27,7 +27,7 @@ import Agent.CLI.Input
 import Agent.CLI.Interrupt (InterruptState)
 import Agent.CLI.Markdown (renderMarkdown)
 import Agent.CLI.Notification
-    ( AttentionRequest(InputRequested)
+    ( AttentionRequest(InputRequested, PlanModeRequested)
     , notifyAttention
     )
 import Agent.CLI.Picker (PickerKey(..), runOverlay)
@@ -95,7 +95,7 @@ confirmEnter resolveColor reason = do
     if not isTty
         then pure False
         else do
-            notifyAttention stderr InputRequested
+            notifyAttention stderr PlanModeRequested
             result <-
                 runOverlay
                     (renderPlanEnterFrame color)

--- a/packages/agent-cli/test/Agent/CLI/NotificationSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/NotificationSpec.hs
@@ -13,3 +13,7 @@ spec =
         it "distinguishes permission prompts" do
             attentionNotificationSequence PermissionRequested
                 `shouldBe` "\ESC]9;Haskell Agent: permission required\ESC\\"
+
+        it "distinguishes plan-mode requests" do
+            attentionNotificationSequence PlanModeRequested
+                `shouldBe` "\ESC]9;Haskell Agent: plan mode requested\ESC\\"


### PR DESCRIPTION
## Summary
- add a dedicated terminal attention notification for plan-mode requests
- emit it before the interactive enter-plan-mode approval prompt
- cover the OSC 9 notification payload in the notification spec

## Testing
- `nix develop -c cabal repl agent-cli:agent-cli-test` (658 examples, 0 failures)
- live tmux smoke check of an agent-triggered `enter_plan_mode` approval overlay
- `git diff --check`