### PR TITLE
Fix nested and streamed Markdown rendering

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Markdown.hs
+++ b/packages/agent-cli/src/Agent/CLI/Markdown.hs
@@ -17,10 +17,24 @@ import Agent.CLI.Style
     , solarizedYellow
     , styleBase
     )
-import Control.Applicative ((<|>))
-import Data.Char (isAlphaNum, isDigit, isSpace)
+import Agent.TUI.FencedCode
+    ( FenceChunk(..)
+    , FencedBlock(..)
+    , fenceChunks
+    )
+import Agent.TUI.Markdown.Inline
+    ( Inline(..)
+    , inlinePlainText
+    , parseInline
+    )
+import Agent.TUI.TextWidth
+    ( displayCharCellWidth
+    , displayTerminalText
+    )
+import Data.Char (isAlphaNum, isAscii, isDigit, isSpace)
 import Data.Colour (Colour)
 import Data.List (transpose)
+import Data.Maybe (fromMaybe, isJust, mapMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import System.Console.ANSI
@@ -36,15 +50,38 @@ import System.Console.ANSI
 renderMarkdown :: Bool -> Text -> Text
 renderMarkdown color text
     | not color = text
-    | otherwise =
-        let cleaned = Text.filter (/= '\ESC') text
-            endsWithNewline = Text.isSuffixOf "\n" cleaned
-            lines_ = Text.splitOn "\n" cleaned
-            linesForParse
-                | endsWithNewline && not (null lines_) = init lines_
-                | otherwise = lines_
-            rendered = Text.intercalate "\n" (renderBlocks linesForParse)
-        in if endsWithNewline then rendered <> "\n" else rendered
+    | otherwise = Text.concat (map renderChunk (fenceChunks cleaned))
+  where
+    cleaned = displayTerminalText text
+    renderChunk (FenceText prose) = renderProse prose
+    renderChunk (FenceBlock block) =
+        let header
+                | Text.null block.fencedInfo = ""
+                | otherwise = md [fg solarizedCyan] block.fencedInfo <> "\n"
+            body = renderFenceBody block.fencedBody
+        in header <> body
+
+renderProse :: Text -> Text
+renderProse text =
+    let endsWithNewline = Text.isSuffixOf "\n" text
+        lines_ = Text.splitOn "\n" text
+        linesForParse
+            | endsWithNewline && not (null lines_) = init lines_
+            | otherwise = lines_
+        rendered = Text.intercalate "\n" (renderBlocks linesForParse)
+    in if endsWithNewline then rendered <> "\n" else rendered
+
+renderFenceBody :: Text -> Text
+renderFenceBody body =
+    let endsWithNewline = Text.isSuffixOf "\n" body
+        lines_ = Text.splitOn "\n" body
+        actualLines
+            | endsWithNewline && not (null lines_) = init lines_
+            | otherwise = lines_
+        rendered =
+            Text.intercalate "\n"
+                (map (md [fg solarizedBase01]) actualLines)
+    in if endsWithNewline then rendered <> "\n" else rendered
 
 -- | Style helper that keeps the agent line wash across nested SGR.
 md :: [SGR] -> Text -> Text
@@ -55,20 +92,12 @@ renderBlocks = go
   where
     go [] = []
     go (line : rest)
-        | Just (marker, info) <- fenceOpen line =
-            let (body, after) = takeFenceBody marker rest
-                header =
-                    if Text.null info
-                        then []
-                        else
-                            [ md [fg solarizedCyan] info ]
-                styledBody = map (md [fg solarizedBase01]) body
-            in header ++ styledBody ++ go after
         | Just (styled, after) <- takeTable (line : rest) =
             styled ++ go after
         | Just (level, title) <- headingLine line =
             -- Hide the markdown `#` markers (grok pretty mode); color the title.
-            md (headingPrefixStyle level) (styleInline title) : go rest
+            renderInlineWith (headingPrefixStyle level) (parseInline title)
+                : go rest
         | Just (indent, item) <- unorderedItemParts line =
             ( indent
                 <> md listMarkerStyle "• "
@@ -82,9 +111,7 @@ renderBlocks = go
             )
                 : go rest
         | Just quote <- blockQuote line =
-            let body
-                    | Text.any (`elem` ['`', '*', '_', '[']) quote = styleInline quote
-                    | otherwise = md quoteStyle quote
+            let body = renderInlineWith quoteStyle (parseInline quote)
             in (md [fg solarizedBase01] "│ " <> body)
                 : go rest
         | isThematicBreak line =
@@ -119,38 +146,6 @@ fg = SetRGBColor Foreground
 -- | Blockquote body: muted so it sits behind surrounding prose.
 quoteStyle :: [SGR]
 quoteStyle = [fg solarizedBase01]
-
-data FenceMarker = BacktickFence !Int | TildeFence !Int
-
-fenceOpen :: Text -> Maybe (FenceMarker, Text)
-fenceOpen line =
-    let stripped = Text.stripStart line
-        tryFence char ctor =
-            let (run, after) = Text.span (== char) stripped
-                n = Text.length run
-            in if n >= 3
-                then Just (ctor n, Text.strip after)
-                else Nothing
-    in tryFence '`' BacktickFence <|> tryFence '~' TildeFence
-
-takeFenceBody :: FenceMarker -> [Text] -> ([Text], [Text])
-takeFenceBody marker = go
-  where
-    go [] = ([], [])
-    go (line : rest)
-        | isFenceClose marker line = ([], rest)
-        | otherwise =
-            let (body, after) = go rest
-            in (line : body, after)
-
-isFenceClose :: FenceMarker -> Text -> Bool
-isFenceClose marker line =
-    let stripped = Text.strip line
-        (char, need) = case marker of
-            BacktickFence n -> ('`', n)
-            TildeFence n -> ('~', n)
-        (run, after) = Text.span (== char) stripped
-    in Text.length run >= need && Text.null (Text.strip after)
 
 headingLine :: Text -> Maybe (Int, Text)
 headingLine line =
@@ -204,11 +199,12 @@ isThematicBreak line =
 
 takeTable :: [Text] -> Maybe ([Text], [Text])
 takeTable (header : sep : rest)
-    | isTableRow header
-    , isSeparatorRow sep =
+    | Just headerCells <- splitTableRow header
+    , Just separatorCells <- splitTableRow sep
+    , length separatorCells == length headerCells
+    , all isSeparatorCell separatorCells =
         let (body, after) = span isTableRow rest
-            headerCells = splitRow header
-            bodyCells = map splitRow body
+            bodyCells = mapMaybe splitTableRow body
             rows = headerCells : bodyCells
             widths = columnWidths rows
             top = md [fg solarizedBase01] (boxLine '┌' '┬' '┐' '─' widths)
@@ -228,95 +224,173 @@ boxLine left mid right fill widths =
         <> Text.singleton right
 
 isTableRow :: Text -> Bool
-isTableRow line =
-    let stripped = Text.strip line
-    in Text.isPrefixOf "|" stripped && Text.count "|" stripped >= 2
+isTableRow = isJust . splitTableRow
 
-isSeparatorRow :: Text -> Bool
-isSeparatorRow line =
-    isTableRow line && all isSepCell (splitRow line)
+isSeparatorCell :: Text -> Bool
+isSeparatorCell cell =
+    Text.any (== '-') cell
+        && Text.null (Text.filter (`notElem` ['-', ':', ' ']) cell)
+
+-- | Split on actual table delimiters, preserving escaped pipes and pipes
+-- inside matching backtick spans.
+splitTableRow :: Text -> Maybe [Text]
+splitTableRow raw =
+    let stripped = Text.strip raw
+        content = fromMaybe stripped (Text.stripPrefix "|" stripped)
+        (cells, delimiterCount) = scan Nothing [] [] 0 False
+            (Text.unpack content)
+    in if delimiterCount >= 1 then Just cells else Nothing
   where
-    isSepCell cell =
-        let t = Text.filter (`notElem` ['-', ':', ' ']) cell
-        in Text.null t && Text.any (== '-') cell
+    scan
+        :: Maybe Int
+        -> String
+        -> [Text]
+        -> Int
+        -> Bool
+        -> String
+        -> ([Text], Int)
+    scan _ current cells delimiterCount trailingDelimiter [] =
+        let allCells = reverse (finishCell current : cells)
+            withoutOuterBorder
+                | trailingDelimiter = dropLast allCells
+                | otherwise = allCells
+        in (withoutOuterBorder, delimiterCount)
+    scan codeRun current cells delimiterCount _ ('\\' : rest) =
+        let (slashes, afterSlashes) = span (== '\\') rest
+            slashCount = 1 + length slashes
+            literalSlashes =
+                replicate
+                    (if startsWithPipe afterSlashes
+                        then slashCount `div` 2
+                        else slashCount)
+                    '\\'
+            current' = literalSlashes <> current
+        in case afterSlashes of
+            '|' : afterPipe
+                | odd slashCount ->
+                    scan codeRun ('|' : current') cells
+                        delimiterCount False afterPipe
+                | codeRun == Nothing ->
+                    splitCell codeRun current' cells delimiterCount afterPipe
+            _ ->
+                scan codeRun current' cells
+                    delimiterCount False afterSlashes
+    scan codeRun current cells delimiterCount _ ('`' : rest) =
+        let (ticks, afterTicks) = span (== '`') rest
+            tickCount = 1 + length ticks
+            marker = replicate tickCount '`'
+            nextCodeRun = case codeRun of
+                Just openCount
+                    | tickCount >= openCount -> Nothing
+                Just openCount -> Just openCount
+                Nothing
+                    | hasClosingRun tickCount afterTicks -> Just tickCount
+                Nothing -> Nothing
+        in scan nextCodeRun (marker <> current) cells
+            delimiterCount False afterTicks
+    scan Nothing current cells delimiterCount _ ('|' : rest) =
+        splitCell Nothing current cells delimiterCount rest
+    scan codeRun current cells delimiterCount _ (character : rest) =
+        scan codeRun (character : current) cells
+            delimiterCount False rest
 
-splitRow :: Text -> [Text]
-splitRow line =
-    let stripped = Text.strip line
-        trimmed =
-            Text.dropWhile (== '|')
-                (Text.dropWhileEnd (== '|') stripped)
-    in map Text.strip (Text.splitOn "|" trimmed)
+    splitCell codeRun current cells delimiterCount rest =
+        scan codeRun [] (finishCell current : cells)
+            (delimiterCount + 1) True rest
+
+    finishCell = Text.strip . Text.pack . reverse
+    startsWithPipe ('|' : _) = True
+    startsWithPipe _ = False
+    hasClosingRun count =
+        Text.isInfixOf (Text.replicate count "`") . Text.pack
+    dropLast values = case reverse values of
+        _ : rest -> reverse rest
+        [] -> []
 
 columnWidths :: [[Text]] -> [Int]
 columnWidths rows =
     let cols = transpose rows
-    in map (maximum . (0 :) . map (Text.length . visibleCellText)) cols
-
--- | Approximate rendered cell text width by stripping common inline markers
--- before padding, so borders align when body cells contain ``code`` / emphasis.
-visibleCellText :: Text -> Text
-visibleCellText = Text.replace "`" "" . Text.replace "**" "" . Text.replace "__" ""
-    . Text.replace "*" "" . Text.replace "_" ""
+    in map (maximum . (0 :) . map renderedWidth) cols
+  where
+    renderedWidth =
+        Text.foldl'
+            (\width character -> width + displayCharCellWidth character)
+            0
+            . inlinePlainText
+            . parseInline
 
 styleTableRow :: Bool -> [Int] -> [Text] -> Text
 styleTableRow isHeader widths cells =
     let cellText w c =
-            let visible = visibleCellText c
-                pad = max 0 (w - Text.length visible)
-                body = " " <> visible <> Text.replicate pad " " <> " "
-            in if isHeader
-                then md [SetConsoleIntensity BoldIntensity] body
-                else
-                    -- Markers were stripped for width; re-apply inline styling
-                    -- only for bare visible text (no markers left to parse).
-                    md [] body
+            let inlines = parseInline c
+                visible = inlinePlainText inlines
+                width' =
+                    Text.foldl'
+                        (\total character ->
+                            total + displayCharCellWidth character)
+                        0
+                        visible
+                padding = max 0 (w - width')
+                base
+                    | isHeader = [SetConsoleIntensity BoldIntensity]
+                    | otherwise = []
+            in " "
+                <> renderInlineWith base inlines
+                <> Text.replicate padding " "
+                <> " "
         parts = zipWith cellText widths (cells ++ repeat "")
         bar = md [fg solarizedBase01] "│"
     in bar <> Text.intercalate bar (take (length widths) parts) <> bar
 
 styleInline :: Text -> Text
-styleInline = renderMarkdownFragment True Nothing
+styleInline = renderInlineWith [] . parseInline
 
 -- | Render an inline markdown fragment whose first character may continue
 -- prose emitted by an earlier streaming chunk.
 renderMarkdownFragment :: Bool -> Maybe Char -> Text -> Text
 renderMarkdownFragment color prevChar text
     | not color = text
-    | otherwise = Text.concat (go prevChar (Text.filter (/= '\ESC') text))
+    | otherwise =
+        renderInlineWith [] $
+            parseInline $
+                protectLeadingUnderscore prevChar (displayTerminalText text)
   where
-    go :: Maybe Char -> Text -> [Text]
-    go prev t
-        | Text.null t = []
-        | Just (code, rest) <- takeInlineCode t =
-            md codeStyle code : go (Text.unsnoc code >>= Just . snd) rest
-        | Just (linkText, url, rest) <- takeLink t =
-            let label = md linkStyle (styleInline linkText)
-            in osc8Link True url label
-                : md urlStyle (" (" <> url <> ")")
-                : go (Just ')') rest
-        | Just (inner, rest) <- takeEmphasis prev "**" t =
-            md [SetConsoleIntensity BoldIntensity] (styleInline inner)
-                : go (Text.unsnoc inner >>= Just . snd) rest
-        | Just (inner, rest) <- takeEmphasis prev "__" t =
-            md [SetConsoleIntensity BoldIntensity] (styleInline inner)
-                : go (Text.unsnoc inner >>= Just . snd) rest
-        | Just (inner, rest) <- takeEmphasis prev "*" t =
-            md [SetItalicized True] (styleInline inner)
-                : go (Text.unsnoc inner >>= Just . snd) rest
-        | Just (inner, rest) <- takeEmphasis prev "_" t =
-            md [SetItalicized True] (styleInline inner)
-                : go (Text.unsnoc inner >>= Just . snd) rest
-        | otherwise =
-            let (plain, rest) = Text.break (`elem` ['`', '[', '*', '_']) t
-            in if Text.null plain
-                then
-                    let c = Text.take 1 t
-                        rest' = Text.drop 1 t
-                    in c : go (Text.uncons c >>= Just . fst) rest'
-                else
-                    plain
-                        : go (Text.unsnoc plain >>= Just . snd) rest
+    protectLeadingUnderscore previous input
+        | maybe False isWordChar previous
+        , Text.isPrefixOf "_" input =
+            "\\" <> input
+        | otherwise = input
+
+renderInlineWith :: [SGR] -> [Inline] -> Text
+renderInlineWith base = Text.concat . map (go base)
+  where
+    go context = \case
+        InlineText text -> styled context text
+        InlineCode text -> styled (context <> codeStyle) text
+        InlineStrong children ->
+            renderInlineWith
+                (context <> [SetConsoleIntensity BoldIntensity])
+                children
+        InlineEmphasis children ->
+            renderInlineWith (context <> [SetItalicized True]) children
+        InlineLink url children ->
+            let label =
+                    renderInlineWith (context <> linkStyle) children
+                linked
+                    | safeUrl url = osc8Link True url label
+                    | otherwise = label
+                suffix
+                    | Text.null url || inlinePlainText children == url = ""
+                    | otherwise =
+                        styled (context <> urlStyle) (" (" <> url <> ")")
+            in linked <> suffix
+
+    styled [] value = value
+    styled styles value = md styles value
+
+    safeUrl url =
+        not (Text.null url)
+            && displayTerminalText url == url
 
     codeStyle =
         [ SetConsoleIntensity BoldIntensity
@@ -340,6 +414,8 @@ splitMarkdownFragment initialPrev = go initialPrev []
   where
     go prev chunks t
         | Text.null t = (Text.concat (reverse chunks), "", prev)
+        | Just (escaped, rest) <- takeEscapedPunctuation t =
+            consume (Just escaped) rest
         | Just (code, rest) <- takeInlineCode t =
             consume (lastChar code) rest
         | Just (_linkText, _url, rest) <- takeLink t =
@@ -355,7 +431,8 @@ splitMarkdownFragment initialPrev = go initialPrev []
         | shouldWait prev t =
             (Text.concat (reverse chunks), t, prev)
         | otherwise =
-            let (plain, rest) = Text.break (`elem` ['`', '[', '*', '_']) t
+            let (plain, rest) =
+                    Text.break (`elem` ['\\', '`', '[', '*', '_']) t
             in if Text.null plain
                 then
                     let literal = Text.take 1 t
@@ -369,6 +446,7 @@ splitMarkdownFragment initialPrev = go initialPrev []
 
     shouldWait prev t
         | Text.any (== '\n') t = False
+        | t == "\\" = True
         | Text.isPrefixOf "`" t = True
         | Text.isPrefixOf "[" t = incompleteLink t
         | Text.isPrefixOf "**" t = potentialEmphasis prev "**" t
@@ -378,13 +456,13 @@ splitMarkdownFragment initialPrev = go initialPrev []
         | otherwise = False
 
     incompleteLink t =
-        case Text.breakOn "]" (Text.drop 1 t) of
-            (_, rest) | Text.null rest -> True
-            (_, rest) ->
-                let afterBracket = Text.drop 1 rest
-                in Text.null afterBracket
-                    || (Text.isPrefixOf "(" afterBracket
-                        && not (")" `Text.isInfixOf` Text.drop 1 afterBracket))
+        case linkLabelEnd (Text.drop 1 t) of
+            Nothing -> True
+            Just afterBracket ->
+                Text.null afterBracket
+                    || case Text.stripPrefix "(" afterBracket of
+                        Nothing -> False
+                        Just destination -> destinationEnd destination == Nothing
 
     potentialEmphasis prev delim t =
         let after = Text.drop (Text.length delim) t
@@ -397,6 +475,17 @@ splitMarkdownFragment initialPrev = go initialPrev []
                 | otherwise -> True
 
     lastChar value = snd <$> Text.unsnoc value
+
+takeEscapedPunctuation :: Text -> Maybe (Char, Text)
+takeEscapedPunctuation text = do
+    afterSlash <- Text.stripPrefix "\\" text
+    (character, rest) <- Text.uncons afterSlash
+    if isAscii character
+        && character >= '!'
+        && character <= '~'
+        && not (isAlphaNum character)
+        then Just (character, rest)
+        else Nothing
 
 takeInlineCode :: Text -> Maybe (Text, Text)
 takeInlineCode t =
@@ -419,18 +508,66 @@ takeInlineCode t =
 takeLink :: Text -> Maybe (Text, Text, Text)
 takeLink t = do
     afterBracket <- Text.stripPrefix "[" t
-    case Text.breakOn "]" afterBracket of
-        (linkText, rest0)
-            | not (Text.null linkText)
-            , Just afterBracketClose <- Text.stripPrefix "]" rest0
-            , Just afterParen <- Text.stripPrefix "(" afterBracketClose ->
-                case Text.breakOn ")" afterParen of
-                    (url, rest1)
-                        | not (Text.null url)
-                        , Just rest <- Text.stripPrefix ")" rest1 ->
-                            Just (linkText, url, rest)
-                    _ -> Nothing
-            | otherwise -> Nothing
+    (linkText, afterBracketClose) <- takeLinkLabel afterBracket
+    afterParen <- Text.stripPrefix "(" afterBracketClose
+    (url, rest) <- takeLinkDestination afterParen
+    if Text.null linkText || Text.null url
+        then Nothing
+        else Just (linkText, url, rest)
+
+linkLabelEnd :: Text -> Maybe Text
+linkLabelEnd = fmap snd . takeLinkLabel
+
+takeLinkLabel :: Text -> Maybe (Text, Text)
+takeLinkLabel = go 0 ""
+  where
+    go :: Int -> Text -> Text -> Maybe (Text, Text)
+    go depth consumed remaining =
+        case Text.uncons remaining of
+            Nothing -> Nothing
+            Just ('\n', _) -> Nothing
+            Just ('\\', afterSlash) ->
+                case Text.uncons afterSlash of
+                    Nothing -> Nothing
+                    Just (escaped, rest) ->
+                        go depth
+                            (consumed <> Text.pack ['\\', escaped])
+                            rest
+            Just ('[', rest) ->
+                go (depth + 1) (consumed <> "[") rest
+            Just (']', rest)
+                | depth == 0 -> Just (consumed, rest)
+                | otherwise ->
+                    go (depth - 1) (consumed <> "]") rest
+            Just (character, rest) ->
+                go depth (consumed <> Text.singleton character) rest
+
+destinationEnd :: Text -> Maybe Text
+destinationEnd = fmap snd . takeLinkDestination
+
+takeLinkDestination :: Text -> Maybe (Text, Text)
+takeLinkDestination = go 0 ""
+  where
+    go :: Int -> Text -> Text -> Maybe (Text, Text)
+    go depth consumed remaining =
+        case Text.uncons remaining of
+            Nothing -> Nothing
+            Just ('\n', _) -> Nothing
+            Just ('\\', afterSlash) ->
+                case Text.uncons afterSlash of
+                    Nothing -> Nothing
+                    Just (escaped, rest) ->
+                        go depth
+                            (consumed <> Text.pack ['\\', escaped])
+                            rest
+            Just ('(', rest) ->
+                go (depth + 1) (consumed <> "(") rest
+            Just (')', rest)
+                | depth == 0 -> Just (consumed, rest)
+                | otherwise ->
+                    go (depth - 1) (consumed <> ")") rest
+            Just (character, rest) ->
+                go depth (consumed <> Text.singleton character) rest
 
 takeEmphasis :: Maybe Char -> Text -> Text -> Maybe (Text, Text)
 takeEmphasis prevChar delim t

--- a/packages/agent-cli/src/Agent/CLI/Render.hs
+++ b/packages/agent-cli/src/Agent/CLI/Render.hs
@@ -31,6 +31,11 @@ import Agent.CLI.Markdown
     , renderMarkdownFragment
     , splitMarkdownFragment
     )
+import Agent.TUI.FencedCode
+    ( FenceMarker
+    , fenceOpener
+    , isFenceCloser
+    )
 import Agent.CLI.Progress
     ( osc9ProgressIndeterminate
     , osc9ProgressRemove
@@ -93,6 +98,7 @@ import Control.Concurrent (ThreadId, forkIO, killThread, threadDelay)
 import Control.Concurrent.MVar (MVar, withMVar)
 import Control.Exception.Safe (tryIO)
 import Control.Monad (unless, void, when)
+import Data.Char (isDigit, isSpace)
 import Data.IORef
 import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe, isJust)
@@ -138,10 +144,317 @@ data RenderConfig = RenderConfig
 data MarkdownStreamState = MarkdownStreamState
     { pending :: !Text
     , context :: !(Maybe Char)
+    , streamMode :: !MarkdownStreamMode
+    , blockPending :: !Text
     }
 
+data MarkdownStreamMode
+    = StreamLineStart
+    | StreamProse
+    | StreamFence !FenceMarker
+    | StreamTableCandidate
+    | StreamTable
+
 emptyMarkdownStreamState :: MarkdownStreamState
-emptyMarkdownStreamState = MarkdownStreamState "" Nothing
+emptyMarkdownStreamState =
+    MarkdownStreamState "" Nothing StreamLineStart ""
+
+feedMarkdownStream
+    :: MarkdownStreamState
+    -> Text
+    -> (MarkdownStreamState, Text)
+feedMarkdownStream state input = case state.streamMode of
+    StreamLineStart -> feedLineStart state input
+    StreamProse -> feedProse state input
+    StreamFence marker -> feedFence marker state input
+    StreamTableCandidate -> feedTableCandidate state input
+    StreamTable -> feedTable state input
+
+feedLineStart
+    :: MarkdownStreamState
+    -> Text
+    -> (MarkdownStreamState, Text)
+feedLineStart state input =
+    let buffered = state.blockPending <> input
+    in case takeCompleteLine buffered of
+        Just (line, rest) ->
+            classifyCompleteLine state{blockPending = ""} line rest
+        Nothing
+            | lineNeedsLookahead buffered ->
+                (state{blockPending = buffered}, "")
+            | otherwise ->
+                feedProse
+                    state
+                        { streamMode = StreamProse
+                        , blockPending = ""
+                        }
+                    buffered
+
+classifyCompleteLine
+    :: MarkdownStreamState
+    -> Text
+    -> Text
+    -> (MarkdownStreamState, Text)
+classifyCompleteLine state line rest
+    | Just (marker, _) <- fenceOpener (dropLineEnding line) =
+        feedMarkdownStream
+            state
+                { streamMode = StreamFence marker
+                , blockPending = line
+                }
+            rest
+    | isPossibleTableHeader line =
+        feedMarkdownStream
+            state
+                { streamMode = StreamTableCandidate
+                , blockPending = line
+                }
+            rest
+    | lineIsBlock line =
+        let (nextState, output) =
+                feedMarkdownStream
+                    state
+                        { streamMode = StreamLineStart
+                        , blockPending = ""
+                        }
+                    rest
+        in (nextState, renderMarkdown True line <> output)
+    | otherwise =
+        feedProse
+            state
+                { streamMode = StreamProse
+                , blockPending = ""
+                }
+            (line <> rest)
+
+feedProse
+    :: MarkdownStreamState
+    -> Text
+    -> (MarkdownStreamState, Text)
+feedProse state input =
+    case Text.breakOn "\n" input of
+        (linePart, rest)
+            | Text.null rest ->
+                let source = state.pending <> linePart
+                    (ready, pending', nextContext) =
+                        splitMarkdownFragment state.context source
+                in ( state
+                        { pending = pending'
+                        , context = nextContext
+                        , streamMode = StreamProse
+                        }
+                   , renderMarkdownFragment True state.context ready
+                   )
+            | otherwise ->
+                let source = state.pending <> linePart <> "\n"
+                    (ready, pending', _) =
+                        splitMarkdownFragment state.context source
+                    rendered =
+                        renderMarkdownFragment True state.context
+                            (ready <> pending')
+                    reset =
+                        state
+                            { pending = ""
+                            , context = Nothing
+                            , streamMode = StreamLineStart
+                            , blockPending = ""
+                            }
+                    (nextState, following) =
+                        feedMarkdownStream reset (Text.drop 1 rest)
+                in (nextState, rendered <> following)
+
+feedFence
+    :: FenceMarker
+    -> MarkdownStreamState
+    -> Text
+    -> (MarkdownStreamState, Text)
+feedFence marker state input =
+    let buffered = state.blockPending <> input
+        (lines_, partial) = completeLines buffered
+        (beforeCloser, closingAndAfter) =
+            break (isFenceCloser marker . dropLineEnding) (drop 1 lines_)
+    in case closingAndAfter of
+        [] -> (state{blockPending = buffered}, "")
+        closing : after ->
+            let block = Text.concat (take 1 lines_ <> beforeCloser <> [closing])
+                rest = Text.concat after <> partial
+                reset =
+                    state
+                        { streamMode = StreamLineStart
+                        , blockPending = ""
+                        , pending = ""
+                        , context = Nothing
+                        }
+                (nextState, following) = feedMarkdownStream reset rest
+            in (nextState, renderMarkdown True block <> following)
+
+feedTableCandidate
+    :: MarkdownStreamState
+    -> Text
+    -> (MarkdownStreamState, Text)
+feedTableCandidate state input =
+    let buffered = state.blockPending <> input
+        (lines_, partial) = completeLines buffered
+    in case lines_ of
+        header : separator : after
+            | isTableSeparator separator ->
+                feedMarkdownStream
+                    state
+                        { streamMode = StreamTable
+                        , blockPending = header <> separator
+                        }
+                    (Text.concat after <> partial)
+            | otherwise ->
+                let reset =
+                        state
+                            { streamMode = StreamLineStart
+                            , blockPending = ""
+                            }
+                    (nextState, following) =
+                        feedMarkdownStream reset
+                            (separator <> Text.concat after <> partial)
+                in (nextState, renderMarkdown True header <> following)
+        _ -> (state{blockPending = buffered}, "")
+
+feedTable
+    :: MarkdownStreamState
+    -> Text
+    -> (MarkdownStreamState, Text)
+feedTable state input =
+    let buffered = state.blockPending <> input
+        (lines_, partial) = completeLines buffered
+        (tableLines, after) =
+            case lines_ of
+                header : separator : rows ->
+                    let (body, following) =
+                            span isPossibleTableHeader rows
+                    in (header : separator : body, following)
+                _ -> (lines_, [])
+    in case after of
+        [] -> (state{blockPending = buffered}, "")
+        line : rest ->
+                let table = Text.concat tableLines
+                    reset =
+                        state
+                            { streamMode = StreamLineStart
+                            , blockPending = ""
+                            }
+                    (nextState, following) =
+                        feedMarkdownStream reset
+                            (line <> Text.concat rest <> partial)
+                in (nextState, renderMarkdown True table <> following)
+
+flushMarkdownStream :: MarkdownStreamState -> Text
+flushMarkdownStream state = case state.streamMode of
+    StreamProse ->
+        renderMarkdownFragment True state.context state.pending
+    StreamLineStart ->
+        renderMarkdown True state.blockPending
+    StreamFence _ ->
+        renderMarkdown True state.blockPending
+    StreamTableCandidate ->
+        renderMarkdown True state.blockPending
+    StreamTable ->
+        renderMarkdown True state.blockPending
+
+takeCompleteLine :: Text -> Maybe (Text, Text)
+takeCompleteLine text =
+    case Text.breakOn "\n" text of
+        (_, rest) | Text.null rest -> Nothing
+        (line, rest) -> Just (line <> "\n", Text.drop 1 rest)
+
+completeLines :: Text -> ([Text], Text)
+completeLines = go []
+  where
+    go reversed remaining =
+        case takeCompleteLine remaining of
+            Nothing -> (reverse reversed, remaining)
+            Just (line, rest) -> go (line : reversed) rest
+
+dropLineEnding :: Text -> Text
+dropLineEnding = Text.dropWhileEnd (== '\n')
+
+lineNeedsLookahead :: Text -> Bool
+lineNeedsLookahead line =
+    let stripped = Text.dropWhile isSpace line
+        markerRun marker = Text.span (== marker) stripped
+        allMarkerOrSpace marker =
+            Text.all (\character -> character == marker || isSpace character)
+                stripped
+    in case Text.uncons stripped of
+        Nothing -> True
+        Just ('#', _) ->
+            let (marks, after) = markerRun '#'
+            in Text.length marks <= 6
+                && (Text.null after || Text.isPrefixOf " " after)
+        Just ('>', _) -> True
+        Just ('|', _) -> True
+        Just ('`', _) ->
+            let (ticks, after) = markerRun '`'
+            in Text.null after || Text.length ticks >= 3
+        Just ('~', _) ->
+            let (tildes, after) = markerRun '~'
+            in Text.null after || Text.length tildes >= 3
+        Just ('+', after) -> Text.null after || Text.isPrefixOf " " after
+        Just ('*', after) ->
+            Text.null after
+                || Text.isPrefixOf " " after
+                || allMarkerOrSpace '*'
+        Just ('-', after) ->
+            Text.null after
+                || Text.isPrefixOf " " after
+                || allMarkerOrSpace '-'
+        Just ('_', _) -> allMarkerOrSpace '_'
+        Just (character, _)
+            | isDigit character ->
+                let (digits, after) = Text.span isDigit stripped
+                in not (Text.null digits)
+                    && ( Text.null after
+                        || after == "."
+                        || Text.isPrefixOf ". " after
+                       )
+        _ -> False
+
+lineIsBlock :: Text -> Bool
+lineIsBlock line =
+    let stripped = Text.dropWhile isSpace (dropLineEnding line)
+        (marks, afterHeading) = Text.span (== '#') stripped
+        heading =
+            not (Text.null marks)
+                && Text.length marks <= 6
+                && Text.isPrefixOf " " afterHeading
+        quote = Text.isPrefixOf ">" stripped
+        bullet = any (`Text.isPrefixOf` stripped) ["- ", "* ", "+ "]
+        (digits, orderedRest) = Text.span isDigit stripped
+        ordered =
+            not (Text.null digits) && Text.isPrefixOf ". " orderedRest
+        thematic marker =
+            let compact = Text.filter (not . isSpace) stripped
+            in Text.length compact >= 3 && Text.all (== marker) compact
+    in heading
+        || quote
+        || bullet
+        || ordered
+        || thematic '-'
+        || thematic '*'
+        || thematic '_'
+
+isPossibleTableHeader :: Text -> Bool
+isPossibleTableHeader =
+    Text.isPrefixOf "|" . Text.dropWhile isSpace . dropLineEnding
+
+isTableSeparator :: Text -> Bool
+isTableSeparator line =
+    let stripped =
+            Text.dropWhile (== '|')
+                (Text.dropWhileEnd (== '|')
+                    (Text.strip (dropLineEnding line)))
+        cells = map Text.strip (Text.splitOn "|" stripped)
+        valid cell =
+            Text.any (== '-') cell
+                && Text.null
+                    (Text.filter (`notElem` ['-', ':', ' ']) cell)
+    in length cells >= 1 && all valid cells
 
 -- | Grok-build @max_thoughts_width@: wrap reasoning display at this column.
 thinkingMaxWidth :: Int
@@ -223,9 +536,10 @@ renderAssistantText :: Bool -> Text -> Text
 renderAssistantText color text =
     paintBackgroundLines color agentBackground (renderMarkdown color text)
 
--- | Stream assistant text append-only while buffering incomplete inline
--- markdown constructs. Once a closing delimiter arrives, the whole construct
--- is emitted with styling and neither delimiter reaches the terminal.
+-- | Stream assistant text append-only. Ordinary prose is emitted as soon as
+-- incomplete inline constructs permit, while line prefixes that may introduce
+-- blocks are held until they can be classified. Fences and tables are buffered
+-- until their extent is known, so no raw markers need to be repainted.
 --
 -- Repainting the full accumulated response with DECSC/DECRC looks correct
 -- inside the current viewport, but once a repaint scrolls the terminal the
@@ -236,18 +550,16 @@ streamAssistantDelta config delta
     | Text.null delta = pure ()
     | otherwise = do
         let safe = Text.filter (/= '\ESC') delta
-        (ready, context) <-
+        ready <-
             atomicModifyIORef' config.renderMarkdownState \state ->
-                let (ready, pending', nextContext) =
-                        splitMarkdownFragment state.context (state.pending <> safe)
-                    state' = MarkdownStreamState pending' nextContext
-                in (state', (ready, state.context))
+                let (state', output) = feedMarkdownStream state safe
+                in (state', output)
         unless (Text.null ready) do
             writeIORef config.renderPrintedText True
             writeIORef config.renderLiveActive True
             Text.hPutStr config.renderStdout
                 ( paintBackgroundLines True agentBackground
-                    (renderMarkdownFragment True context ready)
+                    ready
                 )
             hFlush config.renderStdout
 
@@ -257,30 +569,34 @@ streamAssistantDelta config delta
 -- Returns whether anything was written.
 finalizeAssistantBuffer :: RenderConfig -> Maybe Text -> IO Bool
 finalizeAssistantBuffer config assistantText = do
-    (pending, context) <-
+    pendingOutput <-
         atomicModifyIORef' config.renderMarkdownState \state ->
-            (emptyMarkdownStreamState, (state.pending, state.context))
+            (emptyMarkdownStreamState, flushMarkdownStream state)
     live <- readIORef config.renderLiveActive
     writeIORef config.renderLiveActive False
     if live
         then do
             writeIORef config.renderPrintedText True
-            unless (Text.null pending) do
+            unless (Text.null pendingOutput) do
                 Text.hPutStr config.renderStdout
                     ( paintBackgroundLines True agentBackground
-                        (renderMarkdownFragment True context pending)
+                        pendingOutput
                     )
                 hFlush config.renderStdout
             pure True
         else do
             let raw
-                    | not (Text.null pending) = pending
+                    | not (Text.null pendingOutput) = pendingOutput
                     | otherwise = fromMaybe "" assistantText
             if Text.null raw
                 then pure False
                 else do
                     writeIORef config.renderPrintedText True
-                    Text.hPutStr config.renderStdout (renderAssistantText True raw)
+                    Text.hPutStr config.renderStdout $
+                        if Text.null pendingOutput
+                            then renderAssistantText True raw
+                            else paintBackgroundLines
+                                True agentBackground pendingOutput
                     hFlush config.renderStdout
                     pure True
 

--- a/packages/agent-cli/test/Agent/CLI/MarkdownSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/MarkdownSpec.hs
@@ -104,6 +104,38 @@ spec = do
             out `shouldSatisfy` Text.isInfixOf "Render.hs"
             out `shouldSatisfy` (not . Text.isInfixOf "`Render.hs`")
 
+        it "composes nested inline styles and formatted link labels" do
+            let out =
+                    renderMarkdown True
+                        "**bold and *italic* with `code` and \
+                        \[docs **important**](https://example.com)**"
+            mapM_
+                (\fragment ->
+                    out `shouldSatisfy` Text.isInfixOf fragment)
+                [ "bold and "
+                , "italic"
+                , "code"
+                , "docs "
+                , "important"
+                , " (https://example.com)"
+                ]
+            out `shouldSatisfy` (not . Text.isInfixOf "**")
+            out `shouldSatisfy` (not . Text.isInfixOf "*italic*")
+
+        it "supports escapes and balanced parentheses in link destinations" do
+            let out =
+                    renderMarkdown True
+                        "\\*literal\\* [x](https://example.com/a_(b))"
+            stripAnsi out `shouldSatisfy` Text.isInfixOf "*literal*"
+            out `shouldSatisfy`
+                Text.isInfixOf "https://example.com/a_(b)"
+
+        it "restores heading styling after nested code" do
+            let out = renderMarkdown True "# before `code` after"
+                afterCode = snd (Text.breakOn "code" out)
+            afterCode `shouldSatisfy` Text.isInfixOf "\ESC["
+            stripAnsi out `shouldBe` "before code after"
+
         it "keeps box borders aligned when cells have inline markers" do
             let mdTable = Text.unlines
                     [ "| a | b |"
@@ -126,6 +158,28 @@ spec = do
                 _ ->
                     expectationFailure
                         ("expected exactly two table rows, got " <> show body)
+
+        it "preserves identifiers and styled links in table cells" do
+            let sample =
+                    "| key | value |\n\
+                    \| --- | --- |\n\
+                    \| snake_case | [docs](https://example.com) |"
+                out = renderMarkdown True sample
+                cleaned = stripAnsi out
+            cleaned `shouldSatisfy` Text.isInfixOf "snake_case"
+            cleaned `shouldSatisfy` Text.isInfixOf "docs"
+            out `shouldSatisfy` Text.isInfixOf "https://example.com"
+
+        it "uses strict shared fence rules" do
+            let overIndented =
+                    renderMarkdown True "    ```haskell\nbody\n    ```"
+                invalidInfo =
+                    renderMarkdown True "```bad`info\nbody\n```"
+            overIndented `shouldSatisfy` Text.isInfixOf "```haskell"
+            invalidInfo `shouldSatisfy` Text.isPrefixOf "``"
+            invalidInfo `shouldSatisfy` Text.isInfixOf "bad"
+            invalidInfo `shouldSatisfy` Text.isInfixOf "info"
+            invalidInfo `shouldSatisfy` Text.isInfixOf "body"
 
         it "renders a basic pipe table" do
             let sample = "| file | status |\n| --- | --- |\n| a.hs | ok |"

--- a/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
@@ -18,6 +18,7 @@ import Agent.TUI.Motion (MotionMode(..), foregroundIndicator)
 import Control.Concurrent (forkIO)
 import Control.Concurrent.MVar (newEmptyMVar, newMVar, putMVar, takeMVar)
 import Control.Exception (finally)
+import Control.Monad (forM_)
 import Data.IORef (newIORef, readIORef)
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
@@ -392,6 +393,55 @@ spec = do
                 body <- Text.readFile path
                 body `shouldSatisfy` Text.isInfixOf "**unfinished"
 
+        it "renders streamed block Markdown independently of chunk boundaries" do
+            let samples =
+                    [ "# Heading\n"
+                    , "- one\n  - two\n"
+                    , ">compact **quote**\n"
+                    , "[x **important**](https://example.com/a_(b)) \
+                        \and **bold *italic* `code`**\n"
+                    , "```haskell\nmain = pure ()\n```\n"
+                    , "| Key | Value |\n| --- | --- |\n| snake_case | `code` |\n"
+                    ]
+            forM_ samples \source -> do
+                let expected = stripTerminalControls
+                        (renderAssistantText True source)
+                withRenderConfig False True \config handle path -> do
+                    mapM_
+                        (renderEvent config . TextDelta . Text.singleton)
+                        (Text.unpack source)
+                    renderEvent config (TurnFinished TurnOutput
+                        { responseId = "r1"
+                        , toolCalls = []
+                        , assistantText = Nothing
+                        , tokenUsage = emptyTokenUsage
+                        })
+                    hClose handle
+                    actual <- stripTerminalControls <$> Text.readFile path
+                    actual `shouldBe` expected
+
+        it "does not expose fence or table markers while streaming" do
+            withRenderConfig False True \config handle path -> do
+                mapM_ (renderEvent config . TextDelta)
+                    [ "```haskell\nmain = "
+                    , "pure ()\n```\n"
+                    , "| name | value |\n| --- | --- |\n"
+                    , "| snake_case | **bold** |\n"
+                    ]
+                renderEvent config (TurnFinished TurnOutput
+                    { responseId = "r1"
+                    , toolCalls = []
+                    , assistantText = Nothing
+                    , tokenUsage = emptyTokenUsage
+                    })
+                hClose handle
+                body <- stripTerminalControls <$> Text.readFile path
+                body `shouldSatisfy` Text.isInfixOf "main = pure ()"
+                body `shouldSatisfy` Text.isInfixOf "snake_case"
+                body `shouldSatisfy` Text.isInfixOf "bold"
+                body `shouldSatisfy` (not . Text.isInfixOf "```")
+                body `shouldSatisfy` (not . Text.isInfixOf "**bold**")
+
         it "flushes pre-tool assistant prose before tool lines" do
             withRenderConfig False True \config handle path -> do
                 let call = functionToolCall "c1" "list_dir" "{\"target_directory\":\".\"}"
@@ -570,3 +620,32 @@ withRenderConfigNativeMode showThinking color native motionMode action = do
                 }
         action config handle path
         clearThinking config
+
+stripTerminalControls :: Text.Text -> Text.Text
+stripTerminalControls = go
+  where
+    go text =
+        case Text.break (== '\ESC') text of
+            (before, rest)
+                | Text.null rest -> before
+                | Just after <- Text.stripPrefix "\ESC[" rest ->
+                    before <> go (dropCsi after)
+                | Just after <- Text.stripPrefix "\ESC]" rest ->
+                    before <> go (dropOsc after)
+                | otherwise ->
+                    before <> go (Text.drop 1 rest)
+
+    dropCsi =
+        Text.drop 1
+            . Text.dropWhile
+                (\character ->
+                    not (character >= '@' && character <= '~'))
+
+    dropOsc text =
+        case Text.break (\character -> character == '\BEL' || character == '\ESC')
+                text of
+            (_, rest)
+                | Text.null rest -> ""
+                | Text.isPrefixOf "\BEL" rest -> Text.drop 1 rest
+                | Text.isPrefixOf "\ESC\\" rest -> Text.drop 2 rest
+                | otherwise -> dropOsc (Text.drop 1 rest)

--- a/packages/agent-tui/agent-tui.cabal
+++ b/packages/agent-tui/agent-tui.cabal
@@ -37,6 +37,7 @@ library
     hs-source-dirs:   src
     exposed-modules:  Agent.TUI.FencedCode
                     , Agent.TUI.Markdown
+                    , Agent.TUI.Markdown.Inline
                     , Agent.TUI.Motion
                     , Agent.TUI.Model
                     , Agent.TUI.Presentation
@@ -57,6 +58,7 @@ test-suite agent-tui-test
     hs-source-dirs:   test
     main-is:          Spec.hs
     other-modules:    Agent.TUI.FencedCodeSpec
+                    , Agent.TUI.Markdown.InlineSpec
                     , Agent.TUI.MarkdownSpec
                     , Agent.TUI.MotionSpec
                     , Agent.TUI.ModelSpec

--- a/packages/agent-tui/src/Agent/TUI/Markdown.hs
+++ b/packages/agent-tui/src/Agent/TUI/Markdown.hs
@@ -1,7 +1,6 @@
 -- | Lightweight fullscreen Markdown block rendering.
 module Agent.TUI.Markdown
-    ( InlineSpan(..)
-    , InlineStyle(..)
+    ( Inline(..)
     , inlinePlainText
     , markdownWidget
     , markdownWidgetWithCodeControls
@@ -13,6 +12,11 @@ import Agent.TUI.FencedCode
     ( FenceChunk(..)
     , FencedBlock(..)
     , fenceChunks
+    )
+import Agent.TUI.Markdown.Inline
+    ( Inline(..)
+    , inlinePlainText
+    , parseInline
     )
 import Agent.Syntax
     ( SyntaxHighlighter
@@ -26,10 +30,8 @@ import Agent.TUI.TextWidth
 import qualified Agent.TUI.Theme as Theme
 import Brick
 import qualified Brick.Types as B
-import Data.Char
-    ( isDigit
-    , isSpace
-    )
+import Data.Bits ((.|.))
+import Data.Char (isDigit, isSpace)
 import qualified Data.List as List
 import Data.Maybe (fromMaybe, isJust, mapMaybe)
 import Data.Text (Text)
@@ -40,22 +42,6 @@ import qualified Graphics.Vty as V
 
 terminalCharWidth :: Char -> Int
 terminalCharWidth = displayCharCellWidth
-
-data InlineStyle
-    = InlinePlain
-    | InlineStrong
-    | InlineEmphasis
-    | InlineCode
-    | InlineLink !Text
-    | InlineStrongLink !Text
-    | InlineEmphasisLink !Text
-    deriving (Eq, Show)
-
-data InlineSpan = InlineSpan
-    { inlineStyle :: !InlineStyle
-    , inlineText :: !Text
-    }
-    deriving (Eq, Show)
 
 markdownWidget :: Text -> Widget n
 markdownWidget =
@@ -123,25 +109,27 @@ renderLines lines_
         table : renderLines rest
 renderLines (line : rest)
     | Just heading <- stripHeading line =
-        withAttr Theme.headingAttr
-            (padTop (Pad 1) (inlineWidget (parseInline heading)))
+        padTop (Pad 1)
+            (inlineWidgetWithAttr Theme.headingAttr (parseInline heading))
             : renderLines rest
-    | Just item <- stripBullet line =
+    | Just (indent, item) <- stripBullet line =
         hBox
-            [ withAttr Theme.headingAttr (txt "• ")
-            , inlineWidget (parseInline item)
+            [ txt indent
+            , withAttr Theme.headingAttr (txt "• ")
+            , inlineWidgetWithAttr Theme.assistantAttr (parseInline item)
             ]
             : renderLines rest
-    | Just (number, item) <- stripOrdered line =
+    | Just (indent, number, item) <- stripOrdered line =
         hBox
-            [ withAttr Theme.headingAttr (txt (number <> ". "))
-            , inlineWidget (parseInline item)
+            [ txt indent
+            , withAttr Theme.headingAttr (txt (number <> ". "))
+            , inlineWidgetWithAttr Theme.assistantAttr (parseInline item)
             ]
             : renderLines rest
-    | Just quote <- Text.stripPrefix "> " (Text.stripStart line) =
+    | Just quote <- stripBlockQuote line =
         hBox
             [ withAttr Theme.mutedAttr (txt "│ ")
-            , withAttr Theme.mutedAttr (inlineWidget (parseInline quote))
+            , inlineWidgetWithAttr Theme.mutedAttr (parseInline quote)
             ]
             : renderLines rest
     | Text.null (Text.strip line) =
@@ -150,7 +138,7 @@ renderLines (line : rest)
         withAttr Theme.mutedAttr (vLimit 1 (fill '─'))
             : renderLines rest
     | otherwise =
-        inlineWidget (parseInline line)
+        inlineWidgetWithAttr Theme.assistantAttr (parseInline line)
             : renderLines rest
 
 codeBodyLines :: Text -> [Text]
@@ -250,21 +238,26 @@ stripHeading line =
         then Just (Text.strip rest)
         else Nothing
 
-stripBullet :: Text -> Maybe Text
+stripBullet :: Text -> Maybe (Text, Text)
 stripBullet line =
-    let stripped = Text.stripStart line
-    in asumPrefix ["- ", "* ", "+ "] stripped
+    let (indent, stripped) = Text.span isSpace line
+    in (indent,) <$> asumPrefix ["- ", "* ", "+ "] stripped
 
-stripOrdered :: Text -> Maybe (Text, Text)
+stripOrdered :: Text -> Maybe (Text, Text, Text)
 stripOrdered line =
     let
-        stripped = Text.stripStart line
+        (indent, stripped) = Text.span isSpace line
         (number, rest) = Text.span isDigit stripped
     in if Text.null number
         then Nothing
         else
-            (\item -> (number, Text.strip item))
+            (\item -> (indent, number, Text.strip item))
                 <$> Text.stripPrefix ". " rest
+
+stripBlockQuote :: Text -> Maybe Text
+stripBlockQuote line = do
+    rest <- Text.stripPrefix ">" (Text.stripStart line)
+    pure (fromMaybe rest (Text.stripPrefix " " rest))
 
 isThematicBreak :: Text -> Bool
 isThematicBreak line =
@@ -307,11 +300,10 @@ tableWidget rows@(headerCells : _) =
             traverse
                 (\(rowIndex, cells) ->
                     traverse
-                        (traverse
-                            (resolveInlineSpan
-                                (if rowIndex == 0
-                                    then Theme.headingAttr
-                                    else Theme.assistantAttr))
+                        (resolveInline
+                            (if rowIndex == 0
+                                then Theme.headingAttr
+                                else Theme.assistantAttr)
                             . parseInline)
                         cells)
                 (zip [0 :: Int ..] normalizedRows)
@@ -632,143 +624,11 @@ asumPrefix prefixes text = case prefixes of
         Just value -> Just value
         Nothing -> asumPrefix rest text
 
-parseInline :: Text -> [InlineSpan]
-parseInline = go Nothing []
-  where
-    go _ plain text
-        | Text.null text = flushPlain plain []
-    go previous plain text
-        | Just (body, rest) <- delimited "**" text =
-            flushPlain plain $
-                strongSpans body
-                    <> go (lastChar body) [] rest
-        | Just (body, rest) <- delimited "__" text =
-            flushPlain plain $
-                strongSpans body
-                    <> go (lastChar body) [] rest
-        | Just (body, rest) <- codeSpan text =
-            flushPlain plain $
-                InlineSpan InlineCode body
-                    : go (lastChar body) [] rest
-        | Just (label, url, rest) <- linkSpan text =
-            flushPlain plain $
-                InlineSpan (InlineLink url)
-                    (label
-                        <> if Text.null url || label == url
-                            then ""
-                            else " (" <> url <> ")")
-                    : go (lastChar label) [] rest
-        | Just (body, rest) <- emphasis previous '*' text =
-            flushPlain plain $
-                emphasisSpans body
-                    <> go (lastChar body) [] rest
-        | Just (body, rest) <- emphasis previous '_' text =
-            flushPlain plain $
-                emphasisSpans body
-                    <> go (lastChar body) [] rest
-        | otherwise =
-            case Text.uncons text of
-                Nothing -> flushPlain plain []
-                Just (character, rest) ->
-                    let (ordinary, remaining) =
-                            Text.span (not . inlineMarker) rest
-                        chunk = Text.cons character ordinary
-                    in go (lastChar chunk) (chunk : plain) remaining
-
-    delimited marker text = do
-        after <- Text.stripPrefix marker text
-        let (body, closing) = Text.breakOn marker after
-        if Text.null body || Text.null closing
-            then Nothing
-            else Just (body, Text.drop (Text.length marker) closing)
-
-    codeSpan text = do
-        let (ticks, after) = Text.span (== '`') text
-        if Text.null ticks
-            then Nothing
-            else
-                let (body, closing) = Text.breakOn ticks after
-                in if Text.null closing
-                    then Nothing
-                    else Just
-                        ( body
-                        , Text.drop (Text.length ticks) closing
-                        )
-
-    linkSpan text = do
-        afterOpen <- Text.stripPrefix "[" text
-        let (label, afterLabel) = Text.breakOn "](" afterOpen
-        afterUrl <- Text.stripPrefix "](" afterLabel
-        let (url, closing) = Text.breakOn ")" afterUrl
-        if Text.null label || Text.null closing
-            then Nothing
-            else Just (label, url, Text.drop 1 closing)
-
-    emphasis previous marker text = do
-        after <- Text.stripPrefix (Text.singleton marker) text
-        let (body, closing) =
-                Text.breakOn (Text.singleton marker) after
-            openingBoundary =
-                maybe True (\character -> isSpace character
-                    || character `elem` ("([{\"'" :: String)) previous
-            closingRest = Text.drop 1 closing
-            closingBoundary = case Text.uncons closingRest of
-                Nothing -> True
-                Just (character, _) ->
-                    isSpace character
-                        || character `elem` (".,;:!?)]}\"'" :: String)
-        if Text.null body
-            || Text.null closing
-            || Text.any isSpace (Text.take 1 body)
-            || not openingBoundary
-            || not closingBoundary
-            then Nothing
-            else Just (body, closingRest)
-
-    lastChar value =
-        snd <$> Text.unsnoc value
-
-    inlineMarker character =
-        character `elem` ("*_`[" :: String)
-
-    strongSpans = nestedStyleSpans InlineStrong InlineStrongLink
-
-    emphasisSpans = nestedStyleSpans InlineEmphasis InlineEmphasisLink
-
-    -- Links retain the surrounding style through a combined constructor,
-    -- while code and other semantic child styles override it.
-    nestedStyleSpans plainStyle linkStyle body =
-        let spans = parseInline body
-        in if any overridesParentStyle spans
-            then map (applyNestedStyle plainStyle linkStyle) spans
-            else [InlineSpan plainStyle body]
-
-    overridesParentStyle InlineSpan{inlineStyle = InlineLink _} = True
-    overridesParentStyle InlineSpan{inlineStyle = InlineCode} = True
-    overridesParentStyle _ = False
-
-    applyNestedStyle plainStyle linkStyle span_ =
-        span_
-            { inlineStyle =
-                case span_.inlineStyle of
-                    InlinePlain -> plainStyle
-                    InlineLink url -> linkStyle url
-                    other -> other
-            }
-
-    flushPlain [] rest = rest
-    flushPlain chunks rest =
-        InlineSpan InlinePlain (Text.concat (reverse chunks))
-            : rest
-
-inlinePlainText :: [InlineSpan] -> Text
-inlinePlainText = Text.concat . map (.inlineText)
-
-inlineWidget :: [InlineSpan] -> Widget n
-inlineWidget spans =
+inlineWidgetWithAttr :: AttrName -> [Inline] -> Widget n
+inlineWidgetWithAttr plainAttr inlines =
     B.Widget B.Greedy B.Fixed do
         context <- B.getContext
-        styled <- traverse (resolveInlineSpan Theme.assistantAttr) spans
+        styled <- resolveInline plainAttr inlines
         let width = max 1 context.availWidth
             rows = wrapStyled width styled
             rendered =
@@ -781,45 +641,54 @@ inlineWidget spans =
                     ]
         pure B.emptyResult { B.image = rendered }
 
-resolveInlineSpan
-    :: AttrName
-    -> InlineSpan
-    -> B.RenderM n (V.Attr, Text)
-resolveInlineSpan plainAttr InlineSpan{inlineStyle, inlineText} = do
-    baseAttr <-
-        B.lookupAttrName $
-            case inlineStyle of
-                InlinePlain -> plainAttr
-                _ -> styleAttr inlineStyle
-    let attr = case inlineStyle of
-            InlineStrongLink _ -> baseAttr `V.withStyle` V.bold
-            InlineEmphasisLink _ -> baseAttr `V.withStyle` V.italic
-            _ -> baseAttr
-    pure
-        ( case inlineStyle of
-            InlineLink url
-                | safeUrl url -> attr `V.withURL` url
-            InlineStrongLink url
-                | safeUrl url -> attr `V.withURL` url
-            InlineEmphasisLink url
-                | safeUrl url -> attr `V.withURL` url
-            _ -> attr
-        , displayTerminalText inlineText
-        )
+data InlineContext = InlineContext
+    { inlineStrong :: !Bool
+    , inlineEmphasis :: !Bool
+    , inlineUrl :: !(Maybe Text)
+    }
+
+resolveInline :: AttrName -> [Inline] -> B.RenderM n [(V.Attr, Text)]
+resolveInline plainAttr = fmap concat . traverse (go emptyContext)
   where
+    emptyContext = InlineContext False False Nothing
+
+    go context = \case
+        InlineText text -> one plainAttr context text
+        InlineCode text -> one Theme.inlineCodeAttr context text
+        InlineStrong children ->
+            concat <$> traverse (go context{inlineStrong = True}) children
+        InlineEmphasis children ->
+            concat <$> traverse (go context{inlineEmphasis = True}) children
+        InlineLink url children -> do
+            let linkContext = context{inlineUrl = Just url}
+            label <- concat <$> traverse (go linkContext) children
+            suffix <-
+                if Text.null url || inlinePlainText children == url
+                    then pure []
+                    else one Theme.linkAttr linkContext (" (" <> url <> ")")
+            pure (label <> suffix)
+
+    one baseName context text = do
+        base <- B.lookupAttrName $
+            case context.inlineUrl of
+                Just _ -> Theme.linkAttr
+                Nothing -> baseName
+        let addedStyle =
+                (if context.inlineStrong then V.bold else 0)
+                    .|. (if context.inlineEmphasis then V.italic else 0)
+            style = V.styleMask base .|. addedStyle
+            emphasisAttr
+                | style == 0 = base
+                | otherwise = base `V.withStyle` style
+            linkedAttr = case context.inlineUrl of
+                Just url
+                    | safeUrl url -> emphasisAttr `V.withURL` url
+                _ -> emphasisAttr
+        pure [(linkedAttr, displayTerminalText text)]
+
     safeUrl url =
         not (Text.null url)
             && displayTerminalText url == url
-
-styleAttr :: InlineStyle -> AttrName
-styleAttr = \case
-    InlinePlain -> Theme.assistantAttr
-    InlineStrong -> Theme.strongAttr
-    InlineEmphasis -> Theme.emphasisAttr
-    InlineCode -> Theme.inlineCodeAttr
-    InlineLink _ -> Theme.linkAttr
-    InlineStrongLink _ -> Theme.linkAttr
-    InlineEmphasisLink _ -> Theme.linkAttr
 
 wrapStyled :: Int -> [(V.Attr, Text)] -> [[(V.Attr, Text)]]
 wrapStyled width spans =

--- a/packages/agent-tui/src/Agent/TUI/Markdown/Inline.hs
+++ b/packages/agent-tui/src/Agent/TUI/Markdown/Inline.hs
@@ -1,0 +1,316 @@
+-- | Shared, composable inline Markdown parsing.
+module Agent.TUI.Markdown.Inline
+    ( Inline(..)
+    , inlinePlainText
+    , parseInline
+    ) where
+
+import Data.Char
+    ( isAlphaNum
+    , isAscii
+    , isSpace
+    )
+import qualified Data.List as List
+import Data.Text (Text)
+import qualified Data.Text as Text
+
+data Inline
+    = InlineText !Text
+    | InlineCode !Text
+    | InlineStrong ![Inline]
+    | InlineEmphasis ![Inline]
+    | InlineLink !Text ![Inline]
+    deriving (Eq, Show)
+
+-- | Parse line-local inline Markdown. Malformed constructs remain literal.
+parseInline :: Text -> [Inline]
+parseInline =
+    coalesceText
+        . concat
+        . List.intersperse [InlineText "\n"]
+        . map (parseSequence Nothing Nothing)
+        . Text.splitOn "\n"
+
+-- | Text displayed by either renderer, including the visible destination
+-- appended to links whose label differs from their destination.
+inlinePlainText :: [Inline] -> Text
+inlinePlainText = foldMap inlineText
+  where
+    inlineText = \case
+        InlineText text -> text
+        InlineCode text -> text
+        InlineStrong children -> inlinePlainText children
+        InlineEmphasis children -> inlinePlainText children
+        InlineLink url children ->
+            let label = inlinePlainText children
+            in label
+                <> if Text.null url || label == url
+                    then ""
+                    else " (" <> url <> ")"
+
+-- The optional delimiter belongs to the caller. It is consumed only when it
+-- can close at the current position; otherwise it is parsed as ordinary input.
+parseSequence :: Maybe Text -> Maybe Char -> Text -> [Inline]
+parseSequence closing initialPrevious = go initialPrevious
+  where
+    go previous text
+        | Text.null text = []
+        | Just marker <- closing
+        , marker `Text.isPrefixOf` text
+        , canClose marker previous (Text.drop (Text.length marker) text) =
+            []
+        | Just (escaped, rest) <- escapedPunctuation text =
+            InlineText (Text.singleton escaped)
+                : go (Just escaped) rest
+        | Just (code, rest) <- codeSpan text =
+            InlineCode code : go (lastCharacter code <|> previous) rest
+        | Just (url, label, rest) <- linkSpan text =
+            let children = parseInline label
+                visible = inlinePlainText children
+                previous' =
+                    lastCharacter
+                        (visible
+                            <> if Text.null url || visible == url
+                                then ""
+                                else " (" <> url <> ")")
+                        <|> previous
+            in InlineLink url children : go previous' rest
+        | Just (node, visible, rest) <- styledSpan previous "**" InlineStrong text =
+            node : go (lastCharacter visible <|> previous) rest
+        | Just (node, visible, rest) <- styledSpan previous "__" InlineStrong text =
+            node : go (lastCharacter visible <|> previous) rest
+        | Just (node, visible, rest) <- styledSpan previous "*" InlineEmphasis text =
+            node : go (lastCharacter visible <|> previous) rest
+        | Just (node, visible, rest) <- styledSpan previous "_" InlineEmphasis text =
+            node : go (lastCharacter visible <|> previous) rest
+        | otherwise =
+            let (plain, rest) = takePlain closing text
+                literal
+                    | Text.null plain = Text.take 1 text
+                    | otherwise = plain
+                remaining
+                    | Text.null plain = Text.drop 1 text
+                    | otherwise = rest
+            in InlineText literal
+                : go (lastCharacter literal <|> previous) remaining
+
+styledSpan
+    :: Maybe Char
+    -> Text
+    -> ([Inline] -> Inline)
+    -> Text
+    -> Maybe (Inline, Text, Text)
+styledSpan previous marker constructor text = do
+    afterOpen <- Text.stripPrefix marker text
+    if canOpen marker previous afterOpen
+        then do
+            (bodySource, rest) <- findClosing marker previous afterOpen
+            if Text.null bodySource
+                then Nothing
+                else
+                    let children = parseInline bodySource
+                    in pure
+                        (constructor children, inlinePlainText children, rest)
+        else Nothing
+
+-- Find a closing delimiter by parsing nested constructs in source order. This
+-- lets the first star of a final @***@ close an inner emphasis span before the
+-- remaining @**@ closes its surrounding strong span.
+findClosing :: Text -> Maybe Char -> Text -> Maybe (Text, Text)
+findClosing marker initialPrevious input =
+    scan initialPrevious "" input
+  where
+    scan previous consumed remaining
+        | Text.null remaining = Nothing
+        | Text.any (== '\n') (Text.take 1 remaining) = Nothing
+        | marker `Text.isPrefixOf` remaining
+        , canClose marker previous (Text.drop (Text.length marker) remaining) =
+            Just
+                ( consumed
+                , Text.drop (Text.length marker) remaining
+                )
+        | Just (_, rest) <- escapedPunctuation remaining =
+            consumeThrough rest
+        | Just (_, rest) <- codeSpan remaining =
+            consumeThrough rest
+        | Just (_, _, rest) <- linkSpan remaining =
+            consumeThrough rest
+        | Just rest <- completeStyled "**" remaining =
+            consumeThrough rest
+        | Just rest <- completeStyled "__" remaining =
+            consumeThrough rest
+        | Just rest <- completeStyled "*" remaining =
+            consumeThrough rest
+        | Just rest <- completeStyled "_" remaining =
+            consumeThrough rest
+        | otherwise =
+            consumeThrough (Text.drop 1 remaining)
+      where
+        consumeThrough rest =
+            let consumedLength = Text.length remaining - Text.length rest
+                chunk = Text.take consumedLength remaining
+            in scan
+                (lastCharacter chunk <|> previous)
+                (consumed <> chunk)
+                rest
+
+        completeStyled nestedMarker source = do
+            afterOpen <- Text.stripPrefix nestedMarker source
+            if canOpen nestedMarker previous afterOpen
+                then do
+                    (_, rest) <- findClosing nestedMarker previous afterOpen
+                    pure rest
+                else Nothing
+
+codeSpan :: Text -> Maybe (Text, Text)
+codeSpan text =
+    let (ticks, afterOpen) = Text.span (== '`') text
+        tickCount = Text.length ticks
+    in if tickCount == 0
+        then Nothing
+        else findClose tickCount "" afterOpen
+  where
+    findClose tickCount body remaining
+        | Text.null remaining = Nothing
+        | Text.isPrefixOf "\n" remaining = Nothing
+        | otherwise =
+            let (before, atTicks) = Text.break (== '`') remaining
+            in if Text.null atTicks
+                then Nothing
+                else
+                    let (run, afterRun) = Text.span (== '`') atTicks
+                    in if Text.length run == tickCount
+                        then Just (body <> before, afterRun)
+                        else findClose
+                            tickCount
+                            (body <> before <> run)
+                            afterRun
+
+linkSpan :: Text -> Maybe (Text, Text, Text)
+linkSpan text = do
+    afterOpen <- Text.stripPrefix "[" text
+    (label, afterLabel) <- takeLinkLabel 0 "" afterOpen
+    afterDestinationOpen <- Text.stripPrefix "(" afterLabel
+    (url, rest) <- takeDestination 0 "" afterDestinationOpen
+    if Text.null label
+        then Nothing
+        else Just (url, label, rest)
+
+takeLinkLabel :: Int -> Text -> Text -> Maybe (Text, Text)
+takeLinkLabel depth consumed remaining =
+    case Text.uncons remaining of
+        Nothing -> Nothing
+        Just ('\n', _) -> Nothing
+        Just ('\\', afterSlash) ->
+            case Text.uncons afterSlash of
+                Just (escaped, rest)
+                    | isAsciiPunctuation escaped ->
+                        takeLinkLabel depth
+                            (consumed <> Text.pack ['\\', escaped])
+                            rest
+                _ -> takeLinkLabel depth (consumed <> "\\") afterSlash
+        Just ('[', rest) ->
+            takeLinkLabel (depth + 1) (consumed <> "[") rest
+        Just (']', rest)
+            | depth == 0
+            , Text.isPrefixOf "(" rest ->
+                Just (consumed, rest)
+            | depth > 0 ->
+                takeLinkLabel (depth - 1) (consumed <> "]") rest
+        Just (character, rest) ->
+            takeLinkLabel depth
+                (consumed <> Text.singleton character)
+                rest
+
+takeDestination :: Int -> Text -> Text -> Maybe (Text, Text)
+takeDestination depth consumed remaining =
+    case Text.uncons remaining of
+        Nothing -> Nothing
+        Just ('\n', _) -> Nothing
+        Just ('\\', afterSlash) ->
+            case Text.uncons afterSlash of
+                Just (escaped, rest)
+                    | isAsciiPunctuation escaped ->
+                        takeDestination depth
+                            (consumed <> Text.singleton escaped)
+                            rest
+                _ -> takeDestination depth (consumed <> "\\") afterSlash
+        Just ('(', rest) ->
+            takeDestination (depth + 1) (consumed <> "(") rest
+        Just (')', rest)
+            | depth == 0 -> Just (consumed, rest)
+            | otherwise ->
+                takeDestination (depth - 1) (consumed <> ")") rest
+        Just (character, rest) ->
+            takeDestination depth
+                (consumed <> Text.singleton character)
+                rest
+
+escapedPunctuation :: Text -> Maybe (Char, Text)
+escapedPunctuation text = do
+    afterSlash <- Text.stripPrefix "\\" text
+    (character, rest) <- Text.uncons afterSlash
+    if isAsciiPunctuation character
+        then Just (character, rest)
+        else Nothing
+
+isAsciiPunctuation :: Char -> Bool
+isAsciiPunctuation character =
+    isAscii character
+        && character >= '!'
+        && character <= '~'
+        && not (isAlphaNum character)
+
+canOpen :: Text -> Maybe Char -> Text -> Bool
+canOpen marker previous after =
+    case Text.uncons after of
+        Nothing -> False
+        Just (first, _)
+            | isSpace first -> False
+            | isUnderscore marker ->
+                maybe True (not . isWordCharacter) previous
+            | otherwise -> True
+
+canClose :: Text -> Maybe Char -> Text -> Bool
+canClose marker previous after =
+    case previous of
+        Nothing -> False
+        Just last_
+            | isSpace last_ -> False
+            | isUnderscore marker ->
+                maybe True (not . isWordCharacter . fst) (Text.uncons after)
+            | otherwise -> True
+
+isUnderscore :: Text -> Bool
+isUnderscore = Text.all (== '_')
+
+isWordCharacter :: Char -> Bool
+isWordCharacter character = isAlphaNum character || character == '_'
+
+takePlain :: Maybe Text -> Text -> (Text, Text)
+takePlain closing =
+    Text.span \character ->
+        character /= '\\'
+            && character /= '`'
+            && character /= '['
+            && character /= '*'
+            && character /= '_'
+            && maybe True
+                (\marker -> character /= Text.head marker)
+                closing
+
+lastCharacter :: Text -> Maybe Char
+lastCharacter text = snd <$> Text.unsnoc text
+
+coalesceText :: [Inline] -> [Inline]
+coalesceText = foldr step []
+  where
+    step (InlineText left) (InlineText right : rest) =
+        InlineText (left <> right) : rest
+    step inline rest = inline : rest
+
+infixr 3 <|>
+
+(<|>) :: Maybe a -> Maybe a -> Maybe a
+Just value <|> _ = Just value
+Nothing <|> alternative = alternative

--- a/packages/agent-tui/test/Agent/TUI/Markdown/InlineSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/Markdown/InlineSpec.hs
@@ -1,0 +1,86 @@
+module Agent.TUI.Markdown.InlineSpec (spec) where
+
+import Agent.TUI.Markdown.Inline
+import Test.Hspec
+
+spec :: Spec
+spec = describe "shared inline Markdown parsing" do
+    it "parses recursively composed formatting" do
+        parseInline "**bold and *italic* with `code`**"
+            `shouldBe`
+                [ InlineStrong
+                    [ InlineText "bold and "
+                    , InlineEmphasis [InlineText "italic"]
+                    , InlineText " with "
+                    , InlineCode "code"
+                    ]
+                ]
+
+    it "parses formatting inside link labels" do
+        parseInline "[**important** `docs`](https://example.com)"
+            `shouldBe`
+                [ InlineLink
+                    "https://example.com"
+                    [ InlineStrong [InlineText "important"]
+                    , InlineText " "
+                    , InlineCode "docs"
+                    ]
+                ]
+
+    it "supports multi-backtick code spans" do
+        parseInline "``code `with` ticks``"
+            `shouldBe` [InlineCode "code `with` ticks"]
+
+    it "unescapes ASCII punctuation and keeps non-punctuation slashes" do
+        inlinePlainText (parseInline "\\*literal\\* C:\\Users")
+            `shouldBe` "*literal* C:\\Users"
+
+    it "supports balanced and escaped parentheses in link destinations" do
+        let parsed =
+                parseInline
+                    "[one](https://example.com/a_(b)) [two](https://example.com/a_\\(b\\))"
+        inlinePlainText parsed
+            `shouldBe`
+                "one (https://example.com/a_(b)) two (https://example.com/a_(b))"
+        parsed
+            `shouldBe`
+                [ InlineLink
+                    "https://example.com/a_(b)"
+                    [InlineText "one"]
+                , InlineText " "
+                , InlineLink
+                    "https://example.com/a_(b)"
+                    [InlineText "two"]
+                ]
+
+    it "preserves intraword underscore delimiters" do
+        parseInline "foo__bar__baz snake_case"
+            `shouldBe` [InlineText "foo__bar__baz snake_case"]
+
+    it "parses flanked underscore emphasis" do
+        parseInline "use _established terms_ here"
+            `shouldBe`
+                [ InlineText "use "
+                , InlineEmphasis [InlineText "established terms"]
+                , InlineText " here"
+                ]
+
+    it "leaves unmatched constructs literal" do
+        parseInline "unfinished **bold and [link](url"
+            `shouldBe`
+                [InlineText "unfinished **bold and [link](url"]
+
+    it "does not parse constructs across lines" do
+        parseInline "**first\nsecond**"
+            `shouldBe` [InlineText "**first\nsecond**"]
+
+    it "appends visible destinations only when needed" do
+        inlinePlainText
+            (parseInline
+                "[docs](https://example.com) [https://same](https://same) [](empty)")
+            `shouldBe`
+                "docs (https://example.com) https://same [](empty)"
+
+    it "coalesces long plain input" do
+        parseInline "plain text"
+            `shouldBe` [InlineText "plain text"]

--- a/packages/agent-tui/test/Agent/TUI/MarkdownSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/MarkdownSpec.hs
@@ -31,17 +31,15 @@ spec = describe "fullscreen Markdown rendering" do
         parseInline
             "Use **bold**, *italics*, `code`, and [docs](https://example.com)."
             `shouldBe`
-                [ InlineSpan InlinePlain "Use "
-                , InlineSpan InlineStrong "bold"
-                , InlineSpan InlinePlain ", "
-                , InlineSpan InlineEmphasis "italics"
-                , InlineSpan InlinePlain ", "
-                , InlineSpan InlineCode "code"
-                , InlineSpan InlinePlain ", and "
-                , InlineSpan
-                    (InlineLink "https://example.com")
-                    "docs (https://example.com)"
-                , InlineSpan InlinePlain "."
+                [ InlineText "Use "
+                , InlineStrong [InlineText "bold"]
+                , InlineText ", "
+                , InlineEmphasis [InlineText "italics"]
+                , InlineText ", "
+                , InlineCode "code"
+                , InlineText ", and "
+                , InlineLink "https://example.com" [InlineText "docs"]
+                , InlineText "."
                 ]
 
     it "renders links with native terminal hyperlink metadata" do
@@ -55,13 +53,17 @@ spec = describe "fullscreen Markdown rendering" do
         parseInline
             "**[PR #316](https://example.com/316)** and *[docs](https://example.com)*"
             `shouldBe`
-                [ InlineSpan
-                    (InlineStrongLink "https://example.com/316")
-                    "PR #316 (https://example.com/316)"
-                , InlineSpan InlinePlain " and "
-                , InlineSpan
-                    (InlineEmphasisLink "https://example.com")
-                    "docs (https://example.com)"
+                [ InlineStrong
+                    [ InlineLink
+                        "https://example.com/316"
+                        [InlineText "PR #316"]
+                    ]
+                , InlineText " and "
+                , InlineEmphasis
+                    [ InlineLink
+                        "https://example.com"
+                        [InlineText "docs"]
+                    ]
                 ]
 
     it "renders a strong link with hyperlink metadata and bold styling" do
@@ -86,7 +88,7 @@ spec = describe "fullscreen Markdown rendering" do
     it "supports multi-backtick code and avoids snake_case emphasis" do
         let spans = parseInline "``a ` b`` and snake_case"
         inlinePlainText spans `shouldBe` "a ` b and snake_case"
-        spans `shouldContain` [InlineSpan InlineCode "a ` b"]
+        spans `shouldContain` [InlineCode "a ` b"]
 
     it "lets inline code override surrounding strong text" do
         let input =
@@ -94,11 +96,12 @@ spec = describe "fullscreen Markdown rendering" do
                 \`state = [ResponseItem]` would be simpler.**"
         parseInline input
             `shouldBe`
-                [ InlineSpan InlinePlain "Yes—"
-                , InlineSpan InlineStrong
-                    "for this repository, hardcoding "
-                , InlineSpan InlineCode "state = [ResponseItem]"
-                , InlineSpan InlineStrong " would be simpler."
+                [ InlineText "Yes—"
+                , InlineStrong
+                    [ InlineText "for this repository, hardcoding "
+                    , InlineCode "state = [ResponseItem]"
+                    , InlineText " would be simpler."
+                    ]
                 ]
 
         let region = (80, 3)
@@ -119,16 +122,48 @@ spec = describe "fullscreen Markdown rendering" do
                 Just
                     (attrMapLookup
                         Theme.inlineCodeAttr
-                        Theme.solarizedDark)
+                        Theme.solarizedDark
+                        `V.withStyle` V.bold)
 
     it "leaves unmatched delimiters visible" do
         inlinePlainText (parseInline "unfinished **bold")
             `shouldBe` "unfinished **bold"
 
+    it "inherits heading and blockquote attributes in plain inline spans" do
+        let region = (40, 6)
+            rendered input =
+                concatMap toList $
+                    toList $
+                        displayOpsForPic
+                            (renderWidget
+                                (Just Theme.solarizedDark)
+                                [markdownWidget input :: Widget ()]
+                                region)
+                            region
+            headingSpan = find (hasText "Title") (rendered "# Title")
+            quoteSpan = find (containsText "quoted") (rendered ">quoted")
+        fmap spanAttr headingSpan
+            `shouldBe`
+                Just
+                    (attrMapLookup Theme.headingAttr Theme.solarizedDark)
+        fmap spanAttr quoteSpan
+            `shouldBe`
+                Just
+                    (attrMapLookup Theme.mutedAttr Theme.solarizedDark)
+
+    it "preserves nested list indentation and compact blockquotes" do
+        renderRows 40 "- parent\n  - child\n    1. grandchild\n>quote"
+            `shouldBe`
+                [ "• parent"
+                , "  • child"
+                , "    1. grandchild"
+                , "│ quote"
+                ]
+
     it "keeps long unstyled input in one plain span" do
         let input = Text.replicate 10000 "a"
         parseInline input
-            `shouldBe` [InlineSpan InlinePlain input]
+            `shouldBe` [InlineText input]
 
     it "wraps long fenced-code lines inside the available terminal width" do
         let code = Text.replicate 100 "a"
@@ -580,6 +615,13 @@ hasUrl url = \case
     Skip _ -> False
     RowEnd _ -> False
 
+containsText :: Text.Text -> SpanOp -> Bool
+containsText expected = \case
+    TextSpan{textSpanText} ->
+        expected `Text.isInfixOf` LazyText.toStrict textSpanText
+    Skip _ -> False
+    RowEnd _ -> False
+
 hasText :: Text.Text -> SpanOp -> Bool
 hasText expected = \case
     TextSpan{textSpanText} ->
@@ -597,7 +639,9 @@ hasUrlWithStyle :: Text.Text -> V.Style -> SpanOp -> Bool
 hasUrlWithStyle url style = \case
     TextSpan{textSpanAttr} ->
         V.attrURL textSpanAttr == V.SetTo url
-            && V.attrStyle textSpanAttr == V.SetTo style
+            && case V.attrStyle textSpanAttr of
+                V.SetTo actual -> V.hasStyle actual style
+                _ -> False
     Skip _ -> False
     RowEnd _ -> False
 

--- a/packages/agent-tui/test/Spec.hs
+++ b/packages/agent-tui/test/Spec.hs
@@ -1,6 +1,7 @@
 module Main (main) where
 
 import qualified Agent.TUI.FencedCodeSpec as FencedCodeSpec
+import qualified Agent.TUI.Markdown.InlineSpec as MarkdownInlineSpec
 import qualified Agent.TUI.MarkdownSpec as MarkdownSpec
 import qualified Agent.TUI.MotionSpec as MotionSpec
 import qualified Agent.TUI.ModelSpec as ModelSpec
@@ -12,6 +13,7 @@ import Test.Hspec (hspec)
 main :: IO ()
 main = hspec do
     FencedCodeSpec.spec
+    MarkdownInlineSpec.spec
     MarkdownSpec.spec
     MotionSpec.spec
     ModelSpec.spec


### PR DESCRIPTION
## Summary
- replace the fullscreen and minimal inline renderers with one composable parser that supports nested styles, escaped punctuation, intraword underscores, and balanced link destinations
- preserve heading/quote attributes, nested-list indentation, strict fenced-code parsing, styled table contents, and terminal display widths
- make minimal-mode streaming block-aware and invariant across provider chunk boundaries without repainting terminal scrollback

## Validation
- `nix develop -c cabal test --offline agent-tui-test agent-cli-test --test-show-details=direct`
  - agent-tui: 101 examples, 0 failures
  - agent-cli: 683 examples, 0 failures
- tmux minimal-mode smoke: heading, bold balanced-parenthesis link, nested list, compact quote, styled table, and Haskell fence rendered without Markdown marker leakage
- tmux fullscreen smoke: verified nested indentation, clickable bold link, compact quote, table layout, and fenced-code rendering in the live retained UI
