### PR TITLE
Render grep results with workspace-relative paths

### DIFF
--- a/packages/agent-core/agent-core.cabal
+++ b/packages/agent-core/agent-core.cabal
@@ -179,6 +179,7 @@ test-suite agent-core-test
                     , Agent.ToolArgsSpec
                     , Agent.ToolDispatchSpec
                     , Agent.Tools.DangerousSpec
+                    , Agent.Tools.FileSystem.GrepSpec
                     , Agent.Tools.GhciSpec
                     , Agent.Tools.IOSpec
                     , Agent.Tools.MultiAgentsSpec

--- a/packages/agent-core/src/Agent/Tools/FileSystem/Grep.hs
+++ b/packages/agent-core/src/Agent/Tools/FileSystem/Grep.hs
@@ -1,6 +1,6 @@
 module Agent.Tools.FileSystem.Grep (grepTool) where
 
-import Agent.OsPath (fromText, toText, unsafeToFilePath)
+import Agent.OsPath (fromText, unsafeToFilePath)
 import Agent.ToolArgs (objectArgs, optBool, optInt, optText, reqText)
 import Agent.ToolDSL (PropertySchema(..), PropertyType(..))
 import Agent.ToolDispatch
@@ -22,13 +22,24 @@ import Agent.Tools.Types
     , jsonTool
     , withToolResourceClaims
     )
+import Control.Applicative ((<|>))
 import Data.Aeson (FromJSON(..))
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
-import System.Directory (findExecutable)
+import System.Directory (canonicalizePath, findExecutable)
 import System.Exit (ExitCode(..))
-import System.Process (readProcessWithExitCode)
+import System.FilePath
+    ( addTrailingPathSeparator
+    , isRelative
+    , makeRelative
+    , splitDirectories
+    )
+import System.Process
+    ( CreateProcess(cwd)
+    , proc
+    , readCreateProcessWithExitCode
+    )
 import System.OsPath (OsPath)
 
 data GrepOutputMode = GrepContent | GrepFilesWithMatches | GrepCount
@@ -135,17 +146,36 @@ runGrep env args = do
                 "rg is not installed. Install ripgrep to use the grep tool."
             Just rgPath -> do
                 let limit = effectiveHeadLimit args
-                runRipgrep rgPath path args >>= \case
+                canonicalCwd <- canonicalizePath (unsafeToFilePath env.toolCwd)
+                runRipgrep rgPath canonicalCwd path args >>= \case
                     Left err -> pure (Left err)
-                    Right raw -> pure $ Right (formatGrepCard env.toolCwd raw limit)
+                    Right raw -> pure $ Right
+                        (formatGrepCard env.toolCwd raw limit)
 
 effectiveHeadLimit :: GrepArgs -> Int
 effectiveHeadLimit args = case args.outputMode of
     GrepContent -> min 2000 (fromMaybe 200 args.headLimit)
     _ -> min 10000 (fromMaybe 500 args.headLimit)
 
-runRipgrep :: FilePath -> OsPath -> GrepArgs -> IO (Either Text Text)
-runRipgrep rgPath path args = do
+runRipgrep
+    :: FilePath
+    -> FilePath
+    -> OsPath
+    -> GrepArgs
+    -> IO (Either Text Text)
+runRipgrep rgPath workspace path args = do
+    let absoluteSearchPath = unsafeToFilePath path
+        workspaceRelativePath = makeRelative workspace absoluteSearchPath
+        searchWithinWorkspace =
+            isRelative workspaceRelativePath
+                && case splitDirectories workspaceRelativePath of
+                    ".." : _ -> False
+                    _ -> True
+        (processCwd, searchPath)
+            | searchWithinWorkspace =
+                (Just workspace, workspaceRelativePath)
+            | otherwise =
+                (Nothing, absoluteSearchPath)
     let modeFlags = case args.outputMode of
             GrepContent -> ["--heading", "--with-filename", "--line-number"]
             GrepFilesWithMatches -> ["--files-with-matches"]
@@ -160,9 +190,10 @@ runRipgrep rgPath path args = do
             , ["-i" | args.caseInsensitive]
             , maybe [] (\t -> ["--type", Text.unpack t]) args.fileType
             , if args.multiline then ["-U", "--multiline-dotall"] else []
-            , ["--regexp", Text.unpack args.pattern, "--", unsafeToFilePath path]
+            , ["--regexp", Text.unpack args.pattern, "--", searchPath]
             ]
-    (code, stdout, stderr) <- readProcessWithExitCode rgPath rgArgs ""
+        process = (proc rgPath rgArgs) { cwd = processCwd }
+    (code, stdout, stderr) <- readCreateProcessWithExitCode process ""
     let raw = Text.pack stdout
     case code of
         ExitSuccess -> pure $ Right raw
@@ -177,7 +208,7 @@ formatGrepCard :: OsPath -> Text -> Int -> Text
 formatGrepCard cwd raw limit
     | Text.null (Text.strip raw) = "No matches found."
     | otherwise =
-        let ls = Text.lines raw
+        let ls = map (makeWorkspaceRelative cwd) (Text.lines raw)
             truncated = length ls > limit
             kept = take limit ls
             body = Text.unlines kept
@@ -186,9 +217,20 @@ formatGrepCard cwd raw limit
                     "\n[at least " <> Text.pack (show limit)
                         <> " lines; output truncated]"
                 | otherwise = ""
-        in "<workspace_result workspace_path=\""
-            <> toText cwd
-            <> "\">\n"
+        in "<workspace_result>\n"
             <> body
             <> footer
             <> "</workspace_result>"
+
+makeWorkspaceRelative :: OsPath -> Text -> Text
+makeWorkspaceRelative cwd line =
+    fromMaybe line
+        ( Text.stripPrefix workspacePrefix line
+            <|> Text.stripPrefix currentDirectoryPrefix line
+        )
+  where
+    workspacePrefix =
+        Text.pack
+            (addTrailingPathSeparator (unsafeToFilePath cwd))
+    currentDirectoryPrefix =
+        Text.pack (addTrailingPathSeparator ".")

--- a/packages/agent-core/test/Agent/Tools/FileSystem/GrepSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/FileSystem/GrepSpec.hs
@@ -1,0 +1,62 @@
+module Agent.Tools.FileSystem.GrepSpec (spec) where
+
+import Agent.ToolDispatch
+    ( ToolCallResult(..)
+    , ToolDispatchConfig(..)
+    , dispatchToolCall
+    , functionToolCall
+    )
+import Agent.Tools.FileSystem.Grep (grepTool)
+import Agent.Tools.Types (AppTool(..), defaultToolEnv)
+import Control.Exception.Safe (bracket)
+import qualified Data.Text as Text
+import System.Directory
+    ( createDirectory
+    , findExecutable
+    , getTemporaryDirectory
+    , removeDirectoryRecursive
+    )
+import System.FilePath ((</>))
+import System.OsPath (unsafeEncodeUtf)
+import System.Posix.Temp (mkdtemp)
+import Test.Hspec
+
+spec :: Spec
+spec = describe "grepTool" do
+    it "renders matches with workspace-relative paths" do
+        findExecutable "rg" >>= \case
+            Nothing -> pendingWith "rg is not installed"
+            Just _ -> withTempDir \dir -> do
+                let workspace = dir </> "workspace"
+                    sourceDir = workspace </> "src"
+                createDirectory workspace
+                createDirectory sourceDir
+                writeFile (sourceDir </> "Example.hs") "needle\n"
+                env <- defaultToolEnv (unsafeEncodeUtf workspace)
+                result <- dispatchToolCall testConfig
+                    [(grepTool env).appToolHandler]
+                    (functionToolCall "grep-1" "grep"
+                        "{\"pattern\":\"needle\"}")
+                result.output `shouldBe` Text.intercalate "\n"
+                    [ "<workspace_result>"
+                    , "src/Example.hs"
+                    , "1:needle"
+                    , "</workspace_result>"
+                    ]
+
+testConfig :: ToolDispatchConfig
+testConfig = ToolDispatchConfig
+    { toolDispatchUnknownTool = \name -> "unknown:" <> name
+    , toolDispatchFormatResult = either ("ERR " <>) id
+    , toolDispatchFormatException = \name _ -> "EX " <> name
+    , toolDispatchOnException = \_ _ -> pure ()
+    , toolDispatchOnOutput = \_ _ -> pure ()
+    }
+
+withTempDir :: (FilePath -> IO a) -> IO a
+withTempDir action = do
+    base <- getTemporaryDirectory
+    bracket
+        (mkdtemp (base </> "agent-core-grep-"))
+        removeDirectoryRecursive
+        action

--- a/packages/agent-core/test/Spec.hs
+++ b/packages/agent-core/test/Spec.hs
@@ -21,6 +21,7 @@ import qualified Agent.ToolArgsSpec as ToolArgsSpec
 import qualified Agent.ToolDispatchSpec as ToolDispatchSpec
 import qualified Agent.ToolDSLSpec as ToolDSLSpec
 import qualified Agent.Tools.DangerousSpec as DangerousSpec
+import qualified Agent.Tools.FileSystem.GrepSpec as GrepSpec
 import qualified Agent.Tools.GhciSpec as GhciSpec
 import qualified Agent.Tools.IOSpec as IOSpec
 import qualified Agent.Tools.MultiAgentsSpec as MultiAgentsSpec
@@ -51,6 +52,7 @@ main = hspec do
     ToolArgsSpec.spec
     ToolDispatchSpec.spec
     ToolDSLSpec.spec
+    GrepSpec.spec
     GhciSpec.spec
     IOSpec.spec
     MultiAgentsSpec.spec


### PR DESCRIPTION
## Summary

- run ripgrep from the workspace for searches inside it
- render workspace matches without repeated absolute path prefixes or the redundant `workspace_path` attribute
- preserve absolute paths for searches outside the workspace
- add an integration test for the relative result format

## Testing

- `printf ':main\\n:q\\n' | nix develop -c cabal repl agent-core:test:agent-core-test`
- 331 examples, 0 failures
