### PR TITLE
Make GHCi the default execution tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /.direnv/
 /result
 /result-*
+/eval-results/
 /.ghc.environment.*
 *.hi
 *.o

--- a/README.md
+++ b/README.md
@@ -75,6 +75,19 @@ Start an interactive session:
 agent-cli
 ```
 
+`run_ghci` is the primary execution and scripting tool and is enabled by
+default. Enable the provider's explicit shell tool when needed:
+
+```console
+agent-cli --bash
+```
+
+For bash-only operation, disable GHCi explicitly:
+
+```console
+agent-cli --no-ghci --bash
+```
+
 Run a one-shot task:
 
 ```console

--- a/docs/evals/ghci-vs-bash.md
+++ b/docs/evals/ghci-vs-bash.md
@@ -14,7 +14,7 @@ system-prompt guidance differ.
 The suite uses three isolated, deterministically graded tasks:
 
 1. Aggregate a CSV into an exact report.
-2. Fix and verify a small Haskell module.
+2. Implement and verify a specification-driven C11 command-line program.
 3. Recursively audit a directory tree.
 
 Each one-shot run is saved as a normal agent session. The evaluator reports:
@@ -61,15 +61,48 @@ prevents stale logs from a previous full or filtered run.
 
 The eval makes real provider requests and may incur usage charges.
 
-## Initial comparison
+## C task spot check
 
-Run on August 23, 2026 with OpenAI `gpt-5.6-sol`, low reasoning effort,
-one trial per task/configuration, and a 60-second per-run timeout:
+After replacing the Haskell task, the C task was run once per mode on
+August 23, 2026 with OpenAI `gpt-5.6-sol`, low reasoning effort, and a
+180-second timeout:
+
+| mode | strict result | wall time | input tokens | output tokens |
+|---|---:|---:|---:|---:|
+| ghci-only | pass | 48.65 s | 50,999 | 1,727 |
+| bash-only | pass | 118.07 s | 60,557 | 2,050 |
+| ghci-plus-bash | timeout | 180.15 s | unavailable | unavailable |
+
+Both successful modes produced C that compiled under strict C11 warning flags
+and passed all grader cases. GHCi-only invoked the C compiler and executable
+through `System.Process` from `run_ghci`; bash-only used `shell_command`.
+
+The bash-only wall time includes a 58-second provider-credential retry, so the
+raw latency difference is not attributable to tool choice. The combined run
+wrote a program that passed the external grader, but the agent did not finish
+its verification turn before the timeout. A combined-mode retry behaved the
+same way. Because the evaluator requires both a passing artifact and a clean
+agent exit, both combined runs count as failures.
+
+This is still only a spot check. It demonstrates that the GHCi-only
+configuration can complete and verify a non-Haskell programming task, but it
+does not establish a stable ranking between the modes.
+
+## Superseded pilot comparison
+
+The first pilot, run on August 23, 2026 with OpenAI `gpt-5.6-sol`, used a
+Haskell repair task in the second slot. That task gave `run_ghci` an
+unfair domain-specific advantage, so it has been replaced by the C11 program
+task above. These numbers are retained only as historical context and are not
+results for the current suite.
+
+The superseded pilot used low reasoning effort, one trial per
+task/configuration, and a 60-second per-run timeout:
 
 | task | ghci-only | bash-only | ghci-plus-bash |
 |---|---:|---:|---:|
 | data-summary | pass, 16.35 s | pass, 24.74 s | pass, 21.14 s |
-| haskell-fix | pass, 51.97 s | timeout; retry passed, 52.17 s | pass, 50.10 s |
+| Haskell fix (removed) | pass, 51.97 s | timeout; retry passed, 52.17 s | pass, 50.10 s |
 | tree-audit | pass, 38.24 s | provider rejection; retry timed out at 120 s | timeout; retry passed, 39.83 s |
 
 First-attempt grader pass rates were:
@@ -79,8 +112,9 @@ First-attempt grader pass rates were:
 - **ghci-plus-bash: 2/3**
 
 For the two tasks completed by every mode, GHCi-only was fastest on the data
-summary, while all three modes were close on the Haskell repair. Bash-only
-never completed the tree audit, including a retry with a 120-second timeout.
+summary, while all three modes were close on the removed Haskell repair.
+Bash-only never completed the tree audit, including a retry with a 120-second
+timeout.
 
 Using the successful retry for the combined tree audit, the two modes that
 completed all three tasks totaled:
@@ -94,8 +128,7 @@ GHCi-only therefore used **4.1% less wall time**, **9.9% fewer input tokens**,
 and **10.6% fewer output tokens** than the combined mode, while also completing
 all tasks without a retry.
 
-This is a directional result, not a statistically strong conclusion. Provider
-variance was substantial, and retries were needed for two configurations. Use
-at least three trials per task with a longer timeout before treating latency or
-token deltas as stable. The strongest signal in this sample is reliability:
-GHCi-only completed every first attempt, while bash-only was the least reliable.
+The current suite needs to be rerun before drawing conclusions. In particular,
+the old 3/3 result for GHCi-only included the removed Haskell-specific task.
+Use at least three trials per task with a longer timeout before treating
+latency, token, or reliability deltas as stable.

--- a/docs/evals/ghci-vs-bash.md
+++ b/docs/evals/ghci-vs-bash.md
@@ -1,0 +1,101 @@
+# GHCi-only vs bash-only vs combined eval
+
+This behavioral eval compares three user-facing configurations:
+
+- **ghci-only**: the default, with `run_ghci` and no explicit shell tool.
+- **bash-only**: the provider shell tool with `run_ghci` disabled.
+- **ghci-plus-bash**: `--bash`, which adds the provider shell tool while
+  retaining `run_ghci`.
+
+It uses the same user task prompt in all variants. The complete product
+configurations necessarily differ because their tool schemas and matching
+system-prompt guidance differ.
+
+The suite uses three isolated, deterministically graded tasks:
+
+1. Aggregate a CSV into an exact report.
+2. Fix and verify a small Haskell module.
+3. Recursively audit a directory tree.
+
+Each one-shot run is saved as a normal agent session. The evaluator reports:
+
+- grader pass/fail;
+- wall-clock duration;
+- provider-reported input, output, and cached tokens;
+- ordered tool calls;
+- stdout/stderr logs and the final workspace.
+
+## Run
+
+Build the current agent and evaluator:
+
+```console
+nix develop -c cabal build \
+  agent-cli:exe:agent-cli \
+  agent-cli:exe:eval-ghci-vs-bash
+```
+
+Locate both executables and run one trial per task/configuration:
+
+```console
+agent_bin=$(nix develop -c cabal list-bin agent-cli:exe:agent-cli)
+eval_bin=$(nix develop -c cabal list-bin agent-cli:exe:eval-ghci-vs-bash)
+
+"$eval_bin" \
+  --agent-bin "$agent_bin" \
+  --results-dir "eval-results/ghci-vs-bash-$(date +%Y%m%d-%H%M%S)" \
+  --trials 1 \
+  --timeout-seconds 180 \
+  -- --provider openai --model gpt-5.6-sol
+```
+
+Increase `--trials` for a less noisy comparison. Run order alternates between
+the configurations across tasks and trials. Results are written to
+`results.json` and `summary.md`.
+
+Use `--task NAME` or
+`--mode ghci-only|bash-only|ghci-plus-bash` to rerun a subset.
+Each run has a configurable timeout so a stalled provider response does not
+block the suite indefinitely. Results directories must be new or empty; this
+prevents stale logs from a previous full or filtered run.
+
+The eval makes real provider requests and may incur usage charges.
+
+## Initial comparison
+
+Run on August 23, 2026 with OpenAI `gpt-5.6-sol`, low reasoning effort,
+one trial per task/configuration, and a 60-second per-run timeout:
+
+| task | ghci-only | bash-only | ghci-plus-bash |
+|---|---:|---:|---:|
+| data-summary | pass, 16.35 s | pass, 24.74 s | pass, 21.14 s |
+| haskell-fix | pass, 51.97 s | timeout; retry passed, 52.17 s | pass, 50.10 s |
+| tree-audit | pass, 38.24 s | provider rejection; retry timed out at 120 s | timeout; retry passed, 39.83 s |
+
+First-attempt grader pass rates were:
+
+- **ghci-only: 3/3**
+- **bash-only: 1/3**
+- **ghci-plus-bash: 2/3**
+
+For the two tasks completed by every mode, GHCi-only was fastest on the data
+summary, while all three modes were close on the Haskell repair. Bash-only
+never completed the tree audit, including a retry with a 120-second timeout.
+
+Using the successful retry for the combined tree audit, the two modes that
+completed all three tasks totaled:
+
+| mode | wall time | input tokens | output tokens |
+|---|---:|---:|---:|
+| ghci-only | 106.56 s | 161,932 | 2,889 |
+| ghci-plus-bash | 111.07 s | 179,812 | 3,230 |
+
+GHCi-only therefore used **4.1% less wall time**, **9.9% fewer input tokens**,
+and **10.6% fewer output tokens** than the combined mode, while also completing
+all tasks without a retry.
+
+This is a directional result, not a statistically strong conclusion. Provider
+variance was substantial, and retries were needed for two configurations. Use
+at least three trials per task with a longer timeout before treating latency or
+token deltas as stable. The strongest signal in this sample is reliability:
+GHCi-only completed every first attempt, while bash-only was the least reliable.

--- a/flake.nix
+++ b/flake.nix
@@ -110,6 +110,7 @@
                     include = [
                         "app"
                         "config"
+                        "eval"
                         "skills"
                         "src"
                         "test"

--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -163,6 +163,25 @@ executable agent-telegram
     build-depends:    agent-cli
                     , base >= 4.17 && < 5
 
+executable eval-ghci-vs-bash
+    import:           common-options
+    hs-source-dirs:   eval
+    main-is:          GhciVsBash.hs
+    ghc-options:      -threaded -rtsopts
+    build-depends:    agent-cli
+                    , agent-responses
+                    , aeson >= 2.0
+                    , base >= 4.17 && < 5
+                    , bytestring
+                    , containers
+                    , directory
+                    , filepath
+                    , process >= 1.6.26
+                    , safe-exceptions
+                    , text >= 2.0 && < 2.2
+                    , time
+                    , unix
+
 benchmark subagent-retention-bench
     import:           common-options
     type:             exitcode-stdio-1.0

--- a/packages/agent-cli/eval/GhciVsBash.hs
+++ b/packages/agent-cli/eval/GhciVsBash.hs
@@ -1,0 +1,748 @@
+module Main (main) where
+
+import Agent.CLI.Session
+    ( SessionMeta(..)
+    , SessionTurn(..)
+    , loadSession
+    )
+import Agent.Responses.Types
+    ( CustomToolCall(..)
+    , FunctionCall(..)
+    , ResponseItem(..)
+    )
+import Control.Exception.Safe (tryIO)
+import Control.Monad (forM, forM_, unless, when)
+import Data.Aeson (ToJSON(..), encode, object, (.=))
+import qualified Data.ByteString.Lazy as LBS
+import Data.List (intercalate, sort)
+import qualified Data.Map.Strict as Map
+import Data.Maybe (catMaybes, maybeToList)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.IO as Text
+import Data.Time.Clock (diffUTCTime, getCurrentTime)
+import System.Directory
+    ( copyFile
+    , createDirectoryIfMissing
+    , doesDirectoryExist
+    , doesFileExist
+    , getHomeDirectory
+    , listDirectory
+    , removePathForcibly
+    )
+import System.Environment (getArgs)
+import System.Exit (ExitCode(..), exitFailure)
+import System.FilePath (takeDirectory, (</>))
+import System.IO (IOMode(..), hPutStrLn, stderr, withFile)
+import System.OsPath (unsafeEncodeUtf)
+import System.Process
+    ( CreateProcess(..)
+    , StdStream(..)
+    , getPid
+    , proc
+    , readProcess
+    , waitForProcess
+    , withCreateProcess
+    )
+import System.Posix.Signals
+    ( Signal
+    , sigKILL
+    , sigTERM
+    , signalProcess
+    )
+import System.Posix.Types (ProcessID)
+import System.Timeout (timeout)
+
+data Mode = GhciOnly | BashOnly | GhciAndBash
+    deriving (Eq, Ord, Show)
+
+data Config = Config
+    { agentBin :: !FilePath
+    , resultsDir :: !FilePath
+    , trials :: !Int
+    , timeoutSeconds :: !Int
+    , selectedTask :: !(Maybe Text)
+    , selectedMode :: !(Maybe Mode)
+    , forwardedArgs :: ![String]
+    }
+
+data EvalTask = EvalTask
+    { taskName :: !Text
+    , taskPrompt :: !Text
+    , prepareTask :: !(FilePath -> IO ())
+    , gradeTask :: !(FilePath -> IO (Bool, Text))
+    }
+
+data RunResult = RunResult
+    { resultTask :: !Text
+    , resultTrial :: !Int
+    , resultMode :: !Mode
+    , resultPassed :: !Bool
+    , resultGrade :: !Text
+    , resultExitCode :: !Int
+    , resultTimedOut :: !Bool
+    , resultSeconds :: !Double
+    , resultInputTokens :: !(Maybe Int)
+    , resultOutputTokens :: !(Maybe Int)
+    , resultCachedTokens :: !(Maybe Int)
+    , resultToolCalls :: !(Maybe [Text])
+    , resultSessionId :: !(Maybe Text)
+    , resultProvider :: !(Maybe Text)
+    , resultModel :: !(Maybe Text)
+    , resultEffort :: !(Maybe Text)
+    , resultWorkspace :: !FilePath
+    , resultStdoutLog :: !FilePath
+    , resultStderrLog :: !FilePath
+    }
+
+instance ToJSON Mode where
+    toJSON GhciOnly = toJSON ("ghci-only" :: Text)
+    toJSON BashOnly = toJSON ("bash-only" :: Text)
+    toJSON GhciAndBash = toJSON ("ghci-plus-bash" :: Text)
+
+instance ToJSON RunResult where
+    toJSON result = object
+        [ "task" .= result.resultTask
+        , "trial" .= result.resultTrial
+        , "mode" .= result.resultMode
+        , "passed" .= result.resultPassed
+        , "grade" .= result.resultGrade
+        , "exitCode" .= result.resultExitCode
+        , "timedOut" .= result.resultTimedOut
+        , "seconds" .= result.resultSeconds
+        , "inputTokens" .= result.resultInputTokens
+        , "outputTokens" .= result.resultOutputTokens
+        , "cachedTokens" .= result.resultCachedTokens
+        , "toolCalls" .= result.resultToolCalls
+        , "sessionId" .= result.resultSessionId
+        , "provider" .= result.resultProvider
+        , "model" .= result.resultModel
+        , "effort" .= result.resultEffort
+        , "workspace" .= result.resultWorkspace
+        , "stdoutLog" .= result.resultStdoutLog
+        , "stderrLog" .= result.resultStderrLog
+        ]
+
+main :: IO ()
+main = do
+    args <- getArgs
+    config <- case parseConfig args of
+        Left err -> hPutStrLn stderr err >> exitFailure
+        Right parsed -> pure parsed
+    case config.selectedTask of
+        Just name
+            | name `notElem` map (.taskName) evalTasks -> do
+                hPutStrLn stderr $
+                    "unknown task: " <> Text.unpack name
+                        <> " (expected "
+                        <> intercalate ", " (map (Text.unpack . (.taskName)) evalTasks)
+                        <> ")"
+                exitFailure
+        _ -> pure ()
+    case validateForwardedArgs config.forwardedArgs of
+        Left err -> hPutStrLn stderr err >> exitFailure
+        Right () -> pure ()
+    prepareResultsDirectory config.resultsDir
+    let tasks = evalTasks
+        scheduled =
+            [ (trial, task, mode)
+            | trial <- [1 .. config.trials]
+            , task <- tasks
+            , maybe True (== task.taskName) config.selectedTask
+            , mode <- modeOrder trial task.taskName
+            , maybe True (== mode) config.selectedMode
+            ]
+    results <- forM scheduled \(trial, task, mode) -> do
+        putStrLn $
+            "Running " <> Text.unpack task.taskName
+                <> " trial " <> show trial
+                <> " (" <> modeSlug mode <> ")"
+        runOne config trial task mode
+    LBS.writeFile (config.resultsDir </> "results.json")
+        (encode results)
+    Text.writeFile (config.resultsDir </> "summary.md")
+        (renderSummary config results)
+    putStrLn ""
+    Text.putStrLn (renderConsoleSummary results)
+    unless (all (.resultPassed) results) exitFailure
+
+parseConfig :: [String] -> Either String Config
+parseConfig args =
+    go Config
+        { agentBin = "." </> "agent-cli"
+        , resultsDir = "." </> "eval-results" </> "ghci-vs-bash"
+        , trials = 1
+        , timeoutSeconds = 180
+        , selectedTask = Nothing
+        , selectedMode = Nothing
+        , forwardedArgs = []
+        }
+        args
+  where
+    go config = \case
+        [] -> Right config
+        "--agent-bin" : value : rest ->
+            go config { agentBin = value } rest
+        "--results-dir" : value : rest ->
+            go config { resultsDir = value } rest
+        "--trials" : value : rest -> case reads value of
+            [(count, "")] | count > 0 ->
+                go config { trials = count } rest
+            _ -> Left "--trials expects a positive integer"
+        "--timeout-seconds" : value : rest -> case reads value of
+            [(seconds, "")] | seconds > 0 ->
+                go config { timeoutSeconds = seconds } rest
+            _ -> Left "--timeout-seconds expects a positive integer"
+        "--task" : value : rest ->
+            go config { selectedTask = Just (Text.pack value) } rest
+        "--mode" : value : rest -> case value of
+            "ghci-only" ->
+                go config { selectedMode = Just GhciOnly } rest
+            "bash-only" ->
+                go config { selectedMode = Just BashOnly } rest
+            "ghci-plus-bash" ->
+                go config { selectedMode = Just GhciAndBash } rest
+            _ -> Left "--mode expects ghci-only, bash-only, or ghci-plus-bash"
+        "--" : rest ->
+            Right config { forwardedArgs = rest }
+        "--help" : _ ->
+            Left usage
+        unknown : _ ->
+            Left ("unknown eval argument: " <> unknown <> "\n\n" <> usage)
+
+usage :: String
+usage = unlines
+    [ "Usage: eval-ghci-vs-bash --agent-bin PATH [OPTIONS] [-- AGENT_ARGS]"
+    , ""
+    , "Options:"
+    , "  --results-dir DIR   Artifact directory"
+    , "  --trials N          Repetitions per task and mode (default: 1)"
+    , "  --timeout-seconds N  Per-run timeout (default: 180)"
+    , "  --task NAME         Run only one named task"
+    , "  --mode NAME         ghci-only, bash-only, or ghci-plus-bash"
+    , ""
+    , "Example:"
+    , "  eval-ghci-vs-bash --agent-bin $(cabal list-bin agent-cli:exe:agent-cli) \\"
+    , "    -- --provider openai --model gpt-5.6-sol"
+    ]
+
+evalTasks :: [EvalTask]
+evalTasks =
+    [ dataSummaryTask
+    , haskellFixTask
+    , treeAuditTask
+    ]
+
+dataSummaryTask :: EvalTask
+dataSummaryTask = EvalTask
+    { taskName = "data-summary"
+    , taskPrompt = Text.unlines
+        [ "Complete this task in the workspace. Do not only explain the answer."
+        , "Read numbers.csv and create report.txt with exactly these five lines:"
+        , "count=<integer>"
+        , "sum=<integer>"
+        , "minimum=<integer>"
+        , "maximum=<integer>"
+        , "mean=<decimal with exactly two digits>"
+        ]
+    , prepareTask = \dir ->
+        Text.writeFile (dir </> "numbers.csv")
+            "17,-4,23,9,12,31,-8,6,14,5,19,2\n"
+    , gradeTask = \dir ->
+        exactFile (dir </> "report.txt") $ Text.unlines
+            [ "count=12"
+            , "sum=126"
+            , "minimum=-8"
+            , "maximum=31"
+            , "mean=10.50"
+            ]
+    }
+
+haskellFixTask :: EvalTask
+haskellFixTask = EvalTask
+    { taskName = "haskell-fix"
+    , taskPrompt = Text.unlines
+        [ "Complete this task in the workspace. Do not only explain the answer."
+        , "Fix src/Discount.hs so finalPrice follows all requirements in SPEC.md."
+        , "Keep the exported API unchanged. Verify the behavior if possible."
+        ]
+    , prepareTask = \dir -> do
+        createDirectoryIfMissing True (dir </> "src")
+        Text.writeFile (dir </> "SPEC.md") $ Text.unlines
+            [ "# finalPrice"
+            , "- Quantities below 1 return 0."
+            , "- The first 4 items cost full unit price."
+            , "- Items 5 through 9 receive 10% off the whole order."
+            , "- Quantities 10 and above receive 20% off the whole order."
+            , "- Round the final result to two decimal places."
+            ]
+        Text.writeFile (dir </> "src" </> "Discount.hs") $ Text.unlines
+            [ "module Discount (finalPrice) where"
+            , ""
+            , "finalPrice :: Int -> Double -> Double"
+            , "finalPrice quantity unitPrice"
+            , "    | quantity < 1 = unitPrice"
+            , "    | quantity <= 5 = fromIntegral quantity * unitPrice"
+            , "    | quantity < 10 = fromIntegral quantity * unitPrice * 0.8"
+            , "    | otherwise = fromIntegral quantity * unitPrice * 0.9"
+            ]
+    , gradeTask = gradeHaskellFix
+    }
+
+treeAuditTask :: EvalTask
+treeAuditTask = EvalTask
+    { taskName = "tree-audit"
+    , taskPrompt = Text.unlines
+        [ "Complete this task in the workspace. Do not only explain the answer."
+        , "Recursively inspect the files under logs/."
+        , "Create audit.txt with one line per service, sorted by service name:"
+        , "<service> errors=<ERROR line count> warnings=<WARN line count>"
+        , "Only .log files count; ignore all other files."
+        ]
+    , prepareTask = prepareTreeAudit
+    , gradeTask = \dir ->
+        exactFile (dir </> "audit.txt") $ Text.unlines
+            [ "api errors=3 warnings=2"
+            , "billing errors=1 warnings=3"
+            , "worker errors=2 warnings=1"
+            ]
+    }
+
+prepareTreeAudit :: FilePath -> IO ()
+prepareTreeAudit dir = do
+    let files =
+            [ ("logs/api/2026-08-21.log", ["INFO start", "WARN slow", "ERROR timeout"])
+            , ("logs/api/archive/2026-08-20.log", ["ERROR reset", "WARN retry", "ERROR failed"])
+            , ("logs/api/notes.txt", ["ERROR ignored"])
+            , ("logs/billing/current.log", ["WARN late", "WARN retry", "ERROR declined", "WARN queued"])
+            , ("logs/worker/a.log", ["INFO ready", "ERROR crash"])
+            , ("logs/worker/nested/b.log", ["WARN busy", "ERROR lost"])
+            ]
+    forM_ files \(relative, rows) -> do
+        let path = dir </> relative
+        createDirectoryIfMissing True (takeDirectory path)
+        Text.writeFile path (Text.unlines rows)
+
+gradeHaskellFix :: FilePath -> IO (Bool, Text)
+gradeHaskellFix dir = do
+    let expression =
+            "and [finalPrice 0 10 == 0,"
+                <> " finalPrice 4 10 == 40,"
+                <> " finalPrice 5 10 == 45,"
+                <> " finalPrice 9 10 == 81,"
+                <> " finalPrice 10 10 == 80,"
+                <> " finalPrice 3 1.999 == 6.0]"
+        processSpec =
+            (proc "ghci"
+                [ "-ignore-dot-ghci"
+                , "-v0"
+                , "-isrc"
+                , "src/Discount.hs"
+                , "-e"
+                , expression
+                ])
+                { cwd = Just dir }
+        stdoutPath = dir </> "grader.stdout.log"
+        stderrPath = dir </> "grader.stderr.log"
+    exitCode <- runProcessWithTimeout 15 processSpec stdoutPath stderrPath
+    stdoutText <- readFileIfExists stdoutPath
+    stderrText <- readFileIfExists stderrPath
+    let passed = exitCode == ExitSuccess && trim stdoutText == "True"
+        detail
+            | passed = "all boundary and rounding checks passed"
+            | otherwise =
+                Text.pack $
+                    "grader exit=" <> show exitCode
+                        <> " stdout=" <> trim stdoutText
+                        <> " stderr=" <> trim stderrText
+    pure (passed, detail)
+
+runOne :: Config -> Int -> EvalTask -> Mode -> IO RunResult
+runOne config trial task mode = do
+    let runName =
+            Text.unpack task.taskName
+                <> "-trial-" <> show trial
+                <> "-" <> modeSlug mode
+        workspace = config.resultsDir </> "workspaces" </> runName
+        stdoutLog = config.resultsDir </> "logs" </> runName <> ".stdout.log"
+        stderrLog = config.resultsDir </> "logs" </> runName <> ".stderr.log"
+    resetDirectory workspace
+    createDirectoryIfMissing True (takeDirectory stdoutLog)
+    task.prepareTask workspace
+    home <- getHomeDirectory
+    let sessionsDir = home </> ".haskell-agent" </> "sessions"
+    started <- getCurrentTime
+    let processSpec =
+            proc config.agentBin
+                ( [ "--cwd", workspace
+                  , "--prompt", Text.unpack task.taskPrompt
+                  , "--save-session"
+                  , "--no-agents-md"
+                  , "--no-skills"
+                  , "--max-turns", "30"
+                  ]
+                    <> modeFlags mode
+                    <> config.forwardedArgs
+                )
+    exitCode <- runProcessWithTimeout
+        config.timeoutSeconds processSpec stdoutLog stderrLog
+    ended <- getCurrentTime
+    sessionId <- sessionIdFromLog stderrLog
+    sessionData <- case sessionId of
+        Nothing -> pure Nothing
+        Just identifier -> do
+            loaded <- loadSession
+                (unsafeEncodeUtf sessionsDir)
+                identifier
+            case loaded of
+                Left err -> do
+                    hPutStrLn stderr ("could not load eval session: " <> Text.unpack err)
+                    pure Nothing
+                Right value -> do
+                    copySessionArtifacts config.resultsDir runName sessionsDir identifier
+                    pure (Just value)
+    (passed, rawGrade) <- task.gradeTask workspace
+    let timedOut = exitCode == ExitFailure 124
+        grade
+            | timedOut = "timed out; " <> rawGrade
+            | otherwise = rawGrade
+    let (inputTokens, outputTokens, cachedTokens, toolCalls) =
+            sessionMetrics sessionData
+        (providerName, modelName, effortName) = case sessionData of
+            Just (meta, _) ->
+                ( Just (Text.pack (show meta.metaProvider))
+                , Just meta.metaModel
+                , Just meta.metaEffort
+                )
+            Nothing -> (Nothing, Nothing, Nothing)
+    pure RunResult
+        { resultTask = task.taskName
+        , resultTrial = trial
+        , resultMode = mode
+        , resultPassed = passed && exitCode == ExitSuccess
+        , resultGrade = grade
+        , resultExitCode = exitCodeNumber exitCode
+        , resultTimedOut = timedOut
+        , resultSeconds = realToFrac (diffUTCTime ended started)
+        , resultInputTokens = inputTokens
+        , resultOutputTokens = outputTokens
+        , resultCachedTokens = cachedTokens
+        , resultToolCalls = toolCalls
+        , resultSessionId = sessionId
+        , resultProvider = providerName
+        , resultModel = modelName
+        , resultEffort = effortName
+        , resultWorkspace = workspace
+        , resultStdoutLog = stdoutLog
+        , resultStderrLog = stderrLog
+        }
+
+sessionMetrics
+    :: Maybe (SessionMeta, [SessionTurn])
+    -> (Maybe Int, Maybe Int, Maybe Int, Maybe [Text])
+sessionMetrics Nothing = (Nothing, Nothing, Nothing, Nothing)
+sessionMetrics (Just (_, [])) = (Nothing, Nothing, Nothing, Nothing)
+sessionMetrics (Just (meta, turns)) =
+    ( Just meta.metaInputTokens
+    , Just meta.metaOutputTokens
+    , Just meta.metaCachedTokens
+    , Just (concatMap (concatMap itemToolName . (.turnItems)) turns)
+    )
+
+itemToolName :: ResponseItem -> [Text]
+itemToolName = \case
+    FunctionCallItem call -> [call.name]
+    CustomToolCallItem call -> [call.name]
+    _ -> []
+
+renderSummary :: Config -> [RunResult] -> Text
+renderSummary config results =
+    Text.unlines
+        [ "# GHCi-only vs bash-only vs combined agent eval"
+        , ""
+        , "This compares the product configurations, not mutually exclusive tools:"
+        , "`ghci-only` exposes only `run_ghci`; `bash-only` exposes only the"
+        , "provider shell tool; `ghci-plus-bash` exposes both."
+        , ""
+        , "- Trials per task and mode: " <> Text.pack (show config.trials)
+        , "- Per-run timeout: " <> Text.pack (show config.timeoutSeconds) <> " seconds"
+        , "- Agent binary: `" <> Text.pack config.agentBin <> "`"
+        , "- Forwarded agent arguments: `" <> Text.pack (unwords config.forwardedArgs) <> "`"
+        , ""
+        , renderConsoleSummary results
+        , ""
+        , "## Individual runs"
+        , ""
+        , "| task | trial | mode | pass | timeout | seconds | input | output | cached | tools |"
+        , "|---|---:|---|---:|---:|---:|---:|---:|---:|---|"
+        ]
+        <> Text.unlines (map renderRunRow results)
+
+renderConsoleSummary :: [RunResult] -> Text
+renderConsoleSummary results =
+    Text.unlines $
+        [ "| mode | passed | median successful seconds | median successful input | median successful output | successful tool calls |"
+        , "|---|---:|---:|---:|---:|---|"
+        ]
+            <> map renderModeSummary [GhciOnly, BashOnly, GhciAndBash]
+  where
+    renderModeSummary mode =
+        let selected = filter ((== mode) . (.resultMode)) results
+            successful = filter (.resultPassed) selected
+            passed = length successful
+            tools = Map.toList $ Map.fromListWith (+)
+                [ (name, 1 :: Int)
+                | result <- successful
+                , names <- maybeToList result.resultToolCalls
+                , name <- names
+                ]
+            inputValues =
+                map (fromIntegral @Int @Double) $
+                    catMaybes (map (.resultInputTokens) successful)
+            outputValues =
+                map (fromIntegral @Int @Double) $
+                    catMaybes (map (.resultOutputTokens) successful)
+        in Text.intercalate " | "
+            [ "| " <> Text.pack (modeSlug mode)
+            , Text.pack (show passed <> "/" <> show (length selected))
+            , formatOptionalDoubleMedian (map (.resultSeconds) successful)
+            , formatOptionalMedian inputValues
+            , formatOptionalMedian outputValues
+            , Text.pack (intercalate ", "
+                [Text.unpack name <> "=" <> show count | (name, count) <- tools])
+                <> " |"
+            ]
+
+renderRunRow :: RunResult -> Text
+renderRunRow result = Text.intercalate " | "
+    [ "| " <> result.resultTask
+    , Text.pack (show result.resultTrial)
+    , Text.pack (modeSlug result.resultMode)
+    , if result.resultPassed then "yes" else "no"
+    , if result.resultTimedOut then "yes" else "no"
+    , formatDouble result.resultSeconds
+    , maybe "n/a" (Text.pack . show) result.resultInputTokens
+    , maybe "n/a" (Text.pack . show) result.resultOutputTokens
+    , maybe "n/a" (Text.pack . show) result.resultCachedTokens
+    , maybe "n/a" (Text.intercalate ", ") result.resultToolCalls <> " |"
+    ]
+
+modeOrder :: Int -> Text -> [Mode]
+modeOrder trial name =
+    take 3 . drop offset . cycle $ [GhciOnly, BashOnly, GhciAndBash]
+  where
+    offset = (trial + Text.length name) `mod` 3
+
+modeSlug :: Mode -> String
+modeSlug GhciOnly = "ghci-only"
+modeSlug BashOnly = "bash-only"
+modeSlug GhciAndBash = "ghci-plus-bash"
+
+modeFlags :: Mode -> [String]
+modeFlags GhciOnly = ["--ghci", "--no-bash"]
+modeFlags BashOnly = ["--no-ghci", "--bash"]
+modeFlags GhciAndBash = ["--ghci", "--bash"]
+
+sessionIdFromLog :: FilePath -> IO (Maybe Text)
+sessionIdFromLog path = do
+    exists <- doesFileExist path
+    if not exists
+        then pure Nothing
+        else do
+            contents <- Text.readFile path
+            pure $ case
+                [ Text.strip suffix
+                | line <- Text.lines contents
+                , let (_, suffixWithMarker) = Text.breakOn "session:" line
+                , not (Text.null suffixWithMarker)
+                , let suffix = Text.drop (Text.length ("session:" :: Text)) suffixWithMarker
+                , not (Text.null (Text.strip suffix))
+                ] of
+                sessionId : _ -> Just sessionId
+                [] -> Nothing
+
+validateForwardedArgs :: [String] -> Either String ()
+validateForwardedArgs = go
+  where
+    go [] = Right ()
+    go (flag : _value : rest)
+        | flag `elem` ["--provider", "--model", "--effort", "--compact-threshold"] =
+            go rest
+    go (flag : _)
+        | flag `elem` reservedFlags =
+            Left ("eval controls " <> flag <> "; do not pass it after --")
+        | otherwise =
+            Left
+                ( "unsupported forwarded agent argument: " <> flag
+                    <> " (allowed: --provider, --model, --effort, --compact-threshold)"
+                )
+
+    reservedFlags =
+        [ "--ghci", "--no-ghci", "--bash", "--no-bash"
+        , "--cwd", "--prompt", "-p", "--prompt-file"
+        , "--save-session", "--agents-md", "--no-agents-md", "--skills"
+        , "--no-skills", "--max-turns", "--worktree", "--resume"
+        ]
+
+prepareResultsDirectory :: FilePath -> IO ()
+prepareResultsDirectory path = do
+    exists <- doesDirectoryExist path
+    when exists do
+        entries <- listDirectory path
+        unless (null entries) do
+            hPutStrLn stderr $
+                "results directory is not empty: " <> path
+                    <> " (choose a fresh directory)"
+            exitFailure
+    createDirectoryIfMissing True path
+
+runProcessWithTimeout
+    :: Int
+    -> CreateProcess
+    -> FilePath
+    -> FilePath
+    -> IO ExitCode
+runProcessWithTimeout seconds processSpec stdoutPath stderrPath =
+    withFile stdoutPath WriteMode \stdoutHandle ->
+        withFile stderrPath WriteMode \stderrHandle ->
+            withCreateProcess
+                processSpec
+                    { std_out = UseHandle stdoutHandle
+                    , std_err = UseHandle stderrHandle
+                    , create_group = True
+                    , new_session = True
+                    }
+                \_ _ _ processHandle -> do
+                    sessionId <- getPid processHandle
+                    completed <- timeout
+                        (seconds * 1000000)
+                        (waitForProcess processHandle)
+                    case completed of
+                        Just code -> do
+                            pure code
+                        Nothing -> do
+                            processIds <- case sessionId of
+                                Nothing -> pure []
+                                Just rootPid -> processTreeIds rootPid
+                            signalProcesses processIds sigTERM
+                            _ <- timeout 3000000 (waitForProcess processHandle)
+                            signalProcesses processIds sigKILL
+                            _ <- timeout 3000000 (waitForProcess processHandle)
+                            pure (ExitFailure 124)
+
+signalProcesses :: [ProcessID] -> Signal -> IO ()
+signalProcesses processIds signal =
+    forM_ processIds \pid -> do
+        _ <- tryIO (signalProcess signal pid)
+        pure ()
+
+processTreeIds :: ProcessID -> IO [ProcessID]
+processTreeIds rootPid = do
+    listed <- tryIO (readProcess "ps" ["-axo", "pid=,ppid="] "")
+    pure $ case listed of
+        Left _ -> [rootPid]
+        Right output ->
+            let relationships =
+                    [ (pid, parentPid)
+                    | line <- lines output
+                    , [pidText, parentText] <- [words line]
+                    , [(pid, "")] <- [reads pidText]
+                    , [(parentPid, "")] <- [reads parentText]
+                    ]
+                descendants parent =
+                    concat
+                        [ descendants child <> [child]
+                        | (child, childParent) <- relationships
+                        , childParent == parent
+                        ]
+            in descendants rootPid <> [rootPid]
+
+copySessionArtifacts
+    :: FilePath
+    -> FilePath
+    -> FilePath
+    -> Text
+    -> IO ()
+copySessionArtifacts resultsRoot runName sessionsRootPath sessionId = do
+    let source = sessionsRootPath </> Text.unpack sessionId
+        destination = resultsRoot </> "sessions" </> runName
+    createDirectoryIfMissing True destination
+    forM_ ["meta.json", "transcript.jsonl"] \name -> do
+        let sourcePath = source </> name
+        exists <- doesFileExist sourcePath
+        when exists (copyFile sourcePath (destination </> name))
+
+readFileIfExists :: FilePath -> IO String
+readFileIfExists path = do
+    exists <- doesFileExist path
+    if exists then readFile path else pure ""
+
+resetDirectory :: FilePath -> IO ()
+resetDirectory path = do
+    exists <- doesDirectoryExist path
+    when exists (removePathForcibly path)
+    createDirectoryIfMissing True path
+
+exactFile :: FilePath -> Text -> IO (Bool, Text)
+exactFile path expected = do
+    exists <- doesFileExist path
+    if not exists
+        then pure (False, Text.pack ("missing " <> path))
+        else do
+            actual <- Text.readFile path
+            let passed = normalize actual == normalize expected
+            pure
+                ( passed
+                , if passed
+                    then "exact output matched"
+                    else "expected " <> quoted (normalize expected)
+                        <> " but got " <> quoted (normalize actual)
+                )
+
+normalize :: Text -> Text
+normalize input =
+    let unix = Text.replace "\r\n" "\n" input
+    in maybe unix id (Text.stripSuffix "\n" unix)
+
+quoted :: Text -> Text
+quoted text = "`" <> Text.replace "\n" "\\n" text <> "`"
+
+median :: [Double] -> Double
+median [] = 0
+median values =
+    let ordered = sort values
+        count = length ordered
+        middle = count `div` 2
+    in if odd count
+        then ordered !! middle
+        else (ordered !! (middle - 1) + ordered !! middle) / 2
+
+formatDouble :: Double -> Text
+formatDouble value = Text.pack (showFFloat2 value)
+
+formatOptionalMedian :: [Double] -> Text
+formatOptionalMedian [] = "n/a"
+formatOptionalMedian values =
+    Text.pack (show (round (median values) :: Int))
+
+formatOptionalDoubleMedian :: [Double] -> Text
+formatOptionalDoubleMedian [] = "n/a"
+formatOptionalDoubleMedian values = formatDouble (median values)
+
+showFFloat2 :: Double -> String
+showFFloat2 value =
+    let scaled = round (value * 100) :: Integer
+        (whole, fraction) = scaled `divMod` 100
+    in show whole <> "." <> pad2 fraction
+
+pad2 :: Integer -> String
+pad2 value
+    | value < 10 = "0" <> show value
+    | otherwise = show value
+
+exitCodeNumber :: ExitCode -> Int
+exitCodeNumber ExitSuccess = 0
+exitCodeNumber (ExitFailure code) = code
+
+trim :: String -> String
+trim = Text.unpack . Text.strip . Text.pack

--- a/packages/agent-cli/eval/GhciVsBash.hs
+++ b/packages/agent-cli/eval/GhciVsBash.hs
@@ -41,6 +41,7 @@ import System.Process
     , getPid
     , proc
     , readProcess
+    , readProcessWithExitCode
     , waitForProcess
     , withCreateProcess
     )
@@ -229,7 +230,7 @@ usage = unlines
 evalTasks :: [EvalTask]
 evalTasks =
     [ dataSummaryTask
-    , haskellFixTask
+    , cProgramTask
     , treeAuditTask
     ]
 
@@ -258,35 +259,34 @@ dataSummaryTask = EvalTask
             ]
     }
 
-haskellFixTask :: EvalTask
-haskellFixTask = EvalTask
-    { taskName = "haskell-fix"
+cProgramTask :: EvalTask
+cProgramTask = EvalTask
+    { taskName = "c-program"
     , taskPrompt = Text.unlines
         [ "Complete this task in the workspace. Do not only explain the answer."
-        , "Fix src/Discount.hs so finalPrice follows all requirements in SPEC.md."
-        , "Keep the exported API unchanged. Verify the behavior if possible."
+        , "Write src/max_window.c so it implements the command-line program described in SPEC.md."
+        , "Use standard C11 and no third-party libraries. Verify the behavior if possible."
         ]
     , prepareTask = \dir -> do
         createDirectoryIfMissing True (dir </> "src")
         Text.writeFile (dir </> "SPEC.md") $ Text.unlines
-            [ "# finalPrice"
-            , "- Quantities below 1 return 0."
-            , "- The first 4 items cost full unit price."
-            , "- Items 5 through 9 receive 10% off the whole order."
-            , "- Quantities 10 and above receive 20% off the whole order."
-            , "- Round the final result to two decimal places."
-            ]
-        Text.writeFile (dir </> "src" </> "Discount.hs") $ Text.unlines
-            [ "module Discount (finalPrice) where"
+            [ "# max_window"
             , ""
-            , "finalPrice :: Int -> Double -> Double"
-            , "finalPrice quantity unitPrice"
-            , "    | quantity < 1 = unitPrice"
-            , "    | quantity <= 5 = fromIntegral quantity * unitPrice"
-            , "    | quantity < 10 = fromIntegral quantity * unitPrice * 0.8"
-            , "    | otherwise = fromIntegral quantity * unitPrice * 0.9"
+            , "Build a command-line program from `src/max_window.c`."
+            , ""
+            , "Usage: `max_window WINDOW INTEGER...`"
+            , ""
+            , "- `WINDOW` must be positive and no larger than the number of integers."
+            , "- Every `INTEGER` must fit in a signed 32-bit integer."
+            , "- Find the contiguous window of exactly `WINDOW` integers with the greatest sum."
+            , "- If several windows have the same greatest sum, choose the earliest one."
+            , "- Print exactly `start=<zero-based index> sum=<sum>` followed by a newline."
+            , "- Use a signed 64-bit or wider type for sums."
+            , "- Invalid integers or an invalid argument count/window must return a non-zero exit status."
             ]
-    , gradeTask = gradeHaskellFix
+        Text.writeFile (dir </> "src" </> "max_window.c")
+            "/* Implement the program described in ../SPEC.md. */\n"
+    , gradeTask = gradeCProgram
     }
 
 treeAuditTask :: EvalTask
@@ -323,39 +323,80 @@ prepareTreeAudit dir = do
         createDirectoryIfMissing True (takeDirectory path)
         Text.writeFile path (Text.unlines rows)
 
-gradeHaskellFix :: FilePath -> IO (Bool, Text)
-gradeHaskellFix dir = do
-    let expression =
-            "and [finalPrice 0 10 == 0,"
-                <> " finalPrice 4 10 == 40,"
-                <> " finalPrice 5 10 == 45,"
-                <> " finalPrice 9 10 == 81,"
-                <> " finalPrice 10 10 == 80,"
-                <> " finalPrice 3 1.999 == 6.0]"
+gradeCProgram :: FilePath -> IO (Bool, Text)
+gradeCProgram dir = do
+    let binary = dir </> "grader-max-window"
         processSpec =
-            (proc "ghci"
-                [ "-ignore-dot-ghci"
-                , "-v0"
-                , "-isrc"
-                , "src/Discount.hs"
-                , "-e"
-                , expression
+            (proc "cc"
+                [ "-std=c11"
+                , "-Wall"
+                , "-Wextra"
+                , "-Werror"
+                , "-pedantic"
+                , "src/max_window.c"
+                , "-o"
+                , "grader-max-window"
                 ])
                 { cwd = Just dir }
         stdoutPath = dir </> "grader.stdout.log"
         stderrPath = dir </> "grader.stderr.log"
     exitCode <- runProcessWithTimeout 15 processSpec stdoutPath stderrPath
-    stdoutText <- readFileIfExists stdoutPath
-    stderrText <- readFileIfExists stderrPath
-    let passed = exitCode == ExitSuccess && trim stdoutText == "True"
-        detail
-            | passed = "all boundary and rounding checks passed"
-            | otherwise =
-                Text.pack $
-                    "grader exit=" <> show exitCode
-                        <> " stdout=" <> trim stdoutText
-                        <> " stderr=" <> trim stderrText
-    pure (passed, detail)
+    if exitCode /= ExitSuccess
+        then do
+            stderrText <- readFileIfExists stderrPath
+            pure
+                ( False
+                , Text.pack $
+                    "C compilation failed: " <> trim stderrText
+                )
+        else do
+            validResults <- forM validCases \(args, expected) -> do
+                (code, stdoutText, stderrText) <-
+                    readProcessWithExitCode binary args ""
+                pure $
+                    if code == ExitSuccess && stdoutText == expected
+                        then Nothing
+                        else Just $
+                            "args=" <> show args
+                                <> " exit=" <> show code
+                                <> " stdout=" <> show stdoutText
+                                <> " stderr=" <> show stderrText
+            invalidResults <- forM invalidCases \args -> do
+                (code, stdoutText, stderrText) <-
+                    readProcessWithExitCode binary args ""
+                pure $
+                    if code /= ExitSuccess
+                        then Nothing
+                        else Just $
+                            "invalid args=" <> show args
+                                <> " unexpectedly succeeded"
+                                <> " stdout=" <> show stdoutText
+                                <> " stderr=" <> show stderrText
+            let failures = catMaybes (validResults <> invalidResults)
+            pure
+                ( null failures
+                , if null failures
+                    then "compiled cleanly and passed all valid and invalid input cases"
+                    else Text.pack (intercalate "; " failures)
+                )
+  where
+    validCases =
+        [ (["2", "1", "5", "2", "4"], "start=1 sum=7\n")
+        , (["2", "4", "1", "4", "1"], "start=0 sum=5\n")
+        , (["3", "-5", "-2", "-7", "-1"], "start=1 sum=-10\n")
+        , (["4", "2", "-1", "3", "6"], "start=0 sum=10\n")
+        , ( ["2", "2147483647", "2147483647", "-1"]
+          , "start=0 sum=4294967294\n"
+          )
+        ]
+    invalidCases =
+        [ []
+        , ["0", "1"]
+        , ["2", "1"]
+        , ["1", "not-an-integer"]
+        , ["1", "2147483648"]
+        , ["1", "-2147483649"]
+        ]
 
 runOne :: Config -> Int -> EvalTask -> Mode -> IO RunResult
 runOne config trial task mode = do

--- a/packages/agent-cli/package.nix
+++ b/packages/agent-cli/package.nix
@@ -22,7 +22,10 @@ mkDerivation {
     safe-exceptions stm text
     time transformers unix vector vty vty-crossplatform
   ];
-  executableHaskellDepends = [ base ];
+  executableHaskellDepends = [
+    aeson agent-responses base bytestring containers directory filepath
+    process safe-exceptions text time unix
+  ];
   testHaskellDepends = [
     aeson agent-codex-dialect agent-core agent-grok-build-dialect
     agent-openai agent-responses agent-tui agent-xai ansi-terminal base

--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -192,7 +192,7 @@ import Agent.CLI.Project
 import Agent.CLI.Prompt
     ( secretInputGuidance
     , subscriptionSubagentModelGuidance
-    , systemPrompt
+    , systemPromptForTools
     )
 import Agent.CLI.Request (requestParams, setRequestInstructions)
 import Agent.CLI.ProviderFallback
@@ -286,6 +286,8 @@ import Agent.CLI.Tools (requireToolRegistry, schemasFromAppTools)
 import Agent.CLI.Dialects
     ( CodingTools(..)
     , codingToolsForWithTypes
+    , filterBashTools
+    , filterGhciTools
     , formatAgentsMdForDialect
     , globalAgentsHomeDir
     )
@@ -1827,12 +1829,14 @@ runAgentInitializedWithLock
             , toolsLaunchTurn =
                 launchSessionTurn sessionProcessManager
                     (not (isOneShot options)) policy
+                    options.optGhci options.optBash
             , toolsSessionStatus =
                 sessionProcessStatus sessionProcessManager
             }
         mcpTools = MCP.mcpFleetTools mcpFleet
         tools =
-            coding.codingAppTools
+            filterGhciTools options.optGhci
+                (filterBashTools options.optBash coding.codingAppTools)
                 ++ mcpTools
                 ++ agentSessionTools sessionToolsEnv
         planMode = coding.codingPlanMode
@@ -1865,12 +1869,13 @@ runAgentInitializedWithLock
                 Nothing -> pure ()
         today <- utctDay <$> getCurrentTime
         let instructions =
-                Text.intercalate "\n\n" $
-                    filter (not . Text.null)
-                        [ systemPrompt dialect cwd (Just sessionTmp) today
-                            (isOneShot options)
-                        , secretInputGuidance (map (.appToolName) tools)
-                        ]
+                systemPromptForTools
+                    dialect
+                    (map (.appToolName) tools)
+                    cwd
+                    (Just sessionTmp)
+                    today
+                    (isOneShot options)
             params = requestParams model instructions
                 (schemasFromAppTools dialect tools) effort
             initialItems = maybe [] (foldSessionItems . snd) resumed
@@ -2966,8 +2971,9 @@ runSession catalog connectionId options provider dialect policy tools toolEnv pl
             today <- utctDay <$> getCurrentTime
             modifyIORef' paramsRef $
                 setRequestInstructions
-                    (systemPrompt
+                    (systemPromptForTools
                         dialect
+                        (map (.appToolName) tools)
                         cwd
                         (Just tempDir)
                         today

--- a/packages/agent-cli/src/Agent/CLI/AgentSessions.hs
+++ b/packages/agent-cli/src/Agent/CLI/AgentSessions.hs
@@ -126,10 +126,12 @@ launchSessionTurn
     :: SessionProcessManager
     -> Bool
     -> ApprovalPolicy
+    -> Bool
+    -> Bool
     -> SessionHandle
     -> Text
     -> IO (Either Text Text)
-launchSessionTurn manager background policy handle message =
+launchSessionTurn manager background policy ghciEnabled bashEnabled handle message =
     resolveAgentExecutable >>= \case
         Left err -> pure (Left err)
         Right executable -> do
@@ -209,6 +211,8 @@ launchSessionTurn manager background policy handle message =
                 , "--save-session"
                 ]
                     <> approvalArgs
+                    <> ["--no-ghci" | not ghciEnabled]
+                    <> ["--bash" | bashEnabled]
             cleanupScript =
                 "prompt=$1; shift; "
                     <> "cleanup() { rm -f \"$prompt\"; }; "

--- a/packages/agent-cli/src/Agent/CLI/Dialects.hs
+++ b/packages/agent-cli/src/Agent/CLI/Dialects.hs
@@ -2,7 +2,9 @@ module Agent.CLI.Dialects
     ( CodingTools(..)
     , codingToolsFor
     , codingToolsForWithTypes
+    , filterBashTools
     , filterChildGrokTools
+    , filterGhciTools
     , formatAgentsMdForDialect
     , globalAgentsHomeDir
     ) where
@@ -39,7 +41,7 @@ import Agent.Tools.Secret
     , closeSecretStore
     , newSecretStore
     )
-import Agent.Tools.Types (AppTool, ToolEnv)
+import Agent.Tools.Types (AppTool(..), ToolEnv)
 import Control.Exception.Safe (finally, onException)
 import Data.IORef (newIORef)
 import qualified Data.Map.Strict as Map
@@ -105,6 +107,16 @@ codingToolsForWithTypes
 
 filterChildGrokTools :: Text -> [AppTool] -> [AppTool]
 filterChildGrokTools = filterGrokToolsForType
+
+filterBashTools :: Bool -> [AppTool] -> [AppTool]
+filterBashTools True = id
+filterBashTools False = filter \tool ->
+    tool.appToolName `notElem`
+        ["shell_command", "write_stdin", "run_terminal_cmd"]
+
+filterGhciTools :: Bool -> [AppTool] -> [AppTool]
+filterGhciTools True = id
+filterGhciTools False = filter ((/= "run_ghci") . (.appToolName))
 
 formatAgentsMdForDialect :: Dialect -> OsPath -> LoadedAgentsMd -> Maybe Text
 formatAgentsMdForDialect dialect cwd loaded =

--- a/packages/agent-cli/src/Agent/CLI/Options.hs
+++ b/packages/agent-cli/src/Agent/CLI/Options.hs
@@ -81,6 +81,10 @@ data CliOptions = CliOptions
       -- ^ Discover and inject AGENTS.md at session start (default: True).
     , optSkills :: !Bool
       -- ^ Discover and expose filesystem skills (default: True).
+    , optGhci :: !Bool
+      -- ^ Expose the persistent run_ghci tool (default: True).
+    , optBash :: !Bool
+      -- ^ Expose the provider's explicit shell execution tool (default: False).
     , optScreenMode :: !ScreenMode
     , optMotionMode :: !MotionMode
     } deriving (Eq, Show)
@@ -102,6 +106,8 @@ defaultCliOptions = CliOptions
     , optSaveSession = False
     , optAgentsMd = True
     , optSkills = True
+    , optGhci = True
+    , optBash = False
     , optScreenMode = ScreenAuto
     , optMotionMode = MotionFull
     }
@@ -198,6 +204,14 @@ parseOptions options = \case
         parseOptions options { optSkills = True } rest
     "--no-skills" : rest ->
         parseOptions options { optSkills = False } rest
+    "--ghci" : rest ->
+        parseOptions options { optGhci = True } rest
+    "--no-ghci" : rest ->
+        parseOptions options { optGhci = False } rest
+    "--bash" : rest ->
+        parseOptions options { optBash = True } rest
+    "--no-bash" : rest ->
+        parseOptions options { optBash = False } rest
     "--fullscreen" : rest ->
         parseOptions options { optScreenMode = ScreenFullscreen } rest
     "--minimal" : rest ->
@@ -268,6 +282,10 @@ usage = unlines
     , "      --no-agents-md      Skip AGENTS.md discovery"
     , "      --skills            Discover Agent Skills (default)"
     , "      --no-skills         Disable skill discovery and invocation"
+    , "      --ghci              Enable the persistent GHCi tool (default)"
+    , "      --no-ghci           Disable the persistent GHCi tool"
+    , "      --bash              Enable explicit shell execution tools"
+    , "      --no-bash           Disable explicit shell execution tools (default)"
     , "      --fullscreen        Use the retained full-screen TUI"
     , "      --minimal           Use terminal-native append-only rendering"
     , "      --motion MODE       Animation policy: full, reduced, or off"

--- a/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
@@ -26,7 +26,6 @@ import Agent.CLI.Options
     )
 import Agent.CLI.Prompt
     ( sessionTempGuidance
-    , systemPrompt
     , systemPromptForTools
     )
 import Agent.CLI.Request (requestParams)
@@ -41,7 +40,9 @@ import Agent.CLI.Tools (requireToolRegistry, schemasFromAppTools)
 import Agent.CLI.Dialects
     ( CodingTools(..)
     , codingToolsFor
+    , filterBashTools
     , filterChildGrokTools
+    , filterGhciTools
     )
 import Agent.Codex.Dialect.Subagent (codexSubagentSuffix)
 import Agent.Dialect
@@ -566,10 +567,18 @@ runCodexSubagent runtime tokenProvider sendToRoot =
                     coding.codingPlanMode
                 flip finally coding.codingClose do
                     today <- utctDay <$> getCurrentTime
-                    let baseInstructions =
+                    let codingTools =
+                            filterGhciTools runtime.subagentOptions.optGhci $
+                                filterBashTools
+                                    runtime.subagentOptions.optBash
+                                    coding.codingAppTools
+                        tools =
+                            codingTools <> runtime.subagentMcpTools
+                        baseInstructions =
                             fromMaybe
-                                (systemPrompt
+                                (systemPromptForTools
                                     codexDialect
+                                    (map (.appToolName) tools)
                                     env.subCwd
                                     sessionTmp
                                     today
@@ -581,9 +590,6 @@ runCodexSubagent runtime tokenProvider sendToRoot =
                                 <> "report results clearly. Your agent id is "
                                 <> env.subId.unSubagentId
                                 <> "."
-                        tools =
-                            coding.codingAppTools
-                                <> runtime.subagentMcpTools
                         childParams = requestParams model instructions
                             (schemasFromAppTools codexDialect tools) effort
                     toolRegistry <- requireToolRegistry tools
@@ -675,22 +681,26 @@ runHttpSubagent runtime dialect provider sendToRoot mkBackend =
                     today <- utctDay <$> getCurrentTime
                     shellPath <-
                         Text.pack . fromMaybe defaultShell <$> lookupEnv "SHELL"
-                    let codingTools = case
+                    let childTools = case
                                 dialectChildAgentProtocol childDialect of
-                            CodexCollaborationProtocol ->
-                                coding.codingAppTools
+                            CodexCollaborationProtocol -> coding.codingAppTools
                             GrokTaskProtocol ->
-                                filterChildGrokTools
-                                    agentType coding.codingAppTools
+                                filterChildGrokTools agentType coding.codingAppTools
                             GenericTaskProtocol ->
-                                filterChildGrokTools
-                                    agentType coding.codingAppTools
-                        tools = codingTools <> runtime.subagentMcpTools
+                                filterChildGrokTools agentType coding.codingAppTools
+                        codingTools =
+                            filterGhciTools runtime.subagentOptions.optGhci $
+                                filterBashTools
+                                    runtime.subagentOptions.optBash
+                                    childTools
+                        tools =
+                            codingTools <> runtime.subagentMcpTools
                         baseInstructions =
                             case dialectChildAgentProtocol childDialect of
                                 CodexCollaborationProtocol ->
-                                    systemPrompt
+                                    systemPromptForTools
                                         childDialect
+                                        (map (.appToolName) tools)
                                         env.subCwd
                                         sessionTmp
                                         today

--- a/packages/agent-cli/src/Agent/Telegram.hs
+++ b/packages/agent-cli/src/Agent/Telegram.hs
@@ -1395,6 +1395,8 @@ runAgentTurn runtime key prompt = do
         runtime.runtimeProcessManager
         False
         runtime.runtimePolicy
+        True
+        False
         handle
         agentPrompt >>= \case
             Left err -> fail (Text.unpack err)

--- a/packages/agent-cli/test/Agent/CLI/AgentSessionsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/AgentSessionsSpec.hs
@@ -136,9 +136,9 @@ spec = describe "Agent.CLI.AgentSessions" do
             withExecutableOverride script do
                 handle <- createSession (testCreateAt root root)
                 manager <- newSessionProcessManager root
-                first <- launchSessionTurn manager True ApproveAll handle "one"
+                first <- launchSessionTurn manager True ApproveAll True False handle "one"
                 first `shouldSatisfy` either (const False) (const True)
-                second <- launchSessionTurn manager True ApproveAll handle "two"
+                second <- launchSessionTurn manager True ApproveAll True False handle "two"
                 second `shouldSatisfy` \case
                     Left err -> "already running" `Text.isInfixOf` err
                     Right _ -> False
@@ -146,6 +146,44 @@ spec = describe "Agent.CLI.AgentSessions" do
                     manager
                     handle.sessionMeta.metaId
                     "completed"
+                closeSessionProcessManager manager
+
+    it "forwards bash enablement to managed session turns" $
+        withTempDir "agent-session-runtime-" \root -> do
+            let argsPath = toFilePath root FilePath.</> "agent-args"
+            script <- writeFakeAgentBody root
+                ("printf '%s\\n' \"$@\" > " <> shellQuote argsPath <> "\nexit 0\n")
+            withExecutableOverride script do
+                handle <- createSession (testCreateAt root root)
+                manager <- newSessionProcessManager root
+                launched <-
+                    launchSessionTurn manager True ApproveAll True True handle "one"
+                launched `shouldSatisfy` either (const False) (const True)
+                waitForSessionStatus
+                    manager
+                    handle.sessionMeta.metaId
+                    "completed"
+                args <- lines <$> readFile argsPath
+                args `shouldContain` ["--bash"]
+                closeSessionProcessManager manager
+
+    it "forwards ghci disablement to managed session turns" $
+        withTempDir "agent-session-runtime-" \root -> do
+            let argsPath = toFilePath root FilePath.</> "agent-args"
+            script <- writeFakeAgentBody root
+                ("printf '%s\\n' \"$@\" > " <> shellQuote argsPath <> "\nexit 0\n")
+            withExecutableOverride script do
+                handle <- createSession (testCreateAt root root)
+                manager <- newSessionProcessManager root
+                launched <-
+                    launchSessionTurn manager True ApproveAll False True handle "one"
+                launched `shouldSatisfy` either (const False) (const True)
+                waitForSessionStatus
+                    manager
+                    handle.sessionMeta.metaId
+                    "completed"
+                args <- lines <$> readFile argsPath
+                args `shouldContain` ["--no-ghci", "--bash"]
                 closeSessionProcessManager manager
 
     it "keeps an advisory lock until its owner releases it" $
@@ -216,7 +254,7 @@ spec = describe "Agent.CLI.AgentSessions" do
             withExecutableOverride script do
                 handle <- createSession (testCreateAt root root)
                 manager <- newSessionProcessManager root
-                launchSessionTurn manager True ApproveAll handle "one"
+                launchSessionTurn manager True ApproveAll True False handle "one"
                     `shouldReturn` Left "could not acquire lock"
                 closeSessionProcessManager manager
 
@@ -241,7 +279,8 @@ spec = describe "Agent.CLI.AgentSessions" do
                     \_ -> do
                         handle <- createSession (testCreateAt root root)
                         manager <- newSessionProcessManager root
-                        launchSessionTurn manager False ApproveAll handle "one"
+                        launchSessionTurn
+                            manager False ApproveAll True False handle "one"
                             `shouldReturn`
                                 Right
                                     ("completed session "
@@ -257,7 +296,7 @@ spec = describe "Agent.CLI.AgentSessions" do
             withExecutableOverride script do
                 handle <- createSession (testCreateAt root root)
                 manager <- newSessionProcessManager root
-                _ <- launchSessionTurn manager True ApproveAll handle "one"
+                _ <- launchSessionTurn manager True ApproveAll True False handle "one"
                 closeSessionProcessManager manager
                 waitForFile marker
 

--- a/packages/agent-cli/test/Agent/CLI/DialectsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/DialectsSpec.hs
@@ -3,6 +3,8 @@ module Agent.CLI.DialectsSpec (spec) where
 import Agent.CLI.Dialects
     ( CodingTools(..)
     , codingToolsFor
+    , filterBashTools
+    , filterGhciTools
     , formatAgentsMdForDialect
     , globalAgentsHomeDir
     )
@@ -12,8 +14,15 @@ import Agent.Dialect
     , grokBuildDialect
     )
 import Agent.ProjectInstructions (InstructionFile(..), LoadedAgentsMd(..))
+import Agent.ToolDispatch (noArgsTool)
 import Agent.Tools.Secret (SecretPromptHooks(..))
-import Agent.Tools.Types (AppTool(..), ToolEnv, defaultToolEnv)
+import Agent.Tools.Types
+    ( AppTool(..)
+    , ApprovalRule(AlwaysReadOnly)
+    , ToolEnv
+    , defaultToolEnv
+    , jsonAppTool
+    )
 import Control.Exception.Safe (bracket, finally)
 import Control.Monad (forM_)
 import qualified Data.Text as Text
@@ -68,6 +77,25 @@ spec = describe "Agent.CLI.Dialects" do
                     `shouldContain` ["ask_secret"])
                     `finally` withSecret.codingClose
 
+    it "filters shell and ghci tools independently" do
+        let tools = map fakeTool
+                [ "run_ghci"
+                , "read_file"
+                , "shell_command"
+                , "write_stdin"
+                , "run_terminal_cmd"
+                ]
+            names = map (.appToolName)
+        names (filterBashTools False tools)
+            `shouldBe` ["run_ghci", "read_file"]
+        names (filterGhciTools False tools)
+            `shouldBe`
+                [ "read_file"
+                , "shell_command"
+                , "write_stdin"
+                , "run_terminal_cmd"
+                ]
+
 withTempToolEnv :: (ToolEnv -> IO a) -> IO a
 withTempToolEnv action = do
     root <- getTemporaryDirectory
@@ -76,3 +104,7 @@ withTempToolEnv action = do
         removeDirectoryRecursive
         (\directory ->
             defaultToolEnv (unsafeEncodeUtf directory) >>= action)
+
+fakeTool name =
+    jsonAppTool name "" [] AlwaysReadOnly
+        (noArgsTool name (pure (Right "")))

--- a/packages/agent-cli/test/Agent/CLI/OptionsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/OptionsSpec.hs
@@ -22,6 +22,7 @@ spec = do
                 [ "--provider", "xai"
                 , "--model", "grok-4.6"
                 , "--cwd", "/tmp/work"
+                , "--bash"
                 , "--yolo"
                 , "--max-turns", "3"
                 , "--compact-threshold", "1200"
@@ -32,6 +33,7 @@ spec = do
                     { optProvider = Just XAIProvider
                     , optModel = Just "grok-4.6"
                     , optCwd = Just (fromFilePath "/tmp/work")
+                    , optBash = True
                     , optYolo = True
                     , optMaxTurns = 3
                     , optCompactThreshold = Just 1200
@@ -147,6 +149,22 @@ spec = do
                     { optPrompt = Just "hi"
                     , optSkills = True
                     })
+
+        it "keeps bash disabled by default and enables it explicitly" do
+            parseArgs []
+                `shouldBe` Right (RunAgent defaultCliOptions)
+            parseArgs ["--bash"]
+                `shouldBe` Right (RunAgent defaultCliOptions { optBash = True })
+            parseArgs ["--bash", "--no-bash"]
+                `shouldBe` Right (RunAgent defaultCliOptions { optBash = False })
+
+        it "keeps ghci enabled by default and disables it explicitly" do
+            parseArgs []
+                `shouldBe` Right (RunAgent defaultCliOptions)
+            parseArgs ["--no-ghci"]
+                `shouldBe` Right (RunAgent defaultCliOptions { optGhci = False })
+            parseArgs ["--no-ghci", "--ghci"]
+                `shouldBe` Right (RunAgent defaultCliOptions { optGhci = True })
 
     describe "resolveApprovalPolicy" do
         it "auto-approves one-shot scripts without a TTY" do

--- a/packages/agent-cli/test/Agent/CLI/PromptSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/PromptSpec.hs
@@ -146,6 +146,43 @@ spec = describe "systemPrompt" do
             "Never read, print, summarize"
         withoutSecret `shouldNotSatisfy` Text.isInfixOf "Use ask_secret"
 
+    it "renders ghci-only and bash-only root prompts from registered tools" do
+        let day = fromGregorian 2026 8 19
+            ghciOnly =
+                systemPromptForTools
+                    codexDialect
+                    ["read_file", "grep", "list_dir", "apply_patch", "run_ghci"]
+                    (fromFilePath "/tmp/repo")
+                    Nothing
+                    day
+                    False
+            bashOnly =
+                systemPromptForTools
+                    codexDialect
+                    ["read_file", "grep", "list_dir", "apply_patch", "shell_command"]
+                    (fromFilePath "/tmp/repo")
+                    Nothing
+                    day
+                    False
+        ghciOnly `shouldSatisfy` Text.isInfixOf "Prefer ghci for scripting"
+        ghciOnly `shouldNotSatisfy` Text.isInfixOf "shell_command"
+        bashOnly `shouldSatisfy` Text.isInfixOf "shell_command"
+        bashOnly `shouldNotSatisfy` Text.isInfixOf "run_ghci"
+        bashOnly `shouldNotSatisfy` Text.isInfixOf "Prefer ghci for scripting"
+
+    it "omits hidden Grok terminal names from ghci-only prompts" do
+        let prompt =
+                systemPromptForTools
+                    grokBuildDialect
+                    ["read_file", "grep", "list_dir", "search_replace", "run_ghci"]
+                    (fromFilePath "/tmp/repo")
+                    Nothing
+                    (fromGregorian 2026 8 19)
+                    False
+        prompt `shouldSatisfy` Text.isInfixOf "run_ghci"
+        prompt `shouldNotSatisfy` Text.isInfixOf "run_terminal_command"
+        prompt `shouldNotSatisfy` Text.isInfixOf "run_terminal_cmd"
+
     it "keeps OpenAI web-search references internal" do
         let openai =
                 systemPrompt codexDialect

--- a/packages/agent-codex-dialect/src/Agent/Codex/Dialect/Tools.hs
+++ b/packages/agent-codex-dialect/src/Agent/Codex/Dialect/Tools.hs
@@ -80,17 +80,17 @@ codexTools
 codexTools env shellSession ghci planMode multi = do
     planRef <- newIORef []
     pure $
-        [ readFileTool env
+        [ runGhciTool ghci
+        , readFileTool env
         , grepTool env
         , listDirTool env
-        , shellCommandTool env shellSession
-        , writeStdinTool shellSession
         , applyPatchTool env
         , updatePlanTool planMode planRef
-        , runGhciTool ghci
         , enterCodexPlanModeTool planMode
         , writePlanTool planMode
         , askUserQuestionTool planMode
+        , shellCommandTool env shellSession
+        , writeStdinTool shellSession
         ]
         ++ maybe [] multiAgentTools multi
 

--- a/packages/agent-core/src/Agent/Tools/FileSystem/ReadFile.hs
+++ b/packages/agent-core/src/Agent/Tools/FileSystem/ReadFile.hs
@@ -66,7 +66,7 @@ runReadFile env args = resolveUnderCwd env (fromText args.targetFile) >>= \case
     Right path
         | ".pdf" `Text.isSuffixOf` Text.toLower args.targetFile ->
             pure $ Left
-                "PDF rendering is not available. Use run_terminal_command with pdftotext, or convert the file to text first."
+                "PDF rendering is not available. Use an explicit terminal conversion tool if available, or convert the file to text first."
         | otherwise -> doesFileExist path >>= \case
             False -> pure $ Left $ "File not found: " <> args.targetFile
             True -> readTextFile path >>= \case

--- a/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/TaskControl.hs
+++ b/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/TaskControl.hs
@@ -70,7 +70,7 @@ getTaskOutputDescription :: Text
 getTaskOutputDescription =
     "Get output and status from a background task or subagent.\n\n\
     \Usage notes:\n\
-    \- Pass task_ids with one or more ids from background=true commands or subagents; for a single task use a one-element array. Multiple ids with a positive timeout_ms wait until all complete\n\
+    \- Pass task_ids with one or more ids returned by a background command or subagent; for a single task use a one-element array. Multiple ids with a positive timeout_ms wait until all complete\n\
     \- Omit timeout_ms or pass 0 for a non-blocking status snapshot; set a positive timeout_ms to wait up to that many milliseconds, capped at 600000 (~10 min)\n\
     \- Returns current output and status."
 
@@ -297,7 +297,7 @@ instance FromJSON KillTaskArgs where
 killTaskTool :: GrokSession -> Maybe MultiAgentContext -> AppTool
 killTaskTool session multi = jsonTool "kill_task" killTaskDescription
     [ PropertySchema "task_id" PropertyString True $ Just
-        "The task ID from a background `run_terminal_cmd` call or the subagent ID from `task`."
+        "The id returned by a background command or subagent."
     ]
     False
     TurnSequential

--- a/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Tools.hs
+++ b/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Tools.hs
@@ -56,12 +56,12 @@ grokTools
 grokTools session ghci planMode multi typesRef =
     let env = session.grokEnv
         base =
-            [ readFileTool env
+            [ runGhciTool ghci
+            , readFileTool env
             , grepTool env
             , listDirTool env
             , searchReplaceTool env planMode
             , runTerminalCmdTool session
-            , runGhciTool ghci
             , todoWriteTool session
             , getTaskOutputTool session multi
             , waitTasksTool session multi


### PR DESCRIPTION
## Summary

- make `run_ghci` the first/default execution and scripting tool
- disable provider shell tools by default and expose them with `--bash`
- add default-on `--ghci` / `--no-ghci` so bash-only operation is available with `--no-ghci --bash`
- propagate both settings through root agents, subagents, and managed persisted session turns
- keep system prompts and registered tool schemas aligned for all three modes
- add a repeatable three-way behavioral eval for GHCi-only, bash-only, and combined configurations

## Eval

Ran the deterministic three-task suite with OpenAI `gpt-5.6-sol`, low effort, and a 60-second first-attempt timeout.

First-attempt pass rates:

| mode | passed |
|---|---:|
| GHCi only | 3/3 |
| Bash only | 1/3 |
| GHCi + bash | 2/3 |

Using the successful retry for the combined tree-audit task, the modes that completed all three tasks compared as follows:

| mode | wall time | input tokens | output tokens |
|---|---:|---:|---:|
| GHCi only | 106.56 s | 161,932 | 2,889 |
| GHCi + bash | 111.07 s | 179,812 | 3,230 |

GHCi-only used 4.1% less wall time, 9.9% fewer input tokens, and 10.6% fewer output tokens in this small sample. Bash-only timed out twice on the tree-audit task, including a 120-second retry. Full methodology and caveats are in `docs/evals/ghci-vs-bash.md`.

## Validation

- CLI parsing: 19 examples, 0 failures
- prompt/tool consistency: 8 examples, 0 failures
- managed session propagation: 12 examples, 0 failures
- Codex tools: 26 examples, 0 failures
- Grok tools: 37 examples, 0 failures
- built `agent-cli:exe:agent-cli`
- built `agent-cli:exe:eval-ghci-vs-bash`
- live tmux `--help` smoke test
- timeout fixture verified cleanup of a separately grouped descendant process
- `git diff --check`
