### PR TITLE
perf(tui): bound fullscreen prompt history

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -229,6 +229,16 @@ benchmark subagent-retention-bench
                     , containers
                     , text
 
+benchmark history-retention-bench
+    import:           common-options
+    type:             exitcode-stdio-1.0
+    hs-source-dirs:   benchmark
+    main-is:          HistoryRetention.hs
+    ghc-options:      -O2 -rtsopts "-with-rtsopts=-T"
+    build-depends:    agent-cli
+                    , base >= 4.17 && < 5
+                    , text
+
 test-suite agent-cli-test
     import:           common-options
     type:             exitcode-stdio-1.0

--- a/packages/agent-cli/benchmark/HistoryRetention.hs
+++ b/packages/agent-cli/benchmark/HistoryRetention.hs
@@ -1,0 +1,135 @@
+module Main (main) where
+
+import Agent.CLI.TUI.Bridge (trimHistory)
+import Control.Exception (evaluate)
+import Control.Monad (forM)
+import Data.List (sort)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import GHC.Clock (getMonotonicTimeNSec)
+import GHC.Stats
+    ( GCDetails(..)
+    , RTSStats(..)
+    , getRTSStats
+    , getRTSStatsEnabled
+    )
+import System.CPUTime (getCPUTime)
+import System.Environment (getArgs)
+import System.Exit (die)
+import System.Mem (performGC)
+import Text.Printf (printf)
+
+data Workload
+    = Unbounded
+    | Bounded
+
+data Sample = Sample
+    { elapsedMillis :: !Double
+    , cpuMillis :: !Double
+    , allocatedBytes :: !Integer
+    , liveBytes :: !Integer
+    }
+
+main :: IO ()
+main = do
+    enabled <- getRTSStatsEnabled
+    if enabled
+        then pure ()
+        else die "RTS statistics are disabled; run with +RTS -T"
+    getArgs >>= \case
+        [workloadArg, entryCountArg, entrySizeArg, sampleCountArg] -> do
+            workload <- parseWorkload workloadArg
+            entryCount <- parsePositive "entry count" entryCountArg
+            entrySize <- parsePositive "entry size" entrySizeArg
+            sampleCount <- parsePositive "sample count" sampleCountArg
+            samples <- forM [1 .. sampleCount] \sampleIndex ->
+                measure workload sampleIndex entryCount entrySize
+            let sample = median samples
+            printf
+                "%s,%d,%d,%.3f,%.3f,%d,%d\n"
+                workloadArg
+                entryCount
+                entrySize
+                sample.elapsedMillis
+                sample.cpuMillis
+                sample.allocatedBytes
+                sample.liveBytes
+        _ ->
+            die $
+                "usage: history-retention-bench WORKLOAD ENTRIES ENTRY_SIZE SAMPLES\n"
+                    <> "workloads: unbounded, bounded\n"
+                    <> "output: workload,entries,entry_size,elapsed_ms,cpu_ms,"
+                    <> "allocated_bytes,live_bytes"
+
+parseWorkload :: String -> IO Workload
+parseWorkload = \case
+    "unbounded" -> pure Unbounded
+    "bounded" -> pure Bounded
+    other -> die ("unknown workload: " <> other)
+
+parsePositive :: String -> String -> IO Int
+parsePositive label raw =
+    case reads raw of
+        [(value, "")]
+            | value > 0 -> pure value
+        _ -> die ("invalid " <> label <> ": " <> raw)
+
+measure :: Workload -> Int -> Int -> Int -> IO Sample
+measure workload sampleIndex entryCount entrySize = do
+    performGC
+    beforeStats <- getRTSStats
+    beforeCpu <- getCPUTime
+    beforeElapsed <- getMonotonicTimeNSec
+    history <- buildHistory workload sampleIndex entryCount entrySize
+    residentChecksum <- evaluate (checksumHistory history)
+    performGC
+    afterStats <- getRTSStats
+    -- Keep the selected history live through the measured collection.
+    finalChecksum <- evaluate (checksumHistory history)
+    afterElapsed <- getMonotonicTimeNSec
+    afterCpu <- getCPUTime
+    _ <- evaluate (residentChecksum + finalChecksum)
+    pure Sample
+        { elapsedMillis =
+            fromIntegral (afterElapsed - beforeElapsed) / 1.0e6
+        , cpuMillis =
+            fromIntegral (afterCpu - beforeCpu) / 1.0e9
+        , allocatedBytes =
+            fromIntegral
+                (afterStats.allocated_bytes - beforeStats.allocated_bytes)
+        , liveBytes =
+            fromIntegral afterStats.gc.gcdetails_live_bytes
+        }
+
+buildHistory :: Workload -> Int -> Int -> Int -> IO [Text]
+buildHistory workload sampleIndex entryCount entrySize = do
+    let full =
+            [ Text.pack (show sampleIndex <> ":" <> show entryIndex <> ":")
+                <> Text.replicate entrySize "x"
+            | entryIndex <- [1 .. entryCount]
+            ]
+    _ <- evaluate (checksumHistory full)
+    pure case workload of
+        Unbounded -> full
+        Bounded -> trimHistory full
+
+checksumHistory :: [Text] -> Int
+checksumHistory =
+    foldl'
+        (\checksum text ->
+            Text.foldl'
+                (\value character -> value * 33 + fromEnum character)
+                checksum
+                text)
+        5381
+
+median :: [Sample] -> Sample
+median samples =
+    Sample
+        { elapsedMillis = middle (sort (map (.elapsedMillis) samples))
+        , cpuMillis = middle (sort (map (.cpuMillis) samples))
+        , allocatedBytes = middle (sort (map (.allocatedBytes) samples))
+        , liveBytes = middle (sort (map (.liveBytes) samples))
+        }
+  where
+    middle values = values !! (length values `div` 2)

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -803,7 +803,7 @@ initialFullscreenAppState runtime history initialAgent initialAgents initialCloc
         , appTextReply = Nothing
         , appSlashDismissed = False
         , appPasted = False
-        , appHistory = history
+        , appHistory = Bridge.trimHistory history
         , appHistoryIndex = Nothing
         , appHistoryDraft = ""
         , appKillBuffer = ""

--- a/packages/agent-cli/src/Agent/CLI/TUI/Bridge.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Bridge.hs
@@ -1,12 +1,15 @@
 -- | Pure fullscreen bridge decisions used by the Brick runtime.
 module Agent.CLI.TUI.Bridge
     ( eventFollows
+    , fullscreenHistoryLimit
     , historyMove
     , isSendNowKey
     , mergeUiEvents
     , nativeProgressSignal
     , normalizeAgentSelection
+    , pushHistory
     , reconcileAgentSelection
+    , trimHistory
     ) where
 
 import Agent.CLI.AgentViewport (AgentEntry(..), AgentTarget(..))
@@ -14,6 +17,30 @@ import Agent.TUI.Model (UiEvent(..), UiState(..))
 import Agent.Loop (LoopEvent(..))
 import Data.Text (Text)
 import qualified Graphics.Vty as V
+
+-- | Keep enough prompt recall for normal interactive use without retaining an
+-- unbounded copy of the persistent Haskeline history in the fullscreen state.
+fullscreenHistoryLimit :: Int
+fullscreenHistoryLimit = 1000
+
+trimHistory :: [Text] -> [Text]
+trimHistory entries =
+    maybe entries id (overflowPrefix fullscreenHistoryLimit entries)
+  where
+    -- Preserve the original list when it already fits. On overflow, force the
+    -- bounded spine now: a lazy 'take' would leave the retained prefix pointing
+    -- into the complete on-disk history until the user walked far enough.
+    overflowPrefix 0 [] = Nothing
+    overflowPrefix 0 _ = Just []
+    overflowPrefix _ [] = Nothing
+    overflowPrefix remaining (entry : rest) =
+        case overflowPrefix (remaining - 1) rest of
+            Nothing -> Nothing
+            Just boundedRest ->
+                boundedRest `seq` Just (entry : boundedRest)
+
+pushHistory :: Text -> [Text] -> [Text]
+pushHistory text = trimHistory . (text :)
 
 eventFollows :: UiEvent -> Bool
 eventFollows = \case

--- a/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
@@ -652,7 +652,7 @@ handleComposerKey
         modify' \current ->
             current
                 { appPasted = False
-                , appHistory = text : current.appHistory
+                , appHistory = Bridge.pushHistory text current.appHistory
                 , appHistoryIndex = Nothing
                 , appHistoryDraft = ""
                 }
@@ -696,7 +696,8 @@ handleComposerKey
                         \current ->
                             current
                                 { appPasted = False
-                                , appHistory = draft : current.appHistory
+                                , appHistory =
+                                    Bridge.pushHistory draft current.appHistory
                                 , appHistoryIndex = Nothing
                                 , appHistoryDraft = ""
                                 , appSlashIndex = 0

--- a/packages/agent-cli/test/Agent/CLI/TUIBridgeSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIBridgeSpec.hs
@@ -27,6 +27,7 @@ import Control.Exception.Safe (throwString)
 import Control.Monad (replicateM_)
 import Data.Foldable (toList)
 import Data.IORef (modifyIORef', newIORef, readIORef, writeIORef)
+import qualified Data.Text as Text
 import System.Timeout (timeout)
 import qualified Graphics.Vty as V
 import Test.Hspec
@@ -98,6 +99,18 @@ spec = describe "fullscreen TUI bridge" do
             (UiLoop (ReasoningDelta "thought"))
             (UiLoop (TextDelta "answer"))
             `shouldBe` Nothing
+
+    it "bounds the in-memory prompt history while preserving newest-first order" do
+        let oversized =
+                [ "prompt-" <> Text.pack (show index)
+                | index <- [1 .. fullscreenHistoryLimit + 10]
+                ]
+            trimmed = trimHistory oversized
+            pushed = pushHistory "latest" trimmed
+        length trimmed `shouldBe` fullscreenHistoryLimit
+        trimmed `shouldBe` take fullscreenHistoryLimit oversized
+        length pushed `shouldBe` fullscreenHistoryLimit
+        take 2 pushed `shouldBe` ["latest", "prompt-1"]
 
     it "does not block producers when Brick is not draining events" do
         input <- newFullscreenInputBuffer


### PR DESCRIPTION
## Summary

- cap fullscreen in-memory prompt history at the 1,000 most recent entries
- force the bounded list spine so older persistent-history entries can be collected immediately
- apply the bound both at fullscreen startup and after new prompt submissions
- add an optimized retention benchmark and ordering/limit coverage

Persistent Haskeline history remains unchanged on disk.

## Benchmark

Built with `-O2` and measured with RTS statistics using seven samples:

```bash
nix develop -c cabal build --offline agent-cli:bench:history-retention-bench
bin=$(nix develop -c cabal list-bin agent-cli:bench:history-retention-bench)
"$bin" unbounded ENTRIES ENTRY_SIZE 7 +RTS -T
"$bin" bounded   ENTRIES ENTRY_SIZE 7 +RTS -T
```

| Workload | Unbounded live memory | Bounded live memory | Reduction |
| --- | ---: | ---: | ---: |
| 10,000 × 64-byte prompts | 1.85 MB | 0.58 MB | 68.4% |
| 100,000 × 64-byte prompts | 18.41 MB | 4.18 MB | 77.3% |
| 10,000 × 1 KiB prompts | 11.45 MB | 1.54 MB | 86.5% |
| 50,000 × 256-byte prompts | 18.81 MB | 2.37 MB | 87.4% |

The benchmark keeps the selected history live across the measured major GC and forces a checksum to prevent dead-code elimination.

## Validation

- `cabal repl agent-cli:lib:agent-cli --repl-options=-fno-code` — 92 modules loaded
- `cabal test --offline agent-cli:test:agent-cli-test` — 861 examples, 0 failures
- live fullscreen startup exercised in a 120×40 tmux TTY
- `git diff --check`

The PostgreSQL-backed tests used a short `TMPDIR` symlink to the private session temp directory to stay below the Unix socket path limit.
