### PR TITLE
feat(cli): show provider retry countdown

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -198,6 +198,7 @@ import Agent.CLI.Request (requestParams, setRequestInstructions)
 import Agent.CLI.ProviderFallback
     ( allowsAutomaticBillingFallback
     , automaticCooldownRetryDelay
+    , automaticRetryCountdownText
     , fallbackCandidates
     , isProviderUnavailable
     )
@@ -493,6 +494,7 @@ import Text.Printf (printf)
 import Data.Time.Clock
     ( NominalDiffTime
     , UTCTime
+    , addUTCTime
     , diffUTCTime
     , getCurrentTime
     , utctDay
@@ -3314,32 +3316,57 @@ waitAndRetryPendingTurn
     -> PendingTurn
     -> IO RunResult
 waitAndRetryPendingTurn env delay pending = do
-    let waitMessage =
-            "provider credentials temporarily unavailable; retrying this turn in "
-                <> formatDuration delay
-                <> " (Esc to cancel)"
-    case env.sessionFullscreen of
-        Just runtime ->
-            emitUiEvent runtime
-                (UiSetNotice (Just (warningNotice waitMessage)))
-        Nothing -> do
-            color <- resolveColor stderr
-            putTextLn stderr $
-                roleWarn color (glyphWarn <> waitMessage)
     let cancel = env.sessionLoop.loopCancel
-        -- Give the provider reset boundary a small margin so the automatic
-        -- retry does not race a rounded server timestamp.
-        waitMicros = max 1 (ceiling ((realToFrac delay + 0.25) * 1_000_000 :: Double))
-        waitForCancel =
-            isJust <$> timeout waitMicros (waitCancel cancel)
+        renderCountdown seconds =
+            let message = automaticRetryCountdownText seconds
+            in case env.sessionFullscreen of
+                Just runtime ->
+                    emitUiEvent runtime
+                        (UiSetNotice (Just (progressNotice message)))
+                Nothing ->
+                    renderEvent env.sessionRender (ActivityUpdated message)
+        waitForCancel = do
+            startedAt <- getCurrentTime
+            let retryAt = addUTCTime (max 0 delay) startedAt
+                poll lastShown = do
+                    now <- getCurrentTime
+                    let remaining = max 0 (diffUTCTime retryAt now)
+                        seconds = max 0 (ceiling remaining)
+                    when (lastShown /= Just seconds) (renderCountdown seconds)
+                    if remaining <= 0
+                        then do
+                            -- Give the provider reset boundary a small margin
+                            -- so the retry does not race a rounded timestamp.
+                            isJust <$> timeout 250000 (waitCancel cancel)
+                        else do
+                            let waitMicros =
+                                    max 1 $
+                                        min 1000000
+                                            (ceiling
+                                                (realToFrac remaining
+                                                    * 1_000_000
+                                                    :: Double))
+                            cancelled <-
+                                isJust <$> timeout waitMicros (waitCancel cancel)
+                            if cancelled
+                                then pure True
+                                else poll (Just seconds)
+            poll Nothing
         waitAction = case env.sessionFullscreen of
             Just _ -> waitForCancel
             Nothing ->
                 withEscCancel cancel env.sessionEscPaused waitForCancel
     resetCancel cancel
+    case env.sessionFullscreen of
+        Just _ -> pure ()
+        Nothing -> renderEvent env.sessionRender TurnStarted
     cancelled <-
         (withTurnCancel env.sessionInterrupt cancel waitAction)
-            `finally` resetCancel cancel
+            `finally` do
+                resetCancel cancel
+                case env.sessionFullscreen of
+                    Just _ -> pure ()
+                    Nothing -> clearThinking env.sessionRender
     if cancelled
         then do
             case env.sessionFullscreen of

--- a/packages/agent-cli/src/Agent/CLI/ProviderFallback.hs
+++ b/packages/agent-cli/src/Agent/CLI/ProviderFallback.hs
@@ -2,6 +2,7 @@
 module Agent.CLI.ProviderFallback
     ( allowsAutomaticBillingFallback
     , automaticCooldownRetryDelay
+    , automaticRetryCountdownText
     , fallbackCandidates
     , isProviderUnavailable
     , isUsageExhausted
@@ -13,6 +14,8 @@ import Agent.CLI.Models (ModelOption(..), ModelTarget(..), modelCatalog)
 import Agent.Error (ApiError(..), ErrorType(..))
 import Agent.Provider (BillingMode(..), Provider(..))
 import Data.List (nubBy, sortOn)
+import Data.Text (Text)
+import qualified Data.Text as Text
 import Data.Time.Clock (NominalDiffTime, UTCTime, diffUTCTime)
 
 -- | Keep brief provider cooldowns invisible to the user when no fallback
@@ -42,6 +45,15 @@ automaticCooldownRetryDelay now = \case
             then Just delay
             else Nothing
     _ -> Nothing
+
+-- | Live status text for a brief automatic provider retry. Keep the remaining
+-- time in seconds so a one-minute cooldown visibly counts down instead of
+-- staying at the coarser "1m" duration for most of the wait.
+automaticRetryCountdownText :: Int -> Text
+automaticRetryCountdownText rawSeconds =
+    "Provider temporarily unavailable; retrying automatically in "
+        <> Text.pack (show (max 0 rawSeconds))
+        <> "s · Esc to cancel"
 
 -- | Curated models ordered from strongest to weakest for automatic selection.
 --

--- a/packages/agent-cli/test/Agent/CLI/ProviderFallbackSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ProviderFallbackSpec.hs
@@ -9,6 +9,7 @@ import Agent.CLI.Models (ModelOption(..), ModelTarget(..))
 import Agent.CLI.ProviderFallback
     ( allowsAutomaticBillingFallback
     , automaticCooldownRetryDelay
+    , automaticRetryCountdownText
     , fallbackCandidates
     , rankedModels
     )
@@ -135,6 +136,16 @@ spec = do
             automaticCooldownRetryDelay now
                 (ProviderError AuthenticationError "expired" Nothing)
                 `shouldBe` Nothing
+
+    describe "automaticRetryCountdownText" do
+        it "shows the remaining wait in seconds" do
+            automaticRetryCountdownText 60
+                `shouldBe`
+                    "Provider temporarily unavailable; retrying automatically in 60s · Esc to cancel"
+
+        it "never displays a negative countdown" do
+            automaticRetryCountdownText (-1)
+                `shouldSatisfy` Text.isInfixOf "in 0s"
 
 safeHead :: [a] -> Maybe a
 safeHead = \case


### PR DESCRIPTION
## Summary
- replace the static provider cooldown warning with a live seconds countdown
- show an animated progress indicator in both fullscreen and minimal terminal modes
- preserve Esc cancellation and the provider reset safety margin

## Testing
- `printf '\:quit\\n' | nix develop -c cabal repl agent-cli:lib:agent-cli`\n- `nix develop -c cabal test agent-cli:agent-cli-test --test-options='--match automaticRetryCountdownText'`\n- live fullscreen agent smoke test in tmux\n- `git diff --check`