### PR TITLE
Label Fable as the Anthropic frontier model

### DIFF
--- a/packages/agent-cli/config/models.default.json
+++ b/packages/agent-cli/config/models.default.json
@@ -66,13 +66,13 @@
       "id": "opus",
       "connection": "claude-code",
       "dialect": "claude-code",
-      "label": "frontier · subscription"
+      "label": "previous frontier · subscription"
     },
     {
       "id": "fable",
       "connection": "claude-code",
       "dialect": "claude-code",
-      "label": "fast · subscription"
+      "label": "frontier · subscription"
     }
   ]
 }


### PR DESCRIPTION
The model switcher declared Opus as the Anthropic frontier model. Fable is
the frontier model now, so the labels are swapped:

- `fable` → `frontier · subscription`
- `opus` → `previous frontier · subscription`

Picker order is unchanged and no tests assert on these labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)