### PR TITLE
feat: add dedicated Telegram agent gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,38 @@ agent-cli --worktree
 Use `--provider openai`, `--provider xai`, or `--provider openrouter` to
 override automatic provider detection.
 
+### Telegram
+
+Create a bot with BotFather, find your numeric Telegram user ID, and run the
+interactive setup command:
+
+```console
+agent-telegram setup --provider openai --cwd /path/to/project \
+  --allowed-user 123456789
+agent-telegram start
+agent-telegram status
+```
+
+Setup reads the BotFather token without terminal echo, validates it against
+Telegram, and stores it separately from the non-secret gateway configuration.
+Never paste the bot token into an agent conversation.
+
+Only allowlisted private-chat text messages are handled. Each chat is mapped
+to a persisted agent session under `~/.haskell-agent`; `/new` starts a fresh
+session and `/session` shows the current session ID. Mutating tools are denied
+unless setup is run with `--yolo`. Use `agent-telegram stop` to stop the
+background gateway.
+
+Incoming updates and pending replies are persisted before they are processed.
+Polling continues while agent turns run, conversations are processed in order,
+and separate chats can run concurrently. Pending work resumes when the gateway
+is restarted.
+
+The built-in `telegram-agent` skill lets the normal agent guide this setup.
+Ask it to “set up a Telegram agent”; it will explain the BotFather steps,
+direct secret entry to the interactive setup command, and start the configured
+gateway after setup is complete.
+
 ### Authentication
 
 Works with your Codex subscription, Grok subscription, and provider API keys.

--- a/flake.nix
+++ b/flake.nix
@@ -109,6 +109,7 @@
                     root = ./packages/agent-cli;
                     include = [
                         "app"
+                        "skills"
                         "src"
                         "test"
                         "agent-cli.cabal"
@@ -325,6 +326,7 @@
             {
                 packages.default = agentCliExecutable;
                 packages.agent-cli = agentCliExecutable;
+                packages.agent-telegram = agentCliExecutable;
                 packages.agent-core = agentCorePackage;
                 packages.agent-codex-dialect = agentCodexDialectPackage;
                 packages.agent-grok-build-dialect = agentGrokBuildDialectPackage;
@@ -340,6 +342,10 @@
                 apps.default = flake-utils.lib.mkApp {
                     drv = self.packages.${system}.agent-cli;
                     exePath = "/bin/agent-cli";
+                };
+                apps.agent-telegram = flake-utils.lib.mkApp {
+                    drv = self.packages.${system}.agent-telegram;
+                    exePath = "/bin/agent-telegram";
                 };
                 apps.agent-openai-login = flake-utils.lib.mkApp {
                     drv = self.packages.${system}.agent-openai-login;

--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -11,6 +11,7 @@ maintainer:         marc@digitallyinduced.com
 copyright:          (c) 2026 digitally induced GmbH
 category:           Development
 build-type:         Simple
+data-files:         skills/telegram-agent/SKILL.md
 
 common common-options
     default-language: GHC2021
@@ -37,6 +38,8 @@ common common-options
 library
     import:           common-options
     hs-source-dirs:   src
+    autogen-modules:  Paths_agent_cli
+    other-modules:    Paths_agent_cli
     exposed-modules:  Agent.CLI
                     , Agent.CLI.AgentSessions
                     , Agent.CLI.AgentViewport
@@ -86,6 +89,7 @@ library
                     , Agent.CLI.Subagents.Runtime
                     , Agent.CLI.Style
                     , Agent.CLI.Terminal
+                    , Agent.Telegram
                     , Agent.CLI.TextLayout
                     , Agent.CLI.Timestamp
                     , Agent.CLI.Tools
@@ -120,6 +124,8 @@ library
                     , filelock
                     , filepath
                     , haskeline >= 0.8 && < 0.9
+                    , http-client
+                    , http-client-tls
                     , JuicyPixels
                     , mtl
                     , process >= 1.6.26
@@ -140,6 +146,14 @@ executable agent-cli
     -- Keep the heap ceiling without multiplying a large allocation area by
     -- every host core. Four capabilities cover the agent's concurrent I/O;
     -- leave -A at the GHC RTS default.
+    ghc-options:      -threaded -rtsopts "-with-rtsopts=-N4 -M8G"
+    build-depends:    agent-cli
+                    , base >= 4.17 && < 5
+
+executable agent-telegram
+    import:           common-options
+    hs-source-dirs:   app
+    main-is:          Telegram.hs
     ghc-options:      -threaded -rtsopts "-with-rtsopts=-N4 -M8G"
     build-depends:    agent-cli
                     , base >= 4.17 && < 5
@@ -203,6 +217,7 @@ test-suite agent-cli-test
                     , Agent.CLI.StyleSpec
                     , Agent.CLI.TimestampSpec
                     , Agent.CLI.TerminalSpec
+                    , Agent.TelegramSpec
                     , Agent.CLI.TextLayoutSpec
                     , Agent.CLI.TurnSpec
                     , Agent.CLI.SessionSpec

--- a/packages/agent-cli/app/Telegram.hs
+++ b/packages/agent-cli/app/Telegram.hs
@@ -1,0 +1,6 @@
+module Main (main) where
+
+import Agent.Telegram (telegramMain)
+
+main :: IO ()
+main = telegramMain

--- a/packages/agent-cli/package.nix
+++ b/packages/agent-cli/package.nix
@@ -3,7 +3,8 @@
 , agent-responses, agent-syntax, agent-tui, agent-xai
 , ansi-terminal, async, base, base64-bytestring, brick, bytestring
 , colour, containers, directory, filelock, filepath, haskeline, hspec
-, JuicyPixels, lib, mtl, process, safe-exceptions, stm, text, time
+, http-client, http-client-tls, JuicyPixels, lib, mtl, process
+, safe-exceptions, stm, text, time
 , transformers, unix, vector, vty, vty-crossplatform
 }:
 mkDerivation {
@@ -17,7 +18,8 @@ mkDerivation {
     agent-openai agent-openrouter agent-responses agent-syntax agent-tui
     agent-xai ansi-terminal async base
     base64-bytestring brick bytestring colour containers directory filelock
-    filepath haskeline JuicyPixels mtl process safe-exceptions stm text
+    filepath haskeline http-client http-client-tls JuicyPixels mtl process
+    safe-exceptions stm text
     time transformers unix vector vty vty-crossplatform
   ];
   executableHaskellDepends = [ base ];

--- a/packages/agent-cli/skills/telegram-agent/SKILL.md
+++ b/packages/agent-cli/skills/telegram-agent/SKILL.md
@@ -53,6 +53,22 @@ disables terminal echo and stores the token in a private gateway file.
 
 9. Tell the user to open their new bot and send `/start`. The bot supports
    `/new` for a fresh agent session and `/session` for the current session ID.
+   Text, voice messages, and message reactions are persisted before processing.
+   Voice transcription uses the user's existing Codex subscription, so Codex
+   must already be logged in on the machine running the gateway.
+
+## Telegram delivery behavior
+
+- The gateway shows typing and a native rich-message draft while an agent turn
+  is running.
+- Agent Markdown is converted to Telegram-safe HTML, with a plain-text fallback.
+- A reply containing exactly one supported Telegram reaction emoji is delivered
+  as a reaction to the triggering message instead of as a separate message.
+- Inbound reaction changes become ordinary durable agent turns, including
+  reaction removals.
+- Voice messages are limited to 10 minutes and 20 MB. They are downloaded to a
+  private temporary gateway file, transcribed through `codex app-server`, then
+  deleted before the transcript enters the normal durable agent-session path.
 
 ## Management
 

--- a/packages/agent-cli/skills/telegram-agent/SKILL.md
+++ b/packages/agent-cli/skills/telegram-agent/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: telegram-agent
+description: Set up, start, stop, or troubleshoot a Telegram bot backed by the local agent harness.
+when-to-use: Use when the user asks to create, configure, run, or manage a Telegram agent or Telegram bot.
+argument-hint: "[setup|start|stop|status]"
+user-invocable: true
+---
+
+# Telegram agent
+
+Use the dedicated `agent-telegram` executable. Do not use an `agent-cli`
+Telegram subcommand.
+
+## Security rule
+
+Never ask the user to paste a BotFather token into chat, a prompt, or a tool
+argument. Agent conversations and tool calls may be persisted. Secret entry
+belongs exclusively to the interactive `agent-telegram setup` command, which
+disables terminal echo and stores the token in a private gateway file.
+
+## Setup workflow
+
+1. Explain that the user must open Telegram and message `@BotFather`.
+2. Tell them to run `/newbot`, choose the bot name and username, and keep the
+   returned token private.
+3. Help them obtain their numeric Telegram user ID, for example by messaging
+   `@userinfobot`. This ID is an allowlist entry, not a secret.
+4. Determine the desired provider and project working directory. Default to
+   the current project and a non-mutating approval policy. Only enable
+   `--yolo` when the user explicitly requests it.
+5. Ask the user to run this command in their own interactive terminal:
+
+   ```sh
+   agent-telegram setup --provider <provider> --cwd <project> \
+     --allowed-user <numeric-id>
+   ```
+
+   Add `--model`, `--effort`, or `--yolo` only when requested. The command
+   validates the token using Telegram's `getMe` API.
+6. Wait until the user confirms setup completed. Do not attempt to pipe or
+   inject the token through a shell tool.
+7. Start the configured gateway with:
+
+   ```sh
+   agent-telegram start
+   ```
+
+8. Verify it with:
+
+   ```sh
+   agent-telegram status
+   ```
+
+9. Tell the user to open their new bot and send `/start`. The bot supports
+   `/new` for a fresh agent session and `/session` for the current session ID.
+
+## Management
+
+Use `agent-telegram stop` to stop the background gateway. Logs and durable
+queue state live below `~/.haskell-agent/gateways/telegram/`.

--- a/packages/agent-cli/src/Agent/CLI/AgentSessions.hs
+++ b/packages/agent-cli/src/Agent/CLI/AgentSessions.hs
@@ -100,8 +100,9 @@ data AgentSessionToolsEnv = AgentSessionToolsEnv
     , toolsSessionStatus :: !(Text -> IO Text)
     }
 
-data ManagedSessionProcess = ManagedSessionProcess
-    { managedHandle :: !ProcessHandle }
+data ManagedSessionProcess
+    = ManagedSessionStarting
+    | ManagedSessionRunning !ProcessHandle
 
 data SessionProcessManager = SessionProcessManager
     { managedRoot :: !OsPath
@@ -127,102 +128,133 @@ launchSessionTurn
     -> Text
     -> IO (Either Text Text)
 launchSessionTurn manager background policy handle message =
-    modifyMVar manager.managedProcesses \processes -> do
-        let sessionId = handle.sessionMeta.metaId
-        busy <- case Map.lookup sessionId processes of
-            Nothing -> pure False
-            Just process -> (== Nothing) <$> getProcessExitCode process.managedHandle
-        if busy
-            then pure
-                ( processes
-                , Left ("session " <> sessionId <> " is already running")
-                )
-            else resolveAgentExecutable >>= \case
-                Left err -> pure (processes, Left err)
-                Right executable -> do
-                    parentEnv <- getEnvironment
-                    (promptPath, promptHandle) <- openTempFile
-                        (unsafeToFilePath handle.sessionDir) ".agent-prompt-"
-                    TextIO.hPutStr promptHandle message
-                    hClose promptHandle
-                    setFileMode promptPath 0o600
-                    (readyPath, readyHandle) <- openTempFile
-                        (unsafeToFilePath handle.sessionDir) ".agent-ready-"
-                    hClose readyHandle
-                    setFileMode readyPath 0o600
-                    let childEnv =
-                            (managedSessionReadyEnv, readyPath)
-                                : filter
-                                    ((/= managedSessionReadyEnv) . fst)
-                                    parentEnv
-                        logPath = unsafeToFilePath handle.sessionDir FilePath.</> "agent.log"
-                        approvalArgs = case policy of
-                            ApproveAll -> ["--yolo"]
-                            DenyMutating -> ["--no-yolo"]
-                            PromptMutating -> ["--no-yolo"]
-                        agentArgs =
-                            [ "--resume", Text.unpack sessionId
-                            , "--prompt-file", promptPath
-                            , "--save-session"
-                            ]
-                                <> approvalArgs
-                        cleanupScript =
-                            "prompt=$1; shift; "
-                                <> "cleanup() { rm -f \"$prompt\"; }; "
-                                <> "trap cleanup EXIT HUP INT TERM; "
-                                <> "\"$@\""
-                        args =
-                            [ "-c", cleanupScript
-                            , "agent-session-runner"
-                            , promptPath
-                            , executable
-                            ]
-                                <> agentArgs
-                    started <- try @_ @SomeException do
-                        withFile logPath AppendMode \logHandle ->
-                            setFileMode logPath 0o600 >>
-                            createProcess (proc "/bin/sh" args)
-                                { cwd = Just (unsafeToFilePath handle.sessionMeta.metaCwd)
-                                , std_in = NoStream
-                                , std_out = UseHandle logHandle
-                                , std_err = UseHandle logHandle
-                                , create_group = True
-                                , env = Just childEnv
-                                }
+    resolveAgentExecutable >>= \case
+        Left err -> pure (Left err)
+        Right executable -> do
+            let sessionId = handle.sessionMeta.metaId
+            reserved <- modifyMVar manager.managedProcesses \processes -> do
+                busy <- case Map.lookup sessionId processes of
+                    Nothing -> pure False
+                    Just ManagedSessionStarting -> pure True
+                    Just (ManagedSessionRunning managedHandle) ->
+                        (== Nothing) <$> getProcessExitCode managedHandle
+                if busy
+                    then pure (processes, False)
+                    else pure
+                        ( Map.insert sessionId ManagedSessionStarting processes
+                        , True
+                        )
+            if not reserved
+                then pure (Left ("session " <> sessionId <> " is already running"))
+                else do
+                    started <- try @_ @SomeException
+                        (startManagedSession executable)
                     case started of
                         Left err -> do
-                            removePrivateFile promptPath
-                            removePrivateFile readyPath
-                            pure
-                                ( processes
-                                , Left
-                                    ("failed to start agent session: "
-                                        <> formatException err)
-                                )
-                        Right (_, _, _, process) -> do
-                            ready <- waitForManagedSessionReady process readyPath
-                            removePrivateFile readyPath
-                            case ready of
-                                Left err -> do
-                                    _ <- waitForProcess process
-                                    pure (processes, Left err)
-                                Right ()
-                                    | background ->
-                                        pure
-                                            ( Map.insert sessionId ManagedSessionProcess
-                                                { managedHandle = process }
-                                                processes
-                                            , Right ("started session " <> sessionId)
-                                            )
-                                    | otherwise -> do
-                                        exitCode <- waitForProcess process
-                                        pure (processes, case exitCode of
-                                            ExitSuccess ->
-                                                Right ("completed session " <> sessionId)
-                                            ExitFailure code ->
-                                                Left
-                                                    ("session failed with exit code "
-                                                        <> Text.pack (show code)))
+                            forgetSession manager sessionId
+                            pure $ Left
+                                ("failed to start agent session: "
+                                    <> formatException err)
+                        Right (Left err) -> do
+                            forgetSession manager sessionId
+                            pure (Left err)
+                        Right (Right process) -> do
+                            modifyMVar_ manager.managedProcesses \processes ->
+                                pure (Map.insert sessionId
+                                    (ManagedSessionRunning process)
+                                    processes)
+                            if background
+                                then pure (Right ("started session " <> sessionId))
+                                else do
+                                    exitCode <- waitForProcess process
+                                    forgetSession manager sessionId
+                                    pure case exitCode of
+                                        ExitSuccess ->
+                                            Right ("completed session " <> sessionId)
+                                        ExitFailure code ->
+                                            Left
+                                                ("session failed with exit code "
+                                                    <> Text.pack (show code))
+  where
+    sessionId = handle.sessionMeta.metaId
+
+    startManagedSession executable = do
+        parentEnv <- getEnvironment
+        (promptPath, promptHandle) <- openTempFile
+            (unsafeToFilePath handle.sessionDir) ".agent-prompt-"
+        TextIO.hPutStr promptHandle message
+        hClose promptHandle
+        setFileMode promptPath 0o600
+        (readyPath, readyHandle) <- openTempFile
+            (unsafeToFilePath handle.sessionDir) ".agent-ready-"
+        hClose readyHandle
+        setFileMode readyPath 0o600
+        let childEnv =
+                (managedSessionReadyEnv, readyPath)
+                    : filter
+                        (\(name, _) ->
+                            name /= managedSessionReadyEnv
+                                && name `notElem` gatewayOnlyEnv)
+                        parentEnv
+            logPath = unsafeToFilePath handle.sessionDir FilePath.</> "agent.log"
+            approvalArgs = case policy of
+                ApproveAll -> ["--yolo"]
+                DenyMutating -> ["--no-yolo"]
+                PromptMutating -> ["--no-yolo"]
+            agentArgs =
+                [ "--resume", Text.unpack sessionId
+                , "--prompt-file", promptPath
+                , "--save-session"
+                ]
+                    <> approvalArgs
+            cleanupScript =
+                "prompt=$1; shift; "
+                    <> "cleanup() { rm -f \"$prompt\"; }; "
+                    <> "trap cleanup EXIT HUP INT TERM; "
+                    <> "\"$@\""
+            args =
+                [ "-c", cleanupScript
+                , "agent-session-runner"
+                , promptPath
+                , executable
+                ]
+                    <> agentArgs
+        started <- try @_ @SomeException do
+            withFile logPath AppendMode \logHandle ->
+                setFileMode logPath 0o600 >>
+                createProcess (proc "/bin/sh" args)
+                    { cwd = Just (unsafeToFilePath handle.sessionMeta.metaCwd)
+                    , std_in = NoStream
+                    , std_out = UseHandle logHandle
+                    , std_err = UseHandle logHandle
+                    , create_group = True
+                    , env = Just childEnv
+                    }
+        case started of
+            Left err -> do
+                removePrivateFile promptPath
+                removePrivateFile readyPath
+                pure $ Left
+                    ("failed to start agent session: " <> formatException err)
+            Right (_, _, _, process) -> do
+                ready <- waitForManagedSessionReady process readyPath
+                removePrivateFile readyPath
+                case ready of
+                    Left err -> do
+                        _ <- waitForProcess process
+                        pure (Left err)
+                    Right () -> pure (Right process)
+
+forgetSession :: SessionProcessManager -> Text -> IO ()
+forgetSession manager sessionId =
+    modifyMVar_ manager.managedProcesses
+        (pure . Map.delete sessionId)
+
+gatewayOnlyEnv :: [String]
+gatewayOnlyEnv =
+    [ "TELEGRAM_BOT_TOKEN"
+    , "TELEGRAM_ALLOWED_USERS"
+    ]
 
 sessionProcessStatus :: SessionProcessManager -> Text -> IO Text
 sessionProcessStatus manager sessionId =
@@ -234,8 +266,10 @@ sessionProcessStatus manager sessionId =
                         (manager.managedRoot
                             </> unsafeEncodeUtf (Text.unpack sessionId)))
                 pure (processes, if locked then "running" else "idle")
-            Just process ->
-                getProcessExitCode process.managedHandle >>= \case
+            Just ManagedSessionStarting ->
+                pure (processes, "running")
+            Just (ManagedSessionRunning managedHandle) ->
+                getProcessExitCode managedHandle >>= \case
                     Nothing -> pure (processes, "running")
                     Just ExitSuccess ->
                         pure (Map.delete sessionId processes, "completed")
@@ -250,13 +284,15 @@ closeSessionProcessManager manager =
     modifyMVar_ manager.managedProcesses \processes -> do
         -- Running sessions intentionally outlive the caller. The child owns
         -- the advisory session lock; its wrapper owns prompt cleanup.
-        forM_ (Map.elems processes) \process -> do
-            getProcessExitCode process.managedHandle >>= \case
-                Just _ -> do
-                    _ <- try @_ @SomeException
-                        (waitForProcess process.managedHandle)
-                    pure ()
-                Nothing -> pure ()
+        forM_ (Map.elems processes) \case
+            ManagedSessionStarting -> pure ()
+            ManagedSessionRunning managedHandle ->
+                getProcessExitCode managedHandle >>= \case
+                    Just _ -> do
+                        _ <- try @_ @SomeException
+                            (waitForProcess managedHandle)
+                        pure ()
+                    Nothing -> pure ()
         pure Map.empty
 
 signalManagedSessionReady :: Either Text () -> IO ()

--- a/packages/agent-cli/src/Agent/CLI/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session.hs
@@ -19,6 +19,7 @@ module Agent.CLI.Session
     , addSessionUsage
     , deleteSession
     , loadSession
+    , loadSessionHandle
     , isValidSessionId
     , listSessions
     , sessionDirForId
@@ -555,6 +556,29 @@ loadSession root sessionId = runExceptT do
                 <> ")"
     turns <- loadTranscript transcriptPath
     pure (meta, turns)
+
+loadSessionHandle
+    :: OsPath
+    -> Text
+    -> IO (Either Text (SessionHandle, [SessionTurn]))
+loadSessionHandle root sessionId =
+    loadSession root sessionId >>= \case
+        Left err -> pure (Left err)
+        Right (meta, turns) ->
+            pure do
+                dir <- sessionDirForId root sessionId
+                tempDir <- sessionTempDirForId root sessionId
+                Right
+                    ( SessionHandle
+                        { sessionDir = dir
+                        , sessionTempDir = tempDir
+                        , sessionMetaPath = dir </> unsafeEncodeUtf "meta.json"
+                        , sessionTranscriptPath =
+                            dir </> unsafeEncodeUtf "transcript.jsonl"
+                        , sessionMeta = meta
+                        }
+                    , turns
+                    )
 
 deleteSession :: OsPath -> Text -> IO (Either Text ())
 deleteSession root sessionId = runExceptT do

--- a/packages/agent-cli/src/Agent/CLI/Skills.hs
+++ b/packages/agent-cli/src/Agent/CLI/Skills.hs
@@ -35,6 +35,7 @@ import Data.Text (Text)
 import qualified Data.Text as Text
 import System.IO (stderr)
 import System.OsPath (OsPath)
+import qualified Paths_agent_cli as Paths
 
 reservedSlashNames :: [Text]
 reservedSlashNames =
@@ -73,12 +74,24 @@ loadSkillsCatalogQuiet
     -> IO SkillCatalog
 loadSkillsCatalogQuiet options home projectRoot cwd
     | not options.optSkills = pure (SkillCatalog [] [])
-    | otherwise =
-        discoverSkills SkillDiscoverOptions
+    | otherwise = do
+        discovered <- discoverSkills SkillDiscoverOptions
             { skillsHome = home
             , skillsProjectRoot = projectRoot
             , skillsCwd = cwd
             , skillsMaxDepth = 6
+            }
+        bundledPath <- Paths.getDataFileName "skills/telegram-agent/SKILL.md"
+        bundled <- loadSkillFile BuiltinSkill AgentSkills bundledPath
+        pure discovered
+            { catalogSkills =
+                either (const discovered.catalogSkills)
+                    (: discovered.catalogSkills)
+                    bundled
+            , catalogWarnings =
+                either (: discovered.catalogWarnings)
+                    (const discovered.catalogWarnings)
+                    bundled
             }
 
 reportSkillWarning :: Bool -> SkillWarning -> IO ()
@@ -171,6 +184,7 @@ skillSourceLabel skill =
     scope <> " · " <> origin
   where
     scope = case skill.skillScope of
+        BuiltinSkill -> "built-in"
         UserSkill -> "user"
         RepositorySkill _ True -> "local"
         RepositorySkill _ False -> "repo"

--- a/packages/agent-cli/src/Agent/Telegram.hs
+++ b/packages/agent-cli/src/Agent/Telegram.hs
@@ -3,6 +3,8 @@ module Agent.Telegram
     ( telegramMain
     , parseAllowedUsers
     , splitTelegramText
+    , markdownToTelegramHtml
+    , withTelegramProgressUsing
     , TelegramConfig(..)
     , TelegramCommand(..)
     , TelegramSetupOptions(..)
@@ -12,11 +14,18 @@ module Agent.Telegram
     , TelegramState(..)
     , TelegramPendingTurn(..)
     , TelegramPendingReply(..)
+    , TelegramVoice(..)
+    , TelegramMessage(..)
+    , TelegramUpdate(..)
     , TelegramUpdateAction(..)
     , PendingChatAction(..)
     , emptyTelegramState
     , storeUpdateAction
     , nextPendingAction
+    , checkpointPendingVoiceTranscript
+    , reactionMessageText
+    , telegramReactionEmoji
+    , transcribeWithCodex
     ) where
 
 import Agent.CLI.AgentSessions
@@ -48,36 +57,45 @@ import Agent.FileRetry (writeLazyFileAtomically)
 import Agent.Dialect (DialectId, dialectIdForModel)
 import Agent.OsPath (unsafeToFilePath)
 import Agent.Provider (Provider, parseProvider, providerSlug)
+import Control.Applicative ((<|>))
 import Control.Concurrent (threadDelay)
-import Control.Concurrent.Async (async, race_)
+import Control.Concurrent.Async
+    ( Async
+    , async
+    , cancel
+    , race_
+    , waitCatch
+    , withAsync
+    )
 import Control.Concurrent.MVar
     ( MVar
     , modifyMVar
+    , modifyMVar_
+    , newEmptyMVar
     , newMVar
+    , putMVar
     , readMVar
-    )
-import Control.Concurrent.STM
-    ( TVar
-    , atomically
-    , modifyTVar'
-    , newTVarIO
-    , readTVar
+    , takeMVar
     )
 import Control.Exception.Safe
     ( SomeException
     , bracket
     , displayException
     , finally
+    , mask
     , try
     , tryAny
     )
 import Control.Monad (forM_, unless, void, when)
 import Data.Aeson
     ( FromJSON(..)
+    , Result(..)
     , ToJSON(..)
-    , Value
+    , Value(..)
     , eitherDecode
+    , eitherDecodeStrict'
     , encode
+    , fromJSON
     , object
     , withObject
     , (.:)
@@ -85,17 +103,25 @@ import Data.Aeson
     , (.!=)
     , (.=)
     )
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
 import qualified Data.ByteString.Lazy as LBS
+import qualified Data.ByteString.Lazy.Char8 as LBS8
+import qualified Data.ByteString.Char8 as BS8
 import qualified Data.Text.Encoding as TextEncoding
 import Data.List (find)
+import qualified Data.Map.Strict as Map
+import Data.Map.Strict (Map)
 import Data.Maybe (fromMaybe)
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
+import qualified Data.Vector as Vector
 import qualified Network.HTTP.Client as Http
 import qualified Network.HTTP.Client.TLS as HttpTls
+import qualified System.Directory as Directory
 import System.Directory.OsPath
     ( createDirectoryIfMissing
     , doesFileExist
@@ -106,8 +132,11 @@ import System.Directory.OsPath
     )
 import System.Environment (getArgs, getExecutablePath, lookupEnv)
 import System.Exit (die)
+import System.FilePath (takeExtension)
 import System.IO
-    ( IOMode(AppendMode)
+    ( Handle
+    , IOMode(AppendMode)
+    , hClose
     , hFlush
     , hGetEcho
     , hIsTerminalDevice
@@ -128,8 +157,11 @@ import System.Process
     , createProcess
     , getProcessExitCode
     , proc
+    , terminateProcess
+    , waitForProcess
     )
 import qualified System.FileLock as FileLock
+import qualified System.Timeout as Timeout
 import Text.Read (readMaybe)
 
 data TelegramConfig = TelegramConfig
@@ -259,6 +291,7 @@ data TelegramPendingTurn = TelegramPendingTurn
     , pendingTurnMessageId :: !Integer
     , pendingTurnChat :: !TelegramChatKey
     , pendingTurnText :: !Text
+    , pendingTurnVoice :: !(Maybe TelegramVoice)
     } deriving (Eq, Show)
 
 instance ToJSON TelegramPendingTurn where
@@ -267,6 +300,7 @@ instance ToJSON TelegramPendingTurn where
         , "messageId" .= pending.pendingTurnMessageId
         , "chat" .= pending.pendingTurnChat
         , "text" .= pending.pendingTurnText
+        , "voice" .= pending.pendingTurnVoice
         ]
 
 instance FromJSON TelegramPendingTurn where
@@ -276,10 +310,12 @@ instance FromJSON TelegramPendingTurn where
             <*> o .:? "messageId" .!= 0
             <*> o .: "chat"
             <*> o .: "text"
+            <*> o .:? "voice"
 
 data TelegramPendingReply = TelegramPendingReply
     { pendingUpdateId :: !Integer
     , pendingChat :: !TelegramChatKey
+    , pendingReplyToMessageId :: !(Maybe Integer)
     , pendingText :: !Text
     } deriving (Eq, Show)
 
@@ -287,6 +323,7 @@ instance ToJSON TelegramPendingReply where
     toJSON pending = object
         [ "updateId" .= pending.pendingUpdateId
         , "chat" .= pending.pendingChat
+        , "replyToMessageId" .= pending.pendingReplyToMessageId
         , "text" .= pending.pendingText
         ]
 
@@ -295,7 +332,23 @@ instance FromJSON TelegramPendingReply where
         TelegramPendingReply
             <$> o .: "updateId"
             <*> o .: "chat"
+            <*> o .:? "replyToMessageId"
             <*> o .: "text"
+
+data TelegramVoice = TelegramVoice
+    { voiceFileId :: !Text
+    , voiceDuration :: !Int
+    , voiceMimeType :: !(Maybe Text)
+    , voiceFileSize :: !(Maybe Integer)
+    } deriving (Eq, Show)
+
+instance ToJSON TelegramVoice where
+    toJSON voice = object
+        [ "fileId" .= voice.voiceFileId
+        , "duration" .= voice.voiceDuration
+        , "mimeType" .= voice.voiceMimeType
+        , "fileSize" .= voice.voiceFileSize
+        ]
 
 data TelegramUser = TelegramUser
     { userId :: !Integer
@@ -322,6 +375,7 @@ data TelegramMessage = TelegramMessage
     , messageChat :: !TelegramChat
     , messageThread :: !(Maybe Integer)
     , messageText :: !(Maybe Text)
+    , messageVoice :: !(Maybe TelegramVoice)
     } deriving (Eq, Show)
 
 instance FromJSON TelegramMessage where
@@ -332,10 +386,50 @@ instance FromJSON TelegramMessage where
             <*> o .: "chat"
             <*> o .:? "message_thread_id"
             <*> o .:? "text"
+            <*> o .:? "voice"
+
+instance FromJSON TelegramVoice where
+    parseJSON = withObject "TelegramVoice" \o ->
+        TelegramVoice
+            <$> (o .:? "file_id" >>= maybe (o .: "fileId") pure)
+            <*> (o .:? "duration" .!= 0)
+            <*> (o .:? "mime_type" >>= maybe (o .:? "mimeType") (pure . Just))
+            <*> (o .:? "file_size" >>= maybe (o .:? "fileSize") (pure . Just))
+
+data TelegramReactionType = TelegramReactionType
+    { reactionType :: !Text
+    , reactionEmoji :: !(Maybe Text)
+    , reactionCustomEmojiId :: !(Maybe Text)
+    } deriving (Eq, Show)
+
+instance FromJSON TelegramReactionType where
+    parseJSON = withObject "TelegramReactionType" \o ->
+        TelegramReactionType
+            <$> o .: "type"
+            <*> o .:? "emoji"
+            <*> o .:? "custom_emoji_id"
+
+data TelegramMessageReaction = TelegramMessageReaction
+    { messageReactionChat :: !TelegramChat
+    , messageReactionMessageId :: !Integer
+    , messageReactionUser :: !(Maybe TelegramUser)
+    , messageReactionOld :: ![TelegramReactionType]
+    , messageReactionNew :: ![TelegramReactionType]
+    } deriving (Eq, Show)
+
+instance FromJSON TelegramMessageReaction where
+    parseJSON = withObject "TelegramMessageReaction" \o ->
+        TelegramMessageReaction
+            <$> o .: "chat"
+            <*> o .: "message_id"
+            <*> o .:? "user"
+            <*> (o .:? "old_reaction" .!= [])
+            <*> (o .:? "new_reaction" .!= [])
 
 data TelegramUpdate = TelegramUpdate
     { updateId :: !Integer
     , updateMessage :: !(Maybe TelegramMessage)
+    , updateMessageReaction :: !(Maybe TelegramMessageReaction)
     } deriving (Eq, Show)
 
 instance FromJSON TelegramUpdate where
@@ -343,6 +437,7 @@ instance FromJSON TelegramUpdate where
         TelegramUpdate
             <$> o .: "update_id"
             <*> o .:? "message"
+            <*> o .:? "message_reaction"
 
 data TelegramResponse a = TelegramResponse
     { responseOk :: !Bool
@@ -605,17 +700,18 @@ runTelegram config token = do
     setFileMode (unsafeToFilePath gatewayDir) 0o700
     state <- loadTelegramState statePath
     stateVar <- newMVar state
-    activeChats <- newTVarIO Set.empty
+    workers <- newMVar Map.empty
     manager <- HttpTls.newTlsManager
     processManager <- newSessionProcessManager root
     let client = TelegramClient token manager
         runtime = TelegramRuntime
             { runtimeClient = client
             , runtimeAllowedUsers = config.telegramAllowedUsers
+            , runtimeGatewayDirectory = gatewayDir
             , runtimeSessionsRoot = root
             , runtimeStatePath = statePath
             , runtimeStateVar = stateVar
-            , runtimeActiveChats = activeChats
+            , runtimeWorkers = workers
             , runtimeProcessManager = processManager
             , runtimeProvider = provider
             , runtimeModel = model
@@ -627,7 +723,9 @@ runTelegram config token = do
             }
     Text.putStrLn "Telegram gateway started (private chats only)."
     race_ (pollForever runtime) (dispatchForever runtime)
-        `finally` closeSessionProcessManager processManager
+        `finally` do
+            closeTelegramWorkers runtime
+            closeSessionProcessManager processManager
 
 removePidFile :: OsPath -> ProcessID -> IO ()
 removePidFile home expected = do
@@ -707,10 +805,11 @@ processIsAlive pid =
 data TelegramRuntime = TelegramRuntime
     { runtimeClient :: !TelegramClient
     , runtimeAllowedUsers :: !(Set Integer)
+    , runtimeGatewayDirectory :: !OsPath
     , runtimeSessionsRoot :: !OsPath
     , runtimeStatePath :: !OsPath
     , runtimeStateVar :: !(MVar TelegramState)
-    , runtimeActiveChats :: !(TVar (Set TelegramChatKey))
+    , runtimeWorkers :: !(MVar (Map TelegramChatKey (Async ())))
     , runtimeProcessManager :: !SessionProcessManager
     , runtimeProvider :: !Provider
     , runtimeModel :: !Text
@@ -747,7 +846,7 @@ processUpdate runtime update = do
 
 data TelegramUpdateAction
     = IgnoreUpdate
-    | QueueTurn !Integer !TelegramChatKey !Text
+    | QueueTurn !Integer !TelegramChatKey !Text !(Maybe TelegramVoice)
     deriving (Eq, Show)
 
 storeUpdateAction
@@ -761,11 +860,12 @@ storeUpdateAction updateId action current
     | otherwise =
         advanceOffset case action of
             IgnoreUpdate -> current
-            QueueTurn messageId key text ->
+            QueueTurn messageId key text voice ->
                 current
                     { pendingTurns =
                         current.pendingTurns
-                            <> [TelegramPendingTurn updateId messageId key text]
+                            <> [TelegramPendingTurn
+                                    updateId messageId key text voice]
                     }
   where
     advanceOffset state =
@@ -780,23 +880,58 @@ classifyUpdate
     -> TelegramUpdate
     -> IO TelegramUpdateAction
 classifyUpdate runtime update =
-    case update.updateMessage of
+    pure case update.updateMessage of
         Just message
             | message.messageChat.telegramChatType == "private"
             , Just sender <- message.messageFrom
-            , sender.userId `Set.member` runtime.runtimeAllowedUsers
-            , Just rawText <- message.messageText
-            , not (Text.null (Text.strip rawText)) ->
-                pure (QueueTurn
-                    message.messageId
-                    key
-                    (Text.strip rawText))
-          where
-            key = TelegramChatKey
-                { chatId = message.messageChat.telegramChatId
-                , messageThreadId = message.messageThread
-                }
-        _ -> pure IgnoreUpdate
+            , sender.userId `Set.member` runtime.runtimeAllowedUsers ->
+                let key = TelegramChatKey
+                        { chatId = message.messageChat.telegramChatId
+                        , messageThreadId = message.messageThread
+                        }
+                in case message.messageVoice of
+                    Just voice ->
+                        QueueTurn message.messageId key "[Voice message]" (Just voice)
+                    Nothing
+                        | Just rawText <- message.messageText
+                        , not (Text.null (Text.strip rawText)) ->
+                            QueueTurn message.messageId key
+                                (Text.strip rawText) Nothing
+                    _ -> IgnoreUpdate
+        _ -> case update.updateMessageReaction of
+            Just reaction
+                | reaction.messageReactionChat.telegramChatType == "private"
+                , Just sender <- reaction.messageReactionUser
+                , sender.userId `Set.member` runtime.runtimeAllowedUsers ->
+                    QueueTurn
+                        reaction.messageReactionMessageId
+                        TelegramChatKey
+                            { chatId =
+                                reaction.messageReactionChat.telegramChatId
+                            , messageThreadId = Nothing
+                            }
+                        (reactionMessageText reaction)
+                        Nothing
+            _ -> IgnoreUpdate
+
+reactionMessageText :: TelegramMessageReaction -> Text
+reactionMessageText reaction
+    | null reaction.messageReactionNew =
+        "[Telegram reaction removed from message "
+            <> Text.pack (show reaction.messageReactionMessageId)
+            <> "]"
+    | otherwise =
+        "[Telegram reaction on message "
+            <> Text.pack (show reaction.messageReactionMessageId)
+            <> "]: "
+            <> Text.intercalate " "
+                (map renderReaction reaction.messageReactionNew)
+  where
+    renderReaction value = case
+        (value.reactionEmoji, value.reactionCustomEmojiId) of
+            (Just emoji, _) -> emoji
+            (_, Just customId) -> "custom-emoji:" <> customId
+            _ -> value.reactionType
 
 updateAlreadyStored :: Integer -> TelegramState -> Bool
 updateAlreadyStored updateId state =
@@ -812,26 +947,35 @@ data PendingChatAction
 dispatchForever :: TelegramRuntime -> IO ()
 dispatchForever runtime = do
     state <- readMVar runtime.runtimeStateVar
-    active <- atomically (readTVar runtime.runtimeActiveChats)
+    workers <- readMVar runtime.runtimeWorkers
     let pendingChats = Set.fromList
             (map (.pendingTurnChat) state.pendingTurns
                 <> map (.pendingChat) state.pendingReplies)
-    forM_ (Set.toList (pendingChats `Set.difference` active)) \key -> do
-        claimed <- atomically do
-            current <- readTVar runtime.runtimeActiveChats
-            if key `Set.member` current
-                then pure False
-                else do
-                    modifyTVar' runtime.runtimeActiveChats (Set.insert key)
-                    pure True
-        if claimed
-            then void $ async $
-                processChatQueue runtime key `finally`
-                    atomically
-                        (modifyTVar' runtime.runtimeActiveChats (Set.delete key))
-            else pure ()
+        inactive =
+            pendingChats `Set.difference` Map.keysSet workers
+    forM_ (Set.toList inactive) (startTelegramWorker runtime)
     threadDelay 250_000
     dispatchForever runtime
+
+startTelegramWorker :: TelegramRuntime -> TelegramChatKey -> IO ()
+startTelegramWorker runtime key =
+    mask \restore -> do
+        startGate <- newEmptyMVar
+        worker <- async do
+            takeMVar startGate
+            restore (processChatQueue runtime key) `finally`
+                modifyMVar_ runtime.runtimeWorkers
+                    (pure . Map.delete key)
+        modifyMVar_ runtime.runtimeWorkers \workers ->
+            pure (Map.insert key worker workers)
+        putMVar startGate ()
+
+closeTelegramWorkers :: TelegramRuntime -> IO ()
+closeTelegramWorkers runtime = do
+    workers <- modifyMVar runtime.runtimeWorkers \current ->
+        pure (Map.empty, Map.elems current)
+    forM_ workers cancel
+    forM_ workers (void . waitCatch)
 
 processChatQueue :: TelegramRuntime -> TelegramChatKey -> IO ()
 processChatQueue runtime key =
@@ -840,7 +984,7 @@ processChatQueue runtime key =
         Just action -> do
             result <- tryAny case action of
                 DeliverReply pending -> do
-                    reply runtime pending.pendingChat pending.pendingText
+                    reply runtime pending
                     modifyState runtime \state ->
                         state
                             { pendingReplies =
@@ -850,7 +994,13 @@ processChatQueue runtime key =
                                     state.pendingReplies
                             }
                 RunPendingTurn pending -> do
-                    response <- runQueuedTurn runtime pending
+                    response <- case telegramCommand pending.pendingTurnText of
+                        Nothing ->
+                            withTelegramProgress
+                                runtime.runtimeClient
+                                pending.pendingTurnChat
+                                (runQueuedTurn runtime pending)
+                        Just _ -> runQueuedTurn runtime pending
                     modifyState runtime \state ->
                         state
                             { pendingTurns =
@@ -863,6 +1013,7 @@ processChatQueue runtime key =
                                     <> [ TelegramPendingReply
                                             pending.pendingTurnUpdateId
                                             pending.pendingTurnChat
+                                            (Just pending.pendingTurnMessageId)
                                             response
                                        ]
                             }
@@ -896,10 +1047,285 @@ runQueuedTurn runtime pending =
                 Nothing -> "No session yet. Send a prompt to create one."
                 Just sessionId -> "Session: " <> sessionId
         Just command -> pure ("Unknown command: /" <> command)
-        Nothing -> runAgentTurn
-            runtime
-            pending.pendingTurnChat
-            pending.pendingTurnText
+        Nothing -> case pending.pendingTurnVoice of
+            Nothing ->
+                runAgentTurn
+                    runtime
+                    pending.pendingTurnChat
+                    pending.pendingTurnText
+            Just voice ->
+                tryAny (transcribeTelegramVoice runtime pending voice) >>= \case
+                    Left err -> do
+                        Text.hPutStrLn stderr $
+                            "Telegram voice transcription failed: "
+                                <> redactToken
+                                    runtime.runtimeClient.clientToken
+                                    (Text.pack (displayException err))
+                        pure
+                            "I could not transcribe that voice message. \
+                            \Check that Codex is installed and logged in, and \
+                            \that the subscription has usage available."
+                    Right prompt -> do
+                        checkpointVoiceTranscript runtime pending prompt
+                        runAgentTurn runtime pending.pendingTurnChat prompt
+
+checkpointVoiceTranscript
+    :: TelegramRuntime
+    -> TelegramPendingTurn
+    -> Text
+    -> IO ()
+checkpointVoiceTranscript runtime pending transcript =
+    modifyState runtime
+        (checkpointPendingVoiceTranscript
+            pending.pendingTurnUpdateId
+            transcript)
+
+checkpointPendingVoiceTranscript
+    :: Integer
+    -> Text
+    -> TelegramState
+    -> TelegramState
+checkpointPendingVoiceTranscript updateId transcript state =
+    state
+        { pendingTurns =
+            map checkpoint state.pendingTurns
+        }
+  where
+    checkpoint current
+        | current.pendingTurnUpdateId == updateId =
+            current
+                { pendingTurnText = transcript
+                , pendingTurnVoice = Nothing
+                }
+        | otherwise = current
+
+transcribeTelegramVoice
+    :: TelegramRuntime
+    -> TelegramPendingTurn
+    -> TelegramVoice
+    -> IO Text
+transcribeTelegramVoice runtime pending voice = do
+    when (voice.voiceDuration > 600) $
+        fail "Telegram voice message exceeds the 10-minute limit"
+    when (maybe False (> 20 * 1024 * 1024) voice.voiceFileSize) $
+        fail "Telegram voice message exceeds the 20 MB limit"
+    filePath <- getTelegramFilePath runtime.runtimeClient voice.voiceFileId
+    let extension = case Text.toLower (Text.pack (takeExtension filePath)) of
+            ".wav" -> ".wav"
+            ".mp3" -> ".mp3"
+            ".m4a" -> ".m4a"
+            ".webm" -> ".webm"
+            _ -> ".ogg"
+        localPath =
+            runtime.runtimeGatewayDirectory
+                </> unsafeEncodeUtf
+                    ("voice-"
+                        <> show pending.pendingTurnUpdateId
+                        <> Text.unpack extension)
+    bracket
+        (downloadTelegramFile runtime.runtimeClient filePath localPath)
+        (\path -> void (tryAny (removeFile path)))
+        \path -> do
+            transcriptionCwd <- Directory.getTemporaryDirectory
+            transcript <- transcribeWithCodex
+                transcriptionCwd
+                (unsafeToFilePath path)
+            let clean = Text.strip transcript
+            when (Text.null clean) $
+                fail "Codex returned an empty voice transcription"
+            pure ("[Voice message transcript]: " <> clean)
+
+data TelegramFile = TelegramFile
+    { telegramFilePath :: !(Maybe Text)
+    }
+
+instance FromJSON TelegramFile where
+    parseJSON = withObject "TelegramFile" \o ->
+        TelegramFile <$> o .:? "file_path"
+
+getTelegramFilePath :: TelegramClient -> Text -> IO FilePath
+getTelegramFilePath client fileId =
+    telegramRequest client "getFile" (object ["file_id" .= fileId]) 30 >>= \case
+        Left err -> fail (Text.unpack err)
+        Right response ->
+            case decodeTelegramResponse response :: Either Text TelegramFile of
+                Left err -> fail (Text.unpack err)
+                Right TelegramFile { telegramFilePath = Nothing } ->
+                    fail "Telegram getFile response did not contain file_path"
+                Right TelegramFile { telegramFilePath = Just path } ->
+                    pure (Text.unpack path)
+
+downloadTelegramFile
+    :: TelegramClient
+    -> FilePath
+    -> OsPath
+    -> IO OsPath
+downloadTelegramFile client remotePath destination = do
+    response <- tryAny do
+        request <- Http.parseRequest $
+            "https://api.telegram.org/file/bot"
+                <> Text.unpack client.clientToken
+                <> "/"
+                <> remotePath
+        Http.httpLbs
+            request
+                { Http.responseTimeout =
+                    Http.responseTimeoutMicro 60_000_000
+                }
+            client.clientManager
+    body <- case response of
+        Left err ->
+            fail . Text.unpack $
+                redactToken client.clientToken
+                    (Text.pack (displayException err))
+        Right value -> pure (Http.responseBody value)
+    when (LBS.length body > 20 * 1024 * 1024) $
+        fail "Telegram voice download exceeds the 20 MB limit"
+    LBS.writeFile (unsafeToFilePath destination) body
+    setFileMode (unsafeToFilePath destination) 0o600
+    pure destination
+
+transcribeWithCodex :: FilePath -> FilePath -> IO Text
+transcribeWithCodex cwd audioPath = do
+    result <- Timeout.timeout (5 * 60 * 1_000_000) $
+        bracket start stop \(input, output, _) -> do
+            send input $ object
+                [ "method" .= ("initialize" :: Text)
+                , "id" .= (1 :: Int)
+                , "params" .= object
+                    [ "clientInfo" .= object
+                        [ "name" .= ("haskell_agent_telegram" :: Text)
+                        , "title" .= ("Haskell Agent Telegram" :: Text)
+                        , "version" .= ("0.1.0" :: Text)
+                        ]
+                    ]
+                ]
+            _ <- awaitResult output 1
+            send input $ object
+                [ "method" .= ("initialized" :: Text)
+                , "params" .= object []
+                ]
+            send input $ object
+                [ "method" .= ("thread/start" :: Text)
+                , "id" .= (2 :: Int)
+                , "params" .= object
+                    [ "ephemeral" .= True
+                    , "cwd" .= cwd
+                    , "approvalPolicy" .= ("never" :: Text)
+                    , "sandbox" .= ("read-only" :: Text)
+                    ]
+                ]
+            threadResponse <- awaitResult output 2
+            threadId <- maybe
+                (fail "Codex thread/start response did not contain a thread ID")
+                pure
+                (lookupText ["result", "thread", "id"] threadResponse)
+            send input $ object
+                [ "method" .= ("turn/start" :: Text)
+                , "id" .= (3 :: Int)
+                , "params" .= object
+                    [ "threadId" .= threadId
+                    , "input" .=
+                        [ object
+                            [ "type" .= ("text" :: Text)
+                            , "text" .=
+                                ("Transcribe the attached voice message exactly. \
+                                \Return only the transcription, without commentary."
+                                    :: Text)
+                            ]
+                        , object
+                            [ "type" .= ("localAudio" :: Text)
+                            , "path" .= audioPath
+                            ]
+                        ]
+                    ]
+                ]
+            _ <- awaitResult output 3
+            awaitCodexTranscript output Nothing
+    maybe (fail "Codex voice transcription timed out") pure result
+  where
+    start = do
+        (Just input, Just output, _, process) <-
+            createProcess (proc "codex" ["app-server", "--stdio"])
+                { std_in = CreatePipe
+                , std_out = CreatePipe
+                , std_err = Inherit
+                }
+        pure (input, output, process)
+    stop (input, output, process) = do
+        void (tryAny (hClose input))
+        void (tryAny (hClose output))
+        void (tryAny (terminateProcess process))
+        void (tryAny (waitForProcess process))
+    send handle value = do
+        LBS8.hPutStrLn handle (encode value)
+        hFlush handle
+
+awaitResult :: Handle -> Int -> IO Value
+awaitResult output expectedId = do
+    value <- readCodexValue output
+    case lookupInteger ["id"] value of
+        Just actualId
+            | actualId == fromIntegral expectedId ->
+                case lookupText ["error", "message"] value of
+                    Just message -> fail (Text.unpack message)
+                    Nothing -> pure value
+        _ -> awaitResult output expectedId
+
+awaitCodexTranscript :: Handle -> Maybe Text -> IO Text
+awaitCodexTranscript output latest = do
+    value <- readCodexValue output
+    let latest' = case
+            ( lookupText ["method"] value
+            , lookupText ["params", "item", "type"] value
+            , lookupText ["params", "item", "text"] value
+            ) of
+                (Just "item/completed", Just "agentMessage", Just text) ->
+                    Just text
+                _ -> latest
+    case lookupText ["method"] value of
+        Just "turn/completed" -> case
+            lookupText ["params", "turn", "error", "message"] value of
+                Just message -> fail (Text.unpack message)
+                Nothing ->
+                    maybe
+                        (fail "Codex completed without a transcription")
+                        pure
+                        ( latest'
+                            <|> lookupText
+                                ["params", "turn", "items", "0", "text"]
+                                value
+                        )
+        _ -> awaitCodexTranscript output latest'
+
+readCodexValue :: Handle -> IO Value
+readCodexValue output = do
+    line <- BS8.hGetLine output
+    case eitherDecodeStrict' line of
+        Left _ -> readCodexValue output
+        Right value -> pure value
+
+lookupText :: [Text] -> Value -> Maybe Text
+lookupText path value = case lookupValue path value of
+    Just (String text) -> Just text
+    _ -> Nothing
+
+lookupInteger :: [Text] -> Value -> Maybe Integer
+lookupInteger path value = case lookupValue path value of
+    Just number -> case fromJSON number of
+        Success integer -> Just integer
+        Error _ -> Nothing
+    _ -> Nothing
+
+lookupValue :: [Text] -> Value -> Maybe Value
+lookupValue [] value = Just value
+lookupValue (field : fields) (Object values) =
+    KeyMap.lookup (Key.fromText field) values >>= lookupValue fields
+lookupValue (index : fields) (Array values) = do
+    position <- readMaybe (Text.unpack index)
+    value <- values Vector.!? position
+    lookupValue fields value
+lookupValue _ _ = Nothing
 
 nextChatAction
     :: TelegramRuntime
@@ -948,6 +1374,12 @@ telegramCommand text = do
 runAgentTurn :: TelegramRuntime -> TelegramChatKey -> Text -> IO Text
 runAgentTurn runtime key prompt = do
     handle <- sessionForPrompt runtime key prompt
+    let agentPrompt =
+            prompt
+                <> "\n\n[Telegram delivery context: If the best response is \
+                \only a lightweight acknowledgement, you may respond with \
+                \exactly one standard Telegram reaction emoji. Otherwise \
+                \respond normally. Do not mention this delivery context.]"
     priorTurnCount <- loadSessionHandle
         runtime.runtimeSessionsRoot
         handle.sessionMeta.metaId >>= \case
@@ -958,7 +1390,7 @@ runAgentTurn runtime key prompt = do
         False
         runtime.runtimePolicy
         handle
-        prompt >>= \case
+        agentPrompt >>= \case
             Left err -> fail (Text.unpack err)
             Right _ ->
                 loadSessionHandle
@@ -967,7 +1399,7 @@ runAgentTurn runtime key prompt = do
                         Left err -> fail (Text.unpack err)
                         Right (_, turns)
                             | length turns > priorTurnCount
-                            , latestTurnMatches prompt turns ->
+                            , latestTurnMatches agentPrompt turns ->
                                 pure (renderLatestTurn turns)
                             | otherwise ->
                                 fail
@@ -1033,17 +1465,206 @@ modifyState runtime update =
         saveTelegramState runtime.runtimeStatePath next
         pure (next, ())
 
-reply :: TelegramRuntime -> TelegramChatKey -> Text -> IO ()
-reply runtime key text = do
-    -- Telegram counts astral Unicode characters as two UTF-16 code units.
-    -- A 2000-code-point chunk therefore remains below sendMessage's limit.
-    let chunks = case splitTelegramText 2000 text of
-            [] -> ["(empty response)"]
-            values -> values
-    forM_ chunks \chunk ->
-        sendMessage runtime.runtimeClient key chunk >>= \case
-            Left err -> fail (Text.unpack err)
-            Right () -> pure ()
+reply :: TelegramRuntime -> TelegramPendingReply -> IO ()
+reply runtime pending
+    | Just emoji <- telegramReactionEmoji pending.pendingText
+    , Just messageId <- pending.pendingReplyToMessageId = do
+        setMessageReaction
+            runtime.runtimeClient
+            pending.pendingChat
+            messageId
+            emoji >>= \case
+                Right () -> pure ()
+                Left _ -> sendTextReply
+    | otherwise = do
+        sendTextReply
+  where
+    sendTextReply = do
+        -- Rich HTML entities can expand one source character to six bytes.
+        -- Keep source chunks conservative so the rendered message stays below
+        -- Telegram's 4096-character limit without splitting generated tags.
+        let chunks = case splitTelegramText 600 pending.pendingText of
+                [] -> ["(empty response)"]
+                values -> values
+        forM_ chunks \chunk ->
+            sendRichMessage
+                runtime.runtimeClient
+                pending.pendingChat
+                chunk >>= \case
+                    Left err -> fail (Text.unpack err)
+                    Right () -> pure ()
+
+telegramReactionEmoji :: Text -> Maybe Text
+telegramReactionEmoji text =
+    let candidate = Text.filter (/= '\xFE0F') (Text.strip text)
+        normalized = if candidate == "♥" then "❤" else candidate
+    in if normalized `Set.member` supportedTelegramReactions
+        then Just normalized
+        else Nothing
+
+supportedTelegramReactions :: Set Text
+supportedTelegramReactions = Set.fromList
+    [ "👍", "👎", "❤", "🔥", "🥰", "👏", "😁", "🤔", "🤯", "😱"
+    , "🤬", "😢", "🎉", "🤩", "🤮", "💩", "🙏", "👌", "🕊", "🤡"
+    , "🥱", "🥴", "😍", "🐳", "🌚", "🌭", "💯", "🤣", "⚡"
+    , "🍌", "🏆", "💔", "🤨", "😐", "🍓", "🍾", "💋", "🖕", "😈"
+    , "😴", "😭", "🤓", "👻", "👀", "🎃", "🙈", "😇", "😨"
+    , "🤝", "✍", "🤗", "🫡", "🎅", "🎄", "☃", "💅", "🤪", "🗿"
+    , "🆒", "💘", "🙉", "🦄", "😘", "💊", "🙊", "😎", "👾", "🤷"
+    , "😡"
+    ]
+
+withTelegramProgress
+    :: TelegramClient
+    -> TelegramChatKey
+    -> IO a
+    -> IO a
+withTelegramProgress client key action =
+    withTelegramProgressUsing
+        (sendTypingAction client key)
+        (sendThinkingDraft client key)
+        action
+
+withTelegramProgressUsing :: IO () -> IO () -> IO a -> IO a
+withTelegramProgressUsing sendTyping sendDraft action =
+    withAsync progressLoop (const action)
+  where
+    progressLoop = loop (0 :: Int)
+    loop tick = do
+        -- Chat actions expire after roughly five seconds. Rich drafts last
+        -- longer, so refresh typing every four seconds and the draft every
+        -- fifth tick. Both are best-effort: the final reply remains durable
+        -- even when a client or Bot API version does not support rich drafts.
+        void (tryAny sendTyping)
+        when (tick `mod` 5 == 0) $
+            void (tryAny sendDraft)
+        threadDelay 4_000_000
+        loop (tick + 1)
+
+sendTypingAction :: TelegramClient -> TelegramChatKey -> IO ()
+sendTypingAction client key =
+    telegramRequest client "sendChatAction" body 30 >>= \case
+        Left err -> fail (Text.unpack err)
+        Right response ->
+            case decodeTelegramResponse response :: Either Text Bool of
+                Left err -> fail (Text.unpack err)
+                Right _ -> pure ()
+  where
+    body = object $
+        [ "chat_id" .= key.chatId
+        , "action" .= ("typing" :: Text)
+        ]
+            <> maybe []
+                (\threadId -> ["message_thread_id" .= threadId])
+                key.messageThreadId
+
+-- | Convert the Markdown subset commonly emitted by agents to Telegram's
+-- supported HTML. Literal text and link attributes are always escaped.
+markdownToTelegramHtml :: Text -> Text
+markdownToTelegramHtml input =
+    Text.concat (zipWith renderSegment [0 :: Int ..] (Text.splitOn "```" input))
+  where
+    renderSegment index segment
+        | odd index =
+            "<pre>" <> escapeTelegramHtml (stripLanguage segment) <> "</pre>"
+        | otherwise =
+            Text.replace "\n" "<br>" (renderInline segment)
+
+    stripLanguage segment =
+        case Text.breakOn "\n" segment of
+            (language, rest)
+                | not (Text.null language)
+                , Text.all isLanguageCharacter language ->
+                    Text.drop 1 rest
+            _ -> segment
+
+    isLanguageCharacter char =
+        ('a' <= char && char <= 'z')
+            || ('A' <= char && char <= 'Z')
+            || ('0' <= char && char <= '9')
+            || char `elem` ("-+#_" :: String)
+
+renderInline :: Text -> Text
+renderInline text
+    | Text.null text = ""
+    | Just rest <- Text.stripPrefix "`" text =
+        renderDelimited "`" "<code>" "</code>" rest
+    | Just rest <- Text.stripPrefix "**" text =
+        renderDelimited "**" "<b>" "</b>" rest
+    | Just rest <- Text.stripPrefix "~~" text =
+        renderDelimited "~~" "<s>" "</s>" rest
+    | Just rest <- Text.stripPrefix "*" text =
+        renderDelimited "*" "<i>" "</i>" rest
+    | Just rest <- Text.stripPrefix "[" text =
+        case parseMarkdownLink rest of
+            Just (label, url, remaining) ->
+                "<a href=\"" <> escapeTelegramHtml url <> "\">"
+                    <> escapeTelegramHtml label
+                    <> "</a>"
+                    <> renderInline remaining
+            Nothing -> "&#91;" <> renderInline rest
+    | otherwise =
+        let (plain, rest) = Text.break isMarkdownStarter text
+        in if Text.null plain
+            then escapeTelegramHtml (Text.take 1 text)
+                <> renderInline (Text.drop 1 text)
+            else escapeTelegramHtml plain <> renderInline rest
+  where
+    renderDelimited delimiter opening closing rest =
+        case Text.breakOn delimiter rest of
+            (_, after) | Text.null after ->
+                escapeTelegramHtml delimiter <> renderInline rest
+            (inside, after) ->
+                opening
+                    <> escapeTelegramHtml inside
+                    <> closing
+                    <> renderInline (Text.drop (Text.length delimiter) after)
+
+    isMarkdownStarter char =
+        char == '`' || char == '*' || char == '~' || char == '['
+
+parseMarkdownLink :: Text -> Maybe (Text, Text, Text)
+parseMarkdownLink text = do
+    let (label, afterLabel) = Text.breakOn "](" text
+    unlessMaybe (not (Text.null afterLabel))
+    let afterOpen = Text.drop 2 afterLabel
+        (url, afterUrl) = Text.breakOn ")" afterOpen
+    unlessMaybe (not (Text.null afterUrl))
+    pure (label, url, Text.drop 1 afterUrl)
+
+unlessMaybe :: Bool -> Maybe ()
+unlessMaybe True = Just ()
+unlessMaybe False = Nothing
+
+escapeTelegramHtml :: Text -> Text
+escapeTelegramHtml = Text.concatMap \case
+    '<' -> "&lt;"
+    '>' -> "&gt;"
+    '&' -> "&amp;"
+    '"' -> "&quot;"
+    '\'' -> "&#39;"
+    char -> Text.singleton char
+
+sendThinkingDraft :: TelegramClient -> TelegramChatKey -> IO ()
+sendThinkingDraft client key =
+    telegramRequest client "sendRichMessageDraft" body 30 >>= \case
+        Left err -> fail (Text.unpack err)
+        Right response ->
+            case decodeTelegramResponse response :: Either Text Bool of
+                Left err -> fail (Text.unpack err)
+                Right _ -> pure ()
+  where
+    body = object $
+        [ "chat_id" .= key.chatId
+        , "draft_id" .= (1 :: Int)
+        , "rich_message" .= object
+            [ "html" .=
+                ("<tg-thinking>✨ Thinking…</tg-thinking>" :: Text)
+            ]
+        ]
+            <> maybe []
+                (\threadId -> ["message_thread_id" .= threadId])
+                key.messageThreadId
 
 getUpdates
     :: TelegramClient
@@ -1056,22 +1677,91 @@ getUpdates client offset =
   where
     body = object $
         [ "timeout" .= (30 :: Int)
-        , "allowed_updates" .= (["message"] :: [Text])
+        , "allowed_updates" .=
+            (["message", "message_reaction"] :: [Text])
         ]
             <> maybe [] (\value -> ["offset" .= value]) offset
 
-sendMessage
+setMessageReaction
+    :: TelegramClient
+    -> TelegramChatKey
+    -> Integer
+    -> Text
+    -> IO (Either Text ())
+setMessageReaction client key messageId emoji =
+    telegramRequest client "setMessageReaction" body 30 >>= \case
+        Left err -> pure (Left err)
+        Right response ->
+            pure (() <$ (decodeTelegramResponse response :: Either Text Bool))
+  where
+    body = object
+        [ "chat_id" .= key.chatId
+        , "message_id" .= messageId
+        , "reaction" .=
+            [ object
+                [ "type" .= ("emoji" :: Text)
+                , "emoji" .= emoji
+                ]
+            ]
+        ]
+
+sendRichMessage
     :: TelegramClient
     -> TelegramChatKey
     -> Text
     -> IO (Either Text ())
-sendMessage client key text =
-    telegramRequest client "sendMessage" body 30 >>= \case
+sendRichMessage client key text =
+    telegramRequest client "sendRichMessage" richBody 30 >>= \case
+        Right response
+            | Right (_ :: Value) <- decodeTelegramResponse response ->
+                pure (Right ())
+        _ -> sendHtmlMessage client key text
+  where
+    richBody = object $
+        [ "chat_id" .= key.chatId
+        , "rich_message" .= object
+            [ "html" .= markdownToTelegramHtml text
+            ]
+        ]
+            <> maybe []
+                (\threadId -> ["message_thread_id" .= threadId])
+                key.messageThreadId
+
+sendHtmlMessage
+    :: TelegramClient
+    -> TelegramChatKey
+    -> Text
+    -> IO (Either Text ())
+sendHtmlMessage client key text =
+    telegramRequest client "sendMessage" htmlBody 30 >>= \case
+        Right response
+            | Right (_ :: Value) <- decodeTelegramResponse response ->
+                pure (Right ())
+        _ -> sendPlainMessage client key text
+  where
+    htmlBody = object $
+        [ "chat_id" .= key.chatId
+        , "text" .= markdownToTelegramHtml text
+        , "parse_mode" .= ("HTML" :: Text)
+        ]
+            <> maybe []
+                (\threadId -> ["message_thread_id" .= threadId])
+                key.messageThreadId
+
+sendPlainMessage
+    :: TelegramClient
+    -> TelegramChatKey
+    -> Text
+    -> IO (Either Text ())
+sendPlainMessage client key text =
+    telegramRequest client "sendMessage" (messageBody key text) 30 >>= \case
         Left err -> pure (Left err)
         Right response ->
             pure (() <$ (decodeTelegramResponse response :: Either Text Value))
-  where
-    body = object $
+
+messageBody :: TelegramChatKey -> Text -> Value
+messageBody key text =
+    object $
         [ "chat_id" .= key.chatId
         , "text" .= text
         ]

--- a/packages/agent-cli/src/Agent/Telegram.hs
+++ b/packages/agent-cli/src/Agent/Telegram.hs
@@ -1,0 +1,1148 @@
+-- | Dedicated Telegram gateway backed by persisted agent sessions.
+module Agent.Telegram
+    ( telegramMain
+    , parseAllowedUsers
+    , splitTelegramText
+    , TelegramConfig(..)
+    , TelegramCommand(..)
+    , TelegramSetupOptions(..)
+    , defaultTelegramSetupOptions
+    , parseTelegramArgs
+    , TelegramChatKey(..)
+    , TelegramState(..)
+    , TelegramPendingTurn(..)
+    , TelegramPendingReply(..)
+    , TelegramUpdateAction(..)
+    , PendingChatAction(..)
+    , emptyTelegramState
+    , storeUpdateAction
+    , nextPendingAction
+    ) where
+
+import Agent.CLI.AgentSessions
+    ( SessionProcessManager
+    , closeSessionProcessManager
+    , launchSessionTurn
+    , newSessionProcessManager
+    )
+import Agent.CLI.Options
+    ( ApprovalPolicy(..)
+    , defaultEffortFor
+    )
+import Agent.CLI.Models
+    ( ModelOption(..)
+    , resolveModelOptionDialect
+    )
+import Agent.CLI.Prompt (defaultModelFor)
+import Agent.CLI.Session
+    ( SessionCreate(..)
+    , SessionHandle(..)
+    , SessionMeta(..)
+    , SessionTurn(..)
+    , createSession
+    , loadSessionHandle
+    , sessionTitleFromPrompt
+    , sessionsRoot
+    )
+import Agent.FileRetry (writeLazyFileAtomically)
+import Agent.Dialect (DialectId, dialectIdForModel)
+import Agent.OsPath (unsafeToFilePath)
+import Agent.Provider (Provider, parseProvider, providerSlug)
+import Control.Concurrent (threadDelay)
+import Control.Concurrent.Async (async, race_)
+import Control.Concurrent.MVar
+    ( MVar
+    , modifyMVar
+    , newMVar
+    , readMVar
+    )
+import Control.Concurrent.STM
+    ( TVar
+    , atomically
+    , modifyTVar'
+    , newTVarIO
+    , readTVar
+    )
+import Control.Exception.Safe
+    ( SomeException
+    , bracket
+    , displayException
+    , finally
+    , try
+    , tryAny
+    )
+import Control.Monad (forM_, unless, void, when)
+import Data.Aeson
+    ( FromJSON(..)
+    , ToJSON(..)
+    , Value
+    , eitherDecode
+    , encode
+    , object
+    , withObject
+    , (.:)
+    , (.:?)
+    , (.!=)
+    , (.=)
+    )
+import qualified Data.ByteString.Lazy as LBS
+import qualified Data.Text.Encoding as TextEncoding
+import Data.List (find)
+import Data.Maybe (fromMaybe)
+import Data.Set (Set)
+import qualified Data.Set as Set
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.IO as Text
+import qualified Network.HTTP.Client as Http
+import qualified Network.HTTP.Client.TLS as HttpTls
+import System.Directory.OsPath
+    ( createDirectoryIfMissing
+    , doesFileExist
+    , getCurrentDirectory
+    , getHomeDirectory
+    , makeAbsolute
+    , removeFile
+    )
+import System.Environment (getArgs, getExecutablePath, lookupEnv)
+import System.Exit (die)
+import System.IO
+    ( IOMode(AppendMode)
+    , hFlush
+    , hGetEcho
+    , hIsTerminalDevice
+    , hSetEcho
+    , withFile
+    , stderr
+    , stdin
+    )
+import System.OsPath (OsPath, unsafeEncodeUtf, (</>))
+import System.Posix.Files (setFileMode)
+import System.Posix.Process (getProcessID)
+import System.Posix.Signals (nullSignal, sigTERM, signalProcess)
+import System.Posix.Types (ProcessID)
+import System.Process
+    ( CreateProcess(..)
+    , ProcessHandle
+    , StdStream(..)
+    , createProcess
+    , getProcessExitCode
+    , proc
+    )
+import qualified System.FileLock as FileLock
+import Text.Read (readMaybe)
+
+data TelegramConfig = TelegramConfig
+    { telegramProvider :: !Provider
+    , telegramModel :: !(Maybe Text)
+    , telegramCwd :: !FilePath
+    , telegramEffort :: !(Maybe Text)
+    , telegramYolo :: !Bool
+    , telegramAllowedUsers :: !(Set Integer)
+    } deriving (Eq, Show)
+
+instance ToJSON TelegramConfig where
+    toJSON config = object
+        [ "provider" .= providerSlug config.telegramProvider
+        , "model" .= config.telegramModel
+        , "cwd" .= config.telegramCwd
+        , "effort" .= config.telegramEffort
+        , "yolo" .= config.telegramYolo
+        , "allowedUsers" .= Set.toList config.telegramAllowedUsers
+        ]
+
+instance FromJSON TelegramConfig where
+    parseJSON = withObject "TelegramConfig" \o -> do
+        providerText <- o .: "provider"
+        telegramProvider <- maybe
+            (fail ("unknown provider: " <> Text.unpack providerText))
+            pure
+            (parseProvider providerText)
+        TelegramConfig
+            <$> pure telegramProvider
+            <*> o .:? "model"
+            <*> o .: "cwd"
+            <*> o .:? "effort"
+            <*> (o .:? "yolo" .!= False)
+            <*> (Set.fromList <$> (o .: "allowedUsers"))
+
+data TelegramSetupOptions = TelegramSetupOptions
+    { setupProvider :: !(Maybe Provider)
+    , setupModel :: !(Maybe Text)
+    , setupCwd :: !(Maybe FilePath)
+    , setupEffort :: !(Maybe Text)
+    , setupYolo :: !Bool
+    , setupAllowedUser :: !(Maybe Integer)
+    , setupStart :: !Bool
+    } deriving (Eq, Show)
+
+defaultTelegramSetupOptions :: TelegramSetupOptions
+defaultTelegramSetupOptions = TelegramSetupOptions
+    { setupProvider = Nothing
+    , setupModel = Nothing
+    , setupCwd = Nothing
+    , setupEffort = Nothing
+    , setupYolo = False
+    , setupAllowedUser = Nothing
+    , setupStart = False
+    }
+
+data TelegramCommand
+    = TelegramSetup !TelegramSetupOptions
+    | TelegramRun
+    | TelegramStart
+    | TelegramStop
+    | TelegramStatus
+    | TelegramHelp
+    | TelegramVersion
+    deriving (Eq, Show)
+
+data TelegramChatKey = TelegramChatKey
+    { chatId :: !Integer
+    , messageThreadId :: !(Maybe Integer)
+    } deriving (Eq, Ord, Show)
+
+instance ToJSON TelegramChatKey where
+    toJSON key = object
+        [ "chatId" .= key.chatId
+        , "messageThreadId" .= key.messageThreadId
+        ]
+
+instance FromJSON TelegramChatKey where
+    parseJSON = withObject "TelegramChatKey" \o ->
+        TelegramChatKey
+            <$> o .: "chatId"
+            <*> o .:? "messageThreadId"
+
+data TelegramBinding = TelegramBinding
+    { bindingChat :: !TelegramChatKey
+    , bindingSessionId :: !Text
+    } deriving (Eq, Show)
+
+instance ToJSON TelegramBinding where
+    toJSON binding = object
+        [ "chat" .= binding.bindingChat
+        , "sessionId" .= binding.bindingSessionId
+        ]
+
+instance FromJSON TelegramBinding where
+    parseJSON = withObject "TelegramBinding" \o ->
+        TelegramBinding
+            <$> o .: "chat"
+            <*> o .: "sessionId"
+
+data TelegramState = TelegramState
+    { nextUpdateId :: !(Maybe Integer)
+    , bindings :: ![TelegramBinding]
+    , pendingTurns :: ![TelegramPendingTurn]
+    , pendingReplies :: ![TelegramPendingReply]
+    } deriving (Eq, Show)
+
+instance ToJSON TelegramState where
+    toJSON state = object
+        [ "nextUpdateId" .= state.nextUpdateId
+        , "bindings" .= state.bindings
+        , "pendingTurns" .= state.pendingTurns
+        , "pendingReplies" .= state.pendingReplies
+        ]
+
+instance FromJSON TelegramState where
+    parseJSON = withObject "TelegramState" \o ->
+        TelegramState
+            <$> o .:? "nextUpdateId"
+            <*> (o .:? "bindings" .!= [])
+            <*> (o .:? "pendingTurns" .!= [])
+            <*> (o .:? "pendingReplies" .!= [])
+
+data TelegramPendingTurn = TelegramPendingTurn
+    { pendingTurnUpdateId :: !Integer
+    , pendingTurnMessageId :: !Integer
+    , pendingTurnChat :: !TelegramChatKey
+    , pendingTurnText :: !Text
+    } deriving (Eq, Show)
+
+instance ToJSON TelegramPendingTurn where
+    toJSON pending = object
+        [ "updateId" .= pending.pendingTurnUpdateId
+        , "messageId" .= pending.pendingTurnMessageId
+        , "chat" .= pending.pendingTurnChat
+        , "text" .= pending.pendingTurnText
+        ]
+
+instance FromJSON TelegramPendingTurn where
+    parseJSON = withObject "TelegramPendingTurn" \o ->
+        TelegramPendingTurn
+            <$> o .: "updateId"
+            <*> o .:? "messageId" .!= 0
+            <*> o .: "chat"
+            <*> o .: "text"
+
+data TelegramPendingReply = TelegramPendingReply
+    { pendingUpdateId :: !Integer
+    , pendingChat :: !TelegramChatKey
+    , pendingText :: !Text
+    } deriving (Eq, Show)
+
+instance ToJSON TelegramPendingReply where
+    toJSON pending = object
+        [ "updateId" .= pending.pendingUpdateId
+        , "chat" .= pending.pendingChat
+        , "text" .= pending.pendingText
+        ]
+
+instance FromJSON TelegramPendingReply where
+    parseJSON = withObject "TelegramPendingReply" \o ->
+        TelegramPendingReply
+            <$> o .: "updateId"
+            <*> o .: "chat"
+            <*> o .: "text"
+
+data TelegramUser = TelegramUser
+    { userId :: !Integer
+    } deriving (Eq, Show)
+
+instance FromJSON TelegramUser where
+    parseJSON = withObject "TelegramUser" \o ->
+        TelegramUser <$> o .: "id"
+
+data TelegramChat = TelegramChat
+    { telegramChatId :: !Integer
+    , telegramChatType :: !Text
+    } deriving (Eq, Show)
+
+instance FromJSON TelegramChat where
+    parseJSON = withObject "TelegramChat" \o ->
+        TelegramChat
+            <$> o .: "id"
+            <*> o .: "type"
+
+data TelegramMessage = TelegramMessage
+    { messageId :: !Integer
+    , messageFrom :: !(Maybe TelegramUser)
+    , messageChat :: !TelegramChat
+    , messageThread :: !(Maybe Integer)
+    , messageText :: !(Maybe Text)
+    } deriving (Eq, Show)
+
+instance FromJSON TelegramMessage where
+    parseJSON = withObject "TelegramMessage" \o ->
+        TelegramMessage
+            <$> o .: "message_id"
+            <*> o .:? "from"
+            <*> o .: "chat"
+            <*> o .:? "message_thread_id"
+            <*> o .:? "text"
+
+data TelegramUpdate = TelegramUpdate
+    { updateId :: !Integer
+    , updateMessage :: !(Maybe TelegramMessage)
+    } deriving (Eq, Show)
+
+instance FromJSON TelegramUpdate where
+    parseJSON = withObject "TelegramUpdate" \o ->
+        TelegramUpdate
+            <$> o .: "update_id"
+            <*> o .:? "message"
+
+data TelegramResponse a = TelegramResponse
+    { responseOk :: !Bool
+    , responseResult :: !(Maybe a)
+    , responseDescription :: !(Maybe Text)
+    }
+
+instance FromJSON a => FromJSON (TelegramResponse a) where
+    parseJSON = withObject "TelegramResponse" \o ->
+        TelegramResponse
+            <$> o .: "ok"
+            <*> o .:? "result"
+            <*> o .:? "description"
+
+data TelegramClient = TelegramClient
+    { clientToken :: !Text
+    , clientManager :: !Http.Manager
+    }
+
+emptyTelegramState :: TelegramState
+emptyTelegramState = TelegramState
+    { nextUpdateId = Nothing
+    , bindings = []
+    , pendingTurns = []
+    , pendingReplies = []
+    }
+
+parseAllowedUsers :: Text -> Either Text (Set Integer)
+parseAllowedUsers raw = do
+    let values = filter (not . Text.null) $
+            Text.strip <$> Text.splitOn "," raw
+    users <- traverse parseUser values
+    if null users
+        then Left "TELEGRAM_ALLOWED_USERS must contain at least one numeric user ID"
+        else Right (Set.fromList users)
+  where
+    parseUser value = case readMaybe (Text.unpack value) of
+        Just userId | userId > 0 -> Right userId
+        _ -> Left ("invalid Telegram user ID: " <> value)
+
+splitTelegramText :: Int -> Text -> [Text]
+splitTelegramText limit text
+    | limit < 1 = []
+    | Text.null text = []
+    | otherwise =
+        let (chunk, rest) = Text.splitAt limit text
+        in chunk : splitTelegramText limit rest
+
+telegramMain :: IO ()
+telegramMain =
+    getArgs >>= either die executeTelegramCommand . parseTelegramArgs
+
+parseTelegramArgs :: [String] -> Either String TelegramCommand
+parseTelegramArgs = \case
+    [] -> Right TelegramRun
+    ["run"] -> Right TelegramRun
+    ["start"] -> Right TelegramStart
+    ["stop"] -> Right TelegramStop
+    ["status"] -> Right TelegramStatus
+    ["--help"] -> Right TelegramHelp
+    ["-h"] -> Right TelegramHelp
+    ["--version"] -> Right TelegramVersion
+    "setup" : rest -> TelegramSetup <$> parseSetupOptions rest
+    _ -> Left telegramUsage
+
+parseSetupOptions :: [String] -> Either String TelegramSetupOptions
+parseSetupOptions = go defaultTelegramSetupOptions
+  where
+    go options = \case
+        [] -> Right options
+        "--provider" : value : rest ->
+            case parseProvider (Text.pack value) of
+                Nothing -> Left ("unknown provider: " <> value)
+                Just provider -> go options { setupProvider = Just provider } rest
+        "--model" : value : rest ->
+            go options { setupModel = Just (Text.pack value) } rest
+        "--cwd" : value : rest ->
+            go options { setupCwd = Just value } rest
+        "--effort" : value : rest ->
+            go options { setupEffort = Just (Text.pack value) } rest
+        "--allowed-user" : value : rest ->
+            case readMaybe value of
+                Just userId | userId > 0 ->
+                    go options { setupAllowedUser = Just userId } rest
+                _ -> Left ("invalid Telegram user ID: " <> value)
+        "--yolo" : rest -> go options { setupYolo = True } rest
+        "--start" : rest -> go options { setupStart = True } rest
+        flag : _ -> Left ("unknown setup option: " <> flag <> "\n\n" <> telegramUsage)
+
+executeTelegramCommand :: TelegramCommand -> IO ()
+executeTelegramCommand = \case
+    TelegramSetup options -> setupTelegram options
+    TelegramRun -> runConfiguredTelegram
+    TelegramStart -> startTelegram
+    TelegramStop -> stopTelegram
+    TelegramStatus -> do
+        running <- telegramIsRunning
+        Text.putStrLn (if running then "agent-telegram is running" else "agent-telegram is stopped")
+    TelegramHelp -> putStrLn telegramUsage
+    TelegramVersion -> putStrLn "agent-telegram 0.1.0.0"
+
+telegramUsage :: String
+telegramUsage = unlines
+    [ "Usage: agent-telegram setup [OPTIONS]"
+    , "       agent-telegram run"
+    , "       agent-telegram start"
+    , "       agent-telegram stop"
+    , "       agent-telegram status"
+    , ""
+    , "Setup options:"
+    , "  --provider NAME       openai, xai, or openrouter"
+    , "  --model NAME          optional model override"
+    , "  --cwd PATH            agent working directory"
+    , "  --effort LEVEL        optional reasoning effort"
+    , "  --allowed-user ID     numeric Telegram user ID"
+    , "  --yolo                allow mutating agent tools"
+    , "  --start               start the gateway after setup"
+    ]
+
+gatewayDirectory :: OsPath -> OsPath
+gatewayDirectory home =
+    home
+        </> unsafeEncodeUtf ".haskell-agent"
+        </> unsafeEncodeUtf "gateways"
+        </> unsafeEncodeUtf "telegram"
+
+configPath, tokenPath, statePathFor, pidPath, logPath, lockPath :: OsPath -> OsPath
+configPath home = gatewayDirectory home </> unsafeEncodeUtf "config.json"
+tokenPath home = gatewayDirectory home </> unsafeEncodeUtf "token"
+statePathFor home = gatewayDirectory home </> unsafeEncodeUtf "state.json"
+pidPath home = gatewayDirectory home </> unsafeEncodeUtf "agent-telegram.pid"
+logPath home = gatewayDirectory home </> unsafeEncodeUtf "agent-telegram.log"
+lockPath home = gatewayDirectory home </> unsafeEncodeUtf "agent-telegram.lock"
+
+setupTelegram :: TelegramSetupOptions -> IO ()
+setupTelegram options = do
+    home <- getHomeDirectory
+    provider <- maybe promptProvider pure options.setupProvider
+    cwd <- case options.setupCwd of
+        Nothing -> unsafeToFilePath <$> getCurrentDirectory
+        Just value -> unsafeToFilePath <$> makeAbsolute (unsafeEncodeUtf value)
+    allowedUser <- maybe promptAllowedUser pure options.setupAllowedUser
+    token <- readSecretLine "BotFather token: " >>= maybe
+        (die "a Telegram bot token is required")
+        pure
+    manager <- HttpTls.newTlsManager
+    let client = TelegramClient token manager
+    telegramRequest client "getMe" (object []) 15 >>= \case
+        Left err -> die (Text.unpack err)
+        Right response -> case decodeTelegramResponse response :: Either Text Value of
+            Left err -> die (Text.unpack err)
+            Right _ -> pure ()
+    let directory = gatewayDirectory home
+        config = TelegramConfig
+            { telegramProvider = provider
+            , telegramModel = options.setupModel
+            , telegramCwd = cwd
+            , telegramEffort = options.setupEffort
+            , telegramYolo = options.setupYolo
+            , telegramAllowedUsers = Set.singleton allowedUser
+            }
+    createDirectoryIfMissing True directory
+    setFileMode (unsafeToFilePath directory) 0o700
+    writeLazyFileAtomically (configPath home) 0o600 (encode config)
+    writeLazyFileAtomically (tokenPath home) 0o600
+        (LBS.fromStrict (TextEncoding.encodeUtf8 token))
+    Text.putStrLn "Telegram gateway configured."
+    when options.setupStart startTelegram
+
+promptProvider :: IO Provider
+promptProvider = do
+    Text.hPutStr stderr "Provider [openai]: "
+    hFlush stderr
+    value <- Text.strip <$> Text.getLine
+    let selected = if Text.null value then "openai" else value
+    maybe (die ("unknown provider: " <> Text.unpack selected)) pure
+        (parseProvider selected)
+
+promptAllowedUser :: IO Integer
+promptAllowedUser = do
+    Text.hPutStr stderr "Allowed Telegram user ID: "
+    hFlush stderr
+    Text.getLine >>= \value -> case readMaybe (Text.unpack (Text.strip value)) of
+        Just userId | userId > 0 -> pure userId
+        _ -> die "Telegram user ID must be a positive integer"
+
+readSecretLine :: Text -> IO (Maybe Text)
+readSecretLine prompt = do
+    tty <- hIsTerminalDevice stdin
+    unless tty $
+        die "Telegram setup requires an interactive terminal for secret entry."
+    Text.hPutStr stderr prompt
+    hFlush stderr
+    oldEcho <- hGetEcho stdin
+    value <- bracket
+        (hSetEcho stdin False)
+        (const (hSetEcho stdin oldEcho))
+        (const Text.getLine)
+        <* Text.hPutStrLn stderr ""
+    pure case Text.strip value of
+        "" -> Nothing
+        token -> Just token
+
+loadTelegramConfig :: OsPath -> IO TelegramConfig
+loadTelegramConfig home =
+    eitherDecode <$> LBS.readFile (unsafeToFilePath (configPath home)) >>= \case
+        Left err -> die ("could not decode Telegram config: " <> err)
+        Right config -> pure config
+
+loadTelegramToken :: OsPath -> IO Text
+loadTelegramToken home =
+    lookupEnv "TELEGRAM_BOT_TOKEN" >>= \case
+        Just value | not (null value) -> pure (Text.pack value)
+        _ -> Text.strip . TextEncoding.decodeUtf8 . LBS.toStrict
+            <$> LBS.readFile (unsafeToFilePath (tokenPath home))
+
+runConfiguredTelegram :: IO ()
+runConfiguredTelegram = do
+    home <- getHomeDirectory
+    configExists <- doesFileExist (configPath home)
+    unless configExists $
+        die "Telegram is not configured. Run `agent-telegram setup` first."
+    config <- loadTelegramConfig home
+    token <- loadTelegramToken home
+    FileLock.tryLockFile
+        (unsafeToFilePath (lockPath home))
+        FileLock.Exclusive >>= \case
+            Nothing -> die "agent-telegram is already running"
+            Just lock -> bracket
+                (pure lock)
+                FileLock.unlockFile
+                \_ -> do
+                    pid <- getProcessID
+                    writeLazyFileAtomically (pidPath home) 0o600
+                        (LBS.fromStrict
+                            (TextEncoding.encodeUtf8 (Text.pack (show pid))))
+                    runTelegram config token `finally` removePidFile home pid
+
+runTelegram :: TelegramConfig -> Text -> IO ()
+runTelegram config token = do
+    home <- getHomeDirectory
+    cwd <- makeAbsolute (unsafeEncodeUtf config.telegramCwd)
+    let provider = config.telegramProvider
+        model = fromMaybe (defaultModelFor provider) config.telegramModel
+        effort = fromMaybe (defaultEffortFor provider) config.telegramEffort
+        root = sessionsRoot home
+        gatewayDir = gatewayDirectory home
+        statePath = statePathFor home
+        policy
+            | config.telegramYolo = ApproveAll
+            | otherwise = DenyMutating
+    target <- resolveModelOptionDialect ModelOption
+        { modelProvider = provider
+        , modelId = model
+        , modelTransportId = model
+        , modelDialect = dialectIdForModel provider model
+        , modelLabel = Nothing
+        }
+    createDirectoryIfMissing True gatewayDir
+    setFileMode (unsafeToFilePath gatewayDir) 0o700
+    state <- loadTelegramState statePath
+    stateVar <- newMVar state
+    activeChats <- newTVarIO Set.empty
+    manager <- HttpTls.newTlsManager
+    processManager <- newSessionProcessManager root
+    let client = TelegramClient token manager
+        runtime = TelegramRuntime
+            { runtimeClient = client
+            , runtimeAllowedUsers = config.telegramAllowedUsers
+            , runtimeSessionsRoot = root
+            , runtimeStatePath = statePath
+            , runtimeStateVar = stateVar
+            , runtimeActiveChats = activeChats
+            , runtimeProcessManager = processManager
+            , runtimeProvider = provider
+            , runtimeModel = model
+            , runtimeTransportModel = target.modelTransportId
+            , runtimeDialect = target.modelDialect
+            , runtimeCwd = cwd
+            , runtimeEffort = effort
+            , runtimePolicy = policy
+            }
+    Text.putStrLn "Telegram gateway started (private chats only)."
+    race_ (pollForever runtime) (dispatchForever runtime)
+        `finally` closeSessionProcessManager processManager
+
+removePidFile :: OsPath -> ProcessID -> IO ()
+removePidFile home expected = do
+    current <- loadPid home
+    when (current == Just expected) do
+        _ <- try @_ @SomeException (removeFile (pidPath home))
+        pure ()
+
+startTelegram :: IO ()
+startTelegram = do
+    running <- telegramIsRunning
+    when running (die "agent-telegram is already running")
+    home <- getHomeDirectory
+    configured <- doesFileExist (configPath home)
+    unless configured (die "Telegram is not configured. Run `agent-telegram setup` first.")
+    createDirectoryIfMissing True (gatewayDirectory home)
+    executable <- getExecutablePath
+    withFile (unsafeToFilePath (logPath home)) AppendMode \logHandle -> do
+        (_, _, _, process) <- createProcess (proc executable ["run"])
+            { std_in = NoStream
+            , std_out = UseHandle logHandle
+            , std_err = UseHandle logHandle
+            , create_group = True
+            }
+        waitForGatewayStart home process 100
+    Text.putStrLn "agent-telegram started"
+
+waitForGatewayStart :: OsPath -> ProcessHandle -> Int -> IO ()
+waitForGatewayStart _ process 0 = do
+    exitCode <- getProcessExitCode process
+    die ("agent-telegram did not start" <> maybe "" ((": " <>) . show) exitCode)
+waitForGatewayStart home process attempts = do
+    running <- telegramIsRunning
+    if running
+        then pure ()
+        else getProcessExitCode process >>= \case
+            Just exitCode -> die ("agent-telegram exited during startup: " <> show exitCode)
+            Nothing -> threadDelay 50_000 >> waitForGatewayStart home process (attempts - 1)
+
+stopTelegram :: IO ()
+stopTelegram = do
+    home <- getHomeDirectory
+    loadPid home >>= \case
+        Nothing -> Text.putStrLn "agent-telegram is not running"
+        Just pid -> do
+            alive <- processIsAlive pid
+            if alive
+                then signalProcess sigTERM pid >> Text.putStrLn "agent-telegram stopped"
+                else Text.putStrLn "agent-telegram is not running"
+            _ <- try @_ @SomeException (removeFile (pidPath home))
+            pure ()
+
+telegramIsRunning :: IO Bool
+telegramIsRunning = do
+    home <- getHomeDirectory
+    createDirectoryIfMissing True (gatewayDirectory home)
+    FileLock.tryLockFile
+        (unsafeToFilePath (lockPath home))
+        FileLock.Exclusive >>= \case
+            Nothing -> pure True
+            Just lock -> FileLock.unlockFile lock >> pure False
+
+loadPid :: OsPath -> IO (Maybe ProcessID)
+loadPid home = do
+    exists <- doesFileExist (pidPath home)
+    if not exists
+        then pure Nothing
+        else readMaybe . Text.unpack . Text.strip . TextEncoding.decodeUtf8 . LBS.toStrict
+            <$> LBS.readFile (unsafeToFilePath (pidPath home))
+
+processIsAlive :: ProcessID -> IO Bool
+processIsAlive pid =
+    try @_ @SomeException (signalProcess nullSignal pid) >>= \case
+        Left _ -> pure False
+        Right () -> pure True
+
+data TelegramRuntime = TelegramRuntime
+    { runtimeClient :: !TelegramClient
+    , runtimeAllowedUsers :: !(Set Integer)
+    , runtimeSessionsRoot :: !OsPath
+    , runtimeStatePath :: !OsPath
+    , runtimeStateVar :: !(MVar TelegramState)
+    , runtimeActiveChats :: !(TVar (Set TelegramChatKey))
+    , runtimeProcessManager :: !SessionProcessManager
+    , runtimeProvider :: !Provider
+    , runtimeModel :: !Text
+    , runtimeTransportModel :: !Text
+    , runtimeDialect :: !DialectId
+    , runtimeCwd :: !OsPath
+    , runtimeEffort :: !Text
+    , runtimePolicy :: !ApprovalPolicy
+    }
+
+pollForever :: TelegramRuntime -> IO ()
+pollForever runtime = do
+    state <- readMVar runtime.runtimeStateVar
+    getUpdates runtime.runtimeClient state.nextUpdateId >>= \case
+        Left err -> do
+            Text.hPutStrLn stderr err
+            threadDelay 2_000_000
+        Right updates ->
+            forM_ updates (processUpdate runtime)
+    pollForever runtime
+
+processUpdate :: TelegramRuntime -> TelegramUpdate -> IO ()
+processUpdate runtime update = do
+    handled <- tryAny do
+        action <- classifyUpdate runtime update
+        modifyState runtime (storeUpdateAction update.updateId action)
+    case handled of
+        Left err ->
+            Text.hPutStrLn stderr
+                ("Telegram update could not be persisted and will be retried: "
+                    <> redactToken runtime.runtimeClient.clientToken
+                        (Text.pack (displayException err)))
+        Right () -> pure ()
+
+data TelegramUpdateAction
+    = IgnoreUpdate
+    | QueueTurn !Integer !TelegramChatKey !Text
+    deriving (Eq, Show)
+
+storeUpdateAction
+    :: Integer
+    -> TelegramUpdateAction
+    -> TelegramState
+    -> TelegramState
+storeUpdateAction updateId action current
+    | updateAlreadyStored updateId current =
+        advanceOffset current
+    | otherwise =
+        advanceOffset case action of
+            IgnoreUpdate -> current
+            QueueTurn messageId key text ->
+                current
+                    { pendingTurns =
+                        current.pendingTurns
+                            <> [TelegramPendingTurn updateId messageId key text]
+                    }
+  where
+    advanceOffset state =
+        state
+            { nextUpdateId =
+                Just (max (updateId + 1)
+                    (fromMaybe 0 state.nextUpdateId))
+            }
+
+classifyUpdate
+    :: TelegramRuntime
+    -> TelegramUpdate
+    -> IO TelegramUpdateAction
+classifyUpdate runtime update =
+    case update.updateMessage of
+        Just message
+            | message.messageChat.telegramChatType == "private"
+            , Just sender <- message.messageFrom
+            , sender.userId `Set.member` runtime.runtimeAllowedUsers
+            , Just rawText <- message.messageText
+            , not (Text.null (Text.strip rawText)) ->
+                pure (QueueTurn
+                    message.messageId
+                    key
+                    (Text.strip rawText))
+          where
+            key = TelegramChatKey
+                { chatId = message.messageChat.telegramChatId
+                , messageThreadId = message.messageThread
+                }
+        _ -> pure IgnoreUpdate
+
+updateAlreadyStored :: Integer -> TelegramState -> Bool
+updateAlreadyStored updateId state =
+    any ((== updateId) . (.pendingTurnUpdateId)) state.pendingTurns
+        || any ((== updateId) . (.pendingUpdateId)) state.pendingReplies
+        || maybe False (> updateId) state.nextUpdateId
+
+data PendingChatAction
+    = DeliverReply !TelegramPendingReply
+    | RunPendingTurn !TelegramPendingTurn
+    deriving (Eq, Show)
+
+dispatchForever :: TelegramRuntime -> IO ()
+dispatchForever runtime = do
+    state <- readMVar runtime.runtimeStateVar
+    active <- atomically (readTVar runtime.runtimeActiveChats)
+    let pendingChats = Set.fromList
+            (map (.pendingTurnChat) state.pendingTurns
+                <> map (.pendingChat) state.pendingReplies)
+    forM_ (Set.toList (pendingChats `Set.difference` active)) \key -> do
+        claimed <- atomically do
+            current <- readTVar runtime.runtimeActiveChats
+            if key `Set.member` current
+                then pure False
+                else do
+                    modifyTVar' runtime.runtimeActiveChats (Set.insert key)
+                    pure True
+        if claimed
+            then void $ async $
+                processChatQueue runtime key `finally`
+                    atomically
+                        (modifyTVar' runtime.runtimeActiveChats (Set.delete key))
+            else pure ()
+    threadDelay 250_000
+    dispatchForever runtime
+
+processChatQueue :: TelegramRuntime -> TelegramChatKey -> IO ()
+processChatQueue runtime key =
+    nextChatAction runtime key >>= \case
+        Nothing -> pure ()
+        Just action -> do
+            result <- tryAny case action of
+                DeliverReply pending -> do
+                    reply runtime pending.pendingChat pending.pendingText
+                    modifyState runtime \state ->
+                        state
+                            { pendingReplies =
+                                filter
+                                    ((/= pending.pendingUpdateId)
+                                        . (.pendingUpdateId))
+                                    state.pendingReplies
+                            }
+                RunPendingTurn pending -> do
+                    response <- runQueuedTurn runtime pending
+                    modifyState runtime \state ->
+                        state
+                            { pendingTurns =
+                                filter
+                                    ((/= pending.pendingTurnUpdateId)
+                                        . (.pendingTurnUpdateId))
+                                    state.pendingTurns
+                            , pendingReplies =
+                                state.pendingReplies
+                                    <> [ TelegramPendingReply
+                                            pending.pendingTurnUpdateId
+                                            pending.pendingTurnChat
+                                            response
+                                       ]
+                            }
+            case result of
+                Left err -> do
+                    Text.hPutStrLn stderr
+                        ("Telegram conversation worker failed and will retry: "
+                            <> redactToken runtime.runtimeClient.clientToken
+                                (Text.pack (displayException err)))
+                    threadDelay 2_000_000
+                Right () -> processChatQueue runtime key
+
+runQueuedTurn :: TelegramRuntime -> TelegramPendingTurn -> IO Text
+runQueuedTurn runtime pending =
+    case telegramCommand pending.pendingTurnText of
+        Just "start" -> pure
+            "Send a message to start or continue an agent session. \
+            \Use /new for a fresh session and /session for its ID."
+        Just "new" -> do
+            modifyState runtime \state ->
+                state
+                    { bindings =
+                        filter
+                            ((/= pending.pendingTurnChat) . (.bindingChat))
+                            state.bindings
+                    }
+            pure "Started a new conversation. Send your next prompt."
+        Just "session" -> do
+            state <- readMVar runtime.runtimeStateVar
+            pure case lookupBinding pending.pendingTurnChat state of
+                Nothing -> "No session yet. Send a prompt to create one."
+                Just sessionId -> "Session: " <> sessionId
+        Just command -> pure ("Unknown command: /" <> command)
+        Nothing -> runAgentTurn
+            runtime
+            pending.pendingTurnChat
+            pending.pendingTurnText
+
+nextChatAction
+    :: TelegramRuntime
+    -> TelegramChatKey
+    -> IO (Maybe PendingChatAction)
+nextChatAction runtime key = do
+    state <- readMVar runtime.runtimeStateVar
+    pure (nextPendingAction key state)
+
+nextPendingAction
+    :: TelegramChatKey
+    -> TelegramState
+    -> Maybe PendingChatAction
+nextPendingAction key state =
+    case
+        ( oldestBy (.pendingTurnUpdateId)
+            (filter ((== key) . (.pendingTurnChat)) state.pendingTurns)
+        , oldestBy (.pendingUpdateId)
+            (filter ((== key) . (.pendingChat)) state.pendingReplies)
+        ) of
+        (Nothing, Nothing) -> Nothing
+        (Just turn, Nothing) -> Just (RunPendingTurn turn)
+        (Nothing, Just pending) -> Just (DeliverReply pending)
+        (Just turn, Just pending)
+            | pending.pendingUpdateId <= turn.pendingTurnUpdateId ->
+                Just (DeliverReply pending)
+            | otherwise -> Just (RunPendingTurn turn)
+
+oldestBy :: Ord b => (a -> b) -> [a] -> Maybe a
+oldestBy _ [] = Nothing
+oldestBy getKey (value : values) =
+    Just (foldl choose value values)
+  where
+    choose current candidate
+        | getKey candidate < getKey current = candidate
+        | otherwise = current
+
+telegramCommand :: Text -> Maybe Text
+telegramCommand text = do
+    firstWord <- case Text.words text of
+        [] -> Nothing
+        value : _ -> Just value
+    withoutSlash <- Text.stripPrefix "/" firstWord
+    pure (Text.toLower (Text.takeWhile (/= '@') withoutSlash))
+
+runAgentTurn :: TelegramRuntime -> TelegramChatKey -> Text -> IO Text
+runAgentTurn runtime key prompt = do
+    handle <- sessionForPrompt runtime key prompt
+    priorTurnCount <- loadSessionHandle
+        runtime.runtimeSessionsRoot
+        handle.sessionMeta.metaId >>= \case
+            Left err -> fail (Text.unpack err)
+            Right (_, turns) -> pure (length turns)
+    launchSessionTurn
+        runtime.runtimeProcessManager
+        False
+        runtime.runtimePolicy
+        handle
+        prompt >>= \case
+            Left err -> fail (Text.unpack err)
+            Right _ ->
+                loadSessionHandle
+                    runtime.runtimeSessionsRoot
+                    handle.sessionMeta.metaId >>= \case
+                        Left err -> fail (Text.unpack err)
+                        Right (_, turns)
+                            | length turns > priorTurnCount
+                            , latestTurnMatches prompt turns ->
+                                pure (renderLatestTurn turns)
+                            | otherwise ->
+                                fail
+                                    "agent completed without recording \
+                                    \the Telegram turn"
+
+latestTurnMatches :: Text -> [SessionTurn] -> Bool
+latestTurnMatches prompt turns = case reverse turns of
+    turn : _ -> turn.turnUserText == prompt
+    [] -> False
+
+sessionForPrompt
+    :: TelegramRuntime
+    -> TelegramChatKey
+    -> Text
+    -> IO SessionHandle
+sessionForPrompt runtime key prompt = do
+    state <- readMVar runtime.runtimeStateVar
+    existing <- case lookupBinding key state of
+        Nothing -> pure Nothing
+        Just sessionId ->
+            loadSessionHandle runtime.runtimeSessionsRoot sessionId >>= \case
+                Left _ -> pure Nothing
+                Right (handle, _) -> pure (Just handle)
+    case existing of
+        Just handle -> pure handle
+        Nothing -> do
+            handle <- createSession SessionCreate
+                { createRoot = runtime.runtimeSessionsRoot
+                , createProvider = runtime.runtimeProvider
+                , createModel = runtime.runtimeModel
+                , createTransportModel = runtime.runtimeTransportModel
+                , createDialect = runtime.runtimeDialect
+                , createCwd = runtime.runtimeCwd
+                , createEffort = runtime.runtimeEffort
+                , createTitleHint = Just (sessionTitleFromPrompt prompt)
+                , createTitleIsManual = False
+                }
+            modifyState runtime \current ->
+                current
+                    { bindings =
+                        TelegramBinding key handle.sessionMeta.metaId
+                            : filter ((/= key) . (.bindingChat)) current.bindings
+                    }
+            pure handle
+
+renderLatestTurn :: [SessionTurn] -> Text
+renderLatestTurn turns =
+    case reverse turns of
+        [] -> "The agent completed without recording a response."
+        turn : _ -> fromMaybe
+            (fromMaybe "The agent completed without a text response." turn.turnError)
+            turn.turnAssistantText
+
+lookupBinding :: TelegramChatKey -> TelegramState -> Maybe Text
+lookupBinding key state =
+    (.bindingSessionId) <$> find ((== key) . (.bindingChat)) state.bindings
+
+modifyState :: TelegramRuntime -> (TelegramState -> TelegramState) -> IO ()
+modifyState runtime update =
+    modifyMVar runtime.runtimeStateVar \current -> do
+        let next = update current
+        saveTelegramState runtime.runtimeStatePath next
+        pure (next, ())
+
+reply :: TelegramRuntime -> TelegramChatKey -> Text -> IO ()
+reply runtime key text = do
+    -- Telegram counts astral Unicode characters as two UTF-16 code units.
+    -- A 2000-code-point chunk therefore remains below sendMessage's limit.
+    let chunks = case splitTelegramText 2000 text of
+            [] -> ["(empty response)"]
+            values -> values
+    forM_ chunks \chunk ->
+        sendMessage runtime.runtimeClient key chunk >>= \case
+            Left err -> fail (Text.unpack err)
+            Right () -> pure ()
+
+getUpdates
+    :: TelegramClient
+    -> Maybe Integer
+    -> IO (Either Text [TelegramUpdate])
+getUpdates client offset =
+    telegramRequest client "getUpdates" body 45 >>= \case
+        Left err -> pure (Left err)
+        Right response -> pure (decodeTelegramResponse response)
+  where
+    body = object $
+        [ "timeout" .= (30 :: Int)
+        , "allowed_updates" .= (["message"] :: [Text])
+        ]
+            <> maybe [] (\value -> ["offset" .= value]) offset
+
+sendMessage
+    :: TelegramClient
+    -> TelegramChatKey
+    -> Text
+    -> IO (Either Text ())
+sendMessage client key text =
+    telegramRequest client "sendMessage" body 30 >>= \case
+        Left err -> pure (Left err)
+        Right response ->
+            pure (() <$ (decodeTelegramResponse response :: Either Text Value))
+  where
+    body = object $
+        [ "chat_id" .= key.chatId
+        , "text" .= text
+        ]
+            <> maybe []
+                (\threadId -> ["message_thread_id" .= threadId])
+                key.messageThreadId
+
+telegramRequest
+    :: TelegramClient
+    -> String
+    -> Value
+    -> Int
+    -> IO (Either Text LBS.ByteString)
+telegramRequest client method body timeoutSeconds =
+    tryAny request >>= \case
+        Left err ->
+            pure $ Left $
+                "Telegram request failed: "
+                    <> redactToken client.clientToken
+                        (Text.pack (displayException err))
+        Right response -> pure (Right (Http.responseBody response))
+  where
+    request = do
+        base <- Http.parseRequest $
+            "https://api.telegram.org/bot"
+                <> Text.unpack client.clientToken
+                <> "/"
+                <> method
+        let configured = base
+                { Http.method = "POST"
+                , Http.requestHeaders =
+                    [("Content-Type", "application/json")]
+                , Http.requestBody = Http.RequestBodyLBS (encode body)
+                , Http.responseTimeout =
+                    Http.responseTimeoutMicro
+                        (timeoutSeconds * 1_000_000)
+                }
+        Http.httpLbs configured client.clientManager
+
+decodeTelegramResponse
+    :: forall a. FromJSON a
+    => LBS.ByteString
+    -> Either Text a
+decodeTelegramResponse bytes = do
+    envelope <- case
+            eitherDecode bytes
+                :: Either String (TelegramResponse a)
+        of
+        Left err -> Left ("Telegram returned invalid JSON: " <> Text.pack err)
+        Right value -> Right value
+    if envelope.responseOk
+        then maybe
+            (Left "Telegram response did not contain a result")
+            Right
+            envelope.responseResult
+        else Left $
+            "Telegram API error: "
+                <> fromMaybe "unknown error" envelope.responseDescription
+
+loadTelegramState :: OsPath -> IO TelegramState
+loadTelegramState path = do
+    exists <- doesFileExist path
+    if not exists
+        then pure emptyTelegramState
+        else eitherDecode <$> LBS.readFile (unsafeToFilePath path) >>= \case
+            Left err -> fail ("could not decode Telegram state: " <> err)
+            Right state -> pure state
+
+saveTelegramState :: OsPath -> TelegramState -> IO ()
+saveTelegramState path state =
+    writeLazyFileAtomically path 0o600 (encode state)
+
+redactToken :: Text -> Text -> Text
+redactToken token = Text.replace token "<redacted>"

--- a/packages/agent-cli/test/Agent/CLI/AgentSessionsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/AgentSessionsSpec.hs
@@ -218,6 +218,35 @@ spec = describe "Agent.CLI.AgentSessions" do
                     `shouldReturn` Left "could not acquire lock"
                 closeSessionProcessManager manager
 
+    it "does not expose gateway credentials to managed agent children" $
+        withTempDir "agent-session-runtime-" \root -> do
+            let marker = toFilePath root FilePath.</> "leaked"
+            script <- writeFakeAgentBody root
+                ("if [ -n \"$TELEGRAM_BOT_TOKEN\" ] \
+                \|| [ -n \"$TELEGRAM_ALLOWED_USERS\" ]; then \
+                \printf leaked > " <> shellQuote marker <> "; fi\n")
+            withExecutableOverride script $
+                bracket
+                    (do
+                        oldToken <- lookupEnv "TELEGRAM_BOT_TOKEN"
+                        oldUsers <- lookupEnv "TELEGRAM_ALLOWED_USERS"
+                        setEnv "TELEGRAM_BOT_TOKEN" "secret"
+                        setEnv "TELEGRAM_ALLOWED_USERS" "123"
+                        pure (oldToken, oldUsers))
+                    (\(oldToken, oldUsers) -> do
+                        restoreEnv "TELEGRAM_BOT_TOKEN" oldToken
+                        restoreEnv "TELEGRAM_ALLOWED_USERS" oldUsers)
+                    \_ -> do
+                        handle <- createSession (testCreateAt root root)
+                        manager <- newSessionProcessManager root
+                        launchSessionTurn manager False ApproveAll handle "one"
+                            `shouldReturn`
+                                Right
+                                    ("completed session "
+                                        <> handle.sessionMeta.metaId)
+                        Directory.doesFileExist marker `shouldReturn` False
+                        closeSessionProcessManager manager
+
     it "does not terminate background sessions when the manager closes" $
         withTempDir "agent-session-runtime-" \root -> do
             let marker = toFilePath root FilePath.</> "finished"
@@ -345,6 +374,11 @@ withExecutableOverride executable action =
             Nothing -> unsetEnv "HASKELL_AGENT_EXECUTABLE"
             Just value -> setEnv "HASKELL_AGENT_EXECUTABLE" value)
         (const action)
+
+restoreEnv :: String -> Maybe String -> IO ()
+restoreEnv name = \case
+    Nothing -> unsetEnv name
+    Just value -> setEnv name value
 
 fixedTime :: UTCTime
 fixedTime = UTCTime (fromGregorian 2026 8 21) (secondsToDiffTime 0)

--- a/packages/agent-cli/test/Agent/CLI/SessionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SessionSpec.hs
@@ -141,6 +141,12 @@ spec = describe "Agent.CLI.Session" do
                 listed <- listSessions root
                 map (.metaId) listed `shouldBe` [handle.sessionMeta.metaId]
 
+                loadSessionHandle root handle.sessionMeta.metaId >>= \case
+                    Left err -> expectationFailure (Text.unpack err)
+                    Right (loadedHandle, _) ->
+                        loadedHandle.sessionTempDir
+                            `shouldBe` handle.sessionTempDir
+
         it "combines append metadata and a caller transition in one result" $
             withTempDir "agent-sessions-" \root -> do
                 handle <- createSession (testCreate root)

--- a/packages/agent-cli/test/Agent/CLI/SkillsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SkillsSpec.hs
@@ -22,6 +22,16 @@ spec = describe "Agent.CLI.Skills" do
             False
         catalog `shouldBe` SkillCatalog [] []
 
+    it "loads the packaged Telegram setup skill" do
+        catalog <- loadSkillsCatalogQuiet
+            defaultCliOptions
+            (fromFilePath "/tmp")
+            (fromFilePath "/tmp")
+            (fromFilePath "/tmp")
+        catalog.catalogSkills `shouldSatisfy` any \skill ->
+            skill.skillName == "telegram-agent"
+                && skill.skillScope == BuiltinSkill
+
     it "queues skill metadata after existing startup context" do
         context <- newIORef (Just "agents")
         _ <- queueSkillCatalogContextWithOmissions

--- a/packages/agent-cli/test/Agent/TelegramSpec.hs
+++ b/packages/agent-cli/test/Agent/TelegramSpec.hs
@@ -1,0 +1,121 @@
+module Agent.TelegramSpec (spec) where
+
+import Agent.Telegram
+import Data.Aeson (eitherDecode)
+import qualified Data.ByteString.Lazy.Char8 as LBS
+import qualified Data.Set as Set
+import Agent.Provider (Provider(..))
+import Test.Hspec
+
+spec :: Spec
+spec = describe "Agent.Telegram" do
+    describe "parseTelegramArgs" do
+        it "runs the configured gateway by default" do
+            parseTelegramArgs [] `shouldBe` Right TelegramRun
+            parseTelegramArgs ["run"] `shouldBe` Right TelegramRun
+
+        it "parses non-secret setup options" do
+            parseTelegramArgs
+                [ "setup"
+                , "--provider", "xai"
+                , "--model", "grok-4.6"
+                , "--cwd", "/tmp/project"
+                , "--allowed-user", "123"
+                , "--yolo"
+                , "--start"
+                ]
+                `shouldBe` Right
+                    (TelegramSetup defaultTelegramSetupOptions
+                        { setupProvider = Just XAIProvider
+                        , setupModel = Just "grok-4.6"
+                        , setupCwd = Just "/tmp/project"
+                        , setupYolo = True
+                        , setupAllowedUser = Just 123
+                        , setupStart = True
+                        })
+
+        it "rejects tokens and malformed setup values as arguments" do
+            parseTelegramArgs ["setup", "--token", "secret"]
+                `shouldSatisfy` isLeft
+            parseTelegramArgs ["setup", "--allowed-user", "nope"]
+                `shouldSatisfy` isLeft
+
+    describe "parseAllowedUsers" do
+        it "parses and deduplicates numeric IDs" do
+            parseAllowedUsers "123, 456,123"
+                `shouldBe` Right (Set.fromList [123, 456])
+
+        it "rejects an empty allowlist and malformed IDs" do
+            parseAllowedUsers "" `shouldSatisfy` isLeft
+            parseAllowedUsers "123,nope" `shouldSatisfy` isLeft
+            parseAllowedUsers "-1" `shouldSatisfy` isLeft
+
+    describe "splitTelegramText" do
+        it "keeps messages within the requested limit" do
+            splitTelegramText 4 "abcdefghij"
+                `shouldBe` ["abcd", "efgh", "ij"]
+
+        it "does not emit an empty message" do
+            splitTelegramText 4 "" `shouldBe` []
+
+    describe "durable queue state" do
+        it "loads state written before pending turns were introduced" do
+            let decoded = eitherDecode
+                    (LBS.pack
+                        "{\"nextUpdateId\":12,\"bindings\":[],\"pendingReplies\":[]}")
+                    :: Either String TelegramState
+            decoded `shouldSatisfy` \case
+                Right state ->
+                    state.nextUpdateId == Just 12
+                        && null state.pendingTurns
+                Left _ -> False
+
+        it "persists inbound work and advances the polling offset" do
+            let key = TelegramChatKey 123 Nothing
+                state = storeUpdateAction
+                    10
+                    (QueueTurn 77 key "hello")
+                    emptyTelegramState
+            state.nextUpdateId `shouldBe` Just 11
+            state.pendingTurns `shouldBe`
+                [TelegramPendingTurn 10 77 key "hello"]
+
+        it "does not enqueue a delivered update twice" do
+            let key = TelegramChatKey 123 Nothing
+                once = storeUpdateAction
+                    10
+                    (QueueTurn 77 key "hello")
+                    emptyTelegramState
+                twice = storeUpdateAction
+                    10
+                    (QueueTurn 77 key "hello")
+                    once
+            twice.pendingTurns `shouldBe` once.pendingTurns
+
+        it "selects work in update order within a conversation" do
+            let key = TelegramChatKey 123 Nothing
+                newerTurn = TelegramPendingTurn 12 79 key "later"
+                olderTurn = TelegramPendingTurn 10 77 key "first"
+                middleReply = TelegramPendingReply 11 key "reply"
+                state = emptyTelegramState
+                    { pendingTurns = [newerTurn, olderTurn]
+                    , pendingReplies = [middleReply]
+                    }
+            nextPendingAction key state
+                `shouldBe` Just (RunPendingTurn olderTurn)
+
+        it "keeps delivery ahead of later inbound work" do
+            let key = TelegramChatKey 123 Nothing
+                turn = TelegramPendingTurn 12 79 key "later"
+                reply = TelegramPendingReply 11 key "reply"
+                state = emptyTelegramState
+                    { pendingTurns = [turn]
+                    , pendingReplies = [reply]
+                    }
+            nextPendingAction key state
+                `shouldBe` Just (DeliverReply reply)
+
+isLeft :: Either a b -> Bool
+isLeft = \case
+    Left _ -> True
+    Right _ -> False

--- a/packages/agent-cli/test/Agent/TelegramSpec.hs
+++ b/packages/agent-cli/test/Agent/TelegramSpec.hs
@@ -1,10 +1,18 @@
 module Agent.TelegramSpec (spec) where
 
 import Agent.Telegram
+import Control.Concurrent
+    ( newEmptyMVar
+    , putMVar
+    , takeMVar
+    , threadDelay
+    )
 import Data.Aeson (eitherDecode)
 import qualified Data.ByteString.Lazy.Char8 as LBS
+import Data.IORef (modifyIORef', newIORef, readIORef)
 import qualified Data.Set as Set
 import Agent.Provider (Provider(..))
+import qualified System.Timeout as Timeout
 import Test.Hspec
 
 spec :: Spec
@@ -58,6 +66,99 @@ spec = describe "Agent.Telegram" do
         it "does not emit an empty message" do
             splitTelegramText 4 "" `shouldBe` []
 
+    describe "markdownToTelegramHtml" do
+        it "renders common agent Markdown and preserves line breaks" do
+            markdownToTelegramHtml
+                "**Bold** and *italic*\n`code` ~~gone~~ [site](https://example.com)"
+                `shouldBe`
+                    "<b>Bold</b> and <i>italic</i><br>\
+                    \<code>code</code> <s>gone</s> \
+                    \<a href=\"https://example.com\">site</a>"
+
+        it "escapes literal HTML and link attributes" do
+            markdownToTelegramHtml
+                "<unsafe> & [link](https://example.com/?a=1&b=\"2\")"
+                `shouldBe`
+                    "&lt;unsafe&gt; &amp; \
+                    \<a href=\"https://example.com/?a=1&amp;b=&quot;2&quot;\">link</a>"
+
+        it "renders fenced code without interpreting its Markdown" do
+            markdownToTelegramHtml "before\n```haskell\nx < y && **raw**\n```\nafter"
+                `shouldBe`
+                    "before<br><pre>x &lt; y &amp;&amp; **raw**\n</pre><br>after"
+
+        it "leaves unmatched delimiters literal" do
+            markdownToTelegramHtml "unfinished **bold and `code"
+                `shouldBe` "unfinished **bold and `code"
+
+    describe "Telegram progress lifecycle" do
+        it "cancels and joins an in-flight indicator before returning" do
+            started <- newEmptyMVar
+            events <- newIORef ([] :: [String])
+            let record event = modifyIORef' events (<> [event])
+            withTelegramProgressUsing
+                (do
+                    record "typing-start"
+                    putMVar started ()
+                    threadDelay 10_000_000
+                    record "typing-finish")
+                (pure ())
+                (takeMVar started >> record "action-finish")
+
+            readIORef events `shouldReturn`
+                ["typing-start", "action-finish"]
+
+        it "does not swallow asynchronous cancellation" do
+            result <- Timeout.timeout 50_000 $
+                withTelegramProgressUsing
+                    (threadDelay 10_000_000)
+                    (pure ())
+                    (threadDelay 10_000_000)
+            result `shouldBe` Nothing
+
+    describe "Telegram reactions and voice" do
+        it "turns an inbound reaction into a durable agent message" do
+            let decoded = eitherDecode
+                    (LBS.pack
+                        "{\"update_id\":20,\"message_reaction\":{\
+                        \\"chat\":{\"id\":123,\"type\":\"private\"},\
+                        \\"message_id\":77,\"user\":{\"id\":456},\
+                        \\"old_reaction\":[],\
+                        \\"new_reaction\":[{\"type\":\"emoji\",\
+                        \\"emoji\":\"\\u2764\"}]}}")
+                    :: Either String TelegramUpdate
+            decoded `shouldSatisfy` \case
+                Right update -> case update.updateMessageReaction of
+                    Just reaction ->
+                        reactionMessageText reaction
+                            == "[Telegram reaction on message 77]: ❤"
+                    Nothing -> False
+                Left _ -> False
+
+        it "recognizes emoji-only assistant replies as reactions" do
+            telegramReactionEmoji " 👍 " `shouldBe` Just "👍"
+            telegramReactionEmoji "❤️" `shouldBe` Just "❤"
+            telegramReactionEmoji "Looks good 👍" `shouldBe` Nothing
+
+        it "decodes Telegram voice metadata" do
+            let decoded = eitherDecode
+                    (LBS.pack
+                        "{\"update_id\":21,\"message\":{\
+                        \\"message_id\":78,\"from\":{\"id\":456},\
+                        \\"chat\":{\"id\":123,\"type\":\"private\"},\
+                        \\"voice\":{\"file_id\":\"voice-file\",\"duration\":4,\
+                        \\"mime_type\":\"audio/ogg\",\"file_size\":1024}}}")
+                    :: Either String TelegramUpdate
+            decoded `shouldSatisfy` \case
+                Right update -> case update.updateMessage >>= (.messageVoice) of
+                    Just voice ->
+                        voice.voiceFileId == "voice-file"
+                            && voice.voiceDuration == 4
+                            && voice.voiceMimeType == Just "audio/ogg"
+                            && voice.voiceFileSize == Just 1024
+                    Nothing -> False
+                Left _ -> False
+
     describe "durable queue state" do
         it "loads state written before pending turns were introduced" do
             let decoded = eitherDecode
@@ -74,29 +175,48 @@ spec = describe "Agent.Telegram" do
             let key = TelegramChatKey 123 Nothing
                 state = storeUpdateAction
                     10
-                    (QueueTurn 77 key "hello")
+                    (QueueTurn 77 key "hello" Nothing)
                     emptyTelegramState
             state.nextUpdateId `shouldBe` Just 11
             state.pendingTurns `shouldBe`
-                [TelegramPendingTurn 10 77 key "hello"]
+                [TelegramPendingTurn 10 77 key "hello" Nothing]
 
         it "does not enqueue a delivered update twice" do
             let key = TelegramChatKey 123 Nothing
                 once = storeUpdateAction
                     10
-                    (QueueTurn 77 key "hello")
+                    (QueueTurn 77 key "hello" Nothing)
                     emptyTelegramState
                 twice = storeUpdateAction
                     10
-                    (QueueTurn 77 key "hello")
+                    (QueueTurn 77 key "hello" Nothing)
                     once
             twice.pendingTurns `shouldBe` once.pendingTurns
 
+        it "checkpoints a voice transcript before running the agent" do
+            let key = TelegramChatKey 123 Nothing
+                voice = TelegramVoice "voice-file" 4 (Just "audio/ogg")
+                    (Just 1024)
+                pending = TelegramPendingTurn
+                    10 77 key "[Voice message]" (Just voice)
+                state = checkpointPendingVoiceTranscript
+                    10
+                    "[Voice message transcript]: hello"
+                    emptyTelegramState { pendingTurns = [pending] }
+            state.pendingTurns `shouldBe`
+                [ TelegramPendingTurn
+                    10
+                    77
+                    key
+                    "[Voice message transcript]: hello"
+                    Nothing
+                ]
+
         it "selects work in update order within a conversation" do
             let key = TelegramChatKey 123 Nothing
-                newerTurn = TelegramPendingTurn 12 79 key "later"
-                olderTurn = TelegramPendingTurn 10 77 key "first"
-                middleReply = TelegramPendingReply 11 key "reply"
+                newerTurn = TelegramPendingTurn 12 79 key "later" Nothing
+                olderTurn = TelegramPendingTurn 10 77 key "first" Nothing
+                middleReply = TelegramPendingReply 11 key (Just 77) "reply"
                 state = emptyTelegramState
                     { pendingTurns = [newerTurn, olderTurn]
                     , pendingReplies = [middleReply]
@@ -106,8 +226,8 @@ spec = describe "Agent.Telegram" do
 
         it "keeps delivery ahead of later inbound work" do
             let key = TelegramChatKey 123 Nothing
-                turn = TelegramPendingTurn 12 79 key "later"
-                reply = TelegramPendingReply 11 key "reply"
+                turn = TelegramPendingTurn 12 79 key "later" Nothing
+                reply = TelegramPendingReply 11 key (Just 77) "reply"
                 state = emptyTelegramState
                     { pendingTurns = [turn]
                     , pendingReplies = [reply]

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -47,6 +47,7 @@ import qualified Agent.CLI.StyleSpec as StyleSpec
 import qualified Agent.CLI.TimestampSpec as TimestampSpec
 import qualified Agent.CLI.TurnSpec as TurnSpec
 import qualified Agent.CLI.TerminalSpec as TerminalSpec
+import qualified Agent.TelegramSpec as TelegramSpec
 import qualified Agent.CLI.TextLayoutSpec as TextLayoutSpec
 import qualified Agent.CLI.ToolsSpec as ToolsSpec
 import qualified Agent.CLI.TUIAppSpec as TUIAppSpec
@@ -100,6 +101,7 @@ main = hspec do
     TimestampSpec.spec
     TurnSpec.spec
     TerminalSpec.spec
+    TelegramSpec.spec
     TextLayoutSpec.spec
     SessionSpec.spec
     SessionTitleSpec.spec

--- a/packages/agent-core/src/Agent/Skills.hs
+++ b/packages/agent-core/src/Agent/Skills.hs
@@ -9,6 +9,7 @@ module Agent.Skills
     , SkillWarning(..)
     , defaultSkillCatalogMaxChars
     , discoverSkills
+    , loadSkillFile
     , buildSkillInvocations
     , modelVisibleSkills
     , formatSkillCatalogContext
@@ -67,7 +68,8 @@ data SkillOrigin
     deriving (Eq, Ord, Show)
 
 data SkillScope
-    = UserSkill
+    = BuiltinSkill
+    | UserSkill
     | RepositorySkill
         { skillDepth :: !Int
         , skillAtCwd :: !Bool
@@ -207,7 +209,7 @@ discoverSkills options = do
         if exists
             then do
                 files <- findSkillFiles options.skillsMaxDepth root
-                forM files (loadSkill scope origin)
+                forM files (loadSkillFile scope origin)
             else pure []
     let skills = [skill | Right skill <- results]
         warnings = [warning | Left warning <- results]
@@ -273,12 +275,12 @@ findSkillFiles maxDepth root = go Set.empty 0 root
                                     traverse (go (Set.insert canonical seen) (depth + 1)) children
                                 pure ([skillPath | hasSkill] <> nested)
 
-loadSkill
+loadSkillFile
     :: SkillScope
     -> SkillOrigin
     -> FilePath
     -> IO (Either SkillWarning Skill)
-loadSkill scope origin path = do
+loadSkillFile scope origin path = do
     result <- tryAny (retryOnFileBusy (Text.readFile path))
     case result of
         Left err ->
@@ -391,6 +393,7 @@ skillSortKey skill =
     )
   where
     (scopeRank, depth) = case skill.skillScope of
+        BuiltinSkill -> (-1, 0)
         UserSkill -> (0, 0)
         RepositorySkill d _ -> (1, d)
     originRank = case skill.skillOrigin of
@@ -461,6 +464,7 @@ qualifiedInvocation name siblings index skill =
 
 scopeQualifier :: Skill -> Text
 scopeQualifier skill = case skill.skillScope of
+    BuiltinSkill -> "builtin"
     UserSkill -> "user"
     RepositorySkill _ True -> "local"
     RepositorySkill _ False -> "repo"


### PR DESCRIPTION
## Summary

- add a dedicated `agent-telegram` executable with `setup`, `run`, `start`, `stop`, and `status` commands
- securely prompt for the BotFather token in an interactive terminal, validate it with Telegram, and store it separately with private permissions
- allowlist a numeric Telegram user ID and keep Telegram credentials out of managed agent child environments
- map private Telegram conversations to persisted agent sessions with `/start`, `/new`, and `/session`
- persist inbound turns, reaction changes, voice descriptors/transcripts, and outbound replies so work resumes after restarts
- process each conversation in order while allowing separate chats to run concurrently with tracked worker lifecycles
- show Telegram typing activity and native rich-message drafts while the agent is working
- convert common agent Markdown to Telegram-safe HTML with rich-message, HTML, and plain-text fallbacks
- deliver emoji-only agent acknowledgements through `setMessageReaction`; feed user reaction changes back as durable agent turns
- download bounded Telegram voice messages to private temporary files and transcribe them through the user's existing `codex app-server` subscription before entering the normal session path
- bundle a built-in `telegram-agent` skill so the normal agent can guide BotFather setup without asking for the token in chat
- package the new binary and skill through Cabal and Nix

## Setup

```sh
agent-telegram setup --provider openai --cwd /path/to/project \
  --allowed-user 123456789
agent-telegram start
agent-telegram status
```

Mutating tools remain denied unless setup is run with `--yolo`.
Voice transcription requires an installed, logged-in Codex CLI with subscription usage available.

## Testing

- `nix develop -c cabal test agent-cli-test --test-options='--match Agent.Telegram' --test-show-details=direct` — 22 examples, 0 failures
- `nix develop -c cabal test agent-cli-test --test-show-details=direct` — 712 examples, 0 failures
- `nix develop -c cabal test all --test-show-details=direct` — all non-CLI suites passed; one parallel AgentSessions test was flaky, then passed in isolation and in the complete agent-cli rerun
- live gateway rebuilt, restarted, and confirmed running
- Codex app-server audio handshake reached the authenticated service; successful transcription is currently blocked by this test account's subscription usage limit until August 27, 2026
- existing packaging checks: `nix flake check --no-build`, `nix build .#agent-telegram`, packaged `result/bin/agent-telegram --help`, and Linux `agent-cli` check
