### PR TITLE
Fix stale fullscreen layout artifacts

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -8,6 +8,7 @@ module Agent.CLI.TUI.App
     , agentPaneVisible
     , completionFlashTransitions
     , conversationScrollbarRenderer
+    , choiceRowColumns
     , choiceClosesOnUiTransition
     , elapsedMillisSince
     , emitUiEvent
@@ -38,6 +39,7 @@ module Agent.CLI.TUI.App
     , requestFullscreenText
     , runFullscreen
     , setFullscreenSessionActions
+    , fullscreenBounds
     , fullscreenVtyConfig
     , fullscreenSurface
     , setFullscreenImagePreviews
@@ -1549,27 +1551,28 @@ fullscreenApp = App
 
 drawApp :: AppState -> [Widget Name]
 drawApp state =
-    let mainLayers = stickyPromptLayers state <> [drawMain state]
-        interactiveLayers =
-            agentPopoverLayers state
-                <> imagePreviewLayers
-                    state.appRuntime.runtimeNativeImagePreviews
-                    state.appImagePreviews
-                <> mainLayers
-        dimmedMainLayers = map (forceAttr Theme.dimAttr) mainLayers
-    in
-    case state.appResume of
-        Just resume ->
-            drawResume state resume : dimmedMainLayers
-        Nothing ->
-            case (state.appTextPrompt, state.appChoice, state.appUi.uiPermission) of
-                (Just prompt, _, _) ->
-                    drawTextPrompt state prompt : dimmedMainLayers
-                (Nothing, Just choice, _) ->
-                    drawChoice state choice : dimmedMainLayers
-                (Nothing, Nothing, Just permission) ->
-                    drawPermission state permission : dimmedMainLayers
-                (Nothing, Nothing, Nothing) -> interactiveLayers
+    map fullscreenBounds $
+        case state.appResume of
+            Just resume ->
+                drawResume state resume : dimmedMainLayers
+            Nothing ->
+                case (state.appTextPrompt, state.appChoice, state.appUi.uiPermission) of
+                    (Just prompt, _, _) ->
+                        drawTextPrompt state prompt : dimmedMainLayers
+                    (Nothing, Just choice, _) ->
+                        drawChoice state choice : dimmedMainLayers
+                    (Nothing, Nothing, Just permission) ->
+                        drawPermission state permission : dimmedMainLayers
+                    (Nothing, Nothing, Nothing) -> interactiveLayers
+  where
+    mainLayers = stickyPromptLayers state <> [drawMain state]
+    interactiveLayers =
+        agentPopoverLayers state
+            <> imagePreviewLayers
+                state.appRuntime.runtimeNativeImagePreviews
+                state.appImagePreviews
+            <> mainLayers
+    dimmedMainLayers = map (forceAttr Theme.dimAttr) mainLayers
 
 drawMain :: AppState -> Widget Name
 drawMain state =
@@ -1585,6 +1588,29 @@ drawMain state =
                 , Composer.drawComposer state
                 , drawFooter state
                 ]
+
+-- | Crop a top-level layer to the terminal without filling its unused cells.
+-- Overlay layers must remain transparent, but custom widgets can otherwise
+-- return images (and cursors) outside the render context and make Vty wrap
+-- terminal rows.
+fullscreenBounds :: Widget n -> Widget n
+fullscreenBounds widget =
+    B.Widget B.Greedy B.Greedy do
+        context <- B.getContext
+        result <- B.render widget
+        let width = max 0 context.availWidth
+            height = max 0 context.availHeight
+            cursorInBounds cursor =
+                let Location (column, row) = cursor.cursorLocation
+                in column >= 0
+                    && column < width
+                    && row >= 0
+                    && row < height
+        pure
+            result
+                { B.image = V.crop width height result.image
+                , B.cursors = filter cursorInBounds result.cursors
+                }
 
 -- | Bound the retained main layer to the terminal and explicitly paint every
 -- cell. Some terminals can retain cells from an older, wider layout when a
@@ -3184,11 +3210,19 @@ choiceRow appState selected index (label, detail) =
     let prefix = if selected == index then "› " else "  "
         name = ChoiceRow index
         row =
-            hBox
-                [ txt (prefix <> label)
-                , vLimit 1 (fill ' ')
-                , withAttr Theme.mutedAttr (txt detail)
-                ]
+            Widget Greedy Fixed do
+                context <- getContext
+                let (shownLabel, shownDetail) =
+                        choiceRowColumns
+                            context.availWidth
+                            (prefix <> label)
+                            detail
+                render $
+                    hBox
+                        [ txt shownLabel
+                        , vLimit 1 (fill ' ')
+                        , withAttr Theme.mutedAttr (txt shownDetail)
+                        ]
         styled =
             if selected == index
                 then withAttr Theme.selectedAttr row
@@ -3197,6 +3231,31 @@ choiceRow appState selected index (label, detail) =
             Nothing -> styled
             Just attr -> forceAttr attr row
     in clickable name interactive
+
+-- | Fit a choice label and its right-aligned detail into one terminal row.
+-- When both do not fit, the label gets roughly two thirds of the available
+-- cells and the detail gets the rest; short columns donate their unused space.
+choiceRowColumns :: Int -> Text -> Text -> (Text, Text)
+choiceRowColumns width label detail
+    | width <= 0 = ("", "")
+    | Text.null detail = (truncateDisplayText width label, "")
+    | labelWidth + choiceRowGap + detailWidth <= width = (label, detail)
+    | width <= choiceRowGap + 1 = (truncateDisplayText width label, "")
+    | otherwise =
+        ( truncateDisplayText labelBudget label
+        , truncateDisplayText detailBudget detail
+        )
+  where
+    choiceRowGap = 2
+    labelWidth = terminalTextWidth label
+    detailWidth = terminalTextWidth detail
+    contentBudget = width - choiceRowGap
+    preferredDetailBudget =
+        min detailWidth (max 1 (contentBudget `div` 3))
+    labelBudget =
+        min labelWidth (contentBudget - preferredDetailBudget)
+    detailBudget =
+        min detailWidth (contentBudget - labelBudget)
 
 handleUiEvents :: NonEmpty UiEvent -> EventM Name AppState ()
 handleUiEvents uiEvents = do

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -39,6 +39,7 @@ module Agent.CLI.TUI.App
     , runFullscreen
     , setFullscreenSessionActions
     , fullscreenVtyConfig
+    , fullscreenSurface
     , setFullscreenImagePreviews
     , setFullscreenWindowTitle
     , uiEventRestartsMotionSchedule
@@ -1572,16 +1573,62 @@ drawApp state =
 
 drawMain :: AppState -> Widget Name
 drawMain state =
-    withAttr Theme.baseAttr $
-        vBox
-            [ drawHeader state
-            , drawWorkspace state
-            , drawNotice state
-            , Composer.drawQueuedInputs state.appUi
-            , Composer.drawSlashMenu state
-            , drawFollowStatus state.appUi
-            , Composer.drawComposer state
-            , drawFooter state
+    fullscreenSurface $
+        withAttr Theme.baseAttr $
+            vBox
+                [ drawHeader state
+                , drawWorkspace state
+                , drawNotice state
+                , Composer.drawQueuedInputs state.appUi
+                , Composer.drawSlashMenu state
+                , drawFollowStatus state.appUi
+                , Composer.drawComposer state
+                , drawFooter state
+                ]
+
+-- | Bound the retained main layer to the terminal and explicitly paint every
+-- cell. Some terminals can retain cells from an older, wider layout when a
+-- later Brick image is narrower; an over-wide image can instead trigger
+-- terminal-side wrapping and shift subsequent rows. Keeping the backing layer
+-- exactly the render-context size prevents both failure modes.
+fullscreenSurface :: Widget n -> Widget n
+fullscreenSurface widget =
+    B.Widget B.Greedy B.Greedy do
+        context <- B.getContext
+        base <- B.lookupAttrName Theme.baseAttr
+        result <- B.render widget
+        let width = max 0 context.availWidth
+            height = max 0 context.availHeight
+            cropped = V.crop width height result.image
+            widthPadded =
+                padImageRight
+                    base
+                    (width - V.imageWidth cropped)
+                    cropped
+            padded =
+                padImageBottom
+                    base
+                    width
+                    (height - V.imageHeight widthPadded)
+                    widthPadded
+        pure result { B.image = padded }
+
+padImageRight :: V.Attr -> Int -> V.Image -> V.Image
+padImageRight attr amount image
+    | amount <= 0 || V.imageHeight image <= 0 = image
+    | otherwise =
+        V.horizCat
+            [ image
+            , V.charFill attr ' ' amount (V.imageHeight image)
+            ]
+
+padImageBottom :: V.Attr -> Int -> Int -> V.Image -> V.Image
+padImageBottom attr width amount image
+    | amount <= 0 || width <= 0 = image
+    | otherwise =
+        V.vertCat
+            [ image
+            , V.charFill attr ' ' width amount
             ]
 
 imagePreviewLayers :: Bool -> [TuiImagePreview] -> [Widget Name]

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -11,6 +11,7 @@ import Agent.CLI.TUI.App
     , choiceClosesOnUiTransition
     , elapsedMillisSince
     , fullscreenVtyConfig
+    , fullscreenSurface
     , motionDemandFor
     , lambdaArtWidget
     , nativeProgressKeepaliveDue
@@ -33,8 +34,10 @@ import Agent.CLI.TUI.Types
 import Agent.Loop (LoopEvent(..), emptyTurnOutput)
 import Brick
     ( VScrollbarRenderer(..)
+    , Widget
     , hLimit
     , renderWidget
+    , txt
     , vLimit
     )
 import Agent.Subagents (SubagentId(..))
@@ -195,6 +198,21 @@ spec = do
                         renderWidget Nothing [lambdaArtWidget 0] (5, 3)
             V.imageWidth image `shouldSatisfy` (<= 5)
             V.imageHeight image `shouldSatisfy` (<= 3)
+
+        it "paints an exact terminal-sized backing surface" do
+            let image =
+                    V.picImage $
+                        renderWidget
+                            Nothing
+                            [ ( fullscreenSurface $
+                                    vLimit 1 $
+                                        hLimit 20 $
+                                            txt "content that exceeds the terminal"
+                              ) :: Widget ()
+                            ]
+                            (8, 4)
+            V.imageWidth image `shouldBe` 8
+            V.imageHeight image `shouldBe` 4
 
     describe "resume search cursor" do
         it "uses terminal cells for wide and combining characters" do

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -1,6 +1,7 @@
 module Agent.CLI.TUIAppSpec (spec) where
 
 import Agent.CLI.AgentViewport (AgentEntry(..), AgentTarget(..))
+import Agent.CLI.Input (terminalTextWidth)
 import Agent.CLI.TUI.App
     ( advanceCompletionFlashes
     , agentEntryWindow
@@ -8,8 +9,10 @@ import Agent.CLI.TUI.App
     , agentPaneVisible
     , completionFlashTransitions
     , conversationScrollbarRenderer
+    , choiceRowColumns
     , choiceClosesOnUiTransition
     , elapsedMillisSince
+    , fullscreenBounds
     , fullscreenVtyConfig
     , fullscreenSurface
     , motionDemandFor
@@ -40,6 +43,7 @@ import Brick
     , txt
     , vLimit
     )
+import qualified Brick.Types as B
 import Agent.Subagents (SubagentId(..))
 import Agent.ToolDispatch
     ( ToolCallKind(..)
@@ -214,12 +218,48 @@ spec = do
             V.imageWidth image `shouldBe` 8
             V.imageHeight image `shouldBe` 4
 
+        it "crops oversized overlay layers to the terminal" do
+            let oversized :: Widget ()
+                oversized =
+                    B.Widget B.Greedy B.Greedy $
+                        pure
+                            B.emptyResult
+                                { B.image =
+                                    V.charFill V.defAttr 'x' (20 :: Int) 10
+                                }
+                image =
+                    V.picImage $
+                        renderWidget
+                            Nothing
+                            [fullscreenBounds oversized]
+                            (8, 4)
+            V.imageWidth image `shouldBe` 8
+            V.imageHeight image `shouldBe` 4
+
     describe "resume search cursor" do
         it "uses terminal cells for wide and combining characters" do
             resumeSearchCursorColumn "search: " "漢"
                 `shouldBe` 10
             resumeSearchCursorColumn "search: " "e\x0301"
                 `shouldBe` 9
+
+    describe "choice row layout" do
+        it "keeps long labels and details separated inside the row width" do
+            let (label, detail) =
+                    choiceRowColumns
+                        57
+                        "  openrouter · stealth/ox-alpha · generic-responses"
+                        "default · frontier · free · coding"
+            terminalTextWidth label
+                + 2
+                + terminalTextWidth detail
+                `shouldSatisfy` (<= 57)
+            label `shouldSatisfy` Text.isSuffixOf "…"
+            detail `shouldSatisfy` Text.isSuffixOf "…"
+
+        it "preserves both columns when they already fit" do
+            choiceRowColumns 40 "› model" "default"
+                `shouldBe` ("› model", "default")
 
     describe "onboarding layout" do
         it "uses the complete 18-row surface when it fits" do

--- a/packages/agent-tui/src/Agent/TUI/Markdown.hs
+++ b/packages/agent-tui/src/Agent/TUI/Markdown.hs
@@ -512,7 +512,11 @@ inlineWidgetWithAttr plainAttr inlines =
                         ]
                     | row <- rows
                     ]
-        pure B.emptyResult { B.image = rendered }
+            boundedImage
+                | V.imageWidth rendered > width =
+                    V.cropRight width rendered
+                | otherwise = rendered
+        pure B.emptyResult { B.image = boundedImage }
 
 data InlineContext = InlineContext
     { inlineStrong :: !Bool

--- a/packages/agent-tui/test/Agent/TUI/MarkdownSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/MarkdownSpec.hs
@@ -54,6 +54,16 @@ spec = describe "fullscreen Markdown rendering" do
             spans = concat (renderSpanRows 100 ("PR: " <> url))
         spans `shouldSatisfy` any (hasUrl url)
 
+    it "keeps a wide inline glyph inside a one-cell render context" do
+        let image =
+                V.picImage $
+                    renderWidget
+                        Nothing
+                        [markdownWidget "界" :: Widget ()]
+                        (1, 2)
+        V.imageWidth image `shouldSatisfy` (<= 1)
+        V.imageHeight image `shouldSatisfy` (<= 2)
+
     it "parses links nested inside strong and emphasis spans" do
         parseInline
             "**[PR #316](https://example.com/316)** and *[docs](https://example.com)*"


### PR DESCRIPTION
## Summary
- crop and pad the retained fullscreen main layer so every terminal cell is repainted after layout changes
- crop every top-level overlay/popover layer to the current terminal and discard off-screen cursors
- keep wide inline Markdown glyphs from escaping one-cell render contexts
- allocate model/choice label and detail columns by terminal-cell width, with separated ellipsized text on narrow screens
- add regressions for exact backing surfaces, oversized layers, wide glyphs, and choice-row allocation

## Verification
- complete `agent-cli` test suite: 805 examples, 0 failures
- complete `agent-tui` test suite: 129 examples, 0 failures
- `git diff --check`
- live tmux resize smoke test at 72x22, 90x30, 110x35, and 140x45
- live model chooser test confirmed aligned borders, separated columns, and clean overlay dismissal after resize