### PR TITLE
Refactor Telegram state into per-chat queues

### DIFF
--- a/packages/agent-cli/src/Agent/Telegram.hs
+++ b/packages/agent-cli/src/Agent/Telegram.hs
@@ -112,7 +112,7 @@ import qualified Data.ByteString.Lazy as LBS
 import qualified Data.ByteString.Lazy.Char8 as LBS8
 import qualified Data.ByteString.Char8 as BS8
 import qualified Data.Text.Encoding as TextEncoding
-import Data.List (find)
+import Data.List (sortOn)
 import qualified Data.Map.Strict as Map
 import Data.Map.Strict (Map)
 import Data.Maybe (fromMaybe)
@@ -268,26 +268,58 @@ instance FromJSON TelegramBinding where
 
 data TelegramState = TelegramState
     { nextUpdateId :: !(Maybe Integer)
-    , bindings :: ![TelegramBinding]
-    , pendingTurns :: ![TelegramPendingTurn]
-    , pendingReplies :: ![TelegramPendingReply]
+    , bindings :: !(Map TelegramChatKey Text)
+    , pendingQueues :: !(Map TelegramChatKey (Map Integer PendingChatAction))
     } deriving (Eq, Show)
 
 instance ToJSON TelegramState where
     toJSON state = object
         [ "nextUpdateId" .= state.nextUpdateId
-        , "bindings" .= state.bindings
-        , "pendingTurns" .= state.pendingTurns
-        , "pendingReplies" .= state.pendingReplies
+        , "bindings" .=
+            [ TelegramBinding key sessionId
+            | (key, sessionId) <- Map.toList state.bindings
+            ]
+        , "pendingTurns" .=
+            sortOn (.pendingTurnUpdateId)
+                [ pending
+                | queue <- Map.elems state.pendingQueues
+                , RunPendingTurn pending <- Map.elems queue
+                ]
+        , "pendingReplies" .=
+            sortOn (.pendingUpdateId)
+                [ pending
+                | queue <- Map.elems state.pendingQueues
+                , DeliverReply pending <- Map.elems queue
+                ]
         ]
 
 instance FromJSON TelegramState where
-    parseJSON = withObject "TelegramState" \o ->
-        TelegramState
-            <$> o .:? "nextUpdateId"
-            <*> (o .:? "bindings" .!= [])
-            <*> (o .:? "pendingTurns" .!= [])
-            <*> (o .:? "pendingReplies" .!= [])
+    parseJSON = withObject "TelegramState" \o -> do
+        nextUpdateId <- o .:? "nextUpdateId"
+        storedBindings <-
+            o .:? "bindings" .!= ([] :: [TelegramBinding])
+        pendingTurns <-
+            o .:? "pendingTurns" .!= ([] :: [TelegramPendingTurn])
+        pendingReplies <-
+            o .:? "pendingReplies" .!= ([] :: [TelegramPendingReply])
+        pure TelegramState
+            { nextUpdateId
+            , bindings =
+                foldr
+                    (\binding ->
+                        Map.insert
+                            binding.bindingChat
+                            binding.bindingSessionId)
+                    Map.empty
+                    storedBindings
+            , pendingQueues =
+                foldl'
+                    (flip insertPendingAction)
+                    Map.empty
+                    ( map RunPendingTurn pendingTurns
+                        <> map DeliverReply pendingReplies
+                    )
+            }
 
 data TelegramPendingTurn = TelegramPendingTurn
     { pendingTurnUpdateId :: !Integer
@@ -463,9 +495,8 @@ data TelegramClient = TelegramClient
 emptyTelegramState :: TelegramState
 emptyTelegramState = TelegramState
     { nextUpdateId = Nothing
-    , bindings = []
-    , pendingTurns = []
-    , pendingReplies = []
+    , bindings = Map.empty
+    , pendingQueues = Map.empty
     }
 
 parseAllowedUsers :: Text -> Either Text (Set Integer)
@@ -867,12 +898,11 @@ storeUpdateAction updateId action current
         advanceOffset case action of
             IgnoreUpdate -> current
             QueueTurn messageId key text voice ->
-                current
-                    { pendingTurns =
-                        current.pendingTurns
-                            <> [TelegramPendingTurn
-                                    updateId messageId key text voice]
-                    }
+                enqueuePendingAction
+                    (RunPendingTurn
+                        (TelegramPendingTurn
+                            updateId messageId key text voice))
+                    current
   where
     advanceOffset state =
         state
@@ -941,24 +971,61 @@ reactionMessageText reaction
 
 updateAlreadyStored :: Integer -> TelegramState -> Bool
 updateAlreadyStored updateId state =
-    any ((== updateId) . (.pendingTurnUpdateId)) state.pendingTurns
-        || any ((== updateId) . (.pendingUpdateId)) state.pendingReplies
-        || maybe False (> updateId) state.nextUpdateId
+    maybe False (> updateId) state.nextUpdateId
+        || any (Map.member updateId) state.pendingQueues
 
 data PendingChatAction
     = DeliverReply !TelegramPendingReply
     | RunPendingTurn !TelegramPendingTurn
     deriving (Eq, Show)
 
+pendingActionUpdateId :: PendingChatAction -> Integer
+pendingActionUpdateId = \case
+    DeliverReply pending -> pending.pendingUpdateId
+    RunPendingTurn pending -> pending.pendingTurnUpdateId
+
+pendingActionChat :: PendingChatAction -> TelegramChatKey
+pendingActionChat = \case
+    DeliverReply pending -> pending.pendingChat
+    RunPendingTurn pending -> pending.pendingTurnChat
+
+insertPendingAction
+    :: PendingChatAction
+    -> Map TelegramChatKey (Map Integer PendingChatAction)
+    -> Map TelegramChatKey (Map Integer PendingChatAction)
+insertPendingAction action =
+    Map.alter
+        (Just . Map.insert (pendingActionUpdateId action) action
+            . fromMaybe Map.empty)
+        (pendingActionChat action)
+
+enqueuePendingAction :: PendingChatAction -> TelegramState -> TelegramState
+enqueuePendingAction action state =
+    state
+        { pendingQueues = insertPendingAction action state.pendingQueues
+        }
+
+deletePendingAction :: PendingChatAction -> TelegramState -> TelegramState
+deletePendingAction action state =
+    state
+        { pendingQueues =
+            Map.update
+                (\queue ->
+                    let remaining =
+                            Map.delete (pendingActionUpdateId action) queue
+                    in if Map.null remaining then Nothing else Just remaining)
+                (pendingActionChat action)
+                state.pendingQueues
+        }
+
 dispatchForever :: TelegramRuntime -> IO ()
 dispatchForever runtime = do
     state <- readMVar runtime.runtimeStateVar
     workers <- readMVar runtime.runtimeWorkers
-    let pendingChats = Set.fromList
-            (map (.pendingTurnChat) state.pendingTurns
-                <> map (.pendingChat) state.pendingReplies)
-        inactive =
-            pendingChats `Set.difference` Map.keysSet workers
+    let inactive =
+            Map.keysSet state.pendingQueues
+                `Set.difference`
+                    Map.keysSet workers
     forM_ (Set.toList inactive) (startTelegramWorker runtime)
     threadDelay 250_000
     dispatchForever runtime
@@ -991,14 +1058,8 @@ processChatQueue runtime key =
             result <- tryAny case action of
                 DeliverReply pending -> do
                     reply runtime pending
-                    modifyState runtime \state ->
-                        state
-                            { pendingReplies =
-                                filter
-                                    ((/= pending.pendingUpdateId)
-                                        . (.pendingUpdateId))
-                                    state.pendingReplies
-                            }
+                    modifyState runtime
+                        (deletePendingAction (DeliverReply pending))
                 RunPendingTurn pending -> do
                     response <- case telegramCommand pending.pendingTurnText of
                         Nothing ->
@@ -1008,21 +1069,14 @@ processChatQueue runtime key =
                                 (runQueuedTurn runtime pending)
                         Just _ -> runQueuedTurn runtime pending
                     modifyState runtime \state ->
-                        state
-                            { pendingTurns =
-                                filter
-                                    ((/= pending.pendingTurnUpdateId)
-                                        . (.pendingTurnUpdateId))
-                                    state.pendingTurns
-                            , pendingReplies =
-                                state.pendingReplies
-                                    <> [ TelegramPendingReply
-                                            pending.pendingTurnUpdateId
-                                            pending.pendingTurnChat
-                                            (Just pending.pendingTurnMessageId)
-                                            response
-                                       ]
-                            }
+                        enqueuePendingAction
+                            (DeliverReply
+                                (TelegramPendingReply
+                                    pending.pendingTurnUpdateId
+                                    pending.pendingTurnChat
+                                    (Just pending.pendingTurnMessageId)
+                                    response))
+                            (deletePendingAction (RunPendingTurn pending) state)
             case result of
                 Left err -> do
                     Text.hPutStrLn stderr
@@ -1041,10 +1095,9 @@ runQueuedTurn runtime pending =
         Just "new" -> do
             modifyState runtime \state ->
                 state
-                    { bindings =
-                        filter
-                            ((/= pending.pendingTurnChat) . (.bindingChat))
-                            state.bindings
+                    { bindings = Map.delete
+                        pending.pendingTurnChat
+                        state.bindings
                     }
             pure "Started a new conversation. Send your next prompt."
         Just "session" -> do
@@ -1093,17 +1146,18 @@ checkpointPendingVoiceTranscript
     -> TelegramState
 checkpointPendingVoiceTranscript updateId transcript state =
     state
-        { pendingTurns =
-            map checkpoint state.pendingTurns
+        { pendingQueues =
+            fmap (fmap checkpoint) state.pendingQueues
         }
   where
-    checkpoint current
-        | current.pendingTurnUpdateId == updateId =
-            current
-                { pendingTurnText = transcript
-                , pendingTurnVoice = Nothing
-                }
-        | otherwise = current
+    checkpoint = \case
+        RunPendingTurn current
+            | current.pendingTurnUpdateId == updateId ->
+                RunPendingTurn current
+                    { pendingTurnText = transcript
+                    , pendingTurnVoice = Nothing
+                    }
+        current -> current
 
 transcribeTelegramVoice
     :: TelegramRuntime
@@ -1346,28 +1400,7 @@ nextPendingAction
     -> TelegramState
     -> Maybe PendingChatAction
 nextPendingAction key state =
-    case
-        ( oldestBy (.pendingTurnUpdateId)
-            (filter ((== key) . (.pendingTurnChat)) state.pendingTurns)
-        , oldestBy (.pendingUpdateId)
-            (filter ((== key) . (.pendingChat)) state.pendingReplies)
-        ) of
-        (Nothing, Nothing) -> Nothing
-        (Just turn, Nothing) -> Just (RunPendingTurn turn)
-        (Nothing, Just pending) -> Just (DeliverReply pending)
-        (Just turn, Just pending)
-            | pending.pendingUpdateId <= turn.pendingTurnUpdateId ->
-                Just (DeliverReply pending)
-            | otherwise -> Just (RunPendingTurn turn)
-
-oldestBy :: Ord b => (a -> b) -> [a] -> Maybe a
-oldestBy _ [] = Nothing
-oldestBy getKey (value : values) =
-    Just (foldl choose value values)
-  where
-    choose current candidate
-        | getKey candidate < getKey current = candidate
-        | otherwise = current
+    snd <$> (Map.lookupMin =<< Map.lookup key state.pendingQueues)
 
 telegramCommand :: Text -> Maybe Text
 telegramCommand text = do
@@ -1446,8 +1479,7 @@ sessionForPrompt runtime key prompt = do
             modifyState runtime \current ->
                 current
                     { bindings =
-                        TelegramBinding key handle.sessionMeta.metaId
-                            : filter ((/= key) . (.bindingChat)) current.bindings
+                        Map.insert key handle.sessionMeta.metaId current.bindings
                     }
             pure handle
 
@@ -1461,7 +1493,7 @@ renderLatestTurn turns =
 
 lookupBinding :: TelegramChatKey -> TelegramState -> Maybe Text
 lookupBinding key state =
-    (.bindingSessionId) <$> find ((== key) . (.bindingChat)) state.bindings
+    Map.lookup key state.bindings
 
 modifyState :: TelegramRuntime -> (TelegramState -> TelegramState) -> IO ()
 modifyState runtime update =

--- a/packages/agent-cli/test/Agent/TelegramSpec.hs
+++ b/packages/agent-cli/test/Agent/TelegramSpec.hs
@@ -7,9 +7,10 @@ import Control.Concurrent
     , takeMVar
     , threadDelay
     )
-import Data.Aeson (eitherDecode)
+import Data.Aeson (Value, eitherDecode, encode, object, (.=))
 import qualified Data.ByteString.Lazy.Char8 as LBS
 import Data.IORef (modifyIORef', newIORef, readIORef)
+import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import Agent.Provider (Provider(..))
 import qualified System.Timeout as Timeout
@@ -168,8 +169,102 @@ spec = describe "Agent.Telegram" do
             decoded `shouldSatisfy` \case
                 Right state ->
                     state.nextUpdateId == Just 12
-                        && null state.pendingTurns
+                        && Map.null state.pendingQueues
                 Left _ -> False
+
+        it "loads legacy state into keyed bindings and per-chat queues" do
+            let firstKey = TelegramChatKey 123 Nothing
+                secondKey = TelegramChatKey 456 (Just 7)
+                firstTurn =
+                    TelegramPendingTurn 10 77 firstKey "first" Nothing
+                laterTurn =
+                    TelegramPendingTurn 12 79 firstKey "later" Nothing
+                secondTurn =
+                    TelegramPendingTurn 9 76 secondKey "other" Nothing
+                firstReply =
+                    TelegramPendingReply 11 firstKey (Just 77) "reply"
+                secondReply =
+                    TelegramPendingReply 8 secondKey (Just 75) "other reply"
+                decoded = eitherDecode
+                    (LBS.pack
+                        "{\"nextUpdateId\":12,\"bindings\":[{\
+                        \\"chat\":{\"chatId\":123},\"sessionId\":\"session-1\"}],\
+                        \\"pendingTurns\":[{\
+                        \\"updateId\":12,\"messageId\":79,\
+                        \\"chat\":{\"chatId\":123},\"text\":\"later\"},{\
+                        \\"updateId\":9,\"messageId\":76,\
+                        \\"chat\":{\"chatId\":456,\"messageThreadId\":7},\
+                        \\"text\":\"other\"},{\
+                        \\"updateId\":10,\"messageId\":77,\
+                        \\"chat\":{\"chatId\":123},\"text\":\"first\"}],\
+                        \\"pendingReplies\":[{\
+                        \\"updateId\":11,\"chat\":{\"chatId\":123},\
+                        \\"replyToMessageId\":77,\"text\":\"reply\"},{\
+                        \\"updateId\":8,\
+                        \\"chat\":{\"chatId\":456,\"messageThreadId\":7},\
+                        \\"replyToMessageId\":75,\"text\":\"other reply\"}]}")
+                    :: Either String TelegramState
+            state <- decoded `shouldReturnRight`
+                "legacy Telegram state should decode"
+            Map.lookup firstKey state.bindings `shouldBe` Just "session-1"
+            Map.keysSet state.pendingQueues
+                `shouldBe` Set.fromList [firstKey, secondKey]
+            nextPendingAction firstKey state
+                `shouldBe` Just (RunPendingTurn firstTurn)
+            nextPendingAction secondKey state
+                `shouldBe` Just (DeliverReply secondReply)
+            Map.lookup firstKey state.pendingQueues `shouldBe`
+                Just
+                    (Map.fromList
+                        [ (10, RunPendingTurn firstTurn)
+                        , (11, DeliverReply firstReply)
+                        , (12, RunPendingTurn laterTurn)
+                        ])
+            Map.lookup secondKey state.pendingQueues `shouldBe`
+                Just
+                    (Map.fromList
+                        [ (8, DeliverReply secondReply)
+                        , (9, RunPendingTurn secondTurn)
+                        ])
+
+        it "preserves first-match semantics for duplicate legacy bindings" do
+            let key = TelegramChatKey 123 Nothing
+                decoded = eitherDecode
+                    (LBS.pack
+                        "{\"bindings\":[{\
+                        \\"chat\":{\"chatId\":123},\"sessionId\":\"current\"},{\
+                        \\"chat\":{\"chatId\":123},\"sessionId\":\"stale\"}]}")
+                    :: Either String TelegramState
+            state <- decoded `shouldReturnRight`
+                "legacy Telegram bindings should decode"
+            Map.lookup key state.bindings `shouldBe` Just "current"
+
+        it "writes keyed state using the legacy JSON array fields" do
+            let key = TelegramChatKey 123 Nothing
+                turn = TelegramPendingTurn 10 77 key "hello" Nothing
+                reply = TelegramPendingReply 11 key (Just 77) "reply"
+                state = emptyTelegramState
+                    { nextUpdateId = Just 12
+                    , bindings = Map.singleton key "session-1"
+                    , pendingQueues =
+                        Map.singleton key $ Map.fromList
+                            [ (10, RunPendingTurn turn)
+                            , (11, DeliverReply reply)
+                            ]
+                    }
+                expected = object
+                    [ "nextUpdateId" .= (Just 12 :: Maybe Integer)
+                    , "bindings" .=
+                        [ object
+                            [ "chat" .= key
+                            , "sessionId" .= ("session-1" :: String)
+                            ]
+                        ]
+                    , "pendingTurns" .= [turn]
+                    , "pendingReplies" .= [reply]
+                    ]
+            (eitherDecode (encode state) :: Either String Value)
+                `shouldBe` Right expected
 
         it "persists inbound work and advances the polling offset" do
             let key = TelegramChatKey 123 Nothing
@@ -178,8 +273,10 @@ spec = describe "Agent.Telegram" do
                     (QueueTurn 77 key "hello" Nothing)
                     emptyTelegramState
             state.nextUpdateId `shouldBe` Just 11
-            state.pendingTurns `shouldBe`
-                [TelegramPendingTurn 10 77 key "hello" Nothing]
+            nextPendingAction key state `shouldBe`
+                Just
+                    (RunPendingTurn
+                        (TelegramPendingTurn 10 77 key "hello" Nothing))
 
         it "does not enqueue a delivered update twice" do
             let key = TelegramChatKey 123 Nothing
@@ -191,7 +288,7 @@ spec = describe "Agent.Telegram" do
                     10
                     (QueueTurn 77 key "hello" Nothing)
                     once
-            twice.pendingTurns `shouldBe` once.pendingTurns
+            twice.pendingQueues `shouldBe` once.pendingQueues
 
         it "checkpoints a voice transcript before running the agent" do
             let key = TelegramChatKey 123 Nothing
@@ -202,15 +299,20 @@ spec = describe "Agent.Telegram" do
                 state = checkpointPendingVoiceTranscript
                     10
                     "[Voice message transcript]: hello"
-                    emptyTelegramState { pendingTurns = [pending] }
-            state.pendingTurns `shouldBe`
-                [ TelegramPendingTurn
-                    10
-                    77
-                    key
-                    "[Voice message transcript]: hello"
-                    Nothing
-                ]
+                    emptyTelegramState
+                        { pendingQueues =
+                            Map.singleton key
+                                (Map.singleton 10 (RunPendingTurn pending))
+                        }
+            nextPendingAction key state `shouldBe`
+                Just
+                    (RunPendingTurn
+                        (TelegramPendingTurn
+                            10
+                            77
+                            key
+                            "[Voice message transcript]: hello"
+                            Nothing))
 
         it "selects work in update order within a conversation" do
             let key = TelegramChatKey 123 Nothing
@@ -218,8 +320,12 @@ spec = describe "Agent.Telegram" do
                 olderTurn = TelegramPendingTurn 10 77 key "first" Nothing
                 middleReply = TelegramPendingReply 11 key (Just 77) "reply"
                 state = emptyTelegramState
-                    { pendingTurns = [newerTurn, olderTurn]
-                    , pendingReplies = [middleReply]
+                    { pendingQueues =
+                        Map.singleton key $ Map.fromList
+                            [ (12, RunPendingTurn newerTurn)
+                            , (10, RunPendingTurn olderTurn)
+                            , (11, DeliverReply middleReply)
+                            ]
                     }
             nextPendingAction key state
                 `shouldBe` Just (RunPendingTurn olderTurn)
@@ -229,8 +335,11 @@ spec = describe "Agent.Telegram" do
                 turn = TelegramPendingTurn 12 79 key "later" Nothing
                 reply = TelegramPendingReply 11 key (Just 77) "reply"
                 state = emptyTelegramState
-                    { pendingTurns = [turn]
-                    , pendingReplies = [reply]
+                    { pendingQueues =
+                        Map.singleton key $ Map.fromList
+                            [ (12, RunPendingTurn turn)
+                            , (11, DeliverReply reply)
+                            ]
                     }
             nextPendingAction key state
                 `shouldBe` Just (DeliverReply reply)
@@ -239,3 +348,8 @@ isLeft :: Either a b -> Bool
 isLeft = \case
     Left _ -> True
     Right _ -> False
+
+shouldReturnRight :: Either String a -> String -> IO a
+shouldReturnRight result message = case result of
+    Left err -> expectationFailure (message <> ": " <> err) >> fail message
+    Right value -> pure value


### PR DESCRIPTION
## Summary
- replace global pending turn/reply lists with ordered per-chat queues
- replace session binding scans with a keyed map
- preserve the existing persisted JSON array format for backward compatibility
- add migration, ordering, duplicate-binding, and JSON-shape tests

## Validation
- `nix develop -c cabal test --offline agent-cli:test:agent-cli-test --test-options=--match=Agent.Telegram --test-show-details=direct`
- combined agent-cli suite: 753 examples, 0 failures
- `git diff --check`
