### PR TITLE
Eliminate Codex prompt cache retention requests

### DIFF
--- a/packages/agent-openai/agent-openai.cabal
+++ b/packages/agent-openai/agent-openai.cabal
@@ -56,6 +56,7 @@ library
                     , Agent.OpenAI.Login
                     , Agent.OpenAI.Usage
                     , Agent.OpenAI.Client
+                    , Agent.OpenAI.Request
                     , Agent.OpenAI.Features
                     , Agent.OpenAI.ModelMetadata
                     , Agent.OpenAI.WebSocketClient

--- a/packages/agent-openai/src/Agent/OpenAI/Client.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Client.hs
@@ -20,6 +20,7 @@ import Agent.OpenAI.Features
     , remoteCompactionV2Feature
     )
 import Agent.OpenAI.Http (decodeCodexHttpBody)
+import Agent.OpenAI.Request (sanitizeCodexRequest)
 import Agent.Provider
     ( Credential(..)
     , Provider(..)
@@ -183,7 +184,8 @@ makeCodexRequest options baseUrl accessToken accountId request = do
     -- The ChatGPT Codex HTTP endpoint only serves Responses requests as SSE
     -- and rejects an omitted/false stream flag. WebSocket callers do not need
     -- this field, so enforce it at the HTTP transport boundary.
-    let requestBody = Aeson.toJSON request { OpenAI.stream = Just True }
+    let requestBody = Aeson.toJSON
+            (sanitizeCodexRequest request) { OpenAI.stream = Just True }
         url = Text.dropWhileEnd (== '/') baseUrl <> "/responses"
 
     case URI.parseURI (Text.unpack url) of

--- a/packages/agent-openai/src/Agent/OpenAI/LoopBackend.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/LoopBackend.hs
@@ -32,7 +32,8 @@ import Agent.Error
     , isInlineRetryableProviderResponseError
     )
 import Agent.Loop (Backend(..), LoopEvent(..))
-import Agent.OpenAI.Error (isPreviousResponseIdError)
+import Agent.OpenAI.Error (isResponseChainCompatibilityError)
+import Agent.OpenAI.Request (sanitizeCodexRequest)
 import Agent.OpenAI.WebSocketClient
     ( CodexConn
     , sendWsRequestWithEvents
@@ -496,7 +497,7 @@ openAiBackendWithRetryPolicy
     -> Backend
 openAiBackendWithRetryPolicy retryPolicy send getParams transcript =
     Backend \previousResponseId inputs onLoopEvent -> do
-        baseParams <- getParams
+        baseParams <- sanitizeCodexRequest <$> getParams
         history <- readIORef transcript
         let newItems = turnInputsToItems inputs
             deltaRequest = withRequestInput baseParams newItems
@@ -513,7 +514,9 @@ openAiBackendWithRetryPolicy retryPolicy send getParams transcript =
         result <- sendRetrying onLoopEvent initialRequest initialPrevious emit
         recovered <- case result of
             Left err
-                | isPreviousResponseIdError err && not (null history) ->
+                | isJust initialPrevious
+                , isResponseChainCompatibilityError err
+                , not (null history) ->
                     sendRetrying onLoopEvent fullRequest Nothing emit
                 | otherwise -> pure (Left err)
             Right response -> pure (Right response)

--- a/packages/agent-openai/src/Agent/OpenAI/Request.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Request.hs
@@ -1,0 +1,18 @@
+-- | Request normalization for the ChatGPT Codex transport.
+module Agent.OpenAI.Request
+    ( sanitizeCodexRequest
+    ) where
+
+import Agent.Responses.Types (ResponseCreateParams(..))
+
+-- | Keep prompt-cache retention out of Codex requests.
+--
+-- Retention is provider-managed for this transport. Sending a retained value
+-- explicitly is model-dependent and can make an otherwise valid request fail
+-- after the provider routes a response chain to a different model.
+sanitizeCodexRequest :: ResponseCreateParams -> ResponseCreateParams
+sanitizeCodexRequest ResponseCreateParams{promptCacheRetention = _, ..} =
+    ResponseCreateParams
+        { promptCacheRetention = Nothing
+        , ..
+        }

--- a/packages/agent-openai/src/Agent/OpenAI/WebSocketClient.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/WebSocketClient.hs
@@ -27,6 +27,7 @@ import Agent.OpenAI.Credential (poolTokenProvider)
 import Agent.Error
 import Agent.OpenAI.Error (isPreviousResponseIdError, mkOpenAIError)
 import Agent.OpenAI.Features (remoteCompactionV2Feature)
+import Agent.OpenAI.Request (sanitizeCodexRequest)
 import Agent.Responses.StreamAssembly
     ( ResponseFailure(..)
     , applyStreamEvent
@@ -356,7 +357,7 @@ sendWsRequestWithEventsAndOptions options cc request previousResponseId onEvent 
 -- All fields are flattened at the top level (not nested inside "response").
 buildWsPayloadWithOptions :: CodexWsOptions -> ResponseCreateParams -> Maybe Text -> Aeson.Value
 buildWsPayloadWithOptions options request previousResponseId =
-    case Aeson.toJSON request of
+    case Aeson.toJSON (sanitizeCodexRequest request) of
         Aeson.Object object -> Aeson.Object
             $ addContextManagement
             $ addPreviousResponseId

--- a/packages/agent-openai/test/Agent/OpenAI/ClientSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/ClientSpec.hs
@@ -141,6 +141,28 @@ spec = do
                     expectationFailure
                         ("expected JSON request object, got " <> show other)
 
+        it "strips prompt cache retention from the HTTP request body" do
+            recorded <- newIORef []
+            let handler _request = pure $ jsonCompleted "Apartment"
+                request = withPromptCacheRetention
+                    (Just "24h")
+                    (helloRequest "hi")
+            withMockResponses recorded handler \baseUrl -> do
+                _ <- expectRight =<< createCodexMessageWithProviderAt
+                    baseUrl
+                    (staticBearerProvider "router-key")
+                    request
+                pure ()
+
+            [recordedRequest] <- readIORef recorded
+            case recordedRequest.body of
+                Aeson.Object object ->
+                    KeyMap.lookup "prompt_cache_retention" object
+                        `shouldBe` Nothing
+                other ->
+                    expectationFailure
+                        ("expected JSON request object, got " <> show other)
+
         it "sends chatgpt-account-id when the credential has one" do
             recorded <- newIORef []
             let handler _request = pure $ jsonCompleted "ok"
@@ -323,6 +345,12 @@ helloRequest prompt = defaultResponseCreateParams
     , instructions = Just "You are a test agent."
     , input = Just (ResponseInputText prompt)
     }
+
+withPromptCacheRetention
+    :: Maybe Text -> ResponseCreateParams -> ResponseCreateParams
+withPromptCacheRetention nextRetention
+        ResponseCreateParams { promptCacheRetention = _, .. } =
+    ResponseCreateParams { promptCacheRetention = nextRetention, .. }
 
 decodeResponse :: Aeson.Value -> Response
 decodeResponse value = case Aeson.fromJSON value of

--- a/packages/agent-openai/test/Agent/OpenAI/ErrorSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/ErrorSpec.hs
@@ -55,6 +55,24 @@ spec = do
                 `shouldBe` False
             isPreviousResponseIdError (CredentialsExhausted epoch) `shouldBe` False
 
+    describe "isResponseChainCompatibilityError" do
+        it "detects unsupported inherited prompt cache retention" do
+            isResponseChainCompatibilityError
+                (ProviderError
+                    (UnknownErrorType "invalid_parameter")
+                    "prompt_cache_retention is not supported on this model \
+                    \(code: invalid_parameter)"
+                    Nothing)
+                `shouldBe` True
+
+        it "does not classify unrelated invalid parameters as chain errors" do
+            isResponseChainCompatibilityError
+                (ProviderError
+                    (UnknownErrorType "invalid_parameter")
+                    "temperature is not supported on this model"
+                    Nothing)
+                `shouldBe` False
+
     describe "classifyHttpFailure" do
         it "normalizes the real server_is_overloaded response code" do
             classifyHttpFailure 500 "{\"error\":{\"type\":\"server_error\",\"code\":\"server_is_overloaded\",\"message\":\"Our servers are currently overloaded\"}}"

--- a/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
@@ -463,6 +463,66 @@ spec = do
                 , seed <> turnInputsToItems [UserMessage "new"]
                 ]
 
+        it "starts a fresh chain when inherited cache retention is rejected" do
+            seen <- newIORef []
+            let seed = turnInputsToItems [UserMessage "old"]
+                cacheError = ProviderError
+                    (UnknownErrorType "invalid_parameter")
+                    "prompt_cache_retention is not supported on this model \
+                    \(code: invalid_parameter)"
+                    Nothing
+            transcript <- newIORef seed
+            let send request previous onEvent = do
+                    modifyIORef' seen (++ [(request, previous)])
+                    case previous of
+                        Just _ -> pure (Left cacheError)
+                        Nothing -> do
+                            onEvent (deltaEvent EventOutputTextDelta "ok")
+                            pure $ Right
+                                (testResponse "resp-fresh" [assistantItem "ok"])
+                backend = openAiBackendWith send (pure baseParams) transcript
+            result <- backend.submitTurn (Just "resp-cache")
+                [CompletedTool (functionResult "c1" "tool output")]
+                (const (pure ()))
+            result `shouldBe`
+                Right (emptyTurnOutput "resp-fresh" [] (Just "ok"))
+            requests <- readIORef seen
+            map snd requests `shouldBe` [Just "resp-cache", Nothing]
+            map (inputItems . fst) requests `shouldBe`
+                [ turnInputsToItems
+                    [CompletedTool (functionResult "c1" "tool output")]
+                , seed <> turnInputsToItems
+                    [CompletedTool (functionResult "c1" "tool output")]
+                ]
+
+        it "strips explicitly requested cache retention and starts a fresh chain" do
+            seen <- newIORef []
+            let seed = turnInputsToItems [UserMessage "old"]
+                cacheError = ProviderError
+                    (UnknownErrorType "invalid_parameter")
+                    "prompt_cache_retention is not supported on this model \
+                    \(code: invalid_parameter)"
+                    Nothing
+                params = withPromptCacheRetention (Just "24h") baseParams
+                send request previous _onEvent = do
+                    modifyIORef' seen (++ [(request, previous)])
+                    case previous of
+                        Just _ -> pure (Left cacheError)
+                        Nothing ->
+                            pure $ Right
+                                (testResponse "resp-fresh" [assistantItem "ok"])
+            transcript <- newIORef seed
+            let backend = openAiBackendWith send (pure params) transcript
+            result <- backend.submitTurn (Just "resp-cache")
+                [UserMessage "new"]
+                (const (pure ()))
+            result `shouldBe`
+                Right (emptyTurnOutput "resp-fresh" [] (Just "ok"))
+            requests <- readIORef seen
+            map snd requests `shouldBe` [Just "resp-cache", Nothing]
+            map ((.promptCacheRetention) . fst) requests
+                `shouldBe` [Nothing, Nothing]
+
         it "replays retained messages before an automatic compaction checkpoint" do
             seen <- newIORef []
             let checkpoint = compactionItem "opaque"
@@ -1032,6 +1092,12 @@ baseParams = withModel (Just "gpt-5.6-luna") defaultResponseCreateParams
 withModel :: Maybe Text -> ResponseCreateParams -> ResponseCreateParams
 withModel nextModel ResponseCreateParams { model = _, .. } =
     ResponseCreateParams { model = nextModel, .. }
+
+withPromptCacheRetention
+    :: Maybe Text -> ResponseCreateParams -> ResponseCreateParams
+withPromptCacheRetention nextRetention
+        ResponseCreateParams { promptCacheRetention = _, .. } =
+    ResponseCreateParams { promptCacheRetention = nextRetention, .. }
 
 withEffort :: Text -> ResponseCreateParams -> ResponseCreateParams
 withEffort effort ResponseCreateParams { reasoning = _, .. } =

--- a/packages/agent-openai/test/Agent/OpenAI/WebSocketClientSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/WebSocketClientSpec.hs
@@ -32,6 +32,14 @@ spec = do
         field "store" (buildWsPayloadWithOptions defaultCodexWsOptions request Nothing)
             `shouldBe` Just (Aeson.Bool False)
 
+    it "strips prompt cache retention from Codex requests" do
+        let request = withPromptCacheRetention (Just "24h") sampleRequest
+            payload = buildWsPayloadWithOptions
+                defaultCodexWsOptions request (Just "previous-1")
+        field "prompt_cache_retention" payload `shouldBe` Nothing
+        field "previous_response_id" payload
+            `shouldBe` Just (Aeson.String "previous-1")
+
     it "does not request server-managed compaction by default" do
         contextManagement defaultCodexWsOptions `shouldBe` Nothing
 
@@ -178,7 +186,7 @@ field name = \case
 
 sampleRequest :: ResponseCreateParams
 sampleRequest = defaultResponseCreateParams
-    { model = Just "gpt-test"
+    { model = Just "gpt-5.6-sol"
     , instructions = Just "test"
     , input = Just (ResponseInputItems [])
     , tools = Just []
@@ -193,3 +201,9 @@ sampleRequest = defaultResponseCreateParams
     , include = Just []
     , promptCacheKey = Just "cache-key"
     }
+
+withPromptCacheRetention
+    :: Maybe Text -> ResponseCreateParams -> ResponseCreateParams
+withPromptCacheRetention nextRetention
+        ResponseCreateParams { promptCacheRetention = _, .. } =
+    ResponseCreateParams { promptCacheRetention = nextRetention, .. }

--- a/packages/agent-responses/src/Agent/Responses/Error.hs
+++ b/packages/agent-responses/src/Agent/Responses/Error.hs
@@ -4,6 +4,7 @@ module Agent.Responses.Error
     , mkOpenAIError
     , classifyHttpFailure
     , isPreviousResponseIdError
+    , isResponseChainCompatibilityError
     ) where
 
 import Agent.Error
@@ -257,6 +258,29 @@ isPreviousResponseIdError = \case
         mentionsPreviousResponse message || mentionsPreviousResponse body
     CredentialsExhausted{} -> False
 
+-- | Errors that can be caused by provider-managed state attached to
+-- @previous_response_id@ rather than by the current request body.
+--
+-- The Codex backend can return stored chains carrying
+-- @prompt_cache_retention@ parameter after routing a follow-up to a model that
+-- no longer accepts it. Replaying the local transcript without the continuation
+-- id creates a fresh chain and is safe before any model output is observed.
+isResponseChainCompatibilityError :: ApiError -> Bool
+isResponseChainCompatibilityError error =
+    isPreviousResponseIdError error
+        || apiErrorTextMatches mentionsUnsupportedPromptCacheRetention error
+
+apiErrorTextMatches :: (Text -> Bool) -> ApiError -> Bool
+apiErrorTextMatches predicate = \case
+    ProviderError errorType message _ ->
+        predicate (Text.pack (show errorType)) || predicate message
+    ConnectionError message -> predicate message
+    CredentialError message -> predicate message
+    HttpError _ body -> predicate body
+    JsonDecodeError message body ->
+        predicate message || predicate body
+    CredentialsExhausted{} -> False
+
 mentionsPreviousResponse :: Text -> Bool
 mentionsPreviousResponse value =
     let lowered = Text.toLower value
@@ -264,6 +288,13 @@ mentionsPreviousResponse value =
         || "previous response" `Text.isInfixOf` lowered
         || "response_not_found" `Text.isInfixOf` lowered
         || "previous_response_not_found" `Text.isInfixOf` lowered
+
+mentionsUnsupportedPromptCacheRetention :: Text -> Bool
+mentionsUnsupportedPromptCacheRetention value =
+    let lowered = Text.toLower value
+    in "prompt_cache_retention" `Text.isInfixOf` lowered
+        && ("not supported" `Text.isInfixOf` lowered
+            || "unsupported" `Text.isInfixOf` lowered)
 
 orElse :: Maybe a -> Maybe a -> Maybe a
 orElse (Just value) _ = Just value


### PR DESCRIPTION
## Summary
- strip `prompt_cache_retention` unconditionally from every Codex HTTP and WebSocket request
- recover response chains whose provider-managed state still carries an incompatible retention setting by replaying the local transcript without `previous_response_id`
- cover explicit attempted retention, inherited chain state, and both transport serialization boundaries

## Root cause
Our normal `gpt-5.6-sol` request did **not** serialize `prompt_cache_retention`. The failure came from provider-managed state attached to `previous_response_id`: a previously created response chain carried a retention setting, and a later follow-up was routed to a model/capability configuration that rejected it.

That is why it appeared and then disappeared: only continuation requests referencing the affected remote chain failed. Starting a fresh chain (or otherwise losing/replacing that continuation id) removed the inherited provider state, so an identical local request could work again.

The fix now enforces the intended invariant: this client never sends prompt cache retention, even if a caller puts it in the canonical request value. The fresh-chain replay remains necessary for already-existing remote chains that contain provider-managed retention state.

## Tests
- `nix develop -c cabal test agent-openai-test --test-show-details=direct` (208 examples, 0 failures, 1 pending live test)
- `nix develop -c cabal test agent-responses-test --test-show-details=direct` (28 examples, 0 failures)
