### PR TITLE
fix(cli): select accounts by verified usage

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -43,6 +43,7 @@ library
     autogen-modules:  Paths_agent_cli
     other-modules:    Paths_agent_cli
     exposed-modules:  Agent.CLI
+                    , Agent.CLI.AccountSelection
                     , Agent.CLI.AgentSessions
                     , Agent.CLI.AgentViewport
                     , Agent.CLI.Approval
@@ -206,7 +207,8 @@ test-suite agent-cli-test
     type:             exitcode-stdio-1.0
     hs-source-dirs:   test
     main-is:          Spec.hs
-    other-modules:    Agent.CLI.ApprovalSpec
+    other-modules:    Agent.CLI.AccountSelectionSpec
+                    , Agent.CLI.ApprovalSpec
                     , Agent.CLI.AgentSessionsSpec
                     , Agent.CLI.ArtifactSpec
                     , Agent.CLI.AgentViewportSpec

--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -20,6 +20,7 @@ module Agent.CLI
 import Agent.CLI.Artifact (fencedCodeBlock, lastDiffBlock)
 import Agent.CLI.AccountSelection
     ( SelectedAccount(..)
+    , providerSupportsUsageAccountSelection
     , selectProviderAccount
     )
 import Agent.CLI.Auth
@@ -1413,6 +1414,10 @@ runAgentInitializedWithLock
                         , fromMaybe selectionId active.transitionAccountId
                         )
                     )
+            | not
+                (providerSupportsUsageAccountSelection
+                    initialLoaded.loadedProvider) ->
+                        pure (initialLoaded, Nothing)
             | otherwise -> do
                 let provider = initialLoaded.loadedProvider
                     rememberedIds = fmap
@@ -5837,9 +5842,9 @@ chooseAutomaticProviderTransition
                     pure $ Just ProviderTransition
                         { transitionTarget = choice.modelTarget
                         , transitionAccountSelectionId =
-                            Just selected.selectedSelectionId
+                            (.selectedSelectionId) <$> selected
                         , transitionAccountId =
-                            Just selected.selectedAccountId
+                            (.selectedAccountId) <$> selected
                         , transitionSessionId = sessionId
                         , transitionPendingTurn = Just pending
                         , transitionUnavailableProviders = unavailable
@@ -5891,9 +5896,9 @@ chooseStartupProviderTransition
                     pure $ Just ProviderTransition
                         { transitionTarget = choice.modelTarget
                         , transitionAccountSelectionId =
-                            Just selected.selectedSelectionId
+                            (.selectedSelectionId) <$> selected
                         , transitionAccountId =
-                            Just selected.selectedAccountId
+                            (.selectedAccountId) <$> selected
                         , transitionSessionId = sessionId
                         , transitionPendingTurn = Nothing
                         , transitionUnavailableProviders = unavailable
@@ -5937,51 +5942,57 @@ validateProviderTarget choice =
 validateAutomaticProviderTarget
     :: BillingMode
     -> ModelOption
-    -> IO (Either Text SelectedAccount)
+    -> IO (Either Text (Maybe SelectedAccount))
 validateAutomaticProviderTarget sourceBilling choice = do
-    cwd <- getCurrentDirectory
-    projectRoot <- resolveProjectRoot cwd
-    settings <- loadProjectSettings projectRoot
     let provider = choice.modelTarget.targetProvider
-        rememberedIds = fmap
-            (\account ->
-                ( account.projectAccountSelectionId
-                , account.projectAccountId
-                ))
-            (projectAccountFor provider settings)
-        requiredBilling = case sourceBilling of
-            SubscriptionBilled -> Just SubscriptionBilled
-            ApiBilled -> Nothing
-    selectProviderAccount
-        provider
-        requiredBilling
-        rememberedIds >>= \case
-            Left err -> pure (Left err)
-            Right selected ->
-                loadSelectedAccountAuth
-                    provider
-                    selected.selectedSelectionId
-                    selected.selectedAccountId >>= \case
-                        Left err -> pure (Left err)
-                        Right loaded ->
-                            probeLoadedAutomaticAvailability loaded >>= \case
-                                Left err -> do
-                                    now <- getCurrentTime
-                                    pure $ Left $
-                                        "cannot switch to "
-                                            <> providerSlug provider
-                                            <> ": "
-                                            <> formatApiErrorInlineAt now err
-                                Right usable
-                                    | allowsAutomaticBillingFallback
-                                        sourceBilling
-                                        (tokenProviderBillingMode
-                                            usable.loadedTokenProvider) ->
-                                            pure (Right selected)
-                                    | otherwise ->
-                                        pure $ Left
-                                            "automatic fallback from subscription \
-                                            \billing to API credits is disabled"
+    if not (providerSupportsUsageAccountSelection provider)
+        then fmap (Nothing <$) $
+            loadValidatedProviderTarget
+                probeLoadedAutomaticAvailability
+                choice
+        else do
+            cwd <- getCurrentDirectory
+            projectRoot <- resolveProjectRoot cwd
+            settings <- loadProjectSettings projectRoot
+            let rememberedIds = fmap
+                    (\account ->
+                        ( account.projectAccountSelectionId
+                        , account.projectAccountId
+                        ))
+                    (projectAccountFor provider settings)
+                requiredBilling = case sourceBilling of
+                    SubscriptionBilled -> Just SubscriptionBilled
+                    ApiBilled -> Nothing
+            selectProviderAccount
+                provider
+                requiredBilling
+                rememberedIds >>= \case
+                    Left err -> pure (Left err)
+                    Right selected ->
+                        loadSelectedAccountAuth
+                            provider
+                            selected.selectedSelectionId
+                            selected.selectedAccountId >>= \case
+                                Left err -> pure (Left err)
+                                Right loaded ->
+                                    probeLoadedAutomaticAvailability loaded >>= \case
+                                        Left err -> do
+                                            now <- getCurrentTime
+                                            pure $ Left $
+                                                "cannot switch to "
+                                                    <> providerSlug provider
+                                                    <> ": "
+                                                    <> formatApiErrorInlineAt now err
+                                        Right usable
+                                            | allowsAutomaticBillingFallback
+                                                sourceBilling
+                                                (tokenProviderBillingMode
+                                                    usable.loadedTokenProvider) ->
+                                                    pure (Right (Just selected))
+                                            | otherwise ->
+                                                pure $ Left
+                                                    "automatic fallback from subscription \
+                                                    \billing to API credits is disabled"
 
 loadValidatedProviderTarget
     :: (LoadedAuth -> IO (Either ApiError LoadedAuth))

--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -18,6 +18,10 @@ module Agent.CLI
     ) where
 
 import Agent.CLI.Artifact (fencedCodeBlock, lastDiffBlock)
+import Agent.CLI.AccountSelection
+    ( SelectedAccount(..)
+    , selectProviderAccount
+    )
 import Agent.CLI.Auth
     ( LoadedAuth(..)
     , authErrorNeedsOnboarding
@@ -185,11 +189,14 @@ import Agent.CLI.Progress
     , wrapOscForTmux
     )
 import Agent.CLI.Project
-    ( ProjectModel(..)
+    ( ProjectAccount(..)
+    , ProjectModel(..)
     , ProjectSettings(..)
     , loadProjectSettings
+    , projectAccountFor
     , projectModelProvider
     , resolveProjectRoot
+    , saveProjectAccount
     , saveProjectModel
     )
 import Agent.CLI.Prompt
@@ -205,7 +212,10 @@ import Agent.CLI.ProviderFallback
     , ProviderRecoveryPreference(..)
     , providerRecoveryPreference
     )
-import Agent.CLI.ProviderAvailability (probeLoadedAvailability)
+import Agent.CLI.ProviderAvailability
+    ( probeLoadedAutomaticAvailability
+    , probeLoadedAvailability
+    )
 import Agent.CLI.ProviderTransition
     ( PendingTurn(..)
     , ProviderTransition(..)
@@ -213,6 +223,7 @@ import Agent.CLI.ProviderTransition
     , TurnResult(..)
     , applyProviderTransition
     , setPendingExitAfter
+    , transitionCommitsImmediately
     )
 import Agent.CLI.SessionState (SessionState(..), newSessionState)
 import Agent.CLI.Render
@@ -1348,7 +1359,7 @@ runAgentInitializedWithLock
                 CustomResponsesConnection responses -> Just
                     (connection.connectionId, responses)
                 BuiltinConnection _ -> Nothing
-    (loaded, customBearerToken) <- case customResponses of
+    (initialLoaded, customBearerToken) <- case customResponses of
         Nothing -> do
             builtinLoaded <-
                 loadStartupAuth startup transition requestedProvider
@@ -1390,6 +1401,47 @@ runAgentInitializedWithLock
                     }
                 , if Text.null token then Nothing else Just token
                 )
+    (loaded, startupAccountIds) <- case customResponses of
+        Just _ -> pure (initialLoaded, Nothing)
+        Nothing
+            | Just active <- transition
+            , Just selectionId <- active.transitionAccountSelectionId ->
+                pure
+                    ( initialLoaded
+                    , Just
+                        ( selectionId
+                        , fromMaybe selectionId active.transitionAccountId
+                        )
+                    )
+            | otherwise -> do
+                let provider = initialLoaded.loadedProvider
+                    rememberedIds = fmap
+                        (\account ->
+                            ( account.projectAccountSelectionId
+                            , account.projectAccountId
+                            ))
+                        (projectAccountFor provider projectSettings)
+                selectProviderAccount
+                    provider
+                    Nothing
+                    rememberedIds >>= \case
+                        Left err ->
+                            startupDie startup (Text.unpack err)
+                        Right selected ->
+                            loadSelectedAccountAuth
+                                provider
+                                selected.selectedSelectionId
+                                selected.selectedAccountId
+                                >>= either
+                                    (startupDie startup . Text.unpack)
+                                    (\selectedLoaded ->
+                                        pure
+                                            ( selectedLoaded
+                                            , Just
+                                                ( selected.selectedSelectionId
+                                                , selected.selectedAccountId
+                                                )
+                                            ))
     case (transitionTarget, resumed) of
         (Just target, _)
             | loaded.loadedProvider /= target.targetProvider ->
@@ -1415,9 +1467,20 @@ runAgentInitializedWithLock
                     \billing to API-credit billing"
         _ -> pure ()
     activeAccountRef <- newIORef ""
-    activeAccountIdRef <- newIORef ""
-    activeSelectionRef <- newIORef ""
-    preferredOpenAiAccountRef <- newIORef Nothing
+    activeAccountIdRef <-
+        newIORef (maybe "" snd startupAccountIds)
+    activeSelectionRef <-
+        newIORef $
+            maybe
+                (fromMaybe "" loaded.loadedSelectionId)
+                fst
+                startupAccountIds
+    preferredOpenAiAccountRef <-
+        newIORef $
+            case (loaded.loadedProvider, startupAccountIds) of
+                (OpenAIProvider, Just (_, accountId))
+                    | not (Text.null accountId) -> Just accountId
+                _ -> Nothing
     let selectableTokenProvider =
             case loaded.loadedOpenAiPool of
                 Just pool ->
@@ -2496,8 +2559,10 @@ trackCredentialAccount accountRef accountIdRef selectionRef resolveLabel provide
         getNextToken provider failed >>= \case
             Left err -> pure (Left err)
             Right credential -> do
+                previousAccountId <- readIORef accountIdRef
                 writeIORef accountIdRef credential.accountId
-                writeIORef selectionRef credential.accountId
+                when (previousAccountId /= credential.accountId) $
+                    writeIORef selectionRef credential.accountId
                 resolveLabel credential >>= writeIORef accountRef
                 pure (Right credential)
 
@@ -3456,6 +3521,16 @@ finishTurnWithCooldownRetry
 finishTurnWithCooldownRetry allowCooldownRetry env exitAfter = \case
     TurnSucceeded -> do
         writeIORef env.sessionUnavailableProviders []
+        selectionId <- readIORef env.sessionAccountSelectionId
+        accountId <- readIORef env.sessionAccountId
+        when
+            (not (Text.null (Text.strip selectionId))
+                && not (Text.null (Text.strip accountId))) $
+            saveProjectAccount
+                env.sessionProjectRoot
+                env.sessionProvider
+                selectionId
+                accountId
         case env.sessionFullscreen of
             Nothing -> putTrailingNewline env.sessionPrinted
             Just _ -> pure ()
@@ -5745,7 +5820,7 @@ chooseAutomaticProviderTransition
                     tryCandidates
                         (markUnavailable choice.modelTarget.targetProvider unavailable)
                         rest
-                Right () -> do
+                Right selected -> do
                     let message =
                             providerSlug current
                             <> " unavailable; trying this turn with "
@@ -5761,8 +5836,10 @@ chooseAutomaticProviderTransition
                             emitUiEvent runtime (UiSystemMessage message)
                     pure $ Just ProviderTransition
                         { transitionTarget = choice.modelTarget
-                        , transitionAccountSelectionId = Nothing
-                        , transitionAccountId = Nothing
+                        , transitionAccountSelectionId =
+                            Just selected.selectedSelectionId
+                        , transitionAccountId =
+                            Just selected.selectedAccountId
                         , transitionSessionId = sessionId
                         , transitionPendingTurn = Just pending
                         , transitionUnavailableProviders = unavailable
@@ -5802,7 +5879,7 @@ chooseStartupProviderTransition
                     tryCandidates
                         (markUnavailable choice.modelTarget.targetProvider unavailable)
                         rest
-                Right () -> do
+                Right selected -> do
                     let message =
                             providerSlug current
                             <> " account unavailable; switched to "
@@ -5813,8 +5890,10 @@ chooseStartupProviderTransition
                         emitUiEvent runtime (UiSystemMessage message)
                     pure $ Just ProviderTransition
                         { transitionTarget = choice.modelTarget
-                        , transitionAccountSelectionId = Nothing
-                        , transitionAccountId = Nothing
+                        , transitionAccountSelectionId =
+                            Just selected.selectedSelectionId
+                        , transitionAccountId =
+                            Just selected.selectedAccountId
                         , transitionSessionId = sessionId
                         , transitionPendingTurn = Nothing
                         , transitionUnavailableProviders = unavailable
@@ -5852,27 +5931,63 @@ validateProviderTarget choice =
         `notElem` map builtinConnectionId
             [OpenAIProvider, XAIProvider, OpenRouterProvider]
     then pure (Right ())
-    else fmap (() <$) (loadValidatedProviderTarget choice)
+    else fmap (() <$) $
+        loadValidatedProviderTarget probeLoadedAvailability choice
 
 validateAutomaticProviderTarget
     :: BillingMode
     -> ModelOption
-    -> IO (Either Text ())
-validateAutomaticProviderTarget sourceBilling choice =
-    loadValidatedProviderTarget choice >>= \case
-        Left err -> pure (Left err)
-        Right loaded
-            | allowsAutomaticBillingFallback
-                sourceBilling
-                (tokenProviderBillingMode loaded.loadedTokenProvider) ->
-                    pure (Right ())
-            | otherwise ->
-                pure $ Left
-                    "automatic fallback from subscription billing to API \
-                    \credits is disabled"
+    -> IO (Either Text SelectedAccount)
+validateAutomaticProviderTarget sourceBilling choice = do
+    cwd <- getCurrentDirectory
+    projectRoot <- resolveProjectRoot cwd
+    settings <- loadProjectSettings projectRoot
+    let provider = choice.modelTarget.targetProvider
+        rememberedIds = fmap
+            (\account ->
+                ( account.projectAccountSelectionId
+                , account.projectAccountId
+                ))
+            (projectAccountFor provider settings)
+        requiredBilling = case sourceBilling of
+            SubscriptionBilled -> Just SubscriptionBilled
+            ApiBilled -> Nothing
+    selectProviderAccount
+        provider
+        requiredBilling
+        rememberedIds >>= \case
+            Left err -> pure (Left err)
+            Right selected ->
+                loadSelectedAccountAuth
+                    provider
+                    selected.selectedSelectionId
+                    selected.selectedAccountId >>= \case
+                        Left err -> pure (Left err)
+                        Right loaded ->
+                            probeLoadedAutomaticAvailability loaded >>= \case
+                                Left err -> do
+                                    now <- getCurrentTime
+                                    pure $ Left $
+                                        "cannot switch to "
+                                            <> providerSlug provider
+                                            <> ": "
+                                            <> formatApiErrorInlineAt now err
+                                Right usable
+                                    | allowsAutomaticBillingFallback
+                                        sourceBilling
+                                        (tokenProviderBillingMode
+                                            usable.loadedTokenProvider) ->
+                                            pure (Right selected)
+                                    | otherwise ->
+                                        pure $ Left
+                                            "automatic fallback from subscription \
+                                            \billing to API credits is disabled"
 
-loadValidatedProviderTarget :: ModelOption -> IO (Either Text LoadedAuth)
-loadValidatedProviderTarget choice =
+loadValidatedProviderTarget
+    :: (LoadedAuth -> IO (Either ApiError LoadedAuth))
+    -> ModelOption
+    -> IO (Either Text LoadedAuth)
+loadValidatedProviderTarget probeAvailability choice =
     if not
         (providerSupportsDialect
             choice.modelTarget.targetProvider
@@ -5890,7 +6005,7 @@ loadValidatedProviderTarget choice =
                 <> ": "
                 <> err
         Right loaded ->
-            probeLoadedAvailability loaded >>= \case
+            probeAvailability loaded >>= \case
                 Left err -> do
                     now <- getCurrentTime
                     pure $ Left $
@@ -5963,8 +6078,7 @@ prepareTransitionBackend
     -> IO Backend
 prepareTransitionBackend _ Nothing _ backend = pure backend
 prepareTransitionBackend projectRoot (Just transition) persist backend
-    | transition.transitionCause == ManualTransition
-        || isNothing transition.transitionPendingTurn = do
+    | transitionCommitsImmediately transition = do
         commitProviderTransition projectRoot (Just transition) persist
         pure backend
     | otherwise = do

--- a/packages/agent-cli/src/Agent/CLI/AccountSelection.hs
+++ b/packages/agent-cli/src/Agent/CLI/AccountSelection.hs
@@ -3,6 +3,7 @@ module Agent.CLI.AccountSelection
     ( AccountCandidate(..)
     , SelectedAccount(..)
     , accountCapacity
+    , providerSupportsUsageAccountSelection
     , selectCandidates
     , selectAccount
     , selectProviderAccount
@@ -46,6 +47,16 @@ data SelectedAccount = SelectedAccount
     , selectedLabel :: !Text
     }
     deriving (Eq, Show)
+
+-- | Providers whose credentials can be enumerated and compared through a
+-- provider usage endpoint. Claude Code owns authentication inside its CLI and
+-- therefore keeps the already-loaded auth instead.
+providerSupportsUsageAccountSelection :: Provider -> Bool
+providerSupportsUsageAccountSelection = \case
+    OpenAIProvider -> True
+    XAIProvider -> True
+    OpenRouterProvider -> True
+    ClaudeCodeProvider -> False
 
 -- | Provider-neutral input to the pure account ranking policy. A missing
 -- capacity means that the account could not be verified.
@@ -117,8 +128,7 @@ selectAccount remembered accounts =
         }
 
 -- | Pure ranking policy: a usable remembered account wins. Otherwise choose
--- the greatest capacity, with stable identifiers providing deterministic
--- tie-breaking.
+-- the greatest capacity, preserving discovery order for ties.
 selectCandidates
     :: Maybe (Text, Text)
     -> [AccountCandidate]
@@ -156,9 +166,17 @@ accountCapacity account = case account.loginUsage of
                     else Just (fromIntegral (100 - max 0 used))
             [] -> case usage.creditsRemaining >>= parseAmount of
                 Just remaining
+                    | remaining <= 0
+                    , isFreeTier usage -> Just 1
                     | remaining <= 0 -> Nothing
                     | otherwise -> Just remaining
                 Nothing -> Nothing
+
+isFreeTier :: AccountUsage -> Bool
+isFreeTier usage =
+    maybe False
+        ((== "free tier") . Text.toCaseFold . Text.strip)
+        usage.usagePlan
 
 billingMode :: AccountBilling -> BillingMode
 billingMode = \case

--- a/packages/agent-cli/src/Agent/CLI/AccountSelection.hs
+++ b/packages/agent-cli/src/Agent/CLI/AccountSelection.hs
@@ -1,0 +1,212 @@
+-- | Usage-aware account selection for automatic startup and provider fallback.
+module Agent.CLI.AccountSelection
+    ( AccountCandidate(..)
+    , SelectedAccount(..)
+    , accountCapacity
+    , selectCandidates
+    , selectAccount
+    , selectProviderAccount
+    ) where
+
+import Agent.CLI.Login
+    ( AccountBilling(..)
+    , AccountUsage(..)
+    , LoginAccount(..)
+    , UsageState(..)
+    , UsageWindow(..)
+    , discoverSelectableLoginAccounts
+    , loginAccountSelectionId
+    , refreshLoginAccount
+    )
+import Agent.CLI.Auth
+    ( LoadedAuth(..)
+    , loadAuth
+    , loadAuthForAccount
+    , probeLoadedAuthCredential
+    )
+import qualified Agent.OpenAI.Auth as OpenAI
+import Agent.Provider
+    ( BillingMode(..)
+    , Credential(..)
+    , Provider(..)
+    , providerSlug
+    )
+import Control.Concurrent.Async (mapConcurrently)
+import Data.List (find, sortOn)
+import Data.Ord (Down(..))
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Text.Read (readMaybe)
+
+data SelectedAccount = SelectedAccount
+    { selectedProvider :: !Provider
+    , selectedSelectionId :: !Text
+    , selectedAccountId :: !Text
+    , selectedBillingMode :: !BillingMode
+    , selectedLabel :: !Text
+    }
+    deriving (Eq, Show)
+
+-- | Provider-neutral input to the pure account ranking policy. A missing
+-- capacity means that the account could not be verified.
+data AccountCandidate = AccountCandidate
+    { candidateProvider :: !Provider
+    , candidateSelectionId :: !Text
+    , candidateAccountId :: !Text
+    , candidateBillingMode :: !BillingMode
+    , candidateLabel :: !Text
+    , candidateCapacity :: !(Maybe Double)
+    }
+    deriving (Eq, Show)
+
+-- | Discover and check every enabled account for one provider. Automatic
+-- selection only considers accounts whose usage endpoint returned a usable
+-- result.
+selectProviderAccount
+    :: Provider
+    -> Maybe BillingMode
+    -> Maybe (Text, Text)
+    -> IO (Either Text SelectedAccount)
+selectProviderAccount provider requiredBilling remembered = do
+    providerAccounts <-
+        filter
+            ((== provider) . (.loginProvider))
+            <$> discoverSelectableLoginAccounts
+    let billingAccounts = case requiredBilling of
+            Just required ->
+                filter ((== required) . billingMode . (.loginBilling))
+                    providerAccounts
+            Nothing ->
+                let subscription =
+                        filter
+                            ((== SubscriptionBilled)
+                                . billingMode . (.loginBilling))
+                            providerAccounts
+                in if null subscription then providerAccounts else subscription
+    checked <- mapConcurrently refreshSelectableAccount billingAccounts
+    pure $ case selectAccount remembered checked of
+        Just selected -> Right selected
+        Nothing -> Left $
+            "no "
+                <> providerSlug provider
+                <> " account has verified available usage"
+
+-- | Prefer the remembered project account when it is usable; otherwise choose
+-- the account with the greatest provider-local remaining-capacity score.
+selectAccount
+    :: Maybe (Text, Text)
+    -> [LoginAccount]
+    -> Maybe SelectedAccount
+selectAccount remembered accounts =
+    toSelected <$> selectCandidates remembered (map toCandidate accounts)
+  where
+    toCandidate account = AccountCandidate
+        { candidateProvider = account.loginProvider
+        , candidateSelectionId = loginAccountSelectionId account
+        , candidateAccountId = account.loginAccountId
+        , candidateBillingMode = billingMode account.loginBilling
+        , candidateLabel = account.loginLabel
+        , candidateCapacity = accountCapacity account
+        }
+    toSelected candidate = SelectedAccount
+        { selectedProvider = candidate.candidateProvider
+        , selectedSelectionId = candidate.candidateSelectionId
+        , selectedAccountId = candidate.candidateAccountId
+        , selectedBillingMode = candidate.candidateBillingMode
+        , selectedLabel = candidate.candidateLabel
+        }
+
+-- | Pure ranking policy: a usable remembered account wins. Otherwise choose
+-- the greatest capacity, with stable identifiers providing deterministic
+-- tie-breaking.
+selectCandidates
+    :: Maybe (Text, Text)
+    -> [AccountCandidate]
+    -> Maybe AccountCandidate
+selectCandidates remembered candidates =
+    case remembered >>= rememberedCandidate usable of
+        Just candidate -> Just candidate
+        Nothing -> case sortOn ranking usable of
+            candidate : _ -> Just candidate
+            [] -> Nothing
+  where
+    usable = filter (maybe False (> 0) . (.candidateCapacity)) candidates
+    rememberedCandidate available (selectionId, accountId) =
+        find
+            (\candidate ->
+                candidate.candidateAccountId == accountId
+                    && (candidate.candidateSelectionId == selectionId
+                        || selectionId == accountId))
+            available
+    ranking candidate = Down <$> candidate.candidateCapacity
+
+-- | Provider-local capacity score. Subscription accounts use their tightest
+-- active percentage window. Credit accounts use known remaining credit/key
+-- capacity. Missing capacity data is treated as unverifiable.
+accountCapacity :: LoginAccount -> Maybe Double
+accountCapacity account = case account.loginUsage of
+    UsageNotChecked -> Nothing
+    UsageUnavailable _ -> Nothing
+    UsageAvailable usage ->
+        case usage.usageWindows of
+            window : windows ->
+                let used = maximum (map (.usedPercent) (window : windows))
+                in if used >= 100
+                    then Nothing
+                    else Just (fromIntegral (100 - max 0 used))
+            [] -> case usage.creditsRemaining >>= parseAmount of
+                Just remaining
+                    | remaining <= 0 -> Nothing
+                    | otherwise -> Just remaining
+                Nothing -> Nothing
+
+billingMode :: AccountBilling -> BillingMode
+billingMode = \case
+    SubscriptionBilling _ -> SubscriptionBilled
+    ApiCreditsBilling -> ApiBilled
+
+parseAmount :: Text -> Maybe Double
+parseAmount =
+    readMaybe . Text.unpack . Text.dropWhile (`elem` ("$ " :: String))
+
+refreshSelectableAccount :: LoginAccount -> IO LoginAccount
+refreshSelectableAccount account =
+    refreshCredential account >>= \case
+        Left err ->
+            pure account { loginUsage = UsageUnavailable err }
+        Right refreshed ->
+            refreshLoginAccount refreshed
+  where
+    refreshCredential candidate = case candidate.loginProvider of
+        OpenAIProvider ->
+            loadAuth (Just OpenAIProvider) >>= \case
+                Left err -> pure (Left err)
+                Right loaded -> case loaded.loadedOpenAiPool of
+                    Nothing ->
+                        pure (Left "OpenAI account pool is unavailable")
+                    Just pool ->
+                        OpenAI.getAccessTokenForAccount
+                            pool candidate.loginAccountId >>= \case
+                                Left err ->
+                                    pure (Left (Text.pack (show err)))
+                                Right (token, accountId) ->
+                                    pure $ Right candidate
+                                        { loginAccessToken = token
+                                        , loginAccountId = accountId
+                                        }
+        provider ->
+            loadAuthForAccount
+                provider
+                (loginAccountSelectionId candidate) >>= \case
+                    Left err -> pure (Left err)
+                    Right loaded ->
+                        probeLoadedAuthCredential loaded >>= \case
+                            Left err -> pure (Left (Text.pack (show err)))
+                            Right (credential, _) ->
+                                pure $ Right candidate
+                                    { loginAccessToken =
+                                        credential.accessToken
+                                    , loginAccountId =
+                                        credential.accountId
+                                    }
+

--- a/packages/agent-cli/src/Agent/CLI/Login.hs
+++ b/packages/agent-cli/src/Agent/CLI/Login.hs
@@ -65,7 +65,12 @@ import qualified Agent.OpenAI.Login as OpenAILogin
 import Agent.OsPath (toText, unsafeToFilePath)
 import qualified Agent.OpenAI.Usage as OpenAI
 import qualified Agent.OpenRouter.Usage as OpenRouter
-import Agent.Provider (BillingMode(..), Provider(..), providerSlug)
+import Agent.Provider
+    ( BillingMode(..)
+    , Credential(..)
+    , Provider(..)
+    , providerSlug
+    )
 import qualified Agent.XAI.Auth as XAIAuth
 import qualified Agent.XAI.Usage as XAI
 import Control.Applicative ((<|>))
@@ -858,7 +863,12 @@ refreshLoginAccount account
                                         (openAIUsage snapshot)
                                 }
         XAIProvider ->
-            XAI.fetchGrokUsage account.loginAccessToken >>= \case
+            XAI.fetchGrokUsage Credential
+                { accessToken = account.loginAccessToken
+                , accountId = account.loginAccountId
+                , leaseId = Nothing
+                , provider = XAIProvider
+                } >>= \case
                 Left err ->
                     pure account
                         { loginUsage = UsageUnavailable err }

--- a/packages/agent-cli/src/Agent/CLI/Project.hs
+++ b/packages/agent-cli/src/Agent/CLI/Project.hs
@@ -1,15 +1,18 @@
 -- | Project-scoped settings under @<project>/.haskell-agent/settings.json@.
 module Agent.CLI.Project
-    ( ProjectModel(..)
+    ( ProjectAccount(..)
+    , ProjectModel(..)
     , ProjectSettings(..)
     , defaultProjectSettings
     , loadProjectSettings
     , projectDialectFor
+    , projectAccountFor
     , projectModelFor
     , projectModelProvider
     , projectSettingsPath
     , resolveProjectRoot
     , saveProjectAutoApprove
+    , saveProjectAccount
     , saveProjectModel
     ) where
 
@@ -33,6 +36,7 @@ import Data.Aeson
     , withObject
     , (.:)
     , (.:?)
+    , (.!=)
     , (.=)
     )
 import qualified Data.Aeson as Aeson
@@ -40,7 +44,7 @@ import Data.Aeson.Types (parseMaybe)
 import qualified Data.ByteString.Lazy as LBS
 import Data.Char (isSpace)
 import Data.List (dropWhileEnd)
-import Data.Maybe (fromMaybe)
+import Data.Maybe (fromMaybe, mapMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import System.Directory.OsPath
@@ -67,10 +71,19 @@ data ProjectModel = ProjectModel
     { projectModelTarget :: !ModelTarget
     } deriving (Eq, Show)
 
+-- | Stable account identity remembered for one project/provider.  Secrets and
+-- usage responses are deliberately excluded.
+data ProjectAccount = ProjectAccount
+    { projectAccountProvider :: !Provider
+    , projectAccountSelectionId :: !Text
+    , projectAccountId :: !Text
+    } deriving (Eq, Show)
+
 data ProjectSettings = ProjectSettings
     { settingsVersion :: !Int
     , settingsAutoApprove :: !Bool
     , settingsLastModel :: !(Maybe ProjectModel)
+    , settingsLastAccounts :: ![ProjectAccount]
     } deriving (Eq, Show)
 
 defaultProjectSettings :: ProjectSettings
@@ -78,7 +91,31 @@ defaultProjectSettings = ProjectSettings
     { settingsVersion = settingsSchemaVersion
     , settingsAutoApprove = False
     , settingsLastModel = Nothing
+    , settingsLastAccounts = []
     }
+
+instance ToJSON ProjectAccount where
+    toJSON account = object
+        [ "provider" .= providerSlug account.projectAccountProvider
+        , "selectionId" .= account.projectAccountSelectionId
+        , "accountId" .= account.projectAccountId
+        ]
+
+instance FromJSON ProjectAccount where
+    parseJSON = withObject "ProjectAccount" \o -> do
+        providerText <- o .: "provider"
+        provider <- case parseProvider providerText of
+            Just parsed -> pure parsed
+            Nothing -> fail ("unknown provider: " <> Text.unpack providerText)
+        selectionId <- o .: "selectionId"
+        accountId <- o .:? "accountId" .!= ""
+        if Text.null (Text.strip selectionId)
+            then fail "account selection id must not be empty"
+            else pure ProjectAccount
+                { projectAccountProvider = provider
+                , projectAccountSelectionId = selectionId
+                , projectAccountId = accountId
+                }
 
 instance ToJSON ProjectModel where
     toJSON model = object
@@ -132,6 +169,7 @@ instance ToJSON ProjectSettings where
         [ "version" .= settings.settingsVersion
         , "autoApprove" .= settings.settingsAutoApprove
         , "lastModel" .= settings.settingsLastModel
+        , "lastAccounts" .= settings.settingsLastAccounts
         ]
 
 instance FromJSON ProjectSettings where
@@ -139,6 +177,7 @@ instance FromJSON ProjectSettings where
         version <- fromMaybe settingsSchemaVersion <$> o .:? "version"
         autoApprove <- fromMaybe False <$> o .:? "autoApprove"
         lastModelValue <- o .:? "lastModel"
+        lastAccountsValue <- o .:? "lastAccounts"
         pure ProjectSettings
             { settingsVersion = version
             , settingsAutoApprove = autoApprove
@@ -146,6 +185,8 @@ instance FromJSON ProjectSettings where
             -- unrelated project settings such as auto-approve.
             , settingsLastModel =
                 lastModelValue >>= parseMaybe parseJSON
+            , settingsLastAccounts =
+                maybe [] (mapMaybe (parseMaybe parseJSON)) lastAccountsValue
             }
 
 -- | Settings root for the checkout that contains @cwd@.
@@ -180,6 +221,38 @@ saveProjectAutoApprove :: OsPath -> Bool -> IO ()
 saveProjectAutoApprove projectRoot autoApprove =
     updateProjectSettings projectRoot \settings ->
         settings { settingsAutoApprove = autoApprove }
+
+-- | Remember the last successfully used account for a provider.
+saveProjectAccount
+    :: OsPath
+    -> Provider
+    -> Text
+    -> Text
+    -> IO ()
+saveProjectAccount projectRoot provider selectionId accountId =
+    updateProjectSettings projectRoot \settings ->
+        settings
+            { settingsLastAccounts =
+                ProjectAccount
+                    { projectAccountProvider = provider
+                    , projectAccountSelectionId = selectionId
+                    , projectAccountId = accountId
+                    }
+                    : filter
+                        ((/= provider) . (.projectAccountProvider))
+                        settings.settingsLastAccounts
+            }
+
+projectAccountFor
+    :: Provider
+    -> ProjectSettings
+    -> Maybe ProjectAccount
+projectAccountFor provider settings =
+    case filter
+        ((== provider) . (.projectAccountProvider))
+        settings.settingsLastAccounts of
+        account : _ -> Just account
+        [] -> Nothing
 
 -- | Remember the most recently selected provider/model pair for this project.
 saveProjectModel

--- a/packages/agent-cli/src/Agent/CLI/ProviderAvailability.hs
+++ b/packages/agent-cli/src/Agent/CLI/ProviderAvailability.hs
@@ -7,6 +7,8 @@
 module Agent.CLI.ProviderAvailability
     ( openAiUsageFailure
     , openRouterUsageFailure
+    , probeLoadedAutomaticAvailability
+    , probeLoadedAutomaticAvailabilityWith
     , probeLoadedAvailability
     , probeLoadedAvailabilityWith
     , xaiUsageFailure
@@ -40,7 +42,7 @@ probeLoadedAvailability loaded =
     checkCredential credential = case credential.provider of
         XAIProvider
             | billing == SubscriptionBilled ->
-                XAI.fetchGrokUsage credential.accessToken >>= \case
+                XAI.fetchGrokUsage credential >>= \case
                     Left _ -> pure Nothing
                     Right snapshot -> do
                         now <- getCurrentTime
@@ -62,6 +64,40 @@ probeLoadedAvailability loaded =
                 Left _ -> pure Nothing
                 Right snapshot -> pure (openRouterUsageFailure snapshot)
         _ -> pure Nothing
+
+-- | Automatic fallback must not send a model request merely because the Grok
+-- usage endpoint could not be checked. Manual selection and ordinary startup
+-- keep the tolerant probe above, but fallback requires a conclusive billing
+-- response and skips xAI when that response is unavailable or unreadable.
+probeLoadedAutomaticAvailability
+    :: LoadedAuth
+    -> IO (Either ApiError LoadedAuth)
+probeLoadedAutomaticAvailability loaded
+    | loaded.loadedProvider == XAIProvider
+        , tokenProviderBillingMode loaded.loadedTokenProvider
+            == SubscriptionBilled =
+                probeLoadedAutomaticAvailabilityWith check loaded
+    | otherwise = probeLoadedAvailability loaded
+  where
+    check credential =
+        XAI.fetchGrokUsage credential >>= \case
+            Left err -> pure (Left err)
+            Right snapshot -> do
+                now <- getCurrentTime
+                pure (Right (xaiUsageFailure now snapshot))
+
+-- | Injectable strict usage probe used by automatic Grok fallback.
+probeLoadedAutomaticAvailabilityWith
+    :: (Credential -> IO (Either Text (Maybe ApiError)))
+    -> LoadedAuth
+    -> IO (Either ApiError LoadedAuth)
+probeLoadedAutomaticAvailabilityWith check =
+    probeLoadedAvailabilityWith \credential ->
+        check credential >>= \case
+            Left err ->
+                pure $ Just $ ConnectionError
+                    ("Could not verify Grok usage: " <> err)
+            Right failure -> pure failure
 
 -- | Injectable core used by tests. Returning 'Nothing' means the credential
 -- is usable or the remote check was inconclusive. A returned provider error is

--- a/packages/agent-cli/src/Agent/CLI/ProviderTransition.hs
+++ b/packages/agent-cli/src/Agent/CLI/ProviderTransition.hs
@@ -6,6 +6,7 @@ module Agent.CLI.ProviderTransition
     , TurnResult(..)
     , applyProviderTransition
     , setPendingExitAfter
+    , transitionCommitsImmediately
     ) where
 
 import Agent.CLI.Models (ModelTarget(..))
@@ -69,3 +70,10 @@ applyProviderTransition options transition =
 setPendingExitAfter :: Bool -> PendingTurn -> PendingTurn
 setPendingExitAfter exitAfter pending =
     pending { pendingExitAfter = exitAfter }
+
+-- | Manual selections become the project/session target immediately.
+-- Automatic fallbacks remain provisional until their replacement backend
+-- completes a request successfully, including fallbacks chosen at startup.
+transitionCommitsImmediately :: ProviderTransition -> Bool
+transitionCommitsImmediately transition =
+    transition.transitionCause == ManualTransition

--- a/packages/agent-cli/test/Agent/CLI/AccountSelectionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/AccountSelectionSpec.hs
@@ -1,0 +1,109 @@
+module Agent.CLI.AccountSelectionSpec (spec) where
+
+import Agent.CLI.AccountSelection
+import Agent.CLI.CredentialStore (ManagedAuthKind(..))
+import Agent.CLI.Login
+    ( AccountBilling(..)
+    , AccountUsage(..)
+    , LoginAccount(..)
+    , UsageState(..)
+    , UsageWindow(..)
+    )
+import Agent.Provider (BillingMode(..), Provider(..))
+import Data.Text (Text)
+import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
+import Test.Hspec
+
+spec :: Spec
+spec = describe "account selection" do
+    it "ranks provider-neutral candidates without changing equal-capacity order" do
+        fmap (.candidateSelectionId)
+            (selectCandidates Nothing
+                [candidate "first" "account-1" (Just 50)
+                , candidate "second" "account-2" (Just 50)
+                ])
+            `shouldBe` Just "first"
+
+    it "ignores candidates with unverifiable or exhausted capacity" do
+        fmap (.candidateSelectionId)
+            (selectCandidates Nothing
+                [candidate "unknown" "account-0" Nothing
+                ,candidate "empty" "account-1" (Just 0)
+                ,candidate "usable" "account-2" (Just 1)
+                ])
+            `shouldBe` Just "usable"
+
+    it "prefers the remembered usable project account" do
+        fmap (.selectedAccountId)
+            (selectAccount
+                (Just ("external:openai:second", "account-2"))
+                [subscriptionAccount "first" "account-1" 10
+                , subscriptionAccount "second" "account-2" 80
+                ])
+            `shouldBe` Just "account-2"
+
+    it "uses the account with the most remaining capacity otherwise" do
+        fmap (.selectedAccountId)
+            (selectAccount
+                (Just ("external:openai:exhausted", "account-0"))
+                [subscriptionAccount "exhausted" "account-0" 100
+                , subscriptionAccount "busy" "account-1" 80
+                , subscriptionAccount "free" "account-2" 20
+                ])
+            `shouldBe` Just "account-2"
+
+    it "excludes accounts whose usage could not be checked" do
+        selectAccount Nothing
+            [ (subscriptionAccount "unknown" "account-1" 20)
+                { loginUsage = UsageUnavailable "offline" }
+            ]
+            `shouldBe` Nothing
+
+    it "keeps discovery order for equal-capacity login accounts" do
+        fmap (.selectedSelectionId)
+            (selectAccount Nothing
+                [ subscriptionAccount "z-source" "account-z" 50
+                , subscriptionAccount "a-source" "account-a" 50
+                ])
+            `shouldBe` Just "external:openai:z-source"
+
+candidate :: Text -> Text -> Maybe Double -> AccountCandidate
+candidate selectionId accountId capacity = AccountCandidate
+    { candidateProvider = OpenAIProvider
+    , candidateSelectionId = selectionId
+    , candidateAccountId = accountId
+    , candidateBillingMode = SubscriptionBilled
+    , candidateLabel = accountId
+    , candidateCapacity = capacity
+    }
+
+subscriptionAccount
+    :: Text
+    -> Text
+    -> Int
+    -> LoginAccount
+subscriptionAccount source accountId used = LoginAccount
+    { loginManagedId = Nothing
+    , loginProvider = OpenAIProvider
+    , loginAccountId = accountId
+    , loginLabel = accountId
+    , loginBilling = SubscriptionBilling Nothing
+    , loginSource = source
+    , loginUsage = UsageAvailable AccountUsage
+        { usagePlan = Nothing
+        , usageWindows =
+            [ UsageWindow
+                { windowName = "primary"
+                , usedPercent = used
+                , windowSeconds = 3600
+                , resetsAt = posixSecondsToUTCTime 0
+                }
+            ]
+        , creditsRemaining = Nothing
+        , creditsUsed = Nothing
+        }
+    , loginAccessToken = "redacted"
+    , loginAuthKind = ManagedBearerToken
+    , loginSecretPayload = "redacted"
+    , loginEnabled = True
+    }

--- a/packages/agent-cli/test/Agent/CLI/AccountSelectionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/AccountSelectionSpec.hs
@@ -67,6 +67,25 @@ spec = describe "account selection" do
                 ])
             `shouldBe` Just "external:openai:z-source"
 
+    it "does not usage-rank Claude Code CLI authentication" do
+        providerSupportsUsageAccountSelection ClaudeCodeProvider
+            `shouldBe` False
+
+    it "keeps a verified OpenRouter free-tier key usable at zero credits" do
+        accountCapacity freeTierAccount `shouldBe` Just 1
+
+    it "still rejects a paid OpenRouter key with zero remaining credits" do
+        accountCapacity
+            (freeTierAccount
+                { loginUsage = UsageAvailable AccountUsage
+                    { usagePlan = Nothing
+                    , usageWindows = []
+                    , creditsRemaining = Just "$0.0"
+                    , creditsUsed = Just "$1.0"
+                    }
+                })
+            `shouldBe` Nothing
+
 candidate :: Text -> Text -> Maybe Double -> AccountCandidate
 candidate selectionId accountId capacity = AccountCandidate
     { candidateProvider = OpenAIProvider
@@ -107,3 +126,16 @@ subscriptionAccount source accountId used = LoginAccount
     , loginSecretPayload = "redacted"
     , loginEnabled = True
     }
+
+freeTierAccount :: LoginAccount
+freeTierAccount =
+    (subscriptionAccount "openrouter-env" "openrouter-key" 0)
+        { loginProvider = OpenRouterProvider
+        , loginBilling = ApiCreditsBilling
+        , loginUsage = UsageAvailable AccountUsage
+            { usagePlan = Just "free tier"
+            , usageWindows = []
+            , creditsRemaining = Just "$0.0"
+            , creditsUsed = Just "$0.0"
+            }
+        }

--- a/packages/agent-cli/test/Agent/CLI/ProjectSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ProjectSpec.hs
@@ -8,6 +8,7 @@ import System.OsPath (OsPath, decodeUtf, unsafeEncodeUtf)
 import Control.Exception (bracket)
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy as LBS
+import qualified Data.ByteString.Lazy.Char8 as LBS8
 import qualified Data.Text as Text
 import qualified System.Directory as Directory
 import System.Directory.OsPath
@@ -119,6 +120,41 @@ spec = describe "Agent.CLI.Project" do
                     `shouldBe` Just GrokBuildDialect
                 projectModelFor OpenAIProvider settings `shouldBe` Nothing
 
+        it "remembers one successful account per provider without storing secrets" $
+            withTempDir "agent-project-" \root -> do
+                saveProjectAccount root OpenAIProvider
+                    "managed:openai-1" "chatgpt-account-1"
+                saveProjectAccount root XAIProvider
+                    "managed:xai-1" "grok-account-1"
+
+                settings <- loadProjectSettings root
+                projectAccountFor OpenAIProvider settings
+                    `shouldBe` Just ProjectAccount
+                        { projectAccountProvider = OpenAIProvider
+                        , projectAccountSelectionId = "managed:openai-1"
+                        , projectAccountId = "chatgpt-account-1"
+                        }
+                projectAccountFor XAIProvider settings
+                    `shouldBe` Just ProjectAccount
+                        { projectAccountProvider = XAIProvider
+                        , projectAccountSelectionId = "managed:xai-1"
+                        , projectAccountId = "grok-account-1"
+                        }
+                bytes <- LBS.readFile
+                    (toFilePath (projectSettingsPath root))
+                Text.isInfixOf "secret" (Text.pack (LBS8.unpack bytes))
+                    `shouldBe` False
+
+                saveProjectAccount root OpenAIProvider
+                    "managed:openai-2" "chatgpt-account-2"
+                updated <- loadProjectSettings root
+                projectAccountFor OpenAIProvider updated
+                    `shouldBe` Just ProjectAccount
+                        { projectAccountProvider = OpenAIProvider
+                        , projectAccountSelectionId = "managed:openai-2"
+                        , projectAccountId = "chatgpt-account-2"
+                        }
+
         it "loads legacy OpenRouter settings with the old Grok dialect" $
             withTempDir "agent-project-" \root -> do
                 let dir = root </> fromFilePath ".haskell-agent"
@@ -153,6 +189,7 @@ spec = describe "Agent.CLI.Project" do
                 settings <- loadProjectSettings root
                 settings.settingsAutoApprove `shouldBe` True
                 settings.settingsLastModel `shouldBe` Nothing
+                settings.settingsLastAccounts `shouldBe` []
 
         it "ignores an unknown remembered dialect without resetting approval" $
             withTempDir "agent-project-" \root -> do

--- a/packages/agent-cli/test/Agent/CLI/ProviderAvailabilitySpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ProviderAvailabilitySpec.hs
@@ -4,6 +4,7 @@ import Agent.CLI.Auth (LoadedAuth(..), staticCredentialProvider)
 import Agent.CLI.ProviderAvailability
     ( openAiUsageFailure
     , openRouterUsageFailure
+    , probeLoadedAutomaticAvailabilityWith
     , probeLoadedAvailabilityWith
     , xaiUsageFailure
     )
@@ -155,3 +156,55 @@ spec = do
                 Right _ ->
                     expectationFailure
                         "expected credential exhaustion, got usable auth"
+
+    describe "probeLoadedAutomaticAvailabilityWith" do
+        it "rejects Grok fallback when usage cannot be verified" do
+            let loaded = xaiLoadedAuth
+            result <- probeLoadedAutomaticAvailabilityWith
+                (const (pure (Left "billing unavailable")))
+                loaded
+            case result of
+                Left (ConnectionError message) ->
+                    message `shouldBe`
+                        "Could not verify Grok usage: billing unavailable"
+                Left err ->
+                    expectationFailure
+                        ("expected connection failure, got " <> show err)
+                Right _ ->
+                    expectationFailure
+                        "expected unverifiable Grok usage to be rejected"
+
+        it "rejects exhausted Grok fallback before a model request" do
+            let exhausted =
+                    ProviderError
+                        UsageLimitReached
+                        "exhausted"
+                        (Just 60)
+            result <- probeLoadedAutomaticAvailabilityWith
+                (const (pure (Right (Just exhausted))))
+                xaiLoadedAuth
+            case result of
+                Left CredentialsExhausted{} -> pure ()
+                Left err ->
+                    expectationFailure
+                        ("expected credential exhaustion, got " <> show err)
+                Right _ ->
+                    expectationFailure
+                        "expected exhausted Grok fallback to be rejected"
+
+xaiLoadedAuth :: LoadedAuth
+xaiLoadedAuth =
+    let credential = Credential
+            { accessToken = "token"
+            , accountId = "account"
+            , leaseId = Nothing
+            , provider = XAIProvider
+            }
+    in LoadedAuth
+        { loadedProvider = XAIProvider
+        , loadedTokenProvider =
+            staticCredentialProvider SubscriptionBilled credential
+        , loadedAccountLabel = const (pure "account")
+        , loadedOpenAiPool = Nothing
+        , loadedSelectionId = Nothing
+        }

--- a/packages/agent-cli/test/Agent/CLI/ProviderTransitionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ProviderTransitionSpec.hs
@@ -42,6 +42,17 @@ spec = do
             updated.pendingExitAfter `shouldBe` True
             updated.pendingPlanState `shouldBe` PlanActive
 
+    describe "transitionCommitsImmediately" do
+        it "keeps a startup automatic fallback provisional" do
+            transitionCommitsImmediately (transition Nothing Nothing)
+                `shouldBe` False
+
+        it "commits a manual selection immediately" do
+            let manual =
+                    (transition Nothing Nothing)
+                        { transitionCause = ManualTransition }
+            transitionCommitsImmediately manual `shouldBe` True
+
 transition
     :: Maybe Text
     -> Maybe PendingTurn

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -2,6 +2,7 @@ module Main (main) where
 
 import Test.Hspec (hspec)
 
+import qualified Agent.CLI.AccountSelectionSpec as AccountSelectionSpec
 import qualified Agent.CLI.AgentSessionsSpec as AgentSessionsSpec
 import qualified Agent.CLI.AgentViewportSpec as AgentViewportSpec
 import qualified Agent.CLI.ApprovalSpec as ApprovalSpec
@@ -64,6 +65,7 @@ import qualified Agent.CLI.WorktreeSpec as WorktreeSpec
 
 main :: IO ()
 main = hspec do
+    AccountSelectionSpec.spec
     AgentViewportSpec.spec
     AgentSessionsSpec.spec
     ApprovalSpec.spec

--- a/packages/agent-xai/src/Agent/XAI/Usage.hs
+++ b/packages/agent-xai/src/Agent/XAI/Usage.hs
@@ -6,6 +6,7 @@ module Agent.XAI.Usage
     ) where
 
 import Control.Exception.Safe (tryAny)
+import Agent.Provider (Credential(..))
 import qualified Data.Aeson as Aeson
 import Data.Aeson ((.:))
 import Data.Aeson.Types (Parser)
@@ -54,8 +55,8 @@ decodeGrokUsage body = case Aeson.eitherDecode body of
         Left "Grok returned an unreadable usage response."
     Right snapshot -> Right snapshot
 
-fetchGrokUsage :: Text -> IO (Either Text GrokUsageSnapshot)
-fetchGrokUsage accessToken =
+fetchGrokUsage :: Credential -> IO (Either Text GrokUsageSnapshot)
+fetchGrokUsage credential =
     tryAny requestUsage >>= \case
         Left _ ->
             pure $ Left
@@ -74,8 +75,12 @@ fetchGrokUsage accessToken =
                 "https://cli-chat-proxy.grok.com/v1/billing?format=credits"
         httpLBS
             $ setRequestHeader
-                "Authorization"
-                ["Bearer " <> Text.encodeUtf8 accessToken]
+                "X-Auth-Token"
+                ["Bearer " <> Text.encodeUtf8 credential.accessToken]
+            $ setRequestHeader "X-XAI-Token-Auth" ["true"]
+            $ setRequestHeader
+                "x-userid"
+                [Text.encodeUtf8 credential.accountId]
             $ setRequestHeader "Accept" ["application/json"]
             $ setRequestHeader "x-grok-client-mode" ["shell"]
             $ setRequestHeader "x-grok-client-version" ["0.2.118"]


### PR DESCRIPTION
## Summary

- discover and verify usage for enabled accounts before automatic startup/fallback selection
- prefer the last successfully used project account when usable, otherwise rank available capacity
- avoid model requests when checking exhausted Grok fallback accounts
- persist stable account identifiers only after a successful turn
- keep automatic provider transitions provisional until the replacement succeeds

## Tests

- `cabal test agent-cli-test --test-show-details=direct`
- `cabal test agent-openai-test agent-xai-test agent-openrouter-test --test-show-details=direct`
