### PR TITLE
feat(cli): search persisted conversations

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Command.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command.hs
@@ -109,6 +109,8 @@ data ReplAction
     -- ^ @Nothing@ lists every command; @Just@ is a canonical name without @/@.
     | ReplResume (Maybe Text)
     -- ^ @Nothing@ opens the session picker; @Just@ is a session id.
+    | ReplSearch !Text
+    -- ^ Search persisted conversation turns and open matching sessions.
     | ReplCompact (Maybe Text)
     -- ^ Optional focus note for what to keep while compacting history.
     | ReplClear
@@ -174,6 +176,7 @@ slashCommands =
     , cmd "rename" ["title"] "/rename <TITLE>|--auto" "Rename the current session, or restore automatic titles" True
     , cmd "login" ["accounts"] "/login" "Manage provider credentials and usage" False
     , cmd "resume" [] "/resume [ID]" "Pick a session to resume, or resume ID" True
+    , cmd "search" [] "/search <QUERY>" "Search past conversations and resume a match" True
     , cmd "compact" [] "/compact [FOCUS]" "Summarize history to free context" True
     , cmd "clear" [] "/clear" "Reset the live conversation (same session id)" False
     , cmd "new" [] "/new" "Start a fresh persisted session id" False
@@ -365,6 +368,12 @@ parseSlash catalog raw line = case Text.words line of
                     then ReplLogin
                     else ReplCommandError "usage: /login"
             "resume" -> parseResumeCommand args
+            "search" ->
+                let query =
+                        Text.strip (Text.drop (Text.length command) line)
+                in if Text.null query
+                    then ReplCommandError "usage: /search <QUERY>"
+                    else ReplSearch query
             "compact" ->
                 let focus =
                         Text.strip (Text.drop (Text.length command) line)

--- a/packages/agent-cli/src/Agent/CLI/Resume.hs
+++ b/packages/agent-cli/src/Agent/CLI/Resume.hs
@@ -5,6 +5,7 @@ module Agent.CLI.Resume
     , ResumeSourceFilter(..)
     , ResumeState(..)
     , applyResumeKey
+    , applyResumeSearchResults
     , beginResumeSearch
     , cycleResumeSource
     , endResumeSearch
@@ -15,6 +16,7 @@ module Agent.CLI.Resume
     , insertResumeSearch
     , loadResumeEntry
     , moveResumeBrowser
+    , pickResumeEntries
     , pickResumeSession
     , removeResumeEntry
     , renderResumeFrame
@@ -22,6 +24,7 @@ module Agent.CLI.Resume
     , replaceResumeEntry
     , resumeEntryFromMeta
     , resumeEntriesFrom
+    , resumeSearchEntries
     , resumeRelativeAge
     , resumeSourceLabel
     , selectedResumeBrowser
@@ -48,10 +51,13 @@ import Agent.OsPath (toText)
 import Agent.Provider (providerSlug)
 import Agent.Responses.Types (ResponseItem(..))
 import Agent.Store.Postgres.Connection (StorePool)
+import Agent.Store.Postgres.Session (ConversationSearchResult(..))
 import Control.Monad (forM)
 import Data.Char (isAlphaNum)
 import Data.List (nub)
+import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe)
+import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
@@ -80,6 +86,7 @@ data ResumeEntry = ResumeEntry
     , resumeTurnCount :: !Int
     , resumeToolCount :: !Int
     , resumePrompt :: !Text
+    , resumeMatch :: !(Maybe Text)
     , resumeLoaded :: !Bool
     , resumeTranscript :: ![Text]
     }
@@ -88,6 +95,7 @@ data ResumeEntry = ResumeEntry
 data ResumeBrowser = ResumeBrowser
     { resumeBrowserAll :: ![ResumeEntry]
     , resumeBrowserQuery :: !Text
+    , resumeBrowserAppliedQuery :: !(Maybe Text)
     , resumeBrowserSearching :: !Bool
     , resumeBrowserIndex :: !Int
     , resumeBrowserSource :: !ResumeSourceFilter
@@ -145,6 +153,7 @@ entryFromWith loaded meta turns =
         , resumePrompt =
             fromMaybe ""
                 (firstNonEmpty (map (.turnUserText) turns))
+        , resumeMatch = Nothing
         , resumeLoaded = loaded
         , resumeTranscript = transcriptLines turns
         }
@@ -181,6 +190,7 @@ initialResumeBrowser now entries =
     ResumeBrowser
         { resumeBrowserAll = entries
         , resumeBrowserQuery = ""
+        , resumeBrowserAppliedQuery = Nothing
         , resumeBrowserSearching = False
         , resumeBrowserIndex = 0
         , resumeBrowserSource = ResumeAll
@@ -197,6 +207,8 @@ visibleResumeBrowser browser =
     needle = Text.toLower (Text.strip browser.resumeBrowserQuery)
     matchesQuery entry
         | Text.null needle = True
+        | browser.resumeBrowserAppliedQuery
+            == Just (Text.strip browser.resumeBrowserQuery) = True
         | otherwise =
             any
                 (Text.isInfixOf needle . Text.toLower)
@@ -206,7 +218,68 @@ visibleResumeBrowser browser =
                 , entry.resumeCwd
                 , entry.resumeProvider
                 , entry.resumePrompt
+                , fromMaybe "" entry.resumeMatch
                 ]
+
+applyResumeSearchResults
+    :: Text
+    -> [ResumeEntry]
+    -> ResumeBrowser
+    -> ResumeBrowser
+applyResumeSearchResults query entries browser =
+    browser
+        { resumeBrowserAll = entries
+        , resumeBrowserQuery = stripped
+        , resumeBrowserAppliedQuery =
+            if Text.null stripped then Nothing else Just stripped
+        , resumeBrowserSearching = False
+        , resumeBrowserIndex = 0
+        , resumeBrowserExpanded = Nothing
+        , resumeBrowserDeletePending = Nothing
+        , resumeBrowserNotice = Nothing
+        }
+  where
+    stripped = Text.strip query
+
+-- | Convert ranked turn matches into one resume entry per session, preserving
+-- PostgreSQL result order and attaching a compact matching excerpt.
+resumeSearchEntries
+    :: [SessionMeta]
+    -> [ConversationSearchResult]
+    -> [ResumeEntry]
+resumeSearchEntries metas results =
+    reverse entries
+  where
+    metadataById = Map.fromList [(meta.metaId, meta) | meta <- metas]
+    (_, entries) = foldl' addResult (Set.empty, []) results
+
+    addResult (seen, acc) result
+        | Set.member result.searchSessionId seen = (seen, acc)
+        | otherwise =
+            case Map.lookup result.searchSessionId metadataById of
+                Nothing -> (seen, acc)
+                Just meta ->
+                    let entry =
+                            (resumeEntryFromMeta meta)
+                                { resumePrompt = Text.strip result.searchUserText
+                                , resumeMatch = Just (searchResultSnippet result)
+                                }
+                    in (Set.insert result.searchSessionId seen, entry : acc)
+
+searchResultSnippet :: ConversationSearchResult -> Text
+searchResultSnippet result =
+    Text.take 240 $
+        Text.intercalate "  ·  " $
+            filter (not . Text.null)
+                [ labelled "user" result.searchUserText
+                , maybe "" (labelled "assistant") result.searchAssistantText
+                ]
+  where
+    labelled label value
+        | Text.null compact = ""
+        | otherwise = label <> ": " <> compact
+      where
+        compact = Text.unwords (Text.words value)
 
 sourceEntries :: ResumeBrowser -> [ResumeEntry]
 sourceEntries browser = case browser.resumeBrowserSource of
@@ -392,7 +465,10 @@ visibleResume state
             (\e ->
                 needle `Text.isInfixOf` Text.toLower e.resumeTitle
                     || needle `Text.isInfixOf` Text.toLower e.resumeId
-                    || needle `Text.isInfixOf` Text.toLower e.resumeModel)
+                    || needle `Text.isInfixOf` Text.toLower e.resumeModel
+                    || needle
+                        `Text.isInfixOf`
+                            Text.toLower (fromMaybe "" e.resumeMatch))
             state.resumeAll
   where
     needle = Text.toLower state.resumeFilter
@@ -516,6 +592,7 @@ formatOne color entry =
         <> "  "
         <> entry.resumeTitle
         <> roleMuted color ("  " <> entry.resumeModel)
+        <> maybe "" ("\n    " <>) entry.resumeMatch
 
 -- | TTY picker; non-TTY prints the list. Confirm returns the session id.
 -- Loading is capped to the latest sessions so opening the picker stays cheap.
@@ -528,7 +605,19 @@ pickResumeSession
 pickResumeSession pool color root metas = do
     isTty <- hIsTerminalDevice stdin
     loaded <- loadRecentSessions pool root metas
-    let entries = resumeEntriesFrom loaded
+    pickResumeEntriesWithTty isTty color (resumeEntriesFrom loaded)
+
+pickResumeEntries :: Bool -> [ResumeEntry] -> IO (Maybe Text)
+pickResumeEntries color entries = do
+    isTty <- hIsTerminalDevice stdin
+    pickResumeEntriesWithTty isTty color entries
+
+pickResumeEntriesWithTty
+    :: Bool
+    -> Bool
+    -> [ResumeEntry]
+    -> IO (Maybe Text)
+pickResumeEntriesWithTty isTty color entries =
     if not isTty
         then do
             Text.hPutStrLn stderr (formatResumeListing color entries)

--- a/packages/agent-cli/src/Agent/CLI/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime.hs
@@ -249,14 +249,18 @@ import Agent.Store.Postgres
     )
 import Agent.Store.Types (renderStoreError)
 import Agent.Store.Postgres.Connection (StorePool)
+import qualified Agent.Store.Postgres.Session as StoreSession
 import Agent.Store.Postgres.Skill (LearnedSkill(..))
 import Agent.CLI.PendingInputs (withPendingInputs)
 import Agent.CLI.Resume
     ( ResumeEntry(..)
+    , applyResumeSearchResults
     , initialResumeBrowser
     , loadResumeEntry
+    , pickResumeEntries
     , pickResumeSession
     , resumeEntryFromMeta
+    , resumeSearchEntries
     )
 import Agent.CLI.Plan (cliPlanHooks)
 import Agent.CLI.Progress
@@ -5089,6 +5093,11 @@ replWithDraft env@SessionEnv
                         handleResume databasePool fullscreen maybeId persist >>= \case
                             Nothing -> continue
                             Just result -> pure result
+                    ReplSearch query -> do
+                        handleConversationSearch
+                            databasePool fullscreen query persist >>= \case
+                                Nothing -> continue
+                                Just result -> pure result
                     ReplClear -> do
                         sessionReset
                         fullscreenEvent UiConversationCleared
@@ -6268,6 +6277,116 @@ handleResume databasePool fullscreen maybeId persist = do
                 Nothing -> pure Nothing
                 Just sessionId -> resume sessionId
 
+handleConversationSearch
+    :: StorePool
+    -> Maybe FullscreenRuntime
+    -> Text
+    -> Persistence
+    -> IO (Maybe RunResult)
+handleConversationSearch databasePool fullscreen query persist = do
+    color <- resolveColor stderr
+    home <- getHomeDirectory
+    let root = sessionsRoot home
+        reportError message =
+            case fullscreen of
+                Nothing ->
+                    Text.hPutStrLn stderr (roleError color message)
+                Just runtime ->
+                    emitUiEvent runtime (UiErrorMessage message)
+        reportInfo message =
+            case fullscreen of
+                Nothing ->
+                    Text.hPutStrLn stderr
+                        (roleMuted color (glyphSession <> message))
+                Just runtime ->
+                    emitUiEvent runtime (UiSystemMessage message)
+    sessions <- listSessions databasePool root
+    searchResumeEntries databasePool sessions query >>= \case
+        Left err -> do
+            reportError err
+            pure Nothing
+        Right [] -> do
+            reportInfo ("no conversations matched “" <> Text.strip query <> "”")
+            pure Nothing
+        Right entries -> do
+            currentId <- currentSessionId persist
+            pickSearchChoice
+                databasePool
+                fullscreen
+                color
+                root
+                currentId
+                sessions
+                query
+                entries
+                >>= \case
+                    Nothing -> pure Nothing
+                    Just sessionId ->
+                        handleResume
+                            databasePool
+                            fullscreen
+                            (Just sessionId)
+                            persist
+
+searchResumeEntries
+    :: StorePool
+    -> [SessionMeta]
+    -> Text
+    -> IO (Either Text [ResumeEntry])
+searchResumeEntries databasePool sessions query
+    | Text.null (Text.strip query) =
+        pure (Right (map resumeEntryFromMeta sessions))
+    | otherwise =
+        StoreSession.searchConversationTurns
+            databasePool
+            (Text.strip query)
+            100
+            >>= \case
+                Left err -> pure (Left (renderStoreError err))
+                Right results ->
+                    pure (Right (resumeSearchEntries sessions results))
+
+pickSearchChoice
+    :: StorePool
+    -> Maybe FullscreenRuntime
+    -> Bool
+    -> OsPath
+    -> Maybe Text
+    -> [SessionMeta]
+    -> Text
+    -> [ResumeEntry]
+    -> IO (Maybe Text)
+pickSearchChoice
+    databasePool
+    fullscreen
+    color
+    root
+    currentId
+    sessions
+    query
+    entries =
+        case fullscreen of
+            Nothing -> pickResumeEntries color entries
+            Just runtime -> do
+                now <- getCurrentTime
+                let browser =
+                        applyResumeSearchResults
+                            query
+                            entries
+                            (initialResumeBrowser now entries)
+                    deleteEntry sessionId
+                        | currentId == Just sessionId =
+                            pure (Left "cannot delete the current session")
+                        | otherwise =
+                            deleteSession databasePool root sessionId
+                fmap (.resumeId)
+                    <$> requestFullscreenResume
+                        runtime
+                        browser
+                        (loadResumeEntry databasePool root)
+                        deleteEntry
+                        (searchResumeEntries databasePool sessions)
+
 pickResumeChoice
     :: StorePool
     -> Maybe FullscreenRuntime
@@ -6294,6 +6413,7 @@ pickResumeChoice databasePool fullscreen color root currentId sessions =
                 browser
                 (loadResumeEntry databasePool root)
                 deleteEntry
+                (searchResumeEntries databasePool sessions)
 
 pickAgentChoice
     :: Maybe FullscreenRuntime

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -93,6 +93,7 @@ import Agent.CLI.Permission (PermissionChoice(..))
 import Agent.CLI.Resume
     ( ResumeBrowser(..)
     , ResumeEntry(..)
+    , applyResumeSearchResults
     , beginResumeSearch
     , cycleResumeSource
     , endResumeSearch
@@ -618,11 +619,12 @@ requestFullscreenResume
     -> ResumeBrowser
     -> (Text -> IO (Either Text ResumeEntry))
     -> (Text -> IO (Either Text ()))
+    -> (Text -> IO (Either Text [ResumeEntry]))
     -> IO (Maybe ResumeEntry)
-requestFullscreenResume runtime browser loadEntry deleteEntry = do
+requestFullscreenResume runtime browser loadEntry deleteEntry searchEntries = do
     reply <- newEmptyTMVarIO
     enqueueAppEvent runtime
-        (AppAskResume browser loadEntry deleteEntry reply)
+        (AppAskResume browser loadEntry deleteEntry searchEntries reply)
     atomically (readTMVar reply)
 
 requestFullscreenText
@@ -802,6 +804,7 @@ initialFullscreenAppState runtime history initialAgent initialAgents initialCloc
         , appResumeReply = Nothing
         , appResumeLoad = Nothing
         , appResumeDelete = Nothing
+        , appResumeSearch = Nothing
         , appTextPrompt = Nothing
         , appTextReply = Nothing
         , appSlashDismissed = False
@@ -1103,8 +1106,23 @@ handleResumeSearch browser event
     | otherwise = case event of
         V.EvKey V.KEsc [] ->
             setBrowser (endResumeSearch browser)
-        V.EvKey V.KEnter [] ->
-            setBrowser (endResumeSearch browser)
+        V.EvKey V.KEnter [] -> do
+            state <- get
+            case state.appResumeSearch of
+                Nothing ->
+                    setBrowser (endResumeSearch browser)
+                Just searchEntries -> do
+                    result <- liftIO (searchEntries browser.resumeBrowserQuery)
+                    case result of
+                        Left err ->
+                            setBrowser (setResumeNotice (Just err) browser)
+                        Right entries -> do
+                            setBrowser
+                                (applyResumeSearchResults
+                                    browser.resumeBrowserQuery
+                                    entries
+                                    browser)
+                            revealSelectedResume
         V.EvKey V.KBS [] ->
             setAndReveal $
                 insertResumeSearch ""
@@ -1236,6 +1254,7 @@ resolveResume confirmed = do
             , appResumeReply = Nothing
             , appResumeLoad = Nothing
             , appResumeDelete = Nothing
+            , appResumeSearch = Nothing
             }
     resumeNativeProgressIfRunning
 
@@ -2641,11 +2660,16 @@ resumeList browser =
         [] ->
             padTop (Pad 1) $
                 withAttr Theme.mutedAttr (txt "  No matches")
-        entries ->
+        _ : _ ->
             vBox $
                 intersperse (txt "") $
-                    map (resumeGroup browser selectedId) (groupResumeEntries entries)
+                    map (resumeGroup browser selectedId) groups
   where
+    entries = visibleResumeBrowser browser
+    groups
+        | isJust browser.resumeBrowserAppliedQuery =
+            [("search results", entries)]
+        | otherwise = groupResumeEntries entries
     selectedId = (.resumeId) <$> selectedResumeBrowser browser
 
 resumeGroup
@@ -2716,7 +2740,15 @@ resumeRow browser selectedId entry =
                                 else entry.resumePrompt)
                         ]
                 ]
-        | otherwise = summary
+        | otherwise =
+            case entry.resumeMatch of
+                Nothing -> summary
+                Just match ->
+                    vBox
+                        [ summary
+                        , padLeft (Pad 4) $
+                            withAttr Theme.mutedAttr (txtWrap match)
+                        ]
 
 resumeDetail :: Text -> Text -> Widget Name
 resumeDetail label value =
@@ -2741,7 +2773,7 @@ resumeFooter browser =
                 | isJust browser.resumeBrowserDeletePending ->
                     (Theme.thinkingAttr, "y confirm delete  │  n cancel")
                 | browser.resumeBrowserSearching ->
-                    (Theme.footerAttr, "type to search  │  Enter/Esc done  │  ↑↓ nav")
+                    (Theme.footerAttr, "type to search  │  Enter run  │  Esc close  │  ↑↓ nav")
                 | not hasRows ->
                     (Theme.footerAttr, "f filter  │  / search  │  Esc cancel")
                 | otherwise ->
@@ -3439,7 +3471,8 @@ handleEventInner event = case event of
                 , appAgentHover = Nothing
                 }
         vScrollToBeginning (viewportScroll OverlayViewport)
-    AppEvent (AppAskResume browser loadEntry deleteEntry reply) -> do
+    AppEvent
+        (AppAskResume browser loadEntry deleteEntry searchEntries reply) -> do
         state <- get
         liftIO (state.appRuntime.runtimeNativeProgress False)
         modify' \state ->
@@ -3450,6 +3483,7 @@ handleEventInner event = case event of
                 , appResumeReply = Just reply
                 , appResumeLoad = Just loadEntry
                 , appResumeDelete = Just deleteEntry
+                , appResumeSearch = Just searchEntries
                 , appAgentHover = Nothing
                 }
         vScrollToBeginning (viewportScroll ResumeViewport)

--- a/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
@@ -94,6 +94,7 @@ data AppEvent
         !ResumeBrowser
         !(Text -> IO (Either Text ResumeEntry))
         !(Text -> IO (Either Text ()))
+        !(Text -> IO (Either Text [ResumeEntry]))
         !(TMVar (Maybe ResumeEntry))
     | forall a. AppSuspend !(IO a) !(TMVar (Either SomeException a))
     | AppSetSlashCatalog !SlashCatalog
@@ -184,6 +185,7 @@ data AppState = AppState
     , appResumeReply :: !(Maybe (TMVar (Maybe ResumeEntry)))
     , appResumeLoad :: !(Maybe (Text -> IO (Either Text ResumeEntry)))
     , appResumeDelete :: !(Maybe (Text -> IO (Either Text ())))
+    , appResumeSearch :: !(Maybe (Text -> IO (Either Text [ResumeEntry])))
     , appTextPrompt :: !(Maybe TextOverlay)
     , appTextReply :: !(Maybe (TMVar (Maybe Text)))
     , appSlashDismissed :: !Bool

--- a/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
@@ -188,6 +188,14 @@ spec = do
             parseReplLine "/resume a b"
                 `shouldBe` ReplCommandError "usage: /resume [ID]"
 
+        it "searches past conversations with the full query suffix" do
+            parseReplLine "/search postgres migration"
+                `shouldBe` ReplSearch "postgres migration"
+            parseReplLine "/SEARCH   keep  spaces"
+                `shouldBe` ReplSearch "keep  spaces"
+            parseReplLine "/search"
+                `shouldBe` ReplCommandError "usage: /search <QUERY>"
+
         it "opens the agent hierarchy" do
             parseReplLine "/agents" `shouldBe` ReplAgents
             parseReplLine "/a" `shouldBe` ReplAgents
@@ -268,6 +276,7 @@ spec = do
                     , "rename"
                     , "login"
                     , "resume"
+                    , "search"
                     , "compact"
                     , "clear"
                     , "new"

--- a/packages/agent-cli/test/Agent/CLI/ResumeSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ResumeSpec.hs
@@ -10,6 +10,7 @@ import Agent.CLI.Session
 import Agent.Dialect (DialectId(..))
 import System.OsPath (unsafeEncodeUtf)
 import Agent.Provider (Provider(..))
+import Agent.Store.Postgres.Session (ConversationSearchResult(..))
 import Data.Time.Clock (addUTCTime)
 import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
 import qualified Data.Text as Text
@@ -96,6 +97,17 @@ spec = do
             endResumeSearch searched
                 `shouldSatisfy` (not . (.resumeBrowserSearching))
 
+        it "keeps PostgreSQL search results visible after applying a query" do
+            let applied =
+                    applyResumeSearchResults
+                        "database migration"
+                        (take 1 entries)
+                        browser0
+            applied.resumeBrowserAppliedQuery
+                `shouldBe` Just "database migration"
+            map (.resumeId) (visibleResumeBrowser applied)
+                `shouldBe` ["one"]
+
         it "moves, expands, and removes the selected session" do
             let moved = moveResumeBrowser 1 browser0
                 expanded = toggleResumeExpanded moved
@@ -114,6 +126,40 @@ spec = do
             resumeSourceLabel
                 (cycleResumeSource (cycleResumeSource browser0)).resumeBrowserSource
                 `shouldBe` "All"
+
+    describe "resumeSearchEntries" do
+        it "deduplicates ranked turn matches and attaches the best excerpt" do
+            let at = posixSecondsToUTCTime 120
+                results =
+                    [ ConversationSearchResult
+                        "two" 3 at
+                        "migrate state to postgres"
+                        (Just "the database migration is complete")
+                        0.9
+                    , ConversationSearchResult
+                        "two" 1 at
+                        "older postgres mention"
+                        Nothing
+                        0.4
+                    , ConversationSearchResult
+                        "one" 2 at
+                        "search previous sessions"
+                        Nothing
+                        0.3
+                    ]
+                entries =
+                    resumeSearchEntries
+                        [ sampleMeta "one" "first"
+                        , sampleMeta "two" "second"
+                        ]
+                        results
+            map (.resumeId) entries `shouldBe` ["two", "one"]
+            fmap (.resumeMatch) entries
+                `shouldBe`
+                    [ Just
+                        "user: migrate state to postgres  ·  assistant: the database migration is complete"
+                    , Just "user: search previous sessions"
+                    ]
 
     describe "groupResumeEntries" do
         it "groups matching cwd basenames while preserving first-seen order" do


### PR DESCRIPTION
## Summary

- add `/search <QUERY>` to search PostgreSQL-backed conversation history and resume a matching session
- make Enter in the fullscreen `/resume` search field run PostgreSQL full-text search instead of only filtering session metadata
- show ranked, deduplicated session results with matching user/assistant excerpts
- preserve database ranking in the search-results view and support non-fullscreen result listings

## Testing

- `nix develop -c cabal repl agent-cli:lib:agent-cli` — 105 modules loaded
- focused `Agent.CLI.CommandSpec` in GHCi — 62 examples, 0 failures
- focused `Agent.CLI.ResumeSpec` in GHCi — 15 examples, 0 failures
- tmux TTY smoke test: `/search postgres` rendered ranked matches and excerpts in the resume picker
- tmux TTY smoke test: `/resume`, search for `jsonl`, Enter ran PostgreSQL-backed search
- `git diff --check`