### PR TITLE
Move activity status above prompt composer

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -1579,6 +1579,7 @@ drawMain state =
                 , Composer.drawQueuedInputs state.appUi
                 , Composer.drawSlashMenu state
                 , drawFollowStatus state.appUi
+                , drawPromptActivity state
                 , Composer.drawComposer state
                 , drawFooter state
                 ]
@@ -2137,11 +2138,16 @@ repositoryHeaderText branch cwd =
 
 drawHeaderRight :: AppState -> Widget Name
 drawHeaderRight state =
-    hBox
-        [ activityWidget
-        , withAttr Theme.mutedAttr (txt elapsed)
-        , withAttr Theme.mutedAttr (txt usage)
-        ]
+    withAttr Theme.mutedAttr $
+        txt (formatTokenUsage state.appUi.uiPrompt.promptUsage)
+
+drawPromptActivity :: AppState -> Widget Name
+drawPromptActivity state =
+    padLeftRight 2 $
+        hBox
+            [ activityWidget
+            , withAttr Theme.mutedAttr (txt elapsed)
+            ]
   where
     ui = state.appUi
     waiting = userActionPending state
@@ -2180,9 +2186,6 @@ drawHeaderRight state =
                 <> formatElapsed
                     (fromIntegral ui.uiElapsedMillis / 1000)
             else ""
-    formattedUsage = formatTokenUsage ui.uiPrompt.promptUsage
-    usage =
-        if Text.null formattedUsage then "" else " │ " <> formattedUsage
 
 waitingIndicatorAttr :: AppState -> AttrName
 waitingIndicatorAttr state =


### PR DESCRIPTION
## Summary
- move the active operation indicator and elapsed timer out of the top-right header
- render activity immediately above the prompt composer
- keep token usage in the header

## Validation
- `nix develop -c cabal repl agent-cli:lib:agent-cli` and `:load Agent.CLI.TUI.App`
- live tmux smoke test for idle and running composer states
- `git diff --check`