### PR TITLE
Support image attachments with Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,8 @@ through Claude Code's bidirectional `stream-json` protocol. The thin
 `agent-claude` adapter enforces subscription authentication and translates SDK
 messages into provider-neutral harness events. Claude Code owns tool execution
 and context compaction; the harness renders its assistant and tool events and
-persists its session UUID.
+persists its session UUID. Clipboard and file image attachments are forwarded
+as structured multimodal content.
 
 The default permission mode is Claude Code's non-blocking `dontAsk` mode. Pass
 `--yolo` to bypass Claude Code's permission checks. Permission mode is fixed

--- a/packages/agent-claude/src/Agent/Claude/LoopBackend.hs
+++ b/packages/agent-claude/src/Agent/Claude/LoopBackend.hs
@@ -22,6 +22,7 @@ import Agent.InterAgentMessage (renderInterAgentMessage)
 import Agent.Loop
     ( Backend(..)
     , BackendResult(..)
+    , ImageAttachment(..)
     , LoopEvent(..)
     , TokenUsage(..)
     , TurnInput(..)
@@ -78,12 +79,15 @@ import Claude.Agent.SDK.Errors
     ( ClaudeSDKError(..)
     , renderClaudeSDKError
     )
-import Claude.Agent.SDK.Query (queryTurnWithMessageValidator)
+import Claude.Agent.SDK.Query
+    ( queryTurnContentWithMessageValidator
+    )
 import Claude.Agent.SDK.Types
     ( ClaudeAgentOptions(..)
     , Message(..)
     , ResultMessage(..)
     , SystemMessage(..)
+    , UserContentBlock(..)
     , Usage(..)
     , messageHasParentToolUseId
     )
@@ -183,59 +187,60 @@ submitClaudeCodeTurn
     transcript
     inputs
     onEvent =
-    case flattenTurnInputs inputs of
-        Left err -> pure (Left err)
-        Right inputText -> do
-            params <- getParams
-            let previousSession =
-                    previous >>= canonicalClaudeSessionId
-            result <- withClaudeSDKTurn
-                session
-                (hostTranscriptMatches
-                    checkpoint
-                    transcript
-                    previousSession)
-                previousSession
-                params.model
-                (params.reasoning >>= (.effort))
-                \turn -> do
-                    history <- readIORef transcript
-                    messages <- newIORef []
-                    let prompt =
-                            buildClaudePrompt
-                                params
-                                (turnIsNewSession turn)
-                                history
-                                inputText
-                    awaitResult <-
-                        queryTurnWithMessageValidator
-                            turn
-                            prompt
-                            validateSubscriptionMessage
-                            (\message ->
-                                modifyIORef' messages (message :))
-                    case awaitResult of
-                        Left sdkError ->
-                            pure (Left sdkError)
-                        Right result -> do
-                            turnMessages <- reverse <$> readIORef messages
-                            case interpretClaudeTurn turnMessages result of
-                                Left message ->
-                                    pure $
-                                        Left ResultError
-                                            { subtype = "authentication_error"
-                                            , apiErrorStatus = Nothing
-                                            , errors = [message]
-                                            , result = Nothing
-                                            }
-                                Right completed -> do
-                                    completeTurn
-                                        turn
-                                        completed
-                                        result
-                                        inputs
-                                        onEvent
-            pure (either (Left . sdkErrorToApiError) Right result)
+    do
+        let (inputText, inputImages) = collectTurnInputs inputs
+        params <- getParams
+        let previousSession =
+                previous >>= canonicalClaudeSessionId
+        result <- withClaudeSDKTurn
+            session
+            (hostTranscriptMatches
+                checkpoint
+                transcript
+                previousSession)
+            previousSession
+            params.model
+            (params.reasoning >>= (.effort))
+            \turn -> do
+                history <- readIORef transcript
+                messages <- newIORef []
+                let prompt =
+                        buildClaudePrompt
+                            params
+                            (turnIsNewSession turn)
+                            history
+                            inputText
+                    content =
+                        claudeUserContent inputImages prompt
+                awaitResult <-
+                    queryTurnContentWithMessageValidator
+                        turn
+                        content
+                        validateSubscriptionMessage
+                        (\message ->
+                            modifyIORef' messages (message :))
+                case awaitResult of
+                    Left sdkError ->
+                        pure (Left sdkError)
+                    Right result -> do
+                        turnMessages <- reverse <$> readIORef messages
+                        case interpretClaudeTurn turnMessages result of
+                            Left message ->
+                                pure $
+                                    Left ResultError
+                                        { subtype = "authentication_error"
+                                        , apiErrorStatus = Nothing
+                                        , errors = [message]
+                                        , result = Nothing
+                                        }
+                            Right completed -> do
+                                completeTurn
+                                    turn
+                                    completed
+                                    result
+                                    inputs
+                                    onEvent
+        pure (either (Left . sdkErrorToApiError) Right result)
   where
     completeTurn
         :: ClaudeSDKTurn
@@ -267,32 +272,42 @@ submitClaudeCodeTurn
         mapM_ onEvent completed.events
         pure (Right (output, commit))
 
-flattenTurnInputs :: [TurnInput] -> Either ApiError Text
-flattenTurnInputs inputs =
-    Text.intercalate "\n\n" <$> traverse flatten inputs
+collectTurnInputs :: [TurnInput] -> (Text, [ImageAttachment])
+collectTurnInputs inputs =
+    ( Text.intercalate "\n\n" (concatMap inputText inputs)
+    , concatMap inputImages inputs
+    )
   where
-    flatten = \case
+    inputText = \case
         UserMessage text ->
-            Right text
+            [text]
         AgentMessage message ->
-            Right (renderInterAgentMessage message)
-        UserMultimodal{userText, userImages}
-            | null userImages ->
-                Right userText
-            | otherwise ->
-                Left ProviderError
-                    { errorType = InvalidImageError
-                    , message =
-                        "Claude Code subscription sessions do not support image attachments through this provider."
-                    , retryAfter = Nothing
-                    }
+            [renderInterAgentMessage message]
+        UserMultimodal{userText} ->
+            [userText]
         CompletedTool
             (ToolDispatch.ToolCallResult resultCallId resultOutput _) ->
-            Right $
+            pure $
                 "Host tool result for "
                     <> resultCallId
                     <> ":\n"
                     <> resultOutput
+    inputImages = \case
+        UserMultimodal{userImages} -> userImages
+        _ -> []
+
+claudeUserContent
+    :: [ImageAttachment]
+    -> Text
+    -> [UserContentBlock]
+claudeUserContent images prompt =
+    map imageBlock images <> [UserTextBlock prompt]
+  where
+    imageBlock ImageAttachment{imageMime, imageBytes} =
+        UserImageBlock
+            { mediaType = imageMime
+            , imageBytes
+            }
 
 buildClaudePrompt
     :: ResponseCreateParams

--- a/packages/agent-claude/test/Agent/Claude/LoopBackendSpec.hs
+++ b/packages/agent-claude/test/Agent/Claude/LoopBackendSpec.hs
@@ -35,7 +35,6 @@ import Agent.ToolDispatch
     , ToolCallResult(..)
     )
 import Control.Exception.Safe (bracket, finally)
-import qualified Data.ByteString as ByteString
 import Data.IORef
     ( modifyIORef'
     , newIORef
@@ -170,6 +169,62 @@ spec = do
                     "<--setting-sources>\n<>"
                 arguments `shouldContain` "<--no-chrome>"
                 arguments `shouldNotContain` "<--ax-screen-reader>"
+
+        it "forwards pasted images as Claude image content blocks" $
+            withFakeClaude \fake -> do
+                transcript <- newIORef []
+                result <- timeout 5_000_000 $
+                    withClaudeCodeBackend
+                        (defaultClaudeCodeOptions
+                            fake.executable
+                            fake.workingDirectory)
+                        Nothing
+                        (pure defaultResponseCreateParams)
+                        transcript
+                        \backend ->
+                            submitBackend backend
+                                Nothing
+                                [ UserMultimodal
+                                    { userText = "describe this image"
+                                    , userImages =
+                                        [ ImageAttachment
+                                            { imageMime = "image/png"
+                                            , imageBytes = "png-bytes"
+                                            }
+                                        ]
+                                    }
+                                ]
+                                (\_ -> pure ())
+                result `shouldSatisfy` \case
+                    Just (Right _) -> True
+                    _ -> False
+
+                submitted <- readFile fake.promptLog
+                submitted `shouldContain` "\"type\":\"image\""
+                submitted `shouldContain` "\"type\":\"base64\""
+                submitted `shouldContain`
+                    "\"media_type\":\"image/png\""
+                submitted `shouldContain`
+                    "\"data\":\"cG5nLWJ5dGVz\""
+                submitted `shouldContain` "describe this image"
+
+                history <- readIORef transcript
+                case history of
+                    MessageItem ResponseMessage
+                        { content = MessageContentParts
+                            ( InputTextPart{text}
+                            : InputImagePart{imageUrl}
+                            : _
+                            )
+                        }
+                        : _ -> do
+                            text `shouldBe` "describe this image"
+                            imageUrl `shouldBe`
+                                Just
+                                    "data:image/png;base64,cG5nLWJ5dGVz"
+                    _ ->
+                        expectationFailure
+                            "multimodal user input was not persisted"
 
         it "converts cumulative modelUsage snapshots to per-turn deltas" $
             withFakeClaude \fake -> do
@@ -309,28 +364,6 @@ spec = do
                 arguments `shouldContain` "<--tools>\n<>"
                 arguments `shouldContain`
                     "<--disallowedTools>\n<AskUserQuestion>"
-
-        it "rejects image attachments before starting Claude Code" do
-            transcript <- newIORef []
-            let backend =
-                    claudeCodeOneShotBackend
-                        (defaultClaudeCodeOptions
-                            "/definitely/not/started"
-                            "/")
-                        (pure defaultResponseCreateParams)
-                        transcript
-                image = ImageAttachment
-                    { imageMime = "image/png"
-                    , imageBytes = ByteString.singleton 0
-                    }
-            result <-
-                submitBackend backend
-                    Nothing
-                    [UserMultimodal "look" [image]]
-                    (\_ -> pure ())
-            result `shouldSatisfy` \case
-                Left ProviderError{errorType = InvalidImageError} -> True
-                _ -> False
 
         it "maps none effort to Claude Code's default effort" $
             withFakeClaude \fake -> do

--- a/packages/claude-agent-sdk-haskell/claude-agent-sdk-haskell.cabal
+++ b/packages/claude-agent-sdk-haskell/claude-agent-sdk-haskell.cabal
@@ -50,6 +50,7 @@ library
     build-depends:    base                  >= 4.17 && < 5
                     , aeson                 >= 2.0
                     , async
+                    , base64-bytestring
                     , bytestring
                     , containers
                     , directory

--- a/packages/claude-agent-sdk-haskell/package.nix
+++ b/packages/claude-agent-sdk-haskell/package.nix
@@ -1,5 +1,5 @@
-{ mkDerivation, aeson, async, base, bytestring, containers
-, directory, entropy, filepath, hspec, lib, process
+{ mkDerivation, aeson, async, base, base64-bytestring, bytestring
+, containers, directory, entropy, filepath, hspec, lib, process
 , safe-exceptions, scientific, text, unix, uuid-types
 }:
 mkDerivation {
@@ -7,8 +7,8 @@ mkDerivation {
   version = "0.1.0.0";
   src = ./.;
   libraryHaskellDepends = [
-    aeson async base bytestring containers directory entropy process
-    safe-exceptions scientific text unix uuid-types
+    aeson async base base64-bytestring bytestring containers directory
+    entropy process safe-exceptions scientific text unix uuid-types
   ];
   testHaskellDepends = [
     aeson base bytestring containers directory filepath hspec

--- a/packages/claude-agent-sdk-haskell/src/Claude/Agent/SDK/Client.hs
+++ b/packages/claude-agent-sdk-haskell/src/Claude/Agent/SDK/Client.hs
@@ -7,6 +7,7 @@ module Claude.Agent.SDK.Client
     , withClaudeSDKClientWithoutTools
     , withClaudeSDKTurn
     , sendQuery
+    , sendQueryContent
     , receiveMessage
     , resolveTurnUsage
     , acceptTurnSessionId
@@ -39,6 +40,7 @@ import Claude.Agent.SDK.Types
     ( ClaudeAgentOptions(..)
     , Message
     , ModelUsage(..)
+    , UserContentBlock(..)
     , Usage(..)
     , addUsage
     , emptyUsage
@@ -63,6 +65,7 @@ import Control.Exception.Safe
 import Control.Monad (unless, when)
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString as ByteString
+import qualified Data.ByteString.Base64 as Base64
 import qualified Data.ByteString.Lazy as LazyByteString
 import Data.Bits ((.&.), (.|.))
 import Data.IORef
@@ -76,6 +79,7 @@ import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe, isJust)
 import Data.Text (Text)
 import qualified Data.Text as Text
+import qualified Data.Text.Encoding as TextEncoding
 import qualified Data.UUID.Types as UUID
 import System.Entropy (getEntropy)
 import System.Exit (ExitCode)
@@ -264,7 +268,15 @@ sendQuery
     :: ClaudeSDKTurn
     -> Text
     -> IO (Either ClaudeSDKError ())
-sendQuery turn prompt = do
+sendQuery turn prompt =
+    sendQueryContent turn [UserTextBlock prompt]
+
+-- | Send one SDK streaming-input user message with structured content.
+sendQueryContent
+    :: ClaudeSDKTurn
+    -> [UserContentBlock]
+    -> IO (Either ClaudeSDKError ())
+sendQueryContent turn content = do
     sessionId <- fromMaybe "" <$> turnSessionId turn
     turn.turnRunning.runningTransport.transportWrite
         ( LazyByteString.toStrict
@@ -273,12 +285,7 @@ sendQuery turn prompt = do
                     [ "type" Aeson..= ("user" :: Text)
                     , "message" Aeson..= Aeson.object
                         [ "role" Aeson..= ("user" :: Text)
-                        , "content" Aeson..=
-                            [ Aeson.object
-                                [ "type" Aeson..= ("text" :: Text)
-                                , "text" Aeson..= prompt
-                                ]
-                            ]
+                        , "content" Aeson..= map userContentValue content
                         ]
                     , "parent_tool_use_id" Aeson..= Aeson.Null
                     , "session_id" Aeson..= sessionId
@@ -290,6 +297,24 @@ sendQuery turn prompt = do
                 <> "\n"
             )
         )
+
+userContentValue :: UserContentBlock -> Aeson.Value
+userContentValue = \case
+    UserTextBlock{text} ->
+        Aeson.object
+            [ "type" Aeson..= ("text" :: Text)
+            , "text" Aeson..= text
+            ]
+    UserImageBlock{mediaType, imageBytes} ->
+        Aeson.object
+            [ "type" Aeson..= ("image" :: Text)
+            , "source" Aeson..= Aeson.object
+                [ "type" Aeson..= ("base64" :: Text)
+                , "media_type" Aeson..= mediaType
+                , "data" Aeson..=
+                    TextEncoding.decodeUtf8 (Base64.encode imageBytes)
+                ]
+            ]
 
 -- | Receive and parse one complete stream-json record. Blank lines are
 -- ignored; 'Nothing' denotes EOF.

--- a/packages/claude-agent-sdk-haskell/src/Claude/Agent/SDK/Query.hs
+++ b/packages/claude-agent-sdk-haskell/src/Claude/Agent/SDK/Query.hs
@@ -2,9 +2,13 @@
 -- top-level @query()@ API.
 module Claude.Agent.SDK.Query
     ( query
+    , queryContent
     , queryClient
+    , queryClientContent
     , queryTurn
+    , queryTurnContent
     , queryTurnWithMessageValidator
+    , queryTurnContentWithMessageValidator
     , receiveResponse
     , receiveResponseWithMessageValidator
     ) where
@@ -14,7 +18,7 @@ import Claude.Agent.SDK.Client
     , ClaudeSDKTurn
     , acceptTurnSessionId
     , receiveMessage
-    , sendQuery
+    , sendQueryContent
     , turnDiagnostic
     , turnProcessExit
     , turnStreamInactivityTimeoutMicros
@@ -35,6 +39,7 @@ import Claude.Agent.SDK.Types
     ( ClaudeAgentOptions(..)
     , Message
     , ResultMessage(..)
+    , UserContentBlock(..)
     )
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -48,6 +53,15 @@ query
     -> (Message -> IO ())
     -> IO (Either ClaudeSDKError ResultMessage)
 query options prompt onMessage =
+    queryContent options [UserTextBlock prompt] onMessage
+
+-- | Run a self-contained query with structured user content.
+queryContent
+    :: ClaudeAgentOptions
+    -> [UserContentBlock]
+    -> (Message -> IO ())
+    -> IO (Either ClaudeSDKError ResultMessage)
+queryContent options content onMessage =
     withClaudeSDKClient options \client ->
         withClaudeSDKTurn
             client
@@ -56,7 +70,7 @@ query options prompt onMessage =
             options.model
             options.effort
             \turn -> do
-                result <- queryTurn turn prompt onMessage
+                result <- queryTurnContent turn content onMessage
                 pure ((, pure ()) <$> result)
 
 -- | Submit a prompt through a persistent client and continue its active
@@ -68,6 +82,15 @@ queryClient
     -> (Message -> IO ())
     -> IO (Either ClaudeSDKError ResultMessage)
 queryClient client prompt onMessage =
+    queryClientContent client [UserTextBlock prompt] onMessage
+
+-- | Submit structured user content through a persistent client.
+queryClientContent
+    :: ClaudeSDKClient
+    -> [UserContentBlock]
+    -> (Message -> IO ())
+    -> IO (Either ClaudeSDKError ResultMessage)
+queryClientContent client content onMessage =
     withClaudeSDKTurn
         client
         (pure True)
@@ -75,7 +98,7 @@ queryClient client prompt onMessage =
         Nothing
         Nothing
         \turn -> do
-            result <- queryTurn turn prompt onMessage
+            result <- queryTurnContent turn content onMessage
             pure ((, pure ()) <$> result)
 
 -- | Submit a prompt and receive one complete response. Visible records are
@@ -88,28 +111,45 @@ queryTurn
     -> (Message -> IO ())
     -> IO (Either ClaudeSDKError ResultMessage)
 queryTurn turn prompt onMessage =
-    queryTurnWithMessageValidator
+    queryTurnContent turn [UserTextBlock prompt] onMessage
+
+-- | Submit structured user content and receive one complete response.
+queryTurnContent
+    :: ClaudeSDKTurn
+    -> [UserContentBlock]
+    -> (Message -> IO ())
+    -> IO (Either ClaudeSDKError ResultMessage)
+queryTurnContent turn content onMessage =
+    queryTurnContentWithMessageValidator
         turn
-        prompt
+        content
         (const (pure (Right ())))
         onMessage
 
 -- | Variant of 'queryTurn' that observes and may reject each parsed wire
--- message immediately, before transactional response buffering. Embedders can
--- use this for authentication or policy checks that must fail before a turn
--- reaches its terminal result.
+-- message immediately, before transactional response buffering.
 queryTurnWithMessageValidator
     :: ClaudeSDKTurn
     -> Text
     -> (Message -> IO (Either ClaudeSDKError ()))
     -> (Message -> IO ())
     -> IO (Either ClaudeSDKError ResultMessage)
-queryTurnWithMessageValidator turn prompt validateMessage onMessage = do
+queryTurnWithMessageValidator turn prompt =
+    queryTurnContentWithMessageValidator turn [UserTextBlock prompt]
+
+-- | Structured-content variant of 'queryTurnWithMessageValidator'.
+queryTurnContentWithMessageValidator
+    :: ClaudeSDKTurn
+    -> [UserContentBlock]
+    -> (Message -> IO (Either ClaudeSDKError ()))
+    -> (Message -> IO ())
+    -> IO (Either ClaudeSDKError ResultMessage)
+queryTurnContentWithMessageValidator turn content validateMessage onMessage = do
     completed <-
         timeout
             (max 1 (turnTimeoutMicros turn))
             do
-                sendQuery turn prompt >>= \case
+                sendQueryContent turn content >>= \case
                     Left err -> pure (Left err)
                     Right () ->
                         receiveResponseWithMessageValidator

--- a/packages/claude-agent-sdk-haskell/src/Claude/Agent/SDK/Types.hs
+++ b/packages/claude-agent-sdk-haskell/src/Claude/Agent/SDK/Types.hs
@@ -11,6 +11,7 @@ module Claude.Agent.SDK.Types
     , addUsage
     , ModelUsage(..)
     , MessageOrigin(..)
+    , UserContentBlock(..)
     , ContentBlock(..)
     , UserMessage(..)
     , AssistantMessage(..)
@@ -27,6 +28,8 @@ module Claude.Agent.SDK.Types
 import Data.Aeson (Object, Value)
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.KeyMap as KeyMap
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as ByteString
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Text (Text)
@@ -168,6 +171,26 @@ data MessageOrigin = MessageOrigin
     { kind :: !Text
     , raw :: !Object
     } deriving (Eq, Show)
+
+-- | Content accepted in one streaming-input user message.
+data UserContentBlock
+    = UserTextBlock
+        { text :: !Text
+        }
+    | UserImageBlock
+        { mediaType :: !Text
+        , imageBytes :: !ByteString
+        }
+    deriving (Eq)
+
+instance Show UserContentBlock where
+    show UserTextBlock{text} =
+        "UserTextBlock { text = " <> show text <> " }"
+    show UserImageBlock{mediaType, imageBytes} =
+        "UserImageBlock { mediaType = " <> show mediaType
+            <> ", imageBytes = <redacted>"
+            <> ", imageByteLength = " <> show (ByteString.length imageBytes)
+            <> " }"
 
 data ContentBlock
     = TextBlock

--- a/packages/claude-agent-sdk-haskell/test/Claude/Agent/SDK/ClientSpec.hs
+++ b/packages/claude-agent-sdk-haskell/test/Claude/Agent/SDK/ClientSpec.hs
@@ -93,6 +93,55 @@ spec = describe "ClaudeSDKClient subprocess transport" do
             Aeson.eitherDecodeStrict' input
                 `shouldBe` Right (expectedQueryValue "hello from Haskell")
 
+    it "serializes image content in streaming user messages" do
+        withFakeClaude transportProbeScript \directory executable -> do
+            let argsPath = directory </> "args"
+                environmentPath = directory </> "environment"
+                inputPath = directory </> "input"
+                options =
+                    (testOptions executable directory)
+                        { environment =
+                            Just
+                                [ ("FAKE_ARGS", argsPath)
+                                , ("FAKE_ENVIRONMENT", environmentPath)
+                                , ("FAKE_INPUT", inputPath)
+                                ]
+                        }
+
+            queryResult <-
+                queryContent
+                    options
+                    [ UserImageBlock
+                        { mediaType = "image/png"
+                        , imageBytes = "png-bytes"
+                        }
+                    , UserTextBlock "describe this image"
+                    ]
+                    (const (pure ()))
+            _ <- expectRight queryResult
+
+            input <- ByteString.readFile inputPath
+            Aeson.eitherDecodeStrict' input
+                `shouldBe`
+                    Right
+                        (expectedContentQueryValue
+                            [ Aeson.object
+                                [ "type" Aeson..= ("image" :: Text)
+                                , "source" Aeson..= Aeson.object
+                                    [ "type" Aeson..= ("base64" :: Text)
+                                    , "media_type" Aeson..=
+                                        ("image/png" :: Text)
+                                    , "data" Aeson..=
+                                        ("cG5nLWJ5dGVz" :: Text)
+                                    ]
+                                ]
+                            , Aeson.object
+                                [ "type" Aeson..= ("text" :: Text)
+                                , "text" Aeson..=
+                                    ("describe this image" :: Text)
+                                ]
+                            ])
+
     it "supports minimal and full Claude Code system prompts" do
         mapM_
             (\(promptMode, expectMinimalPrompt) ->
@@ -1182,16 +1231,20 @@ expectedArguments =
 
 expectedQueryValue :: Text -> Aeson.Value
 expectedQueryValue prompt =
+    expectedContentQueryValue
+        [ Aeson.object
+            [ "type" Aeson..= ("text" :: Text)
+            , "text" Aeson..= prompt
+            ]
+        ]
+
+expectedContentQueryValue :: [Aeson.Value] -> Aeson.Value
+expectedContentQueryValue content =
     Aeson.object
         [ "type" Aeson..= ("user" :: Text)
         , "message" Aeson..= Aeson.object
             [ "role" Aeson..= ("user" :: Text)
-            , "content" Aeson..=
-                [ Aeson.object
-                    [ "type" Aeson..= ("text" :: Text)
-                    , "text" Aeson..= prompt
-                    ]
-                ]
+            , "content" Aeson..= content
             ]
         , "parent_tool_use_id" Aeson..= Aeson.Null
         , "session_id" Aeson..= testSessionId

--- a/packages/claude-agent-sdk-haskell/test/Claude/Agent/SDK/ClientSpec.hs
+++ b/packages/claude-agent-sdk-haskell/test/Claude/Agent/SDK/ClientSpec.hs
@@ -197,12 +197,15 @@ spec = describe "ClaudeSDKClient subprocess transport" do
     it "aborts a blocked subprocess output read promptly" do
         withFakeClaude blockedOutputScript \directory executable -> do
             turnFinished <- newEmptyMVar
-            let options =
+            let readyPath = directory </> "query-read"
+                options =
                     (testOptions executable directory)
                         { streamStartupTimeoutMicros =
                             30 * 1_000_000
                         , turnTimeoutMicros =
                             30 * 1_000_000
+                        , environment =
+                            Just [("FAKE_READY", readyPath)]
                         }
             withClaudeSDKClient options \client -> do
                 _ <-
@@ -223,7 +226,8 @@ spec = describe "ClaudeSDKClient subprocess transport" do
                                     pure ((, pure ()) <$> completed)
                         putMVar turnFinished result
 
-                threadDelay 100_000
+                timeout 4_000_000 (waitForPath readyPath)
+                    `shouldReturn` Just ()
                 timeout 4_000_000 (abort client)
                     `shouldReturn` Just ()
                 timeout 2_000_000 (takeMVar turnFinished)
@@ -1313,6 +1317,7 @@ blockedOutputScript =
     unlines
         [ "#!/bin/sh"
         , "IFS= read -r _query"
+        , "printf 'ready\\n' > \"$FAKE_READY\""
         , "trap '' INT TERM"
         , "while :; do sleep 1; done"
         ]


### PR DESCRIPTION
## Summary

- add structured text and base64 image content to the Haskell Claude Agent SDK
- forward `UserMultimodal` attachments through Claude Code subscription sessions instead of rejecting them
- preserve multimodal turns in the host transcript and document Claude image support

## Validation

- `nix develop -c cabal test claude-agent-sdk-haskell-test agent-claude-test --test-show-details=direct` (43 SDK examples and 27 backend examples)
- confirmed Claude Code 2.1.240 accepts Anthropic image blocks over `--input-format stream-json`
- live tmux smoke test: `/paste --send` with a 100x100 PNG reached Claude vision and returned the image's dominant color
