### PR TITLE
fix(tui): unify subagent transcript rendering

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/AgentViewport.hs
+++ b/packages/agent-cli/src/Agent/CLI/AgentViewport.hs
@@ -24,6 +24,7 @@ module Agent.CLI.AgentViewport
     , responseItemLines
     , responseItemPreviewLines
     , responseItemStepPreviews
+    , responseItemsToUiState
     , selectAgentTarget
     , selectedAgentEntry
     ) where
@@ -36,16 +37,38 @@ import Agent.CLI.TextLayout
     , clampSelectionIndex
     , renderSplitPaneFrame
     )
+import Agent.Loop (LoopEvent(..))
+import Agent.Responses.LoopBackend (responseItemToToolCall)
 import Agent.Responses.Types
 import Agent.Subagents (SubagentId(..), SubagentStatus(..))
-import Agent.ToolDispatch (customToolCall, functionToolCall)
+import Agent.ToolDispatch
+    ( ToolCallKind(..)
+    , ToolCallResult(..)
+    , customToolCall
+    , functionToolCall
+    )
+import Agent.TUI.Model
+    ( BlockKind(..)
+    , BlockState(..)
+    , UiBlock(..)
+    , UiEvent(..)
+    , UiState(..)
+    , initialUiState
+    , reduceUi
+    )
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy as LBS
+import Data.Foldable (toList)
 import Data.IORef (IORef)
 import Data.List (findIndex, sortOn)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (listToMaybe)
+import qualified Data.Sequence as Seq
 import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as Text
+import qualified Data.Text.Encoding as TextEncoding
 import qualified Data.Text.IO as Text
 import System.Console.ANSI (getTerminalSize)
 import System.IO (hFlush, hIsTerminalDevice, stderr, stdin)
@@ -83,6 +106,7 @@ data AgentEntry = AgentEntry
     , agentModel :: !(Maybe Text)
     , agentSteps :: ![AgentStep]
     , agentTranscript :: ![Text]
+    , agentConversation :: !UiState
     }
     deriving (Eq, Show)
 
@@ -310,6 +334,15 @@ pickAgentViewport color selected entries = do
 
 responseItemLines :: [ResponseItem] -> [Text]
 responseItemLines = concatMap responseItemLineList
+
+-- | Replay a persisted provider transcript through the same retained UI model
+-- used by the root conversation. The agent picker still consumes compact text
+-- lines, while the fullscreen child view receives rich Markdown, reasoning,
+-- and tool blocks without maintaining a second presentation model.
+responseItemsToUiState :: Bool -> [ResponseItem] -> UiState
+responseItemsToUiState showRawReasoning =
+    normalizeTranscriptUi
+        . foldl' (appendResponseItem showRawReasoning) initialUiState
 
 -- | Keep a compact agent preview: the first line for picker context plus
 -- only the most recent logical lines for the live pane. Earlier response
@@ -591,6 +624,181 @@ responseContentText = \case
     InputFilePart{filename} -> ["[file" <> maybe "" (" " <>) filename <> "]"]
     InputAudioPart{} -> ["[audio]"]
     UnknownContentPart{} -> []
+
+appendResponseItem :: Bool -> UiState -> ResponseItem -> UiState
+appendResponseItem showRawReasoning state = \case
+    MessageItem message ->
+        appendResponseMessage message state
+    FunctionCallItem item ->
+        maybe state
+            (\call -> reduceUi (UiLoop (ToolStarted call)) state)
+            (responseItemToToolCall (FunctionCallItem item))
+    CustomToolCallItem item ->
+        maybe state
+            (\call -> reduceUi (UiLoop (ToolStarted call)) state)
+            (responseItemToToolCall (CustomToolCallItem item))
+    FunctionCallOutputItem output ->
+        reduceUi
+            (UiLoop
+                (ToolFinished ToolCallResult
+                    { callId = output.callId
+                    , output = renderToolOutputValue output.output
+                    , callKind = FunctionCallKind
+                    }))
+            state
+    CustomToolCallOutputItem output ->
+        reduceUi
+            (UiLoop
+                (ToolFinished ToolCallResult
+                    { callId = output.callId
+                    , output = renderToolOutputValue output.output
+                    , callKind = CustomCallKind
+                    }))
+            state
+    ReasoningItemValue reasoning ->
+        appendReasoningItem
+            reasoning.status
+            (reasoningDisplayText showRawReasoning reasoning)
+            state
+    KnownResponseItem ItemAgentMessage tagged ->
+        maybe state
+            (\text -> reduceUi (UiUserSubmitted text) state)
+            (nonEmptyDisplayText (taggedContentText tagged))
+    KnownResponseItem{} -> state
+    ItemReferenceValue{} -> state
+    UnknownResponseItem{} -> state
+
+appendResponseMessage :: ResponseMessage -> UiState -> UiState
+appendResponseMessage message state =
+    case nonEmptyDisplayText (responseMessageText message.content) of
+        Nothing -> state
+        Just text -> case message.role of
+            RoleUser -> reduceUi (UiUserSubmitted text) state
+            RoleAssistant -> reduceUi (UiAssistantHistory text) state
+            RoleSystem -> reduceUi (UiSystemMessage text) state
+            RoleDeveloper ->
+                reduceUi (UiSystemMessage ("Developer:\n" <> text)) state
+            RoleUnknown role ->
+                reduceUi
+                    (UiSystemMessage (role <> ":\n" <> text))
+                    state
+
+appendReasoningItem :: Maybe ItemStatus -> Text -> UiState -> UiState
+appendReasoningItem status raw state =
+    case nonEmptyDisplayText raw of
+        Nothing -> state
+        Just text ->
+            let
+                firstBlock = reasoningStartIndex state
+                previousTurnStart = state.uiTurnStartBlock
+                previousAttemptStart = state.uiAttemptStartBlock
+                previousToolCalls = state.uiToolCalls
+                streamed =
+                    reduceUi
+                        (UiLoop (ReasoningDelta text))
+                        state
+                            { uiTurnStartBlock = firstBlock
+                            , uiAttemptStartBlock = firstBlock
+                            }
+                settled = case status of
+                    Just ItemInProgress -> streamed
+                    _ ->
+                        reduceUi
+                            (UiTurnEnded (itemTerminalState status))
+                            streamed
+            in settled
+                { uiTurnStartBlock = previousTurnStart
+                , uiAttemptStartBlock = previousAttemptStart
+                , uiToolCalls = previousToolCalls
+                }
+
+reasoningStartIndex :: UiState -> Int
+reasoningStartIndex state =
+    case Seq.viewr state.uiBlocks of
+        _ Seq.:> block
+            | block.blockKind == BlockThinking
+            , block.blockState == BlockStreaming ->
+                max 0 (Seq.length state.uiBlocks - 1)
+        _ -> Seq.length state.uiBlocks
+
+itemTerminalState :: Maybe ItemStatus -> BlockState
+itemTerminalState = \case
+    Just ItemIncomplete -> BlockFailed
+    Just (ItemStatusUnknown status)
+        | Text.toLower status `elem`
+            ["failed", "error", "cancelled", "canceled"] ->
+                BlockFailed
+    _ -> BlockComplete
+
+reasoningDisplayText :: Bool -> ReasoningItem -> Text
+reasoningDisplayText showRawReasoning reasoning =
+    Text.intercalate "\n" $
+        filter (not . Text.null . Text.strip) $
+            summaryText
+                <> if showRawReasoning
+                    then rawText
+                    else []
+  where
+    summaryText =
+        [ text
+        | part <- reasoning.summary
+        , Just text <- [part.text]
+        ]
+    rawText =
+        maybe [] (concatMap reasoningContentText) reasoning.content
+
+reasoningContentText :: ResponseContentPart -> [Text]
+reasoningContentText = \case
+    ReasoningTextPart{text} -> [text]
+    SummaryTextPart{text} -> [text]
+    _ -> []
+
+taggedContentText :: TaggedObject -> Text
+taggedContentText tagged =
+    case KeyMap.lookup "content" tagged.fields of
+        Just (Aeson.Array values) ->
+            Text.intercalate "\n" (concatMap taggedPartText (toList values))
+        Just value ->
+            Text.intercalate "\n" (taggedPartText value)
+        Nothing -> ""
+
+taggedPartText :: Aeson.Value -> [Text]
+taggedPartText = \case
+    Aeson.String text -> [text]
+    Aeson.Object object ->
+        case KeyMap.lookup "text" object of
+            Just (Aeson.String text) -> [text]
+            _ -> []
+    _ -> []
+
+renderToolOutputValue :: Aeson.Value -> Text
+renderToolOutputValue = \case
+    Aeson.String text -> text
+    Aeson.Null -> ""
+    value ->
+        TextEncoding.decodeUtf8 $
+            LBS.toStrict (Aeson.encode value)
+
+normalizeTranscriptUi :: UiState -> UiState
+normalizeTranscriptUi state =
+    state
+        { uiRunning = any blockIsLive state.uiBlocks
+        , uiActivity =
+            if any blockIsLive state.uiBlocks
+                then "Working…"
+                else "Ready"
+        , uiCompletionRemainingMillis = 0
+        , uiNotice = Nothing
+        , uiRetryCountdown = Nothing
+        }
+  where
+    blockIsLive block =
+        block.blockState `elem` [BlockStreaming, BlockRunning]
+
+nonEmptyDisplayText :: Text -> Maybe Text
+nonEmptyDisplayText raw =
+    let stripped = Text.strip raw
+    in if Text.null stripped then Nothing else Just stripped
 
 labelled :: Text -> Text -> [Text]
 labelled prefix raw =

--- a/packages/agent-cli/src/Agent/CLI/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime.hs
@@ -53,9 +53,9 @@ import Agent.CLI.AgentViewport
     , formatAgentStatus
     , pickAgentViewport
     , renderAgentViewportPanelFor
-    , responseItemLines
     , responseItemPreviewLines
     , responseItemStepPreviews
+    , responseItemsToUiState
     )
 import Agent.CLI.SessionTitle
     ( SessionTitleEvent(..)
@@ -467,7 +467,8 @@ import Agent.CLI.TUI.App
     )
 import qualified Agent.CLI.TUI.Bridge as TuiBridge
 import Agent.TUI.Model
-    ( UiEvent(..)
+    ( BlockState(..)
+    , UiEvent(..)
     , UiState(..)
     , infoNotice
     , progressNotice
@@ -3215,10 +3216,56 @@ runSession SessionRequest{..} SessionBackend{..} = do
                             | includeSummaries ->
                                 responseItemPreviewLines 12 items
                             | otherwise ->
-                                responseItemLines items
+                                []
                     | includeSummaries =
                         responseItemPreviewLines 0 items
                     | otherwise = []
+                conversationFor target status items
+                    | includeSummaries = initialUiState
+                    | target /= selected = initialUiState
+                    | target == AgentRoot = initialUiState
+                    | otherwise =
+                        settleConversation items status $
+                            responseItemsToUiState
+                                options.optShowRawReasoning
+                                items
+                settleConversation items status conversation =
+                    case status of
+                        Pending -> conversation
+                        Running -> conversation
+                        Completed result ->
+                            let settled =
+                                    finalizeAll BlockComplete conversation
+                            in case result of
+                                Just text
+                                    | null items
+                                    , not (Text.null (Text.strip text)) ->
+                                        reduceUi
+                                            (UiAssistantHistory
+                                                (Text.strip text))
+                                            settled
+                                _ -> settled
+                        Errored message ->
+                            reduceUi
+                                (UiErrorMessage
+                                    (if Text.null (Text.strip message)
+                                        then "Agent failed."
+                                        else Text.strip message))
+                                (finalizeAll BlockFailed conversation)
+                        Interrupted ->
+                            finalizeAll BlockCancelled conversation
+                        Closed ->
+                            finalizeAll BlockComplete conversation
+                        NotFound ->
+                            reduceUi
+                                (UiErrorMessage
+                                    "Agent transcript is unavailable.")
+                                (finalizeAll BlockFailed conversation)
+                  where
+                    finalizeAll terminal ui =
+                        reduceUi
+                            (UiTurnEnded terminal)
+                            ui { uiTurnStartBlock = 0 }
             rootSteps <-
                 if null agents
                     then pure []
@@ -3235,13 +3282,21 @@ runSession SessionRequest{..} SessionBackend{..} = do
                     , agentSteps = rootSteps
                     , agentTranscript =
                         transcriptLines AgentRoot rootItems
+                    , agentConversation = initialUiState
                     }
             children <- mapConcurrentlyBounded 8
-                (materializeChild transcriptLines sessions)
+                (materializeChild
+                    transcriptLines
+                    conversationFor
+                    sessions)
                 agents
             pure (selected, rootEntry : children)
           where
-            materializeChild transcriptLines sessions (path, agentId, status) = do
+            materializeChild
+                    transcriptLines
+                    conversationFor
+                    sessions
+                    (path, agentId, status) = do
                 let target = AgentChild agentId
                 items <- case Map.lookup agentId sessions of
                     Nothing -> pure []
@@ -3270,6 +3325,8 @@ runSession SessionRequest{..} SessionBackend{..} = do
                             <$> Map.lookup agentId sessions
                     , agentSteps = steps
                     , agentTranscript = transcript
+                    , agentConversation =
+                        conversationFor target status items
                     }
         hydrateSelectedAgent agentId = do
             effectiveModel <- readIORef modelRef

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -16,6 +16,7 @@ module Agent.CLI.TUI.App
     , externalUrlCommand
     , hasQueuedFullscreenInput
     , initialFullscreenAppState
+    , mergeConversationView
     , motionDemandFor
     , lambdaArtWidget
     , quickStartRows
@@ -1369,8 +1370,8 @@ activateControl = \case
         confirmChoiceAt index
     ResumeRow sessionId ->
         confirmResumeId sessionId
-    CodeCopy blockId codeIndex ->
-        copyCodeBlock blockId codeIndex
+    CodeCopy target blockId codeIndex ->
+        copyCodeBlock target blockId codeIndex
     MarkdownLink url ->
         openMarkdownLink url
     _ ->
@@ -1394,7 +1395,7 @@ isInteractiveControl = \case
     QuickStartModel -> True
     ChoiceRow _ -> True
     ResumeRow _ -> True
-    CodeCopy _ _ -> True
+    CodeCopy _ _ _ -> True
     _ -> False
 
 isQuickStartControl :: Name -> Bool
@@ -1441,11 +1442,16 @@ externalUrlCommand url
         in Text.isPrefixOf "https://" lower
             || Text.isPrefixOf "http://" lower
 
-copyCodeBlock :: BlockId -> Int -> EventM Name AppState ()
-copyCodeBlock blockId codeIndex = do
+copyCodeBlock
+    :: AgentTarget
+    -> BlockId
+    -> Int
+    -> EventM Name AppState ()
+copyCodeBlock target blockId codeIndex = do
     state <- get
     let code =
-            selectedBlock state.appUi blockId
+            conversationUiForTarget target state
+                >>= \ui -> selectedBlock ui blockId
                 >>= fencedCodeBlock codeIndex . (.blockBody)
     case code of
         Nothing ->
@@ -1809,7 +1815,7 @@ drawConversationPane state =
             withVScrollBarRenderer conversationScrollbarRenderer $
                 withVScrollBars OnRight $
                     viewport ConversationViewport Vertical $
-                        padLeftRight 2 (drawAgentConversation entry)
+                        padLeftRight 2 (drawAgentConversation state entry)
         Nothing
             | conversationIsEmpty state.appUi ->
                 padLeftRight 2 $
@@ -1838,8 +1844,41 @@ selectedAgentConversation selected entries = case selected of
     target ->
         find ((== target) . (.agentTarget)) entries
 
-drawAgentConversation :: AgentEntry -> Widget Name
-drawAgentConversation entry =
+conversationUiForTarget :: AgentTarget -> AppState -> Maybe UiState
+conversationUiForTarget target state = case target of
+    AgentRoot -> Just state.appUi
+    AgentChild _ ->
+        (.agentConversation)
+            <$> find
+                ((== target) . (.agentTarget))
+                state.appAgentEntries
+
+activeConversationUi :: AppState -> UiState
+activeConversationUi state =
+    fromMaybe state.appUi $
+        conversationUiForTarget state.appAgentSelected state
+
+applyChildConversationUiEvent
+    :: AgentTarget
+    -> UiEvent
+    -> AppState
+    -> AppState
+applyChildConversationUiEvent target uiEvent state =
+    state
+        { appAgentEntries =
+            map updateEntry state.appAgentEntries
+        }
+  where
+    updateEntry entry
+        | entry.agentTarget == target =
+            entry
+                { agentConversation =
+                    reduceUi uiEvent entry.agentConversation
+                }
+        | otherwise = entry
+
+drawAgentConversation :: AppState -> AgentEntry -> Widget Name
+drawAgentConversation state entry =
     vBox
         [ withAttr Theme.headingAttr $
             txt ("Viewing " <> entry.agentPath)
@@ -1848,30 +1887,16 @@ drawAgentConversation entry =
                 (entry.agentStatus
                     <> " · input is sent to /root")
         , padTop (Pad 1) $
-            case entry.agentTranscript of
-                [] ->
+            if Seq.null entry.agentConversation.uiBlocks
+                then
                     withAttr Theme.mutedAttr $
                         txt "(no transcript yet)"
-                rows ->
-                    vBox (map drawAgentTranscriptLine rows)
+                else
+                    drawConversationBlocks
+                        state
+                        entry.agentTarget
+                        entry.agentConversation
         ]
-
-drawAgentTranscriptLine :: Text -> Widget Name
-drawAgentTranscriptLine line =
-    padBottom (Pad 1) $
-        case Text.breakOn ": " line of
-            ("user", body) ->
-                withAttr Theme.userAttr $
-                    padAll 1 (txtWrap (Text.drop 2 body))
-            ("assistant", body) ->
-                padLeft (Pad 3) $
-                    withAttr Theme.assistantAttr $
-                        txtWrap (Text.drop 2 body)
-            ("error", body) ->
-                withAttr Theme.errorAttr $
-                    txtWrap (Text.drop 2 body)
-            _ ->
-                withAttr Theme.mutedAttr (txtWrap line)
 
 -- Brick's default scrollbar uses a full block for the thumb and a blank
 -- space for the trough. During rapid viewport reflow, some terminals can
@@ -2257,11 +2282,9 @@ waitingIndicatorAttr state =
 drawTranscript :: AppState -> Widget Name
 drawTranscript state =
     vBox $
-        [vBox (map (drawTranscriptChunk state) blockChunks)]
+        [drawConversationBlocks state AgentRoot state.appUi]
             <> conversationReserveWidgets anchor
   where
-    blockChunks =
-        Transcript.transcriptChunks state.appUi.uiBlocks
     anchor = state.appConversationAnchor
 
 -- | Cache completed transcript blocks in moderately sized groups.
@@ -2274,29 +2297,51 @@ drawTranscript state =
 -- until explicit invalidation, so caching the growing final chunk under a new
 -- last-block key for every append would retain all of those obsolete images.
 -- The final partial/live/animated group remains uncached.
-drawTranscriptChunk :: AppState -> Seq UiBlock -> Widget Name
-drawTranscriptChunk state blocks =
+drawTranscriptChunk
+    :: AppState
+    -> AgentTarget
+    -> UiState
+    -> Seq UiBlock
+    -> Widget Name
+drawTranscriptChunk state target ui blocks =
     case
         Transcript.transcriptChunkCacheKey
-            (cacheableBlock state)
+            (cacheableBlock state target ui)
             dynamicBlockIds
             blocks of
         Just (firstBlockId, lastBlockId) ->
             cached
-                (ConversationChunkCache firstBlockId lastBlockId)
+                (ConversationChunkCache
+                    target
+                    firstBlockId
+                    lastBlockId)
                 rendered
         Nothing -> rendered
   where
-    rendered = vBox (map (drawBlock state) (toList blocks))
+    rendered =
+        vBox (map (drawBlock state target ui) (toList blocks))
     dynamicBlockIds =
         [ blockId
         | state.appUi.uiFocus == FocusScrollback
-        , blockId <- maybeToList state.appUi.uiSelectedBlock
+        , state.appAgentSelected == target
+        , blockId <- maybeToList ui.uiSelectedBlock
         ]
             <> [ blockId
-               | Just (CodeCopy blockId _) <-
+               | Just (CodeCopy hoveredTarget blockId _) <-
                     [state.appHoveredControl]
+               , hoveredTarget == target
                ]
+
+drawConversationBlocks
+    :: AppState
+    -> AgentTarget
+    -> UiState
+    -> Widget Name
+drawConversationBlocks state target ui =
+    vBox $
+        map
+            (drawTranscriptChunk state target ui)
+            (Transcript.transcriptChunks ui.uiBlocks)
 
 stickyPromptLayers :: AppState -> [Widget Name]
 stickyPromptLayers state =
@@ -2403,11 +2448,13 @@ drawQuickStartPanel state =
                 , txt "  "
                 ]
 
-drawBlock :: AppState -> UiBlock -> Widget Name
-drawBlock state block =
-    let ui = state.appUi
-        selected = ui.uiSelectedBlock == Just block.blockId
-        highlighted = selected && ui.uiFocus == FocusScrollback
+drawBlock :: AppState -> AgentTarget -> UiState -> UiBlock -> Widget Name
+drawBlock state target ui block =
+    let selected = ui.uiSelectedBlock == Just block.blockId
+        highlighted =
+            selected
+                && state.appUi.uiFocus == FocusScrollback
+                && state.appAgentSelected == target
         content = case block.blockKind of
             BlockUser ->
                 withAttr Theme.userAttr $
@@ -2425,28 +2472,36 @@ drawBlock state block =
                                     (\codeIndex ->
                                         cached
                                             (CodeBlockCache
+                                                target
                                                 block.blockId
                                                 codeIndex))
-                                    (codeBlockHeader state block.blockId)
+                                    (codeBlockHeader
+                                        state
+                                        target
+                                        block.blockId)
                                     block.blockBody)
             BlockThinking ->
-                accentMarkdownBlock (thinkingBlockAttr state block)
-                    (blockStateGlyph state block <> block.blockTitle)
+                accentMarkdownBlock (thinkingBlockAttr state target block)
+                    (blockStateGlyph state target block <> block.blockTitle)
                     (visibleBody block)
             BlockTool ->
-                accentBlock (statusAttr state block)
-                    (blockStateGlyph state block <> block.blockTitle <> detailSuffix block)
+                accentBlock (statusAttr state target block)
+                    (blockStateGlyph state target block
+                        <> block.blockTitle
+                        <> detailSuffix block)
                     (visibleBody block)
             BlockShell ->
                 accentCodeBlock
                     state.appSyntaxHighlighter
-                    (statusAttr state block)
-                    (blockStateGlyph state block <> block.blockTitle)
+                    (statusAttr state target block)
+                    (blockStateGlyph state target block <> block.blockTitle)
                     block.blockDetail
                     (visibleShellBody block)
             BlockEdit ->
-                accentBlock (statusAttr state block)
-                    (blockStateGlyph state block <> block.blockTitle <> detailSuffix block)
+                accentBlock (statusAttr state target block)
+                    (blockStateGlyph state target block
+                        <> block.blockTitle
+                        <> detailSuffix block)
                     (visibleBody block)
             BlockSystem ->
                 withAttr Theme.mutedAttr (txtWrap block.blockBody)
@@ -2457,7 +2512,7 @@ drawBlock state block =
                 then withAttr Theme.selectedAttr content
                 else content
         rendered =
-            clickable (ConversationBlock block.blockId) $
+            clickable (ConversationBlock target block.blockId) $
                 padBottom (Pad 1) $
                     hBox
                         [ withAttr
@@ -2467,13 +2522,14 @@ drawBlock state block =
                             (txt (if highlighted then "❯ " else "  "))
                         , framed
                         ]
-    in if cacheableBlock state block
+    in if cacheableBlock state target ui block
         then cached
             (ConversationBlockCache
+                target
                 block.blockId
                 highlighted
                 block.blockExpanded
-                (codeCopyCacheState state block.blockId))
+                (codeCopyCacheState state target block.blockId))
             rendered
         else rendered
 
@@ -2486,8 +2542,14 @@ timestampedMessage timestamp body
             , withAttr Theme.mutedAttr (txt ("  " <> timestamp))
             ]
 
-codeBlockHeader :: AppState -> BlockId -> Int -> Text -> Widget Name
-codeBlockHeader state blockId codeIndex language =
+codeBlockHeader
+    :: AppState
+    -> AgentTarget
+    -> BlockId
+    -> Int
+    -> Text
+    -> Widget Name
+codeBlockHeader state target blockId codeIndex language =
     hBox
         [ if Text.null language
             then emptyWidget
@@ -2499,32 +2561,37 @@ codeBlockHeader state blockId codeIndex language =
                 (txt " Copy ")
         ]
   where
-    name = CodeCopy blockId codeIndex
+    name = CodeCopy target blockId codeIndex
 
-codeCopyCacheState :: AppState -> BlockId -> Maybe (Int, Bool)
-codeCopyCacheState state blockId =
+codeCopyCacheState
+    :: AppState
+    -> AgentTarget
+    -> BlockId
+    -> Maybe (Int, Bool)
+codeCopyCacheState state target blockId =
     case state.appHoveredControl of
-        Just (CodeCopy hoveredBlock codeIndex)
-            | hoveredBlock == blockId ->
+        Just (CodeCopy hoveredTarget hoveredBlock codeIndex)
+            | hoveredTarget == target
+            , hoveredBlock == blockId ->
                 Just
                     ( codeIndex
                     , state.appPressedControl
-                        == Just (CodeCopy blockId codeIndex)
+                        == Just (CodeCopy target blockId codeIndex)
                     )
         _ -> Nothing
 
-cacheableBlock :: AppState -> UiBlock -> Bool
-cacheableBlock state block =
+cacheableBlock :: AppState -> AgentTarget -> UiState -> UiBlock -> Bool
+cacheableBlock state target ui block =
     block.blockState
         `notElem` [BlockStreaming, BlockRunning]
         && maybe
             True
             ((/= block.blockId) . (.retryCountdownBlockId))
-            state.appUi.uiRetryCountdown
-        && not (blockFlashing state block)
+            ui.uiRetryCountdown
+        && not (blockFlashing state target block)
 
-blockStateGlyph :: AppState -> UiBlock -> Text
-blockStateGlyph state block = case block.blockState of
+blockStateGlyph :: AppState -> AgentTarget -> UiBlock -> Text
+blockStateGlyph state target block = case block.blockState of
     BlockRunning -> liveGlyph
     BlockStreaming -> liveGlyph
     BlockComplete -> "✓ "
@@ -2533,7 +2600,8 @@ blockStateGlyph state block = case block.blockState of
     BlockCancelled -> "⊘ "
   where
     liveGlyph
-        | userActionPending state =
+        | target == AgentRoot
+        , userActionPending state =
             waitingIndicator
                 motionGlyphSet
                 MotionOff
@@ -2617,9 +2685,9 @@ detailSuffix block
     | Text.null (Text.strip block.blockDetail) = ""
     | otherwise = "  " <> block.blockDetail
 
-statusAttr :: AppState -> UiBlock -> AttrName
-statusAttr state block
-    | blockFlashing state block
+statusAttr :: AppState -> AgentTarget -> UiBlock -> AttrName
+statusAttr state target block
+    | blockFlashing state target block
     , block.blockState == BlockComplete =
         Theme.completionFlashAttr
     | otherwise = case block.blockState of
@@ -2630,17 +2698,18 @@ statusAttr state block
         BlockRunning -> Theme.toolAttr
         BlockStreaming -> Theme.thinkingAttr
 
-thinkingBlockAttr :: AppState -> UiBlock -> AttrName
-thinkingBlockAttr state block
-    | blockFlashing state block
+thinkingBlockAttr :: AppState -> AgentTarget -> UiBlock -> AttrName
+thinkingBlockAttr state target block
+    | blockFlashing state target block
     , block.blockState == BlockComplete =
         Theme.completionFlashAttr
     | otherwise =
         Theme.thinkingAttr
 
-blockFlashing :: AppState -> UiBlock -> Bool
-blockFlashing state block =
-    Map.member block.blockId state.appCompletionFlashes
+blockFlashing :: AppState -> AgentTarget -> UiBlock -> Bool
+blockFlashing state target block =
+    target == AgentRoot
+        && Map.member block.blockId state.appCompletionFlashes
 
 drawNotice :: AppState -> Widget Name
 drawNotice state = case state.appUi.uiNotice of
@@ -3539,18 +3608,37 @@ handleEventInner event = case event of
         state <- get
         let normalized =
                 Bridge.normalizeAgentSelection selected entries
+            mergedEntries =
+                preserveAgentConversationView
+                    normalized
+                    state.appAgentEntries
+                    entries
+            selectionChanged =
+                state.appAgentSelected /= normalized
+            selectedConversationChanged =
+                case normalized of
+                    AgentRoot -> False
+                    target ->
+                        fmap (.agentConversation)
+                            (find
+                                ((== target) . (.agentTarget))
+                                state.appAgentEntries)
+                            /= fmap (.agentConversation)
+                                (find
+                                    ((== target) . (.agentTarget))
+                                    mergedEntries)
         if state.appAgentSelected == normalized
-            && state.appAgentEntries == entries
+            && state.appAgentEntries == mergedEntries
             then pure ()
             else do
                 modify' \current ->
                     current
                         { appAgentSelected = normalized
-                        , appAgentEntries = entries
+                        , appAgentEntries = mergedEntries
                         , appAgentHover =
                             if normalized /= current.appAgentSelected
                                 || length entries <= 1
-                                || agentLayoutTargets entries
+                                || agentLayoutTargets mergedEntries
                                     /= agentLayoutTargets
                                         current.appAgentEntries
                                 then Nothing
@@ -3559,13 +3647,23 @@ handleEventInner event = case event of
                                         if any
                                             ((== hover.agentHoverTarget)
                                                 . (.agentTarget))
-                                            entries
+                                            mergedEntries
                                             then Just hover
                                             else Nothing
                         }
+                when selectedConversationChanged invalidateCache
+                if selectionChanged
+                    then resumeConversationFollow
+                    else when
+                        (selectedConversationChanged
+                            && state.appUi.uiFollow)
+                        do
+                            vScrollToEnd
+                                (viewportScroll ConversationViewport)
+                            queueConversationReflow
                 when
                     ((length state.appAgentEntries > 1)
-                        /= (length entries > 1))
+                        /= (length mergedEntries > 1))
                     do
                         invalidateCache
                         queueConversationReflow
@@ -3691,9 +3789,9 @@ handleEventInner event = case event of
                             (name, V.BLeft)
                                 | isQuickStartControl name ->
                                     Composer.handleControlMouseDown name
-                            (CodeCopy blockId codeIndex, V.BLeft) ->
+                            (CodeCopy target blockId codeIndex, V.BLeft) ->
                                 Composer.handleControlMouseDown
-                                    (CodeCopy blockId codeIndex)
+                                    (CodeCopy target blockId codeIndex)
                             (SlashRow index, V.BLeft) ->
                                 Composer.activateSlashAt
                                     applyLocalUiEventWith
@@ -3714,16 +3812,10 @@ handleEventInner event = case event of
                                     (V.EvKey V.KDown [])
                             (AgentRow target, V.BLeft) -> do
                                 clearAgentHover
-                                liftIO
-                                    (state.appRuntime.runtimeAgentSelect target)
-                                modify' \current ->
-                                    current { appAgentSelected = target }
+                                selectAgentView target
                             (AgentPopover target, V.BLeft) -> do
                                 keepAgentHover target
-                                liftIO
-                                    (state.appRuntime.runtimeAgentSelect target)
-                                modify' \current ->
-                                    current { appAgentSelected = target }
+                                selectAgentView target
                             (link@MarkdownLink{}, V.BLeft) ->
                                 Composer.handleControlMouseDown link
                             _ -> handleMouseDown name button
@@ -3959,6 +4051,15 @@ clearAgentHover =
     modify' \state ->
         state { appAgentHover = Nothing }
 
+selectAgentView :: AgentTarget -> EventM Name AppState ()
+selectAgentView target = do
+    state <- get
+    liftIO (state.appRuntime.runtimeAgentSelect target)
+    when (state.appAgentSelected /= target) do
+        modify' \current ->
+            current { appAgentSelected = target }
+        resumeConversationFollow
+
 isAgentHoverSurface :: Name -> Bool
 isAgentHoverSurface = \case
     AgentPane -> True
@@ -3970,16 +4071,98 @@ agentLayoutTargets :: [AgentEntry] -> [AgentTarget]
 agentLayoutTargets =
     map (.agentTarget) . sortOn (.agentPath)
 
+preserveAgentConversationView
+    :: AgentTarget
+    -> [AgentEntry]
+    -> [AgentEntry]
+    -> [AgentEntry]
+preserveAgentConversationView selected previous =
+    map preserve
+  where
+    preserve incoming
+        | incoming.agentTarget /= selected = incoming
+        | otherwise =
+            case find
+                ((== incoming.agentTarget) . (.agentTarget))
+                previous of
+                Nothing -> incoming
+                Just old ->
+                    incoming
+                        { agentConversation =
+                            mergeConversationView
+                                old.agentConversation
+                                incoming.agentConversation
+                        }
+
+mergeConversationView :: UiState -> UiState -> UiState
+mergeConversationView previous incoming
+    | Seq.null incoming.uiBlocks = incoming
+    | otherwise =
+        incoming
+            { uiBlocks = mergedBlocks
+            , uiSelectedBlock = selected
+            , uiSelectedBlockIndex =
+                selected >>= (`Map.lookup` incoming.uiBlockIndices)
+            }
+  where
+    previousBlocks =
+        Map.fromList
+            [ (block.blockId, block)
+            | block <- toList previous.uiBlocks
+            ]
+    mergedBlocks =
+        fmap
+            (\block ->
+                case Map.lookup block.blockId previousBlocks of
+                    Just old
+                        | sameConversationBlock old block ->
+                            block
+                                { blockExpanded = old.blockExpanded
+                                }
+                    _ -> block)
+            incoming.uiBlocks
+    selected =
+        case previous.uiSelectedBlock of
+            Just ident
+                | Just old <- Map.lookup ident previousBlocks
+                , Just new <-
+                    Map.lookup ident incoming.uiBlockIndices
+                        >>= \index -> Seq.lookup index incoming.uiBlocks
+                , sameConversationBlock old new ->
+                    Just ident
+            _ -> incoming.uiSelectedBlock
+
+sameConversationBlock :: UiBlock -> UiBlock -> Bool
+sameConversationBlock previous incoming =
+    previous.blockKind == incoming.blockKind
+        && previous.blockTitle == incoming.blockTitle
+        && case (previous.blockCallId, incoming.blockCallId) of
+            (Just oldCall, Just newCall) -> oldCall == newCall
+            (Nothing, Nothing) ->
+                previous.blockBody == incoming.blockBody
+            _ -> False
+
 handleMouseDown :: Name -> V.Button -> EventM Name AppState ()
 handleMouseDown name button =
     case button of
         V.BScrollUp -> scrollConversationBy (-mouseScrollLines)
         V.BScrollDown -> scrollConversationBy mouseScrollLines
         V.BLeft -> case name of
-            ConversationBlock ident ->
-                applyLocalUiEventWith
-                    (UiActivateBlock ident)
-                    (applyUiEvent (UiFocusChanged FocusScrollback))
+            ConversationBlock target ident ->
+                case target of
+                    AgentRoot ->
+                        applyLocalUiEventWith
+                            (UiActivateBlock ident)
+                            (applyUiEvent
+                                (UiFocusChanged FocusScrollback))
+                    AgentChild _ -> do
+                        modify' $
+                            applyChildConversationUiEvent
+                                target
+                                (UiActivateBlock ident)
+                        applyLocalUiEvent
+                            (UiFocusChanged FocusScrollback)
+                        queueConversationReflow
             ComposerArea ->
                 applyLocalUiEvent (UiFocusChanged FocusComposer)
             _ -> pure ()
@@ -4006,12 +4189,12 @@ handleScrollbackKey = \case
         leaveFollow
         vScrollToBeginning scroll
         queueConversationReflow
-    V.EvKey V.KEnd [] -> resumeFollow
+    V.EvKey V.KEnd [] -> resumeConversationFollow
     V.EvKey (V.KChar 'g') [] -> do
         leaveFollow
         vScrollToBeginning scroll
         queueConversationReflow
-    V.EvKey (V.KChar 'G') [] -> resumeFollow
+    V.EvKey (V.KChar 'G') [] -> resumeConversationFollow
     V.EvKey V.KLeft [] -> toggle
     V.EvKey V.KRight [] -> toggle
     V.EvKey V.KEnter [] -> toggle
@@ -4023,32 +4206,26 @@ handleScrollbackKey = \case
   where
     scroll = viewportScroll ConversationViewport
     moveBlock delta = do
-        applyLocalUiEvent (UiMoveSelection delta)
         state <- get
-        case state.appUi.uiSelectedBlock of
+        let target = state.appAgentSelected
+        applyActiveConversationUiEvent (UiMoveSelection delta)
+        state <- get
+        case (.uiSelectedBlock) =<< conversationUiForTarget target state of
             Just ident -> do
-                makeVisible (ConversationBlock ident)
+                makeVisible (ConversationBlock target ident)
                 queueConversationReflow
             Nothing -> pure ()
     toggle = do
-        applyLocalUiEvent UiToggleSelected
+        applyActiveConversationUiEvent UiToggleSelected
         queueConversationReflow
     focusComposer =
         applyLocalUiEvent (UiFocusChanged FocusComposer)
     leaveFollow =
         applyLocalUiEvent (UiSetFollow False)
-    resumeFollow = do
-        applyLocalUiEventWith (UiSetFollow True) \state ->
-            state
-                { appConversationAnchor =
-                    Scroll.followConversationTail
-                        <$> state.appConversationAnchor
-                }
-        vScrollToEnd scroll
-        queueConversationReflow
     copySelected = do
         state <- get
-        case state.appUi.uiSelectedBlock >>= selectedBlock state.appUi of
+        let ui = activeConversationUi state
+        case ui.uiSelectedBlock >>= selectedBlock ui of
             Nothing -> pure ()
             Just block -> do
                 copied <- liftIO $
@@ -4061,6 +4238,26 @@ handleScrollbackKey = \case
                                     "Copied selected block."
                                 else warningNotice
                                     "Terminal clipboard is unavailable."
+
+resumeConversationFollow :: EventM Name AppState ()
+resumeConversationFollow = do
+    applyLocalUiEventWith (UiSetFollow True) \state ->
+        state
+            { appConversationAnchor =
+                Scroll.followConversationTail
+                    <$> state.appConversationAnchor
+            }
+    vScrollToEnd (viewportScroll ConversationViewport)
+    queueConversationReflow
+
+applyActiveConversationUiEvent :: UiEvent -> EventM Name AppState ()
+applyActiveConversationUiEvent uiEvent = do
+    state <- get
+    case state.appAgentSelected of
+        AgentRoot ->
+            applyLocalUiEvent uiEvent
+        target@(AgentChild _) ->
+            modify' (applyChildConversationUiEvent target uiEvent)
 
 scrollConversationPage :: Direction -> EventM Name AppState ()
 scrollConversationPage direction = do

--- a/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
@@ -46,17 +46,19 @@ data Name
     = ConversationViewport
     | ConversationReserve
     | OverlayViewport
-    | ConversationBlock !BlockId
+    | ConversationBlock !AgentTarget !BlockId
     | ConversationChunkCache
+        !AgentTarget
         !BlockId
         !BlockId
     | ConversationBlockCache
+        !AgentTarget
         !BlockId
         !Bool
         !Bool
         !(Maybe (Int, Bool))
-    | CodeBlockCache !BlockId !Int
-    | CodeCopy !BlockId !Int
+    | CodeBlockCache !AgentTarget !BlockId !Int
+    | CodeCopy !AgentTarget !BlockId !Int
     | MarkdownLink !Text
     | ComposerArea
     | ComposerCursor

--- a/packages/agent-cli/test/Agent/CLI/AgentViewportSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/AgentViewportSpec.hs
@@ -4,8 +4,16 @@ import Agent.CLI.AgentViewport
 import Agent.CLI.Picker (PickerKey(..))
 import Agent.Responses.Types
 import Agent.Subagents (SubagentId(..), SubagentStatus(..))
+import Agent.TUI.Model
+    ( BlockKind(..)
+    , BlockState(..)
+    , UiBlock(..)
+    , UiState(..)
+    , initialUiState
+    )
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.KeyMap as KeyMap
+import Data.Foldable (toList)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Test.Hspec
@@ -145,6 +153,59 @@ spec = do
                 ]
                 `shouldBe` ["user: request"]
 
+    describe "responseItemsToUiState" do
+        it "replays child messages, reasoning, and tools into retained blocks" do
+            let ui =
+                    responseItemsToUiState False
+                        [ agentMessageItem "Investigate the renderer"
+                        , reasoningItem "Compare both paths" "private detail"
+                        , functionCallItem
+                            "call-1"
+                            "shell_command"
+                            "{\"command\":\"printf done\"}"
+                            (Just ItemCompleted)
+                        , functionOutputItem
+                            "call-1"
+                            (Just ItemCompleted)
+                        , messageItem
+                            RoleAssistant
+                            "Finished with **Markdown** intact."
+                        ]
+                blocks = toList ui.uiBlocks
+            map (.blockKind) blocks
+                `shouldBe`
+                    [ BlockUser
+                    , BlockThinking
+                    , BlockShell
+                    , BlockAssistant
+                    ]
+            map (.blockState) blocks
+                `shouldBe`
+                    [ BlockComplete
+                    , BlockComplete
+                    , BlockComplete
+                    , BlockComplete
+                    ]
+            map (.blockBody) blocks
+                `shouldBe`
+                    [ "Investigate the renderer"
+                    , "Compare both paths"
+                    , "ok"
+                    , "Finished with **Markdown** intact."
+                    ]
+
+        it "shows raw reasoning only when explicitly enabled" do
+            let items = [reasoningItem "Visible summary" "private detail"]
+                body visible =
+                    (.blockBody)
+                        <$> atMay
+                            (toList
+                                (responseItemsToUiState visible items).uiBlocks)
+                            0
+            body False `shouldBe` Just "Visible summary"
+            body True
+                `shouldBe` Just "Visible summary\nprivate detail"
+
     describe "responseItemStepPreviews" do
         it "coalesces tool calls with their outputs and returns newest first" do
             let steps =
@@ -263,6 +324,7 @@ rootEntry =
         , agentModel = Nothing
         , agentSteps = []
         , agentTranscript = ["user: hello", "assistant: ready"]
+        , agentConversation = initialUiState
         }
 
 child :: Text -> Text -> Text -> AgentEntry
@@ -274,6 +336,7 @@ child agentId path status =
         , agentModel = Just "gpt-5.6-luna"
         , agentSteps = []
         , agentTranscript = ["assistant: working"]
+        , agentConversation = initialUiState
         }
 
 messageItem :: ResponseRole -> Text -> ResponseItem
@@ -311,6 +374,53 @@ functionOutputItem callId status =
         , status
         , extraFields = KeyMap.empty
         }
+
+agentMessageItem :: Text -> ResponseItem
+agentMessageItem text =
+    KnownResponseItem ItemAgentMessage TaggedObject
+        { tag = "agent_message"
+        , fields = KeyMap.fromList
+            [ ( "content"
+              , Aeson.toJSON
+                    [ Aeson.object
+                        [ "type" Aeson..= ("input_text" :: Text)
+                        , "text" Aeson..= text
+                        ]
+                    ]
+              )
+            ]
+        }
+
+reasoningItem :: Text -> Text -> ResponseItem
+reasoningItem summary raw =
+    ReasoningItemValue ReasoningItem
+        { itemId = Nothing
+        , summary =
+            [ ReasoningSummaryPart
+                { partType = "summary_text"
+                , text = Just summary
+                , extraFields = KeyMap.empty
+                }
+            ]
+        , content =
+            Just
+                [ ReasoningTextPart
+                    { text = raw
+                    , extraFields = KeyMap.empty
+                    }
+                ]
+        , encryptedContent = Nothing
+        , status = Just ItemCompleted
+        , extraFields = KeyMap.empty
+        }
+
+atMay :: [a] -> Int -> Maybe a
+atMay values index
+    | index < 0 = Nothing
+    | otherwise =
+        case drop index values of
+            value : _ -> Just value
+            [] -> Nothing
 
 rightState :: Either (Maybe AgentTarget) AgentViewportState -> IO AgentViewportState
 rightState result = case result of

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -16,6 +16,7 @@ import Agent.CLI.TUI.App
     , fullscreenBounds
     , fullscreenVtyConfig
     , fullscreenSurface
+    , mergeConversationView
     , motionDemandFor
     , lambdaArtWidget
     , quickStartRows
@@ -56,6 +57,7 @@ import Agent.ToolDispatch
     )
 import Agent.TUI.Model
 import Agent.TUI.Motion
+import Data.Foldable (find)
 import qualified Data.Map.Strict as Map
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -358,6 +360,37 @@ spec = do
             selectedAgentConversation AgentRoot [rootEntry, child]
                 `shouldBe` Nothing
 
+        it "preserves child block selection and expansion across snapshots" do
+            let replay =
+                    foldl
+                        (flip reduceUi)
+                        initialUiState
+                        [ UiUserSubmitted "investigate"
+                        , UiLoop TurnStarted
+                        , UiLoop (ReasoningDelta "compare paths")
+                        , UiAssistantHistory "done"
+                        ]
+            case find
+                    ((== BlockThinking) . (.blockKind))
+                    replay.uiBlocks of
+                Nothing ->
+                    expectationFailure "expected a reasoning block"
+                Just reasoning -> do
+                    let previous =
+                            reduceUi
+                                (UiActivateBlock reasoning.blockId)
+                                replay
+                        merged = mergeConversationView previous replay
+                    merged.uiSelectedBlock
+                        `shouldBe` Just reasoning.blockId
+                    fmap (.blockExpanded)
+                        (find
+                            ((== reasoning.blockId) . (.blockId))
+                            merged.uiBlocks)
+                        `shouldBe` Just True
+                    mergeConversationView previous initialUiState
+                        `shouldBe` initialUiState
+
     describe "conversation scrollbar" do
         it "uses a visible trough that repaints old thumb cells" do
             let renderCell widget =
@@ -628,6 +661,7 @@ rootEntry = AgentEntry
     , agentModel = Nothing
     , agentSteps = []
     , agentTranscript = []
+    , agentConversation = initialUiState
     }
 
 childEntry :: Int -> AgentEntry
@@ -638,6 +672,7 @@ childEntry index = AgentEntry
     , agentModel = Just "gpt-5.6-luna"
     , agentSteps = []
     , agentTranscript = []
+    , agentConversation = initialUiState
     }
   where
     name :: Text

--- a/packages/agent-cli/test/Agent/CLI/TUIBridgeSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIBridgeSpec.hs
@@ -237,7 +237,16 @@ spec = describe "fullscreen TUI bridge" do
     it "falls back to root when the selected agent disappears" do
         let child = AgentChild (SubagentId "child")
             other = AgentChild (SubagentId "other")
-            root = AgentEntry AgentRoot "/root" "active" Nothing [] []
+            root =
+                AgentEntry
+                    { agentTarget = AgentRoot
+                    , agentPath = "/root"
+                    , agentStatus = "active"
+                    , agentModel = Nothing
+                    , agentSteps = []
+                    , agentTranscript = []
+                    , agentConversation = initialUiState
+                    }
         normalizeAgentSelection child [root] `shouldBe` AgentRoot
         normalizeAgentSelection AgentRoot [root] `shouldBe` AgentRoot
         reconcileAgentSelection [AgentRoot] child

--- a/packages/agent-cli/test/Agent/CLI/TUIPropertySpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIPropertySpec.hs
@@ -20,6 +20,11 @@ import Agent.CLI.TUI.Types
     )
 import Agent.Loop (LoopEvent(..))
 import Agent.Subagents (SubagentId(..))
+import Agent.ToolDispatch
+    ( ToolCallKind(..)
+    , ToolCallResult(..)
+    , functionToolCall
+    )
 import Agent.TUI.Model
     ( BlockId(..)
     , BlockState(..)
@@ -219,6 +224,65 @@ spec = do
             rendered `shouldSatisfy`
                 Text.isInfixOf "Inspect AppState before continuing."
             rendered `shouldNotSatisfy` Text.isInfixOf "`AppState`"
+
+        it "renders a selected child with the retained conversation renderer" do
+            let target = AgentChild (SubagentId "renderer")
+                call =
+                    functionToolCall
+                        "call-1"
+                        "shell_command"
+                        "{\"command\":\"printf rich-child\"}"
+                conversation =
+                    foldl
+                        (flip reduceUi)
+                        initialUiState
+                        [ UiUserSubmitted "Investigate the renderer"
+                        , UiLoop TurnStarted
+                        , UiLoop
+                            (ReasoningDelta
+                                "Compare the retained block paths")
+                        , UiLoop (ToolStarted call)
+                        , UiLoop
+                            (ToolFinished ToolCallResult
+                                { callId = "call-1"
+                                , output = "tool output"
+                                , callKind = FunctionCallKind
+                                })
+                        , UiAssistantHistory
+                            "## Result\n\nMarkdown **kept**."
+                        , UiTurnEnded BlockComplete
+                        ]
+                child =
+                    AgentEntry
+                        { agentTarget = target
+                        , agentPath = "/root/renderer"
+                        , agentStatus = "done"
+                        , agentModel = Just "gpt-5.6-luna"
+                        , agentSteps = []
+                        , agentTranscript = []
+                        , agentConversation = conversation
+                        }
+                app =
+                    baseState
+                        { appAgentSelected = target
+                        , appAgentEntries = [rootEntry, child]
+                        }
+                size = (120, 40)
+                frame =
+                    Text.unlines $
+                        pictureRows
+                            (renderWidget
+                                (Just Theme.monochrome)
+                                (drawApp app)
+                                size)
+                            size
+            frame `shouldSatisfy` Text.isInfixOf "Viewing /root/renderer"
+            frame `shouldSatisfy` Text.isInfixOf "Investigate the renderer"
+            frame `shouldSatisfy`
+                Text.isInfixOf "Compare the retained block paths"
+            frame `shouldSatisfy` Text.isInfixOf "rich-child"
+            frame `shouldSatisfy` Text.isInfixOf "tool output"
+            frame `shouldSatisfy` Text.isInfixOf "Markdown kept."
 
 renderTraceProperty :: AppState -> RenderTrace -> Property
 renderTraceProperty baseState (RenderTrace actions) =
@@ -481,6 +545,7 @@ rootEntry = AgentEntry
     , agentModel = Nothing
     , agentSteps = []
     , agentTranscript = []
+    , agentConversation = initialUiState
     }
 
 childEntry :: Text -> Int -> AgentEntry
@@ -494,6 +559,7 @@ childEntry transcript index = AgentEntry
         [ "user: " <> transcript
         , "assistant: " <> Text.reverse transcript
         ]
+    , agentConversation = initialUiState
     }
 
 makeBaseState :: IO AppState

--- a/packages/agent-responses/src/Agent/Responses/LoopBackend.hs
+++ b/packages/agent-responses/src/Agent/Responses/LoopBackend.hs
@@ -5,6 +5,7 @@ module Agent.Responses.LoopBackend
     , tokenProviderStatelessResponsesBackend
     , turnInputsToItems
     , responseToTurnOutput
+    , responseItemToToolCall
     , responseTokenUsage
     , streamEventToLoopEvent
     , streamEventToLoopEventWithRawReasoning


### PR DESCRIPTION
## Summary
- replay persisted child response items into retained `UiState`
- render selected children through the same Markdown, reasoning, and tool-block path as the root transcript
- namespace interaction and cache keys by agent while preserving child selection, expansion, and follow behavior
- keep compact picker summaries without maintaining a duplicate plain-text transcript

## Validation
- `nix develop -c cabal repl agent-cli:lib:agent-cli agent-responses:lib:agent-responses agent-tui:lib:agent-tui`
- focused Hspec coverage for response replay, child-view preservation, and selected-child rendering
- generated fullscreen rendering properties: 300 frame-bound cases and 100 incremental-redraw cases
- live tmux smoke: spawned and selected a child from the top-right panel; verified reasoning, shell/read details, Markdown rendering, and root/child switching