### PR TITLE
fix(tools): validate apply_patch before writing

### DIFF
--- a/packages/agent-codex-dialect/src/Agent/Codex/Dialect/ApplyPatch.hs
+++ b/packages/agent-codex-dialect/src/Agent/Codex/Dialect/ApplyPatch.hs
@@ -21,10 +21,12 @@ import Control.Monad (unless)
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Except
     ( ExceptT(..)
+    , catchE
     , except
     , runExceptT
     , throwE
     )
+import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -195,36 +197,122 @@ applyPatch env raw =
             else applyHunks env hunks
 
 applyHunks :: ToolEnv -> [Hunk] -> ExceptT Text IO Text
-applyHunks env hunks = go hunks [] [] []
+applyHunks env hunks = do
+    (actions, resultSummary) <-
+        prepareHunks env hunks `catchE` \err ->
+            throwE $
+                "Patch validation failed; no files were changed.\n" <> err
+    mapM_ applyPreparedAction actions `catchE` \err ->
+        throwE $
+            "Patch commit failed; files may have been partially changed.\n" <> err
+    pure resultSummary
+
+data VirtualFile
+    = VirtualContents !Text
+    | VirtualMissing
+
+data PreparedAction
+    = PreparedWrite !OsPath !Text
+    | PreparedDelete !OsPath
+
+-- | Validate every hunk against an in-memory view of earlier hunks before
+-- returning any filesystem actions. A stale later hunk therefore cannot leave
+-- earlier files modified even though the overall tool call reports failure.
+prepareHunks
+    :: ToolEnv
+    -> [Hunk]
+    -> ExceptT Text IO ([PreparedAction], Text)
+prepareHunks env hunks = go hunks Map.empty [] [] [] []
   where
-    go [] added modified deleted =
-        pure (summary added modified deleted)
-    go (hunk : rest) added modified deleted = case hunk of
+    go [] _ actions added modified deleted =
+        pure
+            ( reverse actions
+            , summary added modified deleted
+            )
+    go (hunk : rest) files actions added modified deleted = case hunk of
         AddFile path contents -> do
             resolved <- resolvePath env path
-            ExceptT (writeTextFile resolved contents)
-            go rest (path : added) modified deleted
+            go
+                rest
+                (Map.insert resolved (VirtualContents contents) files)
+                (PreparedWrite resolved contents : actions)
+                (path : added)
+                modified
+                deleted
         DeleteFile path -> do
             resolved <- resolvePath env path
-            exists <- lift (doesFileExist resolved)
+            exists <- virtualFileExists resolved files
             unless exists $
                 throwE ("Failed to delete file " <> Text.pack path)
-            ExceptT (deleteTextFile resolved)
-            go rest added modified (path : deleted)
+            go
+                rest
+                (Map.insert resolved VirtualMissing files)
+                (PreparedDelete resolved : actions)
+                added
+                modified
+                (path : deleted)
         UpdateFile path moveTo chunks -> do
             resolved <- resolvePath env path
-            original <- ExceptT (readTextFile resolved)
-            newLines <- except (applyChunks chunks (Text.lines original))
+            original <- virtualFileContents path resolved files
+            newLines <- case applyChunks chunks (Text.lines original) of
+                Left err ->
+                    throwE $
+                        "Failed to update file '"
+                            <> Text.pack path
+                            <> "': "
+                            <> err
+                Right lines_ -> pure lines_
             let newContents = joinFileLines newLines original
             case moveTo of
-                Nothing -> do
-                    ExceptT (writeTextFile resolved newContents)
-                    go rest added (path : modified) deleted
+                Nothing ->
+                    go
+                        rest
+                        (Map.insert resolved (VirtualContents newContents) files)
+                        (PreparedWrite resolved newContents : actions)
+                        added
+                        (path : modified)
+                        deleted
                 Just dest -> do
                     destResolved <- resolvePath env dest
-                    ExceptT (writeTextFile destResolved newContents)
-                    ExceptT (deleteTextFile resolved)
-                    go rest added (dest : modified) deleted
+                    let movedFiles =
+                            Map.insert resolved VirtualMissing $
+                                Map.insert
+                                    destResolved
+                                    (VirtualContents newContents)
+                                    files
+                    go
+                        rest
+                        movedFiles
+                        ( PreparedDelete resolved
+                            : PreparedWrite destResolved newContents
+                            : actions
+                        )
+                        added
+                        (dest : modified)
+                        deleted
+
+    virtualFileExists resolved files =
+        case Map.lookup resolved files of
+            Just (VirtualContents _) -> pure True
+            Just VirtualMissing -> pure False
+            Nothing -> lift (doesFileExist resolved)
+
+    virtualFileContents path resolved files =
+        case Map.lookup resolved files of
+            Just (VirtualContents contents) -> pure contents
+            Just VirtualMissing ->
+                throwE $
+                    "Failed to update file '"
+                        <> Text.pack path
+                        <> "': file does not exist"
+            Nothing -> ExceptT (readTextFile resolved)
+
+applyPreparedAction :: PreparedAction -> ExceptT Text IO ()
+applyPreparedAction = \case
+    PreparedWrite path contents ->
+        ExceptT (writeTextFile path contents)
+    PreparedDelete path ->
+        ExceptT (deleteTextFile path)
 
 resolvePath :: ToolEnv -> FilePath -> ExceptT Text IO OsPath
 resolvePath env path =

--- a/packages/agent-codex-dialect/test/Agent/Codex/DialectSpec.hs
+++ b/packages/agent-codex-dialect/test/Agent/Codex/DialectSpec.hs
@@ -1,5 +1,6 @@
 module Agent.Codex.DialectSpec (spec) where
 
+import Agent.Codex.Dialect.ApplyPatch (applyPatch)
 import Agent.Codex.Dialect.ProjectInstructions (formatCodexAgentsMd)
 import Agent.Codex.Dialect.Prompt (codexSystemPrompt)
 import Agent.Codex.Dialect.Runtime
@@ -18,8 +19,13 @@ import Agent.Tools.Types
     )
 import Control.Exception.Safe (bracket)
 import qualified Data.Text as Text
+import qualified Data.Text.IO as Text
 import Data.Time.Calendar (fromGregorian)
-import System.Directory (getTemporaryDirectory, removeDirectoryRecursive)
+import System.Directory
+    ( doesFileExist
+    , getTemporaryDirectory
+    , removeDirectoryRecursive
+    )
 import System.FilePath ((</>))
 import System.OsPath (unsafeEncodeUtf)
 import System.Posix.Temp (mkdtemp)
@@ -107,6 +113,91 @@ spec = describe "Codex dialect" do
             schedulingPlansConflict first second `shouldBe` False
             schedulingPlansConflict first same `shouldBe` True
             coding.codexClose
+
+    it "does not partially apply a patch when a later hunk is stale" do
+        withTempDir \dir -> do
+            let firstPath = dir </> "first.txt"
+                secondPath = dir </> "second.txt"
+            Text.writeFile firstPath "first old\n"
+            Text.writeFile secondPath "second current\n"
+            env <- defaultToolEnv (unsafeEncodeUtf dir)
+            result <- applyPatch env $
+                "*** Begin Patch\n\
+                \*** Update File: first.txt\n\
+                \@@\n\
+                \-first old\n\
+                \+first new\n\
+                \*** Update File: second.txt\n\
+                \@@\n\
+                \-second stale\n\
+                \+second new\n\
+                \*** End Patch"
+            result `shouldSatisfy` \case
+                Left message ->
+                    and
+                        [ "second.txt" `Text.isInfixOf` message
+                        , "Failed to find expected lines" `Text.isInfixOf` message
+                        , "no files were changed" `Text.isInfixOf` message
+                        ]
+                Right _ -> False
+            Text.readFile firstPath `shouldReturn` "first old\n"
+            Text.readFile secondPath `shouldReturn` "second current\n"
+
+    it "does not commit staged add, move, or delete actions after validation fails" do
+        withTempDir \dir -> do
+            let addedPath = dir </> "added.txt"
+                moveSourcePath = dir </> "move-source.txt"
+                moveDestPath = dir </> "move-dest.txt"
+                deletePath = dir </> "delete.txt"
+                stalePath = dir </> "stale.txt"
+            Text.writeFile moveSourcePath "move old\n"
+            Text.writeFile deletePath "delete me\n"
+            Text.writeFile stalePath "current\n"
+            env <- defaultToolEnv (unsafeEncodeUtf dir)
+            result <- applyPatch env $
+                "*** Begin Patch\n\
+                \*** Add File: added.txt\n\
+                \+added\n\
+                \*** Update File: move-source.txt\n\
+                \*** Move to: move-dest.txt\n\
+                \@@\n\
+                \-move old\n\
+                \+move new\n\
+                \*** Delete File: delete.txt\n\
+                \*** Update File: stale.txt\n\
+                \@@\n\
+                \-stale\n\
+                \+updated\n\
+                \*** End Patch"
+            result `shouldSatisfy` \case
+                Left _ -> True
+                Right _ -> False
+            doesFileExist addedPath `shouldReturn` False
+            Text.readFile moveSourcePath `shouldReturn` "move old\n"
+            doesFileExist moveDestPath `shouldReturn` False
+            Text.readFile deletePath `shouldReturn` "delete me\n"
+            Text.readFile stalePath `shouldReturn` "current\n"
+
+    it "validates later hunks against earlier staged changes" do
+        withTempDir \dir -> do
+            let path = dir </> "staged.txt"
+            Text.writeFile path "before\n"
+            env <- defaultToolEnv (unsafeEncodeUtf dir)
+            result <- applyPatch env $
+                "*** Begin Patch\n\
+                \*** Update File: staged.txt\n\
+                \@@\n\
+                \-before\n\
+                \+middle\n\
+                \*** Update File: staged.txt\n\
+                \@@\n\
+                \-middle\n\
+                \+after\n\
+                \*** End Patch"
+            result `shouldSatisfy` \case
+                Right _ -> True
+                Left _ -> False
+            Text.readFile path `shouldReturn` "after\n"
 
     it "serializes write_stdin only per shell session" do
         withTempDir \dir -> do


### PR DESCRIPTION
## Summary
- stage and validate every `apply_patch` hunk before touching the filesystem
- preserve sequential semantics for repeated paths, adds, deletes, and moves
- report validation failures as no-change and distinguish commit-time partial-write risk
- add regressions for stale later hunks and staged operations

## Root cause
`apply_patch` wrote each hunk immediately. If a later hunk failed exact-context matching, earlier hunks remained applied even though the tool call returned an error. Retrying against the original context then produced repeated “Failed to find expected lines” failures.

## Testing
- `nix develop -c cabal repl agent-codex-dialect:test:agent-codex-dialect-test`
- `hspec Agent.Codex.DialectSpec.spec`
- 9 examples, 0 failures
