### PR TITLE
feat(tui): render todo_write as a truncated checklist

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Render.hs
+++ b/packages/agent-cli/src/Agent/CLI/Render.hs
@@ -14,6 +14,7 @@ module Agent.CLI.Render
     , formatLoopErrorPersistedAt
     , formatSearchReplaceDiff
     , formatThinkingBlock
+    , formatToolBody
     , formatToolOutput
     , formatToolStarted
     , formatTurnStatus
@@ -72,6 +73,7 @@ import Agent.CLI.Style
     , roleWarn
     , terminalGreen
     , terminalRed
+    , terminalYellow
     , motionGlyphSet
     , style
     )
@@ -80,9 +82,14 @@ import Agent.TUI.Presentation
     ( SearchReplaceAction(..)
     , SearchReplaceDiff(..)
     , SearchReplaceLine(..)
+    , TodoDisplayLine(..)
+    , TodoDisplayStatus(..)
     , formatToolOutput
     , parseSearchReplaceDiff
+    , parseTodoList
     , summarizeToolCall
+    , todoCallPreview
+    , todoStatusGlyph
     , toolDetail
     )
 import Agent.ToolDispatch
@@ -546,11 +553,17 @@ renderEventUnlocked config = \case
     ToolFinished result -> do
         calls <- readIORef config.renderToolCalls
         modifyIORef' config.renderToolCalls (Map.delete result.callId)
-        let output = maybe result.output
+        let maybeCall = Map.lookup result.callId calls
+            formatted = maybe result.output
                 (`formatToolOutput` result.output)
-                (Map.lookup result.callId calls)
-        putTextLn config.renderStderr
-            (roleToolOutput config.renderColor (truncateToolOutput output))
+                maybeCall
+            painted = case maybeCall of
+                Just call
+                    | canonicalToolName call.name `elem` ["todo_write", "update_plan"] ->
+                        formatTodoOutput config.renderColor formatted
+                _ ->
+                    roleToolOutput config.renderColor (truncateToolOutput formatted)
+        putTextLn config.renderStderr painted
 
 -- | Style assistant markdown when color is enabled; otherwise return plain text.
 -- The terminal theme owns the default assistant background.
@@ -934,7 +947,8 @@ toolChrome name = case canonicalToolName name of
     "followup_task" -> ToolChrome "Followed up with" ToolDetailMuted
     "list_agents" -> ToolChrome "Listed agents" ToolDetailMuted
     "interrupt_agent" -> ToolChrome "Interrupted" ToolDetailMuted
-    "update_plan" -> ToolChrome "Updated" ToolDetailMuted
+    "todo_write" -> ToolChrome "todo_write" ToolDetailNone
+    "update_plan" -> ToolChrome "update_plan" ToolDetailNone
     "enter_plan_mode" -> ToolChrome "Entered" ToolDetailMuted
     "exit_plan_mode" -> ToolChrome "Exited" ToolDetailMuted
     "ask_user_question" -> ToolChrome "Asked" ToolDetailMuted
@@ -949,7 +963,44 @@ toolChrome name = case canonicalToolName name of
 formatToolBody :: Bool -> ToolCall -> Text
 formatToolBody color call = case canonicalToolName call.name of
     "search_replace" -> formatSearchReplaceDiff color call.arguments
+    "todo_write" -> formatTodoPreview color call
+    "update_plan" -> formatTodoPreview color call
     _ -> ""
+
+formatTodoPreview :: Bool -> ToolCall -> Text
+formatTodoPreview color call =
+    let preview = todoCallPreview call
+    in if Text.null preview
+        then ""
+        else paintTodoLine color (TodoDisplayLine TodoDisplayPending preview)
+
+formatTodoOutput :: Bool -> Text -> Text
+formatTodoOutput color output =
+    let parsed = parseTodoList output
+        shown = take 3 parsed
+        hidden = length parsed - length shown
+        rows = map (paintTodoLine color) shown
+        overflow
+            | hidden > 0 =
+                [ glyphToolAccent
+                    <> glyphToolOut
+                    <> roleMuted color
+                        ("… +" <> Text.pack (show hidden) <> " lines")
+                ]
+            | otherwise = []
+    in Text.intercalate "\n" (rows <> overflow)
+
+paintTodoLine :: Bool -> TodoDisplayLine -> Text
+paintTodoLine color line =
+    let glyph = todoStatusGlyph line.todoLineStatus
+        body = glyph <> " " <> line.todoLineText
+        painted = case line.todoLineStatus of
+            TodoDisplayPending -> roleMuted color body
+            TodoDisplayInProgress ->
+                style color [terminalYellow] body
+            TodoDisplayCompleted -> roleSuccess color body
+            TodoDisplayCancelled -> roleMuted color body
+    in glyphToolAccent <> glyphToolOut <> painted
 
 -- | Compact unified-diff preview for @search_replace@ arguments.
 formatSearchReplaceDiff :: Bool -> Text -> Text

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -172,7 +172,13 @@ import Agent.TUI.Motion
     , quietIndicator
     , waitingIndicator
     )
-import Agent.TUI.Presentation (permissionToolCallPrompt)
+import Agent.TUI.Presentation
+    ( TodoDisplayLine(..)
+    , TodoDisplayStatus(..)
+    , parseTodoList
+    , permissionToolCallPrompt
+    , todoStatusGlyph
+    )
 import Agent.Loop (ImageAttachment(..), LoopEvent(..))
 import Agent.ToolDispatch (ToolCall(..))
 import Brick
@@ -2490,6 +2496,10 @@ drawBlock state target ui block =
                         <> block.blockTitle
                         <> detailSuffix block)
                     (visibleBody block)
+            BlockTodo ->
+                accentBlockWithSections (statusAttr state block)
+                    (blockStateGlyph state block <> block.blockTitle)
+                    (todoBodyWidgets block)
             BlockShell ->
                 accentCodeBlock
                     state.appSyntaxHighlighter
@@ -2661,14 +2671,48 @@ accentBlockWithSections accent title sections =
 visibleBody :: UiBlock -> Text
 visibleBody block
     | block.blockExpanded = block.blockBody
-    | otherwise =
-        let rows = Text.lines block.blockBody
-            shown = take 3 rows
-            hidden = length rows - length shown
-        in Text.unlines shown
-            <> if hidden > 0
-                then "… +" <> Text.pack (show hidden) <> " lines"
-                else ""
+    | otherwise = truncatedLines 3 block.blockBody
+
+todoBodyWidgets :: UiBlock -> [Widget Name]
+todoBodyWidgets block =
+    let parsed = parseTodoList block.blockBody
+        (shown, hidden)
+            | block.blockExpanded = (parsed, 0)
+            | otherwise =
+                let visible = take 3 parsed
+                in (visible, length parsed - length visible)
+        rows = map todoLineWidget shown
+        overflow
+            | hidden > 0 =
+                [ withAttr Theme.mutedAttr
+                    (txt ("… +" <> Text.pack (show hidden) <> " lines"))
+                ]
+            | otherwise = []
+    in case rows <> overflow of
+        [] -> []
+        widgets -> [vBox widgets]
+
+todoLineWidget :: TodoDisplayLine -> Widget Name
+todoLineWidget line =
+    withAttr (todoStatusAttr line.todoLineStatus)
+        (txtWrap (todoStatusGlyph line.todoLineStatus <> " " <> line.todoLineText))
+
+todoStatusAttr :: TodoDisplayStatus -> AttrName
+todoStatusAttr = \case
+    TodoDisplayPending -> Theme.todoPendingAttr
+    TodoDisplayInProgress -> Theme.todoInProgressAttr
+    TodoDisplayCompleted -> Theme.todoCompletedAttr
+    TodoDisplayCancelled -> Theme.todoCancelledAttr
+
+truncatedLines :: Int -> Text -> Text
+truncatedLines shownCount body =
+    let rows = Text.lines body
+        shown = take shownCount rows
+        hidden = length rows - length shown
+    in Text.unlines shown
+        <> if hidden > 0
+            then "… +" <> Text.pack (show hidden) <> " lines"
+            else ""
 
 visibleShellBody :: UiBlock -> Text
 visibleShellBody block

--- a/packages/agent-cli/src/Agent/CLI/TUI/Motion.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Motion.hs
@@ -150,7 +150,7 @@ completionFlashTransitions previous next =
     , blockWasLive oldBlock.blockState
     , block.blockState == BlockComplete
     , block.blockKind
-        `elem` [BlockThinking, BlockTool, BlockShell, BlockEdit]
+        `elem` [BlockThinking, BlockTool, BlockTodo, BlockShell, BlockEdit]
     ]
   where
     previousById =

--- a/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
@@ -103,6 +103,15 @@ spec = do
             let call = functionToolCall "c1" "collaboration.spawn_agent" "{}"
             formatToolOutput call "not json" `shouldBe` "not json"
 
+        it "renders todo_write output as a glyph checklist" do
+            formatToolOutput
+                (functionToolCall "c1" "todo_write" "{}")
+                "- [completed] 1: Find and clone repos\n\
+                \- [pending] 2: Investigate Codex"
+                `shouldBe`
+                    "✓ Find and clone repos\n\
+                    \□ Investigate Codex"
+
     describe "formatElapsed" do
         it "formats seconds and minutes" do
             formatElapsed 0.4 `shouldBe` "0.4s"
@@ -132,6 +141,17 @@ spec = do
         it "keeps unknown tool names" do
             formatToolStarted False (functionToolCall "c5" "custom_tool" "{\"x\":1}")
                 `shouldBe` "◆ custom_tool"
+
+        it "keeps todo_write and update_plan on their wire names" do
+            formatToolStarted False
+                (functionToolCall
+                    "c8"
+                    "todo_write"
+                    "{\"todos\":[{\"id\":\"1\",\"content\":\"Find repos\"}]}")
+                `shouldBe` "◆ todo_write"
+            formatToolStarted False
+                (functionToolCall "c9" "update_plan" "{\"plan\":[]}")
+                `shouldBe` "◆ update_plan"
 
         it "renders learned-skill mutations as visible learning activity" do
             formatToolStarted False
@@ -163,6 +183,16 @@ spec = do
             formatSearchReplaceDiff False
                 "{\"file_path\":\"src/Old.hs\",\"old_string\":\"bye\",\"new_string\":\"\"}"
                 `shouldSatisfy` Text.isInfixOf "delete src/Old.hs"
+
+    describe "formatToolBody" do
+        it "previews the first todo_write item while the call is running" do
+            formatToolBody False
+                (functionToolCall
+                    "c1"
+                    "todo_write"
+                    "{\"todos\":[{\"id\":\"1\",\"content\":\"Find and clone repos\"},\
+                    \{\"id\":\"2\",\"content\":\"Investigate Codex\"}]}")
+                `shouldBe` "❙ ┊ □ Find and clone repos"
 
     describe "formatLoopError" do
         it "explains a max-turn stop" do
@@ -558,6 +588,30 @@ spec = do
                 body `shouldSatisfy` Text.isInfixOf "Listed"
                 body `shouldSatisfy` Text.isInfixOf "\ESC["
                 body `shouldSatisfy` Text.isInfixOf "ok"
+
+        it "renders completed todo_write checklists with truncation" do
+            withRenderConfig False False \config handle path -> do
+                let call =
+                        functionToolCall
+                            "c1"
+                            "todo_write"
+                            "{\"todos\":[{\"id\":\"1\",\"content\":\"Find repos\"}]}"
+                renderEvent config (ToolStarted call)
+                renderEvent config (ToolFinished ToolCallResult
+                    { callId = "c1"
+                    , output =
+                        "- [completed] 1: Find and clone Grok Build and Codex repos\n\
+                        \- [completed] 2: Investigate how Grok Build summarizes completed sessions in TUI\n\
+                        \- [completed] 3: Investigate how Codex summarizes completed sessions in TUI\n\
+                        \- [pending] 4: Implement matching chrome"
+                    , callKind = FunctionCallKind
+                    })
+                hClose handle
+                body <- Text.readFile path
+                body `shouldSatisfy` Text.isInfixOf "◆ todo_write"
+                body `shouldSatisfy` Text.isInfixOf "✓ Find and clone Grok Build and Codex repos"
+                body `shouldSatisfy` Text.isInfixOf "… +1 lines"
+                body `shouldNotSatisfy` Text.isInfixOf "[completed]"
 
         it "keeps thinking plain when color is off" do
             withRenderConfig True False \config handle path -> do

--- a/packages/agent-tui/src/Agent/TUI/Model.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model.hs
@@ -38,6 +38,7 @@ module Agent.TUI.Model
 import Agent.TUI.Presentation
     ( formatSearchReplaceDiff
     , formatToolOutput
+    , todoCallPreview
     , toolCallInput
     , toolCallTitle
     )
@@ -71,6 +72,7 @@ data BlockKind
     | BlockAssistant
     | BlockThinking
     | BlockTool
+    | BlockTodo
     | BlockShell
     | BlockEdit
     | BlockSystem
@@ -648,9 +650,11 @@ reduceLoop event state = case event of
             kind = toolBlockKind call.name
             title = toolCallTitle call
             blockIndex = Seq.length state.uiBlocks
-            body = case call.name of
+            body = case canonicalToolName call.name of
                 "search_replace" ->
                     formatSearchReplaceDiff call.arguments
+                "todo_write" -> todoCallPreview call
+                "update_plan" -> todoCallPreview call
                 _ -> ""
             detail = toolCallInput call
         in appendBlock kind title body detail
@@ -1034,6 +1038,8 @@ toolBlockKind rawName
         BlockShell
     | name `elem` ["search_replace", "apply_patch"] =
         BlockEdit
+    | name `elem` ["todo_write", "update_plan"] =
+        BlockTodo
     | otherwise = BlockTool
   where
     name = canonicalToolName rawName

--- a/packages/agent-tui/src/Agent/TUI/Presentation.hs
+++ b/packages/agent-tui/src/Agent/TUI/Presentation.hs
@@ -3,11 +3,17 @@ module Agent.TUI.Presentation
     ( SearchReplaceAction(..)
     , SearchReplaceDiff(..)
     , SearchReplaceLine(..)
+    , TodoDisplayLine(..)
+    , TodoDisplayStatus(..)
     , formatSearchReplaceDiff
+    , formatTodoList
     , formatToolOutput
     , parseSearchReplaceDiff
+    , parseTodoList
     , permissionToolCallPrompt
     , summarizeToolCall
+    , todoCallPreview
+    , todoStatusGlyph
     , toolCallInput
     , toolCallTitle
     , toolDetail
@@ -22,6 +28,8 @@ import Agent.ToolDispatch
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KeyMap
+import Control.Applicative ((<|>))
+import Data.Char (isSpace)
 import Data.Foldable (toList)
 import Data.Maybe (fromMaybe, mapMaybe)
 import Data.Text (Text)
@@ -152,7 +160,147 @@ formatToolOutput call output = case canonicalToolName call.name of
     "skill_update" -> fromMaybe output (formatSkillMutation output)
     "skill_archive" -> fromMaybe output (formatSkillMutation output)
     "skill_rollback" -> fromMaybe output (formatSkillMutation output)
+    "todo_write" -> formatTodoList output
+    "update_plan" -> formatTodoList output
     _ -> output
+
+data TodoDisplayStatus
+    = TodoDisplayPending
+    | TodoDisplayInProgress
+    | TodoDisplayCompleted
+    | TodoDisplayCancelled
+    deriving (Eq, Show)
+
+data TodoDisplayLine = TodoDisplayLine
+    { todoLineStatus :: !TodoDisplayStatus
+    , todoLineText :: !Text
+    }
+    deriving (Eq, Show)
+
+-- | Compact preview of the first todo content from a @todo_write@ /
+-- @update_plan@ argument payload, used while the tool is still running.
+todoCallPreview :: ToolCall -> Text
+todoCallPreview call = case canonicalToolName call.name of
+    "todo_write" -> firstTodoContentFromArguments call.arguments
+    "update_plan" -> firstPlanStepFromArguments call.arguments
+    _ -> ""
+
+formatTodoList :: Text -> Text
+formatTodoList output =
+    Text.intercalate "\n" (map formatTodoDisplayLine (parseTodoList output))
+
+parseTodoList :: Text -> [TodoDisplayLine]
+parseTodoList output =
+    let rows =
+            [ Text.strip line
+            | line <- Text.lines (Text.stripEnd output)
+            , not (Text.null (Text.strip line))
+            ]
+        parsed = mapMaybe parseTodoDisplayLine rows
+    in if null parsed
+        then map (TodoDisplayLine TodoDisplayPending) rows
+        else parsed
+
+parseTodoDisplayLine :: Text -> Maybe TodoDisplayLine
+parseTodoDisplayLine raw =
+    parseGlyphTodoLine line <|> parseMarkedTodoLine line
+  where
+    line = Text.strip raw
+
+parseGlyphTodoLine :: Text -> Maybe TodoDisplayLine
+parseGlyphTodoLine line =
+    foldr (\(status, glyph) acc -> acc <|> prefixed status glyph) Nothing
+        [ (TodoDisplayCompleted, "✓")
+        , (TodoDisplayInProgress, "▶")
+        , (TodoDisplayCancelled, "✗")
+        , (TodoDisplayPending, "□")
+        ]
+  where
+    prefixed status glyph = do
+        rest <-
+            Text.stripPrefix (glyph <> " ") line
+                <|> Text.stripPrefix glyph line
+        let content = Text.strip rest
+        if Text.null content
+            then Nothing
+            else Just (TodoDisplayLine status content)
+
+parseMarkedTodoLine :: Text -> Maybe TodoDisplayLine
+parseMarkedTodoLine line =
+    let body = Text.strip (Text.dropWhile (== '-') line)
+        (marker, rest) = Text.break (== ']') body
+    in do
+        status <- parseTodoStatusMarker (Text.strip (Text.dropWhile (== '[') marker))
+        rest' <- Text.stripPrefix "]" rest
+        let content = stripTodoIdentifier (Text.strip rest')
+        if Text.null content
+            then Nothing
+            else Just (TodoDisplayLine status content)
+
+parseTodoStatusMarker :: Text -> Maybe TodoDisplayStatus
+parseTodoStatusMarker = \case
+    "pending" -> Just TodoDisplayPending
+    "in_progress" -> Just TodoDisplayInProgress
+    "completed" -> Just TodoDisplayCompleted
+    "cancelled" -> Just TodoDisplayCancelled
+    _ -> Nothing
+
+stripTodoIdentifier :: Text -> Text
+stripTodoIdentifier text =
+    case Text.break (== ':') text of
+        (before, after)
+            | not (Text.null after)
+            , looksLikeTodoId (Text.strip before) ->
+                Text.strip (Text.drop 1 after)
+        _ -> text
+
+looksLikeTodoId :: Text -> Bool
+looksLikeTodoId text =
+    not (Text.null text)
+        && Text.length text <= 24
+        && not (Text.any isSpace text)
+        && Text.all isTodoIdChar text
+
+isTodoIdChar :: Char -> Bool
+isTodoIdChar c =
+    c == '-' || c == '_' || c == '.' || isAsciiAlphaNum c
+
+isAsciiAlphaNum :: Char -> Bool
+isAsciiAlphaNum c =
+    (c >= '0' && c <= '9')
+        || (c >= 'A' && c <= 'Z')
+        || (c >= 'a' && c <= 'z')
+
+formatTodoDisplayLine :: TodoDisplayLine -> Text
+formatTodoDisplayLine line =
+    todoStatusGlyph line.todoLineStatus <> " " <> line.todoLineText
+
+todoStatusGlyph :: TodoDisplayStatus -> Text
+todoStatusGlyph = \case
+    TodoDisplayPending -> "□"
+    TodoDisplayInProgress -> "▶"
+    TodoDisplayCompleted -> "✓"
+    TodoDisplayCancelled -> "✗"
+
+firstTodoContentFromArguments :: Text -> Text
+firstTodoContentFromArguments arguments = fromMaybe "" do
+    Aeson.Object object <- Aeson.decodeStrict (TextEncoding.encodeUtf8 arguments)
+    Aeson.Array todos <- KeyMap.lookup "todos" object
+    Aeson.Object todo <- case toList todos of
+        first : _ -> Just first
+        [] -> Nothing
+    content <- jsonObjectText "content" todo
+    pure (firstLine content)
+
+firstPlanStepFromArguments :: Text -> Text
+firstPlanStepFromArguments arguments = fromMaybe "" do
+    Aeson.Object object <- Aeson.decodeStrict (TextEncoding.encodeUtf8 arguments)
+    Aeson.Array plan <- KeyMap.lookup "plan" object
+    Aeson.Object item <- case toList plan of
+        first : _ -> Just first
+        [] -> Nothing
+    step <- jsonObjectText "step" item
+    pure (firstLine step)
 
 toolVerb :: Text -> Text
 toolVerb name = case canonicalToolName name of
@@ -178,7 +326,8 @@ toolVerb name = case canonicalToolName name of
     "create_agent_session" -> "Created agent session"
     "read_agent_session" -> "Read agent session"
     "send_agent_session_message" -> "Messaged agent session"
-    "update_plan" -> "Updated"
+    "todo_write" -> "todo_write"
+    "update_plan" -> "update_plan"
     "enter_plan_mode" -> "Entered"
     "exit_plan_mode" -> "Exited"
     "ask_user_question" -> "Asked"
@@ -204,7 +353,6 @@ toolDetail call = case canonicalToolName call.name of
     "write_stdin" ->
         maybe "" ("session " <>) (jsonIntField "session_id" call.arguments)
     "apply_patch" -> fromMaybe "patch" (firstPatchPath call.arguments)
-    "update_plan" -> "plan"
     "enter_plan_mode" -> "enter"
     "exit_plan_mode" -> "exit"
     "ask_user_question" -> askUserQuestionDetail call.arguments

--- a/packages/agent-tui/src/Agent/TUI/Theme.hs
+++ b/packages/agent-tui/src/Agent/TUI/Theme.hs
@@ -39,6 +39,10 @@ module Agent.TUI.Theme
     , syntaxWarningAttr
     , syntaxClassAttr
     , thinkingAttr
+    , todoCancelledAttr
+    , todoCompletedAttr
+    , todoInProgressAttr
+    , todoPendingAttr
     , toolAttr
     , userAttr
     , waitingDimAttr
@@ -55,6 +59,7 @@ import qualified Graphics.Vty as V
 
 baseAttr, headerAttr, footerAttr, mutedAttr :: AttrName
 userAttr, assistantAttr, thinkingAttr, toolAttr :: AttrName
+todoPendingAttr, todoInProgressAttr, todoCompletedAttr, todoCancelledAttr :: AttrName
 errorAttr, successAttr, selectedAttr, borderAttr, borderActiveAttr :: AttrName
 headingAttr, codeAttr, dimAttr, emphasisAttr, inlineCodeAttr, linkAttr, strongAttr :: AttrName
 controlLinkAttr, controlLinkHoverAttr, controlLinkActiveAttr :: AttrName
@@ -72,6 +77,10 @@ userAttr = attrName "user"
 assistantAttr = attrName "assistant"
 thinkingAttr = attrName "thinking"
 toolAttr = attrName "tool"
+todoPendingAttr = attrName "todo-pending"
+todoInProgressAttr = attrName "todo-in-progress"
+todoCompletedAttr = attrName "todo-completed"
+todoCancelledAttr = attrName "todo-cancelled"
 errorAttr = attrName "error"
 successAttr = attrName "success"
 selectedAttr = attrName "selected"
@@ -140,6 +149,10 @@ terminalDefault =
         , (waitingDimAttr, palette V.brightBlack)
         , (waitingMidAttr, palette V.yellow)
         , (toolAttr, palette V.cyan)
+        , (todoPendingAttr, V.defAttr)
+        , (todoInProgressAttr, palette V.yellow `V.withStyle` V.bold)
+        , (todoCompletedAttr, palette V.brightBlack)
+        , (todoCancelledAttr, palette V.brightBlack `V.withStyle` V.strikethrough)
         , (errorAttr, palette V.red `V.withStyle` V.bold)
         , (successAttr, palette V.green)
         , (completionFlashAttr,
@@ -193,6 +206,10 @@ monochrome =
         , (waitingDimAttr, V.defAttr)
         , (waitingMidAttr, V.defAttr)
         , (toolAttr, V.defAttr)
+        , (todoPendingAttr, V.defAttr)
+        , (todoInProgressAttr, V.defAttr `V.withStyle` V.bold)
+        , (todoCompletedAttr, V.defAttr)
+        , (todoCancelledAttr, V.defAttr `V.withStyle` V.strikethrough)
         , (errorAttr, V.defAttr `V.withStyle` V.bold)
         , (successAttr, V.defAttr)
         , (completionFlashAttr, V.defAttr `V.withStyle` V.bold)

--- a/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
@@ -661,6 +661,48 @@ spec = describe "fullscreen UI reducer" do
                 block.blockBody `shouldSatisfy` Text.isInfixOf "+new"
             _ -> expectationFailure "expected one running edit block"
 
+    it "renders todo_write as a checklist block" do
+        let call =
+                functionToolCall
+                    "todo-1"
+                    "todo_write"
+                    "{\"todos\":[{\"id\":\"1\",\"content\":\"Find and clone repos\",\"status\":\"pending\"}]}"
+            result = ToolCallResult
+                { callId = "todo-1"
+                , output =
+                    "- [completed] 1: Find and clone repos\n\
+                    \- [in_progress] 2: Investigate Grok Build"
+                , callKind = FunctionCallKind
+                }
+            started =
+                Foldable.toList $
+                    (.uiBlocks) $
+                        apply
+                            [ UiLoop TurnStarted
+                            , UiLoop (ToolStarted call)
+                            ]
+            finished =
+                Foldable.toList $
+                    (.uiBlocks) $
+                        apply
+                            [ UiLoop TurnStarted
+                            , UiLoop (ToolStarted call)
+                            , UiLoop (ToolFinished result)
+                            ]
+        case started of
+            [block] -> do
+                block.blockKind `shouldBe` BlockTodo
+                block.blockTitle `shouldBe` "todo_write"
+                block.blockBody `shouldBe` "Find and clone repos"
+            _ -> expectationFailure "expected one running todo block"
+        case finished of
+            [block] -> do
+                block.blockKind `shouldBe` BlockTodo
+                block.blockTitle `shouldBe` "todo_write"
+                block.blockBody
+                    `shouldBe` "✓ Find and clone repos\n▶ Investigate Grok Build"
+            _ -> expectationFailure "expected one completed todo block"
+
     it "formats collaboration result JSON for display" do
         let call =
                 functionToolCall

--- a/packages/agent-tui/test/Agent/TUI/PresentationSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/PresentationSpec.hs
@@ -170,3 +170,30 @@ spec = describe "tool presentation" do
         summarizeToolCall readSession `shouldBe` "Read agent session session-1"
         summarizeToolCall message `shouldBe`
             "Messaged agent session session-1"
+
+    it "keeps todo_write chrome on the wire name and renders checklist glyphs" do
+        let call = functionToolCall
+                "todo"
+                "todo_write"
+                "{\"todos\":[{\"id\":\"1\",\"content\":\"Find and clone repos\",\"status\":\"completed\"}]}"
+        toolCallTitle call `shouldBe` "todo_write"
+        todoCallPreview call `shouldBe` "Find and clone repos"
+        formatToolOutput call
+            "- [completed] 1: Find and clone repos\n\
+            \- [in_progress] 2: Investigate Grok Build\n\
+            \- [pending] 3: Investigate Codex\n\
+            \- [cancelled] 4: Skip leftover work"
+            `shouldBe`
+                "✓ Find and clone repos\n\
+                \▶ Investigate Grok Build\n\
+                \□ Investigate Codex\n\
+                \✗ Skip leftover work"
+
+    it "formats Codex update_plan output as the same checklist" do
+        let call = functionToolCall "plan" "update_plan" "{\"plan\":[]}"
+        toolCallTitle call `shouldBe` "update_plan"
+        formatToolOutput call
+            "Plan updated:\n- [completed] Clone the repo\n- [pending] Open a PR"
+            `shouldBe`
+                "✓ Clone the repo\n\
+                \□ Open a PR"

--- a/packages/agent-tui/test/Agent/TUI/ThemeSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ThemeSpec.hs
@@ -20,6 +20,7 @@ spec = do
                 , Theme.lambdaTrailAttr
                 , Theme.lambdaGlowAttr
                 , Theme.lambdaSparkAttr
+                , Theme.todoPendingAttr
                 ]
                 `shouldBe`
                     [ V.Default
@@ -30,6 +31,7 @@ spec = do
                     , V.SetTo V.brightBlack
                     , V.Default
                     , V.SetTo V.brightWhite
+                    , V.Default
                     ]
 
     describe "syntax theme attributes" do


### PR DESCRIPTION
## Summary
- Render `todo_write` and Codex `update_plan` as Grok-style checklist blocks: wire-name header, status glyphs (`✓`/`▶`/`□`/`✗`), and `… +N lines` truncation.
- Keep the first item visible while the call is running, then replace it with the formatted checklist on completion.
- Share the parser between the linear CLI chrome and the retained TUI so both surfaces stay in sync.

## Test plan
- [x] `cabal test agent-tui:test:agent-tui-test`
- [x] CLI `RenderSpec` examples matching `todo`
- [ ] Visual check of a live `todo_write` turn in tmux (linear CLI and fullscreen TUI)