### PR TITLE
Improve NixOS Telegram module reliability

### DIFF
--- a/docs/nixos.md
+++ b/docs/nixos.md
@@ -46,11 +46,24 @@ The module:
 - restarts the foreground gateway after failures.
 
 The project directory must exist before the service starts. If `yolo` is
-enabled, it must also be writable by the service user.
+enabled, it must also be writable by the service user. The generated systemd
+unit orders itself after mounts needed by the project and instance home
+directories.
 
 Instance names must begin with a lowercase letter, contain only lowercase
 letters, digits, and hyphens, and be at most 16 characters long. Each enabled
-instance must use a distinct service user and home directory.
+instance must use a distinct service user and home directory. `homeDirectory`,
+`codexHome`, `workingDirectory`, and `tokenFile` must be absolute paths.
+
+Disabled instances do not require the enabled-only options:
+
+```nix
+services.haskell-agent.telegram.instances.assistant.enable = false;
+```
+
+Set `createUser = false` to use an account managed elsewhere. In that case the
+configured user and group must already exist, and the home directory must be
+writable by them.
 
 ## Provider credentials
 
@@ -64,6 +77,10 @@ authentication, the default `CODEX_HOME` is:
 ```
 
 It can be changed with `codexHome`.
+
+Every `environmentFiles` entry must be an absolute path. Prefix it with `-` to
+let systemd ignore a missing file, for example
+`-/run/secrets/haskell-agent-provider`.
 
 ## State and PostgreSQL
 

--- a/nix/modules/telegram.nix
+++ b/nix/modules/telegram.nix
@@ -23,6 +23,8 @@ let
   managedInstances = filterAttrs (_: instance: instance.createUser) enabledInstances;
   instanceHomes = mapAttrsToList (_: instance: instance.homeDirectory) enabledInstances;
   instanceUsers = mapAttrsToList (_: instance: instance.user) enabledInstances;
+  isAbsoluteEnvironmentFile =
+    path: hasPrefix "/" path || (hasPrefix "-/" path && builtins.stringLength path > 2);
 
   instanceType = types.submodule (
     { name, config, ... }:
@@ -177,6 +179,8 @@ let
           description = ''
             Environment files read by systemd at service start. Use these for
             provider API keys instead of putting secret values in Nix options.
+            Prefix an absolute path with <literal>-</literal> to ignore a
+            missing file.
           '';
         };
       };
@@ -230,6 +234,10 @@ in
           message = "services.haskell-agent.telegram.instances.${name}.homeDirectory must be absolute";
         }
         {
+          assertion = hasPrefix "/" instance.codexHome;
+          message = "services.haskell-agent.telegram.instances.${name}.codexHome must be absolute";
+        }
+        {
           assertion = builtins.stringLength "${instance.homeDirectory}/.haskell-agent/postgres/run" <= 90;
           message = "services.haskell-agent.telegram.instances.${name}.homeDirectory is too long for the private PostgreSQL socket";
         }
@@ -246,12 +254,17 @@ in
           message = "services.haskell-agent.telegram.instances.${name}.allowedUsers must contain only positive IDs";
         }
         {
+          assertion =
+            builtins.length instance.allowedUsers == builtins.length (lib.unique instance.allowedUsers);
+          message = "services.haskell-agent.telegram.instances.${name}.allowedUsers must not contain duplicates";
+        }
+        {
           assertion = hasPrefix "/" instance.tokenFile;
           message = "services.haskell-agent.telegram.instances.${name}.tokenFile must be an absolute runtime path";
         }
         {
-          assertion = builtins.all (hasPrefix "/") instance.environmentFiles;
-          message = "services.haskell-agent.telegram.instances.${name}.environmentFiles must contain only absolute paths";
+          assertion = builtins.all isAbsoluteEnvironmentFile instance.environmentFiles;
+          message = "services.haskell-agent.telegram.instances.${name}.environmentFiles must contain only absolute paths, optionally prefixed with -";
         }
       ]) enabledInstances
     );
@@ -300,6 +313,10 @@ in
         wantedBy = [ "multi-user.target" ];
         after = [ "network-online.target" ];
         wants = [ "network-online.target" ];
+        unitConfig.RequiresMountsFor = [
+          instance.homeDirectory
+          instance.workingDirectory
+        ];
 
         environment = instance.environment // {
           HOME = instance.homeDirectory;

--- a/nix/tests/telegram-module.nix
+++ b/nix/tests/telegram-module.nix
@@ -9,43 +9,68 @@ let
     exit 0
   '';
 
-  evaluated = nixpkgs.lib.nixosSystem {
-    inherit system;
-    modules = [
-      (import ../modules/telegram.nix { inherit self; })
-      {
-        system.stateVersion = "26.05";
+  baseModule = {
+    system.stateVersion = "26.05";
+  };
 
-        services.haskell-agent.telegram.instances = {
-          primary = {
-            enable = true;
-            package = testPackage;
-            workingDirectory = "/srv/primary";
-            tokenFile = "/run/keys/primary-token";
-            allowedUsers = [ 123456789 ];
-            model = null;
-            effort = null;
-            respondToAllGroupMessages = true;
-            environment = {
-              HOME = "/tmp/ignored";
-              AGENT_POSTGRES_PORT = "1";
-              MODULE_TEST = "present";
-            };
-          };
+  evaluate =
+    module:
+    nixpkgs.lib.nixosSystem {
+      inherit system;
+      modules = [
+        (import ../modules/telegram.nix { inherit self; })
+        baseModule
+        module
+      ];
+    };
 
-          secondary = {
-            enable = true;
-            package = testPackage;
-            workingDirectory = "/srv/secondary";
-            tokenFile = "/run/keys/secondary-token";
-            allowedUsers = [ 987654321 ];
-            provider = "openrouter";
-            model = "openai/gpt-5.1";
-            postgresPort = 55432;
-          };
+  evaluated = evaluate {
+    services.haskell-agent.telegram.instances = {
+      primary = {
+        enable = true;
+        package = testPackage;
+        workingDirectory = "/srv/primary";
+        tokenFile = "/run/keys/primary-token";
+        allowedUsers = [ 123456789 ];
+        model = null;
+        effort = null;
+        respondToAllGroupMessages = true;
+        environment = {
+          HOME = "/tmp/ignored";
+          AGENT_POSTGRES_PORT = "1";
+          MODULE_TEST = "present";
         };
-      }
-    ];
+        environmentFiles = [
+          "/run/keys/provider"
+          "-/run/keys/optional-provider"
+        ];
+      };
+
+      secondary = {
+        enable = true;
+        package = testPackage;
+        workingDirectory = "/srv/secondary";
+        tokenFile = "/run/keys/secondary-token";
+        allowedUsers = [ 987654321 ];
+        provider = "openrouter";
+        model = "openai/gpt-5.1";
+        postgresPort = 55432;
+      };
+
+      external = {
+        enable = true;
+        package = testPackage;
+        createUser = false;
+        user = "external-agent";
+        group = "external-agent";
+        homeDirectory = "/srv/external-home";
+        workingDirectory = "/srv/external";
+        tokenFile = "/run/keys/external-token";
+        allowedUsers = [ 111222333 ];
+      };
+
+      disabled.enable = false;
+    };
   };
 
   primary = evaluated.config.systemd.services.haskell-agent-telegram-primary;
@@ -54,6 +79,7 @@ let
   primaryService = builtins.toJSON {
     inherit (primary) environment preStart;
     inherit (primary.serviceConfig)
+      EnvironmentFile
       ExecStart
       Group
       LoadCredential
@@ -72,10 +98,74 @@ let
       WorkingDirectory
       ;
   };
+
+  moduleFacts = builtins.toJSON {
+    disabledServiceExists = builtins.hasAttr "haskell-agent-telegram-disabled" evaluated.config.systemd.services;
+    disabledUserExists = builtins.hasAttr "haskell-agent-disabled" evaluated.config.users.users;
+    externalUserExists = builtins.hasAttr "external-agent" evaluated.config.users.users;
+    externalGroupExists = builtins.hasAttr "external-agent" evaluated.config.users.groups;
+    primaryRequiresMountsFor = primary.unitConfig.RequiresMountsFor;
+    primaryTmpfiles = evaluated.config.systemd.tmpfiles.settings."10-haskell-agent-telegram-primary";
+    primaryUser = {
+      inherit (evaluated.config.users.users.haskell-agent-primary)
+        createHome
+        description
+        group
+        home
+        isSystemUser
+        ;
+    };
+  };
+
+  failedAssertions =
+    module:
+    map (assertion: assertion.message) (
+      builtins.filter (assertion: !assertion.assertion) (evaluate module).config.assertions
+    );
+
+  validationFailures = builtins.toJSON {
+    relativeCodexHome = failedAssertions {
+      services.haskell-agent.telegram.instances.invalid = {
+        enable = true;
+        package = testPackage;
+        workingDirectory = "/srv/invalid";
+        tokenFile = "/run/keys/invalid-token";
+        allowedUsers = [ 1 ];
+        codexHome = "relative";
+      };
+    };
+    duplicateAllowedUsers = failedAssertions {
+      services.haskell-agent.telegram.instances.invalid = {
+        enable = true;
+        package = testPackage;
+        workingDirectory = "/srv/invalid";
+        tokenFile = "/run/keys/invalid-token";
+        allowedUsers = [
+          1
+          1
+        ];
+      };
+    };
+    relativeEnvironmentFile = failedAssertions {
+      services.haskell-agent.telegram.instances.invalid = {
+        enable = true;
+        package = testPackage;
+        workingDirectory = "/srv/invalid";
+        tokenFile = "/run/keys/invalid-token";
+        allowedUsers = [ 1 ];
+        environmentFiles = [ "relative.env" ];
+      };
+    };
+  };
 in
 pkgs.runCommand "haskell-agent-telegram-module-test"
   {
-    inherit primaryService secondaryService;
+    inherit
+      moduleFacts
+      primaryService
+      secondaryService
+      validationFailures
+      ;
     nativeBuildInputs = [ pkgs.jq ];
   }
   ''
@@ -124,6 +214,10 @@ pkgs.runCommand "haskell-agent-telegram-module-test"
       and .Group == "haskell-agent-primary"
       and .WorkingDirectory == "/srv/primary"
       and .LoadCredential == ["telegram-token:/run/keys/primary-token"]
+      and .EnvironmentFile == [
+        "/run/keys/provider",
+        "-/run/keys/optional-provider"
+      ]
       and .environment.HOME == "/var/lib/haskell-agent-telegram-primary"
       and .environment.CODEX_HOME == "/var/lib/haskell-agent-telegram-primary/.codex"
       and .environment.AGENT_POSTGRES_PORT == "55432"
@@ -138,6 +232,33 @@ pkgs.runCommand "haskell-agent-telegram-module-test"
       and .WorkingDirectory == "/srv/secondary"
       and .environment.HOME == "/var/lib/haskell-agent-telegram-secondary"
       and .environment.AGENT_POSTGRES_PORT == "55432"
+    ' >/dev/null
+
+    printf '%s\n' "$moduleFacts" | jq -e '
+      (.disabledServiceExists | not)
+      and (.disabledUserExists | not)
+      and (.externalUserExists | not)
+      and (.externalGroupExists | not)
+      and .primaryRequiresMountsFor == [
+        "/var/lib/haskell-agent-telegram-primary",
+        "/srv/primary"
+      ]
+      and .primaryUser == {
+        createHome: true,
+        description: "Haskell Agent Telegram service",
+        group: "haskell-agent-primary",
+        home: "/var/lib/haskell-agent-telegram-primary",
+        isSystemUser: true
+      }
+      and .primaryTmpfiles["/var/lib/haskell-agent-telegram-primary"].d.mode == "0700"
+      and .primaryTmpfiles["/var/lib/haskell-agent-telegram-primary"].d.user == "haskell-agent-primary"
+      and .primaryTmpfiles["/var/lib/haskell-agent-telegram-primary/.haskell-agent/gateways/telegram"].d.mode == "0700"
+    ' >/dev/null
+
+    printf '%s\n' "$validationFailures" | jq -e '
+      (.relativeCodexHome | any(contains(".codexHome must be absolute")))
+      and (.duplicateAllowedUsers | any(contains(".allowedUsers must not contain duplicates")))
+      and (.relativeEnvironmentFile | any(contains(".environmentFiles must contain only absolute paths")))
     ' >/dev/null
 
     touch "$out"


### PR DESCRIPTION
## Summary

- order Telegram services after mounts required by their home and working directories
- validate `codexHome`, duplicate allowed-user IDs, and environment-file paths
- support systemd's `-` prefix for optional environment files
- expand module coverage for disabled instances, externally managed users, tmpfiles, mount dependencies, and validation failures
- document disabled instances, externally managed accounts, absolute paths, and optional environment files

## Validation

- `nix build .#checks.x86_64-linux.nixos-module --print-build-logs`
- `nix flake check --no-build`
- `git diff --check`
