### PR TITLE
fix(tui): enable Cmd+V image paste in fullscreen

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -50,6 +50,7 @@ module Agent.CLI.TUI.App
     , fullscreenBounds
     , fullscreenVtyConfig
     , fullscreenSurface
+    , wrapFullscreenKeyboardVty
     , setFullscreenImagePreviews
     , setFullscreenWindowTitle
     , uiEventRestartsMotionSchedule
@@ -118,7 +119,11 @@ import Agent.CLI.Style (motionGlyphSet)
 import Agent.CLI.Status (formatTokenUsage)
 import Agent.CLI.Timestamp (currentShortMessageTimestamp)
 import Agent.CLI.Terminal
-    ( kittyCtrlVCsiBodies
+    ( TerminalCapabilities(..)
+    , detectTerminalCapabilities
+    , kittyCtrlVCsiBodies
+    , kittyKeyboardDisambiguatePush
+    , kittyKeyboardPop
     , kittySuperVCsiBodies
     , shiftEnterCsiBodies
     )
@@ -206,7 +211,7 @@ import Control.Concurrent.STM
 import Control.Monad (unless, void, when)
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.State.Strict (modify')
-import Control.Exception.Safe (finally, throwIO, tryAny)
+import Control.Exception.Safe (finally, onException, throwIO, tryAny)
 import Control.Exception (AsyncException(UserInterrupt))
 import Data.Char (isControl, isSpace)
 import Data.Foldable (toList)
@@ -574,6 +579,27 @@ fullscreenVtyConfig =
                ]
         }
 
+-- | Enable the smallest Kitty keyboard protocol mode needed for modified
+-- printable keys such as Cmd+V. The mode is tied to the Vty lifecycle so
+-- Brick suspension pops it before handing the terminal to another process and
+-- a rebuilt Vty pushes it again on resume.
+wrapFullscreenKeyboardVty :: Bool -> V.Vty -> IO V.Vty
+wrapFullscreenKeyboardVty enabled vty
+    | not enabled = pure vty
+    | otherwise = do
+        emit kittyKeyboardDisambiguatePush
+            `onException` V.shutdown vty
+        pure vty
+            { V.shutdown = do
+                alreadyShutdown <- V.isShutdown vty
+                unless alreadyShutdown $
+                    emit kittyKeyboardPop `finally` V.shutdown vty
+            }
+  where
+    emit =
+        V.outputByteBuffer (V.outputIface vty)
+            . TextEncoding.encodeUtf8
+
 requestFullscreenPermission
     :: FullscreenRuntime
     -> ToolCall
@@ -674,6 +700,7 @@ runFullscreen runtime workerAction = do
     history <- readReplHistory
     (initialAgent, initialAgents) <- runtime.runtimeAgentSnapshot
     initialClock <- getMonotonicTimeNSec
+    terminal <- detectTerminalCapabilities stdout
     let buildVty = do
             vty <- Vty.mkVty fullscreenVtyConfig
             let output = V.outputIface vty
@@ -690,6 +717,7 @@ runFullscreen runtime workerAction = do
             when (V.supportsMode output V.Hyperlink) $
                 V.setMode output V.Hyperlink True
             wrapNativePreviewVty runtime vty
+                >>= wrapFullscreenKeyboardVty terminal.terminalKittyKeyboard
     initialVty <- buildVty
     let
         initialState =

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -17,6 +17,7 @@ import Agent.CLI.TUI.App
     , fullscreenVtyConfig
     , fullscreenSurface
     , mergeConversationView
+    , wrapFullscreenKeyboardVty
     , motionDemandFor
     , lambdaArtWidget
     , quickStartRows
@@ -39,6 +40,10 @@ import Agent.CLI.TUI.Types
     , TextInputMode(..)
     , TextOverlay(..)
     )
+import Agent.CLI.Terminal
+    ( kittyKeyboardDisambiguatePush
+    , kittyKeyboardPop
+    )
 import Agent.Loop (LoopEvent(..), emptyTurnOutput)
 import Brick
     ( VScrollbarRenderer(..)
@@ -57,11 +62,16 @@ import Agent.ToolDispatch
     )
 import Agent.TUI.Model
 import Agent.TUI.Motion
+import Control.Concurrent.STM (newTChanIO)
+import qualified Data.ByteString as ByteString
 import Data.Foldable (find)
+import Data.IORef (modifyIORef', newIORef, readIORef)
 import qualified Data.Map.Strict as Map
 import Data.Text (Text)
 import qualified Data.Text as Text
+import qualified Data.Text.Encoding as TextEncoding
 import qualified Graphics.Vty as V
+import qualified Graphics.Vty.Output.Mock as VMock
 import Test.Hspec
 
 spec :: Spec
@@ -204,6 +214,52 @@ spec = do
                   , V.EvKey (V.KChar 'v') [V.MMeta]
                   )
                 ]
+
+    describe "fullscreen keyboard protocol lifecycle" do
+        it "pushes Cmd+V reporting and pops it before Vty shutdown" do
+            events <- newIORef
+                ([] :: [Either ByteString.ByteString ()])
+            (_, output) <- VMock.mockTerminal (80, 24)
+            vty <- mockVty
+                output
+                    { V.outputByteBuffer =
+                        \bytes ->
+                            modifyIORef' events (<> [Left bytes])
+                    }
+                (modifyIORef' events (<> [Right ()]))
+                ((Right () `elem`) <$> readIORef events)
+            let push =
+                    TextEncoding.encodeUtf8
+                        kittyKeyboardDisambiguatePush
+                pop = TextEncoding.encodeUtf8 kittyKeyboardPop
+            wrapped <- wrapFullscreenKeyboardVty True vty
+            readIORef events `shouldReturn` [Left push]
+
+            V.shutdown wrapped
+            readIORef events
+                `shouldReturn` [Left push, Left pop, Right ()]
+
+            V.shutdown wrapped
+            readIORef events
+                `shouldReturn` [Left push, Left pop, Right ()]
+
+        it "leaves unsupported terminals in legacy keyboard mode" do
+            events <- newIORef
+                ([] :: [Either ByteString.ByteString ()])
+            (_, output) <- VMock.mockTerminal (80, 24)
+            vty <- mockVty
+                output
+                    { V.outputByteBuffer =
+                        \bytes ->
+                            modifyIORef' events (<> [Left bytes])
+                    }
+                (modifyIORef' events (<> [Right ()]))
+                ((Right () `elem`) <$> readIORef events)
+            wrapped <- wrapFullscreenKeyboardVty False vty
+            readIORef events `shouldReturn` []
+
+            V.shutdown wrapped
+            readIORef events `shouldReturn` [Right ()]
 
     describe "repositoryHeaderText" do
         it "puts the git state before the full checkout path" do
@@ -642,6 +698,26 @@ spec = do
                 `shouldBe` Map.singleton (BlockId 7) 1
             advanceCompletionFlashes 400 active
                 `shouldBe` Map.empty
+
+mockVty :: V.Output -> IO () -> IO Bool -> IO V.Vty
+mockVty output shutdownAction isShutdownAction = do
+    channel <- newTChanIO
+    let input = V.Input
+            { V.eventChannel = channel
+            , V.shutdownInput = pure ()
+            , V.restoreInputState = pure ()
+            , V.inputLogMsg = const (pure ())
+            }
+    pure V.Vty
+        { V.update = const (pure ())
+        , V.nextEvent = pure (V.EvKey V.KEsc [])
+        , V.nextEventNonblocking = pure Nothing
+        , V.inputIface = input
+        , V.outputIface = output
+        , V.refresh = pure ()
+        , V.shutdown = shutdownAction
+        , V.isShutdown = isShutdownAction
+        }
 
 choiceOverlay :: Bool -> ChoiceOverlay
 choiceOverlay closeOnTurnEnd = ChoiceOverlay


### PR DESCRIPTION
## Summary

- enable Kitty modified-key reporting for fullscreen Vty sessions so Ghostty can deliver Cmd+V to the composer when the clipboard contains an image
- scope the keyboard protocol push/pop to each Vty lifecycle, including Brick suspend/resume and shutdown
- add regression coverage for supported terminals, legacy fallback, and idempotent shutdown

## Testing

- `nix develop -c cabal repl agent-cli:test:agent-cli-test --repl-options=-v0` with `hspec Agent.CLI.TUIAppSpec.spec` — 39 examples, 0 failures
- live tmux smoke test with a 1×1 PNG clipboard and the Kitty Cmd+V sequence — image attached as `image/png` and appeared as `image 1` in the composer
