### PR TITLE
Support worktree isolation for collaboration subagents

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime.hs
@@ -1945,8 +1945,19 @@ runAgentInitializedWithLock
             atomicModifyIORef' pendingNotices \xs ->
                 (xs <> [AgentMessage message], ())
             pure (Right "queued")
+        createSubagentWorktree source =
+            createWorktree source (worktreeRoot home) >>= \case
+                Left err -> pure (Left err)
+                Right path -> pure $ Right SubagentWorktree
+                    { subagentWorktreePath = path
+                    , subagentWorktreeCleanup =
+                        removeWorktree source path >>= \case
+                            Left err -> pure (Left err)
+                            Right () -> pure (Right ())
+                    }
         multiCtx = Just MultiAgentContext
             { multiRegistry = registry
+            , multiCwd = cwd
             , multiSelfId = Nothing
             , multiDepth = 0
             , multiTaskPath = taskPathRoot
@@ -1963,16 +1974,7 @@ runAgentInitializedWithLock
                     registry
                     subagentSessions
                     agentTypesRef)
-            , multiCreateWorktree = Just \source ->
-                createWorktree source (worktreeRoot home) >>= \case
-                    Left err -> pure (Left err)
-                    Right path -> pure $ Right SubagentWorktree
-                        { subagentWorktreePath = path
-                        , subagentWorktreeCleanup =
-                            removeWorktree source path >>= \case
-                                Left err -> pure (Left err)
-                                Right () -> pure (Right ())
-                        }
+            , multiCreateWorktree = Just createSubagentWorktree
             , multiPrepareSpawn = Just
                 (prepareCollaborationSpawn
                     provider
@@ -2310,6 +2312,7 @@ runAgentInitializedWithLock
                 , subagentLegacyTarget = legacySubagentTarget
                 , subagentConnection = inferredTarget.targetConnectionId
                 , subagentMapModel = transportModel
+                , subagentCreateWorktree = Just createSubagentWorktree
                 , subagentSessionTmp = toolEnv.toolSessionTmp
                 , subagentSpawnModelGuidance =
                     subscriptionSubagentModelGuidance

--- a/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
@@ -133,6 +133,7 @@ import Agent.GrokBuild.Dialect.Task
 import Agent.Tools.MultiAgents
     ( CollaborationSpawnOptions(..)
     , MultiAgentContext(..)
+    , SubagentWorktree
     )
 import Agent.Tools.PlanMode (PlanModeEnv(..), PlanModeHooks)
 import Agent.Tools.Types
@@ -193,6 +194,8 @@ data SubagentRuntime = SubagentRuntime
     , subagentLegacyTarget :: !(Maybe LegacySubagentTarget)
     , subagentConnection :: !Text
     , subagentMapModel :: !(Text -> Text)
+    , subagentCreateWorktree
+        :: !(Maybe (OsPath -> IO (Either Text SubagentWorktree)))
     , subagentSpawnModelGuidance :: !(Maybe Text)
     }
 
@@ -860,12 +863,13 @@ prepareChild runtime provider currentEffectiveModel currentDialect env sendToRoo
         childToolEnv = childEnv { toolCancel = env.subCancel }
         childCtx = MultiAgentContext
             { multiRegistry = runtime.subagentRegistry
+            , multiCwd = env.subCwd
             , multiSelfId = Just env.subId
             , multiDepth = env.subDepth
             , multiTaskPath = childPath
             , multiRootTurnId = pure env.subRootTurnId
             , multiResumeFromDisk = Nothing
-            , multiCreateWorktree = Nothing
+            , multiCreateWorktree = runtime.subagentCreateWorktree
             , multiPrepareSpawn = Just
                 (prepareCollaborationSpawn
                     provider

--- a/packages/agent-cli/test/Agent/CLI/ToolsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ToolsSpec.hs
@@ -230,6 +230,7 @@ spec = describe "schemasFromAppTools" do
             \registry -> do
                 let context = MultiAgentContext
                         { multiRegistry = registry
+                        , multiCwd = unsafeEncodeUtf "/tmp"
                         , multiSelfId = Nothing
                         , multiDepth = 0
                         , multiTaskPath = taskPathRoot

--- a/packages/agent-core/src/Agent/Subagents/Registry.hs
+++ b/packages/agent-core/src/Agent/Subagents/Registry.hs
@@ -25,6 +25,7 @@ module Agent.Subagents.Registry
     , spawnSubagentAtForTurn
     , spawnSubagentAtPreparedForTurn
     , spawnSubagentAtWithCwdPrepared
+    , spawnSubagentAtWithCwdPreparedForTurn
     , restoreSubagent
     , restoreSubagentAt
     , restoreSubagentAtStatus

--- a/packages/agent-core/src/Agent/Tools/MultiAgents.hs
+++ b/packages/agent-core/src/Agent/Tools/MultiAgents.hs
@@ -23,7 +23,8 @@ import Agent.Subagents
     , queueMessageFromForTurn
     , resolveAgentTarget
     , sendInputMessageForTurn
-    , spawnSubagentAtPreparedForTurn
+    , spawnSubagentAtWithCwdPreparedForTurn
+    , subagentLease
     , waitAnyLive
     , waitSubagentsFrom
     )
@@ -40,6 +41,7 @@ import Agent.InterAgentMessage
     , encryptedInterAgentContent
     , plainInterAgentContent
     )
+import Agent.OsPath (toText)
 import System.OsPath (OsPath)
 import Agent.ToolArgs
     ( objectArgs
@@ -60,6 +62,9 @@ import Agent.Tools.Types
     , ToolExecutionPolicy(..)
     , jsonTool
     )
+import Control.Concurrent.MVar (modifyMVar, newMVar)
+import Control.Exception.Safe (mask, onException)
+import Control.Monad (void)
 import Data.Aeson (FromJSON(..), Value(..), object, (.=))
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Key as Key
@@ -86,6 +91,7 @@ data CollaborationSpawnOptions = CollaborationSpawnOptions
 -- | Per-agent identity for nesting depth / parent linkage / task path.
 data MultiAgentContext = MultiAgentContext
     { multiRegistry :: !SubagentRegistry
+    , multiCwd :: !OsPath
     , multiSelfId :: !(Maybe SubagentId)
     , multiDepth :: !Int
     , multiTaskPath :: !TaskPath
@@ -93,7 +99,7 @@ data MultiAgentContext = MultiAgentContext
       -- | Optional host hook to rehydrate a closed/missing agent from disk
       -- before follow-ups. 'Nothing' means in-memory only.
     , multiResumeFromDisk :: !(Maybe (SubagentId -> IO (Either Text ())))
-      -- | Optional host hook for Grok-style isolated worktree children.
+      -- | Optional host hook for isolated worktree children.
     , multiCreateWorktree :: !(Maybe (OsPath -> IO (Either Text SubagentWorktree)))
       -- | Record model/effort overrides and seed the child transcript before
       -- its worker starts.
@@ -138,6 +144,7 @@ data SpawnAgentArgs = SpawnAgentArgs
     , model :: Maybe Text
     , reasoningEffort :: Maybe Text
     , forkTurns :: Maybe Text
+    , isolation :: Maybe Text
     }
 
 instance FromJSON SpawnAgentArgs where
@@ -147,6 +154,7 @@ instance FromJSON SpawnAgentArgs where
         <*> optText object_ "model"
         <*> optText object_ "reasoning_effort"
         <*> optText object_ "fork_turns"
+        <*> optText object_ "isolation"
 
 spawnAgentTool :: MultiAgentContext -> AppTool
 spawnAgentTool ctx = jsonTool "spawn_agent" spawnAgentDescription
@@ -163,6 +171,8 @@ spawnAgentTool ctx = jsonTool "spawn_agent" spawnAgentDescription
         "Reasoning effort override for the new agent. Omit to inherit the parent effort."
     , PropertySchema "fork_turns" PropertyString False $ Just
         "Optional number of turns to fork. Defaults to `all`. Use `none`, `all`, or a positive integer string such as `3` to fork only the most recent turns."
+    , PropertySchema "isolation" (PropertyEnum ["none", "worktree"]) False $ Just
+        "Workspace isolation for the new agent. Defaults to `none`. Use `worktree` to create a dedicated git worktree whose lifetime is tied to the agent."
     ]
     True
     TurnSequential
@@ -181,35 +191,112 @@ runSpawn ctx call args
         pure (Left "spawn_agent requires a non-empty message")
     | not (validForkTurns args.forkTurns) =
         pure (Left "fork_turns must be none, all, or a positive integer string")
-    | otherwise = do
-        rootTurnId <- ctx.multiRootTurnId
-        let spawnOptions = CollaborationSpawnOptions
-                { collaborationModel = sanitizeOverride args.model
-                , collaborationReasoningEffort =
-                    sanitizeOverride args.reasoningEffort
-                , collaborationForkTurns = normalizeForkTurns args.forkTurns
-                }
-            prepare agentId =
-                maybe (pure ()) (\hook -> hook agentId spawnOptions)
-                    ctx.multiPrepareSpawn
-                    >> pure mempty
-        result <- spawnSubagentAtPreparedForTurn
+    | not (validIsolation args.isolation) =
+        pure (Left "isolation must be none or worktree")
+    | otherwise = mask \restore ->
+        resolveSpawnWorkspace ctx args.isolation >>= \case
+            Left err -> pure (Left err)
+            Right (childCwd, worktree) ->
+                restore (spawnInWorkspace ctx call args childCwd worktree)
+
+spawnInWorkspace
+    :: MultiAgentContext
+    -> ToolCall
+    -> SpawnAgentArgs
+    -> OsPath
+    -> Maybe SubagentWorktree
+    -> IO (Either Text Text)
+spawnInWorkspace ctx call args childCwd worktree = mask \restore -> do
+    ownedWorktree <- traverse makeIdempotentWorktree worktree
+    rootTurnId <- ctx.multiRootTurnId
+    let spawnOptions = CollaborationSpawnOptions
+            { collaborationModel = sanitizeOverride args.model
+            , collaborationReasoningEffort =
+                sanitizeOverride args.reasoningEffort
+            , collaborationForkTurns = normalizeForkTurns args.forkTurns
+            }
+        prepare agentId = do
+            maybe (pure ()) (\hook -> hook agentId spawnOptions)
+                ctx.multiPrepareSpawn
+            pure $ case ownedWorktree of
+                Nothing -> mempty
+                Just lease ->
+                    subagentLease (void lease.subagentWorktreeCleanup)
+    result <- restore
+        (spawnSubagentAtWithCwdPreparedForTurn
             ctx.multiRegistry
             rootTurnId
+            childCwd
             prepare
             ctx.multiSelfId
             ctx.multiTaskPath
             ctx.multiDepth
             args.taskName
             (messageContent call args.message)
-            Nothing
-        pure $ case result of
-            Left err -> Left err
-            Right (_agentId, path) ->
-                Right $ encodeJson $ object
-                    [ "task_name" .= taskPathText path
-                    , "nickname" .= Aeson.Null
-                    ]
+            Nothing)
+        `onException` cleanupWorktreeQuietly ownedWorktree
+    case result of
+        Left err -> cleanupFailedWorktree ownedWorktree err
+        Right (_agentId, path) ->
+            pure $ Right $ encodeJson $ object $
+                [ "task_name" .= taskPathText path
+                , "nickname" .= Aeson.Null
+                ]
+                    <> maybe []
+                        (\lease -> ["worktree" .= toText lease.subagentWorktreePath])
+                        ownedWorktree
+
+resolveSpawnWorkspace
+    :: MultiAgentContext
+    -> Maybe Text
+    -> IO (Either Text (OsPath, Maybe SubagentWorktree))
+resolveSpawnWorkspace ctx isolation
+    | usesWorktree isolation =
+        case ctx.multiCreateWorktree of
+            Nothing ->
+                pure (Left "isolation=\"worktree\" is unavailable in this host.")
+            Just create ->
+                create ctx.multiCwd >>= \case
+                    Left err -> pure (Left err)
+                    Right worktree ->
+                        pure (Right (worktree.subagentWorktreePath, Just worktree))
+    | otherwise = pure (Right (ctx.multiCwd, Nothing))
+
+validIsolation :: Maybe Text -> Bool
+validIsolation = \case
+    Nothing -> True
+    Just raw -> Text.toLower (Text.strip raw) `elem` ["", "none", "worktree"]
+
+usesWorktree :: Maybe Text -> Bool
+usesWorktree =
+    maybe False ((== "worktree") . Text.toLower . Text.strip)
+
+makeIdempotentWorktree :: SubagentWorktree -> IO SubagentWorktree
+makeIdempotentWorktree worktree = do
+    resultVar <- newMVar Nothing
+    let cleanup = modifyMVar resultVar \case
+            Just result -> pure (Just result, result)
+            Nothing -> do
+                result <- worktree.subagentWorktreeCleanup
+                pure (Just result, result)
+    pure worktree { subagentWorktreeCleanup = cleanup }
+
+cleanupWorktreeQuietly :: Maybe SubagentWorktree -> IO ()
+cleanupWorktreeQuietly Nothing = pure ()
+cleanupWorktreeQuietly (Just worktree) =
+    void worktree.subagentWorktreeCleanup
+
+cleanupFailedWorktree
+    :: Maybe SubagentWorktree
+    -> Text
+    -> IO (Either Text Text)
+cleanupFailedWorktree Nothing spawnError = pure (Left spawnError)
+cleanupFailedWorktree (Just worktree) spawnError =
+    worktree.subagentWorktreeCleanup >>= \case
+        Right () -> pure (Left spawnError)
+        Left cleanupError ->
+            pure $ Left $
+                spawnError <> "\nAdditionally, worktree cleanup failed: " <> cleanupError
 
 validForkTurns :: Maybe Text -> Bool
 validForkTurns = \case

--- a/packages/agent-core/test/Agent/Tools/MultiAgentsSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/MultiAgentsSpec.hs
@@ -26,6 +26,7 @@ import Agent.Tools.Types
     )
 import Control.Concurrent.STM
 import Control.Monad (unless)
+import Data.IORef
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -113,6 +114,19 @@ spec = describe "Agent.Tools.MultiAgents" do
             any (Text.isInfixOf "Prefer `gpt-5.6-luna` for small tasks.")
         closeSubagentRegistry registry
 
+    it "advertises optional worktree isolation on spawn_agent" do
+        registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
+            (\_ _ _ _ -> pure $ Left LoopNoResponseId)
+            (\_ _ -> pure ())
+        let propertyNames =
+                [ property.propertyName
+                | tool <- multiAgentTools (rootContext registry Nothing)
+                , tool.appToolName == "spawn_agent"
+                , property <- fromMaybe [] (jsonToolParameters tool)
+                ]
+        propertyNames `shouldContain` ["isolation"]
+        closeSubagentRegistry registry
+
     it "preserves encrypted spawn payloads" do
         spawned <- newEmptyTMVarIO
         registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
@@ -164,6 +178,61 @@ spec = describe "Agent.Tools.MultiAgents" do
             , collaborationReasoningEffort = Just "high"
             , collaborationForkTurns = Just "3"
             }
+        closeSubagentRegistry registry
+
+    it "spawns an isolated child in a host-provided worktree" do
+        childCwd <- newEmptyTMVarIO
+        cleaned <- newIORef False
+        registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp/root")
+            (\env _ _ _ -> do
+                atomically (putTMVar childCwd env.subCwd)
+                pure (resultWithText "done"))
+            (\_ _ -> pure ())
+        let worktreePath = fromFilePath "/tmp/worktree"
+            createWorktree source = do
+                source `shouldBe` fromFilePath "/tmp/root"
+                pure $ Right SubagentWorktree
+                    { subagentWorktreePath = worktreePath
+                    , subagentWorktreeCleanup =
+                        writeIORef cleaned True >> pure (Right ())
+                    }
+            context = (rootContext registry Nothing)
+                { multiCwd = fromFilePath "/tmp/root"
+                , multiCreateWorktree = Just createWorktree
+                }
+            call = ToolCall
+                { callId = "spawn-worktree"
+                , name = "collaboration.spawn_agent"
+                , arguments =
+                    "{\"task_name\":\"worker\",\"message\":\"task\",\
+                    \\"isolation\":\"worktree\"}"
+                , callKind = FunctionCallKind
+                , argumentsEncrypted = False
+                }
+        result <- dispatchToolCall defaultLoopDispatch
+            (appToolHandlers (multiAgentTools context)) call
+        result.output `shouldSatisfy` Text.isInfixOf "/tmp/worktree"
+        atomically (takeTMVar childCwd) `shouldReturn` worktreePath
+        readIORef cleaned `shouldReturn` False
+        closeSubagentRegistry registry
+        readIORef cleaned `shouldReturn` True
+
+    it "rejects worktree isolation when the host does not provide it" do
+        registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
+            (\_ _ _ _ -> pure $ Left LoopNoResponseId)
+            (\_ _ -> pure ())
+        let call = ToolCall
+                { callId = "spawn-worktree-unavailable"
+                , name = "collaboration.spawn_agent"
+                , arguments =
+                    "{\"task_name\":\"worker\",\"message\":\"task\",\
+                    \\"isolation\":\"worktree\"}"
+                , callKind = FunctionCallKind
+                , argumentsEncrypted = False
+                }
+        result <- dispatchToolCall defaultLoopDispatch
+            (appToolHandlers (multiAgentTools (rootContext registry Nothing))) call
+        result.output `shouldSatisfy` Text.isInfixOf "unavailable"
         closeSubagentRegistry registry
 
     it "rejects zero fork turns" do
@@ -298,6 +367,7 @@ spec = describe "Agent.Tools.MultiAgents" do
                 pure (Right "queued")
             context = MultiAgentContext
                 { multiRegistry = registry
+                , multiCwd = fromFilePath "/tmp"
                 , multiSelfId = Nothing
                 , multiDepth = 1
                 , multiTaskPath = workerPath
@@ -330,6 +400,7 @@ rootContext
     -> MultiAgentContext
 rootContext registry sendToRoot = MultiAgentContext
     { multiRegistry = registry
+    , multiCwd = fromFilePath "/tmp"
     , multiSelfId = Nothing
     , multiDepth = 0
     , multiTaskPath = taskPathRoot

--- a/packages/agent-grok-build-dialect/test/Agent/GrokBuild/RuntimeSpec.hs
+++ b/packages/agent-grok-build-dialect/test/Agent/GrokBuild/RuntimeSpec.hs
@@ -422,6 +422,7 @@ call tools name arguments =
 
 rootContext registry = MultiAgentContext
     registry
+    (unsafeEncodeUtf "/tmp")
     Nothing
     0
     taskPathRoot
@@ -434,6 +435,7 @@ rootContext registry = MultiAgentContext
 
 childContext registry = MultiAgentContext
     registry
+    (unsafeEncodeUtf "/tmp")
     (Just (SubagentId "agent-parent"))
     1
     taskPathRoot

--- a/packages/agent-grok-build-dialect/test/Agent/GrokBuild/TaskSpec.hs
+++ b/packages/agent-grok-build-dialect/test/Agent/GrokBuild/TaskSpec.hs
@@ -38,7 +38,7 @@ spec = describe "Agent.GrokBuild.Dialect.Task" do
             (\_ _ _ _ -> pure $ Left LoopNoResponseId)
             (\_ _ -> pure ())
         typesRef <- newIORef Map.empty
-        let ctx = MultiAgentContext registry Nothing 0 taskPathRoot
+        let ctx = MultiAgentContext registry (fromFilePath "/tmp") Nothing 0 taskPathRoot
                 (pure Nothing) Nothing Nothing Nothing Nothing Nothing
             tool = taskTool (fromFilePath "/tmp") ctx typesRef
             parameters = fromMaybe [] (jsonToolParameters tool)
@@ -71,7 +71,7 @@ spec = describe "Agent.GrokBuild.Dialect.Task" do
                 })
             (\_ _ -> pure ())
         typesRef <- newIORef Map.empty
-        let ctx = MultiAgentContext registry Nothing 0 taskPathRoot
+        let ctx = MultiAgentContext registry (fromFilePath "/tmp") Nothing 0 taskPathRoot
                 (pure Nothing) Nothing Nothing Nothing Nothing Nothing
             tool = taskTool (fromFilePath "/tmp") ctx typesRef
         result <- dispatchToolCall defaultLoopDispatch [tool.appToolHandler]
@@ -89,7 +89,7 @@ spec = describe "Agent.GrokBuild.Dialect.Task" do
         registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
             (observeSpec typesRef observed)
             (\_ _ -> pure ())
-        let ctx = MultiAgentContext registry Nothing 0 taskPathRoot
+        let ctx = MultiAgentContext registry (fromFilePath "/tmp") Nothing 0 taskPathRoot
                 (pure Nothing) Nothing Nothing Nothing Nothing Nothing
             tool = taskTool (fromFilePath "/tmp") ctx typesRef
         _ <- dispatchToolCall defaultLoopDispatch [tool.appToolHandler]
@@ -119,7 +119,7 @@ spec = describe "Agent.GrokBuild.Dialect.Task" do
         typesRef <- newIORef Map.empty
         let restore _ =
                 pure (Left "persisted subagent dialect is incompatible")
-            ctx = MultiAgentContext registry Nothing 0 taskPathRoot
+            ctx = MultiAgentContext registry (fromFilePath "/tmp") Nothing 0 taskPathRoot
                 (pure Nothing) (Just restore) Nothing Nothing Nothing Nothing
             tool = taskTool (fromFilePath "/tmp") ctx typesRef
         result <- dispatchToolCall defaultLoopDispatch [tool.appToolHandler]
@@ -154,7 +154,7 @@ spec = describe "Agent.GrokBuild.Dialect.Task" do
             (\_ _ -> pure ())
         typesRef <- newIORef Map.empty
         let childId = SubagentId "agent-child"
-            ctx = MultiAgentContext registry (Just childId) 1 taskPathRoot
+            ctx = MultiAgentContext registry (fromFilePath "/tmp") (Just childId) 1 taskPathRoot
                 (pure Nothing) Nothing Nothing Nothing Nothing Nothing
             tool = taskTool (fromFilePath "/tmp") ctx typesRef
         expectAlwaysReadOnly tool.appToolApproval
@@ -167,7 +167,7 @@ spec = describe "Agent.GrokBuild.Dialect.Task" do
             (\_ _ -> pure ())
         typesRef <- newIORef Map.empty
         let createIsolated = cleanupLease cleaned
-            ctx = MultiAgentContext registry Nothing 0 taskPathRoot (pure Nothing)
+            ctx = MultiAgentContext registry (fromFilePath "/tmp") Nothing 0 taskPathRoot (pure Nothing)
                 Nothing (Just createIsolated) Nothing Nothing Nothing
             tool = taskTool (fromFilePath "/tmp") ctx typesRef
         result <- dispatchToolCall defaultLoopDispatch [tool.appToolHandler]
@@ -188,7 +188,7 @@ spec = describe "Agent.GrokBuild.Dialect.Task" do
         cleaned <- newIORef False
         registry <- closedRegistry
         typesRef <- newIORef Map.empty
-        let ctx = MultiAgentContext registry Nothing 0 taskPathRoot
+        let ctx = MultiAgentContext registry (fromFilePath "/tmp") Nothing 0 taskPathRoot
                 (pure Nothing) Nothing (Just (cleanupLease cleaned)) Nothing Nothing Nothing
             tool = taskTool (fromFilePath "/tmp") ctx typesRef
         result <- dispatchToolCall defaultLoopDispatch [tool.appToolHandler]


### PR DESCRIPTION
## Summary

- add optional `isolation: "worktree"` support to `collaboration.spawn_agent`
- run isolated children in their dedicated worktree and return its path in the spawn result
- tie worktree cleanup to the subagent supervisor lifetime, including failed-spawn cleanup
- propagate the current cwd and worktree creation hook to nested collaboration agents

## Validation

- `nix develop -c cabal repl agent-core:test:agent-core-test` with `:main --match "Agent.Tools.MultiAgents"` — 17 examples, 0 failures
- `nix develop -c cabal repl agent-cli:lib:agent-cli` — loaded successfully
- focused `agent-cli` tool-schema test — 1 example, 0 failures
- `git diff --check`
