### PR TITLE
Refactor subagent registry state

### DIFF
--- a/packages/agent-core/agent-core.cabal
+++ b/packages/agent-core/agent-core.cabal
@@ -37,6 +37,7 @@ common common-opts
 
 library
     import:           common-opts
+    other-modules:    Agent.Subagents.Registry.Internal
     exposed-modules:  Agent.Auth.JWT
                     , Agent.Cancel
                     , Agent.Dialect

--- a/packages/agent-core/package.nix
+++ b/packages/agent-core/package.nix
@@ -1,8 +1,8 @@
 { mkDerivation, aeson, agent-responses-types, async, base
-, base64-bytestring, bytestring, containers, crypton-connection, directory
-, filepath, hspec, lib, process, resourcet, retry, safe-exceptions
-, scientific, stm, text, text-builder, time, tls, transformers, unix
-, vector, websockets, yaml
+, base64-bytestring, bytestring, containers, crypton-connection
+, directory, filepath, hspec, lib, process, resourcet, retry
+, safe-exceptions, scientific, stm, text, text-builder, time, tls
+, transformers, unix, vector, websockets, yaml
 }:
 mkDerivation {
   pname = "agent-core";
@@ -10,16 +10,18 @@ mkDerivation {
   src = ./.;
   libraryHaskellDepends = [
     aeson agent-responses-types async base base64-bytestring bytestring
-    containers crypton-connection directory filepath process resourcet retry
-    safe-exceptions scientific stm text time tls transformers unix vector
-    websockets yaml
+    containers crypton-connection directory filepath process resourcet
+    retry safe-exceptions scientific stm text time tls transformers
+    unix vector websockets yaml
   ];
-  benchmarkHaskellDepends = [ base text text-builder ];
   testHaskellDepends = [
     aeson agent-responses-types async base base64-bytestring bytestring
     containers crypton-connection directory filepath hspec retry
     safe-exceptions stm text time tls unix websockets yaml
   ];
+  benchmarkHaskellDepends = [
+    base bytestring directory safe-exceptions text text-builder unix
+  ];
   description = "Provider-neutral infrastructure for the agent harness";
-  license = lib.meta.getLicenseFromSpdxId "BSD-3-Clause";
+  license = lib.meta.getLicenseFromSpdxId "MIT";
 }

--- a/packages/agent-core/src/Agent/Subagents/Registry.hs
+++ b/packages/agent-core/src/Agent/Subagents/Registry.hs
@@ -53,8 +53,7 @@ module Agent.Subagents.Registry
     ) where
 
 import Agent.Cancel
-    ( CancelFlag
-    , newCancelFlag
+    ( newCancelFlag
     , requestCancel
     , resetCancel
     , waitCancel
@@ -68,6 +67,17 @@ import Agent.InterAgentMessage
 import Agent.Loop (LoopError(..), LoopEvent, LoopResult(..))
 import System.OsPath (OsPath)
 import Agent.Subagents.Format (formatCompletionNotice, isFinalStatus)
+import Agent.Subagents.Registry.Internal
+    ( SubagentLease(..)
+    , SubagentPhase(..)
+    , SubagentRecord(..)
+    , SubagentRegistry(..)
+    , SubagentWork(..)
+    , phaseHoldsSlot
+    , phaseRootTurnId
+    , phaseStatus
+    , subagentLease
+    )
 import Agent.Subagents.Types
     ( RunSubagent
     , RootTurnId(..)
@@ -81,7 +91,7 @@ import Agent.Subagents.Types
     )
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async (Async, async, cancel, race, waitCatch)
-import Control.Concurrent.MVar (MVar, newMVar, withMVar)
+import Control.Concurrent.MVar (newMVar, withMVar)
 import Control.Concurrent.STM
 import Control.Exception.Safe
     ( SomeException
@@ -95,20 +105,18 @@ import Control.Exception.Safe
 import Control.Monad (void)
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Trans.Resource (runResourceT)
-import Data.Acquire (Acquire, allocateAcquire, mkAcquire, withAcquire)
+import Data.Acquire (allocateAcquire, withAcquire)
 import Data.IORef
 import Data.List (sortOn)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Ord (Down(..))
-import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Read as TextRead
 import Data.Time.Clock (getCurrentTime)
 import Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds)
-import Data.Word (Word64)
 import Numeric (showHex)
 import Agent.Subagents.TaskPath
     ( TaskPath
@@ -117,99 +125,6 @@ import Agent.Subagents.TaskPath
     , taskPathRoot
     , taskPathText
     )
-
-data SubagentRecord = SubagentRecord
-    { recordId :: !SubagentId
-    , recordParent :: !(Maybe SubagentId)
-    , recordDepth :: !Int
-    , recordNickname :: !(Maybe Text)
-    , recordPhase :: !(TVar SubagentPhase)
-    , recordCancel :: !CancelFlag
-    , recordMailbox :: !(TQueue SubagentWork)
-    , recordAsync :: !(TVar (Maybe (Async ())))
-      -- | Last successful response id for conversation continuity.
-    , recordPreviousResponseId :: !(TVar (Maybe Text))
-    , recordLastUpdate :: !(TVar (Maybe (Int, SubagentStatus)))
-    , recordTaskPath :: !TaskPath
-    , recordCwd :: !OsPath
-    }
-
-data SubagentWork = SubagentWork
-    { workRootTurnId :: !(Maybe RootTurnId)
-    , workMessage :: !InterAgentMessage
-    }
-
--- | The complete turn lifecycle of an open subagent.
---
--- Pending, running, and interrupting phases each own one active-turn slot.
--- Idle and closed phases never do. Keeping these facts in one value prevents
--- combinations such as an idle agent that still holds capacity.
-data SubagentPhase
-    = AgentIdle !SubagentStatus !(Maybe RootTurnId)
-    | AgentPending !SubagentWork
-    | AgentRunning !(Maybe RootTurnId)
-    | AgentInterrupting !(Maybe RootTurnId)
-    | AgentClosed
-
-phaseStatus :: SubagentPhase -> SubagentStatus
-phaseStatus = \case
-    AgentIdle status _ -> status
-    AgentPending{} -> Pending
-    AgentRunning{} -> Running
-    AgentInterrupting{} -> Interrupted
-    AgentClosed -> Closed
-
-phaseRootTurnId :: SubagentPhase -> Maybe RootTurnId
-phaseRootTurnId = \case
-    AgentPending work -> work.workRootTurnId
-    AgentRunning rootTurnId -> rootTurnId
-    AgentInterrupting rootTurnId -> rootTurnId
-    AgentIdle _ rootTurnId -> rootTurnId
-    AgentClosed -> Nothing
-
-phaseHoldsSlot :: SubagentPhase -> Bool
-phaseHoldsSlot = \case
-    AgentPending{} -> True
-    AgentRunning{} -> True
-    AgentInterrupting{} -> True
-    AgentIdle{} -> False
-    AgentClosed -> False
-
--- | Resources acquired while preparing an agent and transferred to its
--- supervisor. They remain alive across turns and are released in reverse order
--- when the supervisor exits.
-newtype SubagentLease = SubagentLease (Acquire ())
-
-instance Semigroup SubagentLease where
-    SubagentLease left <> SubagentLease right = SubagentLease (left *> right)
-
-instance Monoid SubagentLease where
-    mempty = SubagentLease (pure ())
-
--- | Attach an already-acquired resource to the lifetime of a subagent.
-subagentLease :: IO () -> SubagentLease
-subagentLease cleanup =
-    SubagentLease (mkAcquire (pure ()) (const cleanup))
-
-data SubagentRegistry = SubagentRegistry
-    { registryAgents :: !(TVar (Map SubagentId SubagentRecord))
-    , registryPaths :: !(TVar (Map TaskPath SubagentId))
-    , registryLiveCount :: !(TVar Int)
-    , registryNextUpdateSeq :: !(TVar Int)
-    , registryWaitCursors :: !(TVar (Map (Maybe SubagentId) Int))
-    , registryActiveWaits :: !(TVar (Map (Maybe SubagentId) [SubagentId]))
-    , registryConfig :: !SubagentConfig
-    , registryRunRef :: !(IORef RunSubagent)
-    , registryOnEvent :: !(SubagentId -> LoopEvent -> IO ())
-    , registryOnCompleteRef :: !(IORef (SubagentId -> SubagentStatus -> IO ()))
-    , registryOnSettledRef :: !(IORef (SubagentId -> SubagentStatus -> IO ()))
-    , registryCwd :: !OsPath
-    , registryClosed :: !(TVar Bool)
-    , registryNextSubagentId :: !(TVar Int)
-    , registryNextRootTurnId :: !(TVar Word64)
-    , registryAbortedRootTurns :: !(TVar (Set RootTurnId))
-    , registryLifecycle :: !(MVar ())
-    }
 
 newSubagentRegistry
     :: SubagentConfig

--- a/packages/agent-core/src/Agent/Subagents/Registry/Internal.hs
+++ b/packages/agent-core/src/Agent/Subagents/Registry/Internal.hs
@@ -1,0 +1,126 @@
+module Agent.Subagents.Registry.Internal
+    ( SubagentLease(..)
+    , SubagentPhase(..)
+    , SubagentRecord(..)
+    , SubagentRegistry(..)
+    , SubagentWork(..)
+    , phaseHoldsSlot
+    , phaseRootTurnId
+    , phaseStatus
+    , subagentLease
+    ) where
+
+import Agent.Cancel (CancelFlag)
+import Agent.InterAgentMessage (InterAgentMessage)
+import Agent.Loop (LoopEvent)
+import Agent.Subagents.TaskPath (TaskPath)
+import Agent.Subagents.Types
+    ( RootTurnId
+    , RunSubagent
+    , SubagentConfig
+    , SubagentId
+    , SubagentStatus(..)
+    )
+import Control.Concurrent.Async (Async)
+import Control.Concurrent.MVar (MVar)
+import Control.Concurrent.STM
+import Data.Acquire (Acquire, mkAcquire)
+import Data.IORef (IORef)
+import Data.Map.Strict (Map)
+import Data.Set (Set)
+import Data.Text (Text)
+import Data.Word (Word64)
+import System.OsPath (OsPath)
+
+data SubagentRecord = SubagentRecord
+    { recordId :: !SubagentId
+    , recordParent :: !(Maybe SubagentId)
+    , recordDepth :: !Int
+    , recordNickname :: !(Maybe Text)
+    , recordPhase :: !(TVar SubagentPhase)
+    , recordCancel :: !CancelFlag
+    , recordMailbox :: !(TQueue SubagentWork)
+    , recordAsync :: !(TVar (Maybe (Async ())))
+      -- | Last successful response id for conversation continuity.
+    , recordPreviousResponseId :: !(TVar (Maybe Text))
+    , recordLastUpdate :: !(TVar (Maybe (Int, SubagentStatus)))
+    , recordTaskPath :: !TaskPath
+    , recordCwd :: !OsPath
+    }
+
+data SubagentWork = SubagentWork
+    { workRootTurnId :: !(Maybe RootTurnId)
+    , workMessage :: !InterAgentMessage
+    }
+
+-- | The complete turn lifecycle of an open subagent.
+--
+-- Pending, running, and interrupting phases each own one active-turn slot.
+-- Idle and closed phases never do. Keeping these facts in one value prevents
+-- combinations such as an idle agent that still holds capacity.
+data SubagentPhase
+    = AgentIdle !SubagentStatus !(Maybe RootTurnId)
+    | AgentPending !SubagentWork
+    | AgentRunning !(Maybe RootTurnId)
+    | AgentInterrupting !(Maybe RootTurnId)
+    | AgentClosed
+
+phaseStatus :: SubagentPhase -> SubagentStatus
+phaseStatus = \case
+    AgentIdle status _ -> status
+    AgentPending{} -> Pending
+    AgentRunning{} -> Running
+    AgentInterrupting{} -> Interrupted
+    AgentClosed -> Closed
+
+phaseRootTurnId :: SubagentPhase -> Maybe RootTurnId
+phaseRootTurnId = \case
+    AgentPending work -> work.workRootTurnId
+    AgentRunning rootTurnId -> rootTurnId
+    AgentInterrupting rootTurnId -> rootTurnId
+    AgentIdle _ rootTurnId -> rootTurnId
+    AgentClosed -> Nothing
+
+phaseHoldsSlot :: SubagentPhase -> Bool
+phaseHoldsSlot = \case
+    AgentPending{} -> True
+    AgentRunning{} -> True
+    AgentInterrupting{} -> True
+    AgentIdle{} -> False
+    AgentClosed -> False
+
+-- | Resources acquired while preparing an agent and transferred to its
+-- supervisor. They remain alive across turns and are released in reverse order
+-- when the supervisor exits.
+newtype SubagentLease = SubagentLease (Acquire ())
+
+instance Semigroup SubagentLease where
+    SubagentLease left <> SubagentLease right = SubagentLease (left *> right)
+
+instance Monoid SubagentLease where
+    mempty = SubagentLease (pure ())
+
+-- | Attach an already-acquired resource to the lifetime of a subagent.
+subagentLease :: IO () -> SubagentLease
+subagentLease cleanup =
+    SubagentLease (mkAcquire (pure ()) (const cleanup))
+
+data SubagentRegistry = SubagentRegistry
+    { registryAgents :: !(TVar (Map SubagentId SubagentRecord))
+    , registryPaths :: !(TVar (Map TaskPath SubagentId))
+    , registryLiveCount :: !(TVar Int)
+    , registryNextUpdateSeq :: !(TVar Int)
+    , registryWaitCursors :: !(TVar (Map (Maybe SubagentId) Int))
+    , registryActiveWaits :: !(TVar (Map (Maybe SubagentId) [SubagentId]))
+    , registryConfig :: !SubagentConfig
+    , registryRunRef :: !(IORef RunSubagent)
+    , registryOnEvent :: !(SubagentId -> LoopEvent -> IO ())
+    , registryOnCompleteRef :: !(IORef (SubagentId -> SubagentStatus -> IO ()))
+    , registryOnSettledRef :: !(IORef (SubagentId -> SubagentStatus -> IO ()))
+    , registryCwd :: !OsPath
+    , registryClosed :: !(TVar Bool)
+    , registryNextSubagentId :: !(TVar Int)
+    , registryNextRootTurnId :: !(TVar Word64)
+    , registryAbortedRootTurns :: !(TVar (Set RootTurnId))
+    , registryLifecycle :: !(MVar ())
+    }


### PR DESCRIPTION
## Summary
- extract private registry records, lifecycle phases, lease handling, and shared registry state into `Agent.Subagents.Registry.Internal`
- keep `Agent.Subagents.Registry` as the unchanged public API and operation module
- keep the new implementation module internal through Cabal `other-modules`
- regenerate `package.nix`

This intentionally starts with the lowest-risk shared-state boundary before splitting supervisor and lifecycle operations, preserving the existing STM/MVar synchronization paths.

## Validation
- `cabal build --offline -j1 --builddir=dist-pr6 agent-core:lib:agent-core`
- full `agent-core-test`: 285 examples, 0 failures
- `git diff --check`
- regenerated `package.nix` matches `cabal2nix .`
