### PR TITLE
Render conversation tool results as readable text

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/AgentSessions.hs
+++ b/packages/agent-cli/src/Agent/CLI/AgentSessions.hs
@@ -21,7 +21,7 @@ import Agent.CLI.ManagedTurn (ManagedTurnRequest)
 import Agent.CLI.Error (formatException)
 import Agent.CLI.Session
     ( SessionCreate(..)
-    , SessionActivity
+    , SessionActivity(..)
     , SessionHandle(..)
     , SessionMeta(..)
     , SessionTurn(..)
@@ -65,15 +65,13 @@ import Control.Concurrent.MVar
     )
 import Control.Exception.Safe (SomeException, try)
 import Control.Monad (forM_)
-import Data.Aeson (FromJSON(..), Value, encode, object, (.=))
-import qualified Data.Aeson as Aeson
+import Data.Aeson (FromJSON(..), encode)
 import qualified Data.ByteString.Lazy as LBS
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
-import qualified Data.Text.Encoding as TextEncoding
 import qualified Data.Text.IO as TextIO
 import System.Directory
     ( findExecutable
@@ -532,7 +530,7 @@ instance FromJSON CreateAgentSessionArgs where
 createAgentSessionTool :: AgentSessionToolsEnv -> AppTool
 createAgentSessionTool env = jsonTool
     "create_agent_session"
-    "Create a persisted top-level agent session and start its first turn in the background. Returns the session id immediately."
+    "Create a persisted top-level agent session and start its first turn in the background. Returns the session id and status as readable text."
     [ PropertySchema "message" PropertyString True $ Just
         "Initial task or message for the new agent session."
     , PropertySchema "title" PropertyString False $ Just
@@ -616,7 +614,7 @@ instance FromJSON ReadAgentSessionArgs where
 readAgentSessionTool :: AgentSessionToolsEnv -> AppTool
 readAgentSessionTool env = jsonTool
     "read_agent_session"
-    "Read metadata and recent user/assistant turns from a persisted agent session."
+    "Read metadata and recent user/assistant turns from a persisted agent session as readable labeled text."
     [ PropertySchema "session_id" PropertyString True $ Just
         "Persisted session id returned by create_agent_session or shown by /session."
     , PropertySchema "limit" PropertyInteger False $ Just
@@ -641,10 +639,7 @@ runReadAgentSession env args =
                     else pure Nothing
             let limit = min 100 (max 1 (fromMaybe 20 args.limit))
                 recent = drop (max 0 (length turns - limit)) turns
-            pure $ Right $ encodeJson $ object
-                [ "session" .= sessionJson meta status activity
-                , "turns" .= map turnJson recent
-                ]
+            pure $ Right $ renderAgentSession meta status activity recent
 
 data SendAgentSessionMessageArgs = SendAgentSessionMessageArgs
     { sessionId :: Text
@@ -659,7 +654,7 @@ instance FromJSON SendAgentSessionMessageArgs where
 sendAgentSessionMessageTool :: AgentSessionToolsEnv -> AppTool
 sendAgentSessionMessageTool env = jsonTool
     "send_agent_session_message"
-    "Send a message to a persisted agent session by starting a resumed background turn. Fails if that session is already running."
+    "Send a message to a persisted agent session by starting a resumed background turn. Returns the session id and status as readable text; fails if that session is already running."
     [ PropertySchema "session_id" PropertyString True $ Just
         "Persisted target session id."
     , PropertySchema "message" PropertyString True $ Just
@@ -699,10 +694,7 @@ launchToolSessionTurn env handle message =
         Right launchResult -> do
             let sessionId = handle.sessionMeta.metaId
             status <- statusAfterLaunch env sessionId launchResult
-            pure $ Right $ encodeJson $ object
-                [ "session_id" .= sessionId
-                , "status" .= status
-                ]
+            pure $ Right $ renderSessionLaunch sessionId status
 
 sessionHandle :: StorePool -> OsPath -> SessionMeta -> SessionHandle
 sessionHandle pool root meta =
@@ -726,29 +718,66 @@ statusAfterLaunch env sessionId launchResult
     | "completed session " `Text.isPrefixOf` launchResult = pure "completed"
     | otherwise = env.toolsSessionStatus sessionId
 
-sessionJson :: SessionMeta -> Text -> Maybe SessionActivity -> Value
-sessionJson meta status activity = object
-    [ "id" .= meta.metaId
-    , "status" .= status
-    , "title" .= meta.metaTitle
-    , "provider" .= providerSlug meta.metaProvider
-    , "connection" .= meta.metaConnection
-    , "model" .= meta.metaModel
-    , "dialect" .= dialectSlug meta.metaDialect
-    , "reasoning_effort" .= meta.metaEffort
-    , "cwd" .= unsafeToFilePath meta.metaCwd
-    , "created_at" .= meta.metaCreatedAt
-    , "updated_at" .= meta.metaUpdatedAt
-    , "activity" .= activity
-    ]
+renderSessionLaunch :: Text -> Text -> Text
+renderSessionLaunch sessionId status =
+    "Session: " <> sessionId <> "\nStatus: " <> status
 
-turnJson :: SessionTurn -> Value
-turnJson turn = object
-    [ "at" .= turn.turnAt
-    , "user" .= turn.turnUserText
-    , "assistant" .= turn.turnAssistantText
-    , "error" .= turn.turnError
-    ]
+renderAgentSession
+    :: SessionMeta
+    -> Text
+    -> Maybe SessionActivity
+    -> [SessionTurn]
+    -> Text
+renderAgentSession meta status activity turns =
+    Text.intercalate "\n" $
+        [ "Session"
+        , "  ID: " <> meta.metaId
+        , "  Status: " <> status
+        , "  Title: " <> meta.metaTitle
+        , "  Provider: " <> providerSlug meta.metaProvider
+        , "  Connection: " <> meta.metaConnection
+        , "  Model: " <> meta.metaModel
+        , "  Dialect: " <> dialectSlug meta.metaDialect
+        , "  Reasoning effort: " <> meta.metaEffort
+        , "  Working directory: " <> Text.pack (unsafeToFilePath meta.metaCwd)
+        , "  Created at: " <> Text.pack (show meta.metaCreatedAt)
+        , "  Updated at: " <> Text.pack (show meta.metaUpdatedAt)
+        ]
+            <> maybe [] renderActivity activity
+            <> ["", "Recent turns: " <> Text.pack (show (length turns))]
+            <> case turns of
+                [] -> ["  (none)"]
+                _ -> [""] <> intercalateBlank
+                    (zipWith renderSessionTurn [1 :: Int ..] turns)
 
-encodeJson :: Value -> Text
-encodeJson = TextEncoding.decodeUtf8 . LBS.toStrict . Aeson.encode
+renderActivity :: SessionActivity -> [Text]
+renderActivity activity =
+    [ ""
+    , "Current activity"
+    , "  Kind: " <> activity.activityKind
+    , "  Message: " <> activity.activityMessage
+    ]
+        <> maybe []
+            (\retryAt -> ["  Retry at: " <> Text.pack (show retryAt)])
+            activity.activityRetryAt
+        <> ["  Updated at: " <> Text.pack (show activity.activityUpdatedAt)]
+
+renderSessionTurn :: Int -> SessionTurn -> [Text]
+renderSessionTurn index turn =
+    [ "Turn " <> Text.pack (show index)
+    , "At: " <> Text.pack (show turn.turnAt)
+    , "User:"
+    , indentText turn.turnUserText
+    ]
+        <> maybe [] (\text -> ["Assistant:", indentText text])
+            turn.turnAssistantText
+        <> maybe [] (\text -> ["Error:", indentText text])
+            turn.turnError
+
+intercalateBlank :: [[Text]] -> [Text]
+intercalateBlank = \case
+    [] -> []
+    first : rest -> first <> concatMap ("" :) rest
+
+indentText :: Text -> Text
+indentText = Text.intercalate "\n" . map ("  " <>) . Text.lines

--- a/packages/agent-cli/src/Agent/CLI/Database.hs
+++ b/packages/agent-cli/src/Agent/CLI/Database.hs
@@ -49,9 +49,11 @@ instance FromJSON DatabaseScope where
 
 -- | Storage callbacks for the three model-facing database operations.
 --
--- Successful values are encoded as JSON in the tool result.  Store errors are
--- already sanitized 'Text' because database exception details can contain SQL
--- values that should not be copied into the transcript.
+-- Structured database values are encoded as JSON in the tool result. Conversation
+-- search is rendered as labeled text because its results are primarily read by
+-- the model and by humans rather than consumed as a machine-readable payload.
+-- Store errors are already sanitized 'Text' because database exception details
+-- can contain SQL values that should not be copied into the transcript.
 data DatabaseToolsEnv = DatabaseToolsEnv
     { databaseDescribeScope
         :: !(DatabaseScope -> IO (Either Text Value))
@@ -105,6 +107,23 @@ instance FromJSON ConversationSearchArgs where
         ConversationSearchArgs
             <$> object .: "query"
             <*> (object .:? "limit" >>= pure . maybe 10 id)
+
+data ConversationSearchMatch
+    = ConversationSearchMatch
+        !Text
+        !Integer
+        !(Maybe Text)
+        !Text
+        !(Maybe Text)
+
+instance FromJSON ConversationSearchMatch where
+    parseJSON = withObject "ConversationSearchMatch" \object ->
+        ConversationSearchMatch
+            <$> object .: "session_id"
+            <*> object .: "turn_index"
+            <*> object .:? "occurred_at"
+            <*> object .: "user_text"
+            <*> object .:? "assistant_text"
 
 databaseTools :: DatabaseToolsEnv -> [AppTool]
 databaseTools env =
@@ -184,7 +203,8 @@ conversationSearchTool env = jsonTool
     "conversation_search"
     ( "Search user and assistant messages from past, non-deleted conversations. "
         <> "Use this when earlier decisions, preferences, facts, or work may be "
-        <> "relevant. Results are ranked by PostgreSQL full-text search."
+        <> "relevant. Results are ranked by PostgreSQL full-text search and "
+        <> "returned as readable labeled text."
     )
     [ PropertySchema "query" PropertyString True $ Just
         "Words or a natural-language web-search-style query."
@@ -198,7 +218,8 @@ conversationSearchTool env = jsonTool
             then pure (Left "conversation search query must not be empty")
             else if limit < 1 || limit > 100
                 then pure (Left "conversation search limit must be between 1 and 100")
-                else encodeResult <$> env.databaseSearchConversations query limit)
+                else fmap (>>= renderConversationSearchResult) $
+                    env.databaseSearchConversations query limit)
 
 scopeProperty :: PropertySchema
 scopeProperty = PropertySchema
@@ -213,3 +234,32 @@ scopeProperty = PropertySchema
 encodeResult :: Either Text Value -> Either Text Text
 encodeResult =
     fmap (Text.decodeUtf8 . LBS.toStrict . Aeson.encode)
+
+renderConversationSearchResult :: Value -> Either Text Text
+renderConversationSearchResult value =
+    case Aeson.fromJSON value of
+        Aeson.Error errorMessage ->
+            Left $
+                "conversation search returned an unexpected result: "
+                    <> Text.pack errorMessage
+        Aeson.Success matches ->
+            Right $ case matches of
+                [] -> "(no matching conversations)"
+                _ -> Text.intercalate "\n\n" $
+                    zipWith renderConversationSearchMatch [1 :: Int ..] matches
+
+renderConversationSearchMatch :: Int -> ConversationSearchMatch -> Text
+renderConversationSearchMatch
+    matchNumber
+    (ConversationSearchMatch sessionId turnIndex occurredAt userText assistantText) =
+        Text.intercalate "\n" $
+            [ "Match " <> Text.pack (show matchNumber)
+            , "Session: " <> sessionId
+            , "Turn: " <> Text.pack (show turnIndex)
+            ]
+                <> maybe [] (\timestamp -> ["Occurred at: " <> timestamp]) occurredAt
+                <> ["User:", indentText userText]
+                <> maybe [] (\text -> ["Assistant:", indentText text]) assistantText
+
+indentText :: Text -> Text
+indentText = Text.intercalate "\n" . map ("  " <>) . Text.lines

--- a/packages/agent-cli/test/Agent/CLI/AgentSessionsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/AgentSessionsSpec.hs
@@ -67,7 +67,7 @@ spec = describe "Agent.CLI.AgentSessions" do
         withTempEnv \env launched -> do
             result <- runTool env "create_agent_session"
                 "{\"message\":\"investigate this\",\"title\":\"worker\",\"model\":\"model-2\",\"reasoning_effort\":\"high\"}"
-            result `shouldSatisfy` Text.isInfixOf "\"status\":\"running\""
+            result `shouldSatisfy` Text.isInfixOf "Status: running"
             [(handle, message)] <- readIORef launched
             message `shouldBe` "investigate this"
             handle.sessionMeta.metaTitle `shouldBe` "worker"
@@ -112,9 +112,9 @@ spec = describe "Agent.CLI.AgentSessions" do
                 }
             result <- runTool env "read_agent_session" $
                 "{\"session_id\":\"" <> handle.sessionMeta.metaId <> "\"}"
-            result `shouldSatisfy` Text.isInfixOf "\"user\":\"question\""
-            result `shouldSatisfy` Text.isInfixOf "\"assistant\":\"answer\""
-            result `shouldNotSatisfy` Text.isInfixOf "\"items\""
+            result `shouldSatisfy` Text.isInfixOf "User:\n  question"
+            result `shouldSatisfy` Text.isInfixOf "Assistant:\n  answer"
+            result `shouldNotSatisfy` Text.isInfixOf "items"
 
     it "includes ephemeral retry activity while a session is running" $
         withTempEnv \env _ -> do
@@ -128,9 +128,9 @@ spec = describe "Agent.CLI.AgentSessions" do
             result <- runTool env "read_agent_session" $
                 "{\"session_id\":\"" <> handle.sessionMeta.metaId <> "\"}"
             result `shouldSatisfy`
-                Text.isInfixOf "\"kind\":\"provider_cooldown\""
+                Text.isInfixOf "Kind: provider_cooldown"
             result `shouldSatisfy`
-                Text.isInfixOf "\"message\":\"Waiting before retrying.\""
+                Text.isInfixOf "Message: Waiting before retrying."
 
     it "starts a follow-up turn and rejects messaging the current session" $
         withTempEnv \env launched -> do
@@ -139,7 +139,7 @@ spec = describe "Agent.CLI.AgentSessions" do
                 targetEnv = env { toolsCurrentSessionId = pure (Just "other") }
             result <- runTool targetEnv "send_agent_session_message" $
                 "{\"session_id\":\"" <> target <> "\",\"message\":\"continue\"}"
-            result `shouldSatisfy` Text.isInfixOf "\"status\":\"running\""
+            result `shouldSatisfy` Text.isInfixOf "Status: running"
             [(launchedHandle, message)] <- readIORef launched
             launchedHandle.sessionMeta.metaId `shouldBe` target
             message `shouldBe` "continue"

--- a/packages/agent-cli/test/Agent/CLI/DatabaseSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/DatabaseSpec.hs
@@ -15,6 +15,7 @@ import Agent.Tools.Types
 import Agent.ToolDispatch (dispatchToolCall)
 import Control.Exception.Safe (displayException)
 import Data.Aeson (object, (.=))
+import qualified Data.Aeson as Aeson
 import Data.IORef
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -64,14 +65,44 @@ spec = do
             let env = testEnv
                     { databaseSearchConversations = \query limit -> do
                         writeIORef seen (Just (query, limit))
-                        pure (Right (object ["matches" .= ([] :: [Text])]))
+                        pure (Right (Aeson.toJSON
+                            [ object
+                                [ "session_id" .= ("session-1" :: Text)
+                                , "turn_index" .= (4 :: Int)
+                                , "occurred_at" .= ("2026-08-24T09:30:00Z" :: Text)
+                                , "user_text" .= ("How should we store this?" :: Text)
+                                , "assistant_text" .=
+                                    Just ("Use PostgreSQL.\nKeep scopes explicit." :: Text)
+                                , "rank" .= (0.8 :: Double)
+                                ]
+                            ]))
                     }
             result <- dispatchToolCall dispatchConfig
                 (appToolHandlers (databaseTools env))
                 (functionToolCall "call-4" "conversation_search"
                     "{\"query\":\"postgres memory\",\"limit\":5}")
             readIORef seen `shouldReturn` Just ("postgres memory", 5)
-            result.output `shouldContainText` "\"matches\""
+            result.output `shouldBe`
+                "Match 1\n\
+                \Session: session-1\n\
+                \Turn: 4\n\
+                \Occurred at: 2026-08-24T09:30:00Z\n\
+                \User:\n\
+                \  How should we store this?\n\
+                \Assistant:\n\
+                \  Use PostgreSQL.\n\
+                \  Keep scopes explicit."
+
+        it "renders an empty conversation search result as text" do
+            let env = testEnv
+                    { databaseSearchConversations = \_ _ ->
+                        pure (Right (Aeson.toJSON ([] :: [Aeson.Value])))
+                    }
+            result <- dispatchToolCall dispatchConfig
+                (appToolHandlers (databaseTools env))
+                (functionToolCall "call-5" "conversation_search"
+                    "{\"query\":\"nothing\"}")
+            result.output `shouldBe` "(no matching conversations)"
 
     describe "runStorageCommand" do
         it "dispatches each administrative command to its store action" do
@@ -112,7 +143,8 @@ testEnv = DatabaseToolsEnv
     { databaseDescribeScope = \_ -> pure (Right (object []))
     , databaseRunQuery = \_ _ -> pure (Right (object []))
     , databaseRunExecute = \_ _ _ -> pure (Right (object []))
-    , databaseSearchConversations = \_ _ -> pure (Right (object []))
+    , databaseSearchConversations = \_ _ ->
+        pure (Right (Aeson.toJSON ([] :: [Aeson.Value])))
     }
 
 dispatchConfig :: ToolDispatchConfig

--- a/packages/agent-tui/src/Agent/TUI/Presentation.hs
+++ b/packages/agent-tui/src/Agent/TUI/Presentation.hs
@@ -175,6 +175,9 @@ toolVerb name = case canonicalToolName name of
     "followup_task" -> "Followed up with"
     "list_agents" -> "Listed agents"
     "interrupt_agent" -> "Interrupted"
+    "create_agent_session" -> "Created agent session"
+    "read_agent_session" -> "Read agent session"
+    "send_agent_session_message" -> "Messaged agent session"
     "update_plan" -> "Updated"
     "enter_plan_mode" -> "Entered"
     "exit_plan_mode" -> "Exited"
@@ -186,6 +189,7 @@ toolVerb name = case canonicalToolName name of
     "skill_update" -> "Updated skill"
     "skill_archive" -> "Archived skill"
     "skill_rollback" -> "Restored skill"
+    "conversation_search" -> "Searched conversations"
     other -> other
 
 toolDetail :: ToolCall -> Text
@@ -214,6 +218,12 @@ toolDetail call = case canonicalToolName call.name of
     "send_message" -> jsonTextFieldDefault "target" call.arguments
     "followup_task" -> jsonTextFieldDefault "target" call.arguments
     "interrupt_agent" -> jsonTextFieldDefault "target" call.arguments
+    "create_agent_session" ->
+        firstLine (jsonTextFieldDefault "title" call.arguments)
+    "read_agent_session" ->
+        jsonTextFieldDefault "session_id" call.arguments
+    "send_agent_session_message" ->
+        jsonTextFieldDefault "session_id" call.arguments
     "list_agents" ->
         maybe "" ("under " <>) (nonEmptyJsonText "path_prefix" call.arguments)
     "skill_search" -> firstLine (jsonTextFieldDefault "query" call.arguments)
@@ -222,6 +232,8 @@ toolDetail call = case canonicalToolName call.name of
     "skill_update" -> skillIdentity call.arguments
     "skill_archive" -> skillIdentity call.arguments
     "skill_rollback" -> skillIdentity call.arguments
+    "conversation_search" ->
+        firstLine (jsonTextFieldDefault "query" call.arguments)
     _ -> ""
 
 skillIdentity :: Text -> Text

--- a/packages/agent-tui/test/Agent/TUI/PresentationSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/PresentationSpec.hs
@@ -139,3 +139,28 @@ spec = describe "tool presentation" do
         formatToolOutput call
             "{\"agents\":[{\"agent_status\":\"running\"},null]}"
             `shouldBe` "(no live agents)"
+
+    it "summarizes conversation search calls while preserving text output" do
+        let call = functionToolCall
+                "search"
+                "conversation_search"
+                "{\"query\":\"postgres memory\",\"limit\":5}"
+        summarizeToolCall call
+            `shouldBe` "Searched conversations postgres memory"
+        formatToolOutput call "Match 1\nUser:\n  A question"
+            `shouldBe` "Match 1\nUser:\n  A question"
+
+    it "summarizes persisted agent-session conversation tools" do
+        let create = functionToolCall
+                "create" "create_agent_session"
+                "{\"message\":\"work\",\"title\":\"research\"}"
+            readSession = functionToolCall
+                "read" "read_agent_session"
+                "{\"session_id\":\"session-1\",\"limit\":20}"
+            message = functionToolCall
+                "message" "send_agent_session_message"
+                "{\"session_id\":\"session-1\",\"message\":\"continue\"}"
+        summarizeToolCall create `shouldBe` "Created agent session research"
+        summarizeToolCall readSession `shouldBe` "Read agent session session-1"
+        summarizeToolCall message `shouldBe`
+            "Messaged agent session session-1"


### PR DESCRIPTION
## Summary

- return `conversation_search` matches as labeled text instead of model-facing JSON
- render persisted agent-session create, read, and message results as readable text
- add semantic TUI headings for conversation and agent-session tools
- preserve structured JSON for database tools whose results are intended for machine consumption

## Validation

- `Agent.CLI.DatabaseSpec` database-tool tests: 5 passed in GHCi
- `Agent.CLI.AgentSessionsSpec`: 18 passed in GHCi
- full `agent-tui` test suite: 137 passed in GHCi
- live tmux smoke checks confirmed both `conversation_search` and `read_agent_session` text reaches the model
- `git diff --check`
