### PR TITLE
Add project-wide approval option to permission prompts

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -72,7 +72,7 @@ import Agent.CLI.AgentSessions
 import Agent.CLI.Approval
     ( ApprovalNotice(..)
     , approveToolDecision
-    , approveToolDecisionWithReporter
+    , approveToolDecisionWithReporterAndPersistence
     , toggleAlwaysApprove
     )
 import Agent.CLI.Btw
@@ -202,6 +202,7 @@ import Agent.CLI.Project
     , projectModelProvider
     , resolveProjectRoot
     , saveProjectAccount
+    , saveProjectAutoApprove
     , saveProjectModel
     )
 import Agent.CLI.Prompt
@@ -3373,9 +3374,10 @@ runSession catalog connectionId options provider dialect policy allTools mcpRegi
                     Nothing ->
                         withStdinPaused escPaused $
                             approveToolDecision
-                                policyRef allowedToolsRef toolRegistry planMode call
+                                policyRef allowedToolsRef toolRegistry planMode
+                                projectRoot call
                     Just runtime ->
-                        approveToolDecisionWithReporter
+                        approveToolDecisionWithReporterAndPersistence
                             (requestFullscreenPermission runtime)
                             (\case
                                 ApprovalWarning _ -> pure ()
@@ -3384,6 +3386,7 @@ runSession catalog connectionId options provider dialect policy allTools mcpRegi
                                         (UiSetNotice
                                             (Just
                                                 (successNotice message))))
+                            (saveProjectAutoApprove projectRoot True)
                             policyRef
                             allowedToolsRef
                             toolRegistry

--- a/packages/agent-cli/src/Agent/CLI/Approval.hs
+++ b/packages/agent-cli/src/Agent/CLI/Approval.hs
@@ -4,6 +4,7 @@ module Agent.CLI.Approval
     , approveToolDecision
     , approveToolDecisionWith
     , approveToolDecisionWithReporter
+    , approveToolDecisionWithReporterAndPersistence
     , childApprove
     , toggleAlwaysApprove
     ) where
@@ -64,13 +65,22 @@ approveToolDecision
     -> IORef (Set Text)
     -> ToolRegistry
     -> PlanModeEnv
+    -> OsPath
     -> ToolCall
     -> IO (Either Text Bool)
-approveToolDecision policyRef allowedToolsRef tools planMode call = do
-    approveToolDecisionWith
+approveToolDecision policyRef allowedToolsRef tools planMode projectRoot call = do
+    approveToolDecisionWithReporterAndPersistence
         (\requested -> do
             color <- resolveColor stderr
             promptPermission color requested)
+        (\case
+            ApprovalWarning message -> do
+                color <- resolveColor stderr
+                putTextLn stderr (roleWarn color message)
+            ApprovalSuccess message -> do
+                color <- resolveColor stderr
+                putTextLn stderr (roleSuccess color message))
+        (saveProjectAutoApprove projectRoot True)
         policyRef
         allowedToolsRef
         tools
@@ -86,13 +96,14 @@ approveToolDecisionWith
     -> ToolCall
     -> IO (Either Text Bool)
 approveToolDecisionWith requestPermission =
-    approveToolDecisionWithReporter requestPermission \case
+    approveToolDecisionWithReporterAndPersistence requestPermission (\case
         ApprovalWarning message -> do
             color <- resolveColor stderr
             putTextLn stderr (roleWarn color message)
         ApprovalSuccess message -> do
             color <- resolveColor stderr
-            putTextLn stderr (roleSuccess color message)
+            putTextLn stderr (roleSuccess color message))
+        (pure ())
 
 approveToolDecisionWithReporter
     :: (ToolCall -> IO (Maybe PermissionChoice))
@@ -103,7 +114,20 @@ approveToolDecisionWithReporter
     -> PlanModeEnv
     -> ToolCall
     -> IO (Either Text Bool)
-approveToolDecisionWithReporter requestPermission report policyRef allowedToolsRef tools planMode call = do
+approveToolDecisionWithReporter requestPermission report =
+    approveToolDecisionWithReporterAndPersistence requestPermission report (pure ())
+
+approveToolDecisionWithReporterAndPersistence
+    :: (ToolCall -> IO (Maybe PermissionChoice))
+    -> (ApprovalNotice -> IO ())
+    -> IO ()
+    -> IORef ApprovalPolicy
+    -> IORef (Set Text)
+    -> ToolRegistry
+    -> PlanModeEnv
+    -> ToolCall
+    -> IO (Either Text Bool)
+approveToolDecisionWithReporterAndPersistence requestPermission report persistAlwaysApprove policyRef allowedToolsRef tools planMode call = do
     policy <- readIORef policyRef
     planActive <- isPlanModeActive planMode
     planPath <- planFilePath planMode
@@ -143,6 +167,16 @@ approveToolDecisionWithReporter requestPermission report policyRef allowedToolsR
                                             requestPermission call >>= \case
                                                 Nothing -> pure (Right False)
                                                 Just PermissionAllowOnce ->
+                                                    pure (Right True)
+                                                Just PermissionAllowAll -> do
+                                                    atomicModifyIORef' policyRef $
+                                                        const (ApproveAll, ())
+                                                    persistAlwaysApprove
+                                                    report $
+                                                        ApprovalSuccess
+                                                            (glyphOk
+                                                                <> "auto-approve on \
+                                                                   \(saved for project)")
                                                     pure (Right True)
                                                 Just PermissionAllowTool -> do
                                                     modifyIORef' allowedToolsRef

--- a/packages/agent-cli/src/Agent/CLI/Options.hs
+++ b/packages/agent-cli/src/Agent/CLI/Options.hs
@@ -47,19 +47,25 @@ data ApprovalPolicy
 data ApprovalAnswer
     = AllowOnce
     | AllowAlways
+    | AllowAll
     | Deny
     deriving (Eq, Show)
 
 -- | Parse a mutating-tool approval reply. Matching is case-insensitive
--- and ignores surrounding whitespace.
+-- and ignores surrounding whitespace, except uppercase @A@ is the short
+-- spelling for project-wide auto-approval while lowercase @a@ remembers only
+-- the current tool for this session.
 parseApprovalAnswer :: Text -> ApprovalAnswer
-parseApprovalAnswer raw = case Text.toLower (Text.strip raw) of
-    "y" -> AllowOnce
-    "yes" -> AllowOnce
-    "a" -> AllowAlways
-    "always" -> AllowAlways
-    "yolo" -> AllowAlways
-    _ -> Deny
+parseApprovalAnswer raw
+    | Text.strip raw == "A" = AllowAll
+    | otherwise = case Text.toLower (Text.strip raw) of
+        "y" -> AllowOnce
+        "yes" -> AllowOnce
+        "a" -> AllowAlways
+        "always" -> AllowAlways
+        "all" -> AllowAll
+        "yolo" -> AllowAll
+        _ -> Deny
 
 data CliOptions = CliOptions
     { optProvider :: !(Maybe Provider)

--- a/packages/agent-cli/src/Agent/CLI/Permission.hs
+++ b/packages/agent-cli/src/Agent/CLI/Permission.hs
@@ -25,6 +25,7 @@ import System.IO (hIsTerminalDevice, stderr, stdin)
 
 data PermissionChoice
     = PermissionAllowOnce
+    | PermissionAllowAll
     | PermissionAllowTool
     | PermissionDeny
     deriving (Eq, Show)
@@ -38,6 +39,7 @@ data PermissionState = PermissionState
 permissionLabels :: [Text]
 permissionLabels =
     [ "Allow once"
+    , "Always approve all tools for this project"
     , "Always allow this tool this session"
     , "Deny"
     ]
@@ -55,11 +57,13 @@ applyPermissionKey key state = case key of
     PickerKeyConfirm -> Left (choiceFromIndex state.permIndex)
     PickerKeyUp -> Right state { permIndex = move (-1) state.permIndex }
     PickerKeyDown -> Right state { permIndex = move 1 state.permIndex }
-    PickerKeyChar c -> case Text.toLower (Text.singleton c) of
-        "y" -> Left PermissionAllowOnce
-        "a" -> Left PermissionAllowTool
-        "n" -> Left PermissionDeny
-        _ -> Right state
+    PickerKeyChar 'A' -> Left PermissionAllowAll
+    PickerKeyChar c ->
+        case Text.toLower (Text.singleton c) of
+            "y" -> Left PermissionAllowOnce
+            "a" -> Left PermissionAllowTool
+            "n" -> Left PermissionDeny
+            _ -> Right state
     PickerKeyBackspace -> Right state
   where
     n = length permissionLabels
@@ -68,7 +72,8 @@ applyPermissionKey key state = case key of
 choiceFromIndex :: Int -> PermissionChoice
 choiceFromIndex = \case
     0 -> PermissionAllowOnce
-    1 -> PermissionAllowTool
+    1 -> PermissionAllowAll
+    2 -> PermissionAllowTool
     _ -> PermissionDeny
 
 renderPermissionFrame :: Bool -> PermissionState -> Text
@@ -82,7 +87,7 @@ renderPermissionFrame color state =
                 permissionLabels
         footer =
             roleMuted color
-                "↑↓/jk or scroll · click/enter · y once · a this tool · n/esc deny"
+                "↑↓/jk or scroll · click/enter · y once · A all · a this tool · n/esc deny"
     in Text.intercalate "\n" (header : rows <> [footer])
 
 renderRow :: Bool -> Bool -> Text -> Text
@@ -91,8 +96,9 @@ renderRow color selected label =
         body = if selected then roleSuccess color label else roleMuted color label
     in cursor <> body
 
--- | TTY card; non-TTY keeps cooked @y/n/a@. @a@ on a pipe is still
--- project-wide always-approve so scripts keep working.
+-- | TTY card; non-TTY keeps cooked @y/n/a/A@. Uppercase @A@, @all@, or
+-- @yolo@ enables project-wide auto-approval; lowercase @a@ remembers only the
+-- current tool for this session.
 promptPermission :: Bool -> ToolCall -> IO (Maybe PermissionChoice)
 promptPermission color call = do
     isTty <- hIsTerminalDevice stdin
@@ -111,10 +117,11 @@ promptPermission color call = do
 cooked :: Bool -> Text -> IO (Maybe PermissionChoice)
 cooked color summary = do
     let question =
-            roleWarn color (glyphWarn <> summary <> " [y/N/a] ")
+            roleWarn color (glyphWarn <> summary <> " [y/N/a/A] ")
     readApprovalLine question >>= \case
         Nothing -> pure Nothing
         Just raw -> pure $ Just $ case parseApprovalAnswer raw of
             AllowOnce -> PermissionAllowOnce
             AllowAlways -> PermissionAllowTool
+            AllowAll -> PermissionAllowAll
             Deny -> PermissionDeny

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -2741,6 +2741,7 @@ drawPermission state permission =
                                             (permissionRow permission.permissionIndex)
                                             [0 ..]
                                             [ "Allow once"
+                                            , "Always approve all tools for this project"
                                             , "Always allow this tool this session"
                                             , "Deny"
                                             ]
@@ -3796,6 +3797,7 @@ handlePermissionKey = \case
     V.EvKey V.KBackTab [] -> movePermission (-1)
     V.EvKey (V.KChar '\t') [] -> movePermission 1
     V.EvKey (V.KChar 'y') [] -> resolvePermission PermissionAllowOnce
+    V.EvKey (V.KChar 'A') [] -> resolvePermission PermissionAllowAll
     V.EvKey (V.KChar 'a') [] -> resolvePermission PermissionAllowTool
     V.EvKey (V.KChar 'n') [] -> resolvePermission PermissionDeny
     V.EvKey V.KEsc [] -> resolvePermission PermissionDeny
@@ -3818,7 +3820,8 @@ handlePermissionKey = \case
 permissionChoiceAt :: Int -> PermissionChoice
 permissionChoiceAt = \case
     0 -> PermissionAllowOnce
-    1 -> PermissionAllowTool
+    1 -> PermissionAllowAll
+    2 -> PermissionAllowTool
     _ -> PermissionDeny
 
 resolvePermission

--- a/packages/agent-cli/test/Agent/CLI/ApprovalSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ApprovalSpec.hs
@@ -3,6 +3,7 @@ module Agent.CLI.ApprovalSpec (spec) where
 import Agent.CLI.Approval
     ( ApprovalNotice(..)
     , approveToolDecisionWithReporter
+    , approveToolDecisionWithReporterAndPersistence
     , childApprove
     )
 import Agent.CLI.Options (ApprovalPolicy(..))
@@ -212,6 +213,25 @@ spec = do
             readIORef notices `shouldReturn`
                 [ApprovalSuccess "✓ always allow write this session"]
             readIORef allowed `shouldReturn` Set.singleton "write"
+
+        it "enables and persists project-wide auto-approval from a prompt" do
+            policy <- newIORef PromptMutating
+            allowed <- newIORef Set.empty
+            plan <- newPlanModeEnv (unsafeEncodeUtf "/tmp/approval-test") Nothing
+            notices <- newIORef []
+            persisted <- newIORef (0 :: Int)
+
+            approveToolDecisionWithReporterAndPersistence
+                (\_ -> pure (Just PermissionAllowAll))
+                (\notice -> modifyIORef' notices (<> [notice]))
+                (modifyIORef' persisted (+ 1))
+                policy allowed (registry [mutatingTool]) plan mutatingCall
+                `shouldReturn` Right True
+
+            readIORef policy `shouldReturn` ApproveAll
+            readIORef persisted `shouldReturn` 1
+            readIORef notices `shouldReturn`
+                [ApprovalSuccess "✓ auto-approve on (saved for project)"]
 
         it "shares remembered approval across public and internal Grok aliases" do
             policy <- newIORef PromptMutating

--- a/packages/agent-cli/test/Agent/CLI/OptionsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/OptionsSpec.hs
@@ -202,13 +202,15 @@ spec = do
                 `shouldBe` PromptMutating
 
     describe "parseApprovalAnswer" do
-        it "allows once, always, or denies" do
+        it "allows once, remembers a tool, enables yolo, or denies" do
             parseApprovalAnswer "y" `shouldBe` AllowOnce
             parseApprovalAnswer "Yes" `shouldBe` AllowOnce
             parseApprovalAnswer "  Y  " `shouldBe` AllowOnce
             parseApprovalAnswer "a" `shouldBe` AllowAlways
             parseApprovalAnswer "ALWAYS" `shouldBe` AllowAlways
-            parseApprovalAnswer "yolo" `shouldBe` AllowAlways
+            parseApprovalAnswer "A" `shouldBe` AllowAll
+            parseApprovalAnswer "all" `shouldBe` AllowAll
+            parseApprovalAnswer "yolo" `shouldBe` AllowAll
             parseApprovalAnswer "" `shouldBe` Deny
             parseApprovalAnswer "n" `shouldBe` Deny
             parseApprovalAnswer "no" `shouldBe` Deny

--- a/packages/agent-cli/test/Agent/CLI/PermissionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/PermissionSpec.hs
@@ -16,16 +16,31 @@ spec = do
 
         it "moves down to always-this-tool" do
             case applyPermissionKey PickerKeyDown state of
-                Right down ->
-                    applyPermissionKey PickerKeyConfirm down
-                        `shouldBe` Left PermissionAllowTool
+                Right global ->
+                    case applyPermissionKey PickerKeyDown global of
+                        Right tool ->
+                            applyPermissionKey PickerKeyConfirm tool
+                                `shouldBe` Left PermissionAllowTool
+                        Left choice ->
+                            expectationFailure
+                                ("expected second navigation, got " <> show choice)
                 Left choice ->
                     expectationFailure ("expected navigation, got " <> show choice)
 
-        it "maps y / a / n shortcuts" do
+        it "moves down once to project-wide auto-approval" do
+            case applyPermissionKey PickerKeyDown state of
+                Right down ->
+                    applyPermissionKey PickerKeyConfirm down
+                        `shouldBe` Left PermissionAllowAll
+                Left choice ->
+                    expectationFailure ("expected navigation, got " <> show choice)
+
+        it "maps y / A / a / n shortcuts" do
             applyPermissionKey (PickerKeyChar 'y') state
                 `shouldBe` Left PermissionAllowOnce
             applyPermissionKey (PickerKeyChar 'A') state
+                `shouldBe` Left PermissionAllowAll
+            applyPermissionKey (PickerKeyChar 'a') state
                 `shouldBe` Left PermissionAllowTool
             applyPermissionKey (PickerKeyChar 'n') state
                 `shouldBe` Left PermissionDeny
@@ -35,12 +50,14 @@ spec = do
                 `shouldBe` Left PermissionDeny
 
     describe "renderPermissionFrame" do
-        it "names the tool and the three choices" do
+        it "names the tool and the four choices" do
             let frame =
                     renderPermissionFrame False
                         (initialPermissionState "Allow search_replace src/A.hs?")
             frame `shouldSatisfy`
                 Text.isInfixOf "Allow search_replace src/A.hs?"
             frame `shouldSatisfy` Text.isInfixOf "Allow once"
+            frame `shouldSatisfy`
+                Text.isInfixOf "Always approve all tools for this project"
             frame `shouldSatisfy` Text.isInfixOf "Always allow this tool this session"
             frame `shouldSatisfy` Text.isInfixOf "Deny"

--- a/packages/agent-tui/src/Agent/TUI/Model.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model.hs
@@ -345,7 +345,7 @@ reduceUi event state = case event of
                 (\permission ->
                     permission
                         { permissionIndex =
-                            (permission.permissionIndex + delta) `mod` 3
+                            (permission.permissionIndex + delta) `mod` 4
                         })
                     <$> state.uiPermission
             }

--- a/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
@@ -17,6 +17,15 @@ import Test.Hspec
 
 spec :: Spec
 spec = describe "fullscreen UI reducer" do
+    it "cycles across all four permission choices" do
+        let shown = reduceUi (UiPermissionShown "write a file") initialUiState
+            moved count = iterate (reduceUi (UiPermissionMoved 1)) shown !! count
+        fmap (.permissionIndex) shown.uiPermission `shouldBe` Just 0
+        fmap (.permissionIndex) (moved 1).uiPermission `shouldBe` Just 1
+        fmap (.permissionIndex) (moved 2).uiPermission `shouldBe` Just 2
+        fmap (.permissionIndex) (moved 3).uiPermission `shouldBe` Just 3
+        fmap (.permissionIndex) (moved 4).uiPermission `shouldBe` Just 0
+
     it "retains user, reasoning, and assistant blocks across a turn" do
         let state =
                 apply


### PR DESCRIPTION
## Summary
- add a project-wide always-approve choice to line-mode and fullscreen permission prompts
- persist the existing project auto-approve setting and update the live policy immediately
- keep allow-once selected by default and preserve hard-deny and plan-mode gates

## Testing
- `nix develop -c cabal repl agent-cli:test:agent-cli-test --repl-options=-e --repl-options=main` (803 examples, 0 failures)
- `nix develop -c cabal repl agent-tui:test:agent-tui-test --repl-options=-e --repl-options=main` (129 examples, 0 failures)
- live tmux smoke test: selected uppercase `A`; the edit completed, project auto-approve persisted, and fullscreen status changed to `yolo`