### PR TITLE
Pause fullscreen redraws when terminal is unfocused

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -17,6 +17,8 @@ module Agent.CLI.TUI.App
     , hasQueuedFullscreenInput
     , initialFullscreenAppState
     , motionDemandFor
+    , motionDemandForTerminalFocus
+    , motionModeForTerminalFocus
     , lambdaArtWidget
     , quickStartRows
     , quickStartVisible
@@ -135,6 +137,8 @@ import Agent.CLI.TUI.Motion
     , hasBackgroundActivity
     , isBackgroundAgentActive
     , motionDemandFor
+    , motionDemandForTerminalFocus
+    , motionModeForTerminalFocus
     , nativeProgressKeepaliveDue
     , nextMotionSchedule
     , uiEventRestartsMotionSchedule
@@ -683,6 +687,8 @@ runFullscreen runtime workerAction = do
                 V.setMode output V.BracketedPaste True
             when (V.supportsMode output V.Mouse) $
                 V.setMode output V.Mouse True
+            when (V.supportsMode output V.Focus) $
+                V.setMode output V.Focus True
             -- Vty deliberately leaves OSC 8 output disabled by default even
             -- when rendered attributes contain URLs.
             when (V.supportsMode output V.Hyperlink) $
@@ -832,6 +838,7 @@ initialFullscreenAppState runtime history initialAgent initialAgents initialCloc
         , appClockNanos = initialClock
         , appNativeProgressKeepaliveBucket = 0
         , appSyntaxHighlighter = Nothing
+        , appTerminalFocus = TerminalFocusUnknown
         }
 
 wrapNativePreviewVty :: FullscreenRuntime -> V.Vty -> IO V.Vty
@@ -3380,6 +3387,9 @@ handleEvent event = do
                 state.appRuntime.runtimeImagePreviewRevision
                 (+ 1)
     syncMotionDemand
+    stateAfterMotionSync <- get
+    when (stateAfterMotionSync.appTerminalFocus == TerminalUnfocused) $
+        continueWithoutRedraw
   where
     isMotionTick = \case
         AppEvent AppMotionTick -> True
@@ -3599,7 +3609,11 @@ handleEventInner event = case event of
                 (setFullscreenWindowTitle state.appRuntime)
                 state.appWindowTitle
             atomically (putTMVar reply result)
-            pure state { appAgentHover = Nothing }
+            pure state
+                { appAgentHover = Nothing
+                , appTerminalFocus = TerminalFocusUnknown
+                , appMotionScheduleReset = True
+                }
     MouseDown name button _ _ -> do
         unless (isAgentHoverSurface name) clearAgentHover
         state <- get
@@ -3741,12 +3755,23 @@ handleEventInner event = case event of
     VtyEvent V.EvResize{} -> do
         clearAgentHover
         invalidateCache
-        -- A resize can leave terminal cells from the previous geometry even
-        -- when Brick's next target picture is correctly bounded. Reset Vty's
-        -- assumed display so that redraw repaints the resized surface rather
-        -- than diffing against cells that may have wrapped or moved.
-        getVtyHandle >>= liftIO . V.refresh
+        -- A focused resize can leave cells from the previous geometry. Hidden
+        -- terminals defer the reset until their focus-gained refresh.
+        state <- get
+        when (state.appTerminalFocus /= TerminalUnfocused) $
+            getVtyHandle >>= liftIO . V.refresh
         queueConversationReflow
+    VtyEvent V.EvLostFocus ->
+        modify' \state ->
+            state { appTerminalFocus = TerminalUnfocused }
+    VtyEvent V.EvGainedFocus -> do
+        modify' \state ->
+            state
+                { appTerminalFocus = TerminalFocused
+                , appMotionScheduleReset = True
+                }
+        invalidateCache
+        getVtyHandle >>= liftIO . V.refresh
     VtyEvent vtyEvent -> do
         clearAgentHover
         state <- get

--- a/packages/agent-cli/src/Agent/CLI/TUI/Motion.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Motion.hs
@@ -8,6 +8,8 @@ module Agent.CLI.TUI.Motion
     , hasBackgroundActivity
     , isBackgroundAgentActive
     , motionDemandFor
+    , motionDemandForTerminalFocus
+    , motionModeForTerminalFocus
     , nativeProgressKeepaliveDue
     , nextMotionSchedule
     , uiEventRestartsMotionSchedule
@@ -21,6 +23,7 @@ import Agent.CLI.AgentViewport
 import Agent.CLI.TUI.Types
     ( AppState(..)
     , FullscreenRuntime(..)
+    , TerminalFocus(..)
     )
 import Agent.Loop (LoopEvent(..))
 import Agent.TUI.Model
@@ -92,9 +95,44 @@ motionDemandFor mode waitingForUser backgroundActive completionFlashing ui =
     semanticDemand =
         if uiNeedsTick ui then MotionSlow else MotionNone
 
+-- | Suppress cosmetic motion while the terminal is unfocused, while retaining
+-- semantic ticks used for elapsed time, notice expiry, and progress keepalive.
+motionDemandForTerminalFocus
+    :: TerminalFocus
+    -> MotionMode
+    -> Bool
+    -> Bool
+    -> Bool
+    -> UiState
+    -> MotionDemand
+motionDemandForTerminalFocus
+    focus
+    mode
+    waitingForUser
+    backgroundActive
+    completionFlashing
+    ui
+    | focus == TerminalUnfocused =
+        if uiNeedsTick ui then MotionSlow else MotionNone
+    | otherwise =
+        motionDemandFor
+            mode
+            waitingForUser
+            backgroundActive
+            completionFlashing
+            ui
+
+-- | Unfocused terminals retain only the one-second off-mode cadence, bounded
+-- by any earlier semantic deadline.
+motionModeForTerminalFocus :: TerminalFocus -> MotionMode -> MotionMode
+motionModeForTerminalFocus focus mode
+    | focus == TerminalUnfocused = MotionOff
+    | otherwise = mode
+
 appMotionDemand :: AppState -> MotionDemand
 appMotionDemand state =
-    motionDemandFor
+    motionDemandForTerminalFocus
+        state.appTerminalFocus
         state.appRuntime.runtimeMotionMode
         (userActionPending state)
         (hasBackgroundActivity state.appAgentEntries)
@@ -105,12 +143,16 @@ appMotionTiming :: AppState -> (MotionDemand, Int)
 appMotionTiming state =
     ( demand
     , motionDelayMicros
-        state.appRuntime.runtimeMotionMode
+        effectiveMode
         demand
         (appNextDeadlineMillis state)
     )
   where
     demand = appMotionDemand state
+    effectiveMode =
+        motionModeForTerminalFocus
+            state.appTerminalFocus
+            state.appRuntime.runtimeMotionMode
 
 appNextDeadlineMillis :: AppState -> Maybe Int
 appNextDeadlineMillis state =

--- a/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
@@ -14,6 +14,7 @@ module Agent.CLI.TUI.Types
     , PendingAppEvent(..)
     , PendingUiEvent(..)
     , ResumeOverlay(..)
+    , TerminalFocus(..)
     , TextInputMode(..)
     , TextOverlay(..)
     ) where
@@ -215,7 +216,16 @@ data AppState = AppState
     , appClockNanos :: !Word64
     , appNativeProgressKeepaliveBucket :: !Int
     , appSyntaxHighlighter :: !(Maybe SyntaxHighlighter)
+    , appTerminalFocus :: !TerminalFocus
     }
+
+-- | Best-effort focus state reported by the terminal. Unknown preserves the
+-- normal rendering cadence for terminals that do not support focus events.
+data TerminalFocus
+    = TerminalFocusUnknown
+    | TerminalFocused
+    | TerminalUnfocused
+    deriving (Eq, Show)
 
 data AgentHover = AgentHover
     { agentHoverTarget :: !AgentTarget

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -17,6 +17,8 @@ import Agent.CLI.TUI.App
     , fullscreenVtyConfig
     , fullscreenSurface
     , motionDemandFor
+    , motionDemandForTerminalFocus
+    , motionModeForTerminalFocus
     , lambdaArtWidget
     , quickStartRows
     , quickStartVisible
@@ -35,6 +37,7 @@ import Agent.CLI.TUI.Types
     ( ChoiceOverlay(..)
     , ChoicePresentation(..)
     , Name(..)
+    , TerminalFocus(..)
     , TextInputMode(..)
     , TextOverlay(..)
     )
@@ -411,6 +414,44 @@ spec = do
                 `shouldBe` MotionSlow
             motionDemandFor MotionOff False False False countdown
                 `shouldBe` MotionSlow
+
+        it "suppresses cosmetic motion and slows cadence while unfocused" do
+            let idle =
+                    reduceUi
+                        (UiUserSubmitted "done")
+                        initialUiState
+                running =
+                    reduceUi (UiLoop TurnStarted) idle
+            motionDemandForTerminalFocus
+                TerminalFocused
+                MotionFull
+                False
+                False
+                False
+                running
+                `shouldBe` MotionFast
+            motionDemandForTerminalFocus
+                TerminalUnfocused
+                MotionFull
+                False
+                True
+                True
+                idle
+                `shouldBe` MotionNone
+            motionDemandForTerminalFocus
+                TerminalUnfocused
+                MotionFull
+                False
+                False
+                False
+                running
+                `shouldBe` MotionSlow
+            motionModeForTerminalFocus TerminalFocused MotionFull
+                `shouldBe` MotionFull
+            motionModeForTerminalFocus TerminalFocusUnknown MotionReduced
+                `shouldBe` MotionReduced
+            motionModeForTerminalFocus TerminalUnfocused MotionFull
+                `shouldBe` MotionOff
 
         it "bumps the scheduler generation on demand or timer boundaries" do
             nextMotionSchedule


### PR DESCRIPTION
## Summary

- enable Vty focus reporting for the fullscreen CLI
- retain UI/provider state but suppress Brick/Vty redraws while the terminal is unfocused
- disable cosmetic motion and reduce semantic timer cadence while unfocused
- force a full refresh and restore normal scheduling when focus returns
- preserve existing behavior when terminal focus reporting is unavailable

## Validation

- loaded `agent-cli:lib:agent-cli` successfully in GHCi
- ran `Agent.CLI.TUIAppSpec` in GHCi: 37 examples, 0 failures
- exercised the live fullscreen agent in tmux with `focus-events on`, switched away and back, and verified repaint plus composer input
- `git diff --check`

## Performance

Optimized scratch benchmark built with GHC 9.10.3, `-O2`, and `+RTS -T`. The workload applies 1,000 streamed 16-byte deltas to retained UI state and compares rendering after every update with retaining state while skipping redraws.

| path | median CPU | allocated |
| --- | ---: | ---: |
| render each update | ~1.15 s | 5.41 GB |
| retain state, skip redraw | <1 ms | 5.35 MB |

Additional samples at 100 and 500 chunks showed the same boundary. This is an intentionally worst-case rendering microbenchmark; production streaming already batches deltas into roughly 16 ms frames, but the result confirms that suppressed redraws remove the dominant hidden-terminal work.
