### PR TITLE
Refactor mutable counters under their session owners

### DIFF
--- a/packages/agent-codex-dialect/src/Agent/Codex/Dialect/Shell.hs
+++ b/packages/agent-codex-dialect/src/Agent/Codex/Dialect/Shell.hs
@@ -38,7 +38,6 @@ import Control.Concurrent.MVar
     )
 import Control.Exception.Safe (SomeException, mask, onException, try)
 import Control.Monad (void, when)
-import Data.IORef (IORef, atomicModifyIORef', newIORef, readIORef, writeIORef)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Text (Text)
@@ -56,17 +55,17 @@ data CodexShellResult
 data ManagedCommand = ManagedCommand
     { managedRunning :: !RunningCommand
     , managedLock :: !(MVar ())
-    , managedCursor :: !(IORef RunningOutputCursor)
+    , managedCursor :: !(MVar RunningOutputCursor)
     }
 
 data SessionStore = SessionStore
-    { storeCommands :: !(Map Int ManagedCommand)
+    { storeNextId :: !Int
+    , storeCommands :: !(Map Int ManagedCommand)
     }
 
 data CodexShellSession = CodexShellSession
     { sessionEnv :: !ToolEnv
     , sessionCommands :: !(MVar (Maybe SessionStore))
-    , sessionNextId :: !(IORef Int)
     }
 
 maxManagedCommands :: Int
@@ -75,12 +74,12 @@ maxManagedCommands = 64
 newCodexShellSession :: ToolEnv -> IO CodexShellSession
 newCodexShellSession env = do
     commands <- newMVar $ Just SessionStore
-        { storeCommands = Map.empty }
-    nextId <- newIORef 0
+        { storeNextId = 0
+        , storeCommands = Map.empty
+        }
     pure CodexShellSession
         { sessionEnv = env
         , sessionCommands = commands
-        , sessionNextId = nextId
         }
 
 -- | Stop and join every retained command. Closing is idempotent.
@@ -241,17 +240,10 @@ runningResult commandId task = do
         }
 
 takeRunningOutput :: ManagedCommand -> IO (Text, Text)
-takeRunningOutput task = do
-    cursor <- readIORef task.managedCursor
+takeRunningOutput task =
+  modifyMVar task.managedCursor \cursor -> do
     (output, nextCursor) <- runningOutputSince task.managedRunning cursor
-    writeIORef task.managedCursor nextCursor
-    pure output
-
-nextCommandId :: CodexShellSession -> IO Int
-nextCommandId session =
-    atomicModifyIORef' session.sessionNextId \current ->
-        let next = current + 1
-        in (next, next)
+    pure (nextCursor, output)
 
 startManagedCommand
     :: CodexShellSession
@@ -280,16 +272,17 @@ startManagedCommand session workdir command =
                         Right running -> do
                             prepared <-
                                 (do
-                                    commandId <- nextCommandId session
+                                    let commandId = store.storeNextId + 1
                                     task <- ManagedCommand running
                                         <$> newMVar ()
-                                        <*> newIORef initialRunningOutputCursor
+                                        <*> newMVar initialRunningOutputCursor
                                     pure (commandId, task))
                                     `onException` stopShellCommand running
                             let (commandId, task) = prepared
                             pure
                                 ( Just store
-                                    { storeCommands =
+                                    { storeNextId = commandId
+                                    , storeCommands =
                                         Map.insert
                                             commandId
                                             task

--- a/packages/agent-core/src/Agent/Subagents/Registry.hs
+++ b/packages/agent-core/src/Agent/Subagents/Registry.hs
@@ -117,7 +117,6 @@ import Agent.Subagents.TaskPath
     , taskPathRoot
     , taskPathText
     )
-import System.IO.Unsafe (unsafePerformIO)
 
 data SubagentRecord = SubagentRecord
     { recordId :: !SubagentId
@@ -206,6 +205,7 @@ data SubagentRegistry = SubagentRegistry
     , registryOnSettledRef :: !(IORef (SubagentId -> SubagentStatus -> IO ()))
     , registryCwd :: !OsPath
     , registryClosed :: !(TVar Bool)
+    , registryNextSubagentId :: !(TVar Int)
     , registryNextRootTurnId :: !(TVar Word64)
     , registryAbortedRootTurns :: !(TVar (Set RootTurnId))
     , registryLifecycle :: !(MVar ())
@@ -225,6 +225,7 @@ newSubagentRegistry config cwd run onEvent = do
     waitCursors <- newTVarIO Map.empty
     activeWaits <- newTVarIO Map.empty
     closed <- newTVarIO False
+    nextSubagentId <- newTVarIO 0
     nextRootTurnId <- newTVarIO 0
     abortedRootTurns <- newTVarIO Set.empty
     lifecycle <- newMVar ()
@@ -247,6 +248,7 @@ newSubagentRegistry config cwd run onEvent = do
         , registryOnSettledRef = onSettledRef
         , registryCwd = cwd
         , registryClosed = closed
+        , registryNextSubagentId = nextSubagentId
         , registryNextRootTurnId = nextRootTurnId
         , registryAbortedRootTurns = abortedRootTurns
         , registryLifecycle = lifecycle
@@ -370,7 +372,7 @@ spawnSubagentWithCwdPreparedForTurn
 spawnSubagentWithCwdPreparedForTurn
         registry rootTurnId childCwd beforeStart
         parentId parentDepth message nickname = do
-    agentId <- newSubagentId
+    agentId <- newSubagentId registry
     fmap (fmap fst) $
         spawnSubagentAtWithIdPreparedForTurn
             registry rootTurnId childCwd beforeStart agentId
@@ -447,7 +449,7 @@ spawnSubagentAtWithCwdPreparedForTurn
 spawnSubagentAtWithCwdPreparedForTurn
         registry rootTurnId childCwd beforeStart
         parentId parentPath parentDepth taskName content nickname = do
-    agentId <- newSubagentId
+    agentId <- newSubagentId registry
     spawnSubagentAtWithIdPreparedForTurn
         registry rootTurnId childCwd beforeStart agentId
         parentId parentPath parentDepth taskName content nickname
@@ -1387,7 +1389,7 @@ restoreSubagentResolvedWithCwd
     case result of
         Left err -> pure (Left err)
         Right restored -> do
-            restoreSubagentIndex restored
+            restoreSubagentIndex registry restored
             pure (Right restored)
   where
     normalizedStatus = case restoredStatus of
@@ -1528,25 +1530,25 @@ readStatusSTM registry agentId = do
         Nothing -> pure NotFound
         Just record -> phaseStatus <$> readTVar record.recordPhase
 
-newSubagentId :: IO SubagentId
-newSubagentId = do
-    n <- atomicModifyIORef' subagentIdCounter \i -> (i + 1, i + 1)
+newSubagentId :: SubagentRegistry -> IO SubagentId
+newSubagentId registry = do
+    n <- atomically do
+        current <- readTVar registry.registryNextSubagentId
+        let next = current + 1
+        writeTVar registry.registryNextSubagentId next
+        pure next
     now <- getCurrentTime
     let micros = floor (utcTimeToPOSIXSeconds now * 1000000) :: Integer
         hex = showHex (micros `mod` 0x100000000) ""
         pad = replicate (8 - length hex) '0' <> hex
     pure $ SubagentId $ Text.pack ("agent-" <> pad <> "-" <> show n)
 
-subagentIdCounter :: IORef Int
-subagentIdCounter = unsafePerformIO (newIORef (0 :: Int))
-{-# NOINLINE subagentIdCounter #-}
-
-restoreSubagentIndex :: SubagentId -> IO ()
-restoreSubagentIndex agentId =
+restoreSubagentIndex :: SubagentRegistry -> SubagentId -> IO ()
+restoreSubagentIndex registry agentId =
     case TextRead.decimal (snd (Text.breakOnEnd "-" agentId.unSubagentId)) of
         Right (index, rest) | Text.null rest ->
-            atomicModifyIORef' subagentIdCounter
-                (\current -> (max current index, ()))
+            atomically $
+                modifyTVar' registry.registryNextSubagentId (max index)
         _ -> pure ()
 
 getTaskPath :: SubagentRegistry -> SubagentId -> IO (Maybe TaskPath)

--- a/packages/agent-core/test/Agent/SubagentsSpec.hs
+++ b/packages/agent-core/test/Agent/SubagentsSpec.hs
@@ -662,6 +662,29 @@ spec = describe "Agent.Subagents" do
                 index `shouldSatisfy` (> (1000000 :: Int))
             Left err -> expectationFailure err
 
+    it "keeps generated id indexes local to each registry" do
+        let runner _ _ _ _ = pure $ Right LoopResult
+                { finalResponseId = "independent"
+                , finalText = Nothing
+                , turnsUsed = 1
+                , tokenUsage = emptyTokenUsage
+                }
+            newRegistry =
+                newSubagentRegistry defaultSubagentConfig
+                    (fromFilePath "/tmp")
+                    runner
+                    (\_ _ -> pure ())
+            numericSuffix :: SubagentId -> Either String (Int, Text)
+            numericSuffix agentId =
+                TextRead.decimal
+                    (snd (Text.breakOnEnd "-" agentId.unSubagentId))
+        first <- newRegistry
+        second <- newRegistry
+        Right firstId <- spawnSubagent first Nothing 0 "first" Nothing
+        Right secondId <- spawnSubagent second Nothing 0 "second" Nothing
+        numericSuffix firstId `shouldBe` Right (1 :: Int, "")
+        numericSuffix secondId `shouldBe` Right (1 :: Int, "")
+
     it "does not reopen an agent after the registry is closed" do
         registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
             (\_ _ prompt _ -> pure $ Right LoopResult

--- a/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Shell.hs
+++ b/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Shell.hs
@@ -70,11 +70,15 @@ data BackgroundTask = BackgroundTask
     , backgroundResource :: !ResourceKey
     }
 
+data BackgroundTaskStore = BackgroundTaskStore
+    { backgroundNextId :: !Int
+    , backgroundTasks :: !(Map Text BackgroundTask)
+    }
+
 data GrokSession = GrokSession
     { grokEnv :: !ToolEnv
     , grokShell :: !(MVar PersistentShell)
-    , grokTasks :: !(MVar (Map Text BackgroundTask))
-    , grokNextId :: !(IORef Int)
+    , grokTasks :: !(MVar BackgroundTaskStore)
     , grokTodos :: !(IORef (Map Text (Text, Text)))
     , grokResources :: !ResourceScope
     }
@@ -88,14 +92,15 @@ newGrokSession env = do
             { shellCwd = env.toolCwd
             , shellEnvFile = envFile
             }
-        tasks <- newMVar Map.empty
-        nextId <- newIORef 0
+        tasks <- newMVar BackgroundTaskStore
+            { backgroundNextId = 0
+            , backgroundTasks = Map.empty
+            }
         todos <- newIORef Map.empty
         pure GrokSession
             { grokEnv = env
             , grokShell = shell
             , grokTasks = tasks
-            , grokNextId = nextId
             , grokTodos = todos
             , grokResources = resources
             }
@@ -123,7 +128,8 @@ newGrokSession env = do
 -- Call this when the CLI/session ends, including after exceptions.
 closeGrokSession :: GrokSession -> IO ()
 closeGrokSession session = do
-    modifyMVar_ session.grokTasks (const (pure Map.empty))
+    modifyMVar_ session.grokTasks \store ->
+        pure store { backgroundTasks = Map.empty }
     closeResourceScope session.grokResources
 
 runForegroundStreaming
@@ -169,14 +175,23 @@ startBackgroundCommand session command = do
         Left exception ->
             pure (Left (Text.pack (show exception)))
         Right (resource, running) -> do
-            taskId <- nextTaskId session
-            let task = BackgroundTask
-                    { backgroundId = taskId
-                    , backgroundRunning = running
-                    , backgroundResource = resource
-                    }
-            modifyMVar_ session.grokTasks
-                (\tasks -> pure (Map.insert taskId task tasks))
+            taskId <-
+                (modifyMVar session.grokTasks \store -> do
+                    let next = store.backgroundNextId + 1
+                        taskId = "t" <> Text.pack (show next)
+                        task = BackgroundTask
+                            { backgroundId = taskId
+                            , backgroundRunning = running
+                            , backgroundResource = resource
+                            }
+                    pure
+                        ( store
+                            { backgroundNextId = next
+                            , backgroundTasks =
+                                Map.insert taskId task store.backgroundTasks
+                            }
+                        , taskId
+                        ))
                 `onException` releaseResource resource
             pure $ Right $
                 "Command moved to background.\n\
@@ -185,8 +200,8 @@ startBackgroundCommand session command = do
 
 readTaskOutput :: GrokSession -> Text -> Maybe Int -> IO Text
 readTaskOutput session taskId timeoutMs = do
-    tasks <- readMVar session.grokTasks
-    case Map.lookup taskId tasks of
+    store <- readMVar session.grokTasks
+    case Map.lookup taskId store.backgroundTasks of
         Nothing -> pure $ "Unknown task_id: " <> taskId
         Just task -> do
             case timeoutMs of
@@ -242,17 +257,13 @@ snapshotTask task =
 
 killTask :: GrokSession -> Text -> IO Text
 killTask session taskId = do
-    tasks <- readMVar session.grokTasks
-    case Map.lookup taskId tasks of
+    store <- readMVar session.grokTasks
+    case Map.lookup taskId store.backgroundTasks of
         Nothing -> pure $ "Unknown task_id: " <> taskId
         Just task -> do
             releaseResource task.backgroundResource
             result <- readMVar task.backgroundRunning.runningResult
             pure $ "killed " <> taskId <> "\n" <> formatCommandResult result
-
-nextTaskId :: GrokSession -> IO Text
-nextTaskId session = atomicModifyIORef' session.grokNextId \n ->
-    (n + 1, "t" <> Text.pack (show (n + 1)))
 
 -- | Run the persist wrapper under bash so `export -p` dumps (`declare -x`)
 -- can be sourced on the next call.

--- a/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Task.hs
+++ b/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Task.hs
@@ -421,12 +421,13 @@ recordAgentSpec specsRef agentId spec =
     update specs = (Map.insert agentId spec specs, ())
 
 recordAgentType :: GrokSubagentSpecs -> SubagentId -> Text -> IO ()
-recordAgentType specsRef agentId agentType = do
-    specs <- readIORef specsRef
-    let existing = Map.lookup agentId specs
-        model = existing >>= \spec -> spec.modelOverride
-        effort = existing >>= \spec -> spec.reasoningEffortOverride
-    recordAgentSpec specsRef agentId (GrokSubagentSpec agentType model effort)
+recordAgentType specsRef agentId agentType =
+    atomicModifyIORef' specsRef \specs ->
+        let existing = Map.lookup agentId specs
+            model = existing >>= \spec -> spec.modelOverride
+            effort = existing >>= \spec -> spec.reasoningEffortOverride
+            updated = GrokSubagentSpec agentType model effort
+        in (Map.insert agentId updated specs, ())
 
 lookupAgentType :: GrokSubagentSpecs -> SubagentId -> IO (Maybe Text)
 lookupAgentType specsRef agentId =


### PR DESCRIPTION
## Summary
- move subagent ID allocation from a process-global unsafe IORef into each registry
- allocate Codex command IDs inside the existing session store and serialize output cursors
- allocate Grok task IDs atomically with task registration
- make Grok agent-type updates a single atomic transition

## Why
These counters and cursors belong to existing registry/session owners. Keeping them in separate IORefs weakens lifecycle ownership and, for Grok agent types, allowed lost updates.

## Verification
- multi-package GHCi no-code typecheck: agent-core, agent-codex-dialect, agent-grok-build-dialect
- agent-core: 277 examples, 0 failures
- agent-codex-dialect: 3 examples, 0 failures
- agent-grok-build-dialect: 13 examples, 0 failures
- independent-registry ID regression added

Independent of #355.