### PR TITLE
feat(tui): show a live todo panel above the prompt

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Render.hs
+++ b/packages/agent-cli/src/Agent/CLI/Render.hs
@@ -73,7 +73,6 @@ import Agent.CLI.Style
     , roleWarn
     , terminalGreen
     , terminalRed
-    , terminalYellow
     , motionGlyphSet
     , style
     )
@@ -82,14 +81,9 @@ import Agent.TUI.Presentation
     ( SearchReplaceAction(..)
     , SearchReplaceDiff(..)
     , SearchReplaceLine(..)
-    , TodoDisplayLine(..)
-    , TodoDisplayStatus(..)
     , formatToolOutput
     , parseSearchReplaceDiff
-    , parseTodoList
     , summarizeToolCall
-    , todoCallPreview
-    , todoStatusGlyph
     , toolDetail
     )
 import Agent.ToolDispatch
@@ -536,10 +530,11 @@ renderEventUnlocked config = \case
         commitThinkingUnlocked config
         modifyIORef' config.renderToolCalls (Map.insert call.callId call)
         writeIORef config.renderActivityRef (summarizeToolCall call)
-        putTextLn config.renderStderr (formatToolStarted config.renderColor call)
-        let extra = formatToolBody config.renderColor call
-        unless (Text.null extra) do
-            putTextLn config.renderStderr extra
+        unless (isTodoTool call.name) do
+            putTextLn config.renderStderr (formatToolStarted config.renderColor call)
+            let extra = formatToolBody config.renderColor call
+            unless (Text.null extra) do
+                putTextLn config.renderStderr extra
         when config.renderShowThinking do
             visible <- readIORef config.renderThinkingVisible
             if visible
@@ -559,11 +554,15 @@ renderEventUnlocked config = \case
                 maybeCall
             painted = case maybeCall of
                 Just call
-                    | canonicalToolName call.name `elem` ["todo_write", "update_plan"] ->
-                        formatTodoOutput config.renderColor formatted
+                    | isTodoTool call.name -> Nothing
                 _ ->
-                    roleToolOutput config.renderColor (truncateToolOutput formatted)
-        putTextLn config.renderStderr painted
+                    Just
+                        (roleToolOutput
+                            config.renderColor
+                            (truncateToolOutput formatted))
+        case painted of
+            Nothing -> pure ()
+            Just line -> putTextLn config.renderStderr line
 
 -- | Style assistant markdown when color is enabled; otherwise return plain text.
 -- The terminal theme owns the default assistant background.
@@ -960,47 +959,14 @@ toolChrome name = case canonicalToolName name of
     "skill_rollback" -> ToolChrome "Restored skill" ToolDetailMuted
     _ -> ToolChrome name ToolDetailMuted
 
+isTodoTool :: Text -> Bool
+isTodoTool name =
+    canonicalToolName name `elem` ["todo_write", "update_plan"]
+
 formatToolBody :: Bool -> ToolCall -> Text
 formatToolBody color call = case canonicalToolName call.name of
     "search_replace" -> formatSearchReplaceDiff color call.arguments
-    "todo_write" -> formatTodoPreview color call
-    "update_plan" -> formatTodoPreview color call
     _ -> ""
-
-formatTodoPreview :: Bool -> ToolCall -> Text
-formatTodoPreview color call =
-    let preview = todoCallPreview call
-    in if Text.null preview
-        then ""
-        else paintTodoLine color (TodoDisplayLine TodoDisplayPending preview)
-
-formatTodoOutput :: Bool -> Text -> Text
-formatTodoOutput color output =
-    let parsed = parseTodoList output
-        shown = take 3 parsed
-        hidden = length parsed - length shown
-        rows = map (paintTodoLine color) shown
-        overflow
-            | hidden > 0 =
-                [ glyphToolAccent
-                    <> glyphToolOut
-                    <> roleMuted color
-                        ("… +" <> Text.pack (show hidden) <> " lines")
-                ]
-            | otherwise = []
-    in Text.intercalate "\n" (rows <> overflow)
-
-paintTodoLine :: Bool -> TodoDisplayLine -> Text
-paintTodoLine color line =
-    let glyph = todoStatusGlyph line.todoLineStatus
-        body = glyph <> " " <> line.todoLineText
-        painted = case line.todoLineStatus of
-            TodoDisplayPending -> roleMuted color body
-            TodoDisplayInProgress ->
-                style color [terminalYellow] body
-            TodoDisplayCompleted -> roleSuccess color body
-            TodoDisplayCancelled -> roleMuted color body
-    in glyphToolAccent <> glyphToolOut <> painted
 
 -- | Compact unified-diff preview for @search_replace@ arguments.
 formatSearchReplaceDiff :: Bool -> Text -> Text

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -184,6 +184,7 @@ import Agent.TUI.Motion
 import Agent.TUI.Presentation
     ( TodoDisplayLine(..)
     , TodoDisplayStatus(..)
+    , liveTodoPanelLines
     , parseTodoList
     , permissionToolCallPrompt
     , todoStatusGlyph
@@ -1703,6 +1704,7 @@ drawMain state =
                 , Composer.drawQueuedInputs state.appUi
                 , Composer.drawSlashMenu state
                 , drawFollowStatus state.appUi
+                , drawLiveTodos state.appUi
                 , drawPromptActivity state
                 , Composer.drawComposer state
                 , drawFooter state
@@ -2283,6 +2285,28 @@ drawHeaderRight :: AppState -> Widget Name
 drawHeaderRight state =
     withAttr Theme.mutedAttr $
         txt (formatTokenUsage state.appUi.uiPrompt.promptUsage)
+
+drawLiveTodos :: UiState -> Widget Name
+drawLiveTodos ui =
+    case liveTodoPanelLines 8 (visibleTodoList ui) of
+        [] -> emptyWidget
+        lines_ ->
+            padLeftRight 2 $
+                vBox (map drawLiveTodoLine lines_)
+
+drawLiveTodoLine :: Text -> Widget Name
+drawLiveTodoLine line
+    | "… +" `Text.isPrefixOf` line =
+        withAttr Theme.mutedAttr (txt line)
+    | otherwise =
+        withAttr (todoStatusAttr (todoLineStatusFromText line)) (txtWrap line)
+
+todoLineStatusFromText :: Text -> TodoDisplayStatus
+todoLineStatusFromText line
+    | "▶" `Text.isPrefixOf` line = TodoDisplayInProgress
+    | "✓" `Text.isPrefixOf` line = TodoDisplayCompleted
+    | "✗" `Text.isPrefixOf` line = TodoDisplayCancelled
+    | otherwise = TodoDisplayPending
 
 drawPromptActivity :: AppState -> Widget Name
 drawPromptActivity state =

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -2292,14 +2292,14 @@ drawLiveTodos ui =
         [] -> emptyWidget
         lines_ ->
             padLeftRight 2 $
-                vBox (map drawLiveTodoLine lines_)
+                vBox (map (vLimit 1 . drawLiveTodoLine) lines_)
 
 drawLiveTodoLine :: Text -> Widget Name
 drawLiveTodoLine line
     | "… +" `Text.isPrefixOf` line =
         withAttr Theme.mutedAttr (txt line)
     | otherwise =
-        withAttr (todoStatusAttr (todoLineStatusFromText line)) (txtWrap line)
+        withAttr (todoStatusAttr (todoLineStatusFromText line)) (txt line)
 
 todoLineStatusFromText :: Text -> TodoDisplayStatus
 todoLineStatusFromText line

--- a/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
@@ -185,14 +185,14 @@ spec = do
                 `shouldSatisfy` Text.isInfixOf "delete src/Old.hs"
 
     describe "formatToolBody" do
-        it "previews the first todo_write item while the call is running" do
+        it "does not dump todo_write arguments into linear chrome" do
             formatToolBody False
                 (functionToolCall
                     "c1"
                     "todo_write"
                     "{\"todos\":[{\"id\":\"1\",\"content\":\"Find and clone repos\"},\
                     \{\"id\":\"2\",\"content\":\"Investigate Codex\"}]}")
-                `shouldBe` "❙ ┊ □ Find and clone repos"
+                `shouldBe` ""
 
     describe "formatLoopError" do
         it "explains a max-turn stop" do
@@ -589,7 +589,7 @@ spec = do
                 body `shouldSatisfy` Text.isInfixOf "\ESC["
                 body `shouldSatisfy` Text.isInfixOf "ok"
 
-        it "renders completed todo_write checklists with truncation" do
+        it "suppresses todo_write from linear scrollback" do
             withRenderConfig False False \config handle path -> do
                 let call =
                         functionToolCall
@@ -601,16 +601,13 @@ spec = do
                     { callId = "c1"
                     , output =
                         "- [completed] 1: Find and clone Grok Build and Codex repos\n\
-                        \- [completed] 2: Investigate how Grok Build summarizes completed sessions in TUI\n\
-                        \- [completed] 3: Investigate how Codex summarizes completed sessions in TUI\n\
-                        \- [pending] 4: Implement matching chrome"
+                        \- [pending] 2: Investigate Codex"
                     , callKind = FunctionCallKind
                     })
                 hClose handle
                 body <- Text.readFile path
-                body `shouldSatisfy` Text.isInfixOf "◆ todo_write"
-                body `shouldSatisfy` Text.isInfixOf "✓ Find and clone Grok Build and Codex repos"
-                body `shouldSatisfy` Text.isInfixOf "… +1 lines"
+                body `shouldNotSatisfy` Text.isInfixOf "todo_write"
+                body `shouldNotSatisfy` Text.isInfixOf "Find and clone"
                 body `shouldNotSatisfy` Text.isInfixOf "[completed]"
 
         it "keeps thinking plain when color is off" do

--- a/packages/agent-cli/test/Agent/CLI/TUIPropertySpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIPropertySpec.hs
@@ -38,6 +38,7 @@ import Agent.TUI.Model
     , UiState(..)
     , initialUiState
     , reduceUi
+    , visibleTodoList
     , timestampNewMessageBlocks
     , warningNotice
     )
@@ -224,6 +225,48 @@ spec = do
             rendered `shouldSatisfy`
                 Text.isInfixOf "Inspect AppState before continuing."
             rendered `shouldNotSatisfy` Text.isInfixOf "`AppState`"
+
+        it "keeps live todos to one row each so the prompt stays visible" do
+            let todoCall =
+                    functionToolCall
+                        "todo-1"
+                        "todo_write"
+                        "{\"todos\":[{\"id\":\"1\",\"content\":\"Keep this list\"}]}"
+                longItem =
+                    "Investigate a very long remaining task that would wrap \
+                    \across many columns if the panel used wrapping text"
+                todoResult = ToolCallResult
+                    { callId = "todo-1"
+                    , output =
+                        "- [completed] 1: Find and clone repos\n\
+                        \- [in_progress] 2: "
+                            <> longItem
+                    , callKind = FunctionCallKind
+                    }
+                ui =
+                    reduceUi
+                        (UiLoop (ToolFinished todoResult))
+                        (reduceUi
+                            (UiLoop (ToolStarted todoCall))
+                            (reduceUi (UiLoop TurnStarted) baseState.appUi))
+                app = baseState { appUi = ui }
+                size = (40, 16)
+                rows =
+                    pictureRows
+                        (renderWidget
+                            (Just Theme.monochrome)
+                            (drawApp app)
+                            size)
+                        size
+                rendered = Text.unlines rows
+            length (filter (Text.isInfixOf "Find and clone repos") rows)
+                `shouldBe` 1
+            length (filter (Text.isInfixOf "Investigate a very long") rows)
+                `shouldBe` 1
+            rendered `shouldSatisfy` Text.isInfixOf "Thinking"
+            rendered `shouldSatisfy` Text.isInfixOf "Type a follow-up"
+            visibleTodoList ui
+                `shouldSatisfy` (not . null)
 
         it "renders a selected child with the retained conversation renderer" do
             let target = AgentChild (SubagentId "renderer")

--- a/packages/agent-tui/src/Agent/TUI/Model.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model.hs
@@ -29,6 +29,7 @@ module Agent.TUI.Model
     , timestampNewMessageBlocks
     , progressNotice
     , successNotice
+    , visibleTodoList
     , uiNextDeadlineMillis
     , uiNeedsTick
     , warningNotice
@@ -36,9 +37,11 @@ module Agent.TUI.Model
     ) where
 
 import Agent.TUI.Presentation
-    ( formatSearchReplaceDiff
+    ( TodoDisplayLine
+    , formatSearchReplaceDiff
     , formatToolOutput
-    , todoCallPreview
+    , todoListFromToolOutput
+    , todoListHasOpenWork
     , toolCallInput
     , toolCallTitle
     )
@@ -65,6 +68,7 @@ import qualified Data.Sequence as Seq
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Char (isSpace)
+import Data.Maybe (fromMaybe)
 
 newtype BlockId = BlockId Int
     deriving (Eq, Ord, Show)
@@ -184,6 +188,7 @@ data UiState = UiState
     , uiTurnStartBlock :: !Int
     , uiAttemptStartBlock :: !Int
     , uiToolCalls :: !(Map.Map Text (Int, ToolCall))
+    , uiTodos :: ![TodoDisplayLine]
     }
     deriving (Eq, Show)
 
@@ -260,7 +265,15 @@ initialUiState = UiState
     , uiTurnStartBlock = 0
     , uiAttemptStartBlock = 0
     , uiToolCalls = Map.empty
+    , uiTodos = []
     }
+
+-- | Checklist shown above the prompt. Hidden once every item is done so a
+-- finished list does not linger into the next turn.
+visibleTodoList :: UiState -> [TodoDisplayLine]
+visibleTodoList state
+    | todoListHasOpenWork state.uiTodos = state.uiTodos
+    | otherwise = []
 
 -- | Status-only blocks can appear before the first user turn, but the
 -- conversation is still empty from the user's perspective.
@@ -442,6 +455,7 @@ reduceUi event state = case event of
             , uiAttemptStartBlock = 0
             , uiToolCalls = Map.empty
             , uiRetryCountdown = Nothing
+            , uiTodos = []
             }
     UiSetFollow follow ->
         state
@@ -667,30 +681,35 @@ reduceLoop event state = case event of
             , uiNoticeElapsedMillis = 0
             , uiAttemptStartBlock = Seq.length finalized.uiBlocks
             }
-    ToolStarted call ->
-        let
-            kind = toolBlockKind call.name
-            title = toolCallTitle call
-            blockIndex = Seq.length state.uiBlocks
-            body = case canonicalToolName call.name of
-                "search_replace" ->
-                    formatSearchReplaceDiff call.arguments
-                "todo_write" -> todoCallPreview call
-                "update_plan" -> todoCallPreview call
-                _ -> ""
-            detail = toolCallInput call
-        in appendBlock kind title body detail
-            BlockRunning (Just call.callId)
+    ToolStarted call
+        | isTodoTool call.name ->
             state
                 { uiRunning = True
                 , uiAwaitingInput = False
-                , uiActivity = title
-                , uiToolCalls =
-                    Map.insert
-                        call.callId
-                        (blockIndex, call)
-                        state.uiToolCalls
+                , uiActivity = toolCallTitle call
                 }
+        | otherwise ->
+            let
+                kind = toolBlockKind call.name
+                title = toolCallTitle call
+                blockIndex = Seq.length state.uiBlocks
+                body = case canonicalToolName call.name of
+                    "search_replace" ->
+                        formatSearchReplaceDiff call.arguments
+                    _ -> ""
+                detail = toolCallInput call
+            in appendBlock kind title body detail
+                BlockRunning (Just call.callId)
+                state
+                    { uiRunning = True
+                    , uiAwaitingInput = False
+                    , uiActivity = title
+                    , uiToolCalls =
+                        Map.insert
+                            call.callId
+                            (blockIndex, call)
+                            state.uiToolCalls
+                    }
     ToolOutputUpdated callId output ->
         updateToolOutput callId output state
     ToolFinished result ->
@@ -700,6 +719,7 @@ reduceLoop event state = case event of
                 Just (_, call) ->
                     result
                         { output = formatToolOutput call result.output }
+            todos = fromMaybe state.uiTodos (todoListFromToolOutput result.output)
             next =
                 state
                     { uiRunning = True
@@ -707,6 +727,7 @@ reduceLoop event state = case event of
                     , uiActivity = "Thinking…"
                     , uiToolCalls =
                         Map.delete result.callId state.uiToolCalls
+                    , uiTodos = todos
                     }
         in case activeCall of
             Nothing -> next
@@ -1103,6 +1124,10 @@ selectionAfterTruncate blocks selected =
         _ ->
             let index = Seq.length blocks - 1
             in (\block -> (index, block)) <$> Seq.lookup index blocks
+
+isTodoTool :: Text -> Bool
+isTodoTool name =
+    canonicalToolName name `elem` ["todo_write", "update_plan"]
 
 toolBlockKind :: Text -> BlockKind
 toolBlockKind rawName

--- a/packages/agent-tui/src/Agent/TUI/Model.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model.hs
@@ -687,6 +687,11 @@ reduceLoop event state = case event of
                 { uiRunning = True
                 , uiAwaitingInput = False
                 , uiActivity = toolCallTitle call
+                , uiToolCalls =
+                    Map.insert
+                        call.callId
+                        (Seq.length state.uiBlocks, call)
+                        state.uiToolCalls
                 }
         | otherwise ->
             let
@@ -719,7 +724,13 @@ reduceLoop event state = case event of
                 Just (_, call) ->
                     result
                         { output = formatToolOutput call result.output }
-            todos = fromMaybe state.uiTodos (todoListFromToolOutput result.output)
+            todos =
+                case activeCall of
+                    Just (_, call)
+                        | isTodoTool call.name ->
+                            fromMaybe state.uiTodos
+                                (todoListFromToolOutput result.output)
+                    _ -> state.uiTodos
             next =
                 state
                     { uiRunning = True
@@ -731,8 +742,10 @@ reduceLoop event state = case event of
                     }
         in case activeCall of
             Nothing -> next
-            Just (blockIndex, _) ->
-                completeTool blockIndex displayed next
+            Just (blockIndex, _)
+                | blockIndex < Seq.length state.uiBlocks ->
+                    completeTool blockIndex displayed next
+            Just _ -> next
     TurnFinished output ->
         let finalized = finalizeStreams state
             continuing = not (null output.toolCalls)

--- a/packages/agent-tui/src/Agent/TUI/Presentation.hs
+++ b/packages/agent-tui/src/Agent/TUI/Presentation.hs
@@ -8,11 +8,14 @@ module Agent.TUI.Presentation
     , formatSearchReplaceDiff
     , formatTodoList
     , formatToolOutput
+    , liveTodoPanelLines
     , parseSearchReplaceDiff
     , parseTodoList
     , permissionToolCallPrompt
+    , todoListFromToolOutput
     , summarizeToolCall
     , todoCallPreview
+    , todoListHasOpenWork
     , todoStatusGlyph
     , toolCallInput
     , toolCallTitle
@@ -188,6 +191,38 @@ todoCallPreview call = case canonicalToolName call.name of
 formatTodoList :: Text -> Text
 formatTodoList output =
     Text.intercalate "\n" (map formatTodoDisplayLine (parseTodoList output))
+
+liveTodoPanelLines :: Int -> [TodoDisplayLine] -> [Text]
+liveTodoPanelLines maxRows todos
+    | maxRows <= 0 || null todos = []
+    | length todos <= maxRows =
+        map formatTodoDisplayLine todos
+    | otherwise =
+        let shownCount = max 0 (maxRows - 1)
+            shown = take shownCount todos
+            hidden = length todos - length shown
+        in map formatTodoDisplayLine shown
+            <> ["… +" <> Text.pack (show hidden) <> " more"]
+
+todoListHasOpenWork :: [TodoDisplayLine] -> Bool
+todoListHasOpenWork =
+    any \line ->
+        line.todoLineStatus `elem` [TodoDisplayPending, TodoDisplayInProgress]
+
+-- | Replace the live list only when tool output is an actual checklist.
+-- Unrecognized output is ignored so ordinary tools cannot clobber it.
+todoListFromToolOutput :: Text -> Maybe [TodoDisplayLine]
+todoListFromToolOutput output =
+    let stripped = Text.strip output
+        rows =
+            [ Text.strip line
+            | line <- Text.lines stripped
+            , not (Text.null (Text.strip line))
+            ]
+        parsed = mapMaybe parseTodoDisplayLine rows
+    in if stripped == "No tasks currently tracked."
+        then Just []
+        else if null parsed then Nothing else Just parsed
 
 parseTodoList :: Text -> [TodoDisplayLine]
 parseTodoList output =

--- a/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
@@ -1,6 +1,10 @@
 module Agent.TUI.ModelSpec (spec) where
 
 import Agent.TUI.Model
+import Agent.TUI.Presentation
+    ( TodoDisplayLine(..)
+    , TodoDisplayStatus(..)
+    )
 import Agent.Loop
     ( LoopEvent(..)
     , emptyTurnOutput
@@ -675,7 +679,7 @@ spec = describe "fullscreen UI reducer" do
                 block.blockBody `shouldSatisfy` Text.isInfixOf "+new"
             _ -> expectationFailure "expected one running edit block"
 
-    it "renders todo_write as a checklist block" do
+    it "keeps todo_write in a live panel instead of scrollback" do
         let call =
                 functionToolCall
                     "todo-1"
@@ -689,33 +693,36 @@ spec = describe "fullscreen UI reducer" do
                 , callKind = FunctionCallKind
                 }
             started =
-                Foldable.toList $
-                    (.uiBlocks) $
-                        apply
-                            [ UiLoop TurnStarted
-                            , UiLoop (ToolStarted call)
-                            ]
+                apply
+                    [ UiLoop TurnStarted
+                    , UiLoop (ToolStarted call)
+                    ]
             finished =
-                Foldable.toList $
-                    (.uiBlocks) $
-                        apply
-                            [ UiLoop TurnStarted
-                            , UiLoop (ToolStarted call)
-                            , UiLoop (ToolFinished result)
-                            ]
-        case started of
-            [block] -> do
-                block.blockKind `shouldBe` BlockTodo
-                block.blockTitle `shouldBe` "todo_write"
-                block.blockBody `shouldBe` "Find and clone repos"
-            _ -> expectationFailure "expected one running todo block"
-        case finished of
-            [block] -> do
-                block.blockKind `shouldBe` BlockTodo
-                block.blockTitle `shouldBe` "todo_write"
-                block.blockBody
-                    `shouldBe` "✓ Find and clone repos\n▶ Investigate Grok Build"
-            _ -> expectationFailure "expected one completed todo block"
+                apply
+                    [ UiLoop TurnStarted
+                    , UiLoop (ToolStarted call)
+                    , UiLoop (ToolFinished result)
+                    ]
+            done =
+                apply
+                    [ UiLoop TurnStarted
+                    , UiLoop (ToolStarted call)
+                    , UiLoop (ToolFinished result
+                        { output = "- [completed] 1: Find and clone repos"
+                        })
+                    ]
+        Foldable.toList started.uiBlocks `shouldBe` []
+        started.uiActivity `shouldBe` "todo_write"
+        visibleTodoList started `shouldBe` []
+        Foldable.toList finished.uiBlocks `shouldBe` []
+        map (.todoLineText) (visibleTodoList finished)
+            `shouldBe` ["Find and clone repos", "Investigate Grok Build"]
+        map (.todoLineStatus) (visibleTodoList finished)
+            `shouldBe` [TodoDisplayCompleted, TodoDisplayInProgress]
+        Foldable.toList done.uiBlocks `shouldBe` []
+        visibleTodoList done `shouldBe` []
+        done.uiTodos
+            `shouldBe` [TodoDisplayLine TodoDisplayCompleted "Find and clone repos"]
 
     it "formats collaboration result JSON for display" do
         let call =

--- a/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
@@ -724,6 +724,37 @@ spec = describe "fullscreen UI reducer" do
         done.uiTodos
             `shouldBe` [TodoDisplayLine TodoDisplayCompleted "Find and clone repos"]
 
+    it "does not let ordinary tool output clobber the live todo list" do
+        let todoCall =
+                functionToolCall
+                    "todo-1"
+                    "todo_write"
+                    "{\"todos\":[{\"id\":\"1\",\"content\":\"Keep this list\"}]}"
+            todoResult = ToolCallResult
+                { callId = "todo-1"
+                , output = "- [in_progress] 1: Keep this list"
+                , callKind = FunctionCallKind
+                }
+            shellCall =
+                functionToolCall "shell-1" "run_terminal_cmd" "{\"command\":\"ls\"}"
+            shellResult = ToolCallResult
+                { callId = "shell-1"
+                , output = "- [pending] 99: spoofed checklist from stdout"
+                , callKind = FunctionCallKind
+                }
+            state =
+                apply
+                    [ UiLoop TurnStarted
+                    , UiLoop (ToolStarted todoCall)
+                    , UiLoop (ToolFinished todoResult)
+                    , UiLoop (ToolStarted shellCall)
+                    , UiLoop (ToolFinished shellResult)
+                    ]
+        map (.todoLineText) (visibleTodoList state)
+            `shouldBe` ["Keep this list"]
+        map (.blockKind) (Foldable.toList state.uiBlocks)
+            `shouldBe` [BlockShell]
+
     it "formats collaboration result JSON for display" do
         let call =
                 functionToolCall

--- a/packages/agent-tui/test/Agent/TUI/PresentationSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/PresentationSpec.hs
@@ -197,3 +197,21 @@ spec = describe "tool presentation" do
             `shouldBe`
                 "✓ Clone the repo\n\
                 \□ Open a PR"
+
+    it "keeps a live todo panel while work remains and truncates overflow" do
+        let todos =
+                [ TodoDisplayLine TodoDisplayCompleted "Find repos"
+                , TodoDisplayLine TodoDisplayInProgress "Investigate Grok"
+                , TodoDisplayLine TodoDisplayPending "Investigate Codex"
+                ]
+        todoListHasOpenWork todos `shouldBe` True
+        todoListHasOpenWork [TodoDisplayLine TodoDisplayCompleted "done"]
+            `shouldBe` False
+        liveTodoPanelLines 2 todos
+            `shouldBe`
+                [ "✓ Find repos"
+                , "… +2 more"
+                ]
+        todoListFromToolOutput "ok" `shouldBe` Nothing
+        todoListFromToolOutput "No tasks currently tracked."
+            `shouldBe` Just []


### PR DESCRIPTION
## Summary
- Keep `todo_write` and Codex `update_plan` out of conversation scrollback.
- Store the current checklist in UI state and render it above the prompt while any item is still pending or in progress.
- Auto-hide the panel once every item is completed or cancelled, and restore it from tool output when replaying history.

## Test plan
- [x] `cabal test agent-tui:test:agent-tui-test`
- [x] CLI `RenderSpec` examples matching `todo`
- [ ] Visual check of a live `todo_write` turn in fullscreen TUI