### PR TITLE
Add progressive MCP startup and meta tools

### DIFF
--- a/packages/agent-core/benchmark/McpStartup.hs
+++ b/packages/agent-core/benchmark/McpStartup.hs
@@ -1,14 +1,19 @@
 module Main (main) where
 
 import Agent.MCP
-    ( McpServerConfig(..)
+    ( McpFleet
+    , McpInitState(..)
+    , McpServerConfig(..)
+    , McpServerStatus(..)
     , McpServerStatus(..)
     , closeMcpFleet
     , mcpFleetStatuses
     , mcpFleetTools
     , startMcpFleet
+    , startMcpFleetProgressive
     )
 import Control.Exception.Safe (bracket)
+import Control.Concurrent (threadDelay)
 import Control.Monad (forM)
 import qualified Data.ByteString.Lazy.Char8 as LBS8
 import Data.List (sort)
@@ -27,6 +32,8 @@ data Workload
     = Sequential
     | LegacyToolInspection
     | LifecycleStatusInspection
+    | ProgressiveReady
+    | ProgressiveSettled
 
 data Sample = Sample
     { wallMillis :: !Double
@@ -60,13 +67,15 @@ main =
         _ ->
             die $
                 "usage: mcp-startup-bench WORKLOAD SERVERS DELAY_MS SAMPLES\n"
-                    <> "workloads: sequential, legacy-tools, lifecycle-status"
+                    <> "workloads: sequential, legacy-tools, lifecycle-status, progressive-ready, progressive-settled"
 
 parseWorkload :: String -> IO Workload
 parseWorkload = \case
     "sequential" -> pure Sequential
     "legacy-tools" -> pure LegacyToolInspection
     "lifecycle-status" -> pure LifecycleStatusInspection
+    "progressive-ready" -> pure ProgressiveReady
+    "progressive-settled" -> pure ProgressiveSettled
     other -> die ("unknown workload: " <> other)
 
 parsePositive :: String -> String -> IO Int
@@ -99,6 +108,27 @@ runWorkload workload configs = case workload of
             (\fleet -> do
                 statuses <- mcpFleetStatuses fleet
                 pure (sum (map (.mcpStatusToolCount) statuses)))
+    ProgressiveReady ->
+        bracket
+            (startMcpFleetProgressive (const (pure ())) configs)
+            closeMcpFleet
+            (\fleet -> length <$> mcpFleetStatuses fleet)
+    ProgressiveSettled ->
+        bracket
+            (startMcpFleetProgressive (const (pure ())) configs)
+            closeMcpFleet
+            awaitSettled
+
+awaitSettled :: McpFleet -> IO Int
+awaitSettled fleet = do
+    statuses <- mcpFleetStatuses fleet
+    if any isActive statuses
+        then threadDelay 1000 >> awaitSettled fleet
+        else pure (sum (map (.mcpStatusToolCount) statuses))
+  where
+    isActive :: McpServerStatus -> Bool
+    isActive status =
+        status.mcpStatusState `elem` [McpPending, McpInitializing]
 
 measure :: IO Int -> IO Sample
 measure action = do

--- a/packages/agent-core/src/Agent/MCP.hs
+++ b/packages/agent-core/src/Agent/MCP.hs
@@ -12,8 +12,10 @@ module Agent.MCP
     , McpFleet(..)
     , startMcpFleet
     , startMcpFleetWithProgress
+    , startMcpFleetProgressive
     , closeMcpFleet
     , mcpFleetTools
+    , mcpFleetMetaTools
     , mcpFleetStatuses
     , normalizeMcpToolResult
     ) where
@@ -33,14 +35,21 @@ import Control.Concurrent.Async
     , mapConcurrently
     , waitCatch
     )
+import Control.Concurrent.QSem
+    ( newQSem
+    , signalQSem
+    , waitQSem
+    )
 import Control.Concurrent.MVar
     ( MVar
+    , modifyMVar
     , modifyMVar_
     , newMVar
     , withMVar
     )
 import Control.Concurrent.STM
-    ( TMVar
+    ( STM
+    , TMVar
     , TVar
     , atomically
     , modifyTVar'
@@ -57,13 +66,14 @@ import Control.Concurrent.STM
 import Control.Exception.Safe
     ( SomeException
     , displayException
+    , bracket_
     , finally
     , mask
     , onException
     , throwIO
     , tryAny
     )
-import Control.Monad (unless, void, when)
+import Control.Monad (forM, unless, void, when)
 import Data.Aeson
     ( FromJSON(..)
     , Value(..)
@@ -145,6 +155,11 @@ data McpToolRegistration = McpToolRegistration
     , mcpRegistrationTool :: !AppTool
     }
 
+data McpCatalogEntry = McpCatalogEntry
+    { catalogClient :: !McpClient
+    , catalogTool :: !McpTool
+    }
+
 -- | Initialization state exposed to status and UI code. Reading this state
 -- never starts a process, performs a handshake, or sends an MCP request.
 data McpInitState
@@ -167,6 +182,8 @@ data McpFleet = McpFleet
     , mcpFleetClients :: ![McpClient]
     , mcpFleetServerOrder :: ![Text]
     , mcpFleetFailures :: !(Map.Map Text Text)
+    , mcpFleetCatalog :: !(TVar (Map.Map Text McpCatalogEntry))
+    , mcpFleetWorkers :: !(MVar [Async ()])
     , mcpFleetClosed :: !(MVar Bool)
     }
 
@@ -281,6 +298,14 @@ startMcpFleetWithProgress reportActive configs = mask \restore -> do
             `onException` closeOwnedClients ownedClients
     let (clients, registrations, warnings, failures) =
             foldr collectServerResult ([], [], [], Map.empty) results
+    catalog <- newTVarIO $
+        Map.fromList
+            [ (registration.mcpRegistrationTool.appToolName, McpCatalogEntry client tool)
+            | Right (client, tools, _) <- results
+            , tool <- tools
+            , let registration = registrationFor client tool
+            ]
+    workers <- newMVar []
     let
         fleet = McpFleet
             { mcpFleetRegistrations = registrations
@@ -288,6 +313,8 @@ startMcpFleetWithProgress reportActive configs = mask \restore -> do
             , mcpFleetClients = clients
             , mcpFleetServerOrder = map (.mcpServerName) configs
             , mcpFleetFailures = failures
+            , mcpFleetCatalog = catalog
+            , mcpFleetWorkers = workers
             , mcpFleetClosed = closed
             }
     pure fleet
@@ -385,12 +412,277 @@ validateServerNames = go Set.empty
         | otherwise =
             go (Set.insert config.mcpServerName seen) rest
 
+-- | Spawn configured stdio clients with bounded concurrency, then initialize
+-- and discover each server in tracked background workers. The fleet can be
+-- used immediately through 'mcpFleetMetaTools'.
+startMcpFleetProgressive
+    :: ([McpServerStatus] -> IO ())
+    -> [McpServerConfig]
+    -> IO McpFleet
+startMcpFleetProgressive reportStatuses configs = mask \restore -> do
+    validateServerNames configs
+    closed <- newMVar False
+    workers <- newMVar []
+    catalog <- newTVarIO Map.empty
+    ownedClients <- newIORef []
+    semaphore <- newQSem progressiveSpawnLimit
+    spawnResults <-
+        restore
+            (mapConcurrently
+                (startClientTracked ownedClients semaphore)
+                configs)
+            `onException` closeOwnedClients ownedClients
+    let clients =
+            [ client
+            | Right client <- spawnResults
+            ]
+        failures =
+            Map.fromList
+                [ (config.mcpServerName, err)
+                | (config, Left exception) <- zip configs spawnResults
+                , let err =
+                        redactConfiguredValues config
+                            (exceptionSummary exception)
+                ]
+        warnings =
+            [ "MCP server "
+                <> config.mcpServerName
+                <> " failed to start: "
+                <> err
+            | config <- configs
+            , Just err <- [Map.lookup config.mcpServerName failures]
+            ]
+        fleet = McpFleet
+            { mcpFleetRegistrations = []
+            , mcpFleetWarnings = warnings
+            , mcpFleetClients = clients
+            , mcpFleetServerOrder = map (.mcpServerName) configs
+            , mcpFleetFailures = failures
+            , mcpFleetCatalog = catalog
+            , mcpFleetWorkers = workers
+            , mcpFleetClosed = closed
+            }
+        initializeOne client = do
+            void (reportFleetStatuses reportStatuses fleet)
+            ensureMcpClientReadyWith
+                (publishCatalogEntries catalog client)
+                client >>= \case
+                Left _ -> pure ()
+                Right _ -> pure ()
+            void (reportFleetStatuses reportStatuses fleet)
+    spawned <- newIORef []
+    started <-
+        (forM clients \client -> do
+            worker <-
+                asyncWithUnmask \unmask ->
+                    unmask (initializeOne client)
+            atomicModifyIORef' spawned \current ->
+                (worker : current, ())
+            pure worker)
+            `onException`
+                (readIORef spawned >>= mapM_ stopWorker)
+    modifyMVar_ workers (pure . (started <>))
+    void (reportFleetStatuses reportStatuses fleet)
+    pure fleet
+        `onException` closeMcpFleet fleet
+  where
+    startClientTracked ownedClients semaphore config = mask \restore -> do
+        attempt <-
+            bracket_
+                (waitQSem semaphore)
+                (signalQSem semaphore)
+                (tryAny (restore (startMcpClient config)))
+        case attempt of
+            Left exception -> pure (Left exception)
+            Right client -> do
+                atomicModifyIORef' ownedClients \clients ->
+                    (client : clients, ())
+                pure (Right client)
+
+    closeOwnedClients ownedClients =
+        atomicModifyIORef' ownedClients (\clients -> ([], clients))
+            >>= mapM_ closeMcpClient
+
+    publishCatalogEntries catalog client tools =
+        modifyTVar' catalog \current ->
+            foldl
+                (\entries tool ->
+                    Map.insert
+                        (qualifiedMcpToolName
+                            client.clientConfig.mcpServerName
+                            tool.discoveredName)
+                        (McpCatalogEntry client tool)
+                        entries)
+                current
+                tools
+
+progressiveSpawnLimit :: Int
+progressiveSpawnLimit = 8
+
+reportFleetStatuses
+    :: ([McpServerStatus] -> IO ())
+    -> McpFleet
+    -> IO [McpServerStatus]
+reportFleetStatuses report fleet = do
+    statuses <- mcpFleetStatuses fleet
+    void (tryAny (report statuses))
+    pure statuses
+
+-- | Stable concise MCP tools backed by the fleet's background-populated
+-- catalog. These schemas do not change as servers become ready.
+mcpFleetMetaTools :: McpFleet -> [AppTool]
+mcpFleetMetaTools fleet =
+    [ mcpSearchTool fleet
+    , mcpCallTool fleet
+    ]
+
+mcpSearchTool :: McpFleet -> AppTool
+mcpSearchTool fleet = AppTool
+    { appToolName = "mcp_search"
+    , appToolDescription =
+        "Search currently available MCP tools. Servers may still be connecting."
+    , appToolSchema = RawJsonFunctionSchema $ object
+        [ "type" .= ("object" :: Text)
+        , "properties" .= object
+            [ "query" .= object ["type" .= ("string" :: Text)]
+            , "server" .= object ["type" .= ("string" :: Text)]
+            , "limit" .= object
+                [ "type" .= ("integer" :: Text)
+                , "minimum" .= (1 :: Int)
+                , "maximum" .= (50 :: Int)
+                ]
+            ]
+        , "additionalProperties" .= False
+        ]
+    , appToolHandler = typedTool "mcp_search" \arguments -> do
+        entries <- readTVarIO fleet.mcpFleetCatalog
+        statuses <- mcpFleetStatuses fleet
+        let (query, server, limit) = searchArguments arguments
+            matches :: (Text, McpCatalogEntry) -> Bool
+            matches (name, entry) =
+                maybe True
+                    (\needle ->
+                        Text.toCaseFold needle
+                            `Text.isInfixOf`
+                                Text.toCaseFold
+                                    (name <> " "
+                                        <> entry.catalogTool.discoveredDescription))
+                    query
+                    && maybe True
+                        (== entry.catalogClient.clientConfig.mcpServerName)
+                        server
+            found = take limit (filter matches (Map.toAscList entries))
+            payload = object
+                [ "tools" .=
+                    [ object
+                        [ "name" .= name
+                        , "server" .=
+                            entry.catalogClient.clientConfig.mcpServerName
+                        , "description" .=
+                            entry.catalogTool.discoveredDescription
+                        , "inputSchema" .=
+                            entry.catalogTool.discoveredInputSchema
+                        ]
+                    | (name, entry) <- found
+                    ]
+                , "servers" .= map statusJson statuses
+                ]
+        pure (Right (compactJson payload))
+    , appToolApproval = AlwaysReadOnly
+    , appToolExecution = ParallelSafe
+    }
+
+mcpCallTool :: McpFleet -> AppTool
+mcpCallTool fleet = AppTool
+    { appToolName = "mcp_call"
+    , appToolDescription =
+        "Call a currently available read-only MCP tool by its qualified server__tool name."
+    , appToolSchema = RawJsonFunctionSchema $ object
+        [ "type" .= ("object" :: Text)
+        , "properties" .= object
+            [ "name" .= object ["type" .= ("string" :: Text)]
+            , "arguments" .= object ["type" .= ("object" :: Text)]
+            ]
+        , "required" .= (["name"] :: [Text])
+        , "additionalProperties" .= False
+        ]
+    , appToolHandler = typedTool "mcp_call" \arguments ->
+        case callArguments arguments of
+            Left err -> pure (Left err)
+            Right (name, toolArguments) -> do
+                entries <- readTVarIO fleet.mcpFleetCatalog
+                case Map.lookup name entries of
+                    Just entry ->
+                        callDiscoveredTool
+                            entry.catalogClient
+                            entry.catalogTool
+                            toolArguments
+                    Nothing -> do
+                        statuses <- mcpFleetStatuses fleet
+                        pure . Left $
+                            if any isConnecting statuses
+                                then
+                                    "MCP tool is not available yet; one or more servers are still connecting"
+                                else "Unknown MCP tool: " <> name
+    , appToolApproval = AlwaysReadOnly
+    , appToolExecution = ParallelSafe
+    }
+
+searchArguments :: Value -> (Maybe Text, Maybe Text, Int)
+searchArguments (Object fields) =
+    ( textField "query"
+    , textField "server"
+    , case KeyMap.lookup "limit" fields >>= responseId of
+        Just value -> max 1 (min 50 value)
+        Nothing -> 20
+    )
+  where
+    textField name = case KeyMap.lookup name fields of
+        Just (String value)
+            | not (Text.null (Text.strip value)) -> Just (Text.strip value)
+        _ -> Nothing
+searchArguments _ = (Nothing, Nothing, 20)
+
+callArguments :: Value -> Either Text (Text, Value)
+callArguments (Object fields) =
+    case KeyMap.lookup "name" fields of
+        Just (String name)
+            | not (Text.null (Text.strip name)) ->
+                Right
+                    ( Text.strip name
+                    , maybe (object []) id (KeyMap.lookup "arguments" fields)
+                    )
+        _ -> Left "mcp_call requires a non-empty name"
+callArguments _ = Left "mcp_call arguments must be an object"
+
+statusJson :: McpServerStatus -> Value
+statusJson status = object
+    [ "name" .= status.mcpStatusName
+    , "status" .= case status.mcpStatusState of
+        McpPending -> ("pending" :: Text)
+        McpInitializing -> "initializing"
+        McpReady -> "ready"
+        McpFailed _ -> "failed"
+        McpClosed -> "closed"
+    , "toolCount" .= status.mcpStatusToolCount
+    ]
+
+isConnecting :: McpServerStatus -> Bool
+isConnecting status = case status.mcpStatusState of
+    McpPending -> True
+    McpInitializing -> True
+    _ -> False
+
 closeMcpFleet :: McpFleet -> IO ()
 closeMcpFleet fleet =
     modifyMVar_ fleet.mcpFleetClosed \closed ->
         if closed
             then pure True
             else do
+                activeWorkers <-
+                    modifyMVar fleet.mcpFleetWorkers \workers ->
+                        pure ([], workers)
+                mapM_ stopWorker activeWorkers
                 mapM_ closeMcpClient fleet.mcpFleetClients
                 pure True
 
@@ -464,7 +756,13 @@ data InitializeRole
 ensureMcpClientReady
     :: McpClient
     -> IO (Either Text ([McpTool], [Text]))
-ensureMcpClientReady client = mask \restore -> do
+ensureMcpClientReady = ensureMcpClientReadyWith (const (pure ()))
+
+ensureMcpClientReadyWith
+    :: ([McpTool] -> STM ())
+    -> McpClient
+    -> IO (Either Text ([McpTool], [Text]))
+ensureMcpClientReadyWith publishReady client = mask \restore -> do
     role <- atomically do
         readTVar client.clientLifecycle >>= \case
             ClientPending -> do
@@ -520,10 +818,14 @@ ensureMcpClientReady client = mask \restore -> do
                                 (Left "MCP server closed")
                     ClientInitializing current
                         | current == completion -> do
-                            writeTVar client.clientLifecycle case result of
-                                Left err -> ClientFailed err
-                                Right (tools, warnings) ->
-                                    ClientReady tools warnings
+                            case result of
+                                Left err ->
+                                    writeTVar client.clientLifecycle
+                                        (ClientFailed err)
+                                Right (tools, warnings) -> do
+                                    publishReady tools
+                                    writeTVar client.clientLifecycle
+                                        (ClientReady tools warnings)
                             void (tryPutTMVar completion result)
                     _ -> void (tryPutTMVar completion result)
             pure result
@@ -620,16 +922,7 @@ appToolFor client tool = AppTool
     , appToolSchema = RawJsonFunctionSchema tool.discoveredInputSchema
     , appToolHandler =
         typedTool qualifiedName \arguments -> do
-            let parameters = object
-                    [ "name" .= tool.discoveredName
-                    , "arguments" .= (arguments :: Value)
-                    ]
-                timeoutMicros =
-                    secondsToMicros
-                        client.clientConfig.mcpServerRequestTimeoutSeconds
-            requestMcp client timeoutMicros "tools/call" parameters >>= \case
-                Left err -> pure (Left err)
-                Right result -> pure (normalizeMcpToolResult result)
+            callDiscoveredTool client tool arguments
     , appToolApproval = AlwaysReadOnly
     , appToolExecution = ParallelSafe
     }
@@ -645,6 +938,19 @@ qualifiedMcpToolName serverName toolName =
     escapeComponent =
         Text.replace "__" "%5F%5F"
             . Text.replace "%" "%25"
+
+callDiscoveredTool :: McpClient -> McpTool -> Value -> IO (Either Text Text)
+callDiscoveredTool client tool arguments = do
+    let parameters = object
+            [ "name" .= tool.discoveredName
+            , "arguments" .= arguments
+            ]
+        timeoutMicros =
+            secondsToMicros
+                client.clientConfig.mcpServerRequestTimeoutSeconds
+    requestMcp client timeoutMicros "tools/call" parameters >>= \case
+        Left err -> pure (Left err)
+        Right result -> pure (normalizeMcpToolResult result)
 
 normalizeMcpToolResult :: Value -> Either Text Text
 normalizeMcpToolResult result@(Object fields) =

--- a/packages/agent-core/test/Agent/MCPSpec.hs
+++ b/packages/agent-core/test/Agent/MCPSpec.hs
@@ -166,6 +166,76 @@ spec = describe "Agent.MCP" do
                         , "a%5F%5Fshared__shared_read"
                         ]
 
+    it "returns a progressive fleet before handshake completion and publishes meta-tools" $
+        withDelayedFakeServer \script -> do
+            progress <- newIORef []
+            fleet <- startMcpFleetProgressive
+                (\statuses -> modifyIORef' progress (<> [statuses]))
+                [progressiveConfig script "0.2" "slow"]
+            bracket (pure fleet) closeMcpFleet \_ -> do
+                initial <- mcpFleetStatuses fleet
+                case initial of
+                    [McpServerStatus "slow" state 0] ->
+                        state `shouldSatisfy`
+                            (`elem` [McpPending, McpInitializing])
+                    _ -> expectationFailure ("unexpected initial status: " <> show initial)
+                let tools = mcpFleetMetaTools fleet
+                    dispatch ident name arguments = dispatchToolCall
+                        defaultLoopDispatch
+                        (appToolHandlers tools)
+                        (functionToolCall ident name arguments)
+                early <- dispatch "early" "mcp_call"
+                    "{\"name\":\"slow__delayed_read\",\"arguments\":{}}"
+                early.output `shouldSatisfy`
+                    Text.isInfixOf "still connecting"
+                waitUntilReady fleet
+                searched <- dispatch "search" "mcp_search"
+                    "{\"query\":\"delayed\"}"
+                searched.output `shouldSatisfy`
+                    Text.isInfixOf "slow__delayed_read"
+                called <- dispatch "call" "mcp_call"
+                    "{\"name\":\"slow__delayed_read\",\"arguments\":{}}"
+                called.output `shouldBe` "delayed response"
+                updates <- readIORef progress
+                updates `shouldSatisfy` (not . null)
+
+    it "publishes a fast server before a slow progressive peer settles" $
+        withDelayedFakeServer \script -> do
+            fleet <- startMcpFleetProgressive
+                (const (pure ()))
+                [ progressiveConfig script "0.02" "fast"
+                , progressiveConfig script "0.5" "slow"
+                ]
+            bracket (pure fleet) closeMcpFleet \_ -> do
+                waitForServerReady fleet "fast"
+                statuses <- mcpFleetStatuses fleet
+                find ((== "slow") . (.mcpStatusName)) statuses
+                    `shouldSatisfy`
+                        maybe False
+                            ((`elem` [McpPending, McpInitializing])
+                                . (.mcpStatusState))
+                let tools = mcpFleetMetaTools fleet
+                searched <- dispatchToolCall
+                    defaultLoopDispatch
+                    (appToolHandlers tools)
+                    (functionToolCall "search-fast" "mcp_search"
+                        "{\"server\":\"fast\"}")
+                searched.output `shouldSatisfy`
+                    Text.isInfixOf "fast__delayed_read"
+
+    it "reports a handshake failure after successful process construction" do
+        let config =
+                (baseConfig "exits" "/bin/sh")
+                    { mcpServerArgs = ["-c", "exit 1"]
+                    }
+        fleet <- startMcpFleetProgressive (const (pure ())) [config]
+        bracket (pure fleet) closeMcpFleet \_ -> do
+            waitForServerFailure fleet "exits"
+            statuses <- mcpFleetStatuses fleet
+            case statuses of
+                [McpServerStatus "exits" (McpFailed _) 0] -> pure ()
+                _ -> expectationFailure ("unexpected statuses: " <> show statuses)
+
 withFakeServer :: (FilePath -> IO a) -> IO a
 withFakeServer action = do
     temporary <- getTemporaryDirectory
@@ -189,6 +259,12 @@ concurrentConfig script barrier name = McpServerConfig
     , mcpServerStartupTimeoutSeconds = 2
     , mcpServerRequestTimeoutSeconds = 2
     }
+
+progressiveConfig :: FilePath -> String -> Text.Text -> McpServerConfig
+progressiveConfig script delay name =
+    (baseConfig name script)
+        { mcpServerArgs = [delay]
+        }
 
 baseConfig :: Text.Text -> FilePath -> McpServerConfig
 baseConfig name command = McpServerConfig
@@ -222,6 +298,52 @@ withConcurrentFakeServer action = do
             removeDirectoryRecursive barrier)
         (uncurry action)
 
+withDelayedFakeServer :: (FilePath -> IO a) -> IO a
+withDelayedFakeServer action = do
+    temporary <- getTemporaryDirectory
+    bracket
+        (do
+            (path, handle) <- openTempFile temporary "agent-mcp-delayed.sh"
+            LBS.hPutStr handle delayedFakeServer
+            hClose handle
+            setFileMode path 0o700
+            pure path)
+        removeFile
+        action
+
+waitUntilReady :: McpFleet -> IO ()
+waitUntilReady fleet = waitForServerReady fleet "slow"
+
+waitForServerReady :: McpFleet -> Text.Text -> IO ()
+waitForServerReady fleet name = go (200 :: Int)
+  where
+    go 0 = expectationFailure "MCP server did not become ready"
+    go remaining = do
+        statuses <- mcpFleetStatuses fleet
+        if any
+            (\status ->
+                status.mcpStatusName == name
+                    && status.mcpStatusState == McpReady)
+            statuses
+            then pure ()
+            else threadDelay 10000 >> go (remaining - 1)
+
+waitForServerFailure :: McpFleet -> Text.Text -> IO ()
+waitForServerFailure fleet name = go (200 :: Int)
+  where
+    go 0 = expectationFailure "MCP server did not fail"
+    go remaining = do
+        statuses <- mcpFleetStatuses fleet
+        if any
+            (\status ->
+                status.mcpStatusName == name
+                    && case status.mcpStatusState of
+                        McpFailed _ -> True
+                        _ -> False)
+            statuses
+            then pure ()
+            else threadDelay 10000 >> go (remaining - 1)
+
 fakeServer :: LBS.ByteString
 fakeServer =
     "#!/bin/sh\n\
@@ -241,6 +363,26 @@ fakeServer =
     \        printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":4,\"result\":{\"content\":[{\"type\":\"text\",\"text\":\"second response\"}]}}'\n\
     \        printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":3,\"result\":{\"content\":[{\"type\":\"text\",\"text\":\"first response\"}]}}'\n\
     \      fi\n\
+    \      ;;\n\
+    \  esac\n\
+    \done\n"
+
+delayedFakeServer :: LBS.ByteString
+delayedFakeServer =
+    "#!/bin/sh\n\
+    \delay=\"$1\"\n\
+    \while IFS= read -r line; do\n\
+    \  case \"$line\" in\n\
+    \    *'\"method\":\"initialize\"'*)\n\
+    \      sleep \"$delay\"\n\
+    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"protocolVersion\":\"2025-11-25\",\"capabilities\":{},\"serverInfo\":{\"name\":\"delayed\",\"version\":\"1\"}}}'\n\
+    \      ;;\n\
+    \    *'\"method\":\"notifications/initialized\"'*) ;;\n\
+    \    *'\"method\":\"tools/list\"'*)\n\
+    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":2,\"result\":{\"tools\":[{\"name\":\"delayed_read\",\"description\":\"Delayed read.\",\"inputSchema\":{\"type\":\"object\"},\"annotations\":{\"readOnlyHint\":true}}]}}'\n\
+    \      ;;\n\
+    \    *'\"method\":\"tools/call\"'*)\n\
+    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":3,\"result\":{\"content\":[{\"type\":\"text\",\"text\":\"delayed response\"}]}}'\n\
     \      ;;\n\
     \  esac\n\
     \done\n"


### PR DESCRIPTION
## Summary
- return a progressive MCP fleet after bounded concurrent process spawn instead of waiting for every handshake
- initialize servers in owned background workers and publish each server's catalog incrementally
- expose stable `mcp_search` and `mcp_call` tools while servers connect
- preserve per-server failure isolation and deterministic status reporting
- extend the optimized startup benchmark with prompt-ready and settled workloads

## Validation
- `nix develop -c cabal test --offline agent-core-test` (300 examples, 0 failures on the full stack)
- 4 servers, 200 ms delay, median of 7: progressive-ready 62.919 ms; settled 271.160 ms; blocking fleet 271.456 ms
- 8 servers, 100 ms delay, median of 7: progressive-ready 128.164 ms; settled 239.285 ms; blocking fleet 239.596 ms

Stack 2/4; depends on #391.