### PR TITLE
perf(core): coalesce queued loop events

### DIFF
--- a/packages/agent-core/agent-core.cabal
+++ b/packages/agent-core/agent-core.cabal
@@ -143,6 +143,17 @@ benchmark tool-scheduling-bench
                     , base >= 4.14 && < 5
                     , text
 
+benchmark loop-events-bench
+    import:           common-opts
+    type:             exitcode-stdio-1.0
+    hs-source-dirs:   benchmark
+    main-is:          LoopEvents.hs
+    ghc-options:      -O2 -rtsopts
+    build-depends:    agent-core
+                    , aeson
+                    , base >= 4.14 && < 5
+                    , text
+
 test-suite agent-core-test
     import:           common-opts
     type:             exitcode-stdio-1.0

--- a/packages/agent-core/benchmark/LoopEvents.hs
+++ b/packages/agent-core/benchmark/LoopEvents.hs
@@ -1,0 +1,342 @@
+module Main (main) where
+
+import Agent.Cancel (newCancelFlag)
+import Agent.Loop
+    ( Backend(..)
+    , BackendResult(..)
+    , BackendStateStore(..)
+    , LoopConfig(..)
+    , LoopEvent(..)
+    , LoopResult
+    , defaultLoopDispatch
+    , defaultLoopMaxTurns
+    , emptyTurnOutput
+    , runLoop
+    )
+import Agent.ToolDispatch
+    ( ToolCall(..)
+    , ToolCallResult(..)
+    , functionToolCall
+    , typedStreamingTool
+    )
+import Agent.Tools.Types
+    ( ApprovalRule(..)
+    , ToolExecutionPolicy(..)
+    , ToolRegistry
+    , jsonAppToolWithExecution
+    , mkToolRegistry
+    )
+import Control.Concurrent (threadDelay)
+import Control.Exception (evaluate)
+import Control.Monad (forM, replicateM_)
+import Data.Aeson (FromJSON(..), withObject, (.:))
+import Data.IORef
+    ( IORef
+    , atomicModifyIORef'
+    , newIORef
+    , readIORef
+    , writeIORef
+    )
+import Data.List (sort)
+import qualified Data.Text as Text
+import Data.Word (Word64)
+import GHC.Clock (getMonotonicTimeNSec)
+import GHC.Stats
+    ( RTSStats(..)
+    , getRTSStats
+    , getRTSStatsEnabled
+    )
+import System.CPUTime (getCPUTime)
+import System.Environment (getArgs)
+import System.Exit (die)
+import System.Mem (performGC)
+import Text.Printf (printf)
+
+data Workload
+    = StreamingEvents
+    | ParallelToolEvents
+    | QueuedEvents
+
+data EventArgs = EventArgs
+    { count :: !Int
+    }
+
+instance FromJSON EventArgs where
+    parseJSON = withObject "EventArgs" \fields ->
+        EventArgs <$> fields .: "count"
+
+data WorkloadResult = WorkloadResult
+    { resultChecksum :: !Int
+    , resultProducerFinished :: !Word64
+    }
+
+data Sample = Sample
+    { totalWallMillis :: !Double
+    , producerWallMillis :: !Double
+    , cpuMillis :: !Double
+    , allocatedBytes :: !Integer
+    }
+
+main :: IO ()
+main = do
+    enabled <- getRTSStatsEnabled
+    if not enabled
+        then die "RTS statistics are disabled; run with +RTS -T"
+        else pure ()
+    getArgs >>= \case
+        [workloadArg, eventCountArg, sinkDelayArg, sampleCountArg] -> do
+            workload <- parseWorkload workloadArg
+            eventCount <- parsePositive "event count" eventCountArg
+            sinkDelayMicros <- parseNonNegative
+                "sink delay microseconds" sinkDelayArg
+            sampleCount <- parseOddPositive "sample count" sampleCountArg
+            samples <- forM [1 .. sampleCount] \_ -> do
+                performGC
+                measure workload eventCount sinkDelayMicros
+            let sample = median samples
+            printf
+                "%s,%d,%d,%.3f,%.3f,%.3f,%d\n"
+                workloadArg
+                eventCount
+                sinkDelayMicros
+                sample.totalWallMillis
+                sample.producerWallMillis
+                sample.cpuMillis
+                sample.allocatedBytes
+        _ ->
+            die $
+                "usage: loop-events-bench WORKLOAD EVENTS SINK_DELAY_US SAMPLES\n"
+                    <> "workloads: streaming, parallel-tools, queued-events"
+
+parseWorkload :: String -> IO Workload
+parseWorkload = \case
+    "streaming" -> pure StreamingEvents
+    "parallel-tools" -> pure ParallelToolEvents
+    "queued-events" -> pure QueuedEvents
+    other -> die ("unknown workload: " <> other)
+
+parsePositive :: String -> String -> IO Int
+parsePositive label raw =
+    case reads raw of
+        [(value, "")]
+            | value > 0 -> pure value
+        _ -> die ("invalid " <> label <> ": " <> raw)
+
+parseOddPositive :: String -> String -> IO Int
+parseOddPositive label raw = do
+    value <- parsePositive label raw
+    if odd value
+        then pure value
+        else die (label <> " must be odd: " <> raw)
+
+parseNonNegative :: String -> String -> IO Int
+parseNonNegative label raw =
+    case reads raw of
+        [(value, "")]
+            | value >= 0 -> pure value
+        _ -> die ("invalid " <> label <> ": " <> raw)
+
+measure :: Workload -> Int -> Int -> IO Sample
+measure workload eventCount sinkDelayMicros = do
+    beforeStats <- getRTSStats
+    wallBefore <- getMonotonicTimeNSec
+    cpuBefore <- getCPUTime
+    result <- runWorkload workload eventCount sinkDelayMicros
+    _ <- evaluate
+        (result.resultChecksum + fromIntegral result.resultProducerFinished)
+    cpuAfter <- getCPUTime
+    wallAfter <- getMonotonicTimeNSec
+    performGC
+    afterStats <- getRTSStats
+    pure Sample
+        { totalWallMillis =
+            nanosToMillis (wallAfter - wallBefore)
+        , producerWallMillis =
+            nanosToMillis
+                (fromIntegral result.resultProducerFinished - wallBefore)
+        , cpuMillis =
+            fromIntegral (cpuAfter - cpuBefore) / 1.0e9
+        , allocatedBytes =
+            fromIntegral
+                (afterStats.allocated_bytes - beforeStats.allocated_bytes)
+        }
+
+runWorkload :: Workload -> Int -> Int -> IO WorkloadResult
+runWorkload workload eventCount sinkDelayMicros = do
+    checksumRef <- newIORef 0
+    producerFinishedRef <- newIORef Nothing
+    stateRef <- newIORef []
+    cancel <- newCancelFlag
+    backend <- case workload of
+        StreamingEvents ->
+            pure $ streamingBackend eventCount producerFinishedRef
+        ParallelToolEvents ->
+            parallelToolBackend eventCount producerFinishedRef
+        QueuedEvents ->
+            pure $ queuedEventsBackend eventCount producerFinishedRef
+    let sink event = do
+            if sinkDelayMicros > 0
+                then threadDelay sinkDelayMicros
+                else pure ()
+            atomicModifyIORef' checksumRef \checksum ->
+                (checksum + eventWeight event, ())
+        config = LoopConfig
+            { loopBackend = backend
+            , loopBackendState = BackendStateStore
+                { readBackendState = readIORef stateRef
+                , commitBackendState = writeIORef stateRef
+                }
+            , loopTools = case workload of
+                StreamingEvents -> emptyRegistry
+                ParallelToolEvents -> streamingRegistry
+                QueuedEvents -> emptyRegistry
+            , loopDispatch = defaultLoopDispatch
+            , loopMaxTurns = defaultLoopMaxTurns
+            , loopOnEvent = sink
+            , loopApprove = \_ -> pure (Right True)
+            , loopCancel = cancel
+            }
+    result <- runLoop config Nothing "benchmark"
+    forceSuccess result
+    checksum <- readIORef checksumRef
+    producerFinished <- readIORef producerFinishedRef >>= \case
+        Just timestamp -> pure timestamp
+        Nothing -> die "benchmark producer did not record completion"
+    pure WorkloadResult
+        { resultChecksum = checksum
+        , resultProducerFinished = producerFinished
+        }
+
+streamingBackend
+    :: Int
+    -> IORef (Maybe Word64)
+    -> Backend
+streamingBackend eventCount producerFinishedRef =
+    Backend \_state _previous _inputs onEvent -> do
+        replicateM_ eventCount (onEvent (TextDelta "x"))
+        getMonotonicTimeNSec >>= writeIORef producerFinishedRef . Just
+        pure . Right $ BackendResult
+            { backendOutput =
+                emptyTurnOutput "stream-response" [] (Just "done")
+            , backendState = []
+            }
+
+queuedEventsBackend
+    :: Int
+    -> IORef (Maybe Word64)
+    -> Backend
+queuedEventsBackend eventCount producerFinishedRef =
+    Backend \_state _previous _inputs onEvent -> do
+        replicateM_ eventCount (onEvent (WarningRaised "x"))
+        getMonotonicTimeNSec >>= writeIORef producerFinishedRef . Just
+        pure . Right $ BackendResult
+            { backendOutput =
+                emptyTurnOutput "queued-response" [] (Just "done")
+            , backendState = []
+            }
+
+parallelToolBackend
+    :: Int
+    -> IORef (Maybe Word64)
+    -> IO Backend
+parallelToolBackend eventCount producerFinishedRef = do
+    submissionRef <- newIORef (0 :: Int)
+    let counts = distributeEvents parallelToolCount eventCount
+        calls =
+            [ functionToolCall
+                ("call-" <> Text.pack (show index))
+                "stream-events"
+                ("{\"count\":" <> Text.pack (show count) <> "}")
+            | (index, count) <- zip [1 :: Int ..] counts
+            ]
+    pure $ Backend \_state _previous _inputs _onEvent -> do
+        submission <- atomicModifyIORef' submissionRef \current ->
+            let next = current + 1
+            in (next, next)
+        case submission of
+            1 ->
+                pure . Right $ BackendResult
+                    { backendOutput =
+                        emptyTurnOutput "tool-response" calls Nothing
+                    , backendState = []
+                    }
+            2 -> do
+                getMonotonicTimeNSec >>= writeIORef producerFinishedRef . Just
+                pure . Right $ BackendResult
+                    { backendOutput =
+                        emptyTurnOutput "final-response" [] (Just "done")
+                    , backendState = []
+                    }
+            _ -> die "parallel tool benchmark submitted too many turns"
+
+parallelToolCount :: Int
+parallelToolCount = 4
+
+distributeEvents :: Int -> Int -> [Int]
+distributeEvents buckets total =
+    [ quotient + if index <= remainder then 1 else 0
+    | index <- [1 .. buckets]
+    ]
+  where
+    (quotient, remainder) = total `quotRem` buckets
+
+streamingRegistry :: ToolRegistry
+streamingRegistry =
+    either (error . Text.unpack) id $
+        mkToolRegistry
+            [ jsonAppToolWithExecution
+                "stream-events"
+                ""
+                []
+                AlwaysReadOnly
+                ParallelSafe
+                (typedStreamingTool "stream-events" \emit EventArgs{count} -> do
+                    mapM_
+                        (\size -> emit (Text.replicate size "x"))
+                        [1 .. count]
+                    pure (Right "done"))
+            ]
+
+emptyRegistry :: ToolRegistry
+emptyRegistry =
+    either (error . Text.unpack) id (mkToolRegistry [])
+
+forceSuccess :: Either error LoopResult -> IO ()
+forceSuccess = \case
+    Right result -> result `seq` pure ()
+    Left _ -> die "agent loop benchmark failed"
+
+eventWeight :: LoopEvent -> Int
+eventWeight = \case
+    TextDelta text -> Text.length text
+    ReasoningDelta text -> Text.length text
+    ActivityUpdated text -> Text.length text
+    WarningRaised text -> Text.length text
+    ResponseRestarted text -> Text.length text
+    TurnStarted -> 1
+    TurnFinished _ -> 1
+    ToolStarted call -> Text.length call.callId
+    ToolOutputUpdated callId output ->
+        Text.length callId + Text.length output
+    ToolFinished result ->
+        Text.length result.callId + Text.length result.output
+
+nanosToMillis :: Integral value => value -> Double
+nanosToMillis value =
+    fromIntegral value / 1000000
+
+median :: [Sample] -> Sample
+median samples =
+    Sample
+        { totalWallMillis =
+            middle (sort (map (.totalWallMillis) samples))
+        , producerWallMillis =
+            middle (sort (map (.producerWallMillis) samples))
+        , cpuMillis =
+            middle (sort (map (.cpuMillis) samples))
+        , allocatedBytes =
+            middle (sort (map (.allocatedBytes) samples))
+        }
+
+middle :: [a] -> a
+middle values = values !! (length values `div` 2)

--- a/packages/agent-core/package.nix
+++ b/packages/agent-core/package.nix
@@ -22,7 +22,8 @@ mkDerivation {
     safe-exceptions stm text time tls unix websockets yaml
   ];
   benchmarkHaskellDepends = [
-    base bytestring directory safe-exceptions text text-builder unix
+    aeson base bytestring directory safe-exceptions text text-builder
+    unix
   ];
   description = "Provider-neutral infrastructure for the agent harness";
   license = lib.meta.getLicenseFromSpdxId "MIT";

--- a/packages/agent-core/src/Agent/Loop.hs
+++ b/packages/agent-core/src/Agent/Loop.hs
@@ -32,6 +32,12 @@ import Agent.Cancel (CancelFlag, isCancelled, waitCancel)
 import Agent.Error (ApiError)
 import Agent.InterAgentMessage (InterAgentMessage)
 import Agent.Responses.Types (ResponseItem)
+import Agent.TextBuffer
+    ( TextBuffer
+    , appendTextBuffer
+    , emptyTextBuffer
+    , textBufferToText
+    )
 import Agent.ToolDispatch
     ( ToolCall(..)
     , ToolCallResult(..)
@@ -56,15 +62,21 @@ import Control.Concurrent.Async
 import Control.Concurrent.STM
     ( TBQueue
     , TMVar
+    , STM
+    , TVar
     , atomically
     , newEmptyTMVarIO
+    , newTVar
     , newTBQueueIO
+    , modifyTVar'
     , orElse
     , putTMVar
     , readTBQueue
     , readTMVar
+    , readTVar
     , retry
     , tryPutTMVar
+    , writeTVar
     , writeTBQueue
     )
 import Control.Exception (AsyncException, toException)
@@ -468,7 +480,13 @@ runLoopInputsUnsafe config0 initialState previousResponseId firstInputs = do
 
 data LoopEventCommand
     = DeliverLoopEvent !LoopEvent
+    | DeliverCoalescedLoopEvent !CoalescedLoopEvent
     | FlushLoopEvents !(TMVar ())
+
+data CoalescedLoopEvent
+    = CoalescedTextDelta !(TVar TextBuffer)
+    | CoalescedReasoningDelta !(TVar TextBuffer)
+    | CoalescedToolOutput !Text !(TVar Text)
 
 data LoopEventFailure
     = LoopEventSyncFailure !SomeException
@@ -477,6 +495,7 @@ data LoopEventFailure
 data LoopEventPump = LoopEventPump
     { eventPumpQueue :: !(TBQueue LoopEventCommand)
     , eventPumpFailure :: !(TMVar LoopEventFailure)
+    , eventPumpTail :: !(TVar (Maybe CoalescedLoopEvent))
     , eventPumpSink :: !(LoopEvent -> IO ())
     }
 
@@ -487,9 +506,11 @@ newLoopEventPump :: (LoopEvent -> IO ()) -> IO LoopEventPump
 newLoopEventPump sink = do
     queue <- newTBQueueIO (fromIntegral loopEventQueueCapacity)
     failure <- newEmptyTMVarIO
+    tailEvent <- atomically (newTVar Nothing)
     pure LoopEventPump
         { eventPumpQueue = queue
         , eventPumpFailure = failure
+        , eventPumpTail = tailEvent
         , eventPumpSink = sink
         }
 
@@ -498,27 +519,44 @@ runLoopEventPump pump = go
   where
     go =
         atomically (readTBQueue pump.eventPumpQueue) >>= \case
-            DeliverLoopEvent event -> do
-                outcome <-
-                    (tryAny (pump.eventPumpSink event) >>= \case
-                        Left exception ->
-                            pure (Left (LoopEventSyncFailure exception))
-                        Right () -> pure (Right ()))
-                    `catchAsync` \(exception :: AsyncException) ->
-                        pure (Left (LoopEventAsyncFailure exception))
-                case outcome of
-                    Right () -> go
-                    Left failure -> do
-                        atomically $
-                            void (tryPutTMVar pump.eventPumpFailure failure)
-                        atomically retry
+            DeliverLoopEvent event ->
+                deliver event
+            DeliverCoalescedLoopEvent pending -> do
+                event <- atomically do
+                    current <- readTVar pump.eventPumpTail
+                    whenSTM (sameCoalescedEvent current pending) $
+                        writeTVar pump.eventPumpTail Nothing
+                    materializeCoalescedEvent pending
+                deliver event
             FlushLoopEvents flushed -> do
                 atomically (putTMVar flushed ())
                 go
+    deliver event = do
+        (tryAny (pump.eventPumpSink event) >>= \case
+            Right () -> go
+            Left exception -> do
+                atomically $
+                    recordLoopEventFailure
+                        pump
+                        (LoopEventSyncFailure exception)
+                atomically retry)
+            `catchAsync` \(exception :: AsyncException) -> do
+                atomically $
+                    recordLoopEventFailure
+                        pump
+                        (LoopEventAsyncFailure exception)
+                Exception.throwIO exception
 
 emitLoopEvent :: LoopEventPump -> LoopEvent -> IO ()
-emitLoopEvent pump event =
-    enqueueLoopEventCommand pump (DeliverLoopEvent event)
+emitLoopEvent pump = \case
+    TextDelta text ->
+        enqueueTextDelta pump False text
+    ReasoningDelta text ->
+        enqueueTextDelta pump True text
+    ToolOutputUpdated callId output ->
+        enqueueToolOutput pump callId output
+    event ->
+        enqueueLoopEventCommand pump (DeliverLoopEvent event)
 
 flushLoopEvents :: LoopEventPump -> IO (Either LoopEventFailure ())
 flushLoopEvents pump = do
@@ -540,8 +578,96 @@ enqueueLoopEventCommand pump command =
     atomically
         ( (Left <$> readTMVar pump.eventPumpFailure)
             `orElse`
-          (writeTBQueue pump.eventPumpQueue command >> pure (Right ()))
+          (do
+            clearEventPumpTail pump
+            writeTBQueue pump.eventPumpQueue command
+            pure (Right ()))
         ) >>= either throwLoopEventFailure pure
+
+enqueueTextDelta :: LoopEventPump -> Bool -> Text -> IO ()
+enqueueTextDelta pump reasoning text =
+    atomically
+        ( (Left <$> readTMVar pump.eventPumpFailure)
+            `orElse`
+          (do
+            current <- readTVar pump.eventPumpTail
+            case current of
+                Just (CoalescedTextDelta buffer)
+                    | not reasoning -> do
+                        modifyTVar' buffer (appendTextBuffer text)
+                        pure (Right ())
+                Just (CoalescedReasoningDelta buffer)
+                    | reasoning -> do
+                        modifyTVar' buffer (appendTextBuffer text)
+                        pure (Right ())
+                _ -> do
+                    buffer <- newTVar
+                        (appendTextBuffer text emptyTextBuffer)
+                    let pending =
+                            if reasoning
+                                then CoalescedReasoningDelta buffer
+                                else CoalescedTextDelta buffer
+                    writeTVar pump.eventPumpTail (Just pending)
+                    writeTBQueue pump.eventPumpQueue
+                        (DeliverCoalescedLoopEvent pending)
+                    pure (Right ()))
+        ) >>= either throwLoopEventFailure pure
+
+enqueueToolOutput :: LoopEventPump -> Text -> Text -> IO ()
+enqueueToolOutput pump callId output =
+    atomically
+        ( (Left <$> readTMVar pump.eventPumpFailure)
+            `orElse`
+          (do
+            current <- readTVar pump.eventPumpTail
+            case current of
+                Just (CoalescedToolOutput currentId snapshot)
+                    | currentId == callId -> do
+                        writeTVar snapshot output
+                        pure (Right ())
+                _ -> do
+                    snapshot <- newTVar output
+                    let pending = CoalescedToolOutput callId snapshot
+                    writeTVar pump.eventPumpTail (Just pending)
+                    writeTBQueue pump.eventPumpQueue
+                        (DeliverCoalescedLoopEvent pending)
+                    pure (Right ()))
+        ) >>= either throwLoopEventFailure pure
+
+sameCoalescedEvent
+    :: Maybe CoalescedLoopEvent
+    -> CoalescedLoopEvent
+    -> Bool
+sameCoalescedEvent current pending =
+    case (current, pending) of
+        (Just (CoalescedTextDelta left), CoalescedTextDelta right) ->
+            left == right
+        (Just (CoalescedReasoningDelta left), CoalescedReasoningDelta right) ->
+            left == right
+        ( Just (CoalescedToolOutput leftId left)
+          , CoalescedToolOutput rightId right
+          ) ->
+            leftId == rightId && left == right
+        _ -> False
+
+materializeCoalescedEvent :: CoalescedLoopEvent -> STM LoopEvent
+materializeCoalescedEvent = \case
+    CoalescedTextDelta buffer ->
+        TextDelta . textBufferToText <$> readTVar buffer
+    CoalescedReasoningDelta buffer ->
+        ReasoningDelta . textBufferToText <$> readTVar buffer
+    CoalescedToolOutput callId snapshot ->
+        ToolOutputUpdated callId <$> readTVar snapshot
+
+clearEventPumpTail :: LoopEventPump -> STM ()
+clearEventPumpTail pump =
+    readTVar pump.eventPumpTail >>= \case
+        Nothing -> pure ()
+        Just _ -> writeTVar pump.eventPumpTail Nothing
+
+whenSTM :: Bool -> STM () -> STM ()
+whenSTM True action = action
+whenSTM False _ = pure ()
 
 waitLoopEventFailure :: Async () -> LoopEventPump -> IO LoopEventFailure
 waitLoopEventFailure worker pump =
@@ -574,6 +700,10 @@ handleLoopEventFailure unexpected state progress = \case
         unexpected state progress exception
     LoopEventAsyncFailure exception ->
         Exception.throwIO exception
+
+recordLoopEventFailure :: LoopEventPump -> LoopEventFailure -> STM ()
+recordLoopEventFailure pump failure =
+    void (tryPutTMVar pump.eventPumpFailure failure)
 
 -- | Preserve model order between conflicting calls while allowing independent
 -- calls from the same model turn to overlap. Results are returned in model

--- a/packages/agent-core/test/Agent/LoopSpec.hs
+++ b/packages/agent-core/test/Agent/LoopSpec.hs
@@ -24,7 +24,7 @@ import Agent.Tools.Types
     , withToolResourceClaims
     )
 import Control.Concurrent (forkIO, threadDelay)
-import Control.Concurrent.Async (wait, withAsync)
+import Control.Concurrent.Async (cancel, wait, withAsync)
 import Control.Concurrent.MVar
     ( newEmptyMVar
     , putMVar
@@ -213,7 +213,7 @@ spec = describe "runLoop" do
         backendFinished <- newEmptyMVar
         let backend = Backend \_state _prev _inputs onEvent -> do
                 putMVar backendStarted ()
-                mapM_ (const (onEvent (TextDelta "x"))) [1 .. 300 :: Int]
+                mapM_ (const (onEvent (WarningRaised "x"))) [1 .. 300 :: Int]
                 putMVar backendFinished ()
                 pure $ Right BackendResult
                     { backendOutput =
@@ -241,6 +241,97 @@ spec = describe "runLoop" do
                 , turnsUsed = 1
                 , tokenUsage = emptyTokenUsage
                 }
+
+    it "coalesces adjacent deltas while preserving event boundaries" do
+        sinkStarted <- newEmptyMVar
+        releaseSink <- newEmptyMVar
+        backendFinished <- newEmptyMVar
+        events <- newIORef []
+        let backend = Backend \_state _prev _inputs onEvent -> do
+                onEvent (TextDelta "a")
+                onEvent (TextDelta "b")
+                onEvent (WarningRaised "boundary")
+                onEvent (ReasoningDelta "r1")
+                onEvent (ReasoningDelta "r2")
+                onEvent (TextDelta "c")
+                onEvent (TextDelta "d")
+                putMVar backendFinished ()
+                pure $ Right BackendResult
+                    { backendOutput =
+                        emptyTurnOutput "resp-1" [] (Just "done")
+                    , backendState = []
+                    }
+            onEvent event = do
+                modifyIORef' events (event :)
+                case event of
+                    TurnStarted -> do
+                        putMVar sinkStarted ()
+                        takeMVar releaseSink
+                    _ -> pure ()
+        config0 <- testConfig backend
+        let config = config0 { loopOnEvent = onEvent }
+        withAsync (runLoop config Nothing "go") \running -> do
+            takeMVar sinkStarted
+            takeMVar backendFinished
+            putMVar releaseSink ()
+            wait running `shouldReturn` Right LoopResult
+                { finalResponseId = "resp-1"
+                , finalText = Just "done"
+                , turnsUsed = 1
+                , tokenUsage = emptyTokenUsage
+                }
+        reverse <$> readIORef events `shouldReturn`
+            [ TurnStarted
+            , TextDelta "ab"
+            , WarningRaised "boundary"
+            , ReasoningDelta "r1r2"
+            , TextDelta "cd"
+            , TurnFinished (emptyTurnOutput "resp-1" [] (Just "done"))
+            ]
+
+    it "keeps only the latest adjacent tool-output snapshot per call" do
+        sinkStarted <- newEmptyMVar
+        releaseSink <- newEmptyMVar
+        backendFinished <- newEmptyMVar
+        events <- newIORef []
+        let backend = Backend \_state _prev _inputs onEvent -> do
+                onEvent (ToolOutputUpdated "c1" "a")
+                onEvent (ToolOutputUpdated "c1" "ab")
+                onEvent (ToolOutputUpdated "c2" "x")
+                onEvent (ToolOutputUpdated "c2" "xy")
+                onEvent (ToolOutputUpdated "c1" "abc")
+                putMVar backendFinished ()
+                pure $ Right BackendResult
+                    { backendOutput =
+                        emptyTurnOutput "resp-1" [] (Just "done")
+                    , backendState = []
+                    }
+            onEvent event = do
+                modifyIORef' events (event :)
+                case event of
+                    TurnStarted -> do
+                        putMVar sinkStarted ()
+                        takeMVar releaseSink
+                    _ -> pure ()
+        config0 <- testConfig backend
+        let config = config0 { loopOnEvent = onEvent }
+        withAsync (runLoop config Nothing "go") \running -> do
+            takeMVar sinkStarted
+            takeMVar backendFinished
+            putMVar releaseSink ()
+            wait running `shouldReturn` Right LoopResult
+                { finalResponseId = "resp-1"
+                , finalText = Just "done"
+                , turnsUsed = 1
+                , tokenUsage = emptyTokenUsage
+                }
+        reverse <$> readIORef events `shouldReturn`
+            [ TurnStarted
+            , ToolOutputUpdated "c1" "ab"
+            , ToolOutputUpdated "c2" "xy"
+            , ToolOutputUpdated "c1" "abc"
+            , TurnFinished (emptyTurnOutput "resp-1" [] (Just "done"))
+            ]
 
     it "dispatches consecutive parallel-safe tool calls concurrently" do
         firstStarted <- newEmptyMVar
@@ -901,6 +992,21 @@ spec = describe "runLoop" do
             (runLoop config Nothing "hello"
                 `shouldThrow` (== Exception.ThreadKilled))
             `shouldReturn` Just ()
+
+    it "can be cancelled while the event sink is running" do
+        sinkStarted <- newEmptyMVar
+        submissions <- newIORef []
+        backend <- scriptedBackend submissions
+            [Right (emptyTurnOutput "resp-1" [] (Just "done"))]
+        config0 <- testConfig backend
+        let config = config0
+                { loopOnEvent = \_ -> do
+                    putMVar sinkStarted ()
+                    threadDelay maxBound
+                }
+        withAsync (runLoop config Nothing "hello") \running -> do
+            takeMVar sinkStarted
+            timeout 1000000 (cancel running) `shouldReturn` Just ()
 
     it "emits TurnStarted and TurnFinished around each backend submit" do
         events <- newIORef []


### PR DESCRIPTION
## Summary

Follow-up to #420, which merged while its benchmark was running.

- coalesce adjacent text and reasoning deltas in the event pump
- retain only the latest adjacent `ToolOutputUpdated` snapshot for the same call
- preserve FIFO ordering and explicit event boundaries
- keep non-coalescing events on the existing bounded queue
- preserve async-exception propagation without swallowing worker cancellation
- add an optimized benchmark covering streaming, parallel tools, and queue saturation
- add deterministic tests for coalescing, boundaries, backpressure, and cancellation

## Benchmark

Compared merged `master` (the non-coalescing queue from #420) with this branch using optimized builds (`-O2`, `+RTS -T`). Results are medians of 9 samples for a no-op sink and 7 samples for a sink delayed by 1 ms per delivered event.

### 4,096 events, no-op sink

| workload | merged queue | coalesced queue | allocation before | allocation after |
|---|---:|---:|---:|---:|
| text deltas | 0.847 ms | 0.379 ms | 3.04 MB | 0.62 MB |
| 4 parallel streaming tools | 1.277 ms | 0.431 ms | 5.92 MB | 0.89 MB |
| non-coalescing warnings | 1.027 ms | 1.170 ms | 3.04 MB | 3.30 MB |

The high-volume coalescible paths become substantially faster and allocate 80–85% less. The artificial non-coalescing burst pays about 0.14 ms and 0.26 MB extra across 4,096 events for the boundary check.

### 1,024 events, 1 ms sink delay

| workload | merged total | coalesced total | merged producer blocked | coalesced producer blocked |
|---|---:|---:|---:|---:|
| text deltas | 1330.2 ms | 3.7 ms | 992.0 ms | 0.1 ms |
| 4 parallel streaming tools | 1280.3 ms | 21.0 ms | 964.8 ms | 0.1 ms |
| non-coalescing warnings | 1261.3 ms | 1257.6 ms | 942.5 ms | 941.7 ms |

Non-coalescing events retain the bounded queue's existing backpressure behavior. Coalesced streams no longer fill the queue or make provider/tool producers wait for renderer latency.

Benchmark command shape:

```console
cabal run agent-core:bench:loop-events-bench -- WORKLOAD EVENTS SINK_DELAY_US SAMPLES +RTS -T -RTS
```

Workloads: `streaming`, `parallel-tools`, and `queued-events`.

## Testing

- `nix develop -c cabal repl agent-core:test:agent-core-test`
- `:main`
- 324 examples, 0 failures
- optimized old-vs-new benchmark matrix
