### PR TITLE
Add timestamps to conversation messages

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -102,6 +102,7 @@ import Agent.CLI.Resume
 import Agent.CLI.Render (formatElapsed, summarizeToolCall)
 import Agent.CLI.Style (motionGlyphSet)
 import Agent.CLI.Status (formatTokenUsage)
+import Agent.CLI.Timestamp (currentShortMessageTimestamp)
 import Agent.CLI.Terminal
     ( kittyCtrlVCsiBodies
     , kittySuperVCsiBodies
@@ -2453,19 +2454,22 @@ drawBlock state block =
         content = case block.blockKind of
             BlockUser ->
                 withAttr Theme.userAttr $
-                    padAll 1 (txtWrap block.blockBody)
+                    padAll 1 $
+                        timestampedMessage block.blockTimestamp
+                            (txtWrap block.blockBody)
             BlockAssistant ->
                 padLeft (Pad 3) $
-                    withAttr Theme.assistantAttr
-                        (markdownWidgetWithSyntaxHighlighting
-                            state.appSyntaxHighlighter
-                            (\codeIndex ->
-                                cached
-                                    (CodeBlockCache
-                                        block.blockId
-                                        codeIndex))
-                            (codeBlockHeader state block.blockId)
-                            block.blockBody)
+                    timestampedMessage block.blockTimestamp $
+                        withAttr Theme.assistantAttr
+                            (markdownWidgetWithSyntaxHighlighting
+                                state.appSyntaxHighlighter
+                                (\codeIndex ->
+                                    cached
+                                        (CodeBlockCache
+                                            block.blockId
+                                            codeIndex))
+                                (codeBlockHeader state block.blockId)
+                                block.blockBody)
             BlockThinking ->
                 accentBlock (thinkingBlockAttr state block)
                     (blockStateGlyph state block <> block.blockTitle)
@@ -2513,6 +2517,15 @@ drawBlock state block =
                 (codeCopyCacheState state block.blockId))
             rendered
         else rendered
+
+timestampedMessage :: Text -> Widget Name -> Widget Name
+timestampedMessage timestamp body
+    | Text.null timestamp = body
+    | otherwise =
+        hBox
+            [ padRight Max body
+            , withAttr Theme.mutedAttr (txt ("  " <> timestamp))
+            ]
 
 codeBlockHeader :: AppState -> BlockId -> Int -> Text -> Widget Name
 codeBlockHeader state blockId codeIndex language =
@@ -3154,6 +3167,7 @@ choiceRow appState selected index (label, detail) =
 handleUiEvents :: NonEmpty UiEvent -> EventM Name AppState ()
 handleUiEvents uiEvents = do
     initial <- get
+    timestamp <- liftIO currentShortMessageTimestamp
     renderedContentHeight <-
         if any isSubmittedPrompt uiEvents
             then conversationUnpaddedContentHeight
@@ -3161,7 +3175,7 @@ handleUiEvents uiEvents = do
     let
         (final, nativeProgress, shouldFollow, shouldInvalidate) =
             foldl'
-                (applyOne renderedContentHeight)
+                (applyOne timestamp renderedContentHeight)
                 (initial, Nothing, False, False)
                 uiEvents
     put final
@@ -3180,16 +3194,25 @@ handleUiEvents uiEvents = do
                 vScrollToEnd (viewportScroll ConversationViewport)
   where
     applyOne
+        timestamp
         renderedContentHeight
         (state, previousProgress, followed, invalidated)
         uiEvent =
             let
-                next =
+                unstamped =
                     applyUiEvent uiEvent $
                         applyConversationUiEvent
                             renderedContentHeight
                             uiEvent
                             state
+                next =
+                    unstamped
+                        { appUi =
+                            timestampNewMessageBlocks
+                                (Seq.length state.appUi.uiBlocks)
+                                timestamp
+                                unstamped.appUi
+                        }
                 progress =
                     case Bridge.nativeProgressSignal
                         (userActionPending next)

--- a/packages/agent-cli/src/Agent/CLI/Timestamp.hs
+++ b/packages/agent-cli/src/Agent/CLI/Timestamp.hs
@@ -5,7 +5,9 @@
 -- The REPL UI keeps the unstamped text; assistant replies are scrubbed if
 -- the model echoes a stamp.
 module Agent.CLI.Timestamp
-    ( renderMessageTimestamp
+    ( currentShortMessageTimestamp
+    , renderMessageTimestamp
+    , renderShortMessageTimestamp
     , stampUserText
     , stampUserTextAt
     , stampTurnInputs
@@ -22,6 +24,7 @@ import Data.Time.Format (defaultTimeLocale, formatTime)
 import Data.Time.LocalTime
     ( TimeZone
     , getCurrentTimeZone
+    , getZonedTime
     , timeZoneName
     , utcToZonedTime
     )
@@ -34,6 +37,16 @@ renderMessageTimestamp tz utc =
         formatTime defaultTimeLocale "[%Y-%m-%d %H:%M " local
             <> timeZoneName tz
             <> "]"
+
+-- | Format a local time for the compact right-edge message label.
+renderShortMessageTimestamp :: TimeZone -> UTCTime -> Text
+renderShortMessageTimestamp tz utc =
+    Text.pack $
+        formatTime defaultTimeLocale "%-I:%M %p" (utcToZonedTime tz utc)
+
+currentShortMessageTimestamp :: IO Text
+currentShortMessageTimestamp =
+    Text.pack . formatTime defaultTimeLocale "%-I:%M %p" <$> getZonedTime
 
 -- | Append a local timestamp to @text@ (idempotent if one is already present).
 stampUserText :: Text -> IO Text

--- a/packages/agent-cli/test/Agent/CLI/TimestampSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TimestampSpec.hs
@@ -3,7 +3,7 @@ module Agent.CLI.TimestampSpec (spec) where
 import Agent.CLI.Timestamp
 import Data.Time.Calendar (fromGregorian)
 import Data.Time.Clock (UTCTime(..), secondsToDiffTime)
-import Data.Time.LocalTime (TimeZone(..))
+import Data.Time.LocalTime (TimeZone(..), minutesToTimeZone)
 import qualified Data.Text as Text
 import Test.Hspec
 
@@ -17,6 +17,13 @@ utcSample = UTCTime (fromGregorian 2026 8 20) (secondsToDiffTime (14 * 3600 + 45
 
 spec :: Spec
 spec = do
+    describe "renderShortMessageTimestamp" do
+        it "uses compact local clock labels" do
+            renderShortMessageTimestamp
+                (minutesToTimeZone 120)
+                (UTCTime (fromGregorian 2026 8 24) (11 * 3600 + 53 * 60))
+                `shouldBe` "1:53 PM"
+
     describe "renderMessageTimestamp" do
         it "formats local wall-clock with timezone name" do
             renderMessageTimestamp cest utcSample

--- a/packages/agent-tui/src/Agent/TUI/Model.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model.hs
@@ -25,6 +25,7 @@ module Agent.TUI.Model
     , moveWordRight
     , reduceUi
     , selectedBlockIndex
+    , timestampNewMessageBlocks
     , progressNotice
     , successNotice
     , uiNextDeadlineMillis
@@ -113,6 +114,7 @@ data UiBlock = UiBlock
     , blockKind :: !BlockKind
     , blockTitle :: !Text
     , blockBody :: !Text
+    , blockTimestamp :: !Text
     , blockDetail :: !Text
     , blockState :: !BlockState
     , blockExpanded :: !Bool
@@ -729,6 +731,7 @@ appendBlock kind title body detail blockState callId state =
             , blockKind = kind
             , blockTitle = title
             , blockBody = body
+            , blockTimestamp = ""
             , blockDetail = detail
             , blockState
             , blockExpanded =
@@ -742,6 +745,24 @@ appendBlock kind title body detail blockState callId state =
         , uiSelectedBlockIndex = Just index
         , uiBlockIndices = Map.insert ident index state.uiBlockIndices
         }
+
+-- | Attach one captured wall-clock label to newly appended conversation
+-- messages. Tool and status blocks deliberately remain unstamped.
+timestampNewMessageBlocks :: Int -> Text -> UiState -> UiState
+timestampNewMessageBlocks firstNewIndex timestamp state
+    | Text.null timestamp = state
+    | otherwise =
+        state
+            { uiBlocks =
+                Seq.mapWithIndex
+                    (\index block ->
+                        if index >= firstNewIndex
+                            && Text.null block.blockTimestamp
+                            && block.blockKind `elem` [BlockUser, BlockAssistant]
+                            then block { blockTimestamp = timestamp }
+                            else block)
+                    state.uiBlocks
+            }
 
 completeTool :: Int -> ToolCallResult -> UiState -> UiState
 completeTool blockIndex result state =

--- a/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
@@ -33,6 +33,25 @@ spec = describe "fullscreen UI reducer" do
             `shouldBe` ["hello", "checking", "answer"]
         state.uiRunning `shouldBe` False
 
+    it "timestamps only newly appended user and assistant messages" do
+        let existing =
+                reduceUi (UiUserSubmitted "old prompt") initialUiState
+            appended =
+                applyFrom
+                    existing
+                    [ UiLoop TurnStarted
+                    , UiLoop (ReasoningDelta "thinking")
+                    , UiLoop (TextDelta "answer")
+                    ]
+            stamped =
+                timestampNewMessageBlocks
+                    (length existing.uiBlocks)
+                    "1:53 PM"
+                    appended
+            blocks = Foldable.toList stamped.uiBlocks
+        map (.blockTimestamp) blocks
+            `shouldBe` ["", "", "1:53 PM"]
+
     it "selects and expands a clicked reasoning block in one action" do
         let before =
                 apply


### PR DESCRIPTION
## Summary
- capture a local creation-time label for new user and assistant messages
- render compact timestamps at the right edge without colliding with wrapped content
- keep tool, thinking, system, and error blocks unchanged

## Validation
- `nix develop -c cabal test --offline agent-tui-test agent-cli-test --test-show-details=direct`
- live fullscreen TUI smoke test in tmux