### PR TITLE
Add /afk session handoff to tmux

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -55,6 +55,7 @@ library
                     , Agent.CLI.AgentViewport
                     , Agent.CLI.Approval
                     , Agent.CLI.Artifact
+                    , Agent.CLI.Afk
                     , Agent.CLI.Auth
                     , Agent.CLI.Btw
                     , Agent.CLI.CancelWatch

--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -21,6 +21,12 @@ module Agent.CLI
     ) where
 
 import Agent.CLI.Artifact (fencedCodeBlock, lastDiffBlock)
+import Agent.CLI.Afk
+    ( AfkTarget(..)
+    , handoffLocal
+    , handoffRemote
+    , parseAfkTarget
+    )
 import Agent.CLI.AccountSelection
     ( SelectedAccount(..)
     , providerSupportsUsageAccountSelection
@@ -293,6 +299,7 @@ import Agent.CLI.SessionLock
     , acquireSessionLock
     , releaseSessionLock
     , sessionLockFilePath
+    , sessionLockIsActive
     , sessionLockPath
     )
 import Agent.CLI.Skills
@@ -565,6 +572,7 @@ import qualified Agent.XAI.Options as XAI
 import qualified Agent.XAI.Usage as XAIUsage
 import Control.Applicative ((<|>))
 import Control.Concurrent.Async (link, mapConcurrently, waitSTM, withAsync)
+import Control.Concurrent (threadDelay)
 import Control.Concurrent.Chan (Chan, newChan, readChan, writeChan)
 import Control.Concurrent.MVar
     ( MVar
@@ -591,6 +599,8 @@ import Control.Exception.Safe
     )
 import Control.Monad (forM_, unless, void, when)
 import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as LBS
+import qualified Data.Aeson as Aeson
 import Data.IORef
 import Data.List (elemIndex, findIndex, sortOn)
 import Data.Map.Strict (Map)
@@ -776,6 +786,8 @@ devMainResume resumeId = do
             pure DevQuit
         Right ListSessions -> runListSessions >> pure DevQuit
         Right (ShowSession sessionId) -> runShowSession sessionId >> pure DevQuit
+        Right (WaitSession sessionId) -> runWaitSession sessionId >> pure DevQuit
+        Right (ImportSession cwd) -> runImportSession cwd >> pure DevQuit
         Right (Storage command) ->
             runStorageAdmin command >> pure DevQuit
         Right (RunAgent options) -> do
@@ -796,6 +808,8 @@ run = do
             runLoginManager color
         Right ListSessions -> runListSessions
         Right (ShowSession sessionId) -> runShowSession sessionId
+        Right (WaitSession sessionId) -> runWaitSession sessionId
+        Right (ImportSession cwd) -> runImportSession cwd
         Right (Storage command) -> runStorageAdmin command
         Right (RunAgent options) -> do
             result <- runAgentWithRestarts options
@@ -947,6 +961,34 @@ printTurn turn = do
             Text.putStrLn ("error> " <> err)
         _ -> pure ()
     putStrLn ""
+
+runWaitSession :: Text -> IO ()
+runWaitSession sessionId = do
+    home <- getHomeDirectory
+    dir <- either (die . Text.unpack) pure
+        (sessionDirForId (sessionsRoot home) sessionId)
+    exists <- doesDirectoryExist dir
+    unless exists (die ("session not found: " <> Text.unpack sessionId))
+    let wait = do
+            active <- sessionLockIsActive (sessionLockPath dir)
+            when active (threadDelay 100000 >> wait)
+    wait
+
+runImportSession :: Maybe OsPath -> IO ()
+runImportSession cwd = do
+    bytes <- LBS.getContents
+    transfer <- case Aeson.eitherDecode bytes of
+        Left err -> die ("invalid transferred session: " <> err)
+        Right value -> pure value
+    home <- getHomeDirectory
+    withStoreForHome home \store ->
+        importSessionTransfer
+            (trustedPool store)
+            (sessionsRoot home)
+            cwd
+            transfer >>= \case
+                Left err -> die (Text.unpack err)
+                Right sessionId -> Text.putStrLn sessionId
 
 setStartupNotice :: Maybe FullscreenRuntime -> Text -> IO ()
 setStartupNotice fullscreen message =
@@ -5484,6 +5526,57 @@ replWithDraft env@SessionEnv
                         displayInfo message $
                             Text.putStrLn (roleMuted color message)
                         continue
+                    ReplAfk rawTarget -> do
+                        let failAfk err = do
+                                color <- resolveColor stderr
+                                displayError err $
+                                    putTextLn stderr (roleError color err)
+                                continue
+                            finishAfk message = do
+                                color <- resolveColor stderr
+                                displayInfo message $
+                                    putTextLn stderr
+                                        (roleMuted color (glyphOk <> message))
+                                pure RunQuit
+                        case parseAfkTarget rawTarget of
+                            Left err -> failAfk err
+                            Right target -> case persist of
+                                PersistenceDisabled ->
+                                    failAfk "/afk requires a persisted interactive session"
+                                PersistenceEnabled slotRef ->
+                                    readIORef slotRef >>= \case
+                                        PersistencePending _ _ _ ->
+                                            failAfk
+                                                "/afk is available after the first persisted turn"
+                                        PersistenceActive handle ->
+                                            case target of
+                                                AfkLocal ->
+                                                    handoffLocal
+                                                        handle.sessionMeta.metaId
+                                                        cwd >>= \case
+                                                            Left err -> failAfk err
+                                                            Right message ->
+                                                                finishAfk message
+                                                AfkRemote host path ->
+                                                    loadSession
+                                                        databasePool
+                                                        (sessionsRoot env.sessionHome)
+                                                        handle.sessionMeta.metaId
+                                                        >>= \case
+                                                            Left err -> failAfk err
+                                                            Right (meta, turns) ->
+                                                                handoffRemote
+                                                                    host
+                                                                    path
+                                                                    handle.sessionDir
+                                                                    SessionTransfer
+                                                                        { transferMeta = meta
+                                                                        , transferTurns = turns
+                                                                        }
+                                                                    >>= \case
+                                                                        Left err -> failAfk err
+                                                                        Right message ->
+                                                                            finishAfk message
                     ReplWorktree -> do
                         result <- withReplActivity "Creating worktree…" $
                             createWorktree cwd (worktreeRoot env.sessionHome)

--- a/packages/agent-cli/src/Agent/CLI/Afk.hs
+++ b/packages/agent-cli/src/Agent/CLI/Afk.hs
@@ -1,0 +1,213 @@
+-- | Move an idle persisted session into a detached tmux, locally or over SSH.
+module Agent.CLI.Afk
+    ( AfkTarget(..)
+    , parseAfkTarget
+    , handoffLocal
+    , handoffRemote
+    ) where
+
+import Agent.CLI.Session (SessionMeta(..), SessionTransfer(..))
+import Agent.OsPath (unsafeToFilePath)
+import Control.Concurrent.Async (concurrently)
+import Control.Exception.Safe (tryAny)
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString.Lazy as LBS
+import Data.Char (isAlphaNum)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
+import System.Environment (getExecutablePath, getProgName, lookupEnv)
+import System.Exit (ExitCode(..))
+import System.IO (hClose)
+import System.OsPath (OsPath)
+import System.Process
+    ( CreateProcess(..)
+    , StdStream(CreatePipe, UseHandle)
+    , createProcess
+    , proc
+    , readProcessWithExitCode
+    , waitForProcess
+    )
+
+data AfkTarget
+    = AfkLocal
+    | AfkRemote !Text !Text
+    deriving (Eq, Show)
+
+parseAfkTarget :: Maybe Text -> Either Text AfkTarget
+parseAfkTarget Nothing = Right AfkLocal
+parseAfkTarget (Just raw) =
+    let (host, suffix) = Text.breakOn ":" (Text.strip raw)
+        path = Text.drop 1 suffix
+    in if Text.null host
+            || Text.isPrefixOf "-" host
+            || Text.null suffix
+            || Text.null path
+        then Left "remote AFK target must be HOST:PATH"
+        else Right (AfkRemote host path)
+
+handoffLocal :: Text -> OsPath -> IO (Either Text Text)
+handoffLocal sessionId cwd = do
+    executable <- localExecutable
+    let name = tmuxName sessionId
+        script =
+            quote executable
+                <> " sessions wait " <> quote (Text.unpack sessionId)
+                <> " && exec " <> quote executable
+                <> " --resume " <> quote (Text.unpack sessionId)
+                <> " --cwd " <> quote (unsafeToFilePath cwd)
+    runChecked "tmux"
+        ["new-session", "-d", "-s", Text.unpack name, "sh", "-lc", script]
+        ("session moved to tmux " <> name
+            <> "\nattach with: tmux attach -t " <> name)
+
+handoffRemote
+    :: Text
+    -> Text
+    -> OsPath
+    -> SessionTransfer
+    -> IO (Either Text Text)
+handoffRemote host path sessionDir transfer = do
+    let meta = transfer.transferMeta
+        name = tmuxName meta.metaId
+        remotePath = remotePathWord path
+        sessionId = meta.metaId
+        importCommand =
+            "cd " <> remotePath
+                <> " && agent-cli sessions import --cwd " <> remotePath
+        sessionPath =
+            "\"$HOME/.haskell-agent/sessions/"
+                <> Text.unpack sessionId <> "\""
+        stagingPath =
+            "\"$HOME/.haskell-agent/tmp/afk-"
+                <> Text.unpack sessionId <> ".tar\""
+        uploadCommand =
+            "mkdir -p \"$HOME/.haskell-agent/tmp\""
+                <> " && cat > " <> stagingPath
+        startCommand =
+            "tar -C " <> sessionPath <> " -xf " <> stagingPath
+                <> " && rm -f " <> stagingPath
+                <> " && tmux new-session -d -s " <> quote (Text.unpack name)
+                <> " -c " <> remotePath
+                <> " agent-cli --resume " <> quote (Text.unpack sessionId)
+                <> " --cwd " <> remotePath
+    copyArtifacts host uploadCommand sessionDir >>= \case
+        Left err -> pure (Left err)
+        Right () ->
+            runSshInput host importCommand (Aeson.encode transfer) >>= \case
+                Left err -> pure (Left err)
+                Right _ ->
+                    fmap (\case
+                        Left err -> Left err
+                        Right _ -> Right
+                            ("session moved to " <> host <> " tmux " <> name
+                                <> "\nattach with: ssh -t " <> host
+                                <> " tmux attach -t " <> name))
+                        (runSshInput host startCommand mempty)
+
+runSshInput :: Text -> String -> LBS.ByteString -> IO (Either Text Text)
+runSshInput host remote inputBytes = do
+    attempted <- tryAny do
+        (Just input, Just output, Just errOutput, process) <-
+            createProcess (proc "ssh" [Text.unpack host, "sh", "-lc", quote remote])
+                { std_in = CreatePipe
+                , std_out = CreatePipe
+                , std_err = CreatePipe
+                }
+        LBS.hPut input inputBytes
+        hClose input
+        (out, err) <- concurrently
+            (LBS.hGetContents output)
+            (LBS.hGetContents errOutput)
+        code <- waitForProcess process
+        pure (code, out, err)
+    pure case attempted of
+        Left exception -> Left (Text.pack (show exception))
+        Right (ExitFailure _, _, err) ->
+            Left ("remote AFK handoff failed: " <> decode err)
+        Right (ExitSuccess, out, _) -> Right (Text.strip (decode out))
+
+copyArtifacts :: Text -> String -> OsPath -> IO (Either Text ())
+copyArtifacts host remote sessionDir = do
+    attempted <- tryAny do
+        (Nothing, Just archive, Just tarError, tarProcess) <-
+            createProcess
+                (proc "tar"
+                    [ "-C", unsafeToFilePath sessionDir
+                    , "--exclude=.agent-running.lock"
+                    , "--exclude=.agent-prompt-*"
+                    , "--exclude=.agent-ready-*"
+                    , "-cf", "-", "."
+                    ])
+                    { std_out = CreatePipe
+                    , std_err = CreatePipe
+                    }
+        (Nothing, Just sshOut, Just sshError, sshProcess) <-
+            createProcess
+                (proc "ssh" [Text.unpack host, "sh", "-lc", quote remote])
+                    { std_in = UseHandle archive
+                    , std_out = CreatePipe
+                    , std_err = CreatePipe
+                    }
+        hClose archive
+        ((tarErr, sshStdout), sshErr) <- concurrently
+            (concurrently
+                (LBS.hGetContents tarError)
+                (LBS.hGetContents sshOut))
+            (LBS.hGetContents sshError)
+        tarCode <- waitForProcess tarProcess
+        sshCode <- waitForProcess sshProcess
+        pure (tarCode, sshCode, tarErr, sshStdout, sshErr)
+    pure case attempted of
+        Left exception -> Left (Text.pack (show exception))
+        Right (ExitSuccess, ExitSuccess, _, _, _) -> Right ()
+        Right (tarCode, sshCode, tarErr, _, sshErr) ->
+            Left
+                ("remote AFK artifact transfer failed (tar "
+                    <> Text.pack (show tarCode) <> ", ssh "
+                    <> Text.pack (show sshCode) <> "): "
+                    <> Text.strip (decode (tarErr <> sshErr)))
+
+localExecutable :: IO FilePath
+localExecutable = do
+    lookupEnv "HASKELL_AGENT_EXECUTABLE" >>= \case
+        Just executable | not (null executable) -> pure executable
+        _ -> do
+            prog <- getProgName
+            executable <- getExecutablePath
+            pure $
+                if prog `elem` ["<interactive>", "ghc", "ghci"]
+                    then "agent-cli"
+                    else executable
+
+runChecked :: FilePath -> [String] -> Text -> IO (Either Text Text)
+runChecked command args success = do
+    attempted <- tryAny (readProcessWithExitCode command args "")
+    pure case attempted of
+        Left exception -> Left (Text.pack (show exception))
+        Right (ExitSuccess, _, _) -> Right success
+        Right (ExitFailure _, out, err) ->
+            Left (Text.strip (Text.pack (if null err then out else err)))
+
+tmuxName :: Text -> Text
+tmuxName sessionId =
+    "agent-" <> Text.take 40 (Text.map safe sessionId)
+  where
+    safe character
+        | isAlphaNum character || character `elem` ("-_" :: String) = character
+        | otherwise = '-'
+
+quote :: String -> String
+quote value = "'" <> concatMap escape value <> "'"
+  where
+    escape '\'' = "'\\''"
+    escape character = [character]
+
+remotePathWord :: Text -> String
+remotePathWord path =
+    case Text.stripPrefix "~/" path of
+        Just rest -> "\"$HOME\"/" <> quote (Text.unpack rest)
+        Nothing -> quote (Text.unpack path)
+
+decode :: LBS.ByteString -> Text
+decode = Text.decodeUtf8With (\_ _ -> Just '\xfffd') . LBS.toStrict

--- a/packages/agent-cli/src/Agent/CLI/Command.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command.hs
@@ -74,6 +74,8 @@ data ReplAction
     -- ^ Ask an isolated one-shot question over the current context.
     | ReplShowSession
     | ReplShowSessionInfo
+    | ReplAfk (Maybe Text)
+    -- ^ Hand the active session to tmux, optionally on @host:path@.
     | ReplWorktree
     | ReplRename Text
     | ReplRenameAuto
@@ -167,6 +169,7 @@ slashCommands =
     , cmd "btw" [] "/btw <QUESTION>" "Ask a side question without changing the conversation" True
     , cmd "session" [] "/session" "Print the current session id" False
     , cmd "session-info" ["status", "info"] "/session-info" "Show session details (model, tools, and context usage)" False
+    , cmd "afk" [] "/afk [HOST:PATH]" "Move this session into tmux, locally or over SSH" True
     , cmd "worktree" [] "/worktree" "Start a fresh session in a new git worktree" False
     , cmd "rename" ["title"] "/rename <TITLE>|--auto" "Rename the current session, or restore automatic titles" True
     , cmd "login" ["accounts"] "/login" "Manage provider credentials and usage" False
@@ -339,6 +342,10 @@ parseSlash catalog raw line = case Text.words line of
                 if null args
                     then ReplShowSessionInfo
                     else ReplCommandError "usage: /session-info"
+            "afk" -> case args of
+                [] -> ReplAfk Nothing
+                [target] -> ReplAfk (Just target)
+                _ -> ReplCommandError "usage: /afk [HOST:PATH]"
             "worktree" ->
                 if null args
                     then ReplWorktree

--- a/packages/agent-cli/src/Agent/CLI/Options.hs
+++ b/packages/agent-cli/src/Agent/CLI/Options.hs
@@ -30,6 +30,8 @@ data Command
     | Login
     | ListSessions
     | ShowSession Text
+    | WaitSession Text
+    | ImportSession (Maybe OsPath)
     | Storage StorageCommand
     | RunAgent CliOptions
     deriving (Eq, Show)
@@ -180,6 +182,10 @@ parseSessionsCommand = \case
     [] -> Right ListSessions
     ["list"] -> Right ListSessions
     ["show", sessionId] -> Right (ShowSession (Text.pack sessionId))
+    ["wait", sessionId] -> Right (WaitSession (Text.pack sessionId))
+    ["import"] -> Right (ImportSession Nothing)
+    ["import", "--cwd", cwd] ->
+        Right (ImportSession (Just (unsafeEncodeUtf cwd)))
     ["show"] -> Left "usage: agent-cli sessions show <session-id>"
     other ->
         Left ("unknown sessions command: " <> unwords other

--- a/packages/agent-cli/src/Agent/CLI/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session.hs
@@ -5,6 +5,7 @@ module Agent.CLI.Session
     , LegacySubagentTarget(..)
     , SessionTurn(..)
     , SessionActivity(..)
+    , SessionTransfer(..)
     , SessionCreate(..)
     , Persistence(..)
     , PersistenceState(..)
@@ -23,6 +24,7 @@ module Agent.CLI.Session
     , addSessionUsage
     , deleteSession
     , loadSession
+    , importSessionTransfer
     , loadSessionHandle
     , isValidSessionId
     , listSessions
@@ -145,6 +147,21 @@ data SessionMeta = SessionMeta
     , metaOutputTokens :: !Int
     , metaCachedTokens :: !Int
     } deriving (Eq, Show)
+
+data SessionTransfer = SessionTransfer
+    { transferMeta :: !SessionMeta
+    , transferTurns :: ![SessionTurn]
+    } deriving (Eq, Show)
+
+instance ToJSON SessionTransfer where
+    toJSON transfer = object
+        [ "meta" .= transfer.transferMeta
+        , "turns" .= transfer.transferTurns
+        ]
+
+instance FromJSON SessionTransfer where
+    parseJSON = withObject "SessionTransfer" \o ->
+        SessionTransfer <$> o .: "meta" <*> o .: "turns"
 
 -- | Durable provenance for subagent transcripts written before child target
 -- metadata was persisted. Keeping this target separate from the mutable root
@@ -718,6 +735,45 @@ loadSessionHandle pool root sessionId =
                         }
                     , turns
                     )
+
+-- | Import a transferred session under its existing id and optional cwd.
+importSessionTransfer
+    :: StorePool
+    -> OsPath
+    -> Maybe OsPath
+    -> SessionTransfer
+    -> IO (Either Text Text)
+importSessionTransfer pool root cwd transfer = runExceptT do
+    let sessionId = transfer.transferMeta.metaId
+    dir <- except (sessionDirForId root sessionId)
+    exists <- lift (doesDirectoryExist dir)
+    when exists (throwE ("session already exists: " <> sessionId))
+    lift (ensurePrivateDir root)
+    lift (createDirectory dir)
+    lift (setFileMode (unsafeToFilePath dir) 0o700)
+    _ <- lift (ensureSessionTemp root sessionId) >>= except
+    let meta = transfer.transferMeta
+            { metaCwd = fromMaybe transfer.transferMeta.metaCwd cwd }
+        bytes = Aeson.encode (SessionTransfer meta transfer.transferTurns)
+        legacy = Store.LegacySession
+            { legacySourcePath = "afk:" <> transfer.transferMeta.metaId
+            , legacyContentHash = contentFingerprint bytes
+            , legacyMetadata = toStoredMetadata meta
+            , legacyTurns = map toStoredTurn transfer.transferTurns
+            }
+    lift (Store.importLegacySession pool legacy) >>= \case
+        Left err -> do
+            lift (cleanupTransfer dir sessionId)
+            throwE (renderStoreError err)
+        Right False -> do
+            lift (cleanupTransfer dir sessionId)
+            throwE ("session already exists: " <> sessionId)
+        Right True -> pure sessionId
+  where
+    cleanupTransfer dir sessionId = do
+        _ <- tryIO (removePathForcibly dir)
+        _ <- removeSessionTemp root sessionId
+        pure ()
 
 deleteSession :: StorePool -> OsPath -> Text -> IO (Either Text ())
 deleteSession pool root sessionId = runExceptT do

--- a/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
@@ -1,6 +1,7 @@
 module Agent.CLI.CommandSpec (spec) where
 
 import Agent.CLI.Command
+import Agent.CLI.Afk
 import Agent.Dialect (DialectId(..))
 import Agent.Responses.Types
 import qualified Data.Aeson.KeyMap as KeyMap
@@ -87,6 +88,13 @@ spec = do
             parseReplLine "/info" `shouldBe` ReplShowSessionInfo
             parseReplLine "/status now"
                 `shouldBe` ReplCommandError "usage: /session-info"
+
+        it "hands the session to local or remote tmux" do
+            parseReplLine "/afk" `shouldBe` ReplAfk Nothing
+            parseReplLine "/afk office-builder:~/haskell-agent"
+                `shouldBe` ReplAfk (Just "office-builder:~/haskell-agent")
+            parseReplLine "/afk one two"
+                `shouldBe` ReplCommandError "usage: /afk [HOST:PATH]"
 
         it "starts a fresh session in a new worktree" do
             parseReplLine "/worktree" `shouldBe` ReplWorktree
@@ -229,8 +237,19 @@ spec = do
                     "usage: /effort [none|low|medium|high|xhigh|max]"
             parseReplLine "/bogus"
                 `shouldBe` ReplCommandError "unknown command: /bogus (try /help)"
-            parseReplLine "/"
-                `shouldBe` ReplCommandError "unknown command: / (try /help)"
+
+    describe "parseAfkTarget" do
+        it "selects local tmux without an argument" do
+            parseAfkTarget Nothing `shouldBe` Right AfkLocal
+
+        it "parses an SSH host and remote folder" do
+            parseAfkTarget (Just "office-builder:~/haskell-agent")
+                `shouldBe` Right
+                    (AfkRemote "office-builder" "~/haskell-agent")
+
+        it "rejects incomplete remote targets" do
+            parseAfkTarget (Just "office-builder")
+                `shouldBe` Left "remote AFK target must be HOST:PATH"
 
     describe "slashCommands" do
         it "contains every static slash spec, including gated commands" do
@@ -244,6 +263,7 @@ spec = do
                     , "btw"
                     , "session"
                     , "session-info"
+                    , "afk"
                     , "worktree"
                     , "rename"
                     , "login"

--- a/packages/agent-cli/test/Agent/CLI/OptionsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/OptionsSpec.hs
@@ -106,11 +106,18 @@ spec = do
             parseArgs ["login", "openai"] `shouldSatisfy` isLeft
 
 
-        it "parses sessions list and show" do
+        it "parses session administration commands" do
             parseArgs ["sessions"] `shouldBe` Right ListSessions
             parseArgs ["sessions", "list"] `shouldBe` Right ListSessions
             parseArgs ["sessions", "show", "2026-08-19-abcd1234"]
                 `shouldBe` Right (ShowSession "2026-08-19-abcd1234")
+            parseArgs ["sessions", "wait", "2026-08-19-abcd1234"]
+                `shouldBe` Right (WaitSession "2026-08-19-abcd1234")
+            parseArgs ["sessions", "import"]
+                `shouldBe` Right (ImportSession Nothing)
+            parseArgs ["sessions", "import", "--cwd", "/srv/project"]
+                `shouldBe` Right
+                    (ImportSession (Just (unsafeEncodeUtf "/srv/project")))
 
         it "parses storage administration commands" do
             parseArgs ["storage", "status"]


### PR DESCRIPTION
## Summary

- add `/afk` to stop the foreground agent and resume the same persisted session in a detached local tmux
- add `/afk HOST:PATH` to transfer the conversation and session artifacts over SSH, then resume it in a remote tmux at the requested working directory
- wait for the local session lock before resuming, preserve the session ID remotely, and print attach commands
- add internal session wait/import commands plus transfer serialization

## Remote requirements

The target host needs SSH authentication configured and `agent-cli`, `tmux`, and `tar` available. The requested project directory must already exist, and the session ID must not already exist on that host.

## Validation

- loaded `agent-cli:lib:agent-cli` successfully in GHCi
- ran focused `CommandSpec` and `OptionsSpec`: 84 examples, 0 failures
- exercised `/help afk` through the live fullscreen agent in a real tmux TTY
- smoke-tested local handoff with a real detached tmux and verified the resumed argv
- integration-smoked the remote upload/import/artifact/start sequence with a fake SSH endpoint, including `~/` expansion and artifact extraction
- `git diff --check`
