### PR TITLE
fix(compaction): harden request sizing and context recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ Responses API at `POST /v1/responses` can be configured as:
       "connection": "ollama",
       "model": "qwen2.5-coder:32b",
       "dialect": "generic-responses",
+      "context_window": 32768,
       "label": "local"
     }
   ]
@@ -254,6 +255,10 @@ Responses API at `POST /v1/responses` can be configured as:
 Select it with `agent-cli --model qwen-local` or from `/model`. For an
 authenticated endpoint, set `"api_key_env": "MY_MODEL_API_KEY"` and export
 that variable. Omit `"api_key_optional": true` when the key is required.
+Set `context_window` to the model endpoint's documented token limit so
+`/compact` can bound both its summary request and the installed snapshot.
+Inference still works when this metadata is absent, but `/compact` refuses to
+guess a portable model's limit.
 
 Supported dialects are:
 

--- a/packages/agent-cli/config/models.default.json
+++ b/packages/agent-cli/config/models.default.json
@@ -43,6 +43,7 @@
       "id": "grok-4.6",
       "connection": "xai",
       "dialect": "grok-build",
+      "context_window": 500000,
       "label": "default",
       "default": true,
       "fallback_priority": 10
@@ -51,6 +52,7 @@
       "id": "stealth/ox-alpha",
       "connection": "openrouter",
       "dialect": "generic-responses",
+      "context_window": 1048576,
       "label": "default · frontier · free · coding · 1M context",
       "default": true,
       "fallback_priority": 20

--- a/packages/agent-cli/skills/add-model/SKILL.md
+++ b/packages/agent-cli/skills/add-model/SKILL.md
@@ -25,6 +25,8 @@ API keys in the file.
    user. The resulting request URL is `<base_url>/responses`.
 4. Determine whether authentication is required. Store only the environment
    variable name in the config, never its secret value.
+5. Determine the model's documented context window. Store it as a positive
+   integer `context_window`; do not infer it from a display label.
 
 Ask a concise follow-up question only for information that cannot be inferred
 or verified.
@@ -68,6 +70,7 @@ or `-`, then add:
       "connection": "local-name",
       "model": "exact-wire-model-name",
       "dialect": "generic-responses",
+      "context_window": 32768,
       "label": "local"
     }
   ]
@@ -77,7 +80,8 @@ or `-`, then add:
 For authenticated endpoints, replace `api_key_optional` with
 `"api_key_env": "PROVIDER_API_KEY"` and tell the user which variable to export.
 Use `codex` or `grok-build` only when the endpoint is known to require that
-model-facing protocol; otherwise use `generic-responses`.
+model-facing protocol; otherwise use `generic-responses`. Replace the
+illustrative `32768` context window with the endpoint's documented value.
 
 ### OpenRouter
 
@@ -93,7 +97,8 @@ and wire model name by omitting `model`:
 ```
 
 Use `codex` for OpenAI Codex-style models, `grok-build` for xAI Grok models,
-and `generic-responses` for other model families.
+and `generic-responses` for other model families. Add the model's verified
+numeric `context_window` to the same object.
 
 ### Built-in OpenAI or xAI
 
@@ -108,7 +113,9 @@ OpenAI use:
 }
 ```
 
-For xAI use connection `xai` and dialect `grok-build`.
+For xAI use connection `xai` and dialect `grok-build`, and add its verified
+numeric `context_window`. Built-in OpenAI compaction instead uses the
+repository's Codex model metadata.
 
 ## Validate and finish
 

--- a/packages/agent-cli/src/Agent/CLI/Compaction.hs
+++ b/packages/agent-cli/src/Agent/CLI/Compaction.hs
@@ -40,7 +40,6 @@ import Agent.OpenAI.Compaction
     , estimateItemsTokens
     , estimateRequestTokensWithItems
     , estimateResponseCreateParamsTokens
-    , hasCompactionCheckpoint
     , remoteCompactionRetainedTokenBudget
     , summarizationPrompt
     , trimRemoteCompactionRequestToFit
@@ -59,6 +58,7 @@ import Agent.Responses.LoopBackend
     , withRequestInput
     )
 import Agent.Responses.Types
+import Agent.ToolDispatch (ToolCallResult(..))
 import Agent.Provider
     ( Provider(..)
     , TokenProvider
@@ -189,7 +189,7 @@ runProviderCompactWith openAiSender recordUsage provider tokenProvider
         | null history = pure (compactTextFailure "nothing to compact")
         | otherwise =
             mapCompactAttemptError formatApiError
-                <$> summarizeLocalAttempt
+                <$> summarizePortableLocalAttempt
                     sender
                     params
                     history
@@ -213,7 +213,7 @@ runResponsesCompactWith sender recordUsage paramsRef transcriptRef focus = do
             then pure (compactTextFailure "nothing to compact")
             else
                 mapCompactAttemptError formatApiError
-                    <$> summarizeLocalAttempt
+                    <$> summarizePortableLocalAttempt
                         sender
                         params
                         history
@@ -402,18 +402,35 @@ compactRemoteV2AttemptWithRetainedBudget
                                         (extractRemoteCompactionItem response)
                                 let items =
                                         buildRemoteCompactedHistory
-                                            (max 0
-                                                (retainedBudgetFor checkpoint))
+                                            ( min
+                                                (max 0
+                                                    (retainedBudgetFor checkpoint))
+                                                ( max 0
+                                                    ( contextWindow
+                                                        - estimateRequestTokensWithItems
+                                                            params
+                                                            [checkpoint]
+                                                    )
+                                                )
+                                            )
                                             history
                                             checkpoint
-                                Right CompactOutcome
-                                    { compactBeforeTokens = before
-                                    , compactAfterTokens =
-                                        estimateItemsTokens items
-                                    , compactHistory = items
-                                    , compactSummary =
-                                        "Context compacted remotely."
-                                    }
+                                if
+                                    estimateRequestTokensWithItems params items
+                                        > contextWindow
+                                    then
+                                        Left
+                                            (requestTooLargeError
+                                                "remote compacted snapshot")
+                                    else
+                                        Right CompactOutcome
+                                            { compactBeforeTokens = before
+                                            , compactAfterTokens =
+                                                estimateItemsTokens items
+                                            , compactHistory = items
+                                            , compactSummary =
+                                                "Context compacted remotely."
+                                            }
                             }
   where
     protocolError message =
@@ -426,10 +443,38 @@ summarizeLocalAttempt
     -> Int
     -> Maybe Text
     -> IO (CompactAttempt ApiError)
-summarizeLocalAttempt send params history before focus
+summarizeLocalAttempt =
+    summarizeLocalAttemptWith id
+
+summarizePortableLocalAttempt
+    :: OpenAiCompactionSender
+    -> ResponseCreateParams
+    -> [ResponseItem]
+    -> Int
+    -> Maybe Text
+    -> IO (CompactAttempt ApiError)
+summarizePortableLocalAttempt =
+    summarizeLocalAttemptWith
+        (filter isPortableLocalSummaryItem)
+
+summarizeLocalAttemptWith
+    :: ([ResponseItem] -> [ResponseItem])
+    -> OpenAiCompactionSender
+    -> ResponseCreateParams
+    -> [ResponseItem]
+    -> Int
+    -> Maybe Text
+    -> IO (CompactAttempt ApiError)
+summarizeLocalAttemptWith prepareHistory send params history before focus
     | null history =
         pure $ CompactAttempt emptyTokenUsage $
             Left (ProviderError InvalidRequestError "nothing to compact" Nothing)
+    | null summaryHistory =
+        pure $ CompactAttempt emptyTokenUsage $
+            Left
+                (ProviderError InvalidRequestError
+                    "nothing compatible to compact"
+                    Nothing)
     | otherwise = do
         let summaryPrompt = summarizationPrompt focus
             ResponseCreateParams{..} = params
@@ -454,7 +499,7 @@ summarizeLocalAttempt send params history before focus
                     contextWindow
                     summaryParams
                     [promptItem]
-                    history
+                    summaryHistory
             request =
                 withRequestInput
                     summaryParams
@@ -513,6 +558,20 @@ summarizeLocalAttempt send params history before focus
                                                         , compactSummary = summary
                                                         }
                             }
+  where
+    summaryHistory = prepareHistory history
+
+isPortableLocalSummaryItem :: ResponseItem -> Bool
+isPortableLocalSummaryItem = \case
+    -- OpenAI checkpoints are opaque provider protocol items. Preserve them
+    -- for focused OpenAI summaries, but never replay them through
+    -- xAI/OpenRouter or user-configured Responses endpoints.
+    KnownResponseItem ItemCompaction _ -> False
+    KnownResponseItem ItemCompactionTrigger _ -> False
+    UnknownResponseItem tagged ->
+        Text.toLower (Text.strip tagged.tag)
+            `notElem` ["compaction", "compaction_summary", "compaction_trigger"]
+    _ -> True
 
 autoCompactOpenAiBackend
     :: TokenProvider
@@ -578,20 +637,27 @@ autoCompactOpenAiBackendWithSenderAndHook
     -> Backend
 autoCompactOpenAiBackendWithSenderAndHook configuredThreshold send recordUsage
         getParams onCompacted contextTokensRef backend =
-    autoCompactOpenAiBackendWithLimit
-        getLimit
-        compactAction
-        recordUsage
-        estimateProjectedRequest
-        onCompacted
-        contextTokensRef
-        backend
+    rejectOversizedInitialRequest getParams $
+        boundCompletedToolContinuations getParams $
+            autoCompactOpenAiBackendWithLimit
+                getLimit
+                compactAction
+                recordUsage
+                estimateProjectedRequest
+                onCompacted
+                contextTokensRef
+                backend
   where
     getLimit = do
         params <- getParams
-        pure $ fromMaybe
-            (codexAutoCompactTokenLimitFor params.model)
-            configuredThreshold
+        let configuredLimit =
+                fromMaybe
+                    (codexAutoCompactTokenLimitFor params.model)
+                    configuredThreshold
+        pure $
+            min
+                configuredLimit
+                (codexEffectiveContextWindowFor params.model)
     compactAction history inputs = do
         params <- getParams
         tokenLimit <- getLimit
@@ -687,6 +753,140 @@ autoCompactOpenAiBackendWithSenderAndHook configuredThreshold send recordUsage
                 params
                 (history <> turnInputsToItems inputs)
 
+rejectOversizedInitialRequest
+    :: IO ResponseCreateParams
+    -> Backend
+    -> Backend
+rejectOversizedInitialRequest getParams (Backend submit) =
+    Backend \history previous inputs onEvent ->
+        if null history
+            then do
+                params <- getParams
+                let requestTokens =
+                        estimateRequestTokensWithItems
+                            params
+                            (turnInputsToItems inputs)
+                    contextWindow =
+                        codexEffectiveContextWindowFor params.model
+                if requestTokens > contextWindow
+                    then
+                        pure $
+                            Left $
+                                requestTooLargeError "initial"
+                    else submit history previous inputs onEvent
+            else submit history previous inputs onEvent
+
+-- A completed tool result must be submitted against its live response chain
+-- before that call/output pair can be compacted. If the result itself would
+-- overflow the model context, cap only its output text while preserving the
+-- protocol identifiers and continuation id.
+boundCompletedToolContinuations
+    :: IO ResponseCreateParams
+    -> Backend
+    -> Backend
+boundCompletedToolContinuations getParams (Backend submit) =
+    Backend \history previous inputs onEvent ->
+        if any isCompletedTool inputs
+            then do
+                params <- getParams
+                let contextWindow =
+                        codexEffectiveContextWindowFor params.model
+                    requestTokens candidate =
+                        estimateRequestTokensWithItems
+                            params
+                            (history <> turnInputsToItems candidate)
+                if requestTokens inputs <= contextWindow
+                    then submit history previous inputs onEvent
+                    else
+                        case
+                            fitCompletedToolOutputsToLimit
+                                ( max 0
+                                    ( contextWindow
+                                        - automaticCompactionHeadroom
+                                            contextWindow
+                                    )
+                                )
+                                requestTokens
+                                inputs
+                        of
+                            Just bounded ->
+                                submit history previous bounded onEvent
+                            Nothing ->
+                                case
+                                    fitCompletedToolOutputsToLimit
+                                        contextWindow
+                                        requestTokens
+                                        inputs
+                                of
+                                    Just bounded ->
+                                        submit history previous bounded onEvent
+                                    Nothing ->
+                                        pure $
+                                            Left toolContinuationTooLargeError
+            else submit history previous inputs onEvent
+  where
+    isCompletedTool = \case
+        CompletedTool{} -> True
+        _ -> False
+
+fitCompletedToolOutputsToLimit
+    :: Int
+    -> ([TurnInput] -> Int)
+    -> [TurnInput]
+    -> Maybe [TurnInput]
+fitCompletedToolOutputsToLimit limit requestTokens inputs
+    | requestTokens inputs <= limit = Just inputs
+    | requestTokens minimal > limit = Nothing
+    | otherwise = Just (search 0 maximumOutputLength minimal)
+  where
+    maximumOutputLength =
+        maximum
+            ( 0 :
+                [ Text.length result.output
+                | CompletedTool result <- inputs
+                ]
+            )
+    minimal = capCompletedToolOutputs 0 inputs
+
+    search low high best
+        | low > high = best
+        | otherwise =
+            let middle = (low + high) `div` 2
+                candidate = capCompletedToolOutputs middle inputs
+            in if requestTokens candidate <= limit
+                then search (middle + 1) high candidate
+                else search low (middle - 1) best
+
+capCompletedToolOutputs :: Int -> [TurnInput] -> [TurnInput]
+capCompletedToolOutputs maximumCharacters =
+    map \case
+        CompletedTool result ->
+            CompletedTool ToolCallResult
+                { callId = result.callId
+                , output =
+                    capToolOutput maximumCharacters result.output
+                , callKind = result.callKind
+                }
+        input -> input
+
+capToolOutput :: Int -> Text -> Text
+capToolOutput maximumCharacters text
+    | Text.length text <= maximumCharacters = text
+    | maximumCharacters <= 0 = ""
+    | maximumCharacters <= noticeLength =
+        Text.take maximumCharacters toolOutputTruncationNotice
+    | otherwise =
+        Text.take
+            (maximumCharacters - noticeLength)
+            text
+            <> toolOutputTruncationNotice
+  where
+    noticeLength = Text.length toolOutputTruncationNotice
+
+toolOutputTruncationNotice :: Text
+toolOutputTruncationNotice =
+    "\n[tool output truncated to fit the model context]"
+
 autoCompactOpenAiBackendWith
     :: IO (Either Text CompactOutcome)
     -> IORef (Maybe (Int, Int))
@@ -739,8 +939,7 @@ autoCompactOpenAiBackendWithLimit getLimit compactAction recordUsage
         tokenLimit <- getLimit
         projectedTokens <- estimateProjected contextState history inputs
         let shouldCompact =
-                not (isSaturated contextState history)
-                    && not (null history)
+                not (null history)
                     && projectedTokens >= tokenLimit
         if shouldCompact && not (any isCompletedTool inputs)
             then compactThenSubmit
@@ -762,19 +961,26 @@ autoCompactOpenAiBackendWithLimit getLimit compactAction recordUsage
         runCompaction oldHistory inputs >>= \case
                 Left err ->
                     pure (Left (automaticCompactionError err))
+                Right outcome
+                    | outcome.compactAfterTokens >= tokenLimit ->
+                        pure $
+                            Left $
+                                automaticCompactionError $
+                                    compactedSnapshotThresholdError
+                                        tokenLimit
+                                        outcome.compactAfterTokens
                 Right outcome ->
                     mask \restore -> do
                         let rollback = writeIORef contextTokensRef oldTokens
                         installSubmitAndTrack
                             restore
                             rollback
-                            tokenLimit
                             outcome
                             inputs
                             onEvent
                             `onException` rollback
 
-    installSubmitAndTrack restore rollback tokenLimit outcome inputs onEvent = do
+    installSubmitAndTrack restore rollback outcome inputs onEvent = do
         let compactedHistory = outcome.compactHistory
         writeIORef contextTokensRef $
             Just (outcome.compactAfterTokens, length compactedHistory)
@@ -782,18 +988,7 @@ autoCompactOpenAiBackendWithLimit getLimit compactAction recordUsage
         case result of
             Left _ -> rollback
             Right _ -> do
-                if outcome.compactAfterTokens >= tokenLimit
-                    then
-                        -- The checkpoint itself is larger than the
-                        -- configured trigger. Retaining this marker avoids
-                        -- repeatedly compacting a history that cannot be
-                        -- reduced below the threshold.
-                        writeIORef contextTokensRef $
-                            Just
-                                ( outcome.compactAfterTokens
-                                , saturatedCompactionHistoryLength
-                                )
-                    else invalidateContextTokens
+                invalidateContextTokens
                 onCompacted `catchAny` const (pure ())
         pure result
 
@@ -803,12 +998,7 @@ autoCompactOpenAiBackendWithLimit getLimit compactAction recordUsage
                 `onException` writeIORef contextTokensRef oldTokens
         case result of
             Left _ -> writeIORef contextTokensRef oldTokens
-            Right _ ->
-                case oldTokens of
-                    Just (_, observedLength)
-                        | observedLength == saturatedCompactionHistoryLength ->
-                            writeIORef contextTokensRef oldTokens
-                    _ -> invalidateContextTokens
+            Right _ -> invalidateContextTokens
         pure result
 
     -- Transcript state is committed by the loop after validating the response.
@@ -846,17 +1036,6 @@ estimateProjectedFromCache contextState history inputs =
   where
     pendingItems = turnInputsToItems inputs
 
-saturatedCompactionHistoryLength :: Int
-saturatedCompactionHistoryLength = -1
-
-isSaturated :: Maybe (Int, Int) -> [ResponseItem] -> Bool
-isSaturated contextState history =
-    hasCompactionCheckpoint history
-        && case contextState of
-            Just (_, observedLength) ->
-                observedLength == saturatedCompactionHistoryLength
-            Nothing -> False
-
 automaticCompactionHeadroom :: Int -> Int
 automaticCompactionHeadroom tokenLimit =
     max 1_024 (max 0 tokenLimit `div` 10)
@@ -884,6 +1063,24 @@ requestTooLargeError :: Text -> ApiError
 requestTooLargeError label =
     ProviderError InvalidRequestError
         (label <> " request cannot fit within the model context window")
+        Nothing
+
+compactedSnapshotThresholdError :: Int -> Int -> ApiError
+compactedSnapshotThresholdError tokenLimit compactedTokens =
+    ProviderError InvalidRequestError
+        ( "compaction produced a "
+            <> Text.pack (show compactedTokens)
+            <> "-token snapshot at or above the automatic compaction threshold "
+            <> Text.pack (show tokenLimit)
+            <> "; increase --compact-threshold"
+        )
+        Nothing
+
+toolContinuationTooLargeError :: ApiError
+toolContinuationTooLargeError =
+    ProviderError InvalidRequestError
+        "tool continuation request cannot fit within the model context window \
+        \even after truncating completed tool output"
         Nothing
 
 hasFocus :: Maybe Text -> Bool

--- a/packages/agent-cli/src/Agent/CLI/Compaction.hs
+++ b/packages/agent-cli/src/Agent/CLI/Compaction.hs
@@ -436,7 +436,11 @@ summarizeLocalAttempt send params history before focus
             summaryParams =
                 ResponseCreateParams
                     { tools = Nothing
+                    , toolChoice = Nothing
+                    , maxToolCalls = Nothing
                     , parallelToolCalls = Just False
+                    , previousResponseId = Nothing
+                    , conversation = Nothing
                     -- The ChatGPT Codex REST endpoint only accepts streaming
                     -- Responses requests, and this client decodes its SSE result.
                     , stream = Just True
@@ -588,17 +592,25 @@ autoCompactOpenAiBackendWithSenderAndHook configuredThreshold send recordUsage
         pure $ fromMaybe
             (codexAutoCompactTokenLimitFor params.model)
             configuredThreshold
-    compactAction history = do
+    compactAction history inputs = do
         params <- getParams
         tokenLimit <- getLimit
         let fixedRequestTokens =
                 estimateRequestTokensWithItems params []
+            pendingItems = turnInputsToItems inputs
+            contextWindow =
+                codexEffectiveContextWindowFor params.model
+            checkpointBaseTokens checkpoint =
+                estimateRequestTokensWithItems params [checkpoint]
+            continuationBaseTokens checkpoint =
+                estimateRequestTokensWithItems
+                    params
+                    (checkpoint : pendingItems)
             retainedBudget checkpoint =
                 min remoteCompactionRetainedTokenBudget $
                     max 0
                         ( tokenLimit
-                            - fixedRequestTokens
-                            - estimateItemsTokens [checkpoint]
+                            - continuationBaseTokens checkpoint
                             - automaticCompactionHeadroom tokenLimit
                         )
             thresholdError minimumTokens =
@@ -624,18 +636,49 @@ autoCompactOpenAiBackendWithSenderAndHook configuredThreshold send recordUsage
                         retainedBudget
                 pure $
                     case attempt.compactAttemptResult of
-                        Right outcome
-                            | let compactedRequestTokens =
+                        Right outcome ->
+                            let continuationTokens =
                                     estimateRequestTokensWithItems
                                         params
-                                        outcome.compactHistory
-                            , compactedRequestTokens >= tokenLimit ->
-                                attempt
-                                    { compactAttemptResult =
-                                        Left
-                                            (thresholdError
-                                                compactedRequestTokens)
-                                    }
+                                        (outcome.compactHistory <> pendingItems)
+                                (baseTokens, baseWithPendingTokens) =
+                                    case reverse outcome.compactHistory of
+                                        checkpoint : _ ->
+                                            ( checkpointBaseTokens checkpoint
+                                            , continuationBaseTokens checkpoint
+                                            )
+                                        [] ->
+                                            ( fixedRequestTokens
+                                            , estimateRequestTokensWithItems
+                                                params
+                                                pendingItems
+                                            )
+                            in if continuationTokens > contextWindow
+                                then
+                                    attempt
+                                        { compactAttemptResult =
+                                            Left
+                                                (requestTooLargeError
+                                                    "automatic compacted continuation")
+                                        }
+                                else if baseTokens >= tokenLimit
+                                    then
+                                        attempt
+                                            { compactAttemptResult =
+                                                Left
+                                                    (thresholdError baseTokens)
+                                            }
+                                    else if
+                                        baseWithPendingTokens < tokenLimit
+                                            && continuationTokens >= tokenLimit
+                                        then
+                                            attempt
+                                                { compactAttemptResult =
+                                                    Left
+                                                        (thresholdError
+                                                            continuationTokens)
+                                                }
+                                        else attempt
                         _ -> attempt
     estimateProjectedRequest _ history inputs = do
         params <- getParams
@@ -652,7 +695,7 @@ autoCompactOpenAiBackendWith
 autoCompactOpenAiBackendWith compactAction =
     autoCompactOpenAiBackendWithLimit
         (pure codexAutoCompactTokenLimit)
-        (const
+        (\_history _inputs ->
             (CompactAttempt emptyTokenUsage
                 <$> fmap (either (Left . textCompactionError) Right)
                     compactAction))
@@ -671,14 +714,15 @@ autoCompactOpenAiBackendWithApi
 autoCompactOpenAiBackendWithApi compactAction =
     autoCompactOpenAiBackendWithLimit
         (pure codexAutoCompactTokenLimit)
-        (const (CompactAttempt emptyTokenUsage <$> compactAction))
+        (\_history _inputs ->
+            CompactAttempt emptyTokenUsage <$> compactAction)
         (const (pure ()))
         estimateProjectedFromCache
         (pure ())
 
 autoCompactOpenAiBackendWithLimit
     :: IO Int
-    -> ([ResponseItem] -> IO (CompactAttempt ApiError))
+    -> ([ResponseItem] -> [TurnInput] -> IO (CompactAttempt ApiError))
     -> (TokenUsage -> IO ())
     -> (Maybe (Int, Int) -> [ResponseItem] -> [TurnInput] -> IO Int)
     -> IO ()
@@ -705,9 +749,9 @@ autoCompactOpenAiBackendWithLimit getLimit compactAction recordUsage
             else submitAndTrack
                 contextState history previous inputs onEvent
   where
-    runCompaction history =
+    runCompaction history inputs =
         (.compactAttemptResult)
-            <$> runAttemptAndRecord recordUsage (compactAction history)
+            <$> runAttemptAndRecord recordUsage (compactAction history inputs)
 
     isCompletedTool = \case
         CompletedTool{} -> True
@@ -715,7 +759,7 @@ autoCompactOpenAiBackendWithLimit getLimit compactAction recordUsage
 
     compactThenSubmit tokenLimit oldTokens oldHistory inputs onEvent = do
         onEvent (ActivityUpdated "Compacting context…")
-        runCompaction oldHistory >>= \case
+        runCompaction oldHistory inputs >>= \case
                 Left err ->
                     pure (Left (automaticCompactionError err))
                 Right outcome ->

--- a/packages/agent-cli/src/Agent/CLI/Compaction.hs
+++ b/packages/agent-cli/src/Agent/CLI/Compaction.hs
@@ -601,12 +601,42 @@ autoCompactOpenAiBackendWithSenderAndHook configuredThreshold send recordUsage
                             - estimateItemsTokens [checkpoint]
                             - automaticCompactionHeadroom tokenLimit
                         )
-        compactRemoteV2AttemptWithRetainedBudget
-            send
-            params
-            history
-            (estimateItemsTokens history)
-            retainedBudget
+            thresholdError minimumTokens =
+                ProviderError InvalidRequestError
+                    ( "automatic compaction threshold "
+                        <> Text.pack (show tokenLimit)
+                        <> " is below the minimum compacted request size of "
+                        <> Text.pack (show minimumTokens)
+                        <> " tokens; increase --compact-threshold"
+                    )
+                    Nothing
+        if tokenLimit <= 0 || fixedRequestTokens >= tokenLimit
+            then
+                pure $ CompactAttempt emptyTokenUsage $
+                    Left (thresholdError fixedRequestTokens)
+            else do
+                attempt <-
+                    compactRemoteV2AttemptWithRetainedBudget
+                        send
+                        params
+                        history
+                        (estimateItemsTokens history)
+                        retainedBudget
+                pure $
+                    case attempt.compactAttemptResult of
+                        Right outcome
+                            | let compactedRequestTokens =
+                                    estimateRequestTokensWithItems
+                                        params
+                                        outcome.compactHistory
+                            , compactedRequestTokens >= tokenLimit ->
+                                attempt
+                                    { compactAttemptResult =
+                                        Left
+                                            (thresholdError
+                                                compactedRequestTokens)
+                                    }
+                        _ -> attempt
     estimateProjectedRequest _ history inputs = do
         params <- getParams
         pure $

--- a/packages/agent-cli/src/Agent/CLI/Compaction.hs
+++ b/packages/agent-cli/src/Agent/CLI/Compaction.hs
@@ -14,7 +14,9 @@ module Agent.CLI.Compaction
     , installLiveCompactOutcome
     , runProviderCompact
     , runProviderCompactWith
+    , runProviderCompactWithContextWindow
     , runResponsesCompactWith
+    , runResponsesCompactWithContextWindow
     ) where
 
 import Agent.CLI.Error (formatApiError)
@@ -120,7 +122,24 @@ runProviderCompactWith
     -> IORef [ResponseItem]
     -> Maybe Text
     -> IO (Either Text CompactOutcome)
-runProviderCompactWith openAiSender recordUsage provider tokenProvider
+runProviderCompactWith =
+    runProviderCompactWithContextWindow Nothing
+
+-- | Variant of 'runProviderCompactWith' that receives the selected model's
+-- machine-readable context window. Portable providers must not inherit the
+-- unrelated Codex fallback when their model metadata is absent.
+runProviderCompactWithContextWindow
+    :: Maybe Int
+    -> Maybe OpenAiCompactionSender
+    -> (TokenUsage -> IO ())
+    -> Provider
+    -> Maybe TokenProvider
+    -> IORef ResponseCreateParams
+    -> IORef [ResponseItem]
+    -> Maybe Text
+    -> IO (Either Text CompactOutcome)
+runProviderCompactWithContextWindow contextWindow openAiSender recordUsage
+        provider tokenProvider
         paramsRef transcriptRef focus = do
     params <- readIORef paramsRef
     history <- readIORef transcriptRef
@@ -187,14 +206,17 @@ runProviderCompactWith openAiSender recordUsage provider tokenProvider
 
     summarizeTextAttempt sender params history focus
         | null history = pure (compactTextFailure "nothing to compact")
-        | otherwise =
-            mapCompactAttemptError formatApiError
-                <$> summarizePortableLocalAttempt
-                    sender
-                    params
-                    history
-                    (estimateItemsTokens history)
-                    focus
+        | otherwise = case configuredContextWindow params contextWindow of
+            Left message -> pure (compactTextFailure message)
+            Right limit ->
+                mapCompactAttemptError formatApiError
+                    <$> summarizePortableLocalAttempt
+                        limit
+                        sender
+                        params
+                        history
+                        (estimateItemsTokens history)
+                        focus
 
 -- | Run local-summary compaction through any stateless Responses-compatible
 -- sender, including user-configured local endpoints.
@@ -205,21 +227,52 @@ runResponsesCompactWith
     -> IORef [ResponseItem]
     -> Maybe Text
     -> IO (Either Text CompactOutcome)
-runResponsesCompactWith sender recordUsage paramsRef transcriptRef focus = do
+runResponsesCompactWith =
+    runResponsesCompactWithContextWindow Nothing
+
+runResponsesCompactWithContextWindow
+    :: Maybe Int
+    -> (ResponseCreateParams -> IO (Either ApiError Response))
+    -> (TokenUsage -> IO ())
+    -> IORef ResponseCreateParams
+    -> IORef [ResponseItem]
+    -> Maybe Text
+    -> IO (Either Text CompactOutcome)
+runResponsesCompactWithContextWindow contextWindow sender recordUsage
+        paramsRef transcriptRef focus = do
     params <- readIORef paramsRef
     history <- readIORef transcriptRef
     attempt <- runAttemptAndRecord recordUsage $
         if null history
             then pure (compactTextFailure "nothing to compact")
-            else
-                mapCompactAttemptError formatApiError
-                    <$> summarizePortableLocalAttempt
-                        sender
-                        params
-                        history
-                        (estimateItemsTokens history)
-                        focus
+            else case configuredContextWindow params contextWindow of
+                Left message -> pure (compactTextFailure message)
+                Right limit ->
+                    mapCompactAttemptError formatApiError
+                        <$> summarizePortableLocalAttempt
+                            limit
+                            sender
+                            params
+                            history
+                            (estimateItemsTokens history)
+                            focus
     pure attempt.compactAttemptResult
+
+configuredContextWindow
+    :: ResponseCreateParams
+    -> Maybe Int
+    -> Either Text Int
+configuredContextWindow _params = \case
+    Just contextWindow
+        | contextWindow > 0 -> Right contextWindow
+        | otherwise ->
+            Left "model context_window must be positive"
+    Nothing ->
+        Left
+            ( "the effective transport model has no context_window metadata; "
+                <> "add a positive context_window to its model catalog entry "
+                <> "before using /compact"
+            )
 
 compactTextFailure :: Text -> CompactAttempt Text
 compactTextFailure message =
@@ -443,29 +496,40 @@ summarizeLocalAttempt
     -> Int
     -> Maybe Text
     -> IO (CompactAttempt ApiError)
-summarizeLocalAttempt =
-    summarizeLocalAttemptWith id
+summarizeLocalAttempt send params history before focus =
+    summarizeLocalAttemptWith
+        (codexEffectiveContextWindowFor params.model)
+        id
+        send
+        params
+        history
+        before
+        focus
 
 summarizePortableLocalAttempt
-    :: OpenAiCompactionSender
-    -> ResponseCreateParams
-    -> [ResponseItem]
-    -> Int
-    -> Maybe Text
-    -> IO (CompactAttempt ApiError)
-summarizePortableLocalAttempt =
-    summarizeLocalAttemptWith
-        (filter isPortableLocalSummaryItem)
-
-summarizeLocalAttemptWith
-    :: ([ResponseItem] -> [ResponseItem])
+    :: Int
     -> OpenAiCompactionSender
     -> ResponseCreateParams
     -> [ResponseItem]
     -> Int
     -> Maybe Text
     -> IO (CompactAttempt ApiError)
-summarizeLocalAttemptWith prepareHistory send params history before focus
+summarizePortableLocalAttempt contextWindow =
+    summarizeLocalAttemptWith
+        contextWindow
+        (filter isPortableLocalSummaryItem)
+
+summarizeLocalAttemptWith
+    :: Int
+    -> ([ResponseItem] -> [ResponseItem])
+    -> OpenAiCompactionSender
+    -> ResponseCreateParams
+    -> [ResponseItem]
+    -> Int
+    -> Maybe Text
+    -> IO (CompactAttempt ApiError)
+summarizeLocalAttemptWith contextWindow prepareHistory send params history
+        before focus
     | null history =
         pure $ CompactAttempt emptyTokenUsage $
             Left (ProviderError InvalidRequestError "nothing to compact" Nothing)
@@ -492,8 +556,6 @@ summarizeLocalAttemptWith prepareHistory send params history before focus
                     , ..
                     }
             promptItem = userTextItem summaryPrompt
-            contextWindow =
-                codexEffectiveContextWindowFor summaryParams.model
             requestHistory =
                 trimResponseHistoryToFit
                     contextWindow

--- a/packages/agent-cli/src/Agent/CLI/Compaction.hs
+++ b/packages/agent-cli/src/Agent/CLI/Compaction.hs
@@ -6,6 +6,7 @@ module Agent.CLI.Compaction
     , autoCompactOpenAiBackend
     , autoCompactOpenAiBackendWithThreshold
     , autoCompactOpenAiBackendWithSender
+    , autoCompactOpenAiBackendWithSenderAndHook
     , autoCompactOpenAiBackendWith
     , autoCompactOpenAiBackendWithApi
     , compactOpenAIWith
@@ -32,14 +33,18 @@ import Agent.Loop
     )
 import qualified Agent.OpenAI.Client as OpenAI
 import Agent.OpenAI.Compaction
-    ( buildLocalCompactedHistory
+    ( buildLocalCompactedHistoryToFit
     , buildRemoteCompactedHistory
     , buildRemoteCompactionRequest
     , extractRemoteCompactionItem
     , estimateItemsTokens
+    , estimateRequestTokensWithItems
+    , estimateResponseCreateParamsTokens
+    , hasCompactionCheckpoint
     , remoteCompactionRetainedTokenBudget
     , summarizationPrompt
-    , trimRemoteCompactionHistoryToFit
+    , trimRemoteCompactionRequestToFit
+    , trimResponseHistoryToFit
     , userTextItem
     )
 import Agent.OpenAI.ModelMetadata
@@ -50,7 +55,6 @@ import Agent.OpenAI.ModelMetadata
 import Agent.Responses.LoopBackend
     ( assistantTextFromResponse
     , responseTokenUsage
-    , toolResultToItem
     , turnInputsToItems
     , withRequestInput
     )
@@ -69,7 +73,7 @@ import Control.Monad.Trans.Except
     ( ExceptT
     , throwE
     )
-import Control.Exception.Safe (mask, onException)
+import Control.Exception.Safe (catchAny, mask, onException)
 import Control.Monad (when)
 import Data.IORef (IORef, readIORef, writeIORef)
 import Data.Maybe (fromMaybe)
@@ -351,41 +355,66 @@ compactRemoteV2Attempt
     -> [ResponseItem]
     -> Int
     -> IO (CompactAttempt ApiError)
-compactRemoteV2Attempt send params history before
+compactRemoteV2Attempt send params history before =
+    compactRemoteV2AttemptWithRetainedBudget
+        send
+        params
+        history
+        before
+        (const remoteCompactionRetainedTokenBudget)
+
+compactRemoteV2AttemptWithRetainedBudget
+    :: OpenAiCompactionSender
+    -> ResponseCreateParams
+    -> [ResponseItem]
+    -> Int
+    -> (ResponseItem -> Int)
+    -> IO (CompactAttempt ApiError)
+compactRemoteV2AttemptWithRetainedBudget
+        send params history before retainedBudgetFor
     | null history =
         pure $ CompactAttempt emptyTokenUsage $
             Left (ProviderError InvalidRequestError "nothing to compact" Nothing)
     | otherwise = do
-        let requestHistory =
-                trimRemoteCompactionHistoryToFit
-                    (codexEffectiveContextWindowFor params.model)
-                    params.instructions
+        let contextWindow =
+                codexEffectiveContextWindowFor params.model
+            requestHistory =
+                trimRemoteCompactionRequestToFit
+                    contextWindow
+                    params
                     history
             request = buildRemoteCompactionRequest params requestHistory
-        send request >>= \case
-            Left err ->
-                pure (CompactAttempt emptyTokenUsage (Left err))
-            Right response ->
-                pure CompactAttempt
-                    { compactAttemptUsage = responseTokenUsage response
-                    , compactAttemptResult = do
-                        checkpoint <-
-                            either
-                                (Left . protocolError)
-                                Right
-                                (extractRemoteCompactionItem response)
-                        let items =
-                                buildRemoteCompactedHistory
-                                    remoteCompactionRetainedTokenBudget
-                                    history
-                                    checkpoint
-                        Right CompactOutcome
-                            { compactBeforeTokens = before
-                            , compactAfterTokens = estimateItemsTokens items
-                            , compactHistory = items
-                            , compactSummary = "Context compacted remotely."
+        if estimateResponseCreateParamsTokens request > contextWindow
+            then pure $ CompactAttempt emptyTokenUsage $
+                Left (requestTooLargeError "remote compaction")
+            else
+                send request >>= \case
+                    Left err ->
+                        pure (CompactAttempt emptyTokenUsage (Left err))
+                    Right response ->
+                        pure CompactAttempt
+                            { compactAttemptUsage = responseTokenUsage response
+                            , compactAttemptResult = do
+                                checkpoint <-
+                                    either
+                                        (Left . protocolError)
+                                        Right
+                                        (extractRemoteCompactionItem response)
+                                let items =
+                                        buildRemoteCompactedHistory
+                                            (max 0
+                                                (retainedBudgetFor checkpoint))
+                                            history
+                                            checkpoint
+                                Right CompactOutcome
+                                    { compactBeforeTokens = before
+                                    , compactAfterTokens =
+                                        estimateItemsTokens items
+                                    , compactHistory = items
+                                    , compactSummary =
+                                        "Context compacted remotely."
+                                    }
                             }
-                    }
   where
     protocolError message =
         ProviderError ApiErrorType message Nothing
@@ -413,34 +442,73 @@ summarizeLocalAttempt send params history before focus
                     , stream = Just True
                     , ..
                     }
+            promptItem = userTextItem summaryPrompt
+            contextWindow =
+                codexEffectiveContextWindowFor summaryParams.model
+            requestHistory =
+                trimResponseHistoryToFit
+                    contextWindow
+                    summaryParams
+                    [promptItem]
+                    history
             request =
                 withRequestInput
                     summaryParams
-                    (history <> [userTextItem summaryPrompt])
-        send request >>= \case
-            Left err ->
-                pure (CompactAttempt emptyTokenUsage (Left err))
-            Right response ->
-                pure CompactAttempt
-                    { compactAttemptUsage = responseTokenUsage response
-                    , compactAttemptResult =
-                        case assistantTextFromResponse response of
-                            Nothing ->
-                                Left (ProviderError ApiErrorType
-                                    "compaction produced no summary text"
-                                    Nothing)
-                            Just summary ->
-                                let items =
-                                        buildLocalCompactedHistory
-                                            6 history summary
-                                in Right CompactOutcome
-                                    { compactBeforeTokens = before
-                                    , compactAfterTokens =
-                                        estimateItemsTokens items
-                                    , compactHistory = items
-                                    , compactSummary = summary
-                                    }
-                    }
+                    (requestHistory <> [promptItem])
+        if estimateResponseCreateParamsTokens request > contextWindow
+            then pure $ CompactAttempt emptyTokenUsage $
+                Left (requestTooLargeError "local compaction")
+            else
+                send request >>= \case
+                    Left err ->
+                        pure (CompactAttempt emptyTokenUsage (Left err))
+                    Right response ->
+                        pure CompactAttempt
+                            { compactAttemptUsage = responseTokenUsage response
+                            , compactAttemptResult =
+                                if response.status /= ResponseCompleted
+                                    then Left (ProviderError ApiErrorType
+                                        ( "compaction response was not complete: "
+                                            <> Text.pack (show response.status)
+                                        )
+                                        Nothing)
+                                    else
+                                        case assistantTextFromResponse response of
+                                            Nothing ->
+                                                Left (ProviderError ApiErrorType
+                                                    "compaction produced no summary text"
+                                                    Nothing)
+                                            Just summary
+                                                | Text.null
+                                                    (Text.strip summary) ->
+                                                    Left
+                                                        (ProviderError ApiErrorType
+                                                            "compaction produced no summary text"
+                                                            Nothing)
+                                            Just summary ->
+                                                let items =
+                                                        buildLocalCompactedHistoryToFit
+                                                            contextWindow
+                                                            params
+                                                            6
+                                                            history
+                                                            summary
+                                                in if
+                                                    estimateRequestTokensWithItems
+                                                        params
+                                                        items
+                                                        > contextWindow
+                                                    then Left
+                                                        (requestTooLargeError
+                                                            "local compacted snapshot")
+                                                    else Right CompactOutcome
+                                                        { compactBeforeTokens = before
+                                                        , compactAfterTokens =
+                                                            estimateItemsTokens items
+                                                        , compactHistory = items
+                                                        , compactSummary = summary
+                                                        }
+                            }
 
 autoCompactOpenAiBackend
     :: TokenProvider
@@ -483,10 +551,35 @@ autoCompactOpenAiBackendWithSender
     -> Backend
 autoCompactOpenAiBackendWithSender configuredThreshold send recordUsage
         getParams contextTokensRef backend =
+    autoCompactOpenAiBackendWithSenderAndHook
+        configuredThreshold
+        send
+        recordUsage
+        getParams
+        (pure ())
+        contextTokensRef
+        backend
+
+-- | Variant that runs a best-effort hook after a compacted continuation is
+-- accepted. The root CLI uses it to queue fresh generated project/skill
+-- context for the next turn.
+autoCompactOpenAiBackendWithSenderAndHook
+    :: Maybe Int
+    -> OpenAiCompactionSender
+    -> (TokenUsage -> IO ())
+    -> IO ResponseCreateParams
+    -> IO ()
+    -> IORef (Maybe (Int, Int))
+    -> Backend
+    -> Backend
+autoCompactOpenAiBackendWithSenderAndHook configuredThreshold send recordUsage
+        getParams onCompacted contextTokensRef backend =
     autoCompactOpenAiBackendWithLimit
         getLimit
         compactAction
         recordUsage
+        estimateProjectedRequest
+        onCompacted
         contextTokensRef
         backend
   where
@@ -497,11 +590,29 @@ autoCompactOpenAiBackendWithSender configuredThreshold send recordUsage
             configuredThreshold
     compactAction history = do
         params <- getParams
-        compactRemoteV2Attempt
+        tokenLimit <- getLimit
+        let fixedRequestTokens =
+                estimateRequestTokensWithItems params []
+            retainedBudget checkpoint =
+                min remoteCompactionRetainedTokenBudget $
+                    max 0
+                        ( tokenLimit
+                            - fixedRequestTokens
+                            - estimateItemsTokens [checkpoint]
+                            - automaticCompactionHeadroom tokenLimit
+                        )
+        compactRemoteV2AttemptWithRetainedBudget
             send
             params
             history
             (estimateItemsTokens history)
+            retainedBudget
+    estimateProjectedRequest _ history inputs = do
+        params <- getParams
+        pure $
+            estimateRequestTokensWithItems
+                params
+                (history <> turnInputsToItems inputs)
 
 autoCompactOpenAiBackendWith
     :: IO (Either Text CompactOutcome)
@@ -516,6 +627,8 @@ autoCompactOpenAiBackendWith compactAction =
                 <$> fmap (either (Left . textCompactionError) Right)
                     compactAction))
         (const (pure ()))
+        estimateProjectedFromCache
+        (pure ())
   where
     textCompactionError message =
         ProviderError ApiErrorType message Nothing
@@ -530,38 +643,35 @@ autoCompactOpenAiBackendWithApi compactAction =
         (pure codexAutoCompactTokenLimit)
         (const (CompactAttempt emptyTokenUsage <$> compactAction))
         (const (pure ()))
+        estimateProjectedFromCache
+        (pure ())
 
 autoCompactOpenAiBackendWithLimit
     :: IO Int
     -> ([ResponseItem] -> IO (CompactAttempt ApiError))
     -> (TokenUsage -> IO ())
+    -> (Maybe (Int, Int) -> [ResponseItem] -> [TurnInput] -> IO Int)
+    -> IO ()
     -> IORef (Maybe (Int, Int))
     -> Backend
     -> Backend
 autoCompactOpenAiBackendWithLimit getLimit compactAction recordUsage
+        estimateProjected
+        onCompacted
         contextTokensRef
         (Backend submit) =
     Backend \history previous inputs onEvent -> do
         contextState <- readIORef contextTokensRef
         tokenLimit <- getLimit
-        let historyLength = length history
-            pendingItems = turnInputsToItems inputs
-            projectedTokens =
-                case contextState of
-                    Just (tokens, observedLength)
-                        | observedLength == historyLength ->
-                            tokens + estimateItemsTokens pendingItems
-                    _ ->
-                        estimateItemsTokens (history <> pendingItems)
-            shouldCompact =
-                not (null history)
+        projectedTokens <- estimateProjected contextState history inputs
+        let shouldCompact =
+                not (isSaturated contextState history)
+                    && not (null history)
                     && projectedTokens >= tokenLimit
-        if shouldCompact
-            then if any isCompletedTool inputs
-                then compactToolContinuation
-                    contextState history inputs onEvent
-                else compactThenSubmit
-                    contextState history inputs onEvent
+        if shouldCompact && not (any isCompletedTool inputs)
+            then compactThenSubmit
+                tokenLimit
+                contextState history inputs onEvent
             else submitAndTrack
                 contextState history previous inputs onEvent
   where
@@ -573,30 +683,7 @@ autoCompactOpenAiBackendWithLimit getLimit compactAction recordUsage
         CompletedTool{} -> True
         _ -> False
 
-    -- Tool outputs must be part of the checkpoint, but the wrapped backend has
-    -- not committed them yet. Absorb them into history before compaction, then
-    -- resume from the new checkpoint without sending them a second time.
-    compactToolContinuation oldTokens oldHistory inputs onEvent = do
-        mask \restore -> do
-            let (toolItems, remainingInputs) = absorbCompletedTools inputs
-                compactHistory = oldHistory <> toolItems
-                rollback = writeIORef contextTokensRef oldTokens
-            (do
-                onEvent (ActivityUpdated "Compacting context…")
-                restore (runCompaction compactHistory) >>= \case
-                    Left err -> do
-                        rollback
-                        pure (Left (automaticCompactionError err))
-                    Right outcome ->
-                        installSubmitAndTrack
-                            restore
-                            rollback
-                            outcome
-                            remainingInputs
-                            onEvent
-                ) `onException` rollback
-
-    compactThenSubmit oldTokens oldHistory inputs onEvent = do
+    compactThenSubmit tokenLimit oldTokens oldHistory inputs onEvent = do
         onEvent (ActivityUpdated "Compacting context…")
         runCompaction oldHistory >>= \case
                 Left err ->
@@ -607,19 +694,33 @@ autoCompactOpenAiBackendWithLimit getLimit compactAction recordUsage
                         installSubmitAndTrack
                             restore
                             rollback
+                            tokenLimit
                             outcome
                             inputs
                             onEvent
                             `onException` rollback
 
-    installSubmitAndTrack restore rollback outcome inputs onEvent = do
+    installSubmitAndTrack restore rollback tokenLimit outcome inputs onEvent = do
         let compactedHistory = outcome.compactHistory
         writeIORef contextTokensRef $
             Just (outcome.compactAfterTokens, length compactedHistory)
         result <- restore (submit compactedHistory Nothing inputs onEvent)
         case result of
             Left _ -> rollback
-            Right _ -> invalidateContextTokens
+            Right _ -> do
+                if outcome.compactAfterTokens >= tokenLimit
+                    then
+                        -- The checkpoint itself is larger than the
+                        -- configured trigger. Retaining this marker avoids
+                        -- repeatedly compacting a history that cannot be
+                        -- reduced below the threshold.
+                        writeIORef contextTokensRef $
+                            Just
+                                ( outcome.compactAfterTokens
+                                , saturatedCompactionHistoryLength
+                                )
+                    else invalidateContextTokens
+                onCompacted `catchAny` const (pure ())
         pure result
 
     submitAndTrack oldTokens history previous inputs onEvent = do
@@ -628,7 +729,12 @@ autoCompactOpenAiBackendWithLimit getLimit compactAction recordUsage
                 `onException` writeIORef contextTokensRef oldTokens
         case result of
             Left _ -> writeIORef contextTokensRef oldTokens
-            Right _ -> invalidateContextTokens
+            Right _ ->
+                case oldTokens of
+                    Just (_, observedLength)
+                        | observedLength == saturatedCompactionHistoryLength ->
+                            writeIORef contextTokensRef oldTokens
+                    _ -> invalidateContextTokens
         pure result
 
     -- Transcript state is committed by the loop after validating the response.
@@ -637,16 +743,6 @@ autoCompactOpenAiBackendWithLimit getLimit compactAction recordUsage
     -- leave token metadata describing an uncommitted transcript.
     invalidateContextTokens =
         writeIORef contextTokensRef Nothing
-
-    absorbCompletedTools =
-        foldr
-            (\input (toolItems, otherInputs) ->
-                case input of
-                    CompletedTool result ->
-                        (toolResultToItem result : toolItems, otherInputs)
-                    _ ->
-                        (toolItems, input : otherInputs))
-            ([], [])
 
     automaticCompactionError = \case
         ProviderError errorType message retryAfter ->
@@ -658,6 +754,38 @@ autoCompactOpenAiBackendWithLimit getLimit compactAction recordUsage
         CredentialError message ->
             CredentialError ("automatic compaction failed: " <> message)
         err -> err
+
+estimateProjectedFromCache
+    :: Maybe (Int, Int)
+    -> [ResponseItem]
+    -> [TurnInput]
+    -> IO Int
+estimateProjectedFromCache contextState history inputs =
+    pure $
+        case contextState of
+            Just (tokens, observedLength)
+                | observedLength >= 0
+                , observedLength == length history ->
+                    tokens + estimateItemsTokens pendingItems
+            _ ->
+                estimateItemsTokens (history <> pendingItems)
+  where
+    pendingItems = turnInputsToItems inputs
+
+saturatedCompactionHistoryLength :: Int
+saturatedCompactionHistoryLength = -1
+
+isSaturated :: Maybe (Int, Int) -> [ResponseItem] -> Bool
+isSaturated contextState history =
+    hasCompactionCheckpoint history
+        && case contextState of
+            Just (_, observedLength) ->
+                observedLength == saturatedCompactionHistoryLength
+            Nothing -> False
+
+automaticCompactionHeadroom :: Int -> Int
+automaticCompactionHeadroom tokenLimit =
+    max 1_024 (max 0 tokenLimit `div` 10)
 
 requireTokenProvider
     :: Provider
@@ -677,6 +805,12 @@ providerLabel = \case
     XAIProvider -> "xai"
     OpenRouterProvider -> "openrouter"
     ClaudeCodeProvider -> "claude-code"
+
+requestTooLargeError :: Text -> ApiError
+requestTooLargeError label =
+    ProviderError InvalidRequestError
+        (label <> " request cannot fit within the model context window")
+        Nothing
 
 hasFocus :: Maybe Text -> Bool
 hasFocus =

--- a/packages/agent-cli/src/Agent/CLI/ModelConfig.hs
+++ b/packages/agent-cli/src/Agent/CLI/ModelConfig.hs
@@ -11,6 +11,8 @@ module Agent.CLI.ModelConfig
     , ResponsesConnection(..)
     , builtinConnectionId
     , catalogConnection
+    , catalogContextWindowFor
+    , catalogContextWindowForTransport
     , catalogDefaultForProvider
     , catalogModelById
     , catalogModelsForConnection
@@ -82,6 +84,7 @@ data CatalogModel = CatalogModel
     , catalogModelConnectionId :: !Text
     , catalogModelWireId :: !Text
     , catalogModelDialect :: !DialectId
+    , catalogModelContextWindow :: !(Maybe Int)
     , catalogModelLabel :: !(Maybe Text)
     , catalogModelDefault :: !Bool
     , catalogModelFallbackPriority :: !(Maybe Int)
@@ -116,6 +119,7 @@ data ModelFile = ModelFile
     , modelFileConnection :: !Text
     , modelFileWireId :: !(Maybe Text)
     , modelFileDialect :: !Text
+    , modelFileContextWindow :: !(Maybe Int)
     , modelFileLabel :: !(Maybe Text)
     , modelFileDefault :: !Bool
     , modelFileFallbackPriority :: !(Maybe Int)
@@ -146,6 +150,7 @@ instance FromJSON ModelFile where
             <*> object .: "connection"
             <*> object .:? "model"
             <*> object .: "dialect"
+            <*> object .:? "context_window"
             <*> object .:? "label"
             <*> object .:? "default" .!= False
             <*> object .:? "fallback_priority"
@@ -160,6 +165,41 @@ builtinConnectionId = providerSlug
 catalogConnection :: ModelCatalog -> Text -> Maybe ModelConnection
 catalogConnection catalog connectionId =
     Map.lookup connectionId catalog.catalogConnections
+
+catalogContextWindowFor :: ModelCatalog -> Text -> Text -> Maybe Int
+catalogContextWindowFor catalog connectionId modelId = do
+    model <- catalogModelById catalog modelId
+    if model.catalogModelConnectionId == connectionId
+        then model.catalogModelContextWindow
+        else Nothing
+
+-- | Resolve the selected model's context window against the model actually
+-- sent to the provider. Environment-backed model maps may redirect a stable
+-- catalog id to another configured wire model; in that case, using the source
+-- model's limit could permit an oversized request.
+catalogContextWindowForTransport
+    :: ModelCatalog
+    -> Text
+    -> Text
+    -> Text
+    -> Maybe Int
+catalogContextWindowForTransport catalog connectionId modelId wireModelId = do
+    selected <- catalogModelById catalog modelId
+    if selected.catalogModelConnectionId /= connectionId
+        then Nothing
+        else
+            let effective
+                    | selected.catalogModelWireId == wireModelId =
+                        Just selected
+                    | otherwise =
+                        find
+                            (\candidate ->
+                                candidate.catalogModelConnectionId
+                                    == connectionId
+                                    && candidate.catalogModelWireId
+                                        == wireModelId)
+                            catalog.catalogModels
+            in effective >>= (.catalogModelContextWindow)
 
 catalogModelById :: ModelCatalog -> Text -> Maybe CatalogModel
 catalogModelById catalog modelId =
@@ -429,11 +469,18 @@ validateConfig source config = do
                 Left ("model " <> modelId
                     <> " fallback_priority must not be negative"))
             raw.modelFileFallbackPriority
+        traverse_
+            (\contextWindow -> when (contextWindow <= 0) $
+                Left ("model " <> modelId
+                    <> " context_window must be positive"))
+            raw.modelFileContextWindow
         pure CatalogModel
             { catalogModelId = modelId
             , catalogModelConnectionId = connectionId
             , catalogModelWireId = wireId
             , catalogModelDialect = dialect
+            , catalogModelContextWindow =
+                raw.modelFileContextWindow
             , catalogModelLabel =
                 nonEmptyText =<< raw.modelFileLabel
             , catalogModelDefault = raw.modelFileDefault

--- a/packages/agent-cli/src/Agent/CLI/Provider/OpenAI.hs
+++ b/packages/agent-cli/src/Agent/CLI/Provider/OpenAI.hs
@@ -6,7 +6,7 @@ module Agent.CLI.Provider.OpenAI
 
 import Agent.CLI.Compaction
     ( OpenAiCompactionSender
-    , autoCompactOpenAiBackendWithSender
+    , autoCompactOpenAiBackendWithSenderAndHook
     )
 import Agent.CLI.Connectivity (withConnectionRecovery)
 import Agent.Loop
@@ -62,10 +62,11 @@ lockedOpenAiSession
     -> IO ResponseCreateParams
     -> IORef (Maybe (Int, Int))
     -> (TokenUsage -> IO ())
+    -> IO ()
     -> (OpenAiCompactionSender, Backend)
 lockedOpenAiSession compactThreshold showRawReasoning wsLock fallbackActive
         provider activeConnection getParams contextTokens
-        recordCompactionUsage =
+        recordCompactionUsage onCompacted =
     let sendResponse request previousResponseId onEvent = do
             OpenAiPersistentConnection
                 credential
@@ -139,11 +140,12 @@ lockedOpenAiSession compactThreshold showRawReasoning wsLock fallbackActive
                                 sendHttpCompaction request
                         _ -> pure result
         compactingBackend =
-            autoCompactOpenAiBackendWithSender
+            autoCompactOpenAiBackendWithSenderAndHook
                 compactThreshold
                 compactSender
                 recordCompactionUsage
                 getParams
+                onCompacted
                 contextTokens
                 baseBackend
         turnScopedBackend =

--- a/packages/agent-cli/src/Agent/CLI/Resume.hs
+++ b/packages/agent-cli/src/Agent/CLI/Resume.hs
@@ -51,7 +51,7 @@ import Agent.CLI.Session
 import Agent.CLI.Style (roleMuted, rolePrompt, roleSuccess)
 import Agent.OpenAI.Compaction
     ( hasCompactionCheckpoint
-    , hasGeneratedContextItems
+    , hasReloadedGeneratedContextItems
     , isTranscriptResetTurn
     )
 import Agent.CLI.TextLayout
@@ -139,7 +139,7 @@ resumeNeedsGeneratedContext turns =
             null newerTurns
                 || not
                     (any
-                        (hasGeneratedContextItems . (.turnItems))
+                        (hasReloadedGeneratedContextItems . (.turnItems))
                         newerTurns)
   where
     isContextBoundary turn =

--- a/packages/agent-cli/src/Agent/CLI/Resume.hs
+++ b/packages/agent-cli/src/Agent/CLI/Resume.hs
@@ -23,6 +23,7 @@ module Agent.CLI.Resume
     , renderResumeFrame
     , renderResumeFrameFor
     , replaceResumeEntry
+    , resumeNeedsGeneratedContext
     , resumeEntryFromMeta
     , resumeEntriesFrom
     , resumeSearchEntries
@@ -48,6 +49,11 @@ import Agent.CLI.Session
     , loadSessionResumeStats
     )
 import Agent.CLI.Style (roleMuted, rolePrompt, roleSuccess)
+import Agent.OpenAI.Compaction
+    ( hasCompactionCheckpoint
+    , hasGeneratedContextItems
+    , isTranscriptResetTurn
+    )
 import Agent.CLI.TextLayout
     ( SplitPaneFrame(..)
     , clampSelectionIndex
@@ -120,6 +126,25 @@ data ResumeState = ResumeState
     , resumeIndex :: !Int
     }
     deriving (Eq, Show)
+
+-- | Reinstall generated project and skill context after the newest durable
+-- transcript-replacement boundary until a later persisted turn proves that
+-- the regenerated context was consumed. This also repairs sessions compacted
+-- by older clients that did not reload generated context.
+resumeNeedsGeneratedContext :: [SessionTurn] -> Bool
+resumeNeedsGeneratedContext turns =
+    case break isContextBoundary (reverse turns) of
+        (_, []) -> False
+        (newerTurns, _boundary : _) ->
+            null newerTurns
+                || not
+                    (any
+                        (hasGeneratedContextItems . (.turnItems))
+                        newerTurns)
+  where
+    isContextBoundary turn =
+        isTranscriptResetTurn turn.turnUserText
+            || hasCompactionCheckpoint turn.turnItems
 
 -- | Build picker entries from already loaded sessions.
 resumeEntriesFrom :: [(SessionMeta, [SessionTurn])] -> [ResumeEntry]

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration.hs
@@ -30,7 +30,7 @@ import Agent.CLI.Command ()
 import Agent.CLI.Compaction
     ( installLiveCompactOutcome,
       runProviderCompactWith,
-      runResponsesCompactWith )
+      runResponsesCompactWithContextWindow )
 import Agent.CLI.Config
     ( HarnessConfig(..),
       McpServerConfig(..),
@@ -72,6 +72,7 @@ import Agent.CLI.ModelConfig
       ResponsesConnection(..),
       builtinConnectionId,
       catalogConnection,
+      catalogContextWindowForTransport,
       loadModelCatalogAt )
 import Agent.CLI.Models
     ( defaultModelFor,
@@ -127,6 +128,7 @@ import Agent.CLI.ProviderTransition
                          transitionAutomaticBilling),
       TransitionCause(AutomaticFallback) )
 import Agent.CLI.Recap ()
+import Agent.CLI.Resume ( resumeNeedsGeneratedContext )
 import Agent.CLI.Render ( putTextLn )
 import Agent.CLI.ReplMode ()
 import Agent.CLI.Request ( requestParams )
@@ -297,6 +299,7 @@ import Agent.Provider
       TokenProvider,
       getNextToken,
       providerSlug,
+      runWithTokenProvider,
       tokenProvider,
       tokenProviderBillingMode )
 import Agent.Responses.GenericBackend
@@ -432,7 +435,7 @@ import qualified Data.Map.Strict as Map
 import qualified Agent.OpenAI.Auth as OpenAI
     ( discoverAccounts, getAccessTokenForAccount )
 import qualified Agent.OpenRouter as OpenRouter
-    ( clientOptionsFromEnv, mapModel )
+    ( clientOptionsFromEnv, createResponseWith, mapModel )
 import qualified Agent.OpenRouter.Usage as OpenRouterUsage ()
 import qualified Agent.Provider as Provider ( tokenProvider )
 import qualified Agent.CLI.Session.Lifecycle as SessionLifecycle ()
@@ -442,7 +445,9 @@ import qualified Data.Set as Set ()
 import qualified Data.Text as Text
     ( intercalate, null, pack, unpack )
 import qualified Data.Text.IO as Text ( hPutStr )
+import qualified Agent.XAI.Client as XAIClient ( createResponseWith )
 import qualified Agent.XAI.Options as XAI ( clientOptionsFromEnv )
+import qualified Agent.XAI.Request as XAIRequest ( mapModel )
 import qualified Agent.XAI.Usage as XAIUsage ()
 
 import Agent.CLI.Runtime.Orchestration.Types
@@ -2030,6 +2035,8 @@ runAgentInitializedWithLock
                 (schemasFromAppTools dialect tools) effort
             initialItems = maybe [] (foldSessionItems . snd) resumed
             initialTurns = maybe [] snd resumed
+            resumeNeedsFreshContext =
+                resumeNeedsGeneratedContext initialTurns
             initialPrevious = case transition of
                 Just _ -> Nothing
                 Nothing
@@ -2037,7 +2044,17 @@ runAgentInitializedWithLock
                     | otherwise ->
                         resumed >>= \(meta, _) -> meta.metaLastResponseId
         paramsRef <- newIORef params
-        let subagentRuntime = SubagentRuntime
+        generatedContextReloadRef <- newIORef (pure ())
+        let currentModelContextWindow mapTransportModel = do
+                currentParams <- readIORef paramsRef
+                pure $ do
+                    currentModel <- currentParams.model
+                    catalogContextWindowForTransport
+                        catalog
+                        inferredTarget.targetConnectionId
+                        currentModel
+                        (mapTransportModel currentModel)
+            subagentRuntime = SubagentRuntime
                 { subagentOptions = options
                 , subagentGhciEnabled = ghciEnabledRef
                 , subagentBashEnabled = bashEnabledRef
@@ -2086,8 +2103,12 @@ runAgentInitializedWithLock
                 dialect
                 home
                 cwd
-                (if refreshDialectContext then [] else initialItems)
-                (if refreshDialectContext then Nothing else initialPrevious)
+                (if refreshDialectContext || resumeNeedsFreshContext
+                    then []
+                    else initialItems)
+                (if refreshDialectContext || resumeNeedsFreshContext
+                    then Nothing
+                    else initialPrevious)
         -- Fullscreen sessions load skills after Brick has taken over the
         -- terminal, so filesystem discovery cannot delay the first frame.
         -- Minimal and one-shot sessions still initialize them synchronously
@@ -2169,6 +2190,7 @@ runAgentInitializedWithLock
                                 , tokenProvider = sessionTokenProvider
                                 , openAiPool = sessionOpenAiPool
                                 , startupContext
+                                , generatedContextReloadRef
                                 , skillsRef
                                 , skillInvocationsRef
                                 , escPaused
@@ -2424,6 +2446,7 @@ runAgentInitializedWithLock
                                             (readIORef paramsRef)
                                             contextTokensRef
                                             recordCompactionUsage
+                                            (readIORef generatedContextReloadRef >>= id)
                                     noticingBackend =
                                         withPendingInputs pendingNotices
                                             lockedBackend
@@ -2534,14 +2557,22 @@ runAgentInitializedWithLock
                                 xaiBackend xaiOptions tokenProvider
                                     (pure privateParams)
                             compactRunner focus = do
+                                contextWindow <-
+                                    currentModelContextWindow
+                                        (XAIRequest.mapModel xaiOptions)
                                 historyRef <-
                                     newIORef =<< readLiveTranscript conversationRef
                                 installLiveCompactOutcome conversationRef Nothing
-                                    (runProviderCompactWith
-                                        Nothing
+                                    (runResponsesCompactWithContextWindow
+                                        contextWindow
+                                        (\request ->
+                                            runWithTokenProvider tokenProvider
+                                                \credential ->
+                                                    XAIClient.createResponseWith
+                                                        xaiOptions
+                                                        credential
+                                                        request)
                                         recordCompactionUsage
-                                        provider
-                                        (Just tokenProvider)
                                         paramsRef
                                         historyRef)
                                     focus
@@ -2679,12 +2710,15 @@ runAgentInitializedWithLock
                                 makeBackend
                                     (pure privateParams)
                             compactRunner focus = do
+                                contextWindow <-
+                                    currentModelContextWindow transportModel
                                 historyRef <-
                                     newIORef =<< readLiveTranscript conversationRef
                                 installLiveCompactOutcome conversationRef Nothing
                                     (case customGenericOptions of
                                         Just genericOptions ->
-                                            runResponsesCompactWith
+                                            runResponsesCompactWithContextWindow
+                                                contextWindow
                                                 (\request ->
                                                     GenericResponses.createResponseWith
                                                         genericOptions
@@ -2699,11 +2733,17 @@ runAgentInitializedWithLock
                                                 paramsRef
                                                 historyRef
                                         Nothing ->
-                                            runProviderCompactWith
-                                                Nothing
+                                            runResponsesCompactWithContextWindow
+                                                contextWindow
+                                                (\request ->
+                                                    runWithTokenProvider
+                                                        tokenProvider
+                                                        \credential ->
+                                                            OpenRouter.createResponseWith
+                                                                openRouterOptions
+                                                                credential
+                                                                request)
                                                 recordCompactionUsage
-                                                provider
-                                                (Just tokenProvider)
                                                 paramsRef
                                                 historyRef)
                                     focus

--- a/packages/agent-cli/src/Agent/CLI/Session/Runner.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner.hs
@@ -70,6 +70,7 @@ import Agent.CLI.Project
     )
 import Agent.CLI.Prompt
     ( systemPromptForTools )
+import Agent.CLI.Resume (resumeNeedsGeneratedContext)
 import Agent.CLI.ProviderTransition
     ( PendingTurn(..)
     , TurnResult(..)
@@ -552,20 +553,7 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
                                     <> Text.pack (show omitted)
                                     <> " omitted from model context due to the context budget")
                         pure learnedSkills
-        sessionReset = do
-            resetLiveConversationWith
-                resetBackendState
-                conversationRef
-                planMode
-            writeIORef usageRef emptyTokenUsage
-            writeIORef lastAssistantRef Nothing
-            writeIORef pendingNotices []
-            writeIORef subagentSessions Map.empty
-            writeIORef selectedAgent AgentRoot
-            writeIORef agentStepCache Map.empty
-            case multiCtx of
-                Just ctx -> resetSubagentRegistry ctx.multiRegistry
-                Nothing -> pure ()
+        reloadGeneratedContext = do
             freshAgents <-
                 loadAgentsContext
                     stderrHandle
@@ -585,6 +573,21 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
                 defaultLearnedSkillContextMaxChars
             fresh <- readIORef freshAgents
             writeIORef startupContext fresh
+        sessionReset = do
+            resetLiveConversationWith
+                resetBackendState
+                conversationRef
+                planMode
+            writeIORef usageRef emptyTokenUsage
+            writeIORef lastAssistantRef Nothing
+            writeIORef pendingNotices []
+            writeIORef subagentSessions Map.empty
+            writeIORef selectedAgent AgentRoot
+            writeIORef agentStepCache Map.empty
+            case multiCtx of
+                Just ctx -> resetSubagentRegistry ctx.multiRegistry
+                Nothing -> pure ()
+            reloadGeneratedContext
         refreshSkills queueContext = do
             refreshed <- loadSkillsCatalogQuiet
                 options home projectRoot cwd
@@ -874,11 +877,18 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
     btwRequests <- newChan
     recapRequests <- newChan
     let
+        compactRunnerWithContext focus = do
+            result <- compactRunner focus
+            case result of
+                Left _ -> pure ()
+                Right _ ->
+                    reloadGeneratedContext `catchAny` \_ -> pure ()
+            pure result
         env = SessionEnv
             { sessionLoop = config
             , sessionBtwBackend = btwBackend
             , sessionQueueRecap = writeChan recapRequests
-            , sessionCompact = compactRunner
+            , sessionCompact = compactRunnerWithContext
             , sessionRender = render
             , sessionProvider = provider
             , sessionConnection = connectionId
@@ -939,6 +949,7 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
             , sessionOnPersisted = onPersisted
             , sessionReset = sessionReset
             }
+    writeIORef generatedContextReloadRef reloadGeneratedContext
     writeIORef startup.startupRestartEffort \level -> do
         setSessionEffort env level
         writeIORef restartEffortRef (Just level)
@@ -960,7 +971,8 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
             skills <- loadSkillsCatalogQuiet
                 options home projectRoot cwd
             let queueInitialContext =
-                    null initialTurns && not (isJust initialPrevious)
+                    resumeNeedsGeneratedContext initialTurns
+                        || (null initialTurns && isNothing initialPrevious)
             (omitted, _) <- installSkills startupContext
                 queueInitialContext
                 skills

--- a/packages/agent-cli/src/Agent/CLI/Session/Runtime/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runtime/Types.hs
@@ -120,6 +120,7 @@ data SessionRequest = SessionRequest
     , tokenProvider :: !(Maybe TokenProvider)
     , openAiPool :: !(Maybe OpenAI.Pool)
     , startupContext :: !(IORef (Maybe Text))
+    , generatedContextReloadRef :: !(IORef (IO ()))
     , skillsRef :: !(IORef SkillCatalog)
     , skillInvocationsRef :: !(IORef [SkillInvocation])
     , escPaused :: !(IORef Bool)

--- a/packages/agent-cli/src/Agent/CLI/StartupContext.hs
+++ b/packages/agent-cli/src/Agent/CLI/StartupContext.hs
@@ -38,7 +38,8 @@ import System.IO (Handle)
 import System.OsPath (OsPath)
 
 -- | Discover AGENTS.md once for a fresh session. Resumed transcripts keep
--- whatever instructions were already in history.
+-- whatever instructions were already in history; callers pass an empty
+-- history after a persisted transcript-replacement boundary.
 loadAgentsContext
     :: Handle
     -> Maybe FullscreenRuntime

--- a/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
@@ -22,6 +22,7 @@ import Agent.OpenAI.Compaction
     , estimateRequestTokensWithItems
     , estimateResponseCreateParamsTokens
     , hasCompactionCheckpoint
+    , summarizationPrompt
     , userTextItem
     )
 import Agent.OpenAI.ModelMetadata (codexEffectiveContextWindowFor)
@@ -156,6 +157,57 @@ spec = do
                     "compaction response was not complete"
                         `Text.isInfixOf` message
                 Right _ -> False
+
+        it "clears tool and continuation controls for local summaries" do
+            let paramsValue =
+                    (defaultResponseCreateParams :: ResponseCreateParams)
+                        { tools =
+                            Just
+                                [ FunctionToolValue FunctionTool
+                                    { name = "must_call"
+                                    , description = Nothing
+                                    , parameters = Nothing
+                                    , strict = Just True
+                                    , extraFields = mempty
+                                    }
+                                ]
+                        , toolChoice =
+                            Just (ToolChoiceMode ToolChoiceRequired)
+                        , maxToolCalls = Just 1
+                        , previousResponseId = Just "resp-old"
+                        , conversation = Just (ConversationId "conv-old")
+                        }
+            params <- newIORef paramsValue
+            transcript <- newIORef [userTextItem "old context"]
+            requests <- newIORef []
+            result <-
+                runProviderCompactWith
+                    (Just \request -> do
+                        modifyIORef' requests (<> [request])
+                        pure (Right (summaryResponse "summary")))
+                    (const (pure ()))
+                    OpenAIProvider
+                    Nothing
+                    params
+                    transcript
+                    (Just "focus")
+            result `shouldSatisfy` either (const False) (const True)
+            readIORef requests `shouldReturn`
+                [ paramsValue
+                    { tools = Nothing
+                    , toolChoice = Nothing
+                    , maxToolCalls = Nothing
+                    , parallelToolCalls = Just False
+                    , previousResponseId = Nothing
+                    , conversation = Nothing
+                    , input = Just
+                        (ResponseInputItems
+                            [ userTextItem "old context"
+                            , userTextItem (summarizationPrompt (Just "focus"))
+                            ])
+                    , stream = Just True
+                    }
+                ]
 
         it "bounds oversized local-summary requests before sending them" do
             params <- newIORef defaultResponseCreateParams
@@ -336,21 +388,38 @@ spec = do
             readIORef contextState `shouldReturn` oldContextState
 
         it "includes tool schemas when deciding whether to compact" do
-            let history = [userTextItem "old"]
-                threshold = 200
+            let history =
+                    [userTextItem (Text.replicate 12_000 "old context ")]
                 params = (defaultResponseCreateParams :: ResponseCreateParams)
                     { tools = Just
                         [ FunctionToolValue FunctionTool
                             { name = "large_tool"
                             , description =
-                                Just (Text.replicate 2_000 "schema")
+                                Just (Text.replicate 4_000 "schema")
                             , parameters = Nothing
                             , strict = Just True
                             , extraFields = mempty
                             }
                         ]
                     }
-            contextState <- newIORef (Just (1, length history))
+                paramsWithoutTools =
+                    defaultResponseCreateParams :: ResponseCreateParams
+                projectedItems = history <> [userTextItem "new"]
+                projectedWithoutTools =
+                    estimateRequestTokensWithItems
+                        paramsWithoutTools
+                        projectedItems
+                projectedWithTools =
+                    estimateRequestTokensWithItems params projectedItems
+                threshold =
+                    projectedWithoutTools
+                        + ((projectedWithTools - projectedWithoutTools) `div` 2)
+            estimateRequestTokensWithItems params []
+                `shouldSatisfy` (< threshold)
+            projectedWithoutTools `shouldSatisfy` (< threshold)
+            projectedWithTools `shouldSatisfy` (>= threshold)
+            contextState <-
+                newIORef (Just (projectedWithoutTools, length history))
             compactCalls <- newIORef (0 :: Int)
             let sender _request = do
                     modifyIORef' compactCalls (+ 1)
@@ -409,6 +478,44 @@ spec = do
             compacted <- readIORef seenHistory
             estimateRequestTokensWithItems params compacted
                 `shouldSatisfy` (< threshold)
+
+        it "reserves pending input when sizing the compacted continuation" do
+            let pendingText = Text.replicate 6_000 "pending "
+                pendingItem = userTextItem pendingText
+                params = defaultResponseCreateParams
+                threshold =
+                    estimateRequestTokensWithItems params [pendingItem]
+                        + 8_000
+                history =
+                    [userTextItem (Text.replicate 30_000 "old ")]
+            contextState <- newIORef Nothing
+            continuationTokens <- newIORef 0
+            let sender _request =
+                    pure (Right remoteCompactionResponse)
+                base = Backend \state _ _ _ -> do
+                    writeIORef continuationTokens $
+                        estimateRequestTokensWithItems
+                            params
+                            (state <> [pendingItem])
+                    pure $ successful state TurnOutput
+                        { responseId = "resp-new"
+                        , toolCalls = []
+                        , assistantText = Just "ok"
+                        , tokenUsage = TokenUsage 20 5 0
+                        }
+                backend =
+                    autoCompactOpenAiBackendWithSender
+                        (Just threshold)
+                        sender
+                        (const (pure ()))
+                        (pure params)
+                        contextState
+                        base
+            result <- backend.submitTurn history Nothing
+                [UserMessage pendingText] (const (pure ()))
+            result `shouldSatisfy` either (const False) (const True)
+            tokens <- readIORef continuationTokens
+            tokens `shouldSatisfy` (< threshold)
 
         it "rejects a tiny threshold before starting compaction" do
             let history = [userTextItem "old"]

--- a/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
@@ -5,6 +5,7 @@ import Agent.CLI.Compaction
     , autoCompactOpenAiBackendWith
     , autoCompactOpenAiBackendWithApi
     , autoCompactOpenAiBackendWithSender
+    , autoCompactOpenAiBackendWithSenderAndHook
     , autoCompactOpenAiBackendWithThreshold
     , codexAutoCompactTokenLimit
     , compactOpenAIWith
@@ -16,10 +17,14 @@ import Agent.CLI.Connectivity (withConnectionRecoveryUsing)
 import Agent.Error (ApiError(..), ErrorType(..))
 import Agent.Loop
 import Agent.OpenAI.Compaction
-    ( compactionTriggerItem
+    ( assistantSummaryItem
+    , compactionTriggerItem
+    , estimateRequestTokensWithItems
+    , estimateResponseCreateParamsTokens
     , hasCompactionCheckpoint
     , userTextItem
     )
+import Agent.OpenAI.ModelMetadata (codexEffectiveContextWindowFor)
 import Agent.ToolDispatch
     ( ToolCallKind(..)
     , ToolCallResult(..)
@@ -131,6 +136,122 @@ spec = do
                 Right _ -> False
             readIORef recordedUsage `shouldReturn` [compactionUsage]
 
+        it "rejects incomplete local summaries" do
+            params <- newIORef defaultResponseCreateParams
+            transcript <- newIORef [userTextItem "old context"]
+            result <-
+                runProviderCompactWith
+                    (Just \_ ->
+                        pure (Right (summaryResponseWithStatus
+                            "incomplete"
+                            "partial summary")))
+                    (const (pure ()))
+                    OpenAIProvider
+                    Nothing
+                    params
+                    transcript
+                    (Just "focus")
+            result `shouldSatisfy` \case
+                Left message ->
+                    "compaction response was not complete"
+                        `Text.isInfixOf` message
+                Right _ -> False
+
+        it "bounds oversized local-summary requests before sending them" do
+            params <- newIORef defaultResponseCreateParams
+            let huge = Text.replicate 1_100_000 "x"
+            transcript <- newIORef
+                [ userTextItem huge
+                , userTextItem "recent request"
+                ]
+            requests <- newIORef []
+            result <-
+                runProviderCompactWith
+                    (Just \request -> do
+                        modifyIORef' requests (<> [request])
+                        pure (Right (summaryResponse "bounded summary")))
+                    (const (pure ()))
+                    OpenAIProvider
+                    Nothing
+                    params
+                    transcript
+                    (Just "focus")
+            result `shouldSatisfy` either (const False) (const True)
+            seen <- readIORef requests
+            case seen of
+                [request] -> do
+                    estimateResponseCreateParamsTokens request
+                        `shouldSatisfy`
+                            (<= codexEffectiveContextWindowFor
+                                defaultResponseCreateParams.model)
+                    requestItems request `shouldSatisfy` \items ->
+                        all
+                            (\case
+                                MessageItem message ->
+                                    case message.content of
+                                        MessageContentText text ->
+                                            Text.length text < Text.length huge
+                                        MessageContentParts parts ->
+                                            all
+                                                (\case
+                                                    InputTextPart { text } ->
+                                                        Text.length text
+                                                            < Text.length huge
+                                                    _ -> True)
+                                                parts
+                                _ -> True)
+                            items
+                _ -> expectationFailure
+                    ("expected one local compaction request, got "
+                        <> show (length seen))
+
+        it "bounds the installed local snapshot after summarization" do
+            let paramsValue = defaultResponseCreateParams
+                contextWindow =
+                    codexEffectiveContextWindowFor paramsValue.model
+                history =
+                    [ userTextItem
+                        (Text.replicate 180_000
+                            ("message-" <> Text.pack (show index)))
+                    | index <- [1 :: Int .. 6]
+                    ]
+            params <- newIORef paramsValue
+            transcript <- newIORef history
+            result <-
+                runProviderCompactWith
+                    (Just \_ -> pure (Right (summaryResponse "bounded summary")))
+                    (const (pure ()))
+                    OpenAIProvider
+                    Nothing
+                    params
+                    transcript
+                    (Just "focus")
+            case result of
+                Left err -> expectationFailure (Text.unpack err)
+                Right outcome ->
+                    estimateRequestTokensWithItems
+                        paramsValue
+                        outcome.compactHistory
+                        `shouldSatisfy` (<= contextWindow)
+
+        it "rejects blank local summaries" do
+            params <- newIORef defaultResponseCreateParams
+            transcript <- newIORef [userTextItem "old context"]
+            result <-
+                runProviderCompactWith
+                    (Just \_ -> pure (Right (summaryResponse "   ")))
+                    (const (pure ()))
+                    OpenAIProvider
+                    Nothing
+                    params
+                    transcript
+                    (Just "focus")
+            result `shouldSatisfy` \case
+                Left message ->
+                    "compaction produced no summary text"
+                        `Text.isInfixOf` message
+                Right _ -> False
+
         it "does not record usage for a transport failure" do
             params <- newIORef defaultResponseCreateParams
             transcript <- newIORef [userTextItem "old context"]
@@ -213,6 +334,144 @@ spec = do
             readIORef previous `shouldReturn` Just "resp-old"
             readIORef transcript `shouldReturn` oldHistory
             readIORef contextState `shouldReturn` oldContextState
+
+        it "includes tool schemas when deciding whether to compact" do
+            let history = [userTextItem "old"]
+                threshold = 200
+                params = (defaultResponseCreateParams :: ResponseCreateParams)
+                    { tools = Just
+                        [ FunctionToolValue FunctionTool
+                            { name = "large_tool"
+                            , description =
+                                Just (Text.replicate 2_000 "schema")
+                            , parameters = Nothing
+                            , strict = Just True
+                            , extraFields = mempty
+                            }
+                        ]
+                    }
+            contextState <- newIORef (Just (1, length history))
+            compactCalls <- newIORef (0 :: Int)
+            let sender _request = do
+                    modifyIORef' compactCalls (+ 1)
+                    pure (Right remoteCompactionResponse)
+                base = Backend \state _ _ _ ->
+                    pure $ successful state TurnOutput
+                        { responseId = "resp-new"
+                        , toolCalls = []
+                        , assistantText = Just "ok"
+                        , tokenUsage = TokenUsage 20 5 0
+                        }
+                backend =
+                    autoCompactOpenAiBackendWithSender
+                        (Just threshold)
+                        sender
+                        (const (pure ()))
+                        (pure params)
+                        contextState
+                        base
+            result <- backend.submitTurn history (Just "resp-old")
+                [UserMessage "new"] (const (pure ()))
+            result `shouldSatisfy` either (const False) (const True)
+            readIORef compactCalls `shouldReturn` 1
+
+        it "shrinks retained history below low automatic thresholds" do
+            let history =
+                    [ userTextItem (Text.replicate 200
+                        ("message-" <> Text.pack (show index)))
+                    | index <- [1 :: Int .. 100]
+                    ]
+                threshold = 5_000
+                params = defaultResponseCreateParams
+            contextState <- newIORef Nothing
+            seenHistory <- newIORef []
+            let sender _request =
+                    pure (Right remoteCompactionResponse)
+                base = Backend \state _ _ _ -> do
+                    writeIORef seenHistory state
+                    pure $ successful state TurnOutput
+                        { responseId = "resp-new"
+                        , toolCalls = []
+                        , assistantText = Just "ok"
+                        , tokenUsage = TokenUsage 20 5 0
+                        }
+                backend =
+                    autoCompactOpenAiBackendWithSender
+                        (Just threshold)
+                        sender
+                        (const (pure ()))
+                        (pure params)
+                        contextState
+                        base
+            result <- backend.submitTurn history Nothing
+                [UserMessage "new"] (const (pure ()))
+            result `shouldSatisfy` either (const False) (const True)
+            compacted <- readIORef seenHistory
+            estimateRequestTokensWithItems params compacted
+                `shouldSatisfy` (< threshold)
+
+        it "does not loop when the checkpoint exceeds a tiny threshold" do
+            let history = [userTextItem "old"]
+                threshold = 1
+                params = defaultResponseCreateParams
+            contextState <- newIORef Nothing
+            compactCalls <- newIORef (0 :: Int)
+            seenHistory <- newIORef []
+            let sender _request = do
+                    modifyIORef' compactCalls (+ 1)
+                    pure (Right remoteCompactionResponse)
+                base = Backend \state _ _ _ -> do
+                    writeIORef seenHistory state
+                    pure $ successful state TurnOutput
+                        { responseId = "resp-new"
+                        , toolCalls = []
+                        , assistantText = Just "ok"
+                        , tokenUsage = TokenUsage 20 5 0
+                        }
+                backend =
+                    autoCompactOpenAiBackendWithSender
+                        (Just threshold)
+                        sender
+                        (const (pure ()))
+                        (pure params)
+                        contextState
+                        base
+            first <- backend.submitTurn history Nothing
+                [UserMessage "new"] (const (pure ()))
+            first `shouldSatisfy` either (const False) (const True)
+            compacted <- readIORef seenHistory
+            second <- backend.submitTurn compacted Nothing
+                [UserMessage "again"] (const (pure ()))
+            second `shouldSatisfy` either (const False) (const True)
+            readIORef compactCalls `shouldReturn` 1
+
+        it "runs the post-compaction hook only after a successful continuation" do
+            let history = [userTextItem "old"]
+                threshold = 20
+            contextState <- newIORef (Just (threshold, length history))
+            hookCalls <- newIORef (0 :: Int)
+            let sender _request =
+                    pure (Right remoteCompactionResponse)
+                base = Backend \state _ _ _ ->
+                    pure $ successful state TurnOutput
+                        { responseId = "resp-new"
+                        , toolCalls = []
+                        , assistantText = Just "ok"
+                        , tokenUsage = TokenUsage 20 5 0
+                        }
+                backend =
+                    autoCompactOpenAiBackendWithSenderAndHook
+                        (Just threshold)
+                        sender
+                        (const (pure ()))
+                        (pure defaultResponseCreateParams)
+                        (modifyIORef' hookCalls (+ 1))
+                        contextState
+                        base
+            result <- backend.submitTurn history Nothing
+                [UserMessage "new"] (const (pure ()))
+            result `shouldSatisfy` either (const False) (const True)
+            readIORef hookCalls `shouldReturn` 1
 
     describe "compactOpenAIWith" do
         it "uses remote compaction v2 on normal Responses" do
@@ -304,7 +563,10 @@ spec = do
                 Right outcome -> do
                     outcome.compactSummary `shouldBe` "local summary"
                     outcome.compactHistory
-                        `shouldSatisfy` hasCompactionCheckpoint
+                        `shouldBe`
+                            [ userTextItem "old context"
+                            , assistantSummaryItem "local summary"
+                            ]
             seen <- readIORef requests
             map (.tools) seen `shouldBe` [Nothing]
             map (.parallelToolCalls) seen `shouldBe` [Just False]
@@ -409,17 +671,19 @@ spec = do
             contextState <- newIORef oldContextState
             requests <- newIORef []
             recordedUsage <- newIORef []
+            hookCalls <- newIORef (0 :: Int)
             let sender request = do
                     modifyIORef' requests (<> [request])
                     pure (Right remoteCompactionResponse)
                 base = Backend \_ _ _ _ ->
                     pure (Left (ConnectionError "continuation failed"))
                 backend =
-                    autoCompactOpenAiBackendWithSender
+                    autoCompactOpenAiBackendWithSenderAndHook
                         (Just threshold)
                         sender
                         (\usage -> modifyIORef' recordedUsage (<> [usage]))
                         (pure defaultResponseCreateParams)
+                        (modifyIORef' hookCalls (+ 1))
                         contextState
                         base
             backend.submitTurn history Nothing
@@ -429,6 +693,7 @@ spec = do
                 `shouldReturn` [history <> [compactionTriggerItem]]
             readIORef recordedUsage `shouldReturn` [compactionUsage]
             readIORef contextState `shouldReturn` oldContextState
+            readIORef hookCalls `shouldReturn` 0
 
         it "rolls back compacted state when the continuation is cancelled" do
             let history = [userTextItem "old"]
@@ -509,7 +774,7 @@ spec = do
             readIORef seenPrevious `shouldReturn` [Nothing, Nothing]
             readIORef recordedUsage `shouldReturn` [compactionUsage]
 
-        it "compacts when a pending tool output crosses the limit" do
+        it "defers compaction while continuing a completed tool call" do
             let danglingCall = FunctionCallItem FunctionCall
                     { itemId = Nothing
                     , callId = "call-1"
@@ -531,13 +796,10 @@ spec = do
                 (Just (codexAutoCompactTokenLimit - 10, length oldHistory))
             compactCalls <- newIORef (0 :: Int)
             recordedUsage <- newIORef []
-            historyAtCompact <- newIORef []
             seenPrevious <- newIORef []
             seenInputs <- newIORef []
-            let sender request = do
+            let sender _request = do
                     modifyIORef' compactCalls (+ 1)
-                    writeIORef historyAtCompact
-                        (init (requestItems request))
                     pure (Right remoteCompactionResponse)
                 base = Backend \state previous inputs _ -> do
                     modifyIORef' seenPrevious (<> [previous])
@@ -560,20 +822,12 @@ spec = do
             result <- backend.submitTurn oldHistory (Just "resp-tool") inputs
                 (const (pure ()))
             result `shouldSatisfy` either (const False) (const True)
-            readIORef compactCalls `shouldReturn` 1
-            compactInput <- readIORef historyAtCompact
-            compactInput `shouldSatisfy` \items ->
-                case reverse items of
-                    FunctionCallOutputItem output : _ ->
-                        output.callId == "call-1"
-                            && output.output == Aeson.String toolOutputText
-                    _ -> False
-            readIORef seenPrevious `shouldReturn` [Nothing]
-            readIORef seenInputs `shouldReturn` [[]]
-            let compacted = either (const []) (.backendState) result
-            compacted `shouldSatisfy` hasCompactionCheckpoint
+            readIORef compactCalls `shouldReturn` 0
+            readIORef seenPrevious `shouldReturn` [Just "resp-tool"]
+            readIORef seenInputs `shouldReturn` [inputs]
+            fmap (.backendState) result `shouldBe` Right oldHistory
             readIORef contextState `shouldReturn` Nothing
-            readIORef recordedUsage `shouldReturn` [compactionUsage]
+            readIORef recordedUsage `shouldReturn` []
 
         it "preserves typed provider failures from automatic compaction" do
             let history = [userTextItem "old"]
@@ -689,10 +943,14 @@ withModel nextModel ResponseCreateParams { model = _, .. } =
 
 summaryResponse :: Text -> Response
 summaryResponse summary =
+    summaryResponseWithStatus "completed" summary
+
+summaryResponseWithStatus :: Text -> Text -> Response
+summaryResponseWithStatus responseStatus summary =
     case Aeson.fromJSON $ Aeson.object
         [ "id" .= ("resp-summary" :: Text)
         , "created_at" .= (0 :: Int)
-        , "status" .= ("completed" :: Text)
+        , "status" .= responseStatus
         , "model" .= ("gpt-test" :: Text)
         , "output" .=
             [ Aeson.object

--- a/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
@@ -13,6 +13,7 @@ import Agent.CLI.Compaction
     , runProviderCompact
     , runProviderCompactWith
     , runResponsesCompactWith
+    , runResponsesCompactWithContextWindow
     )
 import Agent.CLI.Connectivity (withConnectionRecoveryUsing)
 import Agent.Error (ApiError(..), ErrorType(..))
@@ -232,7 +233,8 @@ spec = do
             transcript <- newIORef history
             requests <- newIORef []
             result <-
-                runResponsesCompactWith
+                runResponsesCompactWithContextWindow
+                    (Just 258_400)
                     (\request -> do
                         modifyIORef' requests (<> [request])
                         pure (Right (summaryResponse "summary")))
@@ -298,7 +300,8 @@ spec = do
             transcript <- newIORef [remoteCheckpoint]
             requests <- newIORef (0 :: Int)
             result <-
-                runResponsesCompactWith
+                runResponsesCompactWithContextWindow
+                    (Just 258_400)
                     (\_ -> do
                         modifyIORef' requests (+ 1)
                         pure (Right (summaryResponse "summary")))
@@ -311,6 +314,122 @@ spec = do
                     "nothing compatible to compact" `Text.isInfixOf` message
                 Right _ -> False
             readIORef requests `shouldReturn` 0
+
+        it "refuses to guess a portable model context window" do
+            let paramsValue =
+                    (defaultResponseCreateParams :: ResponseCreateParams)
+                        { model = Just "custom-small-model"
+                        }
+            params <- newIORef paramsValue
+            transcript <- newIORef [userTextItem "old context"]
+            requests <- newIORef (0 :: Int)
+            result <-
+                runResponsesCompactWith
+                    (\_ -> do
+                        modifyIORef' requests (+ 1)
+                        pure (Right (summaryResponse "summary")))
+                    (const (pure ()))
+                    params
+                    transcript
+                    Nothing
+            result `shouldSatisfy` \case
+                Left message ->
+                    "context_window" `Text.isInfixOf` message
+                        && "effective transport model" `Text.isInfixOf` message
+                Right _ -> False
+            readIORef requests `shouldReturn` 0
+
+        it "uses a portable model context larger than the Codex fallback" do
+            let contextWindow = 400_000
+                huge = Text.replicate 1_100_000 "x"
+                paramsValue =
+                    (defaultResponseCreateParams :: ResponseCreateParams)
+                        { model = Just "large-portable-model"
+                        }
+            params <- newIORef paramsValue
+            transcript <- newIORef [userTextItem huge]
+            requests <- newIORef []
+            result <-
+                runResponsesCompactWithContextWindow
+                    (Just contextWindow)
+                    (\request -> do
+                        modifyIORef' requests (<> [request])
+                        pure (Right (summaryResponse "summary")))
+                    (const (pure ()))
+                    params
+                    transcript
+                    Nothing
+            case result of
+                Left err -> expectationFailure (Text.unpack err)
+                Right outcome ->
+                    estimateRequestTokensWithItems
+                        paramsValue
+                        outcome.compactHistory
+                        `shouldSatisfy` (<= contextWindow)
+            readIORef requests >>= \case
+                [request] -> do
+                    estimateResponseCreateParamsTokens request
+                        `shouldSatisfy`
+                            (> codexEffectiveContextWindowFor
+                                paramsValue.model)
+                    estimateResponseCreateParamsTokens request
+                        `shouldSatisfy` (<= contextWindow)
+                    requestItems request `shouldSatisfy` \case
+                        MessageItem message : _ ->
+                            case message.content of
+                                MessageContentText text ->
+                                    Text.length text == Text.length huge
+                                MessageContentParts parts ->
+                                    any
+                                        (\case
+                                            InputTextPart { text } ->
+                                                Text.length text
+                                                    == Text.length huge
+                                            _ -> False)
+                                        parts
+                        _ -> False
+                seen ->
+                    expectationFailure
+                        ("expected one portable compaction request, got "
+                            <> show (length seen))
+
+        it "bounds portable requests and snapshots to a smaller model window" do
+            let contextWindow = 8_000
+                paramsValue =
+                    (defaultResponseCreateParams :: ResponseCreateParams)
+                        { model = Just "small-portable-model"
+                        }
+            params <- newIORef paramsValue
+            transcript <- newIORef
+                [ userTextItem (Text.replicate 100_000 "old ")
+                , userTextItem "recent request"
+                ]
+            requests <- newIORef []
+            result <-
+                runResponsesCompactWithContextWindow
+                    (Just contextWindow)
+                    (\request -> do
+                        modifyIORef' requests (<> [request])
+                        pure (Right (summaryResponse "bounded summary")))
+                    (const (pure ()))
+                    params
+                    transcript
+                    Nothing
+            case result of
+                Left err -> expectationFailure (Text.unpack err)
+                Right outcome ->
+                    estimateRequestTokensWithItems
+                        paramsValue
+                        outcome.compactHistory
+                        `shouldSatisfy` (<= contextWindow)
+            readIORef requests >>= \case
+                [request] ->
+                    estimateResponseCreateParamsTokens request
+                        `shouldSatisfy` (<= contextWindow)
+                seen ->
+                    expectationFailure
+                        ("expected one portable compaction request, got "
+                            <> show (length seen))
 
         it "bounds oversized local-summary requests before sending them" do
             params <- newIORef defaultResponseCreateParams
@@ -1169,7 +1288,9 @@ spec = do
                     { itemId = Nothing
                     , callId = "call-oversized"
                     , name = "shell_command"
+                    , namespace = Nothing
                     , arguments = "{}"
+                    , encryptedFunctionArgs = Nothing
                     , status = Nothing
                     , extraFields = mempty
                     }

--- a/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
@@ -12,6 +12,7 @@ import Agent.CLI.Compaction
     , installCompactOutcome
     , runProviderCompact
     , runProviderCompactWith
+    , runResponsesCompactWith
     )
 import Agent.CLI.Connectivity (withConnectionRecoveryUsing)
 import Agent.Error (ApiError(..), ErrorType(..))
@@ -30,6 +31,7 @@ import Agent.ToolDispatch
     ( ToolCallKind(..)
     , ToolCallResult(..)
     )
+import Agent.Responses.LoopBackend (turnInputsToItems)
 import Agent.Responses.Types
 import qualified Data.Aeson as Aeson
 import Data.Aeson ((.=))
@@ -208,6 +210,107 @@ spec = do
                     , stream = Just True
                     }
                 ]
+
+        it "does not replay OpenAI checkpoints to portable summarizers" do
+            let remoteCheckpoint =
+                    KnownResponseItem ItemCompaction TaggedObject
+                        { tag = "compaction"
+                        , fields = mempty
+                        }
+                remoteTrigger =
+                    UnknownResponseItem TaggedObject
+                        { tag = "COMPACTION_TRIGGER"
+                        , fields = mempty
+                        }
+                paramsValue = defaultResponseCreateParams
+                history =
+                    [ userTextItem "old context"
+                    , remoteCheckpoint
+                    , remoteTrigger
+                    ]
+            params <- newIORef paramsValue
+            transcript <- newIORef history
+            requests <- newIORef []
+            result <-
+                runResponsesCompactWith
+                    (\request -> do
+                        modifyIORef' requests (<> [request])
+                        pure (Right (summaryResponse "summary")))
+                    (const (pure ()))
+                    params
+                    transcript
+                    (Just "focus")
+            result `shouldSatisfy` either (const False) (const True)
+            readIORef requests >>= \case
+                [request] ->
+                    requestItems request `shouldSatisfy`
+                        all \case
+                            KnownResponseItem ItemCompaction _ -> False
+                            KnownResponseItem ItemCompactionTrigger _ -> False
+                            UnknownResponseItem tagged ->
+                                Text.toLower (Text.strip tagged.tag)
+                                    `notElem`
+                                        [ "compaction"
+                                        , "compaction_summary"
+                                        , "compaction_trigger"
+                                        ]
+                            _ -> True
+                seen ->
+                    expectationFailure
+                        ("expected one portable summary request, got "
+                            <> show (length seen))
+
+        it "preserves OpenAI checkpoints for focused OpenAI summaries" do
+            let remoteCheckpoint =
+                    KnownResponseItem ItemCompaction TaggedObject
+                        { tag = "compaction"
+                        , fields = mempty
+                        }
+                history = [userTextItem "old context", remoteCheckpoint]
+            params <- newIORef defaultResponseCreateParams
+            transcript <- newIORef history
+            requests <- newIORef []
+            result <-
+                runProviderCompactWith
+                    (Just \request -> do
+                        modifyIORef' requests (<> [request])
+                        pure (Right (summaryResponse "summary")))
+                    (const (pure ()))
+                    OpenAIProvider
+                    Nothing
+                    params
+                    transcript
+                    (Just "focus")
+            result `shouldSatisfy` either (const False) (const True)
+            map requestItems <$> readIORef requests
+                `shouldReturn`
+                    [ history
+                        <> [userTextItem (summarizationPrompt (Just "focus"))]
+                    ]
+
+        it "rejects portable summaries with only opaque checkpoints" do
+            let remoteCheckpoint =
+                    KnownResponseItem ItemCompaction TaggedObject
+                        { tag = "compaction"
+                        , fields = mempty
+                        }
+            params <- newIORef defaultResponseCreateParams
+            transcript <- newIORef [remoteCheckpoint]
+            requests <- newIORef (0 :: Int)
+            result <-
+                runResponsesCompactWith
+                    (\_ -> do
+                        modifyIORef' requests (+ 1)
+                        pure (Right (summaryResponse "summary")))
+                    (const (pure ()))
+                    params
+                    transcript
+                    Nothing
+            result `shouldSatisfy` \case
+                Left message ->
+                    "nothing compatible to compact" `Text.isInfixOf` message
+                Right _ -> False
+            readIORef requests `shouldReturn` 0
 
         it "bounds oversized local-summary requests before sending them" do
             params <- newIORef defaultResponseCreateParams
@@ -651,6 +754,35 @@ spec = do
             map (.parallelToolCalls) <$> readIORef requests
                 `shouldReturn` [Just False]
 
+        it "rejects remote checkpoints that cannot fit the installed snapshot" do
+            let provider = tokenProvider SubscriptionBilled \_ ->
+                    error "remote compaction unexpectedly requested credentials"
+                contextWindow =
+                    codexEffectiveContextWindowFor
+                        defaultResponseCreateParams.model
+                oversizedResponse =
+                    responseWithOutput
+                        [ Aeson.object
+                            [ "type" .= ("compaction" :: Text)
+                            , "encrypted_content" .=
+                                Text.replicate (contextWindow * 4 + 10_000) "x"
+                            ]
+                        ]
+                send _ _ = pure (Right oversizedResponse)
+                history = [userTextItem "old context"]
+            result <- runExceptT $
+                compactOpenAIWith send
+                    (Just provider)
+                    defaultResponseCreateParams
+                    history
+                    100
+                    Nothing
+            result `shouldSatisfy` \case
+                Left message ->
+                    "remote compacted snapshot request cannot fit"
+                        `Text.isInfixOf` message
+                Right _ -> False
+
         it "keeps focused manual compaction on local summarization" do
             requests <- newIORef []
             let provider = tokenProvider SubscriptionBilled \_ ->
@@ -733,6 +865,98 @@ spec = do
                 `shouldReturn`
                     Left (ConnectionError
                         "automatic compaction failed: configured threshold fired")
+
+        it "caps configured thresholds at the effective context window" do
+            let params = defaultResponseCreateParams
+                contextWindow =
+                    codexEffectiveContextWindowFor params.model
+                history =
+                    [ userTextItem
+                        (Text.replicate ((contextWindow + 1_000) * 4) "x")
+                    ]
+                pendingText = "new"
+                projectedTokens =
+                    estimateRequestTokensWithItems
+                        params
+                        (history <> [userTextItem pendingText])
+                threshold = projectedTokens + 1_000
+            projectedTokens `shouldSatisfy` (> contextWindow)
+            projectedTokens `shouldSatisfy` (< threshold)
+            contextState <- newIORef Nothing
+            compactCalls <- newIORef (0 :: Int)
+            seenHistory <- newIORef []
+            let sender _request = do
+                    modifyIORef' compactCalls (+ 1)
+                    pure (Right remoteCompactionResponse)
+                base = Backend \state _ _ _ -> do
+                    modifyIORef' seenHistory (<> [state])
+                    pure $ successful state TurnOutput
+                        { responseId = "resp-new"
+                        , toolCalls = []
+                        , assistantText = Just "ok"
+                        , tokenUsage = TokenUsage 20 5 0
+                        }
+                backend =
+                    autoCompactOpenAiBackendWithSender
+                        (Just threshold)
+                        sender
+                        (const (pure ()))
+                        (pure params)
+                        contextState
+                        base
+            result <- backend.submitTurn history Nothing
+                [UserMessage pendingText] (const (pure ()))
+            result `shouldSatisfy` either (const False) (const True)
+            readIORef compactCalls `shouldReturn` 1
+            readIORef seenHistory >>= \case
+                [compacted] -> hasCompactionCheckpoint compacted
+                    `shouldBe` True
+                seen ->
+                    expectationFailure
+                        ("expected one compacted continuation, got "
+                            <> show (length seen))
+
+        it "rejects an oversized first turn before provider submission" do
+            let params = defaultResponseCreateParams
+                contextWindow =
+                    codexEffectiveContextWindowFor params.model
+                prompt =
+                    Text.replicate ((contextWindow + 1_000) * 4) "x"
+                projectedTokens =
+                    estimateRequestTokensWithItems
+                        params
+                        [userTextItem prompt]
+            projectedTokens `shouldSatisfy` (> contextWindow)
+            contextState <- newIORef Nothing
+            compactCalls <- newIORef (0 :: Int)
+            submitCalls <- newIORef (0 :: Int)
+            let sender _request = do
+                    modifyIORef' compactCalls (+ 1)
+                    pure (Right remoteCompactionResponse)
+                base = Backend \state _ _ _ -> do
+                    modifyIORef' submitCalls (+ 1)
+                    pure $ successful state TurnOutput
+                        { responseId = "resp-new"
+                        , toolCalls = []
+                        , assistantText = Just "ok"
+                        , tokenUsage = TokenUsage 20 5 0
+                        }
+                backend =
+                    autoCompactOpenAiBackendWithSender
+                        (Just (projectedTokens + 1_000))
+                        sender
+                        (const (pure ()))
+                        (pure params)
+                        contextState
+                        base
+            result <- backend.submitTurn [] Nothing
+                [UserMessage prompt] (const (pure ()))
+            result `shouldSatisfy` \case
+                Left (ProviderError InvalidRequestError message _) ->
+                    "initial request cannot fit" `Text.isInfixOf` message
+                _ -> False
+            readIORef compactCalls `shouldReturn` 0
+            readIORef submitCalls `shouldReturn` 0
 
         it "compacts before the next request at the Codex token limit" do
             let oldHistory = [userTextItem "old"]
@@ -937,6 +1161,81 @@ spec = do
             readIORef contextState `shouldReturn` Nothing
             readIORef recordedUsage `shouldReturn` []
 
+        it "truncates oversized tool output before continuing the call" do
+            let params = defaultResponseCreateParams
+                contextWindow =
+                    codexEffectiveContextWindowFor params.model
+                danglingCall = FunctionCallItem FunctionCall
+                    { itemId = Nothing
+                    , callId = "call-oversized"
+                    , name = "shell_command"
+                    , arguments = "{}"
+                    , status = Nothing
+                    , extraFields = mempty
+                    }
+                oldHistory = [userTextItem "run it", danglingCall]
+                originalOutput =
+                    Text.replicate ((contextWindow + 10_000) * 4) "x"
+                toolResult = ToolCallResult
+                    { callId = "call-oversized"
+                    , output = originalOutput
+                    , callKind = FunctionCallKind
+                    }
+                inputs = [CompletedTool toolResult]
+            estimateRequestTokensWithItems
+                params
+                (oldHistory <> turnInputsToItems inputs)
+                `shouldSatisfy` (> contextWindow)
+            contextState <- newIORef Nothing
+            compactCalls <- newIORef (0 :: Int)
+            seenPrevious <- newIORef []
+            seenInputs <- newIORef []
+            let sender _request = do
+                    modifyIORef' compactCalls (+ 1)
+                    pure (Right remoteCompactionResponse)
+                base = Backend \state previous submitted _ -> do
+                    modifyIORef' seenPrevious (<> [previous])
+                    modifyIORef' seenInputs (<> [submitted])
+                    pure $ successful state TurnOutput
+                        { responseId = "resp-new"
+                        , toolCalls = []
+                        , assistantText = Just "ok"
+                        , tokenUsage = TokenUsage 20 5 0
+                        }
+                backend =
+                    autoCompactOpenAiBackendWithSender
+                        Nothing
+                        sender
+                        (const (pure ()))
+                        (pure params)
+                        contextState
+                        base
+            result <- backend.submitTurn oldHistory (Just "resp-tool") inputs
+                (const (pure ()))
+            result `shouldSatisfy` either (const False) (const True)
+            readIORef compactCalls `shouldReturn` 0
+            readIORef seenPrevious `shouldReturn` [Just "resp-tool"]
+            readIORef seenInputs >>= \case
+                [[CompletedTool bounded]] -> do
+                    bounded.callId `shouldBe` toolResult.callId
+                    bounded.callKind `shouldBe` toolResult.callKind
+                    Text.length bounded.output
+                        `shouldSatisfy` (< Text.length originalOutput)
+                    bounded.output
+                        `shouldSatisfy`
+                            Text.isSuffixOf
+                                "[tool output truncated to fit the model context]"
+                    estimateRequestTokensWithItems
+                        params
+                        ( oldHistory
+                            <> turnInputsToItems [CompletedTool bounded]
+                        )
+                        `shouldSatisfy` (<= contextWindow)
+                submitted ->
+                    expectationFailure
+                        ("expected one bounded tool result, got "
+                            <> show submitted)
+
         it "preserves typed provider failures from automatic compaction" do
             let history = [userTextItem "old"]
                 compactError =
@@ -956,6 +1255,40 @@ spec = do
                     Left (ProviderError UsageLimitReached
                         "automatic compaction failed: quota exhausted"
                         (Just 120))
+
+        it "rejects compacted snapshots at or above the trigger" do
+            let history = [userTextItem "old"]
+                oldContextState =
+                    Just (codexAutoCompactTokenLimit, length history)
+                compactedHistory = [userTextItem "still too large"]
+                compactAction =
+                    pure $ Right CompactOutcome
+                        { compactBeforeTokens = codexAutoCompactTokenLimit
+                        , compactAfterTokens = codexAutoCompactTokenLimit
+                        , compactHistory = compactedHistory
+                        , compactSummary = "checkpoint"
+                        }
+            contextState <- newIORef oldContextState
+            continuationCalls <- newIORef (0 :: Int)
+            let base = Backend \state _ _ _ -> do
+                    modifyIORef' continuationCalls (+ 1)
+                    pure $ successful state TurnOutput
+                        { responseId = "resp-new"
+                        , toolCalls = []
+                        , assistantText = Just "ok"
+                        , tokenUsage = TokenUsage 20 5 0
+                        }
+                backend =
+                    autoCompactOpenAiBackendWith
+                        compactAction contextState base
+            result <- backend.submitTurn history Nothing
+                [UserMessage "new"] (const (pure ()))
+            result `shouldSatisfy` \case
+                Left (ProviderError InvalidRequestError message _) ->
+                    "increase --compact-threshold" `Text.isInfixOf` message
+                _ -> False
+            readIORef continuationCalls `shouldReturn` 0
+            readIORef contextState `shouldReturn` oldContextState
 
         it "estimates resumed history when no provider token snapshot exists" do
             let history =

--- a/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
@@ -410,18 +410,18 @@ spec = do
             estimateRequestTokensWithItems params compacted
                 `shouldSatisfy` (< threshold)
 
-        it "does not loop when the checkpoint exceeds a tiny threshold" do
+        it "rejects a tiny threshold before starting compaction" do
             let history = [userTextItem "old"]
                 threshold = 1
                 params = defaultResponseCreateParams
             contextState <- newIORef Nothing
             compactCalls <- newIORef (0 :: Int)
-            seenHistory <- newIORef []
+            continuationCalls <- newIORef (0 :: Int)
             let sender _request = do
                     modifyIORef' compactCalls (+ 1)
                     pure (Right remoteCompactionResponse)
                 base = Backend \state _ _ _ -> do
-                    writeIORef seenHistory state
+                    modifyIORef' continuationCalls (+ 1)
                     pure $ successful state TurnOutput
                         { responseId = "resp-new"
                         , toolCalls = []
@@ -436,14 +436,15 @@ spec = do
                         (pure params)
                         contextState
                         base
-            first <- backend.submitTurn history Nothing
+            result <- backend.submitTurn history Nothing
                 [UserMessage "new"] (const (pure ()))
-            first `shouldSatisfy` either (const False) (const True)
-            compacted <- readIORef seenHistory
-            second <- backend.submitTurn compacted Nothing
-                [UserMessage "again"] (const (pure ()))
-            second `shouldSatisfy` either (const False) (const True)
-            readIORef compactCalls `shouldReturn` 1
+            result `shouldSatisfy` \case
+                Left (ProviderError InvalidRequestError message _) ->
+                    "increase --compact-threshold" `Text.isInfixOf` message
+                _ -> False
+            readIORef compactCalls `shouldReturn` 0
+            readIORef continuationCalls `shouldReturn` 0
+            readIORef contextState `shouldReturn` Nothing
 
         it "runs the post-compaction hook only after a successful continuation" do
             let history = [userTextItem "old"]

--- a/packages/agent-cli/test/Agent/CLI/ModelConfigSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ModelConfigSpec.hs
@@ -34,6 +34,10 @@ spec = describe "Agent.CLI.ModelConfig" do
         fmap (.catalogModelId)
             (catalogDefaultForProvider catalog OpenRouterProvider)
             `shouldBe` Just "stealth/ox-alpha"
+        catalogContextWindowFor catalog "xai" "grok-4.6"
+            `shouldBe` Just 500_000
+        catalogContextWindowFor catalog "openrouter" "stealth/ox-alpha"
+            `shouldBe` Just 1_048_576
         fmap (.catalogModelId)
             (catalogModelsForConnection "openai" catalog)
             `shouldBe`
@@ -60,6 +64,7 @@ spec = describe "Agent.CLI.ModelConfig" do
                 , "    \"connection\": \"ollama\","
                 , "    \"model\": \"qwen2.5-coder:32b\","
                 , "    \"dialect\": \"generic-responses\","
+                , "    \"context_window\": 32768,"
                 , "    \"label\": \"local\""
                 , "  }]"
                 , "}"
@@ -88,6 +93,35 @@ spec = describe "Agent.CLI.ModelConfig" do
             `shouldBe` ["qwen2.5-coder:32b"]
         fmap (.catalogModelDialect) custom
             `shouldBe` [GenericResponsesDialect]
+        fmap (.catalogModelContextWindow) custom
+            `shouldBe` [Just 32_768]
+
+    it "uses the effective configured wire model after a transport remap" do
+        defaults <- readPackagedDefaults
+        let overlay =
+                "{\"version\":1,\"models\":[{\"id\":\"source-model\",\"connection\":\"openrouter\",\"dialect\":\"generic-responses\",\"context_window\":32000},{\"id\":\"provider/target-model\",\"connection\":\"openrouter\",\"dialect\":\"generic-responses\",\"context_window\":128000}]}"
+        catalog <- expectRight
+            (mergeModelConfigs
+                ("models.default.json", defaults)
+                (Just ("models.json", overlay)))
+        catalogContextWindowForTransport
+            catalog
+            "openrouter"
+            "source-model"
+            "source-model"
+            `shouldBe` Just 32_000
+        catalogContextWindowForTransport
+            catalog
+            "openrouter"
+            "source-model"
+            "provider/target-model"
+            `shouldBe` Just 128_000
+        catalogContextWindowForTransport
+            catalog
+            "openrouter"
+            "source-model"
+            "provider/missing-model"
+            `shouldBe` Nothing
 
     it "replaces shipped model metadata by stable id without moving entries" do
         defaults <- readPackagedDefaults
@@ -143,6 +177,15 @@ spec = describe "Agent.CLI.ModelConfig" do
             ("models.default.json", defaults)
             (Just ("models.json", overlay))
             `shouldSatisfy` leftContains "requires api_key_env"
+
+    it "rejects non-positive model context windows" do
+        defaults <- readPackagedDefaults
+        let overlay =
+                "{\"version\":1,\"connections\":{\"local\":{\"api\":\"responses\",\"base_url\":\"http://localhost/v1\",\"api_key_optional\":true}},\"models\":[{\"id\":\"local\",\"connection\":\"local\",\"dialect\":\"generic-responses\",\"context_window\":0}]}"
+        mergeModelConfigs
+            ("models.default.json", defaults)
+            (Just ("models.json", overlay))
+            `shouldSatisfy` leftContains "context_window must be positive"
 
     it "loads ~/.haskell-agent/models.json over an explicit default path" $
         withTempDirectory "agent-model-config-" \root -> do

--- a/packages/agent-cli/test/Agent/CLI/ResumeSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ResumeSpec.hs
@@ -113,6 +113,21 @@ spec = do
             resumeNeedsGeneratedContext [boundary, regenerated]
                 `shouldBe` False
 
+        it "does not mistake ephemeral harness context for a reload" do
+            let boundary = sampleTurn { turnUserText = "/compact" }
+                ephemeral text = sampleTurn
+                    { turnUserText = "continue"
+                    , turnItems = [userTextItem text]
+                    }
+            map
+                (\text ->
+                    resumeNeedsGeneratedContext [boundary, ephemeral text])
+                [ "Plan mode is active. Do not make any edits or writes to the system except for the plan file."
+                , "# Skill instructions: one-off"
+                , "<subagent_notification>done</subagent_notification>"
+                ]
+                `shouldBe` [True, True, True]
+
         it "does not requeue context without a transcript boundary" do
             resumeNeedsGeneratedContext [sampleTurn] `shouldBe` False
 

--- a/packages/agent-cli/test/Agent/CLI/ResumeSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ResumeSpec.hs
@@ -10,12 +10,18 @@ import Agent.CLI.Session
     , TranscriptEffect(..)
     )
 import Agent.Dialect (DialectId(..))
-import System.OsPath (unsafeEncodeUtf)
+import Agent.OpenAI.Compaction (userTextItem)
 import Agent.Provider (Provider(..))
+import Agent.Responses.Types
+    ( CompactionItem(..)
+    , ResponseItem(..)
+    )
 import Agent.Store.Postgres.Session (ConversationSearchResult(..))
+import qualified Data.Aeson.KeyMap as KeyMap
 import Data.Time.Clock (addUTCTime)
 import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
 import qualified Data.Text as Text
+import System.OsPath (unsafeEncodeUtf)
 import Test.Hspec
 
 fromFilePath = unsafeEncodeUtf
@@ -69,6 +75,46 @@ spec = do
             entry.resumePrompt `shouldBe` "hello"
             entry.resumeTranscript
                 `shouldSatisfy` any (Text.isInfixOf "later question")
+
+    describe "resumeNeedsGeneratedContext" do
+        it "requeues context after compact, clear, and new boundaries" do
+            map
+                (\marker ->
+                    resumeNeedsGeneratedContext
+                        [sampleTurn { turnUserText = marker }])
+                ["/compact", "/clear", "/new"]
+                `shouldBe` [True, True, True]
+
+        it "requeues context after a typed automatic-compaction checkpoint" do
+            let checkpoint =
+                    CompactionItemValue CompactionItem
+                        { itemId = Nothing
+                        , encryptedContent = Nothing
+                        , extraFields = KeyMap.empty
+                        }
+            resumeNeedsGeneratedContext
+                [sampleTurn { turnItems = [checkpoint] }]
+                `shouldBe` True
+
+        it "repairs old compacted sessions until regenerated context persists" do
+            let boundary = sampleTurn { turnUserText = "/compact" }
+                ordinary = sampleTurn
+                    { turnUserText = "continue"
+                    , turnItems = [userTextItem "ordinary input"]
+                    }
+                regenerated = ordinary
+                    { turnItems =
+                        [ userTextItem
+                            "## Skills\nThe following reusable skills are available in this session.\n"
+                        ]
+                    }
+            resumeNeedsGeneratedContext [boundary, ordinary]
+                `shouldBe` True
+            resumeNeedsGeneratedContext [boundary, regenerated]
+                `shouldBe` False
+
+        it "does not requeue context without a transcript boundary" do
+            resumeNeedsGeneratedContext [sampleTurn] `shouldBe` False
 
     describe "applyResumeKey" do
         let entries =

--- a/packages/agent-openai/src/Agent/OpenAI/Compaction.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Compaction.hs
@@ -22,7 +22,7 @@ module Agent.OpenAI.Compaction
     , buildLocalCompactedHistoryToFit
     , compactTranscriptAtLastCheckpoint
     , hasCompactionCheckpoint
-    , hasGeneratedContextItems
+    , hasReloadedGeneratedContextItems
     , assistantSummaryItem
     , userTextItem
     , isCompactSessionTurn
@@ -641,24 +641,32 @@ isImageResizeNotice = \case
 -- reinjected from current session state.
 isGeneratedContextUserText :: Text -> Bool
 isGeneratedContextUserText text =
+    isReloadedGeneratedContextUserText text
+        || any (`Text.isPrefixOf` Text.stripStart text)
+            [ "# Skill instructions: "
+            , "Plan mode is active. Do not make any edits or writes to the system except for the plan file."
+            , "The user approved the plan. Plan mode is now off."
+            , "<subagent_notification>"
+            ]
+
+isReloadedGeneratedContextUserText :: Text -> Bool
+isReloadedGeneratedContextUserText text =
     any (`Text.isPrefixOf` Text.stripStart text)
         [ "# AGENTS.md instructions for "
-        , "# Skill instructions: "
         , "## Skills\nThe following reusable skills are available in this session."
         , "<learned-skills>\nThese are durable, reusable instructions learned from earlier sessions."
         , "<system-reminder>\nAs you answer the user's questions, you can use the following context"
-        , "Plan mode is active. Do not make any edits or writes to the system except for the plan file."
-        , "The user approved the plan. Plan mode is now off."
-        , "<subagent_notification>"
         ]
 
--- | Whether persisted items contain generated project, skill, or harness
--- context that can satisfy a post-reset resume without injecting it again.
-hasGeneratedContextItems :: [ResponseItem] -> Bool
-hasGeneratedContextItems = any \case
+-- | Whether persisted items prove that reloadable project and skill context
+-- was consumed after a transcript reset. Ephemeral plan, subagent, and
+-- individually invoked skill wrappers do not satisfy this check.
+hasReloadedGeneratedContextItems :: [ResponseItem] -> Bool
+hasReloadedGeneratedContextItems = any \case
     MessageItem message
         | message.role == RoleUser ->
-            maybe False isGeneratedContextUserText (messageText message)
+            maybe False isReloadedGeneratedContextUserText
+                (messageText message)
     _ -> False
 
 isRemoteRetainedItem :: ResponseItem -> Bool

--- a/packages/agent-openai/src/Agent/OpenAI/Compaction.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Compaction.hs
@@ -38,12 +38,14 @@ import Agent.OpenAI.ModelMetadata (isCodexResponsesLiteModel)
 import Agent.Responses.LoopBackend (withRequestInput)
 import Agent.Responses.Types
 import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KeyMap
 import Data.Maybe (listToMaybe, mapMaybe)
 import qualified Data.ByteString.Lazy as LBS
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
+import qualified Data.Vector as Vector
 
 -- | Marker prefix for compacted summary messages.
 summaryPrefix :: Text
@@ -292,6 +294,12 @@ taggedProtocolIds tagged =
     mapMaybe
         (\name -> taggedTextField name tagged)
         ["call_id", "approval_request_id", "id"]
+
+taggedTextField :: Text -> TaggedObject -> Maybe Text
+taggedTextField name tagged =
+    case KeyMap.lookup (Key.fromText name) tagged.fields of
+        Just (Aeson.String value) -> Just value
+        _ -> Nothing
 
 identifiersMatch :: [Text] -> [Text] -> Bool
 identifiersMatch expected actual =
@@ -562,6 +570,7 @@ sanitizeMessage message =
         , role = message.role
         , status = message.status
         , phase = message.phase
+        , passthrough = message.passthrough
         , extraFields = message.extraFields
         }
 
@@ -727,25 +736,7 @@ groupItems group =
     group.retainedSource : maybe [] pure group.retainedNotice
 
 itemTokenCount :: ResponseItem -> Int
-itemTokenCount = \case
-    MessageItem message -> max 1 (messageTokenCount message)
-    item -> estimateItemsTokens [item]
-
-messageTokenCount :: ResponseMessage -> Int
-messageTokenCount message = case message.content of
-    MessageContentText text -> estimateTokens text
-    MessageContentParts parts ->
-        sum (map contentPartTokenCount parts)
-
-contentPartTokenCount :: ResponseContentPart -> Int
-contentPartTokenCount = \case
-    InputTextPart { text } -> estimateTokens text
-    OutputTextPart { text } -> estimateTokens text
-    RefusalPart { refusal } -> estimateTokens refusal
-    ReasoningTextPart { text } -> estimateTokens text
-    SummaryTextPart { text } -> estimateTokens text
-    PlainTextPart { text } -> estimateTokens text
-    _ -> 0
+itemTokenCount item = estimateItemsTokens [sanitizeCompactionItem item]
 
 truncateItemText :: Int -> ResponseItem -> Maybe ResponseItem
 truncateItemText budget item =

--- a/packages/agent-openai/src/Agent/OpenAI/Compaction.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Compaction.hs
@@ -291,7 +291,7 @@ taggedProtocolIds :: TaggedObject -> [Text]
 taggedProtocolIds tagged =
     mapMaybe
         (\name -> taggedTextField name tagged)
-        ["call_id", "id"]
+        ["call_id", "approval_request_id", "id"]
 
 identifiersMatch :: [Text] -> [Text] -> Bool
 identifiersMatch expected actual =

--- a/packages/agent-openai/src/Agent/OpenAI/Compaction.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Compaction.hs
@@ -22,6 +22,7 @@ module Agent.OpenAI.Compaction
     , buildLocalCompactedHistoryToFit
     , compactTranscriptAtLastCheckpoint
     , hasCompactionCheckpoint
+    , hasGeneratedContextItems
     , assistantSummaryItem
     , userTextItem
     , isCompactSessionTurn
@@ -238,7 +239,7 @@ dropMatchingFunctionOutput callId = go
   where
     go [] = []
     go (FunctionCallOutputItem output : rest)
-        | output.callId == callId = rest
+        | identifiersMatch [callId] [output.callId] = rest
     go (item : rest) = item : go rest
 
 dropMatchingCustomToolOutput :: Text -> [ResponseItem] -> [ResponseItem]
@@ -246,7 +247,7 @@ dropMatchingCustomToolOutput callId = go
   where
     go [] = []
     go (CustomToolCallOutputItem output : rest)
-        | output.callId == callId = rest
+        | identifiersMatch [callId] [output.callId] = rest
     go (item : rest) = item : go rest
 
 pairedOutputType :: ResponseItemType -> Maybe ResponseItemType
@@ -294,9 +295,16 @@ taggedProtocolIds tagged =
 
 identifiersMatch :: [Text] -> [Text] -> Bool
 identifiersMatch expected actual =
-    null expected
-        || null actual
-        || any (`elem` actual) expected
+    not (null expectedIds)
+        && not (null actualIds)
+        && any (`elem` actualIds) expectedIds
+  where
+    expectedIds = nonEmptyIdentifiers expected
+    actualIds = nonEmptyIdentifiers actual
+
+nonEmptyIdentifiers :: [Text] -> [Text]
+nonEmptyIdentifiers =
+    filter (not . Text.null) . map Text.strip
 
 sanitizeRemoteCompactionHistory :: [ResponseItem] -> [ResponseItem]
 sanitizeRemoteCompactionHistory =
@@ -636,10 +644,22 @@ isGeneratedContextUserText text =
     any (`Text.isPrefixOf` Text.stripStart text)
         [ "# AGENTS.md instructions for "
         , "# Skill instructions: "
+        , "## Skills\nThe following reusable skills are available in this session."
+        , "<learned-skills>\nThese are durable, reusable instructions learned from earlier sessions."
+        , "<system-reminder>\nAs you answer the user's questions, you can use the following context"
         , "Plan mode is active. Do not make any edits or writes to the system except for the plan file."
         , "The user approved the plan. Plan mode is now off."
         , "<subagent_notification>"
         ]
+
+-- | Whether persisted items contain generated project, skill, or harness
+-- context that can satisfy a post-reset resume without injecting it again.
+hasGeneratedContextItems :: [ResponseItem] -> Bool
+hasGeneratedContextItems = any \case
+    MessageItem message
+        | message.role == RoleUser ->
+            maybe False isGeneratedContextUserText (messageText message)
+    _ -> False
 
 isRemoteRetainedItem :: ResponseItem -> Bool
 isRemoteRetainedItem = \case

--- a/packages/agent-openai/src/Agent/OpenAI/Compaction.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Compaction.hs
@@ -8,12 +8,18 @@ module Agent.OpenAI.Compaction
     , compactionTriggerItem
     , buildRemoteCompactionRequest
     , trimRemoteCompactionHistoryToFit
+    , trimRemoteCompactionRequestToFit
     , extractRemoteCompactionItem
     , buildRemoteCompactedHistory
     , estimateTokens
     , estimateItemsTokens
+    , estimateResponseCreateParamsTokens
+    , estimateRequestTokensWithItems
+    , trimResponseHistoryToFit
+    , sanitizeCompactionHistory
     , collectRecentUserTexts
     , buildLocalCompactedHistory
+    , buildLocalCompactedHistoryToFit
     , compactTranscriptAtLastCheckpoint
     , hasCompactionCheckpoint
     , assistantSummaryItem
@@ -82,51 +88,219 @@ buildRemoteCompactionRequest params history =
                 , ..
                 }
 
+-- | Estimate the complete serialized request, including instructions, tools,
+-- and all other request-level fields.
+estimateRequestTokensWithItems
+    :: ResponseCreateParams
+    -> [ResponseItem]
+    -> Int
+estimateRequestTokensWithItems params items =
+    estimateEncodedValue (withRequestInput params items)
+
+estimateResponseCreateParamsTokens :: ResponseCreateParams -> Int
+estimateResponseCreateParamsTokens = estimateEncodedValue
+
+estimateEncodedValue :: Aeson.ToJSON value => value -> Int
+estimateEncodedValue value =
+    estimateTokens
+        (TextEncoding.decodeUtf8 (LBS.toStrict (Aeson.encode value)))
+
 contextWindowTruncatedOutputMessage :: Text
 contextWindowTruncatedOutputMessage =
     "Output exceeded the available model context and was truncated"
 
--- | Codex rewrites only a contiguous suffix of tool outputs when the
--- compaction request itself would exceed the model's usable context window.
--- This keeps call/output pairing valid while making room for the trigger.
+-- | Rewrite the oldest oversized, safely-rewritable items when the compaction
+-- request itself would exceed the model's usable context window. Items that
+-- cannot be rewritten are preserved while newer outputs are considered.
 trimRemoteCompactionHistoryToFit
     :: Int
     -> Maybe Text
     -> [ResponseItem]
     -> [ResponseItem]
 trimRemoteCompactionHistoryToFit contextWindow instructionText history =
-    go initialTokens (reverse sanitizedHistory) []
+    trimCompactionHistoryToFitWith
+        sanitizeRemoteCompactionHistory
+        contextWindow
+        requestTokens
+        history
   where
-    sanitizedHistory = map sanitizeOversizedToolCall history
-
-    initialTokens =
+    requestTokens items =
         maybe 0 estimateTokens instructionText
-            + estimateItemsTokens sanitizedHistory
+            + estimateItemsTokens (items <> [compactionTriggerItem])
 
-    go _ [] rewritten = rewritten
-    go tokens remaining rewritten
-        | tokens <= contextWindow =
-            reverse remaining <> rewritten
-    go tokens (item : remaining) rewritten =
-        case rewriteOversizedToolOutput item of
-            Nothing ->
-                reverse (item : remaining) <> rewritten
-            Just replacement ->
-                let nextTokens =
-                        tokens
-                            - estimateItemsTokens [item]
-                            + estimateItemsTokens [replacement]
-                in go nextTokens remaining (replacement : rewritten)
+-- | Trim a compaction request using the complete serialized request size.
+-- Unlike the legacy helper above, this accounts for tools, instructions,
+-- trigger overhead, and all other request fields preserved by the remote
+-- compaction request.
+trimRemoteCompactionRequestToFit
+    :: Int
+    -> ResponseCreateParams
+    -> [ResponseItem]
+    -> [ResponseItem]
+trimRemoteCompactionRequestToFit contextWindow params =
+    trimCompactionHistoryToFitWith
+        sanitizeRemoteCompactionHistory
+        contextWindow
+        requestTokens
+  where
+    requestTokens history =
+        estimateEncodedValue (buildRemoteCompactionRequest params history)
 
-oversizedToolArgumentsMessage :: Text
-oversizedToolArgumentsMessage =
-    "Tool arguments exceeded the provider string limit and were omitted during compaction."
+-- | Trim history for a normal Responses request with fixed trailing items.
+-- Local summarization uses this to bound the transcript before appending its
+-- summary prompt.
+trimResponseHistoryToFit
+    :: Int
+    -> ResponseCreateParams
+    -> [ResponseItem]
+    -> [ResponseItem]
+    -> [ResponseItem]
+trimResponseHistoryToFit contextWindow params trailing =
+    trimCompactionHistoryToFitWith
+        sanitizeCompactionHistory
+        contextWindow
+        requestTokens
+  where
+    requestTokens history =
+        estimateRequestTokensWithItems params (history <> trailing)
 
-oversizedFunctionArguments :: Text
-oversizedFunctionArguments =
-    TextEncoding.decodeUtf8 . LBS.toStrict . Aeson.encode $ Aeson.object
-        [ "compaction_notice" Aeson..= oversizedToolArgumentsMessage
-        ]
+trimCompactionHistoryToFitWith
+    :: ([ResponseItem] -> [ResponseItem])
+    -> Int
+    -> ([ResponseItem] -> Int)
+    -> [ResponseItem]
+    -> [ResponseItem]
+trimCompactionHistoryToFitWith sanitize contextWindow requestTokens history =
+    let sanitized = sanitize history
+        rewritten = rewriteUntilFit sanitized
+    in dropOldestUntilFit rewritten
+  where
+    rewriteUntilFit items
+        | requestTokens items <= contextWindow = items
+        | otherwise =
+            case rewriteFirstReducible [] items of
+                Just smaller -> rewriteUntilFit smaller
+                Nothing -> items
+
+    rewriteFirstReducible _ [] = Nothing
+    rewriteFirstReducible prefix (item : remaining) =
+        let withoutItem = prefix <> remaining
+            availableTokens =
+                max 0 (contextWindow - requestTokens withoutItem)
+            original = prefix <> (item : remaining)
+        in case rewriteItemForBudget availableTokens item of
+            Just compacted
+                | let candidate = prefix <> (compacted : remaining)
+                , requestTokens candidate < requestTokens original ->
+                    Just candidate
+            _ ->
+                rewriteFirstReducible (prefix <> [item]) remaining
+
+    dropOldestUntilFit items
+        | requestTokens items <= contextWindow = items
+        | otherwise =
+            case dropOldestProtocolUnit items of
+                Nothing -> items
+                Just smaller -> dropOldestUntilFit smaller
+
+dropOldestProtocolUnit :: [ResponseItem] -> Maybe [ResponseItem]
+dropOldestProtocolUnit = go []
+  where
+    go _ [] = Nothing
+    go prefix (item@(KnownResponseItem ItemCompaction _) : rest) =
+        go (prefix <> [item]) rest
+    go prefix (FunctionCallItem call : rest) =
+        Just (prefix <> dropMatchingFunctionOutput call.callId rest)
+    go prefix (CustomToolCallItem call : rest) =
+        Just (prefix <> dropMatchingCustomToolOutput call.callId rest)
+    go prefix (KnownResponseItem itemType tagged : rest)
+        | Just outputType <- pairedOutputType itemType =
+            Just $
+                prefix
+                    <> dropMatchingTaggedOutput
+                        (== outputType)
+                        (taggedProtocolIds tagged)
+                        rest
+    go prefix (UnknownResponseItem tagged : rest)
+        | Just outputTag <- pairedUnknownOutputTag tagged.tag =
+            Just $
+                prefix
+                    <> dropMatchingTaggedOutput
+                        (\case
+                            ItemUnknownType itemType -> itemType == outputTag
+                            _ -> False)
+                        (taggedProtocolIds tagged)
+                        rest
+    go prefix (_ : rest) = Just (prefix <> rest)
+
+dropMatchingFunctionOutput :: Text -> [ResponseItem] -> [ResponseItem]
+dropMatchingFunctionOutput callId = go
+  where
+    go [] = []
+    go (FunctionCallOutputItem output : rest)
+        | output.callId == callId = rest
+    go (item : rest) = item : go rest
+
+dropMatchingCustomToolOutput :: Text -> [ResponseItem] -> [ResponseItem]
+dropMatchingCustomToolOutput callId = go
+  where
+    go [] = []
+    go (CustomToolCallOutputItem output : rest)
+        | output.callId == callId = rest
+    go (item : rest) = item : go rest
+
+pairedOutputType :: ResponseItemType -> Maybe ResponseItemType
+pairedOutputType = \case
+    ItemComputerCall -> Just ItemComputerCallOutput
+    ItemToolSearchCall -> Just ItemToolSearchOutput
+    ItemLocalShellCall -> Just ItemLocalShellCallOutput
+    ItemShellCall -> Just ItemShellCallOutput
+    ItemApplyPatchCall -> Just ItemApplyPatchCallOutput
+    ItemMcpApprovalRequest -> Just ItemMcpApprovalResponse
+    ItemProgram -> Just ItemProgramOutput
+    _ -> Nothing
+
+pairedUnknownOutputTag :: Text -> Maybe Text
+pairedUnknownOutputTag itemType
+    | "_call" `Text.isSuffixOf` normalized =
+        Just (normalized <> "_output")
+    | otherwise = Nothing
+  where
+    normalized = Text.toLower (Text.strip itemType)
+
+dropMatchingTaggedOutput
+    :: (ResponseItemType -> Bool)
+    -> [Text]
+    -> [ResponseItem]
+    -> [ResponseItem]
+dropMatchingTaggedOutput isOutput callIds = go
+  where
+    go [] = []
+    go (KnownResponseItem itemType tagged : rest)
+        | isOutput itemType
+        , identifiersMatch callIds (taggedProtocolIds tagged) =
+            rest
+    go (UnknownResponseItem tagged : rest)
+        | isOutput (ItemUnknownType tagged.tag)
+        , identifiersMatch callIds (taggedProtocolIds tagged) =
+            rest
+    go (item : rest) = item : go rest
+
+taggedProtocolIds :: TaggedObject -> [Text]
+taggedProtocolIds tagged =
+    mapMaybe
+        (\name -> taggedTextField name tagged)
+        ["call_id", "id"]
+
+identifiersMatch :: [Text] -> [Text] -> Bool
+identifiersMatch expected actual =
+    null expected
+        || null actual
+        || any (`elem` actual) expected
+
+sanitizeRemoteCompactionHistory :: [ResponseItem] -> [ResponseItem]
+sanitizeRemoteCompactionHistory =
+    map sanitizeOversizedToolCall . sanitizeCompactionHistory
 
 sanitizeOversizedToolCall :: ResponseItem -> ResponseItem
 sanitizeOversizedToolCall = \case
@@ -154,6 +328,16 @@ sanitizeOversizedToolCall = \case
                 , extraFields = call.extraFields
                 }
     item -> item
+
+oversizedToolArgumentsMessage :: Text
+oversizedToolArgumentsMessage =
+    "Tool arguments exceeded the provider string limit and were omitted during compaction."
+
+oversizedFunctionArguments :: Text
+oversizedFunctionArguments =
+    TextEncoding.decodeUtf8 . LBS.toStrict . Aeson.encode $ Aeson.object
+        [ "compaction_notice" Aeson..= oversizedToolArgumentsMessage
+        ]
 
 rewriteOversizedToolOutput :: ResponseItem -> Maybe ResponseItem
 rewriteOversizedToolOutput = \case
@@ -185,7 +369,128 @@ rewriteOversizedToolOutput = \case
             , tools = []
             , extraFields = output.extraFields
             }
+    KnownResponseItem itemType tagged
+        | isTaggedOutputItem itemType ->
+            KnownResponseItem itemType
+                <$> rewriteTaggedOutput tagged
+        | isTaggedInlineResultItem itemType ->
+            KnownResponseItem itemType
+                <$> rewriteTaggedInlineResult tagged
+    -- Provider extensions are decoded as 'ItemUnknownType'. Preserve their
+    -- identity and required metadata, but only redact broad payload fields
+    -- when the wire type is explicitly output-like. Call-shaped extensions
+    -- may safely redact recognized result fields, never generic input fields
+    -- such as content, data, text, or payload.
+    KnownResponseItem (ItemUnknownType itemType) tagged
+        | isOutputLikeType itemType ->
+            KnownResponseItem (ItemUnknownType itemType)
+                <$> rewriteTaggedOutput tagged
+        | isCallLikeType itemType ->
+            KnownResponseItem (ItemUnknownType itemType)
+                <$> rewriteTaggedInlineResult tagged
+    UnknownResponseItem tagged
+        | isOutputLikeType tagged.tag ->
+            UnknownResponseItem <$> rewriteTaggedOutput tagged
+        | isCallLikeType tagged.tag ->
+            UnknownResponseItem <$> rewriteTaggedInlineResult tagged
     _ -> Nothing
+
+isTaggedOutputItem :: ResponseItemType -> Bool
+isTaggedOutputItem = \case
+    ItemComputerCallOutput -> True
+    ItemLocalShellCallOutput -> True
+    ItemShellCallOutput -> True
+    ItemApplyPatchCallOutput -> True
+    ItemMcpApprovalResponse -> True
+    ItemProgramOutput -> True
+    _ -> False
+
+-- Some provider-managed call items carry completed results inline. Limit
+-- rewriting on these shapes to unambiguously result-like fields.
+isTaggedInlineResultItem :: ResponseItemType -> Bool
+isTaggedInlineResultItem = \case
+    ItemFileSearchCall -> True
+    ItemWebSearchCall -> True
+    ItemImageGenerationCall -> True
+    ItemCodeInterpreterCall -> True
+    ItemMcpListTools -> True
+    ItemMcpCall -> True
+    _ -> False
+
+isOutputLikeType :: Text -> Bool
+isOutputLikeType itemType =
+    let normalized = Text.toLower (Text.strip itemType)
+    in Text.isSuffixOf "_output" normalized
+        || Text.isInfixOf "output" normalized
+
+isCallLikeType :: Text -> Bool
+isCallLikeType itemType =
+    Text.isSuffixOf "_call" (Text.toLower (Text.strip itemType))
+
+rewriteTaggedOutput :: TaggedObject -> Maybe TaggedObject
+rewriteTaggedOutput =
+    rewriteTaggedFields
+        [ "output"
+        , "outputs"
+        , "result"
+        , "results"
+        , "stdout"
+        , "stderr"
+        , "response"
+        , "data"
+        , "content"
+        , "text"
+        , "payload"
+        , "tools"
+        ]
+
+rewriteTaggedInlineResult :: TaggedObject -> Maybe TaggedObject
+rewriteTaggedInlineResult =
+    rewriteTaggedFields
+        [ "output"
+        , "outputs"
+        , "result"
+        , "results"
+        , "stdout"
+        , "stderr"
+        , "response"
+        , "tools"
+        ]
+
+rewriteTaggedFields :: [Text] -> TaggedObject -> Maybe TaggedObject
+rewriteTaggedFields payloadKeys tagged =
+    let
+        rewritten =
+            foldr
+                (\name fields ->
+                    let key = Key.fromText name
+                    in case KeyMap.lookup key fields of
+                        Just value ->
+                            KeyMap.insert key (truncatePayload value) fields
+                        Nothing -> fields)
+                tagged.fields
+                payloadKeys
+    in if rewritten == tagged.fields
+        then Nothing
+        else Just tagged { fields = rewritten }
+
+truncatePayload :: Aeson.Value -> Aeson.Value
+truncatePayload = \case
+    Aeson.String _ ->
+        Aeson.String contextWindowTruncatedOutputMessage
+    Aeson.Array _ ->
+        Aeson.Array Vector.empty
+    Aeson.Object _ ->
+        Aeson.Object KeyMap.empty
+    value -> value
+
+rewriteItemForBudget :: Int -> ResponseItem -> Maybe ResponseItem
+rewriteItemForBudget budget item =
+    case item of
+        MessageItem{} ->
+            truncateItemText budget item
+        _ ->
+            rewriteOversizedToolOutput item
 
 -- | A successful v2 stream must complete and contain exactly one compaction
 -- output item. Other output item types are ignored, matching Codex.
@@ -223,8 +528,81 @@ buildRemoteCompactedHistory
 buildRemoteCompactedHistory budget history checkpoint =
     truncateRetainedGroups budget
         (filter (\group -> isRemoteRetainedItem group.retainedSource)
-            (retainedGroups history))
+            (retainedGroups (sanitizeCompactionHistory history)))
         <> [checkpoint]
+
+-- | Remove unbounded inline payloads before a compacted snapshot is retained
+-- or replayed. Textual content remains intact; rich content becomes a short
+-- explanatory input message rather than a base64 URL or opaque JSON blob.
+sanitizeCompactionHistory :: [ResponseItem] -> [ResponseItem]
+sanitizeCompactionHistory = map sanitizeCompactionItem
+
+sanitizeCompactionItem :: ResponseItem -> ResponseItem
+sanitizeCompactionItem (MessageItem message) =
+    MessageItem (sanitizeMessage message)
+sanitizeCompactionItem item = item
+
+sanitizeMessage :: ResponseMessage -> ResponseMessage
+sanitizeMessage message =
+    ResponseMessage
+        { messageId = message.messageId
+        , content = case message.content of
+            MessageContentText _ -> message.content
+            MessageContentParts parts ->
+                MessageContentParts
+                    (concatMap (sanitizeContentPart message.role) parts)
+        , role = message.role
+        , status = message.status
+        , phase = message.phase
+        , extraFields = message.extraFields
+        }
+
+sanitizeContentPart
+    :: ResponseRole
+    -> ResponseContentPart
+    -> [ResponseContentPart]
+sanitizeContentPart role part =
+    case part of
+        InputTextPart{} -> [part]
+        OutputTextPart{} -> [part]
+        RefusalPart{} -> [part]
+        ReasoningTextPart{} -> [part]
+        SummaryTextPart{} -> [part]
+        _ -> [richContentNoticePart role (richContentNotice part)]
+
+richContentNoticePart :: ResponseRole -> Text -> ResponseContentPart
+richContentNoticePart role notice =
+    case role of
+        RoleAssistant ->
+            OutputTextPart
+                { text = notice
+                , annotations = Nothing
+                , logprobs = Nothing
+                , extraFields = KeyMap.empty
+                }
+        _ ->
+            InputTextPart
+                { text = notice
+                , promptCacheBreakpoint = Nothing
+                , extraFields = KeyMap.empty
+                }
+
+richContentNotice :: ResponseContentPart -> Text
+richContentNotice = \case
+    InputImagePart{} ->
+        "<image attachment omitted from compacted context>"
+    InputFilePart{filename} ->
+        "<file attachment omitted from compacted context"
+            <> maybe "" (\name -> ": " <> Text.take 120 name) filename
+            <> ">"
+    InputAudioPart{} ->
+        "<audio attachment omitted from compacted context>"
+    UnknownContentPart tagged ->
+        "<unsupported content omitted from compacted context: "
+            <> Text.take 80 tagged.tag
+            <> ">"
+    _ ->
+        "<rich content omitted from compacted context>"
 
 data RetainedGroup = RetainedGroup
     { retainedSource :: !ResponseItem
@@ -342,28 +720,43 @@ contentPartTokenCount = \case
     _ -> 0
 
 truncateItemText :: Int -> ResponseItem -> Maybe ResponseItem
-truncateItemText budget = \case
-    MessageItem message ->
-        MessageItem <$> truncateMessageText budget message
-    _ -> Nothing
+truncateItemText budget item =
+    case sanitizeCompactionItem item of
+        MessageItem message ->
+            MessageItem <$> truncateMessageText budget message
+        _ -> Nothing
 
 truncateMessageText :: Int -> ResponseMessage -> Maybe ResponseMessage
 truncateMessageText budget message =
-    case message.content of
-        MessageContentText text ->
-            let truncated = takeTokenBudget budget text
-            in if Text.null truncated
-                then Nothing
-                else Just (replaceMessageContent
-                    message
-                    (MessageContentText truncated))
-        MessageContentParts parts ->
-            let truncated = truncateContentParts budget parts
-            in if null truncated
-                then Nothing
-                else Just (replaceMessageContent
-                    message
-                    (MessageContentParts truncated))
+    search 0 (max 0 budget) Nothing
+  where
+    candidateFor textBudget =
+        case message.content of
+            MessageContentText text ->
+                let truncated = takeTokenBudget textBudget text
+                in if Text.null truncated
+                    then Nothing
+                    else Just (replaceMessageContent
+                        message
+                        (MessageContentText truncated))
+            MessageContentParts parts ->
+                let truncated = truncateContentParts textBudget parts
+                in if null truncated
+                    then Nothing
+                    else Just (replaceMessageContent
+                        message
+                        (MessageContentParts truncated))
+
+    search low high best
+        | low > high = best
+        | otherwise =
+            let middle = (low + high) `div` 2
+            in case candidateFor middle of
+                Just candidate
+                    | estimateItemsTokens [MessageItem candidate] <= budget ->
+                        search (middle + 1) high (Just candidate)
+                _ ->
+                    search low (middle - 1) best
 
 replaceMessageContent :: ResponseMessage -> MessageContent -> ResponseMessage
 replaceMessageContent message nextContent =
@@ -456,7 +849,10 @@ summarizationPrompt focus =
         [ "Summarize the conversation so far for a successor coding agent."
         , "The successor will only see this summary plus a few recent user messages;"
         , "it will not see prior tool calls or tool outputs."
-        , "Preserve: the user's goals, important file paths, decisions made,"
+        , "The input may have been sanitized or truncated to fit the context window."
+        , "Preserve: the user's goals, active project instructions, always-active"
+        , "skill constraints, safety and policy constraints, required workflows,"
+        , "important file paths, decisions made,"
         , "errors encountered and how they were fixed, and remaining work."
         , "Be concrete and concise. Do not call tools."
         ]
@@ -486,9 +882,10 @@ collectRecentUserTexts keep items =
     userTextOf = \case
         MessageItem message
             | message.role == RoleUser ->
-                case messageText message of
+                case messageText (sanitizeMessage message) of
                     Just text
-                        | Text.isPrefixOf "/compact" (Text.strip text) -> Nothing
+                        | isCompactSessionTurn text -> Nothing
+                        | isGeneratedContextUserText text -> Nothing
                         | otherwise -> Just text
                     Nothing -> Nothing
         _ -> Nothing
@@ -544,6 +941,64 @@ buildLocalCompactedHistory :: Int -> [ResponseItem] -> Text -> [ResponseItem]
 buildLocalCompactedHistory keepRecent history summary =
     map userTextItem (collectRecentUserTexts keepRecent history)
         <> [assistantSummaryItem summary]
+
+-- | Build a local summary snapshot whose complete next-request size is
+-- bounded. The generated summary is protected while recent user messages are
+-- truncated or discarded oldest-first. Local snapshots target the same 64k
+-- retained-item envelope as remote compaction while still accounting for
+-- request-level instructions and tool schemas.
+buildLocalCompactedHistoryToFit
+    :: Int
+    -> ResponseCreateParams
+    -> Int
+    -> [ResponseItem]
+    -> Text
+    -> [ResponseItem]
+buildLocalCompactedHistoryToFit
+        contextWindow params keepRecent history summary =
+    let targetWindow =
+            min
+                (max 0 contextWindow)
+                ( estimateRequestTokensWithItems params []
+                    + remoteCompactionRetainedTokenBudget
+                )
+        summaryItem = fitLocalSummaryItem targetWindow params summary
+        recentItems =
+            map userTextItem (collectRecentUserTexts keepRecent history)
+    in trimResponseHistoryToFit
+        targetWindow
+        params
+        [summaryItem]
+        recentItems
+            <> [summaryItem]
+
+fitLocalSummaryItem
+    :: Int
+    -> ResponseCreateParams
+    -> Text
+    -> ResponseItem
+fitLocalSummaryItem targetWindow params summary
+    | requestTokens fullItem <= targetWindow = fullItem
+    | Text.null stripped = fullItem
+    | otherwise = maybe fullItem id (search 1 (Text.length stripped - 1) Nothing)
+  where
+    stripped = Text.strip summary
+    fullItem = assistantSummaryItem stripped
+    truncationNotice = "\n\n[Summary truncated to fit compacted context.]"
+    requestTokens item = estimateRequestTokensWithItems params [item]
+
+    candidateFor characters =
+        assistantSummaryItem
+            (Text.take characters stripped <> truncationNotice)
+
+    search low high best
+        | low > high = best
+        | otherwise =
+            let middle = (low + high) `div` 2
+                candidate = candidateFor middle
+            in if requestTokens candidate <= targetWindow
+                then search (middle + 1) high (Just candidate)
+                else search low (middle - 1) best
 
 -- | Legacy helper retained for API compatibility. Installed v2 snapshots must
 -- be replayed in full because they intentionally place retained messages

--- a/packages/agent-openai/test/Agent/OpenAI/CompactionSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/CompactionSpec.hs
@@ -112,6 +112,97 @@ spec = do
             estimateResponseCreateParamsTokens request
                 `shouldSatisfy` (<= 11_000)
 
+        it "omits function arguments above the provider string limit" do
+            let oversized = FunctionCallItem FunctionCall
+                    { itemId = Nothing
+                    , callId = "call-oversized"
+                    , name = "apply_patch"
+                    , namespace = Nothing
+                    , arguments =
+                        Text.replicate
+                            (remoteCompactionMaxStringLength + 1)
+                            "x"
+                    , encryptedFunctionArgs = Nothing
+                    , status = Just ItemCompleted
+                    , extraFields = KeyMap.empty
+                    }
+                trimmed =
+                    trimRemoteCompactionRequestToFit
+                        2_000_000
+                        defaultResponseCreateParams
+                        [user "keep", oversized]
+            case trimmed of
+                [_, FunctionCallItem call] -> do
+                    call.callId `shouldBe` "call-oversized"
+                    call.name `shouldBe` "apply_patch"
+                    Text.length call.arguments
+                        `shouldSatisfy` (<= remoteCompactionMaxStringLength)
+                    Aeson.eitherDecodeStrict'
+                        (TextEncoding.encodeUtf8 call.arguments)
+                        `shouldSatisfy`
+                            (either (const False) (const True)
+                                :: Either String Aeson.Value -> Bool)
+                other ->
+                    expectationFailure
+                        ("expected sanitized function call, got " <> show other)
+
+        it "omits custom-tool input above the provider string limit" do
+            let oversized = CustomToolCallItem CustomToolCall
+                    { itemId = Nothing
+                    , callId = "call-custom"
+                    , name = "apply_patch"
+                    , namespace = Nothing
+                    , input =
+                        Text.replicate
+                            (remoteCompactionMaxStringLength + 1)
+                            "x"
+                    , status = Just ItemCompleted
+                    , extraFields = KeyMap.empty
+                    }
+                trimmed =
+                    trimRemoteCompactionRequestToFit
+                        2_000_000
+                        defaultResponseCreateParams
+                        [oversized]
+            case trimmed of
+                [CustomToolCallItem call] -> do
+                    call.callId `shouldBe` "call-custom"
+                    call.name `shouldBe` "apply_patch"
+                    Text.length call.input
+                        `shouldSatisfy` (<= remoteCompactionMaxStringLength)
+                other ->
+                    expectationFailure
+                        ("expected sanitized custom tool call, got " <> show other)
+
+        it "keeps oversized tool arguments on portable compaction paths" do
+            let arguments =
+                    Text.replicate
+                        (remoteCompactionMaxStringLength + 1)
+                        "x"
+                oversized = FunctionCallItem FunctionCall
+                    { itemId = Nothing
+                    , callId = "call-portable"
+                    , name = "portable_tool"
+                    , namespace = Nothing
+                    , arguments
+                    , encryptedFunctionArgs = Nothing
+                    , status = Just ItemCompleted
+                    , extraFields = KeyMap.empty
+                    }
+                trimmed =
+                    trimResponseHistoryToFit
+                        2_000_000
+                        defaultResponseCreateParams
+                        []
+                        [oversized]
+            case trimmed of
+                [FunctionCallItem call] ->
+                    call.arguments `shouldBe` arguments
+                other ->
+                    expectationFailure
+                        ("expected unchanged portable function call, got "
+                            <> show other)
+
         it "accepts exactly one compaction item alongside unrelated output" do
             let opaque = checkpoint "opaque"
                 response = completedResponse [assistant "ignored", opaque]
@@ -179,6 +270,7 @@ spec = do
                     , role = RoleUser
                     , status = Nothing
                     , phase = Nothing
+                    , passthrough = Nothing
                     , extraFields = KeyMap.empty
                     }
                 compacted =
@@ -212,6 +304,7 @@ spec = do
                     , role = RoleUser
                     , status = Nothing
                     , phase = Nothing
+                    , passthrough = Nothing
                     , extraFields = KeyMap.empty
                     }
                 compacted =
@@ -250,6 +343,7 @@ spec = do
                     , role = RoleAssistant
                     , status = Nothing
                     , phase = Nothing
+                    , passthrough = Nothing
                     , extraFields = KeyMap.empty
                     }
             sanitizeCompactionHistory [rich] `shouldSatisfy` \case
@@ -278,6 +372,7 @@ spec = do
                     , role = RoleUser
                     , status = Nothing
                     , phase = Nothing
+                    , passthrough = Nothing
                     , extraFields = KeyMap.empty
                     }
                 trimmed =
@@ -408,68 +503,6 @@ spec = do
                     expectationFailure
                         ("expected rewritten tool output, got " <> show other)
 
-        it "omits function arguments above the provider string limit" do
-            let oversized = FunctionCallItem FunctionCall
-                    { itemId = Nothing
-                    , callId = "call-oversized"
-                    , name = "apply_patch"
-                    , namespace = Nothing
-                    , arguments =
-                        Text.replicate
-                            (remoteCompactionMaxStringLength + 1)
-                            "x"
-                    , encryptedFunctionArgs = Nothing
-                    , status = Just ItemCompleted
-                    , extraFields = KeyMap.empty
-                    }
-                trimmed =
-                    trimRemoteCompactionHistoryToFit
-                        2_000_000
-                        Nothing
-                        [user "keep", oversized]
-            case trimmed of
-                [_, FunctionCallItem call] -> do
-                    call.callId `shouldBe` "call-oversized"
-                    call.name `shouldBe` "apply_patch"
-                    Text.length call.arguments
-                        `shouldSatisfy` (<= remoteCompactionMaxStringLength)
-                    Aeson.eitherDecodeStrict'
-                        (TextEncoding.encodeUtf8 call.arguments)
-                        `shouldSatisfy`
-                            (either (const False) (const True)
-                                :: Either String Aeson.Value -> Bool)
-                other ->
-                    expectationFailure
-                        ("expected sanitized function call, got " <> show other)
-
-        it "omits custom-tool input above the provider string limit" do
-            let oversized = CustomToolCallItem CustomToolCall
-                    { itemId = Nothing
-                    , callId = "call-custom"
-                    , name = "apply_patch"
-                    , namespace = Nothing
-                    , input =
-                        Text.replicate
-                            (remoteCompactionMaxStringLength + 1)
-                            "x"
-                    , status = Just ItemCompleted
-                    , extraFields = KeyMap.empty
-                    }
-                trimmed =
-                    trimRemoteCompactionHistoryToFit
-                        2_000_000
-                        Nothing
-                        [oversized]
-            case trimmed of
-                [CustomToolCallItem call] -> do
-                    call.callId `shouldBe` "call-custom"
-                    call.name `shouldBe` "apply_patch"
-                    Text.length call.input
-                        `shouldSatisfy` (<= remoteCompactionMaxStringLength)
-                other ->
-                    expectationFailure
-                        ("expected sanitized custom tool call, got " <> show other)
-
         it "truncates oversized messages without rewriting a tiny trailing output" do
             let huge = user (Text.replicate 20_000 "x")
                 tiny = FunctionCallOutputItem FunctionCallOutput
@@ -539,6 +572,8 @@ spec = do
                 recent = FunctionCallOutputItem FunctionCallOutput
                     { itemId = Nothing
                     , callId = "call-1"
+                    , name = Nothing
+                    , namespace = Nothing
                     , output = Aeson.String "ok"
                     , status = Just ItemCompleted
                     , extraFields = KeyMap.empty
@@ -588,13 +623,17 @@ spec = do
                     { itemId = Nothing
                     , callId = ""
                     , name = "shell_command"
+                    , namespace = Nothing
                     , arguments = Text.replicate 20_000 "x"
+                    , encryptedFunctionArgs = Nothing
                     , status = Nothing
                     , extraFields = KeyMap.empty
                     }
                 output = FunctionCallOutputItem FunctionCallOutput
                     { itemId = Nothing
                     , callId = ""
+                    , name = Nothing
+                    , namespace = Nothing
                     , output = Aeson.String "ok"
                     , status = Just ItemCompleted
                     , extraFields = KeyMap.empty
@@ -933,14 +972,11 @@ spec = do
                 `shouldBe` [latest, user "recent"]
 
     describe "hasCompactionCheckpoint" do
-        it "recognizes only typed remote compaction checkpoints" do
+        it "recognizes typed and locally generated compaction checkpoints" do
             hasCompactionCheckpoint [checkpoint "remote"] `shouldBe` True
             hasCompactionCheckpoint
                 (buildLocalCompactedHistory 1 [user "old"] "local summary")
-                `shouldBe` False
-            hasCompactionCheckpoint
-                [assistantSummaryItem "ordinary model-controlled text"]
-                `shouldBe` False
+                `shouldBe` True
             hasCompactionCheckpoint [assistant "ordinary response"]
                 `shouldBe` False
 

--- a/packages/agent-openai/test/Agent/OpenAI/CompactionSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/CompactionSpec.hs
@@ -632,6 +632,31 @@ spec = do
                 `shouldSatisfy` (<= 100)
             trimmed `shouldBe` [recent]
 
+        it "drops MCP approval responses with their oversized requests" do
+            let request = KnownResponseItem ItemMcpApprovalRequest TaggedObject
+                    { tag = "mcp_approval_request"
+                    , fields = KeyMap.fromList
+                        [ ("id", Aeson.String "approval-1")
+                        , ("reason", Aeson.String (Text.replicate 20_000 "x"))
+                        ]
+                    }
+                response = KnownResponseItem ItemMcpApprovalResponse TaggedObject
+                    { tag = "mcp_approval_response"
+                    , fields = KeyMap.fromList
+                        [ ("approval_request_id", Aeson.String "approval-1")
+                        , ("approved", Aeson.Bool True)
+                        ]
+                    }
+                recent = user "recent"
+                trimmed =
+                    trimRemoteCompactionHistoryToFit
+                        100
+                        Nothing
+                        [request, response, recent]
+            estimateItemsTokens (trimmed <> [compactionTriggerItem])
+                `shouldSatisfy` (<= 100)
+            trimmed `shouldBe` [recent]
+
         it "rewrites large tagged output items when they expose a payload field" do
             let output = KnownResponseItem ItemShellCallOutput TaggedObject
                     { tag = "shell_call_output"

--- a/packages/agent-openai/test/Agent/OpenAI/CompactionSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/CompactionSpec.hs
@@ -12,6 +12,7 @@ import qualified Data.Aeson.KeyMap as KeyMap
 import Data.Either (isLeft)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
+import qualified Data.Vector as Vector
 import Test.Hspec
 
 spec :: Spec
@@ -58,6 +59,59 @@ spec = do
                 request = buildRemoteCompactionRequest params [user "hello"]
             request.parallelToolCalls `shouldBe` Just False
 
+        it "includes request-level fields in request token estimates" do
+            let params = (defaultResponseCreateParams :: ResponseCreateParams)
+                    { instructions = Just (Text.replicate 1_000 "i")
+                    , tools = Just []
+                    }
+                history = [user "hello"]
+            estimateRequestTokensWithItems params history
+                `shouldSatisfy` (> estimateItemsTokens history)
+
+        it "trims against the complete remote request size" do
+            let params = (defaultResponseCreateParams :: ResponseCreateParams)
+                    { instructions = Just (Text.replicate 1_000 "i")
+                    , tools = Just []
+                    }
+                history = [user (Text.replicate 4_000 "x")]
+                trimmed =
+                    trimRemoteCompactionRequestToFit 500 params history
+                request = buildRemoteCompactionRequest params trimmed
+            estimateResponseCreateParamsTokens request `shouldSatisfy` (<= 500)
+            trimmed `shouldSatisfy` \items ->
+                case items of
+                    [MessageItem message] ->
+                        Text.length (userOnly message) < 4_000
+                    _ -> True
+
+        it "accounts for large tool schemas when trimming remote requests" do
+            let schemaText = Text.replicate 20_000 "s"
+                tool = FunctionToolValue FunctionTool
+                    { name = "large_schema"
+                    , description = Just schemaText
+                    , parameters = Just (Aeson.object
+                        [ "type" .= ("object" :: Text.Text)
+                        , "properties" .= Aeson.object
+                            [ "value" .= Aeson.object
+                                [ "type" .= ("string" :: Text.Text)
+                                , "description" .= schemaText
+                                ]
+                            ]
+                        ])
+                    , strict = Nothing
+                    , extraFields = KeyMap.empty
+                    }
+                params = (defaultResponseCreateParams :: ResponseCreateParams)
+                    { tools = Just [tool]
+                    }
+                history = [user (Text.replicate 10_000 "x")]
+                trimmed = trimRemoteCompactionRequestToFit 11_000 params history
+                request = buildRemoteCompactionRequest params trimmed
+            estimateRequestTokensWithItems params history
+                `shouldSatisfy` (> estimateItemsTokens history)
+            estimateResponseCreateParamsTokens request
+                `shouldSatisfy` (<= 11_000)
+
         it "accepts exactly one compaction item alongside unrelated output" do
             let opaque = checkpoint "opaque"
                 response = completedResponse [assistant "ignored", opaque]
@@ -91,6 +145,198 @@ spec = do
             buildRemoteCompactedHistory 64_000 history opaque
                 `shouldBe` [user "old", user "recent", opaque]
 
+        it "sanitizes rich user content before retaining it" do
+            let payload = Text.replicate 100_000 "x"
+                rich = MessageItem ResponseMessage
+                    { messageId = Nothing
+                    , content = MessageContentParts
+                        [ InputTextPart "keep this" Nothing KeyMap.empty
+                        , InputImagePart
+                            { detail = Just "auto"
+                            , fileId = Nothing
+                            , imageUrl = Just ("data:image/png;base64," <> payload)
+                            , promptCacheBreakpoint = Nothing
+                            , extraFields = KeyMap.empty
+                            }
+                        , InputFilePart
+                            { detail = Just "auto"
+                            , fileData = Just ("data:text/plain;base64," <> payload)
+                            , fileId = Nothing
+                            , fileUrl = Nothing
+                            , filename = Just "notes.txt"
+                            , promptCacheBreakpoint = Nothing
+                            , extraFields = KeyMap.empty
+                            }
+                        , InputAudioPart
+                            { inputAudio = Aeson.String payload
+                            , extraFields = KeyMap.empty
+                            }
+                        , UnknownContentPart TaggedObject
+                            { tag = "input_unknown"
+                            , fields = KeyMap.empty
+                            }
+                        ]
+                    , role = RoleUser
+                    , status = Nothing
+                    , phase = Nothing
+                    , extraFields = KeyMap.empty
+                    }
+                compacted =
+                    buildRemoteCompactedHistory 1_000 [rich] (checkpoint "opaque")
+            estimateItemsTokens [rich] `shouldSatisfy` (> 50_000)
+            case compacted of
+                retained : _ -> do
+                    let serialized = show retained
+                    length serialized `shouldSatisfy` (< 5_000)
+                    serialized `shouldNotContain` "data:image/png;base64"
+                    serialized `shouldNotContain` "data:text/plain;base64"
+                [] ->
+                    expectationFailure "rich user message was dropped"
+
+        it "omits inline image payloads from retained user messages" do
+            let imageUrl =
+                    "data:image/png;base64,"
+                        <> Text.replicate 1_000_000 "x"
+                multimodal = MessageItem ResponseMessage
+                    { messageId = Nothing
+                    , content = MessageContentParts
+                        [ InputTextPart "inspect this" Nothing KeyMap.empty
+                        , InputImagePart
+                            { detail = Just "auto"
+                            , fileId = Nothing
+                            , imageUrl = Just imageUrl
+                            , promptCacheBreakpoint = Nothing
+                            , extraFields = KeyMap.empty
+                            }
+                        ]
+                    , role = RoleUser
+                    , status = Nothing
+                    , phase = Nothing
+                    , extraFields = KeyMap.empty
+                    }
+                compacted =
+                    buildRemoteCompactedHistory
+                        64_000
+                        [multimodal]
+                        (checkpoint "opaque")
+            estimateItemsTokens compacted `shouldSatisfy` (< 1_000)
+            compacted `shouldSatisfy` \case
+                MessageItem message : _ ->
+                    case message.content of
+                        MessageContentParts parts ->
+                            all (\case InputImagePart{} -> False; _ -> True) parts
+                                && any (\case
+                                    InputTextPart text _ _ ->
+                                        Text.isInfixOf
+                                            "image attachment omitted"
+                                            text
+                                    _ -> False)
+                                    parts
+                        _ -> False
+                _ -> False
+
+        it "uses output text notices for assistant rich content" do
+            let rich = MessageItem ResponseMessage
+                    { messageId = Nothing
+                    , content = MessageContentParts
+                        [ InputImagePart
+                            { detail = Nothing
+                            , fileId = Nothing
+                            , imageUrl = Just "data:image/png;base64,huge"
+                            , promptCacheBreakpoint = Nothing
+                            , extraFields = KeyMap.empty
+                            }
+                        ]
+                    , role = RoleAssistant
+                    , status = Nothing
+                    , phase = Nothing
+                    , extraFields = KeyMap.empty
+                    }
+            sanitizeCompactionHistory [rich] `shouldSatisfy` \case
+                [MessageItem message] ->
+                    case message.content of
+                        MessageContentParts [OutputTextPart{}] -> True
+                        _ -> False
+                _ -> False
+
+        it "rewrites image-bearing messages when trimming a compaction request" do
+            let imageUrl =
+                    "data:image/png;base64,"
+                        <> Text.replicate 1_000_000 "x"
+                multimodal = MessageItem ResponseMessage
+                    { messageId = Nothing
+                    , content = MessageContentParts
+                        [ InputTextPart "inspect this" Nothing KeyMap.empty
+                        , InputImagePart
+                            { detail = Just "auto"
+                            , fileId = Nothing
+                            , imageUrl = Just imageUrl
+                            , promptCacheBreakpoint = Nothing
+                            , extraFields = KeyMap.empty
+                            }
+                        ]
+                    , role = RoleUser
+                    , status = Nothing
+                    , phase = Nothing
+                    , extraFields = KeyMap.empty
+                    }
+                trimmed =
+                    trimRemoteCompactionHistoryToFit
+                        1_000
+                        Nothing
+                        [multimodal]
+            estimateItemsTokens trimmed `shouldSatisfy` (< 1_000)
+            trimmed `shouldSatisfy` \case
+                [MessageItem message] ->
+                    case message.content of
+                        MessageContentParts parts ->
+                            all (\case InputImagePart{} -> False; _ -> True) parts
+                        _ -> False
+                _ -> False
+
+        it "drops an unrewritable oldest item to guarantee the request fits" do
+            let params = (defaultResponseCreateParams :: ResponseCreateParams)
+                    { tools = Just []
+                    }
+                opaque = UnknownResponseItem TaggedObject
+                    { tag = "vendor_blob"
+                    , fields = KeyMap.fromList
+                        [ ("type", Aeson.String "vendor_blob")
+                        , ("blob", Aeson.String (Text.replicate 20_000 "x"))
+                        ]
+                    }
+                recent = user "recent"
+                trimmed =
+                    trimRemoteCompactionRequestToFit
+                        200
+                        params
+                        [opaque, recent]
+            estimateResponseCreateParamsTokens
+                (buildRemoteCompactionRequest params trimmed)
+                `shouldSatisfy` (<= 200)
+            trimmed `shouldSatisfy` elem recent
+
+        it "does not silently discard an irreducible prior checkpoint" do
+            let params = (defaultResponseCreateParams :: ResponseCreateParams)
+                    { tools = Just []
+                    }
+                prior = KnownResponseItem ItemCompaction TaggedObject
+                    { tag = "compaction"
+                    , fields = KeyMap.fromList
+                        [ ("encrypted_content",
+                            Aeson.String (Text.replicate 20_000 "x"))
+                        ]
+                    }
+                trimmed =
+                    trimRemoteCompactionRequestToFit
+                        200
+                        params
+                        [prior]
+            trimmed `shouldBe` [prior]
+            estimateResponseCreateParamsTokens
+                (buildRemoteCompactionRequest params trimmed)
+                `shouldSatisfy` (> 200)
+
         it "drops harness-generated user-role context wrappers" do
             let opaque = checkpoint "opaque"
                 history =
@@ -120,7 +366,7 @@ spec = do
                 old = Text.replicate 40 "o"
                 recent = "recent"
                 compacted =
-                    buildRemoteCompactedHistory 3
+                    buildRemoteCompactedHistory 45
                         [user old, user recent]
                         opaque
                 retainedTexts =
@@ -128,7 +374,12 @@ spec = do
                     | MessageItem message <- compacted
                     , message.role == RoleUser
                     ]
-            retainedTexts `shouldBe` [Text.take 8 old, recent]
+            retainedTexts `shouldSatisfy` \texts ->
+                case texts of
+                    [truncated, newest] ->
+                        Text.length truncated < Text.length old
+                            && newest == recent
+                    _ -> False
             last compacted `shouldBe` opaque
 
         it "rewrites a trailing oversized tool output to fit the request window" do
@@ -216,6 +467,254 @@ spec = do
                     expectationFailure
                         ("expected sanitized custom tool call, got " <> show other)
 
+        it "truncates oversized messages without rewriting a tiny trailing output" do
+            let huge = user (Text.replicate 20_000 "x")
+                tiny = FunctionCallOutputItem FunctionCallOutput
+                    { itemId = Nothing
+                    , callId = "call-1"
+                    , name = Nothing
+                    , namespace = Nothing
+                    , output = Aeson.String "ok"
+                    , status = Just ItemCompleted
+                    , extraFields = KeyMap.empty
+                    }
+                trimmed =
+                    trimRemoteCompactionHistoryToFit
+                        100
+                        Nothing
+                        [huge, tiny]
+            trimmed `shouldSatisfy` any \case
+                FunctionCallOutputItem output ->
+                    output.output == Aeson.String "ok"
+                _ -> False
+            trimmed `shouldSatisfy` any \case
+                MessageItem message ->
+                    case message.content of
+                        MessageContentParts [InputTextPart text _ _] ->
+                            Text.length text < 20_000
+                        MessageContentText text ->
+                            Text.length text < 20_000
+                        _ -> False
+                _ -> False
+
+        it "revisits old messages after rewriting later oversized outputs" do
+            let huge = user (Text.replicate 20_000 "x")
+                output = FunctionCallOutputItem FunctionCallOutput
+                    { itemId = Nothing
+                    , callId = "call-1"
+                    , name = Nothing
+                    , namespace = Nothing
+                    , output = Aeson.String (Text.replicate 20_000 "y")
+                    , status = Just ItemCompleted
+                    , extraFields = KeyMap.empty
+                    }
+                trimmed =
+                    trimRemoteCompactionHistoryToFit
+                        200
+                        Nothing
+                        [huge, output]
+            estimateItemsTokens (trimmed <> [compactionTriggerItem])
+                `shouldSatisfy` (<= 200)
+            trimmed `shouldSatisfy` any \case
+                MessageItem{} -> True
+                _ -> False
+            trimmed `shouldSatisfy` any \case
+                FunctionCallOutputItem result ->
+                    result.output
+                        == Aeson.String
+                            "Output exceeded the available model context and was truncated"
+                _ -> False
+
+        it "drops an irreducible old item so a recent small output can fit" do
+            let old = KnownResponseItem ItemReasoning TaggedObject
+                    { tag = "reasoning"
+                    , fields = KeyMap.fromList
+                        [ ("type", Aeson.String "reasoning")
+                        , ("summary", Aeson.String (Text.replicate 20_000 "x"))
+                        ]
+                    }
+                recent = FunctionCallOutputItem FunctionCallOutput
+                    { itemId = Nothing
+                    , callId = "call-1"
+                    , output = Aeson.String "ok"
+                    , status = Just ItemCompleted
+                    , extraFields = KeyMap.empty
+                    }
+                trimmed =
+                    trimRemoteCompactionHistoryToFit
+                        100
+                        Nothing
+                        [old, recent]
+            estimateItemsTokens (trimmed <> [compactionTriggerItem])
+                `shouldSatisfy` (<= 100)
+            trimmed `shouldBe` [recent]
+
+        it "drops paired tagged outputs with their oversized calls" do
+            let call = KnownResponseItem ItemShellCall TaggedObject
+                    { tag = "shell_call"
+                    , fields = KeyMap.fromList
+                        [ ("id", Aeson.String "call-1")
+                        , ("command", Aeson.String (Text.replicate 20_000 "x"))
+                        ]
+                    }
+                output = KnownResponseItem ItemShellCallOutput TaggedObject
+                    { tag = "shell_call_output"
+                    , fields = KeyMap.fromList
+                        [ ("call_id", Aeson.String "call-1")
+                        , ("output", Aeson.String "ok")
+                        ]
+                    }
+                recent = user "recent"
+                trimmed =
+                    trimRemoteCompactionHistoryToFit
+                        100
+                        Nothing
+                        [call, output, recent]
+            estimateItemsTokens (trimmed <> [compactionTriggerItem])
+                `shouldSatisfy` (<= 100)
+            trimmed `shouldBe` [recent]
+
+        it "rewrites large tagged output items when they expose a payload field" do
+            let output = KnownResponseItem ItemShellCallOutput TaggedObject
+                    { tag = "shell_call_output"
+                    , fields = KeyMap.fromList
+                        [ ("type", Aeson.String "shell_call_output")
+                        , ("id", Aeson.String "shell-output-1")
+                        , ("output", Aeson.String (Text.replicate 20_000 "x"))
+                        ]
+                    }
+                trimmed =
+                    trimRemoteCompactionHistoryToFit
+                        100
+                        Nothing
+                        [user "keep", output]
+            trimmed `shouldSatisfy` any \case
+                KnownResponseItem ItemShellCallOutput tagged ->
+                    KeyMap.lookup "output" tagged.fields
+                        == Just (Aeson.String
+                            "Output exceeded the available model context and was truncated")
+                _ -> False
+
+        it "rewrites plural payload fields on provider-managed outputs" do
+            let output = KnownResponseItem ItemCodeInterpreterCall TaggedObject
+                    { tag = "code_interpreter_call"
+                    , fields = KeyMap.fromList
+                        [ ("id", Aeson.String "code-1")
+                        , ("outputs", Aeson.Array
+                            (Vector.singleton
+                                (Aeson.String (Text.replicate 20_000 "x"))))
+                        ]
+                    }
+                trimmed =
+                    trimRemoteCompactionHistoryToFit
+                        100
+                        Nothing
+                        [user "keep", output]
+            trimmed `shouldSatisfy` any \case
+                KnownResponseItem ItemCodeInterpreterCall tagged ->
+                    KeyMap.lookup "outputs" tagged.fields
+                        == Just (Aeson.Array Vector.empty)
+                _ -> False
+
+        it "rewrites provider-specific output items without dropping their identity" do
+            let output = KnownResponseItem
+                    (ItemUnknownType "vendor_widget_output")
+                    TaggedObject
+                        { tag = "vendor_widget_output"
+                        , fields = KeyMap.fromList
+                            [ ("type", Aeson.String "vendor_widget_output")
+                            , ("id", Aeson.String "vendor-output-1")
+                            , ("result", Aeson.String (Text.replicate 20_000 "x"))
+                            ]
+                        }
+                trimmed =
+                    trimRemoteCompactionHistoryToFit
+                        100
+                        Nothing
+                        [user "keep", output]
+            trimmed `shouldSatisfy` any \case
+                KnownResponseItem (ItemUnknownType "vendor_widget_output") tagged ->
+                    KeyMap.lookup "type" tagged.fields
+                        == Just (Aeson.String "vendor_widget_output")
+                        && KeyMap.lookup "result" tagged.fields
+                            == Just (Aeson.String
+                                "Output exceeded the available model context and was truncated")
+                _ -> False
+
+        it "rewrites inline results on call-shaped provider items" do
+            let output = KnownResponseItem ItemMcpCall TaggedObject
+                    { tag = "mcp_call"
+                    , fields = KeyMap.fromList
+                        [ ("type", Aeson.String "mcp_call")
+                        , ("id", Aeson.String "mcp-1")
+                        , ("status", Aeson.String "completed")
+                        , ("result", Aeson.String (Text.replicate 20_000 "x"))
+                        ]
+                    }
+                trimmed =
+                    trimRemoteCompactionHistoryToFit
+                        100
+                        Nothing
+                        [user "keep", output]
+            trimmed `shouldSatisfy` any \case
+                KnownResponseItem ItemMcpCall tagged ->
+                    KeyMap.lookup "type" tagged.fields
+                        == Just (Aeson.String "mcp_call")
+                        && KeyMap.lookup "status" tagged.fields
+                            == Just (Aeson.String "completed")
+                        && KeyMap.lookup "result" tagged.fields
+                            == Just (Aeson.String
+                                "Output exceeded the available model context and was truncated")
+                _ -> False
+
+        it "drops call-shaped items rather than corrupting input-like payloads" do
+            let recent = user "recent"
+                knownCall = KnownResponseItem ItemMcpCall TaggedObject
+                    { tag = "mcp_call"
+                    , fields = KeyMap.fromList
+                        [ ("type", Aeson.String "mcp_call")
+                        , ("id", Aeson.String "mcp-1")
+                        , ("content", Aeson.String (Text.replicate 20_000 "x"))
+                        ]
+                    }
+                unknownCall = UnknownResponseItem TaggedObject
+                    { tag = "vendor_call"
+                    , fields = KeyMap.fromList
+                        [ ("type", Aeson.String "vendor_call")
+                        , ("id", Aeson.String "vendor-1")
+                        , ("payload", Aeson.String (Text.replicate 20_000 "x"))
+                        ]
+                    }
+                trim call =
+                    trimRemoteCompactionHistoryToFit
+                        100
+                        Nothing
+                        [call, recent]
+            map trim [knownCall, unknownCall]
+                `shouldBe` replicate 2 [recent]
+
+        it "rewrites completely unknown output tags when their payload is recognizable" do
+            let output = UnknownResponseItem TaggedObject
+                    { tag = "acme_output"
+                    , fields = KeyMap.fromList
+                        [ ("type", Aeson.String "acme_output")
+                        , ("output", Aeson.String (Text.replicate 20_000 "x"))
+                        ]
+                    }
+                trimmed =
+                    trimRemoteCompactionHistoryToFit
+                        100
+                        Nothing
+                        [user "keep", output]
+            trimmed `shouldSatisfy` any \case
+                UnknownResponseItem tagged ->
+                    KeyMap.lookup "type" tagged.fields
+                        == Just (Aeson.String "acme_output")
+                        && KeyMap.lookup "output" tagged.fields
+                            == Just (Aeson.String
+                                "Output exceeded the available model context and was truncated")
+                _ -> False
+
     describe "Codex model metadata" do
         it "derives the 90% auto-compaction limit for curated 272k models" do
             codexModelMetadata "gpt-5.6-luna"
@@ -228,6 +727,13 @@ spec = do
                 `shouldBe` 244_800
 
     describe "buildLocalCompactedHistory" do
+        it "asks summaries to preserve durable project constraints" do
+            let prompt = summarizationPrompt Nothing
+            prompt `shouldSatisfy` Text.isInfixOf "active project instructions"
+            prompt `shouldSatisfy` Text.isInfixOf "always-active"
+            prompt `shouldSatisfy` Text.isInfixOf "safety and policy constraints"
+            prompt `shouldSatisfy` Text.isInfixOf "required workflows"
+
         it "keeps recent user texts and an assistant summary" do
             let history =
                     [ user "one"
@@ -250,6 +756,82 @@ spec = do
             let texts = [userOnly m | MessageItem m <- compacted, m.role == RoleUser]
             texts `shouldBe` ["keep me"]
 
+        it "does not skip ordinary messages beginning with /compaction" do
+            let history =
+                    [ user "/compaction algorithm"
+                    , user "keep me"
+                    ]
+                compacted = buildLocalCompactedHistory 3 history "summary"
+                texts = [userOnly m | MessageItem m <- compacted, m.role == RoleUser]
+            texts `shouldBe` ["/compaction algorithm", "keep me"]
+
+        it "omits generated project and skill wrappers from local snapshots" do
+            let history =
+                    [ user "# AGENTS.md instructions for /tmp/project\nrules"
+                    , user "# Skill instructions: test\nrules"
+                    , user "old request"
+                    , user "new request"
+                    ]
+                compacted = buildLocalCompactedHistory 1 history "summary"
+                texts = [userOnly m | MessageItem m <- compacted, m.role == RoleUser]
+            texts `shouldBe` ["new request"]
+
+        it "bounds installed local snapshots with oversized recent users" do
+            let params = (defaultResponseCreateParams :: ResponseCreateParams)
+                    { tools = Just []
+                    }
+                contextWindow = defaultCodexEffectiveContextWindow
+                history =
+                    [ user (Text.replicate 100_000
+                        ("message-" <> Text.pack (show index)))
+                    | index <- [1 :: Int .. 6]
+                    ]
+                compacted =
+                    buildLocalCompactedHistoryToFit
+                        contextWindow
+                        params
+                        6
+                        history
+                        "bounded summary"
+                targetWindow =
+                    min contextWindow
+                        ( estimateRequestTokensWithItems params []
+                            + remoteCompactionRetainedTokenBudget
+                        )
+            estimateRequestTokensWithItems params compacted
+                `shouldSatisfy` (<= targetWindow)
+            case reverse compacted of
+                summaryItem : _ ->
+                    summaryItem `shouldSatisfy` isSummary
+                [] ->
+                    expectationFailure "expected a protected local summary"
+
+        it "bounds normal Responses history with a fixed summary prompt" do
+            let params = (defaultResponseCreateParams :: ResponseCreateParams)
+                    { tools = Nothing
+                    }
+                prompt = user "summarize"
+                trimmed =
+                    trimResponseHistoryToFit
+                        300
+                        params
+                        [prompt]
+                        [user (Text.replicate 20_000 "x")]
+            estimateRequestTokensWithItems params (trimmed <> [prompt])
+                `shouldSatisfy` (<= 300)
+
+        it "uses serialized item sizes for retained-message budgeting" do
+            let history = replicate 100 (user "x")
+                compacted =
+                    buildRemoteCompactedHistory 200 history (checkpoint "opaque")
+                retained =
+                    [ item
+                    | item <- compacted
+                    , not (isCheckpoint item)
+                    ]
+            estimateItemsTokens retained `shouldSatisfy` (<= 200)
+            length retained `shouldSatisfy` (< 100)
+
     describe "compactTranscriptAtLastCheckpoint" do
         it "retains its legacy raw-checkpoint behavior for API compatibility" do
             let first = checkpoint "first"
@@ -265,11 +847,14 @@ spec = do
                 `shouldBe` [latest, user "recent"]
 
     describe "hasCompactionCheckpoint" do
-        it "recognizes remote and local compaction snapshots" do
+        it "recognizes only typed remote compaction checkpoints" do
             hasCompactionCheckpoint [checkpoint "remote"] `shouldBe` True
             hasCompactionCheckpoint
                 (buildLocalCompactedHistory 1 [user "old"] "local summary")
-                `shouldBe` True
+                `shouldBe` False
+            hasCompactionCheckpoint
+                [assistantSummaryItem "ordinary model-controlled text"]
+                `shouldBe` False
             hasCompactionCheckpoint [assistant "ordinary response"]
                 `shouldBe` False
 
@@ -335,6 +920,8 @@ spec = do
                     Text.isPrefixOf summaryPrefix text
                 _ -> False
     isSummary _ = False
+    isCheckpoint (KnownResponseItem ItemCompaction _) = True
+    isCheckpoint _ = False
     isWireValidAssistantSummary (MessageItem m) =
         m.role == RoleAssistant
             && case m.content of

--- a/packages/agent-openai/test/Agent/OpenAI/CompactionSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/CompactionSpec.hs
@@ -342,6 +342,9 @@ spec = do
                 history =
                     [ user "# AGENTS.md instructions for /tmp/project\n\n<INSTRUCTIONS>generated</INSTRUCTIONS>"
                     , user "# Skill instructions: example\n\n<SKILL_INSTRUCTIONS>generated</SKILL_INSTRUCTIONS>"
+                    , user "## Skills\nThe following reusable skills are available in this session.\n"
+                    , user "<learned-skills>\nThese are durable, reusable instructions learned from earlier sessions.\n"
+                    , user "<system-reminder>\nAs you answer the user's questions, you can use the following context\n"
                     , user "<subagent_notification>\nstatus: completed\n</subagent_notification>"
                     , user "real user request"
                     ]
@@ -548,6 +551,61 @@ spec = do
             estimateItemsTokens (trimmed <> [compactionTriggerItem])
                 `shouldSatisfy` (<= 100)
             trimmed `shouldBe` [recent]
+
+        it "does not delete tagged outputs when pairing ids are missing" do
+            let callWith identifier = KnownResponseItem ItemShellCall TaggedObject
+                    { tag = "shell_call"
+                    , fields = KeyMap.fromList $
+                        [ ("command", Aeson.String (Text.replicate 20_000 "x"))
+                        ]
+                            <> maybe []
+                                (\value -> [("id", Aeson.String value)])
+                                identifier
+                    }
+                outputWith identifier =
+                    KnownResponseItem ItemShellCallOutput TaggedObject
+                        { tag = "shell_call_output"
+                        , fields = KeyMap.fromList $
+                            [ ("output", Aeson.String "ok")
+                            ]
+                                <> maybe []
+                                    (\value ->
+                                        [("call_id", Aeson.String value)])
+                                    identifier
+                        }
+                identifiedOutput = outputWith (Just "other-call")
+                unidentifiedOutput = outputWith Nothing
+                recent = user "recent"
+                trim =
+                    trimRemoteCompactionHistoryToFit 200 Nothing
+            trim [callWith Nothing, identifiedOutput, recent]
+                `shouldBe` [identifiedOutput, recent]
+            trim [callWith (Just "call-1"), unidentifiedOutput, recent]
+                `shouldBe` [unidentifiedOutput, recent]
+
+        it "does not pair typed calls with empty identifiers" do
+            let call = FunctionCallItem FunctionCall
+                    { itemId = Nothing
+                    , callId = ""
+                    , name = "shell_command"
+                    , arguments = Text.replicate 20_000 "x"
+                    , status = Nothing
+                    , extraFields = KeyMap.empty
+                    }
+                output = FunctionCallOutputItem FunctionCallOutput
+                    { itemId = Nothing
+                    , callId = ""
+                    , output = Aeson.String "ok"
+                    , status = Just ItemCompleted
+                    , extraFields = KeyMap.empty
+                    }
+                recent = user "recent"
+                trimmed =
+                    trimRemoteCompactionHistoryToFit
+                        200
+                        Nothing
+                        [call, output, recent]
+            trimmed `shouldBe` [output, recent]
 
         it "drops paired tagged outputs with their oversized calls" do
             let call = KnownResponseItem ItemShellCall TaggedObject
@@ -769,6 +827,9 @@ spec = do
             let history =
                     [ user "# AGENTS.md instructions for /tmp/project\nrules"
                     , user "# Skill instructions: test\nrules"
+                    , user "## Skills\nThe following reusable skills are available in this session.\nrules"
+                    , user "<learned-skills>\nThese are durable, reusable instructions learned from earlier sessions.\nrules"
+                    , user "<system-reminder>\nAs you answer the user's questions, you can use the following context\nrules"
                     , user "old request"
                     , user "new request"
                     ]


### PR DESCRIPTION
## Summary

- Size compaction from the complete serialized Responses context, including instructions, tool schemas, retained history, pending inputs, and continuation state.
- Bound remote requests/checkpoints and local-summary requests/snapshots to the model context window, with typed failures for impossible thresholds and oversized first turns.
- Use catalog-provided context_window metadata for xAI, OpenRouter, and custom Responses models, resolving the effective transport/wire model and failing closed when metadata is absent instead of guessing with the Codex limit.
- Preserve protocol continuity while trimming: keep call/output pairs together, match MCP approvals by approval_request_id, and truncate an otherwise over-window completed-tool result before submitting it against its live response chain.
- Keep valid OpenAI checkpoints for focused OpenAI summaries, while preventing opaque OpenAI protocol items from being replayed to xAI, OpenRouter, or custom portable Responses endpoints.
- Reload generated AGENTS.md, filesystem-skill, and learned-skill context after automatic/manual compaction and transcript resets; repair resumed sessions that crossed an older boundary without a durable reload.

## Serious failures fixed

- Large tools, pending inputs, rich attachments, and tool results were omitted or undercounted, allowing over-window compaction and continuation requests.
- A completed-tool continuation intentionally deferred compaction but could still forward an oversized result directly to the provider.
- Configured thresholds above the effective context and oversized first turns could bypass local context enforcement.
- A permanent “saturated” cache marker could disable all future automatic compaction for the session.
- Oversized provider checkpoints or generated summaries could install snapshots that still could not fit the next request.
- Malformed/incomplete compaction responses could be accepted, trimming could orphan protocol-paired items, and MCP approval responses were not paired by their actual approval identifier.
- Portable summarizers could receive opaque OpenAI checkpoints, while indiscriminate filtering could discard valid compressed OpenAI context.
- Compaction/reset/resume paths could silently lose generated project and skill instructions.

## Tests

- `agent-openai-test`: **268 examples, 0 failures, 1 expected pending live-auth test**
- `agent-cli-test`: **1,031 examples, 0 failures, 1 expected pending Linux clipboard test**

Both suites were run from `nix develop` through their Cabal GHCi test components after rebasing onto current `master`.

