### PR TITLE
Fix partial Codex response stream handling

### DIFF
--- a/packages/agent-openai/src/Agent/OpenAI/Http.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Http.hs
@@ -5,29 +5,34 @@ module Agent.OpenAI.Http
 
 import Agent.Error (ApiError(..), ErrorType(..), errorTypeFromText)
 import Agent.OpenAI.Error (mkOpenAIError)
-import Agent.Responses.ResponseMerge (mergeCompletedResponseOutput)
+import Agent.Responses.SSE (parseSseEvents)
+import Agent.Responses.StreamAssembly
+    ( ResponseFailure(..)
+    , StreamAssemblyConfig(..)
+    , buildStreamResponse
+    , failedStreamResponseMessage
+    )
 import qualified Agent.Responses.Types as OpenAI
+import Control.Applicative ((<|>))
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.KeyMap as KeyMap
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 
--- | Decode a successful Responses HTTP body.
---
--- ChatGPT Codex and streaming proxies emit SSE with a terminal
--- @response.completed@ event. Compatible non-streaming hosts return the
--- completed response as a single JSON object. Prefer the SSE completed payload
--- when present so incremental @response.output_item.done@ events can still be
--- merged.
+-- | Decode a successful Responses HTTP body. Streaming bodies use the same
+-- partial-response assembler as the WebSocket and provider SSE transports;
+-- compatible non-streaming hosts may still return one canonical JSON object.
 decodeCodexHttpBody :: Text -> Either ApiError OpenAI.Response
-decodeCodexHttpBody bodyText =
-    case extractCompletedResponse bodyText of
-        Just jsonValue -> decodeResponseValue jsonValue bodyText
-        Nothing -> case decodeJsonResponseBody bodyText of
+decodeCodexHttpBody bodyText
+    | looksLikeSse bodyText = do
+        events <- parseSseEvents bodyText
+        buildStreamResponse streamConfig events
+    | otherwise =
+        case decodeJsonResponseBody bodyText of
             Just jsonValue -> decodeResponseValue jsonValue bodyText
             Nothing -> Left (JsonDecodeError
-                "No response.completed event found in SSE stream"
+                "Invalid Codex Responses body"
                 (Text.take 2000 bodyText))
 
 decodeJsonResponseBody :: Text -> Maybe Aeson.Value
@@ -54,6 +59,31 @@ rejectFailedCodexResponse response =
         OpenAI.ResponseFailed -> Left (failedResponseError response.error)
         _ -> Right response
 
+streamConfig :: StreamAssemblyConfig
+streamConfig = StreamAssemblyConfig
+    { missingCompletionMessage =
+        "No terminal response event found in Codex SSE stream"
+    , classifyStreamError = \streamError ->
+        mkOpenAIError
+            (maybe
+                (maybe ApiErrorType errorTypeFromText streamError.code)
+                errorTypeFromText
+                streamError.errorType)
+            streamError.message
+            streamError.code
+            streamError.retryAfter
+    , classifyFailedResponse = failedStreamResponseError
+    }
+
+failedStreamResponseError :: ResponseFailure -> ApiError
+failedStreamResponseError failure =
+    mkOpenAIError
+        (maybe ApiErrorType errorTypeFromText
+            (failure.failureErrorType <|> failure.failureErrorCode))
+        (failedStreamResponseMessage failure)
+        failure.failureErrorCode
+        Nothing
+
 failedResponseError :: Maybe OpenAI.ResponseError -> ApiError
 failedResponseError Nothing =
     ProviderError ApiErrorType "Codex response failed without error details" Nothing
@@ -64,43 +94,10 @@ failedResponseError (Just responseError) =
         (Just responseError.code)
         Nothing
 
--- | Parse an SSE stream and build its final response.
-extractCompletedResponse :: Text -> Maybe Aeson.Value
-extractCompletedResponse sseText =
-    let eventBlocks = Text.splitOn "\n\n" sseText
-        parsed = map parseSSEBlock eventBlocks
-        completedResponse = lastMay [response | (_, Just response, _) <- parsed]
-        doneItems = [item | (Just "response.output_item.done", _, Just item) <- parsed]
-    in mergeCompletedResponseOutput doneItems <$> completedResponse
-
--- | Parse a single SSE event block, returning its event type, completed
--- response object, and output item object respectively.
-parseSSEBlock :: Text -> (Maybe Text, Maybe Aeson.Value, Maybe Aeson.Value)
-parseSSEBlock block =
-    let eventType = listToMaybe
-            [ Text.strip (Text.drop 6 line)
-            | line <- Text.lines block
-            , Text.isPrefixOf "event:" line
-            ]
-        dataLines =
-            [ Text.drop 5 line
-            | line <- Text.lines block
-            , Text.isPrefixOf "data:" line
-            ]
-        dataText = Text.intercalate "\n" (map Text.strip dataLines)
-    in case Aeson.eitherDecodeStrict' (Text.encodeUtf8 dataText) of
-        Right (Aeson.Object object) ->
-            ( eventType
-            , KeyMap.lookup "response" object
-            , KeyMap.lookup "item" object
-            )
-        _ -> (eventType, Nothing, Nothing)
-
-lastMay :: [value] -> Maybe value
-lastMay [] = Nothing
-lastMay [value] = Just value
-lastMay (_ : rest) = lastMay rest
-
-listToMaybe :: [value] -> Maybe value
-listToMaybe [] = Nothing
-listToMaybe (value : _) = Just value
+looksLikeSse :: Text -> Bool
+looksLikeSse bodyText =
+    any
+        (\line ->
+            Text.isPrefixOf "event:" line
+                || Text.isPrefixOf "data:" line)
+        (Text.lines bodyText)

--- a/packages/agent-openai/src/Agent/OpenAI/LoopBackend.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/LoopBackend.hs
@@ -51,6 +51,7 @@ import Agent.Responses.LoopBackend
     , responseTokenUsage
     , statelessResponsesBackend
     , streamEventToLoopEvent
+    , streamOutputObserved
     , toolResultToItem
     , turnInputsToItems
     , withRequestInput
@@ -120,7 +121,7 @@ openAiResponseSenderReconnecting
     -> IO (Either ApiError Response)
 openAiResponseSenderReconnecting =
     openAiResponseSenderReconnectingWhen
-        (isJust . streamEventToLoopEvent)
+        streamOutputObserved
         markLoopReplayUnsafe
 
 -- | Auxiliary Responses requests are not rendered to the loop, so their
@@ -393,14 +394,7 @@ openAiResponseSenderWithRetryPolicy retryPolicy observed send
             _ -> pure result
 
 auxiliaryOutputObserved :: ResponseStreamEvent -> Bool
-auxiliaryOutputObserved = \case
-    ResponseCompletedEvent{} -> True
-    ResponseDoneEvent{} -> True
-    ResponseFailedEvent{response} -> not (null response.output)
-    ResponseIncompleteEvent{} -> True
-    ResponseOutputItemAddedEvent{} -> True
-    ResponseOutputItemDoneEvent{} -> True
-    event -> isJust (streamEventToLoopEvent event)
+auxiliaryOutputObserved = streamOutputObserved
 
 markLoopReplayUnsafe :: ApiError -> ApiError
 markLoopReplayUnsafe err
@@ -535,7 +529,7 @@ openAiBackendWithRetryPolicy retryPolicy send getParams transcript =
       where
         go emittedLoopEvent retryStatus = do
             result <- send request previousResponseId \event -> do
-                if isJust (streamEventToLoopEvent event)
+                if streamOutputObserved event
                     then writeIORef emittedLoopEvent True
                     else pure ()
                 onStreamEvent event

--- a/packages/agent-openai/src/Agent/OpenAI/WebSocketClient.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/WebSocketClient.hs
@@ -15,6 +15,8 @@ module Agent.OpenAI.WebSocketClient
     , buildCodexWsHeaders
     , StreamEventCallback
     , RawStreamEventCallback
+    , WebSocketReceiveActions(..)
+    , receiveWsResponseWithActions
     , CodexConn
     , closeCodexConn
     , CodexAuthFailed(..)
@@ -25,8 +27,14 @@ import Agent.OpenAI.Credential (poolTokenProvider)
 import Agent.Error
 import Agent.OpenAI.Error (isPreviousResponseIdError, mkOpenAIError)
 import Agent.OpenAI.Features (remoteCompactionV2Feature)
-import Agent.Responses.ResponseMerge (mergeCompletedResponseOutput)
-import Agent.Responses.StreamAssembly (assembleDoneResponse)
+import Agent.Responses.StreamAssembly
+    ( ResponseFailure(..)
+    , applyStreamEvent
+    , emptyStreamAssemblyState
+    , failedStreamResponseMessage
+    , finishStreamResponse
+    , responseFailureFromState
+    )
 import qualified Agent.Responses.Codec as ResponsesCodec
 import qualified Agent.Transport.WebSocket as WebSocket
 import Agent.Provider
@@ -38,6 +46,7 @@ import Agent.Provider
     , runWithTokenProviderAfter
     )
 import Agent.Responses.Types
+import Control.Applicative ((<|>))
 import Control.Retry
     ( RetryPolicyM
     , exponentialBackoff
@@ -341,7 +350,7 @@ sendWsRequestWithEventsAndOptions options cc request previousResponseId onEvent 
             sendRes <- WebSocket.sendWebSocketText wsRequest encoded
             case sendRes of
                 Left apiError -> pure (Left apiError)
-                Right () -> receiveWsResponse wsRequest onEvent
+                Right () -> receiveWsResponse request.model wsRequest onEvent
 
 -- | Pure WebSocket envelope builder, exported for payload contract tests.
 -- All fields are flattened at the top level (not nested inside "response").
@@ -368,127 +377,113 @@ buildWsPayloadWithOptions options request previousResponseId =
             ])
         _ -> id
 
--- | Receive typed WebSocket events until the response is complete.
--- Accumulates output items from 'ResponseOutputItemDoneEvent' values and
--- returns the response carried by a terminal response event.
-receiveWsResponse :: WebSocket.WebSocketRequest -> StreamEventCallback -> IO (Either ApiError Response)
-receiveWsResponse cc onEvent = do
-    itemsRef <- newIORef ([] :: [Aeson.Value])
-    lifecycleResponseRef <- newIORef (Nothing :: Maybe Response)
+data WebSocketReceiveActions = WebSocketReceiveActions
+    { receiveFrame      :: !(IO (Either ApiError LBS.ByteString))
+    , completeRequest   :: !(IO ())
+    , invalidateRequest :: !(Text -> IO ())
+    }
+
+receiveWsResponse
+    :: Maybe Text
+    -> WebSocket.WebSocketRequest
+    -> StreamEventCallback
+    -> IO (Either ApiError Response)
+receiveWsResponse modelHint cc =
+    receiveWsResponseWithActions modelHint WebSocketReceiveActions
+        { receiveFrame = WebSocket.receiveWebSocketData cc
+        , completeRequest = WebSocket.completeWebSocketRequest cc
+        , invalidateRequest = WebSocket.invalidateWebSocketRequest cc
+        }
+
+-- | Injectable receive driver used by the production WebSocket path and by
+-- deterministic terminal-boundary regression tests.
+receiveWsResponseWithActions
+    :: Maybe Text
+    -> WebSocketReceiveActions
+    -> StreamEventCallback
+    -> IO (Either ApiError Response)
+receiveWsResponseWithActions modelHint actions onEvent = do
+    assemblyRef <- newIORef emptyStreamAssemblyState
     framesRef <- newIORef (0 :: Int)
     bytesRef <- newIORef (0 :: Int64)
-    loop itemsRef lifecycleResponseRef framesRef bytesRef
+    loop assemblyRef framesRef bytesRef
   where
-    loop itemsRef lifecycleResponseRef framesRef bytesRef = do
-        msgResult <- WebSocket.receiveWebSocketData cc
+    loop assemblyRef framesRef bytesRef = do
+        msgResult <- actions.receiveFrame
         case msgResult of
             Left e -> do
-                logStreamStats "connection_error" itemsRef framesRef bytesRef
+                logStreamStats "connection_error" framesRef bytesRef
                 pure $ Left e
             Right (msgBytes :: LBS.ByteString) -> do
                 recordFrame framesRef bytesRef msgBytes
                 case ResponsesCodec.decodeResponseStreamEvent msgBytes of
                     Left err -> do
                         let msgPreview = Text.decodeUtf8With Text.lenientDecode (LBS.toStrict msgBytes)
-                        logStreamStats "json_decode_error" itemsRef framesRef bytesRef
-                        WebSocket.invalidateWebSocketRequest cc
+                        logStreamStats "json_decode_error" framesRef bytesRef
+                        actions.invalidateRequest
                             "received a malformed response frame"
                         pure $ Left (JsonDecodeError (Text.pack err) (Text.take 500 msgPreview))
                     Right event -> do
                         onEvent event
+                        modifyIORef' assemblyRef (`applyStreamEvent` event)
                         case event of
                             ResponseErrorEvent { streamError } -> do
-                                logStreamStats "error_event" itemsRef framesRef bytesRef
-                                WebSocket.completeWebSocketRequest cc
+                                logStreamStats "error_event" framesRef bytesRef
+                                actions.completeRequest
                                 pure $ Left (parseWsErrorEvent streamError)
 
                             ResponseNestedErrorEvent { streamError } -> do
-                                logStreamStats "error_event" itemsRef framesRef bytesRef
-                                WebSocket.completeWebSocketRequest cc
+                                logStreamStats "error_event" framesRef bytesRef
+                                actions.completeRequest
                                 pure $ Left (parseWsErrorEvent streamError)
 
-                            ResponseOutputItemDoneEvent { item } -> do
-                                modifyIORef' itemsRef (Aeson.toJSON item :)
-                                loop itemsRef lifecycleResponseRef framesRef bytesRef
+                            ResponseCompletedEvent{} ->
+                                finishTerminal "completed" assemblyRef framesRef bytesRef event
 
-                            ResponseCreatedEvent { response } -> do
-                                writeIORef lifecycleResponseRef (Just response)
-                                loop itemsRef lifecycleResponseRef framesRef bytesRef
+                            ResponseDoneEvent{} ->
+                                finishTerminal "done" assemblyRef framesRef bytesRef event
 
-                            ResponseInProgressEvent { response } -> do
-                                writeIORef lifecycleResponseRef (Just response)
-                                loop itemsRef lifecycleResponseRef framesRef bytesRef
+                            ResponseIncompleteEvent{} ->
+                                finishTerminal "incomplete" assemblyRef framesRef bytesRef event
 
-                            ResponseQueuedEvent { response } -> do
-                                writeIORef lifecycleResponseRef (Just response)
-                                loop itemsRef lifecycleResponseRef framesRef bytesRef
-
-                            ResponseCompletedEvent { response } -> do
-                                items <- reverse <$> readIORef itemsRef
-                                logStreamStats "completed" itemsRef framesRef bytesRef
-                                WebSocket.completeWebSocketRequest cc
-                                parseCompletedResponse items (Aeson.toJSON response)
-
-                            ResponseDoneEvent { responseValue } -> do
-                                items <- reverse <$> readIORef itemsRef
-                                lifecycleResponse <- readIORef lifecycleResponseRef
-                                logStreamStats "done" itemsRef framesRef bytesRef
-                                WebSocket.completeWebSocketRequest cc
-                                pure $
-                                    assembleDoneResponse
-                                        lifecycleResponse
-                                        items
-                                        responseValue
-
-                            ResponseIncompleteEvent { response } -> do
-                                items <- reverse <$> readIORef itemsRef
-                                logStreamStats "incomplete" itemsRef framesRef bytesRef
-                                WebSocket.completeWebSocketRequest cc
-                                parseCompletedResponse items (Aeson.toJSON response)
-
-                            ResponseFailedEvent { response } -> do
-                                logStreamStats "response_failed" itemsRef framesRef bytesRef
-                                WebSocket.completeWebSocketRequest cc
-                                pure $ Left (failedResponseError response)
+                            ResponseFailedEvent{} -> do
+                                state <- readIORef assemblyRef
+                                logStreamStats "response_failed" framesRef bytesRef
+                                actions.completeRequest
+                                pure $ Left
+                                    (failedResponseError
+                                        (responseFailureFromState state))
 
                             -- Ignore other event variants (added, content
                             -- deltas, and future event types).
-                            _ -> loop itemsRef lifecycleResponseRef framesRef bytesRef
+                            _ -> loop assemblyRef framesRef bytesRef
+
+    finishTerminal label assemblyRef framesRef bytesRef event = do
+        state <- readIORef assemblyRef
+        logStreamStats label framesRef bytesRef
+        actions.completeRequest
+        pure (finishStreamResponse modelHint state event)
 
     recordFrame :: IORef Int -> IORef Int64 -> LBS.ByteString -> IO ()
     recordFrame framesRef bytesRef msgBytes = do
         modifyIORef' framesRef (+ 1)
         modifyIORef' bytesRef (+ LBS.length msgBytes)
 
-    logStreamStats :: Text -> IORef [Aeson.Value] -> IORef Int -> IORef Int64 -> IO ()
-    logStreamStats _label _itemsRef _framesRef _bytesRef = pure ()
+    logStreamStats :: Text -> IORef Int -> IORef Int64 -> IO ()
+    logStreamStats _label _framesRef _bytesRef = pure ()
 
-    parseCompletedResponse :: [Aeson.Value] -> Aeson.Value -> IO (Either ApiError Response)
-    parseCompletedResponse doneItems responseVal = do
-        -- Merge accumulated output items into the response object. The
-        -- completed event may contain only messages/reasoning while streamed
-        -- tool calls are present solely in response.output_item.done events.
-        let patched = mergeCompletedResponseOutput doneItems responseVal
-        case Aeson.fromJSON patched of
-            Aeson.Success resp -> pure (Right resp)
-            Aeson.Error err -> pure $ Left (JsonDecodeError (Text.pack err) (Text.decodeUtf8 (LBS.toStrict (LBS.take 2000 (Aeson.encode patched)))))
-
-    failedResponseMessage :: Response -> Text
-    failedResponseMessage response =
-        case response.error of
-            Just responseError -> responseError.message
-            Nothing -> case response.incompleteDetails of
-                Just details -> "response.failed: " <> details.reason
-                Nothing -> "response.failed (no details)"
-
-    failedResponseError response = case response.error of
-        Just responseError ->
-            mkOpenAIError
-                (errorTypeFromText responseError.code)
-                responseError.message
-                (Just responseError.code)
-                Nothing
-        Nothing -> ConnectionError (failedResponseMessage response)
+    failedResponseError failure =
+        case failure.failureErrorType
+                <|> failure.failureErrorCode
+                <|> failure.failureErrorMessage of
+            Nothing -> ConnectionError (failedStreamResponseMessage failure)
+            Just _ ->
+                mkOpenAIError
+                    (maybe ApiErrorType errorTypeFromText
+                        (failure.failureErrorType <|> failure.failureErrorCode))
+                    (failedStreamResponseMessage failure)
+                    failure.failureErrorCode
+                    Nothing
 
 -- | Parse a server @type: error@ event into a structured 'ApiError'.
 --

--- a/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
@@ -8,6 +8,7 @@ import Agent.Error
 import Agent.InterAgentMessage
 import Agent.Loop
 import Agent.OpenAI.LoopBackend
+import Agent.Responses.LoopBackend (streamOutputObserved)
 import Agent.Responses.Types
 import Agent.ToolDispatch
 import Control.Retry (constantDelay, limitRetries)
@@ -227,10 +228,33 @@ spec = do
                 `shouldBe` Nothing
             streamEventToLoopEvent (ResponseOutputItemDoneEvent
                 { item = assistantItem "x"
-                , outputIndex = 0
+                , outputIndex = Just 0
                 , sequenceNumber = Nothing
                 , eventExtraFields = KeyMap.empty
                 }) `shouldBe` Nothing
+
+    describe "streamOutputObserved" do
+        it "treats terminal lifecycle events as replay-unsafe" do
+            streamOutputObserved
+                (ResponseCompletedEvent (Aeson.object []) Nothing KeyMap.empty)
+                `shouldBe` True
+            streamOutputObserved
+                (ResponseDoneEvent (Aeson.object []) Nothing KeyMap.empty)
+                `shouldBe` True
+            streamOutputObserved
+                (ResponseIncompleteEvent (Aeson.object []) Nothing KeyMap.empty)
+                `shouldBe` True
+
+        it "treats failed lifecycle events as output only when output is present" do
+            streamOutputObserved
+                (ResponseFailedEvent
+                    (Aeson.object ["output" Aeson..= [Aeson.object []]])
+                    Nothing
+                    KeyMap.empty)
+                `shouldBe` True
+            streamOutputObserved
+                (ResponseFailedEvent (Aeson.object []) Nothing KeyMap.empty)
+                `shouldBe` False
 
     describe "statelessResponsesBackend" do
         it "replays the local transcript on tool follow-ups" do
@@ -527,7 +551,7 @@ spec = do
             let connectionFailure = ConnectionError "socket closed"
                 outputEvent = ResponseOutputItemDoneEvent
                     { item = assistantItem "partial"
-                    , outputIndex = 0
+                    , outputIndex = Just 0
                     , sequenceNumber = Nothing
                     , eventExtraFields = KeyMap.empty
                     }
@@ -553,8 +577,8 @@ spec = do
             healthy <- newIORef True
             let connectionFailure = ConnectionError "decode failed"
                 completedEvent = ResponseCompletedEvent
-                    { response =
-                        testResponse "resp-completed" [assistantItem "done"]
+                    { responseValue = Aeson.toJSON
+                        (testResponse "resp-completed" [assistantItem "done"])
                     , sequenceNumber = Nothing
                     , eventExtraFields = KeyMap.empty
                     }
@@ -580,8 +604,8 @@ spec = do
             healthy <- newIORef True
             let connectionFailure = ConnectionError "failed response"
                 failedEvent = ResponseFailedEvent
-                    { response =
-                        testResponse "resp-failed" [assistantItem "partial"]
+                    { responseValue = Aeson.toJSON
+                        (testResponse "resp-failed" [assistantItem "partial"])
                     , sequenceNumber = Nothing
                     , eventExtraFields = KeyMap.empty
                     }
@@ -609,7 +633,7 @@ spec = do
             let connectionFailure = ConnectionError "fresh socket closed"
                 outputEvent = ResponseOutputItemDoneEvent
                     { item = assistantItem "partial"
-                    , outputIndex = 0
+                    , outputIndex = Just 0
                     , sequenceNumber = Nothing
                     , eventExtraFields = KeyMap.empty
                     }
@@ -638,7 +662,7 @@ spec = do
                 freshFailure = ConnectionError "fresh socket closed"
                 outputEvent = ResponseOutputItemDoneEvent
                     { item = assistantItem "partial"
-                    , outputIndex = 0
+                    , outputIndex = Just 0
                     , sequenceNumber = Nothing
                     , eventExtraFields = KeyMap.empty
                     }
@@ -1115,7 +1139,7 @@ shouldMarkPostOutputAuxiliaryFailure failure = do
     freshCalls <- newIORef (0 :: Int)
     let outputEvent = ResponseOutputItemDoneEvent
             { item = assistantItem "partial"
-            , outputIndex = 0
+            , outputIndex = Just 0
             , sequenceNumber = Nothing
             , eventExtraFields = KeyMap.empty
             }
@@ -1139,13 +1163,7 @@ shouldMarkPostOutputAuxiliaryFailure failure = do
     readIORef freshCalls `shouldReturn` 0
 
 isAuxiliaryOutputEvent :: ResponseStreamEvent -> Bool
-isAuxiliaryOutputEvent = \case
-    ResponseCompletedEvent{} -> True
-    ResponseFailedEvent{response} -> not (null response.output)
-    ResponseIncompleteEvent{} -> True
-    ResponseOutputItemAddedEvent{} -> True
-    ResponseOutputItemDoneEvent{} -> True
-    _ -> False
+isAuxiliaryOutputEvent = streamOutputObserved
 
 replayUnsafeAuxiliaryFailure :: ApiError -> ApiError
 replayUnsafeAuxiliaryFailure failure =

--- a/packages/agent-openai/test/Agent/OpenAI/ResponsesSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/ResponsesSpec.hs
@@ -111,24 +111,84 @@ spec = do
                     ]
             case Aeson.fromJSON original :: Aeson.Result Responses.ResponseStreamEvent of
                 Aeson.Success Responses.ResponseOutputItemDoneEvent { item, outputIndex } -> do
-                    outputIndex `shouldBe` 0
+                    outputIndex `shouldBe` Just 0
                     item `shouldSatisfy` \case
                         Responses.MessageItem{} -> True
                         _ -> False
                 Aeson.Success other -> expectationFailure ("unexpected event: " <> show other)
                 Aeson.Error err -> expectationFailure err
 
-        it "decodes response completion into a typed response" do
+        it "decodes indexless output-item completion losslessly" do
+            let original = Aeson.object
+                    [ "type" .= ("response.output_item.done" :: Text)
+                    , "sequence_number" .= Aeson.Null
+                    , "output_index" .= Aeson.Null
+                    , "item" .= Aeson.object
+                        [ "type" .= ("function_call" :: Text)
+                        , "call_id" .= ("call_1" :: Text)
+                        , "name" .= ("shell_command" :: Text)
+                        , "arguments" .= ("{}" :: Text)
+                        ]
+                    ]
+            case Aeson.fromJSON original :: Aeson.Result Responses.ResponseStreamEvent of
+                Aeson.Success event@Responses.ResponseOutputItemDoneEvent
+                        { outputIndex, sequenceNumber } -> do
+                    outputIndex `shouldBe` Nothing
+                    sequenceNumber `shouldBe` Nothing
+                    Aeson.toJSON event `shouldBe` original
+                Aeson.Success other -> expectationFailure ("unexpected event: " <> show other)
+                Aeson.Error err -> expectationFailure err
+
+        it "decodes response completion into a lossless response fragment" do
             let original = Aeson.object
                     [ "type" .= ("response.completed" :: Text)
                     , "sequence_number" .= (4 :: Int)
                     , "response" .= canonicalResponseJson "completed"
                     ]
             case Aeson.fromJSON original :: Aeson.Result Responses.ResponseStreamEvent of
-                Aeson.Success Responses.ResponseCompletedEvent { response } ->
-                    response.responseId `shouldBe` "resp_1"
+                Aeson.Success event@Responses.ResponseCompletedEvent { responseValue } -> do
+                    responseValue `shouldBe` canonicalResponseJson "completed"
+                    Aeson.toJSON event `shouldBe` original
                 Aeson.Success other -> expectationFailure ("unexpected event: " <> show other)
                 Aeson.Error err -> expectationFailure err
+
+        it "accepts minimal and partial lifecycle response fragments losslessly" do
+            mapM_ assertLifecycleFixture
+                [ ( "response.created"
+                  , Responses.EventResponseCreated
+                  , Aeson.object ["id" .= ("resp_created" :: Text)]
+                  )
+                , ( "response.in_progress"
+                  , Responses.EventResponseInProgress
+                  , Aeson.object ["id" .= ("resp_progress" :: Text)]
+                  )
+                , ( "response.queued"
+                  , Responses.EventResponseQueued
+                  , Aeson.object ["id" .= ("resp_queued" :: Text)]
+                  )
+                , ( "response.completed"
+                  , Responses.EventResponseCompleted
+                  , Aeson.object
+                        [ "id" .= ("resp_completed" :: Text)
+                        , "usage" .= Aeson.object ["input_tokens" .= (10 :: Int)]
+                        ]
+                  )
+                , ( "response.failed"
+                  , Responses.EventResponseFailed
+                  , Aeson.object
+                        [ "id" .= ("resp_failed" :: Text)
+                        , "error" .= Aeson.object ["message" .= ("failed" :: Text)]
+                        ]
+                  )
+                , ( "response.incomplete"
+                  , Responses.EventResponseIncomplete
+                  , Aeson.object
+                        [ "id" .= ("resp_incomplete" :: Text)
+                        , "incomplete_details" .=
+                            Aeson.object ["reason" .= ("max_output_tokens" :: Text)]
+                        ]
+                  )
+                ]
 
         it "decodes the Codex WebSocket response.done terminal event losslessly" do
             let original = Aeson.object
@@ -150,18 +210,132 @@ spec = do
                 Aeson.Success other -> expectationFailure ("unexpected event: " <> show other)
                 Aeson.Error err -> expectationFailure err
 
-        it "decodes response incomplete into its typed terminal constructor" do
+        it "decodes response incomplete into its typed terminal constructor losslessly" do
             let original = Aeson.object
                     [ "type" .= ("response.incomplete" :: Text)
                     , "sequence_number" .= (5 :: Int)
                     , "response" .= canonicalResponseJson "incomplete"
                     ]
             case Aeson.fromJSON original :: Aeson.Result Responses.ResponseStreamEvent of
-                Aeson.Success Responses.ResponseIncompleteEvent { response } -> do
-                    response.status `shouldBe` Responses.ResponseIncomplete
-                    response.responseId `shouldBe` "resp_1"
+                Aeson.Success event@Responses.ResponseIncompleteEvent { responseValue } -> do
+                    responseValue `shouldBe` canonicalResponseJson "incomplete"
+                    Aeson.toJSON event `shouldBe` original
                 Aeson.Success other -> expectationFailure ("unexpected event: " <> show other)
                 Aeson.Error err -> expectationFailure err
+
+        it "decodes Codex custom-tool input deltas without an output index" do
+            let original = Aeson.object
+                    [ "type" .= ("response.custom_tool_call_input.delta" :: Text)
+                    , "item_id" .= ("ctc_1" :: Text)
+                    , "call_id" .= ("call_1" :: Text)
+                    , "delta" .= ("*** Begin" :: Text)
+                    , "future_event_field" .= True
+                    ]
+            case Aeson.fromJSON original :: Aeson.Result Responses.ResponseStreamEvent of
+                Aeson.Success event@Responses.ResponseCustomToolInputDeltaEvent
+                        { delta, streamItemId, streamCallId, streamOutputIndex } -> do
+                    delta `shouldBe` Just "*** Begin"
+                    streamItemId `shouldBe` Just "ctc_1"
+                    streamCallId `shouldBe` Just "call_1"
+                    streamOutputIndex `shouldBe` Nothing
+                    Aeson.toJSON event `shouldBe` original
+                Aeson.Success other -> expectationFailure ("unexpected event: " <> show other)
+                Aeson.Error err -> expectationFailure err
+
+        it "decodes completed custom-tool input losslessly" do
+            let original = Aeson.object
+                    [ "type" .= ("response.custom_tool_call_input.done" :: Text)
+                    , "item_id" .= ("ctc_1" :: Text)
+                    , "output_index" .= (2 :: Int)
+                    , "input" .= ("*** End Patch" :: Text)
+                    ]
+            case Aeson.fromJSON original :: Aeson.Result Responses.ResponseStreamEvent of
+                Aeson.Success event@Responses.ResponseCustomToolInputDoneEvent
+                        { inputText, streamItemId, streamCallId, streamOutputIndex } -> do
+                    inputText `shouldBe` Just "*** End Patch"
+                    streamItemId `shouldBe` Just "ctc_1"
+                    streamCallId `shouldBe` Nothing
+                    streamOutputIndex `shouldBe` Just 2
+                    Aeson.toJSON event `shouldBe` original
+                Aeson.Success other -> expectationFailure ("unexpected event: " <> show other)
+                Aeson.Error err -> expectationFailure err
+
+        it "decodes reasoning summary parts without requiring an output index" do
+            let part = Aeson.object
+                    [ "type" .= ("summary_text" :: Text)
+                    , "text" .= ("partial summary" :: Text)
+                    ]
+                original = Aeson.object
+                    [ "type" .= ("response.reasoning_summary_part.added" :: Text)
+                    , "item_id" .= ("reasoning_1" :: Text)
+                    , "summary_index" .= (0 :: Int)
+                    , "part" .= part
+                    ]
+            case Aeson.fromJSON original :: Aeson.Result Responses.ResponseStreamEvent of
+                Aeson.Success event@Responses.ResponseReasoningSummaryPartAddedEvent
+                        { streamItemId, streamOutputIndex, summaryIndex, partValue } -> do
+                    streamItemId `shouldBe` Just "reasoning_1"
+                    streamOutputIndex `shouldBe` Nothing
+                    summaryIndex `shouldBe` Just 0
+                    partValue `shouldBe` Just part
+                    Aeson.toJSON event `shouldBe` original
+                Aeson.Success other -> expectationFailure ("unexpected event: " <> show other)
+                Aeson.Error err -> expectationFailure err
+
+        it "decodes completed reasoning summary text without an output index" do
+            let original = Aeson.object
+                    [ "type" .= ("response.reasoning_summary_text.done" :: Text)
+                    , "item_id" .= ("reasoning_1" :: Text)
+                    , "summary_index" .= (0 :: Int)
+                    , "text" .= ("final summary" :: Text)
+                    ]
+            case Aeson.fromJSON original :: Aeson.Result Responses.ResponseStreamEvent of
+                Aeson.Success event@Responses.ResponseReasoningSummaryTextDoneEvent
+                        { streamItemId, streamOutputIndex, summaryIndex, text } -> do
+                    streamItemId `shouldBe` Just "reasoning_1"
+                    streamOutputIndex `shouldBe` Nothing
+                    summaryIndex `shouldBe` Just 0
+                    text `shouldBe` Just "final summary"
+                    Aeson.toJSON event `shouldBe` original
+                Aeson.Success other -> expectationFailure ("unexpected event: " <> show other)
+                Aeson.Error err -> expectationFailure err
+
+        it "accepts payload-light Codex incremental events losslessly" do
+            mapM_
+                (\eventName -> do
+                    let original = Aeson.object ["type" .= eventName]
+                    case Aeson.fromJSON original
+                            :: Aeson.Result Responses.ResponseStreamEvent of
+                        Aeson.Success event ->
+                            Aeson.toJSON event `shouldBe` original
+                        Aeson.Error err ->
+                            expectationFailure
+                                (show (eventName :: Text) <> ": " <> err))
+                [ "response.custom_tool_call_input.delta"
+                , "response.custom_tool_call_input.done"
+                , "response.reasoning_summary_part.added"
+                , "response.reasoning_summary_text.done"
+                ]
+
+        it "recognises Codex metadata and timing events without discarding fields" do
+            mapM_ assertKnownMetadataEvent
+                [ ( "codex.rate_limits"
+                  , Responses.EventCodexRateLimits
+                  , [ "rate_limits" .=
+                        Aeson.object ["primary" .= Aeson.object ["used_percent" .= (12 :: Int)]]
+                    ]
+                  )
+                , ( "response.metadata"
+                  , Responses.EventResponseMetadata
+                  , [ "headers" .=
+                        Aeson.object ["x-codex-turn-state" .= ("state_1" :: Text)]
+                    ]
+                  )
+                , ( "responsesapi.websocket_timing"
+                  , Responses.EventResponsesApiWebSocketTiming
+                  , ["elapsed_ms" .= (17 :: Int)]
+                  )
+                ]
 
         it "decodes the Codex nested error envelope into a typed error" do
             let original = Aeson.object
@@ -366,6 +540,48 @@ assertKnownEvent eventName = do
             Aeson.toJSON event `shouldBe` original
         Aeson.Error err -> expectationFailure (show eventName <> ": " <> err)
 
+assertLifecycleFixture
+    :: (Text, Responses.StreamEventType, Aeson.Value)
+    -> Expectation
+assertLifecycleFixture (eventName, expectedType, responseValue) = do
+    let original = Aeson.object
+            [ "type" .= eventName
+            , "response" .= responseValue
+            , "future_event_field" .= True
+            ]
+    case Aeson.fromJSON original :: Aeson.Result Responses.ResponseStreamEvent of
+        Aeson.Success event -> do
+            Responses.responseStreamEventType event `shouldBe` expectedType
+            lifecycleResponseValue event `shouldBe` Just responseValue
+            Aeson.toJSON event `shouldBe` original
+        Aeson.Error err -> expectationFailure (show eventName <> ": " <> err)
+
+lifecycleResponseValue :: Responses.ResponseStreamEvent -> Maybe Aeson.Value
+lifecycleResponseValue = \case
+    Responses.ResponseCreatedEvent { responseValue } -> Just responseValue
+    Responses.ResponseInProgressEvent { responseValue } -> Just responseValue
+    Responses.ResponseCompletedEvent { responseValue } -> Just responseValue
+    Responses.ResponseDoneEvent { responseValue } -> Just responseValue
+    Responses.ResponseFailedEvent { responseValue } -> Just responseValue
+    Responses.ResponseIncompleteEvent { responseValue } -> Just responseValue
+    Responses.ResponseQueuedEvent { responseValue } -> Just responseValue
+    _ -> Nothing
+
+assertKnownMetadataEvent
+    :: (Text, Responses.StreamEventType, [(Key.Key, Aeson.Value)])
+    -> Expectation
+assertKnownMetadataEvent (eventName, expectedType, payload) = do
+    let original = Aeson.object
+            ([ "type" .= eventName
+             , "sequence_number" .= (8 :: Int)
+             , "future_event_field" .= True
+             ] <> payload)
+    case Aeson.fromJSON original :: Aeson.Result Responses.ResponseStreamEvent of
+        Aeson.Success event -> do
+            Responses.responseStreamEventType event `shouldBe` expectedType
+            Aeson.toJSON event `shouldBe` original
+        Aeson.Error err -> expectationFailure (show eventName <> ": " <> err)
+
 requiredEventFields :: Text -> [(Key.Key, Aeson.Value)]
 requiredEventFields eventName
     | eventName == "response.done" =
@@ -381,7 +597,7 @@ requiredEventFields eventName
         , "response.failed"
         , "response.incomplete"
         , "response.queued"
-        ] = [("response", canonicalResponseJson "completed")]
+        ] = [("response", Aeson.object ["id" .= ("resp_partial" :: Text)])]
     | eventName `elem` ["response.output_item.added", "response.output_item.done"] =
         [ ("output_index", Aeson.Number 0)
         , ("item", Aeson.object
@@ -389,6 +605,16 @@ requiredEventFields eventName
             , "role" .= ("assistant" :: Text)
             , "content" .= ([] :: [Aeson.Value])
             ])
+        ]
+    | eventName == "response.custom_tool_call_input.delta" =
+        [("delta", Aeson.String "partial")]
+    | eventName == "response.custom_tool_call_input.done" =
+        [("input", Aeson.String "complete")]
+    | eventName == "response.reasoning_summary_part.added" =
+        [("summary_index", Aeson.Number 0)]
+    | eventName == "response.reasoning_summary_text.done" =
+        [ ("summary_index", Aeson.Number 0)
+        , ("text", Aeson.String "summary")
         ]
     | eventName == "error" =
         [ ("code", Aeson.String "stream_error")

--- a/packages/agent-openai/test/Agent/OpenAI/WebSocketClientSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/WebSocketClientSpec.hs
@@ -9,6 +9,7 @@ import Control.Retry (constantDelay, limitRetries)
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy as LBS
 import Data.IORef
 import Data.Text (Text)
 
@@ -79,6 +80,91 @@ spec = do
         run (ProviderError UsageLimitReached "quota" (Just 3600))
             `shouldReturn` Left (ProviderError UsageLimitReached "quota" (Just 3600))
         readIORef attempts `shouldReturn` 3
+
+  describe "receiveWsResponseWithActions" do
+    it "assembles the Codex indexless function-call sequence through response.done" do
+        testPartialTerminalResponse
+            [ lifecycleFrame "response.created"
+                (Aeson.object ["id" Aeson..= ("resp-test" :: Text)])
+            , Aeson.encode $ Aeson.object
+                [ "type" Aeson..= ("response.output_item.done" :: Text)
+                , "item" Aeson..= Aeson.object
+                    [ "type" Aeson..= ("function_call" :: Text)
+                    , "call_id" Aeson..= ("call-test" :: Text)
+                    , "name" Aeson..= ("shell_command" :: Text)
+                    , "arguments" Aeson..= ("{}" :: Text)
+                    ]
+                ]
+            , lifecycleFrame "response.done"
+                (Aeson.object
+                    [ "usage" Aeson..= Aeson.object
+                        [ "input_tokens" Aeson..= (10 :: Int)
+                        , "output_tokens" Aeson..= (2 :: Int)
+                        , "total_tokens" Aeson..= (12 :: Int)
+                        ]
+                    ])
+            ]
+            [EventResponseCreated, EventOutputItemDone, EventResponseDone]
+            \response ->
+                [name | FunctionCallItem FunctionCall { name } <- response.output]
+                    `shouldBe` ["shell_command"]
+
+    it "assembles a minimal response.created followed by response.completed" do
+        testPartialTerminalResponse
+            [ lifecycleFrame "response.created"
+                (Aeson.object ["id" Aeson..= ("resp-test" :: Text)])
+            , lifecycleFrame "response.completed" (Aeson.object [])
+            ]
+            [EventResponseCreated, EventResponseCompleted]
+            \response -> response.output `shouldBe` []
+
+testPartialTerminalResponse
+    :: [LBS.ByteString]
+    -> [StreamEventType]
+    -> (Response -> Expectation)
+    -> Expectation
+testPartialTerminalResponse inputFrames expectedTypes checkResponse = do
+    frames <- newIORef inputFrames
+    receiveCount <- newIORef (0 :: Int)
+    completeCount <- newIORef (0 :: Int)
+    invalidations <- newIORef ([] :: [Text])
+    callbackTypes <- newIORef ([] :: [StreamEventType])
+
+    let actions = WebSocketReceiveActions
+            { receiveFrame = do
+                modifyIORef' receiveCount (+ 1)
+                atomicModifyIORef' frames \case
+                    frame : rest -> (rest, Right frame)
+                    [] -> error "unexpected receive after terminal event"
+            , completeRequest = modifyIORef' completeCount (+ 1)
+            , invalidateRequest = \reason ->
+                modifyIORef' invalidations (<> [reason])
+            }
+        onEvent event =
+            modifyIORef' callbackTypes (<> [responseStreamEventType event])
+
+    result <- receiveWsResponseWithActions (Just "gpt-test") actions onEvent
+
+    case result of
+        Left err -> expectationFailure ("unexpected error: " <> show err)
+        Right response -> do
+            response.responseId `shouldBe` "resp-test"
+            response.model `shouldBe` "gpt-test"
+            response.object `shouldBe` "response"
+            response.status `shouldBe` ResponseCompleted
+            checkResponse response
+
+    readIORef callbackTypes `shouldReturn` expectedTypes
+    readIORef receiveCount `shouldReturn` length inputFrames
+    readIORef completeCount `shouldReturn` 1
+    readIORef invalidations `shouldReturn` []
+    readIORef frames `shouldReturn` []
+
+lifecycleFrame :: Text -> Aeson.Value -> LBS.ByteString
+lifecycleFrame eventType responseValue = Aeson.encode $ Aeson.object
+    [ "type" Aeson..= eventType
+    , "response" Aeson..= responseValue
+    ]
 
 contextManagement :: CodexWsOptions -> Maybe Aeson.Value
 contextManagement options =

--- a/packages/agent-openrouter/src/Agent/OpenRouter/Stream.hs
+++ b/packages/agent-openrouter/src/Agent/OpenRouter/Stream.hs
@@ -19,7 +19,7 @@ import Agent.Responses.SSE
 import Agent.Responses.StreamAssembly
     ( StreamAssemblyConfig(..)
     , buildStreamResponse
-    , failedResponseMessage
+    , failedStreamResponseMessage
     )
 import Agent.Responses.Types
 import Agent.OpenRouter.Error (classifyStreamError)
@@ -31,5 +31,5 @@ buildResponse = buildStreamResponse StreamAssemblyConfig
         "No terminal response event found in OpenRouter SSE stream"
     , classifyStreamError
     , classifyFailedResponse =
-        ConnectionError . failedResponseMessage
+        ConnectionError . failedStreamResponseMessage
     }

--- a/packages/agent-responses/src/Agent/Responses/HttpSSE.hs
+++ b/packages/agent-responses/src/Agent/Responses/HttpSSE.hs
@@ -125,7 +125,15 @@ retainForResponse = \case
     ResponseCreatedEvent {} -> True
     ResponseInProgressEvent {} -> True
     ResponseQueuedEvent {} -> True
+    ResponseOutputItemAddedEvent {} -> True
     ResponseOutputItemDoneEvent {} -> True
+    ResponseCustomToolInputDeltaEvent {} -> True
+    ResponseCustomToolInputDoneEvent {} -> True
+    ResponseReasoningSummaryPartAddedEvent {} -> True
+    ResponseReasoningSummaryTextDoneEvent {} -> True
+    event
+        | responseStreamEventType event
+            == EventReasoningSummaryTextDelta -> True
     ResponseCompletedEvent {} -> True
     ResponseDoneEvent {} -> True
     ResponseIncompleteEvent {} -> True

--- a/packages/agent-responses/src/Agent/Responses/LoopBackend.hs
+++ b/packages/agent-responses/src/Agent/Responses/LoopBackend.hs
@@ -6,6 +6,7 @@ module Agent.Responses.LoopBackend
     , responseToTurnOutput
     , responseTokenUsage
     , streamEventToLoopEvent
+    , streamOutputObserved
     , assistantTextFromResponse
     , toolResultToItem
     , withRequestInput
@@ -32,6 +33,7 @@ import Agent.Provider
     , TokenProvider
     , runWithTokenProvider
     )
+import Agent.Responses.StreamAssembly (responseFragmentHasOutput)
 import Agent.Responses.Types
 import Agent.ToolDispatch
     ( ToolCall(..)
@@ -45,7 +47,7 @@ import qualified Data.Aeson.KeyMap as KeyMap
 import Data.ByteString (ByteString)
 import qualified "base64-bytestring" Data.ByteString.Base64 as Base64
 import Data.IORef
-import Data.Maybe (fromMaybe, mapMaybe)
+import Data.Maybe (fromMaybe, isJust, mapMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
@@ -318,6 +320,24 @@ streamEventToLoopEvent = \case
                 _ -> Nothing
             Nothing -> Nothing
     _ -> Nothing
+
+-- | Whether a stream event proves the provider has begun producing response
+-- output. These events make replay unsafe even when they do not map to a
+-- visible loop delta.
+streamOutputObserved :: ResponseStreamEvent -> Bool
+streamOutputObserved event = case event of
+    ResponseCompletedEvent{} -> True
+    ResponseDoneEvent{} -> True
+    ResponseIncompleteEvent{} -> True
+    ResponseFailedEvent { responseValue } ->
+        responseFragmentHasOutput responseValue
+    ResponseOutputItemAddedEvent{} -> True
+    ResponseOutputItemDoneEvent{} -> True
+    ResponseCustomToolInputDeltaEvent{} -> True
+    ResponseCustomToolInputDoneEvent{} -> True
+    ResponseReasoningSummaryPartAddedEvent{} -> True
+    ResponseReasoningSummaryTextDoneEvent{} -> True
+    _ -> isJust (streamEventToLoopEvent event)
 
 extraDeltaText :: Aeson.Object -> Maybe Text
 extraDeltaText extras = nonEmptyText extras "delta" <|> nonEmptyText extras "text"

--- a/packages/agent-responses/src/Agent/Responses/ResponseMerge.hs
+++ b/packages/agent-responses/src/Agent/Responses/ResponseMerge.hs
@@ -1,6 +1,7 @@
 module Agent.Responses.ResponseMerge
     ( mergeCompletedResponseOutput
     , mergeDoneResponse
+    , mergeResponseFragments
     ) where
 
 import qualified Data.Aeson as Aeson
@@ -39,14 +40,9 @@ mergeDoneResponse
 mergeDoneResponse baseResponse streamedItems doneResponse =
     mergeCompletedResponseOutput streamedItems withTerminalStatus
   where
-    mergedResponse = case (baseResponse, doneResponse) of
-        (Just (Aeson.Object baseObject), Aeson.Object doneObject) ->
-            Aeson.Object $
-                KeyMap.foldrWithKey
-                    KeyMap.insert
-                    baseObject
-                    doneObject
-        (_, value) -> value
+    mergedResponse =
+        mergeResponseFragments
+            (Maybe.maybeToList baseResponse <> [doneResponse])
 
     withTerminalStatus = case (doneResponse, mergedResponse) of
         (Aeson.Object doneObject, Aeson.Object mergedObject)
@@ -54,6 +50,21 @@ mergeDoneResponse baseResponse streamedItems doneResponse =
                 Aeson.Object
                     (KeyMap.insert "status" (Aeson.String "completed") mergedObject)
         _ -> mergedResponse
+
+-- | Overlay partial response objects in wire order. Later fragments win while
+-- fields absent from a terminal fragment remain available from earlier
+-- lifecycle events such as @response.created@.
+mergeResponseFragments :: [Aeson.Value] -> Aeson.Value
+mergeResponseFragments =
+    foldl merge (Aeson.Object KeyMap.empty)
+  where
+    merge (Aeson.Object accumulated) (Aeson.Object fragment) =
+        Aeson.Object $
+            KeyMap.foldrWithKey
+                KeyMap.insert
+                accumulated
+                fragment
+    merge _ fragment = fragment
 
 mergeOutputItems :: [Aeson.Value] -> [Aeson.Value] -> [Aeson.Value]
 mergeOutputItems finalItems streamedItems =

--- a/packages/agent-responses/src/Agent/Responses/StreamAssembly.hs
+++ b/packages/agent-responses/src/Agent/Responses/StreamAssembly.hs
@@ -1,24 +1,35 @@
--- | Provider-neutral terminal response assembly for Responses SSE streams.
+-- | Provider-neutral terminal response assembly for Responses streams.
 module Agent.Responses.StreamAssembly
     ( StreamAssemblyConfig(..)
-    , assembleDoneResponse
+    , ResponseFailure(..)
+    , StreamAssemblyState
+    , emptyStreamAssemblyState
+    , applyStreamEvent
+    , finishStreamResponse
     , buildStreamResponse
+    , buildStreamResponseWithModel
+    , assembleDoneResponse
     , failedResponseMessage
+    , failedStreamResponseMessage
+    , responseFailureFromState
+    , responseFragmentHasOutput
     ) where
 
 import Agent.Error (ApiError(..))
-import Agent.Responses.ResponseMerge
-    ( mergeCompletedResponseOutput
-    , mergeDoneResponse
-    )
+import Agent.Responses.ResponseMerge (mergeDoneResponse)
 import Agent.Responses.Types
+import Control.Applicative ((<|>))
 import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
 import qualified Data.ByteString.Lazy as LBS
-import qualified Data.Maybe as Maybe
+import qualified Data.Map.Strict as Map
+import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
 import qualified Data.Text.Encoding.Error as TextEncoding (lenientDecode)
+import qualified Data.Vector as Vector
 
 -- | Provider-specific failure classification around shared event assembly.
 data StreamAssemblyConfig = StreamAssemblyConfig
@@ -26,45 +37,210 @@ data StreamAssemblyConfig = StreamAssemblyConfig
       -- ^ Error message when no terminal response or stream failure is present.
     , classifyStreamError :: !(ResponseStreamError -> ApiError)
       -- ^ Classify top-level and nested stream error events.
-    , classifyFailedResponse :: !(Response -> ApiError)
-      -- ^ Classify a terminal @response.failed@ event.
+    , classifyFailedResponse :: !(ResponseFailure -> ApiError)
+      -- ^ Classify a permissive terminal @response.failed@ payload.
     }
 
--- | Merge streamed output items into the last terminal response. If no
--- completed or incomplete response is present, return the first typed stream
--- failure, falling back to a decode error containing a bounded event preview.
+data ResponseFailure = ResponseFailure
+    { failureErrorType         :: !(Maybe Text)
+    , failureErrorCode         :: !(Maybe Text)
+    , failureErrorMessage      :: !(Maybe Text)
+    , failureIncompleteDetails :: !(Maybe IncompleteDetails)
+    , failureResponseValue     :: !Aeson.Value
+    } deriving (Eq, Show)
+
+data ItemProgress = ItemProgress
+    { itemValue :: !Aeson.Value
+    , itemDone  :: !Bool
+    }
+
+-- | Incremental state shared by HTTP/SSE and reusable WebSocket transports.
+-- Lifecycle response objects are overlaid in wire order; output items are
+-- indexed so an @output_item.done@ replaces its earlier @added@ form.
+data StreamAssemblyState = StreamAssemblyState
+    { responseObject :: !Aeson.Object
+    , outputItems    :: !(Map.Map Int ItemProgress)
+    }
+
+emptyStreamAssemblyState :: StreamAssemblyState
+emptyStreamAssemblyState = StreamAssemblyState
+    { responseObject = KeyMap.empty
+    , outputItems = Map.empty
+    }
+
+applyStreamEvent :: StreamAssemblyState -> ResponseStreamEvent -> StreamAssemblyState
+applyStreamEvent state event = case event of
+    ResponseCreatedEvent { responseValue } -> overlayLifecycle responseValue state
+    ResponseInProgressEvent { responseValue } -> overlayLifecycle responseValue state
+    ResponseQueuedEvent { responseValue } -> overlayLifecycle responseValue state
+    ResponseCompletedEvent { responseValue } -> overlayLifecycle responseValue state
+    ResponseDoneEvent { responseValue } -> overlayLifecycle responseValue state
+    ResponseFailedEvent { responseValue } -> overlayLifecycle responseValue state
+    ResponseIncompleteEvent { responseValue } -> overlayLifecycle responseValue state
+    ResponseOutputItemAddedEvent { item, outputIndex } ->
+        updateStreamItem outputIndex False (Aeson.toJSON item) state
+    ResponseOutputItemDoneEvent { item, outputIndex } ->
+        updateStreamItem outputIndex True (Aeson.toJSON item) state
+    ResponseCustomToolInputDeltaEvent
+        { delta, streamItemId, streamCallId, streamOutputIndex } ->
+            case ( delta
+                 , resolveOutputIndex
+                    streamOutputIndex [streamItemId, streamCallId] state
+                 ) of
+                (Just inputDelta, Just outputIndex) ->
+                    updateCustomToolInput outputIndex
+                        streamItemId
+                        streamCallId
+                        (appendInput inputDelta)
+                        state
+                _ -> state
+    ResponseCustomToolInputDoneEvent
+        { inputText, streamItemId, streamCallId, streamOutputIndex } ->
+            case ( inputText
+                 , resolveOutputIndex
+                    streamOutputIndex [streamItemId, streamCallId] state
+                 ) of
+                (Just finalInput, Just outputIndex) ->
+                    updateCustomToolInput outputIndex
+                        streamItemId
+                        streamCallId
+                        (setInput finalInput)
+                        state
+                _ -> state
+    ResponseReasoningSummaryPartAddedEvent
+        { streamItemId, streamOutputIndex, summaryIndex, partValue } ->
+            case ( summaryIndex
+                 , resolveOutputIndex streamOutputIndex [streamItemId] state
+                 ) of
+                (Just index, Just outputIndex) ->
+                    updateReasoningSummary outputIndex
+                        (fromMaybe "" streamItemId)
+                        index
+                        (maybe id const partValue)
+                        state
+                _ -> state
+    ResponseReasoningSummaryTextDoneEvent
+        { streamItemId, streamOutputIndex, summaryIndex, text } ->
+            case ( summaryIndex
+                 , text
+                 , resolveOutputIndex streamOutputIndex [streamItemId] state
+                 ) of
+                (Just index, Just finalText, Just outputIndex) ->
+                    updateReasoningSummary outputIndex
+                        (fromMaybe "" streamItemId)
+                        index
+                        (setObjectText finalText)
+                        state
+                _ -> state
+    OtherResponseStreamEvent
+        { otherEventType = EventReasoningSummaryTextDelta
+        , eventExtraFields
+        } ->
+            case ( intField "summary_index" eventExtraFields
+                 , textField "delta" eventExtraFields
+                 ) of
+                (Just summaryIndex, Just delta) ->
+                    case resolveOutputIndex
+                            (intField "output_index" eventExtraFields)
+                            [textField "item_id" eventExtraFields]
+                            state of
+                        Just outputIndex ->
+                            updateReasoningSummary outputIndex
+                                (fromMaybe ""
+                                    (textField "item_id" eventExtraFields))
+                                summaryIndex
+                                (appendObjectText delta)
+                                state
+                        Nothing -> state
+                _ -> state
+    _ -> state
+
+-- | Assemble one terminal lifecycle event into the canonical strict response.
+-- Codex lifecycle frames can omit fields unrelated to that event, so only the
+-- response id remains mandatory here.
+finishStreamResponse
+    :: Maybe Text
+    -> StreamAssemblyState
+    -> ResponseStreamEvent
+    -> Either ApiError Response
+finishStreamResponse modelHint state terminalEvent = do
+    terminalStatus <- case terminalEvent of
+        ResponseCompletedEvent{} -> Right "completed"
+        ResponseDoneEvent{} -> Right "completed"
+        ResponseIncompleteEvent{} -> Right "incomplete"
+        ResponseFailedEvent{} -> Right "failed"
+        _ -> Left $ JsonDecodeError
+            "Cannot assemble a non-terminal response event"
+            (jsonPreview terminalEvent)
+    let terminalFragment = responseValueFor terminalEvent
+        withStatus = case terminalFragment of
+            Just (Aeson.Object object)
+                | KeyMap.member "status" object -> state.responseObject
+            _ -> KeyMap.insert "status" (Aeson.String terminalStatus)
+                    state.responseObject
+        withDefaults =
+            insertMissing "object" (Aeson.String "response")
+                $ insertMissing "model" (Aeson.String (fromMaybe "" modelHint))
+                $ insertMissing "created_at" (Aeson.Number 0)
+                $ withStatus
+        withOutput =
+            KeyMap.insert "output"
+                (Aeson.Array (Vector.fromList (assembledOutput state withDefaults)))
+                withDefaults
+        assembled = Aeson.Object withOutput
+    case KeyMap.lookup "id" withOutput of
+        Just (Aeson.String responseId) | not (Text.null responseId) ->
+            case Aeson.fromJSON assembled of
+                Aeson.Success response -> Right response
+                Aeson.Error err -> Left $ JsonDecodeError
+                    (Text.pack err)
+                    (jsonPreview assembled)
+        _ -> Left $ JsonDecodeError
+            "Streamed response did not contain a response id"
+            (jsonPreview assembled)
+
+-- | Build a response without a request-model hint. This remains the shared
+-- entry point used by provider SSE transports.
 buildStreamResponse
     :: StreamAssemblyConfig
     -> [ResponseStreamEvent]
     -> Either ApiError Response
-buildStreamResponse config events = case lastMaybe terminalEvents of
-    Just ResponseCompletedEvent { response } -> decodeMerged response
-    Just ResponseIncompleteEvent { response } -> decodeMerged response
-    Just ResponseDoneEvent { responseValue } ->
-        assembleDoneResponse latestLifecycleResponse doneItems responseValue
-    Just _ -> Left missingCompletion
-    Nothing -> Left (Maybe.fromMaybe missingCompletion (firstFailure config events))
+buildStreamResponse config =
+    buildStreamResponseWithModel config Nothing
+
+-- | Build a response while using the originating request model if the
+-- provider's partial lifecycle frames omit it.
+buildStreamResponseWithModel
+    :: StreamAssemblyConfig
+    -> Maybe Text
+    -> [ResponseStreamEvent]
+    -> Either ApiError Response
+buildStreamResponseWithModel config modelHint events =
+    go emptyStreamAssemblyState events
   where
-    terminalEvents = filter isTerminalEvent events
-    latestLifecycleResponse =
-        lastMaybe (Maybe.mapMaybe lifecycleResponse events)
-    doneItems =
-        [ Aeson.toJSON item
-        | ResponseOutputItemDoneEvent { item } <- events
-        ]
-
-    decodeMerged completed =
-        let merged = mergeCompletedResponseOutput doneItems (Aeson.toJSON completed)
-        in case Aeson.fromJSON merged of
-            Aeson.Success response -> Right response
-            Aeson.Error err -> Left $ JsonDecodeError
-                (Text.pack err)
-                (jsonPreview merged)
-
-    missingCompletion = JsonDecodeError
+    go _ [] = Left $ JsonDecodeError
         config.missingCompletionMessage
         (jsonPreview events)
+    go state (event : rest) =
+        let nextState = applyStreamEvent state event
+        in case event of
+            ResponseCompletedEvent{} ->
+                finishStreamResponse modelHint nextState event
+            ResponseDoneEvent{} ->
+                finishStreamResponse modelHint nextState event
+            ResponseIncompleteEvent{} ->
+                finishStreamResponse modelHint nextState event
+            ResponseFailedEvent{} ->
+                Left (config.classifyFailedResponse
+                    (responseFailureFromState nextState))
+            ResponseErrorEvent { streamError } ->
+                Left (config.classifyStreamError streamError)
+            ResponseNestedErrorEvent { streamError } ->
+                Left (config.classifyStreamError streamError)
+            _ -> go nextState rest
 
+-- | Compatibility wrapper for callers that already hold a complete base
+-- response plus streamed done items.
 assembleDoneResponse
     :: Maybe Response
     -> [Aeson.Value]
@@ -81,34 +257,12 @@ assembleDoneResponse baseResponse doneItems doneResponse =
             (Text.pack err)
             (jsonPreview merged)
 
-firstFailure
-    :: StreamAssemblyConfig
-    -> [ResponseStreamEvent]
-    -> Maybe ApiError
-firstFailure config = Maybe.listToMaybe . Maybe.mapMaybe failure
-  where
-    failure = \case
-        ResponseErrorEvent { streamError } ->
-            Just (config.classifyStreamError streamError)
-        ResponseNestedErrorEvent { streamError } ->
-            Just (config.classifyStreamError streamError)
-        ResponseFailedEvent { response } ->
-            Just (config.classifyFailedResponse response)
-        _ -> Nothing
-
-isTerminalEvent :: ResponseStreamEvent -> Bool
-isTerminalEvent = \case
-    ResponseCompletedEvent{} -> True
-    ResponseDoneEvent{} -> True
-    ResponseIncompleteEvent{} -> True
-    _ -> False
-
-lifecycleResponse :: ResponseStreamEvent -> Maybe Response
-lifecycleResponse = \case
-    ResponseCreatedEvent { response } -> Just response
-    ResponseInProgressEvent { response } -> Just response
-    ResponseQueuedEvent { response } -> Just response
-    _ -> Nothing
+responseFragmentHasOutput :: Aeson.Value -> Bool
+responseFragmentHasOutput (Aeson.Object object) =
+    case KeyMap.lookup "output" object of
+        Just (Aeson.Array output) -> not (Vector.null output)
+        _ -> False
+responseFragmentHasOutput _ = False
 
 -- | Best available text from a failed terminal response.
 failedResponseMessage :: Response -> Text
@@ -118,14 +272,331 @@ failedResponseMessage response = case response.error of
         Just details -> "response.failed: " <> details.reason
         Nothing -> "response.failed (no details)"
 
+failedStreamResponseMessage :: ResponseFailure -> Text
+failedStreamResponseMessage failure =
+    fromMaybe fallback (nonEmpty failure.failureErrorMessage)
+  where
+    fallback = case failure.failureIncompleteDetails of
+        Just details -> "response.failed: " <> details.reason
+        Nothing -> case nonEmpty failure.failureErrorCode of
+            Just code -> "response.failed: " <> code
+            Nothing -> "response.failed (no details)"
+
+responseFailureFromState :: StreamAssemblyState -> ResponseFailure
+responseFailureFromState state =
+    let value = Aeson.Object state.responseObject
+        parseOptional fieldName = case KeyMap.lookup fieldName state.responseObject of
+            Just fieldValue -> case Aeson.fromJSON fieldValue of
+                Aeson.Success parsed -> Just parsed
+                Aeson.Error _ -> Nothing
+            Nothing -> Nothing
+        nestedText objectName fieldName = do
+            Aeson.Object object <-
+                KeyMap.lookup objectName state.responseObject
+            textField fieldName object
+    in ResponseFailure
+        { failureErrorType = nestedText "error" "type"
+        , failureErrorCode = nestedText "error" "code"
+        , failureErrorMessage = nestedText "error" "message"
+        , failureIncompleteDetails = parseOptional "incomplete_details"
+        , failureResponseValue = value
+        }
+
+overlayLifecycle :: Aeson.Value -> StreamAssemblyState -> StreamAssemblyState
+overlayLifecycle (Aeson.Object fragment) state =
+    state
+        { responseObject =
+            KeyMap.foldrWithKey KeyMap.insert state.responseObject fragment
+        }
+overlayLifecycle _ state = state
+
+updateItem
+    :: Int
+    -> Bool
+    -> Aeson.Value
+    -> StreamAssemblyState
+    -> StreamAssemblyState
+updateItem outputIndex done newValue state =
+    state
+        { outputItems =
+            Map.alter
+                (Just . mergeProgress)
+                outputIndex
+                state.outputItems
+        }
+  where
+    mergeProgress Nothing = ItemProgress newValue done
+    mergeProgress (Just old) = ItemProgress
+        { itemValue = mergeObjects old.itemValue newValue
+        , itemDone = old.itemDone || done
+        }
+
+updateStreamItem
+    :: Maybe Int
+    -> Bool
+    -> Aeson.Value
+    -> StreamAssemblyState
+    -> StreamAssemblyState
+updateStreamItem explicitIndex done newValue state =
+    updateItem outputIndex done newValue state
+  where
+    outputIndex =
+        fromMaybe (nextOutputIndex state) $
+            explicitIndex
+                <|> findItemIndex newValue state
+                <|> if done then findPendingItemIndex newValue state else Nothing
+
+resolveOutputIndex
+    :: Maybe Int
+    -> [Maybe Text]
+    -> StreamAssemblyState
+    -> Maybe Int
+resolveOutputIndex explicitIndex identities state =
+    explicitIndex
+        <|> firstJust
+            [ findIdentityIndex wanted state
+            | Just wanted <- identities
+            ]
+        <|> case [wanted | Just wanted <- identities] of
+            [] -> Nothing
+            _ -> Just (nextOutputIndex state)
+
+findIdentityIndex :: Text -> StreamAssemblyState -> Maybe Int
+findIdentityIndex wanted state =
+    fst <$> Map.lookupMin
+        (Map.filter (matchesIdentity wanted . (.itemValue)) state.outputItems)
+  where
+    matchesIdentity wanted = \case
+        Aeson.Object object ->
+            textField "id" object == Just wanted
+                || textField "call_id" object == Just wanted
+        _ -> False
+
+findItemIndex :: Aeson.Value -> StreamAssemblyState -> Maybe Int
+findItemIndex value state =
+    firstJust
+        [ findIdentityIndex identity state
+        | identity <- itemIdentities value
+        ]
+
+findPendingItemIndex :: Aeson.Value -> StreamAssemblyState -> Maybe Int
+findPendingItemIndex value state =
+    case wantedType of
+        Nothing -> Nothing
+        Just _ ->
+            fst <$> Map.lookupMin
+                (Map.filter matchesPending state.outputItems)
+  where
+    wantedType = objectTextField "type" value
+    matchesPending progress =
+        not progress.itemDone
+            && objectTextField "type" progress.itemValue == wantedType
+
+nextOutputIndex :: StreamAssemblyState -> Int
+nextOutputIndex state =
+    maybe 0 ((+ 1) . fst) (Map.lookupMax state.outputItems)
+
+itemIdentities :: Aeson.Value -> [Text]
+itemIdentities = \case
+    Aeson.Object object ->
+        foldMap
+            (\fieldName -> maybe [] pure (textField fieldName object))
+            ["id", "call_id"]
+    _ -> []
+
+objectTextField :: Text -> Aeson.Value -> Maybe Text
+objectTextField fieldName = \case
+    Aeson.Object object -> textField fieldName object
+    _ -> Nothing
+
+firstJust :: [Maybe value] -> Maybe value
+firstJust = foldr (<|>) Nothing
+
+nonEmpty :: Maybe Text -> Maybe Text
+nonEmpty value = value >>= \text ->
+    if Text.null text then Nothing else Just text
+
+updateCustomToolInput
+    :: Int
+    -> Maybe Text
+    -> Maybe Text
+    -> (Aeson.Object -> Aeson.Object)
+    -> StreamAssemblyState
+    -> StreamAssemblyState
+updateCustomToolInput outputIndex itemId callId updateInput state =
+    state
+        { outputItems =
+            Map.alter
+                (Just . updateProgress)
+                outputIndex
+                state.outputItems
+        }
+  where
+    baseObject =
+        maybe id
+            (KeyMap.insert "id" . Aeson.String)
+            itemId
+        $ maybe id
+            (KeyMap.insert "call_id" . Aeson.String)
+            callId
+        $ KeyMap.fromList
+            [ ("type", Aeson.String "custom_tool_call")
+            , ("input", Aeson.String "")
+            ]
+    updateProgress Nothing =
+        ItemProgress (Aeson.Object (updateInput baseObject)) False
+    updateProgress (Just progress) =
+        progress
+            { itemValue = case progress.itemValue of
+                Aeson.Object object -> Aeson.Object (updateInput object)
+                _ -> Aeson.Object (updateInput baseObject)
+            }
+
+updateReasoningSummary
+    :: Int
+    -> Text
+    -> Int
+    -> (Aeson.Value -> Aeson.Value)
+    -> StreamAssemblyState
+    -> StreamAssemblyState
+updateReasoningSummary outputIndex itemId summaryIndex updatePart state =
+    state
+        { outputItems =
+            Map.alter
+                (Just . updateProgress)
+                outputIndex
+                state.outputItems
+        }
+  where
+    baseObject = KeyMap.fromList
+        [ ("type", Aeson.String "reasoning")
+        , ("id", Aeson.String itemId)
+        , ("summary", Aeson.Array Vector.empty)
+        ]
+    updateProgress Nothing =
+        ItemProgress (Aeson.Object (updateSummary baseObject)) False
+    updateProgress (Just progress) =
+        progress
+            { itemValue = case progress.itemValue of
+                Aeson.Object object -> Aeson.Object (updateSummary object)
+                _ -> Aeson.Object (updateSummary baseObject)
+            }
+    updateSummary object =
+        let current = case KeyMap.lookup "summary" object of
+                Just (Aeson.Array values) -> values
+                _ -> Vector.empty
+            updated = updateVectorAt summaryIndex updatePart current
+        in KeyMap.insert "summary" (Aeson.Array updated) object
+
+assembledOutput :: StreamAssemblyState -> Aeson.Object -> [Aeson.Value]
+assembledOutput state response =
+    map (.itemValue) . Map.elems $
+        Map.unionWith combine
+            state.outputItems
+            terminalItems
+  where
+    terminalItems = Map.fromList
+        [ (index, ItemProgress value True)
+        | (index, value) <- zip [0 ..] finalItems
+        ]
+    finalItems = case KeyMap.lookup "output" response of
+        Just (Aeson.Array values) -> Vector.toList values
+        _ -> []
+    combine streamed terminal
+        | streamed.itemDone =
+            ItemProgress
+                (mergeObjects terminal.itemValue streamed.itemValue)
+                True
+        | otherwise =
+            ItemProgress
+                (mergeObjects streamed.itemValue terminal.itemValue)
+                True
+
+responseValueFor :: ResponseStreamEvent -> Maybe Aeson.Value
+responseValueFor = \case
+    ResponseCreatedEvent { responseValue } -> Just responseValue
+    ResponseInProgressEvent { responseValue } -> Just responseValue
+    ResponseQueuedEvent { responseValue } -> Just responseValue
+    ResponseCompletedEvent { responseValue } -> Just responseValue
+    ResponseDoneEvent { responseValue } -> Just responseValue
+    ResponseFailedEvent { responseValue } -> Just responseValue
+    ResponseIncompleteEvent { responseValue } -> Just responseValue
+    _ -> Nothing
+
+mergeObjects :: Aeson.Value -> Aeson.Value -> Aeson.Value
+mergeObjects (Aeson.Object base) (Aeson.Object overlay) =
+    Aeson.Object (KeyMap.foldrWithKey KeyMap.insert base overlay)
+mergeObjects _ overlay = overlay
+
+insertMissing :: Key.Key -> Aeson.Value -> Aeson.Object -> Aeson.Object
+insertMissing key value object
+    | KeyMap.member key object = object
+    | otherwise = KeyMap.insert key value object
+
+appendInput :: Text -> Aeson.Object -> Aeson.Object
+appendInput delta object =
+    let current = fromMaybe "" (textField "input" object)
+    in KeyMap.insert "input" (Aeson.String (current <> delta)) object
+
+setInput :: Text -> Aeson.Object -> Aeson.Object
+setInput input =
+    KeyMap.insert "input" (Aeson.String input)
+
+setObjectText :: Text -> Aeson.Value -> Aeson.Value
+setObjectText text = \case
+    Aeson.Object object ->
+        Aeson.Object (KeyMap.insert "text" (Aeson.String text) object)
+    _ -> Aeson.object
+        [ "type" Aeson..= ("summary_text" :: Text)
+        , "text" Aeson..= text
+        ]
+
+appendObjectText :: Text -> Aeson.Value -> Aeson.Value
+appendObjectText delta = \case
+    Aeson.Object object ->
+        let current = fromMaybe "" (textField "text" object)
+        in Aeson.Object
+            (KeyMap.insert "text" (Aeson.String (current <> delta)) object)
+    _ -> Aeson.object
+        [ "type" Aeson..= ("summary_text" :: Text)
+        , "text" Aeson..= delta
+        ]
+
+updateVectorAt
+    :: Int
+    -> (Aeson.Value -> Aeson.Value)
+    -> Vector.Vector Aeson.Value
+    -> Vector.Vector Aeson.Value
+updateVectorAt index update values
+    | index < 0 = values
+    | index < Vector.length values =
+        values Vector.// [(index, update (values Vector.! index))]
+    | otherwise =
+        let padding = Vector.replicate
+                (index - Vector.length values)
+                (Aeson.object ["type" Aeson..= ("summary_text" :: Text)])
+        in values
+            <> padding
+            <> Vector.singleton
+                (update (Aeson.object ["type" Aeson..= ("summary_text" :: Text)]))
+
+textField :: Text -> Aeson.Object -> Maybe Text
+textField name object =
+    case KeyMap.lookup (Key.fromText name) object of
+        Just (Aeson.String value) -> Just value
+        _ -> Nothing
+
+intField :: Text -> Aeson.Object -> Maybe Int
+intField name object =
+    case KeyMap.lookup (Key.fromText name) object of
+        Just value -> case Aeson.fromJSON value of
+            Aeson.Success int -> Just int
+            Aeson.Error _ -> Nothing
+        Nothing -> Nothing
+
 jsonPreview :: Aeson.ToJSON value => value -> Text
 jsonPreview =
     Text.take 2000
         . TextEncoding.decodeUtf8With TextEncoding.lenientDecode
         . LBS.toStrict
         . Aeson.encode
-
-lastMaybe :: [value] -> Maybe value
-lastMaybe [] = Nothing
-lastMaybe [value] = Just value
-lastMaybe (_ : rest) = lastMaybe rest

--- a/packages/agent-responses/src/Agent/Responses/Types.hs
+++ b/packages/agent-responses/src/Agent/Responses/Types.hs
@@ -95,6 +95,18 @@ objectWith extras members =
 without :: [Text] -> Aeson.Object -> Aeson.Object
 without names object = foldl' (flip (KeyMap.delete . Key.fromText)) object names
 
+-- Optional members decoded through '.:?' collapse both absence and explicit
+-- @null@ to 'Nothing'. Keep explicit nulls in the extras map so known event
+-- variants still round-trip the exact wire object.
+withoutNonNull :: [Text] -> Aeson.Object -> Aeson.Object
+withoutNonNull names object = foldl' remove object names
+  where
+    remove current name =
+        let key = Key.fromText name
+        in case KeyMap.lookup key current of
+            Just Aeson.Null -> current
+            _ -> KeyMap.delete key current
+
 --------------------------------------------------------------------------------
 -- Request primitives
 --------------------------------------------------------------------------------
@@ -1455,7 +1467,10 @@ data StreamEventType
     | EventShellCommandDone
     | EventShellOutputDelta
     | EventShellOutputDone
+    | EventCodexRateLimits
     | EventCodexResponseMetadata
+    | EventResponseMetadata
+    | EventResponsesApiWebSocketTiming
     | StreamEventUnknown !Text
     deriving stock (Eq, Show)
 
@@ -1520,7 +1535,10 @@ streamEventTypeText = \case
     EventShellCommandDone -> "response.shell_call_command.done"
     EventShellOutputDelta -> "response.shell_call_output_content.delta"
     EventShellOutputDone -> "response.shell_call_output_content.done"
+    EventCodexRateLimits -> "codex.rate_limits"
     EventCodexResponseMetadata -> "codex.response.metadata"
+    EventResponseMetadata -> "response.metadata"
+    EventResponsesApiWebSocketTiming -> "responsesapi.websocket_timing"
     StreamEventUnknown value -> value
 
 parseStreamEventType :: Text -> StreamEventType
@@ -1584,7 +1602,10 @@ parseStreamEventType value = case value of
     "response.shell_call_command.done" -> EventShellCommandDone
     "response.shell_call_output_content.delta" -> EventShellOutputDelta
     "response.shell_call_output_content.done" -> EventShellOutputDone
+    "codex.rate_limits" -> EventCodexRateLimits
     "codex.response.metadata" -> EventCodexResponseMetadata
+    "response.metadata" -> EventResponseMetadata
+    "responsesapi.websocket_timing" -> EventResponsesApiWebSocketTiming
     other -> StreamEventUnknown other
 
 -- | Structured payload used by both the documented top-level @error@ event
@@ -1624,17 +1645,17 @@ instance FromJSON ResponseStreamError where
 -- variants retain their exact object members in 'eventExtraFields'.
 data ResponseStreamEvent
     = ResponseCreatedEvent
-        { response         :: !Response
+        { responseValue    :: !Aeson.Value
         , sequenceNumber   :: !(Maybe Int)
         , eventExtraFields :: !Aeson.Object
         }
     | ResponseInProgressEvent
-        { response         :: !Response
+        { responseValue    :: !Aeson.Value
         , sequenceNumber   :: !(Maybe Int)
         , eventExtraFields :: !Aeson.Object
         }
     | ResponseCompletedEvent
-        { response         :: !Response
+        { responseValue    :: !Aeson.Value
         , sequenceNumber   :: !(Maybe Int)
         , eventExtraFields :: !Aeson.Object
         }
@@ -1644,29 +1665,61 @@ data ResponseStreamEvent
         , eventExtraFields :: !Aeson.Object
         }
     | ResponseFailedEvent
-        { response         :: !Response
+        { responseValue    :: !Aeson.Value
         , sequenceNumber   :: !(Maybe Int)
         , eventExtraFields :: !Aeson.Object
         }
     | ResponseIncompleteEvent
-        { response         :: !Response
+        { responseValue    :: !Aeson.Value
         , sequenceNumber   :: !(Maybe Int)
         , eventExtraFields :: !Aeson.Object
         }
     | ResponseQueuedEvent
-        { response         :: !Response
+        { responseValue    :: !Aeson.Value
         , sequenceNumber   :: !(Maybe Int)
         , eventExtraFields :: !Aeson.Object
         }
     | ResponseOutputItemAddedEvent
         { item             :: !ResponseItem
-        , outputIndex      :: !Int
+        , outputIndex      :: !(Maybe Int)
         , sequenceNumber   :: !(Maybe Int)
         , eventExtraFields :: !Aeson.Object
         }
     | ResponseOutputItemDoneEvent
         { item             :: !ResponseItem
-        , outputIndex      :: !Int
+        , outputIndex      :: !(Maybe Int)
+        , sequenceNumber   :: !(Maybe Int)
+        , eventExtraFields :: !Aeson.Object
+        }
+    | ResponseCustomToolInputDeltaEvent
+        { delta            :: !(Maybe Text)
+        , streamItemId     :: !(Maybe Text)
+        , streamCallId     :: !(Maybe Text)
+        , streamOutputIndex :: !(Maybe Int)
+        , sequenceNumber   :: !(Maybe Int)
+        , eventExtraFields :: !Aeson.Object
+        }
+    | ResponseCustomToolInputDoneEvent
+        { inputText        :: !(Maybe Text)
+        , streamItemId     :: !(Maybe Text)
+        , streamCallId     :: !(Maybe Text)
+        , streamOutputIndex :: !(Maybe Int)
+        , sequenceNumber   :: !(Maybe Int)
+        , eventExtraFields :: !Aeson.Object
+        }
+    | ResponseReasoningSummaryPartAddedEvent
+        { streamItemId     :: !(Maybe Text)
+        , streamOutputIndex :: !(Maybe Int)
+        , summaryIndex     :: !(Maybe Int)
+        , partValue        :: !(Maybe Aeson.Value)
+        , sequenceNumber   :: !(Maybe Int)
+        , eventExtraFields :: !Aeson.Object
+        }
+    | ResponseReasoningSummaryTextDoneEvent
+        { streamItemId     :: !(Maybe Text)
+        , streamOutputIndex :: !(Maybe Int)
+        , summaryIndex     :: !(Maybe Int)
+        , text             :: !(Maybe Text)
         , sequenceNumber   :: !(Maybe Int)
         , eventExtraFields :: !Aeson.Object
         }
@@ -1698,6 +1751,10 @@ responseStreamEventType = \case
     ResponseQueuedEvent{} -> EventResponseQueued
     ResponseOutputItemAddedEvent{} -> EventOutputItemAdded
     ResponseOutputItemDoneEvent{} -> EventOutputItemDone
+    ResponseCustomToolInputDeltaEvent{} -> EventCustomToolInputDelta
+    ResponseCustomToolInputDoneEvent{} -> EventCustomToolInputDone
+    ResponseReasoningSummaryPartAddedEvent{} -> EventReasoningSummaryPartAdded
+    ResponseReasoningSummaryTextDoneEvent{} -> EventReasoningSummaryTextDone
     ResponseErrorEvent{} -> EventError
     ResponseNestedErrorEvent{} -> EventError
     OtherResponseStreamEvent { otherEventType } -> otherEventType
@@ -1707,28 +1764,48 @@ responseStreamEventSequenceNumber event = event.sequenceNumber
 
 instance ToJSON ResponseStreamEvent where
     toJSON = \case
-        ResponseCreatedEvent { response, sequenceNumber, eventExtraFields } ->
-            lifecycleEvent "response.created" response sequenceNumber eventExtraFields
-        ResponseInProgressEvent { response, sequenceNumber, eventExtraFields } ->
-            lifecycleEvent "response.in_progress" response sequenceNumber eventExtraFields
-        ResponseCompletedEvent { response, sequenceNumber, eventExtraFields } ->
-            lifecycleEvent "response.completed" response sequenceNumber eventExtraFields
+        ResponseCreatedEvent { responseValue, sequenceNumber, eventExtraFields } ->
+            lifecycleEvent "response.created" responseValue sequenceNumber eventExtraFields
+        ResponseInProgressEvent { responseValue, sequenceNumber, eventExtraFields } ->
+            lifecycleEvent "response.in_progress" responseValue sequenceNumber eventExtraFields
+        ResponseCompletedEvent { responseValue, sequenceNumber, eventExtraFields } ->
+            lifecycleEvent "response.completed" responseValue sequenceNumber eventExtraFields
         ResponseDoneEvent { responseValue, sequenceNumber, eventExtraFields } ->
             objectWith eventExtraFields
                 [ Just (field "type" ("response.done" :: Text))
                 , optionalField "sequence_number" sequenceNumber
                 , Just (field "response" responseValue)
                 ]
-        ResponseFailedEvent { response, sequenceNumber, eventExtraFields } ->
-            lifecycleEvent "response.failed" response sequenceNumber eventExtraFields
-        ResponseIncompleteEvent { response, sequenceNumber, eventExtraFields } ->
-            lifecycleEvent "response.incomplete" response sequenceNumber eventExtraFields
-        ResponseQueuedEvent { response, sequenceNumber, eventExtraFields } ->
-            lifecycleEvent "response.queued" response sequenceNumber eventExtraFields
+        ResponseFailedEvent { responseValue, sequenceNumber, eventExtraFields } ->
+            lifecycleEvent "response.failed" responseValue sequenceNumber eventExtraFields
+        ResponseIncompleteEvent { responseValue, sequenceNumber, eventExtraFields } ->
+            lifecycleEvent "response.incomplete" responseValue sequenceNumber eventExtraFields
+        ResponseQueuedEvent { responseValue, sequenceNumber, eventExtraFields } ->
+            lifecycleEvent "response.queued" responseValue sequenceNumber eventExtraFields
         ResponseOutputItemAddedEvent { item, outputIndex, sequenceNumber, eventExtraFields } ->
             outputItemEvent "response.output_item.added" item outputIndex sequenceNumber eventExtraFields
         ResponseOutputItemDoneEvent { item, outputIndex, sequenceNumber, eventExtraFields } ->
             outputItemEvent "response.output_item.done" item outputIndex sequenceNumber eventExtraFields
+        ResponseCustomToolInputDeltaEvent { delta, streamItemId, streamCallId, streamOutputIndex, sequenceNumber, eventExtraFields } ->
+            indexedItemEvent "response.custom_tool_call_input.delta"
+                streamItemId streamCallId streamOutputIndex sequenceNumber eventExtraFields
+                [optionalField "delta" delta]
+        ResponseCustomToolInputDoneEvent { inputText, streamItemId, streamCallId, streamOutputIndex, sequenceNumber, eventExtraFields } ->
+            indexedItemEvent "response.custom_tool_call_input.done"
+                streamItemId streamCallId streamOutputIndex sequenceNumber eventExtraFields
+                [optionalField "input" inputText]
+        ResponseReasoningSummaryPartAddedEvent { streamItemId, streamOutputIndex, summaryIndex, partValue, sequenceNumber, eventExtraFields } ->
+            indexedItemEvent "response.reasoning_summary_part.added"
+                streamItemId (Nothing :: Maybe Text) streamOutputIndex sequenceNumber eventExtraFields
+                [ optionalField "summary_index" summaryIndex
+                , optionalField "part" partValue
+                ]
+        ResponseReasoningSummaryTextDoneEvent { streamItemId, streamOutputIndex, summaryIndex, text, sequenceNumber, eventExtraFields } ->
+            indexedItemEvent "response.reasoning_summary_text.done"
+                streamItemId (Nothing :: Maybe Text) streamOutputIndex sequenceNumber eventExtraFields
+                [ optionalField "summary_index" summaryIndex
+                , optionalField "text" text
+                ]
         ResponseErrorEvent { streamError, sequenceNumber, eventExtraFields } ->
             topLevelErrorEvent streamError sequenceNumber eventExtraFields
         ResponseNestedErrorEvent { streamError, sequenceNumber, eventExtraFields } ->
@@ -1751,9 +1828,19 @@ instance ToJSON ResponseStreamEvent where
         outputItemEvent eventType item outputIndex sequenceNumber extras = objectWith extras
             [ Just (field "type" (eventType :: Text))
             , optionalField "sequence_number" sequenceNumber
-            , Just (field "output_index" outputIndex)
+            , optionalField "output_index" outputIndex
             , Just (field "item" item)
             ]
+        indexedItemEvent eventType itemId callId outputIndex sequenceNumber extras payloadFields =
+            objectWith extras
+                ( [ Just (field "type" (eventType :: Text))
+                  , optionalField "sequence_number" sequenceNumber
+                  , optionalField "item_id" itemId
+                  , optionalField "call_id" callId
+                  , optionalField "output_index" outputIndex
+                  ]
+                    <> payloadFields
+                )
         topLevelErrorEvent streamError sequenceNumber extras =
             objectWith (KeyMap.union extras streamError.extraFields)
                 [ Just (field "type" ("error" :: Text))
@@ -1775,35 +1862,95 @@ instance FromJSON ResponseStreamEvent where
             EventResponseDone -> ResponseDoneEvent
                 <$> o .: "response"
                 <*> pure sequenceNumber
-                <*> pure (without ["type", "sequence_number", "response"] o)
+                <*> pure
+                    ( without ["type", "response"]
+                    $ withoutNonNull ["sequence_number"] o
+                    )
             EventResponseFailed -> lifecycle ResponseFailedEvent sequenceNumber o
             EventResponseIncomplete -> lifecycle ResponseIncompleteEvent sequenceNumber o
             EventResponseQueued -> lifecycle ResponseQueuedEvent sequenceNumber o
             EventOutputItemAdded -> outputItem ResponseOutputItemAddedEvent sequenceNumber o
             EventOutputItemDone -> outputItem ResponseOutputItemDoneEvent sequenceNumber o
+            EventCustomToolInputDelta -> ResponseCustomToolInputDeltaEvent
+                <$> o .:? "delta"
+                <*> o .:? "item_id"
+                <*> o .:? "call_id"
+                <*> o .:? "output_index"
+                <*> pure sequenceNumber
+                <*> pure
+                    ( without ["type"]
+                    $ withoutNonNull
+                        ["sequence_number", "delta", "item_id", "call_id", "output_index"]
+                        o
+                    )
+            EventCustomToolInputDone -> ResponseCustomToolInputDoneEvent
+                <$> o .:? "input"
+                <*> o .:? "item_id"
+                <*> o .:? "call_id"
+                <*> o .:? "output_index"
+                <*> pure sequenceNumber
+                <*> pure
+                    ( without ["type"]
+                    $ withoutNonNull
+                        ["sequence_number", "input", "item_id", "call_id", "output_index"]
+                        o
+                    )
+            EventReasoningSummaryPartAdded -> ResponseReasoningSummaryPartAddedEvent
+                <$> o .:? "item_id"
+                <*> o .:? "output_index"
+                <*> o .:? "summary_index"
+                <*> o .:? "part"
+                <*> pure sequenceNumber
+                <*> pure
+                    ( without ["type"]
+                    $ withoutNonNull
+                        ["sequence_number", "item_id", "output_index", "summary_index", "part"]
+                        o
+                    )
+            EventReasoningSummaryTextDone -> ResponseReasoningSummaryTextDoneEvent
+                <$> o .:? "item_id"
+                <*> o .:? "output_index"
+                <*> o .:? "summary_index"
+                <*> o .:? "text"
+                <*> pure sequenceNumber
+                <*> pure
+                    ( without ["type"]
+                    $ withoutNonNull
+                        ["sequence_number", "item_id", "output_index", "summary_index", "text"]
+                        o
+                    )
             EventError -> parseErrorEvent sequenceNumber o
             eventType -> pure OtherResponseStreamEvent
                 { otherEventType = eventType
                 , sequenceNumber
-                , eventExtraFields = without ["type", "sequence_number"] o
+                , eventExtraFields =
+                    without ["type"] (withoutNonNull ["sequence_number"] o)
                 }
       where
         lifecycle constructor sequenceNumber object = constructor
             <$> object .: "response"
             <*> pure sequenceNumber
-            <*> pure (without ["type", "sequence_number", "response"] object)
+            <*> pure
+                ( without ["type", "response"]
+                $ withoutNonNull ["sequence_number"] object
+                )
         outputItem constructor sequenceNumber object = constructor
             <$> object .: "item"
-            <*> object .: "output_index"
+            <*> object .:? "output_index"
             <*> pure sequenceNumber
-            <*> pure (without ["type", "sequence_number", "item", "output_index"] object)
+            <*> pure
+                ( without ["type", "item"]
+                $ withoutNonNull ["sequence_number", "output_index"] object
+                )
         parseErrorEvent sequenceNumber object = do
             nestedError <- object .:? "error"
             case nestedError of
                 Just streamError -> pure ResponseNestedErrorEvent
                     { streamError
                     , sequenceNumber
-                    , eventExtraFields = without ["type", "sequence_number", "error"] object
+                    , eventExtraFields =
+                        without ["type", "error"]
+                            (withoutNonNull ["sequence_number"] object)
                     }
                 Nothing -> do
                     streamError <- ResponseStreamError
@@ -1816,7 +1963,9 @@ instance FromJSON ResponseStreamEvent where
                     pure ResponseErrorEvent
                         { streamError
                         , sequenceNumber
-                        , eventExtraFields = mempty
+                        , eventExtraFields =
+                            without ["type", "code", "message", "param", "resets_in_seconds"]
+                                (withoutNonNull ["sequence_number"] object)
                         }
 
 -- | Decode an SSE event when the transport supplied the event name separately.

--- a/packages/agent-responses/test/Agent/Responses/StreamAssemblySpec.hs
+++ b/packages/agent-responses/test/Agent/Responses/StreamAssemblySpec.hs
@@ -24,18 +24,158 @@ spec = describe "buildStreamResponse" do
     it "assembles a partial response.done after a function call" do
         events <- expectRight $ parseSseEvents $ Text.intercalate ""
             [ sseBlock "response.created"
-                "{\"type\":\"response.created\",\"response\":{\"id\":\"resp-done\",\"created_at\":0,\"model\":\"test\",\"status\":\"in_progress\",\"output\":[]}}"
+                "{\"type\":\"response.created\",\"response\":{\"id\":\"resp-done\"}}"
             , sseBlock "response.output_item.done"
                 "{\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"type\":\"function_call\",\"call_id\":\"call-done\",\"name\":\"shell_command\",\"arguments\":\"{\\\"command\\\":\\\"echo done\\\"}\"}}"
             , sseBlock "response.done"
                 "{\"type\":\"response.done\",\"response\":{\"usage\":{\"input_tokens\":10,\"output_tokens\":2,\"total_tokens\":12}}}"
             ]
-        response <- expectRight (buildStreamResponse config events)
+        response <- expectRight
+            (buildStreamResponseWithModel config (Just "request-model") events)
         response.responseId `shouldBe` "resp-done"
+        response.model `shouldBe` "request-model"
         response.status `shouldBe` ResponseCompleted
         fmap (.totalTokens) response.usage `shouldBe` Just 12
         [name | FunctionCallItem FunctionCall { name } <- response.output]
             `shouldBe` ["shell_command"]
+
+    it "assembles minimal created and completed lifecycle fragments" do
+        events <- expectRight $ parseSseEvents $ Text.intercalate ""
+            [ sseBlock "response.created"
+                "{\"type\":\"response.created\",\"response\":{\"id\":\"resp-partial\"}}"
+            , sseBlock "response.completed"
+                "{\"type\":\"response.completed\",\"response\":{\"id\":\"resp-partial\",\"usage\":{\"input_tokens\":7,\"output_tokens\":3,\"total_tokens\":10}}}"
+            ]
+        response <- expectRight
+            (buildStreamResponseWithModel config (Just "request-model") events)
+        response.responseId `shouldBe` "resp-partial"
+        response.createdAt `shouldBe` 0
+        response.model `shouldBe` "request-model"
+        response.object `shouldBe` "response"
+        response.status `shouldBe` ResponseCompleted
+        response.output `shouldBe` []
+        fmap (.totalTokens) response.usage `shouldBe` Just 10
+
+    it "normalizes a minimal incomplete lifecycle fragment" do
+        events <- expectRight $ parseSseEvents $ Text.intercalate ""
+            [ sseBlock "response.created"
+                "{\"type\":\"response.created\",\"response\":{\"id\":\"resp-incomplete\"}}"
+            , sseBlock "response.incomplete"
+                "{\"type\":\"response.incomplete\",\"response\":{\"incomplete_details\":{\"reason\":\"max_output_tokens\"}}}"
+            ]
+        response <- expectRight
+            (buildStreamResponseWithModel config (Just "request-model") events)
+        response.responseId `shouldBe` "resp-incomplete"
+        response.status `shouldBe` ResponseIncomplete
+        fmap (.reason) response.incompleteDetails
+            `shouldBe` Just "max_output_tokens"
+
+    it "replaces indexed added items with done items without duplicates" do
+        events <- expectRight $ parseSseEvents $ Text.intercalate ""
+            [ sseBlock "response.created"
+                "{\"type\":\"response.created\",\"response\":{\"id\":\"resp-indexed\"}}"
+            , sseBlock "response.output_item.added"
+                "{\"type\":\"response.output_item.added\",\"output_index\":1,\"item\":{\"type\":\"function_call\",\"call_id\":\"call-2\",\"name\":\"stale-second\",\"arguments\":\"\"}}"
+            , sseBlock "response.output_item.added"
+                "{\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"type\":\"function_call\",\"call_id\":\"call-1\",\"name\":\"first\",\"arguments\":\"{}\"}}"
+            , sseBlock "response.output_item.done"
+                "{\"type\":\"response.output_item.done\",\"output_index\":1,\"item\":{\"type\":\"function_call\",\"call_id\":\"call-2\",\"name\":\"second\",\"arguments\":\"{}\"}}"
+            , sseBlock "response.completed"
+                "{\"type\":\"response.completed\",\"response\":{\"id\":\"resp-indexed\"}}"
+            ]
+        response <- expectRight
+            (buildStreamResponseWithModel config (Just "request-model") events)
+        [name | FunctionCallItem FunctionCall { name } <- response.output]
+            `shouldBe` ["first", "second"]
+        length response.output `shouldBe` 2
+
+    it "assembles indexless done-only output items in wire order" do
+        events <- expectRight $ parseSseEvents $ Text.intercalate ""
+            [ sseBlock "response.created"
+                "{\"type\":\"response.created\",\"response\":{\"id\":\"resp-indexless\"}}"
+            , sseBlock "response.output_item.done"
+                "{\"type\":\"response.output_item.done\",\"item\":{\"type\":\"function_call\",\"call_id\":\"call-1\",\"name\":\"first\",\"arguments\":\"{}\"}}"
+            , sseBlock "response.output_item.done"
+                "{\"type\":\"response.output_item.done\",\"item\":{\"type\":\"function_call\",\"call_id\":\"call-2\",\"name\":\"second\",\"arguments\":\"{}\"}}"
+            , sseBlock "response.done"
+                "{\"type\":\"response.done\",\"response\":{}}"
+            ]
+        response <- expectRight
+            (buildStreamResponseWithModel config (Just "request-model") events)
+        [name | FunctionCallItem FunctionCall { name } <- response.output]
+            `shouldBe` ["first", "second"]
+
+    it "assembles custom-tool input events without output_index" do
+        events <- expectRight $ parseSseEvents $ Text.intercalate ""
+            [ sseBlock "response.created"
+                "{\"type\":\"response.created\",\"response\":{\"id\":\"resp-custom\"}}"
+            , sseBlock "response.output_item.added"
+                "{\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"type\":\"custom_tool_call\",\"id\":\"ctc-1\",\"call_id\":\"call-1\",\"name\":\"apply_patch\",\"input\":\"\"}}"
+            , sseBlock "response.custom_tool_call_input.delta"
+                "{\"type\":\"response.custom_tool_call_input.delta\",\"item_id\":\"not-the-item\",\"call_id\":\"call-1\",\"delta\":\"*** Begin\"}"
+            , sseBlock "response.custom_tool_call_input.delta"
+                "{\"type\":\"response.custom_tool_call_input.delta\",\"call_id\":\"call-1\",\"delta\":\" Patch\"}"
+            , sseBlock "response.custom_tool_call_input.done"
+                "{\"type\":\"response.custom_tool_call_input.done\",\"item_id\":\"ctc-1\",\"input\":\"*** Begin Patch\"}"
+            , sseBlock "response.completed"
+                "{\"type\":\"response.completed\",\"response\":{\"id\":\"resp-custom\"}}"
+            ]
+        response <- expectRight
+            (buildStreamResponseWithModel config (Just "request-model") events)
+        case response.output of
+            [CustomToolCallItem CustomToolCall { name, input }] ->
+                (name, input)
+                    `shouldBe` ("apply_patch", "*** Begin Patch")
+            other -> expectationFailure
+                ("expected one custom tool call, got " <> show other)
+
+    it "assembles reasoning summary part and text events by item id" do
+        events <- expectRight $ parseSseEvents $ Text.intercalate ""
+            [ sseBlock "response.created"
+                "{\"type\":\"response.created\",\"response\":{\"id\":\"resp-reasoning\"}}"
+            , sseBlock "response.output_item.added"
+                "{\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"type\":\"reasoning\",\"id\":\"rs-1\",\"summary\":[]}}"
+            , sseBlock "response.reasoning_summary_part.added"
+                "{\"type\":\"response.reasoning_summary_part.added\",\"item_id\":\"rs-1\",\"summary_index\":0,\"part\":{\"type\":\"summary_text\",\"text\":\"\"}}"
+            , sseBlock "response.reasoning_summary_text.done"
+                "{\"type\":\"response.reasoning_summary_text.done\",\"item_id\":\"rs-1\",\"summary_index\":0,\"text\":\"Checked the repository.\"}"
+            , sseBlock "response.completed"
+                "{\"type\":\"response.completed\",\"response\":{\"id\":\"resp-reasoning\"}}"
+            ]
+        response <- expectRight
+            (buildStreamResponseWithModel config (Just "request-model") events)
+        case response.output of
+            [ReasoningItemValue ReasoningItem
+                { summary = [ReasoningSummaryPart { text = Just partText }]
+                }] ->
+                    partText `shouldBe` "Checked the repository."
+            other -> expectationFailure
+                ("expected one reasoning summary, got " <> show other)
+
+    it "assembles indexless reasoning summary text deltas by item id" do
+        events <- expectRight $ parseSseEvents $ Text.intercalate ""
+            [ sseBlock "response.created"
+                "{\"type\":\"response.created\",\"response\":{\"id\":\"resp-reasoning-delta\"}}"
+            , sseBlock "response.output_item.added"
+                "{\"type\":\"response.output_item.added\",\"item\":{\"type\":\"reasoning\",\"id\":\"rs-1\",\"summary\":[]}}"
+            , sseBlock "response.reasoning_summary_part.added"
+                "{\"type\":\"response.reasoning_summary_part.added\",\"item_id\":\"rs-1\",\"summary_index\":0,\"part\":{\"type\":\"summary_text\",\"text\":\"\"}}"
+            , sseBlock "response.reasoning_summary_text.delta"
+                "{\"type\":\"response.reasoning_summary_text.delta\",\"item_id\":\"rs-1\",\"summary_index\":0,\"delta\":\"Checked \"}"
+            , sseBlock "response.reasoning_summary_text.delta"
+                "{\"type\":\"response.reasoning_summary_text.delta\",\"item_id\":\"rs-1\",\"summary_index\":0,\"delta\":\"the repository.\"}"
+            , sseBlock "response.completed"
+                "{\"type\":\"response.completed\",\"response\":{\"id\":\"resp-reasoning-delta\"}}"
+            ]
+        response <- expectRight
+            (buildStreamResponseWithModel config (Just "request-model") events)
+        case response.output of
+            [ReasoningItemValue ReasoningItem
+                { summary = [ReasoningSummaryPart { text = Just partText }]
+                }] ->
+                    partText `shouldBe` "Checked the repository."
+            other -> expectationFailure
+                ("expected one reasoning summary, got " <> show other)
 
     it "uses provider classifiers when no terminal response is present" do
         streamEvents <- expectRight $ parseSseEvents $ sseBlock "error"
@@ -47,6 +187,19 @@ spec = describe "buildStreamResponse" do
             "{\"type\":\"response.failed\",\"response\":{\"id\":\"resp-f\",\"created_at\":0,\"model\":\"test\",\"status\":\"failed\",\"incomplete_details\":{\"reason\":\"overloaded\"}}}"
         buildStreamResponse config failedEvents
             `shouldBe` Left (ConnectionError "failed: response.failed: overloaded")
+
+        emptyFailedEvents <- expectRight $ parseSseEvents $
+            sseBlock "response.failed"
+                "{\"type\":\"response.failed\",\"response\":{}}"
+        buildStreamResponse config emptyFailedEvents
+            `shouldBe` Left
+                (ConnectionError "failed: response.failed (no details)")
+
+        messageFailedEvents <- expectRight $ parseSseEvents $
+            sseBlock "response.failed"
+                "{\"type\":\"response.failed\",\"response\":{\"error\":{\"message\":\"exploded\"}}}"
+        buildStreamResponse config messageFailedEvents
+            `shouldBe` Left (ConnectionError "failed: exploded")
 
     it "uses the configured missing-completion message" do
         case buildStreamResponse config [] of
@@ -60,7 +213,9 @@ spec = describe "buildStreamResponse" do
         , classifyStreamError =
             \streamError -> ConnectionError ("stream: " <> streamError.message)
         , classifyFailedResponse =
-            \response -> ConnectionError ("failed: " <> failedResponseMessage response)
+            \failure ->
+                ConnectionError
+                    ("failed: " <> failedStreamResponseMessage failure)
         }
 
 sseBlock :: Text -> Text -> Text

--- a/packages/agent-xai/src/Agent/XAI/Stream.hs
+++ b/packages/agent-xai/src/Agent/XAI/Stream.hs
@@ -8,7 +8,7 @@ module Agent.XAI.Stream
     , buildResponse
     ) where
 
-import Agent.Error (ApiError(..), errorTypeFromText)
+import Agent.Error (ApiError(..), ErrorType(..), errorTypeFromText)
 import Agent.Responses.Error (mkOpenAIError)
 import Agent.Responses.SSE
     ( SseDecoder
@@ -18,12 +18,14 @@ import Agent.Responses.SSE
     , parseSseEvents
     )
 import Agent.Responses.StreamAssembly
-    ( StreamAssemblyConfig(..)
+    ( ResponseFailure(..)
+    , StreamAssemblyConfig(..)
     , buildStreamResponse
-    , failedResponseMessage
+    , failedStreamResponseMessage
     )
 import Agent.Responses.Types
 import Agent.XAI.Error (classifyStreamError)
+import Control.Applicative ((<|>))
 
 -- | Merge streamed output-item events into the terminal completed response.
 buildResponse :: [ResponseStreamEvent] -> Either ApiError Response
@@ -34,12 +36,16 @@ buildResponse = buildStreamResponse StreamAssemblyConfig
     , classifyFailedResponse = failedResponseError
     }
 
-failedResponseError :: Response -> ApiError
-failedResponseError response = case response.error of
-    Just responseError ->
-        mkOpenAIError
-            (errorTypeFromText responseError.code)
-            responseError.message
-            (Just responseError.code)
-            Nothing
-    Nothing -> ConnectionError (failedResponseMessage response)
+failedResponseError :: ResponseFailure -> ApiError
+failedResponseError response =
+    case response.failureErrorType
+            <|> response.failureErrorCode
+            <|> response.failureErrorMessage of
+        Nothing -> ConnectionError (failedStreamResponseMessage response)
+        Just _ ->
+            mkOpenAIError
+                (maybe ApiErrorType errorTypeFromText
+                    (response.failureErrorType <|> response.failureErrorCode))
+                (failedStreamResponseMessage response)
+                response.failureErrorCode
+                Nothing


### PR DESCRIPTION
## Summary
- decode Responses lifecycle frames as lossless partial fragments and assemble a strict final response only at terminal events
- share indexed output/custom-tool/reasoning assembly across SSE and WebSocket transports, including indexless Codex frames
- stop the WebSocket receive loop on `response.done`, `response.completed`, `response.incomplete`, and `response.failed`
- recognize Codex metadata/rate-limit/timing events while continuing to surface genuinely unknown events
- use one replay-safety predicate for visible and non-visible streamed output

## Regression coverage
- exact minimal `response.created` → indexless function call → partial `response.done` WebSocket sequence
- partial lifecycle completed/done/incomplete/failed frames
- output-item added/done replacement, ordering, and deduplication
- custom-tool input and reasoning-summary reconstruction without `output_index`
- lossless payload-light and explicit-null event decoding

## Validation
- `nix develop -c cabal test --offline agent-responses-test agent-openai-test agent-openrouter-test agent-xai-test --test-show-details=direct`
- `nix develop -c cabal build --offline all`
