### PR TITLE
refactor: thread provider backend state explicitly

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -51,7 +51,7 @@ import Agent.CLI.SessionTitle
     , invalidateSessionTitles
     , requestSessionTitle
     , waitForSessionTitleResults
-    , withSessionTitleManager
+    , withSessionTitleManagerExplicit
     )
 import Agent.CLI.AgentSessions
     ( AgentSessionToolsEnv(..)
@@ -69,9 +69,9 @@ import Agent.CLI.Approval
     , toggleAlwaysApprove
     )
 import Agent.CLI.Btw
-    ( BtwBackendFactory
+    ( ExplicitBtwBackendFactory
     , formatBtwError
-    , runBtwWithCancel
+    , runBtwWithCancelExplicit
     )
 import Agent.CLI.CancelWatch (withEscCancel, withStdinPaused)
 import Agent.CLI.Clipboard
@@ -249,13 +249,13 @@ import Agent.CLI.Subagents.Runtime
     , SubagentSession(..)
     , SubagentStoreRoot
     , flushAllSubagentSnapshots
-    , freshOpenAiBackend
+    , freshOpenAiBackendWithParams
     , lookupOrCreateSubagentSession
     , persistAndEvictSubagentSessionWithStatus
     , prepareCollaborationSpawn
     , restoreAgentFromDisk
     , runCodexSubagent
-    , runHttpSubagent
+    , runHttpSubagentWithParams
     )
 import Agent.CLI.Style
     ( beginBackground
@@ -382,7 +382,10 @@ import Agent.OpenAI.LoopBackend
     , openAiResponseSenderReconnecting
     )
 import Agent.Responses.Types
-import Agent.Responses.GenericBackend (genericResponsesBackendWith)
+import Agent.Responses.GenericBackend
+    ( genericResponsesBackendWith
+    , genericResponsesBackendWithFixedParams
+    )
 import Agent.Responses.GenericClient (GenericClientOptions(..))
 import qualified Agent.Responses.GenericClient as GenericResponses
 import Agent.OpenAI.Usage (fetchUsage)
@@ -451,10 +454,13 @@ import Agent.Tools.Types
     , defaultToolEnv
     , setToolSessionTmp
     )
-import Agent.OpenRouter.LoopBackend (openRouterBackend)
+import Agent.OpenRouter.LoopBackend
+    ( openRouterBackend
+    , openRouterBackendWithParams
+    )
 import qualified Agent.OpenRouter as OpenRouter
 import Agent.OsPath (fromText, toText, unsafeToFilePath)
-import Agent.XAI.LoopBackend (xaiBackend)
+import Agent.XAI.LoopBackend (xaiBackend, xaiBackendWithParams)
 import qualified Agent.XAI.Options as XAI
 import Control.Applicative ((<|>))
 import Control.Concurrent.Async (link, mapConcurrently, waitSTM, withAsync)
@@ -2202,10 +2208,9 @@ runAgentInitializedWithLock
                                     noticingBackend =
                                         withPendingInputs pendingNotices
                                             lockedBackend
-                                    btwBackend privateParams =
-                                        freshOpenAiBackend
+                                    btwBackend =
+                                        freshOpenAiBackendWithParams
                                             tokenProvider
-                                            (readIORef privateParams)
                                     compactRunner focus =
                                         withMVar wsLock \_ ->
                                             installCompactOutcome
@@ -2260,23 +2265,21 @@ runAgentInitializedWithLock
                         case multiCtx of
                             Just ctx ->
                                 setSubagentRunner ctx.multiRegistry $
-                                    runHttpSubagent
+                                    runHttpSubagentWithParams
                                         subagentRuntime
                                         dialect
                                         XAIProvider
                                         ctx.multiSendToRoot
-                                        (\childParamsRef ->
-                                            xaiBackend xaiOptions tokenProvider
-                                                (readIORef childParamsRef))
+                                        (xaiBackendWithParams
+                                            xaiOptions tokenProvider)
                             Nothing -> pure ()
                         let backend =
                                 withPendingInputs pendingNotices $
                                     withConnectionRecovery $
                                         xaiBackend xaiOptions tokenProvider
                                             (readIORef paramsRef)
-                            btwBackend privateParams =
-                                xaiBackend xaiOptions tokenProvider
-                                    (readIORef privateParams)
+                            btwBackend =
+                                xaiBackendWithParams xaiOptions tokenProvider
                             compactRunner =
                                 installCompactOutcome previousRef transcriptRef Nothing $
                                     runProviderCompactWith
@@ -2293,7 +2296,7 @@ runAgentInitializedWithLock
                             previousRef persist projectRoot home cwd (Just tokenProvider) loaded.loadedOpenAiPool startupContext skillsRef skillInvocationsRef escPaused interrupt
                             multiCtx rootTurnRef subagentSessions pendingNotices subagentStoreRoot agentTypesRef legacySubagentTarget usageRef activeAccountRef activeAccountIdRef activeSelectionRef resolveActiveAccountLabel (if isJust customGenericOptions then Nothing else Just selectHttpAccount) claimCurrentSession compactRunner activeBackend btwBackend
                     OpenRouterProvider -> do
-                        let makeBackend params =
+                        let makeBackend getParams =
                                 case customGenericOptions of
                                     Just genericOptions ->
                                         genericResponsesBackendWith
@@ -2308,30 +2311,47 @@ runAgentInitializedWithLock
                                                         }
                                                     request
                                                     onEvent)
-                                            params
+                                            getParams
                                     Nothing ->
                                         openRouterBackend openRouterOptions
-                                            tokenProvider params
+                                            tokenProvider getParams
+                            makeBackendWithParams params =
+                                case customGenericOptions of
+                                    Just genericOptions ->
+                                        genericResponsesBackendWithFixedParams
+                                            (\request onEvent ->
+                                                GenericResponses.createResponseWithEvents
+                                                    genericOptions
+                                                        { GenericResponses.model =
+                                                            transportModel
+                                                                (fromMaybe
+                                                                    model
+                                                                    request.model)
+                                                        }
+                                                    request
+                                                    onEvent)
+                                            params
+                                    Nothing ->
+                                        openRouterBackendWithParams
+                                            openRouterOptions
+                                            tokenProvider
+                                            params
                         case multiCtx of
                             Just ctx ->
                                 setSubagentRunner ctx.multiRegistry $
-                                    runHttpSubagent
+                                    runHttpSubagentWithParams
                                         subagentRuntime
                                         dialect
                                         OpenRouterProvider
                                         ctx.multiSendToRoot
-                                        (\childParamsRef ->
-                                            makeBackend
-                                                (readIORef childParamsRef))
+                                        makeBackendWithParams
                             Nothing -> pure ()
                         let backend =
                                 withPendingInputs pendingNotices $
                                     withConnectionRecovery $
                                         makeBackend
                                             (readIORef paramsRef)
-                            btwBackend privateParams =
-                                makeBackend
-                                    (readIORef privateParams)
+                            btwBackend = makeBackendWithParams
                             compactRunner =
                                 installCompactOutcome previousRef transcriptRef Nothing $
                                     case customGenericOptions of
@@ -2589,7 +2609,7 @@ runSession
     -> (SessionHandle -> IO ())
     -> (Maybe Text -> IO (Either Text CompactOutcome))
     -> Backend
-    -> BtwBackendFactory
+    -> ExplicitBtwBackendFactory
     -> IO RunResult
 runSession catalog connectionId options provider dialect policy tools toolEnv planMode startup prompt pendingTurn initialDraft unavailableProviders startupUnavailable paramsRef transcriptRef initialTurns previous persist projectRoot home cwd tokenProvider openAiPool startupContext skillsRef skillInvocationsRef escPaused interrupt multiCtx rootTurnRef subagentSessions pendingNotices storeRoot agentTypes legacyTarget usageRef accountRef accountIdRef selectionRef accountLabel selectAccount onPersisted compactRunner backend btwBackend = do
   initialPrevious <- readIORef previous
@@ -2639,7 +2659,8 @@ runSession catalog connectionId options provider dialect policy tools toolEnv pl
                                               (roleWarn color
                                                   (glyphWarn <> message))
                       _ -> pure ()
-  withSessionTitleManager btwBackend paramsRef showTitleEvent \titleManager -> do
+  withSessionTitleManagerExplicit btwBackend (readIORef paramsRef)
+        showTitleEvent \titleManager -> do
     toolRegistry <- requireToolRegistry tools
     printed <- newIORef False
     attachmentsRef <- newIORef []
@@ -4114,8 +4135,10 @@ replWithDraft env@SessionEnv
                                 (Just
                                     (progressNotice
                                         "btw · asking…")))
+                        params <- readIORef paramsRef
+                        transcript <- readIORef transcriptRef
                         result <-
-                            runBtwWithCancel
+                            runBtwWithCancelExplicit
                                 (\cancel action ->
                                     withTurnCancel interrupt cancel $
                                         case fullscreen of
@@ -4124,8 +4147,8 @@ replWithDraft env@SessionEnv
                                                     cancel escPaused action
                                             Just _ -> action)
                                 btwBackend
-                                paramsRef
-                                transcriptRef
+                                params
+                                transcript
                                 question
                         case result of
                             Left err -> do

--- a/packages/agent-cli/src/Agent/CLI/Btw.hs
+++ b/packages/agent-cli/src/Agent/CLI/Btw.hs
@@ -1,9 +1,13 @@
 -- | Isolated one-shot side questions over a snapshot of the main transcript.
 module Agent.CLI.Btw
     ( BtwBackendFactory
+    , ExplicitBtwBackendFactory
     , BtwError(..)
+    , adaptExplicitBtwBackendFactory
+    , adaptLegacyBtwBackendFactory
     , formatBtwError
     , runBtwWithCancel
+    , runBtwWithCancelExplicit
     , sideQuestionPrompt
     , trimDanglingToolSuffix
     ) where
@@ -36,8 +40,34 @@ import Data.Text (Text)
 import qualified Data.Text as Text
 
 -- | Construct a provider backend over private request parameters and transcript.
+--
+-- This legacy alias is retained for downstream callers. New code should use
+-- 'ExplicitBtwBackendFactory' so immutable side-request parameters are passed
+-- directly rather than hidden in a private reference.
 type BtwBackendFactory =
     IORef ResponseCreateParams -> Backend
+
+type ExplicitBtwBackendFactory =
+    ResponseCreateParams -> Backend
+
+-- | Adapt an explicit factory to the legacy reference-taking API.
+adaptExplicitBtwBackendFactory
+    :: ExplicitBtwBackendFactory
+    -> BtwBackendFactory
+adaptExplicitBtwBackendFactory makeBackend paramsRef =
+    Backend \state previous inputs onEvent -> do
+        params <- readIORef paramsRef
+        (makeBackend params).submitTurn state previous inputs onEvent
+
+-- | Adapt a legacy reference-taking factory to the explicit API. The private
+-- reference is confined to this migration adapter.
+adaptLegacyBtwBackendFactory
+    :: BtwBackendFactory
+    -> ExplicitBtwBackendFactory
+adaptLegacyBtwBackendFactory makeBackend params =
+    Backend \state previous inputs onEvent -> do
+        privateParams <- newIORef params
+        (makeBackend privateParams).submitTurn state previous inputs onEvent
 
 data BtwError
     = BtwTransport !ApiError
@@ -124,9 +154,39 @@ runBtwWithCancel
 runBtwWithCancel withCancelScope makeBackend paramsRef transcriptRef question = do
     params <- clearTurnSpecificParams <$> readIORef paramsRef
     transcript <- trimDanglingToolSuffix <$> readIORef transcriptRef
-    privateParams <- newIORef params
+    runBtwWithCancelUsing withCancelScope
+        (\fixedParams -> makeBackend <$> newIORef fixedParams)
+        params transcript question
+
+runBtwWithCancelExplicit
+    :: (CancelFlag
+        -> IO (Either BtwError Text)
+        -> IO (Either BtwError Text))
+    -> ExplicitBtwBackendFactory
+    -> ResponseCreateParams
+    -> [ResponseItem]
+    -> Text
+    -> IO (Either BtwError Text)
+runBtwWithCancelExplicit withCancelScope makeBackend params transcript question =
+    runBtwWithCancelUsing withCancelScope
+        (pure . makeBackend)
+        (clearTurnSpecificParams params)
+        (trimDanglingToolSuffix transcript)
+        question
+
+runBtwWithCancelUsing
+    :: (CancelFlag
+        -> IO (Either BtwError Text)
+        -> IO (Either BtwError Text))
+    -> (ResponseCreateParams -> IO Backend)
+    -> ResponseCreateParams
+    -> [ResponseItem]
+    -> Text
+    -> IO (Either BtwError Text)
+runBtwWithCancelUsing withCancelScope makeBackend params transcript question = do
+    backend <- makeBackend params
     cancel <- newCancelFlag
-    let Backend submit = makeBackend privateParams
+    let Backend submit = backend
         request =
             submit transcript Nothing
                 [UserMessage (sideQuestionPrompt question)] (\_ -> pure ())

--- a/packages/agent-cli/src/Agent/CLI/SessionEnv.hs
+++ b/packages/agent-cli/src/Agent/CLI/SessionEnv.hs
@@ -6,7 +6,7 @@ module Agent.CLI.SessionEnv
 import Agent.CLI.Interrupt (InterruptState)
 import Agent.CLI.AgentViewport (AgentViewportEnv)
 import Agent.CLI.ModelConfig (ModelCatalog)
-import Agent.CLI.Btw (BtwBackendFactory)
+import Agent.CLI.Btw (ExplicitBtwBackendFactory)
 import Agent.CLI.Compaction (CompactOutcome)
 import Agent.CLI.Options (ApprovalPolicy)
 import Agent.CLI.Render (RenderConfig)
@@ -30,7 +30,7 @@ import Control.Concurrent.STM (STM)
 
 data SessionEnv = SessionEnv
     { sessionLoop :: !LoopConfig
-    , sessionBtwBackend :: !BtwBackendFactory
+    , sessionBtwBackend :: !ExplicitBtwBackendFactory
     , sessionCompact :: !(Maybe Text -> IO (Either Text CompactOutcome))
     , sessionRender :: !RenderConfig
     , sessionProvider :: !Provider

--- a/packages/agent-cli/src/Agent/CLI/SessionTitle.hs
+++ b/packages/agent-cli/src/Agent/CLI/SessionTitle.hs
@@ -11,9 +11,13 @@ module Agent.CLI.SessionTitle
     , titleRefreshIndex
     , waitForSessionTitleResults
     , withSessionTitleManager
+    , withSessionTitleManagerExplicit
     ) where
 
-import Agent.CLI.Btw (BtwBackendFactory)
+import Agent.CLI.Btw
+    ( BtwBackendFactory
+    , ExplicitBtwBackendFactory
+    )
 import Agent.CLI.Error (formatApiErrorInline)
 import Agent.Loop
     ( Backend(..)
@@ -70,8 +74,8 @@ data SessionTitleManager = SessionTitleManager
     , titleResults :: !(TQueue SessionTitleResult)
     , titleRequested :: !(TVar (Set (Text, Int, Int)))
     , titleGenerations :: !(TVar (Map Text Int))
-    , titleBackendFactory :: !BtwBackendFactory
-    , titleParams :: !(IORef ResponseCreateParams)
+    , titleBackendFactory :: !(ResponseCreateParams -> IO Backend)
+    , titleParams :: !(IO ResponseCreateParams)
     }
 
 withSessionTitleManager
@@ -81,6 +85,28 @@ withSessionTitleManager
     -> (SessionTitleManager -> IO a)
     -> IO a
 withSessionTitleManager backendFactory paramsRef onEvent action = do
+    withSessionTitleManagerUsing
+        (\params -> backendFactory <$> newIORef params)
+        (readIORef paramsRef)
+        onEvent
+        action
+
+withSessionTitleManagerExplicit
+    :: ExplicitBtwBackendFactory
+    -> IO ResponseCreateParams
+    -> (SessionTitleEvent -> IO ())
+    -> (SessionTitleManager -> IO a)
+    -> IO a
+withSessionTitleManagerExplicit backendFactory =
+    withSessionTitleManagerUsing (pure . backendFactory)
+
+withSessionTitleManagerUsing
+    :: (ResponseCreateParams -> IO Backend)
+    -> IO ResponseCreateParams
+    -> (SessionTitleEvent -> IO ())
+    -> (SessionTitleManager -> IO a)
+    -> IO a
+withSessionTitleManagerUsing backendFactory getParams onEvent action = do
     jobs <- newTQueueIO
     results <- newTQueueIO
     requested <- newTVarIO Set.empty
@@ -91,7 +117,7 @@ withSessionTitleManager backendFactory paramsRef onEvent action = do
             , titleRequested = requested
             , titleGenerations = generations
             , titleBackendFactory = backendFactory
-            , titleParams = paramsRef
+            , titleParams = getParams
             }
     withAsync (titleWorker onEvent manager) \_ -> action manager
 
@@ -202,11 +228,9 @@ titleWorker onEvent manager = forever do
 
 generateTitle :: SessionTitleManager -> SessionTitleJob -> IO (Either Text Text)
 generateTitle manager job = do
-    baseParams <- readIORef manager.titleParams
+    baseParams <- manager.titleParams
     let params = titleRequestParams baseParams
-    privateParams <- newIORef params
-    let Backend submit =
-            manager.titleBackendFactory privateParams
+    Backend submit <- manager.titleBackendFactory params
     timeout 45000000
         (submit [] Nothing
             [UserMessage (titlePrompt job.jobSource)] (\_ -> pure ()))

--- a/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
@@ -5,6 +5,7 @@ module Agent.CLI.Subagents.Runtime
     , SubagentStoreRoot
     , flushAllSubagentSnapshots
     , freshOpenAiBackend
+    , freshOpenAiBackendWithParams
     , lookupOrCreateSubagentSession
     , persistAndEvictSubagentSessionWithStatus
     , persistSubagentSnapshotWithStatus
@@ -12,6 +13,7 @@ module Agent.CLI.Subagents.Runtime
     , restoreAgentFromDisk
     , runCodexSubagent
     , runHttpSubagent
+    , runHttpSubagentWithParams
     , validatePersistedSubagentTarget
     ) where
 
@@ -543,6 +545,13 @@ freshOpenAiBackend provider getParams = Backend \state previous inputs onEvent -
         let Backend submit = openAiBackend conn getParams
         in submit state previous inputs onEvent
 
+freshOpenAiBackendWithParams
+    :: TokenProvider
+    -> ResponseCreateParams
+    -> Backend
+freshOpenAiBackendWithParams provider params =
+    freshOpenAiBackend provider (pure params)
+
 -- | Child Codex agent: per-agent transcript retained across follow-ups,
 -- independently scoped WebSocket requests, and nested multi-agent tools.
 runCodexSubagent
@@ -613,17 +622,16 @@ runCodexSubagent runtime tokenProvider sendToRoot =
                         childParams = requestParams model instructions
                             (schemasFromAppTools codexDialect tools) effort
                     toolRegistry <- requireToolRegistry tools
-                    childParamsRef <- newIORef childParams
                     httpFallbackActive <- newIORef False
                     let websocketBackend =
-                            freshOpenAiBackend tokenProvider
-                                (readIORef childParamsRef)
+                            freshOpenAiBackendWithParams
+                                tokenProvider childParams
                         httpBackend =
                             statelessResponsesBackend
                                 (\request _onEvent ->
                                     OpenAI.createCodexMessageWithProvider
                                         tokenProvider request)
-                                (readIORef childParamsRef)
+                                (pure childParams)
                         baseBackend =
                             openAiBackendWithTransportFallback
                                 httpFallbackActive
@@ -634,7 +642,7 @@ runCodexSubagent runtime tokenProvider sendToRoot =
                                 autoCompactOpenAiBackendWithThreshold
                                     runtime.subagentOptions.optCompactThreshold
                                     tokenProvider
-                                    (readIORef childParamsRef)
+                                    (pure childParams)
                                     prepared.preparedSession.subSessionContextTokens
                                     baseBackend
                     runPreparedChild
@@ -652,6 +660,28 @@ runHttpSubagent
     -> (IORef ResponseCreateParams -> Backend)
     -> RunSubagent
 runHttpSubagent runtime dialect provider sendToRoot mkBackend =
+    runHttpSubagentUsing runtime dialect provider sendToRoot
+        (\params -> mkBackend <$> newIORef params)
+
+runHttpSubagentWithParams
+    :: SubagentRuntime
+    -> Dialect
+    -> Provider
+    -> Maybe (InterAgentMessage -> IO (Either Text Text))
+    -> (ResponseCreateParams -> Backend)
+    -> RunSubagent
+runHttpSubagentWithParams runtime dialect provider sendToRoot mkBackend =
+    runHttpSubagentUsing runtime dialect provider sendToRoot
+        (pure . mkBackend)
+
+runHttpSubagentUsing
+    :: SubagentRuntime
+    -> Dialect
+    -> Provider
+    -> Maybe (InterAgentMessage -> IO (Either Text Text))
+    -> (ResponseCreateParams -> IO Backend)
+    -> RunSubagent
+runHttpSubagentUsing runtime dialect provider sendToRoot mkBackend =
     \env previous prompt onEvent -> do
         agentType <-
             fromMaybe defaultSubagentType
@@ -758,10 +788,8 @@ runHttpSubagent runtime dialect provider sendToRoot mkBackend =
                         childParams = requestParams model instructions
                             (schemasFromAppTools childDialect tools) effort
                     toolRegistry <- requireToolRegistry tools
-                    childParamsRef <- newIORef childParams
-                    let backend =
-                            withConnectionRecovery $
-                                mkBackend childParamsRef
+                    childBackend <- mkBackend childParams
+                    let backend = withConnectionRecovery childBackend
                     runPreparedChild
                         runtime env prepared.preparedSession toolRegistry
                         backend onEvent

--- a/packages/agent-cli/test/Agent/CLI/BtwSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/BtwSpec.hs
@@ -53,7 +53,7 @@ spec = do
             trimDanglingToolSuffix items `shouldBe` items
 
     describe "runBtwWithCancel" do
-        it "uses private state and preserves parent params including tools" do
+        it "threads explicit state and preserves parent params including tools" do
             let originalItems = turnInputsToItems [UserMessage "earlier context"]
                 tool = KnownResponseTool ToolWebSearch
                     (TaggedObject "web_search" KeyMap.empty)
@@ -75,7 +75,7 @@ spec = do
                     Backend \privateTranscript previous inputs _onEvent -> do
                         writeIORef seenPrevious previous
                         writeIORef seenInputs inputs
-                        writeIORef seenPrivateParams . Just =<< readIORef privateParams
+                        writeIORef seenPrivateParams (Just privateParams)
                         writeIORef seenPrivateTranscript privateTranscript
                         pure $ Right BackendResult
                             { backendOutput =
@@ -83,8 +83,8 @@ spec = do
                                     "side-response" [] (Just "side answer")
                             , backendState = privateTranscript
                             }
-            result <- runBtwWithCancel (\_ action -> action)
-                factory mainParams mainTranscript "why?"
+            result <- runBtwWithCancelExplicit (\_ action -> action)
+                factory originalParams originalItems "why?"
             result `shouldBe` Right "side answer"
             readIORef seenPrevious `shouldReturn` Nothing
             seen <- readIORef seenInputs

--- a/packages/agent-cli/test/Agent/CLI/SessionTitleSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SessionTitleSpec.hs
@@ -47,14 +47,15 @@ spec = describe "Agent.CLI.SessionTitle" do
         paramsRef <- newIORef baseParams
         let backendFactory privateParams =
                 Backend \state _ _ _ -> do
-                    writeIORef seenParams . Just =<< readIORef privateParams
+                    writeIORef seenParams (Just privateParams)
                     pure $ Right BackendResult
                         { backendOutput =
                             emptyTurnOutput "title-response" []
                                 (Just "Auth race cleanup")
                         , backendState = state
                         }
-        withSessionTitleManager backendFactory paramsRef (putMVar notified) \manager -> do
+        withSessionTitleManagerExplicit backendFactory (readIORef paramsRef)
+                (putMVar notified) \manager -> do
             requestSessionTitle manager "session-1" 3 "conversation"
             results <- waitForResults manager 100
             let expected = SessionTitleResult

--- a/packages/agent-core/src/Agent/Retry.hs
+++ b/packages/agent-core/src/Agent/Retry.hs
@@ -1,12 +1,48 @@
 module Agent.Retry
-    ( ExceptionRetry(..)
+    ( AttemptObservation(..)
+    , AttemptOutcome(..)
+    , ExceptionRetry(..)
     , handleSyncExceptions
+    , runObservedAttempt
     , retryingBeforeCommit
     ) where
 
 import qualified Control.Exception.Safe as Safe
 import Control.Retry (RetryPolicyM, retrying)
 import Data.IORef (newIORef, readIORef, writeIORef)
+
+-- | Whether an attempt exposed output that makes replay observable.
+data AttemptObservation
+    = NoOutputObserved
+    | OutputObserved
+    deriving (Eq, Show)
+
+-- | The result of one operation attempt together with its replay boundary.
+data AttemptOutcome result = AttemptOutcome
+    { attemptObservation :: !AttemptObservation
+    , attemptResult :: !result
+    } deriving (Eq, Show)
+
+-- | Run one callback-driven attempt and report whether matching output was
+-- observed. The marker is set before invoking the callback, so a callback
+-- exception still makes the attempt replay-unsafe.
+runObservedAttempt
+    :: (event -> Bool)
+    -> (event -> IO ())
+    -> ((event -> IO ()) -> IO result)
+    -> IO (AttemptOutcome result)
+runObservedAttempt observed onEvent action = do
+    observationRef <- newIORef NoOutputObserved
+    result <- action \event -> do
+        if observed event
+            then writeIORef observationRef OutputObserved
+            else pure ()
+        onEvent event
+    observation <- readIORef observationRef
+    pure AttemptOutcome
+        { attemptObservation = observation
+        , attemptResult = result
+        }
 
 -- | How a synchronous exception raised before an operation commits should be
 -- represented. Both constructors return the error as data; only

--- a/packages/agent-core/test/Agent/RetrySpec.hs
+++ b/packages/agent-core/test/Agent/RetrySpec.hs
@@ -7,7 +7,31 @@ import Data.IORef
 import Test.Hspec
 
 spec :: Spec
-spec = describe "retryingBeforeCommit" do
+spec = do
+  describe "runObservedAttempt" do
+    it "returns explicit output observation metadata" do
+        delivered <- newIORef []
+        outcome <- runObservedAttempt odd
+            (\event -> modifyIORef' delivered (<> [event]))
+            (\emit -> emit (2 :: Int) >> emit 3 >> pure ("done" :: String))
+
+        outcome `shouldBe` AttemptOutcome
+            { attemptObservation = OutputObserved
+            , attemptResult = "done"
+            }
+        readIORef delivered `shouldReturn` [2, 3]
+
+    it "marks output before invoking a failing callback" do
+        outcome <- runObservedAttempt (const True)
+                (\() -> ioError (userError "callback failed"))
+                (\emit -> tryAny (emit ()) >> pure ("caught" :: String))
+
+        outcome `shouldBe` AttemptOutcome
+            { attemptObservation = OutputObserved
+            , attemptResult = "caught"
+            }
+
+  describe "retryingBeforeCommit" do
     it "normalizes synchronous exceptions into the action error channel" do
         result <- handleSyncExceptions
             (const "normalized")

--- a/packages/agent-openai/src/Agent/OpenAI/LoopBackend.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/LoopBackend.hs
@@ -4,6 +4,7 @@
 -- "Agent.Responses.LoopBackend" and are re-exported here for compatibility.
 module Agent.OpenAI.LoopBackend
     ( openAiBackend
+    , openAiBackendWithParams
     , openAiBackendReconnecting
     , openAiAuxiliaryResponseSenderReconnecting
     , openAiAuxiliaryResponseSenderWithConnectionRecovery
@@ -12,6 +13,7 @@ module Agent.OpenAI.LoopBackend
     , openAiResponseSenderWithConnectionRecovery
     , openAiResponseSenderWithRetryPolicy
     , openAiBackendWith
+    , openAiBackendWithRetryPolicyParams
     , openAiBackendWithRetryPolicy
     , openAiBackendWithConnectionRecovery
     , openAiBackendWithTransportFallback
@@ -31,7 +33,7 @@ import Agent.Error
     , isInlineRetryableProviderError
     , isInlineRetryableProviderResponseError
     )
-import Agent.Loop (Backend(..), BackendResult(..), LoopEvent(..))
+import Agent.Loop (Backend(..), LoopEvent(..))
 import Agent.OpenAI.Error (isResponseChainCompatibilityError)
 import Agent.OpenAI.Request (sanitizeCodexRequest)
 import Agent.OpenAI.WebSocketClient
@@ -46,8 +48,16 @@ import Agent.Provider
     , TokenProvider
     , accountFailureFromApiError
     )
+import Agent.Retry
+    ( AttemptObservation(..)
+    , AttemptOutcome(..)
+    , runObservedAttempt
+    )
 import Agent.Responses.LoopBackend
-    ( assistantTextFromResponse
+    ( ResponsesTurn(..)
+    , assistantTextFromResponse
+    , completeResponsesTurn
+    , prepareResponsesTurn
     , responseToTurnOutput
     , responseTokenUsage
     , statelessResponsesBackend
@@ -88,6 +98,10 @@ openAiBackend
 openAiBackend conn =
     openAiBackendWith \request previousResponseId onEvent ->
         sendWsRequestWithEvents conn request previousResponseId onEvent
+
+openAiBackendWithParams :: CodexConn -> ResponseCreateParams -> Backend
+openAiBackendWithParams conn params =
+    openAiBackend conn (pure params)
 
 -- | Reuse the session WebSocket while it is healthy, reconnecting after it dies.
 openAiBackendReconnecting
@@ -184,19 +198,10 @@ openAiResponseSenderReconnectingWhen observed markObservedFailure provider
                 withCodexWsRetrying provider
                     (sendOnFresh request previousResponseId onEvent)
     sendOnFresh request previousResponseId onEvent freshConn _credential =
-        do
-            emittedOutput <- newIORef False
-            result <-
-                sendWsRequestWithEvents freshConn request previousResponseId
-                    \event -> do
-                        if observed event
-                            then writeIORef emittedOutput True
-                            else pure ()
-                        onEvent event
-            emitted <- readIORef emittedOutput
-            pure $ case result of
-                Left err | emitted -> Left (markObservedFailure err)
-                _ -> result
+        runObservedAttempt observed onEvent
+            (\emit ->
+                sendWsRequestWithEvents freshConn request previousResponseId emit)
+            >>= pure . markObservedResult markObservedFailure
 
 -- | Injectable connection recovery used by the reconnecting backend.
 openAiBackendWithConnectionRecovery
@@ -310,10 +315,10 @@ openAiResponseSenderWithConnectionRecoveryUsing observed markObservedFailure
             else sendFreshTracked Nothing request previousResponseId onEvent
 
     tryCurrent request previousResponseId onEvent = do
-        emittedLoopEvent <- newIORef False
-        result <- sendCurrent request previousResponseId
-            (trackOutput emittedLoopEvent onEvent)
-            `onException` writeIORef connectionHealthy False
+        AttemptOutcome{attemptObservation, attemptResult = result} <-
+            runObservedAttempt observed onEvent \emit ->
+                sendCurrent request previousResponseId emit
+                    `onException` writeIORef connectionHealthy False
         case result of
             Left err -> do
                 let deadConnectionOrAccount =
@@ -321,8 +326,7 @@ openAiResponseSenderWithConnectionRecoveryUsing observed markObservedFailure
                 if deadConnectionOrAccount
                     then writeIORef connectionHealthy False
                     else pure ()
-                emitted <- readIORef emittedLoopEvent
-                if emitted
+                if attemptObservation == OutputObserved
                     then pure (Left (markObservedFailure err))
                     else if deadConnectionOrAccount
                         then sendFreshTracked
@@ -334,20 +338,9 @@ openAiResponseSenderWithConnectionRecoveryUsing observed markObservedFailure
             _ -> pure result
 
     sendFreshTracked previousFailure request previousResponseId onEvent = do
-        emittedOutput <- newIORef False
-        result <-
-            sendFresh previousFailure request previousResponseId
-                (trackOutput emittedOutput onEvent)
-        emitted <- readIORef emittedOutput
-        pure $ case result of
-            Left err | emitted -> Left (markObservedFailure err)
-            _ -> result
-
-    trackOutput emittedLoopEvent onEvent event = do
-        if observed event
-            then writeIORef emittedLoopEvent True
-            else pure ()
-        onEvent event
+        outcome <- runObservedAttempt observed onEvent \emit ->
+            sendFresh previousFailure request previousResponseId emit
+        pure (markObservedResult markObservedFailure outcome)
 
     isDeadConnectionOrAccount = \case
         ConnectionError {} -> True
@@ -368,28 +361,34 @@ openAiResponseSenderWithRetryPolicy
     -> (ResponseStreamEvent -> IO ())
     -> IO (Either ApiError Response)
 openAiResponseSenderWithRetryPolicy retryPolicy observed send
-        request previousResponseId onEvent = do
-    emittedOutput <- newIORef False
-    go emittedOutput defaultRetryStatus
+        request previousResponseId onEvent =
+    go defaultRetryStatus
   where
-    go emittedOutput retryStatus = do
-        result <- send request previousResponseId \event -> do
-            if observed event
-                then writeIORef emittedOutput True
-                else pure ()
-            onEvent event
-        emitted <- readIORef emittedOutput
+    go retryStatus = do
+        AttemptOutcome{attemptObservation, attemptResult = result} <-
+            runObservedAttempt observed onEvent
+                (send request previousResponseId)
         case result of
             Left apiError
-                | not emitted
+                | attemptObservation == NoOutputObserved
                 , isInlineRetryableProviderError apiError ->
                     applyPolicy retryPolicy retryStatus >>= \case
                         Nothing -> pure result
                         Just nextStatus -> do
                             threadDelay
                                 (fromMaybe 0 nextStatus.rsPreviousDelay)
-                            go emittedOutput nextStatus
+                            go nextStatus
             _ -> pure result
+
+markObservedResult
+    :: (ApiError -> ApiError)
+    -> AttemptOutcome (Either ApiError value)
+    -> Either ApiError value
+markObservedResult markFailure AttemptOutcome{..} =
+    case attemptResult of
+        Left err | attemptObservation == OutputObserved ->
+            Left (markFailure err)
+        result -> result
 
 auxiliaryOutputObserved :: ResponseStreamEvent -> Bool
 auxiliaryOutputObserved = streamOutputObserved
@@ -442,18 +441,14 @@ openAiBackendWithTransportFallback fallbackActive primary fallback =
             else tryPrimary state previousResponseId inputs onEvent
   where
     tryPrimary state previousResponseId inputs onEvent = do
-        emittedModelOutput <- newIORef False
-        result <- primary.submitTurn state previousResponseId inputs \event -> do
-            if isModelOutput event
-                then writeIORef emittedModelOutput True
-                else pure ()
-            onEvent event
+        AttemptOutcome{attemptObservation, attemptResult = result} <-
+            runObservedAttempt isModelOutput onEvent
+                (primary.submitTurn state previousResponseId inputs)
         case result of
             Left err
                 | isWebSocketTransportFailure err -> do
                     writeIORef fallbackActive True
-                    emitted <- readIORef emittedModelOutput
-                    if emitted
+                    if attemptObservation == OutputObserved
                         then pure result
                         else fallback.submitTurn
                             state previousResponseId inputs onEvent
@@ -480,6 +475,17 @@ openAiBackendWith
 openAiBackendWith =
     openAiBackendWithRetryPolicy transientStreamingResultPolicy
 
+openAiBackendWithRetryPolicyParams
+    :: RetryPolicyM IO
+    -> (ResponseCreateParams
+        -> Maybe Text
+        -> (ResponseStreamEvent -> IO ())
+        -> IO (Either ApiError Response))
+    -> ResponseCreateParams
+    -> Backend
+openAiBackendWithRetryPolicyParams retryPolicy send params =
+    openAiBackendWithRetryPolicy retryPolicy send (pure params)
+
 -- | Streaming retries are replay-safe only until the loop has observed output.
 -- Server error events themselves are not loop-visible, so transient Codex
 -- failures can wait and retry without printing an error or duplicating output.
@@ -494,52 +500,44 @@ openAiBackendWithRetryPolicy
 openAiBackendWithRetryPolicy retryPolicy send getParams =
     Backend \history previousResponseId inputs onLoopEvent -> do
         baseParams <- sanitizeCodexRequest <$> getParams
-        let newItems = turnInputsToItems inputs
-            deltaRequest = withRequestInput baseParams newItems
+        let turn = prepareResponsesTurn baseParams history inputs
+            deltaRequest = turn.responsesDeltaRequest
             -- Live and resumed transcripts already apply compaction snapshots
             -- as full replacements. Remote v2 intentionally keeps retained
             -- messages before its opaque checkpoint, so replay the complete
             -- replacement instead of trimming that retained prefix.
-            fullRequest = withRequestInput baseParams (history <> newItems)
+            fullRequest = turn.responsesFullRequest
             emit event = mapM_ onLoopEvent (streamEventToLoopEvent event)
             (initialRequest, initialPrevious) =
                 case previousResponseId of
                     Nothing | not (null history) -> (fullRequest, Nothing)
                     _ -> (deltaRequest, previousResponseId)
-        result <- sendRetrying onLoopEvent initialRequest initialPrevious emit
-        recovered <- case result of
-            Left err
+        initial <- sendRetrying onLoopEvent initialRequest initialPrevious emit
+        recovered <- case initial of
+            AttemptOutcome NoOutputObserved (Left err)
                 | isJust initialPrevious
                 , isResponseChainCompatibilityError err
                 , not (null history) ->
                     sendRetrying onLoopEvent fullRequest Nothing emit
-                | otherwise -> pure (Left err)
-            Right response -> pure (Right response)
-        case recovered of
+            _ -> pure initial
+        case recovered.attemptResult of
             Left err -> pure (Left err)
             Right response ->
-                pure $ Right BackendResult
-                    { backendOutput = responseToTurnOutput response
-                    , backendState = history <> newItems <> response.output
-                    }
+                pure (Right (completeResponsesTurn turn response))
   where
-    sendRetrying onLoopEvent request previousResponseId onStreamEvent = do
-        emittedLoopEvent <- newIORef False
-        go emittedLoopEvent defaultRetryStatus
+    sendRetrying onLoopEvent request previousResponseId onStreamEvent =
+        go defaultRetryStatus
       where
-        go emittedLoopEvent retryStatus = do
-            result <- send request previousResponseId \event -> do
-                if streamOutputObserved event
-                    then writeIORef emittedLoopEvent True
-                    else pure ()
-                onStreamEvent event
-            emitted <- readIORef emittedLoopEvent
+        go retryStatus = do
+            outcome@AttemptOutcome{attemptObservation, attemptResult = result} <-
+                runObservedAttempt streamOutputObserved onStreamEvent
+                    (send request previousResponseId)
             case result of
                 Left apiError
-                    | not emitted
+                    | attemptObservation == NoOutputObserved
                     , isInlineRetryableProviderResponseError apiError ->
                         applyPolicy retryPolicy retryStatus >>= \case
-                            Nothing -> pure result
+                            Nothing -> pure outcome
                             Just nextStatus -> do
                                 let delayMicros =
                                         fromMaybe 0 nextStatus.rsPreviousDelay
@@ -550,8 +548,8 @@ openAiBackendWithRetryPolicy retryPolicy send getParams =
                                 onLoopEvent $ ActivityUpdated $
                                     "Retrying Codex request (attempt "
                                         <> Text.pack (show attempt) <> ")…"
-                                go emittedLoopEvent nextStatus
-                _ -> pure result
+                                go nextStatus
+                _ -> pure outcome
 
 transientStreamingResultPolicy :: RetryPolicyM IO
 transientStreamingResultPolicy =

--- a/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
@@ -8,7 +8,12 @@ import Agent.Error
 import Agent.InterAgentMessage
 import Agent.Loop
 import Agent.OpenAI.LoopBackend
-import Agent.Responses.LoopBackend (streamOutputObserved)
+import Agent.Responses.LoopBackend
+    ( ResponsesTurn(..)
+    , completeResponsesTurn
+    , prepareResponsesTurn
+    , streamOutputObserved
+    )
 import Agent.Responses.Types
 import Agent.ToolDispatch
 import Control.Retry (constantDelay, limitRetries)
@@ -22,6 +27,34 @@ import Test.Hspec
 
 spec :: Spec
 spec = do
+    describe "ResponsesTurn" do
+        it "keeps delta, replay, and committed transcript order pure" do
+            let history =
+                    turnInputsToItems [UserMessage "old"]
+                        <> [assistantItem "prior answer"]
+                inputs =
+                    [ CompletedTool (functionResult "c1" "tool output")
+                    , UserMessage "next"
+                    ]
+                newItems = turnInputsToItems inputs
+                turn = prepareResponsesTurn baseParams history inputs
+                response = testResponse "resp-next"
+                    [functionCallItem "c2" "read_file" "{}"]
+                completed = completeResponsesTurn turn response
+
+            inputItems turn.responsesDeltaRequest `shouldBe` newItems
+            inputItems turn.responsesFullRequest
+                `shouldBe` history <> newItems
+            completed.backendState
+                `shouldBe`
+                    history
+                        <> newItems
+                        <> [functionCallItem "c2" "read_file" "{}"]
+            completed.backendOutput `shouldBe`
+                emptyTurnOutput "resp-next"
+                    [functionToolCall "c2" "read_file" "{}"]
+                    Nothing
+
     describe "withRequestInput" do
         it "repairs legacy assistant input_text from compacted sessions" do
             let legacySummary = MessageItem ResponseMessage
@@ -460,6 +493,26 @@ spec = do
                 [ turnInputsToItems [UserMessage "new"]
                 , seed <> turnInputsToItems [UserMessage "new"]
                 ]
+
+        it "does not replay a missing response chain after visible output" do
+            seen <- newIORef []
+            let seed = turnInputsToItems [UserMessage "old"]
+                chainError = ProviderError PreviousResponseNotFound
+                    "previous_response_id was not found" Nothing
+                send request previous onEvent = do
+                    modifyIORef' seen (++ [(request, previous)])
+                    onEvent (deltaEvent EventOutputTextDelta "partial")
+                    pure (Left chainError)
+            transcript <- newIORef seed
+            let backend = openAiBackendWith send (pure baseParams)
+            result <- submitWithState transcript backend (Just "resp-missing")
+                [UserMessage "new"]
+                (const (pure ()))
+
+            result `shouldBe` Left chainError
+            map snd <$> readIORef seen
+                `shouldReturn` [Just "resp-missing"]
+            readIORef transcript `shouldReturn` seed
 
         it "starts a fresh chain when inherited cache retention is rejected" do
             seen <- newIORef []

--- a/packages/agent-openrouter/src/Agent/OpenRouter/LoopBackend.hs
+++ b/packages/agent-openrouter/src/Agent/OpenRouter/LoopBackend.hs
@@ -7,14 +7,18 @@
 -- resumed session can seed it and the CLI can persist it.
 module Agent.OpenRouter.LoopBackend
     ( openRouterBackend
+    , openRouterBackendWithParams
     , openRouterBackendWith
+    , openRouterBackendWithFixedParams
     ) where
 
 import Agent.Error (ApiError)
 import Agent.Loop (Backend)
 import Agent.Responses.LoopBackend
     ( statelessResponsesBackend
+    , statelessResponsesBackendWithParams
     , tokenProviderStatelessResponsesBackend
+    , tokenProviderStatelessResponsesBackendWithParams
     )
 import Agent.Responses.Types
 import Agent.Provider (TokenProvider)
@@ -35,6 +39,15 @@ openRouterBackend options provider =
     tokenProviderStatelessResponsesBackend provider
         (createResponseWithEvents options)
 
+openRouterBackendWithParams
+    :: ClientOptions
+    -> TokenProvider
+    -> ResponseCreateParams
+    -> Backend
+openRouterBackendWithParams options provider =
+    tokenProviderStatelessResponsesBackendWithParams provider
+        (createResponseWithEvents options)
+
 -- | Same mapping as 'openRouterBackend', with an injectable transport for tests
 -- and downstream integrations.
 openRouterBackendWith
@@ -44,3 +57,12 @@ openRouterBackendWith
     -> IO ResponseCreateParams
     -> Backend
 openRouterBackendWith = statelessResponsesBackend
+
+openRouterBackendWithFixedParams
+    :: (ResponseCreateParams
+        -> (ResponseStreamEvent -> IO ())
+        -> IO (Either ApiError Response))
+    -> ResponseCreateParams
+    -> Backend
+openRouterBackendWithFixedParams =
+    statelessResponsesBackendWithParams

--- a/packages/agent-responses/src/Agent/Responses/Client.hs
+++ b/packages/agent-responses/src/Agent/Responses/Client.hs
@@ -6,11 +6,15 @@ module Agent.Responses.Client
     ) where
 
 import Agent.Error (ApiError)
+import Agent.Retry
+    ( AttemptObservation(..)
+    , AttemptOutcome(..)
+    , runObservedAttempt
+    )
 import qualified Agent.Responses.HttpSSE as HttpSSE
 import Agent.Responses.Types
 import Control.Retry (RetryPolicyM, retrying)
 import qualified Data.Aeson as Aeson
-import Data.IORef
 import Data.Text (Text)
 import Network.HTTP.Simple (Request)
 
@@ -59,17 +63,17 @@ retryStreamingResultWithPolicy policy retryable request onEvent =
     snd <$> retrying policy shouldRetry runAttempt
   where
     runAttempt _status = do
-        emitted <- newIORef False
-        result <- request \event -> case onEvent of
-            Nothing -> pure ()
-            Just callback -> do
-                writeIORef emitted True
-                callback event
-        didEmit <- readIORef emitted
-        pure (didEmit, result)
+        AttemptOutcome{attemptObservation, attemptResult} <-
+            case onEvent of
+                Nothing ->
+                    AttemptOutcome NoOutputObserved
+                        <$> request (const (pure ()))
+                Just callback ->
+                    runObservedAttempt (const True) callback request
+        pure (attemptObservation, attemptResult)
 
-    shouldRetry _status (emitted, result) = pure $
-        not emitted
+    shouldRetry _status (observation, result) = pure $
+        observation == NoOutputObserved
             && case result of
                 Left apiError -> retryable apiError
                 Right _ -> False

--- a/packages/agent-responses/src/Agent/Responses/GenericBackend.hs
+++ b/packages/agent-responses/src/Agent/Responses/GenericBackend.hs
@@ -1,7 +1,9 @@
 -- | Loop backend for generic stateless Responses-compatible HTTP endpoints.
 module Agent.Responses.GenericBackend
     ( genericResponsesBackend
+    , genericResponsesBackendWithParams
     , genericResponsesBackendWith
+    , genericResponsesBackendWithFixedParams
     ) where
 
 import Agent.Error (ApiError)
@@ -10,7 +12,10 @@ import Agent.Responses.GenericClient
     ( GenericClientOptions
     , createResponseWithEvents
     )
-import Agent.Responses.LoopBackend (statelessResponsesBackend)
+import Agent.Responses.LoopBackend
+    ( statelessResponsesBackend
+    , statelessResponsesBackendWithParams
+    )
 import Agent.Responses.Types
 
 genericResponsesBackend
@@ -20,6 +25,14 @@ genericResponsesBackend
 genericResponsesBackend options =
     statelessResponsesBackend (createResponseWithEvents options)
 
+genericResponsesBackendWithParams
+    :: GenericClientOptions
+    -> ResponseCreateParams
+    -> Backend
+genericResponsesBackendWithParams options =
+    statelessResponsesBackendWithParams
+        (createResponseWithEvents options)
+
 genericResponsesBackendWith
     :: (ResponseCreateParams
         -> (ResponseStreamEvent -> IO ())
@@ -27,3 +40,12 @@ genericResponsesBackendWith
     -> IO ResponseCreateParams
     -> Backend
 genericResponsesBackendWith = statelessResponsesBackend
+
+genericResponsesBackendWithFixedParams
+    :: (ResponseCreateParams
+        -> (ResponseStreamEvent -> IO ())
+        -> IO (Either ApiError Response))
+    -> ResponseCreateParams
+    -> Backend
+genericResponsesBackendWithFixedParams =
+    statelessResponsesBackendWithParams

--- a/packages/agent-responses/src/Agent/Responses/LoopBackend.hs
+++ b/packages/agent-responses/src/Agent/Responses/LoopBackend.hs
@@ -1,7 +1,12 @@
 -- | Provider-neutral loop adapters for Responses-compatible transports.
 module Agent.Responses.LoopBackend
-    ( statelessResponsesBackend
+    ( ResponsesTurn(..)
+    , completeResponsesTurn
+    , prepareResponsesTurn
+    , statelessResponsesBackend
+    , statelessResponsesBackendWithParams
     , tokenProviderStatelessResponsesBackend
+    , tokenProviderStatelessResponsesBackendWithParams
     , turnInputsToItems
     , responseToTurnOutput
     , responseTokenUsage
@@ -53,6 +58,40 @@ import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import Text.Printf (printf)
 
+-- | Pure request/transcript transition shared by Responses-compatible
+-- backends. Stateless transports send 'responsesFullRequest'; OpenAI's
+-- response-chain transport normally sends 'responsesDeltaRequest' and falls
+-- back to the full request when the remote chain is unavailable.
+data ResponsesTurn = ResponsesTurn
+    { responsesNewItems :: ![ResponseItem]
+    , responsesTranscript :: ![ResponseItem]
+    , responsesDeltaRequest :: !ResponseCreateParams
+    , responsesFullRequest :: !ResponseCreateParams
+    } deriving (Eq, Show)
+
+prepareResponsesTurn
+    :: ResponseCreateParams
+    -> [ResponseItem]
+    -> [TurnInput]
+    -> ResponsesTurn
+prepareResponsesTurn baseParams history inputs =
+    ResponsesTurn
+        { responsesNewItems = newItems
+        , responsesTranscript = transcript
+        , responsesDeltaRequest = withRequestInput baseParams newItems
+        , responsesFullRequest = withRequestInput baseParams transcript
+        }
+  where
+    newItems = turnInputsToItems inputs
+    transcript = history <> newItems
+
+completeResponsesTurn :: ResponsesTurn -> Response -> BackendResult
+completeResponsesTurn turn response =
+    BackendResult
+        { backendOutput = responseToTurnOutput response
+        , backendState = turn.responsesTranscript <> response.output
+        }
+
 -- | Adapt a stateless Responses transport to the provider-neutral loop.
 statelessResponsesBackend
     :: (ResponseCreateParams
@@ -63,18 +102,25 @@ statelessResponsesBackend
 statelessResponsesBackend send getParams =
     Backend \history _previousResponseId inputs onEvent -> do
         baseParams <- getParams
-        let newItems = turnInputsToItems inputs
-            requestItems = history <> newItems
-            request = withRequestInput baseParams requestItems
-        result <- send request \event ->
+        let turn = prepareResponsesTurn baseParams history inputs
+        result <- send turn.responsesFullRequest \event ->
             mapM_ onEvent (streamEventToLoopEvent event)
         case result of
             Left err -> pure (Left err)
             Right response ->
-                pure $ Right BackendResult
-                    { backendOutput = responseToTurnOutput response
-                    , backendState = requestItems <> response.output
-                    }
+                pure (Right (completeResponsesTurn turn response))
+
+-- | Fixed-parameter adapter for isolated requests and child agents. The
+-- action-taking variant remains available for live sessions whose effort or
+-- model can change between turns.
+statelessResponsesBackendWithParams
+    :: (ResponseCreateParams
+        -> (ResponseStreamEvent -> IO ())
+        -> IO (Either ApiError Response))
+    -> ResponseCreateParams
+    -> Backend
+statelessResponsesBackendWithParams send params =
+    statelessResponsesBackend send (pure params)
 
 -- | Adapt a credentialed stateless Responses transport to the loop.
 --
@@ -92,6 +138,17 @@ tokenProviderStatelessResponsesBackend provider send =
     statelessResponsesBackend \params onEvent ->
         runWithTokenProvider provider \credential ->
             send credential params onEvent
+
+tokenProviderStatelessResponsesBackendWithParams
+    :: TokenProvider
+    -> (Credential
+        -> ResponseCreateParams
+        -> (ResponseStreamEvent -> IO ())
+        -> IO (Either ApiError Response))
+    -> ResponseCreateParams
+    -> Backend
+tokenProviderStatelessResponsesBackendWithParams provider send params =
+    tokenProviderStatelessResponsesBackend provider send (pure params)
 
 -- | 'input' is also a field on 'CustomToolCall', so a record update is
 -- ambiguous. Rebuild from the constructor instead.

--- a/packages/agent-xai/src/Agent/XAI/LoopBackend.hs
+++ b/packages/agent-xai/src/Agent/XAI/LoopBackend.hs
@@ -7,14 +7,18 @@
 -- resumed session can seed it and the CLI can persist it.
 module Agent.XAI.LoopBackend
     ( xaiBackend
+    , xaiBackendWithParams
     , xaiBackendWith
+    , xaiBackendWithFixedParams
     ) where
 
 import Agent.Error (ApiError)
 import Agent.Loop (Backend)
 import Agent.Responses.LoopBackend
     ( statelessResponsesBackend
+    , statelessResponsesBackendWithParams
     , tokenProviderStatelessResponsesBackend
+    , tokenProviderStatelessResponsesBackendWithParams
     )
 import Agent.Responses.Types
 import Agent.Provider (TokenProvider)
@@ -35,6 +39,15 @@ xaiBackend options provider =
     tokenProviderStatelessResponsesBackend provider
         (createResponseWithEvents options)
 
+xaiBackendWithParams
+    :: ClientOptions
+    -> TokenProvider
+    -> ResponseCreateParams
+    -> Backend
+xaiBackendWithParams options provider =
+    tokenProviderStatelessResponsesBackendWithParams provider
+        (createResponseWithEvents options)
+
 -- | Same mapping as 'xaiBackend', with an injectable transport for tests and
 -- downstream integrations.
 xaiBackendWith
@@ -44,3 +57,12 @@ xaiBackendWith
     -> IO ResponseCreateParams
     -> Backend
 xaiBackendWith = statelessResponsesBackend
+
+xaiBackendWithFixedParams
+    :: (ResponseCreateParams
+        -> (ResponseStreamEvent -> IO ())
+        -> IO (Either ApiError Response))
+    -> ResponseCreateParams
+    -> Backend
+xaiBackendWithFixedParams =
+    statelessResponsesBackendWithParams


### PR DESCRIPTION
## Summary
- add pure provider-neutral Responses request/transcript transitions with exact delta, full-replay, and committed-state ordering
- replace scattered emitted-output retry refs with explicit `AttemptOutcome` metadata, including replay-safe response-chain fallback gating
- add fixed-parameter backend constructors for OpenAI, OpenRouter, xAI, and generic Responses transports
- migrate Btw, session-title, and subagent paths to explicit parameter snapshots while retaining legacy ref-based APIs through adapters
- preserve dynamic per-turn params for live sessions, resume/full-replay behavior, and caller-owned connection/fallback state

## Compatibility
- existing `BtwBackendFactory`, `runBtwWithCancel`, `withSessionTitleManager`, `freshOpenAiBackend`, and `runHttpSubagent` entry points remain available
- new explicit APIs are additive; no forced public API migration

## Validation
- `nix develop -c cabal repl agent-cli:lib:agent-cli agent-core:lib:agent-core agent-codex-dialect:lib:agent-codex-dialect agent-grok-build-dialect:lib:agent-grok-build-dialect agent-tui:lib:agent-tui agent-responses:lib:agent-responses agent-openai:lib:agent-openai agent-xai:lib:agent-xai agent-openrouter:lib:agent-openrouter` (186 modules loaded)
- `nix develop -c cabal test agent-core:agent-core-test agent-responses:agent-responses-test agent-openai:agent-openai-test agent-openrouter:agent-openrouter-test agent-xai:agent-xai-test agent-cli:agent-cli-test --test-show-details=failures`
- `git diff --check`
