### PR TITLE
refactor(responses): type function call argument events

### DIFF
--- a/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
@@ -320,6 +320,27 @@ spec = do
                 (ResponseFailedEvent (Aeson.object []) Nothing KeyMap.empty)
                 `shouldBe` False
 
+        it "treats function-call argument events as replay-unsafe" do
+            streamOutputObserved
+                ResponseFunctionCallArgumentsDeltaEvent
+                    { delta = Just "{}"
+                    , streamItemId = Just "fc_1"
+                    , streamOutputIndex = Just 0
+                    , sequenceNumber = Nothing
+                    , eventExtraFields = KeyMap.empty
+                    }
+                `shouldBe` True
+            streamOutputObserved
+                ResponseFunctionCallArgumentsDoneEvent
+                    { arguments = Just "{}"
+                    , functionName = Just "read_file"
+                    , streamItemId = Just "fc_1"
+                    , streamOutputIndex = Just 0
+                    , sequenceNumber = Nothing
+                    , eventExtraFields = KeyMap.empty
+                    }
+                `shouldBe` True
+
     describe "statelessResponsesBackend" do
         it "replays the local transcript on tool follow-ups" do
             seen <- newIORef []

--- a/packages/agent-openai/test/Agent/OpenAI/ResponsesSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/ResponsesSpec.hs
@@ -98,6 +98,73 @@ spec = do
         it "recognises every currently documented event discriminator" do
             mapM_ assertKnownEvent documentedStreamEventTypes
 
+        it "decodes function-call argument deltas into typed events" do
+            let original = Aeson.object
+                    [ "type" .=
+                        ("response.function_call_arguments.delta" :: Text)
+                    , "sequence_number" .= (7 :: Int)
+                    , "item_id" .= ("fc_1" :: Text)
+                    , "output_index" .= (2 :: Int)
+                    , "delta" .= ("{\"target_file\":" :: Text)
+                    , "future_event_field" .= True
+                    ]
+            case Aeson.fromJSON original
+                    :: Aeson.Result Responses.ResponseStreamEvent of
+                Aeson.Success
+                    event@Responses.ResponseFunctionCallArgumentsDeltaEvent
+                        { delta
+                        , streamItemId
+                        , streamOutputIndex
+                        , sequenceNumber
+                        } -> do
+                            delta `shouldBe` Just "{\"target_file\":"
+                            streamItemId `shouldBe` Just "fc_1"
+                            streamOutputIndex `shouldBe` Just 2
+                            sequenceNumber `shouldBe` Just 7
+                            Responses.responseStreamEventType event
+                                `shouldBe`
+                                    Responses.EventFunctionCallArgumentsDelta
+                            Aeson.toJSON event `shouldBe` original
+                Aeson.Success other ->
+                    expectationFailure ("unexpected event: " <> show other)
+                Aeson.Error err -> expectationFailure err
+
+        it "decodes completed function-call arguments into typed events" do
+            let original = Aeson.object
+                    [ "type" .=
+                        ("response.function_call_arguments.done" :: Text)
+                    , "sequence_number" .= (8 :: Int)
+                    , "item_id" .= ("fc_1" :: Text)
+                    , "output_index" .= (2 :: Int)
+                    , "name" .= ("read_file" :: Text)
+                    , "arguments" .=
+                        ("{\"target_file\":\"README.md\"}" :: Text)
+                    , "future_event_field" .= True
+                    ]
+            case Aeson.fromJSON original
+                    :: Aeson.Result Responses.ResponseStreamEvent of
+                Aeson.Success
+                    event@Responses.ResponseFunctionCallArgumentsDoneEvent
+                        { arguments
+                        , functionName
+                        , streamItemId
+                        , streamOutputIndex
+                        , sequenceNumber
+                        } -> do
+                            arguments `shouldBe`
+                                Just "{\"target_file\":\"README.md\"}"
+                            functionName `shouldBe` Just "read_file"
+                            streamItemId `shouldBe` Just "fc_1"
+                            streamOutputIndex `shouldBe` Just 2
+                            sequenceNumber `shouldBe` Just 8
+                            Responses.responseStreamEventType event
+                                `shouldBe`
+                                    Responses.EventFunctionCallArgumentsDone
+                            Aeson.toJSON event `shouldBe` original
+                Aeson.Success other ->
+                    expectationFailure ("unexpected event: " <> show other)
+                Aeson.Error err -> expectationFailure err
+
         it "decodes output-item completion into a typed event constructor" do
             let original = Aeson.object
                     [ "type" .= ("response.output_item.done" :: Text)
@@ -313,6 +380,8 @@ spec = do
                                 (show (eventName :: Text) <> ": " <> err))
                 [ "response.custom_tool_call_input.delta"
                 , "response.custom_tool_call_input.done"
+                , "response.function_call_arguments.delta"
+                , "response.function_call_arguments.done"
                 , "response.reasoning_summary_part.added"
                 , "response.reasoning_summary_text.done"
                 ]

--- a/packages/agent-responses-types/src/Agent/Responses/Types/Streaming.hs
+++ b/packages/agent-responses-types/src/Agent/Responses/Types/Streaming.hs
@@ -294,6 +294,21 @@ data ResponseStreamEvent
         , sequenceNumber   :: !(Maybe Int)
         , eventExtraFields :: !Aeson.Object
         }
+    | ResponseFunctionCallArgumentsDeltaEvent
+        { delta             :: !(Maybe Text)
+        , streamItemId      :: !(Maybe Text)
+        , streamOutputIndex :: !(Maybe Int)
+        , sequenceNumber    :: !(Maybe Int)
+        , eventExtraFields  :: !Aeson.Object
+        }
+    | ResponseFunctionCallArgumentsDoneEvent
+        { arguments         :: !(Maybe Text)
+        , functionName      :: !(Maybe Text)
+        , streamItemId      :: !(Maybe Text)
+        , streamOutputIndex :: !(Maybe Int)
+        , sequenceNumber    :: !(Maybe Int)
+        , eventExtraFields  :: !Aeson.Object
+        }
     | ResponseCustomToolInputDeltaEvent
         { delta             :: !(Maybe Text)
         , streamItemId      :: !(Maybe Text)
@@ -354,6 +369,10 @@ responseStreamEventType = \case
     ResponseQueuedEvent{} -> EventResponseQueued
     ResponseOutputItemAddedEvent{} -> EventOutputItemAdded
     ResponseOutputItemDoneEvent{} -> EventOutputItemDone
+    ResponseFunctionCallArgumentsDeltaEvent{} ->
+        EventFunctionCallArgumentsDelta
+    ResponseFunctionCallArgumentsDoneEvent{} ->
+        EventFunctionCallArgumentsDone
     ResponseCustomToolInputDeltaEvent{} -> EventCustomToolInputDelta
     ResponseCustomToolInputDoneEvent{} -> EventCustomToolInputDone
     ResponseReasoningSummaryPartAddedEvent{} -> EventReasoningSummaryPartAdded
@@ -389,6 +408,16 @@ instance ToJSON ResponseStreamEvent where
             outputItemEvent "response.output_item.added" item outputIndex sequenceNumber eventExtraFields
         ResponseOutputItemDoneEvent { item, outputIndex, sequenceNumber, eventExtraFields } ->
             outputItemEvent "response.output_item.done" item outputIndex sequenceNumber eventExtraFields
+        ResponseFunctionCallArgumentsDeltaEvent { delta, streamItemId, streamOutputIndex, sequenceNumber, eventExtraFields } ->
+            indexedItemEvent "response.function_call_arguments.delta"
+                streamItemId (Nothing :: Maybe Text) streamOutputIndex sequenceNumber eventExtraFields
+                [optionalField "delta" delta]
+        ResponseFunctionCallArgumentsDoneEvent { arguments, functionName, streamItemId, streamOutputIndex, sequenceNumber, eventExtraFields } ->
+            indexedItemEvent "response.function_call_arguments.done"
+                streamItemId (Nothing :: Maybe Text) streamOutputIndex sequenceNumber eventExtraFields
+                [ optionalField "name" functionName
+                , optionalField "arguments" arguments
+                ]
         ResponseCustomToolInputDeltaEvent { delta, streamItemId, streamCallId, streamOutputIndex, sequenceNumber, eventExtraFields } ->
             indexedItemEvent "response.custom_tool_call_input.delta"
                 streamItemId streamCallId streamOutputIndex sequenceNumber eventExtraFields
@@ -474,6 +503,36 @@ instance FromJSON ResponseStreamEvent where
             EventResponseQueued -> lifecycle ResponseQueuedEvent sequenceNumber o
             EventOutputItemAdded -> outputItem ResponseOutputItemAddedEvent sequenceNumber o
             EventOutputItemDone -> outputItem ResponseOutputItemDoneEvent sequenceNumber o
+            EventFunctionCallArgumentsDelta ->
+                ResponseFunctionCallArgumentsDeltaEvent
+                    <$> o .:? "delta"
+                    <*> o .:? "item_id"
+                    <*> o .:? "output_index"
+                    <*> pure sequenceNumber
+                    <*> pure
+                        ( without ["type"]
+                        $ withoutNonNull
+                            ["sequence_number", "delta", "item_id", "output_index"]
+                            o
+                        )
+            EventFunctionCallArgumentsDone ->
+                ResponseFunctionCallArgumentsDoneEvent
+                    <$> o .:? "arguments"
+                    <*> o .:? "name"
+                    <*> o .:? "item_id"
+                    <*> o .:? "output_index"
+                    <*> pure sequenceNumber
+                    <*> pure
+                        ( without ["type"]
+                        $ withoutNonNull
+                            [ "sequence_number"
+                            , "arguments"
+                            , "name"
+                            , "item_id"
+                            , "output_index"
+                            ]
+                            o
+                        )
             EventCustomToolInputDelta -> ResponseCustomToolInputDeltaEvent
                 <$> o .:? "delta"
                 <*> o .:? "item_id"

--- a/packages/agent-responses/src/Agent/Responses/LoopBackend.hs
+++ b/packages/agent-responses/src/Agent/Responses/LoopBackend.hs
@@ -478,6 +478,8 @@ streamOutputObserved event = case event of
         responseFragmentHasOutput responseValue
     ResponseOutputItemAddedEvent{} -> True
     ResponseOutputItemDoneEvent{} -> True
+    ResponseFunctionCallArgumentsDeltaEvent{} -> True
+    ResponseFunctionCallArgumentsDoneEvent{} -> True
     ResponseCustomToolInputDeltaEvent{} -> True
     ResponseCustomToolInputDoneEvent{} -> True
     ResponseReasoningSummaryPartAddedEvent{} -> True


### PR DESCRIPTION
## Summary

- add typed `ResponseFunctionCallArgumentsDeltaEvent` and `ResponseFunctionCallArgumentsDoneEvent` constructors to the canonical Responses stream model
- preserve `item_id`, `output_index`, sequence numbers, known payload fields, and unknown fields through JSON round trips
- mark function-call argument events as replay-unsafe once output has begun
- add codec and replay-safety coverage

This is intentionally separated from the speculative `read_file` implementation so the canonical event-model change can be reviewed and reused independently.

## Validation

- `agent-openai`: 218 examples, 0 failures, 1 expected pending live-auth test
- `git diff --check`
