### PR TITLE
Support Telegram group chats

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,11 +133,16 @@ Setup reads the BotFather token without terminal echo, validates it against
 Telegram, and stores it separately from the non-secret gateway configuration.
 Never paste the bot token into an agent conversation.
 
-Only allowlisted private-chat text messages are handled. Each chat is mapped
-to a persisted agent session under `~/.haskell-agent`; `/new` starts a fresh
-session and `/session` shows the current session ID. Mutating tools are denied
-unless setup is run with `--yolo`. Use `agent-telegram stop` to stop the
-background gateway.
+Only messages from allowlisted Telegram users are handled. Private chats work
+directly. In groups and supergroups, mention the bot, use a command addressed
+to its username (for example `/new@your_bot`), or reply to one of its messages.
+Ambient group traffic and messages from non-allowlisted members are ignored.
+Each private chat, group, and forum topic is mapped to its own persisted agent
+session under `~/.haskell-agent`; `/new` starts a fresh session and `/session`
+shows the current session ID. Group replies include the sender's identity in
+the agent prompt and are posted as replies to the triggering Telegram message.
+Mutating tools are denied unless setup is run with `--yolo`. Use
+`agent-telegram stop` to stop the background gateway.
 
 Incoming updates and pending replies are persisted before they are processed.
 Polling continues while agent turns run, conversations are processed in order,

--- a/packages/agent-cli/skills/telegram-agent/SKILL.md
+++ b/packages/agent-cli/skills/telegram-agent/SKILL.md
@@ -53,15 +53,22 @@ disables terminal echo and stores the token in a private gateway file.
 
 9. Tell the user to open their new bot and send `/start`. The bot supports
    `/new` for a fresh agent session and `/session` for the current session ID.
-   Text, voice messages, and message reactions are persisted before processing.
-   Voice transcription uses the user's existing Codex subscription, so Codex
-   must already be logged in on the machine running the gateway.
+   To use it in a group, add the bot and mention its `@username`, reply to one
+   of its messages, or address commands to it (for example
+   `/new@your_bot_username`). Each group or forum topic has a shared agent
+   session. Only messages from allowlisted users are accepted; ambient group
+   traffic is ignored. Text, voice messages, and private-chat message reactions
+   are persisted before processing. Voice transcription uses the user's
+   existing Codex subscription, so Codex must already be logged in on the
+   machine running the gateway.
 
 ## Telegram delivery behavior
 
 - The gateway shows typing and a native rich-message draft while an agent turn
   is running.
 - Agent Markdown is converted to Telegram-safe HTML, with a plain-text fallback.
+- Group and supergroup responses reply to the triggering message. Forum topics
+  are isolated from one another.
 - A reply containing exactly one supported Telegram reaction emoji is delivered
   as a reaction to the triggering message instead of as a separate message.
 - Inbound reaction changes become ordinary durable agent turns, including

--- a/packages/agent-cli/src/Agent/Telegram.hs
+++ b/packages/agent-cli/src/Agent/Telegram.hs
@@ -15,11 +15,13 @@ module Agent.Telegram
     , TelegramPendingTurn(..)
     , TelegramPendingReply(..)
     , TelegramVoice(..)
+    , TelegramUser(..)
     , TelegramMessage(..)
     , TelegramUpdate(..)
     , TelegramUpdateAction(..)
     , PendingChatAction(..)
     , emptyTelegramState
+    , classifyTelegramUpdate
     , storeUpdateAction
     , nextPendingAction
     , checkpointPendingVoiceTranscript
@@ -387,11 +389,20 @@ instance ToJSON TelegramVoice where
 
 data TelegramUser = TelegramUser
     { userId :: !Integer
+    , userIsBot :: !Bool
+    , userFirstName :: !(Maybe Text)
+    , userLastName :: !(Maybe Text)
+    , userUsername :: !(Maybe Text)
     } deriving (Eq, Show)
 
 instance FromJSON TelegramUser where
     parseJSON = withObject "TelegramUser" \o ->
-        TelegramUser <$> o .: "id"
+        TelegramUser
+            <$> o .: "id"
+            <*> (o .:? "is_bot" .!= False)
+            <*> o .:? "first_name"
+            <*> o .:? "last_name"
+            <*> o .:? "username"
 
 data TelegramChat = TelegramChat
     { telegramChatId :: !Integer
@@ -411,6 +422,7 @@ data TelegramMessage = TelegramMessage
     , messageThread :: !(Maybe Integer)
     , messageText :: !(Maybe Text)
     , messageVoice :: !(Maybe TelegramVoice)
+    , messageReplyTo :: !(Maybe TelegramMessage)
     } deriving (Eq, Show)
 
 instance FromJSON TelegramMessage where
@@ -422,6 +434,7 @@ instance FromJSON TelegramMessage where
             <*> o .:? "message_thread_id"
             <*> o .:? "text"
             <*> o .:? "voice"
+            <*> o .:? "reply_to_message"
 
 instance FromJSON TelegramVoice where
     parseJSON = withObject "TelegramVoice" \o ->
@@ -745,10 +758,12 @@ runTelegram config token = do
     stateVar <- newMVar state
     workers <- newMVar Map.empty
     manager <- HttpTls.newTlsManager
-    processManager <- newSessionProcessManager root
     let client = TelegramClient token manager
-        runtime = TelegramRuntime
+    bot <- getTelegramBot client
+    processManager <- newSessionProcessManager root
+    let runtime = TelegramRuntime
             { runtimeClient = client
+            , runtimeBot = bot
             , runtimeAllowedUsers = config.telegramAllowedUsers
             , runtimeGatewayDirectory = gatewayDir
             , runtimeSessionsRoot = root
@@ -761,7 +776,7 @@ runTelegram config token = do
             , runtimeEffort = effort
             , runtimePolicy = policy
             }
-    Text.putStrLn "Telegram gateway started (private chats only)."
+    Text.putStrLn "Telegram gateway started (private and group chats)."
     race_ (pollForever runtime) (dispatchForever runtime)
         `finally` do
             closeTelegramWorkers runtime
@@ -844,6 +859,7 @@ processIsAlive pid =
 
 data TelegramRuntime = TelegramRuntime
     { runtimeClient :: !TelegramClient
+    , runtimeBot :: !TelegramUser
     , runtimeAllowedUsers :: !(Set Integer)
     , runtimeGatewayDirectory :: !OsPath
     , runtimeSessionsRoot :: !OsPath
@@ -916,29 +932,27 @@ classifyUpdate
     -> TelegramUpdate
     -> IO TelegramUpdateAction
 classifyUpdate runtime update =
-    pure case update.updateMessage of
+    pure (classifyTelegramUpdate
+        runtime.runtimeBot
+        runtime.runtimeAllowedUsers
+        update)
+
+classifyTelegramUpdate
+    :: TelegramUser
+    -> Set Integer
+    -> TelegramUpdate
+    -> TelegramUpdateAction
+classifyTelegramUpdate bot allowedUsers update =
+    case update.updateMessage of
         Just message
-            | message.messageChat.telegramChatType == "private"
-            , Just sender <- message.messageFrom
-            , sender.userId `Set.member` runtime.runtimeAllowedUsers ->
-                let key = TelegramChatKey
-                        { chatId = message.messageChat.telegramChatId
-                        , messageThreadId = message.messageThread
-                        }
-                in case message.messageVoice of
-                    Just voice ->
-                        QueueTurn message.messageId key "[Voice message]" (Just voice)
-                    Nothing
-                        | Just rawText <- message.messageText
-                        , not (Text.null (Text.strip rawText)) ->
-                            QueueTurn message.messageId key
-                                (Text.strip rawText) Nothing
-                    _ -> IgnoreUpdate
+            | Just sender <- message.messageFrom
+            , sender.userId `Set.member` allowedUsers ->
+                classifyMessage bot sender message
         _ -> case update.updateMessageReaction of
             Just reaction
                 | reaction.messageReactionChat.telegramChatType == "private"
                 , Just sender <- reaction.messageReactionUser
-                , sender.userId `Set.member` runtime.runtimeAllowedUsers ->
+                , sender.userId `Set.member` allowedUsers ->
                     QueueTurn
                         reaction.messageReactionMessageId
                         TelegramChatKey
@@ -949,6 +963,167 @@ classifyUpdate runtime update =
                         (reactionMessageText reaction)
                         Nothing
             _ -> IgnoreUpdate
+
+classifyMessage
+    :: TelegramUser
+    -> TelegramUser
+    -> TelegramMessage
+    -> TelegramUpdateAction
+classifyMessage bot sender message =
+    case message.messageChat.telegramChatType of
+        "private" -> queueMessage id
+        "group" -> classifyGroupMessage
+        "supergroup" -> classifyGroupMessage
+        _ -> IgnoreUpdate
+  where
+    key = TelegramChatKey
+        { chatId = message.messageChat.telegramChatId
+        , messageThreadId = message.messageThread
+        }
+
+    classifyGroupMessage
+        | Just rawText <- message.messageText
+        , Just target <- explicitCommandTarget (Text.strip rawText)
+        , not (botUsernameMatches bot target) =
+            IgnoreUpdate
+        | messageRepliesToBot bot message =
+            queueGroupReply
+        | Just rawText <- message.messageText
+        , Just targetedText <- groupTextForBot bot rawText =
+            queueText (attributeGroupText sender targetedText)
+        | otherwise = IgnoreUpdate
+
+    queueGroupReply =
+        case message.messageVoice of
+            Just voice ->
+                QueueTurn message.messageId key
+                    (attributeGroupMessage sender "[Voice message]")
+                    (Just voice)
+            Nothing
+                | Just rawText <- message.messageText ->
+                    queueText (attributeGroupText sender rawText)
+            _ -> IgnoreUpdate
+
+    queueMessage transform =
+        case message.messageVoice of
+            Just voice ->
+                QueueTurn message.messageId key
+                    (transform "[Voice message]")
+                    (Just voice)
+            Nothing
+                | Just rawText <- message.messageText ->
+                    queueText (transform rawText)
+            _ -> IgnoreUpdate
+
+    queueText rawText
+        | Text.null clean = IgnoreUpdate
+        | otherwise =
+            QueueTurn message.messageId key clean Nothing
+      where
+        clean = Text.strip rawText
+
+messageRepliesToBot :: TelegramUser -> TelegramMessage -> Bool
+messageRepliesToBot bot message =
+    case message.messageReplyTo >>= (.messageFrom) of
+        Just repliedTo -> repliedTo.userId == bot.userId
+        Nothing -> False
+
+groupTextForBot :: TelegramUser -> Text -> Maybe Text
+groupTextForBot bot rawText =
+    case explicitCommandTarget clean of
+        Just target
+            | usernameMatches target -> Just clean
+            | otherwise -> Nothing
+        Nothing -> stripBotMention bot clean
+  where
+    clean = Text.strip rawText
+    usernameMatches = botUsernameMatches bot
+
+botUsernameMatches :: TelegramUser -> Text -> Bool
+botUsernameMatches bot target =
+    maybe False
+        ((== Text.toCaseFold target) . Text.toCaseFold)
+        bot.userUsername
+
+explicitCommandTarget :: Text -> Maybe Text
+explicitCommandTarget text = do
+    firstWord <- case Text.words text of
+        [] -> Nothing
+        value : _ -> Just value
+    command <- Text.stripPrefix "/" firstWord
+    let (_, targetWithAt) = Text.breakOn "@" command
+    Text.stripPrefix "@" targetWithAt
+
+stripBotMention :: TelegramUser -> Text -> Maybe Text
+stripBotMention bot text = do
+    username <- bot.userUsername
+    let needle = "@" <> Text.map asciiLower username
+        folded = Text.map asciiLower text
+        (beforeFolded, matchAndAfter) = Text.breakOn needle folded
+    if Text.null matchAndAfter
+        then Nothing
+        else do
+            let mentionOffset = Text.length beforeFolded
+                (before, mentionAndAfter) = Text.splitAt mentionOffset text
+                after = Text.drop (Text.length needle) mentionAndAfter
+            if mentionBoundaryBefore before && mentionBoundaryAfter after
+                then Just (Text.strip (before <> after))
+                else Nothing
+
+asciiLower :: Char -> Char
+asciiLower char
+    | 'A' <= char && char <= 'Z' =
+        toEnum (fromEnum char + fromEnum 'a' - fromEnum 'A')
+    | otherwise = char
+
+mentionBoundaryBefore :: Text -> Bool
+mentionBoundaryBefore text =
+    maybe True (not . isTelegramUsernameCharacter) (lastTextCharacter text)
+
+mentionBoundaryAfter :: Text -> Bool
+mentionBoundaryAfter text =
+    maybe True (not . isTelegramUsernameCharacter) (firstTextCharacter text)
+
+isTelegramUsernameCharacter :: Char -> Bool
+isTelegramUsernameCharacter char =
+    ('a' <= char && char <= 'z')
+        || ('A' <= char && char <= 'Z')
+        || ('0' <= char && char <= '9')
+        || char == '_'
+
+firstTextCharacter :: Text -> Maybe Char
+firstTextCharacter = fmap fst . Text.uncons
+
+lastTextCharacter :: Text -> Maybe Char
+lastTextCharacter = fmap snd . Text.unsnoc
+
+attributeGroupText :: TelegramUser -> Text -> Text
+attributeGroupText sender text
+    | telegramCommand text /= Nothing = text
+    | otherwise = attributeGroupMessage sender text
+
+attributeGroupMessage :: TelegramUser -> Text -> Text
+attributeGroupMessage sender text =
+    "[Telegram group message from "
+        <> telegramUserLabel sender
+        <> "]\n"
+        <> text
+
+telegramUserLabel :: TelegramUser -> Text
+telegramUserLabel user =
+    let name = Text.unwords
+            [ value
+            | Just value <- [user.userFirstName, user.userLastName]
+            , not (Text.null (Text.strip value))
+            ]
+        username = ("@" <>) <$> user.userUsername
+        identityParts =
+            filter (not . Text.null)
+                [ name
+                , fromMaybe "" username
+                , "user " <> Text.pack (show user.userId)
+                ]
+    in Text.intercalate ", " identityParts
 
 reactionMessageText :: TelegramMessageReaction -> Text
 reactionMessageText reaction
@@ -1193,7 +1368,11 @@ transcribeTelegramVoice runtime pending voice = do
             let clean = Text.strip transcript
             when (Text.null clean) $
                 fail "Codex returned an empty voice transcription"
-            pure ("[Voice message transcript]: " <> clean)
+            pure $
+                let rendered = "[Voice message transcript]: " <> clean
+                in if pending.pendingTurnText == "[Voice message]"
+                    then rendered
+                    else pending.pendingTurnText <> "\n" <> rendered
 
 data TelegramFile = TelegramFile
     { telegramFilePath :: !(Maybe Text)
@@ -1523,10 +1702,13 @@ reply runtime pending
         let chunks = case splitTelegramText 600 pending.pendingText of
                 [] -> ["(empty response)"]
                 values -> values
-        forM_ chunks \chunk ->
+        forM_ (zip [0 :: Int ..] chunks) \(index, chunk) ->
             sendRichMessage
                 runtime.runtimeClient
                 pending.pendingChat
+                (if index == 0
+                    then pending.pendingReplyToMessageId
+                    else Nothing)
                 chunk >>= \case
                     Left err -> fail (Text.unpack err)
                     Right () -> pure ()
@@ -1594,6 +1776,15 @@ sendTypingAction client key =
             <> maybe []
                 (\threadId -> ["message_thread_id" .= threadId])
                 key.messageThreadId
+
+telegramReplyParameters :: Maybe Integer -> [(Key.Key, Value)]
+telegramReplyParameters =
+    maybe [] \messageId ->
+        [ "reply_parameters" .= object
+            [ "message_id" .= messageId
+            , "allow_sending_without_reply" .= True
+            ]
+        ]
 
 -- | Convert the Markdown subset commonly emitted by agents to Telegram's
 -- supported HTML. Literal text and link attributes are always escaped.
@@ -1719,6 +1910,15 @@ getUpdates client offset =
         ]
             <> maybe [] (\value -> ["offset" .= value]) offset
 
+getTelegramBot :: TelegramClient -> IO TelegramUser
+getTelegramBot client =
+    telegramRequest client "getMe" (object []) 15 >>= \case
+        Left err -> fail (Text.unpack err)
+        Right response ->
+            case decodeTelegramResponse response of
+                Left err -> fail (Text.unpack err)
+                Right bot -> pure bot
+
 setMessageReaction
     :: TelegramClient
     -> TelegramChatKey
@@ -1745,14 +1945,15 @@ setMessageReaction client key messageId emoji =
 sendRichMessage
     :: TelegramClient
     -> TelegramChatKey
+    -> Maybe Integer
     -> Text
     -> IO (Either Text ())
-sendRichMessage client key text =
+sendRichMessage client key replyToMessageId text =
     telegramRequest client "sendRichMessage" richBody 30 >>= \case
         Right response
             | Right (_ :: Value) <- decodeTelegramResponse response ->
                 pure (Right ())
-        _ -> sendHtmlMessage client key text
+        _ -> sendHtmlMessage client key replyToMessageId text
   where
     richBody = object $
         [ "chat_id" .= key.chatId
@@ -1763,18 +1964,20 @@ sendRichMessage client key text =
             <> maybe []
                 (\threadId -> ["message_thread_id" .= threadId])
                 key.messageThreadId
+            <> telegramReplyParameters replyToMessageId
 
 sendHtmlMessage
     :: TelegramClient
     -> TelegramChatKey
+    -> Maybe Integer
     -> Text
     -> IO (Either Text ())
-sendHtmlMessage client key text =
+sendHtmlMessage client key replyToMessageId text =
     telegramRequest client "sendMessage" htmlBody 30 >>= \case
         Right response
             | Right (_ :: Value) <- decodeTelegramResponse response ->
                 pure (Right ())
-        _ -> sendPlainMessage client key text
+        _ -> sendPlainMessage client key replyToMessageId text
   where
     htmlBody = object $
         [ "chat_id" .= key.chatId
@@ -1784,20 +1987,24 @@ sendHtmlMessage client key text =
             <> maybe []
                 (\threadId -> ["message_thread_id" .= threadId])
                 key.messageThreadId
+            <> telegramReplyParameters replyToMessageId
 
 sendPlainMessage
     :: TelegramClient
     -> TelegramChatKey
+    -> Maybe Integer
     -> Text
     -> IO (Either Text ())
-sendPlainMessage client key text =
-    telegramRequest client "sendMessage" (messageBody key text) 30 >>= \case
+sendPlainMessage client key replyToMessageId text =
+    telegramRequest client "sendMessage"
+        (messageBody key replyToMessageId text)
+        30 >>= \case
         Left err -> pure (Left err)
         Right response ->
             pure (() <$ (decodeTelegramResponse response :: Either Text Value))
 
-messageBody :: TelegramChatKey -> Text -> Value
-messageBody key text =
+messageBody :: TelegramChatKey -> Maybe Integer -> Text -> Value
+messageBody key replyToMessageId text =
     object $
         [ "chat_id" .= key.chatId
         , "text" .= text
@@ -1805,6 +2012,7 @@ messageBody key text =
             <> maybe []
                 (\threadId -> ["message_thread_id" .= threadId])
                 key.messageThreadId
+            <> telegramReplyParameters replyToMessageId
 
 telegramRequest
     :: TelegramClient

--- a/packages/agent-cli/test/Agent/TelegramSpec.hs
+++ b/packages/agent-cli/test/Agent/TelegramSpec.hs
@@ -160,6 +160,147 @@ spec = describe "Agent.Telegram" do
                     Nothing -> False
                 Left _ -> False
 
+    describe "Telegram group chats" do
+        let bot = TelegramUser
+                { userId = 999
+                , userIsBot = True
+                , userFirstName = Just "Harness"
+                , userLastName = Nothing
+                , userUsername = Just "HarnessBot"
+                }
+            allowedUsers = Set.singleton 456
+            classify bytes = do
+                update <- (eitherDecode (LBS.pack bytes)
+                    :: Either String TelegramUpdate)
+                    `shouldReturnRight` "Telegram update should decode"
+                pure (classifyTelegramUpdate bot allowedUsers update)
+
+        it "routes an allowed mention into the shared group session" do
+            action <- classify
+                "{\"update_id\":22,\"message\":{\
+                \\"message_id\":80,\
+                \\"from\":{\"id\":456,\"first_name\":\"Marc\",\
+                \\"username\":\"marc\"},\
+                \\"chat\":{\"id\":-1001,\"type\":\"group\"},\
+                \\"text\":\"@HarnessBot please summarize\"}}"
+            action `shouldBe`
+                QueueTurn
+                    80
+                    (TelegramChatKey (-1001) Nothing)
+                    "[Telegram group message from Marc, @marc, user 456]\n\
+                    \please summarize"
+                    Nothing
+
+        it "keeps forum topics as separate conversations" do
+            action <- classify
+                "{\"update_id\":23,\"message\":{\
+                \\"message_id\":81,\"message_thread_id\":7,\
+                \\"from\":{\"id\":456,\"first_name\":\"Marc\"},\
+                \\"chat\":{\"id\":-1002,\"type\":\"supergroup\"},\
+                \\"text\":\"@harnessbot check this\"}}"
+            action `shouldBe`
+                QueueTurn
+                    81
+                    (TelegramChatKey (-1002) (Just 7))
+                    "[Telegram group message from Marc, user 456]\ncheck this"
+                    Nothing
+
+        it "accepts commands addressed to this bot without changing them" do
+            action <- classify
+                "{\"update_id\":24,\"message\":{\
+                \\"message_id\":82,\"from\":{\"id\":456},\
+                \\"chat\":{\"id\":-1001,\"type\":\"group\"},\
+                \\"text\":\"/new@HarnessBot\"}}"
+            action `shouldBe`
+                QueueTurn
+                    82
+                    (TelegramChatKey (-1001) Nothing)
+                    "/new@HarnessBot"
+                    Nothing
+
+        it "accepts text and voice replies to the bot" do
+            textAction <- classify
+                "{\"update_id\":25,\"message\":{\
+                \\"message_id\":83,\
+                \\"from\":{\"id\":456,\"first_name\":\"Marc\"},\
+                \\"chat\":{\"id\":-1001,\"type\":\"group\"},\
+                \\"text\":\"continue\",\
+                \\"reply_to_message\":{\"message_id\":70,\
+                \\"from\":{\"id\":999,\"is_bot\":true,\
+                \\"username\":\"HarnessBot\"},\
+                \\"chat\":{\"id\":-1001,\"type\":\"group\"}}}}"
+            textAction `shouldBe`
+                QueueTurn
+                    83
+                    (TelegramChatKey (-1001) Nothing)
+                    "[Telegram group message from Marc, user 456]\ncontinue"
+                    Nothing
+
+            commandAction <- classify
+                "{\"update_id\":26,\"message\":{\
+                \\"message_id\":84,\"from\":{\"id\":456},\
+                \\"chat\":{\"id\":-1001,\"type\":\"group\"},\
+                \\"text\":\"/new\",\
+                \\"reply_to_message\":{\"message_id\":70,\
+                \\"from\":{\"id\":999,\"is_bot\":true},\
+                \\"chat\":{\"id\":-1001,\"type\":\"group\"}}}}"
+            commandAction `shouldBe`
+                QueueTurn
+                    84
+                    (TelegramChatKey (-1001) Nothing)
+                    "/new"
+                    Nothing
+
+            voiceAction <- classify
+                "{\"update_id\":27,\"message\":{\
+                \\"message_id\":85,\"message_thread_id\":7,\
+                \\"from\":{\"id\":456,\"first_name\":\"Marc\"},\
+                \\"chat\":{\"id\":-1002,\"type\":\"supergroup\"},\
+                \\"voice\":{\"file_id\":\"voice-file\",\"duration\":4},\
+                \\"reply_to_message\":{\"message_id\":71,\
+                \\"from\":{\"id\":999,\"is_bot\":true,\
+                \\"username\":\"HarnessBot\"},\
+                \\"chat\":{\"id\":-1002,\"type\":\"supergroup\"}}}}"
+            voiceAction `shouldBe`
+                QueueTurn
+                    85
+                    (TelegramChatKey (-1002) (Just 7))
+                    "[Telegram group message from Marc, user 456]\n\
+                    \[Voice message]"
+                    (Just (TelegramVoice "voice-file" 4 Nothing Nothing))
+
+        it "ignores ambient group traffic, other bots' commands, and blocked users" do
+            ambient <- classify
+                "{\"update_id\":27,\"message\":{\
+                \\"message_id\":85,\"from\":{\"id\":456},\
+                \\"chat\":{\"id\":-1001,\"type\":\"group\"},\
+                \\"text\":\"hello everyone\"}}"
+            ambient `shouldBe` IgnoreUpdate
+
+            otherBot <- classify
+                "{\"update_id\":28,\"message\":{\
+                \\"message_id\":86,\"from\":{\"id\":456},\
+                \\"chat\":{\"id\":-1001,\"type\":\"group\"},\
+                \\"text\":\"/new@OtherBot\"}}"
+            otherBot `shouldBe` IgnoreUpdate
+
+            repliedOtherBot <- classify
+                "{\"update_id\":29,\"message\":{\
+                \\"message_id\":87,\"from\":{\"id\":456},\
+                \\"chat\":{\"id\":-1001,\"type\":\"group\"},\
+                \\"text\":\"/new@OtherBot\",\
+                \\"reply_to_message\":{\"message_id\":70,\
+                \\"from\":{\"id\":999,\"is_bot\":true},\
+                \\"chat\":{\"id\":-1001,\"type\":\"group\"}}}}"
+            repliedOtherBot `shouldBe` IgnoreUpdate
+
+            blocked <- classify
+                "{\"update_id\":30,\"message\":{\
+                \\"message_id\":88,\"from\":{\"id\":123},\
+                \\"chat\":{\"id\":-1001,\"type\":\"group\"},\
+                \\"text\":\"@HarnessBot hello\"}}"
+            blocked `shouldBe` IgnoreUpdate
+
     describe "durable queue state" do
         it "loads state written before pending turns were introduced" do
             let decoded = eitherDecode


### PR DESCRIPTION
## Summary
- accept allowlisted Telegram group and supergroup messages when the bot is mentioned, addressed by command, or replied to
- keep separate persisted conversations per group/forum topic and attribute prompts to the sending member
- reply to the triggering Telegram message while preserving private-chat behavior
- document group usage and add classifier coverage for authorization, commands, replies, voice messages, and topics

## Testing
- `nix develop -c cabal repl agent-cli:test:agent-cli-test --offline --repl-options='-e Test.Hspec.hspec(Agent.TelegramSpec.spec)'` (30 examples, 0 failures)
- `nix develop -c cabal repl agent-cli:test:agent-cli-test --offline --repl-options='-e main'` (789 examples, 0 failures)
- `git diff --check`