### PR TITLE
Show MCP startup progress and initialize servers concurrently

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -1773,9 +1773,14 @@ runAgentInitializedWithLock
     mcpFleet <-
         try @_ @SomeException
             (MCP.startMcpFleetWithProgress
-                (\name ->
+                (\names ->
                     setStartupNotice startup.startupFullscreen
-                        ("Loading tools: " <> name <> "…"))
+                        (if null names
+                            then "Loading built-in tools…"
+                            else
+                                "Loading tools: "
+                                    <> Text.intercalate ", " names
+                                    <> "…"))
                 mcpServerConfigs)
             >>= \case
             Left exception ->

--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -1771,12 +1771,19 @@ runAgentInitializedWithLock
             , config.mcpEnabled
             ]
     mcpFleet <-
-        try @_ @SomeException (MCP.startMcpFleet mcpServerConfigs) >>= \case
+        try @_ @SomeException
+            (MCP.startMcpFleetWithProgress
+                (\name ->
+                    setStartupNotice startup.startupFullscreen
+                        ("Loading tools: " <> name <> "…"))
+                mcpServerConfigs)
+            >>= \case
             Left exception ->
                 startupDie startup
                     ("Failed to initialize MCP tools: " <> show exception)
             Right fleet -> pure fleet
     mapM_ (reportStartupWarning startup) mcpFleet.mcpFleetWarnings
+    setStartupNotice startup.startupFullscreen "Loading built-in tools…"
     coding <-
         codingToolsForWithTypes
             dialect

--- a/packages/agent-core/agent-core.cabal
+++ b/packages/agent-core/agent-core.cabal
@@ -116,6 +116,20 @@ benchmark streaming-text-bench
                     , text
                     , text-builder >= 1.0 && < 1.1
 
+benchmark mcp-startup-bench
+    import:           common-opts
+    type:             exitcode-stdio-1.0
+    hs-source-dirs:   benchmark
+    main-is:          McpStartup.hs
+    ghc-options:      -O2
+    build-depends:    agent-core
+                    , base >= 4.14 && < 5
+                    , bytestring
+                    , directory
+                    , safe-exceptions
+                    , text
+                    , unix
+
 test-suite agent-core-test
     import:           common-opts
     type:             exitcode-stdio-1.0

--- a/packages/agent-core/benchmark/McpStartup.hs
+++ b/packages/agent-core/benchmark/McpStartup.hs
@@ -1,0 +1,152 @@
+module Main (main) where
+
+import Agent.MCP
+    ( McpServerConfig(..)
+    , closeMcpFleet
+    , mcpFleetTools
+    , startMcpFleet
+    )
+import Control.Exception.Safe (bracket)
+import Control.Monad (forM)
+import qualified Data.ByteString.Lazy.Char8 as LBS8
+import Data.List (sort)
+import qualified Data.Text as Text
+import GHC.Clock (getMonotonicTimeNSec)
+import System.CPUTime (getCPUTime)
+import System.Directory (getTemporaryDirectory, removeFile)
+import System.Environment (getArgs)
+import System.Exit (die)
+import System.IO (hClose, openTempFile)
+import System.Mem (performGC)
+import System.Posix.Files (setFileMode)
+import Text.Printf (printf)
+
+data Workload
+    = Sequential
+    | Fleet
+
+data Sample = Sample
+    { wallMillis :: !Double
+    , cpuMillis :: !Double
+    }
+
+main :: IO ()
+main =
+    getArgs >>= \case
+        [workloadArg, serverCountArg, delayMillisArg, sampleCountArg] -> do
+            workload <- parseWorkload workloadArg
+            serverCount <- parsePositive "server count" serverCountArg
+            delayMillis <- parsePositive "delay milliseconds" delayMillisArg
+            sampleCount <- parsePositive "sample count" sampleCountArg
+            withFakeServer \script -> do
+                let configs =
+                        [ fakeConfig script delayMillis index
+                        | index <- [1 .. serverCount]
+                        ]
+                samples <- forM [1 .. sampleCount] \_ -> do
+                    performGC
+                    measure (runWorkload workload configs)
+                let medianSample = median samples
+                printf
+                    "%s,%d,%d,%.3f,%.3f\n"
+                    workloadArg
+                    serverCount
+                    delayMillis
+                    medianSample.wallMillis
+                    medianSample.cpuMillis
+        _ ->
+            die $
+                "usage: mcp-startup-bench WORKLOAD SERVERS DELAY_MS SAMPLES\n"
+                    <> "workloads: sequential, fleet"
+
+parseWorkload :: String -> IO Workload
+parseWorkload = \case
+    "sequential" -> pure Sequential
+    "fleet" -> pure Fleet
+    other -> die ("unknown workload: " <> other)
+
+parsePositive :: String -> String -> IO Int
+parsePositive label raw =
+    case reads raw of
+        [(value, "")]
+            | value > 0 -> pure value
+        _ -> die ("invalid " <> label <> ": " <> raw)
+
+runWorkload :: Workload -> [McpServerConfig] -> IO Int
+runWorkload workload configs = case workload of
+    Sequential ->
+        bracket
+            (mapM (startMcpFleet . pure) configs)
+            (mapM_ closeMcpFleet)
+            (pure . sum . map (length . mcpFleetTools))
+    Fleet ->
+        bracket
+            (startMcpFleet configs)
+            closeMcpFleet
+            (pure . length . mcpFleetTools)
+
+measure :: IO Int -> IO Sample
+measure action = do
+    wallBefore <- getMonotonicTimeNSec
+    cpuBefore <- getCPUTime
+    checksum <- action
+    checksum `seq` pure ()
+    cpuAfter <- getCPUTime
+    wallAfter <- getMonotonicTimeNSec
+    pure Sample
+        { wallMillis =
+            fromIntegral (wallAfter - wallBefore) / 1000000
+        , cpuMillis =
+            fromIntegral (cpuAfter - cpuBefore) / 1000000000
+        }
+
+median :: [Sample] -> Sample
+median samples =
+    Sample
+        { wallMillis = middle (sort (map (.wallMillis) samples))
+        , cpuMillis = middle (sort (map (.cpuMillis) samples))
+        }
+
+middle :: [a] -> a
+middle values = values !! (length values `div` 2)
+
+fakeConfig :: FilePath -> Int -> Int -> McpServerConfig
+fakeConfig script delayMillis index = McpServerConfig
+    { mcpServerName = "fake-" <> Text.pack (show index)
+    , mcpServerCommand = script
+    , mcpServerArgs = [show (fromIntegral delayMillis / 1000 :: Double)]
+    , mcpServerCwd = Nothing
+    , mcpServerEnv = []
+    , mcpServerStartupTimeoutSeconds = 30
+    , mcpServerRequestTimeoutSeconds = 30
+    }
+
+withFakeServer :: (FilePath -> IO a) -> IO a
+withFakeServer action = do
+    temporary <- getTemporaryDirectory
+    bracket
+        (do
+            (path, handle) <- openTempFile temporary "agent-mcp-startup.sh"
+            LBS8.hPutStr handle fakeServer
+            hClose handle
+            setFileMode path 0o700
+            pure path)
+        removeFile
+        action
+
+fakeServer :: LBS8.ByteString
+fakeServer =
+    "#!/bin/sh\n\
+    \delay=\"$1\"\n\
+    \while IFS= read -r line; do\n\
+    \  case \"$line\" in\n\
+    \    *'\"method\":\"initialize\"'*)\n\
+    \      sleep \"$delay\"\n\
+    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"protocolVersion\":\"2025-11-25\",\"capabilities\":{},\"serverInfo\":{\"name\":\"fake\",\"version\":\"1\"}}}'\n\
+    \      ;;\n\
+    \    *'\"method\":\"notifications/initialized\"'*) ;;\n\
+    \    *'\"method\":\"tools/list\"'*)\n\
+    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":2,\"result\":{\"tools\":[]}}'\n\
+    \      ;;\n\
+    \  esac\n\
+    \done\n"

--- a/packages/agent-core/src/Agent/MCP.hs
+++ b/packages/agent-core/src/Agent/MCP.hs
@@ -9,6 +9,7 @@ module Agent.MCP
     , McpToolRegistration(..)
     , McpFleet(..)
     , startMcpFleet
+    , startMcpFleetWithProgress
     , closeMcpFleet
     , mcpFleetTools
     , normalizeMcpToolResult
@@ -202,7 +203,13 @@ emptyInputSchema = object
 -- warnings so one unavailable integration does not disable healthy servers.
 -- Duplicate MCP tool names are fatal because dispatch would be ambiguous.
 startMcpFleet :: [McpServerConfig] -> IO McpFleet
-startMcpFleet configs = mask \restore -> do
+startMcpFleet = startMcpFleetWithProgress (const (pure ()))
+
+-- | Start every server while reporting its configured name immediately before
+-- launching it. The callback is intended for startup UI and deliberately
+-- receives no command arguments or environment values.
+startMcpFleetWithProgress :: (Text -> IO ()) -> [McpServerConfig] -> IO McpFleet
+startMcpFleetWithProgress reportStarting configs = mask \restore -> do
     closed <- newMVar False
     (clients, registrations, warnings) <-
         startServers restore [] [] [] configs
@@ -220,6 +227,8 @@ startMcpFleet configs = mask \restore -> do
     startServers _ clients registrations warnings [] =
         pure (reverse clients, registrations, warnings)
     startServers restore clients registrations warnings (config : rest) = do
+        reportStarting config.mcpServerName
+            `onException` mapM_ closeMcpClient clients
         attempt <- tryAny (restore (startServer config))
             `onException` mapM_ closeMcpClient clients
         case attempt of

--- a/packages/agent-core/src/Agent/MCP.hs
+++ b/packages/agent-core/src/Agent/MCP.hs
@@ -27,6 +27,7 @@ import Control.Concurrent.Async
     ( Async
     , asyncWithUnmask
     , cancel
+    , mapConcurrently
     , waitCatch
     )
 import Control.Concurrent.MVar
@@ -82,6 +83,7 @@ import Data.IORef
 import qualified Data.Map.Strict as Map
 import Data.Maybe (catMaybes, isJust)
 import Data.Scientific (floatingOrInteger)
+import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
@@ -205,14 +207,25 @@ emptyInputSchema = object
 startMcpFleet :: [McpServerConfig] -> IO McpFleet
 startMcpFleet = startMcpFleetWithProgress (const (pure ()))
 
--- | Start every server while reporting its configured name immediately before
--- launching it. The callback is intended for startup UI and deliberately
--- receives no command arguments or environment values.
-startMcpFleetWithProgress :: (Text -> IO ()) -> [McpServerConfig] -> IO McpFleet
-startMcpFleetWithProgress reportStarting configs = mask \restore -> do
+-- | Start every server concurrently while reporting the configured names that
+-- are still initializing. The callback is intended for startup UI and
+-- deliberately receives no command arguments or environment values.
+startMcpFleetWithProgress
+    :: ([Text] -> IO ())
+    -> [McpServerConfig]
+    -> IO McpFleet
+startMcpFleetWithProgress reportActive configs = mask \restore -> do
     closed <- newMVar False
-    (clients, registrations, warnings) <-
-        startServers restore [] [] [] configs
+    ownedClients <- newIORef []
+    activeServers <- newMVar Set.empty
+    results <-
+        restore
+            (mapConcurrently
+                (startServerTracked ownedClients activeServers)
+                configs)
+            `onException` closeOwnedClients ownedClients
+    let (clients, registrations, warnings) =
+            foldr collectServerResult ([], [], []) results
     let
         fleet = McpFleet
             { mcpFleetRegistrations = registrations
@@ -224,31 +237,43 @@ startMcpFleetWithProgress reportStarting configs = mask \restore -> do
         Nothing -> pure fleet
         Just err -> closeMcpFleet fleet >> ioError (userError (Text.unpack err))
   where
-    startServers _ clients registrations warnings [] =
-        pure (reverse clients, registrations, warnings)
-    startServers restore clients registrations warnings (config : rest) = do
-        reportStarting config.mcpServerName
-            `onException` mapM_ closeMcpClient clients
-        attempt <- tryAny (restore (startServer config))
-            `onException` mapM_ closeMcpClient clients
-        case attempt of
-            Left exception ->
-                startServers restore clients registrations
-                    (warnings <> [startupWarning config exception])
-                    rest
+    startServerTracked ownedClients activeServers config = mask \restore -> do
+        updateActive activeServers (Set.insert config.mcpServerName)
+        (do
+            attempt <- tryAny (restore (startServer config))
+            case attempt of
+                Left exception ->
+                    pure (Left (startupWarning config exception))
+                Right result@(client, _, _) -> do
+                    atomicModifyIORef' ownedClients \clients ->
+                        (client : clients, ())
+                    pure (Right result))
+            `finally` updateActive activeServers (Set.delete config.mcpServerName)
+
+    updateActive activeServers update =
+        modifyMVar_ activeServers \current -> do
+            let active = update current
+            reportActive (Set.toAscList active)
+            pure active
+
+    closeOwnedClients ownedClients =
+        atomicModifyIORef' ownedClients (\clients -> ([], clients))
+            >>= mapM_ closeMcpClient
+
+    collectServerResult result (clients, registrations, warnings) =
+        case result of
+            Left warning -> (clients, registrations, warning : warnings)
             Right (client, tools, serverWarnings) ->
-                startServers restore
-                    (client : clients)
-                    (registrations <> map (registrationFor client) tools)
-                    (warnings <> serverWarnings)
-                    rest
-                    `onException` mapM_ closeMcpClient (client : clients)
+                ( client : clients
+                , map (registrationFor client) tools <> registrations
+                , serverWarnings <> warnings
+                )
 
     startServer config = do
         client <- startMcpClient config
-        (tools, warnings) <- discoverMcpTools client
-            `onException` closeMcpClient client
-        pure (client, tools, warnings)
+        flip onException (closeMcpClient client) do
+            (tools, warnings) <- discoverMcpTools client
+            pure (client, tools, warnings)
 
     registrationFor :: McpClient -> McpTool -> McpToolRegistration
     registrationFor client tool = McpToolRegistration

--- a/packages/agent-core/test/Agent/MCPSpec.hs
+++ b/packages/agent-core/test/Agent/MCPSpec.hs
@@ -20,7 +20,12 @@ import qualified Data.ByteString.Lazy as LBS
 import Data.IORef (modifyIORef', newIORef, readIORef)
 import Data.List (find)
 import qualified Data.Text as Text
-import System.Directory (getTemporaryDirectory, removeFile)
+import System.Directory
+    ( createDirectory
+    , getTemporaryDirectory
+    , removeDirectoryRecursive
+    , removeFile
+    )
 import System.IO (hClose, openTempFile)
 import System.Posix.Files (setFileMode)
 import Test.Hspec
@@ -76,7 +81,7 @@ spec = describe "Agent.MCP" do
         withFakeServer \script -> do
             started <- newIORef []
             fleet <- startMcpFleetWithProgress
-                (\name -> modifyIORef' started (<> [name]))
+                (\names -> modifyIORef' started (<> [names]))
                 [ McpServerConfig
                     { mcpServerName = "fake"
                     , mcpServerCommand = script
@@ -88,7 +93,7 @@ spec = describe "Agent.MCP" do
                     }
                 ]
             bracket (pure fleet) closeMcpFleet \_ -> do
-                readIORef started `shouldReturn` ["fake"]
+                readIORef started `shouldReturn` [["fake"], []]
                 let tools = mcpFleetTools fleet
                 map (.appToolName) tools `shouldBe` ["echo_read"]
                 fleet.mcpFleetWarnings `shouldBe`
@@ -108,6 +113,21 @@ spec = describe "Agent.MCP" do
                     firstResult.output `shouldBe` "first response"
                     second.output `shouldBe` "second response"
 
+    it "starts servers concurrently and preserves configured tool order" $
+        withConcurrentFakeServer \script barrier -> do
+            progress <- newIORef []
+            fleet <- startMcpFleetWithProgress
+                (\names -> modifyIORef' progress (<> [names]))
+                [ concurrentConfig script barrier "first"
+                , concurrentConfig script barrier "second"
+                ]
+            bracket (pure fleet) closeMcpFleet \_ -> do
+                map (.appToolName) (mcpFleetTools fleet)
+                    `shouldBe` ["first_read", "second_read"]
+                updates <- readIORef progress
+                updates `shouldContain` [["first", "second"]]
+                last updates `shouldBe` []
+
 withFakeServer :: (FilePath -> IO a) -> IO a
 withFakeServer action = do
     temporary <- getTemporaryDirectory
@@ -120,6 +140,38 @@ withFakeServer action = do
             pure path)
         removeFile
         action
+
+concurrentConfig :: FilePath -> FilePath -> Text.Text -> McpServerConfig
+concurrentConfig script barrier name = McpServerConfig
+    { mcpServerName = name
+    , mcpServerCommand = script
+    , mcpServerArgs = [barrier, Text.unpack name]
+    , mcpServerCwd = Nothing
+    , mcpServerEnv = []
+    , mcpServerStartupTimeoutSeconds = 2
+    , mcpServerRequestTimeoutSeconds = 2
+    }
+
+withConcurrentFakeServer :: (FilePath -> FilePath -> IO a) -> IO a
+withConcurrentFakeServer action = do
+    temporary <- getTemporaryDirectory
+    bracket
+        (do
+            (barrier, barrierHandle) <-
+                openTempFile temporary "agent-mcp-barrier"
+            hClose barrierHandle
+            removeFile barrier
+            createDirectory barrier
+            (script, scriptHandle) <-
+                openTempFile temporary "agent-mcp-concurrent.sh"
+            LBS.hPutStr scriptHandle concurrentFakeServer
+            hClose scriptHandle
+            setFileMode script 0o700
+            pure (script, barrier))
+        (\(script, barrier) -> do
+            removeFile script
+            removeDirectoryRecursive barrier)
+        (uncurry action)
 
 fakeServer :: LBS.ByteString
 fakeServer =
@@ -140,6 +192,27 @@ fakeServer =
     \        printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":4,\"result\":{\"content\":[{\"type\":\"text\",\"text\":\"second response\"}]}}'\n\
     \        printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":3,\"result\":{\"content\":[{\"type\":\"text\",\"text\":\"first response\"}]}}'\n\
     \      fi\n\
+    \      ;;\n\
+    \  esac\n\
+    \done\n"
+
+concurrentFakeServer :: LBS.ByteString
+concurrentFakeServer =
+    "#!/bin/sh\n\
+    \barrier=\"$1\"\n\
+    \name=\"$2\"\n\
+    \while IFS= read -r line; do\n\
+    \  case \"$line\" in\n\
+    \    *'\"method\":\"initialize\"'*)\n\
+    \      : > \"$barrier/$name\"\n\
+    \      while [ \"$(find \"$barrier\" -type f | wc -l)\" -lt 2 ]; do\n\
+    \        sleep 0.01\n\
+    \      done\n\
+    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"protocolVersion\":\"2025-11-25\",\"capabilities\":{},\"serverInfo\":{\"name\":\"fake\",\"version\":\"1\"}}}'\n\
+    \      ;;\n\
+    \    *'\"method\":\"notifications/initialized\"'*) ;;\n\
+    \    *'\"method\":\"tools/list\"'*)\n\
+    \      printf '%s\\n' \"{\\\"jsonrpc\\\":\\\"2.0\\\",\\\"id\\\":2,\\\"result\\\":{\\\"tools\\\":[{\\\"name\\\":\\\"${name}_read\\\",\\\"description\\\":\\\"Read.\\\",\\\"inputSchema\\\":{\\\"type\\\":\\\"object\\\"},\\\"annotations\\\":{\\\"readOnlyHint\\\":true}}]}}\"\n\
     \      ;;\n\
     \  esac\n\
     \done\n"

--- a/packages/agent-core/test/Agent/MCPSpec.hs
+++ b/packages/agent-core/test/Agent/MCPSpec.hs
@@ -17,6 +17,7 @@ import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async (wait, withAsync)
 import Data.Aeson (object, (.=))
 import qualified Data.ByteString.Lazy as LBS
+import Data.IORef (modifyIORef', newIORef, readIORef)
 import Data.List (find)
 import qualified Data.Text as Text
 import System.Directory (getTemporaryDirectory, removeFile)
@@ -73,7 +74,9 @@ spec = describe "Agent.MCP" do
 
     it "initializes a stdio server, exposes only read-only tools, and calls one" $
         withFakeServer \script -> do
-            fleet <- startMcpFleet
+            started <- newIORef []
+            fleet <- startMcpFleetWithProgress
+                (\name -> modifyIORef' started (<> [name]))
                 [ McpServerConfig
                     { mcpServerName = "fake"
                     , mcpServerCommand = script
@@ -85,6 +88,7 @@ spec = describe "Agent.MCP" do
                     }
                 ]
             bracket (pure fleet) closeMcpFleet \_ -> do
+                readIORef started `shouldReturn` ["fake"]
                 let tools = mcpFleetTools fleet
                 map (.appToolName) tools `shouldBe` ["echo_read"]
                 fleet.mcpFleetWarnings `shouldBe`


### PR DESCRIPTION
## Summary
- show the active MCP server names during startup instead of a generic `Loading tools...` notice
- initialize independent MCP stdio servers concurrently while preserving configured tool and warning order
- retain structured cleanup on cancellation and startup failure
- add a reproducible optimized MCP startup benchmark

## Benchmark
Built with GHC 9.10.3 and `-O2`:

```sh
nix develop -c cabal build --offline agent-core:bench:mcp-startup-bench
bin=$(nix develop -c cabal list-bin agent-core:bench:mcp-startup-bench)
"$bin" sequential 4 250 7
"$bin" fleet     4 250 7
```

Median results for four fake MCP servers with a 250 ms initialization delay:

| implementation | wall time | CPU time |
| --- | ---: | ---: |
| sequential baseline | 1111.833 ms | 13.446 ms |
| concurrent fleet | 326.390 ms | 12.481 ms |

Additional median wall-time results:

| servers | delay/server | sequential | concurrent |
| ---: | ---: | ---: | ---: |
| 2 | 250 ms | 553.268 ms | 291.137 ms |
| 4 | 50 ms | 308.020 ms | 118.962 ms |
| 4 | 500 ms | 2111.868 ms | 569.740 ms |
| 8 | 250 ms | 2217.159 ms | 388.519 ms |

A repeated four-server/250 ms run produced 1108.531 ms sequential and 323.580 ms concurrent.

## Validation
- focused `Agent.MCP` suite: 6 examples, 0 failures
- full `agent-core` suite: 276 passed; one unrelated timing-sensitive GHCi cancellation example timed out
- exact failed GHCi cancellation example rerun: 1 example, 0 failures
- live tmux TTY smoke check confirmed `Loading tools: seo-mcp...` renders during startup
