### PR TITLE
fix(xai): restore billing proxy authentication

### DIFF
--- a/packages/agent-xai/src/Agent/XAI/Usage.hs
+++ b/packages/agent-xai/src/Agent/XAI/Usage.hs
@@ -3,6 +3,7 @@ module Agent.XAI.Usage
     ( GrokUsageSnapshot(..)
     , decodeGrokUsage
     , fetchGrokUsage
+    , fetchGrokUsageFrom
     , weeklyLimitLeft
     ) where
 
@@ -35,8 +36,13 @@ instance Aeson.FromJSON GrokUsageSnapshot where
         Aeson.withObject "Grok billing config" parseConfig config
       where
         parseConfig config = do
+            -- The credits service uses proto3 JSON, which omits scalar fields
+            -- at their default value. A freshly reset account can therefore
+            -- omit creditUsagePercent entirely; that represents 0%, not an
+            -- unreadable response.
             creditUsagePercent <-
-                config .: "creditUsagePercent" :: Parser Scientific
+                fromMaybe 0
+                    <$> (config .:? "creditUsagePercent" :: Parser (Maybe Scientific))
             currentPeriod <- config .: "currentPeriod"
             (periodType, startsAt, resetsAt) <-
                 Aeson.withObject "Grok billing period" parsePeriod currentPeriod
@@ -71,7 +77,16 @@ weeklyLimitLeft snapshot
     | otherwise = Nothing
 
 fetchGrokUsage :: Credential -> IO (Either Text GrokUsageSnapshot)
-fetchGrokUsage credential =
+fetchGrokUsage =
+    fetchGrokUsageFrom
+        "https://cli-chat-proxy.grok.com/v1/billing?format=credits"
+
+-- | Injectable endpoint variant used by request-contract tests.
+fetchGrokUsageFrom
+    :: String
+    -> Credential
+    -> IO (Either Text GrokUsageSnapshot)
+fetchGrokUsageFrom endpoint credential =
     tryAny requestUsage >>= \case
         Left _ ->
             pure $ Left
@@ -85,14 +100,12 @@ fetchGrokUsage credential =
                         ("Grok billing returned HTTP " <> Text.pack (show status))
   where
     requestUsage = do
-        request <-
-            parseRequest
-                "https://cli-chat-proxy.grok.com/v1/billing?format=credits"
+        request <- parseRequest endpoint
         httpLBS
             $ setRequestHeader
-                "X-Auth-Token"
+                "Authorization"
                 ["Bearer " <> Text.encodeUtf8 credential.accessToken]
-            $ setRequestHeader "X-XAI-Token-Auth" ["true"]
+            $ setRequestHeader "X-XAI-Token-Auth" ["xai-grok-cli"]
             $ setRequestHeader
                 "x-userid"
                 [Text.encodeUtf8 credential.accountId]

--- a/packages/agent-xai/test/Agent/XAI/UsageSpec.hs
+++ b/packages/agent-xai/test/Agent/XAI/UsageSpec.hs
@@ -1,11 +1,19 @@
 module Agent.XAI.UsageSpec (spec) where
 
+import Agent.Provider (Credential(..), Provider(..))
 import Agent.XAI.Usage
+import Control.Concurrent.MVar (MVar, newEmptyMVar, putMVar, takeMVar)
 import qualified Data.ByteString.Lazy.Char8 as LBS
+import qualified Data.CaseInsensitive as CI
+import Data.Text (Text)
+import qualified Data.Text.Encoding as Text
+import qualified Network.HTTP.Types as HTTP
+import qualified Network.Wai as Wai
+import qualified Network.Wai.Handler.Warp as Warp
 import Test.Hspec
 
 spec :: Spec
-spec =
+spec = do
     describe "decodeGrokUsage" do
         it "decodes and floors the current subscription period" do
             let body = LBS.pack
@@ -32,6 +40,18 @@ spec =
             decodeGrokUsage "not json"
                 `shouldBe` Left "Grok returned an unreadable usage response."
 
+        it "treats an omitted proto3 zero percentage as freshly reset usage" do
+            let body = LBS.pack
+                    "{\"config\":{\"isUnifiedBillingUser\":true,\
+                    \\"currentPeriod\":{\"type\":\"USAGE_PERIOD_TYPE_WEEKLY\",\
+                    \\"start\":\"2026-08-24T15:14:26Z\",\
+                    \\"end\":\"2026-08-31T15:14:26Z\"}}}"
+            case decodeGrokUsage body of
+                Left err -> expectationFailure (show err)
+                Right snapshot -> do
+                    snapshot.usedPercent `shouldBe` 0
+                    weeklyLimitLeft snapshot `shouldBe` Just 100
+
         it "does not label non-weekly periods as weekly" do
             let body = LBS.pack
                     "{\"config\":{\"creditUsagePercent\":20,\
@@ -40,3 +60,45 @@ spec =
                     \\"end\":\"2026-09-01T00:00:00Z\"}}}"
             fmap weeklyLimitLeft (decodeGrokUsage body)
                 `shouldBe` Right Nothing
+
+    describe "fetchGrokUsageFrom" do
+        it "uses the current Grok CLI proxy authentication contract" do
+            headersSeen <- newEmptyMVar
+            Warp.testWithApplication
+                (pure (billingApp headersSeen))
+                \port -> do
+                    result <- fetchGrokUsageFrom
+                        ("http://127.0.0.1:" <> show port <> "/v1/billing?format=credits")
+                        testCredential
+                    fmap (.usedPercent) result `shouldBe` Right 20
+            headers <- takeMVar headersSeen
+            lookup "Authorization" headers
+                `shouldBe` Just "Bearer token-a"
+            lookup "X-XAI-Token-Auth" headers
+                `shouldBe` Just "xai-grok-cli"
+            lookup "x-userid" headers
+                `shouldBe` Just "user-a"
+            lookup "X-Auth-Token" headers `shouldBe` Nothing
+
+billingApp
+    :: MVar [(Text, Text)]
+    -> Wai.Application
+billingApp headersSeen request respond = do
+    putMVar headersSeen
+        [ (Text.decodeUtf8 (CI.original name), Text.decodeUtf8 value)
+        | (name, value) <- Wai.requestHeaders request
+        ]
+    respond $ Wai.responseLBS HTTP.status200
+        [("Content-Type", "application/json")]
+        "{\"config\":{\"creditUsagePercent\":20,\
+        \\"currentPeriod\":{\"type\":\"USAGE_PERIOD_TYPE_WEEKLY\",\
+        \\"start\":\"2026-08-24T00:00:00Z\",\
+        \\"end\":\"2026-08-31T00:00:00Z\"}}}"
+
+testCredential :: Credential
+testCredential = Credential
+    { accessToken = "token-a"
+    , accountId = "user-a"
+    , leaseId = Nothing
+    , provider = XAIProvider
+    }


### PR DESCRIPTION
## Summary

- restore the Grok CLI proxy billing authentication contract
- treat omitted proto3 `creditUsagePercent` as zero after a usage reset
- add request-header and reset-response regression coverage

## Root cause

The billing probe used `X-Auth-Token` and `X-XAI-Token-Auth: true`, which the current CLI proxy rejects with HTTP 401. The proxy expects `Authorization: Bearer ...` and `X-XAI-Token-Auth: xai-grok-cli`.

Freshly reset unified-billing responses can also omit the zero-valued `creditUsagePercent` proto3 scalar. The decoder previously rejected those successful responses.

## Validation

- `nix develop -c cabal repl agent-xai:test:agent-xai-test --offline`
- 50 examples, 0 failures, 1 optional live test pending
- verified the final Haskell usage fetch against an active xAI subscription; it returned a weekly snapshot with 0% used
