### PR TITLE
Fix slow text paste handling

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Clipboard.hs
+++ b/packages/agent-cli/src/Agent/CLI/Clipboard.hs
@@ -5,7 +5,9 @@ module Agent.CLI.Clipboard
     , readClipboardImage
     , readClipboardImages
     , readClipboardImagesImageFirst
+    , readClipboardText
     , nonEmptyClipboardImages
+    , nonEmptyClipboardText
     , loadImagesFromPastedText
     , formatImageSize
     ) where
@@ -107,6 +109,14 @@ nonEmptyClipboardImages
     -> Maybe [ImageAttachment]
 nonEmptyClipboardImages = \case
     Right images@(_:_) -> Just images
+    _ -> Nothing
+
+-- | Keep successful clipboard text, including whitespace-only text. Explicit
+-- Ctrl/Cmd+V should behave like a normal text paste whenever the clipboard
+-- exposes text, falling back to image attachment only when it does not.
+nonEmptyClipboardText :: Either Text Text -> Maybe Text
+nonEmptyClipboardText = \case
+    Right text | not (Text.null text) -> Just text
     _ -> Nothing
 
 formatImageSize :: Int -> Text

--- a/packages/agent-cli/src/Agent/CLI/Input.hs
+++ b/packages/agent-cli/src/Agent/CLI/Input.hs
@@ -31,8 +31,8 @@ module Agent.CLI.Input
     ) where
 
 import Agent.CLI.Clipboard
-    ( nonEmptyClipboardImages
-    , readClipboardImages
+    ( nonEmptyClipboardText
+    , readClipboardText
     )
 import Agent.CLI.Command
     ( SkillCommand
@@ -531,7 +531,7 @@ readEditorKey = do
             | isEOFError err -> pure EditorEof
             | otherwise -> throwIO err
         Right char
-            | isClipboardPasteKey char -> pure (EditorClipboardPaste Nothing)
+            | isClipboardPasteKey char -> readClipboardEditorKey
             | otherwise -> case char of
                 '\n' -> pure EditorEnter
                 '\r' -> pure EditorEnter
@@ -590,6 +590,7 @@ readCsiKey =
         Left err -> pure (EditorInputError err)
         Right body
             | isShiftEnterCsiBody body -> pure (EditorChar '\n')
+            | isClipboardPasteCsiBody body -> readClipboardEditorKey
             | Just key <- decodeKittyEditorKey body -> pure key
             | otherwise -> case body of
                 "A" -> pure EditorUp
@@ -606,14 +607,18 @@ readCsiKey =
                 "200~" ->
                     readBracketedPaste >>= \case
                         Left err -> pure (EditorInputError err)
-                        Right pasted -> do
-                            images <-
-                                nonEmptyClipboardImages <$> readClipboardImages
-                            pure $ case images of
-                                Just attached ->
-                                    EditorClipboardPaste (Just attached)
-                                Nothing -> EditorPaste pasted
+                        Right pasted
+                            | Text.null pasted ->
+                                pure (EditorClipboardPaste Nothing)
+                            | otherwise -> pure (EditorPaste pasted)
                 _ -> pure EditorIgnore
+
+readClipboardEditorKey :: IO EditorKey
+readClipboardEditorKey =
+    readClipboardText >>= \result ->
+        pure $ case nonEmptyClipboardText result of
+            Just text -> EditorPaste text
+            Nothing -> EditorClipboardPaste Nothing
 
 readCsiBody :: IO (Either Text String)
 readCsiBody = go 0 []

--- a/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
@@ -26,6 +26,10 @@ module Agent.CLI.TUI.Composer
     , wrapDraft
     ) where
 
+import Agent.CLI.Clipboard
+    ( nonEmptyClipboardText
+    , readClipboardText
+    )
 import Agent.CLI.Command
     ( SlashMenu(..)
     , SlashSuggestion(..)
@@ -547,8 +551,12 @@ handleComposerKey
                 moveCursor 1
         V.EvKey (V.KChar 'v') modifiers
             | V.MCtrl `elem` modifiers
-                || V.MMeta `elem` modifiers ->
-                submitRaw (ReplClipboardPaste ui.uiDraft Nothing)
+                || V.MMeta `elem` modifiers -> do
+                clipboardText <- liftIO readClipboardText
+                case nonEmptyClipboardText clipboardText of
+                    Just text -> insertPastedText text
+                    Nothing ->
+                        submitRaw (ReplClipboardPaste ui.uiDraft Nothing)
         V.EvKey V.KDel [] ->
             deleteAfter
         V.EvKey V.KLeft modifiers
@@ -573,16 +581,12 @@ handleComposerKey
             scrollConversationPage Down
         V.EvKey (V.KChar character) [] ->
             insertText (Text.singleton character)
-        V.EvPaste bytes -> do
-            let pasted = decodePaste bytes
-                before = Text.take ui.uiCursor ui.uiDraft
-                after = Text.drop ui.uiCursor ui.uiDraft
-                pastedDraft = before <> pasted <> after
-            modifyUi
-                (UiSetNotice
-                    (Just (progressNotice "Reading clipboard…")))
-            submitRaw
-                (ReplClipboardPasteOrText ui.uiDraft pastedDraft)
+        V.EvPaste bytes ->
+            case decodePaste bytes of
+                pasted
+                    | Text.null pasted ->
+                        submitRaw (ReplClipboardPaste ui.uiDraft Nothing)
+                    | otherwise -> insertPastedText pasted
         _ -> pure ()
   where
     submitRaw replLine = do
@@ -704,6 +708,10 @@ handleComposerKey
             UiSetDraft
                 (before <> inserted <> after)
                 (ui.uiCursor + Text.length inserted)
+
+    insertPastedText inserted = do
+        insertText inserted
+        modify' \current -> current { appPasted = True }
 
     deleteBefore = do
         state <- get

--- a/packages/agent-cli/test/Agent/CLI/ClipboardSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ClipboardSpec.hs
@@ -48,6 +48,13 @@ spec = do
             nonEmptyClipboardImages (Left "not an image")
                 `shouldBe` Nothing
 
+    describe "nonEmptyClipboardText" do
+        it "keeps successful text, including whitespace" do
+            nonEmptyClipboardText (Right "hello") `shouldBe` Just "hello"
+            nonEmptyClipboardText (Right "  ") `shouldBe` Just "  "
+            nonEmptyClipboardText (Right "") `shouldBe` Nothing
+            nonEmptyClipboardText (Left "not text") `shouldBe` Nothing
+
     describe "loadImagesFromPastedText" do
         it "returns Nothing for ordinary prompt text" do
             result <- loadImagesFromPastedText "fix the bug in Main.hs"


### PR DESCRIPTION
## Summary
- insert non-empty bracketed text pastes directly instead of probing image clipboard formats first
- make Ctrl/Cmd+V paste clipboard text, with image attachment as the fallback
- preserve image attachment behavior for empty/non-text clipboard contents in inline and fullscreen editors

## Verification
- loaded `agent-cli:lib:agent-cli` successfully in Cabal GHCi
- `nix develop -c cabal test agent-cli:agent-cli-test --test-options=--match clipboard`
- `nix develop -c cabal test agent-cli:agent-cli-test --test-options=--match nonEmptyClipboardText`
- tmux TTY smoke test for Ctrl+V and bracketed Command+V-style text paste