### PR TITLE
Keep the agent loop running after tool preparation errors

### DIFF
--- a/packages/agent-core/src/Agent/Loop.hs
+++ b/packages/agent-core/src/Agent/Loop.hs
@@ -829,8 +829,17 @@ schedulingPlanForPrepared config (PreparedToolCall call approval) =
 -- is prepared serially even when the resulting handlers may run concurrently.
 prepareToolCall :: LoopConfig -> ToolCall -> IO PreparedToolCall
 prepareToolCall config call = do
-    approval <- config.loopApprove call
-    pure (PreparedToolCall call (normalizeApproval approval))
+    approval <- tryAny (config.loopApprove call)
+    pure $
+        PreparedToolCall call $
+            case approval of
+                Left exception ->
+                    ToolApprovalDenied
+                        ("Tool " <> call.name
+                            <> " could not be prepared: "
+                            <> exceptionSummary exception)
+                Right decision ->
+                    normalizeApproval decision
   where
     normalizeApproval = \case
         Left denial -> ToolApprovalDenied denial

--- a/packages/agent-core/test/Agent/LoopSpec.hs
+++ b/packages/agent-core/test/Agent/LoopSpec.hs
@@ -838,6 +838,38 @@ spec = describe "runLoop" do
                 crashed.output `shouldSatisfy` Text.isInfixOf "crashed"
             other -> expectationFailure ("unexpected submissions: " <> show other)
 
+    it "keeps looping after a handler returns a validation error" do
+        submissions <- newIORef []
+        backend <- scriptedBackend submissions
+            [ Right $ emptyTurnOutput "resp-1"
+                [functionToolCall "c1" "shell_command"
+                    "{\"timeout_ms\":1000,\"yield_time_ms\":1000}"]
+                Nothing
+            , Right $ emptyTurnOutput "resp-2" [] (Just "retried")
+            ]
+        let handlers =
+                [ noArgsTool "shell_command" $
+                    pure (Left
+                        "timeout_ms and yield_time_ms are mutually exclusive")
+                ]
+        config0 <- testConfig backend
+        result <- runLoop
+            config0 { loopTools = registryFromHandlers handlers }
+            Nothing
+            "go"
+        result `shouldBe` Right LoopResult
+            { finalResponseId = "resp-2"
+            , finalText = Just "retried"
+            , turnsUsed = 2
+            , tokenUsage = emptyTokenUsage
+            }
+        seen <- readIORef submissions
+        case seen of
+            [_, (Just "resp-1", [CompletedTool failed])] ->
+                failed.output `shouldBe`
+                    "Error: timeout_ms and yield_time_ms are mutually exclusive"
+            other -> expectationFailure ("unexpected submissions: " <> show other)
+
     it "surfaces a transport Left as LoopTransport" do
         submissions <- newIORef []
         backend <- scriptedBackend submissions
@@ -957,7 +989,34 @@ spec = describe "runLoop" do
         result `shouldBe`
             Left (LoopUnexpected "user error (backend exploded)")
 
-    it "turns synchronous approval exceptions into a failed turn" do
+    it "keeps looping after a synchronous approval exception" do
+        submissions <- newIORef []
+        backend <- scriptedBackend submissions
+            [ Right $ emptyTurnOutput "resp-1"
+                [functionToolCall "c1" "echo" "{\"message\":\"hi\"}"]
+                Nothing
+            , Right $ emptyTurnOutput "resp-2" [] (Just "recovered")
+            ]
+        config0 <- testConfig backend
+        let config = config0
+                { loopApprove = \_ ->
+                    Exception.throwIO (userError "approval exploded")
+                }
+        result <- runLoop config Nothing "hello"
+        result `shouldBe` Right LoopResult
+            { finalResponseId = "resp-2"
+            , finalText = Just "recovered"
+            , turnsUsed = 2
+            , tokenUsage = emptyTokenUsage
+            }
+        seen <- readIORef submissions
+        case seen of
+            [_, (Just "resp-1", [CompletedTool failed])] ->
+                failed.output `shouldBe`
+                    "Tool echo could not be prepared: user error (approval exploded)"
+            other -> expectationFailure ("unexpected submissions: " <> show other)
+
+    it "does not turn asynchronous approval cancellation into tool output" do
         submissions <- newIORef []
         backend <- scriptedBackend submissions
             [ Right $ emptyTurnOutput "resp-1"
@@ -967,11 +1026,10 @@ spec = describe "runLoop" do
         config0 <- testConfig backend
         let config = config0
                 { loopApprove = \_ ->
-                    Exception.throwIO (userError "approval exploded")
+                    Exception.throwIO Exception.ThreadKilled
                 }
-        result <- runLoop config Nothing "hello"
-        result `shouldBe`
-            Left (LoopUnexpected "user error (approval exploded)")
+        runLoop config Nothing "hello"
+            `shouldThrow` (== Exception.ThreadKilled)
 
     it "does not turn asynchronous backend cancellation into a failed turn" do
         config <- testConfig $ Backend \_state _prev _inputs _onEvent ->


### PR DESCRIPTION
## Summary

- convert synchronous tool approval/preparation exceptions into in-band tool results
- continue the model event loop after recoverable validation failures
- preserve asynchronous cancellation instead of turning it into tool output
- add regressions for mutually exclusive shell arguments and approval failures

## Verification

- `nix develop -c cabal test --offline agent-core:test:agent-core-test`
- 326 examples, 0 failures
- `git diff --check`