### PR TITLE
refactor(core): share message targets and task validation

### DIFF
--- a/packages/agent-core/src/Agent/Tools/MultiAgents.hs
+++ b/packages/agent-core/src/Agent/Tools/MultiAgents.hs
@@ -352,26 +352,16 @@ runSendMessage :: MultiAgentContext -> ToolCall -> MessageArgs -> IO (Either Tex
 runSendMessage ctx call args
     | Text.null (Text.strip args.message) =
         pure (Left "send_message requires a non-empty message")
-    | otherwise = do
-        case resolveTaskPath ctx.multiTaskPath args.target of
-            Right targetPath | targetPath == taskPathRoot ->
-                sendToRoot ctx (messageContent call args.message)
-            _ -> do
-                restored <- maybeRestore ctx args.target
-                case restored of
-                    Left err -> pure (Left err)
-                    Right () -> do
-                        resolved <-
-                            resolveAgentTarget
-                                ctx.multiRegistry ctx.multiTaskPath args.target
-                        case resolved of
-                            Left err -> pure (Left err)
-                            Right agentId -> do
-                                rootTurnId <- ctx.multiRootTurnId
-                                queueMessageFromForTurn
-                                    ctx.multiRegistry rootTurnId
-                                    ctx.multiTaskPath agentId
-                                    (messageContent call args.message)
+    | otherwise =
+        withMessageTarget ctx args.target \target ->
+            case target of
+                RootMessageTarget ->
+                    sendToRoot ctx (messageContent call args.message)
+                AgentMessageTarget agentId rootTurnId ->
+                    queueMessageFromForTurn
+                        ctx.multiRegistry rootTurnId
+                        ctx.multiTaskPath agentId
+                        (messageContent call args.message)
 
 followupTaskTool :: MultiAgentContext -> AppTool
 followupTaskTool ctx = jsonTool "followup_task" followupDescription
@@ -394,26 +384,43 @@ runFollowup :: MultiAgentContext -> ToolCall -> MessageArgs -> IO (Either Text T
 runFollowup ctx call args
     | Text.null (Text.strip args.message) =
         pure (Left "followup_task requires a non-empty message")
-    | otherwise = do
-        case resolveTaskPath ctx.multiTaskPath args.target of
-            Right targetPath | targetPath == taskPathRoot ->
-                pure (Left "followup_task cannot target the root agent; use send_message")
-            _ -> do
-                restored <- maybeRestore ctx args.target
-                case restored of
-                    Left err -> pure (Left err)
-                    Right () -> do
-                        resolved <-
-                            resolveAgentTarget
-                                ctx.multiRegistry ctx.multiTaskPath args.target
-                        case resolved of
-                            Left err -> pure (Left err)
-                            Right agentId -> do
-                                rootTurnId <- ctx.multiRootTurnId
-                                sendInputMessageForTurn
-                                    ctx.multiRegistry rootTurnId
-                                    ctx.multiTaskPath agentId
-                                    (messageContent call args.message) False
+    | otherwise =
+        withMessageTarget ctx args.target \target ->
+            case target of
+                RootMessageTarget ->
+                    pure (Left "followup_task cannot target the root agent; use send_message")
+                AgentMessageTarget agentId rootTurnId ->
+                    sendInputMessageForTurn
+                        ctx.multiRegistry rootTurnId
+                        ctx.multiTaskPath agentId
+                        (messageContent call args.message) False
+
+data MessageTarget
+    = RootMessageTarget
+    | AgentMessageTarget SubagentId (Maybe RootTurnId)
+
+withMessageTarget
+    :: MultiAgentContext
+    -> Text
+    -> (MessageTarget -> IO (Either Text Text))
+    -> IO (Either Text Text)
+withMessageTarget ctx target action =
+    case resolveTaskPath ctx.multiTaskPath target of
+        Right targetPath | targetPath == taskPathRoot ->
+            action RootMessageTarget
+        _ -> do
+            restored <- maybeRestore ctx target
+            case restored of
+                Left err -> pure (Left err)
+                Right () -> do
+                    resolved <-
+                        resolveAgentTarget
+                            ctx.multiRegistry ctx.multiTaskPath target
+                    case resolved of
+                        Left err -> pure (Left err)
+                        Right agentId -> do
+                            rootTurnId <- ctx.multiRootTurnId
+                            action (AgentMessageTarget agentId rootTurnId)
 
 sendToRoot :: MultiAgentContext -> InterAgentMessageContent -> IO (Either Text Text)
 sendToRoot ctx content =

--- a/packages/agent-core/src/Agent/Tools/MultiAgents.hs
+++ b/packages/agent-core/src/Agent/Tools/MultiAgents.hs
@@ -350,18 +350,18 @@ sendMessageDescription =
 
 runSendMessage :: MultiAgentContext -> ToolCall -> MessageArgs -> IO (Either Text Text)
 runSendMessage ctx call args
-    | Text.null (Text.strip args.message) =
-        pure (Left "send_message requires a non-empty message")
-    | otherwise =
-        withMessageTarget ctx args.target \target ->
-            case target of
-                RootMessageTarget ->
-                    sendToRoot ctx (messageContent call args.message)
-                AgentMessageTarget agentId rootTurnId ->
-                    queueMessageFromForTurn
-                        ctx.multiRegistry rootTurnId
-                        ctx.multiTaskPath agentId
-                        (messageContent call args.message)
+    = case validateMessage "send_message" args.message of
+        Left err -> pure (Left err)
+        Right () ->
+            withMessageTarget ctx args.target \target ->
+                case target of
+                    RootMessageTarget ->
+                        sendToRoot ctx (messageContent call args.message)
+                    AgentMessageTarget agentId rootTurnId ->
+                        queueMessageFromForTurn
+                            ctx.multiRegistry rootTurnId
+                            ctx.multiTaskPath agentId
+                            (messageContent call args.message)
 
 followupTaskTool :: MultiAgentContext -> AppTool
 followupTaskTool ctx = jsonTool "followup_task" followupDescription
@@ -382,18 +382,24 @@ followupDescription =
 
 runFollowup :: MultiAgentContext -> ToolCall -> MessageArgs -> IO (Either Text Text)
 runFollowup ctx call args
-    | Text.null (Text.strip args.message) =
-        pure (Left "followup_task requires a non-empty message")
-    | otherwise =
-        withMessageTarget ctx args.target \target ->
-            case target of
-                RootMessageTarget ->
-                    pure (Left "followup_task cannot target the root agent; use send_message")
-                AgentMessageTarget agentId rootTurnId ->
-                    sendInputMessageForTurn
-                        ctx.multiRegistry rootTurnId
-                        ctx.multiTaskPath agentId
-                        (messageContent call args.message) False
+    = case validateMessage "followup_task" args.message of
+        Left err -> pure (Left err)
+        Right () ->
+            withMessageTarget ctx args.target \target ->
+                case target of
+                    RootMessageTarget ->
+                        pure (Left "followup_task cannot target the root agent; use send_message")
+                    AgentMessageTarget agentId rootTurnId ->
+                        sendInputMessageForTurn
+                            ctx.multiRegistry rootTurnId
+                            ctx.multiTaskPath agentId
+                            (messageContent call args.message) False
+
+validateMessage :: Text -> Text -> Either Text ()
+validateMessage toolName message
+    | Text.null (Text.strip message) =
+        Left (toolName <> " requires a non-empty message")
+    | otherwise = Right ()
 
 data MessageTarget
     = RootMessageTarget

--- a/packages/agent-core/test/Agent/Tools/MultiAgentsSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/MultiAgentsSpec.hs
@@ -264,6 +264,29 @@ spec = describe "Agent.Tools.MultiAgents" do
         result.output `shouldSatisfy` Text.isInfixOf "restore failed"
         closeSubagentRegistry registry
 
+    it "rejects blank send and follow-up messages before resolving targets" do
+        registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
+            (\_ _ _ _ -> pure $ Left LoopNoResponseId)
+            (\_ _ -> pure ())
+        let handlers = appToolHandlers
+                (multiAgentTools (rootContext registry Nothing))
+            blankCall name = ToolCall
+                { callId = "blank-" <> name
+                , name = "collaboration." <> name
+                , arguments = "{\"target\":\"/root\",\"message\":\" \\n \"}"
+                , callKind = FunctionCallKind
+                , argumentsEncrypted = False
+                }
+        sendResult <- dispatchToolCall defaultLoopDispatch handlers
+            (blankCall "send_message")
+        followupResult <- dispatchToolCall defaultLoopDispatch handlers
+            (blankCall "followup_task")
+        sendResult.output `shouldBe`
+            "Error: send_message requires a non-empty message"
+        followupResult.output `shouldBe`
+            "Error: followup_task requires a non-empty message"
+        closeSubagentRegistry registry
+
     it "routes encrypted child messages to the root inbox" do
         rootInbox <- newEmptyTMVarIO
         registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")

--- a/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/TaskControl.hs
+++ b/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/TaskControl.hs
@@ -2,6 +2,7 @@ module Agent.GrokBuild.Dialect.TaskControl
     ( getTaskOutputTool
     , waitTasksTool
     , killTaskTool
+    , validateTaskIds
     ) where
 
 import Agent.Subagents
@@ -80,28 +81,16 @@ runGetTaskOutput
     -> TaskOutputArgs
     -> IO (Either Text Text)
 runGetTaskOutput session multi args
-    | null resolvedIds =
-        pure (Left "Provide a non-empty task_ids list.")
-    | length resolvedIds > maxTaskOutputIds =
-        pure $ Left $
-            "task_ids exceeds maximum of "
-                <> Text.pack (show maxTaskOutputIds)
-                <> " entries."
-    | otherwise = do
-        entries <- mapConcurrently
-            (runOneTaskOutput session multi effectiveTimeout)
-            resolvedIds
-        pure $ Right $ case entries of
-            [entry] -> entry.output
-            _ -> formatMultiTaskOutput waits entries
+    = case validateTaskIds args.taskIds of
+        Left err -> pure (Left err)
+        Right resolvedIds -> do
+            entries <- mapConcurrently
+                (runOneTaskOutput session multi effectiveTimeout)
+                resolvedIds
+            pure $ Right $ case entries of
+                [entry] -> entry.output
+                _ -> formatMultiTaskOutput waits entries
   where
-    resolvedIds =
-        nub
-            [ stripped
-            | taskId <- args.taskIds
-            , let stripped = Text.strip taskId
-            , not (Text.null stripped)
-            ]
     waits = maybe False (> 0) args.timeoutMs
     effectiveTimeout
         | waits = Just (min maxTaskOutputWaitMs (fromMaybe 0 args.timeoutMs))
@@ -238,26 +227,15 @@ runWaitTasks
     -> WaitTasksArgs
     -> IO (Either Text Text)
 runWaitTasks session multi args
-    | null taskIds = pure (Left "Provide a non-empty task_ids list.")
-    | length taskIds > maxTaskOutputIds =
-        pure $ Left $
-            "task_ids exceeds maximum of "
-                <> Text.pack (show maxTaskOutputIds)
-                <> " entries."
-    | otherwise = do
-        started <- getCurrentTime
-        waitLoop started
+    = case validateTaskIds args.waitTaskIds of
+        Left err -> pure (Left err)
+        Right taskIds -> do
+            started <- getCurrentTime
+            waitLoop taskIds started
   where
-    taskIds =
-        nub
-            [ stripped
-            | taskId <- args.waitTaskIds
-            , let stripped = Text.strip taskId
-            , not (Text.null stripped)
-            ]
     timeoutMs = min maxTaskOutputWaitMs
         (max 1 (fromMaybe maxTaskOutputWaitMs args.waitTimeoutMs))
-    waitLoop started = do
+    waitLoop taskIds started = do
         entries <- mapConcurrently
             (runOneTaskOutput session multi Nothing)
             taskIds
@@ -270,7 +248,25 @@ runWaitTasks session multi args
                 floor (realToFrac (diffUTCTime now started) * (1000 :: Double))
         if satisfied || elapsedMs >= timeoutMs
             then pure $ Right $ formatWaitResult args.waitMode completed entries
-            else threadDelay 50000 >> waitLoop started
+            else threadDelay 50000 >> waitLoop taskIds started
+
+validateTaskIds :: [Text] -> Either Text [Text]
+validateTaskIds taskIds
+    | null resolvedIds = Left "Provide a non-empty task_ids list."
+    | length resolvedIds > maxTaskOutputIds =
+        Left $
+            "task_ids exceeds maximum of "
+                <> Text.pack (show maxTaskOutputIds)
+                <> " entries."
+    | otherwise = Right resolvedIds
+  where
+    resolvedIds =
+        nub
+            [ stripped
+            | taskId <- taskIds
+            , let stripped = Text.strip taskId
+            , not (Text.null stripped)
+            ]
 
 formatWaitResult :: WaitMode -> Int -> [TaskOutputEntry] -> Text
 formatWaitResult mode completed entries =

--- a/packages/agent-grok-build-dialect/test/Agent/GrokBuild/DialectSpec.hs
+++ b/packages/agent-grok-build-dialect/test/Agent/GrokBuild/DialectSpec.hs
@@ -9,6 +9,7 @@ import Agent.GrokBuild.Dialect.Runtime
     ( GrokCodingTools(..)
     , newGrokCodingTools
     )
+import Agent.GrokBuild.Dialect.TaskControl (validateTaskIds)
 import Agent.ProjectInstructions (InstructionFile(..), LoadedAgentsMd(..))
 import Agent.Tools.Types (AppTool(..), defaultToolEnv)
 import Control.Exception.Safe (bracket)
@@ -24,6 +25,15 @@ import Test.Hspec
 
 spec :: Spec
 spec = describe "Grok Build dialect" do
+    it "normalizes and validates task id lists consistently" do
+        validateTaskIds [" task-1 ", "", "task-1", "task-2"]
+            `shouldBe` Right ["task-1", "task-2"]
+        validateTaskIds [" ", "\t"]
+            `shouldBe` Left "Provide a non-empty task_ids list."
+        validateTaskIds (map (("task-" <>) . Text.pack . show) [1 .. 21 :: Int])
+            `shouldBe`
+                Left "task_ids exceeds maximum of 20 entries."
+
     it "renders the Grok Build tool contract" do
         let prompt =
                 grokSystemPrompt


### PR DESCRIPTION
## Summary
- share target restoration/resolution and root-turn lookup between `send_message` and `followup_task`
- share blank-message validation while preserving tool-specific errors and root-target behavior
- centralize Grok task ID trimming, deduplication, empty-list validation, and maximum-count validation
- add focused coverage for message and task-ID validation

## Validation
- `nix develop -c cabal test agent-core:test:agent-core-test --test-show-details=direct` — 306 examples passed
- `nix develop -c cabal test agent-grok-build-dialect:agent-grok-build-dialect-test --test-show-details=direct` — 14 examples passed