### PR TITLE
Show provider capacity in fullscreen composer

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -352,6 +352,9 @@ import Agent.CLI.Turn (applyPendingSessionTitles, runOneTurn)
 import Agent.CLI.Usage
     ( AccountUsageLine(..)
     , formatDuration
+    , formatGrokLimitStatus
+    , formatOpenAiLimitStatus
+    , formatOpenRouterLimitStatus
     , formatUsageReport
     )
 import Agent.CLI.Worktree
@@ -484,9 +487,11 @@ import Agent.Tools.Types
     )
 import Agent.OpenRouter.LoopBackend (openRouterBackend)
 import qualified Agent.OpenRouter as OpenRouter
+import qualified Agent.OpenRouter.Usage as OpenRouterUsage
 import Agent.OsPath (fromText, toText, unsafeToFilePath)
 import Agent.XAI.LoopBackend (xaiBackend)
 import qualified Agent.XAI.Options as XAI
+import qualified Agent.XAI.Usage as XAIUsage
 import Control.Applicative ((<|>))
 import Control.Concurrent.Async (link, mapConcurrently, waitSTM, withAsync)
 import Control.Concurrent.Chan (Chan, newChan, readChan, writeChan)
@@ -3743,6 +3748,7 @@ buildPromptState params planState policy account accountSelectable usage attachm
         , promptAccount = account
         , promptAccountSelectable = accountSelectable
         , promptUsage = usage
+        , promptLimitStatus = Nothing
         , promptAttachments = attachments
         }
 
@@ -4060,16 +4066,26 @@ replWithDraft env@SessionEnv
                         (isJust selectAccount)
                         usage
                         (length pendingAttachments)
-            readIORef startupUnavailableRef >>= \case
-                Nothing ->
-                    Right
-                        <$> readFullscreenLineWithModels
-                            runtime skillCommands (catalogModelIds catalog)
-                            promptState draft
-                Just unavailable ->
-                    readFullscreenLineOrWithModels
-                        runtime skillCommands (catalogModelIds catalog)
-                        promptState draft unavailable
+                readPrompt =
+                    readIORef startupUnavailableRef >>= \case
+                        Nothing ->
+                            Right
+                                <$> readFullscreenLineWithModels
+                                    runtime
+                                    skillCommands
+                                    (catalogModelIds catalog)
+                                    promptState
+                                    draft
+                        Just unavailable ->
+                            readFullscreenLineOrWithModels
+                                runtime
+                                skillCommands
+                                (catalogModelIds catalog)
+                                promptState
+                                draft
+                                unavailable
+            withAsync (refreshAccountLimit runtime) \_ ->
+                readPrompt
         Nothing -> Right <$> withMVar render.renderLock \_ -> do
             -- The inline editor redraws its ANSI frame with several writes.
             -- Keep the renderer out for the complete prompt lifetime so a
@@ -4147,6 +4163,53 @@ replWithDraft env@SessionEnv
                 policy
                 mline
   where
+    refreshAccountLimit runtime =
+        case (provider, tokenProvider) of
+            (XAIProvider, Just tokens)
+                | tokenProviderBillingMode tokens == SubscriptionBilled ->
+                    refreshWith
+                        tokens
+                        XAIUsage.fetchGrokUsage
+                        formatGrokLimitStatus
+            (OpenAIProvider, Just tokens)
+                | tokenProviderBillingMode tokens == SubscriptionBilled ->
+                    getNextToken tokens Nothing >>= \case
+                        Left _ -> pure ()
+                        Right credential
+                            | Text.null (Text.strip credential.accountId) ->
+                                pure ()
+                            | otherwise ->
+                                fetchUsage
+                                    credential.accessToken
+                                    credential.accountId >>= \case
+                                        Left _ -> pure ()
+                                        Right snapshot ->
+                                            publish
+                                                (formatOpenAiLimitStatus snapshot)
+            (OpenRouterProvider, Just tokens) ->
+                getNextToken tokens Nothing >>= \case
+                    Left _ -> pure ()
+                    Right credential ->
+                        OpenRouterUsage.fetchOpenRouterUsage
+                            credential.accessToken >>= \case
+                                Left _ -> pure ()
+                                Right snapshot ->
+                                    publish
+                                        (formatOpenRouterLimitStatus snapshot)
+            _ -> pure ()
+      where
+        refreshWith tokens fetch formatStatus =
+            getNextToken tokens Nothing >>= \case
+                Left _ -> pure ()
+                Right credential ->
+                    fetch credential >>= \case
+                        Left _ -> pure ()
+                        Right snapshot -> publish (formatStatus snapshot)
+        publish limitStatus =
+            forM_
+                limitStatus
+                (emitUiEvent runtime . UiSetPromptLimitStatus . Just)
+
     handleReplLine skillCommands skillInvocations stdoutColor planState policy = \case
         ReplEof -> do
             when (isNothing fullscreen) $

--- a/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
@@ -294,7 +294,8 @@ drawComposerStatus :: AppState -> Widget Name
 drawComposerStatus state =
     hBox $
         intersperse (withAttr Theme.mutedAttr (txt " · ")) $
-            modelAndEffort
+            accountLimit
+                <> modelAndEffort
                 <> [ modeControl
                    | not (Text.null mode)
                    ]
@@ -307,6 +308,14 @@ drawComposerStatus state =
     prompt = state.appUi.uiPrompt
     mode = prompt.promptMode
     account = prompt.promptAccount
+    accountLimit =
+        [ withAttr
+            (if limitStatus.promptLimitWarning
+                then Theme.syntaxWarningAttr
+                else Theme.successAttr)
+            (txt limitStatus.promptLimitText)
+        | limitStatus <- maybeToList prompt.promptLimitStatus
+        ]
     modelControl =
         clickable ComposerModel $
             forceAttr
@@ -331,6 +340,10 @@ drawComposerStatus state =
             forceAttr
                 (controlAttr state ComposerAccount Theme.controlLinkAttr)
                 (txt account)
+
+    maybeToList = \case
+        Nothing -> []
+        Just value -> [value]
 
 handlePromptControlClick
     :: ApplyLocalUiEvent

--- a/packages/agent-cli/src/Agent/CLI/Usage.hs
+++ b/packages/agent-cli/src/Agent/CLI/Usage.hs
@@ -3,6 +3,9 @@ module Agent.CLI.Usage
     ( AccountUsageLine(..)
     , formatAccountUsage
     , formatDuration
+    , formatGrokLimitStatus
+    , formatOpenAiLimitStatus
+    , formatOpenRouterLimitStatus
     , formatUsageReport
     , formatUsageSummary
     , formatUsageWindow
@@ -14,6 +17,10 @@ import Agent.CLI.Error (formatApiErrorInlineAt)
 import Agent.CLI.Style (roleMuted, roleSuccess, roleWarn)
 import Agent.Error (ApiError)
 import Agent.OpenAI.Usage (UsageLimit(..), UsageSnapshot(..), UsageWindow(..))
+import Agent.OpenRouter.Usage (OpenRouterUsage(..))
+import Agent.TUI.Model (PromptLimitStatus(..))
+import Agent.XAI.Usage (GrokUsageSnapshot, weeklyLimitLeft)
+import Control.Applicative ((<|>))
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Time.Calendar (fromGregorian)
@@ -26,6 +33,87 @@ data AccountUsageLine = AccountUsageLine
     , usageResult :: !(Either ApiError UsageSnapshot)
     }
     deriving (Show)
+
+formatGrokLimitStatus :: GrokUsageSnapshot -> Maybe PromptLimitStatus
+formatGrokLimitStatus snapshot =
+    percentLimitStatus "Weekly limit left" <$> weeklyLimitLeft snapshot
+
+formatOpenAiLimitStatus :: UsageSnapshot -> Maybe PromptLimitStatus
+formatOpenAiLimitStatus snapshot = do
+    limits <- snapshot.rateLimit
+    case limits.secondaryWindow of
+        Just window ->
+            pure $
+                percentLimitStatus
+                    "Weekly limit left"
+                    (remainingWindowPercent window)
+        Nothing ->
+            percentLimitStatus
+                "5h limit left"
+                . remainingWindowPercent
+                <$> limits.primaryWindow
+
+formatOpenRouterLimitStatus :: OpenRouterUsage -> Maybe PromptLimitStatus
+formatOpenRouterLimitStatus usage =
+    keyLimitStatus <|> creditStatus
+  where
+    keyRemaining =
+        usage.keyLimitRemaining
+            <|> ((-) <$> usage.keyLimit <*> usage.keyUsage)
+    keyLimitStatus = case (usage.keyLimit, keyRemaining) of
+        (Just limit, Just remaining)
+            | limit > 0 ->
+                Just $
+                    percentLimitStatus
+                        "Key limit left"
+                        (remainingPercent remaining limit)
+        (_, Just remaining) ->
+            Just (amountLimitStatus "Key limit left" remaining False)
+        _ -> Nothing
+    creditStatus = do
+        credits <- usage.totalCredits
+        spent <- usage.totalUsage
+        let remaining = max 0 (credits - spent)
+            warning
+                | credits <= 0 = remaining <= 0
+                | otherwise = remainingPercent remaining credits <= 10
+        pure (amountLimitStatus "Credits left" remaining warning)
+
+percentLimitStatus :: Text -> Int -> PromptLimitStatus
+percentLimitStatus label remaining =
+    let clamped = max 0 (min 100 remaining)
+    in PromptLimitStatus
+        { promptLimitText =
+            label <> ": " <> Text.pack (show clamped) <> "%"
+        , promptLimitWarning = clamped <= 10
+        }
+
+remainingWindowPercent :: UsageWindow -> Int
+remainingWindowPercent window =
+    max 0 (100 - window.usedPercent)
+
+remainingPercent :: Real a => a -> a -> Int
+remainingPercent remaining total =
+    max 0 $
+        min 100 $
+            round
+                (100 * toRational remaining / toRational total)
+
+amountLimitStatus :: Real a => Text -> a -> Bool -> PromptLimitStatus
+amountLimitStatus label remaining warning =
+    PromptLimitStatus
+        { promptLimitText = label <> ": $" <> formatMoney remaining
+        , promptLimitWarning = warning
+        }
+
+formatMoney :: Real a => a -> Text
+formatMoney amount =
+    let cents = max 0 (round (toRational amount * 100) :: Integer)
+        (dollars, remainder) = cents `divMod` 100
+        centsText
+            | remainder < 10 = "0" <> Text.pack (show remainder)
+            | otherwise = Text.pack (show remainder)
+    in Text.pack (show dollars) <> "." <> centsText
 
 formatUsageReport :: Bool -> UTCTime -> [AccountUsageLine] -> Text
 formatUsageReport color now lines_ =

--- a/packages/agent-cli/test/Agent/CLI/ProviderAvailabilitySpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ProviderAvailabilitySpec.hs
@@ -30,6 +30,7 @@ spec = do
         it "classifies exhausted Grok usage with its reset delay" do
             xaiUsageFailure now XAI.GrokUsageSnapshot
                 { usedPercent = 100
+                , periodType = "USAGE_PERIOD_TYPE_WEEKLY"
                 , windowSeconds = 3600
                 , resetsAt = addUTCTime 90 now
                 }
@@ -43,6 +44,7 @@ spec = do
         it "leaves Grok credentials usable below the limit" do
             xaiUsageFailure now XAI.GrokUsageSnapshot
                 { usedPercent = 99
+                , periodType = "USAGE_PERIOD_TYPE_WEEKLY"
                 , windowSeconds = 3600
                 , resetsAt = addUTCTime 90 now
                 }

--- a/packages/agent-cli/test/Agent/CLI/UsageSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/UsageSpec.hs
@@ -3,6 +3,9 @@ module Agent.CLI.UsageSpec (spec) where
 import Agent.CLI.Usage
 import Agent.Error (ApiError(..), ErrorType(..))
 import Agent.OpenAI.Usage
+import qualified Agent.OpenRouter.Usage as OpenRouter
+import Agent.TUI.Model (PromptLimitStatus(..))
+import qualified Agent.XAI.Usage as XAI
 import qualified Data.Text as Text
 import Data.Time.Calendar (fromGregorian)
 import Data.Time.Clock (UTCTime(..), addUTCTime)
@@ -77,6 +80,66 @@ spec = do
                 (Left (ConnectionError "offline"))
                 `shouldBe` "usage unavailable"
 
+    describe "composer limit status" do
+        it "uses OpenAI's weekly window ahead of its 5-hour window" do
+            formatOpenAiLimitStatus sampleSnapshot
+                `shouldBe`
+                    Just PromptLimitStatus
+                        { promptLimitText = "Weekly limit left: 28%"
+                        , promptLimitWarning = False
+                        }
+
+        it "falls back to OpenAI's 5-hour window" do
+            let snapshot = UsageSnapshot
+                    { planType = sampleSnapshot.planType
+                    , rateLimit =
+                        Just UsageLimit
+                            { allowed = True
+                            , limitReached = False
+                            , primaryWindow = Just sampleWindow
+                            , secondaryWindow = Nothing
+                            }
+                    , additionalRateLimits = []
+                    }
+            formatOpenAiLimitStatus snapshot
+                `shouldBe`
+                    Just PromptLimitStatus
+                        { promptLimitText = "5h limit left: 69%"
+                        , promptLimitWarning = False
+                        }
+
+        it "formats Grok's weekly reserve" do
+            formatGrokLimitStatus XAI.GrokUsageSnapshot
+                { XAI.usedPercent = 96
+                , XAI.periodType = "USAGE_PERIOD_TYPE_WEEKLY"
+                , XAI.windowSeconds = 604800
+                , XAI.resetsAt = epoch
+                }
+                `shouldBe`
+                    Just PromptLimitStatus
+                        { promptLimitText = "Weekly limit left: 4%"
+                        , promptLimitWarning = True
+                        }
+
+        it "formats an OpenRouter key limit as a percentage" do
+            formatOpenRouterLimitStatus sampleOpenRouterUsage
+                `shouldBe`
+                    Just PromptLimitStatus
+                        { promptLimitText = "Key limit left: 25%"
+                        , promptLimitWarning = False
+                        }
+
+        it "falls back to the OpenRouter credit balance" do
+            formatOpenRouterLimitStatus sampleOpenRouterUsage
+                { OpenRouter.keyLimit = Nothing
+                , OpenRouter.keyLimitRemaining = Nothing
+                }
+                `shouldBe`
+                    Just PromptLimitStatus
+                        { promptLimitText = "Credits left: $37.50"
+                        , promptLimitWarning = False
+                        }
+
 sampleWindow :: UsageWindow
 sampleWindow = UsageWindow
     { usedPercent = 31
@@ -100,6 +163,17 @@ sampleSnapshot = UsageSnapshot
             }
         }
     , additionalRateLimits = []
+    }
+
+sampleOpenRouterUsage :: OpenRouter.OpenRouterUsage
+sampleOpenRouterUsage = OpenRouter.OpenRouterUsage
+    { OpenRouter.keyLabel = Just "coding"
+    , OpenRouter.keyUsage = Just 75
+    , OpenRouter.keyLimit = Just 100
+    , OpenRouter.keyLimitRemaining = Just 25
+    , OpenRouter.isFreeTier = Just False
+    , OpenRouter.totalCredits = Just 50
+    , OpenRouter.totalUsage = Just 12.5
     }
 
 epoch :: UTCTime

--- a/packages/agent-tui/src/Agent/TUI/Model.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model.hs
@@ -7,6 +7,7 @@ module Agent.TUI.Model
     , NoticeKind(..)
     , RetryCountdown(..)
     , PermissionOverlay(..)
+    , PromptLimitStatus(..)
     , PromptState(..)
     , UiBlock(..)
     , UiEvent(..)
@@ -134,6 +135,12 @@ data PermissionOverlay = PermissionOverlay
     }
     deriving (Eq, Show)
 
+data PromptLimitStatus = PromptLimitStatus
+    { promptLimitText :: !Text
+    , promptLimitWarning :: !Bool
+    }
+    deriving (Eq, Show)
+
 data PromptState = PromptState
     { promptModel :: !Text
     , promptEffort :: !Text
@@ -141,6 +148,7 @@ data PromptState = PromptState
     , promptAccount :: !Text
     , promptAccountSelectable :: !Bool
     , promptUsage :: !TokenUsage
+    , promptLimitStatus :: !(Maybe PromptLimitStatus)
     , promptAttachments :: !Int
     }
     deriving (Eq, Show)
@@ -184,6 +192,7 @@ data UiEvent
     | UiSetDraft !Text !Int
     | UiSetPrompt !PromptState
     | UiSetPromptEffort !Text
+    | UiSetPromptLimitStatus !(Maybe PromptLimitStatus)
     | UiSetAwaitingInput !Bool
     | UiSetRepository !Text !Text
     | UiSetNotice !(Maybe UiNotice)
@@ -229,6 +238,7 @@ initialUiState = UiState
         , promptAccount = ""
         , promptAccountSelectable = False
         , promptUsage = emptyTokenUsage
+        , promptLimitStatus = Nothing
         , promptAttachments = 0
         }
     , uiBranch = ""
@@ -309,6 +319,11 @@ reduceUi event state = case event of
     UiSetPromptEffort effort ->
         state
             { uiPrompt = state.uiPrompt { promptEffort = effort }
+            }
+    UiSetPromptLimitStatus limitStatus ->
+        state
+            { uiPrompt =
+                state.uiPrompt { promptLimitStatus = limitStatus }
             }
     UiSetAwaitingInput awaiting ->
         (if awaiting then finalizeStreams state else state)

--- a/packages/agent-xai/src/Agent/XAI/Usage.hs
+++ b/packages/agent-xai/src/Agent/XAI/Usage.hs
@@ -3,14 +3,16 @@ module Agent.XAI.Usage
     ( GrokUsageSnapshot(..)
     , decodeGrokUsage
     , fetchGrokUsage
+    , weeklyLimitLeft
     ) where
 
 import Control.Exception.Safe (tryAny)
 import Agent.Provider (Credential(..))
 import qualified Data.Aeson as Aeson
-import Data.Aeson ((.:))
+import Data.Aeson ((.:), (.:?))
 import Data.Aeson.Types (Parser)
 import qualified Data.ByteString.Lazy as LBS
+import Data.Maybe (fromMaybe)
 import Data.Scientific (Scientific)
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -21,6 +23,7 @@ import Network.HTTP.Simple
 
 data GrokUsageSnapshot = GrokUsageSnapshot
     { usedPercent :: !Int
+    , periodType :: !Text
     , windowSeconds :: !Int
     , resetsAt :: !UTCTime
     }
@@ -35,25 +38,37 @@ instance Aeson.FromJSON GrokUsageSnapshot where
             creditUsagePercent <-
                 config .: "creditUsagePercent" :: Parser Scientific
             currentPeriod <- config .: "currentPeriod"
-            (startsAt, resetsAt) <-
+            (periodType, startsAt, resetsAt) <-
                 Aeson.withObject "Grok billing period" parsePeriod currentPeriod
             let usedPercent = max 0 (min 100 (floor creditUsagePercent))
                 windowSeconds =
                     max 1 (round (diffUTCTime resetsAt startsAt))
             pure GrokUsageSnapshot
                 { usedPercent
+                , periodType
                 , windowSeconds
                 , resetsAt
                 }
 
         parsePeriod period =
-            (,) <$> period .: "start" <*> period .: "end"
+            (,,)
+                <$> (fromMaybe "" <$> period .:? "type")
+                <*> period .: "start"
+                <*> period .: "end"
 
 decodeGrokUsage :: LBS.ByteString -> Either Text GrokUsageSnapshot
 decodeGrokUsage body = case Aeson.eitherDecode body of
     Left _ ->
         Left "Grok returned an unreadable usage response."
     Right snapshot -> Right snapshot
+
+-- | The fullscreen composer mirrors Grok Build's weekly reserve label only
+-- when the billing service explicitly reports a weekly period.
+weeklyLimitLeft :: GrokUsageSnapshot -> Maybe Int
+weeklyLimitLeft snapshot
+    | snapshot.periodType == "USAGE_PERIOD_TYPE_WEEKLY" =
+        Just (max 0 (100 - snapshot.usedPercent))
+    | otherwise = Nothing
 
 fetchGrokUsage :: Credential -> IO (Either Text GrokUsageSnapshot)
 fetchGrokUsage credential =

--- a/packages/agent-xai/test/Agent/XAI/UsageSpec.hs
+++ b/packages/agent-xai/test/Agent/XAI/UsageSpec.hs
@@ -10,13 +10,16 @@ spec =
         it "decodes and floors the current subscription period" do
             let body = LBS.pack
                     "{\"config\":{\"creditUsagePercent\":31.9,\
-                    \\"currentPeriod\":{\"start\":\"2026-08-20T00:00:00Z\",\
+                    \\"currentPeriod\":{\"type\":\"USAGE_PERIOD_TYPE_WEEKLY\",\
+                    \\"start\":\"2026-08-20T00:00:00Z\",\
                     \\"end\":\"2026-08-21T00:00:00Z\"}}}"
             case decodeGrokUsage body of
                 Left err -> expectationFailure (show err)
                 Right snapshot -> do
                     snapshot.usedPercent `shouldBe` 31
+                    snapshot.periodType `shouldBe` "USAGE_PERIOD_TYPE_WEEKLY"
                     snapshot.windowSeconds `shouldBe` 86400
+                    weeklyLimitLeft snapshot `shouldBe` Just 69
 
         it "clamps percentages to the provider range" do
             let body = LBS.pack
@@ -28,3 +31,12 @@ spec =
         it "hides parser internals for unreadable responses" do
             decodeGrokUsage "not json"
                 `shouldBe` Left "Grok returned an unreadable usage response."
+
+        it "does not label non-weekly periods as weekly" do
+            let body = LBS.pack
+                    "{\"config\":{\"creditUsagePercent\":20,\
+                    \\"currentPeriod\":{\"type\":\"USAGE_PERIOD_TYPE_MONTHLY\",\
+                    \\"start\":\"2026-08-01T00:00:00Z\",\
+                    \\"end\":\"2026-09-01T00:00:00Z\"}}}"
+            fmap weeklyLimitLeft (decodeGrokUsage body)
+                `shouldBe` Right Nothing


### PR DESCRIPTION
## Summary

- add a provider-neutral capacity status to the fullscreen composer footer
- show OpenAI weekly capacity with a 5-hour fallback, Grok weekly capacity, and OpenRouter key limits or credit balance
- fetch capacity asynchronously and highlight low remaining capacity
- add provider formatter and Grok billing-period coverage

## Validation

- affected package graph loads successfully in GHCi through `nix develop`
- complete `agent-cli` test suite passes
- `agent-xai` test suite: 48 examples, 0 failures, 1 expected pending live test
- real tmux fullscreen smoke test showed the OpenRouter credit balance in the composer footer
