### PR TITLE
Add interactive MCP server manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,12 @@ Configure local stdio MCP servers in `~/.haskell-agent/config.json`:
 }
 ```
 
+In an interactive session, `/mcp` opens a local-server manager. Use the arrow
+keys or `j`/`k` to navigate, Enter to inspect discovered tools, `a` to add a
+server, Space to enable or disable it, `x` to remove it, and `r` to restart the
+MCP runtime. Saved changes restart the runtime while resuming the same session.
+Environment variable values are never displayed.
+
 The harness starts enabled servers once per root session and shares their tools
 with subagents. MCP tool names are preserved, so they must not collide with
 built-in or other configured tools. Only tools explicitly annotated

--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -65,6 +65,7 @@ library
                     , Agent.CLI.Login
                     , Agent.CLI.Markdown
                     , Agent.CLI.ModelPicker
+                    , Agent.CLI.McpManager
                     , Agent.CLI.ModelConfig
                     , Agent.CLI.Models
                     , Agent.CLI.Notification
@@ -226,6 +227,7 @@ test-suite agent-cli-test
                     , Agent.CLI.InterruptSpec
                     , Agent.CLI.LoginSpec
                     , Agent.CLI.MarkdownSpec
+                    , Agent.CLI.McpManagerSpec
                     , Agent.CLI.ModelPickerSpec
                     , Agent.CLI.ModelConfigSpec
                     , Agent.CLI.ModelsSpec

--- a/packages/agent-cli/package.nix
+++ b/packages/agent-cli/package.nix
@@ -1,10 +1,12 @@
-{ mkDerivation, aeson, agent-claude, agent-codex-dialect, agent-core
-, agent-grok-build-dialect, agent-openai, agent-openrouter, agent-responses
-, agent-responses-types, agent-syntax, agent-tui, agent-xai, ansi-terminal
-, async, base, base64-bytestring, brick, bytestring, colour, containers
+{ mkDerivation, aeson, agent-claude, agent-codex-dialect
+, agent-core, agent-grok-build-dialect, agent-openai
+, agent-openrouter, agent-responses, agent-responses-types
+, agent-syntax, agent-tui, agent-xai, ansi-terminal, async, base
+, base64-bytestring, brick, bytestring, colour, containers
 , directory, filelock, filepath, haskeline, hspec, http-client
-, http-client-tls, JuicyPixels, lib, mtl, process, safe-exceptions, stm
-, text, time, transformers, unix, vector, vty, vty-crossplatform
+, http-client-tls, JuicyPixels, lib, mtl, process, safe-exceptions
+, stm, text, time, transformers, unix, vector, vty
+, vty-crossplatform
 }:
 mkDerivation {
   pname = "agent-cli";
@@ -12,26 +14,28 @@ mkDerivation {
   src = ./.;
   isLibrary = true;
   isExecutable = true;
+  enableSeparateDataOutput = true;
   libraryHaskellDepends = [
-    aeson agent-claude agent-codex-dialect agent-core agent-grok-build-dialect
-    agent-openai agent-openrouter agent-responses agent-responses-types
-    agent-syntax agent-tui agent-xai ansi-terminal async base
-    base64-bytestring brick bytestring colour containers directory filelock
-    filepath haskeline http-client http-client-tls JuicyPixels mtl process
-    safe-exceptions stm text time transformers unix vector vty
-    vty-crossplatform
+    aeson agent-claude agent-codex-dialect agent-core
+    agent-grok-build-dialect agent-openai agent-openrouter
+    agent-responses agent-responses-types agent-syntax agent-tui
+    agent-xai ansi-terminal async base base64-bytestring brick
+    bytestring colour containers directory filelock filepath haskeline
+    http-client http-client-tls JuicyPixels mtl process safe-exceptions
+    stm text time transformers unix vector vty vty-crossplatform
   ];
   executableHaskellDepends = [
-    aeson agent-responses agent-responses-types base bytestring containers
-    directory filepath process safe-exceptions text time unix
+    aeson agent-responses agent-responses-types base bytestring
+    containers directory filepath process safe-exceptions text time
+    unix
   ];
   testHaskellDepends = [
     aeson agent-claude agent-codex-dialect agent-core
-    agent-grok-build-dialect agent-openai agent-openrouter agent-responses
-    agent-responses-types agent-tui agent-xai ansi-terminal async base
-    base64-bytestring brick bytestring colour containers directory filepath
-    haskeline hspec JuicyPixels mtl process safe-exceptions stm text time
-    transformers unix vty
+    agent-grok-build-dialect agent-openai agent-openrouter
+    agent-responses agent-responses-types agent-tui agent-xai
+    ansi-terminal async base brick bytestring colour containers
+    directory filepath haskeline hspec JuicyPixels process
+    safe-exceptions stm text time transformers unix vty
   ];
   benchmarkHaskellDepends = [
     aeson agent-core agent-responses base bytestring containers
@@ -39,5 +43,4 @@ mkDerivation {
   ];
   description = "Command-line interface for the universal agent harness";
   license = lib.meta.getLicenseFromSpdxId "MIT";
-  mainProgram = "agent-cli";
 }

--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -141,6 +141,7 @@ import Agent.CLI.Login
     , refreshLoginAccount
     , runLoginManager
     )
+import Agent.CLI.McpManager (runMcpManager)
 import Agent.CLI.ModelPicker (pickModel)
 import Agent.CLI.ModelConfig
     ( ConnectionKind(..)
@@ -544,6 +545,7 @@ data DevResult
 
 data RunResult
     = RunQuit
+    | RunRestart Text
     | RunReload Text
     | RunSwitchProvider ProviderTransition
     | RunProviderStartFailed ApiError
@@ -751,6 +753,10 @@ runAgentWithRestarts options = do
                 go fullscreenInputs sessionState
                     (applyProviderTransition current next)
                     (Just next)
+            RunRestart sessionId ->
+                go fullscreenInputs sessionState
+                    (restartSessionOptions current sessionId)
+                    Nothing
             RunProviderStartFailed apiError ->
                 case transition of
                     Just failed
@@ -1190,6 +1196,15 @@ runFullscreenRestartLoop
         -- The notifier in 'runFullscreen' watches this whole tail-recursive
         -- chain, rather than stopping Brick after the first provider exits.
         action >>= \case
+            RunRestart sessionId -> do
+                let nextOptions = restartSessionOptions options sessionId
+                prepared <- prepareAgentIteration
+                    fullscreenInputs
+                    sessionState
+                    (Just runtime)
+                    nextOptions
+                    Nothing
+                loop nextOptions Nothing prepared.preparedRun
             RunSwitchProvider next -> do
                 let nextOptions = applyProviderTransition options next
                 prepared <- prepareAgentIteration
@@ -2278,7 +2293,7 @@ runAgentInitializedWithLock
                                         projectRoot transition persist noticingBackend
                                 withAsync switchLoop \switchWorker -> do
                                     link switchWorker
-                                    runSession catalog inferredTarget.targetConnectionId options provider dialect policy allTools ghciEnabledRef bashEnabledRef toolEnv planMode startup prompt pendingTurn unavailableProviders startupUnavailable paramsRef transcriptRef initialTurns
+                                    runSession catalog inferredTarget.targetConnectionId options provider dialect policy allTools mcpFleet.mcpFleetRegistrations mcpFleet.mcpFleetWarnings ghciEnabledRef bashEnabledRef toolEnv planMode startup prompt pendingTurn unavailableProviders startupUnavailable paramsRef transcriptRef initialTurns
                                         previousRef persist projectRoot home cwd (Just tokenProvider) loaded.loadedOpenAiPool startupContext skillsRef skillInvocationsRef escPaused interrupt
                                         multiCtx rootTurnRef subagentSessions pendingNotices subagentStoreRoot agentTypesRef legacySubagentTarget usageRef activeAccountRef activeAccountIdRef activeSelectionRef resolveActiveAccountLabel selectAccount claimCurrentSession compactRunner activeBackend btwBackend)
                             >>= \case
@@ -2342,7 +2357,7 @@ runAgentInitializedWithLock
                         activeBackend <-
                             prepareTransitionBackend
                                 projectRoot transition persist backend
-                        runSession catalog inferredTarget.targetConnectionId options provider dialect policy allTools ghciEnabledRef bashEnabledRef toolEnv planMode startup prompt pendingTurn unavailableProviders startupUnavailable paramsRef transcriptRef initialTurns
+                        runSession catalog inferredTarget.targetConnectionId options provider dialect policy allTools mcpFleet.mcpFleetRegistrations mcpFleet.mcpFleetWarnings ghciEnabledRef bashEnabledRef toolEnv planMode startup prompt pendingTurn unavailableProviders startupUnavailable paramsRef transcriptRef initialTurns
                             previousRef persist projectRoot home cwd (Just tokenProvider) loaded.loadedOpenAiPool startupContext skillsRef skillInvocationsRef escPaused interrupt
                             multiCtx rootTurnRef subagentSessions pendingNotices subagentStoreRoot agentTypesRef legacySubagentTarget usageRef activeAccountRef activeAccountIdRef activeSelectionRef resolveActiveAccountLabel (if isJust customGenericOptions then Nothing else Just selectHttpAccount) claimCurrentSession compactRunner activeBackend btwBackend
                     ClaudeCodeProvider -> do
@@ -2403,7 +2418,7 @@ runAgentInitializedWithLock
                                 activeBackend <-
                                     prepareTransitionBackend
                                         projectRoot transition persist backend
-                                runSession catalog inferredTarget.targetConnectionId options provider dialect policy allTools ghciEnabledRef bashEnabledRef toolEnv planMode startup prompt pendingTurn unavailableProviders startupUnavailable paramsRef transcriptRef initialTurns
+                                runSession catalog inferredTarget.targetConnectionId options provider dialect policy allTools mcpFleet.mcpFleetRegistrations mcpFleet.mcpFleetWarnings ghciEnabledRef bashEnabledRef toolEnv planMode startup prompt pendingTurn unavailableProviders startupUnavailable paramsRef transcriptRef initialTurns
                                     previousRef persist projectRoot home cwd Nothing Nothing startupContext skillsRef skillInvocationsRef escPaused interrupt
                                     multiCtx rootTurnRef subagentSessions pendingNotices subagentStoreRoot agentTypesRef legacySubagentTarget usageRef activeAccountRef activeAccountIdRef activeSelectionRef resolveActiveAccountLabel Nothing claimCurrentSession compactRunner activeBackend btwBackend
                     OpenRouterProvider -> do
@@ -2475,7 +2490,7 @@ runAgentInitializedWithLock
                         activeBackend <-
                             prepareTransitionBackend
                                 projectRoot transition persist backend
-                        runSession catalog inferredTarget.targetConnectionId options provider dialect policy allTools ghciEnabledRef bashEnabledRef toolEnv planMode startup prompt pendingTurn unavailableProviders startupUnavailable paramsRef transcriptRef initialTurns
+                        runSession catalog inferredTarget.targetConnectionId options provider dialect policy allTools mcpFleet.mcpFleetRegistrations mcpFleet.mcpFleetWarnings ghciEnabledRef bashEnabledRef toolEnv planMode startup prompt pendingTurn unavailableProviders startupUnavailable paramsRef transcriptRef initialTurns
                             previousRef persist projectRoot home cwd (Just tokenProvider) loaded.loadedOpenAiPool startupContext skillsRef skillInvocationsRef escPaused interrupt
                             multiCtx rootTurnRef subagentSessions pendingNotices subagentStoreRoot agentTypesRef legacySubagentTarget usageRef activeAccountRef activeAccountIdRef activeSelectionRef resolveActiveAccountLabel (Just selectHttpAccount) claimCurrentSession compactRunner activeBackend btwBackend
           where
@@ -2664,6 +2679,8 @@ runSession
     -> Dialect
     -> ApprovalPolicy
     -> [AppTool]
+    -> [MCP.McpToolRegistration]
+    -> [Text]
     -> IORef Bool
     -> IORef Bool
     -> ToolEnv
@@ -2706,7 +2723,7 @@ runSession
     -> Backend
     -> BtwBackendFactory
     -> IO RunResult
-runSession catalog connectionId options provider dialect policy allTools ghciEnabledRef bashEnabledRef toolEnv planMode startup prompt pendingTurn unavailableProviders startupUnavailable paramsRef transcriptRef initialTurns previous persist projectRoot home cwd tokenProvider openAiPool startupContext skillsRef skillInvocationsRef escPaused interrupt multiCtx rootTurnRef subagentSessions pendingNotices storeRoot agentTypes legacyTarget usageRef accountRef accountIdRef selectionRef accountLabel selectAccount onPersisted compactRunner backend btwBackend = do
+runSession catalog connectionId options provider dialect policy allTools mcpRegistrations mcpWarnings ghciEnabledRef bashEnabledRef toolEnv planMode startup prompt pendingTurn unavailableProviders startupUnavailable paramsRef transcriptRef initialTurns previous persist projectRoot home cwd tokenProvider openAiPool startupContext skillsRef skillInvocationsRef escPaused interrupt multiCtx rootTurnRef subagentSessions pendingNotices storeRoot agentTypes legacyTarget usageRef accountRef accountIdRef selectionRef accountLabel selectAccount onPersisted compactRunner backend btwBackend = do
   initialPrevious <- readIORef previous
   ioLock <- newMVar ()
   let fullscreen = startup.startupFullscreen
@@ -3195,6 +3212,8 @@ runSession catalog connectionId options provider dialect policy allTools ghciEna
             , sessionProjectRoot = projectRoot
             , sessionCwd = cwd
             , sessionHome = home
+            , sessionMcpRegistrations = mcpRegistrations
+            , sessionMcpWarnings = mcpWarnings
             , sessionSetTempDir = setSessionTempDir
             , sessionTokenProvider = tokenProvider
             , sessionOpenAiPool = openAiPool
@@ -4183,6 +4202,19 @@ replWithDraft env@SessionEnv
                                     Just target ->
                                         viewport.viewportSelect target
                                 continue
+                    ReplMcp -> do
+                        color <- resolveColor stderr
+                        restart <-
+                            legacy $
+                                runMcpManager
+                                    color
+                                    env.sessionHome
+                                    env.sessionMcpRegistrations
+                                    env.sessionMcpWarnings
+                        if restart
+                            then requestMcpRestart
+                                fullscreen persist
+                            else continue
 
                     ReplCopyLast -> do
                         answer <- readIORef lastAssistantRef
@@ -6072,6 +6104,42 @@ requestReload fullscreen persist = do
             handle <- ensureSession slotRef
             reportInfo ("reloading; session " <> handle.sessionMeta.metaId)
             pure (RunReload handle.sessionMeta.metaId)
+
+requestMcpRestart
+    :: Maybe FullscreenRuntime
+    -> Persistence
+    -> IO RunResult
+requestMcpRestart fullscreen persist = do
+    color <- resolveColor stderr
+    let report message =
+            case fullscreen of
+                Nothing ->
+                    putTextLn stderr
+                        (roleMuted color (glyphSession <> message))
+                Just runtime ->
+                    emitUiEvent runtime (UiSystemMessage message)
+    case persist of
+        PersistenceDisabled -> do
+            report
+                "MCP configuration saved; restart the agent to apply it"
+            pure RunQuit
+        PersistenceEnabled slotRef -> do
+            handle <- ensureSession slotRef
+            report "restarting MCP servers…"
+            pure (RunRestart handle.sessionMeta.metaId)
+
+restartSessionOptions :: CliOptions -> Text -> CliOptions
+restartSessionOptions options sessionId =
+    options
+        { optProvider = Nothing
+        , optModel = Nothing
+        , optCwd = Nothing
+        , optWorktree = False
+        , optEffort = Nothing
+        , optPrompt = Nothing
+        , optPromptFile = Nothing
+        , optResume = Just sessionId
+        }
 
 enterPlanFromSlash :: SessionEnv -> Maybe Text -> IO (Maybe ProviderTransition)
 enterPlanFromSlash env@SessionEnv

--- a/packages/agent-cli/src/Agent/CLI/Command.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command.hs
@@ -67,6 +67,7 @@ data ReplAction
     | ReplCopySession
     | ReplShowTerminal
     | ReplAgents
+    | ReplMcp
     | ReplSkills !Bool
     | ReplShowShell
     | ReplSetShell !ShellMode
@@ -138,6 +139,7 @@ slashCommands =
     , cmd "copy-session" [] "/copy-session" "Copy the current session id" False
     , cmd "terminal" ["ghostty"] "/terminal" "Show detected terminal capabilities" False
     , cmd "agents" ["a"] "/agents" "Browse the agent hierarchy and switch viewport" False
+    , cmd "mcp" [] "/mcp" "Manage local MCP servers" False
     , cmd "skills" [] "/skills [reload]" "List discovered skills or reload them from disk" True
     , cmd "shell" [] "/shell [ghci|bash|both|none]" "Show or select the allowed shell tools" True
     , cmd "always-approve" ["yolo"] "/always-approve" "Toggle project auto-approve (or Shift+Tab)" False
@@ -282,6 +284,10 @@ parseSlash skills line = case Text.words line of
                 if null args
                     then ReplAgents
                     else ReplCommandError "usage: /agents"
+            "mcp" ->
+                if null args
+                    then ReplMcp
+                    else ReplCommandError "usage: /mcp"
             "skills" -> case args of
                 [] -> ReplSkills False
                 ["reload"] -> ReplSkills True

--- a/packages/agent-cli/src/Agent/CLI/Config.hs
+++ b/packages/agent-cli/src/Agent/CLI/Config.hs
@@ -6,9 +6,10 @@ module Agent.CLI.Config
     , defaultHarnessConfig
     , harnessConfigPath
     , loadHarnessConfig
+    , saveHarnessConfig
     ) where
 
-import Agent.FileRetry (retryOnFileBusy)
+import Agent.FileRetry (retryOnFileBusy, writeLazyFileAtomically)
 import Agent.OsPath (unsafeToFilePath)
 import Control.Exception.Safe (displayException, tryIO)
 import Control.Monad (unless, when)
@@ -25,8 +26,9 @@ import qualified Data.Map.Strict as Map
 import Data.Map.Strict (Map)
 import Data.Text (Text)
 import qualified Data.Text as Text
-import System.Directory.OsPath (doesFileExist)
+import System.Directory.OsPath (createDirectoryIfMissing, doesFileExist)
 import System.OsPath (OsPath, unsafeEncodeUtf, (</>))
+import System.Posix.Files (setFileMode)
 
 harnessConfigSchemaVersion :: Int
 harnessConfigSchemaVersion = 1
@@ -68,11 +70,32 @@ instance Show McpServerConfig where
             <> show server.mcpRequestTimeoutSeconds
             <> " }"
 
+instance Aeson.ToJSON McpServerConfig where
+    toJSON server =
+        Aeson.object
+            [ "enabled" Aeson..= server.mcpEnabled
+            , "command" Aeson..= server.mcpCommand
+            , "args" Aeson..= server.mcpArgs
+            , "cwd" Aeson..= server.mcpCwd
+            , "env" Aeson..= server.mcpEnv
+            , "startupTimeoutSeconds"
+                Aeson..= server.mcpStartupTimeoutSeconds
+            , "requestTimeoutSeconds"
+                Aeson..= server.mcpRequestTimeoutSeconds
+            ]
+
 data HarnessConfig = HarnessConfig
     { configVersion :: !Int
     , configMcpServers :: !(Map Text McpServerConfig)
     }
     deriving (Eq, Show)
+
+instance Aeson.ToJSON HarnessConfig where
+    toJSON config =
+        Aeson.object
+            [ "version" Aeson..= config.configVersion
+            , "mcpServers" Aeson..= config.configMcpServers
+            ]
 
 defaultHarnessConfig :: HarnessConfig
 defaultHarnessConfig = HarnessConfig
@@ -138,6 +161,31 @@ loadHarnessConfig home = do
                             )
                     Right parsed -> Right parsed
                 validateHarnessConfig config
+
+-- | Persist the machine-wide harness configuration with owner-only
+-- permissions. The replacement is atomic so an interrupted edit cannot leave
+-- a partially-written JSON file for the next agent startup.
+saveHarnessConfig :: OsPath -> HarnessConfig -> IO (Either Text ())
+saveHarnessConfig home config =
+    case validateHarnessConfig config of
+        Left err -> pure (Left err)
+        Right valid -> do
+            let directory =
+                    home </> unsafeEncodeUtf ".haskell-agent"
+                path = harnessConfigPath home
+            result <- tryIO do
+                createDirectoryIfMissing True directory
+                setFileMode (unsafeToFilePath directory) 0o700
+                writeLazyFileAtomically path 0o600 (Aeson.encode valid)
+            pure case result of
+                Left exception ->
+                    Left
+                        ( "Failed to write "
+                            <> Text.pack (unsafeToFilePath path)
+                            <> ": "
+                            <> Text.pack (displayException exception)
+                        )
+                Right () -> Right ()
 
 validateHarnessConfig :: HarnessConfig -> Either Text HarnessConfig
 validateHarnessConfig config = do

--- a/packages/agent-cli/src/Agent/CLI/McpManager.hs
+++ b/packages/agent-cli/src/Agent/CLI/McpManager.hs
@@ -1,0 +1,567 @@
+-- | Interactive management of local stdio MCP servers.
+module Agent.CLI.McpManager
+    ( McpEntry(..)
+    , McpEntryStatus(..)
+    , McpManagerAction(..)
+    , McpManagerState(..)
+    , applyMcpManagerKey
+    , initialMcpManagerState
+    , parseMcpCommand
+    , renderMcpManagerFrame
+    , runMcpManager
+    , suggestMcpName
+    ) where
+
+import Agent.CLI.Config
+    ( HarnessConfig(..)
+    , McpServerConfig(..)
+    , loadHarnessConfig
+    , saveHarnessConfig
+    )
+import Agent.CLI.Input (readApprovalLine)
+import Agent.CLI.Picker
+    ( PickerKey(..)
+    , runOverlay
+    )
+import Agent.CLI.Style
+    ( roleError
+    , roleMuted
+    , rolePrompt
+    , roleSuccess
+    , roleWarn
+    )
+import Agent.MCP (McpToolRegistration(..))
+import Agent.Tools.Types (AppTool(..))
+import Data.Char (isAlphaNum, isSpace, toLower)
+import Data.List (find)
+import qualified Data.Map.Strict as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Set as Set
+import Data.Set (Set)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.IO as Text
+import System.FilePath (dropExtension, takeFileName)
+import System.IO
+    ( hFlush
+    , hIsTerminalDevice
+    , isEOF
+    , stderr
+    , stdin
+    )
+import System.OsPath (OsPath)
+
+data McpEntryStatus
+    = McpDisabled
+    | McpPendingRestart
+    | McpReady !Int
+    | McpUnavailable !Text
+    deriving (Eq, Show)
+
+data McpEntry = McpEntry
+    { mcpEntryName :: !Text
+    , mcpEntryConfig :: !McpServerConfig
+    , mcpEntryStatus :: !McpEntryStatus
+    , mcpEntryTools :: ![(Text, Text)]
+    , mcpEntryWarnings :: ![Text]
+    }
+    deriving (Eq, Show)
+
+data McpManagerState = McpManagerState
+    { mcpManagerEntries :: ![McpEntry]
+    , mcpManagerIndex :: !Int
+    , mcpManagerExpanded :: !(Maybe Text)
+    , mcpManagerRestartPending :: !Bool
+    , mcpManagerNotice :: !(Maybe (Bool, Text))
+    }
+    deriving (Eq, Show)
+
+data McpManagerAction
+    = McpManagerClose
+    | McpManagerRestart
+    | McpManagerAdd
+    | McpManagerToggle !Text
+    | McpManagerRemove !Text
+    deriving (Eq, Show)
+
+initialMcpManagerState
+    :: HarnessConfig
+    -> [McpToolRegistration]
+    -> [Text]
+    -> Set Text
+    -> Maybe (Bool, Text)
+    -> McpManagerState
+initialMcpManagerState config registrations warnings pending notice =
+    McpManagerState
+        { mcpManagerEntries =
+            [ entryFor label server
+            | (label, server) <- Map.toAscList config.configMcpServers
+            ]
+        , mcpManagerIndex = 0
+        , mcpManagerExpanded = Nothing
+        , mcpManagerRestartPending = not (Set.null pending)
+        , mcpManagerNotice = notice
+        }
+  where
+    toolsByServer =
+        Map.fromListWith (<>)
+            [ ( registration.mcpRegistrationServer
+              , [ ( tool.appToolName
+                  , firstLine tool.appToolDescription
+                  )
+                ]
+              )
+            | registration <- registrations
+            , let tool = registration.mcpRegistrationTool
+            ]
+    entryFor label server =
+        let entryWarnings = warningsFor label warnings
+            tools = Map.findWithDefault [] label toolsByServer
+            failed =
+                find (Text.isInfixOf " failed to start:") entryWarnings
+            status
+                | not server.mcpEnabled = McpDisabled
+                | label `Set.member` pending = McpPendingRestart
+                | Just warning <- failed =
+                    McpUnavailable (failureSummary warning)
+                | otherwise = McpReady (length tools)
+        in McpEntry
+            { mcpEntryName = label
+            , mcpEntryConfig = server
+            , mcpEntryStatus = status
+            , mcpEntryTools = tools
+            , mcpEntryWarnings = entryWarnings
+            }
+
+applyMcpManagerKey
+    :: PickerKey
+    -> McpManagerState
+    -> Either McpManagerAction McpManagerState
+applyMcpManagerKey key state = case key of
+    PickerKeyCancel -> Left McpManagerClose
+    PickerKeyConfirm ->
+        case selectedEntry state of
+            Nothing -> Right state
+            Just entry ->
+                Right state
+                    { mcpManagerExpanded =
+                        if state.mcpManagerExpanded == Just entry.mcpEntryName
+                            then Nothing
+                            else Just entry.mcpEntryName
+                    }
+    PickerKeyChar 'r' -> Left McpManagerRestart
+    PickerKeyChar 'R' -> Left McpManagerRestart
+    PickerKeyChar 'a' -> Left McpManagerAdd
+    PickerKeyChar 'A' -> Left McpManagerAdd
+    PickerKeyChar ' ' -> selectedAction McpManagerToggle
+    PickerKeyChar 'e' -> selectedAction McpManagerToggle
+    PickerKeyChar 'E' -> selectedAction McpManagerToggle
+    PickerKeyChar 'x' -> selectedAction McpManagerRemove
+    PickerKeyChar 'X' -> selectedAction McpManagerRemove
+    PickerKeyUp -> Right (moveSelection (-1) state)
+    PickerKeyDown -> Right (moveSelection 1 state)
+    _ -> Right state
+  where
+    selectedAction constructor =
+        maybe (Right state) (Left . constructor . (.mcpEntryName))
+            (selectedEntry state)
+
+renderMcpManagerFrame :: Bool -> McpManagerState -> Text
+renderMcpManagerFrame color state =
+    Text.intercalate "\n" $
+        [ rolePrompt color "MCP servers"
+            <> roleMuted color
+                (" · " <> Text.pack (show (length state.mcpManagerEntries))
+                    <> " local")
+            <> if state.mcpManagerRestartPending
+                then roleWarn color " · restart pending"
+                else ""
+        ]
+            <> maybe [] renderNotice state.mcpManagerNotice
+            <> body
+            <> [ roleMuted color
+                    "↑↓/jk or scroll · enter details · a add · space enable/disable · x remove"
+               , roleMuted color
+                    "r restart/refresh · esc/q close"
+               ]
+  where
+    renderNotice (success, message) =
+        [ (if success then roleSuccess else roleError) color message ]
+    body = case state.mcpManagerEntries of
+        [] ->
+            [ roleWarn color "No local MCP servers configured."
+            , roleMuted color
+                "Press a to add a stdio server."
+            ]
+        entries ->
+            concat $
+                zipWith (renderEntry color state) [0 ..] entries
+
+runMcpManager
+    :: Bool
+    -> OsPath
+    -> [McpToolRegistration]
+    -> [Text]
+    -> IO Bool
+runMcpManager color home registrations warnings = do
+    loadHarnessConfig home >>= \case
+        Left err -> do
+            Text.hPutStrLn stderr (roleError color err)
+            pure False
+        Right config -> do
+            tty <- hIsTerminalDevice stdin
+            if not tty
+                then do
+                    Text.hPutStrLn stderr $
+                        renderMcpManagerFrame color
+                            (initialMcpManagerState
+                                config registrations warnings Set.empty Nothing)
+                    hFlush stderr
+                    pure False
+                else loop config Set.empty False Nothing
+  where
+    loop config pending changed notice = do
+        let state =
+                initialMcpManagerState
+                    config registrations warnings pending notice
+        runOverlay (renderMcpManagerFrame color) applyMcpManagerKey state
+            >>= \case
+                Nothing -> pure changed
+                Just McpManagerClose -> pure changed
+                Just McpManagerRestart -> pure True
+                Just McpManagerAdd ->
+                    promptNewServer config >>= \case
+                        Left err ->
+                            loop config pending changed (Just (False, err))
+                        Right Nothing ->
+                            loop config pending changed Nothing
+                        Right (Just (label, server)) ->
+                            persist
+                                (config
+                                    { configMcpServers =
+                                        Map.insert label server
+                                            config.configMcpServers
+                                    })
+                                (Set.insert label pending)
+                                ("Added " <> label)
+                Just (McpManagerToggle label) ->
+                    case Map.lookup label config.configMcpServers of
+                        Nothing ->
+                            loop config pending changed
+                                (Just (False, "MCP server no longer exists"))
+                        Just server ->
+                            let enabled = not server.mcpEnabled
+                                updated =
+                                    config
+                                        { configMcpServers =
+                                            Map.insert label
+                                                (server { mcpEnabled = enabled })
+                                                config.configMcpServers
+                                        }
+                                message =
+                                    label <> if enabled
+                                        then " enabled"
+                                        else " disabled"
+                            in persist updated (Set.insert label pending) message
+                Just (McpManagerRemove label) -> do
+                    confirmed <-
+                        confirm
+                            ("Remove MCP server " <> quote label <> "? [y/N] ")
+                    if not confirmed
+                        then loop config pending changed Nothing
+                        else
+                            persist
+                                (config
+                                    { configMcpServers =
+                                        Map.delete label config.configMcpServers
+                                    })
+                                (Set.insert label pending)
+                                ("Removed " <> label)
+      where
+        persist updated pending' message =
+            saveHarnessConfig home updated >>= \case
+                Left err ->
+                    loop config pending changed (Just (False, err))
+                Right () ->
+                    loop updated pending' True (Just (True, message))
+
+promptNewServer
+    :: HarnessConfig
+    -> IO (Either Text (Maybe (Text, McpServerConfig)))
+promptNewServer config =
+    promptLine "Command: " >>= \case
+        Nothing -> pure (Right Nothing)
+        Just raw
+            | Text.null (Text.strip raw) -> pure (Right Nothing)
+            | otherwise -> case parseMcpCommand raw of
+                Left err -> pure (Left err)
+                Right (command, arguments) -> do
+                    let suggested = suggestMcpName command arguments
+                    promptLine ("Name [" <> suggested <> "]: ") >>= \case
+                        Nothing -> pure (Right Nothing)
+                        Just rawName ->
+                            let label =
+                                    if Text.null (Text.strip rawName)
+                                        then suggested
+                                        else Text.strip rawName
+                            in if Map.member label config.configMcpServers
+                                then pure
+                                    (Left
+                                        ("MCP server " <> quote label
+                                            <> " already exists"))
+                                else pure . Right . Just $
+                                    ( label
+                                    , McpServerConfig
+                                        { mcpEnabled = True
+                                        , mcpCommand = command
+                                        , mcpArgs = arguments
+                                        , mcpCwd = Nothing
+                                        , mcpEnv = Map.empty
+                                        , mcpStartupTimeoutSeconds = 30
+                                        , mcpRequestTimeoutSeconds = 60
+                                        }
+                                    )
+
+parseMcpCommand :: Text -> Either Text (Text, [Text])
+parseMcpCommand input = do
+    arguments <- parseWords (Text.unpack input)
+    case map Text.pack arguments of
+        command : rest
+            | not (Text.null (Text.strip command)) ->
+                Right (command, rest)
+        _ -> Left "MCP command must not be empty"
+
+suggestMcpName :: Text -> [Text] -> Text
+suggestMcpName command arguments =
+    fromMaybe "mcp-server" (find usable candidates)
+  where
+    candidates = map normalizeCandidate $
+        case Text.toLower (baseName command) of
+            "nix" ->
+                dropLauncherOptions ["run"] arguments
+                    <> [command]
+            "npx" ->
+                dropLauncherOptions [] arguments
+                    <> [command]
+            "node" ->
+                dropLauncherOptions [] arguments
+                    <> [command]
+            _ -> command : arguments
+    dropLauncherOptions subcommands =
+        dropWhile
+            (\value ->
+                "-" `Text.isPrefixOf` value
+                    || Text.toLower value `elem` subcommands)
+    normalizeCandidate =
+        Text.map normalizeChar
+            . Text.pack . dropExtension . Text.unpack . baseName
+    baseName =
+        Text.pack . takeFileName . Text.unpack
+    normalizeChar char
+        | isAlphaNum char || char `elem` ['-', '_', '.'] = toLower char
+        | otherwise = '-'
+    usable candidate =
+        not (Text.null candidate)
+            && candidate `notElem` ["run", "exec", "npx", "node", "nix"]
+            && not ("-" `Text.isPrefixOf` candidate)
+
+renderEntry :: Bool -> McpManagerState -> Int -> McpEntry -> [Text]
+renderEntry color state index entry =
+    [ prefix
+        <> enabledMarker
+        <> " "
+        <> entry.mcpEntryName
+        <> " "
+        <> renderStatus color entry.mcpEntryStatus
+    ]
+        <> if state.mcpManagerExpanded == Just entry.mcpEntryName
+            then renderDetails color entry
+            else []
+  where
+    prefix =
+        if index == state.mcpManagerIndex
+            then rolePrompt color "› "
+            else "  "
+    enabledMarker =
+        if entry.mcpEntryConfig.mcpEnabled
+            then roleSuccess color "●"
+            else roleMuted color "○"
+
+renderStatus :: Bool -> McpEntryStatus -> Text
+renderStatus color = \case
+    McpDisabled -> roleMuted color "[disabled]"
+    McpPendingRestart -> roleWarn color "[restart pending]"
+    McpReady count ->
+        roleSuccess color "[ready]"
+            <> roleMuted color
+                (" · " <> Text.pack (show count) <> plural count " tool")
+    McpUnavailable reason ->
+        roleError color "[unavailable]"
+            <> roleMuted color (" · " <> truncateText 72 reason)
+
+renderDetails :: Bool -> McpEntry -> [Text]
+renderDetails color entry =
+    [ roleMuted color ("    command: " <> renderCommand server)
+    ]
+        <> maybe []
+            (\cwd -> [roleMuted color ("    cwd: " <> cwd)])
+            server.mcpCwd
+        <> unlessEmpty envNames
+            [ roleMuted color
+                ("    env: " <> Text.intercalate ", " envNames
+                    <> " (values hidden)")
+            ]
+        <> [ roleMuted color
+                ("    timeouts: startup "
+                    <> Text.pack (show server.mcpStartupTimeoutSeconds)
+                    <> "s · request "
+                    <> Text.pack (show server.mcpRequestTimeoutSeconds)
+                    <> "s")
+           ]
+        <> toolLines
+        <> warningLines
+  where
+    server = entry.mcpEntryConfig
+    envNames = Map.keys server.mcpEnv
+    toolLines = case entry.mcpEntryTools of
+        [] -> [roleMuted color "    tools: none exposed"]
+        tools ->
+            roleMuted color
+                ("    tools (" <> Text.pack (show (length tools)) <> "):")
+                : [ roleMuted color
+                        ("      " <> name
+                            <> if Text.null description
+                                then ""
+                                else " — " <> truncateText 88 description)
+                  | (name, description) <- tools
+                  ]
+    warningLines =
+        [ roleWarn color ("    warning: " <> warningSummary warning)
+        | warning <- entry.mcpEntryWarnings
+        , not (" failed to start:" `Text.isInfixOf` warning)
+        ]
+
+renderCommand :: McpServerConfig -> Text
+renderCommand server =
+    Text.intercalate " " $
+        map shellQuote (server.mcpCommand : server.mcpArgs)
+
+shellQuote :: Text -> Text
+shellQuote value
+    | not (Text.null value)
+    , Text.all safe value = value
+    | otherwise =
+        "'" <> Text.replace "'" "'\\''" value <> "'"
+  where
+    safe char =
+        isAlphaNum char || char `elem` ("-._/:@+=," :: String)
+
+warningsFor :: Text -> [Text] -> [Text]
+warningsFor label =
+    filter (Text.isPrefixOf ("MCP server " <> label <> " "))
+
+failureSummary :: Text -> Text
+failureSummary warning =
+    let marker = " failed to start: "
+        (_, suffix) = Text.breakOn marker warning
+    in if Text.null suffix
+        then warning
+        else Text.strip (Text.drop (Text.length marker) suffix)
+
+warningSummary :: Text -> Text
+warningSummary warning =
+    let marker = " skipped "
+        (_, suffix) = Text.breakOn marker warning
+    in if Text.null suffix
+        then warning
+        else "skipped " <> Text.strip (Text.drop (Text.length marker) suffix)
+
+selectedEntry :: McpManagerState -> Maybe McpEntry
+selectedEntry state =
+    case drop state.mcpManagerIndex state.mcpManagerEntries of
+        entry : _ -> Just entry
+        [] -> Nothing
+
+moveSelection :: Int -> McpManagerState -> McpManagerState
+moveSelection delta state
+    | count == 0 = state { mcpManagerIndex = 0 }
+    | otherwise =
+        state
+            { mcpManagerIndex =
+                (state.mcpManagerIndex + delta) `mod` count
+            }
+  where
+    count = length state.mcpManagerEntries
+
+promptLine :: Text -> IO (Maybe Text)
+promptLine prompt = do
+    Text.hPutStr stderr prompt
+    hFlush stderr
+    eof <- isEOF
+    if eof then pure Nothing else Just <$> Text.getLine
+
+confirm :: Text -> IO Bool
+confirm prompt =
+    readApprovalLine prompt >>= \case
+        Just answer ->
+            pure (Text.toLower (Text.strip answer) `elem` ["y", "yes"])
+        Nothing -> pure False
+
+parseWords :: String -> Either Text [String]
+parseWords = go WordUnquoted False False [] []
+  where
+    go quote escaped started current completed = \case
+        []
+            | escaped -> Left "MCP command ends with an incomplete escape"
+            | quote /= WordUnquoted ->
+                Left "MCP command contains an unterminated quote"
+            | started -> Right (reverse (reverse current : completed))
+            | otherwise -> Right (reverse completed)
+        char : rest
+            | escaped ->
+                go quote False True (char : current) completed rest
+            | quote == WordSingle ->
+                if char == '\''
+                    then go WordUnquoted False True current completed rest
+                    else go quote False True (char : current) completed rest
+            | quote == WordDouble ->
+                case char of
+                    '"' -> go WordUnquoted False True current completed rest
+                    '\\' -> go quote True True current completed rest
+                    _ -> go quote False True (char : current) completed rest
+            | isSpace char ->
+                if started
+                    then
+                        go WordUnquoted False False []
+                            (reverse current : completed) rest
+                    else go WordUnquoted False False [] completed rest
+            | otherwise -> case char of
+                '\'' -> go WordSingle False True current completed rest
+                '"' -> go WordDouble False True current completed rest
+                '\\' -> go WordUnquoted True True current completed rest
+                _ -> go WordUnquoted False True (char : current) completed rest
+
+data WordQuote
+    = WordUnquoted
+    | WordSingle
+    | WordDouble
+    deriving (Eq)
+
+firstLine :: Text -> Text
+firstLine = Text.strip . Text.takeWhile (/= '\n')
+
+truncateText :: Int -> Text -> Text
+truncateText limit value
+    | Text.length value <= limit = value
+    | otherwise = Text.take (max 0 (limit - 1)) value <> "…"
+
+plural :: Int -> Text -> Text
+plural count noun = noun <> if count == 1 then "" else "s"
+
+unlessEmpty :: [a] -> [b] -> [b]
+unlessEmpty values output
+    | null values = []
+    | otherwise = output
+
+quote :: Text -> Text
+quote value = "'" <> value <> "'"

--- a/packages/agent-cli/src/Agent/CLI/SessionEnv.hs
+++ b/packages/agent-cli/src/Agent/CLI/SessionEnv.hs
@@ -18,6 +18,7 @@ import Agent.CLI.TUI.App (FullscreenRuntime)
 import Agent.Dialect (Dialect)
 import Agent.Error (ApiError)
 import Agent.Loop (ImageAttachment, LoopConfig, TokenUsage)
+import Agent.MCP (McpToolRegistration)
 import qualified Agent.OpenAI.Auth as OpenAI
 import Agent.Responses.Types (ResponseCreateParams, ResponseItem)
 import System.OsPath (OsPath)
@@ -52,6 +53,8 @@ data SessionEnv = SessionEnv
     , sessionProjectRoot :: !OsPath
     , sessionCwd :: !OsPath
     , sessionHome :: !OsPath
+    , sessionMcpRegistrations :: ![McpToolRegistration]
+    , sessionMcpWarnings :: ![Text]
     , sessionSetTempDir :: !(OsPath -> IO ())
     , sessionTokenProvider :: !(Maybe TokenProvider)
     , sessionOpenAiPool :: !(Maybe OpenAI.Pool)

--- a/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
@@ -168,6 +168,12 @@ spec = do
             parseReplLine "/agents now"
                 `shouldBe` ReplCommandError "usage: /agents"
 
+        it "opens the MCP server manager" do
+            parseReplLine "/mcp" `shouldBe` ReplMcp
+            parseReplLine "/MCP" `shouldBe` ReplMcp
+            parseReplLine "/mcp now"
+                `shouldBe` ReplCommandError "usage: /mcp"
+
         it "lists slash commands with /help" do
             parseReplLine "/help" `shouldBe` ReplHelp Nothing
             parseReplLine "/help model" `shouldBe` ReplHelp (Just "model")
@@ -237,6 +243,7 @@ spec = do
                     , "copy-session"
                     , "terminal"
                     , "agents"
+                    , "mcp"
                     , "skills"
                     , "shell"
                     , "always-approve"
@@ -260,6 +267,7 @@ spec = do
                         && "/model" `elem` xs
                         && "/m" `elem` xs
                         && "/agents" `elem` xs
+                        && "/mcp" `elem` xs
                         && "/btw" `elem` xs)
             slashCompletionCandidates "" "/mo" `shouldBe` ["/model"]
             slashCompletionCandidates "ledom/" "high" `shouldBe` []
@@ -332,6 +340,7 @@ spec = do
             listing `shouldSatisfy` ("(/m)" `isInfixOf`)
             listing `shouldSatisfy` ("/btw <QUESTION>" `isInfixOf`)
             listing `shouldSatisfy` ("/agents" `isInfixOf`)
+            listing `shouldSatisfy` ("/mcp" `isInfixOf`)
             listing `shouldSatisfy` ("/usage" `isInfixOf`)
             listing `shouldSatisfy` ("/worktree" `isInfixOf`)
             Text.unpack (formatSlashHelp False (Just "effort"))

--- a/packages/agent-cli/test/Agent/CLI/ConfigSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ConfigSpec.hs
@@ -18,6 +18,10 @@ import System.OsPath
     , unsafeEncodeUtf
     )
 import System.Posix.Temp (mkdtemp)
+import System.Posix.Files
+    ( fileMode
+    , getFileStatus
+    )
 import Test.Hspec
 
 spec :: Spec
@@ -90,6 +94,43 @@ spec = describe "Agent.CLI.Config" do
                     "Invalid " `Text.isPrefixOf` err
                         && "config.json" `Text.isInfixOf` err
                 Right _ -> False
+
+    it "atomically saves a private, loadable MCP configuration" $
+        withTempDir "agent-config-" \home -> do
+            let server = McpServerConfig
+                    { mcpEnabled = True
+                    , mcpCommand = "nix"
+                    , mcpArgs = ["run", "/tmp/seo-mcp"]
+                    , mcpCwd = Just "/tmp"
+                    , mcpEnv = Map.fromList [("TOKEN", "secret")]
+                    , mcpStartupTimeoutSeconds = 90
+                    , mcpRequestTimeoutSeconds = 45
+                    }
+                config = defaultHarnessConfig
+                    { configMcpServers = Map.singleton "seo-mcp" server
+                    }
+            saveHarnessConfig home config `shouldReturn` Right ()
+            loadHarnessConfig home `shouldReturn` Right config
+            status <- getFileStatus (filePath (harnessConfigPath home))
+            fileMode status `shouldBe` 0o100600
+
+    it "validates before saving" $
+        withTempDir "agent-config-" \home -> do
+            let broken = defaultHarnessConfig
+                    { configMcpServers =
+                        Map.singleton "broken" McpServerConfig
+                            { mcpEnabled = True
+                            , mcpCommand = ""
+                            , mcpArgs = []
+                            , mcpCwd = Nothing
+                            , mcpEnv = Map.empty
+                            , mcpStartupTimeoutSeconds = 30
+                            , mcpRequestTimeoutSeconds = 60
+                            }
+                    }
+            saveHarnessConfig home broken
+                `shouldReturn`
+                    Left "MCP server 'broken' has an empty command"
 
 writeConfig :: OsPath -> LBS.ByteString -> IO ()
 writeConfig home bytes = do

--- a/packages/agent-cli/test/Agent/CLI/McpManagerSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/McpManagerSpec.hs
@@ -1,0 +1,116 @@
+module Agent.CLI.McpManagerSpec (spec) where
+
+import Agent.CLI.Config
+import Agent.CLI.McpManager
+import Agent.CLI.Picker (PickerKey(..))
+import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
+import qualified Data.Text as Text
+import Test.Hspec
+
+spec :: Spec
+spec = describe "Agent.CLI.McpManager" do
+    describe "command parsing" do
+        it "splits quoted stdio commands without invoking a shell" do
+            parseMcpCommand
+                "nix run '/path with spaces/seo-mcp' --flag=\"two words\""
+                `shouldBe`
+                    Right
+                        ( "nix"
+                        , [ "run"
+                          , "/path with spaces/seo-mcp"
+                          , "--flag=two words"
+                          ]
+                        )
+
+        it "supports escaped spaces and empty quoted arguments" do
+            parseMcpCommand "server one\\ two ''"
+                `shouldBe` Right ("server", ["one two", ""])
+
+        it "rejects incomplete quoting and escapes" do
+            parseMcpCommand "server 'unfinished"
+                `shouldBe`
+                    Left "MCP command contains an unterminated quote"
+            parseMcpCommand "server trailing\\"
+                `shouldBe`
+                    Left "MCP command ends with an incomplete escape"
+
+        it "suggests useful labels for common launchers" do
+            suggestMcpName "nix" ["run", "/repo/seo-mcp"]
+                `shouldBe` "seo-mcp"
+            suggestMcpName
+                "npx"
+                ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]
+                `shouldBe` "server-filesystem"
+            suggestMcpName "/usr/local/bin/my-server" []
+                `shouldBe` "my-server"
+
+    describe "navigation and actions" do
+        let alpha = server True "alpha-command"
+            beta = server False "beta-command"
+            state =
+                initialMcpManagerState
+                    defaultHarnessConfig
+                        { configMcpServers =
+                            Map.fromList
+                                [ ("alpha", alpha)
+                                , ("beta", beta)
+                                ]
+                        }
+                    []
+                    []
+                    Set.empty
+                    Nothing
+
+        it "moves, expands, toggles, removes, adds, and refreshes" do
+            applyMcpManagerKey PickerKeyDown state
+                `shouldSatisfy` \case
+                    Right moved -> moved.mcpManagerIndex == 1
+                    Left _ -> False
+            applyMcpManagerKey PickerKeyConfirm state
+                `shouldSatisfy` \case
+                    Right expanded ->
+                        expanded.mcpManagerExpanded == Just "alpha"
+                    Left _ -> False
+            applyMcpManagerKey (PickerKeyChar ' ') state
+                `shouldBe` Left (McpManagerToggle "alpha")
+            applyMcpManagerKey (PickerKeyChar 'x') state
+                `shouldBe` Left (McpManagerRemove "alpha")
+            applyMcpManagerKey (PickerKeyChar 'a') state
+                `shouldBe` Left McpManagerAdd
+            applyMcpManagerKey (PickerKeyChar 'r') state
+                `shouldBe` Left McpManagerRestart
+
+        it "renders status, command details, and hidden environment values" do
+            let configured = alpha
+                    { mcpArgs = ["arg with spaces"]
+                    , mcpEnv = Map.singleton "TOKEN" "do-not-render"
+                    }
+                expanded =
+                    (initialMcpManagerState
+                        defaultHarnessConfig
+                            { configMcpServers =
+                                Map.singleton "alpha" configured
+                            }
+                        []
+                        []
+                        Set.empty
+                        Nothing)
+                        { mcpManagerExpanded = Just "alpha" }
+                frame = renderMcpManagerFrame False expanded
+            frame `shouldSatisfy` Text.isInfixOf "[ready]"
+            frame `shouldSatisfy`
+                Text.isInfixOf "alpha-command 'arg with spaces'"
+            frame `shouldSatisfy` Text.isInfixOf "TOKEN (values hidden)"
+            frame `shouldNotSatisfy` Text.isInfixOf "do-not-render"
+
+server :: Bool -> Text.Text -> McpServerConfig
+server enabled command = McpServerConfig
+    { mcpEnabled = enabled
+    , mcpCommand = command
+    , mcpArgs = []
+    , mcpCwd = Nothing
+    , mcpEnv = Map.empty
+    , mcpStartupTimeoutSeconds = 30
+    , mcpRequestTimeoutSeconds = 60
+    }

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -22,6 +22,7 @@ import qualified Agent.CLI.InputSpec as InputSpec
 import qualified Agent.CLI.InterruptSpec as InterruptSpec
 import qualified Agent.CLI.LoginSpec as LoginSpec
 import qualified Agent.CLI.MarkdownSpec as MarkdownSpec
+import qualified Agent.CLI.McpManagerSpec as McpManagerSpec
 import qualified Agent.CLI.ModelConfigSpec as ModelConfigSpec
 import qualified Agent.CLI.ModelPickerSpec as ModelPickerSpec
 import qualified Agent.CLI.ModelsSpec as ModelsSpec
@@ -84,6 +85,7 @@ main = hspec do
     InterruptSpec.spec
     LoginSpec.spec
     MarkdownSpec.spec
+    McpManagerSpec.spec
     ModelConfigSpec.spec
     ModelPickerSpec.spec
     ModelsSpec.spec


### PR DESCRIPTION
## Summary

- add an interactive `/mcp` manager for local stdio servers
- show runtime status, discovered tools, configuration details, and startup warnings without displaying environment values
- support adding, enabling, disabling, and removing servers with atomic owner-only configuration writes
- restart the MCP runtime after changes while resuming the same persisted session
- add command, configuration, rendering, parser, and persistence coverage

## Testing

- `nix develop -c cabal repl agent-cli:test:agent-cli-test --repl-options=-e main` (793 examples, 0 failures)
- `nix build path:.#agent-cli --no-link`
- `git diff --check`
- manually exercised `/mcp` in tmux, including details, add/cancel, and restart/resume
