### PR TITLE
fix(cli): retry interrupted streamed responses

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Connectivity.hs
+++ b/packages/agent-cli/src/Agent/CLI/Connectivity.hs
@@ -36,11 +36,10 @@ withConnectionRecovery =
     withConnectionRecoveryUsing
         (threadDelay . reconnectDelayMicros)
 
--- | Injectable variant used by tests.
---
--- Retrying stops once response text/reasoning has streamed. Replaying after
--- visible output could duplicate it; those rare mid-stream failures continue
--- through the existing error path instead.
+-- | Injectable variant used by tests. If a response already streamed, emit a
+-- structural restart boundary before the next attempt. Providers may generate
+-- a different continuation when replayed, so renderers keep the failed partial
+-- attempt visible rather than trying to splice or silently deduplicate it.
 withConnectionRecoveryUsing
     :: (Int -> IO ())
     -> Backend
@@ -54,14 +53,15 @@ withConnectionRecoveryUsing waitBeforeRetry (Backend submit) =
                     onEvent event
                 didStream <- readIORef streamed
                 case result of
-                    Left ConnectionError{}
-                        | not didStream -> do
-                            onEvent (ActivityUpdated (waitingMessage attempt))
-                            waitBeforeRetry attempt
-                            onEvent
-                                (ActivityUpdated
-                                    "Checking internet connection…")
-                            go (attempt + 1)
+                    Left ConnectionError{} -> do
+                        onEvent (ActivityUpdated (waitingMessage attempt))
+                        waitBeforeRetry attempt
+                        onEvent
+                            (ActivityUpdated
+                                "Checking internet connection…")
+                        when didStream $
+                            onEvent (ResponseRestarted restartMessage)
+                        go (attempt + 1)
                     _ -> pure result
         in go 1
 
@@ -76,6 +76,11 @@ waitingMessage attempt =
     "Connection lost; waiting for internet. Retrying automatically in "
         <> formatDelay (reconnectDelayMicros attempt)
         <> " (Esc or Ctrl-C to cancel)…"
+
+restartMessage :: Text
+restartMessage =
+    "Connection interrupted the response; restarting automatically. "
+        <> "The new attempt may repeat partial output shown above."
 
 formatDelay :: Int -> Text
 formatDelay micros =

--- a/packages/agent-cli/src/Agent/CLI/Render.hs
+++ b/packages/agent-cli/src/Agent/CLI/Render.hs
@@ -493,6 +493,21 @@ renderEventUnlocked config = \case
         putTextLn config.renderStderr
             (roleWarn config.renderColor (glyphWarn <> warning))
         when visible (startThinkingSpinnerUnlocked config)
+    ResponseRestarted message -> do
+        commitThinkingUnlocked config
+        if config.renderColor
+            then do
+                didPrint <- finalizeAssistantBuffer config Nothing
+                when didPrint (putTextLn config.renderStdout "")
+            else do
+                Text.hPutStr config.renderStdout "\n"
+                hFlush config.renderStdout
+                writeIORef config.renderMarkdownState emptyMarkdownStreamState
+                writeIORef config.renderLiveActive False
+        writeIORef config.renderActivityRef "Retrying response…"
+        putTextLn config.renderStderr
+            (roleWarn config.renderColor (glyphWarn <> message))
+        startThinkingSpinnerUnlocked config
     TurnStarted -> do
         writeIORef config.renderMarkdownState emptyMarkdownStreamState
         writeIORef config.renderLiveActive False
@@ -1006,6 +1021,8 @@ formatLoopErrorColoredAt color now =
 formatLoopErrorPersistedAt :: UTCTime -> LoopError -> Text
 formatLoopErrorPersistedAt now = \case
     LoopTransport err -> formatApiErrorPersistedAt now err
+    LoopTransportAfterOutput err ->
+        formatInterruptedResponse (formatApiErrorPersistedAt now err)
     LoopMaxTurns turn ->
         "Stopped: maximum turns reached."
             <> maybe "" ("\n" <>) turn.assistantText
@@ -1024,6 +1041,13 @@ formatLoopErrorColoredMaybeAt color maybeNow = \case
                 <> case maybeNow of
                     Nothing -> formatApiError err
                     Just now -> formatApiErrorAt now err
+    LoopTransportAfterOutput err ->
+        roleError color $
+            glyphErr
+                <> formatInterruptedResponse
+                    (case maybeNow of
+                        Nothing -> formatApiError err
+                        Just now -> formatApiErrorAt now err)
     LoopMaxTurns turn ->
         roleError color (glyphErr <> "stopped: max turns reached")
             <> maybe "" (\text -> "\n" <> text) turn.assistantText
@@ -1040,3 +1064,10 @@ formatLoopErrorColoredMaybeAt color maybeNow = \case
                 <> "\nRetry the message.")
     LoopCancelled _ ->
         roleMuted color (glyphCancel <> "cancelled")
+
+formatInterruptedResponse :: Text -> Text
+formatInterruptedResponse details =
+    "Response interrupted after partial output.\n"
+        <> "The turn has stopped; nothing is still running.\n"
+        <> details
+        <> "\nSend \"continue\" to continue the task, or retry your last message."

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -3298,6 +3298,7 @@ uiEventCanCompleteBlocks :: UiEvent -> Bool
 uiEventCanCompleteBlocks = \case
     UiLoop (ToolFinished _) -> True
     UiLoop (TurnFinished _) -> True
+    UiLoop (ResponseRestarted _) -> True
     UiSetAwaitingInput True -> True
     UiTurnEnded _ -> True
     _ -> False
@@ -3317,6 +3318,7 @@ uiEventRestartsMotionSchedule event previous next newFlashes =
     explicitReset = case event of
         UiLoop TurnStarted -> True
         UiLoop (WarningRaised _) -> True
+        UiLoop (ResponseRestarted _) -> True
         UiSetNotice (Just _) -> True
         UiInputPromoted _ -> True
         UiTurnRestarted -> True

--- a/packages/agent-cli/test/Agent/CLI/ConnectivitySpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ConnectivitySpec.hs
@@ -97,19 +97,49 @@ spec = describe "withConnectionRecovery" do
                 }
         readIORef attempts `shouldReturn` 2
 
-    it "does not replay a submission after visible output streamed" do
+    it "restarts a submission after visible output streamed" do
         attempts <- newIORef (0 :: Int)
         waits <- newIORef []
+        events <- newIORef []
         let backend = withConnectionRecoveryUsing
                 (\attempt -> modifyIORef' waits (<> [attempt]))
-                (Backend \_ _ _ onEvent -> do
-                    modifyIORef' attempts (+ 1)
-                    onEvent (TextDelta "partial")
-                    pure (Left (ConnectionError "dropped")))
-        result <- backend.submitTurn [] Nothing [] (const (pure ()))
-        result `shouldBe` Left (ConnectionError "dropped")
-        readIORef attempts `shouldReturn` 1
-        readIORef waits `shouldReturn` []
+                (Backend \state _ _ onEvent -> do
+                    attempt <- atomicModifyIORef' attempts
+                        \n -> (n + 1, n + 1)
+                    if attempt == 1
+                        then do
+                            onEvent (TextDelta "partial")
+                            pure (Left (ConnectionError "dropped"))
+                        else do
+                            onEvent (TextDelta "complete")
+                            pure (Right
+                                BackendResult
+                                    { backendOutput =
+                                        emptyTurnOutput
+                                            "response"
+                                            []
+                                            (Just "complete")
+                                    , backendState = state
+                                    }))
+        result <- backend.submitTurn [] Nothing []
+            (\event -> modifyIORef' events (<> [event]))
+        result `shouldBe`
+            Right BackendResult
+                { backendOutput =
+                    emptyTurnOutput "response" [] (Just "complete")
+                , backendState = []
+                }
+        readIORef attempts `shouldReturn` 2
+        readIORef waits `shouldReturn` [1]
+        readIORef events `shouldReturn`
+            [ TextDelta "partial"
+            , ActivityUpdated
+                "Connection lost; waiting for internet. Retrying automatically in 1s (Esc or Ctrl-C to cancel)…"
+            , ActivityUpdated "Checking internet connection…"
+            , ResponseRestarted
+                "Connection interrupted the response; restarting automatically. The new attempt may repeat partial output shown above."
+            , TextDelta "complete"
+            ]
 
     it "does not duplicate queued inputs across reconnect attempts" do
         attempts <- newIORef (0 :: Int)

--- a/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
@@ -212,6 +212,19 @@ spec = do
             rendered `shouldNotSatisfy`
                 Text.isInfixOf "ProviderError"
 
+        it "makes a mid-response transport stop explicit" do
+            let rendered =
+                    formatLoopError
+                        (LoopTransportAfterOutput
+                            (ConnectionError
+                                "WebSocket receive error: ParseException \"not enough bytes\""))
+            rendered `shouldSatisfy`
+                Text.isInfixOf "Response interrupted after partial output"
+            rendered `shouldSatisfy`
+                Text.isInfixOf "nothing is still running"
+            rendered `shouldSatisfy`
+                Text.isInfixOf "Send \"continue\" to continue the task"
+
         it "explains an incomplete provider response" do
             formatLoopError LoopNoResponseId
                 `shouldSatisfy`
@@ -292,6 +305,38 @@ spec = do
                 body `shouldSatisfy`
                     Text.isInfixOf
                         "Codex usage is low: primary 8% left."
+
+        it "closes a partial Markdown stream before an automatic retry" do
+            withRenderConfig False True \config handle path -> do
+                let message =
+                        "Connection interrupted the response; restarting automatically."
+                renderEvent config TurnStarted
+                renderEvent config
+                    (TextDelta "partial\n```haskell\nunfinished")
+                renderEvent config (ResponseRestarted message)
+                renderEvent config (TextDelta "# Complete\n")
+                renderEvent config (TurnFinished TurnOutput
+                    { responseId = "r1"
+                    , toolCalls = []
+                    , assistantText = Just "Complete"
+                    , tokenUsage = emptyTokenUsage
+                    })
+                activity <- readIORef config.renderActivityRef
+                activity `shouldBe` "Retrying response…"
+                hClose handle
+                body <- stripTerminalControls <$> Text.readFile path
+                body `shouldSatisfy` Text.isInfixOf "partial"
+                body `shouldSatisfy` Text.isInfixOf message
+                body `shouldSatisfy` Text.isInfixOf "Complete"
+                body `shouldSatisfy` (not . Text.isInfixOf "# Complete")
+                let partialIndex =
+                        Text.length (fst (Text.breakOn "partial" body))
+                    warningIndex =
+                        Text.length (fst (Text.breakOn message body))
+                    completeIndex =
+                        Text.length (fst (Text.breakOn "Complete" body))
+                partialIndex `shouldSatisfy` (< warningIndex)
+                warningIndex `shouldSatisfy` (< completeIndex)
 
         it "buffers reasoning summaries and commits one thinking block" do
             withRenderConfig True False \config handle path -> do

--- a/packages/agent-core/src/Agent/Loop.hs
+++ b/packages/agent-core/src/Agent/Loop.hs
@@ -48,6 +48,7 @@ import Control.Exception.Safe (SomeException, displayException, mask, tryAny)
 import Data.Aeson (FromJSON(..), ToJSON(..), object, withObject, (.:), (.:?), (.!=), (.=))
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as ByteString
+import Data.IORef (newIORef, readIORef, writeIORef)
 import Data.Maybe (catMaybes, maybeToList)
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -173,6 +174,10 @@ data LoopEvent
     | ActivityUpdated Text
     -- | A persistent user-visible warning that must not replace live activity.
     | WarningRaised Text
+    -- | A streamed response was interrupted and its provider submission is
+    -- being retried. Renderers must close the partial stream before displaying
+    -- output from the new attempt.
+    | ResponseRestarted Text
     | TurnStarted
     | TurnFinished TurnOutput
     | ToolStarted ToolCall
@@ -206,6 +211,10 @@ data LoopResult = LoopResult
 
 data LoopError
     = LoopTransport ApiError
+    -- | The transport failed after text or reasoning was already exposed.
+    -- Connection-recovery backends normally retry these with a visible stream
+    -- boundary; this remains the terminal fallback for unwrapped backends.
+    | LoopTransportAfterOutput ApiError
     | LoopMaxTurns TurnOutput
     | LoopNoResponseId
     -- | An unexpected synchronous exception escaped a backend, approval
@@ -308,13 +317,20 @@ runLoopInputsUnsafe config0 initialState previousResponseId firstInputs = do
                     then finish state progress (Left (LoopCancelled []))
                     else do
                         config.loopOnEvent TurnStarted
+                        outputSeen <- newIORef False
+                        let onBackendEvent event = do
+                                case event of
+                                    TextDelta _ -> writeIORef outputSeen True
+                                    ReasoningDelta _ -> writeIORef outputSeen True
+                                    _ -> pure ()
+                                config.loopOnEvent event
                         -- Race the model call against cancel so Ctrl-C / Esc
                         -- can stop reasoning mid-stream, not only between tools.
                         raced <- mask \restore -> do
                             result <- restore $ race
                                 (waitCancel config.loopCancel)
                                 (config.loopBackend.submitTurn
-                                    state prev inputs config.loopOnEvent)
+                                    state prev inputs onBackendEvent)
                             case result of
                                 Right (Right BackendResult{..})
                                     | not
@@ -327,8 +343,12 @@ runLoopInputsUnsafe config0 initialState previousResponseId firstInputs = do
                         case raced of
                             Left () ->
                                 finish state progress (Left (LoopCancelled []))
-                            Right (Left err) ->
-                                finish state progress (Left (LoopTransport err))
+                            Right (Left err) -> do
+                                emitted <- readIORef outputSeen
+                                finish state progress $ Left $
+                                    if emitted
+                                        then LoopTransportAfterOutput err
+                                        else LoopTransport err
                             Right (Right BackendResult{backendOutput = turn})
                                 | Text.null turn.responseId ->
                                     finish state progress (Left LoopNoResponseId)

--- a/packages/agent-core/test/Agent/LoopSpec.hs
+++ b/packages/agent-core/test/Agent/LoopSpec.hs
@@ -446,6 +446,15 @@ spec = describe "runLoop" do
         execution.executionResult
             `shouldBe` Left (LoopUnexpected "user error (renderer exploded)")
 
+    it "marks a transport failure after streamed output as interrupted" do
+        let backend = Backend \_state _prev _inputs onEvent -> do
+                onEvent (TextDelta "partial")
+                pure (Left (ConnectionError "down"))
+        config <- testConfig backend
+        result <- runLoop config Nothing "hello"
+        result `shouldBe`
+            Left (LoopTransportAfterOutput (ConnectionError "down"))
+
     it "turns synchronous backend exceptions into a failed turn" do
         config <- testConfig $ Backend \_state _prev _inputs _onEvent ->
             Exception.throwIO (userError "backend exploded")

--- a/packages/agent-tui/src/Agent/TUI/Model.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model.hs
@@ -612,6 +612,15 @@ reduceLoop event state = case event of
             { uiNotice = Just (warningNotice warning)
             , uiNoticeElapsedMillis = 0
             }
+    ResponseRestarted message ->
+        let finalized = finalizeStreams state
+        in finalized
+            { uiRunning = True
+            , uiActivity = "Retrying response…"
+            , uiNotice = Just (warningNotice message)
+            , uiNoticeElapsedMillis = 0
+            , uiTurnStartBlock = Seq.length finalized.uiBlocks
+            }
     ToolStarted call ->
         let
             kind = toolBlockKind call.name

--- a/packages/agent-tui/src/Agent/TUI/Model.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model.hs
@@ -167,6 +167,7 @@ data UiState = UiState
     , uiElapsedMillis :: !Int
     , uiCompletionRemainingMillis :: !Int
     , uiTurnStartBlock :: !Int
+    , uiAttemptStartBlock :: !Int
     , uiToolCalls :: !(Map.Map Text (Int, ToolCall))
     }
     deriving (Eq, Show)
@@ -237,6 +238,7 @@ initialUiState = UiState
     , uiElapsedMillis = 0
     , uiCompletionRemainingMillis = 0
     , uiTurnStartBlock = 0
+    , uiAttemptStartBlock = 0
     , uiToolCalls = Map.empty
     }
 
@@ -396,6 +398,7 @@ reduceUi event state = case event of
             , uiBlockIndices = Map.empty
             , uiNextBlockId = 1
             , uiTurnStartBlock = 0
+            , uiAttemptStartBlock = 0
             , uiToolCalls = Map.empty
             , uiRetryCountdown = Nothing
             }
@@ -437,6 +440,7 @@ reduceUi event state = case event of
             , uiNoticeElapsedMillis = 0
             , uiCompletionRemainingMillis = 0
             , uiToolCalls = Map.empty
+            , uiAttemptStartBlock = state.uiTurnStartBlock
             }
 
 advanceUiTime :: Int -> UiState -> UiState
@@ -597,6 +601,7 @@ reduceLoop event state = case event of
             , uiElapsedMillis = 0
             , uiCompletionRemainingMillis = 0
             , uiTurnStartBlock = Seq.length state.uiBlocks
+            , uiAttemptStartBlock = Seq.length state.uiBlocks
             , uiToolCalls = Map.empty
             }
     ReasoningDelta delta ->
@@ -619,7 +624,7 @@ reduceLoop event state = case event of
             , uiActivity = "Retrying response…"
             , uiNotice = Just (warningNotice message)
             , uiNoticeElapsedMillis = 0
-            , uiTurnStartBlock = Seq.length finalized.uiBlocks
+            , uiAttemptStartBlock = Seq.length finalized.uiBlocks
             }
     ToolStarted call ->
         let
@@ -672,7 +677,7 @@ reduceLoop event state = case event of
                     | not (Text.null (Text.strip text))
                     , not
                         (hasAssistantTextSince
-                            finalized.uiTurnStartBlock
+                            finalized.uiAttemptStartBlock
                             finalized) ->
                         appendBlock BlockAssistant "Assistant" text ""
                             BlockComplete Nothing finalized

--- a/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
@@ -182,6 +182,23 @@ spec = describe "fullscreen UI reducer" do
                     (warningNotice
                         "Codex usage is low: primary 8% left.")
 
+    it "separates a partial response from its automatic retry" do
+        let message =
+                "Connection interrupted the response; restarting automatically."
+            state =
+                apply
+                    [ UiLoop TurnStarted
+                    , UiLoop (TextDelta "partial")
+                    , UiLoop (ResponseRestarted message)
+                    , UiLoop (TextDelta "complete")
+                    ]
+            blocks = Foldable.toList state.uiBlocks
+        map (.blockBody) blocks `shouldBe` ["partial", "complete"]
+        map (.blockState) blocks
+            `shouldBe` [BlockComplete, BlockStreaming]
+        state.uiActivity `shouldBe` "Writing…"
+        state.uiNotice `shouldBe` Just (warningNotice message)
+
     it "matches tool completion by call id" do
         let call = functionToolCall "c1" "run_terminal_cmd" "{\"command\":\"git status\"}"
             result = ToolCallResult

--- a/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
@@ -199,6 +199,46 @@ spec = describe "fullscreen UI reducer" do
         state.uiActivity `shouldBe` "Writing…"
         state.uiNotice `shouldBe` Just (warningNotice message)
 
+    it "discards every response attempt when restarting effort after recovery" do
+        let initialPrompt =
+                initialUiState.uiPrompt
+                    { promptEffort = "low"
+                    }
+            state =
+                apply
+                    [ UiSetPrompt initialPrompt
+                    , UiUserSubmitted "try this"
+                    , UiLoop TurnStarted
+                    , UiLoop (TextDelta "failed partial")
+                    , UiLoop
+                        (ResponseRestarted
+                            "Connection interrupted; restarting.")
+                    , UiLoop (TextDelta "retried partial")
+                    , UiSetPromptEffort "high"
+                    , UiTurnRestarted
+                    ]
+            blocks = Foldable.toList state.uiBlocks
+        map (.blockBody) blocks `shouldBe` ["try this"]
+        state.uiPrompt.promptEffort `shouldBe` "high"
+        state.uiRunning `shouldBe` False
+        state.uiActivity `shouldBe` "Restarting…"
+
+    it "uses the retry boundary for a non-streaming response fallback" do
+        let state =
+                apply
+                    [ UiLoop TurnStarted
+                    , UiLoop (TextDelta "failed partial")
+                    , UiLoop
+                        (ResponseRestarted
+                            "Connection interrupted; restarting.")
+                    , UiLoop
+                        (TurnFinished
+                            (emptyTurnOutput
+                                "r1" [] (Just "complete retry")))
+                    ]
+        map (.blockBody) (Foldable.toList state.uiBlocks)
+            `shouldBe` ["failed partial", "complete retry"]
+
     it "matches tool completion by call id" do
         let call = functionToolCall "c1" "run_terminal_cmd" "{\"command\":\"git status\"}"
             result = ToolCallResult


### PR DESCRIPTION
## Summary

- retry `ConnectionError` submissions even when text or reasoning has already streamed
- emit a structural response-restart boundary so minimal and fullscreen renderers close the partial attempt before showing regenerated output
- preserve explicit interrupted-response diagnostics as a fallback for unwrapped backends

## Root cause

An EOF in the middle of a WebSocket frame is surfaced as `ParseException "not enough bytes"`. Connection recovery previously stopped after visible output began to avoid silently duplicating text, which left the turn terminated after a partial response.

The retry now keeps the failed partial attempt visible, labels the restart, and starts regenerated output in a fresh rendering block. Retrying the provider submission does not rerun already completed local tools.

## Testing

- `nix develop -c cabal test agent-core-test` — 291 examples
- `nix develop -c cabal test agent-cli-test` — 786 examples
- `nix develop -c cabal test agent-tui-test` — 125 examples
