### PR TITLE
refactor: share Markdown parsing across CLI and TUI

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Markdown.hs
+++ b/packages/agent-cli/src/Agent/CLI/Markdown.hs
@@ -27,14 +27,14 @@ import Agent.TUI.Markdown.Inline
     , inlinePlainText
     , parseInline
     )
+import qualified Agent.TUI.Markdown.Block as Block
 import Agent.TUI.TextWidth
     ( displayCharCellWidth
     , displayTerminalText
     )
-import Data.Char (isAlphaNum, isAscii, isDigit, isSpace)
+import Data.Char (isAlphaNum, isAscii, isSpace)
 import Data.Colour (Colour)
 import Data.List (transpose)
-import Data.Maybe (fromMaybe, isJust, mapMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import System.Console.ANSI
@@ -92,29 +92,31 @@ renderBlocks = go
   where
     go [] = []
     go (line : rest)
-        | Just (styled, after) <- takeTable (line : rest) =
-            styled ++ go after
-        | Just (level, title) <- headingLine line =
+        | Just (rows, after) <- Block.takeTableRows (line : rest) =
+            renderTable rows ++ go after
+        | Just (level, title) <- Block.headingParts line =
             -- Hide the markdown `#` markers (grok pretty mode); color the title.
             renderInlineWith (headingPrefixStyle level) (parseInline title)
                 : go rest
-        | Just (indent, item) <- unorderedItemParts line =
+        | Just (indent, item) <- Block.bulletParts line =
             ( indent
                 <> md listMarkerStyle "• "
                 <> styleInline item
             )
                 : go rest
-        | Just (indent, digits, item) <- orderedItemParts line =
+        | Just (indent, digits, item) <- Block.orderedParts line =
             ( indent
                 <> md listMarkerStyle (digits <> ". ")
                 <> styleInline item
             )
                 : go rest
-        | Just quote <- blockQuote line =
-            let body = renderInlineWith quoteStyle (parseInline quote)
+        | Just quote <- Block.blockQuoteRemainder line =
+            let body =
+                    renderInlineWith quoteStyle
+                        (parseInline (Text.stripStart quote))
             in (md [fg solarizedBase01] "│ " <> body)
                 : go rest
-        | isThematicBreak line =
+        | Block.isThematicBreak line =
             md [fg solarizedBase01] (Text.replicate 40 "─")
                 : go rest
         | Text.null (Text.strip line) = line : go rest
@@ -147,74 +149,16 @@ fg = SetRGBColor Foreground
 quoteStyle :: [SGR]
 quoteStyle = [fg solarizedBase01]
 
-headingLine :: Text -> Maybe (Int, Text)
-headingLine line =
-    let stripped = Text.stripStart line
-        (marks, after) = Text.span (== '#') stripped
-        level = Text.length marks
-    in if level >= 1 && level <= 6 && startsWithSpace after
-        then Just (level, Text.strip after)
-        else Nothing
-
-startsWithSpace :: Text -> Bool
-startsWithSpace t = case Text.uncons t of
-    Just (c, _) -> isSpace c
-    Nothing -> False
-
-unorderedItemParts :: Text -> Maybe (Text, Text)
-unorderedItemParts line =
-    let (indent, stripped) = Text.span isSpace line
-    in case Text.uncons stripped of
-        Just (c, rest)
-            | c `elem` ['-', '*', '+']
-            , Just (sp, after) <- Text.uncons rest
-            , isSpace sp ->
-                Just (indent, Text.strip after)
-        _ -> Nothing
-
--- | Ordered list: number marker and item body separately so the marker can
--- be colored without restyling the whole line twice.
-orderedItemParts :: Text -> Maybe (Text, Text, Text)
-orderedItemParts line =
-    let (indent, stripped) = Text.span isSpace line
-        (digits, after) = Text.span isDigit stripped
-    in if not (Text.null digits)
-        then case Text.stripPrefix ". " after of
-            Just item -> Just (indent, digits, Text.strip item)
-            Nothing -> Nothing
-        else Nothing
-
-blockQuote :: Text -> Maybe Text
-blockQuote line = case Text.stripPrefix ">" (Text.stripStart line) of
-    Just rest -> Just (Text.stripStart rest)
-    Nothing -> Nothing
-
-isThematicBreak :: Text -> Bool
-isThematicBreak line =
-    let stripped = Text.filter (not . isSpace) (Text.strip line)
-    in Text.length stripped >= 3
-        && (Text.all (== '-') stripped
-            || Text.all (== '*') stripped
-            || Text.all (== '_') stripped)
-
-takeTable :: [Text] -> Maybe ([Text], [Text])
-takeTable (header : sep : rest)
-    | Just headerCells <- splitTableRow header
-    , Just separatorCells <- splitTableRow sep
-    , length separatorCells == length headerCells
-    , all isSeparatorCell separatorCells =
-        let (body, after) = span isTableRow rest
-            bodyCells = mapMaybe splitTableRow body
-            rows = headerCells : bodyCells
-            widths = columnWidths rows
-            top = md [fg solarizedBase01] (boxLine '┌' '┬' '┐' '─' widths)
-            mid = md [fg solarizedBase01] (boxLine '├' '┼' '┤' '─' widths)
-            bot = md [fg solarizedBase01] (boxLine '└' '┴' '┘' '─' widths)
-            headerRow = styleTableRow True widths headerCells
-            bodyRows = map (styleTableRow False widths) bodyCells
-            styled = [top, headerRow, mid] ++ bodyRows ++ [bot]
-        in Just (styled, after)
-takeTable _ = Nothing
+renderTable :: [[Text]] -> [Text]
+renderTable [] = []
+renderTable rows@(headerCells : bodyCells) =
+    let widths = columnWidths rows
+        top = md [fg solarizedBase01] (boxLine '┌' '┬' '┐' '─' widths)
+        mid = md [fg solarizedBase01] (boxLine '├' '┼' '┤' '─' widths)
+        bot = md [fg solarizedBase01] (boxLine '└' '┴' '┘' '─' widths)
+        headerRow = styleTableRow True widths headerCells
+        bodyRows = map (styleTableRow False widths) bodyCells
+    in [top, headerRow, mid] ++ bodyRows ++ [bot]
 
 boxLine :: Char -> Char -> Char -> Char -> [Int] -> Text
 boxLine left mid right fill widths =
@@ -222,90 +166,6 @@ boxLine left mid right fill widths =
         <> Text.intercalate (Text.singleton mid)
             [ Text.replicate (w + 2) (Text.singleton fill) | w <- widths ]
         <> Text.singleton right
-
-isTableRow :: Text -> Bool
-isTableRow = isJust . splitTableRow
-
-isSeparatorCell :: Text -> Bool
-isSeparatorCell cell =
-    Text.any (== '-') cell
-        && Text.null (Text.filter (`notElem` ['-', ':', ' ']) cell)
-
--- | Split on actual table delimiters, preserving escaped pipes and pipes
--- inside matching backtick spans.
-splitTableRow :: Text -> Maybe [Text]
-splitTableRow raw =
-    let stripped = Text.strip raw
-        content = fromMaybe stripped (Text.stripPrefix "|" stripped)
-        (cells, delimiterCount) = scan Nothing [] [] 0 False
-            (Text.unpack content)
-    in if delimiterCount >= 1 then Just cells else Nothing
-  where
-    scan
-        :: Maybe Int
-        -> String
-        -> [Text]
-        -> Int
-        -> Bool
-        -> String
-        -> ([Text], Int)
-    scan _ current cells delimiterCount trailingDelimiter [] =
-        let allCells = reverse (finishCell current : cells)
-            withoutOuterBorder
-                | trailingDelimiter = dropLast allCells
-                | otherwise = allCells
-        in (withoutOuterBorder, delimiterCount)
-    scan codeRun current cells delimiterCount _ ('\\' : rest) =
-        let (slashes, afterSlashes) = span (== '\\') rest
-            slashCount = 1 + length slashes
-            literalSlashes =
-                replicate
-                    (if startsWithPipe afterSlashes
-                        then slashCount `div` 2
-                        else slashCount)
-                    '\\'
-            current' = literalSlashes <> current
-        in case afterSlashes of
-            '|' : afterPipe
-                | odd slashCount ->
-                    scan codeRun ('|' : current') cells
-                        delimiterCount False afterPipe
-                | codeRun == Nothing ->
-                    splitCell codeRun current' cells delimiterCount afterPipe
-            _ ->
-                scan codeRun current' cells
-                    delimiterCount False afterSlashes
-    scan codeRun current cells delimiterCount _ ('`' : rest) =
-        let (ticks, afterTicks) = span (== '`') rest
-            tickCount = 1 + length ticks
-            marker = replicate tickCount '`'
-            nextCodeRun = case codeRun of
-                Just openCount
-                    | tickCount >= openCount -> Nothing
-                Just openCount -> Just openCount
-                Nothing
-                    | hasClosingRun tickCount afterTicks -> Just tickCount
-                Nothing -> Nothing
-        in scan nextCodeRun (marker <> current) cells
-            delimiterCount False afterTicks
-    scan Nothing current cells delimiterCount _ ('|' : rest) =
-        splitCell Nothing current cells delimiterCount rest
-    scan codeRun current cells delimiterCount _ (character : rest) =
-        scan codeRun (character : current) cells
-            delimiterCount False rest
-
-    splitCell codeRun current cells delimiterCount rest =
-        scan codeRun [] (finishCell current : cells)
-            (delimiterCount + 1) True rest
-
-    finishCell = Text.strip . Text.pack . reverse
-    startsWithPipe ('|' : _) = True
-    startsWithPipe _ = False
-    hasClosingRun count =
-        Text.isInfixOf (Text.replicate count "`") . Text.pack
-    dropLast values = case reverse values of
-        _ : rest -> reverse rest
-        [] -> []
 
 columnWidths :: [[Text]] -> [Int]
 columnWidths rows =

--- a/packages/agent-tui/agent-tui.cabal
+++ b/packages/agent-tui/agent-tui.cabal
@@ -37,6 +37,7 @@ library
     hs-source-dirs:   src
     exposed-modules:  Agent.TUI.FencedCode
                     , Agent.TUI.Markdown
+                    , Agent.TUI.Markdown.Block
                     , Agent.TUI.Markdown.Inline
                     , Agent.TUI.Motion
                     , Agent.TUI.Model
@@ -58,6 +59,7 @@ test-suite agent-tui-test
     hs-source-dirs:   test
     main-is:          Spec.hs
     other-modules:    Agent.TUI.FencedCodeSpec
+                    , Agent.TUI.Markdown.BlockSpec
                     , Agent.TUI.Markdown.InlineSpec
                     , Agent.TUI.MarkdownSpec
                     , Agent.TUI.MotionSpec

--- a/packages/agent-tui/src/Agent/TUI/Markdown.hs
+++ b/packages/agent-tui/src/Agent/TUI/Markdown.hs
@@ -18,6 +18,7 @@ import Agent.TUI.Markdown.Inline
     , inlinePlainText
     , parseInline
     )
+import qualified Agent.TUI.Markdown.Block as Block
 import Agent.Syntax
     ( SyntaxHighlighter
     , SyntaxSpan(..)
@@ -31,9 +32,9 @@ import qualified Agent.TUI.Theme as Theme
 import Brick
 import qualified Brick.Types as B
 import Data.Bits ((.|.))
-import Data.Char (isDigit, isSpace)
+import Data.Char (isSpace)
 import qualified Data.List as List
-import Data.Maybe (fromMaybe, isJust, mapMaybe)
+import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Lazy as LazyText
@@ -105,28 +106,30 @@ renderLines
     -> [Widget n]
 renderLines [] = []
 renderLines lines_
-    | Just (table, rest) <- takeTable lines_ =
-        table : renderLines rest
+    | Just (rows, rest) <- Block.takeTableRows lines_ =
+        tableWidget rows : renderLines rest
 renderLines (line : rest)
-    | Just heading <- stripHeading line =
+    | Just (_, heading) <- Block.headingParts line =
         padTop (Pad 1)
             (inlineWidgetWithAttr Theme.headingAttr (parseInline heading))
             : renderLines rest
-    | Just (indent, item) <- stripBullet line =
+    | Just (indent, item) <- Block.bulletParts line =
         hBox
             [ txt indent
             , withAttr Theme.headingAttr (txt "• ")
             , inlineWidgetWithAttr Theme.assistantAttr (parseInline item)
             ]
             : renderLines rest
-    | Just (indent, number, item) <- stripOrdered line =
+    | Just (indent, number, item) <- Block.orderedParts line =
         hBox
             [ txt indent
             , withAttr Theme.headingAttr (txt (number <> ". "))
             , inlineWidgetWithAttr Theme.assistantAttr (parseInline item)
             ]
             : renderLines rest
-    | Just quote <- stripBlockQuote line =
+    | Just rawQuote <- Block.blockQuoteRemainder line =
+        let quote = fromMaybe rawQuote (Text.stripPrefix " " rawQuote)
+        in
         hBox
             [ withAttr Theme.mutedAttr (txt "│ ")
             , inlineWidgetWithAttr Theme.mutedAttr (parseInline quote)
@@ -134,7 +137,7 @@ renderLines (line : rest)
             : renderLines rest
     | Text.null (Text.strip line) =
         txt " " : renderLines rest
-    | isThematicBreak line =
+    | Block.isThematicBreak line =
         withAttr Theme.mutedAttr (vLimit 1 (fill '─'))
             : renderLines rest
     | otherwise =
@@ -227,63 +230,6 @@ renderCodeRow paddingAttr horizontalPadding fragments =
         | horizontalPadding <= 0 = V.emptyImage
         | otherwise =
             V.charFill paddingAttr ' ' horizontalPadding 1
-
-stripHeading :: Text -> Maybe Text
-stripHeading line =
-    let stripped = Text.stripStart line
-        (marks, rest) = Text.span (== '#') stripped
-    in if not (Text.null marks)
-        && Text.length marks <= 6
-        && Text.isPrefixOf " " rest
-        then Just (Text.strip rest)
-        else Nothing
-
-stripBullet :: Text -> Maybe (Text, Text)
-stripBullet line =
-    let (indent, stripped) = Text.span isSpace line
-    in (indent,) <$> asumPrefix ["- ", "* ", "+ "] stripped
-
-stripOrdered :: Text -> Maybe (Text, Text, Text)
-stripOrdered line =
-    let
-        (indent, stripped) = Text.span isSpace line
-        (number, rest) = Text.span isDigit stripped
-    in if Text.null number
-        then Nothing
-        else
-            (\item -> (indent, number, Text.strip item))
-                <$> Text.stripPrefix ". " rest
-
-stripBlockQuote :: Text -> Maybe Text
-stripBlockQuote line = do
-    rest <- Text.stripPrefix ">" (Text.stripStart line)
-    pure (fromMaybe rest (Text.stripPrefix " " rest))
-
-isThematicBreak :: Text -> Bool
-isThematicBreak line =
-    let stripped = Text.filter (not . isSpace) (Text.strip line)
-    in Text.length stripped >= 3
-        && (Text.all (== '-') stripped
-            || Text.all (== '*') stripped
-            || Text.all (== '_') stripped)
-
-takeTable :: [Text] -> Maybe (Widget n, [Text])
-takeTable (rawHeader : separator : rest)
-    | Just headerCells <- splitTableRow rawHeader
-    , Just separatorCells <- splitTableRow separator
-    , length separatorCells == length headerCells
-    , all isSeparatorCell separatorCells =
-        let
-            (body, after) = span isTableRow rest
-            rows = headerCells : mapMaybe splitTableRow body
-        in Just (tableWidget rows, after)
-takeTable _ = Nothing
-
-isSeparatorCell :: Text -> Bool
-isSeparatorCell cell =
-    Text.any (== '-') cell
-        && Text.null
-            (Text.filter (`notElem` ['-', ':', ' ']) cell)
 
 -- | Render a table against the width Brick actually gives it. Natural column
 -- widths are only preferences: short columns keep their size while verbose
@@ -530,100 +476,6 @@ fragmentsDisplayWidth =
                 0
                 . snd)
 
-isTableRow :: Text -> Bool
-isTableRow = isJust . splitTableRow
-
--- | Split a pipe row on actual column delimiters. Escaped pipes and pipes
--- inside matching backtick spans remain part of their cell.
-splitTableRow :: Text -> Maybe [Text]
-splitTableRow raw =
-    let stripped = Text.strip raw
-        content = fromMaybe stripped (Text.stripPrefix "|" stripped)
-        (cells, delimiterCount) = scan Nothing [] [] 0 False
-            (Text.unpack content)
-    in if delimiterCount >= 1
-        then Just cells
-        else Nothing
-  where
-    scan
-        :: Maybe Int
-        -> String
-        -> [Text]
-        -> Int
-        -> Bool
-        -> String
-        -> ([Text], Int)
-    scan _ current cells delimiterCount trailingDelimiter [] =
-        let allCells =
-                reverse
-                    (finishCell current : cells)
-            withoutOuterBorder
-                | trailingDelimiter = dropLast allCells
-                | otherwise = allCells
-        in (withoutOuterBorder, delimiterCount)
-    scan codeRun current cells delimiterCount _ ('\\' : rest) =
-        let (slashes, afterSlashes) = span (== '\\') rest
-            slashCount = 1 + length slashes
-            literalSlashes = replicate
-                (if startsWithPipe afterSlashes
-                    then slashCount `div` 2
-                    else slashCount)
-                '\\'
-            current' = literalSlashes <> current
-        in case afterSlashes of
-            '|' : afterPipe
-                | odd slashCount ->
-                    scan codeRun ('|' : current') cells
-                        delimiterCount False afterPipe
-                | codeRun == Nothing ->
-                    splitCell codeRun current' cells
-                        delimiterCount afterPipe
-            _ ->
-                scan codeRun current' cells
-                    delimiterCount False afterSlashes
-    scan codeRun current cells delimiterCount _ ('`' : rest) =
-        let (ticks, afterTicks) = span (== '`') rest
-            tickCount = 1 + length ticks
-            marker = replicate tickCount '`'
-            nextCodeRun = case codeRun of
-                Just openCount
-                    | tickCount >= openCount -> Nothing
-                Just openCount -> Just openCount
-                Nothing
-                    | hasClosingRun tickCount afterTicks ->
-                        Just tickCount
-                Nothing -> Nothing
-        in scan nextCodeRun (marker <> current) cells
-            delimiterCount False afterTicks
-    scan Nothing current cells delimiterCount _ ('|' : rest) =
-        splitCell Nothing current cells delimiterCount rest
-    scan codeRun current cells delimiterCount _ (character : rest) =
-        scan codeRun (character : current) cells
-            delimiterCount False rest
-
-    splitCell codeRun current cells delimiterCount rest =
-        scan codeRun [] (finishCell current : cells)
-            (delimiterCount + 1) True rest
-
-    finishCell = Text.strip . Text.pack . reverse
-
-    startsWithPipe ('|' : _) = True
-    startsWithPipe _ = False
-
-    hasClosingRun count =
-        Text.isInfixOf (Text.replicate count "`") . Text.pack
-
-    dropLast values = case reverse values of
-        _ : rest -> reverse rest
-        [] -> []
-
-asumPrefix :: [Text] -> Text -> Maybe Text
-asumPrefix prefixes text = case prefixes of
-    [] -> Nothing
-    prefix : rest -> case Text.stripPrefix prefix text of
-        Just value -> Just value
-        Nothing -> asumPrefix rest text
-
 inlineWidgetWithAttr :: AttrName -> [Inline] -> Widget n
 inlineWidgetWithAttr plainAttr inlines =
     B.Widget B.Greedy B.Fixed do
@@ -693,58 +545,31 @@ resolveInline plainAttr = fmap concat . traverse (go emptyContext)
 wrapStyled :: Int -> [(V.Attr, Text)] -> [[(V.Attr, Text)]]
 wrapStyled width spans =
     finalize $
-        List.foldl' addCell ([[]], 0) cells
+        List.foldl' addCell ([[]], 0) (styledCells spans)
   where
-    cells =
-        [ (attr, character)
-        | (attr, text) <- spans
-        , character <- Text.unpack text
-        ]
-    addCell (rows, used) (attr, cell)
-        | cell == '\n' = ([] : rows, 0)
+    addCell (rows, used) cell@(_, character)
+        | character == '\n' = ([] : rows, 0)
         | used > 0
         , used + cellWidth > width =
-            ([(attr, Builder.singleton cell)] : rows, cellWidth)
+            ([cell] : rows, cellWidth)
         | otherwise =
             case rows of
-                [] ->
-                    ([[(attr, Builder.singleton cell)]], cellWidth)
+                [] -> ([[cell]], cellWidth)
                 row : rest ->
-                    (appendCell attr cell row : rest, used + cellWidth)
+                    ((cell : row) : rest, used + cellWidth)
       where
-        cellWidth = terminalCharWidth cell
-    appendCell attr cell row =
-        case row of
-            (previousAttr, previousText) : prior
-                | previousAttr == attr ->
-                    ( previousAttr
-                    , previousText <> Builder.singleton cell
-                    ) : prior
-            _ -> (attr, Builder.singleton cell) : row
+        cellWidth = terminalCharWidth character
     finalize (rows, _) =
-        let ordered =
-                map
-                    (map
-                        (\(attr, text) ->
-                            ( attr
-                            , LazyText.toStrict (Builder.toLazyText text)
-                            ))
-                        . reverse)
-                    (reverse rows)
+        let ordered = map (groupStyledCells . reverse) (reverse rows)
         in if null ordered then [[]] else ordered
 
 -- | Table cells prefer word boundaries, but still hard-wrap an individual
 -- token that is wider than its column.
 wrapStyledWords :: Int -> [(V.Attr, Text)] -> [[(V.Attr, Text)]]
 wrapStyledWords width spans =
-    map groupCells (wrapCells cells)
+    map groupStyledCells (wrapCells (styledCells spans))
   where
     width' = max 1 width
-    cells =
-        [ (attr, character)
-        | (attr, text) <- spans
-        , character <- Text.unpack text
-        ]
 
     wrapCells [] = [[]]
     wrapCells remaining =
@@ -784,13 +609,23 @@ wrapStyledWords width spans =
     dropTrailingSpace =
         reverse . dropWhile (isSpace . snd) . reverse
 
-    groupCells =
-        map
-            (\(attr, text) ->
-                (attr, LazyText.toStrict (Builder.toLazyText text)))
-            . reverse
-            . List.foldl' appendCell []
+type StyledCell = (V.Attr, Char)
 
+styledCells :: [(V.Attr, Text)] -> [StyledCell]
+styledCells spans =
+    [ (attr, character)
+    | (attr, text) <- spans
+    , character <- Text.unpack text
+    ]
+
+groupStyledCells :: [StyledCell] -> [(V.Attr, Text)]
+groupStyledCells =
+    map
+        (\(attr, text) ->
+            (attr, LazyText.toStrict (Builder.toLazyText text)))
+        . reverse
+        . List.foldl' appendCell []
+  where
     appendCell grouped (attr, character) =
         case grouped of
             (previousAttr, previousText) : rest

--- a/packages/agent-tui/src/Agent/TUI/Markdown.hs
+++ b/packages/agent-tui/src/Agent/TUI/Markdown.hs
@@ -109,11 +109,11 @@ renderLines lines_
     | Just (rows, rest) <- Block.takeTableRows lines_ =
         tableWidget rows : renderLines rest
 renderLines (line : rest)
-    | Just (_, heading) <- Block.headingParts line =
+    | Just (_, heading) <- Block.headingPartsWith (== ' ') line =
         padTop (Pad 1)
             (inlineWidgetWithAttr Theme.headingAttr (parseInline heading))
             : renderLines rest
-    | Just (indent, item) <- Block.bulletParts line =
+    | Just (indent, item) <- Block.bulletPartsWith (== ' ') line =
         hBox
             [ txt indent
             , withAttr Theme.headingAttr (txt "• ")

--- a/packages/agent-tui/src/Agent/TUI/Markdown/Block.hs
+++ b/packages/agent-tui/src/Agent/TUI/Markdown/Block.hs
@@ -2,7 +2,9 @@
 -- both terminal renderers.
 module Agent.TUI.Markdown.Block
     ( headingParts
+    , headingPartsWith
     , bulletParts
+    , bulletPartsWith
     , orderedParts
     , blockQuoteRemainder
     , isThematicBreak
@@ -16,24 +18,30 @@ import Data.Text (Text)
 import qualified Data.Text as Text
 
 headingParts :: Text -> Maybe (Int, Text)
-headingParts line =
+headingParts = headingPartsWith isSpace
+
+headingPartsWith :: (Char -> Bool) -> Text -> Maybe (Int, Text)
+headingPartsWith isSeparator line =
     let stripped = Text.stripStart line
         (marks, after) = Text.span (== '#') stripped
         level = Text.length marks
     in if level >= 1
         && level <= 6
-        && startsWithSpace after
+        && startsWith isSeparator after
         then Just (level, Text.strip after)
         else Nothing
 
 bulletParts :: Text -> Maybe (Text, Text)
-bulletParts line =
+bulletParts = bulletPartsWith isSpace
+
+bulletPartsWith :: (Char -> Bool) -> Text -> Maybe (Text, Text)
+bulletPartsWith isSeparator line =
     let (indent, stripped) = Text.span isSpace line
     in case Text.uncons stripped of
         Just (marker, rest)
             | marker `elem` ['-', '*', '+']
             , Just (separator, after) <- Text.uncons rest
-            , isSpace separator ->
+            , isSeparator separator ->
                 Just (indent, Text.strip after)
         _ -> Nothing
 
@@ -159,7 +167,7 @@ splitTableRow raw =
         _ : rest -> reverse rest
         [] -> []
 
-startsWithSpace :: Text -> Bool
-startsWithSpace text = case Text.uncons text of
-    Just (character, _) -> isSpace character
+startsWith :: (Char -> Bool) -> Text -> Bool
+startsWith predicate text = case Text.uncons text of
+    Just (character, _) -> predicate character
     Nothing -> False

--- a/packages/agent-tui/src/Agent/TUI/Markdown/Block.hs
+++ b/packages/agent-tui/src/Agent/TUI/Markdown/Block.hs
@@ -1,0 +1,165 @@
+-- | Renderer-neutral parsing for the Markdown block constructs supported by
+-- both terminal renderers.
+module Agent.TUI.Markdown.Block
+    ( headingParts
+    , bulletParts
+    , orderedParts
+    , blockQuoteRemainder
+    , isThematicBreak
+    , takeTableRows
+    , splitTableRow
+    ) where
+
+import Data.Char (isDigit, isSpace)
+import Data.Maybe (fromMaybe, isJust, mapMaybe)
+import Data.Text (Text)
+import qualified Data.Text as Text
+
+headingParts :: Text -> Maybe (Int, Text)
+headingParts line =
+    let stripped = Text.stripStart line
+        (marks, after) = Text.span (== '#') stripped
+        level = Text.length marks
+    in if level >= 1
+        && level <= 6
+        && startsWithSpace after
+        then Just (level, Text.strip after)
+        else Nothing
+
+bulletParts :: Text -> Maybe (Text, Text)
+bulletParts line =
+    let (indent, stripped) = Text.span isSpace line
+    in case Text.uncons stripped of
+        Just (marker, rest)
+            | marker `elem` ['-', '*', '+']
+            , Just (separator, after) <- Text.uncons rest
+            , isSpace separator ->
+                Just (indent, Text.strip after)
+        _ -> Nothing
+
+orderedParts :: Text -> Maybe (Text, Text, Text)
+orderedParts line =
+    let (indent, stripped) = Text.span isSpace line
+        (number, rest) = Text.span isDigit stripped
+    in if Text.null number
+        then Nothing
+        else
+            (\item -> (indent, number, Text.strip item))
+                <$> Text.stripPrefix ". " rest
+
+-- | Remove indentation before the quote marker and the marker itself. The
+-- caller chooses how much whitespace after the marker to discard.
+blockQuoteRemainder :: Text -> Maybe Text
+blockQuoteRemainder =
+    Text.stripPrefix ">" . Text.stripStart
+
+isThematicBreak :: Text -> Bool
+isThematicBreak line =
+    let stripped = Text.filter (not . isSpace) (Text.strip line)
+    in Text.length stripped >= 3
+        && (Text.all (== '-') stripped
+            || Text.all (== '*') stripped
+            || Text.all (== '_') stripped)
+
+-- | Parse a complete pipe table from the front of a line sequence. The first
+-- row is the header; the separator row is consumed but omitted from the
+-- returned rows.
+takeTableRows :: [Text] -> Maybe ([[Text]], [Text])
+takeTableRows (header : separator : rest)
+    | Just headerCells <- splitTableRow header
+    , Just separatorCells <- splitTableRow separator
+    , length separatorCells == length headerCells
+    , all isSeparatorCell separatorCells =
+        let (body, after) = span isTableRow rest
+        in Just (headerCells : mapMaybe splitTableRow body, after)
+takeTableRows _ = Nothing
+
+isTableRow :: Text -> Bool
+isTableRow = isJust . splitTableRow
+
+isSeparatorCell :: Text -> Bool
+isSeparatorCell cell =
+    Text.any (== '-') cell
+        && Text.null
+            (Text.filter (`notElem` ['-', ':', ' ']) cell)
+
+-- | Split a pipe row on actual column delimiters. Escaped pipes and pipes
+-- inside matching backtick spans remain part of their cell.
+splitTableRow :: Text -> Maybe [Text]
+splitTableRow raw =
+    let stripped = Text.strip raw
+        content = fromMaybe stripped (Text.stripPrefix "|" stripped)
+        (cells, delimiterCount) =
+            scan Nothing [] [] 0 False (Text.unpack content)
+    in if delimiterCount >= 1 then Just cells else Nothing
+  where
+    scan
+        :: Maybe Int
+        -> String
+        -> [Text]
+        -> Int
+        -> Bool
+        -> String
+        -> ([Text], Int)
+    scan _ current cells delimiterCount trailingDelimiter [] =
+        let allCells = reverse (finishCell current : cells)
+            withoutOuterBorder
+                | trailingDelimiter = dropLast allCells
+                | otherwise = allCells
+        in (withoutOuterBorder, delimiterCount)
+    scan codeRun current cells delimiterCount _ ('\\' : rest) =
+        let (slashes, afterSlashes) = span (== '\\') rest
+            slashCount = 1 + length slashes
+            literalSlashes =
+                replicate
+                    (if startsWithPipe afterSlashes
+                        then slashCount `div` 2
+                        else slashCount)
+                    '\\'
+            current' = literalSlashes <> current
+        in case afterSlashes of
+            '|' : afterPipe
+                | odd slashCount ->
+                    scan codeRun ('|' : current') cells
+                        delimiterCount False afterPipe
+                | codeRun == Nothing ->
+                    splitCell codeRun current' cells delimiterCount afterPipe
+            _ ->
+                scan codeRun current' cells
+                    delimiterCount False afterSlashes
+    scan codeRun current cells delimiterCount _ ('`' : rest) =
+        let (ticks, afterTicks) = span (== '`') rest
+            tickCount = 1 + length ticks
+            marker = replicate tickCount '`'
+            nextCodeRun = case codeRun of
+                Just openCount
+                    | tickCount >= openCount -> Nothing
+                Just openCount -> Just openCount
+                Nothing
+                    | hasClosingRun tickCount afterTicks -> Just tickCount
+                Nothing -> Nothing
+        in scan nextCodeRun (marker <> current) cells
+            delimiterCount False afterTicks
+    scan Nothing current cells delimiterCount _ ('|' : rest) =
+        splitCell Nothing current cells delimiterCount rest
+    scan codeRun current cells delimiterCount _ (character : rest) =
+        scan codeRun (character : current) cells
+            delimiterCount False rest
+
+    splitCell codeRun current cells delimiterCount rest =
+        scan codeRun [] (finishCell current : cells)
+            (delimiterCount + 1) True rest
+
+    finishCell = Text.strip . Text.pack . reverse
+    startsWithPipe ('|' : _) = True
+    startsWithPipe _ = False
+    hasClosingRun count =
+        Text.isInfixOf (Text.replicate count "`") . Text.pack
+    dropLast values = case reverse values of
+        _ : rest -> reverse rest
+        [] -> []
+
+startsWithSpace :: Text -> Bool
+startsWithSpace text = case Text.uncons text of
+    Just (character, _) -> isSpace character
+    Nothing -> False

--- a/packages/agent-tui/test/Agent/TUI/Markdown/BlockSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/Markdown/BlockSpec.hs
@@ -9,10 +9,12 @@ spec = describe "Markdown block parsing" do
         headingParts "  ### Title  " `shouldBe` Just (3, "Title")
         headingParts "###Title" `shouldBe` Nothing
         headingParts "####### Title" `shouldBe` Nothing
+        headingPartsWith (== ' ') "#\tTitle" `shouldBe` Nothing
 
     it "parses indented unordered and ordered list items" do
         bulletParts "  * item" `shouldBe` Just ("  ", "item")
         bulletParts "\t-\titem" `shouldBe` Just ("\t", "item")
+        bulletPartsWith (== ' ') "\t-\titem" `shouldBe` Nothing
         orderedParts "    12. item" `shouldBe`
             Just ("    ", "12", "item")
 

--- a/packages/agent-tui/test/Agent/TUI/Markdown/BlockSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/Markdown/BlockSpec.hs
@@ -1,0 +1,47 @@
+module Agent.TUI.Markdown.BlockSpec (spec) where
+
+import Agent.TUI.Markdown.Block
+import Test.Hspec
+
+spec :: Spec
+spec = describe "Markdown block parsing" do
+    it "parses heading levels and requires following whitespace" do
+        headingParts "  ### Title  " `shouldBe` Just (3, "Title")
+        headingParts "###Title" `shouldBe` Nothing
+        headingParts "####### Title" `shouldBe` Nothing
+
+    it "parses indented unordered and ordered list items" do
+        bulletParts "  * item" `shouldBe` Just ("  ", "item")
+        bulletParts "\t-\titem" `shouldBe` Just ("\t", "item")
+        orderedParts "    12. item" `shouldBe`
+            Just ("    ", "12", "item")
+
+    it "removes only the block quote marker" do
+        blockQuoteRemainder "  >  quote" `shouldBe` Just "  quote"
+        blockQuoteRemainder "plain" `shouldBe` Nothing
+
+    it "recognizes thematic breaks" do
+        isThematicBreak " * * * " `shouldBe` True
+        isThematicBreak "--" `shouldBe` False
+        isThematicBreak "-*-" `shouldBe` False
+
+    it "parses tables and consumes the separator row" do
+        takeTableRows
+            [ "| name | value |"
+            , "| :--- | ---: |"
+            , "| a | b |"
+            , "after"
+            ]
+            `shouldBe`
+                Just
+                    ( [["name", "value"], ["a", "b"]]
+                    , ["after"]
+                    )
+
+    it "preserves escaped and code-span pipes inside cells" do
+        splitTableRow "| a\\|b | `c|d` | e |" `shouldBe`
+            Just ["a|b", "`c|d`", "e"]
+
+    it "rejects malformed tables" do
+        takeTableRows ["a | b", "---", "c | d"] `shouldBe` Nothing
+        takeTableRows ["a | b", "--- | --- | ---"] `shouldBe` Nothing

--- a/packages/agent-tui/test/Spec.hs
+++ b/packages/agent-tui/test/Spec.hs
@@ -1,6 +1,7 @@
 module Main (main) where
 
 import qualified Agent.TUI.FencedCodeSpec as FencedCodeSpec
+import qualified Agent.TUI.Markdown.BlockSpec as MarkdownBlockSpec
 import qualified Agent.TUI.Markdown.InlineSpec as MarkdownInlineSpec
 import qualified Agent.TUI.MarkdownSpec as MarkdownSpec
 import qualified Agent.TUI.MotionSpec as MotionSpec
@@ -13,6 +14,7 @@ import Test.Hspec (hspec)
 main :: IO ()
 main = hspec do
     FencedCodeSpec.spec
+    MarkdownBlockSpec.spec
     MarkdownInlineSpec.spec
     MarkdownSpec.spec
     MotionSpec.spec


### PR DESCRIPTION
## Summary
- add renderer-neutral Markdown block/table parsing under agent-tui
- reuse the parser from CLI and Brick renderers
- add focused parser regression coverage

## Validation
- targeted agent-tui Markdown specs passed
- agent-cli Markdown specs passed
- multi-package GHCi/typecheck passed
- live tmux Markdown/list/table smoke test performed by the implementation agent
