### PR TITLE
experiment: evaluate direct, RLM, and Codex todo agents

### DIFF
--- a/docs/evals/agent-vs-codex-todo.md
+++ b/docs/evals/agent-vs-codex-todo.md
@@ -1,0 +1,130 @@
+# agent-cli vs Codex: real-world Haskell todo app
+
+This eval gives `agent-cli` and Codex the same model, reasoning effort, prompt,
+empty Git workspace, automatic approval policy, and timeout. The task is to
+build a GHC 9.10 HTTP todo server with a Nix flake and in-memory `MVar`
+persistence.
+
+This compares the two product configurations, not identical tool schemas or
+system prompts. Codex runs ephemerally with user config and exec-policy rules
+disabled; both runners still use their own built-in coding-agent contracts.
+
+The evaluator records:
+
+- deterministic grader pass/fail;
+- coding-agent wall-clock duration;
+- provider-reported input, output, and cached-input tokens;
+- stdout/stderr logs;
+- completed workspaces;
+- the `agent-cli` session transcript and Codex thread id, when available.
+
+Wall time stops when the coding agent exits. Building and exercising the
+finished application happens afterward and is deliberately excluded from the
+agent-time comparison.
+
+## Run
+
+Build the current `agent-cli` and evaluator:
+
+```console
+nix develop -c cabal build \
+  agent-cli:exe:agent-cli \
+  agent-cli:exe:eval-agent-vs-codex-todo
+```
+
+Locate the executables and run at least three trials:
+
+```console
+agent_bin=$(nix develop -c cabal list-bin agent-cli:exe:agent-cli)
+eval_bin=$(nix develop -c cabal list-bin agent-cli:exe:eval-agent-vs-codex-todo)
+
+"$eval_bin" \
+  --agent-bin "$agent_bin" \
+  --codex-bin "$(command -v codex)" \
+  --model gpt-5.6-sol \
+  --effort medium \
+  --trials 3 \
+  --timeout-seconds 900 \
+  --results-dir "eval-results/agent-vs-codex-todo-$(date +%Y%m%d-%H%M%S)"
+```
+
+Run order alternates by trial to reduce ordering bias. Use
+`--runner agent-cli` or `--runner codex` for a focused smoke test. Results
+directories must be new or empty.
+
+The eval makes real model requests and may incur usage charges.
+
+## Grading
+
+The external grader verifies that:
+
+1. `nix develop -c ghc --numeric-version` reports GHC 9.10.
+2. Haskell source uses `MVar`.
+3. `PORT=<isolated-port> nix run` starts an HTTP server.
+4. `GET /tasks` initially returns an empty JSON array.
+5. Two `POST /tasks` requests return HTTP 201 with exact task fields and
+   produce persistent in-memory state.
+6. `DELETE /tasks/:id` returns HTTP 204 and the following `GET` reflects the
+   deletion.
+
+The grader uses a fresh process and workspace for every run. A solution only
+counts as successful when both the agent exits cleanly and every grader check
+passes.
+
+## Results: August 24, 2026
+
+The suite was run on the x86-64 Linux host `office-builder` with:
+
+- model `gpt-5.6-sol`;
+- medium reasoning effort;
+- three trials per runner;
+- a 900-second timeout per run;
+- `agent-cli 0.1.0.0`;
+- `codex-cli 0.144.4`.
+
+All six runs exited cleanly and passed every external grader check.
+
+### Medians
+
+| runner | passed | agent seconds | input tokens | cached input | output tokens |
+|---|---:|---:|---:|---:|---:|
+| agent-cli | 3/3 | 193.69 | 182,194 | 118,272 | 7,473 |
+| Codex | 3/3 | 235.73 | 760,465 | 672,000 | 6,661 |
+
+Compared with Codex, the `agent-cli` medians were:
+
+- 17.8% less wall-clock time;
+- 76.0% fewer reported input tokens;
+- 82.4% fewer cached-input tokens;
+- 12.2% more output tokens.
+
+The reported input-token difference is dominated by cached context. Across all
+three trials, subtracting cached input left 184,726 uncached input tokens for
+`agent-cli` and 234,122 for Codex, so `agent-cli` used 21.1% fewer uncached
+input tokens.
+
+### Individual runs
+
+| trial | runner | pass | agent seconds | grade seconds | input | cached | output |
+|---:|---|---:|---:|---:|---:|---:|---:|
+| 1 | agent-cli | yes | 214.00 | 36.11 | 227,898 | 144,256 | 7,599 |
+| 1 | Codex | yes | 257.56 | 37.35 | 1,142,833 | 1,030,400 | 7,641 |
+| 2 | Codex | yes | 235.73 | 18.27 | 760,465 | 672,000 | 6,661 |
+| 2 | agent-cli | yes | 170.45 | 33.38 | 153,002 | 118,272 | 6,935 |
+| 3 | agent-cli | yes | 193.69 | 87.25 | 182,194 | 115,840 | 7,473 |
+| 3 | Codex | yes | 161.94 | 11.37 | 470,472 | 437,248 | 5,813 |
+
+Run order alternated as designed. Codex was fastest in trial 3, while
+`agent-cli` was faster in trials 1 and 2 and had the lower median.
+
+### Aggregate totals
+
+| runner | agent seconds | input | cached input | uncached input | output |
+|---|---:|---:|---:|---:|---:|
+| agent-cli | 578.14 | 563,094 | 378,368 | 184,726 | 22,007 |
+| Codex | 655.23 | 2,373,770 | 2,139,648 | 234,122 | 20,115 |
+
+These results compare complete product configurations. The runners use the
+same task prompt, model, effort, approval policy, and isolated workspace, but
+their system prompts, tool contracts, execution strategies, context caching,
+and installed CLI versions differ.

--- a/docs/evals/agent-vs-codex-todo.md
+++ b/docs/evals/agent-vs-codex-todo.md
@@ -9,6 +9,12 @@ This compares the two product configurations, not identical tool schemas or
 system prompts. Codex runs ephemerally with user config and exec-policy rules
 disabled; both runners still use their own built-in coding-agent contracts.
 
+The revised evaluator disables agent-cli subagents and its GHCi tool, enables
+its explicit Bash tool, and requires both runners to personally build and
+exercise the application before finishing. This prevents unreported
+child-model usage and gives both runners a shell-based execution path on hosts
+without `ghci` in the ambient `PATH`.
+
 The evaluator records:
 
 - deterministic grader pass/fail;
@@ -72,6 +78,14 @@ counts as successful when both the agent exits cleanly and every grader check
 passes.
 
 ## Results: August 24, 2026
+
+The results below are from the original run. Transcript analysis found that
+agent-cli could not launch its registered GHCi runner, performed only static
+verification, and delegated review to a `gpt-5.6-luna` child whose usage was
+not included in the root-session totals. Codex built and exercised its
+applications itself. These numbers are therefore retained as historical data,
+not as an apples-to-apples efficiency conclusion. The revised run uses
+`--no-subagents --no-ghci --bash` and requires recorded self-verification.
 
 The suite was run on the x86-64 Linux host `office-builder` with:
 

--- a/docs/evals/agent-vs-codex-todo.md
+++ b/docs/evals/agent-vs-codex-todo.md
@@ -96,6 +96,39 @@ passes.
 
 ## Results: August 24, 2026
 
+### Controlled prebuilt-flake smoke run: `gpt-5.6-terra`
+
+The evaluator prebuilt the exact shared flake before timing and copied the same
+immutable `flake.nix` and `flake.lock` into every workspace. All three runners
+preserved both files, self-verified, and passed the independent grader.
+
+| runner | pass | seconds | input | uncached | cached | output |
+|---|---:|---:|---:|---:|---:|---:|
+| agent-cli | yes | 250.51 | 268,201 | 27,305 | 240,896 | 6,385 |
+| agent-cli RLM | yes | 420.11 | 695,037 | 122,237 | 572,800 | 17,084 |
+| Codex | yes | 190.98 | 659,186 | 40,690 | 618,496 | 6,759 |
+
+Removing Nix closure variance changed the result materially. Direct agent-cli
+used 59.3% fewer total input tokens than Codex, but took 31.2% longer. RLM was
+67.7% slower than direct agent-cli and used 159.1% more total input, 347.7%
+more uncached input, 137.8% more cached input, and 167.6% more output. RLM also
+took 120.0% longer than Codex and used 5.4% more total input.
+
+The RLM transcript explains the regression. It used a read-only worker to
+inspect the supplied flake, a coding worker to create `app/Main.hs`, and
+another read-only worker to review the result. The coding worker returned
+source with missing or incorrectly qualified imports. The root then loaded the
+complete file, rewrote it itself, encountered a compile error at runtime, and
+performed multiple textual repair and verification turns. The delegation did
+not reduce root work; it duplicated implementation and review context before
+the root took over. In this small, tightly specified one-file task, worker
+startup and handoff overhead outweighed any context-isolation benefit.
+
+This remains a one-trial smoke result rather than a stable median. It does,
+however, show why controlling the Nix fixture is essential: the earlier warm
+RLM result looked much stronger while runner-specific flake choices and
+first-use package builds still differed.
+
 ### In-process RLM prototype: `gpt-5.6-terra`
 
 A one-trial smoke comparison was run on `office-builder` with medium effort

--- a/docs/evals/agent-vs-codex-todo.md
+++ b/docs/evals/agent-vs-codex-todo.md
@@ -9,11 +9,19 @@ This compares the two product configurations, not identical tool schemas or
 system prompts. Codex runs ephemerally with user config and exec-policy rules
 disabled; both runners still use their own built-in coding-agent contracts.
 
-The revised evaluator disables agent-cli subagents and its GHCi tool, enables
-its explicit Bash tool, and requires both runners to personally build and
-exercise the application before finishing. This prevents unreported
-child-model usage and gives both runners a shell-based execution path on hosts
-without `ghci` in the ambient `PATH`.
+The evaluator has three runners:
+
+- `agent-cli`: disables subagents and GHCi, enables the explicit Bash tool, and
+  requires the root agent to implement and verify the application itself;
+- `agent-cli-rlm`: gives the root only the GHCi tool plus `rlmQuery`,
+  `rlmQueryMany`, and `rlmCode` helpers backed by in-process subagents;
+- `codex`: runs Codex exec with matching model, effort, approval, and task
+  constraints.
+
+RLM worker usage is included in the root session totals. Read-only workers may
+run concurrently; coding workers are serialized to avoid overlapping edits.
+The packaged `agent-cli` puts GHC on `PATH`, because RLM mode requires the
+persistent GHCi coordinator.
 
 The evaluator records:
 
@@ -54,9 +62,9 @@ eval_bin=$(nix develop -c cabal list-bin agent-cli:exe:eval-agent-vs-codex-todo)
   --results-dir "eval-results/agent-vs-codex-todo-$(date +%Y%m%d-%H%M%S)"
 ```
 
-Run order alternates by trial to reduce ordering bias. Use
-`--runner agent-cli` or `--runner codex` for a focused smoke test. Results
-directories must be new or empty.
+Run order alternates by trial to reduce ordering bias. Use `--runner
+agent-cli`, `--runner agent-cli-rlm`, or `--runner codex` for a focused smoke
+test. Results directories must be new or empty.
 
 The eval makes real model requests and may incur usage charges.
 
@@ -78,6 +86,45 @@ counts as successful when both the agent exits cleanly and every grader check
 passes.
 
 ## Results: August 24, 2026
+
+### In-process RLM prototype: `gpt-5.6-terra`
+
+A one-trial smoke comparison was run on `office-builder` with medium effort
+and a 1,200-second timeout. All three corrected runners passed their own
+verification and the independent grader.
+
+| runner | pass | seconds | input | uncached | cached | output |
+|---|---:|---:|---:|---:|---:|---:|
+| agent-cli | yes | 206.61 | 371,798 | 28,886 | 342,912 | 6,545 |
+| agent-cli RLM, warm Nix cache | yes | 248.30 | 155,518 | 49,790 | 105,728 | 9,342 |
+| Codex | yes | 713.20 | 1,886,187 | 111,851 | 1,774,336 | 9,637 |
+
+Against direct agent-cli in this sample, RLM used 58.2% fewer total input
+tokens and 69.2% fewer cached-input tokens, but 72.4% more uncached input,
+42.7% more output, and 20.2% more time. Against Codex, RLM used 91.8% fewer
+total input tokens, 94.0% fewer cached tokens, 55.5% fewer uncached tokens,
+3.1% fewer output tokens, and 65.2% less time.
+
+The first corrected RLM run took 835.26 seconds with 333,778 input tokens
+(245,504 cached), 9,133 output tokens, and still passed. Its generated flake
+selected a Nix package set that was not warm on the host. The first GHC version
+check exhausted the command timeout while Nix built dependencies, then the
+retry succeeded. After warming that exact package set, the second RLM run took
+248.30 seconds. This makes the timing result unsuitable as a controlled
+performance conclusion: model choices changed the generated flake, and
+first-use Nix closure cost dominated both the cold RLM run and the Codex run.
+The token reduction is less sensitive to that host-cache artifact, but this is
+still only one successful trial per configuration and needs repetition.
+
+Transcript inspection explains the token shape. The RLM root made one
+read-only inspection call, delegated the initial implementation to a coding
+worker, inspected the result locally, and used a second coding worker for a
+focused API correction. The root then performed the required Nix and HTTP
+checks itself. This kept large implementation contexts inside short-lived
+workers instead of replaying them through every root turn, substantially
+reducing cached-context amplification. It also added uncached prompts and
+worker responses, explaining why uncached input and output increased relative
+to direct agent-cli.
 
 ### Revised self-verifying run: `gpt-5.6-sol`
 

--- a/docs/evals/agent-vs-codex-todo.md
+++ b/docs/evals/agent-vs-codex-todo.md
@@ -79,7 +79,7 @@ passes.
 
 ## Results: August 24, 2026
 
-### Revised self-verifying run
+### Revised self-verifying run: `gpt-5.6-sol`
 
 The revised suite was run on `office-builder` with the same model, medium
 effort, three trials, and 900-second per-run timeout. agent-cli used
@@ -113,6 +113,32 @@ after creating its plan, produced no project files, and reached the 900-second
 timeout. This revised result supports a narrower conclusion than the original:
 agent-cli still has materially lower cached-context amplification, but it was
 not faster or more reliable in this sample.
+
+### Revised self-verifying run: `gpt-5.6-terra`
+
+The same corrected suite was also run on `office-builder` with
+`gpt-5.6-terra`, medium effort, three trials, and the same 900-second timeout.
+All six runs self-verified without delegation and passed the independent
+grader.
+
+| runner | passed | median successful seconds | median input | median uncached | median output | median cached |
+|---|---:|---:|---:|---:|---:|---:|
+| agent-cli | 3/3 | 348.18 | 507,968 | 53,952 | 11,088 | 454,016 |
+| Codex | 3/3 | 240.18 | 579,451 | 55,675 | 5,482 | 523,776 |
+
+agent-cli used 12.3% fewer total input tokens, 13.3% fewer cached-input
+tokens, and 3.1% fewer uncached-input tokens. It used 102.3% more output
+tokens and took 45.0% longer at the median. Unlike the `gpt-5.6-sol` run,
+agent-cli completed all three trials.
+
+| trial | runner | pass | seconds | input | uncached | cached | output |
+|---:|---|---:|---:|---:|---:|---:|---:|
+| 1 | agent-cli | yes | 350.99 | 717,087 | 65,311 | 651,776 | 11,088 |
+| 1 | Codex | yes | 240.18 | 579,451 | 55,675 | 523,776 | 5,482 |
+| 2 | Codex | yes | 285.41 | 948,267 | 60,971 | 887,296 | 8,260 |
+| 2 | agent-cli | yes | 348.18 | 507,968 | 53,952 | 454,016 | 11,702 |
+| 3 | agent-cli | yes | 208.74 | 373,138 | 46,994 | 326,144 | 7,311 |
+| 3 | Codex | yes | 141.61 | 359,581 | 28,317 | 331,264 | 4,781 |
 
 ### Original run
 

--- a/docs/evals/agent-vs-codex-todo.md
+++ b/docs/evals/agent-vs-codex-todo.md
@@ -79,6 +79,43 @@ passes.
 
 ## Results: August 24, 2026
 
+### Revised self-verifying run
+
+The revised suite was run on `office-builder` with the same model, medium
+effort, three trials, and 900-second per-run timeout. agent-cli used
+`--no-subagents --no-ghci --bash`; both runners had to record successful GHC,
+build, `nix run`, and HTTP CRUD verification. A run only passed when it was
+self-verified, did not delegate, exited successfully, and passed the independent
+grader.
+
+| runner | passed | median successful seconds | median input | median uncached | median output | median cached |
+|---|---:|---:|---:|---:|---:|---:|
+| agent-cli | 2/3 | 232.20 | 383,787 | 48,491 | 7,136 | 335,296 |
+| Codex | 3/3 | 213.94 | 657,318 | 51,364 | 6,835 | 610,816 |
+
+Among successful runs, agent-cli used 41.6% fewer total input tokens and 45.1%
+fewer cached-input tokens. The uncached-input advantage was much smaller at
+5.6%, and agent-cli used 4.4% more output tokens. Codex had the faster median by
+8.5% and completed all three trials.
+
+| trial | runner | pass | seconds | input | uncached | cached | output |
+|---:|---|---:|---:|---:|---:|---:|---:|
+| 1 | agent-cli | yes | 175.95 | 251,329 | 42,177 | 209,152 | 5,571 |
+| 1 | Codex | yes | 213.94 | 657,318 | 46,502 | 610,816 | 7,459 |
+| 2 | Codex | yes | 207.32 | 547,104 | 58,400 | 488,704 | 6,835 |
+| 2 | agent-cli | yes | 288.45 | 516,245 | 54,805 | 461,440 | 8,702 |
+| 3 | agent-cli | no | 900.11 | n/a | n/a | n/a | n/a |
+| 3 | Codex | yes | 221.13 | 666,020 | 51,364 | 614,656 | 6,822 |
+
+Every completed run self-verified without delegation and passed the external
+GHC 9.10, `MVar`, and HTTP CRUD checks. agent-cli trial 3 stalled immediately
+after creating its plan, produced no project files, and reached the 900-second
+timeout. This revised result supports a narrower conclusion than the original:
+agent-cli still has materially lower cached-context amplification, but it was
+not faster or more reliable in this sample.
+
+### Original run
+
 The results below are from the original run. Transcript analysis found that
 agent-cli could not launch its registered GHCi runner, performed only static
 verification, and delegated review to a `gpt-5.6-luna` child whose usage was

--- a/docs/evals/agent-vs-codex-todo.md
+++ b/docs/evals/agent-vs-codex-todo.md
@@ -1,7 +1,7 @@
 # agent-cli vs Codex: real-world Haskell todo app
 
 This eval gives `agent-cli` and Codex the same model, reasoning effort, prompt,
-empty Git workspace, automatic approval policy, and timeout. The task is to
+workspace fixture, automatic approval policy, and timeout. The task is to
 build a GHC 9.10 HTTP todo server with a Nix flake and in-memory `MVar`
 persistence.
 
@@ -22,6 +22,14 @@ RLM worker usage is included in the root session totals. Read-only workers may
 run concurrently; coding workers are serialized to avoid overlapping edits.
 The packaged `agent-cli` puts GHC on `PATH`, because RLM mode requires the
 persistent GHCi coordinator.
+
+Every workspace starts with the same pinned `flake.nix` and `flake.lock`. The
+fixture exposes GHC 9.10 plus Aeson, WAI, Warp, and http-types, and runs
+`app/Main.hs`. The evaluator builds the fixture and development environment
+before starting any timed agent run. Agents are told not to change either
+flake file, and the grader requires both files to remain byte-for-byte
+identical. This removes dependency selection and first-use Nix compilation
+from the timed comparison while leaving the Haskell implementation task open.
 
 The evaluator records:
 
@@ -72,13 +80,14 @@ The eval makes real model requests and may incur usage charges.
 
 The external grader verifies that:
 
-1. `nix develop -c ghc --numeric-version` reports GHC 9.10.
-2. Haskell source uses `MVar`.
-3. `PORT=<isolated-port> nix run` starts an HTTP server.
-4. `GET /tasks` initially returns an empty JSON array.
-5. Two `POST /tasks` requests return HTTP 201 with exact task fields and
+1. The provided `flake.nix` and `flake.lock` are unchanged.
+2. `nix develop -c ghc --numeric-version` reports GHC 9.10.
+3. Haskell source uses `MVar`.
+4. `PORT=<isolated-port> nix run` starts an HTTP server.
+5. `GET /tasks` initially returns an empty JSON array.
+6. Two `POST /tasks` requests return HTTP 201 with exact task fields and
    produce persistent in-memory state.
-6. `DELETE /tasks/:id` returns HTTP 204 and the following `GET` reflects the
+7. `DELETE /tasks/:id` returns HTTP 204 and the following `GET` reflects the
    deletion.
 
 The grader uses a fresh process and workspace for every run. A solution only

--- a/flake.nix
+++ b/flake.nix
@@ -297,6 +297,7 @@
                                 (old.postInstall or "")
                                 + ''
                                     wrapProgram "$out/bin/agent-cli" \
+                                        --prefix PATH : "${pkgs.lib.makeBinPath [ haskellPackages.ghc ]}" \
                                         --set-default AGENT_SYNTAX_DIR \
                                             "${skylightingSyntaxDirectory}"
                                 '';

--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -190,6 +190,24 @@ executable eval-ghci-vs-bash
                     , time
                     , unix
 
+executable eval-agent-vs-codex-todo
+    import:           common-options
+    hs-source-dirs:   eval
+    main-is:          AgentVsCodexTodo.hs
+    ghc-options:      -threaded -rtsopts
+    build-depends:    agent-cli
+                    , agent-responses-types
+                    , aeson >= 2.0
+                    , base >= 4.17 && < 5
+                    , bytestring
+                    , directory
+                    , filepath
+                    , process >= 1.6.26
+                    , safe-exceptions
+                    , text >= 2.0 && < 2.2
+                    , time
+                    , unix
+
 benchmark subagent-retention-bench
     import:           common-options
     type:             exitcode-stdio-1.0

--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -83,6 +83,7 @@ library
                     , Agent.CLI.ProviderFallback
                     , Agent.CLI.ProviderAvailability
                     , Agent.CLI.ProviderTransition
+                    , Agent.CLI.Rlm
                     , Agent.CLI.Render
                     , Agent.CLI.ReplMode
                     , Agent.CLI.Resume
@@ -264,6 +265,7 @@ test-suite agent-cli-test
                     , Agent.CLI.ProviderAvailabilitySpec
                     , Agent.CLI.ProviderTransitionSpec
                     , Agent.CLI.RequestSpec
+                    , Agent.CLI.RlmSpec
                     , Agent.CLI.RenderSpec
                     , Agent.CLI.ReplStatusSpec
                     , Agent.CLI.ResumeSpec

--- a/packages/agent-cli/eval/AgentVsCodexTodo.hs
+++ b/packages/agent-cli/eval/AgentVsCodexTodo.hs
@@ -66,7 +66,7 @@ import System.Posix.Signals
 import System.Posix.Types (ProcessID)
 import System.Timeout (timeout)
 
-data Runner = AgentCli | Codex
+data Runner = AgentCli | AgentCliRlm | Codex
     deriving (Eq, Ord, Show)
 
 data Config = Config
@@ -117,6 +117,7 @@ data HttpResponse = HttpResponse
 
 instance ToJSON Runner where
     toJSON AgentCli = toJSON ("agent-cli" :: Text)
+    toJSON AgentCliRlm = toJSON ("agent-cli-rlm" :: Text)
     toJSON Codex = toJSON ("codex" :: Text)
 
 instance ToJSON RunResult where
@@ -208,8 +209,10 @@ parseConfig = go Config
             _ -> Left "--timeout-seconds expects a positive integer"
         "--runner" : value : rest -> case value of
             "agent-cli" -> go config { selectedRunner = Just AgentCli } rest
+            "agent-cli-rlm" ->
+                go config { selectedRunner = Just AgentCliRlm } rest
             "codex" -> go config { selectedRunner = Just Codex } rest
-            _ -> Left "--runner expects agent-cli or codex"
+            _ -> Left "--runner expects agent-cli, agent-cli-rlm, or codex"
         "--help" : _ -> Left usage
         unknown : _ -> Left ("unknown eval argument: " <> unknown <> "\n\n" <> usage)
 
@@ -225,7 +228,7 @@ usage = unlines
     , "  --effort LEVEL         Same reasoning effort for both (default: medium)"
     , "  --trials N             Repetitions per runner (default: 1)"
     , "  --timeout-seconds N    Agent timeout per run (default: 900)"
-    , "  --runner NAME          Run only agent-cli or codex"
+    , "  --runner NAME          Run only agent-cli, agent-cli-rlm, or codex"
     ]
 
 todoPrompt :: Text
@@ -254,6 +257,13 @@ todoPrompt = Text.unlines
     , "- Start the server with `nix run path:.` and test GET, POST, and DELETE with `curl`."
     , "- End your final response with exactly `SELF_VERIFIED: yes` only after those checks succeed."
     ]
+
+rlmTodoPrompt :: Text
+rlmTodoPrompt =
+    Text.replace
+        "- Do not spawn subagents or use web search; do the implementation and verification yourself."
+        "- Use the RLM worker helpers for delegated inspection and implementation; do not use web search."
+        todoPrompt
 
 runOne :: Config -> Int -> Runner -> IO RunResult
 runOne config trial runner = do
@@ -285,6 +295,23 @@ runOne config trial runner = do
                     , "--model", Text.unpack config.model
                     , "--effort", Text.unpack config.effort
                     ]
+            AgentCliRlm ->
+                proc config.agentBin
+                    [ "--cwd", workspace
+                    , "--prompt", Text.unpack rlmTodoPrompt
+                    , "--save-session"
+                    , "--no-agents-md"
+                    , "--no-skills"
+                    , "--no-subagents"
+                    , "--rlm"
+                    , "--rlm-model", Text.unpack config.model
+                    , "--rlm-effort", Text.unpack config.effort
+                    , "--yolo"
+                    , "--max-turns", "50"
+                    , "--provider", "openai"
+                    , "--model", Text.unpack config.model
+                    , "--effort", Text.unpack config.effort
+                    ]
             Codex ->
                 proc config.codexBin
                     [ "exec"
@@ -306,15 +333,19 @@ runOne config trial runner = do
     ended <- getCurrentTime
     sessionId <- case runner of
         AgentCli -> sessionIdFromLog stderrLog
+        AgentCliRlm -> sessionIdFromLog stderrLog
         Codex -> codexSessionId stdoutLog
     usageResult <- case runner of
         AgentCli -> agentUsage sessionsDir config.resultsDir runName sessionId
+        AgentCliRlm -> agentUsage sessionsDir config.resultsDir runName sessionId
         Codex -> codexUsage stdoutLog
     gradeStarted <- getCurrentTime
     (graded, gradeMessage) <- gradeTodo workspace port
     gradeEnded <- getCurrentTime
     let timedOut = exitCode == ExitFailure 124
-        comparable = usageResult.selfVerified && not usageResult.delegated
+        comparable =
+            usageResult.selfVerified
+                && (runner == AgentCliRlm || not usageResult.delegated)
         finalGrade = Text.intercalate "; "
             [ if timedOut then "timed out" else "agent exited"
             , "self-verified=" <> yesNo usageResult.selfVerified
@@ -371,8 +402,10 @@ sessionUsage meta turns = TokenUsage
     }
   where
     delegatedTurn SessionTurn { turnItems = items } =
-        "spawn_agent" `Text.isInfixOf`
-            Text.decodeUtf8 (LBS.toStrict (encode items))
+        let encoded = Text.decodeUtf8 (LBS.toStrict (encode items))
+        in "spawn_agent" `Text.isInfixOf` encoded
+            || "rlmQuery" `Text.isInfixOf` encoded
+            || "rlmCode" `Text.isInfixOf` encoded
 
 emptyUsage :: TokenUsage
 emptyUsage = TokenUsage Nothing Nothing Nothing False False
@@ -743,15 +776,17 @@ onlyTaskNamed expected response =
 
 runnerOrder :: Int -> [Runner]
 runnerOrder trial
-    | odd trial = [AgentCli, Codex]
-    | otherwise = [Codex, AgentCli]
+    | odd trial = [AgentCli, AgentCliRlm, Codex]
+    | otherwise = [Codex, AgentCliRlm, AgentCli]
 
 runnerOffset :: Runner -> Int
 runnerOffset AgentCli = 1
-runnerOffset Codex = 2
+runnerOffset AgentCliRlm = 2
+runnerOffset Codex = 3
 
 runnerSlug :: Runner -> String
 runnerSlug AgentCli = "agent-cli"
+runnerSlug AgentCliRlm = "agent-cli-rlm"
 runnerSlug Codex = "codex"
 
 collectVersions :: Config -> IO [(Text, Text)]
@@ -804,7 +839,7 @@ renderConsoleSummary results =
         [ "| runner | passed | median successful seconds | median successful input | median successful uncached | median successful output | median successful cached |"
         , "|---|---:|---:|---:|---:|---:|---:|"
         ]
-            <> map renderRunnerSummary [AgentCli, Codex]
+            <> map renderRunnerSummary [AgentCli, AgentCliRlm, Codex]
   where
     renderRunnerSummary runner =
         let selected = filter ((== runner) . (.resultRunner)) results

--- a/packages/agent-cli/eval/AgentVsCodexTodo.hs
+++ b/packages/agent-cli/eval/AgentVsCodexTodo.hs
@@ -2,8 +2,9 @@ module Main (main) where
 
 import Agent.CLI.Session
     ( SessionMeta(..)
-    , SessionTurn
+    , SessionTurn(..)
     , loadSession
+    , sessionConversationText
     )
 import Control.Concurrent (threadDelay)
 import Control.Exception.Safe (finally, tryIO)
@@ -91,6 +92,9 @@ data RunResult = RunResult
     , resultInputTokens :: !(Maybe Int)
     , resultOutputTokens :: !(Maybe Int)
     , resultCachedTokens :: !(Maybe Int)
+    , resultUncachedInputTokens :: !(Maybe Int)
+    , resultSelfVerified :: !Bool
+    , resultDelegated :: !Bool
     , resultSessionId :: !(Maybe Text)
     , resultWorkspace :: !FilePath
     , resultStdoutLog :: !FilePath
@@ -101,6 +105,8 @@ data TokenUsage = TokenUsage
     { inputTokens :: !(Maybe Int)
     , outputTokens :: !(Maybe Int)
     , cachedTokens :: !(Maybe Int)
+    , selfVerified :: !Bool
+    , delegated :: !Bool
     }
 
 data HttpResponse = HttpResponse
@@ -126,6 +132,9 @@ instance ToJSON RunResult where
         , "inputTokens" .= result.resultInputTokens
         , "outputTokens" .= result.resultOutputTokens
         , "cachedTokens" .= result.resultCachedTokens
+        , "uncachedInputTokens" .= result.resultUncachedInputTokens
+        , "selfVerified" .= result.resultSelfVerified
+        , "delegated" .= result.resultDelegated
         , "sessionId" .= result.resultSessionId
         , "workspace" .= result.resultWorkspace
         , "stdoutLog" .= result.resultStdoutLog
@@ -138,6 +147,7 @@ main = do
     config <- case parseConfig args of
         Left err -> hPutStrLn stderr err >> exitFailure
         Right parsed -> pure parsed
+    ensureExecutionEnvironment
     prepareResultsDirectory config.resultsDir
     Text.writeFile (config.resultsDir </> "prompt.txt") todoPrompt
     versions <- collectVersions config
@@ -236,6 +246,13 @@ todoPrompt = Text.unlines
     , "- `DELETE /tasks/:id` deletes an existing task and uses HTTP 204."
     , "- Store all task state in memory in an `MVar`; do not use a database or disk persistence."
     , "- Use `application/json` for JSON responses."
+    , ""
+    , "Fair-evaluation constraints:"
+    , "- Do not spawn subagents or use web search; do the implementation and verification yourself."
+    , "- Verify GHC with `nix develop path:. -c ghc --numeric-version`."
+    , "- Build with `nix build path:.`."
+    , "- Start the server with `nix run path:.` and test GET, POST, and DELETE with `curl`."
+    , "- End your final response with exactly `SELF_VERIFIED: yes` only after those checks succeed."
     ]
 
 runOne :: Config -> Int -> Runner -> IO RunResult
@@ -249,8 +266,9 @@ runOne config trial runner = do
     createDirectoryIfMissing True (takeDirectory stdoutLog)
     _ <- readProcessWithExitCode "git" ["-C", workspace, "init", "--quiet"] ""
     home <- getHomeDirectory
+    executionEnv <- executionEnvironment
     let sessionsDir = home </> ".haskell-agent" </> "sessions"
-        processSpec = case runner of
+        processSpec = (case runner of
             AgentCli ->
                 proc config.agentBin
                     [ "--cwd", workspace
@@ -258,6 +276,9 @@ runOne config trial runner = do
                     , "--save-session"
                     , "--no-agents-md"
                     , "--no-skills"
+                    , "--no-subagents"
+                    , "--bash"
+                    , "--no-ghci"
                     , "--yolo"
                     , "--max-turns", "50"
                     , "--provider", "openai"
@@ -278,6 +299,7 @@ runOne config trial runner = do
                     , "--color", "never"
                     , Text.unpack todoPrompt
                     ]
+            ) { env = Just executionEnv }
     started <- getCurrentTime
     exitCode <- runProcessWithTimeout
         config.timeoutSeconds processSpec stdoutLog stderrLog
@@ -292,13 +314,17 @@ runOne config trial runner = do
     (graded, gradeMessage) <- gradeTodo workspace port
     gradeEnded <- getCurrentTime
     let timedOut = exitCode == ExitFailure 124
-        finalGrade
-            | timedOut = "timed out; " <> gradeMessage
-            | otherwise = gradeMessage
+        comparable = usageResult.selfVerified && not usageResult.delegated
+        finalGrade = Text.intercalate "; "
+            [ if timedOut then "timed out" else "agent exited"
+            , "self-verified=" <> yesNo usageResult.selfVerified
+            , "delegated=" <> yesNo usageResult.delegated
+            , gradeMessage
+            ]
     pure RunResult
         { resultTrial = trial
         , resultRunner = runner
-        , resultPassed = graded && exitCode == ExitSuccess
+        , resultPassed = graded && comparable && exitCode == ExitSuccess
         , resultGrade = finalGrade
         , resultExitCode = exitCodeNumber exitCode
         , resultTimedOut = timedOut
@@ -307,6 +333,10 @@ runOne config trial runner = do
         , resultInputTokens = usageResult.inputTokens
         , resultOutputTokens = usageResult.outputTokens
         , resultCachedTokens = usageResult.cachedTokens
+        , resultUncachedInputTokens =
+            uncachedInput usageResult.inputTokens usageResult.cachedTokens
+        , resultSelfVerified = usageResult.selfVerified
+        , resultDelegated = usageResult.delegated
         , resultSessionId = sessionId
         , resultWorkspace = workspace
         , resultStdoutLog = stdoutLog
@@ -332,14 +362,20 @@ agentUsage sessionsDir resultsRoot runName (Just identifier) = do
 
 sessionUsage :: SessionMeta -> [SessionTurn] -> TokenUsage
 sessionUsage _ [] = emptyUsage
-sessionUsage meta _ = TokenUsage
+sessionUsage meta turns = TokenUsage
     { inputTokens = Just meta.metaInputTokens
     , outputTokens = Just meta.metaOutputTokens
     , cachedTokens = Just meta.metaCachedTokens
+    , selfVerified = "SELF_VERIFIED: yes" `Text.isInfixOf` sessionConversationText turns
+    , delegated = any delegatedTurn turns
     }
+  where
+    delegatedTurn SessionTurn { turnItems = items } =
+        "spawn_agent" `Text.isInfixOf`
+            Text.decodeUtf8 (LBS.toStrict (encode items))
 
 emptyUsage :: TokenUsage
-emptyUsage = TokenUsage Nothing Nothing Nothing
+emptyUsage = TokenUsage Nothing Nothing Nothing False False
 
 codexUsage :: FilePath -> IO TokenUsage
 codexUsage path = do
@@ -361,7 +397,30 @@ codexUsage path = do
                         <|> nestedInt
                             ["input_tokens_details", "cached_tokens"]
                             finalUsage
+                , selfVerified = any
+                    selfVerifiedEvent
+                    events
+                , delegated = any
+                    delegatedEvent
+                    events
                 }
+  where
+    selfVerifiedEvent (Object event) =
+        lookupText "type" event == Just "item.completed"
+            && case lookupKey "item" event of
+                Just (Object item) ->
+                    lookupText "type" item == Just "agent_message"
+                        && maybe False ("SELF_VERIFIED: yes" `Text.isInfixOf`) (lookupText "text" item)
+                _ -> False
+    selfVerifiedEvent _ = False
+    delegatedEvent (Object event) =
+        lookupText "type" event == Just "item.completed"
+            && case lookupKey "item" event of
+                Just (Object item) ->
+                    lookupText "type" item == Just "command_execution"
+                        && maybe False ("spawn_agent" `Text.isInfixOf`) (lookupText "command" item)
+                _ -> False
+    delegatedEvent _ = False
 
 codexSessionId :: FilePath -> IO (Maybe Text)
 codexSessionId path = do
@@ -410,6 +469,28 @@ valueInt :: Value -> Maybe Int
 valueInt value = case fromJSON value of
     Success number -> Just number
     Error _ -> Nothing
+
+uncachedInput :: Maybe Int -> Maybe Int -> Maybe Int
+uncachedInput (Just input) (Just cached) = Just (max 0 (input - cached))
+uncachedInput _ _ = Nothing
+
+ensureExecutionEnvironment :: IO ()
+ensureExecutionEnvironment = do
+    forM_ [("nix", ["--version"]), ("curl", ["--version"]), ("bash", ["--version"])] $
+        \(executable, args) ->
+            tryIO (readProcessWithExitCode executable args "") >>= \case
+                Right (ExitSuccess, _, _) -> pure ()
+                Right (_, _, err) ->
+                    hPutStrLn stderr
+                        ("execution preflight failed for " <> executable <> ": " <> err)
+                        >> exitFailure
+                Left err ->
+                    hPutStrLn stderr
+                        ("execution preflight failed for " <> executable <> ": " <> show err)
+                        >> exitFailure
+
+executionEnvironment :: IO [(String, String)]
+executionEnvironment = getEnvironment
 
 gradeTodo :: FilePath -> Int -> IO (Bool, Text)
 gradeTodo workspace port = do
@@ -712,16 +793,16 @@ renderSummary config versions results =
             , ""
             , "## Individual runs"
             , ""
-            , "| trial | runner | pass | timeout | agent seconds | grade seconds | input | output | cached | grade |"
-            , "|---:|---|---:|---:|---:|---:|---:|---:|---:|---|"
+            , "| trial | runner | pass | self-verified | delegated | timeout | agent seconds | grade seconds | input | uncached | output | cached | grade |"
+            , "|---:|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|"
             ]
         <> Text.unlines (map renderRunRow results)
 
 renderConsoleSummary :: [RunResult] -> Text
 renderConsoleSummary results =
     Text.unlines $
-        [ "| runner | passed | median successful seconds | median successful input | median successful output | median successful cached |"
-        , "|---|---:|---:|---:|---:|---:|"
+        [ "| runner | passed | median successful seconds | median successful input | median successful uncached | median successful output | median successful cached |"
+        , "|---|---:|---:|---:|---:|---:|---:|"
         ]
             <> map renderRunnerSummary [AgentCli, Codex]
   where
@@ -733,6 +814,7 @@ renderConsoleSummary results =
             , Text.pack (show (length successful) <> "/" <> show (length selected))
             , optionalMedian (map (.resultSeconds) successful)
             , optionalIntMedian (catMaybes (map (.resultInputTokens) successful))
+            , optionalIntMedian (catMaybes (map (.resultUncachedInputTokens) successful))
             , optionalIntMedian (catMaybes (map (.resultOutputTokens) successful))
             , optionalIntMedian (catMaybes (map (.resultCachedTokens) successful)) <> " |"
             ]
@@ -742,10 +824,13 @@ renderRunRow result = Text.intercalate " | "
     [ "| " <> Text.pack (show result.resultTrial)
     , Text.pack (runnerSlug result.resultRunner)
     , yesNo result.resultPassed
+    , yesNo result.resultSelfVerified
+    , yesNo result.resultDelegated
     , yesNo result.resultTimedOut
     , formatDouble result.resultSeconds
     , formatDouble result.resultGradeSeconds
     , maybe "n/a" (Text.pack . show) result.resultInputTokens
+    , maybe "n/a" (Text.pack . show) result.resultUncachedInputTokens
     , maybe "n/a" (Text.pack . show) result.resultOutputTokens
     , maybe "n/a" (Text.pack . show) result.resultCachedTokens
     , Text.replace "|" "\\|" result.resultGrade <> " |"

--- a/packages/agent-cli/eval/AgentVsCodexTodo.hs
+++ b/packages/agent-cli/eval/AgentVsCodexTodo.hs
@@ -151,6 +151,9 @@ main = do
     ensureExecutionEnvironment
     prepareResultsDirectory config.resultsDir
     Text.writeFile (config.resultsDir </> "prompt.txt") todoPrompt
+    Text.writeFile (config.resultsDir </> "provided-flake.nix") providedFlake
+    Text.writeFile (config.resultsDir </> "provided-flake.lock") providedFlakeLock
+    prebuildProvidedFlake config.resultsDir
     versions <- collectVersions config
     let scheduled =
             [ (trial, runner)
@@ -233,11 +236,14 @@ usage = unlines
 
 todoPrompt :: Text
 todoPrompt = Text.unlines
-    [ "Build a complete Haskell todo application in the empty workspace."
+    [ "Build a complete Haskell todo application in the provided workspace."
     , "Do not only explain the solution: create all files and verify the app."
+    , "A prebuilt `flake.nix` and its lock file are already present."
     , ""
     , "Requirements:"
-    , "- Use a Nix flake for all dependencies and a development environment."
+    , "- Do not edit, replace, delete, or regenerate `flake.nix` or `flake.lock`."
+    , "- Implement the server in `app/Main.hs`, which the provided flake runs."
+    , "- You may create other project files, but they must not require flake changes."
     , "- Use GHC 9.10."
     , "- `nix run` must build and start the application."
     , "- The application is an HTTP server."
@@ -265,6 +271,108 @@ rlmTodoPrompt =
         "- Use the RLM worker helpers for delegated inspection and implementation; do not use web search."
         todoPrompt
 
+providedFlake :: Text
+providedFlake = Text.unlines
+    [ "{"
+    , "  description = \"Prebuilt GHC 9.10 environment for the todo eval\";"
+    , ""
+    , "  inputs.nixpkgs.url ="
+    , "    \"github:NixOS/nixpkgs/afe3d8ac4395617bdcdac9f188ac8717a062e014\";"
+    , ""
+    , "  outputs = { self, nixpkgs }:"
+    , "    let"
+    , "      systems = [ \"x86_64-linux\" \"aarch64-linux\" \"aarch64-darwin\" ];"
+    , "      forAllSystems = nixpkgs.lib.genAttrs systems;"
+    , "      packagesFor = system:"
+    , "        let"
+    , "          pkgs = import nixpkgs { inherit system; };"
+    , "          ghcEnv = pkgs.haskellPackages.ghcWithPackages (hpkgs: with hpkgs; ["
+    , "            aeson"
+    , "            http-types"
+    , "            wai"
+    , "            warp"
+    , "          ]);"
+    , "        in { inherit pkgs ghcEnv; };"
+    , "    in {"
+    , "      packages = forAllSystems (system:"
+    , "        let env = packagesFor system; in {"
+    , "          default = env.pkgs.writeShellApplication {"
+    , "            name = \"todo-server\";"
+    , "            runtimeInputs = [ env.ghcEnv ];"
+    , "            text = ''exec runghc app/Main.hs'';"
+    , "          };"
+    , "        });"
+    , ""
+    , "      devShells = forAllSystems (system:"
+    , "        let env = packagesFor system; in {"
+    , "          default = env.pkgs.mkShell {"
+    , "            packages = [ env.ghcEnv env.pkgs.cabal-install env.pkgs.curl ];"
+    , "          };"
+    , "        });"
+    , "    };"
+    , "}"
+    ]
+
+providedFlakeLock :: Text
+providedFlakeLock = Text.unlines
+    [ "{"
+    , "  \"nodes\": {"
+    , "    \"nixpkgs\": {"
+    , "      \"locked\": {"
+    , "        \"lastModified\": 1787111413,"
+    , "        \"narHash\": \"sha256-sFosWtq21eHGJRnTc/hvf4M1obRgLEUMNm/IzllkHMA=\","
+    , "        \"owner\": \"NixOS\","
+    , "        \"repo\": \"nixpkgs\","
+    , "        \"rev\": \"afe3d8ac4395617bdcdac9f188ac8717a062e014\","
+    , "        \"type\": \"github\""
+    , "      },"
+    , "      \"original\": {"
+    , "        \"owner\": \"NixOS\","
+    , "        \"repo\": \"nixpkgs\","
+    , "        \"rev\": \"afe3d8ac4395617bdcdac9f188ac8717a062e014\","
+    , "        \"type\": \"github\""
+    , "      }"
+    , "    },"
+    , "    \"root\": {"
+    , "      \"inputs\": {"
+    , "        \"nixpkgs\": \"nixpkgs\""
+    , "      }"
+    , "    }"
+    , "  },"
+    , "  \"root\": \"root\","
+    , "  \"version\": 7"
+    , "}"
+    ]
+
+prebuildProvidedFlake :: FilePath -> IO ()
+prebuildProvidedFlake resultsRoot = do
+    let fixture = resultsRoot </> "prebuilt-flake"
+    resetDirectory fixture
+    createDirectoryIfMissing True (fixture </> "app")
+    Text.writeFile (fixture </> "flake.nix") providedFlake
+    Text.writeFile (fixture </> "flake.lock") providedFlakeLock
+    Text.writeFile (fixture </> "app" </> "Main.hs")
+        "main :: IO ()\nmain = pure ()\n"
+    putStrLn "Prebuilding the shared Nix flake before timed runs..."
+    runRequired fixture "nix" ["build", "path:."]
+    runRequired fixture "nix"
+        ["develop", "path:.", "-c", "ghc", "--numeric-version"]
+
+runRequired :: FilePath -> FilePath -> [String] -> IO ()
+runRequired workingDirectory executable args =
+    readCreateProcessWithExitCode
+        (proc executable args) { cwd = Just workingDirectory }
+        ""
+        >>= \case
+            (ExitSuccess, _, _) -> pure ()
+            (_, stdoutText, stderrText) -> do
+                hPutStrLn stderr $
+                    unwords (executable : args)
+                        <> " failed while preparing the eval fixture:\n"
+                        <> stdoutText
+                        <> stderrText
+                exitFailure
+
 runOne :: Config -> Int -> Runner -> IO RunResult
 runOne config trial runner = do
     let runName = "todo-trial-" <> show trial <> "-" <> runnerSlug runner
@@ -274,6 +382,8 @@ runOne config trial runner = do
         port = 38000 + trial * 10 + runnerOffset runner
     resetDirectory workspace
     createDirectoryIfMissing True (takeDirectory stdoutLog)
+    Text.writeFile (workspace </> "flake.nix") providedFlake
+    Text.writeFile (workspace </> "flake.lock") providedFlakeLock
     _ <- readProcessWithExitCode "git" ["-C", workspace, "init", "--quiet"] ""
     home <- getHomeDirectory
     executionEnv <- executionEnvironment
@@ -528,8 +638,19 @@ executionEnvironment = getEnvironment
 gradeTodo :: FilePath -> Int -> IO (Bool, Text)
 gradeTodo workspace port = do
     flakeExists <- doesFileExist (workspace </> "flake.nix")
-    ghcCheck <- if not flakeExists
-        then pure (False, "missing flake.nix")
+    lockExists <- doesFileExist (workspace </> "flake.lock")
+    flakeUnchanged <- if flakeExists
+        then (== providedFlake) <$> Text.readFile (workspace </> "flake.nix")
+        else pure False
+    lockUnchanged <- if lockExists
+        then (== providedFlakeLock) <$> Text.readFile (workspace </> "flake.lock")
+        else pure False
+    let fixtureUnchanged = flakeUnchanged && lockUnchanged
+    ghcCheck <- if not fixtureUnchanged
+        then pure
+            ( False
+            , "provided flake fixture was modified or removed"
+            )
         else do
             ghcResult <- timeout (5 * 60 * 1000000) $
                 readCreateProcessWithExitCode
@@ -544,11 +665,17 @@ gradeTodo workspace port = do
                     (False, "nix develop failed: " <> oneLine (Text.pack err))
                 Nothing -> (False, "nix develop timed out")
     mvarCheck <- workspaceUsesMVar workspace
-    httpCheck <- if flakeExists
+    httpCheck <- if fixtureUnchanged
         then runHttpGrade workspace port
-        else pure (False, "cannot run app without flake.nix")
+        else pure (False, "cannot run app with a modified flake fixture")
     let checks =
-            [ ("ghc-9.10", fst ghcCheck, snd ghcCheck)
+            [ ( "flake-unchanged"
+              , fixtureUnchanged
+              , if fixtureUnchanged
+                    then "provided flake.nix and flake.lock preserved exactly"
+                    else "provided flake.nix or flake.lock was modified or removed"
+              )
+            , ("ghc-9.10", fst ghcCheck, snd ghcCheck)
             , ("mvar", mvarCheck, if mvarCheck then "MVar found in Haskell source" else "no MVar found in Haskell source")
             , ("http-crud", fst httpCheck, snd httpCheck)
             ]

--- a/packages/agent-cli/eval/AgentVsCodexTodo.hs
+++ b/packages/agent-cli/eval/AgentVsCodexTodo.hs
@@ -1,0 +1,910 @@
+module Main (main) where
+
+import Agent.CLI.Session
+    ( SessionMeta(..)
+    , SessionTurn
+    , loadSession
+    )
+import Control.Concurrent (threadDelay)
+import Control.Exception.Safe (finally, tryIO)
+import Control.Monad (forM, forM_, unless, when)
+import Data.Aeson
+    ( ToJSON(..)
+    , Value(..)
+    , decode
+    , encode
+    , fromJSON
+    , object
+    , Result(..)
+    , (.=)
+    )
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy as LBS
+import Data.List (sort)
+import qualified Data.List as List
+import Data.Maybe (catMaybes)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
+import qualified Data.Text.IO as Text
+import Data.Time.Clock (diffUTCTime, getCurrentTime)
+import System.Directory
+    ( copyFile
+    , createDirectoryIfMissing
+    , doesDirectoryExist
+    , doesFileExist
+    , getHomeDirectory
+    , listDirectory
+    , removePathForcibly
+    )
+import System.Environment (getArgs, getEnvironment)
+import System.Exit (ExitCode(..), exitFailure)
+import System.FilePath (takeDirectory, takeExtension, (</>))
+import System.IO (IOMode(..), hPutStrLn, stderr, withFile)
+import System.OsPath (unsafeEncodeUtf)
+import System.Process
+    ( CreateProcess(..)
+    , ProcessHandle
+    , StdStream(..)
+    , getPid
+    , getProcessExitCode
+    , proc
+    , readCreateProcessWithExitCode
+    , readProcess
+    , readProcessWithExitCode
+    , waitForProcess
+    , withCreateProcess
+    )
+import System.Posix.Signals
+    ( Signal
+    , sigKILL
+    , sigTERM
+    , signalProcess
+    )
+import System.Posix.Types (ProcessID)
+import System.Timeout (timeout)
+
+data Runner = AgentCli | Codex
+    deriving (Eq, Ord, Show)
+
+data Config = Config
+    { agentBin :: !FilePath
+    , codexBin :: !FilePath
+    , resultsDir :: !FilePath
+    , model :: !Text
+    , effort :: !Text
+    , trials :: !Int
+    , timeoutSeconds :: !Int
+    , selectedRunner :: !(Maybe Runner)
+    }
+
+data RunResult = RunResult
+    { resultTrial :: !Int
+    , resultRunner :: !Runner
+    , resultPassed :: !Bool
+    , resultGrade :: !Text
+    , resultExitCode :: !Int
+    , resultTimedOut :: !Bool
+    , resultSeconds :: !Double
+    , resultGradeSeconds :: !Double
+    , resultInputTokens :: !(Maybe Int)
+    , resultOutputTokens :: !(Maybe Int)
+    , resultCachedTokens :: !(Maybe Int)
+    , resultSessionId :: !(Maybe Text)
+    , resultWorkspace :: !FilePath
+    , resultStdoutLog :: !FilePath
+    , resultStderrLog :: !FilePath
+    }
+
+data TokenUsage = TokenUsage
+    { inputTokens :: !(Maybe Int)
+    , outputTokens :: !(Maybe Int)
+    , cachedTokens :: !(Maybe Int)
+    }
+
+data HttpResponse = HttpResponse
+    { responseStatus :: !Int
+    , responseContentType :: !Text
+    , responseBody :: !LBS.ByteString
+    }
+
+instance ToJSON Runner where
+    toJSON AgentCli = toJSON ("agent-cli" :: Text)
+    toJSON Codex = toJSON ("codex" :: Text)
+
+instance ToJSON RunResult where
+    toJSON result = object
+        [ "trial" .= result.resultTrial
+        , "runner" .= result.resultRunner
+        , "passed" .= result.resultPassed
+        , "grade" .= result.resultGrade
+        , "exitCode" .= result.resultExitCode
+        , "timedOut" .= result.resultTimedOut
+        , "seconds" .= result.resultSeconds
+        , "gradeSeconds" .= result.resultGradeSeconds
+        , "inputTokens" .= result.resultInputTokens
+        , "outputTokens" .= result.resultOutputTokens
+        , "cachedTokens" .= result.resultCachedTokens
+        , "sessionId" .= result.resultSessionId
+        , "workspace" .= result.resultWorkspace
+        , "stdoutLog" .= result.resultStdoutLog
+        , "stderrLog" .= result.resultStderrLog
+        ]
+
+main :: IO ()
+main = do
+    args <- getArgs
+    config <- case parseConfig args of
+        Left err -> hPutStrLn stderr err >> exitFailure
+        Right parsed -> pure parsed
+    prepareResultsDirectory config.resultsDir
+    Text.writeFile (config.resultsDir </> "prompt.txt") todoPrompt
+    versions <- collectVersions config
+    let scheduled =
+            [ (trial, runner)
+            | trial <- [1 .. config.trials]
+            , runner <- runnerOrder trial
+            , maybe True (== runner) config.selectedRunner
+            ]
+    results <- forM scheduled \(trial, runner) -> do
+        putStrLn $
+            "Running todo-app trial " <> show trial
+                <> " (" <> runnerSlug runner <> ")"
+        runOne config trial runner
+    LBS.writeFile (config.resultsDir </> "results.json") (encode results)
+    Text.writeFile (config.resultsDir </> "summary.md")
+        (renderSummary config versions results)
+    putStrLn ""
+    Text.putStrLn (renderConsoleSummary results)
+    unless (all (.resultPassed) results) exitFailure
+
+parseConfig :: [String] -> Either String Config
+parseConfig = go Config
+    { agentBin = "." </> "agent-cli"
+    , codexBin = "codex"
+    , resultsDir = "." </> "eval-results" </> "agent-vs-codex-todo"
+    , model = ""
+    , effort = "medium"
+    , trials = 1
+    , timeoutSeconds = 900
+    , selectedRunner = Nothing
+    }
+  where
+    go config = \case
+        []
+            | Text.null config.model -> Left ("--model is required\n\n" <> usage)
+            | otherwise -> Right config
+        "--agent-bin" : value : rest ->
+            go config { agentBin = value } rest
+        "--codex-bin" : value : rest ->
+            go config { codexBin = value } rest
+        "--results-dir" : value : rest ->
+            go config { resultsDir = value } rest
+        "--model" : value : rest ->
+            go config { model = Text.pack value } rest
+        "--effort" : value : rest
+            | value `elem` ["none", "low", "medium", "high", "xhigh"] ->
+                go config { effort = Text.pack value } rest
+            | otherwise ->
+                Left "--effort expects none, low, medium, high, or xhigh"
+        "--trials" : value : rest -> case reads value of
+            [(count, "")] | count > 0 ->
+                go config { trials = count } rest
+            _ -> Left "--trials expects a positive integer"
+        "--timeout-seconds" : value : rest -> case reads value of
+            [(seconds, "")] | seconds > 0 ->
+                go config { timeoutSeconds = seconds } rest
+            _ -> Left "--timeout-seconds expects a positive integer"
+        "--runner" : value : rest -> case value of
+            "agent-cli" -> go config { selectedRunner = Just AgentCli } rest
+            "codex" -> go config { selectedRunner = Just Codex } rest
+            _ -> Left "--runner expects agent-cli or codex"
+        "--help" : _ -> Left usage
+        unknown : _ -> Left ("unknown eval argument: " <> unknown <> "\n\n" <> usage)
+
+usage :: String
+usage = unlines
+    [ "Usage: eval-agent-vs-codex-todo --model MODEL [OPTIONS]"
+    , ""
+    , "Options:"
+    , "  --agent-bin PATH       agent-cli executable"
+    , "  --codex-bin PATH       Codex executable (default: codex)"
+    , "  --results-dir DIR      New or empty artifact directory"
+    , "  --model MODEL          Exact model passed to both runners (required)"
+    , "  --effort LEVEL         Same reasoning effort for both (default: medium)"
+    , "  --trials N             Repetitions per runner (default: 1)"
+    , "  --timeout-seconds N    Agent timeout per run (default: 900)"
+    , "  --runner NAME          Run only agent-cli or codex"
+    ]
+
+todoPrompt :: Text
+todoPrompt = Text.unlines
+    [ "Build a complete Haskell todo application in the empty workspace."
+    , "Do not only explain the solution: create all files and verify the app."
+    , ""
+    , "Requirements:"
+    , "- Use a Nix flake for all dependencies and a development environment."
+    , "- Use GHC 9.10."
+    , "- `nix run` must build and start the application."
+    , "- The application is an HTTP server."
+    , "- Read the listening port from the `PORT` environment variable, defaulting to 3000."
+    , "- `GET /tasks` returns a JSON array of tasks."
+    , "- A task has exactly these fields: `id` (Int), `name` (Text), and `description` (Text)."
+    , "- `POST /tasks` accepts JSON with `name` and `description`, creates a task,"
+    , "  assigns an integer id, returns the created task as JSON, and uses HTTP 201."
+    , "- `DELETE /tasks/:id` deletes an existing task and uses HTTP 204."
+    , "- Store all task state in memory in an `MVar`; do not use a database or disk persistence."
+    , "- Use `application/json` for JSON responses."
+    ]
+
+runOne :: Config -> Int -> Runner -> IO RunResult
+runOne config trial runner = do
+    let runName = "todo-trial-" <> show trial <> "-" <> runnerSlug runner
+        workspace = config.resultsDir </> "workspaces" </> runName
+        stdoutLog = config.resultsDir </> "logs" </> runName <> ".stdout.log"
+        stderrLog = config.resultsDir </> "logs" </> runName <> ".stderr.log"
+        port = 38000 + trial * 10 + runnerOffset runner
+    resetDirectory workspace
+    createDirectoryIfMissing True (takeDirectory stdoutLog)
+    _ <- readProcessWithExitCode "git" ["-C", workspace, "init", "--quiet"] ""
+    home <- getHomeDirectory
+    let sessionsDir = home </> ".haskell-agent" </> "sessions"
+        processSpec = case runner of
+            AgentCli ->
+                proc config.agentBin
+                    [ "--cwd", workspace
+                    , "--prompt", Text.unpack todoPrompt
+                    , "--save-session"
+                    , "--no-agents-md"
+                    , "--no-skills"
+                    , "--yolo"
+                    , "--max-turns", "50"
+                    , "--provider", "openai"
+                    , "--model", Text.unpack config.model
+                    , "--effort", Text.unpack config.effort
+                    ]
+            Codex ->
+                proc config.codexBin
+                    [ "exec"
+                    , "--cd", workspace
+                    , "--model", Text.unpack config.model
+                    , "-c", "model_reasoning_effort=" <> show (Text.unpack config.effort)
+                    , "--dangerously-bypass-approvals-and-sandbox"
+                    , "--ephemeral"
+                    , "--ignore-user-config"
+                    , "--ignore-rules"
+                    , "--json"
+                    , "--color", "never"
+                    , Text.unpack todoPrompt
+                    ]
+    started <- getCurrentTime
+    exitCode <- runProcessWithTimeout
+        config.timeoutSeconds processSpec stdoutLog stderrLog
+    ended <- getCurrentTime
+    sessionId <- case runner of
+        AgentCli -> sessionIdFromLog stderrLog
+        Codex -> codexSessionId stdoutLog
+    usageResult <- case runner of
+        AgentCli -> agentUsage sessionsDir config.resultsDir runName sessionId
+        Codex -> codexUsage stdoutLog
+    gradeStarted <- getCurrentTime
+    (graded, gradeMessage) <- gradeTodo workspace port
+    gradeEnded <- getCurrentTime
+    let timedOut = exitCode == ExitFailure 124
+        finalGrade
+            | timedOut = "timed out; " <> gradeMessage
+            | otherwise = gradeMessage
+    pure RunResult
+        { resultTrial = trial
+        , resultRunner = runner
+        , resultPassed = graded && exitCode == ExitSuccess
+        , resultGrade = finalGrade
+        , resultExitCode = exitCodeNumber exitCode
+        , resultTimedOut = timedOut
+        , resultSeconds = realToFrac (diffUTCTime ended started)
+        , resultGradeSeconds = realToFrac (diffUTCTime gradeEnded gradeStarted)
+        , resultInputTokens = usageResult.inputTokens
+        , resultOutputTokens = usageResult.outputTokens
+        , resultCachedTokens = usageResult.cachedTokens
+        , resultSessionId = sessionId
+        , resultWorkspace = workspace
+        , resultStdoutLog = stdoutLog
+        , resultStderrLog = stderrLog
+        }
+
+agentUsage
+    :: FilePath
+    -> FilePath
+    -> FilePath
+    -> Maybe Text
+    -> IO TokenUsage
+agentUsage _ _ _ Nothing = pure emptyUsage
+agentUsage sessionsDir resultsRoot runName (Just identifier) = do
+    loaded <- loadSession (unsafeEncodeUtf sessionsDir) identifier
+    case loaded of
+        Left err -> do
+            hPutStrLn stderr ("could not load eval session: " <> Text.unpack err)
+            pure emptyUsage
+        Right (meta, turns) -> do
+            copySessionArtifacts resultsRoot runName sessionsDir identifier
+            pure (sessionUsage meta turns)
+
+sessionUsage :: SessionMeta -> [SessionTurn] -> TokenUsage
+sessionUsage _ [] = emptyUsage
+sessionUsage meta _ = TokenUsage
+    { inputTokens = Just meta.metaInputTokens
+    , outputTokens = Just meta.metaOutputTokens
+    , cachedTokens = Just meta.metaCachedTokens
+    }
+
+emptyUsage :: TokenUsage
+emptyUsage = TokenUsage Nothing Nothing Nothing
+
+codexUsage :: FilePath -> IO TokenUsage
+codexUsage path = do
+    events <- readJsonLines path
+    pure $ case
+        [ usage
+        | Object event <- events
+        , lookupText "type" event == Just "turn.completed"
+        , Just (Object usage) <- [lookupKey "usage" event]
+        ] of
+        [] -> emptyUsage
+        usages ->
+            let finalUsage = last usages
+            in TokenUsage
+                { inputTokens = lookupInt "input_tokens" finalUsage
+                , outputTokens = lookupInt "output_tokens" finalUsage
+                , cachedTokens =
+                    lookupInt "cached_input_tokens" finalUsage
+                        <|> nestedInt
+                            ["input_tokens_details", "cached_tokens"]
+                            finalUsage
+                }
+
+codexSessionId :: FilePath -> IO (Maybe Text)
+codexSessionId path = do
+    events <- readJsonLines path
+    pure $ case catMaybes (map eventSessionId events) of
+        identifier : _ -> Just identifier
+        [] -> Nothing
+  where
+    eventSessionId (Object event) =
+        lookupText "thread_id" event <|> lookupText "session_id" event
+    eventSessionId _ = Nothing
+
+readJsonLines :: FilePath -> IO [Value]
+readJsonLines path = do
+    exists <- doesFileExist path
+    if not exists
+        then pure []
+        else do
+            contents <- Text.readFile path
+            pure
+                [ value
+                | line <- Text.lines contents
+                , Just value <-
+                    [decode (LBS.fromStrict (Text.encodeUtf8 line))]
+                ]
+
+lookupKey :: Text -> KeyMap.KeyMap Value -> Maybe Value
+lookupKey name = KeyMap.lookup (Key.fromText name)
+
+lookupText :: Text -> KeyMap.KeyMap Value -> Maybe Text
+lookupText name fields = case lookupKey name fields of
+    Just (String value) -> Just value
+    _ -> Nothing
+
+lookupInt :: Text -> KeyMap.KeyMap Value -> Maybe Int
+lookupInt name fields = lookupKey name fields >>= valueInt
+
+nestedInt :: [Text] -> KeyMap.KeyMap Value -> Maybe Int
+nestedInt [] _ = Nothing
+nestedInt [name] fields = lookupInt name fields
+nestedInt (name : rest) fields = case lookupKey name fields of
+    Just (Object nested) -> nestedInt rest nested
+    _ -> Nothing
+
+valueInt :: Value -> Maybe Int
+valueInt value = case fromJSON value of
+    Success number -> Just number
+    Error _ -> Nothing
+
+gradeTodo :: FilePath -> Int -> IO (Bool, Text)
+gradeTodo workspace port = do
+    flakeExists <- doesFileExist (workspace </> "flake.nix")
+    ghcCheck <- if not flakeExists
+        then pure (False, "missing flake.nix")
+        else do
+            ghcResult <- timeout (5 * 60 * 1000000) $
+                readCreateProcessWithExitCode
+                    (proc "nix" ["develop", "path:.", "-c", "ghc", "--numeric-version"])
+                        { cwd = Just workspace }
+                    ""
+            pure $ case ghcResult of
+                Just (ExitSuccess, version, _) ->
+                    ("9.10." `Text.isPrefixOf` Text.strip (Text.pack version),
+                        "GHC version " <> Text.strip (Text.pack version))
+                Just (_, _, err) ->
+                    (False, "nix develop failed: " <> oneLine (Text.pack err))
+                Nothing -> (False, "nix develop timed out")
+    mvarCheck <- workspaceUsesMVar workspace
+    httpCheck <- if flakeExists
+        then runHttpGrade workspace port
+        else pure (False, "cannot run app without flake.nix")
+    let checks =
+            [ ("ghc-9.10", fst ghcCheck, snd ghcCheck)
+            , ("mvar", mvarCheck, if mvarCheck then "MVar found in Haskell source" else "no MVar found in Haskell source")
+            , ("http-crud", fst httpCheck, snd httpCheck)
+            ]
+        passed = all (\(_, ok, _) -> ok) checks
+        message = Text.intercalate "; "
+            [ name <> "=" <> (if ok then "pass" else "fail") <> " (" <> detail <> ")"
+            | (name, ok, detail) <- checks
+            ]
+    pure (passed, message)
+
+workspaceUsesMVar :: FilePath -> IO Bool
+workspaceUsesMVar root = do
+    files <- recursiveFiles root
+    contents <- forM
+        [ path | path <- files, takeExtension path `elem` [".hs", ".lhs"] ]
+        Text.readFile
+    let source = Text.unlines contents
+    pure $
+        "MVar" `Text.isInfixOf` source
+            && any (`Text.isInfixOf` source)
+                ["newMVar", "newEmptyMVar"]
+            && any (`Text.isInfixOf` source)
+                [ "modifyMVar", "modifyMVar_", "modifyMVarMasked"
+                , "readMVar", "withMVar", "swapMVar", "takeMVar", "putMVar"
+                ]
+
+recursiveFiles :: FilePath -> IO [FilePath]
+recursiveFiles root = do
+    entries <- listDirectory root
+    fmap concat $ forM entries \entry -> do
+        let path = root </> entry
+        isDir <- doesDirectoryExist path
+        if isDir && entry /= ".git"
+            then recursiveFiles path
+            else pure [path | not isDir]
+
+runHttpGrade :: FilePath -> Int -> IO (Bool, Text)
+runHttpGrade workspace port = do
+    environment <- getEnvironment
+    let stdoutPath = workspace </> ".eval-server.stdout.log"
+        stderrPath = workspace </> ".eval-server.stderr.log"
+    withFile stdoutPath WriteMode \stdoutHandle ->
+        withFile stderrPath WriteMode \stderrHandle -> do
+            let processSpec =
+                    (proc "nix" ["run", "path:."])
+                        { cwd = Just workspace
+                        , env = Just (("PORT", show port) : filter ((/= "PORT") . fst) environment)
+                        , std_out = UseHandle stdoutHandle
+                        , std_err = UseHandle stderrHandle
+                        , std_in = NoStream
+                        , create_group = True
+                        , new_session = True
+                        }
+            withCreateProcess processSpec \_ _ _ processHandle ->
+                gradeRunningServer processHandle port
+                    `finally` stopProcessTree processHandle
+
+gradeRunningServer :: ProcessHandle -> Int -> IO (Bool, Text)
+gradeRunningServer processHandle port = do
+    ready <- waitForServer processHandle port 600
+    if not ready
+        then pure (False, "`nix run` did not expose GET /tasks within 5 minutes")
+        else do
+            initial <- curl port "GET" "/tasks" Nothing
+            createdOne <- curl port "POST" "/tasks"
+                (Just "{\"name\":\"write eval\",\"description\":\"compare harnesses\"}")
+            let firstId = createdOne >>= responseTaskId
+            afterFirst <- curl port "GET" "/tasks" Nothing
+            createdTwo <- curl port "POST" "/tasks"
+                (Just "{\"name\":\"publish report\",\"description\":\"record tokens and time\"}")
+            afterSecond <- curl port "GET" "/tasks" Nothing
+            deleted <- case firstId of
+                Nothing -> pure Nothing
+                Just identifier ->
+                    curl port "DELETE" ("/tasks/" <> show identifier) Nothing
+            final <- curl port "GET" "/tasks" Nothing
+            let checks =
+                    [ ("initial GET", maybe False isEmptyTaskList initial)
+                    , ("first POST", maybe False validFirstTask createdOne)
+                    , ("first persisted", maybe False (containsTask "write eval" "compare harnesses") afterFirst)
+                    , ("second POST", maybe False validSecondTask createdTwo)
+                    , ("two tasks", maybe False ((== 2) . taskCount) afterSecond)
+                    , ("unique ids", uniqueCreatedIds createdOne createdTwo)
+                    , ("DELETE", maybe False ((== 204) . (.responseStatus)) deleted)
+                    , ("deletion persisted", maybe False (onlyTaskNamed "publish report") final)
+                    ]
+                failed = [name | (name, ok) <- checks, not ok]
+            pure
+                ( null failed
+                , if null failed
+                    then "GET/POST/DELETE behavior passed"
+                    else "failed checks: " <> Text.intercalate ", " failed
+                )
+
+waitForServer :: ProcessHandle -> Int -> Int -> IO Bool
+waitForServer _ _ attempts | attempts <= 0 = pure False
+waitForServer processHandle port attempts = do
+    exited <- getProcessExitCode processHandle
+    case exited of
+        Just _ -> pure False
+        Nothing -> do
+            response <- curl port "GET" "/tasks" Nothing
+            case response of
+                Just value | value.responseStatus == 200 -> pure True
+                _ -> threadDelay 500000 >> waitForServer processHandle port (attempts - 1)
+
+curl :: Int -> String -> String -> Maybe String -> IO (Maybe HttpResponse)
+curl port method path body = do
+    let url = "http://127.0.0.1:" <> show port <> path
+        args =
+            [ "--silent", "--show-error"
+            , "--max-time", "2"
+            , "--request", method
+            , "--write-out", "\n__STATUS__%{http_code}\n__CONTENT_TYPE__%{content_type}"
+            ]
+                <> case body of
+                    Nothing -> []
+                    Just json ->
+                        [ "--header", "Content-Type: application/json"
+                        , "--data-binary", json
+                        ]
+                <> [url]
+    result <- tryIO (readProcessWithExitCode "curl" args "")
+    pure $ case result of
+        Right (ExitSuccess, output, _) -> parseCurlOutput output
+        _ -> Nothing
+
+parseCurlOutput :: String -> Maybe HttpResponse
+parseCurlOutput output = do
+    let rows = lines output
+        statusPrefix = "__STATUS__"
+        contentTypePrefix = "__CONTENT_TYPE__"
+    statusText <- case
+        [ drop (length statusPrefix) row
+        | row <- rows
+        , statusPrefix `List.isPrefixOf` row
+        ] of
+        value : _ -> Just value
+        [] -> Nothing
+    let contentType = case
+            [ drop (length contentTypePrefix) row
+            | row <- rows
+            , contentTypePrefix `List.isPrefixOf` row
+            ] of
+            value : _ -> value
+            [] -> ""
+    status <- case reads statusText of
+        [(value, "")] -> Just value
+        _ -> Nothing
+    let bodyLines =
+            takeWhile (not . List.isPrefixOf statusPrefix) rows
+    pure HttpResponse
+        { responseStatus = status
+        , responseContentType = Text.pack contentType
+        , responseBody = LBS.fromStrict (Text.encodeUtf8 (Text.pack (unlines bodyLines)))
+        }
+
+isEmptyTaskList :: HttpResponse -> Bool
+isEmptyTaskList response =
+    response.responseStatus == 200
+        && isJsonResponse response
+        && taskCount response == 0
+
+validFirstTask :: HttpResponse -> Bool
+validFirstTask response =
+    response.responseStatus == 201
+        && isJsonResponse response
+        && containsTask "write eval" "compare harnesses" response
+        && maybe False (> 0) (responseTaskId response)
+
+validSecondTask :: HttpResponse -> Bool
+validSecondTask response =
+    response.responseStatus == 201
+        && isJsonResponse response
+        && containsTask "publish report" "record tokens and time" response
+        && maybe False (> 0) (responseTaskId response)
+
+isJsonResponse :: HttpResponse -> Bool
+isJsonResponse response =
+    "application/json" `Text.isPrefixOf`
+        Text.toLower response.responseContentType
+
+uniqueCreatedIds :: Maybe HttpResponse -> Maybe HttpResponse -> Bool
+uniqueCreatedIds first second = case (first >>= responseTaskId, second >>= responseTaskId) of
+    (Just firstId, Just secondId) -> firstId /= secondId
+    _ -> False
+
+responseTaskId :: HttpResponse -> Maybe Int
+responseTaskId response = do
+    Object fields <- decode response.responseBody
+    lookupInt "id" fields
+
+taskCount :: HttpResponse -> Int
+taskCount response = case decode response.responseBody of
+    Just (Array tasks) -> length tasks
+    _ -> -1
+
+containsTask :: Text -> Text -> HttpResponse -> Bool
+containsTask expectedName expectedDescription response =
+    isJsonResponse response
+        && case decode response.responseBody of
+            Just (Array tasks) -> any matches tasks
+            Just value -> matches value
+            Nothing -> False
+  where
+    matches (Object fields) =
+        lookupText "name" fields == Just expectedName
+            && lookupText "description" fields == Just expectedDescription
+            && maybe False (> 0) (lookupInt "id" fields)
+            && KeyMap.size fields == 3
+    matches _ = False
+
+onlyTaskNamed :: Text -> HttpResponse -> Bool
+onlyTaskNamed expected response =
+    isJsonResponse response
+        && case decode response.responseBody of
+            Just (Array tasks) -> case toList tasks of
+                [Object fields] ->
+                    lookupText "name" fields == Just expected
+                        && lookupText "description" fields == Just "record tokens and time"
+                        && maybe False (> 0) (lookupInt "id" fields)
+                        && KeyMap.size fields == 3
+                _ -> False
+            _ -> False
+
+runnerOrder :: Int -> [Runner]
+runnerOrder trial
+    | odd trial = [AgentCli, Codex]
+    | otherwise = [Codex, AgentCli]
+
+runnerOffset :: Runner -> Int
+runnerOffset AgentCli = 1
+runnerOffset Codex = 2
+
+runnerSlug :: Runner -> String
+runnerSlug AgentCli = "agent-cli"
+runnerSlug Codex = "codex"
+
+collectVersions :: Config -> IO [(Text, Text)]
+collectVersions config = do
+    agentVersion <- commandVersion config.agentBin ["--version"]
+    codexVersion <- commandVersion config.codexBin ["--version"]
+    pure [("agent-cli", agentVersion), ("codex", codexVersion)]
+
+commandVersion :: FilePath -> [String] -> IO Text
+commandVersion executable args = do
+    result <- tryIO (readProcessWithExitCode executable args "")
+    pure $ case result of
+        Right (ExitSuccess, output, _) -> Text.strip (Text.pack output)
+        Right (_, _, err) -> "unavailable: " <> oneLine (Text.pack err)
+        Left err -> "unavailable: " <> Text.pack (show err)
+
+renderSummary :: Config -> [(Text, Text)] -> [RunResult] -> Text
+renderSummary config versions results =
+    Text.unlines
+        [ "# agent-cli vs Codex: Haskell todo application"
+        , ""
+        , "Both runners received the same task prompt, model, reasoning effort,"
+        , "empty Git workspace, auto-approval policy, and per-run timeout."
+        , "Wall time covers the coding-agent process only; deterministic grading"
+        , "runs afterward and is not included."
+        , ""
+        , "- Model: `" <> config.model <> "`"
+        , "- Reasoning effort: `" <> config.effort <> "`"
+        , "- Trials per runner: " <> Text.pack (show config.trials)
+        , "- Per-run timeout: " <> Text.pack (show config.timeoutSeconds) <> " seconds"
+        ]
+        <> Text.unlines
+            [ "- " <> name <> " version: `" <> version <> "`"
+            | (name, version) <- versions
+            ]
+        <> Text.unlines
+            [ ""
+            , renderConsoleSummary results
+            , ""
+            , "## Individual runs"
+            , ""
+            , "| trial | runner | pass | timeout | agent seconds | grade seconds | input | output | cached | grade |"
+            , "|---:|---|---:|---:|---:|---:|---:|---:|---:|---|"
+            ]
+        <> Text.unlines (map renderRunRow results)
+
+renderConsoleSummary :: [RunResult] -> Text
+renderConsoleSummary results =
+    Text.unlines $
+        [ "| runner | passed | median successful seconds | median successful input | median successful output | median successful cached |"
+        , "|---|---:|---:|---:|---:|---:|"
+        ]
+            <> map renderRunnerSummary [AgentCli, Codex]
+  where
+    renderRunnerSummary runner =
+        let selected = filter ((== runner) . (.resultRunner)) results
+            successful = filter (.resultPassed) selected
+        in Text.intercalate " | "
+            [ "| " <> Text.pack (runnerSlug runner)
+            , Text.pack (show (length successful) <> "/" <> show (length selected))
+            , optionalMedian (map (.resultSeconds) successful)
+            , optionalIntMedian (catMaybes (map (.resultInputTokens) successful))
+            , optionalIntMedian (catMaybes (map (.resultOutputTokens) successful))
+            , optionalIntMedian (catMaybes (map (.resultCachedTokens) successful)) <> " |"
+            ]
+
+renderRunRow :: RunResult -> Text
+renderRunRow result = Text.intercalate " | "
+    [ "| " <> Text.pack (show result.resultTrial)
+    , Text.pack (runnerSlug result.resultRunner)
+    , yesNo result.resultPassed
+    , yesNo result.resultTimedOut
+    , formatDouble result.resultSeconds
+    , formatDouble result.resultGradeSeconds
+    , maybe "n/a" (Text.pack . show) result.resultInputTokens
+    , maybe "n/a" (Text.pack . show) result.resultOutputTokens
+    , maybe "n/a" (Text.pack . show) result.resultCachedTokens
+    , Text.replace "|" "\\|" result.resultGrade <> " |"
+    ]
+
+yesNo :: Bool -> Text
+yesNo True = "yes"
+yesNo False = "no"
+
+optionalMedian :: [Double] -> Text
+optionalMedian [] = "n/a"
+optionalMedian values = formatDouble (median values)
+
+optionalIntMedian :: [Int] -> Text
+optionalIntMedian [] = "n/a"
+optionalIntMedian values =
+    Text.pack (show (round (median (map fromIntegral values)) :: Int))
+
+median :: [Double] -> Double
+median [] = 0
+median values =
+    let ordered = sort values
+        count = length ordered
+        middle = count `div` 2
+    in if odd count
+        then ordered !! middle
+        else (ordered !! (middle - 1) + ordered !! middle) / 2
+
+formatDouble :: Double -> Text
+formatDouble value =
+    let scaled = round (value * 100) :: Integer
+        (whole, fraction) = scaled `divMod` 100
+    in Text.pack (show whole <> "." <> if fraction < 10 then "0" <> show fraction else show fraction)
+
+exitCodeNumber :: ExitCode -> Int
+exitCodeNumber ExitSuccess = 0
+exitCodeNumber (ExitFailure code) = code
+
+oneLine :: Text -> Text
+oneLine = Text.unwords . Text.words
+
+sessionIdFromLog :: FilePath -> IO (Maybe Text)
+sessionIdFromLog path = do
+    exists <- doesFileExist path
+    if not exists
+        then pure Nothing
+        else do
+            contents <- Text.readFile path
+            pure $ case
+                [ Text.strip suffix
+                | line <- Text.lines contents
+                , let (_, suffixWithMarker) = Text.breakOn "session:" line
+                , not (Text.null suffixWithMarker)
+                , let suffix = Text.drop (Text.length ("session:" :: Text)) suffixWithMarker
+                , not (Text.null (Text.strip suffix))
+                ] of
+                identifier : _ -> Just identifier
+                [] -> Nothing
+
+prepareResultsDirectory :: FilePath -> IO ()
+prepareResultsDirectory path = do
+    exists <- doesDirectoryExist path
+    when exists do
+        entries <- listDirectory path
+        unless (null entries) do
+            hPutStrLn stderr $
+                "results directory is not empty: " <> path
+                    <> " (choose a fresh directory)"
+            exitFailure
+    createDirectoryIfMissing True path
+
+resetDirectory :: FilePath -> IO ()
+resetDirectory path = do
+    exists <- doesDirectoryExist path
+    when exists (removePathForcibly path)
+    createDirectoryIfMissing True path
+
+runProcessWithTimeout
+    :: Int
+    -> CreateProcess
+    -> FilePath
+    -> FilePath
+    -> IO ExitCode
+runProcessWithTimeout seconds processSpec stdoutPath stderrPath =
+    withFile stdoutPath WriteMode \stdoutHandle ->
+        withFile stderrPath WriteMode \stderrHandle ->
+            withCreateProcess
+                processSpec
+                    { std_in = NoStream
+                    , std_out = UseHandle stdoutHandle
+                    , std_err = UseHandle stderrHandle
+                    , create_group = True
+                    , new_session = True
+                    }
+                \_ _ _ processHandle -> do
+                    completed <- timeout
+                        (seconds * 1000000)
+                        (waitForProcess processHandle)
+                    case completed of
+                        Just code -> pure code
+                        Nothing -> stopProcessTree processHandle >> pure (ExitFailure 124)
+
+stopProcessTree :: ProcessHandle -> IO ()
+stopProcessTree processHandle = do
+    root <- getPid processHandle
+    processIds <- case root of
+        Nothing -> pure []
+        Just rootPid -> processTreeIds rootPid
+    signalProcesses processIds sigTERM
+    _ <- timeout 3000000 (waitForProcess processHandle)
+    signalProcesses processIds sigKILL
+    _ <- timeout 3000000 (waitForProcess processHandle)
+    pure ()
+
+signalProcesses :: [ProcessID] -> Signal -> IO ()
+signalProcesses processIds signal =
+    forM_ processIds \pid -> do
+        _ <- tryIO (signalProcess signal pid)
+        pure ()
+
+processTreeIds :: ProcessID -> IO [ProcessID]
+processTreeIds rootPid = do
+    listed <- tryIO (readProcess "ps" ["-axo", "pid=,ppid="] "")
+    pure $ case listed of
+        Left _ -> [rootPid]
+        Right output ->
+            let relationships =
+                    [ (pid, parentPid)
+                    | line <- lines output
+                    , [pidText, parentText] <- [words line]
+                    , [(pid, "")] <- [reads pidText]
+                    , [(parentPid, "")] <- [reads parentText]
+                    ]
+                descendants parent =
+                    concat
+                        [ descendants child <> [child]
+                        | (child, childParent) <- relationships
+                        , childParent == parent
+                        ]
+            in descendants rootPid <> [rootPid]
+
+copySessionArtifacts
+    :: FilePath
+    -> FilePath
+    -> FilePath
+    -> Text
+    -> IO ()
+copySessionArtifacts resultsRoot runName sessionsRootPath sessionId = do
+    let source = sessionsRootPath </> Text.unpack sessionId
+        destination = resultsRoot </> "sessions" </> runName
+    createDirectoryIfMissing True destination
+    forM_ ["meta.json", "transcript.jsonl"] \name -> do
+        let sourcePath = source </> name
+        exists <- doesFileExist sourcePath
+        when exists (copyFile sourcePath (destination </> name))
+
+(<|>) :: Maybe a -> Maybe a -> Maybe a
+Just value <|> _ = Just value
+Nothing <|> other = other
+
+toList :: Foldable f => f a -> [a]
+toList = foldr (:) []

--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -1790,50 +1790,52 @@ runAgentInitializedWithLock
             atomicModifyIORef' pendingNotices \xs ->
                 (xs <> [AgentMessage message], ())
             pure (Right "queued")
-        multiCtx = Just MultiAgentContext
-            { multiRegistry = registry
-            , multiSelfId = Nothing
-            , multiDepth = 0
-            , multiTaskPath = taskPathRoot
-            , multiRootTurnId = readIORef rootTurnRef
-            , multiResumeFromDisk = Just
-                (restoreAgentFromDisk
-                    provider
-                    inferredTarget.targetConnectionId
-                    transportModel
-                    inferredTarget.targetWireModelId
-                    dialectId
-                    legacySubagentTarget
-                    subagentStoreRoot
-                    registry
-                    subagentSessions
-                    agentTypesRef)
-            , multiCreateWorktree = Just \source ->
-                createWorktree source (worktreeRoot home) >>= \case
-                    Left err -> pure (Left err)
-                    Right path -> pure $ Right SubagentWorktree
-                        { subagentWorktreePath = path
-                        , subagentWorktreeCleanup =
-                            removeWorktree source path >>= \case
-                                Left err -> pure (Left err)
-                                Right () -> pure (Right ())
-                        }
-            , multiPrepareSpawn = Just
-                (prepareCollaborationSpawn
-                    provider
-                    inferredTarget.targetConnectionId
-                    transportModel
-                    inferredTarget.targetWireModelId
-                    dialectId
-                    legacySubagentTarget
-                    subagentSessions subagentStoreRoot agentTypesRef
-                    subagentForkSource)
-            , multiSendToRoot = Just sendToRoot
-            , multiSpawnModelGuidance =
-                subscriptionSubagentModelGuidance
-                    provider
-                    (tokenProviderBillingMode tokenProvider)
-            }
+        multiCtx
+            | not options.optSubagents = Nothing
+            | otherwise = Just MultiAgentContext
+                { multiRegistry = registry
+                , multiSelfId = Nothing
+                , multiDepth = 0
+                , multiTaskPath = taskPathRoot
+                , multiRootTurnId = readIORef rootTurnRef
+                , multiResumeFromDisk = Just
+                    (restoreAgentFromDisk
+                        provider
+                        inferredTarget.targetConnectionId
+                        transportModel
+                        inferredTarget.targetWireModelId
+                        dialectId
+                        legacySubagentTarget
+                        subagentStoreRoot
+                        registry
+                        subagentSessions
+                        agentTypesRef)
+                , multiCreateWorktree = Just \source ->
+                    createWorktree source (worktreeRoot home) >>= \case
+                        Left err -> pure (Left err)
+                        Right path -> pure $ Right SubagentWorktree
+                            { subagentWorktreePath = path
+                            , subagentWorktreeCleanup =
+                                removeWorktree source path >>= \case
+                                    Left err -> pure (Left err)
+                                    Right () -> pure (Right ())
+                            }
+                , multiPrepareSpawn = Just
+                    (prepareCollaborationSpawn
+                        provider
+                        inferredTarget.targetConnectionId
+                        transportModel
+                        inferredTarget.targetWireModelId
+                        dialectId
+                        legacySubagentTarget
+                        subagentSessions subagentStoreRoot agentTypesRef
+                        subagentForkSource)
+                , multiSendToRoot = Just sendToRoot
+                , multiSpawnModelGuidance =
+                    subscriptionSubagentModelGuidance
+                        provider
+                        (tokenProviderBillingMode tokenProvider)
+                }
     prompt <- loadPrompt options
     persist <-
         preparePersistence
@@ -1953,7 +1955,9 @@ runAgentInitializedWithLock
                 sessionProcessStatus sessionProcessManager
             }
         mcpTools = MCP.mcpFleetTools mcpFleet
-        sessionTools = agentSessionTools sessionToolsEnv
+        sessionTools
+            | options.optSubagents = agentSessionTools sessionToolsEnv
+            | otherwise = []
         allTools = coding.codingAppTools ++ mcpTools ++ sessionTools
         tools =
             filterGhciTools options.optGhci

--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -23,6 +23,14 @@ import Agent.CLI.AccountSelection
     , providerSupportsUsageAccountSelection
     , selectProviderAccount
     )
+import Agent.CLI.Rlm
+    ( RlmConfig(..)
+    , RlmMode(..)
+    , closeRlmRuntime
+    , newRlmRuntime
+    , rlmGhciHelpers
+    , rlmRootGuidance
+    )
 import Agent.CLI.Auth
     ( LoadedAuth(..)
     , authErrorNeedsOnboarding
@@ -297,15 +305,20 @@ import Agent.CLI.Terminal
     , resolveColor
     , withSynchronizedOutput
     )
-import Agent.CLI.Tools (requireToolRegistry, schemasFromAppTools)
+import Agent.CLI.Tools
+    ( requireToolRegistry
+    , schemasFromAppTools
+    , schemasFromAppToolsWithWeb
+    )
 import Agent.CLI.Dialects
     ( CodingTools(..)
-    , codingToolsForWithTypes
+    , codingToolsForWithTypesAndGhciHelpers
     , filterBashTools
     , filterGhciTools
     , formatAgentsMdForDialect
     , globalAgentsHomeDir
     , isBashToolName
+    , isGhciTool
     , isGhciToolName
     )
 import Agent.CLI.TUI.App
@@ -451,12 +464,17 @@ import Agent.Subagents
     , setSubagentOnSettled
     , setSubagentRunner
     )
-import Agent.GrokBuild.Dialect.Task (GrokSubagentSpecs)
+import Agent.GrokBuild.Dialect.Task
+    ( GrokSubagentSpec(..)
+    , GrokSubagentSpecs
+    , recordAgentSpec
+    )
 import Agent.Subagents.TaskPath (taskPathRoot, taskPathText)
 import Agent.TextBuffer (emptyTextBuffer)
 import Agent.ToolDispatch (ToolCall(..), canonicalToolName)
 import Agent.Tools.MultiAgents
-    ( MultiAgentContext(..)
+    ( CollaborationSpawnOptions(..)
+    , MultiAgentContext(..)
     , SubagentWorktree(..)
     )
 import Agent.Tools.PlanMode
@@ -1785,13 +1803,14 @@ runAgentInitializedWithLock
         (\_ _ _ _ -> pure $ Left LoopNoResponseId)
         (\_ _ -> pure ())
     rootTurnRef <- newIORef (Nothing :: Maybe RootTurnId)
+    subagentUsageRef <- newIORef Map.empty
     agentTypesRef <- newIORef Map.empty
     let sendToRoot message = do
             atomicModifyIORef' pendingNotices \xs ->
                 (xs <> [AgentMessage message], ())
             pure (Right "queued")
         multiCtx
-            | not options.optSubagents = Nothing
+            | not options.optSubagents && not options.optRlm = Nothing
             | otherwise = Just MultiAgentContext
                 { multiRegistry = registry
                 , multiSelfId = Nothing
@@ -1894,15 +1913,49 @@ runAgentInitializedWithLock
             Right fleet -> pure fleet
     mapM_ (reportStartupWarning startup) mcpFleet.mcpFleetWarnings
     setStartupNotice startup.startupFullscreen "Loading built-in tools…"
+    rlmRuntime <- case (options.optRlm, multiCtx) of
+        (True, Just ctx) -> do
+            let prepareWorker agentId mode = do
+                    forM_ ctx.multiPrepareSpawn \prepare ->
+                        prepare agentId CollaborationSpawnOptions
+                            { collaborationModel = options.optRlmModel
+                            , collaborationReasoningEffort = options.optRlmEffort
+                            , collaborationForkTurns = Just "none"
+                            }
+                    recordAgentSpec agentTypesRef agentId GrokSubagentSpec
+                        { agentType = case mode of
+                            RlmReadOnly -> "rlm_readonly"
+                            RlmCoding -> "rlm_coding"
+                        , modelOverride = options.optRlmModel
+                        , reasoningEffortOverride = options.optRlmEffort
+                        }
+                    pure mempty
+            Just <$> newRlmRuntime RlmConfig
+                { rlmMailbox = sessionTmp </> unsafeEncodeUtf "rlm"
+                , rlmContext = ctx
+                , rlmModel = options.optRlmModel
+                , rlmEffort = options.optRlmEffort
+                , rlmMaxCalls = options.optRlmMaxCalls
+                , rlmParallelism = options.optRlmParallelism
+                , rlmWorkerTimeoutSeconds =
+                    options.optRlmWorkerTimeoutSeconds
+                , rlmPrepareWorker = prepareWorker
+                }
+        _ -> pure Nothing
     coding <-
-        codingToolsForWithTypes
+        codingToolsForWithTypesAndGhciHelpers
             dialect
             toolEnv
             (Just planHooks)
             secretHooks
             multiCtx
             agentTypesRef
-            `onException` (MCP.closeMcpFleet mcpFleet >> cleanupScratch)
+            (maybe [] rlmGhciHelpers rlmRuntime)
+            `onException`
+                ( mapM_ closeRlmRuntime rlmRuntime
+                    >> MCP.closeMcpFleet mcpFleet
+                    >> cleanupScratch
+                )
     case multiCtx of
         Just ctx -> do
             setSubagentOnComplete ctx.multiRegistry \agentId status -> do
@@ -1956,20 +2009,28 @@ runAgentInitializedWithLock
             }
         mcpTools = MCP.mcpFleetTools mcpFleet
         sessionTools
-            | options.optSubagents = agentSessionTools sessionToolsEnv
+            | options.optSubagents && not options.optRlm =
+                agentSessionTools sessionToolsEnv
             | otherwise = []
-        allTools = coding.codingAppTools ++ mcpTools ++ sessionTools
+        allTools
+            | options.optRlm = filter isGhciTool coding.codingAppTools
+            | otherwise = coding.codingAppTools ++ mcpTools ++ sessionTools
         tools =
-            filterGhciTools options.optGhci
-                (filterBashTools options.optBash coding.codingAppTools)
-                ++ mcpTools
-                ++ sessionTools
+            if options.optRlm
+                then filter isGhciTool coding.codingAppTools
+                else
+                    filterGhciTools options.optGhci
+                        (filterBashTools
+                            options.optBash coding.codingAppTools)
+                        ++ mcpTools
+                        ++ sessionTools
         planMode = coding.codingPlanMode
         -- Keep planSessionDir and subagent store root in sync.
         noteSessionDir dir = do
             writeIORef planMode.planSessionDir (Just dir)
             writeIORef subagentStoreRoot (Just dir)
         closeAll = do
+            mapM_ closeRlmRuntime rlmRuntime
             case multiCtx of
                 Just ctx -> do
                     interruptActiveSubagents ctx.multiRegistry
@@ -2001,8 +2062,13 @@ runAgentInitializedWithLock
                     (Just sessionTmp)
                     today
                     (isOneShot options)
+                    <> if options.optRlm
+                        then "\n\n" <> rlmRootGuidance
+                        else ""
             params = requestParams model instructions
-                (schemasFromAppTools dialect tools) effort
+                (schemasFromAppToolsWithWeb
+                    (not options.optRlm) dialect tools)
+                effort
             initialItems = maybe [] (foldSessionItems . snd) resumed
             initialTurns = maybe [] snd resumed
             initialPrevious = case transition of
@@ -2032,6 +2098,12 @@ runAgentInitializedWithLock
                     subscriptionSubagentModelGuidance
                         provider
                         (tokenProviderBillingMode tokenProvider)
+                , subagentRecordUsage = \rootTurnId usage ->
+                    forM_ rootTurnId \owned ->
+                        atomicModifyIORef' subagentUsageRef \usages ->
+                            ( Map.insertWith addTokenUsage owned usage usages
+                            , ()
+                            )
                 }
         transcriptRef <- newIORef initialItems
         contextTokensRef <- newIORef Nothing
@@ -2352,7 +2424,7 @@ runAgentInitializedWithLock
                                     link switchWorker
                                     runSession catalog inferredTarget.targetConnectionId options provider dialect policy allTools ghciEnabledRef bashEnabledRef toolEnv planMode startup prompt pendingTurn unavailableProviders startupUnavailable paramsRef transcriptRef initialTurns
                                         previousRef persist projectRoot home cwd (Just tokenProvider) loaded.loadedOpenAiPool startupContext skillsRef skillInvocationsRef escPaused interrupt
-                                        multiCtx rootTurnRef subagentSessions pendingNotices subagentStoreRoot agentTypesRef legacySubagentTarget usageRef activeAccountRef activeAccountIdRef activeSelectionRef resolveActiveAccountLabel selectAccount claimCurrentSession compactRunner activeBackend btwBackend)
+                                        multiCtx rootTurnRef subagentUsageRef subagentSessions pendingNotices subagentStoreRoot agentTypesRef legacySubagentTarget usageRef activeAccountRef activeAccountIdRef activeSelectionRef resolveActiveAccountLabel selectAccount claimCurrentSession compactRunner activeBackend btwBackend)
                             >>= \case
                                 Left (CodexAuthFailed err) ->
                                     case transition of
@@ -2416,7 +2488,7 @@ runAgentInitializedWithLock
                                 projectRoot transition persist backend
                         runSession catalog inferredTarget.targetConnectionId options provider dialect policy allTools ghciEnabledRef bashEnabledRef toolEnv planMode startup prompt pendingTurn unavailableProviders startupUnavailable paramsRef transcriptRef initialTurns
                             previousRef persist projectRoot home cwd (Just tokenProvider) loaded.loadedOpenAiPool startupContext skillsRef skillInvocationsRef escPaused interrupt
-                            multiCtx rootTurnRef subagentSessions pendingNotices subagentStoreRoot agentTypesRef legacySubagentTarget usageRef activeAccountRef activeAccountIdRef activeSelectionRef resolveActiveAccountLabel (if isJust customGenericOptions then Nothing else Just selectHttpAccount) claimCurrentSession compactRunner activeBackend btwBackend
+                            multiCtx rootTurnRef subagentUsageRef subagentSessions pendingNotices subagentStoreRoot agentTypesRef legacySubagentTarget usageRef activeAccountRef activeAccountIdRef activeSelectionRef resolveActiveAccountLabel (if isJust customGenericOptions then Nothing else Just selectHttpAccount) claimCurrentSession compactRunner activeBackend btwBackend
                     ClaudeCodeProvider -> do
                         claudeAuth <-
                             loadClaudeCodeAuth
@@ -2477,7 +2549,7 @@ runAgentInitializedWithLock
                                         projectRoot transition persist backend
                                 runSession catalog inferredTarget.targetConnectionId options provider dialect policy allTools ghciEnabledRef bashEnabledRef toolEnv planMode startup prompt pendingTurn unavailableProviders startupUnavailable paramsRef transcriptRef initialTurns
                                     previousRef persist projectRoot home cwd Nothing Nothing startupContext skillsRef skillInvocationsRef escPaused interrupt
-                                    multiCtx rootTurnRef subagentSessions pendingNotices subagentStoreRoot agentTypesRef legacySubagentTarget usageRef activeAccountRef activeAccountIdRef activeSelectionRef resolveActiveAccountLabel Nothing claimCurrentSession compactRunner activeBackend btwBackend
+                                    multiCtx rootTurnRef subagentUsageRef subagentSessions pendingNotices subagentStoreRoot agentTypesRef legacySubagentTarget usageRef activeAccountRef activeAccountIdRef activeSelectionRef resolveActiveAccountLabel Nothing claimCurrentSession compactRunner activeBackend btwBackend
                     OpenRouterProvider -> do
                         let makeBackend params =
                                 case customGenericOptions of
@@ -2549,7 +2621,7 @@ runAgentInitializedWithLock
                                 projectRoot transition persist backend
                         runSession catalog inferredTarget.targetConnectionId options provider dialect policy allTools ghciEnabledRef bashEnabledRef toolEnv planMode startup prompt pendingTurn unavailableProviders startupUnavailable paramsRef transcriptRef initialTurns
                             previousRef persist projectRoot home cwd (Just tokenProvider) loaded.loadedOpenAiPool startupContext skillsRef skillInvocationsRef escPaused interrupt
-                            multiCtx rootTurnRef subagentSessions pendingNotices subagentStoreRoot agentTypesRef legacySubagentTarget usageRef activeAccountRef activeAccountIdRef activeSelectionRef resolveActiveAccountLabel (Just selectHttpAccount) claimCurrentSession compactRunner activeBackend btwBackend
+                            multiCtx rootTurnRef subagentUsageRef subagentSessions pendingNotices subagentStoreRoot agentTypesRef legacySubagentTarget usageRef activeAccountRef activeAccountIdRef activeSelectionRef resolveActiveAccountLabel (Just selectHttpAccount) claimCurrentSession compactRunner activeBackend btwBackend
           where
             startupFailure err = do
                 now <- getCurrentTime
@@ -2764,6 +2836,7 @@ runSession
     -> InterruptState
     -> Maybe MultiAgentContext
     -> IORef (Maybe RootTurnId)
+    -> IORef (Map RootTurnId TokenUsage)
     -> IORef (Map SubagentId SubagentSession)
     -> IORef [TurnInput]
     -> SubagentStoreRoot
@@ -2780,7 +2853,7 @@ runSession
     -> Backend
     -> BtwBackendFactory
     -> IO RunResult
-runSession catalog connectionId options provider dialect policy allTools ghciEnabledRef bashEnabledRef toolEnv planMode startup prompt pendingTurn unavailableProviders startupUnavailable paramsRef transcriptRef initialTurns previous persist projectRoot home cwd tokenProvider openAiPool startupContext skillsRef skillInvocationsRef escPaused interrupt multiCtx rootTurnRef subagentSessions pendingNotices storeRoot agentTypes legacyTarget usageRef accountRef accountIdRef selectionRef accountLabel selectAccount onPersisted compactRunner backend btwBackend = do
+runSession catalog connectionId options provider dialect policy allTools ghciEnabledRef bashEnabledRef toolEnv planMode startup prompt pendingTurn unavailableProviders startupUnavailable paramsRef transcriptRef initialTurns previous persist projectRoot home cwd tokenProvider openAiPool startupContext skillsRef skillInvocationsRef escPaused interrupt multiCtx rootTurnRef subagentUsageRef subagentSessions pendingNotices storeRoot agentTypes legacyTarget usageRef accountRef accountIdRef selectionRef accountLabel selectAccount onPersisted compactRunner backend btwBackend = do
   initialPrevious <- readIORef previous
   ioLock <- newMVar ()
   let fullscreen = startup.startupFullscreen
@@ -3195,6 +3268,12 @@ runSession catalog connectionId options provider dialect policy allTools ghciEna
                     Nothing -> pure ()
                 Nothing -> pure ()
             finishSubagentTurn rootTurnId
+        drainSubagentUsage rootTurnId = case rootTurnId of
+            Nothing -> pure emptyTokenUsage
+            Just owned ->
+                atomicModifyIORef' subagentUsageRef \usages ->
+                    let usage = Map.findWithDefault emptyTokenUsage owned usages
+                    in (Map.delete owned usages, usage)
         activeShellTools ghciEnabled bashEnabled =
             filterGhciTools ghciEnabled
                 (filterBashTools bashEnabled allTools)
@@ -3299,6 +3378,7 @@ runSession catalog connectionId options provider dialect policy allTools ghciEna
             , sessionBeginSubagentTurn = beginSubagentTurn
             , sessionFinishSubagentTurn = finishSubagentTurn
             , sessionAbortSubagentTurn = abortSubagentTurn
+            , sessionDrainSubagentUsage = drainSubagentUsage
             , sessionOnPersisted = onPersisted
             , sessionReset = sessionReset
             }

--- a/packages/agent-cli/src/Agent/CLI/Dialects.hs
+++ b/packages/agent-cli/src/Agent/CLI/Dialects.hs
@@ -2,9 +2,11 @@ module Agent.CLI.Dialects
     ( CodingTools(..)
     , codingToolsFor
     , codingToolsForWithTypes
+    , codingToolsForWithTypesAndGhciHelpers
     , filterBashTools
     , filterChildGrokTools
     , filterGhciTools
+    , filterReadOnlyTools
     , isBashTool
     , isBashToolName
     , isGhciTool
@@ -17,6 +19,7 @@ import Agent.Codex.Dialect.ProjectInstructions (formatCodexAgentsMd)
 import Agent.Codex.Dialect.Runtime
     ( CodexCodingTools(..)
     , newCodexCodingTools
+    , newCodexCodingToolsWithGhciHelpers
     )
 import Agent.Dialect
     ( Dialect
@@ -31,6 +34,7 @@ import Agent.GrokBuild.Dialect.ProjectInstructions (formatGrokAgentsMd)
 import Agent.GrokBuild.Dialect.Runtime
     ( GrokCodingTools(..)
     , newGrokCodingTools
+    , newGrokCodingToolsWithGhciHelpers
     )
 import Agent.GrokBuild.Dialect.Task
     ( GrokSubagentSpecs
@@ -49,7 +53,7 @@ import Agent.Tools.Secret
     , closeSecretStore
     , newSecretStore
     )
-import Agent.Tools.Types (AppTool(..), ToolEnv(..))
+import Agent.Tools.Types (AppTool(..), ApprovalRule(..), ToolEnv(..))
 import Control.Exception.Safe (finally, onException)
 import Data.IORef (newIORef)
 import qualified Data.Map.Strict as Map
@@ -85,6 +89,20 @@ codingToolsForWithTypes
     -> IO CodingTools
 codingToolsForWithTypes
         dialect env planHooks secretHooks multi typesRef = do
+    codingToolsForWithTypesAndGhciHelpers
+        dialect env planHooks secretHooks multi typesRef []
+
+codingToolsForWithTypesAndGhciHelpers
+    :: Dialect
+    -> ToolEnv
+    -> Maybe PlanModeHooks
+    -> Maybe SecretPromptHooks
+    -> Maybe MultiAgentContext
+    -> GrokSubagentSpecs
+    -> [Text]
+    -> IO CodingTools
+codingToolsForWithTypesAndGhciHelpers
+        dialect env planHooks secretHooks multi typesRef ghciHelpers = do
     secretStore <- traverse (newSecretStore env) secretHooks
     let closeSecrets = mapM_ closeSecretStore secretStore
         secretTools = maybe [] (pure . askSecretTool) secretStore
@@ -97,7 +115,11 @@ codingToolsForWithTypes
                 }
     flip onException closeSecrets $ case dialectToolSurface dialect of
         CodexToolSurface -> do
-            coding <- newCodexCodingTools env planHooks multi
+            coding <-
+                if null ghciHelpers
+                    then newCodexCodingTools env planHooks multi
+                    else newCodexCodingToolsWithGhciHelpers
+                        env planHooks multi ghciHelpers
             pure $
                 finish
                     coding.codexAppTools
@@ -105,7 +127,11 @@ codingToolsForWithTypes
                     coding.codexClose
                     typesRef
         GrokBuildToolSurface -> do
-            coding <- newGrokCodingTools env planHooks multi typesRef
+            coding <-
+                if null ghciHelpers
+                    then newGrokCodingTools env planHooks multi typesRef
+                    else newGrokCodingToolsWithGhciHelpers
+                        env planHooks multi typesRef ghciHelpers
             pure $
                 finish
                     coding.grokAppTools
@@ -131,6 +157,12 @@ filterBashTools False = filter (not . isBashTool)
 filterGhciTools :: Bool -> [AppTool] -> [AppTool]
 filterGhciTools True = id
 filterGhciTools False = filter (not . isGhciTool)
+
+filterReadOnlyTools :: [AppTool] -> [AppTool]
+filterReadOnlyTools = filter \tool -> case tool.appToolApproval of
+    AlwaysReadOnly -> True
+    ClassifyReadOnly _ -> False
+    AlwaysPrompt -> False
 
 isBashTool :: AppTool -> Bool
 isBashTool = isBashToolName . (.appToolName)

--- a/packages/agent-cli/src/Agent/CLI/Options.hs
+++ b/packages/agent-cli/src/Agent/CLI/Options.hs
@@ -87,6 +87,14 @@ data CliOptions = CliOptions
       -- ^ Expose the provider's explicit shell execution tool (default: False).
     , optSubagents :: !Bool
       -- ^ Expose collaboration and subagent tools (default: True).
+    , optRlm :: !Bool
+      -- ^ Use the experimental recursive-language-model orchestrator.
+    , optRlmModel :: !(Maybe Text)
+    , optRlmEffort :: !(Maybe Text)
+    , optRlmMaxCalls :: !Int
+    , optRlmParallelism :: !Int
+    , optRlmWorkerMaxTurns :: !Int
+    , optRlmWorkerTimeoutSeconds :: !Int
     , optScreenMode :: !ScreenMode
     , optMotionMode :: !MotionMode
     } deriving (Eq, Show)
@@ -111,6 +119,13 @@ defaultCliOptions = CliOptions
     , optGhci = True
     , optBash = False
     , optSubagents = True
+    , optRlm = False
+    , optRlmModel = Nothing
+    , optRlmEffort = Nothing
+    , optRlmMaxCalls = 8
+    , optRlmParallelism = 4
+    , optRlmWorkerMaxTurns = 50
+    , optRlmWorkerTimeoutSeconds = 600
     , optScreenMode = ScreenAuto
     , optMotionMode = MotionFull
     }
@@ -222,6 +237,27 @@ parseOptions options = \case
         parseOptions options { optSubagents = True } rest
     "--no-subagents" : rest ->
         parseOptions options { optSubagents = False } rest
+    "--rlm" : rest ->
+        parseOptions options { optRlm = True } rest
+    "--no-rlm" : rest ->
+        parseOptions options { optRlm = False } rest
+    "--rlm-model" : value : rest ->
+        parseOptions options { optRlmModel = Just (Text.pack value) } rest
+    "--rlm-effort" : value : rest -> do
+        effort <- parseEffort (Text.pack value)
+        parseOptions options { optRlmEffort = Just effort } rest
+    "--rlm-max-calls" : value : rest -> do
+        count <- parsePositiveInt "--rlm-max-calls" value
+        parseOptions options { optRlmMaxCalls = count } rest
+    "--rlm-parallelism" : value : rest -> do
+        count <- parsePositiveInt "--rlm-parallelism" value
+        parseOptions options { optRlmParallelism = count } rest
+    "--rlm-worker-max-turns" : value : rest -> do
+        count <- parsePositiveInt "--rlm-worker-max-turns" value
+        parseOptions options { optRlmWorkerMaxTurns = count } rest
+    "--rlm-worker-timeout-seconds" : value : rest -> do
+        seconds <- parsePositiveInt "--rlm-worker-timeout-seconds" value
+        parseOptions options { optRlmWorkerTimeoutSeconds = seconds } rest
     "--fullscreen" : rest ->
         parseOptions options { optScreenMode = ScreenFullscreen } rest
     "--minimal" : rest ->
@@ -243,6 +279,8 @@ validate options
         Left "use either -p/--prompt or --prompt-file, not both"
     | options.optMaxTurns < 1 =
         Left "--max-turns must be at least 1"
+    | options.optRlm && not options.optGhci =
+        Left "--rlm requires GHCi; remove --no-ghci"
     | isJust options.optResume && options.optWorktree =
         Left "use either --resume or --worktree, not both"
     | otherwise = Right options
@@ -251,6 +289,9 @@ parseInt :: String -> String -> Either String Int
 parseInt flag value = case reads value of
     [(n, "")] | n >= 1 -> Right n
     _ -> Left (flag <> " expects a positive integer, got " <> value)
+
+parsePositiveInt :: String -> String -> Either String Int
+parsePositiveInt = parseInt
 
 parseMotionMode :: String -> Either String MotionMode
 parseMotionMode raw = case Text.toLower (Text.pack raw) of
@@ -299,6 +340,16 @@ usage = unlines
     , "      --no-bash           Disable explicit shell execution tools (default)"
     , "      --subagents         Enable collaboration/subagent tools (default)"
     , "      --no-subagents      Disable collaboration/subagent tools"
+    , "      --rlm               Enable experimental in-process RLM mode"
+    , "      --no-rlm            Disable experimental RLM mode (default)"
+    , "      --rlm-model MODEL   Model override for RLM workers"
+    , "      --rlm-effort LEVEL  Reasoning effort override for RLM workers"
+    , "      --rlm-max-calls N   Maximum RLM worker calls (default: 8)"
+    , "      --rlm-parallelism N Maximum parallel read-only workers (default: 4)"
+    , "      --rlm-worker-max-turns N"
+    , "                          Maximum turns per RLM worker (default: 50)"
+    , "      --rlm-worker-timeout-seconds N"
+    , "                          Timeout per RLM worker (default: 600)"
     , "      --fullscreen        Use the retained full-screen TUI"
     , "      --minimal           Use terminal-native append-only rendering"
     , "      --motion MODE       Animation policy: full, reduced, or off"

--- a/packages/agent-cli/src/Agent/CLI/Options.hs
+++ b/packages/agent-cli/src/Agent/CLI/Options.hs
@@ -85,6 +85,8 @@ data CliOptions = CliOptions
       -- ^ Expose the persistent run_ghci tool (default: True).
     , optBash :: !Bool
       -- ^ Expose the provider's explicit shell execution tool (default: False).
+    , optSubagents :: !Bool
+      -- ^ Expose collaboration and subagent tools (default: True).
     , optScreenMode :: !ScreenMode
     , optMotionMode :: !MotionMode
     } deriving (Eq, Show)
@@ -108,6 +110,7 @@ defaultCliOptions = CliOptions
     , optSkills = True
     , optGhci = True
     , optBash = False
+    , optSubagents = True
     , optScreenMode = ScreenAuto
     , optMotionMode = MotionFull
     }
@@ -215,6 +218,10 @@ parseOptions options = \case
         parseOptions options { optBash = True } rest
     "--no-bash" : rest ->
         parseOptions options { optBash = False } rest
+    "--subagents" : rest ->
+        parseOptions options { optSubagents = True } rest
+    "--no-subagents" : rest ->
+        parseOptions options { optSubagents = False } rest
     "--fullscreen" : rest ->
         parseOptions options { optScreenMode = ScreenFullscreen } rest
     "--minimal" : rest ->
@@ -290,6 +297,8 @@ usage = unlines
     , "      --no-ghci           Disable the persistent GHCi tool"
     , "      --bash              Enable explicit shell execution tools"
     , "      --no-bash           Disable explicit shell execution tools (default)"
+    , "      --subagents         Enable collaboration/subagent tools (default)"
+    , "      --no-subagents      Disable collaboration/subagent tools"
     , "      --fullscreen        Use the retained full-screen TUI"
     , "      --minimal           Use terminal-native append-only rendering"
     , "      --motion MODE       Animation policy: full, reduced, or off"

--- a/packages/agent-cli/src/Agent/CLI/Rlm.hs
+++ b/packages/agent-cli/src/Agent/CLI/Rlm.hs
@@ -1,0 +1,320 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+-- | Small mailbox bridge used by the experimental recursive-language-model
+-- mode.  The GHCi process is only a coordinator: every request is dispatched
+-- to the normal in-process 'SubagentRegistry' runner.
+module Agent.CLI.Rlm
+    ( RlmMode(..)
+    , RlmConfig(..)
+    , RlmRuntime
+    , newRlmRuntime
+    , closeRlmRuntime
+    , rlmGhciHelpers
+    , rlmRootGuidance
+    ) where
+
+import Agent.InterAgentMessage (plainInterAgentContent)
+import Agent.Loop (LoopResult(..), TokenUsage(..))
+import Agent.Subagents
+    ( RootTurnId
+    , SubagentId(..)
+    , SubagentLease
+    , SubagentStatus(..)
+    , getLastResult
+    , getStatus
+    , interruptSubagent
+    , spawnSubagentAtPreparedForTurn
+    , waitSubagentsFrom
+    )
+import Agent.Subagents.TaskPath (taskPathRoot)
+import Agent.Tools.MultiAgents (MultiAgentContext(..))
+import Agent.OsPath (unsafeToFilePath)
+import Control.Concurrent
+    ( QSem
+    , MVar
+    , newMVar
+    , newQSem
+    , readMVar
+    , threadDelay
+    , waitQSem
+    , signalQSem
+    )
+import Control.Concurrent.Async (Async, async, cancel, waitCatch)
+import Control.Concurrent.MVar (modifyMVar, withMVar)
+import Control.Exception.Safe (finally, tryAny)
+import Control.Monad (forM_, forever, void, when)
+import Data.Aeson (Value, encode, object, (.=))
+import qualified Data.ByteString.Lazy as LazyByteString
+import Data.IORef (IORef, atomicModifyIORef', newIORef, readIORef)
+import Data.List (isSuffixOf)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as TextEncoding
+import System.Directory
+    ( createDirectoryIfMissing
+    , doesFileExist
+    , listDirectory
+    , removeFile
+    , renameFile
+    )
+import System.FilePath ((</>), dropExtension)
+import System.OsPath (OsPath)
+
+data RlmMode = RlmReadOnly | RlmCoding
+    deriving (Eq, Show)
+
+data RlmConfig = RlmConfig
+    { rlmMailbox :: !OsPath
+    , rlmContext :: !MultiAgentContext
+    , rlmModel :: !(Maybe Text)
+    , rlmEffort :: !(Maybe Text)
+    , rlmMaxCalls :: !Int
+    , rlmParallelism :: !Int
+    , rlmWorkerTimeoutSeconds :: !Int
+    , rlmPrepareWorker :: !(SubagentId -> RlmMode -> IO SubagentLease)
+    }
+
+data RlmRuntime = RlmRuntime
+    { rlmConfig :: !RlmConfig
+    , rlmWatcher :: Async ()
+    , rlmWorkers :: !(IORef [Async ()])
+    , rlmSemaphore :: !QSem
+    , rlmCodingLock :: !(MVar ())
+    , rlmBudget :: !(MVar (Maybe RootTurnId, Int))
+    , rlmCounter :: !(IORef Int)
+    , rlmClosed :: !(MVar Bool)
+    }
+
+newRlmRuntime :: RlmConfig -> IO RlmRuntime
+newRlmRuntime config = do
+    let mailbox = unsafeToFilePath config.rlmMailbox
+    createDirectoryIfMissing True mailbox
+    workers <- newIORef []
+    semaphore <- newQSem (max 1 config.rlmParallelism)
+    codingLock <- newMVar ()
+    budget <- newMVar (Nothing, 0)
+    counter <- newIORef 0
+    closed <- newMVar False
+    let runtime0 = RlmRuntime
+            { rlmConfig = config
+            , rlmWatcher = error "rlm watcher not initialized"
+            , rlmWorkers = workers
+            , rlmSemaphore = semaphore
+            , rlmCodingLock = codingLock
+            , rlmBudget = budget
+            , rlmCounter = counter
+            , rlmClosed = closed
+            }
+    watcher <- async (watchMailbox runtime0)
+    pure runtime0 { rlmWatcher = watcher }
+
+closeRlmRuntime :: RlmRuntime -> IO ()
+closeRlmRuntime runtime = do
+    shouldClose <- modifyMVar runtime.rlmClosed \closed ->
+        pure (True, not closed)
+    when shouldClose $ do
+        cancel runtime.rlmWatcher
+        _ <- waitCatch runtime.rlmWatcher
+        workers <- readIORef runtime.rlmWorkers
+        mapM_ cancel workers
+        mapM_ waitCatch workers
+
+-- | Startup statements installed in the persistent GHCi session.
+rlmGhciHelpers :: RlmRuntime -> [Text]
+rlmGhciHelpers runtime =
+    let mailbox = Text.pack (show (unsafeToFilePath runtime.rlmConfig.rlmMailbox))
+        poll =
+            "let rlmAwait = \\(_,resp) -> do { e <- AgentRlmDir.doesFileExist resp; "
+                <> "if e then do { x <- AgentRlmIO.readFile resp; AgentRlmDir.removeFile resp; "
+                <> "pure x } else AgentRlmConcurrent.threadDelay 50000 >> rlmAwait (\"\",resp) }"
+        start =
+            "let rlmStart = \\mode prompt -> do { (p,h) <- AgentRlmIO.openTempFile "
+                <> mailbox
+                <> " \"rlm-\"; AgentRlmIO.hPutStr h (mode ++ \"\\n\" ++ prompt); "
+                <> "AgentRlmIO.hClose h; let req = p ++ \".req\" in AgentRlmDir.renameFile p req; "
+                <> "pure (req, AgentRlmPath.dropExtension req ++ \".resp\") }"
+        query =
+            "let rlmQuery = \\prompt -> rlmStart \"readonly\" prompt >>= rlmAwait; "
+                <> "rlmCode = \\prompt -> rlmStart \"coding\" prompt >>= rlmAwait; "
+                <> "rlmQueryMany = \\prompts -> mapM (rlmStart \"readonly\") prompts >>= mapM rlmAwait"
+    in
+        [ "import qualified System.IO as AgentRlmIO"
+        , "import qualified System.Directory as AgentRlmDir"
+        , "import qualified Control.Concurrent as AgentRlmConcurrent"
+        , "import qualified System.FilePath as AgentRlmPath"
+        , start
+        , poll
+        , query
+        ]
+
+rlmRootGuidance :: Text
+rlmRootGuidance =
+    "RLM mode is active. You have only run_ghci. Use rlmQuery for independent "
+        <> "read-only investigations and rlmCode for focused implementation tasks. "
+        <> "Use rlmQueryMany to submit independent investigations together. Workers "
+        <> "are in-process subagents; synthesize their structured results and do not "
+        <> "assume that a request succeeded unless its status is completed."
+
+watchMailbox :: RlmRuntime -> IO ()
+watchMailbox runtime =
+    (`finally` pure ()) $ forever do
+        closed <- readMVar runtime.rlmClosed
+        if closed
+            then pure ()
+            else do
+                files <- tryAny (listDirectory (unsafeToFilePath runtime.rlmConfig.rlmMailbox))
+                case files of
+                    Right names ->
+                        forM_ (filter (".req" `isSuffixOf`) names) \name -> do
+                            let mailbox = unsafeToFilePath runtime.rlmConfig.rlmMailbox
+                                source = mailbox </> name
+                                claimed = dropExtension source <> ".work"
+                            claimedOk <- tryAny (renameFile source claimed)
+                            case claimedOk of
+                                Right () -> do
+                                    worker <- async (handleRequest runtime claimed)
+                                    atomicModifyIORef' runtime.rlmWorkers
+                                        (\xs -> (worker : xs, ()))
+                                Left _ -> pure ()
+                    Left _ -> pure ()
+                threadDelay 50000
+
+handleRequest :: RlmRuntime -> FilePath -> IO ()
+handleRequest runtime requestPath =
+    (`finally` removeIfExists requestPath) do
+        contents <- readFile requestPath
+        let (modeLine, promptLines) = case lines contents of
+                [] -> ("readonly", [])
+                first : rest -> (first, rest)
+            mode = if modeLine == "coding" then RlmCoding else RlmReadOnly
+            responsePath = dropExtension requestPath <> ".resp"
+        response <- withBudget runtime mode \rootTurnId ->
+            withPermit runtime mode $
+                dispatchRequest runtime rootTurnId mode (Text.pack (unlines promptLines))
+        writeFile responsePath (Text.unpack response.responsePayload)
+
+withBudget
+    :: RlmRuntime
+    -> RlmMode
+    -> (RootTurnId -> IO RlmResponse)
+    -> IO RlmResponse
+withBudget runtime _mode action =
+    case runtime.rlmConfig.rlmContext of
+        ctx -> do
+            rootTurn <- ctx.multiRootTurnId
+            case rootTurn of
+                Nothing -> pure (errorResponse "no active root turn")
+                Just turnId -> do
+                    allowed <- modifyBudget runtime turnId
+                    if not allowed
+                        then pure (errorResponse "RLM call budget exhausted")
+                        else action turnId
+
+modifyBudget :: RlmRuntime -> RootTurnId -> IO Bool
+modifyBudget runtime turnId =
+    modifyMVar runtime.rlmBudget \state@(current, used) ->
+        if current == Just turnId
+            then
+                let limit = max 1 runtime.rlmConfig.rlmMaxCalls
+                in if used >= limit
+                    then pure (state, False)
+                    else pure ((current, used + 1), True)
+            else pure ((Just turnId, 1), True)
+
+withPermit :: RlmRuntime -> RlmMode -> IO a -> IO a
+withPermit runtime mode action =
+    bracketQSem runtime.rlmSemaphore $
+        if mode == RlmCoding
+            then withMVar runtime.rlmCodingLock (const action)
+            else action
+
+dispatchRequest :: RlmRuntime -> RootTurnId -> RlmMode -> Text -> IO RlmResponse
+dispatchRequest runtime rootTurn mode prompt = do
+    n <- atomicModifyIORef' runtime.rlmCounter (\x -> (x + 1, x + 1))
+    let taskName = Text.pack ("rlm_" <> show n)
+    spawned <-
+        spawnSubagentAtPreparedForTurn
+            (let MultiAgentContext { multiRegistry = registry } =
+                    runtime.rlmConfig.rlmContext
+             in registry)
+            (Just rootTurn)
+            (\agentId -> runtime.rlmConfig.rlmPrepareWorker agentId mode)
+            Nothing
+            taskPathRoot
+            0
+            taskName
+            (plainInterAgentContent prompt)
+            Nothing
+    case spawned of
+        Left err -> pure (errorResponse err)
+        Right (agentId, _) -> do
+            let MultiAgentContext { multiRegistry = registry } =
+                    runtime.rlmConfig.rlmContext
+            (_, timedOut) <-
+                waitSubagentsFrom
+                    registry
+                    Nothing
+                    [agentId]
+                    (max 1 runtime.rlmConfig.rlmWorkerTimeoutSeconds * 1000)
+            status <- getStatus registry agentId
+            result <- getLastResult registry agentId
+            when timedOut (void (interruptSubagent registry agentId))
+            pure (responseFor agentId status timedOut result)
+
+data RlmResponse = RlmResponse
+    { responsePayload :: !Text
+    }
+
+responseFor :: SubagentId -> SubagentStatus -> Bool -> Maybe LoopResult -> RlmResponse
+responseFor agentId status timedOut result =
+    let SubagentId agentName = agentId
+        statusText :: Text
+        statusText
+            | timedOut = "timeout"
+            | otherwise = case status of
+                Pending -> "pending"
+                Running -> "running"
+                Completed _ -> "completed"
+                Errored _ -> "error"
+                Interrupted -> "interrupted"
+                Closed -> "closed"
+                NotFound -> "not_found"
+        value = object
+            [ "status" .= statusText
+            , "agent_id" .= agentName
+            , "result" .= maybe (Nothing :: Maybe Text) (.finalText) result
+            , "turns_used" .= maybe 0 (.turnsUsed) result
+            , "usage" .= maybe
+                (object ["input" .= (0 :: Int), "output" .= (0 :: Int), "cached" .= (0 :: Int)])
+                (usageValue . (.tokenUsage))
+                result
+            ]
+    in RlmResponse (decodeUtf8Lazy (encode value))
+
+usageValue :: TokenUsage -> Value
+usageValue usage = object
+    [ "input" .= usage.inputTokens
+    , "output" .= usage.outputTokens
+    , "cached" .= usage.cachedTokens
+    ]
+
+errorResponse :: Text -> RlmResponse
+errorResponse message =
+    RlmResponse (decodeUtf8Lazy (encode (object
+        [ "status" .= ("error" :: Text)
+        , "error" .= message
+        ])))
+
+decodeUtf8Lazy :: LazyByteString.ByteString -> Text
+decodeUtf8Lazy = TextEncoding.decodeUtf8 . LazyByteString.toStrict
+
+bracketQSem :: QSem -> IO a -> IO a
+bracketQSem sem action = do
+    waitQSem sem
+    action `finally` signalQSem sem
+
+removeIfExists :: FilePath -> IO ()
+removeIfExists path = do
+    exists <- doesFileExist path
+    when exists (void (tryAny (removeFile path)))
+

--- a/packages/agent-cli/src/Agent/CLI/Rlm.hs
+++ b/packages/agent-cli/src/Agent/CLI/Rlm.hs
@@ -131,8 +131,8 @@ rlmGhciHelpers runtime =
             "let rlmStart = \\mode prompt -> do { (p,h) <- AgentRlmIO.openTempFile "
                 <> mailbox
                 <> " \"rlm-\"; AgentRlmIO.hPutStr h (mode ++ \"\\n\" ++ prompt); "
-                <> "AgentRlmIO.hClose h; let req = p ++ \".req\" in AgentRlmDir.renameFile p req; "
-                <> "pure (req, AgentRlmPath.dropExtension req ++ \".resp\") }"
+                <> "AgentRlmIO.hClose h; AgentRlmDir.renameFile p (p ++ \".req\"); "
+                <> "pure (p ++ \".req\", p ++ \".resp\") }"
         query =
             "let rlmQuery = \\prompt -> rlmStart \"readonly\" prompt >>= rlmAwait; "
                 <> "rlmCode = \\prompt -> rlmStart \"coding\" prompt >>= rlmAwait; "

--- a/packages/agent-cli/src/Agent/CLI/SessionEnv.hs
+++ b/packages/agent-cli/src/Agent/CLI/SessionEnv.hs
@@ -83,6 +83,7 @@ data SessionEnv = SessionEnv
     , sessionBeginSubagentTurn :: !(IO (Maybe RootTurnId))
     , sessionFinishSubagentTurn :: !(Maybe RootTurnId -> IO ())
     , sessionAbortSubagentTurn :: !(Maybe RootTurnId -> IO ())
+    , sessionDrainSubagentUsage :: !(Maybe RootTurnId -> IO TokenUsage)
     , sessionOnPersisted :: !(SessionHandle -> IO ())
     , sessionReset :: !(IO ())
     }

--- a/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
@@ -49,6 +49,7 @@ import Agent.CLI.Dialects
     , filterBashTools
     , filterChildGrokTools
     , filterGhciTools
+    , filterReadOnlyTools
     )
 import Agent.Codex.Dialect.Subagent (codexSubagentSuffix)
 import Agent.Dialect
@@ -74,6 +75,7 @@ import Agent.Loop
     , LoopError(..)
     , LoopEvent
     , LoopResult(..)
+    , TokenUsage
     , TurnInput(..)
     , defaultLoopDispatch
     , runLoop
@@ -97,6 +99,7 @@ import Agent.Subagents
     ( RunSubagent
     , SubagentId(..)
     , SubagentRegistry
+    , RootTurnId
     , SubagentSpawnEnv(..)
     , SubagentStatus(..)
     , getPreviousResponseId
@@ -190,6 +193,7 @@ data SubagentRuntime = SubagentRuntime
     , subagentConnection :: !Text
     , subagentMapModel :: !(Text -> Text)
     , subagentSpawnModelGuidance :: !(Maybe Text)
+    , subagentRecordUsage :: !(Maybe RootTurnId -> TokenUsage -> IO ())
     }
 
 data PreparedChild = PreparedChild
@@ -555,6 +559,9 @@ runCodexSubagent
     -> RunSubagent
 runCodexSubagent runtime tokenProvider sendToRoot =
     \env previous prompt onEvent -> do
+        agentType <-
+            fromMaybe defaultSubagentType
+                <$> lookupAgentType runtime.subagentTypes env.subId
         childModel <- lookupAgentModel runtime.subagentTypes env.subId
         childEffort <- lookupAgentReasoningEffort runtime.subagentTypes env.subId
         parentParams <- readIORef runtime.subagentParams
@@ -584,7 +591,9 @@ runCodexSubagent runtime tokenProvider sendToRoot =
                         prepared.preparedToolEnv
                         (Just runtime.subagentPlanHooks)
                         Nothing
-                        (Just prepared.preparedMultiContext)
+                        (if runtime.subagentOptions.optRlm
+                            then Nothing
+                            else Just prepared.preparedMultiContext)
                 syncStoreRootFromPlan
                     runtime.subagentStoreRoot
                     coding.codingPlanMode
@@ -592,11 +601,21 @@ runCodexSubagent runtime tokenProvider sendToRoot =
                     today <- utctDay <$> getCurrentTime
                     ghciEnabled <- readIORef runtime.subagentGhciEnabled
                     bashEnabled <- readIORef runtime.subagentBashEnabled
-                    let codingTools =
+                    let baseTools
+                            | agentType == "rlm_readonly" =
+                                filterReadOnlyTools coding.codingAppTools
+                            | otherwise = coding.codingAppTools
+                        codingTools =
                             filterGhciTools ghciEnabled $
-                                filterBashTools bashEnabled coding.codingAppTools
+                                filterBashTools
+                                    (bashEnabled || runtime.subagentOptions.optRlm)
+                                    baseTools
                         tools =
-                            codingTools <> runtime.subagentMcpTools
+                            codingTools
+                                <> [ tool
+                                   | not runtime.subagentOptions.optRlm
+                                   , tool <- runtime.subagentMcpTools
+                                   ]
                         baseInstructions =
                             fromMaybe
                                 (systemPromptForTools
@@ -613,6 +632,7 @@ runCodexSubagent runtime tokenProvider sendToRoot =
                                 <> "report results clearly. Your agent id is "
                                 <> env.subId.unSubagentId
                                 <> "."
+                                <> rlmWorkerSuffix agentType
                         childParams = requestParams model instructions
                             (schemasFromAppTools codexDialect tools) effort
                     toolRegistry <- requireToolRegistry tools
@@ -696,7 +716,9 @@ runHttpSubagent runtime dialect provider sendToRoot mkBackend =
                         prepared.preparedToolEnv
                         (Just runtime.subagentPlanHooks)
                         Nothing
-                        (Just prepared.preparedMultiContext)
+                        (if runtime.subagentOptions.optRlm
+                            then Nothing
+                            else Just prepared.preparedMultiContext)
                 flip finally coding.codingClose do
                     today <- utctDay <$> getCurrentTime
                     shellPath <-
@@ -713,11 +735,21 @@ runHttpSubagent runtime dialect provider sendToRoot mkBackend =
                                 []
                     ghciEnabled <- readIORef runtime.subagentGhciEnabled
                     bashEnabled <- readIORef runtime.subagentBashEnabled
-                    let codingTools =
+                    let modeTools
+                            | agentType == "rlm_readonly" =
+                                filterReadOnlyTools childTools
+                            | otherwise = childTools
+                        codingTools =
                             filterGhciTools ghciEnabled $
-                                filterBashTools bashEnabled childTools
+                                filterBashTools
+                                    (bashEnabled || runtime.subagentOptions.optRlm)
+                                    modeTools
                         tools =
-                            codingTools <> runtime.subagentMcpTools
+                            codingTools
+                                <> [ tool
+                                   | not runtime.subagentOptions.optRlm
+                                   , tool <- runtime.subagentMcpTools
+                                   ]
                         baseInstructions =
                             case dialectChildAgentProtocol childDialect of
                                 CodexCollaborationProtocol ->
@@ -770,6 +802,7 @@ runHttpSubagent runtime dialect provider sendToRoot mkBackend =
                                         genericSubagentSuffix agentType env.subId
                                     NoHostChildAgentProtocol ->
                                         ""
+                                <> rlmWorkerSuffix agentType
                         childParams = requestParams model instructions
                             (schemasFromAppTools childDialect tools) effort
                     toolRegistry <- requireToolRegistry tools
@@ -901,7 +934,10 @@ runPreparedChild runtime env session toolRegistry backend onEvent runChild = do
                 }
             , loopTools = toolRegistry
             , loopDispatch = defaultLoopDispatch
-            , loopMaxTurns = runtime.subagentOptions.optMaxTurns
+            , loopMaxTurns =
+                if runtime.subagentOptions.optRlm
+                    then runtime.subagentOptions.optRlmWorkerMaxTurns
+                    else runtime.subagentOptions.optMaxTurns
             , loopOnEvent = onEvent
             , loopApprove =
                 \call ->
@@ -911,10 +947,14 @@ runPreparedChild runtime env session toolRegistry backend onEvent runChild = do
     result <- runChild config
     case result of
         Right loopResult ->
-            setPreviousResponseId
-                runtime.subagentRegistry
-                env.subId
-                loopResult.finalResponseId
+            do
+                setPreviousResponseId
+                    runtime.subagentRegistry
+                    env.subId
+                    loopResult.finalResponseId
+                runtime.subagentRecordUsage
+                    env.subRootTurnId
+                    loopResult.tokenUsage
         Left _ ->
             modifyIORef' session.subSessionTranscript trimDanglingToolSuffix
     persistSubagentSnapshot
@@ -947,6 +987,14 @@ genericSubagentSuffix agentType agentId =
             _ ->
                 "\n\nStart broad and narrow down. Check multiple locations and naming conventions. \
                 \Never create documentation files unless explicitly requested."
+
+rlmWorkerSuffix :: Text -> Text
+rlmWorkerSuffix agentType
+    | agentType == "rlm_readonly" =
+        "\n\nYou are an RLM read-only worker. Inspect and analyze only; do not modify files. Return a concise, self-contained result to the root orchestrator."
+    | agentType == "rlm_coding" =
+        "\n\nYou are an RLM coding worker. Implement the delegated change directly, verify it, and return a concise summary to the root orchestrator."
+    | otherwise = ""
 
 lookupOrCreateSubagentSession
     :: IORef (Map SubagentId SubagentSession)

--- a/packages/agent-cli/src/Agent/CLI/Tools.hs
+++ b/packages/agent-cli/src/Agent/CLI/Tools.hs
@@ -3,6 +3,7 @@ module Agent.CLI.Tools
     ( requireToolRegistry
     , lookupAppTool
     , schemasFromAppTools
+    , schemasFromAppToolsWithWeb
     , webSearchTool
     ) where
 
@@ -54,17 +55,22 @@ webSearchTool = KnownResponseTool ToolWebSearch TaggedObject
     }
 
 schemasFromAppTools :: Dialect -> [AppTool] -> [ResponseTool]
-schemasFromAppTools dialect tools = case dialectToolLayout dialect of
+schemasFromAppTools = schemasFromAppToolsWithWeb True
+
+schemasFromAppToolsWithWeb :: Bool -> Dialect -> [AppTool] -> [ResponseTool]
+schemasFromAppToolsWithWeb includeWeb dialect tools = case dialectToolLayout dialect of
     CollaborationNamespaceLayout ->
         let (multi, rest) = partition isMultiAgentTool tools
-            base = webSearchTool : mapMaybe (schemaFromAppTool dialect) rest
+            base = webTools <> mapMaybe (schemaFromAppTool dialect) rest
         in if null multi
             then base
             else base ++ [multiAgentNamespaceTool multi]
     FlatToolLayout ->
-        webSearchTool : mapMaybe (schemaFromAppTool dialect) tools
+        webTools <> mapMaybe (schemaFromAppTool dialect) tools
     NoHostToolLayout ->
         []
+  where
+    webTools = [webSearchTool | includeWeb]
 
 isMultiAgentTool :: AppTool -> Bool
 isMultiAgentTool tool = tool.appToolName `elem` multiAgentToolNames

--- a/packages/agent-cli/src/Agent/CLI/Turn.hs
+++ b/packages/agent-cli/src/Agent/CLI/Turn.hs
@@ -162,6 +162,7 @@ runOneTurn env@SessionEnv
     , sessionBeginSubagentTurn = beginSubagentTurn
     , sessionFinishSubagentTurn = finishSubagentTurn
     , sessionAbortSubagentTurn = abortSubagentTurn
+    , sessionDrainSubagentUsage = drainSubagentUsage
     , sessionOnPersisted = onPersisted
     } promptText inputs = do
   -- Clear the prior turn before publishing this flag to Ctrl-C / Esc.
@@ -266,7 +267,14 @@ runOneTurn env@SessionEnv
                 >> restorePlanStateAfterIncomplete planMode initialPlanState
                 >> abortSubagentTurn rootTurnId
             )
-    let result = execution.executionResult
+    subagentUsage <- drainSubagentUsage rootTurnId
+    let result = fmap
+            (\loopResult ->
+                loopResult
+                    { tokenUsage =
+                        addTokenUsage loopResult.tokenUsage subagentUsage
+                    })
+            execution.executionResult
     clearThinking render
     finishedAt <- getCurrentTime
     restartEffort <-

--- a/packages/agent-cli/test/Agent/CLI/DialectsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/DialectsSpec.hs
@@ -5,6 +5,7 @@ import Agent.CLI.Dialects
     , codingToolsFor
     , filterBashTools
     , filterGhciTools
+    , filterReadOnlyTools
     , formatAgentsMdForDialect
     , globalAgentsHomeDir
     )
@@ -19,7 +20,7 @@ import Agent.ToolDispatch (noArgsTool)
 import Agent.Tools.Secret (SecretPromptHooks(..))
 import Agent.Tools.Types
     ( AppTool(..)
-    , ApprovalRule(AlwaysReadOnly)
+    , ApprovalRule(AlwaysPrompt, AlwaysReadOnly)
     , ToolEnv
     , defaultToolEnv
     , jsonAppTool
@@ -107,6 +108,16 @@ spec = describe "Agent.CLI.Dialects" do
                 , "write_stdin"
                 , "run_terminal_cmd"
                 ]
+
+    it "keeps only statically read-only tools for RLM inspectors" do
+        let readTool = fakeTool "read_file"
+            writeTool =
+                readTool
+                    { appToolName = "write_file"
+                    , appToolApproval = AlwaysPrompt
+                    }
+        map (.appToolName) (filterReadOnlyTools [readTool, writeTool])
+            `shouldBe` ["read_file"]
 
 withTempToolEnv :: (ToolEnv -> IO a) -> IO a
 withTempToolEnv action = do

--- a/packages/agent-cli/test/Agent/CLI/OptionsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/OptionsSpec.hs
@@ -41,6 +41,35 @@ spec = do
                     , optPrompt = Just "hello"
                     })
 
+        it "parses the experimental in-process RLM options" do
+            parseArgs
+                [ "--rlm"
+                , "--rlm-model", "gpt-5.6-luna"
+                , "--rlm-effort", "low"
+                , "--rlm-max-calls", "12"
+                , "--rlm-parallelism", "3"
+                , "--rlm-worker-max-turns", "20"
+                , "--rlm-worker-timeout-seconds", "90"
+                ]
+                `shouldBe` Right (RunAgent defaultCliOptions
+                    { optRlm = True
+                    , optRlmModel = Just "gpt-5.6-luna"
+                    , optRlmEffort = Just "low"
+                    , optRlmMaxCalls = 12
+                    , optRlmParallelism = 3
+                    , optRlmWorkerMaxTurns = 20
+                    , optRlmWorkerTimeoutSeconds = 90
+                    })
+
+        it "requires GHCi for RLM mode" do
+            parseArgs ["--rlm", "--no-ghci"] `shouldSatisfy` isLeft
+
+        it "rejects invalid RLM numeric options" do
+            parseArgs ["--rlm-max-calls", "0"] `shouldSatisfy` isLeft
+            parseArgs ["--rlm-parallelism", "-1"] `shouldSatisfy` isLeft
+            parseArgs ["--rlm-worker-max-turns", "x"] `shouldSatisfy` isLeft
+            parseArgs ["--rlm-worker-timeout-seconds", "0"] `shouldSatisfy` isLeft
+
         it "parses --subagents and --no-subagents" do
             parseArgs ["--no-subagents", "-p", "hello"]
                 `shouldBe` Right (RunAgent defaultCliOptions

--- a/packages/agent-cli/test/Agent/CLI/OptionsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/OptionsSpec.hs
@@ -41,6 +41,18 @@ spec = do
                     , optPrompt = Just "hello"
                     })
 
+        it "parses --subagents and --no-subagents" do
+            parseArgs ["--no-subagents", "-p", "hello"]
+                `shouldBe` Right (RunAgent defaultCliOptions
+                    { optSubagents = False
+                    , optPrompt = Just "hello"
+                    })
+            parseArgs ["--no-subagents", "--subagents", "-p", "hello"]
+                `shouldBe` Right (RunAgent defaultCliOptions
+                    { optSubagents = True
+                    , optPrompt = Just "hello"
+                    })
+
         it "parses --worktree" do
             parseArgs ["--worktree"]
                 `shouldBe` Right (RunAgent defaultCliOptions { optWorktree = True })

--- a/packages/agent-cli/test/Agent/CLI/RlmSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RlmSpec.hs
@@ -1,0 +1,93 @@
+module Agent.CLI.RlmSpec (spec) where
+
+import Agent.CLI.Rlm
+import Agent.Loop (LoopResult(..), TokenUsage(..))
+import Agent.Subagents
+    ( beginRootTurn
+    , closeSubagentRegistry
+    , defaultSubagentConfig
+    , newSubagentRegistry
+    )
+import Agent.Subagents.TaskPath (taskPathRoot)
+import Agent.Tools.MultiAgents (MultiAgentContext(..))
+import Control.Concurrent (threadDelay)
+import Control.Exception.Safe (bracket)
+import Data.Text qualified as Text
+import System.Directory
+    ( doesFileExist
+    , getTemporaryDirectory
+    , removeDirectoryRecursive
+    )
+import System.FilePath ((</>))
+import System.OsPath (unsafeEncodeUtf)
+import System.Posix.Temp (mkdtemp)
+import System.Timeout (timeout)
+import Test.Hspec
+
+spec :: Spec
+spec = describe "Agent.CLI.Rlm" do
+    it "dispatches mailbox requests through the in-process subagent registry" do
+        withTempDirectory \directory -> do
+            let cwd = unsafeEncodeUtf directory
+                mailboxPath = directory </> "mailbox"
+                mailbox = unsafeEncodeUtf mailboxPath
+            registry <-
+                newSubagentRegistry defaultSubagentConfig cwd
+                    (\_ _ _ _ ->
+                        pure $ Right LoopResult
+                            { finalResponseId = "worker-response"
+                            , finalText = Just "worker answer"
+                            , turnsUsed = 2
+                            , tokenUsage = TokenUsage 11 7 3
+                            })
+                    (\_ _ -> pure ())
+            rootTurn <- beginRootTurn registry
+            let context = MultiAgentContext
+                    { multiRegistry = registry
+                    , multiSelfId = Nothing
+                    , multiDepth = 0
+                    , multiTaskPath = taskPathRoot
+                    , multiRootTurnId = pure (Just rootTurn)
+                    , multiResumeFromDisk = Nothing
+                    , multiCreateWorktree = Nothing
+                    , multiPrepareSpawn = Nothing
+                    , multiSendToRoot = Nothing
+                    , multiSpawnModelGuidance = Nothing
+                    }
+            runtime <- newRlmRuntime RlmConfig
+                { rlmMailbox = mailbox
+                , rlmContext = context
+                , rlmModel = Nothing
+                , rlmEffort = Nothing
+                , rlmMaxCalls = 2
+                , rlmParallelism = 2
+                , rlmWorkerTimeoutSeconds = 10
+                , rlmPrepareWorker = \_ _ -> pure mempty
+                }
+            let request = mailboxPath </> "request.req"
+                response = mailboxPath </> "request.resp"
+            writeFile request "readonly\ninspect the project"
+            received <- timeout 3000000 (waitForFile response)
+            closeRlmRuntime runtime
+            closeSubagentRegistry registry
+            case received of
+                Nothing -> expectationFailure "timed out waiting for RLM response"
+                Just body -> do
+                    body `shouldSatisfy` Text.isInfixOf "\"worker answer\""
+                    body `shouldSatisfy` Text.isInfixOf "\"input\":11"
+                    body `shouldSatisfy` Text.isInfixOf "\"turns_used\":2"
+
+waitForFile :: FilePath -> IO Text.Text
+waitForFile path = do
+    exists <- doesFileExist path
+    if exists
+        then Text.pack <$> readFile path
+        else threadDelay 10000 >> waitForFile path
+
+withTempDirectory :: (FilePath -> IO a) -> IO a
+withTempDirectory action = do
+    root <- getTemporaryDirectory
+    bracket
+        (mkdtemp (root </> "agent-cli-rlm-"))
+        removeDirectoryRecursive
+        action

--- a/packages/agent-cli/test/Agent/CLI/ToolsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ToolsSpec.hs
@@ -45,6 +45,14 @@ spec = describe "schemasFromAppTools" do
                 tagged.fields `shouldBe` KeyMap.empty
             other -> expectationFailure ("expected web_search first, got " <> show other)
 
+    it "can omit web_search for a constrained root tool surface" do
+        case schemasFromAppToolsWithWeb False codexDialect [jsonTool] of
+            [FunctionToolValue tool] ->
+                tool.name `shouldBe` "read_file"
+            other ->
+                expectationFailure
+                    ("expected only the app tool, got " <> show other)
+
     it "builds a strict function tool for OpenAI JSON tools" do
         case schemasFromAppTools codexDialect [jsonTool] of
             [_, FunctionToolValue tool] -> do

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -39,6 +39,7 @@ import qualified Agent.CLI.ProviderFallbackSpec as ProviderFallbackSpec
 import qualified Agent.CLI.ProviderAvailabilitySpec as ProviderAvailabilitySpec
 import qualified Agent.CLI.ProviderTransitionSpec as ProviderTransitionSpec
 import qualified Agent.CLI.RequestSpec as RequestSpec
+import qualified Agent.CLI.RlmSpec as RlmSpec
 import qualified Agent.CLI.RenderSpec as RenderSpec
 import qualified Agent.CLI.ReplStatusSpec as ReplStatusSpec
 import qualified Agent.CLI.ResumeSpec as ResumeSpec
@@ -102,6 +103,7 @@ main = hspec do
     ProviderAvailabilitySpec.spec
     ProviderTransitionSpec.spec
     RequestSpec.spec
+    RlmSpec.spec
     RenderSpec.spec
     ReplStatusSpec.spec
     ResumeSpec.spec

--- a/packages/agent-codex-dialect/src/Agent/Codex/Dialect/Runtime.hs
+++ b/packages/agent-codex-dialect/src/Agent/Codex/Dialect/Runtime.hs
@@ -1,6 +1,7 @@
 module Agent.Codex.Dialect.Runtime
     ( CodexCodingTools(..)
     , newCodexCodingTools
+    , newCodexCodingToolsWithGhciHelpers
     ) where
 
 import Agent.Codex.Dialect.Shell
@@ -13,11 +14,16 @@ import Agent.ResourceScope
     , closeResourceScope
     , newResourceScope
     )
-import Agent.Tools.Ghci (closeGhciSession, newGhciSession)
+import Agent.Tools.Ghci
+    ( closeGhciSession
+    , newGhciSession
+    , newGhciSessionWithHelpers
+    )
 import Agent.Tools.MultiAgents (MultiAgentContext)
 import Agent.Tools.PlanMode (PlanModeEnv, PlanModeHooks, newPlanModeEnv)
 import Agent.Tools.Types (AppTool, ToolEnv(..))
 import Control.Exception.Safe (onException)
+import Data.Text (Text)
 
 data CodexCodingTools = CodexCodingTools
     { codexAppTools :: ![AppTool]
@@ -31,6 +37,15 @@ newCodexCodingTools
     -> Maybe MultiAgentContext
     -> IO CodexCodingTools
 newCodexCodingTools env hooks multi = do
+    newCodexCodingToolsWithGhciHelpers env hooks multi []
+
+newCodexCodingToolsWithGhciHelpers
+    :: ToolEnv
+    -> Maybe PlanModeHooks
+    -> Maybe MultiAgentContext
+    -> [Text]
+    -> IO CodexCodingTools
+newCodexCodingToolsWithGhciHelpers env hooks multi ghciHelpers = do
     resources <- newResourceScope
     flip onException (closeResourceScope resources) do
         plan <- newPlanModeEnv env.toolCwd hooks
@@ -38,7 +53,9 @@ newCodexCodingTools env hooks multi = do
             (newCodexShellSession env)
             closeCodexShellSession
         (_, ghci) <- allocateResource resources
-            (newGhciSession env)
+            (if null ghciHelpers
+                then newGhciSession env
+                else newGhciSessionWithHelpers env ghciHelpers)
             closeGhciSession
         tools <- codexTools env shellSession ghci plan multi
         pure CodexCodingTools

--- a/packages/agent-core/src/Agent/Subagents/Registry.hs
+++ b/packages/agent-core/src/Agent/Subagents/Registry.hs
@@ -43,6 +43,7 @@ module Agent.Subagents.Registry
     , closeSubagent
     , interruptSubagent
     , getStatus
+    , getLastResult
     , getPreviousResponseId
     , getSubagentCwd
     , getSubagentIdentity
@@ -130,6 +131,7 @@ data SubagentRecord = SubagentRecord
       -- | Last successful response id for conversation continuity.
     , recordPreviousResponseId :: !(TVar (Maybe Text))
     , recordLastUpdate :: !(TVar (Maybe (Int, SubagentStatus)))
+    , recordLastResult :: !(TVar (Maybe LoopResult))
     , recordTaskPath :: !TaskPath
     , recordCwd :: !OsPath
     }
@@ -475,6 +477,7 @@ spawnSubagentAtWithIdPreparedForTurn
     asyncVar <- newTVarIO Nothing
     previousVar <- newTVarIO Nothing
     lastUpdateVar <- newTVarIO Nothing
+    lastResultVar <- newTVarIO Nothing
     admitted <- withMVar registry.registryLifecycle \_ -> atomically do
         closed <- readTVar registry.registryClosed
         aborted <- isRootTurnAborted registry rootTurnId
@@ -536,6 +539,7 @@ spawnSubagentAtWithIdPreparedForTurn
                                                                 , recordAsync = asyncVar
                                                                 , recordPreviousResponseId = previousVar
                                                                 , recordLastUpdate = lastUpdateVar
+                                                                , recordLastResult = lastResultVar
                                                                 , recordTaskPath = childPath
                                                                 , recordCwd = childCwd
                                                                 }
@@ -649,9 +653,10 @@ runSupervisor registry record = awaitWork
                 Right (Right loopResult) -> Completed loopResult.finalText
         case result of
             Right (Right loopResult) ->
-                atomically $
+                atomically do
                     writeTVar record.recordPreviousResponseId
                         (Just loopResult.finalResponseId)
+                    writeTVar record.recordLastResult (Just loopResult)
             _ -> pure ()
         atomically (nextSupervisorStep registry record) >>= \case
             SupervisorStop -> pure ()
@@ -1437,6 +1442,7 @@ restoreSubagentResolvedWithCwd
         asyncVar <- newTVarIO Nothing
         previousVar <- newTVarIO previous
         lastUpdateVar <- newTVarIO Nothing
+        lastResultVar <- newTVarIO Nothing
         restored <- atomically do
             closed <- readTVar registry.registryClosed
             if closed
@@ -1465,6 +1471,7 @@ restoreSubagentResolvedWithCwd
                                             , recordAsync = asyncVar
                                             , recordPreviousResponseId = previousVar
                                             , recordLastUpdate = lastUpdateVar
+                                            , recordLastResult = lastResultVar
                                             , recordTaskPath = resolvedPath
                                             , recordCwd = childCwd
                                             }
@@ -1490,6 +1497,18 @@ restoreSubagentResolvedWithCwd
 
 getStatus :: SubagentRegistry -> SubagentId -> IO SubagentStatus
 getStatus registry agentId = atomically (readStatusSTM registry agentId)
+
+-- | Return the most recently completed loop result for a subagent.
+--
+-- The result is retained independently of the public lifecycle status so
+-- callers such as the in-process RLM bridge can recover token usage and the
+-- final response without changing collaboration status payloads.
+getLastResult :: SubagentRegistry -> SubagentId -> IO (Maybe LoopResult)
+getLastResult registry agentId = atomically do
+    agents <- readTVar registry.registryAgents
+    case Map.lookup agentId agents of
+        Nothing -> pure Nothing
+        Just record -> readTVar record.recordLastResult
 
 getPreviousResponseId :: SubagentRegistry -> SubagentId -> IO (Maybe Text)
 getPreviousResponseId registry agentId = atomically do

--- a/packages/agent-core/src/Agent/Tools/Ghci/Runtime.hs
+++ b/packages/agent-core/src/Agent/Tools/Ghci/Runtime.hs
@@ -8,6 +8,7 @@ module Agent.Tools.Ghci.Runtime
     , GhciOutcome(..)
     , GhciResult(..)
     , newGhciSession
+    , newGhciSessionWithHelpers
     , closeGhciSession
     , evalGhci
     , classifyGhci
@@ -152,12 +153,19 @@ data GhciSession = GhciSession
     { ghciEnv :: !ToolEnv
     , ghciRuntime :: !(MVar GhciRuntimeState)
     , ghciMarkerSeed :: !Text
+    , ghciExtraHelpers :: ![Text]
     }
 
 type GhciRuntime = StateT GhciRuntimeState IO
 
 newGhciSession :: ToolEnv -> IO GhciSession
-newGhciSession env = do
+newGhciSession env = newGhciSessionWithHelpers env []
+
+-- | Create a persistent GHCi session with additional startup statements.
+-- Statements are reinstalled after commands such as @:load@ that reset the
+-- interactive context.
+newGhciSessionWithHelpers :: ToolEnv -> [Text] -> IO GhciSession
+newGhciSessionWithHelpers env extraHelpers = do
     runtime <- newMVar GhciRuntimeState
         { runtimeSessionState = GhciNotStarted
         , runtimeNextMarker = 0
@@ -168,6 +176,7 @@ newGhciSession env = do
         { ghciEnv = env
         , ghciRuntime = runtime
         , ghciMarkerSeed = seed
+        , ghciExtraHelpers = extraHelpers
         }
 
 closeGhciSession :: GhciSession -> IO ()
@@ -250,7 +259,7 @@ evalRawGhci session expression requestedTimeout = do
                 sent <- liftIO $ try @_ @SomeException do
                     sendGhciInput process expression
                     when (ghciInputResetsHelpers expression)
-                        (sendGhciHelpers process)
+                        (sendGhciHelpers session process)
                     sendMarker process marker
                 case sent of
                     Left err -> do
@@ -447,7 +456,7 @@ startProcess session = mask \restore ->
                 marker <- nextMarker session
                 sent <- liftIO $
                     try @_ @SomeException do
-                        sendGhciHelpers process
+                        sendGhciHelpers session process
                         sendMarker process marker
                 case sent of
                     Left err -> do
@@ -640,10 +649,10 @@ ghciInputResetsHelpers expression =
 -- | Install a tiny, provider-neutral scripting prelude. These bindings target
 -- the repetitive process and file operations seen in agent GHCi sessions while
 -- keeping argv-based execution as the default (rather than shell strings).
-sendGhciHelpers :: GhciProcess -> IO ()
-sendGhciHelpers process =
+sendGhciHelpers :: GhciSession -> GhciProcess -> IO ()
+sendGhciHelpers session process =
     mapM_ (sendLine process)
-        [ "import qualified System.Process as AgentGhciProcess"
+        ( [ "import qualified System.Process as AgentGhciProcess"
         , "import qualified System.IO as AgentGhciIO"
         , "import qualified Data.Text.IO as AgentGhciTextIO"
         , "import qualified System.Directory as AgentGhciDirectory"
@@ -657,6 +666,8 @@ sendGhciHelpers process =
         , "let readText = AgentGhciTextIO.readFile; writeText = AgentGhciTextIO.writeFile; appendText = AgentGhciTextIO.appendFile"
         , "let listFiles = AgentGhciDirectory.listDirectory; pathExists = AgentGhciDirectory.doesPathExist"
         ]
+            <> session.ghciExtraHelpers
+        )
 
 frameGhciInput :: Text -> Text
 frameGhciInput expression

--- a/packages/agent-core/test/Agent/SubagentsSpec.hs
+++ b/packages/agent-core/test/Agent/SubagentsSpec.hs
@@ -105,6 +105,23 @@ spec = describe "Agent.Subagents" do
         timedOut `shouldBe` False
         Map.lookup agentId statuses `shouldBe` Just (Completed (Just "done:hello"))
 
+    it "retains the last completed loop result separately from public status" do
+        expected <- pure LoopResult
+            { finalResponseId = "child-result"
+            , finalText = Just "result text"
+            , turnsUsed = 2
+            , tokenUsage = emptyTokenUsage
+            }
+        registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
+            (\_ _ _ _ -> pure (Right expected))
+            (\_ _ -> pure ())
+        Right agentId <- spawnSubagent registry Nothing 0 "result" Nothing
+        (statuses, timedOut) <- waitSubagents registry [agentId] 15000
+        timedOut `shouldBe` False
+        Map.lookup agentId statuses
+            `shouldBe` Just (Completed (Just "result text"))
+        getLastResult registry agentId `shouldReturn` Just expected
+
     it "does not launch a prepared supervisor after registry shutdown" do
         entered <- newEmptyMVar
         release <- newEmptyMVar

--- a/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Runtime.hs
+++ b/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Runtime.hs
@@ -1,6 +1,7 @@
 module Agent.GrokBuild.Dialect.Runtime
     ( GrokCodingTools(..)
     , newGrokCodingTools
+    , newGrokCodingToolsWithGhciHelpers
     ) where
 
 import Agent.GrokBuild.Dialect.Task (GrokSubagentSpecs)
@@ -14,11 +15,16 @@ import Agent.ResourceScope
     , closeResourceScope
     , newResourceScope
     )
-import Agent.Tools.Ghci (closeGhciSession, newGhciSession)
+import Agent.Tools.Ghci
+    ( closeGhciSession
+    , newGhciSession
+    , newGhciSessionWithHelpers
+    )
 import Agent.Tools.MultiAgents (MultiAgentContext)
 import Agent.Tools.PlanMode (PlanModeEnv, PlanModeHooks, newPlanModeEnv)
 import Agent.Tools.Types (AppTool, ToolEnv(..))
 import Control.Exception.Safe (onException)
+import Data.Text (Text)
 
 data GrokCodingTools = GrokCodingTools
     { grokAppTools :: ![AppTool]
@@ -34,6 +40,16 @@ newGrokCodingTools
     -> GrokSubagentSpecs
     -> IO GrokCodingTools
 newGrokCodingTools env hooks multi typesRef = do
+    newGrokCodingToolsWithGhciHelpers env hooks multi typesRef []
+
+newGrokCodingToolsWithGhciHelpers
+    :: ToolEnv
+    -> Maybe PlanModeHooks
+    -> Maybe MultiAgentContext
+    -> GrokSubagentSpecs
+    -> [Text]
+    -> IO GrokCodingTools
+newGrokCodingToolsWithGhciHelpers env hooks multi typesRef ghciHelpers = do
     resources <- newResourceScope
     flip onException (closeResourceScope resources) do
         plan <- newPlanModeEnv env.toolCwd hooks
@@ -41,7 +57,9 @@ newGrokCodingTools env hooks multi typesRef = do
             (newGrokSession env)
             closeGrokSession
         (_, ghci) <- allocateResource resources
-            (newGhciSession env)
+            (if null ghciHelpers
+                then newGhciSession env
+                else newGhciSessionWithHelpers env ghciHelpers)
             closeGhciSession
         pure GrokCodingTools
             { grokAppTools = grokTools session ghci plan multi typesRef


### PR DESCRIPTION
## Experiment — do not merge

This PR records an exploratory comparison between direct `agent-cli`, an in-process recursive-language-model (RLM) mode, and Codex. It is intentionally left as a draft and is **not proposed for merge**. The implementation and transcripts are useful as an experimental artifact.

## What was built

- reproducible Haskell todo-server coding eval
- deterministic grading of GHC 9.10, `MVar` state, JSON schema, and GET/POST/DELETE behavior
- wall-clock and provider-reported token accounting
- in-process RLM workers exposed through `rlmQuery`, `rlmQueryMany`, and `rlmCode`
- worker usage included in root-session token totals
- immutable shared `flake.nix` and `flake.lock` fixture
- Nix package and development closures prebuilt before timed runs
- byte-for-byte grading that agents did not modify the supplied flake fixture

## Controlled result

Run on `office-builder` on August 24, 2026 with `gpt-5.6-terra`, medium effort, and one trial per runner. Every runner preserved the supplied flake, self-verified, and passed the independent grader.

| runner | passed | seconds | input | uncached | cached | output |
|---|---:|---:|---:|---:|---:|---:|
| agent-cli | yes | 250.51 | 268,201 | 27,305 | 240,896 | 6,385 |
| agent-cli RLM | yes | 420.11 | 695,037 | 122,237 | 572,800 | 17,084 |
| Codex | yes | 190.98 | 659,186 | 40,690 | 618,496 | 6,759 |

Direct agent-cli used **59.3% fewer total input tokens** than Codex, but took **31.2% longer**. RLM took **67.7% longer** than direct agent-cli and used **159.1% more total input**, **347.7% more uncached input**, **137.8% more cached input**, and **167.6% more output**.

## Interpretation

The controlled run did not show an advantage for RLM on this task. The RLM worker produced code with faulty imports; the root then reread and substantially rewrote the complete file and performed several repair turns. Delegation duplicated implementation and review context instead of reducing root work.

This is a small, tightly specified, one-file task. Worker startup and handoff overhead are large relative to the implementation. RLM may still be useful for larger tasks with separable research or implementation units, but that requires a different eval.

## Why the prebuilt fixture matters

Earlier runs let each agent construct its own flake. Those timings were dominated by different first-use Nix closures and produced misleading comparisons. The final controlled fixture gives every runner identical pinned dependencies and prebuilds them before timing.

## Caveats

- The final controlled comparison has only one trial per runner; it is a smoke result, not a stable median.
- Product prompts and tool contracts still differ between agent-cli and Codex.
- The RLM prototype needs better worker task scoping, validation, and handoff before another performance evaluation.
- Earlier cold/warm runs are retained in the documentation as historical data, with their comparability limitations explained.

## Validation

- `agent-cli` test suite: 807 examples, 0 failures
- evaluator and agent-cli executables build with GHC 9.10.3
- shared flake prebuild smoke-tested
- all three controlled generated applications passed the external grader
- full methodology and transcript analysis in `docs/evals/agent-vs-codex-todo.md`
