### PR TITLE
Cover inline code rendering in thought blocks

### DIFF
--- a/packages/agent-cli/test/Agent/CLI/TUIPropertySpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIPropertySpec.hs
@@ -198,6 +198,28 @@ spec = do
             rendered `shouldSatisfy` Text.isInfixOf "Planning the fix"
             rendered `shouldSatisfy` (not . Text.isInfixOf "**")
 
+        it "renders inline Markdown in thought blocks" do
+            let app = baseState
+                    { appUi =
+                        reduceUi
+                            (UiLoop
+                                (ReasoningDelta
+                                    "Inspect `AppState` before continuing."))
+                            baseState.appUi
+                    }
+                size = (80, 24)
+                rendered =
+                    Text.unlines $
+                        pictureRows
+                            (renderWidget
+                                (Just Theme.monochrome)
+                                (drawApp app)
+                                size)
+                            size
+            rendered `shouldSatisfy`
+                Text.isInfixOf "Inspect AppState before continuing."
+            rendered `shouldNotSatisfy` Text.isInfixOf "`AppState`"
+
 renderTraceProperty :: AppState -> RenderTrace -> Property
 renderTraceProperty baseState (RenderTrace actions) =
     conjoin $


### PR DESCRIPTION
## Summary
- add a fullscreen renderer regression for inline-code Markdown in Thought blocks
- verify `` `AppState` `` is rendered as `AppState` rather than with literal backticks

The production Markdown rendering path is already present on `master` via #461; after rebasing, this PR retains the additional regression for the originally reported inline-code case.

## Validation
- `nix develop -c cabal repl agent-cli:test:agent-cli-test` and `hspec Agent.CLI.TUIPropertySpec.spec`
  - 6 examples, 0 failures
  - 300 generated-frame property checks
  - 100 incremental-redraw property checks
- prior live tmux smoke check confirmed a Thought containing `` `AppState` `` displays without literal backticks
