### PR TITLE
Fix compaction across images and tool continuations

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Compaction.hs
+++ b/packages/agent-cli/src/Agent/CLI/Compaction.hs
@@ -44,7 +44,6 @@ import Agent.OpenAI.ModelMetadata
 import Agent.Responses.LoopBackend
     ( assistantTextFromResponse
     , responseTokenUsage
-    , toolResultToItem
     , turnInputsToItems
     , withRequestInput
     )
@@ -529,8 +528,8 @@ autoCompactOpenAiBackendWithLimit getLimit compactAction recordUsage
                     && projectedTokens >= tokenLimit
         if shouldCompact
             then if any isCompletedTool inputs
-                then compactToolContinuation
-                    contextState history inputs onEvent
+                then submitAndTrack
+                    contextState history previous inputs onEvent
                 else compactThenSubmit
                     contextState history inputs onEvent
             else submitAndTrack
@@ -541,31 +540,10 @@ autoCompactOpenAiBackendWithLimit getLimit compactAction recordUsage
             <$> runAttemptAndRecord recordUsage (compactAction history)
 
     isCompletedTool = \case
+        -- Commit the tool result before compacting so the call and output
+        -- remain a coherent pair in the next compaction request.
         CompletedTool{} -> True
         _ -> False
-
-    -- Tool outputs must be part of the checkpoint, but the wrapped backend has
-    -- not committed them yet. Absorb them into history before compaction, then
-    -- resume from the new checkpoint without sending them a second time.
-    compactToolContinuation oldTokens oldHistory inputs onEvent = do
-        mask \restore -> do
-            let (toolItems, remainingInputs) = absorbCompletedTools inputs
-                compactHistory = oldHistory <> toolItems
-                rollback = writeIORef contextTokensRef oldTokens
-            (do
-                onEvent (ActivityUpdated "Compacting context…")
-                restore (runCompaction compactHistory) >>= \case
-                    Left err -> do
-                        rollback
-                        pure (Left (automaticCompactionError err))
-                    Right outcome ->
-                        installSubmitAndTrack
-                            restore
-                            rollback
-                            outcome
-                            remainingInputs
-                            onEvent
-                ) `onException` rollback
 
     compactThenSubmit oldTokens oldHistory inputs onEvent = do
         onEvent (ActivityUpdated "Compacting context…")
@@ -608,16 +586,6 @@ autoCompactOpenAiBackendWithLimit getLimit compactAction recordUsage
     -- leave token metadata describing an uncommitted transcript.
     invalidateContextTokens =
         writeIORef contextTokensRef Nothing
-
-    absorbCompletedTools =
-        foldr
-            (\input (toolItems, otherInputs) ->
-                case input of
-                    CompletedTool result ->
-                        (toolResultToItem result : toolItems, otherInputs)
-                    _ ->
-                        (toolItems, input : otherInputs))
-            ([], [])
 
     automaticCompactionError = \case
         ProviderError errorType message retryAfter ->

--- a/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
@@ -480,7 +480,7 @@ spec = do
             readIORef seenPrevious `shouldReturn` [Nothing, Nothing]
             readIORef recordedUsage `shouldReturn` [compactionUsage]
 
-        it "compacts when a pending tool output crosses the limit" do
+        it "defers compaction while continuing a completed tool call" do
             let danglingCall = FunctionCallItem FunctionCall
                     { itemId = Nothing
                     , callId = "call-1"
@@ -500,13 +500,10 @@ spec = do
                 (Just (codexAutoCompactTokenLimit - 10, length oldHistory))
             compactCalls <- newIORef (0 :: Int)
             recordedUsage <- newIORef []
-            historyAtCompact <- newIORef []
             seenPrevious <- newIORef []
             seenInputs <- newIORef []
-            let sender request = do
+            let sender _request = do
                     modifyIORef' compactCalls (+ 1)
-                    writeIORef historyAtCompact
-                        (init (requestItems request))
                     pure (Right remoteCompactionResponse)
                 base = Backend \state previous inputs _ -> do
                     modifyIORef' seenPrevious (<> [previous])
@@ -529,20 +526,12 @@ spec = do
             result <- backend.submitTurn oldHistory (Just "resp-tool") inputs
                 (const (pure ()))
             result `shouldSatisfy` either (const False) (const True)
-            readIORef compactCalls `shouldReturn` 1
-            compactInput <- readIORef historyAtCompact
-            compactInput `shouldSatisfy` \items ->
-                case reverse items of
-                    FunctionCallOutputItem output : _ ->
-                        output.callId == "call-1"
-                            && output.output == Aeson.String toolOutputText
-                    _ -> False
-            readIORef seenPrevious `shouldReturn` [Nothing]
-            readIORef seenInputs `shouldReturn` [[]]
-            let compacted = either (const []) (.backendState) result
-            compacted `shouldSatisfy` hasCompactionCheckpoint
+            readIORef compactCalls `shouldReturn` 0
+            readIORef seenPrevious `shouldReturn` [Just "resp-tool"]
+            readIORef seenInputs `shouldReturn` [inputs]
+            fmap (.backendState) result `shouldBe` Right oldHistory
             readIORef contextState `shouldReturn` Nothing
-            readIORef recordedUsage `shouldReturn` [compactionUsage]
+            readIORef recordedUsage `shouldReturn` []
 
         it "preserves typed provider failures from automatic compaction" do
             let history = [userTextItem "old"]

--- a/packages/agent-openai/src/Agent/OpenAI/Compaction.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Compaction.hs
@@ -111,6 +111,8 @@ trimRemoteCompactionHistoryToFit contextWindow instructionText history =
 
 rewriteOversizedToolOutput :: ResponseItem -> Maybe ResponseItem
 rewriteOversizedToolOutput = \case
+    MessageItem message ->
+        MessageItem <$> omitMessageImages message
     FunctionCallOutputItem output ->
         Just $ FunctionCallOutputItem FunctionCallOutput
             { itemId = output.itemId
@@ -138,6 +140,36 @@ rewriteOversizedToolOutput = \case
                     tagged.fields
             }
     _ -> Nothing
+
+omitRemoteRetainedImages :: ResponseItem -> ResponseItem
+omitRemoteRetainedImages = \case
+    MessageItem message ->
+        maybe (MessageItem message) MessageItem (omitMessageImages message)
+    item -> item
+
+omitMessageImages :: ResponseMessage -> Maybe ResponseMessage
+omitMessageImages message =
+    case message.content of
+        MessageContentParts parts
+            | any isInputImagePart parts ->
+                Just $ replaceMessageContent message $
+                    MessageContentParts (concatMap omitImagePart parts)
+        _ -> Nothing
+
+isInputImagePart :: ResponseContentPart -> Bool
+isInputImagePart = \case
+    InputImagePart {} -> True
+    _ -> False
+
+omitImagePart :: ResponseContentPart -> [ResponseContentPart]
+omitImagePart = \case
+    InputImagePart {} ->
+        [ InputTextPart
+            "[Earlier image attachment omitted during compaction]"
+            Nothing
+            KeyMap.empty
+        ]
+    part -> [part]
 
 -- | A successful v2 stream must complete and contain exactly one compaction
 -- output item. Other output item types are ignored, matching Codex.
@@ -174,9 +206,18 @@ buildRemoteCompactedHistory
     -> [ResponseItem]
 buildRemoteCompactedHistory budget history checkpoint =
     truncateRetainedGroups budget
-        (filter (\group -> isRemoteRetainedItem group.retainedSource)
-            (retainedGroups history))
+        (map sanitizeRemoteRetainedGroup
+            (filter (\group -> isRemoteRetainedItem group.retainedSource)
+                (retainedGroups history)))
         <> [checkpoint]
+
+sanitizeRemoteRetainedGroup :: RetainedGroup -> RetainedGroup
+sanitizeRemoteRetainedGroup group =
+    -- Inline image payloads otherwise survive every checkpoint and can make
+    -- the newly compacted history immediately exceed the token threshold.
+    group
+        { retainedSource = omitRemoteRetainedImages group.retainedSource
+        }
 
 data RetainedGroup = RetainedGroup
     { retainedSource :: !ResponseItem

--- a/packages/agent-openai/test/Agent/OpenAI/CompactionSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/CompactionSpec.hs
@@ -119,6 +119,51 @@ spec = do
             retainedTexts `shouldBe` [Text.take 8 old, recent]
             last compacted `shouldBe` opaque
 
+        it "omits inline image payloads from retained user messages" do
+            let opaque = checkpoint "opaque"
+                imageUrl =
+                    "data:image/png;base64,"
+                        <> Text.replicate 1_000_000 "x"
+                multimodal = MessageItem ResponseMessage
+                    { messageId = Nothing
+                    , content = MessageContentParts
+                        [ InputTextPart "inspect this" Nothing KeyMap.empty
+                        , InputImagePart
+                            { detail = Just "auto"
+                            , fileId = Nothing
+                            , imageUrl = Just imageUrl
+                            , promptCacheBreakpoint = Nothing
+                            , extraFields = KeyMap.empty
+                            }
+                        ]
+                    , role = RoleUser
+                    , status = Nothing
+                    , phase = Nothing
+                    , extraFields = KeyMap.empty
+                    }
+                compacted =
+                    buildRemoteCompactedHistory 64_000 [multimodal] opaque
+            estimateItemsTokens compacted `shouldSatisfy` (< 1_000)
+            case compacted of
+                MessageItem message : _ ->
+                    case message.content of
+                        MessageContentParts parts -> do
+                            parts `shouldSatisfy`
+                                all (\case InputImagePart {} -> False; _ -> True)
+                            parts `shouldSatisfy`
+                                any (\case
+                                    InputTextPart text _ _ ->
+                                        Text.isInfixOf
+                                            "image attachment omitted"
+                                            text
+                                    _ -> False)
+                        other ->
+                            expectationFailure
+                                ("expected retained content parts, got " <> show other)
+                other ->
+                    expectationFailure
+                        ("expected retained user message, got " <> show other)
+
         it "rewrites a trailing oversized tool output to fit the request window" do
             let oversized = FunctionCallOutputItem FunctionCallOutput
                     { itemId = Nothing
@@ -139,6 +184,41 @@ spec = do
                 other ->
                     expectationFailure
                         ("expected rewritten tool output, got " <> show other)
+
+        it "rewrites image-bearing messages when trimming a compaction request" do
+            let imageUrl =
+                    "data:image/png;base64,"
+                        <> Text.replicate 1_000_000 "x"
+                multimodal = MessageItem ResponseMessage
+                    { messageId = Nothing
+                    , content = MessageContentParts
+                        [ InputTextPart "inspect this" Nothing KeyMap.empty
+                        , InputImagePart
+                            { detail = Just "auto"
+                            , fileId = Nothing
+                            , imageUrl = Just imageUrl
+                            , promptCacheBreakpoint = Nothing
+                            , extraFields = KeyMap.empty
+                            }
+                        ]
+                    , role = RoleUser
+                    , status = Nothing
+                    , phase = Nothing
+                    , extraFields = KeyMap.empty
+                    }
+                trimmed =
+                    trimRemoteCompactionHistoryToFit
+                        1_000
+                        Nothing
+                        [multimodal]
+            estimateItemsTokens trimmed `shouldSatisfy` (< 1_000)
+            trimmed `shouldSatisfy` \case
+                [MessageItem message] ->
+                    case message.content of
+                        MessageContentParts parts ->
+                            all (\case InputImagePart {} -> False; _ -> True) parts
+                        _ -> False
+                _ -> False
 
     describe "Codex model metadata" do
         it "derives the 90% auto-compaction limit for curated 272k models" do


### PR DESCRIPTION
## Summary

- omit inline image payloads from history retained after remote compaction
- rewrite image-bearing messages when a compaction request exceeds the usable context window
- defer automatic compaction until completed tool results have been committed, preserving call/output continuity
- add regression coverage for image retention and tool continuation behavior

## Root cause

Remote compaction retained non-text image parts while its retention budget treated them as zero-cost. Large inline base64 images therefore survived every checkpoint and immediately retriggered compaction. At the same time, compacting directly across a completed tool input absorbed the call result into an opaque checkpoint before the normal continuation was committed, breaking tool context continuity.

## Validation

- `cabal build agent-openai:test:agent-openai-test agent-cli:test:agent-cli-test`
- full `agent-openai` suite: 215 examples, 0 failures, 1 pending
- `autoCompactOpenAiBackendWith` tests: 8 examples, 0 failures
- `git diff --check`