### PR TITLE
perf(tui): retain 100 recent prompts

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TUI/Bridge.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Bridge.hs
@@ -21,7 +21,7 @@ import qualified Graphics.Vty as V
 -- | Keep enough prompt recall for normal interactive use without retaining an
 -- unbounded copy of the persistent Haskeline history in the fullscreen state.
 fullscreenHistoryLimit :: Int
-fullscreenHistoryLimit = 1000
+fullscreenHistoryLimit = 100
 
 trimHistory :: [Text] -> [Text]
 trimHistory entries =


### PR DESCRIPTION
## Summary

- reduce the fullscreen composer’s in-memory prompt recall limit from 1,000 entries to 100
- keep conversation scrollback, model transcript context, and persistent Haskeline history unchanged
- further reduce retained live memory for long prompt histories

## Benchmark

Optimized `history-retention-bench`, median of 7 samples per workload:

| Entries | Entry size | Unbounded live | Bounded live | Reduction |
|---:|---:|---:|---:|---:|
| 1,000 | 64 B | 190,888 B | 93,120 B | 51.2% |
| 10,000 | 64 B | 1,846,888 B | 453,120 B | 75.5% |
| 100,000 | 64 B | 18,406,896 B | 4,053,120 B | 78.0% |
| 10,000 | 1,024 B | 11,447,864 B | 550,096 B | 95.2% |
| 50,000 | 256 B | 18,807,096 B | 2,072,528 B | 89.0% |

## Validation

- `cabal repl agent-cli:lib:agent-cli --repl-options=-fno-code`
- `cabal test --offline agent-cli:test:agent-cli-test --test-show-details=direct` — 875 examples, 0 failures
- optimized history-retention benchmark
- fullscreen tmux launch smoke test
