### PR TITLE
Fix bracketed paste in the running-turn composer

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
@@ -18,6 +18,7 @@ module Agent.CLI.TUI.Composer
     , handleEffortControlClick
     , handlePromptControlClick
     , newFullscreenInputBuffer
+    , prepareBracketedPaste
     , promoteFullscreenInput
     , queuedFullscreenInputDisplays
     , readFullscreenInputs
@@ -470,6 +471,36 @@ activateSlashAt
                     (V.EvKey V.KEnter [])
         _ -> pure ()
 
+-- | An idle composer can hand bracketed paste classification to the main REPL,
+-- which is already waiting for input. During a running turn that consumer is
+-- blocked, so insert terminal text locally rather than leaving the draft behind
+-- a persistent "Reading clipboard…" notice.
+prepareBracketedPaste
+    :: Bool
+    -> Text
+    -> Int
+    -> Text
+    -> (Text, Int, Maybe ReplLine)
+prepareBracketedPaste awaitingInput draft cursor pasted =
+    let boundedCursor = max 0 (min (Text.length draft) cursor)
+        before = Text.take boundedCursor draft
+        after = Text.drop boundedCursor draft
+        pastedDraft = before <> pasted <> after
+        pastedCursor = boundedCursor + Text.length pasted
+    in if Text.null pasted
+        then
+            ( draft
+            , boundedCursor
+            , Just (ReplClipboardPaste draft Nothing)
+            )
+        else if awaitingInput
+        then
+            ( draft
+            , boundedCursor
+            , Just (ReplClipboardPasteOrText draft pasted pastedDraft)
+            )
+        else (pastedDraft, pastedCursor, Nothing)
+
 -- | Handle one composer key. The host supplies Ctrl-C policy and conversation
 -- page scrolling because those actions also affect non-composer UI state.
 handleComposerKey
@@ -604,20 +635,23 @@ handleComposerKey
             insertText (Text.singleton character)
         V.EvPaste bytes -> do
             let pasted = decodePaste bytes
-                before = Text.take ui.uiCursor ui.uiDraft
-                after = Text.drop ui.uiCursor ui.uiDraft
-                pastedDraft = before <> pasted <> after
-            if Text.null pasted
-                then submitRaw (ReplClipboardPaste ui.uiDraft Nothing)
-                else do
-                    modifyUi
-                        (UiSetNotice
-                            (Just (progressNotice "Reading clipboard…")))
-                    submitRaw
-                        (ReplClipboardPasteOrText
-                            ui.uiDraft
-                            pasted
-                            pastedDraft)
+                (pastedDraft, pastedCursor, clipboardInput) =
+                    prepareBracketedPaste
+                        ui.uiAwaitingInput
+                        ui.uiDraft
+                        ui.uiCursor
+                        pasted
+            case clipboardInput of
+                Nothing -> do
+                    modifyUiResetSlash
+                        (UiSetDraft pastedDraft pastedCursor)
+                    modify' \current -> current { appPasted = True }
+                Just replLine -> do
+                    when (not (Text.null pasted)) $
+                        modifyUi
+                            (UiSetNotice
+                                (Just (progressNotice "Reading clipboard…")))
+                    submitRaw replLine
         _ -> pure ()
   where
     submitRaw replLine = do

--- a/packages/agent-cli/test/Agent/CLI/TUIComposerSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIComposerSpec.hs
@@ -51,6 +51,30 @@ spec = describe "fullscreen composer" do
         decodePaste (ByteString.pack [97, 0, 10, 9, 27, 98])
             `shouldBe` "a\n\tb"
 
+    it "inserts bracketed paste immediately while a turn is running" do
+        prepareBracketedPaste False "next message" 4 " pasted"
+            `shouldBe` ("next pasted message", 11, Nothing)
+
+    it "defers clipboard classification only while the REPL is awaiting input" do
+        prepareBracketedPaste True "next message" 4 " pasted"
+            `shouldBe`
+                ( "next message"
+                , 4
+                , Just
+                    (ReplClipboardPasteOrText
+                        "next message"
+                        " pasted"
+                        "next pasted message")
+                )
+
+    it "keeps empty paste events available for native clipboard images" do
+        prepareBracketedPaste False "next message" 4 ""
+            `shouldBe`
+                ( "next message"
+                , 4
+                , Just (ReplClipboardPaste "next message" Nothing)
+                )
+
     it "keeps clipboard preludes immediately before promoted input" do
         buffer <- newFullscreenInputBuffer
         atomically do


### PR DESCRIPTION
## Summary

- keep bracketed text paste responsive in the fullscreen next-message composer while a turn is running
- only delegate clipboard/image classification when the main REPL is actually awaiting input
- add regression coverage for running-turn and idle paste behavior

## Root cause

The fullscreen UI queued `ReplClipboardPasteOrText` while an active turn occupied the main REPL. The UI immediately showed `Reading clipboard…`, but the queued action could not be consumed until the turn ended, leaving the draft and notice stuck.

## Verification

- `nix develop -c cabal test agent-cli:test:agent-cli-test --test-show-details=direct` (803 examples, 0 failures)
- `git diff --check`
- tmux/Vty smoke test during an active GHCi tool call: bracketed paste immediately rendered as `draft PASTED`, without a clipboard notice or interruption
