### PR TITLE
Add quick-start actions to the empty conversation view

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -18,6 +18,8 @@ module Agent.CLI.TUI.App
     , initialFullscreenAppState
     , motionDemandFor
     , lambdaArtWidget
+    , quickStartRows
+    , quickStartVisible
     , nativeProgressKeepaliveDue
     , nextMotionSchedule
     , newFullscreenInputBuffer
@@ -1350,6 +1352,18 @@ activateControl = \case
         Composer.handlePromptControlClick
             applyLocalUiEventWith
             ReplChooseAccount
+    QuickStartWorktree ->
+        activateQuickStartCommand "/worktree"
+    QuickStartResume ->
+        activateQuickStartCommand "/resume"
+    QuickStartCommands ->
+        applyLocalUiEventWith
+            (UiSetDraft "/" 1)
+            (applyUiEvent (UiFocusChanged FocusComposer))
+    QuickStartModel ->
+        Composer.handlePromptControlClick
+            applyLocalUiEventWith
+            ReplChooseModel
     ChoiceRow index ->
         confirmChoiceAt index
     ResumeRow sessionId ->
@@ -1361,15 +1375,33 @@ activateControl = \case
     _ ->
         pure ()
 
+activateQuickStartCommand :: Text -> EventM Name AppState ()
+activateQuickStartCommand command =
+    Composer.handlePromptControlClick
+        applyLocalUiEventWith
+        (const (ReplText command))
+
 isInteractiveControl :: Name -> Bool
 isInteractiveControl = \case
     ComposerModel -> True
     ComposerEffort -> True
     ComposerMode -> True
     ComposerAccount -> True
+    QuickStartWorktree -> True
+    QuickStartResume -> True
+    QuickStartCommands -> True
+    QuickStartModel -> True
     ChoiceRow _ -> True
     ResumeRow _ -> True
     CodeCopy _ _ -> True
+    _ -> False
+
+isQuickStartControl :: Name -> Bool
+isQuickStartControl = \case
+    QuickStartWorktree -> True
+    QuickStartResume -> True
+    QuickStartCommands -> True
+    QuickStartModel -> True
     _ -> False
 
 openMarkdownLink :: Text -> EventM Name AppState ()
@@ -2267,7 +2299,21 @@ conversationReserveWidgets = \case
 
 drawEmptyConversation :: AppState -> Widget Name
 drawEmptyConversation state =
-    center (lambdaArtWidget frame)
+    B.Widget B.Greedy B.Greedy do
+        context <- B.getContext
+        let width = context.availWidth
+            height = context.availHeight
+        B.render $
+            if quickStartVisible width height
+                then
+                    center $
+                        vBox
+                            [ vLimit
+                                (max 8 (height - quickStartReservedRows))
+                                (hCenter (lambdaArtWidget frame))
+                            , hCenter (drawQuickStartPanel state)
+                            ]
+                else center (lambdaArtWidget frame)
   where
     frame
         | userActionPending state = 0
@@ -2275,6 +2321,48 @@ drawEmptyConversation state =
             MotionFull -> state.appMotionElapsedMillis `div` 160
             MotionReduced -> 0
             MotionOff -> 0
+
+quickStartReservedRows :: Int
+quickStartReservedRows = 9
+
+quickStartVisible :: Int -> Int -> Bool
+quickStartVisible width height =
+    width >= 48 && height >= 20
+
+quickStartRows :: [(Name, Text, Text)]
+quickStartRows =
+    [ (QuickStartWorktree, "New worktree", "/worktree")
+    , (QuickStartResume, "Resume session", "/resume")
+    , (QuickStartCommands, "Browse commands", "/")
+    , (QuickStartModel, "Manage models", "/model")
+    ]
+
+drawQuickStartPanel :: AppState -> Widget Name
+drawQuickStartPanel state =
+    hLimit 44 $
+        vBox
+            [ withAttr Theme.headingAttr $
+                hCenter (txt "What would you like to do?")
+            , padTop (Pad 1) $
+                vBox (map drawQuickStartRow quickStartRows)
+            , padTop (Pad 1) $
+                withAttr Theme.mutedAttr $
+                    hCenter (txt "Tip: Type / to browse commands and skills.")
+            ]
+  where
+    drawQuickStartRow (name, label, command) =
+        clickable name $
+            case Composer.controlInteractionAttr state name of
+                Just attr -> forceAttr attr row
+                Nothing -> row
+      where
+        row =
+            hBox
+                [ withAttr Theme.controlLinkAttr (txt ("  " <> label))
+                , vLimit 1 (fill ' ')
+                , withAttr Theme.mutedAttr (txt command)
+                , txt "  "
+                ]
 
 drawBlock :: AppState -> UiBlock -> Widget Name
 drawBlock state block =
@@ -3554,6 +3642,9 @@ handleEventInner event = case event of
                                 Composer.handleControlMouseDown ComposerMode
                             (ComposerAccount, V.BLeft) ->
                                 Composer.handleControlMouseDown ComposerAccount
+                            (name, V.BLeft)
+                                | isQuickStartControl name ->
+                                    Composer.handleControlMouseDown name
                             (CodeCopy blockId codeIndex, V.BLeft) ->
                                 Composer.handleControlMouseDown
                                     (CodeCopy blockId codeIndex)

--- a/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
@@ -61,6 +61,10 @@ data Name
     | ComposerEffort
     | ComposerMode
     | ComposerAccount
+    | QuickStartWorktree
+    | QuickStartResume
+    | QuickStartCommands
+    | QuickStartModel
     | ChoiceRow !Int
     | ResumeViewport
     | ResumeRow !Text

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -18,6 +18,8 @@ import Agent.CLI.TUI.App
     , fullscreenSurface
     , motionDemandFor
     , lambdaArtWidget
+    , quickStartRows
+    , quickStartVisible
     , nativeProgressKeepaliveDue
     , nextMotionSchedule
     , onboardingVisibleRowIndices
@@ -32,6 +34,7 @@ import Agent.CLI.TUI.App
 import Agent.CLI.TUI.Types
     ( ChoiceOverlay(..)
     , ChoicePresentation(..)
+    , Name(..)
     , TextInputMode(..)
     , TextOverlay(..)
     )
@@ -219,6 +222,20 @@ spec = do
                         renderWidget Nothing [lambdaArtWidget 0] (5, 3)
             V.imageWidth image `shouldSatisfy` (<= 5)
             V.imageHeight image `shouldSatisfy` (<= 3)
+
+        it "shows quick-start actions only when the empty pane has room" do
+            quickStartVisible 100 30 `shouldBe` True
+            quickStartVisible 47 30 `shouldBe` False
+            quickStartVisible 100 19 `shouldBe` False
+
+        it "surfaces the existing high-value startup commands" do
+            quickStartRows
+                `shouldBe`
+                    [ (QuickStartWorktree, "New worktree", "/worktree")
+                    , (QuickStartResume, "Resume session", "/resume")
+                    , (QuickStartCommands, "Browse commands", "/")
+                    , (QuickStartModel, "Manage models", "/model")
+                    ]
 
         it "paints an exact terminal-sized backing surface" do
             let image =


### PR DESCRIPTION
## Summary

- add a compact quick-start panel to the empty conversation view
- provide clickable actions for creating a worktree, resuming a session, browsing commands, and choosing a model
- keep the composer active and fall back to the lambda-only view on narrow terminals
- cover the action list and responsive visibility thresholds with focused tests

## Testing

- `nix develop -c cabal repl agent-cli:test:agent-cli-test` with `Agent.CLI.TUIAppSpec`: 36 examples, 0 failures
- live tmux smoke test at 120x40, including command and model-picker clicks
- live tmux resize check confirming the compact fallback at 45x17
