### PR TITLE
Show full commands in permission prompts

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Permission.hs
+++ b/packages/agent-cli/src/Agent/CLI/Permission.hs
@@ -15,8 +15,8 @@ import Agent.CLI.Notification
     )
 import Agent.CLI.Options (ApprovalAnswer(..), parseApprovalAnswer)
 import Agent.CLI.Picker (PickerKey(..), runOverlay)
-import Agent.CLI.Render (summarizeToolCall)
 import Agent.CLI.Style (glyphWarn, roleMuted, roleSuccess, roleWarn)
+import Agent.TUI.Presentation (permissionToolCallPrompt)
 import Agent.ToolDispatch (ToolCall)
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
@@ -74,7 +74,7 @@ choiceFromIndex = \case
 renderPermissionFrame :: Bool -> PermissionState -> Text
 renderPermissionFrame color state =
     let header =
-            roleWarn color (glyphWarn <> "Allow " <> state.permSummary <> "?")
+            roleWarn color (glyphWarn <> state.permSummary)
         rows =
             zipWith
                 (\i label -> renderRow color (i == state.permIndex) label)
@@ -96,7 +96,7 @@ renderRow color selected label =
 promptPermission :: Bool -> ToolCall -> IO (Maybe PermissionChoice)
 promptPermission color call = do
     isTty <- hIsTerminalDevice stdin
-    let summary = summarizeToolCall call
+    let summary = permissionToolCallPrompt call
     if not isTty
         then cooked color summary
         else do
@@ -111,7 +111,7 @@ promptPermission color call = do
 cooked :: Bool -> Text -> IO (Maybe PermissionChoice)
 cooked color summary = do
     let question =
-            roleWarn color (glyphWarn <> "Allow " <> summary <> "? [y/N/a] ")
+            roleWarn color (glyphWarn <> summary <> " [y/N/a] ")
     readApprovalLine question >>= \case
         Nothing -> pure Nothing
         Just raw -> pure $ Just $ case parseApprovalAnswer raw of

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -99,7 +99,7 @@ import Agent.CLI.Resume
     , toggleResumeExpanded
     , visibleResumeBrowser
     )
-import Agent.CLI.Render (formatElapsed, summarizeToolCall)
+import Agent.CLI.Render (formatElapsed)
 import Agent.CLI.Style (motionGlyphSet)
 import Agent.CLI.Status (formatTokenUsage)
 import Agent.CLI.Terminal
@@ -141,6 +141,7 @@ import Agent.TUI.Motion
     , quietIndicator
     , waitingIndicator
     )
+import Agent.TUI.Presentation (permissionToolCallPrompt)
 import Agent.Loop (ImageAttachment(..), LoopEvent(..))
 import Agent.ToolDispatch (ToolCall(..))
 import Brick
@@ -508,7 +509,7 @@ requestFullscreenPermission
     -> IO (Maybe PermissionChoice)
 requestFullscreenPermission runtime call = do
     reply <- newEmptyTMVarIO
-    let summary = summarizeToolCall call
+    let summary = permissionToolCallPrompt call
     enqueueAppEvent runtime (AppAskPermission summary reply)
     atomically (readTMVar reply)
 
@@ -2733,7 +2734,7 @@ drawPermission state permission =
                         (waitingOverlayLabel state "Permission") $
                         padAll 1 $
                             vBox
-                                [ txtWrap ("Allow " <> permission.permissionSummary <> "?")
+                                [ txtWrap permission.permissionSummary
                                 , padTop (Pad 1) $
                                     vBox $
                                         zipWith

--- a/packages/agent-cli/test/Agent/CLI/PermissionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/PermissionSpec.hs
@@ -38,8 +38,9 @@ spec = do
         it "names the tool and the three choices" do
             let frame =
                     renderPermissionFrame False
-                        (initialPermissionState "search_replace src/A.hs")
-            frame `shouldSatisfy` Text.isInfixOf "search_replace src/A.hs"
+                        (initialPermissionState "Allow search_replace src/A.hs?")
+            frame `shouldSatisfy`
+                Text.isInfixOf "Allow search_replace src/A.hs?"
             frame `shouldSatisfy` Text.isInfixOf "Allow once"
             frame `shouldSatisfy` Text.isInfixOf "Always allow this tool this session"
             frame `shouldSatisfy` Text.isInfixOf "Deny"

--- a/packages/agent-tui/src/Agent/TUI/Presentation.hs
+++ b/packages/agent-tui/src/Agent/TUI/Presentation.hs
@@ -6,6 +6,7 @@ module Agent.TUI.Presentation
     , formatSearchReplaceDiff
     , formatToolOutput
     , parseSearchReplaceDiff
+    , permissionToolCallPrompt
     , summarizeToolCall
     , toolCallInput
     , toolCallTitle
@@ -13,6 +14,7 @@ module Agent.TUI.Presentation
     ) where
 
 import Agent.JsonText (jsonTextField, jsonTextFieldDefault)
+import Agent.TUI.TextWidth (displayTerminalText)
 import Agent.ToolDispatch
     ( ToolCall(..)
     , canonicalToolName
@@ -31,6 +33,30 @@ summarizeToolCall call =
     let verb = toolVerb call.name
         detail = toolDetail call
     in if Text.null detail then verb else verb <> " " <> detail
+
+-- | Complete question shown before a mutating tool call is approved.
+-- Command-like tools include their full input: a first-line activity summary
+-- is not enough for multiline @do@ blocks or shell scripts.
+permissionToolCallPrompt :: ToolCall -> Text
+permissionToolCallPrompt call =
+    displayTerminalText case canonicalToolName call.name of
+        "run_ghci" ->
+            detailedPrompt
+                "Evaluate this Haskell code in GHCi?"
+                (jsonTextFieldDefault "expression" call.arguments)
+        "run_terminal_cmd" ->
+            detailedPrompt
+                "Run this shell command?"
+                (jsonTextFieldDefault "command" call.arguments)
+        "shell_command" ->
+            detailedPrompt
+                "Run this shell command?"
+                (jsonTextFieldDefault "command" call.arguments)
+        _ -> "Allow " <> summarizeToolCall call <> "?"
+  where
+    detailedPrompt question input
+        | Text.null (Text.strip input) = question
+        | otherwise = question <> "\n\n" <> input
 
 -- | Compact heading for a retained tool block. GHCi expressions are rendered
 -- separately as code, so keeping them out of the heading avoids an unbounded

--- a/packages/agent-tui/test/Agent/TUI/PresentationSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/PresentationSpec.hs
@@ -52,6 +52,34 @@ spec = describe "tool presentation" do
             `shouldBe` "do { putStrLn \"one\"; putStrLn \"two\" }"
         summarizeToolCall call
             `shouldBe` "$ do { putStrLn \"one\"; putStrLn \"two\" }"
+        permissionToolCallPrompt call
+            `shouldBe`
+                "Evaluate this Haskell code in GHCi?\n\n\
+                \do { putStrLn \"one\"; putStrLn \"two\" }"
+
+    it "shows complete multiline code and shell commands for permission" do
+        permissionToolCallPrompt
+            (functionToolCall
+                "ghci"
+                "run_ghci"
+                "{\"expression\":\"do\\n  putStrLn \\\"one\\\"\\n  putStrLn \\\"two\\\"\"}")
+            `shouldBe`
+                "Evaluate this Haskell code in GHCi?\n\n\
+                \do\n  putStrLn \"one\"\n  putStrLn \"two\""
+        permissionToolCallPrompt
+            (functionToolCall
+                "shell"
+                "shell_command"
+                "{\"command\":\"git status --short\\ngit diff --check\"}")
+            `shouldBe`
+                "Run this shell command?\n\ngit status --short\ngit diff --check"
+        permissionToolCallPrompt
+            (functionToolCall
+                "shell"
+                "shell_command"
+                "{\"command\":\"printf '\\u001b]0;owned\\u0007'\"}")
+            `shouldBe`
+                "Run this shell command?\n\nprintf '␛]0;owned␇'"
 
     it "falls back to the safe prompt text for ask_secret detail" do
         toolDetail


### PR DESCRIPTION
## Summary
- show complete multiline GHCi expressions in permission prompts
- show complete multiline shell commands in both minimal and fullscreen dialogs
- render terminal control characters as inert visible glyphs

## Tests
- `nix develop -c cabal repl agent-tui:test:agent-tui-test --repl-options=-e --repl-options=main` (129 examples)
- `nix develop -c cabal repl agent-cli:test:agent-cli-test --repl-options=-e --repl-options=main` (801 examples)
- multi-package GHCi typecheck
- live tmux TTY smoke test with a multiline `do` block
- `git diff --check`