### PR TITLE
Use Applicative alternative in inline parser

### DIFF
--- a/packages/agent-tui/src/Agent/TUI/Markdown/Inline.hs
+++ b/packages/agent-tui/src/Agent/TUI/Markdown/Inline.hs
@@ -5,6 +5,7 @@ module Agent.TUI.Markdown.Inline
     , parseInline
     ) where
 
+import Control.Applicative ((<|>))
 import Data.Char
     ( isAlphaNum
     , isAscii
@@ -367,9 +368,3 @@ coalesceText = foldr step []
     step (InlineText left) (InlineText right : rest) =
         InlineText (left <> right) : rest
     step inline rest = inline : rest
-
-infixr 3 <|>
-
-(<|>) :: Maybe a -> Maybe a -> Maybe a
-Just value <|> _ = Just value
-Nothing <|> alternative = alternative


### PR DESCRIPTION
## Summary
- use Control.Applicative ((<|>)) for Maybe parsing
- remove the local duplicate operator

## Validation
- nix develop -c cabal test agent-tui:test:agent-tui-test --offline
- 137 examples, 0 failures
- git diff --check