### PR TITLE
Extract Agent.CLI startup authentication

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -59,6 +59,7 @@ library
                     , Agent.CLI.Session.Selection
                     , Agent.CLI.Session.Runtime.Types
                     , Agent.CLI.SessionAdmin
+                    , Agent.CLI.Startup.Auth
                     , Agent.CLI.StartupContext
                     , Agent.CLI.Startup.Format
                     , Agent.CLI.TUI.Composer.Buffer

--- a/packages/agent-cli/src/Agent/CLI/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime.hs
@@ -35,8 +35,6 @@ import Agent.CLI.AccountSelection
     )
 import Agent.CLI.Auth
     ( LoadedAuth(..)
-    , authErrorNeedsOnboarding
-    , loadAuth
     , loadAuthForAccount
     , preferredOpenAiTokenProvider
     , probeLoadedAuthCredential
@@ -239,7 +237,6 @@ import Agent.Store.Postgres
 import Agent.Store.Types (renderStoreError)
 import Agent.Store.Postgres.Connection (StorePool)
 import qualified Agent.Store.Postgres.Session as StoreSession
-import Agent.Store.Postgres.Skill (LearnedSkill(..))
 import Agent.CLI.PendingInputs (withPendingInputs)
 import Agent.CLI.Resume
     ( ResumeEntry(..)
@@ -387,6 +384,14 @@ import Agent.CLI.Startup.Format
     , formatStartupDuration
     , formatStartupTimings
     )
+import Agent.CLI.Startup.Auth
+    ( learnAboutUserOnboardingPrompt
+    , loadStartupAuth
+    , markStartupStage
+    , recordStartupTiming
+    , setStartupNotice
+    , startupDie
+    )
 import Agent.CLI.Subagents.Runtime
     ( SubagentRuntime(..)
     , SubagentSession(..)
@@ -449,7 +454,6 @@ import Agent.CLI.TUI.App
     , readFullscreenLineWithCatalog
     , requestFullscreenPermission
     , requestFullscreenChoiceWithBody
-    , requestFullscreenOnboarding
     , requestFullscreenResume
     , requestFullscreenSecret
     , requestFullscreenText
@@ -675,7 +679,6 @@ import qualified Data.Set as Set
 import Text.Printf (printf)
 import Data.Time.Clock
     ( NominalDiffTime
-    , UTCTime
     , addUTCTime
     , diffUTCTime
     , getCurrentTime
@@ -883,29 +886,6 @@ withRestoredCurrentDirectory action = do
     originalCwd <- getCurrentDirectory
     action `finally` setCurrentDirectory originalCwd
 
-setStartupNotice :: Maybe FullscreenRuntime -> Text -> IO ()
-setStartupNotice fullscreen message =
-    case fullscreen of
-        Nothing -> pure ()
-        Just runtime ->
-            emitUiEvent runtime
-                (UiSetNotice (Just (progressNotice message)))
-
-recordStartupTiming
-    :: UTCTime
-    -> IORef [(Text, NominalDiffTime)]
-    -> Text
-    -> IO ()
-recordStartupTiming startedAt timingsRef label = do
-    elapsed <- (`diffUTCTime` startedAt) <$> getCurrentTime
-    atomicModifyIORef' timingsRef \timings ->
-        (timings <> [(label, elapsed)], ())
-
-markStartupStage :: StartupRuntime -> Text -> IO ()
-markStartupStage startup label = do
-    recordStartupTiming startup.startupStartedAt startup.startupTimings label
-    setStartupNotice startup.startupFullscreen label
-
 finishStartup :: StartupRuntime -> IO ()
 finishStartup startup = do
     writeIORef startup.startupFinished True
@@ -931,12 +911,6 @@ finishStartup startup = do
                 Nothing -> putTextLn stderr message
                 Just runtime -> emitUiEvent runtime (UiSystemMessage message)
         _ -> pure ()
-
-startupDie :: StartupRuntime -> String -> IO a
-startupDie startup message =
-    case startup.startupFullscreen of
-        Nothing -> die message
-        Just _ -> throwIO (StartupFailure message)
 
 reportStartupWarning :: StartupRuntime -> Text -> IO ()
 reportStartupWarning startup message =
@@ -3820,105 +3794,6 @@ runSession SessionRequest{..} SessionBackend{..} = do
     _ <- waitForSessionTitleResults 5000000 titleManager
     applyPendingSessionTitles env
     pure result
-
-loadStartupAuth
-    :: StartupRuntime
-    -> Maybe ProviderTransition
-    -> Maybe Provider
-    -> IO (LoadedAuth, Bool)
-loadStartupAuth startup transition requestedProvider =
-    loadTransitionAuth transition requestedProvider >>= \case
-        Right loaded -> pure (loaded, False)
-        Left err
-            | isNothing transition
-            , authErrorNeedsOnboarding err
-            , Just runtime <- startup.startupFullscreen ->
-                runCredentialOnboarding startup runtime
-                    >>= \(provider, learnAboutUser) ->
-                        loadAuth (Just provider)
-                            >>= either
-                                (startupDie startup . Text.unpack)
-                                (\loaded -> pure (loaded, learnAboutUser))
-            | otherwise ->
-                startupDie startup (Text.unpack err)
-
-loadTransitionAuth
-    :: Maybe ProviderTransition
-    -> Maybe Provider
-    -> IO (Either Text LoadedAuth)
-loadTransitionAuth transition requestedProvider =
-    case transition of
-        Just active
-            | Just selectionId <- active.transitionAccountSelectionId ->
-                loadSelectedAccountAuth
-                    active.transitionTarget.targetProvider
-                    selectionId
-                    (fromMaybe selectionId active.transitionAccountId)
-        _ -> loadAuth requestedProvider
-
-runCredentialOnboarding
-    :: StartupRuntime
-    -> FullscreenRuntime
-    -> IO (Provider, Bool)
-runCredentialOnboarding startup runtime = do
-    markStartupStage startup "Choose how to connect…"
-    loop
-  where
-    choices =
-        [ ( OpenAIProvider
-          , ("Sign in with ChatGPT", "Use an OpenAI subscription")
-          )
-        , ( XAIProvider
-          , ("Sign in with Grok", "Use an xAI subscription")
-          )
-        , ( OpenRouterProvider
-          , ("Add an OpenRouter API key", "Use API credits")
-          )
-        ]
-    loop =
-        requestFullscreenOnboarding
-            runtime
-            "Welcome to haskell-agent"
-            "haskell-agent can access AI models with a subscription or API key."
-            (map snd choices)
-            >>= \case
-                Nothing -> throwIO StartupCancelled
-                Just index ->
-                    case atMay index choices of
-                        Nothing -> loop
-                        Just (provider, _) -> do
-                            connected <-
-                                withFullscreenSuspended runtime $
-                                    resolveColor stderr >>= \color ->
-                                        connectProviderAccount color provider
-                            case connected of
-                                Nothing -> loop
-                                Just _ -> do
-                                    markStartupStage startup
-                                        "Personalize your agent…"
-                                    learnAboutUser <-
-                                        requestFullscreenOnboarding
-                                            runtime
-                                            "Personalize your agent"
-                                            "haskell-agent can learn your technical defaults from a confirmed public GitHub profile. You review the profile before anything is saved."
-                                            [ ( "Learn from my GitHub"
-                                              , "Inspect public repositories and propose a technical profile"
-                                              )
-                                            , ( "Skip for now"
-                                              , "Run /learn-about-user whenever you want"
-                                              )
-                                            ]
-                                    pure (provider, learnAboutUser == Just 0)
-
-learnAboutUserOnboardingPrompt :: [LearnedSkill] -> Maybe Text
-learnAboutUserOnboardingPrompt learnedSkills
-    | any
-        ((== "user-technical-profile") . (.learnedSkillSlug))
-        learnedSkills =
-            Nothing
-    | otherwise =
-        Just
-            "$learn-about-user Learn my technical preferences from my public GitHub profile, show me the proposed profile, and ask before saving it."
 
 runPendingTurn
     :: PendingTurnPresentation

--- a/packages/agent-cli/src/Agent/CLI/Startup/Auth.hs
+++ b/packages/agent-cli/src/Agent/CLI/Startup/Auth.hs
@@ -1,0 +1,193 @@
+-- | Startup authentication, credential onboarding, and progress reporting.
+module Agent.CLI.Startup.Auth
+    ( learnAboutUserOnboardingPrompt
+    , loadStartupAuth
+    , markStartupStage
+    , recordStartupTiming
+    , setStartupNotice
+    , startupDie
+    ) where
+
+import Agent.CLI.Auth
+    ( LoadedAuth
+    , authErrorNeedsOnboarding
+    , loadAuth
+    )
+import Agent.CLI.Login (connectProviderAccount)
+import Agent.CLI.Models (ModelTarget(..))
+import Agent.CLI.Provider.Switch (loadSelectedAccountAuth)
+import Agent.CLI.ProviderTransition (ProviderTransition(..))
+import Agent.CLI.Runtime.Types
+    ( StartupCancelled(..)
+    , StartupFailure(..)
+    , StartupRuntime(..)
+    )
+import Agent.CLI.Terminal (resolveColor)
+import Agent.CLI.TUI.App
+    ( FullscreenRuntime
+    , emitUiEvent
+    , requestFullscreenOnboarding
+    , withFullscreenSuspended
+    )
+import Agent.Provider
+    ( Provider(..)
+    )
+import Agent.Store.Postgres.Skill (LearnedSkill(..))
+import Agent.TUI.Model
+    ( UiEvent(..)
+    , progressNotice
+    )
+import Control.Exception.Safe (throwIO)
+import Data.IORef
+    ( IORef
+    , atomicModifyIORef'
+    )
+import Data.Maybe
+    ( fromMaybe
+    , isNothing
+    )
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Data.Time.Clock
+    ( NominalDiffTime
+    , UTCTime
+    , diffUTCTime
+    , getCurrentTime
+    )
+import System.Exit (die)
+import System.IO (stderr)
+
+setStartupNotice :: Maybe FullscreenRuntime -> Text -> IO ()
+setStartupNotice fullscreen message =
+    case fullscreen of
+        Nothing -> pure ()
+        Just runtime ->
+            emitUiEvent runtime
+                (UiSetNotice (Just (progressNotice message)))
+
+recordStartupTiming
+    :: UTCTime
+    -> IORef [(Text, NominalDiffTime)]
+    -> Text
+    -> IO ()
+recordStartupTiming startedAt timingsRef label = do
+    elapsed <- (`diffUTCTime` startedAt) <$> getCurrentTime
+    atomicModifyIORef' timingsRef \timings ->
+        (timings <> [(label, elapsed)], ())
+
+markStartupStage :: StartupRuntime -> Text -> IO ()
+markStartupStage startup label = do
+    recordStartupTiming startup.startupStartedAt startup.startupTimings label
+    setStartupNotice startup.startupFullscreen label
+
+startupDie :: StartupRuntime -> String -> IO a
+startupDie startup message =
+    case startup.startupFullscreen of
+        Nothing -> die message
+        Just _ -> throwIO (StartupFailure message)
+
+loadStartupAuth
+    :: StartupRuntime
+    -> Maybe ProviderTransition
+    -> Maybe Provider
+    -> IO (LoadedAuth, Bool)
+loadStartupAuth startup transition requestedProvider =
+    loadTransitionAuth transition requestedProvider >>= \case
+        Right loaded -> pure (loaded, False)
+        Left err
+            | isNothing transition
+            , authErrorNeedsOnboarding err
+            , Just runtime <- startup.startupFullscreen ->
+                runCredentialOnboarding startup runtime
+                    >>= \(provider, learnAboutUser) ->
+                        loadAuth (Just provider)
+                            >>= either
+                                (startupDie startup . Text.unpack)
+                                (\loaded -> pure (loaded, learnAboutUser))
+            | otherwise ->
+                startupDie startup (Text.unpack err)
+
+loadTransitionAuth
+    :: Maybe ProviderTransition
+    -> Maybe Provider
+    -> IO (Either Text LoadedAuth)
+loadTransitionAuth transition requestedProvider =
+    case transition of
+        Just active
+            | Just selectionId <- active.transitionAccountSelectionId ->
+                loadSelectedAccountAuth
+                    active.transitionTarget.targetProvider
+                    selectionId
+                    (fromMaybe selectionId active.transitionAccountId)
+        _ -> loadAuth requestedProvider
+
+runCredentialOnboarding
+    :: StartupRuntime
+    -> FullscreenRuntime
+    -> IO (Provider, Bool)
+runCredentialOnboarding startup runtime = do
+    markStartupStage startup "Choose how to connect…"
+    loop
+  where
+    choices =
+        [ ( OpenAIProvider
+          , ("Sign in with ChatGPT", "Use an OpenAI subscription")
+          )
+        , ( XAIProvider
+          , ("Sign in with Grok", "Use an xAI subscription")
+          )
+        , ( OpenRouterProvider
+          , ("Add an OpenRouter API key", "Use API credits")
+          )
+        ]
+    loop =
+        requestFullscreenOnboarding
+            runtime
+            "Welcome to haskell-agent"
+            "haskell-agent can access AI models with a subscription or API key."
+            (map snd choices)
+            >>= \case
+                Nothing -> throwIO StartupCancelled
+                Just index ->
+                    case atMay index choices of
+                        Nothing -> loop
+                        Just (provider, _) -> do
+                            connected <-
+                                withFullscreenSuspended runtime $
+                                    resolveColor stderr >>= \color ->
+                                        connectProviderAccount color provider
+                            case connected of
+                                Nothing -> loop
+                                Just _ -> do
+                                    markStartupStage startup
+                                        "Personalize your agent…"
+                                    learnAboutUser <-
+                                        requestFullscreenOnboarding
+                                            runtime
+                                            "Personalize your agent"
+                                            "haskell-agent can learn your technical defaults from a confirmed public GitHub profile. You review the profile before anything is saved."
+                                            [ ( "Learn from my GitHub"
+                                              , "Inspect public repositories and propose a technical profile"
+                                              )
+                                            , ( "Skip for now"
+                                              , "Run /learn-about-user whenever you want"
+                                              )
+                                            ]
+                                    pure (provider, learnAboutUser == Just 0)
+
+learnAboutUserOnboardingPrompt :: [LearnedSkill] -> Maybe Text
+learnAboutUserOnboardingPrompt learnedSkills
+    | any
+        ((== "user-technical-profile") . (.learnedSkillSlug))
+        learnedSkills =
+            Nothing
+    | otherwise =
+        Just
+            "$learn-about-user Learn my technical preferences from my public GitHub profile, show me the proposed profile, and ask before saving it."
+
+atMay :: Int -> [a] -> Maybe a
+atMay index values
+    | index < 0 = Nothing
+    | otherwise = case drop index values of
+        value : _ -> Just value
+        [] -> Nothing


### PR DESCRIPTION
## Summary
- move startup credential loading and transition auth into `Agent.CLI.Startup.Auth`
- isolate first-run credential and personalization onboarding
- centralize startup progress timing, notices, and fatal error routing
- reduce `Agent.CLI.Runtime` while preserving behavior

## Validation
- `printf ":quit\n" | nix develop -c cabal repl agent-cli:lib:agent-cli --repl-options=-fno-code` (111 modules)
- `printf ":main\n:q\n" | TMPDIR=/tmp nix develop -c cabal repl agent-cli:test:agent-cli-test` (874 examples, 0 failures)
- `git diff --check`