### PR TITLE
Fix session titles to use complete turns

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/SessionTitle.hs
+++ b/packages/agent-cli/src/Agent/CLI/SessionTitle.hs
@@ -7,6 +7,7 @@ module Agent.CLI.SessionTitle
     , cleanGeneratedTitle
     , invalidateSessionTitles
     , requestSessionTitle
+    , shouldRequestSessionTitle
     , takeSessionTitleResults
     , titleRefreshIndex
     , waitForSessionTitleResults
@@ -158,6 +159,13 @@ titleRefreshIndex milestone
     | milestone >= 6 = 2
     | milestone >= 3 = 1
     | otherwise = 0
+
+shouldRequestSessionTitle :: Int -> Int -> Bool
+shouldRequestSessionTitle milestone refreshIndex
+    | milestone == 1 = refreshIndex == 0
+    | milestone `elem` [3, 6] =
+        refreshIndex < titleRefreshIndex milestone
+    | otherwise = False
 
 titleWorker :: (SessionTitleEvent -> IO ()) -> SessionTitleManager -> IO ()
 titleWorker onEvent manager = forever do

--- a/packages/agent-cli/src/Agent/CLI/Turn.hs
+++ b/packages/agent-cli/src/Agent/CLI/Turn.hs
@@ -56,6 +56,7 @@ import Agent.CLI.SessionEnv (SessionEnv(..))
 import Agent.CLI.SessionTitle
     ( SessionTitleResult(..)
     , requestSessionTitle
+    , shouldRequestSessionTitle
     , takeSessionTitleResults
     , titleRefreshIndex
     )
@@ -202,14 +203,6 @@ runOneTurn env@SessionEnv
                             (roleMuted color
                                 (glyphSession <> "session: "
                                     <> handle.sessionMeta.metaId))
-            titleTurns <- readIORef env.sessionTitleTurnCount
-            when
-                ( titleTurns == 0
-                    && not handle.sessionMeta.metaTitleIsManual
-                    && handle.sessionMeta.metaTitleRefreshIndex == 0
-                )
-                (requestSessionTitle env.sessionTitleManager
-                    handle.sessionMeta.metaId 1 promptText)
         PersistenceDisabled -> pure ()
     prev <- readIORef previous
     beforeItems <- readIORef transcriptRef
@@ -460,10 +453,9 @@ runOneTurn env@SessionEnv
                     let countedMeta = countedHandle.sessionMeta
                     writeIORef slotRef (PersistenceActive countedHandle)
                     when
-                        ( titleTurns `elem` [3, 6]
-                            && not countedMeta.metaTitleIsManual
-                            && countedMeta.metaTitleRefreshIndex
-                                < titleRefreshIndex titleTurns
+                        ( not countedMeta.metaTitleIsManual
+                            && shouldRequestSessionTitle titleTurns
+                                countedMeta.metaTitleRefreshIndex
                         )
                         (requestConversationTitle env countedHandle titleTurns)
                     when (countedMeta.metaTitle /= handle.sessionMeta.metaTitle) do

--- a/packages/agent-cli/test/Agent/CLI/SessionTitleSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SessionTitleSpec.hs
@@ -1,7 +1,12 @@
 module Agent.CLI.SessionTitleSpec (spec) where
 
 import Agent.CLI.SessionTitle
-import Agent.Loop (Backend(..), BackendResult(..), emptyTurnOutput)
+import Agent.Loop
+    ( Backend(..)
+    , BackendResult(..)
+    , TurnInput(..)
+    , emptyTurnOutput
+    )
 import Agent.Responses.Types
 import Control.Concurrent
     ( newEmptyMVar
@@ -26,8 +31,21 @@ spec = describe "Agent.CLI.SessionTitle" do
             fmap Text.length (cleanGeneratedTitle (Text.replicate 100 "a"))
                 `shouldBe` Just 80
 
+    describe "shouldRequestSessionTitle" do
+        it "requests titles after the complete first, third, and sixth turns" do
+            shouldRequestSessionTitle 1 0 `shouldBe` True
+            shouldRequestSessionTitle 2 0 `shouldBe` False
+            shouldRequestSessionTitle 3 0 `shouldBe` True
+            shouldRequestSessionTitle 6 1 `shouldBe` True
+
+        it "does not repeat completed refresh milestones" do
+            shouldRequestSessionTitle 1 1 `shouldBe` False
+            shouldRequestSessionTitle 3 1 `shouldBe` False
+            shouldRequestSessionTitle 6 2 `shouldBe` False
+
     it "runs a private tool-free title request and returns a tagged result" do
         seenParams <- newIORef Nothing
+        seenInputs <- newIORef []
         notified <- newEmptyMVar
         let sessionReasoning = ReasoningConfig
                 { context = Nothing
@@ -46,8 +64,9 @@ spec = describe "Agent.CLI.SessionTitle" do
                             }
         paramsRef <- newIORef baseParams
         let backendFactory privateParams =
-                Backend \state _ _ _ -> do
+                Backend \state _ inputs _ -> do
                     writeIORef seenParams . Just =<< readIORef privateParams
+                    writeIORef seenInputs inputs
                     pure $ Right BackendResult
                         { backendOutput =
                             emptyTurnOutput "title-response" []
@@ -55,7 +74,8 @@ spec = describe "Agent.CLI.SessionTitle" do
                         , backendState = state
                         }
         withSessionTitleManager backendFactory paramsRef (putMVar notified) \manager -> do
-            requestSessionTitle manager "session-1" 3 "conversation"
+            requestSessionTitle manager "session-1" 3
+                "User:\nFix auth\n\nAssistant:\nI found the race"
             results <- waitForResults manager 100
             let expected = SessionTitleResult
                     { resultSessionId = "session-1"
@@ -70,6 +90,10 @@ spec = describe "Agent.CLI.SessionTitle" do
         sent.parallelToolCalls `shouldBe` Just False
         sent.maxOutputTokens `shouldBe` Nothing
         sent.reasoning `shouldBe` Just sessionReasoning
+        [UserMessage titleInput] <- readIORef seenInputs
+        titleInput `shouldSatisfy` Text.isInfixOf "User:\nFix auth"
+        titleInput `shouldSatisfy`
+            Text.isInfixOf "Assistant:\nI found the race"
 
     it "drops a stale result after a manual rename invalidates generation" do
         started <- newEmptyMVar


### PR DESCRIPTION
## Summary
- generate the initial session title after the first turn is persisted
- use the same full user/assistant conversation source for title milestones 1, 3, and 6
- add coverage for milestone scheduling and conversation context

## Verification
- loaded `Agent.CLI.SessionTitle` and `Agent.CLI.Turn` in GHCi
- ran `Agent.CLI.SessionTitleSpec`: 8 examples, 0 failures