### PR TITLE
Index retained TUI blocks by stable position

### DIFF
--- a/packages/agent-tui/src/Agent/TUI/Model.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model.hs
@@ -140,6 +140,8 @@ data UiState = UiState
     , uiQueuedInputs :: !(Seq Text)
     , uiFocus :: !Focus
     , uiSelectedBlock :: !(Maybe BlockId)
+    , uiSelectedBlockIndex :: !(Maybe Int)
+    , uiBlockIndices :: !(Map.Map BlockId Int)
     , uiFollow :: !Bool
     , uiRunning :: !Bool
     , uiAwaitingInput :: !Bool
@@ -153,7 +155,7 @@ data UiState = UiState
     , uiElapsedMillis :: !Int
     , uiCompletionRemainingMillis :: !Int
     , uiTurnStartBlock :: !Int
-    , uiToolCalls :: !(Map.Map Text ToolCall)
+    , uiToolCalls :: !(Map.Map Text (Int, ToolCall))
     }
     deriving (Eq, Show)
 
@@ -196,6 +198,8 @@ initialUiState = UiState
     , uiQueuedInputs = Seq.empty
     , uiFocus = FocusComposer
     , uiSelectedBlock = Nothing
+    , uiSelectedBlockIndex = Nothing
+    , uiBlockIndices = Map.empty
     , uiFollow = True
     , uiRunning = False
     , uiAwaitingInput = False
@@ -345,8 +349,11 @@ reduceUi event state = case event of
         state
             { uiBlocks = Seq.empty
             , uiSelectedBlock = Nothing
+            , uiSelectedBlockIndex = Nothing
+            , uiBlockIndices = Map.empty
             , uiNextBlockId = 1
             , uiTurnStartBlock = 0
+            , uiToolCalls = Map.empty
             }
     UiSetFollow follow ->
         state
@@ -357,12 +364,28 @@ reduceUi event state = case event of
                         (Seq.length state.uiBlocks - 1)
                         state.uiBlocks
                     else state.uiSelectedBlock
+            , uiSelectedBlockIndex =
+                if follow
+                    then
+                        if Seq.null state.uiBlocks
+                            then Nothing
+                            else Just (Seq.length state.uiBlocks - 1)
+                    else state.uiSelectedBlockIndex
             }
     UiTurnEnded terminalState ->
         finalizeTurn terminalState state
     UiTurnRestarted ->
-        state
-            { uiBlocks = Seq.take state.uiTurnStartBlock state.uiBlocks
+        let blocks = Seq.take state.uiTurnStartBlock state.uiBlocks
+            selected =
+                selectionAfterTruncate
+                    blocks
+                    state.uiSelectedBlockIndex
+        in state
+            { uiBlocks = blocks
+            , uiSelectedBlock = (.blockId) . snd <$> selected
+            , uiSelectedBlockIndex = fst <$> selected
+            , uiBlockIndices =
+                Map.filter (< Seq.length blocks) state.uiBlockIndices
             , uiRunning = False
             , uiActivity = "Restarting…"
             , uiNotice =
@@ -467,6 +490,7 @@ reduceLoop event state = case event of
     ToolStarted call ->
         let
             kind = toolBlockKind call.name
+            blockIndex = Seq.length state.uiBlocks
             body = case call.name of
                 "search_replace" ->
                     formatSearchReplaceDiff call.arguments
@@ -477,22 +501,33 @@ reduceLoop event state = case event of
                 { uiRunning = True
                 , uiAwaitingInput = False
                 , uiActivity = summarizeToolCall call
-                , uiToolCalls = Map.insert call.callId call state.uiToolCalls
+                , uiToolCalls =
+                    Map.insert
+                        call.callId
+                        (blockIndex, call)
+                        state.uiToolCalls
                 }
     ToolOutputUpdated callId output ->
         updateToolOutput callId output state
     ToolFinished result ->
-        let displayed = case Map.lookup result.callId state.uiToolCalls of
+        let activeCall = Map.lookup result.callId state.uiToolCalls
+            displayed = case activeCall of
                 Nothing -> result
-                Just call ->
+                Just (_, call) ->
                     result
                         { output = formatToolOutput call result.output }
-        in completeTool displayed state
-            { uiRunning = True
-            , uiAwaitingInput = False
-            , uiActivity = "Thinking…"
-            , uiToolCalls = Map.delete result.callId state.uiToolCalls
-            }
+            next =
+                state
+                    { uiRunning = True
+                    , uiAwaitingInput = False
+                    , uiActivity = "Thinking…"
+                    , uiToolCalls =
+                        Map.delete result.callId state.uiToolCalls
+                    }
+        in case activeCall of
+            Nothing -> next
+            Just (blockIndex, _) ->
+                completeTool blockIndex displayed next
     TurnFinished output ->
         let finalized = finalizeStreams state
             continuing = not (null output.toolCalls)
@@ -546,7 +581,8 @@ appendBlock
     -> UiState
     -> UiState
 appendBlock kind title body detail blockState callId state =
-    let ident = BlockId state.uiNextBlockId
+    let index = Seq.length state.uiBlocks
+        ident = BlockId state.uiNextBlockId
         block = UiBlock
             { blockId = ident
             , blockKind = kind
@@ -562,13 +598,15 @@ appendBlock kind title body detail blockState callId state =
         { uiBlocks = state.uiBlocks Seq.|> block
         , uiNextBlockId = state.uiNextBlockId + 1
         , uiSelectedBlock = Just ident
+        , uiSelectedBlockIndex = Just index
+        , uiBlockIndices = Map.insert ident index state.uiBlockIndices
         }
 
-completeTool :: ToolCallResult -> UiState -> UiState
-completeTool result state =
+completeTool :: Int -> ToolCallResult -> UiState -> UiState
+completeTool blockIndex result state =
     state
         { uiBlocks =
-            fmap
+            Seq.adjust
                 (\block ->
                     if block.blockCallId == Just result.callId
                         then block
@@ -576,21 +614,26 @@ completeTool result state =
                             , blockState = toolResultState result.output
                             }
                         else block)
+                blockIndex
                 state.uiBlocks
         }
 
 updateToolOutput :: Text -> Text -> UiState -> UiState
 updateToolOutput callId output state =
-    state
-        { uiBlocks =
-            fmap
-                (\block ->
-                    if block.blockCallId == Just callId
-                        && block.blockState == BlockRunning
-                        then block { blockBody = output }
-                        else block)
-                state.uiBlocks
-        }
+    case Map.lookup callId state.uiToolCalls of
+        Nothing -> state
+        Just (blockIndex, _) ->
+            state
+                { uiBlocks =
+                    Seq.adjust
+                        (\block ->
+                            if block.blockCallId == Just callId
+                                && block.blockState == BlockRunning
+                                then block { blockBody = output }
+                                else block)
+                        blockIndex
+                        state.uiBlocks
+                }
 
 finalizeTurn :: BlockState -> UiState -> UiState
 finalizeTurn terminalState state =
@@ -666,10 +709,15 @@ hasAssistantTextSince start =
 moveSelection :: Int -> UiState -> UiState
 moveSelection delta state =
     case Seq.lookup next blocks of
-        Nothing -> state { uiSelectedBlock = Nothing }
+        Nothing ->
+            state
+                { uiSelectedBlock = Nothing
+                , uiSelectedBlockIndex = Nothing
+                }
         Just block ->
             state
                 { uiSelectedBlock = Just block.blockId
+                , uiSelectedBlockIndex = Just next
                 , uiFollow = next == lastIndex
                 }
   where
@@ -679,22 +727,24 @@ moveSelection delta state =
 
 selectBlock :: BlockId -> UiState -> UiState
 selectBlock ident state =
-    case Seq.findIndexL ((== ident) . (.blockId)) state.uiBlocks of
+    case Map.lookup ident state.uiBlockIndices of
         Nothing -> state
-        Just index ->
-            state
-                { uiSelectedBlock = Just ident
-                , uiFollow = index == Seq.length state.uiBlocks - 1
-                }
+        Just index -> case Seq.lookup index state.uiBlocks of
+            Just block
+                | block.blockId == ident ->
+                    state
+                        { uiSelectedBlock = Just ident
+                        , uiSelectedBlockIndex = Just index
+                        , uiFollow =
+                            index == Seq.length state.uiBlocks - 1
+                        }
+            _ -> state
 
 selectedBlockIndex :: UiState -> Int
 selectedBlockIndex state =
-    case state.uiSelectedBlock of
-        Nothing -> max 0 (Seq.length state.uiBlocks - 1)
-        Just ident ->
-            case Seq.findIndexL ((== ident) . (.blockId)) state.uiBlocks of
-                Nothing -> max 0 (Seq.length state.uiBlocks - 1)
-                Just index -> index
+    maybe fallback fst (selectedBlockEntry state)
+  where
+    fallback = max 0 (Seq.length state.uiBlocks - 1)
 
 -- | Delete whitespace and the previous non-whitespace word before the cursor.
 deleteWordBefore :: Text -> Int -> (Text, Int)
@@ -765,19 +815,41 @@ moveWordRight text cursor =
 
 toggleSelected :: UiState -> UiState
 toggleSelected state =
-    case state.uiSelectedBlock of
+    case selectedBlockEntry state of
         Nothing -> state
-        Just ident ->
+        Just (index, _) ->
             state
                 { uiBlocks =
-                    fmap
+                    Seq.adjust
                         (\block ->
-                            if block.blockId == ident
-                                then block
-                                    { blockExpanded = not block.blockExpanded }
-                                else block)
+                            block
+                                { blockExpanded = not block.blockExpanded })
+                        index
                         state.uiBlocks
                 }
+
+selectedBlockEntry :: UiState -> Maybe (Int, UiBlock)
+selectedBlockEntry state = do
+    ident <- state.uiSelectedBlock
+    index <- state.uiSelectedBlockIndex
+    storedIndex <- Map.lookup ident state.uiBlockIndices
+    block <- Seq.lookup index state.uiBlocks
+    if storedIndex == index && block.blockId == ident
+        then Just (index, block)
+        else Nothing
+
+selectionAfterTruncate
+    :: Seq UiBlock
+    -> Maybe Int
+    -> Maybe (Int, UiBlock)
+selectionAfterTruncate blocks selected =
+    case selected of
+        Just index
+            | Just block <- Seq.lookup index blocks ->
+                Just (index, block)
+        _ ->
+            let index = Seq.length blocks - 1
+            in (\block -> (index, block)) <$> Seq.lookup index blocks
 
 toolBlockKind :: Text -> BlockKind
 toolBlockKind rawName

--- a/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
@@ -73,6 +73,48 @@ spec = describe "fullscreen UI reducer" do
             `shouldBe` Just
                 (progressNotice "Restarting current turn…")
 
+    it "keeps block positions and selection stable across restart, append, and clear" do
+        let restarted =
+                apply
+                    [ UiUserSubmitted "try this"
+                    , UiLoop TurnStarted
+                    , UiLoop (ReasoningDelta "partial thought")
+                    , UiLoop (TextDelta "partial answer")
+                    , UiTurnRestarted
+                    ]
+            appended =
+                reduceUi
+                    (UiSystemMessage "retrying")
+                    restarted
+            toggled = reduceUi UiToggleSelected appended
+            cleared = reduceUi UiConversationCleared toggled
+            repopulated =
+                reduceUi
+                    (UiUserSubmitted "fresh start")
+                    cleared
+        map (.blockId) (Foldable.toList restarted.uiBlocks)
+            `shouldBe` [BlockId 1]
+        restarted.uiSelectedBlock `shouldBe` Just (BlockId 1)
+        restarted.uiSelectedBlockIndex `shouldBe` Just 0
+        selectedBlockIndex restarted `shouldBe` 0
+        restarted.uiNextBlockId `shouldBe` 4
+        map (.blockId) (Foldable.toList appended.uiBlocks)
+            `shouldBe` [BlockId 1, BlockId 4]
+        appended.uiSelectedBlock `shouldBe` Just (BlockId 4)
+        appended.uiSelectedBlockIndex `shouldBe` Just 1
+        selectedBlockIndex appended `shouldBe` 1
+        map (.blockExpanded) (Foldable.toList toggled.uiBlocks)
+            `shouldBe` [True, False]
+        cleared.uiBlocks `shouldBe` mempty
+        cleared.uiSelectedBlock `shouldBe` Nothing
+        cleared.uiSelectedBlockIndex `shouldBe` Nothing
+        cleared.uiBlockIndices `shouldBe` mempty
+        cleared.uiNextBlockId `shouldBe` 1
+        map (.blockId) (Foldable.toList repopulated.uiBlocks)
+            `shouldBe` [BlockId 1]
+        repopulated.uiSelectedBlock `shouldBe` Just (BlockId 1)
+        repopulated.uiSelectedBlockIndex `shouldBe` Just 0
+
     it "clears a cancellation progress notice when the turn ends" do
         let state =
                 apply
@@ -166,6 +208,131 @@ spec = describe "fullscreen UI reducer" do
             blocks = Foldable.toList state.uiBlocks
         map (.blockBody) blocks `shouldBe` ["first output", ""]
         map (.blockState) blocks `shouldBe` [BlockRunning, BlockRunning]
+
+    it "tracks active tool calls by their exact block positions" do
+        let first =
+                functionToolCall
+                    "c1"
+                    "run_terminal_cmd"
+                    "{\"command\":\"first\"}"
+            second =
+                functionToolCall
+                    "c2"
+                    "run_terminal_cmd"
+                    "{\"command\":\"second\"}"
+            running =
+                apply
+                    [ UiUserSubmitted "run both"
+                    , UiLoop TurnStarted
+                    , UiLoop (ToolStarted first)
+                    , UiSystemMessage "between tools"
+                    , UiLoop (ToolStarted second)
+                    ]
+            firstUpdated =
+                reduceUi
+                    (UiLoop (ToolOutputUpdated "c1" "first output"))
+                    running
+            secondFinished =
+                reduceUi
+                    (UiLoop
+                        (ToolFinished
+                            ToolCallResult
+                                { callId = "c2"
+                                , output = "exit: 0\nsecond output"
+                                , callKind = FunctionCallKind
+                                }))
+                    firstUpdated
+            blocks = Foldable.toList secondFinished.uiBlocks
+        Foldable.toList running.uiToolCalls
+            `shouldBe` [(1, first), (3, second)]
+        map (.blockBody) blocks
+            `shouldBe`
+                [ "run both"
+                , "first output"
+                , "between tools"
+                , "exit: 0\nsecond output"
+                ]
+        map (.blockState) blocks
+            `shouldBe`
+                [ BlockComplete
+                , BlockRunning
+                , BlockComplete
+                , BlockComplete
+                ]
+        Foldable.toList secondFinished.uiToolCalls
+            `shouldBe` [(1, first)]
+
+    it "drops tool block positions when the conversation is cleared" do
+        let call =
+                functionToolCall
+                    "c1"
+                    "run_terminal_cmd"
+                    "{\"command\":\"work\"}"
+            result = ToolCallResult
+                { callId = "c1"
+                , output = "exit: 0\nlate final output"
+                , callKind = FunctionCallKind
+                }
+            started =
+                apply
+                    [ UiLoop TurnStarted
+                    , UiLoop (ToolStarted call)
+                    ]
+            cleared = reduceUi UiConversationCleared started
+            reused =
+                reduceUi
+                    (UiUserSubmitted "replacement block")
+                    cleared
+            afterLateEvents =
+                applyFrom
+                    reused
+                    [ UiLoop (ToolOutputUpdated "c1" "late live output")
+                    , UiLoop (ToolFinished result)
+                    ]
+        cleared.uiToolCalls `shouldBe` mempty
+        case Foldable.toList afterLateEvents.uiBlocks of
+            [block] -> do
+                block.blockKind `shouldBe` BlockUser
+                block.blockBody `shouldBe` "replacement block"
+                block.blockState `shouldBe` BlockComplete
+            _ -> expectationFailure "expected one replacement block"
+
+    it "drops tool block positions when the current turn is restarted" do
+        let call =
+                functionToolCall
+                    "c1"
+                    "run_terminal_cmd"
+                    "{\"command\":\"work\"}"
+            result = ToolCallResult
+                { callId = "c1"
+                , output = "exit: 0\nlate final output"
+                , callKind = FunctionCallKind
+                }
+            started =
+                apply
+                    [ UiUserSubmitted "run work"
+                    , UiLoop TurnStarted
+                    , UiLoop (ToolStarted call)
+                    ]
+            restarted = reduceUi UiTurnRestarted started
+            reused =
+                reduceUi
+                    (UiSystemMessage "replacement block")
+                    restarted
+            afterLateEvents =
+                applyFrom
+                    reused
+                    [ UiLoop (ToolOutputUpdated "c1" "late live output")
+                    , UiLoop (ToolFinished result)
+                    ]
+        restarted.uiToolCalls `shouldBe` mempty
+        case Foldable.toList afterLateEvents.uiBlocks of
+            [userBlock, replacementBlock] -> do
+                userBlock.blockBody `shouldBe` "run work"
+                replacementBlock.blockKind `shouldBe` BlockSystem
+                replacementBlock.blockBody `shouldBe` "replacement block"
+                replacementBlock.blockState `shouldBe` BlockComplete
+            _ -> expectationFailure "expected retained and replacement blocks"
 
     it "replaces a live snapshot with the final tool result" do
         let call = functionToolCall "c1" "run_terminal_cmd" "{\"command\":\"work\"}"
@@ -512,6 +679,9 @@ spec = describe "fullscreen UI reducer" do
 
 apply :: [UiEvent] -> UiState
 apply events = foldl (flip reduceUi) initialUiState events
+
+applyFrom :: UiState -> [UiEvent] -> UiState
+applyFrom = foldl (flip reduceUi)
 
 toolStateFor :: Text -> BlockState
 toolStateFor output =


### PR DESCRIPTION
## Summary
- track selected blocks by stable sequence position alongside their public block IDs
- associate active tool calls with their retained block positions
- use indexed sequence updates for selection toggles, tool snapshots, and completion
- preserve correct indices through restart truncation, clear, and later appends

## Validation
- agent-tui suite: 111 examples, 0 failures
- combined agent-cli suite: 753 examples, 0 failures
- agent-tui and agent-cli library builds succeeded
- live fullscreen agent exercised in tmux; retained TUI rendered successfully
- `git diff --check`
