### PR TITLE
Bound internal GHCi memory usage

### DIFF
--- a/packages/agent-core/src/Agent/Tools/Ghci/Runtime.hs
+++ b/packages/agent-core/src/Agent/Tools/Ghci/Runtime.hs
@@ -504,6 +504,14 @@ ghciArgs =
     , "-XGHC2021"
     ]
         ++ map ("-X" <>) defaultGhciExtensions
+        ++
+            -- Keep the agent's scripting GHCi bounded independently of the
+            -- development REPL, and return unused megablocks promptly.
+            [ "+RTS"
+            , "-M256M"
+            , "-Fd1"
+            , "-RTS"
+            ]
 
 spawnProcess :: ToolEnv -> IO (Either Text GhciProcess)
 spawnProcess env = do
@@ -643,7 +651,8 @@ ghciInputResetsHelpers expression =
 sendGhciHelpers :: GhciProcess -> IO ()
 sendGhciHelpers process =
     mapM_ (sendLine process)
-        [ "import qualified System.Process as AgentGhciProcess"
+        [ ":set +r"
+        , "import qualified System.Process as AgentGhciProcess"
         , "import qualified System.IO as AgentGhciIO"
         , "import qualified Data.Text.IO as AgentGhciTextIO"
         , "import qualified System.Directory as AgentGhciDirectory"

--- a/packages/agent-core/test/Agent/Tools/GhciSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/GhciSpec.hs
@@ -99,6 +99,24 @@ spec = describe "Agent.Tools.Ghci" do
             readBack.ghciOutput
                 `shouldSatisfy` Text.isInfixOf "hello from helper"
 
+    it "enables evaluated module CAF reversion" do
+        withTempGhci \ghci -> do
+            settings <- evalGhci ghci ":set" 10000
+            settings.ghciOk `shouldBe` True
+            settings.ghciOutput
+                `shouldSatisfy` Text.isInfixOf "options currently set: +r"
+
+    it "caps the managed heap at 256 MiB" do
+        withTempGhci \ghci -> do
+            imported <- evalGhci ghci "import GHC.RTS.Flags" 10000
+            imported.ghciOk `shouldBe` True
+            maximumBlocks <- evalGhci ghci
+                "getRTSFlags >>= print . maxHeapSize . gcFlags"
+                10000
+            maximumBlocks.ghciOk `shouldBe` True
+            maximumBlocks.ghciOutput
+                `shouldSatisfy` Text.isInfixOf "65536"
+
     it "runs commands in an explicit working directory" do
         withTempEnv \env ->
             bracket (newGhciSession env) closeGhciSession \ghci -> do


### PR DESCRIPTION
## Summary

- cap the agent's internal `run_ghci` managed heap at 256 MiB
- return unused megablocks more aggressively with `-Fd1`
- enable GHCi `+r` so evaluated module CAFs can be reverted between commands
- add integration coverage for both runtime settings

## Validation

- `nix develop -c cabal repl agent-core:lib:agent-core --offline`
- `nix develop -c cabal test --offline agent-core:test:agent-core-test`
  - 293 examples, 0 failures
- `git diff --check`

## Memory boundary benchmark

GHC 9.10.3, macOS arm64, five samples per case. Each process allocated and retained a strict `ByteString`; figures are median maximum RSS from `/usr/bin/time -l`.

| Requested value | Existing settings | `-M256M -Fd1` |
| --- | ---: | ---: |
| 200 MiB | 435.7 MiB RSS, completed | 328.7 MiB RSS, completed |
| 300 MiB | 603.8 MiB RSS, completed | 112.7 MiB RSS, controlled `heap overflow` |

The RTS ceiling bounds the managed heap rather than total RSS, so successful 200 MiB allocations can still exceed 256 MiB RSS due to runtime and code overhead.
