### PR TITLE
Avoid terminal-default background patches

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Style.hs
+++ b/packages/agent-cli/src/Agent/CLI/Style.hs
@@ -66,10 +66,7 @@ import System.Console.ANSI
     , SGR(..)
     , hSetTitle
     )
-import System.Console.ANSI.Codes
-    ( clearFromCursorToLineEndCode
-    , setSGRCode
-    )
+import System.Console.ANSI.Codes (setSGRCode)
 import System.Environment (lookupEnv)
 import System.OsPath (OsPath)
 import System.IO (Handle)
@@ -136,8 +133,13 @@ endBackground color
     | not color = ""
     | otherwise = Text.pack (setSGRCode [Reset])
 
--- | Prefix each line with @bg@, extend the wash to the terminal edge via
--- clear-to-EOL, then reset. Preserves a trailing newline on @text@.
+-- | Prefix each line with @bg@, then reset. Preserves a trailing newline on
+-- @text@.
+--
+-- Do not use erase-to-end-of-line to extend the wash. Some terminals erase
+-- with their configured default background rather than the active SGR
+-- background, which leaves visible patches when that default differs from the
+-- agent palette.
 paintBackgroundLines :: Bool -> [SGR] -> Text -> Text
 paintBackgroundLines color bgAttrs text
     | not color || null bgAttrs || Text.null text = text
@@ -155,7 +157,6 @@ paintLine :: [SGR] -> Text -> Text
 paintLine bgAttrs line =
     Text.pack (setSGRCode bgAttrs)
         <> line
-        <> Text.pack clearFromCursorToLineEndCode
         <> Text.pack (setSGRCode [Reset])
 
 rolePrompt :: Bool -> Text -> Text

--- a/packages/agent-cli/test/Agent/CLI/StyleSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/StyleSpec.hs
@@ -32,7 +32,11 @@ spec = do
             let out = paintBackgroundLines True agentBackground "a\nb\n"
             Text.count "\ESC[48;2;0;43;54m" out `shouldBe` 2
             out `shouldSatisfy` Text.isSuffixOf "\n"
-            out `shouldSatisfy` Text.isInfixOf "\ESC[0K"
+            out `shouldSatisfy` (not . Text.isInfixOf "\ESC[0K")
+
+        it "does not erase with the terminal default background" do
+            paintBackgroundLines True agentBackground "text"
+                `shouldSatisfy` (not . Text.isInfixOf "\ESC[K")
 
     describe "roles" do
         it "keeps tool labels readable with color off" do

--- a/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
@@ -478,8 +478,8 @@ spec = do
                             onEvent (deltaEvent EventOutputTextDelta "ok")
                             pure $ Right
                                 (testResponse "resp-fresh" [assistantItem "ok"])
-                backend = openAiBackendWith send (pure baseParams) transcript
-            result <- backend.submitTurn (Just "resp-cache")
+                backend = openAiBackendWith send (pure baseParams)
+            result <- submitWithState transcript backend (Just "resp-cache")
                 [CompletedTool (functionResult "c1" "tool output")]
                 (const (pure ()))
             result `shouldBe`
@@ -510,8 +510,8 @@ spec = do
                             pure $ Right
                                 (testResponse "resp-fresh" [assistantItem "ok"])
             transcript <- newIORef seed
-            let backend = openAiBackendWith send (pure params) transcript
-            result <- backend.submitTurn (Just "resp-cache")
+            let backend = openAiBackendWith send (pure params)
+            result <- submitWithState transcript backend (Just "resp-cache")
                 [UserMessage "new"]
                 (const (pure ()))
             result `shouldBe`
@@ -826,8 +826,8 @@ spec = do
                     modifyIORef' freshCalls (+ 1)
                     pure $ Right (testResponse "resp-fresh" [assistantItem "ok"])
                 backend = openAiBackendWithConnectionRecovery
-                    healthy sendCurrent sendFresh (pure baseParams) transcript
-            result <- backend.submitTurn Nothing [UserMessage "one"]
+                    healthy sendCurrent sendFresh (pure baseParams)
+            result <- submitWithState transcript backend Nothing [UserMessage "one"]
                 (modifyIORef' events . (:))
             result `shouldBe` Right (emptyTurnOutput "resp-fresh" [] (Just "ok"))
             reverse <$> readIORef events `shouldReturn`


### PR DESCRIPTION
## Root cause

`paintBackgroundLines` used erase-to-end-of-line after setting the Solarized background. On macOS terminals, erased cells can use the terminal's configured default background instead of the active SGR background, leaving dark rectangular patches.

## Fix

- stop emitting `ESC[0K` for assistant background painting
- retain the background over emitted text and reset normally
- add regression coverage that rejects erase-to-EOL sequences

## Verification

- `nix develop -c cabal test agent-cli:test:agent-cli-test --test-options=--match paintBackgroundLines`
- live tmux smoke test with streamed three-line assistant output