### PR TITLE
Use Text UTF-8 storage length for syntax byte limits

### DIFF
--- a/packages/agent-syntax/src/Agent/Syntax.hs
+++ b/packages/agent-syntax/src/Agent/Syntax.hs
@@ -13,10 +13,10 @@ module Agent.Syntax
     , resolveFenceLanguage
     ) where
 
-import Data.Char (ord)
 import qualified Data.Map.Strict as Map
 import Data.Text (Text)
 import qualified Data.Text as Text
+import qualified Data.Text.Unsafe as TextUnsafe
 import Skylighting.Core
     ( SyntaxMap
     , TokenType(..)
@@ -264,13 +264,4 @@ sourceLineCount source
     | otherwise = Text.count "\n" source + 1
 
 utf8Length :: Text -> Int
-utf8Length = Text.foldl' (\total character -> total + utf8CharLength character) 0
-
-utf8CharLength :: Char -> Int
-utf8CharLength character
-    | code <= 0x7f = 1
-    | code <= 0x7ff = 2
-    | code <= 0xffff = 3
-    | otherwise = 4
-  where
-    code = ord character
+utf8Length = TextUnsafe.lengthWord8

--- a/packages/agent-syntax/test/Agent/SyntaxSpec.hs
+++ b/packages/agent-syntax/test/Agent/SyntaxSpec.hs
@@ -99,6 +99,20 @@ spec = describe "syntax highlighting" do
         highlightCode highlighter "haskell" (Text.replicate 5000 "\n")
             `shouldSatisfy` isLeft
 
+    it "counts UTF-8 bytes at the highlighting boundary" do
+        highlighter <- requireHighlighter
+        let prefix = "--"
+            exactSource = prefix <> Text.replicate 131071 "é"
+            oversizedSource = exactSource <> "é"
+            byteLimitError = \case
+                Left message ->
+                    message == "Code block exceeds the syntax-highlighting byte limit"
+                Right _ -> False
+        highlightCode highlighter "haskell" exactSource
+            `shouldSatisfy` (not . byteLimitError)
+        highlightCode highlighter "haskell" oversizedSource
+            `shouldSatisfy` byteLimitError
+
 requireHighlighter :: IO SyntaxHighlighter
 requireHighlighter = do
     syntaxDirectory <- sourceSyntaxDirectory


### PR DESCRIPTION
Use strict `Text`’s existing UTF-8 storage length via `Data.Text.Unsafe.lengthWord8` when enforcing syntax-highlighting byte limits. This is O(1), does not allocate an encoded copy, and avoids traversing oversized model/tool responses during redraws.

Adds boundary coverage using multibyte text to ensure the limit is measured in UTF-8 bytes rather than Unicode code points.

Validation:
- `agent-syntax` test suite: 10 examples, 0 failures
- `git diff --check`