### PR TITLE
fix(tui): align conversation timestamps

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -2533,17 +2533,18 @@ drawBlock state block =
                             (txtWrap block.blockBody)
             BlockAssistant ->
                 padLeft (Pad 3) $
-                    timestampedMessage block.blockTimestamp $
-                        withAttr Theme.assistantAttr
-                            (markdownWidgetWithSyntaxHighlighting
-                                state.appSyntaxHighlighter
-                                (\codeIndex ->
-                                    cached
-                                        (CodeBlockCache
-                                            block.blockId
-                                            codeIndex))
-                                (codeBlockHeader state block.blockId)
-                                block.blockBody)
+                    padRight (Pad 1) $
+                        timestampedMessage block.blockTimestamp $
+                            withAttr Theme.assistantAttr
+                                (markdownWidgetWithSyntaxHighlighting
+                                    state.appSyntaxHighlighter
+                                    (\codeIndex ->
+                                        cached
+                                            (CodeBlockCache
+                                                block.blockId
+                                                codeIndex))
+                                    (codeBlockHeader state block.blockId)
+                                    block.blockBody)
             BlockThinking ->
                 accentBlock (thinkingBlockAttr state block)
                     (blockStateGlyph state block <> block.blockTitle)


### PR DESCRIPTION
## Summary
- give assistant messages the same one-cell right inset as user messages
- align user and assistant timestamps to the same terminal column

## Verification
- loaded `Agent.CLI.TUI.App` successfully in GHCi
- exercised the fullscreen UI in tmux with a new user/assistant exchange and confirmed both timestamps end in the same column
- `git diff --check`