### PR TITLE
Use System.IO.Temp for Grok temporary resources

### DIFF
--- a/packages/agent-grok-build-dialect/agent-grok-build-dialect.cabal
+++ b/packages/agent-grok-build-dialect/agent-grok-build-dialect.cabal
@@ -103,5 +103,6 @@ test-suite agent-grok-build-dialect-test
                     , hspec
                     , safe-exceptions
                     , text
+                    , temporary
                     , time
                     , unix

--- a/packages/agent-grok-build-dialect/agent-grok-build-dialect.cabal
+++ b/packages/agent-grok-build-dialect/agent-grok-build-dialect.cabal
@@ -62,6 +62,7 @@ library
                     , process
                     , safe-exceptions
                     , text
+                    , temporary
                     , time
                     , transformers
                     , unix

--- a/packages/agent-grok-build-dialect/package.nix
+++ b/packages/agent-grok-build-dialect/package.nix
@@ -1,6 +1,6 @@
 { mkDerivation, aeson, agent-core, async, base, containers
-, directory, filepath, hspec, lib, process, safe-exceptions, text
-, time, transformers, unix
+, directory, filepath, hspec, lib, process, safe-exceptions
+, temporary, text, time, transformers, unix
 }:
 mkDerivation {
   pname = "agent-grok-build-dialect";
@@ -12,7 +12,7 @@ mkDerivation {
   ];
   testHaskellDepends = [
     agent-core async base containers directory filepath hspec
-    safe-exceptions text time unix
+    safe-exceptions temporary text time unix
   ];
   benchmarkHaskellDepends = [
     aeson agent-core async base containers filepath safe-exceptions

--- a/packages/agent-grok-build-dialect/package.nix
+++ b/packages/agent-grok-build-dialect/package.nix
@@ -8,7 +8,7 @@ mkDerivation {
   src = ./.;
   libraryHaskellDepends = [
     aeson agent-core async base containers directory filepath process
-    safe-exceptions text time transformers unix
+    safe-exceptions temporary text time transformers unix
   ];
   testHaskellDepends = [
     agent-core async base containers directory filepath hspec

--- a/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Shell.hs
+++ b/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Shell.hs
@@ -51,13 +51,12 @@ import qualified Data.Text.IO as Text
 import System.Directory.OsPath
     ( doesDirectoryExist
     , doesFileExist
-    , getTemporaryDirectory
     , removeFile
     )
 import System.IO (hClose)
-import System.OsPath (OsPath, unsafeEncodeUtf, (<.>), (</>))
+import System.IO.Temp (getCanonicalTemporaryDirectory, openTempFile)
+import System.OsPath (OsPath, unsafeEncodeUtf, (<.>))
 import System.Posix.Files (ownerReadMode, ownerWriteMode, setFileMode, unionFileModes)
-import System.Posix.Temp (mkstemp)
 
 data PersistentShell = PersistentShell
     { shellCwd :: !OsPath
@@ -107,9 +106,9 @@ newGrokSession env = do
   where
     acquireEnvFile =
         mask \restore -> do
-            tmp <- getTemporaryDirectory
+            tmp <- getCanonicalTemporaryDirectory
             (envFileRaw, handle) <- restore $
-                mkstemp (unsafeToFilePath (tmp </> unsafeEncodeUtf "agent-grok-env"))
+                openTempFile tmp "agent-grok-env"
             let envFile = unsafeEncodeUtf envFileRaw
             let rollback = do
                     void $ tryAny (hClose handle)

--- a/packages/agent-grok-build-dialect/test/Agent/GrokBuild/DialectSpec.hs
+++ b/packages/agent-grok-build-dialect/test/Agent/GrokBuild/DialectSpec.hs
@@ -1,5 +1,11 @@
 module Agent.GrokBuild.DialectSpec (spec) where
 
+import Agent.GrokBuild.Dialect.Shell
+    ( GrokSession(..)
+    , PersistentShell(..)
+    , closeGrokSession
+    , newGrokSession
+    )
 import Agent.GrokBuild.Dialect.ProjectInstructions (formatGrokAgentsMd)
 import Agent.GrokBuild.Dialect.Prompt
     ( codingGrokPromptTools
@@ -11,13 +17,19 @@ import Agent.GrokBuild.Dialect.Runtime
     )
 import Agent.GrokBuild.Dialect.TaskControl (validateTaskIds)
 import Agent.ProjectInstructions (InstructionFile(..), LoadedAgentsMd(..))
+import Agent.OsPath (unsafeToFilePath)
 import Agent.Tools.Types (AppTool(..), defaultToolEnv)
+import Control.Concurrent.MVar (readMVar)
+import Control.Exception.Safe (bracket)
+import Data.Bits ((.&.))
 import Data.IORef (newIORef)
 import qualified Data.Map.Strict as Map
 import qualified Data.Text as Text
 import Data.Time.Calendar (fromGregorian)
+import System.Directory (doesFileExist)
 import System.IO.Temp (withSystemTempDirectory)
 import System.OsPath (unsafeEncodeUtf)
+import System.Posix.Files (fileMode, getFileStatus)
 import Test.Hspec
 
 spec :: Spec
@@ -60,6 +72,19 @@ spec = describe "Grok Build dialect" do
                 `shouldBe` replicate 7 True
             names `shouldNotContain` ["shell_command", "apply_patch"]
             coding.grokClose
+
+    it "owns a private temporary shell environment file until session close" do
+        path <- withTempDir \dir -> do
+            env <- defaultToolEnv (unsafeEncodeUtf dir)
+            bracket (newGrokSession env) closeGrokSession \session -> do
+                shell <- readMVar session.grokShell
+                let path = unsafeToFilePath shell.shellEnvFile
+                doesFileExist path `shouldReturn` True
+                mode <- fileMode <$> getFileStatus path
+                mode .&. 0o777 `shouldBe` 0o600
+                pure path
+        doesFileExist path `shouldReturn` False
+        doesFileExist (path <> ".cwd") `shouldReturn` False
 
     it "formats and neutralizes project instruction reminders" do
         let loaded = LoadedAgentsMd

--- a/packages/agent-grok-build-dialect/test/Agent/GrokBuild/DialectSpec.hs
+++ b/packages/agent-grok-build-dialect/test/Agent/GrokBuild/DialectSpec.hs
@@ -12,15 +12,12 @@ import Agent.GrokBuild.Dialect.Runtime
 import Agent.GrokBuild.Dialect.TaskControl (validateTaskIds)
 import Agent.ProjectInstructions (InstructionFile(..), LoadedAgentsMd(..))
 import Agent.Tools.Types (AppTool(..), defaultToolEnv)
-import Control.Exception.Safe (bracket)
 import Data.IORef (newIORef)
 import qualified Data.Map.Strict as Map
 import qualified Data.Text as Text
 import Data.Time.Calendar (fromGregorian)
-import System.Directory (getTemporaryDirectory, removeDirectoryRecursive)
-import System.FilePath ((</>))
+import System.IO.Temp (withSystemTempDirectory)
 import System.OsPath (unsafeEncodeUtf)
-import System.Posix.Temp (mkdtemp)
 import Test.Hspec
 
 spec :: Spec
@@ -81,9 +78,4 @@ spec = describe "Grok Build dialect" do
             Nothing -> expectationFailure "expected rendered instructions"
 
 withTempDir :: (FilePath -> IO a) -> IO a
-withTempDir action = do
-    tmp <- getTemporaryDirectory
-    bracket
-        (mkdtemp (tmp </> "agent-grok-build-dialect-XXXXXX"))
-        removeDirectoryRecursive
-        action
+withTempDir = withSystemTempDirectory "agent-grok-build-dialect"

--- a/packages/agent-grok-build-dialect/test/Agent/GrokBuild/RuntimeSpec.hs
+++ b/packages/agent-grok-build-dialect/test/Agent/GrokBuild/RuntimeSpec.hs
@@ -70,13 +70,8 @@ import Data.Time
     , addUTCTime
     , fromGregorian
     )
-import System.Directory
-    ( getTemporaryDirectory
-    , removeDirectoryRecursive
-    )
-import System.FilePath ((</>))
+import System.IO.Temp (withSystemTempDirectory)
 import System.OsPath (unsafeEncodeUtf)
-import System.Posix.Temp (mkdtemp)
 import System.Timeout (timeout)
 import Test.Hspec
 
@@ -563,9 +558,4 @@ fake name = AppTool
     }
 
 withTempDir :: (FilePath -> IO a) -> IO a
-withTempDir action = do
-    tmp <- getTemporaryDirectory
-    bracket
-        (mkdtemp (tmp </> "agent-grok-runtime-XXXXXX"))
-        removeDirectoryRecursive
-        action
+withTempDir = withSystemTempDirectory "agent-grok-runtime"

--- a/packages/agent-store/src/Agent/Store/Postgres/Migrations.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Migrations.hs
@@ -135,11 +135,11 @@ coreMigrations =
         { migrationVersion = 7
         , migrationName = "session recap summaries"
         , migrationStatements =
-            [ "ALTER TABLE harness.sessions\
+            [ "ALTER TABLE IF EXISTS harness.sessions\
               \ ADD COLUMN IF NOT EXISTS last_recap text"
-            , "ALTER TABLE harness.sessions\
+            , "ALTER TABLE IF EXISTS harness.sessions\
               \ ADD COLUMN IF NOT EXISTS last_turn_summary text"
-            , "ALTER TABLE harness.sessions\
+            , "ALTER TABLE IF EXISTS harness.sessions\
               \ ADD COLUMN IF NOT EXISTS last_recap_main_turns\
               \ bigint NOT NULL DEFAULT 0"
             ]


### PR DESCRIPTION
Use `System.IO.Temp` for Grok temporary resources.

- Replace test-only `mkdtemp` helpers with `withSystemTempDirectory`.
- Replace the production Grok environment-file `mkstemp` path with `openTempFile` in the canonical temporary directory.
- Preserve `ResourceScope` rollback/cleanup behavior and enforce mode `0600`.
- Add lifecycle and file-permission coverage.

The failed CI run also exposed an upstream recap migration regression in the newly advanced base: partial legacy-schema migration fixtures do not contain `harness.sessions`. The recap migration now uses `ALTER TABLE IF EXISTS`, preserving normal upgrades while allowing those supported partial legacy migrations to complete.

Validation after rebasing onto the latest master:
- `agent-store`: 31 examples, 0 failures
- `agent-grok-build-dialect`: 32 examples, 0 failures
- `git diff --check`