### PR TITLE
Extract Agent.CLI session attachment handling

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -53,6 +53,7 @@ library
                     , Agent.CLI.Provider.Switch
                     , Agent.CLI.Runtime
                     , Agent.CLI.Runtime.Types
+                    , Agent.CLI.Session.Attachments
                     , Agent.CLI.Session.Choices
                     , Agent.CLI.Session.History
                     , Agent.CLI.Session.Selection

--- a/packages/agent-cli/src/Agent/CLI/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime.hs
@@ -106,8 +106,7 @@ import Agent.CLI.Btw
     )
 import Agent.CLI.CancelWatch (withEscCancel, withStdinPaused)
 import Agent.CLI.Clipboard
-    ( appendUniqueImageAttachments
-    , formatImageSize
+    ( formatImageSize
     , loadImagesFromPastedText
     , nonEmptyClipboardImages
     , readClipboardImagesForPaste
@@ -150,12 +149,6 @@ import Agent.CLI.Error
     ( formatApiErrorAt
     , formatApiErrorInlineAt
     , formatApiErrorRetryCountdownParts
-    )
-import Agent.CLI.ImagePreview
-    ( detectImagePreviewProtocol
-    , previewColumnsFor
-    , previewRowsFor
-    , renderImagePreview
     )
 import Agent.CLI.Input
     ( ReplLine(..)
@@ -337,6 +330,11 @@ import Agent.CLI.Session.Choices
     , effortChoice
     , modelChoice
     , showAccountUsage
+    )
+import Agent.CLI.Session.Attachments
+    ( putImagePreview
+    , queueAttachedImages
+    , queueClipboardImages
     )
 import Agent.CLI.Session.History
     ( detectGitBranch
@@ -6033,88 +6031,6 @@ setNativeProgress handle active = do
                 | otherwise = osc9ProgressRemove
         Text.hPutStr handle (wrapOscForTmux inTmux sequence_)
         hFlush handle
-
--- | Queue clipboard / Finder-paste images and optionally draw an in-terminal
--- thumbnail. The caller reports the returned message through the active UI.
-queueAttachedImages
-    :: IORef [ImageAttachment]
-    -> IORef Int
-    -> Bool
-    -> Bool
-    -> [ImageAttachment]
-    -> IO Text
-queueAttachedImages attachmentsRef previewIdRef color showPreview images = do
-    (added, pendingCount) <- atomicModifyIORef' attachmentsRef \existing ->
-        let (pending, unique) =
-                appendUniqueImageAttachments existing images
-        in (pending, (unique, length pending))
-    let sizes =
-            Text.intercalate ", "
-                [ img.imageMime <> " (" <> formatImageSize (BS.length img.imageBytes) <> ")"
-                | img <- added
-                ]
-        duplicateCount = length images - length added
-        queued = Text.pack (show pendingCount)
-    when (showPreview && not (null added)) $
-        putImagePreview previewIdRef color added
-    pure $ case (added, duplicateCount) of
-        ([], _) ->
-            "image already attached — not added again ("
-                <> queued
-                <> " queued)"
-        (_, 0) ->
-            "attached "
-                <> sizes
-                <> " — send with next message ("
-                <> queued
-                <> " queued)"
-        _ ->
-            "attached "
-                <> sizes
-                <> "; skipped "
-                <> Text.pack (show duplicateCount)
-                <> " duplicate image"
-                <> (if duplicateCount == 1 then "" else "s")
-                <> " ("
-                <> queued
-                <> " queued)"
-
-queueClipboardImages
-    :: IORef [ImageAttachment]
-    -> IORef Int
-    -> Bool
-    -> Bool
-    -> IO (Either Text Text)
-queueClipboardImages
-    attachmentsRef
-    previewIdRef
-    color
-    showPreview = do
-    imagesResult <- readClipboardImagesForPaste
-    case imagesResult of
-        Right images@(_:_) ->
-            Right <$> queueAttachedImages
-                attachmentsRef previewIdRef color showPreview images
-        Right [] ->
-            pure (Left "no image found on the clipboard")
-        Left err -> pure (Left err)
-
-putImagePreview :: IORef Int -> Bool -> [ImageAttachment] -> IO ()
-putImagePreview previewIdRef color images = do
-    protocol <- detectImagePreviewProtocol stdout
-    inTmux <- isJust <$> lookupEnv "TMUX"
-    size <- getTerminalSize
-    let (termRows, termCols) = fromMaybe (24, 80) size
-        columns = previewColumnsFor termCols
-        rows = previewRowsFor termRows
-    startId <- atomicModifyIORef' previewIdRef \n ->
-        (n + max 1 (length images), n)
-    case renderImagePreview protocol inTmux (roleMuted color) columns rows startId images of
-        Nothing -> pure ()
-        Just block -> do
-            -- Graphics sequences must not go through the Solarized wash.
-            Text.putStrLn block
-            hFlush stdout
 
 putTrailingNewline :: IORef Bool -> IO ()
 putTrailingNewline printed = do

--- a/packages/agent-cli/src/Agent/CLI/Session/Attachments.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Attachments.hs
@@ -1,0 +1,125 @@
+-- | Queue and preview image attachments for an interactive session.
+module Agent.CLI.Session.Attachments
+    ( putImagePreview
+    , queueAttachedImages
+    , queueClipboardImages
+    ) where
+
+import Agent.CLI.Clipboard
+    ( appendUniqueImageAttachments
+    , formatImageSize
+    , readClipboardImagesForPaste
+    )
+import Agent.CLI.ImagePreview
+    ( detectImagePreviewProtocol
+    , previewColumnsFor
+    , previewRowsFor
+    , renderImagePreview
+    )
+import Agent.CLI.Style (roleMuted)
+import Agent.Loop (ImageAttachment(..))
+import Control.Monad (when)
+import qualified Data.ByteString as BS
+import Data.IORef
+    ( IORef
+    , atomicModifyIORef'
+    )
+import Data.Maybe
+    ( fromMaybe
+    , isJust
+    )
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.IO as Text
+import System.Console.ANSI (getTerminalSize)
+import System.Environment (lookupEnv)
+import System.IO
+    ( hFlush
+    , stdout
+    )
+
+-- | Queue clipboard / Finder-paste images and optionally draw an in-terminal
+-- thumbnail. The caller reports the returned message through the active UI.
+queueAttachedImages
+    :: IORef [ImageAttachment]
+    -> IORef Int
+    -> Bool
+    -> Bool
+    -> [ImageAttachment]
+    -> IO Text
+queueAttachedImages attachmentsRef previewIdRef color showPreview images = do
+    (added, pendingCount) <- atomicModifyIORef' attachmentsRef \existing ->
+        let (pending, unique) =
+                appendUniqueImageAttachments existing images
+        in (pending, (unique, length pending))
+    let sizes =
+            Text.intercalate ", "
+                [ img.imageMime
+                    <> " ("
+                    <> formatImageSize (BS.length img.imageBytes)
+                    <> ")"
+                | img <- added
+                ]
+        duplicateCount = length images - length added
+        queued = Text.pack (show pendingCount)
+    when (showPreview && not (null added)) $
+        putImagePreview previewIdRef color added
+    pure $ case (added, duplicateCount) of
+        ([], _) ->
+            "image already attached — not added again ("
+                <> queued
+                <> " queued)"
+        (_, 0) ->
+            "attached "
+                <> sizes
+                <> " — send with next message ("
+                <> queued
+                <> " queued)"
+        _ ->
+            "attached "
+                <> sizes
+                <> "; skipped "
+                <> Text.pack (show duplicateCount)
+                <> " duplicate image"
+                <> (if duplicateCount == 1 then "" else "s")
+                <> " ("
+                <> queued
+                <> " queued)"
+
+queueClipboardImages
+    :: IORef [ImageAttachment]
+    -> IORef Int
+    -> Bool
+    -> Bool
+    -> IO (Either Text Text)
+queueClipboardImages
+    attachmentsRef
+    previewIdRef
+    color
+    showPreview = do
+    imagesResult <- readClipboardImagesForPaste
+    case imagesResult of
+        Right images@(_:_) ->
+            Right <$> queueAttachedImages
+                attachmentsRef previewIdRef color showPreview images
+        Right [] ->
+            pure (Left "no image found on the clipboard")
+        Left err -> pure (Left err)
+
+putImagePreview :: IORef Int -> Bool -> [ImageAttachment] -> IO ()
+putImagePreview previewIdRef color images = do
+    protocol <- detectImagePreviewProtocol stdout
+    inTmux <- isJust <$> lookupEnv "TMUX"
+    size <- getTerminalSize
+    let (termRows, termCols) = fromMaybe (24, 80) size
+        columns = previewColumnsFor termCols
+        rows = previewRowsFor termRows
+    startId <- atomicModifyIORef' previewIdRef \n ->
+        (n + max 1 (length images), n)
+    case renderImagePreview
+        protocol inTmux (roleMuted color) columns rows startId images of
+        Nothing -> pure ()
+        Just block -> do
+            -- Graphics sequences must not go through the Solarized wash.
+            Text.putStrLn block
+            hFlush stdout


### PR DESCRIPTION
## Summary
- move image queuing and duplicate detection out of `Agent.CLI.Runtime`
- isolate clipboard attachment loading and terminal image previews in `Agent.CLI.Session.Attachments`
- keep existing REPL and fullscreen behavior unchanged

## Validation
- `printf ":quit\n" | nix develop -c cabal repl agent-cli:lib:agent-cli --repl-options=-fno-code` (109 modules)
- `printf ":main\n:q\n" | TMPDIR=/tmp nix develop -c cabal repl agent-cli:test:agent-cli-test` (868 examples, 0 failures)
- `git diff --check`