### PR TITLE
perf(tui): speed up long transcript scrolling

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -129,6 +129,7 @@ library
                     , Agent.CLI.TUI.Composer
                     , Agent.CLI.TUI.ImagePreview
                     , Agent.CLI.TUI.Scroll
+                    , Agent.CLI.TUI.Transcript
                     , Agent.CLI.TUI.Types
                     , Agent.CLI.Turn
                     , Agent.CLI.TurnState
@@ -298,6 +299,7 @@ test-suite agent-cli-test
                     , Agent.CLI.TUIImagePreviewSpec
                     , Agent.CLI.TUIPropertySpec
                     , Agent.CLI.TUIScrollSpec
+                    , Agent.CLI.TUITranscriptSpec
                     , Agent.CLI.UsageSpec
                     , Agent.CLI.WebLspSpec
                     , Agent.CLI.WorktreeSpec
@@ -368,7 +370,8 @@ benchmark transcript-scrolling-bench
     hs-source-dirs:   benchmark
     main-is:          TranscriptScrolling.hs
     ghc-options:      -O2 -rtsopts "-with-rtsopts=-T"
-    build-depends:    base >= 4.17 && < 5
+    build-depends:    agent-cli
+                    , base >= 4.17 && < 5
                     , brick >= 2.9 && < 3
                     , deepseq
                     , text

--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -361,3 +361,15 @@ benchmark clipboard-latency-bench
                     , filepath
                     , safe-exceptions
                     , text
+
+benchmark transcript-scrolling-bench
+    import:           common-options
+    type:             exitcode-stdio-1.0
+    hs-source-dirs:   benchmark
+    main-is:          TranscriptScrolling.hs
+    ghc-options:      -O2 -rtsopts "-with-rtsopts=-T"
+    build-depends:    base >= 4.17 && < 5
+                    , brick >= 2.9 && < 3
+                    , deepseq
+                    , text
+                    , vty >= 6.4 && < 7

--- a/packages/agent-cli/benchmark/TranscriptScrolling.hs
+++ b/packages/agent-cli/benchmark/TranscriptScrolling.hs
@@ -1,0 +1,220 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Benchmark retained transcript redraws, the dominant work triggered by
+-- scrolling a long Brick viewport.
+module Main (main) where
+
+import Brick
+    ( Padding(..)
+    , ViewportType(..)
+    , Widget
+    , attrMap
+    , cached
+    , hBox
+    , padBottom
+    , renderFinal
+    , txt
+    , txtWrap
+    , vBox
+    , viewport
+    )
+import Brick.Types (RenderState)
+import Control.DeepSeq (force)
+import Control.Monad (replicateM)
+import Data.IORef (IORef, newIORef, readIORef, writeIORef)
+import Data.List (sortOn)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import GHC.Clock (getMonotonicTimeNSec)
+import GHC.Stats
+    ( RTSStats(..)
+    , getRTSStats
+    )
+import qualified Graphics.Vty as V
+import Graphics.Vty.PictureToSpans (displayOpsForPic)
+import System.CPUTime (getCPUTime)
+import System.Environment (getArgs)
+import System.Mem (performGC)
+
+data Name
+    = TranscriptViewport
+    | TranscriptBlock !Int
+    | TranscriptChunk !Int !Int
+    deriving (Eq, Ord, Read, Show)
+
+data Workload
+    = PerBlockCache
+    | ChunkCache
+
+data Sample = Sample
+    { elapsedMillis :: !Double
+    , cpuMillis :: !Double
+    , allocatedBytes :: !Integer
+    }
+
+main :: IO ()
+main = do
+    arguments <- getArgs
+    case arguments of
+        [workloadText, blockCountText, bodyLinesText, sampleCountText] -> do
+            workload <- parseWorkload workloadText
+            let blockCount = read blockCountText
+                bodyLines = read bodyLinesText
+                sampleCount = read sampleCountText
+                widget = transcriptWidget workload blockCount bodyLines
+            initialState <- warmCache widget
+            stateRef <- newIORef initialState
+            samples <-
+                replicateM sampleCount $
+                    measure redrawsPerSample widget stateRef
+            printSample
+                workloadText
+                blockCount
+                bodyLines
+                sampleCount
+                (median samples)
+        _ ->
+            error
+                "usage: transcript-scrolling-bench \
+                \(per-block-cache|chunk-cache) BLOCKS BODY_LINES SAMPLES"
+
+parseWorkload :: String -> IO Workload
+parseWorkload = \case
+    "per-block-cache" -> pure PerBlockCache
+    "chunk-cache" -> pure ChunkCache
+    other -> error ("unknown workload: " <> other)
+
+transcriptWidget :: Workload -> Int -> Int -> Widget Name
+transcriptWidget workload blockCount bodyLines =
+    viewport TranscriptViewport Vertical $
+        case workload of
+            PerBlockCache -> vBox blocks
+            ChunkCache ->
+                vBox
+                    [ if length widgets == transcriptChunkSize
+                        then
+                            cached
+                                (TranscriptChunk
+                                    first
+                                    (first + length widgets - 1))
+                                rendered
+                        else rendered
+                    | (first, widgets) <-
+                        zip [1, 1 + transcriptChunkSize ..]
+                            (chunksOf transcriptChunkSize blocks)
+                    , let rendered = vBox widgets
+                    ]
+  where
+    body =
+        Text.intercalate "\n" $
+            replicate bodyLines representativeLine
+    blocks =
+        [ cached (TranscriptBlock index) $
+            padBottom (Pad 1) $
+                hBox [txt "  ", txtWrap body]
+        | index <- [1 .. blockCount]
+        ]
+
+representativeLine :: Text
+representativeLine =
+    "Representative retained transcript text that wraps across the viewport."
+
+transcriptChunkSize :: Int
+transcriptChunkSize = 32
+
+redrawsPerSample :: Int
+redrawsPerSample = 25
+
+benchmarkRegion :: V.DisplayRegion
+benchmarkRegion = (100, 32)
+
+warmCache :: Widget Name -> IO (RenderState Name)
+warmCache widget = do
+    let (renderState, picture, _, _) =
+            renderFinal
+                (attrMap V.defAttr [])
+                [widget]
+                benchmarkRegion
+                (const Nothing)
+                emptyRenderState
+    let !_ = force (show (displayOpsForPic picture benchmarkRegion))
+    pure renderState
+
+measure
+    :: Int
+    -> Widget Name
+    -> IORef (RenderState Name)
+    -> IO Sample
+measure iterations widget stateRef = do
+    performGC
+    beforeStats <- getRTSStats
+    beforeCpu <- getCPUTime
+    beforeTime <- getMonotonicTimeNSec
+    checksum <- redraw iterations 0
+    checksum `seq` pure ()
+    afterTime <- getMonotonicTimeNSec
+    afterCpu <- getCPUTime
+    afterStats <- getRTSStats
+    pure Sample
+        { elapsedMillis =
+            fromIntegral (afterTime - beforeTime) / 1.0e6
+        , cpuMillis =
+            fromIntegral (afterCpu - beforeCpu) / 1.0e9
+        , allocatedBytes =
+            fromIntegral
+                (allocated_bytes afterStats - allocated_bytes beforeStats)
+        }
+  where
+    redraw remaining checksum
+        | remaining <= 0 = pure checksum
+        | otherwise = do
+            renderState <- readIORef stateRef
+            let (nextState, picture, _, extents) =
+                    renderFinal
+                        (attrMap V.defAttr [])
+                        [widget]
+                        benchmarkRegion
+                        (const Nothing)
+                        renderState
+            let !rendered =
+                    force
+                        ( show (displayOpsForPic picture benchmarkRegion)
+                        , length extents
+                        )
+            writeIORef stateRef $! nextState
+            redraw
+                (remaining - 1)
+                (checksum + length (fst rendered) + snd rendered)
+
+median :: [Sample] -> Sample
+median samples =
+    sortOn (.elapsedMillis) samples !! (length samples `div` 2)
+
+printSample :: String -> Int -> Int -> Int -> Sample -> IO ()
+printSample workload blockCount bodyLines sampleCount sample =
+    putStrLn $
+        unwords
+            [ workload
+            , "blocks=" <> show blockCount
+            , "body_lines=" <> show bodyLines
+            , "redraws_per_sample=" <> show redrawsPerSample
+            , "samples=" <> show sampleCount
+            , "elapsed_ms=" <> show sample.elapsedMillis
+            , "cpu_ms=" <> show sample.cpuMillis
+            , "allocated_bytes=" <> show sample.allocatedBytes
+            ]
+
+chunksOf :: Int -> [a] -> [[a]]
+chunksOf _ [] = []
+chunksOf size values =
+    let (prefix, suffix) = splitAt size values
+    in prefix : chunksOf size suffix
+
+emptyRenderState :: RenderState Name
+emptyRenderState =
+    read
+        "RS {viewportMap = fromList [], rsScrollRequests = [], \
+        \observedNames = fromList [], renderCache = fromList [], \
+        \clickableNames = [], requestedVisibleNames_ = fromList [], \
+        \reportedExtents = fromList []}"

--- a/packages/agent-cli/benchmark/TranscriptScrolling.hs
+++ b/packages/agent-cli/benchmark/TranscriptScrolling.hs
@@ -20,6 +20,7 @@ import Brick
     , viewport
     )
 import Brick.Types (RenderState)
+import Agent.CLI.TUI.Transcript (transcriptChunkSize)
 import Control.DeepSeq (force)
 import Control.Monad (replicateM)
 import Data.IORef (IORef, newIORef, readIORef, writeIORef)
@@ -119,9 +120,6 @@ transcriptWidget workload blockCount bodyLines =
 representativeLine :: Text
 representativeLine =
     "Representative retained transcript text that wraps across the viewport."
-
-transcriptChunkSize :: Int
-transcriptChunkSize = 32
 
 redrawsPerSample :: Int
 redrawsPerSample = 25

--- a/packages/agent-cli/package.nix
+++ b/packages/agent-cli/package.nix
@@ -3,10 +3,10 @@
 , agent-openrouter, agent-responses, agent-responses-types
 , agent-store, agent-syntax, agent-tui, agent-xai, ansi-terminal
 , async, base, base64-bytestring, brick, bytestring, colour
-, containers, directory, filelock, filepath, haskeline, hasql-pool
-, hspec, http-client, http-client-tls, http-types, JuicyPixels, lib
-, mtl, network, network-uri, process, QuickCheck, retry
-, safe-exceptions, scientific, stm, tagsoup, text, time
+, containers, deepseq, directory, filelock, filepath, haskeline
+, hasql-pool, hspec, http-client, http-client-tls, http-types
+, JuicyPixels, lib, mtl, network, network-uri, process, QuickCheck
+, retry, safe-exceptions, scientific, stm, tagsoup, text, time
 , transformers, unix, vector, vty, vty-crossplatform
 }:
 mkDerivation {
@@ -41,8 +41,9 @@ mkDerivation {
     QuickCheck safe-exceptions stm text time transformers unix vty
   ];
   benchmarkHaskellDepends = [
-    aeson agent-core agent-responses agent-store base bytestring
-    containers directory filepath JuicyPixels safe-exceptions text
+    aeson agent-core agent-responses agent-store base brick bytestring
+    containers deepseq directory filepath JuicyPixels safe-exceptions
+    text vty
   ];
   description = "Command-line interface for the universal agent harness";
   license = lib.meta.getLicenseFromSpdxId "MIT";

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -153,6 +153,7 @@ import Agent.Syntax
     , loadSyntaxHighlighter
     )
 import qualified Agent.CLI.TUI.Scroll as Scroll
+import qualified Agent.CLI.TUI.Transcript as Transcript
 import Agent.CLI.TUI.Types
 import Agent.TUI.Model
 import Agent.TUI.Motion
@@ -211,7 +212,7 @@ import Data.IORef
 import Data.List (find, findIndex, intersperse, nub, sort, sortOn)
 import Data.List.NonEmpty (NonEmpty(..))
 import qualified Data.Map.Strict as Map
-import Data.Maybe (fromMaybe, isJust, isNothing, mapMaybe)
+import Data.Maybe (fromMaybe, isJust, isNothing, mapMaybe, maybeToList)
 import Data.Sequence (Seq, ViewL(..), ViewR(..), (|>))
 import qualified Data.Sequence as Seq
 import Data.Text (Text)
@@ -2203,7 +2204,7 @@ drawTranscript state =
             <> conversationReserveWidgets anchor
   where
     blockChunks =
-        toList (Seq.chunksOf transcriptChunkSize state.appUi.uiBlocks)
+        Transcript.transcriptChunks state.appUi.uiBlocks
     anchor = state.appConversationAnchor
 
 -- | Cache completed transcript blocks in moderately sized groups.
@@ -2218,36 +2219,27 @@ drawTranscript state =
 -- The final partial/live/animated group remains uncached.
 drawTranscriptChunk :: AppState -> Seq UiBlock -> Widget Name
 drawTranscriptChunk state blocks =
-    case (Seq.lookup 0 blocks, Seq.lookup (Seq.length blocks - 1) blocks) of
-        (Just firstBlock, Just lastBlock)
-            | Seq.length blocks == transcriptChunkSize
-            , all (cacheableBlock state) blocks ->
-                if chunkHasDynamicInteraction
-                    then rendered
-                    else
-                        cached
-                            (ConversationChunkCache
-                                firstBlock.blockId
-                                lastBlock.blockId)
-                            rendered
-        _ -> rendered
+    case
+        Transcript.transcriptChunkCacheKey
+            (cacheableBlock state)
+            dynamicBlockIds
+            blocks of
+        Just (firstBlockId, lastBlockId) ->
+            cached
+                (ConversationChunkCache firstBlockId lastBlockId)
+                rendered
+        Nothing -> rendered
   where
     rendered = vBox (map (drawBlock state) (toList blocks))
-    blockIds = map (.blockId) (toList blocks)
-    chunkHasDynamicInteraction =
-        any (.blockExpanded) blocks
-            || highlightedBlockInChunk
-            || codeInteractionInChunk
-    highlightedBlockInChunk =
-        state.appUi.uiFocus == FocusScrollback
-            && maybe False (`elem` blockIds) state.appUi.uiSelectedBlock
-    codeInteractionInChunk =
-        case state.appHoveredControl of
-            Just (CodeCopy blockId _) -> blockId `elem` blockIds
-            _ -> False
-
-transcriptChunkSize :: Int
-transcriptChunkSize = 32
+    dynamicBlockIds =
+        [ blockId
+        | state.appUi.uiFocus == FocusScrollback
+        , blockId <- maybeToList state.appUi.uiSelectedBlock
+        ]
+            <> [ blockId
+               | Just (CodeCopy blockId _) <-
+                    [state.appHoveredControl]
+               ]
 
 stickyPromptLayers :: AppState -> [Widget Name]
 stickyPromptLayers state =

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -2199,11 +2199,55 @@ waitingIndicatorAttr state =
 drawTranscript :: AppState -> Widget Name
 drawTranscript state =
     vBox $
-        [vBox (map (drawBlock state) blocks)]
+        [vBox (map (drawTranscriptChunk state) blockChunks)]
             <> conversationReserveWidgets anchor
   where
-    blocks = toList state.appUi.uiBlocks
+    blockChunks =
+        toList (Seq.chunksOf transcriptChunkSize state.appUi.uiBlocks)
     anchor = state.appConversationAnchor
+
+-- | Cache completed transcript blocks in moderately sized groups.
+--
+-- A Brick viewport must still lay out its complete child to determine the
+-- scroll range. Per-block caching avoids repeated Markdown parsing, but a
+-- redraw still has to combine one image per retained block. Grouping stable
+-- blocks means ordinary scrolling traverses roughly one cached image per 32
+-- blocks instead. Only full chunks are cached: Brick retains cache entries
+-- until explicit invalidation, so caching the growing final chunk under a new
+-- last-block key for every append would retain all of those obsolete images.
+-- The final partial/live/animated group remains uncached.
+drawTranscriptChunk :: AppState -> Seq UiBlock -> Widget Name
+drawTranscriptChunk state blocks =
+    case (Seq.lookup 0 blocks, Seq.lookup (Seq.length blocks - 1) blocks) of
+        (Just firstBlock, Just lastBlock)
+            | Seq.length blocks == transcriptChunkSize
+            , all (cacheableBlock state) blocks ->
+                if chunkHasDynamicInteraction
+                    then rendered
+                    else
+                        cached
+                            (ConversationChunkCache
+                                firstBlock.blockId
+                                lastBlock.blockId)
+                            rendered
+        _ -> rendered
+  where
+    rendered = vBox (map (drawBlock state) (toList blocks))
+    blockIds = map (.blockId) (toList blocks)
+    chunkHasDynamicInteraction =
+        any (.blockExpanded) blocks
+            || highlightedBlockInChunk
+            || codeInteractionInChunk
+    highlightedBlockInChunk =
+        state.appUi.uiFocus == FocusScrollback
+            && maybe False (`elem` blockIds) state.appUi.uiSelectedBlock
+    codeInteractionInChunk =
+        case state.appHoveredControl of
+            Just (CodeCopy blockId _) -> blockId `elem` blockIds
+            _ -> False
+
+transcriptChunkSize :: Int
+transcriptChunkSize = 32
 
 stickyPromptLayers :: AppState -> [Widget Name]
 stickyPromptLayers state =

--- a/packages/agent-cli/src/Agent/CLI/TUI/Transcript.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Transcript.hs
@@ -1,0 +1,44 @@
+-- | Stable chunking and cache policy for the retained conversation transcript.
+module Agent.CLI.TUI.Transcript
+    ( transcriptChunkCacheKey
+    , transcriptChunkSize
+    , transcriptChunks
+    ) where
+
+import Agent.TUI.Model (BlockId, UiBlock(..))
+import Data.Foldable (toList)
+import Data.Sequence (Seq)
+import qualified Data.Sequence as Seq
+
+-- | Group retained blocks so completed history can be cached as larger images.
+transcriptChunks :: Seq UiBlock -> [Seq UiBlock]
+transcriptChunks =
+    toList . Seq.chunksOf transcriptChunkSize
+
+-- | Return a stable cache key when a transcript chunk is safe to retain.
+--
+-- Only full chunks are cached. Brick keeps cached results until explicit
+-- invalidation, so caching the growing final chunk under a changing endpoint
+-- would retain an obsolete large image after every appended block.
+transcriptChunkCacheKey
+    :: (UiBlock -> Bool)
+    -- ^ Whether an individual block is stable and cacheable.
+    -> [BlockId]
+    -- ^ Blocks with dynamic interaction state, such as selection or hover.
+    -> Seq UiBlock
+    -> Maybe (BlockId, BlockId)
+transcriptChunkCacheKey cacheable dynamicBlockIds blocks
+    | Seq.length blocks /= transcriptChunkSize = Nothing
+    | not (all cacheable blocks) = Nothing
+    | any (.blockExpanded) blocks = Nothing
+    | any ((`elem` dynamicBlockIds) . (.blockId)) blocks = Nothing
+    | otherwise = case
+        ( Seq.lookup 0 blocks
+        , Seq.lookup (Seq.length blocks - 1) blocks
+        ) of
+        (Just firstBlock, Just lastBlock) ->
+            Just (firstBlock.blockId, lastBlock.blockId)
+        _ -> Nothing
+
+transcriptChunkSize :: Int
+transcriptChunkSize = 32

--- a/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
@@ -47,6 +47,9 @@ data Name
     | ConversationReserve
     | OverlayViewport
     | ConversationBlock !BlockId
+    | ConversationChunkCache
+        !BlockId
+        !BlockId
     | ConversationBlockCache
         !BlockId
         !Bool

--- a/packages/agent-cli/test/Agent/CLI/TUITranscriptSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUITranscriptSpec.hs
@@ -1,0 +1,71 @@
+module Agent.CLI.TUITranscriptSpec (spec) where
+
+import Agent.CLI.TUI.Transcript
+    ( transcriptChunkCacheKey
+    , transcriptChunkSize
+    , transcriptChunks
+    )
+import Agent.TUI.Model
+    ( BlockId(..)
+    , BlockKind(..)
+    , BlockState(..)
+    , UiBlock(..)
+    )
+import qualified Data.Sequence as Seq
+import Test.Hspec
+
+spec :: Spec
+spec = describe "fullscreen transcript caching" do
+    it "splits retained history into fixed-size chunks" do
+        map Seq.length (transcriptChunks (Seq.fromList (map block [1 .. 65])))
+            `shouldBe` [32, 32, 1]
+
+    it "caches a complete stable chunk by its endpoint IDs" do
+        transcriptChunkCacheKey
+            (const True)
+            []
+            completeChunk
+            `shouldBe` Just (BlockId 1, BlockId transcriptChunkSize)
+
+    it "does not cache the growing final partial chunk" do
+        transcriptChunkCacheKey
+            (const True)
+            []
+            (Seq.take (transcriptChunkSize - 1) completeChunk)
+            `shouldBe` Nothing
+
+    it "does not cache chunks containing unstable blocks" do
+        transcriptChunkCacheKey
+            ((/= BlockId 7) . (.blockId))
+            []
+            completeChunk
+            `shouldBe` Nothing
+
+    it "does not cache expanded or interactive chunks" do
+        let expanded =
+                Seq.adjust
+                    (\value -> value { blockExpanded = True })
+                    5
+                    completeChunk
+        transcriptChunkCacheKey (const True) [] expanded
+            `shouldBe` Nothing
+        transcriptChunkCacheKey (const True) [BlockId 12] completeChunk
+            `shouldBe` Nothing
+        transcriptChunkCacheKey (const True) [BlockId 99] completeChunk
+            `shouldBe` Just (BlockId 1, BlockId transcriptChunkSize)
+  where
+    completeChunk =
+        Seq.fromList (map block [1 .. transcriptChunkSize])
+
+block :: Int -> UiBlock
+block number = UiBlock
+    { blockId = BlockId number
+    , blockKind = BlockAssistant
+    , blockTitle = "Assistant"
+    , blockBody = "body"
+    , blockTimestamp = ""
+    , blockDetail = ""
+    , blockState = BlockComplete
+    , blockExpanded = False
+    , blockCallId = Nothing
+    }

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -64,6 +64,7 @@ import qualified Agent.CLI.TUIComposerSpec as TUIComposerSpec
 import qualified Agent.CLI.TUIImagePreviewSpec as TUIImagePreviewSpec
 import qualified Agent.CLI.TUIPropertySpec as TUIPropertySpec
 import qualified Agent.CLI.TUIScrollSpec as TUIScrollSpec
+import qualified Agent.CLI.TUITranscriptSpec as TUITranscriptSpec
 import qualified Agent.CLI.UsageSpec as UsageSpec
 import qualified Agent.CLI.WebLspSpec as WebLspSpec
 import qualified Agent.CLI.WorktreeSpec as WorktreeSpec
@@ -132,6 +133,7 @@ main = hspec do
     TUIImagePreviewSpec.spec
     TUIPropertySpec.spec
     TUIScrollSpec.spec
+    TUITranscriptSpec.spec
     UsageSpec.spec
     WebLspSpec.spec
     WorktreeSpec.spec


### PR DESCRIPTION
## Summary

- cache stable transcript blocks in fixed groups of 32
- leave the growing final chunk and interactive/animated chunks uncached
- isolate transcript chunking and cache eligibility in `Agent.CLI.TUI.Transcript`
- add focused cache-policy tests and an optimized retained-redraw benchmark
- regenerate the checked-in Nix package expression

## Why

Brick must lay out the complete child of a vertical viewport to determine its scroll range. The transcript already cached individual completed blocks, which avoided repeated Markdown parsing, but every scrolling redraw still traversed and combined one image per retained block. That work grows linearly with long-running sessions.

The new outer cache reduces stable history to roughly one cached image per 32 blocks. Only full chunks are cached because Brick retains cache entries until invalidation; caching the growing final chunk with a changing endpoint would retain obsolete large images. Chunks containing expanded, selected, hovered, streaming, running, retrying, or flashing content bypass the outer cache.

The pure chunking and eligibility policy lives in `Agent.CLI.TUI.Transcript`; `Agent.CLI.TUI.App` retains only renderer-specific drawing and interaction-state assembly.

## Benchmark

Optimized `-O2` benchmark, 25 retained redraws per sample, median of 9 samples, `+RTS -T`:

| Workload | Per-block cache | Chunk cache | Allocation before | Allocation after |
| --- | ---: | ---: | ---: | ---: |
| 10,000 blocks, 2 body lines | 513.3 ms | 10.5 ms | 1,059,965,960 B | 70,212,176 B |
| 5,000 blocks, 8 body lines | 246.5 ms | 9.9 ms | 554,401,520 B | 62,207,016 B |

Commands:

```sh
nix develop -c cabal build --offline agent-cli:bench:transcript-scrolling-bench
bin=$(nix develop -c cabal list-bin agent-cli:bench:transcript-scrolling-bench)
"$bin" per-block-cache 10000 2 9 +RTS -T
"$bin" chunk-cache 10000 2 9 +RTS -T
"$bin" per-block-cache 5000 8 9 +RTS -T
"$bin" chunk-cache 5000 8 9 +RTS -T
```

The benchmark isolates repeated retained redraw/layout work triggered by scrolling. A real resumed long session was also exercised with repeated PageUp/PageDown in tmux, including after the module extraction.

## Validation

- `cabal repl agent-cli:lib:agent-cli`: loaded `Agent.CLI.TUI.Transcript` and `Agent.CLI.TUI.App`
- `nix develop -c cabal test --offline agent-cli:agent-cli-test --test-option=--match --test-option=fullscreen`
  - 44 examples passed
  - 300 generated-frame property cases passed
  - 100 incremental-redraw property cases passed
  - 5 focused transcript cache-policy examples passed
- optimized benchmark rebuilt and rerun after extraction
- tmux smoke test on a resumed long session passed without visual corruption
