### PR TITLE
feat(cli): recap long-running sessions in the terminal

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -117,6 +117,7 @@ library
                     , Agent.CLI.Progress
                     , Agent.CLI.Project
                     , Agent.CLI.Prompt
+                    , Agent.CLI.Recap
                     , Agent.CLI.Request
                     , Agent.CLI.ProviderFallback
                     , Agent.CLI.ProviderAvailability
@@ -290,6 +291,7 @@ test-suite agent-cli-test
                     , Agent.CLI.PendingInputsSpec
                     , Agent.CLI.ProgressSpec
                     , Agent.CLI.PromptSpec
+                    , Agent.CLI.RecapSpec
                     , Agent.CLI.ProviderFallbackSpec
                     , Agent.CLI.ProviderAvailabilitySpec
                     , Agent.CLI.ProviderTransitionSpec

--- a/packages/agent-cli/src/Agent/CLI/Command.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command.hs
@@ -72,6 +72,8 @@ data ReplAction
     -- ^ Enter plan mode. @Just@ starts a turn with that description.
     | ReplBtw Text
     -- ^ Ask an isolated one-shot question over the current context.
+    | ReplRecap
+    -- ^ Generate a display-only "where was I" recap of the current session.
     | ReplShowSession
     | ReplShowSessionInfo
     | ReplAfk (Maybe Text)
@@ -169,6 +171,7 @@ slashCommands =
     , cmd "effort" [] "/effort [none|low|medium|high|xhigh|max]" "Show or set reasoning effort" True
     , cmd "plan" [] "/plan [description]" "Enter plan mode (or Shift+Tab)" True
     , cmd "btw" [] "/btw <QUESTION>" "Ask a side question without changing the conversation" True
+    , cmd "recap" ["summarize"] "/recap" "Summarize the session so far" False
     , cmd "session" [] "/session" "Print the current session id" False
     , cmd "session-info" ["status", "info"] "/session-info" "Show session details (model, tools, and context usage)" False
     , cmd "afk" [] "/afk [HOST:PATH]" "Move this session into tmux, locally or over SSH" True
@@ -337,6 +340,10 @@ parseSlash catalog raw line = case Text.words line of
                 in if Text.null question
                     then ReplCommandError "usage: /btw <QUESTION>"
                     else ReplBtw question
+            "recap" ->
+                if null args
+                    then ReplRecap
+                    else ReplCommandError "usage: /recap"
             "session" ->
                 if null args
                     then ReplShowSession

--- a/packages/agent-cli/src/Agent/CLI/Recap.hs
+++ b/packages/agent-cli/src/Agent/CLI/Recap.hs
@@ -1,0 +1,405 @@
+-- | Display-only session recap and last-turn dashboard summaries.
+--
+-- A side call over a transcript snapshot that never mutates the conversation.
+module Agent.CLI.Recap
+    ( RecapError(..)
+    , RecapGateFailure(..)
+    , RecapKind(..)
+    , RecapOutcome(..)
+    , RecapRequest(..)
+    , autoRecapAwayThreshold
+    , autoRecapIdleThreshold
+    , autoRecapRetryInterval
+    , cleanRecapText
+    , cleanTurnSummaryText
+    , formatRecapError
+    , lastUserAnchor
+    , mainTurnCount
+    , recapAutoRawDisplayMax
+    , recapGate
+    , recapInstruction
+    , recapMaxChars
+    , recapPersistMaxChars
+    , recapPreview
+    , recapUnavailableToast
+    , runRecapWithCancel
+    , runTurnSummaryWithCancel
+    , shouldSuppressAutoRecapDisplay
+    , turnSummaryInstruction
+    , turnSummaryMaxChars
+    ) where
+
+import Agent.Cancel (CancelFlag, newCancelFlag, waitCancel)
+import Agent.CLI.Btw
+    ( BtwBackendFactory
+    , trimDanglingToolSuffix
+    )
+import Agent.CLI.Error (formatApiErrorInline)
+import Agent.Loop
+    ( Backend(..)
+    , BackendResult(..)
+    , TurnInput(..)
+    , TurnOutput(..)
+    )
+import Agent.Responses.Types
+    ( MessageContent(..)
+    , ResponseContentPart(..)
+    , ResponseCreateParams(..)
+    , ResponseItem(..)
+    , ResponseMessage(..)
+    , ResponseRole(..)
+    , ToolChoice(..)
+    , ToolChoiceMode(..)
+    )
+import Control.Applicative ((<|>))
+import Control.Concurrent.Async (race)
+import Data.IORef (IORef, newIORef, readIORef)
+import Data.Maybe (fromMaybe, mapMaybe)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Data.Time.Clock (NominalDiffTime)
+
+data RecapKind
+    = RecapManual
+    | RecapAuto
+    deriving (Eq, Show)
+
+data RecapRequest
+    = RecapSession !RecapKind
+    | RecapTurnSummary
+    deriving (Eq, Show)
+
+data RecapGateFailure
+    = RecapNoMainTurns
+    | RecapNoNewMainTurn
+    | RecapTooFewTurns
+    | RecapIdleThresholdUnmet
+    deriving (Eq, Show)
+
+data RecapError
+    = RecapTransport !Text
+    | RecapCancelled
+    | RecapEmpty
+    | RecapUnexpectedToolCall
+    | RecapInvalidResponse
+    deriving (Eq, Show)
+
+data RecapOutcome
+    = RecapShown !Text
+    | RecapSuppressed !Text
+    deriving (Eq, Show)
+
+recapMaxChars :: Int
+recapMaxChars = 1200
+
+recapPersistMaxChars :: Int
+recapPersistMaxChars = 240
+
+recapAutoRawDisplayMax :: Int
+recapAutoRawDisplayMax = 500
+
+turnSummaryMaxChars :: Int
+turnSummaryMaxChars = 200
+
+minTurnsForAutoRecap :: Int
+minTurnsForAutoRecap = 3
+
+-- | Terminal unfocused debounce before an automatic recap is requested.
+autoRecapAwayThreshold :: NominalDiffTime
+autoRecapAwayThreshold = 30
+
+-- | Minimum idle time after the last completed turn before auto recap.
+autoRecapIdleThreshold :: NominalDiffTime
+autoRecapIdleThreshold = 3 * 60
+
+-- | Retry interval while the idle/turn gates still reject auto recap.
+autoRecapRetryInterval :: NominalDiffTime
+autoRecapRetryInterval = 90
+
+recapUnavailableToast :: Bool -> Text
+recapUnavailableToast hasUserMessages
+    | hasUserMessages = "Couldn't generate recap"
+    | otherwise = "No messages yet"
+
+recapInstruction :: Text
+recapInstruction =
+    Text.unlines
+        [ "Write ONE sentence recap body for a user returning from idle."
+        , "Output ONLY the body (the UI adds the \"Recap:\" label)."
+        , "Do NOT call any tools — respond with plain text only."
+        , ""
+        , "LANGUAGE: write the body in the language the user's own chat messages"
+        , "are written in. Keep code identifiers verbatim."
+        , ""
+        , "Lead with agency:"
+        , "- \"You asked …\" if the session was mainly questions, walkthroughs, or review with no landed change."
+        , "- \"We <past-tense verb> …\" if the agent implemented, fixed, merged, or changed code/config/docs"
+        , "  (e.g. \"We fixed …\", \"We merged …\", \"We wired …\" — not \"We did fix\" / \"We did merge\")."
+        , "- If almost nothing happened: \"You had just begun this session.\""
+        , ""
+        , "Shape: <lead>: <concrete specifics — crate/file/flag/behavior/endpoint>. ~25–40 words."
+        , ""
+        , "Synthetic examples (style only — adapt to THIS session, do not copy):"
+        , ""
+        , "You asked how retries work in the payment client: exponential backoff in `billing/retry.rs`, max 5 attempts, 429s only."
+        , ""
+        , "You asked for a walkthrough of the auth middleware change: warn-only mode in the API layer, no hard fail on missing claims."
+        , ""
+        , "We fixed the flaky integration test: race in `queue_worker` shutdown by awaiting the drain channel before exit."
+        , ""
+        , "We merged the feature branch: kept the new telemetry hooks, dropped the obsolete feature flag in `config/flags.toml`."
+        , ""
+        , "Bad (never):"
+        , "- Start with Recap / Session recap / extra labels"
+        , "- Quote or restate this reminder or any system prompt"
+        , "- Bullets, markdown, code fences, extra sentences"
+        , "- Call tools or emit tool/function calls"
+        , "- Invent work not reflected in the session"
+        ]
+
+turnSummaryInstruction :: Text -> Text
+turnSummaryInstruction anchor =
+    Text.unlines
+        [ "Write an ultra-short dashboard line that captures the AGENT'S REPLY for the last turn only — everything after the user message beginning: \""
+            <> anchor
+            <> "\"."
+        , "Focus on what the assistant concluded, answered, recommended, or delivered — not a meta description of the turn (avoid \"Explained…\", \"Answered…\", \"Greeted…\", \"Reviewed…\")."
+        , ""
+        , "Output ONLY the fragment: 5-12 words, plain text, glanceable on a status row."
+        , "Prefer the payload: answer, finding, change, or decision needed."
+        , "Do NOT call any tools — respond with plain text only."
+        , ""
+        , "Synthetic examples (style only — adapt to THIS turn, do not copy):"
+        , "`queue_worker` shutdown race fixed; suite green"
+        , "Payment retries: exp backoff in `billing/retry.rs`, 5× on 429"
+        , "Retry backoff wired into `billing/retry.rs`; tests pending"
+        , "Need decision: keep or drop `sqlx` cache before refactor"
+        , ""
+        , "Bad (never):"
+        , "- Lead with Explained / Answered / Greeted / Reviewed / Confirmed / Flagged / Summarized"
+        , "- Labels, quotes, bullets, markdown, code fences, multi-sentence dumps"
+        , "- Filler like \"no code changes\" or \"awaiting task\" unless that is the whole point"
+        , "- Summarize earlier turns or the whole session"
+        , "- Call tools or invent content not in the agent's reply"
+        ]
+
+recapGate
+    :: Int
+    -> Int
+    -> RecapKind
+    -> Bool
+    -> Either RecapGateFailure ()
+recapGate mainTurns lastCommitted kind idleOk
+    | mainTurns <= 0 = Left RecapNoMainTurns
+    | kind == RecapAuto && mainTurns <= lastCommitted = Left RecapNoNewMainTurn
+    | kind == RecapAuto && mainTurns < minTurnsForAutoRecap = Left RecapTooFewTurns
+    | kind == RecapAuto && not idleOk = Left RecapIdleThresholdUnmet
+    | otherwise = Right ()
+
+mainTurnCount :: [ResponseItem] -> Int
+mainTurnCount =
+    length . filter isMainUserMessage
+
+lastUserAnchor :: [ResponseItem] -> Maybe Text
+lastUserAnchor items =
+    case reverse (mapMaybe userMessageText items) of
+        [] -> Nothing
+        text : _ ->
+            let collapsed = Text.unwords (Text.words text)
+                stripped = Text.filter (\c -> c /= '<' && c /= '>') collapsed
+            in if Text.null (Text.strip stripped)
+                then Nothing
+                else Just (truncateAt 120 stripped)
+
+cleanRecapText :: Text -> Text
+cleanRecapText raw =
+    capLength recapMaxChars (stripWrappingQuotes (stripLeadingLabel collapsed))
+  where
+    collapsed = Text.unwords (Text.words raw)
+
+cleanTurnSummaryText :: Text -> Text
+cleanTurnSummaryText = capLength turnSummaryMaxChars . cleanRecapText
+
+recapPreview :: Text -> Text
+recapPreview = Text.take recapPersistMaxChars
+
+shouldSuppressAutoRecapDisplay :: RecapKind -> Text -> Text -> Bool
+shouldSuppressAutoRecapDisplay kind raw summary =
+    kind == RecapAuto
+        && ( Text.length raw > recapAutoRawDisplayMax
+                || (Text.isSuffixOf "\8230" summary
+                    && Text.length summary >= recapMaxChars)
+           )
+
+formatRecapError :: RecapError -> Text
+formatRecapError = \case
+    RecapTransport message -> "recap failed: " <> message
+    RecapCancelled -> "recap cancelled"
+    RecapEmpty -> "recap returned an empty response"
+    RecapUnexpectedToolCall -> "recap attempted a tool call; no recap tools were run"
+    RecapInvalidResponse -> "recap returned an invalid response"
+
+runRecapWithCancel
+    :: (CancelFlag
+        -> IO (Either RecapError Text)
+        -> IO (Either RecapError Text))
+    -> BtwBackendFactory
+    -> IORef ResponseCreateParams
+    -> IORef [ResponseItem]
+    -> RecapKind
+    -> IO (Either RecapError RecapOutcome)
+runRecapWithCancel withCancelScope makeBackend paramsRef transcriptRef kind = do
+    result <-
+        runSideCallWithCancel
+            withCancelScope
+            makeBackend
+            paramsRef
+            transcriptRef
+            recapInstruction
+    pure $ case result of
+        Left err -> Left err
+        Right raw ->
+            let summary = cleanRecapText raw
+            in if Text.null summary
+                then Left RecapEmpty
+                else
+                    Right $
+                        if shouldSuppressAutoRecapDisplay kind raw summary
+                            then RecapSuppressed summary
+                            else RecapShown summary
+
+runTurnSummaryWithCancel
+    :: (CancelFlag
+        -> IO (Either RecapError Text)
+        -> IO (Either RecapError Text))
+    -> BtwBackendFactory
+    -> IORef ResponseCreateParams
+    -> IORef [ResponseItem]
+    -> IO (Either RecapError Text)
+runTurnSummaryWithCancel withCancelScope makeBackend paramsRef transcriptRef = do
+    transcript <- trimDanglingToolSuffix <$> readIORef transcriptRef
+    case lastUserAnchor transcript of
+        Nothing -> pure (Left RecapEmpty)
+        Just anchor -> do
+            result <-
+                runSideCallWithCancel
+                    withCancelScope
+                    makeBackend
+                    paramsRef
+                    transcriptRef
+                    (turnSummaryInstruction anchor)
+            pure $ case result of
+                Left err -> Left err
+                Right raw ->
+                    let summary = cleanTurnSummaryText raw
+                    in if Text.null summary
+                        then Left RecapEmpty
+                        else Right summary
+
+runSideCallWithCancel
+    :: (CancelFlag
+        -> IO (Either RecapError Text)
+        -> IO (Either RecapError Text))
+    -> BtwBackendFactory
+    -> IORef ResponseCreateParams
+    -> IORef [ResponseItem]
+    -> Text
+    -> IO (Either RecapError Text)
+runSideCallWithCancel withCancelScope makeBackend paramsRef transcriptRef instruction = do
+    params <- clearTurnSpecificParams <$> readIORef paramsRef
+    transcript <- trimDanglingToolSuffix <$> readIORef transcriptRef
+    privateParams <- newIORef params
+    cancel <- newCancelFlag
+    let Backend submit = makeBackend privateParams
+        request =
+            submit transcript Nothing
+                [UserMessage instruction] (\_ -> pure ())
+        action = do
+            result <- race (waitCancel cancel) request
+            pure $ case result of
+                Left () -> Left RecapCancelled
+                Right (Left err) ->
+                    Left (RecapTransport (formatApiErrorInline err))
+                Right (Right result) -> classifyTurn result.backendOutput
+    withCancelScope cancel action
+
+clearTurnSpecificParams :: ResponseCreateParams -> ResponseCreateParams
+clearTurnSpecificParams ResponseCreateParams{..} =
+    ResponseCreateParams
+        { input = Nothing
+        , previousResponseId = Nothing
+        , toolChoice = Just (ToolChoiceMode ToolChoiceNone)
+        , ..
+        }
+
+classifyTurn :: TurnOutput -> Either RecapError Text
+classifyTurn turn
+    | Text.null turn.responseId = Left RecapInvalidResponse
+    | not (null turn.toolCalls) = Left RecapUnexpectedToolCall
+    | otherwise = case turn.assistantText of
+        Just text | not (Text.null (Text.strip text)) -> Right text
+        _ -> Left RecapEmpty
+
+isMainUserMessage :: ResponseItem -> Bool
+isMainUserMessage = \case
+    MessageItem message ->
+        message.role == RoleUser
+            && not (Text.null (Text.strip (messageText message)))
+    _ -> False
+
+userMessageText :: ResponseItem -> Maybe Text
+userMessageText = \case
+    MessageItem message
+        | message.role == RoleUser ->
+            let text = Text.strip (messageText message)
+            in if Text.null text then Nothing else Just text
+    _ -> Nothing
+
+messageText :: ResponseMessage -> Text
+messageText message = case message.content of
+    MessageContentText text -> text
+    MessageContentParts parts ->
+        Text.unwords
+            [ text
+            | part <- parts
+            , text <- case part of
+                InputTextPart{text} -> [text]
+                OutputTextPart{text} -> [text]
+                _ -> []
+            ]
+
+stripLeadingLabel :: Text -> Text
+stripLeadingLabel text =
+    fromMaybe text (stripFirst labels)
+  where
+    labels =
+        [ "Recap —"
+        , "Recap—"
+        , "Recap -"
+        , "Recap:"
+        , "recap:"
+        , "Session recap:"
+        , "Summary:"
+        ]
+    stripFirst [] = Nothing
+    stripFirst (label : rest) =
+        (Text.strip <$> Text.stripPrefix label text) <|> stripFirst rest
+
+stripWrappingQuotes :: Text -> Text
+stripWrappingQuotes text =
+    case (Text.uncons text, Text.unsnoc text) of
+        (Just ('"', _), Just (_, '"')) | Text.length text >= 2 ->
+            Text.strip (Text.dropEnd 1 (Text.drop 1 text))
+        (Just ('\'', _), Just (_, '\'')) | Text.length text >= 2 ->
+            Text.strip (Text.dropEnd 1 (Text.drop 1 text))
+        _ -> text
+
+capLength :: Int -> Text -> Text
+capLength limit text
+    | Text.length text <= limit = text
+    | otherwise = Text.stripEnd (Text.take limit text) <> "\8230"
+
+truncateAt :: Int -> Text -> Text
+truncateAt limit text
+    | Text.length text <= limit = text
+    | otherwise = Text.stripEnd (Text.take limit text) <> "\8230"

--- a/packages/agent-cli/src/Agent/CLI/Resume.hs
+++ b/packages/agent-cli/src/Agent/CLI/Resume.hs
@@ -86,6 +86,8 @@ data ResumeEntry = ResumeEntry
     , resumeTurnCount :: !Int
     , resumeToolCount :: !Int
     , resumePrompt :: !Text
+    , resumeRecap :: !(Maybe Text)
+    , resumeLastTurnSummary :: !(Maybe Text)
     , resumeMatch :: !(Maybe Text)
     , resumeLoaded :: !Bool
     , resumeTranscript :: ![Text]
@@ -153,6 +155,8 @@ entryFromWith loaded meta turns =
         , resumePrompt =
             fromMaybe ""
                 (firstNonEmpty (map (.turnUserText) turns))
+        , resumeRecap = meta.metaLastRecap
+        , resumeLastTurnSummary = meta.metaLastTurnSummary
         , resumeMatch = Nothing
         , resumeLoaded = loaded
         , resumeTranscript = transcriptLines turns

--- a/packages/agent-cli/src/Agent/CLI/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime.hs
@@ -104,6 +104,19 @@ import Agent.CLI.Btw
     ( formatBtwError
     , runBtwWithCancel
     )
+import Agent.CLI.Recap
+    ( RecapKind(..)
+    , RecapOutcome(..)
+    , RecapRequest(..)
+    , autoRecapIdleThreshold
+    , formatRecapError
+    , mainTurnCount
+    , recapGate
+    , recapPreview
+    , recapUnavailableToast
+    , runRecapWithCancel
+    , runTurnSummaryWithCancel
+    )
 import Agent.CLI.CancelWatch (withEscCancel, withStdinPaused)
 import Agent.CLI.Clipboard
     ( appendUniqueImageAttachments
@@ -656,6 +669,7 @@ import Control.Exception.Safe
     ( SomeException
     , catchAny
     , finally
+    , tryAny
     , mask_
     , onException
     , throwIO
@@ -1222,6 +1236,7 @@ prepareAgentIteration
                         runtime
                         (requestCancel toolEnv.toolCancel)
                         (const (pure ()))
+                        (pure ())
                         (\level ->
                             readIORef restartEffortActionRef >>= ($ level))
                         (noteFullscreenCtrlC interrupt)
@@ -1275,6 +1290,7 @@ resetFullscreenSessionActions runtime =
         runtime
         (pure ())
         (const (pure ()))
+        (pure ())
         (const (pure ()))
         -- No session-local interrupt state is alive between providers. A
         -- transition must remain escapable even if auth probing blocks.
@@ -3671,9 +3687,13 @@ runSession SessionRequest{..} SessionBackend{..} = do
             ghciEnabled <- readIORef ghciEnabledRef
             bashEnabled <- readIORef bashEnabledRef
             refreshShellParams ghciEnabled bashEnabled
+    btwRequests <- newChan
+    recapRequests <- newChan
+    let
         env = SessionEnv
             { sessionLoop = config
             , sessionBtwBackend = btwBackend
+            , sessionQueueRecap = writeChan recapRequests
             , sessionCompact = compactRunner
             , sessionRender = render
             , sessionProvider = provider
@@ -3737,12 +3757,12 @@ runSession SessionRequest{..} SessionBackend{..} = do
         setSessionEffort env level
         writeIORef restartEffortRef (Just level)
         requestCancel toolEnv.toolCancel
-    btwRequests <- newChan
     forM_ fullscreen \runtime ->
         setFullscreenSessionActions
             runtime
             (requestCancel toolEnv.toolCancel)
             (writeChan btwRequests)
+            (writeChan recapRequests (RecapSession RecapAuto))
             (\level ->
                 readIORef startup.startupRestartEffort >>= ($ level))
             (noteFullscreenCtrlC interrupt)
@@ -3816,9 +3836,18 @@ runSession SessionRequest{..} SessionBackend{..} = do
             question <- readChan btwRequests
             runBtwQuestion False env question
             btwWorker
+        recapWorker = do
+            request <- readChan recapRequests
+            case request of
+                RecapSession kind -> runSessionRecap False env kind
+                RecapTurnSummary -> runSessionTurnSummary env
+            recapWorker
     result <- case fullscreen of
-        Just _ -> withAsync btwWorker (const sessionAction)
-        Nothing -> sessionAction
+        Just _ ->
+            withAsync btwWorker \_ ->
+                withAsync recapWorker (const sessionAction)
+        Nothing ->
+            withAsync recapWorker (const sessionAction)
     _ <- waitForSessionTitleResults 5000000 titleManager
     applyPendingSessionTitles env
     pure result
@@ -4013,6 +4042,7 @@ finishTurnWithCooldownRetry
     -> IO RunResult
 finishTurnWithCooldownRetry allowCooldownRetry env exitAfter = \case
     TurnSucceeded -> do
+        env.sessionQueueRecap RecapTurnSummary
         writeIORef env.sessionUnavailableProviders []
         selectionId <- readIORef env.sessionAccountSelectionId
         accountId <- readIORef env.sessionAccountId
@@ -4254,6 +4284,145 @@ runBtwQuestion registerCancel env question = do
                     emitUiEvent runtime (UiAssistantHistory answer)
                 Nothing ->
                     putTextLn stdout (renderAssistantText color answer)
+
+runSessionRecap :: Bool -> SessionEnv -> RecapKind -> IO ()
+runSessionRecap registerCancel env kind = do
+    let fullscreen = env.sessionFullscreen
+        transcriptRef = env.sessionTranscript
+    color <- resolveColor stdout
+    transcript <- readIORef transcriptRef
+    let mainTurns = mainTurnCount transcript
+        hasMessages = mainTurns > 0
+    lastCommittedTurns <- recapWatermark env
+    lastCompletedAt <- recapLastCompletedAt env
+    now <- getCurrentTime
+    let idleOk =
+            case lastCompletedAt of
+                Nothing -> False
+                Just finished ->
+                    diffUTCTime now finished >= autoRecapIdleThreshold
+    case recapGate mainTurns lastCommittedTurns kind idleOk of
+        Left _ ->
+            case kind of
+                RecapManual -> recapUnavailable env hasMessages
+                RecapAuto -> pure ()
+        Right () -> do
+            when (kind == RecapManual) $
+                forM_ fullscreen \runtime ->
+                    emitUiEvent runtime UiRecapStarted
+            result <-
+                runRecapWithCancel
+                    (\cancel action ->
+                        if registerCancel
+                            then
+                                withTurnCancel env.sessionInterrupt cancel $
+                                    case fullscreen of
+                                        Nothing ->
+                                            withEscCancel
+                                                cancel
+                                                env.sessionEscPaused
+                                                action
+                                        Just _ -> action
+                            else action)
+                    env.sessionBtwBackend
+                    env.sessionParams
+                    transcriptRef
+                    kind
+            case result of
+                Left err ->
+                    case kind of
+                        RecapManual -> recapFailed env (formatRecapError err)
+                        RecapAuto -> pure ()
+                Right (RecapShown summary) -> do
+                    persistSessionRecap env summary mainTurns
+                    displayRecap env color summary
+                Right (RecapSuppressed summary) ->
+                    persistSessionRecap env summary mainTurns
+
+recapWatermark :: SessionEnv -> IO Int
+recapWatermark env =
+    case env.sessionPersist of
+        PersistenceDisabled -> pure 0
+        PersistenceEnabled slotRef ->
+            readIORef slotRef >>= \case
+                PersistencePending _ _ _ -> pure 0
+                PersistenceActive handle ->
+                    pure handle.sessionMeta.metaLastRecapMainTurns
+
+recapLastCompletedAt :: SessionEnv -> IO (Maybe UTCTime)
+recapLastCompletedAt env =
+    case env.sessionPersist of
+        PersistenceDisabled -> pure Nothing
+        PersistenceEnabled slotRef ->
+            readIORef slotRef >>= \case
+                PersistencePending _ _ _ -> pure Nothing
+                PersistenceActive handle ->
+                    loadSession
+                        handle.sessionPool
+                        (takeDirectory handle.sessionDir)
+                        handle.sessionMeta.metaId
+                        >>= \case
+                            Left _ ->
+                                pure (Just handle.sessionMeta.metaUpdatedAt)
+                            Right (_, turns) ->
+                                pure $
+                                    case reverse turns of
+                                        turn : _ -> Just turn.turnAt
+                                        [] -> Just handle.sessionMeta.metaUpdatedAt
+
+persistSessionRecap :: SessionEnv -> Text -> Int -> IO ()
+persistSessionRecap env summary mainTurns =
+    case env.sessionPersist of
+        PersistenceDisabled -> pure ()
+        PersistenceEnabled slotRef ->
+            readIORef slotRef >>= \case
+                PersistencePending _ _ _ -> pure ()
+                PersistenceActive handle -> do
+                    updated <-
+                        setSessionRecap (recapPreview summary) mainTurns handle
+                    writeIORef slotRef (PersistenceActive updated)
+
+displayRecap :: SessionEnv -> Bool -> Text -> IO ()
+displayRecap env color summary =
+    let message = "Recap: " <> summary
+    in case env.sessionFullscreen of
+        Just runtime ->
+            emitUiEvent runtime (UiRecapReady summary)
+        Nothing ->
+            putTextLn stdout (roleMuted color message)
+
+recapUnavailable :: SessionEnv -> Bool -> IO ()
+recapUnavailable env hasMessages =
+    recapFailed env (recapUnavailableToast hasMessages)
+
+recapFailed :: SessionEnv -> Text -> IO ()
+recapFailed env message = do
+    color <- resolveColor stderr
+    case env.sessionFullscreen of
+        Just runtime ->
+            emitUiEvent runtime (UiRecapUnavailable message)
+        Nothing ->
+            putTextLn stderr (roleMuted color message)
+
+runSessionTurnSummary :: SessionEnv -> IO ()
+runSessionTurnSummary env = do
+    result <-
+        runTurnSummaryWithCancel
+            (\_ action -> action)
+            env.sessionBtwBackend
+            env.sessionParams
+            env.sessionTranscript
+    case result of
+        Left _ -> pure ()
+        Right summary ->
+            case env.sessionPersist of
+                PersistenceDisabled -> pure ()
+                PersistenceEnabled slotRef ->
+                    readIORef slotRef >>= \case
+                        PersistencePending _ _ _ -> pure ()
+                        PersistenceActive handle -> do
+                            updated <- setSessionTurnSummary summary handle
+                            writeIORef slotRef (PersistenceActive updated)
 
 repl :: SessionEnv -> IO RunResult
 repl env = replWithDraft env ""
@@ -5140,6 +5309,15 @@ replWithDraft env@SessionEnv
                     ReplBtw question -> do
                         runBtwQuestion True env question
                         continue
+                    ReplRecap ->
+                        case fullscreen of
+                            Just runtime -> do
+                                emitUiEvent runtime UiRecapStarted
+                                env.sessionQueueRecap (RecapSession RecapManual)
+                                continue
+                            Nothing -> do
+                                runSessionRecap True env RecapManual
+                                continue
                     ReplResume maybeId -> do
                         handleResume databasePool fullscreen maybeId persist >>= \case
                             Nothing -> continue
@@ -5180,6 +5358,9 @@ replWithDraft env@SessionEnv
                                                 , metaInputTokens = 0
                                                 , metaOutputTokens = 0
                                                 , metaCachedTokens = 0
+                                                , metaLastRecap = Nothing
+                                                , metaLastTurnSummary = Nothing
+                                                , metaLastRecapMainTurns = 0
                                                 }
                                         writeSessionMeta
                                             handle'.sessionPool

--- a/packages/agent-cli/src/Agent/CLI/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session.hs
@@ -39,6 +39,8 @@ module Agent.CLI.Session
     , setGeneratedSessionTitle
     , setManualSessionTitle
     , resetSessionTitleToAuto
+    , setSessionRecap
+    , setSessionTurnSummary
     , sessionConversationText
     , sessionLegacySubagentTarget
     , sessionTitleTurnCountFromSlot
@@ -146,6 +148,9 @@ data SessionMeta = SessionMeta
     , metaInputTokens :: !Int
     , metaOutputTokens :: !Int
     , metaCachedTokens :: !Int
+    , metaLastRecap :: !(Maybe Text)
+    , metaLastTurnSummary :: !(Maybe Text)
+    , metaLastRecapMainTurns :: !Int
     } deriving (Eq, Show)
 
 data SessionTransfer = SessionTransfer
@@ -234,6 +239,9 @@ instance ToJSON SessionMeta where
         , "inputTokens" .= meta.metaInputTokens
         , "outputTokens" .= meta.metaOutputTokens
         , "cachedTokens" .= meta.metaCachedTokens
+        , "lastRecap" .= meta.metaLastRecap
+        , "lastTurnSummary" .= meta.metaLastTurnSummary
+        , "lastRecapMainTurns" .= meta.metaLastRecapMainTurns
         ]
 
 instance FromJSON SessionMeta where
@@ -280,6 +288,9 @@ instance FromJSON SessionMeta where
             <*> (o .:? "inputTokens" .!= 0)
             <*> (o .:? "outputTokens" .!= 0)
             <*> (o .:? "cachedTokens" .!= 0)
+            <*> o .:? "lastRecap"
+            <*> o .:? "lastTurnSummary"
+            <*> (o .:? "lastRecapMainTurns" .!= 0)
 
 data SessionTurn = SessionTurn
     { turnAt :: !UTCTime
@@ -525,6 +536,9 @@ createReservedSession spec sessionId tempDir = do
             , metaInputTokens = 0
             , metaOutputTokens = 0
             , metaCachedTokens = 0
+            , metaLastRecap = Nothing
+            , metaLastTurnSummary = Nothing
+            , metaLastRecapMainTurns = 0
             }
         handle = SessionHandle
             { sessionPool = pool
@@ -886,6 +900,21 @@ resetSessionTitleToAuto handle = do
     writeSessionMeta handle.sessionPool handle.sessionMetaPath meta
     pure handle { sessionMeta = meta }
 
+setSessionRecap :: Text -> Int -> SessionHandle -> IO SessionHandle
+setSessionRecap summary mainTurns handle = do
+    let meta = handle.sessionMeta
+            { metaLastRecap = Just summary
+            , metaLastRecapMainTurns = max 0 mainTurns
+            }
+    writeSessionMeta handle.sessionPool handle.sessionMetaPath meta
+    pure handle { sessionMeta = meta }
+
+setSessionTurnSummary :: Text -> SessionHandle -> IO SessionHandle
+setSessionTurnSummary summary handle = do
+    let meta = handle.sessionMeta { metaLastTurnSummary = Just summary }
+    writeSessionMeta handle.sessionPool handle.sessionMetaPath meta
+    pure handle { sessionMeta = meta }
+
 sessionUsageFromMeta :: SessionMeta -> TokenUsage
 sessionUsageFromMeta meta = TokenUsage
     { inputTokens = meta.metaInputTokens
@@ -1053,6 +1082,10 @@ toStoredMetadata meta = Store.SessionMetadata
     , sessionMetadataInputTokens = fromIntegral meta.metaInputTokens
     , sessionMetadataOutputTokens = fromIntegral meta.metaOutputTokens
     , sessionMetadataCachedTokens = fromIntegral meta.metaCachedTokens
+    , sessionMetadataLastRecap = meta.metaLastRecap
+    , sessionMetadataLastTurnSummary = meta.metaLastTurnSummary
+    , sessionMetadataLastRecapMainTurns =
+        fromIntegral meta.metaLastRecapMainTurns
     }
 
 fromStoredMetadata :: Store.SessionMetadata -> Either Text SessionMeta
@@ -1100,6 +1133,10 @@ fromStoredMetadata stored = do
         , metaInputTokens = fromIntegral stored.sessionMetadataInputTokens
         , metaOutputTokens = fromIntegral stored.sessionMetadataOutputTokens
         , metaCachedTokens = fromIntegral stored.sessionMetadataCachedTokens
+        , metaLastRecap = stored.sessionMetadataLastRecap
+        , metaLastTurnSummary = stored.sessionMetadataLastTurnSummary
+        , metaLastRecapMainTurns =
+            fromIntegral stored.sessionMetadataLastRecapMainTurns
         }
 
 toStoredLegacyTarget

--- a/packages/agent-cli/src/Agent/CLI/SessionEnv.hs
+++ b/packages/agent-cli/src/Agent/CLI/SessionEnv.hs
@@ -7,6 +7,7 @@ import Agent.CLI.Interrupt (InterruptState)
 import Agent.CLI.AgentViewport (AgentViewportEnv)
 import Agent.CLI.ModelConfig (ModelCatalog)
 import Agent.CLI.Btw (BtwBackendFactory)
+import Agent.CLI.Recap (RecapRequest)
 import Agent.CLI.Command (ShellMode)
 import Agent.CLI.Compaction (CompactOutcome)
 import Agent.CLI.Options (ApprovalPolicy)
@@ -35,6 +36,7 @@ import Control.Concurrent.STM (STM)
 data SessionEnv = SessionEnv
     { sessionLoop :: !LoopConfig
     , sessionBtwBackend :: !BtwBackendFactory
+    , sessionQueueRecap :: !(RecapRequest -> IO ())
     , sessionCompact :: !(Maybe Text -> IO (Either Text CompactOutcome))
     , sessionRender :: !RenderConfig
     , sessionProvider :: !Provider

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -186,6 +186,7 @@ import Brick.Widgets.Center (center, centerLayer, hCenter)
 import Codec.Picture (pixelAt)
 import Control.Concurrent.Async (wait, waitCatch, withAsync)
 import Control.Concurrent (threadDelay)
+import Control.Monad (forever, unless, void, when, (>=>))
 import Control.Concurrent.STM
     ( STM
     , atomically
@@ -201,7 +202,11 @@ import Control.Concurrent.STM
     , takeTMVar
     , writeTVar
     )
-import Control.Monad (unless, void, when)
+import Agent.CLI.Recap
+    ( autoRecapAwayThreshold
+    , autoRecapIdleThreshold
+    , autoRecapRetryInterval
+    )
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.State.Strict (modify')
 import Control.Exception.Safe (finally, throwIO, tryAny)
@@ -304,6 +309,7 @@ newFullscreenRuntimeWithSyntaxLoader
         sessionActions <- newIORef FullscreenSessionActions
             { sessionCancel = cancelAction
             , sessionBtw = const (pure ())
+            , sessionRecap = pure ()
             , sessionRestartEffort = restartEffortAction
             , sessionCtrlC = ctrlCAction
             , sessionAgentSnapshot = agentSnapshot
@@ -318,6 +324,8 @@ newFullscreenRuntimeWithSyntaxLoader
             , runtimeBtw = \question ->
                 readIORef sessionActions >>= \actions ->
                     actions.sessionBtw question
+            , runtimeRecap =
+                readIORef sessionActions >>= (.sessionRecap)
             , runtimeRestartEffort = \level ->
                 readIORef sessionActions >>= \actions ->
                     actions.sessionRestartEffort level
@@ -353,6 +361,7 @@ setFullscreenSessionActions
     :: FullscreenRuntime
     -> IO ()
     -> (Text -> IO ())
+    -> IO ()
     -> (Text -> IO ())
     -> IO CtrlCDecision
     -> IO (AgentTarget, [AgentEntry])
@@ -362,6 +371,7 @@ setFullscreenSessionActions
     runtime
     cancelAction
     btwAction
+    recapAction
     restartEffortAction
     ctrlCAction
     agentSnapshot
@@ -369,6 +379,7 @@ setFullscreenSessionActions
         writeIORef runtime.runtimeSessionActions FullscreenSessionActions
             { sessionCancel = cancelAction
             , sessionBtw = btwAction
+            , sessionRecap = recapAction
             , sessionRestartEffort = restartEffortAction
             , sessionCtrlC = ctrlCAction
             , sessionAgentSnapshot = agentSnapshot
@@ -687,6 +698,8 @@ runFullscreen runtime workerAction = do
             -- when rendered attributes contain URLs.
             when (V.supportsMode output V.Hyperlink) $
                 V.setMode output V.Hyperlink True
+            when (V.supportsMode output V.Focus) $
+                V.setMode output V.Focus True
             wrapNativePreviewVty runtime vty
     initialVty <- buildVty
     let
@@ -707,9 +720,10 @@ runFullscreen runtime workerAction = do
         withAsync uiTicker \_uiTicker ->
             withAsync (agentTicker (initialAgent, initialAgents)) \_agentTicker ->
                 withAsync (eventPump runtime) \_eventPump ->
-                    withAsync
-                        (loadSyntaxHighlighterForRuntime runtime)
-                        \_syntaxLoader ->
+                    withAsync (recapTicker runtime) \_recapTicker ->
+                        withAsync
+                            (loadSyntaxHighlighterForRuntime runtime)
+                            \_syntaxLoader ->
                             withAsync
                                 (void (waitCatch worker)
                                     >> enqueueAppEvent runtime AppStop)
@@ -737,6 +751,10 @@ runFullscreen runtime workerAction = do
                                                     }
                                     wait worker
   where
+    recapTicker _runtime = forever do
+        threadDelay 20_000_000
+        enqueueAppEvent runtime AppRecapPoll
+
     uiTicker = waitForDemand
       where
         waitForDemand = do
@@ -824,6 +842,11 @@ initialFullscreenAppState runtime history initialAgent initialAgents initialCloc
         , appPressedControl = Nothing
         , appWorkerStopped = False
         , appConversationAnchor = Nothing
+        , appTerminalFocused = True
+        , appFocusLostAt = Nothing
+        , appAutoRecapShownThisAway = False
+        , appLastAutoRecapAttemptAt = Nothing
+        , appLastTurnCompletedAt = Nothing
         , appConversationReflowQueued = False
         , appWindowTitle = Nothing
         , appMotionElapsedMillis = 0
@@ -2411,6 +2434,11 @@ drawBlock state block =
                     (visibleBody block)
             BlockSystem ->
                 withAttr Theme.mutedAttr (txtWrap block.blockBody)
+            BlockRecap ->
+                accentBlock
+                    (statusAttr state block)
+                    (blockStateGlyph state block <> "Recap")
+                    (visibleBody block)
             BlockError ->
                 withAttr Theme.errorAttr (txtWrap block.blockBody)
         framed =
@@ -2799,7 +2827,7 @@ resumeRow browser selectedId entry =
             vBox
                 [ summary
                 , padLeft (Pad 4) $
-                    vBox
+                    vBox $
                         [ resumeDetail "ID" entry.resumeId
                         , resumeDetail "CWD" entry.resumeCwd
                         , resumeDetail "Model" entry.resumeModel
@@ -2821,7 +2849,18 @@ resumeRow browser selectedId entry =
                                 <> "    Tools  "
                                 <> Text.pack (show entry.resumeToolCount)
                             )
-                        , resumeDetail
+                        ]
+                            <> maybe
+                                []
+                                (\recap -> [resumeDetail "Recap" recap])
+                                (nonEmptyResumeText entry.resumeRecap)
+                            <> maybe
+                                []
+                                (\summaryLine ->
+                                    [resumeDetail "Last turn" summaryLine])
+                                (nonEmptyResumeText entry.resumeLastTurnSummary)
+                            <>
+                        [ resumeDetail
                             "Prompt"
                             (if Text.null entry.resumePrompt
                                 then "(none)"
@@ -2844,6 +2883,11 @@ resumeDetail label value =
         [ withAttr Theme.mutedAttr (txt (Text.justifyLeft 12 ' ' label))
         , txtWrap value
         ]
+
+nonEmptyResumeText :: Maybe Text -> Maybe Text
+nonEmptyResumeText =
+    fmap Text.strip >=> \text ->
+        if Text.null text then Nothing else Just text
 
 resumeAbsoluteTime :: UTCTime -> Text
 resumeAbsoluteTime =
@@ -3256,6 +3300,15 @@ applyUiEvent uiEvent state =
         nextState0 =
             state
                 { appUi = nextUi
+                , appAutoRecapShownThisAway =
+                    case uiEvent of
+                        UiRecapReady _ -> True
+                        _ -> state.appAutoRecapShownThisAway
+                , appLastTurnCompletedAt =
+                    case uiEvent of
+                        UiLoop (TurnFinished _) -> Just state.appClockNanos
+                        UiTurnEnded BlockComplete -> Just state.appClockNanos
+                        _ -> state.appLastTurnCompletedAt
                 , appCompletionFlashes =
                     Map.union newFlashes retainedFlashes
                 , appMotionScheduleReset =
@@ -3331,6 +3384,57 @@ advanceAppClockNow :: EventM Name AppState ()
 advanceAppClockNow = do
     now <- liftIO getMonotonicTimeNSec
     modify' (advanceAppTime now)
+
+noteTerminalFocusLost :: EventM Name AppState ()
+noteTerminalFocusLost = do
+    now <- liftIO getMonotonicTimeNSec
+    modify' \state ->
+        state
+            { appTerminalFocused = False
+            , appFocusLostAt = Just now
+            , appAutoRecapShownThisAway = False
+            , appLastAutoRecapAttemptAt = Nothing
+            }
+
+noteTerminalFocusGained :: EventM Name AppState ()
+noteTerminalFocusGained = do
+    maybeRequestAutoRecap
+    modify' \state ->
+        state
+            { appTerminalFocused = True
+            , appFocusLostAt = Nothing
+            }
+
+maybeRequestAutoRecap :: EventM Name AppState ()
+maybeRequestAutoRecap = do
+    now <- liftIO getMonotonicTimeNSec
+    state <- get
+    when (shouldRequestAutoRecap now state) do
+        modify' \current ->
+            current { appLastAutoRecapAttemptAt = Just now }
+        liftIO state.appRuntime.runtimeRecap
+
+shouldRequestAutoRecap :: Word64 -> AppState -> Bool
+shouldRequestAutoRecap now state =
+    not state.appTerminalFocused
+        && not state.appAutoRecapShownThisAway
+        && not (userActionPending state)
+        && not state.appUi.uiRunning
+        && not (hasBackgroundActivity state.appAgentEntries)
+        && elapsedSeconds now state.appFocusLostAt >= autoRecapAwayThreshold
+        && elapsedSeconds now state.appLastTurnCompletedAt
+            >= autoRecapIdleThreshold
+        && ( case state.appLastAutoRecapAttemptAt of
+                Nothing -> True
+                Just attempted ->
+                    elapsedSeconds now (Just attempted)
+                        >= autoRecapRetryInterval
+           )
+
+elapsedSeconds :: Word64 -> Maybe Word64 -> NominalDiffTime
+elapsedSeconds _ Nothing = 0
+elapsedSeconds now (Just started) =
+    realToFrac (now - started) / 1_000_000_000
 
 applyLocalUiEvent :: UiEvent -> EventM Name AppState ()
 applyLocalUiEvent event =
@@ -3419,6 +3523,8 @@ handleEventInner event = case event of
                 writeTVar
                     state.appRuntime.runtimeMotionTickQueued
                     False
+    AppEvent AppRecapPoll ->
+        maybeRequestAutoRecap
     AppEvent AppStop -> do
         modify' \state -> state { appWorkerStopped = True }
         halt
@@ -3738,6 +3844,10 @@ handleEventInner event = case event of
                 , appPressedControl = Nothing
                 , appAgentHover = Nothing
                 }
+    VtyEvent V.EvLostFocus ->
+        noteTerminalFocusLost
+    VtyEvent V.EvGainedFocus ->
+        noteTerminalFocusGained
     VtyEvent V.EvResize{} -> do
         clearAgentHover
         invalidateCache

--- a/packages/agent-cli/src/Agent/CLI/TUI/Bridge.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Bridge.hs
@@ -21,6 +21,9 @@ eventFollows = \case
     UiUserSubmitted _ -> True
     UiAssistantHistory _ -> True
     UiSystemMessage _ -> True
+    UiRecapStarted -> True
+    UiRecapReady _ -> True
+    UiRecapUnavailable _ -> True
     UiErrorMessage _ -> True
     UiRetryCountdown{} -> True
     UiConversationCleared -> True

--- a/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
@@ -113,6 +113,7 @@ data AppEvent
     | AppSyntaxHighlighterLoaded !(Maybe SyntaxHighlighter)
     | AppConversationReflow
     | AppMotionTick
+    | AppRecapPoll
     | AppStop
 
 data PendingAppEvent
@@ -142,6 +143,7 @@ data FullscreenRuntime = FullscreenRuntime
     , runtimeInput :: !FullscreenInputBuffer
     , runtimeCancel :: !(IO ())
     , runtimeBtw :: !(Text -> IO ())
+    , runtimeRecap :: !(IO ())
     , runtimeRestartEffort :: !(Text -> IO ())
     , runtimeCtrlC :: !(IO CtrlCDecision)
     , runtimeCopy :: !(Text -> IO Bool)
@@ -172,6 +174,7 @@ data FullscreenRuntime = FullscreenRuntime
 data FullscreenSessionActions = FullscreenSessionActions
     { sessionCancel :: !(IO ())
     , sessionBtw :: !(Text -> IO ())
+    , sessionRecap :: !(IO ())
     , sessionRestartEffort :: !(Text -> IO ())
     , sessionCtrlC :: !(IO CtrlCDecision)
     , sessionAgentSnapshot :: !(IO (AgentTarget, [AgentEntry]))
@@ -207,6 +210,11 @@ data AppState = AppState
     , appPressedControl :: !(Maybe Name)
     , appWorkerStopped :: !Bool
     , appConversationAnchor :: !(Maybe Scroll.ConversationAnchor)
+    , appTerminalFocused :: !Bool
+    , appFocusLostAt :: !(Maybe Word64)
+    , appAutoRecapShownThisAway :: !Bool
+    , appLastAutoRecapAttemptAt :: !(Maybe Word64)
+    , appLastTurnCompletedAt :: !(Maybe Word64)
     , appConversationReflowQueued :: !Bool
     , appWindowTitle :: !(Maybe Text)
     , appMotionElapsedMillis :: !Int

--- a/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
@@ -236,6 +236,12 @@ spec = do
             parseReplLine "/btw"
                 `shouldBe` ReplCommandError "usage: /btw <QUESTION>"
 
+        it "requests a session recap" do
+            parseReplLine "/recap" `shouldBe` ReplRecap
+            parseReplLine "/summarize" `shouldBe` ReplRecap
+            parseReplLine "/recap now"
+                `shouldBe` ReplCommandError "usage: /recap"
+
         it "rejects unknown levels, extra args, and unknown commands" do
             parseReplLine "/effort bogus"
                 `shouldBe` ReplCommandError
@@ -269,6 +275,7 @@ spec = do
                     , "effort"
                     , "plan"
                     , "btw"
+                    , "recap"
                     , "session"
                     , "session-info"
                     , "afk"

--- a/packages/agent-cli/test/Agent/CLI/RecapSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RecapSpec.hs
@@ -1,0 +1,104 @@
+module Agent.CLI.RecapSpec (spec) where
+
+import Agent.CLI.Recap
+import Agent.Loop
+    ( Backend(..)
+    , BackendResult(..)
+    , TurnInput(..)
+    , emptyTurnOutput
+    )
+import Agent.Responses.Types
+import Agent.ToolDispatch (functionToolCall)
+import Data.IORef
+import qualified Data.Text as Text
+import Test.Hspec
+
+spec :: Spec
+spec = describe "Agent.CLI.Recap" do
+    describe "cleanRecapText" do
+        it "collapses whitespace and strips stray labels" do
+            cleanRecapText "Recap:  We  fixed\nauth"
+                `shouldBe` "We fixed auth"
+            cleanRecapText "\"We merged the branch\""
+                `shouldBe` "We merged the branch"
+
+        it "caps runaway recaps" do
+            let out = cleanRecapText (Text.replicate (recapMaxChars + 20) "a")
+            Text.length out `shouldBe` recapMaxChars + 1
+            Text.last out `shouldBe` '\8230'
+
+    describe "recapGate" do
+        it "allows a manual recap after the first user turn" do
+            recapGate 1 0 RecapManual True `shouldBe` Right ()
+            recapGate 0 0 RecapManual True `shouldBe` Left RecapNoMainTurns
+
+        it "requires idle time, three turns, and a new turn for auto recap" do
+            recapGate 3 2 RecapAuto True `shouldBe` Right ()
+            recapGate 2 0 RecapAuto True `shouldBe` Left RecapTooFewTurns
+            recapGate 3 3 RecapAuto True `shouldBe` Left RecapNoNewMainTurn
+            recapGate 3 2 RecapAuto False `shouldBe` Left RecapIdleThresholdUnmet
+
+    describe "shouldSuppressAutoRecapDisplay" do
+        it "hides long-tail automatic recaps but always shows manual ones" do
+            shouldSuppressAutoRecapDisplay
+                RecapAuto
+                (Text.replicate (recapAutoRawDisplayMax + 1) "x")
+                "short"
+                `shouldBe` True
+            shouldSuppressAutoRecapDisplay RecapManual
+                (Text.replicate (recapAutoRawDisplayMax + 1) "x")
+                "short"
+                `shouldBe` False
+
+    describe "runRecapWithCancel" do
+        it "appends the recap instruction without mutating parent state" do
+            let original =
+                    [ MessageItem ResponseMessage
+                        { messageId = Just "u1"
+                        , content = MessageContentText "fix auth"
+                        , role = RoleUser
+                        , status = Just ItemCompleted
+                        , phase = Nothing
+                        , extraFields = mempty
+                        }
+                    ]
+            params <- newIORef defaultResponseCreateParams
+            transcript <- newIORef original
+            seenInputs <- newIORef []
+            let factory _ = Backend \state _ inputs _ -> do
+                    writeIORef seenInputs inputs
+                    pure $ Right BackendResult
+                        { backendOutput =
+                            emptyTurnOutput "recap-1" []
+                                (Just "We fixed auth retries in billing/retry.rs.")
+                        , backendState = state
+                        }
+            result <-
+                runRecapWithCancel (\_ action -> action)
+                    factory params transcript RecapManual
+            result
+                `shouldBe`
+                    Right
+                        (RecapShown
+                            "We fixed auth retries in billing/retry.rs.")
+            readIORef transcript `shouldReturn` original
+            seen <- readIORef seenInputs
+            seen `shouldSatisfy` \case
+                [UserMessage text] ->
+                    "Write ONE sentence recap body" `Text.isInfixOf` text
+                _ -> False
+
+        it "rejects tool calls" do
+            params <- newIORef defaultResponseCreateParams
+            transcript <- newIORef []
+            let factory _ = Backend \state _ _ _ ->
+                    pure $ Right BackendResult
+                        { backendOutput =
+                            emptyTurnOutput "recap-1"
+                                [functionToolCall "call-1" "shell_command" "{}"]
+                                Nothing
+                        , backendState = state
+                        }
+            runRecapWithCancel (\_ action -> action)
+                factory params transcript RecapManual
+                >>= (`shouldBe` Left RecapUnexpectedToolCall)

--- a/packages/agent-cli/test/Agent/CLI/ResumeSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ResumeSpec.hs
@@ -253,4 +253,7 @@ sampleMeta sid title =
         , metaInputTokens = 0
         , metaOutputTokens = 0
         , metaCachedTokens = 0
+        , metaLastRecap = Nothing
+        , metaLastTurnSummary = Nothing
+        , metaLastRecapMainTurns = 0
         }

--- a/packages/agent-cli/test/Agent/CLI/SessionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SessionSpec.hs
@@ -380,6 +380,15 @@ spec = describe "Agent.CLI.Session" do
                     }
             Aeson.eitherDecode (Aeson.encode turn) `shouldBe` Right turn
 
+        it "round-trips recap metadata" do
+            let meta =
+                    (testMeta "session-1")
+                        { metaLastRecap = Just "We fixed auth retries."
+                        , metaLastTurnSummary = Just "Auth retries wired"
+                        , metaLastRecapMainTurns = 3
+                        }
+            Aeson.eitherDecode (Aeson.encode meta) `shouldBe` Right meta
+
 testCreate :: StorePool -> OsPath -> SessionCreate
 testCreate pool root = SessionCreate
     { createPool = pool
@@ -424,6 +433,9 @@ testMeta sessionId = SessionMeta
     , metaInputTokens = 0
     , metaOutputTokens = 0
     , metaCachedTokens = 0
+    , metaLastRecap = Nothing
+    , metaLastTurnSummary = Nothing
+    , metaLastRecapMainTurns = 0
     }
 
 fixedTime :: UTCTime

--- a/packages/agent-cli/test/Agent/CLI/TUIBridgeSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIBridgeSpec.hs
@@ -145,17 +145,19 @@ spec = describe "fullscreen TUI bridge" do
             runtime
             (modifyIORef' calls (<> ["new cancel"]))
             (const (modifyIORef' calls (<> ["new btw"])))
+            (modifyIORef' calls (<> ["new recap"]))
             (const (modifyIORef' calls (<> ["new effort"])))
             (pure SoftCancel)
             (pure (AgentRoot, []))
             (const (modifyIORef' calls (<> ["new agent"])))
         runtime.runtimeCancel
         runtime.runtimeBtw "question"
+        runtime.runtimeRecap
         runtime.runtimeRestartEffort "high"
         runtime.runtimeAgentSelect AgentRoot
         decision <- runtime.runtimeCtrlC
         readIORef calls `shouldReturn`
-            ["old cancel", "new cancel", "new btw", "new effort", "new agent"]
+            ["old cancel", "new cancel", "new btw", "new recap", "new effort", "new agent"]
         decision `shouldBe` SoftCancel
 
     it "defers syntax loading until the runtime starts it" do

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -40,6 +40,7 @@ import qualified Agent.CLI.PlanSpec as PlanSpec
 import qualified Agent.CLI.ProgressSpec as ProgressSpec
 import qualified Agent.CLI.ProjectSpec as ProjectSpec
 import qualified Agent.CLI.PromptSpec as PromptSpec
+import qualified Agent.CLI.RecapSpec as RecapSpec
 import qualified Agent.CLI.ProviderFallbackSpec as ProviderFallbackSpec
 import qualified Agent.CLI.ProviderAvailabilitySpec as ProviderAvailabilitySpec
 import qualified Agent.CLI.ProviderTransitionSpec as ProviderTransitionSpec
@@ -109,6 +110,7 @@ main = hspec do
     ProgressSpec.spec
     ProjectSpec.spec
     PromptSpec.spec
+    RecapSpec.spec
     ProviderFallbackSpec.spec
     ProviderAvailabilitySpec.spec
     ProviderTransitionSpec.spec

--- a/packages/agent-store/src/Agent/Store/Postgres/Migrations.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Migrations.hs
@@ -131,6 +131,19 @@ coreMigrations =
         , migrationStatements =
             [migrateOpaqueSessionFieldsToTextStatement]
         }
+    , Migration
+        { migrationVersion = 7
+        , migrationName = "session recap summaries"
+        , migrationStatements =
+            [ "ALTER TABLE harness.sessions\
+              \ ADD COLUMN IF NOT EXISTS last_recap text"
+            , "ALTER TABLE harness.sessions\
+              \ ADD COLUMN IF NOT EXISTS last_turn_summary text"
+            , "ALTER TABLE harness.sessions\
+              \ ADD COLUMN IF NOT EXISTS last_recap_main_turns\
+              \ bigint NOT NULL DEFAULT 0"
+            ]
+        }
     ]
 
 -- Version 1 shipped only on the in-development PostgreSQL branch. Empty

--- a/packages/agent-store/src/Agent/Store/Postgres/Session.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Session.hs
@@ -87,6 +87,9 @@ data SessionMetadata = SessionMetadata
     , sessionMetadataInputTokens :: !Int64
     , sessionMetadataOutputTokens :: !Int64
     , sessionMetadataCachedTokens :: !Int64
+    , sessionMetadataLastRecap :: !(Maybe Text)
+    , sessionMetadataLastTurnSummary :: !(Maybe Text)
+    , sessionMetadataLastRecapMainTurns :: !Int64
     }
     deriving (Eq, Show)
 
@@ -174,6 +177,9 @@ sessionSchemaStatements =
       \ input_tokens bigint NOT NULL CHECK (input_tokens >= 0),\
       \ output_tokens bigint NOT NULL CHECK (output_tokens >= 0),\
       \ cached_tokens bigint NOT NULL CHECK (cached_tokens >= 0),\
+      \ last_recap text,\
+      \ last_turn_summary text,\
+      \ last_recap_main_turns bigint NOT NULL DEFAULT 0 CHECK (last_recap_main_turns >= 0),\
       \ next_event_sequence bigint NOT NULL DEFAULT 1,\
       \ next_turn_index bigint NOT NULL DEFAULT 0,\
       \ deleted_at timestamptz,\
@@ -620,10 +626,10 @@ insertSessionStatement = mkStatement
     \ legacy_target_effective_model, legacy_target_dialect,\
     \ cwd, effort, title, title_is_manual, title_refresh_index,\
     \ title_user_turns, last_response_id, input_tokens, output_tokens,\
-    \ cached_tokens\
+    \ cached_tokens, last_recap, last_turn_summary, last_recap_main_turns\
     \ ) VALUES (\
     \ $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13,\
-    \ $14, $15, $16, $17, $18, $19, $20, $21, $22, $23\
+    \ $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26\
     \ ) RETURNING session_id::text"
     metadataParams
     (Decoders.singleRow (Decoders.column (Decoders.nonNullable Decoders.text)))
@@ -671,7 +677,8 @@ metadataUpdateSql =
     \ cwd = $14, effort = $15, title = $16, title_is_manual = $17,\
     \ title_refresh_index = $18, title_user_turns = $19,\
     \ last_response_id = $20, input_tokens = $21, output_tokens = $22,\
-    \ cached_tokens = $23"
+    \ cached_tokens = $23, last_recap = $24, last_turn_summary = $25,\
+    \ last_recap_main_turns = $26"
 
 insertEventStatement :: Statement EventInsert Text
 insertEventStatement = mkStatement
@@ -756,7 +763,8 @@ metadataSelectSql =
     \ legacy_target_effective_model, legacy_target_dialect,\
     \ cwd, effort, title, title_is_manual, title_refresh_index,\
     \ title_user_turns, last_response_id, input_tokens, output_tokens,\
-    \ cached_tokens FROM harness.sessions"
+    \ cached_tokens, last_recap, last_turn_summary, last_recap_main_turns\
+    \ FROM harness.sessions"
 
 loadTurnsStatement :: Statement Text [TurnRow]
 loadTurnsStatement = mkStatement
@@ -900,6 +908,9 @@ metadataParams =
     <> ((.sessionMetadataInputTokens) >$< Encoders.param (Encoders.nonNullable Encoders.int8))
     <> ((.sessionMetadataOutputTokens) >$< Encoders.param (Encoders.nonNullable Encoders.int8))
     <> ((.sessionMetadataCachedTokens) >$< Encoders.param (Encoders.nonNullable Encoders.int8))
+    <> ((.sessionMetadataLastRecap) >$< Encoders.param (Encoders.nullable Encoders.text))
+    <> ((.sessionMetadataLastTurnSummary) >$< Encoders.param (Encoders.nullable Encoders.text))
+    <> ((.sessionMetadataLastRecapMainTurns) >$< Encoders.param (Encoders.nonNullable Encoders.int8))
   where
     legacyField
         :: (SessionLegacyTarget -> Text)
@@ -934,6 +945,9 @@ metadataRow =
         <*> Decoders.column (Decoders.nullable Decoders.text)
         <*> Decoders.column (Decoders.nonNullable Decoders.int8)
         <*> Decoders.column (Decoders.nonNullable Decoders.int8)
+        <*> Decoders.column (Decoders.nonNullable Decoders.int8)
+        <*> Decoders.column (Decoders.nullable Decoders.text)
+        <*> Decoders.column (Decoders.nullable Decoders.text)
         <*> Decoders.column (Decoders.nonNullable Decoders.int8)
 
 decodeLegacyTarget

--- a/packages/agent-store/test/Agent/Store/Postgres/SessionSpec.hs
+++ b/packages/agent-store/test/Agent/Store/Postgres/SessionSpec.hs
@@ -148,6 +148,9 @@ testMetadata now = SessionMetadata
     , sessionMetadataInputTokens = 10
     , sessionMetadataOutputTokens = 5
     , sessionMetadataCachedTokens = 2
+    , sessionMetadataLastRecap = Nothing
+    , sessionMetadataLastTurnSummary = Nothing
+    , sessionMetadataLastRecapMainTurns = 0
     }
 
 testTurn :: UTCTime -> SessionTurn

--- a/packages/agent-store/test/Agent/Store/Postgres/SkillSpec.hs
+++ b/packages/agent-store/test/Agent/Store/Postgres/SkillSpec.hs
@@ -324,6 +324,9 @@ testMetadata now = SessionMetadata
     , sessionMetadataInputTokens = 0
     , sessionMetadataOutputTokens = 0
     , sessionMetadataCachedTokens = 0
+    , sessionMetadataLastRecap = Nothing
+    , sessionMetadataLastTurnSummary = Nothing
+    , sessionMetadataLastRecapMainTurns = 0
     }
 
 shouldContainBytes :: ByteString.ByteString -> ByteString.ByteString -> Expectation

--- a/packages/agent-tui/src/Agent/TUI/Model.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model.hs
@@ -56,7 +56,9 @@ import Agent.ToolDispatch
     , ToolCallResult(..)
     , canonicalToolName
     )
+import qualified Data.Foldable as Foldable
 import qualified Data.Map.Strict as Map
+import Data.Maybe (listToMaybe)
 import Data.Sequence (Seq)
 import qualified Data.Sequence as Seq
 import Data.Text (Text)
@@ -74,6 +76,7 @@ data BlockKind
     | BlockShell
     | BlockEdit
     | BlockSystem
+    | BlockRecap
     | BlockError
     deriving (Eq, Show)
 
@@ -207,6 +210,9 @@ data UiEvent
     | UiHistory !Text
     | UiAssistantHistory !Text
     | UiSystemMessage !Text
+    | UiRecapStarted
+    | UiRecapReady !Text
+    | UiRecapUnavailable !Text
     | UiErrorMessage !Text
     -- | Append an error whose retry guidance counts down in place.
     | UiRetryCountdown !Text !Int !Text
@@ -380,6 +386,22 @@ reduceUi event state = case event of
                 BlockComplete Nothing state
     UiSystemMessage message ->
         appendBlock BlockSystem "System" message "" BlockComplete Nothing state
+    UiRecapStarted ->
+        replaceOrAppendRecap "Generating recap…" BlockRunning state
+    UiRecapReady summary ->
+        replaceOrAppendRecap summary BlockComplete state
+    UiRecapUnavailable message ->
+        case latestRecapIndex state of
+            Just index ->
+                (removeBlockAt index state)
+                    { uiNotice = Just (warningNotice message)
+                    , uiNoticeElapsedMillis = 0
+                    }
+            Nothing ->
+                state
+                    { uiNotice = Just (warningNotice message)
+                    , uiNoticeElapsedMillis = 0
+                    }
     UiErrorMessage message ->
         (appendBlock BlockError "Error" message "" BlockFailed Nothing state)
             { uiRetryCountdown = Nothing }
@@ -729,6 +751,56 @@ appendOrExtend kind title delta streamState state =
         _ ->
             appendBlock kind title delta "" streamState Nothing state
 
+replaceOrAppendRecap :: Text -> BlockState -> UiState -> UiState
+replaceOrAppendRecap body blockState state =
+    case latestRecapIndex state of
+        Just index ->
+            state
+                { uiBlocks =
+                    Seq.adjust
+                        (\block ->
+                            block
+                                { blockBody = body
+                                , blockState
+                                })
+                        index
+                        state.uiBlocks
+                }
+        Nothing ->
+            appendBlock BlockRecap "Recap" body "" blockState Nothing state
+
+latestRecapIndex :: UiState -> Maybe Int
+latestRecapIndex state =
+    case Seq.findIndexR ((== BlockRecap) . (.blockKind)) state.uiBlocks of
+        Just index -> Just index
+        Nothing -> Nothing
+
+selectedIndexFor :: Maybe BlockId -> Seq UiBlock -> Maybe Int
+selectedIndexFor selected remaining =
+    selected >>= \ident -> Seq.findIndexL ((== ident) . (.blockId)) remaining
+
+removeBlockAt :: Int -> UiState -> UiState
+removeBlockAt index state =
+    let remaining = Seq.deleteAt index state.uiBlocks
+        selected =
+            listToMaybe
+                [ block.blockId
+                | idx <- [min index (max 0 (Seq.length remaining - 1))]
+                , idx >= 0
+                , idx < Seq.length remaining
+                , let block = Seq.index remaining idx
+                ]
+    in state
+        { uiBlocks = remaining
+        , uiSelectedBlock = selected
+        , uiSelectedBlockIndex = selectedIndexFor selected remaining
+        , uiBlockIndices =
+            Map.fromList
+                [ (block.blockId, idx)
+                | (idx, block) <- zip [0 ..] (Foldable.toList remaining)
+                ]
+        }
+
 appendBlock
     :: BlockKind
     -> Text
@@ -750,7 +822,7 @@ appendBlock kind title body detail blockState callId state =
             , blockDetail = detail
             , blockState
             , blockExpanded =
-                kind `elem` [BlockUser, BlockAssistant, BlockSystem, BlockError]
+                kind `elem` [BlockUser, BlockAssistant, BlockSystem, BlockRecap, BlockError]
             , blockCallId = callId
             }
     in state

--- a/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
@@ -26,6 +26,20 @@ spec = describe "fullscreen UI reducer" do
         fmap (.permissionIndex) (moved 3).uiPermission `shouldBe` Just 3
         fmap (.permissionIndex) (moved 4).uiPermission `shouldBe` Just 0
 
+    it "reuses one recap block instead of stacking spinners" do
+        let started = reduceUi UiRecapStarted initialUiState
+            ready =
+                reduceUi
+                    (UiRecapReady "We fixed auth retries in billing/retry.rs.")
+                    started
+            blocks = Foldable.toList ready.uiBlocks
+        map (.blockKind) (Foldable.toList started.uiBlocks)
+            `shouldBe` [BlockRecap]
+        map (.blockKind) blocks `shouldBe` [BlockRecap]
+        map (.blockBody) blocks
+            `shouldBe` ["We fixed auth retries in billing/retry.rs."]
+        map (.blockState) blocks `shouldBe` [BlockComplete]
+
     it "retains user, reasoning, and assistant blocks across a turn" do
         let state =
                 apply


### PR DESCRIPTION
## Summary

Returning to a long-running agent session often leaves you staring at a PR or a pile of tool output without a clear “what actually landed.” This adds a display-only recap for that moment.

- `/recap` (alias `/summarize`) generates a one-sentence recap of the session so far
- After the terminal has been unfocused and the last turn is idle, the TUI pre-generates the same recap so it is already in scrollback when you come back
- Recaps never mutate the model conversation; they are a tool-free side call over a transcript snapshot
- Successful turns also persist a short last-turn line, shown with the recap on expanded `/resume` cards
- Session metadata stores `last_recap`, `last_turn_summary`, and `last_recap_main_turns` via a new PostgreSQL migration

The recap is one sentence (~25–40 words), in the user’s language, and leads with agency: “You asked …” for Q&A/review, or “We fixed/merged/wired …” when code actually changed.

## Validation

- GHCi typecheck of `agent-cli` (109 modules)
- `agent-cli` RecapSpec: 7 examples, 0 failures
- `agent-cli` slashCommands: 10 examples, 0 failures
- `agent-tui`: 136 examples, 0 failures
- Recap metadata JSON round-trip covered in SessionSpec
- `git diff --check`

Postgres-backed session tests were not re-run here because this worktree’s temp path exceeds the Unix socket length limit.