### PR TITLE
Lazy-load skill instructions with view_skill

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/LearnedSkills.hs
+++ b/packages/agent-cli/src/Agent/CLI/LearnedSkills.hs
@@ -6,11 +6,18 @@ module Agent.CLI.LearnedSkills
     , LearnedSkillArchiveRequest(..)
     , LearnedSkillRollbackRequest(..)
     , learnedSkillTools
+    , defaultLearnedSkillContextMaxChars
     , formatLearnedSkillContext
     , queueLearnedSkillContextWithOmissions
     ) where
 
 import Agent.CLI.Database (DatabaseScope(..))
+import Agent.OsPath (toText)
+import Agent.Skills
+    ( Skill(..)
+    , SkillInvocation(..)
+    , resolveSkillInvocation
+    )
 import Agent.Store.Postgres.Scope
     ( Scope(..)
     , ScopeKind(..)
@@ -40,7 +47,7 @@ import qualified Data.Aeson as Aeson
 import Data.Aeson.Types (Parser)
 import qualified Data.ByteString.Lazy as LBS
 import Data.Int (Int64)
-import Data.IORef (IORef, modifyIORef')
+import Data.IORef (IORef, modifyIORef', readIORef)
 import Data.List (sortOn)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe, isJust)
@@ -120,13 +127,13 @@ instance FromJSON SearchArgs where
             <$> object .: "query"
             <*> (object .:? "limit" >>= pure . fromMaybe 10)
 
-data ReadArgs = ReadArgs !DatabaseScope !Text !(Maybe Integer)
+data ViewArgs = ViewArgs !Text !(Maybe DatabaseScope) !(Maybe Integer)
 
-instance FromJSON ReadArgs where
-    parseJSON = withObject "ReadArgs" \object ->
-        ReadArgs
-            <$> object .: "scope"
-            <*> object .: "slug"
+instance FromJSON ViewArgs where
+    parseJSON = withObject "ViewArgs" \object ->
+        ViewArgs
+            <$> object .: "name"
+            <*> object .:? "scope"
             <*> object .:? "revision"
 
 instance FromJSON LearnedSkillCreateRequest where
@@ -178,10 +185,10 @@ instance FromJSON LearnedSkillRollbackRequest where
             <*> object .: "change_summary"
             <*> object .: "evidence"
 
-learnedSkillTools :: LearnedSkillToolsEnv -> [AppTool]
-learnedSkillTools env =
+learnedSkillTools :: IORef [SkillInvocation] -> LearnedSkillToolsEnv -> [AppTool]
+learnedSkillTools invocationsRef env =
     [ searchTool env
-    , readTool env
+    , viewTool invocationsRef env
     , createTool env
     , updateTool env
     , archiveTool env
@@ -194,7 +201,7 @@ searchTool env = jsonTool
     ( "Search active reusable skills learned from earlier sessions across the "
         <> "current user, repository, and checkout scopes. Search before "
         <> "creating a skill so you update an existing lesson instead of "
-        <> "creating a duplicate. Results are summaries; use skill_read for "
+        <> "creating a duplicate. Results are summaries; use view_skill for "
         <> "the complete instructions and revision history."
     )
     [ PropertySchema "query" PropertyString True $ Just
@@ -209,30 +216,75 @@ searchTool env = jsonTool
             Left err -> pure (Left err)
             Right () -> encodeResult <$> env.learnedSkillSearch query limit)
 
-readTool :: LearnedSkillToolsEnv -> AppTool
-readTool env = jsonTool
-    "skill_read"
-    ( "Read one learned skill's complete current instructions, evidence, and "
-        <> "revision summaries. Pass an earlier revision to inspect its full "
-        <> "body and evidence before a rollback. Use this before applying a "
-        <> "relevant or manual skill listed in startup context or returned by "
-        <> "skill_search."
+viewTool :: IORef [SkillInvocation] -> LearnedSkillToolsEnv -> AppTool
+viewTool invocationsRef env = jsonTool
+    "view_skill"
+    ( "Load one skill's complete instructions on demand. For filesystem skills, "
+        <> "pass its catalog name without a scope. For learned skills, pass the "
+        <> "slug as name and its user, repository, or checkout scope. Pass an "
+        <> "earlier revision to inspect learned-skill history before rollback."
     )
-    [ scopeProperty
-    , slugProperty
+    [ PropertySchema "name" PropertyString True $ Just
+        "Filesystem skill name or learned-skill slug."
+    , PropertySchema
+        "scope"
+        (PropertyEnum ["user", "repository", "checkout"])
+        False
+        (Just "Required for learned skills; omit for filesystem skills.")
     , PropertySchema "revision" PropertyInteger False $ Just
-        "Revision body to inspect; omit for the current revision."
+        "Learned-skill revision to inspect; omit for current."
     ]
     True
     ParallelSafe
-    (typedTool "skill_read" \(ReadArgs scope slug revision) ->
-        case do
-            validateSlug slug
-            maybe (Right ()) (validatePositiveRevision "revision") revision
-        of
-            Left err -> pure (Left err)
-            Right () ->
-                encodeResult <$> env.learnedSkillRead scope slug revision)
+    (typedTool "view_skill" \(ViewArgs name scope revision) ->
+        case scope of
+            Nothing ->
+                case revision of
+                    Just _ ->
+                        pure
+                            (Left
+                                "revision requires a learned-skill scope")
+                    Nothing -> do
+                        invocations <- readIORef invocationsRef
+                        pure $
+                            encodeResult $
+                                filesystemSkillValue
+                                    <$> resolveSkillInvocation
+                                        invocations
+                                        (normalizeFilesystemSkillName name)
+            Just selected ->
+                case do
+                    validateSlug name
+                    maybe
+                        (Right ())
+                        (validatePositiveRevision "revision")
+                        revision
+                of
+                    Left err -> pure (Left err)
+                    Right () ->
+                        encodeResult
+                            <$> env.learnedSkillRead selected name revision)
+
+filesystemSkillValue :: SkillInvocation -> Value
+filesystemSkillValue invocation =
+    let skill = invocation.invocationSkill
+    in Aeson.object
+        [ "kind" Aeson..= ("filesystem" :: Text)
+        , "name" Aeson..= invocation.invocationName
+        , "title" Aeson..= skill.skillDisplayName
+        , "description" Aeson..= skill.skillDescription
+        , "when_to_use" Aeson..= skill.skillWhenToUse
+        , "instructions" Aeson..= skill.skillBody
+        , "skill_file" Aeson..= toText skill.skillPath
+        , "skill_directory" Aeson..= toText skill.skillDirectory
+        ]
+
+normalizeFilesystemSkillName :: Text -> Text
+normalizeFilesystemSkillName raw =
+    case Text.uncons (Text.strip raw) of
+        Just (prefix, name)
+            | prefix == '$' || prefix == '/' -> name
+        _ -> Text.strip raw
 
 createTool :: LearnedSkillToolsEnv -> AppTool
 createTool env = jsonTool
@@ -270,7 +322,7 @@ createTool env = jsonTool
 updateTool :: LearnedSkillToolsEnv -> AppTool
 updateTool env = jsonTool
     "skill_update"
-    ( "Create a new immutable revision of an existing learned skill. Read the "
+    ( "Create a new immutable revision of an existing learned skill. View the "
         <> "skill first and pass its current revision for optimistic "
         <> "concurrency. Supply only fields that should change, plus evidence "
         <> "and a change summary. Use skill_archive instead of rewriting a "
@@ -324,7 +376,7 @@ rollbackTool :: LearnedSkillToolsEnv -> AppTool
 rollbackTool env = jsonTool
     "skill_rollback"
     ( "Restore the contents and status of an earlier learned-skill revision "
-        <> "as a new immutable revision. Read the skill history first and pass "
+        <> "as a new immutable revision. View the skill history first and pass "
         <> "the current revision for optimistic concurrency. This mutating "
         <> "tool requires approval."
     )
@@ -384,7 +436,7 @@ expectedRevisionProperty = PropertySchema
     "expected_revision"
     PropertyInteger
     True
-    (Just "Current revision returned by skill_read; prevents lost updates.")
+    (Just "Current revision returned by view_skill; prevents lost updates.")
 
 changeSummaryProperty :: PropertySchema
 changeSummaryProperty = PropertySchema
@@ -568,6 +620,9 @@ encodeResult :: Either Text Value -> Either Text Text
 encodeResult =
     fmap (Text.decodeUtf8 . LBS.toStrict . Aeson.encode)
 
+defaultLearnedSkillContextMaxChars :: Int
+defaultLearnedSkillContextMaxChars = 8000
+
 formatLearnedSkillContext
     :: Int
     -> [LearnedSkill]
@@ -624,11 +679,11 @@ contextHeader :: Text
 contextHeader =
     "<learned-skills>\n\
     \These are durable, reusable instructions learned from earlier sessions. \
-    \Apply every skill marked `always`. For `relevant` skills, call skill_read \
-    \when its applicability matches the task. Apply `manual` skills only when \
-    \explicitly requested or intentionally selected. When instructions \
-    \conflict, checkout scope overrides repository scope, which overrides user \
-    \scope.\n\n"
+    \Apply every skill marked `always`. For `relevant` skills, call view_skill \
+    \with its name and scope when its applicability matches the task. Apply \
+    \`manual` skills only when explicitly requested or intentionally selected. \
+    \When instructions conflict, checkout scope overrides repository scope, \
+    \which overrides user scope.\n\n"
 
 contextFooter :: Text
 contextFooter = "\n</learned-skills>"

--- a/packages/agent-cli/src/Agent/CLI/Prompt.hs
+++ b/packages/agent-cli/src/Agent/CLI/Prompt.hs
@@ -142,7 +142,7 @@ learnedSkillGuidance available
     | otherwise =
         Text.unlines
             [ "Learned skills:"
-            , "- Use skill_search and skill_read when reusable guidance from earlier sessions may apply."
+            , "- Use skill_search and view_skill when reusable guidance from earlier sessions may apply."
             , "- When the user establishes a durable preference, decision, lesson, or repeatable procedure that will help future sessions, consider promoting it with skill_create or skill_update."
             , "- Store actionable reusable guidance, not ordinary facts or transient task state. Search before creating, prefer updating an existing skill, and choose the narrowest correct scope."
             ]

--- a/packages/agent-cli/src/Agent/CLI/Render.hs
+++ b/packages/agent-cli/src/Agent/CLI/Render.hs
@@ -939,7 +939,7 @@ toolChrome name = case canonicalToolName name of
     "exit_plan_mode" -> ToolChrome "Exited" ToolDetailMuted
     "ask_user_question" -> ToolChrome "Asked" ToolDetailMuted
     "skill_search" -> ToolChrome "Searched skills" ToolDetailMuted
-    "skill_read" -> ToolChrome "Read skill" ToolDetailMuted
+    "view_skill" -> ToolChrome "Viewed skill" ToolDetailMuted
     "skill_create" -> ToolChrome "Learned" ToolDetailMuted
     "skill_update" -> ToolChrome "Updated skill" ToolDetailMuted
     "skill_archive" -> ToolChrome "Archived skill" ToolDetailMuted

--- a/packages/agent-cli/src/Agent/CLI/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime.hs
@@ -136,7 +136,8 @@ import Agent.CLI.Database.Storage
     , runStorageCommand
     )
 import Agent.CLI.LearnedSkills
-    ( learnedSkillTools
+    ( defaultLearnedSkillContextMaxChars
+    , learnedSkillTools
     , queueLearnedSkillContextWithOmissions
     )
 import Agent.CLI.LearnedSkills.Store
@@ -530,7 +531,6 @@ import Agent.Skills
     , SkillCatalog(..)
     , SkillInvocation(..)
     , SkillWarning(..)
-    , defaultSkillCatalogMaxChars
     , formatSkillActivation
     , resolveSkillInvocation
     , resolveSkillMentions
@@ -2129,6 +2129,8 @@ runAgentInitializedWithLock
         Nothing -> pure ()
     ghciEnabledRef <- newIORef options.optGhci
     bashEnabledRef <- newIORef options.optBash
+    skillsRef <- newIORef (SkillCatalog [] [])
+    skillInvocationsRef <- newIORef []
     let claimCurrentSession handle = do
             let desired = sessionLockPath handle.sessionDir
             readIORef activeSessionLock >>= \case
@@ -2184,7 +2186,8 @@ runAgentInitializedWithLock
         sessionTools = agentSessionTools sessionToolsEnv
         gatewayTools = maybe [] managedGatewayTools promptRequest
         databaseAppTools = databaseTools databaseToolsEnv
-        learnedSkillAppTools = learnedSkillTools learnedSkillToolsEnv
+        learnedSkillAppTools =
+            learnedSkillTools skillInvocationsRef learnedSkillToolsEnv
         allTools =
             coding.codingAppTools
                 ++ extraTools
@@ -2312,9 +2315,6 @@ runAgentInitializedWithLock
         -- terminal, so filesystem discovery cannot delay the first frame.
         -- Minimal and one-shot sessions still initialize them synchronously
         -- before their first prompt/turn below.
-        skillsRef <- newIORef (SkillCatalog [] [])
-        skillInvocationsRef <- newIORef []
-
         usageRef <- newIORef $ case resumed of
             Just (meta, turns) -> sessionUsageFromTurns meta turns
             Nothing -> emptyTokenUsage
@@ -3358,12 +3358,12 @@ runSession SessionRequest{..} SessionBackend{..} = do
             freshAgents <-
                 loadAgentsContext fullscreen options dialect home cwd [] Nothing
             freshSkills <- loadSkillsCatalogQuiet options home projectRoot cwd
-            (omitted, skillContextChars) <-
+            (omitted, _) <-
                 installSkills freshAgents True freshSkills
             reportSkillCatalog True freshSkills omitted
             void $ installLearnedSkills
                 freshAgents
-                (defaultSkillCatalogMaxChars - skillContextChars)
+                defaultLearnedSkillContextMaxChars
             fresh <- readIORef freshAgents
             writeIORef startupContext fresh
         refreshSkills queueContext = do
@@ -3727,7 +3727,7 @@ runSession SessionRequest{..} SessionBackend{..} = do
                 options home projectRoot cwd
             let queueInitialContext =
                     null initialTurns && not (isJust initialPrevious)
-            (omitted, skillContextChars) <- installSkills startupContext
+            (omitted, _) <- installSkills startupContext
                 queueInitialContext
                 skills
             reportSkillCatalog (isNothing fullscreen) skills omitted
@@ -3735,7 +3735,7 @@ runSession SessionRequest{..} SessionBackend{..} = do
                 if queueInitialContext
                     then installLearnedSkills
                         startupContext
-                        (defaultSkillCatalogMaxChars - skillContextChars)
+                        defaultLearnedSkillContextMaxChars
                     else pure []
             finishStartup startup
             pure learnedSkills

--- a/packages/agent-cli/test/Agent/CLI/LearnedSkillsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/LearnedSkillsSpec.hs
@@ -1,7 +1,15 @@
 module Agent.CLI.LearnedSkillsSpec (spec) where
 
 import Agent.CLI (learnAboutUserOnboardingPrompt)
+import Agent.CLI.Database (DatabaseScope(..))
 import Agent.CLI.LearnedSkills
+import Agent.Skills
+    ( Skill(..)
+    , SkillContextMode(..)
+    , SkillInvocation(..)
+    , SkillOrigin(..)
+    , SkillScope(..)
+    )
 import Agent.Store.Postgres.Scope
     ( Scope(..)
     , ScopeKind(..)
@@ -30,16 +38,18 @@ import Data.IORef (newIORef, readIORef, writeIORef)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Time.Clock (UTCTime)
+import System.OsPath (unsafeEncodeUtf)
 import Test.Hspec
 
 spec :: Spec
 spec = do
     describe "learnedSkillTools" do
         it "registers read-only search/read and approved sequential mutations" do
-            let tools = learnedSkillTools testEnv
+            invocationsRef <- newIORef []
+            let tools = learnedSkillTools invocationsRef testEnv
             map (.appToolName) tools `shouldBe`
                 [ "skill_search"
-                , "skill_read"
+                , "view_skill"
                 , "skill_create"
                 , "skill_update"
                 , "skill_archive"
@@ -65,6 +75,7 @@ spec = do
         it "dispatches search and create requests to the environment" do
             searchSeen <- newIORef Nothing
             createSeen <- newIORef Nothing
+            invocationsRef <- newIORef []
             let env = testEnv
                     { learnedSkillSearch = \query limit -> do
                         writeIORef searchSeen (Just (query, limit))
@@ -74,11 +85,11 @@ spec = do
                         pure (Right (object ["status" .= ("applied" :: Text)]))
                     }
             searchResult <- dispatchToolCall dispatchConfig
-                (appToolHandlers (learnedSkillTools env))
+                (appToolHandlers (learnedSkillTools invocationsRef env))
                 (functionToolCall "call-1" "skill_search"
                     "{\"query\":\"postgres session\",\"limit\":4}")
             createResult <- dispatchToolCall dispatchConfig
-                (appToolHandlers (learnedSkillTools env))
+                (appToolHandlers (learnedSkillTools invocationsRef env))
                 (functionToolCall "call-2" "skill_create"
                     "{\"scope\":\"repository\",\
                         \\"slug\":\"postgres-session\",\
@@ -95,8 +106,37 @@ spec = do
             searchResult.output `shouldContainText` "\"matches\""
             createResult.output `shouldContainText` "\"applied\""
 
+        it "views filesystem and learned skills through one lazy-loading tool" do
+            learnedSeen <- newIORef Nothing
+            invocationsRef <- newIORef
+                [SkillInvocation "deploy" filesystemSkill True]
+            let env = testEnv
+                    { learnedSkillRead = \scope slug revision -> do
+                        writeIORef learnedSeen (Just (scope, slug, revision))
+                        pure (Right (object
+                            [ "instructions" .= ("Learned body" :: Text)
+                            ]))
+                    }
+                handlers =
+                    appToolHandlers (learnedSkillTools invocationsRef env)
+            filesystemResult <- dispatchToolCall dispatchConfig handlers
+                (functionToolCall "call-view-file" "view_skill"
+                    "{\"name\":\"$deploy\"}")
+            learnedResult <- dispatchToolCall dispatchConfig handlers
+                (functionToolCall "call-view-learned" "view_skill"
+                    "{\"name\":\"postgres-session\",\
+                    \\"scope\":\"repository\",\
+                    \\"revision\":2}")
+            filesystemResult.output `shouldContainText` "\"kind\":\"filesystem\""
+            filesystemResult.output `shouldContainText`
+                "\"instructions\":\"Deploy carefully.\""
+            readIORef learnedSeen `shouldReturn`
+                Just (DatabaseRepositoryScope, "postgres-session", Just 2)
+            learnedResult.output `shouldContainText` "\"Learned body\""
+
         it "rejects invalid mutations before calling storage" do
             called <- newIORef False
+            invocationsRef <- newIORef []
             let env = testEnv
                     { learnedSkillCreate = \_ -> do
                         writeIORef called True
@@ -106,7 +146,7 @@ spec = do
                         pure (Right (object []))
                     }
             badSlug <- dispatchToolCall dispatchConfig
-                (appToolHandlers (learnedSkillTools env))
+                (appToolHandlers (learnedSkillTools invocationsRef env))
                 (functionToolCall "call-3" "skill_create"
                     "{\"scope\":\"user\",\
                     \\"slug\":\"Bad Slug\",\
@@ -120,7 +160,7 @@ spec = do
             badSlug.output `shouldContainText` "lowercase ASCII"
 
             emptyEvidence <- dispatchToolCall dispatchConfig
-                (appToolHandlers (learnedSkillTools env))
+                (appToolHandlers (learnedSkillTools invocationsRef env))
                 (functionToolCall "call-4" "skill_create"
                     "{\"scope\":\"user\",\
                     \\"slug\":\"valid-skill\",\
@@ -134,7 +174,7 @@ spec = do
             emptyEvidence.output `shouldContainText` "evidence must not be empty"
 
             noOp <- dispatchToolCall dispatchConfig
-                (appToolHandlers (learnedSkillTools env))
+                (appToolHandlers (learnedSkillTools invocationsRef env))
                 (functionToolCall "call-5" "skill_update"
                     "{\"scope\":\"user\",\
                     \\"slug\":\"valid-skill\",\
@@ -277,6 +317,33 @@ testScope kind =
 
 timestamp :: UTCTime
 timestamp = read "2026-08-24 15:00:00 UTC"
+
+filesystemSkill :: Skill
+filesystemSkill = Skill
+    { skillName = "deploy"
+    , skillDescription = "Deploy the service"
+    , skillDisplayName = Just "Deploy"
+    , skillShortDescription = Nothing
+    , skillDefaultPrompt = Nothing
+    , skillWhenToUse = Just "When releasing"
+    , skillContextMode = SkillContextOnDemand
+    , skillArgumentHint = Nothing
+    , skillUserInvocable = True
+    , skillModelInvocable = True
+    , skillAllowedTools = []
+    , skillModelOverride = Nothing
+    , skillEffortOverride = Nothing
+    , skillLicense = Nothing
+    , skillCompatibility = Nothing
+    , skillMetadata = mempty
+    , skillPath = unsafeEncodeUtf "/tmp/deploy/SKILL.md"
+    , skillDirectory = unsafeEncodeUtf "/tmp/deploy"
+    , skillBody = "Deploy carefully."
+    , skillFileText =
+        "---\nname: deploy\ndescription: Deploy the service\n---\nDeploy carefully."
+    , skillScope = UserSkill
+    , skillOrigin = AgentSkills
+    }
 
 shouldContainText :: Text -> Text -> Expectation
 shouldContainText actual expected =

--- a/packages/agent-cli/test/Agent/CLI/PromptSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/PromptSpec.hs
@@ -167,7 +167,7 @@ spec = describe "systemPrompt" do
                     genericResponsesDialect
                     [ "read_file"
                     , "skill_search"
-                    , "skill_read"
+                    , "view_skill"
                     , "skill_create"
                     , "skill_update"
                     ]

--- a/packages/agent-cli/test/Agent/CLI/SkillsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SkillsSpec.hs
@@ -120,7 +120,11 @@ spec = describe "Agent.CLI.Skills" do
             Nothing -> expectationFailure "expected startup context"
             Just text -> do
                 text `shouldSatisfy` Text.isPrefixOf "agents\n\n## Skills"
-                text `shouldSatisfy` Text.isInfixOf "/tmp/deploy/SKILL.md"
+                text `shouldSatisfy` Text.isInfixOf
+                    "call `view_skill` with the listed name"
+                text `shouldSatisfy` Text.isInfixOf "$deploy: Deploy the service"
+                text `shouldSatisfy`
+                    (not . Text.isInfixOf "/tmp/deploy/SKILL.md")
 
     it "maps invocation metadata into a slash command" do
         let invocation = SkillInvocation "deploy" fakeSkill True

--- a/packages/agent-core/src/Agent/Skills.hs
+++ b/packages/agent-core/src/Agent/Skills.hs
@@ -577,7 +577,7 @@ formatSkillCatalogContext maxChars catalog
                 , "Always-active skills are included in full below and must be followed for every matching turn."
                 , "Use a skill when the user names it or the task clearly matches its description."
                 , "Users can explicitly invoke a skill with `$skill-name`."
-                , "After choosing a skill, read its SKILL.md from the listed path and follow it."
+                , "For on-demand skills, call `view_skill` with the listed name to load the full instructions."
                 , "Resolve relative scripts, references, and assets from the skill directory."
                 , "Load only the resources needed for the task; do not carry skills across turns unless relevant again."
                 , "Briefly state which skill(s) you are using. If a skill cannot be read, say so and continue with the best fallback."
@@ -607,9 +607,6 @@ renderSkillLine skill =
                 <> Text.replace "\n" " " skill.skillDescription
                 <> maybe "" (\trigger -> " Trigger: " <> Text.replace "\n" " " trigger)
                     skill.skillWhenToUse
-                <> " (file: "
-                <> toText skill.skillPath
-                <> ")"
 
 fitSkillLines :: Int -> [Skill] -> ([Text], Int)
 fitSkillLines budget = go budget []
@@ -633,8 +630,7 @@ renderShortenedSkillLine remaining skill =
         SkillContextAlways -> Nothing
         SkillContextOnDemand ->
             let prefix = "- $" <> skill.skillName <> ": "
-                suffix = " (file: " <> toText skill.skillPath <> ")"
-                available = remaining - Text.length prefix - Text.length suffix - 2
+                available = remaining - Text.length prefix - 2
             in if available < 12
                 then Nothing
                 else Just $
@@ -642,7 +638,6 @@ renderShortenedSkillLine remaining skill =
                         <> Text.take available
                             (Text.replace "\n" " " skill.skillDescription)
                         <> "…"
-                        <> suffix
 
 formatSkillActivation :: SkillInvocation -> Text -> Text
 formatSkillActivation invocation arguments =

--- a/packages/agent-tui/src/Agent/TUI/Presentation.hs
+++ b/packages/agent-tui/src/Agent/TUI/Presentation.hs
@@ -184,7 +184,7 @@ toolVerb name = case canonicalToolName name of
     "ask_user_question" -> "Asked"
     "ask_secret" -> "Requested secret"
     "skill_search" -> "Searched skills"
-    "skill_read" -> "Read skill"
+    "view_skill" -> "Viewed skill"
     "skill_create" -> "Learned"
     "skill_update" -> "Updated skill"
     "skill_archive" -> "Archived skill"
@@ -227,7 +227,7 @@ toolDetail call = case canonicalToolName call.name of
     "list_agents" ->
         maybe "" ("under " <>) (nonEmptyJsonText "path_prefix" call.arguments)
     "skill_search" -> firstLine (jsonTextFieldDefault "query" call.arguments)
-    "skill_read" -> skillIdentity call.arguments
+    "view_skill" -> viewSkillIdentity call.arguments
     "skill_create" -> skillIdentity call.arguments
     "skill_update" -> skillIdentity call.arguments
     "skill_archive" -> skillIdentity call.arguments
@@ -245,6 +245,17 @@ skillIdentity arguments =
     of
         (Just scope, Just slug) -> scope <> "/" <> slug
         (Nothing, Just slug) -> slug
+        _ -> "the selected skill"
+
+viewSkillIdentity :: Text -> Text
+viewSkillIdentity arguments =
+    case
+        ( nonEmptyJsonText "scope" arguments
+        , nonEmptyJsonText "name" arguments
+        )
+    of
+        (Just scope, Just name) -> scope <> "/" <> name
+        (Nothing, Just name) -> name
         _ -> "the selected skill"
 
 formatSkillMutation :: Text -> Maybe Text

--- a/packages/agent-tui/test/Agent/TUI/PresentationSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/PresentationSpec.hs
@@ -90,6 +90,12 @@ spec = describe "tool presentation" do
             `shouldBe` "Enter API token"
 
     it "renders learned-skill mutations with scope, slug, and approval intent" do
+        summarizeToolCall
+            (functionToolCall
+                "view"
+                "view_skill"
+                "{\"scope\":\"repository\",\"name\":\"postgres-sessions\"}")
+            `shouldBe` "Viewed skill repository/postgres-sessions"
         let create = functionToolCall
                 "skill"
                 "skill_create"


### PR DESCRIPTION
## Summary

- add a unified `view_skill` tool for filesystem and learned skills
- keep on-demand filesystem skill instructions out of startup context
- give learned skills an independent startup-context budget
- update CLI/TUI presentation and prompts for the new tool

## Validation

- agent CLI focused tests: 34 examples, 0 failures
- agent core skill tests: 12 examples, 0 failures
- agent TUI presentation tests: 9 examples, 0 failures
- tmux smoke test invoking `view_skill` for a packaged skill
- `git diff --check`
