### PR TITLE
Make Bash the default execution mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,17 +76,17 @@ Start an interactive session:
 agent-cli
 ```
 
-`run_ghci` is the primary execution and scripting tool and is enabled by
-default. Enable the provider's explicit shell tool when needed:
+The provider's Bash/shell execution tool is enabled by default. Enable the
+persistent `run_ghci` tool when needed:
 
 ```console
-agent-cli --bash
+agent-cli --ghci
 ```
 
-For bash-only operation, disable GHCi explicitly:
+For GHCi-only operation, disable Bash explicitly:
 
 ```console
-agent-cli --no-ghci --bash
+agent-cli --ghci --no-bash
 ```
 
 During an interactive session, switch the available shell tools without

--- a/docs/evals/ghci-vs-bash.md
+++ b/docs/evals/ghci-vs-bash.md
@@ -2,10 +2,12 @@
 
 This behavioral eval compares three user-facing configurations:
 
-- **ghci-only**: the default, with `run_ghci` and no explicit shell tool.
-- **bash-only**: the provider shell tool with `run_ghci` disabled.
-- **ghci-plus-bash**: `--bash`, which adds the provider shell tool while
-  retaining `run_ghci`.
+- **ghci-only**: `--ghci --no-bash`, with `run_ghci` and no explicit shell
+  tool.
+- **bash-only**: the default, with the provider shell tool and `run_ghci`
+  disabled.
+- **ghci-plus-bash**: `--ghci`, which adds `run_ghci` while retaining the
+  provider shell tool.
 
 It uses the same user task prompt in all variants. The complete product
 configurations necessarily differ because their tool schemas and matching

--- a/packages/agent-cli/src/Agent/CLI/Options.hs
+++ b/packages/agent-cli/src/Agent/CLI/Options.hs
@@ -88,9 +88,9 @@ data CliOptions = CliOptions
     , optSkills :: !Bool
       -- ^ Discover and expose filesystem skills (default: True).
     , optGhci :: !Bool
-      -- ^ Expose the persistent run_ghci tool (default: True).
+      -- ^ Expose the persistent run_ghci tool (default: False).
     , optBash :: !Bool
-      -- ^ Expose the provider's explicit shell execution tool (default: False).
+      -- ^ Expose the provider's explicit shell execution tool (default: True).
     , optScreenMode :: !ScreenMode
     , optMotionMode :: !MotionMode
     } deriving (Eq, Show)
@@ -112,8 +112,8 @@ defaultCliOptions = CliOptions
     , optSaveSession = False
     , optAgentsMd = True
     , optSkills = True
-    , optGhci = True
-    , optBash = False
+    , optGhci = False
+    , optBash = True
     , optScreenMode = ScreenAuto
     , optMotionMode = MotionFull
     }
@@ -292,10 +292,10 @@ usage = unlines
     , "      --no-agents-md      Skip AGENTS.md discovery"
     , "      --skills            Discover Agent Skills (default)"
     , "      --no-skills         Disable skill discovery and invocation"
-    , "      --ghci              Enable the persistent GHCi tool (default)"
-    , "      --no-ghci           Disable the persistent GHCi tool"
-    , "      --bash              Enable explicit shell execution tools"
-    , "      --no-bash           Disable explicit shell execution tools (default)"
+    , "      --ghci              Enable the persistent GHCi tool"
+    , "      --no-ghci           Disable the persistent GHCi tool (default)"
+    , "      --bash              Enable explicit shell execution tools (default)"
+    , "      --no-bash           Disable explicit shell execution tools"
     , "      --fullscreen        Use the retained full-screen TUI"
     , "      --minimal           Use terminal-native append-only rendering"
     , "      --motion MODE       Animation policy: full, reduced, or off"

--- a/packages/agent-cli/test/Agent/CLI/OptionsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/OptionsSpec.hs
@@ -162,21 +162,23 @@ spec = do
                     , optSkills = True
                     })
 
-        it "keeps bash disabled by default and enables it explicitly" do
+        it "keeps bash enabled by default and disables it explicitly" do
             parseArgs []
                 `shouldBe` Right (RunAgent defaultCliOptions)
-            parseArgs ["--bash"]
-                `shouldBe` Right (RunAgent defaultCliOptions { optBash = True })
-            parseArgs ["--bash", "--no-bash"]
+            defaultCliOptions.optBash `shouldBe` True
+            parseArgs ["--no-bash"]
                 `shouldBe` Right (RunAgent defaultCliOptions { optBash = False })
+            parseArgs ["--no-bash", "--bash"]
+                `shouldBe` Right (RunAgent defaultCliOptions { optBash = True })
 
-        it "keeps ghci enabled by default and disables it explicitly" do
+        it "keeps ghci disabled by default and enables it explicitly" do
             parseArgs []
                 `shouldBe` Right (RunAgent defaultCliOptions)
-            parseArgs ["--no-ghci"]
-                `shouldBe` Right (RunAgent defaultCliOptions { optGhci = False })
-            parseArgs ["--no-ghci", "--ghci"]
+            defaultCliOptions.optGhci `shouldBe` False
+            parseArgs ["--ghci"]
                 `shouldBe` Right (RunAgent defaultCliOptions { optGhci = True })
+            parseArgs ["--ghci", "--no-ghci"]
+                `shouldBe` Right (RunAgent defaultCliOptions { optGhci = False })
 
     describe "resolveApprovalPolicy" do
         it "auto-approves one-shot scripts without a TTY" do


### PR DESCRIPTION
## Summary
- enable the provider Bash/shell tool by default
- make the persistent GHCi tool opt-in with `--ghci`
- update CLI help, tests, README, and eval documentation

## Testing
- `nix develop -c cabal test agent-cli:test:agent-cli-test --test-show-details=direct` (839 examples, 0 failures)
- `git diff --check`