### PR TITLE
Validate scope IDs with uuid-types

### DIFF
--- a/packages/agent-store/agent-store.cabal
+++ b/packages/agent-store/agent-store.cabal
@@ -71,6 +71,7 @@ library
                     , text
                     , time
                     , unix
+                    , uuid-types
 
 benchmark pool-cache-bench
     import:           common-opts

--- a/packages/agent-store/package.nix
+++ b/packages/agent-store/package.nix
@@ -1,7 +1,7 @@
 { mkDerivation, async, base, bytestring, containers, contravariant
 , directory, filelock, filepath, hasql, hasql-pool
 , hasql-transaction, hspec, lib, pqi-ffi, process, safe-exceptions
-, stm, temporary, text, time, unix
+, stm, temporary, text, time, unix, uuid-types
 }:
 mkDerivation {
   pname = "agent-store";
@@ -10,7 +10,7 @@ mkDerivation {
   libraryHaskellDepends = [
     async base bytestring containers contravariant directory filelock
     filepath hasql hasql-pool hasql-transaction pqi-ffi process
-    safe-exceptions stm text time unix
+    safe-exceptions stm text time unix uuid-types
   ];
   testHaskellDepends = [
     async base bytestring hasql hspec safe-exceptions temporary text

--- a/packages/agent-store/src/Agent/Store/Postgres/Scope.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Scope.hs
@@ -28,11 +28,12 @@ module Agent.Store.Postgres.Scope
 
 import Control.Monad (forM_)
 import qualified Data.ByteString as ByteString
-import Data.Char (isHexDigit)
+import Control.Applicative ((<|>))
 import Data.Functor.Contravariant ((>$<))
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
+import qualified Data.UUID.Types as UUID
 import qualified Hasql.Decoders as Decoders
 import qualified Hasql.Encoders as Encoders
 import Hasql.Pool (Pool)
@@ -79,10 +80,27 @@ data ScopeDatabase = ScopeDatabase
 -- safe without accepting caller-controlled SQL syntax.
 mkScopeId :: Text -> Either Text ScopeId
 mkScopeId raw =
-    let compact = Text.toLower (Text.filter (/= '-') (Text.strip raw))
-    in if Text.length compact == 32 && Text.all isHexDigit compact
-        then Right (ScopeId compact)
-        else Left "scope id must be a UUID (32 hex digits, with optional hyphens)"
+    case UUID.fromText stripped <|> parseCompact stripped of
+        Just uuid ->
+            Right
+                (ScopeId
+                    (Text.filter (/= '-') (Text.toLower (UUID.toText uuid))))
+        Nothing ->
+            Left "scope id must be a UUID (32 hex digits, with optional hyphens)"
+  where
+    stripped = Text.strip raw
+    parseCompact compact
+        | Text.length compact == 32
+        , Text.all (/= '-') compact =
+            UUID.fromText $
+                Text.intercalate "-"
+                    [ Text.take 8 compact
+                    , Text.take 4 (Text.drop 8 compact)
+                    , Text.take 4 (Text.drop 12 compact)
+                    , Text.take 4 (Text.drop 16 compact)
+                    , Text.drop 20 compact
+                    ]
+        | otherwise = Nothing
 
 -- | Derive a stable 128-bit scope identifier from a caller-resolved logical
 -- key.  The digest is computed by PostgreSQL's pgcrypto extension so CLI

--- a/packages/agent-store/test/Agent/Store/Postgres/ScopeSpec.hs
+++ b/packages/agent-store/test/Agent/Store/Postgres/ScopeSpec.hs
@@ -51,6 +51,8 @@ spec = describe "custom PostgreSQL scopes" do
     it "rejects identifiers outside the UUID-shaped safe alphabet" do
         mkScopeId "not-a-scope" `shouldBe`
             Left "scope id must be a UUID (32 hex digits, with optional hyphens)"
+        mkScopeId "01234567-89abcdef0123-4567-89abcdef" `shouldBe`
+            Left "scope id must be a UUID (32 hex digits, with optional hyphens)"
 
     it "migrates a durable started-to-final audit lifecycle" do
         let migrationSql = ByteString.unlines customSchemaStatements


### PR DESCRIPTION
Use `uuid-types` for canonical UUID validation while retaining the compact lowercase PostgreSQL-safe representation.

Accepts canonical hyphenated UUIDs and 32-character compact UUIDs, but rejects malformed hyphen placement that the previous character filter accepted.

Validation:
- `agent-store` test suite: 31 examples, 0 failures
- `git diff --check`