### PR TITLE
Refactor CLI input into focused modules

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -61,6 +61,12 @@ library
                     , Agent.CLI.Error
                     , Agent.CLI.ImagePreview
                     , Agent.CLI.Input
+                    , Agent.CLI.Input.Types
+                    , Agent.CLI.Input.Display
+                    , Agent.CLI.Input.Paste
+                    , Agent.CLI.Input.History
+                    , Agent.CLI.Input.KeyDecoder
+                    , Agent.CLI.Input.Picker
                     , Agent.CLI.Interrupt
                     , Agent.CLI.Login
                     , Agent.CLI.Markdown

--- a/packages/agent-cli/package.nix
+++ b/packages/agent-cli/package.nix
@@ -1,10 +1,12 @@
-{ mkDerivation, aeson, agent-claude, agent-codex-dialect, agent-core
-, agent-grok-build-dialect, agent-openai, agent-openrouter, agent-responses
-, agent-responses-types, agent-syntax, agent-tui, agent-xai, ansi-terminal
-, async, base, base64-bytestring, brick, bytestring, colour, containers
+{ mkDerivation, aeson, agent-claude, agent-codex-dialect
+, agent-core, agent-grok-build-dialect, agent-openai
+, agent-openrouter, agent-responses, agent-responses-types
+, agent-syntax, agent-tui, agent-xai, ansi-terminal, async, base
+, base64-bytestring, brick, bytestring, colour, containers
 , directory, filelock, filepath, haskeline, hspec, http-client
-, http-client-tls, JuicyPixels, lib, mtl, process, safe-exceptions, stm
-, text, time, transformers, unix, vector, vty, vty-crossplatform
+, http-client-tls, JuicyPixels, lib, mtl, process, safe-exceptions
+, stm, text, time, transformers, unix, vector, vty
+, vty-crossplatform
 }:
 mkDerivation {
   pname = "agent-cli";
@@ -12,26 +14,28 @@ mkDerivation {
   src = ./.;
   isLibrary = true;
   isExecutable = true;
+  enableSeparateDataOutput = true;
   libraryHaskellDepends = [
-    aeson agent-claude agent-codex-dialect agent-core agent-grok-build-dialect
-    agent-openai agent-openrouter agent-responses agent-responses-types
-    agent-syntax agent-tui agent-xai ansi-terminal async base
-    base64-bytestring brick bytestring colour containers directory filelock
-    filepath haskeline http-client http-client-tls JuicyPixels mtl process
-    safe-exceptions stm text time transformers unix vector vty
-    vty-crossplatform
+    aeson agent-claude agent-codex-dialect agent-core
+    agent-grok-build-dialect agent-openai agent-openrouter
+    agent-responses agent-responses-types agent-syntax agent-tui
+    agent-xai ansi-terminal async base base64-bytestring brick
+    bytestring colour containers directory filelock filepath haskeline
+    http-client http-client-tls JuicyPixels mtl process safe-exceptions
+    stm text time transformers unix vector vty vty-crossplatform
   ];
   executableHaskellDepends = [
-    aeson agent-responses agent-responses-types base bytestring containers
-    directory filepath process safe-exceptions text time unix
+    aeson agent-responses agent-responses-types base bytestring
+    containers directory filepath process safe-exceptions text time
+    unix
   ];
   testHaskellDepends = [
     aeson agent-claude agent-codex-dialect agent-core
-    agent-grok-build-dialect agent-openai agent-openrouter agent-responses
-    agent-responses-types agent-tui agent-xai ansi-terminal async base
-    base64-bytestring brick bytestring colour containers directory filepath
-    haskeline hspec JuicyPixels mtl process safe-exceptions stm text time
-    transformers unix vty
+    agent-grok-build-dialect agent-openai agent-openrouter
+    agent-responses agent-responses-types agent-tui agent-xai
+    ansi-terminal async base brick bytestring colour containers
+    directory filepath haskeline hspec JuicyPixels process
+    safe-exceptions stm text time transformers unix vty
   ];
   benchmarkHaskellDepends = [
     aeson agent-core agent-responses base bytestring containers
@@ -39,5 +43,4 @@ mkDerivation {
   ];
   description = "Command-line interface for the universal agent harness";
   license = lib.meta.getLicenseFromSpdxId "MIT";
-  mainProgram = "agent-cli";
 }

--- a/packages/agent-cli/src/Agent/CLI/Input.hs
+++ b/packages/agent-cli/src/Agent/CLI/Input.hs
@@ -40,6 +40,12 @@ import Agent.CLI.Command
     , SlashSuggestion(..)
     , slashMenuForWithSkillsAndModels
     )
+import Agent.CLI.Input.Display
+import Agent.CLI.Input.History
+import Agent.CLI.Input.KeyDecoder
+import Agent.CLI.Input.Paste
+import Agent.CLI.Input.Picker
+import Agent.CLI.Input.Types
 import Agent.CLI.Interrupt
     ( IdleCtrlCResult(..)
     , InterruptState
@@ -51,20 +57,12 @@ import Agent.CLI.Terminal
     , emitTerminalSequence
     , kittyKeyboardDisambiguatePush
     , kittyKeyboardPop
-    , shiftEnterCsiBodies
     , stripAnsi
     )
-import Agent.Loop (ImageAttachment)
-import Agent.TUI.TextWidth (charCellWidth)
 import Control.Exception.Safe (bracket, bracket_, catchIO, throwIO, tryIO)
 import Control.Monad (unless, when)
-import Data.Bits ((.&.))
 import Data.Char
-    ( GeneralCategory(..)
-    , chr
-    , generalCategory
-    , isSpace
-    , ord
+    ( isSpace
     )
 import Data.List (isPrefixOf)
 import Data.Maybe (fromMaybe)
@@ -88,10 +86,8 @@ import System.Console.Haskeline.History
     , writeHistory
     )
 import System.Directory
-    ( createDirectoryIfMissing
-    , getHomeDirectory
+    ( getHomeDirectory
     )
-import System.FilePath (takeDirectory, (</>))
 import System.IO
     ( BufferMode(..)
     , Handle
@@ -107,7 +103,6 @@ import System.IO
     , stdout
     )
 import System.IO.Error (isEOFError)
-import System.Posix.Files (setFileMode)
 import System.Posix.IO (stdInput)
 import System.Posix.Terminal
     ( TerminalMode(..)
@@ -119,137 +114,6 @@ import System.Posix.Terminal
     , withTime
     , withoutMode
     )
-import System.Posix.Types (FileMode)
-
--- | Outcome of an interactive REPL read.
-data ReplLine
-    = ReplEof
-    | ReplText Text
-    -- | Submitted text that arrived as a paste (bracketed paste, or a
-    -- multi-line / burst heuristic). @replText@ is the payload with CSI
-    -- paste wrappers stripped.
-    | ReplPasted Text
-    -- | Attach a native clipboard image while keeping the current draft.
-    | ReplClipboardPaste !Text !(Maybe [ImageAttachment])
-    -- | Classify a bracketed paste off the UI thread. If the clipboard contains
-    -- an image, attach it and keep the original draft; otherwise restore the
-    -- supplied draft with the pasted terminal text inserted.
-    | ReplClipboardPasteOrText !Text !Text
-    | ReplCycleMode Text
-    -- ^ Shift+Tab: cycle idle mode and keep the current draft.
-    | ReplChooseModel Text
-    -- ^ Fullscreen status click: open the model selector and keep the draft.
-    | ReplChooseEffort Text
-    -- ^ Fullscreen status click: open the effort selector and keep the draft.
-    | ReplChooseAccount Text
-    -- ^ Fullscreen status click: open the account selector and keep the draft.
-    | ReplQuitInterrupt
-    deriving (Eq, Show)
-
--- | Keep empty composers inert unless they have queued image attachments.
--- Providers expect a non-empty text part alongside image parts, so image-only
--- submissions receive a small synthetic prompt.
-submissionPromptText :: Int -> Text -> Maybe Text
-submissionPromptText attachmentCount text
-    | not (Text.null (Text.strip text)) = Just text
-    | attachmentCount > 0 = Just "The user attached an image."
-    | otherwise = Nothing
-
--- | Strip terminal bracketed-paste wrappers (raw @CSI 200~@ / @CSI 201~@,
--- or the printable sentinels used by older history/input versions) and decide
--- whether the buffer looks pasted rather than typed.
-classifyPastedText :: Text -> (Text, Bool)
-classifyPastedText raw =
-    let stripped = stripBracketedPaste raw
-        looksPasted =
-            raw /= stripped
-                || Text.count "\n" stripped >= 3
-    in (stripped, looksPasted)
-
--- | Compact prompt chip for a multi-line paste. Single-line pastes stay inline.
-formatPasteChip :: Text -> Text
-formatPasteChip text =
-    let n = max 1 (length (Text.lines text))
-    in if n < 4
-        then text
-        else "[Pasted: " <> Text.pack (show n) <> " lines]"
-
-stripBracketedPaste :: Text -> Text
-stripBracketedPaste text =
-    Text.filter (not . isPasteSentinel)
-        (Text.replace pasteEnd "" (Text.replace pasteStart "" text))
-  where
-    pasteStart = "\ESC[200~"
-    pasteEnd = "\ESC[201~"
-
-pasteStartSentinel, pasteEndSentinel :: Char
-pasteStartSentinel = '\x27E6'
-pasteEndSentinel = '\x27E7'
-
-isPasteSentinel :: Char -> Bool
-isPasteSentinel char =
-    char == pasteStartSentinel || char == pasteEndSentinel
-
--- | @~/.haskell-agent/history@ given the user's home directory.
-replHistoryPath :: FilePath -> FilePath
-replHistoryPath home = home </> ".haskell-agent" </> "history"
-
-readReplHistory :: IO [Text]
-readReplHistory = do
-    home <- getHomeDirectory
-    let path = replHistoryPath home
-    ensureHistoryParent path
-    history <- readHistory path `catchIO` \_ -> pure emptyHistory
-    pure (map Text.pack (historyLines history))
-
-appendReplHistory :: Text -> IO ()
-appendReplHistory text
-    | Text.all isSpace text = pure ()
-    | otherwise = do
-        home <- getHomeDirectory
-        let path = replHistoryPath home
-        ensureHistoryParent path
-        history <- readHistory path `catchIO` \_ -> pure emptyHistory
-        writeHistory path (addHistory (Text.unpack text) history)
-            `catchIO` \_ -> pure ()
-
--- | Keys understood by the multiple-choice TTY picker.
-data ChoiceKey
-    = ChoiceUp
-    | ChoiceDown
-    | ChoiceEnter
-    | ChoiceCancel
-    | ChoiceDigit Int
-    deriving (Eq, Show)
-
--- | Parse a short key / CSI sequence into a 'ChoiceKey'.
--- Used by the picker and unit tests; 'Nothing' means ignore and keep reading.
-parseChoiceKey :: String -> Maybe ChoiceKey
-parseChoiceKey = \case
-    "\n" -> Just ChoiceEnter
-    "\r" -> Just ChoiceEnter
-    "\ESC" -> Just ChoiceCancel
-    "\ESC[A" -> Just ChoiceUp
-    "\ESC[B" -> Just ChoiceDown
-    "\ESCOA" -> Just ChoiceUp
-    "\ESCOB" -> Just ChoiceDown
-    "k" -> Just ChoiceUp
-    "j" -> Just ChoiceDown
-    "q" -> Just ChoiceCancel
-    "Q" -> Just ChoiceCancel
-    [c]
-        | c >= '1' && c <= '9' ->
-            Just (ChoiceDigit (ord c - ord '0'))
-    _ -> Nothing
-
--- | Wrap highlight index for ↑ / ↓ (and j / k). Other keys leave @idx@ alone.
-choiceMoveIndex :: Int -> Int -> ChoiceKey -> Int
-choiceMoveIndex len idx key
-    | len <= 0 = 0
-    | otherwise = case key of
-        ChoiceUp -> if idx <= 0 then len - 1 else idx - 1
-        ChoiceDown -> if idx >= len - 1 then 0 else idx + 1
-        _ -> idx
 
 -- | Read a REPL prompt line. Persists history under 'replHistoryPath' when
 -- stdin is a TTY. 'ReplEof' means EOF; 'ReplQuitInterrupt' means a confirmed
@@ -314,105 +178,6 @@ readReplLineConfigured skills modelIds slashEnabled interrupt prompt initial = d
     classifySubmitted text =
         let (stripped, pasted) = classifyPastedText text
         in if pasted then ReplPasted stripped else ReplText stripped
-
-data EditorState = EditorState
-    { editorText :: !Text
-    , editorCursor :: !Int
-    , editorSelected :: !Int
-    , editorHistoryIndex :: !(Maybe Int)
-    , editorHistoryDraft :: !Text
-    , editorKillBuffer :: !Text
-    , editorPasted :: !Bool
-    , editorSlashEnabled :: !Bool
-    , editorSlashDismissed :: !Bool
-    , editorSkillCommands :: ![SkillCommand]
-    , editorModelIds :: ![Text]
-    }
-
-data DisplayCell = DisplayCell
-    { displayCellText :: !Text
-    , displayCellWidth :: !Int
-    }
-
-terminalTextWidth :: Text -> Int
-terminalTextWidth = cellsWidth . displayCells
-
-terminalCharWidth :: Char -> Int
-terminalCharWidth = (.displayCellWidth) . displayCell
-
-displayCells :: Text -> [DisplayCell]
-displayCells = map displayCell . Text.unpack
-
-displayCell :: Char -> DisplayCell
-displayCell char =
-    let shown = safeDisplayChar char
-    in DisplayCell
-        { displayCellText = shown
-        , displayCellWidth = textColumns shown
-        }
-
-safeDisplayChar :: Char -> Text
-safeDisplayChar char
-    | char == '\n' || char == '\r' = "↵"
-    | char == '\t' = "⇥"
-    | code >= 0 && code <= 0x1f =
-        Text.singleton (chr (0x2400 + code))
-    | code == 0x7f = "␡"
-    | code >= 0x80 && code <= 0x9f = "�"
-    | generalCategory char == Format = "�"
-    | otherwise = Text.singleton char
-  where
-    code = ord char
-
-textColumns :: Text -> Int
-textColumns = sum . map charColumns . Text.unpack
-
-charColumns :: Char -> Int
-charColumns = charCellWidth
-
-cellsWidth :: [DisplayCell] -> Int
-cellsWidth = sum . map (.displayCellWidth)
-
-renderCells :: [DisplayCell] -> Text
-renderCells = Text.concat . map (.displayCellText)
-
-takeColumns :: Int -> [DisplayCell] -> [DisplayCell]
-takeColumns width = go 0
-  where
-    go _ [] = []
-    go used (cell:rest)
-        | used + cell.displayCellWidth > width = []
-        | otherwise = cell : go (used + cell.displayCellWidth) rest
-
-takeSuffixColumns :: Int -> [DisplayCell] -> [DisplayCell]
-takeSuffixColumns width = reverse . takeColumns width . reverse
-
-data EditorKey
-    = EditorChar !Char
-    | EditorEnter
-    | EditorBackspace
-    | EditorDelete
-    | EditorLeft
-    | EditorRight
-    | EditorHome
-    | EditorEnd
-    | EditorUp
-    | EditorDown
-    | EditorTab
-    | EditorEscape
-    | EditorInterrupt
-    | EditorEof
-    | EditorKillStart
-    | EditorKillEnd
-    | EditorKillWord
-    | EditorYank
-    | EditorClearScreen
-    | EditorCycleMode
-    | EditorClipboardPaste !(Maybe [ImageAttachment])
-    | EditorPaste !Text
-    | EditorInputError !Text
-    | EditorIgnore
-    deriving (Eq, Show)
 
 -- | First-party inline editor for the interactive TTY path. It owns the
 -- prompt redraw so slash suggestions can update after every keystroke.
@@ -791,22 +556,6 @@ readEditorKey = do
                     | char >= ' ' -> pure (EditorChar char)
                     | otherwise -> pure EditorIgnore
 
-isClipboardPasteKey :: Char -> Bool
-isClipboardPasteKey = (== '\SYN')
-
-isClipboardPasteCsiBody :: String -> Bool
-isClipboardPasteCsiBody body =
-    case parseKittyKey body of
-        Just KittyKey{kittyCodepoint, kittyModifiers, kittyEvent}
-            | kittyEvent /= kittyRelease ->
-                kittyCodepoint == ord 'v'
-                    && (hasModifier kittyCtrl kittyModifiers
-                        || hasModifier kittySuper kittyModifiers)
-        _ -> False
-
-isShiftEnterCsiBody :: String -> Bool
-isShiftEnterCsiBody body = body `elem` shiftEnterCsiBodies
-
 readEscapeKey :: IO EditorKey
 readEscapeKey = do
     ready <- hWaitForInput stdin 25
@@ -865,21 +614,6 @@ readCsiKey =
                                     EditorClipboardPaste (Just attached)
                                 Nothing -> EditorPaste pasted
                 _ -> pure EditorIgnore
-
-data KittyKey = KittyKey
-    { kittyCodepoint :: !Int
-    , kittyModifiers :: !Int
-    , kittyEvent :: !Int
-    }
-
-kittyShift, kittyCtrl, kittySuper, kittyRelease :: Int
-kittyShift = 1
-kittyCtrl = 4
-kittySuper = 8
-kittyRelease = 3
-
-hasModifier :: Int -> Int -> Bool
-hasModifier modifier modifiers = modifiers .&. modifier /= 0
 
 readCsiBody :: IO (Either Text String)
 readCsiBody = go 0 []
@@ -942,22 +676,6 @@ readBracketedPaste = go 0 []
                     drainBracketedPaste (take (markerLength - 1) next)
             TimedOut -> pure ()
             TimedEof -> pure ()
-
--- | Validate input captured after a bracketed-paste start marker. The input
--- must contain an end marker, and the payload must fit the supplied limit.
-decodeBracketedPastePayload :: Int -> Text -> Either Text Text
-decodeBracketedPastePayload limit input =
-    let (payload, rest) = Text.breakOn (Text.pack bracketedPasteEnd) input
-    in if Text.null rest
-        then Left "bracketed paste is missing its end marker"
-        else if Text.length payload > max 0 limit
-            then Left "bracketed paste exceeds the size limit"
-            else Right payload
-
-data TimedRead
-    = TimedChar !Char
-    | TimedOut
-    | TimedEof
 
 readTimedChar :: Int -> IO TimedRead
 readTimedChar timeoutMs = do
@@ -1077,31 +795,6 @@ renderMenuRow width selected start localIndex suggestion =
         then "\ESC[1;36m" <> row <> "\ESC[0m"
         else "\ESC[2m" <> row <> "\ESC[0m"
 
-visibleEditorText :: Int -> Text -> Int -> (Text, Int)
-visibleEditorText available raw cursor =
-    let cells = displayCells raw
-        before = take cursor cells
-    in if cellsWidth cells <= available
-        then (renderCells cells, cellsWidth before)
-        else
-            let leftRoom = max 1 (available * 2 `div` 3)
-                visibleBefore = takeSuffixColumns leftRoom before
-                start = length before - length visibleBefore
-                shownCells = takeColumns available (drop start cells)
-            in (renderCells shownCells, cellsWidth visibleBefore)
-
-displayEditorText :: Text -> Text
-displayEditorText = renderCells . displayCells
-
-truncateDisplayText :: Int -> Text -> Text
-truncateDisplayText width text
-    | width <= 0 = ""
-    | cellsWidth cells <= width = renderCells cells
-    | width == 1 = "…"
-    | otherwise = renderCells (takeColumns (width - 1) cells) <> "…"
-  where
-    cells = displayCells text
-
 visibleWidth :: Text -> Int
 visibleWidth = terminalTextWidth . stripAnsi
 
@@ -1205,13 +898,6 @@ putChoiceLine handle line = do
     Text.hPutStr handle (Text.pack clearLineCode)
     Text.hPutStrLn handle line
     hFlush handle
-
--- | Map one approval keypress to the text 'parseApprovalAnswer' expects.
--- Enter / Return become empty (deny by default).
-approvalKeyText :: Char -> Text
-approvalKeyText c
-    | c == '\n' || c == '\r' = ""
-    | otherwise = Text.singleton c
 
 -- | Single-key approval on a TTY: disable canonical input, read one byte,
 -- echo it (except bare Enter), then restore the previous terminal state.
@@ -1343,94 +1029,3 @@ readRawLine = do
     if done
         then pure Nothing
         else Just <$> Text.getLine
-
-ensureHistoryParent :: FilePath -> IO ()
-ensureHistoryParent path = do
-    let dir = takeDirectory path
-    createDirectoryIfMissing True dir
-    -- Best-effort private mode; ignore failures on filesystems that refuse.
-    trySetMode dir 0o700
-
-parseKittyKey :: String -> Maybe KittyKey
-parseKittyKey body = do
-    raw <- stripFinal 'u' body
-    parseKittyKeyFields raw
-
-parseKittyKeyFields :: String -> Maybe KittyKey
-parseKittyKeyFields raw = do
-    let fields = splitFields ';' raw
-    codeField <- listAt 0 fields
-    let modifierField = fromMaybe "1" (listAt 1 fields)
-        modifierParts = splitFields ':' modifierField
-    codepoint <- readDecimal (takeWhile (/= ':') codeField)
-    encodedModifiers <- listAt 0 modifierParts >>= readDecimal
-    event <- maybe (Just 1) readDecimal (listAt 1 modifierParts)
-    pure KittyKey
-        { kittyCodepoint = codepoint
-        , kittyModifiers = max 0 (encodedModifiers - 1)
-        , kittyEvent = event
-        }
-
-decodeKittyEditorKey :: String -> Maybe EditorKey
-decodeKittyEditorKey body
-    | isClipboardPasteCsiBody body =
-        Just (EditorClipboardPaste Nothing)
-    | otherwise = do
-        KittyKey{kittyCodepoint, kittyModifiers, kittyEvent} <- parseKittyKey body
-        if kittyEvent == kittyRelease
-            then Just EditorIgnore
-            else Just (decodeKittyControl kittyModifiers kittyCodepoint)
-
-decodeKittyControl :: Int -> Int -> EditorKey
-decodeKittyControl modifiers codepoint
-    | codepoint == 9 && hasModifier kittyShift modifiers = EditorCycleMode
-    | hasModifier kittyCtrl modifiers = case codepoint of
-        97 -> EditorHome
-        98 -> EditorLeft
-        99 -> EditorInterrupt
-        100 -> EditorEof
-        101 -> EditorEnd
-        102 -> EditorRight
-        107 -> EditorKillEnd
-        108 -> EditorClearScreen
-        110 -> EditorDown
-        112 -> EditorUp
-        117 -> EditorKillStart
-        119 -> EditorKillWord
-        121 -> EditorYank
-        _ -> EditorIgnore
-    | codepoint == 27 = EditorEscape
-    | otherwise = EditorIgnore
-
-splitFields :: Eq a => a -> [a] -> [[a]]
-splitFields separator = go
-  where
-    go xs =
-        let (field, rest) = break (== separator) xs
-        in field : case rest of
-            [] -> []
-            _ : remaining -> go remaining
-
-listAt :: Int -> [a] -> Maybe a
-listAt index xs
-    | index < 0 = Nothing
-    | otherwise = case drop index xs of
-        value : _ -> Just value
-        [] -> Nothing
-
-stripFinal :: Eq a => a -> [a] -> Maybe [a]
-stripFinal suffix xs =
-    case reverse xs of
-        lastValue : rest
-            | lastValue == suffix -> Just (reverse rest)
-        _ -> Nothing
-
-readDecimal :: String -> Maybe Int
-readDecimal input =
-    case reads input of
-        [(value, "")] -> Just value
-        _ -> Nothing
-
-trySetMode :: FilePath -> FileMode -> IO ()
-trySetMode path mode =
-    setFileMode path mode `catchIO` \_ -> pure ()

--- a/packages/agent-cli/src/Agent/CLI/Input/Display.hs
+++ b/packages/agent-cli/src/Agent/CLI/Input/Display.hs
@@ -1,0 +1,100 @@
+-- | Width-aware rendering helpers for inline terminal input.
+module Agent.CLI.Input.Display
+    ( terminalTextWidth
+    , terminalCharWidth
+    , displayCells
+    , displayCell
+    , safeDisplayChar
+    , textColumns
+    , charColumns
+    , cellsWidth
+    , renderCells
+    , takeColumns
+    , takeSuffixColumns
+    , visibleEditorText
+    , displayEditorText
+    , truncateDisplayText
+    ) where
+
+import Agent.CLI.Input.Types (DisplayCell(..))
+import Agent.TUI.TextWidth (charCellWidth)
+import Data.Char (GeneralCategory(..), chr, generalCategory, ord)
+import Data.Text (Text)
+import qualified Data.Text as Text
+
+terminalTextWidth :: Text -> Int
+terminalTextWidth = cellsWidth . displayCells
+
+terminalCharWidth :: Char -> Int
+terminalCharWidth = (.displayCellWidth) . displayCell
+
+displayCells :: Text -> [DisplayCell]
+displayCells = map displayCell . Text.unpack
+
+displayCell :: Char -> DisplayCell
+displayCell char =
+    let shown = safeDisplayChar char
+    in DisplayCell
+        { displayCellText = shown
+        , displayCellWidth = textColumns shown
+        }
+
+safeDisplayChar :: Char -> Text
+safeDisplayChar char
+    | char == '\n' || char == '\r' = "↵"
+    | char == '\t' = "⇥"
+    | code >= 0 && code <= 0x1f = Text.singleton (chr (0x2400 + code))
+    | code == 0x7f = "␡"
+    | code >= 0x80 && code <= 0x9f = "�"
+    | generalCategory char == Format = "�"
+    | otherwise = Text.singleton char
+  where
+    code = ord char
+
+textColumns :: Text -> Int
+textColumns = sum . map charColumns . Text.unpack
+
+charColumns :: Char -> Int
+charColumns = charCellWidth
+
+cellsWidth :: [DisplayCell] -> Int
+cellsWidth = sum . map (.displayCellWidth)
+
+renderCells :: [DisplayCell] -> Text
+renderCells = Text.concat . map (.displayCellText)
+
+takeColumns :: Int -> [DisplayCell] -> [DisplayCell]
+takeColumns width = go 0
+  where
+    go _ [] = []
+    go used (cell : rest)
+        | used + cell.displayCellWidth > width = []
+        | otherwise = cell : go (used + cell.displayCellWidth) rest
+
+takeSuffixColumns :: Int -> [DisplayCell] -> [DisplayCell]
+takeSuffixColumns width = reverse . takeColumns width . reverse
+
+visibleEditorText :: Int -> Text -> Int -> (Text, Int)
+visibleEditorText available raw cursor =
+    let cells = displayCells raw
+        before = take cursor cells
+    in if cellsWidth cells <= available
+        then (renderCells cells, cellsWidth before)
+        else
+            let leftRoom = max 1 (available * 2 `div` 3)
+                visibleBefore = takeSuffixColumns leftRoom before
+                start = length before - length visibleBefore
+                shownCells = takeColumns available (drop start cells)
+            in (renderCells shownCells, cellsWidth visibleBefore)
+
+displayEditorText :: Text -> Text
+displayEditorText = renderCells . displayCells
+
+truncateDisplayText :: Int -> Text -> Text
+truncateDisplayText width text
+    | width <= 0 = ""
+    | cellsWidth cells <= width = renderCells cells
+    | width == 1 = "…"
+    | otherwise = renderCells (takeColumns (width - 1) cells) <> "…"
+  where
+    cells = displayCells text

--- a/packages/agent-cli/src/Agent/CLI/Input/History.hs
+++ b/packages/agent-cli/src/Agent/CLI/Input/History.hs
@@ -1,0 +1,56 @@
+-- | Persistent REPL history helpers.
+module Agent.CLI.Input.History
+    ( replHistoryPath
+    , readReplHistory
+    , appendReplHistory
+    , ensureHistoryParent
+    , trySetMode
+    ) where
+
+import Control.Exception.Safe (catchIO)
+import Data.Char (isSpace)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import System.Console.Haskeline.History
+    ( addHistory
+    , emptyHistory
+    , historyLines
+    , readHistory
+    , writeHistory
+    )
+import System.Directory (createDirectoryIfMissing, getHomeDirectory)
+import System.FilePath (takeDirectory, (</>))
+import System.Posix.Files (setFileMode)
+import System.Posix.Types (FileMode)
+
+replHistoryPath :: FilePath -> FilePath
+replHistoryPath home = home </> ".haskell-agent" </> "history"
+
+readReplHistory :: IO [Text]
+readReplHistory = do
+    home <- getHomeDirectory
+    let path = replHistoryPath home
+    ensureHistoryParent path
+    history <- readHistory path `catchIO` \_ -> pure emptyHistory
+    pure (map Text.pack (historyLines history))
+
+appendReplHistory :: Text -> IO ()
+appendReplHistory text
+    | Text.all isSpace text = pure ()
+    | otherwise = do
+        home <- getHomeDirectory
+        let path = replHistoryPath home
+        ensureHistoryParent path
+        history <- readHistory path `catchIO` \_ -> pure emptyHistory
+        writeHistory path (addHistory (Text.unpack text) history)
+            `catchIO` \_ -> pure ()
+
+ensureHistoryParent :: FilePath -> IO ()
+ensureHistoryParent path = do
+    let dir = takeDirectory path
+    createDirectoryIfMissing True dir
+    trySetMode dir 0o700
+
+trySetMode :: FilePath -> FileMode -> IO ()
+trySetMode path mode =
+    setFileMode path mode `catchIO` \_ -> pure ()

--- a/packages/agent-cli/src/Agent/CLI/Input/KeyDecoder.hs
+++ b/packages/agent-cli/src/Agent/CLI/Input/KeyDecoder.hs
@@ -1,0 +1,129 @@
+-- | Pure decoding for Kitty keyboard and terminal input sequences.
+module Agent.CLI.Input.KeyDecoder
+    ( kittyShift
+    , kittyCtrl
+    , kittySuper
+    , kittyRelease
+    , hasModifier
+    , parseKittyKey
+    , parseKittyKeyFields
+    , decodeKittyEditorKey
+    , decodeKittyControl
+    , isClipboardPasteKey
+    , isClipboardPasteCsiBody
+    , isShiftEnterCsiBody
+    , splitFields
+    , listAt
+    , stripFinal
+    , readDecimal
+    ) where
+
+import Agent.CLI.Input.Types (EditorKey(..), KittyKey(..))
+import Agent.CLI.Terminal (shiftEnterCsiBodies)
+import Data.Bits ((.&.))
+import Data.Char (ord)
+import Data.Maybe (fromMaybe)
+
+kittyShift, kittyCtrl, kittySuper, kittyRelease :: Int
+kittyShift = 1
+kittyCtrl = 4
+kittySuper = 8
+kittyRelease = 3
+
+hasModifier :: Int -> Int -> Bool
+hasModifier modifier modifiers = modifiers .&. modifier /= 0
+
+isClipboardPasteKey :: Char -> Bool
+isClipboardPasteKey = (== '\SYN')
+
+isClipboardPasteCsiBody :: String -> Bool
+isClipboardPasteCsiBody body =
+    case parseKittyKey body of
+        Just KittyKey{kittyCodepoint, kittyModifiers, kittyEvent}
+            | kittyEvent /= kittyRelease ->
+                kittyCodepoint == ord 'v'
+                    && (hasModifier kittyCtrl kittyModifiers
+                        || hasModifier kittySuper kittyModifiers)
+        _ -> False
+
+isShiftEnterCsiBody :: String -> Bool
+isShiftEnterCsiBody body = body `elem` shiftEnterCsiBodies
+
+parseKittyKey :: String -> Maybe KittyKey
+parseKittyKey body = do
+    raw <- stripFinal 'u' body
+    parseKittyKeyFields raw
+
+parseKittyKeyFields :: String -> Maybe KittyKey
+parseKittyKeyFields raw = do
+    let fields = splitFields ';' raw
+        modifierField = fromMaybe "1" (listAt 1 fields)
+        modifierParts = splitFields ':' modifierField
+    codeField <- listAt 0 fields
+    codepoint <- readDecimal (takeWhile (/= ':') codeField)
+    encodedModifiers <- listAt 0 modifierParts >>= readDecimal
+    event <- maybe (Just 1) readDecimal (listAt 1 modifierParts)
+    pure KittyKey
+        { kittyCodepoint = codepoint
+        , kittyModifiers = max 0 (encodedModifiers - 1)
+        , kittyEvent = event
+        }
+
+decodeKittyEditorKey :: String -> Maybe EditorKey
+decodeKittyEditorKey body
+    | isClipboardPasteCsiBody body = Just (EditorClipboardPaste Nothing)
+    | otherwise = do
+        KittyKey{kittyCodepoint, kittyModifiers, kittyEvent} <- parseKittyKey body
+        if kittyEvent == kittyRelease
+            then Just EditorIgnore
+            else Just (decodeKittyControl kittyModifiers kittyCodepoint)
+
+decodeKittyControl :: Int -> Int -> EditorKey
+decodeKittyControl modifiers codepoint
+    | codepoint == 9 && hasModifier kittyShift modifiers = EditorCycleMode
+    | hasModifier kittyCtrl modifiers = case codepoint of
+        97 -> EditorHome
+        98 -> EditorLeft
+        99 -> EditorInterrupt
+        100 -> EditorEof
+        101 -> EditorEnd
+        102 -> EditorRight
+        107 -> EditorKillEnd
+        108 -> EditorClearScreen
+        110 -> EditorDown
+        112 -> EditorUp
+        117 -> EditorKillStart
+        119 -> EditorKillWord
+        121 -> EditorYank
+        _ -> EditorIgnore
+    | codepoint == 27 = EditorEscape
+    | otherwise = EditorIgnore
+
+splitFields :: Eq a => a -> [a] -> [[a]]
+splitFields separator = go
+  where
+    go xs =
+        let (field, rest) = break (== separator) xs
+        in field : case rest of
+            [] -> []
+            _ : remaining -> go remaining
+
+listAt :: Int -> [a] -> Maybe a
+listAt index xs
+    | index < 0 = Nothing
+    | otherwise = case drop index xs of
+        value : _ -> Just value
+        [] -> Nothing
+
+stripFinal :: Eq a => a -> [a] -> Maybe [a]
+stripFinal suffix xs =
+    case reverse xs of
+        lastValue : rest
+            | lastValue == suffix -> Just (reverse rest)
+        _ -> Nothing
+
+readDecimal :: String -> Maybe Int
+readDecimal input =
+    case reads input of
+        [(value, "")] -> Just value
+        _ -> Nothing

--- a/packages/agent-cli/src/Agent/CLI/Input/Paste.hs
+++ b/packages/agent-cli/src/Agent/CLI/Input/Paste.hs
@@ -1,0 +1,51 @@
+-- | Bracketed-paste classification and decoding.
+module Agent.CLI.Input.Paste
+    ( submissionPromptText
+    , classifyPastedText
+    , formatPasteChip
+    , stripBracketedPaste
+    , decodeBracketedPastePayload
+    ) where
+
+import Data.Text (Text)
+import qualified Data.Text as Text
+
+submissionPromptText :: Int -> Text -> Maybe Text
+submissionPromptText attachmentCount text
+    | not (Text.null (Text.strip text)) = Just text
+    | attachmentCount > 0 = Just "The user attached an image."
+    | otherwise = Nothing
+
+classifyPastedText :: Text -> (Text, Bool)
+classifyPastedText raw =
+    let stripped = stripBracketedPaste raw
+        looksPasted = raw /= stripped || Text.count "\n" stripped >= 3
+    in (stripped, looksPasted)
+
+formatPasteChip :: Text -> Text
+formatPasteChip text =
+    let n = max 1 (length (Text.lines text))
+    in if n < 4
+        then text
+        else "[Pasted: " <> Text.pack (show n) <> " lines]"
+
+stripBracketedPaste :: Text -> Text
+stripBracketedPaste text =
+    Text.filter (not . isPasteSentinel)
+        (Text.replace pasteEnd "" (Text.replace pasteStart "" text))
+  where
+    pasteStart = "\ESC[200~"
+    pasteEnd = "\ESC[201~"
+
+isPasteSentinel :: Char -> Bool
+isPasteSentinel char =
+    char == '\x27E6' || char == '\x27E7'
+
+decodeBracketedPastePayload :: Int -> Text -> Either Text Text
+decodeBracketedPastePayload limit input =
+    let (payload, rest) = Text.breakOn (Text.pack "\ESC[201~") input
+    in if Text.null rest
+        then Left "bracketed paste is missing its end marker"
+        else if Text.length payload > max 0 limit
+            then Left "bracketed paste exceeds the size limit"
+            else Right payload

--- a/packages/agent-cli/src/Agent/CLI/Input/Picker.hs
+++ b/packages/agent-cli/src/Agent/CLI/Input/Picker.hs
@@ -1,0 +1,41 @@
+-- | Pure picker and approval-key helpers.
+module Agent.CLI.Input.Picker
+    ( parseChoiceKey
+    , choiceMoveIndex
+    , approvalKeyText
+    ) where
+
+import Agent.CLI.Input.Types (ChoiceKey(..))
+import Data.Char (ord)
+import Data.Text (Text)
+import qualified Data.Text as Text
+
+parseChoiceKey :: String -> Maybe ChoiceKey
+parseChoiceKey = \case
+    "\n" -> Just ChoiceEnter
+    "\r" -> Just ChoiceEnter
+    "\ESC" -> Just ChoiceCancel
+    "\ESC[A" -> Just ChoiceUp
+    "\ESC[B" -> Just ChoiceDown
+    "\ESCOA" -> Just ChoiceUp
+    "\ESCOB" -> Just ChoiceDown
+    "k" -> Just ChoiceUp
+    "j" -> Just ChoiceDown
+    "q" -> Just ChoiceCancel
+    "Q" -> Just ChoiceCancel
+    [c]
+        | c >= '1' && c <= '9' -> Just (ChoiceDigit (ord c - ord '0'))
+    _ -> Nothing
+
+choiceMoveIndex :: Int -> Int -> ChoiceKey -> Int
+choiceMoveIndex len idx key
+    | len <= 0 = 0
+    | otherwise = case key of
+        ChoiceUp -> if idx <= 0 then len - 1 else idx - 1
+        ChoiceDown -> if idx >= len - 1 then 0 else idx + 1
+        _ -> idx
+
+approvalKeyText :: Char -> Text
+approvalKeyText c
+    | c == '\n' || c == '\r' = ""
+    | otherwise = Text.singleton c

--- a/packages/agent-cli/src/Agent/CLI/Input/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Input/Types.hs
@@ -1,0 +1,93 @@
+-- | Dependency-light types shared by the inline editor and fullscreen TUI.
+module Agent.CLI.Input.Types
+    ( ReplLine(..)
+    , ChoiceKey(..)
+    , EditorState(..)
+    , DisplayCell(..)
+    , EditorKey(..)
+    , KittyKey(..)
+    , TimedRead(..)
+    ) where
+
+import Agent.CLI.Command (SkillCommand)
+import Agent.Loop (ImageAttachment)
+import Data.Text (Text)
+
+-- | Outcome of an interactive REPL read.
+data ReplLine
+    = ReplEof
+    | ReplText Text
+    | ReplPasted Text
+    | ReplClipboardPaste !Text !(Maybe [ImageAttachment])
+    | ReplClipboardPasteOrText !Text !Text
+    | ReplCycleMode Text
+    | ReplChooseModel Text
+    | ReplChooseEffort Text
+    | ReplChooseAccount Text
+    | ReplQuitInterrupt
+    deriving (Eq, Show)
+
+data ChoiceKey
+    = ChoiceUp
+    | ChoiceDown
+    | ChoiceEnter
+    | ChoiceCancel
+    | ChoiceDigit Int
+    deriving (Eq, Show)
+
+data EditorState = EditorState
+    { editorText :: !Text
+    , editorCursor :: !Int
+    , editorSelected :: !Int
+    , editorHistoryIndex :: !(Maybe Int)
+    , editorHistoryDraft :: !Text
+    , editorKillBuffer :: !Text
+    , editorPasted :: !Bool
+    , editorSlashEnabled :: !Bool
+    , editorSlashDismissed :: !Bool
+    , editorSkillCommands :: ![SkillCommand]
+    , editorModelIds :: ![Text]
+    }
+
+data DisplayCell = DisplayCell
+    { displayCellText :: !Text
+    , displayCellWidth :: !Int
+    }
+
+data EditorKey
+    = EditorChar !Char
+    | EditorEnter
+    | EditorBackspace
+    | EditorDelete
+    | EditorLeft
+    | EditorRight
+    | EditorHome
+    | EditorEnd
+    | EditorUp
+    | EditorDown
+    | EditorTab
+    | EditorEscape
+    | EditorInterrupt
+    | EditorEof
+    | EditorKillStart
+    | EditorKillEnd
+    | EditorKillWord
+    | EditorYank
+    | EditorClearScreen
+    | EditorCycleMode
+    | EditorClipboardPaste !(Maybe [ImageAttachment])
+    | EditorPaste !Text
+    | EditorInputError !Text
+    | EditorIgnore
+    deriving (Eq, Show)
+
+data KittyKey = KittyKey
+    { kittyCodepoint :: !Int
+    , kittyModifiers :: !Int
+    , kittyEvent :: !Int
+    }
+
+data TimedRead
+    = TimedChar !Char
+    | TimedOut
+    | TimedEof

--- a/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
@@ -20,7 +20,7 @@ module Agent.CLI.TUI.Types
 
 import Agent.CLI.AgentViewport (AgentEntry, AgentTarget)
 import Agent.CLI.Command (SkillCommand)
-import Agent.CLI.Input (ReplLine)
+import Agent.CLI.Input.Types (ReplLine)
 import Agent.CLI.Interrupt (CtrlCDecision)
 import Agent.CLI.Permission (PermissionChoice)
 import Agent.CLI.Resume (ResumeBrowser, ResumeEntry)


### PR DESCRIPTION
## Summary
- split `Agent.CLI.Input` into focused types, display, paste, history, key-decoding, and picker modules
- keep `Agent.CLI.Input` as the compatibility facade and editor orchestrator
- move the TUI's `ReplLine` dependency to `Agent.CLI.Input.Types` to reduce coupling
- regenerate `packages/agent-cli/package.nix`

## Validation
- `cabal build --offline --builddir=dist-pr2 agent-cli:lib:agent-cli`
- `cabal build --offline --builddir=dist-pr2 agent-cli:exe:agent-cli`
- full `agent-cli-test`: 780 examples, 0 failures
- real tmux TTY smoke of `readReplLine`, producing `ReplText` through the raw inline editor
- `git diff --check`