### PR TITLE
Show live provider retry countdown

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -101,6 +101,7 @@ import Agent.CLI.Connectivity (withConnectionRecovery)
 import Agent.CLI.Error
     ( formatApiErrorAt
     , formatApiErrorInlineAt
+    , formatApiErrorRetryCountdownParts
     )
 import Agent.CLI.ImagePreview
     ( detectImagePreviewProtocol
@@ -3505,15 +3506,29 @@ reportProviderUnavailable
     -> IO ()
 reportProviderUnavailable fullscreen apiError = do
     now <- getCurrentTime
-    let message =
-            "No usable fallback provider account is available.\n"
-            <> formatApiErrorAt now apiError
+    let leading = "No usable fallback provider account is available.\n"
+        message = leading <> formatApiErrorAt now apiError
     case fullscreen of
         Nothing -> do
             color <- resolveColor stderr
             putTextLn stderr (roleError color message)
         Just runtime ->
-            emitUiEvent runtime (UiErrorMessage message)
+            case (apiError, formatApiErrorRetryCountdownParts apiError) of
+                (CredentialsExhausted{retryAt}, Just (prefix, suffix)) ->
+                    let remainingMillis =
+                            max 0
+                                (ceiling
+                                    ( realToFrac (diffUTCTime retryAt now)
+                                        * 1000
+                                        :: Double
+                                    ))
+                    in emitUiEvent runtime
+                        (UiRetryCountdown
+                            (leading <> prefix)
+                            remainingMillis
+                            suffix)
+                _ ->
+                    emitUiEvent runtime (UiErrorMessage message)
 
 setSessionEffort :: SessionEnv -> Text -> IO ()
 setSessionEffort env level = do

--- a/packages/agent-cli/src/Agent/CLI/Error.hs
+++ b/packages/agent-cli/src/Agent/CLI/Error.hs
@@ -9,6 +9,7 @@ module Agent.CLI.Error
     , formatApiErrorInline
     , formatApiErrorInlineAt
     , formatApiErrorPersistedAt
+    , formatApiErrorRetryCountdownParts
     , formatException
     ) where
 
@@ -94,13 +95,22 @@ formatApiErrorWith maybeNow retryPresentation = \case
             details
             [action]
     CredentialsExhausted{retryAt} ->
-        message
-            "Provider unavailable."
-            []
-            [ "All accounts for this provider are temporarily unavailable."
-            , credentialsRetryGuidance maybeNow retryAt
-                <> ", or choose another provider with /model."
-            ]
+        let (prefix, suffix) = credentialsExhaustedRetryParts
+        in prefix <> credentialsRetryGuidance maybeNow retryAt <> suffix
+
+-- | Static text around the live retry phrase for errors with an absolute
+-- credential reset deadline. The TUI inserts @Try again in …@ and updates it.
+formatApiErrorRetryCountdownParts :: ApiError -> Maybe (Text, Text)
+formatApiErrorRetryCountdownParts = \case
+    CredentialsExhausted{} -> Just credentialsExhaustedRetryParts
+    _ -> Nothing
+
+credentialsExhaustedRetryParts :: (Text, Text)
+credentialsExhaustedRetryParts =
+    ( "Provider unavailable.\n\
+      \All accounts for this provider are temporarily unavailable.\n"
+    , ", or choose another provider with /model."
+    )
 
 formatProviderError
     :: RetryPresentation

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -2531,6 +2531,10 @@ cacheableBlock :: AppState -> UiBlock -> Bool
 cacheableBlock state block =
     block.blockState
         `notElem` [BlockStreaming, BlockRunning]
+        && maybe
+            True
+            ((/= block.blockId) . (.retryCountdownBlockId))
+            state.appUi.uiRetryCountdown
         && not (blockFlashing state block)
 
 blockStateGlyph :: AppState -> UiBlock -> Text

--- a/packages/agent-cli/src/Agent/CLI/TUI/Bridge.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Bridge.hs
@@ -22,6 +22,7 @@ eventFollows = \case
     UiAssistantHistory _ -> True
     UiSystemMessage _ -> True
     UiErrorMessage _ -> True
+    UiRetryCountdown{} -> True
     UiConversationCleared -> True
     _ -> False
 

--- a/packages/agent-cli/test/Agent/CLI/ErrorSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ErrorSpec.hs
@@ -124,6 +124,19 @@ spec = do
                 (ProviderError RateLimitError "slow down" (Just 0))
                 `shouldSatisfy` Text.isInfixOf "Try again now"
 
+        it "exposes live countdown framing only for credential exhaustion" do
+            formatApiErrorRetryCountdownParts
+                (CredentialsExhausted (addUTCTime 60 epoch))
+                `shouldBe`
+                    Just
+                        ( "Provider unavailable.\n\
+                          \All accounts for this provider are temporarily unavailable.\n"
+                        , ", or choose another provider with /model."
+                        )
+            formatApiErrorRetryCountdownParts
+                (ProviderError RateLimitError "slow down" (Just 60))
+                `shouldBe` Nothing
+
         it "bounds and sanitizes provider detail text" do
             let rendered =
                     formatApiErrorAt epoch

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -290,6 +290,21 @@ spec = do
             motionDemandFor MotionOff False False False running
                 `shouldBe` MotionSlow
 
+        it "keeps semantic countdown updates active in every motion mode" do
+            let countdown =
+                    reduceUi
+                        (UiRetryCountdown
+                            "Provider unavailable.\n"
+                            60000
+                            ", or choose another provider.")
+                        initialUiState
+            motionDemandFor MotionFull False False False countdown
+                `shouldBe` MotionSlow
+            motionDemandFor MotionReduced False False False countdown
+                `shouldBe` MotionSlow
+            motionDemandFor MotionOff False False False countdown
+                `shouldBe` MotionSlow
+
         it "bumps the scheduler generation on demand or timer boundaries" do
             nextMotionSchedule
                 False

--- a/packages/agent-cli/test/Agent/CLI/TUIBridgeSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIBridgeSpec.hs
@@ -36,6 +36,9 @@ spec = describe "fullscreen TUI bridge" do
     it "follows retained output events but not draft-only events" do
         eventFollows (UiSystemMessage "copied") `shouldBe` True
         eventFollows (UiErrorMessage "failed") `shouldBe` True
+        eventFollows
+            (UiRetryCountdown "Provider unavailable.\n" 60000 ".")
+            `shouldBe` True
         eventFollows (UiSetDraft "draft" 5) `shouldBe` False
 
     it "starts and clears native terminal progress" do

--- a/packages/agent-tui/src/Agent/TUI/Model.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model.hs
@@ -5,6 +5,7 @@ module Agent.TUI.Model
     , BlockState(..)
     , Focus(..)
     , NoticeKind(..)
+    , RetryCountdown(..)
     , PermissionOverlay(..)
     , PromptState(..)
     , UiBlock(..)
@@ -89,6 +90,15 @@ data UiNotice = UiNotice
     }
     deriving (Eq, Show)
 
+-- | A live retry deadline attached to one retained error block.
+data RetryCountdown = RetryCountdown
+    { retryCountdownBlockId :: !BlockId
+    , retryCountdownPrefix :: !Text
+    , retryCountdownRemainingMillis :: !Int
+    , retryCountdownSuffix :: !Text
+    }
+    deriving (Eq, Show)
+
 data BlockState
     = BlockStreaming
     | BlockRunning
@@ -152,6 +162,7 @@ data UiState = UiState
     , uiCwd :: !Text
     , uiPermission :: !(Maybe PermissionOverlay)
     , uiNotice :: !(Maybe UiNotice)
+    , uiRetryCountdown :: !(Maybe RetryCountdown)
     , uiNoticeElapsedMillis :: !Int
     , uiElapsedMillis :: !Int
     , uiCompletionRemainingMillis :: !Int
@@ -184,6 +195,8 @@ data UiEvent
     | UiAssistantHistory !Text
     | UiSystemMessage !Text
     | UiErrorMessage !Text
+    -- | Append an error whose retry guidance counts down in place.
+    | UiRetryCountdown !Text !Int !Text
     | UiConversationCleared
     | UiSetFollow !Bool
     | UiTurnEnded !BlockState
@@ -218,6 +231,7 @@ initialUiState = UiState
     , uiCwd = ""
     , uiPermission = Nothing
     , uiNotice = Nothing
+    , uiRetryCountdown = Nothing
     , uiNoticeElapsedMillis = 0
     , uiElapsedMillis = 0
     , uiCompletionRemainingMillis = 0
@@ -345,7 +359,32 @@ reduceUi event state = case event of
     UiSystemMessage message ->
         appendBlock BlockSystem "System" message "" BlockComplete Nothing state
     UiErrorMessage message ->
-        appendBlock BlockError "Error" message "" BlockFailed Nothing state
+        (appendBlock BlockError "Error" message "" BlockFailed Nothing state)
+            { uiRetryCountdown = Nothing }
+    UiRetryCountdown prefix remainingMillis suffix ->
+        let
+            ident = BlockId state.uiNextBlockId
+            remaining = max 0 remainingMillis
+            withBlock =
+                appendBlock
+                    BlockError
+                    "Error"
+                    (retryCountdownText prefix remaining suffix)
+                    ""
+                    BlockFailed
+                    Nothing
+                    state
+        in withBlock
+            { uiRetryCountdown =
+                if remaining == 0
+                    then Nothing
+                    else Just RetryCountdown
+                        { retryCountdownBlockId = ident
+                        , retryCountdownPrefix = prefix
+                        , retryCountdownRemainingMillis = remaining
+                        , retryCountdownSuffix = suffix
+                        }
+            }
     UiConversationCleared ->
         state
             { uiBlocks = Seq.empty
@@ -355,6 +394,7 @@ reduceUi event state = case event of
             , uiNextBlockId = 1
             , uiTurnStartBlock = 0
             , uiToolCalls = Map.empty
+            , uiRetryCountdown = Nothing
             }
     UiSetFollow follow ->
         state
@@ -415,7 +455,9 @@ advanceUiTime rawElapsedMillis state =
             , maybe False (.noticeTransient) state.uiNotice =
                 Nothing
             | otherwise = state.uiNotice
-    in state
+        countdown =
+            advanceRetryCountdown elapsedMillis state
+    in countdown
         { uiElapsedMillis =
             if state.uiRunning
                 then state.uiElapsedMillis + elapsedMillis
@@ -435,6 +477,8 @@ uiNeedsTick :: UiState -> Bool
 uiNeedsTick state =
     state.uiRunning
         || state.uiCompletionRemainingMillis > 0
+        || maybe False ((> 0) . (.retryCountdownRemainingMillis))
+            state.uiRetryCountdown
         || maybe False noticeNeedsTick state.uiNotice
   where
     noticeNeedsTick notice =
@@ -443,11 +487,20 @@ uiNeedsTick state =
 uiNextDeadlineMillis :: UiState -> Maybe Int
 uiNextDeadlineMillis state =
     minimumMaybe $
-        completionDeadline <> noticeDeadline
+        completionDeadline <> countdownDeadline <> noticeDeadline
   where
     completionDeadline =
         [state.uiCompletionRemainingMillis
         | state.uiCompletionRemainingMillis > 0]
+    countdownDeadline =
+        case state.uiRetryCountdown of
+            Just countdown ->
+                [ min
+                    countdown.retryCountdownRemainingMillis
+                    (millisecondsUntilNextDisplayedSecond
+                        countdown.retryCountdownRemainingMillis)
+                ]
+            Nothing -> []
     noticeDeadline =
         case state.uiNotice of
             Just notice
@@ -460,6 +513,74 @@ uiNextDeadlineMillis state =
                 []
     minimumMaybe [] = Nothing
     minimumMaybe values = Just (minimum values)
+
+advanceRetryCountdown :: Int -> UiState -> UiState
+advanceRetryCountdown elapsedMillis state =
+    case state.uiRetryCountdown of
+        Nothing -> state
+        Just countdown ->
+            let
+                remaining =
+                    max 0
+                        ( countdown.retryCountdownRemainingMillis
+                            - elapsedMillis
+                        )
+                body =
+                    retryCountdownText
+                        countdown.retryCountdownPrefix
+                        remaining
+                        countdown.retryCountdownSuffix
+                blocks =
+                    case Map.lookup
+                        countdown.retryCountdownBlockId
+                        state.uiBlockIndices of
+                        Nothing -> state.uiBlocks
+                        Just index ->
+                            Seq.adjust
+                                (\block -> block { blockBody = body })
+                                index
+                                state.uiBlocks
+            in state
+                { uiBlocks = blocks
+                , uiRetryCountdown =
+                    if remaining == 0
+                        then Nothing
+                        else Just countdown
+                            { retryCountdownRemainingMillis = remaining }
+                }
+
+retryCountdownText :: Text -> Int -> Text -> Text
+retryCountdownText prefix remainingMillis suffix =
+    prefix
+        <> (if remainingMillis <= 0
+                then "Try again now"
+                else
+                    "Try again in "
+                        <> formatCountdownSeconds
+                            ((remainingMillis + 999) `div` 1000))
+        <> suffix
+
+formatCountdownSeconds :: Int -> Text
+formatCountdownSeconds rawSeconds =
+    let
+        total = max 0 rawSeconds
+        hours = total `div` 3600
+        minutes = (total `mod` 3600) `div` 60
+        seconds = total `mod` 60
+        showText = Text.pack . show
+        pad2 value
+            | value < 10 = "0" <> showText value
+            | otherwise = showText value
+    in if hours > 0
+        then showText hours <> "h" <> pad2 minutes <> "m" <> pad2 seconds <> "s"
+        else if minutes > 0
+            then showText minutes <> "m" <> pad2 seconds <> "s"
+            else showText seconds <> "s"
+
+millisecondsUntilNextDisplayedSecond :: Int -> Int
+millisecondsUntilNextDisplayedSecond remainingMillis =
+    let remainder = remainingMillis `mod` 1000
+    in if remainder == 0 then 1000 else remainder
 
 reduceLoop :: LoopEvent -> UiState -> UiState
 reduceLoop event state = case event of

--- a/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
@@ -494,6 +494,38 @@ spec = describe "fullscreen UI reducer" do
                     (warningNotice
                         "Cancelling the current turn; sending this prompt next…")
 
+    it "updates retry errors in place until the deadline reaches now" do
+        let started =
+                reduceUi
+                    (UiRetryCountdown
+                        "Provider unavailable.\n"
+                        61000
+                        ", or choose another provider.")
+                    initialUiState
+            afterSecond = advanceUiTime 1000 started
+            finished = advanceUiTime 60000 afterSecond
+            bodies =
+                map (.blockBody) . Foldable.toList . (.uiBlocks)
+        bodies started
+            `shouldBe`
+                [ "Provider unavailable.\n\
+                  \Try again in 1m01s, or choose another provider."
+                ]
+        bodies afterSecond
+            `shouldBe`
+                [ "Provider unavailable.\n\
+                  \Try again in 1m00s, or choose another provider."
+                ]
+        bodies finished
+            `shouldBe`
+                [ "Provider unavailable.\n\
+                  \Try again now, or choose another provider."
+                ]
+        uiNeedsTick started `shouldBe` True
+        uiNextDeadlineMillis started `shouldBe` Just 1000
+        finished.uiRetryCountdown `shouldBe` Nothing
+        uiNeedsTick finished `shouldBe` False
+
     it "shows a search-replace diff while the tool is running" do
         let call =
                 functionToolCall


### PR DESCRIPTION
## Summary
- render credential-exhaustion retry guidance as a retained live countdown
- reuse the fullscreen semantic motion ticker so countdowns update in every motion mode
- keep dynamic error blocks out of the Brick cache until the deadline expires

## Validation
- agent-tui ModelSpec: 34 examples, 0 failures
- agent-cli ErrorSpec: 11 examples, 0 failures
- agent-cli TUIAppSpec: 28 examples, 0 failures
- agent-cli TUIBridgeSpec: 10 examples, 0 failures
- tmux smoke test confirmed in-place countdown updates while the prompt remained active