### PR TITLE
Fix Cmd-V in fullscreen composer

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -102,7 +102,11 @@ import Agent.CLI.Resume
 import Agent.CLI.Render (formatElapsed, summarizeToolCall)
 import Agent.CLI.Style (motionGlyphSet)
 import Agent.CLI.Status (formatTokenUsage)
-import Agent.CLI.Terminal (shiftEnterCsiBodies)
+import Agent.CLI.Terminal
+    ( kittyCtrlVCsiBodies
+    , kittySuperVCsiBodies
+    , shiftEnterCsiBodies
+    )
 import qualified Agent.TUI.Theme as Theme
 import qualified Agent.CLI.TUI.Bridge as Bridge
 import qualified Agent.CLI.TUI.Composer as Composer
@@ -474,7 +478,7 @@ readFullscreenLineOrWithModels
 
 -- | Fullscreen Vty configuration, including enhanced-keyboard encodings that
 -- are not present in the default terminfo input table. Without these entries,
--- Vty emits the payload of Shift+Enter sequences as printable characters.
+-- Vty emits the payload of modified-key sequences as printable characters.
 fullscreenVtyConfig :: V.VtyUserConfig
 fullscreenVtyConfig =
     V.defaultConfig
@@ -486,6 +490,16 @@ fullscreenVtyConfig =
               )
             | body <- shiftEnterCsiBodies
             ]
+            <> [ ( Nothing
+                 , "\ESC[" <> body
+                 , V.EvKey (V.KChar 'v') [modifier]
+                 )
+               | (modifier, bodies) <-
+                    [ (V.MCtrl, kittyCtrlVCsiBodies)
+                    , (V.MMeta, kittySuperVCsiBodies)
+                    ]
+               , body <- bodies
+               ]
         }
 
 requestFullscreenPermission

--- a/packages/agent-cli/src/Agent/CLI/Terminal.hs
+++ b/packages/agent-cli/src/Agent/CLI/Terminal.hs
@@ -16,6 +16,8 @@ module Agent.CLI.Terminal
     , synchronizedOutputBegin
     , synchronizedOutputEnd
     , stripAnsi
+    , kittyCtrlVCsiBodies
+    , kittySuperVCsiBodies
     , shiftEnterCsiBodies
     , kittyKeyboardDisambiguatePush
     , kittyKeyboardPush
@@ -190,6 +192,21 @@ shiftEnterCsiBodies :: [String]
 shiftEnterCsiBodies =
     [ "27;2;13~"
     , "13;2u"
+    ]
+
+-- | CSI bodies emitted by Kitty's keyboard protocol for Ctrl+V and Cmd+V.
+--
+-- The longer key-code form includes the shifted and base-layout codepoints.
+-- Event type 1 is an explicit key press; terminals may omit it.
+kittyCtrlVCsiBodies, kittySuperVCsiBodies :: [String]
+kittyCtrlVCsiBodies = kittyModifiedVCsiBodies 5
+kittySuperVCsiBodies = kittyModifiedVCsiBodies 9
+
+kittyModifiedVCsiBodies :: Int -> [String]
+kittyModifiedVCsiBodies encodedModifier =
+    [ keyCode <> ";" <> show encodedModifier <> event <> "u"
+    | keyCode <- ["118", "118:86:86"]
+    , event <- ["", ":1"]
     ]
 
 -- | Push only Kitty's unambiguous-key flag. This is enough for an inline

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -148,18 +148,32 @@ spec = do
             after.uiPrompt.promptModel `shouldBe` "gpt-5.6-sol"
 
     describe "fullscreenVtyConfig" do
-        it "maps enhanced-keyboard Shift+Enter sequences before Vty decodes them" do
-            V.configInputMap fullscreenVtyConfig
-                `shouldMatchList`
-                    [ ( Nothing
-                      , "\ESC[27;2;13~"
-                      , V.EvKey V.KEnter [V.MShift]
-                      )
-                    , ( Nothing
-                      , "\ESC[13;2u"
-                      , V.EvKey V.KEnter [V.MShift]
-                      )
-                    ]
+        it "maps enhanced-keyboard sequences before Vty decodes them" do
+            let mappings = V.configInputMap fullscreenVtyConfig
+            mappings `shouldContain`
+                [ ( Nothing
+                  , "\ESC[27;2;13~"
+                  , V.EvKey V.KEnter [V.MShift]
+                  )
+                , ( Nothing
+                  , "\ESC[13;2u"
+                  , V.EvKey V.KEnter [V.MShift]
+                  )
+                ]
+            mappings `shouldContain`
+                [ ( Nothing
+                  , "\ESC[118;5u"
+                  , V.EvKey (V.KChar 'v') [V.MCtrl]
+                  )
+                , ( Nothing
+                  , "\ESC[118;9u"
+                  , V.EvKey (V.KChar 'v') [V.MMeta]
+                  )
+                , ( Nothing
+                  , "\ESC[118:86:86;9:1u"
+                  , V.EvKey (V.KChar 'v') [V.MMeta]
+                  )
+                ]
 
     describe "repositoryHeaderText" do
         it "puts the git state before the full checkout path" do

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -160,7 +160,8 @@ spec = do
                   , V.EvKey V.KEnter [V.MShift]
                   )
                 ]
-            mappings `shouldContain`
+            mapM_
+                (\mapping -> mappings `shouldContain` [mapping])
                 [ ( Nothing
                   , "\ESC[118;5u"
                   , V.EvKey (V.KChar 'v') [V.MCtrl]


### PR DESCRIPTION
## Summary
- map Kitty keyboard protocol Ctrl-V and Cmd-V sequences before Vty decoding
- support ordinary and extended keycode forms with optional explicit press events
- add regression coverage for fullscreen Vty input mappings

## Verification
- agent-cli test suite in GHCi
- `git diff --check`
- live tmux TTY smoke test: Kitty Cmd-V sequence triggered clipboard attachment instead of rendering escape-sequence text