### PR TITLE
Run /btw side questions immediately

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -1268,6 +1268,7 @@ prepareAgentIteration
                     setFullscreenSessionActions
                         runtime
                         (requestCancel toolEnv.toolCancel)
+                        (const (pure ()))
                         (\level ->
                             readIORef restartEffortActionRef >>= ($ level))
                         (noteFullscreenCtrlC interrupt)
@@ -1320,6 +1321,7 @@ resetFullscreenSessionActions runtime =
     setFullscreenSessionActions
         runtime
         (pure ())
+        (const (pure ()))
         (const (pure ()))
         -- No session-local interrupt state is alive between providers. A
         -- transition must remain escapable even if auth probing blocks.
@@ -3687,6 +3689,18 @@ runSession catalog connectionId options provider dialect policy allTools mcpRegi
         setSessionEffort env level
         writeIORef restartEffortRef (Just level)
         requestCancel toolEnv.toolCancel
+    btwRequests <- newChan
+    forM_ fullscreen \runtime ->
+        setFullscreenSessionActions
+            runtime
+            (requestCancel toolEnv.toolCancel)
+            (writeChan btwRequests)
+            (\level ->
+                readIORef startup.startupRestartEffort >>= ($ level))
+            (noteFullscreenCtrlC interrupt)
+            (readIORef startup.startupAgentSnapshot >>= id)
+            (\target ->
+                readIORef startup.startupAgentSelect >>= ($ target))
     let initializeSkills = do
             markStartupStage startup "Loading skills…"
             skills <- loadSkillsCatalogQuiet
@@ -3721,7 +3735,13 @@ runSession catalog connectionId options provider dialect policy allTools mcpRegi
                     Nothing ->
                         readIORef startup.startupSessionState.sessionDraft
                             >>= replWithDraft env
-    result <- sessionAction
+        btwWorker = do
+            question <- readChan btwRequests
+            runBtwQuestion False env question
+            btwWorker
+    result <- case fullscreen of
+        Just _ -> withAsync btwWorker (const sessionAction)
+        Nothing -> sessionAction
     _ <- waitForSessionTitleResults 5000000 titleManager
     applyPendingSessionTitles env
     pure result
@@ -4145,13 +4165,55 @@ setSessionEffort env level = do
                     writeIORef slotRef
                         (PersistenceActive handle { sessionMeta = meta })
 
+runBtwQuestion :: Bool -> SessionEnv -> Text -> IO ()
+runBtwQuestion registerCancel env question = do
+    let fullscreen = env.sessionFullscreen
+    color <- resolveColor stdout
+    forM_ fullscreen \runtime ->
+        emitUiEvent runtime
+            (UiSetNotice (Just (progressNotice "btw · asking…")))
+    result <-
+        runBtwWithCancel
+            (\cancel action ->
+                if registerCancel
+                    then
+                        withTurnCancel env.sessionInterrupt cancel $
+                            case fullscreen of
+                                Nothing ->
+                                    withEscCancel
+                                        cancel
+                                        env.sessionEscPaused
+                                        action
+                                Just _ -> action
+                    else action)
+            env.sessionBtwBackend
+            env.sessionParams
+            env.sessionTranscript
+            question
+    forM_ fullscreen \runtime ->
+        emitUiEvent runtime (UiSetNotice Nothing)
+    case result of
+        Left err -> do
+            errorColor <- resolveColor stderr
+            let message = formatBtwError err
+            case fullscreen of
+                Just runtime ->
+                    emitUiEvent runtime (UiErrorMessage message)
+                Nothing ->
+                    putTextLn stderr (roleError errorColor message)
+        Right answer ->
+            case fullscreen of
+                Just runtime ->
+                    emitUiEvent runtime (UiAssistantHistory answer)
+                Nothing ->
+                    putTextLn stdout (renderAssistantText color answer)
+
 repl :: SessionEnv -> IO RunResult
 repl env = replWithDraft env ""
 
 replWithDraft :: SessionEnv -> Text -> IO RunResult
 replWithDraft env@SessionEnv
-    { sessionBtwBackend = btwBackend
-    , sessionCompact = compactRunner
+    { sessionCompact = compactRunner
     , sessionRender = render
     , sessionProvider = provider
     , sessionConnection = connectionId
@@ -4162,7 +4224,6 @@ replWithDraft env@SessionEnv
     , sessionPrinted = printed
     , sessionParams = paramsRef
     , sessionPolicy = policyRef
-    , sessionTranscript = transcriptRef
     , sessionPersist = persist
     , sessionDatabasePool = databasePool
     , sessionPlanMode = planMode
@@ -4177,7 +4238,6 @@ replWithDraft env@SessionEnv
     , sessionAttachments = attachmentsRef
     , sessionPreviewId = previewIdRef
     , sessionInterrupt = interrupt
-    , sessionEscPaused = escPaused
     , sessionStoreRoot = storeRoot
     , sessionUsage = usageRef
     , sessionAccount = accountRef
@@ -4874,40 +4934,7 @@ replWithDraft env@SessionEnv
                                 pure (RunSwitchProvider providerSwitch)
                             Nothing -> continue
                     ReplBtw question -> do
-                        color <- resolveColor stdout
-                        fullscreenEvent
-                            (UiSetNotice
-                                (Just
-                                    (progressNotice
-                                        "btw · asking…")))
-                        result <-
-                            runBtwWithCancel
-                                (\cancel action ->
-                                    withTurnCancel interrupt cancel $
-                                        case fullscreen of
-                                            Nothing ->
-                                                withEscCancel
-                                                    cancel escPaused action
-                                            Just _ -> action)
-                                btwBackend
-                                paramsRef
-                                transcriptRef
-                                question
-                        case result of
-                            Left err -> do
-                                errorColor <- resolveColor stderr
-                                let message = formatBtwError err
-                                displayError message $
-                                    putTextLn stderr
-                                        (roleError errorColor message)
-                            Right answer ->
-                                case fullscreen of
-                                    Just runtime ->
-                                        emitUiEvent runtime
-                                            (UiAssistantHistory answer)
-                                    Nothing ->
-                                        putTextLn stdout
-                                            (renderAssistantText color answer)
+                        runBtwQuestion True env question
                         continue
                     ReplResume maybeId -> do
                         handleResume databasePool fullscreen maybeId persist >>= \case

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -276,6 +276,7 @@ newFullscreenRuntimeWithSyntaxLoader
         imagePreviewInTmux <- isJust <$> lookupEnv "TMUX"
         sessionActions <- newIORef FullscreenSessionActions
             { sessionCancel = cancelAction
+            , sessionBtw = const (pure ())
             , sessionRestartEffort = restartEffortAction
             , sessionCtrlC = ctrlCAction
             , sessionAgentSnapshot = agentSnapshot
@@ -287,6 +288,9 @@ newFullscreenRuntimeWithSyntaxLoader
             , runtimeInput = inputBuffer
             , runtimeCancel =
                 readIORef sessionActions >>= (.sessionCancel)
+            , runtimeBtw = \question ->
+                readIORef sessionActions >>= \actions ->
+                    actions.sessionBtw question
             , runtimeRestartEffort = \level ->
                 readIORef sessionActions >>= \actions ->
                     actions.sessionRestartEffort level
@@ -322,6 +326,7 @@ setFullscreenSessionActions
     :: FullscreenRuntime
     -> IO ()
     -> (Text -> IO ())
+    -> (Text -> IO ())
     -> IO CtrlCDecision
     -> IO (AgentTarget, [AgentEntry])
     -> (AgentTarget -> IO ())
@@ -329,12 +334,14 @@ setFullscreenSessionActions
 setFullscreenSessionActions
     runtime
     cancelAction
+    btwAction
     restartEffortAction
     ctrlCAction
     agentSnapshot
     agentSelect =
         writeIORef runtime.runtimeSessionActions FullscreenSessionActions
             { sessionCancel = cancelAction
+            , sessionBtw = btwAction
             , sessionRestartEffort = restartEffortAction
             , sessionCtrlC = ctrlCAction
             , sessionAgentSnapshot = agentSnapshot

--- a/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
@@ -17,6 +17,7 @@ module Agent.CLI.TUI.Composer
     , handleControlMouseUp
     , handleEffortControlClick
     , handlePromptControlClick
+    , immediateBtwQuestion
     , newFullscreenInputBuffer
     , promoteFullscreenInput
     , queuedFullscreenInputDisplays
@@ -31,8 +32,10 @@ import Agent.CLI.Clipboard
     , readClipboardText
     )
 import Agent.CLI.Command
-    ( SlashMenu(..)
+    ( ReplAction(..)
+    , SlashMenu(..)
     , SlashSuggestion(..)
+    , parseReplLine
     , slashMenuForWithSkillsAndModels
     )
 import Agent.CLI.Input
@@ -635,11 +638,17 @@ handleComposerKey
 
     submitText state text pasted = do
         liftIO (appendReplHistory text)
-        enqueueInput
-            state
-            (if pasted then ReplPasted text else ReplText text)
-            (Just text)
-            True
+        let replLine = if pasted then ReplPasted text else ReplText text
+        case immediateBtwQuestion state.appUi replLine of
+            Just question -> do
+                applyUiEvent UiDraftSubmitted \current ->
+                    current
+                        { appSlashIndex = 0
+                        , appSlashDismissed = False
+                        }
+                liftIO (state.appRuntime.runtimeBtw question)
+            Nothing ->
+                enqueueInput state replLine (Just text) True
         modify' \current ->
             current
                 { appPasted = False
@@ -894,6 +903,22 @@ handleComposerKey
                 menu.slashMenuReplaceStart
                     + Text.length suggestion.slashSuggestionReplacement
         modifyUiResetSlash (UiSetDraft next cursor)
+
+-- | Side questions are independent requests and should not wait behind the
+-- active turn's ordinary follow-up queue.
+immediateBtwQuestion :: UiState -> ReplLine -> Maybe Text
+immediateBtwQuestion ui replLine
+    | not ui.uiRunning = Nothing
+    | otherwise =
+        case replLine of
+            ReplText text -> fromText text
+            ReplPasted text -> fromText text
+            _ -> Nothing
+  where
+    fromText text =
+        case parseReplLine text of
+            ReplBtw question -> Just question
+            _ -> Nothing
 
 applyComposerUiEvent :: UiEvent -> AppState -> AppState
 applyComposerUiEvent uiEvent state =

--- a/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
@@ -131,6 +131,7 @@ data FullscreenRuntime = FullscreenRuntime
     , runtimeMailbox :: !AppEventMailbox
     , runtimeInput :: !FullscreenInputBuffer
     , runtimeCancel :: !(IO ())
+    , runtimeBtw :: !(Text -> IO ())
     , runtimeRestartEffort :: !(Text -> IO ())
     , runtimeCtrlC :: !(IO CtrlCDecision)
     , runtimeCopy :: !(Text -> IO Bool)
@@ -160,6 +161,7 @@ data FullscreenRuntime = FullscreenRuntime
 -- resources belonging to a backend that has already shut down.
 data FullscreenSessionActions = FullscreenSessionActions
     { sessionCancel :: !(IO ())
+    , sessionBtw :: !(Text -> IO ())
     , sessionRestartEffort :: !(Text -> IO ())
     , sessionCtrlC :: !(IO CtrlCDecision)
     , sessionAgentSnapshot :: !(IO (AgentTarget, [AgentEntry]))

--- a/packages/agent-cli/test/Agent/CLI/TUIBridgeSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIBridgeSpec.hs
@@ -144,16 +144,18 @@ spec = describe "fullscreen TUI bridge" do
         setFullscreenSessionActions
             runtime
             (modifyIORef' calls (<> ["new cancel"]))
+            (const (modifyIORef' calls (<> ["new btw"])))
             (const (modifyIORef' calls (<> ["new effort"])))
             (pure SoftCancel)
             (pure (AgentRoot, []))
             (const (modifyIORef' calls (<> ["new agent"])))
         runtime.runtimeCancel
+        runtime.runtimeBtw "question"
         runtime.runtimeRestartEffort "high"
         runtime.runtimeAgentSelect AgentRoot
         decision <- runtime.runtimeCtrlC
         readIORef calls `shouldReturn`
-            ["old cancel", "new cancel", "new effort", "new agent"]
+            ["old cancel", "new cancel", "new btw", "new effort", "new agent"]
         decision `shouldBe` SoftCancel
 
     it "defers syntax loading until the runtime starts it" do

--- a/packages/agent-cli/test/Agent/CLI/TUIComposerSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIComposerSpec.hs
@@ -3,6 +3,7 @@ module Agent.CLI.TUIComposerSpec (spec) where
 import Agent.CLI.Input (ReplLine(..))
 import Agent.CLI.TUI.Composer
 import Agent.CLI.TUI.Types
+import Agent.TUI.Model (UiState(..), initialUiState)
 import Control.Concurrent.STM (atomically)
 import qualified Data.ByteString as ByteString
 import Data.Foldable (toList)
@@ -15,6 +16,20 @@ spec = describe "fullscreen composer" do
     it "cancels a running turn even when the slash menu is open" do
         composerEscapeAction False True
             `shouldBe` EscapeCancelTurn
+
+    it "runs /btw immediately only while a turn is active" do
+        immediateBtwQuestion
+            initialUiState { uiRunning = True }
+            (ReplText "/btw why?")
+            `shouldBe` Just "why?"
+        immediateBtwQuestion
+            initialUiState
+            (ReplText "/btw why?")
+            `shouldBe` Nothing
+        immediateBtwQuestion
+            initialUiState { uiRunning = True }
+            (ReplText "ordinary follow-up")
+            `shouldBe` Nothing
 
     it "dismisses slash completion or clears the draft while idle" do
         composerEscapeAction True True


### PR DESCRIPTION
## Summary

- detect `/btw` submissions in the fullscreen composer while a turn is active
- dispatch side questions through a session-scoped worker instead of the ordinary follow-up queue
- preserve the main turn's cancellation target while the independent side request runs
- keep idle `/btw` behavior unchanged and clear its progress notice on completion
- cover immediate command detection and session callback rebinding

## Verification

- `printf ':quit\n' | nix develop -c cabal repl agent-cli:lib:agent-cli`
- agent-cli test REPL: fullscreen composer tests (13 examples, 0 failures)
- agent-cli test REPL: provider-specific action rebinding test (1 example, 0 failures)
- tmux smoke test: `/btw` returned its answer while the main turn remained blocked on a tool permission prompt
- `git diff --check`
