### PR TITLE
feat(tools): schedule calls by structured resources

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Database.hs
+++ b/packages/agent-cli/src/Agent/CLI/Database.hs
@@ -10,11 +10,22 @@ module Agent.CLI.Database
     ) where
 
 import Agent.ToolDSL (PropertySchema(..), PropertyType(..))
-import Agent.ToolDispatch (typedTool)
+import Agent.ToolDispatch
+    ( ToolCall (..)
+    , decodeToolArguments
+    , toolArgumentsValue
+    , typedTool
+    )
+import Agent.Tools.Scheduling
+    ( ToolAccess(..)
+    , ToolResource(..)
+    , ToolResourceClaim(..)
+    )
 import Agent.Tools.Types
     ( AppTool
     , ToolExecutionPolicy(..)
     , jsonTool
+    , withToolResourceClaims
     )
 import Data.Aeson
     ( FromJSON(..)
@@ -63,18 +74,13 @@ data DatabaseToolsEnv = DatabaseToolsEnv
         :: !(Text -> Int -> IO (Either Text Value))
     }
 
-data SchemaArgs = SchemaArgs
-    { schemaScope :: !DatabaseScope
-    }
+newtype SchemaArgs = SchemaArgs DatabaseScope
 
 instance FromJSON SchemaArgs where
     parseJSON = withObject "SchemaArgs" \object ->
         SchemaArgs <$> object .: "scope"
 
-data QueryArgs = QueryArgs
-    { queryScope :: !DatabaseScope
-    , querySql :: !Text
-    }
+data QueryArgs = QueryArgs !DatabaseScope !Text
 
 instance FromJSON QueryArgs where
     parseJSON = withObject "QueryArgs" \object ->
@@ -82,11 +88,7 @@ instance FromJSON QueryArgs where
             <$> object .: "scope"
             <*> object .: "sql"
 
-data ExecuteArgs = ExecuteArgs
-    { executeScope :: !DatabaseScope
-    , executeSql :: !Text
-    , executePurpose :: !Text
-    }
+data ExecuteArgs = ExecuteArgs !DatabaseScope !Text !Text
 
 instance FromJSON ExecuteArgs where
     parseJSON = withObject "ExecuteArgs" \object ->
@@ -95,10 +97,7 @@ instance FromJSON ExecuteArgs where
             <*> object .: "sql"
             <*> object .: "purpose"
 
-data ConversationSearchArgs = ConversationSearchArgs
-    { conversationSearchQuery :: !Text
-    , conversationSearchLimit :: !Int
-    }
+data ConversationSearchArgs = ConversationSearchArgs !Text !Int
 
 instance FromJSON ConversationSearchArgs where
     parseJSON = withObject "ConversationSearchArgs" \object ->
@@ -115,7 +114,9 @@ databaseTools env =
     ]
 
 schemaTool :: DatabaseToolsEnv -> AppTool
-schemaTool env = jsonTool
+schemaTool env =
+    withToolResourceClaims (schemaClaims ToolRead) $
+    jsonTool
     "database_schema"
     ( "Inspect the user-defined PostgreSQL tables visible in one durable "
         <> "scope. Returns tables, columns, keys, constraints, indexes, and "
@@ -129,7 +130,9 @@ schemaTool env = jsonTool
         encodeResult <$> env.databaseDescribeScope scope)
 
 queryTool :: DatabaseToolsEnv -> AppTool
-queryTool env = jsonTool
+queryTool env =
+    withToolResourceClaims (queryClaims ToolRead) $
+    jsonTool
     "database_query"
     ( "Run one read-only PostgreSQL query against user-defined tables in one "
         <> "durable scope. The database enforces a read-only transaction, "
@@ -149,7 +152,9 @@ queryTool env = jsonTool
                 <$> env.databaseRunQuery scope sql)
 
 executeTool :: DatabaseToolsEnv -> AppTool
-executeTool env = jsonTool
+executeTool env =
+    withToolResourceClaims (executeClaims ToolWrite) $
+    jsonTool
     "database_execute"
     ( "Execute a transactional PostgreSQL DDL/DML batch against user-defined "
         <> "tables in one durable scope. Use this to create or alter structured "
@@ -180,7 +185,9 @@ executeTool env = jsonTool
                         sql)
 
 conversationSearchTool :: DatabaseToolsEnv -> AppTool
-conversationSearchTool env = jsonTool
+conversationSearchTool env =
+    withToolResourceClaims (const (pure (Right conversationClaims))) $
+    jsonTool
     "conversation_search"
     ( "Search user and assistant messages from past, non-deleted conversations. "
         <> "Use this when earlier decisions, preferences, facts, or work may be "
@@ -209,6 +216,55 @@ scopeProperty = PropertySchema
         ( "Durable data scope: user for cross-project personal data, repository "
             <> "for data shared by clones/worktrees, or checkout for this worktree."
         ))
+
+schemaClaims
+    :: ToolAccess
+    -> ToolCall
+    -> IO (Either Text [ToolResourceClaim])
+schemaClaims access call =
+    pure $ do
+        SchemaArgs scope <-
+            decodeToolArguments (toolArgumentsValue call.arguments)
+                :: Either Text SchemaArgs
+        pureScopeClaim access scope
+
+queryClaims
+    :: ToolAccess
+    -> ToolCall
+    -> IO (Either Text [ToolResourceClaim])
+queryClaims access call =
+    pure $ do
+        QueryArgs scope _ <-
+            decodeToolArguments (toolArgumentsValue call.arguments)
+                :: Either Text QueryArgs
+        pureScopeClaim access scope
+
+executeClaims
+    :: ToolAccess
+    -> ToolCall
+    -> IO (Either Text [ToolResourceClaim])
+executeClaims access call =
+    pure $ do
+        ExecuteArgs scope _ _ <-
+            decodeToolArguments (toolArgumentsValue call.arguments)
+                :: Either Text ExecuteArgs
+        pureScopeClaim access scope
+
+pureScopeClaim :: ToolAccess -> DatabaseScope -> Either Text [ToolResourceClaim]
+pureScopeClaim access scope =
+    Right
+        [ ToolResourceClaim access
+            (ToolNamedResource ("database-scope:" <> scopeName scope)) ]
+
+conversationClaims :: [ToolResourceClaim]
+conversationClaims =
+    [ToolResourceClaim ToolRead (ToolNamedResource "conversation-store")]
+
+scopeName :: DatabaseScope -> Text
+scopeName = \case
+    DatabaseUserScope -> "user"
+    DatabaseRepositoryScope -> "repository"
+    DatabaseCheckoutScope -> "checkout"
 
 encodeResult :: Either Text Value -> Either Text Text
 encodeResult =

--- a/packages/agent-cli/src/Agent/CLI/GatewayBridge.hs
+++ b/packages/agent-cli/src/Agent/CLI/GatewayBridge.hs
@@ -16,7 +16,7 @@ module Agent.CLI.GatewayBridge
 import Agent.CLI.ManagedTurn (ManagedTurnRequest(..))
 import Agent.CLI.Permission (PermissionChoice(..))
 import Agent.FileRetry (retryOnFileBusy, writeLazyFileAtomically)
-import Agent.Loop (LoopEvent(..))
+import Agent.Loop (LoopEvent(..), ToolSchedulingSnapshot(..))
 import Agent.OsPath (unsafeToFilePath)
 import Agent.ToolArgs (objectArgs, optInt, optText, reqText)
 import Agent.ToolDSL (PropertySchema(..), PropertyType(..))
@@ -316,6 +316,8 @@ publishManagedLoopEvent request event =
         WarningRaised message -> ("warning", nonEmpty "Warning" message)
         ResponseRestarted _ -> ("retrying", "Retrying response…")
         ToolStarted call -> ("tool", "Running " <> call.name <> "…")
+        ToolSchedulingUpdated snapshot ->
+            ("tool", schedulingActivity snapshot)
         ToolOutputUpdated name _ -> ("tool", "Running " <> name <> "…")
         ToolFinished _ -> ("thinking", "Thinking…")
         TurnFinished _ -> ("finished", "Finishing…")
@@ -323,6 +325,16 @@ publishManagedLoopEvent request event =
     nonEmpty fallback value
         | Text.null (Text.strip value) = fallback
         | otherwise = Text.strip value
+
+    schedulingActivity :: ToolSchedulingSnapshot -> Text
+    schedulingActivity snapshot =
+        let running = length snapshot.schedulingReadyCallIds
+            queued = length snapshot.schedulingBlockedCallIds
+        in "Running " <> Text.pack (show running) <> " tool"
+            <> if running == 1 then "" else "s"
+            <> if queued == 0
+                then ""
+                else "; " <> Text.pack (show queued) <> " queued"
 
 writeManagedBridgeResponse
     :: ManagedTurnRequest

--- a/packages/agent-cli/src/Agent/CLI/Render.hs
+++ b/packages/agent-cli/src/Agent/CLI/Render.hs
@@ -75,7 +75,12 @@ import Agent.CLI.Style
     , motionGlyphSet
     , style
     )
-import Agent.Loop (LoopError(..), LoopEvent(..), TurnOutput(..))
+import Agent.Loop
+    ( LoopError(..)
+    , LoopEvent(..)
+    , ToolSchedulingSnapshot(..)
+    , TurnOutput(..)
+    )
 import Agent.TUI.Presentation
     ( SearchReplaceAction(..)
     , SearchReplaceDiff(..)
@@ -538,6 +543,9 @@ renderEventUnlocked config = \case
             if visible
                 then paintThinkingFrame config
                 else startThinkingSpinnerUnlocked config
+    ToolSchedulingUpdated snapshot ->
+        writeIORef config.renderActivityRef
+            (schedulingActivity snapshot)
     -- The append-only renderer cannot safely repaint accumulated snapshots
     -- without duplicating output in terminal scrollback. The retained TUI
     -- handles these updates; minimal mode prints the final ToolFinished result.
@@ -551,6 +559,16 @@ renderEventUnlocked config = \case
                 (Map.lookup result.callId calls)
         putTextLn config.renderStderr
             (roleToolOutput config.renderColor (truncateToolOutput output))
+
+schedulingActivity :: ToolSchedulingSnapshot -> Text
+schedulingActivity snapshot =
+    let running = length snapshot.schedulingReadyCallIds
+        queued = length snapshot.schedulingBlockedCallIds
+    in "Running " <> Text.pack (show running) <> " tool"
+        <> if running == 1 then "" else "s"
+        <> if queued == 0
+            then ""
+            else "; " <> Text.pack (show queued) <> " queued"
 
 -- | Style assistant markdown when color is enabled; otherwise return plain text.
 -- The terminal theme owns the default assistant background.

--- a/packages/agent-cli/test/Agent/CLI/DatabaseSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/DatabaseSpec.hs
@@ -9,8 +9,11 @@ import Agent.ToolDispatch
     , ToolDispatchConfig(..)
     , functionToolCall
     )
+import Agent.Tools.Scheduling (schedulingPlansConflict)
 import Agent.Tools.Types
     ( appToolHandlers
+    , mkToolRegistry
+    , toolSchedulingPlanFor
     )
 import Agent.ToolDispatch (dispatchToolCall)
 import Control.Exception.Safe (displayException)
@@ -23,6 +26,22 @@ import Test.Hspec
 spec :: Spec
 spec = do
     describe "databaseTools" do
+        it "claims independent scopes separately and serializes writes" do
+            let registry =
+                    either (error . Text.unpack) id $
+                        mkToolRegistry (databaseTools testEnv)
+            userRead <- toolSchedulingPlanFor registry
+                (functionToolCall "user-read" "database_query"
+                    "{\"scope\":\"user\",\"sql\":\"select 1\"}")
+            repositoryRead <- toolSchedulingPlanFor registry
+                (functionToolCall "repo-read" "database_query"
+                    "{\"scope\":\"repository\",\"sql\":\"select 1\"}")
+            userWrite <- toolSchedulingPlanFor registry
+                (functionToolCall "user-write" "database_execute"
+                    "{\"scope\":\"user\",\"sql\":\"select 1\",\"purpose\":\"test\"}")
+            schedulingPlansConflict userRead repositoryRead `shouldBe` False
+            schedulingPlansConflict userRead userWrite `shouldBe` True
+
         it "dispatches a read-only query to the selected scope" do
             seen <- newIORef Nothing
             let env = testEnv

--- a/packages/agent-codex-dialect/src/Agent/Codex/Dialect/Tools.hs
+++ b/packages/agent-codex-dialect/src/Agent/Codex/Dialect/Tools.hs
@@ -6,7 +6,6 @@
 -- Multi-agent v1 tools are optional and registered when a registry is supplied.
 module Agent.Codex.Dialect.Tools
     ( codexTools
-    , shellCommandIsReadOnly
     ) where
 
 import Agent.OsPath (fromText)
@@ -56,6 +55,8 @@ import Agent.Tools.PlanMode
     , askUserQuestionTool
     , enterCodexPlanModeTool
     , isPlanModeActive
+    , planFilePath
+    , planModeBlockedEditMessage
     , writePlanTool
     )
 import Agent.Tools.Scheduling
@@ -80,7 +81,6 @@ import Data.Aeson.Types (parseFail)
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
-import qualified System.FilePath as FilePath
 import System.OsPath (unsafeEncodeUtf)
 
 codexTools
@@ -96,13 +96,13 @@ codexTools env shellSession ghci planMode multi =
         , readFileTool env
         , grepTool env
         , listDirTool env
-        , applyPatchTool env
+        , applyPatchTool env planMode
         , updatePlanTool planMode
         , enterCodexPlanModeTool planMode
         , writePlanTool planMode
         , askUserQuestionTool planMode
-        , shellCommandTool env shellSession
-        , writeStdinTool shellSession
+        , shellCommandTool env shellSession planMode
+        , writeStdinTool shellSession planMode
         ]
         ++ maybe [] multiAgentTools multi
 
@@ -124,9 +124,8 @@ instance FromJSON ShellCommandArgs where
         <*> optIntOrString object "timeout_ms"
         <*> optIntOrString object "yield_time_ms"
 
-shellCommandTool :: ToolEnv -> CodexShellSession -> AppTool
-shellCommandTool env session =
-    withToolResourceClaims (shellCommandResourceClaims env) $
+shellCommandTool :: ToolEnv -> CodexShellSession -> PlanModeEnv -> AppTool
+shellCommandTool env session planMode =
     jsonTool "shell_command" shellDescription
     [ PropertySchema "command" PropertyString True $ Just
         "Shell script to run in the user's default shell."
@@ -139,117 +138,7 @@ shellCommandTool env session =
     ]
     False
     TurnSequential
-    (typedStreamingTool "shell_command" (runShell env session))
-
-shellCommandResourceClaims
-    :: ToolEnv
-    -> ToolCall
-    -> IO (Either Text [ToolResourceClaim])
-shellCommandResourceClaims env call =
-    case
-        decodeToolArguments (toolArgumentsValue call.arguments)
-            :: Either Text ShellCommandArgs
-    of
-        Left err -> pure (Left err)
-        Right args
-            | args.yieldTimeMs /= Nothing ->
-                pure (Left "yielding shell commands remain exclusive")
-            | not (shellCommandIsReadOnly args.command) ->
-                pure (Left "shell command is not in the read-only allowlist")
-            | otherwise -> do
-                let requested = maybe env.toolCwd fromText args.workdir
-                resolveUnderCwd env requested
-                    >>= pure . fmap
-                        (\_ ->
-                            [ ToolResourceClaim
-                                ToolRead
-                                ToolAllPaths
-                            ])
-
-shellCommandIsReadOnly :: Text -> Bool
-shellCommandIsReadOnly command
-    | Text.null stripped = False
-    | Text.any (`elem` forbiddenChars) stripped = False
-    | "$(" `Text.isInfixOf` stripped = False
-    | "`" `Text.isInfixOf` stripped = False
-    | "$" `Text.isInfixOf` stripped = False
-    | otherwise =
-        case Text.words stripped of
-            [] -> False
-            executable : arguments ->
-                allowedCommand
-                    (Text.pack
-                        (FilePath.takeFileName (Text.unpack executable)))
-                    arguments
-  where
-    stripped = Text.strip command
-    forbiddenChars = ['\n', '\r', ';', '&', '|', '>', '<']
-
-allowedCommand :: Text -> [Text] -> Bool
-allowedCommand executable arguments
-    | executable `elem`
-        [ "cat", "head", "tail", "grep", "rg", "fd", "ls"
-        , "pwd", "wc", "stat", "file", "jq", "sort", "uniq", "cut"
-        , "tr", "realpath", "basename", "dirname", "which", "du", "df"
-        , "nl", "ps", "test", "diff", "printf", "echo"
-        ] =
-        not (any mutatingFlag arguments)
-            && not (executable == "sort" && any outputFlag arguments)
-    | executable == "find" =
-        not (any findAction arguments)
-    | executable == "sed" =
-        safeSed arguments
-    | executable == "git" =
-        case arguments of
-            subcommand : _ ->
-                subcommand `elem`
-                    [ "diff", "log", "show", "rev-parse"
-                    , "ls-files", "blame", "grep", "merge-base", "rev-list"
-                    , "symbolic-ref", "ls-remote"
-                    ]
-                    && not (any gitMutatingFlag arguments)
-            [] -> False
-    | executable == "gh" =
-        case arguments of
-            "pr" : subcommand : _ ->
-                subcommand `elem` ["view", "list", "checks", "status", "diff"]
-            "repo" : "view" : _ -> True
-            "run" : subcommand : _ -> subcommand `elem` ["list", "view"]
-            "auth" : "status" : _ -> True
-            _ -> False
-    | otherwise = False
-  where
-    mutatingFlag argument =
-        argument `elem` ["-i", "--in-place", "--delete", "-delete"]
-    outputFlag argument =
-        argument == "-o"
-            || "--output" `Text.isPrefixOf` argument
-    findAction argument =
-        argument `elem`
-            [ "-delete", "-exec", "-execdir", "-ok", "-okdir"
-            , "-fprint", "-fprintf", "-fls"
-            ]
-    gitMutatingFlag argument =
-        outputFlag argument
-            || argument `elem`
-                [ "-d", "-D", "-m", "-M", "-c", "-C"
-                , "--delete", "--move", "--copy"
-                ]
-
-safeSed :: [Text] -> Bool
-safeSed = \case
-    "-n" : script : paths ->
-        safePrintScript script
-            && not (null paths)
-            && all (not . Text.isPrefixOf "-") paths
-    _ -> False
-  where
-    safePrintScript raw =
-        let script = Text.dropAround (`elem` ['\'', '"']) raw
-            withoutDigits = Text.filter
-                (\char -> char < '0' || char > '9')
-                script
-        in withoutDigits `elem` ["p", ",p"]
+    (typedStreamingTool "shell_command" (runShell env session planMode))
 
 shellDescription :: Text
 shellDescription =
@@ -260,44 +149,53 @@ shellDescription =
 runShell
     :: ToolEnv
     -> CodexShellSession
+    -> PlanModeEnv
     -> (Text -> IO ())
     -> ShellCommandArgs
     -> IO (Either Text Text)
-runShell env session emitOutput args
+runShell env session planMode emitOutput args
     | commandLooksLikeRmRf args.command =
         pure (Left (forbiddenRmRfReason args.command))
     | args.timeoutMs /= Nothing && args.yieldTimeMs /= Nothing =
         pure (Left "timeout_ms and yield_time_ms are mutually exclusive")
     | otherwise = do
-        workdir <- case args.workdir of
-            Nothing -> pure (Right env.toolCwd)
-            Just dir -> resolveUnderCwd env (fromText dir)
-        case workdir of
-            Left err -> pure (Left err)
-            Right dir -> case args.yieldTimeMs of
-                Just requestedYield -> do
-                    let yieldMs = clampMs requestedYield
-                    startCodexShellCommand
-                        session
-                        dir
-                        (Text.unpack args.command)
-                        yieldMs
-                        (\out err -> emitOutput (commandBody out err))
-                        >>= pure . fmap renderShellResult
-                Nothing -> do
-                    let timeoutMs = clampMs (fromMaybe 10000 args.timeoutMs)
-                    result <- runShellCommandStreaming
-                        env
-                        dir
-                        (Text.unpack args.command)
-                        timeoutMs
-                        (\out err -> emitOutput (commandBody out err))
-                    if result.commandCancelled
-                        then pure $ Left "Error: Command cancelled"
-                        else if result.commandTimedOut
-                        then pure $ Left $
-                            "Error: Command timed out after " <> Text.pack (show timeoutMs) <> "ms"
-                        else pure $ Right $ renderFinished result
+        active <- isPlanModeActive planMode
+        if active
+            then pure (Left "Rejected: shell commands are not allowed in plan mode.")
+            else do
+                workdir <- case args.workdir of
+                    Nothing -> pure (Right env.toolCwd)
+                    Just dir -> resolveUnderCwd env (fromText dir)
+                case workdir of
+                    Left err -> pure (Left err)
+                    Right dir -> case args.yieldTimeMs of
+                        Just requestedYield -> do
+                            let yieldMs = clampMs requestedYield
+                            startCodexShellCommand
+                                session
+                                dir
+                                (Text.unpack args.command)
+                                yieldMs
+                                (\out err -> emitOutput (commandBody out err))
+                                >>= pure . fmap renderShellResult
+                        Nothing -> do
+                            let timeoutMs =
+                                    clampMs (fromMaybe 10000 args.timeoutMs)
+                            result <- runShellCommandStreaming
+                                env
+                                dir
+                                (Text.unpack args.command)
+                                timeoutMs
+                                (\out err ->
+                                    emitOutput (commandBody out err))
+                            if result.commandCancelled
+                                then pure $ Left "Error: Command cancelled"
+                                else if result.commandTimedOut
+                                then pure $ Left $
+                                    "Error: Command timed out after "
+                                        <> Text.pack (show timeoutMs)
+                                        <> "ms"
+                                else pure $ Right $ renderFinished result
 
 data WriteStdinArgs = WriteStdinArgs
     { sessionId :: Int
@@ -311,8 +209,8 @@ instance FromJSON WriteStdinArgs where
         <*> optText object "chars"
         <*> optIntOrString object "yield_time_ms"
 
-writeStdinTool :: CodexShellSession -> AppTool
-writeStdinTool session =
+writeStdinTool :: CodexShellSession -> PlanModeEnv -> AppTool
+writeStdinTool session planMode =
     withToolResourceClaims writeStdinResourceClaims $
     jsonAppToolWithExecution "write_stdin" writeStdinDescription
         [ PropertySchema "session_id" PropertyInteger True $ Just
@@ -324,7 +222,7 @@ writeStdinTool session =
         ]
         (ClassifyReadOnly writeStdinIsReadOnly)
         TurnSequential
-        (typedTool "write_stdin" (runWriteStdin session))
+        (typedTool "write_stdin" (runWriteStdin session planMode))
 
 writeStdinResourceClaims
     :: ToolCall
@@ -351,15 +249,20 @@ writeStdinIsReadOnly call =
 
 runWriteStdin
     :: CodexShellSession
+    -> PlanModeEnv
     -> WriteStdinArgs
     -> IO (Either Text Text)
-runWriteStdin session args = do
-    let yieldMs = clampMs (fromMaybe 5000 args.yieldTimeMs)
-    fmap renderShellResult <$> continueCodexShellCommand
-        session
-        args.sessionId
-        (fromMaybe "" args.chars)
-        yieldMs
+runWriteStdin session planMode args = do
+    active <- isPlanModeActive planMode
+    if active
+        then pure (Left "Rejected: shell sessions are not available in plan mode.")
+        else do
+            let yieldMs = clampMs (fromMaybe 5000 args.yieldTimeMs)
+            fmap renderShellResult <$> continueCodexShellCommand
+                session
+                args.sessionId
+                (fromMaybe "" args.chars)
+                yieldMs
 
 clampMs :: Int -> Int
 clampMs = min 300000 . max 1
@@ -402,12 +305,12 @@ instance FromJSON ApplyPatchArgs where
         ApplyPatchArgs <$> (reqText object "input" <|> reqText object "patch" <|> reqText object "command")
     parseJSON _ = parseFail "apply_patch expects freeform patch text"
 
-applyPatchTool :: ToolEnv -> AppTool
-applyPatchTool env =
+applyPatchTool :: ToolEnv -> PlanModeEnv -> AppTool
+applyPatchTool env planMode =
     withToolResourceClaims (applyPatchResourceClaims env) $
     freeformApplyPatchAppToolWithExecution
         "apply_patch" applyPatchDescription AlwaysPrompt TurnSequential
-        (typedTool "apply_patch" (runApplyPatch env))
+        (typedTool "apply_patch" (runApplyPatch env planMode))
 
 applyPatchResourceClaims
     :: ToolEnv
@@ -462,8 +365,18 @@ applyPatchDescription =
     \*** Delete File: path\n\
     \*** End Patch"
 
-runApplyPatch :: ToolEnv -> ApplyPatchArgs -> IO (Either Text Text)
-runApplyPatch env args = applyPatch env args.patch
+runApplyPatch
+    :: ToolEnv
+    -> PlanModeEnv
+    -> ApplyPatchArgs
+    -> IO (Either Text Text)
+runApplyPatch env planMode args = do
+    active <- isPlanModeActive planMode
+    if not active
+        then applyPatch env args.patch
+        else do
+            path <- planFilePath planMode
+            pure (Left (planModeBlockedEditMessage path))
 
 --------------------------------------------------------------------------------
 -- update_plan

--- a/packages/agent-codex-dialect/test/Agent/Codex/DialectSpec.hs
+++ b/packages/agent-codex-dialect/test/Agent/Codex/DialectSpec.hs
@@ -6,13 +6,22 @@ import Agent.Codex.Dialect.Runtime
     ( CodexCodingTools(..)
     , newCodexCodingTools
     )
-import Agent.Codex.Dialect.Tools (shellCommandIsReadOnly)
 import Agent.ProjectInstructions (InstructionFile(..), LoadedAgentsMd(..))
-import Agent.ToolDispatch (customToolCall, functionToolCall)
-import Agent.Tools.Scheduling (schedulingPlansConflict)
+import Agent.ToolDispatch
+    ( ToolCallResult(..)
+    , ToolDispatchConfig(..)
+    , customToolCall
+    , functionToolCall
+    )
+import Agent.Tools.PlanMode (activatePlanMode)
+import Agent.Tools.Scheduling
+    ( ToolSchedulingPlan(..)
+    , schedulingPlansConflict
+    )
 import Agent.Tools.Types
     ( AppTool(..)
     , defaultToolEnv
+    , dispatchRegisteredToolCall
     , mkToolRegistry
     , toolSchedulingPlanFor
     )
@@ -68,27 +77,6 @@ spec = describe "Codex dialect" do
                 "# AGENTS.md instructions for /repo\n\n<INSTRUCTIONS>\n\
                 \global\n\n--- project-doc ---\n\nproject\n</INSTRUCTIONS>"
 
-    it "classifies only strict observational shell commands as read-only" do
-        map shellCommandIsReadOnly
-            [ "rg --files"
-            , "sed -n '1,80p' src/Main.hs"
-            , "git diff -- src/Main.hs"
-            , "gh pr view 123 --json statusCheckRollup"
-            ]
-            `shouldBe` replicate 4 True
-        map shellCommandIsReadOnly
-            [ "git status --short"
-            , "git fetch origin"
-            , "cat src/Main.hs > copy"
-            , "printf x | tee output"
-            , "nix develop -c cabal test"
-            , "bash -c 'rg foo'"
-            , "find . -delete"
-            , "sed -n '/pattern/w output' src/Main.hs"
-            , "git diff --output=copy"
-            ]
-            `shouldBe` replicate 9 False
-
     it "derives disjoint apply_patch resources from patch paths" do
         withTempDir \dir -> do
             env <- defaultToolEnv (unsafeEncodeUtf dir)
@@ -106,6 +94,12 @@ spec = describe "Codex dialect" do
             same <- toolSchedulingPlanFor registry (patch "p3" "a.txt")
             schedulingPlansConflict first second `shouldBe` False
             schedulingPlansConflict first same `shouldBe` True
+
+            activatePlanMode coding.codexPlanMode
+            blocked <- dispatchRegisteredToolCall testDispatchConfig registry
+                (patch "p4" "blocked.txt")
+            blocked.output `shouldSatisfy`
+                Text.isInfixOf "file edits are not allowed in plan mode"
             coding.codexClose
 
     it "serializes write_stdin only per shell session" do
@@ -121,8 +115,12 @@ spec = describe "Codex dialect" do
             first <- toolSchedulingPlanFor registry (stdin "s1" "1")
             second <- toolSchedulingPlanFor registry (stdin "s2" "2")
             same <- toolSchedulingPlanFor registry (stdin "s3" "1")
+            shell <- toolSchedulingPlanFor registry
+                (functionToolCall "shell" "shell_command"
+                    "{\"command\":\"pwd\"}")
             schedulingPlansConflict first second `shouldBe` False
             schedulingPlansConflict first same `shouldBe` True
+            shell `shouldBe` ToolExclusive
             coding.codexClose
 
 withTempDir :: (FilePath -> IO a) -> IO a
@@ -132,3 +130,12 @@ withTempDir action = do
         (mkdtemp (tmp </> "agent-codex-dialect-XXXXXX"))
         removeDirectoryRecursive
         action
+
+testDispatchConfig :: ToolDispatchConfig
+testDispatchConfig = ToolDispatchConfig
+    { toolDispatchUnknownTool = \name -> "unknown:" <> name
+    , toolDispatchFormatResult = either ("ERR " <>) id
+    , toolDispatchFormatException = \name _ -> "EX " <> name
+    , toolDispatchOnException = \_ _ -> pure ()
+    , toolDispatchOnOutput = \_ _ -> pure ()
+    }

--- a/packages/agent-core/agent-core.cabal
+++ b/packages/agent-core/agent-core.cabal
@@ -138,7 +138,7 @@ benchmark tool-scheduling-bench
     type:             exitcode-stdio-1.0
     hs-source-dirs:   benchmark
     main-is:          ToolScheduling.hs
-    ghc-options:      -O2 -rtsopts
+    ghc-options:      -O2 -threaded -rtsopts
     build-depends:    agent-core
                     , base >= 4.14 && < 5
                     , text

--- a/packages/agent-core/benchmark/LoopEvents.hs
+++ b/packages/agent-core/benchmark/LoopEvents.hs
@@ -316,6 +316,12 @@ eventWeight = \case
     TurnStarted -> 1
     TurnFinished _ -> 1
     ToolStarted call -> Text.length call.callId
+    ToolSchedulingUpdated snapshot ->
+        sum (map Text.length snapshot.schedulingReadyCallIds)
+            + sum
+                [ Text.length blocked + Text.length blocker
+                | (blocked, blocker) <- snapshot.schedulingBlockedCallIds
+                ]
     ToolOutputUpdated callId output ->
         Text.length callId + Text.length output
     ToolFinished result ->

--- a/packages/agent-core/benchmark/ToolScheduling.hs
+++ b/packages/agent-core/benchmark/ToolScheduling.hs
@@ -31,7 +31,7 @@ import Agent.Tools.Types
     )
 import Control.Concurrent (threadDelay)
 import Control.Exception (evaluate)
-import Control.Monad (forM)
+import Control.Monad (forM, forM_)
 import Data.IORef
     ( atomicModifyIORef'
     , newIORef
@@ -57,6 +57,7 @@ data Workload
     = OldSequential
     | NewDisjoint
     | NewConflicting
+    | NewMixed !Int
     | ExistingParallel
     deriving (Eq, Show)
 
@@ -73,6 +74,10 @@ main = do
         then pure ()
         else die "RTS statistics are disabled; run with +RTS -T"
     getArgs >>= \case
+        ["matrix", delayArg, sampleCountArg] -> do
+            delayMicros <- parseNonNegative "delay microseconds" delayArg
+            sampleCount <- parsePositive "sample count" sampleCountArg
+            runMatrix delayMicros sampleCount
         [workloadArg, callCountArg, delayArg, sampleCountArg] -> do
             workload <- parseWorkload workloadArg
             callCount <- parsePositive "call count" callCountArg
@@ -89,19 +94,89 @@ main = do
                 result.wallMillis
                 result.cpuMillis
                 result.allocatedBytes
+        [workloadArg, callCountArg, delayArg, sampleCountArg, contentionArg] -> do
+            contention <- parsePercent contentionArg
+            workload <- parseWorkloadWithContention workloadArg contention
+            callCount <- parsePositive "call count" callCountArg
+            delayMicros <- parseNonNegative "delay microseconds" delayArg
+            sampleCount <- parsePositive "sample count" sampleCountArg
+            samples <- forM [1 .. sampleCount] \_ ->
+                measure (runWorkload workload callCount delayMicros)
+            let result = median samples
+            printf
+                "%s,%d,%d,%d,%.3f,%.3f,%d\n"
+                workloadArg
+                callCount
+                delayMicros
+                contention
+                result.wallMillis
+                result.cpuMillis
+                result.allocatedBytes
         _ ->
             die $
-                "usage: tool-scheduling-bench WORKLOAD CALLS DELAY_US SAMPLES\n"
+                "usage: tool-scheduling-bench WORKLOAD CALLS DELAY_US SAMPLES [CONTENTION_PERCENT]\n"
+                    <> "   or: tool-scheduling-bench matrix DELAY_US SAMPLES\n"
                     <> "workloads: old-sequential, new-disjoint, "
-                    <> "new-conflicting, existing-parallel"
+                    <> "new-conflicting, new-mixed, existing-parallel\n"
 
 parseWorkload :: String -> IO Workload
 parseWorkload = \case
     "old-sequential" -> pure OldSequential
     "new-disjoint" -> pure NewDisjoint
     "new-conflicting" -> pure NewConflicting
+    "new-mixed" -> pure (NewMixed 50)
     "existing-parallel" -> pure ExistingParallel
     other -> die ("unknown workload: " <> other)
+
+parsePercent :: String -> IO Int
+parsePercent raw =
+    case reads raw of
+        [(value, "")]
+            | value >= 0 && value <= 100 -> pure value
+        _ -> die ("invalid contention percentage: " <> raw)
+
+parseWorkloadWithContention :: String -> Int -> IO Workload
+parseWorkloadWithContention raw contention =
+    case raw of
+        "new-mixed" -> pure (NewMixed contention)
+        _ -> parseWorkload raw
+
+runMatrix :: Int -> Int -> IO ()
+runMatrix delayMicros sampleCount =
+    forM_ [8, 32, 128] \callCount -> do
+        forM_ ["old-sequential", "existing-parallel"] \workload -> do
+            parsed <- parseWorkload workload
+            samples <- forM [1 .. sampleCount] \_ ->
+                measure (runWorkload parsed callCount delayMicros)
+            let result = median samples
+            printf
+                "%s,%d,%d,%d,%.3f,%.3f,%d\n"
+                workload
+                callCount
+                delayMicros
+                (if workload == "old-sequential" then 100 else 0 :: Int)
+                result.wallMillis
+                result.cpuMillis
+                result.allocatedBytes
+        forM_ ["new-disjoint", "new-mixed", "new-conflicting"] \workload ->
+            forM_ [0, 50, 100] \contention ->
+                if workload == "new-disjoint" && contention /= 0
+                    || workload == "new-conflicting" && contention /= 100
+                    then pure ()
+                    else do
+                        parsed <- parseWorkloadWithContention workload contention
+                        samples <- forM [1 .. sampleCount] \_ ->
+                            measure (runWorkload parsed callCount delayMicros)
+                        let result = median samples
+                        printf
+                            "%s,%d,%d,%d,%.3f,%.3f,%d\n"
+                            workload
+                            callCount
+                            delayMicros
+                            contention
+                            result.wallMillis
+                            result.cpuMillis
+                            result.allocatedBytes
 
 parsePositive :: String -> String -> IO Int
 parsePositive label raw =
@@ -142,7 +217,7 @@ runWorkload workload callCount delayMicros = do
                 }
         tools =
             zipWith
-                (benchmarkTool workload delayMicros)
+                (benchmarkTool workload delayMicros callCount)
                 [1 ..]
                 names
         registry =
@@ -165,8 +240,8 @@ runWorkload workload callCount delayMicros = do
         Right LoopResult { turnsUsed } -> turnsUsed + callCount
         Left err -> error (show err)
 
-benchmarkTool :: Workload -> Int -> Int -> Text -> AppTool
-benchmarkTool workload delayMicros index name =
+benchmarkTool :: Workload -> Int -> Int -> Int -> Text -> AppTool
+benchmarkTool workload delayMicros callCount index name =
     addClaims $
         jsonAppToolWithExecution
             name
@@ -179,16 +254,21 @@ benchmarkTool workload delayMicros index name =
                 pure (Right "ok"))
   where
     execution = case workload of
-        ExistingParallel -> ParallelSafe
-        _ -> TurnSequential
+        OldSequential -> TurnSequential
+        _ -> ParallelSafe
     addClaims = case workload of
         NewDisjoint ->
             withToolResourceClaims
-                (const (pure (Right [writeClaim resourceName])))
+                (dynamicClaims False)
         NewConflicting ->
             withToolResourceClaims
-                (const (pure (Right [writeClaim "shared"])))
+                (dynamicClaims True)
+        NewMixed contention ->
+            withToolResourceClaims
+                (dynamicClaims (index * 100 <= contention * max 1 callCount))
         _ -> id
+    dynamicClaims shared _ =
+        pure (Right [writeClaim (if shared then "shared" else resourceName)])
     resourceName = "resource-" <> Text.pack (show index)
     writeClaim resource =
         ToolResourceClaim ToolWrite (ToolNamedResource resource)

--- a/packages/agent-core/src/Agent/Loop.hs
+++ b/packages/agent-core/src/Agent/Loop.hs
@@ -12,6 +12,7 @@ module Agent.Loop
     , LoopConfig(..)
     , LoopExecution(..)
     , LoopEvent(..)
+    , ToolSchedulingSnapshot(..)
     , LoopError(..)
     , LoopProgress(..)
     , LoopResult(..)
@@ -44,12 +45,15 @@ import Agent.ToolDispatch
     , ToolDispatchConfig(..)
     )
 import Agent.Tools.Scheduling
-    ( ToolSchedulingPlan(..)
-    , schedulingPlansConflict
+    ( SchedulingDecision(..)
+    , ToolSchedulingPlan(..)
+    , nextSchedulingWave
     )
 import Agent.Tools.Types
-    ( ToolRegistry
+    ( ToolExecutionPolicy(..)
+    , ToolRegistry
     , dispatchRegisteredToolCall
+    , toolExecutionPolicyFor
     , toolSchedulingPlanFor
     )
 import Control.Concurrent.Async
@@ -95,6 +99,7 @@ import Data.Aeson (FromJSON(..), ToJSON(..), object, withObject, (.:), (.:?), (.
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as ByteString
 import Data.IORef (newIORef, readIORef, writeIORef)
+import Data.Maybe (mapMaybe)
 import qualified Data.Map.Strict as Map
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -142,6 +147,11 @@ data TurnInput
         }
     | CompletedTool ToolCallResult
     deriving (Eq, Show)
+
+data ToolSchedulingSnapshot = ToolSchedulingSnapshot
+    { schedulingReadyCallIds :: ![Text]
+    , schedulingBlockedCallIds :: ![(Text, Text)]
+    } deriving (Eq, Show)
 
 -- | Provider-reported token counts for one model response. @inputTokens@
 -- typically includes any cached prefix; @cachedTokens@ is that subset when
@@ -248,6 +258,7 @@ data LoopEvent
     | TurnStarted
     | TurnFinished TurnOutput
     | ToolStarted ToolCall
+    | ToolSchedulingUpdated ToolSchedulingSnapshot
     -- | Latest accumulated output snapshot for an in-flight tool call.
     | ToolOutputUpdated Text Text
     | ToolFinished ToolCallResult
@@ -709,11 +720,46 @@ recordLoopEventFailure pump failure =
 -- calls from the same model turn to overlap. Results are returned in model
 -- order regardless of completion order.
 runToolCalls :: LoopConfig -> [ToolCall] -> IO [ToolCallResult]
-runToolCalls config calls = do
-    prepared <- prepareIndexedToolCalls config (zip [0..] calls)
-    scheduled <- traverse schedule prepared
-    go scheduled Map.empty
+runToolCalls config = runApprovalBatches
   where
+    runApprovalBatches [] = pure []
+    runApprovalBatches remaining = do
+        let (current, later) = nextApprovalBatch remaining
+        currentResults <- runScheduledCalls current
+        cancelled <- isCancelled config.loopCancel
+        if cancelled
+            then pure currentResults
+            else (currentResults <>) <$> runApprovalBatches later
+
+    nextApprovalBatch = collect []
+      where
+        collect accumulated [] = (reverse accumulated, [])
+        collect accumulated (call : rest)
+            | toolExecutionPolicyFor config.loopTools call
+                == TurnApprovalBarrier =
+                (reverse (call : accumulated), rest)
+            | otherwise =
+                collect (call : accumulated) rest
+
+    runScheduledCalls current = do
+        prepared <- prepareIndexedToolCalls config (zip [0..] current)
+        runPlannedGroups [] prepared
+
+    runPlannedGroups completed [] =
+        pure completed
+    runPlannedGroups completed remaining =
+        race
+            (waitCancel config.loopCancel)
+            (scheduleThroughExclusive remaining) >>= \case
+                Left () -> pure completed
+                Right (planned, later) -> do
+                    groupResults <- runWaves planned Map.empty
+                    let completed' = completed <> groupResults
+                    cancelled <- isCancelled config.loopCancel
+                    if cancelled
+                        then pure completed'
+                        else runPlannedGroups completed' later
+
     schedule
         :: IndexedPreparedToolCall
         -> IO PreparedScheduledToolCall
@@ -725,40 +771,103 @@ runToolCalls config calls = do
             , prepared = indexed.prepared
             }
 
-    go
+    -- Claims are resolved once. Stop after the first exclusive plan so calls
+    -- following arbitrary stateful work resolve against its completed state.
+    scheduleThroughExclusive = collect []
+      where
+        collect accumulated [] =
+            pure (reverse accumulated, [])
+        collect accumulated (indexed : rest) = do
+            scheduled <- schedule indexed
+            let planned = scheduled : accumulated
+            case scheduled.plan of
+                Just ToolExclusive ->
+                    pure (reverse planned, rest)
+                _ ->
+                    collect planned rest
+
+    runWaves
         :: [PreparedScheduledToolCall]
         -> Map.Map Int ToolCallResult
         -> IO [ToolCallResult]
-    go [] completed =
+    runWaves [] completed =
         pure (map snd (Map.toAscList completed))
-    go remaining completed = do
-        let ready = readyCalls remaining
-            readyIndexes = Map.fromList [(call.index, ()) | call <- ready]
+    runWaves remaining completed = do
+        let decision =
+                nextSchedulingWave
+                    [ (scheduled.index, scheduled.plan)
+                    | scheduled <- remaining
+                    ]
+            readyIndexes =
+                Map.fromList
+                    [ (index, ())
+                    | index <- decision.schedulingReady
+                    ]
+            ready =
+                filter
+                    (\scheduled ->
+                        Map.member scheduled.index readyIndexes)
+                    remaining
             pending =
                 filter
                     (\scheduled ->
                         Map.notMember scheduled.index readyIndexes)
                     remaining
+            callIds =
+                Map.fromList
+                    [ ( scheduled.index
+                      , scheduledCallId scheduled.prepared
+                      )
+                    | scheduled <- remaining
+                    ]
+            readyCallIds =
+                mapMaybe
+                    (\scheduled ->
+                        scheduledCallId scheduled.prepared
+                            <$ scheduled.plan)
+                    ready
+            blockedCallIds =
+                mapMaybe
+                    (\(blocked, blocker) ->
+                        (,)
+                            <$> Map.lookup blocked callIds
+                            <*> Map.lookup blocker callIds)
+                    decision.schedulingBlocked
+            snapshot = ToolSchedulingSnapshot
+                { schedulingReadyCallIds = readyCallIds
+                , schedulingBlockedCallIds = blockedCallIds
+                }
+        if null readyCallIds && null blockedCallIds
+            then pure ()
+            else config.loopOnEvent
+                (ToolSchedulingUpdated snapshot)
         batchResults <-
             mapConcurrently
                 (\scheduled -> do
                     result <-
-                        runPreparedToolCall config scheduled.prepared
-                    pure (fmap (\value -> (scheduled.index, value)) result))
+                        runPreparedToolCall
+                            config
+                            scheduled.prepared
+                    pure
+                        (fmap
+                            (\value ->
+                                (scheduled.index, value))
+                            result))
                 ready
         let completed' =
                 foldr
                     (\result acc ->
                         maybe
                             acc
-                            (\(index, value) -> Map.insert index value acc)
+                            (\(index, value) ->
+                                Map.insert index value acc)
                             result)
                     completed
                     batchResults
         cancelled <- isCancelled config.loopCancel
         if cancelled
             then pure (map snd (Map.toAscList completed'))
-            else go pending completed'
+            else runWaves pending completed'
 
 data IndexedPreparedToolCall = IndexedPreparedToolCall
     { index :: !Int
@@ -767,21 +876,9 @@ data IndexedPreparedToolCall = IndexedPreparedToolCall
 
 data PreparedScheduledToolCall = PreparedScheduledToolCall
     { index :: !Int
-    , plan :: !ToolSchedulingPlan
+    , plan :: !(Maybe ToolSchedulingPlan)
     , prepared :: !PreparedToolCall
     }
-
-readyCalls :: [PreparedScheduledToolCall] -> [PreparedScheduledToolCall]
-readyCalls calls =
-    [ call
-    | call <- calls
-    , not
-        (any
-            (\earlier ->
-                earlier.index < call.index
-                    && schedulingPlansConflict earlier.plan call.plan)
-            calls)
-    ]
 
 prepareIndexedToolCalls
     :: LoopConfig
@@ -815,15 +912,18 @@ data PreparedToolCall =
 schedulingPlanForPrepared
     :: LoopConfig
     -> PreparedToolCall
-    -> IO ToolSchedulingPlan
+    -> IO (Maybe ToolSchedulingPlan)
 schedulingPlanForPrepared config (PreparedToolCall call approval) =
     case approval of
-        ToolApprovalGranted ->
-            toolSchedulingPlanFor config.loopTools call
+        ToolApprovalGranted -> Just
+            <$> toolSchedulingPlanFor config.loopTools call
         ToolApprovalDenied{} ->
-            pure ToolUnconstrained
+            pure Nothing
         ToolApprovalRejected ->
-            pure ToolUnconstrained
+            pure Nothing
+
+scheduledCallId :: PreparedToolCall -> Text
+scheduledCallId (PreparedToolCall call _) = call.callId
 
 -- | Approval may touch interactive or otherwise order-sensitive state, so it
 -- is prepared serially even when the resulting handlers may run concurrently.

--- a/packages/agent-core/src/Agent/Tools/MultiAgents.hs
+++ b/packages/agent-core/src/Agent/Tools/MultiAgents.hs
@@ -29,6 +29,7 @@ import Agent.Subagents
     )
 import Agent.Subagents.TaskPath
     ( TaskPath
+    , joinTaskPath
     , resolveTaskPath
     , taskPathRoot
     , taskPathText
@@ -54,11 +55,23 @@ import Agent.ToolDSL
     ( PropertySchema(..)
     , PropertyType(..)
     )
-import Agent.ToolDispatch (ToolCall(..), typedTool, typedToolWithCall)
+import Agent.ToolDispatch
+    ( ToolCall(..)
+    , decodeToolArguments
+    , toolArgumentsValue
+    , typedTool
+    , typedToolWithCall
+    )
+import Agent.Tools.Scheduling
+    ( ToolAccess(..)
+    , ToolResource(..)
+    , ToolResourceClaim(..)
+    )
 import Agent.Tools.Types
     ( AppTool
     , ToolExecutionPolicy(..)
     , jsonTool
+    , withToolResourceClaims
     )
 import Data.Aeson (FromJSON(..), Value(..), object, (.=))
 import qualified Data.Aeson as Aeson
@@ -149,7 +162,9 @@ instance FromJSON SpawnAgentArgs where
         <*> optText object_ "fork_turns"
 
 spawnAgentTool :: MultiAgentContext -> AppTool
-spawnAgentTool ctx = jsonTool "spawn_agent" spawnAgentDescription
+spawnAgentTool ctx =
+    withToolResourceClaims (spawnResourceClaims ctx) $
+    jsonTool "spawn_agent" spawnAgentDescription
     [ PropertySchema "task_name" PropertyString True $ Just
         "Task name for the new agent. Use lowercase letters, digits, and underscores."
     , PropertySchema "message"
@@ -174,6 +189,21 @@ spawnAgentDescription =
     \/root/task1 and you spawn_agent with task_name \"task_3\" the agent will \
     \have canonical task name /root/task1/task_3. You may refer to this agent \
     \as task_3 or /root/task1/task_3. Returns the canonical task_name."
+
+spawnResourceClaims
+    :: MultiAgentContext
+    -> ToolCall
+    -> IO (Either Text [ToolResourceClaim])
+spawnResourceClaims ctx call =
+    pure $ do
+        args <-
+            decodeToolArguments (toolArgumentsValue call.arguments)
+                :: Either Text SpawnAgentArgs
+        path <- joinTaskPath ctx.multiTaskPath args.taskName
+        Right
+            [ registryWriteClaim
+            , ToolResourceClaim ToolWrite
+                (ToolNamedResource ("agent-task:" <> taskPathText path)) ]
 
 runSpawn :: MultiAgentContext -> ToolCall -> SpawnAgentArgs -> IO (Either Text Text)
 runSpawn ctx call args
@@ -333,7 +363,9 @@ instance FromJSON MessageArgs where
         <*> reqText object_ "message"
 
 sendMessageTool :: MultiAgentContext -> AppTool
-sendMessageTool ctx = jsonTool "send_message" sendMessageDescription
+sendMessageTool ctx =
+    withToolResourceClaims (messageResourceClaims ctx) $
+    jsonTool "send_message" sendMessageDescription
     [ PropertySchema "target" PropertyString True $ Just
         "Relative or canonical task name to message (from spawn_agent)."
     , PropertySchema "message"
@@ -364,7 +396,9 @@ runSendMessage ctx call args
                             (messageContent call args.message)
 
 followupTaskTool :: MultiAgentContext -> AppTool
-followupTaskTool ctx = jsonTool "followup_task" followupDescription
+followupTaskTool ctx =
+    withToolResourceClaims (messageResourceClaims ctx) $
+    jsonTool "followup_task" followupDescription
     [ PropertySchema "target" PropertyString True $ Just
         "Agent id or canonical task name to send a follow-up task to (from spawn_agent)."
     , PropertySchema "message"
@@ -379,6 +413,18 @@ followupDescription =
     "Send a follow-up task to an existing non-root target agent and trigger a \
     \turn if it is idle. If the target is already running, deliver the task \
     \promptly at message boundaries."
+
+messageResourceClaims
+    :: MultiAgentContext
+    -> ToolCall
+    -> IO (Either Text [ToolResourceClaim])
+messageResourceClaims ctx call =
+    pure $ do
+        args <-
+            decodeToolArguments (toolArgumentsValue call.arguments)
+                :: Either Text MessageArgs
+        target <- targetResourceClaim ctx ToolWrite args.target
+        Right [registryReadClaim, target]
 
 runFollowup :: MultiAgentContext -> ToolCall -> MessageArgs -> IO (Either Text Text)
 runFollowup ctx call args
@@ -487,6 +533,14 @@ listAgentsDescription =
     "List live agents in the current root thread tree. Optionally filter by \
     \task-path prefix."
 
+registryReadClaim :: ToolResourceClaim
+registryReadClaim =
+    ToolResourceClaim ToolRead (ToolNamedResource "agent-registry")
+
+registryWriteClaim :: ToolResourceClaim
+registryWriteClaim =
+    ToolResourceClaim ToolWrite (ToolNamedResource "agent-registry")
+
 runListAgents :: MultiAgentContext -> ListAgentsArgs -> IO (Either Text Text)
 runListAgents ctx args = do
     agents <- listAgents ctx.multiRegistry args.pathPrefix
@@ -510,7 +564,9 @@ instance FromJSON InterruptAgentArgs where
     parseJSON = objectArgs \object_ -> InterruptAgentArgs <$> reqText object_ "target"
 
 interruptAgentTool :: MultiAgentContext -> AppTool
-interruptAgentTool ctx = jsonTool "interrupt_agent" interruptDescription
+interruptAgentTool ctx =
+    withToolResourceClaims (targetResourceClaims ctx ToolWrite) $
+    jsonTool "interrupt_agent" interruptDescription
     [ PropertySchema "target" PropertyString True $ Just
         "Agent id or canonical task name to interrupt (from spawn_agent)."
     ]
@@ -522,6 +578,32 @@ interruptDescription :: Text
 interruptDescription =
     "Interrupt an agent's current turn, if any, and return its previous status. \
     \The agent remains available for messages and follow-up tasks."
+
+targetResourceClaims
+    :: MultiAgentContext
+    -> ToolAccess
+    -> ToolCall
+    -> IO (Either Text [ToolResourceClaim])
+targetResourceClaims ctx access call =
+    pure $ do
+        args <-
+            decodeToolArguments (toolArgumentsValue call.arguments)
+                :: Either Text InterruptAgentArgs
+        target <- targetResourceClaim ctx access args.target
+        Right [registryReadClaim, target]
+
+targetResourceClaim
+    :: MultiAgentContext
+    -> ToolAccess
+    -> Text
+    -> Either Text ToolResourceClaim
+targetResourceClaim ctx access target =
+    agentClaim access <$> resolveTaskPath ctx.multiTaskPath target
+
+agentClaim :: ToolAccess -> TaskPath -> ToolResourceClaim
+agentClaim access path =
+    ToolResourceClaim access
+        (ToolNamedResource ("agent-task:" <> taskPathText path))
 
 encryptedString :: Text -> PropertyType
 encryptedString description = PropertyRaw $ object

--- a/packages/agent-core/src/Agent/Tools/PlanMode.hs
+++ b/packages/agent-core/src/Agent/Tools/PlanMode.hs
@@ -213,7 +213,7 @@ enterPlanModeToolWith completion env = jsonTool "enter_plan_mode"
     -- The tool performs its own explicit user confirmation through
     -- planConfirmEnter, so it must not also trigger generic tool approval.
     True
-    TurnSequential
+    TurnApprovalBarrier
     (typedTool "enter_plan_mode" (runEnterPlanMode completion env))
 
 enterPlanDescription :: PlanCompletion -> Text
@@ -298,7 +298,7 @@ exitPlanModeTool env = jsonTool "exit_plan_mode" exitPlanDescription
         "Optional short summary shown with the plan approval prompt."
     ]
     False
-    TurnSequential
+    TurnApprovalBarrier
     (typedTool "exit_plan_mode" (runExitPlanMode env))
 
 exitPlanDescription :: Text

--- a/packages/agent-core/src/Agent/Tools/Scheduling.hs
+++ b/packages/agent-core/src/Agent/Tools/Scheduling.hs
@@ -3,9 +3,13 @@ module Agent.Tools.Scheduling
     , ToolResource(..)
     , ToolResourceClaim(..)
     , ToolSchedulingPlan(..)
+    , SchedulingDecision(..)
+    , nextSchedulingWave
     , schedulingPlansConflict
     ) where
 
+import Data.Foldable (toList)
+import Data.List.NonEmpty (NonEmpty)
 import Data.Text (Text)
 import System.OsPath
     ( OsPath
@@ -22,7 +26,7 @@ data ToolAccess
     deriving (Eq, Show)
 
 data ToolResource
-    = ToolAllPaths
+    = ToolAllResources
     | ToolPath !OsPath
     | ToolPathTree !OsPath
     | ToolNamedResource !Text
@@ -34,10 +38,52 @@ data ToolResourceClaim = ToolResourceClaim
     } deriving (Eq, Show)
 
 data ToolSchedulingPlan
-    = ToolUnconstrained
-    | ToolResourceClaims ![ToolResourceClaim]
+    = ToolResourceClaims !(NonEmpty ToolResourceClaim)
     | ToolExclusive
     deriving (Eq, Show)
+
+data SchedulingDecision key = SchedulingDecision
+    { schedulingReady :: ![key]
+    , schedulingBlocked :: ![(key, key)]
+    } deriving (Eq, Show)
+
+-- | Select the next deterministic scheduling wave. A 'Nothing' plan denotes
+-- work that does not execute a handler (for example, an approval rejection);
+-- it is always ready and never blocks another call.
+nextSchedulingWave
+    :: [(key, Maybe ToolSchedulingPlan)]
+    -> SchedulingDecision key
+nextSchedulingWave entries =
+    SchedulingDecision
+        { schedulingReady =
+            [ key
+            | (key, blocker) <- decisions
+            , maybe True (const False) blocker
+            ]
+        , schedulingBlocked =
+            [ (key, blocker)
+            | (key, Just blocker) <- decisions
+            ]
+        }
+  where
+    indexed = zip [0 :: Int ..] entries
+    decisions =
+        [ (key, blockerFor position plan)
+        | (position, (key, plan)) <- indexed
+        ]
+    blockerFor _ Nothing = Nothing
+    blockerFor position (Just current) =
+        firstConflicting
+            [ (key, plan)
+            | (_, (key, plan)) <- take position indexed
+            ]
+            current
+    firstConflicting [] _ = Nothing
+    firstConflicting ((_, Nothing) : rest) current =
+        firstConflicting rest current
+    firstConflicting ((key, Just earlier) : rest) current
+        | schedulingPlansConflict earlier current = Just key
+        | otherwise = firstConflicting rest current
 
 schedulingPlansConflict
     :: ToolSchedulingPlan
@@ -45,13 +91,11 @@ schedulingPlansConflict
     -> Bool
 schedulingPlansConflict ToolExclusive _ = True
 schedulingPlansConflict _ ToolExclusive = True
-schedulingPlansConflict ToolUnconstrained _ = False
-schedulingPlansConflict _ ToolUnconstrained = False
 schedulingPlansConflict (ToolResourceClaims left) (ToolResourceClaims right) =
     or
         [ claimsConflict leftClaim rightClaim
-        | leftClaim <- left
-        , rightClaim <- right
+        | leftClaim <- toList left
+        , rightClaim <- toList right
         ]
 
 claimsConflict :: ToolResourceClaim -> ToolResourceClaim -> Bool
@@ -60,11 +104,8 @@ claimsConflict left right =
         && (left.claimAccess == ToolWrite || right.claimAccess == ToolWrite)
 
 resourcesOverlap :: ToolResource -> ToolResource -> Bool
-resourcesOverlap ToolAllPaths ToolAllPaths = True
-resourcesOverlap ToolAllPaths ToolPath{} = True
-resourcesOverlap ToolAllPaths ToolPathTree{} = True
-resourcesOverlap ToolPath{} ToolAllPaths = True
-resourcesOverlap ToolPathTree{} ToolAllPaths = True
+resourcesOverlap ToolAllResources _ = True
+resourcesOverlap _ ToolAllResources = True
 resourcesOverlap (ToolNamedResource left) (ToolNamedResource right) =
     left == right
 resourcesOverlap (ToolPath left) (ToolPath right) =

--- a/packages/agent-core/src/Agent/Tools/Types.hs
+++ b/packages/agent-core/src/Agent/Tools/Types.hs
@@ -48,6 +48,7 @@ import Control.Exception.Safe (tryAny)
 import Control.Monad (foldM)
 import Data.Aeson (Value)
 import Data.IORef (IORef, newIORef, writeIORef)
+import Data.List.NonEmpty (NonEmpty(..))
 import qualified Data.Map.Strict as Map
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -75,8 +76,19 @@ data ApprovalRule
 data ToolExecutionPolicy
     = ParallelSafe
     | TurnSequential
+    -- | Run exclusively and defer approval of later calls from the same model
+    -- response until this handler finishes. Use for state transitions that can
+    -- change whether following calls are permitted.
+    | TurnApprovalBarrier
     deriving (Eq, Show)
 
+-- | Resolve the resources touched by one call.
+--
+-- Resolvers run once after approval. Calls following an exclusive plan are
+-- resolved only after that plan finishes, so arbitrary stateful tools cannot
+-- stale later claims. Resolvers must still be bounded and observational: they
+-- must not acquire leases or perform externally visible mutations. Errors,
+-- exceptions, and empty claim lists fail closed to exclusive execution.
 type ToolResourceResolver =
     ToolCall -> IO (Either Text [ToolResourceClaim])
 
@@ -215,6 +227,8 @@ rawJsonAppToolWithExecution
     , appToolResourceClaims = Nothing
     }
 
+-- | Refine a tool's static parallel/sequential policy with call-specific
+-- resource claims. Approval barriers remain exclusive.
 withToolResourceClaims
     :: ToolResourceResolver
     -> AppTool
@@ -296,18 +310,27 @@ toolSchedulingPlanFor
 toolSchedulingPlanFor registry call =
     case lookupRegisteredTool call.name registry of
         Nothing -> pure ToolExclusive
-        Just tool -> case tool.appToolResourceClaims of
-            Just resolve -> do
-                resolved <- tryAny (resolve call)
-                pure $ case resolved of
-                    Left _ -> ToolExclusive
-                    Right (Left _) -> ToolExclusive
-                    Right (Right claims) -> ToolResourceClaims claims
-            Nothing -> pure $ case tool.appToolExecution of
-                ParallelSafe ->
-                    ToolResourceClaims
-                        [ToolResourceClaim ToolRead ToolAllPaths]
-                TurnSequential -> ToolExclusive
+        Just tool
+            | tool.appToolExecution == TurnApprovalBarrier ->
+                pure ToolExclusive
+            | otherwise ->
+                case tool.appToolResourceClaims of
+                    Just resolve -> do
+                        resolved <- tryAny (resolve call)
+                        pure $ case resolved of
+                            Left _ -> ToolExclusive
+                            Right (Left _) -> ToolExclusive
+                            Right (Right (claim : claims)) ->
+                                ToolResourceClaims (claim :| claims)
+                            Right (Right []) -> ToolExclusive
+                    Nothing -> pure $ case tool.appToolExecution of
+                        ParallelSafe ->
+                            ToolResourceClaims
+                                (ToolResourceClaim
+                                    ToolRead
+                                    ToolAllResources :| [])
+                        TurnSequential -> ToolExclusive
+                        TurnApprovalBarrier -> ToolExclusive
 
 dispatchRegisteredToolCall
     :: ToolDispatchConfig

--- a/packages/agent-core/test/Agent/LoopSpec.hs
+++ b/packages/agent-core/test/Agent/LoopSpec.hs
@@ -7,10 +7,12 @@ import Agent.Responses.Types (ResponseItem(..), TaggedObject(..))
 import Agent.ToolArgs (objectArgs, reqText)
 import Agent.ToolDispatch
 import Agent.Tools.Scheduling
-    ( ToolAccess(..)
+    ( SchedulingDecision(..)
+    , ToolAccess(..)
     , ToolResource(..)
     , ToolResourceClaim(..)
     , ToolSchedulingPlan(..)
+    , nextSchedulingWave
     , schedulingPlansConflict
     )
 import Agent.Tools.Types
@@ -21,6 +23,7 @@ import Agent.Tools.Types
     , jsonAppToolWithExecution
     , mkToolRegistry
     , toolExecutionPolicyFor
+    , toolSchedulingPlanFor
     , withToolResourceClaims
     )
 import Control.Concurrent (forkIO, threadDelay)
@@ -35,6 +38,7 @@ import Control.Concurrent.MVar
 import qualified Control.Exception as Exception
 import Data.Aeson (FromJSON(..))
 import Data.IORef
+import Data.List.NonEmpty (NonEmpty((:|)))
 import Data.Text (Text)
 import qualified Data.Text as Text
 import System.Timeout (timeout)
@@ -459,6 +463,61 @@ spec = describe "runLoop" do
                 , tokenUsage = emptyTokenUsage
                 }
 
+    it "defers later approvals until an approval barrier finishes" do
+        transitioned <- newIORef False
+        laterRan <- newIORef False
+        approvalStates <- newIORef []
+        let barrier =
+                jsonAppToolWithExecution
+                    "barrier"
+                    ""
+                    []
+                    AlwaysReadOnly
+                    TurnApprovalBarrier
+                    (noArgsTool "barrier" do
+                        writeIORef transitioned True
+                        pure (Right "transitioned"))
+            later =
+                jsonAppToolWithExecution
+                    "later"
+                    ""
+                    []
+                    AlwaysReadOnly
+                    ParallelSafe
+                    (noArgsTool "later" do
+                        writeIORef laterRan True
+                        pure (Right "unexpected"))
+        submissions <- newIORef []
+        backend <- scriptedBackend submissions
+            [ Right $ emptyTurnOutput "resp-1"
+                [ functionToolCall "c1" "barrier" "{}"
+                , functionToolCall "c2" "later" "{}"
+                ]
+                Nothing
+            , Right $ emptyTurnOutput "resp-2" [] (Just "ok")
+            ]
+        config0 <- testConfig backend
+        let approve :: ToolCall -> IO (Either Text Bool)
+            approve call = do
+                active <- readIORef transitioned
+                modifyIORef' approvalStates (<> [(call.name, active)])
+                if call.name == "later" && active
+                    then pure (Left "blocked after transition")
+                    else pure (Right True)
+            config = config0
+                { loopTools = registryFromTools [barrier, later]
+                , loopApprove = approve
+                }
+        runLoop config Nothing "go" `shouldReturn` Right LoopResult
+            { finalResponseId = "resp-2"
+            , finalText = Just "ok"
+            , turnsUsed = 2
+            , tokenUsage = emptyTokenUsage
+            }
+        readIORef approvalStates `shouldReturn`
+            [("barrier", False), ("later", True)]
+        readIORef laterRan `shouldReturn` False
+
     it "keeps sequential calls as barriers around parallel-safe batches" do
         firstSafeStarted <- newEmptyMVar
         secondSafeStarted <- newEmptyMVar
@@ -556,6 +615,205 @@ spec = describe "runLoop" do
                 putMVar release ()
                 result <- wait running
                 result `shouldSatisfy` either (const False) (const True)
+
+    it "emits scheduling snapshots with call ids and blockers" do
+        events <- newIORef []
+        let tools =
+                [ resourceTool "first" "file:a" (pure (Right "first"))
+                , resourceTool "conflicting" "file:a" (pure (Right "conflicting"))
+                , resourceTool "independent" "file:b" (pure (Right "independent"))
+                ]
+        submissions <- newIORef []
+        backend <- scriptedBackend submissions
+            [ Right $ emptyTurnOutput "resp-1"
+                [ functionToolCall "c1" "first" "{}"
+                , functionToolCall "c2" "conflicting" "{}"
+                , functionToolCall "c3" "independent" "{}"
+                ]
+                Nothing
+            , Right $ emptyTurnOutput "resp-2" [] (Just "ok")
+            ]
+        config0 <- testConfig backend
+        let config = config0
+                { loopTools = registryFromTools tools
+                , loopOnEvent = \event -> modifyIORef' events (event :)
+                }
+        result <- runLoop config Nothing "go"
+        result `shouldSatisfy` either (const False) (const True)
+        seen <- reverse <$> readIORef events
+        let snapshots =
+                [ snapshot
+                | ToolSchedulingUpdated snapshot <- seen
+                ]
+        snapshots `shouldBe`
+            [ ToolSchedulingSnapshot
+                { schedulingReadyCallIds = ["c1", "c3"]
+                , schedulingBlockedCallIds = [("c2", "c1")]
+                }
+            , ToolSchedulingSnapshot
+                { schedulingReadyCallIds = ["c2"]
+                , schedulingBlockedCallIds = []
+                }
+            ]
+
+    it "does not report denied calls as running in scheduling snapshots" do
+        events <- newIORef []
+        let tools =
+                [ resourceTool "denied" "file:a" (pure (Right "unexpected"))
+                , resourceTool "allowed" "file:b" (pure (Right "allowed"))
+                ]
+        submissions <- newIORef []
+        backend <- scriptedBackend submissions
+            [ Right $ emptyTurnOutput "resp-1"
+                [ functionToolCall "c1" "denied" "{}"
+                , functionToolCall "c2" "allowed" "{}"
+                ]
+                Nothing
+            , Right $ emptyTurnOutput "resp-2" [] (Just "ok")
+            ]
+        config0 <- testConfig backend
+        let config = config0
+                { loopTools = registryFromTools tools
+                , loopApprove = \call ->
+                    pure (Right (call.name /= "denied"))
+                , loopOnEvent = \event -> modifyIORef' events (event :)
+                }
+        result <- runLoop config Nothing "go"
+        result `shouldSatisfy` either (const False) (const True)
+        seen <- reverse <$> readIORef events
+        let snapshots =
+                [ snapshot
+                | ToolSchedulingUpdated snapshot <- seen
+                ]
+        snapshots `shouldBe`
+            [ ToolSchedulingSnapshot
+                { schedulingReadyCallIds = ["c2"]
+                , schedulingBlockedCallIds = []
+                }
+            ]
+
+    it "cancels while dynamic resource claims are resolving" do
+        resolverStarted <- newEmptyMVar
+        resolverRelease <- newEmptyMVar
+        handlerStarted <- newEmptyMVar
+        let tool =
+                withToolResourceClaims
+                    (\_ -> do
+                        putMVar resolverStarted ()
+                        takeMVar resolverRelease
+                        pure $ Right
+                            [ ToolResourceClaim ToolWrite $
+                                ToolNamedResource "blocked-resolver"
+                            ])
+                    (jsonAppToolWithExecution
+                        "slow-resolver"
+                        ""
+                        []
+                        AlwaysReadOnly
+                        TurnSequential
+                        (noArgsTool "slow-resolver" do
+                            putMVar handlerStarted ()
+                            pure (Right "unexpected")))
+        submissions <- newIORef []
+        backend <- scriptedBackend submissions
+            [ Right $ emptyTurnOutput "resp-1"
+                [functionToolCall "c1" "slow-resolver" "{}"]
+                Nothing
+            ]
+        config0 <- testConfig backend
+        let config =
+                config0 { loopTools = registryFromTools [tool] }
+        withAsync (runLoop config Nothing "go") \running -> do
+            timeout concurrencyProbeMicros (takeMVar resolverStarted)
+                `shouldReturn` Just ()
+            requestCancel config.loopCancel
+            timeout concurrencyProbeMicros (wait running)
+                `shouldReturn` Just (Left (LoopCancelled []))
+            tryReadMVar handlerStarted `shouldReturn` Nothing
+
+    it "resolves claims after a preceding exclusive call finishes" do
+        transitioned <- newIORef False
+        resolutionStates <- newIORef []
+        let transition =
+                jsonAppToolWithExecution
+                    "transition"
+                    ""
+                    []
+                    AlwaysReadOnly
+                    TurnSequential
+                    (noArgsTool "transition" do
+                        writeIORef transitioned True
+                        pure (Right "transitioned"))
+            dependent =
+                withToolResourceClaims
+                    (\_ -> do
+                        current <- readIORef transitioned
+                        modifyIORef' resolutionStates (<> [current])
+                        pure $ Right
+                            [ ToolResourceClaim ToolWrite $
+                                ToolNamedResource "dependent"
+                            ])
+                    (jsonAppToolWithExecution
+                        "dependent"
+                        ""
+                        []
+                        AlwaysReadOnly
+                        TurnSequential
+                        (noArgsTool "dependent" (pure (Right "dependent"))))
+        submissions <- newIORef []
+        backend <- scriptedBackend submissions
+            [ Right $ emptyTurnOutput "resp-1"
+                [ functionToolCall "c1" "transition" "{}"
+                , functionToolCall "c2" "dependent" "{}"
+                ]
+                Nothing
+            , Right $ emptyTurnOutput "resp-2" [] (Just "ok")
+            ]
+        config0 <- testConfig backend
+        result <- runLoop
+            config0
+                { loopTools =
+                    registryFromTools [transition, dependent]
+                }
+            Nothing
+            "go"
+        result `shouldSatisfy` either (const False) (const True)
+        readIORef resolutionStates `shouldReturn` [True]
+
+    it "resolves each dynamic scheduling plan once" do
+        resolverCalls <- newIORef (0 :: Int)
+        let tool =
+                withToolResourceClaims
+                    (\_ -> do
+                        modifyIORef' resolverCalls (+ 1)
+                        pure $ Right
+                            [ ToolResourceClaim ToolWrite $
+                                ToolNamedResource "shared"
+                            ])
+                    (jsonAppToolWithExecution
+                        "writer"
+                        ""
+                        []
+                        AlwaysReadOnly
+                        TurnSequential
+                        (noArgsTool "writer" (pure (Right "ok"))))
+        submissions <- newIORef []
+        backend <- scriptedBackend submissions
+            [ Right $ emptyTurnOutput "resp-1"
+                [ functionToolCall "c1" "writer" "{}"
+                , functionToolCall "c2" "writer" "{}"
+                , functionToolCall "c3" "writer" "{}"
+                ]
+                Nothing
+            , Right $ emptyTurnOutput "resp-2" [] (Just "ok")
+            ]
+        config0 <- testConfig backend
+        result <- runLoop
+            config0 { loopTools = registryFromTools [tool] }
+            Nothing
+            "go"
+        result `shouldSatisfy` either (const False) (const True)
+        readIORef resolverCalls `shouldReturn` 3
 
     it "returns concurrent tool results in model order" do
         firstStarted <- newEmptyMVar
@@ -757,22 +1015,104 @@ spec = describe "runLoop" do
         result `shouldSatisfy` either (const False) (const True)
         readIORef resolverCalls `shouldReturn` 0
 
+    it "treats an empty dynamic resource set as an exclusive plan" do
+        let tool =
+                withToolResourceClaims
+                    (\_ -> pure (Right []))
+                    (jsonAppToolWithExecution
+                        "empty"
+                        ""
+                        []
+                        AlwaysReadOnly
+                        ParallelSafe
+                        (noArgsTool "empty" (pure (Right "ok"))))
+            call = functionToolCall "c1" "empty" "{}"
+        let registry = registryFromTools [tool]
+        plan <- toolSchedulingPlanFor registry call
+        plan `shouldBe` ToolExclusive
+
+    it "keeps approval barriers exclusive even when claims are attached" do
+        let tool =
+                withToolResourceClaims
+                    (\_ -> pure $ Right
+                        [ ToolResourceClaim ToolRead $
+                            ToolNamedResource "state"
+                        ])
+                    (jsonAppToolWithExecution
+                        "barrier"
+                        ""
+                        []
+                        AlwaysReadOnly
+                        TurnApprovalBarrier
+                        (noArgsTool "barrier" (pure (Right "ok"))))
+            registry = registryFromTools [tool]
+        plan <- toolSchedulingPlanFor registry
+            (functionToolCall "c1" "barrier" "{}")
+        plan `shouldBe` ToolExclusive
+
+    it "selects a stable wave and reports the earliest blocker" do
+        let writePlan name =
+                Just
+                    (ToolResourceClaims
+                        (ToolResourceClaim
+                            ToolWrite
+                            (ToolNamedResource name) :| []))
+            decision =
+                nextSchedulingWave
+                    [ (1 :: Int, writePlan "a")
+                    , (2, writePlan "a")
+                    , (3, writePlan "b")
+                    , (4, writePlan "a")
+                    ]
+        decision `shouldBe` SchedulingDecision
+            { schedulingReady = [1, 3]
+            , schedulingBlocked = [(2, 1), (4, 1)]
+            }
+
+    it "progresses blocked calls without starving later independent work" do
+        let writePlan name =
+                Just
+                    (ToolResourceClaims
+                        (ToolResourceClaim
+                            ToolWrite
+                            (ToolNamedResource name) :| []))
+            firstWave =
+                nextSchedulingWave
+                    [ (1 :: Int, writePlan "a")
+                    , (2, writePlan "a")
+                    , (3, writePlan "b")
+                    ]
+            secondWave =
+                nextSchedulingWave
+                    [ (2 :: Int, writePlan "a") ]
+        firstWave `shouldBe` SchedulingDecision
+            { schedulingReady = [1, 3]
+            , schedulingBlocked = [(2, 1)]
+            }
+        secondWave `shouldBe` SchedulingDecision
+            { schedulingReady = [2]
+            , schedulingBlocked = []
+            }
+
     it "detects overlapping filesystem resource claims" do
         let root = unsafeEncodeUtf "/workspace/src"
             file = unsafeEncodeUtf "/workspace/src/Main.hs"
             other = unsafeEncodeUtf "/workspace/test/Spec.hs"
             readTree =
                 ToolResourceClaims
-                    [ToolResourceClaim ToolRead (ToolPathTree root)]
+                    (ToolResourceClaim ToolRead (ToolPathTree root) :| [])
             writeFile path =
                 ToolResourceClaims
-                    [ToolResourceClaim ToolWrite (ToolPath path)]
+                    (ToolResourceClaim ToolWrite (ToolPath path) :| [])
         schedulingPlansConflict readTree (writeFile file) `shouldBe` True
         schedulingPlansConflict readTree (writeFile other) `shouldBe` False
         schedulingPlansConflict
             (ToolResourceClaims
-                [ToolResourceClaim ToolRead ToolAllPaths])
-            (writeFile other)
+                (ToolResourceClaim ToolRead ToolAllResources :| []))
+            (ToolResourceClaims
+                (ToolResourceClaim
+                    ToolWrite
+                    (ToolNamedResource "database-scope:user") :| []))
             `shouldBe` True
 
     it "treats unknown tools as sequential" do
@@ -1103,6 +1443,10 @@ spec = describe "runLoop" do
             , TurnFinished $ emptyTurnOutput "resp-1"
                 [functionToolCall "c1" "echo" "{\"message\":\"hi\"}"]
                 Nothing
+            , ToolSchedulingUpdated ToolSchedulingSnapshot
+                { schedulingReadyCallIds = ["c1"]
+                , schedulingBlockedCallIds = []
+                }
             , ToolStarted (functionToolCall "c1" "echo" "{\"message\":\"hi\"}")
             , ToolFinished (functionResult "c1" "echo:hi")
             , TurnStarted

--- a/packages/agent-core/test/Agent/Tools/MultiAgentsSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/MultiAgentsSpec.hs
@@ -16,6 +16,10 @@ import Agent.ToolDispatch
     , ToolCallResult(..)
     , dispatchToolCall
     )
+import Agent.Tools.Scheduling
+    ( ToolSchedulingPlan(..)
+    , schedulingPlansConflict
+    )
 import Agent.ToolDSL (PropertySchema(..))
 import Agent.Tools.MultiAgents
 import Agent.Tools.Types
@@ -23,6 +27,8 @@ import Agent.Tools.Types
     , ApprovalRule(..)
     , appToolHandlers
     , jsonToolParameters
+    , mkToolRegistry
+    , toolSchedulingPlanFor
     )
 import Control.Concurrent.STM
 import Control.Monad (unless)
@@ -35,6 +41,36 @@ fromFilePath = unsafeEncodeUtf
 
 spec :: Spec
 spec = describe "Agent.Tools.MultiAgents" do
+    it "uses pure task-path claims for registry and target mutations" do
+        registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
+            (\_ _ _ _ -> pure $ Left LoopNoResponseId)
+            (\_ _ -> pure ())
+        let context = rootContext registry Nothing
+        toolRegistry <- case mkToolRegistry (multiAgentTools context) of
+            Left err -> expectationFailure (Text.unpack err) >> fail "unreachable"
+            Right value -> pure value
+        firstSpawn <- toolSchedulingPlanFor toolRegistry
+            (spawnCall "worker_a")
+        secondSpawn <- toolSchedulingPlanFor toolRegistry
+            (spawnCall "worker_b")
+        first <- toolSchedulingPlanFor toolRegistry
+            (messageCall "send-a" "worker_a")
+        sameByPath <- toolSchedulingPlanFor toolRegistry
+            (messageCall "send-a-path" "/root/worker_a")
+        second <- toolSchedulingPlanFor toolRegistry
+            (messageCall "send-b" "worker_b")
+        listed <- toolSchedulingPlanFor toolRegistry
+            (ToolCall "list" "collaboration.list_agents" "{}"
+                FunctionCallKind False)
+        unknown <- toolSchedulingPlanFor toolRegistry sendMissingCall
+        schedulingPlansConflict firstSpawn secondSpawn `shouldBe` True
+        schedulingPlansConflict first second `shouldBe` False
+        schedulingPlansConflict first sameByPath `shouldBe` True
+        schedulingPlansConflict first listed `shouldBe` True
+        schedulingPlansConflict first unknown `shouldBe` True
+        unknown `shouldBe` ToolExclusive
+        closeSubagentRegistry registry
+
     it "keeps plaintext inter-agent content useful in Show output" do
         let rendered = show (PlainInterAgentContent "visible task")
         rendered `shouldContain` "PlainInterAgentContent"
@@ -369,6 +405,16 @@ spawnCall taskName = ToolCall
     , name = "collaboration.spawn_agent"
     , arguments =
         "{\"task_name\":\"" <> taskName <> "\",\"message\":\"task\"}"
+    , callKind = FunctionCallKind
+    , argumentsEncrypted = False
+    }
+
+messageCall :: Text -> Text -> ToolCall
+messageCall callId target = ToolCall
+    { callId
+    , name = "collaboration.send_message"
+    , arguments =
+        "{\"target\":\"" <> target <> "\",\"message\":\"hello\"}"
     , callKind = FunctionCallKind
     , argumentsEncrypted = False
     }

--- a/packages/agent-core/test/Agent/Tools/PlanModeSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/PlanModeSpec.hs
@@ -12,6 +12,7 @@ import Agent.Tools.PlanMode
 import Agent.Tools.Types
     ( AppTool(..)
     , ApprovalRule(..)
+    , ToolExecutionPolicy(..)
     , jsonToolParameters
     )
 import Control.Exception.Safe (bracket)
@@ -31,9 +32,14 @@ spec :: Spec
 spec = describe "Agent.Tools.PlanMode" do
     it "uses its dedicated confirmation instead of generic tool approval" do
         withTempPlan \env ->
-            case (enterPlanModeTool env).appToolApproval of
-                AlwaysReadOnly -> pure ()
-                _ -> expectationFailure "enter_plan_mode should be read-only"
+            let enter = enterPlanModeTool env
+            in do
+                case enter.appToolApproval of
+                    AlwaysReadOnly -> pure ()
+                    _ -> expectationFailure "enter_plan_mode should be read-only"
+                enter.appToolExecution `shouldBe` TurnApprovalBarrier
+                (exitPlanModeTool env).appToolExecution
+                    `shouldBe` TurnApprovalBarrier
 
     it "activates and deactivates plan mode" do
         withTempPlan \env -> do

--- a/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/SearchReplace.hs
+++ b/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/SearchReplace.hs
@@ -4,7 +4,12 @@ import Agent.OsPath (fromText)
 import System.OsPath (OsPath)
 import Agent.ToolArgs (objectArgs, optBool, reqText)
 import Agent.ToolDSL (PropertySchema(..), PropertyType(..))
-import Agent.ToolDispatch (typedTool)
+import Agent.ToolDispatch
+    ( ToolCall (..)
+    , decodeToolArguments
+    , toolArgumentsValue
+    , typedTool
+    )
 import Agent.Tools.FileSystem.GitIgnore (isGitIgnored)
 import Agent.GrokBuild.Dialect.Common (jsonTool)
 import Agent.Tools.IO (readTextFile, resolveUnderCwd, writeTextFile)
@@ -21,6 +26,12 @@ import Agent.Tools.Types
     , ToolEnv(..)
     , ToolExecutionPolicy(..)
     )
+import Agent.Tools.Scheduling
+    ( ToolAccess(..)
+    , ToolResource(..)
+    , ToolResourceClaim(..)
+    )
+import Agent.Tools.Types (withToolResourceClaims)
 import Control.Monad (unless, when)
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Except
@@ -51,7 +62,9 @@ instance FromJSON SearchReplaceArgs where
         <*> (fromMaybe False <$> optBool object "replace_all")
 
 searchReplaceTool :: ToolEnv -> PlanModeEnv -> AppTool
-searchReplaceTool env planMode = jsonTool "search_replace" searchReplaceDescription
+searchReplaceTool env planMode =
+    withToolResourceClaims (searchReplaceResourceClaims env) $
+    jsonTool "search_replace" searchReplaceDescription
     [ PropertySchema "file_path" PropertyString True $ Just
         "The path to the file to modify. Relative paths are resolved within the workspace. Absolute paths are accepted only when they resolve within the workspace."
     , PropertySchema "old_string" PropertyString True $ Just
@@ -64,6 +77,21 @@ searchReplaceTool env planMode = jsonTool "search_replace" searchReplaceDescript
     False
     TurnSequential
     (typedTool "search_replace" (runSearchReplace env planMode))
+
+searchReplaceResourceClaims
+    :: ToolEnv
+    -> ToolCall
+    -> IO (Either Text [ToolResourceClaim])
+searchReplaceResourceClaims env call =
+    case decodeToolArguments (toolArgumentsValue call.arguments)
+        :: Either Text SearchReplaceArgs
+    of
+        Left err -> pure (Left err)
+        Right args ->
+            resolveUnderCwd env (fromText args.filePath)
+                >>= pure . fmap
+                    (\path ->
+                        [ToolResourceClaim ToolWrite (ToolPath path)])
 
 searchReplaceDescription :: Text
 searchReplaceDescription =

--- a/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Terminal.hs
+++ b/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Terminal.hs
@@ -15,6 +15,10 @@ import Agent.Tools.IO
     ( combineCommandOutput
     , formatCommandResult
     )
+import Agent.Tools.PlanMode
+    ( PlanModeEnv
+    , isPlanModeActive
+    )
 import Agent.Tools.Types
     ( AppTool
     , ToolExecutionPolicy(..)
@@ -38,8 +42,8 @@ instance FromJSON TerminalArgs where
         <*> reqText object "description"
         <*> (fromMaybe False <$> optBool object "background")
 
-runTerminalCmdTool :: GrokSession -> AppTool
-runTerminalCmdTool session = jsonTool "run_terminal_cmd" terminalDescription
+runTerminalCmdTool :: GrokSession -> PlanModeEnv -> AppTool
+runTerminalCmdTool session planMode = jsonTool "run_terminal_cmd" terminalDescription
     [ PropertySchema "command" PropertyString True $ Just
         "The bash command to run."
     , PropertySchema "timeout" PropertyInteger False $ Just
@@ -51,7 +55,7 @@ runTerminalCmdTool session = jsonTool "run_terminal_cmd" terminalDescription
     ]
     False
     TurnSequential
-    (typedStreamingTool "run_terminal_cmd" (runTerminal session))
+    (typedStreamingTool "run_terminal_cmd" (runTerminal session planMode))
 
 terminalDescription :: Text
 terminalDescription =
@@ -61,10 +65,11 @@ terminalDescription =
 
 runTerminal
     :: GrokSession
+    -> PlanModeEnv
     -> (Text -> IO ())
     -> TerminalArgs
     -> IO (Either Text Text)
-runTerminal session emitOutput args
+runTerminal session planMode emitOutput args
     | Text.null args.description =
         pure (Left "Missing parameter: description")
     | commandLooksLikeRmRf args.command =
@@ -72,13 +77,19 @@ runTerminal session emitOutput args
     | not args.background && hasUnwaitedBackgroundOp args.command =
         pure $ Left
             "The command contains a background '&'. Set background=true to run it as a background task, or append `wait` if you meant to wait for the children."
-    | args.background = startBackground session args.command
     | otherwise = do
-        let timeoutMs = min 300000 (max 1 (fromMaybe 120000 args.timeout))
-        result <- runForegroundStreaming
-            session
-            (Text.unpack args.command)
-            timeoutMs
-            (\out err ->
-                emitOutput (stripAnsi (combineCommandOutput out err)))
-        pure $ Right $ stripAnsi (formatCommandResult result)
+        active <- isPlanModeActive planMode
+        if active
+            then pure (Left "Rejected: terminal commands are not allowed in plan mode.")
+            else if args.background
+                then startBackground session args.command
+            else do
+                let timeoutMs =
+                        min 300000 (max 1 (fromMaybe 120000 args.timeout))
+                result <- runForegroundStreaming
+                    session
+                    (Text.unpack args.command)
+                    timeoutMs
+                    (\out err ->
+                        emitOutput (stripAnsi (combineCommandOutput out err)))
+                pure $ Right $ stripAnsi (formatCommandResult result)

--- a/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Tools.hs
+++ b/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Tools.hs
@@ -71,7 +71,7 @@ grokTools
             , grepTool env
             , listDirTool env
             , searchReplaceTool env planMode
-            , runTerminalCmdTool session
+            , runTerminalCmdTool session planMode
             , todoWriteTool session
             , getTaskOutputTool session multi
             , waitTasksTool session multi

--- a/packages/agent-grok-build-dialect/test/Agent/GrokBuild/DialectSpec.hs
+++ b/packages/agent-grok-build-dialect/test/Agent/GrokBuild/DialectSpec.hs
@@ -11,10 +11,28 @@ import Agent.GrokBuild.Dialect.Runtime
     )
 import Agent.GrokBuild.Dialect.TaskControl (validateTaskIds)
 import Agent.ProjectInstructions (InstructionFile(..), LoadedAgentsMd(..))
-import Agent.Tools.Types (AppTool(..), defaultToolEnv)
+import Agent.ToolDispatch
+    ( ToolCall
+    , ToolCallResult(..)
+    , ToolDispatchConfig(..)
+    , functionToolCall
+    )
+import Agent.Tools.PlanMode (activatePlanMode)
+import Agent.Tools.Scheduling
+    ( ToolSchedulingPlan(..)
+    , schedulingPlansConflict
+    )
+import Agent.Tools.Types
+    ( AppTool(..)
+    , defaultToolEnv
+    , dispatchRegisteredToolCall
+    , mkToolRegistry
+    , toolSchedulingPlanFor
+    )
 import Control.Exception.Safe (bracket)
 import Data.IORef (newIORef)
 import qualified Data.Map.Strict as Map
+import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Time.Calendar (fromGregorian)
 import System.Directory (getTemporaryDirectory, removeDirectoryRecursive)
@@ -64,6 +82,69 @@ spec = describe "Grok Build dialect" do
             names `shouldNotContain` ["shell_command", "apply_patch"]
             coding.grokClose
 
+    it "keeps terminal calls exclusive and rejects them in plan mode" do
+        withTempDir \dir -> do
+            env <- defaultToolEnv (unsafeEncodeUtf dir)
+            typesRef <- newIORef Map.empty
+            coding <- newGrokCodingTools env Nothing Nothing typesRef
+            let registry =
+                    either (error . Text.unpack) id $
+                        mkToolRegistry coding.grokAppTools
+            let terminal :: Text -> Text -> ToolCall
+                terminal ident command =
+                    functionToolCall
+                        ident
+                        "run_terminal_cmd"
+                        ( "{\"command\":"
+                            <> Text.pack (show command)
+                            <> ",\"description\":\"inspect files\"}"
+                        )
+            plan <- toolSchedulingPlanFor registry (terminal "c1" "cat a.txt")
+            plan `shouldBe` ToolExclusive
+
+            activatePlanMode coding.grokPlanMode
+            blocked <- dispatchRegisteredToolCall testDispatchConfig registry
+                (terminal "c4" "pwd")
+            blocked.output `shouldSatisfy`
+                Text.isInfixOf "terminal commands are not allowed in plan mode"
+            blockedBackground <-
+                dispatchRegisteredToolCall testDispatchConfig registry $
+                    functionToolCall
+                        "c5"
+                        "run_terminal_cmd"
+                        "{\"command\":\"sleep 60\",\"description\":\"wait\",\
+                        \\"background\":true}"
+            blockedBackground.output `shouldSatisfy`
+                Text.isInfixOf "terminal commands are not allowed in plan mode"
+            coding.grokClose
+
+    it "derives exact write claims for search_replace paths" do
+        withTempDir \dir -> do
+            env <- defaultToolEnv (unsafeEncodeUtf dir)
+            typesRef <- newIORef Map.empty
+            coding <- newGrokCodingTools env Nothing Nothing typesRef
+            let registry =
+                    either (error . Text.unpack) id $
+                        mkToolRegistry coding.grokAppTools
+                replace :: Text -> Text -> ToolCall
+                replace ident path =
+                    functionToolCall
+                        ident
+                        "search_replace"
+                        ( "{\"file_path\":"
+                            <> Text.pack (show path)
+                            <> ",\"old_string\":\"a\",\"new_string\":\"b\"}"
+                        )
+            first <- toolSchedulingPlanFor registry
+                (replace "r1" "src/a.hs")
+            second <- toolSchedulingPlanFor registry
+                (replace "r2" "src/b.hs")
+            same <- toolSchedulingPlanFor registry
+                (replace "r3" "src/a.hs")
+            schedulingPlansConflict first second `shouldBe` False
+            schedulingPlansConflict first same `shouldBe` True
+            coding.grokClose
+
     it "formats and neutralizes project instruction reminders" do
         let loaded = LoadedAgentsMd
                 { loadedGlobal = Nothing
@@ -87,3 +168,12 @@ withTempDir action = do
         (mkdtemp (tmp </> "agent-grok-build-dialect-XXXXXX"))
         removeDirectoryRecursive
         action
+
+testDispatchConfig :: ToolDispatchConfig
+testDispatchConfig = ToolDispatchConfig
+    { toolDispatchUnknownTool = \name -> "unknown:" <> name
+    , toolDispatchFormatResult = either ("ERR " <>) id
+    , toolDispatchFormatException = \name _ -> "EX " <> name
+    , toolDispatchOnException = \_ _ -> pure ()
+    , toolDispatchOnOutput = \_ _ -> pure ()
+    }

--- a/packages/agent-tui/src/Agent/TUI/Model.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model.hs
@@ -47,6 +47,7 @@ import Agent.TUI.Motion
     )
 import Agent.Loop
     ( LoopEvent(..)
+    , ToolSchedulingSnapshot(..)
     , TokenUsage
     , TurnOutput(..)
     , emptyTokenUsage
@@ -665,6 +666,19 @@ reduceLoop event state = case event of
                         (blockIndex, call)
                         state.uiToolCalls
                 }
+    ToolSchedulingUpdated snapshot ->
+        let running = length snapshot.schedulingReadyCallIds
+            queued = length snapshot.schedulingBlockedCallIds
+            activity =
+                "Running " <> Text.pack (show running) <> " tool"
+                    <> if running == 1 then "" else "s"
+                    <> if queued == 0
+                        then ""
+                        else
+                            "; "
+                                <> Text.pack (show queued)
+                                <> " queued"
+        in state { uiActivity = activity }
     ToolOutputUpdated callId output ->
         updateToolOutput callId output state
     ToolFinished result ->

--- a/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
@@ -3,6 +3,7 @@ module Agent.TUI.ModelSpec (spec) where
 import Agent.TUI.Model
 import Agent.Loop
     ( LoopEvent(..)
+    , ToolSchedulingSnapshot(..)
     , emptyTurnOutput
     )
 import Agent.ToolDispatch
@@ -209,6 +210,19 @@ spec = describe "fullscreen UI reducer" do
                 Just
                     (warningNotice
                         "Codex usage is low: primary 8% left.")
+
+    it "shows scheduling diagnostics while a tool wave is running" do
+        let state =
+                apply
+                    [ UiLoop TurnStarted
+                    , UiLoop
+                        (ToolSchedulingUpdated
+                            ToolSchedulingSnapshot
+                                { schedulingReadyCallIds = ["c1", "c3"]
+                                , schedulingBlockedCallIds = [("c2", "c1")]
+                                })
+                    ]
+        state.uiActivity `shouldBe` "Running 2 tools; 1 queued"
 
     it "separates a partial response from its automatic retry" do
         let message =


### PR DESCRIPTION
## Summary

- extract deterministic resource scheduling into `Agent.Tools.Scheduling`
- resolve approved calls to structured read/write claims and execute stable, model-order waves
- parallelize exact non-conflicting filesystem paths, database scopes, shell sessions, and collaboration targets
- keep shell/terminal commands, approval barriers, unknown tools, invalid arguments, and failed/empty resolvers exclusive
- surface running/queued scheduling diagnostics through the CLI, gateway, and TUI

## Scheduling semantics

- approvals remain serial and plan-mode transitions split approval batches
- an exclusive call stops further plan resolution; later calls are resolved only after it completes
- resource conflicts preserve the earliest blocker while allowing safe calls to bypass unrelated blocked calls
- tool results retain model order, and existing cancellation/error behavior is preserved
- the scheduler is turn-handler-local; processes intentionally left running after a shell handler returns remain outside its lifetime, as before

## Validation

- `agent-core`: 342 examples, 0 failures
- `agent-codex-dialect`: 5 examples, 0 failures
- `agent-grok-build-dialect`: 31 examples, 0 failures
- `agent-tui`: 136 examples, 0 failures
- `agent-cli`: 863 examples, 0 failures
- `git diff --check origin/master...HEAD`
- live `agent-cli` TTY smoke in tmux with a fresh home; onboarding/prompt rendering and exit handling passed
- two independent focused reviews of the scheduler and structured-claim integrations

## Benchmark

Built with GHC 9.10.3 using benchmark options `-O2 -threaded -rtsopts`:

```sh
nix develop -c cabal build --offline agent-core:bench:tool-scheduling-bench
bin=$(nix develop -c cabal list-bin agent-core:bench:tool-scheduling-bench)
"$bin" matrix 10000 5 +RTS -N4 -T
```

The retained matrix measures 8, 32, and 128 calls with 10 ms handlers over five samples. Representative 128-call medians:

| workload | wall ms | CPU ms | allocated bytes |
|---|---:|---:|---:|
| old sequential | 1398.746 | 16.798 | 2,613,584 |
| existing static parallel | 11.789 | 2.784 | 2,602,560 |
| new disjoint resources | 11.955 | 2.876 | 2,519,536 |
| new mixed, 50% contention | 698.147 | 8.829 | 3,722,248 |
| new conflicting resources | 1392.920 | 19.344 | 6,620,992 |

Disjoint structured calls retain the existing parallel baseline, while conflicting calls remain serialized. The mixed workload scales with actual contention rather than forcing the entire batch to run sequentially.
