### PR TITLE
fix(cli): exit cleanly on startup interrupt

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -148,7 +148,7 @@ import Agent.CLI.ReplMode
 import Agent.CLI.Interrupt
     ( CtrlCDecision(..)
     , InterruptState
-    , isWrappedUserInterrupt
+    , catchUserInterrupt
     , newInterruptState
     , noteFullscreenCtrlC
     , withCtrlCHandler
@@ -543,7 +543,6 @@ import Control.Exception.Safe
     ( Exception
     , SomeException
     , catchAny
-    , catchAsync
     , finally
     , mask_
     , onException
@@ -783,13 +782,16 @@ managedPostgresConfigForHome home = do
 -- Automatic transitions carry the exact failed turn in memory and commit
 -- persisted provider metadata only after the replacement backend succeeds.
 runAgentWithRestarts :: CliOptions -> IO DevResult
-runAgentWithRestarts options = do
-    fullscreenInputs <- newFullscreenInputBuffer
-    sessionState <- newSessionState
-    mcpSupervisor <- MCP.newMcpSupervisor
-    withRestoredCurrentDirectory
-        (go mcpSupervisor fullscreenInputs sessionState options Nothing)
-        `finally` MCP.closeMcpSupervisor mcpSupervisor
+runAgentWithRestarts options =
+    catchUserInterrupt
+        (do
+            fullscreenInputs <- newFullscreenInputBuffer
+            sessionState <- newSessionState
+            mcpSupervisor <- MCP.newMcpSupervisor
+            withRestoredCurrentDirectory
+                (go mcpSupervisor fullscreenInputs sessionState options Nothing)
+                `finally` MCP.closeMcpSupervisor mcpSupervisor)
+        (pure DevQuit)
   where
     go mcpSupervisor fullscreenInputs sessionState current transition =
         runAgent mcpSupervisor fullscreenInputs sessionState current transition >>= \case
@@ -2940,18 +2942,8 @@ withInterruptResume
     -> IO a
     -> IO a
 withInterruptResume fullscreen progName persist interrupted action =
-    (action `catchAny` handleSyncException) `catchAsync` handleInterrupt
+    catchUserInterrupt action finishInterrupt
   where
-    -- UserInterrupt can arrive asynchronously from the installed SIGINT
-    -- handler or wrapped as a synchronous exception by safe-exceptions when
-    -- the inline editor's double-Ctrl-C path calls throwIO.
-    handleInterrupt (e :: AsyncException) =
-        case e of
-            UserInterrupt -> finishInterrupt
-            _ -> throwIO e
-    handleSyncException (e :: SomeException)
-        | isWrappedUserInterrupt e = finishInterrupt
-        | otherwise = throwIO e
     finishInterrupt = do
         case fullscreen of
             Nothing -> printResumeHint progName persist

--- a/packages/agent-cli/src/Agent/CLI/Interrupt.hs
+++ b/packages/agent-cli/src/Agent/CLI/Interrupt.hs
@@ -12,6 +12,7 @@ module Agent.CLI.Interrupt
     , withTurnCancel
     , noteIdleCtrlC
     , isWrappedUserInterrupt
+    , catchUserInterrupt
     , noteFullscreenCtrlC
     ) where
 
@@ -27,7 +28,10 @@ import Control.Exception.Safe
     , SyncExceptionWrapper(..)
     , bracket
     , bracket_
+    , catchAny
+    , catchAsync
     , catchIO
+    , throwIO
     )
 import Control.Monad (void)
 import Data.IORef (IORef, newIORef, readIORef, writeIORef)
@@ -194,3 +198,17 @@ isWrappedUserInterrupt e =
                 Just UserInterrupt -> True
                 _ -> False
         Nothing -> False
+
+-- | Handle both forms in which Ctrl-C can reach the CLI: asynchronously from
+-- the RTS/SIGINT handler, or synchronously wrapped by safe-exceptions.
+catchUserInterrupt :: IO a -> IO a -> IO a
+catchUserInterrupt action onInterrupt =
+    (action `catchAny` handleSyncException) `catchAsync` handleAsyncException
+  where
+    handleAsyncException (e :: AsyncException) =
+        case e of
+            UserInterrupt -> onInterrupt
+            _ -> throwIO e
+    handleSyncException (e :: SomeException)
+        | isWrappedUserInterrupt e = onInterrupt
+        | otherwise = throwIO e

--- a/packages/agent-cli/test/Agent/CLI/InterruptSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/InterruptSpec.hs
@@ -1,8 +1,9 @@
 module Agent.CLI.InterruptSpec (spec) where
 
 import Agent.CLI.Interrupt
+import qualified Control.Exception as Base
 import Control.Exception (AsyncException(ThreadKilled, UserInterrupt))
-import Control.Exception.Safe (toSyncException)
+import Control.Exception.Safe (finally, throwIO, toSyncException)
 import Test.Hspec
 
 spec :: Spec
@@ -27,3 +28,29 @@ spec = do
 
         it "rejects other wrapped async exceptions" do
             isWrappedUserInterrupt (toSyncException ThreadKilled) `shouldBe` False
+
+    describe "catchUserInterrupt" do
+        it "handles an asynchronous UserInterrupt" do
+            catchUserInterrupt
+                (Base.throwIO UserInterrupt)
+                (pure ("stopped" :: String))
+                `shouldReturn` ("stopped" :: String)
+
+        it "handles a synchronously wrapped UserInterrupt" do
+            catchUserInterrupt
+                (throwIO UserInterrupt)
+                (pure ("stopped" :: String))
+                `shouldReturn` ("stopped" :: String)
+
+        it "handles a UserInterrupt propagated through a finalizer" do
+            catchUserInterrupt
+                (pure ("completed" :: String)
+                    `finally` Base.throwIO UserInterrupt)
+                (pure "stopped")
+                `shouldReturn` "stopped"
+
+        it "does not swallow other asynchronous exceptions" do
+            catchUserInterrupt
+                (Base.throwIO ThreadKilled)
+                (pure ())
+                `shouldThrow` anyException


### PR DESCRIPTION
## Summary

- catch `UserInterrupt` across the full agent startup/restart lifecycle
- share interrupt handling between startup shutdown and the existing resume-hint path
- preserve propagation of non-`UserInterrupt` asynchronous exceptions
- add regression coverage for direct, safe-exceptions-wrapped, and finalizer-propagated interrupts

## Testing

- `printf ':main --match catchUserInterrupt\\n:q\\n' | nix develop -c cabal repl agent-cli:test:agent-cli-test`
  - 4 examples, 0 failures
- `nix develop -c cabal build --offline agent-cli:exe:agent-cli`
- tmux TTY smoke test against the compiled executable
  - confirmed Ctrl-C shutdown exits with status 0
  - no `user interrupt` message or backtrace
