### PR TITLE
feat(telegram): add managed gateway parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,21 +133,42 @@ Setup reads the BotFather token without terminal echo, validates it against
 Telegram, and stores it separately from the non-secret gateway configuration.
 Never paste the bot token into an agent conversation.
 
-Only messages from allowlisted Telegram users are handled. Private chats work
-directly. In groups and supergroups, mention the bot, use a command addressed
-to its username (for example `/new@your_bot`), or reply to one of its messages.
-Ambient group traffic and messages from non-allowlisted members are ignored.
+Only messages from allowlisted Telegram users are handled. Repeat
+`--allowed-user` during setup, or manage the local allowlist later with
+`agent-telegram users list|add ID|remove ID`; running gateways must be restarted
+after an allowlist change. Private chats work directly. In groups and
+supergroups, mention the bot, use a command addressed to its username (for
+example `/new@your_bot`), or reply to one of its messages. Ambient group traffic
+and messages from non-allowlisted members are ignored.
+
 Each private chat, group, and forum topic is mapped to its own persisted agent
-session under `~/.haskell-agent`; `/new` starts a fresh session and `/session`
-shows the current session ID. Group replies include the sender's identity in
-the agent prompt and are posted as replies to the triggering Telegram message.
-Mutating tools are denied unless setup is run with `--yolo`. Use
-`agent-telegram stop` to stop the background gateway.
+session under `~/.haskell-agent`; `/new` starts a fresh session, `/session`
+shows the current session ID, `/status` reports queued/retrying/failed work,
+and `/retry` requeues the latest failed turn. Group replies include the
+sender's identity in the agent prompt and are posted as replies to the
+triggering Telegram message.
+
+The default approval mode asks through Telegram inline buttons when a mutating
+tool is requested. `--deny-mutations` disables those tools and `--yolo`
+auto-approves them. Approval and choice callbacks are scoped to the originating
+conversation and allowlisted user.
 
 Incoming updates and pending replies are persisted before they are processed.
 Polling continues while agent turns run, conversations are processed in order,
-and separate chats can run concurrently. Pending work resumes when the gateway
-is restarted.
+and separate chats can run concurrently through a bounded worker pool. Pending
+work, callback bindings, retry schedules, delivery checkpoints, and dead
+letters resume when the gateway is restarted. Telegram 429/5xx responses and
+transient turn failures use bounded backoff; agent turns have a 20-minute
+deadline.
+
+The gateway accepts edited messages, reactions, photos, documents, audio,
+video, video notes, animations, stickers, locations, contacts, venues, polls,
+and dice. Images are sent to multimodal providers natively; other downloaded
+files are attached through Responses `input_file` content or a private local
+path fallback. The agent can send documents, photos, and voice files, react to
+messages, and ask generic inline-button questions through gateway-scoped tools.
+Bot credentials remain in the parent gateway process and are never inherited
+by the agent child.
 
 The built-in `telegram-agent` skill lets the normal agent guide this setup.
 Ask it to “set up a Telegram agent”; it will explain the BotFather steps,

--- a/packages/agent-claude/agent-claude.cabal
+++ b/packages/agent-claude/agent-claude.cabal
@@ -52,6 +52,7 @@ library
                     , bytestring
                     , containers
                     , directory
+                    , filepath
                     , process               >= 1.6.26
                     , safe-exceptions
                     , text

--- a/packages/agent-claude/package.nix
+++ b/packages/agent-claude/package.nix
@@ -1,21 +1,21 @@
-{ mkDerivation, aeson, agent-core, agent-responses, agent-responses-types, base
-, bytestring, claude-agent-sdk-haskell, containers, directory
-, filepath, hspec, lib, process, safe-exceptions, text, unix
-, uuid-types
+{ mkDerivation, aeson, agent-core, agent-responses
+, agent-responses-types, base, bytestring, claude-agent-sdk-haskell
+, containers, directory, filepath, hspec, lib, process
+, safe-exceptions, text, unix, uuid-types
 }:
 mkDerivation {
   pname = "agent-claude";
   version = "0.1.0.0";
   src = ./.;
   libraryHaskellDepends = [
-    aeson agent-core agent-responses agent-responses-types base bytestring
-    claude-agent-sdk-haskell containers directory process
-    safe-exceptions text uuid-types
+    aeson agent-core agent-responses agent-responses-types base
+    bytestring claude-agent-sdk-haskell containers directory filepath
+    process safe-exceptions text uuid-types
   ];
   testHaskellDepends = [
     agent-core agent-responses agent-responses-types base bytestring
-    claude-agent-sdk-haskell
-    directory filepath hspec safe-exceptions text unix
+    claude-agent-sdk-haskell directory filepath hspec safe-exceptions
+    text unix
   ];
   description = "Claude Code subscription adapter for Agent.Loop";
   license = lib.meta.getLicenseFromSpdxId "MIT";

--- a/packages/agent-claude/src/Agent/Claude/LoopBackend.hs
+++ b/packages/agent-claude/src/Agent/Claude/LoopBackend.hs
@@ -22,6 +22,7 @@ import Agent.InterAgentMessage (renderInterAgentMessage)
 import Agent.Loop
     ( Backend(..)
     , BackendResult(..)
+    , FileAttachment(..)
     , ImageAttachment(..)
     , LoopEvent(..)
     , TokenUsage(..)
@@ -56,6 +57,7 @@ import Claude.Agent.SDK.Client
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.KeyMap as KeyMap
 import qualified Data.ByteString.Lazy as LazyByteString
+import qualified Data.Char as Char
 import Data.IORef
     ( IORef
     , atomicModifyIORef'
@@ -70,6 +72,9 @@ import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
 import Data.Text.Encoding.Error (lenientDecode)
 import qualified Data.UUID.Types as UUID
+import qualified System.Directory as Directory
+import System.FilePath (takeExtension)
+import System.IO (hClose, openBinaryTempFile)
 import System.Mem.StableName
     ( StableName
     , eqStableName
@@ -91,6 +96,8 @@ import Claude.Agent.SDK.Types
     , Usage(..)
     , messageHasParentToolUseId
     )
+import Control.Exception.Safe (bracket, tryAny)
+import Control.Monad (void)
 
 data HostTranscriptCheckpoint = HostTranscriptCheckpoint
     { checkpointTranscript :: !(StableName [ResponseItem])
@@ -188,60 +195,69 @@ submitClaudeCodeTurn
     inputs
     onEvent =
     do
-        let (inputText, inputImages) = collectTurnInputs inputs
-        params <- getParams
-        let previousSession =
-                previous >>= canonicalClaudeSessionId
-        result <- withClaudeSDKTurn
-            session
-            (hostTranscriptMatches
-                checkpoint
-                transcript
-                previousSession)
-            previousSession
-            params.model
-            (params.reasoning >>= (.effort))
-            \turn -> do
-                history <- readIORef transcript
-                messages <- newIORef []
-                let prompt =
-                        buildClaudePrompt
-                            params
-                            (turnIsNewSession turn)
-                            history
-                            inputText
-                    content =
-                        claudeUserContent inputImages prompt
-                awaitResult <-
-                    queryTurnContentWithMessageValidator
-                        turn
-                        content
-                        validateSubscriptionMessage
-                        (\message ->
-                            modifyIORef' messages (message :))
-                case awaitResult of
-                    Left sdkError ->
-                        pure (Left sdkError)
-                    Right result -> do
-                        turnMessages <- reverse <$> readIORef messages
-                        case interpretClaudeTurn turnMessages result of
-                            Left message ->
-                                pure $
-                                    Left ResultError
-                                        { subtype = "authentication_error"
-                                        , apiErrorStatus = Nothing
-                                        , errors = [message]
-                                        , result = Nothing
-                                        }
-                            Right completed -> do
-                                completeTurn
-                                    turn
-                                    completed
-                                    result
-                                    inputs
-                                    onEvent
-        pure (either (Left . sdkErrorToApiError) Right result)
+        bracket
+            (collectTurnInputs inputs)
+            (cleanupCollectedTurnInputs . snd3)
+            \(inputText, inputImages, _inputFiles) -> do
+                params <- getParams
+                let previousSession =
+                        previous >>= canonicalClaudeSessionId
+                result <- withClaudeSDKTurn
+                    session
+                    (hostTranscriptMatches
+                        checkpoint
+                        transcript
+                        previousSession)
+                    previousSession
+                    params.model
+                    (params.reasoning >>= (.effort))
+                    \turn -> do
+                        history <- readIORef transcript
+                        messages <- newIORef []
+                        let prompt =
+                                buildClaudePrompt
+                                    params
+                                    (turnIsNewSession turn)
+                                    history
+                                    inputText
+                            content =
+                                claudeUserContent inputImages prompt
+                        awaitResult <-
+                            queryTurnContentWithMessageValidator
+                                turn
+                                content
+                                validateSubscriptionMessage
+                                (\message ->
+                                    modifyIORef' messages (message :))
+                        case awaitResult of
+                            Left sdkError ->
+                                pure (Left sdkError)
+                            Right result -> do
+                                turnMessages <- reverse <$> readIORef messages
+                                case interpretClaudeTurn turnMessages result of
+                                    Left message ->
+                                        pure $
+                                            Left ResultError
+                                                { subtype = "authentication_error"
+                                                , apiErrorStatus = Nothing
+                                                , errors = [message]
+                                                , result = Nothing
+                                                }
+                                    Right completed -> do
+                                        completeTurn
+                                            turn
+                                            completed
+                                            result
+                                            inputs
+                                            onEvent
+                pure (either (Left . sdkErrorToApiError) Right result)
   where
+    snd3 (_, _, c) = c
+
+    cleanupCollectedTurnInputs :: [FilePath] -> IO ()
+    cleanupCollectedTurnInputs = mapM_ \path ->
+        void (tryAny (Directory.removeFile path))
+
     completeTurn
         :: ClaudeSDKTurn
         -> CompletedClaudeTurn
@@ -272,11 +288,17 @@ submitClaudeCodeTurn
         mapM_ onEvent completed.events
         pure (Right (output, commit))
 
-collectTurnInputs :: [TurnInput] -> (Text, [ImageAttachment])
-collectTurnInputs inputs =
-    ( Text.intercalate "\n\n" (concatMap inputText inputs)
-    , concatMap inputImages inputs
-    )
+collectTurnInputs :: [TurnInput] -> IO (Text, [ImageAttachment], [FilePath])
+collectTurnInputs inputs = do
+    fileInputs <- fmap concat (mapM inputFiles inputs)
+    pure
+        ( Text.intercalate "\n\n"
+            ( concatMap inputText inputs
+                <> map fst fileInputs
+            )
+        , concatMap inputImages inputs
+        , map snd fileInputs
+        )
   where
     inputText = \case
         UserMessage text ->
@@ -284,6 +306,8 @@ collectTurnInputs inputs =
         AgentMessage message ->
             [renderInterAgentMessage message]
         UserMultimodal{userText} ->
+            [userText]
+        UserMultimodalFiles{userText} ->
             [userText]
         CompletedTool
             (ToolDispatch.ToolCallResult resultCallId resultOutput _) ->
@@ -294,7 +318,38 @@ collectTurnInputs inputs =
                     <> resultOutput
     inputImages = \case
         UserMultimodal{userImages} -> userImages
+        UserMultimodalFiles{userImages} -> userImages
         _ -> []
+    inputFiles = \case
+        UserMultimodalFiles{userFiles} -> mapM writeFallbackFile userFiles
+        _ -> pure []
+
+    writeFallbackFile :: FileAttachment -> IO (Text, FilePath)
+    writeFallbackFile FileAttachment{fileName, fileMime, fileBytes} = do
+        tmpDir <- Directory.getTemporaryDirectory
+        let prefix =
+                maybe "attachment" sanitizePrefix fileName
+                <> fromMaybe "" (fileName >>= nonEmptyExtension)
+        (path, handle) <- openBinaryTempFile tmpDir prefix
+        hClose handle
+        LazyByteString.writeFile path (LazyByteString.fromStrict fileBytes)
+        pure
+            ( Text.unlines
+                [ "[Attached file]"
+                , "name: " <> fromMaybe "unknown" fileName
+                , "mime: " <> fileMime
+                , "path: " <> Text.pack path
+                ]
+            , path
+            )
+
+    sanitizePrefix = Text.unpack . Text.filter validPrefixChar
+    nonEmptyExtension name =
+        case takeExtension (Text.unpack name) of
+            "" -> Nothing
+            extension -> Just extension
+    validPrefixChar char =
+        Char.isAlphaNum char || char == '-' || char == '_'
 
 claudeUserContent
     :: [ImageAttachment]

--- a/packages/agent-claude/test/Agent/Claude/LoopBackendSpec.hs
+++ b/packages/agent-claude/test/Agent/Claude/LoopBackendSpec.hs
@@ -13,6 +13,7 @@ import Agent.Error (ApiError(..), ErrorType(..))
 import Agent.Loop
     ( Backend(..)
     , BackendResult(..)
+    , FileAttachment(..)
     , ImageAttachment(..)
     , LoopEvent(..)
     , TokenUsage(..)
@@ -225,6 +226,43 @@ spec = do
                     _ ->
                         expectationFailure
                             "multimodal user input was not persisted"
+
+        it "includes attached files in the Claude prompt fallback" $
+            withFakeClaude \fake -> do
+                transcript <- newIORef []
+                result <- timeout 5_000_000 $ do
+                    let filePath = fake.workingDirectory <> "/attachment.txt"
+                    writeFile filePath "file-bytes"
+                    withClaudeCodeBackend
+                        (defaultClaudeCodeOptions
+                            fake.executable
+                            fake.workingDirectory)
+                        Nothing
+                        (pure defaultResponseCreateParams)
+                        transcript
+                        \backend ->
+                            submitBackend backend
+                                Nothing
+                                [ UserMultimodalFiles
+                                    { userText = "describe this file"
+                                    , userImages = []
+                                    , userFiles =
+                                        [ FileAttachment
+                                            { fileName = Just "attachment.txt"
+                                            , fileMime = "text/plain"
+                                            , fileBytes = "file-bytes"
+                                            }
+                                        ]
+                                    }
+                                ]
+                                (\_ -> pure ())
+                result `shouldSatisfy` \case
+                    Just (Right _) -> True
+                    _ -> False
+                submitted <- readFile fake.promptLog
+                submitted `shouldContain` "[Attached file]"
+                submitted `shouldContain` "attachment.txt"
+                submitted `shouldContain` "describe this file"
 
         it "converts cumulative modelUsage snapshots to per-turn deltas" $
             withFakeClaude \fake -> do

--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -66,6 +66,7 @@ library
                     , Agent.CLI.Dialects
                     , Agent.CLI.Error
                     , Agent.CLI.ImagePreview
+                    , Agent.CLI.GatewayBridge
                     , Agent.CLI.Input
                     , Agent.CLI.Input.Types
                     , Agent.CLI.Input.Display
@@ -75,6 +76,7 @@ library
                     , Agent.CLI.Input.Picker
                     , Agent.CLI.Interrupt
                     , Agent.CLI.Login
+                    , Agent.CLI.ManagedTurn
                     , Agent.CLI.Markdown
                     , Agent.CLI.ModelPicker
                     , Agent.CLI.McpManager
@@ -109,6 +111,9 @@ library
                     , Agent.CLI.Style
                     , Agent.CLI.Terminal
                     , Agent.Telegram
+                    , Agent.Telegram.Client
+                    , Agent.Telegram.Bridge
+                    , Agent.Telegram.Log
                     , Agent.Telegram.Markdown
                     , Agent.Telegram.Types
                     , Agent.Telegram.Voice
@@ -151,9 +156,11 @@ library
                     , haskeline >= 0.8 && < 0.9
                     , http-client
                     , http-client-tls
+                    , http-types
                     , JuicyPixels
                     , mtl
                     , process >= 1.6.26
+                    , retry >= 0.9.3.1 && < 0.10
                     , safe-exceptions
                     , stm
                     , text >= 2.0 && < 2.2
@@ -238,6 +245,7 @@ test-suite agent-cli-test
                     , Agent.CLI.CredentialStoreSpec
                     , Agent.CLI.DialectsSpec
                     , Agent.CLI.ErrorSpec
+                    , Agent.CLI.GatewayBridgeSpec
                     , Agent.CLI.ImagePreviewSpec
                     , Agent.CLI.InputSpec
                     , Agent.CLI.InterruptSpec
@@ -247,6 +255,7 @@ test-suite agent-cli-test
                     , Agent.CLI.ModelPickerSpec
                     , Agent.CLI.ModelConfigSpec
                     , Agent.CLI.ModelsSpec
+                    , Agent.CLI.ManagedTurnSpec
                     , Agent.CLI.NotificationSpec
                     , Agent.CLI.OptionsSpec
                     , Agent.CLI.PlanSpec

--- a/packages/agent-cli/package.nix
+++ b/packages/agent-cli/package.nix
@@ -4,9 +4,9 @@
 , agent-syntax, agent-tui, agent-xai, ansi-terminal, async, base
 , base64-bytestring, brick, bytestring, colour, containers
 , directory, filelock, filepath, haskeline, hspec, http-client
-, http-client-tls, JuicyPixels, lib, mtl, process, safe-exceptions
-, stm, text, time, transformers, unix, vector, vty
-, vty-crossplatform
+, http-client-tls, http-types, JuicyPixels, lib, mtl, process
+, retry, safe-exceptions, stm, text, time, transformers, unix
+, vector, vty, vty-crossplatform
 }:
 mkDerivation {
   pname = "agent-cli";
@@ -21,8 +21,9 @@ mkDerivation {
     agent-responses agent-responses-types agent-syntax agent-tui
     agent-xai ansi-terminal async base base64-bytestring brick
     bytestring colour containers directory filelock filepath haskeline
-    http-client http-client-tls JuicyPixels mtl process safe-exceptions
-    stm text time transformers unix vector vty vty-crossplatform
+    http-client http-client-tls http-types JuicyPixels mtl process
+    retry safe-exceptions stm text time transformers unix vector vty
+    vty-crossplatform
   ];
   executableHaskellDepends = [
     aeson agent-responses agent-responses-types base bytestring

--- a/packages/agent-cli/skills/telegram-agent/SKILL.md
+++ b/packages/agent-cli/skills/telegram-agent/SKILL.md
@@ -25,9 +25,10 @@ disables terminal echo and stores the token in a private gateway file.
    returned token private.
 3. Help them obtain their numeric Telegram user ID, for example by messaging
    `@userinfobot`. This ID is an allowlist entry, not a secret.
-4. Determine the desired provider and project working directory. Default to
-   the current project and a non-mutating approval policy. Only enable
-   `--yolo` when the user explicitly requests it.
+4. Determine the desired provider and project working directory. The default
+   approval mode asks through Telegram inline buttons. Use
+   `--deny-mutations` when the user wants a read-only gateway, and only enable
+   `--yolo` when the user explicitly requests full auto-approval.
 5. Ask the user to run this command in their own interactive terminal:
 
    ```sh
@@ -35,8 +36,9 @@ disables terminal echo and stores the token in a private gateway file.
      --allowed-user <numeric-id>
    ```
 
-   Add `--model`, `--effort`, or `--yolo` only when requested. The command
-   validates the token using Telegram's `getMe` API.
+   Repeat `--allowed-user` for multiple users. Add `--model`, `--effort`,
+   `--deny-mutations`, or `--yolo` only when requested. The command validates
+   the token using Telegram's `getMe` API.
 6. Wait until the user confirms setup completed. Do not attempt to pipe or
    inject the token through a shell tool.
 7. Start the configured gateway with:
@@ -52,32 +54,42 @@ disables terminal echo and stores the token in a private gateway file.
    ```
 
 9. Tell the user to open their new bot and send `/start`. The bot supports
-   `/new` for a fresh agent session and `/session` for the current session ID.
+   `/new` for a fresh agent session, `/session` for the current session ID,
+   `/status` for queue/retry state, and `/retry` for the latest failed turn.
    To use it in a group, add the bot and mention its `@username`, reply to one
    of its messages, or address commands to it (for example
    `/new@your_bot_username`). Each group or forum topic has a shared agent
    session. Only messages from allowlisted users are accepted; ambient group
-   traffic is ignored. Text, voice messages, and private-chat message reactions
-   are persisted before processing. Voice transcription uses the user's
-   existing Codex subscription, so Codex must already be logged in on the
-   machine running the gateway.
+   traffic is ignored. Text, edited messages, reactions, photos, documents,
+   audio, video, video notes, animations, stickers, locations, contacts,
+   venues, polls, dice, and voice messages are persisted before processing.
+   Voice transcription uses the user's existing Codex subscription, so Codex
+   must already be logged in on the machine running the gateway.
 
 ## Telegram delivery behavior
 
-- The gateway shows typing and a native rich-message draft while an agent turn
-  is running.
+- The gateway shows typing and a native rich-message draft whose text follows
+  current model/tool/retry activity.
 - Agent Markdown is converted to Telegram-safe HTML, with a plain-text fallback.
 - Group and supergroup responses reply to the triggering message. Forum topics
   are isolated from one another.
 - A reply containing exactly one supported Telegram reaction emoji is delivered
   as a reaction to the triggering message instead of as a separate message.
 - Inbound reaction changes become ordinary durable agent turns, including
-  reaction removals.
+  reaction removals. Group reactions are accepted only for messages recorded
+  as bot output.
+- Mutating-tool approvals and generic choices use scoped, expiring inline
+  buttons. The agent can also send Telegram documents, photos, voice files,
+  and reactions through parent-owned gateway tools.
+- Transient Telegram and agent failures use bounded backoff and durable retry
+  metadata. `/retry` restores the latest dead-lettered turn.
 - Voice messages are limited to 10 minutes and 20 MB. They are downloaded to a
   private temporary gateway file, transcribed through `codex app-server`, then
   deleted before the transcript enters the normal durable agent-session path.
 
 ## Management
 
-Use `agent-telegram stop` to stop the background gateway. Logs and durable
-queue state live below `~/.haskell-agent/gateways/telegram/`.
+Use `agent-telegram users list|add ID|remove ID` to manage the local allowlist;
+restart the running gateway after changes. Use `agent-telegram stop` to stop
+the background gateway. Redacted JSON logs and durable queue state live below
+`~/.haskell-agent/gateways/telegram/`.

--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -69,6 +69,17 @@ import Agent.CLI.AgentSessions
     , signalManagedSessionReady
     , sessionProcessStatus
     )
+import Agent.CLI.ManagedTurn
+    ( ManagedTurnRequest(..)
+    , loadManagedTurnRequest
+    , managedTurnInputs
+    , managedTurnRequestFromText
+    )
+import Agent.CLI.GatewayBridge
+    ( managedGatewayTools
+    , publishManagedLoopEvent
+    , requestManagedApproval
+    )
 import Agent.CLI.Approval
     ( ApprovalNotice(..)
     , approveToolDecision
@@ -1957,12 +1968,13 @@ runAgentInitializedWithLock
                     provider
                     (tokenProviderBillingMode tokenProvider)
             }
-    prompt <- loadPrompt options
+    promptRequest <- loadPrompt options
+    let promptText = fmap (\request -> request.managedTurnText) promptRequest
     persist <-
         preparePersistence
             fullscreen options root
                 inferredTarget { targetDialect = dialectId }
-                (isNothing transition) cwd effort prompt resumed
+                (isNothing transition) cwd effort promptText resumed
     writeIORef persistSlotRef persist
     (sessionTmp, ephemeralSessionId) <-
         persistenceTempDir persist >>= \case
@@ -2116,12 +2128,15 @@ runAgentInitializedWithLock
                 then MCP.mcpFleetMetaTools mcpFleet
                 else MCP.mcpFleetTools mcpFleet
         sessionTools = agentSessionTools sessionToolsEnv
-        allTools = coding.codingAppTools ++ mcpTools ++ sessionTools
+        gatewayTools = maybe [] managedGatewayTools promptRequest
+        allTools =
+            coding.codingAppTools ++ mcpTools ++ sessionTools ++ gatewayTools
         tools =
             filterGhciTools options.optGhci
                 (filterBashTools options.optBash coding.codingAppTools)
                 ++ mcpTools
                 ++ sessionTools
+                ++ gatewayTools
         planMode = coding.codingPlanMode
         -- Keep planSessionDir and subagent store root in sync.
         noteSessionDir dir = do
@@ -2143,7 +2158,10 @@ runAgentInitializedWithLock
     flip finally closeAll do
         case
                 mcpToolCollision
-                    (coding.codingAppTools ++ agentSessionTools sessionToolsEnv)
+                    ( coding.codingAppTools
+                        ++ agentSessionTools sessionToolsEnv
+                        ++ gatewayTools
+                    )
                     mcpFleet.mcpFleetRegistrations
             of
                 Just err ->
@@ -2198,7 +2216,9 @@ runAgentInitializedWithLock
         writeIORef subagentForkSource (Just transcriptRef)
         let titleHint = case resumed of
                 Just (meta, _) -> Just meta.metaTitle
-                Nothing -> sessionTitleFromPrompt <$> prompt
+                Nothing ->
+                    fmap (\request -> sessionTitleFromPrompt request.managedTurnText)
+                        promptRequest
         setWindowTitle (cliWindowTitle cwd titleHint)
         markStartupStage startup "Loading instructions…"
         startupContext <-
@@ -2250,7 +2270,7 @@ runAgentInitializedWithLock
                             && isNothing resumed
                             && isNothing options.optProvider
                             && isNothing options.optModel
-                            && isNothing prompt
+                            && isNothing promptRequest
                     withStartupAvailability action
                         | shouldProbeAtStartup =
                             withAsync
@@ -2509,7 +2529,7 @@ runAgentInitializedWithLock
                                         projectRoot transition persist noticingBackend
                                 withAsync switchLoop \switchWorker -> do
                                     link switchWorker
-                                    runSession catalog inferredTarget.targetConnectionId options provider dialect policy allTools mcpFleet.mcpFleetRegistrations mcpFleet.mcpFleetWarnings ghciEnabledRef bashEnabledRef toolEnv planMode startup prompt pendingTurn unavailableProviders startupUnavailable paramsRef transcriptRef initialTurns
+                                    runSession catalog inferredTarget.targetConnectionId options provider dialect policy allTools mcpFleet.mcpFleetRegistrations mcpFleet.mcpFleetWarnings ghciEnabledRef bashEnabledRef toolEnv planMode startup promptRequest pendingTurn unavailableProviders startupUnavailable paramsRef transcriptRef initialTurns
                                         previousRef persist projectRoot home cwd (Just tokenProvider) loaded.loadedOpenAiPool startupContext skillsRef skillInvocationsRef escPaused interrupt
                                         multiCtx rootTurnRef subagentSessions pendingNotices subagentStoreRoot agentTypesRef legacySubagentTarget usageRef activeAccountRef activeAccountIdRef activeSelectionRef resolveActiveAccountLabel selectAccount claimCurrentSession compactRunner activeBackend btwBackend)
                             >>= \case
@@ -2573,7 +2593,7 @@ runAgentInitializedWithLock
                         activeBackend <-
                             prepareTransitionBackend
                                 projectRoot transition persist backend
-                        runSession catalog inferredTarget.targetConnectionId options provider dialect policy allTools mcpFleet.mcpFleetRegistrations mcpFleet.mcpFleetWarnings ghciEnabledRef bashEnabledRef toolEnv planMode startup prompt pendingTurn unavailableProviders startupUnavailable paramsRef transcriptRef initialTurns
+                        runSession catalog inferredTarget.targetConnectionId options provider dialect policy allTools mcpFleet.mcpFleetRegistrations mcpFleet.mcpFleetWarnings ghciEnabledRef bashEnabledRef toolEnv planMode startup promptRequest pendingTurn unavailableProviders startupUnavailable paramsRef transcriptRef initialTurns
                             previousRef persist projectRoot home cwd (Just tokenProvider) loaded.loadedOpenAiPool startupContext skillsRef skillInvocationsRef escPaused interrupt
                             multiCtx rootTurnRef subagentSessions pendingNotices subagentStoreRoot agentTypesRef legacySubagentTarget usageRef activeAccountRef activeAccountIdRef activeSelectionRef resolveActiveAccountLabel (if isJust customGenericOptions then Nothing else Just selectHttpAccount) claimCurrentSession compactRunner activeBackend btwBackend
                     ClaudeCodeProvider -> do
@@ -2634,7 +2654,7 @@ runAgentInitializedWithLock
                                 activeBackend <-
                                     prepareTransitionBackend
                                         projectRoot transition persist backend
-                                runSession catalog inferredTarget.targetConnectionId options provider dialect policy allTools mcpFleet.mcpFleetRegistrations mcpFleet.mcpFleetWarnings ghciEnabledRef bashEnabledRef toolEnv planMode startup prompt pendingTurn unavailableProviders startupUnavailable paramsRef transcriptRef initialTurns
+                                runSession catalog inferredTarget.targetConnectionId options provider dialect policy allTools mcpFleet.mcpFleetRegistrations mcpFleet.mcpFleetWarnings ghciEnabledRef bashEnabledRef toolEnv planMode startup promptRequest pendingTurn unavailableProviders startupUnavailable paramsRef transcriptRef initialTurns
                                     previousRef persist projectRoot home cwd Nothing Nothing startupContext skillsRef skillInvocationsRef escPaused interrupt
                                     multiCtx rootTurnRef subagentSessions pendingNotices subagentStoreRoot agentTypesRef legacySubagentTarget usageRef activeAccountRef activeAccountIdRef activeSelectionRef resolveActiveAccountLabel Nothing claimCurrentSession compactRunner activeBackend btwBackend
                     OpenRouterProvider -> do
@@ -2706,7 +2726,7 @@ runAgentInitializedWithLock
                         activeBackend <-
                             prepareTransitionBackend
                                 projectRoot transition persist backend
-                        runSession catalog inferredTarget.targetConnectionId options provider dialect policy allTools mcpFleet.mcpFleetRegistrations mcpFleet.mcpFleetWarnings ghciEnabledRef bashEnabledRef toolEnv planMode startup prompt pendingTurn unavailableProviders startupUnavailable paramsRef transcriptRef initialTurns
+                        runSession catalog inferredTarget.targetConnectionId options provider dialect policy allTools mcpFleet.mcpFleetRegistrations mcpFleet.mcpFleetWarnings ghciEnabledRef bashEnabledRef toolEnv planMode startup promptRequest pendingTurn unavailableProviders startupUnavailable paramsRef transcriptRef initialTurns
                             previousRef persist projectRoot home cwd (Just tokenProvider) loaded.loadedOpenAiPool startupContext skillsRef skillInvocationsRef escPaused interrupt
                             multiCtx rootTurnRef subagentSessions pendingNotices subagentStoreRoot agentTypesRef legacySubagentTarget usageRef activeAccountRef activeAccountIdRef activeSelectionRef resolveActiveAccountLabel (Just selectHttpAccount) claimCurrentSession compactRunner activeBackend btwBackend
           where
@@ -2976,7 +2996,7 @@ runSession
     -> ToolEnv
     -> PlanModeEnv
     -> StartupRuntime
-    -> Maybe Text
+    -> Maybe ManagedTurnRequest
     -> Maybe PendingTurn
     -> [Provider]
     -> Maybe (STM ApiError)
@@ -3013,7 +3033,7 @@ runSession
     -> Backend
     -> BtwBackendFactory
     -> IO RunResult
-runSession catalog connectionId options provider dialect policy allTools mcpRegistrations mcpWarnings ghciEnabledRef bashEnabledRef toolEnv planMode startup prompt pendingTurn unavailableProviders startupUnavailable paramsRef transcriptRef initialTurns previous persist projectRoot home cwd tokenProvider openAiPool startupContext skillsRef skillInvocationsRef escPaused interrupt multiCtx rootTurnRef subagentSessions pendingNotices storeRoot agentTypes legacyTarget usageRef accountRef accountIdRef selectionRef accountLabel selectAccount onPersisted compactRunner backend btwBackend = do
+runSession catalog connectionId options provider dialect policy allTools mcpRegistrations mcpWarnings ghciEnabledRef bashEnabledRef toolEnv planMode startup promptRequest pendingTurn unavailableProviders startupUnavailable paramsRef transcriptRef initialTurns previous persist projectRoot home cwd tokenProvider openAiPool startupContext skillsRef skillInvocationsRef escPaused interrupt multiCtx rootTurnRef subagentSessions pendingNotices storeRoot agentTypes legacyTarget usageRef accountRef accountIdRef selectionRef accountLabel selectAccount onPersisted compactRunner backend btwBackend = do
   initialPrevious <- readIORef previous
   ioLock <- newMVar ()
   let fullscreen = startup.startupFullscreen
@@ -3351,19 +3371,22 @@ runSession catalog connectionId options provider dialect policy allTools mcpRegi
                         options.optMotionMode
             , renderMotionMode = options.optMotionMode
             }
-        emitLoop event = case fullscreen of
-            Nothing -> renderEvent render event
-            Just runtime -> do
-                case event of
-                    TurnStarted -> do
-                        now <- getCurrentTime
-                        writeIORef startedAtRef (Just now)
-                        writeIORef activityRef "Thinking…"
-                    TextDelta _ -> writeIORef printed True
-                    ToolStarted _ ->
-                        writeIORef activityRef "Running tool…"
-                    _ -> pure ()
-                emitUiEvent runtime (UiLoop event)
+        emitLoop event = do
+            forM_ promptRequest \request ->
+                publishManagedLoopEvent request event
+            case fullscreen of
+                Nothing -> renderEvent render event
+                Just runtime -> do
+                    case event of
+                        TurnStarted -> do
+                            now <- getCurrentTime
+                            writeIORef startedAtRef (Just now)
+                            writeIORef activityRef "Thinking…"
+                        TextDelta _ -> writeIORef printed True
+                        ToolStarted _ ->
+                            writeIORef activityRef "Running tool…"
+                        _ -> pure ()
+                    emitUiEvent runtime (UiLoop event)
         shellToolAllowed call = do
             ghciEnabled <- readIORef ghciEnabledRef
             bashEnabled <- readIORef bashEnabledRef
@@ -3373,28 +3396,40 @@ runSession catalog connectionId options provider dialect policy allTools mcpRegi
                     && (not (isBashToolName toolName) || bashEnabled)
         approveRegisteredTool call =
             withMVar ioLock \_ ->
-                case fullscreen of
-                    Nothing ->
-                        withStdinPaused escPaused $
-                            approveToolDecision
-                                policyRef allowedToolsRef toolRegistry planMode
-                                projectRoot call
-                    Just runtime ->
-                        approveToolDecisionWithReporterAndPersistence
-                            (requestFullscreenPermission runtime)
-                            (\case
-                                ApprovalWarning _ -> pure ()
-                                ApprovalSuccess message ->
-                                    emitUiEvent runtime
-                                        (UiSetNotice
-                                            (Just
-                                                (successNotice message))))
-                            (saveProjectAutoApprove projectRoot True)
-                            policyRef
-                            allowedToolsRef
-                            toolRegistry
-                            planMode
-                            call
+                case promptRequest of
+                    Just request
+                        | isJust request.managedTurnBridgeDirectory ->
+                            approveToolDecisionWithReporterAndPersistence
+                                (requestManagedApproval request)
+                                (const (pure ()))
+                                (pure ())
+                                policyRef
+                                allowedToolsRef
+                                toolRegistry
+                                planMode
+                                call
+                    _ -> case fullscreen of
+                        Nothing ->
+                            withStdinPaused escPaused $
+                                approveToolDecision
+                                    policyRef allowedToolsRef toolRegistry planMode
+                                    projectRoot call
+                        Just runtime ->
+                            approveToolDecisionWithReporterAndPersistence
+                                (requestFullscreenPermission runtime)
+                                (\case
+                                    ApprovalWarning _ -> pure ()
+                                    ApprovalSuccess message ->
+                                        emitUiEvent runtime
+                                            (UiSetNotice
+                                                (Just
+                                                    (successNotice message))))
+                                (saveProjectAutoApprove projectRoot True)
+                                policyRef
+                                allowedToolsRef
+                                toolRegistry
+                                planMode
+                                call
         config = LoopConfig
             { loopBackend = backend
             , loopBackendState = BackendStateStore
@@ -3563,11 +3598,16 @@ runSession catalog connectionId options provider dialect policy allTools mcpRegi
                             else SubmitPendingTurn)
                         env
                         pending
-                Nothing -> case prompt of
-                    Just text -> do
-                        inputs <- preparePromptSkillInputs env text [UserMessage text]
-                            >>= either (die . Text.unpack) pure
-                        result <- runOneTurn env text inputs
+                Nothing -> case promptRequest of
+                    Just request -> do
+                        inputs <- managedTurnInputs cwd request
+                        skillInputs <-
+                            preparePromptSkillInputs
+                                env
+                                request.managedTurnText
+                                inputs
+                                >>= either (die . Text.unpack) pure
+                        result <- runOneTurn env request.managedTurnText skillInputs
                         finishTurn env True result
                     Nothing ->
                         readIORef startup.startupSessionState.sessionDraft
@@ -6516,6 +6556,7 @@ restartSessionOptions options sessionId =
         , optEffort = Nothing
         , optPrompt = Nothing
         , optPromptFile = Nothing
+        , optManagedTurnFile = Nothing
         , optResume = Just sessionId
         }
 
@@ -6711,10 +6752,20 @@ putTrailingNewline printed = do
     didPrint <- readIORef printed
     if didPrint then putStrLn "" else pure ()
 
-loadPrompt :: CliOptions -> IO (Maybe Text)
-loadPrompt options = case (options.optPrompt, options.optPromptFile) of
-    (Just text, _) -> pure (Just text)
-    (_, Just path) -> Just . Text.strip <$> Text.readFile (unsafeToFilePath path)
+loadPrompt :: CliOptions -> IO (Maybe ManagedTurnRequest)
+loadPrompt options =
+  case
+        ( options.optPrompt
+        , options.optPromptFile
+        , options.optManagedTurnFile
+        )
+    of
+    (Just text, _, _) ->
+        pure (Just (managedTurnRequestFromText (Text.strip text)))
+    (_, Just path, _) ->
+        loadManagedTurnRequest path >>= either (die . Text.unpack) (pure . Just)
+    (_, _, Just path) ->
+        loadManagedTurnRequest path >>= either (die . Text.unpack) (pure . Just)
     _ -> pure Nothing
 
 handleResume

--- a/packages/agent-cli/src/Agent/CLI/AgentSessions.hs
+++ b/packages/agent-cli/src/Agent/CLI/AgentSessions.hs
@@ -3,16 +3,21 @@
 -- independent from the caller's model loop while remaining resumable.
 module Agent.CLI.AgentSessions
     ( AgentSessionToolsEnv(..)
+    , SessionProcessLifetime(..)
     , SessionProcessManager
     , agentSessionTools
     , closeSessionProcessManager
+    , launchManagedTurn
+    , launchManagedTurnBounded
     , launchSessionTurn
     , newSessionProcessManager
+    , newSessionProcessManagerWithLifetime
     , signalManagedSessionReady
     , sessionProcessStatus
     ) where
 
 import Agent.CLI.Options (ApprovalPolicy(..))
+import Agent.CLI.ManagedTurn (ManagedTurnRequest)
 import Agent.CLI.Error (formatException)
 import Agent.CLI.Session
     ( SessionCreate(..)
@@ -59,7 +64,7 @@ import Control.Concurrent.MVar
     )
 import Control.Exception.Safe (SomeException, try)
 import Control.Monad (forM_)
-import Data.Aeson (FromJSON(..), Value, object, (.=))
+import Data.Aeson (FromJSON(..), Value, encode, object, (.=))
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy as LBS
 import Data.Map.Strict (Map)
@@ -85,10 +90,18 @@ import System.Process
     , ProcessHandle
     , StdStream(..)
     , createProcess
+    , getPid
     , getProcessExitCode
     , proc
+    , terminateProcess
     , waitForProcess
     )
+import System.Posix.Signals
+    ( sigKILL
+    , sigTERM
+    , signalProcessGroup
+    )
+import qualified System.Timeout as Timeout
 
 data AgentSessionToolsEnv = AgentSessionToolsEnv
     { toolsRoot :: !OsPath
@@ -111,14 +124,28 @@ data ManagedSessionProcess
 data SessionProcessManager = SessionProcessManager
     { managedRoot :: !OsPath
     , managedProcesses :: !(MVar (Map Text ManagedSessionProcess))
+    , managedLifetime :: !SessionProcessLifetime
     }
 
+data SessionProcessLifetime
+    = DetachedSessionProcesses
+    | ScopedSessionProcesses
+    deriving (Eq, Show)
+
 newSessionProcessManager :: OsPath -> IO SessionProcessManager
-newSessionProcessManager root = do
+newSessionProcessManager =
+    newSessionProcessManagerWithLifetime DetachedSessionProcesses
+
+newSessionProcessManagerWithLifetime
+    :: SessionProcessLifetime
+    -> OsPath
+    -> IO SessionProcessManager
+newSessionProcessManagerWithLifetime lifetime root = do
     processes <- newMVar Map.empty
     pure SessionProcessManager
         { managedRoot = root
         , managedProcesses = processes
+        , managedLifetime = lifetime
         }
 
 -- | Start one background turn for a persisted session. A second turn is
@@ -134,6 +161,32 @@ launchSessionTurn
     -> Text
     -> IO (Either Text Text)
 launchSessionTurn manager background policy ghciEnabled bashEnabled handle message =
+    launchSessionTurnInput
+        manager
+        background
+        policy
+        ghciEnabled
+        bashEnabled
+        Nothing
+        handle
+        (ManagedTextInput message)
+
+data ManagedTurnInput
+    = ManagedTextInput !Text
+    | ManagedRequestInput !ManagedTurnRequest
+
+launchSessionTurnInput
+    :: SessionProcessManager
+    -> Bool
+    -> ApprovalPolicy
+    -> Bool
+    -> Bool
+    -> Maybe Int
+    -> SessionHandle
+    -> ManagedTurnInput
+    -> IO (Either Text Text)
+launchSessionTurnInput
+        manager background policy ghciEnabled bashEnabled turnTimeout handle input =
     resolveAgentExecutable >>= \case
         Left err -> pure (Left err)
         Right executable -> do
@@ -172,12 +225,23 @@ launchSessionTurn manager background policy ghciEnabled bashEnabled handle messa
                             if background
                                 then pure (Right ("started session " <> sessionId))
                                 else do
-                                    exitCode <- waitForProcess process
+                                    exitResult <- case turnTimeout of
+                                        Nothing -> Right <$> waitForProcess process
+                                        Just micros ->
+                                            Timeout.timeout micros
+                                                (waitForManagedExit process) >>= \case
+                                                    Nothing -> do
+                                                        terminateManagedProcess process
+                                                        pure (Left
+                                                            "agent session timed out")
+                                                    Just exitCode ->
+                                                        pure (Right exitCode)
                                     forgetSession manager sessionId
-                                    pure case exitCode of
-                                        ExitSuccess ->
+                                    pure case exitResult of
+                                        Left err -> Left err
+                                        Right ExitSuccess ->
                                             Right ("completed session " <> sessionId)
-                                        ExitFailure code ->
+                                        Right (ExitFailure code) ->
                                             Left
                                                 ("session failed with exit code "
                                                     <> Text.pack (show code))
@@ -186,11 +250,15 @@ launchSessionTurn manager background policy ghciEnabled bashEnabled handle messa
 
     startManagedSession executable = do
         parentEnv <- getEnvironment
-        (promptPath, promptHandle) <- openTempFile
-            (unsafeToFilePath handle.sessionDir) ".agent-prompt-"
-        TextIO.hPutStr promptHandle message
-        hClose promptHandle
-        setFileMode promptPath 0o600
+        (inputPath, inputHandle) <- openTempFile
+            (unsafeToFilePath handle.sessionTempDir) ".agent-turn-"
+        case input of
+            ManagedTextInput message ->
+                TextIO.hPutStr inputHandle message
+            ManagedRequestInput request ->
+                LBS.hPut inputHandle (encode request)
+        hClose inputHandle
+        setFileMode inputPath 0o600
         (readyPath, readyHandle) <- openTempFile
             (unsafeToFilePath handle.sessionDir) ".agent-ready-"
         hClose readyHandle
@@ -205,13 +273,17 @@ launchSessionTurn manager background policy ghciEnabled bashEnabled handle messa
             logPath = unsafeToFilePath handle.sessionDir FilePath.</> "agent.log"
             approvalArgs = case policy of
                 ApproveAll -> ["--yolo"]
-                DenyMutating -> ["--no-yolo"]
+                DenyMutating -> ["--managed-deny-mutations"]
                 PromptMutating -> ["--no-yolo"]
+            inputArgs = case input of
+                ManagedTextInput _ -> ["--prompt-file", inputPath]
+                ManagedRequestInput _ -> ["--managed-turn-file", inputPath]
             agentArgs =
                 [ "--resume", Text.unpack sessionId
-                , "--prompt-file", promptPath
-                , "--save-session"
                 ]
+                    <> inputArgs
+                    <> [ "--save-session"
+                       ]
                     <> approvalArgs
                     <> ["--no-ghci" | not ghciEnabled]
                     <> ["--bash" | bashEnabled]
@@ -223,7 +295,7 @@ launchSessionTurn manager background policy ghciEnabled bashEnabled handle messa
             args =
                 [ "-c", cleanupScript
                 , "agent-session-runner"
-                , promptPath
+                , inputPath
                 , executable
                 ]
                     <> agentArgs
@@ -240,18 +312,69 @@ launchSessionTurn manager background policy ghciEnabled bashEnabled handle messa
                     }
         case started of
             Left err -> do
-                removePrivateFile promptPath
+                removePrivateFile inputPath
                 removePrivateFile readyPath
                 pure $ Left
                     ("failed to start agent session: " <> formatException err)
             Right (_, _, _, process) -> do
-                ready <- waitForManagedSessionReady process readyPath
+                ready <- Timeout.timeout 30_000_000
+                    (waitForManagedSessionReady process readyPath) >>= \case
+                        Nothing -> do
+                            _ <- try @_ @SomeException (terminateProcess process)
+                            _ <- try @_ @SomeException (waitForProcess process)
+                            pure (Left
+                                "agent session did not become ready within 30 seconds")
+                        Just result -> pure result
                 removePrivateFile readyPath
                 case ready of
                     Left err -> do
                         _ <- waitForProcess process
                         pure (Left err)
                     Right () -> pure (Right process)
+
+-- | Launch a structured gateway turn through the private request-file
+-- interface, without exposing gateway credentials to the child.
+launchManagedTurn
+    :: SessionProcessManager
+    -> Bool
+    -> ApprovalPolicy
+    -> Bool
+    -> Bool
+    -> SessionHandle
+    -> ManagedTurnRequest
+    -> IO (Either Text Text)
+launchManagedTurn manager background policy ghciEnabled bashEnabled handle request =
+    launchManagedTurnBounded
+        manager
+        background
+        policy
+        ghciEnabled
+        bashEnabled
+        Nothing
+        handle
+        request
+
+launchManagedTurnBounded
+    :: SessionProcessManager
+    -> Bool
+    -> ApprovalPolicy
+    -> Bool
+    -> Bool
+    -> Maybe Int
+    -> SessionHandle
+    -> ManagedTurnRequest
+    -> IO (Either Text Text)
+launchManagedTurnBounded
+        manager background policy ghciEnabled bashEnabled turnTimeout handle request =
+    launchSessionTurnInput
+        manager
+        background
+        policy
+        ghciEnabled
+        bashEnabled
+        turnTimeout
+        handle
+        (ManagedRequestInput request)
 
 forgetSession :: SessionProcessManager -> Text -> IO ()
 forgetSession manager sessionId =
@@ -290,8 +413,6 @@ sessionProcessStatus manager sessionId =
 closeSessionProcessManager :: SessionProcessManager -> IO ()
 closeSessionProcessManager manager =
     modifyMVar_ manager.managedProcesses \processes -> do
-        -- Running sessions intentionally outlive the caller. The child owns
-        -- the advisory session lock; its wrapper owns prompt cleanup.
         forM_ (Map.elems processes) \case
             ManagedSessionStarting -> pure ()
             ManagedSessionRunning managedHandle ->
@@ -300,8 +421,36 @@ closeSessionProcessManager manager =
                         _ <- try @_ @SomeException
                             (waitForProcess managedHandle)
                         pure ()
-                    Nothing -> pure ()
+                    Nothing ->
+                        case manager.managedLifetime of
+                            DetachedSessionProcesses -> pure ()
+                            ScopedSessionProcesses -> do
+                                terminateManagedProcess managedHandle
         pure Map.empty
+
+waitForManagedExit :: ProcessHandle -> IO ExitCode
+waitForManagedExit process =
+    getProcessExitCode process >>= \case
+        Nothing -> threadDelay 10_000 >> waitForManagedExit process
+        Just exitCode -> do
+            _ <- try @_ @SomeException (waitForProcess process)
+            pure exitCode
+
+terminateManagedProcess :: ProcessHandle -> IO ()
+terminateManagedProcess process = do
+    processGroup <- getPid process
+    let signalGroup signal =
+            case processGroup of
+                Nothing -> terminateProcess process
+                Just pid -> signalProcessGroup signal pid
+    _ <- try @_ @SomeException (signalGroup sigTERM)
+    stopped <- Timeout.timeout 2_000_000 (waitForManagedExit process)
+    case stopped of
+        Just _ -> pure ()
+        Nothing -> do
+            _ <- try @_ @SomeException (signalGroup sigKILL)
+            _ <- try @_ @SomeException (waitForManagedExit process)
+            pure ()
 
 signalManagedSessionReady :: Either Text () -> IO ()
 signalManagedSessionReady result =

--- a/packages/agent-cli/src/Agent/CLI/GatewayBridge.hs
+++ b/packages/agent-cli/src/Agent/CLI/GatewayBridge.hs
@@ -1,0 +1,470 @@
+-- | Private request/response bridge for gateway-owned agent turns.
+module Agent.CLI.GatewayBridge
+    ( ManagedBridgeRequest(..)
+    , ManagedBridgeResponse(..)
+    , ManagedActivity(..)
+    , managedGatewayTools
+    , publishManagedLoopEvent
+    , requestManagedApproval
+    , managedBridgeRequestsDirectory
+    , managedBridgeResponsesDirectory
+    , managedBridgeActivityPath
+    , writeManagedBridgeResponse
+    , writeManagedBridgeResponseAt
+    ) where
+
+import Agent.CLI.ManagedTurn (ManagedTurnRequest(..))
+import Agent.CLI.Permission (PermissionChoice(..))
+import Agent.FileRetry (retryOnFileBusy, writeLazyFileAtomically)
+import Agent.Loop (LoopEvent(..))
+import Agent.OsPath (unsafeToFilePath)
+import Agent.ToolArgs (objectArgs, optInt, optText, reqText)
+import Agent.ToolDSL (PropertySchema(..), PropertyType(..))
+import Agent.ToolDispatch
+    ( ToolCall(..)
+    , typedToolWithCall
+    )
+import Agent.Tools.Types
+    ( AppTool
+    , ToolExecutionPolicy(..)
+    , jsonTool
+    )
+import Control.Concurrent (threadDelay)
+import Control.Exception.Safe (SomeException, finally, try)
+import Control.Monad (void)
+import Data.Aeson
+    ( FromJSON(..)
+    , ToJSON(..)
+    , Value(..)
+    , eitherDecode
+    , encode
+    , object
+    , withObject
+    , (.:)
+    , (.:?)
+    , (.!=)
+    , (.=)
+    )
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy as LBS
+import Data.Char (isAlphaNum)
+import Data.Maybe (fromMaybe)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as TextEncoding
+import Data.Time.Clock (UTCTime, getCurrentTime)
+import Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds)
+import System.Directory
+    ( createDirectoryIfMissing
+    , doesFileExist
+    , removeFile
+    )
+import System.OsPath (OsPath, unsafeEncodeUtf, (</>))
+import System.Posix.Files (setFileMode)
+import System.Posix.Process (getProcessID)
+
+bridgeSchemaVersion :: Int
+bridgeSchemaVersion = 1
+
+data ManagedBridgeRequest = ManagedBridgeRequest
+    { bridgeRequestVersion :: !Int
+    , bridgeRequestId :: !Text
+    , bridgeRequestKind :: !Text
+    , bridgeRequestPayload :: !Value
+    } deriving (Eq, Show)
+
+instance ToJSON ManagedBridgeRequest where
+    toJSON request = object
+        [ "version" .= request.bridgeRequestVersion
+        , "id" .= request.bridgeRequestId
+        , "kind" .= request.bridgeRequestKind
+        , "payload" .= request.bridgeRequestPayload
+        ]
+
+instance FromJSON ManagedBridgeRequest where
+    parseJSON = withObject "ManagedBridgeRequest" \o ->
+        ManagedBridgeRequest
+            <$> (o .:? "version" .!= bridgeSchemaVersion)
+            <*> o .: "id"
+            <*> o .: "kind"
+            <*> (o .:? "payload" .!= Object KeyMap.empty)
+
+data ManagedBridgeResponse = ManagedBridgeResponse
+    { bridgeResponseVersion :: !Int
+    , bridgeResponseId :: !Text
+    , bridgeResponseOk :: !Bool
+    , bridgeResponseResult :: !(Maybe Value)
+    , bridgeResponseError :: !(Maybe Text)
+    } deriving (Eq, Show)
+
+instance ToJSON ManagedBridgeResponse where
+    toJSON response = object
+        [ "version" .= response.bridgeResponseVersion
+        , "id" .= response.bridgeResponseId
+        , "ok" .= response.bridgeResponseOk
+        , "result" .= response.bridgeResponseResult
+        , "error" .= response.bridgeResponseError
+        ]
+
+instance FromJSON ManagedBridgeResponse where
+    parseJSON = withObject "ManagedBridgeResponse" \o ->
+        ManagedBridgeResponse
+            <$> (o .:? "version" .!= bridgeSchemaVersion)
+            <*> o .: "id"
+            <*> o .: "ok"
+            <*> o .:? "result"
+            <*> o .:? "error"
+
+data ManagedActivity = ManagedActivity
+    { managedActivityVersion :: !Int
+    , managedActivityKind :: !Text
+    , managedActivityMessage :: !Text
+    , managedActivityUpdatedAt :: !UTCTime
+    } deriving (Eq, Show)
+
+instance ToJSON ManagedActivity where
+    toJSON activity = object
+        [ "version" .= activity.managedActivityVersion
+        , "kind" .= activity.managedActivityKind
+        , "message" .= activity.managedActivityMessage
+        , "updated_at" .= activity.managedActivityUpdatedAt
+        ]
+
+instance FromJSON ManagedActivity where
+    parseJSON = withObject "ManagedActivity" \o ->
+        ManagedActivity
+            <$> (o .:? "version" .!= bridgeSchemaVersion)
+            <*> o .: "kind"
+            <*> o .: "message"
+            <*> o .: "updated_at"
+
+managedGatewayTools :: ManagedTurnRequest -> [AppTool]
+managedGatewayTools request =
+    case request.managedTurnBridgeDirectory of
+        Nothing -> []
+        Just _ ->
+            [ sendPathTool
+                "send_telegram_document"
+                "Send a file from the private session temp directory to the current Telegram conversation."
+                "send_document"
+            , sendPathTool
+                "send_telegram_photo"
+                "Send an image from the private session temp directory to the current Telegram conversation."
+                "send_photo"
+            , sendPathTool
+                "send_telegram_voice"
+                "Send an audio file as a Telegram voice reply to the current conversation."
+                "send_voice"
+            , reactTool
+            , choiceTool
+            ]
+  where
+    sendPathTool name description kind =
+        jsonTool
+            name
+            description
+            [ PropertySchema "path" PropertyString True
+                (Just "Absolute path to a file under the session temp directory.")
+            , PropertySchema "caption" PropertyString False
+                (Just "Optional Telegram caption.")
+            , PropertySchema "filename" PropertyString False
+                (Just "Optional download filename.")
+            ]
+            True
+            TurnSequential
+            (typedToolWithCall name \call args ->
+                bridgeTool request call kind (toPathPayload args))
+
+    reactTool =
+        jsonTool
+            "react_to_telegram_message"
+            "React to the triggering Telegram message, or to an explicit message id."
+            [ PropertySchema "emoji" PropertyString True
+                (Just "One standard Telegram reaction emoji.")
+            , PropertySchema "message_id" PropertyInteger False
+                (Just "Optional Telegram message id; defaults to the triggering message.")
+            ]
+            True
+            TurnSequential
+            (typedToolWithCall "react_to_telegram_message" \call args ->
+                bridgeTool request call "react" (toReactionPayload args))
+
+    choiceTool =
+        jsonTool
+            "ask_telegram_choice"
+            "Ask the Telegram user to choose one option using inline buttons and wait for the answer."
+            [ PropertySchema "question" PropertyString True
+                (Just "Question displayed above the inline buttons.")
+            , PropertySchema "options" (PropertyArray PropertyString) True
+                (Just "Between 1 and 8 short button labels.")
+            ]
+            True
+            TurnSequential
+            (typedToolWithCall "ask_telegram_choice" \call args ->
+                bridgeTool request call "ask_choice" (toChoicePayload args))
+
+data SendPathArgs = SendPathArgs
+    { sendPath :: !Text
+    , sendCaption :: !(Maybe Text)
+    , sendFilename :: !(Maybe Text)
+    }
+
+instance FromJSON SendPathArgs where
+    parseJSON = objectArgs \input ->
+        SendPathArgs
+            <$> reqText input "path"
+            <*> optText input "caption"
+            <*> optText input "filename"
+
+toPathPayload :: SendPathArgs -> Value
+toPathPayload args = object
+    [ "path" .= args.sendPath
+    , "caption" .= args.sendCaption
+    , "filename" .= args.sendFilename
+    ]
+
+data ReactionArgs = ReactionArgs
+    { reactionEmoji :: !Text
+    , reactionMessageId :: !(Maybe Int)
+    }
+
+instance FromJSON ReactionArgs where
+    parseJSON = objectArgs \input ->
+        ReactionArgs
+            <$> reqText input "emoji"
+            <*> optInt input "message_id"
+
+toReactionPayload :: ReactionArgs -> Value
+toReactionPayload args = object
+    [ "emoji" .= args.reactionEmoji
+    , "message_id" .= args.reactionMessageId
+    ]
+
+data ChoiceArgs = ChoiceArgs
+    { choiceQuestion :: !Text
+    , choiceOptions :: ![Text]
+    }
+
+instance FromJSON ChoiceArgs where
+    parseJSON = withObject "ChoiceArgs" \o ->
+        ChoiceArgs <$> o .: "question" <*> o .: "options"
+
+toChoicePayload :: ChoiceArgs -> Value
+toChoicePayload args = object
+    [ "question" .= args.choiceQuestion
+    , "options" .= args.choiceOptions
+    ]
+
+bridgeTool
+    :: ManagedTurnRequest
+    -> ToolCall
+    -> Text
+    -> Value
+    -> IO (Either Text Text)
+bridgeTool request call kind payload =
+    performBridgeRequest request call.callId kind payload (30 * 60 * 1_000_000)
+        >>= \case
+            Left err -> pure (Left err)
+            Right (String text) -> pure (Right text)
+            Right value ->
+                pure (Right
+                    (TextEncoding.decodeUtf8 (LBS.toStrict (encode value))))
+
+requestManagedApproval
+    :: ManagedTurnRequest
+    -> ToolCall
+    -> IO (Maybe PermissionChoice)
+requestManagedApproval request call =
+    performBridgeRequest
+        request
+        call.callId
+        "approval"
+        (object
+            [ "tool_name" .= call.name
+            , "arguments" .= call.arguments
+            ])
+        (30 * 60 * 1_000_000) >>= \case
+            Right (String "allow_once") -> pure (Just PermissionAllowOnce)
+            Right (String "allow_tool") -> pure (Just PermissionAllowTool)
+            Right (String "allow_all") -> pure (Just PermissionAllowAll)
+            Right (String "deny") -> pure (Just PermissionDeny)
+            _ -> pure Nothing
+
+publishManagedLoopEvent :: ManagedTurnRequest -> LoopEvent -> IO ()
+publishManagedLoopEvent request event =
+    case request.managedTurnBridgeDirectory of
+        Nothing -> pure ()
+        Just _ -> do
+            now <- getCurrentTime
+            let (kind, message) = activityFor event
+            void $ try @_ @SomeException $
+                writeLazyFileAtomically
+                    (managedBridgeActivityPath request)
+                    0o600
+                    (encode ManagedActivity
+                        { managedActivityVersion = bridgeSchemaVersion
+                        , managedActivityKind = kind
+                        , managedActivityMessage = message
+                        , managedActivityUpdatedAt = now
+                        })
+  where
+    activityFor = \case
+        TurnStarted -> ("thinking", "Thinking…")
+        ReasoningDelta _ -> ("thinking", "Thinking…")
+        TextDelta _ -> ("writing", "Writing reply…")
+        ActivityUpdated message -> ("activity", nonEmpty "Working…" message)
+        WarningRaised message -> ("warning", nonEmpty "Warning" message)
+        ResponseRestarted _ -> ("retrying", "Retrying response…")
+        ToolStarted call -> ("tool", "Running " <> call.name <> "…")
+        ToolOutputUpdated name _ -> ("tool", "Running " <> name <> "…")
+        ToolFinished _ -> ("thinking", "Thinking…")
+        TurnFinished _ -> ("finished", "Finishing…")
+
+    nonEmpty fallback value
+        | Text.null (Text.strip value) = fallback
+        | otherwise = Text.strip value
+
+writeManagedBridgeResponse
+    :: ManagedTurnRequest
+    -> ManagedBridgeResponse
+    -> IO ()
+writeManagedBridgeResponse request response = do
+    ensureBridgeDirectories request
+    writeManagedBridgeResponseAt
+        (fromMaybe
+            (error "managed gateway bridge directory is unavailable")
+            request.managedTurnBridgeDirectory)
+        response
+
+writeManagedBridgeResponseAt
+    :: FilePath
+    -> ManagedBridgeResponse
+    -> IO ()
+writeManagedBridgeResponseAt bridgeDirectory response = do
+    let root = unsafeEncodeUtf bridgeDirectory
+        responses = root </> unsafeEncodeUtf "responses"
+    createDirectoryIfMissing True (unsafeToFilePath responses)
+    setFileMode (unsafeToFilePath root) 0o700
+    setFileMode (unsafeToFilePath responses) 0o700
+    writeLazyFileAtomically
+        (responses
+            </> unsafeEncodeUtf
+                (Text.unpack response.bridgeResponseId <> ".json"))
+        0o600
+        (encode response)
+
+performBridgeRequest
+    :: ManagedTurnRequest
+    -> Text
+    -> Text
+    -> Value
+    -> Int
+    -> IO (Either Text Value)
+performBridgeRequest request callId kind payload timeoutMicros =
+    case request.managedTurnBridgeDirectory of
+        Nothing -> pure (Left "managed gateway bridge is unavailable")
+        Just _ -> do
+            ensureBridgeDirectories request
+            requestId <- uniqueRequestId callId
+            let requestPath =
+                    managedBridgeRequestsDirectory request
+                        </> unsafeEncodeUtf (Text.unpack requestId <> ".json")
+                responsePath =
+                    managedBridgeResponsesDirectory request
+                        </> unsafeEncodeUtf (Text.unpack requestId <> ".json")
+                bridgeRequest = ManagedBridgeRequest
+                    { bridgeRequestVersion = bridgeSchemaVersion
+                    , bridgeRequestId = requestId
+                    , bridgeRequestKind = kind
+                    , bridgeRequestPayload = payload
+                    }
+            writeLazyFileAtomically requestPath 0o600 (encode bridgeRequest)
+            waitForBridgeResponse responsePath timeoutMicros
+                `finally` do
+                    removePrivateFile requestPath
+                    removePrivateFile responsePath
+
+waitForBridgeResponse :: OsPath -> Int -> IO (Either Text Value)
+waitForBridgeResponse path timeoutMicros = go timeoutMicros
+  where
+    step = 100_000
+    go :: Int -> IO (Either Text Value)
+    go remaining
+        | remaining <= 0 =
+            pure (Left "timed out waiting for the Telegram gateway")
+        | otherwise = do
+            exists <- doesFileExist (unsafeToFilePath path)
+            if not exists
+                then threadDelay step >> go (remaining - step)
+                else do
+                    decoded <- try @_ @SomeException do
+                        bytes <- retryOnFileBusy
+                            (LBS.readFile (unsafeToFilePath path))
+                        pure
+                            (eitherDecode bytes
+                                :: Either String ManagedBridgeResponse)
+                    case decoded of
+                        Left _ -> threadDelay step >> go (remaining - step)
+                        Right (Left _) -> threadDelay step >> go (remaining - step)
+                        Right (Right response)
+                            | response.bridgeResponseOk ->
+                                pure (Right
+                                    (fromMaybe Null response.bridgeResponseResult))
+                            | otherwise ->
+                                pure (Left
+                                    (fromMaybe
+                                        "Telegram gateway request failed"
+                                        response.bridgeResponseError))
+
+ensureBridgeDirectories :: ManagedTurnRequest -> IO ()
+ensureBridgeDirectories request = do
+    let paths =
+            [ bridgeRoot request
+            , managedBridgeRequestsDirectory request
+            , managedBridgeResponsesDirectory request
+            ]
+    mapM_ (\path -> do
+        createDirectoryIfMissing True (unsafeToFilePath path)
+        setFileMode (unsafeToFilePath path) 0o700) paths
+
+managedBridgeRequestsDirectory :: ManagedTurnRequest -> OsPath
+managedBridgeRequestsDirectory request =
+    bridgeRoot request </> unsafeEncodeUtf "requests"
+
+managedBridgeResponsesDirectory :: ManagedTurnRequest -> OsPath
+managedBridgeResponsesDirectory request =
+    bridgeRoot request </> unsafeEncodeUtf "responses"
+
+managedBridgeActivityPath :: ManagedTurnRequest -> OsPath
+managedBridgeActivityPath request =
+    bridgeRoot request </> unsafeEncodeUtf "activity.json"
+
+bridgeRoot :: ManagedTurnRequest -> OsPath
+bridgeRoot request =
+    unsafeEncodeUtf $
+        fromMaybe
+            (error "managed gateway bridge directory is unavailable")
+            request.managedTurnBridgeDirectory
+
+uniqueRequestId :: Text -> IO Text
+uniqueRequestId callId = do
+    now <- getCurrentTime
+    pid <- getProcessID
+    let micros =
+            floor (utcTimeToPOSIXSeconds now * 1_000_000) :: Integer
+        safeCall = Text.take 40 (Text.map sanitize callId)
+    pure $
+        (if Text.null safeCall then "request" else safeCall)
+            <> "-"
+            <> Text.pack (show pid)
+            <> "-"
+            <> Text.pack (show micros)
+  where
+    sanitize char
+        | isAlphaNum char = char
+        | otherwise = '-'
+
+removePrivateFile :: OsPath -> IO ()
+removePrivateFile path = do
+    _ <- try @_ @SomeException (removeFile (unsafeToFilePath path))
+    pure ()

--- a/packages/agent-cli/src/Agent/CLI/ManagedTurn.hs
+++ b/packages/agent-cli/src/Agent/CLI/ManagedTurn.hs
@@ -1,0 +1,195 @@
+-- | Versioned prompt-file payloads for managed background turns.
+module Agent.CLI.ManagedTurn
+    ( ManagedTurnMedia(..)
+    , ManagedTurnContext(..)
+    , ManagedTurnRequest(..)
+    , managedTurnRequestFromText
+    , managedTurnRequestWithImages
+    , managedTurnRequestWithFiles
+    , managedTurnRequestWithGateway
+    , renderManagedTurnPrompt
+    , loadManagedTurnRequest
+    , managedTurnInputs
+    ) where
+
+import Agent.Loop
+    ( FileAttachment(..)
+    , ImageAttachment(..)
+    , TurnInput(..)
+    )
+import Agent.FileRetry (retryOnFileBusy)
+import Agent.OsPath (unsafeToFilePath)
+import Data.Aeson
+    ( FromJSON(..)
+    , ToJSON(..)
+    , object
+    , withObject
+    , (.:)
+    , (.:?)
+    , (.!=)
+    , (.=)
+    )
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as LBS
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as TextEncoding
+import System.Directory.OsPath (doesFileExist)
+import System.OsPath (OsPath)
+
+data ManagedTurnMedia = ManagedTurnMedia
+    { managedTurnMediaPath :: !FilePath
+    , managedTurnMediaMime :: !Text
+    , managedTurnMediaName :: !(Maybe Text)
+    } deriving (Eq, Show)
+
+instance ToJSON ManagedTurnMedia where
+    toJSON media = object
+        [ "path" .= media.managedTurnMediaPath
+        , "mime" .= media.managedTurnMediaMime
+        , "name" .= media.managedTurnMediaName
+        ]
+
+instance FromJSON ManagedTurnMedia where
+    parseJSON = withObject "ManagedTurnMedia" \o ->
+        ManagedTurnMedia
+            <$> o .: "path"
+            <*> o .: "mime"
+            <*> o .:? "name"
+
+data ManagedTurnContext = ManagedTurnContext
+    { managedGateway :: !Text
+    , managedChatId :: !Integer
+    , managedMessageThreadId :: !(Maybe Integer)
+    , managedReplyToMessageId :: !(Maybe Integer)
+    , managedUserId :: !Integer
+    } deriving (Eq, Show)
+
+instance ToJSON ManagedTurnContext where
+    toJSON context = object
+        [ "gateway" .= context.managedGateway
+        , "chat_id" .= context.managedChatId
+        , "message_thread_id" .= context.managedMessageThreadId
+        , "reply_to_message_id" .= context.managedReplyToMessageId
+        , "user_id" .= context.managedUserId
+        ]
+
+instance FromJSON ManagedTurnContext where
+    parseJSON = withObject "ManagedTurnContext" \o ->
+        ManagedTurnContext
+            <$> o .: "gateway"
+            <*> o .: "chat_id"
+            <*> o .:? "message_thread_id"
+            <*> o .:? "reply_to_message_id"
+            <*> o .: "user_id"
+
+data ManagedTurnRequest = ManagedTurnRequest
+    { managedTurnVersion :: !Int
+    , managedTurnText :: !Text
+    , managedTurnImages :: ![ManagedTurnMedia]
+    , managedTurnFiles :: ![ManagedTurnMedia]
+    , managedTurnBridgeDirectory :: !(Maybe FilePath)
+    , managedTurnContext :: !(Maybe ManagedTurnContext)
+    } deriving (Eq, Show)
+
+instance ToJSON ManagedTurnRequest where
+    toJSON request = object
+        [ "version" .= request.managedTurnVersion
+        , "text" .= request.managedTurnText
+        , "images" .= request.managedTurnImages
+        , "files" .= request.managedTurnFiles
+        , "bridge_directory" .= request.managedTurnBridgeDirectory
+        , "context" .= request.managedTurnContext
+        ]
+
+instance FromJSON ManagedTurnRequest where
+    parseJSON = withObject "ManagedTurnRequest" \o ->
+        ManagedTurnRequest
+            <$> (o .:? "version" .!= 1)
+            <*> o .: "text"
+            <*> (o .:? "images" .!= [])
+            <*> (o .:? "files" .!= [])
+            <*> o .:? "bridge_directory"
+            <*> o .:? "context"
+
+managedTurnRequestFromText :: Text -> ManagedTurnRequest
+managedTurnRequestFromText text =
+    ManagedTurnRequest 1 text [] [] Nothing Nothing
+
+managedTurnRequestWithImages :: Text -> [ManagedTurnMedia] -> ManagedTurnRequest
+managedTurnRequestWithImages text images =
+    ManagedTurnRequest 1 text images [] Nothing Nothing
+
+managedTurnRequestWithFiles :: Text -> [ManagedTurnMedia] -> ManagedTurnRequest
+managedTurnRequestWithFiles text files =
+    ManagedTurnRequest 1 text [] files Nothing Nothing
+
+managedTurnRequestWithGateway
+    :: FilePath
+    -> ManagedTurnContext
+    -> ManagedTurnRequest
+    -> ManagedTurnRequest
+managedTurnRequestWithGateway bridgeDirectory context request =
+    request
+        { managedTurnBridgeDirectory = Just bridgeDirectory
+        , managedTurnContext = Just context
+        }
+
+loadManagedTurnRequest :: OsPath -> IO (Either Text ManagedTurnRequest)
+loadManagedTurnRequest path = do
+    exists <- doesFileExist path
+    if not exists
+        then pure (Left "managed turn request file does not exist")
+        else do
+            bytes <- retryOnFileBusy (LBS.readFile (unsafeToFilePath path))
+            case Aeson.eitherDecode bytes of
+                Right request@ManagedTurnRequest{managedTurnVersion = version}
+                    | version == 1 ->
+                        pure (Right request)
+                Right request ->
+                    pure (Left
+                        ("unsupported managed turn version: "
+                            <> Text.pack (show request.managedTurnVersion)))
+                Left err ->
+                    pure (Left
+                        ("could not decode managed turn request: "
+                            <> Text.pack err))
+
+managedTurnInputs :: OsPath -> ManagedTurnRequest -> IO [TurnInput]
+managedTurnInputs _ request
+    | null request.managedTurnImages && null request.managedTurnFiles =
+        pure [UserMessage request.managedTurnText]
+    | otherwise = do
+        images <- mapM loadImage request.managedTurnImages
+        files <- mapM loadFile request.managedTurnFiles
+        pure
+            [ UserMultimodalFiles
+                { userText = request.managedTurnText
+                , userImages = images
+                , userFiles = files
+                }
+            ]
+  where
+    loadImage ManagedTurnMedia{managedTurnMediaPath = path, managedTurnMediaMime = mime} = do
+        bytes <- BS.readFile path
+        pure ImageAttachment
+            { imageMime = mime
+            , imageBytes = bytes
+            }
+
+    loadFile ManagedTurnMedia
+        { managedTurnMediaPath = path
+        , managedTurnMediaName = name
+        , managedTurnMediaMime = mime
+        } = do
+        bytes <- BS.readFile path
+        pure FileAttachment
+            { fileName = name
+            , fileMime = mime
+            , fileBytes = bytes
+            }
+
+renderManagedTurnPrompt :: ManagedTurnRequest -> Text
+renderManagedTurnPrompt =
+    TextEncoding.decodeUtf8 . LBS.toStrict . Aeson.encode

--- a/packages/agent-cli/src/Agent/CLI/Options.hs
+++ b/packages/agent-cli/src/Agent/CLI/Options.hs
@@ -74,6 +74,7 @@ data CliOptions = CliOptions
     , optWorktree :: !Bool
     , optYolo :: !Bool
     , optNoYolo :: !Bool
+    , optManagedDenyMutations :: !Bool
     , optMaxTurns :: !Int
     , optCompactThreshold :: !(Maybe Int)
       -- ^ OpenAI automatic-compaction threshold in estimated context tokens.
@@ -81,6 +82,7 @@ data CliOptions = CliOptions
       -- ^ 'Nothing' means use 'defaultEffortFor' once the provider is known.
     , optPrompt :: !(Maybe Text)
     , optPromptFile :: !(Maybe OsPath)
+    , optManagedTurnFile :: !(Maybe OsPath)
     , optResume :: !(Maybe Text)
     , optSaveSession :: !Bool
     , optAgentsMd :: !Bool
@@ -103,11 +105,13 @@ defaultCliOptions = CliOptions
     , optWorktree = False
     , optYolo = False
     , optNoYolo = False
+    , optManagedDenyMutations = False
     , optMaxTurns = 500
     , optCompactThreshold = Nothing
     , optEffort = Nothing
     , optPrompt = Nothing
     , optPromptFile = Nothing
+    , optManagedTurnFile = Nothing
     , optResume = Nothing
     , optSaveSession = False
     , optAgentsMd = True
@@ -127,7 +131,10 @@ defaultEffortFor = \case
     ClaudeCodeProvider -> "xhigh"
 
 isOneShot :: CliOptions -> Bool
-isOneShot options = isJust options.optPrompt || isJust options.optPromptFile
+isOneShot options =
+    isJust options.optPrompt
+        || isJust options.optPromptFile
+        || isJust options.optManagedTurnFile
 
 -- | One-shot without a TTY auto-approves so scripts do not hang, unless
 -- @--no-yolo@ is set. Interactive sessions prompt on mutating tools, unless
@@ -135,6 +142,9 @@ isOneShot options = isJust options.optPrompt || isJust options.optPromptFile
 resolveApprovalPolicy :: CliOptions -> Bool -> Bool -> ApprovalPolicy
 resolveApprovalPolicy options isTty projectAutoApprove
     | options.optYolo && not options.optNoYolo = ApproveAll
+    | options.optManagedDenyMutations = DenyMutating
+    | isJust options.optManagedTurnFile && options.optNoYolo =
+        PromptMutating
     | options.optNoYolo && not isTty = DenyMutating
     | not isTty && isOneShot options = ApproveAll
     | not isTty = DenyMutating
@@ -186,6 +196,13 @@ parseOptions options = \case
         parseOptions options { optYolo = True, optNoYolo = False } rest
     "--no-yolo" : rest ->
         parseOptions options { optNoYolo = True, optYolo = False } rest
+    "--managed-deny-mutations" : rest ->
+        parseOptions options
+            { optManagedDenyMutations = True
+            , optNoYolo = True
+            , optYolo = False
+            }
+            rest
     "--max-turns" : value : rest -> do
         turns <- parseInt "--max-turns" value
         parseOptions options { optMaxTurns = turns } rest
@@ -201,6 +218,8 @@ parseOptions options = \case
         parseOptions options { optPrompt = Just (Text.pack value) } rest
     "--prompt-file" : value : rest ->
         parseOptions options { optPromptFile = Just (unsafeEncodeUtf value) } rest
+    "--managed-turn-file" : value : rest ->
+        parseOptions options { optManagedTurnFile = Just (unsafeEncodeUtf value) } rest
     "--resume" : value : rest ->
         parseOptions options { optResume = Just (Text.pack value) } rest
     "--save-session" : rest ->
@@ -238,8 +257,13 @@ parseOptions options = \case
 
 validate :: CliOptions -> Either String CliOptions
 validate options
-    | isJust options.optPrompt && isJust options.optPromptFile =
-        Left "use either -p/--prompt or --prompt-file, not both"
+    | length
+        (filter id
+            [ isJust options.optPrompt
+            , isJust options.optPromptFile
+            , isJust options.optManagedTurnFile
+            ]) > 1 =
+        Left "use only one of -p/--prompt, --prompt-file, or --managed-turn-file"
     | options.optMaxTurns < 1 =
         Left "--max-turns must be at least 1"
     | isJust options.optResume && options.optWorktree =

--- a/packages/agent-cli/src/Agent/CLI/Timestamp.hs
+++ b/packages/agent-cli/src/Agent/CLI/Timestamp.hs
@@ -81,6 +81,12 @@ stampTurnInputs inputs = do
                 { userText = stampUserTextAt tz now userText
                 , userImages
                 }
+        UserMultimodalFiles{userText, userImages, userFiles} ->
+            UserMultimodalFiles
+                { userText = stampUserTextAt tz now userText
+                , userImages
+                , userFiles
+                }
         other -> other
 
 hasTrailingTimestamp :: Text -> Bool

--- a/packages/agent-cli/src/Agent/CLI/Turn.hs
+++ b/packages/agent-cli/src/Agent/CLI/Turn.hs
@@ -480,6 +480,8 @@ grokFrameLastUserInput = reverse . go . reverse
         UserMessage (grokUserQuery text) : rest
     go (input@UserMultimodal{userText} : rest) =
         input { userText = grokUserQuery userText } : rest
+    go (input@UserMultimodalFiles{userText} : rest) =
+        input { userText = grokUserQuery userText } : rest
     go (input : rest) = input : go rest
 
 grokUserQuery :: Text -> Text

--- a/packages/agent-cli/src/Agent/Telegram.hs
+++ b/packages/agent-cli/src/Agent/Telegram.hs
@@ -10,6 +10,7 @@ module Agent.Telegram
     , TelegramSetupOptions(..)
     , defaultTelegramSetupOptions
     , parseTelegramArgs
+    , TelegramUsersCommand(..)
     , TelegramChatKey(..)
     , TelegramState(..)
     , TelegramPendingTurn(..)
@@ -31,10 +32,18 @@ module Agent.Telegram
     ) where
 
 import Agent.CLI.AgentSessions
-    ( SessionProcessManager
+    ( SessionProcessLifetime(..)
+    , SessionProcessManager
     , closeSessionProcessManager
-    , launchSessionTurn
-    , newSessionProcessManager
+    , launchManagedTurnBounded
+    , newSessionProcessManagerWithLifetime
+    )
+import Agent.CLI.ManagedTurn
+    ( ManagedTurnMedia(..)
+    , ManagedTurnContext(..)
+    , ManagedTurnRequest(..)
+    , managedTurnRequestFromText
+    , managedTurnRequestWithGateway
     )
 import Agent.CLI.Options
     ( ApprovalPolicy(..)
@@ -60,62 +69,63 @@ import Agent.CLI.Session
     , sessionsRoot
     )
 import Agent.Telegram.Types
+import Agent.Telegram.Bridge
+    ( TelegramBridgeEnv(..)
+    , processTelegramCallbacks
+    , withTelegramBridge
+    )
+import qualified Agent.Telegram.Client as TelegramClient
+import Agent.Telegram.Log (logTelegramEvent)
 import Agent.Telegram.Markdown (markdownToTelegramHtml)
 import Agent.Telegram.Voice (transcribeWithCodex)
 import Agent.FileRetry (writeLazyFileAtomically)
 import Agent.OsPath (unsafeToFilePath)
 import Agent.Provider (Provider, parseProvider)
+import Control.Applicative ((<|>))
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async
-    ( Async
-    , async
-    , cancel
+    ( replicateConcurrently_
     , race_
-    , waitCatch
     , withAsync
     )
+import Control.Concurrent.Chan (Chan, newChan, readChan, writeChan)
 import Control.Concurrent.MVar
     ( MVar
     , modifyMVar
     , modifyMVar_
-    , newEmptyMVar
     , newMVar
-    , putMVar
     , readMVar
-    , takeMVar
     )
 import Control.Exception.Safe
     ( SomeException
     , bracket
     , displayException
     , finally
-    , mask
     , try
     , tryAny
     )
-import Control.Monad (forM_, unless, void, when)
+import Control.Monad (forM, forM_, unless, void, when)
 import Data.Aeson
-    ( FromJSON(..)
-    , Value(..)
+    ( Value(..)
     , eitherDecode
     , encode
     , object
-    , withObject
-    , (.:?)
     , (.=)
     )
-import qualified Data.Aeson.Key as Key
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Text.Encoding as TextEncoding
 import qualified Data.Map.Strict as Map
-import Data.Map.Strict (Map)
-import Data.Maybe (fromMaybe)
+import Data.Maybe (fromMaybe, maybeToList)
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
-import qualified Network.HTTP.Client as Http
+import Data.Time.Clock
+    ( addUTCTime
+    , diffUTCTime
+    , getCurrentTime
+    )
 import qualified Network.HTTP.Client.TLS as HttpTls
 import qualified System.Directory as Directory
 import System.Directory.OsPath
@@ -173,8 +183,26 @@ splitTelegramText limit text
     | limit < 1 = []
     | Text.null text = []
     | otherwise =
-        let (chunk, rest) = Text.splitAt limit text
+        let (prefix, suffix) = Text.splitAt limit text
+            splitAtBoundary
+                | Text.null suffix = Text.length prefix
+                | otherwise =
+                    fromMaybe (Text.length prefix)
+                        (preferredBoundary prefix)
+            (chunk, rest) = Text.splitAt splitAtBoundary text
         in chunk : splitTelegramText limit rest
+  where
+    preferredBoundary prefix =
+        let reverseIndex character =
+                (\index -> Text.length prefix - index - 1)
+                    <$> Text.findIndex (== character) (Text.reverse prefix)
+            newline = reverseIndex '\n'
+            space = reverseIndex ' '
+            boundary = max newline space
+            minimumUseful = max 1 (limit `div` 2)
+        in case boundary of
+            Just index | index + 1 >= minimumUseful -> Just (index + 1)
+            _ -> Nothing
 
 telegramMain :: IO ()
 telegramMain =
@@ -187,11 +215,21 @@ parseTelegramArgs = \case
     ["start"] -> Right TelegramStart
     ["stop"] -> Right TelegramStop
     ["status"] -> Right TelegramStatus
+    ["users", "list"] -> Right (TelegramUsers TelegramUsersList)
+    ["users", "add", value] ->
+        TelegramUsers . TelegramUsersAdd <$> parseUserId value
+    ["users", "remove", value] ->
+        TelegramUsers . TelegramUsersRemove <$> parseUserId value
     ["--help"] -> Right TelegramHelp
     ["-h"] -> Right TelegramHelp
     ["--version"] -> Right TelegramVersion
     "setup" : rest -> TelegramSetup <$> parseSetupOptions rest
     _ -> Left telegramUsage
+  where
+    parseUserId value =
+        case readMaybe value of
+            Just userId | userId > 0 -> Right userId
+            _ -> Left ("invalid Telegram user ID: " <> value)
 
 parseSetupOptions :: [String] -> Either String TelegramSetupOptions
 parseSetupOptions = go defaultTelegramSetupOptions
@@ -211,9 +249,16 @@ parseSetupOptions = go defaultTelegramSetupOptions
         "--allowed-user" : value : rest ->
             case readMaybe value of
                 Just userId | userId > 0 ->
-                    go options { setupAllowedUser = Just userId } rest
+                    go options
+                        { setupAllowedUsers =
+                            options.setupAllowedUsers <> [userId]
+                        }
+                        rest
                 _ -> Left ("invalid Telegram user ID: " <> value)
-        "--yolo" : rest -> go options { setupYolo = True } rest
+        "--yolo" : rest ->
+            go options { setupApprovalMode = TelegramApprovalYolo } rest
+        "--deny-mutations" : rest ->
+            go options { setupApprovalMode = TelegramApprovalDeny } rest
         "--start" : rest -> go options { setupStart = True } rest
         flag : _ -> Left ("unknown setup option: " <> flag <> "\n\n" <> telegramUsage)
 
@@ -223,9 +268,8 @@ executeTelegramCommand = \case
     TelegramRun -> runConfiguredTelegram
     TelegramStart -> startTelegram
     TelegramStop -> stopTelegram
-    TelegramStatus -> do
-        running <- telegramIsRunning
-        Text.putStrLn (if running then "agent-telegram is running" else "agent-telegram is stopped")
+    TelegramStatus -> telegramStatus
+    TelegramUsers command -> manageTelegramUsers command
     TelegramHelp -> putStrLn telegramUsage
     TelegramVersion -> putStrLn "agent-telegram 0.1.0.0"
 
@@ -236,6 +280,7 @@ telegramUsage = unlines
     , "       agent-telegram start"
     , "       agent-telegram stop"
     , "       agent-telegram status"
+    , "       agent-telegram users list|add ID|remove ID"
     , ""
     , "Setup options:"
     , "  --provider NAME       openai, xai, or openrouter"
@@ -243,9 +288,61 @@ telegramUsage = unlines
     , "  --cwd PATH            agent working directory"
     , "  --effort LEVEL        optional reasoning effort"
     , "  --allowed-user ID     numeric Telegram user ID"
-    , "  --yolo                allow mutating agent tools"
+    , "                          may be repeated"
+    , "  --yolo                auto-approve mutating agent tools"
+    , "  --deny-mutations       deny mutating agent tools"
+    , "                          default: ask with Telegram buttons"
     , "  --start               start the gateway after setup"
     ]
+
+manageTelegramUsers :: TelegramUsersCommand -> IO ()
+manageTelegramUsers command = do
+    home <- getHomeDirectory
+    configured <- doesFileExist (configPath home)
+    unless configured (die "Telegram is not configured. Run `agent-telegram setup` first.")
+    config <- loadTelegramConfig home
+    let users = config.telegramAllowedUsers
+        updated = case command of
+            TelegramUsersList -> config
+            TelegramUsersAdd userId ->
+                config { telegramAllowedUsers = Set.insert userId users }
+            TelegramUsersRemove userId ->
+                config { telegramAllowedUsers = Set.delete userId users }
+    case command of
+        TelegramUsersList ->
+            forM_ (Set.toAscList users) (Text.putStrLn . Text.pack . show)
+        _ -> do
+            when (Set.null updated.telegramAllowedUsers) $
+                die "refusing to remove the last allowed Telegram user"
+            writeLazyFileAtomically
+                (configPath home)
+                0o600
+                (encode updated)
+            Text.putStrLn "Telegram allowlist updated. Restart the gateway to apply it."
+
+telegramStatus :: IO ()
+telegramStatus = do
+    home <- getHomeDirectory
+    running <- telegramIsRunning
+    stateExists <- doesFileExist (statePathFor home)
+    state <-
+        if stateExists
+            then loadTelegramState (statePathFor home)
+            else pure emptyTelegramState
+    let queued = sum (map Map.size (Map.elems state.pendingQueues))
+        callbacks = Map.size state.pendingCallbacks
+        retries = Map.size state.retryMetadata
+        failed = length state.deadLetters
+    Text.putStrLn $
+        (if running then "agent-telegram is running" else "agent-telegram is stopped")
+            <> " · queued "
+            <> Text.pack (show queued)
+            <> " · callbacks "
+            <> Text.pack (show callbacks)
+            <> " · retries "
+            <> Text.pack (show retries)
+            <> " · failed "
+            <> Text.pack (show failed)
 
 gatewayDirectory :: OsPath -> OsPath
 gatewayDirectory home =
@@ -269,15 +366,20 @@ setupTelegram options = do
     cwd <- case options.setupCwd of
         Nothing -> unsafeToFilePath <$> getCurrentDirectory
         Just value -> unsafeToFilePath <$> makeAbsolute (unsafeEncodeUtf value)
-    allowedUser <- maybe promptAllowedUser pure options.setupAllowedUser
+    allowedUsers <- case options.setupAllowedUsers of
+        [] -> Set.singleton <$> promptAllowedUser
+        values -> pure (Set.fromList values)
     token <- readSecretLine "BotFather token: " >>= maybe
         (die "a Telegram bot token is required")
         pure
     manager <- HttpTls.newTlsManager
     let client = TelegramClient token manager
-    telegramRequest client "getMe" (object []) 15 >>= \case
+    TelegramClient.telegramRequest client "getMe" (object []) 15 >>= \case
         Left err -> die (Text.unpack err)
-        Right response -> case decodeTelegramResponse response :: Either Text Value of
+        Right response -> case
+                TelegramClient.decodeTelegramResponse response
+                    :: Either Text Value
+            of
             Left err -> die (Text.unpack err)
             Right _ -> pure ()
     let directory = gatewayDirectory home
@@ -286,8 +388,8 @@ setupTelegram options = do
             , telegramModel = options.setupModel
             , telegramCwd = cwd
             , telegramEffort = options.setupEffort
-            , telegramYolo = options.setupYolo
-            , telegramAllowedUsers = Set.singleton allowedUser
+            , telegramApprovalMode = options.setupApprovalMode
+            , telegramAllowedUsers = allowedUsers
             }
     createDirectoryIfMissing True directory
     setFileMode (unsafeToFilePath directory) 0o700
@@ -378,9 +480,10 @@ runTelegram config token = do
         root = sessionsRoot home
         gatewayDir = gatewayDirectory home
         statePath = statePathFor home
-        policy
-            | config.telegramYolo = ApproveAll
-            | otherwise = DenyMutating
+        policy = case config.telegramApprovalMode of
+            TelegramApprovalPrompt -> PromptMutating
+            TelegramApprovalDeny -> DenyMutating
+            TelegramApprovalYolo -> ApproveAll
         configuredOption = config.telegramModel >>= \model ->
             case resolveConfiguredModel catalog model of
                 Just option
@@ -399,11 +502,13 @@ runTelegram config token = do
     setFileMode (unsafeToFilePath gatewayDir) 0o700
     state <- loadTelegramState statePath
     stateVar <- newMVar state
-    workers <- newMVar Map.empty
+    workQueue <- newChan
+    scheduled <- newMVar Set.empty
     manager <- HttpTls.newTlsManager
     let client = TelegramClient token manager
-    bot <- getTelegramBot client
-    processManager <- newSessionProcessManager root
+    bot <- TelegramClient.getTelegramBot client
+    processManager <-
+        newSessionProcessManagerWithLifetime ScopedSessionProcesses root
     let runtime = TelegramRuntime
             { runtimeClient = client
             , runtimeBot = bot
@@ -412,7 +517,8 @@ runTelegram config token = do
             , runtimeSessionsRoot = root
             , runtimeStatePath = statePath
             , runtimeStateVar = stateVar
-            , runtimeWorkers = workers
+            , runtimeWorkQueue = workQueue
+            , runtimeScheduled = scheduled
             , runtimeProcessManager = processManager
             , runtimeTarget = target
             , runtimeCwd = cwd
@@ -422,7 +528,6 @@ runTelegram config token = do
     Text.putStrLn "Telegram gateway started (private and group chats)."
     race_ (pollForever runtime) (dispatchForever runtime)
         `finally` do
-            closeTelegramWorkers runtime
             closeSessionProcessManager processManager
 
 removePidFile :: OsPath -> ProcessID -> IO ()
@@ -508,7 +613,8 @@ data TelegramRuntime = TelegramRuntime
     , runtimeSessionsRoot :: !OsPath
     , runtimeStatePath :: !OsPath
     , runtimeStateVar :: !(MVar TelegramState)
-    , runtimeWorkers :: !(MVar (Map TelegramChatKey (Async ())))
+    , runtimeWorkQueue :: !(Chan TelegramChatKey)
+    , runtimeScheduled :: !(MVar (Set TelegramChatKey))
     , runtimeProcessManager :: !SessionProcessManager
     , runtimeTarget :: !ModelTarget
     , runtimeCwd :: !OsPath
@@ -519,9 +625,12 @@ data TelegramRuntime = TelegramRuntime
 pollForever :: TelegramRuntime -> IO ()
 pollForever runtime = do
     state <- readMVar runtime.runtimeStateVar
-    getUpdates runtime.runtimeClient state.nextUpdateId >>= \case
+    TelegramClient.getUpdates runtime.runtimeClient state.nextUpdateId >>= \case
         Left err -> do
-            Text.hPutStrLn stderr err
+            logTelegramEvent "poll_failed"
+                [ "error" .=
+                    redactToken runtime.runtimeClient.clientToken err
+                ]
             threadDelay 2_000_000
         Right updates ->
             forM_ updates (processUpdate runtime)
@@ -534,15 +643,19 @@ processUpdate runtime update = do
         modifyState runtime (storeUpdateAction update.updateId action)
     case handled of
         Left err ->
-            Text.hPutStrLn stderr
-                ("Telegram update could not be persisted and will be retried: "
-                    <> redactToken runtime.runtimeClient.clientToken
-                        (Text.pack (displayException err)))
+            logTelegramEvent "update_persist_failed"
+                [ "update_id" .= update.updateId
+                , "error" .=
+                    redactToken runtime.runtimeClient.clientToken
+                        (Text.pack (displayException err))
+                ]
         Right () -> pure ()
 
 data TelegramUpdateAction
     = IgnoreUpdate
     | QueueTurn !Integer !TelegramChatKey !Text !(Maybe TelegramVoice)
+    | QueueMediaTurn !TelegramPendingMediaTurn
+    | QueueCallback !TelegramPendingCallback
     deriving (Eq, Show)
 
 storeUpdateAction
@@ -557,11 +670,33 @@ storeUpdateAction updateId action current
         advanceOffset case action of
             IgnoreUpdate -> current
             QueueTurn messageId key text voice ->
-                enqueuePendingAction
+                enqueueIncomingAction
                     (RunPendingTurn
                         (TelegramPendingTurn
                             updateId messageId key text voice))
                     current
+            QueueMediaTurn pending ->
+                let prepared = pending
+                        { pendingMediaUpdateId = updateId
+                        }
+                    replaced =
+                        if pending.pendingMediaEdited
+                            then removePendingMessage
+                                pending.pendingMediaChat
+                                pending.pendingMediaMessageId
+                                current
+                            else current
+                in enqueueIncomingAction
+                    (RunPendingMediaTurn prepared)
+                    replaced
+            QueueCallback pending ->
+                current
+                    { pendingCallbacks =
+                        Map.insert
+                            pending.pendingCallbackUpdateId
+                            pending
+                            current.pendingCallbacks
+                    }
   where
     advanceOffset state =
         state
@@ -570,15 +705,148 @@ storeUpdateAction updateId action current
                     (fromMaybe 0 state.nextUpdateId))
             }
 
+enqueueIncomingAction :: PendingChatAction -> TelegramState -> TelegramState
+enqueueIncomingAction incoming state =
+    case previousBatchableAction incoming state of
+        Nothing -> enqueuePendingAction incoming state
+        Just previous ->
+            let merged = mergePendingActions previous incoming
+            in enqueuePendingAction
+                merged
+                (deletePendingAction previous state)
+
+previousBatchableAction
+    :: PendingChatAction
+    -> TelegramState
+    -> Maybe PendingChatAction
+previousBatchableAction incoming state = do
+    guardBatchable incoming
+    queue <- Map.lookup (pendingActionChatLocal incoming) state.pendingQueues
+    (_, previous) <- Map.lookupMax queue
+    guardBatchable previous
+    if pendingActionUpdateIdLocal previous
+            < pendingActionUpdateIdLocal incoming
+        then Just previous
+        else Nothing
+
+guardBatchable :: PendingChatAction -> Maybe ()
+guardBatchable = \case
+    RunPendingTurn pending
+        | pending.pendingTurnVoice == Nothing
+        , telegramCommand pending.pendingTurnText == Nothing
+        , not ("[Telegram reaction" `Text.isPrefixOf` pending.pendingTurnText) ->
+            Just ()
+    RunPendingMediaTurn pending
+        | telegramCommand pending.pendingMediaText == Nothing ->
+            Just ()
+    _ -> Nothing
+
+mergePendingActions
+    :: PendingChatAction
+    -> PendingChatAction
+    -> PendingChatAction
+mergePendingActions previous incoming =
+    let (previousText, previousMedia, previousUser, _, _, previousGroup) =
+            pendingActionParts previous
+        (incomingText, incomingMedia, incomingUser, incomingMessageId,
+            incomingEdited, incomingGroup) =
+                pendingActionParts incoming
+    in RunPendingMediaTurn TelegramPendingMediaTurn
+        { pendingMediaUpdateId = pendingActionUpdateIdLocal incoming
+        , pendingMediaMessageId = incomingMessageId
+        , pendingMediaChat = pendingActionChatLocal incoming
+        , pendingMediaUserId =
+            if incomingUser == 0 then previousUser else incomingUser
+        , pendingMediaText =
+            Text.intercalate
+                "\n\n---\n\n"
+                (filter (not . Text.null)
+                    [Text.strip previousText, Text.strip incomingText])
+        , pendingMediaAttachments = previousMedia <> incomingMedia
+        , pendingMediaEdited = incomingEdited
+        , pendingMediaGroupId = incomingGroup <|> previousGroup
+        }
+
+pendingActionParts
+    :: PendingChatAction
+    -> (Text, [TelegramMedia], Integer, Integer, Bool, Maybe Text)
+pendingActionParts = \case
+    RunPendingTurn pending ->
+        ( pending.pendingTurnText
+        , []
+        , 0
+        , pending.pendingTurnMessageId
+        , False
+        , Nothing
+        )
+    RunPendingMediaTurn pending ->
+        ( pending.pendingMediaText
+        , pending.pendingMediaAttachments
+        , pending.pendingMediaUserId
+        , pending.pendingMediaMessageId
+        , pending.pendingMediaEdited
+        , pending.pendingMediaGroupId
+        )
+    DeliverReply pending ->
+        (pending.pendingText, [], 0, fromMaybe 0 pending.pendingReplyToMessageId,
+            False, Nothing)
+
+removePendingMessage
+    :: TelegramChatKey
+    -> Integer
+    -> TelegramState
+    -> TelegramState
+removePendingMessage key messageId state =
+    state
+        { pendingQueues =
+            Map.update
+                (\queue ->
+                    let remaining =
+                            Map.filter
+                                (not . sameMessage)
+                                queue
+                    in if Map.null remaining then Nothing else Just remaining)
+                key
+                state.pendingQueues
+        }
+  where
+    sameMessage = \case
+        RunPendingTurn pending ->
+            pending.pendingTurnMessageId == messageId
+        RunPendingMediaTurn pending ->
+            pending.pendingMediaMessageId == messageId
+        DeliverReply _ -> False
+
 classifyUpdate
     :: TelegramRuntime
     -> TelegramUpdate
     -> IO TelegramUpdateAction
 classifyUpdate runtime update =
-    pure (classifyTelegramUpdate
-        runtime.runtimeBot
-        runtime.runtimeAllowedUsers
-        update)
+    case update.updateMessageReaction of
+        Just reaction
+            | reaction.messageReactionChat.telegramChatType /= "private" -> do
+                state <- readMVar runtime.runtimeStateVar
+                let key = TelegramChatKey
+                        { chatId =
+                            reaction.messageReactionChat.telegramChatId
+                        , messageThreadId = Nothing
+                        }
+                    belongsToBot =
+                        maybe False
+                            (Set.member reaction.messageReactionMessageId)
+                            (Map.lookup key state.outboundMessageIds)
+                pure $
+                    if belongsToBot
+                        then classifyTelegramUpdate
+                            runtime.runtimeBot
+                            runtime.runtimeAllowedUsers
+                            update
+                        else IgnoreUpdate
+        _ ->
+            pure (classifyTelegramUpdate
+                runtime.runtimeBot
+                runtime.runtimeAllowedUsers
+                update)
 
 classifyTelegramUpdate
     :: TelegramUser
@@ -586,35 +854,92 @@ classifyTelegramUpdate
     -> TelegramUpdate
     -> TelegramUpdateAction
 classifyTelegramUpdate bot allowedUsers update =
-    case update.updateMessage of
-        Just message
+    case update of
+        TelegramUpdate
+            { updateMessage = Just message
+            , updateEditedMessage = _
+            , updateMessageReaction = _
+            , updateCallbackQuery = _
+            }
             | Just sender <- message.messageFrom
             , sender.userId `Set.member` allowedUsers ->
-                classifyMessage bot sender message
-        _ -> case update.updateMessageReaction of
-            Just reaction
-                | reaction.messageReactionChat.telegramChatType == "private"
-                , Just sender <- reaction.messageReactionUser
-                , sender.userId `Set.member` allowedUsers ->
-                    QueueTurn
-                        reaction.messageReactionMessageId
-                        TelegramChatKey
-                            { chatId =
-                                reaction.messageReactionChat.telegramChatId
-                            , messageThreadId = Nothing
-                            }
-                        (reactionMessageText reaction)
-                        Nothing
-            _ -> IgnoreUpdate
+                setActionUpdateId update.updateId
+                    (classifyMessage bot sender message)
+        TelegramUpdate
+            { updateMessage = Nothing
+            , updateEditedMessage = Just message
+            , updateMessageReaction = _
+            , updateCallbackQuery = _
+            }
+            | Just sender <- message.messageFrom
+            , sender.userId `Set.member` allowedUsers ->
+                setActionUpdateId update.updateId
+                    (classifyEditedMessage bot sender message)
+        TelegramUpdate
+            { updateMessageReaction = Just reaction
+            , updateCallbackQuery = _
+            }
+            | Just sender <- reaction.messageReactionUser
+            , sender.userId `Set.member` allowedUsers ->
+                QueueTurn
+                    reaction.messageReactionMessageId
+                    TelegramChatKey
+                        { chatId = reaction.messageReactionChat.telegramChatId
+                        , messageThreadId = Nothing
+                        }
+                    (reactionMessageText reaction)
+                    Nothing
+        TelegramUpdate
+            { updateCallbackQuery = Just callback
+            }
+            | sender <- callback.callbackQueryFrom
+            , sender.userId `Set.member` allowedUsers
+            , Just callbackData <- callback.callbackQueryData ->
+                QueueCallback TelegramPendingCallback
+                    { pendingCallbackUpdateId = update.updateId
+                    , pendingCallbackQueryId = callback.callbackQueryId
+                    , pendingCallbackUserId = sender.userId
+                    , pendingCallbackChat =
+                        (\message -> TelegramChatKey
+                            { chatId = message.messageChat.telegramChatId
+                            , messageThreadId = message.messageThread
+                            })
+                            <$> callback.callbackQueryMessage
+                    , pendingCallbackMessageId =
+                        (.messageId) <$> callback.callbackQueryMessage
+                    , pendingCallbackData = callbackData
+                    }
+        _ -> IgnoreUpdate
+
+setActionUpdateId :: Integer -> TelegramUpdateAction -> TelegramUpdateAction
+setActionUpdateId updateId = \case
+    QueueMediaTurn pending ->
+        QueueMediaTurn pending { pendingMediaUpdateId = updateId }
+    action -> action
+
+classifyEditedMessage
+    :: TelegramUser
+    -> TelegramUser
+    -> TelegramMessage
+    -> TelegramUpdateAction
+classifyEditedMessage = classifyMessageLike True
 
 classifyMessage
     :: TelegramUser
     -> TelegramUser
     -> TelegramMessage
     -> TelegramUpdateAction
-classifyMessage bot sender message =
+classifyMessage = classifyMessageLike False
+
+classifyMessageLike
+    :: Bool
+    -> TelegramUser
+    -> TelegramUser
+    -> TelegramMessage
+    -> TelegramUpdateAction
+classifyMessageLike edited bot sender message =
     case message.messageChat.telegramChatType of
-        "private" -> queueMessage id
+        "private" -> classifyPrivateMessage
         "group" -> classifyGroupMessage
         "supergroup" -> classifyGroupMessage
         _ -> IgnoreUpdate
@@ -624,16 +949,45 @@ classifyMessage bot sender message =
         , messageThreadId = message.messageThread
         }
 
+    classifyPrivateMessage
+        | Just voice <- message.messageVoice =
+            queueVoice "[Voice message]" voice
+        | hasTelegramMedia message =
+            queueMedia
+                (fromMaybe
+                    (if edited then "[Edited Telegram media]" else "[Telegram media]")
+                    (messageContentText message))
+        | otherwise = queueMessage id
+
+    queueVoice text voice =
+        QueueTurn message.messageId key text (Just voice)
+
+    queueMedia promptText =
+        QueueMediaTurn
+            TelegramPendingMediaTurn
+                { pendingMediaUpdateId = message.messageId
+                , pendingMediaMessageId = message.messageId
+                , pendingMediaChat = key
+                , pendingMediaUserId = sender.userId
+                , pendingMediaText =
+                    messageContextPrefix message <> promptText
+                , pendingMediaAttachments = messageMediaAttachments message
+                , pendingMediaEdited = edited
+                , pendingMediaGroupId = message.messageMediaGroupId
+                }
+
     classifyGroupMessage
-        | Just rawText <- message.messageText
+        | Just rawText <- messageContentText message
         , Just target <- explicitCommandTarget (Text.strip rawText)
         , not (botUsernameMatches bot target) =
             IgnoreUpdate
         | messageRepliesToBot bot message =
             queueGroupReply
-        | Just rawText <- message.messageText
+        | Just rawText <- messageContentText message
         , Just targetedText <- groupTextForBot bot rawText =
-            queueText (attributeGroupText sender targetedText)
+            if hasTelegramMedia message
+                then queueMedia (attributeGroupText sender targetedText)
+                else queueText (attributeGroupText sender targetedText)
         | otherwise = IgnoreUpdate
 
     queueGroupReply =
@@ -643,9 +997,16 @@ classifyMessage bot sender message =
                     (attributeGroupMessage sender "[Voice message]")
                     (Just voice)
             Nothing
-                | Just rawText <- message.messageText ->
+                | hasTelegramMedia message ->
+                    queueMedia
+                        (attributeGroupMessage sender
+                            (fromMaybe
+                                (if edited then "[Edited Telegram media]" else "[Telegram media]")
+                                (messageContentText message)))
+            Nothing
+                | Just rawText <- messageContentText message ->
                     queueText (attributeGroupText sender rawText)
-            _ -> IgnoreUpdate
+            Nothing -> IgnoreUpdate
 
     queueMessage transform =
         case message.messageVoice of
@@ -654,16 +1015,237 @@ classifyMessage bot sender message =
                     (transform "[Voice message]")
                     (Just voice)
             Nothing
-                | Just rawText <- message.messageText ->
+                | hasTelegramMedia message ->
+                    queueMedia
+                        (transform
+                            (fromMaybe
+                                (if edited then "[Edited Telegram media]" else "[Telegram media]")
+                                (messageContentText message)))
+            Nothing
+                | Just rawText <- messageContentText message ->
                     queueText (transform rawText)
-            _ -> IgnoreUpdate
+            Nothing -> IgnoreUpdate
 
     queueText rawText
         | Text.null clean = IgnoreUpdate
+        | edited =
+            QueueMediaTurn TelegramPendingMediaTurn
+                { pendingMediaUpdateId = message.messageId
+                , pendingMediaMessageId = message.messageId
+                , pendingMediaChat = key
+                , pendingMediaUserId = sender.userId
+                , pendingMediaText = clean
+                , pendingMediaAttachments = []
+                , pendingMediaEdited = True
+                , pendingMediaGroupId = message.messageMediaGroupId
+                }
         | otherwise =
             QueueTurn message.messageId key clean Nothing
       where
-        clean = Text.strip rawText
+        clean
+            | telegramCommand rawText /= Nothing = Text.strip rawText
+            | otherwise =
+                Text.strip (messageContextPrefix message <> rawText)
+
+hasTelegramMedia :: TelegramMessage -> Bool
+hasTelegramMedia = not . null . messageMediaAttachments
+
+messageMediaAttachments :: TelegramMessage -> [TelegramMedia]
+messageMediaAttachments message =
+    concat
+        [ maybeToList photoAttachment
+        , maybeToList documentAttachment
+        , maybeToList audioAttachment
+        , maybeToList videoAttachment
+        , maybeToList videoNoteAttachment
+        , maybeToList animationAttachment
+        , maybeToList stickerAttachment
+        ]
+  where
+    photoAttachment =
+        case reverse message.messagePhoto of
+            photo : _ ->
+                Just TelegramMedia
+                    { telegramMediaKind = TelegramMediaPhoto
+                    , telegramMediaFile =
+                        Just TelegramFileMedia
+                            { fileMediaFileId = photo.photoFileId
+                            , fileMediaName = Nothing
+                            , fileMediaMimeType = Just "image/jpeg"
+                            , fileMediaFileSize = photo.photoFileSize
+                            , fileMediaDuration = Nothing
+                            }
+                    , telegramMediaDescription = "[Photo]"
+                    }
+            [] -> Nothing
+
+    documentAttachment =
+        fmap
+            (\document -> TelegramMedia
+                { telegramMediaKind = TelegramMediaDocument
+                , telegramMediaFile =
+                    Just TelegramFileMedia
+                        { fileMediaFileId = document.documentFileId
+                        , fileMediaName = document.documentFileName
+                        , fileMediaMimeType = document.documentMimeType
+                        , fileMediaFileSize = document.documentFileSize
+                        , fileMediaDuration = Nothing
+                        }
+                , telegramMediaDescription =
+                    "[Document: "
+                        <> fromMaybe document.documentFileId document.documentFileName
+                        <> "]"
+                })
+            message.messageDocument
+
+    audioAttachment =
+        fmap
+            (\audio -> TelegramMedia
+                { telegramMediaKind = TelegramMediaAudio
+                , telegramMediaFile =
+                    Just TelegramFileMedia
+                        { fileMediaFileId = audio.audioFileId
+                        , fileMediaName = audio.audioFileName
+                        , fileMediaMimeType = audio.audioMimeType
+                        , fileMediaFileSize = audio.audioFileSize
+                        , fileMediaDuration = Just audio.audioDuration
+                        }
+                , telegramMediaDescription =
+                    "[Audio file: "
+                        <> fromMaybe "audio" audio.audioFileName
+                        <> "]"
+                })
+            message.messageAudio
+
+    videoAttachment =
+        fmap
+            (\video -> TelegramMedia
+                { telegramMediaKind = TelegramMediaVideo
+                , telegramMediaFile =
+                    Just TelegramFileMedia
+                        { fileMediaFileId = video.videoFileId
+                        , fileMediaName = video.videoFileName
+                        , fileMediaMimeType = video.videoMimeType
+                        , fileMediaFileSize = video.videoFileSize
+                        , fileMediaDuration = Just video.videoDuration
+                        }
+                , telegramMediaDescription =
+                    "[Video file: "
+                        <> fromMaybe "video" video.videoFileName
+                        <> "]"
+                })
+            message.messageVideo
+
+    videoNoteAttachment =
+        fmap
+            (\note -> TelegramMedia
+                { telegramMediaKind = TelegramMediaVideoNote
+                , telegramMediaFile =
+                    Just TelegramFileMedia
+                        { fileMediaFileId = note.videoNoteFileId
+                        , fileMediaName = Nothing
+                        , fileMediaMimeType = Just "video/mp4"
+                        , fileMediaFileSize = note.videoNoteFileSize
+                        , fileMediaDuration = Just note.videoNoteDuration
+                        }
+                , telegramMediaDescription = "[Video note]"
+                })
+            message.messageVideoNote
+
+    animationAttachment =
+        fmap
+            (\animation -> TelegramMedia
+                { telegramMediaKind = TelegramMediaAnimation
+                , telegramMediaFile =
+                    Just TelegramFileMedia
+                        { fileMediaFileId = animation.animationFileId
+                        , fileMediaName = animation.animationFileName
+                        , fileMediaMimeType = animation.animationMimeType
+                        , fileMediaFileSize = animation.animationFileSize
+                        , fileMediaDuration = Nothing
+                        }
+                , telegramMediaDescription = "[Animation]"
+                })
+            message.messageAnimation
+
+    stickerAttachment =
+        fmap
+            (\sticker -> TelegramMedia
+                { telegramMediaKind = TelegramMediaSticker
+                , telegramMediaFile =
+                    Just TelegramFileMedia
+                        { fileMediaFileId = sticker.stickerFileId
+                        , fileMediaName = Nothing
+                        , fileMediaMimeType = Just "application/octet-stream"
+                        , fileMediaFileSize = sticker.stickerFileSize
+                        , fileMediaDuration = Nothing
+                        }
+                , telegramMediaDescription =
+                    "[Sticker"
+                        <> maybe "" (\emoji -> " " <> emoji) sticker.stickerEmoji
+                        <> "]"
+                })
+            message.messageSticker
+
+messageContentText :: TelegramMessage -> Maybe Text
+messageContentText message =
+    case message.messageText <|> message.messageCaption of
+        Just text -> Just text
+        Nothing
+            | Just _ <- message.messageVoice ->
+                Just "[Voice message]"
+            | Just audio <- message.messageAudio ->
+                Just ("[Audio file: " <> fromMaybe "audio" audio.audioFileName <> "]")
+            | Just document <- message.messageDocument ->
+                Just ("[Document: " <> fromMaybe document.documentFileId document.documentFileName <> "]")
+            | not (null message.messagePhoto) ->
+                Just "[Photo]"
+            | Just video <- message.messageVideo ->
+                Just ("[Video file: " <> fromMaybe "video" video.videoFileName <> "]")
+            | Just _ <- message.messageVideoNote ->
+                Just "[Video note]"
+            | Just _ <- message.messageAnimation ->
+                Just "[Animation]"
+            | Just sticker <- message.messageSticker ->
+                Just
+                    ("[Sticker"
+                        <> maybe "" (\emoji -> " " <> emoji) sticker.stickerEmoji
+                        <> "]")
+            | Just location <- message.messageLocation ->
+                Just
+                    ("[Location: "
+                        <> Text.pack (show location.locationLatitude)
+                        <> ", "
+                        <> Text.pack (show location.locationLongitude)
+                        <> "]")
+            | Just contact <- message.messageContact ->
+                Just ("[Contact: " <> contact.contactFirstName <> "]")
+            | Just venue <- message.messageVenue ->
+                Just ("[Venue: " <> venue.venueTitle <> "]")
+            | Just poll <- message.messagePoll ->
+                Just ("[Poll: " <> poll.pollQuestion <> "]")
+            | Just dice <- message.messageDice ->
+                Just ("[Dice: " <> dice.diceEmoji <> " " <> Text.pack (show dice.diceValue) <> "]")
+            | otherwise -> Nothing
+
+messageContextPrefix :: TelegramMessage -> Text
+messageContextPrefix message =
+    forwarded <> replied
+  where
+    forwarded =
+        case message.messageForwardOrigin of
+            Nothing -> ""
+            Just _ -> "[Forwarded Telegram message]\n"
+    replied =
+        case message.messageReplyTo of
+            Just replyMessage
+                | Just content <- messageContentText replyMessage ->
+                    "[Replying to Telegram message "
+                    <> Text.pack (show replyMessage.messageId)
+                    <> ": "
+                    <> Text.take 1000 (Text.replace "\n" " " content)
+                    <> "]\n"
+            _ -> ""
 
 messageRepliesToBot :: TelegramUser -> TelegramMessage -> Bool
 messageRepliesToBot bot message =
@@ -791,49 +1373,54 @@ updateAlreadyStored :: Integer -> TelegramState -> Bool
 updateAlreadyStored updateId state =
     maybe False (> updateId) state.nextUpdateId
         || any (Map.member updateId) state.pendingQueues
+        || Map.member updateId state.pendingCallbacks
 
 dispatchForever :: TelegramRuntime -> IO ()
-dispatchForever runtime = do
+dispatchForever runtime =
+    race_
+        (scheduleTelegramWorkForever runtime)
+        (replicateConcurrently_ 8 (telegramWorkerLoop runtime))
+
+scheduleTelegramWorkForever :: TelegramRuntime -> IO ()
+scheduleTelegramWorkForever runtime = do
+    processTelegramCallbacks
+        runtime.runtimeClient
+        runtime.runtimeAllowedUsers
+        (modifyState runtime)
+        (readMVar runtime.runtimeStateVar)
     state <- readMVar runtime.runtimeStateVar
-    workers <- readMVar runtime.runtimeWorkers
+    scheduled <- readMVar runtime.runtimeScheduled
     let inactive =
             Map.keysSet state.pendingQueues
                 `Set.difference`
-                    Map.keysSet workers
-    forM_ (Set.toList inactive) (startTelegramWorker runtime)
+                    scheduled
+    forM_ (Set.toList inactive) \key -> do
+        inserted <- modifyMVar runtime.runtimeScheduled \current ->
+            if Set.member key current
+                then pure (current, False)
+                else pure (Set.insert key current, True)
+        when inserted (writeChan runtime.runtimeWorkQueue key)
     threadDelay 250_000
-    dispatchForever runtime
+    scheduleTelegramWorkForever runtime
 
-startTelegramWorker :: TelegramRuntime -> TelegramChatKey -> IO ()
-startTelegramWorker runtime key =
-    mask \restore -> do
-        startGate <- newEmptyMVar
-        worker <- async do
-            takeMVar startGate
-            restore (processChatQueue runtime key) `finally`
-                modifyMVar_ runtime.runtimeWorkers
-                    (pure . Map.delete key)
-        modifyMVar_ runtime.runtimeWorkers \workers ->
-            pure (Map.insert key worker workers)
-        putMVar startGate ()
-
-closeTelegramWorkers :: TelegramRuntime -> IO ()
-closeTelegramWorkers runtime = do
-    workers <- modifyMVar runtime.runtimeWorkers \current ->
-        pure (Map.empty, Map.elems current)
-    forM_ workers cancel
-    forM_ workers (void . waitCatch)
+telegramWorkerLoop :: TelegramRuntime -> IO ()
+telegramWorkerLoop runtime = do
+    key <- readChan runtime.runtimeWorkQueue
+    processChatQueue runtime key `finally`
+        modifyMVar_ runtime.runtimeScheduled
+            (pure . Set.delete key)
+    telegramWorkerLoop runtime
 
 processChatQueue :: TelegramRuntime -> TelegramChatKey -> IO ()
 processChatQueue runtime key =
     nextChatAction runtime key >>= \case
         Nothing -> pure ()
         Just action -> do
+            waitForActionRetry runtime action
             result <- tryAny case action of
                 DeliverReply pending -> do
                     reply runtime pending
-                    modifyState runtime
-                        (deletePendingAction (DeliverReply pending))
+                    modifyState runtime (completePendingAction action)
                 RunPendingTurn pending -> do
                     response <- case telegramCommand pending.pendingTurnText of
                         Nothing ->
@@ -850,14 +1437,43 @@ processChatQueue runtime key =
                                     pending.pendingTurnChat
                                     (Just pending.pendingTurnMessageId)
                                     response))
-                            (deletePendingAction (RunPendingTurn pending) state)
+                            (completePendingAction action state)
+                RunPendingMediaTurn pending -> do
+                    response <- case telegramCommand pending.pendingMediaText of
+                        Nothing ->
+                            withTelegramProgress
+                                runtime.runtimeClient
+                                pending.pendingMediaChat
+                                (runQueuedMediaTurn runtime pending)
+                        Just _ -> runQueuedMediaTurn runtime pending
+                    modifyState runtime \state ->
+                        enqueuePendingAction
+                            (DeliverReply
+                                (TelegramPendingReply
+                                    pending.pendingMediaUpdateId
+                                    pending.pendingMediaChat
+                                    (Just pending.pendingMediaMessageId)
+                                    response))
+                            (completePendingAction action state)
             case result of
                 Left err -> do
-                    Text.hPutStrLn stderr
-                        ("Telegram conversation worker failed and will retry: "
-                            <> redactToken runtime.runtimeClient.clientToken
-                                (Text.pack (displayException err)))
-                    threadDelay 2_000_000
+                    delay <- recordPendingFailure
+                        runtime
+                        action
+                        (redactToken
+                            runtime.runtimeClient.clientToken
+                            (Text.pack (displayException err)))
+                    logTelegramEvent "action_failed"
+                        [ "chat_id" .= (pendingActionChatLocal action).chatId
+                        , "thread_id" .=
+                            (pendingActionChatLocal action).messageThreadId
+                        , "update_id" .= pendingActionUpdateIdLocal action
+                        , "error" .=
+                            redactToken runtime.runtimeClient.clientToken
+                                (Text.pack (displayException err))
+                        ]
+                    maybe (pure ()) threadDelay delay
+                    processChatQueue runtime key
                 Right () -> processChatQueue runtime key
 
 runQueuedTurn :: TelegramRuntime -> TelegramPendingTurn -> IO Text
@@ -879,28 +1495,201 @@ runQueuedTurn runtime pending =
             pure case lookupBinding pending.pendingTurnChat state of
                 Nothing -> "No session yet. Send a prompt to create one."
                 Just sessionId -> "Session: " <> sessionId
+        Just "status" -> telegramConversationStatus runtime pending.pendingTurnChat
+        Just "retry" ->
+            retryLastDeadLetter
+                runtime
+                pending.pendingTurnChat
+                (pending.pendingTurnUpdateId + 1)
         Just command -> pure ("Unknown command: /" <> command)
         Nothing -> case pending.pendingTurnVoice of
             Nothing ->
                 runAgentTurn
                     runtime
                     pending.pendingTurnChat
+                    (telegramTurnUserId runtime pending.pendingTurnChat)
+                    (Just pending.pendingTurnMessageId)
                     pending.pendingTurnText
             Just voice ->
                 tryAny (transcribeTelegramVoice runtime pending voice) >>= \case
                     Left err -> do
-                        Text.hPutStrLn stderr $
-                            "Telegram voice transcription failed: "
-                                <> redactToken
+                        logTelegramEvent "voice_transcription_failed"
+                            [ "update_id" .= pending.pendingTurnUpdateId
+                            , "chat_id" .= pending.pendingTurnChat.chatId
+                            , "error" .=
+                                redactToken
                                     runtime.runtimeClient.clientToken
                                     (Text.pack (displayException err))
+                            ]
                         pure
                             "I could not transcribe that voice message. \
                             \Check that Codex is installed and logged in, and \
                             \that the subscription has usage available."
                     Right prompt -> do
                         checkpointVoiceTranscript runtime pending prompt
-                        runAgentTurn runtime pending.pendingTurnChat prompt
+                        runAgentTurn
+                            runtime
+                            pending.pendingTurnChat
+                            (telegramTurnUserId runtime pending.pendingTurnChat)
+                            (Just pending.pendingTurnMessageId)
+                            prompt
+
+telegramConversationStatus :: TelegramRuntime -> TelegramChatKey -> IO Text
+telegramConversationStatus runtime key = do
+    state <- readMVar runtime.runtimeStateVar
+    let queued = maybe 0 Map.size (Map.lookup key state.pendingQueues)
+        retries =
+            length
+                [ ()
+                | action <- maybe [] Map.elems
+                    (Map.lookup key state.pendingQueues)
+                , Map.member (pendingRetryKey action) state.retryMetadata
+                ]
+        failed =
+            length
+                [ ()
+                | dead <- state.deadLetters
+                , dead.deadLetterChat == Just key
+                ]
+        session = fromMaybe "none" (lookupBinding key state)
+    pure $ Text.unlines
+        [ "Session: " <> session
+        , "Queued actions: " <> Text.pack (show queued)
+        , "Retrying: " <> Text.pack (show retries)
+        , "Failed turns available for /retry: "
+            <> Text.pack (show failed)
+        ]
+
+retryLastDeadLetter
+    :: TelegramRuntime
+    -> TelegramChatKey
+    -> Integer
+    -> IO Text
+retryLastDeadLetter runtime key nextUpdateId =
+    modifyMVar runtime.runtimeStateVar \state ->
+        case takeLastDeadLetter key state.deadLetters of
+            Nothing ->
+                pure (state, "There is no failed turn to retry.")
+            Just (dead, remaining) ->
+                case dead.deadLetterAction of
+                    Nothing ->
+                        pure (state { deadLetters = remaining }
+                            , "The last failure cannot be retried.")
+                    Just action -> do
+                        let retried = rekeyPendingAction nextUpdateId action
+                            next =
+                                enqueuePendingAction retried state
+                                    { deadLetters = remaining
+                                    }
+                        saveTelegramState runtime.runtimeStatePath next
+                        pure (next, "Queued the last failed turn for retry.")
+
+takeLastDeadLetter
+    :: TelegramChatKey
+    -> [TelegramDeadLetter]
+    -> Maybe (TelegramDeadLetter, [TelegramDeadLetter])
+takeLastDeadLetter key = go [] . reverse
+  where
+    go _ [] = Nothing
+    go skipped (dead : rest)
+        | dead.deadLetterChat == Just key =
+            Just (dead, reverse rest <> reverse skipped)
+        | otherwise = go (dead : skipped) rest
+
+rekeyPendingAction :: Integer -> PendingChatAction -> PendingChatAction
+rekeyPendingAction updateId = \case
+    DeliverReply pending ->
+        DeliverReply pending { pendingUpdateId = updateId }
+    RunPendingTurn pending ->
+        RunPendingTurn pending { pendingTurnUpdateId = updateId }
+    RunPendingMediaTurn pending ->
+        RunPendingMediaTurn pending { pendingMediaUpdateId = updateId }
+
+runQueuedMediaTurn :: TelegramRuntime -> TelegramPendingMediaTurn -> IO Text
+runQueuedMediaTurn runtime pending = do
+    handle <- sessionForPrompt runtime pending.pendingMediaChat pending.pendingMediaText
+    attachments <- downloadTelegramMediaAttachments runtime handle pending
+    let imageAttachments =
+            [ media
+            | (TelegramMediaPhoto, media) <- attachments
+            ]
+        fileAttachments =
+            [ media
+            | (kind, media) <- attachments
+            , kind /= TelegramMediaPhoto
+            ]
+        request = ManagedTurnRequest
+            { managedTurnVersion = 1
+            , managedTurnText = pending.pendingMediaText
+            , managedTurnImages = imageAttachments
+            , managedTurnFiles = fileAttachments
+            , managedTurnBridgeDirectory = Nothing
+            , managedTurnContext = Nothing
+            }
+    let bridgeDir =
+            handle.sessionTempDir
+                </> unsafeEncodeUtf
+                    ("telegram-bridge-"
+                        <> maybe "turn" show (Just pending.pendingMediaMessageId))
+        bridgePath = unsafeToFilePath bridgeDir
+        gatewayRequest =
+            managedTurnRequestWithGateway
+                bridgePath
+                ManagedTurnContext
+                    { managedGateway = "telegram"
+                    , managedChatId = pending.pendingMediaChat.chatId
+                    , managedMessageThreadId =
+                        pending.pendingMediaChat.messageThreadId
+                    , managedReplyToMessageId =
+                        Just pending.pendingMediaMessageId
+                    , managedUserId = pending.pendingMediaUserId
+                    }
+                request
+        bridgeEnv = TelegramBridgeEnv
+            { telegramBridgeClient = runtime.runtimeClient
+            , telegramBridgeRequest = gatewayRequest
+            , telegramBridgeChat = pending.pendingMediaChat
+            , telegramBridgeUserId = pending.pendingMediaUserId
+            , telegramBridgeReplyTo = Just pending.pendingMediaMessageId
+            , telegramBridgeAllowedRoot =
+                unsafeToFilePath handle.sessionTempDir
+            , telegramBridgeModifyState = modifyState runtime
+            }
+    createDirectoryIfMissing True bridgeDir
+    setFileMode bridgePath 0o700
+    priorTurnCount <- loadSessionHandle
+        runtime.runtimeSessionsRoot
+        handle.sessionMeta.metaId >>= \case
+            Left err -> fail (Text.unpack err)
+            Right (_, turns) -> pure (length turns)
+    result <-
+        (withTelegramBridge bridgeEnv $
+            launchManagedTurnBounded
+                runtime.runtimeProcessManager
+                False
+                runtime.runtimePolicy
+                True
+                False
+                (Just (20 * 60 * 1_000_000))
+                handle
+                gatewayRequest)
+            `finally` cleanupTelegramBridge runtime bridgePath bridgeDir
+    (case result of
+        Left err -> fail (Text.unpack err)
+        Right _ ->
+            loadSessionHandle
+                runtime.runtimeSessionsRoot
+                handle.sessionMeta.metaId >>= \case
+                    Left err -> fail (Text.unpack err)
+                    Right (_, turns)
+                        | length turns > priorTurnCount
+                        , latestTurnMatches pending.pendingMediaText turns ->
+                            pure (renderLatestTurn turns)
+                        | otherwise ->
+                            fail
+                                "agent completed without recording \
+                                \the Telegram turn")
+        `finally` cleanupManagedTurnMedia request
 
 checkpointVoiceTranscript
     :: TelegramRuntime
@@ -943,7 +1732,10 @@ transcribeTelegramVoice runtime pending voice = do
         fail "Telegram voice message exceeds the 10-minute limit"
     when (maybe False (> 20 * 1024 * 1024) voice.voiceFileSize) $
         fail "Telegram voice message exceeds the 20 MB limit"
-    filePath <- getTelegramFilePath runtime.runtimeClient voice.voiceFileId
+    filePath <-
+        TelegramClient.getTelegramFilePath
+            runtime.runtimeClient
+            voice.voiceFileId
     let extension = case Text.toLower (Text.pack (takeExtension filePath)) of
             ".wav" -> ".wav"
             ".mp3" -> ".mp3"
@@ -957,7 +1749,11 @@ transcribeTelegramVoice runtime pending voice = do
                         <> show pending.pendingTurnUpdateId
                         <> Text.unpack extension)
     bracket
-        (downloadTelegramFile runtime.runtimeClient filePath localPath)
+        (TelegramClient.downloadTelegramFile
+            runtime.runtimeClient
+            (20 * 1024 * 1024)
+            filePath
+            localPath)
         (\path -> void (tryAny (removeFile path)))
         \path -> do
             transcriptionCwd <- Directory.getTemporaryDirectory
@@ -973,55 +1769,73 @@ transcribeTelegramVoice runtime pending voice = do
                     then rendered
                     else pending.pendingTurnText <> "\n" <> rendered
 
-data TelegramFile = TelegramFile
-    { telegramFilePath :: !(Maybe Text)
-    }
+downloadTelegramMediaAttachments
+    :: TelegramRuntime
+    -> SessionHandle
+    -> TelegramPendingMediaTurn
+    -> IO [(TelegramMediaKind, ManagedTurnMedia)]
+downloadTelegramMediaAttachments runtime handle pending =
+    concat <$> forM
+        (zip [0 :: Int ..] pending.pendingMediaAttachments)
+        \(index, media) ->
+            case media.telegramMediaFile of
+                Nothing -> pure []
+                Just file -> do
+                    filePath <- TelegramClient.getTelegramFilePath
+                        runtime.runtimeClient
+                        file.fileMediaFileId
+                    let extension =
+                            fromMaybe
+                                (kindExtension media.telegramMediaKind)
+                                (fileMediaExtension file)
+                        localPath =
+                            handle.sessionTempDir
+                                </> unsafeEncodeUtf
+                                    ("media-"
+                                        <> show pending.pendingMediaUpdateId
+                                        <> "-"
+                                        <> show index
+                                        <> extension)
+                    path <-
+                        TelegramClient.downloadTelegramFile
+                            runtime.runtimeClient
+                            (20 * 1024 * 1024)
+                            filePath
+                            localPath
+                    pure
+                        [ ( media.telegramMediaKind
+                          , ManagedTurnMedia
+                                { managedTurnMediaPath =
+                                    unsafeToFilePath path
+                                , managedTurnMediaMime =
+                                    fromMaybe "application/octet-stream"
+                                        file.fileMediaMimeType
+                                , managedTurnMediaName =
+                                    file.fileMediaName
+                                }
+                          )
+                        ]
+  where
+    fileMediaExtension file =
+        case file.fileMediaName of
+            Just name | not (Text.null name) ->
+                let ext = takeExtension (Text.unpack name)
+                in if null ext then Nothing else Just ext
+            _ -> Nothing
 
-instance FromJSON TelegramFile where
-    parseJSON = withObject "TelegramFile" \o ->
-        TelegramFile <$> o .:? "file_path"
-
-getTelegramFilePath :: TelegramClient -> Text -> IO FilePath
-getTelegramFilePath client fileId =
-    telegramRequest client "getFile" (object ["file_id" .= fileId]) 30 >>= \case
-        Left err -> fail (Text.unpack err)
-        Right response ->
-            case decodeTelegramResponse response :: Either Text TelegramFile of
-                Left err -> fail (Text.unpack err)
-                Right TelegramFile { telegramFilePath = Nothing } ->
-                    fail "Telegram getFile response did not contain file_path"
-                Right TelegramFile { telegramFilePath = Just path } ->
-                    pure (Text.unpack path)
-
-downloadTelegramFile
-    :: TelegramClient
-    -> FilePath
-    -> OsPath
-    -> IO OsPath
-downloadTelegramFile client remotePath destination = do
-    response <- tryAny do
-        request <- Http.parseRequest $
-            "https://api.telegram.org/file/bot"
-                <> Text.unpack client.clientToken
-                <> "/"
-                <> remotePath
-        Http.httpLbs
-            request
-                { Http.responseTimeout =
-                    Http.responseTimeoutMicro 60_000_000
-                }
-            client.clientManager
-    body <- case response of
-        Left err ->
-            fail . Text.unpack $
-                redactToken client.clientToken
-                    (Text.pack (displayException err))
-        Right value -> pure (Http.responseBody value)
-    when (LBS.length body > 20 * 1024 * 1024) $
-        fail "Telegram voice download exceeds the 20 MB limit"
-    LBS.writeFile (unsafeToFilePath destination) body
-    setFileMode (unsafeToFilePath destination) 0o600
-    pure destination
+    kindExtension = \case
+        TelegramMediaPhoto -> ".jpg"
+        TelegramMediaDocument -> ".bin"
+        TelegramMediaVideo -> ".mp4"
+        TelegramMediaVideoNote -> ".mp4"
+        TelegramMediaAudio -> ".ogg"
+        TelegramMediaAnimation -> ".mp4"
+        TelegramMediaSticker -> ".webp"
+        TelegramMediaLocation -> ".txt"
+        TelegramMediaContact -> ".txt"
+        TelegramMediaVenue -> ".txt"
+        TelegramMediaPoll -> ".txt"
+        TelegramMediaDice -> ".txt"
 
 nextChatAction
     :: TelegramRuntime
@@ -1038,6 +1852,137 @@ nextPendingAction
 nextPendingAction key state =
     snd <$> (Map.lookupMin =<< Map.lookup key state.pendingQueues)
 
+completePendingAction
+    :: PendingChatAction
+    -> TelegramState
+    -> TelegramState
+completePendingAction action state =
+    (deletePendingAction action state)
+        { retryMetadata =
+            Map.delete (pendingRetryKey action) state.retryMetadata
+        , deliveryCheckpoints =
+            Map.delete (pendingRetryKey action) state.deliveryCheckpoints
+        }
+
+waitForActionRetry :: TelegramRuntime -> PendingChatAction -> IO ()
+waitForActionRetry runtime action = do
+    state <- readMVar runtime.runtimeStateVar
+    case Map.lookup (pendingRetryKey action) state.retryMetadata
+        >>= (.retryNextAt) of
+        Nothing -> pure ()
+        Just retryAt -> do
+            now <- getCurrentTime
+            let micros =
+                    floor
+                        (max 0 (realToFrac (diffUTCTime retryAt now) * 1_000_000)
+                            :: Double)
+            when (micros > 0) (threadDelay micros)
+
+recordPendingFailure
+    :: TelegramRuntime
+    -> PendingChatAction
+    -> Text
+    -> IO (Maybe Int)
+recordPendingFailure runtime action err =
+    modifyMVar runtime.runtimeStateVar \state -> do
+        now <- getCurrentTime
+        let key = pendingRetryKey action
+            previous =
+                fromMaybe
+                    (TelegramRetryMetadata 0 Nothing Nothing)
+                    (Map.lookup key state.retryMetadata)
+            attempts = previous.retryAttempts + 1
+        if attempts >= 5
+            then do
+                let withoutAction =
+                        (deletePendingAction action state)
+                            { retryMetadata =
+                                Map.delete key state.retryMetadata
+                            , deadLetters =
+                                state.deadLetters
+                                    <> [ TelegramDeadLetter
+                                            { deadLetterUpdateId =
+                                                pendingActionUpdateIdLocal action
+                                            , deadLetterChat =
+                                                Just (pendingActionChatLocal action)
+                                            , deadLetterError = err
+                                            , deadLetterFailedAt = now
+                                            , deadLetterAction = Just action
+                                            }
+                                       ]
+                            }
+                    next = case failureReply action of
+                        Nothing -> withoutAction
+                        Just pending ->
+                            enqueuePendingAction
+                                (DeliverReply pending)
+                                withoutAction
+                saveTelegramState runtime.runtimeStatePath next
+                pure (next, Nothing)
+            else do
+                let seconds = min 60 (2 ^ attempts)
+                    retryAt = addUTCTime (fromIntegral seconds) now
+                    next = state
+                        { retryMetadata =
+                            Map.insert
+                                key
+                                TelegramRetryMetadata
+                                    { retryAttempts = attempts
+                                    , retryNextAt = Just retryAt
+                                    , retryLastError = Just err
+                                    }
+                                state.retryMetadata
+                        }
+                saveTelegramState runtime.runtimeStatePath next
+                pure (next, Just (seconds * 1_000_000))
+
+failureReply :: PendingChatAction -> Maybe TelegramPendingReply
+failureReply = \case
+    DeliverReply _ -> Nothing
+    RunPendingTurn pending ->
+        Just TelegramPendingReply
+            { pendingUpdateId = pending.pendingTurnUpdateId
+            , pendingChat = pending.pendingTurnChat
+            , pendingReplyToMessageId = Just pending.pendingTurnMessageId
+            , pendingText =
+                "This turn failed after 5 attempts. Send /retry to try it again."
+            }
+    RunPendingMediaTurn pending ->
+        Just TelegramPendingReply
+            { pendingUpdateId = pending.pendingMediaUpdateId
+            , pendingChat = pending.pendingMediaChat
+            , pendingReplyToMessageId = Just pending.pendingMediaMessageId
+            , pendingText =
+                "This media turn failed after 5 attempts. Send /retry to try it again."
+            }
+
+pendingRetryKey :: PendingChatAction -> Text
+pendingRetryKey action =
+    Text.intercalate ":"
+        [ Text.pack (show (pendingActionChatLocal action).chatId)
+        , maybe
+            "-"
+            (Text.pack . show)
+            (pendingActionChatLocal action).messageThreadId
+        , Text.pack (show (pendingActionUpdateIdLocal action))
+        , case action of
+            DeliverReply _ -> "reply"
+            RunPendingTurn _ -> "turn"
+            RunPendingMediaTurn _ -> "media"
+        ]
+
+pendingActionUpdateIdLocal :: PendingChatAction -> Integer
+pendingActionUpdateIdLocal = \case
+    DeliverReply pending -> pending.pendingUpdateId
+    RunPendingTurn pending -> pending.pendingTurnUpdateId
+    RunPendingMediaTurn pending -> pending.pendingMediaUpdateId
+
+pendingActionChatLocal :: PendingChatAction -> TelegramChatKey
+pendingActionChatLocal = \case
+    DeliverReply pending -> pending.pendingChat
+    RunPendingTurn pending -> pending.pendingTurnChat
+    RunPendingMediaTurn pending -> pending.pendingMediaChat
+
 telegramCommand :: Text -> Maybe Text
 telegramCommand text = do
     firstWord <- case Text.words text of
@@ -1046,8 +1991,14 @@ telegramCommand text = do
     withoutSlash <- Text.stripPrefix "/" firstWord
     pure (Text.toLower (Text.takeWhile (/= '@') withoutSlash))
 
-runAgentTurn :: TelegramRuntime -> TelegramChatKey -> Text -> IO Text
-runAgentTurn runtime key prompt = do
+runAgentTurn
+    :: TelegramRuntime
+    -> TelegramChatKey
+    -> Integer
+    -> Maybe Integer
+    -> Text
+    -> IO Text
+runAgentTurn runtime key userId replyToMessageId prompt = do
     handle <- sessionForPrompt runtime key prompt
     let agentPrompt =
             prompt
@@ -1055,19 +2006,72 @@ runAgentTurn runtime key prompt = do
                 \only a lightweight acknowledgement, you may respond with \
                 \exactly one standard Telegram reaction emoji. Otherwise \
                 \respond normally. Do not mention this delivery context.]"
+    runManagedAgentTurn
+        runtime
+        handle
+        key
+        userId
+        replyToMessageId
+        (managedTurnRequestFromText agentPrompt)
+        agentPrompt
+
+runManagedAgentTurn
+    :: TelegramRuntime
+    -> SessionHandle
+    -> TelegramChatKey
+    -> Integer
+    -> Maybe Integer
+    -> ManagedTurnRequest
+    -> Text
+    -> IO Text
+runManagedAgentTurn
+        runtime handle key userId replyToMessageId baseRequest expectedPrompt = do
+    let bridgeDir =
+            handle.sessionTempDir
+                </> unsafeEncodeUtf
+                    ("telegram-bridge-"
+                        <> maybe "turn" show replyToMessageId)
+        bridgePath = unsafeToFilePath bridgeDir
+        request =
+            managedTurnRequestWithGateway
+                bridgePath
+                ManagedTurnContext
+                    { managedGateway = "telegram"
+                    , managedChatId = key.chatId
+                    , managedMessageThreadId = key.messageThreadId
+                    , managedReplyToMessageId = replyToMessageId
+                    , managedUserId = userId
+                    }
+                baseRequest
+        bridgeEnv = TelegramBridgeEnv
+            { telegramBridgeClient = runtime.runtimeClient
+            , telegramBridgeRequest = request
+            , telegramBridgeChat = key
+            , telegramBridgeUserId = userId
+            , telegramBridgeReplyTo = replyToMessageId
+            , telegramBridgeAllowedRoot =
+                unsafeToFilePath handle.sessionTempDir
+            , telegramBridgeModifyState = modifyState runtime
+            }
+    createDirectoryIfMissing True bridgeDir
+    setFileMode bridgePath 0o700
     priorTurnCount <- loadSessionHandle
         runtime.runtimeSessionsRoot
         handle.sessionMeta.metaId >>= \case
             Left err -> fail (Text.unpack err)
             Right (_, turns) -> pure (length turns)
-    launchSessionTurn
-        runtime.runtimeProcessManager
-        False
-        runtime.runtimePolicy
-        True
-        False
-        handle
-        agentPrompt >>= \case
+    (withTelegramBridge bridgeEnv $
+        launchManagedTurnBounded
+            runtime.runtimeProcessManager
+            False
+            runtime.runtimePolicy
+            True
+            False
+            (Just (20 * 60 * 1_000_000))
+            handle
+            request)
+        `finally` cleanupTelegramBridge runtime bridgePath bridgeDir
+        >>= \case
             Left err -> fail (Text.unpack err)
             Right _ ->
                 loadSessionHandle
@@ -1076,12 +2080,43 @@ runAgentTurn runtime key prompt = do
                         Left err -> fail (Text.unpack err)
                         Right (_, turns)
                             | length turns > priorTurnCount
-                            , latestTurnMatches agentPrompt turns ->
+                            , latestTurnMatches expectedPrompt turns ->
                                 pure (renderLatestTurn turns)
                             | otherwise ->
                                 fail
                                     "agent completed without recording \
                                     \the Telegram turn"
+
+telegramTurnUserId :: TelegramRuntime -> TelegramChatKey -> Integer
+telegramTurnUserId runtime key
+    | key.chatId > 0 = key.chatId
+    | Set.size runtime.runtimeAllowedUsers == 1 =
+        Set.findMin runtime.runtimeAllowedUsers
+    | otherwise = 0
+
+cleanupManagedTurnMedia :: ManagedTurnRequest -> IO ()
+cleanupManagedTurnMedia request =
+    forM_
+        (request.managedTurnImages <> request.managedTurnFiles)
+        \media ->
+            void $ tryAny $
+                removeFile (unsafeEncodeUtf media.managedTurnMediaPath)
+
+cleanupTelegramBridge
+    :: TelegramRuntime
+    -> FilePath
+    -> OsPath
+    -> IO ()
+cleanupTelegramBridge runtime bridgePath bridgeDir = do
+    modifyState runtime \state ->
+        state
+            { callbackBindings =
+                Map.filter
+                    ((/= bridgePath) . (.callbackBindingBridgeDirectory))
+                    state.callbackBindings
+            }
+    void $ tryAny $
+        Directory.removePathForcibly (unsafeToFilePath bridgeDir)
 
 latestTurnMatches :: Text -> [SessionTurn] -> Bool
 latestTurnMatches prompt turns = case reverse turns of
@@ -1142,7 +2177,7 @@ reply :: TelegramRuntime -> TelegramPendingReply -> IO ()
 reply runtime pending
     | Just emoji <- telegramReactionEmoji pending.pendingText
     , Just messageId <- pending.pendingReplyToMessageId = do
-        setMessageReaction
+        TelegramClient.setMessageReaction
             runtime.runtimeClient
             pending.pendingChat
             messageId
@@ -1159,8 +2194,14 @@ reply runtime pending
         let chunks = case splitTelegramText 600 pending.pendingText of
                 [] -> ["(empty response)"]
                 values -> values
-        forM_ (zip [0 :: Int ..] chunks) \(index, chunk) ->
-            sendRichMessage
+            checkpointKey =
+                pendingRetryKey (DeliverReply pending)
+        state <- readMVar runtime.runtimeStateVar
+        let startIndex =
+                fromMaybe 0
+                    (Map.lookup checkpointKey state.deliveryCheckpoints)
+        forM_ (drop startIndex (zip [0 :: Int ..] chunks)) \(index, chunk) ->
+            TelegramClient.sendRichMessage
                 runtime.runtimeClient
                 pending.pendingChat
                 (if index == 0
@@ -1168,7 +2209,25 @@ reply runtime pending
                     else Nothing)
                 chunk >>= \case
                     Left err -> fail (Text.unpack err)
-                    Right () -> pure ()
+                    Right messageId ->
+                        modifyState runtime \current ->
+                            current
+                                { deliveryCheckpoints =
+                                    Map.insert
+                                        checkpointKey
+                                        (index + 1)
+                                        current.deliveryCheckpoints
+                                , outboundMessageIds =
+                                    maybe
+                                        current.outboundMessageIds
+                                        (\sentId ->
+                                            Map.insertWith
+                                                Set.union
+                                                pending.pendingChat
+                                                (Set.singleton sentId)
+                                                current.outboundMessageIds)
+                                        messageId
+                                }
 
 telegramReactionEmoji :: Text -> Maybe Text
 telegramReactionEmoji text =
@@ -1197,8 +2256,8 @@ withTelegramProgress
     -> IO a
 withTelegramProgress client key action =
     withTelegramProgressUsing
-        (sendTypingAction client key)
-        (sendThinkingDraft client key)
+        (TelegramClient.sendTypingAction client key)
+        (TelegramClient.sendThinkingDraft client key "Thinking…")
         action
 
 withTelegramProgressUsing :: IO () -> IO () -> IO a -> IO a
@@ -1216,225 +2275,6 @@ withTelegramProgressUsing sendTyping sendDraft action =
             void (tryAny sendDraft)
         threadDelay 4_000_000
         loop (tick + 1)
-
-sendTypingAction :: TelegramClient -> TelegramChatKey -> IO ()
-sendTypingAction client key =
-    telegramRequest client "sendChatAction" body 30 >>= \case
-        Left err -> fail (Text.unpack err)
-        Right response ->
-            case decodeTelegramResponse response :: Either Text Bool of
-                Left err -> fail (Text.unpack err)
-                Right _ -> pure ()
-  where
-    body = object $
-        [ "chat_id" .= key.chatId
-        , "action" .= ("typing" :: Text)
-        ]
-            <> maybe []
-                (\threadId -> ["message_thread_id" .= threadId])
-                key.messageThreadId
-
-telegramReplyParameters :: Maybe Integer -> [(Key.Key, Value)]
-telegramReplyParameters =
-    maybe [] \messageId ->
-        [ "reply_parameters" .= object
-            [ "message_id" .= messageId
-            , "allow_sending_without_reply" .= True
-            ]
-        ]
-
-sendThinkingDraft :: TelegramClient -> TelegramChatKey -> IO ()
-sendThinkingDraft client key =
-    telegramRequest client "sendRichMessageDraft" body 30 >>= \case
-        Left err -> fail (Text.unpack err)
-        Right response ->
-            case decodeTelegramResponse response :: Either Text Bool of
-                Left err -> fail (Text.unpack err)
-                Right _ -> pure ()
-  where
-    body = object $
-        [ "chat_id" .= key.chatId
-        , "draft_id" .= (1 :: Int)
-        , "rich_message" .= object
-            [ "html" .=
-                ("<tg-thinking>✨ Thinking…</tg-thinking>" :: Text)
-            ]
-        ]
-            <> maybe []
-                (\threadId -> ["message_thread_id" .= threadId])
-                key.messageThreadId
-
-getUpdates
-    :: TelegramClient
-    -> Maybe Integer
-    -> IO (Either Text [TelegramUpdate])
-getUpdates client offset =
-    telegramRequest client "getUpdates" body 45 >>= \case
-        Left err -> pure (Left err)
-        Right response -> pure (decodeTelegramResponse response)
-  where
-    body = object $
-        [ "timeout" .= (30 :: Int)
-        , "allowed_updates" .=
-            (["message", "message_reaction"] :: [Text])
-        ]
-            <> maybe [] (\value -> ["offset" .= value]) offset
-
-getTelegramBot :: TelegramClient -> IO TelegramUser
-getTelegramBot client =
-    telegramRequest client "getMe" (object []) 15 >>= \case
-        Left err -> fail (Text.unpack err)
-        Right response ->
-            case decodeTelegramResponse response of
-                Left err -> fail (Text.unpack err)
-                Right bot -> pure bot
-
-setMessageReaction
-    :: TelegramClient
-    -> TelegramChatKey
-    -> Integer
-    -> Text
-    -> IO (Either Text ())
-setMessageReaction client key messageId emoji =
-    telegramRequest client "setMessageReaction" body 30 >>= \case
-        Left err -> pure (Left err)
-        Right response ->
-            pure (() <$ (decodeTelegramResponse response :: Either Text Bool))
-  where
-    body = object
-        [ "chat_id" .= key.chatId
-        , "message_id" .= messageId
-        , "reaction" .=
-            [ object
-                [ "type" .= ("emoji" :: Text)
-                , "emoji" .= emoji
-                ]
-            ]
-        ]
-
-sendRichMessage
-    :: TelegramClient
-    -> TelegramChatKey
-    -> Maybe Integer
-    -> Text
-    -> IO (Either Text ())
-sendRichMessage client key replyToMessageId text =
-    telegramRequest client "sendRichMessage" richBody 30 >>= \case
-        Right response
-            | Right (_ :: Value) <- decodeTelegramResponse response ->
-                pure (Right ())
-        _ -> sendHtmlMessage client key replyToMessageId text
-  where
-    richBody = object $
-        [ "chat_id" .= key.chatId
-        , "rich_message" .= object
-            [ "html" .= markdownToTelegramHtml text
-            ]
-        ]
-            <> maybe []
-                (\threadId -> ["message_thread_id" .= threadId])
-                key.messageThreadId
-            <> telegramReplyParameters replyToMessageId
-
-sendHtmlMessage
-    :: TelegramClient
-    -> TelegramChatKey
-    -> Maybe Integer
-    -> Text
-    -> IO (Either Text ())
-sendHtmlMessage client key replyToMessageId text =
-    telegramRequest client "sendMessage" htmlBody 30 >>= \case
-        Right response
-            | Right (_ :: Value) <- decodeTelegramResponse response ->
-                pure (Right ())
-        _ -> sendPlainMessage client key replyToMessageId text
-  where
-    htmlBody = object $
-        [ "chat_id" .= key.chatId
-        , "text" .= markdownToTelegramHtml text
-        , "parse_mode" .= ("HTML" :: Text)
-        ]
-            <> maybe []
-                (\threadId -> ["message_thread_id" .= threadId])
-                key.messageThreadId
-            <> telegramReplyParameters replyToMessageId
-
-sendPlainMessage
-    :: TelegramClient
-    -> TelegramChatKey
-    -> Maybe Integer
-    -> Text
-    -> IO (Either Text ())
-sendPlainMessage client key replyToMessageId text =
-    telegramRequest client "sendMessage"
-        (messageBody key replyToMessageId text)
-        30 >>= \case
-        Left err -> pure (Left err)
-        Right response ->
-            pure (() <$ (decodeTelegramResponse response :: Either Text Value))
-
-messageBody :: TelegramChatKey -> Maybe Integer -> Text -> Value
-messageBody key replyToMessageId text =
-    object $
-        [ "chat_id" .= key.chatId
-        , "text" .= text
-        ]
-            <> maybe []
-                (\threadId -> ["message_thread_id" .= threadId])
-                key.messageThreadId
-            <> telegramReplyParameters replyToMessageId
-
-telegramRequest
-    :: TelegramClient
-    -> String
-    -> Value
-    -> Int
-    -> IO (Either Text LBS.ByteString)
-telegramRequest client method body timeoutSeconds =
-    tryAny request >>= \case
-        Left err ->
-            pure $ Left $
-                "Telegram request failed: "
-                    <> redactToken client.clientToken
-                        (Text.pack (displayException err))
-        Right response -> pure (Right (Http.responseBody response))
-  where
-    request = do
-        base <- Http.parseRequest $
-            "https://api.telegram.org/bot"
-                <> Text.unpack client.clientToken
-                <> "/"
-                <> method
-        let configured = base
-                { Http.method = "POST"
-                , Http.requestHeaders =
-                    [("Content-Type", "application/json")]
-                , Http.requestBody = Http.RequestBodyLBS (encode body)
-                , Http.responseTimeout =
-                    Http.responseTimeoutMicro
-                        (timeoutSeconds * 1_000_000)
-                }
-        Http.httpLbs configured client.clientManager
-
-decodeTelegramResponse
-    :: forall a. FromJSON a
-    => LBS.ByteString
-    -> Either Text a
-decodeTelegramResponse bytes = do
-    envelope <- case
-            eitherDecode bytes
-                :: Either String (TelegramResponse a)
-        of
-        Left err -> Left ("Telegram returned invalid JSON: " <> Text.pack err)
-        Right value -> Right value
-    if envelope.responseOk
-        then maybe
-            (Left "Telegram response did not contain a result")
-            Right
-            envelope.responseResult
-        else Left $
-            "Telegram API error: "
-                <> fromMaybe "unknown error" envelope.responseDescription
 
 loadTelegramState :: OsPath -> IO TelegramState
 loadTelegramState path = do

--- a/packages/agent-cli/src/Agent/Telegram/Bridge.hs
+++ b/packages/agent-cli/src/Agent/Telegram/Bridge.hs
@@ -1,0 +1,504 @@
+-- | Parent-side Telegram implementation of the private managed-turn bridge.
+module Agent.Telegram.Bridge
+    ( TelegramBridgeEnv(..)
+    , withTelegramBridge
+    , processTelegramCallbacks
+    ) where
+
+import Agent.CLI.GatewayBridge
+    ( ManagedActivity(..)
+    , ManagedBridgeRequest(..)
+    , ManagedBridgeResponse(..)
+    , managedBridgeActivityPath
+    , managedBridgeRequestsDirectory
+    , writeManagedBridgeResponse
+    , writeManagedBridgeResponseAt
+    )
+import Agent.CLI.ManagedTurn (ManagedTurnRequest(..))
+import Agent.FileRetry (retryOnFileBusy)
+import Agent.OsPath (unsafeToFilePath)
+import qualified Agent.Telegram.Client as Client
+import Agent.Telegram.Types
+import Control.Concurrent (threadDelay)
+import Control.Concurrent.Async (withAsync)
+import Control.Exception.Safe (SomeException, displayException, try)
+import Control.Monad (forM_, void, when)
+import Data.Aeson
+    ( FromJSON(..)
+    , Result(..)
+    , Value(..)
+    , eitherDecode
+    , fromJSON
+    , withObject
+    , (.:)
+    , (.:?)
+    )
+import qualified Data.ByteString.Lazy as LBS
+import Data.IORef
+    ( IORef
+    , modifyIORef'
+    , newIORef
+    , readIORef
+    )
+import Data.List (isPrefixOf)
+import qualified Data.Map.Strict as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Set as Set
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Data.Time.Clock (addUTCTime, getCurrentTime)
+import System.Directory
+    ( canonicalizePath
+    , doesFileExist
+    , listDirectory
+    )
+import System.FilePath (addTrailingPathSeparator)
+
+data TelegramBridgeEnv = TelegramBridgeEnv
+    { telegramBridgeClient :: !TelegramClient
+    , telegramBridgeRequest :: !ManagedTurnRequest
+    , telegramBridgeChat :: !TelegramChatKey
+    , telegramBridgeUserId :: !Integer
+    , telegramBridgeReplyTo :: !(Maybe Integer)
+    , telegramBridgeAllowedRoot :: !FilePath
+    , telegramBridgeModifyState ::
+        !((TelegramState -> TelegramState) -> IO ())
+    }
+
+data PathRequest = PathRequest
+    { pathRequestPath :: !FilePath
+    , pathRequestCaption :: !(Maybe Text)
+    , pathRequestFilename :: !(Maybe Text)
+    }
+
+instance FromJSON PathRequest where
+    parseJSON = withObject "PathRequest" \o ->
+        PathRequest
+            <$> (Text.unpack <$> o .: "path")
+            <*> o .:? "caption"
+            <*> o .:? "filename"
+
+data ReactionRequest = ReactionRequest
+    { reactionRequestEmoji :: !Text
+    , reactionRequestMessageId :: !(Maybe Integer)
+    }
+
+instance FromJSON ReactionRequest where
+    parseJSON = withObject "ReactionRequest" \o ->
+        ReactionRequest <$> o .: "emoji" <*> o .:? "message_id"
+
+data ChoiceRequest = ChoiceRequest
+    { choiceRequestQuestion :: !Text
+    , choiceRequestOptions :: ![Text]
+    }
+
+instance FromJSON ChoiceRequest where
+    parseJSON = withObject "ChoiceRequest" \o ->
+        ChoiceRequest <$> o .: "question" <*> o .: "options"
+
+data ApprovalRequest = ApprovalRequest
+    { approvalToolName :: !Text
+    , approvalArguments :: !Text
+    }
+
+instance FromJSON ApprovalRequest where
+    parseJSON = withObject "ApprovalRequest" \o ->
+        ApprovalRequest <$> o .: "tool_name" <*> o .: "arguments"
+
+withTelegramBridge :: TelegramBridgeEnv -> IO a -> IO a
+withTelegramBridge env action =
+    withAsync (bridgeLoop env) (const action)
+
+bridgeLoop :: TelegramBridgeEnv -> IO ()
+bridgeLoop env = do
+    seen <- newIORef Set.empty
+    go seen (0 :: Int)
+  where
+    go seen tick = do
+        processBridgeRequests env seen
+        when (tick `mod` 40 == 0) (publishActivity env)
+        threadDelay 100_000
+        go seen (tick + 1)
+
+processBridgeRequests :: TelegramBridgeEnv -> IORef (Set.Set FilePath) -> IO ()
+processBridgeRequests env seenRef = do
+    let directory =
+            unsafeToFilePath
+                (managedBridgeRequestsDirectory env.telegramBridgeRequest)
+    files <- try @_ @SomeException (listDirectory directory) >>= \case
+        Left _ -> pure []
+        Right values -> pure values
+    seen <- readIORef seenRef
+    forM_ (filter (`Set.notMember` seen) files) \name -> do
+        let path = directory <> "/" <> name
+        decodeBridgeRequest path >>= \case
+            Nothing -> pure ()
+            Just request -> do
+                modifyIORef' seenRef (Set.insert name)
+                processBridgeRequest env request
+
+decodeBridgeRequest :: FilePath -> IO (Maybe ManagedBridgeRequest)
+decodeBridgeRequest path =
+    try @_ @SomeException
+        (retryOnFileBusy (LBS.readFile path)) >>= \case
+            Left _ -> pure Nothing
+            Right bytes ->
+                pure (either (const Nothing) Just (eitherDecode bytes))
+
+processBridgeRequest :: TelegramBridgeEnv -> ManagedBridgeRequest -> IO ()
+processBridgeRequest env request =
+    try @_ @SomeException (dispatch request) >>= \case
+        Left err ->
+            respondError env request
+                (Text.pack (displayException err))
+        Right (Left err) -> respondError env request err
+        Right (Right Nothing) -> pure ()
+        Right (Right (Just result)) -> respondOk env request result
+  where
+    dispatch current =
+        case current.bridgeRequestKind of
+            "send_document" ->
+                withPathPayload current \(payload :: PathRequest) ->
+                    sendPath Client.sendTelegramDocument payload
+            "send_photo" ->
+                withPathPayload current \(payload :: PathRequest) ->
+                    sendPath Client.sendTelegramPhoto payload
+            "send_voice" ->
+                withPathPayload current \(payload :: PathRequest) ->
+                    sendPath Client.sendTelegramVoice payload
+            "react" ->
+                withPayload current \(payload :: ReactionRequest) -> do
+                    let messageId =
+                            fromMaybe
+                                (fromMaybe 0 env.telegramBridgeReplyTo)
+                                payload.reactionRequestMessageId
+                    if messageId <= 0
+                        then pure (Left
+                            "no Telegram message is available for a reaction")
+                        else
+                            Client.setMessageReaction
+                                env.telegramBridgeClient
+                                env.telegramBridgeChat
+                                messageId
+                                payload.reactionRequestEmoji
+                                >>= pure . fmap (const (Just (String "reaction sent")))
+            "ask_choice" ->
+                withPayload current \(payload :: ChoiceRequest) ->
+                    registerChoice env current
+                        payload.choiceRequestQuestion
+                        [ (label, label)
+                        | label <- payload.choiceRequestOptions
+                        ]
+            "approval" ->
+                withPayload current \(payload :: ApprovalRequest) ->
+                    registerChoice env current
+                        (approvalText payload)
+                        [ ("Allow once", "allow_once")
+                        , ("Always this tool", "allow_tool")
+                        , ("Allow all", "allow_all")
+                        , ("Deny", "deny")
+                        ]
+            other ->
+                pure (Left ("unknown Telegram bridge request: " <> other))
+
+    withPathPayload current use =
+        withPayload current \payload -> do
+            allowed <- pathIsAllowed
+                env.telegramBridgeAllowedRoot
+                payload.pathRequestPath
+            if allowed
+                then use payload
+                else pure (Left
+                    "Telegram file path is outside the private session directory")
+
+    sendPath send payload =
+        send
+            env.telegramBridgeClient
+            env.telegramBridgeChat
+            payload.pathRequestPath
+            payload.pathRequestCaption
+            payload.pathRequestFilename
+            >>= pure . fmap
+                (Just . String . maybe "sent" (\messageId ->
+                    "sent Telegram message " <> Text.pack (show messageId)))
+
+withPayload
+    :: FromJSON a
+    => ManagedBridgeRequest
+    -> (a -> IO (Either Text (Maybe Value)))
+    -> IO (Either Text (Maybe Value))
+withPayload request use =
+    case fromJSON request.bridgeRequestPayload of
+        Error err -> pure (Left (Text.pack err))
+        Success payload -> use payload
+
+registerChoice
+    :: TelegramBridgeEnv
+    -> ManagedBridgeRequest
+    -> Text
+    -> [(Text, Text)]
+    -> IO (Either Text (Maybe Value))
+registerChoice env request question rawOptions = do
+    let options = take 8
+            [ (Text.take 48 (Text.strip label), value)
+            | (label, value) <- rawOptions
+            , not (Text.null (Text.strip label))
+            ]
+    if null options
+        then pure (Left "Telegram choice requires at least one option")
+        else do
+            now <- getCurrentTime
+            let expiresAt = addUTCTime (30 * 60) now
+                bindings =
+                    [ TelegramCallbackBinding
+                        { callbackBindingData =
+                            callbackToken request.bridgeRequestId index
+                        , callbackBindingRequestId = request.bridgeRequestId
+                        , callbackBindingChat = env.telegramBridgeChat
+                        , callbackBindingUserId = env.telegramBridgeUserId
+                        , callbackBindingMessageId = Nothing
+                        , callbackBindingBridgeDirectory =
+                            fromMaybe
+                                (error "Telegram bridge directory is missing")
+                                env.telegramBridgeRequest.managedTurnBridgeDirectory
+                        , callbackBindingValue = value
+                        , callbackBindingExpiresAt = expiresAt
+                        , callbackBindingConsumed = False
+                        }
+                    | (index, (_, value)) <- zip [0 :: Int ..] options
+                    ]
+                rows = chunksOf 2
+                    [ (label, binding.callbackBindingData)
+                    | ((label, _), binding) <- zip options bindings
+                    ]
+            env.telegramBridgeModifyState \state ->
+                state
+                    { callbackBindings =
+                        foldr
+                            (\binding ->
+                                Map.insert
+                                    binding.callbackBindingData
+                                    binding)
+                            state.callbackBindings
+                            bindings
+                    }
+            Client.sendMessageWithKeyboard
+                env.telegramBridgeClient
+                env.telegramBridgeChat
+                env.telegramBridgeReplyTo
+                question
+                rows >>= \case
+                    Left err -> do
+                        removeRequestBindings env request.bridgeRequestId
+                        pure (Left err)
+                    Right messageId -> do
+                        env.telegramBridgeModifyState \state ->
+                            state
+                                { callbackBindings =
+                                    fmap
+                                        (\binding ->
+                                            if binding.callbackBindingRequestId
+                                                == request.bridgeRequestId
+                                                then binding
+                                                    { callbackBindingMessageId =
+                                                        messageId
+                                                    }
+                                                else binding)
+                                        state.callbackBindings
+                                }
+                        pure (Right Nothing)
+
+removeRequestBindings :: TelegramBridgeEnv -> Text -> IO ()
+removeRequestBindings env requestId =
+    env.telegramBridgeModifyState \state ->
+        state
+            { callbackBindings =
+                Map.filter
+                    ((/= requestId) . (.callbackBindingRequestId))
+                    state.callbackBindings
+            }
+
+processTelegramCallbacks
+    :: TelegramClient
+    -> Set.Set Integer
+    -> ((TelegramState -> TelegramState) -> IO ())
+    -> IO TelegramState
+    -> IO ()
+processTelegramCallbacks client allowedUsers modifyState readState =
+    readState >>= \state ->
+        case Map.lookupMin state.pendingCallbacks of
+            Nothing -> pure ()
+            Just (updateId, callback) -> do
+                now <- getCurrentTime
+                case Map.lookup callback.pendingCallbackData state.callbackBindings of
+                    Nothing ->
+                        finishInvalid updateId callback
+                            "This button has expired."
+                    Just binding
+                        | binding.callbackBindingConsumed ->
+                            finishInvalid updateId callback
+                                "This button was already used."
+                        | binding.callbackBindingExpiresAt < now ->
+                            finishInvalid updateId callback
+                                "This button has expired."
+                        | callback.pendingCallbackUserId
+                            `Set.notMember` allowedUsers ->
+                            finishInvalid updateId callback
+                                "You are not allowed to use this button."
+                        | binding.callbackBindingUserId /= 0
+                        , binding.callbackBindingUserId
+                            /= callback.pendingCallbackUserId ->
+                            finishInvalid updateId callback
+                                "This button belongs to another user."
+                        | not (callbackChatMatches binding callback) ->
+                            finishInvalid updateId callback
+                                "This button belongs to another conversation."
+                        | otherwise -> do
+                            writeManagedBridgeResponseAt
+                                binding.callbackBindingBridgeDirectory
+                                ManagedBridgeResponse
+                                    { bridgeResponseVersion = 1
+                                    , bridgeResponseId =
+                                        binding.callbackBindingRequestId
+                                    , bridgeResponseOk = True
+                                    , bridgeResponseResult =
+                                        Just (String binding.callbackBindingValue)
+                                    , bridgeResponseError = Nothing
+                                    }
+                            void $ Client.answerCallbackQuery
+                                client
+                                callback.pendingCallbackQueryId
+                                (Just "Selected")
+                            forM_ binding.callbackBindingMessageId \messageId ->
+                                void $ Client.editMessageText
+                                    client
+                                    binding.callbackBindingChat
+                                    messageId
+                                    ("Selected: " <> binding.callbackBindingValue)
+                            modifyState \current ->
+                                current
+                                    { pendingCallbacks =
+                                        Map.delete updateId current.pendingCallbacks
+                                    , callbackBindings =
+                                        Map.filter
+                                            ((/= binding.callbackBindingRequestId)
+                                                . (.callbackBindingRequestId))
+                                            current.callbackBindings
+                                    }
+                processTelegramCallbacks
+                    client
+                    allowedUsers
+                    modifyState
+                    readState
+  where
+    finishInvalid updateId callback message = do
+        void $ Client.answerCallbackQuery
+            client
+            callback.pendingCallbackQueryId
+            (Just message)
+        modifyState \state ->
+            state
+                { pendingCallbacks =
+                    Map.delete updateId state.pendingCallbacks
+                }
+
+callbackChatMatches
+    :: TelegramCallbackBinding
+    -> TelegramPendingCallback
+    -> Bool
+callbackChatMatches binding callback =
+    case callback.pendingCallbackChat of
+        Nothing -> False
+        Just key -> key == binding.callbackBindingChat
+
+publishActivity :: TelegramBridgeEnv -> IO ()
+publishActivity env = do
+    let path = unsafeToFilePath
+            (managedBridgeActivityPath env.telegramBridgeRequest)
+    exists <- doesFileExist path
+    status <-
+        if not exists
+            then pure "Thinking…"
+            else
+                try @_ @SomeException
+                    (retryOnFileBusy (LBS.readFile path)) >>= \case
+                        Left _ -> pure "Thinking…"
+                        Right bytes ->
+                            pure case
+                                    eitherDecode bytes
+                                        :: Either String ManagedActivity
+                                of
+                                Right activity ->
+                                    Text.take 100
+                                        activity.managedActivityMessage
+                                Left _ -> "Thinking…"
+    void $ try @_ @SomeException $
+        Client.sendTypingAction
+            env.telegramBridgeClient
+            env.telegramBridgeChat
+    void $ try @_ @SomeException $
+        Client.sendThinkingDraft
+            env.telegramBridgeClient
+            env.telegramBridgeChat
+            status
+
+respondOk :: TelegramBridgeEnv -> ManagedBridgeRequest -> Value -> IO ()
+respondOk env request result =
+    writeManagedBridgeResponse env.telegramBridgeRequest ManagedBridgeResponse
+        { bridgeResponseVersion = 1
+        , bridgeResponseId = request.bridgeRequestId
+        , bridgeResponseOk = True
+        , bridgeResponseResult = Just result
+        , bridgeResponseError = Nothing
+        }
+
+respondError :: TelegramBridgeEnv -> ManagedBridgeRequest -> Text -> IO ()
+respondError env request err =
+    writeManagedBridgeResponse env.telegramBridgeRequest ManagedBridgeResponse
+        { bridgeResponseVersion = 1
+        , bridgeResponseId = request.bridgeRequestId
+        , bridgeResponseOk = False
+        , bridgeResponseResult = Nothing
+        , bridgeResponseError = Just err
+        }
+
+approvalText :: ApprovalRequest -> Text
+approvalText request =
+    "Allow the agent to run "
+        <> request.approvalToolName
+        <> "?\n\n"
+        <> Text.take 1200 request.approvalArguments
+
+callbackToken :: Text -> Int -> Text
+callbackToken requestId index =
+    "ha:"
+        <> Text.takeEnd 48
+            (Text.map
+                (\char ->
+                    if isTokenChar char then char else '-')
+                requestId)
+        <> ":"
+        <> Text.pack (show index)
+  where
+    isTokenChar char =
+        ('a' <= char && char <= 'z')
+            || ('A' <= char && char <= 'Z')
+            || ('0' <= char && char <= '9')
+            || char `elem` ['-', '_']
+
+pathIsAllowed :: FilePath -> FilePath -> IO Bool
+pathIsAllowed root path = do
+    canonicalRootPath <- canonicalizePath root
+    canonicalPath <- canonicalizePath path
+    let canonicalRoot = addTrailingPathSeparator canonicalRootPath
+    pure $
+        canonicalPath == canonicalRootPath
+            || canonicalRoot `isPrefixOf` canonicalPath
+
+chunksOf :: Int -> [a] -> [[a]]
+chunksOf size values
+    | size <= 0 = []
+    | null values = []
+    | otherwise =
+        let (chunk, rest) = splitAt size values
+        in chunk : chunksOf size rest

--- a/packages/agent-cli/src/Agent/Telegram/Client.hs
+++ b/packages/agent-cli/src/Agent/Telegram/Client.hs
@@ -1,0 +1,598 @@
+-- | Telegram Bot API transport with bounded, status-aware retries.
+module Agent.Telegram.Client
+    ( TelegramRequestError(..)
+    , telegramRequest
+    , telegramRequestWith
+    , decodeTelegramResponse
+    , getUpdates
+    , getTelegramBot
+    , getTelegramFilePath
+    , downloadTelegramFile
+    , sendTypingAction
+    , sendThinkingDraft
+    , setMessageReaction
+    , sendRichMessage
+    , sendMessageWithKeyboard
+    , editMessageText
+    , answerCallbackQuery
+    , sendTelegramDocument
+    , sendTelegramPhoto
+    , sendTelegramVoice
+    , redactToken
+    ) where
+
+import Agent.Telegram.Markdown (markdownToTelegramHtml)
+import Agent.Telegram.Types
+import Control.Concurrent (threadDelay)
+import Control.Exception.Safe (displayException, tryAny)
+import Control.Monad (when)
+import Control.Retry
+    ( fullJitterBackoff
+    , limitRetries
+    , retrying
+    )
+import Data.Aeson
+    ( FromJSON(..)
+    , Value
+    , eitherDecode
+    , encode
+    , object
+    , withObject
+    , (.:?)
+    , (.=)
+    )
+import qualified Data.Aeson.Key as Key
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as BS8
+import qualified Data.ByteString.Lazy as LBS
+import qualified Data.ByteString.Lazy.Char8 as LBS8
+import Data.Maybe (fromMaybe)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Network.HTTP.Client as Http
+import Network.HTTP.Types.Status (statusCode)
+import System.Directory (doesFileExist)
+import System.FilePath (takeFileName)
+import System.OsPath (OsPath)
+import Agent.OsPath (unsafeToFilePath)
+import System.Posix.Files (setFileMode)
+
+data TelegramRequestError = TelegramRequestError
+    { telegramErrorMessage :: !Text
+    , telegramErrorCode :: !(Maybe Int)
+    , telegramRetryAfter :: !(Maybe Int)
+    , telegramErrorRetryable :: !Bool
+    } deriving (Eq, Show)
+
+data TelegramFile = TelegramFile
+    { telegramFilePath :: !(Maybe Text)
+    }
+
+instance FromJSON TelegramFile where
+    parseJSON = withObject "TelegramFile" \o ->
+        TelegramFile <$> o .:? "file_path"
+
+telegramRequest
+    :: TelegramClient
+    -> String
+    -> Value
+    -> Int
+    -> IO (Either Text LBS.ByteString)
+telegramRequest client =
+    telegramRequestWith (Http.httpLbs `flip` client.clientManager) client
+
+telegramRequestWith
+    :: (Http.Request -> IO (Http.Response LBS.ByteString))
+    -> TelegramClient
+    -> String
+    -> Value
+    -> Int
+    -> IO (Either Text LBS.ByteString)
+telegramRequestWith send client method body timeoutSeconds =
+    runRetrying client do
+        base <- Http.parseRequest $
+            "https://api.telegram.org/bot"
+                <> Text.unpack client.clientToken
+                <> "/"
+                <> method
+        let configured = base
+                { Http.method = "POST"
+                , Http.requestHeaders =
+                    [("Content-Type", "application/json")]
+                , Http.requestBody = Http.RequestBodyLBS (encode body)
+                , Http.responseTimeout =
+                    Http.responseTimeoutMicro
+                        (timeoutSeconds * 1_000_000)
+                }
+        send configured
+
+runRetrying
+    :: TelegramClient
+    -> IO (Http.Response LBS.ByteString)
+    -> IO (Either Text LBS.ByteString)
+runRetrying client request = do
+    result <- retrying
+        (fullJitterBackoff 250_000 <> limitRetries 4)
+        shouldRetry
+        (const attempt)
+    pure $ case result of
+        Left err -> Left (renderRequestError client err)
+        Right body -> Right body
+  where
+    attempt =
+        tryAny request >>= \case
+            Left err ->
+                pure $ Left TelegramRequestError
+                    { telegramErrorMessage =
+                        "Telegram request failed: "
+                            <> Text.pack (displayException err)
+                    , telegramErrorCode = Nothing
+                    , telegramRetryAfter = Nothing
+                    , telegramErrorRetryable = True
+                    }
+            Right response -> do
+                let code = statusCode (Http.responseStatus response)
+                    body = Http.responseBody response
+                pure $
+                    if code >= 200 && code < 300
+                        then case responseFailure body of
+                            Nothing -> Right body
+                            Just err -> Left err
+                        else Left $
+                            fromMaybe
+                                TelegramRequestError
+                                    { telegramErrorMessage =
+                                        "Telegram HTTP error "
+                                            <> Text.pack (show code)
+                                    , telegramErrorCode = Just code
+                                    , telegramRetryAfter = Nothing
+                                    , telegramErrorRetryable =
+                                        code == 429 || code >= 500
+                                    }
+                                (responseFailure body)
+
+    shouldRetry _ = \case
+        Right _ -> pure False
+        Left err
+            | not err.telegramErrorRetryable -> pure False
+            | otherwise -> do
+                maybe (pure ()) (\seconds ->
+                    threadDelay (max 1 seconds * 1_000_000))
+                    err.telegramRetryAfter
+                pure True
+
+responseFailure :: LBS.ByteString -> Maybe TelegramRequestError
+responseFailure bytes =
+    case eitherDecode bytes :: Either String (TelegramResponse Value) of
+        Left _ -> Nothing
+        Right envelope
+            | envelope.responseOk -> Nothing
+            | otherwise ->
+                Just TelegramRequestError
+                    { telegramErrorMessage =
+                        "Telegram API error: "
+                            <> fromMaybe
+                                "unknown error"
+                                envelope.responseDescription
+                    , telegramErrorCode = envelope.responseErrorCode
+                    , telegramRetryAfter =
+                        envelope.responseParameters >>= (.responseRetryAfter)
+                    , telegramErrorRetryable =
+                        envelope.responseErrorCode == Just 429
+                            || maybe False (>= 500) envelope.responseErrorCode
+                    }
+
+renderRequestError :: TelegramClient -> TelegramRequestError -> Text
+renderRequestError client err =
+    redactToken client.clientToken err.telegramErrorMessage
+
+decodeTelegramResponse
+    :: forall a. FromJSON a
+    => LBS.ByteString
+    -> Either Text a
+decodeTelegramResponse bytes = do
+    envelope <- case
+            eitherDecode bytes
+                :: Either String (TelegramResponse a)
+        of
+        Left err -> Left ("Telegram returned invalid JSON: " <> Text.pack err)
+        Right value -> Right value
+    if envelope.responseOk
+        then maybe
+            (Left "Telegram response did not contain a result")
+            Right
+            envelope.responseResult
+        else Left $
+            "Telegram API error: "
+                <> fromMaybe "unknown error" envelope.responseDescription
+
+getUpdates
+    :: TelegramClient
+    -> Maybe Integer
+    -> IO (Either Text [TelegramUpdate])
+getUpdates client offset =
+    telegramRequest client "getUpdates" body 45 >>= \case
+        Left err -> pure (Left err)
+        Right response -> pure (decodeTelegramResponse response)
+  where
+    body = object $
+        [ "timeout" .= (30 :: Int)
+        , "allowed_updates" .=
+            ( [ "message"
+              , "edited_message"
+              , "message_reaction"
+              , "callback_query"
+              ] :: [Text]
+            )
+        ]
+            <> maybe [] (\value -> ["offset" .= value]) offset
+
+getTelegramBot :: TelegramClient -> IO TelegramUser
+getTelegramBot client =
+    telegramRequest client "getMe" (object []) 15 >>= \case
+        Left err -> fail (Text.unpack err)
+        Right response ->
+            either (fail . Text.unpack) pure (decodeTelegramResponse response)
+
+getTelegramFilePath :: TelegramClient -> Text -> IO FilePath
+getTelegramFilePath client fileId =
+    telegramRequest client "getFile" (object ["file_id" .= fileId]) 30 >>= \case
+        Left err -> fail (Text.unpack err)
+        Right response ->
+            case decodeTelegramResponse response :: Either Text TelegramFile of
+                Left err -> fail (Text.unpack err)
+                Right TelegramFile { telegramFilePath = Nothing } ->
+                    fail "Telegram getFile response did not contain file_path"
+                Right TelegramFile { telegramFilePath = Just path } ->
+                    pure (Text.unpack path)
+
+downloadTelegramFile
+    :: TelegramClient
+    -> Integer
+    -> FilePath
+    -> OsPath
+    -> IO OsPath
+downloadTelegramFile client maxBytes remotePath destination = do
+    response <- runRetrying client do
+        request <- Http.parseRequest $
+            "https://api.telegram.org/file/bot"
+                <> Text.unpack client.clientToken
+                <> "/"
+                <> remotePath
+        Http.httpLbs
+            request
+                { Http.responseTimeout =
+                    Http.responseTimeoutMicro 60_000_000
+                }
+            client.clientManager
+    body <- either (fail . Text.unpack) pure response
+    when (LBS.length body > fromIntegral maxBytes) $
+        fail "Telegram file download exceeds the configured limit"
+    LBS.writeFile (unsafeToFilePath destination) body
+    setFileMode (unsafeToFilePath destination) 0o600
+    pure destination
+
+sendTypingAction :: TelegramClient -> TelegramChatKey -> IO ()
+sendTypingAction client key =
+    expectBool client "sendChatAction" $
+        object $
+            [ "chat_id" .= key.chatId
+            , "action" .= ("typing" :: Text)
+            ]
+                <> threadParameters key
+
+sendThinkingDraft :: TelegramClient -> TelegramChatKey -> Text -> IO ()
+sendThinkingDraft client key status =
+    expectBool client "sendRichMessageDraft" $
+        object $
+            [ "chat_id" .= key.chatId
+            , "draft_id" .= (1 :: Int)
+            , "rich_message" .= object
+                [ "html" .=
+                    ("<tg-thinking>"
+                        <> escapeHtml status
+                        <> "</tg-thinking>")
+                ]
+            ]
+                <> threadParameters key
+
+setMessageReaction
+    :: TelegramClient
+    -> TelegramChatKey
+    -> Integer
+    -> Text
+    -> IO (Either Text ())
+setMessageReaction client key messageId emoji =
+    requestUnit client "setMessageReaction" $ object
+        [ "chat_id" .= key.chatId
+        , "message_id" .= messageId
+        , "reaction" .=
+            [ object
+                [ "type" .= ("emoji" :: Text)
+                , "emoji" .= emoji
+                ]
+            ]
+        ]
+
+sendRichMessage
+    :: TelegramClient
+    -> TelegramChatKey
+    -> Maybe Integer
+    -> Text
+    -> IO (Either Text (Maybe Integer))
+sendRichMessage client key replyToMessageId text =
+    telegramRequest client "sendRichMessage" richBody 30 >>= \case
+        Right response
+            | Right messageId <- decodeSentMessageId response ->
+                pure (Right messageId)
+        _ -> sendHtmlMessage client key replyToMessageId text
+  where
+    richBody = object $
+        [ "chat_id" .= key.chatId
+        , "rich_message" .= object
+            [ "html" .= markdownToTelegramHtml text
+            ]
+        ]
+            <> threadParameters key
+            <> replyParameters replyToMessageId
+
+sendHtmlMessage
+    :: TelegramClient
+    -> TelegramChatKey
+    -> Maybe Integer
+    -> Text
+    -> IO (Either Text (Maybe Integer))
+sendHtmlMessage client key replyToMessageId text =
+    telegramRequest client "sendMessage" htmlBody 30 >>= \case
+        Right response
+            | Right messageId <- decodeSentMessageId response ->
+                pure (Right messageId)
+        _ -> sendPlainMessage client key replyToMessageId text
+  where
+    htmlBody = object $
+        [ "chat_id" .= key.chatId
+        , "text" .= markdownToTelegramHtml text
+        , "parse_mode" .= ("HTML" :: Text)
+        ]
+            <> threadParameters key
+            <> replyParameters replyToMessageId
+
+sendPlainMessage
+    :: TelegramClient
+    -> TelegramChatKey
+    -> Maybe Integer
+    -> Text
+    -> IO (Either Text (Maybe Integer))
+sendPlainMessage client key replyToMessageId text =
+    telegramRequest client "sendMessage" body 30 >>= \case
+        Left err -> pure (Left err)
+        Right response -> pure (decodeSentMessageId response)
+  where
+    body = object $
+        [ "chat_id" .= key.chatId
+        , "text" .= text
+        ]
+            <> threadParameters key
+            <> replyParameters replyToMessageId
+
+sendMessageWithKeyboard
+    :: TelegramClient
+    -> TelegramChatKey
+    -> Maybe Integer
+    -> Text
+    -> [[(Text, Text)]]
+    -> IO (Either Text (Maybe Integer))
+sendMessageWithKeyboard client key replyToMessageId text rows =
+    telegramRequest client "sendMessage" body 30 >>= \case
+        Left err -> pure (Left err)
+        Right response -> pure (decodeSentMessageId response)
+  where
+    body = object $
+        [ "chat_id" .= key.chatId
+        , "text" .= text
+        , "reply_markup" .= object
+            [ "inline_keyboard" .=
+                [ [ object
+                        [ "text" .= label
+                        , "callback_data" .= callbackData
+                        ]
+                  | (label, callbackData) <- row
+                  ]
+                | row <- rows
+                ]
+            ]
+        ]
+            <> threadParameters key
+            <> replyParameters replyToMessageId
+
+editMessageText
+    :: TelegramClient
+    -> TelegramChatKey
+    -> Integer
+    -> Text
+    -> IO (Either Text ())
+editMessageText client key messageId text =
+    requestUnit client "editMessageText" $ object
+        [ "chat_id" .= key.chatId
+        , "message_id" .= messageId
+        , "text" .= text
+        , "reply_markup" .= object
+            [ "inline_keyboard" .= ([] :: [[Value]])
+            ]
+        ]
+
+answerCallbackQuery
+    :: TelegramClient
+    -> Text
+    -> Maybe Text
+    -> IO (Either Text ())
+answerCallbackQuery client queryId answerText =
+    requestUnit client "answerCallbackQuery" $
+        object $
+            ["callback_query_id" .= queryId]
+                <> maybe [] (\text -> ["text" .= text]) answerText
+
+sendTelegramDocument
+    :: TelegramClient
+    -> TelegramChatKey
+    -> FilePath
+    -> Maybe Text
+    -> Maybe Text
+    -> IO (Either Text (Maybe Integer))
+sendTelegramDocument client key path caption filename =
+    sendMultipartFile client key "sendDocument" "document" path caption filename
+
+sendTelegramPhoto
+    :: TelegramClient
+    -> TelegramChatKey
+    -> FilePath
+    -> Maybe Text
+    -> Maybe Text
+    -> IO (Either Text (Maybe Integer))
+sendTelegramPhoto client key path caption filename =
+    sendMultipartFile client key "sendPhoto" "photo" path caption filename
+
+sendTelegramVoice
+    :: TelegramClient
+    -> TelegramChatKey
+    -> FilePath
+    -> Maybe Text
+    -> Maybe Text
+    -> IO (Either Text (Maybe Integer))
+sendTelegramVoice client key path caption filename =
+    sendMultipartFile client key "sendVoice" "voice" path caption filename
+
+sendMultipartFile
+    :: TelegramClient
+    -> TelegramChatKey
+    -> String
+    -> Text
+    -> FilePath
+    -> Maybe Text
+    -> Maybe Text
+    -> IO (Either Text (Maybe Integer))
+sendMultipartFile client key method fieldName path caption requestedName = do
+    exists <- doesFileExist path
+    if not exists
+        then pure (Left ("file does not exist: " <> Text.pack path))
+        else do
+            bytes <- BS.readFile path
+            let boundary = "haskell-agent-telegram-boundary"
+                filename = fromMaybe (Text.pack (takeFileName path)) requestedName
+                fields =
+                    [("chat_id", Text.pack (show key.chatId))]
+                        <> maybe []
+                            (\threadId ->
+                                [("message_thread_id", Text.pack (show threadId))])
+                            key.messageThreadId
+                        <> maybe [] (\text -> [("caption", text)]) caption
+                body = multipartBody boundary fields fieldName filename bytes
+            result <- runRetrying client do
+                base <- Http.parseRequest $
+                    "https://api.telegram.org/bot"
+                        <> Text.unpack client.clientToken
+                        <> "/"
+                        <> method
+                Http.httpLbs
+                    base
+                        { Http.method = "POST"
+                        , Http.requestHeaders =
+                            [ ( "Content-Type"
+                              , "multipart/form-data; boundary=" <> boundary
+                              )
+                            ]
+                        , Http.requestBody = Http.RequestBodyLBS body
+                        , Http.responseTimeout =
+                            Http.responseTimeoutMicro 60_000_000
+                        }
+                    client.clientManager
+            case result of
+                Left err -> pure (Left err)
+                Right response -> pure (decodeSentMessageId response)
+
+multipartBody
+    :: BS.ByteString
+    -> [(Text, Text)]
+    -> Text
+    -> Text
+    -> BS.ByteString
+    -> LBS.ByteString
+multipartBody boundary fields fileField filename fileBytes =
+    mconcat
+        (map textPart fields)
+        <> filePart
+        <> LBS8.pack ("--" <> BS8.unpack boundary <> "--\r\n")
+  where
+    delimiter = "--" <> BS8.unpack boundary <> "\r\n"
+    textPart (name, value) = LBS8.pack $
+        delimiter
+            <> "Content-Disposition: form-data; name=\""
+            <> Text.unpack name
+            <> "\"\r\n\r\n"
+            <> Text.unpack value
+            <> "\r\n"
+    filePart =
+        LBS8.pack
+            ( delimiter
+                <> "Content-Disposition: form-data; name=\""
+                <> Text.unpack fileField
+                <> "\"; filename=\""
+                <> Text.unpack (sanitizeFilename filename)
+                <> "\"\r\n"
+                <> "Content-Type: application/octet-stream\r\n\r\n"
+            )
+            <> LBS.fromStrict fileBytes
+            <> "\r\n"
+
+sanitizeFilename :: Text -> Text
+sanitizeFilename =
+    Text.map \char ->
+        if char `elem` ['\r', '\n', '"'] then '_' else char
+
+decodeSentMessageId :: LBS.ByteString -> Either Text (Maybe Integer)
+decodeSentMessageId response =
+    case decodeTelegramResponse response :: Either Text TelegramMessage of
+        Right message -> Right (Just message.messageId)
+        Left _ ->
+            (() <$ (decodeTelegramResponse response :: Either Text Bool))
+                >> Right Nothing
+
+expectBool :: TelegramClient -> String -> Value -> IO ()
+expectBool client method body =
+    telegramRequest client method body 30 >>= \case
+        Left err -> fail (Text.unpack err)
+        Right response ->
+            case decodeTelegramResponse response :: Either Text Bool of
+                Left err -> fail (Text.unpack err)
+                Right _ -> pure ()
+
+requestUnit :: TelegramClient -> String -> Value -> IO (Either Text ())
+requestUnit client method body =
+    telegramRequest client method body 30 >>= \case
+        Left err -> pure (Left err)
+        Right response ->
+            pure (() <$ (decodeTelegramResponse response :: Either Text Value))
+
+threadParameters :: TelegramChatKey -> [(Key.Key, Value)]
+threadParameters key =
+    maybe []
+        (\threadId -> ["message_thread_id" .= threadId])
+        key.messageThreadId
+
+replyParameters :: Maybe Integer -> [(Key.Key, Value)]
+replyParameters =
+    maybe [] \messageId ->
+        [ "reply_parameters" .= object
+            [ "message_id" .= messageId
+            , "allow_sending_without_reply" .= True
+            ]
+        ]
+
+escapeHtml :: Text -> Text
+escapeHtml =
+    Text.replace ">" "&gt;"
+        . Text.replace "<" "&lt;"
+        . Text.replace "&" "&amp;"
+
+redactToken :: Text -> Text -> Text
+redactToken token = Text.replace token "<redacted>"

--- a/packages/agent-cli/src/Agent/Telegram/Log.hs
+++ b/packages/agent-cli/src/Agent/Telegram/Log.hs
@@ -1,0 +1,24 @@
+-- | Redacted structured logging for the Telegram gateway.
+module Agent.Telegram.Log
+    ( logTelegramEvent
+    ) where
+
+import Data.Aeson (Value, encode, object, (.=))
+import qualified Data.Aeson.Key as Key
+import qualified Data.ByteString.Lazy as LBS
+import Data.Text (Text)
+import qualified Data.Text.Encoding as TextEncoding
+import qualified Data.Text.IO as Text
+import Data.Time.Clock (getCurrentTime)
+import System.IO (stderr)
+
+logTelegramEvent :: Text -> [(Key.Key, Value)] -> IO ()
+logTelegramEvent event fields = do
+    now <- getCurrentTime
+    Text.hPutStrLn stderr $
+        TextEncoding.decodeUtf8 . LBS.toStrict . encode . object $
+            [ "at" .= now
+            , "gateway" .= ("telegram" :: Text)
+            , "event" .= event
+            ]
+                <> fields

--- a/packages/agent-cli/src/Agent/Telegram/Types.hs
+++ b/packages/agent-cli/src/Agent/Telegram/Types.hs
@@ -3,21 +3,45 @@
 -- | Telegram wire types and durable queue state.
 module Agent.Telegram.Types
     ( TelegramConfig(..)
+    , TelegramApprovalMode(..)
     , TelegramSetupOptions(..)
     , defaultTelegramSetupOptions
     , TelegramCommand(..)
+    , TelegramUsersCommand(..)
     , TelegramChatKey(..)
     , TelegramBinding(..)
     , TelegramState(..)
     , TelegramPendingTurn(..)
     , TelegramPendingReply(..)
+    , TelegramPendingMediaTurn(..)
+    , TelegramPendingCallback(..)
+    , TelegramRetryMetadata(..)
+    , TelegramDeadLetter(..)
+    , TelegramCallbackBinding(..)
     , TelegramVoice(..)
+    , TelegramMedia(..)
+    , TelegramMediaKind(..)
+    , TelegramFileMedia(..)
+    , TelegramPhotoSize(..)
+    , TelegramDocument(..)
+    , TelegramVideo(..)
+    , TelegramVideoNote(..)
+    , TelegramAudio(..)
+    , TelegramAnimation(..)
+    , TelegramSticker(..)
+    , TelegramLocation(..)
+    , TelegramContact(..)
+    , TelegramVenue(..)
+    , TelegramPoll(..)
+    , TelegramDice(..)
     , TelegramUser(..)
     , TelegramChat(..)
     , TelegramMessage(..)
     , TelegramReactionType(..)
     , TelegramMessageReaction(..)
+    , TelegramCallbackQuery(..)
     , TelegramUpdate(..)
+    , TelegramResponseParameters(..)
     , TelegramResponse(..)
     , TelegramClient(..)
     , PendingChatAction(..)
@@ -38,6 +62,8 @@ import Data.Aeson
     , (.!=)
     , (.=)
     )
+import Data.Aeson (Value)
+import qualified Data.Aeson as Aeson
 import qualified Data.Map.Strict as Map
 import Data.Map.Strict (Map)
 import Data.List (sortOn)
@@ -46,14 +72,58 @@ import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as Text
+import Data.Time.Clock (UTCTime)
 import qualified Network.HTTP.Client as Http
+
+data TelegramApprovalMode
+    = TelegramApprovalPrompt
+    | TelegramApprovalDeny
+    | TelegramApprovalYolo
+    deriving (Eq, Show)
+
+instance ToJSON PendingChatAction where
+    toJSON = \case
+        DeliverReply pending -> object
+            [ "kind" .= ("reply" :: Text)
+            , "reply" .= pending
+            ]
+        RunPendingTurn pending -> object
+            [ "kind" .= ("turn" :: Text)
+            , "turn" .= pending
+            ]
+        RunPendingMediaTurn pending -> object
+            [ "kind" .= ("media_turn" :: Text)
+            , "mediaTurn" .= pending
+            ]
+
+instance FromJSON PendingChatAction where
+    parseJSON = withObject "PendingChatAction" \o -> do
+        kind <- o .: "kind"
+        case (kind :: Text) of
+            "reply" -> DeliverReply <$> o .: "reply"
+            "turn" -> RunPendingTurn <$> o .: "turn"
+            "media_turn" -> RunPendingMediaTurn <$> o .: "mediaTurn"
+            _ -> fail ("unknown pending Telegram action: " <> Text.unpack kind)
+
+instance ToJSON TelegramApprovalMode where
+    toJSON = \case
+        TelegramApprovalPrompt -> "prompt"
+        TelegramApprovalDeny -> "deny"
+        TelegramApprovalYolo -> "yolo"
+
+instance FromJSON TelegramApprovalMode where
+    parseJSON = Aeson.withText "TelegramApprovalMode" \case
+        "prompt" -> pure TelegramApprovalPrompt
+        "deny" -> pure TelegramApprovalDeny
+        "yolo" -> pure TelegramApprovalYolo
+        other -> fail ("unknown Telegram approval mode: " <> Text.unpack other)
 
 data TelegramConfig = TelegramConfig
     { telegramProvider :: !Provider
     , telegramModel :: !(Maybe Text)
     , telegramCwd :: !FilePath
     , telegramEffort :: !(Maybe Text)
-    , telegramYolo :: !Bool
+    , telegramApprovalMode :: !TelegramApprovalMode
     , telegramAllowedUsers :: !(Set Integer)
     } deriving (Eq, Show)
 
@@ -63,7 +133,7 @@ instance ToJSON TelegramConfig where
         , "model" .= config.telegramModel
         , "cwd" .= config.telegramCwd
         , "effort" .= config.telegramEffort
-        , "yolo" .= config.telegramYolo
+        , "approvalMode" .= config.telegramApprovalMode
         , "allowedUsers" .= Set.toList config.telegramAllowedUsers
         ]
 
@@ -74,12 +144,17 @@ instance FromJSON TelegramConfig where
             (fail ("unknown provider: " <> Text.unpack providerText))
             pure
             (parseProvider providerText)
+        legacyYolo <- o .:? "yolo" .!= False
+        approvalMode <- o .:? "approvalMode" .!=
+            (if legacyYolo
+                then TelegramApprovalYolo
+                else TelegramApprovalPrompt)
         TelegramConfig
             <$> pure telegramProvider
             <*> o .:? "model"
             <*> o .: "cwd"
             <*> o .:? "effort"
-            <*> (o .:? "yolo" .!= False)
+            <*> pure approvalMode
             <*> (Set.fromList <$> o .: "allowedUsers")
 
 data TelegramSetupOptions = TelegramSetupOptions
@@ -87,8 +162,8 @@ data TelegramSetupOptions = TelegramSetupOptions
     , setupModel :: !(Maybe Text)
     , setupCwd :: !(Maybe FilePath)
     , setupEffort :: !(Maybe Text)
-    , setupYolo :: !Bool
-    , setupAllowedUser :: !(Maybe Integer)
+    , setupApprovalMode :: !TelegramApprovalMode
+    , setupAllowedUsers :: ![Integer]
     , setupStart :: !Bool
     } deriving (Eq, Show)
 
@@ -98,8 +173,8 @@ defaultTelegramSetupOptions = TelegramSetupOptions
     , setupModel = Nothing
     , setupCwd = Nothing
     , setupEffort = Nothing
-    , setupYolo = False
-    , setupAllowedUser = Nothing
+    , setupApprovalMode = TelegramApprovalPrompt
+    , setupAllowedUsers = []
     , setupStart = False
     }
 
@@ -109,8 +184,15 @@ data TelegramCommand
     | TelegramStart
     | TelegramStop
     | TelegramStatus
+    | TelegramUsers !TelegramUsersCommand
     | TelegramHelp
     | TelegramVersion
+    deriving (Eq, Show)
+
+data TelegramUsersCommand
+    = TelegramUsersList
+    | TelegramUsersAdd !Integer
+    | TelegramUsersRemove !Integer
     deriving (Eq, Show)
 
 data TelegramChatKey = TelegramChatKey
@@ -144,14 +226,22 @@ instance FromJSON TelegramBinding where
         TelegramBinding <$> o .: "chat" <*> o .: "sessionId"
 
 data TelegramState = TelegramState
-    { nextUpdateId :: !(Maybe Integer)
+    { telegramStateVersion :: !Int
+    , nextUpdateId :: !(Maybe Integer)
     , bindings :: !(Map TelegramChatKey Text)
     , pendingQueues :: !(Map TelegramChatKey (Map Integer PendingChatAction))
+    , pendingCallbacks :: !(Map Integer TelegramPendingCallback)
+    , callbackBindings :: !(Map Text TelegramCallbackBinding)
+    , retryMetadata :: !(Map Text TelegramRetryMetadata)
+    , deliveryCheckpoints :: !(Map Text Int)
+    , deadLetters :: ![TelegramDeadLetter]
+    , outboundMessageIds :: !(Map TelegramChatKey (Set Integer))
     } deriving (Eq, Show)
 
 instance ToJSON TelegramState where
     toJSON state = object
-        [ "nextUpdateId" .= state.nextUpdateId
+        [ "version" .= state.telegramStateVersion
+        , "nextUpdateId" .= state.nextUpdateId
         , "bindings" .=
             [ TelegramBinding key sessionId
             | (key, sessionId) <- Map.toList state.bindings
@@ -168,16 +258,51 @@ instance ToJSON TelegramState where
                 | queue <- Map.elems state.pendingQueues
                 , DeliverReply pending <- Map.elems queue
                 ]
+        , "pendingMediaTurns" .=
+            sortOn (.pendingMediaUpdateId)
+                [ pending
+                | queue <- Map.elems state.pendingQueues
+                , RunPendingMediaTurn pending <- Map.elems queue
+                ]
+        , "pendingCallbacks" .= Map.elems state.pendingCallbacks
+        , "callbackBindings" .= Map.elems state.callbackBindings
+        , "retryMetadata" .= Map.toList state.retryMetadata
+        , "deliveryCheckpoints" .= Map.toList state.deliveryCheckpoints
+        , "deadLetters" .= state.deadLetters
+        , "outboundMessages" .=
+            [ TelegramOutboundMessages key (Set.toList messageIds)
+            | (key, messageIds) <- Map.toList state.outboundMessageIds
+            ]
         ]
 
 instance FromJSON TelegramState where
     parseJSON = withObject "TelegramState" \o -> do
+        storedVersion <- o .:? "version" .!= 1
+        if storedVersion `elem` [1 :: Int, 2]
+            then pure ()
+            else fail
+                ("unsupported Telegram state version: "
+                    <> show storedVersion)
         nextUpdateId <- o .:? "nextUpdateId"
         storedBindings <- o .:? "bindings" .!= ([] :: [TelegramBinding])
         pendingTurns <- o .:? "pendingTurns" .!= ([] :: [TelegramPendingTurn])
         pendingReplies <- o .:? "pendingReplies" .!= ([] :: [TelegramPendingReply])
+        pendingMediaTurns <-
+            o .:? "pendingMediaTurns" .!= ([] :: [TelegramPendingMediaTurn])
+        storedCallbacks <-
+            o .:? "pendingCallbacks" .!= ([] :: [TelegramPendingCallback])
+        storedCallbackBindings <-
+            o .:? "callbackBindings" .!= ([] :: [TelegramCallbackBinding])
+        storedRetries <-
+            o .:? "retryMetadata" .!= ([] :: [(Text, TelegramRetryMetadata)])
+        storedDeliveryCheckpoints <-
+            o .:? "deliveryCheckpoints" .!= ([] :: [(Text, Int)])
+        deadLetters <- o .:? "deadLetters" .!= []
+        outboundMessages <-
+            o .:? "outboundMessages" .!= ([] :: [TelegramOutboundMessages])
         pure TelegramState
-            { nextUpdateId
+            { telegramStateVersion = 2
+            , nextUpdateId
             , bindings =
                 foldr
                     (\binding ->
@@ -188,8 +313,44 @@ instance FromJSON TelegramState where
                 foldl'
                     (flip insertPendingAction)
                     Map.empty
-                    (map RunPendingTurn pendingTurns <> map DeliverReply pendingReplies)
+                    ( map RunPendingTurn pendingTurns
+                        <> map DeliverReply pendingReplies
+                        <> map RunPendingMediaTurn pendingMediaTurns
+                    )
+            , pendingCallbacks =
+                Map.fromList
+                    [ (callback.pendingCallbackUpdateId, callback)
+                    | callback <- storedCallbacks
+                    ]
+            , callbackBindings =
+                Map.fromList
+                    [ (binding.callbackBindingData, binding)
+                    | binding <- storedCallbackBindings
+                    ]
+            , retryMetadata = Map.fromList storedRetries
+            , deliveryCheckpoints = Map.fromList storedDeliveryCheckpoints
+            , deadLetters
+            , outboundMessageIds =
+                Map.fromList
+                    [ (messages.outboundChat, Set.fromList messages.outboundIds)
+                    | messages <- outboundMessages
+                    ]
             }
+
+data TelegramOutboundMessages = TelegramOutboundMessages
+    { outboundChat :: !TelegramChatKey
+    , outboundIds :: ![Integer]
+    } deriving (Eq, Show)
+
+instance ToJSON TelegramOutboundMessages where
+    toJSON messages = object
+        [ "chat" .= messages.outboundChat
+        , "messageIds" .= messages.outboundIds
+        ]
+
+instance FromJSON TelegramOutboundMessages where
+    parseJSON = withObject "TelegramOutboundMessages" \o ->
+        TelegramOutboundMessages <$> o .: "chat" <*> o .:? "messageIds" .!= []
 
 data TelegramPendingTurn = TelegramPendingTurn
     { pendingTurnUpdateId :: !Integer
@@ -239,6 +400,154 @@ instance FromJSON TelegramPendingReply where
             <*> o .: "chat"
             <*> o .:? "replyToMessageId"
             <*> o .: "text"
+
+data TelegramPendingMediaTurn = TelegramPendingMediaTurn
+    { pendingMediaUpdateId :: !Integer
+    , pendingMediaMessageId :: !Integer
+    , pendingMediaChat :: !TelegramChatKey
+    , pendingMediaUserId :: !Integer
+    , pendingMediaText :: !Text
+    , pendingMediaAttachments :: ![TelegramMedia]
+    , pendingMediaEdited :: !Bool
+    , pendingMediaGroupId :: !(Maybe Text)
+    } deriving (Eq, Show)
+
+instance ToJSON TelegramPendingMediaTurn where
+    toJSON pending = object
+        [ "updateId" .= pending.pendingMediaUpdateId
+        , "messageId" .= pending.pendingMediaMessageId
+        , "chat" .= pending.pendingMediaChat
+        , "userId" .= pending.pendingMediaUserId
+        , "text" .= pending.pendingMediaText
+        , "attachments" .= pending.pendingMediaAttachments
+        , "edited" .= pending.pendingMediaEdited
+        , "mediaGroupId" .= pending.pendingMediaGroupId
+        ]
+
+instance FromJSON TelegramPendingMediaTurn where
+    parseJSON = withObject "TelegramPendingMediaTurn" \o ->
+        TelegramPendingMediaTurn
+            <$> o .: "updateId"
+            <*> o .:? "messageId" .!= 0
+            <*> o .: "chat"
+            <*> o .:? "userId" .!= 0
+            <*> o .:? "text" .!= ""
+            <*> o .:? "attachments" .!= []
+            <*> o .:? "edited" .!= False
+            <*> o .:? "mediaGroupId"
+
+data TelegramPendingCallback = TelegramPendingCallback
+    { pendingCallbackUpdateId :: !Integer
+    , pendingCallbackQueryId :: !Text
+    , pendingCallbackUserId :: !Integer
+    , pendingCallbackChat :: !(Maybe TelegramChatKey)
+    , pendingCallbackMessageId :: !(Maybe Integer)
+    , pendingCallbackData :: !Text
+    } deriving (Eq, Show)
+
+instance ToJSON TelegramPendingCallback where
+    toJSON pending = object
+        [ "updateId" .= pending.pendingCallbackUpdateId
+        , "queryId" .= pending.pendingCallbackQueryId
+        , "userId" .= pending.pendingCallbackUserId
+        , "chat" .= pending.pendingCallbackChat
+        , "messageId" .= pending.pendingCallbackMessageId
+        , "data" .= pending.pendingCallbackData
+        ]
+
+instance FromJSON TelegramPendingCallback where
+    parseJSON = withObject "TelegramPendingCallback" \o ->
+        TelegramPendingCallback
+            <$> o .: "updateId"
+            <*> o .: "queryId"
+            <*> o .: "userId"
+            <*> o .:? "chat"
+            <*> o .:? "messageId"
+            <*> o .: "data"
+
+data TelegramRetryMetadata = TelegramRetryMetadata
+    { retryAttempts :: !Int
+    , retryNextAt :: !(Maybe UTCTime)
+    , retryLastError :: !(Maybe Text)
+    } deriving (Eq, Show)
+
+instance ToJSON TelegramRetryMetadata where
+    toJSON retry = object
+        [ "attempts" .= retry.retryAttempts
+        , "nextAt" .= retry.retryNextAt
+        , "lastError" .= retry.retryLastError
+        ]
+
+instance FromJSON TelegramRetryMetadata where
+    parseJSON = withObject "TelegramRetryMetadata" \o ->
+        TelegramRetryMetadata
+            <$> o .:? "attempts" .!= 0
+            <*> o .:? "nextAt"
+            <*> o .:? "lastError"
+
+data TelegramDeadLetter = TelegramDeadLetter
+    { deadLetterUpdateId :: !Integer
+    , deadLetterChat :: !(Maybe TelegramChatKey)
+    , deadLetterError :: !Text
+    , deadLetterFailedAt :: !UTCTime
+    , deadLetterAction :: !(Maybe PendingChatAction)
+    } deriving (Eq, Show)
+
+instance ToJSON TelegramDeadLetter where
+    toJSON dead = object
+        [ "updateId" .= dead.deadLetterUpdateId
+        , "chat" .= dead.deadLetterChat
+        , "error" .= dead.deadLetterError
+        , "failedAt" .= dead.deadLetterFailedAt
+        , "action" .= dead.deadLetterAction
+        ]
+
+instance FromJSON TelegramDeadLetter where
+    parseJSON = withObject "TelegramDeadLetter" \o ->
+        TelegramDeadLetter
+            <$> o .: "updateId"
+            <*> o .:? "chat"
+            <*> o .: "error"
+            <*> o .: "failedAt"
+            <*> o .:? "action"
+
+data TelegramCallbackBinding = TelegramCallbackBinding
+    { callbackBindingData :: !Text
+    , callbackBindingRequestId :: !Text
+    , callbackBindingChat :: !TelegramChatKey
+    , callbackBindingUserId :: !Integer
+    , callbackBindingMessageId :: !(Maybe Integer)
+    , callbackBindingBridgeDirectory :: !FilePath
+    , callbackBindingValue :: !Text
+    , callbackBindingExpiresAt :: !UTCTime
+    , callbackBindingConsumed :: !Bool
+    } deriving (Eq, Show)
+
+instance ToJSON TelegramCallbackBinding where
+    toJSON binding = object
+        [ "data" .= binding.callbackBindingData
+        , "requestId" .= binding.callbackBindingRequestId
+        , "chat" .= binding.callbackBindingChat
+        , "userId" .= binding.callbackBindingUserId
+        , "messageId" .= binding.callbackBindingMessageId
+        , "bridgeDirectory" .= binding.callbackBindingBridgeDirectory
+        , "value" .= binding.callbackBindingValue
+        , "expiresAt" .= binding.callbackBindingExpiresAt
+        , "consumed" .= binding.callbackBindingConsumed
+        ]
+
+instance FromJSON TelegramCallbackBinding where
+    parseJSON = withObject "TelegramCallbackBinding" \o ->
+        TelegramCallbackBinding
+            <$> o .: "data"
+            <*> o .: "requestId"
+            <*> o .: "chat"
+            <*> o .: "userId"
+            <*> o .:? "messageId"
+            <*> o .: "bridgeDirectory"
+            <*> o .: "value"
+            <*> o .: "expiresAt"
+            <*> o .:? "consumed" .!= False
 
 data TelegramVoice = TelegramVoice
     { voiceFileId :: !Text
@@ -295,7 +604,23 @@ data TelegramMessage = TelegramMessage
     , messageChat :: !TelegramChat
     , messageThread :: !(Maybe Integer)
     , messageText :: !(Maybe Text)
+    , messageCaption :: !(Maybe Text)
     , messageVoice :: !(Maybe TelegramVoice)
+    , messageAudio :: !(Maybe TelegramAudio)
+    , messageDocument :: !(Maybe TelegramDocument)
+    , messagePhoto :: ![TelegramPhotoSize]
+    , messageVideo :: !(Maybe TelegramVideo)
+    , messageVideoNote :: !(Maybe TelegramVideoNote)
+    , messageAnimation :: !(Maybe TelegramAnimation)
+    , messageSticker :: !(Maybe TelegramSticker)
+    , messageLocation :: !(Maybe TelegramLocation)
+    , messageContact :: !(Maybe TelegramContact)
+    , messageVenue :: !(Maybe TelegramVenue)
+    , messagePoll :: !(Maybe TelegramPoll)
+    , messageDice :: !(Maybe TelegramDice)
+    , messageMediaGroupId :: !(Maybe Text)
+    , messageForwardOrigin :: !(Maybe Value)
+    , messageEditDate :: !(Maybe Integer)
     , messageReplyTo :: !(Maybe TelegramMessage)
     } deriving (Eq, Show)
 
@@ -307,7 +632,23 @@ instance FromJSON TelegramMessage where
             <*> o .: "chat"
             <*> o .:? "message_thread_id"
             <*> o .:? "text"
+            <*> o .:? "caption"
             <*> o .:? "voice"
+            <*> o .:? "audio"
+            <*> o .:? "document"
+            <*> (o .:? "photo" .!= [])
+            <*> o .:? "video"
+            <*> o .:? "video_note"
+            <*> o .:? "animation"
+            <*> o .:? "sticker"
+            <*> o .:? "location"
+            <*> o .:? "contact"
+            <*> o .:? "venue"
+            <*> o .:? "poll"
+            <*> o .:? "dice"
+            <*> o .:? "media_group_id"
+            <*> o .:? "forward_origin"
+            <*> o .:? "edit_date"
             <*> o .:? "reply_to_message"
 
 data TelegramReactionType = TelegramReactionType
@@ -340,10 +681,259 @@ instance FromJSON TelegramMessageReaction where
             <*> (o .:? "old_reaction" .!= [])
             <*> (o .:? "new_reaction" .!= [])
 
+data TelegramPhotoSize = TelegramPhotoSize
+    { photoFileId :: !Text
+    , photoWidth :: !Int
+    , photoHeight :: !Int
+    , photoFileSize :: !(Maybe Integer)
+    } deriving (Eq, Show)
+
+instance FromJSON TelegramPhotoSize where
+    parseJSON = withObject "TelegramPhotoSize" \o ->
+        TelegramPhotoSize
+            <$> o .: "file_id"
+            <*> o .:? "width" .!= 0
+            <*> o .:? "height" .!= 0
+            <*> o .:? "file_size"
+
+data TelegramDocument = TelegramDocument
+    { documentFileId :: !Text
+    , documentFileName :: !(Maybe Text)
+    , documentMimeType :: !(Maybe Text)
+    , documentFileSize :: !(Maybe Integer)
+    } deriving (Eq, Show)
+
+instance FromJSON TelegramDocument where
+    parseJSON = withObject "TelegramDocument" \o ->
+        TelegramDocument
+            <$> o .: "file_id"
+            <*> o .:? "file_name"
+            <*> o .:? "mime_type"
+            <*> o .:? "file_size"
+
+data TelegramVideo = TelegramVideo
+    { videoFileId :: !Text
+    , videoDuration :: !Int
+    , videoMimeType :: !(Maybe Text)
+    , videoFileName :: !(Maybe Text)
+    , videoFileSize :: !(Maybe Integer)
+    } deriving (Eq, Show)
+
+instance FromJSON TelegramVideo where
+    parseJSON = withObject "TelegramVideo" \o ->
+        TelegramVideo
+            <$> o .: "file_id"
+            <*> o .:? "duration" .!= 0
+            <*> o .:? "mime_type"
+            <*> o .:? "file_name"
+            <*> o .:? "file_size"
+
+data TelegramVideoNote = TelegramVideoNote
+    { videoNoteFileId :: !Text
+    , videoNoteDuration :: !Int
+    , videoNoteLength :: !Int
+    , videoNoteFileSize :: !(Maybe Integer)
+    } deriving (Eq, Show)
+
+instance FromJSON TelegramVideoNote where
+    parseJSON = withObject "TelegramVideoNote" \o ->
+        TelegramVideoNote
+            <$> o .: "file_id"
+            <*> o .:? "duration" .!= 0
+            <*> o .:? "length" .!= 0
+            <*> o .:? "file_size"
+
+data TelegramAudio = TelegramAudio
+    { audioFileId :: !Text
+    , audioDuration :: !Int
+    , audioMimeType :: !(Maybe Text)
+    , audioFileName :: !(Maybe Text)
+    , audioFileSize :: !(Maybe Integer)
+    } deriving (Eq, Show)
+
+instance FromJSON TelegramAudio where
+    parseJSON = withObject "TelegramAudio" \o ->
+        TelegramAudio
+            <$> o .: "file_id"
+            <*> o .:? "duration" .!= 0
+            <*> o .:? "mime_type"
+            <*> o .:? "file_name"
+            <*> o .:? "file_size"
+
+data TelegramAnimation = TelegramAnimation
+    { animationFileId :: !Text
+    , animationMimeType :: !(Maybe Text)
+    , animationFileName :: !(Maybe Text)
+    , animationFileSize :: !(Maybe Integer)
+    } deriving (Eq, Show)
+
+instance FromJSON TelegramAnimation where
+    parseJSON = withObject "TelegramAnimation" \o ->
+        TelegramAnimation
+            <$> o .: "file_id"
+            <*> o .:? "mime_type"
+            <*> o .:? "file_name"
+            <*> o .:? "file_size"
+
+data TelegramSticker = TelegramSticker
+    { stickerFileId :: !Text
+    , stickerEmoji :: !(Maybe Text)
+    , stickerIsAnimated :: !Bool
+    , stickerFileSize :: !(Maybe Integer)
+    } deriving (Eq, Show)
+
+instance FromJSON TelegramSticker where
+    parseJSON = withObject "TelegramSticker" \o ->
+        TelegramSticker
+            <$> o .: "file_id"
+            <*> o .:? "emoji"
+            <*> o .:? "is_animated" .!= False
+            <*> o .:? "file_size"
+
+data TelegramLocation = TelegramLocation
+    { locationLatitude :: !Double
+    , locationLongitude :: !Double
+    } deriving (Eq, Show)
+
+instance FromJSON TelegramLocation where
+    parseJSON = withObject "TelegramLocation" \o ->
+        TelegramLocation <$> o .: "latitude" <*> o .: "longitude"
+
+data TelegramContact = TelegramContact
+    { contactPhoneNumber :: !Text
+    , contactFirstName :: !Text
+    , contactLastName :: !(Maybe Text)
+    } deriving (Eq, Show)
+
+instance FromJSON TelegramContact where
+    parseJSON = withObject "TelegramContact" \o ->
+        TelegramContact <$> o .: "phone_number" <*> o .: "first_name" <*> o .:? "last_name"
+
+data TelegramVenue = TelegramVenue
+    { venueTitle :: !Text
+    , venueAddress :: !Text
+    } deriving (Eq, Show)
+
+instance FromJSON TelegramVenue where
+    parseJSON = withObject "TelegramVenue" \o ->
+        TelegramVenue <$> o .: "title" <*> o .: "address"
+
+data TelegramPoll = TelegramPoll
+    { pollId :: !Text
+    , pollQuestion :: !Text
+    } deriving (Eq, Show)
+
+instance FromJSON TelegramPoll where
+    parseJSON = withObject "TelegramPoll" \o ->
+        TelegramPoll <$> o .: "id" <*> o .: "question"
+
+data TelegramDice = TelegramDice
+    { diceEmoji :: !Text
+    , diceValue :: !Int
+    } deriving (Eq, Show)
+
+instance FromJSON TelegramDice where
+    parseJSON = withObject "TelegramDice" \o ->
+        TelegramDice <$> o .: "emoji" <*> o .: "value"
+
+data TelegramMediaKind
+    = TelegramMediaPhoto
+    | TelegramMediaDocument
+    | TelegramMediaVideo
+    | TelegramMediaVideoNote
+    | TelegramMediaAudio
+    | TelegramMediaAnimation
+    | TelegramMediaSticker
+    | TelegramMediaLocation
+    | TelegramMediaContact
+    | TelegramMediaVenue
+    | TelegramMediaPoll
+    | TelegramMediaDice
+    deriving (Eq, Show)
+
+instance ToJSON TelegramMediaKind where
+    toJSON = \case
+        TelegramMediaPhoto -> "photo"
+        TelegramMediaDocument -> "document"
+        TelegramMediaVideo -> "video"
+        TelegramMediaVideoNote -> "video_note"
+        TelegramMediaAudio -> "audio"
+        TelegramMediaAnimation -> "animation"
+        TelegramMediaSticker -> "sticker"
+        TelegramMediaLocation -> "location"
+        TelegramMediaContact -> "contact"
+        TelegramMediaVenue -> "venue"
+        TelegramMediaPoll -> "poll"
+        TelegramMediaDice -> "dice"
+
+instance FromJSON TelegramMediaKind where
+    parseJSON = Aeson.withText "TelegramMediaKind" \case
+        "photo" -> pure TelegramMediaPhoto
+        "document" -> pure TelegramMediaDocument
+        "video" -> pure TelegramMediaVideo
+        "video_note" -> pure TelegramMediaVideoNote
+        "audio" -> pure TelegramMediaAudio
+        "animation" -> pure TelegramMediaAnimation
+        "sticker" -> pure TelegramMediaSticker
+        "location" -> pure TelegramMediaLocation
+        "contact" -> pure TelegramMediaContact
+        "venue" -> pure TelegramMediaVenue
+        "poll" -> pure TelegramMediaPoll
+        "dice" -> pure TelegramMediaDice
+        other -> fail ("unknown Telegram media kind: " <> Text.unpack other)
+
+data TelegramFileMedia = TelegramFileMedia
+    { fileMediaFileId :: !Text
+    , fileMediaName :: !(Maybe Text)
+    , fileMediaMimeType :: !(Maybe Text)
+    , fileMediaFileSize :: !(Maybe Integer)
+    , fileMediaDuration :: !(Maybe Int)
+    } deriving (Eq, Show)
+
+instance ToJSON TelegramFileMedia where
+    toJSON media = object
+        [ "fileId" .= media.fileMediaFileId
+        , "name" .= media.fileMediaName
+        , "mimeType" .= media.fileMediaMimeType
+        , "fileSize" .= media.fileMediaFileSize
+        , "duration" .= media.fileMediaDuration
+        ]
+
+instance FromJSON TelegramFileMedia where
+    parseJSON = withObject "TelegramFileMedia" \o ->
+        TelegramFileMedia
+            <$> (o .:? "file_id" >>= maybe (o .: "fileId") pure)
+            <*> (o .:? "file_name" >>= maybe (o .:? "name") (pure . Just))
+            <*> (o .:? "mime_type" >>= maybe (o .:? "mimeType") (pure . Just))
+            <*> (o .:? "file_size" >>= maybe (o .:? "fileSize") (pure . Just))
+            <*> o .:? "duration"
+
+data TelegramMedia = TelegramMedia
+    { telegramMediaKind :: !TelegramMediaKind
+    , telegramMediaFile :: !(Maybe TelegramFileMedia)
+    , telegramMediaDescription :: !Text
+    } deriving (Eq, Show)
+
+instance ToJSON TelegramMedia where
+    toJSON media = object
+        [ "kind" .= media.telegramMediaKind
+        , "file" .= media.telegramMediaFile
+        , "description" .= media.telegramMediaDescription
+        ]
+
+instance FromJSON TelegramMedia where
+    parseJSON = withObject "TelegramMedia" \o ->
+        TelegramMedia
+            <$> o .: "kind"
+            <*> o .:? "file"
+            <*> o .:? "description" .!= ""
+
 data TelegramUpdate = TelegramUpdate
     { updateId :: !Integer
     , updateMessage :: !(Maybe TelegramMessage)
+    , updateEditedMessage :: !(Maybe TelegramMessage)
     , updateMessageReaction :: !(Maybe TelegramMessageReaction)
+    , updateCallbackQuery :: !(Maybe TelegramCallbackQuery)
     } deriving (Eq, Show)
 
 instance FromJSON TelegramUpdate where
@@ -351,17 +941,49 @@ instance FromJSON TelegramUpdate where
         TelegramUpdate
             <$> o .: "update_id"
             <*> o .:? "message"
+            <*> o .:? "edited_message"
             <*> o .:? "message_reaction"
+            <*> o .:? "callback_query"
+
+data TelegramCallbackQuery = TelegramCallbackQuery
+    { callbackQueryId :: !Text
+    , callbackQueryFrom :: !TelegramUser
+    , callbackQueryMessage :: !(Maybe TelegramMessage)
+    , callbackQueryData :: !(Maybe Text)
+    } deriving (Eq, Show)
+
+instance FromJSON TelegramCallbackQuery where
+    parseJSON = withObject "TelegramCallbackQuery" \o ->
+        TelegramCallbackQuery
+            <$> o .: "id"
+            <*> o .: "from"
+            <*> o .:? "message"
+            <*> o .:? "data"
 
 data TelegramResponse a = TelegramResponse
     { responseOk :: !Bool
     , responseResult :: !(Maybe a)
     , responseDescription :: !(Maybe Text)
+    , responseErrorCode :: !(Maybe Int)
+    , responseParameters :: !(Maybe TelegramResponseParameters)
     }
 
 instance FromJSON a => FromJSON (TelegramResponse a) where
     parseJSON = withObject "TelegramResponse" \o ->
-        TelegramResponse <$> o .: "ok" <*> o .:? "result" <*> o .:? "description"
+        TelegramResponse
+            <$> o .: "ok"
+            <*> o .:? "result"
+            <*> o .:? "description"
+            <*> o .:? "error_code"
+            <*> o .:? "parameters"
+
+data TelegramResponseParameters = TelegramResponseParameters
+    { responseRetryAfter :: !(Maybe Int)
+    } deriving (Eq, Show)
+
+instance FromJSON TelegramResponseParameters where
+    parseJSON = withObject "TelegramResponseParameters" \o ->
+        TelegramResponseParameters <$> o .:? "retry_after"
 
 data TelegramClient = TelegramClient
     { clientToken :: !Text
@@ -371,17 +993,20 @@ data TelegramClient = TelegramClient
 data PendingChatAction
     = DeliverReply !TelegramPendingReply
     | RunPendingTurn !TelegramPendingTurn
+    | RunPendingMediaTurn !TelegramPendingMediaTurn
     deriving (Eq, Show)
 
 pendingActionUpdateId :: PendingChatAction -> Integer
 pendingActionUpdateId = \case
     DeliverReply pending -> pending.pendingUpdateId
     RunPendingTurn pending -> pending.pendingTurnUpdateId
+    RunPendingMediaTurn pending -> pending.pendingMediaUpdateId
 
 pendingActionChat :: PendingChatAction -> TelegramChatKey
 pendingActionChat = \case
     DeliverReply pending -> pending.pendingChat
     RunPendingTurn pending -> pending.pendingTurnChat
+    RunPendingMediaTurn pending -> pending.pendingMediaChat
 
 insertPendingAction
     :: PendingChatAction
@@ -410,7 +1035,14 @@ deletePendingAction action state =
 
 emptyTelegramState :: TelegramState
 emptyTelegramState = TelegramState
-    { nextUpdateId = Nothing
+    { telegramStateVersion = 2
+    , nextUpdateId = Nothing
     , bindings = Map.empty
     , pendingQueues = Map.empty
+    , pendingCallbacks = Map.empty
+    , callbackBindings = Map.empty
+    , retryMetadata = Map.empty
+    , deliveryCheckpoints = Map.empty
+    , deadLetters = []
+    , outboundMessageIds = Map.empty
     }

--- a/packages/agent-cli/test/Agent/CLI/AgentSessionsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/AgentSessionsSpec.hs
@@ -2,6 +2,7 @@ module Agent.CLI.AgentSessionsSpec (spec) where
 
 import Agent.CLI.AgentSessions
 import Agent.CLI.Models (ModelTarget(..))
+import Agent.CLI.ManagedTurn (managedTurnRequestFromText)
 import Agent.CLI.Options (ApprovalPolicy(..))
 import Agent.CLI.Session
 import Agent.CLI.SessionLock
@@ -202,6 +203,23 @@ spec = describe "Agent.CLI.AgentSessions" do
                 args `shouldContain` ["--no-ghci", "--bash"]
                 closeSessionProcessManager manager
 
+    it "distinguishes managed deny from remote prompt approval" $
+        withTempDir "agent-session-runtime-" \root -> do
+            let argsPath = toFilePath root FilePath.</> "agent-args"
+            script <- writeFakeAgentBody root
+                ("printf '%s\\n' \"$@\" > " <> shellQuote argsPath <> "\nexit 0\n")
+            withExecutableOverride script do
+                handle <- createSession (testCreateAt root root)
+                manager <- newSessionProcessManager root
+                launchManagedTurnBounded
+                    manager False DenyMutating True False Nothing handle
+                    (managedTurnRequestFromText "one")
+                    `shouldReturn`
+                        Right ("completed session " <> handle.sessionMeta.metaId)
+                args <- lines <$> readFile argsPath
+                args `shouldContain` ["--managed-deny-mutations"]
+                closeSessionProcessManager manager
+
     it "keeps an advisory lock until its owner releases it" $
         withTempDir "agent-session-lock-" \root -> do
             handle <- createSession (testCreateAt root root)
@@ -315,6 +333,42 @@ spec = describe "Agent.CLI.AgentSessions" do
                 _ <- launchSessionTurn manager True ApproveAll True False handle "one"
                 closeSessionProcessManager manager
                 waitForFile marker
+
+    it "terminates scoped gateway children when the manager closes" $
+        withTempDir "agent-session-runtime-" \root -> do
+            let marker = toFilePath root FilePath.</> "finished"
+            script <- writeFakeAgentBody root
+                ("sleep 1\nprintf done > " <> shellQuote marker <> "\n")
+            withExecutableOverride script do
+                handle <- createSession (testCreateAt root root)
+                manager <- newSessionProcessManagerWithLifetime
+                    ScopedSessionProcesses
+                    root
+                _ <- launchSessionTurn
+                    manager True ApproveAll True False handle "one"
+                closeSessionProcessManager manager
+                threadDelay 1_200_000
+                Directory.doesFileExist marker `shouldReturn` False
+
+    it "bounds a foreground managed gateway turn" $
+        withTempDir "agent-session-runtime-" \root -> do
+            script <- writeFakeAgentBody root "sleep 1\n"
+            withExecutableOverride script do
+                handle <- createSession (testCreateAt root root)
+                manager <- newSessionProcessManagerWithLifetime
+                    ScopedSessionProcesses
+                    root
+                result <- launchManagedTurnBounded
+                    manager
+                    False
+                    PromptMutating
+                    True
+                    False
+                    (Just 50_000)
+                    handle
+                    (managedTurnRequestFromText "one")
+                result `shouldBe` Left "agent session timed out"
+                closeSessionProcessManager manager
 
 runTool :: AgentSessionToolsEnv -> Text.Text -> Text.Text -> IO Text.Text
 runTool env name arguments = do

--- a/packages/agent-cli/test/Agent/CLI/GatewayBridgeSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/GatewayBridgeSpec.hs
@@ -1,0 +1,130 @@
+module Agent.CLI.GatewayBridgeSpec (spec) where
+
+import Agent.CLI.GatewayBridge
+import Agent.CLI.ManagedTurn
+import Agent.CLI.Permission (PermissionChoice(..))
+import Agent.Loop (LoopEvent(..), defaultLoopDispatch)
+import Agent.OsPath (unsafeToFilePath)
+import Agent.ToolDispatch
+    ( ToolCallResult(..)
+    , dispatchToolCall
+    , functionToolCall
+    )
+import Agent.Tools.Types (appToolHandlers)
+import Control.Concurrent (threadDelay)
+import Control.Concurrent.Async (withAsync, wait)
+import Control.Exception.Safe (bracket)
+import Data.Aeson (Value(..), eitherDecode)
+import qualified Data.ByteString.Lazy as LBS
+import Data.Maybe (listToMaybe)
+import System.Directory
+    ( createDirectoryIfMissing
+    , getTemporaryDirectory
+    , listDirectory
+    , removePathForcibly
+    )
+import System.FilePath ((</>))
+import System.Posix.Temp (mkdtemp)
+import Test.Hspec
+
+spec :: Spec
+spec = describe "Agent.CLI.GatewayBridge" do
+    it "round-trips a channel tool request through private files" $
+        withBridgeRequest \request -> do
+            let call = functionToolCall
+                    "call-1"
+                    "send_telegram_document"
+                    "{\"path\":\"/tmp/report.pdf\",\"caption\":\"Report\"}"
+            withAsync
+                (dispatchToolCall
+                    defaultLoopDispatch
+                    (appToolHandlers (managedGatewayTools request))
+                    call)
+                \running -> do
+                    bridgeRequest <- waitForBridgeRequest request
+                    bridgeRequest.bridgeRequestKind `shouldBe` "send_document"
+                    writeManagedBridgeResponse request ManagedBridgeResponse
+                        { bridgeResponseVersion = 1
+                        , bridgeResponseId = bridgeRequest.bridgeRequestId
+                        , bridgeResponseOk = True
+                        , bridgeResponseResult = Just (String "sent")
+                        , bridgeResponseError = Nothing
+                        }
+                    result <- wait running
+                    result.output `shouldBe` "sent"
+
+    it "uses the bridge for mutating-tool approval choices" $
+        withBridgeRequest \request -> do
+            let call = functionToolCall
+                    "approval-1"
+                    "apply_patch"
+                    "*** Begin Patch"
+            withAsync (requestManagedApproval request call) \running -> do
+                bridgeRequest <- waitForBridgeRequest request
+                bridgeRequest.bridgeRequestKind `shouldBe` "approval"
+                writeManagedBridgeResponse request ManagedBridgeResponse
+                    { bridgeResponseVersion = 1
+                    , bridgeResponseId = bridgeRequest.bridgeRequestId
+                    , bridgeResponseOk = True
+                    , bridgeResponseResult = Just (String "allow_once")
+                    , bridgeResponseError = Nothing
+                    }
+                wait running `shouldReturn` Just PermissionAllowOnce
+
+    it "publishes redacted activity rather than streamed content" $
+        withBridgeRequest \request -> do
+            publishManagedLoopEvent request (TextDelta "secret response text")
+            bytes <- LBS.readFile
+                (unsafeToFilePath (managedBridgeActivityPath request))
+            activity <- case
+                    eitherDecode bytes
+                        :: Either String ManagedActivity
+                of
+                Left err -> expectationFailure err >> fail err
+                Right value -> pure value
+            activity.managedActivityKind `shouldBe` "writing"
+            activity.managedActivityMessage `shouldBe` "Writing reply…"
+
+withBridgeRequest :: (ManagedTurnRequest -> IO a) -> IO a
+withBridgeRequest action =
+    withTempDir "gateway-bridge-spec-" \dir -> do
+        let request =
+                managedTurnRequestWithGateway
+                    dir
+                    ManagedTurnContext
+                        { managedGateway = "telegram"
+                        , managedChatId = 123
+                        , managedMessageThreadId = Nothing
+                        , managedReplyToMessageId = Just 77
+                        , managedUserId = 456
+                        }
+                    (managedTurnRequestFromText "hello")
+        createDirectoryIfMissing True
+            (unsafeToFilePath (managedBridgeRequestsDirectory request))
+        createDirectoryIfMissing True
+            (unsafeToFilePath (managedBridgeResponsesDirectory request))
+        action request
+
+waitForBridgeRequest :: ManagedTurnRequest -> IO ManagedBridgeRequest
+waitForBridgeRequest request = go (100 :: Int)
+  where
+    directory =
+        unsafeToFilePath (managedBridgeRequestsDirectory request)
+    go 0 = expectationFailure "timed out waiting for bridge request" >> fail "timeout"
+    go attempts = do
+        files <- listDirectory directory
+        case listToMaybe files of
+            Nothing -> threadDelay 20_000 >> go (attempts - 1)
+            Just name -> do
+                bytes <- LBS.readFile (directory </> name)
+                case eitherDecode bytes of
+                    Left _ -> threadDelay 20_000 >> go (attempts - 1)
+                    Right value -> pure value
+
+withTempDir :: String -> (FilePath -> IO a) -> IO a
+withTempDir prefix action = do
+    tmp <- getTemporaryDirectory
+    bracket
+        (mkdtemp (tmp </> prefix))
+        removePathForcibly
+        action

--- a/packages/agent-cli/test/Agent/CLI/ManagedTurnSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ManagedTurnSpec.hs
@@ -1,0 +1,48 @@
+module Agent.CLI.ManagedTurnSpec (spec) where
+
+import Agent.CLI.ManagedTurn
+    ( managedTurnRequestFromText
+    , loadManagedTurnRequest
+    , renderManagedTurnPrompt
+    )
+import Agent.OsPath (fromText)
+import qualified Data.Text as Text
+import qualified Data.Text.IO as Text
+import System.Directory
+    ( createDirectoryIfMissing
+    , getTemporaryDirectory
+    , removePathForcibly
+    )
+import System.FilePath ((</>))
+import Control.Exception (finally)
+import Data.Unique (newUnique, hashUnique)
+import Test.Hspec
+
+spec :: Spec
+spec = describe "Agent.CLI.ManagedTurn" do
+    it "round-trips a prompt-file request through JSON" $
+        withManagedTempDir \dir -> do
+            let request = managedTurnRequestFromText "hello"
+                pathFile = dir </> "prompt.json"
+                path = fromText (Text.pack pathFile)
+            Text.writeFile pathFile (renderManagedTurnPrompt request)
+            loaded <- loadManagedTurnRequest path
+            loaded `shouldBe` Right request
+
+    it "rejects non-JSON managed turn files" $
+        withManagedTempDir \dir -> do
+            let pathFile = dir </> "prompt.txt"
+                path = fromText (Text.pack pathFile)
+            Text.writeFile pathFile "plain text"
+            loaded <- loadManagedTurnRequest path
+            loaded `shouldSatisfy` \case
+                Left err -> "could not decode" `Text.isInfixOf` err
+                Right _ -> False
+
+withManagedTempDir :: (FilePath -> IO a) -> IO a
+withManagedTempDir action = do
+    root <- getTemporaryDirectory
+    unique <- hashUnique <$> newUnique
+    let dir = root </> ("agent-cli-managed-turn-spec-" <> show unique)
+    createDirectoryIfMissing True dir
+    action dir `finally` removePathForcibly dir

--- a/packages/agent-cli/test/Agent/CLI/OptionsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/OptionsSpec.hs
@@ -88,6 +88,13 @@ spec = do
 
         it "rejects using both -p and --prompt-file" do
             parseArgs ["-p", "a", "--prompt-file", "b"] `shouldSatisfy` isLeft
+            parseArgs ["-p", "a", "--managed-turn-file", "b"]
+                `shouldSatisfy` isLeft
+
+        it "parses the internal managed-turn request file" do
+            parseArgs ["--managed-turn-file", "turn.json"]
+                `shouldBe` Right (RunAgent defaultCliOptions
+                    { optManagedTurnFile = Just (fromFilePath "turn.json") })
 
         it "requires a positive compaction threshold" do
             parseArgs ["--compact-threshold", "0"] `shouldSatisfy` isLeft
@@ -187,6 +194,26 @@ spec = do
             resolveApprovalPolicy defaultCliOptions { optNoYolo = True } False False
                 `shouldBe` DenyMutating
 
+        it "keeps managed non-TTY turns in remote prompt mode" do
+            resolveApprovalPolicy
+                defaultCliOptions
+                    { optManagedTurnFile = Just (fromFilePath "turn.json")
+                    , optNoYolo = True
+                    }
+                False
+                False
+                `shouldBe` PromptMutating
+
+        it "keeps explicitly denied managed turns non-mutating" do
+            resolveApprovalPolicy
+                defaultCliOptions
+                    { optManagedTurnFile = Just (fromFilePath "turn.json")
+                    , optManagedDenyMutations = True
+                    }
+                False
+                False
+                `shouldBe` DenyMutating
+
         it "does not auto-approve a piped interactive REPL" do
             resolveApprovalPolicy defaultCliOptions False False
                 `shouldBe` DenyMutating
@@ -224,10 +251,13 @@ spec = do
             defaultEffortFor ClaudeCodeProvider `shouldBe` "xhigh"
 
     describe "isOneShot" do
-        it "is true for -p and --prompt-file" do
+        it "is true for text, prompt-file, and managed-turn-file input" do
             isOneShot defaultCliOptions `shouldBe` False
             isOneShot defaultCliOptions { optPrompt = Just "x" } `shouldBe` True
             isOneShot defaultCliOptions { optPromptFile = Just (fromFilePath "x.md") } `shouldBe` True
+            isOneShot defaultCliOptions
+                { optManagedTurnFile = Just (fromFilePath "turn.json") }
+                `shouldBe` True
 
 isLeft :: Either a b -> Bool
 isLeft = \case

--- a/packages/agent-cli/test/Agent/TelegramSpec.hs
+++ b/packages/agent-cli/test/Agent/TelegramSpec.hs
@@ -1,6 +1,17 @@
 module Agent.TelegramSpec (spec) where
 
 import Agent.Telegram
+import Agent.Telegram.Types
+    ( TelegramApprovalMode(..)
+    , TelegramFileMedia(..)
+    , TelegramMedia(..)
+    , TelegramMediaKind(..)
+    , TelegramCallbackBinding(..)
+    , TelegramDeadLetter(..)
+    , TelegramPendingCallback(..)
+    , TelegramPendingMediaTurn(..)
+    , TelegramRetryMetadata(..)
+    )
 import Control.Concurrent
     ( newEmptyMVar
     , putMVar
@@ -12,6 +23,7 @@ import qualified Data.ByteString.Lazy.Char8 as LBS
 import Data.IORef (modifyIORef', newIORef, readIORef)
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
+import qualified Data.Text as Text
 import Agent.Provider (Provider(..))
 import qualified System.Timeout as Timeout
 import Test.Hspec
@@ -38,8 +50,8 @@ spec = describe "Agent.Telegram" do
                         { setupProvider = Just XAIProvider
                         , setupModel = Just "grok-4.6"
                         , setupCwd = Just "/tmp/project"
-                        , setupYolo = True
-                        , setupAllowedUser = Just 123
+                        , setupApprovalMode = TelegramApprovalYolo
+                        , setupAllowedUsers = [123]
                         , setupStart = True
                         })
 
@@ -58,6 +70,21 @@ spec = describe "Agent.Telegram" do
             parseAllowedUsers "" `shouldSatisfy` isLeft
             parseAllowedUsers "123,nope" `shouldSatisfy` isLeft
             parseAllowedUsers "-1" `shouldSatisfy` isLeft
+
+    describe "Telegram config migration" do
+        it "maps legacy yolo booleans onto explicit approval modes" do
+            let decode yolo = eitherDecode
+                    (encode (object
+                        [ "provider" .= ("xai" :: String)
+                        , "cwd" .= ("/tmp" :: String)
+                        , "allowedUsers" .= ([123] :: [Integer])
+                        , "yolo" .= yolo
+                        ]))
+                    :: Either String TelegramConfig
+            fmap (.telegramApprovalMode) (decode False)
+                `shouldBe` Right TelegramApprovalPrompt
+            fmap (.telegramApprovalMode) (decode True)
+                `shouldBe` Right TelegramApprovalYolo
 
     describe "splitTelegramText" do
         it "keeps messages within the requested limit" do
@@ -136,6 +163,36 @@ spec = describe "Agent.Telegram" do
                     Nothing -> False
                 Left _ -> False
 
+        it "routes allowed callback queries onto the durable callback queue" do
+            let bot = TelegramUser
+                    { userId = 999
+                    , userIsBot = True
+                    , userFirstName = Just "Harness"
+                    , userLastName = Nothing
+                    , userUsername = Just "HarnessBot"
+                    }
+                decoded = eitherDecode
+                    (LBS.pack
+                        "{\"update_id\":24,\"callback_query\":{\
+                        \\"id\":\"callback-1\",\"from\":{\"id\":456},\
+                        \\"data\":\"ha:request:0\",\
+                        \\"message\":{\"message_id\":88,\
+                        \\"chat\":{\"id\":123,\"type\":\"private\"}}}}")
+                    :: Either String TelegramUpdate
+            update <- decoded `shouldReturnRight`
+                "Telegram callback update should decode"
+            classifyTelegramUpdate bot (Set.singleton 456) update
+                `shouldBe`
+                    QueueCallback TelegramPendingCallback
+                        { pendingCallbackUpdateId = 24
+                        , pendingCallbackQueryId = "callback-1"
+                        , pendingCallbackUserId = 456
+                        , pendingCallbackChat =
+                            Just (TelegramChatKey 123 Nothing)
+                        , pendingCallbackMessageId = Just 88
+                        , pendingCallbackData = "ha:request:0"
+                        }
+
         it "recognizes emoji-only assistant replies as reactions" do
             telegramReactionEmoji " 👍 " `shouldBe` Just "👍"
             telegramReactionEmoji "❤️" `shouldBe` Just "❤"
@@ -159,6 +216,113 @@ spec = describe "Agent.Telegram" do
                             && voice.voiceFileSize == Just 1024
                     Nothing -> False
                 Left _ -> False
+
+    describe "Telegram media messages" do
+        let bot = TelegramUser
+                { userId = 999
+                , userIsBot = True
+                , userFirstName = Just "Harness"
+                , userLastName = Nothing
+                , userUsername = Just "HarnessBot"
+                }
+            allowedUsers = Set.singleton 456
+            classify bytes = do
+                update <- (eitherDecode (LBS.pack bytes)
+                    :: Either String TelegramUpdate)
+                    `shouldReturnRight` "Telegram update should decode"
+                pure (classifyTelegramUpdate bot allowedUsers update)
+
+        it "queues private photo captions as managed media turns" do
+            action <- classify
+                "{\"update_id\":31,\"message\":{\
+                \\"message_id\":90,\"from\":{\"id\":456},\
+                \\"chat\":{\"id\":123,\"type\":\"private\"},\
+                \\"caption\":\"summarize this\",\
+                \\"photo\":[{\
+                \\"file_id\":\"small\",\"width\":10,\"height\":10},{\
+                \\"file_id\":\"large\",\"width\":20,\"height\":20,\
+                \\"file_size\":1024}]}}"
+            action `shouldBe`
+                QueueMediaTurn
+                    TelegramPendingMediaTurn
+                        { pendingMediaUpdateId = 31
+                        , pendingMediaMessageId = 90
+                        , pendingMediaChat = TelegramChatKey 123 Nothing
+                        , pendingMediaUserId = 456
+                        , pendingMediaText = "summarize this"
+                        , pendingMediaAttachments =
+                            [ TelegramMedia
+                                { telegramMediaKind = TelegramMediaPhoto
+                                , telegramMediaFile =
+                                    Just TelegramFileMedia
+                                        { fileMediaFileId = "large"
+                                        , fileMediaName = Nothing
+                                        , fileMediaMimeType = Just "image/jpeg"
+                                        , fileMediaFileSize = Just 1024
+                                        , fileMediaDuration = Nothing
+                                        }
+                                , telegramMediaDescription = "[Photo]"
+                                }
+                            ]
+                        , pendingMediaEdited = False
+                        , pendingMediaGroupId = Nothing
+                        }
+
+        it "routes edited text through replaceable managed-turn work" do
+            action <- classify
+                "{\"update_id\":33,\"edited_message\":{\
+                \\"message_id\":90,\"from\":{\"id\":456},\
+                \\"chat\":{\"id\":123,\"type\":\"private\"},\
+                \\"text\":\"corrected text\"}}"
+            action `shouldBe`
+                QueueMediaTurn TelegramPendingMediaTurn
+                    { pendingMediaUpdateId = 33
+                    , pendingMediaMessageId = 90
+                    , pendingMediaChat = TelegramChatKey 123 Nothing
+                    , pendingMediaUserId = 456
+                    , pendingMediaText = "corrected text"
+                    , pendingMediaAttachments = []
+                    , pendingMediaEdited = True
+                    , pendingMediaGroupId = Nothing
+                    }
+
+        it "queues group media replies as attributed managed media turns" do
+            action <- classify
+                "{\"update_id\":32,\"message\":{\
+                \\"message_id\":91,\"from\":{\"id\":456,\"first_name\":\"Marc\"},\
+                \\"chat\":{\"id\":-1001,\"type\":\"group\"},\
+                \\"document\":{\"file_id\":\"doc-file\",\"file_name\":\"report.pdf\",\
+                \\"mime_type\":\"application/pdf\",\"file_size\":2048},\
+                \\"reply_to_message\":{\"message_id\":77,\
+                \\"from\":{\"id\":999,\"is_bot\":true},\
+                \\"chat\":{\"id\":-1001,\"type\":\"group\"}}}}"
+            action `shouldBe`
+                QueueMediaTurn
+                    TelegramPendingMediaTurn
+                        { pendingMediaUpdateId = 32
+                        , pendingMediaMessageId = 91
+                        , pendingMediaChat = TelegramChatKey (-1001) Nothing
+                        , pendingMediaUserId = 456
+                        , pendingMediaText =
+                            "[Telegram group message from Marc, user 456]\n\
+                            \[Document: report.pdf]"
+                        , pendingMediaAttachments =
+                            [ TelegramMedia
+                                { telegramMediaKind = TelegramMediaDocument
+                                , telegramMediaFile =
+                                    Just TelegramFileMedia
+                                        { fileMediaFileId = "doc-file"
+                                        , fileMediaName = Just "report.pdf"
+                                        , fileMediaMimeType = Just "application/pdf"
+                                        , fileMediaFileSize = Just 2048
+                                        , fileMediaDuration = Nothing
+                                        }
+                                , telegramMediaDescription = "[Document: report.pdf]"
+                                }
+                            ]
+                        , pendingMediaEdited = False
+                        , pendingMediaGroupId = Nothing
+                        }
 
     describe "Telegram group chats" do
         let bot = TelegramUser
@@ -394,7 +558,8 @@ spec = describe "Agent.Telegram" do
                             ]
                     }
                 expected = object
-                    [ "nextUpdateId" .= (Just 12 :: Maybe Integer)
+                    [ "version" .= (2 :: Int)
+                    , "nextUpdateId" .= (Just 12 :: Maybe Integer)
                     , "bindings" .=
                         [ object
                             [ "chat" .= key
@@ -403,6 +568,15 @@ spec = describe "Agent.Telegram" do
                         ]
                     , "pendingTurns" .= [turn]
                     , "pendingReplies" .= [reply]
+                    , "pendingMediaTurns" .= ([] :: [TelegramPendingMediaTurn])
+                    , "pendingCallbacks" .= ([] :: [TelegramPendingCallback])
+                    , "callbackBindings" .= ([] :: [TelegramCallbackBinding])
+                    , "retryMetadata" .=
+                        ([] :: [(Text.Text, TelegramRetryMetadata)])
+                    , "deliveryCheckpoints" .=
+                        ([] :: [(Text.Text, Int)])
+                    , "deadLetters" .= ([] :: [TelegramDeadLetter])
+                    , "outboundMessages" .= ([] :: [Value])
                     ]
             (eitherDecode (encode state) :: Either String Value)
                 `shouldBe` Right expected
@@ -430,6 +604,42 @@ spec = describe "Agent.Telegram" do
                     (QueueTurn 77 key "hello" Nothing)
                     once
             twice.pendingQueues `shouldBe` once.pendingQueues
+
+        it "coalesces adjacent text bursts into one managed turn" do
+            let key = TelegramChatKey 123 Nothing
+                first = storeUpdateAction
+                    10
+                    (QueueTurn 77 key "first" Nothing)
+                    emptyTelegramState
+                second = storeUpdateAction
+                    11
+                    (QueueTurn 78 key "second" Nothing)
+                    first
+            nextPendingAction key second `shouldBe`
+                Just
+                    (RunPendingMediaTurn TelegramPendingMediaTurn
+                        { pendingMediaUpdateId = 11
+                        , pendingMediaMessageId = 78
+                        , pendingMediaChat = key
+                        , pendingMediaUserId = 0
+                        , pendingMediaText = "first\n\n---\n\nsecond"
+                        , pendingMediaAttachments = []
+                        , pendingMediaEdited = False
+                        , pendingMediaGroupId = Nothing
+                        })
+
+        it "persists callback, retry, and chunk-delivery state" do
+            let key = TelegramChatKey 123 Nothing
+                callback = TelegramPendingCallback
+                    20 "callback-1" 456 (Just key) (Just 80) "ha:request:0"
+                retry = TelegramRetryMetadata 2 Nothing (Just "temporary")
+                state = emptyTelegramState
+                    { pendingCallbacks = Map.singleton 20 callback
+                    , retryMetadata = Map.singleton "turn" retry
+                    , deliveryCheckpoints = Map.singleton "reply" 2
+                    }
+            (eitherDecode (encode state) :: Either String TelegramState)
+                `shouldBe` Right state
 
         it "checkpoints a voice transcript before running the agent" do
             let key = TelegramChatKey 123 Nothing

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -18,6 +18,7 @@ import qualified Agent.CLI.ConnectivitySpec as ConnectivitySpec
 import qualified Agent.CLI.CredentialStoreSpec as CredentialStoreSpec
 import qualified Agent.CLI.DialectsSpec as DialectsSpec
 import qualified Agent.CLI.ErrorSpec as ErrorSpec
+import qualified Agent.CLI.GatewayBridgeSpec as GatewayBridgeSpec
 import qualified Agent.CLI.ImagePreviewSpec as ImagePreviewSpec
 import qualified Agent.CLI.InputSpec as InputSpec
 import qualified Agent.CLI.InterruptSpec as InterruptSpec
@@ -82,6 +83,7 @@ main = hspec do
     CredentialStoreSpec.spec
     DialectsSpec.spec
     ErrorSpec.spec
+    GatewayBridgeSpec.spec
     ImagePreviewSpec.spec
     InputSpec.spec
     InterruptSpec.spec

--- a/packages/agent-core/src/Agent/Loop.hs
+++ b/packages/agent-core/src/Agent/Loop.hs
@@ -7,6 +7,7 @@ module Agent.Loop
     ( Backend(..)
     , BackendResult(..)
     , BackendStateStore(..)
+    , FileAttachment(..)
     , ImageAttachment(..)
     , LoopConfig(..)
     , LoopExecution(..)
@@ -66,12 +67,33 @@ instance Show ImageAttachment where
             <> ", imageByteLength = " <> show (ByteString.length image.imageBytes)
             <> " }"
 
+-- | File bytes attached to a user turn. Providers that cannot ingest files
+-- natively should fall back to a local path or text summary.
+data FileAttachment = FileAttachment
+    { fileName :: !(Maybe Text)
+    , fileMime :: !Text
+    , fileBytes :: !ByteString
+    } deriving (Eq)
+
+instance Show FileAttachment where
+    show file =
+        "FileAttachment { fileName = " <> show file.fileName
+            <> ", fileMime = " <> show file.fileMime
+            <> ", fileBytes = <redacted>"
+            <> ", fileByteLength = " <> show (ByteString.length file.fileBytes)
+            <> " }"
+
 data TurnInput
     = UserMessage Text
     | AgentMessage InterAgentMessage
     | UserMultimodal
         { userText :: !Text
         , userImages :: ![ImageAttachment]
+        }
+    | UserMultimodalFiles
+        { userText :: !Text
+        , userImages :: ![ImageAttachment]
+        , userFiles :: ![FileAttachment]
         }
     | CompletedTool ToolCallResult
     deriving (Eq, Show)

--- a/packages/agent-core/test/Agent/LoopSpec.hs
+++ b/packages/agent-core/test/Agent/LoopSpec.hs
@@ -41,6 +41,15 @@ spec = describe "runLoop" do
         rendered `shouldContain` "<redacted>"
         rendered `shouldNotContain` "secret-image-bytes"
 
+    it "shows file metadata without exposing file bytes" do
+        let file = FileAttachment (Just "report.pdf") "application/pdf" "secret-file-bytes"
+            rendered = show file
+        rendered `shouldContain` "report.pdf"
+        rendered `shouldContain` "application/pdf"
+        rendered `shouldContain` "fileByteLength = 17"
+        rendered `shouldContain` "<redacted>"
+        rendered `shouldNotContain` "secret-file-bytes"
+
     it "combines TokenUsage component-wise" do
         TokenUsage 10 4 6 <> TokenUsage 3 2 1
             `shouldBe` TokenUsage 13 6 7
@@ -89,6 +98,31 @@ spec = describe "runLoop" do
         result `shouldBe` Right LoopResult
             { finalResponseId = "resp-m"
             , finalText = Just "saw it"
+            , turnsUsed = 1
+            , tokenUsage = emptyTokenUsage
+            }
+        seen <- readIORef submissions
+        seen `shouldBe` [(Nothing, inputs)]
+
+    it "accepts file attachments in multimodal turns" do
+        submissions <- newIORef []
+        backend <- scriptedBackend submissions
+            [ Right $ emptyTurnOutput "resp-f" [] (Just "saw files")
+            ]
+        let image = ImageAttachment "image/png" "abc"
+            file = FileAttachment (Just "notes.txt") "text/plain" "file-bytes"
+            inputs =
+                [ UserMultimodalFiles
+                    { userText = "see this"
+                    , userImages = [image]
+                    , userFiles = [file]
+                    }
+                ]
+        config <- testConfig backend
+        result <- runLoopInputs config Nothing inputs
+        result `shouldBe` Right LoopResult
+            { finalResponseId = "resp-f"
+            , finalText = Just "saw files"
             , turnsUsed = 1
             , tokenUsage = emptyTokenUsage
             }

--- a/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
@@ -116,6 +116,23 @@ spec = do
                 other ->
                     expectationFailure ("expected one user message, got " <> show other)
 
+        it "encodes multimodal files as input_image plus input_file parts" do
+            let image = ImageAttachment "image/png" "png-bytes"
+                file = FileAttachment (Just "notes.txt") "text/plain" "file-bytes"
+            case turnInputsToItems
+                    [UserMultimodalFiles "see this" [image] [file]] of
+                [MessageItem message] -> do
+                    message.role `shouldBe` RoleUser
+                    case message.content of
+                        MessageContentParts parts ->
+                            parts `shouldSatisfy` \ps ->
+                                any isInputFile ps && any isInputImage ps
+                        other ->
+                            expectationFailure
+                                ("expected text+image+file parts, got " <> show other)
+                other ->
+                    expectationFailure ("expected one user message, got " <> show other)
+
         it "encodes function results as function_call_output strings" do
             let items = turnInputsToItems
                     [CompletedTool (functionResult "c1" "echoed")]
@@ -1350,3 +1367,13 @@ replayUnsafeAuxiliaryFailure failure =
             <> Text.pack (show failure)
         )
         Nothing
+
+isInputFile :: ResponseContentPart -> Bool
+isInputFile = \case
+    InputFilePart{} -> True
+    _ -> False
+
+isInputImage :: ResponseContentPart -> Bool
+isInputImage = \case
+    InputImagePart{} -> True
+    _ -> False

--- a/packages/agent-responses/src/Agent/Responses/LoopBackend.hs
+++ b/packages/agent-responses/src/Agent/Responses/LoopBackend.hs
@@ -22,6 +22,7 @@ import Agent.InterAgentMessage
 import Agent.Loop
     ( Backend(..)
     , BackendResult(..)
+    , FileAttachment(..)
     , ImageAttachment(..)
     , LoopEvent(..)
     , TokenUsage(..)
@@ -144,12 +145,28 @@ turnInputToItem = \case
     UserMessage text -> userMessageItem text
     AgentMessage message -> agentMessageItem message
     UserMultimodal{userText, userImages} -> multimodalUserItem userText userImages
+    UserMultimodalFiles{userText, userImages, userFiles} ->
+        multimodalFilesItem userText userImages userFiles
     CompletedTool result -> toolResultToItem result
 
 userMessageItem :: Text -> ResponseItem
 userMessageItem text = MessageItem ResponseMessage
     { messageId = Nothing
     , content = MessageContentParts [InputTextPart text Nothing KeyMap.empty]
+    , role = RoleUser
+    , status = Nothing
+    , phase = Nothing
+    , extraFields = KeyMap.empty
+    }
+
+multimodalFilesItem :: Text -> [ImageAttachment] -> [FileAttachment] -> ResponseItem
+multimodalFilesItem text images files = MessageItem ResponseMessage
+    { messageId = Nothing
+    , content = MessageContentParts
+        ( InputTextPart text Nothing KeyMap.empty
+        : map imageAttachmentPart images
+        <> map fileAttachmentPart files
+        )
     , role = RoleUser
     , status = Nothing
     , phase = Nothing
@@ -202,6 +219,18 @@ imageAttachmentPart ImageAttachment{imageMime, imageBytes} =
         { detail = Just "auto"
         , fileId = Nothing
         , imageUrl = Just (imageDataUrl imageMime imageBytes)
+        , promptCacheBreakpoint = Nothing
+        , extraFields = KeyMap.empty
+        }
+
+fileAttachmentPart :: FileAttachment -> ResponseContentPart
+fileAttachmentPart FileAttachment{fileName, fileMime, fileBytes} =
+    InputFilePart
+        { detail = Just "auto"
+        , fileData = Just (imageDataUrl fileMime fileBytes)
+        , fileId = Nothing
+        , fileUrl = Nothing
+        , filename = fileName
         , promptCacheBreakpoint = Nothing
         , extraFields = KeyMap.empty
         }

--- a/packages/agent-responses/test/Agent/Responses/LoopBackendSpec.hs
+++ b/packages/agent-responses/test/Agent/Responses/LoopBackendSpec.hs
@@ -1,7 +1,12 @@
 module Agent.Responses.LoopBackendSpec (spec) where
 
 import Agent.Error (ApiError(..), ErrorType(..))
-import Agent.Loop (Backend(..), TurnInput(..))
+import Agent.Loop
+    ( Backend(..)
+    , FileAttachment(..)
+    , ImageAttachment(..)
+    , TurnInput(..)
+    )
 import Agent.Provider
     ( Credential(..)
     , BillingMode(..)
@@ -10,13 +15,35 @@ import Agent.Provider
     , tokenProvider
     )
 import Agent.Responses.LoopBackend (tokenProviderStatelessResponsesBackend)
-import Agent.Responses.Types (defaultResponseCreateParams)
+import Agent.Responses.LoopBackend (turnInputsToItems)
+import Agent.Responses.Types
+    ( MessageContent(..)
+    , ResponseContentPart(..)
+    , ResponseItem(..)
+    , ResponseMessage(..)
+    , ResponseRole(..)
+    , defaultResponseCreateParams
+    )
 import Data.IORef
 import qualified Data.Text as Text
 import Test.Hspec
 
 spec :: Spec
 spec = describe "tokenProviderStatelessResponsesBackend" do
+    it "encodes file attachments as input_file parts" do
+        let image = ImageAttachment "image/png" "png-bytes"
+            file = FileAttachment (Just "notes.txt") "text/plain" "file-bytes"
+        case turnInputsToItems
+                [UserMultimodalFiles "see this" [image] [file]] of
+            [MessageItem message] -> do
+                message.role `shouldBe` RoleUser
+                case message.content of
+                    MessageContentParts parts ->
+                        parts `shouldSatisfy` \ps ->
+                            any isInputFile ps && any isInputImage ps
+                    _ -> expectationFailure "expected multimodal message parts"
+            other -> expectationFailure ("unexpected items: " <> show other)
+
     it "reacquires a credential after an authentication rejection" do
         attempts <- newIORef []
         let first = credential "first"
@@ -48,3 +75,13 @@ credential label = Credential
     , leaseId = Nothing
     , provider = OpenRouterProvider
     }
+
+isInputFile :: ResponseContentPart -> Bool
+isInputFile = \case
+    InputFilePart{} -> True
+    _ -> False
+
+isInputImage :: ResponseContentPart -> Bool
+isInputImage = \case
+    InputImagePart{} -> True
+    _ -> False


### PR DESCRIPTION
## Summary

- add versioned managed turns and provider-neutral file attachments across the core, Responses, and Claude backends
- add a secure child/parent gateway bridge for Telegram files, reactions, inline choices, and remote tool approvals
- expand the polling gateway with rich media, edited messages, callbacks, reaction handling, managed allowlists, and prompt/deny/yolo approval modes
- harden processing with scoped child lifetimes, a 20-minute turn timeout, per-chat serialization, a bounded worker pool, batching, durable retries, dead letters, and delivery checkpoints
- update Telegram documentation, package metadata, and coverage for the new behavior

## Validation

- `nix develop -c cabal test agent-core-test agent-responses-test agent-openai-test agent-claude-test agent-cli-test --test-show-details=failures`
- multi-package GHCi load (214 modules)
- `nix build path:.#agent-telegram --no-link`
- packaged `agent-telegram --help` smoke-tested in a real TTY
- `git diff --check`
