### PR TITLE
refactor(openai): share Codex JSON POST transport

### DIFF
--- a/packages/agent-openai/src/Agent/OpenAI/Client.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Client.hs
@@ -19,7 +19,7 @@ import Agent.OpenAI.Features
     ( betaFeaturesHeaderValue
     , remoteCompactionV2Feature
     )
-import Agent.OpenAI.Http (decodeCodexHttpBody)
+import Agent.OpenAI.Http (decodeCodexHttpBody, postCodexJson)
 import Agent.OpenAI.Request (sanitizeCodexRequest)
 import Agent.Provider
     ( Credential(..)
@@ -29,7 +29,7 @@ import Agent.Provider
     )
 import Agent.Retry (handleSyncExceptions)
 import qualified Agent.Responses.Types as OpenAI
-import Control.Monad (forM_, when)
+import Control.Monad (forM_)
 import Control.Retry
     ( RetryPolicyM
     , exponentialBackoff
@@ -42,11 +42,9 @@ import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import qualified Data.Text.Encoding.Error as Text (lenientDecode)
-import qualified Network.URI as URI
-
-import OpenSSL
 import qualified System.IO.Streams as Streams
-import Network.Http.Client
+import Network.Http.Client (Response, getStatusCode)
+import qualified Network.Http.Client
 
 -- | ChatGPT Codex REST prefix. 'createCodexMessage' and
 -- 'createCodexMessageWithProvider' POST to @{defaultCodexBaseUrl}/responses@.
@@ -189,28 +187,20 @@ makeCodexRequest options baseUrl accessToken accountId request = do
     -- this field, so enforce it at the HTTP transport boundary.
     let requestBody = Aeson.toJSON
             (sanitizeCodexRequest request) { OpenAI.stream = Just True }
-        url = Text.dropWhileEnd (== '/') baseUrl <> "/responses"
-
-    case URI.parseURI (Text.unpack url) of
-        Nothing -> pure $ Left (JsonDecodeError ("Invalid URL: " <> url) "")
-        Just uri -> do
-            let path = Text.encodeUtf8 (Text.pack uri.uriPath)
-            withOpenSSL $
-                withConnection (establishConnection (Text.encodeUtf8 url)) $ \conn -> do
-                    let req = buildRequest1 $ do
-                                http POST path
-                                setContentType "application/json"
-                                Network.Http.Client.setHeader "Authorization" ("Bearer " <> Text.encodeUtf8 accessToken)
-                                -- ChatGPT's Codex backend requires this header.
-                                -- OpenAI-compatible proxies (llm-router) do not.
-                                when (not (Text.null (Text.strip accountId))) $
-                                    Network.Http.Client.setHeader "chatgpt-account-id" (Text.encodeUtf8 accountId)
-                                forM_ (betaFeaturesHeaderValue options.betaFeatures) \features ->
-                                    Network.Http.Client.setHeader
-                                        "x-codex-beta-features"
-                                        (Text.encodeUtf8 features)
-                    sendRequest conn req (jsonBody requestBody)
-                    receiveResponse conn responseHandler
+    postCodexJson
+        baseUrl
+        "/responses"
+        accessToken
+        accountId
+        addBetaFeaturesHeader
+        requestBody
+        responseHandler
+  where
+    addBetaFeaturesHeader req =
+        req *> forM_ (betaFeaturesHeaderValue options.betaFeatures) \features ->
+            Network.Http.Client.setHeader
+                "x-codex-beta-features"
+                (Text.encodeUtf8 features)
 
 responseHandler :: Response -> Streams.InputStream BS.ByteString -> IO (Either ApiError OpenAI.Response)
 responseHandler response stream = do

--- a/packages/agent-openai/src/Agent/OpenAI/CompactClient.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/CompactClient.hs
@@ -8,6 +8,7 @@ module Agent.OpenAI.CompactClient
 import Agent.Error (ApiError(..), ErrorType(..))
 import Agent.OpenAI.Client (defaultCodexBaseUrl)
 import Agent.OpenAI.Error (classifyHttpFailure)
+import Agent.OpenAI.Http (postCodexJson)
 import Agent.Responses.Types hiding (Response)
 import Agent.Provider
     ( Credential(..)
@@ -16,7 +17,6 @@ import Agent.Provider
     , runWithTokenProvider
     )
 import Control.Exception.Safe (tryAny)
-import Control.Monad (when)
 import Data.Aeson ((.=))
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.KeyMap as KeyMap
@@ -26,23 +26,8 @@ import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import qualified Data.Text.Encoding.Error as Text (lenientDecode)
-import Network.Http.Client
-    ( Method(POST)
-    , Response
-    , buildRequest1
-    , establishConnection
-    , getStatusCode
-    , http
-    , jsonBody
-    , receiveResponse
-    , sendRequest
-    , setContentType
-    , setHeader
-    , withConnection
-    )
-import OpenSSL (withOpenSSL)
+import Network.Http.Client (Response, getStatusCode)
 import qualified System.IO.Streams as Streams
-import qualified Network.URI as URI
 
 -- | Body for Codex @/responses/compact@ (subset of CompactionInput).
 data CompactRequest = CompactRequest
@@ -98,24 +83,14 @@ postCompact baseUrl credential request =
         Right result -> pure result
   where
     perform = do
-        let url = Text.dropWhileEnd (== '/') baseUrl <> "/responses/compact"
-            body = Aeson.toJSON request
-        case URI.parseURI (Text.unpack url) of
-            Nothing -> pure $ Left (JsonDecodeError ("Invalid URL: " <> url) "")
-            Just uri ->
-                withOpenSSL $
-                    withConnection (establishConnection (Text.encodeUtf8 url)) $ \conn -> do
-                        let path = Text.encodeUtf8 (Text.pack uri.uriPath)
-                            req = buildRequest1 $ do
-                                http POST path
-                                setContentType "application/json"
-                                setHeader "Authorization"
-                                    ("Bearer " <> Text.encodeUtf8 credential.accessToken)
-                                when (not (Text.null (Text.strip credential.accountId))) $
-                                    setHeader "chatgpt-account-id"
-                                        (Text.encodeUtf8 credential.accountId)
-                        sendRequest conn req (jsonBody body)
-                        receiveResponse conn compactResponseHandler
+        postCodexJson
+            baseUrl
+            "/responses/compact"
+            credential.accessToken
+            credential.accountId
+            id
+            (Aeson.toJSON request)
+            compactResponseHandler
 
 compactResponseHandler
     :: Response

--- a/packages/agent-openai/src/Agent/OpenAI/Http.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Http.hs
@@ -1,5 +1,6 @@
 module Agent.OpenAI.Http
-    ( decodeCodexHttpBody
+    ( postCodexJson
+    , decodeCodexHttpBody
     , rejectFailedCodexResponse
     ) where
 
@@ -16,9 +17,64 @@ import qualified Agent.Responses.Types as OpenAI
 import Control.Applicative ((<|>))
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString as BS
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
+import Network.Http.Client
+    ( Method(POST)
+    , RequestBuilder
+    , Response
+    , buildRequest1
+    , establishConnection
+    , http
+    , jsonBody
+    , receiveResponse
+    , sendRequest
+    , setContentType
+    , setHeader
+    , withConnection
+    )
+import OpenSSL (withOpenSSL)
+import qualified Network.URI as URI
+import qualified System.IO.Streams as Streams
+
+-- | Execute a JSON POST against a Codex-compatible endpoint.
+--
+-- Authentication and the optional broker account header are shared by the
+-- normal Responses and compaction endpoints. Callers can add endpoint-specific
+-- headers with the request modifier and retain control over response decoding
+-- through the supplied handler.
+postCodexJson
+    :: Text
+    -> Text
+    -> Text
+    -> Text
+    -> (RequestBuilder () -> RequestBuilder ())
+    -> Aeson.Value
+    -> (Response -> Streams.InputStream BS.ByteString -> IO (Either ApiError value))
+    -> IO (Either ApiError value)
+postCodexJson baseUrl endpoint accessToken accountId configureRequest body handler = do
+    let url = Text.dropWhileEnd (== '/') baseUrl <> endpoint
+    case URI.parseURI (Text.unpack url) of
+        Nothing -> pure $ Left (JsonDecodeError ("Invalid URL: " <> url) "")
+        Just uri ->
+            let path = Text.encodeUtf8 (Text.pack uri.uriPath)
+                request = buildRequest1 $ configureRequest do
+                    http POST path
+                    setContentType "application/json"
+                    setHeader
+                        "Authorization"
+                        ("Bearer " <> Text.encodeUtf8 accessToken)
+                    if Text.null (Text.strip accountId)
+                        then pure ()
+                        else setHeader
+                            "chatgpt-account-id"
+                            (Text.encodeUtf8 accountId)
+            in withOpenSSL $
+                withConnection (establishConnection (Text.encodeUtf8 url)) \connection -> do
+                    sendRequest connection request (jsonBody body)
+                    receiveResponse connection handler
 
 -- | Decode a successful Responses HTTP body. Streaming bodies use the same
 -- partial-response assembler as the WebSocket and provider SSE transports;


### PR DESCRIPTION
## Summary
- extract common Codex-compatible JSON POST setup into `Agent.OpenAI.Http.postCodexJson`
- share URL parsing, TLS connection setup, bearer/account headers, request sending, and response dispatch
- keep endpoint-specific beta headers and response decoders in the regular and compaction clients

## Validation
- `nix develop -c cabal repl agent-openai:lib:agent-openai`
- `nix develop -c cabal test agent-openai:agent-openai-test`
- 213 examples passed; 1 live test pending

The broader xAI/OpenRouter Responses-client abstraction was deliberately left out to keep retry and callback replay semantics explicit.