### PR TITLE
feat(openai): render reasoning summaries

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -478,7 +478,7 @@ import Agent.OpenAI.Compaction
 import qualified Agent.OpenAI.Auth as OpenAI
 import Agent.OpenAI.LoopBackend
     ( openAiAuxiliaryResponseSenderReconnecting
-    , openAiBackendWith
+    , openAiBackendWithReasoningVisibility
     , openAiResponseSenderReconnecting
     )
 import Agent.Responses.Types
@@ -2416,7 +2416,7 @@ runAgentInitializedWithLock
                     (Just sessionTmp)
                     today
                     (isOneShot options)
-            params = requestParams model instructions
+            params = requestParams provider model instructions
                 (schemasFromAppTools dialect tools) effort
             initialItems = maybe [] (foldSessionItems . snd) resumed
             initialTurns = maybe [] snd resumed
@@ -2736,6 +2736,7 @@ runAgentInitializedWithLock
                                 let (compactSender, lockedBackend) =
                                         lockedOpenAiSession
                                             options.optCompactThreshold
+                                            options.optShowRawReasoning
                                             wsLock
                                             tokenProvider
                                             activeConnectionRef
@@ -2747,6 +2748,7 @@ runAgentInitializedWithLock
                                             lockedBackend
                                     btwBackend privateParams =
                                         freshOpenAiBackend
+                                            options.optShowRawReasoning
                                             tokenProvider
                                             (readIORef privateParams)
                                     compactRunner focus =
@@ -7632,6 +7634,7 @@ reservedSessionId = \case
 -- transcript mutation must not interleave between those two requests.
 lockedOpenAiSession
     :: Maybe Int
+    -> Bool
     -> MVar ()
     -> TokenProvider
     -> IORef OpenAiPersistentConnection
@@ -7639,7 +7642,7 @@ lockedOpenAiSession
     -> IORef (Maybe (Int, Int))
     -> (TokenUsage -> IO ())
     -> (OpenAiCompactionSender, Backend)
-lockedOpenAiSession compactThreshold wsLock provider activeConnection
+lockedOpenAiSession compactThreshold showRawReasoning wsLock provider activeConnection
         getParams contextTokens
         recordCompactionUsage =
     let sendResponse request previousResponseId onEvent = do
@@ -7672,7 +7675,10 @@ lockedOpenAiSession compactThreshold wsLock provider activeConnection
                 onEvent
         baseBackend =
             withConnectionRecovery $
-                openAiBackendWith sendResponse getParams
+                openAiBackendWithReasoningVisibility
+                    showRawReasoning
+                    sendResponse
+                    getParams
         compactSender request =
             sendAuxiliary request Nothing (const (pure ()))
         compactingBackend =

--- a/packages/agent-cli/src/Agent/CLI/Options.hs
+++ b/packages/agent-cli/src/Agent/CLI/Options.hs
@@ -93,6 +93,8 @@ data CliOptions = CliOptions
       -- ^ OpenAI automatic-compaction threshold in estimated context tokens.
     , optEffort :: !(Maybe Text)
       -- ^ 'Nothing' means use 'defaultEffortFor' once the provider is known.
+    , optShowRawReasoning :: !Bool
+      -- ^ Show raw OpenAI reasoning text instead of summaries only.
     , optPrompt :: !(Maybe Text)
     , optPromptFile :: !(Maybe OsPath)
     , optManagedTurnFile :: !(Maybe OsPath)
@@ -122,6 +124,7 @@ defaultCliOptions = CliOptions
     , optMaxTurns = 500
     , optCompactThreshold = Nothing
     , optEffort = Nothing
+    , optShowRawReasoning = False
     , optPrompt = Nothing
     , optPromptFile = Nothing
     , optManagedTurnFile = Nothing
@@ -246,6 +249,8 @@ parseOptions options = \case
     "--effort" : value : rest -> do
         effort <- parseEffort (Text.pack value)
         parseOptions options { optEffort = Just effort } rest
+    "--show-raw-reasoning" : rest ->
+        parseOptions options { optShowRawReasoning = True } rest
     "-p" : value : rest ->
         parseOptions options { optPrompt = Just (Text.pack value) } rest
     "--prompt" : value : rest ->
@@ -367,6 +372,8 @@ usage = unlines
     , "      --effort LEVEL      Reasoning effort: none, low, medium, high, xhigh, max"
     , "                          (default: xhigh for Claude Code, high for xai/grok,"
     , "                          medium otherwise)"
+    , "      --show-raw-reasoning"
+    , "                          Show raw OpenAI reasoning (default: summaries only)"
     , "      --version           Print the agent-cli version"
     , "      --help              Show this help"
     , ""

--- a/packages/agent-cli/src/Agent/CLI/Request.hs
+++ b/packages/agent-cli/src/Agent/CLI/Request.hs
@@ -5,18 +5,20 @@ module Agent.CLI.Request
     ) where
 
 import Agent.Responses.Types
+import Agent.Provider (Provider(..))
 import qualified Data.Aeson.KeyMap as KeyMap
 import Data.Text (Text)
 
 -- | Codex requires @store = false@. Continuation still uses
 -- @previous_response_id@, with the local transcript available for recovery.
 requestParams
-    :: Text
+    :: Provider
+    -> Text
     -> Text
     -> [ResponseTool]
     -> Text
     -> ResponseCreateParams
-requestParams modelName instructionText toolSchemas effort =
+requestParams provider modelName instructionText toolSchemas effort =
     case defaultResponseCreateParams of
         ResponseCreateParams{..} ->
             ResponseCreateParams
@@ -28,7 +30,10 @@ requestParams modelName instructionText toolSchemas effort =
                     , effort = Just effort
                     , generateSummary = Nothing
                     , reasoningMode = Nothing
-                    , summary = Nothing
+                    , summary =
+                        if provider == OpenAIProvider
+                            then Just "auto"
+                            else Nothing
                     , extraFields = KeyMap.empty
                     }
                 , store = Just False

--- a/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
@@ -82,13 +82,15 @@ import Agent.Loop
     )
 import qualified Agent.OpenAI.Client as OpenAI
 import Agent.OpenAI.LoopBackend
-    ( openAiBackend
+    ( openAiBackendWithRawReasoning
     , openAiBackendWithTransportFallback
-    , statelessResponsesBackend
     )
 import Agent.OpenAI.WebSocketClient (withCodexWsRetrying)
 import System.OsPath (OsPath)
 import Agent.Provider (Provider(..), TokenProvider, providerSlug)
+import Agent.Responses.LoopBackend
+    ( statelessResponsesBackendWithRawReasoning
+    )
 import Agent.Responses.Types
     ( ReasoningConfig(..)
     , ResponseCreateParams(..)
@@ -540,13 +542,19 @@ restoreAgentFromDisk
 -- | Use a disposable WebSocket for side questions so cancellation cannot
 -- leave abandoned response frames queued on the main conversation connection.
 freshOpenAiBackend
-    :: TokenProvider
+    :: Bool
+    -> TokenProvider
     -> IO ResponseCreateParams
     -> Backend
-freshOpenAiBackend provider getParams = Backend \state previous inputs onEvent ->
-    withCodexWsRetrying provider \conn _credential ->
-        let Backend submit = openAiBackend conn getParams
-        in submit state previous inputs onEvent
+freshOpenAiBackend showRawReasoning provider getParams =
+    Backend \state previous inputs onEvent ->
+        withCodexWsRetrying provider \conn _credential ->
+            let Backend submit =
+                    openAiBackendWithRawReasoning
+                        showRawReasoning
+                        conn
+                        getParams
+            in submit state previous inputs onEvent
 
 -- | Child Codex agent: per-agent transcript retained across follow-ups,
 -- independently scoped WebSocket requests, and nested multi-agent tools.
@@ -623,16 +631,19 @@ runCodexSubagent runtime tokenProvider sendToRoot =
                                 <> "report results clearly. Your agent id is "
                                 <> env.subId.unSubagentId
                                 <> "."
-                        childParams = requestParams model instructions
+                        childParams = requestParams OpenAIProvider model instructions
                             (schemasFromAppTools codexDialect tools) effort
                     toolRegistry <- requireToolRegistry tools
                     childParamsRef <- newIORef childParams
                     httpFallbackActive <- newIORef False
                     let websocketBackend =
-                            freshOpenAiBackend tokenProvider
+                            freshOpenAiBackend
+                                runtime.subagentOptions.optShowRawReasoning
+                                tokenProvider
                                 (readIORef childParamsRef)
                         httpBackend =
-                            statelessResponsesBackend
+                            statelessResponsesBackendWithRawReasoning
+                                runtime.subagentOptions.optShowRawReasoning
                                 (\request _onEvent ->
                                     OpenAI.createCodexMessageWithProvider
                                         tokenProvider request)
@@ -794,7 +805,7 @@ runHttpSubagent runtime dialect provider sendToRoot mkBackend =
                                         genericSubagentSuffix agentType env.subId
                                     NoHostChildAgentProtocol ->
                                         ""
-                        childParams = requestParams model instructions
+                        childParams = requestParams provider model instructions
                             (schemasFromAppTools childDialect tools) effort
                     toolRegistry <- requireToolRegistry tools
                     childParamsRef <- newIORef childParams

--- a/packages/agent-cli/test/Agent/CLI/OptionsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/OptionsSpec.hs
@@ -61,6 +61,12 @@ spec = do
             parseArgs ["--effort", "HIGH"]
                 `shouldBe` Right (RunAgent defaultCliOptions { optEffort = Just "high" })
 
+        it "keeps raw OpenAI reasoning hidden unless explicitly requested" do
+            defaultCliOptions.optShowRawReasoning `shouldBe` False
+            parseArgs ["--show-raw-reasoning"]
+                `shouldBe` Right
+                    (RunAgent defaultCliOptions { optShowRawReasoning = True })
+
         it "rejects unknown effort levels" do
             parseArgs ["--effort", "extreme"] `shouldSatisfy` isLeft
 

--- a/packages/agent-cli/test/Agent/CLI/RequestSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RequestSpec.hs
@@ -2,6 +2,7 @@ module Agent.CLI.RequestSpec (spec) where
 
 import Agent.CLI.Request (requestParams)
 import Agent.CLI.Tools (webSearchTool)
+import Agent.Provider (Provider(..))
 import Agent.Responses.Types
 import qualified Data.Aeson.KeyMap as KeyMap
 import Test.Hspec
@@ -11,6 +12,7 @@ spec = describe "requestParams" do
     it "constructs a non-storing request with model, instructions, tools, and effort" do
         let params =
                 requestParams
+                    OpenAIProvider
                     "test-model"
                     "test instructions"
                     [webSearchTool]
@@ -26,5 +28,15 @@ spec = describe "requestParams" do
                 reasoning.context `shouldBe` Nothing
                 reasoning.generateSummary `shouldBe` Nothing
                 reasoning.reasoningMode `shouldBe` Nothing
-                reasoning.summary `shouldBe` Nothing
+                reasoning.summary `shouldBe` Just "auto"
                 reasoning.extraFields `shouldBe` KeyMap.empty
+
+    it "leaves reasoning summaries provider-controlled outside OpenAI" do
+        let params =
+                requestParams
+                    OpenRouterProvider
+                    "test-model"
+                    "test instructions"
+                    []
+                    "medium"
+        (params.reasoning >>= (.summary)) `shouldBe` Nothing

--- a/packages/agent-cli/test/Agent/CLI/SubagentStoreSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SubagentStoreSpec.hs
@@ -78,7 +78,8 @@ spec = describe "Agent.CLI.SubagentStore" do
                     , collaborationForkTurns = Nothing
                     }
             Just session <- Map.lookup agentId <$> readIORef sessionsRef
-            let rootParams = requestParams "gpt-5.6-sol" "" [] "medium"
+            let rootParams =
+                    requestParams OpenAIProvider "gpt-5.6-sol" "" [] "medium"
             resolveChildModelAndEffort
                 OpenAIProvider
                 rootParams
@@ -88,7 +89,8 @@ spec = describe "Agent.CLI.SubagentStore" do
                 `shouldBe` ("gpt-5.6-luna", "medium")
 
         it "keeps an explicit child model override" do
-            let rootParams = requestParams "gpt-5.6-sol" "" [] "medium"
+            let rootParams =
+                    requestParams OpenAIProvider "gpt-5.6-sol" "" [] "medium"
             resolveChildModelAndEffort
                 OpenAIProvider
                 rootParams

--- a/packages/agent-openai/src/Agent/OpenAI/LoopBackend.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/LoopBackend.hs
@@ -4,6 +4,7 @@
 -- "Agent.Responses.LoopBackend" and are re-exported here for compatibility.
 module Agent.OpenAI.LoopBackend
     ( openAiBackend
+    , openAiBackendWithRawReasoning
     , openAiBackendReconnecting
     , openAiAuxiliaryResponseSenderReconnecting
     , openAiAuxiliaryResponseSenderWithConnectionRecovery
@@ -12,6 +13,7 @@ module Agent.OpenAI.LoopBackend
     , openAiResponseSenderWithConnectionRecovery
     , openAiResponseSenderWithRetryPolicy
     , openAiBackendWith
+    , openAiBackendWithReasoningVisibility
     , openAiBackendWithRetryPolicy
     , openAiBackendWithConnectionRecovery
     , openAiBackendWithTransportFallback
@@ -31,6 +33,7 @@ import Agent.Error
     , isInlineRetryableProviderError
     , isInlineRetryableProviderResponseError
     )
+import qualified Agent.Responses.LoopBackend as Responses
 import Agent.Loop (Backend(..), BackendResult(..), LoopEvent(..))
 import Agent.OpenAI.Error (isResponseChainCompatibilityError)
 import Agent.OpenAI.Request (sanitizeCodexRequest)
@@ -51,8 +54,6 @@ import Agent.Responses.LoopBackend
     ( assistantTextFromResponse
     , responseToTurnOutput
     , responseTokenUsage
-    , statelessResponsesBackend
-    , streamEventToLoopEvent
     , streamOutputObserved
     , toolResultToItem
     , turnInputsToItems
@@ -89,6 +90,18 @@ openAiBackend
 openAiBackend conn =
     openAiBackendWith \request previousResponseId onEvent ->
         sendWsRequestWithEvents conn request previousResponseId onEvent
+
+-- | OpenAI backend with explicit raw-reasoning visibility. Normal Codex
+-- sessions should use 'openAiBackend', which displays summaries only.
+openAiBackendWithRawReasoning
+    :: Bool
+    -> CodexConn
+    -> IO ResponseCreateParams
+    -> Backend
+openAiBackendWithRawReasoning showRawReasoning conn =
+    openAiBackendWithReasoningVisibility showRawReasoning
+        \request previousResponseId onEvent ->
+            sendWsRequestWithEvents conn request previousResponseId onEvent
 
 -- | Reuse the session WebSocket while it is healthy, reconnecting after it dies.
 openAiBackendReconnecting
@@ -483,7 +496,22 @@ openAiBackendWith
     -> IO ResponseCreateParams
     -> Backend
 openAiBackendWith =
-    openAiBackendWithRetryPolicy transientStreamingResultPolicy
+    openAiBackendWithReasoningVisibility False
+
+-- | Injectable OpenAI backend with Codex-style reasoning visibility:
+-- summaries are always shown and raw reasoning is opt-in.
+openAiBackendWithReasoningVisibility
+    :: Bool
+    -> (ResponseCreateParams
+        -> Maybe Text
+        -> (ResponseStreamEvent -> IO ())
+        -> IO (Either ApiError Response))
+    -> IO ResponseCreateParams
+    -> Backend
+openAiBackendWithReasoningVisibility showRawReasoning =
+    openAiBackendWithRetryPolicyAndReasoningVisibility
+        showRawReasoning
+        transientStreamingResultPolicy
 
 -- | Streaming retries are replay-safe only until the loop has observed output.
 -- Server error events themselves are not loop-visible, so transient Codex
@@ -496,7 +524,20 @@ openAiBackendWithRetryPolicy
         -> IO (Either ApiError Response))
     -> IO ResponseCreateParams
     -> Backend
-openAiBackendWithRetryPolicy retryPolicy send getParams =
+openAiBackendWithRetryPolicy =
+    openAiBackendWithRetryPolicyAndReasoningVisibility False
+
+openAiBackendWithRetryPolicyAndReasoningVisibility
+    :: Bool
+    -> RetryPolicyM IO
+    -> (ResponseCreateParams
+        -> Maybe Text
+        -> (ResponseStreamEvent -> IO ())
+        -> IO (Either ApiError Response))
+    -> IO ResponseCreateParams
+    -> Backend
+openAiBackendWithRetryPolicyAndReasoningVisibility
+        showRawReasoning retryPolicy send getParams =
     Backend \history previousResponseId inputs onLoopEvent -> do
         baseParams <- sanitizeCodexRequest <$> getParams
         let newItems = turnInputsToItems inputs
@@ -506,7 +547,11 @@ openAiBackendWithRetryPolicy retryPolicy send getParams =
             -- messages before its opaque checkpoint, so replay the complete
             -- replacement instead of trimming that retained prefix.
             fullRequest = withRequestInput baseParams (history <> newItems)
-            emit event = mapM_ onLoopEvent (streamEventToLoopEvent event)
+            emit event =
+                mapM_ onLoopEvent
+                    (Responses.streamEventToLoopEventWithRawReasoning
+                        showRawReasoning
+                        event)
             (initialRequest, initialPrevious) =
                 case previousResponseId of
                     Nothing | not (null history) -> (fullRequest, Nothing)
@@ -561,6 +606,23 @@ openAiBackendWithRetryPolicy retryPolicy send getParams =
 transientStreamingResultPolicy :: RetryPolicyM IO
 transientStreamingResultPolicy =
     exponentialBackoff 5_000_000 <> limitRetries 3
+
+-- | OpenAI's default event projection: reasoning summaries are visible, while
+-- raw chain-of-thought deltas are suppressed.
+streamEventToLoopEvent :: ResponseStreamEvent -> Maybe LoopEvent
+streamEventToLoopEvent =
+    Responses.streamEventToLoopEventWithRawReasoning False
+
+-- | Stateless OpenAI transport with the same summary-only default as the
+-- WebSocket backend.
+statelessResponsesBackend
+    :: (ResponseCreateParams
+        -> (ResponseStreamEvent -> IO ())
+        -> IO (Either ApiError Response))
+    -> IO ResponseCreateParams
+    -> Backend
+statelessResponsesBackend =
+    Responses.statelessResponsesBackendWithRawReasoning False
 
 formatRetryScheduled :: ApiError -> Int -> Int -> Text
 formatRetryScheduled apiError attempt delayMicros =

--- a/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
@@ -208,11 +208,11 @@ spec = do
                 }
 
     describe "streamEventToLoopEvent" do
-        it "maps output_text.delta and reasoning deltas" do
+        it "maps output and summary deltas but hides raw reasoning" do
             streamEventToLoopEvent (deltaEvent EventOutputTextDelta "hello")
                 `shouldBe` Just (TextDelta "hello")
             streamEventToLoopEvent (deltaEvent EventReasoningTextDelta "think")
-                `shouldBe` Just (ReasoningDelta "think")
+                `shouldBe` Nothing
             streamEventToLoopEvent (deltaEvent EventReasoningSummaryTextDelta "sum")
                 `shouldBe` Just (ReasoningDelta "sum")
 
@@ -412,6 +412,28 @@ spec = do
                 ]
 
     describe "openAiBackendWith" do
+        it "shows raw reasoning only when explicitly enabled" do
+            let send _request _previous onEvent = do
+                    onEvent (deltaEvent EventReasoningTextDelta "raw")
+                    onEvent (deltaEvent EventReasoningSummaryTextDelta "summary")
+                    pure $ Right (testResponse "resp-1" [assistantItem "ok"])
+                collect showRawReasoning = do
+                    events <- newIORef []
+                    transcript <- newIORef []
+                    let backend =
+                            openAiBackendWithReasoningVisibility
+                                showRawReasoning
+                                send
+                                (pure baseParams)
+                    _ <- submitWithState transcript backend Nothing
+                        [UserMessage "hello"]
+                        (modifyIORef' events . (:))
+                    reverse <$> readIORef events
+
+            collect False `shouldReturn` [ReasoningDelta "summary"]
+            collect True `shouldReturn`
+                [ReasoningDelta "raw", ReasoningDelta "summary"]
+
         it "sends only the new items and threads previous_response_id" do
             seen <- newIORef []
             events <- newIORef []

--- a/packages/agent-responses/src/Agent/Responses/LoopBackend.hs
+++ b/packages/agent-responses/src/Agent/Responses/LoopBackend.hs
@@ -1,11 +1,13 @@
 -- | Provider-neutral loop adapters for Responses-compatible transports.
 module Agent.Responses.LoopBackend
     ( statelessResponsesBackend
+    , statelessResponsesBackendWithRawReasoning
     , tokenProviderStatelessResponsesBackend
     , turnInputsToItems
     , responseToTurnOutput
     , responseTokenUsage
     , streamEventToLoopEvent
+    , streamEventToLoopEventWithRawReasoning
     , streamOutputObserved
     , assistantTextFromResponse
     , toolResultToItem
@@ -62,13 +64,26 @@ statelessResponsesBackend
     -> IO ResponseCreateParams
     -> Backend
 statelessResponsesBackend send getParams =
+    statelessResponsesBackendWithRawReasoning True send getParams
+
+-- | Adapt a stateless Responses transport while optionally exposing raw
+-- reasoning text. Reasoning summaries remain visible in either mode.
+statelessResponsesBackendWithRawReasoning
+    :: Bool
+    -> (ResponseCreateParams
+        -> (ResponseStreamEvent -> IO ())
+        -> IO (Either ApiError Response))
+    -> IO ResponseCreateParams
+    -> Backend
+statelessResponsesBackendWithRawReasoning showRawReasoning send getParams =
     Backend \history _previousResponseId inputs onEvent -> do
         baseParams <- getParams
         let newItems = turnInputsToItems inputs
             requestItems = history <> newItems
             request = withRequestInput baseParams requestItems
         result <- send request \event ->
-            mapM_ onEvent (streamEventToLoopEvent event)
+            mapM_ onEvent
+                (streamEventToLoopEventWithRawReasoning showRawReasoning event)
         case result of
             Left err -> pure (Left err)
             Right response ->
@@ -420,7 +435,15 @@ assistantTextFromResponse response = case
         values -> Just (Text.intercalate "\n" values)
 
 streamEventToLoopEvent :: ResponseStreamEvent -> Maybe LoopEvent
-streamEventToLoopEvent = \case
+streamEventToLoopEvent = streamEventToLoopEventWithRawReasoning True
+
+-- | Convert a Responses stream event, optionally suppressing raw
+-- @response.reasoning_text.delta@ events. Summary deltas are always exposed.
+streamEventToLoopEventWithRawReasoning
+    :: Bool
+    -> ResponseStreamEvent
+    -> Maybe LoopEvent
+streamEventToLoopEventWithRawReasoning showRawReasoning = \case
     OtherResponseStreamEvent
         { otherEventType = StreamEventUnknown eventType } ->
             Just
@@ -435,7 +458,9 @@ streamEventToLoopEvent = \case
         case extraDeltaText eventExtraFields of
             Just text -> case otherEventType of
                 EventOutputTextDelta -> Just (TextDelta text)
-                EventReasoningTextDelta -> Just (ReasoningDelta text)
+                EventReasoningTextDelta
+                    | showRawReasoning -> Just (ReasoningDelta text)
+                    | otherwise -> Nothing
                 EventReasoningSummaryTextDelta -> Just (ReasoningDelta text)
                 _ -> Nothing
             Nothing -> Nothing

--- a/packages/agent-responses/test/Agent/Responses/LoopBackendSpec.hs
+++ b/packages/agent-responses/test/Agent/Responses/LoopBackendSpec.hs
@@ -5,6 +5,7 @@ import Agent.Loop
     ( Backend(..)
     , FileAttachment(..)
     , ImageAttachment(..)
+    , LoopEvent(..)
     , TurnInput(..)
     )
 import Agent.Provider
@@ -14,16 +15,24 @@ import Agent.Provider
     , Provider(..)
     , tokenProvider
     )
-import Agent.Responses.LoopBackend (tokenProviderStatelessResponsesBackend)
-import Agent.Responses.LoopBackend (turnInputsToItems)
+import Agent.Responses.LoopBackend
+    ( statelessResponsesBackend
+    , statelessResponsesBackendWithRawReasoning
+    , tokenProviderStatelessResponsesBackend
+    , turnInputsToItems
+    )
 import Agent.Responses.Types
     ( MessageContent(..)
     , ResponseContentPart(..)
     , ResponseItem(..)
     , ResponseMessage(..)
     , ResponseRole(..)
+    , ResponseStreamEvent(..)
+    , StreamEventType(..)
     , defaultResponseCreateParams
     )
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.KeyMap as KeyMap
 import Data.IORef
 import qualified Data.Text as Text
 import Test.Hspec
@@ -67,6 +76,53 @@ spec = describe "tokenProviderStatelessResponsesBackend" do
 
         result `shouldBe` Left (ConnectionError "stopped after failover")
         readIORef attempts `shouldReturn` [first, second]
+
+    it "forwards raw provider reasoning text to the UI loop" do
+        events <- newIORef []
+        let send _params onStreamEvent = do
+                onStreamEvent OtherResponseStreamEvent
+                    { otherEventType = EventReasoningTextDelta
+                    , sequenceNumber = Just 1
+                    , eventExtraFields =
+                        KeyMap.singleton "delta"
+                            (Aeson.String "checking the implementation")
+                    }
+                pure (Left (ConnectionError "stop after reasoning"))
+            backend =
+                statelessResponsesBackend send
+                    (pure defaultResponseCreateParams)
+
+        result <- backend.submitTurn [] Nothing [UserMessage "hello"]
+            (\event -> modifyIORef' events (<> [event]))
+
+        result `shouldBe` Left (ConnectionError "stop after reasoning")
+        readIORef events `shouldReturn`
+            [ReasoningDelta "checking the implementation"]
+
+    it "can hide raw reasoning while retaining reasoning summaries" do
+        events <- newIORef []
+        let send _params onStreamEvent = do
+                onStreamEvent OtherResponseStreamEvent
+                    { otherEventType = EventReasoningTextDelta
+                    , sequenceNumber = Just 1
+                    , eventExtraFields =
+                        KeyMap.singleton "delta" (Aeson.String "raw")
+                    }
+                onStreamEvent OtherResponseStreamEvent
+                    { otherEventType = EventReasoningSummaryTextDelta
+                    , sequenceNumber = Just 2
+                    , eventExtraFields =
+                        KeyMap.singleton "delta" (Aeson.String "summary")
+                    }
+                pure (Left (ConnectionError "stop after reasoning"))
+            backend =
+                statelessResponsesBackendWithRawReasoning False send
+                    (pure defaultResponseCreateParams)
+
+        _ <- backend.submitTurn [] Nothing [UserMessage "hello"]
+            (\event -> modifyIORef' events (<> [event]))
+
+        readIORef events `shouldReturn` [ReasoningDelta "summary"]
 
 credential :: String -> Credential
 credential label = Credential


### PR DESCRIPTION
## Summary
- request automatic reasoning summaries for OpenAI models
- display OpenAI summaries by default while gating raw reasoning behind `--show-raw-reasoning`
- apply the visibility policy consistently across root, side-question, subagent, WebSocket, and HTTP paths

## Testing
- `nix develop -c cabal test agent-responses-test agent-openai-test agent-cli-test`
- manual tmux smoke test with `gpt-5.6-luna` confirmed `Thought` summary blocks render
