### PR TITLE
fix(tui): repaint cleanly after terminal resize

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -294,6 +294,7 @@ test-suite agent-cli-test
                     , Agent.CLI.TUIBridgeSpec
                     , Agent.CLI.TUIComposerSpec
                     , Agent.CLI.TUIImagePreviewSpec
+                    , Agent.CLI.TUIPropertySpec
                     , Agent.CLI.TUIScrollSpec
                     , Agent.CLI.UsageSpec
                     , Agent.CLI.WebLspSpec
@@ -324,6 +325,7 @@ test-suite agent-cli-test
                     , hspec >= 2.11 && < 2.12
                     , JuicyPixels
                     , process
+                    , QuickCheck >= 2.14 && < 2.16
                     , safe-exceptions
                     , stm
                     , text

--- a/packages/agent-cli/package.nix
+++ b/packages/agent-cli/package.nix
@@ -5,9 +5,9 @@
 , async, base, base64-bytestring, brick, bytestring, colour
 , containers, directory, filelock, filepath, haskeline, hasql-pool
 , hspec, http-client, http-client-tls, http-types, JuicyPixels, lib
-, mtl, network, network-uri, process, retry, safe-exceptions
-, scientific, stm, tagsoup, text, time, transformers, unix, vector
-, vty, vty-crossplatform
+, mtl, network, network-uri, process, QuickCheck, retry
+, safe-exceptions, scientific, stm, tagsoup, text, time
+, transformers, unix, vector, vty, vty-crossplatform
 }:
 mkDerivation {
   pname = "agent-cli";
@@ -38,7 +38,7 @@ mkDerivation {
     agent-responses agent-responses-types agent-store agent-tui
     agent-xai ansi-terminal async base brick bytestring colour
     containers directory filepath haskeline hspec JuicyPixels process
-    safe-exceptions stm text time transformers unix vty
+    QuickCheck safe-exceptions stm text time transformers unix vty
   ];
   benchmarkHaskellDepends = [
     aeson agent-core agent-responses agent-store base bytestring

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -10,10 +10,12 @@ module Agent.CLI.TUI.App
     , conversationScrollbarRenderer
     , choiceRowColumns
     , choiceClosesOnUiTransition
+    , drawApp
     , elapsedMillisSince
     , emitUiEvent
     , externalUrlCommand
     , hasQueuedFullscreenInput
+    , initialFullscreenAppState
     , motionDemandFor
     , lambdaArtWidget
     , nativeProgressKeepaliveDue
@@ -681,43 +683,13 @@ runFullscreen runtime workerAction = do
             wrapNativePreviewVty runtime vty
     initialVty <- buildVty
     let
-        initialState = AppState
-            { appUi = runtime.runtimeInitial
-            , appPermissionReply = Nothing
-            , appRuntime = runtime
-            , appSlashIndex = 0
-            , appChoice = Nothing
-            , appChoiceReply = Nothing
-            , appResume = Nothing
-            , appResumeReply = Nothing
-            , appResumeLoad = Nothing
-            , appResumeDelete = Nothing
-            , appTextPrompt = Nothing
-            , appTextReply = Nothing
-            , appSlashDismissed = False
-            , appPasted = False
-            , appHistory = history
-            , appHistoryIndex = Nothing
-            , appHistoryDraft = ""
-            , appKillBuffer = ""
-            , appSlashCatalog = defaultSlashCatalog
-            , appImagePreviews = []
-            , appAgentSelected = initialAgent
-            , appAgentEntries = initialAgents
-            , appAgentHover = Nothing
-            , appHoveredControl = Nothing
-            , appPressedControl = Nothing
-            , appWorkerStopped = False
-            , appConversationAnchor = Nothing
-            , appConversationReflowQueued = False
-            , appWindowTitle = Nothing
-            , appMotionElapsedMillis = 0
-            , appCompletionFlashes = Map.empty
-            , appMotionScheduleReset = False
-            , appClockNanos = initialClock
-            , appNativeProgressKeepaliveBucket = 0
-            , appSyntaxHighlighter = Nothing
-            }
+        initialState =
+            initialFullscreenAppState
+                runtime
+                history
+                initialAgent
+                initialAgents
+                initialClock
         (initialDemand, initialDelay) =
             appMotionTiming initialState
     atomically $
@@ -804,6 +776,55 @@ runFullscreen runtime workerAction = do
                         (uncurry AppAgentSnapshot snapshot)
                     pure snapshot
         agentTicker previous'
+
+-- | Construct the retained application state shared by the live entry point
+-- and renderer tests. Generated tests should start from the same defaults as
+-- a real fullscreen session instead of assembling an approximate state.
+initialFullscreenAppState
+    :: FullscreenRuntime
+    -> [Text]
+    -> AgentTarget
+    -> [AgentEntry]
+    -> Word64
+    -> AppState
+initialFullscreenAppState runtime history initialAgent initialAgents initialClock =
+    AppState
+        { appUi = runtime.runtimeInitial
+        , appPermissionReply = Nothing
+        , appRuntime = runtime
+        , appSlashIndex = 0
+        , appChoice = Nothing
+        , appChoiceReply = Nothing
+        , appResume = Nothing
+        , appResumeReply = Nothing
+        , appResumeLoad = Nothing
+        , appResumeDelete = Nothing
+        , appTextPrompt = Nothing
+        , appTextReply = Nothing
+        , appSlashDismissed = False
+        , appPasted = False
+        , appHistory = history
+        , appHistoryIndex = Nothing
+        , appHistoryDraft = ""
+        , appKillBuffer = ""
+        , appSlashCatalog = defaultSlashCatalog
+        , appImagePreviews = []
+        , appAgentSelected = initialAgent
+        , appAgentEntries = initialAgents
+        , appAgentHover = Nothing
+        , appHoveredControl = Nothing
+        , appPressedControl = Nothing
+        , appWorkerStopped = False
+        , appConversationAnchor = Nothing
+        , appConversationReflowQueued = False
+        , appWindowTitle = Nothing
+        , appMotionElapsedMillis = 0
+        , appCompletionFlashes = Map.empty
+        , appMotionScheduleReset = False
+        , appClockNanos = initialClock
+        , appNativeProgressKeepaliveBucket = 0
+        , appSyntaxHighlighter = Nothing
+        }
 
 wrapNativePreviewVty :: FullscreenRuntime -> V.Vty -> IO V.Vty
 wrapNativePreviewVty runtime vty
@@ -3850,6 +3871,11 @@ handleEventInner event = case event of
     VtyEvent V.EvResize{} -> do
         clearAgentHover
         invalidateCache
+        -- A resize can leave terminal cells from the previous geometry even
+        -- when Brick's next target picture is correctly bounded. Reset Vty's
+        -- assumed display so that redraw repaints the resized surface rather
+        -- than diffing against cells that may have wrapped or moved.
+        getVtyHandle >>= liftIO . V.refresh
         queueConversationReflow
     VtyEvent vtyEvent -> do
         clearAgentHover

--- a/packages/agent-cli/test/Agent/CLI/TUIPropertySpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIPropertySpec.hs
@@ -1,0 +1,619 @@
+module Agent.CLI.TUIPropertySpec (spec) where
+
+import Agent.CLI.AgentViewport
+    ( AgentEntry(..)
+    , AgentTarget(..)
+    )
+import Agent.CLI.Interrupt (CtrlCDecision(..))
+import Agent.CLI.TUI.App
+    ( drawApp
+    , initialFullscreenAppState
+    , newFullscreenInputBuffer
+    , newFullscreenRuntimeWithSyntaxLoader
+    )
+import Agent.CLI.TUI.Types
+    ( AppState(..)
+    , ChoiceOverlay(..)
+    , ChoicePresentation(..)
+    , TextInputMode(..)
+    , TextOverlay(..)
+    )
+import Agent.Subagents (SubagentId(..))
+import Agent.TUI.Model
+    ( BlockId(..)
+    , BlockState(..)
+    , Focus(..)
+    , PermissionOverlay(..)
+    , PromptLimitStatus(..)
+    , PromptState(..)
+    , RetryCountdown(..)
+    , UiBlock(..)
+    , UiEvent(..)
+    , UiState(..)
+    , initialUiState
+    , reduceUi
+    , timestampNewMessageBlocks
+    , warningNotice
+    )
+import Agent.TUI.Motion (MotionMode(..))
+import qualified Agent.TUI.Theme as Theme
+import Brick (renderWidget)
+import Control.Monad (forM)
+import Data.Foldable (toList)
+import Data.IORef (readIORef)
+import Data.List (find, nub)
+import qualified Data.Map.Strict as Map
+import qualified Data.Sequence as Seq
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Lazy as LazyText
+import qualified Graphics.Vty as V
+import qualified Graphics.Vty.Output as VOutput
+import Graphics.Vty.Output.Mock (mockTerminal)
+import Graphics.Vty.PictureToSpans (displayOpsForPic)
+import Graphics.Vty.Span (SpanOp(..))
+import Test.Hspec
+import Test.Hspec.QuickCheck (modifyMaxSuccess, prop)
+import Test.QuickCheck
+    ( Arbitrary(..)
+    , Gen
+    , Property
+    , chooseInt
+    , conjoin
+    , counterexample
+    , elements
+    , frequency
+    , ioProperty
+    , shrinkList
+    , sized
+    , vectorOf
+    , (===)
+    )
+
+newtype RenderTrace = RenderTrace [TuiAction]
+    deriving (Show)
+
+data TuiAction
+    = Resize !Int !Int
+    | Submit !Text
+    | Assistant !Text
+    | SystemMessage !Text
+    | ErrorMessage !Text
+    | SetDraft !Text !Int
+    | QueueInput !Text
+    | StartQueuedInput
+    | SetRepository !Text !Text
+    | SetNotice !Text
+    | ClearNotice
+    | MoveSelection !Int
+    | ToggleSelected
+    | SetFocus !Focus
+    | ShowPermission !Text
+    | MovePermission !Int
+    | HidePermission
+    | SetRetryCountdown !Text !Int !Text
+    | SetFollow !Bool
+    | EndTurn !BlockState
+    | RestartTurn
+    | ClearConversation
+    | ShowChoice !ChoicePresentation !Text !Text ![(Text, Text)] !Int
+    | ShowText !TextInputMode !Text !Text !Text !Int
+    | CloseAppOverlay
+    | SetAgents !Int !Text
+    deriving (Show)
+
+data RenderHarness = RenderHarness
+    { harnessApp :: !AppState
+    , harnessSize :: !(Int, Int)
+    }
+
+spec :: Spec
+spec = do
+    baseState <- runIO makeBaseState
+
+    describe "generated fullscreen rendering" do
+        modifyMaxSuccess (const 300) $
+            prop "keeps every generated frame and cursor inside the terminal" $
+                renderTraceProperty baseState
+
+        modifyMaxSuccess (const 100) $
+            prop "keeps Vty's incremental assumed frame equal to a clean frame" $
+                incrementalTraceProperty baseState
+
+        it "covers the terminal after a tall timestamped conversation is cleared" do
+            let populated =
+                    foldl
+                        (flip applyAction)
+                        (RenderHarness baseState (80, 40))
+                        (concat
+                            [ [ Submit ("prompt " <> Text.pack (show index))
+                              , Assistant
+                                    (Text.replicate 8
+                                        ("long answer " <> Text.pack (show index) <> " "))
+                              ]
+                            | index <- [1 :: Int .. 20]
+                            ])
+                cleared =
+                    applyAction
+                        (Resize 43 17)
+                        (applyAction ClearConversation populated)
+            assertFrame cleared
+
+        it "keeps narrow composer status borders intact" do
+            let app = baseState
+                    { appUi =
+                        baseState.appUi
+                            { uiDraft =
+                                "wide 漢字 emoji 🚀 combining é and a very long draft that wraps"
+                            , uiCursor = 66
+                            , uiPrompt =
+                                baseState.appUi.uiPrompt
+                                    { promptModel = "gpt-5.6-sol"
+                                    , promptEffort = "medium"
+                                    , promptMode = "ask"
+                                    , promptAccount =
+                                        "marc@digitallyinduced.com"
+                                    , promptLimitStatus =
+                                        Just PromptLimitStatus
+                                            { promptLimitText =
+                                                "5h limit left: 71%"
+                                            , promptLimitWarning = False
+                                            }
+                                    }
+                            }
+                    }
+                size = (43, 17)
+                picture =
+                    renderWidget
+                        (Just Theme.monochrome)
+                        (drawApp app)
+                        size
+                rows = pictureRows picture size
+            case find (Text.isInfixOf "gpt-5.6-sol") rows of
+                Nothing ->
+                    expectationFailure "composer status row was not rendered"
+                Just row -> do
+                    Text.take 1 row `shouldBe` "╰"
+                    Text.stripEnd row `shouldSatisfy` Text.isSuffixOf "╯"
+
+renderTraceProperty :: AppState -> RenderTrace -> Property
+renderTraceProperty baseState (RenderTrace actions) =
+    conjoin $
+        zipWith
+            (\index harness ->
+                counterexample
+                    ("after action " <> show index <> ": "
+                        <> show (actions !! (index - 1)))
+                    (frameProperties "generated frame" harness))
+            [1 :: Int ..]
+            (traceHarnesses baseState actions)
+
+incrementalTraceProperty :: AppState -> RenderTrace -> Property
+incrementalTraceProperty baseState (RenderTrace actions) =
+    ioProperty do
+        let harnesses = traceHarnesses baseState actions
+        (_, mockOutput) <- mockTerminal (80, 24)
+        let output =
+                mockOutput
+                    { VOutput.outputByteBuffer = const (pure ())
+                    }
+        results <-
+            forM (zip [1 :: Int ..] harnesses) \(index, harness) -> do
+                let app = harness.harnessApp
+                    size = harness.harnessSize
+                    picture =
+                        renderWidget
+                            (Just Theme.monochrome)
+                            (drawApp app)
+                            size
+                    cleanOps = displayOpsForPic picture size
+                output.setDisplayBounds size
+                context <- VOutput.displayContext output size
+                VOutput.outputPicture context picture
+                assumed <- readIORef output.assumedStateRef
+                pure $
+                    counterexample
+                        ("Vty assumed-state mismatch after action "
+                            <> show index)
+                        (assumed.prevOutputOps === Just cleanOps)
+        pure (conjoin results)
+
+traceHarnesses :: AppState -> [TuiAction] -> [RenderHarness]
+traceHarnesses baseState =
+    drop 1 . scanl (flip applyAction) initialHarness
+  where
+    initialHarness = RenderHarness baseState (80, 24)
+
+frameProperties :: String -> RenderHarness -> Property
+frameProperties label harness =
+    conjoin
+        [ counterexample (label <> ": composed width")
+            (V.imageWidth composed === width)
+        , counterexample (label <> ": composed height")
+            (V.imageHeight composed === height)
+        , counterexample (label <> ": top-level layer bounds")
+            (all layerFits layers === True)
+        , counterexample (label <> ": cursor bounds")
+            (cursorFits width height picture.picCursor === True)
+        , counterexample (label <> ": deterministic clean redraw")
+            (picture === cleanRedraw)
+        , uiStateProperties app.appUi
+        ]
+  where
+    app = harness.harnessApp
+    size@(width, height) = harness.harnessSize
+    widgets = drawApp app
+    picture = renderWidget (Just Theme.monochrome) widgets size
+    cleanRedraw = renderWidget (Just Theme.monochrome) widgets size
+    composed = V.picImage picture
+    layers =
+        [ V.picImage $
+            renderWidget (Just Theme.monochrome) [widget] size
+        | widget <- widgets
+        ]
+    layerFits image =
+        V.imageWidth image <= width
+            && V.imageHeight image <= height
+
+uiStateProperties :: UiState -> Property
+uiStateProperties state =
+    conjoin
+        [ counterexample "block IDs are unique"
+            (length blockIds === length (nub blockIds))
+        , counterexample "block index map matches retained order"
+            (state.uiBlockIndices === expectedIndices)
+        , counterexample "next block ID is after every retained block"
+            ((state.uiNextBlockId > maximum (0 : blockIds)) === True)
+        , counterexample "draft cursor is in bounds"
+            ((state.uiCursor >= 0
+                && state.uiCursor <= Text.length state.uiDraft)
+                === True)
+        , counterexample "selected block ID and index agree"
+            (selectionIsValid state === True)
+        , counterexample "permission selection is in bounds"
+            ((maybe True
+                (\permission ->
+                    permission.permissionIndex >= 0
+                        && permission.permissionIndex < 4)
+                state.uiPermission)
+                === True)
+        , counterexample "retry countdown is non-negative"
+            ((maybe True
+                ((>= 0) . (.retryCountdownRemainingMillis))
+                state.uiRetryCountdown)
+                === True)
+        ]
+  where
+    blocks = toList state.uiBlocks
+    blockIds = map (blockNumber . (.blockId)) blocks
+    expectedIndices =
+        Map.fromList
+            [ (block.blockId, index)
+            | (index, block) <- zip [0 :: Int ..] blocks
+            ]
+
+selectionIsValid :: UiState -> Bool
+selectionIsValid state =
+    case (state.uiSelectedBlock, state.uiSelectedBlockIndex) of
+        (Nothing, Nothing) -> True
+        (Just ident, Just index) ->
+            index >= 0
+                && index < Seq.length state.uiBlocks
+                && maybe False ((== ident) . (.blockId))
+                    (Seq.lookup index state.uiBlocks)
+                && Map.lookup ident state.uiBlockIndices == Just index
+        _ -> False
+
+blockNumber :: BlockId -> Int
+blockNumber (BlockId number) = number
+
+cursorFits :: Int -> Int -> V.Cursor -> Bool
+cursorFits width height = \case
+    V.NoCursor -> True
+    V.PositionOnly _ column row -> inBounds column row
+    V.Cursor column row -> inBounds column row
+    V.AbsoluteCursor column row -> inBounds column row
+  where
+    inBounds column row =
+        column >= 0
+            && column < width
+            && row >= 0
+            && row < height
+
+pictureRows :: V.Picture -> (Int, Int) -> [Text]
+pictureRows picture size =
+    map
+        (Text.concat . map spanText . toList)
+        (toList (displayOpsForPic picture size))
+  where
+    spanText = \case
+        TextSpan _ _ _ text -> LazyText.toStrict text
+        Skip width -> Text.replicate width " "
+        RowEnd width -> Text.replicate width " "
+
+applyAction :: TuiAction -> RenderHarness -> RenderHarness
+applyAction action harness =
+    case action of
+        Resize width height ->
+            harness
+                { harnessSize =
+                    (max 1 width, max 1 height)
+                }
+        Submit text -> applyUi (UiUserSubmitted text)
+        Assistant text -> applyUi (UiAssistantHistory text)
+        SystemMessage text -> applyUi (UiSystemMessage text)
+        ErrorMessage text -> applyUi (UiErrorMessage text)
+        SetDraft text cursor -> applyUi (UiSetDraft text cursor)
+        QueueInput text -> applyUi (UiInputQueued text)
+        StartQueuedInput -> applyUi UiQueuedInputStarted
+        SetRepository branch cwd -> applyUi (UiSetRepository branch cwd)
+        SetNotice text -> applyUi (UiSetNotice (Just (warningNotice text)))
+        ClearNotice -> applyUi (UiSetNotice Nothing)
+        MoveSelection amount -> applyUi (UiMoveSelection amount)
+        ToggleSelected -> applyUi UiToggleSelected
+        SetFocus focus -> applyUi (UiFocusChanged focus)
+        ShowPermission summary -> applyUi (UiPermissionShown summary)
+        MovePermission amount -> applyUi (UiPermissionMoved amount)
+        HidePermission -> applyUi UiPermissionHidden
+        SetRetryCountdown prefix remaining suffix ->
+            applyUi (UiRetryCountdown prefix remaining suffix)
+        SetFollow follow -> applyUi (UiSetFollow follow)
+        EndTurn blockState -> applyUi (UiTurnEnded blockState)
+        RestartTurn -> applyUi UiTurnRestarted
+        ClearConversation -> applyUi UiConversationCleared
+        ShowChoice presentation title body rows rawIndex ->
+            let index = rawIndex `mod` length rows
+            in harness
+                { harnessApp =
+                    harness.harnessApp
+                        { appChoice =
+                            Just ChoiceOverlay
+                                { choicePresentation = presentation
+                                , choiceTitle = title
+                                , choiceBody = body
+                                , choiceIndex = index
+                                , choiceRows = rows
+                                , choiceCloseOnTurnEnd = False
+                                }
+                        , appTextPrompt = Nothing
+                        }
+                }
+        ShowText mode title body draft rawCursor ->
+            harness
+                { harnessApp =
+                    harness.harnessApp
+                        { appChoice = Nothing
+                        , appTextPrompt =
+                            Just TextOverlay
+                                { textTitle = title
+                                , textBody = body
+                                , textDraft = draft
+                                , textCursor =
+                                    max 0
+                                        (min (Text.length draft) rawCursor)
+                                , textInputMode = mode
+                                }
+                        }
+                }
+        CloseAppOverlay ->
+            harness
+                { harnessApp =
+                    harness.harnessApp
+                        { appChoice = Nothing
+                        , appTextPrompt = Nothing
+                        }
+                }
+        SetAgents rawCount transcript ->
+            let count = max 0 (min 8 rawCount)
+                children = map (childEntry transcript) [1 .. count]
+                selected = case reverse children of
+                    [] -> AgentRoot
+                    child : _ -> child.agentTarget
+            in harness
+                { harnessApp =
+                    harness.harnessApp
+                        { appAgentEntries = rootEntry : children
+                        , appAgentSelected = selected
+                        }
+                }
+  where
+    applyUi event =
+        let app = harness.harnessApp
+            previous = app.appUi
+            next =
+                timestampNewMessageBlocks
+                    (Seq.length previous.uiBlocks)
+                    "11:58 PM"
+                    (reduceUi event previous)
+        in harness
+            { harnessApp = app { appUi = next }
+            }
+
+rootEntry :: AgentEntry
+rootEntry = AgentEntry
+    { agentTarget = AgentRoot
+    , agentPath = "/root"
+    , agentStatus = "running"
+    , agentSteps = []
+    , agentTranscript = []
+    }
+
+childEntry :: Text -> Int -> AgentEntry
+childEntry transcript index = AgentEntry
+    { agentTarget = AgentChild (SubagentId ("agent-" <> Text.pack (show index)))
+    , agentPath = "/root/task_" <> Text.pack (show index)
+    , agentStatus = if even index then "running" else "done"
+    , agentSteps = []
+    , agentTranscript =
+        [ "user: " <> transcript
+        , "assistant: " <> Text.reverse transcript
+        ]
+    }
+
+makeBaseState :: IO AppState
+makeBaseState = do
+    input <- newFullscreenInputBuffer
+    runtime <-
+        newFullscreenRuntimeWithSyntaxLoader
+            (pure (Left "disabled in renderer property tests"))
+            input
+            (pure ())
+            (const (pure ()))
+            (pure WarnExit)
+            (const (pure True))
+            (const (pure ()))
+            (const (pure ()))
+            (pure (AgentRoot, [rootEntry]))
+            (const (pure ()))
+            (pure ())
+            (const (pure ()))
+            MotionOff
+            False
+            initialUiState
+    pure $
+        initialFullscreenAppState
+            runtime
+            []
+            AgentRoot
+            [rootEntry]
+            0
+
+instance Arbitrary RenderTrace where
+    arbitrary = sized \size -> do
+        count <- chooseInt (1, max 1 (min 30 (size + 1)))
+        RenderTrace <$> vectorOf count genAction
+
+    shrink (RenderTrace actions) =
+        RenderTrace <$> shrinkList (const []) actions
+
+genAction :: Gen TuiAction
+genAction =
+    frequency
+        [ (8, uncurry Resize <$> genTerminalSize)
+        , (7, Submit <$> genBodyText)
+        , (7, Assistant <$> genBodyText)
+        , (3, SystemMessage <$> genBodyText)
+        , (3, ErrorMessage <$> genBodyText)
+        , (7, SetDraft <$> genBodyText <*> genCursor)
+        , (3, QueueInput <$> genBodyText)
+        , (1, pure StartQueuedInput)
+        , (2, SetRepository <$> genLineText <*> genLineText)
+        , (2, SetNotice <$> genLineText)
+        , (1, pure ClearNotice)
+        , (2, MoveSelection <$> chooseInt (-20, 20))
+        , (1, pure ToggleSelected)
+        , (2, SetFocus <$> elements [FocusComposer, FocusScrollback])
+        , (2, ShowPermission <$> genLineText)
+        , (1, MovePermission <$> chooseInt (-20, 20))
+        , (1, pure HidePermission)
+        , (2, SetRetryCountdown
+                <$> genLineText
+                <*> chooseInt (-1000, 100000)
+                <*> genLineText)
+        , (1, SetFollow <$> arbitrary)
+        , (1, EndTurn <$> elements
+                [ BlockComplete
+                , BlockFailed
+                , BlockCancelled
+                , BlockDenied
+                ])
+        , (1, pure RestartTurn)
+        , (2, pure ClearConversation)
+        , (3, ShowChoice
+                <$> elements [ChoiceDialog, ChoiceOnboarding]
+                <*> genLineText
+                <*> genBodyText
+                <*> genChoiceRows
+                <*> genCursor)
+        , (3, ShowText
+                <$> elements [TextInputPlain, TextInputSecret]
+                <*> genLineText
+                <*> genBodyText
+                <*> genBodyText
+                <*> genCursor)
+        , (2, pure CloseAppOverlay)
+        , (3, SetAgents <$> chooseInt (0, 8) <*> genBodyText)
+        ]
+
+genTerminalSize :: Gen (Int, Int)
+genTerminalSize =
+    frequency
+        [ (5, elements
+            [ (1, 1)
+            , (2, 3)
+            , (9, 10)
+            , (39, 9)
+            , (40, 10)
+            , (41, 11)
+            , (71, 24)
+            , (72, 10)
+            , (72, 24)
+            , (73, 25)
+            , (79, 23)
+            , (80, 24)
+            , (81, 25)
+            , (120, 40)
+            ])
+        , (1, (,) <$> chooseInt (1, 180) <*> chooseInt (1, 60))
+        ]
+
+genChoiceRows :: Gen [(Text, Text)]
+genChoiceRows = do
+    count <- chooseInt (1, 6)
+    vectorOf count ((,) <$> genLineText <*> genLineText)
+
+genCursor :: Gen Int
+genCursor = chooseInt (-20, 240)
+
+genLineText :: Gen Text
+genLineText = Text.filter (/= '\n') <$> genBodyText
+
+genBodyText :: Gen Text
+genBodyText = do
+    length' <-
+        frequency
+            [ (4, elements
+                [ 0, 1, 2, 8, 9, 10
+                , 39, 40, 41
+                , 71, 72, 73
+                , 79, 80, 81
+                , 120, 200
+                ])
+            , (1, chooseInt (0, 220))
+            ]
+    Text.pack <$> vectorOf length' genDisplayChar
+
+genDisplayChar :: Gen Char
+genDisplayChar =
+    frequency
+        [ (20, elements ['a' .. 'z'])
+        , (5, elements ['0' .. '9'])
+        , (5, elements [' ', ' ', ' ', '\n'])
+        , (2, elements ['`', '*', '_', '#', '|', '[', ']', '(', ')'])
+        , (3, elements ['漢', '界', '語'])
+        , (2, elements ['é', 'ø', 'ß'])
+        , (2, elements ['🙂', '🚀', '✓', '✕'])
+        , (1, elements ['\x0301', '\xFE0F'])
+        ]
+
+assertFrame :: RenderHarness -> Expectation
+assertFrame harness = do
+    V.imageWidth composed `shouldBe` width
+    V.imageHeight composed `shouldBe` height
+    mapM_
+        (\image -> do
+            V.imageWidth image `shouldSatisfy` (<= width)
+            V.imageHeight image `shouldSatisfy` (<= height))
+        layers
+    cursorFits width height picture.picCursor `shouldBe` True
+  where
+    app = harness.harnessApp
+    size@(width, height) = harness.harnessSize
+    widgets = drawApp app
+    picture = renderWidget (Just Theme.monochrome) widgets size
+    composed = V.picImage picture
+    layers =
+        [ V.picImage $
+            renderWidget (Just Theme.monochrome) [widget] size
+        | widget <- widgets
+        ]

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -62,6 +62,7 @@ import qualified Agent.CLI.TUIAppSpec as TUIAppSpec
 import qualified Agent.CLI.TUIBridgeSpec as TUIBridgeSpec
 import qualified Agent.CLI.TUIComposerSpec as TUIComposerSpec
 import qualified Agent.CLI.TUIImagePreviewSpec as TUIImagePreviewSpec
+import qualified Agent.CLI.TUIPropertySpec as TUIPropertySpec
 import qualified Agent.CLI.TUIScrollSpec as TUIScrollSpec
 import qualified Agent.CLI.UsageSpec as UsageSpec
 import qualified Agent.CLI.WebLspSpec as WebLspSpec
@@ -129,6 +130,7 @@ main = hspec do
     TUIBridgeSpec.spec
     TUIComposerSpec.spec
     TUIImagePreviewSpec.spec
+    TUIPropertySpec.spec
     TUIScrollSpec.spec
     UsageSpec.spec
     WebLspSpec.spec


### PR DESCRIPTION
## Summary

- force Vty to refresh its assumed display after terminal resize events so stale cells from the previous geometry are repainted
- share the live fullscreen initial-state constructor with renderer tests
- add QuickCheck action traces covering terminal breakpoints, conversations, overlays, permissions, agents, and Unicode input
- assert exact terminal coverage, bounded layers and cursors, deterministic redraws, and retained UI-state invariants
- add regressions for clearing tall timestamped conversations and narrow composer borders

## Testing

- focused existing TUI and property specs: 38 examples, 0 failures
- QuickCheck rendering traces: 300 passed
- QuickCheck incremental rendering traces: 100 passed
- reproduced the stale border in tmux by resizing from 100x30 to 43x17, then verified the fix at 43x17 and after resizing back to 100x30
