### PR TITLE
Allow agents to read discovered skill files

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -2932,7 +2932,12 @@ runSession catalog connectionId options provider dialect policy allTools ghciEna
     writeIORef startup.startupAgentSnapshot
         (loadAgentSnapshot False)
     writeIORef startup.startupAgentSelect selectAgent
-    let sessionReset = do
+    let installSkills context queueContext skills = do
+            installSkillToolRoots toolEnv skills
+            installSkillCatalogWithOmissions
+                reservedSlashNames queueContext context
+                skillsRef skillInvocationsRef skills
+        sessionReset = do
             resetLiveConversation previous transcriptRef attachmentsRef planMode
             writeIORef usageRef emptyTokenUsage
             writeIORef lastAssistantRef Nothing
@@ -2946,20 +2951,14 @@ runSession catalog connectionId options provider dialect policy allTools ghciEna
             freshAgents <-
                 loadAgentsContext fullscreen options dialect home cwd [] Nothing
             freshSkills <- loadSkillsCatalogQuiet options home projectRoot cwd
-            installSkillToolRoots toolEnv freshSkills
-            omitted <- installSkillCatalogWithOmissions
-                reservedSlashNames True freshAgents
-                skillsRef skillInvocationsRef freshSkills
+            omitted <- installSkills freshAgents True freshSkills
             reportSkillCatalog True freshSkills omitted
             fresh <- readIORef freshAgents
             writeIORef startupContext fresh
         refreshSkills queueContext = do
             refreshed <- loadSkillsCatalogQuiet
                 options home projectRoot cwd
-            installSkillToolRoots toolEnv refreshed
-            omitted <- installSkillCatalogWithOmissions
-                reservedSlashNames queueContext startupContext
-                skillsRef skillInvocationsRef refreshed
+            omitted <- installSkills startupContext queueContext refreshed
             when queueContext $
                 reportSkillCatalog True refreshed omitted
         formatSkillWarning warning =
@@ -3240,10 +3239,9 @@ runSession catalog connectionId options provider dialect policy allTools ghciEna
             markStartupStage startup "Loading skills…"
             skills <- loadSkillsCatalogQuiet
                 options home projectRoot cwd
-            omitted <- installSkillCatalogWithOmissions
-                reservedSlashNames
+            omitted <- installSkills startupContext
                 (null initialTurns && not (isJust initialPrevious))
-                startupContext skillsRef skillInvocationsRef skills
+                skills
             reportSkillCatalog (isNothing fullscreen) skills omitted
             finishStartup startup
         sessionAction = do

--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -235,6 +235,7 @@ import Agent.CLI.SessionLock
 import Agent.CLI.Skills
     ( formatSkillsListing
     , installSkillCatalogWithOmissions
+    , installSkillToolRoots
     , loadSkillsCatalogQuiet
     , reservedSlashNames
     , skillInvocationCommand
@@ -1946,6 +1947,7 @@ runAgentInitializedWithLock
                 , subagentBashEnabled = bashEnabledRef
                 , subagentPolicy = policy
                 , subagentPlanHooks = planHooks
+                , subagentSkillRoots = toolEnv.toolSkillRoots
                 , subagentParams = paramsRef
                 , subagentMcpTools = mcpTools
                 , subagentRegistry = registry
@@ -2944,6 +2946,7 @@ runSession catalog connectionId options provider dialect policy allTools ghciEna
             freshAgents <-
                 loadAgentsContext fullscreen options dialect home cwd [] Nothing
             freshSkills <- loadSkillsCatalogQuiet options home projectRoot cwd
+            installSkillToolRoots toolEnv freshSkills
             omitted <- installSkillCatalogWithOmissions
                 reservedSlashNames True freshAgents
                 skillsRef skillInvocationsRef freshSkills
@@ -2953,6 +2956,7 @@ runSession catalog connectionId options provider dialect policy allTools ghciEna
         refreshSkills queueContext = do
             refreshed <- loadSkillsCatalogQuiet
                 options home projectRoot cwd
+            installSkillToolRoots toolEnv refreshed
             omitted <- installSkillCatalogWithOmissions
                 reservedSlashNames queueContext startupContext
                 skillsRef skillInvocationsRef refreshed

--- a/packages/agent-cli/src/Agent/CLI/Skills.hs
+++ b/packages/agent-cli/src/Agent/CLI/Skills.hs
@@ -3,6 +3,7 @@ module Agent.CLI.Skills
     ( formatSkillsListing
     , installSkillCatalog
     , installSkillCatalogWithOmissions
+    , installSkillToolRoots
     , loadSkillsCatalog
     , loadSkillsCatalogQuiet
     , queueSkillCatalogContext
@@ -28,6 +29,7 @@ import Agent.CLI.Style
 import Agent.CLI.Terminal (resolveColor)
 import Agent.OsPath (toText)
 import Agent.Skills
+import Agent.Tools.Types (ToolEnv, setToolSkillRoots)
 import Control.Monad (void, when)
 import Data.IORef (IORef, modifyIORef', writeIORef)
 import Data.Maybe (fromMaybe)
@@ -184,6 +186,13 @@ installSkillCatalogWithOmissions reservedNames queueContext contextRef catalogRe
     if queueContext
         then queueSkillCatalogContextWithOmissions contextRef catalog
         else pure 0
+
+-- | Expose only the directories belonging to the current catalog. This lets
+-- models read SKILL.md and skill-relative resources even when packaged skills
+-- live outside the worktree (for example under /nix/store).
+installSkillToolRoots :: ToolEnv -> SkillCatalog -> IO ()
+installSkillToolRoots env catalog =
+    setToolSkillRoots env (map (.skillDirectory) catalog.catalogSkills)
 
 skillInvocationCommand :: SkillInvocation -> SkillCommand
 skillInvocationCommand invocation =

--- a/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
@@ -179,6 +179,7 @@ data SubagentRuntime = SubagentRuntime
     , subagentBashEnabled :: !(IORef Bool)
     , subagentPolicy :: !ApprovalPolicy
     , subagentPlanHooks :: !PlanModeHooks
+    , subagentSkillRoots :: !(IORef [OsPath])
     , subagentSessionTmp :: !(IORef (Maybe OsPath))
     , subagentMcpTools :: ![AppTool]
     , subagentParams :: !(IORef ResponseCreateParams)
@@ -802,6 +803,8 @@ prepareChild
 prepareChild runtime provider currentEffectiveModel currentDialect env sendToRoot = do
     parentParams <- readIORef runtime.subagentParams
     childEnv <- defaultToolEnv env.subCwd
+    skillRoots <- readIORef runtime.subagentSkillRoots
+    writeIORef childEnv.toolSkillRoots skillRoots
     sessionTmp <- readIORef runtime.subagentSessionTmp
     setToolSessionTmp childEnv sessionTmp
     childPath <-

--- a/packages/agent-cli/test/Agent/CLI/SkillsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SkillsSpec.hs
@@ -3,10 +3,13 @@ module Agent.CLI.SkillsSpec (spec) where
 import Agent.CLI.Command (SkillCommand(..))
 import Agent.CLI.Options (CliOptions(..), defaultCliOptions)
 import Agent.CLI.Skills
-import System.OsPath (unsafeEncodeUtf)
+import System.OsPath (takeDirectory, unsafeEncodeUtf)
 import Agent.Skills
 import Data.IORef (newIORef, readIORef)
 import qualified Data.Text as Text
+import Agent.Tools.IO (resolveForRead, resolveUnderCwd)
+import Agent.Tools.Types (defaultToolEnv)
+import Data.Either (isLeft, isRight)
 import Test.Hspec
 
 fromFilePath = unsafeEncodeUtf
@@ -34,6 +37,31 @@ spec = describe "Agent.CLI.Skills" do
                     catalog.catalogSkills
         map (.skillScope) matching `shouldBe` [BuiltinSkill]
         map (.skillModelInvocable) matching `shouldBe` [True]
+
+    it "allows file tools to read packaged skills but not their parent directory" do
+        catalog <- loadSkillsCatalog
+            defaultCliOptions
+            (fromFilePath "/tmp")
+            (fromFilePath "/tmp")
+            (fromFilePath "/tmp")
+            False
+        env <- defaultToolEnv (fromFilePath "/tmp")
+        installSkillToolRoots env catalog
+        telegram <- case
+                filter ((== "telegram-agent") . (.skillName))
+                    catalog.catalogSkills of
+            [skill] -> pure skill
+            skills ->
+                expectationFailure
+                    ("expected one packaged Telegram skill, got "
+                        <> show (length skills))
+                    >> fail "unreachable"
+        resolveForRead env telegram.skillPath
+            >>= (`shouldSatisfy` isRight)
+        resolveForRead env (takeDirectory telegram.skillDirectory)
+            >>= (`shouldSatisfy` isLeft)
+        resolveUnderCwd env telegram.skillPath
+            >>= (`shouldSatisfy` isLeft)
 
     it "loads the packaged add-model skill" do
         catalog <- loadSkillsCatalog

--- a/packages/agent-core/src/Agent/Tools/FileSystem.hs
+++ b/packages/agent-core/src/Agent/Tools/FileSystem.hs
@@ -4,6 +4,7 @@ module Agent.Tools.FileSystem
     , listDirectoryEntries
     , readTextFile
     , renameTextFile
+    , resolveForRead
     , resolveUnderCwd
     , writeTextFile
     ) where
@@ -45,12 +46,28 @@ import System.IO.Error (isDoesNotExistError)
 -- that canonicalizes outside the cwd or an explicitly allowed root, including
 -- via symlinks. Relative paths are always cwd-relative.
 resolveUnderCwd :: ToolEnv -> OsPath -> IO (Either Text OsPath)
-resolveUnderCwd env requested = do
+resolveUnderCwd env requested =
+    resolveWithRoots env requested []
+
+-- | Resolve a read-only tool path, additionally allowing resources belonging
+-- to the current skill catalog. Mutating tools deliberately continue to use
+-- 'resolveUnderCwd', so discovering a user skill does not make it editable.
+resolveForRead :: ToolEnv -> OsPath -> IO (Either Text OsPath)
+resolveForRead env requested = do
+    skillRoots <- readIORef env.toolSkillRoots
+    resolveWithRoots env requested skillRoots
+
+resolveWithRoots
+    :: ToolEnv
+    -> OsPath
+    -> [OsPath]
+    -> IO (Either Text OsPath)
+resolveWithRoots env requested extraRoots = do
     absCwd <- canonicalizePath env.toolCwd
     configuredRoots <- readIORef env.toolAllowedRoots
     sessionTmp <- readIORef env.toolSessionTmp
     allowedRoots <- mapM canonicalizePath
-        (configuredRoots <> maybe [] pure sessionTmp)
+        (configuredRoots <> extraRoots <> maybe [] pure sessionTmp)
     let combined
             | isAbsolute requested = requested
             | otherwise = absCwd </> requested

--- a/packages/agent-core/src/Agent/Tools/FileSystem/Grep.hs
+++ b/packages/agent-core/src/Agent/Tools/FileSystem/Grep.hs
@@ -4,7 +4,7 @@ import Agent.OsPath (fromText, toText, unsafeToFilePath)
 import Agent.ToolArgs (objectArgs, optBool, optInt, optText, reqText)
 import Agent.ToolDSL (PropertySchema(..), PropertyType(..))
 import Agent.ToolDispatch (typedTool)
-import Agent.Tools.IO (resolveUnderCwd)
+import Agent.Tools.IO (resolveForRead)
 import Agent.Tools.Types
     ( AppTool
     , ToolEnv(..)
@@ -99,7 +99,7 @@ grepDescription =
 runGrep :: ToolEnv -> GrepArgs -> IO (Either Text Text)
 runGrep env args = do
     let searchRoot = maybe env.toolCwd fromText args.path
-    resolveUnderCwd env searchRoot >>= \case
+    resolveForRead env searchRoot >>= \case
         Left err -> pure (Left err)
         Right path -> findExecutable "rg" >>= \case
             Nothing -> pure $ Left

--- a/packages/agent-core/src/Agent/Tools/FileSystem/ListDir.hs
+++ b/packages/agent-core/src/Agent/Tools/FileSystem/ListDir.hs
@@ -5,7 +5,7 @@ import Agent.ToolArgs (objectArgs, reqText)
 import Agent.ToolDSL (PropertySchema(..), PropertyType(..))
 import Agent.ToolDispatch (typedTool)
 import Agent.Tools.FileSystem.GitIgnore (isGitIgnored)
-import Agent.Tools.IO (listDirectoryEntries, resolveUnderCwd)
+import Agent.Tools.IO (listDirectoryEntries, resolveForRead)
 import Agent.Tools.Types
     ( AppTool
     , ToolEnv(..)
@@ -48,7 +48,7 @@ maxListItems :: Int
 maxListItems = 200
 
 runListDir :: ToolEnv -> ListDirArgs -> IO (Either Text Text)
-runListDir env args = resolveUnderCwd env (fromText args.targetDirectory) >>= \case
+runListDir env args = resolveForRead env (fromText args.targetDirectory) >>= \case
     Left err -> pure (Left err)
     Right path -> doesDirectoryExist path >>= \case
         False -> pure $ Left $

--- a/packages/agent-core/src/Agent/Tools/FileSystem/ReadFile.hs
+++ b/packages/agent-core/src/Agent/Tools/FileSystem/ReadFile.hs
@@ -4,7 +4,7 @@ import Agent.OsPath (fromText)
 import Agent.ToolArgs (objectArgs, optInt, optText, reqText)
 import Agent.ToolDSL (PropertySchema(..), PropertyType(..))
 import Agent.ToolDispatch (typedTool)
-import Agent.Tools.IO (readTextFile, resolveUnderCwd)
+import Agent.Tools.IO (readTextFile, resolveForRead)
 import Agent.Tools.Types
     ( AppTool
     , ToolEnv
@@ -61,7 +61,7 @@ maxReadTokens :: Int
 maxReadTokens = 25000
 
 runReadFile :: ToolEnv -> ReadFileArgs -> IO (Either Text Text)
-runReadFile env args = resolveUnderCwd env (fromText args.targetFile) >>= \case
+runReadFile env args = resolveForRead env (fromText args.targetFile) >>= \case
     Left err -> pure (Left err)
     Right path
         | ".pdf" `Text.isSuffixOf` Text.toLower args.targetFile ->

--- a/packages/agent-core/src/Agent/Tools/IO.hs
+++ b/packages/agent-core/src/Agent/Tools/IO.hs
@@ -5,6 +5,7 @@ module Agent.Tools.IO
     , combineCommandOutput
     , commandResultOutput
     , formatCommandResult
+    , resolveForRead
     , resolveUnderCwd
     , readTextFile
     , writeTextFile
@@ -32,6 +33,7 @@ import Agent.Tools.FileSystem
     , listDirectoryEntries
     , readTextFile
     , renameTextFile
+    , resolveForRead
     , resolveUnderCwd
     , writeTextFile
     )

--- a/packages/agent-core/src/Agent/Tools/Types.hs
+++ b/packages/agent-core/src/Agent/Tools/Types.hs
@@ -6,6 +6,7 @@ module Agent.Tools.Types
     , ToolRegistry
     , ToolEnv(..)
     , defaultToolEnv
+    , setToolSkillRoots
     , setToolSessionTmp
     , jsonTool
     , jsonAppTool
@@ -88,6 +89,10 @@ data ToolEnv = ToolEnv
     , toolAllowedRoots :: !(IORef [OsPath])
       -- | Additional non-session filesystem roots. The current
       -- 'toolSessionTmp' is always allowed implicitly.
+    , toolSkillRoots :: !(IORef [OsPath])
+      -- | Directories belonging to the currently discovered skill catalog.
+      -- Kept separate so catalog refreshes can replace them without
+      -- disturbing other explicitly allowed roots.
     , toolSessionTmp :: !(IORef (Maybe OsPath))
     , toolStdoutCap :: !Int
       -- | Soft-cancel latch for the active turn. Shell tools race against it.
@@ -98,14 +103,20 @@ defaultToolEnv :: OsPath -> IO ToolEnv
 defaultToolEnv cwd = do
     cancel <- newCancelFlag
     allowedRoots <- newIORef []
+    skillRoots <- newIORef []
     sessionTmp <- newIORef Nothing
     pure ToolEnv
         { toolCwd = dropTrailingPathSeparator cwd
         , toolAllowedRoots = allowedRoots
+        , toolSkillRoots = skillRoots
         , toolSessionTmp = sessionTmp
         , toolStdoutCap = 100000
         , toolCancel = cancel
         }
+
+-- | Replace the directories exposed for the current skill catalog.
+setToolSkillRoots :: ToolEnv -> [OsPath] -> IO ()
+setToolSkillRoots env = writeIORef env.toolSkillRoots
 
 -- | Change the private scratch directory used by subsequent filesystem and
 -- shell calls. The resolver treats this value as an allowed root directly, so


### PR DESCRIPTION
## Summary
- expose discovered skill directories to read-only filesystem tools
- keep mutating tools confined to existing writable roots
- refresh skill roots with the catalog and propagate them to child agents

## Tests
- `nix develop -c cabal test agent-cli:test:agent-cli-test --test-options=--match Agent.CLI.Skills --test-show-details=direct`
- `nix develop -c cabal test agent-core:test:agent-core-test --test-options=--match Agent.Tools.IO --test-show-details=direct`
- `git diff --check`