### PR TITLE
Refactor OpenAI connection state ownership

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -380,7 +380,10 @@ import Agent.OpenAI.Compaction
     )
 import qualified Agent.OpenAI.Auth as OpenAI
 import Agent.OpenAI.LoopBackend
-    ( openAiAuxiliaryResponseSenderReconnecting
+    ( ConnectionHealth
+    , markConnectionUnhealthy
+    , newConnectionHealth
+    , openAiAuxiliaryResponseSenderReconnecting
     , openAiBackendWith
     , openAiResponseSenderReconnecting
     )
@@ -570,7 +573,10 @@ data ActiveHttpAuth = ActiveHttpAuth
     }
 
 data OpenAiPersistentConnection
-    = OpenAiPersistentConnection !Credential !(IORef Bool) !CodexConn
+    = OpenAiPersistentConnection
+        !Credential
+        !ConnectionHealth
+        !CodexConn
 
 data AccountSwitchRequest
     = AccountSwitchRequest !Credential !(MVar (Either ApiError Text))
@@ -2001,7 +2007,7 @@ runAgentInitializedWithLock
                         try @_ @CodexAuthFailed
                             (withCodexWsWithProvider tokenProvider \conn credential -> do
                                 wsLock <- newMVar ()
-                                initialWsHealthy <- newIORef True
+                                initialWsHealthy <- newConnectionHealth True
                                 activeConnectionRef <- newIORef $
                                     OpenAiPersistentConnection
                                         credential
@@ -2071,7 +2077,8 @@ runAgentInitializedWithLock
                                                         newCredential
                                                         newConn = do
                                                             newHealthy <-
-                                                                newIORef True
+                                                                newConnectionHealth
+                                                                    True
                                                             label <-
                                                                 resolveActiveAccountLabel
                                                                     newCredential
@@ -2094,9 +2101,8 @@ runAgentInitializedWithLock
                                                     awaitNext newHealthy =
                                                         readChan switchRequests
                                                             `finally`
-                                                                writeIORef
+                                                                markConnectionUnhealthy
                                                                     newHealthy
-                                                                    False
                                                 oldConnection <-
                                                     readIORef activeConnectionRef
                                                 previousAccountId <-
@@ -2106,7 +2112,8 @@ runAgentInitializedWithLock
                                                         oldHealthy
                                                         oldConn =
                                                             oldConnection
-                                                writeIORef oldHealthy False
+                                                markConnectionUnhealthy
+                                                    oldHealthy
                                                 closeCodexConn oldConn
                                                 writeIORef
                                                     preferredOpenAiAccountRef

--- a/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
@@ -80,7 +80,8 @@ import Agent.Loop
     )
 import qualified Agent.OpenAI.Client as OpenAI
 import Agent.OpenAI.LoopBackend
-    ( openAiBackend
+    ( newTransportFallbackState
+    , openAiBackend
     , openAiBackendWithTransportFallback
     , statelessResponsesBackend
     )
@@ -616,7 +617,7 @@ runCodexSubagent runtime tokenProvider sendToRoot =
                             (schemasFromAppTools codexDialect tools) effort
                     toolRegistry <- requireToolRegistry tools
                     childParamsRef <- newIORef childParams
-                    httpFallbackActive <- newIORef False
+                    httpFallbackActive <- newTransportFallbackState False
                     let websocketBackend =
                             freshOpenAiBackend tokenProvider
                                 (readIORef childParamsRef)

--- a/packages/agent-openai/src/Agent/OpenAI/LoopBackend.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/LoopBackend.hs
@@ -3,7 +3,14 @@
 -- Provider-neutral conversion and stateless transport helpers live in
 -- "Agent.Responses.LoopBackend" and are re-exported here for compatibility.
 module Agent.OpenAI.LoopBackend
-    ( openAiBackend
+    ( ConnectionHealth
+    , newConnectionHealth
+    , readConnectionHealth
+    , markConnectionUnhealthy
+    , TransportFallbackState
+    , newTransportFallbackState
+    , readTransportFallbackState
+    , openAiBackend
     , openAiBackendReconnecting
     , openAiAuxiliaryResponseSenderReconnecting
     , openAiAuxiliaryResponseSenderWithConnectionRecovery
@@ -59,7 +66,8 @@ import Agent.Responses.LoopBackend
     )
 import Agent.Responses.Types
 import Control.Concurrent (threadDelay)
-import Control.Exception.Safe (onException)
+import Control.Concurrent.MVar (MVar, modifyMVar, newMVar, readMVar)
+import qualified Control.Exception.Safe as Safe
 import Control.Retry
     ( RetryPolicyM
     , applyPolicy
@@ -73,6 +81,38 @@ import Data.IORef
 import Data.Maybe (fromMaybe, isJust)
 import Data.Text (Text)
 import qualified Data.Text as Text
+
+-- | Exclusive ownership of a reusable connection and its health transition.
+--
+-- The state remains locked for the request because a Codex WebSocket is not
+-- multiplexed: a second caller must not observe it as healthy while the first
+-- caller is still deciding whether it survived the request.
+newtype ConnectionHealth = ConnectionHealth (MVar Bool)
+
+newConnectionHealth :: Bool -> IO ConnectionHealth
+newConnectionHealth = fmap ConnectionHealth . newMVar
+
+readConnectionHealth :: ConnectionHealth -> IO Bool
+readConnectionHealth (ConnectionHealth state) = readMVar state
+
+markConnectionUnhealthy :: ConnectionHealth -> IO ()
+markConnectionUnhealthy (ConnectionHealth state) =
+    modifyMVar state \_ -> pure (False, ())
+
+-- | Exclusive ownership of the primary-to-fallback transport transition.
+--
+-- Keeping the turn under this lock prevents concurrent callers from both
+-- replaying on the primary after the first transport failure. Once fallback is
+-- active, turns remain serialized through the same backend ownership boundary.
+newtype TransportFallbackState = TransportFallbackState (MVar Bool)
+
+newTransportFallbackState :: Bool -> IO TransportFallbackState
+newTransportFallbackState =
+    fmap TransportFallbackState . newMVar
+
+readTransportFallbackState :: TransportFallbackState -> IO Bool
+readTransportFallbackState (TransportFallbackState state) =
+    readMVar state
 
 -- | Close over a live Codex WebSocket and the request fields the loop does
 -- not own (model, instructions, tools, reasoning). The params action is
@@ -93,7 +133,7 @@ openAiBackend conn =
 openAiBackendReconnecting
     :: TokenProvider
     -> Credential
-    -> IORef Bool
+    -> ConnectionHealth
     -> CodexConn
     -> IO ResponseCreateParams
     -> Backend
@@ -112,7 +152,7 @@ openAiBackendReconnecting provider currentCredential connectionHealthy conn =
 openAiResponseSenderReconnecting
     :: TokenProvider
     -> Credential
-    -> IORef Bool
+    -> ConnectionHealth
     -> CodexConn
     -> ResponseCreateParams
     -> Maybe Text
@@ -130,7 +170,7 @@ openAiResponseSenderReconnecting =
 openAiAuxiliaryResponseSenderReconnecting
     :: TokenProvider
     -> Credential
-    -> IORef Bool
+    -> ConnectionHealth
     -> CodexConn
     -> ResponseCreateParams
     -> Maybe Text
@@ -154,7 +194,7 @@ openAiResponseSenderReconnectingWhen
     -> (ApiError -> ApiError)
     -> TokenProvider
     -> Credential
-    -> IORef Bool
+    -> ConnectionHealth
     -> CodexConn
     -> ResponseCreateParams
     -> Maybe Text
@@ -200,7 +240,7 @@ openAiResponseSenderReconnectingWhen observed markObservedFailure provider
 
 -- | Injectable connection recovery used by the reconnecting backend.
 openAiBackendWithConnectionRecovery
-    :: IORef Bool
+    :: ConnectionHealth
     -> (ResponseCreateParams
         -> Maybe Text
         -> (ResponseStreamEvent -> IO ())
@@ -220,7 +260,7 @@ openAiBackendWithConnectionRecovery connectionHealthy sendCurrent sendFresh =
             sendFresh
 
 openAiResponseSenderWithConnectionRecovery
-    :: IORef Bool
+    :: ConnectionHealth
     -> (ResponseCreateParams
         -> Maybe Text
         -> (ResponseStreamEvent -> IO ())
@@ -240,7 +280,7 @@ openAiResponseSenderWithConnectionRecovery =
         markLoopReplayUnsafe
 
 openAiAuxiliaryResponseSenderWithConnectionRecovery
-    :: IORef Bool
+    :: ConnectionHealth
     -> (ResponseCreateParams
         -> Maybe Text
         -> (ResponseStreamEvent -> IO ())
@@ -263,7 +303,7 @@ openAiAuxiliaryResponseSenderWithConnectionRecovery =
 -- produced enough output that replaying it is no longer safe.
 openAiResponseSenderWithConnectionRecoveryWhen
     :: (ResponseStreamEvent -> Bool)
-    -> IORef Bool
+    -> ConnectionHealth
     -> (ResponseCreateParams
         -> Maybe Text
         -> (ResponseStreamEvent -> IO ())
@@ -285,7 +325,7 @@ openAiResponseSenderWithConnectionRecoveryWhen observed =
 openAiResponseSenderWithConnectionRecoveryUsing
     :: (ResponseStreamEvent -> Bool)
     -> (ApiError -> ApiError)
-    -> IORef Bool
+    -> ConnectionHealth
     -> (ResponseCreateParams
         -> Maybe Text
         -> (ResponseStreamEvent -> IO ())
@@ -300,38 +340,49 @@ openAiResponseSenderWithConnectionRecoveryUsing
     -> (ResponseStreamEvent -> IO ())
     -> IO (Either ApiError Response)
 openAiResponseSenderWithConnectionRecoveryUsing observed markObservedFailure
-        connectionHealthy sendCurrent sendFresh =
+        (ConnectionHealth connectionHealth) sendCurrent sendFresh =
     sendWithRecovery
   where
     sendWithRecovery request previousResponseId onEvent = do
-        healthy <- readIORef connectionHealthy
-        if healthy
-            then tryCurrent request previousResponseId onEvent
-            else sendFreshTracked Nothing request previousResponseId onEvent
+        outcome <- modifyMVar connectionHealth \healthy -> do
+            attempted <- Safe.tryAny $
+                if healthy
+                    then tryCurrent request previousResponseId onEvent
+                    else
+                        (False,) <$>
+                            sendFreshTracked
+                                Nothing request previousResponseId onEvent
+            case attempted of
+                Left exception ->
+                    pure (False, Left exception)
+                Right (nextHealth, result) ->
+                    pure (nextHealth, Right result)
+        either Safe.throwIO pure outcome
 
     tryCurrent request previousResponseId onEvent = do
         emittedLoopEvent <- newIORef False
         result <- sendCurrent request previousResponseId
             (trackOutput emittedLoopEvent onEvent)
-            `onException` writeIORef connectionHealthy False
         case result of
             Left err -> do
                 let deadConnectionOrAccount =
                         isDeadConnectionOrAccount err
-                if deadConnectionOrAccount
-                    then writeIORef connectionHealthy False
-                    else pure ()
                 emitted <- readIORef emittedLoopEvent
                 if emitted
-                    then pure (Left (markObservedFailure err))
+                    then pure
+                        ( not deadConnectionOrAccount
+                        , Left (markObservedFailure err)
+                        )
                     else if deadConnectionOrAccount
-                        then sendFreshTracked
-                            (Just err)
-                            request
-                            previousResponseId
-                            onEvent
-                        else pure result
-            _ -> pure result
+                        then
+                            (False,) <$>
+                                sendFreshTracked
+                                    (Just err)
+                                    request
+                                    previousResponseId
+                                    onEvent
+                        else pure (True, result)
+            _ -> pure (True, result)
 
     sendFreshTracked previousFailure request previousResponseId onEvent = do
         emittedOutput <- newIORef False
@@ -430,16 +481,25 @@ isReplayUnsafeError = \case
 -- first response frame. Replaying the same logical turn over the stateless HTTP
 -- backend is safe while no text or reasoning delta has reached the caller.
 openAiBackendWithTransportFallback
-    :: IORef Bool
+    :: TransportFallbackState
     -> Backend
     -> Backend
     -> Backend
-openAiBackendWithTransportFallback fallbackActive primary fallback =
+openAiBackendWithTransportFallback
+        (TransportFallbackState fallbackState) primary fallback =
     Backend \state previousResponseId inputs onEvent -> do
-        active <- readIORef fallbackActive
-        if active
-            then fallback.submitTurn state previousResponseId inputs onEvent
-            else tryPrimary state previousResponseId inputs onEvent
+        outcome <- modifyMVar fallbackState \active ->
+            if active
+                then do
+                    attempted <- Safe.tryAny $
+                        fallback.submitTurn
+                            state previousResponseId inputs onEvent
+                    pure (True, attempted)
+                else do
+                    (nextActive, attempted) <-
+                        tryPrimary state previousResponseId inputs onEvent
+                    pure (nextActive, attempted)
+        either Safe.throwIO pure outcome
   where
     tryPrimary state previousResponseId inputs onEvent = do
         emittedModelOutput <- newIORef False
@@ -451,13 +511,15 @@ openAiBackendWithTransportFallback fallbackActive primary fallback =
         case result of
             Left err
                 | isWebSocketTransportFailure err -> do
-                    writeIORef fallbackActive True
                     emitted <- readIORef emittedModelOutput
                     if emitted
-                        then pure result
-                        else fallback.submitTurn
-                            state previousResponseId inputs onEvent
-            _ -> pure result
+                        then pure (True, Right result)
+                        else do
+                            attempted <- Safe.tryAny $
+                                fallback.submitTurn
+                                    state previousResponseId inputs onEvent
+                            pure (True, attempted)
+            _ -> pure (False, Right result)
 
     isModelOutput = \case
         TextDelta {} -> True

--- a/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
@@ -11,6 +11,13 @@ import Agent.OpenAI.LoopBackend
 import Agent.Responses.LoopBackend (streamOutputObserved)
 import Agent.Responses.Types
 import Agent.ToolDispatch
+import Control.Concurrent.Async (wait, withAsync)
+import Control.Concurrent.MVar
+    ( newEmptyMVar
+    , putMVar
+    , readMVar
+    , takeMVar
+    )
 import Control.Retry (constantDelay, limitRetries)
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Key as Key
@@ -18,6 +25,7 @@ import qualified Data.Aeson.KeyMap as KeyMap
 import Data.IORef
 import Data.Text (Text)
 import qualified Data.Text as Text
+import System.Timeout (timeout)
 import Test.Hspec
 
 spec :: Spec
@@ -595,10 +603,84 @@ spec = do
             reverse observedEvents `shouldBe` [TextDelta "partial"]
 
     describe "openAiBackendWithConnectionRecovery" do
+        it "serializes a reusable-socket failure across concurrent senders" do
+            currentCalls <- newIORef (0 :: Int)
+            freshCalls <- newIORef (0 :: Int)
+            firstCurrentStarted <- newEmptyMVar
+            laterCurrentStarted <- newEmptyMVar
+            releaseCurrent <- newEmptyMVar
+            secondSenderStarted <- newEmptyMVar
+            healthy <- newConnectionHealth True
+            let connectionFailure = ConnectionError "socket closed"
+                response = testResponse "resp-fresh" [assistantItem "ok"]
+                sendCurrent _request _previous _onEvent = do
+                    callNumber <- atomicModifyIORef' currentCalls \n ->
+                        let next = n + 1
+                        in (next, next)
+                    if callNumber == 1
+                        then putMVar firstCurrentStarted ()
+                        else putMVar laterCurrentStarted ()
+                    readMVar releaseCurrent
+                    pure (Left connectionFailure)
+                sendFresh _failure _request _previous _onEvent = do
+                    modifyIORef' freshCalls (+ 1)
+                    pure (Right response)
+                sender =
+                    openAiAuxiliaryResponseSenderWithConnectionRecovery
+                        healthy
+                        sendCurrent
+                        sendFresh
+            withAsync
+                (sender baseParams Nothing (const (pure ())))
+                \firstSender -> do
+                    takeMVar firstCurrentStarted
+                    withAsync
+                        ( putMVar secondSenderStarted ()
+                            >> sender baseParams Nothing (const (pure ()))
+                        )
+                        \secondSender -> do
+                            takeMVar secondSenderStarted
+                            overlappingCurrent <- timeout
+                                concurrencyProbeMicros
+                                (takeMVar laterCurrentStarted)
+                            overlappingCurrent `shouldBe` Nothing
+                            putMVar releaseCurrent ()
+                            firstResult <- wait firstSender
+                            secondResult <- wait secondSender
+                            firstResult `shouldBe` Right response
+                            secondResult `shouldBe` Right response
+            readConnectionHealth healthy `shouldReturn` False
+            readIORef currentCalls `shouldReturn` 1
+            readIORef freshCalls `shouldReturn` 2
+
+        it "marks a throwing reusable connection unhealthy and releases ownership" do
+            currentCalls <- newIORef (0 :: Int)
+            freshCalls <- newIORef (0 :: Int)
+            healthy <- newConnectionHealth True
+            let response = testResponse "resp-fresh" [assistantItem "ok"]
+                sendCurrent _request _previous _onEvent = do
+                    modifyIORef' currentCalls (+ 1)
+                    ioError (userError "socket read failed")
+                sendFresh _failure _request _previous _onEvent = do
+                    modifyIORef' freshCalls (+ 1)
+                    pure (Right response)
+                sender =
+                    openAiAuxiliaryResponseSenderWithConnectionRecovery
+                        healthy
+                        sendCurrent
+                        sendFresh
+            sender baseParams Nothing (const (pure ()))
+                `shouldThrow` anyIOException
+            readConnectionHealth healthy `shouldReturn` False
+            sender baseParams Nothing (const (pure ()))
+                `shouldReturn` Right response
+            readIORef currentCalls `shouldReturn` 1
+            readIORef freshCalls `shouldReturn` 1
+
         it "keeps auxiliary requests on the healthy reusable connection" do
             currentCalls <- newIORef (0 :: Int)
             freshCalls <- newIORef (0 :: Int)
-            healthy <- newIORef True
+            healthy <- newConnectionHealth True
             let response = testResponse "resp-current" [assistantItem "ok"]
                 sendCurrent _request _previous _onEvent = do
                     modifyIORef' currentCalls (+ 1)
@@ -613,7 +695,7 @@ spec = do
                         sendFresh
             sender baseParams Nothing (const (pure ()))
                 `shouldReturn` Right response
-            readIORef healthy `shouldReturn` True
+            readConnectionHealth healthy `shouldReturn` True
             readIORef currentCalls `shouldReturn` 1
             readIORef freshCalls `shouldReturn` 0
 
@@ -621,7 +703,7 @@ spec = do
             currentCalls <- newIORef (0 :: Int)
             freshCalls <- newIORef (0 :: Int)
             failures <- newIORef []
-            healthy <- newIORef True
+            healthy <- newConnectionHealth True
             let connectionFailure = ConnectionError "socket closed"
             let sendCurrent _request _previous _onEvent = do
                     modifyIORef' currentCalls (+ 1)
@@ -641,7 +723,7 @@ spec = do
                 Right (testResponse "resp-fresh" [assistantItem "ok"])
             second `shouldBe`
                 Right (testResponse "resp-fresh" [assistantItem "ok"])
-            readIORef healthy `shouldReturn` False
+            readConnectionHealth healthy `shouldReturn` False
             readIORef currentCalls `shouldReturn` 1
             readIORef freshCalls `shouldReturn` 2
             readIORef failures `shouldReturn`
@@ -649,7 +731,7 @@ spec = do
 
         it "does not replay auxiliary requests after an output item arrived" do
             freshCalls <- newIORef (0 :: Int)
-            healthy <- newIORef True
+            healthy <- newConnectionHealth True
             let connectionFailure = ConnectionError "socket closed"
                 outputEvent = ResponseOutputItemDoneEvent
                     { item = assistantItem "partial"
@@ -671,12 +753,12 @@ spec = do
             sender baseParams Nothing (const (pure ()))
                 `shouldReturn` Left
                     (replayUnsafeAuxiliaryFailure connectionFailure)
-            readIORef healthy `shouldReturn` False
+            readConnectionHealth healthy `shouldReturn` False
             readIORef freshCalls `shouldReturn` 0
 
         it "does not replay after a terminal auxiliary response arrived" do
             freshCalls <- newIORef (0 :: Int)
-            healthy <- newIORef True
+            healthy <- newConnectionHealth True
             let connectionFailure = ConnectionError "decode failed"
                 completedEvent = ResponseCompletedEvent
                     { responseValue = Aeson.toJSON
@@ -703,7 +785,7 @@ spec = do
 
         it "does not replay a failed auxiliary response with partial output" do
             freshCalls <- newIORef (0 :: Int)
-            healthy <- newIORef True
+            healthy <- newConnectionHealth True
             let connectionFailure = ConnectionError "failed response"
                 failedEvent = ResponseFailedEvent
                     { responseValue = Aeson.toJSON
@@ -731,7 +813,7 @@ spec = do
         it "marks output from an initially fresh auxiliary connection as replay-unsafe" do
             currentCalls <- newIORef (0 :: Int)
             freshCalls <- newIORef (0 :: Int)
-            healthy <- newIORef False
+            healthy <- newConnectionHealth False
             let connectionFailure = ConnectionError "fresh socket closed"
                 outputEvent = ResponseOutputItemDoneEvent
                     { item = assistantItem "partial"
@@ -759,7 +841,7 @@ spec = do
 
         it "marks fresh auxiliary output after a pre-output current failure" do
             freshCalls <- newIORef (0 :: Int)
-            healthy <- newIORef True
+            healthy <- newConnectionHealth True
             let currentFailure = ConnectionError "current socket closed"
                 freshFailure = ConnectionError "fresh socket closed"
                 outputEvent = ResponseOutputItemDoneEvent
@@ -783,13 +865,13 @@ spec = do
             sender baseParams Nothing (const (pure ()))
                 `shouldReturn` Left
                     (replayUnsafeAuxiliaryFailure freshFailure)
-            readIORef healthy `shouldReturn` False
+            readConnectionHealth healthy `shouldReturn` False
             readIORef freshCalls `shouldReturn` 1
 
         it "replays on a fresh connection when the reusable socket dies before output" do
             currentCalls <- newIORef (0 :: Int)
             freshCalls <- newIORef (0 :: Int)
-            healthy <- newIORef True
+            healthy <- newConnectionHealth True
             transcript <- newIORef []
             let sendCurrent _request _previous _onEvent = do
                     modifyIORef' currentCalls (+ 1)
@@ -804,13 +886,13 @@ spec = do
                 [UserMessage "two"] (const (pure ()))
             first `shouldBe` Right (emptyTurnOutput "resp-fresh" [] (Just "ok"))
             second `shouldBe` Right (emptyTurnOutput "resp-fresh" [] (Just "ok"))
-            readIORef healthy `shouldReturn` False
+            readConnectionHealth healthy `shouldReturn` False
             readIORef currentCalls `shouldReturn` 1
             readIORef freshCalls `shouldReturn` 2
 
         it "still replays after an informational Codex rate-limit warning" do
             freshCalls <- newIORef (0 :: Int)
-            healthy <- newIORef True
+            healthy <- newConnectionHealth True
             transcript <- newIORef []
             events <- newIORef []
             let rateLimitsEvent =
@@ -834,12 +916,12 @@ spec = do
                 [ WarningRaised
                     "Codex usage is low: primary 8% left. Check /usage for reset details."
                 ]
-            readIORef healthy `shouldReturn` False
+            readConnectionHealth healthy `shouldReturn` False
             readIORef freshCalls `shouldReturn` 1
 
         it "does not replay after loop-visible output was already streamed" do
             freshCalls <- newIORef (0 :: Int)
-            healthy <- newIORef True
+            healthy <- newConnectionHealth True
             transcript <- newIORef []
             events <- newIORef []
             let sendCurrent _request _previous onEvent = do
@@ -854,12 +936,12 @@ spec = do
                 (modifyIORef' events . (:))
             result `shouldBe` Left (ConnectionError "socket closed")
             reverse <$> readIORef events `shouldReturn` [TextDelta "partial"]
-            readIORef healthy `shouldReturn` False
+            readConnectionHealth healthy `shouldReturn` False
             readIORef freshCalls `shouldReturn` 0
 
         it "does not treat provider errors as a dead connection" do
             freshCalls <- newIORef (0 :: Int)
-            healthy <- newIORef True
+            healthy <- newConnectionHealth True
             transcript <- newIORef []
             let sendCurrent _request _previous _onEvent =
                     pure $ Left $ ProviderError InvalidRequestError "bad request" Nothing
@@ -871,13 +953,13 @@ spec = do
             result <- submitWithState transcript providerErrorBackend Nothing
                 [UserMessage "one"] (const (pure ()))
             result `shouldBe` Left (ProviderError InvalidRequestError "bad request" Nothing)
-            readIORef healthy `shouldReturn` True
+            readConnectionHealth healthy `shouldReturn` True
             readIORef freshCalls `shouldReturn` 0
 
         it "reconnects immediately after a websocket connection-limit error" do
             currentCalls <- newIORef (0 :: Int)
             freshCalls <- newIORef (0 :: Int)
-            healthy <- newIORef True
+            healthy <- newConnectionHealth True
             transcript <- newIORef []
             let sendCurrent _request _previous _onEvent = do
                     modifyIORef' currentCalls (+ 1)
@@ -891,13 +973,13 @@ spec = do
             result <- submitWithState transcript backend Nothing
                 [UserMessage "one"] (const (pure ()))
             result `shouldBe` Right (emptyTurnOutput "resp-fresh" [] (Just "ok"))
-            readIORef healthy `shouldReturn` False
+            readConnectionHealth healthy `shouldReturn` False
             readIORef currentCalls `shouldReturn` 1
             readIORef freshCalls `shouldReturn` 1
 
         it "reacquires a credential after an in-band usage-limit error" do
             freshCalls <- newIORef (0 :: Int)
-            healthy <- newIORef True
+            healthy <- newConnectionHealth True
             transcript <- newIORef []
             let sendCurrent _request _previous _onEvent =
                     pure $ Left $ ProviderError UsageLimitReached
@@ -910,11 +992,11 @@ spec = do
             result <- submitWithState transcript backend Nothing
                 [UserMessage "one"] (const (pure ()))
             result `shouldBe` Right (emptyTurnOutput "resp-fresh" [] (Just "ok"))
-            readIORef healthy `shouldReturn` False
+            readConnectionHealth healthy `shouldReturn` False
             readIORef freshCalls `shouldReturn` 1
 
         it "reports the exhausted reusable connection before replaying on a fresh account" do
-            healthy <- newIORef True
+            healthy <- newConnectionHealth True
             transcript <- newIORef (turnInputsToItems [UserMessage "old"])
             failures <- newIORef []
             seen <- newIORef []
@@ -988,8 +1070,93 @@ spec = do
                 ]
 
     describe "openAiBackendWithTransportFallback" do
+        it "allows only one concurrent primary failure before fallback activation" do
+            fallbackActive <- newTransportFallbackState False
+            primaryCalls <- newIORef (0 :: Int)
+            fallbackCalls <- newIORef (0 :: Int)
+            firstPrimaryStarted <- newEmptyMVar
+            laterPrimaryStarted <- newEmptyMVar
+            releasePrimary <- newEmptyMVar
+            secondTurnStarted <- newEmptyMVar
+            firstTranscript <- newIORef []
+            secondTranscript <- newIORef []
+            let primary = Backend \_state _previous _inputs _onEvent -> do
+                    callNumber <- atomicModifyIORef' primaryCalls \n ->
+                        let next = n + 1
+                        in (next, next)
+                    if callNumber == 1
+                        then putMVar firstPrimaryStarted ()
+                        else putMVar laterPrimaryStarted ()
+                    readMVar releasePrimary
+                    pure (Left (ConnectionError "socket closed"))
+                fallback = Backend \state _previous _inputs _onEvent -> do
+                    modifyIORef' fallbackCalls (+ 1)
+                    pure $ Right BackendResult
+                        { backendOutput =
+                            emptyTurnOutput "resp-http" [] (Just "ok")
+                        , backendState = state
+                        }
+                backend =
+                    openAiBackendWithTransportFallback
+                        fallbackActive primary fallback
+                submit transcript message =
+                    submitWithState transcript backend Nothing
+                        [UserMessage message] (const (pure ()))
+                expected =
+                    Right (emptyTurnOutput "resp-http" [] (Just "ok"))
+            withAsync (submit firstTranscript "one") \firstTurn -> do
+                takeMVar firstPrimaryStarted
+                withAsync
+                    (putMVar secondTurnStarted () >> submit secondTranscript "two")
+                    \secondTurn -> do
+                        takeMVar secondTurnStarted
+                        overlappingPrimary <- timeout
+                            concurrencyProbeMicros
+                            (takeMVar laterPrimaryStarted)
+                        overlappingPrimary `shouldBe` Nothing
+                        putMVar releasePrimary ()
+                        firstResult <- wait firstTurn
+                        secondResult <- wait secondTurn
+                        firstResult `shouldBe` expected
+                        secondResult `shouldBe` expected
+            readTransportFallbackState fallbackActive `shouldReturn` True
+            readIORef primaryCalls `shouldReturn` 1
+            readIORef fallbackCalls `shouldReturn` 2
+
+        it "keeps fallback active when the fallback backend throws" do
+            fallbackActive <- newTransportFallbackState False
+            primaryCalls <- newIORef (0 :: Int)
+            fallbackCalls <- newIORef (0 :: Int)
+            transcript <- newIORef []
+            let primary = Backend \_state _previous _inputs _onEvent -> do
+                    modifyIORef' primaryCalls (+ 1)
+                    pure (Left (ConnectionError "socket closed"))
+                fallback = Backend \state _previous _inputs _onEvent -> do
+                    callNumber <- atomicModifyIORef' fallbackCalls \n ->
+                        let next = n + 1
+                        in (next, next)
+                    if callNumber == 1
+                        then ioError (userError "fallback failed")
+                        else pure $ Right BackendResult
+                            { backendOutput =
+                                emptyTurnOutput "resp-http" [] (Just "ok")
+                            , backendState = state
+                            }
+                backend =
+                    openAiBackendWithTransportFallback
+                        fallbackActive primary fallback
+                submit =
+                    submitWithState transcript backend Nothing
+                        [UserMessage "one"] (const (pure ()))
+            submit `shouldThrow` anyIOException
+            readTransportFallbackState fallbackActive `shouldReturn` True
+            submit `shouldReturn`
+                Right (emptyTurnOutput "resp-http" [] (Just "ok"))
+            readIORef primaryCalls `shouldReturn` 1
+            readIORef fallbackCalls `shouldReturn` 2
+
         it "switches permanently to fallback after a pre-output connection error" do
-            fallbackActive <- newIORef False
+            fallbackActive <- newTransportFallbackState False
             primaryCalls <- newIORef (0 :: Int)
             fallbackCalls <- newIORef (0 :: Int)
             transcript <- newIORef []
@@ -1013,12 +1180,12 @@ spec = do
                 [UserMessage "two"] (const (pure ()))
             first `shouldBe` Right (emptyTurnOutput "resp-http" [] (Just "ok"))
             second `shouldBe` Right (emptyTurnOutput "resp-http" [] (Just "ok"))
-            readIORef fallbackActive `shouldReturn` True
+            readTransportFallbackState fallbackActive `shouldReturn` True
             readIORef primaryCalls `shouldReturn` 1
             readIORef fallbackCalls `shouldReturn` 2
 
         it "does not replay a failed turn after model output was exposed" do
-            fallbackActive <- newIORef False
+            fallbackActive <- newTransportFallbackState False
             fallbackCalls <- newIORef (0 :: Int)
             transcript <- newIORef []
             let primary = Backend \_state _previous _inputs onEvent -> do
@@ -1037,11 +1204,11 @@ spec = do
             result <- submitWithState transcript backend Nothing
                 [UserMessage "one"] (const (pure ()))
             result `shouldBe` Left (ConnectionError "socket closed")
-            readIORef fallbackActive `shouldReturn` True
+            readTransportFallbackState fallbackActive `shouldReturn` True
             readIORef fallbackCalls `shouldReturn` 0
 
         it "falls back immediately after a websocket connection-limit error" do
-            fallbackActive <- newIORef False
+            fallbackActive <- newTransportFallbackState False
             primaryCalls <- newIORef (0 :: Int)
             fallbackCalls <- newIORef (0 :: Int)
             events <- newIORef []
@@ -1072,7 +1239,7 @@ spec = do
             readIORef fallbackCalls `shouldReturn` 1
 
         it "preserves non-transport provider failures" do
-            fallbackActive <- newIORef False
+            fallbackActive <- newTransportFallbackState False
             fallbackCalls <- newIORef (0 :: Int)
             transcript <- newIORef []
             let primary = Backend \_state _previous _inputs _onEvent ->
@@ -1092,12 +1259,15 @@ spec = do
                 [UserMessage "one"] (const (pure ()))
             result `shouldBe` Left (ProviderError InvalidRequestError
                 "bad request" Nothing)
-            readIORef fallbackActive `shouldReturn` False
+            readTransportFallbackState fallbackActive `shouldReturn` False
             readIORef fallbackCalls `shouldReturn` 0
 
 --------------------------------------------------------------------------------
 -- Fixtures
 --------------------------------------------------------------------------------
+
+concurrencyProbeMicros :: Int
+concurrencyProbeMicros = 100_000
 
 submitWithState
     :: IORef [ResponseItem]
@@ -1280,7 +1450,7 @@ inputItems request = case request.input of
 
 shouldRetryFreshAuxiliaryFailure :: ApiError -> Expectation
 shouldRetryFreshAuxiliaryFailure initialFailure = do
-    healthy <- newIORef False
+    healthy <- newConnectionHealth False
     currentCalls <- newIORef (0 :: Int)
     freshCalls <- newIORef (0 :: Int)
     let response = testResponse "resp-retried" [assistantItem "ok"]
@@ -1312,7 +1482,7 @@ shouldRetryFreshAuxiliaryFailure initialFailure = do
 
 shouldMarkPostOutputAuxiliaryFailure :: ApiError -> Expectation
 shouldMarkPostOutputAuxiliaryFailure failure = do
-    healthy <- newIORef True
+    healthy <- newConnectionHealth True
     currentCalls <- newIORef (0 :: Int)
     freshCalls <- newIORef (0 :: Int)
     let outputEvent = ResponseOutputItemDoneEvent


### PR DESCRIPTION
## Summary
- replace caller-owned OpenAI connection-health `IORef Bool` values with an opaque synchronized owner
- serialize reusable WebSocket recovery so concurrent callers cannot both use a connection while its health is unresolved
- make transport fallback activation a coherent transition and preserve it when fallback execution throws
- migrate CLI persistent connections and Codex subagents to the synchronized state APIs
- add race and exception-cleanup tests for connection recovery and transport fallback

## Tests
- `nix develop -c cabal test agent-openai:test:agent-openai-test --test-show-details=direct` (217 examples, 0 failures, 1 live Codex functional pending without credentials)
- `nix develop -c cabal repl agent-openai:lib:agent-openai agent-cli:lib:agent-cli --repl-options=-fno-code`

Follow-up to #360.
