### PR TITLE
Attach pasted image paths immediately

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -4213,9 +4213,14 @@ replWithDraft env@SessionEnv
                                         (roleMuted stdoutColor
                                             (glyphOk <> message))
             continueWith keptDraft
-        ReplClipboardPasteOrText keptDraft pastedDraft -> do
-            imagesResult <- readClipboardImagesImageFirst
-            case nonEmptyClipboardImages imagesResult of
+        ReplClipboardPasteOrText keptDraft pasted pastedDraft -> do
+            pastedImages <- loadImagesFromPastedText pasted
+            imagesResult <- case pastedImages of
+                Just images@(_:_) -> pure (Just images)
+                _ ->
+                    nonEmptyClipboardImages
+                        <$> readClipboardImagesImageFirst
+            case imagesResult of
                 Just images -> do
                     message <- queueAttachedImages
                         attachmentsRef
@@ -4230,7 +4235,7 @@ replWithDraft env@SessionEnv
                             (roleMuted stdoutColor
                                 (glyphOk <> message))
                     continueWith keptDraft
-                Nothing -> do
+                _ -> do
                     fullscreenEvent (UiSetNotice Nothing)
                     continueWith pastedDraft
         ReplChooseModel keptDraft -> do

--- a/packages/agent-cli/src/Agent/CLI/Command.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command.hs
@@ -171,9 +171,20 @@ parseReplLineWithSkills skills raw =
         else if line == ":reload"
             then ReplReload
             else case Text.uncons line of
-                Just ('/', _) -> parseSlash skills line
+                Just ('/', _)
+                    | looksLikeAbsolutePath line -> ReplPrompt raw
+                    | otherwise -> parseSlash skills line
                 Just (':', _) -> parseColon raw
                 _ -> ReplPrompt raw
+
+-- Absolute paths share slash commands' leading slash. A path with at least
+-- one further separator is unambiguously path-like, so leave it as prompt
+-- text instead of reporting its first component as an unknown command.
+looksLikeAbsolutePath :: Text -> Bool
+looksLikeAbsolutePath line =
+    case Text.words line of
+        first : _ -> Text.any (== '/') (Text.drop 1 first)
+        [] -> False
 
 parseColon :: Text -> ReplAction
 parseColon raw

--- a/packages/agent-cli/src/Agent/CLI/Input.hs
+++ b/packages/agent-cli/src/Agent/CLI/Input.hs
@@ -303,9 +303,14 @@ readInlineEditor
                 Text.hPutStr stdout "\ESC[2J\ESC[H"
                 redrawEditor prompt state
                 editorLoop history entries state
-            EditorPaste pasted ->
-                continue history entries
-                    (insertText pasted state) { editorPasted = True }
+            EditorPaste pasted -> do
+                finishEditorLine prompt state
+                let pastedState =
+                        (insertText pasted state) { editorPasted = True }
+                pure $ ReplClipboardPasteOrText
+                    state.editorText
+                    pasted
+                    pastedState.editorText
             EditorInputError message -> do
                 finishEditorLine prompt state
                 Text.putStrLn ("input ignored: " <> message)

--- a/packages/agent-cli/src/Agent/CLI/Input/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Input/Types.hs
@@ -19,7 +19,11 @@ data ReplLine
     | ReplText Text
     | ReplPasted Text
     | ReplClipboardPaste !Text !(Maybe [ImageAttachment])
-    | ReplClipboardPasteOrText !Text !Text
+    -- | Classify a bracketed paste off the UI thread. The fields are the draft
+    -- before the paste, the raw pasted payload, and the draft with that payload
+    -- inserted. Image paths or clipboard images become attachments; otherwise
+    -- the inserted draft is restored.
+    | ReplClipboardPasteOrText !Text !Text !Text
     | ReplCycleMode Text
     | ReplChooseModel Text
     | ReplChooseEffort Text

--- a/packages/agent-cli/src/Agent/CLI/Plan.hs
+++ b/packages/agent-cli/src/Agent/CLI/Plan.hs
@@ -221,7 +221,7 @@ readChangeNotes interrupt color = do
             if Text.null (Text.strip text)
                 then readChangeNotes interrupt color
                 else pure (Text.strip text)
-        ReplClipboardPasteOrText _ text ->
+        ReplClipboardPasteOrText _ _ text ->
             if Text.null (Text.strip text)
                 then readChangeNotes interrupt color
                 else pure (Text.strip text)
@@ -265,7 +265,7 @@ askQuestion interrupt resolveColor question options = do
                             if Text.null (Text.strip text)
                                 then askQuestion interrupt resolveColor question []
                                 else pure (Just (Text.strip text))
-                        ReplClipboardPasteOrText _ text ->
+                        ReplClipboardPasteOrText _ _ text ->
                             if Text.null (Text.strip text)
                                 then askQuestion interrupt resolveColor question []
                                 else pure (Just (Text.strip text))

--- a/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
@@ -589,12 +589,22 @@ handleComposerKey
             scrollConversationPage Down
         V.EvKey (V.KChar character) [] ->
             insertText (Text.singleton character)
-        V.EvPaste bytes ->
-            case decodePaste bytes of
-                pasted
-                    | Text.null pasted ->
-                        submitRaw (ReplClipboardPaste ui.uiDraft Nothing)
-                    | otherwise -> insertPastedText pasted
+        V.EvPaste bytes -> do
+            let pasted = decodePaste bytes
+                before = Text.take ui.uiCursor ui.uiDraft
+                after = Text.drop ui.uiCursor ui.uiDraft
+                pastedDraft = before <> pasted <> after
+            if Text.null pasted
+                then submitRaw (ReplClipboardPaste ui.uiDraft Nothing)
+                else do
+                    modifyUi
+                        (UiSetNotice
+                            (Just (progressNotice "Reading clipboard…")))
+                    submitRaw
+                        (ReplClipboardPasteOrText
+                            ui.uiDraft
+                            pasted
+                            pastedDraft)
         _ -> pure ()
   where
     submitRaw replLine = do

--- a/packages/agent-cli/src/Agent/CLI/TUI/Composer/Buffer.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Composer/Buffer.hs
@@ -87,7 +87,7 @@ isPromptPrelude :: FullscreenInput -> Bool
 isPromptPrelude input =
     case input.fullscreenInputLine of
         ReplClipboardPaste _ _ -> True
-        ReplClipboardPasteOrText _ _ -> True
+        ReplClipboardPasteOrText _ _ _ -> True
         _ -> False
 
 takeFullscreenInput

--- a/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
@@ -31,6 +31,14 @@ spec = do
             parseReplLine "  :status  "
                 `shouldBe` ReplPrompt "  :status  "
 
+        it "treats absolute paths as prompt text rather than slash commands" do
+            parseReplLine "/Users/marc/Downloads/template.png"
+                `shouldBe` ReplPrompt "/Users/marc/Downloads/template.png"
+            parseReplLine
+                "  /Users/marc/Downloads/template.png use this template  "
+                `shouldBe` ReplPrompt
+                    "  /Users/marc/Downloads/template.png use this template  "
+
         it "shows the current effort with a bare /effort" do
             parseReplLine "/effort" `shouldBe` ReplShowEffort
             parseReplLine "  /Effort  " `shouldBe` ReplShowEffort

--- a/packages/agent-cli/test/Agent/CLI/TUIComposerSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIComposerSpec.hs
@@ -60,13 +60,20 @@ spec = describe "fullscreen composer" do
                 (input (ReplClipboardPaste "draft" Nothing))
             appendFullscreenInput
                 buffer
-                (input (ReplClipboardPasteOrText "before" "before/path.png"))
+                (input
+                    (ReplClipboardPasteOrText
+                        "before"
+                        "/path.png"
+                        "before/path.png"))
             promoteFullscreenInput buffer (input (ReplText "urgent"))
         queued <- atomically (readFullscreenInputs buffer)
         map (.fullscreenInputLine) (toList queued)
             `shouldBe`
                 [ ReplClipboardPaste "draft" Nothing
-                , ReplClipboardPasteOrText "before" "before/path.png"
+                , ReplClipboardPasteOrText
+                    "before"
+                    "/path.png"
+                    "before/path.png"
                 , ReplText "urgent"
                 , ReplText "queued"
                 ]


### PR DESCRIPTION
## Summary
- treat absolute filesystem paths as prompt input instead of unknown slash commands
- recognize pasted image paths immediately in fullscreen and minimal composers
- preserve ordinary pasted text and existing clipboard-image fallback behavior

## Validation
- `nix develop -c cabal test agent-cli:test:agent-cli-test --test-show-details=direct`
- interactive tmux smoke tests in fullscreen and minimal modes