### PR TITLE
fix(nix): include GHCi in installed agent CLI

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -293,12 +293,17 @@
                             nativeBuildInputs =
                                 (old.nativeBuildInputs or [ ])
                                 ++ [ pkgs.makeWrapper ];
+                            disallowedRequisites = pkgs.lib.remove
+                                haskellPackages.ghc
+                                (old.disallowedRequisites or [ ]);
                             postInstall =
                                 (old.postInstall or "")
                                 + ''
                                     wrapProgram "$out/bin/agent-cli" \
                                         --set-default AGENT_SYNTAX_DIR \
-                                            "${skylightingSyntaxDirectory}"
+                                            "${skylightingSyntaxDirectory}" \
+                                        --prefix PATH : \
+                                            "${pkgs.lib.makeBinPath [ haskellPackages.ghc ]}"
                                 '';
                         });
                 agentOpenaiExecutables = pkgs.haskell.lib.justStaticExecutables agentOpenaiPackage;


### PR DESCRIPTION
## Summary

- add the flake's GHC to the installed `agent-cli` runtime PATH
- allow the intentional GHC runtime reference while preserving other `justStaticExecutables` restrictions
- make the default `run_ghci` tool work for `nix run` and `nix profile` users without a host GHC installation

## Testing

- `nix build .#agent-cli --no-link --print-out-paths`
- ran the packaged `agent-cli --version` with an otherwise empty `PATH`
- verified the generated wrapper includes the packaged GHC 9.10.3 binary directory
