### PR TITLE
Recommend Luna for small subscription-backed subagent tasks

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -186,6 +186,7 @@ import Agent.CLI.Project
     )
 import Agent.CLI.Prompt
     ( secretInputGuidance
+    , subscriptionSubagentModelGuidance
     , systemPrompt
     )
 import Agent.CLI.Request (requestParams, setRequestInstructions)
@@ -1678,6 +1679,10 @@ runAgentInitializedWithLock
                     subagentSessions subagentStoreRoot agentTypesRef
                     subagentForkSource)
             , multiSendToRoot = Just sendToRoot
+            , multiSpawnModelGuidance =
+                subscriptionSubagentModelGuidance
+                    provider
+                    (tokenProviderBillingMode tokenProvider)
             }
     prompt <- loadPrompt options
     persist <-
@@ -1805,6 +1810,10 @@ runAgentInitializedWithLock
                 , subagentConnection = inferredTarget.targetConnectionId
                 , subagentMapModel = transportModel
                 , subagentSessionTmp = toolEnv.toolSessionTmp
+                , subagentSpawnModelGuidance =
+                    subscriptionSubagentModelGuidance
+                        provider
+                        (tokenProviderBillingMode tokenProvider)
                 }
         transcriptRef <- newIORef initialItems
         contextTokensRef <- newIORef Nothing

--- a/packages/agent-cli/src/Agent/CLI/Prompt.hs
+++ b/packages/agent-cli/src/Agent/CLI/Prompt.hs
@@ -1,6 +1,7 @@
 -- | Dialect-specific system prompt closed over by the transport backend.
 module Agent.CLI.Prompt
     ( secretInputGuidance
+    , subscriptionSubagentModelGuidance
     , sessionTempGuidance
     , systemPrompt
     , systemPromptForTools
@@ -22,11 +23,29 @@ import Agent.GrokBuild.Dialect.Prompt
     , grokSystemPromptForTools
     )
 import Agent.OsPath (toText)
+import Agent.Provider (BillingMode(..), Provider(..))
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Time.Calendar (Day)
 import Data.Time.Format (defaultTimeLocale, formatTime)
 import System.OsPath (OsPath)
+
+-- | Nudge subscription-backed OpenAI sessions toward the inexpensive model
+-- for bounded delegation without encouraging unnecessary or risky spawning.
+subscriptionSubagentModelGuidance :: Provider -> BillingMode -> Maybe Text
+subscriptionSubagentModelGuidance provider billing
+    | provider == OpenAIProvider
+    , billing == SubscriptionBilled =
+        Just $ Text.unwords
+            [ "When OpenAI subscription billing is active, prefer"
+            , "`gpt-5.6-luna` for small, bounded tasks such as codebase searches,"
+            , "locating definitions, straightforward reviews, test investigation,"
+            , "and concise summaries. Keep the parent model for complex debugging,"
+            , "architecture, security-sensitive analysis, or work requiring"
+            , "substantial judgment. Do not spawn a subagent when doing the work"
+            , "directly would be faster."
+            ]
+    | otherwise = Nothing
 
 -- | @isNonInteractive@ is True for one-shot @-p@ (no human in the loop).
 systemPrompt :: Dialect -> OsPath -> Maybe OsPath -> Day -> Bool -> Text

--- a/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
@@ -178,6 +178,7 @@ data SubagentRuntime = SubagentRuntime
     , subagentLegacyTarget :: !(Maybe LegacySubagentTarget)
     , subagentConnection :: !Text
     , subagentMapModel :: !(Text -> Text)
+    , subagentSpawnModelGuidance :: !(Maybe Text)
     }
 
 data PreparedChild = PreparedChild
@@ -810,6 +811,7 @@ prepareChild runtime provider currentEffectiveModel currentDialect env sendToRoo
                     CodexCollaborationProtocol -> sendToRoot
                     GrokTaskProtocol -> Nothing
                     GenericTaskProtocol -> Nothing
+            , multiSpawnModelGuidance = runtime.subagentSpawnModelGuidance
             }
     pure PreparedChild
         { preparedParentParams = parentParams

--- a/packages/agent-cli/test/Agent/CLI/PromptSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/PromptSpec.hs
@@ -7,6 +7,7 @@ import Agent.Dialect
     , grokBuildDialect
     )
 import System.OsPath (unsafeEncodeUtf)
+import Agent.Provider (BillingMode(..), Provider(..))
 import Data.Time.Calendar (fromGregorian)
 import qualified Data.Text as Text
 import Test.Hspec
@@ -213,3 +214,16 @@ spec = describe "systemPrompt" do
             "relative paths still resolve against the workspace"
         rootPrompt `shouldSatisfy` Text.isInfixOf "HASKELL_AGENT_TMPDIR"
         childPrompt `shouldSatisfy` Text.isInfixOf "TMPDIR"
+    it "recommends Luna only for subscription-backed OpenAI subagents" do
+        let subscriptionGuidance =
+                subscriptionSubagentModelGuidance
+                    OpenAIProvider
+                    SubscriptionBilled
+        subscriptionGuidance `shouldSatisfy`
+            maybe False (Text.isInfixOf "`gpt-5.6-luna`")
+        subscriptionGuidance `shouldSatisfy`
+            maybe False (Text.isInfixOf "small, bounded tasks")
+        subscriptionSubagentModelGuidance OpenAIProvider ApiBilled
+            `shouldBe` Nothing
+        subscriptionSubagentModelGuidance XAIProvider SubscriptionBilled
+            `shouldBe` Nothing

--- a/packages/agent-cli/test/Agent/CLI/ToolsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ToolsSpec.hs
@@ -185,6 +185,7 @@ spec = describe "schemasFromAppTools" do
                         , multiCreateWorktree = Nothing
                         , multiPrepareSpawn = Nothing
                         , multiSendToRoot = Nothing
+                        , multiSpawnModelGuidance = Nothing
                         }
                     namespaces =
                         [ tagged

--- a/packages/agent-core/src/Agent/Tools/MultiAgents.hs
+++ b/packages/agent-core/src/Agent/Tools/MultiAgents.hs
@@ -101,6 +101,8 @@ data MultiAgentContext = MultiAgentContext
         :: !(Maybe (SubagentId -> CollaborationSpawnOptions -> IO ()))
       -- | Deliver a child message to the root agent's next model turn.
     , multiSendToRoot :: !(Maybe (InterAgentMessage -> IO (Either Text Text)))
+      -- | Optional provider/billing-specific guidance for model overrides.
+    , multiSpawnModelGuidance :: !(Maybe Text)
     }
 
 multiAgentNamespace :: Text
@@ -153,7 +155,10 @@ spawnAgentTool ctx = jsonTool "spawn_agent" spawnAgentDescription
     , PropertySchema "message"
         (encryptedString "Initial plain-text task for the new agent.") True Nothing
     , PropertySchema "model" PropertyString False $ Just
-        "Model override for the new agent. Omit unless an explicit override is needed."
+        (Text.intercalate " " $
+            [ "Model override for the new agent. Omit unless an explicit override is needed."
+            ]
+                <> maybe [] pure ctx.multiSpawnModelGuidance)
     , PropertySchema "reasoning_effort" PropertyString False $ Just
         "Reasoning effort override for the new agent. Omit to inherit the parent effort."
     , PropertySchema "fork_turns" PropertyString False $ Just

--- a/packages/agent-core/test/Agent/Tools/MultiAgentsSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/MultiAgentsSpec.hs
@@ -16,11 +16,13 @@ import Agent.ToolDispatch
     , ToolCallResult(..)
     , dispatchToolCall
     )
+import Agent.ToolDSL (PropertySchema(..))
 import Agent.Tools.MultiAgents
 import Agent.Tools.Types
     ( AppTool(..)
     , ApprovalRule(..)
     , appToolHandlers
+    , jsonToolParameters
     )
 import Control.Concurrent.STM
 import Control.Monad (unless)
@@ -89,6 +91,26 @@ spec = describe "Agent.Tools.MultiAgents" do
             (spawnCall "level5")
         rejected.output `shouldSatisfy`
             Text.isInfixOf "maximum depth 4"
+        closeSubagentRegistry registry
+
+    it "adds host-provided model guidance to spawn_agent" do
+        registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
+            (\_ _ _ _ -> pure $ Left LoopNoResponseId)
+            (\_ _ -> pure ())
+        let context = (rootContext registry Nothing)
+                { multiSpawnModelGuidance =
+                    Just "Prefer `gpt-5.6-luna` for small tasks."
+                }
+            descriptions =
+                [ description
+                | tool <- multiAgentTools context
+                , tool.appToolName == "spawn_agent"
+                , property <- fromMaybe [] (jsonToolParameters tool)
+                , property.propertyName == "model"
+                , description <- maybe [] pure property.description
+                ]
+        descriptions `shouldSatisfy`
+            any (Text.isInfixOf "Prefer `gpt-5.6-luna` for small tasks.")
         closeSubagentRegistry registry
 
     it "preserves encrypted spawn payloads" do
@@ -261,6 +283,7 @@ spec = describe "Agent.Tools.MultiAgents" do
                 , multiCreateWorktree = Nothing
                 , multiPrepareSpawn = Nothing
                 , multiSendToRoot = Just deliverRoot
+                , multiSpawnModelGuidance = Nothing
                 }
         result <- dispatchToolCall defaultLoopDispatch
             (appToolHandlers (multiAgentTools context))
@@ -292,6 +315,7 @@ rootContext registry sendToRoot = MultiAgentContext
     , multiCreateWorktree = Nothing
     , multiPrepareSpawn = Nothing
     , multiSendToRoot = sendToRoot
+    , multiSpawnModelGuidance = Nothing
     }
 
 childContext :: SubagentRegistry -> SubagentId -> Int -> IO MultiAgentContext

--- a/packages/agent-grok-build-dialect/test/Agent/GrokBuild/TaskSpec.hs
+++ b/packages/agent-grok-build-dialect/test/Agent/GrokBuild/TaskSpec.hs
@@ -39,7 +39,7 @@ spec = describe "Agent.GrokBuild.Dialect.Task" do
             (\_ _ -> pure ())
         typesRef <- newIORef Map.empty
         let ctx = MultiAgentContext registry Nothing 0 taskPathRoot
-                (pure Nothing) Nothing Nothing Nothing Nothing
+                (pure Nothing) Nothing Nothing Nothing Nothing Nothing
             tool = taskTool (fromFilePath "/tmp") ctx typesRef
             parameters = fromMaybe [] (jsonToolParameters tool)
         let isolationTypes =
@@ -72,7 +72,7 @@ spec = describe "Agent.GrokBuild.Dialect.Task" do
             (\_ _ -> pure ())
         typesRef <- newIORef Map.empty
         let ctx = MultiAgentContext registry Nothing 0 taskPathRoot
-                (pure Nothing) Nothing Nothing Nothing Nothing
+                (pure Nothing) Nothing Nothing Nothing Nothing Nothing
             tool = taskTool (fromFilePath "/tmp") ctx typesRef
         result <- dispatchToolCall defaultLoopDispatch [tool.appToolHandler]
             (functionToolCall "c1" "task"
@@ -90,7 +90,7 @@ spec = describe "Agent.GrokBuild.Dialect.Task" do
             (observeSpec typesRef observed)
             (\_ _ -> pure ())
         let ctx = MultiAgentContext registry Nothing 0 taskPathRoot
-                (pure Nothing) Nothing Nothing Nothing Nothing
+                (pure Nothing) Nothing Nothing Nothing Nothing Nothing
             tool = taskTool (fromFilePath "/tmp") ctx typesRef
         _ <- dispatchToolCall defaultLoopDispatch [tool.appToolHandler]
             (functionToolCall "c1" "task" raceArgs)
@@ -120,7 +120,7 @@ spec = describe "Agent.GrokBuild.Dialect.Task" do
         let restore _ =
                 pure (Left "persisted subagent dialect is incompatible")
             ctx = MultiAgentContext registry Nothing 0 taskPathRoot
-                (pure Nothing) (Just restore) Nothing Nothing Nothing
+                (pure Nothing) (Just restore) Nothing Nothing Nothing Nothing
             tool = taskTool (fromFilePath "/tmp") ctx typesRef
         result <- dispatchToolCall defaultLoopDispatch [tool.appToolHandler]
             (functionToolCall "c1" "task"
@@ -155,7 +155,7 @@ spec = describe "Agent.GrokBuild.Dialect.Task" do
         typesRef <- newIORef Map.empty
         let childId = SubagentId "agent-child"
             ctx = MultiAgentContext registry (Just childId) 1 taskPathRoot
-                (pure Nothing) Nothing Nothing Nothing Nothing
+                (pure Nothing) Nothing Nothing Nothing Nothing Nothing
             tool = taskTool (fromFilePath "/tmp") ctx typesRef
         expectAlwaysReadOnly tool.appToolApproval
         closeSubagentRegistry registry
@@ -168,7 +168,7 @@ spec = describe "Agent.GrokBuild.Dialect.Task" do
         typesRef <- newIORef Map.empty
         let createIsolated = cleanupLease cleaned
             ctx = MultiAgentContext registry Nothing 0 taskPathRoot (pure Nothing)
-                Nothing (Just createIsolated) Nothing Nothing
+                Nothing (Just createIsolated) Nothing Nothing Nothing
             tool = taskTool (fromFilePath "/tmp") ctx typesRef
         result <- dispatchToolCall defaultLoopDispatch [tool.appToolHandler]
             (functionToolCall "c1" "task"
@@ -189,7 +189,7 @@ spec = describe "Agent.GrokBuild.Dialect.Task" do
         registry <- closedRegistry
         typesRef <- newIORef Map.empty
         let ctx = MultiAgentContext registry Nothing 0 taskPathRoot
-                (pure Nothing) Nothing (Just (cleanupLease cleaned)) Nothing Nothing
+                (pure Nothing) Nothing (Just (cleanupLease cleaned)) Nothing Nothing Nothing
             tool = taskTool (fromFilePath "/tmp") ctx typesRef
         result <- dispatchToolCall defaultLoopDispatch [tool.appToolHandler]
             (functionToolCall "c1" "task" worktreeArgs)


### PR DESCRIPTION
## Summary

- add provider/billing-specific guidance to the `spawn_agent` model override schema
- recommend `gpt-5.6-luna` for small, bounded tasks only when the active OpenAI account is subscription billed
- keep complex, architectural, and security-sensitive work on the parent model and discourage unnecessary delegation
- propagate the guidance to nested subagents without changing explicit model selection or automatically rewriting models

## Testing

- `printf '\\x3aquit\\n' | nix develop -c cabal repl agent-cli:lib:agent-cli agent-core:lib:agent-core --offline -v0`\n- `nix develop -c cabal test --offline agent-core:test:agent-core-test --test-option=-m --test-option=host-provided`\n- `nix develop -c cabal test --offline agent-cli:test:agent-cli-test --test-option=-m --test-option='recommends Luna'`\n- `git diff --check`