### PR TITLE
Generate session titles after completed turns

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Turn.hs
+++ b/packages/agent-cli/src/Agent/CLI/Turn.hs
@@ -6,6 +6,7 @@ module Agent.CLI.Turn
     , grokFirstTurnPrefix
     , grokFrameLastUserInput
     , grokUserQuery
+    , automaticTitleMilestone
     , restorePlanStateAfterIncomplete
     , runOneTurn
     ) where
@@ -202,14 +203,6 @@ runOneTurn env@SessionEnv
                             (roleMuted color
                                 (glyphSession <> "session: "
                                     <> handle.sessionMeta.metaId))
-            titleTurns <- readIORef env.sessionTitleTurnCount
-            when
-                ( titleTurns == 0
-                    && not handle.sessionMeta.metaTitleIsManual
-                    && handle.sessionMeta.metaTitleRefreshIndex == 0
-                )
-                (requestSessionTitle env.sessionTitleManager
-                    handle.sessionMeta.metaId 1 promptText)
         PersistenceDisabled -> pure ()
     prev <- readIORef previous
     beforeItems <- readIORef transcriptRef
@@ -459,13 +452,13 @@ runOneTurn env@SessionEnv
                     writeIORef env.sessionTitleTurnCount titleTurns
                     let countedMeta = countedHandle.sessionMeta
                     writeIORef slotRef (PersistenceActive countedHandle)
-                    when
-                        ( titleTurns `elem` [3, 6]
-                            && not countedMeta.metaTitleIsManual
-                            && countedMeta.metaTitleRefreshIndex
-                                < titleRefreshIndex titleTurns
-                        )
-                        (requestConversationTitle env countedHandle titleTurns)
+                    case automaticTitleMilestone
+                            titleTurns
+                            countedMeta.metaTitleIsManual
+                            countedMeta.metaTitleRefreshIndex of
+                        Nothing -> pure ()
+                        Just milestone ->
+                            requestConversationTitle env countedHandle milestone
                     when (countedMeta.metaTitle /= handle.sessionMeta.metaTitle) do
                         setWindowTitle
                             (cliWindowTitle countedMeta.metaCwd
@@ -627,6 +620,18 @@ requestConversationTitle env handle milestone =
                     handle.sessionMeta.metaId
                     milestone
                     (sessionConversationText turns)
+
+-- | Select automatic title milestones only after their completed user turn
+-- has been persisted. Milestone one intentionally shares refresh index zero
+-- with the prompt-derived fallback title; later milestones require a strictly
+-- newer generated-title refresh index.
+automaticTitleMilestone :: Int -> Bool -> Int -> Maybe Int
+automaticTitleMilestone completedTurns manual refreshIndex
+    | manual = Nothing
+    | completedTurns == 1 && refreshIndex == 0 = Just 1
+    | completedTurns `elem` [3, 6]
+    , refreshIndex < titleRefreshIndex completedTurns = Just completedTurns
+    | otherwise = Nothing
 
 applyPendingSessionTitles :: SessionEnv -> IO ()
 applyPendingSessionTitles env =

--- a/packages/agent-cli/test/Agent/CLI/TurnSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TurnSpec.hs
@@ -2,6 +2,7 @@ module Agent.CLI.TurnSpec (spec) where
 
 import Agent.CLI.Turn
     ( IncompleteTurnCheckpoint(..)
+    , automaticTitleMilestone
     , checkpointIncompleteTurn
     , grokFirstTurnPrefix
     , grokFrameLastUserInput
@@ -165,6 +166,22 @@ spec = do
                 `shouldNotBe` partialTranscript <> turnInputsToItems inputs
             checkpoint.checkpointTranscript
                 `shouldBe` history <> turnInputsToItems inputs
+
+    describe "automaticTitleMilestone" do
+        it "starts the initial title only after the first completed turn" do
+            automaticTitleMilestone 0 False 0 `shouldBe` Nothing
+            automaticTitleMilestone 1 False 0 `shouldBe` Just 1
+
+        it "refreshes at completed turns three and six" do
+            automaticTitleMilestone 2 False 0 `shouldBe` Nothing
+            automaticTitleMilestone 3 False 0 `shouldBe` Just 3
+            automaticTitleMilestone 3 False 1 `shouldBe` Nothing
+            automaticTitleMilestone 6 False 1 `shouldBe` Just 6
+            automaticTitleMilestone 6 False 2 `shouldBe` Nothing
+
+        it "never replaces a manual title" do
+            automaticTitleMilestone 1 True 0 `shouldBe` Nothing
+            automaticTitleMilestone 3 True 0 `shouldBe` Nothing
 
     describe "restorePlanStateAfterIncomplete" do
         it "undoes an agent-initiated plan-mode entry after cancellation" do


### PR DESCRIPTION
## Summary
- keep title generation on its own disposable WebSocket
- schedule the initial automatic title only after the first successful turn is persisted
- build title input from the persisted conversation, including the assistant response
- preserve refresh milestones at turns 3 and 6 and protect manual titles

## Verification
- Nix-backed Cabal GHCi loaded the changed `Agent.CLI.Turn` module
- focused `Agent.CLI.TurnSpec`: 20 examples, 0 failures
- live tmux smoke: `update_plan` -> model continuation -> final response completed without hanging
- persisted live tmux smoke completed `update_plan` -> delayed `run_ghci` -> `update_plan` -> final response
- while that persisted main turn was active, the process had exactly one established OpenAI connection, confirming title generation no longer starts before main-turn completion

The live account reached its usage limit when the post-turn title request ran, so the smoke verifies the hang regression and request ordering, while generated-title success remains covered by the existing mocked title-manager tests.
