### PR TITLE
Extract Agent.CLI session interaction helpers

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -56,6 +56,7 @@ library
                     , Agent.CLI.Session.Attachments
                     , Agent.CLI.Session.Choices
                     , Agent.CLI.Session.History
+                    , Agent.CLI.Session.Interaction
                     , Agent.CLI.Session.Selection
                     , Agent.CLI.Session.Runtime.Types
                     , Agent.CLI.SessionAdmin

--- a/packages/agent-cli/src/Agent/CLI/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime.hs
@@ -98,10 +98,6 @@ import Agent.CLI.AccountPicker
     , accountPickerRow
     , loadAllAccountPickerOptions
     )
-import Agent.CLI.Btw
-    ( formatBtwError
-    , runBtwWithCancel
-    )
 import Agent.CLI.CancelWatch (withEscCancel, withStdinPaused)
 import Agent.CLI.Clipboard
     ( formatImageSize
@@ -317,7 +313,6 @@ import Agent.CLI.Render
     , clearThinking
     , emptyMarkdownStreamState
     , putTextLn
-    , renderAssistantText
     , renderEvent
     )
 import Agent.CLI.Session
@@ -338,6 +333,12 @@ import Agent.CLI.Session.History
     , foldSessionItems
     , hydrateUiHistory
     , resetLiveConversation
+    )
+import Agent.CLI.Session.Interaction
+    ( buildPromptState
+    , runBtwQuestion
+    , setSessionEffort
+    , syncFullscreenPrompt
     )
 import Agent.CLI.Session.Selection
     ( currentSessionId
@@ -465,8 +466,7 @@ import Agent.CLI.TUI.App
     )
 import qualified Agent.CLI.TUI.Bridge as TuiBridge
 import Agent.TUI.Model
-    ( PromptState(..)
-    , UiEvent(..)
+    ( UiEvent(..)
     , UiState(..)
     , infoNotice
     , progressNotice
@@ -3827,50 +3827,6 @@ runPendingTurnWithCooldownRetry
     finishTurnWithCooldownRetry
         allowCooldownRetry env pending.pendingExitAfter result
 
--- | A retained fullscreen runtime survives provider rebuilds. Publish the new
--- session's prompt metadata before replaying a pending turn so the composer
--- does not keep showing the exhausted provider while its replacement runs.
-syncFullscreenPrompt :: SessionEnv -> IO ()
-syncFullscreenPrompt env =
-    forM_ env.sessionFullscreen \runtime -> do
-        planState <- readIORef env.sessionPlanMode.planStateRef
-        params <- readIORef env.sessionParams
-        policy <- readIORef env.sessionPolicy
-        account <- readIORef env.sessionAccount
-        usage <- readIORef env.sessionUsage
-        attachments <- readIORef env.sessionAttachments
-        emitUiEvent runtime $ UiSetPrompt $
-            buildPromptState
-                params
-                planState
-                policy
-                account
-                (isJust env.sessionSelectAccount)
-                usage
-                (length attachments)
-
-buildPromptState
-    :: ResponseCreateParams
-    -> PlanModeState
-    -> ApprovalPolicy
-    -> Text
-    -> Bool
-    -> TokenUsage
-    -> Int
-    -> PromptState
-buildPromptState params planState policy account accountSelectable usage attachments =
-    PromptState
-        { promptModel = currentModel params
-        , promptEffort = currentEffort params
-        , promptMode =
-            replModeLabel (replModeFromState planState policy)
-        , promptAccount = account
-        , promptAccountSelectable = accountSelectable
-        , promptUsage = usage
-        , promptLimitStatus = Nothing
-        , promptAttachments = attachments
-        }
-
 finishTurn
     :: SessionEnv
     -> Bool
@@ -4057,76 +4013,6 @@ waitAndRetryPendingTurn env delay pending = do
             runPendingTurnWithCooldownRetry
                 False RestartPendingTurn env pending
                 `finally` clearPersistenceActivity env.sessionPersist
-
-setSessionEffort :: SessionEnv -> Text -> IO ()
-setSessionEffort env level = do
-    modifyIORef' env.sessionParams (setReasoningEffort level)
-    case env.sessionFullscreen of
-        Just runtime ->
-            emitUiEvent runtime (UiSetPromptEffort level)
-        Nothing -> pure ()
-    case env.sessionPersist of
-        PersistenceDisabled -> pure ()
-        PersistenceEnabled slotRef -> do
-            slot <- readIORef slotRef
-            case slot of
-                PersistencePending pending sessionId tempDir ->
-                    writeIORef slotRef
-                        (PersistencePending
-                            pending { createEffort = level }
-                            sessionId
-                            tempDir)
-                PersistenceActive handle -> do
-                    let meta = handle.sessionMeta { metaEffort = level }
-                    writeSessionMeta
-                        handle.sessionPool
-                        handle.sessionMetaPath
-                        meta
-                    writeIORef slotRef
-                        (PersistenceActive handle { sessionMeta = meta })
-
-runBtwQuestion :: Bool -> SessionEnv -> Text -> IO ()
-runBtwQuestion registerCancel env question = do
-    let fullscreen = env.sessionFullscreen
-    color <- resolveColor stdout
-    forM_ fullscreen \runtime ->
-        emitUiEvent runtime
-            (UiSetNotice (Just (progressNotice "btw · asking…")))
-    result <-
-        runBtwWithCancel
-            (\cancel action ->
-                if registerCancel
-                    then
-                        withTurnCancel env.sessionInterrupt cancel $
-                            case fullscreen of
-                                Nothing ->
-                                    withEscCancel
-                                        cancel
-                                        env.sessionEscPaused
-                                        action
-                                Just _ -> action
-                    else action)
-            env.sessionBtwBackend
-            env.sessionParams
-            env.sessionTranscript
-            question
-    forM_ fullscreen \runtime ->
-        emitUiEvent runtime (UiSetNotice Nothing)
-    case result of
-        Left err -> do
-            errorColor <- resolveColor stderr
-            let message = formatBtwError err
-            case fullscreen of
-                Just runtime ->
-                    emitUiEvent runtime (UiErrorMessage message)
-                Nothing ->
-                    putTextLn stderr (roleError errorColor message)
-        Right answer ->
-            case fullscreen of
-                Just runtime ->
-                    emitUiEvent runtime (UiAssistantHistory answer)
-                Nothing ->
-                    putTextLn stdout (renderAssistantText color answer)
 
 repl :: SessionEnv -> IO RunResult
 repl env = replWithDraft env ""

--- a/packages/agent-cli/src/Agent/CLI/Session/Interaction.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Interaction.hs
@@ -1,0 +1,175 @@
+-- | Session interaction helpers shared by turn handling and the REPL.
+module Agent.CLI.Session.Interaction
+    ( buildPromptState
+    , runBtwQuestion
+    , setSessionEffort
+    , syncFullscreenPrompt
+    ) where
+
+import Agent.CLI.Btw
+    ( formatBtwError
+    , runBtwWithCancel
+    )
+import Agent.CLI.CancelWatch (withEscCancel)
+import Agent.CLI.Command
+    ( currentEffort
+    , currentModel
+    , setReasoningEffort
+    )
+import Agent.CLI.Interrupt (withTurnCancel)
+import Agent.CLI.Options (ApprovalPolicy)
+import Agent.CLI.Render
+    ( putTextLn
+    , renderAssistantText
+    )
+import Agent.CLI.ReplMode
+    ( replModeFromState
+    , replModeLabel
+    )
+import Agent.CLI.Session
+    ( Persistence(..)
+    , PersistenceState(..)
+    , SessionHandle(..)
+    , SessionMeta(..)
+    , SessionCreate(..)
+    , writeSessionMeta
+    )
+import Agent.CLI.SessionEnv (SessionEnv(..))
+import Agent.CLI.Style (roleError)
+import Agent.CLI.Terminal (resolveColor)
+import Agent.CLI.TUI.App
+    ( emitUiEvent
+    )
+import Agent.Loop (TokenUsage)
+import Agent.Responses.Types (ResponseCreateParams)
+import Agent.Tools.PlanMode
+    ( PlanModeEnv(..)
+    , PlanModeState
+    )
+import Agent.TUI.Model
+    ( PromptState(..)
+    , UiEvent(..)
+    , progressNotice
+    )
+import Control.Monad (forM_)
+import Data.IORef
+    ( modifyIORef'
+    , readIORef
+    , writeIORef
+    )
+import Data.Maybe (isJust)
+import Data.Text (Text)
+import System.IO (stderr, stdout)
+
+-- | Publish the current session prompt metadata to a retained fullscreen
+-- runtime before replaying a pending turn after a provider rebuild.
+syncFullscreenPrompt :: SessionEnv -> IO ()
+syncFullscreenPrompt env =
+    forM_ env.sessionFullscreen \runtime -> do
+        planState <- readIORef env.sessionPlanMode.planStateRef
+        params <- readIORef env.sessionParams
+        policy <- readIORef env.sessionPolicy
+        account <- readIORef env.sessionAccount
+        usage <- readIORef env.sessionUsage
+        attachments <- readIORef env.sessionAttachments
+        emitUiEvent runtime $ UiSetPrompt $
+            buildPromptState
+                params
+                planState
+                policy
+                account
+                (isJust env.sessionSelectAccount)
+                usage
+                (length attachments)
+
+buildPromptState
+    :: ResponseCreateParams
+    -> PlanModeState
+    -> ApprovalPolicy
+    -> Text
+    -> Bool
+    -> TokenUsage
+    -> Int
+    -> PromptState
+buildPromptState params planState policy account accountSelectable usage attachments =
+    PromptState
+        { promptModel = currentModel params
+        , promptEffort = currentEffort params
+        , promptMode =
+            replModeLabel (replModeFromState planState policy)
+        , promptAccount = account
+        , promptAccountSelectable = accountSelectable
+        , promptUsage = usage
+        , promptLimitStatus = Nothing
+        , promptAttachments = attachments
+        }
+
+setSessionEffort :: SessionEnv -> Text -> IO ()
+setSessionEffort env level = do
+    modifyIORef' env.sessionParams (setReasoningEffort level)
+    case env.sessionFullscreen of
+        Just runtime ->
+            emitUiEvent runtime (UiSetPromptEffort level)
+        Nothing -> pure ()
+    case env.sessionPersist of
+        PersistenceDisabled -> pure ()
+        PersistenceEnabled slotRef -> do
+            slot <- readIORef slotRef
+            case slot of
+                PersistencePending pending sessionId tempDir ->
+                    writeIORef slotRef
+                        (PersistencePending
+                            pending { createEffort = level }
+                            sessionId
+                            tempDir)
+                PersistenceActive handle -> do
+                    let meta = handle.sessionMeta { metaEffort = level }
+                    writeSessionMeta
+                        handle.sessionPool
+                        handle.sessionMetaPath
+                        meta
+                    writeIORef slotRef
+                        (PersistenceActive handle { sessionMeta = meta })
+
+runBtwQuestion :: Bool -> SessionEnv -> Text -> IO ()
+runBtwQuestion registerCancel env question = do
+    let fullscreen = env.sessionFullscreen
+    color <- resolveColor stdout
+    forM_ fullscreen \runtime ->
+        emitUiEvent runtime
+            (UiSetNotice (Just (progressNotice "btw · asking…")))
+    result <-
+        runBtwWithCancel
+            (\cancel action ->
+                if registerCancel
+                    then
+                        withTurnCancel env.sessionInterrupt cancel $
+                            case fullscreen of
+                                Nothing ->
+                                    withEscCancel
+                                        cancel
+                                        env.sessionEscPaused
+                                        action
+                                Just _ -> action
+                    else action)
+            env.sessionBtwBackend
+            env.sessionParams
+            env.sessionTranscript
+            question
+    forM_ fullscreen \runtime ->
+        emitUiEvent runtime (UiSetNotice Nothing)
+    case result of
+        Left err -> do
+            errorColor <- resolveColor stderr
+            let message = formatBtwError err
+            case fullscreen of
+                Just runtime ->
+                    emitUiEvent runtime (UiErrorMessage message)
+                Nothing ->
+                    putTextLn stderr (roleError errorColor message)
+        Right answer ->
+            case fullscreen of
+                Just runtime ->
+                    emitUiEvent runtime (UiAssistantHistory answer)
+                Nothing ->
+                    putTextLn stdout (renderAssistantText color answer)


### PR DESCRIPTION
## Summary
- move prompt synchronization and construction into `Agent.CLI.Session.Interaction`
- move session effort persistence and fullscreen updates
- move side-question execution and rendering
- reduce `Agent.CLI.Runtime` while leaving REPL recursion in place for the next extraction

## Validation
- `printf ":quit\n" | nix develop -c cabal repl agent-cli:lib:agent-cli --repl-options=-fno-code` (112 modules)
- `printf ":main\n:q\n" | TMPDIR=/tmp nix develop -c cabal repl agent-cli:test:agent-cli-test` (875 examples, 0 failures)
- `git diff --check`