### PR TITLE
feat(ghci): add scripting helpers

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Prompt.hs
+++ b/packages/agent-cli/src/Agent/CLI/Prompt.hs
@@ -144,6 +144,9 @@ ghciGuidance =
         , "run_ghci keeps a persistent GHCi session: bindings and loaded modules stick across calls."
         , "The session enables GHC2021 plus BlockArguments, OverloadedStrings, OverloadedRecordDot, DuplicateRecordFields, NoFieldSelectors, LambdaCase, and RecordWildCards."
         , "Pure expressions do not need user approval; IO and side-effecting GHCi commands do."
+        , "Useful built-ins: cmd/cmdIn capture argv-based commands, cmd_/cmdIn_ print their output, and readText/writeText/appendText/listFiles/pathExists cover common file operations."
+        , "Examples: cmd \"git\" [\"status\",\"--short\"]; cmdIn \"/repo\" \"git\" [\"diff\",\"--check\"]; text <- readText \"input.txt\"."
+        , "Imports are standalone GHCi statements, never lines inside a do block. Split imports, reusable bindings, and execution across calls instead of building one giant expression."
         , "Prefer shell tools (run_terminal_cmd or shell_command) for OS commands, package installs, servers, and anything that is not Haskell evaluation."
         , "Drive GHCi with complete expressions; do not expect interactive human input."
         ]
@@ -169,6 +172,9 @@ ghciGuidanceForTools dialect available
             , "run_ghci keeps a persistent GHCi session: bindings and loaded modules stick across calls."
             , "The session enables GHC2021 plus BlockArguments, OverloadedStrings, OverloadedRecordDot, DuplicateRecordFields, NoFieldSelectors, LambdaCase, and RecordWildCards."
             , "Pure expressions do not need user approval; IO and side-effecting GHCi commands do."
+            , "Useful built-ins: cmd/cmdIn capture argv-based commands, cmd_/cmdIn_ print their output, and readText/writeText/appendText/listFiles/pathExists cover common file operations."
+            , "Examples: cmd \"git\" [\"status\",\"--short\"]; cmdIn \"/repo\" \"git\" [\"diff\",\"--check\"]; text <- readText \"input.txt\"."
+            , "Imports are standalone GHCi statements, never lines inside a do block. Split imports, reusable bindings, and execution across calls instead of building one giant expression."
             ]
                 <> shellGuidance
                 <> [ "Drive GHCi with complete expressions; do not expect interactive human input."

--- a/packages/agent-cli/test/Agent/CLI/PromptSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/PromptSpec.hs
@@ -180,6 +180,12 @@ spec = describe "systemPrompt" do
                     day
                     False
         ghciOnly `shouldSatisfy` Text.isInfixOf "Prefer ghci for scripting"
+        ghciOnly `shouldSatisfy` Text.isInfixOf
+            "cmd \"git\" [\"status\",\"--short\"]"
+        ghciOnly `shouldSatisfy` Text.isInfixOf
+            "Imports are standalone GHCi statements"
+        ghciOnly `shouldSatisfy` Text.isInfixOf
+            "instead of building one giant expression"
         ghciOnly `shouldNotSatisfy` Text.isInfixOf "shell_command"
         bashOnly `shouldSatisfy` Text.isInfixOf "shell_command"
         bashOnly `shouldNotSatisfy` Text.isInfixOf "run_ghci"

--- a/packages/agent-core/src/Agent/Tools/Ghci/Runtime.hs
+++ b/packages/agent-core/src/Agent/Tools/Ghci/Runtime.hs
@@ -55,7 +55,7 @@ import Control.Exception.Safe
     , onException
     , try
     )
-import Control.Monad (void)
+import Control.Monad (void, when)
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Trans.State.Strict
     ( StateT
@@ -249,6 +249,8 @@ evalRawGhci session expression requestedTimeout = do
                 marker <- nextMarker session
                 sent <- liftIO $ try @_ @SomeException do
                     sendGhciInput process expression
+                    when (ghciInputResetsHelpers expression)
+                        (sendGhciHelpers process)
                     sendMarker process marker
                 case sent of
                     Left err -> do
@@ -444,7 +446,9 @@ startProcess session = mask \restore ->
             else do
                 marker <- nextMarker session
                 sent <- liftIO $
-                    try @_ @SomeException (sendMarker process marker)
+                    try @_ @SomeException do
+                        sendGhciHelpers process
+                        sendMarker process marker
                 case sent of
                     Left err -> do
                         liftIO (shutdownProcessBestEffort process)
@@ -616,6 +620,43 @@ waitForExit handle timeoutMs = go (max 1 timeoutMs)
 sendGhciInput :: GhciProcess -> Text -> IO ()
 sendGhciInput process expression =
     sendLine process (frameGhciInput expression)
+
+-- GHCi discards interactive bindings when its loaded module context changes.
+-- Reinstall the built-ins before framing completion for those commands.
+ghciInputResetsHelpers :: Text -> Bool
+ghciInputResetsHelpers expression =
+    case Text.uncons (Text.stripStart expression) of
+        Just (':', rest) ->
+            commandName rest `elem`
+                [ "load", "l", "reload", "r"
+                , "add", "unadd", "module", "m"
+                ]
+        _ -> False
+  where
+    commandName =
+        Text.toLower
+            . Text.takeWhile (not . (`elem` [' ', '\t', '\r', '\n']))
+
+-- | Install a tiny, provider-neutral scripting prelude. These bindings target
+-- the repetitive process and file operations seen in agent GHCi sessions while
+-- keeping argv-based execution as the default (rather than shell strings).
+sendGhciHelpers :: GhciProcess -> IO ()
+sendGhciHelpers process =
+    mapM_ (sendLine process)
+        [ "import qualified System.Process as AgentGhciProcess"
+        , "import qualified System.IO as AgentGhciIO"
+        , "import qualified Data.Text.IO as AgentGhciTextIO"
+        , "import qualified System.Directory as AgentGhciDirectory"
+        , "let cmdWithInput executable arguments input = AgentGhciProcess.readProcessWithExitCode executable arguments input"
+        , "let cmd executable arguments = cmdWithInput executable arguments \"\""
+        , "let cmdInWithInput directory executable arguments input = AgentGhciProcess.readCreateProcessWithExitCode ((AgentGhciProcess.proc executable arguments) { AgentGhciProcess.cwd = Just directory }) input"
+        , "let cmdIn directory executable arguments = cmdInWithInput directory executable arguments \"\""
+        , "let printCmdResult (exitCode, stdoutText, stderrText) = putStr stdoutText >> AgentGhciIO.hPutStr AgentGhciIO.stderr stderrText >> print exitCode"
+        , "let cmd_ executable arguments = cmd executable arguments >>= printCmdResult"
+        , "let cmdIn_ directory executable arguments = cmdIn directory executable arguments >>= printCmdResult"
+        , "let readText = AgentGhciTextIO.readFile; writeText = AgentGhciTextIO.writeFile; appendText = AgentGhciTextIO.appendFile"
+        , "let listFiles = AgentGhciDirectory.listDirectory; pathExists = AgentGhciDirectory.doesPathExist"
+        ]
 
 frameGhciInput :: Text -> Text
 frameGhciInput expression

--- a/packages/agent-core/src/Agent/Tools/Ghci/Tool.hs
+++ b/packages/agent-core/src/Agent/Tools/Ghci/Tool.hs
@@ -72,6 +72,9 @@ ghciDescription =
     "Evaluate Haskell in a persistent GHCi session for this agent.\n\
     \Bindings and loaded modules persist across calls.\n\
     \Pure expressions auto-approve; IO and side-effecting GHCi commands need approval.\n\
+    \Built-in helpers: cmd/cmdIn capture argv-based commands; cmd_/cmdIn_ print their output; \
+    \readText/writeText/appendText, listFiles, and pathExists handle common file tasks.\n\
+    \Imports must be separate GHCi statements, not lines inside a do block. Split setup and execution across calls.\n\
     \Prefer this over shell tools for calculations, type exploration, and small Haskell scripts.\n\
     \The session starts with GHC2021 plus BlockArguments, OverloadedStrings, \
     \OverloadedRecordDot, DuplicateRecordFields, NoFieldSelectors, LambdaCase, \

--- a/packages/agent-core/test/Agent/Tools/GhciSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/GhciSpec.hs
@@ -22,7 +22,10 @@ import Control.Concurrent.Async (mapConcurrently, wait, withAsync)
 import Control.Exception.Safe (SomeException, bracket, try)
 import Data.Either (isRight)
 import qualified Data.Text as Text
-import System.Directory (getTemporaryDirectory, removeDirectoryRecursive)
+import System.Directory
+    ( getTemporaryDirectory
+    , removeDirectoryRecursive
+    )
 import System.FilePath ((</>))
 import System.Posix.Signals (nullSignal, signalProcess)
 import System.Posix.Temp (mkdtemp)
@@ -73,6 +76,50 @@ spec = describe "Agent.Tools.Ghci" do
             value <- evalGhci ghci "x" 10000
             value.ghciOk `shouldBe` True
             value.ghciOutput `shouldSatisfy` Text.isInfixOf "42"
+
+    it "preloads concise command and file helpers" do
+        withTempGhci \ghci -> do
+            command <- evalGhci ghci
+                "cmd \"printf\" [\"helper-output\"]"
+                10000
+            command.ghciOk `shouldBe` True
+            command.ghciOutput
+                `shouldSatisfy` Text.isInfixOf "helper-output"
+
+            let outputPath = "helper-output.txt" :: FilePath
+            written <- evalGhci ghci
+                ("writeText " <> Text.pack (show outputPath)
+                    <> " \"hello from helper\"")
+                10000
+            written.ghciOk `shouldBe` True
+            readBack <- evalGhci ghci
+                ("readText " <> Text.pack (show outputPath))
+                10000
+            readBack.ghciOk `shouldBe` True
+            readBack.ghciOutput
+                `shouldSatisfy` Text.isInfixOf "hello from helper"
+
+    it "runs commands in an explicit working directory" do
+        withTempEnv \env ->
+            bracket (newGhciSession env) closeGhciSession \ghci -> do
+                result <- evalGhci ghci
+                    "cmdIn \".\" \"pwd\" []"
+                    10000
+                result.ghciOk `shouldBe` True
+                result.ghciOutput `shouldSatisfy`
+                    Text.isInfixOf (Text.pack (toFilePath env.toolCwd))
+
+    it "restores helpers after loading a module clears interactive bindings" do
+        withTempEnv \env -> do
+            writeFile (toFilePath env.toolCwd </> "Loaded.hs")
+                "module Loaded where\nanswer = 42\n"
+            bracket (newGhciSession env) closeGhciSession \ghci -> do
+                loaded <- evalGhci ghci ":load Loaded.hs" 10000
+                loaded.ghciOk `shouldBe` True
+                command <- evalGhci ghci "cmd \"printf\" [\"restored\"]" 10000
+                command.ghciOk `shouldBe` True
+                command.ghciOutput
+                    `shouldSatisfy` Text.isInfixOf "restored"
 
     it "serializes concurrent evaluations through the shared runtime state" do
         withTempGhci \ghci -> do


### PR DESCRIPTION
## Summary
- preload concise argv-based command helpers in every persistent GHCi session
- add common UTF-8 text and directory helpers for one-off scripts
- restore helper bindings after `:load`, `:reload`, and other context-resetting commands
- teach models to split imports, bindings, and execution across persistent calls instead of producing giant `do` blocks

## Motivation
A sample of the 50 most recently modified session transcripts found:
- 27 sessions using `run_ghci`
- 372 distinct expressions invoking process APIs across 17 sessions
- 80 `do` expressions longer than 500 characters
- 16 expressions incorrectly placing imports inside a `do` block

The most common boilerplate was `readProcessWithExitCode`, explicit `cwd` record updates, stdout/stderr rendering, and basic text/directory operations.

## Helpers
- `cmd`, `cmdWithInput`
- `cmdIn`, `cmdInWithInput`
- `cmd_`, `cmdIn_`
- `readText`, `writeText`, `appendText`
- `listFiles`, `pathExists`

Command helpers use executable-plus-argv APIs rather than shell strings.

## Validation
- rebased onto current `origin/master`
- `Agent.Tools.Ghci`: 22 examples, 0 failures through the Cabal test REPL
- focused `Agent.CLI.Prompt` regression: 1 example, 0 failures through the Cabal test REPL
- multi-package `agent-core` + `agent-cli` REPL typecheck: 192 modules loaded
- `git diff --check`
