### PR TITLE
Fix Telegram reply splitting at rendered limit

### DIFF
--- a/packages/agent-cli/src/Agent/Telegram.hs
+++ b/packages/agent-cli/src/Agent/Telegram.hs
@@ -60,7 +60,10 @@ import Agent.CLI.Session
     , sessionsRoot
     )
 import Agent.Telegram.Types
-import Agent.Telegram.Markdown (markdownToTelegramHtml)
+import Agent.Telegram.Markdown
+    ( markdownToTelegramHtml
+    , telegramRenderedLength
+    )
 import Agent.Telegram.Voice (transcribeWithCodex)
 import Agent.FileRetry (writeLazyFileAtomically)
 import Agent.OsPath (unsafeToFilePath)
@@ -172,9 +175,22 @@ splitTelegramText :: Int -> Text -> [Text]
 splitTelegramText limit text
     | limit < 1 = []
     | Text.null text = []
+    | telegramRenderedLength text <= limit = [text]
     | otherwise =
-        let (chunk, rest) = Text.splitAt limit text
+        let (chunk, rest) = Text.splitAt (largestFittingPrefix text) text
         in chunk : splitTelegramText limit rest
+  where
+    largestFittingPrefix value = search 1 (Text.length value)
+      where
+        search low high
+            | low >= high = low
+            | renderedLength midpoint <= limit = search midpoint high
+            | otherwise = search low (midpoint - 1)
+          where
+            midpoint = low + (high - low + 1) `div` 2
+
+        renderedLength =
+            telegramRenderedLength . (`Text.take` value)
 
 telegramMain :: IO ()
 telegramMain =
@@ -1153,10 +1169,8 @@ reply runtime pending
         sendTextReply
   where
     sendTextReply = do
-        -- Rich HTML entities can expand one source character to six bytes.
-        -- Keep source chunks conservative so the rendered message stays below
-        -- Telegram's 4096-character limit without splitting generated tags.
-        let chunks = case splitTelegramText 600 pending.pendingText of
+        -- Telegram accepts messages up to 4096 rendered characters.
+        let chunks = case splitTelegramText 4096 pending.pendingText of
                 [] -> ["(empty response)"]
                 values -> values
         forM_ (zip [0 :: Int ..] chunks) \(index, chunk) ->

--- a/packages/agent-cli/src/Agent/Telegram/Markdown.hs
+++ b/packages/agent-cli/src/Agent/Telegram/Markdown.hs
@@ -1,6 +1,7 @@
 -- | Markdown subset conversion for Telegram HTML messages.
 module Agent.Telegram.Markdown
     ( markdownToTelegramHtml
+    , telegramRenderedLength
     , escapeTelegramHtml
     ) where
 
@@ -30,6 +31,26 @@ markdownToTelegramHtml input =
             || ('A' <= char && char <= 'Z')
             || ('0' <= char && char <= '9')
             || char `elem` ("-+#_" :: String)
+
+telegramRenderedLength :: Text -> Int
+telegramRenderedLength = go 0 . markdownToTelegramHtml
+  where
+    go count html
+        | Text.null html = count
+        | Just rest <- Text.stripPrefix "<br>" html =
+            go (count + 1) rest
+        | Just rest <- Text.stripPrefix "<" html =
+            case Text.breakOn ">" rest of
+                (_, afterTag)
+                    | Text.null afterTag -> go (count + 1) rest
+                    | otherwise -> go count (Text.drop 1 afterTag)
+        | Just rest <- Text.stripPrefix "&" html =
+            case Text.breakOn ";" rest of
+                (_, afterEntity)
+                    | Text.null afterEntity -> go (count + 1) rest
+                    | otherwise -> go (count + 1) (Text.drop 1 afterEntity)
+        | otherwise =
+            go (count + 1) (Text.drop 1 html)
 
 renderInline :: Text -> Text
 renderInline text

--- a/packages/agent-cli/test/Agent/TelegramSpec.hs
+++ b/packages/agent-cli/test/Agent/TelegramSpec.hs
@@ -12,6 +12,7 @@ import qualified Data.ByteString.Lazy.Char8 as LBS
 import Data.IORef (modifyIORef', newIORef, readIORef)
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
+import qualified Data.Text as Text
 import Agent.Provider (Provider(..))
 import qualified System.Timeout as Timeout
 import Test.Hspec
@@ -63,6 +64,27 @@ spec = describe "Agent.Telegram" do
         it "keeps messages within the requested limit" do
             splitTelegramText 4 "abcdefghij"
                 `shouldBe` ["abcd", "efgh", "ij"]
+
+        it "does not split a message at the rendered limit" do
+            splitTelegramText 4096 (Text.replicate 4096 "a")
+                `shouldBe` [Text.replicate 4096 "a"]
+
+        it "does not count HTML escaping toward the rendered limit" do
+            splitTelegramText 4096 (Text.replicate 4096 "<")
+                `shouldBe` [Text.replicate 4096 "<"]
+
+        it "splits only when escaped text exceeds the rendered limit" do
+            splitTelegramText 4096 (Text.replicate 4097 "<")
+                `shouldBe`
+                    [ Text.replicate 4096 "<"
+                    , "<"
+                    ]
+
+        it "does not count link markup toward the rendered limit" do
+            let link = "[site](https://example.com/"
+                    <> Text.replicate 4096 "a"
+                    <> ")"
+            splitTelegramText 4 link `shouldBe` [link]
 
         it "does not emit an empty message" do
             splitTelegramText 4 "" `shouldBe` []


### PR DESCRIPTION
## Summary
- stop splitting Telegram replies into fixed 600-character messages
- split only when rendered content exceeds Telegram's 4096-character limit
- exclude HTML escaping and Markdown/link markup from the visible character count

## Tests
- `nix develop -c cabal test agent-cli-test -v0 --test-options=--match Agent.Telegram --test-show-details=direct`
- 34 examples, 0 failures