### PR TITLE
refactor: remove unnecessary local IORefs

### DIFF
--- a/packages/agent-codex-dialect/src/Agent/Codex/Dialect/Tools.hs
+++ b/packages/agent-codex-dialect/src/Agent/Codex/Dialect/Tools.hs
@@ -65,7 +65,6 @@ import Control.Applicative ((<|>))
 import Data.Aeson (FromJSON(..), Value(..), withObject)
 import qualified Data.Aeson.KeyMap as KeyMap
 import Data.Aeson.Types (parseFail)
-import Data.IORef
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -77,15 +76,14 @@ codexTools
     -> PlanModeEnv
     -> Maybe MultiAgentContext
     -> IO [AppTool]
-codexTools env shellSession ghci planMode multi = do
-    planRef <- newIORef []
+codexTools env shellSession ghci planMode multi =
     pure $
         [ runGhciTool ghci
         , readFileTool env
         , grepTool env
         , listDirTool env
         , applyPatchTool env
-        , updatePlanTool planMode planRef
+        , updatePlanTool planMode
         , enterCodexPlanModeTool planMode
         , writePlanTool planMode
         , askUserQuestionTool planMode
@@ -314,8 +312,8 @@ instance FromJSON UpdatePlanArgs where
             Just value -> parseJSON value
         pure UpdatePlanArgs { explanation, plan }
 
-updatePlanTool :: PlanModeEnv -> IORef [PlanItem] -> AppTool
-updatePlanTool planMode planRef = jsonTool "update_plan" updatePlanDescription
+updatePlanTool :: PlanModeEnv -> AppTool
+updatePlanTool planMode = jsonTool "update_plan" updatePlanDescription
     [ PropertySchema "explanation" PropertyString False $ Just
         "Optional explanation for this plan update."
     , PropertySchema "plan" (PropertyArray (PropertyObject
@@ -326,7 +324,7 @@ updatePlanTool planMode planRef = jsonTool "update_plan" updatePlanDescription
     ]
     True
     TurnSequential
-    (typedTool "update_plan" (runUpdatePlan planMode planRef))
+    (typedTool "update_plan" (runUpdatePlan planMode))
 
 updatePlanDescription :: Text
 updatePlanDescription =
@@ -335,28 +333,27 @@ updatePlanDescription =
     \At most one step can be in_progress at a time.\n\
     \This is a progress checklist, not Plan Mode. It errors while Plan Mode is active."
 
-runUpdatePlan :: PlanModeEnv -> IORef [PlanItem] -> UpdatePlanArgs -> IO (Either Text Text)
-runUpdatePlan planMode planRef args = do
+runUpdatePlan :: PlanModeEnv -> UpdatePlanArgs -> IO (Either Text Text)
+runUpdatePlan planMode args = do
     active <- isPlanModeActive planMode
     if active
         then pure $ Left
             "update_plan is unavailable in Plan Mode. Write the design to plan.md \
             \and present it with a <proposed_plan> block when ready."
-        else runUpdatePlanBody planRef args
+        else pure (runUpdatePlanBody args)
 
-runUpdatePlanBody :: IORef [PlanItem] -> UpdatePlanArgs -> IO (Either Text Text)
-runUpdatePlanBody planRef args
+runUpdatePlanBody :: UpdatePlanArgs -> Either Text Text
+runUpdatePlanBody args
     | any (\item -> item.status `notElem` ["pending", "in_progress", "completed"]) args.plan =
-        pure (Left "Each plan status must be pending, in_progress, or completed.")
+        Left "Each plan status must be pending, in_progress, or completed."
     | length (filter (\item -> item.status == "in_progress") args.plan) > 1 =
-        pure (Left "At most one step can be in_progress at a time.")
-    | otherwise = do
-        writeIORef planRef args.plan
+        Left "At most one step can be in_progress at a time."
+    | otherwise =
         let rendered = Text.unlines (map renderItem args.plan)
             header = case args.explanation of
                 Nothing -> "Plan updated:\n"
                 Just explanation -> explanation <> "\nPlan updated:\n"
-        pure $ Right (header <> rendered)
+        in Right (header <> rendered)
   where
     renderItem :: PlanItem -> Text
     renderItem item = "- [" <> item.status <> "] " <> item.step

--- a/packages/agent-openai/src/Agent/OpenAI/WebSocketClient.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/WebSocketClient.hs
@@ -58,7 +58,6 @@ import qualified Control.Exception as Exception
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.KeyMap as KeyMap
 import qualified Data.ByteString.Lazy as LBS
-import Data.IORef
 import Data.Int (Int64)
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -403,75 +402,66 @@ receiveWsResponseWithActions
     -> WebSocketReceiveActions
     -> StreamEventCallback
     -> IO (Either ApiError Response)
-receiveWsResponseWithActions modelHint actions onEvent = do
-    assemblyRef <- newIORef emptyStreamAssemblyState
-    framesRef <- newIORef (0 :: Int)
-    bytesRef <- newIORef (0 :: Int64)
-    loop assemblyRef framesRef bytesRef
+receiveWsResponseWithActions modelHint actions onEvent =
+    loop emptyStreamAssemblyState 0 0
   where
-    loop assemblyRef framesRef bytesRef = do
+    loop assembly frames bytes = do
         msgResult <- actions.receiveFrame
         case msgResult of
             Left e -> do
-                logStreamStats "connection_error" framesRef bytesRef
+                logStreamStats "connection_error" frames bytes
                 pure $ Left e
             Right (msgBytes :: LBS.ByteString) -> do
-                recordFrame framesRef bytesRef msgBytes
+                let frames' = frames + 1
+                    bytes' = bytes + LBS.length msgBytes
                 case ResponsesCodec.decodeResponseStreamEvent msgBytes of
                     Left err -> do
                         let msgPreview = Text.decodeUtf8With Text.lenientDecode (LBS.toStrict msgBytes)
-                        logStreamStats "json_decode_error" framesRef bytesRef
+                        logStreamStats "json_decode_error" frames' bytes'
                         actions.invalidateRequest
                             "received a malformed response frame"
                         pure $ Left (JsonDecodeError (Text.pack err) (Text.take 500 msgPreview))
                     Right event -> do
                         onEvent event
-                        modifyIORef' assemblyRef (`applyStreamEvent` event)
+                        let assembly' = applyStreamEvent assembly event
                         case event of
                             ResponseErrorEvent { streamError } -> do
-                                logStreamStats "error_event" framesRef bytesRef
+                                logStreamStats "error_event" frames' bytes'
                                 actions.completeRequest
                                 pure $ Left (parseWsErrorEvent streamError)
 
                             ResponseNestedErrorEvent { streamError } -> do
-                                logStreamStats "error_event" framesRef bytesRef
+                                logStreamStats "error_event" frames' bytes'
                                 actions.completeRequest
                                 pure $ Left (parseWsErrorEvent streamError)
 
                             ResponseCompletedEvent{} ->
-                                finishTerminal "completed" assemblyRef framesRef bytesRef event
+                                finishTerminal "completed" assembly' frames' bytes' event
 
                             ResponseDoneEvent{} ->
-                                finishTerminal "done" assemblyRef framesRef bytesRef event
+                                finishTerminal "done" assembly' frames' bytes' event
 
                             ResponseIncompleteEvent{} ->
-                                finishTerminal "incomplete" assemblyRef framesRef bytesRef event
+                                finishTerminal "incomplete" assembly' frames' bytes' event
 
                             ResponseFailedEvent{} -> do
-                                state <- readIORef assemblyRef
-                                logStreamStats "response_failed" framesRef bytesRef
+                                logStreamStats "response_failed" frames' bytes'
                                 actions.completeRequest
                                 pure $ Left
                                     (failedResponseError
-                                        (responseFailureFromState state))
+                                        (responseFailureFromState assembly'))
 
                             -- Ignore other event variants (added, content
                             -- deltas, and future event types).
-                            _ -> loop assemblyRef framesRef bytesRef
+                            _ -> loop assembly' frames' bytes'
 
-    finishTerminal label assemblyRef framesRef bytesRef event = do
-        state <- readIORef assemblyRef
-        logStreamStats label framesRef bytesRef
+    finishTerminal label assembly frames bytes event = do
+        logStreamStats label frames bytes
         actions.completeRequest
-        pure (finishStreamResponse modelHint state event)
+        pure (finishStreamResponse modelHint assembly event)
 
-    recordFrame :: IORef Int -> IORef Int64 -> LBS.ByteString -> IO ()
-    recordFrame framesRef bytesRef msgBytes = do
-        modifyIORef' framesRef (+ 1)
-        modifyIORef' bytesRef (+ LBS.length msgBytes)
-
-    logStreamStats :: Text -> IORef Int -> IORef Int64 -> IO ()
-    logStreamStats _label _framesRef _bytesRef = pure ()
+    logStreamStats :: Text -> Int -> Int64 -> IO ()
+    logStreamStats _label _frames _bytes = pure ()
 
     failedResponseError failure =
         case failure.failureErrorType


### PR DESCRIPTION
## Summary
- remove the write-only Codex update-plan IORef and make plan rendering pure
- thread OpenAI WebSocket assembly and frame counters through the receive loop

## Verification
- `nix develop -c cabal repl agent-codex-dialect:lib:agent-codex-dialect agent-openai:lib:agent-openai --repl-options=-fno-code`
- `nix develop -c cabal test agent-codex-dialect:test:agent-codex-dialect-test agent-openai:test:agent-openai-test --test-show-details=direct`
- 3 Codex examples passed; 208 OpenAI examples passed; 1 live-auth test remained pending

The shell snapshot ref, session-title parameter ref, and runtime dialect refs are intentionally retained for now because they coordinate concurrent/runtime state or remain mutable configuration. These are deferred to their dedicated PRs.