### PR TITLE
feat(cli): show subagent models in agent panel

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/AgentViewport.hs
+++ b/packages/agent-cli/src/Agent/CLI/AgentViewport.hs
@@ -9,6 +9,7 @@ module Agent.CLI.AgentViewport
     , agentDisplayName
     , agentEntryTreeLabel
     , agentEntryTreeLabelWithGlyph
+    , agentEntryTreeLabelWithGlyphModel
     , agentStatusGlyph
     , agentStepsForStatus
     , applyAgentViewportKey
@@ -79,6 +80,7 @@ data AgentEntry = AgentEntry
     { agentTarget :: !AgentTarget
     , agentPath :: !Text
     , agentStatus :: !Text
+    , agentModel :: !(Maybe Text)
     , agentSteps :: ![AgentStep]
     , agentTranscript :: ![Text]
     }
@@ -628,6 +630,37 @@ agentEntryTreeLabelWithGlyph
     -> AgentEntry
     -> Text
 agentEntryTreeLabelWithGlyph glyph entries index entry =
+    agentEntryTreeLabelWithGlyphDetail
+        glyph
+        (entry.agentStatus <> maybe "" (" · " <>) entry.agentModel)
+        entries
+        index
+        entry
+
+-- | Compact label for the narrow fullscreen agent pane. The glyph already
+-- carries status, so prefer the model text when it is available.
+agentEntryTreeLabelWithGlyphModel
+    :: Text
+    -> [AgentEntry]
+    -> Int
+    -> AgentEntry
+    -> Text
+agentEntryTreeLabelWithGlyphModel glyph entries index entry =
+    agentEntryTreeLabelWithGlyphDetail
+        glyph
+        (maybe entry.agentStatus id entry.agentModel)
+        entries
+        index
+        entry
+
+agentEntryTreeLabelWithGlyphDetail
+    :: Text
+    -> Text
+    -> [AgentEntry]
+    -> Int
+    -> AgentEntry
+    -> Text
+agentEntryTreeLabelWithGlyphDetail glyph detail entries index entry =
     treePrefixFrom
         (laterSiblingIndex (drop (index + 1) entries))
         (pathSegments entry.agentPath)
@@ -635,7 +668,7 @@ agentEntryTreeLabelWithGlyph glyph entries index entry =
         <> "  "
         <> glyph
         <> " "
-        <> entry.agentStatus
+        <> detail
 
 agentDisplayName :: Text -> Text
 agentDisplayName path =
@@ -711,6 +744,7 @@ agentTreeRowLabel row =
         <> agentStatusGlyph entry.agentStatus
         <> " "
         <> entry.agentStatus
+        <> maybe "" (" · " <>) entry.agentModel
 
 pathSegments :: Text -> [Text]
 pathSegments path =

--- a/packages/agent-cli/src/Agent/CLI/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime.hs
@@ -3239,6 +3239,7 @@ runSession SessionRequest{..} SessionBackend{..} = do
                     { agentTarget = AgentRoot
                     , agentPath = "/root"
                     , agentStatus = "active"
+                    , agentModel = Nothing
                     , agentSteps = rootSteps
                     , agentTranscript =
                         transcriptLines AgentRoot rootItems
@@ -3272,6 +3273,9 @@ runSession SessionRequest{..} SessionBackend{..} = do
                     { agentTarget = target
                     , agentPath = taskPathText path
                     , agentStatus = formatAgentStatus status
+                    , agentModel =
+                        (.subSessionEffectiveModel)
+                            <$> Map.lookup agentId sessions
                     , agentSteps = steps
                     , agentTranscript = transcript
                     }

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -73,7 +73,7 @@ import Agent.CLI.AgentViewport
     , AgentStepState(..)
     , AgentTarget(..)
     , agentDisplayName
-    , agentEntryTreeLabelWithGlyph
+    , agentEntryTreeLabelWithGlyphModel
     , agentStatusGlyph
     )
 import Agent.CLI.Interrupt (CtrlCDecision(..))
@@ -1938,7 +1938,7 @@ drawAgentPane state entryLimit selected hovered entries =
             row = hBox
                 [ txt
                     (marker
-                        <> agentEntryTreeLabelWithGlyph
+                        <> agentEntryTreeLabelWithGlyphModel
                             statusGlyph
                             ordered
                             index

--- a/packages/agent-cli/test/Agent/CLI/AgentViewportSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/AgentViewportSpec.hs
@@ -28,9 +28,9 @@ spec = do
                     Text.intercalate "\n"
                         [ "agents"
                         , "  ▾ root  ● active"
-                        , "  ├─ alpha  ● running"
-                        , "› │  └─ gamma  ✓ done"
-                        , "  └─ beta  ● running"
+                        , "  ├─ alpha  ● running · gpt-5.6-luna"
+                        , "› │  └─ gamma  ✓ done · gpt-5.6-luna"
+                        , "  └─ beta  ● running · gpt-5.6-luna"
                         , "  viewing /root/alpha/gamma · /agents to switch"
                         ]
 
@@ -49,14 +49,19 @@ spec = do
                     Text.intercalate "\n"
                         [ "agents"
                         , "› ▾ root  ● active"
-                        , "  ├─ alpha  ● running"
-                        , "  │  ├─ one  ● running"
-                        , "  │  │  └─ deep  ✓ done"
-                        , "  │  └─ two  ✓ done"
-                        , "  └─ beta  ● running"
-                        , "     └─ leaf  ✓ done"
+                        , "  ├─ alpha  ● running · gpt-5.6-luna"
+                        , "  │  ├─ one  ● running · gpt-5.6-luna"
+                        , "  │  │  └─ deep  ✓ done · gpt-5.6-luna"
+                        , "  │  └─ two  ✓ done · gpt-5.6-luna"
+                        , "  └─ beta  ● running · gpt-5.6-luna"
+                        , "     └─ leaf  ✓ done · gpt-5.6-luna"
                         , "  viewing /root · /agents to switch"
                         ]
+
+        it "uses the model instead of redundant status text in narrow panes" do
+            let entries = [rootEntry, child "alpha" "/root/alpha" "running"]
+            agentEntryTreeLabelWithGlyphModel "●" entries 1 (entries !! 1)
+                `shouldBe` "└─ alpha  ● gpt-5.6-luna"
 
     describe "agent viewport selection" do
         let entries =
@@ -255,6 +260,7 @@ rootEntry =
         { agentTarget = AgentRoot
         , agentPath = "/root"
         , agentStatus = "active"
+        , agentModel = Nothing
         , agentSteps = []
         , agentTranscript = ["user: hello", "assistant: ready"]
         }
@@ -265,6 +271,7 @@ child agentId path status =
         { agentTarget = AgentChild (SubagentId agentId)
         , agentPath = path
         , agentStatus = status
+        , agentModel = Just "gpt-5.6-luna"
         , agentSteps = []
         , agentTranscript = ["assistant: working"]
         }

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -608,6 +608,7 @@ rootEntry = AgentEntry
     { agentTarget = AgentRoot
     , agentPath = "/root"
     , agentStatus = "active"
+    , agentModel = Nothing
     , agentSteps = []
     , agentTranscript = []
     }
@@ -617,6 +618,7 @@ childEntry index = AgentEntry
     { agentTarget = AgentChild (SubagentId name)
     , agentPath = "/root/" <> name
     , agentStatus = "running"
+    , agentModel = Just "gpt-5.6-luna"
     , agentSteps = []
     , agentTranscript = []
     }

--- a/packages/agent-cli/test/Agent/CLI/TUIBridgeSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIBridgeSpec.hs
@@ -224,7 +224,7 @@ spec = describe "fullscreen TUI bridge" do
     it "falls back to root when the selected agent disappears" do
         let child = AgentChild (SubagentId "child")
             other = AgentChild (SubagentId "other")
-            root = AgentEntry AgentRoot "/root" "active" [] []
+            root = AgentEntry AgentRoot "/root" "active" Nothing [] []
         normalizeAgentSelection child [root] `shouldBe` AgentRoot
         normalizeAgentSelection AgentRoot [root] `shouldBe` AgentRoot
         reconcileAgentSelection [AgentRoot] child

--- a/packages/agent-cli/test/Agent/CLI/TUIPropertySpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIPropertySpec.hs
@@ -434,6 +434,7 @@ rootEntry = AgentEntry
     { agentTarget = AgentRoot
     , agentPath = "/root"
     , agentStatus = "running"
+    , agentModel = Nothing
     , agentSteps = []
     , agentTranscript = []
     }
@@ -443,6 +444,7 @@ childEntry transcript index = AgentEntry
     { agentTarget = AgentChild (SubagentId ("agent-" <> Text.pack (show index)))
     , agentPath = "/root/task_" <> Text.pack (show index)
     , agentStatus = if even index then "running" else "done"
+    , agentModel = Just "gpt-5.6-luna"
     , agentSteps = []
     , agentTranscript =
         [ "user: " <> transcript


### PR DESCRIPTION
## Summary
- carry each subagent’s effective model into agent viewport entries
- show the model in the top-right fullscreen agent pane while retaining status via the glyph
- include model details in the larger agent tree and picker views

## Validation
- `nix develop -c cabal repl agent-cli:test:agent-cli-test`
- `Agent.CLI.AgentViewportSpec`: 17 examples, 0 failures
- live fullscreen tmux smoke test with a `gpt-5.6-luna` subagent
- `git diff --check`