### PR TITLE
Diagnose credential exhaustion in background sessions

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -356,7 +356,10 @@ import Agent.Claude
     )
 import Agent.Loop
 import qualified Agent.MCP as MCP
-import Agent.Error (ApiError(..))
+import Agent.Error
+    ( ApiError(..)
+    , CredentialExhaustionReason(..)
+    )
 import Agent.Dialect
     ( Dialect
     , DialectId
@@ -3495,7 +3498,9 @@ waitAndRetryPendingTurn
     -> PendingTurn
     -> IO RunResult
 waitAndRetryPendingTurn env delay pending = do
-    let cancel = env.sessionLoop.loopCancel
+    startedAt <- getCurrentTime
+    let retryAt = addUTCTime (max 0 delay) startedAt
+        cancel = env.sessionLoop.loopCancel
         renderCountdown seconds =
             let message = automaticRetryCountdownText seconds
             in case env.sessionFullscreen of
@@ -3505,9 +3510,7 @@ waitAndRetryPendingTurn env delay pending = do
                 Nothing ->
                     renderEvent env.sessionRender (ActivityUpdated message)
         waitForCancel = do
-            startedAt <- getCurrentTime
-            let retryAt = addUTCTime (max 0 delay) startedAt
-                poll lastShown = do
+            let poll lastShown = do
                     now <- getCurrentTime
                     let remaining = max 0 (diffUTCTime retryAt now)
                         seconds = max 0 (ceiling remaining)
@@ -3535,6 +3538,11 @@ waitAndRetryPendingTurn env delay pending = do
             Just _ -> waitForCancel
             Nothing ->
                 withEscCancel cancel env.sessionEscPaused waitForCancel
+    setPersistenceActivity
+        env.sessionPersist
+        "provider_cooldown"
+        "Provider temporarily unavailable; waiting before automatically retrying the pending turn."
+        (Just retryAt)
     resetCancel cancel
     case env.sessionFullscreen of
         Just _ -> pure ()
@@ -3543,6 +3551,7 @@ waitAndRetryPendingTurn env delay pending = do
         (withTurnCancel env.sessionInterrupt cancel waitAction)
             `finally` do
                 resetCancel cancel
+                clearPersistenceActivity env.sessionPersist
                 case env.sessionFullscreen of
                     Just _ -> pure ()
                     Nothing -> clearThinking env.sessionRender
@@ -3572,8 +3581,14 @@ waitAndRetryPendingTurn env delay pending = do
                     color <- resolveColor stderr
                     putTextLn stderr
                         (roleMuted color (glyphOk <> "retrying turn"))
+            setPersistenceActivity
+                env.sessionPersist
+                "provider_retry"
+                "Retrying the pending turn after the provider cooldown."
+                Nothing
             runPendingTurnWithCooldownRetry
                 False RestartPendingTurn env pending
+                `finally` clearPersistenceActivity env.sessionPersist
 
 reportProviderUnavailable
     :: Maybe FullscreenRuntime
@@ -5996,6 +6011,10 @@ reloadAuth provider maybeTokenProvider =
                     getNextToken tokenProvider (Just FailedCredential
                         { credential = current
                         , failure = AccountAuthenticationRejected
+                        , failureReason = ExhaustedByAuthentication
+                            { exhaustionErrorType = Nothing
+                            , exhaustionStatusCode = Nothing
+                            }
                         }) >>= \case
                         Left err -> do
                             now <- getCurrentTime

--- a/packages/agent-cli/src/Agent/CLI/AgentSessions.hs
+++ b/packages/agent-cli/src/Agent/CLI/AgentSessions.hs
@@ -16,10 +16,12 @@ import Agent.CLI.Options (ApprovalPolicy(..))
 import Agent.CLI.Error (formatException)
 import Agent.CLI.Session
     ( SessionCreate(..)
+    , SessionActivity
     , SessionHandle(..)
     , SessionMeta(..)
     , SessionTurn(..)
     , createSession
+    , loadSessionActivity
     , loadSession
     , sessionTempDirForId
     , sessionTitleFromPrompt
@@ -481,10 +483,14 @@ runReadAgentSession env args =
         Left err -> pure (Left err)
         Right (meta, turns) -> do
             status <- env.toolsSessionStatus args.sessionId
+            activity <-
+                if status == "running"
+                    then loadSessionActivity env.toolsRoot args.sessionId
+                    else pure Nothing
             let limit = min 100 (max 1 (fromMaybe 20 args.limit))
                 recent = drop (max 0 (length turns - limit)) turns
             pure $ Right $ encodeJson $ object
-                [ "session" .= sessionJson meta status
+                [ "session" .= sessionJson meta status activity
                 , "turns" .= map turnJson recent
                 ]
 
@@ -567,8 +573,8 @@ statusAfterLaunch env sessionId launchResult
     | "completed session " `Text.isPrefixOf` launchResult = pure "completed"
     | otherwise = env.toolsSessionStatus sessionId
 
-sessionJson :: SessionMeta -> Text -> Value
-sessionJson meta status = object
+sessionJson :: SessionMeta -> Text -> Maybe SessionActivity -> Value
+sessionJson meta status activity = object
     [ "id" .= meta.metaId
     , "status" .= status
     , "title" .= meta.metaTitle
@@ -580,6 +586,7 @@ sessionJson meta status = object
     , "cwd" .= unsafeToFilePath meta.metaCwd
     , "created_at" .= meta.metaCreatedAt
     , "updated_at" .= meta.metaUpdatedAt
+    , "activity" .= activity
     ]
 
 turnJson :: SessionTurn -> Value

--- a/packages/agent-cli/src/Agent/CLI/Auth.hs
+++ b/packages/agent-cli/src/Agent/CLI/Auth.hs
@@ -1065,11 +1065,14 @@ managedGrokCredential metadata secret stateRef refresh failed = do
     case failed of
         Just FailedCredential
             { failure = AccountRateLimited { retryAfterSeconds }
+            , failureReason
             } -> do
                 now <- getCurrentTime
                 let seconds = max 1 (fromMaybe 60 retryAfterSeconds)
                 pure $ Left $ CredentialsExhausted
-                    (addUTCTime (fromIntegral seconds) now)
+                    { retryAt = addUTCTime (fromIntegral seconds) now
+                    , exhaustionReasons = [failureReason]
+                    }
         Just FailedCredential
             { credential = rejected
             , failure = AccountAuthenticationRejected
@@ -1306,11 +1309,16 @@ reloadableFileCredentialProvider expectedProvider billing initial reload = do
                         writeIORef cache (Just credential)
                         pure (Right credential)
     pure $ tokenProvider billing \failed -> case failed of
-            Just FailedCredential { failure = AccountRateLimited { retryAfterSeconds } } -> do
+            Just FailedCredential
+                { failure = AccountRateLimited { retryAfterSeconds }
+                , failureReason
+                } -> do
                 now <- getCurrentTime
                 let seconds = max 1 (fromMaybe 60 retryAfterSeconds)
                 pure $ Left $ CredentialsExhausted
-                    (addUTCTime (fromIntegral seconds) now)
+                    { retryAt = addUTCTime (fromIntegral seconds) now
+                    , exhaustionReasons = [failureReason]
+                    }
             Just FailedCredential
                 { credential = rejected
                 , failure = AccountAuthenticationRejected
@@ -1328,11 +1336,14 @@ staticCredentialProvider billing credential =
         Nothing -> pure (Right credential)
         Just FailedCredential
             { failure = AccountRateLimited { retryAfterSeconds }
+            , failureReason
             } -> do
                 now <- getCurrentTime
                 let seconds = max 1 (fromMaybe 60 retryAfterSeconds)
                 pure $ Left $ CredentialsExhausted
-                    (addUTCTime (fromIntegral seconds) now)
+                    { retryAt = addUTCTime (fromIntegral seconds) now
+                    , exhaustionReasons = [failureReason]
+                    }
         Just FailedCredential
             { failure = AccountAuthenticationRejected
             } ->

--- a/packages/agent-cli/src/Agent/CLI/Error.hs
+++ b/packages/agent-cli/src/Agent/CLI/Error.hs
@@ -16,10 +16,13 @@ module Agent.CLI.Error
 import Agent.CLI.Duration (formatDuration)
 import Agent.Error
     ( ApiError(..)
+    , CredentialExhaustionReason(..)
     , ErrorType(..)
+    , errorTypeText
     )
 import Control.Exception.Safe (Exception, displayException)
 import Data.Char (isControl)
+import Data.List (nub)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Time.Clock (UTCTime, addUTCTime, diffUTCTime)
@@ -94,23 +97,83 @@ formatApiErrorWith maybeNow retryPresentation = \case
             "The operation could not be completed."
             details
             [action]
-    CredentialsExhausted{retryAt} ->
-        let (prefix, suffix) = credentialsExhaustedRetryParts
+    CredentialsExhausted{retryAt, exhaustionReasons} ->
+        let (prefix, suffix) =
+                credentialsExhaustedRetryParts exhaustionReasons
         in prefix <> credentialsRetryGuidance maybeNow retryAt <> suffix
 
 -- | Static text around the live retry phrase for errors with an absolute
 -- credential reset deadline. The TUI inserts @Try again in …@ and updates it.
 formatApiErrorRetryCountdownParts :: ApiError -> Maybe (Text, Text)
 formatApiErrorRetryCountdownParts = \case
-    CredentialsExhausted{} -> Just credentialsExhaustedRetryParts
+    CredentialsExhausted{exhaustionReasons} ->
+        Just (credentialsExhaustedRetryParts exhaustionReasons)
     _ -> Nothing
 
-credentialsExhaustedRetryParts :: (Text, Text)
-credentialsExhaustedRetryParts =
+credentialsExhaustedRetryParts
+    :: [CredentialExhaustionReason]
+    -> (Text, Text)
+credentialsExhaustedRetryParts reasons =
     ( "Provider unavailable.\n\
       \All accounts for this provider are temporarily unavailable.\n"
     , ", or choose another provider with /model."
+        <> exhaustionReasonDetails reasons
     )
+
+exhaustionReasonDetails :: [CredentialExhaustionReason] -> Text
+exhaustionReasonDetails reasons =
+    case nub (map formatExhaustionReason reasons) of
+        [] -> ""
+        rendered ->
+            "\nObserved account failures: "
+                <> Text.intercalate "; " rendered
+                <> "."
+
+formatExhaustionReason :: CredentialExhaustionReason -> Text
+formatExhaustionReason = \case
+    ExhaustedByRateLimit
+        { exhaustionErrorType
+        , exhaustionStatusCode
+        , exhaustionRetryAfter
+        } ->
+            "rate or usage limit"
+                <> formatReasonMetadata
+                    exhaustionErrorType
+                    exhaustionStatusCode
+                    exhaustionRetryAfter
+    ExhaustedByAuthentication
+        { exhaustionErrorType
+        , exhaustionStatusCode
+        } ->
+            "authentication rejected or credential refresh failed"
+                <> formatReasonMetadata
+                    exhaustionErrorType
+                    exhaustionStatusCode
+                    Nothing
+
+formatReasonMetadata
+    :: Maybe ErrorType
+    -> Maybe Int
+    -> Maybe Int
+    -> Text
+formatReasonMetadata maybeErrorType maybeStatus maybeRetryAfter =
+    case details of
+        [] -> ""
+        _ -> " (" <> Text.intercalate ", " details <> ")"
+  where
+    details =
+        maybe [] (\value -> ["type " <> errorTypeText value]) maybeErrorType
+            <> maybe
+                []
+                (\value -> ["HTTP " <> Text.pack (show value)])
+                maybeStatus
+            <> maybe
+                []
+                (\value ->
+                    [ "provider retry-after "
+                        <> formatDuration (fromIntegral value)
+                    ])
+                maybeRetryAfter
 
 formatProviderError
     :: RetryPresentation

--- a/packages/agent-cli/src/Agent/CLI/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session.hs
@@ -4,6 +4,7 @@ module Agent.CLI.Session
     , SessionMeta(..)
     , LegacySubagentTarget(..)
     , SessionTurn(..)
+    , SessionActivity(..)
     , SessionCreate(..)
     , Persistence(..)
     , PersistenceState(..)
@@ -11,6 +12,9 @@ module Agent.CLI.Session
     , newPendingPersistenceReserved
     , newActivePersistence
     , persistenceTempDir
+    , setPersistenceActivity
+    , clearPersistenceActivity
+    , loadSessionActivity
     , cleanupPendingPersistence
     , createSession
     , appendTurn
@@ -96,6 +100,7 @@ import System.Directory.OsPath
     , doesFileExist
     , listDirectory
     , removePathForcibly
+    , removeFile
     )
 import System.OsPath (OsPath, takeDirectory, unsafeEncodeUtf, (</>))
 import System.Posix.Files (setFileMode)
@@ -288,6 +293,32 @@ instance FromJSON SessionTurn where
             <*> o .: "items"
             <*> o .:? "usage"
 
+-- | Ephemeral progress for a running persisted session. This lives in the
+-- session temp directory rather than the transcript so polling clients can
+-- explain long waits without adding synthetic conversation turns.
+data SessionActivity = SessionActivity
+    { activityKind :: !Text
+    , activityMessage :: !Text
+    , activityRetryAt :: !(Maybe UTCTime)
+    , activityUpdatedAt :: !UTCTime
+    } deriving (Eq, Show)
+
+instance ToJSON SessionActivity where
+    toJSON activity = object
+        [ "kind" .= activity.activityKind
+        , "message" .= activity.activityMessage
+        , "retry_at" .= activity.activityRetryAt
+        , "updated_at" .= activity.activityUpdatedAt
+        ]
+
+instance FromJSON SessionActivity where
+    parseJSON = withObject "SessionActivity" \o ->
+        SessionActivity
+            <$> o .: "kind"
+            <*> o .: "message"
+            <*> o .:? "retry_at"
+            <*> o .: "updated_at"
+
 data SessionHandle = SessionHandle
     { sessionDir :: !OsPath
     , sessionTempDir :: !OsPath
@@ -339,7 +370,12 @@ newPendingPersistenceReserved spec sessionId tempDir = do
 newActivePersistence :: SessionHandle -> IO Persistence
 newActivePersistence handle = do
     ensurePrivateDir handle.sessionTempDir
-    PersistenceEnabled <$> newIORef (PersistenceActive handle)
+    persistence <-
+        PersistenceEnabled <$> newIORef (PersistenceActive handle)
+    -- A prior process may have died while a cooldown/retry marker was active.
+    -- Never attribute that stale activity to a newly resumed turn.
+    clearPersistenceActivity persistence
+    pure persistence
 
 persistenceTempDir :: Persistence -> IO (Maybe OsPath)
 persistenceTempDir = \case
@@ -348,6 +384,60 @@ persistenceTempDir = \case
         readIORef slotRef <&> \case
             PersistencePending _ _ tempDir -> Just tempDir
             PersistenceActive handle -> Just handle.sessionTempDir
+
+setPersistenceActivity
+    :: Persistence
+    -> Text
+    -> Text
+    -> Maybe UTCTime
+    -> IO ()
+setPersistenceActivity persistence kind message retryAt =
+    persistenceTempDir persistence >>= \case
+        Nothing -> pure ()
+        Just tempDir -> do
+            _ <- tryIO do
+                ensurePrivateDir tempDir
+                now <- getCurrentTime
+                writeLazyFileAtomically
+                    (sessionActivityPath tempDir)
+                    0o600
+                    (Aeson.encode SessionActivity
+                        { activityKind = kind
+                        , activityMessage = message
+                        , activityRetryAt = retryAt
+                        , activityUpdatedAt = now
+                        })
+            pure ()
+
+clearPersistenceActivity :: Persistence -> IO ()
+clearPersistenceActivity persistence =
+    persistenceTempDir persistence >>= mapM_ \tempDir -> do
+        _ <- tryIO (removeFile (sessionActivityPath tempDir))
+        pure ()
+
+loadSessionActivity
+    :: OsPath
+    -> Text
+    -> IO (Maybe SessionActivity)
+loadSessionActivity root sessionId =
+    case sessionTempDirForId root sessionId of
+        Left _ -> pure Nothing
+        Right tempDir -> do
+            let path = sessionActivityPath tempDir
+            exists <- doesFileExist path
+            if not exists
+                then pure Nothing
+                else
+                    tryIO (retryOnFileBusy (LBS.readFile (unsafeToFilePath path)))
+                        <&> \case
+                            Left _ -> Nothing
+                            Right bytes ->
+                                either (const Nothing) Just
+                                    (Aeson.eitherDecode bytes)
+
+sessionActivityPath :: OsPath -> OsPath
+sessionActivityPath tempDir =
+    tempDir </> unsafeEncodeUtf "activity.json"
 
 -- | Remove scratch space only when a reserved session never became durable.
 cleanupPendingPersistence :: Persistence -> IO ()

--- a/packages/agent-cli/test/Agent/CLI/AgentSessionsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/AgentSessionsSpec.hs
@@ -106,6 +106,22 @@ spec = describe "Agent.CLI.AgentSessions" do
             result `shouldSatisfy` Text.isInfixOf "\"assistant\":\"answer\""
             result `shouldNotSatisfy` Text.isInfixOf "\"items\""
 
+    it "includes ephemeral retry activity while a session is running" $
+        withTempEnv \env _ -> do
+            handle <- createSession (testCreate env.toolsRoot)
+            persistence <- newActivePersistence handle
+            setPersistenceActivity
+                persistence
+                "provider_cooldown"
+                "Waiting before retrying."
+                (Just fixedTime)
+            result <- runTool env "read_agent_session" $
+                "{\"session_id\":\"" <> handle.sessionMeta.metaId <> "\"}"
+            result `shouldSatisfy`
+                Text.isInfixOf "\"kind\":\"provider_cooldown\""
+            result `shouldSatisfy`
+                Text.isInfixOf "\"message\":\"Waiting before retrying.\""
+
     it "starts a follow-up turn and rejects messaging the current session" $
         withTempEnv \env launched -> do
             handle <- createSession (testCreate env.toolsRoot)

--- a/packages/agent-cli/test/Agent/CLI/AuthSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/AuthSpec.hs
@@ -3,7 +3,11 @@ module Agent.CLI.AuthSpec (spec) where
 import Agent.CLI.Auth
 import Agent.CLI.CredentialStore
 import qualified Agent.CLI.Login as Login
-import Agent.Error (ApiError(..))
+import Agent.Error
+    ( ApiError(..)
+    , CredentialExhaustionReason(..)
+    , credentialsExhausted
+    )
 import System.OsPath (OsPath, decodeUtf, unsafeEncodeUtf)
 import Agent.OpenAI.Auth (AuthState(..))
 import qualified Agent.OpenAI.Auth as OpenAI
@@ -69,14 +73,14 @@ spec = do
                 exhausted = LoadedAuth
                     { loadedProvider = XAIProvider
                     , loadedTokenProvider = tokenProvider SubscriptionBilled \_ ->
-                        pure (Left (CredentialsExhausted retryAt))
+                        pure (Left (credentialsExhausted retryAt))
                     , loadedAccountLabel = pure . credentialAccountLabel
                     , loadedSelectionId = Nothing
                     , loadedOpenAiPool = Nothing
                     }
             result <- probeLoadedAuth exhausted
             case result of
-                Left err -> err `shouldBe` CredentialsExhausted retryAt
+                Left err -> err `shouldBe` credentialsExhausted retryAt
                 Right _ -> expectationFailure "expected exhausted auth"
 
         it "returns and seeds the credential used for the account display" do
@@ -394,6 +398,7 @@ spec = do
                             AccountRateLimited
                                 { retryAfterSeconds = Just 60
                                 }
+                        , failureReason = testRateLimitReason (Just 60)
                         })
                 >>= \case
                     Right credential ->
@@ -431,6 +436,7 @@ spec = do
                             AccountRateLimited
                                 { retryAfterSeconds = Just 60
                                 }
+                        , failureReason = testRateLimitReason (Just 60)
                         })
                 >>= \case
                     Right credential ->
@@ -649,8 +655,10 @@ spec = do
                     (const (pure (Right refreshedGrokTokens)))
                 getNextToken provider
                     (Just
-                        (FailedCredential staleManagedGrok
-                            AccountAuthenticationRejected))
+                        (FailedCredential
+                            staleManagedGrok
+                            AccountAuthenticationRejected
+                            testAuthenticationReason))
                     `shouldReturn` Right freshManagedGrok
 
         it "adopts a token rotated by another process without refreshing" $
@@ -678,8 +686,10 @@ spec = do
             result <- getNextToken
                 (staticCredentialProvider SubscriptionBilled staleGrok)
                 (Just
-                    (FailedCredential staleGrok
-                        (AccountRateLimited (Just 7))))
+                    (FailedCredential
+                        staleGrok
+                        (AccountRateLimited (Just 7))
+                        (testRateLimitReason (Just 7))))
             case result of
                 Left CredentialsExhausted{retryAt} ->
                     diffUTCTime retryAt before `shouldSatisfy` (>= 7)
@@ -718,6 +728,7 @@ spec = do
             reloaded <- getNextToken provider (Just FailedCredential
                 { credential = staleGrok
                 , failure = AccountAuthenticationRejected
+                , failureReason = testAuthenticationReason
                 })
             reloaded `shouldBe` Right freshGrok
             getNextToken provider Nothing `shouldReturn` Right freshGrok
@@ -730,6 +741,7 @@ spec = do
             result <- getNextToken provider (Just FailedCredential
                 { credential = staleGrok
                 , failure = AccountAuthenticationRejected
+                , failureReason = testAuthenticationReason
                 })
             case result of
                 Left (CredentialError message) ->
@@ -960,6 +972,19 @@ tokenObject accountId token = Aeson.object
     , "refresh_token" .= ("refresh-" <> accountId)
     , "account_id" .= accountId
     ]
+
+testAuthenticationReason :: CredentialExhaustionReason
+testAuthenticationReason = ExhaustedByAuthentication
+    { exhaustionErrorType = Nothing
+    , exhaustionStatusCode = Just 401
+    }
+
+testRateLimitReason :: Maybe Int -> CredentialExhaustionReason
+testRateLimitReason retryAfter = ExhaustedByRateLimit
+    { exhaustionErrorType = Nothing
+    , exhaustionStatusCode = Just 429
+    , exhaustionRetryAfter = retryAfter
+    }
 
 staleGrok :: Credential
 staleGrok = Credential

--- a/packages/agent-cli/test/Agent/CLI/ErrorSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ErrorSpec.hs
@@ -1,7 +1,12 @@
 module Agent.CLI.ErrorSpec (spec) where
 
 import Agent.CLI.Error
-import Agent.Error (ApiError(..), ErrorType(..))
+import Agent.Error
+    ( ApiError(..)
+    , CredentialExhaustionReason(..)
+    , ErrorType(..)
+    , credentialsExhausted
+    )
 import Control.Monad (forM_)
 import qualified Data.Text as Text
 import Data.Time.Calendar (fromGregorian)
@@ -105,20 +110,20 @@ spec = do
                 (ProviderError RateLimitError "slow down" (Just 121))
                 `shouldSatisfy` Text.isInfixOf "Try again in 2m"
             formatApiErrorAt epoch
-                (CredentialsExhausted
+                (credentialsExhausted
                     (addUTCTime (5 * 86400 + 21 * 3600) epoch))
                 `shouldSatisfy` Text.isInfixOf "Try again in 5d 21h"
             formatApiError
-                (CredentialsExhausted
+                (credentialsExhausted
                     (addUTCTime (5 * 86400 + 21 * 3600) epoch))
                 `shouldSatisfy`
                     Text.isInfixOf "2026-08-27 21:00:00 UTC"
             formatApiError
-                (CredentialsExhausted (addUTCTime 37.4 epoch))
+                (credentialsExhausted (addUTCTime 37.4 epoch))
                 `shouldSatisfy`
                     Text.isInfixOf "2026-08-22 00:00:38 UTC"
             formatApiErrorAt epoch
-                (CredentialsExhausted epoch)
+                (credentialsExhausted epoch)
                 `shouldSatisfy` Text.isInfixOf "Try again now"
             formatApiErrorAt epoch
                 (ProviderError RateLimitError "slow down" (Just 0))
@@ -126,7 +131,7 @@ spec = do
 
         it "exposes live countdown framing only for credential exhaustion" do
             formatApiErrorRetryCountdownParts
-                (CredentialsExhausted (addUTCTime 60 epoch))
+                (credentialsExhausted (addUTCTime 60 epoch))
                 `shouldBe`
                     Just
                         ( "Provider unavailable.\n\
@@ -136,6 +141,29 @@ spec = do
             formatApiErrorRetryCountdownParts
                 (ProviderError RateLimitError "slow down" (Just 60))
                 `shouldBe` Nothing
+
+        it "renders redacted credential exhaustion causes" do
+            let rendered = formatApiErrorAt epoch $ CredentialsExhausted
+                    { retryAt = addUTCTime 60 epoch
+                    , exhaustionReasons =
+                        [ ExhaustedByRateLimit
+                            { exhaustionErrorType =
+                                Just UsageLimitReached
+                            , exhaustionStatusCode = Nothing
+                            , exhaustionRetryAfter = Nothing
+                            }
+                        , ExhaustedByAuthentication
+                            { exhaustionErrorType =
+                                Just AuthenticationError
+                            , exhaustionStatusCode = Just 401
+                            }
+                        ]
+                    }
+            rendered `shouldSatisfy`
+                Text.isInfixOf "Observed account failures"
+            rendered `shouldSatisfy`
+                Text.isInfixOf "type usage_limit_reached"
+            rendered `shouldSatisfy` Text.isInfixOf "HTTP 401"
 
         it "bounds and sanitizes provider detail text" do
             let rendered =
@@ -179,7 +207,7 @@ sampleErrors =
     , JsonDecodeError "bad JSON" "raw body"
     , CredentialError "credential file is invalid"
     , ConnectionError "socket closed"
-    , CredentialsExhausted (addUTCTime 60 epoch)
+    , credentialsExhausted (addUTCTime 60 epoch)
     ]
         <> [ ProviderError errorType "provider detail" (Just 60)
            | errorType <- allErrorTypes

--- a/packages/agent-cli/test/Agent/CLI/ProviderFallbackSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ProviderFallbackSpec.hs
@@ -15,7 +15,11 @@ import Agent.CLI.ProviderFallback
     , providerRecoveryPreference
     , rankedModels
     )
-import Agent.Error (ApiError(..), ErrorType(..))
+import Agent.Error
+    ( ApiError(..)
+    , ErrorType(..)
+    , credentialsExhausted
+    )
 import Agent.Provider (BillingMode(..), Provider(..))
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Text as Text
@@ -54,7 +58,7 @@ spec = do
 
     describe "fallbackCandidates" do
         let exhausted =
-                CredentialsExhausted
+                credentialsExhausted
                     (UTCTime (fromGregorian 2026 8 20) 0)
 
         it "selects the best model for each other provider" do
@@ -128,17 +132,17 @@ spec = do
 
         it "waits through a brief credential cooldown" do
             automaticCooldownRetryDelay now
-                (CredentialsExhausted (addUTCTime 60 now))
+                (credentialsExhausted (addUTCTime 60 now))
                 `shouldBe` Just 60
 
         it "retries immediately when the reset time has just passed" do
             automaticCooldownRetryDelay now
-                (CredentialsExhausted (addUTCTime (-1) now))
+                (credentialsExhausted (addUTCTime (-1) now))
                 `shouldBe` Just 0
 
         it "returns control for a long cooldown" do
             automaticCooldownRetryDelay now
-                (CredentialsExhausted (addUTCTime 121 now))
+                (credentialsExhausted (addUTCTime 121 now))
                 `shouldBe` Nothing
 
         it "does not retry authentication failures as cooldowns" do
@@ -151,17 +155,17 @@ spec = do
 
         it "retries a transient all-account cooldown before provider fallback" do
             providerRecoveryPreference True now
-                (CredentialsExhausted (addUTCTime 60 now))
+                (credentialsExhausted (addUTCTime 60 now))
                 `shouldBe` RetryCurrentProviderAfter 60
 
         it "falls back for a genuine long usage-window exhaustion" do
             providerRecoveryPreference True now
-                (CredentialsExhausted (addUTCTime 3600 now))
+                (credentialsExhausted (addUTCTime 3600 now))
                 `shouldBe` TryProviderFallback
 
         it "does not repeat the cooldown retry after its one retry allowance" do
             providerRecoveryPreference False now
-                (CredentialsExhausted (addUTCTime 60 now))
+                (credentialsExhausted (addUTCTime 60 now))
                 `shouldBe` TryProviderFallback
 
     describe "automaticRetryCountdownText" do

--- a/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
@@ -2,7 +2,7 @@ module Agent.CLI.RenderSpec (spec) where
 
 import Agent.CLI.Render
 import Agent.CLI.Style (motionGlyphSet)
-import Agent.Error (ApiError(..), ErrorType(..))
+import Agent.Error (ApiError(..), ErrorType(..), credentialsExhausted)
 import Agent.Loop (LoopError(..), LoopEvent(..), TurnOutput(..), emptyTokenUsage)
 import Agent.ToolDispatch
     ( ToolCallKind(..)
@@ -164,7 +164,7 @@ spec = do
                 retryAt = addUTCTime (5 * 86400 + 21 * 3600) now
                 rendered =
                     formatLoopErrorAt now
-                        (LoopTransport (CredentialsExhausted retryAt))
+                        (LoopTransport (credentialsExhausted retryAt))
             rendered `shouldSatisfy`
                 Text.isInfixOf
                     "All accounts for this provider are temporarily unavailable"
@@ -181,7 +181,7 @@ spec = do
                 rendered =
                     formatLoopErrorPersistedAt
                         (UTCTime (fromGregorian 2026 8 22) 0)
-                        (LoopTransport (CredentialsExhausted retryAt))
+                        (LoopTransport (credentialsExhausted retryAt))
             rendered `shouldSatisfy`
                 Text.isInfixOf "2026-08-27 21:00:00 UTC"
             rendered `shouldNotSatisfy` Text.isInfixOf "Try again in"

--- a/packages/agent-cli/test/Agent/CLI/SessionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SessionSpec.hs
@@ -65,6 +65,42 @@ spec = describe "Agent.CLI.Session" do
                 `shouldBe` "Resume this session with: 'it'\\''s' --resume id"
 
     describe "createSession/appendTurn/loadSession" do
+        it "round-trips and clears ephemeral session activity" $
+            withTempDir "agent-session-activity-" \root -> do
+                handle <- createSession (testCreate root)
+                persistence <- newActivePersistence handle
+                setPersistenceActivity
+                    persistence
+                    "provider_cooldown"
+                    "Waiting before retrying."
+                    (Just fixedTime)
+
+                activity <-
+                    loadSessionActivity root handle.sessionMeta.metaId
+                activity `shouldSatisfy` maybe False
+                    (\current ->
+                        current.activityKind == "provider_cooldown"
+                            && current.activityMessage
+                                == "Waiting before retrying."
+                            && current.activityRetryAt == Just fixedTime)
+
+                clearPersistenceActivity persistence
+                loadSessionActivity root handle.sessionMeta.metaId
+                    `shouldReturn` Nothing
+
+        it "clears stale activity when a session is resumed" $
+            withTempDir "agent-session-activity-resume-" \root -> do
+                handle <- createSession (testCreate root)
+                persistence <- newActivePersistence handle
+                setPersistenceActivity
+                    persistence
+                    "provider_retry"
+                    "Retrying."
+                    Nothing
+                _ <- newActivePersistence handle
+                loadSessionActivity root handle.sessionMeta.metaId
+                    `shouldReturn` Nothing
+
         it "round-trips meta and transcript items with private modes" $
             withTempDir "agent-sessions-" \root -> do
                 handle <- createSession (testCreate root)

--- a/packages/agent-core/src/Agent/Error.hs
+++ b/packages/agent-core/src/Agent/Error.hs
@@ -1,6 +1,7 @@
 module Agent.Error
     ( ApiError(..)
     , ErrorType(..)
+    , CredentialExhaustionReason(..)
     , RetryDisposition(..)
     , errorTypeFromText
     , errorTypeText
@@ -9,6 +10,9 @@ module Agent.Error
     , isInlineRetryableProviderError
     , isInlineRetryableProviderResponseError
     , apiErrorRetryAfter
+    , credentialExhaustionReasonFromApiError
+    , credentialsExhausted
+    , credentialsExhaustedWithReasons
     , credentialsExhaustedRetryAt
     ) where
 
@@ -41,6 +45,22 @@ data ErrorType
     | CyberPolicyError
     | MisalignmentPolicyViolation
     | UnknownErrorType !Text
+    deriving (Eq, Show)
+
+-- | Redacted, structured reason why a credential entered cooldown.
+--
+-- Provider response bodies and token material are deliberately excluded so
+-- this value is safe to retain in session errors and account snapshots.
+data CredentialExhaustionReason
+    = ExhaustedByRateLimit
+        { exhaustionErrorType :: !(Maybe ErrorType)
+        , exhaustionStatusCode :: !(Maybe Int)
+        , exhaustionRetryAfter :: !(Maybe Int)
+        }
+    | ExhaustedByAuthentication
+        { exhaustionErrorType :: !(Maybe ErrorType)
+        , exhaustionStatusCode :: !(Maybe Int)
+        }
     deriving (Eq, Show)
 
 -- | Whether retrying can help, and which layer should own the retry.
@@ -129,7 +149,10 @@ data ApiError
         }
     | CredentialError { credentialMessage :: !Text }
     | ConnectionError { exception :: !Text }
-    | CredentialsExhausted { retryAt :: !UTCTime }
+    | CredentialsExhausted
+        { retryAt :: !UTCTime
+        , exhaustionReasons :: ![CredentialExhaustionReason]
+        }
     deriving (Eq, Show)
 
 retryDisposition :: ApiError -> RetryDisposition
@@ -177,6 +200,61 @@ apiErrorRetryAfter :: ApiError -> Maybe Int
 apiErrorRetryAfter (ProviderError _ _ value) = value
 apiErrorRetryAfter _ = Nothing
 
+-- | Extract a token-safe account-cooldown reason from an upstream error.
+credentialExhaustionReasonFromApiError
+    :: ApiError
+    -> Maybe CredentialExhaustionReason
+credentialExhaustionReasonFromApiError = \case
+    HttpError 429 _ ->
+        Just ExhaustedByRateLimit
+            { exhaustionErrorType = Nothing
+            , exhaustionStatusCode = Just 429
+            , exhaustionRetryAfter = Nothing
+            }
+    ProviderError errorType _ retryAfter
+        | errorType `elem`
+            [ RateLimitError
+            , UsageLimitReached
+            , UsageBalanceExhausted
+            ] ->
+                Just ExhaustedByRateLimit
+                    { exhaustionErrorType = Just errorType
+                    , exhaustionStatusCode = Nothing
+                    , exhaustionRetryAfter = retryAfter
+                    }
+    HttpError status _
+        | status == 401 || status == 403 ->
+            Just ExhaustedByAuthentication
+                { exhaustionErrorType = Nothing
+                , exhaustionStatusCode = Just status
+                }
+    ProviderError AuthenticationError _ _ ->
+        Just ExhaustedByAuthentication
+            { exhaustionErrorType = Just AuthenticationError
+            , exhaustionStatusCode = Nothing
+            }
+    CredentialError{} ->
+        Just ExhaustedByAuthentication
+            { exhaustionErrorType = Nothing
+            , exhaustionStatusCode = Nothing
+            }
+    _ -> Nothing
+
+-- | Construct an exhaustion error when no more specific cooldown diagnostics
+-- are available.
+credentialsExhausted :: UTCTime -> ApiError
+credentialsExhausted retryAt =
+    credentialsExhaustedWithReasons retryAt []
+
+credentialsExhaustedWithReasons
+    :: UTCTime
+    -> [CredentialExhaustionReason]
+    -> ApiError
+credentialsExhaustedWithReasons retryAt exhaustionReasons = CredentialsExhausted
+    { retryAt
+    , exhaustionReasons
+    }
+
 credentialsExhaustedRetryAt :: ApiError -> Maybe UTCTime
-credentialsExhaustedRetryAt (CredentialsExhausted value) = Just value
+credentialsExhaustedRetryAt CredentialsExhausted{retryAt} = Just retryAt
 credentialsExhaustedRetryAt _ = Nothing

--- a/packages/agent-core/src/Agent/Provider.hs
+++ b/packages/agent-core/src/Agent/Provider.hs
@@ -15,15 +15,19 @@ module Agent.Provider
     , runWithTokenProviderAfter
     , seedTokenProvider
     , accountFailureFromApiError
+    , accountFailureReason
     ) where
 
 import Agent.Error
     ( ApiError(..)
+    , CredentialExhaustionReason(..)
     , ErrorType(..)
     , apiErrorRetryAfter
+    , credentialExhaustionReasonFromApiError
     )
 import qualified Data.Aeson as Aeson
 import Data.IORef
+import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 
 data Provider
@@ -96,6 +100,7 @@ data AccountFailure
 data FailedCredential = FailedCredential
     { credential :: !Credential
     , failure :: !AccountFailure
+    , failureReason :: !CredentialExhaustionReason
     }
     deriving (Eq, Show)
 
@@ -166,6 +171,8 @@ runWithTokenProviderAfter provider initialFailure action =
                         go (attemptsLeft - 1) $ Just FailedCredential
                             { credential
                             , failure
+                            , failureReason =
+                                accountFailureReason err failure
                             }
                 result -> pure result
 
@@ -186,3 +193,24 @@ accountFailureFromApiError err = case err of
   where
     rateLimited = Just $ AccountRateLimited (apiErrorRetryAfter err)
     authenticationRejected = Just AccountAuthenticationRejected
+
+accountFailureReason
+    :: ApiError
+    -> AccountFailure
+    -> CredentialExhaustionReason
+accountFailureReason err failure =
+    fromMaybe (fallback failure)
+        (credentialExhaustionReasonFromApiError err)
+  where
+    fallback = \case
+        AccountRateLimited{retryAfterSeconds} ->
+            ExhaustedByRateLimit
+                { exhaustionErrorType = Nothing
+                , exhaustionStatusCode = Nothing
+                , exhaustionRetryAfter = retryAfterSeconds
+                }
+        AccountAuthenticationRejected ->
+            ExhaustedByAuthentication
+                { exhaustionErrorType = Nothing
+                , exhaustionStatusCode = Nothing
+                }

--- a/packages/agent-core/test/Agent/ErrorSpec.hs
+++ b/packages/agent-core/test/Agent/ErrorSpec.hs
@@ -29,3 +29,23 @@ spec = do
         retryDisposition
             (ProviderError InvalidRequestError "bad request" Nothing)
             `shouldBe` DoNotRetry
+
+  describe "credentialExhaustionReasonFromApiError" do
+    it "retains structured rate-limit metadata without provider bodies" do
+        credentialExhaustionReasonFromApiError
+            (ProviderError UsageLimitReached
+                "sensitive provider detail"
+                (Just 90))
+            `shouldBe` Just ExhaustedByRateLimit
+                { exhaustionErrorType = Just UsageLimitReached
+                , exhaustionStatusCode = Nothing
+                , exhaustionRetryAfter = Just 90
+                }
+
+    it "retains only the status for HTTP authentication failures" do
+        credentialExhaustionReasonFromApiError
+            (HttpError 401 "sensitive response body")
+            `shouldBe` Just ExhaustedByAuthentication
+                { exhaustionErrorType = Nothing
+                , exhaustionStatusCode = Just 401
+                }

--- a/packages/agent-openai/src/Agent/OpenAI/Auth.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Auth.hs
@@ -19,7 +19,9 @@ module Agent.OpenAI.Auth
 
       -- * Cooldown management
     , reportRateLimit
+    , reportRateLimitWithReason
     , reportAuthBroken
+    , reportAuthBrokenWithReason
     , refreshAfterAuthFailure
     , recoverAfterAuthFailure
     , authFailureRetrySeconds
@@ -46,7 +48,13 @@ module Agent.OpenAI.Auth
     , deriveEmail
     ) where
 
-import Agent.Error (ApiError(..), ErrorType(..))
+import Agent.Error
+    ( ApiError(..)
+    , CredentialExhaustionReason(..)
+    , ErrorType(..)
+    , credentialExhaustionReasonFromApiError
+    , credentialsExhaustedWithReasons
+    )
 import Agent.OpenAI.Auth.JWT
     ( deriveAccountId
     , deriveEmail
@@ -71,7 +79,7 @@ import Data.IORef
     , newIORef
     , readIORef
     )
-import Data.List (find)
+import Data.List (find, nub)
 import Data.Maybe (catMaybes, fromMaybe)
 import qualified Data.Set as Set
 import Data.Text (Text)
@@ -87,9 +95,14 @@ import Data.Time.Clock
 -- State
 --------------------------------------------------------------------------------
 
+data AccountCooldown = AccountCooldown
+    { cooldownUntil :: !UTCTime
+    , cooldownReason :: !CredentialExhaustionReason
+    }
+
 data AccountCooldowns = AccountCooldowns
-    { cooldownRateLimitUntil :: !(Maybe UTCTime)
-    , cooldownAuthBrokenUntil :: !(Maybe UTCTime)
+    { cooldownRateLimit :: !(Maybe AccountCooldown)
+    , cooldownAuthBroken :: !(Maybe AccountCooldown)
     }
 
 -- | All mutable state for one account. Auth, cooldowns, and recovery
@@ -115,7 +128,8 @@ type AccountDiscovery = [Text] -> IO (Either ApiError [AuthState])
 
 data PoolState = PoolState
     { stateEntries :: ![AccountEntry]
-    , stateEmptyRetryAt :: !(Maybe UTCTime)
+    , stateEmptyExhaustion
+        :: !(Maybe (UTCTime, [CredentialExhaustionReason]))
     , stateCounter :: !Int
     , stateDiscovery :: !(Maybe (MVar Bool))
     }
@@ -203,7 +217,7 @@ buildPool initial emptyRetryAt refresh discovery = do
     let offset = floor (toRational (utctDayTime now) * 1000) :: Int
     state <- newIORef PoolState
         { stateEntries = entries
-        , stateEmptyRetryAt = emptyRetryAt
+        , stateEmptyExhaustion = (, []) <$> emptyRetryAt
         , stateCounter = offset `mod` max 1 (length entries)
         , stateDiscovery = Nothing
         }
@@ -243,28 +257,40 @@ getAccessTokenWithDiscovery pool allowDiscovery = do
     let accountIdsAtCheckout = map (.entryAccountId) entries
     result <- go (length entries)
     case result of
-        Left exhausted@CredentialsExhausted{retryAt = previousRetryAt}
+        Left exhausted@CredentialsExhausted
+            { retryAt = previousRetryAt
+            , exhaustionReasons = previousReasons
+            }
             | allowDiscovery ->
                 discoverAdditionalAccounts pool accountIdsAtCheckout >>= \case
                     True -> getAccessTokenWithDiscovery pool False
                     False -> do
                         current <- readIORef pool.poolState
                         if null current.stateEntries
-                            then pure $ Left $ CredentialsExhausted $
-                                fromMaybe previousRetryAt
-                                    current.stateEmptyRetryAt
+                            then
+                                let (retryAt, reasons) =
+                                        fromMaybe
+                                            (previousRetryAt, previousReasons)
+                                            current.stateEmptyExhaustion
+                                in pure $ Left $
+                                    credentialsExhaustedWithReasons
+                                        retryAt reasons
                             else pure (Left exhausted)
         _ -> pure result
   where
     go attemptsLeft
         | attemptsLeft <= 0 = do
             pickAccount pool >>= \case
-                Left earliest -> pure $ Left (CredentialsExhausted earliest)
+                Left (earliest, reasons) ->
+                    pure $ Left $
+                        credentialsExhaustedWithReasons earliest reasons
                 Right _ -> pure $ Left $ ConnectionError
                     "Agent.OpenAI.Auth.getAccessToken: failover budget exhausted"
         | otherwise =
             pickAccount pool >>= \case
-                Left earliest -> pure $ Left (CredentialsExhausted earliest)
+                Left (earliest, reasons) ->
+                    pure $ Left $
+                        credentialsExhaustedWithReasons earliest reasons
                 Right entry ->
                     currentAuthState pool entry >>= \case
                         Right state ->
@@ -273,7 +299,10 @@ getAccessTokenWithDiscovery pool allowDiscovery = do
                             | CredentialsExhausted{} <- err ->
                                 go (attemptsLeft - 1)
                             | isAuthError err -> do
-                                reportAuthBroken pool entry.entryAccountId
+                                reportAuthBrokenWithReason
+                                    pool
+                                    entry.entryAccountId
+                                    (authReasonFromApiError err)
                                 go (attemptsLeft - 1)
                             | otherwise -> pure (Left err)
 
@@ -288,8 +317,9 @@ currentAuthState pool entry =
             let updated = expireCooldowns now current
             in (updated, updated)
         case effectiveCooldown state.accountCooldowns of
-            Just until_ ->
-                pure (Left (CredentialsExhausted until_))
+            Just (until_, reasons) ->
+                pure $ Left $
+                    credentialsExhaustedWithReasons until_ reasons
             Nothing ->
                 if needsRefresh state.accountAuth now
                     then refreshEntry pool entry state.accountAuth
@@ -312,7 +342,7 @@ refreshEntryAfterAuthFailure
     -> IO (Either ApiError AuthState)
 refreshEntryAfterAuthFailure =
     refreshEntryWithCooldownTransition \cooldowns ->
-        cooldowns { cooldownAuthBrokenUntil = Nothing }
+        cooldowns { cooldownAuthBroken = Nothing }
 
 refreshEntryWithCooldownTransition
     :: (AccountCooldowns -> AccountCooldowns)
@@ -396,8 +426,13 @@ finishDiscovery
 finishDiscovery outcome candidates current =
     let withoutOwner = current { stateDiscovery = Nothing }
     in case outcome of
-        Just (Left CredentialsExhausted{retryAt}) ->
-            (withoutOwner { stateEmptyRetryAt = Just retryAt }, False)
+        Just (Left CredentialsExhausted{retryAt, exhaustionReasons}) ->
+            ( withoutOwner
+                { stateEmptyExhaustion =
+                    Just (retryAt, exhaustionReasons)
+                }
+            , False
+            )
         Just (Right _) ->
             appendEntries candidates withoutOwner
         _ ->
@@ -411,8 +446,8 @@ appendEntries candidates current =
     in
         ( current
             { stateEntries = current.stateEntries <> reverse newEntries
-            , stateEmptyRetryAt =
-                if added then Nothing else current.stateEmptyRetryAt
+            , stateEmptyExhaustion =
+                if added then Nothing else current.stateEmptyExhaustion
             }
         , added
         )
@@ -433,31 +468,40 @@ discoverAccounts pool = do
 -- Selection and cooldowns
 --------------------------------------------------------------------------------
 
-pickAccount :: Pool -> IO (Either UTCTime AccountEntry)
+pickAccount
+    :: Pool
+    -> IO
+        (Either
+            (UTCTime, [CredentialExhaustionReason])
+            AccountEntry)
 pickAccount pool = do
     now <- getCurrentTime
-    (entries, startIdx, emptyRetryAt) <-
+    (entries, startIdx, emptyExhaustion) <-
         atomicModifyIORef' pool.poolState selectStart
     case entries of
-        [] -> pure (Left (fromMaybe now emptyRetryAt))
+        [] -> pure (Left (fromMaybe (now, []) emptyExhaustion))
         _ -> do
             available <- tryFrom entries startIdx now 0
             case available of
                 Just entry -> pure (Right entry)
                 Nothing -> do
-                    expirations <- fmap catMaybes $ forM entries \entry ->
+                    cooldowns <- fmap catMaybes $ forM entries \entry ->
                         effectiveCooldown . (.accountCooldowns)
                             <$> readIORef entry.entryState
-                    case expirations of
-                        [] -> pure (Left now)
+                    case cooldowns of
+                        [] -> pure (Left (now, []))
                         (first : rest) ->
-                            pure (Left (minimum (first : rest)))
+                            let active = first : rest
+                            in pure $ Left
+                                ( minimum (map fst active)
+                                , nub (concatMap snd active)
+                                )
   where
     selectStart current =
         case current.stateEntries of
             [] ->
                 ( current
-                , ([], 0, current.stateEmptyRetryAt)
+                , ([], 0, current.stateEmptyExhaustion)
                 )
             entries ->
                 let n = length entries
@@ -465,7 +509,7 @@ pickAccount pool = do
                     nextCounter = (current.stateCounter + 1) `mod` n
                 in
                     ( current { stateCounter = nextCounter }
-                    , (entries, startIdx, current.stateEmptyRetryAt)
+                    , (entries, startIdx, current.stateEmptyExhaustion)
                     )
 
     tryFrom entries startIdx now offset
@@ -481,41 +525,73 @@ pickAccount pool = do
                 Just _ -> tryFrom entries startIdx now (offset + 1)
 
 reportRateLimit :: Pool -> Text -> Maybe Int -> IO ()
-reportRateLimit pool limitedAccountId retryAfter = do
+reportRateLimit pool limitedAccountId retryAfter =
+    reportRateLimitWithReason
+        pool
+        limitedAccountId
+        retryAfter
+        ExhaustedByRateLimit
+            { exhaustionErrorType = Nothing
+            , exhaustionStatusCode = Nothing
+            , exhaustionRetryAfter = retryAfter
+            }
+
+reportRateLimitWithReason
+    :: Pool
+    -> Text
+    -> Maybe Int
+    -> CredentialExhaustionReason
+    -> IO ()
+reportRateLimitWithReason pool limitedAccountId retryAfter reason = do
     now <- getCurrentTime
     let seconds = fromMaybe rateLimitCooldownSeconds retryAfter
         until_ = addUTCTime (fromIntegral seconds) now
     updateAccountLocked pool limitedAccountId \current ->
         current
             { accountCooldowns = current.accountCooldowns
-                { cooldownRateLimitUntil =
-                    extendCooldown until_
-                        current.accountCooldowns.cooldownRateLimitUntil
+                { cooldownRateLimit =
+                    extendCooldown until_ reason
+                        current.accountCooldowns.cooldownRateLimit
                 }
             }
 
 reportAuthBroken :: Pool -> Text -> IO ()
-reportAuthBroken pool brokenAccountId = do
+reportAuthBroken pool brokenAccountId =
+    reportAuthBrokenWithReason pool brokenAccountId genericAuthReason
+
+reportAuthBrokenWithReason
+    :: Pool
+    -> Text
+    -> CredentialExhaustionReason
+    -> IO ()
+reportAuthBrokenWithReason pool brokenAccountId reason = do
     now <- getCurrentTime
     updateAccountLocked pool brokenAccountId $
-        setAuthBrokenCooldownTransition now
+        setAuthBrokenCooldownTransition now reason
 
-setAuthBrokenCooldownAt :: Pool -> Text -> UTCTime -> IO ()
-setAuthBrokenCooldownAt pool accountId now =
-    updateAccount pool accountId (setAuthBrokenCooldownTransition now)
+setAuthBrokenCooldownAt
+    :: Pool
+    -> Text
+    -> UTCTime
+    -> CredentialExhaustionReason
+    -> IO ()
+setAuthBrokenCooldownAt pool accountId now reason =
+    updateAccount pool accountId
+        (setAuthBrokenCooldownTransition now reason)
 
 setAuthBrokenCooldownTransition
     :: UTCTime
+    -> CredentialExhaustionReason
     -> AccountState
     -> AccountState
-setAuthBrokenCooldownTransition now current =
+setAuthBrokenCooldownTransition now reason current =
     let until_ =
             addUTCTime (fromIntegral authFailureRetrySeconds) now
     in current
         { accountCooldowns = current.accountCooldowns
-            { cooldownAuthBrokenUntil =
-                extendCooldown until_
-                    current.accountCooldowns.cooldownAuthBrokenUntil
+            { cooldownAuthBroken =
+                extendCooldown until_ reason
+                    current.accountCooldowns.cooldownAuthBroken
             }
         }
 
@@ -537,7 +613,10 @@ refreshAfterAuthFailure pool rejectedAccountId =
                     Left err -> do
                         now <- getCurrentTime
                         setAuthBrokenCooldownAt
-                            pool rejectedAccountId now
+                            pool
+                            rejectedAccountId
+                            now
+                            (authReasonFromApiError err)
                         pure (Left err)
 
 -- | Recover a specifically rejected token. Recovery ownership and throttling
@@ -568,8 +647,11 @@ recoverAfterAuthFailure pool rejectedAccountId rejectedAccessToken =
                     AuthAlreadyRecovered current ->
                         pure (Right current)
                     AuthRecoveryCoolingDown retryAt -> do
-                        setAuthBrokenCooldownAt pool rejectedAccountId now
-                        pure (Left (CredentialsExhausted retryAt))
+                        setAuthBrokenCooldownAt
+                            pool rejectedAccountId now genericAuthReason
+                        pure $ Left $
+                            credentialsExhaustedWithReasons
+                                retryAt [genericAuthReason]
                     AuthRecoveryOwner stale ->
                         refreshEntryAfterAuthFailure
                             pool entry stale >>= \case
@@ -577,7 +659,10 @@ recoverAfterAuthFailure pool rejectedAccountId rejectedAccessToken =
                                 pure (Right refreshed)
                             Left err -> do
                                 setAuthBrokenCooldownAt
-                                    pool rejectedAccountId now
+                                    pool
+                                    rejectedAccountId
+                                    now
+                                    (authReasonFromApiError err)
                                 pure (Left err)
 
 data AuthRecoveryDecision
@@ -622,6 +707,7 @@ readAccountState pool targetAccountId =
 data AccountSnapshot = AccountSnapshot
     { snapshotAuth :: !AuthState
     , snapshotCooldownUntil :: !(Maybe UTCTime)
+    , snapshotCooldownReasons :: ![CredentialExhaustionReason]
     }
     deriving (Show)
 
@@ -633,7 +719,9 @@ snapshotAccounts pool = do
         pure AccountSnapshot
             { snapshotAuth = state.accountAuth
             , snapshotCooldownUntil =
-                effectiveCooldown state.accountCooldowns
+                fst <$> effectiveCooldown state.accountCooldowns
+            , snapshotCooldownReasons =
+                maybe [] snd (effectiveCooldown state.accountCooldowns)
             }
 
 getAccessTokenForAccount
@@ -655,8 +743,9 @@ getAccessTokenForAccount pool targetAccountId =
                         , effectiveCooldown updated.accountCooldowns
                         )
                 case cooldown of
-                    Just until_ ->
-                        pure (Left (CredentialsExhausted until_))
+                    Just (until_, reasons) ->
+                        pure $ Left $
+                            credentialsExhaustedWithReasons until_ reasons
                     Nothing -> do
                         state <- (.accountAuth) <$> readIORef entry.entryState
                         if needsRefresh state now
@@ -716,37 +805,64 @@ atomicModifyAccount entry =
 
 emptyCooldowns :: AccountCooldowns
 emptyCooldowns = AccountCooldowns
-    { cooldownRateLimitUntil = Nothing
-    , cooldownAuthBrokenUntil = Nothing
+    { cooldownRateLimit = Nothing
+    , cooldownAuthBroken = Nothing
     }
 
-extendCooldown :: UTCTime -> Maybe UTCTime -> Maybe UTCTime
-extendCooldown until_ =
-    Just . maybe until_ (max until_)
+extendCooldown
+    :: UTCTime
+    -> CredentialExhaustionReason
+    -> Maybe AccountCooldown
+    -> Maybe AccountCooldown
+extendCooldown until_ reason = \case
+    Just current
+        | current.cooldownUntil > until_ -> Just current
+    _ ->
+        Just AccountCooldown
+            { cooldownUntil = until_
+            , cooldownReason = reason
+            }
 
 expireCooldowns :: UTCTime -> AccountState -> AccountState
 expireCooldowns now current =
     current
         { accountCooldowns = AccountCooldowns
-            { cooldownRateLimitUntil =
-                keepFuture current.accountCooldowns.cooldownRateLimitUntil
-            , cooldownAuthBrokenUntil =
-                keepFuture current.accountCooldowns.cooldownAuthBrokenUntil
+            { cooldownRateLimit =
+                keepFuture current.accountCooldowns.cooldownRateLimit
+            , cooldownAuthBroken =
+                keepFuture current.accountCooldowns.cooldownAuthBroken
             }
         }
   where
     keepFuture cooldown
-        | maybe False (> now) cooldown = cooldown
+        | maybe False ((> now) . (.cooldownUntil)) cooldown = cooldown
         | otherwise = Nothing
 
-effectiveCooldown :: AccountCooldowns -> Maybe UTCTime
+effectiveCooldown
+    :: AccountCooldowns
+    -> Maybe (UTCTime, [CredentialExhaustionReason])
 effectiveCooldown cooldowns =
     case catMaybes
-        [ cooldowns.cooldownRateLimitUntil
-        , cooldowns.cooldownAuthBrokenUntil
+        [ cooldowns.cooldownRateLimit
+        , cooldowns.cooldownAuthBroken
         ] of
         [] -> Nothing
-        (first : rest) -> Just (maximum (first : rest))
+        active ->
+            Just
+                ( maximum (map (.cooldownUntil) active)
+                , nub (map (.cooldownReason) active)
+                )
+
+genericAuthReason :: CredentialExhaustionReason
+genericAuthReason = ExhaustedByAuthentication
+    { exhaustionErrorType = Nothing
+    , exhaustionStatusCode = Nothing
+    }
+
+authReasonFromApiError :: ApiError -> CredentialExhaustionReason
+authReasonFromApiError err =
+    fromMaybe genericAuthReason
+        (credentialExhaustionReasonFromApiError err)
 
 isAuthError :: ApiError -> Bool
 isAuthError (HttpError 401 _) = True

--- a/packages/agent-openai/src/Agent/OpenAI/Credential.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Credential.hs
@@ -7,7 +7,11 @@ module Agent.OpenAI.Credential
     ) where
 
 import qualified Agent.OpenAI.Auth as Auth
-import Agent.Error (ApiError(..), ErrorType(..))
+import Agent.Error
+    ( ApiError(..)
+    , CredentialExhaustionReason
+    , ErrorType(..)
+    )
 import Agent.Provider
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
@@ -21,16 +25,20 @@ poolTokenProviderWithBilling :: BillingMode -> Auth.Pool -> IO TokenProvider
 poolTokenProviderWithBilling billing pool =
     pure $ tokenProvider billing \failed -> case failed of
             Nothing -> acquireFromPool pool
-            Just FailedCredential { credential, failure } ->
+            Just FailedCredential { credential, failure, failureReason } ->
                 case failure of
                     AccountRateLimited { retryAfterSeconds } -> do
-                        Auth.reportRateLimit pool credential.accountId
+                        Auth.reportRateLimitWithReason
+                            pool
+                            credential.accountId
                             (max 1 <$> retryAfterSeconds)
+                            failureReason
                         acquireFromPool pool
                     AccountAuthenticationRejected -> do
                         state <- Auth.readAccountState pool credential.accountId
                         if maybe False (Text.null . (.refreshToken)) state
-                            then rejectStaticCredential pool credential.accountId
+                            then rejectStaticCredential
+                                pool credential.accountId failureReason
                             else do
                                 Auth.recoverAfterAuthFailure
                                     pool
@@ -41,10 +49,14 @@ poolTokenProviderWithBilling billing pool =
                                                 credentialFromAuthState refreshed
                                         Left _ -> acquireFromPool pool
 
-rejectStaticCredential :: Auth.Pool -> Text -> IO (Either ApiError Credential)
-rejectStaticCredential pool accountId = do
+rejectStaticCredential
+    :: Auth.Pool
+    -> Text
+    -> CredentialExhaustionReason
+    -> IO (Either ApiError Credential)
+rejectStaticCredential pool accountId reason = do
     accountIds <- Auth.allAccountIds pool
-    Auth.reportAuthBroken pool accountId
+    Auth.reportAuthBrokenWithReason pool accountId reason
     acquireFromPool pool >>= \case
         Left CredentialsExhausted{}
             | accountIds == [accountId] ->
@@ -64,12 +76,17 @@ staticBearerProvider apiKey = tokenProvider ApiBilled \failed -> case failed of
                 , leaseId = Nothing
                 , provider = OpenAIProvider
                 }
-        Just FailedCredential { failure = AccountRateLimited { retryAfterSeconds } } -> do
+        Just FailedCredential
+            { failure = AccountRateLimited { retryAfterSeconds }
+            , failureReason
+            } -> do
             now <- getCurrentTime
             let seconds = max 1
                     (fromMaybe staticBearerRateLimitCooldownSeconds retryAfterSeconds)
             pure $ Left $ CredentialsExhausted
-                (addUTCTime (fromIntegral seconds) now)
+                { retryAt = addUTCTime (fromIntegral seconds) now
+                , exhaustionReasons = [failureReason]
+                }
         Just FailedCredential { failure = AccountAuthenticationRejected } ->
             pure $ Left $ ProviderError AuthenticationError
                 "static bearer token was rejected"

--- a/packages/agent-openai/src/Agent/OpenAI/LoopBackend.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/LoopBackend.hs
@@ -45,6 +45,7 @@ import Agent.Provider
     , FailedCredential(..)
     , TokenProvider
     , accountFailureFromApiError
+    , accountFailureReason
     )
 import Agent.Responses.LoopBackend
     ( assistantTextFromResponse
@@ -172,12 +173,16 @@ openAiResponseSenderReconnectingWhen observed markObservedFailure provider
     sendCurrent request previousResponseId onEvent =
         sendWsRequestWithEvents conn request previousResponseId onEvent
     sendFresh previousFailure request previousResponseId onEvent =
-        case previousFailure >>= accountFailureFromApiError of
-            Just failure ->
+        case previousFailure >>= \err ->
+                (\failure ->
+                    (failure, accountFailureReason err failure))
+                    <$> accountFailureFromApiError err of
+            Just (failure, failureReason) ->
                 withCodexWsRetryingAfter provider
                     FailedCredential
                         { credential = currentCredential
                         , failure
+                        , failureReason
                         }
                     (sendOnFresh request previousResponseId onEvent)
             Nothing ->

--- a/packages/agent-openai/test/Agent/OpenAI/AuthSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/AuthSpec.hs
@@ -1,7 +1,12 @@
 module Agent.OpenAI.AuthSpec (spec) where
 
 import Agent.OpenAI.Auth
-import Agent.Error (ApiError(..), ErrorType(..))
+import Agent.Error
+    ( ApiError(..)
+    , CredentialExhaustionReason(..)
+    , ErrorType(..)
+    , credentialsExhausted
+    )
 import Control.Concurrent.Async (wait, withAsync)
 import Control.Concurrent.MVar
     ( newEmptyMVar
@@ -51,6 +56,7 @@ spec = do
                 snapshot = AccountSnapshot
                     { snapshotAuth = auth
                     , snapshotCooldownUntil = Just epoch
+                    , snapshotCooldownReasons = []
                     }
                 rendered = show snapshot
             rendered `shouldContain` "snapshot-account"
@@ -281,7 +287,14 @@ spec = do
             reportRateLimit pool "only-acc" (Just 60)
             result <- getAccessToken pool
             case result of
-                Left (CredentialsExhausted _) -> pure ()
+                Left CredentialsExhausted{exhaustionReasons} ->
+                    exhaustionReasons `shouldBe`
+                        [ ExhaustedByRateLimit
+                            { exhaustionErrorType = Nothing
+                            , exhaustionStatusCode = Nothing
+                            , exhaustionRetryAfter = Just 60
+                            }
+                        ]
                 other -> expectationFailure ("expected CredentialsExhausted, got " <> show other)
 
         it "discovers a broker account that became available after startup" $ do
@@ -379,17 +392,17 @@ spec = do
             result <- getAccessToken pool
 
             case result of
-                Left (CredentialsExhausted _) -> pure ()
+                Left CredentialsExhausted{} -> pure ()
                 other -> expectationFailure ("expected CredentialsExhausted, got " <> show other)
 
         it "starts empty at the broker reset and discovers capacity later" $ do
             let initialReset = UTCTime (fromGregorian 2026 7 18) 0
-            discoveryResult <- newIORef (Left (CredentialsExhausted initialReset))
+            discoveryResult <- newIORef (Left (credentialsExhausted initialReset))
             let discover _ = readIORef discoveryResult
             pool <- newUnavailableDiscoveringPool initialReset neverRefresh discover
 
             first <- getAccessToken pool
-            first `shouldBe` Left (CredentialsExhausted initialReset)
+            first `shouldBe` Left (credentialsExhausted initialReset)
             allAccountIds pool `shouldReturn` []
 
             writeIORef discoveryResult (Right [mkFreshAuth "capacity-returned"])
@@ -401,10 +414,11 @@ spec = do
         it "updates an empty pool when the broker reports a later reset" $ do
             let initialReset = UTCTime (fromGregorian 2026 7 18) 0
                 laterReset = UTCTime (fromGregorian 2026 7 21) 0
-                discover _ = pure (Left (CredentialsExhausted laterReset))
+                discover _ = pure (Left (credentialsExhausted laterReset))
             pool <- newUnavailableDiscoveringPool initialReset neverRefresh discover
 
-            getAccessToken pool `shouldReturn` Left (CredentialsExhausted laterReset)
+            getAccessToken pool
+                `shouldReturn` Left (credentialsExhausted laterReset)
 
     describe "reportAuthBroken" $ do
         it "cools the account down" $ do

--- a/packages/agent-openai/test/Agent/OpenAI/CredentialSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/CredentialSpec.hs
@@ -3,7 +3,11 @@ module Agent.OpenAI.CredentialSpec (spec) where
 import Agent.OpenAI.Auth (AuthState(..), newPool)
 import qualified Agent.OpenAI.Auth as Auth
 import Agent.OpenAI.Credential
-import Agent.Error (ApiError(..), ErrorType(..))
+import Agent.Error
+    ( ApiError(..)
+    , CredentialExhaustionReason(..)
+    , ErrorType(..)
+    )
 import Agent.Provider
 import qualified Data.Aeson as Aeson
 import Data.Aeson ((.=))
@@ -74,7 +78,15 @@ spec = do
             result `shouldBe` Right "acc-b"
             readIORef reportedFailures `shouldReturn`
                 [ Nothing
-                , failed (credentialFor "acc-a") (AccountRateLimited (Just 90))
+                , Just FailedCredential
+                    { credential = credentialFor "acc-a"
+                    , failure = AccountRateLimited (Just 90)
+                    , failureReason = ExhaustedByRateLimit
+                        { exhaustionErrorType = Just UsageLimitReached
+                        , exhaustionStatusCode = Nothing
+                        , exhaustionRetryAfter = Just 90
+                        }
+                    }
                 ]
 
         it "does not poison credentials after transport failures" do
@@ -155,6 +167,11 @@ spec = do
                 (Just FailedCredential
                     { credential = first
                     , failure = AccountRateLimited (Just 60)
+                    , failureReason = ExhaustedByRateLimit
+                        { exhaustionErrorType = Just RateLimitError
+                        , exhaustionStatusCode = Just 429
+                        , exhaustionRetryAfter = Just 60
+                        }
                     })
 
             second.accountId `shouldNotBe` first.accountId
@@ -370,7 +387,22 @@ expectCredential = \case
     Right credential -> pure credential
 
 failed :: Credential -> AccountFailure -> Maybe FailedCredential
-failed credential failure = Just FailedCredential { credential, failure }
+failed credential failure = Just FailedCredential
+    { credential
+    , failure
+    , failureReason = case failure of
+        AccountRateLimited{retryAfterSeconds} ->
+            ExhaustedByRateLimit
+                { exhaustionErrorType = Just RateLimitError
+                , exhaustionStatusCode = Nothing
+                , exhaustionRetryAfter = retryAfterSeconds
+                }
+        AccountAuthenticationRejected ->
+            ExhaustedByAuthentication
+                { exhaustionErrorType = Just AuthenticationError
+                , exhaustionStatusCode = Nothing
+                }
+    }
 
 credentialFor :: Text -> Credential
 credentialFor accountId = Credential

--- a/packages/agent-openai/test/Agent/OpenAI/ErrorSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/ErrorSpec.hs
@@ -53,7 +53,7 @@ spec = do
             isPreviousResponseIdError
                 (ProviderError RateLimitError "usage window exhausted" (Just 60))
                 `shouldBe` False
-            isPreviousResponseIdError (CredentialsExhausted epoch) `shouldBe` False
+            isPreviousResponseIdError (credentialsExhausted epoch) `shouldBe` False
 
     describe "isResponseChainCompatibilityError" do
         it "detects unsupported inherited prompt cache retention" do

--- a/packages/agent-openrouter/src/Agent/OpenRouter/Credential.hs
+++ b/packages/agent-openrouter/src/Agent/OpenRouter/Credential.hs
@@ -18,12 +18,17 @@ staticApiKeyProvider :: Text -> TokenProvider
 staticApiKeyProvider apiKey = tokenProvider ApiBilled \failed -> case failed of
         Nothing ->
             pure $ Right (credentialFromApiKey apiKey)
-        Just FailedCredential { failure = AccountRateLimited { retryAfterSeconds } } -> do
+        Just FailedCredential
+            { failure = AccountRateLimited { retryAfterSeconds }
+            , failureReason
+            } -> do
             now <- getCurrentTime
             let seconds = max 1
                     (fromMaybe staticApiKeyRateLimitCooldownSeconds retryAfterSeconds)
             pure $ Left $ CredentialsExhausted
-                (addUTCTime (fromIntegral seconds) now)
+                { retryAt = addUTCTime (fromIntegral seconds) now
+                , exhaustionReasons = [failureReason]
+                }
         Just FailedCredential { failure = AccountAuthenticationRejected } ->
             pure $ Left $ ProviderError AuthenticationError
                 "static OpenRouter API key was rejected"

--- a/packages/agent-openrouter/test/Agent/OpenRouter/CredentialSpec.hs
+++ b/packages/agent-openrouter/test/Agent/OpenRouter/CredentialSpec.hs
@@ -1,6 +1,10 @@
 module Agent.OpenRouter.CredentialSpec (spec) where
 
-import Agent.Error (ApiError(..), ErrorType(..))
+import Agent.Error
+    ( ApiError(..)
+    , CredentialExhaustionReason(..)
+    , ErrorType(..)
+    )
 import Agent.OpenRouter.Credential
 import Agent.Provider
 import Data.Time.Clock (addUTCTime, getCurrentTime)
@@ -28,6 +32,11 @@ spec = describe "staticApiKeyProvider" do
             (Just FailedCredential
                 { credential = first
                 , failure = AccountRateLimited (Just 90)
+                , failureReason = ExhaustedByRateLimit
+                    { exhaustionErrorType = Just RateLimitError
+                    , exhaustionStatusCode = Just 429
+                    , exhaustionRetryAfter = Just 90
+                    }
                 })
         case exhausted of
             Left CredentialsExhausted { retryAt } ->
@@ -41,6 +50,10 @@ spec = describe "staticApiKeyProvider" do
             (Just FailedCredential
                 { credential = first
                 , failure = AccountAuthenticationRejected
+                , failureReason = ExhaustedByAuthentication
+                    { exhaustionErrorType = Just AuthenticationError
+                    , exhaustionStatusCode = Just 401
+                    }
                 })
         case rejected of
             Left (ProviderError AuthenticationError _ _) -> pure ()


### PR DESCRIPTION
## Summary
- preserve redacted rate-limit/authentication causes when credentials enter cooldown
- surface those causes in CLI exhaustion errors without retaining provider bodies or tokens
- publish ephemeral provider cooldown/retry activity for running background sessions
- clear stale activity when a persisted session resumes

This makes failures like session `2026-08-23-2fd37618` distinguishable instead of collapsing every account failure into a generic 60-second `CredentialsExhausted` result.

## Validation
- multi-package library and test-component GHCi typecheck
- `agent-core`: 286 examples, 0 failures
- `agent-openai`: 213 examples, 0 failures, 1 pending live test
- `agent-openrouter`: 39 examples, 0 failures, 1 pending live test
- `agent-cli`: 780 examples, 0 failures
- live CLI prompt smoke-tested in tmux from the changed multi-package GHCi session
