### PR TITLE
refactor(cli): centralize conversation session state

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -85,6 +85,7 @@ library
                     , Agent.CLI.Resume
                     , Agent.CLI.Session
                     , Agent.CLI.SessionEnv
+                    , Agent.CLI.SessionState
                     , Agent.CLI.SessionLock
                     , Agent.CLI.SessionTitle
                     , Agent.CLI.Secret
@@ -251,6 +252,7 @@ test-suite agent-cli-test
                     , Agent.CLI.TextLayoutSpec
                     , Agent.CLI.TurnSpec
                     , Agent.CLI.SessionSpec
+                    , Agent.CLI.SessionStateSpec
                     , Agent.CLI.SessionTitleSpec
                     , Agent.CLI.SkillsSpec
                     , Agent.CLI.SubagentStoreSpec

--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -224,6 +224,14 @@ import Agent.CLI.Render
     )
 import Agent.CLI.Session
 import Agent.CLI.SessionEnv (SessionEnv(..))
+import Agent.CLI.SessionState
+    ( SessionState(..)
+    , addSessionTokenUsage
+    , clearSessionPreviousResponseId
+    , replaceSessionTranscript
+    , resetSessionConversation
+    , setSessionTranscript
+    )
 import Agent.CLI.SessionLock
     ( SessionLock
     , acquireSessionLock
@@ -330,6 +338,7 @@ import Agent.TUI.Model
     )
 import Agent.TUI.Motion (nativeProgressAnimationEnabled)
 import Agent.CLI.Turn (applyPendingSessionTitles, runOneTurn)
+import Agent.CLI.TurnState (ConversationState(..))
 import Agent.CLI.Usage
     ( AccountUsageLine(..)
     , formatDuration
@@ -1678,7 +1687,7 @@ runAgentInitializedWithLock
     -- Per-subagent transcripts / previous ids, shared across send_input / task.
     subagentSessions <- newIORef Map.empty
     subagentStoreRoot <- newIORef Nothing
-    subagentForkSource <- newIORef (Nothing :: Maybe (IORef [ResponseItem]))
+    subagentForkSource <- newIORef (Nothing :: Maybe (IO [ResponseItem]))
     pendingNotices <- newIORef ([] :: [TurnInput])
     registry <- newSubagentRegistry defaultSubagentConfig cwd
         (\_ _ _ _ -> pure $ Left LoopNoResponseId)
@@ -1908,10 +1917,7 @@ runAgentInitializedWithLock
                         provider
                         (tokenProviderBillingMode tokenProvider)
                 }
-        transcriptRef <- newIORef initialItems
         contextTokensRef <- newIORef Nothing
-        previousRef <- newIORef initialPrevious
-        writeIORef subagentForkSource (Just transcriptRef)
         let titleHint = case resumed of
                 Just (meta, _) -> Just meta.metaTitle
                 Nothing -> sessionTitleFromPrompt <$> prompt
@@ -1933,10 +1939,30 @@ runAgentInitializedWithLock
         skillsRef <- newIORef (SkillCatalog [] [])
         skillInvocationsRef <- newIORef []
 
-        usageRef <- newIORef $ case resumed of
-            Just (meta, turns) -> sessionUsageFromTurns meta turns
-            Nothing -> emptyTokenUsage
-        let recordCompactionUsage usage =
+        let initialUsage = case resumed of
+                Just (meta, turns) -> sessionUsageFromTurns meta turns
+                Nothing -> emptyTokenUsage
+        sessionStateRef <- newIORef SessionState
+            { sessionConversation = ConversationState
+                { conversationPreviousResponseId = initialPrevious
+                , conversationTranscript = initialItems
+                , conversationStartupContext = startupContext
+                , conversationUsage = initialUsage
+                , conversationLastAssistant = Nothing
+                }
+            }
+        writeIORef subagentForkSource $
+            Just
+                ( (.sessionConversation.conversationTranscript)
+                    <$> readIORef sessionStateRef
+                )
+        let readSessionTranscript =
+                (.sessionConversation.conversationTranscript)
+                    <$> readIORef sessionStateRef
+            installCompaction outcome =
+                atomicModifyIORef' sessionStateRef \state ->
+                    (replaceSessionTranscript outcome.compactHistory state, ())
+            recordCompactionUsage usage =
                 when (usage /= emptyTokenUsage) $
                     mask_ do
                         case persist of
@@ -1946,7 +1972,8 @@ runAgentInitializedWithLock
                                 claimCurrentSession handle
                                 updated <- addSessionUsage usage handle
                                 writeIORef slotRef (PersistenceActive updated)
-                        modifyIORef' usageRef (`addTokenUsage` usage)
+                        atomicModifyIORef' sessionStateRef \state ->
+                            (addSessionTokenUsage usage state, ())
         case persist of
             PersistenceEnabled slotRef -> do
                 slot <- readIORef slotRef
@@ -2209,25 +2236,24 @@ runAgentInitializedWithLock
                                     compactRunner focus =
                                         withMVar wsLock \_ ->
                                             installCompactOutcome
-                                                previousRef
-                                                transcriptRef
+                                                installCompaction
                                                 (Just contextTokensRef)
                                                 (runProviderCompactWith
                                                     (Just compactSender)
                                                     recordCompactionUsage
                                                     provider
                                                     (Just tokenProvider)
-                                                    paramsRef
-                                                    transcriptRef)
+                                                    (readIORef paramsRef)
+                                                    readSessionTranscript)
                                                 focus
                                 activeBackend <-
                                     prepareTransitionBackend
                                         projectRoot transition persist noticingBackend
                                 withAsync switchLoop \switchWorker -> do
                                     link switchWorker
-                                    runSession catalog inferredTarget.targetConnectionId options provider dialect policy tools toolEnv planMode startup prompt pendingTurn transitionDraft unavailableProviders startupUnavailable paramsRef transcriptRef initialTurns
-                                        previousRef persist projectRoot home cwd (Just tokenProvider) loaded.loadedOpenAiPool startupContext skillsRef skillInvocationsRef escPaused interrupt
-                                        multiCtx rootTurnRef subagentSessions pendingNotices subagentStoreRoot agentTypesRef legacySubagentTarget usageRef activeAccountRef activeAccountIdRef activeSelectionRef resolveActiveAccountLabel selectAccount claimCurrentSession compactRunner activeBackend btwBackend)
+                                    runSession catalog inferredTarget.targetConnectionId options provider dialect policy tools toolEnv planMode startup prompt pendingTurn transitionDraft unavailableProviders startupUnavailable paramsRef sessionStateRef initialTurns
+                                        persist projectRoot home cwd (Just tokenProvider) loaded.loadedOpenAiPool skillsRef skillInvocationsRef escPaused interrupt
+                                        multiCtx rootTurnRef subagentSessions pendingNotices subagentStoreRoot agentTypesRef legacySubagentTarget activeAccountRef activeAccountIdRef activeSelectionRef resolveActiveAccountLabel selectAccount claimCurrentSession compactRunner activeBackend btwBackend)
                             >>= \case
                                 Left (CodexAuthFailed err) ->
                                     case transition of
@@ -2278,20 +2304,20 @@ runAgentInitializedWithLock
                                 xaiBackend xaiOptions tokenProvider
                                     (readIORef privateParams)
                             compactRunner =
-                                installCompactOutcome previousRef transcriptRef Nothing $
+                                installCompactOutcome installCompaction Nothing $
                                     runProviderCompactWith
                                         Nothing
                                         recordCompactionUsage
                                         provider
                                         (Just tokenProvider)
-                                        paramsRef
-                                        transcriptRef
+                                        (readIORef paramsRef)
+                                        readSessionTranscript
                         activeBackend <-
                             prepareTransitionBackend
                                 projectRoot transition persist backend
-                        runSession catalog inferredTarget.targetConnectionId options provider dialect policy tools toolEnv planMode startup prompt pendingTurn transitionDraft unavailableProviders startupUnavailable paramsRef transcriptRef initialTurns
-                            previousRef persist projectRoot home cwd (Just tokenProvider) loaded.loadedOpenAiPool startupContext skillsRef skillInvocationsRef escPaused interrupt
-                            multiCtx rootTurnRef subagentSessions pendingNotices subagentStoreRoot agentTypesRef legacySubagentTarget usageRef activeAccountRef activeAccountIdRef activeSelectionRef resolveActiveAccountLabel (if isJust customGenericOptions then Nothing else Just selectHttpAccount) claimCurrentSession compactRunner activeBackend btwBackend
+                        runSession catalog inferredTarget.targetConnectionId options provider dialect policy tools toolEnv planMode startup prompt pendingTurn transitionDraft unavailableProviders startupUnavailable paramsRef sessionStateRef initialTurns
+                            persist projectRoot home cwd (Just tokenProvider) loaded.loadedOpenAiPool skillsRef skillInvocationsRef escPaused interrupt
+                            multiCtx rootTurnRef subagentSessions pendingNotices subagentStoreRoot agentTypesRef legacySubagentTarget activeAccountRef activeAccountIdRef activeSelectionRef resolveActiveAccountLabel (if isJust customGenericOptions then Nothing else Just selectHttpAccount) claimCurrentSession compactRunner activeBackend btwBackend
                     OpenRouterProvider -> do
                         let makeBackend params =
                                 case customGenericOptions of
@@ -2333,7 +2359,7 @@ runAgentInitializedWithLock
                                 makeBackend
                                     (readIORef privateParams)
                             compactRunner =
-                                installCompactOutcome previousRef transcriptRef Nothing $
+                                installCompactOutcome installCompaction Nothing $
                                     case customGenericOptions of
                                         Just genericOptions ->
                                             runResponsesCompactWith
@@ -2348,22 +2374,22 @@ runAgentInitializedWithLock
                                                             }
                                                         request)
                                                 recordCompactionUsage
-                                                paramsRef
-                                                transcriptRef
+                                                (readIORef paramsRef)
+                                                readSessionTranscript
                                         Nothing ->
                                             runProviderCompactWith
                                                 Nothing
                                                 recordCompactionUsage
                                                 provider
                                                 (Just tokenProvider)
-                                                paramsRef
-                                                transcriptRef
+                                                (readIORef paramsRef)
+                                                readSessionTranscript
                         activeBackend <-
                             prepareTransitionBackend
                                 projectRoot transition persist backend
-                        runSession catalog inferredTarget.targetConnectionId options provider dialect policy tools toolEnv planMode startup prompt pendingTurn transitionDraft unavailableProviders startupUnavailable paramsRef transcriptRef initialTurns
-                            previousRef persist projectRoot home cwd (Just tokenProvider) loaded.loadedOpenAiPool startupContext skillsRef skillInvocationsRef escPaused interrupt
-                            multiCtx rootTurnRef subagentSessions pendingNotices subagentStoreRoot agentTypesRef legacySubagentTarget usageRef activeAccountRef activeAccountIdRef activeSelectionRef resolveActiveAccountLabel (Just selectHttpAccount) claimCurrentSession compactRunner activeBackend btwBackend
+                        runSession catalog inferredTarget.targetConnectionId options provider dialect policy tools toolEnv planMode startup prompt pendingTurn transitionDraft unavailableProviders startupUnavailable paramsRef sessionStateRef initialTurns
+                            persist projectRoot home cwd (Just tokenProvider) loaded.loadedOpenAiPool skillsRef skillInvocationsRef escPaused interrupt
+                            multiCtx rootTurnRef subagentSessions pendingNotices subagentStoreRoot agentTypesRef legacySubagentTarget activeAccountRef activeAccountIdRef activeSelectionRef resolveActiveAccountLabel (Just selectHttpAccount) claimCurrentSession compactRunner activeBackend btwBackend
           where
             startupFailure err = do
                 now <- getCurrentTime
@@ -2559,16 +2585,14 @@ runSession
     -> [Provider]
     -> Maybe (STM ApiError)
     -> IORef ResponseCreateParams
-    -> IORef [ResponseItem]
+    -> IORef SessionState
     -> [SessionTurn]
-    -> IORef (Maybe Text)
     -> Persistence
     -> OsPath
     -> OsPath
     -> OsPath
     -> Maybe TokenProvider
     -> Maybe OpenAI.Pool
-    -> IORef (Maybe Text)
     -> IORef SkillCatalog
     -> IORef [SkillInvocation]
     -> IORef Bool
@@ -2580,7 +2604,6 @@ runSession
     -> SubagentStoreRoot
     -> GrokSubagentSpecs
     -> Maybe LegacySubagentTarget
-    -> IORef TokenUsage
     -> IORef Text
     -> IORef Text
     -> IORef Text
@@ -2591,8 +2614,10 @@ runSession
     -> Backend
     -> BtwBackendFactory
     -> IO RunResult
-runSession catalog connectionId options provider dialect policy tools toolEnv planMode startup prompt pendingTurn initialDraft unavailableProviders startupUnavailable paramsRef transcriptRef initialTurns previous persist projectRoot home cwd tokenProvider openAiPool startupContext skillsRef skillInvocationsRef escPaused interrupt multiCtx rootTurnRef subagentSessions pendingNotices storeRoot agentTypes legacyTarget usageRef accountRef accountIdRef selectionRef accountLabel selectAccount onPersisted compactRunner backend btwBackend = do
-  initialPrevious <- readIORef previous
+runSession catalog connectionId options provider dialect policy tools toolEnv planMode startup prompt pendingTurn initialDraft unavailableProviders startupUnavailable paramsRef sessionStateRef initialTurns persist projectRoot home cwd tokenProvider openAiPool skillsRef skillInvocationsRef escPaused interrupt multiCtx rootTurnRef subagentSessions pendingNotices storeRoot agentTypes legacyTarget accountRef accountIdRef selectionRef accountLabel selectAccount onPersisted compactRunner backend btwBackend = do
+  initialPrevious <-
+      (.sessionConversation.conversationPreviousResponseId)
+          <$> readIORef sessionStateRef
   ioLock <- newMVar ()
   let fullscreen = startup.startupFullscreen
       terminal = startup.startupTerminal
@@ -2653,7 +2678,6 @@ runSession catalog connectionId options provider dialect policy tools toolEnv pl
     startedAtRef <- newIORef Nothing
     toolCallsRef <- newIORef Map.empty
     allowedToolsRef <- newIORef Set.empty
-    lastAssistantRef <- newIORef Nothing
     modelRef <- newIORef =<< (currentModel <$> readIORef paramsRef)
     unavailableProvidersRef <- newIORef unavailableProviders
     startupUnavailableRef <- newIORef startupUnavailable
@@ -2682,7 +2706,9 @@ runSession catalog connectionId options provider dialect policy tools toolEnv pl
                         )
                     pure steps
         loadAgentSnapshot includeSummaries = do
-            rootItems <- readIORef transcriptRef
+            rootItems <-
+                (.sessionConversation.conversationTranscript)
+                    <$> readIORef sessionStateRef
             agents <- case multiCtx of
                 Nothing -> pure []
                 Just ctx -> listAgents ctx.multiRegistry Nothing
@@ -2816,9 +2842,6 @@ runSession catalog connectionId options provider dialect policy tools toolEnv pl
         (loadAgentSnapshot False)
     writeIORef startup.startupAgentSelect selectAgent
     let sessionReset = do
-            resetLiveConversation previous transcriptRef attachmentsRef planMode
-            writeIORef usageRef emptyTokenUsage
-            writeIORef lastAssistantRef Nothing
             writeIORef pendingNotices []
             writeIORef subagentSessions Map.empty
             writeIORef selectedAgent AgentRoot
@@ -2828,18 +2851,20 @@ runSession catalog connectionId options provider dialect policy tools toolEnv pl
                 Nothing -> pure ()
             freshAgents <-
                 loadAgentsContext fullscreen options dialect home cwd [] Nothing
+            atomicModifyIORef' sessionStateRef \state ->
+                (resetSessionConversation freshAgents state, ())
+            writeIORef attachmentsRef []
+            deactivatePlanMode planMode
             freshSkills <- loadSkillsCatalogQuiet options home projectRoot cwd
             omitted <- installSkillCatalogWithOmissions
-                reservedSlashNames True freshAgents
+                reservedSlashNames True sessionStateRef
                 skillsRef skillInvocationsRef freshSkills
             reportSkillCatalog True freshSkills omitted
-            fresh <- readIORef freshAgents
-            writeIORef startupContext fresh
         refreshSkills queueContext = do
             refreshed <- loadSkillsCatalogQuiet
                 options home projectRoot cwd
             omitted <- installSkillCatalogWithOmissions
-                reservedSlashNames queueContext startupContext
+                reservedSlashNames queueContext sessionStateRef
                 skillsRef skillInvocationsRef refreshed
             when queueContext $
                 reportSkillCatalog True refreshed omitted
@@ -2944,8 +2969,12 @@ runSession catalog connectionId options provider dialect policy tools toolEnv pl
         config = LoopConfig
             { loopBackend = backend
             , loopBackendState = BackendStateStore
-                { readBackendState = readIORef transcriptRef
-                , commitBackendState = writeIORef transcriptRef
+                { readBackendState =
+                    (.sessionConversation.conversationTranscript)
+                        <$> readIORef sessionStateRef
+                , commitBackendState = \items ->
+                    atomicModifyIORef' sessionStateRef \state ->
+                        (setSessionTranscript items state, ())
                 }
             , loopTools = toolRegistry
             , loopDispatch = defaultLoopDispatch
@@ -3015,11 +3044,10 @@ runSession catalog connectionId options provider dialect policy tools toolEnv pl
             , sessionDialect = dialect
             , sessionUnavailableProviders = unavailableProvidersRef
             , sessionStartupUnavailable = startupUnavailableRef
-            , sessionPrevious = previous
+            , sessionState = sessionStateRef
             , sessionPrinted = printed
             , sessionParams = paramsRef
             , sessionPolicy = policyRef
-            , sessionTranscript = transcriptRef
             , sessionPersist = persist
             , sessionTitleManager = titleManager
             , sessionTitleTurnCount = titleTurnCount
@@ -3030,7 +3058,6 @@ runSession catalog connectionId options provider dialect policy tools toolEnv pl
             , sessionSetTempDir = setSessionTempDir
             , sessionTokenProvider = tokenProvider
             , sessionOpenAiPool = openAiPool
-            , sessionStartupContext = startupContext
             , sessionSkills = skillsRef
             , sessionSkillInvocations = skillInvocationsRef
             , sessionRefreshSkills = refreshSkills
@@ -3040,13 +3067,11 @@ runSession catalog connectionId options provider dialect policy tools toolEnv pl
             , sessionInterrupt = interrupt
             , sessionRestartEffort = restartEffortRef
             , sessionStoreRoot = storeRoot
-            , sessionUsage = usageRef
             , sessionAccount = accountRef
             , sessionAccountId = accountIdRef
             , sessionAccountSelectionId = selectionRef
             , sessionAccountLabel = accountLabel
             , sessionSelectAccount = selectAccount
-            , sessionLastAssistant = lastAssistantRef
             , sessionTerminal = terminal
             , sessionFullscreen = fullscreen
             , sessionSetWindowTitle = setWindowTitle
@@ -3068,7 +3093,7 @@ runSession catalog connectionId options provider dialect policy tools toolEnv pl
             omitted <- installSkillCatalogWithOmissions
                 reservedSlashNames
                 (null initialTurns && not (isJust initialPrevious))
-                startupContext skillsRef skillInvocationsRef skills
+                sessionStateRef skillsRef skillInvocationsRef skills
             reportSkillCatalog (isNothing fullscreen) skills omitted
             finishStartup startup
         sessionAction = do
@@ -3233,7 +3258,9 @@ syncFullscreenPrompt env =
         params <- readIORef env.sessionParams
         policy <- readIORef env.sessionPolicy
         account <- readIORef env.sessionAccount
-        usage <- readIORef env.sessionUsage
+        usage <-
+            (.sessionConversation.conversationUsage)
+                <$> readIORef env.sessionState
         attachments <- readIORef env.sessionAttachments
         emitUiEvent runtime $ UiSetPrompt $
             buildPromptState
@@ -3481,11 +3508,10 @@ replWithDraft env@SessionEnv
     , sessionModelCatalog = catalog
     , sessionDialect = dialect
     , sessionStartupUnavailable = startupUnavailableRef
-    , sessionPrevious = previous
+    , sessionState = sessionStateRef
     , sessionPrinted = printed
     , sessionParams = paramsRef
     , sessionPolicy = policyRef
-    , sessionTranscript = transcriptRef
     , sessionPersist = persist
     , sessionPlanMode = planMode
     , sessionProjectRoot = projectRoot
@@ -3500,12 +3526,10 @@ replWithDraft env@SessionEnv
     , sessionInterrupt = interrupt
     , sessionEscPaused = escPaused
     , sessionStoreRoot = storeRoot
-    , sessionUsage = usageRef
     , sessionAccount = accountRef
     , sessionAccountId = accountIdRef
     , sessionAccountSelectionId = selectionRef
     , sessionSelectAccount = selectAccount
-    , sessionLastAssistant = lastAssistantRef
     , sessionTerminal = terminal
     , sessionFullscreen = fullscreen
     , sessionSetWindowTitle = setWindowTitle
@@ -3514,6 +3538,7 @@ replWithDraft env@SessionEnv
     } draft = do
     refreshSkills False
     skillInvocations <- readIORef skillInvocationsRef
+    conversation <- (.sessionConversation) <$> readIORef sessionStateRef
     let skillCommands =
             map skillInvocationCommand
                 (filter (.invocationSkill.skillUserInvocable) skillInvocations)
@@ -3525,7 +3550,7 @@ replWithDraft env@SessionEnv
     policy <- readIORef policyRef
     pendingAttachments <- readIORef attachmentsRef
     let idleMode = replModeFromState planState policy
-    usage <- readIORef usageRef
+    let usage = conversation.conversationUsage
     account <- readIORef accountRef
     mlineResult <- case fullscreen of
         Just runtime -> do
@@ -3953,14 +3978,18 @@ replWithDraft env@SessionEnv
                                 continue
 
                     ReplCopyLast -> do
-                        answer <- readIORef lastAssistantRef
+                        answer <-
+                            (.sessionConversation.conversationLastAssistant)
+                                <$> readIORef sessionStateRef
                         copyCommand
                             "last response"
                             "no assistant response to copy"
                             answer
                         continue
                     ReplCopyCode index -> do
-                        answer <- readIORef lastAssistantRef
+                        answer <-
+                            (.sessionConversation.conversationLastAssistant)
+                                <$> readIORef sessionStateRef
                         let label =
                                 "code block " <> Text.pack (show index)
                         copyCommand
@@ -3969,7 +3998,9 @@ replWithDraft env@SessionEnv
                             (answer >>= fencedCodeBlock index)
                         continue
                     ReplCopyDiff -> do
-                        answer <- readIORef lastAssistantRef
+                        answer <-
+                            (.sessionConversation.conversationLastAssistant)
+                                <$> readIORef sessionStateRef
                         copyCommand
                             "diff block"
                             "no diff block was found"
@@ -4036,7 +4067,7 @@ replWithDraft env@SessionEnv
                                     projectRoot provider connectionId name
                                     choice.modelTarget.targetWireModelId
                                     choice.modelTarget.targetDialect
-                                    paramsRef render previous persist
+                                    paramsRef render sessionStateRef persist
                                 displayInfo message $
                                     Text.putStrLn
                                         (roleMuted color (glyphOk <> message))
@@ -4125,7 +4156,9 @@ replWithDraft env@SessionEnv
                                             Just _ -> action)
                                 btwBackend
                                 paramsRef
-                                transcriptRef
+                                ( (.sessionConversation.conversationTranscript)
+                                    <$> readIORef sessionStateRef
+                                )
                                 question
                         case result of
                             Left err -> do
@@ -4544,7 +4577,7 @@ replWithDraft env@SessionEnv
                         choice.modelTarget.targetModelId
                         choice.modelTarget.targetWireModelId
                         choice.modelTarget.targetDialect
-                        paramsRef render previous persist
+                        paramsRef render sessionStateRef persist
                     displayInfo message $
                         Text.putStrLn
                             (roleMuted color
@@ -5120,12 +5153,12 @@ applyModelChange
     -> DialectId
     -> IORef ResponseCreateParams
     -> RenderConfig
-    -> IORef (Maybe Text)
+    -> IORef SessionState
     -> Persistence
     -> IO Text
 applyModelChange
         projectRoot provider connection name transportModel dialectId
-        paramsRef render previous persist = do
+        paramsRef render sessionStateRef persist = do
     modifyIORef' paramsRef (setModel name)
     writeIORef render.renderModelRef name
     saveProjectModel projectRoot ModelTarget
@@ -5137,8 +5170,7 @@ applyModelChange
         }
     clearedChain <- case provider of
         OpenAIProvider ->
-            atomicModifyIORef' previous \prev ->
-                (Nothing, isJust prev)
+            atomicModifyIORef' sessionStateRef clearSessionPreviousResponseId
         _ -> pure False
     case persist of
         PersistenceDisabled -> pure ()
@@ -5844,10 +5876,10 @@ loadAgentsContext
     -> OsPath
     -> [ResponseItem]
     -> Maybe Text
-    -> IO (IORef (Maybe Text))
+    -> IO (Maybe Text)
 loadAgentsContext fullscreen options dialect home cwd initialItems initialPrevious
-    | not options.optAgentsMd = newIORef Nothing
-    | not (null initialItems) || isJust initialPrevious = newIORef Nothing
+    | not options.optAgentsMd = pure Nothing
+    | not (null initialItems) || isJust initialPrevious = pure Nothing
     | otherwise = do
         let discoverOptions = DiscoverOptions
                 { discoverMaxBytes = defaultDiscoverOptions.discoverMaxBytes
@@ -5857,7 +5889,7 @@ loadAgentsContext fullscreen options dialect home cwd initialItems initialPrevio
         loaded <- discoverProjectInstructions discoverOptions cwd
         let files = loadedInstructionFiles loaded
         case formatAgentsMdForDialect dialect cwd loaded of
-            Nothing -> newIORef Nothing
+            Nothing -> pure Nothing
             Just text -> do
                 let message =
                         "agents.md: loaded "
@@ -5870,7 +5902,7 @@ loadAgentsContext fullscreen options dialect home cwd initialItems initialPrevio
                             (roleMuted color (glyphSession <> message))
                     Just runtime ->
                         emitUiEvent runtime (UiSystemMessage message)
-                newIORef (Just text)
+                pure (Just text)
 
 preparePromptSkillInputs
     :: SessionEnv
@@ -6160,19 +6192,6 @@ lockedOpenAiSession compactThreshold wsLock provider activeConnection
             withMVar wsLock \_ ->
                 compactingBackend.submitTurn state previous inputs onEvent
     in (compactSender, serializedBackend)
-
--- | Drop live conversation state without touching persisted session files.
-resetLiveConversation
-    :: IORef (Maybe Text)
-    -> IORef [ResponseItem]
-    -> IORef [ImageAttachment]
-    -> PlanModeEnv
-    -> IO ()
-resetLiveConversation previous transcriptRef attachmentsRef planMode = do
-    writeIORef previous Nothing
-    writeIORef transcriptRef []
-    writeIORef attachmentsRef []
-    deactivatePlanMode planMode
 
 detectGitBranch :: OsPath -> IO Text
 detectGitBranch cwd = do

--- a/packages/agent-cli/src/Agent/CLI/Btw.hs
+++ b/packages/agent-cli/src/Agent/CLI/Btw.hs
@@ -118,12 +118,12 @@ runBtwWithCancel
         -> IO (Either BtwError Text))
     -> BtwBackendFactory
     -> IORef ResponseCreateParams
-    -> IORef [ResponseItem]
+    -> IO [ResponseItem]
     -> Text
     -> IO (Either BtwError Text)
-runBtwWithCancel withCancelScope makeBackend paramsRef transcriptRef question = do
+runBtwWithCancel withCancelScope makeBackend paramsRef getTranscript question = do
     params <- clearTurnSpecificParams <$> readIORef paramsRef
-    transcript <- trimDanglingToolSuffix <$> readIORef transcriptRef
+    transcript <- trimDanglingToolSuffix <$> getTranscript
     privateParams <- newIORef params
     cancel <- newCancelFlag
     let Backend submit = makeBackend privateParams

--- a/packages/agent-cli/src/Agent/CLI/Compaction.hs
+++ b/packages/agent-cli/src/Agent/CLI/Compaction.hs
@@ -95,8 +95,14 @@ runProviderCompact
     -> IORef [ResponseItem]
     -> Maybe Text
     -> IO (Either Text CompactOutcome)
-runProviderCompact =
-    runProviderCompactWith Nothing (const (pure ()))
+runProviderCompact provider tokenProvider paramsRef transcriptRef =
+    runProviderCompactWith
+        Nothing
+        (const (pure ()))
+        provider
+        tokenProvider
+        (readIORef paramsRef)
+        (readIORef transcriptRef)
 
 -- | Run manual compaction, optionally routing OpenAI through the active model
 -- session. Provider-reported compaction usage is recorded as soon as a
@@ -106,14 +112,14 @@ runProviderCompactWith
     -> (TokenUsage -> IO ())
     -> Provider
     -> Maybe TokenProvider
-    -> IORef ResponseCreateParams
-    -> IORef [ResponseItem]
+    -> IO ResponseCreateParams
+    -> IO [ResponseItem]
     -> Maybe Text
     -> IO (Either Text CompactOutcome)
 runProviderCompactWith openAiSender recordUsage provider tokenProvider
-        paramsRef transcriptRef focus = do
-    params <- readIORef paramsRef
-    history <- readIORef transcriptRef
+        getParams getHistory focus = do
+    params <- getParams
+    history <- getHistory
     attempt <- runAttemptAndRecord recordUsage $ case provider of
         OpenAIProvider ->
             case openAiSender of
@@ -188,13 +194,13 @@ runProviderCompactWith openAiSender recordUsage provider tokenProvider
 runResponsesCompactWith
     :: (ResponseCreateParams -> IO (Either ApiError Response))
     -> (TokenUsage -> IO ())
-    -> IORef ResponseCreateParams
-    -> IORef [ResponseItem]
+    -> IO ResponseCreateParams
+    -> IO [ResponseItem]
     -> Maybe Text
     -> IO (Either Text CompactOutcome)
-runResponsesCompactWith sender recordUsage paramsRef transcriptRef focus = do
-    params <- readIORef paramsRef
-    history <- readIORef transcriptRef
+runResponsesCompactWith sender recordUsage getParams getHistory focus = do
+    params <- getParams
+    history <- getHistory
     attempt <- runAttemptAndRecord recordUsage $
         if null history
             then pure (compactTextFailure "nothing to compact")
@@ -249,20 +255,18 @@ runAttemptAndRecord recordUsage action =
 -- prevents the next request from pairing compacted local history with the
 -- pre-compaction response chain.
 installCompactOutcome
-    :: IORef (Maybe Text)
-    -> IORef [ResponseItem]
+    :: (CompactOutcome -> IO ())
     -> Maybe (IORef (Maybe (Int, Int)))
     -> (Maybe Text -> IO (Either Text CompactOutcome))
     -> Maybe Text
     -> IO (Either Text CompactOutcome)
-installCompactOutcome previous transcript contextTokens runCompact focus =
+installCompactOutcome install contextTokens runCompact focus =
     mask \restore -> do
         result <- restore (runCompact focus)
         case result of
             Left _ -> pure ()
             Right outcome -> do
-                writeIORef previous Nothing
-                writeIORef transcript outcome.compactHistory
+                install outcome
                 case contextTokens of
                     Nothing -> pure ()
                     Just ref ->

--- a/packages/agent-cli/src/Agent/CLI/SessionEnv.hs
+++ b/packages/agent-cli/src/Agent/CLI/SessionEnv.hs
@@ -11,14 +11,15 @@ import Agent.CLI.Compaction (CompactOutcome)
 import Agent.CLI.Options (ApprovalPolicy)
 import Agent.CLI.Render (RenderConfig)
 import Agent.CLI.Session (Persistence, SessionHandle)
+import Agent.CLI.SessionState (SessionState)
 import Agent.CLI.SessionTitle (SessionTitleManager)
 import Agent.CLI.Terminal (TerminalCapabilities)
 import Agent.CLI.TUI.App (FullscreenRuntime)
 import Agent.Dialect (Dialect)
 import Agent.Error (ApiError)
-import Agent.Loop (ImageAttachment, LoopConfig, TokenUsage)
+import Agent.Loop (ImageAttachment, LoopConfig)
 import qualified Agent.OpenAI.Auth as OpenAI
-import Agent.Responses.Types (ResponseCreateParams, ResponseItem)
+import Agent.Responses.Types (ResponseCreateParams)
 import System.OsPath (OsPath)
 import Agent.Provider (Credential, Provider, TokenProvider)
 import Agent.Skills (SkillCatalog, SkillInvocation)
@@ -39,11 +40,10 @@ data SessionEnv = SessionEnv
     , sessionDialect :: !Dialect
     , sessionUnavailableProviders :: !(IORef [Provider])
     , sessionStartupUnavailable :: !(IORef (Maybe (STM ApiError)))
-    , sessionPrevious :: !(IORef (Maybe Text))
+    , sessionState :: !(IORef SessionState)
     , sessionPrinted :: !(IORef Bool)
     , sessionParams :: !(IORef ResponseCreateParams)
     , sessionPolicy :: !(IORef ApprovalPolicy)
-    , sessionTranscript :: !(IORef [ResponseItem])
     , sessionPersist :: !Persistence
     , sessionTitleManager :: !SessionTitleManager
     , sessionTitleTurnCount :: !(IORef Int)
@@ -54,7 +54,6 @@ data SessionEnv = SessionEnv
     , sessionSetTempDir :: !(OsPath -> IO ())
     , sessionTokenProvider :: !(Maybe TokenProvider)
     , sessionOpenAiPool :: !(Maybe OpenAI.Pool)
-    , sessionStartupContext :: !(IORef (Maybe Text))
     , sessionSkills :: !(IORef SkillCatalog)
     , sessionSkillInvocations :: !(IORef [SkillInvocation])
     , sessionRefreshSkills :: !(Bool -> IO ())
@@ -64,14 +63,12 @@ data SessionEnv = SessionEnv
     , sessionInterrupt :: !InterruptState
     , sessionRestartEffort :: !(IORef (Maybe Text))
     , sessionStoreRoot :: !(IORef (Maybe OsPath))
-    , sessionUsage :: !(IORef TokenUsage)
     , sessionAccount :: !(IORef Text)
     , sessionAccountId :: !(IORef Text)
     , sessionAccountSelectionId :: !(IORef Text)
     , sessionAccountLabel :: !(Credential -> IO Text)
     , sessionSelectAccount
         :: !(Maybe (Text -> IO (Either ApiError Text)))
-    , sessionLastAssistant :: !(IORef (Maybe Text))
     , sessionTerminal :: !TerminalCapabilities
     , sessionFullscreen :: !(Maybe FullscreenRuntime)
     , sessionSetWindowTitle :: !(Text -> IO ())

--- a/packages/agent-cli/src/Agent/CLI/SessionState.hs
+++ b/packages/agent-cli/src/Agent/CLI/SessionState.hs
@@ -1,0 +1,121 @@
+-- | Coherent mutable state for the live CLI conversation.
+--
+-- The CLI owns one mutable cell containing this record. Transitions stay pure
+-- so turns, compaction, startup context, and UI readers cannot observe
+-- partially committed conversation state.
+module Agent.CLI.SessionState
+    ( SessionState(..)
+    , addSessionTokenUsage
+    , applySessionConversationPatch
+    , appendSessionStartupContext
+    , beginSessionTurn
+    , clearSessionPreviousResponseId
+    , replaceSessionTranscript
+    , resetSessionConversation
+    , setSessionTranscript
+    ) where
+
+import Agent.CLI.TurnState
+    ( ConversationPatch
+    , ConversationState(..)
+    , applyConversationPatch
+    )
+import Agent.Loop (TokenUsage, addTokenUsage, emptyTokenUsage)
+import Agent.Responses.Types (ResponseItem)
+import Data.Maybe (isJust)
+import Data.Text (Text)
+
+data SessionState = SessionState
+    { sessionConversation :: !ConversationState
+    } deriving (Eq, Show)
+
+-- | Snapshot a turn's starting conversation while consuming startup context.
+beginSessionTurn :: SessionState -> (SessionState, ConversationState)
+beginSessionTurn state =
+    ( state
+        { sessionConversation =
+            conversation { conversationStartupContext = Nothing }
+        }
+    , conversation
+    )
+  where
+    conversation = state.sessionConversation
+
+clearSessionPreviousResponseId :: SessionState -> (SessionState, Bool)
+clearSessionPreviousResponseId state =
+    ( state
+        { sessionConversation =
+            conversation { conversationPreviousResponseId = Nothing }
+        }
+    , isJust conversation.conversationPreviousResponseId
+    )
+  where
+    conversation = state.sessionConversation
+
+applySessionConversationPatch
+    :: ConversationPatch
+    -> SessionState
+    -> SessionState
+applySessionConversationPatch patch state =
+    state
+        { sessionConversation =
+            applyConversationPatch patch state.sessionConversation
+        }
+
+addSessionTokenUsage :: TokenUsage -> SessionState -> SessionState
+addSessionTokenUsage usage state =
+    state
+        { sessionConversation =
+            conversation
+                { conversationUsage =
+                    addTokenUsage conversation.conversationUsage usage
+                }
+        }
+  where
+    conversation = state.sessionConversation
+
+appendSessionStartupContext :: Text -> SessionState -> SessionState
+appendSessionStartupContext context state =
+    state
+        { sessionConversation =
+            conversation
+                { conversationStartupContext =
+                    Just $ case conversation.conversationStartupContext of
+                        Nothing -> context
+                        Just existing -> existing <> "\n\n" <> context
+                }
+        }
+  where
+    conversation = state.sessionConversation
+
+setSessionTranscript :: [ResponseItem] -> SessionState -> SessionState
+setSessionTranscript items state =
+    state
+        { sessionConversation =
+            state.sessionConversation
+                { conversationTranscript = items
+                }
+        }
+
+-- | Install compacted local history and detach it from any server-side chain.
+replaceSessionTranscript :: [ResponseItem] -> SessionState -> SessionState
+replaceSessionTranscript items state =
+    state
+        { sessionConversation =
+            state.sessionConversation
+                { conversationPreviousResponseId = Nothing
+                , conversationTranscript = items
+                }
+        }
+
+resetSessionConversation :: Maybe Text -> SessionState -> SessionState
+resetSessionConversation startup state =
+    state
+        { sessionConversation = ConversationState
+            { conversationPreviousResponseId = Nothing
+            , conversationTranscript = []
+            , conversationStartupContext = startup
+            , conversationUsage = emptyTokenUsage
+            , conversationLastAssistant = Nothing
+            }
+        }

--- a/packages/agent-cli/src/Agent/CLI/Skills.hs
+++ b/packages/agent-cli/src/Agent/CLI/Skills.hs
@@ -18,6 +18,10 @@ import Agent.CLI.Command
     )
 import Agent.CLI.Options (CliOptions(..))
 import Agent.CLI.Render (putTextLn)
+import Agent.CLI.SessionState
+    ( SessionState
+    , appendSessionStartupContext
+    )
 import Agent.CLI.Style
     ( glyphSession
     , glyphWarn
@@ -29,7 +33,7 @@ import Agent.CLI.Terminal (resolveColor)
 import Agent.OsPath (toText)
 import Agent.Skills
 import Control.Monad (void, when)
-import Data.IORef (IORef, modifyIORef', writeIORef)
+import Data.IORef (IORef, atomicModifyIORef', writeIORef)
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -123,7 +127,7 @@ reportSkillWarning color warning =
                 <> ": "
                 <> warning.skillWarningMessage)
 
-queueSkillCatalogContext :: IORef (Maybe Text) -> SkillCatalog -> IO ()
+queueSkillCatalogContext :: IORef SessionState -> SkillCatalog -> IO ()
 queueSkillCatalogContext contextRef catalog = do
     omitted <- queueSkillCatalogContextWithOmissions contextRef catalog
     when (omitted > 0) do
@@ -136,17 +140,15 @@ queueSkillCatalogContext contextRef catalog = do
                     <> " omitted from model context due to the catalog budget")
 
 queueSkillCatalogContextWithOmissions
-    :: IORef (Maybe Text)
+    :: IORef SessionState
     -> SkillCatalog
     -> IO Int
 queueSkillCatalogContextWithOmissions contextRef catalog =
     case formatSkillCatalogContext defaultSkillCatalogMaxChars catalog of
         (Nothing, omitted) -> pure omitted
         (Just text, omitted) -> do
-            modifyIORef' contextRef \current ->
-                Just $ case current of
-                    Nothing -> text
-                    Just existing -> existing <> "\n\n" <> text
+            atomicModifyIORef' contextRef \state ->
+                (appendSessionStartupContext text state, ())
             pure omitted
 
 -- | Publish a freshly discovered catalog to all session consumers. Keeping
@@ -155,7 +157,7 @@ queueSkillCatalogContextWithOmissions contextRef catalog =
 installSkillCatalog
     :: [Text]
     -> Bool
-    -> IORef (Maybe Text)
+    -> IORef SessionState
     -> IORef SkillCatalog
     -> IORef [SkillInvocation]
     -> SkillCatalog
@@ -173,7 +175,7 @@ installSkillCatalog reservedNames queueContext contextRef catalogRef invocations
 installSkillCatalogWithOmissions
     :: [Text]
     -> Bool
-    -> IORef (Maybe Text)
+    -> IORef SessionState
     -> IORef SkillCatalog
     -> IORef [SkillInvocation]
     -> SkillCatalog

--- a/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
@@ -218,7 +218,7 @@ prepareCollaborationSpawn
     -> IORef (Map SubagentId SubagentSession)
     -> SubagentStoreRoot
     -> GrokSubagentSpecs
-    -> IORef (Maybe (IORef [ResponseItem]))
+    -> IORef (Maybe (IO [ResponseItem]))
     -> SubagentId
     -> CollaborationSpawnOptions
     -> IO ()
@@ -255,7 +255,7 @@ prepareCollaborationSpawn
             childDialect
             agentId
     source <- readIORef sourceRef
-    sourceItems <- maybe (pure []) readIORef source
+    sourceItems <- maybe (pure []) id source
     writeIORef session.subSessionTranscript
         (forkSubagentTranscript spawnOptions.collaborationForkTurns sourceItems)
 
@@ -803,7 +803,8 @@ prepareChild runtime provider currentEffectiveModel currentDialect env sendToRoo
             currentEffectiveModel
             currentDialect
             env.subId
-    nestedForkSource <- newIORef (Just session.subSessionTranscript)
+    nestedForkSource <-
+        newIORef (Just (readIORef session.subSessionTranscript))
     let sessionDialect = dialectForId session.subSessionDialect
         childToolEnv = childEnv { toolCancel = env.subCancel }
         childCtx = MultiAgentContext

--- a/packages/agent-cli/src/Agent/CLI/Turn.hs
+++ b/packages/agent-cli/src/Agent/CLI/Turn.hs
@@ -53,6 +53,10 @@ import Agent.CLI.Session
     , setGeneratedSessionTitle
     )
 import Agent.CLI.SessionEnv (SessionEnv(..))
+import Agent.CLI.SessionState
+    ( applySessionConversationPatch
+    , beginSessionTurn
+    )
 import Agent.CLI.SessionTitle
     ( SessionTitleResult(..)
     , requestSessionTitle
@@ -76,13 +80,10 @@ import Agent.CLI.Terminal
 import Agent.CLI.Timestamp (stampTurnInputs, stripBracketedTimestamps)
 import Agent.CLI.TurnState
     ( ConversationOutcome(..)
-    , ConversationPatch(..)
-    , FieldUpdate(..)
+    , ConversationState(..)
     , PreparedTurn(..)
-    , StartupUpdate(..)
     , finishConversation
     , inputOnlyTurnItems
-    , restoreStartupContext
     , turnInputsWithContext
     , turnNewItems
     )
@@ -94,7 +95,6 @@ import Agent.Loop
     , LoopProgress(..)
     , LoopResult(..)
     , TurnInput(..)
-    , addTokenUsage
     , runLoopInputsDetailed
     )
 import Agent.Provider (Provider(..))
@@ -144,17 +144,13 @@ runOneTurn :: SessionEnv -> Text -> [TurnInput] -> IO TurnResult
 runOneTurn env@SessionEnv
     { sessionLoop = config
     , sessionRender = render
-    , sessionPrevious = previous
+    , sessionState = sessionStateRef
     , sessionPrinted = printed
-    , sessionTranscript = transcriptRef
     , sessionPersist = persist
     , sessionPlanMode = planMode
-    , sessionStartupContext = startupContext
     , sessionEscPaused = escPaused
     , sessionInterrupt = interrupt
     , sessionStoreRoot = storeRoot
-    , sessionUsage = usageRef
-    , sessionLastAssistant = lastAssistantRef
     , sessionTerminal = terminal
     , sessionFullscreen = fullscreen
     , sessionSetWindowTitle = setWindowTitle
@@ -211,9 +207,13 @@ runOneTurn env@SessionEnv
                 (requestSessionTitle env.sessionTitleManager
                     handle.sessionMeta.metaId 1 promptText)
         PersistenceDisabled -> pure ()
-    prev <- readIORef previous
-    beforeItems <- readIORef transcriptRef
-    pendingStartup <- atomicModifyIORef' startupContext \pendingCtx -> (Nothing, pendingCtx)
+    conversation <-
+        atomicModifyIORef' sessionStateRef \state ->
+            let (state', snapshot) = beginSessionTurn state
+            in (state', snapshot)
+    let prev = conversation.conversationPreviousResponseId
+        beforeItems = conversation.conversationTranscript
+        pendingStartup = conversation.conversationStartupContext
     planActive <- isPlanModeActive planMode
     planPath <- planFilePath planMode
     let planReminder =
@@ -244,23 +244,9 @@ runOneTurn env@SessionEnv
             , preparedConsumedStartup = pendingStartup
             , preparedTurnInputs = turnInputs
             }
-        commitConversationPatch patch = do
-            case patch.patchPreviousResponseId of
-                KeepField -> pure ()
-                SetField value -> writeIORef previous value
-            case patch.patchTranscript of
-                KeepField -> pure ()
-                SetField value -> writeIORef transcriptRef value
-            case patch.patchStartupContext of
-                KeepStartup -> pure ()
-                RestoreStartup consumed ->
-                    atomicModifyIORef' startupContext \current ->
-                        (restoreStartupContext consumed current, ())
-            atomicModifyIORef' usageRef \current ->
-                (addTokenUsage current patch.patchUsageDelta, ())
-            case patch.patchLastAssistant of
-                KeepField -> pure ()
-                SetField value -> writeIORef lastAssistantRef value
+        commitConversationPatch patch =
+            atomicModifyIORef' sessionStateRef \state ->
+                (applySessionConversationPatch patch state, ())
     startedAt <- readIORef render.renderStartedAt
     wallStarted <- getCurrentTime
     when (isNothing fullscreen && terminal.terminalSemanticPrompts) $

--- a/packages/agent-cli/test/Agent/CLI/BtwSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/BtwSpec.hs
@@ -84,7 +84,7 @@ spec = do
                             , backendState = privateTranscript
                             }
             result <- runBtwWithCancel (\_ action -> action)
-                factory mainParams mainTranscript "why?"
+                factory mainParams (readIORef mainTranscript) "why?"
             result `shouldBe` Right "side answer"
             readIORef seenPrevious `shouldReturn` Nothing
             seen <- readIORef seenInputs
@@ -115,7 +115,7 @@ spec = do
                         , backendState = state
                         }
             result <- runBtwWithCancel (\_ action -> action)
-                factory params transcript "do something"
+                factory params (readIORef transcript) "do something"
             result `shouldBe` Left BtwUnexpectedToolCall
             readIORef submissions `shouldReturn` 1
 
@@ -131,10 +131,10 @@ spec = do
                         , backendState = state
                         }
             runBtwWithCancel (\_ action -> action)
-                transport params transcript "why?"
+                transport params (readIORef transcript) "why?"
                 `shouldReturn` Left (BtwTransport (ConnectionError "offline"))
             runBtwWithCancel (\_ action -> action)
-                empty params transcript "why?"
+                empty params (readIORef transcript) "why?"
                 `shouldReturn` Left BtwEmptyResponse
 
     describe "formatBtwError" do

--- a/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
@@ -83,8 +83,8 @@ spec = do
                     record
                     OpenAIProvider
                     Nothing
-                    params
-                    transcript
+                    (readIORef params)
+                    (readIORef transcript)
                     Nothing
             result `shouldSatisfy` either (const False) (const True)
             map requestItems <$> readIORef requests
@@ -104,8 +104,8 @@ spec = do
                     (\_ -> getMaskingState >>= writeIORef recorderMasking)
                     OpenAIProvider
                     Nothing
-                    params
-                    transcript
+                    (readIORef params)
+                    (readIORef transcript)
                     Nothing
             result `shouldSatisfy` either (const False) (const True)
             readIORef senderMasking `shouldReturn` Unmasked
@@ -121,8 +121,8 @@ spec = do
                     (\usage -> modifyIORef' recordedUsage (<> [usage]))
                     OpenAIProvider
                     Nothing
-                    params
-                    transcript
+                    (readIORef params)
+                    (readIORef transcript)
                     (Just "focus")
             result `shouldSatisfy` \case
                 Left message ->
@@ -141,8 +141,8 @@ spec = do
                     (\usage -> modifyIORef' recordedUsage (<> [usage]))
                     OpenAIProvider
                     Nothing
-                    params
-                    transcript
+                    (readIORef params)
+                    (readIORef transcript)
                     Nothing
             result `shouldSatisfy` \case
                 Left message -> "offline" `Text.isInfixOf` message
@@ -159,8 +159,8 @@ spec = do
                     (\usage -> modifyIORef' recordedUsage (<> [usage]))
                     OpenAIProvider
                     Nothing
-                    params
-                    transcript
+                    (readIORef params)
+                    (readIORef transcript)
                     Nothing
             result `shouldSatisfy` \case
                 Left message ->
@@ -170,8 +170,11 @@ spec = do
 
     describe "installCompactOutcome" do
         it "clears the previous response id with transcript and token state" do
-            previous <- newIORef (Just "resp-old")
-            transcript <- newIORef [userTextItem "old context"]
+            conversation <-
+                newIORef
+                    ( Just "resp-old"
+                    , [userTextItem "old context"]
+                    ) :: IO (IORef (Maybe Text, [ResponseItem]))
             contextState <- newIORef (Just (100, 1))
             actionMasking <- newIORef MaskedUninterruptible
             let compactedHistory = [userTextItem "compacted context"]
@@ -185,33 +188,35 @@ spec = do
                     getMaskingState >>= writeIORef actionMasking
                     pure (Right outcome)
             installCompactOutcome
-                previous
-                transcript
+                (\installed ->
+                    writeIORef conversation
+                        (Nothing, installed.compactHistory))
                 (Just contextState)
                 compactAction
                 Nothing
                 `shouldReturn` Right outcome
             readIORef actionMasking `shouldReturn` Unmasked
-            readIORef previous `shouldReturn` Nothing
-            readIORef transcript `shouldReturn` compactedHistory
+            readIORef conversation `shouldReturn` (Nothing, compactedHistory)
             readIORef contextState `shouldReturn`
                 Just (outcome.compactAfterTokens, length compactedHistory)
 
         it "leaves live state unchanged when compaction fails" do
             let oldHistory = [userTextItem "old context"]
                 oldContextState = Just (100, length oldHistory)
-            previous <- newIORef (Just "resp-old")
-            transcript <- newIORef oldHistory
+            conversation <-
+                newIORef (Just "resp-old", oldHistory)
+                    :: IO (IORef (Maybe Text, [ResponseItem]))
             contextState <- newIORef oldContextState
             installCompactOutcome
-                previous
-                transcript
+                (\installed ->
+                    writeIORef conversation
+                        (Nothing, installed.compactHistory))
                 (Just contextState)
                 (const (pure (Left "failed")))
                 Nothing
                 `shouldReturn` Left "failed"
-            readIORef previous `shouldReturn` Just "resp-old"
-            readIORef transcript `shouldReturn` oldHistory
+            readIORef conversation `shouldReturn`
+                (Just "resp-old", oldHistory)
             readIORef contextState `shouldReturn` oldContextState
 
     describe "compactOpenAIWith" do

--- a/packages/agent-cli/test/Agent/CLI/SessionStateSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SessionStateSpec.hs
@@ -1,0 +1,87 @@
+module Agent.CLI.SessionStateSpec (spec) where
+
+import Agent.CLI.SessionState
+import Agent.CLI.TurnState
+import Agent.Loop (TokenUsage(..), TurnInput(..), emptyTokenUsage)
+import Agent.Responses.LoopBackend (turnInputsToItems)
+import Test.Hspec
+
+spec :: Spec
+spec = describe "Agent.CLI.SessionState" do
+    it "snapshots a turn and consumes startup context atomically" do
+        let initial = testState
+                { sessionConversation =
+                    initialConversation
+                        { conversationStartupContext = Just "instructions"
+                        }
+                }
+            (started, snapshot) = beginSessionTurn initial
+        snapshot.conversationStartupContext `shouldBe` Just "instructions"
+        started.sessionConversation.conversationStartupContext
+            `shouldBe` Nothing
+
+    it "applies turn deltas without losing concurrently queued state" do
+        let concurrent = testState
+                { sessionConversation =
+                    initialConversation
+                        { conversationStartupContext = Just "new skills"
+                        , conversationUsage = TokenUsage 3 2 1
+                        }
+                }
+            patch = ConversationPatch
+                { patchPreviousResponseId = SetField (Just "resp-1")
+                , patchTranscript = KeepField
+                , patchStartupContext = RestoreStartup "instructions"
+                , patchUsageDelta = TokenUsage 7 5 2
+                , patchLastAssistant = SetField (Just "answer")
+                }
+            updated =
+                applySessionConversationPatch patch concurrent
+                    |> (.sessionConversation)
+        updated.conversationPreviousResponseId `shouldBe` Just "resp-1"
+        updated.conversationStartupContext
+            `shouldBe` Just "instructions\n\nnew skills"
+        updated.conversationUsage `shouldBe` TokenUsage 10 7 3
+        updated.conversationLastAssistant `shouldBe` Just "answer"
+
+    it "installs compaction without disturbing unrelated conversation state" do
+        let compacted = turnInputsToItems [UserMessage "summary"]
+            initial = testState
+                { sessionConversation =
+                    initialConversation
+                        { conversationPreviousResponseId = Just "resp-old"
+                        , conversationStartupContext = Just "queued"
+                        , conversationUsage = TokenUsage 8 4 2
+                        , conversationLastAssistant = Just "answer"
+                        }
+                }
+            updated =
+                replaceSessionTranscript compacted initial
+                    |> (.sessionConversation)
+        updated.conversationPreviousResponseId `shouldBe` Nothing
+        updated.conversationTranscript `shouldBe` compacted
+        updated.conversationStartupContext `shouldBe` Just "queued"
+        updated.conversationUsage `shouldBe` TokenUsage 8 4 2
+        updated.conversationLastAssistant `shouldBe` Just "answer"
+
+    it "resets all conversation-owned fields together" do
+        let reset = resetSessionConversation (Just "fresh") testState
+                |> (.sessionConversation)
+        reset `shouldBe` initialConversation
+            { conversationStartupContext = Just "fresh"
+            }
+
+testState :: SessionState
+testState = SessionState initialConversation
+
+initialConversation :: ConversationState
+initialConversation = ConversationState
+    { conversationPreviousResponseId = Nothing
+    , conversationTranscript = []
+    , conversationStartupContext = Nothing
+    , conversationUsage = emptyTokenUsage
+    , conversationLastAssistant = Nothing
+    }
+
+(|>) :: a -> (a -> b) -> b
+value |> f = f value

--- a/packages/agent-cli/test/Agent/CLI/SkillsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SkillsSpec.hs
@@ -2,7 +2,10 @@ module Agent.CLI.SkillsSpec (spec) where
 
 import Agent.CLI.Command (SkillCommand(..))
 import Agent.CLI.Options (CliOptions(..), defaultCliOptions)
+import Agent.CLI.SessionState (SessionState(..))
 import Agent.CLI.Skills
+import Agent.CLI.TurnState (ConversationState(..))
+import Agent.Loop (emptyTokenUsage)
 import System.OsPath (unsafeEncodeUtf)
 import Agent.Skills
 import Data.IORef (newIORef, readIORef)
@@ -49,11 +52,12 @@ spec = describe "Agent.CLI.Skills" do
         map (.skillModelInvocable) matching `shouldBe` [True]
 
     it "queues skill metadata after existing startup context" do
-        context <- newIORef (Just "agents")
+        context <- newIORef (testSessionState (Just "agents"))
         _ <- queueSkillCatalogContextWithOmissions
             context
             (SkillCatalog [fakeSkill] [])
-        readIORef context >>= \case
+        (.sessionConversation.conversationStartupContext)
+            <$> readIORef context >>= \case
             Nothing -> expectationFailure "expected startup context"
             Just text -> do
                 text `shouldSatisfy` Text.isPrefixOf "agents\n\n## Skills"
@@ -69,7 +73,7 @@ spec = describe "Agent.CLI.Skills" do
             }
 
     it "installs a deferred catalog, invocations, and startup context together" do
-        context <- newIORef (Just "agents")
+        context <- newIORef (testSessionState (Just "agents"))
         catalogRef <- newIORef (SkillCatalog [] [])
         invocationsRef <- newIORef []
         let catalog = SkillCatalog [fakeSkill] []
@@ -78,7 +82,8 @@ spec = describe "Agent.CLI.Skills" do
         readIORef catalogRef `shouldReturn` catalog
         readIORef invocationsRef `shouldReturn`
             [SkillInvocation "deploy" fakeSkill True]
-        readIORef context >>= \case
+        (.sessionConversation.conversationStartupContext)
+            <$> readIORef context >>= \case
             Nothing -> expectationFailure "expected startup context"
             Just text ->
                 text `shouldSatisfy` Text.isPrefixOf "agents\n\n## Skills"
@@ -107,3 +112,15 @@ fakeSkill = Skill
     , skillScope = UserSkill
     , skillOrigin = AgentSkills
     }
+
+testSessionState :: Maybe Text.Text -> SessionState
+testSessionState startup =
+    SessionState
+        { sessionConversation = ConversationState
+            { conversationPreviousResponseId = Nothing
+            , conversationTranscript = []
+            , conversationStartupContext = startup
+            , conversationUsage = emptyTokenUsage
+            , conversationLastAssistant = Nothing
+            }
+        }

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -43,6 +43,7 @@ import qualified Agent.CLI.ReplStatusSpec as ReplStatusSpec
 import qualified Agent.CLI.ResumeSpec as ResumeSpec
 import qualified Agent.CLI.SecretSpec as SecretSpec
 import qualified Agent.CLI.SessionSpec as SessionSpec
+import qualified Agent.CLI.SessionStateSpec as SessionStateSpec
 import qualified Agent.CLI.SessionTitleSpec as SessionTitleSpec
 import qualified Agent.CLI.SkillsSpec as SkillsSpec
 import qualified Agent.CLI.SubagentStoreSpec as SubagentStoreSpec
@@ -110,6 +111,7 @@ main = hspec do
     TelegramSpec.spec
     TextLayoutSpec.spec
     SessionSpec.spec
+    SessionStateSpec.spec
     SessionTitleSpec.spec
     SkillsSpec.spec
     SubagentStoreSpec.spec


### PR DESCRIPTION
## Summary

- add a CLI-owned `SessionState` record around the existing pure `ConversationState`
- replace five independent session refs (previous response, transcript, startup context, usage, last assistant) with one atomic state cell
- interpret turn patches, backend transcript commits, compaction installs, resets, model-chain clearing, skill context queueing, `/btw`, UI reads, and subagent fork snapshots through pure transitions/getters
- preserve usage deltas and startup-context merges so concurrent compaction or skill refresh updates are not lost

## Foundation and scope

The pure turn-state work from #304 and the explicit `BackendStateStore` API are already in `master`, so this PR has no stacked backend-state dependency.

This is the first coherent batch. It intentionally leaves request/UI refs, skill catalog/invocation refs, and account/auth display refs for separate follow-ups rather than mixing unrelated lifecycle owners into this review.

## Validation

- Nix multi-package REPL loaded `Agent.CLI` across CLI, core, TUI, responses, dialect, and provider libraries (187 modules)
- `nix develop -c cabal test agent-cli:test:agent-cli-test --test-show-details=direct` (767 examples, 0 failures)
- tmux minimal-mode smoke: live prompt plus successful `/clear`
- tmux fullscreen smoke: retained UI plus successful `/clear` and refreshed prompt
- independent concurrency/semantics review: no actionable findings
