### PR TITLE
fix(gateway): ignore atomic-write temp files

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/GatewayBridge.hs
+++ b/packages/agent-cli/src/Agent/CLI/GatewayBridge.hs
@@ -9,6 +9,7 @@ module Agent.CLI.GatewayBridge
     , managedBridgeRequestsDirectory
     , managedBridgeResponsesDirectory
     , managedBridgeActivityPath
+    , isManagedBridgeRequestFile
     , writeManagedBridgeResponse
     , writeManagedBridgeResponseAt
     ) where
@@ -59,6 +60,7 @@ import System.Directory
     , doesFileExist
     , removeFile
     )
+import System.FilePath (takeExtension)
 import System.OsPath (OsPath, unsafeEncodeUtf, (</>))
 import System.Posix.Files (setFileMode)
 import System.Posix.Process (getProcessID)
@@ -438,6 +440,12 @@ managedBridgeResponsesDirectory request =
 managedBridgeActivityPath :: ManagedTurnRequest -> OsPath
 managedBridgeActivityPath request =
     bridgeRoot request </> unsafeEncodeUtf "activity.json"
+
+-- | Whether a directory entry is a fully published bridge request.
+-- Atomic writers expose their unique @.tmp@ file before renaming it, so
+-- request-directory consumers must not attempt to open every entry they see.
+isManagedBridgeRequestFile :: FilePath -> Bool
+isManagedBridgeRequestFile path = takeExtension path == ".json"
 
 bridgeRoot :: ManagedTurnRequest -> OsPath
 bridgeRoot request =

--- a/packages/agent-cli/src/Agent/Telegram/Bridge.hs
+++ b/packages/agent-cli/src/Agent/Telegram/Bridge.hs
@@ -9,6 +9,7 @@ import Agent.CLI.GatewayBridge
     ( ManagedActivity(..)
     , ManagedBridgeRequest(..)
     , ManagedBridgeResponse(..)
+    , isManagedBridgeRequestFile
     , managedBridgeActivityPath
     , managedBridgeRequestsDirectory
     , writeManagedBridgeResponse
@@ -129,7 +130,13 @@ processBridgeRequests env seenRef = do
         Left _ -> pure []
         Right values -> pure values
     seen <- readIORef seenRef
-    forM_ (filter (`Set.notMember` seen) files) \name -> do
+    forM_
+        (filter
+            (\name ->
+                isManagedBridgeRequestFile name
+                    && Set.notMember name seen)
+            files)
+        \name -> do
         let path = directory <> "/" <> name
         decodeBridgeRequest path >>= \case
             Nothing -> pure ()

--- a/packages/agent-cli/test/Agent/CLI/GatewayBridgeSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/GatewayBridgeSpec.hs
@@ -29,6 +29,11 @@ import Test.Hspec
 
 spec :: Spec
 spec = describe "Agent.CLI.GatewayBridge" do
+    it "recognizes only fully published request files" do
+        isManagedBridgeRequestFile "call-1.json" `shouldBe` True
+        isManagedBridgeRequestFile "call-1.json123.tmp" `shouldBe` False
+        isManagedBridgeRequestFile "call-1.tmp" `shouldBe` False
+
     it "round-trips a channel tool request through private files" $
         withBridgeRequest \request -> do
             let call = functionToolCall
@@ -113,7 +118,7 @@ waitForBridgeRequest request = go (100 :: Int)
     go 0 = expectationFailure "timed out waiting for bridge request" >> fail "timeout"
     go attempts = do
         files <- listDirectory directory
-        case listToMaybe files of
+        case listToMaybe (filter isManagedBridgeRequestFile files) of
             Nothing -> threadDelay 20_000 >> go (attempts - 1)
             Just name -> do
                 bytes <- LBS.readFile (directory </> name)


### PR DESCRIPTION
## Summary
- recognize only final `.json` files as published gateway bridge requests
- ignore atomic writer `.tmp` entries in the Telegram bridge request loop
- make the GatewayBridge test poller follow the same publication rule

## Why
`writeLazyFileAtomically` creates a visible temporary file before renaming it. Directory readers could observe and open that file while the writer still held it, causing the repeated `ResourceBusy` failures seen in CI on PRs #433 and #434.

## Validation
- focused GatewayBridge Hspec: 4 examples, 0 failures
- parallel stress: 25/25 runs passed with 4 Hspec workers
- `nix flake check`: all checks passed
