### PR TITLE
Consolidate credential file locking

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -51,6 +51,7 @@ library
                     , Agent.CLI.PromptHooks
                     , Agent.CLI.Provider.OpenAI
                     , Agent.CLI.Provider.Switch
+                    , Agent.CLI.PrivateFileLock
                     , Agent.CLI.Runtime
                     , Agent.CLI.Runtime.Types
                     , Agent.CLI.Session.Attachments

--- a/packages/agent-cli/src/Agent/CLI/Auth/OpenAI.hs
+++ b/packages/agent-cli/src/Agent/CLI/Auth/OpenAI.hs
@@ -20,6 +20,7 @@ import Agent.CLI.CredentialStore
     , updateManagedCredentialSecret
     )
 import Agent.CLI.Environment (lookupNonEmpty)
+import Agent.CLI.PrivateFileLock (withPrivateFileLock)
 import Agent.Error (ApiError(..))
 import Agent.FileRetry (retryOnFileBusy)
 import qualified Agent.OpenAI.Auth as OpenAI
@@ -38,7 +39,6 @@ import Agent.Provider
     )
 import Control.Applicative ((<|>))
 import Control.Concurrent.MVar (MVar, newMVar, withMVar)
-import Control.Exception.Safe (bracket, bracket_)
 import Control.Monad (when)
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Except (ExceptT, throwE)
@@ -59,24 +59,10 @@ import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
 import Data.Time.Clock (UTCTime, getCurrentTime)
 import System.Directory.OsPath
-    ( createDirectoryIfMissing
-    , doesFileExist
+    ( doesFileExist
     , getHomeDirectory
     )
-import System.IO (SeekMode(AbsoluteSeek))
-import System.OsPath (OsPath, takeDirectory, unsafeEncodeUtf, (</>))
-import System.Posix.Files (setFileMode)
-import System.Posix.IO
-    ( LockRequest(Unlock, WriteLock)
-    , OpenFileFlags(..)
-    , OpenMode(ReadWrite)
-    , closeFd
-    , defaultFileFlags
-    , openFd
-    , setLock
-    , waitToSetLock
-    )
-import System.Posix.Types (Fd)
+import System.OsPath (OsPath, unsafeEncodeUtf, (</>))
 
 -- | Pin normal checkouts to one OpenAI pool account until that credential is
 -- reported as failed. A failure for the selected credential clears the pin
@@ -398,7 +384,7 @@ withOpenAiSourceLock :: OpenAiCredentialSource -> IO a -> IO a
 withOpenAiSourceLock source action =
     openAiSourceLockPath source >>= \case
         Nothing -> action
-        Just path -> withAdvisoryFileLock path action
+        Just path -> withPrivateFileLock path action
 
 openAiSourceLockPath :: OpenAiCredentialSource -> IO (Maybe OsPath)
 openAiSourceLockPath source =
@@ -429,30 +415,6 @@ safeLockName = Text.map replace
         | otherwise = '-'
     allowed =
         "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_"
-
-withAdvisoryFileLock :: OsPath -> IO a -> IO a
-withAdvisoryFileLock path action = do
-    createDirectoryIfMissing True (takeDirectory path)
-    setFileMode (unsafeToFilePath (takeDirectory path)) 0o700
-    bracket
-        (openRefreshLock path)
-        closeFd
-        (\fd -> bracket_ (lockRefreshFd fd) (unlockRefreshFd fd) action)
-
-openRefreshLock :: OsPath -> IO Fd
-openRefreshLock path =
-    openFd
-        (unsafeToFilePath path)
-        ReadWrite
-        defaultFileFlags { creat = Just 0o600, cloexec = True }
-
-lockRefreshFd :: Fd -> IO ()
-lockRefreshFd fd =
-    waitToSetLock fd (WriteLock, AbsoluteSeek, 0, 0)
-
-unlockRefreshFd :: Fd -> IO ()
-unlockRefreshFd fd =
-    setLock fd (Unlock, AbsoluteSeek, 0, 0)
 
 reloadOpenAiAccount
     :: OpenAiCredentialSource

--- a/packages/agent-cli/src/Agent/CLI/CredentialStore.hs
+++ b/packages/agent-cli/src/Agent/CLI/CredentialStore.hs
@@ -16,6 +16,7 @@ module Agent.CLI.CredentialStore
     ) where
 
 import Agent.CLI.Error (formatException)
+import Agent.CLI.PrivateFileLock (withPrivateFileLock)
 import Agent.FileRetry (retryOnFileBusy, writeLazyFileAtomically)
 import Agent.OsPath (toText, unsafeToFilePath)
 import Agent.Provider
@@ -25,7 +26,7 @@ import Agent.Provider
     , providerSlug
     )
 import Control.Concurrent.MVar (MVar, newMVar, withMVar)
-import Control.Exception.Safe (bracket, bracket_, tryIO)
+import Control.Exception.Safe (tryIO)
 import qualified Data.Aeson as Aeson
 import Data.Aeson ((.:), (.:?), (.=))
 import qualified Data.ByteString.Lazy as LBS
@@ -39,18 +40,7 @@ import System.Directory.OsPath
     , getHomeDirectory
     )
 import System.OsPath (OsPath, takeDirectory, unsafeEncodeUtf, (</>))
-import System.IO (SeekMode(AbsoluteSeek))
 import System.Posix.Files (setFileMode)
-import System.Posix.IO
-    ( LockRequest(Unlock, WriteLock)
-    , OpenFileFlags(..)
-    , OpenMode(ReadWrite)
-    , closeFd
-    , defaultFileFlags
-    , openFd
-    , setLock
-    , waitToSetLock
-    )
 import System.IO.Unsafe (unsafePerformIO)
 
 data ManagedAuthKind
@@ -192,8 +182,7 @@ managedSecretsPath home =
         </> unsafeEncodeUtf "credentials"
         </> unsafeEncodeUtf "secrets.json"
 
--- | Serialize OAuth rotation across threads and harness processes. POSIX
--- record locks are released automatically if a process exits.
+-- | Serialize OAuth rotation across threads and harness processes.
 withCredentialRefreshFileLock :: IO value -> IO value
 withCredentialRefreshFileLock action =
     withMVar credentialRefreshThreadLock
@@ -202,22 +191,10 @@ withCredentialRefreshFileLock action =
 withCredentialRefreshFileLockUnlocked :: IO value -> IO value
 withCredentialRefreshFileLockUnlocked action = do
     home <- getHomeDirectory
-    let directory = takeDirectory (managedSecretsPath home)
-        lockPath = directory </> unsafeEncodeUtf "refresh.lock"
-    createDirectoryIfMissing True directory
-    setFileMode (unsafeToFilePath directory) 0o700
-    bracket
-        (openFd (unsafeToFilePath lockPath) ReadWrite lockFlags)
-        closeFd
-        \fd -> do
-            setFileMode (unsafeToFilePath lockPath) 0o600
-            waitToSetLock fd (WriteLock, AbsoluteSeek, 0, 0)
-            action
-  where
-    lockFlags = defaultFileFlags
-        { creat = Just 0o600
-        , cloexec = True
-        }
+    let lockPath =
+            takeDirectory (managedSecretsPath home)
+                </> unsafeEncodeUtf "refresh.lock"
+    withPrivateFileLock lockPath action
 
 credentialRefreshThreadLock :: MVar ()
 credentialRefreshThreadLock = unsafePerformIO (newMVar ())
@@ -389,25 +366,8 @@ withCredentialStoreLock home action =
         withCredentialStoreFileLock home action
 
 withCredentialStoreFileLock :: OsPath -> IO a -> IO a
-withCredentialStoreFileLock home action = do
-    let path = managedCredentialsLockPath home
-        directoryPath = takeDirectory path
-        lock = (WriteLock, AbsoluteSeek, 0, 0)
-        unlock = (Unlock, AbsoluteSeek, 0, 0)
-        flags = defaultFileFlags
-            { creat = Just 0o600
-            , cloexec = True
-            }
-    createDirectoryIfMissing True directoryPath
-    setFileMode (unsafeToFilePath directoryPath) 0o700
-    bracket
-        (openFd (unsafeToFilePath path) ReadWrite flags)
-        closeFd
-        (\fd ->
-            bracket_
-                (waitToSetLock fd lock)
-                (setLock fd unlock)
-                action)
+withCredentialStoreFileLock home =
+    withPrivateFileLock (managedCredentialsLockPath home)
 
 credentialStoreProcessLock :: MVar ()
 credentialStoreProcessLock = unsafePerformIO (newMVar ())

--- a/packages/agent-cli/src/Agent/CLI/PrivateFileLock.hs
+++ b/packages/agent-cli/src/Agent/CLI/PrivateFileLock.hs
@@ -1,0 +1,41 @@
+-- | Blocking cross-process locks for private harness state.
+module Agent.CLI.PrivateFileLock
+    ( withPrivateFileLock
+    ) where
+
+import Agent.OsPath (unsafeToFilePath)
+import Control.Exception.Safe (bracket)
+import qualified System.FileLock as FileLock
+import System.Directory.OsPath (createDirectoryIfMissing)
+import System.OsPath (OsPath, takeDirectory)
+import System.Posix.Files (setFileMode)
+import System.Posix.IO
+    ( OpenFileFlags(..)
+    , OpenMode(ReadWrite)
+    , closeFd
+    , defaultFileFlags
+    , openFd
+    )
+
+-- | Run an action while holding an exclusive lock on a private lock file.
+--
+-- Lock files are permanent coordination points. Their parent directories and
+-- contents remain accessible only to the owning user, and the operating system
+-- releases the lock if the process exits.
+withPrivateFileLock :: OsPath -> IO a -> IO a
+withPrivateFileLock path action = do
+    let directory = takeDirectory path
+        filePath = unsafeToFilePath path
+    createDirectoryIfMissing True directory
+    setFileMode (unsafeToFilePath directory) 0o700
+    -- 'filelock' creates a missing file with ordinary open permissions.
+    -- Pre-create it with its private mode so there is no wider-permission
+    -- window before the chmod below.
+    bracket
+        (openFd filePath ReadWrite
+            defaultFileFlags { creat = Just 0o600, cloexec = True })
+        closeFd
+        (const (setFileMode filePath 0o600))
+    FileLock.withFileLock filePath FileLock.Exclusive \_ -> do
+        setFileMode filePath 0o600
+        action

--- a/packages/agent-cli/test/Agent/CLI/CredentialStoreSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CredentialStoreSpec.hs
@@ -2,15 +2,25 @@ module Agent.CLI.CredentialStoreSpec (spec) where
 
 import Agent.CLI.CredentialStore
 import Agent.Provider (BillingMode(..), Provider(..))
-import Control.Exception.Safe (bracket)
+import Control.Concurrent (threadDelay)
+import Control.Concurrent.Async (withAsync, wait)
+import Control.Exception.Safe (SomeException, bracket, try)
+import Control.Monad (void)
 import qualified Data.Aeson as Aeson
 import Data.Aeson ((.:), (.=))
 import qualified Data.ByteString.Lazy.Char8 as LBS
 import Data.Bits ((.&.))
 import Data.List (isInfixOf)
-import System.OsPath (OsPath, decodeUtf, unsafeEncodeUtf)
+import System.OsPath
+    ( OsPath
+    , decodeUtf
+    , takeDirectory
+    , unsafeEncodeUtf
+    , (</>)
+    )
 import System.Directory
     ( createDirectory
+    , doesFileExist
     , getTemporaryDirectory
     , removeFile
     , removePathForcibly
@@ -18,6 +28,8 @@ import System.Directory
 import System.Environment (lookupEnv, setEnv, unsetEnv)
 import System.IO (hClose, openTempFile)
 import System.Posix.Files (fileMode, getFileStatus)
+import System.Posix.Process (forkProcess, getProcessStatus)
+import System.Posix.Signals (sigKILL, signalProcess)
 import Test.Hspec
 
 fromFilePath = unsafeEncodeUtf
@@ -39,10 +51,49 @@ spec =
         it "writes private directories and files" $
             withTempHome \home -> do
                 upsertManagedCredential account secret `shouldReturn` Right ()
+                withCredentialRefreshFileLock (pure ())
+                let directory = takeDirectory (managedCredentialsPath home)
+                    storeLock = directory </> fromFilePath "store.lock"
+                    refreshLock = directory </> fromFilePath "refresh.lock"
+                directoryStatus <- getFileStatus (toFilePath directory)
                 metadataStatus <- getFileStatus (toFilePath (managedCredentialsPath home))
                 secretStatus <- getFileStatus (toFilePath (managedSecretsPath home))
+                storeLockStatus <- getFileStatus (toFilePath storeLock)
+                refreshLockStatus <- getFileStatus (toFilePath refreshLock)
+                fileMode directoryStatus .&. 0o777 `shouldBe` 0o700
                 fileMode metadataStatus .&. 0o777 `shouldBe` 0o600
                 fileMode secretStatus .&. 0o777 `shouldBe` 0o600
+                fileMode storeLockStatus .&. 0o777 `shouldBe` 0o600
+                fileMode refreshLockStatus .&. 0o777 `shouldBe` 0o600
+
+        it "serializes refreshes across processes" $
+            withTempHome \home -> do
+                let directory = takeDirectory (managedCredentialsPath home)
+                    locked = toFilePath (directory </> fromFilePath "child-locked")
+                    release = toFilePath (directory </> fromFilePath "release-child")
+                    acquired = toFilePath (directory </> fromFilePath "parent-acquired")
+                bracket
+                    (forkProcess $
+                        withCredentialRefreshFileLock do
+                            writeFile locked ""
+                            waitForFile release)
+                    (\pid -> do
+                        writeFile release ""
+                        void $ try @_ @SomeException (signalProcess sigKILL pid)
+                        void $ try @_ @SomeException
+                            (getProcessStatus False False pid))
+                    \pid -> do
+                        waitForFile locked
+                        withAsync
+                            (withCredentialRefreshFileLock
+                                (writeFile acquired ""))
+                            \waiting -> do
+                                threadDelay 100000
+                                doesFileExist acquired `shouldReturn` False
+                                writeFile release ""
+                                _ <- getProcessStatus True False pid
+                                wait waiting
+                                doesFileExist acquired `shouldReturn` True
 
         it "enables, disables, and deletes a managed credential" $
             withTempHome \_ -> do
@@ -222,3 +273,14 @@ withTempHome action =
         removeFile path
         createDirectory path
         pure path
+
+waitForFile :: FilePath -> IO ()
+waitForFile path = go (100 :: Int)
+  where
+    go remaining
+        | remaining <= 0 =
+            expectationFailure ("timed out waiting for " <> path)
+        | otherwise =
+            doesFileExist path >>= \case
+                True -> pure ()
+                False -> threadDelay 10000 >> go (remaining - 1)


### PR DESCRIPTION
## Summary
- centralize credential/auth lock acquisition through a shared System.FileLock helper
- preserve private directory/file modes and exception-safe release
- add focused lock coverage

## Validation
- nix develop -c cabal test agent-cli:test:agent-cli-test --offline --test-show-details=direct --test-options="--match /managed credential store/"
- 8 examples, 0 failures
- git diff --check