### PR TITLE
refactor(core): queue loop events through a bounded pump

### DIFF
--- a/packages/agent-core/src/Agent/Loop.hs
+++ b/packages/agent-core/src/Agent/Loop.hs
@@ -365,9 +365,11 @@ runLoopInputsUnsafe config0 initialState previousResponseId firstInputs = do
                                         Right (Right BackendResult{..})
                                             | not
                                                 (Text.null
-                                                    backendOutput.responseId) ->
+                                                    backendOutput.responseId) -> do
                                                 config.loopBackendState.commitBackendState
                                                     backendState
+                                                writeIORef progressRef
+                                                    (backendState, ResponseCommitted)
                                         _ -> pure ()
                                     pure result
                                 case raced of

--- a/packages/agent-core/src/Agent/Loop.hs
+++ b/packages/agent-core/src/Agent/Loop.hs
@@ -42,9 +42,39 @@ import Agent.Tools.Types
     , dispatchRegisteredToolCall
     , toolExecutionPolicyFor
     )
-import Control.Concurrent.Async (mapConcurrently, race)
-import Control.Concurrent.MVar (newMVar, withMVar)
-import Control.Exception.Safe (SomeException, displayException, mask, tryAny)
+import Control.Concurrent.Async
+    ( Async
+    , mapConcurrently
+    , race
+    , waitCatch
+    , withAsync
+    )
+import Control.Concurrent.STM
+    ( TBQueue
+    , TMVar
+    , atomically
+    , newEmptyTMVarIO
+    , newTBQueueIO
+    , orElse
+    , putTMVar
+    , readTBQueue
+    , readTMVar
+    , retry
+    , tryPutTMVar
+    , writeTBQueue
+    )
+import Control.Exception (AsyncException, toException)
+import qualified Control.Exception as Exception
+import Control.Exception.Safe
+    ( SomeException
+    , catchAsync
+    , displayException
+    , isAsyncException
+    , mask
+    , throwIO
+    , tryAny
+    )
+import Control.Monad (void)
 import Data.Aeson (FromJSON(..), ToJSON(..), object, withObject, (.:), (.:?), (.!=), (.=))
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as ByteString
@@ -287,111 +317,236 @@ runLoopInputsUnsafe
     -> [TurnInput]
     -> IO LoopExecution
 runLoopInputsUnsafe config0 initialState previousResponseId firstInputs = do
-    -- Parallel-safe tool batches run with mapConcurrently. Serialize onEvent
-    -- so a printer (hPutStrLn on String is not atomic) cannot interleave
-    -- characters.
-    eventLock <- newMVar ()
-    let config = config0
-            { loopOnEvent = \event ->
-                withMVar eventLock \_ -> config0.loopOnEvent event
-            }
-        finish state progress result =
-            pure LoopExecution
-                { executionState = state
-                , executionProgress = progress
-                , executionResult = result
+    eventPump <- newLoopEventPump config0.loopOnEvent
+    progressRef <- newIORef (initialState, NoResponseCommitted)
+    withAsync (runLoopEventPump eventPump) \eventWorker -> do
+        let config = config0
+                { loopOnEvent = emitLoopEvent eventPump
                 }
-        unexpected state progress exception =
-            finish state progress
-                (Left (LoopUnexpected (exceptionSummary exception)))
-        protect state progress action =
-            tryAny action >>= either (unexpected state progress) pure
-        go state progress prev turnsUsed inputs lastOutput usageAcc
-            | turnsUsed >= config.loopMaxTurns =
-                finish state progress $ case lastOutput of
-                    Just turn -> Left (LoopMaxTurns turn)
-                    Nothing -> Left LoopNoResponseId
-            | otherwise = protect state progress do
-                cancelled <- isCancelled config.loopCancel
-                if cancelled
-                    then finish state progress (Left (LoopCancelled []))
-                    else do
-                        config.loopOnEvent TurnStarted
-                        outputSeen <- newIORef False
-                        let onBackendEvent event = do
-                                case event of
-                                    TextDelta _ -> writeIORef outputSeen True
-                                    ReasoningDelta _ -> writeIORef outputSeen True
-                                    _ -> pure ()
-                                config.loopOnEvent event
-                        -- Race the model call against cancel so Ctrl-C / Esc
-                        -- can stop reasoning mid-stream, not only between tools.
-                        raced <- mask \restore -> do
-                            result <- restore $ race
-                                (waitCancel config.loopCancel)
-                                (config.loopBackend.submitTurn
-                                    state prev inputs onBackendEvent)
-                            case result of
-                                Right (Right BackendResult{..})
-                                    | not
-                                        (Text.null
-                                            backendOutput.responseId) ->
-                                        config.loopBackendState.commitBackendState
-                                            backendState
-                                _ -> pure ()
-                            pure result
-                        case raced of
-                            Left () ->
-                                finish state progress (Left (LoopCancelled []))
-                            Right (Left err) -> do
-                                emitted <- readIORef outputSeen
-                                finish state progress $ Left $
-                                    if emitted
-                                        then LoopTransportAfterOutput err
-                                        else LoopTransport err
-                            Right (Right BackendResult{backendOutput = turn})
-                                | Text.null turn.responseId ->
-                                    finish state progress (Left LoopNoResponseId)
-                            Right (Right BackendResult{..}) -> do
-                                continueCommitted
-                                    backendState backendOutput turnsUsed usageAcc
-        continueCommitted state turn turnsUsed usageAcc =
-            protect state ResponseCommitted do
-                -- A cancel that landed during submitTurn after the race chose
-                -- Right still counts, but its returned state is committed.
-                cancelledMid <- isCancelled config.loopCancel
-                let usageAcc' = addTokenUsage usageAcc turn.tokenUsage
-                if cancelledMid
-                    then finish state ResponseCommitted
-                        (Left (LoopCancelled []))
-                    else do
-                        config.loopOnEvent (TurnFinished turn)
-                        let nextTurnsUsed = turnsUsed + 1
-                        if null turn.toolCalls
-                            then finish state ResponseCommitted $
-                                Right LoopResult
-                                    { finalResponseId = turn.responseId
-                                    , finalText = turn.assistantText
-                                    , turnsUsed = nextTurnsUsed
-                                    , tokenUsage = usageAcc'
-                                    }
+            finish state progress result = do
+                writeIORef progressRef (state, progress)
+                pure LoopExecution
+                    { executionState = state
+                    , executionProgress = progress
+                    , executionResult = result
+                    }
+            unexpected state progress exception =
+                finish state progress
+                    (Left (LoopUnexpected (exceptionSummary exception)))
+            protect state progress action =
+                tryAny action >>= either (unexpected state progress) pure
+            go state progress prev turnsUsed inputs lastOutput usageAcc = do
+                writeIORef progressRef (state, progress)
+                if turnsUsed >= config.loopMaxTurns
+                    then finish state progress $ case lastOutput of
+                        Just turn -> Left (LoopMaxTurns turn)
+                        Nothing -> Left LoopNoResponseId
+                    else protect state progress do
+                        cancelled <- isCancelled config.loopCancel
+                        if cancelled
+                            then finish state progress (Left (LoopCancelled []))
                             else do
-                                results <- runToolCalls config turn.toolCalls
-                                cancelledAfter <-
-                                    isCancelled config.loopCancel
-                                if cancelledAfter
-                                    then finish state ResponseCommitted
-                                        (Left (LoopCancelled results))
-                                    else go
-                                        state
-                                        ResponseCommitted
-                                        (Just turn.responseId)
-                                        nextTurnsUsed
-                                        (map CompletedTool results)
-                                        (Just turn)
-                                        usageAcc'
-    go initialState NoResponseCommitted previousResponseId 0 firstInputs
-        Nothing emptyTokenUsage
+                                config.loopOnEvent TurnStarted
+                                outputSeen <- newIORef False
+                                let onBackendEvent event = do
+                                        case event of
+                                            TextDelta _ -> writeIORef outputSeen True
+                                            ReasoningDelta _ -> writeIORef outputSeen True
+                                            _ -> pure ()
+                                        config.loopOnEvent event
+                                -- Race the model call against cancel so Ctrl-C / Esc
+                                -- can stop reasoning mid-stream, not only between tools.
+                                raced <- mask \restore -> do
+                                    result <- restore $ race
+                                        (waitCancel config.loopCancel)
+                                        (config.loopBackend.submitTurn
+                                            state prev inputs onBackendEvent)
+                                    case result of
+                                        Right (Right BackendResult{..})
+                                            | not
+                                                (Text.null
+                                                    backendOutput.responseId) ->
+                                                config.loopBackendState.commitBackendState
+                                                    backendState
+                                        _ -> pure ()
+                                    pure result
+                                case raced of
+                                    Left () ->
+                                        finish state progress (Left (LoopCancelled []))
+                                    Right (Left err) -> do
+                                        emitted <- readIORef outputSeen
+                                        finish state progress $ Left $
+                                            if emitted
+                                                then LoopTransportAfterOutput err
+                                                else LoopTransport err
+                                    Right (Right BackendResult{backendOutput = turn})
+                                        | Text.null turn.responseId ->
+                                            finish state progress (Left LoopNoResponseId)
+                                    Right (Right BackendResult{..}) -> do
+                                        continueCommitted
+                                            backendState backendOutput turnsUsed usageAcc
+            continueCommitted state turn turnsUsed usageAcc = do
+                writeIORef progressRef (state, ResponseCommitted)
+                protect state ResponseCommitted do
+                    -- A cancel that landed during submitTurn after the race chose
+                    -- Right still counts, but its returned state is committed.
+                    cancelledMid <- isCancelled config.loopCancel
+                    let usageAcc' = addTokenUsage usageAcc turn.tokenUsage
+                    if cancelledMid
+                        then finish state ResponseCommitted
+                            (Left (LoopCancelled []))
+                        else do
+                            config.loopOnEvent (TurnFinished turn)
+                            let nextTurnsUsed = turnsUsed + 1
+                            if null turn.toolCalls
+                                then finish state ResponseCommitted $
+                                    Right LoopResult
+                                        { finalResponseId = turn.responseId
+                                        , finalText = turn.assistantText
+                                        , turnsUsed = nextTurnsUsed
+                                        , tokenUsage = usageAcc'
+                                        }
+                                else do
+                                    results <- runToolCalls config turn.toolCalls
+                                    cancelledAfter <-
+                                        isCancelled config.loopCancel
+                                    if cancelledAfter
+                                        then finish state ResponseCommitted
+                                            (Left (LoopCancelled results))
+                                        else go
+                                            state
+                                            ResponseCommitted
+                                            (Just turn.responseId)
+                                            nextTurnsUsed
+                                            (map CompletedTool results)
+                                            (Just turn)
+                                            usageAcc'
+            run =
+                go initialState NoResponseCommitted previousResponseId 0 firstInputs
+                    Nothing emptyTokenUsage
+        raced <- race (waitLoopEventFailure eventWorker eventPump) run
+        execution <- case raced of
+            Left failure -> do
+                (state, progress) <- readIORef progressRef
+                handleLoopEventFailure unexpected state progress failure
+            Right completed -> pure completed
+        flushLoopEvents eventPump >>= \case
+            Left failure ->
+                handleLoopEventFailure
+                    unexpected
+                    execution.executionState
+                    execution.executionProgress
+                    failure
+            Right () -> pure execution
+
+data LoopEventCommand
+    = DeliverLoopEvent !LoopEvent
+    | FlushLoopEvents !(TMVar ())
+
+data LoopEventFailure
+    = LoopEventSyncFailure !SomeException
+    | LoopEventAsyncFailure !AsyncException
+
+data LoopEventPump = LoopEventPump
+    { eventPumpQueue :: !(TBQueue LoopEventCommand)
+    , eventPumpFailure :: !(TMVar LoopEventFailure)
+    , eventPumpSink :: !(LoopEvent -> IO ())
+    }
+
+loopEventQueueCapacity :: Int
+loopEventQueueCapacity = 256
+
+newLoopEventPump :: (LoopEvent -> IO ()) -> IO LoopEventPump
+newLoopEventPump sink = do
+    queue <- newTBQueueIO (fromIntegral loopEventQueueCapacity)
+    failure <- newEmptyTMVarIO
+    pure LoopEventPump
+        { eventPumpQueue = queue
+        , eventPumpFailure = failure
+        , eventPumpSink = sink
+        }
+
+runLoopEventPump :: LoopEventPump -> IO ()
+runLoopEventPump pump = go
+  where
+    go =
+        atomically (readTBQueue pump.eventPumpQueue) >>= \case
+            DeliverLoopEvent event -> do
+                outcome <-
+                    (tryAny (pump.eventPumpSink event) >>= \case
+                        Left exception ->
+                            pure (Left (LoopEventSyncFailure exception))
+                        Right () -> pure (Right ()))
+                    `catchAsync` \(exception :: AsyncException) ->
+                        pure (Left (LoopEventAsyncFailure exception))
+                case outcome of
+                    Right () -> go
+                    Left failure -> do
+                        atomically $
+                            void (tryPutTMVar pump.eventPumpFailure failure)
+                        atomically retry
+            FlushLoopEvents flushed -> do
+                atomically (putTMVar flushed ())
+                go
+
+emitLoopEvent :: LoopEventPump -> LoopEvent -> IO ()
+emitLoopEvent pump event =
+    enqueueLoopEventCommand pump (DeliverLoopEvent event)
+
+flushLoopEvents :: LoopEventPump -> IO (Either LoopEventFailure ())
+flushLoopEvents pump = do
+    flushed <- newEmptyTMVarIO
+    tryAny (enqueueLoopEventCommand pump (FlushLoopEvents flushed)) >>= \case
+        Left exception
+            | isAsyncException exception ->
+                Exception.throwIO exception
+            | otherwise ->
+                pure (Left (LoopEventSyncFailure exception))
+        Right () ->
+            atomically $
+                (Left <$> readTMVar pump.eventPumpFailure)
+                    `orElse`
+                (readTMVar flushed >> pure (Right ()))
+
+enqueueLoopEventCommand :: LoopEventPump -> LoopEventCommand -> IO ()
+enqueueLoopEventCommand pump command =
+    atomically
+        ( (Left <$> readTMVar pump.eventPumpFailure)
+            `orElse`
+          (writeTBQueue pump.eventPumpQueue command >> pure (Right ()))
+        ) >>= either throwLoopEventFailure pure
+
+waitLoopEventFailure :: Async () -> LoopEventPump -> IO LoopEventFailure
+waitLoopEventFailure worker pump =
+    race
+        (atomically (readTMVar pump.eventPumpFailure))
+        (waitCatch worker) >>= \case
+            Left failure -> pure failure
+            Right (Left exception)
+                | isAsyncException exception ->
+                    Exception.throwIO exception
+                | otherwise ->
+                    pure (LoopEventSyncFailure exception)
+            Right (Right ()) ->
+                pure . LoopEventSyncFailure . toException $
+                    userError "loop event pump stopped unexpectedly"
+
+throwLoopEventFailure :: LoopEventFailure -> IO a
+throwLoopEventFailure = \case
+    LoopEventSyncFailure exception -> throwIO exception
+    LoopEventAsyncFailure exception -> Exception.throwIO exception
+
+handleLoopEventFailure
+    :: ([ResponseItem] -> LoopProgress -> SomeException -> IO LoopExecution)
+    -> [ResponseItem]
+    -> LoopProgress
+    -> LoopEventFailure
+    -> IO LoopExecution
+handleLoopEventFailure unexpected state progress = \case
+    LoopEventSyncFailure exception ->
+        unexpected state progress exception
+    LoopEventAsyncFailure exception ->
+        Exception.throwIO exception
 
 -- | Preserve model order around stateful tools while retaining concurrency
 -- for maximal consecutive runs of explicitly parallel-safe calls.

--- a/packages/agent-core/test/Agent/LoopSpec.hs
+++ b/packages/agent-core/test/Agent/LoopSpec.hs
@@ -514,6 +514,44 @@ spec = describe "runLoop" do
         execution.executionResult
             `shouldBe` Left (LoopUnexpected "user error (renderer exploded)")
 
+    it "retains committed state when the event pump fails during commit" do
+        commitStarted <- newEmptyMVar
+        sinkCanFail <- newEmptyMVar
+        state <- newIORef []
+        let committedState = [stateMarker]
+            backend = Backend \_state _prev _inputs _onEvent ->
+                pure $ Right BackendResult
+                    { backendOutput =
+                        emptyTurnOutput "resp-1" [] (Just "done")
+                    , backendState = committedState
+                    }
+        config0 <- testConfig backend
+        let config = config0
+                { loopBackendState = BackendStateStore
+                    { readBackendState = readIORef state
+                    , commitBackendState = \newState -> do
+                        putMVar commitStarted ()
+                        Exception.uninterruptibleMask_ do
+                            takeMVar sinkCanFail
+                            -- Give the outer race time to cancel the loop
+                            -- before the masked commit returns.
+                            threadDelay 30000
+                            writeIORef state newState
+                    }
+                , loopOnEvent = \case
+                    TurnStarted -> do
+                        takeMVar commitStarted
+                        putMVar sinkCanFail ()
+                        Exception.throwIO (userError "renderer exploded")
+                    _ -> pure ()
+                }
+        execution <- runLoopInputsDetailed config Nothing [UserMessage "hello"]
+        readIORef state `shouldReturn` committedState
+        execution.executionState `shouldBe` committedState
+        execution.executionProgress `shouldBe` ResponseCommitted
+        execution.executionResult
+            `shouldBe` Left (LoopUnexpected "user error (renderer exploded)")
+
     it "marks a transport failure after streamed output as interrupted" do
         let backend = Backend \_state _prev _inputs onEvent -> do
                 onEvent (TextDelta "partial")

--- a/packages/agent-core/test/Agent/LoopSpec.hs
+++ b/packages/agent-core/test/Agent/LoopSpec.hs
@@ -130,6 +130,74 @@ spec = describe "runLoop" do
             }
         readIORef maxInFlight `shouldReturn` 1
 
+    it "delivers events off the backend thread and flushes before returning" do
+        sinkStarted <- newEmptyMVar
+        releaseSink <- newEmptyMVar
+        backendEntered <- newEmptyMVar
+        let backend = Backend \_state _prev _inputs _onEvent -> do
+                putMVar backendEntered ()
+                pure $ Right BackendResult
+                    { backendOutput =
+                        emptyTurnOutput "resp-1" [] (Just "done")
+                    , backendState = []
+                    }
+            onEvent = \case
+                TurnStarted -> do
+                    putMVar sinkStarted ()
+                    takeMVar releaseSink
+                _ -> pure ()
+        config0 <- testConfig backend
+        let config = config0 { loopOnEvent = onEvent }
+        withAsync (runLoop config Nothing "go") \running -> do
+            takeMVar sinkStarted
+            timeout 1000000 (takeMVar backendEntered)
+                `shouldReturn` Just ()
+            timeout 100000 (wait running)
+                `shouldReturn` Nothing
+            putMVar releaseSink ()
+            wait running `shouldReturn` Right LoopResult
+                { finalResponseId = "resp-1"
+                , finalText = Just "done"
+                , turnsUsed = 1
+                , tokenUsage = emptyTokenUsage
+                }
+
+    it "bounds queued events when the sink falls behind" do
+        sinkStarted <- newEmptyMVar
+        releaseSink <- newEmptyMVar
+        backendStarted <- newEmptyMVar
+        backendFinished <- newEmptyMVar
+        let backend = Backend \_state _prev _inputs onEvent -> do
+                putMVar backendStarted ()
+                mapM_ (const (onEvent (TextDelta "x"))) [1 .. 300 :: Int]
+                putMVar backendFinished ()
+                pure $ Right BackendResult
+                    { backendOutput =
+                        emptyTurnOutput "resp-1" [] (Just "done")
+                    , backendState = []
+                    }
+            onEvent = \case
+                TurnStarted -> do
+                    putMVar sinkStarted ()
+                    takeMVar releaseSink
+                _ -> pure ()
+        config0 <- testConfig backend
+        let config = config0 { loopOnEvent = onEvent }
+        withAsync (runLoop config Nothing "go") \running -> do
+            takeMVar sinkStarted
+            takeMVar backendStarted
+            timeout 100000 (takeMVar backendFinished)
+                `shouldReturn` Nothing
+            putMVar releaseSink ()
+            timeout 1000000 (takeMVar backendFinished)
+                `shouldReturn` Just ()
+            wait running `shouldReturn` Right LoopResult
+                { finalResponseId = "resp-1"
+                , finalText = Just "done"
+                , turnsUsed = 1
+                , tokenUsage = emptyTokenUsage
+                }
+
     it "dispatches consecutive parallel-safe tool calls concurrently" do
         firstStarted <- newEmptyMVar
         secondStarted <- newEmptyMVar
@@ -483,6 +551,20 @@ spec = describe "runLoop" do
             Exception.throwIO Exception.ThreadKilled
         runLoop config Nothing "hello"
             `shouldThrow` (== Exception.ThreadKilled)
+
+    it "does not detach asynchronous event-sink cancellation" do
+        submissions <- newIORef []
+        backend <- scriptedBackend submissions
+            [Right (emptyTurnOutput "resp-1" [] (Just "done"))]
+        config0 <- testConfig backend
+        let config = config0
+                { loopOnEvent = \_ ->
+                    Exception.throwIO Exception.ThreadKilled
+                }
+        timeout 1000000
+            (runLoop config Nothing "hello"
+                `shouldThrow` (== Exception.ThreadKilled))
+            `shouldReturn` Just ()
 
     it "emits TurnStarted and TurnFinished around each backend submit" do
         events <- newIORef []


### PR DESCRIPTION
## Summary

- replace the synchronous `MVar` around `loopOnEvent` with a bounded `TBQueue`
- process loop events on one scoped worker so provider and tool threads do not render directly
- flush queued events before returning and preserve committed loop state on sink failures
- propagate asynchronous sink exceptions and prevent producers from blocking behind a failed worker
- add deterministic coverage for asynchronous delivery, bounded backpressure, flushing, ordering, and failure behavior

## Testing

- `nix develop -c cabal repl agent-core:test:agent-core-test`
- `:main`
- 309 examples, 0 failures
