### PR TITLE
feat: add secure ask_secret tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,20 @@ override automatic provider detection.
 
 Works with your Codex subscription, Grok subscription, and provider API keys.
 
+### Secret entry
+
+Interactive root agents can request API keys and tokens with the built-in
+`ask_secret` tool. The harness reads the value through a masked terminal
+prompt, writes it to a private temporary file, and returns only the file path
+to the model. This keeps the secret out of chat history, tool arguments,
+transcripts, and command text.
+
+Secret files are created below the session scratch directory with owner-only
+permissions and removed when the agent's tool runtime closes. Commands should
+delete them sooner after consumption when possible. This protects against
+accidental persistence; it is not an isolation boundary against commands
+running unsandboxed as the same operating-system user.
+
 ## Vision
 
 ### The agent harness is the interface

--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -80,6 +80,7 @@ library
                     , Agent.CLI.SessionEnv
                     , Agent.CLI.SessionLock
                     , Agent.CLI.SessionTitle
+                    , Agent.CLI.Secret
                     , Agent.CLI.Skills
                     , Agent.CLI.Status
                     , Agent.CLI.SubagentStore
@@ -200,6 +201,7 @@ test-suite agent-cli-test
                     , Agent.CLI.RenderSpec
                     , Agent.CLI.ReplStatusSpec
                     , Agent.CLI.ResumeSpec
+                    , Agent.CLI.SecretSpec
                     , Agent.CLI.StyleSpec
                     , Agent.CLI.TimestampSpec
                     , Agent.CLI.TerminalSpec

--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -26,6 +26,10 @@ import Agent.CLI.Auth
     , preferredOpenAiTokenProvider
     , probeLoadedAuthCredential
     )
+import Agent.CLI.Secret
+    ( promptSecretLine
+    , sanitizeSecretPromptText
+    )
 import Agent.CLI.AgentViewport
     ( AgentEntry(..)
     , AgentStep
@@ -164,7 +168,11 @@ import Agent.CLI.Project
     , resolveProjectRoot
     , saveProjectModel
     )
-import Agent.CLI.Prompt (defaultModelFor, systemPrompt)
+import Agent.CLI.Prompt
+    ( defaultModelFor
+    , secretInputGuidance
+    , systemPrompt
+    )
 import Agent.CLI.Request (requestParams, setRequestInstructions)
 import Agent.CLI.ProviderFallback
     ( allowsAutomaticBillingFallback
@@ -274,6 +282,7 @@ import Agent.CLI.TUI.App
     , requestFullscreenChoiceWithBody
     , requestFullscreenOnboarding
     , requestFullscreenResume
+    , requestFullscreenSecret
     , requestFullscreenText
     , runFullscreen
     , setFullscreenSessionActions
@@ -402,8 +411,12 @@ import Agent.Tools.PlanMode
     , deactivatePlanMode
     , planFilePath
     )
+import Agent.Tools.Secret
+    ( SecretPrompt(..)
+    , SecretPromptHooks(..)
+    )
 import Agent.Tools.Types
-    ( AppTool
+    ( AppTool(..)
     , ToolEnv(..)
     , defaultToolEnv
     , setToolSessionTmp
@@ -1355,6 +1368,15 @@ runAgentInitializedWithLock
     let basePlanHooks =
             cliPlanHooks interrupt escPaused (resolveColor stderr)
         planHooks = fullscreenAwarePlanHooks uiRuntimeRef basePlanHooks
+        baseSecretHooks = SecretPromptHooks \request ->
+            Right <$> promptSecretLine
+                escPaused
+                request.secretPromptMessage
+                request.secretPromptPurpose
+        secretHooks
+            | isOneShot options || not isTty = Nothing
+            | otherwise =
+                Just (fullscreenAwareSecretHooks uiRuntimeRef baseSecretHooks)
         provider = loaded.loadedProvider
         model = fromMaybe
             (case transitionTarget of
@@ -1516,7 +1538,12 @@ runAgentInitializedWithLock
         toolEnv = baseToolEnv
     coding <-
         codingToolsForWithTypes
-            dialect toolEnv (Just planHooks) multiCtx agentTypesRef
+            dialect
+            toolEnv
+            (Just planHooks)
+            secretHooks
+            multiCtx
+            agentTypesRef
             `onException` cleanupScratch
     case multiCtx of
         Just ctx -> do
@@ -1584,8 +1611,12 @@ runAgentInitializedWithLock
     flip finally closeAll do
         today <- utctDay <$> getCurrentTime
         let instructions =
-                systemPrompt dialect cwd (Just sessionTmp) today
-                    (isOneShot options)
+                Text.intercalate "\n\n" $
+                    filter (not . Text.null)
+                        [ systemPrompt dialect cwd (Just sessionTmp) today
+                            (isOneShot options)
+                        , secretInputGuidance (map (.appToolName) tools)
+                        ]
             params = requestParams model instructions
                 (schemasFromAppTools dialect tools) effort
             initialItems = maybe [] (foldSessionItems . snd) resumed
@@ -4574,6 +4605,34 @@ fullscreenAwarePlanHooks runtimeRef hooks = PlanModeHooks
                         [(choice, "") | choice <- choices]
                         >>= pure . (>>= (`atMay` choices))
     }
+
+fullscreenAwareSecretHooks
+    :: IORef (Maybe FullscreenRuntime)
+    -> SecretPromptHooks
+    -> SecretPromptHooks
+fullscreenAwareSecretHooks runtimeRef hooks =
+    SecretPromptHooks \request ->
+        withCurrentFullscreen runtimeRef
+            (hooks.promptSecret request)
+            \runtime ->
+                Right <$> requestFullscreenSecret
+                    runtime
+                    "Secret requested by agent"
+                    (secretRequestBody request)
+
+secretRequestBody :: SecretPrompt -> Text
+secretRequestBody request =
+    Text.intercalate "\n\n" $
+        filter (not . Text.null)
+            [ maybe ""
+                (\purpose ->
+                    "Purpose: "
+                        <> sanitizeSecretPromptText (Text.strip purpose))
+                request.secretPromptPurpose
+            , sanitizeSecretPromptText
+                (Text.strip request.secretPromptMessage)
+            , "Input is hidden and is not added to conversation history."
+            ]
 
 withCurrentFullscreen
     :: IORef (Maybe FullscreenRuntime)

--- a/packages/agent-cli/src/Agent/CLI/Dialects.hs
+++ b/packages/agent-cli/src/Agent/CLI/Dialects.hs
@@ -33,7 +33,14 @@ import Agent.GrokBuild.Dialect.Task
 import Agent.ProjectInstructions (LoadedAgentsMd)
 import Agent.Tools.MultiAgents (MultiAgentContext)
 import Agent.Tools.PlanMode (PlanModeEnv, PlanModeHooks)
+import Agent.Tools.Secret
+    ( SecretPromptHooks
+    , askSecretTool
+    , closeSecretStore
+    , newSecretStore
+    )
 import Agent.Tools.Types (AppTool, ToolEnv)
+import Control.Exception.Safe (finally, onException)
 import Data.IORef (newIORef)
 import qualified Data.Map.Strict as Map
 import Data.Text (Text)
@@ -50,37 +57,51 @@ codingToolsFor
     :: Dialect
     -> ToolEnv
     -> Maybe PlanModeHooks
+    -> Maybe SecretPromptHooks
     -> Maybe MultiAgentContext
     -> IO CodingTools
-codingToolsFor dialect env hooks multi = do
+codingToolsFor dialect env planHooks secretHooks multi = do
     typesRef <- newIORef Map.empty
-    codingToolsForWithTypes dialect env hooks multi typesRef
+    codingToolsForWithTypes
+        dialect env planHooks secretHooks multi typesRef
 
 codingToolsForWithTypes
     :: Dialect
     -> ToolEnv
     -> Maybe PlanModeHooks
+    -> Maybe SecretPromptHooks
     -> Maybe MultiAgentContext
     -> GrokSubagentSpecs
     -> IO CodingTools
-codingToolsForWithTypes dialect env hooks multi typesRef =
-    case dialectToolSurface dialect of
+codingToolsForWithTypes
+        dialect env planHooks secretHooks multi typesRef = do
+    secretStore <- traverse (newSecretStore env) secretHooks
+    let closeSecrets = mapM_ closeSecretStore secretStore
+        secretTools = maybe [] (pure . askSecretTool) secretStore
+        finish tools plan close agentTypes =
+            CodingTools
+                { codingAppTools = tools <> secretTools
+                , codingPlanMode = plan
+                , codingClose = close `finally` closeSecrets
+                , codingAgentTypes = agentTypes
+                }
+    flip onException closeSecrets $ case dialectToolSurface dialect of
         CodexToolSurface -> do
-            coding <- newCodexCodingTools env hooks multi
-            pure CodingTools
-                { codingAppTools = coding.codexAppTools
-                , codingPlanMode = coding.codexPlanMode
-                , codingClose = coding.codexClose
-                , codingAgentTypes = typesRef
-                }
+            coding <- newCodexCodingTools env planHooks multi
+            pure $
+                finish
+                    coding.codexAppTools
+                    coding.codexPlanMode
+                    coding.codexClose
+                    typesRef
         GrokBuildToolSurface -> do
-            coding <- newGrokCodingTools env hooks multi typesRef
-            pure CodingTools
-                { codingAppTools = coding.grokAppTools
-                , codingPlanMode = coding.grokPlanMode
-                , codingClose = coding.grokClose
-                , codingAgentTypes = coding.grokAgentTypes
-                }
+            coding <- newGrokCodingTools env planHooks multi typesRef
+            pure $
+                finish
+                    coding.grokAppTools
+                    coding.grokPlanMode
+                    coding.grokClose
+                    coding.grokAgentTypes
 
 filterChildGrokTools :: Text -> [AppTool] -> [AppTool]
 filterChildGrokTools = filterGrokToolsForType

--- a/packages/agent-cli/src/Agent/CLI/Prompt.hs
+++ b/packages/agent-cli/src/Agent/CLI/Prompt.hs
@@ -1,6 +1,7 @@
 -- | Dialect-specific system prompt closed over by the transport backend.
 module Agent.CLI.Prompt
     ( defaultModelFor
+    , secretInputGuidance
     , sessionTempGuidance
     , systemPrompt
     , systemPromptForTools
@@ -69,6 +70,7 @@ systemPromptForTools
         filter (not . Text.null)
             [ base
             , sessionTempGuidance sessionTmp
+            , secretInputGuidance available
             , ghciGuidanceForTools dialect available
             , timeContextGuidance
             ]
@@ -102,6 +104,20 @@ sessionTempGuidance = \case
             , "Use this private directory for clones, downloads, extracted files, generated assets, and other scratch work."
             , "Filesystem tools may access both the workspace and this directory; relative paths still resolve against the workspace."
             , "HASKELL_AGENT_TMPDIR and TMPDIR point to this directory for shell commands."
+            ]
+
+-- | Keep sensitive values outside model-visible text and tool arguments when
+-- the host exposes the dedicated secret-entry capability.
+secretInputGuidance :: [Text] -> Text
+secretInputGuidance available
+    | "ask_secret" `notElem` available = ""
+    | otherwise =
+        Text.unlines
+            [ "Secret handling:"
+            , "- Never ask the user to paste a token, API key, password, or other secret into chat or a normal tool argument."
+            , "- Use ask_secret to request sensitive values. It returns a private temporary file path, never the secret value."
+            , "- Pass that path to a consumer that supports file input and delete the file promptly after use."
+            , "- Never read, print, summarize, or otherwise expose the secret file contents."
             ]
 
 -- | Prefer GHCI as the general-purpose scripting environment.

--- a/packages/agent-cli/src/Agent/CLI/Secret.hs
+++ b/packages/agent-cli/src/Agent/CLI/Secret.hs
@@ -1,0 +1,90 @@
+-- | Trusted, non-persisted secret entry for the line-oriented CLI.
+module Agent.CLI.Secret
+    ( promptSecretLine
+    , sanitizeSecretPromptText
+    , secretPromptMessage
+    ) where
+
+import Agent.CLI.CancelWatch (withStdinPaused)
+import Agent.CLI.Notification
+    ( AttentionRequest(InputRequested)
+    , notifyAttention
+    )
+import Control.Exception.Safe (bracket_, finally, tryIO)
+import Data.Char (isControl)
+import Data.IORef (IORef)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.IO as Text
+import System.IO
+    ( hFlush
+    , hGetEcho
+    , hIsTerminalDevice
+    , hSetEcho
+    , stderr
+    , stdin
+    )
+
+-- | Ask for one line of secret text without echoing it.
+--
+-- The value is read directly from the terminal and never passes through the
+-- ordinary REPL input path or its history. An unavailable terminal or empty
+-- value returns 'Nothing'.
+promptSecretLine
+    :: IORef Bool
+    -> Text
+    -> Maybe Text
+    -> IO (Maybe Text)
+promptSecretLine escPaused prompt purpose =
+    withStdinPaused escPaused do
+        tty <- hIsTerminalDevice stdin
+        if not tty
+            then pure Nothing
+            else do
+                notifyAttention stderr InputRequested
+                Text.hPutStr stderr (secretPromptMessage prompt purpose)
+                hFlush stderr
+                result <-
+                    tryIO do
+                        oldEcho <- hGetEcho stdin
+                        bracket_
+                            (hSetEcho stdin False)
+                            (hSetEcho stdin oldEcho)
+                            Text.getLine
+                        `finally` Text.hPutStrLn stderr ""
+                pure case result of
+                    Left _ -> Nothing
+                    Right value
+                        | Text.null value -> Nothing
+                        | otherwise -> Just value
+
+-- | Trusted chrome shown before the no-echo input field.
+secretPromptMessage :: Text -> Maybe Text -> Text
+secretPromptMessage prompt purpose =
+    Text.unlines
+        ( [ "Secret requested by agent"
+          ]
+            <> [ "Purpose: " <> sanitizeDisplayText value
+               | Just value <- [purpose]
+               , not (Text.null (Text.strip value))
+               ]
+            <> [ sanitizeDisplayText prompt
+               , "Input is hidden and is not added to conversation history."
+               ]
+        )
+        <> "secret> "
+
+sanitizeDisplayText :: Text -> Text
+sanitizeDisplayText = sanitizeSecretPromptText
+
+-- | Constrain model-controlled prompt chrome to one terminal-safe line.
+--
+-- This replaces every control character, including line endings, tabs, escape
+-- sequences, and bell characters. Callers remain responsible for adding any
+-- trusted layout around the sanitized text.
+sanitizeSecretPromptText :: Text -> Text
+sanitizeSecretPromptText =
+    Text.map \character ->
+        if isControl character
+            then ' '
+            else character

--- a/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
@@ -547,6 +547,7 @@ runCodexSubagent runtime tokenProvider sendToRoot =
                         codexDialect
                         prepared.preparedToolEnv
                         (Just runtime.subagentPlanHooks)
+                        Nothing
                         (Just prepared.preparedMultiContext)
                 syncStoreRootFromPlan
                     runtime.subagentStoreRoot
@@ -653,6 +654,7 @@ runHttpSubagent runtime dialect provider sendToRoot mkBackend =
                         childDialect
                         prepared.preparedToolEnv
                         (Just runtime.subagentPlanHooks)
+                        Nothing
                         (Just prepared.preparedMultiContext)
                 flip finally coding.codingClose do
                     today <- utctDay <$> getCurrentTime

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -32,6 +32,7 @@ module Agent.CLI.TUI.App
     , requestFullscreenChoiceWithBody
     , requestFullscreenOnboarding
     , requestFullscreenResume
+    , requestFullscreenSecret
     , requestFullscreenText
     , runFullscreen
     , setFullscreenSessionActions
@@ -39,12 +40,16 @@ module Agent.CLI.TUI.App
     , setFullscreenImagePreviews
     , setFullscreenWindowTitle
     , uiEventRestartsMotionSchedule
+    , maskedSecretText
+    , normalizeTextOverlayInsertion
+    , textOverlayDisplayText
     , withFullscreenSuspended
     ) where
 
 import Agent.CLI.Clipboard
     ( formatImageSize
     )
+import Agent.CLI.Secret (sanitizeSecretPromptText)
 import Agent.CLI.Artifact (fencedCodeBlock)
 import Agent.CLI.Input
     ( ReplLine(..)
@@ -156,6 +161,7 @@ import Control.Concurrent.STM
     , readTMVar
     , registerDelay
     , retry
+    , takeTMVar
     , writeTVar
     )
 import Control.Monad (unless, void, when)
@@ -516,8 +522,28 @@ requestFullscreenText
 requestFullscreenText runtime title body initial = do
     reply <- newEmptyTMVarIO
     enqueueAppEvent runtime
-        (AppAskText title body initial reply)
+        (AppAskText TextInputPlain title body initial reply)
     atomically (readTMVar reply)
+
+-- | Request a secret through a masked fullscreen prompt.
+--
+-- The returned value exists only in transient overlay state and the reply
+-- 'TMVar'; it is never rendered or added to normal prompt history.
+requestFullscreenSecret
+    :: FullscreenRuntime
+    -> Text
+    -> Text
+    -> IO (Maybe Text)
+requestFullscreenSecret runtime title body = do
+    reply <- newEmptyTMVarIO
+    enqueueAppEvent runtime
+        (AppAskText
+            TextInputSecret
+            (sanitizeSecretPromptText title)
+            (sanitizeSecretPromptText body)
+            ""
+            reply)
+    atomically (takeTMVar reply)
 
 withFullscreenSuspended :: FullscreenRuntime -> IO a -> IO a
 withFullscreenSuspended runtime action = do
@@ -1374,7 +1400,11 @@ handleTextPromptKey = \case
             _ <- handleCtrlC
             when state.appUi.uiRunning (resolveTextPrompt False)
     V.EvKey V.KEnter [] -> resolveTextPrompt True
-    V.EvKey V.KEnter [V.MShift] -> insert "\n"
+    V.EvKey V.KEnter [V.MShift] -> do
+        state <- get
+        case (.textInputMode) <$> state.appTextPrompt of
+            Just TextInputPlain -> insert "\n"
+            _ -> pure ()
     V.EvKey V.KPageUp [] ->
         vScrollPage (viewportScroll OverlayViewport) Up
     V.EvKey V.KPageDown [] ->
@@ -1413,11 +1443,16 @@ handleTextPromptKey = \case
         | V.MCtrl `elem` modifiers ->
             edit deleteToLineEnd
     V.EvKey (V.KChar character) [] ->
-        insert (Text.singleton character)
+        insertForMode (Text.singleton character)
     V.EvPaste bytes ->
-        insert (Composer.decodePaste bytes)
+        insertForMode (Composer.decodePaste bytes)
     _ -> pure ()
   where
+    insertForMode raw = do
+        state <- get
+        let mode =
+                maybe TextInputPlain (.textInputMode) state.appTextPrompt
+        insert (normalizeTextOverlayInsertion mode raw)
     edit change =
         modify' \state ->
             state
@@ -2999,13 +3034,33 @@ drawTextPrompt state prompt =
 
 renderTextDraft :: TextOverlay -> Widget Name
 renderTextDraft prompt =
-    let content =
-            if Text.null prompt.textDraft
+    let displayDraft = textOverlayDisplayText prompt
+        content =
+            if Text.null displayDraft
                 then withAttr Theme.mutedAttr (txt " ")
-                else txt prompt.textDraft
+                else txt displayDraft
         (row, column) =
-            Composer.draftCursorLocation prompt.textDraft prompt.textCursor
+            Composer.draftCursorLocation displayDraft prompt.textCursor
     in showCursor OverlayCursor (Location (column, row)) content
+
+-- | Replace every code point with one fixed-width masking glyph.
+maskedSecretText :: Text -> Text
+maskedSecretText value =
+    Text.replicate (Text.length value) "•"
+
+-- | Text that may be painted for an overlay draft.
+textOverlayDisplayText :: TextOverlay -> Text
+textOverlayDisplayText prompt = case prompt.textInputMode of
+    TextInputPlain -> prompt.textDraft
+    TextInputSecret -> maskedSecretText prompt.textDraft
+
+-- | Secret prompts are deliberately single-line. Plain overlays preserve
+-- multiline input, while secret pastes stop before the first line ending.
+normalizeTextOverlayInsertion :: TextInputMode -> Text -> Text
+normalizeTextOverlayInsertion = \case
+    TextInputPlain -> id
+    TextInputSecret -> Text.takeWhile \character ->
+        character /= '\n' && character /= '\r'
 
 choiceRow :: AppState -> Int -> Int -> (Text, Text) -> Widget Name
 choiceRow appState selected index (label, detail) =
@@ -3480,7 +3535,7 @@ handleEventInner event = case event of
                 , appAgentHover = Nothing
                 }
         vScrollToBeginning (viewportScroll ResumeViewport)
-    AppEvent (AppAskText title body initial reply) -> do
+    AppEvent (AppAskText mode title body initial reply) -> do
         state <- get
         liftIO (state.appRuntime.runtimeNativeProgress False)
         modify' \state ->
@@ -3490,6 +3545,7 @@ handleEventInner event = case event of
                     , textBody = body
                     , textDraft = initial
                     , textCursor = Text.length initial
+                    , textInputMode = mode
                     }
                 , appTextReply = Just reply
                 , appAgentHover = Nothing

--- a/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
@@ -14,6 +14,7 @@ module Agent.CLI.TUI.Types
     , PendingAppEvent(..)
     , PendingUiEvent(..)
     , ResumeOverlay(..)
+    , TextInputMode(..)
     , TextOverlay(..)
     ) where
 
@@ -83,6 +84,7 @@ data AppEvent
         ![(Text, Text)]
         !(TMVar (Maybe Int))
     | AppAskText
+        !TextInputMode
         !Text
         !Text
         !Text
@@ -231,4 +233,10 @@ data TextOverlay = TextOverlay
     , textBody :: !Text
     , textDraft :: !Text
     , textCursor :: !Int
+    , textInputMode :: !TextInputMode
     }
+
+data TextInputMode
+    = TextInputPlain
+    | TextInputSecret
+    deriving (Eq, Show)

--- a/packages/agent-cli/test/Agent/CLI/DialectsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/DialectsSpec.hs
@@ -1,7 +1,9 @@
 module Agent.CLI.DialectsSpec (spec) where
 
 import Agent.CLI.Dialects
-    ( formatAgentsMdForDialect
+    ( CodingTools(..)
+    , codingToolsFor
+    , formatAgentsMdForDialect
     , globalAgentsHomeDir
     )
 import Agent.Dialect
@@ -10,8 +12,15 @@ import Agent.Dialect
     , grokBuildDialect
     )
 import Agent.ProjectInstructions (InstructionFile(..), LoadedAgentsMd(..))
+import Agent.Tools.Secret (SecretPromptHooks(..))
+import Agent.Tools.Types (AppTool(..), ToolEnv, defaultToolEnv)
+import Control.Exception.Safe (bracket, finally)
+import Control.Monad (forM_)
 import qualified Data.Text as Text
+import System.Directory (getTemporaryDirectory, removeDirectoryRecursive)
+import System.FilePath ((</>))
 import System.OsPath (unsafeEncodeUtf)
+import System.Posix.Temp (mkdtemp)
 import Test.Hspec
 
 spec :: Spec
@@ -41,3 +50,29 @@ spec = describe "Agent.CLI.Dialects" do
             `shouldBe` unsafeEncodeUtf "/home/u/.grok"
         globalAgentsHomeDir genericResponsesDialect home
             `shouldBe` unsafeEncodeUtf "/home/u/.haskell-agent"
+
+    it "registers ask_secret only when root prompt hooks are supplied" do
+        withTempToolEnv \env ->
+            forM_ [codexDialect, grokBuildDialect] \dialect -> do
+                withoutSecret <-
+                    codingToolsFor dialect env Nothing Nothing Nothing
+                map (.appToolName) withoutSecret.codingAppTools
+                    `shouldNotContain` ["ask_secret"]
+                withoutSecret.codingClose
+
+                let hooks = SecretPromptHooks
+                        (const (pure (Right Nothing)))
+                withSecret <-
+                    codingToolsFor dialect env Nothing (Just hooks) Nothing
+                (map (.appToolName) withSecret.codingAppTools
+                    `shouldContain` ["ask_secret"])
+                    `finally` withSecret.codingClose
+
+withTempToolEnv :: (ToolEnv -> IO a) -> IO a
+withTempToolEnv action = do
+    root <- getTemporaryDirectory
+    bracket
+        (mkdtemp (root </> "agent-cli-dialects-"))
+        removeDirectoryRecursive
+        (\directory ->
+            defaultToolEnv (unsafeEncodeUtf directory) >>= action)

--- a/packages/agent-cli/test/Agent/CLI/PromptSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/PromptSpec.hs
@@ -119,6 +119,32 @@ spec = describe "systemPrompt" do
         prompt `shouldNotSatisfy` Text.isInfixOf "run_terminal_cmd"
         prompt `shouldNotSatisfy` Text.isInfixOf "run_ghci"
         prompt `shouldNotSatisfy` Text.isInfixOf "Prefer ghci for scripting"
+        prompt `shouldNotSatisfy` Text.isInfixOf "Use ask_secret"
+
+    it "adds secret guidance only when ask_secret is registered" do
+        let withSecret =
+                systemPromptForTools
+                    genericResponsesDialect
+                    ["read_file", "ask_secret"]
+                    (fromFilePath "/tmp/repo")
+                    Nothing
+                    (fromGregorian 2026 8 19)
+                    False
+            withoutSecret =
+                systemPromptForTools
+                    genericResponsesDialect
+                    ["read_file"]
+                    (fromFilePath "/tmp/repo")
+                    Nothing
+                    (fromGregorian 2026 8 19)
+                    False
+        withSecret `shouldSatisfy` Text.isInfixOf
+            "Never ask the user to paste a token"
+        withSecret `shouldSatisfy` Text.isInfixOf
+            "It returns a private temporary file path"
+        withSecret `shouldSatisfy` Text.isInfixOf
+            "Never read, print, summarize"
+        withoutSecret `shouldNotSatisfy` Text.isInfixOf "Use ask_secret"
 
     it "keeps OpenAI web-search references internal" do
         let openai =

--- a/packages/agent-cli/test/Agent/CLI/SecretSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SecretSpec.hs
@@ -1,0 +1,45 @@
+module Agent.CLI.SecretSpec (spec) where
+
+import Agent.CLI.Secret
+    ( sanitizeSecretPromptText
+    , secretPromptMessage
+    )
+import qualified Data.Text as Text
+import Test.Hspec
+
+spec :: Spec
+spec = describe "line-mode secret prompt" do
+    it "identifies trusted secret entry without including a value" do
+        let rendered =
+                secretPromptMessage
+                    "Enter the BotFather token"
+                    (Just "Configure the Telegram gateway")
+        rendered `shouldSatisfy`
+            Text.isInfixOf "Secret requested by agent"
+        rendered `shouldSatisfy`
+            Text.isInfixOf "Purpose: Configure the Telegram gateway"
+        rendered `shouldSatisfy`
+            Text.isInfixOf "Enter the BotFather token"
+        rendered `shouldSatisfy`
+            Text.isSuffixOf "secret> "
+
+    it "does not render an absent or blank purpose" do
+        secretPromptMessage "API key" Nothing
+            `shouldNotSatisfy` Text.isInfixOf "Purpose:"
+        secretPromptMessage "API key" (Just "  ")
+            `shouldNotSatisfy` Text.isInfixOf "Purpose:"
+
+    it "neutralizes terminal control characters in model-supplied chrome" do
+        let rendered =
+                secretPromptMessage
+                    "Token:\ESC]52;c;payload\BEL"
+                    (Just "Deploy\ESC[2J")
+        rendered `shouldNotSatisfy` Text.isInfixOf "\ESC"
+        rendered `shouldNotSatisfy` Text.isInfixOf "\BEL"
+
+    it "constrains model-controlled chrome to one safe line" do
+        let rendered =
+                sanitizeSecretPromptText
+                    "first\nsecond\tthird\r\ESC[2J\BEL"
+        rendered `shouldNotSatisfy` Text.any (`elem` ['\n', '\t', '\r', '\ESC', '\BEL'])
+        rendered `shouldBe` "first second third  [2J "

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -16,14 +16,19 @@ import Agent.CLI.TUI.App
     , nativeProgressKeepaliveDue
     , nextMotionSchedule
     , onboardingVisibleRowIndices
+    , maskedSecretText
+    , normalizeTextOverlayInsertion
     , repositoryHeaderText
     , resumeSearchCursorColumn
     , selectedAgentConversation
+    , textOverlayDisplayText
     , uiEventRestartsMotionSchedule
     )
 import Agent.CLI.TUI.Types
     ( ChoiceOverlay(..)
     , ChoicePresentation(..)
+    , TextInputMode(..)
+    , TextOverlay(..)
     )
 import Agent.Loop (LoopEvent(..), emptyTurnOutput)
 import Brick
@@ -48,6 +53,29 @@ import Test.Hspec
 
 spec :: Spec
 spec = do
+    describe "secret text overlay" do
+        it "renders only fixed-width masking glyphs" do
+            maskedSecretText "top-secret-123"
+                `shouldBe` Text.replicate 14 "•"
+            let overlay = TextOverlay
+                    { textTitle = "Secret requested by agent"
+                    , textBody = "Enter an API key"
+                    , textDraft = "top-secret-123"
+                    , textCursor = 14
+                    , textInputMode = TextInputSecret
+                    }
+            textOverlayDisplayText overlay
+                `shouldBe` Text.replicate 14 "•"
+            textOverlayDisplayText overlay
+                `shouldNotSatisfy` Text.isInfixOf "secret"
+
+        it "preserves plain overlays and keeps secret pastes single-line" do
+            let value = "first\nsecond\rthird"
+            normalizeTextOverlayInsertion TextInputPlain value
+                `shouldBe` value
+            normalizeTextOverlayInsertion TextInputSecret value
+                `shouldBe` "first"
+
     describe "choice overlay lifecycle" do
         it "closes a running-turn choice on success or cancellation" do
             let running =

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -39,6 +39,7 @@ import qualified Agent.CLI.RequestSpec as RequestSpec
 import qualified Agent.CLI.RenderSpec as RenderSpec
 import qualified Agent.CLI.ReplStatusSpec as ReplStatusSpec
 import qualified Agent.CLI.ResumeSpec as ResumeSpec
+import qualified Agent.CLI.SecretSpec as SecretSpec
 import qualified Agent.CLI.SessionSpec as SessionSpec
 import qualified Agent.CLI.SessionTitleSpec as SessionTitleSpec
 import qualified Agent.CLI.SkillsSpec as SkillsSpec
@@ -96,6 +97,7 @@ main = hspec do
     RenderSpec.spec
     ReplStatusSpec.spec
     ResumeSpec.spec
+    SecretSpec.spec
     StyleSpec.spec
     TimestampSpec.spec
     TurnSpec.spec

--- a/packages/agent-core/README.md
+++ b/packages/agent-core/README.md
@@ -18,6 +18,10 @@ Provider-neutral infrastructure shared by the harness transports:
 - `Agent.Tools.Types`, `Agent.Tools.IO`, `Agent.Tools.Ghci`, and related
   modules provide dialect-neutral execution primitives. Concrete tool names,
   schemas, prompts, and resource composition belong to dialect packages.
+- `Agent.Tools.Secret` provides scoped, owner-only temporary secret files for
+  trusted host prompts. It keeps secret values out of model-visible tool
+  arguments and results, but does not sandbox same-user processes from the
+  returned path.
 - `Agent.Transport.WebSocket` owns reusable WebSocket sessions, ping/pong
   handling, STM-scoped request ownership, serialized writes, bounded receive
   buffering, and provider-neutral failure classification. Interrupted or

--- a/packages/agent-core/agent-core.cabal
+++ b/packages/agent-core/agent-core.cabal
@@ -76,6 +76,7 @@ library
                     , Agent.Tools.IO
                     , Agent.Tools.MultiAgents
                     , Agent.Tools.PlanMode
+                    , Agent.Tools.Secret
                     , Agent.Tools.Types
                     , Agent.Transport.WebSocket
     hs-source-dirs:   src
@@ -142,6 +143,7 @@ test-suite agent-core-test
                     , Agent.Tools.IOSpec
                     , Agent.Tools.MultiAgentsSpec
                     , Agent.Tools.PlanModeSpec
+                    , Agent.Tools.SecretSpec
                     , Agent.ToolDSLSpec
                     , Agent.Transport.WebSocketSpec
     build-depends:    base >= 4.14 && < 5

--- a/packages/agent-core/src/Agent/Tools/Secret.hs
+++ b/packages/agent-core/src/Agent/Tools/Secret.hs
@@ -1,0 +1,254 @@
+-- | Secure, harness-mediated secret entry for model tool calls.
+--
+-- The secret itself is supplied by a trusted host hook and is never present in
+-- the model's tool arguments or result. The model receives only the path of a
+-- private, temporary file containing the exact bytes entered by the user.
+module Agent.Tools.Secret
+    ( SecretPrompt(..)
+    , SecretPromptHooks(..)
+    , SecretStore
+    , newSecretStore
+    , closeSecretStore
+    , askSecretTool
+    ) where
+
+import Agent.OsPath (unsafeToFilePath)
+import Agent.ToolArgs (optText, reqText)
+import Agent.ToolDSL
+    ( PropertySchema(..)
+    , PropertyType(..)
+    )
+import Agent.ToolDispatch (typedTool)
+import Agent.Tools.Types
+    ( AppTool
+    , ToolEnv(..)
+    , ToolExecutionPolicy(..)
+    , jsonTool
+    )
+import Control.Concurrent.MVar
+    ( MVar
+    , modifyMVar
+    , newMVar
+    )
+import Control.Exception.Safe
+    ( SomeException
+    , bracketOnError
+    , displayException
+    , mask
+    , onException
+    , tryAny
+    , tryIO
+    )
+import Control.Monad (void)
+import Data.Aeson
+    ( FromJSON(..)
+    , Value
+    , object
+    , withObject
+    , (.=)
+    )
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as LBS
+import Data.IORef (readIORef)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
+import System.Directory
+    ( doesDirectoryExist
+    , removeDirectory
+    , removeFile
+    )
+import System.FilePath ((</>))
+import System.IO (Handle, hClose)
+import System.Posix.Temp (mkdtemp, mkstemp)
+import System.Posix.IO
+    ( FdOption(CloseOnExec)
+    , closeFd
+    , fdToHandle
+    , handleToFd
+    , setFdOption
+    )
+
+-- | Non-secret context shown by the trusted host UI.
+data SecretPrompt = SecretPrompt
+    { secretPromptMessage :: !Text
+    , secretPromptPurpose :: !(Maybe Text)
+    }
+    deriving (Eq, Show)
+
+-- | Host interaction used by 'askSecretTool'.
+--
+-- @Left@ reports that secure entry is unavailable, @Right Nothing@ means the
+-- user cancelled, and @Right (Just value)@ supplies the exact secret.
+newtype SecretPromptHooks = SecretPromptHooks
+    { promptSecret :: SecretPrompt -> IO (Either Text (Maybe Text))
+    }
+
+data SecretArtifact = SecretArtifact
+    { artifactDirectory :: !FilePath
+    , artifactFile :: !FilePath
+    }
+
+data SecretStoreState
+    = SecretStoreOpen ![SecretArtifact]
+    | SecretStoreClosed
+
+-- | Session-scoped owner of temporary secret files.
+data SecretStore = SecretStore
+    { secretToolEnv :: !ToolEnv
+    , secretHooks :: !SecretPromptHooks
+    , secretState :: !(MVar SecretStoreState)
+    }
+
+newSecretStore :: ToolEnv -> SecretPromptHooks -> IO SecretStore
+newSecretStore env hooks = do
+    state <- newMVar (SecretStoreOpen [])
+    pure SecretStore
+        { secretToolEnv = env
+        , secretHooks = hooks
+        , secretState = state
+        }
+
+-- | Remove every secret file still owned by the store. Idempotent.
+closeSecretStore :: SecretStore -> IO ()
+closeSecretStore store = do
+    artifacts <- modifyMVar store.secretState \case
+        SecretStoreClosed -> pure (SecretStoreClosed, [])
+        SecretStoreOpen current -> pure (SecretStoreClosed, current)
+    mapM_ removeSecretArtifact artifacts
+
+data AskSecretArgs = AskSecretArgs
+    { prompt :: !Text
+    , purpose :: !(Maybe Text)
+    }
+
+instance FromJSON AskSecretArgs where
+    parseJSON = withObject "ask_secret" \input -> AskSecretArgs
+        <$> reqText input "prompt"
+        <*> optText input "purpose"
+
+askSecretTool :: SecretStore -> AppTool
+askSecretTool store = jsonTool "ask_secret" askSecretDescription
+    [ PropertySchema "prompt" PropertyString True $ Just
+        "The trusted prompt shown to the user. Never include a secret value."
+    , PropertySchema "purpose" PropertyString False $ Just
+        "Optional explanation of why the secret is needed."
+    ]
+    -- The handler performs an explicit trusted user interaction. A second
+    -- generic mutating-tool approval would be redundant.
+    True
+    TurnSequential
+    (typedTool "ask_secret" (runAskSecret store))
+
+askSecretDescription :: Text
+askSecretDescription =
+    "Ask the user for a secret without placing it in chat or tool arguments. "
+        <> "The harness writes the exact value to a private temporary file and "
+        <> "returns only its path. Never read, print, or echo the file contents."
+
+runAskSecret :: SecretStore -> AskSecretArgs -> IO (Either Text Text)
+runAskSecret store args
+    | Text.null (Text.strip args.prompt) =
+        pure (Left "Secret prompt must not be empty.")
+    | otherwise = do
+        prompted <- tryAny $
+            store.secretHooks.promptSecret SecretPrompt
+            { secretPromptMessage = args.prompt
+            , secretPromptPurpose = args.purpose
+            }
+        case prompted of
+            Left _ -> pure (Left "Secure secret entry failed.")
+            Right (Left err) -> pure (Left err)
+            Right (Right Nothing) -> pure (Left "Secret entry cancelled.")
+            Right (Right (Just secret))
+                | Text.null secret -> pure (Left "No secret was entered.")
+                | otherwise -> storeSecret store secret
+
+storeSecret :: SecretStore -> Text -> IO (Either Text Text)
+storeSecret store secret =
+    createSecretArtifact store.secretToolEnv secret >>= \case
+        Left err -> pure (Left err)
+        Right artifact -> do
+            accepted <- modifyMVar store.secretState \case
+                SecretStoreClosed -> pure (SecretStoreClosed, False)
+                SecretStoreOpen current ->
+                    pure (SecretStoreOpen (artifact : current), True)
+            if not accepted
+                then do
+                    removeSecretArtifact artifact
+                    pure (Left "Secret storage is already closed.")
+                else pure $ Right $ encodeJson $ object
+                    [ "secret_file" .= Text.pack artifact.artifactFile
+                    , "message" .=
+                        ( "Secret saved to a private temporary file. Pass this "
+                            <> "path directly to the consuming program without "
+                            <> "reading or echoing the contents. Delete the file "
+                            <> "as soon as it has been consumed."
+                            :: Text
+                        )
+                    ]
+
+createSecretArtifact
+    :: ToolEnv
+    -> Text
+    -> IO (Either Text SecretArtifact)
+createSecretArtifact env secret =
+    readIORef env.toolSessionTmp >>= \case
+        Nothing ->
+            pure (Left "Secure secret entry requires a session temporary directory.")
+        Just temp -> do
+            let tempPath = unsafeToFilePath temp
+            exists <- doesDirectoryExist tempPath
+            if not exists
+                then pure (Left "The session temporary directory does not exist.")
+                else do
+                    result <- tryAny (createUnder tempPath)
+                    pure $ case result of
+                        Left err -> Left
+                            ("Failed to store secret securely: " <> exceptionText err)
+                        Right artifact -> Right artifact
+  where
+    createUnder :: FilePath -> IO SecretArtifact
+    createUnder tempPath = mask \restore -> do
+        directory <- mkdtemp (tempPath </> ".agent-secret-")
+        let removeDirectoryOnly = void (tryIO (removeDirectory directory))
+        (file, initialHandle) <-
+            mkstemp (directory </> "secret-")
+                `onException` removeDirectoryOnly
+        handle <- do
+            fd <-
+                handleToFd initialHandle
+                    `onException` void (tryIO (hClose initialHandle))
+            bracketOnError
+                (pure fd)
+                closeFd
+                \ownedFd -> do
+                    setFdOption ownedFd CloseOnExec True
+                    fdToHandle ownedFd
+        let artifact = SecretArtifact
+                { artifactDirectory = directory
+                , artifactFile = file
+                }
+            rollback = closeAndRemove handle artifact
+        restore
+            (BS.hPut handle (Text.encodeUtf8 secret) >> hClose handle)
+            `onException` rollback
+        pure artifact
+
+removeSecretArtifact :: SecretArtifact -> IO ()
+removeSecretArtifact artifact = do
+    void (tryIO (removeFile artifact.artifactFile))
+    void (tryIO (removeDirectory artifact.artifactDirectory))
+
+closeAndRemove :: Handle -> SecretArtifact -> IO ()
+closeAndRemove handle artifact = do
+    void (tryIO (hClose handle))
+    removeSecretArtifact artifact
+
+exceptionText :: SomeException -> Text
+exceptionText = Text.pack . displayException
+
+encodeJson :: Value -> Text
+encodeJson = Text.decodeUtf8 . LBS.toStrict . Aeson.encode
+

--- a/packages/agent-core/test/Agent/Tools/SecretSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/SecretSpec.hs
@@ -1,0 +1,186 @@
+module Agent.Tools.SecretSpec (spec) where
+
+import Agent.ToolDispatch
+    ( ToolCallResult(..)
+    , ToolDispatchConfig(..)
+    , dispatchToolCall
+    , functionToolCall
+    )
+import Agent.ToolDSL (PropertySchema(..))
+import Agent.Tools.Secret
+import Agent.Tools.Types
+    ( AppTool(..)
+    , ApprovalRule(..)
+    , defaultToolEnv
+    , jsonToolParameters
+    , setToolSessionTmp
+    )
+import Control.Exception.Safe (bracket, throwString)
+import Data.Aeson (Value(..))
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString as BS
+import Data.Bits ((.&.))
+import Data.IORef
+import Data.Maybe (fromMaybe)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
+import System.Directory
+    ( doesDirectoryExist
+    , doesFileExist
+    , getTemporaryDirectory
+    , listDirectory
+    , removeDirectoryRecursive
+    )
+import System.FilePath (takeDirectory, (</>))
+import System.OsPath (unsafeEncodeUtf)
+import System.Posix.Files (fileMode, getFileStatus)
+import System.Posix.Temp (mkdtemp)
+import Test.Hspec
+
+spec :: Spec
+spec = describe "Agent.Tools.Secret" do
+    it "advertises only non-secret prompt context" do
+        withStore (const (pure (Right Nothing))) \_ tool _ -> do
+            let parameters = fromMaybe [] (jsonToolParameters tool)
+            map (.propertyName) parameters `shouldBe` ["prompt", "purpose"]
+            map (.required) parameters `shouldBe` [True, False]
+            case tool.appToolApproval of
+                AlwaysReadOnly -> pure ()
+                _ -> expectationFailure "ask_secret should self-authorize"
+
+    it "passes prompt context to the trusted hook" do
+        seen <- newIORef Nothing
+        let hook request = do
+                writeIORef seen (Just request)
+                pure (Right Nothing)
+        withStore hook \_ tool _ -> do
+            _ <- runTool tool
+                "{\"prompt\":\"Bot token\",\"purpose\":\"Configure Telegram\"}"
+            readIORef seen `shouldReturn` Just SecretPrompt
+                { secretPromptMessage = "Bot token"
+                , secretPromptPurpose = Just "Configure Telegram"
+                }
+
+    it "creates a private exact-content file and never returns the secret" do
+        let secret = "token with spaces\nand-a-second-line"
+        withStore (const (pure (Right (Just secret)))) \_ tool _ -> do
+            output <- runTool tool "{\"prompt\":\"Token\"}"
+            output `shouldNotSatisfy` Text.isInfixOf secret
+            path <- resultSecretPath output
+            BS.readFile path `shouldReturn` Text.encodeUtf8 secret
+            modeOf path `shouldReturn` 0o600
+            modeOf (takeDirectory path) `shouldReturn` 0o700
+
+    it "creates unique files for repeated requests" do
+        withStore (const (pure (Right (Just "secret")))) \_ tool _ -> do
+            first <- runTool tool "{\"prompt\":\"First\"}" >>= resultSecretPath
+            second <- runTool tool "{\"prompt\":\"Second\"}" >>= resultSecretPath
+            first `shouldNotBe` second
+
+    it "removes owned files and directories when closed" do
+        withStoreManual (const (pure (Right (Just "secret")))) \store tool _ -> do
+            path <- runTool tool "{\"prompt\":\"Token\"}" >>= resultSecretPath
+            let directory = takeDirectory path
+            doesFileExist path `shouldReturn` True
+            closeSecretStore store
+            doesFileExist path `shouldReturn` False
+            doesDirectoryExist directory `shouldReturn` False
+            closeSecretStore store
+
+    it "creates no artifact when the user cancels" do
+        withStore (const (pure (Right Nothing))) \_ tool temp -> do
+            output <- runTool tool "{\"prompt\":\"Token\"}"
+            output `shouldBe` "ERR Secret entry cancelled."
+            listDirectory temp `shouldReturn` []
+
+    it "fails closed when secure entry is unavailable" do
+        withStore
+            (const (pure (Left "Secure secret entry requires an interactive terminal.")))
+            \_ tool temp -> do
+                output <- runTool tool "{\"prompt\":\"Token\"}"
+                output `shouldBe`
+                    "ERR Secure secret entry requires an interactive terminal."
+                listDirectory temp `shouldReturn` []
+
+    it "does not expose host prompt exceptions" do
+        withStore
+            (const (throwString "host detail that must stay private"))
+            \_ tool temp -> do
+                output <- runTool tool "{\"prompt\":\"Token\"}"
+                output `shouldBe` "ERR Secure secret entry failed."
+                output `shouldNotSatisfy` Text.isInfixOf "host detail"
+                listDirectory temp `shouldReturn` []
+
+    it "requires a configured session temporary directory" do
+        root <- getTemporaryDirectory
+        bracket
+            (mkdtemp (root </> "agent-secret-no-temp-"))
+            removeDirectoryRecursive
+            \workspace -> do
+                env <- defaultToolEnv (unsafeEncodeUtf workspace)
+                store <- newSecretStore env
+                    (SecretPromptHooks (const (pure (Right (Just "secret")))))
+                let tool = askSecretTool store
+                runTool tool "{\"prompt\":\"Token\"}"
+                    `shouldReturn`
+                        "ERR Secure secret entry requires a session temporary directory."
+                closeSecretStore store
+
+withStore
+    :: (SecretPrompt -> IO (Either Text (Maybe Text)))
+    -> (SecretStore -> AppTool -> FilePath -> IO a)
+    -> IO a
+withStore hook action =
+    withStoreManual hook \store tool temp ->
+        action store tool temp
+
+withStoreManual
+    :: (SecretPrompt -> IO (Either Text (Maybe Text)))
+    -> (SecretStore -> AppTool -> FilePath -> IO a)
+    -> IO a
+withStoreManual hook action = do
+    root <- getTemporaryDirectory
+    bracket
+        (mkdtemp (root </> "agent-secret-test-"))
+        removeDirectoryRecursive
+        \workspace -> do
+            temp <- mkdtemp (workspace </> "session-tmp-")
+            env <- defaultToolEnv (unsafeEncodeUtf workspace)
+            setToolSessionTmp env (Just (unsafeEncodeUtf temp))
+            bracket
+                (newSecretStore env (SecretPromptHooks hook))
+                closeSecretStore
+                (\store -> action store (askSecretTool store) temp)
+
+runTool :: AppTool -> Text -> IO Text
+runTool tool arguments = do
+    result <- dispatchToolCall testDispatchConfig
+        [tool.appToolHandler]
+        (functionToolCall "secret-1" "ask_secret" arguments)
+    pure result.output
+
+resultSecretPath :: Text -> IO FilePath
+resultSecretPath output =
+    case Aeson.decodeStrict' (Text.encodeUtf8 output) of
+        Just (Object value)
+            | Just (String path) <-
+                KeyMap.lookup (Key.fromText "secret_file") value ->
+                    pure (Text.unpack path)
+        _ -> expectationFailure ("missing secret_file in output: " <> Text.unpack output)
+            >> pure ""
+
+modeOf :: FilePath -> IO Integer
+modeOf path =
+    fromIntegral . (.&. 0o777) . fileMode <$> getFileStatus path
+
+testDispatchConfig :: ToolDispatchConfig
+testDispatchConfig = ToolDispatchConfig
+    { toolDispatchUnknownTool = \name -> "unknown:" <> name
+    , toolDispatchFormatResult = either ("ERR " <>) id
+    , toolDispatchFormatException = \name _ -> "EX " <> name
+    , toolDispatchOnException = \_ _ -> pure ()
+    , toolDispatchOnOutput = \_ _ -> pure ()
+    }

--- a/packages/agent-core/test/Spec.hs
+++ b/packages/agent-core/test/Spec.hs
@@ -24,6 +24,7 @@ import qualified Agent.Tools.GhciSpec as GhciSpec
 import qualified Agent.Tools.IOSpec as IOSpec
 import qualified Agent.Tools.MultiAgentsSpec as MultiAgentsSpec
 import qualified Agent.Tools.PlanModeSpec as PlanModeSpec
+import qualified Agent.Tools.SecretSpec as SecretSpec
 import qualified Agent.Transport.WebSocketSpec as WebSocketSpec
 import Test.Hspec (hspec)
 
@@ -52,5 +53,6 @@ main = hspec do
     IOSpec.spec
     MultiAgentsSpec.spec
     PlanModeSpec.spec
+    SecretSpec.spec
     DangerousSpec.spec
     WebSocketSpec.spec

--- a/packages/agent-tui/src/Agent/TUI/Presentation.hs
+++ b/packages/agent-tui/src/Agent/TUI/Presentation.hs
@@ -125,6 +125,7 @@ toolVerb name = case canonicalToolName name of
     "enter_plan_mode" -> "Entered"
     "exit_plan_mode" -> "Exited"
     "ask_user_question" -> "Asked"
+    "ask_secret" -> "Requested secret"
     other -> other
 
 toolDetail :: ToolCall -> Text
@@ -143,6 +144,12 @@ toolDetail call = case canonicalToolName call.name of
     "enter_plan_mode" -> "enter"
     "exit_plan_mode" -> "exit"
     "ask_user_question" -> askUserQuestionDetail call.arguments
+    "ask_secret" ->
+        firstLine $
+            let purpose = jsonTextFieldDefault "purpose" call.arguments
+            in if Text.null (Text.strip purpose)
+                then jsonTextFieldDefault "prompt" call.arguments
+                else purpose
     "spawn_agent" -> jsonTextFieldDefault "task_name" call.arguments
     "send_message" -> jsonTextFieldDefault "target" call.arguments
     "followup_task" -> jsonTextFieldDefault "target" call.arguments

--- a/packages/agent-tui/test/Agent/TUI/PresentationSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/PresentationSpec.hs
@@ -34,6 +34,20 @@ spec = describe "tool presentation" do
                 "wait_commands_or_subagents"
                 "{\"task_ids\":[\"t1\"]}")
             `shouldBe` "Waited"
+        summarizeToolCall
+            (functionToolCall
+                "secret"
+                "ask_secret"
+                "{\"prompt\":\"Enter token\",\"purpose\":\"Configure Telegram\"}")
+            `shouldBe` "Requested secret Configure Telegram"
+
+    it "falls back to the safe prompt text for ask_secret detail" do
+        toolDetail
+            (functionToolCall
+                "secret"
+                "ask_secret"
+                "{\"prompt\":\"Enter API token\"}")
+            `shouldBe` "Enter API token"
 
     it "parses and truncates search-replace diffs once for all renderers" do
         let oldText = Text.intercalate "\\n"


### PR DESCRIPTION
## Summary
- Add a new root-only `ask_secret` tool that writes the user-provided secret to a private temp file and returns only the file path to the model.
- Wire secure line-mode and fullscreen secret prompts into the CLI, with masked terminal input and sanitized chrome.
- Document the security model and the same-UID limitation.

## Security notes
- Secret values never appear in tool arguments, tool results, or model-visible prompt text.
- Secret files and their containing directories are created with owner-only permissions, file descriptors are close-on-exec, and artifacts are cleaned up when the tool runtime closes.
- The tool is available only to interactive root agents, not one-shot/non-TTY sessions or subagents.
- This is not a sandbox: commands running as the same OS user can still read the returned file path.

## Validation
- `nix develop -c sh -lc 'printf ":quit\n" | cabal repl agent-cli:lib:agent-cli agent-core:lib:agent-core agent-tui:lib:agent-tui agent-codex-dialect:lib:agent-codex-dialect agent-grok-build-dialect:lib:agent-grok-build-dialect'` — 175 modules loaded
- `nix develop -c cabal test --offline agent-core:agent-core-test --test-show-details=direct` — 269 examples, 0 failures
- `nix develop -c cabal test --offline agent-cli:agent-cli-test --builddir=dist-ask-secret --test-show-details=direct` — 697 examples, 0 failures
- `nix develop -c cabal test --offline agent-tui:agent-tui-test --test-show-details=direct` — 103 examples, 0 failures
- Live tmux smoke test of `promptSecretLine`; a 21-character dummy secret was accepted and did not appear in captured terminal output.
