### PR TITLE
Add reusable NixOS module for Telegram agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,10 @@ Ask it to “set up a Telegram agent”; it will explain the BotFather steps,
 direct secret entry to the interactive setup command, and start the configured
 gateway after setup is complete.
 
+On NixOS, use the flake's reusable multi-instance service module instead of
+maintaining the systemd and PostgreSQL runtime configuration by hand. See
+[`docs/nixos.md`](docs/nixos.md).
+
 ### Model catalog and local models
 
 The model picker is driven by a versioned catalog. The application ships its

--- a/docs/nixos.md
+++ b/docs/nixos.md
@@ -1,0 +1,96 @@
+# NixOS
+
+The flake exports `nixosModules.default` and `nixosModules.telegram` for
+running one or more Telegram gateways as systemd services.
+
+```nix
+{
+  inputs.haskell-agent.url = "github:digitallyinduced/haskell-agent";
+
+  outputs = { self, nixpkgs, haskell-agent, ... }: {
+    nixosConfigurations.example = nixpkgs.lib.nixosSystem {
+      system = "x86_64-linux";
+      modules = [
+        haskell-agent.nixosModules.default
+        ({ pkgs, ... }: {
+          services.haskell-agent.telegram.instances.assistant = {
+            enable = true;
+            workingDirectory = "/srv/project";
+            tokenFile = "/run/secrets/telegram-bot-token";
+            allowedUsers = [ 123456789 ];
+
+            provider = "openai";
+            yolo = false;
+            extraPackages = with pkgs; [
+              gh
+              nix
+              ripgrep
+            ];
+          };
+        })
+      ];
+    };
+  };
+}
+```
+
+The module:
+
+- creates a dedicated system user and private home for each instance;
+- writes the non-secret gateway configuration declaratively;
+- loads the BotFather token through systemd credentials, without copying it
+  to the Nix store;
+- supplies Bash, Git, and PostgreSQL 18 by default;
+- configures the private managed PostgreSQL cluster used for durable agent
+  state; and
+- restarts the foreground gateway after failures.
+
+The project directory must exist before the service starts. If `yolo` is
+enabled, it must also be writable by the service user.
+
+Instance names must begin with a lowercase letter, contain only lowercase
+letters, digits, and hyphens, and be at most 16 characters long. Each enabled
+instance must use a distinct service user and home directory.
+
+## Provider credentials
+
+Provider credentials are separate from the Telegram token. Provision them in
+the instance home using the provider's normal login flow, or use
+`environmentFiles` for API-key environment variables. For OpenAI subscription
+authentication, the default `CODEX_HOME` is:
+
+```text
+/var/lib/haskell-agent-telegram-INSTANCE/.codex
+```
+
+It can be changed with `codexHome`.
+
+## State and PostgreSQL
+
+Each instance gets an isolated state tree:
+
+```text
+/var/lib/haskell-agent-telegram-INSTANCE/.haskell-agent/
+├── gateways/telegram/
+│   ├── config.json
+│   ├── state.json
+│   └── token -> /run/credentials/haskell-agent-telegram-INSTANCE.service/telegram-token
+└── postgres/
+    ├── data/
+    ├── run/
+    └── postgres.log
+```
+
+Haskell-agent initializes, starts, and migrates its private PostgreSQL server.
+It listens only on a mode-0700 Unix socket below the instance state directory;
+it does not use the system-wide `services.postgresql` server. Instances may
+therefore keep the default port even when they run on the same host.
+
+Changing `postgresPackage` across PostgreSQL major versions requires migrating
+the existing cluster first. Haskell-agent rejects a cluster created by an
+incompatible major version instead of attempting an unsafe in-place upgrade.
+
+Do not back up a running PostgreSQL data directory as ordinary files. Use
+`pg_dump` through the private socket for database contents, and separately
+back up `gateways/telegram/state.json`. Provider credentials and the Telegram
+token should be covered by the host's secret-management recovery procedure.

--- a/flake.nix
+++ b/flake.nix
@@ -556,9 +556,19 @@
                     agent-openrouter = agentOpenrouterPackage;
                     claude-agent-sdk-haskell = claudeAgentSdkHaskellPackage;
                     agent-claude = agentClaudePackage;
+                } // pkgs.lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
+                    nixos-module = import ./nix/tests/telegram-module.nix {
+                        inherit self nixpkgs pkgs system;
+                    };
                 };
 
                 formatter = pkgs.nixfmt-rfc-style;
             }
-        );
+        )
+        // {
+            nixosModules.telegram = import ./nix/modules/telegram.nix {
+                inherit self;
+            };
+            nixosModules.default = self.nixosModules.telegram;
+        };
 }

--- a/nix/modules/telegram.nix
+++ b/nix/modules/telegram.nix
@@ -1,0 +1,351 @@
+{ self }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib)
+    filterAttrs
+    hasPrefix
+    mapAttrs'
+    mapAttrsToList
+    mkEnableOption
+    mkIf
+    mkOption
+    nameValuePair
+    types
+    ;
+
+  cfg = config.services.haskell-agent.telegram;
+  enabledInstances = filterAttrs (_: instance: instance.enable) cfg.instances;
+  managedInstances = filterAttrs (_: instance: instance.createUser) enabledInstances;
+  instanceHomes = mapAttrsToList (_: instance: instance.homeDirectory) enabledInstances;
+  instanceUsers = mapAttrsToList (_: instance: instance.user) enabledInstances;
+
+  instanceType = types.submodule (
+    { name, config, ... }:
+    {
+      options = {
+        enable = mkEnableOption "this Telegram agent instance";
+
+        package = mkOption {
+          type = types.package;
+          default = self.packages.${pkgs.stdenv.hostPlatform.system}.agent-telegram;
+          defaultText = lib.literalExpression "haskell-agent.packages.\${pkgs.system}.agent-telegram";
+          description = "The haskell-agent package providing the agent-telegram executable.";
+        };
+
+        user = mkOption {
+          type = types.str;
+          default = "haskell-agent-${name}";
+          description = "User account under which the instance runs.";
+        };
+
+        group = mkOption {
+          type = types.str;
+          default = config.user;
+          defaultText = lib.literalExpression "config.user";
+          description = "Group under which the instance runs.";
+        };
+
+        createUser = mkOption {
+          type = types.bool;
+          default = true;
+          description = "Whether to create the configured system user and group.";
+        };
+
+        homeDirectory = mkOption {
+          type = types.str;
+          default = "/var/lib/haskell-agent-telegram-${name}";
+          description = ''
+            Persistent home directory for the instance. Haskell-agent keeps
+            gateway and managed PostgreSQL state below
+            <filename>.haskell-agent</filename> in this directory.
+          '';
+        };
+
+        workingDirectory = mkOption {
+          type = types.str;
+          description = ''
+            Project directory exposed to the agent. It must exist before the
+            service starts and be writable when mutating tools are enabled.
+          '';
+        };
+
+        tokenFile = mkOption {
+          type = types.str;
+          description = ''
+            Path to the BotFather token. The file is loaded with systemd
+            credentials and is never copied to the Nix store.
+          '';
+        };
+
+        provider = mkOption {
+          type = types.enum [
+            "openai"
+            "xai"
+            "openrouter"
+            "claude-code"
+          ];
+          default = "openai";
+          example = "openrouter";
+          description = "Provider name written to the Telegram gateway configuration.";
+        };
+
+        model = mkOption {
+          type = types.nullOr types.str;
+          default = null;
+          example = "gpt-5.6-sol";
+          description = "Optional model override. Null uses the provider default.";
+        };
+
+        effort = mkOption {
+          type = types.nullOr types.str;
+          default = null;
+          example = "high";
+          description = "Optional reasoning-effort override.";
+        };
+
+        yolo = mkOption {
+          type = types.bool;
+          default = false;
+          description = "Whether mutating tools may run without interactive approval.";
+        };
+
+        allowedUsers = mkOption {
+          type = types.listOf types.ints.unsigned;
+          default = [ ];
+          example = [ 123456789 ];
+          description = "Telegram user IDs allowed to interact with the bot.";
+        };
+
+        respondToAllGroupMessages = mkOption {
+          type = types.bool;
+          default = false;
+          description = ''
+            Whether messages from allowed users in groups are handled without
+            requiring a mention or reply to the bot.
+          '';
+        };
+
+        codexHome = mkOption {
+          type = types.str;
+          default = "${config.homeDirectory}/.codex";
+          defaultText = lib.literalExpression ''"${config.homeDirectory}/.codex"'';
+          description = "CODEX_HOME used by the OpenAI provider.";
+        };
+
+        postgresPackage = mkOption {
+          type = types.package;
+          default = pkgs.postgresql_18;
+          defaultText = lib.literalExpression "pkgs.postgresql_18";
+          description = "PostgreSQL package used for the private managed state database.";
+        };
+
+        postgresPort = mkOption {
+          type = types.port;
+          default = 55432;
+          description = ''
+            Port recorded by the private PostgreSQL cluster. The server listens
+            only on its per-instance Unix socket, so instances may share this value.
+          '';
+        };
+
+        extraPackages = mkOption {
+          type = types.listOf types.package;
+          default = [ ];
+          example = lib.literalExpression "with pkgs; [ gh nix ripgrep ]";
+          description = "Additional packages added to PATH for the agent's Bash tool.";
+        };
+
+        environment = mkOption {
+          type = types.attrsOf types.str;
+          default = { };
+          example = {
+            GH_PROMPT_DISABLED = "true";
+            PAGER = "cat";
+          };
+          description = "Additional environment variables for the service.";
+        };
+
+        environmentFiles = mkOption {
+          type = types.listOf types.str;
+          default = [ ];
+          description = ''
+            Environment files read by systemd at service start. Use these for
+            provider API keys instead of putting secret values in Nix options.
+          '';
+        };
+      };
+    }
+  );
+
+  gatewayDirectory = instance: "${instance.homeDirectory}/.haskell-agent/gateways/telegram";
+
+  gatewayConfig =
+    name: instance:
+    pkgs.writeText "haskell-agent-telegram-${name}.json" (
+      builtins.toJSON {
+        provider = instance.provider;
+        model = instance.model;
+        cwd = instance.workingDirectory;
+        effort = instance.effort;
+        yolo = instance.yolo;
+        allowedUsers = instance.allowedUsers;
+        inherit (instance) respondToAllGroupMessages;
+      }
+    );
+
+  serviceName = name: "haskell-agent-telegram-${name}";
+in
+{
+  options.services.haskell-agent.telegram.instances = mkOption {
+    type = types.attrsOf instanceType;
+    default = { };
+    description = "Named agent-telegram service instances.";
+  };
+
+  config = mkIf (enabledInstances != { }) {
+    assertions = [
+      {
+        assertion = builtins.length instanceHomes == builtins.length (lib.unique instanceHomes);
+        message = "Enabled Telegram agent instances must use distinct homeDirectory values";
+      }
+      {
+        assertion = builtins.length instanceUsers == builtins.length (lib.unique instanceUsers);
+        message = "Enabled Telegram agent instances must use distinct user values";
+      }
+    ]
+    ++ lib.concatLists (
+      mapAttrsToList (name: instance: [
+        {
+          assertion = builtins.match "[a-z][a-z0-9-]{0,15}" name != null;
+          message = "Telegram agent instance name ${name} must match [a-z][a-z0-9-]{0,15}";
+        }
+        {
+          assertion = hasPrefix "/" instance.homeDirectory;
+          message = "services.haskell-agent.telegram.instances.${name}.homeDirectory must be absolute";
+        }
+        {
+          assertion = builtins.stringLength "${instance.homeDirectory}/.haskell-agent/postgres/run" <= 90;
+          message = "services.haskell-agent.telegram.instances.${name}.homeDirectory is too long for the private PostgreSQL socket";
+        }
+        {
+          assertion = hasPrefix "/" instance.workingDirectory;
+          message = "services.haskell-agent.telegram.instances.${name}.workingDirectory must be absolute";
+        }
+        {
+          assertion = instance.allowedUsers != [ ];
+          message = "services.haskell-agent.telegram.instances.${name}.allowedUsers must not be empty";
+        }
+        {
+          assertion = builtins.all (userId: userId > 0) instance.allowedUsers;
+          message = "services.haskell-agent.telegram.instances.${name}.allowedUsers must contain only positive IDs";
+        }
+        {
+          assertion = hasPrefix "/" instance.tokenFile;
+          message = "services.haskell-agent.telegram.instances.${name}.tokenFile must be an absolute runtime path";
+        }
+        {
+          assertion = builtins.all (hasPrefix "/") instance.environmentFiles;
+          message = "services.haskell-agent.telegram.instances.${name}.environmentFiles must contain only absolute paths";
+        }
+      ]) enabledInstances
+    );
+
+    users.groups = mapAttrs' (_: instance: nameValuePair instance.group { }) managedInstances;
+
+    users.users = mapAttrs' (
+      _: instance:
+      nameValuePair instance.user {
+        isSystemUser = true;
+        group = instance.group;
+        home = instance.homeDirectory;
+        createHome = true;
+        description = "Haskell Agent Telegram service";
+      }
+    ) managedInstances;
+
+    systemd.tmpfiles.settings = mapAttrs' (
+      name: instance:
+      nameValuePair "10-haskell-agent-telegram-${name}" (
+        lib.genAttrs
+          [
+            instance.homeDirectory
+            "${instance.homeDirectory}/.haskell-agent"
+            "${instance.homeDirectory}/.haskell-agent/gateways"
+            (gatewayDirectory instance)
+          ]
+          (_: {
+            d = {
+              mode = "0700";
+              user = instance.user;
+              group = instance.group;
+            };
+          })
+      )
+    ) enabledInstances;
+
+    systemd.services = mapAttrs' (
+      name: instance:
+      let
+        directory = gatewayDirectory instance;
+        generatedConfig = gatewayConfig name instance;
+      in
+      nameValuePair (serviceName name) {
+        description = "Haskell Agent Telegram gateway (${name})";
+        wantedBy = [ "multi-user.target" ];
+        after = [ "network-online.target" ];
+        wants = [ "network-online.target" ];
+
+        environment = instance.environment // {
+          HOME = instance.homeDirectory;
+          CODEX_HOME = instance.codexHome;
+          AGENT_POSTGRES_BIN = "${instance.postgresPackage}/bin";
+          AGENT_POSTGRES_PORT = toString instance.postgresPort;
+        };
+
+        path = [
+          instance.package
+          instance.postgresPackage
+          pkgs.bash
+          pkgs.coreutils
+          pkgs.git
+        ]
+        ++ instance.extraPackages;
+
+        preStart = ''
+          install -d -m 0700 ${lib.escapeShellArg directory}
+          generated_config="$(mktemp ${lib.escapeShellArg "${directory}/config.json.XXXXXX"})"
+          install -m 0600 \
+              ${lib.escapeShellArg generatedConfig} \
+              "$generated_config"
+          mv -f "$generated_config" ${lib.escapeShellArg "${directory}/config.json"}
+          ln -sfn \
+              "$CREDENTIALS_DIRECTORY/telegram-token" \
+              ${lib.escapeShellArg "${directory}/token"}
+        '';
+
+        serviceConfig = {
+          Type = "simple";
+          User = instance.user;
+          Group = instance.group;
+          WorkingDirectory = instance.workingDirectory;
+          ExecStart = "${instance.package}/bin/agent-telegram run";
+          LoadCredential = [
+            "telegram-token:${instance.tokenFile}"
+          ];
+          EnvironmentFile = instance.environmentFiles;
+          Restart = "on-failure";
+          RestartSec = "5s";
+          UMask = "0077";
+          NoNewPrivileges = true;
+          PrivateTmp = true;
+          LimitNOFILE = 65536;
+        };
+      }
+    ) enabledInstances;
+  };
+}

--- a/nix/tests/telegram-module.nix
+++ b/nix/tests/telegram-module.nix
@@ -1,0 +1,144 @@
+{
+  self,
+  nixpkgs,
+  pkgs,
+  system,
+}:
+let
+  testPackage = pkgs.writeShellScriptBin "agent-telegram" ''
+    exit 0
+  '';
+
+  evaluated = nixpkgs.lib.nixosSystem {
+    inherit system;
+    modules = [
+      (import ../modules/telegram.nix { inherit self; })
+      {
+        system.stateVersion = "26.05";
+
+        services.haskell-agent.telegram.instances = {
+          primary = {
+            enable = true;
+            package = testPackage;
+            workingDirectory = "/srv/primary";
+            tokenFile = "/run/keys/primary-token";
+            allowedUsers = [ 123456789 ];
+            model = null;
+            effort = null;
+            respondToAllGroupMessages = true;
+            environment = {
+              HOME = "/tmp/ignored";
+              AGENT_POSTGRES_PORT = "1";
+              MODULE_TEST = "present";
+            };
+          };
+
+          secondary = {
+            enable = true;
+            package = testPackage;
+            workingDirectory = "/srv/secondary";
+            tokenFile = "/run/keys/secondary-token";
+            allowedUsers = [ 987654321 ];
+            provider = "openrouter";
+            model = "openai/gpt-5.1";
+            postgresPort = 55432;
+          };
+        };
+      }
+    ];
+  };
+
+  primary = evaluated.config.systemd.services.haskell-agent-telegram-primary;
+  secondary = evaluated.config.systemd.services.haskell-agent-telegram-secondary;
+
+  primaryService = builtins.toJSON {
+    inherit (primary) environment preStart;
+    inherit (primary.serviceConfig)
+      ExecStart
+      Group
+      LoadCredential
+      User
+      WorkingDirectory
+      ;
+  };
+
+  secondaryService = builtins.toJSON {
+    inherit (secondary) environment preStart;
+    inherit (secondary.serviceConfig)
+      ExecStart
+      Group
+      LoadCredential
+      User
+      WorkingDirectory
+      ;
+  };
+in
+pkgs.runCommand "haskell-agent-telegram-module-test"
+  {
+    inherit primaryService secondaryService;
+    nativeBuildInputs = [ pkgs.jq ];
+  }
+  ''
+    primary_config="$(
+      printf '%s\n' "$primaryService" |
+        jq -r .preStart |
+        grep -o "/nix/store/[^ ']*-haskell-agent-telegram-primary.json" |
+        head -n1
+    )"
+    secondary_config="$(
+      printf '%s\n' "$secondaryService" |
+        jq -r .preStart |
+        grep -o "/nix/store/[^ ']*-haskell-agent-telegram-secondary.json" |
+        head -n1
+    )"
+
+    test -f "$primary_config"
+    test -f "$secondary_config"
+
+    jq -e '
+      . == {
+        allowedUsers: [123456789],
+        cwd: "/srv/primary",
+        effort: null,
+        model: null,
+        provider: "openai",
+        respondToAllGroupMessages: true,
+        yolo: false
+      }
+    ' "$primary_config" >/dev/null
+
+    jq -e '
+      . == {
+        allowedUsers: [987654321],
+        cwd: "/srv/secondary",
+        effort: null,
+        model: "openai/gpt-5.1",
+        provider: "openrouter",
+        respondToAllGroupMessages: false,
+        yolo: false
+      }
+    ' "$secondary_config" >/dev/null
+
+    printf '%s\n' "$primaryService" | jq -e '
+      .User == "haskell-agent-primary"
+      and .Group == "haskell-agent-primary"
+      and .WorkingDirectory == "/srv/primary"
+      and .LoadCredential == ["telegram-token:/run/keys/primary-token"]
+      and .environment.HOME == "/var/lib/haskell-agent-telegram-primary"
+      and .environment.CODEX_HOME == "/var/lib/haskell-agent-telegram-primary/.codex"
+      and .environment.AGENT_POSTGRES_PORT == "55432"
+      and (.environment.AGENT_POSTGRES_BIN | endswith("/bin"))
+      and .environment.MODULE_TEST == "present"
+      and (.ExecStart | endswith("/bin/agent-telegram run"))
+      and (.preStart | contains("$CREDENTIALS_DIRECTORY/telegram-token"))
+    ' >/dev/null
+
+    printf '%s\n' "$secondaryService" | jq -e '
+      .User == "haskell-agent-secondary"
+      and .WorkingDirectory == "/srv/secondary"
+      and .environment.HOME == "/var/lib/haskell-agent-telegram-secondary"
+      and .environment.AGENT_POSTGRES_PORT == "55432"
+    ' >/dev/null
+
+    touch "$out"
+  ''


### PR DESCRIPTION
## Summary

- export `nixosModules.default` and `nixosModules.telegram`
- support isolated, named `agent-telegram` systemd instances
- generate non-secret gateway configuration declaratively and load BotFather tokens through systemd credentials
- provide the managed PostgreSQL runtime and per-instance state directories
- document provider credentials, state layout, PostgreSQL upgrades, and backup requirements
- add a lightweight two-instance NixOS evaluation check

## Validation

- `nix build .#checks.aarch64-linux.nixos-module --no-link -L`
- `nix flake check --no-build`