### PR TITLE
Suspend GHCi when switching to bash mode

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -2605,7 +2605,7 @@ runAgentInitializedWithLock
                                         projectRoot transition persist noticingBackend
                                 withAsync switchLoop \switchWorker -> do
                                     link switchWorker
-                                    runSession catalog inferredTarget.targetConnectionId options provider dialect policy allTools mcpFleet.mcpFleetRegistrations mcpFleet.mcpFleetWarnings ghciEnabledRef bashEnabledRef toolEnv planMode startup databaseScopes prompt pendingTurn unavailableProviders startupUnavailable paramsRef transcriptRef initialTurns
+                                    runSession catalog inferredTarget.targetConnectionId options provider dialect policy allTools coding.codingSuspendGhci mcpFleet.mcpFleetRegistrations mcpFleet.mcpFleetWarnings ghciEnabledRef bashEnabledRef toolEnv planMode startup databaseScopes prompt pendingTurn unavailableProviders startupUnavailable paramsRef transcriptRef initialTurns
                                         previousRef persist projectRoot home cwd (Just tokenProvider) loaded.loadedOpenAiPool startupContext skillsRef skillInvocationsRef escPaused interrupt
                                         multiCtx rootTurnRef subagentSessions pendingNotices subagentStoreRoot agentTypesRef legacySubagentTarget usageRef activeAccountRef activeAccountIdRef activeSelectionRef resolveActiveAccountLabel selectAccount claimCurrentSession compactRunner activeBackend btwBackend)
                             >>= \case
@@ -2669,7 +2669,7 @@ runAgentInitializedWithLock
                         activeBackend <-
                             prepareTransitionBackend
                                 projectRoot transition persist backend
-                        runSession catalog inferredTarget.targetConnectionId options provider dialect policy allTools mcpFleet.mcpFleetRegistrations mcpFleet.mcpFleetWarnings ghciEnabledRef bashEnabledRef toolEnv planMode startup databaseScopes prompt pendingTurn unavailableProviders startupUnavailable paramsRef transcriptRef initialTurns
+                        runSession catalog inferredTarget.targetConnectionId options provider dialect policy allTools coding.codingSuspendGhci mcpFleet.mcpFleetRegistrations mcpFleet.mcpFleetWarnings ghciEnabledRef bashEnabledRef toolEnv planMode startup databaseScopes prompt pendingTurn unavailableProviders startupUnavailable paramsRef transcriptRef initialTurns
                             previousRef persist projectRoot home cwd (Just tokenProvider) loaded.loadedOpenAiPool startupContext skillsRef skillInvocationsRef escPaused interrupt
                             multiCtx rootTurnRef subagentSessions pendingNotices subagentStoreRoot agentTypesRef legacySubagentTarget usageRef activeAccountRef activeAccountIdRef activeSelectionRef resolveActiveAccountLabel (if isJust customGenericOptions then Nothing else Just selectHttpAccount) claimCurrentSession compactRunner activeBackend btwBackend
                     ClaudeCodeProvider -> do
@@ -2730,7 +2730,7 @@ runAgentInitializedWithLock
                                 activeBackend <-
                                     prepareTransitionBackend
                                         projectRoot transition persist backend
-                                runSession catalog inferredTarget.targetConnectionId options provider dialect policy allTools mcpFleet.mcpFleetRegistrations mcpFleet.mcpFleetWarnings ghciEnabledRef bashEnabledRef toolEnv planMode startup databaseScopes prompt pendingTurn unavailableProviders startupUnavailable paramsRef transcriptRef initialTurns
+                                runSession catalog inferredTarget.targetConnectionId options provider dialect policy allTools coding.codingSuspendGhci mcpFleet.mcpFleetRegistrations mcpFleet.mcpFleetWarnings ghciEnabledRef bashEnabledRef toolEnv planMode startup databaseScopes prompt pendingTurn unavailableProviders startupUnavailable paramsRef transcriptRef initialTurns
                                     previousRef persist projectRoot home cwd Nothing Nothing startupContext skillsRef skillInvocationsRef escPaused interrupt
                                     multiCtx rootTurnRef subagentSessions pendingNotices subagentStoreRoot agentTypesRef legacySubagentTarget usageRef activeAccountRef activeAccountIdRef activeSelectionRef resolveActiveAccountLabel Nothing claimCurrentSession compactRunner activeBackend btwBackend
                     OpenRouterProvider -> do
@@ -2802,7 +2802,7 @@ runAgentInitializedWithLock
                         activeBackend <-
                             prepareTransitionBackend
                                 projectRoot transition persist backend
-                        runSession catalog inferredTarget.targetConnectionId options provider dialect policy allTools mcpFleet.mcpFleetRegistrations mcpFleet.mcpFleetWarnings ghciEnabledRef bashEnabledRef toolEnv planMode startup databaseScopes prompt pendingTurn unavailableProviders startupUnavailable paramsRef transcriptRef initialTurns
+                        runSession catalog inferredTarget.targetConnectionId options provider dialect policy allTools coding.codingSuspendGhci mcpFleet.mcpFleetRegistrations mcpFleet.mcpFleetWarnings ghciEnabledRef bashEnabledRef toolEnv planMode startup databaseScopes prompt pendingTurn unavailableProviders startupUnavailable paramsRef transcriptRef initialTurns
                             previousRef persist projectRoot home cwd (Just tokenProvider) loaded.loadedOpenAiPool startupContext skillsRef skillInvocationsRef escPaused interrupt
                             multiCtx rootTurnRef subagentSessions pendingNotices subagentStoreRoot agentTypesRef legacySubagentTarget usageRef activeAccountRef activeAccountIdRef activeSelectionRef resolveActiveAccountLabel (Just selectHttpAccount) claimCurrentSession compactRunner activeBackend btwBackend
           where
@@ -3071,6 +3071,7 @@ runSession
     -> Dialect
     -> ApprovalPolicy
     -> [AppTool]
+    -> IO ()
     -> [MCP.McpToolRegistration]
     -> [Text]
     -> IORef Bool
@@ -3116,7 +3117,7 @@ runSession
     -> Backend
     -> BtwBackendFactory
     -> IO RunResult
-runSession catalog connectionId options provider dialect policy allTools mcpRegistrations mcpWarnings ghciEnabledRef bashEnabledRef toolEnv planMode startup databaseScopes prompt pendingTurn unavailableProviders startupUnavailable paramsRef transcriptRef initialTurns previous persist projectRoot home cwd tokenProvider openAiPool startupContext skillsRef skillInvocationsRef escPaused interrupt multiCtx rootTurnRef subagentSessions pendingNotices storeRoot agentTypes legacyTarget usageRef accountRef accountIdRef selectionRef accountLabel selectAccount onPersisted compactRunner backend btwBackend = do
+runSession catalog connectionId options provider dialect policy allTools suspendGhci mcpRegistrations mcpWarnings ghciEnabledRef bashEnabledRef toolEnv planMode startup databaseScopes prompt pendingTurn unavailableProviders startupUnavailable paramsRef transcriptRef initialTurns previous persist projectRoot home cwd tokenProvider openAiPool startupContext skillsRef skillInvocationsRef escPaused interrupt multiCtx rootTurnRef subagentSessions pendingNotices storeRoot agentTypes legacyTarget usageRef accountRef accountIdRef selectionRef accountLabel selectAccount onPersisted compactRunner backend btwBackend = do
   initialPrevious <- readIORef previous
   ioLock <- newMVar ()
   let fullscreen = startup.startupFullscreen
@@ -3616,6 +3617,7 @@ runSession catalog connectionId options provider dialect policy allTools mcpRegi
             let (ghciEnabled, bashEnabled) = shellModeFlags mode
             writeIORef ghciEnabledRef ghciEnabled
             writeIORef bashEnabledRef bashEnabled
+            unless ghciEnabled suspendGhci
             refreshShellParams ghciEnabled bashEnabled
             pure ("shell tools: " <> shellModeLabel mode)
         setSessionTempDir tempDir = do

--- a/packages/agent-cli/src/Agent/CLI/Dialects.hs
+++ b/packages/agent-cli/src/Agent/CLI/Dialects.hs
@@ -59,6 +59,7 @@ import System.OsPath (OsPath, unsafeEncodeUtf, (</>))
 data CodingTools = CodingTools
     { codingAppTools :: ![AppTool]
     , codingPlanMode :: !PlanModeEnv
+    , codingSuspendGhci :: !(IO ())
     , codingClose :: !(IO ())
     , codingAgentTypes :: !GrokSubagentSpecs
     }
@@ -88,10 +89,11 @@ codingToolsForWithTypes
     secretStore <- traverse (newSecretStore env) secretHooks
     let closeSecrets = mapM_ closeSecretStore secretStore
         secretTools = maybe [] (pure . askSecretTool) secretStore
-        finish tools plan close agentTypes =
+        finish tools plan suspendGhci close agentTypes =
             CodingTools
                 { codingAppTools = tools <> secretTools
                 , codingPlanMode = plan
+                , codingSuspendGhci = suspendGhci
                 , codingClose = close `finally` closeSecrets
                 , codingAgentTypes = agentTypes
                 }
@@ -102,6 +104,7 @@ codingToolsForWithTypes
                 finish
                     coding.codexAppTools
                     coding.codexPlanMode
+                    coding.codexSuspendGhci
                     coding.codexClose
                     typesRef
         GrokBuildToolSurface -> do
@@ -110,6 +113,7 @@ codingToolsForWithTypes
                 finish
                     coding.grokAppTools
                     coding.grokPlanMode
+                    coding.grokSuspendGhci
                     coding.grokClose
                     coding.grokAgentTypes
         ClaudeCodeToolSurface -> do
@@ -118,6 +122,7 @@ codingToolsForWithTypes
                 finish
                     []
                     plan
+                    (pure ())
                     (pure ())
                     typesRef
 

--- a/packages/agent-codex-dialect/src/Agent/Codex/Dialect/Runtime.hs
+++ b/packages/agent-codex-dialect/src/Agent/Codex/Dialect/Runtime.hs
@@ -13,7 +13,11 @@ import Agent.ResourceScope
     , closeResourceScope
     , newResourceScope
     )
-import Agent.Tools.Ghci (closeGhciSession, newGhciSession)
+import Agent.Tools.Ghci
+    ( closeGhciSession
+    , newGhciSession
+    , suspendGhciSession
+    )
 import Agent.Tools.MultiAgents (MultiAgentContext)
 import Agent.Tools.PlanMode (PlanModeEnv, PlanModeHooks, newPlanModeEnv)
 import Agent.Tools.Types (AppTool, ToolEnv(..))
@@ -22,6 +26,7 @@ import Control.Exception.Safe (onException)
 data CodexCodingTools = CodexCodingTools
     { codexAppTools :: ![AppTool]
     , codexPlanMode :: !PlanModeEnv
+    , codexSuspendGhci :: !(IO ())
     , codexClose :: !(IO ())
     }
 
@@ -44,5 +49,6 @@ newCodexCodingTools env hooks multi = do
         pure CodexCodingTools
             { codexAppTools = tools
             , codexPlanMode = plan
+            , codexSuspendGhci = suspendGhciSession ghci
             , codexClose = closeResourceScope resources
             }

--- a/packages/agent-core/src/Agent/Tools/Ghci/Runtime.hs
+++ b/packages/agent-core/src/Agent/Tools/Ghci/Runtime.hs
@@ -8,6 +8,7 @@ module Agent.Tools.Ghci.Runtime
     , GhciOutcome(..)
     , GhciResult(..)
     , newGhciSession
+    , suspendGhciSession
     , closeGhciSession
     , evalGhci
     , classifyGhci
@@ -169,6 +170,20 @@ newGhciSession env = do
         , ghciRuntime = runtime
         , ghciMarkerSeed = seed
         }
+
+suspendGhciSession :: GhciSession -> IO ()
+suspendGhciSession session =
+    withGhciRuntime session do
+        current <- gets (.runtimeSessionState)
+        case current of
+            GhciRunning process -> do
+                liftIO (shutdownProcessBestEffort process)
+                modify' \runtime -> runtime
+                    { runtimeSessionState = GhciNotStarted
+                    , runtimeClassificationCache = Nothing
+                    }
+            GhciNotStarted -> pure ()
+            GhciClosed -> pure ()
 
 closeGhciSession :: GhciSession -> IO ()
 closeGhciSession session =

--- a/packages/agent-core/test/Agent/Tools/GhciSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/GhciSpec.hs
@@ -14,6 +14,7 @@ import Agent.Tools.Ghci
     , defaultGhciExtensions
     , evalGhci
     , newGhciSession
+    , suspendGhciSession
     , typeLooksEffectful
     )
 import Agent.Tools.Types (ToolEnv(..))
@@ -76,6 +77,24 @@ spec = describe "Agent.Tools.Ghci" do
             value <- evalGhci ghci "x" 10000
             value.ghciOk `shouldBe` True
             value.ghciOutput `shouldSatisfy` Text.isInfixOf "42"
+
+    it "releases the process when suspended and starts fresh on reuse" do
+        withTempEnv \env -> do
+            let pidFile = toFilePath env.toolCwd </> "suspended-child.pid"
+            bracket (newGhciSession env) closeGhciSession \ghci -> do
+                bind <- evalGhci ghci "let suspendedBinding = 42" 10000
+                bind.ghciOk `shouldBe` True
+                spawned <- evalGhci ghci (backgroundCommand pidFile) 10000
+                spawned.ghciOk `shouldBe` True
+                childPid <- read <$> readFile pidFile
+                processAlive childPid `shouldReturn` True
+                suspendGhciSession ghci
+                waitForProcessDeath childPid
+                missing <- evalGhci ghci "suspendedBinding" 10000
+                missing.ghciOk `shouldBe` False
+                recovered <- evalGhci ghci "6 * 7" 10000
+                recovered.ghciOk `shouldBe` True
+                recovered.ghciOutput `shouldSatisfy` Text.isInfixOf "42"
 
     it "preloads concise command and file helpers" do
         withTempGhci \ghci -> do

--- a/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Runtime.hs
+++ b/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Runtime.hs
@@ -14,7 +14,11 @@ import Agent.ResourceScope
     , closeResourceScope
     , newResourceScope
     )
-import Agent.Tools.Ghci (closeGhciSession, newGhciSession)
+import Agent.Tools.Ghci
+    ( closeGhciSession
+    , newGhciSession
+    , suspendGhciSession
+    )
 import Agent.Tools.MultiAgents (MultiAgentContext)
 import Agent.Tools.PlanMode (PlanModeEnv, PlanModeHooks, newPlanModeEnv)
 import Agent.Tools.Types (AppTool, ToolEnv(..))
@@ -23,6 +27,7 @@ import Control.Exception.Safe (onException)
 data GrokCodingTools = GrokCodingTools
     { grokAppTools :: ![AppTool]
     , grokPlanMode :: !PlanModeEnv
+    , grokSuspendGhci :: !(IO ())
     , grokClose :: !(IO ())
     , grokAgentTypes :: !GrokSubagentSpecs
     }
@@ -46,6 +51,7 @@ newGrokCodingTools env hooks multi typesRef = do
         pure GrokCodingTools
             { grokAppTools = grokTools session ghci plan multi typesRef
             , grokPlanMode = plan
+            , grokSuspendGhci = suspendGhciSession ghci
             , grokClose = closeResourceScope resources
             , grokAgentTypes = typesRef
             }


### PR DESCRIPTION
## Summary
- add a resumable GHCi suspension operation that terminates the active process group
- suspend an already-running `run_ghci` session when `/shell` switches to `bash` or `none`
- retain lazy restart behavior when GHCi is enabled again
- add regression coverage for child-process termination and fresh-session reuse

## Validation
- loaded the affected multi-package libraries in GHCi (215 modules)
- ran `Agent.Tools.Ghci` focused regression test in GHCi: 1 example, 0 failures
- ran `git diff --check`
