### PR TITLE
Share file URI encoding across CLI integrations

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -92,6 +92,7 @@ library
                     , Agent.CLI.Dialects
                     , Agent.CLI.Environment
                     , Agent.CLI.Error
+                    , Agent.CLI.FileUri
                     , Agent.CLI.ImagePreview
                     , Agent.CLI.GatewayBridge
                     , Agent.CLI.Input
@@ -300,6 +301,7 @@ test-suite agent-cli-test
                     , Agent.CLI.DialectsSpec
                     , Agent.CLI.DatabaseSpec
                     , Agent.CLI.ErrorSpec
+                    , Agent.CLI.FileUriSpec
                     , Agent.CLI.GatewayBridgeSpec
                     , Agent.CLI.ImagePreviewSpec
                     , Agent.CLI.InputSpec

--- a/packages/agent-cli/src/Agent/CLI/FileUri.hs
+++ b/packages/agent-cli/src/Agent/CLI/FileUri.hs
@@ -1,0 +1,36 @@
+-- | File URI encoding shared by terminal and language-server integrations.
+module Agent.CLI.FileUri
+    ( fileUri
+    , fileUriPath
+    ) where
+
+import Control.Monad (guard)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Network.URI
+    ( escapeURIString
+    , isUnreserved
+    , parseURI
+    , unEscapeString
+    , uriPath
+    , uriScheme
+    )
+
+-- | Encode a filesystem path as a file URI.
+--
+-- Slashes and URI-unreserved characters stay readable. Colons are also valid
+-- within URI path segments and are kept for compatibility with terminal OSC 7
+-- working-directory reports.
+fileUri :: FilePath -> Text
+fileUri path =
+    Text.pack ("file://" <> escapeURIString uriPathCharacter path)
+  where
+    uriPathCharacter character =
+        character == '/' || character == ':' || isUnreserved character
+
+-- | Decode the path component of a file URI.
+fileUriPath :: Text -> Maybe FilePath
+fileUriPath raw = do
+    uri <- parseURI (Text.unpack raw)
+    guard (uriScheme uri == "file:")
+    pure (unEscapeString (uriPath uri))

--- a/packages/agent-cli/src/Agent/CLI/Lsp.hs
+++ b/packages/agent-cli/src/Agent/CLI/Lsp.hs
@@ -13,6 +13,10 @@ import Agent.CLI.Config
     ( LspConfig(..)
     , LspServerConfig(..)
     )
+import Agent.CLI.FileUri
+    ( fileUri
+    , fileUriPath
+    )
 import Agent.GrokBuild.Dialect.Lsp
     ( LspOperation(..)
     , LspRequest(..)
@@ -105,14 +109,6 @@ import System.Process
     )
 import System.Timeout (timeout)
 import System.Posix.Types (ProcessID)
-import Network.URI
-    ( escapeURIString
-    , isUnreserved
-    , parseURI
-    , unEscapeString
-    , uriPath
-    , uriScheme
-    )
 
 data LspStartup = LspStartup
     { lspStartupRuntime :: !(Maybe LspRuntime)
@@ -1175,21 +1171,6 @@ pathWithin root candidate =
                     `isPrefixOfString` relative
                 ))
 
-fileUri :: FilePath -> Text
-fileUri path =
-    Text.pack
-        ("file://" <> escapeURIString uriPathCharacter path)
-  where
-    uriPathCharacter character =
-        character == '/' || isUnreserved character
-
-uriFilePath :: Text -> Maybe FilePath
-uriFilePath raw = do
-    uri <- parseURI (Text.unpack raw)
-    if uriScheme uri /= "file:"
-        then Nothing
-        else Just (unEscapeString (uriPath uri))
-
 formatLspResult :: LspOperation -> Aeson.Value -> Text
 formatLspResult operation value =
     case operation of
@@ -1227,7 +1208,7 @@ locationFromObject object = do
                 <|> KeyMap.lookup "targetRange" object
         (line, character) =
             fromMaybe (0, 0) (range >>= startPosition)
-        path = maybe uri Text.pack (uriFilePath uri)
+        path = maybe uri Text.pack (fileUriPath uri)
     pure $
         path
             <> ":"

--- a/packages/agent-cli/src/Agent/CLI/Terminal.hs
+++ b/packages/agent-cli/src/Agent/CLI/Terminal.hs
@@ -31,16 +31,15 @@ module Agent.CLI.Terminal
     , withSynchronizedOutput
     ) where
 
+import Agent.CLI.FileUri (fileUri)
 import Control.Exception.Safe (bracket_)
-import qualified Data.ByteString as BS
 import qualified Data.ByteString.Base64 as Base64
-import Data.Char (isAlphaNum, isAscii, toLower)
+import Data.Char (toLower)
 import Data.Maybe (fromMaybe, isJust)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
 import qualified Data.Text.IO as Text
-import Numeric (showHex)
 import System.Environment (lookupEnv)
 import System.IO (Handle, hFlush, hIsTerminalDevice)
 import System.Posix.Terminal
@@ -176,9 +175,6 @@ osc7WorkingDirectory :: FilePath -> Text
 osc7WorkingDirectory path =
     "\ESC]7;" <> fileUri path <> "\ESC\\"
 
-fileUri :: FilePath -> Text
-fileUri path = "file://" <> percentEncodePath (Text.pack path)
-
 osc9Notification :: Text -> Text
 osc9Notification title =
     "\ESC]9;" <> sanitizeOsc title <> "\ESC\\"
@@ -289,21 +285,3 @@ sanitizeOsc =
     Text.filter (\char -> char /= '\ESC' && char /= '\BEL')
         . Text.replace "\n" " "
         . Text.replace "\r" " "
-
-percentEncodePath :: Text -> Text
-percentEncodePath = Text.concatMap encodeChar
-  where
-    encodeChar char
-        | (isAscii char && isAlphaNum char)
-            || char `elem` ("/-._~:" :: String) = Text.singleton char
-        | otherwise =
-            Text.concat
-                [ "%" <> hexByte byte
-                | byte <- BS.unpack (TextEncoding.encodeUtf8 (Text.singleton char))
-                ]
-    hexByte byte =
-        let raw = map upperHex (showHex byte "")
-        in Text.pack (if length raw == 1 then '0' : raw else raw)
-    upperHex c
-        | c >= 'a' && c <= 'f' = toEnum (fromEnum c - 32)
-        | otherwise = c

--- a/packages/agent-cli/test/Agent/CLI/FileUriSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/FileUriSpec.hs
@@ -1,0 +1,24 @@
+module Agent.CLI.FileUriSpec (spec) where
+
+import Agent.CLI.FileUri
+import Test.Hspec
+
+spec :: Spec
+spec =
+    describe "file URI codec" do
+        it "percent-encodes reserved and non-ASCII path bytes" do
+            fileUri "/tmp/a b#?%/é:cache"
+                `shouldBe` "file:///tmp/a%20b%23%3F%25/%C3%A9:cache"
+
+        it "round-trips representative absolute paths" do
+            mapM_
+                (\path -> fileUriPath (fileUri path) `shouldBe` Just path)
+                [ "/tmp/plain"
+                , "/tmp/a b"
+                , "/tmp/hash#query?percent%"
+                , "/tmp/café/日本語"
+                , "/tmp/cache:key"
+                ]
+
+        it "rejects non-file URI schemes" do
+            fileUriPath "https://example.com/file" `shouldBe` Nothing

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -20,6 +20,7 @@ import qualified Agent.CLI.DialectsSpec as DialectsSpec
 import qualified Agent.CLI.DatabaseSpec as DatabaseSpec
 import qualified Agent.CLI.EnvironmentSpec as EnvironmentSpec
 import qualified Agent.CLI.ErrorSpec as ErrorSpec
+import qualified Agent.CLI.FileUriSpec as FileUriSpec
 import qualified Agent.CLI.GatewayBridgeSpec as GatewayBridgeSpec
 import qualified Agent.CLI.ImagePreviewSpec as ImagePreviewSpec
 import qualified Agent.CLI.InputSpec as InputSpec
@@ -91,6 +92,7 @@ main = hspec do
     DatabaseSpec.spec
     EnvironmentSpec.spec
     ErrorSpec.spec
+    FileUriSpec.spec
     GatewayBridgeSpec.spec
     ImagePreviewSpec.spec
     InputSpec.spec


### PR DESCRIPTION
## Summary
- add one shared `Network.URI`-based file URI codec for terminal OSC 7 and LSP
- preserve UTF-8 percent encoding, colon compatibility, validation, and decoding
- add reserved-character, Unicode, and round-trip tests

## Validation
- file URI tests: 3/3 passed
- terminal protocol tests: 7/7 passed
- Web/LSP tests: 9/9 passed
- required tmux GHCi/CLI smoke check passed
- `git diff --check`

The full CLI suite reached 883 examples; 26 PostgreSQL integration cases were blocked only by Darwin Unix-socket path length under the long session temporary directory.