### PR TITLE
fix(tui): make markdown links clickable

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -12,6 +12,7 @@ module Agent.CLI.TUI.App
     , choiceClosesOnUiTransition
     , elapsedMillisSince
     , emitUiEvent
+    , externalUrlCommand
     , hasQueuedFullscreenInput
     , motionDemandFor
     , lambdaArtWidget
@@ -125,8 +126,8 @@ import Agent.CLI.TUI.ImagePreview
     )
 import Agent.TUI.Markdown
     ( codeWidgetWithSyntaxHighlighting
-    , markdownWidget
-    , markdownWidgetWithSyntaxHighlighting
+    , markdownWidgetWithLinks
+    , markdownWidgetWithSyntaxHighlightingAndLinks
     )
 import Agent.Syntax
     ( SyntaxHighlighter
@@ -181,7 +182,7 @@ import Control.Monad.IO.Class (liftIO)
 import Control.Monad.State.Strict (modify')
 import Control.Exception.Safe (finally, throwIO, tryAny)
 import Control.Exception (AsyncException(UserInterrupt))
-import Data.Char (isControl)
+import Data.Char (isControl, isSpace)
 import Data.Foldable (toList)
 import Data.IORef
     ( modifyIORef'
@@ -206,8 +207,10 @@ import GHC.Clock (getMonotonicTimeNSec)
 import qualified Graphics.Vty as V
 import qualified Graphics.Vty.CrossPlatform as Vty
 import System.Environment (lookupEnv)
+import System.Info (os)
 import System.IO (stdout)
 import System.Posix.Process (getProcessID)
+import System.Process (callProcess)
 
 newFullscreenInputBuffer :: IO FullscreenInputBuffer
 newFullscreenInputBuffer = Composer.newFullscreenInputBuffer
@@ -1387,6 +1390,8 @@ activateControl = \case
         confirmResumeId sessionId
     CodeCopy blockId codeIndex ->
         copyCodeBlock blockId codeIndex
+    MarkdownLink url ->
+        openMarkdownLink url
     _ ->
         pure ()
 
@@ -1400,6 +1405,42 @@ isInteractiveControl = \case
     ResumeRow _ -> True
     CodeCopy _ _ -> True
     _ -> False
+
+openMarkdownLink :: Text -> EventM Name AppState ()
+openMarkdownLink url = do
+    opened <- liftIO (openExternalUrl url)
+    unless opened $
+        modify' $
+            applyUiEvent
+                (UiSetNotice
+                    (Just (warningNotice "Could not open that link.")))
+
+openExternalUrl :: Text -> IO Bool
+openExternalUrl url =
+    case externalUrlCommand url of
+        Nothing -> pure False
+        Just (command, arguments) ->
+            either (const False) (const True)
+                <$> tryAny (callProcess command arguments)
+
+externalUrlCommand :: Text -> Maybe (FilePath, [String])
+externalUrlCommand url
+    | Text.length url > 4096 = Nothing
+    | Text.any (\character -> isControl character || isSpace character) url =
+        Nothing
+    | not (isWebUrl url) = Nothing
+    | os == "darwin" = Just ("/usr/bin/open", [Text.unpack url])
+    | os == "mingw32" =
+        Just
+            ( "rundll32"
+            , ["url.dll,FileProtocolHandler", Text.unpack url]
+            )
+    | otherwise = Just ("xdg-open", [Text.unpack url])
+  where
+    isWebUrl value =
+        let lower = Text.toLower value
+        in Text.isPrefixOf "https://" lower
+            || Text.isPrefixOf "http://" lower
 
 copyCodeBlock :: BlockId -> Int -> EventM Name AppState ()
 copyCodeBlock blockId codeIndex = do
@@ -2543,8 +2584,9 @@ drawBlock state block =
                     padRight (Pad 1) $
                         timestampedMessage block.blockTimestamp $
                             withAttr Theme.assistantAttr
-                                (markdownWidgetWithSyntaxHighlighting
+                                (markdownWidgetWithSyntaxHighlightingAndLinks
                                     state.appSyntaxHighlighter
+                                    MarkdownLink
                                     (\codeIndex ->
                                         cached
                                             (CodeBlockCache
@@ -3039,7 +3081,9 @@ drawDialogChoice appState choice =
                                         else padBottom (Pad 1) $
                                             vLimitPercent 65 $
                                                 viewport OverlayViewport Vertical $
-                                                    markdownWidget choice.choiceBody
+                                                    markdownWidgetWithLinks
+                                                        MarkdownLink
+                                                        choice.choiceBody
                                     , vBox $
                                         zipWith
                                             (choiceRow
@@ -3187,7 +3231,9 @@ drawTextPrompt state prompt =
                                         else padBottom (Pad 1) $
                                             vLimitPercent 60 $
                                                 viewport OverlayViewport Vertical $
-                                                    markdownWidget prompt.textBody
+                                                    markdownWidgetWithLinks
+                                                        MarkdownLink
+                                                        prompt.textBody
                                     , overrideAttr Border.borderAttr Theme.borderActiveAttr $
                                         withBorderStyle unicodeRounded $
                                             borderWithLabel (txt " Answer ") $
@@ -3855,6 +3901,8 @@ handleEventInner event = case event of
                                     (state.appRuntime.runtimeAgentSelect target)
                                 modify' \current ->
                                     current { appAgentSelected = target }
+                            (link@MarkdownLink{}, V.BLeft) ->
+                                Composer.handleControlMouseDown link
                             _ -> handleMouseDown name button
                     (Nothing, Just _, _) ->
                         case (name, button) of
@@ -3886,6 +3934,9 @@ handleEventInner event = case event of
         keepAgentHover target
     MouseUp AgentPane Nothing _ ->
         pure ()
+    MouseUp link@MarkdownLink{} (Just V.BLeft) _ -> do
+        clearAgentHover
+        Composer.handleControlMouseUp link (activateControl link)
     MouseUp name button _
         | isInteractiveControl name
         , button == Just V.BLeft || button == Nothing -> do

--- a/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
@@ -54,6 +54,7 @@ data Name
         !(Maybe (Int, Bool))
     | CodeBlockCache !BlockId !Int
     | CodeCopy !BlockId !Int
+    | MarkdownLink !Text
     | ComposerArea
     | ComposerCursor
     | ComposerModel

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -12,6 +12,7 @@ import Agent.CLI.TUI.App
     , choiceRowColumns
     , choiceClosesOnUiTransition
     , elapsedMillisSince
+    , externalUrlCommand
     , fullscreenBounds
     , fullscreenVtyConfig
     , fullscreenSurface
@@ -60,6 +61,22 @@ import Test.Hspec
 
 spec :: Spec
 spec = do
+    describe "externalUrlCommand" do
+        it "opens HTTP(S) URLs without passing through a shell" do
+            let url = "https://github.com/digitallyinduced/haskell-agent"
+            externalUrlCommand url
+                `shouldSatisfy`
+                    maybe False ((== [Text.unpack url]) . snd)
+
+        it "rejects unsafe or malformed destinations" do
+            externalUrlCommand "file:///tmp/report" `shouldBe` Nothing
+            externalUrlCommand "javascript:alert(1)" `shouldBe` Nothing
+            externalUrlCommand "https://example.com/a b" `shouldBe` Nothing
+            externalUrlCommand "https://example.com/\nowned" `shouldBe` Nothing
+            externalUrlCommand
+                ("https://example.com/" <> Text.replicate 4096 "a")
+                `shouldBe` Nothing
+
     describe "secret text overlay" do
         it "renders only fixed-width masking glyphs" do
             maskedSecretText "top-secret-123"

--- a/packages/agent-tui/src/Agent/TUI/Markdown.hs
+++ b/packages/agent-tui/src/Agent/TUI/Markdown.hs
@@ -4,8 +4,10 @@ module Agent.TUI.Markdown
     , codeWidgetWithSyntaxHighlighting
     , inlinePlainText
     , markdownWidget
+    , markdownWidgetWithLinks
     , markdownWidgetWithCodeControls
     , markdownWidgetWithSyntaxHighlighting
+    , markdownWidgetWithSyntaxHighlightingAndLinks
     , parseInline
     ) where
 
@@ -45,17 +47,34 @@ import qualified Graphics.Vty as V
 terminalCharWidth :: Char -> Int
 terminalCharWidth = displayCharCellWidth
 
-markdownWidget :: Text -> Widget n
+markdownWidget :: Ord n => Text -> Widget n
 markdownWidget =
     markdownWidgetWithCodeControls \_ language ->
         if Text.null language
             then emptyWidget
             else withAttr Theme.mutedAttr (txt language)
 
+-- | Render Markdown with application-level click targets for links.
+markdownWidgetWithLinks
+    :: Ord n
+    => (Text -> n)
+    -> Text
+    -> Widget n
+markdownWidgetWithLinks linkName =
+    markdownWidgetWithSyntaxHighlightingAndLinks
+        Nothing
+        linkName
+        (\_ widget -> widget)
+        (\_ language ->
+            if Text.null language
+                then emptyWidget
+                else withAttr Theme.mutedAttr (txt language))
+
 -- | Render Markdown, allowing callers to add an interactive control to each
 -- fenced code block header. Code block indices are one-based.
 markdownWidgetWithCodeControls
-    :: (Int -> Text -> Widget n)
+    :: Ord n
+    => (Int -> Text -> Widget n)
     -> Text
     -> Widget n
 markdownWidgetWithCodeControls codeHeader input =
@@ -70,15 +89,60 @@ markdownWidgetWithCodeControls codeHeader input =
 -- callers can use it to retain completed code bodies while later prose
 -- continues streaming.
 markdownWidgetWithSyntaxHighlighting
-    :: Maybe SyntaxHighlighter
+    :: Ord n
+    => Maybe SyntaxHighlighter
     -> (Int -> Widget n -> Widget n)
     -> (Int -> Text -> Widget n)
     -> Text
     -> Widget n
 markdownWidgetWithSyntaxHighlighting syntaxHighlighter cacheCode codeHeader input =
+    markdownWidgetWithInteractions
+        syntaxHighlighter
+        Nothing
+        cacheCode
+        codeHeader
+        input
+
+-- | Render Markdown with syntax highlighting, code controls, and
+-- application-level click targets for links.
+markdownWidgetWithSyntaxHighlightingAndLinks
+    :: Ord n
+    => Maybe SyntaxHighlighter
+    -> (Text -> n)
+    -> (Int -> Widget n -> Widget n)
+    -> (Int -> Text -> Widget n)
+    -> Text
+    -> Widget n
+markdownWidgetWithSyntaxHighlightingAndLinks
+    syntaxHighlighter
+    linkName
+    cacheCode
+    codeHeader
+    input =
+        markdownWidgetWithInteractions
+            syntaxHighlighter
+            (Just linkName)
+            cacheCode
+            codeHeader
+            input
+
+markdownWidgetWithInteractions
+    :: Ord n
+    => Maybe SyntaxHighlighter
+    -> Maybe (Text -> n)
+    -> (Int -> Widget n -> Widget n)
+    -> (Int -> Text -> Widget n)
+    -> Text
+    -> Widget n
+markdownWidgetWithInteractions
+    syntaxHighlighter
+    linkName
+    cacheCode
+    codeHeader
+    input =
     vBox $
         concatMap
-            (renderChunk syntaxHighlighter cacheCode codeHeader)
+            (renderChunk syntaxHighlighter linkName cacheCode codeHeader)
             (fenceChunks input)
 
 -- | Render a standalone code body with the same width bounding and optional
@@ -93,14 +157,16 @@ codeWidgetWithSyntaxHighlighting syntaxHighlighter language =
         . codeBodyLines
 
 renderChunk
-    :: Maybe SyntaxHighlighter
+    :: Ord n
+    => Maybe SyntaxHighlighter
+    -> Maybe (Text -> n)
     -> (Int -> Widget n -> Widget n)
     -> (Int -> Text -> Widget n)
     -> FenceChunk
     -> [Widget n]
-renderChunk _ _ _ (FenceText prose) =
-    renderLines (Text.lines prose)
-renderChunk syntaxHighlighter cacheCode codeHeader (FenceBlock block) =
+renderChunk _ linkName _ _ (FenceText prose) =
+    renderLines linkName (Text.lines prose)
+renderChunk syntaxHighlighter _ cacheCode codeHeader (FenceBlock block) =
     [ codeHeader block.fencedIndex block.fencedInfo
     , if block.fencedClosed
         then cacheCode block.fencedIndex bodyWidget
@@ -114,47 +180,49 @@ renderChunk syntaxHighlighter cacheCode codeHeader (FenceBlock block) =
             (codeBodyLines block.fencedBody)
 
 renderLines
-    :: [Text]
+    :: Ord n
+    => Maybe (Text -> n)
+    -> [Text]
     -> [Widget n]
-renderLines [] = []
-renderLines lines_
+renderLines _ [] = []
+renderLines linkName lines_
     | Just (rows, rest) <- Block.takeTableRows lines_ =
-        tableWidget rows : renderLines rest
-renderLines (line : rest)
+        tableWidget rows : renderLines linkName rest
+renderLines linkName (line : rest)
     | Just (_, heading) <- Block.headingPartsWith (== ' ') line =
         padTop (Pad 1)
-            (inlineWidgetWithAttr Theme.headingAttr (parseInline heading))
-            : renderLines rest
+            (inlineWidgetWithAttr linkName Theme.headingAttr (parseInline heading))
+            : renderLines linkName rest
     | Just (indent, item) <- Block.bulletPartsWith (== ' ') line =
         hBox
             [ txt indent
             , withAttr Theme.headingAttr (txt "• ")
-            , inlineWidgetWithAttr Theme.assistantAttr (parseInline item)
+            , inlineWidgetWithAttr linkName Theme.assistantAttr (parseInline item)
             ]
-            : renderLines rest
+            : renderLines linkName rest
     | Just (indent, number, item) <- Block.orderedParts line =
         hBox
             [ txt indent
             , withAttr Theme.headingAttr (txt (number <> ". "))
-            , inlineWidgetWithAttr Theme.assistantAttr (parseInline item)
+            , inlineWidgetWithAttr linkName Theme.assistantAttr (parseInline item)
             ]
-            : renderLines rest
+            : renderLines linkName rest
     | Just rawQuote <- Block.blockQuoteRemainder line =
         let quote = fromMaybe rawQuote (Text.stripPrefix " " rawQuote)
         in
         hBox
             [ withAttr Theme.mutedAttr (txt "│ ")
-            , inlineWidgetWithAttr Theme.mutedAttr (parseInline quote)
+            , inlineWidgetWithAttr linkName Theme.mutedAttr (parseInline quote)
             ]
-            : renderLines rest
+            : renderLines linkName rest
     | Text.null (Text.strip line) =
-        txt " " : renderLines rest
+        txt " " : renderLines linkName rest
     | Block.isThematicBreak line =
         withAttr Theme.mutedAttr (vLimit 1 (fill '─'))
-            : renderLines rest
+            : renderLines linkName rest
     | otherwise =
-        inlineWidgetWithAttr Theme.assistantAttr (parseInline line)
-            : renderLines rest
+        inlineWidgetWithAttr linkName Theme.assistantAttr (parseInline line)
+            : renderLines linkName rest
 
 codeBodyLines :: Text -> [Text]
 codeBodyLines body
@@ -497,26 +565,35 @@ fragmentsDisplayWidth =
                 0
                 . snd)
 
-inlineWidgetWithAttr :: AttrName -> [Inline] -> Widget n
-inlineWidgetWithAttr plainAttr inlines =
+inlineWidgetWithAttr
+    :: Ord n
+    => Maybe (Text -> n)
+    -> AttrName
+    -> [Inline]
+    -> Widget n
+inlineWidgetWithAttr linkName plainAttr inlines =
     B.Widget B.Greedy B.Fixed do
         context <- B.getContext
         styled <- resolveInline plainAttr inlines
         let width = max 1 context.availWidth
             rows = wrapStyled width styled
-            rendered =
-                V.vertCat
-                    [ V.horizCat
-                        [ V.text attr (LazyText.fromStrict text)
-                        | (attr, text) <- row
-                        ]
-                    | row <- rows
+            rowWidget row =
+                hBox
+                    [ linkWidget attr text
+                    | (attr, text) <- row
                     ]
-            boundedImage
-                | V.imageWidth rendered > width =
-                    V.cropRight width rendered
-                | otherwise = rendered
-        pure B.emptyResult { B.image = boundedImage }
+            linkWidget attr text =
+                case (linkName, V.attrURL attr) of
+                    (Just toName, V.SetTo url) ->
+                        clickable (toName url) (spanWidget attr text)
+                    _ -> spanWidget attr text
+            spanWidget attr text =
+                B.Widget B.Fixed B.Fixed $
+                    pure B.emptyResult
+                        { B.image =
+                            V.text attr (LazyText.fromStrict text)
+                        }
+        B.render (vBox (map rowWidget rows))
 
 data InlineContext = InlineContext
     { inlineStrong :: !Bool

--- a/packages/agent-tui/test/Agent/TUI/MarkdownSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/MarkdownSpec.hs
@@ -6,8 +6,12 @@ import Agent.TUI.TextWidth (displayCharCellWidth)
 import qualified Agent.TUI.Theme as Theme
 import Brick
     ( (<=>)
+    , Extent(..)
+    , Location(..)
+    , RenderState
     , ViewportType(..)
     , Widget
+    , renderFinal
     , renderWidget
     , txt
     , viewport
@@ -16,7 +20,7 @@ import Brick.AttrMap (attrMapLookup)
 import Control.Monad (forM_)
 import Data.Char (isControl)
 import Data.Foldable (toList)
-import Data.List (find, findIndex, isInfixOf)
+import Data.List (find, findIndex, isInfixOf, sortOn)
 import qualified Data.Text as Text
 import qualified Data.Text.Lazy as LazyText
 import qualified Graphics.Vty as V
@@ -53,6 +57,41 @@ spec = describe "fullscreen Markdown rendering" do
         let url = "https://github.com/digitallyinduced/haskell-agent/pull/339"
             spans = concat (renderSpanRows 100 ("PR: " <> url))
         spans `shouldSatisfy` any (hasUrl url)
+
+    it "registers application click targets for links" do
+        let url = "https://example.com/docs"
+            widget :: Widget Text.Text
+            widget = markdownWidgetWithLinks id ("Read [docs](" <> url <> ")")
+            (_, _, _, extents) =
+                renderFinal
+                    Theme.terminalDefault
+                    [widget]
+                    (40, 3)
+                    (const Nothing)
+                    emptyRenderState
+        map
+            (\extent ->
+                ( extentName extent
+                , extentUpperLeft extent
+                , extentSize extent
+                ))
+            extents
+            `shouldContain` [(url, Location (5, 0), (31, 1))]
+
+    it "registers a click target for every wrapped link fragment" do
+        let url = "https://example.com/abcdefgh"
+            widget :: Widget Text.Text
+            widget = markdownWidgetWithLinks id url
+            (_, _, _, extents) =
+                renderFinal
+                    Theme.terminalDefault
+                    [widget]
+                    (10, 4)
+                    (const Nothing)
+                    emptyRenderState
+        let ordered = sortOn extentUpperLeft extents
+        map extentName ordered `shouldBe` replicate 3 url
+        map extentSize ordered `shouldBe` [(10, 1), (10, 1), (8, 1)]
 
     it "keeps a wide inline glyph inside a one-cell render context" do
         let image =
@@ -652,6 +691,14 @@ renderSpanRows width input =
                 displayOpsForPic
                     (renderWidget Nothing [widget] region)
                     region
+
+emptyRenderState :: (Ord n, Read n) => RenderState n
+emptyRenderState =
+    read
+        "RS {viewportMap = fromList [], rsScrollRequests = [], \
+        \observedNames = fromList [], renderCache = fromList [], \
+        \clickableNames = [], requestedVisibleNames_ = fromList [], \
+        \reportedExtents = fromList []}"
 
 spanRowText :: [SpanOp] -> Text.Text
 spanRowText =


### PR DESCRIPTION
## Summary

- register Brick click extents for Markdown links, including links that wrap across rows
- open clicked HTTP(S) links with the platform URL handler without invoking a shell
- handle link activation on left-button release so mouse-motion events cannot open URLs
- retain existing OSC 8 hyperlink metadata

## Tests

- `TMPDIR=/tmp/ha-link-tests nix develop -c cabal test agent-tui-test agent-cli-test --test-show-details=failures`
- loaded `agent-tui` and `agent-cli` together in GHCi
- exercised the fullscreen agent in tmux and confirmed a bare HTTPS link rendered in the conversation view
