### PR TITLE
Avoid duplicate images from repeated paste

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -82,7 +82,8 @@ import Agent.CLI.Btw
     )
 import Agent.CLI.CancelWatch (withEscCancel, withStdinPaused)
 import Agent.CLI.Clipboard
-    ( formatImageSize
+    ( appendUniqueImageAttachments
+    , formatImageSize
     , loadImagesFromPastedText
     , nonEmptyClipboardImages
     , readClipboardImagesForPaste
@@ -6654,20 +6655,40 @@ queueAttachedImages
     -> [ImageAttachment]
     -> IO Text
 queueAttachedImages attachmentsRef previewIdRef color showPreview images = do
-    modifyIORef' attachmentsRef (<> images)
-    pending <- readIORef attachmentsRef
+    (added, pendingCount) <- atomicModifyIORef' attachmentsRef \existing ->
+        let (pending, unique) =
+                appendUniqueImageAttachments existing images
+        in (pending, (unique, length pending))
     let sizes =
             Text.intercalate ", "
                 [ img.imageMime <> " (" <> formatImageSize (BS.length img.imageBytes) <> ")"
-                | img <- images
+                | img <- added
                 ]
-    when showPreview (putImagePreview previewIdRef color images)
-    pure $
-        "attached "
-            <> sizes
-            <> " — send with next message ("
-            <> Text.pack (show (length pending))
-            <> " queued)"
+        duplicateCount = length images - length added
+        queued = Text.pack (show pendingCount)
+    when (showPreview && not (null added)) $
+        putImagePreview previewIdRef color added
+    pure $ case (added, duplicateCount) of
+        ([], _) ->
+            "image already attached — not added again ("
+                <> queued
+                <> " queued)"
+        (_, 0) ->
+            "attached "
+                <> sizes
+                <> " — send with next message ("
+                <> queued
+                <> " queued)"
+        _ ->
+            "attached "
+                <> sizes
+                <> "; skipped "
+                <> Text.pack (show duplicateCount)
+                <> " duplicate image"
+                <> (if duplicateCount == 1 then "" else "s")
+                <> " ("
+                <> queued
+                <> " queued)"
 
 queueClipboardImages
     :: IORef [ImageAttachment]

--- a/packages/agent-cli/src/Agent/CLI/Clipboard.hs
+++ b/packages/agent-cli/src/Agent/CLI/Clipboard.hs
@@ -9,6 +9,7 @@ module Agent.CLI.Clipboard
     , readClipboardText
     , nonEmptyClipboardImages
     , nonEmptyClipboardText
+    , appendUniqueImageAttachments
     , loadImagesFromPastedText
     , formatImageSize
     ) where
@@ -20,6 +21,7 @@ import Control.Monad (filterM)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import Data.Char (toLower)
+import Data.List (foldl')
 import Data.Text (Text)
 import qualified Data.Text as Text
 import System.Directory
@@ -155,6 +157,21 @@ nonEmptyClipboardText :: Either Text Text -> Maybe Text
 nonEmptyClipboardText = \case
     Right text | not (Text.null text) -> Just text
     _ -> Nothing
+
+-- | Append only images whose bytes are not already attached. Comparing the
+-- payload rather than the MIME label also suppresses a repeated paste if the
+-- same clipboard bytes are reported with different metadata.
+appendUniqueImageAttachments
+    :: [ImageAttachment]
+    -> [ImageAttachment]
+    -> ([ImageAttachment], [ImageAttachment])
+appendUniqueImageAttachments existing incoming =
+    foldl' appendOne (existing, []) incoming
+  where
+    appendOne (allImages, added) image
+        | any (sameImage image) allImages = (allImages, added)
+        | otherwise = (allImages <> [image], added <> [image])
+    sameImage left right = left.imageBytes == right.imageBytes
 
 formatImageSize :: Int -> Text
 formatImageSize n

--- a/packages/agent-cli/test/Agent/CLI/ClipboardSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ClipboardSpec.hs
@@ -55,6 +55,23 @@ spec = do
             nonEmptyClipboardText (Right "") `shouldBe` Nothing
             nonEmptyClipboardText (Left "not text") `shouldBe` Nothing
 
+    describe "appendUniqueImageAttachments" do
+        let first = ImageAttachment "image/png" "same-image-bytes"
+            relabeled = ImageAttachment "image/jpeg" "same-image-bytes"
+            second = ImageAttachment "image/png" "other-image-bytes"
+
+        it "does not append an image already attached to the message" do
+            appendUniqueImageAttachments [first] [first]
+                `shouldBe` ([first], [])
+
+        it "compares bytes even if clipboard MIME metadata changes" do
+            appendUniqueImageAttachments [first] [relabeled]
+                `shouldBe` ([first], [])
+
+        it "deduplicates within one paste while preserving new image order" do
+            appendUniqueImageAttachments [] [first, first, second]
+                `shouldBe` ([first, second], [first, second])
+
     describe "loadImagesFromPastedText" do
         it "returns Nothing for ordinary prompt text" do
             result <- loadImagesFromPastedText "fix the bug in Main.hs"


### PR DESCRIPTION
## Summary
- suppress byte-identical images already attached to the current message
- deduplicate repeated images within the same multi-image paste
- avoid rendering another preview and show a clear duplicate notice

## Testing
- `nix develop -c cabal test agent-cli:test:agent-cli-test --test-options=--match appendUniqueImageAttachments --test-show-details=direct`
- `git diff --check`
- live composer startup/rendering smoke-tested in tmux