### PR TITLE
refactor(cli): share terminal and auth helpers

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -67,6 +67,7 @@ library
                     , Agent.CLI.Database.Storage
                     , Agent.CLI.Duration
                     , Agent.CLI.Dialects
+                    , Agent.CLI.Environment
                     , Agent.CLI.Error
                     , Agent.CLI.ImagePreview
                     , Agent.CLI.Input
@@ -238,6 +239,7 @@ test-suite agent-cli-test
                     , Agent.CLI.AgentSessionsSpec
                     , Agent.CLI.ArtifactSpec
                     , Agent.CLI.AgentViewportSpec
+                    , Agent.CLI.EnvironmentSpec
                     , Agent.CLI.AuthSpec
                     , Agent.CLI.BtwSpec
                     , Agent.CLI.CancelWatchSpec

--- a/packages/agent-cli/src/Agent/CLI/Auth.hs
+++ b/packages/agent-cli/src/Agent/CLI/Auth.hs
@@ -54,6 +54,7 @@ import Agent.CLI.CredentialStore
     , ManagedSecret(..)
     , loadManagedCredentials
     )
+import Agent.CLI.Environment (lookupNonEmpty)
 import Agent.Error (ApiError(..))
 import qualified Agent.Claude.Auth as ClaudeCode
 import Agent.Provider
@@ -63,6 +64,7 @@ import Agent.Provider
     , FailedCredential(..)
     , Provider(..)
     , TokenProvider
+    , credentialsExhaustedForRateLimit
     , getNextToken
     , providerSlug
     , seedTokenProvider
@@ -85,11 +87,9 @@ import Data.List (find)
 import Data.Maybe (fromMaybe, isJust, listToMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
-import Data.Time.Clock (addUTCTime, getCurrentTime)
+import Data.Time.Clock (getCurrentTime)
 import System.Directory.OsPath (doesFileExist, getHomeDirectory)
 import System.OsPath (unsafeEncodeUtf, (</>))
-import qualified System.OsPath as OsPath
-import qualified System.Process.Environment.OsString as Environment
 
 loadAuth :: Maybe Provider -> IO (Either Text LoadedAuth)
 loadAuth requested = runExceptT do
@@ -421,22 +421,17 @@ reloadableFileCredentialProvider expectedProvider billing initial reload = do
                         writeIORef cache (Just credential)
                         pure (Right credential)
     pure $ tokenProvider billing \failed -> case failed of
-            Just FailedCredential
-                { failure = AccountRateLimited { retryAfterSeconds }
-                , failureReason
-                } -> do
-                now <- getCurrentTime
-                let seconds = max 1 (fromMaybe 60 retryAfterSeconds)
-                pure $ Left $ CredentialsExhausted
-                    { retryAt = addUTCTime (fromIntegral seconds) now
-                    , exhaustionReasons = [failureReason]
-                    }
-            Just FailedCredential
-                { credential = rejected
-                , failure = AccountAuthenticationRejected
-                } -> do
-                writeIORef cache Nothing
-                loadFresh (Just rejected.accessToken)
+            Just reported -> credentialsExhaustedForRateLimit reported >>= \case
+                Just err -> pure (Left err)
+                Nothing -> case reported of
+                    FailedCredential
+                        { credential = rejected
+                        , failure = AccountAuthenticationRejected
+                        } -> do
+                            writeIORef cache Nothing
+                            loadFresh (Just rejected.accessToken)
+                    _ -> pure $ Left $ CredentialError
+                        "unsupported credential failure"
             Nothing ->
                 readIORef cache >>= \case
                     Just credential -> pure (Right credential)
@@ -446,31 +441,10 @@ staticCredentialProvider :: BillingMode -> Credential -> TokenProvider
 staticCredentialProvider billing credential =
     tokenProvider billing \failed -> case failed of
         Nothing -> pure (Right credential)
-        Just FailedCredential
-            { failure = AccountRateLimited { retryAfterSeconds }
-            , failureReason
-            } -> do
-                now <- getCurrentTime
-                let seconds = max 1 (fromMaybe 60 retryAfterSeconds)
-                pure $ Left $ CredentialsExhausted
-                    { retryAt = addUTCTime (fromIntegral seconds) now
-                    , exhaustionReasons = [failureReason]
-                    }
-        Just FailedCredential
-            { failure = AccountAuthenticationRejected
-            } ->
-                pure $ Left $ CredentialError
-                    "static credential was rejected"
-
-lookupNonEmpty :: String -> IO (Maybe Text)
-lookupNonEmpty name = do
-    value <- Environment.getEnv (OsPath.unsafeEncodeUtf name)
-    pure $ case value of
-        Just raw
-            | Right text <- OsPath.decodeUtf raw
-            , not (null text) ->
-                Just (Text.pack text)
-        _ -> Nothing
+        Just reported -> credentialsExhaustedForRateLimit reported >>= \case
+            Just err -> pure (Left err)
+            Nothing -> pure $ Left $ CredentialError
+                "static credential was rejected"
 
 noAuthHint :: Text
 noAuthHint =

--- a/packages/agent-cli/src/Agent/CLI/Auth/Grok.hs
+++ b/packages/agent-cli/src/Agent/CLI/Auth/Grok.hs
@@ -17,6 +17,7 @@ import Agent.CLI.CredentialStore
     , upsertManagedCredentialAfterRefresh
     , withCredentialRefreshFileLock
     )
+import Agent.CLI.Environment (lookupNonEmpty)
 import Agent.Error (ApiError(..))
 import Agent.FileRetry (retryOnFileBusy)
 import qualified Agent.OpenAI.Auth as OpenAI
@@ -27,6 +28,7 @@ import Agent.Provider
     , FailedCredential(..)
     , Provider(XAIProvider)
     , TokenProvider
+    , credentialsExhaustedForRateLimit
     , tokenProvider
     )
 import qualified Agent.XAI.Auth as XAIAuth
@@ -42,13 +44,10 @@ import Data.IORef
     )
 import Data.Maybe (catMaybes, fromMaybe, listToMaybe)
 import Data.Text (Text)
-import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
 import Data.Time.Clock (UTCTime, addUTCTime, getCurrentTime)
 import System.Directory.OsPath (doesFileExist, getHomeDirectory)
 import System.OsPath (unsafeEncodeUtf, (</>))
-import qualified System.OsPath as OsPath
-import qualified System.Process.Environment.OsString as Environment
 
 loadExternalGrokCredentials :: IO [(Text, Credential)]
 loadExternalGrokCredentials = do
@@ -99,24 +98,19 @@ managedGrokCredential
 managedGrokCredential metadata secret stateRef refresh failed = do
     current <- readIORef stateRef
     case failed of
-        Just FailedCredential
-            { failure = AccountRateLimited { retryAfterSeconds }
-            , failureReason
-            } -> do
-                now <- getCurrentTime
-                let seconds = max 1 (fromMaybe 60 retryAfterSeconds)
-                pure $ Left $ CredentialsExhausted
-                    { retryAt = addUTCTime (fromIntegral seconds) now
-                    , exhaustionReasons = [failureReason]
+        Just reported -> credentialsExhaustedForRateLimit reported >>= \case
+            Just err -> pure (Left err)
+            Nothing -> case reported of
+                FailedCredential
+                    { credential = rejected
+                    , failure = AccountAuthenticationRejected
                     }
-        Just FailedCredential
-            { credential = rejected
-            , failure = AccountAuthenticationRejected
-            }
-            | rejected.accessToken /= current.grokAccessToken ->
-                pure (Right (grokCredentialFromState metadata current))
-            | otherwise ->
-                refreshManagedGrok metadata secret stateRef refresh current
+                    | rejected.accessToken /= current.grokAccessToken ->
+                        pure (Right (grokCredentialFromState metadata current))
+                    | otherwise ->
+                        refreshManagedGrok metadata secret stateRef refresh current
+                _ -> pure $ Left $ CredentialError
+                    "unsupported credential failure"
         Nothing -> do
             now <- getCurrentTime
             if grokNeedsRefresh now current
@@ -249,13 +243,3 @@ loadManagedCredentialById credentialId =
                     (filter
                         ((== credentialId) . (.managedId) . fst)
                         credentials))
-
-lookupNonEmpty :: String -> IO (Maybe Text)
-lookupNonEmpty name = do
-    value <- Environment.getEnv (OsPath.unsafeEncodeUtf name)
-    pure $ case value of
-        Just raw
-            | Right text <- OsPath.decodeUtf raw
-            , not (null text) ->
-                Just (Text.pack text)
-        _ -> Nothing

--- a/packages/agent-cli/src/Agent/CLI/Auth/OpenAI.hs
+++ b/packages/agent-cli/src/Agent/CLI/Auth/OpenAI.hs
@@ -19,6 +19,7 @@ import Agent.CLI.CredentialStore
     , loadManagedCredentials
     , updateManagedCredentialSecret
     )
+import Agent.CLI.Environment (lookupNonEmpty)
 import Agent.Error (ApiError(..))
 import Agent.FileRetry (retryOnFileBusy)
 import qualified Agent.OpenAI.Auth as OpenAI
@@ -64,7 +65,6 @@ import System.Directory.OsPath
     )
 import System.IO (SeekMode(AbsoluteSeek))
 import System.OsPath (OsPath, takeDirectory, unsafeEncodeUtf, (</>))
-import qualified System.OsPath as OsPath
 import System.Posix.Files (setFileMode)
 import System.Posix.IO
     ( LockRequest(Unlock, WriteLock)
@@ -77,7 +77,6 @@ import System.Posix.IO
     , waitToSetLock
     )
 import System.Posix.Types (Fd)
-import qualified System.Process.Environment.OsString as Environment
 
 -- | Pin normal checkouts to one OpenAI pool account until that credential is
 -- reported as failed. A failure for the selected credential clears the pin
@@ -550,15 +549,6 @@ openaiAccountIdForToken token = do
             <|> (fromIdToken >>= OpenAI.deriveAccountId)
             <|> OpenAI.deriveAccountId token
 
-lookupNonEmpty :: String -> IO (Maybe Text)
-lookupNonEmpty name = do
-    value <- Environment.getEnv (OsPath.unsafeEncodeUtf name)
-    pure $ case value of
-        Just raw
-            | Right text <- OsPath.decodeUtf raw
-            , not (null text) ->
-                Just (Text.pack text)
-        _ -> Nothing
 
 noAuthHint :: Text
 noAuthHint =

--- a/packages/agent-cli/src/Agent/CLI/CancelWatch.hs
+++ b/packages/agent-cli/src/Agent/CLI/CancelWatch.hs
@@ -7,6 +7,7 @@ module Agent.CLI.CancelWatch
     ) where
 
 import Agent.Cancel (CancelFlag, requestCancel)
+import Agent.CLI.Terminal (rawAttrs)
 import Control.Concurrent (forkIO, threadDelay)
 import Control.Concurrent.MVar (newEmptyMVar, putMVar, takeMVar)
 import Control.Exception.Safe (bracket, finally)
@@ -30,10 +31,7 @@ import System.Posix.Terminal
     , TerminalState(..)
     , getTerminalAttributes
     , setTerminalAttributes
-    , withMinInput
     , withMode
-    , withTime
-    , withoutMode
     )
 
 -- | Run @action@ while Esc on a TTY stdin requests soft cancel.
@@ -94,17 +92,6 @@ withStdinPaused paused action = do
                     hSetBuffering stdin activeBuf
                     writeIORef paused False
             bracket enter (const restore) (\_ -> action)
-
-rawAttrs :: TerminalAttributes -> TerminalAttributes
-rawAttrs oldTerm =
-    flip withMinInput 1
-        . flip withTime 0
-        . flip withoutMode EnableEcho
-        -- Non-canonical so VMIN/VTIME expose a lone Esc.
-        . flip withoutMode ProcessInput
-        -- Keep Ctrl-C as SIGINT / UserInterrupt.
-        . flip withMode KeyboardInterrupts
-        $ oldTerm
 
 cookedAttrs :: TerminalAttributes -> TerminalAttributes
 cookedAttrs term =

--- a/packages/agent-cli/src/Agent/CLI/Environment.hs
+++ b/packages/agent-cli/src/Agent/CLI/Environment.hs
@@ -1,0 +1,21 @@
+-- | Environment lookups used by the CLI.
+module Agent.CLI.Environment
+    ( lookupNonEmpty
+    ) where
+
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified System.Process.Environment.OsString as Environment
+import qualified System.OsPath as OsPath
+
+-- | Read a non-empty environment variable using the platform environment
+-- representation, decoding its value as UTF-8.
+lookupNonEmpty :: String -> IO (Maybe Text)
+lookupNonEmpty name = do
+    value <- Environment.getEnv (OsPath.unsafeEncodeUtf name)
+    pure $ case value of
+        Just raw
+            | Right text <- OsPath.decodeUtf raw
+            , not (null text) ->
+                Just (Text.pack text)
+        _ -> Nothing

--- a/packages/agent-cli/src/Agent/CLI/Login.hs
+++ b/packages/agent-cli/src/Agent/CLI/Login.hs
@@ -44,6 +44,7 @@ import Agent.CLI.Error
     ( formatApiErrorInlineAt
     , formatException
     )
+import Agent.CLI.Environment (lookupNonEmpty)
 import Agent.CLI.Input (readApprovalLine)
 import Agent.CLI.Picker
     ( PickerKey(..)
@@ -93,7 +94,6 @@ import qualified Data.Text.IO as Text
 import Data.Time.Clock (UTCTime, addUTCTime, getCurrentTime)
 import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
 import System.Directory.OsPath (doesFileExist, getHomeDirectory)
-import System.Environment (lookupEnv)
 import System.OsPath (OsPath, unsafeEncodeUtf, (</>))
 import System.IO
     ( hFlush
@@ -1034,10 +1034,3 @@ creditLines usage =
         [ ("credits remaining " <>) <$> usage.creditsRemaining
         , ("used " <>) <$> usage.creditsUsed
         ]
-
-lookupNonEmpty :: String -> IO (Maybe Text)
-lookupNonEmpty name = do
-    value <- lookupEnv name
-    pure case value of
-        Just text | not (null text) -> Just (Text.pack text)
-        _ -> Nothing

--- a/packages/agent-cli/src/Agent/CLI/Picker.hs
+++ b/packages/agent-cli/src/Agent/CLI/Picker.hs
@@ -50,7 +50,7 @@ import System.IO
 import System.IO.Error (isEOFError)
 import System.Posix.IO (stdInput)
 import System.Posix.Terminal
-    ( TerminalState(..)
+    ( TerminalState(Immediately)
     , getTerminalAttributes
     , setTerminalAttributes
     )

--- a/packages/agent-cli/src/Agent/CLI/Picker.hs
+++ b/packages/agent-cli/src/Agent/CLI/Picker.hs
@@ -18,6 +18,7 @@ import Agent.CLI.Terminal
     , emitTerminalSequence
     , kittyKeyboardPop
     , kittyKeyboardPush
+    , rawAttrs
     , stripAnsi
     , withSynchronizedOutput
     )
@@ -49,15 +50,9 @@ import System.IO
 import System.IO.Error (isEOFError)
 import System.Posix.IO (stdInput)
 import System.Posix.Terminal
-    ( TerminalAttributes
-    , TerminalMode(..)
-    , TerminalState(..)
+    ( TerminalState(..)
     , getTerminalAttributes
     , setTerminalAttributes
-    , withMinInput
-    , withMode
-    , withTime
-    , withoutMode
     )
 
 data PickerKey
@@ -349,15 +344,6 @@ readCsiTail = go []
         if char >= '@' && char <= '~'
             then pure (reverse accumulated)
             else go accumulated
-
-rawAttrs :: TerminalAttributes -> TerminalAttributes
-rawAttrs oldTerm =
-    flip withMinInput 1
-        . flip withTime 0
-        . flip withoutMode EnableEcho
-        . flip withoutMode ProcessInput
-        . flip withMode KeyboardInterrupts
-        $ oldTerm
 
 frameTop :: Handle -> Int -> IO (Maybe Int)
 frameTop handle lineCount =

--- a/packages/agent-cli/src/Agent/CLI/Terminal.hs
+++ b/packages/agent-cli/src/Agent/CLI/Terminal.hs
@@ -2,6 +2,7 @@
 module Agent.CLI.Terminal
     ( TerminalKind(..)
     , TerminalCapabilities(..)
+    , rawAttrs
     , detectTerminalCapabilities
     , formatTerminalCapabilities
     , resolveColor
@@ -42,6 +43,27 @@ import qualified Data.Text.IO as Text
 import Numeric (showHex)
 import System.Environment (lookupEnv)
 import System.IO (Handle, hFlush, hIsTerminalDevice)
+import System.Posix.Terminal
+    ( TerminalAttributes
+    , TerminalMode(..)
+    , withMinInput
+    , withMode
+    , withTime
+    , withoutMode
+    )
+
+-- | Put terminal input in the raw mode used by interactive overlays and the
+-- Esc cancellation watcher.
+rawAttrs :: TerminalAttributes -> TerminalAttributes
+rawAttrs oldTerm =
+    flip withMinInput 1
+        . flip withTime 0
+        . flip withoutMode EnableEcho
+        -- Non-canonical so VMIN/VTIME expose a lone Esc.
+        . flip withoutMode ProcessInput
+        -- Keep Ctrl-C as SIGINT / UserInterrupt.
+        . flip withMode KeyboardInterrupts
+        $ oldTerm
 
 data TerminalKind
     = TerminalGhostty

--- a/packages/agent-cli/test/Agent/CLI/EnvironmentSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/EnvironmentSpec.hs
@@ -1,0 +1,27 @@
+module Agent.CLI.EnvironmentSpec (spec) where
+
+import Agent.CLI.Environment (lookupNonEmpty)
+import Control.Exception (bracket_)
+import System.Environment (lookupEnv, setEnv, unsetEnv)
+import Test.Hspec
+
+spec :: Spec
+spec = describe "lookupNonEmpty" do
+    it "treats empty values as absent" do
+        withEnvironment "AGENT_CLI_ENVIRONMENT_SPEC" (Just "") do
+            lookupNonEmpty "AGENT_CLI_ENVIRONMENT_SPEC"
+                `shouldReturn` Nothing
+
+    it "decodes UTF-8 environment values" do
+        withEnvironment "AGENT_CLI_ENVIRONMENT_SPEC" (Just "café 🚀") do
+            lookupNonEmpty "AGENT_CLI_ENVIRONMENT_SPEC"
+                `shouldReturn` Just "café 🚀"
+
+withEnvironment :: String -> Maybe String -> IO a -> IO a
+withEnvironment name value action = do
+    previous <- lookupEnv name
+    bracket_ (setValue value) (setValue previous) action
+  where
+    setValue = \case
+        Nothing -> unsetEnv name
+        Just content -> setEnv name content

--- a/packages/agent-cli/test/Agent/CLI/EnvironmentSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/EnvironmentSpec.hs
@@ -1,7 +1,7 @@
 module Agent.CLI.EnvironmentSpec (spec) where
 
 import Agent.CLI.Environment (lookupNonEmpty)
-import Control.Exception (bracket_)
+import Control.Exception.Safe (bracket_)
 import System.Environment (lookupEnv, setEnv, unsetEnv)
 import Test.Hspec
 

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -18,6 +18,7 @@ import qualified Agent.CLI.ConnectivitySpec as ConnectivitySpec
 import qualified Agent.CLI.CredentialStoreSpec as CredentialStoreSpec
 import qualified Agent.CLI.DialectsSpec as DialectsSpec
 import qualified Agent.CLI.DatabaseSpec as DatabaseSpec
+import qualified Agent.CLI.EnvironmentSpec as EnvironmentSpec
 import qualified Agent.CLI.ErrorSpec as ErrorSpec
 import qualified Agent.CLI.ImagePreviewSpec as ImagePreviewSpec
 import qualified Agent.CLI.InputSpec as InputSpec
@@ -84,6 +85,7 @@ main = hspec do
     CredentialStoreSpec.spec
     DialectsSpec.spec
     DatabaseSpec.spec
+    EnvironmentSpec.spec
     ErrorSpec.spec
     ImagePreviewSpec.spec
     InputSpec.spec

--- a/packages/agent-core/src/Agent/Provider.hs
+++ b/packages/agent-core/src/Agent/Provider.hs
@@ -16,6 +16,7 @@ module Agent.Provider
     , seedTokenProvider
     , accountFailureFromApiError
     , accountFailureReason
+    , credentialsExhaustedForRateLimit
     ) where
 
 import Agent.Error
@@ -29,6 +30,7 @@ import qualified Data.Aeson as Aeson
 import Data.IORef
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
+import Data.Time.Clock (addUTCTime, getCurrentTime)
 
 data Provider
     = OpenAIProvider
@@ -214,3 +216,20 @@ accountFailureReason err failure =
                 { exhaustionErrorType = Nothing
                 , exhaustionStatusCode = Nothing
                 }
+
+-- | Convert a rate-limited credential report into the shared cooldown error.
+-- Other failure kinds do not represent a provider-wide exhaustion window.
+credentialsExhaustedForRateLimit
+    :: FailedCredential
+    -> IO (Maybe ApiError)
+credentialsExhaustedForRateLimit FailedCredential
+    { failure = AccountRateLimited { retryAfterSeconds }
+    , failureReason
+    } = do
+    now <- getCurrentTime
+    let seconds = max 1 (fromMaybe 60 retryAfterSeconds)
+    pure $ Just $ CredentialsExhausted
+        { retryAt = addUTCTime (fromIntegral seconds) now
+        , exhaustionReasons = [failureReason]
+        }
+credentialsExhaustedForRateLimit _ = pure Nothing


### PR DESCRIPTION
## Summary
- centralize raw terminal attribute setup
- share UTF-8-safe non-empty environment lookup
- share rate-limit credential exhaustion construction
- add environment lookup coverage

## Validation
- `TMPDIR=/tmp/ha nix develop -c cabal test agent-cli:agent-cli-test --offline --test-show-details=direct`
- 848 examples, 0 failures
- real tmux TTY smoke: launched the live agent from `cabal repl`, opened `/model`, captured the picker, cancelled with `q`, and confirmed the normal prompt was restored

CLI changes are limited to terminal/auth helper plumbing; no credential-source precedence changes.