### PR TITLE
Inherit Ghostty terminal themes in the CLI

### DIFF
--- a/docs/ghostty.md
+++ b/docs/ghostty.md
@@ -6,6 +6,10 @@ wrapped for tmux passthrough when `TMUX` is set.
 
 ## Integrated features
 
+- Native theme inheritance: the CLI uses Ghostty's configured foreground,
+  background, and ANSI palette instead of forcing a built-in dark palette.
+  This supports light themes such as `Modus Operandi Tinted` and follows
+  Ghostty's automatic light/dark theme switching.
 - Kitty graphics previews for pasted images.
 - OSC 7 working-directory reporting, including agent worktrees.
 - OSC 8 links for Markdown URLs and absolute tool file paths.

--- a/packages/agent-cli/src/Agent/CLI/Markdown.hs
+++ b/packages/agent-cli/src/Agent/CLI/Markdown.hs
@@ -8,13 +8,13 @@ module Agent.CLI.Markdown
 import Agent.CLI.Style
     ( agentBackground
     , osc8Link
-    , solarizedBase01
-    , solarizedBlue
-    , solarizedCyan
-    , solarizedGreen
-    , solarizedMagenta
-    , solarizedViolet
-    , solarizedYellow
+    , terminalBlue
+    , terminalCyan
+    , terminalGreen
+    , terminalMagenta
+    , terminalMuted
+    , terminalViolet
+    , terminalYellow
     , styleBase
     )
 import Agent.TUI.FencedCode
@@ -33,20 +33,18 @@ import Agent.TUI.TextWidth
     , displayTerminalText
     )
 import Data.Char (isAlphaNum, isAscii, isSpace)
-import Data.Colour (Colour)
 import Data.List (transpose)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import System.Console.ANSI
     ( ConsoleIntensity(..)
-    , ConsoleLayer(..)
     , SGR(..)
     , Underlining(..)
     )
 
 -- | When @color@ is 'True', style a useful subset of GFM for a TTY.
 -- When 'False', return @text@ unchanged (pipes, redirects, tests).
--- Nested spans restore 'agentBackground' after each 'Reset'.
+-- Nested spans restore the terminal-owned 'agentBackground' after each 'Reset'.
 renderMarkdown :: Bool -> Text -> Text
 renderMarkdown color text
     | not color = text
@@ -57,7 +55,7 @@ renderMarkdown color text
     renderChunk (FenceBlock block) =
         let header
                 | Text.null block.fencedInfo = ""
-                | otherwise = md [fg solarizedCyan] block.fencedInfo <> "\n"
+                | otherwise = md [terminalCyan] block.fencedInfo <> "\n"
             body = renderFenceBody block.fencedBody
         in header <> body
 
@@ -80,10 +78,10 @@ renderFenceBody body =
             | otherwise = lines_
         rendered =
             Text.intercalate "\n"
-                (map (md [fg solarizedBase01]) actualLines)
+                (map (md [terminalMuted]) actualLines)
     in if endsWithNewline then rendered <> "\n" else rendered
 
--- | Style helper that keeps the agent line wash across nested SGR.
+-- | Style helper that restores the agent's terminal-default background.
 md :: [SGR] -> Text -> Text
 md = styleBase True agentBackground
 
@@ -114,10 +112,10 @@ renderBlocks = go
             let body =
                     renderInlineWith quoteStyle
                         (parseInline (Text.stripStart quote))
-            in (md [fg solarizedBase01] "│ " <> body)
+            in (md [terminalMuted] "│ " <> body)
                 : go rest
         | Block.isThematicBreak line =
-            md [fg solarizedBase01] (Text.replicate 40 "─")
+            md [terminalMuted] (Text.replicate 40 "─")
                 : go rest
         | Text.null (Text.strip line) = line : go rest
         | otherwise = styleInline line : go rest
@@ -129,33 +127,30 @@ headingPrefixStyle level =
 
 headingColor :: Int -> [SGR]
 headingColor = \case
-    1 -> [fg solarizedMagenta]
-    2 -> [fg solarizedCyan]
-    3 -> [fg solarizedBlue]
-    4 -> [fg solarizedYellow]
-    5 -> [fg solarizedGreen]
-    _ -> [fg solarizedViolet]
+    1 -> [terminalMagenta]
+    2 -> [terminalCyan]
+    3 -> [terminalBlue]
+    4 -> [terminalYellow]
+    5 -> [terminalGreen]
+    _ -> [terminalViolet]
 
 listMarkerStyle :: [SGR]
 listMarkerStyle =
     [ SetConsoleIntensity BoldIntensity
-    , fg solarizedCyan
+    , terminalCyan
     ]
-
-fg :: Colour Float -> SGR
-fg = SetRGBColor Foreground
 
 -- | Blockquote body: muted so it sits behind surrounding prose.
 quoteStyle :: [SGR]
-quoteStyle = [fg solarizedBase01]
+quoteStyle = [terminalMuted]
 
 renderTable :: [[Text]] -> [Text]
 renderTable [] = []
 renderTable rows@(headerCells : bodyCells) =
     let widths = columnWidths rows
-        top = md [fg solarizedBase01] (boxLine '┌' '┬' '┐' '─' widths)
-        mid = md [fg solarizedBase01] (boxLine '├' '┼' '┤' '─' widths)
-        bot = md [fg solarizedBase01] (boxLine '└' '┴' '┘' '─' widths)
+        top = md [terminalMuted] (boxLine '┌' '┬' '┐' '─' widths)
+        mid = md [terminalMuted] (boxLine '├' '┼' '┤' '─' widths)
+        bot = md [terminalMuted] (boxLine '└' '┴' '┘' '─' widths)
         headerRow = styleTableRow True widths headerCells
         bodyRows = map (styleTableRow False widths) bodyCells
     in [top, headerRow, mid] ++ bodyRows ++ [bot]
@@ -199,7 +194,7 @@ styleTableRow isHeader widths cells =
                 <> Text.replicate padding " "
                 <> " "
         parts = zipWith cellText widths (cells ++ repeat "")
-        bar = md [fg solarizedBase01] "│"
+        bar = md [terminalMuted] "│"
     in bar <> Text.intercalate bar (take (length widths) parts) <> bar
 
 styleInline :: Text -> Text
@@ -254,13 +249,13 @@ renderInlineWith base = Text.concat . map (go base)
 
     codeStyle =
         [ SetConsoleIntensity BoldIntensity
-        , fg solarizedCyan
+        , terminalCyan
         ]
     linkStyle =
-        [ fg solarizedBlue
+        [ terminalBlue
         , SetUnderlining SingleUnderline
         ]
-    urlStyle = [fg solarizedBase01]
+    urlStyle = [terminalMuted]
 
 -- | Split an inline markdown stream into a prefix that can be rendered without
 -- future input and a suffix beginning at a possibly incomplete construct.

--- a/packages/agent-cli/src/Agent/CLI/Plan.hs
+++ b/packages/agent-cli/src/Agent/CLI/Plan.hs
@@ -39,7 +39,7 @@ import Agent.CLI.Style
     , rolePrompt
     , roleSuccess
     , roleWarn
-    , solarizedCyan
+    , terminalCyan
     , style
     )
 import Agent.Tools.PlanMode
@@ -57,7 +57,6 @@ import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
 import System.Console.ANSI
     ( ConsoleIntensity(..)
-    , ConsoleLayer(..)
     , SGR(..)
     )
 import System.Console.ANSI.Codes (clearFromCursorToLineEndCode)
@@ -289,7 +288,7 @@ formatChoiceLine color selected label
     | selected =
         style color
             [ SetConsoleIntensity BoldIntensity
-            , SetRGBColor Foreground solarizedCyan
+            , terminalCyan
             ]
             label
     | otherwise = roleMuted color label

--- a/packages/agent-cli/src/Agent/CLI/Render.hs
+++ b/packages/agent-cli/src/Agent/CLI/Render.hs
@@ -70,8 +70,8 @@ import Agent.CLI.Style
     , roleToolOutput
     , roleToolPath
     , roleWarn
-    , solarizedGreen
-    , solarizedRed
+    , terminalGreen
+    , terminalRed
     , motionGlyphSet
     , style
     )
@@ -117,7 +117,6 @@ import Agent.TUI.Motion
     , motionIntervalMicros
     , nativeProgressAnimationEnabled
     )
-import System.Console.ANSI (ConsoleLayer(..), SGR(..))
 import System.Environment (lookupEnv)
 import System.IO (Handle, hFlush)
 
@@ -554,7 +553,7 @@ renderEventUnlocked config = \case
             (roleToolOutput config.renderColor (truncateToolOutput output))
 
 -- | Style assistant markdown when color is enabled; otherwise return plain text.
--- Color mode also paints each line with 'agentBackground'.
+-- The terminal theme owns the default assistant background.
 renderAssistantText :: Bool -> Text -> Text
 renderAssistantText color text =
     paintBackgroundLines color agentBackground (renderMarkdown color text)
@@ -970,9 +969,9 @@ formatSearchReplaceDiff color arguments =
   where
     paintLine = \case
         SearchReplaceRemoved line ->
-            style color [SetRGBColor Foreground solarizedRed] ("  -" <> line)
+            style color [terminalRed] ("  -" <> line)
         SearchReplaceAdded line ->
-            style color [SetRGBColor Foreground solarizedGreen] ("  +" <> line)
+            style color [terminalGreen] ("  +" <> line)
 
 renderToolPath :: Bool -> Text -> Text
 renderToolPath color path =

--- a/packages/agent-cli/src/Agent/CLI/Style.hs
+++ b/packages/agent-cli/src/Agent/CLI/Style.hs
@@ -1,8 +1,10 @@
 -- | Shared ANSI roles for TTY chrome and markdown. Callers pass a color
 -- flag; when 'False' (pipes, 'NO_COLOR', tests) text is unchanged.
 --
--- Palette is Solarized Dark (Ethan Schoonover): truecolor RGB, not the
--- 256-color approximation, so washes match a Solarized terminal theme.
+-- Semantic colors use the terminal's configurable ANSI palette, while
+-- foreground and background remain at their terminal defaults. This lets
+-- Ghostty and other terminal themes control both light/dark appearance and
+-- the actual accent colors.
 module Agent.CLI.Style
     ( style
     , styleBase
@@ -38,15 +40,15 @@ module Agent.CLI.Style
     , detectColorLevel
     , adaptSgr
     , osc8Link
-    , solarizedCyan
-    , solarizedMagenta
-    , solarizedYellow
-    , solarizedRed
-    , solarizedGreen
-    , solarizedBlue
-    , solarizedViolet
-    , solarizedOrange
-    , solarizedBase01
+    , terminalCyan
+    , terminalMagenta
+    , terminalYellow
+    , terminalRed
+    , terminalGreen
+    , terminalBlue
+    , terminalViolet
+    , terminalOrange
+    , terminalMuted
     , cliWindowTitle
     , setCliWindowTitle
     ) where
@@ -56,7 +58,7 @@ import Agent.TUI.Motion
     , foregroundSpinnerFrames
     )
 import Data.Colour (Colour)
-import Data.Colour.SRGB (RGB(..), sRGB24, toSRGB24)
+import Data.Colour.SRGB (RGB(..), toSRGB24)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Word (Word8)
@@ -64,6 +66,8 @@ import System.Console.ANSI
     ( ConsoleIntensity(..)
     , ConsoleLayer(..)
     , SGR(..)
+    , Color(..)
+    , ColorIntensity(..)
     , hSetTitle
     )
 import System.Console.ANSI.Codes (setSGRCode)
@@ -72,39 +76,25 @@ import System.OsPath (OsPath)
 import System.IO (Handle)
 import System.IO.Unsafe (unsafePerformIO)
 
--- Solarized Dark (https://ethanschoonover.com/solarized/)
-solarizedBase03, solarizedBase02, solarizedBase01 :: Colour Float
-solarizedBase03 = sRGB24 0x00 0x2b 0x36
-solarizedBase02 = sRGB24 0x07 0x36 0x42
-solarizedBase01 = sRGB24 0x58 0x6e 0x75
+terminalCyan, terminalMagenta, terminalYellow, terminalRed :: SGR
+terminalGreen, terminalBlue, terminalViolet, terminalOrange, terminalMuted :: SGR
+terminalCyan = SetColor Foreground Dull Cyan
+terminalMagenta = SetColor Foreground Dull Magenta
+terminalYellow = SetColor Foreground Dull Yellow
+terminalRed = SetColor Foreground Dull Red
+terminalGreen = SetColor Foreground Dull Green
+terminalBlue = SetColor Foreground Dull Blue
+terminalViolet = SetColor Foreground Vivid Magenta
+terminalOrange = SetColor Foreground Vivid Yellow
+terminalMuted = SetColor Foreground Vivid Black
 
-solarizedYellow, solarizedOrange, solarizedRed :: Colour Float
-solarizedYellow = sRGB24 0xb5 0x89 0x00
-solarizedOrange = sRGB24 0xcb 0x4b 0x16
-solarizedRed = sRGB24 0xdc 0x32 0x2f
-
-solarizedMagenta, solarizedViolet, solarizedBlue :: Colour Float
-solarizedMagenta = sRGB24 0xd3 0x36 0x82
-solarizedViolet = sRGB24 0x6c 0x71 0xc4
-solarizedBlue = sRGB24 0x26 0x8b 0xd2
-
-solarizedCyan, solarizedGreen :: Colour Float
-solarizedCyan = sRGB24 0x2a 0xa1 0x98
-solarizedGreen = sRGB24 0x85 0x99 0x00
-
-fg :: Colour Float -> SGR
-fg = SetRGBColor Foreground
-
-bg :: Colour Float -> SGR
-bg = SetRGBColor Background
-
--- | Solarized base02 strip behind the REPL prompt and typed input.
+-- | Prompt background. Empty means the terminal theme's default background.
 userBackground :: [SGR]
-userBackground = [bg solarizedBase02]
+userBackground = []
 
--- | Solarized base03 strip behind assistant stdout lines.
+-- | Assistant background. Empty means the terminal theme's default background.
 agentBackground :: [SGR]
-agentBackground = [bg solarizedBase03]
+agentBackground = []
 
 -- | Apply SGR attributes when @color@ is 'True'; otherwise return @text@.
 -- Ends with a full 'Reset'.
@@ -163,60 +153,60 @@ rolePrompt :: Bool -> Text -> Text
 rolePrompt color =
     styleBase color userBackground
         [ SetConsoleIntensity BoldIntensity
-        , fg solarizedCyan
+        , terminalCyan
         ]
 
 roleToolArrow :: Bool -> Text -> Text
-roleToolArrow color = style color [fg solarizedBase01]
+roleToolArrow color = style color [terminalMuted]
 
 roleToolName :: Bool -> Text -> Text
 roleToolName color =
     style color
         [ SetConsoleIntensity BoldIntensity
-        , fg solarizedMagenta
+        , terminalMagenta
         ]
 
 roleToolDetail :: Bool -> Text -> Text
-roleToolDetail color = style color [fg solarizedBase01]
+roleToolDetail color = style color [terminalMuted]
 
--- | File paths on tool rows (Solarized orange).
+-- | File paths on tool rows.
 roleToolPath :: Bool -> Text -> Text
-roleToolPath color = style color [fg solarizedOrange]
+roleToolPath color = style color [terminalOrange]
 
--- | Shell / GHCi command text on tool rows (Solarized yellow).
+-- | Shell / GHCi command text on tool rows.
 roleToolCommand :: Bool -> Text -> Text
-roleToolCommand color = style color [fg solarizedYellow]
+roleToolCommand color = style color [terminalYellow]
 
 roleToolOutput :: Bool -> Text -> Text
-roleToolOutput color = style color [fg solarizedBase01]
+roleToolOutput color = style color [terminalMuted]
 
 roleThinking :: Bool -> Text -> Text
 roleThinking color =
     style color
-        [ fg solarizedYellow
+        [ terminalYellow
         ]
 
 roleError :: Bool -> Text -> Text
 roleError color =
     style color
         [ SetConsoleIntensity BoldIntensity
-        , fg solarizedRed
+        , terminalRed
         ]
 
 roleWarn :: Bool -> Text -> Text
 roleWarn color =
     style color
         [ SetConsoleIntensity BoldIntensity
-        , fg solarizedYellow
+        , terminalYellow
         ]
 
 roleMuted :: Bool -> Text -> Text
-roleMuted color = style color [fg solarizedBase01]
+roleMuted color = style color [terminalMuted]
 
 roleSuccess :: Bool -> Text -> Text
 roleSuccess color =
     style color
-        [ fg solarizedGreen
+        [ terminalGreen
         ]
 
 supportsUnicodeChrome :: Bool

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -1542,7 +1542,7 @@ fullscreenApp = App
         vScrollToEnd (viewportScroll ConversationViewport)
     , appAttrMap = \state ->
         if state.appRuntime.runtimeColor
-            then Theme.solarizedDark
+            then Theme.terminalDefault
             else Theme.monochrome
     }
 

--- a/packages/agent-cli/test/Agent/CLI/MarkdownSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/MarkdownSpec.hs
@@ -204,10 +204,10 @@ spec = do
         it "preserves a trailing newline" do
             renderMarkdown True "hi\n" `shouldSatisfy` Text.isSuffixOf "\n"
 
-        it "restores the agent wash after inline spans" do
+        it "restores the terminal default background after inline spans" do
             let out = renderMarkdown True "see `file.txt` now"
-            -- Nested Reset must re-open Solarized base03 so line painting sticks.
-            out `shouldSatisfy` Text.isInfixOf "\ESC[0;48;2;0;43;54m"
+            out `shouldSatisfy` Text.isInfixOf "\ESC[1;36m"
+            out `shouldSatisfy` (not . Text.isInfixOf "48;")
 
     describe "splitMarkdownFragment" do
         it "holds a bold span until its closing delimiter arrives" do

--- a/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
@@ -422,7 +422,7 @@ spec = do
                 body <- Text.readFile path
                 body `shouldSatisfy` Text.isInfixOf "hello"
                 body `shouldSatisfy` Text.isInfixOf "\ESC["
-                body `shouldSatisfy` Text.isInfixOf "\ESC[48;2;0;43;54m"
+                body `shouldSatisfy` (not . Text.isInfixOf "48;")
                 body `shouldSatisfy` (not . Text.isInfixOf "**")
                 readIORef config.renderLiveActive `shouldReturn` False
 
@@ -435,7 +435,6 @@ spec = do
                 body `shouldSatisfy` Text.isInfixOf "first "
                 body `shouldSatisfy` Text.isInfixOf "second"
                 Text.count "first " body `shouldBe` 1
-                body `shouldSatisfy` Text.isInfixOf "\ESC["
                 body `shouldSatisfy` (not . Text.isInfixOf "\ESC7")
                 body `shouldSatisfy` (not . Text.isInfixOf "\ESC8")
 

--- a/packages/agent-cli/test/Agent/CLI/StyleSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/StyleSpec.hs
@@ -19,20 +19,17 @@ spec = do
             out `shouldSatisfy` Text.isInfixOf "\ESC["
             out `shouldSatisfy` (not . Text.isPrefixOf "λ")
 
-        it "restores a base wash after nested styling" do
+        it "uses the terminal default background after nested styling" do
             let out = styleBase True agentBackground [] "hi"
-            -- Reset then reopen Solarized base03 (combined into one SGR sequence).
-            out `shouldSatisfy` Text.isInfixOf "\ESC[0;48;2;0;43;54m"
+            out `shouldSatisfy` (not . Text.isInfixOf "48;")
 
     describe "paintBackgroundLines" do
         it "leaves text unchanged when color is off" do
             paintBackgroundLines False agentBackground "a\nb" `shouldBe` "a\nb"
 
-        it "paints each line and preserves a trailing newline" do
-            let out = paintBackgroundLines True agentBackground "a\nb\n"
-            Text.count "\ESC[48;2;0;43;54m" out `shouldBe` 2
-            out `shouldSatisfy` Text.isSuffixOf "\n"
-            out `shouldSatisfy` (not . Text.isInfixOf "\ESC[0K")
+        it "leaves lines on the terminal theme's default background" do
+            paintBackgroundLines True agentBackground "a\nb\n"
+                `shouldBe` "a\nb\n"
 
         it "does not erase with the terminal default background" do
             paintBackgroundLines True agentBackground "text"
@@ -46,11 +43,10 @@ spec = do
             roleError False "boom" `shouldBe` "boom"
             roleMuted False "session: 1" `shouldBe` "session: 1"
 
-        it "keeps the user wash under the prompt glyph" do
+        it "uses the terminal cyan slot without forcing a background" do
             let out = rolePrompt True "λ"
-            -- Background may share an SGR sequence with bold/cyan attrs (truecolor).
-            out `shouldSatisfy` Text.isInfixOf "48;2;7;54;66"
-            out `shouldSatisfy` Text.isInfixOf "\ESC[0;48;2;7;54;66m"
+            out `shouldSatisfy` Text.isInfixOf "\ESC[1;36m"
+            out `shouldSatisfy` (not . Text.isInfixOf "48;")
 
     describe "chrome glyphs" do
         it "exposes the shared Unicode markers" do

--- a/packages/agent-tui/src/Agent/TUI/Theme.hs
+++ b/packages/agent-tui/src/Agent/TUI/Theme.hs
@@ -45,7 +45,7 @@ module Agent.TUI.Theme
     , waitingMidAttr
     , completionFlashAttr
     , monochrome
-    , solarizedDark
+    , terminalDefault
     ) where
 
 import Agent.Syntax (SyntaxClass(..))
@@ -124,132 +124,60 @@ waitingDimAttr = attrName "waiting-dim"
 waitingMidAttr = attrName "waiting-mid"
 completionFlashAttr = attrName "completion-flash"
 
-solarizedDark :: AttrMap
-solarizedDark =
-    attrMap
-        (V.defAttr
-            `V.withForeColor` rgb 131 148 150
-            `V.withBackColor` rgb 0 43 54)
-        [ (baseAttr, V.defAttr
-            `V.withForeColor` rgb 131 148 150
-            `V.withBackColor` rgb 0 43 54)
-        , (headerAttr, V.defAttr
-            `V.withForeColor` rgb 147 161 161
-            `V.withBackColor` rgb 0 43 54)
-        , (footerAttr, V.defAttr
-            `V.withForeColor` rgb 88 110 117
-            `V.withBackColor` rgb 0 43 54)
-        , (mutedAttr, V.defAttr
-            `V.withForeColor` rgb 88 110 117
-            `V.withBackColor` rgb 0 43 54)
-        , (userAttr, V.defAttr
-            `V.withForeColor` rgb 147 161 161
-            `V.withBackColor` rgb 7 54 66)
-        , (assistantAttr, V.defAttr
-            `V.withForeColor` rgb 131 148 150
-            `V.withBackColor` rgb 0 43 54)
-        , (thinkingAttr, V.defAttr
-            `V.withForeColor` rgb 181 137 0
-            `V.withBackColor` rgb 0 43 54)
-        , (waitingDimAttr, V.defAttr
-            `V.withForeColor` rgb 101 83 0
-            `V.withBackColor` rgb 0 43 54)
-        , (waitingMidAttr, V.defAttr
-            `V.withForeColor` rgb 150 112 0
-            `V.withBackColor` rgb 0 43 54)
-        , (toolAttr, V.defAttr
-            `V.withForeColor` rgb 42 161 152
-            `V.withBackColor` rgb 0 43 54)
-        , (errorAttr, V.defAttr
-            `V.withForeColor` rgb 220 50 47
-            `V.withBackColor` rgb 0 43 54
-            `V.withStyle` V.bold)
-        , (successAttr, V.defAttr
-            `V.withForeColor` rgb 133 153 0
-            `V.withBackColor` rgb 0 43 54)
-        , (completionFlashAttr, V.defAttr
-            `V.withForeColor` rgb 181 196 0
-            `V.withBackColor` rgb 0 43 54
-            `V.withStyle` V.bold)
-        , (selectedAttr, V.defAttr
-            `V.withForeColor` rgb 147 161 161
-            `V.withBackColor` rgb 7 54 66)
-        -- Persistent UI chrome stays on Solarized's base ramp. Saturated
-        -- accents are reserved for semantic content and exceptional states.
-        , (borderAttr, V.defAttr
-            `V.withForeColor` rgb 88 110 117
-            `V.withBackColor` rgb 0 43 54)
-        , (borderActiveAttr, V.defAttr
-            `V.withForeColor` rgb 101 123 131
-            `V.withBackColor` rgb 0 43 54)
-        , (headingAttr, V.defAttr
-            `V.withForeColor` rgb 211 54 130
-            `V.withBackColor` rgb 0 43 54
-            `V.withStyle` V.bold)
-        , (codeAttr, V.defAttr
-            `V.withForeColor` rgb 42 161 152
-            -- Keep fenced code distinct from the terminal's Solarized
-            -- selection background so native drag selections stay visible.
-            `V.withBackColor` codeBlockBackground)
-        , (dimAttr, V.defAttr
-            `V.withForeColor` rgb 88 110 117
-            `V.withBackColor` rgb 0 43 54)
-        , (emphasisAttr, V.defAttr
-            `V.withForeColor` rgb 147 161 161
-            `V.withBackColor` rgb 0 43 54
-            `V.withStyle` V.italic)
-        , (inlineCodeAttr, V.defAttr
-            `V.withForeColor` rgb 42 161 152
-            `V.withBackColor` rgb 7 54 66)
-        , (lambdaDimAttr, V.defAttr
-            `V.withForeColor` rgb 69 94 100
-            `V.withBackColor` rgb 0 43 54)
-        , (lambdaTrailAttr, V.defAttr
-            `V.withForeColor` rgb 88 110 117
-            `V.withBackColor` rgb 0 43 54)
-        , (lambdaGlowAttr, V.defAttr
-            `V.withForeColor` rgb 101 123 131
-            `V.withBackColor` rgb 0 43 54
-            `V.withStyle` V.bold)
-        , (lambdaSparkAttr, V.defAttr
-            `V.withForeColor` rgb 131 148 150
-            `V.withBackColor` rgb 0 43 54
-            `V.withStyle` V.bold)
-        , (linkAttr, V.defAttr
-            `V.withForeColor` rgb 38 139 210
-            `V.withBackColor` rgb 0 43 54
-            `V.withStyle` V.underline)
-        , (strongAttr, V.defAttr
-            `V.withForeColor` rgb 147 161 161
-            `V.withBackColor` rgb 0 43 54
-            `V.withStyle` V.bold)
-        , (controlLinkAttr, V.defAttr
-            `V.withForeColor` rgb 101 123 131
-            `V.withBackColor` rgb 0 43 54)
-        , (controlLinkHoverAttr, V.defAttr
-            `V.withForeColor` rgb 131 148 150
-            `V.withBackColor` rgb 0 43 54
-            `V.withStyle` V.underline)
-        , (controlLinkActiveAttr, V.defAttr
-            `V.withForeColor` rgb 147 161 161
-            `V.withBackColor` rgb 7 54 66
-            `V.withStyle` V.bold)
-        , (syntaxNormalAttr, codeColor 42 161 152)
-        , (syntaxKeywordAttr, codeColor 211 54 130)
-        , (syntaxTypeAttr, codeColor 181 137 0)
-        , (syntaxFunctionAttr, codeColor 38 139 210)
-        , (syntaxVariableAttr, codeColor 42 161 152)
-        , (syntaxStringAttr, codeColor 42 161 152)
-        , (syntaxNumberAttr, codeColor 108 113 196)
+-- | Theme using only the terminal's default foreground/background and its
+-- configurable ANSI palette. Ghostty themes therefore apply directly,
+-- including automatic light/dark theme switching.
+terminalDefault :: AttrMap
+terminalDefault =
+    attrMap V.defAttr
+        [ (baseAttr, V.defAttr)
+        , (headerAttr, V.defAttr `V.withStyle` V.bold)
+        , (footerAttr, palette V.brightBlack)
+        , (mutedAttr, palette V.brightBlack)
+        , (userAttr, V.defAttr `V.withStyle` V.bold)
+        , (assistantAttr, V.defAttr)
+        , (thinkingAttr, palette V.yellow)
+        , (waitingDimAttr, palette V.brightBlack)
+        , (waitingMidAttr, palette V.yellow)
+        , (toolAttr, palette V.cyan)
+        , (errorAttr, palette V.red `V.withStyle` V.bold)
+        , (successAttr, palette V.green)
+        , (completionFlashAttr,
+            palette V.brightGreen `V.withStyle` V.bold)
+        , (selectedAttr, V.defAttr `V.withStyle` V.reverseVideo)
+        , (borderAttr, palette V.brightBlack)
+        , (borderActiveAttr, V.defAttr)
+        , (headingAttr, palette V.magenta `V.withStyle` V.bold)
+        , (codeAttr, palette V.cyan)
+        , (dimAttr, palette V.brightBlack)
+        , (emphasisAttr, V.defAttr `V.withStyle` V.italic)
+        , (inlineCodeAttr, palette V.cyan `V.withStyle` V.reverseVideo)
+        , (lambdaDimAttr, palette V.brightBlack)
+        , (lambdaTrailAttr, palette V.brightBlack)
+        , (lambdaGlowAttr, V.defAttr `V.withStyle` V.bold)
+        , (lambdaSparkAttr,
+            palette V.brightWhite `V.withStyle` V.bold)
+        , (linkAttr, palette V.blue `V.withStyle` V.underline)
+        , (strongAttr, V.defAttr `V.withStyle` V.bold)
+        , (controlLinkAttr, palette V.brightBlack)
+        , (controlLinkHoverAttr, V.defAttr `V.withStyle` V.underline)
+        , (controlLinkActiveAttr, V.defAttr `V.withStyle` V.reverseVideo)
+        , (syntaxNormalAttr, palette V.cyan)
+        , (syntaxKeywordAttr, palette V.magenta)
+        , (syntaxTypeAttr, palette V.yellow)
+        , (syntaxFunctionAttr, palette V.blue)
+        , (syntaxVariableAttr, palette V.cyan)
+        , (syntaxStringAttr, palette V.green)
+        , (syntaxNumberAttr, palette V.brightMagenta)
         , (syntaxCommentAttr,
-            codeColor 88 110 117 `V.withStyle` V.italic)
-        , (syntaxOperatorAttr, codeColor 203 75 22)
-        , (syntaxAnnotationAttr, codeColor 133 153 0)
-        , (syntaxPreprocessorAttr, codeColor 203 75 22)
+            palette V.brightBlack `V.withStyle` V.italic)
+        , (syntaxOperatorAttr, palette V.brightYellow)
+        , (syntaxAnnotationAttr, palette V.green)
+        , (syntaxPreprocessorAttr, palette V.brightYellow)
         , (syntaxWarningAttr,
-            codeColor 181 137 0 `V.withStyle` V.bold)
+            palette V.yellow `V.withStyle` V.bold)
         , (syntaxErrorAttr,
-            codeColor 220 50 47 `V.withStyle` V.bold)
+            palette V.red `V.withStyle` V.bold)
         ]
 
 monochrome :: AttrMap
@@ -303,18 +231,5 @@ monochrome =
             `V.withStyle` (V.bold .|. V.reverseVideo))
         ]
 
-codeColor :: Int -> Int -> Int -> V.Attr
-codeColor r g b =
-    V.defAttr
-        `V.withForeColor` rgb r g b
-        `V.withBackColor` codeBlockBackground
-
-codeBlockBackground :: V.Color
-codeBlockBackground = rgb 0 43 54
-
-rgb :: Int -> Int -> Int -> V.Color
-rgb r g b =
-    V.RGBColor
-        (fromIntegral r)
-        (fromIntegral g)
-        (fromIntegral b)
+palette :: V.Color -> V.Attr
+palette = V.withForeColor V.defAttr

--- a/packages/agent-tui/test/Agent/TUI/MarkdownSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/MarkdownSpec.hs
@@ -117,7 +117,7 @@ spec = describe "fullscreen Markdown rendering" do
                     toList $
                         displayOpsForPic
                             (renderWidget
-                                (Just Theme.solarizedDark)
+                                (Just Theme.terminalDefault)
                                 [widget]
                                 region)
                             region
@@ -127,7 +127,7 @@ spec = describe "fullscreen Markdown rendering" do
                 Just
                     (attrMapLookup
                         Theme.inlineCodeAttr
-                        Theme.solarizedDark
+                        Theme.terminalDefault
                         `V.withStyle` V.bold)
 
     it "leaves unmatched delimiters visible" do
@@ -141,7 +141,7 @@ spec = describe "fullscreen Markdown rendering" do
                     toList $
                         displayOpsForPic
                             (renderWidget
-                                (Just Theme.solarizedDark)
+                                (Just Theme.terminalDefault)
                                 [markdownWidget input :: Widget ()]
                                 region)
                             region
@@ -150,11 +150,11 @@ spec = describe "fullscreen Markdown rendering" do
         fmap spanAttr headingSpan
             `shouldBe`
                 Just
-                    (attrMapLookup Theme.headingAttr Theme.solarizedDark)
+                    (attrMapLookup Theme.headingAttr Theme.terminalDefault)
         fmap spanAttr quoteSpan
             `shouldBe`
                 Just
-                    (attrMapLookup Theme.mutedAttr Theme.solarizedDark)
+                    (attrMapLookup Theme.mutedAttr Theme.terminalDefault)
 
     it "preserves nested list indentation and compact blockquotes" do
         renderRows 40 "- parent\n  - child\n    1. grandchild\n>quote"
@@ -273,15 +273,15 @@ spec = describe "fullscreen Markdown rendering" do
                                     input
                         in show $
                             renderWidget
-                                (Just Theme.solarizedDark)
+                                (Just Theme.terminalDefault)
                                 [widget]
                                 (80, 8)
                     closed =
                         render "```haskell\nmain = putStrLn \"hello\"\n```"
                     open =
                         render "```haskell\nmain = putStrLn \"hello\""
-                closed `shouldSatisfy` isInfixOf "RGBColor 38 139 210"
-                open `shouldSatisfy` (not . isInfixOf "RGBColor 38 139 210")
+                closed `shouldSatisfy` isInfixOf "ISOColor 4"
+                open `shouldSatisfy` (not . isInfixOf "ISOColor 4")
 
     it "renders thematic breaks inside a vertical viewport" do
         let widget :: Widget ()
@@ -612,12 +612,12 @@ renderedCodePayloadRows width widget =
             toList $
                 displayOpsForPic
                     (renderWidget
-                        (Just Theme.solarizedDark)
+                        (Just Theme.terminalDefault)
                         [widget]
                         region)
                     region
     codeAttr =
-        attrMapLookup Theme.codeAttr Theme.solarizedDark
+        attrMapLookup Theme.codeAttr Theme.terminalDefault
     payloadText row =
         Text.dropEnd 1 $
             Text.drop 1 $

--- a/packages/agent-tui/test/Agent/TUI/ThemeSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ThemeSpec.hs
@@ -10,8 +10,8 @@ import Test.Hspec
 spec :: Spec
 spec = do
     describe "structural theme attributes" do
-        it "keeps active chrome and controls on the Solarized neutral ramp" do
-            map solarizedForeground
+        it "uses the terminal ANSI palette without fixing a background" do
+            map terminalForeground
                 [ Theme.borderActiveAttr
                 , Theme.controlLinkAttr
                 , Theme.controlLinkHoverAttr
@@ -22,35 +22,30 @@ spec = do
                 , Theme.lambdaSparkAttr
                 ]
                 `shouldBe`
-                    [ V.SetTo (V.RGBColor 101 123 131)
-                    , V.SetTo (V.RGBColor 101 123 131)
-                    , V.SetTo (V.RGBColor 131 148 150)
-                    , V.SetTo (V.RGBColor 147 161 161)
-                    , V.SetTo (V.RGBColor 69 94 100)
-                    , V.SetTo (V.RGBColor 88 110 117)
-                    , V.SetTo (V.RGBColor 101 123 131)
-                    , V.SetTo (V.RGBColor 131 148 150)
+                    [ V.Default
+                    , V.SetTo V.brightBlack
+                    , V.Default
+                    , V.Default
+                    , V.SetTo V.brightBlack
+                    , V.SetTo V.brightBlack
+                    , V.Default
+                    , V.SetTo V.brightWhite
                     ]
 
     describe "syntax theme attributes" do
-        it "keeps native text selection visible over fenced code" do
-            let background attribute =
-                    V.attrBackColor
-                        (attrMapLookup attribute Theme.solarizedDark)
-            background Theme.codeAttr
-                `shouldNotBe` background Theme.selectedAttr
-
-        it "keeps every Solarized syntax class on the code-block background" do
-            let codeBackground =
-                    V.attrBackColor
-                        (attrMapLookup Theme.codeAttr Theme.solarizedDark)
+        it "leaves every syntax background to the terminal theme" do
             map
                 ( V.attrBackColor
-                    . (`attrMapLookup` Theme.solarizedDark)
+                    . (`attrMapLookup` Theme.terminalDefault)
                     . Theme.syntaxClassAttr
                 )
                 allSyntaxClasses
-                `shouldBe` replicate (length allSyntaxClasses) codeBackground
+                `shouldBe` replicate (length allSyntaxClasses) V.Default
+
+        it "uses reverse video for selections on light and dark themes" do
+            V.attrStyle
+                (attrMapLookup Theme.selectedAttr Theme.terminalDefault)
+                `shouldBe` V.SetTo V.reverseVideo
 
         it "does not introduce colors in monochrome mode" do
             map
@@ -67,9 +62,9 @@ spec = do
                         (length allSyntaxClasses)
                         (V.Default, V.Default)
 
-solarizedForeground :: AttrName -> V.MaybeDefault V.Color
-solarizedForeground =
-    V.attrForeColor . (`attrMapLookup` Theme.solarizedDark)
+terminalForeground :: AttrName -> V.MaybeDefault V.Color
+terminalForeground =
+    V.attrForeColor . (`attrMapLookup` Theme.terminalDefault)
 
 allSyntaxClasses :: [SyntaxClass]
 allSyntaxClasses = [minBound .. maxBound]


### PR DESCRIPTION
## Summary

- replace the hard-coded Solarized Dark colors in fullscreen and minimal rendering with the terminal default foreground/background and ANSI palette
- make light themes such as Ghostty's Modus Operandi Tinted readable and follow terminal light/dark theme switching
- update Markdown, tool, plan, diff, selection, and syntax-highlight roles to use terminal-owned colors
- document Ghostty theme inheritance

## Testing

- GHCi: Agent.TUI.ThemeSpec (4 examples)
- GHCi: Agent.TUI.MarkdownSpec (41 examples)
- GHCi: Agent.CLI.StyleSpec (12 examples)
- GHCi: Agent.CLI.MarkdownSpec (28 examples)
- GHCi: Agent.CLI.RenderSpec (45 examples)
- loaded all edited library modules under the repository warning settings
- `git diff --check`
- live fullscreen tmux smoke test with `TERM_PROGRAM=ghostty`; verified ANSI/default colors and no forced RGB backgrounds