### PR TITLE
fix(cli): retry transient provider cooldowns before fallback

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -197,10 +197,11 @@ import Agent.CLI.Prompt
 import Agent.CLI.Request (requestParams, setRequestInstructions)
 import Agent.CLI.ProviderFallback
     ( allowsAutomaticBillingFallback
-    , automaticCooldownRetryDelay
     , automaticRetryCountdownText
     , fallbackCandidates
     , isProviderUnavailable
+    , ProviderRecoveryPreference(..)
+    , providerRecoveryPreference
     )
 import Agent.CLI.ProviderAvailability (probeLoadedAvailability)
 import Agent.CLI.ProviderTransition
@@ -3290,22 +3291,25 @@ finishTurnWithCooldownRetry allowCooldownRetry env exitAfter = \case
         finishTurnWithCooldownRetry allowCooldownRetry env exitAfter result
     TurnProviderUnavailable apiError pending ->
         let pending' = setPendingExitAfter exitAfter pending
-        in requestAutomaticProviderFallback env apiError pending' >>= \case
-            Just providerTransition ->
-                pure (RunSwitchProvider providerTransition)
-            Nothing -> do
-                now <- getCurrentTime
-                case automaticCooldownRetryDelay now apiError of
-                    Just delay | allowCooldownRetry ->
-                        waitAndRetryPendingTurn env delay pending'
-                    _ -> do
-                        reportProviderUnavailable
-                            env.sessionFullscreen apiError
-                        if exitAfter
-                            then exitFailure
-                            else do
-                                notifyAttention stderr InputRequested
-                                replWithDraft env pending.pendingPromptText
+        in do
+            now <- getCurrentTime
+            case providerRecoveryPreference
+                    allowCooldownRetry now apiError of
+                RetryCurrentProviderAfter delay ->
+                    waitAndRetryPendingTurn env delay pending'
+                TryProviderFallback ->
+                    requestAutomaticProviderFallback env apiError pending'
+                        >>= \case
+                        Just providerTransition ->
+                            pure (RunSwitchProvider providerTransition)
+                        Nothing -> do
+                            reportProviderUnavailable
+                                env.sessionFullscreen apiError
+                            if exitAfter
+                                then exitFailure
+                                else do
+                                    notifyAttention stderr InputRequested
+                                    replWithDraft env pending.pendingPromptText
 
 continueAfterTurn :: SessionEnv -> IO RunResult
 continueAfterTurn env = do

--- a/packages/agent-cli/src/Agent/CLI/ProviderFallback.hs
+++ b/packages/agent-cli/src/Agent/CLI/ProviderFallback.hs
@@ -6,6 +6,8 @@ module Agent.CLI.ProviderFallback
     , fallbackCandidates
     , isProviderUnavailable
     , isUsageExhausted
+    , ProviderRecoveryPreference(..)
+    , providerRecoveryPreference
     , rankedModels
     ) where
 
@@ -18,11 +20,22 @@ import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Time.Clock (NominalDiffTime, UTCTime, diffUTCTime)
 
--- | Keep brief provider cooldowns invisible to the user when no fallback
--- account is available. Longer waits return control to the prompt instead of
--- making the CLI appear hung.
+-- | Keep brief provider cooldowns invisible to the user. Longer waits are
+-- eligible for cross-provider fallback instead of making the CLI appear hung.
 maxAutomaticCooldownWait :: NominalDiffTime
 maxAutomaticCooldownWait = 120
+
+-- | Whether a provider-unavailable turn should first wait for the current
+-- provider or immediately enter cross-provider fallback.
+--
+-- A brief 'CredentialsExhausted' window commonly represents a transient 429
+-- shared by otherwise usable accounts. Retrying it first prevents that
+-- temporary cooldown from being recorded as permanent provider exhaustion by
+-- the fallback chain. Long usage-window resets still fall back immediately.
+data ProviderRecoveryPreference
+    = RetryCurrentProviderAfter !NominalDiffTime
+    | TryProviderFallback
+    deriving (Eq, Show)
 
 -- | Automatic fallback may use another subscription account, but must never
 -- turn subscription exhaustion into API-credit spending. Manual provider
@@ -45,6 +58,17 @@ automaticCooldownRetryDelay now = \case
             then Just delay
             else Nothing
     _ -> Nothing
+
+providerRecoveryPreference
+    :: Bool
+    -> UTCTime
+    -> ApiError
+    -> ProviderRecoveryPreference
+providerRecoveryPreference allowCooldownRetry now err =
+    case automaticCooldownRetryDelay now err of
+        Just delay
+            | allowCooldownRetry -> RetryCurrentProviderAfter delay
+        _ -> TryProviderFallback
 
 -- | Live status text for a brief automatic provider retry. Keep the remaining
 -- time in seconds so a one-minute cooldown visibly counts down instead of

--- a/packages/agent-cli/test/Agent/CLI/ProviderFallbackSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ProviderFallbackSpec.hs
@@ -11,6 +11,8 @@ import Agent.CLI.ProviderFallback
     , automaticCooldownRetryDelay
     , automaticRetryCountdownText
     , fallbackCandidates
+    , ProviderRecoveryPreference(..)
+    , providerRecoveryPreference
     , rankedModels
     )
 import Agent.Error (ApiError(..), ErrorType(..))
@@ -136,6 +138,24 @@ spec = do
             automaticCooldownRetryDelay now
                 (ProviderError AuthenticationError "expired" Nothing)
                 `shouldBe` Nothing
+
+    describe "providerRecoveryPreference" do
+        let now = UTCTime (fromGregorian 2026 8 21) 0
+
+        it "retries a transient all-account cooldown before provider fallback" do
+            providerRecoveryPreference True now
+                (CredentialsExhausted (addUTCTime 60 now))
+                `shouldBe` RetryCurrentProviderAfter 60
+
+        it "falls back for a genuine long usage-window exhaustion" do
+            providerRecoveryPreference True now
+                (CredentialsExhausted (addUTCTime 3600 now))
+                `shouldBe` TryProviderFallback
+
+        it "does not repeat the cooldown retry after its one retry allowance" do
+            providerRecoveryPreference False now
+                (CredentialsExhausted (addUTCTime 60 now))
+                `shouldBe` TryProviderFallback
 
     describe "automaticRetryCountdownText" do
         it "shows the remaining wait in seconds" do


### PR DESCRIPTION
## Summary

- retry brief all-account credential cooldowns on the current provider before attempting cross-provider fallback
- keep long usage-window exhaustion eligible for immediate fallback
- prevent a transient Codex 429 from marking OpenAI unavailable for the fallback chain
- add regression coverage for transient, long, and repeated cooldown recovery

## Root cause

`TurnProviderUnavailable` attempted cross-provider fallback before consulting the existing short-cooldown retry policy. Because `CredentialsExhausted` is also used when every account is briefly cooling down, a temporary Codex failure was treated like provider-wide usage exhaustion even when another account still had quota.

## Validation

- `nix develop -c cabal repl agent-cli:lib:agent-cli agent-cli:test:agent-cli-test` (affected library and test suite typechecked)
- `nix develop -c cabal repl agent-cli:test:agent-cli-test`, then `:main --match providerRecoveryPreference` (3 examples, 0 failures)
- live CLI TTY smoke check in tmux
- `git diff HEAD^ HEAD --check`
