### PR TITLE
Add Codex-style dollar skill mentions

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Command.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command.hs
@@ -31,7 +31,7 @@ import Agent.CLI.Style (roleMuted, rolePrompt)
 import Agent.Responses.Types
 
 import qualified Data.Aeson.KeyMap as KeyMap
-import Data.Char (isSpace)
+import Data.Char (isAlphaNum, isSpace)
 import Data.List (find, isPrefixOf, sortOn)
 import Data.Maybe (fromMaybe, mapMaybe)
 import Data.Ord (Down(..))
@@ -559,13 +559,69 @@ slashMenuForWithSkillsAndModels
     -> Int
     -> Maybe SlashMenu
 slashMenuForWithSkillsAndModels skills modelIds text cursor
-    | cursor < 1 || not (Text.isPrefixOf "/" text) = Nothing
-    | otherwise =
+    | cursor < 1 = Nothing
+    | Text.isPrefixOf "/" text =
         let commandToken = Text.takeWhile (not . isSpace) text
             commandEnd = Text.length commandToken
         in if cursor <= commandEnd
             then commandMenu skills (Text.take cursor text) commandEnd
             else argumentMenu modelIds commandToken commandEnd text cursor
+    | otherwise =
+        skillMentionMenu skills text cursor
+
+skillMentionMenu :: [SkillCommand] -> Text -> Int -> Maybe SlashMenu
+skillMentionMenu skills text cursor = do
+    let before = Text.take cursor text
+        token = Text.takeWhileEnd (not . isSpace) before
+        replaceStart = cursor - Text.length token
+    queryToken <- Text.stripPrefix "$" token
+    if Text.any (not . mentionNameChar) queryToken
+        then Nothing
+        else do
+            let query = Text.toLower queryToken
+                scored =
+                    mapMaybe
+                        (\(order, skill) -> do
+                            (score, positions) <-
+                                fuzzyMatch query
+                                    (Text.toLower skill.skillCommandName)
+                            pure (score, order, skill, positions))
+                        (zip [0 :: Int ..] skills)
+                ordered
+                    | Text.null query = scored
+                    | otherwise =
+                        sortOn
+                            (\(score, order, _, _) -> (Down score, order))
+                            scored
+                rows =
+                    [ SlashSuggestion
+                        { slashSuggestionDisplay =
+                            "$" <> skill.skillCommandName
+                        , slashSuggestionReplacement =
+                            "$" <> skill.skillCommandName <> " "
+                        , slashSuggestionSummary =
+                            skill.skillCommandSummary
+                                <> " · skill · "
+                                <> skill.skillCommandSource
+                        , slashSuggestionTakesArguments = True
+                        , slashSuggestionMatchPositions = map (+ 1) positions
+                        }
+                    | (_, _, skill, positions) <- ordered
+                    ]
+                replaceEnd =
+                    cursor
+                        + Text.length
+                            (Text.takeWhile mentionNameChar (Text.drop cursor text))
+            if null rows
+                then Nothing
+                else Just SlashMenu
+                    { slashMenuReplaceStart = replaceStart
+                    , slashMenuReplaceEnd = replaceEnd
+                    , slashMenuSuggestions = rows
+                    }
+  where
+    mentionNameChar char =
+        not (isSpace char) && (char == '-' || char == ':' || isAlphaNum char)
 
 commandMenu :: [SkillCommand] -> Text -> Int -> Maybe SlashMenu
 commandMenu skills token replaceEnd =

--- a/packages/agent-cli/src/Agent/CLI/Skills.hs
+++ b/packages/agent-cli/src/Agent/CLI/Skills.hs
@@ -246,13 +246,17 @@ formatSkillsListing color catalog invocations =
         , invocation.invocationSkill.skillPath == skill.skillPath
         ]
     render skill =
-        let names = namesFor skill
+        let slashNames = namesFor skill
+            dollarNames = dollarNamesFor skill
             invocationText =
-                if null names
-                    then case dollarNamesFor skill of
-                        dollar : _ -> dollar <> " only"
-                        [] -> "(model-only)"
-                    else Text.intercalate ", " names
+                case dollarNames of
+                    dollar : _ ->
+                        Text.intercalate ", "
+                            (dollar : slashNames)
+                    [] ->
+                        if null slashNames
+                            then "(model-only)"
+                            else Text.intercalate ", " slashNames
         in rolePrompt color invocationText
             <> "  "
             <> roleMuted color

--- a/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
@@ -80,12 +80,20 @@ drawSlashMenu state = case currentSlashMenu state of
         in padLeftRight 2 $
             withAttr Theme.borderAttr $
                 withBorderStyle unicodeRounded $
-                    Border.borderWithLabel (txt " Commands ") $
+                    Border.borderWithLabel (txt (menuLabel menu)) $
                         vBox $
                             zipWith
                                 (drawSlashRow selected)
                                 [start ..]
                                 suggestions
+  where
+    menuLabel menu =
+        case menu.slashMenuSuggestions of
+            suggestion : _
+                | "$" `Text.isPrefixOf`
+                    suggestion.slashSuggestionDisplay ->
+                        " Skills "
+            _ -> " Commands "
 
 drawSlashRow :: Int -> Int -> SlashSuggestion -> Widget Name
 drawSlashRow selected index suggestion =

--- a/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
@@ -368,6 +368,20 @@ spec = do
             Text.unpack help `shouldSatisfy` ("Deploy the service" `isInfixOf`)
             Text.unpack help `shouldSatisfy` ("skill · repo · agents" `isInfixOf`)
 
+        it "offers Codex-style dollar skill mentions inside prompts" do
+            fmap (map (.slashSuggestionDisplay) . (.slashMenuSuggestions))
+                (slashMenuForWithSkills skills "please $dep" 11)
+                `shouldBe` Just ["$deploy"]
+            fmap
+                (\menu ->
+                    ( menu.slashMenuReplaceStart
+                    , menu.slashMenuReplaceEnd
+                    , map (.slashSuggestionReplacement)
+                        menu.slashMenuSuggestions
+                    ))
+                (slashMenuForWithSkills skills "please $dep later" 11)
+                `shouldBe` Just (7, 11, ["$deploy "])
+
         it "combines runtime skills and model ids" do
             slashCompletionCandidatesWithSkillsAndModels
                 skills

--- a/packages/agent-cli/test/Agent/CLI/SkillsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SkillsSpec.hs
@@ -96,6 +96,15 @@ spec = describe "Agent.CLI.Skills" do
             , skillCommandSource = "user · agents"
             }
 
+    it "lists Codex dollar syntax before the slash compatibility alias" do
+        let invocation = SkillInvocation "deploy" fakeSkill True
+            listing =
+                formatSkillsListing
+                    False
+                    (SkillCatalog [fakeSkill] [])
+                    [invocation]
+        listing `shouldSatisfy` Text.isInfixOf "$deploy, /deploy"
+
     it "installs a deferred catalog, invocations, and startup context together" do
         context <- newIORef (Just "agents")
         catalogRef <- newIORef (SkillCatalog [] [])

--- a/packages/agent-core/src/Agent/Skills.hs
+++ b/packages/agent-core/src/Agent/Skills.hs
@@ -532,6 +532,7 @@ formatSkillCatalogContext maxChars catalog
                 [ "## Skills"
                 , "The following reusable skills are available in this session."
                 , "Use a skill when the user names it or the task clearly matches its description."
+                , "Users can explicitly invoke a skill with `$skill-name`."
                 , "After choosing a skill, read its SKILL.md from the listed path and follow it."
                 , "Resolve relative scripts, references, and assets from the skill directory."
                 , "Load only the resources needed for the task; do not carry skills across turns unless relevant again."
@@ -548,7 +549,7 @@ formatSkillCatalogContext maxChars catalog
 
 renderSkillLine :: Skill -> Text
 renderSkillLine skill =
-    "- "
+    "- $"
         <> skill.skillName
         <> ": "
         <> Text.replace "\n" " " skill.skillDescription
@@ -576,7 +577,7 @@ fitSkillLines budget = go budget []
 
 renderShortenedSkillLine :: Int -> Skill -> Maybe Text
 renderShortenedSkillLine remaining skill =
-    let prefix = "- " <> skill.skillName <> ": "
+    let prefix = "- $" <> skill.skillName <> ": "
         suffix = " (file: " <> toText skill.skillPath <> ")"
         available = remaining - Text.length prefix - Text.length suffix - 2
     in if available < 12

--- a/packages/agent-core/test/Agent/SkillsSpec.hs
+++ b/packages/agent-core/test/Agent/SkillsSpec.hs
@@ -114,7 +114,9 @@ spec = describe "Agent.Skills" do
                 formatSkillCatalogContext 1000 (SkillCatalog [visible, hidden] [])
         case rendered of
             Just text -> do
-                text `shouldSatisfy` Text.isInfixOf "visible"
+                text `shouldSatisfy` Text.isInfixOf "$visible"
+                text `shouldSatisfy`
+                    Text.isInfixOf "explicitly invoke a skill with `$skill-name`"
                 text `shouldSatisfy` (not . Text.isInfixOf "hidden")
                 Text.length text `shouldSatisfy` (<= 1000)
             Nothing ->


### PR DESCRIPTION
## Summary
- expose `$skill-name` as the primary explicit skill invocation syntax
- add inline dollar-skill completion to both CLI editors and label it as Skills in the fullscreen TUI
- retain `/skill-name` as a compatibility alias and document the syntax in model context

## Testing
- multi-package GHCi load: 196 modules
- `Agent.Skills`: 9 examples, 0 failures
- `Agent.CLI.Skills`: 8 examples, 0 failures
- Codex-style completion spec: 1 example, 0 failures
- live fullscreen TUI smoke test in tmux with `$add` -> `$add-model`
- `git diff --check`
