### PR TITLE
Use progressive MCP startup in interactive CLI sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ Configure local stdio MCP servers in `~/.haskell-agent/config.json`:
 ```json
 {
   "version": 1,
+  "mcpInitStrategy": "auto",
   "mcpServers": {
     "seo-mcp": {
       "command": "nix",
@@ -287,10 +288,16 @@ server, Space to enable or disable it, `x` to remove it, and `r` to restart the
 MCP runtime. Saved changes restart the runtime while resuming the same session.
 Environment variable values are never displayed.
 
+`mcpInitStrategy` accepts `auto`, `progressive`, or `blocking`. `auto`
+starts MCP servers progressively for interactive sessions so the prompt is
+available immediately, while one-shot commands wait for MCP initialization.
+
 The harness starts enabled servers once per root session and shares their tools
-with subagents. MCP tool names are preserved, so they must not collide with
-built-in or other configured tools. Only tools explicitly annotated
-`readOnlyHint: true` are exposed.
+with subagents. Blocking startup exposes read-only tools as
+`server__tool`. Progressive startup exposes stable `mcp_search` and `mcp_call`
+tools immediately, then publishes each server's read-only catalog as it
+becomes ready. Only tools explicitly annotated `readOnlyHint: true` are
+available.
 
 ### Secret entry
 

--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -9,6 +9,8 @@ module Agent.CLI
     , devArgs
     , devMain
     , devMainResume
+    , formatMcpModelNotice
+    , formatMcpProgress
     , formatReplStatusLine
     , formatRepositoryPath
     , formatStartupTimings
@@ -93,6 +95,7 @@ import Agent.CLI.Config
     ( HarnessConfig(..)
     , McpServerConfig(..)
     , loadHarnessConfig
+    , useProgressiveMcp
     )
 import Agent.CLI.Compaction
     ( CompactOutcome(..)
@@ -512,7 +515,7 @@ import Control.Exception.Safe
     , throwIO
     , try
     )
-import Control.Monad (forM_, void, when)
+import Control.Monad (forM_, unless, void, when)
 import qualified Data.ByteString as BS
 import Data.IORef
 import Data.List (elemIndex, findIndex, sortOn)
@@ -626,6 +629,7 @@ data StartupRuntime = StartupRuntime
     , startupStartedAt :: !UTCTime
     , startupTimings :: !(IORef [(Text, NominalDiffTime)])
     , startupSyntaxLoadDuration :: !(IORef (Maybe NominalDiffTime))
+    , startupFinished :: !(IORef Bool)
     , startupSessionState :: !SessionState
     }
 
@@ -863,6 +867,7 @@ markStartupStage startup label = do
 
 finishStartup :: StartupRuntime -> IO ()
 finishStartup startup = do
+    writeIORef startup.startupFinished True
     recordStartupTiming startup.startupStartedAt startup.startupTimings "ready"
     case startup.startupFullscreen of
         Nothing -> pure ()
@@ -1022,6 +1027,7 @@ prepareAgentIteration
     startedAt <- getCurrentTime
     startupTimingsRef <- newIORef []
     syntaxLoadDurationRef <- newIORef Nothing
+    startupFinishedRef <- newIORef False
     home <- getHomeDirectory
     let root = sessionsRoot home
     resumed <- case options.optResume of
@@ -1210,6 +1216,7 @@ prepareAgentIteration
                         , startupStartedAt = startedAt
                         , startupTimings = startupTimingsRef
                         , startupSyntaxLoadDuration = syntaxLoadDurationRef
+                        , startupFinished = startupFinishedRef
                         , startupSessionState = sessionState
                         }
                 runAgentInitialized
@@ -1933,18 +1940,48 @@ runAgentInitializedWithLock
                 Map.toAscList harnessConfig.configMcpServers
             , config.mcpEnabled
             ]
+        progressiveMcp =
+            useProgressiveMcp
+                harnessConfig.configMcpInitStrategy
+                (isOneShot options)
+    mcpStatusPhaseRef <- newIORef (Nothing :: Maybe Bool)
+    let reportProgressiveMcp statuses = do
+            finished <- readIORef startup.startupFinished
+            unless finished do
+                setStartupNotice startup.startupFullscreen
+                    (formatMcpProgress statuses)
+                -- A callback can race with finishStartup between the read and
+                -- the UI update. Clear a late notice if startup won the race.
+                readIORef startup.startupFinished >>= \nowFinished ->
+                    when nowFinished $
+                        forM_ startup.startupFullscreen \runtime ->
+                            emitUiEvent runtime (UiSetNotice Nothing)
+            let (connecting, _, _) = summarizeMcpStatuses statuses
+                isConnecting = connecting > 0
+            settled <-
+                atomicModifyIORef' mcpStatusPhaseRef \previous ->
+                    (Just isConnecting, previous == Just True && not isConnecting)
+            when (settled && not (null statuses)) $
+                atomicModifyIORef' pendingNotices \notices ->
+                    (notices <> [UserMessage (formatMcpModelNotice statuses)], ())
     mcpFleet <-
         try @_ @SomeException
-            (MCP.startMcpFleetWithProgress
-                (\names ->
-                    setStartupNotice startup.startupFullscreen
-                        (if null names
-                            then "Loading built-in tools…"
-                            else
-                                "Loading tools: "
-                                    <> Text.intercalate ", " names
-                                    <> "…"))
-                mcpServerConfigs)
+            (if progressiveMcp
+                then
+                    MCP.startMcpFleetProgressive
+                        reportProgressiveMcp
+                        mcpServerConfigs
+                else
+                    MCP.startMcpFleetWithProgress
+                        (\names ->
+                            setStartupNotice startup.startupFullscreen
+                                (if null names
+                                    then "Loading built-in tools…"
+                                    else
+                                        "Loading tools: "
+                                            <> Text.intercalate ", " names
+                                            <> "…"))
+                        mcpServerConfigs)
             >>= \case
             Left exception ->
                 startupDie startup
@@ -2012,7 +2049,10 @@ runAgentInitializedWithLock
             , toolsSessionStatus =
                 sessionProcessStatus sessionProcessManager
             }
-        mcpTools = MCP.mcpFleetTools mcpFleet
+        mcpTools =
+            if progressiveMcp && not (null mcpServerConfigs)
+                then MCP.mcpFleetMetaTools mcpFleet
+                else MCP.mcpFleetTools mcpFleet
         sessionTools = agentSessionTools sessionToolsEnv
         allTools = coding.codingAppTools ++ mcpTools ++ sessionTools
         tools =
@@ -2780,6 +2820,78 @@ printResumeHint progName = \case
 
 shouldPersist :: CliOptions -> Bool
 shouldPersist options = not (isOneShot options) || options.optSaveSession
+
+summarizeMcpStatuses :: [MCP.McpServerStatus] -> (Int, Int, Int)
+summarizeMcpStatuses statuses =
+    ( length (filter isConnecting statuses)
+    , length (filter isReady statuses)
+    , length (filter isFailed statuses)
+    )
+  where
+    isConnecting status = case status.mcpStatusState of
+        MCP.McpPending -> True
+        MCP.McpInitializing -> True
+        _ -> False
+    isReady status = status.mcpStatusState == MCP.McpReady
+    isFailed status = case status.mcpStatusState of
+        MCP.McpFailed _ -> True
+        _ -> False
+
+formatMcpProgress :: [MCP.McpServerStatus] -> Text
+formatMcpProgress statuses =
+    let (connecting, ready, failed) = summarizeMcpStatuses statuses
+    in if null statuses || connecting == 0
+        then
+            "Loading built-in tools…"
+                <> if ready + failed == 0
+                    then ""
+                    else
+                        " MCP: "
+                            <> Text.pack (show ready)
+                            <> " ready"
+                            <> if failed == 0
+                                then ""
+                                else
+                                    ", "
+                                        <> Text.pack (show failed)
+                                        <> " unavailable"
+        else
+            "Loading built-in tools… MCP: "
+                <> Text.pack (show connecting)
+                <> " connecting, "
+                <> Text.pack (show ready)
+                <> " ready"
+
+formatMcpModelNotice :: [MCP.McpServerStatus] -> Text
+formatMcpModelNotice statuses =
+    let connecting =
+            [ status.mcpStatusName
+            | status <- statuses
+            , status.mcpStatusState
+                `elem` [MCP.McpPending, MCP.McpInitializing]
+            ]
+        ready =
+            [ status.mcpStatusName
+            | status <- statuses
+            , status.mcpStatusState == MCP.McpReady
+            ]
+        failed =
+            [ status.mcpStatusName
+            | status <- statuses
+            , case status.mcpStatusState of
+                MCP.McpFailed _ -> True
+                _ -> False
+            ]
+    in "<system-reminder>MCP status changed. "
+        <> statusPart "Connecting" connecting
+        <> statusPart "Ready" ready
+        <> statusPart "Unavailable" failed
+        <> "Use mcp_search to discover currently available MCP tools and "
+        <> "mcp_call to invoke one by its server__tool name.</system-reminder>"
+  where
+    statusPart _ [] = ""
+    statusPart label names =
+        label <> ": " <> Text.intercalate ", " names <> ". "
 
 isJustCwd :: CliOptions -> Bool
 isJustCwd options = case options.optCwd of

--- a/packages/agent-cli/src/Agent/CLI/Config.hs
+++ b/packages/agent-cli/src/Agent/CLI/Config.hs
@@ -2,11 +2,13 @@
 -- @~/.haskell-agent/config.json@.
 module Agent.CLI.Config
     ( HarnessConfig(..)
+    , McpInitStrategy(..)
     , McpServerConfig(..)
     , defaultHarnessConfig
     , harnessConfigPath
     , loadHarnessConfig
     , saveHarnessConfig
+    , useProgressiveMcp
     ) where
 
 import Agent.FileRetry (retryOnFileBusy, writeLazyFileAtomically)
@@ -15,6 +17,7 @@ import Control.Exception.Safe (displayException, tryIO)
 import Control.Monad (unless, when)
 import Data.Aeson
     ( FromJSON(..)
+    , withText
     , withObject
     , (.:)
     , (.:?)
@@ -52,6 +55,31 @@ data McpServerConfig = McpServerConfig
     }
     deriving (Eq)
 
+data McpInitStrategy
+    = McpInitAuto
+    | McpInitProgressive
+    | McpInitBlocking
+    deriving (Eq, Show)
+
+-- | Resolve the configured MCP startup policy for the current invocation.
+-- Interactive sessions favor prompt availability, while one-shot commands
+-- preserve deterministic startup unless explicitly overridden.
+useProgressiveMcp :: McpInitStrategy -> Bool -> Bool
+useProgressiveMcp strategy oneShot = case strategy of
+    McpInitAuto -> not oneShot
+    McpInitProgressive -> True
+    McpInitBlocking -> False
+
+instance FromJSON McpInitStrategy where
+    parseJSON = withText "McpInitStrategy" \case
+        "auto" -> pure McpInitAuto
+        "progressive" -> pure McpInitProgressive
+        "blocking" -> pure McpInitBlocking
+        value ->
+            fail
+                ("unknown MCP initialization strategy: "
+                    <> Text.unpack value)
+
 instance Show McpServerConfig where
     show server =
         "McpServerConfig { mcpEnabled = "
@@ -86,6 +114,7 @@ instance Aeson.ToJSON McpServerConfig where
 
 data HarnessConfig = HarnessConfig
     { configVersion :: !Int
+    , configMcpInitStrategy :: !McpInitStrategy
     , configMcpServers :: !(Map Text McpServerConfig)
     }
     deriving (Eq, Show)
@@ -100,6 +129,7 @@ instance Aeson.ToJSON HarnessConfig where
 defaultHarnessConfig :: HarnessConfig
 defaultHarnessConfig = HarnessConfig
     { configVersion = harnessConfigSchemaVersion
+    , configMcpInitStrategy = McpInitAuto
     , configMcpServers = Map.empty
     }
 
@@ -120,6 +150,7 @@ instance FromJSON HarnessConfig where
     parseJSON = withObject "HarnessConfig" \object ->
         HarnessConfig
             <$> object .:? "version" .!= harnessConfigSchemaVersion
+            <*> object .:? "mcpInitStrategy" .!= McpInitAuto
             <*> object .:? "mcpServers" .!= Map.empty
 
 -- | @~/.haskell-agent/config.json@ for a supplied home directory.

--- a/packages/agent-cli/test/Agent/CLI/ConfigSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ConfigSpec.hs
@@ -42,6 +42,7 @@ spec = describe "Agent.CLI.Config" do
             case result of
                 Left err -> expectationFailure (show err)
                 Right config -> do
+                    config.configMcpInitStrategy `shouldBe` McpInitAuto
                     Map.keys config.configMcpServers
                         `shouldBe` ["alpha", "zeta"]
                     Map.lookup "alpha" config.configMcpServers
@@ -64,6 +65,36 @@ spec = describe "Agent.CLI.Config" do
                             , mcpStartupTimeoutSeconds = 30
                             , mcpRequestTimeoutSeconds = 60
                             }
+
+    it "loads the MCP initialization strategy" $
+        withTempDir "agent-config-" \home -> do
+            writeConfig home
+                "{\"mcpInitStrategy\":\"progressive\"}"
+            result <- loadHarnessConfig home
+            fmap (.configMcpInitStrategy) result
+                `shouldBe` Right McpInitProgressive
+
+    it "rejects unknown MCP initialization strategies" $
+        withTempDir "agent-config-" \home -> do
+            writeConfig home
+                "{\"mcpInitStrategy\":\"eventually\"}"
+            result <- loadHarnessConfig home
+            result `shouldSatisfy` \case
+                Left err ->
+                    "unknown MCP initialization strategy"
+                        `Text.isInfixOf` err
+                Right _ -> False
+
+    describe "useProgressiveMcp" do
+        it "uses progressive startup for interactive auto mode" $
+            useProgressiveMcp McpInitAuto False `shouldBe` True
+
+        it "uses blocking startup for one-shot auto mode" $
+            useProgressiveMcp McpInitAuto True `shouldBe` False
+
+        it "honors explicit overrides" do
+            useProgressiveMcp McpInitProgressive True `shouldBe` True
+            useProgressiveMcp McpInitBlocking False `shouldBe` False
 
     it "rejects unsupported versions" $
         withTempDir "agent-config-" \home -> do

--- a/packages/agent-cli/test/Agent/CLI/ReplStatusSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ReplStatusSpec.hs
@@ -8,6 +8,8 @@ import Agent.CLI
     , buildPromptState
     , cycleReplInteraction
     , devArgs
+    , formatMcpModelNotice
+    , formatMcpProgress
     , formatReplStatusLine
     , formatRepositoryPath
     , formatStartupTimings
@@ -31,9 +33,13 @@ import Agent.CLI.ReplMode
     )
 import Agent.Dialect (DialectId(..))
 import Agent.Loop (LoopEvent(..), TokenUsage(..), emptyTokenUsage)
+import Agent.MCP
+    ( McpInitState(..)
+    , McpServerStatus(..)
+    )
 import Agent.Provider (Provider(..))
 import Agent.Responses.Types (defaultResponseCreateParams)
-import System.OsPath (unsafeEncodeUtf)
+import System.OsPath (OsPath, unsafeEncodeUtf)
 import Agent.TUI.Model
     ( PromptState(..)
     , UiEvent(..)
@@ -55,11 +61,34 @@ import System.Directory
 import System.Posix.Temp (mkdtemp)
 import Test.Hspec
 
+fromFilePath :: FilePath -> OsPath
 fromFilePath = unsafeEncodeUtf
+
+mcpStatus :: Text.Text -> McpInitState -> Int -> McpServerStatus
+mcpStatus name state toolCount = McpServerStatus
+    { mcpStatusName = name
+    , mcpStatusState = state
+    , mcpStatusToolCount = toolCount
+    }
 
 spec :: Spec
 spec = do
     catalog <- runIO readPackagedCatalog
+    describe "progressive MCP status" do
+        it "formats connecting and ready startup progress" do
+            formatMcpProgress
+                [mcpStatus "slow" McpInitializing 0]
+                `shouldBe` "Loading built-in tools… MCP: 1 connecting, 0 ready"
+            formatMcpProgress
+                [mcpStatus "fast" McpReady 2, mcpStatus "bad" (McpFailed "boom") 0]
+                `shouldBe` "Loading built-in tools… MCP: 1 ready, 1 unavailable"
+
+        it "gives the model stable discovery and invocation guidance" do
+            formatMcpModelNotice
+                [mcpStatus "fast" McpReady 2, mcpStatus "bad" (McpFailed "boom") 0]
+                `shouldBe`
+                    "<system-reminder>MCP status changed. Ready: fast. Unavailable: bad. Use mcp_search to discover currently available MCP tools and mcp_call to invoke one by its server__tool name.</system-reminder>"
+
     describe "accountSwitchTarget" do
         it "uses the destination provider default when changing provider" do
             let target =


### PR DESCRIPTION
## Summary
- add `auto`, `progressive`, and `blocking` MCP initialization strategies
- default interactive sessions to progressive startup while keeping one-shot runs deterministic
- register stable MCP meta-tools with root and child agents
- surface connecting/ready progress in the CLI and model startup context
- document the new configuration and add config/status regression tests

## Validation
- `nix develop -c cabal test --offline agent-cli-test` (791 examples, 0 failures)
- live tmux validation with a delayed fake MCP in fullscreen and minimal renderers; the prompt remained usable during startup and the session settled cleanly
- core startup benchmarks are recorded in #393

Stack 3/4; depends on #393.