### PR TITLE
Render reasoning summaries as Markdown

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -2539,7 +2539,7 @@ drawBlock state block =
                                     (codeBlockHeader state block.blockId)
                                     block.blockBody)
             BlockThinking ->
-                accentBlock (thinkingBlockAttr state block)
+                accentMarkdownBlock (thinkingBlockAttr state block)
                     (blockStateGlyph state block <> block.blockTitle)
                     (visibleBody block)
             BlockTool ->
@@ -2661,6 +2661,13 @@ accentBlock accent title body =
         if Text.null (Text.strip body)
             then []
             else [txtWrap body]
+
+accentMarkdownBlock :: AttrName -> Text -> Text -> Widget Name
+accentMarkdownBlock accent title body =
+    accentBlockWithSections accent title $
+        if Text.null (Text.strip body)
+            then []
+            else [markdownWidgetWithLinks MarkdownLink body]
 
 accentCodeBlock
     :: Maybe SyntaxHighlighter

--- a/packages/agent-cli/test/Agent/CLI/TUIPropertySpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIPropertySpec.hs
@@ -18,6 +18,7 @@ import Agent.CLI.TUI.Types
     , TextInputMode(..)
     , TextOverlay(..)
     )
+import Agent.Loop (LoopEvent(..))
 import Agent.Subagents (SubagentId(..))
 import Agent.TUI.Model
     ( BlockId(..)
@@ -175,6 +176,27 @@ spec = do
                 Just row -> do
                     Text.take 1 row `shouldBe` "╰"
                     Text.stripEnd row `shouldSatisfy` Text.isSuffixOf "╯"
+
+        it "renders reasoning summaries as Markdown instead of literal markers" do
+            let reasoningUi =
+                    reduceUi
+                        (UiLoop
+                            (ReasoningDelta
+                                "**Inspecting dependencies**\n\n**Planning the fix**"))
+                        (reduceUi (UiLoop TurnStarted) baseState.appUi)
+                app = baseState { appUi = reasoningUi }
+                size = (80, 20)
+                rows =
+                    pictureRows
+                        (renderWidget
+                            (Just Theme.monochrome)
+                            (drawApp app)
+                            size)
+                        size
+                rendered = Text.unlines rows
+            rendered `shouldSatisfy` Text.isInfixOf "Inspecting dependencies"
+            rendered `shouldSatisfy` Text.isInfixOf "Planning the fix"
+            rendered `shouldSatisfy` (not . Text.isInfixOf "**")
 
 renderTraceProperty :: AppState -> RenderTrace -> Property
 renderTraceProperty baseState (RenderTrace actions) =

--- a/packages/agent-responses/src/Agent/Responses/LoopBackend.hs
+++ b/packages/agent-responses/src/Agent/Responses/LoopBackend.hs
@@ -444,6 +444,10 @@ streamEventToLoopEventWithRawReasoning
     -> ResponseStreamEvent
     -> Maybe LoopEvent
 streamEventToLoopEventWithRawReasoning showRawReasoning = \case
+    ResponseReasoningSummaryPartAddedEvent
+        { summaryIndex = Just index }
+        | index > 0 ->
+            Just (ReasoningDelta "\n\n")
     OtherResponseStreamEvent
         { otherEventType = StreamEventUnknown eventType } ->
             Just

--- a/packages/agent-responses/test/Agent/Responses/LoopBackendSpec.hs
+++ b/packages/agent-responses/test/Agent/Responses/LoopBackendSpec.hs
@@ -124,6 +124,53 @@ spec = describe "tokenProviderStatelessResponsesBackend" do
 
         readIORef events `shouldReturn` [ReasoningDelta "summary"]
 
+    it "separates multiple reasoning summary parts for Markdown rendering" do
+        events <- newIORef []
+        let send _params onStreamEvent = do
+                onStreamEvent ResponseReasoningSummaryPartAddedEvent
+                    { streamItemId = Just "reasoning-1"
+                    , streamOutputIndex = Just 0
+                    , summaryIndex = Just 0
+                    , partValue = Nothing
+                    , sequenceNumber = Just 1
+                    , eventExtraFields = KeyMap.empty
+                    }
+                onStreamEvent OtherResponseStreamEvent
+                    { otherEventType = EventReasoningSummaryTextDelta
+                    , sequenceNumber = Just 2
+                    , eventExtraFields =
+                        KeyMap.singleton "delta"
+                            (Aeson.String "**Inspecting dependencies**")
+                    }
+                onStreamEvent ResponseReasoningSummaryPartAddedEvent
+                    { streamItemId = Just "reasoning-1"
+                    , streamOutputIndex = Just 0
+                    , summaryIndex = Just 1
+                    , partValue = Nothing
+                    , sequenceNumber = Just 3
+                    , eventExtraFields = KeyMap.empty
+                    }
+                onStreamEvent OtherResponseStreamEvent
+                    { otherEventType = EventReasoningSummaryTextDelta
+                    , sequenceNumber = Just 4
+                    , eventExtraFields =
+                        KeyMap.singleton "delta"
+                            (Aeson.String "**Planning the fix**")
+                    }
+                pure (Left (ConnectionError "stop after reasoning"))
+            backend =
+                statelessResponsesBackendWithRawReasoning False send
+                    (pure defaultResponseCreateParams)
+
+        _ <- backend.submitTurn [] Nothing [UserMessage "hello"]
+            (\event -> modifyIORef' events (<> [event]))
+
+        readIORef events `shouldReturn`
+            [ ReasoningDelta "**Inspecting dependencies**"
+            , ReasoningDelta "\n\n"
+            , ReasoningDelta "**Planning the fix**"
+            ]
+
 credential :: String -> Credential
 credential label = Credential
     { accessToken = "token-" <> Text.pack label


### PR DESCRIPTION
## Summary
- render fullscreen reasoning blocks with the shared Markdown widget
- preserve paragraph boundaries between streamed reasoning summary parts
- add response mapping and fullscreen rendering regressions

## Validation
- `agent-responses` GHCi test suite: 32 examples, 0 failures
- fullscreen rendering tests: 5 examples, 0 failures; 300 frame properties and 100 incremental-render properties
- live tmux TTY smoke test
- `git diff --check`