### PR TITLE
Separate current and legacy subagent metadata

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/SubagentStore.hs
+++ b/packages/agent-cli/src/Agent/CLI/SubagentStore.hs
@@ -7,7 +7,12 @@
 --   <sessionDir>/agents/<agentId>/transcript.json
 -- @
 module Agent.CLI.SubagentStore
-    ( SubagentDiskMeta(..)
+    ( SubagentDiskFields(..)
+    , SubagentTarget(..)
+    , LegacySubagentTargetFields(..)
+    , SubagentDiskMeta(..)
+    , SubagentStateSnapshot(..)
+    , subagentDiskFields
     , isValidSubagentStoreId
     , subagentStoreDir
     , forkSubagentTranscript
@@ -45,13 +50,14 @@ import System.Directory.OsPath
 import System.OsPath (OsPath, unsafeEncodeUtf, (</>))
 import System.Posix.Files (setFileMode)
 
-data SubagentDiskMeta = SubagentDiskMeta
+-- | Metadata shared by current and legacy subagent stores.
+--
+-- Current writers always persist a status, while older stores may omit it.
+-- The target fields are kept out of this record because their completeness is
+-- what distinguishes current metadata from legacy metadata.
+data SubagentDiskFields = SubagentDiskFields
     { diskPreviousResponseId :: !(Maybe Text)
     , diskStatus :: !(Maybe SubagentStatus)
-    , diskProvider :: !(Maybe Provider)
-    , diskConnection :: !(Maybe Text)
-    , diskEffectiveModel :: !(Maybe Text)
-    , diskDialect :: !(Maybe DialectId)
     , diskAgentType :: !(Maybe Text)
     , diskAgentModel :: !(Maybe Text)
     , diskReasoningEffort :: !(Maybe Text)
@@ -61,22 +67,79 @@ data SubagentDiskMeta = SubagentDiskMeta
     , diskDepth :: !(Maybe Int)
     } deriving (Eq, Show)
 
+-- | Complete target metadata written by current versions.
+data SubagentTarget = SubagentTarget
+    { targetProvider :: !Provider
+    , targetConnection :: !Text
+    , targetEffectiveModel :: !Text
+    , targetDialect :: !DialectId
+    } deriving (Eq, Show)
+
+-- | Partial target metadata accepted from older @meta.json@ files.
+data LegacySubagentTargetFields = LegacySubagentTargetFields
+    { legacyDiskProvider :: !(Maybe Provider)
+    , legacyDiskConnection :: !(Maybe Text)
+    , legacyDiskEffectiveModel :: !(Maybe Text)
+    , legacyDiskDialect :: !(Maybe DialectId)
+    } deriving (Eq, Show)
+
+-- | Persisted metadata is either current, with a complete restoration target,
+-- or legacy, with a target that must be normalized against the parent
+-- session's durable legacy target before use.
+data SubagentDiskMeta
+    = CurrentSubagentDiskMeta !SubagentDiskFields !SubagentTarget
+    | LegacySubagentDiskMeta !SubagentDiskFields !LegacySubagentTargetFields
+    deriving (Eq, Show)
+
+-- | Named inputs for a subagent snapshot save.
+data SubagentStateSnapshot = SubagentStateSnapshot
+    { snapshotItems :: ![ResponseItem]
+    , snapshotPreviousResponseId :: !(Maybe Text)
+    , snapshotStatus :: !SubagentStatus
+    , snapshotTarget :: !SubagentTarget
+    , snapshotAgentType :: !(Maybe Text)
+    , snapshotAgentModel :: !(Maybe Text)
+    , snapshotReasoningEffort :: !(Maybe Text)
+    , snapshotCwd :: !(Maybe OsPath)
+    , snapshotIdentity :: !(Maybe SubagentIdentity)
+    }
+
+subagentDiskFields :: SubagentDiskMeta -> SubagentDiskFields
+subagentDiskFields = \case
+    CurrentSubagentDiskMeta fields _ -> fields
+    LegacySubagentDiskMeta fields _ -> fields
+
 instance ToJSON SubagentDiskMeta where
     toJSON meta = object
-        [ "previousResponseId" .= meta.diskPreviousResponseId
-        , "status" .= fmap encodeDiskStatus meta.diskStatus
-        , "provider" .= fmap providerSlug meta.diskProvider
-        , "connection" .= meta.diskConnection
-        , "effectiveModel" .= meta.diskEffectiveModel
-        , "dialect" .= fmap dialectSlug meta.diskDialect
-        , "agentType" .= meta.diskAgentType
-        , "agentModel" .= meta.diskAgentModel
-        , "reasoningEffort" .= meta.diskReasoningEffort
-        , "cwd" .= fmap unsafeToFilePath meta.diskCwd
-        , "taskPath" .= meta.diskTaskPath
-        , "parentId" .= meta.diskParentId
-        , "depth" .= meta.diskDepth
+        [ "previousResponseId" .= fields.diskPreviousResponseId
+        , "status" .= fmap encodeDiskStatus fields.diskStatus
+        , "provider" .= fmap providerSlug provider
+        , "connection" .= connection
+        , "effectiveModel" .= effectiveModel
+        , "dialect" .= fmap dialectSlug dialect
+        , "agentType" .= fields.diskAgentType
+        , "agentModel" .= fields.diskAgentModel
+        , "reasoningEffort" .= fields.diskReasoningEffort
+        , "cwd" .= fmap unsafeToFilePath fields.diskCwd
+        , "taskPath" .= fields.diskTaskPath
+        , "parentId" .= fields.diskParentId
+        , "depth" .= fields.diskDepth
         ]
+      where
+        fields = subagentDiskFields meta
+        (provider, connection, effectiveModel, dialect) = case meta of
+            CurrentSubagentDiskMeta _ target ->
+                ( Just target.targetProvider
+                , Just target.targetConnection
+                , Just target.targetEffectiveModel
+                , Just target.targetDialect
+                )
+            LegacySubagentDiskMeta _ legacy ->
+                ( legacy.legacyDiskProvider
+                , legacy.legacyDiskConnection
+                , legacy.legacyDiskEffectiveModel
+                , legacy.legacyDiskDialect
+                )
 
 instance FromJSON SubagentDiskMeta where
     parseJSON = withObject "SubagentDiskMeta" \o -> do
@@ -89,13 +152,10 @@ instance FromJSON SubagentDiskMeta where
                 storedConnection <|> (providerSlug <$> diskProvider)
         dialectText <- o .:? "dialect"
         diskDialect <- traverse parseDiskDialect dialectText
-        SubagentDiskMeta
+        diskEffectiveModel <- o .:? "effectiveModel"
+        fields <- SubagentDiskFields
             <$> o .:? "previousResponseId"
             <*> pure diskStatus
-            <*> pure diskProvider
-            <*> pure diskConnection
-            <*> o .:? "effectiveModel"
-            <*> pure diskDialect
             <*> o .:? "agentType"
             <*> o .:? "agentModel"
             <*> o .:? "reasoningEffort"
@@ -103,6 +163,23 @@ instance FromJSON SubagentDiskMeta where
             <*> o .:? "taskPath"
             <*> o .:? "parentId"
             <*> o .:? "depth"
+        pure $ case
+                (diskProvider, diskConnection, diskEffectiveModel, diskDialect)
+                of
+            (Just provider, Just connection, Just effectiveModel, Just dialect) ->
+                CurrentSubagentDiskMeta fields SubagentTarget
+                    { targetProvider = provider
+                    , targetConnection = connection
+                    , targetEffectiveModel = effectiveModel
+                    , targetDialect = dialect
+                    }
+            _ ->
+                LegacySubagentDiskMeta fields LegacySubagentTargetFields
+                    { legacyDiskProvider = diskProvider
+                    , legacyDiskConnection = diskConnection
+                    , legacyDiskEffectiveModel = diskEffectiveModel
+                    , legacyDiskDialect = diskDialect
+                    }
 
 parseDiskDialect :: Text -> Parser DialectId
 parseDiskDialect text =
@@ -192,23 +269,9 @@ takeRecentTurns count items =
 saveSubagentState
     :: OsPath
     -> SubagentId
-    -> [ResponseItem]
-    -> Maybe Text
-    -> SubagentStatus
-    -> Provider
-    -> Text
-    -> Text
-    -> DialectId
-    -> Maybe Text
-    -> Maybe Text
-    -> Maybe Text
-    -> Maybe OsPath
-    -> Maybe SubagentIdentity
+    -> SubagentStateSnapshot
     -> IO (Either Text ())
-saveSubagentState
-        sessionDir agentId items previous status provider connection effectiveModel dialect
-        agentType agentModel
-        reasoningEffort cwd identity =
+saveSubagentState sessionDir agentId snapshot =
     case subagentStoreDir sessionDir agentId of
         Left err -> pure (Left err)
         Right dir -> do
@@ -216,22 +279,29 @@ saveSubagentState
                 transcriptPath = dir </> unsafeEncodeUtf "transcript.json"
             createDirectoryIfMissing True dir
             _ <- tryAny (setFileMode (unsafeToFilePath dir) 0o700)
-            writeLazyFileAtomically metaPath 0o600 $ Aeson.encode SubagentDiskMeta
-                { diskPreviousResponseId = previous
-                , diskStatus = Just status
-                , diskProvider = Just provider
-                , diskConnection = Just connection
-                , diskEffectiveModel = Just effectiveModel
-                , diskDialect = Just dialect
-                , diskAgentType = agentType
-                , diskAgentModel = agentModel
-                , diskReasoningEffort = reasoningEffort
-                , diskCwd = cwd
-                , diskTaskPath = taskPathText . (.identityTaskPath) <$> identity
-                , diskParentId = identity >>= (.identityParent)
-                , diskDepth = (.identityDepth) <$> identity
-                }
-            writeLazyFileAtomically transcriptPath 0o600 (Aeson.encode items)
+            let fields = SubagentDiskFields
+                    { diskPreviousResponseId =
+                        snapshot.snapshotPreviousResponseId
+                    , diskStatus = Just snapshot.snapshotStatus
+                    , diskAgentType = snapshot.snapshotAgentType
+                    , diskAgentModel = snapshot.snapshotAgentModel
+                    , diskReasoningEffort = snapshot.snapshotReasoningEffort
+                    , diskCwd = snapshot.snapshotCwd
+                    , diskTaskPath =
+                        taskPathText . (.identityTaskPath)
+                            <$> snapshot.snapshotIdentity
+                    , diskParentId =
+                        snapshot.snapshotIdentity >>= (.identityParent)
+                    , diskDepth =
+                        (.identityDepth) <$> snapshot.snapshotIdentity
+                    }
+                meta =
+                    CurrentSubagentDiskMeta fields snapshot.snapshotTarget
+            writeLazyFileAtomically metaPath 0o600 (Aeson.encode meta)
+            writeLazyFileAtomically
+                transcriptPath
+                0o600
+                (Aeson.encode snapshot.snapshotItems)
             pure (Right ())
 
 loadSubagentState
@@ -251,8 +321,12 @@ loadSubagentState sessionDir agentId =
                 else do
                     metaResult <- if hasMeta
                         then decodeFile metaPath
-                        else pure (Right (SubagentDiskMeta
-                            Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing))
+                        else pure (Right (LegacySubagentDiskMeta
+                            (SubagentDiskFields
+                                Nothing Nothing Nothing Nothing Nothing
+                                Nothing Nothing Nothing Nothing)
+                            (LegacySubagentTargetFields
+                                Nothing Nothing Nothing Nothing)))
                     itemsResult <- if hasTranscript
                         then decodeFile transcriptPath
                         else pure (Right [])

--- a/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
@@ -31,10 +31,15 @@ import Agent.CLI.Prompt
 import Agent.CLI.Request (requestParams)
 import Agent.CLI.Session (LegacySubagentTarget(..))
 import Agent.CLI.SubagentStore
-    ( SubagentDiskMeta(..)
+    ( LegacySubagentTargetFields(..)
+    , SubagentDiskFields(..)
+    , SubagentDiskMeta(..)
+    , SubagentStateSnapshot(..)
+    , SubagentTarget(..)
     , forkSubagentTranscript
     , loadSubagentState
     , saveSubagentState
+    , subagentDiskFields
     )
 import Agent.CLI.Tools (requireToolRegistry, schemasFromAppTools)
 import Agent.CLI.Dialects
@@ -348,12 +353,24 @@ saveSubagentSnapshotWithStatus
     agentCwd <- getSubagentCwd registry agentId
     identity <- getSubagentIdentity registry agentId
     saveSubagentState
-        sessionDir agentId items previous status
-        session.subSessionProvider session.subSessionConnection
-        session.subSessionEffectiveModel
-        session.subSessionDialect
-        agentType agentModel
-        reasoningEffort agentCwd identity
+        sessionDir
+        agentId
+        SubagentStateSnapshot
+            { snapshotItems = items
+            , snapshotPreviousResponseId = previous
+            , snapshotStatus = status
+            , snapshotTarget = SubagentTarget
+                { targetProvider = session.subSessionProvider
+                , targetConnection = session.subSessionConnection
+                , targetEffectiveModel = session.subSessionEffectiveModel
+                , targetDialect = session.subSessionDialect
+                }
+            , snapshotAgentType = agentType
+            , snapshotAgentModel = agentModel
+            , snapshotReasoningEffort = reasoningEffort
+            , snapshotCwd = agentCwd
+            , snapshotIdentity = identity
+            }
 
 flushAllSubagentSnapshots
     :: SubagentStoreRoot
@@ -416,16 +433,17 @@ restoreAgentFromDisk
                         restoreSession session Nothing \_ ->
                             reopenInMemory Nothing Nothing
                     Right (Just (items, meta)) -> do
-                        let expectedEffectiveModel =
+                        let fields = subagentDiskFields meta
+                            expectedEffectiveModel =
                                 maybe
                                     parentEffectiveModel
                                     mapModel
-                                    meta.diskAgentModel
+                                    fields.diskAgentModel
                             expectedDialect =
                                 maybe
                                     parentDialect
                                     (dialectIdForModel provider . mapModel)
-                                    meta.diskAgentModel
+                                    fields.diskAgentModel
                         case validatePersistedSubagentTarget
                                 provider
                                 connection
@@ -434,24 +452,26 @@ restoreAgentFromDisk
                                 legacyTarget
                                 meta of
                             Left err -> pure (Left err)
-                            Right (_, _, storedDialect)
+                            Right storedTarget
                                 | not
                                     (providerSupportsDialect
-                                        provider storedDialect) ->
+                                        provider storedTarget.targetDialect) ->
                                     pure $ Left $
                                         unsupportedDialectMessage
-                                            provider agentId storedDialect
-                            Right (storedConnection, storedEffectiveModel, storedDialect) -> do
+                                            provider
+                                            agentId
+                                            storedTarget.targetDialect
+                            Right storedTarget -> do
                                 session <-
                                     getOrInstallSubagentSession
                                         sessionsRef
                                         provider
-                                        storedConnection
-                                        storedEffectiveModel
-                                        storedDialect
+                                        storedTarget.targetConnection
+                                        storedTarget.targetEffectiveModel
+                                        storedTarget.targetDialect
                                         agentId
-                                restoreSession session (Just (items, meta)) \_ ->
-                                    reopenPersisted meta >>= \case
+                                restoreSession session (Just (items, fields)) \_ ->
+                                    reopenPersisted fields >>= \case
                                         Left err -> pure (Left err)
                                         Right () -> pure (Right ())
     restoreSession session loaded reopen =
@@ -473,32 +493,32 @@ restoreAgentFromDisk
                 Right () -> do
                     case loaded of
                         Nothing -> pure ()
-                        Just (items, meta) -> do
-                            recordPersistedAgentSpec typesRef agentId meta
+                        Just (items, fields) -> do
+                            recordPersistedAgentSpec typesRef agentId fields
                             unless hydrated $
                                 writeIORef session.subSessionTranscript items
                     pure (True, Right ())
-    reopenPersisted meta =
-        case meta.diskTaskPath of
+    reopenPersisted fields =
+        case fields.diskTaskPath of
             Nothing -> restoreAt taskPathRoot
             Just pathText ->
                 case parseTaskPath pathText of
                     Left err -> pure (Left err)
                     Right taskPath -> restoreAt taskPath
       where
-        restoredStatus = fromMaybe (Completed Nothing) meta.diskStatus
+        restoredStatus = fromMaybe (Completed Nothing) fields.diskStatus
         restoreAt taskPath = do
             let restore =
-                    case meta.diskCwd of
+                    case fields.diskCwd of
                         Just childCwd ->
                             restoreSubagentAtWithCwdStatus
                                 registry childCwd
                         Nothing ->
                             restoreSubagentAtStatus registry
             restore
-                agentId meta.diskParentId taskPath
-                (fromMaybe 1 meta.diskDepth)
-                Nothing meta.diskPreviousResponseId restoredStatus
+                agentId fields.diskParentId taskPath
+                (fromMaybe 1 fields.diskDepth)
+                Nothing fields.diskPreviousResponseId restoredStatus
                 >>= pure . fmap (const ())
     reopenInMemory previous requestedCwd = do
         restored <- case requestedCwd of
@@ -995,35 +1015,39 @@ ensureSubagentSessionHydratedLocked
                         meta of
                     Left err ->
                         throwIO (userError (Text.unpack err))
-                    Right (_, _, storedDialect)
+                    Right storedTarget
                         | not
                             (providerSupportsDialect
-                                session.subSessionProvider storedDialect) ->
+                                session.subSessionProvider
+                                storedTarget.targetDialect) ->
                             throwIO $
                                 userError $
                                     Text.unpack $
                                         unsupportedDialectMessage
                                             session.subSessionProvider
                                             agentId
-                                            storedDialect
+                                            storedTarget.targetDialect
                     Right _ -> do
                         writeIORef session.subSessionTranscript items
                         writeIORef session.subSessionContextTokens Nothing
-                        recordPersistedAgentSpec typesRef agentId meta
+                        recordPersistedAgentSpec
+                            typesRef
+                            agentId
+                            (subagentDiskFields meta)
         pure True
 
 recordPersistedAgentSpec
     :: GrokSubagentSpecs
     -> SubagentId
-    -> SubagentDiskMeta
+    -> SubagentDiskFields
     -> IO ()
-recordPersistedAgentSpec typesRef agentId meta =
-    case meta.diskAgentType of
+recordPersistedAgentSpec typesRef agentId fields =
+    case fields.diskAgentType of
         Just agentType ->
             recordAgentSpec typesRef agentId GrokSubagentSpec
                 { agentType
-                , modelOverride = meta.diskAgentModel
-                , reasoningEffortOverride = meta.diskReasoningEffort
+                , modelOverride = fields.diskAgentModel
+                , reasoningEffortOverride = fields.diskReasoningEffort
                 }
         Nothing -> pure ()
 
@@ -1034,73 +1058,71 @@ validatePersistedSubagentTarget
     -> DialectId
     -> Maybe LegacySubagentTarget
     -> SubagentDiskMeta
-    -> Either Text (Text, Text, DialectId)
+    -> Either Text SubagentTarget
 validatePersistedSubagentTarget
         provider connection expectedEffectiveModel expectedDialect legacyTarget meta = do
-    let legacyDialect =
-            legacyDialectForTarget
-                legacyTarget
-                provider
-                connection
-                expectedEffectiveModel
-                expectedDialect
-    storedProvider <- case meta.diskProvider of
-        Just storedProvider -> Right storedProvider
-        Nothing
-            | Nothing <- legacyDialect ->
-                Left
-                    "cannot restore a legacy subagent without provider metadata \
-                    \after changing the session target; reopen the parent \
-                    \session under its original target first"
-        Nothing -> Right provider
-    storedConnection <- case meta.diskConnection of
-        Just stored -> Right stored
-        Nothing
-            | Just _ <- legacyDialect -> Right connection
-            | otherwise ->
-                Left
-                    "cannot restore a legacy subagent without connection metadata \
-                    \after changing the session target; reopen the parent \
-                    \session under its original target first"
-    storedEffectiveModel <- case meta.diskEffectiveModel of
-        Just stored -> Right stored
-        Nothing
-            | Just _ <- legacyDialect -> Right expectedEffectiveModel
-            | otherwise ->
-                Left
-                    "cannot restore a legacy subagent without effective model \
-                    \metadata after changing the session target; reopen the \
-                    \parent session under its original target first"
-    case subagentTargetError
-            provider connection expectedEffectiveModel
-            storedProvider storedConnection storedEffectiveModel of
+    let expectedTarget = SubagentTarget
+            { targetProvider = provider
+            , targetConnection = connection
+            , targetEffectiveModel = expectedEffectiveModel
+            , targetDialect = expectedDialect
+            }
+    storedTarget <- normalizePersistedSubagentTarget
+        legacyTarget
+        expectedTarget
+        meta
+    case subagentTargetError expectedTarget storedTarget of
         Just err -> Left err
         Nothing -> Right ()
-    storedDialect <- case meta.diskDialect of
-        Just stored -> Right stored
-        Nothing -> case legacyDialect of
-            Just legacy -> Right legacy
+    Right storedTarget
+
+normalizePersistedSubagentTarget
+    :: Maybe LegacySubagentTarget
+    -> SubagentTarget
+    -> SubagentDiskMeta
+    -> Either Text SubagentTarget
+normalizePersistedSubagentTarget legacyTarget expectedTarget = \case
+    CurrentSubagentDiskMeta _ storedTarget ->
+        Right storedTarget
+    LegacySubagentDiskMeta _ legacyFields -> do
+        legacyDialect <- case
+                legacyDialectForTarget legacyTarget expectedTarget
+                of
+            Just dialect -> Right dialect
             Nothing ->
                 Left
-                    "cannot restore a legacy subagent without dialect metadata \
-                    \after changing the session target; reopen the parent \
-                    \session under its original target first"
-    Right (storedConnection, storedEffectiveModel, storedDialect)
+                    "cannot restore a legacy subagent with incomplete target \
+                    \metadata after changing the session target; reopen the \
+                    \parent session under its original target first"
+        Right SubagentTarget
+            { targetProvider =
+                fromMaybe
+                    expectedTarget.targetProvider
+                    legacyFields.legacyDiskProvider
+            , targetConnection =
+                fromMaybe
+                    expectedTarget.targetConnection
+                    legacyFields.legacyDiskConnection
+            , targetEffectiveModel =
+                fromMaybe
+                    expectedTarget.targetEffectiveModel
+                    legacyFields.legacyDiskEffectiveModel
+            , targetDialect =
+                fromMaybe legacyDialect legacyFields.legacyDiskDialect
+            }
 
 legacyDialectForTarget
     :: Maybe LegacySubagentTarget
-    -> Provider
-    -> Text
-    -> Text
-    -> DialectId
+    -> SubagentTarget
     -> Maybe DialectId
-legacyDialectForTarget target provider connection effectiveModel dialect = do
+legacyDialectForTarget target expectedTarget = do
     legacy <- target
-    if legacy.legacyTargetProvider == provider
-        && legacy.legacyTargetConnection == connection
-        && legacy.legacyTargetEffectiveModel == effectiveModel
-        && legacy.legacyTargetDialect == dialect
-        then Just dialect
+    if legacy.legacyTargetProvider == expectedTarget.targetProvider
+        && legacy.legacyTargetConnection == expectedTarget.targetConnection
+        && legacy.legacyTargetEffectiveModel
+            == expectedTarget.targetEffectiveModel
+        && legacy.legacyTargetDialect == expectedTarget.targetDialect
+        then Just expectedTarget.targetDialect
         else Nothing
 
 activeSubagentTargetError
@@ -1111,45 +1133,45 @@ activeSubagentTargetError
     -> Maybe Text
 activeSubagentTargetError provider connection effectiveModel session =
     subagentTargetError
-        provider
-        connection
-        effectiveModel
-        session.subSessionProvider
-        session.subSessionConnection
-        session.subSessionEffectiveModel
+        SubagentTarget
+            { targetProvider = provider
+            , targetConnection = connection
+            , targetEffectiveModel = effectiveModel
+            , targetDialect = session.subSessionDialect
+            }
+        SubagentTarget
+            { targetProvider = session.subSessionProvider
+            , targetConnection = session.subSessionConnection
+            , targetEffectiveModel = session.subSessionEffectiveModel
+            , targetDialect = session.subSessionDialect
+            }
 
 subagentTargetError
-    :: Provider
-    -> Text
-    -> Text
-    -> Provider
-    -> Text
-    -> Text
+    :: SubagentTarget
+    -> SubagentTarget
     -> Maybe Text
-subagentTargetError
-        provider connection effectiveModel
-        storedProvider storedConnection storedEffectiveModel
-    | storedProvider /= provider =
+subagentTargetError expected stored
+    | stored.targetProvider /= expected.targetProvider =
         Just
             ( "cannot continue subagent created for the "
-                <> providerSlug storedProvider
+                <> providerSlug stored.targetProvider
                 <> " transport under "
-                <> providerSlug provider
+                <> providerSlug expected.targetProvider
             )
-    | storedConnection /= connection =
+    | stored.targetConnection /= expected.targetConnection =
         Just
             ( "cannot continue subagent created for connection "
-                <> storedConnection
+                <> stored.targetConnection
                 <> " under connection "
-                <> connection
+                <> expected.targetConnection
             )
-    | storedEffectiveModel /= effectiveModel =
+    | stored.targetEffectiveModel /= expected.targetEffectiveModel =
         Just
             ( "cannot continue subagent after its effective model changed \
                 \from "
-                <> storedEffectiveModel
+                <> stored.targetEffectiveModel
                 <> " to "
-                <> effectiveModel
+                <> expected.targetEffectiveModel
             )
     | otherwise = Nothing
 

--- a/packages/agent-cli/test/Agent/CLI/SubagentStoreSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SubagentStoreSpec.hs
@@ -63,30 +63,42 @@ spec = describe "Agent.CLI.SubagentStore" do
                     }
             Right taskPath <- pure (parseTaskPath "/root/research/worker")
             let identity = SubagentIdentity (Just parentId) 2 taskPath
-            saveSubagentState dir agentId [item] (Just "resp-1")
-                (Completed (Just "done")) XAIProvider "xai" "grok-4.5-mini"
-                GrokBuildDialect (Just "explore")
-                (Just "grok-4.5-mini") (Just "high")
-                (Just (fromFilePath "/tmp/work"))
-                (Just identity)
+                snapshot =
+                    (testSnapshot
+                        [item]
+                        (Completed (Just "done"))
+                        XAIProvider
+                        "xai"
+                        "grok-4.5-mini"
+                        GrokBuildDialect)
+                        { snapshotPreviousResponseId = Just "resp-1"
+                        , snapshotAgentType = Just "explore"
+                        , snapshotAgentModel = Just "grok-4.5-mini"
+                        , snapshotReasoningEffort = Just "high"
+                        , snapshotCwd = Just (fromFilePath "/tmp/work")
+                        , snapshotIdentity = Just identity
+                        }
+            saveSubagentState dir agentId snapshot
                 `shouldReturn` Right ()
             loaded <- loadSubagentState dir agentId
             case loaded of
-                Right (Just (items, meta)) -> do
+                Right (Just (items, CurrentSubagentDiskMeta fields target)) -> do
                     length items `shouldBe` 1
-                    meta.diskPreviousResponseId `shouldBe` Just "resp-1"
-                    meta.diskStatus `shouldBe` Just (Completed (Just "done"))
-                    meta.diskProvider `shouldBe` Just XAIProvider
-                    meta.diskConnection `shouldBe` Just "xai"
-                    meta.diskEffectiveModel `shouldBe` Just "grok-4.5-mini"
-                    meta.diskDialect `shouldBe` Just GrokBuildDialect
-                    meta.diskAgentType `shouldBe` Just "explore"
-                    meta.diskAgentModel `shouldBe` Just "grok-4.5-mini"
-                    meta.diskReasoningEffort `shouldBe` Just "high"
-                    meta.diskCwd `shouldBe` Just (fromFilePath "/tmp/work")
-                    meta.diskTaskPath `shouldBe` Just "/root/research/worker"
-                    meta.diskParentId `shouldBe` Just parentId
-                    meta.diskDepth `shouldBe` Just 2
+                    fields.diskPreviousResponseId `shouldBe` Just "resp-1"
+                    fields.diskStatus `shouldBe`
+                        Just (Completed (Just "done"))
+                    target.targetProvider `shouldBe` XAIProvider
+                    target.targetConnection `shouldBe` "xai"
+                    target.targetEffectiveModel `shouldBe` "grok-4.5-mini"
+                    target.targetDialect `shouldBe` GrokBuildDialect
+                    fields.diskAgentType `shouldBe` Just "explore"
+                    fields.diskAgentModel `shouldBe` Just "grok-4.5-mini"
+                    fields.diskReasoningEffort `shouldBe` Just "high"
+                    fields.diskCwd `shouldBe` Just (fromFilePath "/tmp/work")
+                    fields.diskTaskPath `shouldBe`
+                        Just "/root/research/worker"
+                    fields.diskParentId `shouldBe` Just parentId
+                    fields.diskDepth `shouldBe` Just 2
                 other -> expectationFailure ("unexpected load: " <> show other)
             case subagentStoreDir dir agentId of
                 Right path ->
@@ -104,9 +116,16 @@ spec = describe "Agent.CLI.SubagentStore" do
     it "loads legacy metadata without task topology" do
         withTempDir \dir -> do
             let agentId = SubagentId "agent-legacy-1"
-            saveSubagentState dir agentId [] (Just "legacy") Interrupted
-                XAIProvider "xai" "grok-4.6" GrokBuildDialect
-                Nothing Nothing Nothing Nothing Nothing
+                snapshot =
+                    (testSnapshot
+                        []
+                        Interrupted
+                        XAIProvider
+                        "xai"
+                        "grok-4.6"
+                        GrokBuildDialect)
+                        { snapshotPreviousResponseId = Just "legacy" }
+            saveSubagentState dir agentId snapshot
                 `shouldReturn` Right ()
             Right path <- pure (subagentStoreDir dir agentId)
             LBS.writeFile
@@ -114,39 +133,53 @@ spec = describe "Agent.CLI.SubagentStore" do
                 "{\"previousResponseId\":\"legacy\"}"
             loaded <- loadSubagentState dir agentId
             case loaded of
-                Right (Just (_, meta)) -> do
-                    meta.diskTaskPath `shouldBe` Nothing
-                    meta.diskParentId `shouldBe` Nothing
-                    meta.diskDepth `shouldBe` Nothing
-                    meta.diskStatus `shouldBe` Nothing
-                    meta.diskProvider `shouldBe` Nothing
-                    meta.diskConnection `shouldBe` Nothing
-                    meta.diskEffectiveModel `shouldBe` Nothing
-                    meta.diskDialect `shouldBe` Nothing
+                Right (Just (_, LegacySubagentDiskMeta fields target)) -> do
+                    fields.diskTaskPath `shouldBe` Nothing
+                    fields.diskParentId `shouldBe` Nothing
+                    fields.diskDepth `shouldBe` Nothing
+                    fields.diskStatus `shouldBe` Nothing
+                    target.legacyDiskProvider `shouldBe` Nothing
+                    target.legacyDiskConnection `shouldBe` Nothing
+                    target.legacyDiskEffectiveModel `shouldBe` Nothing
+                    target.legacyDiskDialect `shouldBe` Nothing
                 other -> expectationFailure ("unexpected load: " <> show other)
 
-    it "derives a missing legacy connection from the persisted provider" do
+    it "normalizes a derivable connection into current target metadata" do
         withTempDir \dir -> do
             let agentId = SubagentId "agent-legacy-connection"
-            saveSubagentState dir agentId [] Nothing Interrupted
-                XAIProvider "xai" "grok-4.6" GrokBuildDialect
-                Nothing Nothing Nothing Nothing Nothing
+            saveSubagentState
+                dir
+                agentId
+                (testSnapshot
+                    []
+                    Interrupted
+                    XAIProvider
+                    "xai"
+                    "grok-4.6"
+                    GrokBuildDialect)
                 `shouldReturn` Right ()
             Right path <- pure (subagentStoreDir dir agentId)
             LBS.writeFile
                 (toFilePath (path </> fromFilePath "meta.json"))
                 "{\"provider\":\"xai\",\"effectiveModel\":\"grok-4.6\",\"dialect\":\"grok-build\"}"
             loadSubagentState dir agentId >>= \case
-                Right (Just (_, meta)) ->
-                    meta.diskConnection `shouldBe` Just "xai"
+                Right (Just (_, CurrentSubagentDiskMeta _ target)) ->
+                    target.targetConnection `shouldBe` "xai"
                 other -> expectationFailure ("unexpected load: " <> show other)
 
     it "fails closed on corrupt transcript JSON" do
         withTempDir \dir -> do
             let agentId = SubagentId "agent-corrupt-1"
-            saveSubagentState dir agentId [] (Just "r") Interrupted
-                OpenAIProvider "openai" "gpt-5.6-luna" CodexDialect
-                Nothing Nothing Nothing Nothing Nothing
+                snapshot =
+                    (testSnapshot
+                        []
+                        Interrupted
+                        OpenAIProvider
+                        "openai"
+                        "gpt-5.6-luna"
+                        CodexDialect)
+                        { snapshotPreviousResponseId = Just "r" }
+            saveSubagentState dir agentId snapshot
                 `shouldReturn` Right ()
             Right path <- pure (subagentStoreDir dir agentId)
             LBS.writeFile
@@ -180,7 +213,12 @@ spec = describe "Agent.CLI.SubagentStore" do
                 Nothing
                 persistedMeta
                 `shouldBe`
-                    Right ("openrouter", "openai/gpt-5.1", CodexDialect)
+                    Right SubagentTarget
+                        { targetProvider = OpenRouterProvider
+                        , targetConnection = "openrouter"
+                        , targetEffectiveModel = "openai/gpt-5.1"
+                        , targetDialect = CodexDialect
+                        }
 
         it "rejects an inherited child after the parent target changes" do
             validatePersistedSubagentTarget
@@ -221,7 +259,12 @@ spec = describe "Agent.CLI.SubagentStore" do
                 (Just legacyTarget)
                 legacyMeta
                 `shouldBe`
-                    Right ("openrouter", "openai/gpt-5.1", GrokBuildDialect)
+                    Right SubagentTarget
+                        { targetProvider = OpenRouterProvider
+                        , targetConnection = "openrouter"
+                        , targetEffectiveModel = "openai/gpt-5.1"
+                        , targetDialect = GrokBuildDialect
+                        }
             validatePersistedSubagentTarget
                 OpenRouterProvider
                 "openrouter"
@@ -246,10 +289,16 @@ spec = describe "Agent.CLI.SubagentStore" do
                 persistedItems =
                     replicate 20000 (messageItem RoleUser "persisted")
                 workerCount = 16
-            saveSubagentState dir agentId persistedItems Nothing
-                (Completed Nothing)
-                OpenAIProvider "openai" "gpt-5.6-luna" CodexDialect
-                Nothing Nothing Nothing Nothing Nothing
+            saveSubagentState
+                dir
+                agentId
+                (testSnapshot
+                    persistedItems
+                    (Completed Nothing)
+                    OpenAIProvider
+                    "openai"
+                    "gpt-5.6-luna"
+                    CodexDialect)
                 `shouldReturn` Right ()
             sessionsRef <- newIORef Map.empty
             storeRootRef <- newIORef (Just dir)
@@ -282,10 +331,16 @@ spec = describe "Agent.CLI.SubagentStore" do
                 persisted = [messageItem RoleUser "persisted"]
                 inMemory = [messageItem RoleAssistant "in-memory"]
                 workerCount = 8
-            saveSubagentState dir agentId persisted Nothing
-                (Completed Nothing)
-                OpenAIProvider "openai" "gpt-5.6-luna" CodexDialect
-                Nothing Nothing Nothing Nothing Nothing
+            saveSubagentState
+                dir
+                agentId
+                (testSnapshot
+                    persisted
+                    (Completed Nothing)
+                    OpenAIProvider
+                    "openai"
+                    "gpt-5.6-luna"
+                    CodexDialect)
                 `shouldReturn` Right ()
             sessionsRef <- newIORef Map.empty
             storeRootRef <- newIORef (Just dir)
@@ -463,21 +518,29 @@ legacyTarget = LegacySubagentTarget
     }
 
 persistedMeta :: SubagentDiskMeta
-persistedMeta = legacyMeta
-    { diskProvider = Just OpenRouterProvider
-    , diskConnection = Just "openrouter"
-    , diskEffectiveModel = Just "openai/gpt-5.1"
-    , diskDialect = Just CodexDialect
-    }
+persistedMeta =
+    CurrentSubagentDiskMeta emptyDiskFields SubagentTarget
+        { targetProvider = OpenRouterProvider
+        , targetConnection = "openrouter"
+        , targetEffectiveModel = "openai/gpt-5.1"
+        , targetDialect = CodexDialect
+        }
 
 legacyMeta :: SubagentDiskMeta
-legacyMeta = SubagentDiskMeta
+legacyMeta =
+    LegacySubagentDiskMeta
+        emptyDiskFields
+        LegacySubagentTargetFields
+            { legacyDiskProvider = Nothing
+            , legacyDiskConnection = Nothing
+            , legacyDiskEffectiveModel = Nothing
+            , legacyDiskDialect = Nothing
+            }
+
+emptyDiskFields :: SubagentDiskFields
+emptyDiskFields = SubagentDiskFields
     { diskPreviousResponseId = Nothing
     , diskStatus = Nothing
-    , diskProvider = Nothing
-    , diskConnection = Nothing
-    , diskEffectiveModel = Nothing
-    , diskDialect = Nothing
     , diskAgentType = Nothing
     , diskAgentModel = Nothing
     , diskReasoningEffort = Nothing
@@ -486,6 +549,32 @@ legacyMeta = SubagentDiskMeta
     , diskParentId = Nothing
     , diskDepth = Nothing
     }
+
+testSnapshot
+    :: [ResponseItem]
+    -> SubagentStatus
+    -> Provider
+    -> Text
+    -> Text
+    -> DialectId
+    -> SubagentStateSnapshot
+testSnapshot items status provider connection effectiveModel dialect =
+    SubagentStateSnapshot
+        { snapshotItems = items
+        , snapshotPreviousResponseId = Nothing
+        , snapshotStatus = status
+        , snapshotTarget = SubagentTarget
+            { targetProvider = provider
+            , targetConnection = connection
+            , targetEffectiveModel = effectiveModel
+            , targetDialect = dialect
+            }
+        , snapshotAgentType = Nothing
+        , snapshotAgentModel = Nothing
+        , snapshotReasoningEffort = Nothing
+        , snapshotCwd = Nothing
+        , snapshotIdentity = Nothing
+        }
 
 isLeft :: Either a b -> Bool
 isLeft = \case


### PR DESCRIPTION
## Summary
- split persisted subagent metadata into explicit current and legacy representations
- make current target metadata complete while retaining backward-compatible legacy decoding
- replace the long positional save API with a named snapshot record
- normalize legacy targets once and reuse the current validation path

## Validation
- focused subagent-store tests: 16 examples, 0 failures
- combined agent-cli suite: 753 examples, 0 failures
- agent-cli library build succeeded
- `git diff --check`
