### PR TITLE
Make bare URLs clickable in terminal output

### DIFF
--- a/packages/agent-cli/test/Agent/CLI/MarkdownSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/MarkdownSpec.hs
@@ -130,6 +130,14 @@ spec = do
             out `shouldSatisfy`
                 Text.isInfixOf "https://example.com/a_(b)"
 
+        it "wraps bare URLs in OSC 8 hyperlinks" do
+            let url = "https://github.com/digitallyinduced/haskell-agent/pull/339"
+                out = renderMarkdown True ("PR: " <> url)
+            out `shouldSatisfy`
+                Text.isInfixOf ("\ESC]8;;" <> url <> "\ESC\\")
+            out `shouldSatisfy` Text.isInfixOf url
+            out `shouldSatisfy` Text.isInfixOf "\ESC]8;;\ESC\\"
+
         it "restores heading styling after nested code" do
             let out = renderMarkdown True "# before `code` after"
                 afterCode = snd (Text.breakOn "code" out)

--- a/packages/agent-tui/src/Agent/TUI/Markdown/Inline.hs
+++ b/packages/agent-tui/src/Agent/TUI/Markdown/Inline.hs
@@ -8,6 +8,7 @@ module Agent.TUI.Markdown.Inline
 import Data.Char
     ( isAlphaNum
     , isAscii
+    , isControl
     , isSpace
     )
 import qualified Data.List as List
@@ -75,6 +76,10 @@ parseSequence closing initialPrevious = go initialPrevious
                                 else " (" <> url <> ")")
                         <|> previous
             in InlineLink url children : go previous' rest
+        | maybe True (not . isWordCharacter) previous
+        , Just (url, rest) <- bareUrlSpan text =
+            InlineLink url [InlineText url]
+                : go (lastCharacter url <|> previous) rest
         | Just (node, visible, rest) <- styledSpan previous "**" InlineStrong text =
             node : go (lastCharacter visible <|> previous) rest
         | Just (node, visible, rest) <- styledSpan previous "__" InlineStrong text =
@@ -246,6 +251,43 @@ takeDestination depth consumed remaining =
                 (consumed <> Text.singleton character)
                 rest
 
+bareUrlSpan :: Text -> Maybe (Text, Text)
+bareUrlSpan text = do
+    afterScheme <-
+        Text.stripPrefix "https://" text
+            <|> Text.stripPrefix "http://" text
+    let schemeLength = Text.length text - Text.length afterScheme
+        candidate = Text.takeWhile isUrlCharacter text
+        url = trimBareUrl candidate
+    if Text.length url > schemeLength
+        then Just (url, Text.drop (Text.length url) text)
+        else Nothing
+  where
+    isUrlCharacter character =
+        not (isSpace character)
+            && not (isControl character)
+
+trimBareUrl :: Text -> Text
+trimBareUrl candidate =
+    case Text.unsnoc candidate of
+        Just (prefix, character)
+            | character `elem` (".,;:!?\"'" :: String) ->
+                trimBareUrl prefix
+            | character == ')'
+            , unmatchedClosing '(' ')' candidate ->
+                trimBareUrl prefix
+            | character == ']'
+            , unmatchedClosing '[' ']' candidate ->
+                trimBareUrl prefix
+            | character == '}'
+            , unmatchedClosing '{' '}' candidate ->
+                trimBareUrl prefix
+        _ -> candidate
+  where
+    unmatchedClosing opening closing text =
+        Text.count (Text.singleton closing) text
+            > Text.count (Text.singleton opening) text
+
 escapedPunctuation :: Text -> Maybe (Char, Text)
 escapedPunctuation text = do
     afterSlash <- Text.stripPrefix "\\" text
@@ -288,16 +330,33 @@ isWordCharacter :: Char -> Bool
 isWordCharacter character = isAlphaNum character || character == '_'
 
 takePlain :: Maybe Text -> Text -> (Text, Text)
-takePlain closing =
-    Text.span \character ->
-        character /= '\\'
-            && character /= '`'
-            && character /= '['
-            && character /= '*'
-            && character /= '_'
-            && maybe True
-                (\marker -> character /= Text.head marker)
+takePlain closing text =
+    case
+        [ index
+        | Just index <-
+            [ Text.findIndex isMarkupStart text
+            , prefixIndex "https://" text
+            , prefixIndex "http://" text
+            ]
+        ] of
+        [] -> (text, "")
+        indexes -> Text.splitAt (minimum indexes) text
+  where
+    isMarkupStart character =
+        character == '\\'
+            || character == '`'
+            || character == '['
+            || character == '*'
+            || character == '_'
+            || maybe False
+                (\marker -> character == Text.head marker)
                 closing
+
+    prefixIndex prefix source =
+        let (before, match) = Text.breakOn prefix source
+        in if Text.null match
+            then Nothing
+            else Just (Text.length before)
 
 lastCharacter :: Text -> Maybe Char
 lastCharacter text = snd <$> Text.unsnoc text

--- a/packages/agent-tui/test/Agent/TUI/Markdown/InlineSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/Markdown/InlineSpec.hs
@@ -53,6 +53,38 @@ spec = describe "shared inline Markdown parsing" do
                     [InlineText "two"]
                 ]
 
+    it "parses bare HTTP(S) URLs without changing their visible text" do
+        let url = "https://github.com/digitallyinduced/haskell-agent/pull/339"
+        parseInline ("PR: " <> url)
+            `shouldBe`
+                [ InlineText "PR: "
+                , InlineLink url [InlineText url]
+                ]
+        inlinePlainText (parseInline ("PR: " <> url))
+            `shouldBe` "PR: " <> url
+
+    it "leaves trailing sentence punctuation outside bare URLs" do
+        parseInline
+            "See https://example.com/a_(b)), then http://example.net/path."
+            `shouldBe`
+                [ InlineText "See "
+                , InlineLink
+                    "https://example.com/a_(b)"
+                    [InlineText "https://example.com/a_(b)"]
+                , InlineText "), then "
+                , InlineLink
+                    "http://example.net/path"
+                    [InlineText "http://example.net/path"]
+                , InlineText "."
+                ]
+
+    it "does not autolink URLs inside code or embedded in words" do
+        parseInline "`https://example.com` abchttps://example.com"
+            `shouldBe`
+                [ InlineCode "https://example.com"
+                , InlineText " abchttps://example.com"
+                ]
+
     it "preserves intraword underscore delimiters" do
         parseInline "foo__bar__baz snake_case"
             `shouldBe` [InlineText "foo__bar__baz snake_case"]

--- a/packages/agent-tui/test/Agent/TUI/MarkdownSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/MarkdownSpec.hs
@@ -49,6 +49,11 @@ spec = describe "fullscreen Markdown rendering" do
         rendered `shouldSatisfy`
             isInfixOf "attrURL = SetTo \"https://example.com\""
 
+    it "renders bare URLs with native terminal hyperlink metadata" do
+        let url = "https://github.com/digitallyinduced/haskell-agent/pull/339"
+            spans = concat (renderSpanRows 100 ("PR: " <> url))
+        spans `shouldSatisfy` any (hasUrl url)
+
     it "parses links nested inside strong and emphasis spans" do
         parseInline
             "**[PR #316](https://example.com/316)** and *[docs](https://example.com)*"


### PR DESCRIPTION
## Summary
- recognize bare `http://` and `https://` URLs in shared inline Markdown parsing
- emit existing Vty/OSC 8 hyperlink metadata in fullscreen and classic CLI output
- keep trailing sentence punctuation, inline code, and embedded word fragments out of links

## Testing
- `printf ':main\\n:q\\n' | nix develop -c cabal repl --offline agent-tui:test:agent-tui-test` (105 examples, 0 failures)
- focused `agent-cli` GHCi test for bare URL OSC 8 rendering
- live fullscreen tmux smoke test confirmed hyperlink metadata on a GitHub PR URL
