### PR TITLE
Reuse shared process termination

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -161,6 +161,7 @@ library
                     , Agent.CLI.WebFetch
                     , Agent.CLI.Worktree
     build-depends:    agent-core >= 0.1 && < 0.2
+                    , agent-process >= 0.1 && < 0.2
                     , agent-codex-dialect >= 0.1 && < 0.2
                     , agent-grok-build-dialect >= 0.1 && < 0.2
                     , agent-store >= 0.1 && < 0.2

--- a/packages/agent-cli/package.nix
+++ b/packages/agent-cli/package.nix
@@ -1,14 +1,14 @@
 { mkDerivation, aeson, agent-claude, agent-codex-dialect
 , agent-core, agent-grok-build-dialect, agent-openai
-, agent-openrouter, agent-responses, agent-responses-types
-, agent-store, agent-syntax, agent-tui, agent-xai, ansi-terminal
-, async, base, base64-bytestring, brick, bytestring, colour
-, containers, deepseq, directory, filelock, filepath, haskeline
-, hasql-pool, hspec, http-client, http-client-tls, http-types
-, JuicyPixels, lib, mtl, network, network-uri, optparse-applicative
-, process, QuickCheck, retry, safe-exceptions, scientific, stm
-, tagsoup, text, time, transformers, unix, vector, vty
-, vty-crossplatform
+, agent-openrouter, agent-process, agent-responses
+, agent-responses-types, agent-store, agent-syntax, agent-tui
+, agent-xai, ansi-terminal, async, base, base64-bytestring, brick
+, bytestring, colour, containers, deepseq, directory, filelock
+, filepath, haskeline, hasql-pool, hspec, http-client
+, http-client-tls, http-types, JuicyPixels, lib, mtl, network
+, network-uri, optparse-applicative, process, QuickCheck, retry
+, safe-exceptions, scientific, stm, tagsoup, text, time
+, transformers, unix, vector, vty, vty-crossplatform
 }:
 mkDerivation {
   pname = "agent-cli";
@@ -20,13 +20,13 @@ mkDerivation {
   libraryHaskellDepends = [
     aeson agent-claude agent-codex-dialect agent-core
     agent-grok-build-dialect agent-openai agent-openrouter
-    agent-responses agent-responses-types agent-store agent-syntax
-    agent-tui agent-xai ansi-terminal async base base64-bytestring
-    brick bytestring colour containers directory filelock filepath
-    haskeline hasql-pool http-client http-client-tls http-types
-    JuicyPixels mtl network network-uri optparse-applicative process
-    retry safe-exceptions scientific stm tagsoup text time transformers
-    unix vector vty vty-crossplatform
+    agent-process agent-responses agent-responses-types agent-store
+    agent-syntax agent-tui agent-xai ansi-terminal async base
+    base64-bytestring brick bytestring colour containers directory
+    filelock filepath haskeline hasql-pool http-client http-client-tls
+    http-types JuicyPixels mtl network network-uri optparse-applicative
+    process retry safe-exceptions scientific stm tagsoup text time
+    transformers unix vector vty vty-crossplatform
   ];
   executableHaskellDepends = [
     aeson agent-responses agent-responses-types agent-store base

--- a/packages/agent-cli/src/Agent/CLI/AgentSessions.hs
+++ b/packages/agent-cli/src/Agent/CLI/AgentSessions.hs
@@ -19,6 +19,7 @@ module Agent.CLI.AgentSessions
 import Agent.CLI.Options (ApprovalPolicy(..))
 import Agent.CLI.ManagedTurn (ManagedTurnRequest)
 import Agent.CLI.Error (formatException)
+import Agent.Process (terminateProcessGroup)
 import Agent.CLI.Session
     ( SessionCreate(..)
     , SessionActivity(..)
@@ -98,11 +99,6 @@ import System.Process
     , proc
     , terminateProcess
     , waitForProcess
-    )
-import System.Posix.Signals
-    ( sigKILL
-    , sigTERM
-    , signalProcessGroup
     )
 import qualified System.Timeout as Timeout
 
@@ -525,28 +521,12 @@ sessionManagerIsOpen state =
         SessionManagerClosed -> False
 
 waitForManagedExit :: ProcessHandle -> IO ExitCode
-waitForManagedExit process =
-    getProcessExitCode process >>= \case
-        Nothing -> threadDelay 10_000 >> waitForManagedExit process
-        Just exitCode -> do
-            _ <- try @_ @SomeException (waitForProcess process)
-            pure exitCode
+waitForManagedExit = waitForProcess
 
 terminateManagedProcess :: ProcessHandle -> IO ()
 terminateManagedProcess process = do
     processGroup <- getPid process
-    let signalGroup signal =
-            case processGroup of
-                Nothing -> terminateProcess process
-                Just pid -> signalProcessGroup signal pid
-    _ <- try @_ @SomeException (signalGroup sigTERM)
-    stopped <- Timeout.timeout 2_000_000 (waitForManagedExit process)
-    case stopped of
-        Just _ -> pure ()
-        Nothing -> do
-            _ <- try @_ @SomeException (signalGroup sigKILL)
-            _ <- try @_ @SomeException (waitForManagedExit process)
-            pure ()
+    terminateProcessGroup processGroup process
 
 signalManagedSessionReady :: Either Text () -> IO ()
 signalManagedSessionReady result =

--- a/packages/agent-cli/src/Agent/CLI/AgentSessions.hs
+++ b/packages/agent-cli/src/Agent/CLI/AgentSessions.hs
@@ -19,7 +19,10 @@ module Agent.CLI.AgentSessions
 import Agent.CLI.Options (ApprovalPolicy(..))
 import Agent.CLI.ManagedTurn (ManagedTurnRequest)
 import Agent.CLI.Error (formatException)
-import Agent.Process (terminateProcessGroup)
+import Agent.Process
+    ( terminateProcessGroupWith
+    , terminateThenKillPolicy
+    )
 import Agent.CLI.Session
     ( SessionCreate(..)
     , SessionActivity(..)
@@ -526,7 +529,7 @@ waitForManagedExit = waitForProcess
 terminateManagedProcess :: ProcessHandle -> IO ()
 terminateManagedProcess process = do
     processGroup <- getPid process
-    terminateProcessGroup processGroup process
+    terminateProcessGroupWith terminateThenKillPolicy processGroup process
 
 signalManagedSessionReady :: Either Text () -> IO ()
 signalManagedSessionReady result =

--- a/packages/agent-process/src/Agent/Process.hs
+++ b/packages/agent-process/src/Agent/Process.hs
@@ -1,5 +1,9 @@
 module Agent.Process
-    ( terminateProcessGroup
+    ( ProcessTerminationPolicy(..)
+    , defaultProcessTerminationPolicy
+    , terminateThenKillPolicy
+    , terminateProcessGroup
+    , terminateProcessGroupWith
     ) where
 
 import Control.Concurrent (threadDelay)
@@ -8,6 +12,7 @@ import Control.Monad (unless, void)
 import Data.Either (isRight)
 import System.Posix.Signals
     ( nullSignal
+    , Signal
     , sigINT
     , sigKILL
     , sigTERM
@@ -20,20 +25,61 @@ import System.Process
     , terminateProcess
     )
 
--- | Stop a child process and its descendants with bounded escalation.
+data ProcessTerminationPolicy = ProcessTerminationPolicy
+    { firstSignal :: !Signal
+    , firstWaitMilliseconds :: !Int
+    , secondSignal :: !(Maybe Signal)
+    , secondWaitMilliseconds :: !Int
+    }
+
+-- | The normal policy used by shared process owners.
+defaultProcessTerminationPolicy :: ProcessTerminationPolicy
+defaultProcessTerminationPolicy = ProcessTerminationPolicy
+    { firstSignal = sigINT
+    , firstWaitMilliseconds = 250
+    , secondSignal = Just sigTERM
+    , secondWaitMilliseconds = 750
+    }
+
+-- | Compatibility policy for callers that historically sent TERM, waited
+-- two seconds, and then escalated directly to KILL.
+terminateThenKillPolicy :: ProcessTerminationPolicy
+terminateThenKillPolicy = ProcessTerminationPolicy
+    { firstSignal = sigTERM
+    , firstWaitMilliseconds = 2_000
+    , secondSignal = Nothing
+    , secondWaitMilliseconds = 0
+    }
+
+-- | Stop a child process and its descendants with the shared default policy.
 terminateProcessGroup
     :: Maybe ProcessGroupID
     -> ProcessHandle
     -> IO ()
-terminateProcessGroup groupId processHandle = do
+terminateProcessGroup = terminateProcessGroupWith defaultProcessTerminationPolicy
+
+-- | Stop a child process and its descendants with an explicit escalation
+-- policy.
+terminateProcessGroupWith
+    :: ProcessTerminationPolicy
+    -> Maybe ProcessGroupID
+    -> ProcessHandle
+    -> IO ()
+terminateProcessGroupWith policy groupId processHandle = do
     alive <- processGroupAlive groupId processHandle
     whenAlive alive do
-        signalGroup sigINT
-        interrupted <- waitForProcessGroupExit groupId processHandle 250
+        signalGroup (firstSignal policy)
+        interrupted <- waitForProcessGroupExit
+            groupId
+            processHandle
+            (firstWaitMilliseconds policy)
         unless interrupted do
-            signalGroup sigTERM
+            mapM_ signalGroup (secondSignal policy)
             void $ try @_ @SomeException (terminateProcess processHandle)
-            terminated <- waitForProcessGroupExit groupId processHandle 750
+            terminated <- waitForProcessGroupExit
+                groupId
+                processHandle
+                (secondWaitMilliseconds policy)
             unless terminated do
                 signalGroup sigKILL
                 void $ try @_ @SomeException (terminateProcess processHandle)


### PR DESCRIPTION
Reuse the shared `Agent.Process` process-group shutdown implementation and replace the local polling loop with `waitForProcess`.

The shared helper now supports explicit termination policies. Existing callers keep the default INT (250 ms) → TERM (750 ms) → KILL escalation, while managed sessions select a compatibility TERM (2 s) → KILL policy so their previous shutdown timing and signals are preserved.

Validation:
- `Agent.CLI.AgentSessions` and all 112 `agent-cli` library modules loaded successfully in the Cabal REPL
- full agent-cli test executable ran 880 examples; the only failures were 26 PostgreSQL cases caused by the long temporary path exceeding the macOS Unix-socket path limit
- `git diff --check`