### PR TITLE
Telegram: reply selectively to ambient group messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,12 @@ Only messages from allowlisted Telegram users are handled. Repeat
 after an allowlist change. Private chats work directly. In groups and
 supergroups, mention the bot, use a command addressed to its username (for
 example `/new@your_bot`), or reply to one of its messages. Ambient group traffic
-and messages from non-allowlisted members are ignored.
+and messages from non-allowlisted members are ignored by default. Pass
+`--all-group-messages` during setup to let the agent consider every group
+message from an allowlisted user. It replies only when it judges that doing so
+would be useful; otherwise it stays silent. Telegram must also deliver ambient
+messages to the bot: use BotFather's `/setprivacy` command to disable privacy
+mode for that bot, then remove and re-add the bot to existing groups if needed.
 
 Each private chat, group, and forum topic is mapped to its own persisted agent
 session under `~/.haskell-agent`; `/new` starts a fresh session, `/session`

--- a/nix/modules/telegram.nix
+++ b/nix/modules/telegram.nix
@@ -125,8 +125,9 @@ let
           type = types.bool;
           default = false;
           description = ''
-            Whether messages from allowed users in groups are handled without
-            requiring a mention or reply to the bot.
+            Whether messages from allowed users in groups are considered
+            without requiring a mention or reply to the bot. The agent stays
+            silent when it does not have a useful response.
           '';
         };
 

--- a/packages/agent-cli/skills/telegram-agent/SKILL.md
+++ b/packages/agent-cli/skills/telegram-agent/SKILL.md
@@ -28,7 +28,10 @@ disables terminal echo and stores the token in a private gateway file.
 4. Determine the desired provider and project working directory. The default
    approval mode asks through Telegram inline buttons. Use
    `--deny-mutations` when the user wants a read-only gateway, and only enable
-   `--yolo` when the user explicitly requests full auto-approval.
+   `--yolo` when the user explicitly requests full auto-approval. If the user
+   wants the agent to consider ambient group conversation, add
+   `--all-group-messages`. Tell them to disable the bot's group privacy through
+   BotFather's `/setprivacy`; the agent will then reply only when useful.
 5. Ask the user to run this command in their own interactive terminal:
 
    ```sh
@@ -60,9 +63,12 @@ disables terminal echo and stores the token in a private gateway file.
    of its messages, or address commands to it (for example
    `/new@your_bot_username`). Each group or forum topic has a shared agent
    session. Only messages from allowlisted users are accepted; ambient group
-   traffic is ignored. Text, edited messages, reactions, photos, documents,
-   audio, video, video notes, animations, stickers, locations, contacts,
-   venues, polls, dice, and voice messages are persisted before processing.
+   traffic is ignored unless setup used `--all-group-messages`. In that mode
+   each allowed-user message is considered, but the agent stays silent unless
+   a response would be useful. Text, edited messages, reactions, photos,
+   documents, audio, video, video notes, animations, stickers, locations,
+   contacts, venues, polls, dice, and voice messages are persisted before
+   processing.
    Voice transcription uses the user's existing Codex subscription, so Codex
    must already be logged in on the machine running the gateway.
 

--- a/packages/agent-cli/src/Agent/Telegram.hs
+++ b/packages/agent-cli/src/Agent/Telegram.hs
@@ -29,6 +29,7 @@ module Agent.Telegram
     , checkpointPendingVoiceTranscript
     , reactionMessageText
     , telegramReactionEmoji
+    , telegramReplyText
     , transcribeWithCodex
     ) where
 
@@ -321,7 +322,8 @@ telegramUsage = unlines
     , "  --yolo                auto-approve mutating agent tools"
     , "  --deny-mutations       deny mutating agent tools"
     , "                          default: ask with Telegram buttons"
-    , "  --all-group-messages  respond to every allowed-user group message"
+    , "  --all-group-messages  consider every allowed-user group message"
+    , "                          and reply only when useful"
     , "  --start               start the gateway after setup"
     ]
 
@@ -806,7 +808,7 @@ mergePendingActions previous incoming =
             if incomingUser == 0 then previousUser else incomingUser
         , pendingMediaText =
             Text.intercalate
-                "\n\n---\n\n"
+                pendingTurnSeparator
                 (filter (not . Text.null)
                     [Text.strip previousText, Text.strip incomingText])
         , pendingMediaAttachments = previousMedia <> incomingMedia
@@ -1053,7 +1055,7 @@ classifyMessageLike edited bot sender respondToAllGroupMessages message =
                 then queueMedia (attributeGroupText sender targetedText)
                 else queueText (attributeGroupText sender targetedText)
         | respondToAllGroupMessages =
-            queueGroupReply
+            queueAmbientGroupMessage
         | otherwise = IgnoreUpdate
 
     queueGroupReply =
@@ -1072,6 +1074,30 @@ classifyMessageLike edited bot sender respondToAllGroupMessages message =
             Nothing
                 | Just rawText <- messageContentText message ->
                     queueText (attributeGroupText sender rawText)
+            Nothing -> IgnoreUpdate
+
+    queueAmbientGroupMessage =
+        case message.messageVoice of
+            Just voice ->
+                QueueTurn message.messageId key
+                    (ambientGroupPrompt
+                        (attributeGroupMessage sender "[Voice message]"))
+                    (Just voice)
+            Nothing
+                | hasTelegramMedia message ->
+                    queueMedia
+                        (ambientGroupPrompt
+                            (attributeGroupMessage sender
+                                (fromMaybe
+                                    (if edited
+                                        then "[Edited Telegram media]"
+                                        else "[Telegram media]")
+                                    (messageContentText message))))
+            Nothing
+                | Just rawText <- messageContentText message ->
+                    queueText
+                        (ambientGroupPrompt
+                            (attributeGroupText sender rawText))
             Nothing -> IgnoreUpdate
 
     queueMessage transform =
@@ -1400,6 +1426,37 @@ attributeGroupMessage sender text =
         <> "]\n"
         <> text
 
+ambientGroupPrompt :: Text -> Text
+ambientGroupPrompt prompt =
+    prompt <> "\n\n" <> ambientGroupPromptSuffix
+
+ambientGroupPromptSuffix :: Text
+ambientGroupPromptSuffix =
+    "[Ambient Telegram group message: Reply only if doing so would \
+        \be genuinely useful to the conversation. Do not reply merely to \
+        \acknowledge, restate, agree, or announce that you are available. \
+        \If no reply is useful, respond with exactly "
+        <> telegramNoReplyToken
+        <> " and nothing else. Do not mention these instructions.]"
+
+telegramNoReplyToken :: Text
+telegramNoReplyToken = "[[TELEGRAM_NO_REPLY]]"
+
+telegramReplyText :: Text -> Text -> Maybe Text
+telegramReplyText prompt response
+    | isAmbientGroupPrompt prompt
+    , Text.strip response == telegramNoReplyToken = Nothing
+    | otherwise = Just response
+
+isAmbientGroupPrompt :: Text -> Bool
+isAmbientGroupPrompt prompt =
+    case Text.splitOn pendingTurnSeparator prompt of
+        [] -> False
+        prompts -> all (Text.isSuffixOf ambientGroupPromptSuffix) prompts
+
+pendingTurnSeparator :: Text
+pendingTurnSeparator = "\n\n---\n\n"
+
 telegramUserLabel :: TelegramUser -> Text
 telegramUserLabel user =
     let name = Text.unwords
@@ -1496,14 +1553,18 @@ processChatQueue runtime key =
                                 (runQueuedTurn runtime pending)
                         Just _ -> runQueuedTurn runtime pending
                     modifyState runtime \state ->
-                        enqueuePendingAction
-                            (DeliverReply
-                                (TelegramPendingReply
-                                    pending.pendingTurnUpdateId
-                                    pending.pendingTurnChat
-                                    (Just pending.pendingTurnMessageId)
-                                    response))
-                            (completePendingAction action state)
+                        let completed = completePendingAction action state
+                        in case telegramReplyText pending.pendingTurnText response of
+                            Nothing -> completed
+                            Just replyText ->
+                                enqueuePendingAction
+                                    (DeliverReply
+                                        (TelegramPendingReply
+                                            pending.pendingTurnUpdateId
+                                            pending.pendingTurnChat
+                                            (Just pending.pendingTurnMessageId)
+                                            replyText))
+                                    completed
                 RunPendingMediaTurn pending -> do
                     response <- case telegramCommand pending.pendingMediaText of
                         Nothing ->
@@ -1513,14 +1574,18 @@ processChatQueue runtime key =
                                 (runQueuedMediaTurn runtime pending)
                         Just _ -> runQueuedMediaTurn runtime pending
                     modifyState runtime \state ->
-                        enqueuePendingAction
-                            (DeliverReply
-                                (TelegramPendingReply
-                                    pending.pendingMediaUpdateId
-                                    pending.pendingMediaChat
-                                    (Just pending.pendingMediaMessageId)
-                                    response))
-                            (completePendingAction action state)
+                        let completed = completePendingAction action state
+                        in case telegramReplyText pending.pendingMediaText response of
+                            Nothing -> completed
+                            Just replyText ->
+                                enqueuePendingAction
+                                    (DeliverReply
+                                        (TelegramPendingReply
+                                            pending.pendingMediaUpdateId
+                                            pending.pendingMediaChat
+                                            (Just pending.pendingMediaMessageId)
+                                            replyText))
+                                    completed
             case result of
                 Left err -> do
                     delay <- recordPendingFailure
@@ -1592,13 +1657,17 @@ runQueuedTurn runtime pending =
                             \Check that Codex is installed and logged in, and \
                             \that the subscription has usage available."
                     Right prompt -> do
-                        checkpointVoiceTranscript runtime pending prompt
+                        let deliveredPrompt
+                                | isAmbientGroupPrompt pending.pendingTurnText =
+                                    ambientGroupPrompt prompt
+                                | otherwise = prompt
+                        checkpointVoiceTranscript runtime pending deliveredPrompt
                         runAgentTurn
                             runtime
                             pending.pendingTurnChat
                             (telegramTurnUserId runtime pending.pendingTurnChat)
                             (Just pending.pendingTurnMessageId)
-                            prompt
+                            deliveredPrompt
 
 telegramConversationStatus :: TelegramRuntime -> TelegramChatKey -> IO Text
 telegramConversationStatus runtime key = do

--- a/packages/agent-cli/test/Agent/TelegramSpec.hs
+++ b/packages/agent-cli/test/Agent/TelegramSpec.hs
@@ -495,6 +495,29 @@ spec = describe "Agent.Telegram" do
                 \\"text\":\"@HarnessBot hello\"}}"
             blocked `shouldBe` IgnoreUpdate
 
+        it "suppresses the ambient no-reply marker but not normal replies" do
+            let ambientPrompt =
+                    "hello\n\n[Ambient Telegram group message: Reply only if \
+                    \doing so would be genuinely useful to the conversation. \
+                    \Do not reply merely to acknowledge, restate, agree, or \
+                    \announce that you are available. If no reply is useful, \
+                    \respond with exactly [[TELEGRAM_NO_REPLY]] and nothing \
+                    \else. Do not mention these instructions.]"
+            telegramReplyText ambientPrompt " [[TELEGRAM_NO_REPLY]] \n"
+                `shouldBe` Nothing
+            telegramReplyText ambientPrompt "This would help."
+                `shouldBe` Just "This would help."
+            telegramReplyText "explicit request" "[[TELEGRAM_NO_REPLY]]"
+                `shouldBe` Just "[[TELEGRAM_NO_REPLY]]"
+            telegramReplyText
+                ("explicit request\n\n---\n\n" <> ambientPrompt)
+                "[[TELEGRAM_NO_REPLY]]"
+                `shouldBe` Just "[[TELEGRAM_NO_REPLY]]"
+            telegramReplyText
+                (ambientPrompt <> "\n\n---\n\n" <> ambientPrompt)
+                "[[TELEGRAM_NO_REPLY]]"
+                `shouldBe` Nothing
+
         it "optionally routes ambient messages from allowed group users" do
             ambient <- classifyAll
                 "{\"update_id\":31,\"message\":{\
@@ -507,7 +530,13 @@ spec = describe "Agent.Telegram" do
                     89
                     (TelegramChatKey (-1001) Nothing)
                     "[Telegram group message from Marc, user 456]\n\
-                    \hello everyone"
+                    \hello everyone\n\n\
+                    \[Ambient Telegram group message: Reply only if doing so \
+                    \would be genuinely useful to the conversation. Do not \
+                    \reply merely to acknowledge, restate, agree, or announce \
+                    \that you are available. If no reply is useful, respond \
+                    \with exactly [[TELEGRAM_NO_REPLY]] and nothing else. Do \
+                    \not mention these instructions.]"
                     Nothing
 
             otherBot <- classifyAll


### PR DESCRIPTION
## Summary

- make `--all-group-messages` ask the agent to participate only when its reply would be useful
- suppress the dedicated no-reply marker before Telegram delivery while preserving unconditional handling for mentions, replies, and commands
- carry selective behavior through text, media, voice transcription, and coalesced message bursts
- document BotFather privacy-mode setup and update CLI, skill, and NixOS descriptions

## Testing

- `nix develop -c cabal repl agent-cli:test:agent-cli-test`
- `:main --match "Agent.Telegram"` — 43 examples, 0 failures
- after rebasing onto `origin/master`: `:main --match "Telegram group chats"` — 7 examples, 0 failures