### PR TITLE
Fix nested subagent model inheritance

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
@@ -10,6 +10,7 @@ module Agent.CLI.Subagents.Runtime
     , persistSubagentSnapshotWithStatus
     , prepareCollaborationSpawn
     , restoreAgentFromDisk
+    , resolveChildModelAndEffort
     , runCodexSubagent
     , runHttpSubagent
     , validatePersistedSubagentTarget
@@ -559,20 +560,28 @@ runCodexSubagent runtime tokenProvider sendToRoot =
         childModel <- lookupAgentModel runtime.subagentTypes env.subId
         childEffort <- lookupAgentReasoningEffort runtime.subagentTypes env.subId
         parentParams <- readIORef runtime.subagentParams
-        let (model, effort) =
+        let (provisionalModel, _) =
                 resolveChildModelAndEffort
                     OpenAIProvider
                     parentParams
+                    (fromMaybe "" parentParams.model)
                     childModel
                     childEffort
         prepared <-
             prepareChild
                 runtime
                 OpenAIProvider
-                model
+                provisionalModel
                 (dialectId codexDialect)
                 env
                 sendToRoot
+        let (model, effort) =
+                resolveChildModelAndEffort
+                    OpenAIProvider
+                    parentParams
+                    prepared.preparedSession.subSessionEffectiveModel
+                    childModel
+                    childEffort
         sessionTmp <- readIORef runtime.subagentSessionTmp
         case activeSubagentTargetError
                 OpenAIProvider runtime.subagentConnection
@@ -664,24 +673,38 @@ runHttpSubagent runtime dialect provider sendToRoot mkBackend =
         childEffort <-
             lookupAgentReasoningEffort runtime.subagentTypes env.subId
         parentParams <- readIORef runtime.subagentParams
-        let (model, effort) =
+        let (provisionalModel, _) =
                 resolveChildModelAndEffort
                     provider
                     parentParams
+                    (fromMaybe "" parentParams.model)
                     childModel
                     childEffort
-            effectiveModel = runtime.subagentMapModel model
+            provisionalEffectiveModel =
+                runtime.subagentMapModel provisionalModel
         prepared <-
             prepareChild
                 runtime
                 provider
-                effectiveModel
+                provisionalEffectiveModel
                 (maybe
                     (dialectId dialect)
                     (dialectIdForModel provider . runtime.subagentMapModel)
                     childModel)
                 env
                 sendToRoot
+        let (model, effort) =
+                resolveChildModelAndEffort
+                    provider
+                    parentParams
+                    prepared.preparedSession.subSessionEffectiveModel
+                    childModel
+                    childEffort
+            effectiveModel =
+                maybe
+                    prepared.preparedSession.subSessionEffectiveModel
+                    runtime.subagentMapModel
+                    childModel
         sessionTmp <- readIORef runtime.subagentSessionTmp
         case activeSubagentTargetError
                 provider runtime.subagentConnection
@@ -871,17 +894,17 @@ prepareChild runtime provider currentEffectiveModel currentDialect env sendToRoo
 resolveChildModelAndEffort
     :: Provider
     -> ResponseCreateParams
+    -> Text
     -> Maybe Text
     -> Maybe Text
     -> (Text, Text)
-resolveChildModelAndEffort provider parentParams childModel childEffort =
+resolveChildModelAndEffort
+        provider parentParams inheritedModel childModel childEffort =
     ( model
     , fromMaybe inheritedEffort childEffort
     )
   where
-    model = fromMaybe
-        (fromMaybe "" parentParams.model)
-        childModel
+    model = fromMaybe inheritedModel childModel
     inheritedEffort = case parentParams.reasoning of
         Just cfg -> fromMaybe (defaultEffortFor provider) cfg.effort
         Nothing -> defaultEffortFor provider

--- a/packages/agent-cli/test/Agent/CLI/SubagentStoreSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SubagentStoreSpec.hs
@@ -9,9 +9,12 @@ import Agent.CLI.Subagents.Runtime
     , flushAllSubagentSnapshots
     , lookupOrCreateSubagentSession
     , persistAndEvictSubagentSessionWithStatus
+    , prepareCollaborationSpawn
     , restoreAgentFromDisk
+    , resolveChildModelAndEffort
     , validatePersistedSubagentTarget
     )
+import Agent.CLI.Request (requestParams)
 import Agent.Responses.Types
 import System.OsPath (OsPath, decodeUtf, unsafeEncodeUtf)
 import Agent.Subagents
@@ -23,6 +26,7 @@ import Agent.Subagents
     , newSubagentRegistry
     )
 import Agent.Subagents.TaskPath (parseTaskPath)
+import Agent.Tools.MultiAgents (CollaborationSpawnOptions(..))
 import Control.Concurrent.Async (mapConcurrently, wait, withAsync)
 import Control.Concurrent.MVar
     ( newEmptyMVar
@@ -49,6 +53,50 @@ toFilePath path = either (error . show) id (decodeUtf path)
 
 spec :: Spec
 spec = describe "Agent.CLI.SubagentStore" do
+    describe "nested subagent model inheritance" do
+        it "uses the immediate parent's effective model when no override is set" do
+            sessionsRef <- newIORef Map.empty
+            storeRootRef <- newIORef Nothing
+            typesRef <- newIORef Map.empty
+            forkSourceRef <- newIORef Nothing
+            let agentId = SubagentId "agent-nested"
+            prepareCollaborationSpawn
+                OpenAIProvider
+                "openai"
+                id
+                "gpt-5.6-luna"
+                CodexDialect
+                Nothing
+                sessionsRef
+                storeRootRef
+                typesRef
+                forkSourceRef
+                agentId
+                CollaborationSpawnOptions
+                    { collaborationModel = Nothing
+                    , collaborationReasoningEffort = Nothing
+                    , collaborationForkTurns = Nothing
+                    }
+            Just session <- Map.lookup agentId <$> readIORef sessionsRef
+            let rootParams = requestParams "gpt-5.6-sol" "" [] "medium"
+            resolveChildModelAndEffort
+                OpenAIProvider
+                rootParams
+                session.subSessionEffectiveModel
+                Nothing
+                Nothing
+                `shouldBe` ("gpt-5.6-luna", "medium")
+
+        it "keeps an explicit child model override" do
+            let rootParams = requestParams "gpt-5.6-sol" "" [] "medium"
+            resolveChildModelAndEffort
+                OpenAIProvider
+                rootParams
+                "gpt-5.6-luna"
+                (Just "gpt-5.6-nano")
+                (Just "high")
+                `shouldBe` ("gpt-5.6-nano", "high")
+
     it "round-trips transcript items and meta" do
         withTempDir \dir -> do
             let agentId = SubagentId "agent-test-1"


### PR DESCRIPTION
## Summary
- resolve an implicit nested child model from its pre-created immediate-parent session instead of the root request parameters
- preserve explicit child model overrides and HTTP transport model mapping
- add regression coverage for a Luna parent nested under a Sol root

## Background
A nested subagent spawned without a model override was prepared with its immediate parent's effective model, but the worker later resolved the omitted model from the root session parameters. That produced an immediate target mismatch such as:

```
cannot continue subagent after its effective model changed from gpt-5.6-luna to gpt-5.6-sol
```

## Testing
- GHCi load: `nix develop -c cabal repl agent-cli:lib:agent-cli --offline`
- focused `Agent.CLI.SubagentStore` spec: 18 examples, 0 failures
- full `agent-cli-test` suite in GHCi with a short temporary directory: 848 examples, 0 failures
