### PR TITLE
Keep TUI open on provider startup failures

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -1252,48 +1252,79 @@ runFullscreenRestartLoop
     loop options transition action =
         -- The notifier in 'runFullscreen' watches this whole tail-recursive
         -- chain, rather than stopping Brick after the first provider exits.
-        action >>= \case
-            RunRestart sessionId -> do
-                let nextOptions = restartSessionOptions options sessionId
-                prepared <- prepareAgentIteration
-                    fullscreenInputs
-                    sessionState
-                    (Just runtime)
-                    nextOptions
-                    Nothing
-                loop nextOptions Nothing prepared.preparedRun
-            RunSwitchProvider next -> do
-                let nextOptions = applyProviderTransition options next
-                prepared <- prepareAgentIteration
-                    fullscreenInputs
-                    sessionState
-                    (Just runtime)
-                    nextOptions
-                    (Just next)
-                loop nextOptions (Just next) prepared.preparedRun
-            RunProviderStartFailed apiError ->
-                case transition of
-                    Just failed
-                        | failed.transitionCause == AutomaticFallback ->
-                            continueAutomaticFallback
-                                (Just runtime) failed apiError >>= \case
-                                Just next -> do
-                                    let nextOptions =
-                                            applyProviderTransition options next
-                                    prepared <- prepareAgentIteration
-                                        fullscreenInputs
-                                        sessionState
-                                        (Just runtime)
-                                        nextOptions
-                                        (Just next)
-                                    loop
-                                        nextOptions
-                                        (Just next)
-                                        prepared.preparedRun
-                                Nothing ->
-                                    pure (RunProviderStartFailed apiError)
-                    _ -> pure (RunProviderStartFailed apiError)
-            result -> pure result
+        try @_ @StartupFailure action >>= \case
+            Left (StartupFailure message) ->
+                recoverStartup options transition (Text.pack message)
+            Right result -> case result of
+                RunRestart sessionId -> do
+                    let nextOptions = restartSessionOptions options sessionId
+                    retryStartup nextOptions Nothing
+                RunSwitchProvider next -> do
+                    let nextOptions = applyProviderTransition options next
+                    retryStartup nextOptions (Just next)
+                RunProviderStartFailed apiError ->
+                    case transition of
+                        Just failed
+                            | failed.transitionCause == AutomaticFallback ->
+                                continueAutomaticFallback
+                                    (Just runtime) failed apiError >>= \case
+                                    Just next -> do
+                                        let nextOptions =
+                                                applyProviderTransition
+                                                    options next
+                                        retryStartup nextOptions (Just next)
+                                    Nothing ->
+                                        recoverProviderStart
+                                            options transition apiError
+                        _ ->
+                            recoverProviderStart options transition apiError
+                other -> pure other
+
+    recoverProviderStart options transition apiError = do
+        now <- getCurrentTime
+        recoverStartup
+            options
+            transition
+            (formatApiErrorAt now apiError)
+
+    retryStartup options transition = do
+        emitUiEvent runtime $
+            UiSetNotice (Just (progressNotice "Retrying startup…"))
+        try @_ @StartupFailure
+            (prepareAgentIteration
+                fullscreenInputs
+                sessionState
+                (Just runtime)
+                options
+                transition) >>= \case
+                    Left (StartupFailure message) ->
+                        recoverStartup
+                            options transition (Text.pack message)
+                    Right prepared ->
+                        loop options transition prepared.preparedRun
+
+    recoverStartup options transition message = do
+        emitUiEvent runtime (UiSetNotice Nothing)
+        requestFullscreenChoiceWithBody
+            runtime
+            "Couldn’t start the agent"
+            message
+            0
+            [ ( "Retry"
+              , "Try loading credentials and account usage again"
+              )
+            , ( "Manage"
+              , "Connect, refresh, enable, or remove provider accounts"
+              )
+            , ("Exit", "Close the agent")
+            ] >>= \case
+                Just 0 ->
+                    retryStartup options transition
+                Just 1 -> do
+                    color <- resolveColor stderr
+                    withFullscreenSuspended runtime (runLoginManager color)
+                    retryStartup options transition
+                _ -> pure RunQuit
 
 runAgentInitialized
     :: CliOptions

--- a/packages/agent-cli/src/Agent/CLI/Auth.hs
+++ b/packages/agent-cli/src/Agent/CLI/Auth.hs
@@ -288,10 +288,10 @@ detectProvider Nothing = do
     grok <- lift hasGrokAuth
     openai <- lift hasOpenAiAuth
     openrouter <- lift hasOpenRouterAuth
-    if grok
-        then pure XAIProvider
-        else if openai
-            then pure OpenAIProvider
+    if openai
+        then pure OpenAIProvider
+        else if grok
+            then pure XAIProvider
             else if openrouter
                 then pure OpenRouterProvider
                 else throwE noAuthHint

--- a/packages/agent-cli/test/Agent/CLI/AuthSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/AuthSpec.hs
@@ -67,6 +67,30 @@ spec = do
             authErrorNeedsOnboarding "credential store is unreadable"
                 `shouldBe` False
 
+    describe "loadAuth" do
+        it "prefers OpenAI when automatic detection finds OpenAI and xAI auth" $
+            withTempHome \_ ->
+                withCleanOpenAiEnv $
+                withCleanGrokEnv $
+                withEnv "AGENT_BROKER_URL" Nothing do
+                    storeOpenAiAccount
+                        "openai"
+                        "openai-account"
+                        True
+                        "openai-token"
+                    storeManagedAccount
+                        SubscriptionBilled
+                        XAIProvider
+                        "xai"
+                        "xai-account"
+                        "Grok"
+                        True
+                        "xai-token"
+                    loadAuth Nothing >>= \case
+                        Left err -> expectationFailure (Text.unpack err)
+                        Right loaded ->
+                            loaded.loadedProvider `shouldBe` OpenAIProvider
+
     describe "probeLoadedAuth" do
         it "rejects auth whose accounts are currently cooling down" do
             let retryAt = UTCTime (fromGregorian 2026 8 21) 3600


### PR DESCRIPTION
## Summary
- recover provider preparation and connection failures inside the fullscreen runtime
- offer Retry, Manage accounts, or Exit instead of terminating the CLI
- prefer OpenAI during automatic detection when both OpenAI and xAI credentials exist

## Testing
- `nix develop -c cabal test agent-cli:agent-cli-test --test-show-details=direct` (802 examples, 0 failures)
- `nix develop -c cabal repl agent-cli:lib:agent-cli --repl-options=-e --repl-options=:quit`
- tmux smoke test with an exhausted xAI account, including retrying startup without closing the TUI
- `git diff --check`