### PR TITLE
Avoid repeated clipboard probes on image paste

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -327,3 +327,17 @@ benchmark image-preview-latency-bench
                     , base >= 4.17 && < 5
                     , bytestring
                     , JuicyPixels
+
+benchmark clipboard-latency-bench
+    import:           common-options
+    type:             exitcode-stdio-1.0
+    hs-source-dirs:   benchmark
+    main-is:          ClipboardLatency.hs
+    ghc-options:      -O2
+    build-depends:    agent-cli
+                    , agent-core
+                    , base >= 4.17 && < 5
+                    , directory
+                    , filepath
+                    , safe-exceptions
+                    , text

--- a/packages/agent-cli/benchmark/ClipboardLatency.hs
+++ b/packages/agent-cli/benchmark/ClipboardLatency.hs
@@ -1,0 +1,133 @@
+module Main (main) where
+
+import Agent.CLI.Clipboard
+    ( ClipboardContent(..)
+    , readClipboard
+    , readClipboardImages
+    , readClipboardImagesForPaste
+    )
+import Agent.Loop (ImageAttachment(..))
+import Control.Exception.Safe (bracket)
+import Control.Monad (when)
+import Data.List (sort)
+import qualified Data.Text as Text
+import GHC.Clock (getMonotonicTimeNSec)
+import System.CPUTime (getCPUTime)
+import System.Directory
+    ( Permissions(executable)
+    , createDirectory
+    , doesDirectoryExist
+    , getPermissions
+    , getTemporaryDirectory
+    , removePathForcibly
+    , setPermissions
+    )
+import System.Environment (getArgs, getEnv, setEnv)
+import System.FilePath ((</>), searchPathSeparator)
+import System.Info (os)
+
+data Sample = Sample
+    { sampleElapsedMillis :: !Double
+    , sampleCpuMillis :: !Double
+    }
+
+main :: IO ()
+main = do
+    when (os /= "darwin") $
+        fail "clipboard-latency-bench currently models the macOS paste path"
+    samples <- parseSamples <$> getArgs
+    withFakeClipboard do
+        putStrLn
+            ("text clipboard failure path, samples=" <> show samples
+                <> ", fake osascript delay=10ms")
+        benchmark "old-repeat-probes" samples oldFailureProbe
+        benchmark "new-single-pass" samples newFailureProbe
+
+parseSamples :: [String] -> Int
+parseSamples = \case
+    [samples] -> max 1 (read samples)
+    _ -> 7
+
+benchmark :: String -> Int -> IO Int -> IO ()
+benchmark label count action = do
+    measured <- mapM (const (measure action)) [1 .. count]
+    let elapsed = median (map (.sampleElapsedMillis) measured)
+        cpu = median (map (.sampleCpuMillis) measured)
+    putStrLn
+        (label
+            <> " elapsed-ms=" <> show elapsed
+            <> " cpu-ms=" <> show cpu)
+
+measure :: IO Int -> IO Sample
+measure action = do
+    beforeCpu <- getCPUTime
+    beforeElapsed <- getMonotonicTimeNSec
+    checksum <- action
+    afterElapsed <- getMonotonicTimeNSec
+    afterCpu <- getCPUTime
+    checksum `seq`
+        pure Sample
+            { sampleElapsedMillis =
+                fromIntegral (afterElapsed - beforeElapsed) / 1_000_000
+            , sampleCpuMillis =
+                fromIntegral (afterCpu - beforeCpu) / 1_000_000_000
+            }
+
+-- Baseline matching the replaced call sites: try images, then call the richer
+-- general clipboard reader after failure, repeating image and path probes.
+oldFailureProbe :: IO Int
+oldFailureProbe =
+    readClipboardImages >>= \case
+        Right images -> pure (length images)
+        Left _ -> clipboardContentChecksum <$> readClipboard
+
+newFailureProbe :: IO Int
+newFailureProbe =
+    readClipboardImagesForPaste >>= \case
+        Right images -> pure (length images)
+        Left err -> pure (Text.length err)
+
+clipboardContentChecksum :: ClipboardContent -> Int
+clipboardContentChecksum = \case
+    ClipboardImage image -> Text.length image.imageMime
+    ClipboardText text -> Text.length text
+    ClipboardPaths paths -> sum (map length paths)
+    ClipboardEmpty -> 0
+
+withFakeClipboard :: IO a -> IO a
+withFakeClipboard action = do
+    tmp <- getTemporaryDirectory
+    let binDir = tmp </> "agent-clipboard-latency-bench"
+    originalPath <- getEnv "PATH"
+    bracket
+        (do
+            removeDirectoryIfPresent binDir
+            createDirectory binDir
+            writeExecutable
+                (binDir </> "osascript")
+                "#!/bin/sh\n/bin/sleep 0.01\nexit 1\n"
+            writeExecutable
+                (binDir </> "pbpaste")
+                "#!/bin/sh\nprintf 'benchmark clipboard text'\n"
+            setEnv
+                "PATH"
+                (binDir <> [searchPathSeparator] <> originalPath))
+        (\_ -> do
+            setEnv "PATH" originalPath
+            removeDirectoryIfPresent binDir)
+        (const action)
+
+writeExecutable :: FilePath -> String -> IO ()
+writeExecutable path contents = do
+    writeFile path contents
+    permissions <- getPermissions path
+    setPermissions path permissions { executable = True }
+
+removeDirectoryIfPresent :: FilePath -> IO ()
+removeDirectoryIfPresent path = do
+    exists <- doesDirectoryExist path
+    when exists (removePathForcibly path)
+
+median :: Ord a => [a] -> a
+median values =
+    sort values !! (length values `div` 2)

--- a/packages/agent-cli/package.nix
+++ b/packages/agent-cli/package.nix
@@ -39,7 +39,7 @@ mkDerivation {
   ];
   benchmarkHaskellDepends = [
     aeson agent-core agent-responses base bytestring containers
-    JuicyPixels text
+    directory filepath JuicyPixels safe-exceptions text
   ];
   description = "Command-line interface for the universal agent harness";
   license = lib.meta.getLicenseFromSpdxId "MIT";

--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -82,12 +82,10 @@ import Agent.CLI.Btw
     )
 import Agent.CLI.CancelWatch (withEscCancel, withStdinPaused)
 import Agent.CLI.Clipboard
-    ( ClipboardContent(..)
-    , formatImageSize
+    ( formatImageSize
     , loadImagesFromPastedText
     , nonEmptyClipboardImages
-    , readClipboard
-    , readClipboardImages
+    , readClipboardImagesForPaste
     , readClipboardImagesImageFirst
     )
 import Agent.CLI.Command
@@ -4342,44 +4340,12 @@ replWithDraft env@SessionEnv
                     ReplPaste pasteImmediate pasteCaption -> do
                         color <- resolveColor stdout
                         errColor <- resolveColor stderr
-                        imagesResult <- readClipboardImages
+                        imagesResult <- readClipboardImagesForPaste
                         case imagesResult of
                             Left err -> do
-                                -- Fall back to a richer clipboard sniff for better errors.
-                                content <- readClipboard
-                                let
-                                    message = case content of
-                                        ClipboardText _ ->
-                                            "clipboard has text, not an image \
-                                            \(paste text normally into the prompt)"
-                                        ClipboardPaths paths ->
-                                            "clipboard has file path(s), \
-                                            \but no loadable image: "
-                                                <> Text.intercalate
-                                                    ", " (map Text.pack paths)
-                                        ClipboardEmpty ->
-                                            err
-                                        ClipboardImage image ->
-                                            -- Shouldn't happen if readClipboardImages failed, but be safe.
-                                            "attached "
-                                                <> image.imageMime
-                                case content of
-                                    ClipboardImage image -> do
-                                        attachMessage <- queueAttachedImages
-                                            attachmentsRef
-                                            previewIdRef
-                                            color
-                                            (isNothing fullscreen)
-                                            [image]
-                                        syncFullscreenImagePreviews
-                                        displayInfo attachMessage $
-                                            Text.putStrLn
-                                                (roleMuted color
-                                                    (glyphOk <> attachMessage))
-                                    _ ->
-                                        displayError message $
-                                            Text.hPutStrLn stderr
-                                                (roleError errColor message)
+                                displayError err $
+                                    Text.hPutStrLn stderr
+                                        (roleError errColor err)
                                 continue
                             Right [] -> do
                                 displayError "no image found on the clipboard" $
@@ -6616,30 +6582,14 @@ queueClipboardImages
     previewIdRef
     color
     showPreview = do
-    imagesResult <- readClipboardImages
+    imagesResult <- readClipboardImagesForPaste
     case imagesResult of
         Right images@(_:_) ->
             Right <$> queueAttachedImages
                 attachmentsRef previewIdRef color showPreview images
         Right [] ->
             pure (Left "no image found on the clipboard")
-        Left err -> reportClipboardImageError err
-  where
-    reportClipboardImageError err =
-        readClipboard >>= \case
-            ClipboardText _ ->
-                pure $ Left
-                    "clipboard has text, not an image \
-                    \(paste text normally into the prompt)"
-            ClipboardPaths paths ->
-                pure $ Left
-                    ("clipboard has file path(s), but no loadable image: "
-                        <> Text.intercalate ", " (map Text.pack paths))
-            ClipboardEmpty ->
-                pure (Left err)
-            ClipboardImage image ->
-                Right <$> queueAttachedImages
-                    attachmentsRef previewIdRef color showPreview [image]
+        Left err -> pure (Left err)
 
 putImagePreview :: IORef Int -> Bool -> [ImageAttachment] -> IO ()
 putImagePreview previewIdRef color images = do

--- a/packages/agent-cli/src/Agent/CLI/Clipboard.hs
+++ b/packages/agent-cli/src/Agent/CLI/Clipboard.hs
@@ -5,6 +5,7 @@ module Agent.CLI.Clipboard
     , readClipboardImage
     , readClipboardImages
     , readClipboardImagesImageFirst
+    , readClipboardImagesForPaste
     , readClipboardText
     , nonEmptyClipboardImages
     , nonEmptyClipboardText
@@ -92,6 +93,42 @@ readClipboardImagesImageFirst = do
                         Right images@(_:_) -> pure (Right images)
                         Right [] -> pure (Left bitmapError)
                         Left err -> pure (Left err)
+
+-- | Read images for an explicit image-paste action and produce the richer
+-- text/path diagnostics without probing the clipboard a second time.
+readClipboardImagesForPaste :: IO (Either Text [ImageAttachment])
+readClipboardImagesForPaste = do
+    paths <- readClipboardPaths
+    existingPaths <- filterM doesFileExist paths
+    let imagePaths =
+            filter (isImageExtension . takeExtension) existingPaths
+    case imagePaths of
+        _ : _ ->
+            mapM readImageFile imagePaths >>= \loaded ->
+                pure $ case sequence loaded of
+                    Right images@(_ : _) -> Right images
+                    _ -> Left (clipboardPathsError existingPaths)
+        [] ->
+            readClipboardImageBytes >>= \case
+                Right image -> pure (Right [image])
+                Left imageError
+                    | not (null existingPaths) ->
+                        pure (Left (clipboardPathsError existingPaths))
+                    | otherwise ->
+                        readClipboardText >>= \case
+                            Right text
+                                | not (Text.null (Text.strip text)) ->
+                                    pure (Left clipboardTextError)
+                            _ -> pure (Left imageError)
+
+clipboardTextError :: Text
+clipboardTextError =
+    "clipboard has text, not an image (paste text normally into the prompt)"
+
+clipboardPathsError :: [FilePath] -> Text
+clipboardPathsError paths =
+    "clipboard has file path(s), but no loadable image: "
+        <> Text.intercalate ", " (map Text.pack paths)
 
 -- | Prefer PNG; fall back to JPEG. Back-compat for one-image callers.
 readClipboardImage :: IO (Either Text ImageAttachment)


### PR DESCRIPTION
## Summary
- probe clipboard paths, bitmap data, and text once for explicit image paste actions
- preserve rich text/path diagnostics without repeating slow AppleScript calls
- add an optimized latency benchmark for the failed image-paste path

## Validation
- `nix develop -c cabal test agent-cli:agent-cli-test --test-options=--match clipboard`
- `nix develop -c sh -c "printf ':quit\n' | cabal repl agent-cli:lib:agent-cli"`
- tmux smoke: `/paste` with text clipboard reports the expected text-not-image diagnostic
- `git diff --check`

## Benchmark
11 samples, optimized benchmark, fake macOS `osascript` with a 10 ms delay:
- old repeated probes: median 130.958 ms elapsed, 3.909 ms CPU
- new single pass: median 57.717 ms elapsed, 1.862 ms CPU