### PR TITLE
Extract Agent.CLI session lifecycle

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -57,6 +57,7 @@ library
                     , Agent.CLI.Session.Choices
                     , Agent.CLI.Session.History
                     , Agent.CLI.Session.Interaction
+                    , Agent.CLI.Session.Lifecycle
                     , Agent.CLI.Session.Retry
                     , Agent.CLI.Session.Selection
                     , Agent.CLI.Session.Runtime.Types

--- a/packages/agent-cli/src/Agent/CLI/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime.hs
@@ -230,10 +230,6 @@ import Agent.CLI.Models
     , resolveModelOptionDialect
     , resolvePersistedDialect
     )
-import Agent.CLI.Notification
-    ( AttentionRequest(InputRequested)
-    , notifyAttention
-    )
 import Agent.CLI.Options
 import Agent.Store.Postgres
     ( ManagedPostgresConfig
@@ -272,7 +268,6 @@ import Agent.CLI.Project
     , projectAccountFor
     , projectModelProvider
     , resolveProjectRoot
-    , saveProjectAccount
     , saveProjectAutoApprove
     , saveProjectMaxConcurrentAgents
     , saveProjectModel
@@ -286,8 +281,6 @@ import Agent.CLI.ProviderFallback
     ( allowsAutomaticBillingFallback
     , fallbackCandidates
     , isProviderUnavailable
-    , ProviderRecoveryPreference(..)
-    , providerRecoveryPreference
     )
 import Agent.CLI.Provider.OpenAI
     ( OpenAiPersistentConnection(..)
@@ -318,7 +311,6 @@ import Agent.CLI.ProviderTransition
     , TransitionCause(..)
     , TurnResult(..)
     , applyProviderTransition
-    , setPendingExitAfter
     , transitionCommitsImmediately
     )
 import Agent.CLI.SessionState (SessionState(..), newSessionState)
@@ -352,9 +344,9 @@ import Agent.CLI.Session.Interaction
     ( buildPromptState
     , runBtwQuestion
     , setSessionEffort
-    , syncFullscreenPrompt
     )
-import Agent.CLI.Session.Retry (waitAndRetryPendingTurn)
+import Agent.CLI.Session.Lifecycle (SessionContinuation(..))
+import qualified Agent.CLI.Session.Lifecycle as SessionLifecycle
 import Agent.CLI.Session.Selection
     ( currentSessionId
     , handleConversationSearch
@@ -462,7 +454,6 @@ import Agent.CLI.TUI.App
     ( FullscreenInputBuffer
     , FullscreenRuntime
     , emitUiEvent
-    , hasQueuedFullscreenInput
     , newFullscreenInputBuffer
     , newFullscreenRuntime
     , queuedFullscreenInputDisplays
@@ -725,7 +716,7 @@ import System.Environment (getArgs, getProgName, lookupEnv)
 import System.OsPath (OsPath, decodeFS, unsafeEncodeUtf, (</>), takeDirectory, takeFileName)
 import System.Console.ANSI (getTerminalSize)
 import System.Console.ANSI.Codes (clearFromCursorToLineEndCode)
-import System.Exit (ExitCode(..), die, exitFailure)
+import System.Exit (ExitCode(..), die)
 import System.IO (Handle, hFlush, hIsTerminalDevice, stderr, stdin, stdout)
 import System.Mem.StableName (StableName, makeStableName)
 import System.Process (readProcessWithExitCode)
@@ -3919,133 +3910,26 @@ runSession SessionRequest{..} SessionBackend{..} = do
     applyPendingSessionTitles env
     pure result
 
+sessionContinuation :: SessionContinuation
+sessionContinuation =
+    SessionContinuation
+        { resumeSession = repl
+        , resumeSessionWithDraft = replWithDraft
+        }
+
 runPendingTurn
     :: PendingTurnPresentation
     -> SessionEnv
     -> PendingTurn
     -> IO RunResult
-runPendingTurn presentation =
-    runPendingTurnWithCooldownRetry True presentation
-
-runPendingTurnWithCooldownRetry
-    :: Bool
-    -> PendingTurnPresentation
-    -> SessionEnv
-    -> PendingTurn
-    -> IO RunResult
-runPendingTurnWithCooldownRetry
-    allowCooldownRetry presentation env pending = do
-    writeIORef env.sessionPlanMode.planStateRef pending.pendingPlanState
-    syncFullscreenPrompt env
-    case env.sessionFullscreen of
-        Nothing -> pure ()
-        Just runtime -> case presentation of
-            SubmitPendingTurn ->
-                emitUiEvent runtime
-                    (UiUserSubmitted pending.pendingPromptText)
-            RestartPendingTurn ->
-                emitUiEvent runtime UiTurnRestarted
-            ContinuePendingTurn ->
-                pure ()
-    result <- runOneTurn env pending.pendingPromptText pending.pendingInputs
-    finishTurnWithCooldownRetry
-        allowCooldownRetry env pending.pendingExitAfter result
+runPendingTurn = SessionLifecycle.runPendingTurn sessionContinuation
 
 finishTurn
     :: SessionEnv
     -> Bool
     -> TurnResult
     -> IO RunResult
-finishTurn = finishTurnWithCooldownRetry True
-
-finishTurnWithCooldownRetry
-    :: Bool
-    -> SessionEnv
-    -> Bool
-    -> TurnResult
-    -> IO RunResult
-finishTurnWithCooldownRetry allowCooldownRetry env exitAfter = \case
-    TurnSucceeded -> do
-        env.sessionQueueRecap RecapTurnSummary
-        writeIORef env.sessionUnavailableProviders []
-        selectionId <- readIORef env.sessionAccountSelectionId
-        accountId <- readIORef env.sessionAccountId
-        when
-            (not (Text.null (Text.strip selectionId))
-                && not (Text.null (Text.strip accountId))) $
-            saveProjectAccount
-                env.sessionProjectRoot
-                env.sessionProvider
-                selectionId
-                accountId
-        case env.sessionFullscreen of
-            Nothing -> putTrailingNewline env.sessionPrinted
-            Just _ -> pure ()
-        if exitAfter
-            then pure RunQuit
-            else continueAfterTurn env
-    TurnCancelled -> do
-        case env.sessionFullscreen of
-            Nothing -> putTrailingNewline env.sessionPrinted
-            Just _ -> pure ()
-        if exitAfter
-            then pure RunQuit
-            else repl env
-    TurnFailed ->
-        if exitAfter
-            then exitFailure
-            else do
-                case env.sessionFullscreen of
-                    Nothing -> putTrailingNewline env.sessionPrinted
-                    Just _ -> pure ()
-                continueAfterTurn env
-    TurnRestartRequested level pending -> do
-        setSessionEffort env level
-        writeIORef env.sessionPlanMode.planStateRef pending.pendingPlanState
-        case env.sessionFullscreen of
-            Just runtime ->
-                emitUiEvent runtime
-                    (UiSystemMessage
-                        ("restarting current turn with " <> level <> " effort"))
-            Nothing -> pure ()
-        result <- runOneTurn env pending.pendingPromptText pending.pendingInputs
-        finishTurnWithCooldownRetry allowCooldownRetry env exitAfter result
-    TurnProviderUnavailable apiError pending ->
-        let pending' = setPendingExitAfter exitAfter pending
-        in do
-            now <- getCurrentTime
-            case providerRecoveryPreference
-                    allowCooldownRetry now apiError of
-                RetryCurrentProviderAfter delay ->
-                    waitAndRetryPendingTurn
-                        (replWithDraft env)
-                        (runPendingTurnWithCooldownRetry
-                            False RestartPendingTurn env)
-                        env
-                        delay
-                        pending'
-                TryProviderFallback ->
-                    requestAutomaticProviderFallback env apiError pending'
-                        >>= \case
-                        Just providerTransition ->
-                            pure (RunSwitchProvider providerTransition)
-                        Nothing -> do
-                            reportProviderUnavailable
-                                env.sessionFullscreen apiError
-                            if exitAfter
-                                then exitFailure
-                                else do
-                                    notifyAttention stderr InputRequested
-                                    replWithDraft env pending.pendingPromptText
-
-continueAfterTurn :: SessionEnv -> IO RunResult
-continueAfterTurn env = do
-    queued <- case env.sessionFullscreen of
-        Nothing -> pure False
-        Just runtime -> hasQueuedFullscreenInput runtime
-    when (not queued) $
-        notifyAttention stderr InputRequested
-    repl env
+finishTurn = SessionLifecycle.finishTurn sessionContinuation
 
 runSessionRecap :: Bool -> SessionEnv -> RecapKind -> IO ()
 runSessionRecap registerCancel env kind = do

--- a/packages/agent-cli/src/Agent/CLI/Session/Lifecycle.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Lifecycle.hs
@@ -1,0 +1,203 @@
+-- | Pending-turn execution and turn-completion transitions.
+module Agent.CLI.Session.Lifecycle
+    ( SessionContinuation(..)
+    , finishTurn
+    , runPendingTurn
+    ) where
+
+import Agent.CLI.Notification
+    ( AttentionRequest(InputRequested)
+    , notifyAttention
+    )
+import Agent.CLI.Project (saveProjectAccount)
+import Agent.CLI.Recap (RecapRequest(RecapTurnSummary))
+import Agent.CLI.Provider.Switch
+    ( reportProviderUnavailable
+    , requestAutomaticProviderFallback
+    )
+import Agent.CLI.ProviderFallback
+    ( ProviderRecoveryPreference(..)
+    , providerRecoveryPreference
+    )
+import Agent.CLI.ProviderTransition
+    ( PendingTurn(..)
+    , TurnResult(..)
+    , setPendingExitAfter
+    )
+import Agent.CLI.Runtime.Types
+    ( PendingTurnPresentation(..)
+    , RunResult(..)
+    )
+import Agent.CLI.Session.Interaction
+    ( setSessionEffort
+    , syncFullscreenPrompt
+    )
+import Agent.CLI.Session.Retry (waitAndRetryPendingTurn)
+import Agent.CLI.SessionEnv (SessionEnv(..))
+import Agent.CLI.TUI.App
+    ( emitUiEvent
+    , hasQueuedFullscreenInput
+    )
+import Agent.CLI.Turn (runOneTurn)
+import Agent.Tools.PlanMode (PlanModeEnv(..))
+import Agent.TUI.Model (UiEvent(..))
+import Control.Monad (when)
+import Data.IORef
+    ( IORef
+    , readIORef
+    , writeIORef
+    )
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Data.Time.Clock (getCurrentTime)
+import System.Exit (exitFailure)
+import System.IO (stderr)
+
+data SessionContinuation = SessionContinuation
+    { resumeSession :: SessionEnv -> IO RunResult
+    , resumeSessionWithDraft :: SessionEnv -> Text -> IO RunResult
+    }
+
+runPendingTurn
+    :: SessionContinuation
+    -> PendingTurnPresentation
+    -> SessionEnv
+    -> PendingTurn
+    -> IO RunResult
+runPendingTurn continuation presentation =
+    runPendingTurnWithCooldownRetry continuation True presentation
+
+runPendingTurnWithCooldownRetry
+    :: SessionContinuation
+    -> Bool
+    -> PendingTurnPresentation
+    -> SessionEnv
+    -> PendingTurn
+    -> IO RunResult
+runPendingTurnWithCooldownRetry
+    continuation allowCooldownRetry presentation env pending = do
+    writeIORef env.sessionPlanMode.planStateRef pending.pendingPlanState
+    syncFullscreenPrompt env
+    case env.sessionFullscreen of
+        Nothing -> pure ()
+        Just runtime -> case presentation of
+            SubmitPendingTurn ->
+                emitUiEvent runtime
+                    (UiUserSubmitted pending.pendingPromptText)
+            RestartPendingTurn ->
+                emitUiEvent runtime UiTurnRestarted
+            ContinuePendingTurn ->
+                pure ()
+    result <- runOneTurn env pending.pendingPromptText pending.pendingInputs
+    finishTurnWithCooldownRetry
+        continuation allowCooldownRetry env pending.pendingExitAfter result
+
+finishTurn
+    :: SessionContinuation
+    -> SessionEnv
+    -> Bool
+    -> TurnResult
+    -> IO RunResult
+finishTurn continuation =
+    finishTurnWithCooldownRetry continuation True
+
+finishTurnWithCooldownRetry
+    :: SessionContinuation
+    -> Bool
+    -> SessionEnv
+    -> Bool
+    -> TurnResult
+    -> IO RunResult
+finishTurnWithCooldownRetry continuation allowCooldownRetry env exitAfter = \case
+    TurnSucceeded -> do
+        env.sessionQueueRecap RecapTurnSummary
+        writeIORef env.sessionUnavailableProviders []
+        selectionId <- readIORef env.sessionAccountSelectionId
+        accountId <- readIORef env.sessionAccountId
+        when
+            (not (Text.null (Text.strip selectionId))
+                && not (Text.null (Text.strip accountId))) $
+            saveProjectAccount
+                env.sessionProjectRoot
+                env.sessionProvider
+                selectionId
+                accountId
+        case env.sessionFullscreen of
+            Nothing -> putTrailingNewline env.sessionPrinted
+            Just _ -> pure ()
+        if exitAfter
+            then pure RunQuit
+            else continueAfterTurn continuation env
+    TurnCancelled -> do
+        case env.sessionFullscreen of
+            Nothing -> putTrailingNewline env.sessionPrinted
+            Just _ -> pure ()
+        if exitAfter
+            then pure RunQuit
+            else continuation.resumeSession env
+    TurnFailed ->
+        if exitAfter
+            then exitFailure
+            else do
+                case env.sessionFullscreen of
+                    Nothing -> putTrailingNewline env.sessionPrinted
+                    Just _ -> pure ()
+                continueAfterTurn continuation env
+    TurnRestartRequested level pending -> do
+        setSessionEffort env level
+        writeIORef env.sessionPlanMode.planStateRef pending.pendingPlanState
+        case env.sessionFullscreen of
+            Just runtime ->
+                emitUiEvent runtime
+                    (UiSystemMessage
+                        ("restarting current turn with " <> level <> " effort"))
+            Nothing -> pure ()
+        result <- runOneTurn env pending.pendingPromptText pending.pendingInputs
+        finishTurnWithCooldownRetry
+            continuation allowCooldownRetry env exitAfter result
+    TurnProviderUnavailable apiError pending ->
+        let pending' = setPendingExitAfter exitAfter pending
+        in do
+            now <- getCurrentTime
+            case providerRecoveryPreference
+                    allowCooldownRetry now apiError of
+                RetryCurrentProviderAfter delay ->
+                    waitAndRetryPendingTurn
+                        (continuation.resumeSessionWithDraft env)
+                        (runPendingTurnWithCooldownRetry
+                            continuation False RestartPendingTurn env)
+                        env
+                        delay
+                        pending'
+                TryProviderFallback ->
+                    requestAutomaticProviderFallback env apiError pending'
+                        >>= \case
+                        Just providerTransition ->
+                            pure (RunSwitchProvider providerTransition)
+                        Nothing -> do
+                            reportProviderUnavailable
+                                env.sessionFullscreen apiError
+                            if exitAfter
+                                then exitFailure
+                                else do
+                                    notifyAttention stderr InputRequested
+                                    continuation.resumeSessionWithDraft
+                                        env
+                                        pending.pendingPromptText
+
+continueAfterTurn
+    :: SessionContinuation
+    -> SessionEnv
+    -> IO RunResult
+continueAfterTurn continuation env = do
+    queued <- case env.sessionFullscreen of
+        Nothing -> pure False
+        Just runtime -> hasQueuedFullscreenInput runtime
+    when (not queued) $
+        notifyAttention stderr InputRequested
+    continuation.resumeSession env
+
+putTrailingNewline :: IORef Bool -> IO ()
+putTrailingNewline printed = do
+    didPrint <- readIORef printed
+    when didPrint (putStrLn "")


### PR DESCRIPTION
## Summary
- move pending-turn execution and turn-completion transitions into `Agent.CLI.Session.Lifecycle`
- isolate provider cooldown retry and fallback routing behind explicit session continuations
- centralize successful account persistence and post-turn notification behavior
- reduce `Agent.CLI.Runtime` while preserving recursive REPL behavior

## Validation
- `printf ":quit\n" | nix develop -c cabal repl agent-cli:lib:agent-cli --repl-options=-fno-code` (114 modules)
- `printf ":main\n:q\n" | TMPDIR=/tmp nix develop -c cabal repl agent-cli:test:agent-cli-test` (884 examples, 0 failures)
- `git diff --check`