### PR TITLE
Keep native code block selection visible

### DIFF
--- a/packages/agent-tui/src/Agent/TUI/Theme.hs
+++ b/packages/agent-tui/src/Agent/TUI/Theme.hs
@@ -188,7 +188,9 @@ solarizedDark =
             `V.withStyle` V.bold)
         , (codeAttr, V.defAttr
             `V.withForeColor` rgb 42 161 152
-            `V.withBackColor` rgb 7 54 66)
+            -- Keep fenced code distinct from the terminal's Solarized
+            -- selection background so native drag selections stay visible.
+            `V.withBackColor` codeBlockBackground)
         , (dimAttr, V.defAttr
             `V.withForeColor` rgb 88 110 117
             `V.withBackColor` rgb 0 43 54)
@@ -305,7 +307,10 @@ codeColor :: Int -> Int -> Int -> V.Attr
 codeColor r g b =
     V.defAttr
         `V.withForeColor` rgb r g b
-        `V.withBackColor` rgb 7 54 66
+        `V.withBackColor` codeBlockBackground
+
+codeBlockBackground :: V.Color
+codeBlockBackground = rgb 0 43 54
 
 rgb :: Int -> Int -> Int -> V.Color
 rgb r g b =

--- a/packages/agent-tui/test/Agent/TUI/ThemeSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ThemeSpec.hs
@@ -33,6 +33,13 @@ spec = do
                     ]
 
     describe "syntax theme attributes" do
+        it "keeps native text selection visible over fenced code" do
+            let background attribute =
+                    V.attrBackColor
+                        (attrMapLookup attribute Theme.solarizedDark)
+            background Theme.codeAttr
+                `shouldNotBe` background Theme.selectedAttr
+
         it "keeps every Solarized syntax class on the code-block background" do
             let codeBackground =
                     V.attrBackColor


### PR DESCRIPTION
## Summary
- use a fenced-code background distinct from the Solarized selection color
- keep syntax-highlighted spans on the same fenced-code background
- add a regression test requiring code and selection backgrounds to differ

## Testing
- `nix develop -c cabal repl agent-tui:test:agent-tui-test` (`:main`): 128 examples, 0 failures
- live fullscreen tmux smoke test with a syntax-highlighted fenced Haskell block
- `git diff --check origin/master...HEAD`