### PR TITLE
perf: parallelize independent agent workloads

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -258,6 +258,21 @@ benchmark history-retention-bench
                     , base >= 4.17 && < 5
                     , text
 
+benchmark concurrency-bench
+    import:           common-options
+    type:             exitcode-stdio-1.0
+    hs-source-dirs:   benchmark
+    main-is:          Concurrency.hs
+    ghc-options:      -O2 -threaded -rtsopts "-with-rtsopts=-T"
+    build-depends:    agent-cli
+                    , agent-core
+                    , base >= 4.17 && < 5
+                    , bytestring
+                    , directory
+                    , filepath
+                    , safe-exceptions
+                    , time
+
 test-suite agent-cli-test
     import:           common-options
     type:             exitcode-stdio-1.0

--- a/packages/agent-cli/benchmark/Concurrency.hs
+++ b/packages/agent-cli/benchmark/Concurrency.hs
@@ -1,0 +1,142 @@
+module Main (main) where
+
+import Agent.Concurrent (mapConcurrentlyBounded)
+import Control.Concurrent (threadDelay)
+import Control.Exception.Safe (SomeException, bracket)
+import qualified Control.Exception.Safe as Exception
+import Control.Monad (when)
+import qualified Data.ByteString as BS
+import Data.List (sort)
+import GHC.Clock (getMonotonicTimeNSec)
+import GHC.Stats
+    ( RTSStats(..)
+    , getRTSStats
+    , getRTSStatsEnabled
+    )
+import System.CPUTime (getCPUTime)
+import System.Directory
+    ( createDirectoryIfMissing
+    , getTemporaryDirectory
+    , removePathForcibly
+    )
+import System.Environment (getArgs)
+import System.FilePath ((</>))
+import System.Mem (performMajorGC)
+
+data Sample = Sample
+    { sampleElapsedMillis :: !Double
+    , sampleCpuMillis :: !Double
+    , sampleAllocatedBytes :: !Word
+    }
+
+main :: IO ()
+main = do
+    statsEnabled <- getRTSStatsEnabled
+    when (not statsEnabled) $
+        fail "run with +RTS -T"
+    (count, bytesPerFile, samples) <- parseArgs <$> getArgs
+    withInputFiles count bytesPerFile \paths -> do
+        putStrLn
+            ("count=" <> show count
+                <> " bytes-per-file=" <> show bytesPerFile
+                <> " samples=" <> show samples)
+        benchmark "startup-serial" samples
+            (serialDelayed count)
+        benchmark "startup-bounded-8" samples
+            (boundedDelayed count)
+        benchmark "attachments-serial" samples
+            (serialRead paths)
+        benchmark "attachments-bounded-4" samples
+            (boundedRead paths)
+
+parseArgs :: [String] -> (Int, Int, Int)
+parseArgs = \case
+    [count, bytesPerFile, samples] ->
+        (max 1 (read count), max 1 (read bytesPerFile), max 1 (read samples))
+    _ -> (32, 16 * 1024, 7)
+
+benchmark :: String -> Int -> IO Int -> IO ()
+benchmark label count action = do
+    samples <- mapM (const (measure action)) [1 .. max 1 count]
+    let elapsed = median (map (.sampleElapsedMillis) samples)
+        cpu = median (map (.sampleCpuMillis) samples)
+        allocated = median (map (.sampleAllocatedBytes) samples)
+    putStrLn
+        (label
+            <> " elapsed-ms=" <> show elapsed
+            <> " cpu-ms=" <> show cpu
+            <> " allocated-bytes=" <> show allocated)
+
+measure :: IO Int -> IO Sample
+measure action = do
+    performMajorGC
+    beforeStats <- getRTSStats
+    beforeCpu <- getCPUTime
+    beforeElapsed <- getMonotonicTimeNSec
+    checksum <- action
+    checksum `seq` pure ()
+    afterElapsed <- getMonotonicTimeNSec
+    afterCpu <- getCPUTime
+    afterStats <- getRTSStats
+    pure Sample
+        { sampleElapsedMillis =
+            fromIntegral (afterElapsed - beforeElapsed) / 1_000_000
+        , sampleCpuMillis =
+            fromIntegral (afterCpu - beforeCpu) / 1_000_000_000
+        , sampleAllocatedBytes =
+            fromIntegral
+                (allocated_bytes afterStats - allocated_bytes beforeStats)
+        }
+
+serialDelayed :: Int -> IO Int
+serialDelayed count = do
+    values <- mapM (const delayedWork) [1 .. count]
+    pure (sum values)
+
+boundedDelayed :: Int -> IO Int
+boundedDelayed count = do
+    values <- mapConcurrentlyBounded 8 (const delayedWork) [1 .. count]
+    pure (sum values)
+
+delayedWork :: IO Int
+delayedWork = threadDelay 20_000 >> pure 1
+
+serialRead :: [FilePath] -> IO Int
+serialRead paths =
+    sumLengths <$> mapM BS.readFile paths
+
+boundedRead :: [FilePath] -> IO Int
+boundedRead paths =
+    sumLengths <$> mapConcurrentlyBounded 4 BS.readFile paths
+
+sumLengths :: [BS.ByteString] -> Int
+sumLengths = foldr ((+) . BS.length) 0
+
+withInputFiles :: Int -> Int -> ([FilePath] -> IO a) -> IO a
+withInputFiles count bytesPerFile action = do
+    root <- getTemporaryDirectory
+    let directory = root </> "agent-cli-concurrency-bench"
+        contents = BS.replicate bytesPerFile 97
+        paths =
+            [ directory </> ("attachment-" <> show index <> ".bin")
+            | index <- [1 .. count]
+            ]
+    bracket
+        (do
+            removePathIfPresent directory
+            createDirectoryIfMissing True directory
+            mapM_ (`BS.writeFile` contents) paths
+            pure paths)
+        (const (removePathIfPresent directory))
+        action
+
+removePathIfPresent :: FilePath -> IO ()
+removePathIfPresent path =
+    removePathForcibly path `catchAny` const (pure ())
+
+catchAny :: IO a -> (SomeException -> IO a) -> IO a
+catchAny = Exception.catchAny
+
+median :: Ord a => [a] -> a
+median values =
+    sort values !! (length values `div` 2)

--- a/packages/agent-cli/package.nix
+++ b/packages/agent-cli/package.nix
@@ -43,7 +43,7 @@ mkDerivation {
   benchmarkHaskellDepends = [
     aeson agent-core agent-responses agent-store base brick bytestring
     containers deepseq directory filepath JuicyPixels safe-exceptions
-    text vty
+    text time vty
   ];
   description = "Command-line interface for the universal agent harness";
   license = lib.meta.getLicenseFromSpdxId "MIT";

--- a/packages/agent-cli/src/Agent/CLI/AgentSessions.hs
+++ b/packages/agent-cli/src/Agent/CLI/AgentSessions.hs
@@ -41,6 +41,7 @@ import Agent.CLI.Models
     , ModelTarget(..)
     , resolveModelOptionDialect
     )
+import Agent.Concurrent (forConcurrentlyBounded_)
 import Agent.OsPath (fromText, unsafeToFilePath)
 import Agent.Dialect
     ( DialectId
@@ -61,10 +62,13 @@ import Control.Concurrent.MVar
     ( MVar
     , modifyMVar
     , modifyMVar_
+    , newEmptyMVar
     , newMVar
+    , putMVar
+    , readMVar
     )
-import Control.Exception.Safe (SomeException, try)
-import Control.Monad (forM_)
+import Control.Exception.Safe (SomeException, finally, try)
+import Control.Monad (void)
 import Data.Aeson (FromJSON(..), encode)
 import qualified Data.ByteString.Lazy as LBS
 import Data.Map.Strict (Map)
@@ -118,12 +122,22 @@ data AgentSessionToolsEnv = AgentSessionToolsEnv
     }
 
 data ManagedSessionProcess
-    = ManagedSessionStarting
+    = ManagedSessionStarting !(MVar ())
     | ManagedSessionRunning !ProcessHandle
+
+data SessionProcessState = SessionProcessState
+    { sessionManagerLifecycle :: !SessionManagerLifecycle
+    , sessionManagerProcesses :: !(Map Text ManagedSessionProcess)
+    }
+
+data SessionManagerLifecycle
+    = SessionManagerOpen
+    | SessionManagerClosing !(MVar ())
+    | SessionManagerClosed
 
 data SessionProcessManager = SessionProcessManager
     { managedRoot :: !OsPath
-    , managedProcesses :: !(MVar (Map Text ManagedSessionProcess))
+    , managedProcesses :: !(MVar SessionProcessState)
     , managedLifetime :: !SessionProcessLifetime
     }
 
@@ -141,7 +155,10 @@ newSessionProcessManagerWithLifetime
     -> OsPath
     -> IO SessionProcessManager
 newSessionProcessManagerWithLifetime lifetime root = do
-    processes <- newMVar Map.empty
+    processes <- newMVar SessionProcessState
+        { sessionManagerLifecycle = SessionManagerOpen
+        , sessionManagerProcesses = Map.empty
+        }
     pure SessionProcessManager
         { managedRoot = root
         , managedProcesses = processes
@@ -191,21 +208,29 @@ launchSessionTurnInput
         Left err -> pure (Left err)
         Right executable -> do
             let sessionId = handle.sessionMeta.metaId
-            reserved <- modifyMVar manager.managedProcesses \processes -> do
-                busy <- case Map.lookup sessionId processes of
+            completion <- newEmptyMVar
+            reserved <- modifyMVar manager.managedProcesses \state -> do
+                busy <- case Map.lookup sessionId state.sessionManagerProcesses of
                     Nothing -> pure False
-                    Just ManagedSessionStarting -> pure True
+                    Just ManagedSessionStarting{} -> pure True
                     Just (ManagedSessionRunning managedHandle) ->
                         (== Nothing) <$> getProcessExitCode managedHandle
-                if busy
-                    then pure (processes, False)
+                if not (sessionManagerIsOpen state) || busy
+                    then pure (state, False)
                     else pure
-                        ( Map.insert sessionId ManagedSessionStarting processes
+                        ( state
+                            { sessionManagerProcesses =
+                                Map.insert
+                                    sessionId
+                                    (ManagedSessionStarting completion)
+                                    state.sessionManagerProcesses
+                            }
                         , True
                         )
             if not reserved
-                then pure (Left ("session " <> sessionId <> " is already running"))
-                else do
+                then pure (Left ("session " <> sessionId
+                    <> " is already running or its process manager is closed"))
+                else (`finally` putMVar completion ()) do
                     started <- try @_ @SomeException
                         (startManagedSession executable)
                     case started of
@@ -218,33 +243,51 @@ launchSessionTurnInput
                             forgetSession manager sessionId
                             pure (Left err)
                         Right (Right process) -> do
-                            modifyMVar_ manager.managedProcesses \processes ->
-                                pure (Map.insert sessionId
-                                    (ManagedSessionRunning process)
-                                    processes)
-                            if background
-                                then pure (Right ("started session " <> sessionId))
-                                else do
-                                    exitResult <- case turnTimeout of
-                                        Nothing -> Right <$> waitForProcess process
-                                        Just micros ->
-                                            Timeout.timeout micros
-                                                (waitForManagedExit process) >>= \case
-                                                    Nothing -> do
-                                                        terminateManagedProcess process
-                                                        pure (Left
-                                                            "agent session timed out")
-                                                    Just exitCode ->
-                                                        pure (Right exitCode)
-                                    forgetSession manager sessionId
-                                    pure case exitResult of
-                                        Left err -> Left err
-                                        Right ExitSuccess ->
-                                            Right ("completed session " <> sessionId)
-                                        Right (ExitFailure code) ->
-                                            Left
-                                                ("session failed with exit code "
-                                                    <> Text.pack (show code))
+                            published <-
+                                modifyMVar manager.managedProcesses \state ->
+                                    if not (sessionManagerIsOpen state)
+                                        then pure (state, False)
+                                        else pure
+                                            ( state
+                                                { sessionManagerProcesses =
+                                                    Map.insert sessionId
+                                                        (ManagedSessionRunning process)
+                                                        state.sessionManagerProcesses
+                                                }
+                                            , True
+                                            )
+                            if not published
+                                then do
+                                    terminateManagedProcess process
+                                    pure (Left
+                                        "session process manager closed during startup")
+                                else if background
+                                    then pure (Right ("started session " <> sessionId))
+                                    else do
+                                        exitResult <- case turnTimeout of
+                                            Nothing ->
+                                                Right <$> waitForProcess process
+                                            Just micros ->
+                                                Timeout.timeout micros
+                                                    (waitForManagedExit process)
+                                                        >>= \case
+                                                            Nothing -> do
+                                                                terminateManagedProcess
+                                                                    process
+                                                                pure (Left
+                                                                    "agent session timed out")
+                                                            Just exitCode ->
+                                                                pure (Right exitCode)
+                                        forgetSession manager sessionId
+                                        pure case exitResult of
+                                            Left err -> Left err
+                                            Right ExitSuccess ->
+                                                Right
+                                                    ("completed session " <> sessionId)
+                                            Right (ExitFailure code) ->
+                                                Left
+                                                    ("session failed with exit code "
+                                                        <> Text.pack (show code))
   where
     sessionId = handle.sessionMeta.metaId
 
@@ -379,7 +422,10 @@ launchManagedTurnBounded
 forgetSession :: SessionProcessManager -> Text -> IO ()
 forgetSession manager sessionId =
     modifyMVar_ manager.managedProcesses
-        (pure . Map.delete sessionId)
+        (\state -> pure state
+            { sessionManagerProcesses =
+                Map.delete sessionId state.sessionManagerProcesses
+            })
 
 gatewayOnlyEnv :: [String]
 gatewayOnlyEnv =
@@ -389,44 +435,94 @@ gatewayOnlyEnv =
 
 sessionProcessStatus :: SessionProcessManager -> Text -> IO Text
 sessionProcessStatus manager sessionId =
-    modifyMVar manager.managedProcesses \processes ->
-        case Map.lookup sessionId processes of
+    modifyMVar manager.managedProcesses \state ->
+        case Map.lookup sessionId state.sessionManagerProcesses of
             Nothing -> do
                 locked <- sessionLockIsActive
                     (sessionLockPath
                         (manager.managedRoot
                             </> unsafeEncodeUtf (Text.unpack sessionId)))
-                pure (processes, if locked then "running" else "idle")
-            Just ManagedSessionStarting ->
-                pure (processes, "running")
+                pure (state, if locked then "running" else "idle")
+            Just ManagedSessionStarting{} ->
+                pure (state, "running")
             Just (ManagedSessionRunning managedHandle) ->
                 getProcessExitCode managedHandle >>= \case
-                    Nothing -> pure (processes, "running")
+                    Nothing -> pure (state, "running")
                     Just ExitSuccess ->
-                        pure (Map.delete sessionId processes, "completed")
+                        pure
+                            ( state
+                                { sessionManagerProcesses =
+                                    Map.delete sessionId
+                                        state.sessionManagerProcesses
+                                }
+                            , "completed"
+                            )
                     Just (ExitFailure code) ->
                         pure
-                            ( Map.delete sessionId processes
+                            ( state
+                                { sessionManagerProcesses =
+                                    Map.delete sessionId
+                                        state.sessionManagerProcesses
+                                }
                             , "failed (" <> Text.pack (show code) <> ")"
                             )
 
 closeSessionProcessManager :: SessionProcessManager -> IO ()
-closeSessionProcessManager manager =
-    modifyMVar_ manager.managedProcesses \processes -> do
-        forM_ (Map.elems processes) \case
-            ManagedSessionStarting -> pure ()
-            ManagedSessionRunning managedHandle ->
-                getProcessExitCode managedHandle >>= \case
-                    Just _ -> do
-                        _ <- try @_ @SomeException
-                            (waitForProcess managedHandle)
-                        pure ()
-                    Nothing ->
-                        case manager.managedLifetime of
-                            DetachedSessionProcesses -> pure ()
-                            ScopedSessionProcesses -> do
-                                terminateManagedProcess managedHandle
-        pure Map.empty
+closeSessionProcessManager manager = do
+    decision <- modifyMVar manager.managedProcesses \state ->
+        case state.sessionManagerLifecycle of
+            SessionManagerClosed -> pure (state, Left Nothing)
+            SessionManagerClosing completion ->
+                pure (state, Left (Just completion))
+            SessionManagerOpen -> do
+                completion <- newEmptyMVar
+                pure
+                    ( state
+                        { sessionManagerLifecycle =
+                            SessionManagerClosing completion
+                        , sessionManagerProcesses = Map.empty
+                        }
+                    , Right
+                        ( completion
+                        , Map.elems state.sessionManagerProcesses
+                        )
+                    )
+    case decision of
+        Left Nothing -> pure ()
+        Left (Just completion) -> readMVar completion
+        Right (completion, processes) ->
+            closeProcesses processes `finally` do
+                modifyMVar_ manager.managedProcesses \state ->
+                    pure state
+                        { sessionManagerLifecycle = SessionManagerClosed
+                        }
+                putMVar completion ()
+  where
+    closeProcesses processes = do
+        let waitStarting = \case
+                ManagedSessionStarting completion -> readMVar completion
+                ManagedSessionRunning _ -> pure ()
+            closeRunning = \case
+                ManagedSessionStarting{} -> pure ()
+                ManagedSessionRunning managedHandle ->
+                    getProcessExitCode managedHandle >>= \case
+                        Just _ ->
+                            void $ try @_ @SomeException
+                                (waitForProcess managedHandle)
+                        Nothing ->
+                            case manager.managedLifetime of
+                                DetachedSessionProcesses -> pure ()
+                                ScopedSessionProcesses ->
+                                    terminateManagedProcess managedHandle
+        forConcurrentlyBounded_ 8 waitStarting processes
+        forConcurrentlyBounded_ 8 closeRunning processes
+
+sessionManagerIsOpen :: SessionProcessState -> Bool
+sessionManagerIsOpen state =
+    case state.sessionManagerLifecycle of
+        SessionManagerOpen -> True
+        SessionManagerClosing{} -> False
+        SessionManagerClosed -> False
 
 waitForManagedExit :: ProcessHandle -> IO ExitCode
 waitForManagedExit process =

--- a/packages/agent-cli/src/Agent/CLI/ManagedTurn.hs
+++ b/packages/agent-cli/src/Agent/CLI/ManagedTurn.hs
@@ -17,6 +17,7 @@ import Agent.Loop
     , ImageAttachment(..)
     , TurnInput(..)
     )
+import Agent.Concurrent (mapConcurrentlyBounded)
 import Agent.FileRetry (retryOnFileBusy)
 import Agent.OsPath (unsafeToFilePath)
 import Data.Aeson
@@ -161,8 +162,11 @@ managedTurnInputs _ request
     | null request.managedTurnImages && null request.managedTurnFiles =
         pure [UserMessage request.managedTurnText]
     | otherwise = do
-        images <- mapM loadImage request.managedTurnImages
-        files <- mapM loadFile request.managedTurnFiles
+        loaded <- mapConcurrentlyBounded 4 loadMedia
+            (map Left request.managedTurnImages
+                <> map Right request.managedTurnFiles)
+        let images = [image | Left image <- loaded]
+            files = [file | Right file <- loaded]
         pure
             [ UserMultimodalFiles
                 { userText = request.managedTurnText
@@ -171,6 +175,10 @@ managedTurnInputs _ request
                 }
             ]
   where
+    loadMedia = \case
+        Left media -> Left <$> loadImage media
+        Right media -> Right <$> loadFile media
+
     loadImage ManagedTurnMedia{managedTurnMediaPath = path, managedTurnMediaMime = mime} = do
         bytes <- BS.readFile path
         pure ImageAttachment

--- a/packages/agent-cli/src/Agent/CLI/Resume.hs
+++ b/packages/agent-cli/src/Agent/CLI/Resume.hs
@@ -40,6 +40,7 @@ import Agent.CLI.Session
     ( SessionMeta(..)
     , SessionTurn(..)
     , loadSession
+    , loadSessions
     )
 import Agent.CLI.Style (roleMuted, rolePrompt, roleSuccess)
 import Agent.CLI.TextLayout
@@ -52,7 +53,6 @@ import Agent.Provider (providerSlug)
 import Agent.Responses.Types (ResponseItem(..))
 import Agent.Store.Postgres.Connection (StorePool)
 import Agent.Store.Postgres.Session (ConversationSearchResult(..))
-import Control.Monad (forM)
 import Data.Char (isAlphaNum)
 import Data.List (nub)
 import qualified Data.Map.Strict as Map
@@ -640,22 +640,24 @@ loadRecentSessions
     -> OsPath
     -> [SessionMeta]
     -> IO [(SessionMeta, [SessionTurn])]
-loadRecentSessions pool root metas =
-    forM (take 20 metas) \meta ->
-        loadSession pool root meta.metaId >>= \case
-            Right loaded -> pure loaded
-            Left err ->
-                pure
-                    ( meta
-                    , [ SessionTurn
-                            { turnAt = meta.metaUpdatedAt
-                            , turnUserText = ""
-                            , turnAssistantText =
-                                Just ("Transcript unavailable: " <> err)
-                            , turnError = Nothing
-                            , turnResponseId = Nothing
-                            , turnItems = []
-                            , turnUsage = Nothing
-                            }
-                      ]
-                    )
+loadRecentSessions pool root metas = do
+    let recent = take 20 metas
+    loaded <- loadSessions pool root (map (.metaId) recent)
+    pure (zipWith loadedOrUnavailable recent loaded)
+  where
+    loadedOrUnavailable meta = \case
+        Right session -> session
+        Left err ->
+            ( meta
+            , [ SessionTurn
+                    { turnAt = meta.metaUpdatedAt
+                    , turnUserText = ""
+                    , turnAssistantText =
+                        Just ("Transcript unavailable: " <> err)
+                    , turnError = Nothing
+                    , turnResponseId = Nothing
+                    , turnItems = []
+                    , turnUsage = Nothing
+                    }
+              ]
+            )

--- a/packages/agent-cli/src/Agent/CLI/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime.hs
@@ -494,6 +494,7 @@ import Agent.CLI.Worktree
     , worktreeRoot
     )
 import Agent.Cancel (requestCancel, resetCancel, waitCancel)
+import Agent.Concurrent (mapConcurrentlyBounded)
 import Agent.Claude
     ( ClaudeCodeAuth(..)
     , ClaudeCodeOptions(..)
@@ -638,7 +639,16 @@ import Agent.XAI.LoopBackend (xaiBackend)
 import qualified Agent.XAI.Options as XAI
 import qualified Agent.XAI.Usage as XAIUsage
 import Control.Applicative ((<|>))
-import Control.Concurrent.Async (link, waitSTM, withAsync)
+import Control.Concurrent.Async
+    ( cancel
+    , concurrently
+    , concurrently_
+    , link
+    , waitCatch
+    , waitEitherCatch
+    , waitSTM
+    , withAsync
+    )
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.Chan (Chan, newChan, readChan, writeChan)
 import Control.Concurrent.MVar
@@ -658,6 +668,7 @@ import Control.Exception.Safe
     ( SomeException
     , catchAny
     , finally
+    , mask
     , mask_
     , onException
     , throwIO
@@ -1397,12 +1408,16 @@ runAgentInitializedWithLock
         deriveDatabaseScopes stateDirectory projectRootPath >>= \case
             Left err -> startupDie startup (Text.unpack err)
             Right scopes -> pure scopes
-    projectSettings <- loadProjectSettings projectRoot
-    catalog <-
-        loadModelCatalog home >>= either
-            (startupDie startup . Text.unpack)
-            pure
-    branch <- detectGitBranch cwd
+    (projectSettings, (catalogResult, branch)) <-
+        concurrently
+            (loadProjectSettings projectRoot)
+            (concurrently
+                (loadModelCatalog home)
+                (detectGitBranch cwd))
+    catalog <- either
+        (startupDie startup . Text.unpack)
+        pure
+        catalogResult
     setStartupRepository fullscreen home branch cwd
     markStartupStage startup "Loading credentials…"
     let transitionTarget = (.transitionTarget) <$> transition
@@ -2085,21 +2100,19 @@ runAgentInitializedWithLock
                         , lspStartupWarnings = []
                         }
                     )
-            | otherwise = do
-                webRuntime <-
-                    newWebFetchRuntime
+            | otherwise =
+                concurrentlyAcquire
+                    (newWebFetchRuntime
                         harnessConfig.configWebFetch
                         toolEnv >>= \case
                             Left err ->
                                 startupDie startup
                                     ("Failed to initialize web_fetch: "
                                         <> Text.unpack err)
-                            Right runtime -> pure runtime
-                lspStartup <-
-                    newLspRuntime harnessConfig.configLsp toolEnv
-                        `onException`
-                            mapM_ closeWebFetchRuntime webRuntime
-                pure (webRuntime, lspStartup)
+                            Right runtime -> pure runtime)
+                    (mapM_ closeWebFetchRuntime)
+                    (newLspRuntime harnessConfig.configLsp toolEnv)
+                    (mapM_ closeLspRuntime . (.lspStartupRuntime))
     (webFetchRuntime, lspStartup) <-
         acquireGrokExtras `onException` closeBeforeSession
     mapM_ (reportStartupWarning startup) lspStartup.lspStartupWarnings
@@ -2108,9 +2121,9 @@ runAgentInitializedWithLock
             maybe [] (pure . webFetchRuntimeTool) webFetchRuntime
                 <> maybe [] (pure . lspRuntimeTool) lspRuntime
         closeExtraTools =
-            mapM_ closeLspRuntime lspRuntime
-                `finally`
-                    mapM_ closeWebFetchRuntime webFetchRuntime
+            concurrently_
+                (mapM_ closeLspRuntime lspRuntime)
+                (mapM_ closeWebFetchRuntime webFetchRuntime)
     case multiCtx of
         Just ctx -> do
             setSubagentOnComplete ctx.multiRegistry \agentId status -> do
@@ -3223,7 +3236,7 @@ runSession SessionRequest{..} SessionBackend{..} = do
                     , agentTranscript =
                         transcriptLines AgentRoot rootItems
                     }
-            children <- mapM
+            children <- mapConcurrentlyBounded 8
                 (materializeChild transcriptLines sessions)
                 agents
             pure (selected, rootEntry : children)
@@ -5754,6 +5767,59 @@ replWithDraft env@SessionEnv
                         Text.hPutStrLn stderr
                             (roleError color
                                 "terminal clipboard is unavailable")
+
+concurrentlyAcquire
+    :: IO a
+    -> (a -> IO ())
+    -> IO b
+    -> (b -> IO ())
+    -> IO (a, b)
+concurrentlyAcquire acquireLeft releaseLeft acquireRight releaseRight =
+    mask \restore ->
+        withAsync (restore acquireLeft) \leftWorker ->
+            withAsync (restore acquireRight) \rightWorker -> do
+                let cleanupResult release = \case
+                        Left _ -> pure ()
+                        Right value -> release value
+                    cancelAndCleanup = do
+                        cancel leftWorker
+                        cancel rightWorker
+                        leftResult <- waitCatch leftWorker
+                        rightResult <- waitCatch rightWorker
+                        cleanupResult releaseLeft leftResult
+                        cleanupResult releaseRight rightResult
+                first <-
+                    restore (waitEitherCatch leftWorker rightWorker)
+                        `onException` cancelAndCleanup
+                case first of
+                    Left (Left exception) -> do
+                        cancel rightWorker
+                        waitCatch rightWorker >>= cleanupResult releaseRight
+                        throwIO exception
+                    Right (Left exception) -> do
+                        cancel leftWorker
+                        waitCatch leftWorker >>= cleanupResult releaseLeft
+                        throwIO exception
+                    Left (Right leftValue) -> do
+                        rightResult <-
+                            restore (waitCatch rightWorker)
+                                `onException` releaseLeft leftValue
+                        case rightResult of
+                            Left exception -> do
+                                releaseLeft leftValue
+                                throwIO exception
+                            Right rightValue ->
+                                pure (leftValue, rightValue)
+                    Right (Right rightValue) -> do
+                        leftResult <-
+                            restore (waitCatch leftWorker)
+                                `onException` releaseRight rightValue
+                        case leftResult of
+                            Left exception -> do
+                                releaseRight rightValue
+                                throwIO exception
+                            Right leftValue ->
+                                pure (leftValue, rightValue)
 
 requestReload
     :: Maybe FullscreenRuntime

--- a/packages/agent-cli/src/Agent/CLI/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session.hs
@@ -24,6 +24,7 @@ module Agent.CLI.Session
     , addSessionUsage
     , deleteSession
     , loadSession
+    , loadSessions
     , importSessionTransfer
     , loadSessionHandle
     , isValidSessionId
@@ -710,6 +711,36 @@ loadSession pool root sessionId = runExceptT do
     case stored' of
         Nothing -> throwE ("session not found: " <> sessionId)
         Just value -> decodeStoredSession sessionId value
+
+-- | Load several sessions with one batched PostgreSQL read while preserving
+-- request order. A missing database row still takes the legacy import path.
+loadSessions
+    :: StorePool
+    -> OsPath
+    -> [Text]
+    -> IO [Either Text (SessionMeta, [SessionTurn])]
+loadSessions pool root sessionIds = do
+    let validated =
+            [ sessionDirForId root sessionId
+                >> Right sessionId
+            | sessionId <- sessionIds
+            ]
+        validIds = [sessionId | Right sessionId <- validated]
+    stored <- Store.loadSessions pool validIds
+    restoreResults validated stored
+  where
+    restoreResults [] [] = pure []
+    restoreResults (Left err : rest) results =
+        (Left err :) <$> restoreResults rest results
+    restoreResults (Right sessionId : rest) (result : results) = do
+        loaded <- case result of
+            Left err -> pure (Left (renderStoreError err))
+            Right Nothing -> loadSession pool root sessionId
+            Right (Just value) ->
+                runExceptT (decodeStoredSession sessionId value)
+        (loaded :) <$> restoreResults rest results
+    restoreResults _ _ =
+        pure [Left "batched session load returned an unexpected result count"]
 
 loadSessionHandle
     :: StorePool

--- a/packages/agent-cli/src/Agent/CLI/Session/Choices.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Choices.hs
@@ -16,6 +16,7 @@ import Agent.CLI.Models
     , PickerState(..)
     , initialPickerStateResolved
     )
+import Agent.Concurrent (mapConcurrentlyBounded)
 import Agent.CLI.Options (reasoningEfforts)
 import Agent.CLI.Style
     ( roleError
@@ -146,7 +147,7 @@ accountUsageText color provider tokenProvider openAiPool = do
             case openAiPool of
                 Just pool -> do
                     snapshots <- OpenAI.snapshotAccounts pool
-                    lines_ <- mapM fetchSnapshot snapshots
+                    lines_ <- mapConcurrentlyBounded 4 fetchSnapshot snapshots
                     pure (formatUsageReport color now lines_)
                 Nothing ->
                     case tokenProvider of

--- a/packages/agent-cli/test/Agent/CLI/AgentSessionsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/AgentSessionsSpec.hs
@@ -174,6 +174,31 @@ spec = describe "Agent.CLI.AgentSessions" do
                     "completed"
                 closeSessionProcessManager manager
 
+    it "closes scoped children concurrently and rejects later launches" $
+        withTempStoreDir "agent-session-runtime-" \pool root -> do
+            let marker = toFilePath root FilePath.</> "stopped"
+            script <- writeFakeAgentBody root
+                ("trap 'printf stopped > " <> shellQuote marker
+                    <> "; exit 0' TERM INT\nsleep 30\n")
+            withExecutableOverride script do
+                handle <- createSession (testCreateAt pool root root)
+                manager <-
+                    newSessionProcessManagerWithLifetime
+                        ScopedSessionProcesses
+                        root
+                launchSessionTurn
+                    manager True ApproveAll True False handle "one"
+                    `shouldReturn`
+                        Right ("started session " <> handle.sessionMeta.metaId)
+                closeSessionProcessManager manager
+                waitForFile marker
+                launchSessionTurn
+                    manager True ApproveAll True False handle "two"
+                    `shouldReturn`
+                        Left
+                            ("session " <> handle.sessionMeta.metaId
+                                <> " is already running or its process manager is closed")
+
     it "forwards bash enablement to managed session turns" $
         withTempStoreDir "agent-session-runtime-" \pool root -> do
             let argsPath = toFilePath root FilePath.</> "agent-args"

--- a/packages/agent-cli/test/Agent/CLI/ManagedTurnSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ManagedTurnSpec.hs
@@ -1,11 +1,20 @@
 module Agent.CLI.ManagedTurnSpec (spec) where
 
 import Agent.CLI.ManagedTurn
-    ( managedTurnRequestFromText
+    ( ManagedTurnMedia(..)
+    , ManagedTurnRequest(..)
+    , managedTurnInputs
+    , managedTurnRequestFromText
     , loadManagedTurnRequest
     , renderManagedTurnPrompt
     )
+import Agent.Loop
+    ( FileAttachment(..)
+    , ImageAttachment(..)
+    , TurnInput(..)
+    )
 import Agent.OsPath (fromText)
+import qualified Data.ByteString.Char8 as ByteString.Char8
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
 import System.Directory
@@ -38,6 +47,80 @@ spec = describe "Agent.CLI.ManagedTurn" do
             loaded `shouldSatisfy` \case
                 Left err -> "could not decode" `Text.isInfixOf` err
                 Right _ -> False
+
+    it "loads multimodal images and files concurrently without reordering them" $
+        withManagedTempDir \dir -> do
+            let imagePaths =
+                    [ dir </> "image-1.bin"
+                    , dir </> "image-2.bin"
+                    ]
+                filePaths =
+                    [ dir </> "file-1.txt"
+                    , dir </> "file-2.txt"
+                    ]
+                write path contents =
+                    ByteString.Char8.writeFile path contents
+            mapM_ (\(path, contents) -> write path contents)
+                [ (imagePaths !! 0, "image-one")
+                , (imagePaths !! 1, "image-two")
+                , (filePaths !! 0, "file-one")
+                , (filePaths !! 1, "file-two")
+                ]
+            let request =
+                    (managedTurnRequestFromText "summarize")
+                        { managedTurnImages =
+                            [ ManagedTurnMedia
+                                { managedTurnMediaPath = imagePaths !! 0
+                                , managedTurnMediaMime = "image/test"
+                                , managedTurnMediaName = Nothing
+                                }
+                            , ManagedTurnMedia
+                                { managedTurnMediaPath = imagePaths !! 1
+                                , managedTurnMediaMime = "image/test"
+                                , managedTurnMediaName = Nothing
+                                }
+                            ]
+                        , managedTurnFiles =
+                            [ ManagedTurnMedia
+                                { managedTurnMediaPath = filePaths !! 0
+                                , managedTurnMediaMime = "text/plain"
+                                , managedTurnMediaName = Just "one.txt"
+                                }
+                            , ManagedTurnMedia
+                                { managedTurnMediaPath = filePaths !! 1
+                                , managedTurnMediaMime = "text/plain"
+                                , managedTurnMediaName = Just "two.txt"
+                                }
+                            ]
+                        }
+            managedTurnInputs (fromText (Text.pack dir)) request
+                `shouldReturn`
+                    [ UserMultimodalFiles
+                        { userText = "summarize"
+                        , userImages =
+                            [ ImageAttachment
+                                { imageMime = "image/test"
+                                , imageBytes = "image-one"
+                                }
+                            , ImageAttachment
+                                { imageMime = "image/test"
+                                , imageBytes = "image-two"
+                                }
+                            ]
+                        , userFiles =
+                            [ FileAttachment
+                                { fileName = Just "one.txt"
+                                , fileMime = "text/plain"
+                                , fileBytes = "file-one"
+                                }
+                            , FileAttachment
+                                { fileName = Just "two.txt"
+                                , fileMime = "text/plain"
+                                , fileBytes = "file-two"
+                                }
+                            ]
+                        }
+                    ]
 
 withManagedTempDir :: (FilePath -> IO a) -> IO a
 withManagedTempDir action = do

--- a/packages/agent-cli/test/Agent/CLI/SessionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SessionSpec.hs
@@ -287,6 +287,17 @@ spec = describe "Agent.CLI.Session" do
                             , outputTokens = 4
                             , cachedTokens = 2
                             }
+                loadSessions pool root
+                    [final.sessionMeta.metaId, "missing", final.sessionMeta.metaId]
+                    >>= \results ->
+                        fmap (fmap (\(meta, turns) -> (meta.metaId, turns))) results
+                            `shouldBe`
+                                [ Right
+                                    (final.sessionMeta.metaId, [normalTurn, compactTurn])
+                                , Left "session not found: missing"
+                                , Right
+                                    (final.sessionMeta.metaId, [normalTurn, compactTurn])
+                                ]
 
                 listed <- listSessions pool root
                 map (.metaId) listed `shouldBe` [handle.sessionMeta.metaId]

--- a/packages/agent-core/agent-core.cabal
+++ b/packages/agent-core/agent-core.cabal
@@ -39,6 +39,7 @@ library
     import:           common-opts
     exposed-modules:  Agent.Auth.JWT
                     , Agent.Cancel
+                    , Agent.Concurrent
                     , Agent.Dialect
                     , Agent.Error
                     , Agent.FileRetry
@@ -154,6 +155,15 @@ benchmark loop-events-bench
                     , base >= 4.14 && < 5
                     , text
 
+benchmark concurrent-discovery-bench
+    import:           common-opts
+    type:             exitcode-stdio-1.0
+    hs-source-dirs:   benchmark
+    main-is:          ConcurrentDiscovery.hs
+    ghc-options:      -O2 -rtsopts
+    build-depends:    agent-core
+                    , base >= 4.14 && < 5
+
 test-suite agent-core-test
     import:           common-opts
     type:             exitcode-stdio-1.0
@@ -161,6 +171,7 @@ test-suite agent-core-test
     main-is:          Spec.hs
     other-modules:    Agent.Auth.JWTSpec
                     , Agent.CancelSpec
+                    , Agent.ConcurrentSpec
                     , Agent.DialectSpec
                     , Agent.ErrorSpec
                     , Agent.Http.HeaderSpec

--- a/packages/agent-core/benchmark/ConcurrentDiscovery.hs
+++ b/packages/agent-core/benchmark/ConcurrentDiscovery.hs
@@ -1,0 +1,166 @@
+module Main (main) where
+
+import Agent.Concurrent (mapConcurrentlyBounded)
+import Control.Concurrent (threadDelay)
+import Control.Exception (evaluate)
+import Control.Monad (forM, forM_)
+import Data.List (sort)
+import GHC.Clock (getMonotonicTimeNSec)
+import GHC.Stats
+    ( RTSStats(..)
+    , getRTSStats
+    , getRTSStatsEnabled
+    )
+import System.Environment (getArgs)
+import System.Exit (die)
+import System.Mem (performGC)
+import System.CPUTime (getCPUTime)
+import Text.Printf (printf)
+
+-- | One delayed operation models an independent discovery probe (for
+-- example, reading metadata for a candidate file or skill).  The result is
+-- deliberately consumed by the benchmark so neither traversal can be
+-- optimized away.
+data DiscoveryResult = DiscoveryResult
+    { discoveryIndex :: !Int
+    , discoveryChecksum :: !Int
+    }
+
+data Sample = Sample
+    { elapsedMillis :: !Double
+    , cpuMillis :: !Double
+    , allocatedBytes :: !Integer
+    }
+
+data Scenario = Scenario
+    { taskCount :: !Int
+    , workerLimit :: !Int
+    , delayMicros :: !Int
+    , sampleCount :: !Int
+    }
+
+main :: IO ()
+main = do
+    statsEnabled <- getRTSStatsEnabled
+    scenarios <- getArgs >>= parseScenarios
+    putStrLn "mode,tasks,limit,delay_us,samples,elapsed_ms,cpu_ms,allocated_bytes"
+    forM_ scenarios \scenario -> do
+        serial <- measureMany scenario.sampleCount statsEnabled (runSerial scenario)
+        bounded <- measureMany scenario.sampleCount statsEnabled (runBounded scenario)
+        printResult "serial" scenario serial
+        printResult "bounded" scenario bounded
+
+parseScenarios :: [String] -> IO [Scenario]
+parseScenarios [] =
+    pure
+        [ Scenario tasks limit 1000 5
+        | tasks <- [8, 32, 128]
+        , limit <- [1, 4, 8, 16]
+        ]
+parseScenarios [tasksArg, limitArg, delayArg, samplesArg] = do
+    tasks <- parsePositive "task count" tasksArg
+    limit <- parsePositive "worker limit" limitArg
+    delay <- parseNonNegative "delay microseconds" delayArg
+    samples <- parsePositive "sample count" samplesArg
+    pure [Scenario tasks limit delay samples]
+parseScenarios _ =
+    die
+        "usage: concurrent-discovery-bench [TASKS LIMIT DELAY_US SAMPLES]\n\
+        \without arguments, runs tasks 8,32,128 x limits 1,4,8,16 (1ms delay)"
+
+parsePositive :: String -> String -> IO Int
+parsePositive label raw =
+    case reads raw of
+        [(value, "")]
+            | value > 0 -> pure value
+        _ -> die ("invalid " <> label <> ": " <> raw)
+
+parseNonNegative :: String -> String -> IO Int
+parseNonNegative label raw =
+    case reads raw of
+        [(value, "")]
+            | value >= 0 -> pure value
+        _ -> die ("invalid " <> label <> ": " <> raw)
+
+runSerial :: Scenario -> IO Int
+runSerial scenario =
+    consumeResults <$> mapM (discover scenario.delayMicros) [1 .. scenario.taskCount]
+
+runBounded :: Scenario -> IO Int
+runBounded scenario =
+    consumeResults
+        <$> mapConcurrentlyBounded
+            scenario.workerLimit
+            (discover scenario.delayMicros)
+            [1 .. scenario.taskCount]
+
+discover :: Int -> Int -> IO DiscoveryResult
+discover delayMicros index = do
+    threadDelay delayMicros
+    pure
+        DiscoveryResult
+            { discoveryIndex = index
+            , discoveryChecksum = index * 31 + delayMicros
+            }
+
+consumeResults :: [DiscoveryResult] -> Int
+consumeResults =
+    foldr
+        (\result total ->
+            total
+                + result.discoveryIndex
+                + result.discoveryChecksum)
+        0
+
+measureMany :: Int -> Bool -> IO Int -> IO Sample
+measureMany sampleCount statsEnabled action = do
+    samples <- forM [1 .. sampleCount] \_ -> measureOne statsEnabled action
+    pure (median samples)
+
+measureOne :: Bool -> IO Int -> IO Sample
+measureOne statsEnabled action = do
+    performGC
+    beforeStats <- if statsEnabled then Just <$> getRTSStats else pure Nothing
+    beforeCpu <- getCPUTime
+    beforeWall <- getMonotonicTimeNSec
+    result <- action
+    evaluate result
+    afterWall <- getMonotonicTimeNSec
+    afterCpu <- getCPUTime
+    afterStats <- if statsEnabled then Just <$> getRTSStats else pure Nothing
+    pure
+        Sample
+            { elapsedMillis =
+                fromIntegral (afterWall - beforeWall) / 1.0e6
+            , cpuMillis =
+                fromIntegral (afterCpu - beforeCpu) / 1.0e9
+            , allocatedBytes = allocatedDelta beforeStats afterStats
+            }
+
+allocatedDelta :: Maybe RTSStats -> Maybe RTSStats -> Integer
+allocatedDelta (Just beforeStats) (Just afterStats) =
+    fromIntegral (afterStats.allocated_bytes - beforeStats.allocated_bytes)
+allocatedDelta _ _ = 0
+
+printResult :: String -> Scenario -> Sample -> IO ()
+printResult mode scenario sample =
+    printf
+        "%s,%d,%d,%d,%d,%.3f,%.3f,%d\n"
+        mode
+        scenario.taskCount
+        scenario.workerLimit
+        scenario.delayMicros
+        scenario.sampleCount
+        sample.elapsedMillis
+        sample.cpuMillis
+        sample.allocatedBytes
+
+median :: [Sample] -> Sample
+median samples =
+    Sample
+        { elapsedMillis = middle (sort (map (.elapsedMillis) samples))
+        , cpuMillis = middle (sort (map (.cpuMillis) samples))
+        , allocatedBytes = middle (sort (map (.allocatedBytes) samples))
+        }
+  where
+    middle values = values !! (length values `div` 2)

--- a/packages/agent-core/src/Agent/Concurrent.hs
+++ b/packages/agent-core/src/Agent/Concurrent.hs
@@ -1,0 +1,53 @@
+-- | Small structured-concurrency helpers shared by agent subsystems.
+module Agent.Concurrent
+    ( mapConcurrentlyBounded
+    , forConcurrentlyBounded_
+    ) where
+
+import Control.Concurrent.Async (replicateConcurrently_)
+import Control.Concurrent.STM
+    ( atomically
+    , modifyTVar'
+    , newTQueueIO
+    , newTVarIO
+    , readTQueue
+    , readTVarIO
+    , writeTQueue
+    )
+import Control.Monad (forM_, replicateM_, void)
+import qualified Data.Map.Strict as Map
+
+-- | Apply an action with at most the requested number of active workers.
+--
+-- Results retain input order. Worker lifetimes are scoped by
+-- 'replicateConcurrently_', so an exception cancels and joins the remaining
+-- workers before it escapes.
+mapConcurrentlyBounded :: Int -> (a -> IO b) -> [a] -> IO [b]
+mapConcurrentlyBounded _ _ [] = pure []
+mapConcurrentlyBounded requested action values = do
+    let workerCount = min (max 1 requested) (length values)
+    queue <- newTQueueIO
+    results <- newTVarIO Map.empty
+    atomically do
+        forM_ (zip [0 :: Int ..] values) $
+            writeTQueue queue . Just
+        replicateM_ workerCount (writeTQueue queue Nothing)
+    let worker =
+            atomically (readTQueue queue) >>= \case
+                Nothing -> pure ()
+                Just (index, value) -> do
+                    result <- action value
+                    atomically $
+                        modifyTVar' results (Map.insert index result)
+                    worker
+    replicateConcurrently_ workerCount worker
+    completed <- readTVarIO results
+    pure
+        [ completed Map.! index
+        | index <- [0 .. length values - 1]
+        ]
+
+-- | Bounded, structured traversal when results are not needed.
+forConcurrentlyBounded_ :: Int -> (a -> IO b) -> [a] -> IO ()
+forConcurrentlyBounded_ requested action values =
+    void (mapConcurrentlyBounded requested action values)

--- a/packages/agent-core/src/Agent/MCP.hs
+++ b/packages/agent-core/src/Agent/MCP.hs
@@ -37,6 +37,7 @@ import Agent.Tools.Types
     , ToolSchema(..)
     )
 import Agent.ToolDispatch (typedTool)
+import Agent.Concurrent (forConcurrentlyBounded_)
 import Control.Concurrent.Async
     ( Async
     , asyncWithUnmask
@@ -654,14 +655,14 @@ closeMcpSupervisor supervisor = do
                 void (tryPutTMVar entry.supervisorPendingResult
                     (Left "MCP supervisor closed")))
             pending
-    mapM_
+    forConcurrentlyBounded_ 8
         (\entry -> do
             worker <- atomically
                 (readTMVar entry.supervisorPendingWorker)
             cancel worker
             void (waitCatch worker))
         pending
-    mapM_ closeMcpFleet fleets
+    forConcurrentlyBounded_ 4 closeMcpFleet fleets
 
 resolveEffectiveCwds :: [McpServerConfig] -> IO [McpServerConfig]
 resolveEffectiveCwds configs = do
@@ -1527,9 +1528,9 @@ closeMcpFleet fleet =
                 activeWorkers <-
                     modifyMVar fleet.mcpFleetWorkers \workers ->
                         pure ([], workers)
-                mapM_ stopWorker activeWorkers
+                forConcurrentlyBounded_ 8 stopWorker activeWorkers
                 clients <- Map.elems <$> readTVarIO fleet.mcpFleetClients
-                mapM_ closeMcpClient clients
+                forConcurrentlyBounded_ 8 closeMcpClient clients
                 pure True
 
 startMcpClient :: McpServerConfig -> IO McpClient

--- a/packages/agent-core/src/Agent/ProjectInstructions.hs
+++ b/packages/agent-core/src/Agent/ProjectInstructions.hs
@@ -15,10 +15,12 @@ module Agent.ProjectInstructions
     , nonEmptyInstructionContent
     ) where
 
+import Agent.Concurrent (mapConcurrentlyBounded)
 import Agent.FileRetry (retryOnFileBusy)
 import Agent.OsPath (directoryChain, toText, unsafeToFilePath)
+import Control.Applicative ((<|>))
+import Control.Concurrent.Async (concurrently)
 import Control.Exception.Safe (tryAny)
-import Control.Monad (filterM, foldM)
 import qualified Data.ByteString as BS
 import Data.List (sort)
 import Data.Maybe (mapMaybe)
@@ -102,10 +104,13 @@ discoverProjectInstructions options cwd
         loaded <-
             if usesCodexDiscovery options
                 then do
-                    global <-
-                        maybe (pure Nothing) readPreferredAgentsMd
-                            options.discoverGlobalDir
-                    project <- mapMaybe id <$> traverse readPreferredAgentsMd dirs
+                    (global, projectFiles) <- concurrently
+                        (maybe (pure Nothing) readPreferredAgentsMd
+                            options.discoverGlobalDir)
+                        (mapConcurrentlyBounded instructionDirectoryConcurrency
+                            readPreferredAgentsMd
+                            dirs)
+                    let project = mapMaybe id projectFiles
                     pure LoadedAgentsMd
                         { loadedGlobal = global
                         , loadedProject = project
@@ -124,8 +129,12 @@ discoverGrokInstructions
     -> [OsPath]
     -> IO LoadedAgentsMd
 discoverGrokInstructions options dirs = do
-    home <- maybe (pure []) readGrokHomeInstructions options.discoverGlobalDir
-    project <- concat <$> traverse readGrokDirectoryInstructions dirs
+    (home, projectParts) <- concurrently
+        (maybe (pure []) readGrokHomeInstructions options.discoverGlobalDir)
+        (mapConcurrentlyBounded instructionDirectoryConcurrency
+            readGrokDirectoryInstructions
+            dirs)
+    let project = concat projectParts
     combined <- dedupeInstructionFiles (home <> project)
     pure $ case (home, combined) of
         ([], _) -> LoadedAgentsMd
@@ -145,29 +154,35 @@ discoverGrokInstructions options dirs = do
 -- Cursor homes. For custom harness homes, only that explicit directory is
 -- inspected.
 readGrokHomeInstructions :: OsPath -> IO [InstructionFile]
-readGrokHomeInstructions globalDir = do
-    primary <- readGrokHomeRoot globalDir
-    compatible <-
-        if takeFileName globalDir == unsafeEncodeUtf ".grok"
-            then concat <$> traverse readGrokHomeRoot
-                [ takeDirectory globalDir </> unsafeEncodeUtf ".claude"
-                , takeDirectory globalDir </> unsafeEncodeUtf ".cursor"
-                ]
-            else pure []
-    pure (primary <> compatible)
+readGrokHomeInstructions globalDir =
+    concat
+        <$> mapConcurrentlyBounded instructionDirectoryConcurrency
+            readGrokHomeRoot
+            roots
+  where
+    roots
+        | takeFileName globalDir == unsafeEncodeUtf ".grok" =
+            [ globalDir
+            , takeDirectory globalDir </> unsafeEncodeUtf ".claude"
+            , takeDirectory globalDir </> unsafeEncodeUtf ".cursor"
+            ]
+        | otherwise = [globalDir]
 
 readGrokHomeRoot :: OsPath -> IO [InstructionFile]
 readGrokHomeRoot dir = do
-    named <- readNamedInstructionFiles dir
-    rules <- readRulesDirectory (dir </> unsafeEncodeUtf "rules")
+    (named, rules) <- concurrently
+        (readNamedInstructionFiles dir)
+        (readRulesDirectory (dir </> unsafeEncodeUtf "rules"))
     pure (named <> rules)
 
 readGrokDirectoryInstructions :: OsPath -> IO [InstructionFile]
 readGrokDirectoryInstructions dir = do
-    named <- readNamedInstructionFiles dir
-    rules <- concat <$> traverse
-        (readRulesDirectory . (dir </>))
-        grokProjectRulesDirectories
+    (named, ruleGroups) <- concurrently
+        (readNamedInstructionFiles dir)
+        (mapConcurrentlyBounded instructionDirectoryConcurrency
+            (readRulesDirectory . (dir </>))
+            grokProjectRulesDirectories)
+    let rules = concat ruleGroups
     pure (named <> rules)
 
 grokProjectRulesDirectories :: [OsPath]
@@ -179,16 +194,26 @@ grokProjectRulesDirectories =
 
 readNamedInstructionFiles :: OsPath -> IO [InstructionFile]
 readNamedInstructionFiles dir = do
-    preferredAgents <- readPreferredAgentsMd dir
+    (preferredAgents, loadedOthers) <- concurrently
+        (readPreferredAgentsMd dir)
+        (mapConcurrentlyBounded instructionFileConcurrency
+            (\name -> do
+                loaded <- readAgentsFile (dir </> name)
+                pure (name, loaded))
+            grokInstructionNames)
     let names = case preferredAgents of
             Just file
                 | takeFileName file.instructionPath
                     == unsafeEncodeUtf "AGENTS.override.md" ->
                     filter (not . isAgentsMdSpelling) grokInstructionNames
             _ -> grokInstructionNames
-    other <- mapMaybe id <$> traverse
-        (readAgentsFile . (dir </>))
-        names
+        allowedNames = Set.fromList names
+        other =
+            mapMaybe snd
+                [ loaded
+                | loaded@(name, _) <- loadedOthers
+                , name `Set.member` allowedNames
+                ]
     dedupeInstructionFiles (maybe [] pure preferredAgents <> other)
 
 isAgentsMdSpelling :: OsPath -> Bool
@@ -215,39 +240,53 @@ readRulesDirectory dir = do
         then pure []
         else do
             entries <- sort <$> listDirectory dir
-            markdown <- filterM
-                (doesFileExist . (dir </>))
-                [ name
-                | name <- entries
-                , Text.toLower (toText (takeExtension name)) == ".md"
-                ]
-            mapMaybe id <$> traverse (readAgentsFile . (dir </>)) markdown
+            let candidates =
+                    [ name
+                    | name <- entries
+                    , Text.toLower (toText (takeExtension name)) == ".md"
+                    ]
+            classified <-
+                mapConcurrentlyBounded instructionFileConcurrency
+                    (\name -> do
+                        exists <- doesFileExist (dir </> name)
+                        pure (name, exists))
+                    candidates
+            mapMaybe id
+                <$> mapConcurrentlyBounded instructionFileConcurrency
+                    (readAgentsFile . (dir </>))
+                    [name | (name, True) <- classified]
 
 -- | Case-insensitive filesystems can resolve several compatibility spellings
 -- to the same file. Symlinked rule files can do the same. Keep the first
 -- occurrence so order and precedence stay deterministic.
 dedupeInstructionFiles :: [InstructionFile] -> IO [InstructionFile]
-dedupeInstructionFiles files =
-    reverse . snd <$> foldM step (Set.empty, []) files
+dedupeInstructionFiles files = do
+    canonicals <-
+        mapConcurrentlyBounded instructionFileConcurrency canonical files
+    pure (reverse (snd (foldl step (Set.empty, []) (zip canonicals files))))
   where
+    canonical :: InstructionFile -> IO OsPath
+    canonical file =
+        tryAny (canonicalizePath file.instructionPath) >>= \case
+            Left _ -> pure file.instructionPath
+            Right path -> pure path
+
     step
         :: (Set.Set OsPath, [InstructionFile])
-        -> InstructionFile
-        -> IO (Set.Set OsPath, [InstructionFile])
-    step (seen, kept) file = do
-        canonical <-
-            tryAny (canonicalizePath file.instructionPath) >>= \case
-                Left _ -> pure file.instructionPath
-                Right path -> pure path
-        if Set.member canonical seen
-            then pure (seen, kept)
-            else pure (Set.insert canonical seen, file : kept)
+        -> (OsPath, InstructionFile)
+        -> (Set.Set OsPath, [InstructionFile])
+    step (seen, kept) (canonical, file)
+        | Set.member canonical seen = (seen, kept)
+        | otherwise = (Set.insert canonical seen, file : kept)
 
 findProjectRoot :: [OsPath] -> OsPath -> IO OsPath
 findProjectRoot markers start = go start
   where
     go dir = do
-        hit <- fmap or $ traverse (\marker -> doesPathExist (dir </> marker)) markers
+        hit <- fmap or $
+            mapConcurrentlyBounded instructionFileConcurrency
+                (\marker -> doesPathExist (dir </> marker))
+                markers
         if hit
             then pure dir
             else do
@@ -259,10 +298,10 @@ findProjectRoot markers start = go start
 -- | Prefer @AGENTS.override.md@ over @AGENTS.md@ in a directory.
 readPreferredAgentsMd :: OsPath -> IO (Maybe InstructionFile)
 readPreferredAgentsMd dir = do
-    override <- readAgentsFile (dir </> unsafeEncodeUtf "AGENTS.override.md")
-    case override of
-        Just file -> pure (Just file)
-        Nothing -> readAgentsFile (dir </> unsafeEncodeUtf "AGENTS.md")
+    (override, base) <- concurrently
+        (readAgentsFile (dir </> unsafeEncodeUtf "AGENTS.override.md"))
+        (readAgentsFile (dir </> unsafeEncodeUtf "AGENTS.md"))
+    pure (override <|> base)
 
 readAgentsFile :: OsPath -> IO (Maybe InstructionFile)
 readAgentsFile path = do
@@ -302,3 +341,9 @@ applyByteBudget maxBytes loaded =
                     let truncated = TextEncoding.decodeUtf8With TextEncodingError.ignore
                             (BS.take remaining encoded)
                     in [file { instructionContent = truncated }]
+
+instructionDirectoryConcurrency :: Int
+instructionDirectoryConcurrency = 8
+
+instructionFileConcurrency :: Int
+instructionFileConcurrency = 16

--- a/packages/agent-core/src/Agent/Skills.hs
+++ b/packages/agent-core/src/Agent/Skills.hs
@@ -19,11 +19,18 @@ module Agent.Skills
     , resolveSkillMentions
     ) where
 
+import Agent.Concurrent (mapConcurrentlyBounded)
 import Agent.FileRetry (retryOnFileBusy)
 import Agent.OsPath (directoryChain, toText, unsafeToFilePath)
 import Control.Applicative ((<|>))
+import Control.Concurrent.STM
+    ( atomically
+    , modifyTVar'
+    , newTVarIO
+    , readTVar
+    )
 import Control.Exception.Safe (displayException, tryAny)
-import Control.Monad (filterM, forM)
+import Control.Monad (filterM)
 import Data.Aeson
     ( FromJSON(..)
     , Object
@@ -38,7 +45,7 @@ import System.OsPath (OsPath, unsafeEncodeUtf)
 import Data.Aeson.Types (Parser)
 import qualified Data.ByteString as BS
 import Data.Char (isAlphaNum)
-import Data.List (find, sortOn)
+import Data.List (find, sort, sortOn)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe)
@@ -224,13 +231,18 @@ defaultSkillCatalogMaxChars = 8000
 discoverSkills :: SkillDiscoverOptions -> IO SkillCatalog
 discoverSkills options = do
     roots <- skillRoots options
-    results <- fmap concat $ forM roots \(scope, origin, root) -> do
-        exists <- doesDirectoryExist root
-        if exists
-            then do
-                files <- findSkillFiles options.skillsMaxDepth root
-                forM files (loadSkillFile scope origin)
-            else pure []
+    results <- fmap concat $
+        mapConcurrentlyBounded skillRootConcurrency
+            (\(scope, origin, root) -> do
+                exists <- doesDirectoryExist root
+                if exists
+                    then do
+                        files <- findSkillFiles options.skillsMaxDepth root
+                        mapConcurrentlyBounded skillFileConcurrency
+                            (loadSkillFile scope origin)
+                            files
+                    else pure [])
+            roots
     let skills = [skill | Right skill <- results]
         warnings = [warning | Left warning <- results]
     pure SkillCatalog
@@ -240,9 +252,14 @@ discoverSkills options = do
 
 skillRoots :: SkillDiscoverOptions -> IO [(SkillScope, SkillOrigin, FilePath)]
 skillRoots options = do
-    projectRoot <- canonicalizePath (unsafeToFilePath options.skillsProjectRoot)
-    cwd <- canonicalizePath (unsafeToFilePath options.skillsCwd)
-    home <- canonicalizePath (unsafeToFilePath options.skillsHome)
+    canonical <- mapConcurrentlyBounded 3 canonicalizePath
+        [ unsafeToFilePath options.skillsProjectRoot
+        , unsafeToFilePath options.skillsCwd
+        , unsafeToFilePath options.skillsHome
+        ]
+    let (projectRoot, cwd, home) = case canonical of
+            [project, current, userHome] -> (project, current, userHome)
+            _ -> error "skillRoots: canonical path count changed"
     let dirs =
             map unsafeToFilePath $
                 directoryChain (unsafeEncodeUtf projectRoot) (unsafeEncodeUtf cwd)
@@ -275,29 +292,60 @@ skillRoots options = do
         CodexSkills -> ".codex" </> "skills"
 
 findSkillFiles :: Int -> FilePath -> IO [FilePath]
-findSkillFiles maxDepth root = go Set.empty 0 root
+findSkillFiles maxDepth root = do
+    seen <- newTVarIO Set.empty
+    sort <$> go seen 0 [root]
   where
-    go seen depth dir
-        | depth > maxDepth = pure []
-        | otherwise = do
-            canonicalResult <- tryAny (canonicalizePath dir)
-            case canonicalResult of
-                Left _ -> pure []
-                Right canonical
-                    | canonical `Set.member` seen -> pure []
-                    | otherwise -> do
-                        entriesResult <- tryAny (listDirectory dir)
-                        case entriesResult of
-                            Left _ -> pure []
-                            Right entries -> do
-                                let skillPath = dir </> "SKILL.md"
-                                hasSkill <- doesFileExist skillPath
-                                children <-
-                                    filterM doesDirectoryExist
-                                        [dir </> entry | entry <- entries]
-                                nested <- fmap concat $
-                                    traverse (go (Set.insert canonical seen) (depth + 1)) children
-                                pure ([skillPath | hasSkill] <> nested)
+    go _ depth _ | depth > maxDepth = pure []
+    go _ _ [] = pure []
+    go seen depth dirs = do
+        let orderedDirs = sort dirs
+        canonicalized <-
+            mapConcurrentlyBounded skillDirectoryConcurrency
+                (\dir -> fmap ((,) dir) <$> tryAny (canonicalizePath dir))
+                orderedDirs
+        claimed <- atomically do
+            visited <- readTVar seen
+            let claim (current, selected) = \case
+                    Left _ -> (current, selected)
+                    Right (dir, canonical)
+                        | canonical `Set.member` current ->
+                            (current, selected)
+                        | otherwise ->
+                            (Set.insert canonical current, dir : selected)
+                (updated, selected) =
+                    foldl claim (visited, []) canonicalized
+            modifyTVar' seen (const updated)
+            pure (reverse selected)
+        inspected <-
+            mapConcurrentlyBounded skillDirectoryConcurrency
+                inspectDirectory
+                claimed
+        let found = concatMap fst inspected
+            children = concatMap snd inspected
+        nested <- go seen (depth + 1) children
+        pure (found <> nested)
+
+    inspectDirectory dir = do
+        entriesResult <- tryAny (listDirectory dir)
+        case entriesResult of
+            Left _ -> pure ([], [])
+            Right entries -> do
+                let skillPath = dir </> "SKILL.md"
+                hasSkill <- doesFileExist skillPath
+                children <-
+                    filterM doesDirectoryExist
+                        [dir </> entry | entry <- sort entries]
+                pure ([skillPath | hasSkill], children)
+
+skillRootConcurrency :: Int
+skillRootConcurrency = 4
+
+skillDirectoryConcurrency :: Int
+skillDirectoryConcurrency = 8
+
+skillFileConcurrency :: Int
+skillFileConcurrency = 8
 
 loadSkillFile
     :: SkillScope

--- a/packages/agent-core/src/Agent/Subagents/Registry.hs
+++ b/packages/agent-core/src/Agent/Subagents/Registry.hs
@@ -59,6 +59,10 @@ import Agent.Cancel
     , resetCancel
     , waitCancel
     )
+import Agent.Concurrent
+    ( forConcurrentlyBounded_
+    , mapConcurrentlyBounded
+    )
 import Agent.InterAgentMessage
     ( InterAgentMessage(..)
     , InterAgentMessageContent
@@ -97,7 +101,7 @@ import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Trans.Resource (runResourceT)
 import Data.Acquire (Acquire, allocateAcquire, mkAcquire, withAcquire)
 import Data.IORef
-import Data.List (sortOn)
+import Data.List (groupBy, sortOn)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Ord (Down(..))
@@ -294,8 +298,11 @@ closeSubagentRegistryLocked registry = do
     records <- atomically do
         writeTVar registry.registryClosed True
         Map.elems <$> readTVar registry.registryAgents
-    mapM_ (shutdownRecord registry) $
-        sortOn (Down . (.recordDepth)) records
+    mapM_
+        (forConcurrentlyBounded_ 8 (shutdownRecord registry))
+        (groupBy
+            (\left right -> left.recordDepth == right.recordDepth)
+            (sortOn (Down . (.recordDepth)) records))
 
 -- | Shut down live children and reopen the registry for a fresh session.
 resetSubagentRegistry :: SubagentRegistry -> IO ()
@@ -1141,7 +1148,9 @@ abortRootTurn registry rootTurnId =
             modifyTVar' registry.registryAbortedRootTurns (Set.insert rootTurnId)
             agents <- Map.elems <$> readTVar registry.registryAgents
             fmap concat $ mapM selectOwned agents
-        settled <- mapM (interruptRecordForTurn registry rootTurnId) records
+        settled <- mapConcurrentlyBounded 8
+            (interruptRecordForTurn registry rootTurnId)
+            records
         mapM_
             (\record -> notifySettled registry record.recordId Interrupted)
             [record | (record, True) <- zip records settled]
@@ -1215,7 +1224,9 @@ interruptActiveSubagents registry =
             records <- filterMSTM isActiveRecord agents
             pure (wasClosed, records)
         (do
-            settled <- mapM (interruptRecord registry) records
+            settled <- mapConcurrentlyBounded 8
+                (interruptRecord registry)
+                records
             mapM_
                 (\record -> notifySettled registry record.recordId Interrupted)
                 [record | (record, True) <- zip records settled])

--- a/packages/agent-core/src/Agent/Tools/FileSystem.hs
+++ b/packages/agent-core/src/Agent/Tools/FileSystem.hs
@@ -10,6 +10,7 @@ module Agent.Tools.FileSystem
     ) where
 
 import Agent.FileRetry (retryOnFileBusy)
+import Agent.Concurrent (mapConcurrentlyBounded)
 import Agent.OsPath (toText, unsafeToFilePath)
 import Agent.Tools.Types (ToolEnv(..))
 import Control.Exception.Safe (SomeException, try, tryIO)
@@ -63,11 +64,16 @@ resolveWithRoots
     -> [OsPath]
     -> IO (Either Text OsPath)
 resolveWithRoots env requested extraRoots = do
-    absCwd <- canonicalizePath env.toolCwd
     configuredRoots <- readIORef env.toolAllowedRoots
     sessionTmp <- readIORef env.toolSessionTmp
-    allowedRoots <- mapM canonicalizePath
-        (configuredRoots <> extraRoots <> maybe [] pure sessionTmp)
+    canonicalRoots <-
+        mapConcurrentlyBounded rootCanonicalizationConcurrency canonicalizePath
+            ( env.toolCwd
+            : configuredRoots <> extraRoots <> maybe [] pure sessionTmp
+            )
+    let (absCwd, allowedRoots) = case canonicalRoots of
+            root : roots -> (root, roots)
+            [] -> error "resolveWithRoots: cwd canonicalization omitted"
     let combined
             | isAbsolute requested = requested
             | otherwise = absCwd </> requested
@@ -148,8 +154,18 @@ renameTextFile from to = do
 listDirectoryEntries :: OsPath -> IO (Either Text [(OsPath, Bool)])
 listDirectoryEntries path = try @_ @SomeException (listDirectory path) >>= \case
     Left err -> pure $ Left $ "Failed to list directory: " <> Text.pack (show err)
-    Right names -> Right <$> mapM (classify path) names
+    Right names ->
+        Right
+            <$> mapConcurrentlyBounded directoryClassificationConcurrency
+                (classify path)
+                names
   where
     classify root name = do
         isDir <- doesDirectoryExist (root </> name)
         pure (name, isDir)
+
+rootCanonicalizationConcurrency :: Int
+rootCanonicalizationConcurrency = 8
+
+directoryClassificationConcurrency :: Int
+directoryClassificationConcurrency = 16

--- a/packages/agent-core/test/Agent/ConcurrentSpec.hs
+++ b/packages/agent-core/test/Agent/ConcurrentSpec.hs
@@ -1,0 +1,78 @@
+module Agent.ConcurrentSpec (spec) where
+
+import Agent.Concurrent
+import Control.Concurrent (threadDelay)
+import Control.Concurrent.Async (withAsync, waitCatch)
+import Control.Concurrent.MVar
+import Control.Exception.Safe (finally)
+import Data.Either (isLeft)
+import Data.IORef
+import Test.Hspec
+
+spec :: Spec
+spec = describe "bounded concurrency" do
+    it "preserves input order while overlapping work" do
+        results <-
+            mapConcurrentlyBounded 3
+                (\value -> do
+                    threadDelay ((4 - value) * 10000)
+                    pure (value * 2))
+                [1, 2, 3]
+        results `shouldBe` [2, 4, 6]
+
+    it "never exceeds the requested active worker count" do
+        active <- newIORef (0 :: Int)
+        peak <- newIORef (0 :: Int)
+        let run value =
+                bracketActive active peak do
+                    threadDelay 20000
+                    pure value
+        mapConcurrentlyBounded 3 run [1 .. 12 :: Int]
+            `shouldReturn` [1 .. 12]
+        readIORef peak `shouldReturn` 3
+
+    it "clamps a non-positive limit to one worker" do
+        active <- newIORef (0 :: Int)
+        peak <- newIORef (0 :: Int)
+        mapConcurrentlyBounded 0
+            (\value -> bracketActive active peak (pure value))
+            [1 .. 4 :: Int]
+            `shouldReturn` [1 .. 4]
+        readIORef peak `shouldReturn` 1
+
+    it "cancels and joins sibling workers when one fails" do
+        siblingStarted <- newEmptyMVar
+        siblingStopped <- newEmptyMVar
+        releaseSibling <- newEmptyMVar @()
+        let action :: Int -> IO ()
+            action = \case
+                (0 :: Int) ->
+                    (putMVar siblingStarted () >> takeMVar releaseSibling)
+                        `finally` putMVar siblingStopped ()
+                _ -> do
+                    takeMVar siblingStarted
+                    fail "worker failed"
+        withAsync (mapConcurrentlyBounded 2 action [0, 1]) \running -> do
+            waitCatch running `shouldReturnSatisfy` isLeft
+            tryTakeMVar siblingStopped `shouldReturn` Just ()
+
+    it "does not invoke the action for empty input" do
+        invoked <- newIORef False
+        mapConcurrentlyBounded 4
+            (\() -> writeIORef invoked True)
+            []
+            `shouldReturn` []
+        readIORef invoked `shouldReturn` False
+
+bracketActive :: IORef Int -> IORef Int -> IO a -> IO a
+bracketActive active peak action = do
+    current <- atomicModifyIORef' active \count ->
+        let next = count + 1
+        in (next, next)
+    atomicModifyIORef' peak \old -> (max old current, ())
+    action `finally`
+        atomicModifyIORef' active \count -> (count - 1, ())
+
+shouldReturnSatisfy :: Show a => IO a -> (a -> Bool) -> Expectation
+shouldReturnSatisfy action predicate =
+    action >>= (`shouldSatisfy` predicate)

--- a/packages/agent-core/test/Spec.hs
+++ b/packages/agent-core/test/Spec.hs
@@ -2,6 +2,7 @@ module Main (main) where
 
 import qualified Agent.Auth.JWTSpec as JWTSpec
 import qualified Agent.CancelSpec as CancelSpec
+import qualified Agent.ConcurrentSpec as ConcurrentSpec
 import qualified Agent.DialectSpec as DialectSpec
 import qualified Agent.ErrorSpec as ErrorSpec
 import qualified Agent.Http.HeaderSpec as HttpHeaderSpec
@@ -34,6 +35,7 @@ main :: IO ()
 main = hspec do
     JWTSpec.spec
     CancelSpec.spec
+    ConcurrentSpec.spec
     DialectSpec.spec
     ErrorSpec.spec
     HttpHeaderSpec.spec

--- a/packages/agent-grok-build-dialect/agent-grok-build-dialect.cabal
+++ b/packages/agent-grok-build-dialect/agent-grok-build-dialect.cabal
@@ -66,6 +66,24 @@ library
                     , transformers
                     , unix
 
+benchmark workflow-snapshots-bench
+    import:           common-opts
+    type:             exitcode-stdio-1.0
+    hs-source-dirs:   benchmark
+    main-is:          WorkflowSnapshots.hs
+    ghc-options:      -O2 -threaded -rtsopts "-with-rtsopts=-T"
+    build-depends:    agent-grok-build-dialect
+                    , agent-core
+                    , aeson
+                    , async
+                    , base >= 4.14 && < 5
+                    , containers
+                    , filepath
+                    , safe-exceptions
+                    , text
+                    , time
+                    , unix
+
 test-suite agent-grok-build-dialect-test
     import:           common-opts
     type:             exitcode-stdio-1.0
@@ -77,6 +95,7 @@ test-suite agent-grok-build-dialect-test
                     , Agent.GrokBuild.WebLspSpec
     build-depends:    agent-grok-build-dialect
                     , agent-core
+                    , async
                     , base >= 4.14 && < 5
                     , containers
                     , directory

--- a/packages/agent-grok-build-dialect/benchmark/WorkflowSnapshots.hs
+++ b/packages/agent-grok-build-dialect/benchmark/WorkflowSnapshots.hs
@@ -1,0 +1,101 @@
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Main (main) where
+
+import Agent.GrokBuild.Dialect.Workflow
+    ( workflowRunSnapshotsWith
+    , workflowTool
+    , newWorkflowRuntime
+    )
+import Agent.InterAgentMessage (interAgentMessagePayload)
+import Agent.Loop
+    ( LoopResult(..)
+    , defaultLoopDispatch
+    , emptyTokenUsage
+    )
+import Agent.Subagents
+    ( closeSubagentRegistry
+    , defaultSubagentConfig
+    , newSubagentRegistry
+    , SubagentId
+    , SubagentStatus(..)
+    )
+import Agent.Subagents.TaskPath (taskPathRoot)
+import Agent.ToolDispatch
+    ( dispatchToolCall
+    , functionToolCall
+    )
+import Agent.Tools.MultiAgents (MultiAgentContext(..))
+import Agent.Tools.Types (AppTool(..))
+import Control.Concurrent (newMVar, threadDelay, withMVar)
+import Control.Exception.Safe (bracket)
+import Control.Monad (forM_)
+import Data.IORef (newIORef)
+import qualified Data.Map.Strict as Map
+import qualified Data.Text as Text
+import Data.Time.Clock (diffUTCTime, getCurrentTime)
+import System.OsPath (unsafeEncodeUtf)
+import Text.Printf (printf)
+
+main :: IO ()
+main =
+    bracket newRegistry closeSubagentRegistry \registry -> do
+        specs <- newIORef Map.empty
+        runtime <- newWorkflowRuntime
+            (unsafeEncodeUtf "/tmp")
+            (rootContext registry)
+            specs
+        forM_ [1 .. 32 :: Int] \n -> do
+            _ <- dispatchToolCall
+                defaultLoopDispatch
+                [(workflowTool runtime).appToolHandler]
+                (functionToolCall (Text.pack ("call-" <> show n))
+                    "workflow"
+                    "{\"name\":\"deep-research\",\"args\":\"benchmark\"}")
+            pure ()
+        serialLock <- newMVar ()
+        measure "workflow-snapshots-serial" $
+            workflowRunSnapshotsWith
+                (\agentId ->
+                    withMVar serialLock \_ -> delayedStatus agentId)
+                runtime
+        measure "workflow-snapshots-bounded-8" $
+            workflowRunSnapshotsWith delayedStatus runtime
+  where
+    delayedStatus :: SubagentId -> IO SubagentStatus
+    delayedStatus _ = threadDelay 20_000 >> pure Running
+
+    measure :: String -> IO [a] -> IO ()
+    measure label action = do
+        started <- getCurrentTime
+        snapshots <- action
+        length snapshots `seq` pure ()
+        finished <- getCurrentTime
+        printf "%s,%.3f\n" label
+            (realToFrac (diffUTCTime finished started) * (1000 :: Double))
+
+    newRegistry =
+        newSubagentRegistry
+            defaultSubagentConfig
+            (unsafeEncodeUtf "/tmp")
+            (\_ _ prompt _ -> pure (Right LoopResult
+                { finalResponseId = "response"
+                , finalText = Just ("done:" <> interAgentMessagePayload prompt)
+                , turnsUsed = 1
+                , tokenUsage = emptyTokenUsage
+                }))
+            (\_ _ -> pure ())
+
+    rootContext registry = MultiAgentContext
+        registry
+        Nothing
+        0
+        taskPathRoot
+        (pure Nothing)
+        Nothing
+        Nothing
+        Nothing
+        Nothing
+        Nothing

--- a/packages/agent-grok-build-dialect/package.nix
+++ b/packages/agent-grok-build-dialect/package.nix
@@ -11,7 +11,11 @@ mkDerivation {
     safe-exceptions text time transformers unix
   ];
   testHaskellDepends = [
-    agent-core base containers directory filepath hspec safe-exceptions
+    agent-core async base containers directory filepath hspec
+    safe-exceptions text time unix
+  ];
+  benchmarkHaskellDepends = [
+    aeson agent-core async base containers filepath safe-exceptions
     text time unix
   ];
   description = "Grok Build model-facing dialect for the universal agent harness";

--- a/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Scheduler.hs
+++ b/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Scheduler.hs
@@ -21,6 +21,7 @@ module Agent.GrokBuild.Dialect.Scheduler
     ) where
 
 import Agent.GrokBuild.Dialect.Common (jsonTool)
+import Agent.Concurrent (mapConcurrentlyBounded)
 import Agent.InterAgentMessage
     ( InterAgentMessage(..)
     , InterAgentMessageType(QueuedMessage)
@@ -92,6 +93,9 @@ import System.OsPath (OsPath)
 
 maximumScheduledTasks :: Int
 maximumScheduledTasks = 50
+
+schedulerConcurrencyLimit :: Int
+schedulerConcurrencyLimit = 8
 
 recurringTaskTtlSeconds :: Integer
 recurringTaskTtlSeconds = 7 * 24 * 60 * 60
@@ -584,7 +588,15 @@ schedulerActor now fire isActive state signal = loop
         fires <- modifyMVar state \snapshot ->
             let (updated, due) = advanceScheduler current snapshot
             in pure (updated, due)
-        mapM_ runFire fires
+        fireResults <-
+            mapConcurrentlyBounded schedulerConcurrencyLimit runFire fires
+        modifyMVar_ state \snapshot ->
+            pure snapshot
+                { schedulerTasks =
+                    foldr publishFire
+                        snapshot.schedulerTasks
+                        fireResults
+                }
         currentAfterFire <- now
         snapshot <- readMVar state
         let delayMicros = nextDelayMicros currentAfterFire snapshot
@@ -595,37 +607,46 @@ schedulerActor now fire isActive state signal = loop
     runFire scheduled =
         tryAny (fire scheduled) >>= \case
             Right (Right agentId) ->
-                modifyMVar_ state \snapshot ->
-                    pure snapshot
-                        { schedulerTasks =
-                            Map.adjust
-                                (\task ->
-                                    task
-                                        { scheduledActiveAgent =
-                                            Just agentId
-                                        })
-                                scheduled.scheduledFireTaskId
-                                snapshot.schedulerTasks
-                        }
-            _ -> pure ()
+                pure (Just (scheduled.scheduledFireTaskId, agentId))
+            _ -> pure Nothing
+
+    publishFire Nothing tasks = tasks
+    publishFire (Just (taskId, agentId)) tasks =
+        Map.adjust
+            (\task ->
+                task
+                    { scheduledActiveAgent =
+                        Just agentId
+                    })
+            taskId
+            tasks
 
     refreshActiveAgents = do
         snapshot <- readMVar state
-        activity <-
-            Map.traverseWithKey
-                (\_ task ->
-                    case task.scheduledActiveAgent of
-                        Nothing -> pure False
-                        Just agentId -> isActive agentId)
-                snapshot.schedulerTasks
+        let active =
+                [ (taskId, agentId)
+                | (taskId, task) <- Map.toAscList snapshot.schedulerTasks
+                , Just agentId <- [task.scheduledActiveAgent]
+                ]
+        activity <- Map.fromAscList
+            <$> mapConcurrentlyBounded
+                schedulerConcurrencyLimit
+                (\(taskId, agentId) ->
+                    (\activeNow -> (taskId, activeNow))
+                        <$> isActive agentId)
+                active
         modifyMVar_ state \current ->
             pure current
                 { schedulerTasks =
                     Map.mapWithKey
                         (\taskId task ->
-                            if Map.findWithDefault False taskId activity
-                                then task
-                                else task { scheduledActiveAgent = Nothing })
+                            case task.scheduledActiveAgent of
+                                Nothing -> task
+                                Just _
+                                    | Map.findWithDefault False taskId activity ->
+                                        task
+                                    | otherwise ->
+                                        task { scheduledActiveAgent = Nothing })
                         current.schedulerTasks
                 }
 

--- a/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Workflow.hs
+++ b/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Workflow.hs
@@ -10,9 +10,11 @@ module Agent.GrokBuild.Dialect.Workflow
     , newWorkflowRuntime
     , workflowTool
     , workflowRunSnapshots
+    , workflowRunSnapshotsWith
     , formatWorkflowRuns
     ) where
 
+import Agent.Concurrent (mapConcurrentlyBounded)
 import Agent.GrokBuild.Dialect.Common (jsonTool)
 import Agent.GrokBuild.Dialect.Task
     ( GrokSubagentSpec(..)
@@ -77,6 +79,9 @@ data WorkflowRuntime = WorkflowRuntime
     , workflowSpecs :: !GrokSubagentSpecs
     , workflowStore :: !(MVar WorkflowStore)
     }
+
+workflowSnapshotConcurrencyLimit :: Int
+workflowSnapshotConcurrencyLimit = 8
 
 data WorkflowRunSnapshot = WorkflowRunSnapshot
     { workflowRunId :: !Text
@@ -330,9 +335,18 @@ launchWorkflow runtime workflowName objective = do
 workflowRunSnapshots
     :: WorkflowRuntime
     -> IO [WorkflowRunSnapshot]
-workflowRunSnapshots runtime = do
+workflowRunSnapshots runtime =
+    workflowRunSnapshotsWith
+        (getStatus runtime.workflowMulti.multiRegistry)
+        runtime
+
+workflowRunSnapshotsWith
+    :: (SubagentId -> IO SubagentStatus)
+    -> WorkflowRuntime
+    -> IO [WorkflowRunSnapshot]
+workflowRunSnapshotsWith readStatus runtime = do
     store <- readMVar runtime.workflowStore
-    mapM snapshotRun $
+    mapConcurrentlyBounded workflowSnapshotConcurrencyLimit snapshotRun $
         sortOn
             (\run ->
                 ( run.workflowStartedAt
@@ -343,9 +357,7 @@ workflowRunSnapshots runtime = do
     snapshotRun :: WorkflowRun -> IO WorkflowRunSnapshot
     snapshotRun run = do
         status <-
-            getStatus
-                runtime.workflowMulti.multiRegistry
-                run.workflowAgentId
+            readStatus run.workflowAgentId
         pure WorkflowRunSnapshot
             { workflowRunId = run.workflowInternalRunId
             , workflowRunName = run.workflowDisplayName

--- a/packages/agent-grok-build-dialect/test/Agent/GrokBuild/RuntimeSpec.hs
+++ b/packages/agent-grok-build-dialect/test/Agent/GrokBuild/RuntimeSpec.hs
@@ -19,6 +19,7 @@ import Agent.Loop
     )
 import Agent.Subagents
     ( SubagentId(..)
+    , SubagentStatus(..)
     , closeSubagentRegistry
     , defaultSubagentConfig
     , newSubagentRegistry
@@ -40,14 +41,20 @@ import Agent.Tools.Types
     , defaultToolEnv
     , jsonToolParameters
     )
-import Control.Concurrent (threadDelay)
+import Control.Concurrent
+    ( newChan
+    , readChan
+    , threadDelay
+    , writeChan
+    )
+import Control.Concurrent.Async (wait, withAsync)
 import Control.Concurrent.MVar
     ( newEmptyMVar
     , takeMVar
     , tryPutMVar
     )
 import Control.Exception.Safe (bracket)
-import Control.Monad (forM_)
+import Control.Monad (forM_, replicateM, replicateM_)
 import Data.IORef
     ( IORef
     , newIORef
@@ -196,6 +203,45 @@ spec = do
                     writeIORef active False
                     waitForCount fireCount 2
 
+        it "launches distinct due tasks concurrently with a bound of eight" do
+            clock <- newIORef fixedTime
+            started <- newChan
+            release <- newChan
+            bracket
+                (testScheduler
+                    (readIORef clock)
+                    (\fire -> do
+                        writeChan started fire.scheduledFireTaskId
+                        readChan release
+                        pure (Right testAgent)))
+                closeSchedulerRuntime
+                \runtime -> do
+                    forM_ [1 .. (9 :: Int)] \index -> do
+                        result <- call
+                            [schedulerCreateTool runtime]
+                            "scheduler_create"
+                            ("{\"interval\":\"60s\",\"prompt\":\"task "
+                                <> Text.pack (show index)
+                                <> "\"}")
+                        result.output `shouldSatisfy`
+                            Text.isInfixOf "\"updated\":false"
+                    writeIORef clock (addUTCTime 60 fixedTime)
+                    _ <- call
+                        [schedulerCreateTool runtime]
+                        "scheduler_create"
+                        "{\"interval\":\"1d\",\"prompt\":\"wake scheduler\"}"
+                    firstWave <-
+                        replicateM 8
+                            (timeout 1000000 (readChan started))
+                    firstWave `shouldSatisfy` all (/= Nothing)
+                    timeout 100000 (readChan started)
+                        `shouldReturn` Nothing
+                    writeChan release ()
+                    ninthStarted <-
+                        timeout 1000000 (readChan started)
+                    ninthStarted `shouldSatisfy` (/= Nothing)
+                    replicateM_ 8 (writeChan release ())
+
         it "enforces the 50-task limit and releases expired task slots" do
             nowRef <- newIORef fixedTime
             bracket
@@ -303,6 +349,46 @@ spec = do
                         ["deep-research", "deep-research-2"]
                 map (.workflowRunId) runs
                     `shouldMatchList` ["wf_1", "wf_2"]
+
+        it "probes workflow run statuses concurrently and preserves run order" do
+            withRegistry \registry -> do
+                specs <- newIORef Map.empty
+                runtime <-
+                    newWorkflowRuntime
+                        (unsafeEncodeUtf "/tmp")
+                        (rootContext registry)
+                        specs
+                forM_
+                    [ "first research"
+                    , "second research"
+                    ]
+                    \query -> do
+                        _ <- call
+                            [workflowTool runtime]
+                            "workflow"
+                            ("{\"name\":\"deep-research\",\"args\":{\"query\":\""
+                                <> query
+                                <> "\"}}")
+                        pure ()
+                started <- newChan
+                release <- newChan
+                let readStatus agentId = do
+                        writeChan started agentId
+                        readChan release
+                        pure Running
+                withAsync
+                    (workflowRunSnapshotsWith readStatus runtime)
+                    \snapshotsAsync -> do
+                        firstStarted <-
+                            timeout 1000000 (readChan started)
+                        secondStarted <-
+                            timeout 1000000 (readChan started)
+                        firstStarted `shouldSatisfy` (/= Nothing)
+                        secondStarted `shouldSatisfy` (/= Nothing)
+                        replicateM_ 2 (writeChan release ())
+                        snapshots <- wait snapshotsAsync
+                        map (.workflowRunId) snapshots
+                            `shouldBe` ["wf_1", "wf_2"]
 
         it "returns stable errors for unsupported workflow sources" do
             withRegistry \registry -> do

--- a/packages/agent-store/agent-store.cabal
+++ b/packages/agent-store/agent-store.cabal
@@ -37,6 +37,7 @@ library
     import:           common-opts
     exposed-modules:  Agent.Store.Types
                     , Agent.Store.SessionItem
+                    , Agent.Store.PoolCache
                     , Agent.Store.Postgres
                     , Agent.Store.Postgres.Config
                     , Agent.Store.Postgres.Connection
@@ -53,6 +54,7 @@ library
                     , Agent.Store.Postgres.SessionItem
     hs-source-dirs:   src
     build-depends:    base >= 4.14 && < 5
+                    , async
                     , bytestring
                     , containers
                     , contravariant
@@ -65,9 +67,22 @@ library
                     , pqi-ffi
                     , process
                     , safe-exceptions
+                    , stm
                     , text
                     , time
                     , unix
+
+benchmark pool-cache-bench
+    import:           common-opts
+    type:             exitcode-stdio-1.0
+    ghc-options:      -O2 -threaded
+    hs-source-dirs:   benchmark
+    main-is:          PoolCache.hs
+    build-depends:    agent-store
+                    , async
+                    , base >= 4.14 && < 5
+                    , containers
+                    , time
 
 test-suite agent-store-test
     import:           common-opts
@@ -78,10 +93,12 @@ test-suite agent-store-test
     other-modules:    Agent.Store.Postgres.ConfigSpec
                     , Agent.Store.Postgres.CustomSpec
                     , Agent.Store.Postgres.ManagedSpec
+                    , Agent.Store.PoolCacheSpec
                     , Agent.Store.Postgres.ScopeSpec
                     , Agent.Store.Postgres.SessionSpec
                     , Agent.Store.Postgres.SkillSpec
     build-depends:    agent-store
+                    , async
                     , base >= 4.14 && < 5
                     , bytestring
                     , hspec

--- a/packages/agent-store/benchmark/PoolCache.hs
+++ b/packages/agent-store/benchmark/PoolCache.hs
@@ -1,0 +1,110 @@
+{-# LANGUAGE NumericUnderscores #-}
+
+module Main (main) where
+
+import Agent.Store.PoolCache
+import Control.Concurrent (threadDelay)
+import Control.Concurrent.Async (mapConcurrently)
+import Control.Concurrent.MVar
+import qualified Control.Exception as Exception
+import Data.List (sort)
+import qualified Data.Map.Strict as Map
+import Data.Time.Clock
+import System.Environment (getArgs)
+import Text.Printf (printf)
+import Text.Read (readMaybe)
+
+data Sample = Sample
+    { elapsedMillis :: !Double
+    , openCount :: !Int
+    }
+
+main :: IO ()
+main =
+    getArgs >>= \case
+        [countArg, delayArg, samplesArg] -> do
+            count <- parsePositive "role count" countArg
+            delayMillis <- parsePositive "open delay milliseconds" delayArg
+            sampleCount <- parsePositive "sample count" samplesArg
+            benchmark "old-different" sampleCount
+                (oldDifferent count delayMillis)
+            benchmark "new-different" sampleCount
+                (newDifferent count delayMillis)
+            benchmark "new-same-role" sampleCount
+                (newSameRole count delayMillis)
+        _ ->
+            fail "usage: pool-cache-bench ROLE_COUNT DELAY_MS SAMPLE_COUNT"
+
+benchmark :: String -> Int -> IO Sample -> IO ()
+benchmark label sampleCount action = do
+    samples <- mapM (const action) [1 .. sampleCount]
+    let medianElapsed =
+            sort (map (.elapsedMillis) samples)
+                !! (sampleCount `div` 2)
+        medianOpens =
+            sort (map (.openCount) samples)
+                !! (sampleCount `div` 2)
+    printf "%s,%.3f,%d\n" label medianElapsed medianOpens
+
+oldDifferent :: Int -> Int -> IO Sample
+oldDifferent count delayMillis = do
+    state <- newMVar Map.empty
+    opens <- newMVar (0 :: Int)
+    measure opens $
+        mapConcurrently
+            (\key ->
+                modifyMVar state \entries ->
+                    case Map.lookup key entries of
+                        Just resource -> pure (entries, resource)
+                        Nothing -> do
+                            recordOpen opens delayMillis
+                            pure (Map.insert key key entries, key))
+            [1 .. count]
+
+newDifferent :: Int -> Int -> IO Sample
+newDifferent count delayMillis = do
+    opens <- newMVar (0 :: Int)
+    cache <- benchmarkCache opens delayMillis
+    measure opens $
+        mapConcurrently (acquirePoolCache cache) [1 .. count]
+
+newSameRole :: Int -> Int -> IO Sample
+newSameRole count delayMillis = do
+    opens <- newMVar (0 :: Int)
+    cache <- benchmarkCache opens delayMillis
+    measure opens $
+        mapConcurrently
+            (const (acquirePoolCache cache (1 :: Int)))
+            [1 .. count]
+
+benchmarkCache :: MVar Int -> Int -> IO (PoolCache Int String Int)
+benchmarkCache opens delayMillis =
+    newPoolCache
+        8
+        "closed"
+        Exception.displayException
+        (\key -> recordOpen opens delayMillis >> pure (Right key))
+        (const (pure ()))
+
+recordOpen :: MVar Int -> Int -> IO ()
+recordOpen opens delayMillis = do
+    modifyMVar_ opens (pure . (+ 1))
+    threadDelay (delayMillis * 1_000)
+
+measure :: MVar Int -> IO a -> IO Sample
+measure opens action = do
+    started <- getCurrentTime
+    _ <- action
+    finished <- getCurrentTime
+    count <- readMVar opens
+    pure Sample
+        { elapsedMillis =
+            realToFrac (diffUTCTime finished started) * 1_000
+        , openCount = count
+        }
+
+parsePositive :: String -> String -> IO Int
+parsePositive label raw =
+    case readMaybe raw of
+        Just value | value > 0 -> pure value
+        _ -> fail ("invalid " <> label <> ": " <> raw)

--- a/packages/agent-store/package.nix
+++ b/packages/agent-store/package.nix
@@ -1,20 +1,22 @@
-{ mkDerivation, base, bytestring, containers, contravariant
+{ mkDerivation, async, base, bytestring, containers, contravariant
 , directory, filelock, filepath, hasql, hasql-pool
 , hasql-transaction, hspec, lib, pqi-ffi, process, safe-exceptions
-, temporary, text, time, unix
+, stm, temporary, text, time, unix
 }:
 mkDerivation {
   pname = "agent-store";
   version = "0.1.0.0";
   src = ./.;
   libraryHaskellDepends = [
-    base bytestring containers contravariant directory filelock
+    async base bytestring containers contravariant directory filelock
     filepath hasql hasql-pool hasql-transaction pqi-ffi process
-    safe-exceptions text time unix
+    safe-exceptions stm text time unix
   ];
   testHaskellDepends = [
-    base bytestring hasql hspec safe-exceptions temporary text time
+    async base bytestring hasql hspec safe-exceptions temporary text
+    time
   ];
+  benchmarkHaskellDepends = [ async base containers time ];
   description = "PostgreSQL persistence for the agent harness";
   license = lib.meta.getLicenseFromSpdxId "MIT";
 }

--- a/packages/agent-store/src/Agent/Store/PoolCache.hs
+++ b/packages/agent-store/src/Agent/Store/PoolCache.hs
@@ -1,0 +1,264 @@
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE RankNTypes #-}
+
+-- | A lifecycle-safe, per-key single-flight cache for owned resources.
+module Agent.Store.PoolCache
+    ( PoolCache
+    , newPoolCache
+    , acquirePoolCache
+    , closePoolCache
+    ) where
+
+import Control.Concurrent.Async (replicateConcurrently_)
+import Control.Concurrent.MVar
+import Control.Concurrent.STM
+import qualified Control.Exception as Exception
+import Control.Monad (forM_, replicateM_, void)
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+
+data PoolCache key err resource = PoolCache
+    { cacheState :: !(MVar (PoolCacheState key err resource))
+    , cacheOpen :: !(key -> IO (Either err resource))
+    , cacheClose :: !(resource -> IO ())
+    , cacheClosedError :: !err
+    , cacheExceptionError :: !(Exception.SomeException -> err)
+    , cacheCloseConcurrency :: !Int
+    }
+
+data PoolCacheState key err resource
+    = CacheOpen !(Map key (PoolCacheEntry err resource))
+    | CacheClosing !(TMVar (Either Exception.SomeException ()))
+    | CacheClosed !(Either Exception.SomeException ())
+
+data PoolCacheEntry err resource
+    = PoolReady !resource
+    | PoolOpening !(TMVar (Either err resource))
+
+data AcquireDecision err resource
+    = AcquireReady !(Either err resource)
+    | AcquireWait !(TMVar (Either err resource))
+    | AcquireLead !(TMVar (Either err resource))
+
+data CloseDecision err resource
+    = CloseComplete !(Either Exception.SomeException ())
+    | CloseWait !(TMVar (Either Exception.SomeException ()))
+    | CloseLead
+        !(TMVar (Either Exception.SomeException ()))
+        ![resource]
+        ![TMVar (Either err resource)]
+
+newPoolCache
+    :: Int
+    -> err
+    -> (Exception.SomeException -> err)
+    -> (key -> IO (Either err resource))
+    -> (resource -> IO ())
+    -> IO (PoolCache key err resource)
+newPoolCache closeConcurrency closedError exceptionError open close = do
+    state <- newMVar (CacheOpen Map.empty)
+    pure PoolCache
+        { cacheState = state
+        , cacheOpen = open
+        , cacheClose = close
+        , cacheClosedError = closedError
+        , cacheExceptionError = exceptionError
+        , cacheCloseConcurrency = max 1 closeConcurrency
+        }
+
+acquirePoolCache
+    :: Ord key
+    => PoolCache key err resource
+    -> key
+    -> IO (Either err resource)
+acquirePoolCache cache key =
+    Exception.mask \restore -> do
+        decision <- modifyMVar cache.cacheState \case
+            state@CacheClosing{} ->
+                pure (state, AcquireReady (Left cache.cacheClosedError))
+            state@CacheClosed{} ->
+                pure (state, AcquireReady (Left cache.cacheClosedError))
+            CacheOpen entries ->
+                case Map.lookup key entries of
+                    Just (PoolReady resource) ->
+                        pure
+                            ( CacheOpen entries
+                            , AcquireReady (Right resource)
+                            )
+                    Just (PoolOpening completion) ->
+                        pure (CacheOpen entries, AcquireWait completion)
+                    Nothing -> do
+                        completion <- newEmptyTMVarIO
+                        pure
+                            ( CacheOpen
+                                (Map.insert key
+                                    (PoolOpening completion)
+                                    entries)
+                            , AcquireLead completion
+                            )
+        case decision of
+            AcquireReady result -> pure result
+            AcquireWait completion ->
+                restore (atomically (readTMVar completion))
+            AcquireLead completion -> do
+                opened <-
+                    tryAnyException
+                        (restore (cache.cacheOpen key))
+                case opened of
+                    Left exception -> do
+                        abandonOpening cache key completion
+                            (Left (cache.cacheExceptionError exception))
+                        Exception.throwIO exception
+                    Right (Left err) -> do
+                        abandonOpening cache key completion (Left err)
+                        pure (Left err)
+                    Right (Right resource) ->
+                        publishResource cache key completion resource restore
+
+abandonOpening
+    :: Ord key
+    => PoolCache key err resource
+    -> key
+    -> TMVar (Either err resource)
+    -> Either err resource
+    -> IO ()
+abandonOpening cache key completion result = do
+    modifyMVar_ cache.cacheState \case
+        CacheOpen entries ->
+            pure (CacheOpen (Map.delete key entries))
+        state -> pure state
+    atomically $ void (tryPutTMVar completion result)
+
+publishResource
+    :: Ord key
+    => PoolCache key err resource
+    -> key
+    -> TMVar (Either err resource)
+    -> resource
+    -> (forall a. IO a -> IO a)
+    -> IO (Either err resource)
+publishResource cache key completion resource restore = do
+    accepted <- modifyMVar cache.cacheState \case
+        CacheOpen entries ->
+            case Map.lookup key entries of
+                Just PoolOpening{} -> do
+                    -- Publish the result before releasing the cache-state
+                    -- lock. Shutdown can therefore linearize only before
+                    -- this acquisition (and reject it) or after it.
+                    atomically $
+                        void (tryPutTMVar completion (Right resource))
+                    pure
+                        ( CacheOpen
+                            (Map.insert key (PoolReady resource) entries)
+                        , True
+                        )
+                _ -> pure (CacheOpen entries, False)
+        state -> pure (state, False)
+    if accepted
+        then pure (Right resource)
+        else do
+            closed <-
+                tryAnyException
+                    (restore (cache.cacheClose resource))
+            let result = Left cache.cacheClosedError
+            atomically $ void (tryPutTMVar completion result)
+            case closed of
+                Left exception -> Exception.throwIO exception
+                Right () -> pure result
+
+closePoolCache :: PoolCache key err resource -> IO ()
+closePoolCache cache =
+    Exception.mask \restore -> do
+        decision <- modifyMVar cache.cacheState \case
+            state@(CacheClosed outcome) ->
+                pure (state, CloseComplete outcome)
+            state@(CacheClosing completion) ->
+                pure (state, CloseWait completion)
+            CacheOpen entries -> do
+                completion <- newEmptyTMVarIO
+                let ready =
+                        [ resource
+                        | PoolReady resource <- Map.elems entries
+                        ]
+                    opening =
+                        [ pending
+                        | PoolOpening pending <- Map.elems entries
+                        ]
+                pure
+                    ( CacheClosing completion
+                    , CloseLead completion ready opening
+                    )
+        case decision of
+            CloseComplete outcome -> replayClose outcome
+            CloseWait completion ->
+                restore (atomically (readTMVar completion))
+                    >>= replayClose
+            CloseLead completion ready opening -> do
+                outcome <-
+                    tryAnyException (restore (closeOwned cache ready opening))
+                modifyMVar_ cache.cacheState \_ ->
+                    pure (CacheClosed outcome)
+                atomically $ void (tryPutTMVar completion outcome)
+                replayClose outcome
+
+closeOwned
+    :: PoolCache key err resource
+    -> [resource]
+    -> [TMVar (Either err resource)]
+    -> IO ()
+closeOwned cache ready opening = do
+    outcomes <- mapConcurrentlyBounded
+        cache.cacheCloseConcurrency
+        run
+        (map CloseResource ready <> map WaitOpening opening)
+    case [exception | Left exception <- outcomes] of
+        exception : _ -> Exception.throwIO exception
+        [] -> pure ()
+  where
+    run = \case
+        CloseResource resource ->
+            tryAnyException (cache.cacheClose resource)
+        WaitOpening completion -> do
+            _ <- atomically (readTMVar completion)
+            pure (Right ())
+
+data CloseAction err resource
+    = CloseResource !resource
+    | WaitOpening !(TMVar (Either err resource))
+
+replayClose :: Either Exception.SomeException () -> IO ()
+replayClose = either Exception.throwIO pure
+
+tryAnyException
+    :: IO a
+    -> IO (Either Exception.SomeException a)
+tryAnyException = Exception.try
+
+mapConcurrentlyBounded
+    :: Int
+    -> (a -> IO b)
+    -> [a]
+    -> IO [b]
+mapConcurrentlyBounded _ _ [] = pure []
+mapConcurrentlyBounded limit action values = do
+    let workerCount = min (max 1 limit) (length values)
+    queue <- newTQueueIO
+    results <- newTVarIO Map.empty
+    atomically do
+        forM_ (zip [0 :: Int ..] values) $
+            writeTQueue queue . Just
+        replicateM_ workerCount (writeTQueue queue Nothing)
+    let worker =
+            atomically (readTQueue queue) >>= \case
+                Nothing -> pure ()
+                Just (index, value) -> do
+                    result <- action value
+                    atomically $
+                        modifyTVar' results (Map.insert index result)
+                    worker
+    replicateConcurrently_ workerCount worker
+    completed <- readTVarIO results
+    pure
+        [ completed Map.! index
+        | index <- [0 .. length values - 1]
+        ]

--- a/packages/agent-store/src/Agent/Store/Postgres.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres.hs
@@ -17,10 +17,13 @@ module Agent.Store.Postgres
     ) where
 
 import Control.Concurrent.MVar
+import Control.Concurrent.Async (mapConcurrently)
+import Control.Concurrent.STM
+import qualified Control.Exception as Exception
 import Control.Exception.Safe (bracket, mask, onException)
-import Data.Map.Strict (Map)
-import qualified Data.Map.Strict as Map
+import Control.Monad (void)
 import Data.Text (Text)
+import qualified Data.Text as Text
 import Data.Time.Clock
     ( UTCTime(..)
     , diffTimeToPicoseconds
@@ -31,14 +34,21 @@ import Agent.Store.Postgres.Config
 import Agent.Store.Postgres.Connection
 import Agent.Store.Postgres.Managed
 import Agent.Store.Postgres.Migrations
+import Agent.Store.PoolCache
 import Agent.Store.Types
 
 data Store = Store
     { storeConfigInternal :: !ManagedPostgresConfig
     , provisioningPoolInternal :: !StorePool
     , trustedPoolInternal :: !StorePool
-    , scopePoolsInternal :: !(MVar (Map Text StorePool))
+    , scopePoolsInternal :: !(PoolCache Text StoreError StorePool)
+    , storeCloseInternal :: !(MVar StoreCloseState)
     }
+
+data StoreCloseState
+    = StoreOpen
+    | StoreClosing !(TMVar (Either Exception.SomeException ()))
+    | StoreClosed !(Either Exception.SomeException ())
 
 openStore :: ManagedPostgresConfig -> IO (Either StoreError Store)
 openStore config = mask \restore ->
@@ -67,22 +77,54 @@ openStore config = mask \restore ->
                                         closeStorePool ownerPool
                                         pure (Left err)
                                     Right runtimePool -> do
-                                        pools <- newMVar Map.empty
+                                        pools <- newPoolCache
+                                            8
+                                            storeClosedError
+                                            storeExceptionError
+                                            (\role ->
+                                                openRoleStorePool
+                                                    config
+                                                    role
+                                                    (defaultPoolConfig
+                                                        { poolSize = 2
+                                                        }))
+                                            closeStorePool
+                                        closeState <- newMVar StoreOpen
                                         pure $ Right Store
                                             { storeConfigInternal = config
                                             , provisioningPoolInternal =
                                                 ownerPool
                                             , trustedPoolInternal = runtimePool
                                             , scopePoolsInternal = pools
+                                            , storeCloseInternal = closeState
                                             }
 
 closeStore :: Store -> IO ()
-closeStore store = do
-    pools <- takeMVar store.scopePoolsInternal
-    mapM_ closeStorePool (Map.elems pools)
-    putMVar store.scopePoolsInternal Map.empty
-    closeStorePool store.trustedPoolInternal
-    closeStorePool store.provisioningPoolInternal
+closeStore store =
+    Exception.mask \restore -> do
+        decision <- modifyMVar store.storeCloseInternal \case
+            state@(StoreClosed outcome) ->
+                pure (state, Left outcome)
+            state@(StoreClosing completion) ->
+                pure (state, Right (Left completion))
+            StoreOpen -> do
+                completion <- newEmptyTMVarIO
+                pure
+                    ( StoreClosing completion
+                    , Right (Right completion)
+                    )
+        case decision of
+            Left outcome -> replayStoreClose outcome
+            Right (Left completion) ->
+                restore (atomically (readTMVar completion))
+                    >>= replayStoreClose
+            Right (Right completion) -> do
+                outcome <-
+                    tryAnyException (restore (closeAllStorePools store))
+                modifyMVar_ store.storeCloseInternal \_ ->
+                    pure (StoreClosed outcome)
+                atomically $ void (tryPutTMVar completion outcome)
+                replayStoreClose outcome
 
 -- | Open a store for the duration of an action and always release every pool.
 withStore
@@ -111,15 +153,37 @@ trustedPool = (.trustedPoolInternal)
 
 scopePool :: Store -> Text -> IO (Either StoreError StorePool)
 scopePool store role =
-    modifyMVar store.scopePoolsInternal \pools ->
-        case Map.lookup role pools of
-            Just pool -> pure (pools, Right pool)
-            Nothing -> do
-                let options = defaultPoolConfig { poolSize = 2 }
-                openRoleStorePool store.storeConfigInternal role options >>= \case
-                    Left err -> pure (pools, Left err)
-                    Right pool ->
-                        pure (Map.insert role pool pools, Right pool)
+    acquirePoolCache store.scopePoolsInternal role
+
+closeAllStorePools :: Store -> IO ()
+closeAllStorePools store = do
+    outcomes <- mapConcurrently
+        tryAnyException
+        [ closePoolCache store.scopePoolsInternal
+        , closeStorePool store.trustedPoolInternal
+        , closeStorePool store.provisioningPoolInternal
+        ]
+    case [exception | Left exception <- outcomes] of
+        exception : _ -> Exception.throwIO exception
+        [] -> pure ()
+
+replayStoreClose :: Either Exception.SomeException () -> IO ()
+replayStoreClose = either Exception.throwIO pure
+
+tryAnyException
+    :: IO a
+    -> IO (Either Exception.SomeException a)
+tryAnyException = Exception.try
+
+storeClosedError :: StoreError
+storeClosedError =
+    StoreConnectionError "PostgreSQL store is closed"
+
+storeExceptionError :: Exception.SomeException -> StoreError
+storeExceptionError exception =
+    StoreConnectionError
+        ("PostgreSQL scope pool initialization failed: "
+            <> Text.pack (Exception.displayException exception))
 
 -- | Match PostgreSQL's @timestamptz@ microsecond precision before retaining
 -- timestamps in application state.

--- a/packages/agent-store/src/Agent/Store/Postgres/Session.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Session.hs
@@ -24,6 +24,7 @@ module Agent.Store.Postgres.Session
     , replaceSessionMetadata
     , appendSessionTurn
     , loadSession
+    , loadSessions
     , loadSessionEvents
     , listSessionMetadata
     , searchConversationTurns
@@ -36,6 +37,7 @@ import Control.Monad (forM, forM_, unless)
 import Data.ByteString (ByteString)
 import Data.Functor.Contravariant ((>$<))
 import Data.Int (Int32, Int64)
+import qualified Data.Map.Strict as Map
 import Data.Text (Text)
 import Data.Time.Clock (UTCTime)
 import qualified Hasql.Decoders as Decoders
@@ -371,21 +373,60 @@ loadSession
     -> Text
     -> IO (Either StoreError (Maybe StoredSession))
 loadSession pool sessionKey =
+    loadSessions pool [sessionKey] >>= \case
+        [result] -> pure result
+        _ -> pure (Left (StoreDataError "batched session load returned no result"))
+
+-- | Load sessions in the same order as the requested keys.
+--
+-- Metadata and turn projections are fetched in two set-based statements under
+-- one repeatable-read snapshot. Missing keys remain as 'Nothing', and duplicate
+-- keys produce duplicate results without repeating the database reads.
+loadSessions
+    :: StorePool
+    -> [Text]
+    -> IO [Either StoreError (Maybe StoredSession)]
+loadSessions _ [] = pure []
+loadSessions pool sessionKeys =
     withSession pool
         (Transactions.transaction Transactions.RepeatableRead Transactions.Read do
-            metadata <- Transaction.statement sessionKey loadMetadataStatement
-            case metadata of
-                Nothing -> pure (Right Nothing)
-                Just value -> do
-                    rows <- Transaction.statement sessionKey loadTurnsStatement
-                    turns <- forM rows loadStoredTurn
-                    pure do
-                        decodedTurns <- sequence turns
-                        pure $ Just StoredSession
-                            { storedMetadata = value
-                            , storedTurns = decodedTurns
-                            })
-        >>= flattenDataResult
+            metadata <- Transaction.statement
+                sessionKeys
+                loadMetadataManyStatement
+            rows <- Transaction.statement sessionKeys loadTurnsManyStatement
+            turns <- forM rows \(sessionKey, row) ->
+                fmap ((,) sessionKey) (loadStoredTurn row)
+            pure (assembleSessions sessionKeys metadata turns))
+        >>= \case
+            Left err -> pure (replicate (length sessionKeys) (Left err))
+            Right results ->
+                pure (map (either (Left . StoreDataError) Right) results)
+
+assembleSessions
+    :: [Text]
+    -> [SessionMetadata]
+    -> [(Text, Either Text StoredTurn)]
+    -> [Either Text (Maybe StoredSession)]
+assembleSessions sessionKeys metadata turns =
+    map assemble sessionKeys
+  where
+    metadataByKey =
+        Map.fromList
+            [(value.sessionMetadataKey, value) | value <- metadata]
+    turnsByKey =
+        Map.fromListWith (flip (++))
+            [(sessionKey, [turn]) | (sessionKey, turn) <- turns]
+
+    assemble sessionKey =
+        case Map.lookup sessionKey metadataByKey of
+            Nothing -> Right Nothing
+            Just value -> do
+                decodedTurns <-
+                    sequence (Map.findWithDefault [] sessionKey turnsByKey)
+                pure $ Just StoredSession
+                    { storedMetadata = value
+                    , storedTurns = decodedTurns
+                    }
 
 loadSessionEvents
     :: StorePool
@@ -596,14 +637,6 @@ decodeUsage input output cached =
                 }
         _ -> Left "stored session turn has partial usage counters"
 
-flattenDataResult
-    :: Either StoreError (Either Text a)
-    -> IO (Either StoreError a)
-flattenDataResult = pure . \case
-    Left err -> Left err
-    Right (Left err) -> Left (StoreDataError err)
-    Right (Right value) -> Right value
-
 sessionExistsStatement :: Statement Text Bool
 sessionExistsStatement = mkStatement
     "SELECT EXISTS (SELECT 1 FROM harness.sessions WHERE session_key = $1)"
@@ -731,12 +764,13 @@ insertTurnStatement = mkStatement
     turnResponseId :: TurnInsert -> Maybe Text
     turnResponseId value = value.turnInsertTurn.sessionTurnResponseId
 
-loadMetadataStatement :: Statement Text (Maybe SessionMetadata)
-loadMetadataStatement = mkStatement
+loadMetadataManyStatement :: Statement [Text] [SessionMetadata]
+loadMetadataManyStatement = mkStatement
     (metadataSelectSql
-        <> " WHERE session_key = $1 AND deleted_at IS NULL")
-    (Encoders.param (Encoders.nonNullable Encoders.text))
-    (Decoders.rowMaybe metadataRow)
+        <> " WHERE session_key = ANY($1::text[]) AND deleted_at IS NULL\
+           \ ORDER BY array_position($1::text[], session_key)")
+    textArrayParams
+    (Decoders.rowList metadataRow)
     True
 
 listMetadataStatement :: Statement () [SessionMetadata]
@@ -758,30 +792,43 @@ metadataSelectSql =
     \ title_user_turns, last_response_id, input_tokens, output_tokens,\
     \ cached_tokens FROM harness.sessions"
 
-loadTurnsStatement :: Statement Text [TurnRow]
-loadTurnsStatement = mkStatement
-    "SELECT t.turn_id::text, t.turn_index, t.event_sequence, t.occurred_at,\
+loadTurnsManyStatement :: Statement [Text] [(Text, TurnRow)]
+loadTurnsManyStatement = mkStatement
+    "SELECT s.session_key, t.turn_id::text, t.turn_index, t.event_sequence,\
+    \ t.occurred_at,\
     \ t.user_text, t.assistant_text, t.error_text, t.response_id,\
     \ t.usage_input_tokens, t.usage_output_tokens, t.usage_cached_tokens\
     \ FROM harness.session_turns t\
     \ JOIN harness.sessions s ON s.session_id = t.session_id\
-    \ WHERE s.session_key = $1\
-    \ ORDER BY t.turn_index ASC"
-    (Encoders.param (Encoders.nonNullable Encoders.text))
+    \ WHERE s.session_key = ANY($1::text[]) AND s.deleted_at IS NULL\
+    \ ORDER BY array_position($1::text[], s.session_key), t.turn_index ASC"
+    textArrayParams
     (Decoders.rowList $
-        TurnRow
+        (,)
             <$> Decoders.column (Decoders.nonNullable Decoders.text)
-            <*> Decoders.column (Decoders.nonNullable Decoders.int8)
-            <*> Decoders.column (Decoders.nonNullable Decoders.int8)
-            <*> Decoders.column (Decoders.nonNullable Decoders.timestamptz)
-            <*> Decoders.column (Decoders.nonNullable Decoders.text)
-            <*> Decoders.column (Decoders.nullable Decoders.text)
-            <*> Decoders.column (Decoders.nullable Decoders.text)
-            <*> Decoders.column (Decoders.nullable Decoders.text)
-            <*> Decoders.column (Decoders.nullable Decoders.int8)
-            <*> Decoders.column (Decoders.nullable Decoders.int8)
-            <*> Decoders.column (Decoders.nullable Decoders.int8))
+            <*> turnRowDecoder)
     True
+
+turnRowDecoder :: Decoders.Row TurnRow
+turnRowDecoder =
+    TurnRow
+        <$> Decoders.column (Decoders.nonNullable Decoders.text)
+        <*> Decoders.column (Decoders.nonNullable Decoders.int8)
+        <*> Decoders.column (Decoders.nonNullable Decoders.int8)
+        <*> Decoders.column (Decoders.nonNullable Decoders.timestamptz)
+        <*> Decoders.column (Decoders.nonNullable Decoders.text)
+        <*> Decoders.column (Decoders.nullable Decoders.text)
+        <*> Decoders.column (Decoders.nullable Decoders.text)
+        <*> Decoders.column (Decoders.nullable Decoders.text)
+        <*> Decoders.column (Decoders.nullable Decoders.int8)
+        <*> Decoders.column (Decoders.nullable Decoders.int8)
+        <*> Decoders.column (Decoders.nullable Decoders.int8)
+
+textArrayParams :: Encoders.Params [Text]
+textArrayParams =
+    Encoders.param $
+        Encoders.nonNullable $
+            Encoders.foldableArray (Encoders.nonNullable Encoders.text)
 
 loadEventsStatement :: Statement Text [StoredEvent]
 loadEventsStatement = mkStatement

--- a/packages/agent-store/test/Agent/Store/PoolCacheSpec.hs
+++ b/packages/agent-store/test/Agent/Store/PoolCacheSpec.hs
@@ -1,0 +1,166 @@
+{-# LANGUAGE NumericUnderscores #-}
+
+module Agent.Store.PoolCacheSpec (spec) where
+
+import Agent.Store.PoolCache
+import Control.Concurrent (threadDelay)
+import Control.Concurrent.Async
+    ( cancel
+    , wait
+    , waitCatch
+    , withAsync
+    )
+import Control.Concurrent.Chan
+import Control.Concurrent.MVar
+import qualified Control.Exception as Exception
+import Data.IORef
+import Data.List (sort)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import System.Timeout (timeout)
+import Test.Hspec
+
+spec :: Spec
+spec = describe "PoolCache" do
+    it "single-flights callers for the same key" do
+        calls <- newIORef (0 :: Int)
+        started <- newEmptyMVar
+        release <- newEmptyMVar
+        cache <- newPoolCache
+            4
+            ("closed" :: Text)
+            exceptionText
+            (\(_ :: Text) -> do
+                atomicModifyIORef' calls (\count -> (count + 1, ()))
+                putMVar started ()
+                takeMVar release
+                pure (Right (1 :: Int)))
+            (const (pure ()))
+        withAsync (acquirePoolCache cache "role") \first -> do
+            takeMVar started
+            withAsync (acquirePoolCache cache "role") \second -> do
+                threadDelay 20_000
+                readIORef calls `shouldReturn` 1
+                putMVar release ()
+                wait first `shouldReturn` Right 1
+                wait second `shouldReturn` Right 1
+
+    it "opens different keys concurrently" do
+        started <- newChan
+        release <- newEmptyMVar
+        cache <- newPoolCache
+            4
+            ("closed" :: Text)
+            exceptionText
+            (\key -> do
+                writeChan started key
+                readMVar release
+                pure (Right key))
+            (const (pure ()))
+        withAsync (acquirePoolCache cache ("one" :: Text)) \first ->
+            withAsync (acquirePoolCache cache "two") \second -> do
+                observed <- timeout 250_000 do
+                    left <- readChan started
+                    right <- readChan started
+                    pure [left, right]
+                fmap (all (`elem` ["one", "two"])) observed
+                    `shouldBe` Just True
+                putMVar release ()
+                wait first `shouldReturn` Right "one"
+                wait second `shouldReturn` Right "two"
+
+    it "removes a failed entry so a later caller can retry" do
+        calls <- newIORef (0 :: Int)
+        cache <- newPoolCache
+            2
+            ("closed" :: Text)
+            exceptionText
+            (\(_ :: Text) -> do
+                attempt <- atomicModifyIORef' calls
+                    (\count -> (count + 1, count + 1))
+                pure if attempt == 1
+                    then Left "failed"
+                    else Right (7 :: Int))
+            (const (pure ()))
+        acquirePoolCache cache "role" `shouldReturn` Left "failed"
+        acquirePoolCache cache "role" `shouldReturn` Right 7
+        readIORef calls `shouldReturn` 2
+
+    it "wakes same-key waiters when the opening leader is cancelled" do
+        started <- newEmptyMVar
+        blocked <- newEmptyMVar
+        cache <- newPoolCache
+            2
+            ("closed" :: Text)
+            (const "interrupted")
+            (\(_ :: Text) -> do
+                putMVar started ()
+                takeMVar blocked
+                pure (Right (1 :: Int)))
+            (const (pure ()))
+        withAsync (acquirePoolCache cache "role") \leader -> do
+            takeMVar started
+            withAsync (acquirePoolCache cache "role") \waiter -> do
+                threadDelay 20_000
+                cancel leader
+                _ <- waitCatch leader
+                timeout 250_000 (wait waiter)
+                    `shouldReturn` Just (Left "interrupted")
+
+    it "closes a resource opened concurrently with shutdown exactly once" do
+        started <- newEmptyMVar
+        release <- newEmptyMVar
+        closes <- newIORef (0 :: Int)
+        cache <- newPoolCache
+            2
+            ("closed" :: Text)
+            exceptionText
+            (\(_ :: Text) -> do
+                putMVar started ()
+                takeMVar release
+                pure (Right (1 :: Int)))
+            (\_ -> atomicModifyIORef' closes (\count -> (count + 1, ())))
+        withAsync (acquirePoolCache cache "role") \opening -> do
+            takeMVar started
+            withAsync (closePoolCache cache) \closing -> do
+                threadDelay 20_000
+                acquirePoolCache cache "other"
+                    `shouldReturn` Left "closed"
+                putMVar release ()
+                wait opening `shouldReturn` Left "closed"
+                wait closing
+                readIORef closes `shouldReturn` 1
+                closePoolCache cache
+                readIORef closes `shouldReturn` 1
+
+    it "closes independent ready resources concurrently and only once" do
+        started <- newChan
+        release <- newEmptyMVar
+        closes <- newIORef ([] :: [Text])
+        cache <- newPoolCache
+            2
+            ("closed" :: Text)
+            exceptionText
+            (pure . Right)
+            (\resource -> do
+                writeChan started resource
+                readMVar release
+                atomicModifyIORef' closes
+                    (\values -> (resource : values, ())))
+        acquirePoolCache cache "one" `shouldReturn` Right ("one" :: Text)
+        acquirePoolCache cache "two" `shouldReturn` Right ("two" :: Text)
+        withAsync (closePoolCache cache) \closing -> do
+            observed <- timeout 250_000 do
+                left <- readChan started
+                right <- readChan started
+                pure [left, right]
+            fmap (all (`elem` ["one", "two"])) observed
+                `shouldBe` Just True
+            putMVar release ()
+            wait closing
+        sort <$> readIORef closes `shouldReturn` ["one", "two"]
+        closePoolCache cache
+        sort <$> readIORef closes `shouldReturn` ["one", "two"]
+
+exceptionText :: Exception.SomeException -> Text
+exceptionText = Text.pack . Exception.displayException

--- a/packages/agent-store/test/Agent/Store/Postgres/SessionSpec.hs
+++ b/packages/agent-store/test/Agent/Store/Postgres/SessionSpec.hs
@@ -105,6 +105,54 @@ spec = describe "PostgreSQL session schema" do
                                 other ->
                                     expectationFailure
                                         ("unexpected stored session: " <> show other)
+                            let metadata2 = metadata
+                                    { sessionMetadataKey = "session-2"
+                                    , sessionMetadataTitle = "second"
+                                    }
+                                turn2 = turn
+                                    { sessionTurnUserText = "batch load"
+                                    }
+                            createSession pool metadata2
+                                `shouldReturn` Right True
+                            appendSessionTurn pool turn2 metadata2
+                                `shouldReturn` Right True
+                            loadSessions pool [] `shouldReturn` []
+                            loadSessions pool
+                                [ "session-2"
+                                , "missing"
+                                , "session-1"
+                                , "session-2"
+                                ] >>= \results ->
+                                    fmap
+                                        (fmap
+                                            (fmap
+                                                (\stored ->
+                                                    ( stored.storedMetadata.sessionMetadataKey
+                                                    , map
+                                                        ( (.sessionTurnUserText)
+                                                            . (.storedTurn)
+                                                        )
+                                                        stored.storedTurns
+                                                    ))))
+                                        results
+                                        `shouldBe`
+                                            [ Right
+                                                (Just
+                                                    ( "session-2"
+                                                    , ["batch load"]
+                                                    ))
+                                            , Right Nothing
+                                            , Right
+                                                (Just
+                                                    ( "session-1"
+                                                    , ["/compact"]
+                                                    ))
+                                            , Right
+                                                (Just
+                                                    ( "session-2"
+                                                    , ["batch load"]
+                                                    ))
+                                            ]
                             searchConversationTurns pool "compact" 10 >>= \case
                                 Right [match] -> do
                                     match.searchSessionId `shouldBe` "session-1"

--- a/packages/agent-store/test/Spec.hs
+++ b/packages/agent-store/test/Spec.hs
@@ -7,12 +7,14 @@ import Test.Hspec (hspec)
 import qualified Agent.Store.Postgres.ConfigSpec as ConfigSpec
 import qualified Agent.Store.Postgres.CustomSpec as CustomSpec
 import qualified Agent.Store.Postgres.ManagedSpec as ManagedSpec
+import qualified Agent.Store.PoolCacheSpec as PoolCacheSpec
 import qualified Agent.Store.Postgres.ScopeSpec as ScopeSpec
 import qualified Agent.Store.Postgres.SessionSpec as SessionSpec
 import qualified Agent.Store.Postgres.SkillSpec as SkillSpec
 
 main :: IO ()
 main = hspec do
+    PoolCacheSpec.spec
     ConfigSpec.spec
     ScopeSpec.spec
     CustomSpec.spec

--- a/packages/agent-telegram/agent-telegram.cabal
+++ b/packages/agent-telegram/agent-telegram.cabal
@@ -88,5 +88,22 @@ test-suite agent-telegram-test
                     , base >= 4.17 && < 5
                     , bytestring
                     , containers
+                    , directory
+                    , filepath
                     , hspec >= 2.11 && < 2.12
+                    , safe-exceptions
+                    , temporary
                     , text
+
+benchmark media-downloads-bench
+    import:           common-options
+    type:             exitcode-stdio-1.0
+    hs-source-dirs:   benchmark
+    main-is:          MediaDownloads.hs
+    ghc-options:      -O2 -threaded -rtsopts "-with-rtsopts=-T"
+    build-depends:    agent-telegram
+                    , base >= 4.17 && < 5
+                    , filepath
+                    , text
+                    , temporary
+                    , time

--- a/packages/agent-telegram/benchmark/MediaDownloads.hs
+++ b/packages/agent-telegram/benchmark/MediaDownloads.hs
@@ -1,0 +1,89 @@
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Main (main) where
+
+import Agent.Telegram
+    ( downloadTelegramMediaAttachmentsWith
+    )
+import Agent.Telegram.Types
+    ( TelegramFileMedia(..)
+    , TelegramMedia(..)
+    , TelegramMediaKind(..)
+    )
+import Control.Concurrent (threadDelay)
+import Data.Time.Clock (diffUTCTime, getCurrentTime)
+import qualified Data.Text as Text
+import System.Environment (getArgs)
+import System.IO.Temp (withSystemTempDirectory)
+import System.OsPath (OsPath, unsafeEncodeUtf)
+import Text.Printf (printf)
+import Text.Read (readMaybe)
+
+main :: IO ()
+main =
+    getArgs >>= \case
+        [countArg, delayArg] -> do
+            count <- parsePositive "attachment count" countArg
+            delayMillis <- parsePositive "download delay milliseconds" delayArg
+            withSystemTempDirectory "agent-telegram-media-bench" \directory ->
+                do
+                    let tempDir = unsafeEncodeUtf directory
+                    serial <- measure
+                        (serialDownloads count delayMillis tempDir)
+                    bounded <- measure
+                        (boundedDownloads count delayMillis tempDir)
+                    printf "serial,%.3f\nbounded-4,%.3f\n"
+                        serial
+                        bounded
+        _ ->
+            fail "usage: media-downloads-bench ATTACHMENT_COUNT DELAY_MS"
+
+serialDownloads :: Int -> Int -> OsPath -> IO ()
+serialDownloads count delayMillis tempDir =
+    mapM_ (downloadOne delayMillis tempDir) [0 .. count - 1]
+
+boundedDownloads :: Int -> Int -> OsPath -> IO ()
+boundedDownloads count delayMillis tempDir = do
+    _ <- downloadTelegramMediaAttachmentsWith
+        (pure . Text.unpack)
+        (\_ target -> threadDelay (delayMillis * 1_000) >> pure target)
+        tempDir
+        42
+        (attachments count)
+    pure ()
+
+downloadOne :: Int -> OsPath -> Int -> IO ()
+downloadOne delayMillis _tempDir _index =
+    threadDelay (delayMillis * 1_000)
+
+attachments :: Int -> [TelegramMedia]
+attachments count =
+    [ TelegramMedia
+        { telegramMediaKind = TelegramMediaDocument
+        , telegramMediaFile =
+            Just TelegramFileMedia
+                { fileMediaFileId = Text.pack (show index)
+                , fileMediaName = Just "payload.bin"
+                , fileMediaMimeType = Just "application/octet-stream"
+                , fileMediaFileSize = Nothing
+                , fileMediaDuration = Nothing
+                }
+        , telegramMediaDescription = ""
+        }
+    | index <- [0 .. count - 1]
+    ]
+
+measure :: IO a -> IO Double
+measure action = do
+    started <- getCurrentTime
+    _ <- action
+    finished <- getCurrentTime
+    pure (realToFrac (diffUTCTime finished started) * 1_000)
+
+parsePositive :: String -> String -> IO Int
+parsePositive label raw =
+    case readMaybe raw of
+        Just value | value > 0 -> pure value
+        _ -> fail ("invalid " <> label <> ": " <> raw)

--- a/packages/agent-telegram/package.nix
+++ b/packages/agent-telegram/package.nix
@@ -1,7 +1,7 @@
 { mkDerivation, aeson, agent-cli, agent-core, agent-store, async
 , base, bytestring, containers, directory, filelock, filepath
 , hspec, http-client, http-client-tls, http-types, lib, process
-, retry, safe-exceptions, text, time, unix, vector
+, retry, safe-exceptions, temporary, text, time, unix, vector
 }:
 mkDerivation {
   pname = "agent-telegram";
@@ -16,8 +16,10 @@ mkDerivation {
   ];
   executableHaskellDepends = [ base ];
   testHaskellDepends = [
-    aeson agent-core base bytestring containers hspec text
+    aeson agent-core base bytestring containers directory filepath
+    hspec safe-exceptions temporary text
   ];
+  benchmarkHaskellDepends = [ base filepath temporary text time ];
   description = "Telegram gateway for the universal agent harness";
   license = lib.meta.getLicenseFromSpdxId "MIT";
   mainProgram = "agent-telegram";

--- a/packages/agent-telegram/src/Agent/Telegram.hs
+++ b/packages/agent-telegram/src/Agent/Telegram.hs
@@ -31,6 +31,7 @@ module Agent.Telegram
     , telegramReactionEmoji
     , telegramReplyText
     , transcribeWithCodex
+    , downloadTelegramMediaAttachmentsWith
     ) where
 
 import Agent.CLI.AgentSessions
@@ -98,6 +99,7 @@ import Agent.Telegram.Markdown
     )
 import Agent.Telegram.Voice (transcribeWithCodex)
 import Agent.FileRetry (writeLazyFileAtomically)
+import Agent.Concurrent (mapConcurrentlyBounded)
 import Agent.OsPath (unsafeToFilePath)
 import Agent.Provider (Provider, parseProvider)
 import Agent.Store.Postgres
@@ -127,10 +129,11 @@ import Control.Exception.Safe
     , bracket
     , displayException
     , finally
+    , onException
     , try
     , tryAny
     )
-import Control.Monad (forM, forM_, unless, void, when)
+import Control.Monad (forM_, unless, void, when)
 import Data.Aeson
     ( Value(..)
     , eitherDecode
@@ -302,6 +305,15 @@ parseSetupOptions = go defaultTelegramSetupOptions
             go options { setupApprovalMode = TelegramApprovalDeny } rest
         "--all-group-messages" : rest ->
             go options { setupRespondToAllGroupMessages = True } rest
+        "--workers" : value : rest ->
+            case readMaybe value of
+                Just workers
+                    | workers >= 1
+                    , workers <= maximumTelegramWorkerCount ->
+                        go options { setupWorkerCount = workers } rest
+                _ -> Left
+                    ("workers must be between 1 and "
+                        <> show maximumTelegramWorkerCount)
         "--start" : rest -> go options { setupStart = True } rest
         flag : _ -> Left ("unknown setup option: " <> flag <> "\n\n" <> telegramUsage)
 
@@ -337,6 +349,7 @@ telegramUsage = unlines
     , "                          default: ask with Telegram buttons"
     , "  --all-group-messages  consider every allowed-user group message"
     , "                          and reply only when useful"
+    , "  --workers N           concurrent chat workers (1-64, default: 8)"
     , "  --start               start the gateway after setup"
     ]
 
@@ -437,6 +450,7 @@ setupTelegram options = do
             , telegramAllowedUsers = allowedUsers
             , telegramRespondToAllGroupMessages =
                 options.setupRespondToAllGroupMessages
+            , telegramWorkerCount = options.setupWorkerCount
             }
     createDirectoryIfMissing True directory
     setFileMode (unsafeToFilePath directory) 0o700
@@ -572,6 +586,7 @@ runTelegramWithStore store home config token = do
             , runtimeAllowedUsers = config.telegramAllowedUsers
             , runtimeRespondToAllGroupMessages =
                 config.telegramRespondToAllGroupMessages
+            , runtimeWorkerCount = config.telegramWorkerCount
             , runtimeGatewayDirectory = gatewayDir
             , runtimePool = trustedPool store
             , runtimeSessionsRoot = root
@@ -670,6 +685,7 @@ data TelegramRuntime = TelegramRuntime
     , runtimeBot :: !TelegramUser
     , runtimeAllowedUsers :: !(Set Integer)
     , runtimeRespondToAllGroupMessages :: !Bool
+    , runtimeWorkerCount :: !Int
     , runtimeGatewayDirectory :: !OsPath
     , runtimePool :: !StorePool
     , runtimeSessionsRoot :: !OsPath
@@ -750,7 +766,9 @@ dispatchForever :: TelegramRuntime -> IO ()
 dispatchForever runtime =
     race_
         (scheduleTelegramWorkForever runtime)
-        (replicateConcurrently_ 8 (telegramWorkerLoop runtime))
+        (replicateConcurrently_
+            runtime.runtimeWorkerCount
+            (telegramWorkerLoop runtime))
 
 scheduleTelegramWorkForever :: TelegramRuntime -> IO ()
 scheduleTelegramWorkForever runtime = do
@@ -1140,47 +1158,72 @@ downloadTelegramMediaAttachments
     -> TelegramPendingMediaTurn
     -> IO [(TelegramMediaKind, ManagedTurnMedia)]
 downloadTelegramMediaAttachments runtime handle pending =
-    concat <$> forM
-        (zip [0 :: Int ..] pending.pendingMediaAttachments)
-        \(index, media) ->
-            case media.telegramMediaFile of
-                Nothing -> pure []
-                Just file -> do
-                    filePath <- TelegramClient.getTelegramFilePath
-                        runtime.runtimeClient
-                        file.fileMediaFileId
-                    let extension =
-                            fromMaybe
-                                (kindExtension media.telegramMediaKind)
-                                (fileMediaExtension file)
-                        localPath =
-                            handle.sessionTempDir
-                                </> unsafeEncodeUtf
-                                    ("media-"
-                                        <> show pending.pendingMediaUpdateId
-                                        <> "-"
-                                        <> show index
-                                        <> extension)
-                    path <-
-                        TelegramClient.downloadTelegramFile
-                            runtime.runtimeClient
-                            (20 * 1024 * 1024)
-                            filePath
-                            localPath
-                    pure
-                        [ ( media.telegramMediaKind
-                          , ManagedTurnMedia
-                                { managedTurnMediaPath =
-                                    unsafeToFilePath path
-                                , managedTurnMediaMime =
-                                    fromMaybe "application/octet-stream"
-                                        file.fileMediaMimeType
-                                , managedTurnMediaName =
-                                    file.fileMediaName
-                                }
-                          )
-                        ]
+    downloadTelegramMediaAttachmentsWith
+        (TelegramClient.getTelegramFilePath runtime.runtimeClient)
+        (TelegramClient.downloadTelegramFile
+            runtime.runtimeClient
+            (20 * 1024 * 1024))
+        handle.sessionTempDir
+        pending.pendingMediaUpdateId
+        pending.pendingMediaAttachments
+
+-- | Download one Telegram media batch with bounded concurrency. The injected
+-- operations make ordering, cleanup, and cancellation behavior testable
+-- without a live Telegram API.
+downloadTelegramMediaAttachmentsWith
+    :: (Text -> IO FilePath)
+    -> (FilePath -> OsPath -> IO OsPath)
+    -> OsPath
+    -> Integer
+    -> [TelegramMedia]
+    -> IO [(TelegramMediaKind, ManagedTurnMedia)]
+downloadTelegramMediaAttachmentsWith getFilePath downloadFile tempDir updateId media =
+    do
+        cleanupPaths <- newMVar []
+        let cleanup =
+                readMVar cleanupPaths >>= mapM_ \path ->
+                    void (tryAny (removeFile path))
+            downloadOne (index, attachment) =
+                case attachment.telegramMediaFile of
+                    Nothing -> pure []
+                    Just file -> do
+                        filePath <- getFilePath file.fileMediaFileId
+                        let extension =
+                                fromMaybe
+                                    (kindExtension attachment.telegramMediaKind)
+                                    (fileMediaExtension file)
+                            localPath =
+                                tempDir
+                                    </> unsafeEncodeUtf
+                                        ("media-"
+                                            <> show updateId
+                                            <> "-"
+                                            <> show index
+                                            <> extension)
+                        modifyMVar_ cleanupPaths (pure . (localPath :))
+                        path <- downloadFile filePath localPath
+                        pure
+                            [ ( attachment.telegramMediaKind
+                              , ManagedTurnMedia
+                                    { managedTurnMediaPath =
+                                        unsafeToFilePath path
+                                    , managedTurnMediaMime =
+                                        fromMaybe "application/octet-stream"
+                                            file.fileMediaMimeType
+                                    , managedTurnMediaName =
+                                        file.fileMediaName
+                                    }
+                              )
+                            ]
+        concat
+            <$> mapConcurrentlyBounded
+                telegramMediaDownloadConcurrency
+                downloadOne
+                (zip [0 :: Int ..] media)
+            `onException` cleanup
   where
+    telegramMediaDownloadConcurrency = 4
+
     fileMediaExtension file =
         case file.fileMediaName of
             Just name | not (Text.null name) ->

--- a/packages/agent-telegram/src/Agent/Telegram/Bridge.hs
+++ b/packages/agent-telegram/src/Agent/Telegram/Bridge.hs
@@ -3,6 +3,7 @@ module Agent.Telegram.Bridge
     ( TelegramBridgeEnv(..)
     , withTelegramBridge
     , processTelegramCallbacks
+    , processBridgeRequestBatch
     ) where
 
 import Agent.CLI.GatewayBridge
@@ -16,6 +17,7 @@ import Agent.CLI.GatewayBridge
     )
 import Agent.CLI.ManagedTurn (ManagedTurnRequest(..))
 import Agent.FileRetry (retryOnFileBusy)
+import Agent.Concurrent (mapConcurrentlyBounded)
 import Agent.OsPath (unsafeToFilePath)
 import qualified Agent.Telegram.Client as Client
 import Agent.Telegram.Types
@@ -36,13 +38,13 @@ import Data.Aeson
 import qualified Data.ByteString.Lazy as LBS
 import Data.IORef
     ( IORef
-    , modifyIORef'
+    , atomicModifyIORef'
     , newIORef
     , readIORef
     )
-import Data.List (isPrefixOf)
+import Data.List (isPrefixOf, sort)
 import qualified Data.Map.Strict as Map
-import Data.Maybe (fromMaybe)
+import Data.Maybe (catMaybes, fromMaybe)
 import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -132,20 +134,45 @@ processBridgeRequests env seenRef = do
     files <- try @_ @SomeException (listDirectory directory) >>= \case
         Left _ -> pure []
         Right values -> pure values
+    processBridgeRequestBatch
+        seenRef
+        files
+        (decodeBridgeRequest . (directory </>))
+        (processBridgeRequest env)
+
+-- | Decode and dispatch one deterministic bridge polling batch. Successfully
+-- decoded names are admitted exactly once before concurrent dispatch begins.
+processBridgeRequestBatch
+    :: IORef (Set.Set FilePath)
+    -> [FilePath]
+    -> (FilePath -> IO (Maybe request))
+    -> (request -> IO ())
+    -> IO ()
+processBridgeRequestBatch seenRef files decode dispatch = do
     seen <- readIORef seenRef
     let published =
-            filter
-                (\name ->
-                    takeExtension name == ".json"
-                        && name `Set.notMember` seen)
-                files
-    forM_ published \name -> do
-        let path = directory </> name
-        decodeBridgeRequest path >>= \case
-            Nothing -> pure ()
-            Just request -> do
-                modifyIORef' seenRef (Set.insert name)
-                processBridgeRequest env request
+            sort $
+                filter
+                    (\name ->
+                        takeExtension name == ".json"
+                            && name `Set.notMember` seen)
+                    files
+    decoded <-
+        mapConcurrentlyBounded telegramBridgeConcurrency
+            (\name -> fmap ((,) name) <$> decode name)
+            published
+    let admitted = catMaybes decoded
+    atomicModifyIORef' seenRef \current ->
+        ( foldr (Set.insert . fst) current admitted
+        , ()
+        )
+    void $
+        mapConcurrentlyBounded telegramBridgeConcurrency
+            (dispatch . snd)
+            admitted
+
+telegramBridgeConcurrency :: Int
+telegramBridgeConcurrency = 4
 
 decodeBridgeRequest :: FilePath -> IO (Maybe ManagedBridgeRequest)
 decodeBridgeRequest path =

--- a/packages/agent-telegram/src/Agent/Telegram/Types.hs
+++ b/packages/agent-telegram/src/Agent/Telegram/Types.hs
@@ -6,6 +6,8 @@ module Agent.Telegram.Types
     , TelegramApprovalMode(..)
     , TelegramSetupOptions(..)
     , defaultTelegramSetupOptions
+    , defaultTelegramWorkerCount
+    , maximumTelegramWorkerCount
     , TelegramCommand(..)
     , TelegramUsersCommand(..)
     , TelegramChatKey(..)
@@ -126,7 +128,14 @@ data TelegramConfig = TelegramConfig
     , telegramApprovalMode :: !TelegramApprovalMode
     , telegramAllowedUsers :: !(Set Integer)
     , telegramRespondToAllGroupMessages :: !Bool
+    , telegramWorkerCount :: !Int
     } deriving (Eq, Show)
+
+defaultTelegramWorkerCount :: Int
+defaultTelegramWorkerCount = 8
+
+maximumTelegramWorkerCount :: Int
+maximumTelegramWorkerCount = 64
 
 instance ToJSON TelegramConfig where
     toJSON config = object
@@ -138,6 +147,7 @@ instance ToJSON TelegramConfig where
         , "allowedUsers" .= Set.toList config.telegramAllowedUsers
         , "respondToAllGroupMessages"
             .= config.telegramRespondToAllGroupMessages
+        , "workers" .= config.telegramWorkerCount
         ]
 
 instance FromJSON TelegramConfig where
@@ -152,6 +162,12 @@ instance FromJSON TelegramConfig where
             (if legacyYolo
                 then TelegramApprovalYolo
                 else TelegramApprovalPrompt)
+        workerCount <- o .:? "workers" .!= defaultTelegramWorkerCount
+        if workerCount < 1 || workerCount > maximumTelegramWorkerCount
+            then fail
+                ("workers must be between 1 and "
+                    <> show maximumTelegramWorkerCount)
+            else pure ()
         TelegramConfig
             <$> pure telegramProvider
             <*> o .:? "model"
@@ -160,6 +176,7 @@ instance FromJSON TelegramConfig where
             <*> pure approvalMode
             <*> (Set.fromList <$> o .: "allowedUsers")
             <*> (o .:? "respondToAllGroupMessages" .!= False)
+            <*> pure workerCount
 
 data TelegramSetupOptions = TelegramSetupOptions
     { setupProvider :: !(Maybe Provider)
@@ -169,6 +186,7 @@ data TelegramSetupOptions = TelegramSetupOptions
     , setupApprovalMode :: !TelegramApprovalMode
     , setupAllowedUsers :: ![Integer]
     , setupRespondToAllGroupMessages :: !Bool
+    , setupWorkerCount :: !Int
     , setupStart :: !Bool
     } deriving (Eq, Show)
 
@@ -181,6 +199,7 @@ defaultTelegramSetupOptions = TelegramSetupOptions
     , setupApprovalMode = TelegramApprovalPrompt
     , setupAllowedUsers = []
     , setupRespondToAllGroupMessages = False
+    , setupWorkerCount = defaultTelegramWorkerCount
     , setupStart = False
     }
 

--- a/packages/agent-telegram/test/Agent/TelegramSpec.hs
+++ b/packages/agent-telegram/test/Agent/TelegramSpec.hs
@@ -1,8 +1,11 @@
 module Agent.TelegramSpec (spec) where
 
 import Agent.Telegram
+import Agent.OsPath (unsafeToFilePath)
+import qualified Agent.Telegram.Bridge as Bridge
 import Agent.Telegram.Types
     ( TelegramApprovalMode(..)
+    , defaultTelegramWorkerCount
     , TelegramFileMedia(..)
     , TelegramMedia(..)
     , TelegramMediaKind(..)
@@ -12,19 +15,29 @@ import Agent.Telegram.Types
     , TelegramPendingMediaTurn(..)
     , TelegramRetryMetadata(..)
     )
+import Data.List (sort)
 import Control.Concurrent
     ( newEmptyMVar
     , putMVar
     , takeMVar
     , threadDelay
     )
+import Control.Exception.Safe (finally)
 import Data.Aeson (Value, eitherDecode, encode, object, (.=))
 import qualified Data.ByteString.Lazy.Char8 as LBS
-import Data.IORef (modifyIORef', newIORef, readIORef)
+import Data.IORef
+    ( atomicModifyIORef'
+    , modifyIORef'
+    , newIORef
+    , readIORef
+    )
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import qualified Data.Text as Text
 import Agent.Provider (Provider(..))
+import System.Directory (listDirectory)
+import System.IO.Temp (withSystemTempDirectory)
+import System.OsPath (unsafeEncodeUtf)
 import qualified System.Timeout as Timeout
 import Test.Hspec
 
@@ -43,6 +56,7 @@ spec = describe "Agent.Telegram" do
                 , "--cwd", "/tmp/project"
                 , "--allowed-user", "123"
                 , "--all-group-messages"
+                , "--workers", "12"
                 , "--yolo"
                 , "--start"
                 ]
@@ -54,6 +68,7 @@ spec = describe "Agent.Telegram" do
                         , setupApprovalMode = TelegramApprovalYolo
                         , setupAllowedUsers = [123]
                         , setupRespondToAllGroupMessages = True
+                        , setupWorkerCount = 12
                         , setupStart = True
                         })
 
@@ -61,6 +76,10 @@ spec = describe "Agent.Telegram" do
             parseTelegramArgs ["setup", "--token", "secret"]
                 `shouldSatisfy` isLeft
             parseTelegramArgs ["setup", "--allowed-user", "nope"]
+                `shouldSatisfy` isLeft
+            parseTelegramArgs ["setup", "--workers", "0"]
+                `shouldSatisfy` isLeft
+            parseTelegramArgs ["setup", "--workers", "65"]
                 `shouldSatisfy` isLeft
 
     describe "parseAllowedUsers" do
@@ -87,6 +106,119 @@ spec = describe "Agent.Telegram" do
                 `shouldBe` Right TelegramApprovalPrompt
             fmap (.telegramApprovalMode) (decode True)
                 `shouldBe` Right TelegramApprovalYolo
+
+        it "defaults old configs to eight workers and validates explicit values" do
+            let base workers = object $
+                    [ "provider" .= ("xai" :: String)
+                    , "cwd" .= ("/tmp" :: String)
+                    , "allowedUsers" .= ([123] :: [Integer])
+                    ] <> maybe [] (\value -> ["workers" .= value]) workers
+                decode :: Maybe Int -> Either String TelegramConfig
+                decode workers =
+                    eitherDecode (encode (base workers))
+            fmap (.telegramWorkerCount) (decode Nothing)
+                `shouldBe` Right defaultTelegramWorkerCount
+            fmap (.telegramWorkerCount) (decode (Just (16 :: Int)))
+                `shouldBe` Right 16
+            decode (Just (0 :: Int)) `shouldSatisfy` isLeft
+            decode (Just (65 :: Int)) `shouldSatisfy` isLeft
+
+    describe "Telegram media downloads" do
+        it "downloads concurrently with a bound and preserves attachment order" $
+            withSystemTempDirectory "telegram-media-" \directory -> do
+                active <- newIORef (0 :: Int)
+                maximumActive <- newIORef (0 :: Int)
+                let attachments =
+                        zipWith testMedia
+                            [ TelegramMediaPhoto
+                            , TelegramMediaDocument
+                            , TelegramMediaVideo
+                            , TelegramMediaAudio
+                            , TelegramMediaAnimation
+                            , TelegramMediaSticker
+                            ]
+                            [1 :: Int ..]
+                    download remote local = do
+                        current <- atomicModifyIORef' active \count ->
+                            let next = count + 1 in (next, next)
+                        atomicModifyIORef' maximumActive \seen ->
+                            (max seen current, ())
+                        let finish =
+                                atomicModifyIORef' active
+                                    (\count -> (count - 1, ()))
+                        (do
+                            threadDelay
+                                ((7 - read (dropWhile (not . (`elem` ['0'..'9'])) remote))
+                                    * 10_000)
+                            writeFile (unsafeToFilePath local) remote
+                            pure local)
+                            `finally` finish
+                results <- downloadTelegramMediaAttachmentsWith
+                    (pure . Text.unpack)
+                    download
+                    (unsafeEncodeUtf directory)
+                    42
+                    attachments
+                map fst results `shouldBe` map (.telegramMediaKind) attachments
+                observed <- readIORef maximumActive
+                observed `shouldSatisfy` (\value -> value > 1 && value <= 4)
+
+        it "removes completed and partial targets when one download fails" $
+            withSystemTempDirectory "telegram-media-failure-" \directory -> do
+                let attachments =
+                        zipWith testMedia
+                            [ TelegramMediaPhoto
+                            , TelegramMediaDocument
+                            , TelegramMediaVideo
+                            ]
+                            [1 :: Int ..]
+                    download remote local = do
+                        writeFile (unsafeToFilePath local) remote
+                        if remote == "file-2"
+                            then fail "download failed"
+                            else threadDelay 50_000 >> pure local
+                downloadTelegramMediaAttachmentsWith
+                    (pure . Text.unpack)
+                    download
+                    (unsafeEncodeUtf directory)
+                    43
+                    attachments
+                    `shouldThrow` anyException
+                listDirectory directory `shouldReturn` []
+
+    describe "Telegram bridge request batches" do
+        it "admits JSON requests once and dispatches them with a bound" do
+            seen <- newIORef Set.empty
+            dispatched <- newIORef []
+            active <- newIORef (0 :: Int)
+            maximumActive <- newIORef (0 :: Int)
+            let files =
+                    [ "request-6.json"
+                    , "ignored.tmp"
+                    , "request-2.json"
+                    , "request-5.json"
+                    , "request-1.json"
+                    , "request-4.json"
+                    , "request-3.json"
+                    ]
+                decode name = pure (Just name)
+                dispatch name = do
+                    current <- atomicModifyIORef' active \count ->
+                        let next = count + 1 in (next, next)
+                    atomicModifyIORef' maximumActive \value ->
+                        (max value current, ())
+                    (threadDelay 20_000
+                        >> modifyIORef' dispatched (name :))
+                        `finally`
+                            atomicModifyIORef' active
+                                (\count -> (count - 1, ()))
+            Bridge.processBridgeRequestBatch seen files decode dispatch
+            Bridge.processBridgeRequestBatch seen files decode dispatch
+            completed <- readIORef dispatched
+            sort completed `shouldBe`
+                sort (filter (Text.isSuffixOf ".json" . Text.pack) files)
+            observed <- readIORef maximumActive
+            observed `shouldSatisfy` (\value -> value > 1 && value <= 4)
 
     describe "splitTelegramText" do
         it "keeps messages within the requested limit" do
@@ -785,3 +917,17 @@ shouldReturnRight :: Either String a -> String -> IO a
 shouldReturnRight result message = case result of
     Left err -> expectationFailure (message <> ": " <> err) >> fail message
     Right value -> pure value
+
+testMedia :: TelegramMediaKind -> Int -> TelegramMedia
+testMedia kind index = TelegramMedia
+    { telegramMediaKind = kind
+    , telegramMediaFile =
+        Just TelegramFileMedia
+            { fileMediaFileId = "file-" <> Text.pack (show index)
+            , fileMediaName = Just ("attachment-" <> Text.pack (show index))
+            , fileMediaMimeType = Just "application/octet-stream"
+            , fileMediaFileSize = Just 10
+            , fileMediaDuration = Nothing
+            }
+    , telegramMediaDescription = ""
+    }


### PR DESCRIPTION
## Summary

- add an ordered, fixed-worker bounded-concurrency helper and apply it to independent project instruction, skill, filesystem, subagent, and MCP discovery work
- parallelize independent CLI startup/runtime operations, attachment handling, session cleanup, usage probes, and agent viewport materialization
- batch recent-session metadata and turn loading through PostgreSQL with `loadSessions`, preserving requested order, duplicates, missing sessions, and legacy filesystem fallback
- add bounded workers for Telegram update/media processing and Grok scheduler/workflow status work
- single-flight PostgreSQL pool creation and close independent pools concurrently
- add concurrency regression tests and focused benchmarks across the affected packages

## Validation

- `agent-core:agent-core-test` — 336 examples, 0 failures
- `agent-cli:agent-cli-test` — 877 examples, 0 failures
- `agent-store:agent-store-test` — 31 examples, 0 failures
- `agent-telegram:agent-telegram-test` — 47 examples, 0 failures
- `agent-grok-build-dialect:agent-grok-build-dialect-test` — 31 examples, 0 failures
- regenerated affected `package.nix` files with `cabal2nix` (no diff)
- live fullscreen onboarding smoke-tested in tmux

## Representative benchmark results

- core discovery: 40.083 ms serial → 4.907 ms bounded
- CLI startup: 666.341 ms serial → 83.789 ms bounded
- store pool acquisition: 174.439 ms previous → 11.088 ms single-flight/concurrent
- Telegram media: 311.819 ms serial → 80.204 ms bounded
- Grok workflow snapshots: 668.044 ms serial → 84.205 ms bounded
