### PR TITLE
Add MCP fleet reuse and reconnect

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,9 @@ with subagents. Blocking startup exposes read-only tools as
 `server__tool`. Progressive startup exposes stable `mcp_search` and `mcp_call`
 tools immediately, then publishes each server's read-only catalog as it
 becomes ready. Only tools explicitly annotated `readOnlyHint: true` are
-available.
+available. Live MCP fleets are reused across provider/session rebuilds when
+their configuration is unchanged. Progressive `mcp_call` invocations also
+restart a failed stdio transport once and retry the read-only call.
 
 ### Secret entry
 

--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -733,14 +733,16 @@ runAgentWithRestarts :: CliOptions -> IO DevResult
 runAgentWithRestarts options = do
     fullscreenInputs <- newFullscreenInputBuffer
     sessionState <- newSessionState
+    mcpSupervisor <- MCP.newMcpSupervisor
     withRestoredCurrentDirectory
-        (go fullscreenInputs sessionState options Nothing)
+        (go mcpSupervisor fullscreenInputs sessionState options Nothing)
+        `finally` MCP.closeMcpSupervisor mcpSupervisor
   where
-    go fullscreenInputs sessionState current transition =
-        runAgent fullscreenInputs sessionState current transition >>= \case
+    go mcpSupervisor fullscreenInputs sessionState current transition =
+        runAgent mcpSupervisor fullscreenInputs sessionState current transition >>= \case
             RunResumeSession sessionId ->
                 newSessionState >>= \nextState ->
-                    go fullscreenInputs nextState
+                    go mcpSupervisor fullscreenInputs nextState
                         current
                             { optProvider = Nothing
                             , optModel = Nothing
@@ -754,7 +756,7 @@ runAgentWithRestarts options = do
                         Nothing
             RunSwitchWorktree path provider model effort ->
                 newSessionState >>= \nextState ->
-                    go fullscreenInputs nextState
+                    go mcpSupervisor fullscreenInputs nextState
                         current
                             { optProvider = Just provider
                             , optModel = Just model
@@ -767,11 +769,11 @@ runAgentWithRestarts options = do
                             }
                         Nothing
             RunSwitchProvider next ->
-                go fullscreenInputs sessionState
+                go mcpSupervisor fullscreenInputs sessionState
                     (applyProviderTransition current next)
                     (Just next)
             RunRestart sessionId ->
-                go fullscreenInputs sessionState
+                go mcpSupervisor fullscreenInputs sessionState
                     (restartSessionOptions current sessionId)
                     Nothing
             RunProviderStartFailed apiError ->
@@ -781,7 +783,7 @@ runAgentWithRestarts options = do
                             continueAutomaticFallback
                                 Nothing failed apiError >>= \case
                                 Just next ->
-                                    go fullscreenInputs sessionState
+                                    go mcpSupervisor fullscreenInputs sessionState
                                         (applyProviderTransition current next)
                                         (Just next)
                                 Nothing -> do
@@ -971,20 +973,22 @@ formatRepositoryPath home cwd
     cwdText = toText cwd
 
 runAgent
-    :: FullscreenInputBuffer
+    :: MCP.McpSupervisor
+    -> FullscreenInputBuffer
     -> SessionState
     -> CliOptions
     -> Maybe ProviderTransition
     -> IO RunResult
-runAgent fullscreenInputs sessionState options transition = do
+runAgent mcpSupervisor fullscreenInputs sessionState options transition = do
     prepared <-
         prepareAgentIteration
-            fullscreenInputs sessionState Nothing options transition
+            mcpSupervisor fullscreenInputs sessionState Nothing options transition
     let runPrepared = case prepared.preparedFullscreen of
             Nothing -> prepared.preparedRun
             Just runtime ->
                 runFullscreen runtime $
                     runFullscreenRestartLoop
+                        mcpSupervisor
                         fullscreenInputs
                         sessionState
                         runtime
@@ -1009,13 +1013,15 @@ runAgent fullscreenInputs sessionState options transition = do
 -- alternate screen until the whole provider-restart chain finishes. Session
 -- resumes still return to 'runAgentWithRestarts' and start a fresh UI.
 prepareAgentIteration
-    :: FullscreenInputBuffer
+    :: MCP.McpSupervisor
+    -> FullscreenInputBuffer
     -> SessionState
     -> Maybe FullscreenRuntime
     -> CliOptions
     -> Maybe ProviderTransition
     -> IO PreparedAgent
 prepareAgentIteration
+        mcpSupervisor
         fullscreenInputs sessionState activeFullscreen options transition = do
     forM_ activeFullscreen resetFullscreenSessionActions
     resumeLockRef <- newIORef (Nothing :: Maybe SessionLock)
@@ -1220,7 +1226,15 @@ prepareAgentIteration
                         , startupSessionState = sessionState
                         }
                 runAgentInitialized
-                    options transition home root resumed resumeLock cwd startup
+                    mcpSupervisor
+                    options
+                    transition
+                    home
+                    root
+                    resumed
+                    resumeLock
+                    cwd
+                    startup
         cleanup = do
             writeIORef uiRuntimeRef Nothing
             writeIORef cancelToolRef (pure ())
@@ -1243,7 +1257,8 @@ resetFullscreenSessionActions runtime =
         (const (pure ()))
 
 runFullscreenRestartLoop
-    :: FullscreenInputBuffer
+    :: MCP.McpSupervisor
+    -> FullscreenInputBuffer
     -> SessionState
     -> FullscreenRuntime
     -> CliOptions
@@ -1251,6 +1266,7 @@ runFullscreenRestartLoop
     -> IO RunResult
     -> IO RunResult
 runFullscreenRestartLoop
+    mcpSupervisor
     fullscreenInputs
     sessionState
     runtime =
@@ -1299,6 +1315,7 @@ runFullscreenRestartLoop
             UiSetNotice (Just (progressNotice "Retrying startup…"))
         try @_ @StartupFailure
             (prepareAgentIteration
+                mcpSupervisor
                 fullscreenInputs
                 sessionState
                 (Just runtime)
@@ -1334,7 +1351,8 @@ runFullscreenRestartLoop
                 _ -> pure RunQuit
 
 runAgentInitialized
-    :: CliOptions
+    :: MCP.McpSupervisor
+    -> CliOptions
     -> Maybe ProviderTransition
     -> OsPath
     -> OsPath
@@ -1343,13 +1361,15 @@ runAgentInitialized
     -> OsPath
     -> StartupRuntime
     -> IO RunResult
-runAgentInitialized options transition home root resumed resumeLock cwd startup =
+runAgentInitialized
+        mcpSupervisor options transition home root resumed resumeLock cwd startup =
     runAgentInitializedWithLock
-        options transition home root resumed resumeLock cwd startup
+        mcpSupervisor options transition home root resumed resumeLock cwd startup
         `onException` mapM_ releaseSessionLock resumeLock
 
 runAgentInitializedWithLock
-    :: CliOptions
+    :: MCP.McpSupervisor
+    -> CliOptions
     -> Maybe ProviderTransition
     -> OsPath
     -> OsPath
@@ -1359,6 +1379,7 @@ runAgentInitializedWithLock
     -> StartupRuntime
     -> IO RunResult
 runAgentInitializedWithLock
+        mcpSupervisor
         options transition home root resumed resumeLock cwd startup = do
     let baseToolEnv = startup.startupToolEnv
         interrupt = startup.startupInterrupt
@@ -1957,7 +1978,9 @@ runAgentInitializedWithLock
                 { MCP.mcpServerName = label
                 , MCP.mcpServerCommand = Text.unpack config.mcpCommand
                 , MCP.mcpServerArgs = map Text.unpack config.mcpArgs
-                , MCP.mcpServerCwd = Text.unpack <$> config.mcpCwd
+                , MCP.mcpServerCwd =
+                    Just $
+                        maybe (unsafeToFilePath cwd) Text.unpack config.mcpCwd
                 , MCP.mcpServerEnv =
                     [ (Text.unpack name, Text.unpack value)
                     | (name, value) <- Map.toAscList config.mcpEnv
@@ -1995,15 +2018,17 @@ runAgentInitializedWithLock
             when (settled && not (null statuses)) $
                 atomicModifyIORef' pendingNotices \notices ->
                     (notices <> [UserMessage (formatMcpModelNotice statuses)], ())
-    mcpFleet <-
+    mcpLease <-
         try @_ @SomeException
             (if progressiveMcp
                 then
-                    MCP.startMcpFleetProgressive
+                    MCP.acquireMcpFleetProgressive
+                        mcpSupervisor
                         reportProgressiveMcp
                         mcpServerConfigs
                 else
-                    MCP.startMcpFleetWithProgress
+                    MCP.acquireMcpFleetWithProgress
+                        mcpSupervisor
                         (\names ->
                             setStartupNotice startup.startupFullscreen
                                 (if null names
@@ -2017,7 +2042,8 @@ runAgentInitializedWithLock
             Left exception ->
                 startupDie startup
                     ("Failed to initialize MCP tools: " <> show exception)
-            Right fleet -> pure fleet
+            Right lease -> pure lease
+    let mcpFleet = mcpLease.mcpLeaseFleet
     mapM_ (reportStartupWarning startup) mcpFleet.mcpFleetWarnings
     setStartupNotice startup.startupFullscreen "Loading built-in tools…"
     coding <-
@@ -2028,7 +2054,8 @@ runAgentInitializedWithLock
             secretHooks
             multiCtx
             agentTypesRef
-            `onException` (MCP.closeMcpFleet mcpFleet >> cleanupScratch)
+            `onException`
+                (MCP.releaseMcpFleetLease mcpLease >> cleanupScratch)
     case multiCtx of
         Just ctx -> do
             setSubagentOnComplete ctx.multiRegistry \agentId status -> do
@@ -2106,7 +2133,7 @@ runAgentInitializedWithLock
                 Nothing -> pure ()
             closeSessionProcessManager sessionProcessManager
             readIORef activeSessionLock >>= mapM_ releaseSessionLock
-            MCP.closeMcpFleet mcpFleet
+            MCP.releaseMcpFleetLease mcpLease
             coding.codingClose
             cleanupScratch
     flip finally closeAll do

--- a/packages/agent-core/benchmark/McpStartup.hs
+++ b/packages/agent-core/benchmark/McpStartup.hs
@@ -2,13 +2,17 @@ module Main (main) where
 
 import Agent.MCP
     ( McpFleet
+    , McpFleetLease(..)
     , McpInitState(..)
     , McpServerConfig(..)
     , McpServerStatus(..)
-    , McpServerStatus(..)
+    , acquireMcpFleet
     , closeMcpFleet
+    , closeMcpSupervisor
     , mcpFleetStatuses
     , mcpFleetTools
+    , newMcpSupervisor
+    , releaseMcpFleetLease
     , startMcpFleet
     , startMcpFleetProgressive
     )
@@ -34,6 +38,7 @@ data Workload
     | LifecycleStatusInspection
     | ProgressiveReady
     | ProgressiveSettled
+    | SupervisorReuse
 
 data Sample = Sample
     { wallMillis :: !Double
@@ -55,7 +60,7 @@ main =
                         ]
                 samples <- forM [1 .. sampleCount] \_ -> do
                     performGC
-                    measure (runWorkload workload configs)
+                    measureWorkload workload configs
                 let medianSample = median samples
                 printf
                     "%s,%d,%d,%.3f,%.3f\n"
@@ -67,7 +72,7 @@ main =
         _ ->
             die $
                 "usage: mcp-startup-bench WORKLOAD SERVERS DELAY_MS SAMPLES\n"
-                    <> "workloads: sequential, legacy-tools, lifecycle-status, progressive-ready, progressive-settled"
+                    <> "workloads: sequential, legacy-tools, lifecycle-status, progressive-ready, progressive-settled, supervisor-reuse"
 
 parseWorkload :: String -> IO Workload
 parseWorkload = \case
@@ -76,6 +81,7 @@ parseWorkload = \case
     "lifecycle-status" -> pure LifecycleStatusInspection
     "progressive-ready" -> pure ProgressiveReady
     "progressive-settled" -> pure ProgressiveSettled
+    "supervisor-reuse" -> pure SupervisorReuse
     other -> die ("unknown workload: " <> other)
 
 parsePositive :: String -> String -> IO Int
@@ -118,6 +124,20 @@ runWorkload workload configs = case workload of
             (startMcpFleetProgressive (const (pure ())) configs)
             closeMcpFleet
             awaitSettled
+    SupervisorReuse ->
+        error "SupervisorReuse is measured with a prewarmed supervisor"
+
+measureWorkload :: Workload -> [McpServerConfig] -> IO Sample
+measureWorkload SupervisorReuse configs =
+    bracket newMcpSupervisor closeMcpSupervisor \supervisor -> do
+        first <- acquireMcpFleet supervisor configs
+        releaseMcpFleetLease first
+        measure do
+            second <- acquireMcpFleet supervisor configs
+            let checksum = length (mcpFleetTools second.mcpLeaseFleet)
+            releaseMcpFleetLease second
+            pure checksum
+measureWorkload workload configs = measure (runWorkload workload configs)
 
 awaitSettled :: McpFleet -> IO Int
 awaitSettled fleet = do

--- a/packages/agent-core/src/Agent/MCP.hs
+++ b/packages/agent-core/src/Agent/MCP.hs
@@ -10,6 +10,14 @@ module Agent.MCP
     , McpServerStatus(..)
     , McpToolRegistration(..)
     , McpFleet(..)
+    , McpSupervisor
+    , McpFleetLease(..)
+    , newMcpSupervisor
+    , acquireMcpFleet
+    , acquireMcpFleetWithProgress
+    , acquireMcpFleetProgressive
+    , releaseMcpFleetLease
+    , closeMcpSupervisor
     , startMcpFleet
     , startMcpFleetWithProgress
     , startMcpFleetProgressive
@@ -97,6 +105,7 @@ import Data.IORef
     , readIORef
     )
 import qualified Data.Map.Strict as Map
+import Data.List (find, sortOn)
 import Data.Maybe (catMaybes, isJust)
 import Data.Scientific (floatingOrInteger)
 import qualified Data.Set as Set
@@ -106,6 +115,7 @@ import qualified Data.Text.Encoding as TextEncoding
 import Data.Text.Encoding.Error (lenientDecode)
 import qualified Data.Vector as Vector
 import System.Environment (getEnvironment)
+import System.Directory (getCurrentDirectory)
 import System.IO
     ( BufferMode(..)
     , Handle
@@ -179,13 +189,495 @@ data McpServerStatus = McpServerStatus
 data McpFleet = McpFleet
     { mcpFleetRegistrations :: ![McpToolRegistration]
     , mcpFleetWarnings :: ![Text]
-    , mcpFleetClients :: ![McpClient]
+    , mcpFleetClients :: !(TVar (Map.Map Text McpClient))
     , mcpFleetServerOrder :: ![Text]
     , mcpFleetFailures :: !(Map.Map Text Text)
     , mcpFleetCatalog :: !(TVar (Map.Map Text McpCatalogEntry))
+    , mcpFleetReconnects :: !(Map.Map Text (MVar ()))
     , mcpFleetWorkers :: !(MVar [Async ()])
     , mcpFleetClosed :: !(MVar Bool)
     }
+
+data McpSupervisor = McpSupervisor
+    { supervisorState :: !(MVar McpSupervisorState)
+    }
+
+data McpSupervisorState = McpSupervisorState
+    { supervisorClosed :: !Bool
+    , supervisorNextLeaseId :: !Int
+    , supervisorEntries :: ![McpSupervisorEntry]
+    , supervisorPending :: ![McpSupervisorPending]
+    }
+
+data McpSupervisorEntry = McpSupervisorEntry
+    { supervisorEntryId :: !Int
+    , supervisorEntryProgressive :: !Bool
+    , supervisorEntryConfigs :: ![McpServerConfig]
+    , supervisorEntryFleet :: !McpFleet
+    , supervisorEntryLeases :: !Int
+    }
+
+data McpSupervisorPending = McpSupervisorPending
+    { supervisorPendingId :: !Int
+    , supervisorPendingProgressive :: !Bool
+    , supervisorPendingConfigs :: ![McpServerConfig]
+    , supervisorPendingResult :: !(TMVar (Either Text McpFleet))
+    , supervisorPendingWorker ::
+        !(TMVar (Async (Either Text McpFleet)))
+    , supervisorPendingLeases :: !Int
+    }
+
+data McpAcquireDecision
+    = UseReady !(Int, McpFleet)
+    | WaitPending !Int !(TMVar (Either Text McpFleet))
+    | StartPending
+        !Int
+        !(TMVar (Either Text McpFleet))
+        !(TMVar (Async (Either Text McpFleet)))
+
+data McpFleetLease = McpFleetLease
+    { mcpLeaseFleet :: !McpFleet
+    , mcpLeaseRelease :: !(IO ())
+    }
+
+-- | A process-scoped cache of MCP fleets. Released leases remain warm for a
+-- later provider/session rebuild; changed configurations replace idle fleets,
+-- and 'closeMcpSupervisor' performs the final deterministic shutdown.
+newMcpSupervisor :: IO McpSupervisor
+newMcpSupervisor =
+    McpSupervisor <$> newMVar McpSupervisorState
+        { supervisorClosed = False
+        , supervisorNextLeaseId = 1
+        , supervisorEntries = []
+        , supervisorPending = []
+        }
+
+acquireMcpFleet
+    :: McpSupervisor
+    -> [McpServerConfig]
+    -> IO McpFleetLease
+acquireMcpFleet supervisor configs =
+    resolveEffectiveCwds configs >>= acquireMcpFleetWith supervisor False
+        (startMcpFleetWithProgress (const (pure ())))
+
+acquireMcpFleetWithProgress
+    :: McpSupervisor
+    -> ([Text] -> IO ())
+    -> [McpServerConfig]
+    -> IO McpFleetLease
+acquireMcpFleetWithProgress supervisor report configs =
+    resolveEffectiveCwds configs >>= acquireMcpFleetWith supervisor False
+        (startMcpFleetWithProgress report)
+
+acquireMcpFleetProgressive
+    :: McpSupervisor
+    -> ([McpServerStatus] -> IO ())
+    -> [McpServerConfig]
+    -> IO McpFleetLease
+acquireMcpFleetProgressive supervisor report configs =
+    resolveEffectiveCwds configs >>= acquireMcpFleetWith supervisor True
+        (startMcpFleetProgressive report)
+
+acquireMcpFleetWith
+    :: McpSupervisor
+    -> Bool
+    -> ([McpServerConfig] -> IO McpFleet)
+    -> [McpServerConfig]
+    -> IO McpFleetLease
+acquireMcpFleetWith supervisor progressive start configs =
+  mask \restore -> do
+    (decision, obsolete) <-
+        modifyMVar supervisor.supervisorState \state ->
+            if state.supervisorClosed
+                then ioError (userError "MCP supervisor closed")
+                else do
+                    (healthyEntries, failedIdle) <-
+                        partitionReusable state.supervisorEntries
+                    matching <- findMatching healthyEntries
+                    case matching of
+                        Just entry -> do
+                            let retained = entry
+                                    { supervisorEntryLeases =
+                                        entry.supervisorEntryLeases + 1
+                                    }
+                                otherIdle =
+                                    idleExcept entry.supervisorEntryId
+                                        healthyEntries
+                                removed = failedIdle <> otherIdle
+                            pure
+                                ( state
+                                    { supervisorEntries =
+                                        replaceEntry retained
+                                            (withoutEntries removed
+                                                healthyEntries)
+                                    }
+                                , ( UseReady
+                                        ( entry.supervisorEntryId
+                                        , entry.supervisorEntryFleet
+                                        )
+                                  , map (.supervisorEntryFleet) removed
+                                  )
+                                )
+                        Nothing ->
+                            case findPending state.supervisorPending of
+                                Just pending -> do
+                                    let retained = pending
+                                            { supervisorPendingLeases =
+                                                pending.supervisorPendingLeases + 1
+                                            }
+                                    pure
+                                        ( state
+                                            { supervisorEntries = healthyEntries
+                                            , supervisorPending =
+                                                replacePending retained
+                                                    state.supervisorPending
+                                            }
+                                        , ( WaitPending
+                                                pending.supervisorPendingId
+                                                pending.supervisorPendingResult
+                                          , map (.supervisorEntryFleet) failedIdle
+                                          )
+                                        )
+                                Nothing -> do
+                                    completion <- newEmptyTMVarIO
+                                    workerSlot <- newEmptyTMVarIO
+                                    let pending = McpSupervisorPending
+                                            { supervisorPendingId =
+                                                state.supervisorNextLeaseId
+                                            , supervisorPendingProgressive =
+                                                progressive
+                                            , supervisorPendingConfigs = configs
+                                            , supervisorPendingResult = completion
+                                            , supervisorPendingWorker = workerSlot
+                                            , supervisorPendingLeases = 1
+                                            }
+                                        healthyIdle = filter isIdle healthyEntries
+                                        removed = failedIdle <> healthyIdle
+                                    pure
+                                        ( state
+                                            { supervisorNextLeaseId =
+                                                state.supervisorNextLeaseId + 1
+                                            , supervisorEntries =
+                                                filter (not . isIdle) healthyEntries
+                                            , supervisorPending =
+                                                pending : state.supervisorPending
+                                            }
+                                        , ( StartPending
+                                                pending.supervisorPendingId
+                                                completion
+                                                workerSlot
+                                          , map (.supervisorEntryFleet) removed
+                                          )
+                                        )
+    case decision of
+        UseReady acquired -> do
+            mapM_ closeMcpFleet obsolete
+            makeLease acquired
+        WaitPending entryId completion -> do
+            mapM_ closeMcpFleet obsolete
+            result <-
+                restore (atomically (readTMVar completion))
+                    `onException` releaseSupervisorEntry supervisor entryId
+            either (ioError . userError . Text.unpack)
+                (\fleet -> makeLease (entryId, fleet))
+                result
+        StartPending entryId completion workerSlot -> do
+            worker <-
+                asyncWithUnmask \unmask ->
+                    tryAny (unmask (start configs)) >>= \case
+                        Left exception ->
+                            pure (Left (exceptionSummary exception))
+                        Right fleet -> pure (Right fleet)
+            atomically $ void (tryPutTMVar workerSlot worker)
+            mapM_ closeMcpFleet obsolete
+            outcome <-
+                restore (waitCatch worker)
+                    `onException` do
+                        cancel worker
+                        void (waitCatch worker)
+                        failPending entryId completion
+                            "MCP fleet startup cancelled"
+            case outcome of
+                Left exception -> do
+                    let err = exceptionSummary exception
+                    failPending entryId completion err
+                    ioError (userError (Text.unpack err))
+                Right (Left err) -> do
+                    failPending entryId completion err
+                    ioError (userError (Text.unpack err))
+                Right (Right fleet) -> do
+                    accepted <-
+                        publishPending entryId completion fleet
+                            `onException` closeMcpFleet fleet
+                    if accepted
+                        then makeLease (entryId, fleet)
+                        else do
+                            closeMcpFleet fleet
+                            ioError (userError "MCP supervisor closed")
+  where
+    makeLease :: (Int, McpFleet) -> IO McpFleetLease
+    makeLease (entryId, fleet) = do
+        released <- newIORef False
+        let release =
+                atomicModifyIORef' released (\done -> (True, done))
+                    >>= \alreadyReleased ->
+                        unless alreadyReleased $
+                            releaseSupervisorEntry supervisor entryId
+        pure McpFleetLease
+            { mcpLeaseFleet = fleet
+            , mcpLeaseRelease = release
+            }
+
+    findPending :: [McpSupervisorPending] -> Maybe McpSupervisorPending
+    findPending = go
+      where
+        go
+            :: [McpSupervisorPending]
+            -> Maybe McpSupervisorPending
+        go [] = Nothing
+        go (pending : rest)
+            | pending.supervisorPendingProgressive == progressive
+            , sameServerConfigs pending.supervisorPendingConfigs configs =
+                Just pending
+            | otherwise = go rest
+
+    replacePending
+        :: McpSupervisorPending
+        -> [McpSupervisorPending]
+        -> [McpSupervisorPending]
+    replacePending replacement =
+        map \pending ->
+            if pending.supervisorPendingId == replacement.supervisorPendingId
+                then replacement
+                else pending
+
+    failPending
+        :: Int
+        -> TMVar (Either Text McpFleet)
+        -> Text
+        -> IO ()
+    failPending entryId completion err =
+        modifyMVar_ supervisor.supervisorState \state -> do
+            atomically $ void (tryPutTMVar completion (Left err))
+            pure state
+                { supervisorPending =
+                    filter
+                        ((/= entryId) . (.supervisorPendingId))
+                        state.supervisorPending
+                }
+
+    publishPending
+        :: Int
+        -> TMVar (Either Text McpFleet)
+        -> McpFleet
+        -> IO Bool
+    publishPending entryId completion fleet =
+        modifyMVar supervisor.supervisorState \state ->
+            case find
+                ((== entryId) . (.supervisorPendingId))
+                state.supervisorPending of
+                Nothing -> do
+                    atomically $
+                        void (tryPutTMVar completion
+                            (Left "MCP supervisor closed"))
+                    pure (state, False)
+                Just pending
+                    | state.supervisorClosed -> do
+                        atomically $
+                            void (tryPutTMVar completion
+                                (Left "MCP supervisor closed"))
+                        pure
+                            ( state
+                                { supervisorPending =
+                                    filter
+                                        ((/= entryId) . (.supervisorPendingId))
+                                        state.supervisorPending
+                                }
+                            , False
+                            )
+                    | otherwise -> do
+                        let entry = McpSupervisorEntry
+                                { supervisorEntryId = entryId
+                                , supervisorEntryProgressive = progressive
+                                , supervisorEntryConfigs = configs
+                                , supervisorEntryFleet = fleet
+                                , supervisorEntryLeases =
+                                    pending.supervisorPendingLeases
+                                }
+                        atomically $
+                            void (tryPutTMVar completion (Right fleet))
+                        pure
+                            ( state
+                                { supervisorEntries =
+                                    entry : state.supervisorEntries
+                                , supervisorPending =
+                                    filter
+                                        ((/= entryId) . (.supervisorPendingId))
+                                        state.supervisorPending
+                                }
+                            , True
+                            )
+
+    findMatching
+        :: [McpSupervisorEntry]
+        -> IO (Maybe McpSupervisorEntry)
+    findMatching = go
+      where
+        go :: [McpSupervisorEntry] -> IO (Maybe McpSupervisorEntry)
+        go [] = pure Nothing
+        go (entry : rest)
+            | entry.supervisorEntryProgressive /= progressive
+                || not
+                    (sameServerConfigs
+                        entry.supervisorEntryConfigs configs) =
+                    go rest
+            | otherwise = do
+                statuses <- mcpFleetStatuses entry.supervisorEntryFleet
+                if all statusReusable statuses
+                    then pure (Just entry)
+                    else go rest
+
+    replaceEntry
+        :: McpSupervisorEntry
+        -> [McpSupervisorEntry]
+        -> [McpSupervisorEntry]
+    replaceEntry replacement =
+        map \entry ->
+            if entry.supervisorEntryId == replacement.supervisorEntryId
+                then replacement
+                else entry
+
+    isIdle :: McpSupervisorEntry -> Bool
+    isIdle entry = entry.supervisorEntryLeases == 0
+
+    idleExcept :: Int -> [McpSupervisorEntry] -> [McpSupervisorEntry]
+    idleExcept retainedId =
+        filter \entry ->
+            isIdle entry && entry.supervisorEntryId /= retainedId
+
+    withoutEntries
+        :: [McpSupervisorEntry]
+        -> [McpSupervisorEntry]
+        -> [McpSupervisorEntry]
+    withoutEntries removed =
+        filter \entry ->
+            all
+                ((/= entry.supervisorEntryId) . (.supervisorEntryId))
+                removed
+
+    partitionReusable
+        :: [McpSupervisorEntry]
+        -> IO ([McpSupervisorEntry], [McpSupervisorEntry])
+    partitionReusable = go [] []
+      where
+        go
+            :: [McpSupervisorEntry]
+            -> [McpSupervisorEntry]
+            -> [McpSupervisorEntry]
+            -> IO ([McpSupervisorEntry], [McpSupervisorEntry])
+        go healthy failed [] =
+            pure (reverse healthy, reverse failed)
+        go healthy failed (entry : rest) = do
+            statuses <- mcpFleetStatuses entry.supervisorEntryFleet
+            let reusable =
+                    all
+                        (\status -> case status.mcpStatusState of
+                            McpFailed _ -> False
+                            McpClosed -> False
+                            _ -> True)
+                        statuses
+            if reusable || entry.supervisorEntryLeases > 0
+                then go (entry : healthy) failed rest
+                else go healthy (entry : failed) rest
+
+    statusReusable :: McpServerStatus -> Bool
+    statusReusable status = case status.mcpStatusState of
+        McpFailed _ -> False
+        McpClosed -> False
+        _ -> True
+
+releaseMcpFleetLease :: McpFleetLease -> IO ()
+releaseMcpFleetLease = (.mcpLeaseRelease)
+
+releaseSupervisorEntry :: McpSupervisor -> Int -> IO ()
+releaseSupervisorEntry supervisor entryId = do
+    modifyMVar_ supervisor.supervisorState \state ->
+        pure state
+            { supervisorEntries =
+                map releaseOne state.supervisorEntries
+            , supervisorPending =
+                map releasePending state.supervisorPending
+            }
+  where
+    releaseOne :: McpSupervisorEntry -> McpSupervisorEntry
+    releaseOne entry
+        | entry.supervisorEntryId == entryId =
+            entry
+                { supervisorEntryLeases =
+                    max 0 (entry.supervisorEntryLeases - 1)
+                }
+        | otherwise = entry
+
+    releasePending :: McpSupervisorPending -> McpSupervisorPending
+    releasePending pending
+        | pending.supervisorPendingId == entryId =
+            pending
+                { supervisorPendingLeases =
+                    max 0 (pending.supervisorPendingLeases - 1)
+                }
+        | otherwise = pending
+
+closeMcpSupervisor :: McpSupervisor -> IO ()
+closeMcpSupervisor supervisor = do
+    (fleets, pending) <-
+        modifyMVar supervisor.supervisorState \state ->
+            if state.supervisorClosed
+                then pure (state, ([], []))
+                else
+                    pure
+                        ( state
+                            { supervisorClosed = True
+                            , supervisorEntries = []
+                            , supervisorPending = []
+                            }
+                        , ( map (.supervisorEntryFleet)
+                                state.supervisorEntries
+                          , state.supervisorPending
+                          )
+                        )
+    atomically $
+        mapM_
+            (\entry ->
+                void (tryPutTMVar entry.supervisorPendingResult
+                    (Left "MCP supervisor closed")))
+            pending
+    mapM_
+        (\entry -> do
+            worker <- atomically
+                (readTMVar entry.supervisorPendingWorker)
+            cancel worker
+            void (waitCatch worker))
+        pending
+    mapM_ closeMcpFleet fleets
+
+resolveEffectiveCwds :: [McpServerConfig] -> IO [McpServerConfig]
+resolveEffectiveCwds configs = do
+    current <- getCurrentDirectory
+    pure
+        [ case config.mcpServerCwd of
+            Just _ -> config
+            Nothing -> config { mcpServerCwd = Just current }
+        | config <- configs
+        ]
+
+sameServerConfigs :: [McpServerConfig] -> [McpServerConfig] -> Bool
+sameServerConfigs left right =
+    map normalize left == map normalize right
+  where
+    normalize config =
+        config
+            { mcpServerEnv = sortOn fst config.mcpServerEnv
+            }
 
 mcpFleetTools :: McpFleet -> [AppTool]
 mcpFleetTools = map (.mcpRegistrationTool) . (.mcpFleetRegistrations)
@@ -193,7 +685,8 @@ mcpFleetTools = map (.mcpRegistrationTool) . (.mcpFleetRegistrations)
 -- | Snapshot server status without triggering initialization or other I/O.
 mcpFleetStatuses :: McpFleet -> IO [McpServerStatus]
 mcpFleetStatuses fleet = do
-    clientStatuses <- mapM mcpClientStatus fleet.mcpFleetClients
+    clients <- Map.elems <$> readTVarIO fleet.mcpFleetClients
+    clientStatuses <- mapM mcpClientStatus clients
     let byName =
             Map.fromList
                 [ (status.mcpStatusName, status)
@@ -305,15 +798,26 @@ startMcpFleetWithProgress reportActive configs = mask \restore -> do
             , tool <- tools
             , let registration = registrationFor client tool
             ]
+    clientsVar <- newTVarIO $
+        Map.fromList
+            [ (client.clientConfig.mcpServerName, client)
+            | client <- clients
+            ]
     workers <- newMVar []
+    reconnects <- Map.fromList <$> mapM
+        (\config -> do
+            lock <- newMVar ()
+            pure (config.mcpServerName, lock))
+        configs
     let
         fleet = McpFleet
             { mcpFleetRegistrations = registrations
             , mcpFleetWarnings = warnings
-            , mcpFleetClients = clients
+            , mcpFleetClients = clientsVar
             , mcpFleetServerOrder = map (.mcpServerName) configs
             , mcpFleetFailures = failures
             , mcpFleetCatalog = catalog
+            , mcpFleetReconnects = reconnects
             , mcpFleetWorkers = workers
             , mcpFleetClosed = closed
             }
@@ -425,6 +929,12 @@ startMcpFleetProgressive reportStatuses configs = mask \restore -> do
     workers <- newMVar []
     catalog <- newTVarIO Map.empty
     ownedClients <- newIORef []
+    clientsVar <- newTVarIO Map.empty
+    reconnects <- Map.fromList <$> mapM
+        (\config -> do
+            lock <- newMVar ()
+            pure (config.mcpServerName, lock))
+        configs
     semaphore <- newQSem progressiveSpawnLimit
     spawnResults <-
         restore
@@ -455,10 +965,11 @@ startMcpFleetProgressive reportStatuses configs = mask \restore -> do
         fleet = McpFleet
             { mcpFleetRegistrations = []
             , mcpFleetWarnings = warnings
-            , mcpFleetClients = clients
+            , mcpFleetClients = clientsVar
             , mcpFleetServerOrder = map (.mcpServerName) configs
             , mcpFleetFailures = failures
             , mcpFleetCatalog = catalog
+            , mcpFleetReconnects = reconnects
             , mcpFleetWorkers = workers
             , mcpFleetClosed = closed
             }
@@ -470,6 +981,12 @@ startMcpFleetProgressive reportStatuses configs = mask \restore -> do
                 Left _ -> pure ()
                 Right _ -> pure ()
             void (reportFleetStatuses reportStatuses fleet)
+    atomically $
+        writeTVar clientsVar $
+            Map.fromList
+                [ (client.clientConfig.mcpServerName, client)
+                | client <- clients
+                ]
     spawned <- newIORef []
     started <-
         (forM clients \client -> do
@@ -592,6 +1109,105 @@ mcpSearchTool fleet = AppTool
     , appToolExecution = ParallelSafe
     }
 
+callCatalogEntryWithReconnect
+    :: McpFleet
+    -> Text
+    -> McpCatalogEntry
+    -> Value
+    -> IO (Either Text Text)
+callCatalogEntryWithReconnect fleet qualifiedName entry arguments =
+    callDiscoveredTool entry.catalogClient entry.catalogTool arguments
+        >>= \case
+            Right result -> pure (Right result)
+            Left originalError -> do
+                failed <- readTVarIO entry.catalogClient.clientFailure
+                case failed of
+                    Nothing -> pure (Left originalError)
+                    Just _ ->
+                        -- Stable meta-tool handlers can transparently replace
+                        -- a failed stdio transport and retry the read-only
+                        -- call once. The per-server lock makes this
+                        -- single-flight across concurrent calls.
+                        reconnectCatalogEntry fleet qualifiedName entry
+                            >>= \case
+                                Left reconnectError ->
+                                    pure . Left $
+                                        originalError
+                                            <> "; MCP reconnect failed: "
+                                            <> reconnectError
+                                Right replacement ->
+                                    callDiscoveredTool
+                                        replacement.catalogClient
+                                        replacement.catalogTool
+                                        arguments
+
+reconnectCatalogEntry
+    :: McpFleet
+    -> Text
+    -> McpCatalogEntry
+    -> IO (Either Text McpCatalogEntry)
+reconnectCatalogEntry fleet qualifiedName failedEntry =
+    case Map.lookup serverName fleet.mcpFleetReconnects of
+        Nothing -> pure (Left "MCP server is not supervised")
+        Just reconnectLock ->
+            withMVar reconnectLock \_ ->
+                withMVar fleet.mcpFleetClosed \closed ->
+                    if closed
+                        then pure (Left "MCP server closed")
+                        else do
+                            current <- readTVarIO fleet.mcpFleetCatalog
+                            case Map.lookup qualifiedName current of
+                                Just replacement
+                                    | replacement.catalogClient.clientFailure
+                                        /= failedEntry.catalogClient.clientFailure ->
+                                            pure (Right replacement)
+                                _ -> restart current
+  where
+    serverName =
+        failedEntry.catalogClient.clientConfig.mcpServerName
+    config = failedEntry.catalogClient.clientConfig
+
+    restart _ = do
+        started <- tryAny (startMcpClient config)
+        case started of
+            Left exception ->
+                pure . Left $
+                    redactConfiguredValues config
+                        (exceptionSummary exception)
+            Right replacementClient ->
+                ensureMcpClientReady replacementClient >>= \case
+                    Left err -> do
+                        closeMcpClient replacementClient
+                        pure (Left err)
+                    Right (tools, _) -> do
+                        let replacementEntries =
+                                Map.fromList
+                                    [ ( qualifiedMcpToolName
+                                            serverName tool.discoveredName
+                                      , McpCatalogEntry replacementClient tool
+                                      )
+                                    | tool <- tools
+                                    ]
+                        previousClient <- atomically do
+                            clients <- readTVar fleet.mcpFleetClients
+                            currentCatalog <- readTVar fleet.mcpFleetCatalog
+                            let withoutServer =
+                                    Map.filter
+                                        ((/= serverName)
+                                            . (.clientConfig.mcpServerName)
+                                            . (.catalogClient))
+                                        currentCatalog
+                            writeTVar fleet.mcpFleetClients
+                                (Map.insert serverName replacementClient clients)
+                            writeTVar fleet.mcpFleetCatalog
+                                (replacementEntries <> withoutServer)
+                            pure (Map.lookup serverName clients)
+                        mapM_ closeMcpClient previousClient
+                        case Map.lookup qualifiedName replacementEntries of
+                            Nothing ->
+                                pure (Left "MCP tool disappeared after reconnect")
+                            Just replacement -> pure (Right replacement)
+
 mcpCallTool :: McpFleet -> AppTool
 mcpCallTool fleet = AppTool
     { appToolName = "mcp_call"
@@ -613,10 +1229,8 @@ mcpCallTool fleet = AppTool
                 entries <- readTVarIO fleet.mcpFleetCatalog
                 case Map.lookup name entries of
                     Just entry ->
-                        callDiscoveredTool
-                            entry.catalogClient
-                            entry.catalogTool
-                            toolArguments
+                        callCatalogEntryWithReconnect
+                            fleet name entry toolArguments
                     Nothing -> do
                         statuses <- mcpFleetStatuses fleet
                         pure . Left $
@@ -683,7 +1297,8 @@ closeMcpFleet fleet =
                     modifyMVar fleet.mcpFleetWorkers \workers ->
                         pure ([], workers)
                 mapM_ stopWorker activeWorkers
-                mapM_ closeMcpClient fleet.mcpFleetClients
+                clients <- Map.elems <$> readTVarIO fleet.mcpFleetClients
+                mapM_ closeMcpClient clients
                 pure True
 
 startMcpClient :: McpServerConfig -> IO McpClient
@@ -833,14 +1448,16 @@ ensureMcpClientReadyWith publishReady client = mask \restore -> do
 mcpClientStatus :: McpClient -> IO McpServerStatus
 mcpClientStatus client = do
     state <- readTVarIO client.clientLifecycle
+    transportFailure <- readTVarIO client.clientFailure
     pure McpServerStatus
         { mcpStatusName = client.clientConfig.mcpServerName
-        , mcpStatusState = case state of
-            ClientPending -> McpPending
-            ClientInitializing _ -> McpInitializing
-            ClientReady _ _ -> McpReady
-            ClientFailed err -> McpFailed err
-            ClientClosed -> McpClosed
+        , mcpStatusState = case (state, transportFailure) of
+            (ClientClosed, _) -> McpClosed
+            (_, Just err) -> McpFailed err
+            (ClientPending, _) -> McpPending
+            (ClientInitializing _, _) -> McpInitializing
+            (ClientReady _ _, _) -> McpReady
+            (ClientFailed err, _) -> McpFailed err
         , mcpStatusToolCount = case state of
             ClientReady tools _ -> length tools
             _ -> 0

--- a/packages/agent-core/test/Agent/MCPSpec.hs
+++ b/packages/agent-core/test/Agent/MCPSpec.hs
@@ -14,7 +14,7 @@ import Agent.Tools.Types
     )
 import Control.Exception.Safe (bracket)
 import Control.Concurrent (threadDelay)
-import Control.Concurrent.Async (wait, withAsync)
+import Control.Concurrent.Async (async, wait, waitCatch, withAsync)
 import Data.Aeson (object, (.=))
 import qualified Data.ByteString.Lazy as LBS
 import Data.IORef (modifyIORef', newIORef, readIORef)
@@ -25,9 +25,11 @@ import System.Directory
     , getTemporaryDirectory
     , removeDirectoryRecursive
     , removeFile
+    , withCurrentDirectory
     )
 import System.IO (hClose, openTempFile)
 import System.Posix.Files (setFileMode)
+import System.Timeout (timeout)
 import Test.Hspec
 
 spec :: Spec
@@ -236,6 +238,128 @@ spec = describe "Agent.MCP" do
                 [McpServerStatus "exits" (McpFailed _) 0] -> pure ()
                 _ -> expectationFailure ("unexpected statuses: " <> show statuses)
 
+    describe "McpSupervisor" do
+        it "single-flights concurrent acquisitions for the same configuration" $
+            withCountingFakeServer \script counter -> do
+                supervisor <- newMcpSupervisor
+                bracket (pure supervisor) closeMcpSupervisor \_ -> do
+                    let config =
+                            (baseConfig "shared" script)
+                                { mcpServerArgs = [counter, "0.2"]
+                                }
+                    withAsync (acquireMcpFleet supervisor [config]) \first ->
+                        withAsync (acquireMcpFleet supervisor [config]) \second -> do
+                            firstLease <- wait first
+                            secondLease <- wait second
+                            releaseMcpFleetLease firstLease
+                            releaseMcpFleetLease secondLease
+                    countStarts counter `shouldReturn` 1
+
+        it "reuses an idle fleet with the same canonical configuration" $
+            withCountingFakeServer \script counter -> do
+                supervisor <- newMcpSupervisor
+                bracket (pure supervisor) closeMcpSupervisor \_ -> do
+                    let config =
+                            (baseConfig "cached" script)
+                                { mcpServerArgs = [counter]
+                                , mcpServerEnv =
+                                    [("SECOND", "2"), ("FIRST", "1")]
+                                }
+                    first <- acquireMcpFleet supervisor [config]
+                    releaseMcpFleetLease first
+                    second <- acquireMcpFleet supervisor
+                        [ config
+                            { mcpServerEnv =
+                                [("FIRST", "1"), ("SECOND", "2")]
+                            }
+                        ]
+                    releaseMcpFleetLease second
+                    countStarts counter `shouldReturn` 1
+
+        it "starts a replacement fleet when the configuration changes" $
+            withCountingFakeServer \script counter -> do
+                supervisor <- newMcpSupervisor
+                bracket (pure supervisor) closeMcpSupervisor \_ -> do
+                    first <- acquireMcpFleet supervisor
+                        [ (baseConfig "cached" script)
+                            { mcpServerArgs = [counter, "first"]
+                            }
+                        ]
+                    releaseMcpFleetLease first
+                    second <- acquireMcpFleet supervisor
+                        [ (baseConfig "cached" script)
+                            { mcpServerArgs = [counter, "second"]
+                            }
+                        ]
+                    releaseMcpFleetLease second
+                    countStarts counter `shouldReturn` 2
+
+        it "does not reuse an inherited-cwd fleet after the cwd changes" $
+            withCountingFakeServer \script counter ->
+                withDistinctWorkingDirectories \firstDir secondDir -> do
+                    supervisor <- newMcpSupervisor
+                    bracket (pure supervisor) closeMcpSupervisor \_ -> do
+                        let config =
+                                (baseConfig "cwd-sensitive" script)
+                                    { mcpServerArgs = [counter]
+                                    }
+                        first <- withCurrentDirectory firstDir $
+                            acquireMcpFleet supervisor [config]
+                        releaseMcpFleetLease first
+                        second <- withCurrentDirectory secondDir $
+                            acquireMcpFleet supervisor [config]
+                        releaseMcpFleetLease second
+                        countStarts counter `shouldReturn` 2
+
+        it "cancels and joins a pending startup when the supervisor closes" $
+            withCountingFakeServer \script counter -> do
+                supervisor <- newMcpSupervisor
+                acquiring <- async $
+                    acquireMcpFleet supervisor
+                        [ (baseConfig "slow-close" script)
+                            { mcpServerArgs = [counter, "2"]
+                            }
+                        ]
+                threadDelay 50000
+                timeout 1000000 (closeMcpSupervisor supervisor)
+                    `shouldReturn` Just ()
+                _ <- waitCatch acquiring
+                pure ()
+
+        it "reconnects once and retries a meta-tool call after transport loss" $
+            withCountingReconnectServer \script counter -> do
+                fleet <- startMcpFleetProgressive
+                    (const (pure ()))
+                    [ (baseConfig "reconnect" script)
+                        { mcpServerArgs = [counter]
+                        }
+                    ]
+                bracket (pure fleet) closeMcpFleet \_ -> do
+                    waitForServerReady fleet "reconnect"
+                    let tools = mcpFleetMetaTools fleet
+                    called <- dispatchToolCall
+                        defaultLoopDispatch
+                        (appToolHandlers tools)
+                        (functionToolCall "reconnect-call" "mcp_call"
+                            "{\"name\":\"reconnect__read\",\"arguments\":{}}")
+                    called.output `shouldBe` "reconnected response"
+                    countStarts counter `shouldReturn` 2
+
+        it "rebuilds an idle fleet whose transport failed" $
+            withCountingFailingServer \script counter -> do
+                supervisor <- newMcpSupervisor
+                bracket (pure supervisor) closeMcpSupervisor \_ -> do
+                    let config =
+                            (baseConfig "recover" script)
+                                { mcpServerArgs = [counter]
+                                }
+                    first <- acquireMcpFleet supervisor [config]
+                    waitForServerFailure first.mcpLeaseFleet "recover"
+                    releaseMcpFleetLease first
+                    second <- acquireMcpFleet supervisor [config]
+                    releaseMcpFleetLease second
+                    countStarts counter `shouldReturn` 2
+
 withFakeServer :: (FilePath -> IO a) -> IO a
 withFakeServer action = do
     temporary <- getTemporaryDirectory
@@ -248,6 +372,61 @@ withFakeServer action = do
             pure path)
         removeFile
         action
+
+withCountingFakeServer :: (FilePath -> FilePath -> IO a) -> IO a
+withCountingFakeServer = withCountingServer countingFakeServer
+
+withCountingFailingServer :: (FilePath -> FilePath -> IO a) -> IO a
+withCountingFailingServer = withCountingServer countingFailingServer
+
+withCountingReconnectServer :: (FilePath -> FilePath -> IO a) -> IO a
+withCountingReconnectServer = withCountingServer countingReconnectServer
+
+withCountingServer
+    :: LBS.ByteString
+    -> (FilePath -> FilePath -> IO a)
+    -> IO a
+withCountingServer body action = do
+    temporary <- getTemporaryDirectory
+    bracket
+        (do
+            (counter, counterHandle) <-
+                openTempFile temporary "agent-mcp-start-count"
+            hClose counterHandle
+            (script, scriptHandle) <-
+                openTempFile temporary "agent-mcp-counting.sh"
+            LBS.hPutStr scriptHandle body
+            hClose scriptHandle
+            setFileMode script 0o700
+            pure (script, counter))
+        (\(script, counter) -> do
+            removeFile script
+            removeFile counter)
+        (uncurry action)
+
+withDistinctWorkingDirectories :: (FilePath -> FilePath -> IO a) -> IO a
+withDistinctWorkingDirectories action = do
+    temporary <- getTemporaryDirectory
+    bracket
+        (do
+            (first, firstHandle) <-
+                openTempFile temporary "agent-mcp-cwd-first"
+            hClose firstHandle
+            removeFile first
+            createDirectory first
+            (second, secondHandle) <-
+                openTempFile temporary "agent-mcp-cwd-second"
+            hClose secondHandle
+            removeFile second
+            createDirectory second
+            pure (first, second))
+        (\(first, second) -> do
+            removeDirectoryRecursive first
+            removeDirectoryRecursive second)
+        (uncurry action)
+
+countStarts :: FilePath -> IO Int
+countStarts path = length . lines <$> readFile path
 
 concurrentConfig :: FilePath -> FilePath -> Text.Text -> McpServerConfig
 concurrentConfig script barrier name = McpServerConfig
@@ -363,6 +542,68 @@ fakeServer =
     \        printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":4,\"result\":{\"content\":[{\"type\":\"text\",\"text\":\"second response\"}]}}'\n\
     \        printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":3,\"result\":{\"content\":[{\"type\":\"text\",\"text\":\"first response\"}]}}'\n\
     \      fi\n\
+    \      ;;\n\
+    \  esac\n\
+    \done\n"
+
+countingReconnectServer :: LBS.ByteString
+countingReconnectServer =
+    "#!/bin/sh\n\
+    \counter=\"$1\"\n\
+    \printf 'started\\n' >> \"$counter\"\n\
+    \instance=\"$(wc -l < \"$counter\" | tr -d ' ')\"\n\
+    \while IFS= read -r line; do\n\
+    \  case \"$line\" in\n\
+    \    *'\"method\":\"initialize\"'*)\n\
+    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"protocolVersion\":\"2025-11-25\",\"capabilities\":{},\"serverInfo\":{\"name\":\"reconnect\",\"version\":\"1\"}}}'\n\
+    \      ;;\n\
+    \    *'\"method\":\"notifications/initialized\"'*) ;;\n\
+    \    *'\"method\":\"tools/list\"'*)\n\
+    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":2,\"result\":{\"tools\":[{\"name\":\"read\",\"description\":\"Read.\",\"inputSchema\":{\"type\":\"object\"},\"annotations\":{\"readOnlyHint\":true}}]}}'\n\
+    \      ;;\n\
+    \    *'\"method\":\"tools/call\"'*)\n\
+    \      if [ \"$instance\" -eq 1 ]; then\n\
+    \        exit 0\n\
+    \      else\n\
+    \        printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":3,\"result\":{\"content\":[{\"type\":\"text\",\"text\":\"reconnected response\"}]}}'\n\
+    \      fi\n\
+    \      ;;\n\
+    \  esac\n\
+    \done\n"
+
+countingFakeServer :: LBS.ByteString
+countingFakeServer =
+    "#!/bin/sh\n\
+    \counter=\"$1\"\n\
+    \delay=\"$2\"\n\
+    \printf 'started\\n' >> \"$counter\"\n\
+    \while IFS= read -r line; do\n\
+    \  case \"$line\" in\n\
+    \    *'\"method\":\"initialize\"'*)\n\
+    \      if [ -n \"$delay\" ]; then sleep \"$delay\"; fi\n\
+    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"protocolVersion\":\"2025-11-25\",\"capabilities\":{},\"serverInfo\":{\"name\":\"counting\",\"version\":\"1\"}}}'\n\
+    \      ;;\n\
+    \    *'\"method\":\"notifications/initialized\"'*) ;;\n\
+    \    *'\"method\":\"tools/list\"'*)\n\
+    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":2,\"result\":{\"tools\":[]}}'\n\
+    \      ;;\n\
+    \  esac\n\
+    \done\n"
+
+countingFailingServer :: LBS.ByteString
+countingFailingServer =
+    "#!/bin/sh\n\
+    \counter=\"$1\"\n\
+    \printf 'started\\n' >> \"$counter\"\n\
+    \while IFS= read -r line; do\n\
+    \  case \"$line\" in\n\
+    \    *'\"method\":\"initialize\"'*)\n\
+    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"protocolVersion\":\"2025-11-25\",\"capabilities\":{},\"serverInfo\":{\"name\":\"failing\",\"version\":\"1\"}}}'\n\
+    \      ;;\n\
+    \    *'\"method\":\"notifications/initialized\"'*) ;;\n\
+    \    *'\"method\":\"tools/list\"'*)\n\
+    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":2,\"result\":{\"tools\":[]}}'\n\
+    \      exit 0\n\
     \      ;;\n\
     \  esac\n\
     \done\n"


### PR DESCRIPTION
## Summary
- add a process-scoped MCP supervisor with idempotent leases and exact canonical config matching
- keep released fleets warm across provider/session rebuilds
- single-flight concurrent acquisitions so identical requests start one fleet
- start and close slow fleets outside the supervisor critical section
- reconnect failed read-only meta-tool calls once under a per-server lock
- replace and close failed clients without accumulating retired transports
- preserve progressive client visibility before initialization workers begin

## Validation
- `nix develop -c cabal test --offline agent-core-test` (300 examples, 0 failures)
- `nix develop -c cabal test --offline agent-cli-test` (791 examples, 0 failures)
- focused MCP suite: 16 examples, including concurrent acquisition, config replacement, reconnect, and failed-fleet rebuild
- optimized warm-reuse benchmark, 4 servers with 200 ms delay, median of 11: 0.014 ms

Stack 4/4; depends on #394.