### PR TITLE
refactor(cli): commit account display state atomically

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -226,7 +226,10 @@ import Agent.CLI.Session
 import Agent.CLI.SessionEnv (SessionEnv(..))
 import Agent.CLI.SessionState
     ( SessionState(..)
+    , SessionAccountPatch(..)
+    , SessionAccountState(..)
     , addSessionTokenUsage
+    , applySessionAccountPatch
     , clearSessionPreviousResponseId
     , replaceSessionTranscript
     , resetSessionConversation
@@ -338,7 +341,7 @@ import Agent.TUI.Model
     )
 import Agent.TUI.Motion (nativeProgressAnimationEnabled)
 import Agent.CLI.Turn (applyPendingSessionTitles, runOneTurn)
-import Agent.CLI.TurnState (ConversationState(..))
+import Agent.CLI.TurnState (ConversationState(..), FieldUpdate(..))
 import Agent.CLI.Usage
     ( AccountUsageLine(..)
     , formatDuration
@@ -1394,9 +1397,37 @@ runAgentInitializedWithLock
                     "automatic provider fallback would cross from subscription \
                     \billing to API-credit billing"
         _ -> pure ()
-    activeAccountRef <- newIORef ""
-    activeAccountIdRef <- newIORef ""
-    activeSelectionRef <- newIORef ""
+    sessionStateRef <- newIORef SessionState
+        { sessionConversation = ConversationState
+            { conversationPreviousResponseId = Nothing
+            , conversationTranscript = []
+            , conversationStartupContext = Nothing
+            , conversationUsage = emptyTokenUsage
+            , conversationLastAssistant = Nothing
+            }
+        , sessionSkillCatalog = SkillCatalog [] []
+        , sessionSkillInvocations = []
+        , sessionAccount = SessionAccountState
+            { accountLabel = ""
+            , accountId = ""
+            , accountSelectionId = ""
+            }
+        }
+    let commitAccount patch =
+            atomicModifyIORef' sessionStateRef \state ->
+                (applySessionAccountPatch patch state, ())
+        replaceAccount label accountId selectionId =
+            commitAccount SessionAccountPatch
+                { patchAccountLabel = SetField label
+                , patchAccountId = SetField accountId
+                , patchAccountSelectionId = SetField selectionId
+                }
+        replaceAccountIdentity label accountId =
+            commitAccount SessionAccountPatch
+                { patchAccountLabel = SetField label
+                , patchAccountId = SetField accountId
+                , patchAccountSelectionId = KeepField
+                }
     preferredOpenAiAccountRef <- newIORef Nothing
     let selectableTokenProvider =
             case loaded.loadedOpenAiPool of
@@ -1409,7 +1440,7 @@ runAgentInitializedWithLock
                     loaded.loadedTokenProvider
     initialHttp <- case customResponses of
         Just (connectionId, _) -> do
-            writeIORef activeAccountRef connectionId
+            replaceAccountIdentity connectionId ""
             pure
                 ( selectableTokenProvider
                 , const (pure connectionId)
@@ -1426,13 +1457,11 @@ runAgentInitializedWithLock
                 probeLoadedAuthCredential loaded >>= \case
                     Right (credential, usable) -> do
                         label <- usable.loadedAccountLabel credential
-                        writeIORef activeAccountRef label
-                        writeIORef activeAccountIdRef credential.accountId
                         let selectionId =
                                 fromMaybe
                                     credential.accountId
                                     usable.loadedSelectionId
-                        writeIORef activeSelectionRef selectionId
+                        replaceAccount label credential.accountId selectionId
                         pure
                             ( usable.loadedTokenProvider
                             , usable.loadedAccountLabel
@@ -1443,8 +1472,7 @@ runAgentInitializedWithLock
                                 XAIProvider -> "Grok"
                                 OpenRouterProvider -> "OpenRouter"
                             selectionId = fromMaybe "" loaded.loadedSelectionId
-                        writeIORef activeAccountRef fallback
-                        writeIORef activeSelectionRef selectionId
+                        replaceAccount fallback "" selectionId
                         pure
                             ( selectableTokenProvider
                             , loaded.loadedAccountLabel
@@ -1484,10 +1512,9 @@ runAgentInitializedWithLock
                                     if current.activeHttpGeneration
                                         == snapshot.activeHttpGeneration
                                         then do
-                                            writeIORef
-                                                activeAccountIdRef
+                                            replaceAccountIdentity
+                                                label
                                                 credential.accountId
-                                            writeIORef activeAccountRef label
                                             pure current
                                                 { activeHttpAccountId =
                                                     credential.accountId
@@ -1505,9 +1532,7 @@ runAgentInitializedWithLock
             case loaded.loadedProvider of
                 OpenAIProvider ->
                     trackCredentialAccount
-                        activeAccountRef
-                        activeAccountIdRef
-                        activeSelectionRef
+                        sessionStateRef
                         resolveActiveAccountLabel
                         selectableTokenProvider
                 _ -> switchableTokenProvider
@@ -1534,13 +1559,10 @@ runAgentInitializedWithLock
                                                 selectedSelectionId
                                                 usable.loadedSelectionId
                                     modifyMVar_ activeHttpAuth \current -> do
-                                        writeIORef
-                                            activeAccountIdRef
+                                        replaceAccount
+                                            label
                                             credential.accountId
-                                        writeIORef
-                                            activeSelectionRef
                                             selectionId
-                                        writeIORef activeAccountRef label
                                         pure ActiveHttpAuth
                                             { activeHttpGeneration =
                                                 current.activeHttpGeneration + 1
@@ -1935,17 +1957,18 @@ runAgentInitializedWithLock
         let initialUsage = case resumed of
                 Just (meta, turns) -> sessionUsageFromTurns meta turns
                 Nothing -> emptyTokenUsage
-        sessionStateRef <- newIORef SessionState
-            { sessionConversation = ConversationState
-                { conversationPreviousResponseId = initialPrevious
-                , conversationTranscript = initialItems
-                , conversationStartupContext = startupContext
-                , conversationUsage = initialUsage
-                , conversationLastAssistant = Nothing
+        atomicModifyIORef' sessionStateRef \state ->
+            ( state
+                { sessionConversation = ConversationState
+                    { conversationPreviousResponseId = initialPrevious
+                    , conversationTranscript = initialItems
+                    , conversationStartupContext = startupContext
+                    , conversationUsage = initialUsage
+                    , conversationLastAssistant = Nothing
+                    }
                 }
-            , sessionSkillCatalog = SkillCatalog [] []
-            , sessionSkillInvocations = []
-            }
+            , ()
+            )
         writeIORef subagentForkSource $
             Just
                 ( (.sessionConversation.conversationTranscript)
@@ -2092,15 +2115,10 @@ runAgentInitializedWithLock
                                                                     newCredential
                                                                     newHealthy
                                                                     newConn
-                                                            writeIORef
-                                                                activeAccountIdRef
-                                                                newCredential.accountId
-                                                            writeIORef
-                                                                activeSelectionRef
-                                                                newCredential.accountId
-                                                            writeIORef
-                                                                activeAccountRef
+                                                            replaceAccount
                                                                 label
+                                                                newCredential.accountId
+                                                                newCredential.accountId
                                                             pure (newHealthy, label)
                                                     awaitNext newHealthy =
                                                         readChan switchRequests
@@ -2111,7 +2129,8 @@ runAgentInitializedWithLock
                                                 oldConnection <-
                                                     readIORef activeConnectionRef
                                                 previousAccountId <-
-                                                    readIORef activeAccountIdRef
+                                                    (.sessionAccount.accountId)
+                                                        <$> readIORef sessionStateRef
                                                 let OpenAiPersistentConnection
                                                         _
                                                         oldHealthy
@@ -2248,7 +2267,7 @@ runAgentInitializedWithLock
                                     link switchWorker
                                     runSession catalog inferredTarget.targetConnectionId options provider dialect policy tools toolEnv planMode startup prompt pendingTurn transitionDraft unavailableProviders startupUnavailable paramsRef sessionStateRef initialTurns
                                         persist projectRoot home cwd (Just tokenProvider) loaded.loadedOpenAiPool escPaused interrupt
-                                        multiCtx rootTurnRef subagentSessions pendingNotices subagentStoreRoot agentTypesRef legacySubagentTarget activeAccountRef activeAccountIdRef activeSelectionRef resolveActiveAccountLabel selectAccount claimCurrentSession compactRunner activeBackend btwBackend)
+                                        multiCtx rootTurnRef subagentSessions pendingNotices subagentStoreRoot agentTypesRef legacySubagentTarget selectAccount claimCurrentSession compactRunner activeBackend btwBackend)
                             >>= \case
                                 Left (CodexAuthFailed err) ->
                                     case transition of
@@ -2312,7 +2331,7 @@ runAgentInitializedWithLock
                                 projectRoot transition persist backend
                         runSession catalog inferredTarget.targetConnectionId options provider dialect policy tools toolEnv planMode startup prompt pendingTurn transitionDraft unavailableProviders startupUnavailable paramsRef sessionStateRef initialTurns
                             persist projectRoot home cwd (Just tokenProvider) loaded.loadedOpenAiPool escPaused interrupt
-                            multiCtx rootTurnRef subagentSessions pendingNotices subagentStoreRoot agentTypesRef legacySubagentTarget activeAccountRef activeAccountIdRef activeSelectionRef resolveActiveAccountLabel (if isJust customGenericOptions then Nothing else Just selectHttpAccount) claimCurrentSession compactRunner activeBackend btwBackend
+                            multiCtx rootTurnRef subagentSessions pendingNotices subagentStoreRoot agentTypesRef legacySubagentTarget (if isJust customGenericOptions then Nothing else Just selectHttpAccount) claimCurrentSession compactRunner activeBackend btwBackend
                     OpenRouterProvider -> do
                         let makeBackend params =
                                 case customGenericOptions of
@@ -2384,7 +2403,7 @@ runAgentInitializedWithLock
                                 projectRoot transition persist backend
                         runSession catalog inferredTarget.targetConnectionId options provider dialect policy tools toolEnv planMode startup prompt pendingTurn transitionDraft unavailableProviders startupUnavailable paramsRef sessionStateRef initialTurns
                             persist projectRoot home cwd (Just tokenProvider) loaded.loadedOpenAiPool escPaused interrupt
-                            multiCtx rootTurnRef subagentSessions pendingNotices subagentStoreRoot agentTypesRef legacySubagentTarget activeAccountRef activeAccountIdRef activeSelectionRef resolveActiveAccountLabel (Just selectHttpAccount) claimCurrentSession compactRunner activeBackend btwBackend
+                            multiCtx rootTurnRef subagentSessions pendingNotices subagentStoreRoot agentTypesRef legacySubagentTarget (Just selectHttpAccount) claimCurrentSession compactRunner activeBackend btwBackend
           where
             startupFailure err = do
                 now <- getCurrentTime
@@ -2392,20 +2411,27 @@ runAgentInitializedWithLock
                     (Text.unpack (formatApiErrorAt now err))
 
 trackCredentialAccount
-    :: IORef Text
-    -> IORef Text
-    -> IORef Text
+    :: IORef SessionState
     -> (Credential -> IO Text)
     -> TokenProvider
     -> TokenProvider
-trackCredentialAccount accountRef accountIdRef selectionRef resolveLabel provider =
+trackCredentialAccount sessionStateRef resolveLabel provider =
     tokenProvider (tokenProviderBillingMode provider) \failed ->
         getNextToken provider failed >>= \case
             Left err -> pure (Left err)
             Right credential -> do
-                writeIORef accountIdRef credential.accountId
-                writeIORef selectionRef credential.accountId
-                resolveLabel credential >>= writeIORef accountRef
+                label <- resolveLabel credential
+                atomicModifyIORef' sessionStateRef \state ->
+                    ( applySessionAccountPatch
+                        SessionAccountPatch
+                            { patchAccountLabel = SetField label
+                            , patchAccountId = SetField credential.accountId
+                            , patchAccountSelectionId =
+                                SetField credential.accountId
+                            }
+                        state
+                    , ()
+                    )
                 pure (Right credential)
 
 preparePersistence
@@ -2597,17 +2623,13 @@ runSession
     -> SubagentStoreRoot
     -> GrokSubagentSpecs
     -> Maybe LegacySubagentTarget
-    -> IORef Text
-    -> IORef Text
-    -> IORef Text
-    -> (Credential -> IO Text)
     -> Maybe (Text -> IO (Either ApiError Text))
     -> (SessionHandle -> IO ())
     -> (Maybe Text -> IO (Either Text CompactOutcome))
     -> Backend
     -> BtwBackendFactory
     -> IO RunResult
-runSession catalog connectionId options provider dialect policy tools toolEnv planMode startup prompt pendingTurn initialDraft unavailableProviders startupUnavailable paramsRef sessionStateRef initialTurns persist projectRoot home cwd tokenProvider openAiPool escPaused interrupt multiCtx rootTurnRef subagentSessions pendingNotices storeRoot agentTypes legacyTarget accountRef accountIdRef selectionRef accountLabel selectAccount onPersisted compactRunner backend btwBackend = do
+runSession catalog connectionId options provider dialect policy tools toolEnv planMode startup prompt pendingTurn initialDraft unavailableProviders startupUnavailable paramsRef sessionStateRef initialTurns persist projectRoot home cwd tokenProvider openAiPool escPaused interrupt multiCtx rootTurnRef subagentSessions pendingNotices storeRoot agentTypes legacyTarget selectAccount onPersisted compactRunner backend btwBackend = do
   initialPrevious <-
       (.sessionConversation.conversationPreviousResponseId)
           <$> readIORef sessionStateRef
@@ -3056,10 +3078,6 @@ runSession catalog connectionId options provider dialect policy tools toolEnv pl
             , sessionInterrupt = interrupt
             , sessionRestartEffort = restartEffortRef
             , sessionStoreRoot = storeRoot
-            , sessionAccount = accountRef
-            , sessionAccountId = accountIdRef
-            , sessionAccountSelectionId = selectionRef
-            , sessionAccountLabel = accountLabel
             , sessionSelectAccount = selectAccount
             , sessionTerminal = terminal
             , sessionFullscreen = fullscreen
@@ -3246,10 +3264,9 @@ syncFullscreenPrompt env =
         planState <- readIORef env.sessionPlanMode.planStateRef
         params <- readIORef env.sessionParams
         policy <- readIORef env.sessionPolicy
-        account <- readIORef env.sessionAccount
-        usage <-
-            (.sessionConversation.conversationUsage)
-                <$> readIORef env.sessionState
+        sessionState <- readIORef env.sessionState
+        let account = sessionState.sessionAccount.accountLabel
+            usage = sessionState.sessionConversation.conversationUsage
         attachments <- readIORef env.sessionAttachments
         emitUiEvent runtime $ UiSetPrompt $
             buildPromptState
@@ -3513,9 +3530,6 @@ replWithDraft env@SessionEnv
     , sessionInterrupt = interrupt
     , sessionEscPaused = escPaused
     , sessionStoreRoot = storeRoot
-    , sessionAccount = accountRef
-    , sessionAccountId = accountIdRef
-    , sessionAccountSelectionId = selectionRef
     , sessionSelectAccount = selectAccount
     , sessionTerminal = terminal
     , sessionFullscreen = fullscreen
@@ -3538,8 +3552,8 @@ replWithDraft env@SessionEnv
     policy <- readIORef policyRef
     pendingAttachments <- readIORef attachmentsRef
     let idleMode = replModeFromState planState policy
-    let usage = conversation.conversationUsage
-    account <- readIORef accountRef
+        usage = conversation.conversationUsage
+        account = sessionState.sessionAccount.accountLabel
     mlineResult <- case fullscreen of
         Just runtime -> do
             setFullscreenImagePreviews runtime pendingAttachments
@@ -4584,8 +4598,9 @@ replWithDraft env@SessionEnv
     chooseAccount keptDraft next =
         case fullscreen of
             Just runtime -> do
-                currentSelectionId <- readIORef selectionRef
-                currentAccountId <- readIORef accountIdRef
+                sessionAccount <- (.sessionAccount) <$> readIORef sessionStateRef
+                let currentSelectionId = sessionAccount.accountSelectionId
+                    currentAccountId = sessionAccount.accountId
                 options <- withReplActivity
                     "Loading account usage…"
                     (loadAllAccountPickerOptions provider)

--- a/packages/agent-cli/src/Agent/CLI/SessionEnv.hs
+++ b/packages/agent-cli/src/Agent/CLI/SessionEnv.hs
@@ -21,7 +21,7 @@ import Agent.Loop (ImageAttachment, LoopConfig)
 import qualified Agent.OpenAI.Auth as OpenAI
 import Agent.Responses.Types (ResponseCreateParams)
 import System.OsPath (OsPath)
-import Agent.Provider (Credential, Provider, TokenProvider)
+import Agent.Provider (Provider, TokenProvider)
 import Agent.Subagents (RootTurnId)
 import Agent.Tools.PlanMode (PlanModeEnv)
 import Data.IORef (IORef)
@@ -60,10 +60,6 @@ data SessionEnv = SessionEnv
     , sessionInterrupt :: !InterruptState
     , sessionRestartEffort :: !(IORef (Maybe Text))
     , sessionStoreRoot :: !(IORef (Maybe OsPath))
-    , sessionAccount :: !(IORef Text)
-    , sessionAccountId :: !(IORef Text)
-    , sessionAccountSelectionId :: !(IORef Text)
-    , sessionAccountLabel :: !(Credential -> IO Text)
     , sessionSelectAccount
         :: !(Maybe (Text -> IO (Either ApiError Text)))
     , sessionTerminal :: !TerminalCapabilities

--- a/packages/agent-cli/src/Agent/CLI/SessionState.hs
+++ b/packages/agent-cli/src/Agent/CLI/SessionState.hs
@@ -1,11 +1,14 @@
--- | Coherent mutable state for the live CLI conversation.
+-- | Coherent mutable state for the live CLI session.
 --
 -- The CLI owns one mutable cell containing this record. Transitions stay pure
--- so turns, compaction, startup context, and UI readers cannot observe
--- partially committed conversation state.
+-- so turns, compaction, skills, auth, and UI readers cannot observe partially
+-- committed session state.
 module Agent.CLI.SessionState
     ( SessionState(..)
+    , SessionAccountState(..)
+    , SessionAccountPatch(..)
     , addSessionTokenUsage
+    , applySessionAccountPatch
     , applySessionConversationPatch
     , appendSessionStartupContext
     , beginSessionTurn
@@ -18,6 +21,7 @@ module Agent.CLI.SessionState
 import Agent.CLI.TurnState
     ( ConversationPatch
     , ConversationState(..)
+    , FieldUpdate(..)
     , applyConversationPatch
     )
 import Agent.Loop (TokenUsage, addTokenUsage, emptyTokenUsage)
@@ -30,7 +34,43 @@ data SessionState = SessionState
     { sessionConversation :: !ConversationState
     , sessionSkillCatalog :: !SkillCatalog
     , sessionSkillInvocations :: ![SkillInvocation]
+    , sessionAccount :: !SessionAccountState
     } deriving (Eq, Show)
+
+data SessionAccountState = SessionAccountState
+    { accountLabel :: !Text
+    , accountId :: !Text
+    , accountSelectionId :: !Text
+    } deriving (Eq, Show)
+
+data SessionAccountPatch = SessionAccountPatch
+    { patchAccountLabel :: !(FieldUpdate Text)
+    , patchAccountId :: !(FieldUpdate Text)
+    , patchAccountSelectionId :: !(FieldUpdate Text)
+    } deriving (Eq, Show)
+
+applySessionAccountPatch
+    :: SessionAccountPatch
+    -> SessionState
+    -> SessionState
+applySessionAccountPatch patch state =
+    state
+        { sessionAccount = account
+            { accountLabel =
+                applyField patch.patchAccountLabel account.accountLabel
+            , accountId =
+                applyField patch.patchAccountId account.accountId
+            , accountSelectionId =
+                applyField
+                    patch.patchAccountSelectionId
+                    account.accountSelectionId
+            }
+        }
+  where
+    account = state.sessionAccount
+    applyField update current = case update of
+        KeepField -> current
+        SetField value -> value
 
 -- | Snapshot a turn's starting conversation while consuming startup context.
 beginSessionTurn :: SessionState -> (SessionState, ConversationState)

--- a/packages/agent-cli/test/Agent/CLI/SessionStateSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SessionStateSpec.hs
@@ -72,11 +72,39 @@ spec = describe "Agent.CLI.SessionState" do
             { conversationStartupContext = Just "fresh"
             }
 
+    it "applies account updates without disturbing unrelated session state" do
+        let initial = testState
+                { sessionAccount = SessionAccountState
+                    { accountLabel = "old@example.com"
+                    , accountId = "account-old"
+                    , accountSelectionId = "selection-old"
+                    }
+                }
+            updated = applySessionAccountPatch
+                SessionAccountPatch
+                    { patchAccountLabel = SetField "new@example.com"
+                    , patchAccountId = SetField "account-new"
+                    , patchAccountSelectionId = KeepField
+                    }
+                initial
+        updated.sessionAccount `shouldBe` SessionAccountState
+            { accountLabel = "new@example.com"
+            , accountId = "account-new"
+            , accountSelectionId = "selection-old"
+            }
+        updated.sessionConversation `shouldBe` initialConversation
+        updated.sessionSkillCatalog `shouldBe` SkillCatalog [] []
+
 testState :: SessionState
 testState = SessionState
     { sessionConversation = initialConversation
     , sessionSkillCatalog = SkillCatalog [] []
     , sessionSkillInvocations = []
+    , sessionAccount = SessionAccountState
+        { accountLabel = ""
+        , accountId = ""
+        , accountSelectionId = ""
+        }
     }
 
 initialConversation :: ConversationState

--- a/packages/agent-cli/test/Agent/CLI/SkillsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SkillsSpec.hs
@@ -2,7 +2,7 @@ module Agent.CLI.SkillsSpec (spec) where
 
 import Agent.CLI.Command (SkillCommand(..))
 import Agent.CLI.Options (CliOptions(..), defaultCliOptions)
-import Agent.CLI.SessionState (SessionState(..))
+import Agent.CLI.SessionState (SessionAccountState(..), SessionState(..))
 import Agent.CLI.Skills
 import Agent.CLI.TurnState (ConversationState(..))
 import Agent.Loop (emptyTokenUsage)
@@ -123,4 +123,9 @@ testSessionState startup =
             }
         , sessionSkillCatalog = SkillCatalog [] []
         , sessionSkillInvocations = []
+        , sessionAccount = SessionAccountState
+            { accountLabel = ""
+            , accountId = ""
+            , accountSelectionId = ""
+            }
         }


### PR DESCRIPTION
## Summary
- add account display/identity/selection to the coherent CLI `SessionState`
- replace three independent account `IORef`s with pure `SessionAccountPatch` transitions committed atomically
- read one state snapshot for prompt rendering and account-picker matching
- remove the obsolete account refs and unused account-label resolver from `SessionEnv`/`runSession`

## Stack
- based on #365 (skills state)
- #365 is based on #362 (conversation state)
- pure turn state and explicit backend-state APIs are already present on `master`; no unpublished dependency is required

## Validation
- Nix multi-package GHCi: `Agent.CLI` loaded across 187 modules
- `nix develop -c cabal test all -j1 --test-options=--seed=1 --test-show-details=failures`
- `agent-cli-test`: 768 examples, 0 failures
- independent review: no actionable findings

The default randomized suite exposed the existing order-sensitive OpenAI pool test `shares one in-flight discovery without locking pool inspection`; the exact test passes in isolation and the complete fixed-seed suite passes.

## Tmux smoke
- launched the rebuilt CLI in a real 120x35 fullscreen tmux TTY
- verified the active account label renders in the prompt footer after provider fallback
- opened `/account`, verified the active account is selected in the credential list, escaped back to the prompt, and confirmed the same account label remained visible
