### PR TITLE
Type the Agent.CLI session runtime boundary

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -54,6 +54,7 @@ library
                     , Agent.CLI.Runtime
                     , Agent.CLI.Runtime.Types
                     , Agent.CLI.Session.History
+                    , Agent.CLI.Session.Runtime.Types
                     , Agent.CLI.SessionAdmin
                     , Agent.CLI.StartupContext
                     , Agent.CLI.Startup.Format

--- a/packages/agent-cli/src/Agent/CLI/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime.hs
@@ -101,8 +101,7 @@ import Agent.CLI.AccountPicker
     , loadAllAccountPickerOptions
     )
 import Agent.CLI.Btw
-    ( BtwBackendFactory
-    , formatBtwError
+    ( formatBtwError
     , runBtwWithCancel
     )
 import Agent.CLI.CancelWatch (withEscCancel, withStdinPaused)
@@ -132,8 +131,7 @@ import Agent.CLI.Compaction
 import Agent.CLI.Connectivity (withConnectionRecovery)
 import Agent.CLI.Database (databaseTools)
 import Agent.CLI.Database.Store
-    ( DatabaseScopes
-    , databaseToolsEnvForStore
+    ( databaseToolsEnvForStore
     , deriveDatabaseScopes
     )
 import Agent.CLI.Database.Storage
@@ -179,13 +177,16 @@ import Agent.CLI.Runtime.Types
     , PendingTurnPresentation(..)
     , PreparedAgent(..)
     , RunResult(..)
+    )
+import Agent.CLI.Session.Runtime.Types
+    ( SessionBackend(..)
+    , SessionRequest(..)
     , StartupCancelled(..)
     , StartupFailure(..)
     , StartupRuntime(..)
     )
 import Agent.CLI.Interrupt
     ( CtrlCDecision(..)
-    , InterruptState
     , catchUserInterrupt
     , newInterruptState
     , noteFullscreenCtrlC
@@ -377,7 +378,6 @@ import Agent.CLI.Startup.Format
 import Agent.CLI.Subagents.Runtime
     ( SubagentRuntime(..)
     , SubagentSession(..)
-    , SubagentStoreRoot
     , flushAllSubagentSnapshots
     , freshOpenAiBackend
     , lookupOrCreateSubagentSession
@@ -497,8 +497,7 @@ import Agent.Error
     , CredentialExhaustionReason(..)
     )
 import Agent.Dialect
-    ( Dialect
-    , DialectId(..)
+    ( DialectId(..)
     , ToolLayout(..)
     , dialectForId
     , dialectId
@@ -563,7 +562,6 @@ import Agent.Provider
 import qualified Agent.Provider as Provider
 import Agent.Subagents
     ( RootTurnId
-    , SubagentId(..)
     , SubagentStatus(..)
     , abortRootTurn
     , beginRootTurn
@@ -588,7 +586,6 @@ import Agent.GrokBuild.Dialect.Goal
     , resumeGoal
     )
 import Agent.GrokBuild.Dialect.Runtime (GrokRuntimeControl(..))
-import Agent.GrokBuild.Dialect.Task (GrokSubagentSpecs)
 import Agent.GrokBuild.Dialect.Workflow
     ( formatWorkflowRuns
     , workflowRunSnapshots
@@ -642,11 +639,10 @@ import Control.Concurrent.MVar
     , tryPutMVar
     , withMVar
     )
-import Control.Concurrent.STM (STM, retry)
+import Control.Concurrent.STM (retry)
 import Control.Exception (AsyncException(UserInterrupt))
 import Control.Exception.Safe
-    ( Exception
-    , SomeException
+    ( SomeException
     , catchAny
     , finally
     , mask_
@@ -2370,6 +2366,68 @@ runAgentInitializedWithLock
                             && isNothing options.optProvider
                             && isNothing options.optModel
                             && isNothing promptRequest
+                    sessionRequest
+                        startupUnavailable
+                        sessionTokenProvider
+                        sessionOpenAiPool
+                        sessionSelectAccount
+                        sessionCompactRunner =
+                            SessionRequest
+                                { catalog
+                                , connectionId =
+                                    inferredTarget.targetConnectionId
+                                , options
+                                , provider
+                                , dialect
+                                , policy
+                                , allTools
+                                , suspendGhci = coding.codingSuspendGhci
+                                , grokRuntime = coding.codingGrokRuntime
+                                , mcpRegistrations =
+                                    mcpFleet.mcpFleetRegistrations
+                                , mcpWarnings = mcpFleet.mcpFleetWarnings
+                                , ghciEnabledRef
+                                , bashEnabledRef
+                                , toolEnv
+                                , planMode
+                                , startup
+                                , learnAboutUserRequested
+                                , databaseScopes
+                                , promptRequest
+                                , pendingTurn
+                                , unavailableProviders
+                                , startupUnavailable
+                                , paramsRef
+                                , transcriptRef
+                                , initialTurns
+                                , previous = previousRef
+                                , persist
+                                , projectRoot
+                                , home
+                                , cwd
+                                , tokenProvider = sessionTokenProvider
+                                , openAiPool = sessionOpenAiPool
+                                , startupContext
+                                , skillsRef
+                                , skillInvocationsRef
+                                , escPaused
+                                , interrupt
+                                , multiCtx
+                                , rootTurnRef
+                                , subagentSessions
+                                , pendingNotices
+                                , storeRoot = subagentStoreRoot
+                                , agentTypes = agentTypesRef
+                                , legacyTarget = legacySubagentTarget
+                                , usageRef
+                                , accountRef = activeAccountRef
+                                , accountIdRef = activeAccountIdRef
+                                , selectionRef = activeSelectionRef
+                                , accountLabel = resolveActiveAccountLabel
+                                , selectAccount = sessionSelectAccount
+                                , onPersisted = claimCurrentSession
+                                , compactRunner = sessionCompactRunner
+                                }
                     withStartupAvailability action
                         | shouldProbeAtStartup =
                             withAsync
@@ -2630,9 +2688,17 @@ runAgentInitializedWithLock
                                         projectRoot transition persist noticingBackend
                                 withAsync switchLoop \switchWorker -> do
                                     link switchWorker
-                                    runSession catalog inferredTarget.targetConnectionId options provider dialect policy allTools coding.codingSuspendGhci coding.codingGrokRuntime mcpFleet.mcpFleetRegistrations mcpFleet.mcpFleetWarnings ghciEnabledRef bashEnabledRef toolEnv planMode startup learnAboutUserRequested databaseScopes promptRequest pendingTurn unavailableProviders startupUnavailable paramsRef transcriptRef initialTurns
-                                        previousRef persist projectRoot home cwd (Just tokenProvider) loaded.loadedOpenAiPool startupContext skillsRef skillInvocationsRef escPaused interrupt
-                                        multiCtx rootTurnRef subagentSessions pendingNotices subagentStoreRoot agentTypesRef legacySubagentTarget usageRef activeAccountRef activeAccountIdRef activeSelectionRef resolveActiveAccountLabel selectAccount claimCurrentSession compactRunner activeBackend btwBackend)
+                                    runSession
+                                        (sessionRequest
+                                            startupUnavailable
+                                            (Just tokenProvider)
+                                            loaded.loadedOpenAiPool
+                                            selectAccount
+                                            compactRunner)
+                                        SessionBackend
+                                            { backend = activeBackend
+                                            , btwBackend
+                                            })
                             >>= \case
                                 Left (CodexAuthFailed err) ->
                                     case transition of
@@ -2694,9 +2760,19 @@ runAgentInitializedWithLock
                         activeBackend <-
                             prepareTransitionBackend
                                 projectRoot transition persist backend
-                        runSession catalog inferredTarget.targetConnectionId options provider dialect policy allTools coding.codingSuspendGhci coding.codingGrokRuntime mcpFleet.mcpFleetRegistrations mcpFleet.mcpFleetWarnings ghciEnabledRef bashEnabledRef toolEnv planMode startup learnAboutUserRequested databaseScopes promptRequest pendingTurn unavailableProviders startupUnavailable paramsRef transcriptRef initialTurns
-                            previousRef persist projectRoot home cwd (Just tokenProvider) loaded.loadedOpenAiPool startupContext skillsRef skillInvocationsRef escPaused interrupt
-                            multiCtx rootTurnRef subagentSessions pendingNotices subagentStoreRoot agentTypesRef legacySubagentTarget usageRef activeAccountRef activeAccountIdRef activeSelectionRef resolveActiveAccountLabel (if isJust customGenericOptions then Nothing else Just selectHttpAccount) claimCurrentSession compactRunner activeBackend btwBackend
+                        runSession
+                            (sessionRequest
+                                startupUnavailable
+                                (Just tokenProvider)
+                                loaded.loadedOpenAiPool
+                                (if isJust customGenericOptions
+                                    then Nothing
+                                    else Just selectHttpAccount)
+                                compactRunner)
+                            SessionBackend
+                                { backend = activeBackend
+                                , btwBackend
+                                }
                     ClaudeCodeProvider -> do
                         claudeAuth <-
                             loadClaudeCodeAuth
@@ -2755,9 +2831,17 @@ runAgentInitializedWithLock
                                 activeBackend <-
                                     prepareTransitionBackend
                                         projectRoot transition persist backend
-                                runSession catalog inferredTarget.targetConnectionId options provider dialect policy allTools coding.codingSuspendGhci coding.codingGrokRuntime mcpFleet.mcpFleetRegistrations mcpFleet.mcpFleetWarnings ghciEnabledRef bashEnabledRef toolEnv planMode startup learnAboutUserRequested databaseScopes promptRequest pendingTurn unavailableProviders startupUnavailable paramsRef transcriptRef initialTurns
-                                    previousRef persist projectRoot home cwd Nothing Nothing startupContext skillsRef skillInvocationsRef escPaused interrupt
-                                    multiCtx rootTurnRef subagentSessions pendingNotices subagentStoreRoot agentTypesRef legacySubagentTarget usageRef activeAccountRef activeAccountIdRef activeSelectionRef resolveActiveAccountLabel Nothing claimCurrentSession compactRunner activeBackend btwBackend
+                                runSession
+                                    (sessionRequest
+                                        startupUnavailable
+                                        Nothing
+                                        Nothing
+                                        Nothing
+                                        compactRunner)
+                                    SessionBackend
+                                        { backend = activeBackend
+                                        , btwBackend
+                                        }
                     OpenRouterProvider -> do
                         let makeBackend params =
                                 case customGenericOptions of
@@ -2827,9 +2911,17 @@ runAgentInitializedWithLock
                         activeBackend <-
                             prepareTransitionBackend
                                 projectRoot transition persist backend
-                        runSession catalog inferredTarget.targetConnectionId options provider dialect policy allTools coding.codingSuspendGhci coding.codingGrokRuntime mcpFleet.mcpFleetRegistrations mcpFleet.mcpFleetWarnings ghciEnabledRef bashEnabledRef toolEnv planMode startup learnAboutUserRequested databaseScopes promptRequest pendingTurn unavailableProviders startupUnavailable paramsRef transcriptRef initialTurns
-                            previousRef persist projectRoot home cwd (Just tokenProvider) loaded.loadedOpenAiPool startupContext skillsRef skillInvocationsRef escPaused interrupt
-                            multiCtx rootTurnRef subagentSessions pendingNotices subagentStoreRoot agentTypesRef legacySubagentTarget usageRef activeAccountRef activeAccountIdRef activeSelectionRef resolveActiveAccountLabel (Just selectHttpAccount) claimCurrentSession compactRunner activeBackend btwBackend
+                        runSession
+                            (sessionRequest
+                                startupUnavailable
+                                (Just tokenProvider)
+                                loaded.loadedOpenAiPool
+                                (Just selectHttpAccount)
+                                compactRunner)
+                            SessionBackend
+                                { backend = activeBackend
+                                , btwBackend
+                                }
           where
             startupFailure err = do
                 now <- getCurrentTime
@@ -3007,62 +3099,10 @@ isJustCwd options = case options.optCwd of
 
 
 runSession
-    :: ModelCatalog
-    -> Text
-    -> CliOptions
-    -> Provider
-    -> Dialect
-    -> ApprovalPolicy
-    -> [AppTool]
-    -> IO ()
-    -> Maybe GrokRuntimeControl
-    -> [MCP.McpToolRegistration]
-    -> [Text]
-    -> IORef Bool
-    -> IORef Bool
-    -> ToolEnv
-    -> PlanModeEnv
-    -> StartupRuntime
-    -> Bool
-    -> DatabaseScopes
-    -> Maybe ManagedTurnRequest
-    -> Maybe PendingTurn
-    -> [Provider]
-    -> Maybe (STM ApiError)
-    -> IORef ResponseCreateParams
-    -> IORef [ResponseItem]
-    -> [SessionTurn]
-    -> IORef (Maybe Text)
-    -> Persistence
-    -> OsPath
-    -> OsPath
-    -> OsPath
-    -> Maybe TokenProvider
-    -> Maybe OpenAI.Pool
-    -> IORef (Maybe Text)
-    -> IORef SkillCatalog
-    -> IORef [SkillInvocation]
-    -> IORef Bool
-    -> InterruptState
-    -> Maybe MultiAgentContext
-    -> IORef (Maybe RootTurnId)
-    -> IORef (Map SubagentId SubagentSession)
-    -> IORef [TurnInput]
-    -> SubagentStoreRoot
-    -> GrokSubagentSpecs
-    -> Maybe LegacySubagentTarget
-    -> IORef TokenUsage
-    -> IORef Text
-    -> IORef Text
-    -> IORef Text
-    -> (Credential -> IO Text)
-    -> Maybe (Text -> IO (Either ApiError Text))
-    -> (SessionHandle -> IO ())
-    -> (Maybe Text -> IO (Either Text CompactOutcome))
-    -> Backend
-    -> BtwBackendFactory
+    :: SessionRequest
+    -> SessionBackend
     -> IO RunResult
-runSession catalog connectionId options provider dialect policy allTools suspendGhci grokRuntime mcpRegistrations mcpWarnings ghciEnabledRef bashEnabledRef toolEnv planMode startup learnAboutUserRequested databaseScopes promptRequest pendingTurn unavailableProviders startupUnavailable paramsRef transcriptRef initialTurns previous persist projectRoot home cwd tokenProvider openAiPool startupContext skillsRef skillInvocationsRef escPaused interrupt multiCtx rootTurnRef subagentSessions pendingNotices storeRoot agentTypes legacyTarget usageRef accountRef accountIdRef selectionRef accountLabel selectAccount onPersisted compactRunner backend btwBackend = do
+runSession SessionRequest{..} SessionBackend{..} = do
   initialPrevious <- readIORef previous
   ioLock <- newMVar ()
   let fullscreen = startup.startupFullscreen

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Types.hs
@@ -9,26 +9,16 @@ module Agent.CLI.Runtime.Types
     , StartupRuntime(..)
     ) where
 
-import Agent.CLI.AgentViewport
-    ( AgentEntry
-    , AgentTarget
-    )
-import Agent.CLI.Interrupt (InterruptState)
 import Agent.CLI.ProviderTransition (ProviderTransition)
-import Agent.CLI.SessionState (SessionState)
-import Agent.CLI.Terminal (TerminalCapabilities)
+import Agent.CLI.Session.Runtime.Types
+    ( StartupCancelled(..)
+    , StartupFailure(..)
+    , StartupRuntime(..)
+    )
 import Agent.CLI.TUI.App (FullscreenRuntime)
 import Agent.Error (ApiError)
 import Agent.Provider (Provider)
-import Agent.Store.Postgres (Store)
-import Agent.Tools.Types (ToolEnv)
-import Control.Exception.Safe (Exception)
-import Data.IORef (IORef)
 import Data.Text (Text)
-import Data.Time.Clock
-    ( NominalDiffTime
-    , UTCTime
-    )
 import System.OsPath (OsPath)
 
 -- | How the GHCi-driven agent REPL finished.
@@ -59,36 +49,3 @@ data PendingTurnPresentation
     = SubmitPendingTurn
     | RestartPendingTurn
     | ContinuePendingTurn
-
-data StartupRuntime = StartupRuntime
-    { startupToolEnv :: !ToolEnv
-    , startupDatabaseStore :: !Store
-    , startupInterrupt :: !InterruptState
-    , startupEscPaused :: !(IORef Bool)
-    , startupUiRuntimeRef :: !(IORef (Maybe FullscreenRuntime))
-    , startupFullscreen :: !(Maybe FullscreenRuntime)
-    , startupTerminal :: !TerminalCapabilities
-    , startupUseColor :: !Bool
-    , startupStderrTty :: !Bool
-    , startupStdinTty :: !Bool
-    , startupStdoutTty :: !Bool
-    , startupFullscreenReused :: !Bool
-    , startupAgentSnapshot :: !(IORef (IO (AgentTarget, [AgentEntry])))
-    , startupAgentSelect :: !(IORef (AgentTarget -> IO ()))
-    , startupRestartEffort :: !(IORef (Text -> IO ()))
-    , startupStartedAt :: !UTCTime
-    , startupTimings :: !(IORef [(Text, NominalDiffTime)])
-    , startupSyntaxLoadDuration :: !(IORef (Maybe NominalDiffTime))
-    , startupFinished :: !(IORef Bool)
-    , startupSessionState :: !SessionState
-    }
-
-newtype StartupFailure = StartupFailure String
-    deriving (Show)
-
-instance Exception StartupFailure
-
-data StartupCancelled = StartupCancelled
-    deriving (Show)
-
-instance Exception StartupCancelled

--- a/packages/agent-cli/src/Agent/CLI/Session/History.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/History.hs
@@ -32,7 +32,6 @@ import Data.IORef
     ( IORef
     , writeIORef
     )
-import Data.List (foldl')
 import Data.Text (Text)
 import qualified Data.Text as Text
 import System.Exit (ExitCode(..))

--- a/packages/agent-cli/src/Agent/CLI/Session/Runtime/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runtime/Types.hs
@@ -1,0 +1,175 @@
+-- | Typed inputs shared by provider startup and the session loop.
+module Agent.CLI.Session.Runtime.Types
+    ( SessionBackend(..)
+    , SessionRequest(..)
+    , StartupCancelled(..)
+    , StartupFailure(..)
+    , StartupRuntime(..)
+    ) where
+
+import Agent.CLI.AgentViewport
+    ( AgentEntry
+    , AgentTarget
+    )
+import Agent.CLI.Btw (BtwBackendFactory)
+import Agent.CLI.Compaction (CompactOutcome)
+import Agent.CLI.Database.Store (DatabaseScopes)
+import Agent.CLI.Interrupt (InterruptState)
+import Agent.CLI.ManagedTurn (ManagedTurnRequest)
+import Agent.CLI.ModelConfig (ModelCatalog)
+import Agent.CLI.Options
+    ( ApprovalPolicy
+    , CliOptions
+    )
+import Agent.CLI.ProviderTransition (PendingTurn)
+import Agent.CLI.Session
+    ( LegacySubagentTarget
+    , Persistence
+    , SessionHandle
+    , SessionTurn
+    )
+import Agent.CLI.SessionState (SessionState)
+import Agent.CLI.Subagents.Runtime
+    ( SubagentSession
+    , SubagentStoreRoot
+    )
+import Agent.CLI.Terminal (TerminalCapabilities)
+import Agent.CLI.TUI.App (FullscreenRuntime)
+import Agent.Dialect (Dialect)
+import Agent.Error (ApiError)
+import Agent.GrokBuild.Dialect.Runtime (GrokRuntimeControl)
+import Agent.GrokBuild.Dialect.Task (GrokSubagentSpecs)
+import Agent.Loop
+    ( Backend
+    , TokenUsage
+    , TurnInput
+    )
+import qualified Agent.MCP as MCP
+import qualified Agent.OpenAI.Auth as OpenAI
+import Agent.Provider
+    ( Credential
+    , Provider
+    , TokenProvider
+    )
+import Agent.Responses.Types
+    ( ResponseCreateParams
+    , ResponseItem
+    )
+import Agent.Skills
+    ( SkillCatalog
+    , SkillInvocation
+    )
+import Agent.Store.Postgres (Store)
+import Agent.Subagents
+    ( RootTurnId
+    , SubagentId
+    )
+import Agent.Tools.MultiAgents (MultiAgentContext)
+import Agent.Tools.PlanMode (PlanModeEnv)
+import Agent.Tools.Types
+    ( AppTool
+    , ToolEnv
+    )
+import Control.Concurrent.STM (STM)
+import Control.Exception.Safe (Exception)
+import Data.IORef (IORef)
+import Data.Map.Strict (Map)
+import Data.Text (Text)
+import Data.Time.Clock
+    ( NominalDiffTime
+    , UTCTime
+    )
+import System.OsPath (OsPath)
+
+data SessionBackend = SessionBackend
+    { backend :: !Backend
+    , btwBackend :: !BtwBackendFactory
+    }
+
+data SessionRequest = SessionRequest
+    { catalog :: !ModelCatalog
+    , connectionId :: !Text
+    , options :: !CliOptions
+    , provider :: !Provider
+    , dialect :: !Dialect
+    , policy :: !ApprovalPolicy
+    , allTools :: ![AppTool]
+    , suspendGhci :: !(IO ())
+    , grokRuntime :: !(Maybe GrokRuntimeControl)
+    , mcpRegistrations :: ![MCP.McpToolRegistration]
+    , mcpWarnings :: ![Text]
+    , ghciEnabledRef :: !(IORef Bool)
+    , bashEnabledRef :: !(IORef Bool)
+    , toolEnv :: !ToolEnv
+    , planMode :: !PlanModeEnv
+    , startup :: !StartupRuntime
+    , learnAboutUserRequested :: !Bool
+    , databaseScopes :: !DatabaseScopes
+    , promptRequest :: !(Maybe ManagedTurnRequest)
+    , pendingTurn :: !(Maybe PendingTurn)
+    , unavailableProviders :: ![Provider]
+    , startupUnavailable :: !(Maybe (STM ApiError))
+    , paramsRef :: !(IORef ResponseCreateParams)
+    , transcriptRef :: !(IORef [ResponseItem])
+    , initialTurns :: ![SessionTurn]
+    , previous :: !(IORef (Maybe Text))
+    , persist :: !Persistence
+    , projectRoot :: !OsPath
+    , home :: !OsPath
+    , cwd :: !OsPath
+    , tokenProvider :: !(Maybe TokenProvider)
+    , openAiPool :: !(Maybe OpenAI.Pool)
+    , startupContext :: !(IORef (Maybe Text))
+    , skillsRef :: !(IORef SkillCatalog)
+    , skillInvocationsRef :: !(IORef [SkillInvocation])
+    , escPaused :: !(IORef Bool)
+    , interrupt :: !InterruptState
+    , multiCtx :: !(Maybe MultiAgentContext)
+    , rootTurnRef :: !(IORef (Maybe RootTurnId))
+    , subagentSessions :: !(IORef (Map SubagentId SubagentSession))
+    , pendingNotices :: !(IORef [TurnInput])
+    , storeRoot :: !SubagentStoreRoot
+    , agentTypes :: !GrokSubagentSpecs
+    , legacyTarget :: !(Maybe LegacySubagentTarget)
+    , usageRef :: !(IORef TokenUsage)
+    , accountRef :: !(IORef Text)
+    , accountIdRef :: !(IORef Text)
+    , selectionRef :: !(IORef Text)
+    , accountLabel :: !(Credential -> IO Text)
+    , selectAccount :: !(Maybe (Text -> IO (Either ApiError Text)))
+    , onPersisted :: !(SessionHandle -> IO ())
+    , compactRunner :: !(Maybe Text -> IO (Either Text CompactOutcome))
+    }
+
+data StartupRuntime = StartupRuntime
+    { startupToolEnv :: !ToolEnv
+    , startupDatabaseStore :: !Store
+    , startupInterrupt :: !InterruptState
+    , startupEscPaused :: !(IORef Bool)
+    , startupUiRuntimeRef :: !(IORef (Maybe FullscreenRuntime))
+    , startupFullscreen :: !(Maybe FullscreenRuntime)
+    , startupTerminal :: !TerminalCapabilities
+    , startupUseColor :: !Bool
+    , startupStderrTty :: !Bool
+    , startupStdinTty :: !Bool
+    , startupStdoutTty :: !Bool
+    , startupFullscreenReused :: !Bool
+    , startupAgentSnapshot :: !(IORef (IO (AgentTarget, [AgentEntry])))
+    , startupAgentSelect :: !(IORef (AgentTarget -> IO ()))
+    , startupRestartEffort :: !(IORef (Text -> IO ()))
+    , startupStartedAt :: !UTCTime
+    , startupTimings :: !(IORef [(Text, NominalDiffTime)])
+    , startupSyntaxLoadDuration :: !(IORef (Maybe NominalDiffTime))
+    , startupFinished :: !(IORef Bool)
+    , startupSessionState :: !SessionState
+    }
+
+newtype StartupFailure = StartupFailure String
+    deriving (Show)
+
+instance Exception StartupFailure
+
+data StartupCancelled = StartupCancelled
+    deriving (Show)
+
+instance Exception StartupCancelled


### PR DESCRIPTION
## Summary
- replace the 50-argument `runSession` call with typed `SessionRequest` and `SessionBackend` records
- share one provider-independent request constructor across OpenAI, xAI, Claude Code, and OpenRouter
- move startup runtime types behind the new session-runtime boundary while preserving compatibility re-exports

## Validation
- `printf ":quit\n" | nix develop -c cabal repl agent-cli:lib:agent-cli --repl-options=-fno-code`
- `printf ":main\n:q\n" | TMPDIR=/tmp nix develop -c cabal repl agent-cli:test:agent-cli-test` (862 examples, 0 failures)
- `git diff --check`