### PR TITLE
Support Codex response metadata events

### DIFF
--- a/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
@@ -216,6 +216,15 @@ spec = do
                 `shouldBe` Nothing
             streamEventToLoopEvent (deltaEvent EventOutputTextDone "done")
                 `shouldBe` Nothing
+            streamEventToLoopEvent
+                (OtherResponseStreamEvent
+                    { otherEventType = EventCodexResponseMetadata
+                    , sequenceNumber = Nothing
+                    , eventExtraFields = KeyMap.singleton
+                        "metadata"
+                        (Aeson.object ["request_id" Aeson..= ("req-1" :: Text)])
+                    })
+                `shouldBe` Nothing
             streamEventToLoopEvent (ResponseOutputItemDoneEvent
                 { item = assistantItem "x"
                 , outputIndex = 0

--- a/packages/agent-openai/test/Agent/OpenAI/ResponsesSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/ResponsesSpec.hs
@@ -194,6 +194,21 @@ spec = do
                     Aeson.toJSON event `shouldBe` original
                 Aeson.Error err -> expectationFailure err
 
+        it "recognises Codex response metadata and preserves its payload" do
+            let original = Aeson.object
+                    [ "type" .= ("codex.response.metadata" :: Text)
+                    , "sequence_number" .= (10 :: Int)
+                    , "metadata" .= Aeson.object
+                        [ "request_id" .= ("req_1" :: Text)
+                        ]
+                    ]
+            case Aeson.fromJSON original :: Aeson.Result Responses.ResponseStreamEvent of
+                Aeson.Success event -> do
+                    Responses.responseStreamEventType event
+                        `shouldBe` Responses.EventCodexResponseMetadata
+                    Aeson.toJSON event `shouldBe` original
+                Aeson.Error err -> expectationFailure err
+
         it "rejects disagreement between the SSE name and JSON type" do
             let value = Aeson.object
                     [ "type" .= ("response.output_text.done" :: Text)
@@ -424,5 +439,5 @@ documentedStreamEventTypes =
     , "response.audio.done", "response.audio.transcript.delta", "response.audio.transcript.done"
     , "response.shell_call_command.added", "response.shell_call_command.delta"
     , "response.shell_call_command.done", "response.shell_call_output_content.delta"
-    , "response.shell_call_output_content.done"
+    , "response.shell_call_output_content.done", "codex.response.metadata"
     ]

--- a/packages/agent-responses/src/Agent/Responses/Types.hs
+++ b/packages/agent-responses/src/Agent/Responses/Types.hs
@@ -1455,6 +1455,7 @@ data StreamEventType
     | EventShellCommandDone
     | EventShellOutputDelta
     | EventShellOutputDone
+    | EventCodexResponseMetadata
     | StreamEventUnknown !Text
     deriving stock (Eq, Show)
 
@@ -1519,6 +1520,7 @@ streamEventTypeText = \case
     EventShellCommandDone -> "response.shell_call_command.done"
     EventShellOutputDelta -> "response.shell_call_output_content.delta"
     EventShellOutputDone -> "response.shell_call_output_content.done"
+    EventCodexResponseMetadata -> "codex.response.metadata"
     StreamEventUnknown value -> value
 
 parseStreamEventType :: Text -> StreamEventType
@@ -1582,6 +1584,7 @@ parseStreamEventType value = case value of
     "response.shell_call_command.done" -> EventShellCommandDone
     "response.shell_call_output_content.delta" -> EventShellOutputDelta
     "response.shell_call_output_content.done" -> EventShellOutputDone
+    "codex.response.metadata" -> EventCodexResponseMetadata
     other -> StreamEventUnknown other
 
 -- | Structured payload used by both the documented top-level @error@ event


### PR DESCRIPTION
## Summary
- recognize `codex.response.metadata` as a known Codex WebSocket event
- preserve its payload losslessly through JSON decoding and encoding
- ignore the informational event in the loop instead of showing an unsupported-provider warning

## Testing
- `nix develop -c cabal repl agent-openai:test:agent-openai-test`
- ran `Agent.OpenAI.ResponsesSpec.spec` and `Agent.OpenAI.LoopBackendSpec.spec` in GHCi: 60 examples, 0 failures
- `git diff --check`