### PR TITLE
Harden TUI rendering with QuickCheck

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Input.hs
+++ b/packages/agent-cli/src/Agent/CLI/Input.hs
@@ -63,6 +63,10 @@ import Agent.CLI.Terminal
     , kittyKeyboardPop
     , stripAnsi
     )
+import Agent.TUI.TextWidth
+    ( nextGraphemeBoundary
+    , previousGraphemeBoundary
+    )
 import Control.Exception.Safe
     ( bracket
     , bracket_
@@ -306,12 +310,18 @@ readInlineEditor
             EditorBackspace -> continue history entries (backspace state)
             EditorDelete -> continue history entries (deleteAtCursor state)
             EditorLeft -> continue history entries state
-                { editorCursor = max 0 (state.editorCursor - 1)
+                { editorCursor =
+                    previousGraphemeBoundary
+                        state.editorText
+                        state.editorCursor
                 , editorSelected = 0
                 , editorSlashDismissed = False
                 }
             EditorRight -> continue history entries state
-                { editorCursor = min (Text.length state.editorText) (state.editorCursor + 1)
+                { editorCursor =
+                    nextGraphemeBoundary
+                        state.editorText
+                        state.editorCursor
                 , editorSelected = 0
                 , editorSlashDismissed = False
                 }
@@ -476,9 +486,13 @@ backspace :: EditorState -> EditorState
 backspace state
     | state.editorCursor <= 0 = state
     | otherwise =
-        let start = state.editorCursor - 1
+        let start =
+                previousGraphemeBoundary
+                    state.editorText
+                    state.editorCursor
             (before, rest) = Text.splitAt start state.editorText
-            (_, after) = Text.splitAt 1 rest
+            (_, after) =
+                Text.splitAt (state.editorCursor - start) rest
             text = before <> after
         in state
             { editorText = text
@@ -494,7 +508,11 @@ deleteAtCursor state
     | state.editorCursor >= Text.length state.editorText = state
     | otherwise =
         let (before, rest) = Text.splitAt state.editorCursor state.editorText
-            (_, after) = Text.splitAt 1 rest
+            end =
+                nextGraphemeBoundary
+                    state.editorText
+                    state.editorCursor
+            (_, after) = Text.splitAt (end - state.editorCursor) rest
             text = before <> after
         in state
             { editorText = text

--- a/packages/agent-cli/src/Agent/CLI/Input/Display.hs
+++ b/packages/agent-cli/src/Agent/CLI/Input/Display.hs
@@ -17,8 +17,12 @@ module Agent.CLI.Input.Display
     ) where
 
 import Agent.CLI.Input.Types (DisplayCell(..))
-import Agent.TUI.TextWidth (charCellWidth)
-import Data.Char (GeneralCategory(..), chr, generalCategory, ord)
+import Agent.TUI.TextWidth
+    ( charCellWidth
+    , displayTerminalText
+    , graphemeCellWidth
+    , graphemeClusters
+    )
 import Data.Text (Text)
 import qualified Data.Text as Text
 
@@ -29,30 +33,34 @@ terminalCharWidth :: Char -> Int
 terminalCharWidth = (.displayCellWidth) . displayCell
 
 displayCells :: Text -> [DisplayCell]
-displayCells = map displayCell . Text.unpack
+displayCells = map displayCluster . graphemeClusters
 
 displayCell :: Char -> DisplayCell
-displayCell char =
-    let shown = safeDisplayChar char
+displayCell = displayCluster . Text.singleton
+
+displayCluster :: Text -> DisplayCell
+displayCluster cluster =
+    let lineSafe =
+            Text.concatMap
+                (\character ->
+                    if character == '\n'
+                        then "↵"
+                        else Text.singleton character)
+                cluster
+        shown = displayTerminalText lineSafe
     in DisplayCell
         { displayCellText = shown
         , displayCellWidth = textColumns shown
+        , displayCellSourceLength = Text.length cluster
         }
 
 safeDisplayChar :: Char -> Text
 safeDisplayChar char
-    | char == '\n' || char == '\r' = "↵"
-    | char == '\t' = "⇥"
-    | code >= 0 && code <= 0x1f = Text.singleton (chr (0x2400 + code))
-    | code == 0x7f = "␡"
-    | code >= 0x80 && code <= 0x9f = "�"
-    | generalCategory char == Format = "�"
-    | otherwise = Text.singleton char
-  where
-    code = ord char
+    | char == '\n' = "↵"
+    | otherwise = displayTerminalText (Text.singleton char)
 
 textColumns :: Text -> Int
-textColumns = sum . map charColumns . Text.unpack
+textColumns = sum . map graphemeCellWidth . graphemeClusters
 
 charColumns :: Char -> Int
 charColumns = charCellWidth
@@ -72,20 +80,61 @@ takeColumns width = go 0
         | otherwise = cell : go (used + cell.displayCellWidth) rest
 
 takeSuffixColumns :: Int -> [DisplayCell] -> [DisplayCell]
-takeSuffixColumns width = reverse . takeColumns width . reverse
+takeSuffixColumns width =
+    dropWhile ((== 0) . (.displayCellWidth))
+        . reverse
+        . takeColumns width
+        . reverse
 
 visibleEditorText :: Int -> Text -> Int -> (Text, Int)
-visibleEditorText available raw cursor =
-    let cells = displayCells raw
-        before = take cursor cells
-    in if cellsWidth cells <= available
-        then (renderCells cells, cellsWidth before)
-        else
-            let leftRoom = max 1 (available * 2 `div` 3)
-                visibleBefore = takeSuffixColumns leftRoom before
-                start = length before - length visibleBefore
-                shownCells = takeColumns available (drop start cells)
-            in (renderCells shownCells, cellsWidth visibleBefore)
+visibleEditorText available raw requestedCursor
+    | available <= 0 = ("", 0)
+    | otherwise =
+        let cells = fitCells False (displayCells raw)
+            cursor = max 0 (min (Text.length raw) requestedCursor)
+            before = cellsBeforeCursor cursor cells
+        in if cellsWidth cells <= available
+            then (renderCells cells, cellsWidth before)
+            else
+                let leftRoom = max 1 (available * 2 `div` 3)
+                    preferredBefore = takeSuffixColumns leftRoom before
+                    -- A wide glyph may not fit in the preferred left-hand
+                    -- budget. If it fits in the full viewport, keep it
+                    -- rather than dropping all text before the cursor.
+                    visibleBefore =
+                        if null preferredBefore
+                            then takeSuffixColumns available before
+                            else preferredBefore
+                    start = length before - length visibleBefore
+                    shownCells = takeColumns available (drop start cells)
+                in (renderCells shownCells, cellsWidth visibleBefore)
+  where
+    -- A single terminal glyph can occupy two cells, so it cannot be shown
+    -- verbatim in a one-cell viewport. Keep a visible placeholder and,
+    -- crucially, preserve the cursor's cell position.
+    fitCells _ [] = []
+    fitCells suppressCombining (cell : rest)
+        | cell.displayCellWidth > available =
+            cell
+                { displayCellText = "…"
+                , displayCellWidth = 1
+                }
+                : fitCells True rest
+        | suppressCombining
+        , cell.displayCellWidth == 0 =
+            cell { displayCellText = "" } : fitCells True rest
+        | otherwise =
+            cell : fitCells False rest
+
+    cellsBeforeCursor cursor = go 0
+      where
+        go _ [] = []
+        go offset (cell : rest)
+            | offset + cell.displayCellSourceLength <= cursor =
+                cell : go
+                    (offset + cell.displayCellSourceLength)
+                    rest
+            | otherwise = []
 
 displayEditorText :: Text -> Text
 displayEditorText = renderCells . displayCells

--- a/packages/agent-cli/src/Agent/CLI/Input/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Input/Types.hs
@@ -55,6 +55,7 @@ data EditorState = EditorState
 data DisplayCell = DisplayCell
     { displayCellText :: !Text
     , displayCellWidth :: !Int
+    , displayCellSourceLength :: !Int
     }
 
 data EditorKey

--- a/packages/agent-cli/src/Agent/CLI/Markdown.hs
+++ b/packages/agent-cli/src/Agent/CLI/Markdown.hs
@@ -29,8 +29,9 @@ import Agent.TUI.Markdown.Inline
     )
 import qualified Agent.TUI.Markdown.Block as Block
 import Agent.TUI.TextWidth
-    ( displayCharCellWidth
-    , displayTerminalText
+    ( displayTerminalText
+    , graphemeCellWidth
+    , graphemeClusters
     )
 import Data.Char (isAlphaNum, isAscii, isSpace)
 import Data.List (transpose)
@@ -168,9 +169,7 @@ columnWidths rows =
     in map (maximum . (0 :) . map renderedWidth) cols
   where
     renderedWidth =
-        Text.foldl'
-            (\width character -> width + displayCharCellWidth character)
-            0
+        terminalDisplayWidth
             . inlinePlainText
             . parseInline
 
@@ -179,12 +178,7 @@ styleTableRow isHeader widths cells =
     let cellText w c =
             let inlines = parseInline c
                 visible = inlinePlainText inlines
-                width' =
-                    Text.foldl'
-                        (\total character ->
-                            total + displayCharCellWidth character)
-                        0
-                        visible
+                width' = terminalDisplayWidth visible
                 padding = max 0 (w - width')
                 base
                     | isHeader = [SetConsoleIntensity BoldIntensity]
@@ -196,6 +190,13 @@ styleTableRow isHeader widths cells =
         parts = zipWith cellText widths (cells ++ repeat "")
         bar = md [terminalMuted] "│"
     in bar <> Text.intercalate bar (take (length widths) parts) <> bar
+
+terminalDisplayWidth :: Text -> Int
+terminalDisplayWidth =
+    sum
+        . map graphemeCellWidth
+        . graphemeClusters
+        . displayTerminalText
 
 styleInline :: Text -> Text
 styleInline = renderInlineWith [] . parseInline

--- a/packages/agent-cli/src/Agent/CLI/Render.hs
+++ b/packages/agent-cli/src/Agent/CLI/Render.hs
@@ -118,6 +118,7 @@ import Agent.TUI.Motion
     , motionIntervalMicros
     , nativeProgressAnimationEnabled
     )
+import Agent.TUI.TextWidth (splitTerminalGraphemeSuffix)
 import System.Environment (lookupEnv)
 import System.IO (Handle, hFlush)
 
@@ -238,8 +239,21 @@ feedProse state input =
         (linePart, rest)
             | Text.null rest ->
                 let source = state.pending <> linePart
-                    (ready, pending', nextContext) =
+                    (parsedReady, parsedPending, parsedContext) =
                         splitMarkdownFragment state.context source
+                    (stablePrefix, graphemePending) =
+                        splitTerminalGraphemeSuffix parsedReady
+                    (ready, reparsedPending, nextContext)
+                        | Text.null graphemePending =
+                            (parsedReady, "", parsedContext)
+                        | otherwise =
+                            splitMarkdownFragment
+                                state.context
+                                stablePrefix
+                    pending' =
+                        reparsedPending
+                            <> graphemePending
+                            <> parsedPending
                 in ( state
                         { pending = pending'
                         , context = nextContext

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -165,6 +165,7 @@ import Agent.TUI.Markdown
     , markdownWidgetWithLinks
     , markdownWidgetWithSyntaxHighlightingAndLinks
     )
+import Agent.TUI.TextWidth (displayTerminalText)
 import Agent.Syntax
     ( SyntaxHighlighter
     , loadSyntaxHighlighter
@@ -1694,6 +1695,12 @@ drawApp state =
             <> mainLayers
     dimmedMainLayers = map (forceAttr Theme.dimAttr) mainLayers
 
+terminalTxt :: Text -> Widget n
+terminalTxt = txt . displayTerminalText
+
+terminalTxtWrap :: Text -> Widget n
+terminalTxtWrap = txtWrap . displayTerminalText
+
 drawMain :: AppState -> Widget Name
 drawMain state =
     fullscreenSurface $
@@ -1824,7 +1831,7 @@ drawImagePreviews native previews =
                         else renderTuiImagePreview maxWidth maxHeight preview
                 , hCenter $
                     withAttr Theme.mutedAttr $
-                        txt $
+                        terminalTxt $
                             "🖼 "
                                 <> preview.previewMime
                                 <> " · "
@@ -1947,16 +1954,16 @@ drawAgentConversation :: AppState -> AgentEntry -> Widget Name
 drawAgentConversation state entry =
     vBox
         [ withAttr Theme.headingAttr $
-            txt ("Viewing " <> entry.agentPath)
+            terminalTxt ("Viewing " <> entry.agentPath)
         , withAttr Theme.mutedAttr $
-            txt
+            terminalTxt
                 (entry.agentStatus
                     <> " · input is sent to /root")
         , padTop (Pad 1) $
             if Seq.null entry.agentConversation.uiBlocks
                 then
                     withAttr Theme.mutedAttr $
-                        txt "(no transcript yet)"
+                        terminalTxt "(no transcript yet)"
                 else
                     drawConversationBlocks
                         state
@@ -2061,7 +2068,7 @@ drawAgentPane state entryLimit selected hovered entries =
                 | otherwise =
                     agentStatusGlyph entry.agentStatus
             row = hBox
-                [ txt
+                [ terminalTxt
                     (marker
                         <> agentEntryTreeLabelWithGlyphModel
                             statusGlyph
@@ -2156,7 +2163,7 @@ drawAgentPopover state placeLeft width height entry =
                         withBorderStyle unicodeRounded $
                             borderWithLabel
                                 (withAttr Theme.headingAttr $
-                                    txt
+                                    terminalTxt
                                         (" "
                                             <> truncateDisplayText
                                                 (max 1 (width - 6))
@@ -2193,14 +2200,14 @@ drawAgentStep state width step =
                     txt (agentStepGlyph state step.agentStepState)
                 , txt " "
                 , withAttr Theme.assistantAttr $
-                    txt
+                    terminalTxt
                         (truncateDisplayText
                             (max 1 (width - 2))
                             step.agentStepTitle)
                 ]
             , padLeft (Pad 2) $
                 withAttr Theme.mutedAttr $
-                    txt
+                    terminalTxt
                         (truncateDisplayText
                             (max 1 (width - 2))
                             (fromMaybe
@@ -2269,12 +2276,13 @@ drawHeader state =
 drawRepositoryHeader :: UiState -> Widget Name
 drawRepositoryHeader state
     | Text.null state.uiBranch =
-        withAttr Theme.mutedAttr (txt state.uiCwd)
+        withAttr Theme.mutedAttr (terminalTxt state.uiCwd)
     | otherwise =
         hBox
             [ txt "\xE0A0 "
             , withAttr Theme.mutedAttr $
-                txt (repositoryHeaderText state.uiBranch state.uiCwd)
+                terminalTxt
+                    (repositoryHeaderText state.uiBranch state.uiCwd)
             ]
 
 repositoryHeaderText :: Text -> Text -> Text
@@ -2285,7 +2293,7 @@ repositoryHeaderText branch cwd =
 drawHeaderRight :: AppState -> Widget Name
 drawHeaderRight state =
     withAttr Theme.mutedAttr $
-        txt (formatTokenUsage state.appUi.uiPrompt.promptUsage)
+        terminalTxt (formatTokenUsage state.appUi.uiPrompt.promptUsage)
 
 drawLiveTodos :: UiState -> Widget Name
 drawLiveTodos ui =
@@ -2314,7 +2322,7 @@ drawPromptActivity state =
     padLeftRight 2 $
         hBox
             [ activityWidget
-            , withAttr Theme.mutedAttr (txt elapsed)
+            , withAttr Theme.mutedAttr (terminalTxt elapsed)
             ]
   where
     ui = state.appUi
@@ -2330,7 +2338,7 @@ drawPromptActivity state =
                 , withAttr Theme.thinkingAttr (txt " Waiting for you")
                 ]
         | otherwise =
-            withAttr activityAttr (txt activity)
+            withAttr activityAttr (terminalTxt activity)
     activityAttr
         | ui.uiRunning = Theme.thinkingAttr
         | ui.uiCompletionRemainingMillis > 0 = Theme.successAttr
@@ -2442,7 +2450,7 @@ stickyPromptLayers state =
                             withAttr Theme.userAttr $
                                 vLimit 5 $
                                     padAll 1 $
-                                        txtWrap
+                                        terminalTxtWrap
                                             (stickyPromptPreview
                                                 anchor.anchorText)
                 ]
@@ -2548,7 +2556,7 @@ drawBlock state target ui block =
                 withAttr Theme.userAttr $
                     padAll 1 $
                         timestampedMessage block.blockTimestamp
-                            (txtWrap block.blockBody)
+                            (terminalTxtWrap block.blockBody)
             BlockAssistant ->
                 padLeft (Pad 3) $
                     padRight (Pad 1) $
@@ -2596,14 +2604,16 @@ drawBlock state target ui block =
                         <> detailSuffix block)
                     (visibleBody block)
             BlockSystem ->
-                withAttr Theme.mutedAttr (txtWrap block.blockBody)
+                withAttr Theme.mutedAttr
+                    (terminalTxtWrap block.blockBody)
             BlockRecap ->
                 accentBlock
                     (statusAttr state target block)
                     (blockStateGlyph state target block <> "Recap")
                     (visibleBody block)
             BlockError ->
-                withAttr Theme.errorAttr (txtWrap block.blockBody)
+                withAttr Theme.errorAttr
+                    (terminalTxtWrap block.blockBody)
         framed =
             if highlighted
                 then withAttr Theme.selectedAttr content
@@ -2636,7 +2646,8 @@ timestampedMessage timestamp body
     | otherwise =
         hBox
             [ padRight Max body
-            , withAttr Theme.mutedAttr (txt ("  " <> timestamp))
+            , withAttr Theme.mutedAttr
+                (terminalTxt ("  " <> timestamp))
             ]
 
 codeBlockHeader
@@ -2650,7 +2661,7 @@ codeBlockHeader state target blockId codeIndex language =
     hBox
         [ if Text.null language
             then emptyWidget
-            else withAttr Theme.mutedAttr (txt language)
+            else withAttr Theme.mutedAttr (terminalTxt language)
         , vLimit 1 (fill ' ')
         , clickable name $
             withAttr
@@ -2716,7 +2727,7 @@ accentBlock accent title body =
     accentBlockWithSections accent title $
         if Text.null (Text.strip body)
             then []
-            else [txtWrap body]
+            else [terminalTxtWrap body]
 
 accentMarkdownBlock :: AttrName -> Text -> Text -> Widget Name
 accentMarkdownBlock accent title body =
@@ -2737,7 +2748,7 @@ accentCodeBlock syntaxHighlighter accent title code body =
         [ codeWidgetWithSyntaxHighlighting syntaxHighlighter "haskell" code
         | not (Text.null (Text.strip code))
         ]
-            <> [ txtWrap body
+            <> [ terminalTxtWrap body
                | not (Text.null (Text.strip body))
                ]
 
@@ -2751,7 +2762,7 @@ accentBlockWithSections accent title sections =
         [ withAttr accent (txt "❙")
         , padLeft (Pad 2) $
             vBox $
-                [withAttr accent (txtWrap title)]
+                [withAttr accent (terminalTxtWrap title)]
                     <> map (padTop (Pad 1)) sections
         ]
 
@@ -2848,7 +2859,8 @@ drawNotice state = case state.appUi.uiNotice of
     Just notice ->
         let (attr, prefix) = noticePresentation state notice.noticeKind
         in withAttr attr $
-            padLeftRight 2 (txtWrap (prefix <> notice.noticeText))
+            padLeftRight 2
+                (terminalTxtWrap (prefix <> notice.noticeText))
 
 noticePresentation :: AppState -> NoticeKind -> (AttrName, Text)
 noticePresentation state = \case
@@ -2912,7 +2924,8 @@ drawPermission state permission =
                         (waitingOverlayLabel state "Permission") $
                         padAll 1 $
                             vBox
-                                [ txtWrap permission.permissionSummary
+                                [ terminalTxtWrap
+                                    permission.permissionSummary
                                 , padTop (Pad 1) $
                                     vBox $
                                         zipWith
@@ -2928,7 +2941,7 @@ drawPermission state permission =
 permissionRow :: Int -> Int -> Text -> Widget Name
 permissionRow selected index label =
     let prefix = if selected == index then "› " else "  "
-        widget = txt (prefix <> label)
+        widget = terminalTxt (prefix <> label)
         styled =
             if selected == index
                 then withAttr Theme.selectedAttr widget
@@ -2963,7 +2976,8 @@ resumeHeader browser =
         [ search
         , vLimit 1 (fill ' ')
         , withAttr Theme.mutedAttr $
-            txt (resumeSourceLabel browser.resumeBrowserSource <> "  f")
+            terminalTxt
+                (resumeSourceLabel browser.resumeBrowserSource <> "  f")
         ]
   where
     prefix
@@ -2978,11 +2992,12 @@ resumeHeader browser =
                     (resumeSearchCursorColumn
                         prefix
                         browser.resumeBrowserQuery, 0))
-                (txt (prefix <> browser.resumeBrowserQuery <> " "))
+                (terminalTxt
+                    (prefix <> browser.resumeBrowserQuery <> " "))
         | Text.null browser.resumeBrowserQuery =
-            withAttr Theme.mutedAttr (txt prefix)
+            withAttr Theme.mutedAttr (terminalTxt prefix)
         | otherwise =
-            txt (prefix <> browser.resumeBrowserQuery)
+            terminalTxt (prefix <> browser.resumeBrowserQuery)
 
 resumeSearchCursorColumn :: Text -> Text -> Int
 resumeSearchCursorColumn prefix query =
@@ -3015,7 +3030,7 @@ resumeGroup browser selectedId (project, entries) =
     vBox
         [ hBox
             [ withAttr Theme.mutedAttr $
-                txt (" " <> project <> " ")
+                terminalTxt (" " <> project <> " ")
             , withAttr Theme.mutedAttr (vLimit 1 (fill '─'))
             ]
         , vBox (map (resumeRow browser selectedId) entries)
@@ -3035,7 +3050,8 @@ resumeRow browser selectedId entry =
         | otherwise = "› "
     summary =
         hBox
-            [ hLimitPercent 78 (txt (marker <> entry.resumeTitle))
+            [ hLimitPercent 78
+                (terminalTxt (marker <> entry.resumeTitle))
             , vLimit 1 (fill ' ')
             , withAttr Theme.mutedAttr $
                 txt (resumeRelativeAge browser.resumeBrowserNow entry.resumeUpdatedAt)
@@ -3099,7 +3115,7 @@ resumeDetail :: Text -> Text -> Widget Name
 resumeDetail label value =
     hBox
         [ withAttr Theme.mutedAttr (txt (Text.justifyLeft 12 ' ' label))
-        , txtWrap value
+        , terminalTxtWrap value
         ]
 
 nonEmptyResumeText :: Maybe Text -> Maybe Text
@@ -3113,7 +3129,7 @@ resumeAbsoluteTime =
 
 resumeFooter :: ResumeBrowser -> Widget Name
 resumeFooter browser =
-    withAttr attr (txt footer)
+    withAttr attr (terminalTxt footer)
   where
     hasRows = not (null (visibleResumeBrowser browser))
     (attr, footer) =
@@ -3204,8 +3220,9 @@ drawOnboardingChoice appState choice =
         | otherwise =
             vLimit 1 $
                 case sourceIndex of
-                    0 -> withAttr Theme.headingAttr (txt choice.choiceTitle)
-                    2 -> txtWrap choice.choiceBody
+                    0 -> withAttr Theme.headingAttr
+                        (terminalTxt choice.choiceTitle)
+                    2 -> terminalTxtWrap choice.choiceBody
                     3 ->
                         withAttr Theme.mutedAttr $
                             txt "Choose a sign-in option below, or add your own API key."
@@ -3239,10 +3256,10 @@ onboardingChoiceRow appState width selected index (label, detail) =
             if showDetail
                 then hBox
                     [ hLimit 36 $
-                        padRight Max (txt (prefix <> label))
-                    , withAttr Theme.mutedAttr (txt detail)
+                        padRight Max (terminalTxt (prefix <> label))
+                    , withAttr Theme.mutedAttr (terminalTxt detail)
                     ]
-                else txt (prefix <> label)
+                else terminalTxt (prefix <> label)
     styled =
         if selected == index
             then withAttr Theme.selectedAttr row
@@ -3283,7 +3300,7 @@ waitingOverlayLabel state label =
                     motionGlyphSet
                     state.appRuntime.runtimeMotionMode
                     state.appMotionElapsedMillis)
-        , txt (" " <> label <> " ")
+        , terminalTxt (" " <> label <> " ")
         ]
 
 drawTextPrompt :: AppState -> TextOverlay -> Widget Name
@@ -3321,7 +3338,7 @@ renderTextDraft prompt =
         content =
             if Text.null displayDraft
                 then withAttr Theme.mutedAttr (txt " ")
-                else txt displayDraft
+                else terminalTxt displayDraft
         (row, column) =
             Composer.draftCursorLocation displayDraft prompt.textCursor
     in showCursor OverlayCursor (Location (column, row)) content
@@ -3359,9 +3376,10 @@ choiceRow appState selected index (label, detail) =
                             detail
                 render $
                     hBox
-                        [ txt shownLabel
+                        [ terminalTxt shownLabel
                         , vLimit 1 (fill ' ')
-                        , withAttr Theme.mutedAttr (txt shownDetail)
+                        , withAttr Theme.mutedAttr
+                            (terminalTxt shownDetail)
                         ]
         styled =
             if selected == index

--- a/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
@@ -44,6 +44,7 @@ import Agent.CLI.Input
     , appendReplHistory
     , displayEditorText
     , submissionPromptText
+    , truncateDisplayText
     )
 import Agent.CLI.Interrupt (CtrlCDecision)
 import Agent.CLI.Options (reasoningEfforts)
@@ -53,8 +54,14 @@ import Agent.CLI.TUI.Composer.Edit
 import Agent.CLI.TUI.Types
 import qualified Agent.TUI.Theme as Theme
 import Agent.TUI.Model
+import Agent.TUI.TextWidth
+    ( nextGraphemeBoundary
+    , previousGraphemeBoundary
+    , terminalTextImage
+    )
 import Brick
 import Brick.BChan (writeBChan)
+import qualified Brick.Types as B
 import qualified Brick.Widgets.Border as Border
 import Brick.Widgets.Border.Style (unicodeRounded)
 import qualified Brick.Widgets.Border.Style as BorderStyle
@@ -110,10 +117,11 @@ drawSlashRow selected index suggestion =
     let prefix = if selected == index then "❯ " else "  "
         row =
             hBox
-                [ txt (prefix <> suggestion.slashSuggestionDisplay)
+                [ terminalTxt
+                    (prefix <> suggestion.slashSuggestionDisplay)
                 , vLimit 1 (fill ' ')
                 , withAttr Theme.mutedAttr
-                    (txt suggestion.slashSuggestionSummary)
+                    (terminalTxt suggestion.slashSuggestionSummary)
                 ]
         styled =
             if selected == index
@@ -136,15 +144,13 @@ drawQueuedInputs state =
                                     <> Text.pack
                                         (show (Seq.length state.uiQueuedInputs))
                                     <> " · "))
-                        , withAttr Theme.mutedAttr (txt (queuePreview next))
+                        , withAttr Theme.mutedAttr
+                            (terminalTxt (queuePreview next))
                         ]
 
 queuePreview :: Text -> Text
 queuePreview text =
-    let oneLine = Text.unwords (Text.words text)
-    in if Text.length oneLine > 100
-        then Text.take 99 oneLine <> "…"
-        else oneLine
+    truncateDisplayText 100 (Text.unwords (Text.words text))
 
 drawComposer :: AppState -> Widget Name
 drawComposer appState =
@@ -294,7 +300,16 @@ renderDraft focused height state =
     -- and can place the insertion cursor on them.
     renderRow row
         | Text.null row = txt " "
-        | otherwise = txt (displayEditorText row)
+        | otherwise = terminalTxt (displayEditorText row)
+
+terminalTxt :: Text -> Widget n
+terminalTxt text =
+    B.Widget B.Fixed B.Fixed do
+        context <- B.getContext
+        attr <- B.lookupAttrName (B.ctxAttrName context)
+        pure B.emptyResult
+            { B.image = terminalTextImage attr text
+            }
 
 drawComposerStatus :: AppState -> Widget Name
 drawComposerStatus state =
@@ -307,7 +322,7 @@ drawComposerStatus state =
                    ]
                 <> [ if prompt.promptAccountSelectable
                         then accountControl
-                        else withAttr Theme.mutedAttr (txt account)
+                        else withAttr Theme.mutedAttr (terminalTxt account)
                    | not (Text.null account)
                    ]
   where
@@ -319,19 +334,19 @@ drawComposerStatus state =
             (if limitStatus.promptLimitWarning
                 then Theme.syntaxWarningAttr
                 else Theme.successAttr)
-            (txt limitStatus.promptLimitText)
+            (terminalTxt limitStatus.promptLimitText)
         | limitStatus <- maybeToList prompt.promptLimitStatus
         ]
     modelControl =
         clickable ComposerModel $
             forceAttr
                 (controlAttr state ComposerModel Theme.controlLinkAttr)
-                (txt prompt.promptModel)
+                (terminalTxt prompt.promptModel)
     effortControl =
         clickable ComposerEffort $
             forceAttr
                 (controlAttr state ComposerEffort Theme.controlLinkAttr)
-                (txt ("(" <> prompt.promptEffort <> ")"))
+                (terminalTxt ("(" <> prompt.promptEffort <> ")"))
     modelAndEffort
         | Text.null prompt.promptModel = []
         | Text.null prompt.promptEffort = [modelControl]
@@ -340,12 +355,12 @@ drawComposerStatus state =
         clickable ComposerMode $
             forceAttr
                 (controlAttr state ComposerMode Theme.controlLinkAttr)
-                (txt mode)
+                (terminalTxt mode)
     accountControl =
         clickable ComposerAccount $
             forceAttr
                 (controlAttr state ComposerAccount Theme.controlLinkAttr)
-                (txt account)
+                (terminalTxt account)
 
     maybeToList = \case
         Nothing -> []
@@ -772,17 +787,24 @@ handleComposerKey
         state <- get
         let ui = state.appUi
         when (ui.uiCursor > 0) do
-            let before = Text.take (ui.uiCursor - 1) ui.uiDraft
+            let start =
+                    previousGraphemeBoundary
+                        ui.uiDraft
+                        ui.uiCursor
+                before = Text.take start ui.uiDraft
                 after = Text.drop ui.uiCursor ui.uiDraft
             modifyUiResetSlash
-                (UiSetDraft (before <> after) (ui.uiCursor - 1))
+                (UiSetDraft (before <> after) start)
 
     deleteAfter = do
         state <- get
         let ui = state.appUi
         when (ui.uiCursor < Text.length ui.uiDraft) do
             let before = Text.take ui.uiCursor ui.uiDraft
-                after = Text.drop (ui.uiCursor + 1) ui.uiDraft
+                after =
+                    Text.drop
+                        (nextGraphemeBoundary ui.uiDraft ui.uiCursor)
+                        ui.uiDraft
             modifyUiResetSlash
                 (UiSetDraft (before <> after) ui.uiCursor)
 
@@ -821,9 +843,17 @@ handleComposerKey
         when (not (Text.null state.appKillBuffer)) $
             insertText state.appKillBuffer
 
+    moveCursor :: Int -> EventM Name AppState ()
     moveCursor delta = do
         state <- get
-        setCursor (state.appUi.uiCursor + delta)
+        let ui = state.appUi
+            cursor
+                | delta < 0 =
+                    previousGraphemeBoundary ui.uiDraft ui.uiCursor
+                | delta > 0 =
+                    nextGraphemeBoundary ui.uiDraft ui.uiCursor
+                | otherwise = ui.uiCursor
+        setCursor cursor
 
     setCursor cursor =
         get >>= \current ->

--- a/packages/agent-cli/src/Agent/CLI/TUI/Composer/Edit.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Composer/Edit.hs
@@ -5,7 +5,10 @@ module Agent.CLI.TUI.Composer.Edit
     , wrapDraft
     ) where
 
-import Agent.CLI.Input (terminalCharWidth, terminalTextWidth)
+import Agent.CLI.Input (terminalTextWidth)
+import Agent.CLI.Input.Display (displayCells)
+import Agent.CLI.Input.Types (DisplayCell(..))
+import Agent.TUI.TextWidth (clampGraphemeCursor)
 import Data.ByteString (ByteString)
 import Data.Char (isControl)
 import Data.Maybe (fromMaybe)
@@ -14,21 +17,24 @@ import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import Data.Text.Encoding.Error (lenientDecode)
 
--- | Visually wrap a draft without changing its underlying text. The cursor
--- offset is measured in the original text and returned in wrapped row/column
--- coordinates. Long unbroken text is split at terminal cell boundaries.
+-- | Visually wrap a draft without changing its underlying editor state. The
+-- cursor offset is measured in the original text and returned in wrapped
+-- row/column coordinates. Long unbroken text is split at terminal cell
+-- boundaries; a glyph wider than the entire viewport is shown as an ellipsis.
 wrapDraft :: Int -> Text -> Int -> ([Text], (Int, Int))
 wrapDraft requestedWidth text requestedCursor =
     let width = max 1 requestedWidth
-        cursor = max 0 (min (Text.length text) requestedCursor)
+        cursor = clampGraphemeCursor text requestedCursor
         (rowsRev, currentRev, currentWidth, currentRow, cursorLocation) =
-            go width cursor 0 [] [] 0 0 Nothing (Text.unpack text)
+            go width cursor 0 [] [] 0 0 Nothing (draftTokens text)
         (finalRowsRev, finalCurrentRev, finalRow, finalColumn)
             | cursor == Text.length text && currentWidth >= width =
                 (finishRow rowsRev currentRev, [], currentRow + 1, 0)
             | otherwise =
                 (rowsRev, currentRev, currentRow, currentWidth)
-        rows = reverse (Text.pack (reverse finalCurrentRev) : finalRowsRev)
+        rows =
+            reverse
+                (Text.concat (reverse finalCurrentRev) : finalRowsRev)
         location =
             fromMaybe
                 (finalRow, finalColumn)
@@ -40,17 +46,16 @@ wrapDraft requestedWidth text requestedCursor =
         -> Int
         -> Int
         -> [Text]
-        -> [Char]
+        -> [Text]
         -> Int
         -> Int
         -> Maybe (Int, Int)
-        -> [Char]
-        -> ([Text], [Char], Int, Int, Maybe (Int, Int))
+        -> [DraftToken]
+        -> ([Text], [Text], Int, Int, Maybe (Int, Int))
     go _ _ _ rowsRev currentRev currentWidth currentRow location [] =
         (rowsRev, currentRev, currentWidth, currentRow, location)
     go width cursor index rowsRev currentRev currentWidth currentRow location
-        (character : rest)
-        | character == '\n' =
+        (DraftLineBreak : rest) =
             let atVisualBoundary = currentWidth >= width
                 rowsAfterBoundary
                     | atVisualBoundary = finishRow rowsRev currentRev
@@ -58,14 +63,11 @@ wrapDraft requestedWidth text requestedCursor =
                 rowAfterBoundary
                     | atVisualBoundary = currentRow + 1
                     | otherwise = currentRow
-                columnAfterBoundary
-                    | atVisualBoundary = 0
-                    | otherwise = currentWidth
                 location' =
                     recordCursor
                         cursor
                         index
-                        (rowAfterBoundary, columnAfterBoundary)
+                        (currentRow, currentWidth)
                         location
                 (nextRows, nextRow)
                     | atVisualBoundary =
@@ -74,40 +76,46 @@ wrapDraft requestedWidth text requestedCursor =
                         (finishRow rowsAfterBoundary currentRev, currentRow + 1)
             in go
                 width cursor (index + 1) nextRows [] 0 nextRow location' rest
-        | otherwise =
-            let characterWidth = terminalCharWidth character
-                shouldWrap =
-                    characterWidth > 0
-                        && ( currentWidth >= width
-                            || (currentWidth > 0
-                                && currentWidth + characterWidth > width)
-                           )
-                rows' =
-                    if shouldWrap
-                        then finishRow rowsRev currentRev
-                        else rowsRev
-                currentRev' = if shouldWrap then [] else currentRev
-                currentWidth' = if shouldWrap then 0 else currentWidth
-                currentRow' = if shouldWrap then currentRow + 1 else currentRow
-                location' =
-                    recordCursor
-                        cursor
-                        index
-                        (currentRow', currentWidth')
-                        location
-            in go
-                width
-                cursor
-                (index + 1)
-                rows'
-                (character : currentRev')
-                (currentWidth' + characterWidth)
-                currentRow'
-                location'
-                rest
+    go width cursor index rowsRev currentRev currentWidth currentRow location
+        (DraftCell cell : rest) =
+        let displayText
+                | cell.displayCellWidth > width = "…"
+                | otherwise = cell.displayCellText
+            displayWidth
+                | cell.displayCellWidth > width = 1
+                | otherwise = cell.displayCellWidth
+            shouldWrap =
+                displayWidth > 0
+                    && ( currentWidth >= width
+                        || (currentWidth > 0
+                            && currentWidth + displayWidth > width)
+                       )
+            rows' =
+                if shouldWrap
+                    then finishRow rowsRev currentRev
+                    else rowsRev
+            currentRev' = if shouldWrap then [] else currentRev
+            currentWidth' = if shouldWrap then 0 else currentWidth
+            currentRow' = if shouldWrap then currentRow + 1 else currentRow
+            location' =
+                recordCursor
+                    cursor
+                    index
+                    (currentRow', currentWidth')
+                    location
+        in go
+            width
+            cursor
+            (index + cell.displayCellSourceLength)
+            rows'
+            (displayText : currentRev')
+            (currentWidth' + displayWidth)
+            currentRow'
+            location'
+            rest
 
     finishRow rowsRev currentRev =
-        Text.pack (reverse currentRev) : rowsRev
+        Text.concat (reverse currentRev) : rowsRev
 
     recordCursor cursor index location = \case
         Nothing
@@ -115,8 +123,9 @@ wrapDraft requestedWidth text requestedCursor =
         previous -> previous
 
 draftCursorLocation :: Text -> Int -> (Int, Int)
-draftCursorLocation text cursor =
-    let before = Text.take cursor text
+draftCursorLocation text requestedCursor =
+    let cursor = clampGraphemeCursor text requestedCursor
+        before = Text.take cursor text
         rows = Text.splitOn "\n" before
     in case reverse rows of
         [] -> (0, 0)
@@ -130,3 +139,18 @@ decodePaste =
                 || character == '\t'
                 || not (isControl character))
         . Text.decodeUtf8With lenientDecode
+
+data DraftToken
+    = DraftLineBreak
+    | DraftCell !DisplayCell
+
+draftTokens :: Text -> [DraftToken]
+draftTokens raw
+    | Text.null raw = []
+    | otherwise =
+        let (line, rest) = Text.break (== '\n') raw
+            lineTokens = map DraftCell (displayCells line)
+        in if Text.null rest
+            then lineTokens
+            else lineTokens
+                <> (DraftLineBreak : draftTokens (Text.drop 1 rest))

--- a/packages/agent-cli/src/Agent/CLI/TextLayout.hs
+++ b/packages/agent-cli/src/Agent/CLI/TextLayout.hs
@@ -8,6 +8,13 @@ module Agent.CLI.TextLayout
     , transcriptPreviewRows
     ) where
 
+import Agent.CLI.Input
+    ( displayEditorText
+    , terminalTextWidth
+    , truncateDisplayText
+    )
+import Agent.CLI.Input.Display (displayCells)
+import Agent.CLI.Input.Types (DisplayCell(..))
 import Data.Text (Text)
 import qualified Data.Text as Text
 
@@ -41,26 +48,30 @@ renderSplitPaneFrame :: SplitPaneFrame item -> Text
 renderSplitPaneFrame frame =
     Text.intercalate "\n" (header : headings : body <> [footer])
   where
-    cols = max frame.splitPaneMinColumns frame.splitPaneColumns
-    bodyRows = frame.splitPaneBodyRows
-    dividerWidth = Text.length frame.splitPaneDivider
-    divider = frame.splitPaneMutedStyle frame.splitPaneDivider
-    leftWidth =
+    cols = max 0 (max frame.splitPaneMinColumns frame.splitPaneColumns)
+    bodyRows = max 0 frame.splitPaneBodyRows
+    dividerText = truncateDisplayText cols frame.splitPaneDivider
+    dividerWidth = terminalTextWidth dividerText
+    divider = frame.splitPaneMutedStyle dividerText
+    paneWidth = max 0 (cols - dividerWidth)
+    desiredLeftWidth =
         max frame.splitPaneLeftMinWidth $
             min frame.splitPaneLeftMaxWidth
-                ((cols - dividerWidth) * 2 `div` 5)
-    rightWidth = max 1 (cols - leftWidth - dividerWidth)
+                (paneWidth * 2 `div` 5)
+    leftWidth = max 0 (min paneWidth desiredLeftWidth)
+    rightWidth = paneWidth - leftWidth
     items = frame.splitPaneItems
     itemCount = length items
     selectedIndex =
         clampSelectionIndex itemCount frame.splitPaneSelectedIndex
     shown = selectionWindow bodyRows selectedIndex items
     selected = atMay selectedIndex items
+    fittedTitle = truncateDisplayText cols frame.splitPaneTitle
     header =
-        frame.splitPanePromptStyle frame.splitPaneTitle
+        frame.splitPanePromptStyle fittedTitle
             <> frame.splitPaneMutedStyle
                 (fitTextCell
-                    (max 0 (cols - Text.length frame.splitPaneTitle))
+                    (max 0 (cols - terminalTextWidth fittedTitle))
                     (" · " <> frame.splitPaneHeaderDetail itemCount))
     headings =
         frame.splitPanePromptStyle
@@ -87,12 +98,12 @@ renderSplitPaneFrame frame =
         Nothing ->
             frame.splitPaneMutedStyle
                 (fitTextCell rightWidth frame.splitPaneEmptyTranscript)
-                : repeat ""
+                : repeat (Text.replicate rightWidth " ")
         Just item ->
             map (fitTextCell rightWidth)
                 (transcriptPreviewRows
                     rightWidth bodyRows (frame.splitPaneTranscript item))
-                <> repeat ""
+                <> repeat (Text.replicate rightWidth " ")
     body =
         take bodyRows $
             zipWith (\left right -> left <> divider <> right) leftRows rightRows
@@ -131,24 +142,42 @@ transcriptPreviewRows width count logicalLines =
 hardWrapText :: Int -> Text -> [Text]
 hardWrapText width raw
     | Text.null raw = [""]
-    | otherwise = go raw
+    | otherwise = go [] 0 (displayCells raw)
   where
     width' = max 1 width
-    go text
-        | Text.null text = []
+    go currentRev _ [] =
+        [Text.concat (reverse currentRev) | not (null currentRev)]
+    go currentRev used input@(cell : rest)
+        | cell.displayCellWidth > width' =
+            let replacement =
+                    truncateDisplayText width' cell.displayCellText
+                prefix =
+                    [ Text.concat (reverse currentRev)
+                    | not (null currentRev)
+                    ]
+            in prefix <> (replacement : go [] 0 rest)
+        | cell.displayCellWidth > 0
+            && used > 0
+            && used + cell.displayCellWidth > width' =
+                Text.concat (reverse currentRev) : go [] 0 input
         | otherwise =
-            let (line, rest) = Text.splitAt width' text
-            in line : go rest
+            go
+                (cell.displayCellText : currentRev)
+                (used + cell.displayCellWidth)
+                rest
 
 fitTextCell :: Int -> Text -> Text
 fitTextCell width raw
     | width <= 0 = ""
-    | Text.length clean <= width =
-        clean <> Text.replicate (width - Text.length clean) " "
-    | width == 1 = "…"
-    | otherwise = Text.take (width - 1) clean <> "…"
+    | otherwise =
+        fitted
+            <> Text.replicate
+                (max 0 (width - terminalTextWidth fitted))
+                " "
   where
     clean =
-        Text.map
-            (\c -> if c == '\t' || c == '\r' || c == '\n' then ' ' else c)
-            raw
+        displayEditorText $
+            Text.map
+                (\c -> if c == '\t' || c == '\r' || c == '\n' then ' ' else c)
+                raw
+    fitted = truncateDisplayText width clean

--- a/packages/agent-cli/test/Agent/CLI/InputSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/InputSpec.hs
@@ -18,10 +18,27 @@ import Agent.CLI.Input
     , truncateDisplayText
     , visibleEditorText
     )
+import Data.Char (isControl)
 import Data.Either (isLeft)
 import qualified Data.Text as Text
+import qualified Graphics.Vty as V
 import System.FilePath ((</>))
 import Test.Hspec
+import Test.Hspec.QuickCheck (modifyMaxSuccess, prop)
+import Test.QuickCheck
+    ( Arbitrary(..)
+    , Gen
+    , Property
+    , chooseInt
+    , conjoin
+    , counterexample
+    , elements
+    , vectorOf
+    , (===)
+    )
+
+data EditorViewportCase = EditorViewportCase !Int !Text.Text !Int
+    deriving (Show)
 
 spec :: Spec
 spec = do
@@ -121,14 +138,59 @@ spec = do
             displayEditorText "\ESC]0;owned\BEL"
                 `shouldBe` "␛]0;owned␇"
 
+        it "does not leak a newline joined to a variation selector" do
+            let input = Text.pack ['\n', '\xfe0f']
+                displayed = displayEditorText input
+            displayed `shouldBe` Text.singleton '\x21b5'
+            displayed `shouldSatisfy` not . Text.any (== '\n')
+            V.safeWctwidth displayed `shouldBe` terminalTextWidth input
+
         it "measures wide and combining Unicode in terminal columns" do
             terminalTextWidth "a界🙂e\x0301" `shouldBe` 6
             visibleEditorText 3 "a界b" 2 `shouldBe` ("界b", 2)
+
+        it "keeps a wide cursor glyph visible in a narrow viewport" do
+            visibleEditorText 2 "a界" 2 `shouldBe` ("界", 2)
+            visibleEditorText 1 "界" 1 `shouldBe` ("…", 1)
+
+        it "does not detach combining marks from a hidden wide glyph" do
+            visibleEditorText 1 "界\x0301" 2 `shouldBe` ("…", 1)
+            visibleEditorText 2 "a界\x0301" 3 `shouldBe` ("界\x0301", 2)
+
+        it "preserves supported emoji and safely substitutes width mismatches" do
+            let womanTechnologist =
+                    Text.pack ['\x1f469', '\x200d', '\x1f4bb']
+                usFlag =
+                    Text.pack ['\x1f1fa', '\x1f1f8']
+                thumbsUpMedium =
+                    Text.pack ['\x1f44d', '\x1f3fd']
+                keycapOne =
+                    Text.pack ['1', '\xfe0f', '\x20e3']
+                text =
+                    womanTechnologist
+                        <> usFlag
+                        <> thumbsUpMedium
+                        <> keycapOne
+                displayed =
+                    womanTechnologist
+                        <> usFlag
+                        <> thumbsUpMedium
+                        <> "１"
+            displayEditorText text `shouldBe` displayed
+            terminalTextWidth text `shouldBe` 8
+            visibleEditorText 2 womanTechnologist 3
+                `shouldBe` (womanTechnologist, 2)
+            visibleEditorText 1 womanTechnologist 3
+                `shouldBe` ("…", 1)
 
         it "truncates the complete row without exceeding its column budget" do
             let truncated = truncateDisplayText 5 "/always-approve"
             truncated `shouldBe` "/alw…"
             terminalTextWidth truncated `shouldBe` 5
+
+        modifyMaxSuccess (const 1000) $
+            prop "keeps generated editor viewports visible and in bounds" $
+                editorViewportProperty
 
     describe "clipboard image paste key" do
         it "recognizes legacy Ctrl+V without treating ordinary v as paste" do
@@ -152,3 +214,44 @@ spec = do
             isShiftEnterCsiBody "27;2;13~" `shouldBe` True
             isShiftEnterCsiBody "13;2u" `shouldBe` True
             isShiftEnterCsiBody "13u" `shouldBe` False
+
+editorViewportProperty :: EditorViewportCase -> Property
+editorViewportProperty (EditorViewportCase available raw requestedCursor) =
+    conjoin
+        [ counterexample "visible text exceeds available columns"
+            ((terminalTextWidth shown <= available) === True)
+        , counterexample "visible cursor is outside rendered text"
+            ((column >= 0 && column <= terminalTextWidth shown) === True)
+        , counterexample "nonempty editor text disappeared"
+            ((not (Text.null shown)) === True)
+        , counterexample "visible text contains terminal controls"
+            (Text.all (not . isControl) shown === True)
+        , counterexample "Vty and editor width models disagree"
+            (V.safeWctwidth shown === terminalTextWidth shown)
+        ]
+  where
+    cursor = max 0 (min (Text.length raw) requestedCursor)
+    (shown, column) = visibleEditorText available raw cursor
+
+instance Arbitrary EditorViewportCase where
+    arbitrary = do
+        available <- chooseInt (1, 80)
+        atomCount <- chooseInt (1, 90)
+        raw <- Text.concat <$> vectorOf atomCount genEditorAtom
+        cursor <- chooseInt (-20, Text.length raw + 20)
+        pure $
+            EditorViewportCase
+                available
+                raw
+                cursor
+
+genEditorAtom :: Gen Text.Text
+genEditorAtom =
+    elements
+        [ "a", "z", "0", " ", "\t", "\r", "\n"
+        , "界", "語", "🙂", "🚀", "é", "ø", "e\x0301"
+        , Text.pack ['\x1f469', '\x200d', '\x1f4bb']
+        , Text.pack ['\x1f1fa', '\x1f1f8']
+        , Text.pack ['\x1f44d', '\x1f3fd']
+        , Text.pack ['1', '\xfe0f', '\x20e3']
+        ]

--- a/packages/agent-cli/test/Agent/CLI/MarkdownSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/MarkdownSpec.hs
@@ -1,5 +1,6 @@
 module Agent.CLI.MarkdownSpec (spec) where
 
+import Agent.CLI.Input (terminalTextWidth)
 import Agent.CLI.Markdown
     ( renderMarkdown
     , renderMarkdownFragment
@@ -167,6 +168,18 @@ spec = do
                     expectationFailure
                         ("expected exactly two table rows, got " <> show body)
 
+        it "keeps table borders aligned around multi-codepoint graphemes" do
+            let womanTechnologist =
+                    Text.pack ['\x1f469', '\x200d', '\x1f4bb']
+                mdTable =
+                    "| kind | value |\n\
+                    \| --- | --- |\n\
+                    \| emoji | " <> womanTechnologist <> " |"
+                rows =
+                    filter (not . Text.null . Text.strip)
+                        (map stripAnsi (Text.lines (renderMarkdown True mdTable)))
+            map terminalTextWidth rows `shouldSatisfy` allEqual
+
         it "preserves identifiers and styled links in table cells" do
             let sample =
                     "| key | value |\n\
@@ -247,3 +260,7 @@ spec = do
             renderMarkdownFragment True Nothing ready1
                 <> renderMarkdownFragment True context1 ready2
                 `shouldBe` "snake_case_name"
+
+allEqual :: Eq a => [a] -> Bool
+allEqual [] = True
+allEqual (first : rest) = all (== first) rest

--- a/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
@@ -523,6 +523,37 @@ spec = do
                     actual <- stripTerminalControls <$> Text.readFile path
                     actual `shouldBe` expected
 
+        it "preserves emoji graphemes split across streaming deltas" do
+            let womanTechnologist =
+                    Text.pack ['\x1f469', '\x200d', '\x1f4bb']
+                keycapOne =
+                    Text.pack ['1', '\xfe0f', '\x20e3']
+                usFlag =
+                    Text.pack ['\x1f1fa', '\x1f1f8']
+                source =
+                    "status "
+                        <> womanTechnologist
+                        <> " "
+                        <> keycapOne
+                        <> " "
+                        <> usFlag
+                expected =
+                    stripTerminalControls
+                        (renderAssistantText True source)
+            withRenderConfig False True \config handle path -> do
+                mapM_
+                    (renderEvent config . TextDelta . Text.singleton)
+                    (Text.unpack source)
+                renderEvent config (TurnFinished TurnOutput
+                    { responseId = "r1"
+                    , toolCalls = []
+                    , assistantText = Nothing
+                    , tokenUsage = emptyTokenUsage
+                    })
+                hClose handle
+                actual <- stripTerminalControls <$> Text.readFile path
+                actual `shouldBe` expected
+
         it "does not expose fence or table markers while streaming" do
             withRenderConfig False True \config handle path -> do
                 mapM_ (renderEvent config . TextDelta)

--- a/packages/agent-cli/test/Agent/CLI/SessionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SessionSpec.hs
@@ -23,6 +23,7 @@ import Agent.Store.Postgres.Connection (StorePool)
 import Agent.Store.Types (renderStoreError)
 import Control.Exception (bracket)
 import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KeyMap
 import qualified Data.ByteString.Lazy as LBS
 import Data.IORef
@@ -42,12 +43,344 @@ import System.OsPath (OsPath, decodeUtf, unsafeEncodeUtf, (</>))
 import System.Posix.Files (fileMode, getFileStatus)
 import System.Posix.Temp (mkdtemp)
 import Test.Hspec
+import Test.Hspec.QuickCheck (modifyMaxSuccess, prop)
+import Test.QuickCheck
+    ( Arbitrary(..)
+    , Gen
+    , Property
+    , checkCoverage
+    , chooseInt
+    , counterexample
+    , cover
+    , elements
+    , frequency
+    , oneof
+    , resize
+    , sized
+    , vectorOf
+    , (===)
+    )
 
 fromFilePath :: FilePath -> OsPath
 fromFilePath = unsafeEncodeUtf
 
 toFilePath :: OsPath -> FilePath
 toFilePath path = either (error . show) id (decodeUtf path)
+
+newtype StoredRoundTripItem = StoredRoundTripItem ResponseItem
+    deriving (Show)
+
+newtype StoredRoundTripContentPart =
+    StoredRoundTripContentPart ResponseContentPart
+    deriving (Show)
+
+instance Arbitrary StoredRoundTripItem where
+    arbitrary = StoredRoundTripItem <$> genResponseItem
+    shrink _ = []
+
+instance Arbitrary StoredRoundTripContentPart where
+    arbitrary = StoredRoundTripContentPart <$> genContentPart
+    shrink _ = []
+
+storedResponseItemRoundTrip :: StoredRoundTripItem -> Property
+storedResponseItemRoundTrip (StoredRoundTripItem item) =
+    checkCoverage $
+        foldr
+            (\label -> cover 7 (responseItemKind item == label) label)
+            (counterexample ("failed to round-trip " <> show item) $
+            fromStoredResponseItem (toStoredResponseItem item)
+                === Right item)
+            responseItemKinds
+
+storedContentPartRoundTrip :: StoredRoundTripContentPart -> Property
+storedContentPartRoundTrip (StoredRoundTripContentPart part) =
+    checkCoverage $
+        foldr
+            (\label -> cover 7 (contentPartKind part == label) label)
+            (counterexample ("failed to round-trip " <> show part) $
+            fromStoredResponseItem (toStoredResponseItem item)
+                === Right item)
+            contentPartKinds
+  where
+    item = MessageItem ResponseMessage
+        { messageId = Just "generated-message"
+        , content = MessageContentParts [part]
+        , role = RoleAssistant
+        , status = Just ItemCompleted
+        , phase = Just "final"
+        , extraFields = KeyMap.empty
+        }
+
+genResponseItem :: Gen ResponseItem
+genResponseItem =
+    oneof
+        [ MessageItem <$> genResponseMessage
+        , FunctionCallItem <$> genFunctionCall
+        , FunctionCallOutputItem <$> genFunctionCallOutput
+        , CustomToolCallItem <$> genCustomToolCall
+        , CustomToolCallOutputItem <$> genCustomToolCallOutput
+        , ReasoningItemValue <$> genReasoningItem
+        , ItemReferenceValue <$> genItemReference
+        , do
+            tagged <- genTaggedObject "known-item-"
+            pure (KnownResponseItem (parseResponseItemType tagged.tag) tagged)
+        , UnknownResponseItem <$> genTaggedObject "unknown-item-"
+        ]
+
+genResponseMessage :: Gen ResponseMessage
+genResponseMessage =
+    ResponseMessage
+        <$> genMaybe genText
+        <*> genMessageContent
+        <*> genResponseRole
+        <*> genMaybe genItemStatus
+        <*> genMaybe genText
+        <*> genJsonObject
+
+genMessageContent :: Gen MessageContent
+genMessageContent =
+    frequency
+        [ (2, MessageContentText <$> genText)
+        , (3, MessageContentParts <$> genSmallList genContentPart)
+        ]
+
+genFunctionCall :: Gen FunctionCall
+genFunctionCall =
+    FunctionCall
+        <$> genMaybe genText
+        <*> genText
+        <*> genText
+        <*> genText
+        <*> genMaybe genItemStatus
+        <*> genJsonObject
+
+genFunctionCallOutput :: Gen FunctionCallOutput
+genFunctionCallOutput =
+    FunctionCallOutput
+        <$> genMaybe genText
+        <*> genText
+        <*> genJsonValue
+        <*> genMaybe genItemStatus
+        <*> genJsonObject
+
+genCustomToolCall :: Gen CustomToolCall
+genCustomToolCall =
+    CustomToolCall
+        <$> genMaybe genText
+        <*> genText
+        <*> genText
+        <*> genText
+        <*> genMaybe genItemStatus
+        <*> genJsonObject
+
+genCustomToolCallOutput :: Gen CustomToolCallOutput
+genCustomToolCallOutput =
+    CustomToolCallOutput
+        <$> genMaybe genText
+        <*> genText
+        <*> genMaybe genText
+        <*> genJsonValue
+        <*> genMaybe genItemStatus
+        <*> genJsonObject
+
+genReasoningItem :: Gen ReasoningItem
+genReasoningItem =
+    ReasoningItem
+        <$> genMaybe genText
+        <*> genSmallList genReasoningSummaryPart
+        <*> genMaybe (genSmallList genContentPart)
+        <*> genMaybe genText
+        <*> genMaybe genItemStatus
+        <*> genJsonObject
+
+genReasoningSummaryPart :: Gen ReasoningSummaryPart
+genReasoningSummaryPart =
+    ReasoningSummaryPart
+        <$> genText
+        <*> genMaybe genText
+        <*> genJsonObject
+
+genItemReference :: Gen ItemReference
+genItemReference =
+    ItemReference
+        <$> genText
+        <*> genJsonObject
+
+genContentPart :: Gen ResponseContentPart
+genContentPart =
+    oneof
+        [ InputTextPart
+            <$> genText
+            <*> genMaybe genJsonValue
+            <*> genJsonObject
+        , InputImagePart
+            <$> genMaybe genText
+            <*> genMaybe genText
+            <*> genMaybe genText
+            <*> genMaybe genJsonValue
+            <*> genJsonObject
+        , InputFilePart
+            <$> genMaybe genText
+            <*> genMaybe genText
+            <*> genMaybe genText
+            <*> genMaybe genText
+            <*> genMaybe genText
+            <*> genMaybe genJsonValue
+            <*> genJsonObject
+        , InputAudioPart
+            <$> genJsonValue
+            <*> genJsonObject
+        , OutputTextPart
+            <$> genText
+            <*> genMaybe (genSmallList genJsonValue)
+            <*> genMaybe (genSmallList genJsonValue)
+            <*> genJsonObject
+        , RefusalPart
+            <$> genText
+            <*> genJsonObject
+        , ReasoningTextPart
+            <$> genText
+            <*> genJsonObject
+        , SummaryTextPart
+            <$> genText
+            <*> genJsonObject
+        , UnknownContentPart <$> genTaggedObject "unknown-content-"
+        ]
+
+genResponseRole :: Gen ResponseRole
+genResponseRole =
+    frequency
+        [ (4, elements
+            [ RoleUser
+            , RoleAssistant
+            , RoleSystem
+            , RoleDeveloper
+            ])
+        , (1, RoleUnknown . ("role-" <>) <$> genText)
+        ]
+
+genItemStatus :: Gen ItemStatus
+genItemStatus =
+    frequency
+        [ (3, elements
+            [ ItemInProgress
+            , ItemCompleted
+            , ItemIncomplete
+            ])
+        , (1, ItemStatusUnknown . ("status-" <>) <$> genText)
+        ]
+
+genTaggedObject :: Text.Text -> Gen TaggedObject
+genTaggedObject prefix =
+    TaggedObject
+        <$> ((prefix <>) <$> genText)
+        <*> genJsonObject
+
+genJsonObject :: Gen Aeson.Object
+genJsonObject = sized genJsonObjectAt
+
+genJsonObjectAt :: Int -> Gen Aeson.Object
+genJsonObjectAt size = do
+    count <- chooseInt (0, min 4 (max 0 size))
+    fields <-
+        vectorOf count $
+            (,)
+                <$> (Key.fromText <$> genText)
+                <*> resize (max 0 (size - 1)) genJsonValue
+    pure (KeyMap.fromList fields)
+
+genJsonValue :: Gen Aeson.Value
+genJsonValue = sized go
+  where
+    go size
+        | size <= 0 = scalar
+        | otherwise =
+            frequency
+                [ (6, scalar)
+                , (2, do
+                    count <- chooseInt (0, min 4 size)
+                    Aeson.toJSON
+                        <$> vectorOf count
+                            (resize (size `div` 2) genJsonValue))
+                , (2, Aeson.Object
+                        <$> genJsonObjectAt (size `div` 2))
+                ]
+
+    scalar =
+        oneof
+            [ pure Aeson.Null
+            , Aeson.Bool <$> arbitrary
+            , Aeson.String <$> genText
+            , Aeson.Number . fromIntegral
+                <$> chooseInt (-100000, 100000)
+            ]
+
+genText :: Gen Text.Text
+genText = do
+    length' <- chooseInt (0, 24)
+    Text.pack <$> vectorOf length' genTextChar
+
+genTextChar :: Gen Char
+genTextChar =
+    frequency
+        [ (20, elements ['a' .. 'z'])
+        , (5, elements ['A' .. 'Z'])
+        , (5, elements ['0' .. '9'])
+        , (4, elements [' ', '\n', '\t', '"', '\\'])
+        , (3, elements ['界', '語', '漢'])
+        , (2, elements ['🙂', '🚀', '✓'])
+        , (1, elements ['\x0301', 'é', 'ß'])
+        ]
+
+genMaybe :: Gen a -> Gen (Maybe a)
+genMaybe value =
+    frequency
+        [ (1, pure Nothing)
+        , (3, Just <$> value)
+        ]
+
+genSmallList :: Gen a -> Gen [a]
+genSmallList value = do
+    count <- chooseInt (0, 4)
+    vectorOf count value
+
+responseItemKinds :: [String]
+responseItemKinds =
+    [ "message", "function call", "function output"
+    , "custom call", "custom output", "reasoning"
+    , "reference", "known tagged", "unknown tagged"
+    ]
+
+responseItemKind :: ResponseItem -> String
+responseItemKind = \case
+    MessageItem{} -> "message"
+    FunctionCallItem{} -> "function call"
+    FunctionCallOutputItem{} -> "function output"
+    CustomToolCallItem{} -> "custom call"
+    CustomToolCallOutputItem{} -> "custom output"
+    ReasoningItemValue{} -> "reasoning"
+    ItemReferenceValue{} -> "reference"
+    KnownResponseItem{} -> "known tagged"
+    UnknownResponseItem{} -> "unknown tagged"
+
+contentPartKinds :: [String]
+contentPartKinds =
+    [ "input text", "input image", "input file"
+    , "input audio", "output text", "refusal"
+    , "reasoning text", "summary text", "unknown content"
+    ]
+
+contentPartKind :: ResponseContentPart -> String
+contentPartKind = \case
+    InputTextPart{} -> "input text"
+    InputImagePart{} -> "input image"
+    InputFilePart{} -> "input file"
+    InputAudioPart{} -> "input audio"
+    OutputTextPart{} -> "output text"
+    RefusalPart{} -> "refusal"
+    ReasoningTextPart{} -> "reasoning text"
+    SummaryTextPart{} -> "summary text"
+    UnknownContentPart{} -> "unknown content"
 
 spec :: Spec
 spec = describe "Agent.CLI.Session" do
@@ -190,6 +523,14 @@ spec = describe "Agent.CLI.Session" do
                     ]
             traverse fromStoredResponseItem (map toStoredResponseItem items)
                 `shouldBe` Right items
+
+        modifyMaxSuccess (const 500) $
+            prop "round-trips generated response items through storage" $
+                storedResponseItemRoundTrip
+
+        modifyMaxSuccess (const 500) $
+            prop "round-trips every generated response content part" $
+                storedContentPartRoundTrip
 
     describe "PostgreSQL session persistence" do
         it "round-trips and clears ephemeral session activity" $

--- a/packages/agent-cli/test/Agent/CLI/TUIComposerSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIComposerSpec.hs
@@ -1,16 +1,48 @@
 module Agent.CLI.TUIComposerSpec (spec) where
 
-import Agent.CLI.Input (ReplLine(..))
 import Agent.CLI.Dictation (insertDictation)
+import Agent.CLI.Input
+    ( ReplLine(..)
+    , displayEditorText
+    , terminalTextWidth
+    )
 import Agent.CLI.TUI.Composer
 import Agent.CLI.TUI.Types
 import Agent.TUI.Model (UiState(..), initialUiState)
+import Agent.TUI.TextWidth
+    ( clampGraphemeCursor
+    , graphemeCellWidth
+    , graphemeClusters
+    , nextGraphemeBoundary
+    , previousGraphemeBoundary
+    )
 import Control.Concurrent.STM (atomically)
 import qualified Data.ByteString as ByteString
+import Data.Char (isControl)
 import Data.Foldable (toList)
 import qualified Data.Sequence as Seq
 import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
 import Test.Hspec
+import Test.Hspec.QuickCheck (modifyMaxSuccess, prop)
+import Test.QuickCheck
+    ( Arbitrary(..)
+    , Gen
+    , Property
+    , chooseInt
+    , conjoin
+    , counterexample
+    , elements
+    , vectorOf
+    , (===)
+    )
+
+data DraftCase = DraftCase !Int !Text !Int
+    deriving (Show)
+
+newtype PasteBytes = PasteBytes ByteString.ByteString
+    deriving (Show)
 
 spec :: Spec
 spec = describe "fullscreen composer" do
@@ -55,6 +87,12 @@ spec = describe "fullscreen composer" do
         wrapDraft 5 "abc\ndefghi" 10
             `shouldBe` (["abc", "defgh", "i"], (2, 1))
 
+    it "distinguishes the cursor positions before and after a full-row newline" do
+        wrapDraft 2 "ab\nc" 2
+            `shouldBe` (["ab", "c"], (0, 2))
+        wrapDraft 2 "ab\nc" 3
+            `shouldBe` (["ab", "c"], (1, 0))
+
     it "wraps using terminal columns for wide characters" do
         wrapDraft 3 "a界b" 2
             `shouldBe` (["a界", "b"], (1, 0))
@@ -62,6 +100,26 @@ spec = describe "fullscreen composer" do
     it "keeps combining marks attached at a visual boundary" do
         wrapDraft 1 "e\x0301x" 2
             `shouldBe` (["e\x0301", "x"], (1, 0))
+
+    it "fits wide glyphs into a one-cell composer" do
+        wrapDraft 1 "界" 1
+            `shouldBe` (["…", ""], (1, 0))
+
+    it "never splits emoji graphemes while wrapping or placing the cursor" do
+        let womanTechnologist =
+                Text.pack ['\x1f469', '\x200d', '\x1f4bb']
+        wrapDraft 2 womanTechnologist 3
+            `shouldBe` ([womanTechnologist, ""], (1, 0))
+        wrapDraft 2 ("a" <> womanTechnologist) 4
+            `shouldBe` (["a", womanTechnologist, ""], (2, 0))
+        wrapDraft 1 womanTechnologist 3
+            `shouldBe` (["…", ""], (1, 0))
+        draftCursorLocation womanTechnologist 1 `shouldBe` (0, 0)
+        draftCursorLocation womanTechnologist 3 `shouldBe` (0, 2)
+
+    modifyMaxSuccess (const 500) $
+        prop "wraps generated Unicode drafts without overflowing rows" $
+            wrapDraftProperty
 
     it "filters control characters from bracketed paste text" do
         decodePaste (ByteString.pack [97, 0, 10, 9, 27, 98])
@@ -72,6 +130,10 @@ spec = describe "fullscreen composer" do
             `shouldBe` ("please fix this now", 15)
         insertDictation "hello" 5 ", world"
             `shouldBe` ("hello, world", 12)
+
+    modifyMaxSuccess (const 300) $
+        prop "decodes arbitrary paste bytes into stable safe text" $
+            decodePasteProperty
 
     it "keeps clipboard preludes immediately before promoted input" do
         buffer <- newFullscreenInputBuffer
@@ -132,3 +194,90 @@ spec = describe "fullscreen composer" do
         , fullscreenInputQueued = True
         , fullscreenInputDisplay = Nothing
         }
+
+wrapDraftProperty :: DraftCase -> Property
+wrapDraftProperty (DraftCase width draft requestedCursor) =
+    conjoin
+        [ counterexample "wrapped rows are nonempty"
+            (not (null rows) === True)
+        , counterexample "wrapped row width"
+            (all ((<= width) . terminalTextWidth) rows === True)
+        , counterexample "cursor row"
+            ((cursorRow >= 0 && cursorRow < length rows) === True)
+        , counterexample "cursor column"
+            ((cursorColumn >= 0 && cursorColumn <= width) === True)
+        , counterexample "wrapping preserves draft text when glyphs fit"
+            (if all ((<= width) . graphemeCellWidth)
+                    (filter (/= "\n") (graphemeClusters draft))
+                then Text.concat rows === displayedDraft
+                else True === True)
+        , counterexample "cursor movement is monotonic"
+            ((previousLocation <= location && location <= nextLocation)
+                === True)
+        , counterexample "explicit newline moves the cursor"
+            (all explicitNewlineMoves newlineOffsets === True)
+        ]
+  where
+    cursor = clampGraphemeCursor draft requestedCursor
+    (rows, location@(cursorRow, cursorColumn)) =
+        wrapDraft width draft cursor
+    (_, previousLocation) =
+        wrapDraft width draft
+            (previousGraphemeBoundary draft cursor)
+    (_, nextLocation) =
+        wrapDraft width draft
+            (nextGraphemeBoundary draft cursor)
+    displayedDraft =
+        Text.concat (map displayEditorText (Text.splitOn "\n" draft))
+    newlineOffsets =
+        [ index
+        | (index, character) <- zip [0 :: Int ..] (Text.unpack draft)
+        , character == '\n'
+        ]
+    explicitNewlineMoves index =
+        snd (wrapDraft width draft index)
+            /= snd (wrapDraft width draft (index + 1))
+
+decodePasteProperty :: PasteBytes -> Property
+decodePasteProperty (PasteBytes bytes) =
+    conjoin
+        [ counterexample "paste contains unsafe controls"
+            (Text.all allowed decoded === True)
+        , counterexample "paste decoding is idempotent"
+            (decodePaste (Text.encodeUtf8 decoded) === decoded)
+        ]
+  where
+    decoded = decodePaste bytes
+    allowed character =
+        character == '\n'
+            || character == '\t'
+            || not (isControl character)
+
+instance Arbitrary DraftCase where
+    arbitrary = do
+        width <- chooseInt (1, 120)
+        atomCount <- chooseInt (0, 110)
+        draft <- Text.concat <$> vectorOf atomCount genDraftAtom
+        cursor <- chooseInt (-20, Text.length draft + 20)
+        pure (DraftCase width draft cursor)
+
+instance Arbitrary PasteBytes where
+    arbitrary = do
+        size <- chooseInt (0, 400)
+        PasteBytes . ByteString.pack
+            <$> vectorOf size (fromIntegral <$> chooseInt (0, 255))
+
+genDraftAtom :: Gen Text
+genDraftAtom =
+    elements
+        [ "a", "z", "0", " ", " ", "\n"
+        , "界", "語", "🙂", "🚀", "é", "ø", "e\x0301"
+        , Text.pack ['\x1f469', '\x200d', '\x1f4bb']
+        , Text.pack
+            [ '\x1f468', '\x200d', '\x1f469', '\x200d'
+            , '\x1f467', '\x200d', '\x1f466'
+            ]
+        , Text.pack ['\x1f1fa', '\x1f1f8']
+        , Text.pack ['\x1f44d', '\x1f3fd']
+        , Text.pack ['1', '\xfe0f', '\x20e3']
+        ]

--- a/packages/agent-cli/test/Agent/CLI/TUIPropertySpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIPropertySpec.hs
@@ -4,6 +4,7 @@ import Agent.CLI.AgentViewport
     ( AgentEntry(..)
     , AgentTarget(..)
     )
+import Agent.CLI.Input (terminalTextWidth)
 import Agent.CLI.Interrupt (CtrlCDecision(..))
 import Agent.CLI.TUI.App
     ( drawApp
@@ -50,6 +51,7 @@ import Data.Foldable (toList)
 import Data.IORef (readIORef)
 import Data.List (find, nub)
 import qualified Data.Map.Strict as Map
+import Data.Maybe (mapMaybe)
 import qualified Data.Sequence as Seq
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -327,6 +329,20 @@ spec = do
             frame `shouldSatisfy` Text.isInfixOf "tool output"
             frame `shouldSatisfy` Text.isInfixOf "Markdown kept."
 
+        it "keeps variation selectors from crossing adjacent choice widgets" do
+            let label = Text.replicate 33 "a" <> "✓"
+                detail = Text.singleton '\xfe0f' <> "detail"
+                harness =
+                    applyAction
+                        (ShowChoice
+                            ChoiceOnboarding
+                            "Sign in"
+                            ""
+                            [(label, detail)]
+                            0)
+                        (RenderHarness baseState (80, 24))
+            assertFrame harness
+
 renderTraceProperty :: AppState -> RenderTrace -> Property
 renderTraceProperty baseState (RenderTrace actions) =
     conjoin $
@@ -384,6 +400,10 @@ frameProperties label harness =
             (V.imageHeight composed === height)
         , counterexample (label <> ": top-level layer bounds")
             (all layerFits layers === True)
+        , counterexample
+            (label <> ": Vty text spans match terminal widths: "
+                <> show spanMismatches)
+            (null spanMismatches === True)
         , counterexample (label <> ": cursor bounds")
             (cursorFits width height picture.picCursor === True)
         , counterexample (label <> ": deterministic clean redraw")
@@ -402,9 +422,25 @@ frameProperties label harness =
             renderWidget (Just Theme.monochrome) [widget] size
         | widget <- widgets
         ]
+    spanMismatches =
+        concatMap (spanWidthMismatches . toList)
+            (toList (displayOpsForPic picture size))
     layerFits image =
         V.imageWidth image <= width
             && V.imageHeight image <= height
+
+spanWidthMismatches :: [SpanOp] -> [(Int, Int, Text)]
+spanWidthMismatches =
+    mapMaybe \case
+        TextSpan{textSpanOutputWidth, textSpanText} ->
+            let text = LazyText.toStrict textSpanText
+                terminalWidth = terminalTextWidth text
+            in if textSpanOutputWidth == terminalWidth
+                then Nothing
+                else Just
+                    (textSpanOutputWidth, terminalWidth, text)
+        Skip _ -> Nothing
+        RowEnd _ -> Nothing
 
 uiStateProperties :: UiState -> Property
 uiStateProperties state =
@@ -760,6 +796,9 @@ assertFrame harness = do
             V.imageWidth image `shouldSatisfy` (<= width)
             V.imageHeight image `shouldSatisfy` (<= height))
         layers
+    concatMap (spanWidthMismatches . toList)
+        (toList (displayOpsForPic picture size))
+        `shouldBe` []
     cursorFits width height picture.picCursor `shouldBe` True
   where
     app = harness.harnessApp

--- a/packages/agent-cli/test/Agent/CLI/TextLayoutSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TextLayoutSpec.hs
@@ -1,8 +1,35 @@
 module Agent.CLI.TextLayoutSpec (spec) where
 
+import Agent.CLI.Input (terminalTextWidth)
 import Agent.CLI.TextLayout
 import qualified Data.Text as Text
 import Test.Hspec
+import Test.Hspec.QuickCheck (modifyMaxSuccess, prop)
+import Test.QuickCheck
+    ( Arbitrary(..)
+    , Gen
+    , Property
+    , chooseInt
+    , conjoin
+    , counterexample
+    , elements
+    , vectorOf
+    , (===)
+    )
+
+data TextCellCase = TextCellCase !Int !Text.Text
+    deriving (Show)
+
+data SplitPaneCase = SplitPaneCase
+    { paneColumns :: !Int
+    , paneBodyRows :: !Int
+    , paneTitle :: !Text.Text
+    , paneDetail :: !Text.Text
+    , paneItems :: ![Text.Text]
+    , paneTranscript :: ![Text.Text]
+    , paneFooter :: !Text.Text
+    }
+    deriving (Show)
 
 spec :: Spec
 spec = do
@@ -53,6 +80,19 @@ spec = do
             fitTextCell 4 "abcde" `shouldBe` "abc…"
             fitTextCell 1 "ab" `shouldBe` "…"
             fitTextCell 0 "ab" `shouldBe` ""
+            fitTextCell 4 "界界" `shouldBe` "界界"
+
+        it "keeps newline-plus-variation-selector input on one frame row" do
+            let raw = Text.pack ['a', '\n', '\xfe0f', 'b']
+                fitted = fitTextCell 4 raw
+            fitted `shouldBe` "a b "
+            fitted `shouldSatisfy`
+                Text.all (`notElem` ['\t', '\r', '\n'])
+            terminalTextWidth fitted `shouldBe` 4
+
+        modifyMaxSuccess (const 500) $
+            prop "always occupies exactly its requested terminal-cell width" $
+                fitTextCellProperty
 
     describe "renderSplitPaneFrame" do
         it "keeps the selected item visible and previews its transcript" do
@@ -84,3 +124,131 @@ spec = do
             frame `shouldSatisfy` Text.isInfixOf "three trans"
             frame `shouldSatisfy` Text.isInfixOf "cript"
             length (Text.lines frame) `shouldBe` 5
+
+        it "does not let joined newlines split generated frame fields" do
+            let joinedNewline = Text.pack ['x', '\n', '\xfe0f', 'y']
+                frame = renderSplitPaneFrame SplitPaneFrame
+                    { splitPaneMinColumns = 12
+                    , splitPaneColumns = 20
+                    , splitPaneBodyRows = 1
+                    , splitPaneLeftMinWidth = 4
+                    , splitPaneLeftMaxWidth = 6
+                    , splitPaneDivider = " │ "
+                    , splitPaneTitle = joinedNewline
+                    , splitPaneHeaderDetail = const joinedNewline
+                    , splitPaneLeftHeading = joinedNewline
+                    , splitPaneRightHeading = const joinedNewline
+                    , splitPaneItems = [joinedNewline]
+                    , splitPaneSelectedIndex = 0
+                    , splitPaneLeftLabel = \_ item -> item
+                    , splitPaneTranscript = const [joinedNewline]
+                    , splitPaneEmptyTranscript = joinedNewline
+                    , splitPaneFooter = joinedNewline
+                    , splitPanePromptStyle = id
+                    , splitPaneMutedStyle = id
+                    , splitPaneSelectedStyle = id
+                    }
+                rows = Text.splitOn "\n" frame
+            length rows `shouldBe` 4
+            map terminalTextWidth rows `shouldBe` replicate 4 20
+
+        modifyMaxSuccess (const 300) $
+            prop "keeps every generated Unicode row within the pane geometry" $
+                splitPaneGeometryProperty
+
+fitTextCellProperty :: TextCellCase -> Property
+fitTextCellProperty (TextCellCase width raw) =
+    conjoin
+        [ counterexample "terminal width"
+            (terminalTextWidth fitted === width)
+        , counterexample "embedded layout controls"
+            (Text.all (`notElem` ['\t', '\r', '\n']) fitted === True)
+        , counterexample "idempotence"
+            (fitTextCell width fitted === fitted)
+        ]
+  where
+    fitted = fitTextCell width raw
+
+splitPaneGeometryProperty :: SplitPaneCase -> Property
+splitPaneGeometryProperty generated =
+    conjoin $
+        [ counterexample
+            ("row " <> show index <> " has terminal width "
+                <> show (terminalTextWidth row)
+                <> " instead of " <> show generated.paneColumns
+                <> ": " <> show row)
+            (terminalTextWidth row === generated.paneColumns)
+        | (index, row) <- zip [0 :: Int ..] rows
+        ]
+            <> [ counterexample "rendered row count"
+                    (length rows === generated.paneBodyRows + 3)
+               ]
+  where
+    values =
+        case generated.paneItems of
+            [] -> [""]
+            items -> items
+    rendered =
+        renderSplitPaneFrame SplitPaneFrame
+            { splitPaneMinColumns = 5
+            , splitPaneColumns = generated.paneColumns
+            , splitPaneBodyRows = generated.paneBodyRows
+            , splitPaneLeftMinWidth = 1
+            , splitPaneLeftMaxWidth =
+                max 1 (generated.paneColumns - 4)
+            , splitPaneDivider = " │ "
+            , splitPaneTitle = generated.paneTitle
+            , splitPaneHeaderDetail = const generated.paneDetail
+            , splitPaneLeftHeading = "項目"
+            , splitPaneRightHeading = const "preview 🚀"
+            , splitPaneItems = values
+            , splitPaneSelectedIndex = length values - 1
+            , splitPaneLeftLabel = \_ item -> item
+            , splitPaneTranscript = const generated.paneTranscript
+            , splitPaneEmptyTranscript = "(空)"
+            , splitPaneFooter = generated.paneFooter
+            , splitPanePromptStyle = id
+            , splitPaneMutedStyle = id
+            , splitPaneSelectedStyle = id
+            }
+    rows = Text.splitOn "\n" rendered
+
+instance Arbitrary TextCellCase where
+    arbitrary =
+        TextCellCase
+            <$> chooseInt (0, 100)
+            <*> genDisplayText
+
+instance Arbitrary SplitPaneCase where
+    arbitrary = do
+        columns <- chooseInt (5, 120)
+        bodyRows <- chooseInt (0, 10)
+        title <- genDisplayText
+        detail <- genDisplayText
+        itemCount <- chooseInt (0, 12)
+        items <- vectorOf itemCount genDisplayText
+        transcriptCount <- chooseInt (0, 12)
+        transcript <- vectorOf transcriptCount genDisplayText
+        footer <- genDisplayText
+        pure SplitPaneCase
+            { paneColumns = columns
+            , paneBodyRows = bodyRows
+            , paneTitle = title
+            , paneDetail = detail
+            , paneItems = items
+            , paneTranscript = transcript
+            , paneFooter = footer
+            }
+
+genDisplayText :: Gen Text.Text
+genDisplayText = do
+    size <- chooseInt (0, 160)
+    Text.pack <$> vectorOf size genDisplayChar
+
+genDisplayChar :: Gen Char
+genDisplayChar =
+    elements $
+        ['a' .. 'z']
+            <> ['0' .. '9']
+            <> [' ', ' ', '\t', '\r', '\n']
+            <> ['界', '語', '🙂', '🚀', 'é', 'ø', '\x0301', '\xFE0F']

--- a/packages/agent-responses/agent-responses.cabal
+++ b/packages/agent-responses/agent-responses.cabal
@@ -89,5 +89,6 @@ test-suite agent-responses-test
                     , aeson >= 2.0
                     , bytestring
                     , hspec
+                    , QuickCheck >= 2.14 && < 2.16
                     , retry
                     , text

--- a/packages/agent-responses/package.nix
+++ b/packages/agent-responses/package.nix
@@ -1,19 +1,21 @@
-{ mkDerivation, aeson, agent-core, agent-responses-types, base, base64-bytestring
-, bytestring, containers, hspec, http-client, http-client-tls
-, http-conduit, lib, safe-exceptions, scientific, text, vector
+{ mkDerivation, aeson, agent-core, agent-responses-types, base
+, base64-bytestring, bytestring, containers, hspec, http-client
+, http-client-tls, http-conduit, lib, QuickCheck, retry
+, safe-exceptions, scientific, text, vector
 }:
 mkDerivation {
   pname = "agent-responses";
   version = "0.1.0.0";
   src = ./.;
   libraryHaskellDepends = [
-    aeson agent-core agent-responses-types base base64-bytestring bytestring containers
-    http-client http-client-tls http-conduit safe-exceptions scientific
-    text vector
+    aeson agent-core agent-responses-types base base64-bytestring
+    bytestring containers http-client http-client-tls http-conduit
+    retry safe-exceptions scientific text vector
   ];
   testHaskellDepends = [
-    aeson agent-core agent-responses-types base bytestring hspec text
+    aeson agent-core agent-responses-types base bytestring hspec
+    QuickCheck retry text
   ];
   description = "Provider-neutral Responses codecs and adapters";
-  license = lib.licenses.bsd3;
+  license = lib.meta.getLicenseFromSpdxId "BSD-3-Clause";
 }

--- a/packages/agent-responses/test/Agent/Responses/SSESpec.hs
+++ b/packages/agent-responses/test/Agent/Responses/SSESpec.hs
@@ -3,14 +3,38 @@ module Agent.Responses.SSESpec (spec) where
 import Agent.Error (ApiError(..))
 import Agent.Responses.SSE
 import Agent.Responses.Types
+import Control.Monad (foldM)
+import qualified Data.Aeson as Aeson
+import Data.Aeson ((.=))
+import qualified Data.Aeson.KeyMap as KeyMap
 import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as LBS
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import Test.Hspec
+import Test.Hspec.QuickCheck (modifyMaxSuccess, prop)
+import Test.QuickCheck
+    ( Arbitrary(..)
+    , Gen
+    , Property
+    , chooseInt
+    , conjoin
+    , counterexample
+    , elements
+    , frequency
+    , listOf
+    , oneof
+    , vectorOf
+    , (===)
+    )
 
 spec :: Spec
 spec = describe "Responses SSE decoder" do
+    modifyMaxSuccess (const 500) $
+        prop "is invariant under generated HTTP chunk boundaries" $
+            chunkingInvariant
+
     it "decodes arbitrary HTTP chunk boundaries, including split UTF-8" do
         mapM_ checkSplit [0 .. BS.length splitBytes]
 
@@ -55,15 +79,216 @@ checkSplit offset = do
         `shouldBe` [EventOutputItemDone, EventResponseCompleted]
 
 decodeChunks :: [BS.ByteString] -> IO [ResponseStreamEvent]
-decodeChunks chunks = do
-    (decoder, reversedEvents) <- foldl step (pure (newSseDecoder, [])) chunks
-    trailing <- expectRight (finishSseDecoder decoder)
+decodeChunks chunks =
+    expectRight (decodeChunksEither chunks)
+
+decodeChunksEither
+    :: [BS.ByteString]
+    -> Either ApiError [ResponseStreamEvent]
+decodeChunksEither chunks = do
+    (decoder, reversedEvents) <-
+        foldM step (newSseDecoder, []) chunks
+    trailing <- finishSseDecoder decoder
     pure (reverse reversedEvents <> trailing)
   where
-    step accumulated chunk = do
-        (decoder, reversedEvents) <- accumulated
-        (nextDecoder, events) <- expectRight (feedSseDecoder decoder chunk)
+    step (decoder, reversedEvents) chunk = do
+        (nextDecoder, events) <- feedSseDecoder decoder chunk
         pure (nextDecoder, reverse events <> reversedEvents)
+
+data GeneratedChunkedStream = GeneratedChunkedStream
+    { generatedBody :: !Text
+    , generatedChunks :: ![BS.ByteString]
+    }
+
+instance Show GeneratedChunkedStream where
+    show stream =
+        "GeneratedChunkedStream { body = "
+            <> show stream.generatedBody
+            <> ", chunkSizes = "
+            <> show (map BS.length stream.generatedChunks)
+            <> " }"
+
+instance Arbitrary GeneratedChunkedStream where
+    arbitrary = do
+        body <- genSseBody
+        chunks <- genChunks (Text.encodeUtf8 body)
+        pure GeneratedChunkedStream
+            { generatedBody = body
+            , generatedChunks = chunks
+            }
+
+    shrink _ = []
+
+chunkingInvariant :: GeneratedChunkedStream -> Property
+chunkingInvariant stream =
+    conjoin
+        [ counterexample
+            ("chunks do not reconstruct body: " <> show stream)
+            (BS.concat stream.generatedChunks
+                === Text.encodeUtf8 stream.generatedBody)
+        , counterexample
+            ("chunked decoder differs from one-shot decoder: " <> show stream)
+            (decodeChunksEither stream.generatedChunks
+                === parseSseEvents stream.generatedBody)
+        ]
+
+genSseBody :: Gen Text
+genSseBody = do
+    lineEnding <- elements ["\n", "\r\n"]
+    eventCount <- chooseInt (1, 8)
+    events <- mapM genEvent [0 .. eventCount - 1]
+    includeEventLines <- vectorOf eventCount (frequency [(3, pure True), (1, pure False)])
+    includeComments <- vectorOf eventCount (frequency [(1, pure True), (3, pure False)])
+    includeDone <- frequency [(1, pure True), (3, pure False)]
+    unterminated <- frequency [(1, pure True), (3, pure False)]
+    let blocks =
+            concat
+                [ [ if comment
+                        then ": generated keepalive" <> lineEnding <> lineEnding
+                        else ""
+                  , eventBlock lineEnding withEvent event
+                  ]
+                | (event, withEvent, comment) <-
+                    zip3 events includeEventLines includeComments
+                ]
+        withDone =
+            if includeDone
+                then blocks
+                    <> ["data: [DONE]" <> lineEnding <> lineEnding]
+                else blocks
+        body = Text.concat withDone
+    pure $
+        if unterminated
+            then dropFinalBlankLine lineEnding body
+            else body
+
+genEvent :: Int -> Gen ResponseStreamEvent
+genEvent index =
+    oneof
+        [ genLifecycleEvent index
+        , genOutputItemEvent index
+        , genCustomToolDelta index
+        ]
+
+genLifecycleEvent :: Int -> Gen ResponseStreamEvent
+genLifecycleEvent index = do
+    model <- genText
+    status <-
+        elements ["completed", "incomplete", "failed"]
+            :: Gen Text
+    let response =
+            Aeson.object
+                [ "id" .= ("resp-" <> Text.pack (show index))
+                , "created_at" .= index
+                , "model" .= model
+                , "status" .= status
+                ]
+    elements
+        [ ResponseCreatedEvent response (Just index) KeyMap.empty
+        , ResponseInProgressEvent response (Just index) KeyMap.empty
+        , ResponseCompletedEvent response (Just index) KeyMap.empty
+        , ResponseDoneEvent response (Just index) KeyMap.empty
+        , ResponseFailedEvent response (Just index) KeyMap.empty
+        , ResponseIncompleteEvent response (Just index) KeyMap.empty
+        , ResponseQueuedEvent response (Just index) KeyMap.empty
+        ]
+
+genOutputItemEvent :: Int -> Gen ResponseStreamEvent
+genOutputItemEvent index = do
+    body <- genText
+    let item =
+            MessageItem ResponseMessage
+                { messageId = Just ("msg-" <> Text.pack (show index))
+                , content =
+                    MessageContentParts
+                        [ OutputTextPart
+                            { text = body
+                            , annotations = Nothing
+                            , logprobs = Nothing
+                            , extraFields = KeyMap.empty
+                            }
+                        ]
+                , role = RoleAssistant
+                , status = Just ItemCompleted
+                , phase = Nothing
+                , extraFields = KeyMap.empty
+                }
+    elements
+        [ ResponseOutputItemAddedEvent
+            item (Just index) (Just index) KeyMap.empty
+        , ResponseOutputItemDoneEvent
+            item (Just index) (Just index) KeyMap.empty
+        ]
+
+genCustomToolDelta :: Int -> Gen ResponseStreamEvent
+genCustomToolDelta index = do
+    delta <- genText
+    let itemId = Just ("item-" <> Text.pack (show index))
+        callId = Just ("call-" <> Text.pack (show index))
+    elements
+        [ ResponseCustomToolInputDeltaEvent
+            (Just delta) itemId callId (Just index) (Just index) KeyMap.empty
+        , ResponseCustomToolInputDoneEvent
+            (Just delta) itemId callId (Just index) (Just index) KeyMap.empty
+        ]
+
+genText :: Gen Text
+genText = do
+    count <- chooseInt (0, 80)
+    Text.pack <$> vectorOf count genTextChar
+
+genTextChar :: Gen Char
+genTextChar =
+    frequency
+        [ (20, elements ['a' .. 'z'])
+        , (5, elements ['0' .. '9'])
+        , (4, elements [' ', '\n', '\t', '"', '\\'])
+        , (3, elements ['é', '界', '🙂', '\x0301'])
+        ]
+
+eventBlock :: Text -> Bool -> ResponseStreamEvent -> Text
+eventBlock lineEnding includeEventLine event =
+    eventLine
+        <> "data: "
+        <> Text.decodeUtf8 (LBS.toStrict (Aeson.encode event))
+        <> lineEnding
+        <> lineEnding
+  where
+    eventLine
+        | includeEventLine =
+            "event: "
+                <> streamEventTypeText (responseStreamEventType event)
+                <> lineEnding
+        | otherwise = ""
+
+dropFinalBlankLine :: Text -> Text -> Text
+dropFinalBlankLine lineEnding body =
+    case Text.stripSuffix (lineEnding <> lineEnding) body of
+        Just prefix -> prefix
+        Nothing -> body
+
+genChunks :: BS.ByteString -> Gen [BS.ByteString]
+genChunks bytes = do
+    sizes <- listOf (chooseInt (1, max 1 (min 64 (BS.length bytes))))
+    includeEmpty <- frequency [(1, pure True), (3, pure False)]
+    let chunks = splitBySizes sizes bytes
+    pure $
+        if includeEmpty
+            then BS.empty : intersperseEmpty chunks <> [BS.empty]
+            else chunks
+
+splitBySizes :: [Int] -> BS.ByteString -> [BS.ByteString]
+splitBySizes _ bytes | BS.null bytes = []
+splitBySizes [] bytes = [bytes]
+splitBySizes (size : sizes) bytes =
+    let (chunk, rest) = BS.splitAt size bytes
+    in chunk : splitBySizes sizes rest
+
+intersperseEmpty :: [BS.ByteString] -> [BS.ByteString]
+intersperseEmpty [] = []
+intersperseEmpty [chunk] = [chunk]
+intersperseEmpty (chunk : chunks) =
+    chunk : BS.empty : intersperseEmpty chunks
 
 eventTypes :: [ResponseStreamEvent] -> [StreamEventType]
 eventTypes = map responseStreamEventType

--- a/packages/agent-tui/src/Agent/TUI/Markdown.hs
+++ b/packages/agent-tui/src/Agent/TUI/Markdown.hs
@@ -28,8 +28,10 @@ import Agent.Syntax
     , highlightCode
     )
 import Agent.TUI.TextWidth
-    ( displayCharCellWidth
-    , displayTerminalText
+    ( displayTerminalText
+    , graphemeCellWidth
+    , graphemeClusters
+    , terminalTextImage
     )
 import qualified Agent.TUI.Theme as Theme
 import Brick
@@ -44,15 +46,13 @@ import qualified Data.Text.Lazy as LazyText
 import qualified Data.Text.Lazy.Builder as Builder
 import qualified Graphics.Vty as V
 
-terminalCharWidth :: Char -> Int
-terminalCharWidth = displayCharCellWidth
-
 markdownWidget :: Ord n => Text -> Widget n
 markdownWidget =
     markdownWidgetWithCodeControls \_ language ->
         if Text.null language
             then emptyWidget
-            else withAttr Theme.mutedAttr (txt language)
+            else withAttr Theme.mutedAttr
+                (txt (displayTerminalText language))
 
 -- | Render Markdown with application-level click targets for links.
 markdownWidgetWithLinks
@@ -68,7 +68,8 @@ markdownWidgetWithLinks linkName =
         (\_ language ->
             if Text.null language
                 then emptyWidget
-                else withAttr Theme.mutedAttr (txt language))
+                else withAttr Theme.mutedAttr
+                    (txt (displayTerminalText language)))
 
 -- | Render Markdown, allowing callers to add an interactive control to each
 -- fenced code block header. Code block indices are one-based.
@@ -309,7 +310,7 @@ renderCodeRow paddingAttr horizontalPadding fragments =
     V.horizCat
         [ blank
         , V.horizCat
-            [ V.text attr (LazyText.fromStrict text)
+            [ terminalTextImage attr text
             | (attr, text) <- fragments
             ]
         , blank
@@ -412,7 +413,10 @@ tableWidget rows@(headerCells : _) =
 
 cellDisplayWidth :: Text -> Int
 cellDisplayWidth =
-    Text.foldl' (\width char -> width + terminalCharWidth char) 0
+    sum
+        . map graphemeCellWidth
+        . graphemeClusters
+        . displayTerminalText
         . inlinePlainText
         . parseInline
 
@@ -420,8 +424,9 @@ cellMinimumWidth :: Text -> Int
 cellMinimumWidth =
     maximum
         . (1 :)
-        . map terminalCharWidth
-        . Text.unpack
+        . map graphemeCellWidth
+        . graphemeClusters
+        . displayTerminalText
         . inlinePlainText
         . parseInline
 
@@ -476,7 +481,7 @@ compactTableImage width borderAttr rows =
 renderStyledLine :: [(V.Attr, Text)] -> V.Image
 renderStyledLine fragments =
     V.horizCat
-        [ V.text attr (LazyText.fromStrict text)
+        [ terminalTextImage attr text
         | (attr, text) <- fragments
         ]
 
@@ -549,7 +554,7 @@ renderTableCell paddingAttr horizontalPadding width fragments =
   where
     content =
         V.horizCat
-            [ V.text attr (LazyText.fromStrict text)
+            [ terminalTextImage attr text
             | (attr, text) <- fragments
             ]
     blank count
@@ -560,9 +565,9 @@ fragmentsDisplayWidth :: [(V.Attr, Text)] -> Int
 fragmentsDisplayWidth =
     sum
         . map
-            (Text.foldl'
-                (\width character -> width + terminalCharWidth character)
-                0
+            (sum
+                . map graphemeCellWidth
+                . graphemeClusters
                 . snd)
 
 inlineWidgetWithAttr
@@ -591,7 +596,7 @@ inlineWidgetWithAttr linkName plainAttr inlines =
                 B.Widget B.Fixed B.Fixed $
                     pure B.emptyResult
                         { B.image =
-                            V.text attr (LazyText.fromStrict text)
+                            terminalTextImage attr text
                         }
         B.render (vBox (map rowWidget rows))
 
@@ -649,8 +654,8 @@ wrapStyled width spans =
     finalize $
         List.foldl' addCell ([[]], 0) (styledCells spans)
   where
-    addCell (rows, used) cell@(_, character)
-        | character == '\n' = ([] : rows, 0)
+    addCell (rows, used) cell@(_, cluster, cellWidth)
+        | cluster == "\n" = ([] : rows, 0)
         | used > 0
         , used + cellWidth > width =
             ([cell] : rows, cellWidth)
@@ -659,8 +664,6 @@ wrapStyled width spans =
                 [] -> ([[cell]], cellWidth)
                 row : rest ->
                     ((cell : row) : rest, used + cellWidth)
-      where
-        cellWidth = terminalCharWidth character
     finalize (rows, _) =
         let ordered = map (groupStyledCells . reverse) (reverse rows)
         in if null ordered then [[]] else ordered
@@ -692,19 +695,17 @@ wrapStyledCode width spans =
     takeFitting = go 0 []
       where
         go _ taken [] = (reverse taken, [])
-        go used taken allCells@((attr, character) : rest)
+        go used taken allCells@(cell@(_, _, cellWidth) : rest)
             | used > 0
             , used + cellWidth > width' =
                 (reverse taken, allCells)
             | otherwise =
-                go (used + cellWidth) ((attr, character) : taken) rest
-          where
-            cellWidth = terminalCharWidth character
+                go (used + cellWidth) (cell : taken) rest
 
     lastSpaceIndex =
         List.foldl'
-            (\found (index, (_, character)) ->
-                if isSpace character then Just index else found)
+            (\found (index, cell) ->
+                if styledCellIsSpace cell then Just index else found)
             Nothing
             . zip [0 :: Int ..]
 
@@ -727,7 +728,7 @@ wrapStyledWords width spans =
                         | index > 0 ->
                             let (line, carried) = splitAt index fitting
                                 next =
-                                    dropWhile (isSpace . snd)
+                                    dropWhile styledCellIsSpace
                                         (carried <> overflow)
                             in dropTrailingSpace line : wrapCells next
                     _ -> fitting : wrapCells overflow
@@ -735,33 +736,35 @@ wrapStyledWords width spans =
     takeFitting = go 0 []
       where
         go _ taken [] = (reverse taken, [])
-        go used taken allCells@((attr, character) : rest)
+        go used taken allCells@(cell@(_, _, cellWidth) : rest)
             | used > 0
             , used + cellWidth > width' =
                 (reverse taken, allCells)
             | otherwise =
-                go (used + cellWidth) ((attr, character) : taken) rest
-          where
-            cellWidth = terminalCharWidth character
+                go (used + cellWidth) (cell : taken) rest
 
     lastSpaceIndex =
         List.foldl'
-            (\found (index, (_, character)) ->
-                if isSpace character then Just index else found)
+            (\found (index, cell) ->
+                if styledCellIsSpace cell then Just index else found)
             Nothing
             . zip [0 :: Int ..]
 
     dropTrailingSpace =
-        reverse . dropWhile (isSpace . snd) . reverse
+        reverse . dropWhile styledCellIsSpace . reverse
 
-type StyledCell = (V.Attr, Char)
+type StyledCell = (V.Attr, Text, Int)
 
 styledCells :: [(V.Attr, Text)] -> [StyledCell]
 styledCells spans =
-    [ (attr, character)
+    [ (attr, cluster, graphemeCellWidth cluster)
     | (attr, text) <- spans
-    , character <- Text.unpack text
+    , cluster <- graphemeClusters text
     ]
+
+styledCellIsSpace :: StyledCell -> Bool
+styledCellIsSpace (_, cluster, _) =
+    not (Text.null cluster) && Text.all isSpace cluster
 
 groupStyledCells :: [StyledCell] -> [(V.Attr, Text)]
 groupStyledCells =
@@ -771,10 +774,10 @@ groupStyledCells =
         . reverse
         . List.foldl' appendCell []
   where
-    appendCell grouped (attr, character) =
+    appendCell grouped (attr, cluster, _) =
         case grouped of
             (previousAttr, previousText) : rest
                 | previousAttr == attr ->
-                    (previousAttr, previousText <> Builder.singleton character)
+                    (previousAttr, previousText <> Builder.fromText cluster)
                         : rest
-            _ -> (attr, Builder.singleton character) : grouped
+            _ -> (attr, Builder.fromText cluster) : grouped

--- a/packages/agent-tui/src/Agent/TUI/Model.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model.hs
@@ -45,6 +45,7 @@ import Agent.TUI.Presentation
     , toolCallInput
     , toolCallTitle
     )
+import Agent.TUI.TextWidth (clampGraphemeCursor)
 import Agent.TUI.Motion
     ( completionStatusDurationMillis
     , transientNoticeDurationMillis
@@ -333,7 +334,7 @@ reduceUi event state = case event of
     UiSetDraft text cursor ->
         state
             { uiDraft = text
-            , uiCursor = max 0 (min (Text.length text) cursor)
+            , uiCursor = clampGraphemeCursor text cursor
             }
     UiSetPrompt prompt ->
         state { uiPrompt = prompt }

--- a/packages/agent-tui/src/Agent/TUI/TextWidth.hs
+++ b/packages/agent-tui/src/Agent/TUI/TextWidth.hs
@@ -4,6 +4,13 @@ module Agent.TUI.TextWidth
     , displayCharCellWidth
     , displayTerminalChar
     , displayTerminalText
+    , graphemeCellWidth
+    , graphemeClusters
+    , splitTerminalGraphemeSuffix
+    , terminalTextImage
+    , clampGraphemeCursor
+    , nextGraphemeBoundary
+    , previousGraphemeBoundary
     , isWideCharacter
     ) where
 
@@ -25,7 +32,7 @@ import qualified Graphics.Vty as V
 charCellWidth :: Char -> Int
 charCellWidth char
     | category `elem` [NonSpacingMark, SpacingCombiningMark, EnclosingMark] = 0
-    | category `elem` [Control, Surrogate, NotAssigned] = 0
+    | category `elem` [Control, Format, Surrogate, NotAssigned] = 0
     | isWideCharacter char = 2
     | otherwise = 1
   where
@@ -52,6 +59,7 @@ displayTerminalChar char
     | char == '\n' = "\n"
     | char == '\r' = "↵"
     | char == '\t' = "⇥"
+    | isVariationSelector char = ""
     | code >= 0 && code <= 0x1f =
         Text.singleton (chr (0x2400 + code))
     | code == 0x7f = "␡"
@@ -62,7 +70,287 @@ displayTerminalChar char
     code = ord char
 
 displayTerminalText :: Text -> Text
-displayTerminalText = Text.concatMap displayTerminalChar
+displayTerminalText =
+    Text.concat . map displayTerminalCluster . graphemeClusters
+  where
+    -- ZWJ and emoji tag characters are terminal formatting controls when
+    -- they occur on their own, but are required source characters inside a
+    -- recognized emoji grapheme. Other format characters remain inert
+    -- replacement glyphs.
+    displayTerminalCluster cluster
+        | needsVtyCompatibleWidth cluster
+        , V.safeWctwidth preserved /= graphemeCellWidth cluster =
+            compatibleFallback cluster
+        | otherwise = preserved
+      where
+        preserved
+            | '\x20e3' `Text.elem` cluster
+            , not (isKeycapCluster (Text.unpack cluster)) =
+                Text.concatMap displayInvalidKeycapChar cluster
+            | Text.length cluster > 1
+            , Text.any isEmojiCandidate cluster =
+                Text.concatMap displayEmojiClusterChar cluster
+            | otherwise =
+                Text.concatMap displayOrdinaryClusterChar cluster
+
+    displayEmojiClusterChar character
+        | character == '\x200d'
+            || isEmojiTag character
+            || isVariationSelector character =
+            Text.singleton character
+        | otherwise = displayTerminalChar character
+
+    displayInvalidKeycapChar character
+        | character == '\x20e3' = "�"
+        | isVariationSelector character = ""
+        | otherwise = displayTerminalChar character
+
+    -- Variation selectors only have meaning when attached to a compatible
+    -- base character. Dropping a dangling selector prevents adjacent Vty
+    -- text spans from accidentally forming a wider emoji grapheme after
+    -- Brick has already split the source into separate widgets.
+    displayOrdinaryClusterChar character
+        | isVariationSelector character = ""
+        | otherwise = displayTerminalChar character
+
+    -- Vty 6 measures some modern terminal graphemes differently from the
+    -- terminal itself (notably long family ZWJ sequences and keycaps). Such
+    -- text cannot safely be placed in a Vty image: its span accounting and
+    -- the terminal cursor would disagree. Preserve a representative glyph
+    -- with the same target width instead.
+    compatibleFallback cluster =
+        case Text.find
+            (\character ->
+                V.safeWcwidth character == targetWidth
+                    && displayTerminalChar character
+                        == Text.singleton character)
+            cluster of
+            Just character -> Text.singleton character
+            Nothing ->
+                case fullWidthAscii cluster of
+                    Just character
+                        | V.safeWcwidth character == targetWidth ->
+                            Text.singleton character
+                    _
+                        | targetWidth == 2 -> "？"
+                        | targetWidth == 0 -> ""
+                        | otherwise -> "�"
+      where
+        targetWidth = graphemeCellWidth cluster
+
+    fullWidthAscii =
+        fmap (chr . (+ 0xfee0) . ord)
+            . Text.find
+                (\character ->
+                    character >= '!' && character <= '~')
+
+-- | Split text into the terminal grapheme units that must not be wrapped or
+-- truncated independently. This covers combining sequences and the emoji
+-- constructions commonly emitted by terminals: ZWJ sequences, regional
+-- indicator flags, skin-tone modifiers, keycaps, and emoji tag sequences.
+graphemeClusters :: Text -> [Text]
+graphemeClusters = map Text.pack . go . Text.unpack
+  where
+    go [] = []
+    go input =
+        let (cluster, rest) = takeCluster input
+        in cluster : go rest
+
+    takeCluster [] = ([], [])
+    takeCluster (character : rest)
+        | isRegionalIndicator character =
+            let (extensions, afterExtensions) =
+                    takeClusterExtensions True rest
+            in case afterExtensions of
+                next : remaining
+                    | isRegionalIndicator next ->
+                        let (nextExtensions, afterNext) =
+                                takeClusterExtensions True remaining
+                        in ( character
+                                : extensions
+                                <> (next : nextExtensions)
+                           , afterNext
+                           )
+                _ -> (character : extensions, afterExtensions)
+        | otherwise =
+            let (extensions, afterExtensions) =
+                    takeClusterExtensions
+                        (isEmojiCandidate character)
+                        rest
+                initial = character : extensions
+            in takeEmojiJoins initial afterExtensions
+
+    takeEmojiJoins cluster ('\x200d' : next : rest)
+        | any isEmojiCandidate cluster
+        , isEmojiCandidate next =
+            let (extensions, remaining) =
+                    takeClusterExtensions True rest
+            in takeEmojiJoins
+                (cluster <> ('\x200d' : next : extensions))
+                remaining
+    takeEmojiJoins cluster rest = (cluster, rest)
+
+    takeClusterExtensions allowEmoji = goExtensions
+      where
+        goExtensions (character : rest)
+            | isCombiningMark character =
+                let (extensions, remaining) = goExtensions rest
+                in (character : extensions, remaining)
+            | allowEmoji
+            , isEmojiModifier character || isEmojiTag character =
+                let (extensions, remaining) = goExtensions rest
+                in (character : extensions, remaining)
+        goExtensions remaining = ([], remaining)
+
+-- | Hold a trailing cluster that may combine with the next streamed chunk.
+--
+-- This is intentionally narrower than general Unicode grapheme segmentation:
+-- ordinary combining marks can still combine across terminal SGR sequences,
+-- while emoji, flags, keycaps, and trailing ZWJ sequences must be sanitized as
+-- a whole or they can be irreversibly replaced before the next chunk arrives.
+splitTerminalGraphemeSuffix :: Text -> (Text, Text)
+splitTerminalGraphemeSuffix text =
+    case reverse (graphemeClusters text) of
+        [] -> ("", "")
+        lastCluster : previous
+            | lastCluster == Text.singleton '\x200d'
+            , previousCluster : _ <- previous ->
+                splitAtSuffix (previousCluster <> lastCluster)
+            | clusterMayExtend lastCluster ->
+                splitAtSuffix lastCluster
+            | otherwise -> (text, "")
+  where
+    splitAtSuffix suffix =
+        (Text.dropEnd (Text.length suffix) text, suffix)
+
+    clusterMayExtend cluster =
+        Text.any isEmojiCandidate cluster
+            || Text.any isKeycapBase cluster
+
+-- | Width of one cluster as displayed by a modern terminal.
+graphemeCellWidth :: Text -> Int
+graphemeCellWidth cluster
+    | Text.null cluster = 0
+    | isRegionalIndicatorPair characters = 2
+    | isKeycapCluster characters = 2
+    | any isEmojiModifier characters = 2
+    | hasEmojiTagSequence characters = 2
+    | '\xfe0f' `elem` characters
+    , any isEmojiCandidate characters = 2
+    | '\x200d' `elem` characters
+    , any isEmojiCandidate characters = 2
+    | otherwise = sum (map charCellWidth characters)
+  where
+    characters = Text.unpack cluster
+
+-- | Build a single-line Vty image after replacing any grapheme whose terminal
+-- width disagrees with Vty's width model. This keeps Vty's span accounting,
+-- our layout model, and the terminal cursor in agreement.
+--
+-- The input is sanitized with 'displayTerminalText' before it reaches Vty.
+-- Callers should split structural newlines before constructing an image.
+terminalTextImage :: V.Attr -> Text -> V.Image
+terminalTextImage attr =
+    V.text' attr . displayTerminalText
+
+clampGraphemeCursor :: Text -> Int -> Int
+clampGraphemeCursor text requested =
+    last $
+        takeWhile (<= bounded) (graphemeBoundaries text)
+  where
+    bounded = max 0 (min (Text.length text) requested)
+
+previousGraphemeBoundary :: Text -> Int -> Int
+previousGraphemeBoundary text requested =
+    case takeWhile (< cursor) (graphemeBoundaries text) of
+        [] -> 0
+        boundaries -> last boundaries
+  where
+    cursor = clampGraphemeCursor text requested
+
+nextGraphemeBoundary :: Text -> Int -> Int
+nextGraphemeBoundary text requested =
+    case dropWhile (<= bounded) (graphemeBoundaries text) of
+        boundary : _ -> boundary
+        [] -> Text.length text
+  where
+    bounded = max 0 (min (Text.length text) requested)
+
+graphemeBoundaries :: Text -> [Int]
+graphemeBoundaries =
+    scanl
+        (\offset cluster -> offset + Text.length cluster)
+        0
+        . graphemeClusters
+
+isCombiningMark :: Char -> Bool
+isCombiningMark character =
+    generalCategory character
+        `elem` [NonSpacingMark, SpacingCombiningMark, EnclosingMark]
+
+isEmojiCandidate :: Char -> Bool
+isEmojiCandidate character =
+    let code = ord character
+    in (code >= 0x1f000 && code <= 0x1faff)
+        || (code >= 0x2600 && code <= 0x27ff)
+        || code == 0x00a9
+        || code == 0x00ae
+        || code == 0x3030
+        || code == 0x303d
+        || code == 0x3297
+        || code == 0x3299
+
+isRegionalIndicator :: Char -> Bool
+isRegionalIndicator character =
+    let code = ord character
+    in code >= 0x1f1e6 && code <= 0x1f1ff
+
+isRegionalIndicatorPair :: [Char] -> Bool
+isRegionalIndicatorPair characters =
+    length (filter isRegionalIndicator characters) == 2
+
+needsVtyCompatibleWidth :: Text -> Bool
+needsVtyCompatibleWidth cluster =
+    any isEmojiCandidate characters
+        || isKeycapCluster characters
+  where
+    characters = Text.unpack cluster
+
+isKeycapCluster :: [Char] -> Bool
+isKeycapCluster characters =
+    '\x20e3' `elem` characters
+        && any isKeycapBase characters
+
+isKeycapBase :: Char -> Bool
+isKeycapBase character =
+    (character >= '0' && character <= '9')
+        || character == '#'
+        || character == '*'
+
+hasEmojiTagSequence :: [Char] -> Bool
+hasEmojiTagSequence characters =
+    any isEmojiTag characters
+        && any isEmojiCandidate characters
+
+isEmojiModifier :: Char -> Bool
+isEmojiModifier character =
+    let code = ord character
+    in code >= 0x1f3fb && code <= 0x1f3ff
+
+isEmojiTag :: Char -> Bool
+isEmojiTag character =
+    let code = ord character
+    in code >= 0xe0020 && code <= 0xe007f
+
+-- Variation selectors are meaningful only when they remain attached to the
+-- character they modify. Keeping a standalone selector lets Vty merge it with
+-- text from an adjacent widget, potentially changing that glyph's terminal
+-- width after layout has already been calculated.
+isVariationSelector :: Char -> Bool
+isVariationSelector character =
+    let code = ord character
+    in (code >= 0xfe00 && code <= 0xfe0f)
+        || (code >= 0xe0100 && code <= 0xe01ef)
 
 -- | Report whether Vty's terminal-width table treats a character as wide.
 --

--- a/packages/agent-tui/test/Agent/TUI/MarkdownSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/MarkdownSpec.hs
@@ -2,7 +2,11 @@ module Agent.TUI.MarkdownSpec (spec) where
 
 import Agent.TUI.Markdown
 import Agent.Syntax (loadSyntaxHighlighterFrom)
-import Agent.TUI.TextWidth (displayCharCellWidth)
+import Agent.TUI.TextWidth
+    ( displayTerminalText
+    , graphemeCellWidth
+    , graphemeClusters
+    )
 import qualified Agent.TUI.Theme as Theme
 import Brick
     ( (<=>)
@@ -102,6 +106,24 @@ spec = describe "fullscreen Markdown rendering" do
                         (1, 2)
         V.imageWidth image `shouldSatisfy` (<= 1)
         V.imageHeight image `shouldSatisfy` (<= 2)
+
+    it "safely substitutes unsupported ZWJ widths without corrupting rows" do
+        let family =
+                Text.pack
+                    [ '\x1f468'
+                    , '\x200d'
+                    , '\x1f469'
+                    , '\x200d'
+                    , '\x1f467'
+                    , '\x200d'
+                    , '\x1f466'
+                    ]
+            input = "a" <> family <> "b"
+            displayed = displayTerminalText input
+            rows = renderRows 4 input
+        displayed `shouldBe` "a？b"
+        rows `shouldBe` [displayed]
+        map rowDisplayWidth rows `shouldBe` [4]
 
     it "parses links nested inside strong and emphasis spans" do
         parseInline
@@ -500,10 +522,24 @@ spec = describe "fullscreen Markdown rendering" do
                     \| combining | é |"
                 rows = renderRows 80 input
                 plain = Text.unlines rows
-            plain `shouldSatisfy` Text.isInfixOf "漢字🙂"
+            plain `shouldSatisfy`
+                Text.isInfixOf (displayTerminalText "漢字🙂")
             plain `shouldSatisfy` Text.isInfixOf "é"
             map rowDisplayWidth rows
                 `shouldSatisfy` allEqual
+
+        it "measures visible replacements when table cells contain controls" do
+            let standaloneTag = Text.singleton '\xe0067'
+                input =
+                    "| Kind | Value |\n\
+                    \| --- | --- |\n\
+                    \| control | \BEL |\n\
+                    \| format | " <> standaloneTag <> " |"
+                rows = renderRows 80 input
+                plain = Text.unlines rows
+            plain `shouldSatisfy` Text.isInfixOf "␇"
+            plain `shouldSatisfy` Text.isInfixOf "�"
+            map rowDisplayWidth rows `shouldSatisfy` allEqual
 
         it "keeps escaped and code-span pipes inside their cells" do
             let input =
@@ -712,18 +748,16 @@ spanRowText =
 
 rowDisplayWidth :: Text.Text -> Int
 rowDisplayWidth =
-    Text.foldl'
-        (\width character -> width + displayCharCellWidth character)
-        0
+    sum . map graphemeCellWidth . graphemeClusters
 
 characterColumns :: Char -> Text.Text -> [Int]
-characterColumns target = go 0 . Text.unpack
+characterColumns target = go 0 . graphemeClusters
   where
     go _ [] = []
-    go column (character : rest) =
+    go column (cluster : rest) =
         let following =
-                go (column + displayCharCellWidth character) rest
-        in if character == target
+                go (column + graphemeCellWidth cluster) rest
+        in if cluster == Text.singleton target
             then column : following
             else following
 

--- a/packages/agent-tui/test/Agent/TUI/TextWidthSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/TextWidthSpec.hs
@@ -16,7 +16,7 @@ spec = describe "terminal character width" do
 
     it "keeps raw controls zero-width but display placeholders one cell wide" do
         charCellWidth '\BEL' `shouldBe` 0
-        charCellWidth '\x200d' `shouldBe` 1
+        charCellWidth '\x200d' `shouldBe` 0
         displayCharCellWidth '\BEL' `shouldBe` 1
         displayCharCellWidth '\t' `shouldBe` 1
         displayCharCellWidth '\x200d' `shouldBe` 1

--- a/packages/agent-tui/test/Agent/TUI/TextWidthSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/TextWidthSpec.hs
@@ -1,6 +1,8 @@
 module Agent.TUI.TextWidthSpec (spec) where
 
 import Agent.TUI.TextWidth
+import qualified Data.Text as Text
+import qualified Graphics.Vty as V
 import Test.Hspec
 
 spec :: Spec
@@ -27,3 +29,112 @@ spec = describe "terminal character width" do
         isWideCharacter 'a' `shouldBe` False
         isWideCharacter '\x0301' `shouldBe` False
         isWideCharacter '·' `shouldBe` False
+
+    it "keeps common emoji graphemes indivisible and two cells wide" do
+        let womanTechnologist =
+                Text.pack ['\x1f469', '\x200d', '\x1f4bb']
+            usFlag =
+                Text.pack ['\x1f1fa', '\x1f1f8']
+            thumbsUpMedium =
+                Text.pack ['\x1f44d', '\x1f3fd']
+            keycapOne =
+                Text.pack ['1', '\xfe0f', '\x20e3']
+        graphemeClusters
+            (womanTechnologist <> usFlag <> thumbsUpMedium <> keycapOne)
+            `shouldBe`
+                [ womanTechnologist
+                , usFlag
+                , thumbsUpMedium
+                , keycapOne
+                ]
+        map graphemeCellWidth
+            [womanTechnologist, usFlag, thumbsUpMedium, keycapOne]
+            `shouldBe` [2, 2, 2, 2]
+
+    it "does not attach emoji modifiers or tags to ordinary text" do
+        let modifier = Text.singleton '\x1f3fd'
+            tag = Text.singleton '\xe0067'
+        graphemeClusters ("a" <> modifier <> "b" <> tag)
+            `shouldBe` ["a", modifier, "b", tag]
+
+    it "moves and clamps cursors at grapheme boundaries" do
+        let womanTechnologist =
+                Text.pack ['\x1f469', '\x200d', '\x1f4bb']
+            text = "a" <> womanTechnologist <> "b"
+        clampGraphemeCursor text 2 `shouldBe` 1
+        previousGraphemeBoundary text 4 `shouldBe` 1
+        nextGraphemeBoundary text 1 `shouldBe` 4
+        nextGraphemeBoundary text 2 `shouldBe` 4
+
+    it "holds only terminal graphemes that may extend across stream chunks" do
+        let woman = Text.singleton '\x1f469'
+            trailingJoin = woman <> Text.singleton '\x200d'
+        splitTerminalGraphemeSuffix "plain text"
+            `shouldBe` ("plain text", "")
+        splitTerminalGraphemeSuffix ("hello " <> woman)
+            `shouldBe` ("hello ", woman)
+        splitTerminalGraphemeSuffix trailingJoin
+            `shouldBe` ("", trailingJoin)
+        splitTerminalGraphemeSuffix "version 1"
+            `shouldBe` ("version ", "1")
+
+    it "declares modern emoji sequence widths correctly to Vty" do
+        let family =
+                Text.pack
+                    [ '\x1f468'
+                    , '\x200d'
+                    , '\x1f469'
+                    , '\x200d'
+                    , '\x1f467'
+                    , '\x200d'
+                    , '\x1f466'
+                    ]
+            keycapOne =
+                Text.pack ['1', '\xfe0f', '\x20e3']
+        V.imageWidth (terminalTextImage V.defAttr family)
+            `shouldBe` 2
+        V.imageWidth (terminalTextImage V.defAttr keycapOne)
+            `shouldBe` 2
+        displayTerminalText family
+            `shouldBe` "？"
+        displayTerminalText keycapOne
+            `shouldBe` "１"
+
+    it "substitutes every emoji presentation that Vty under-measures" do
+        let heart =
+                Text.pack ['\x2665', '\xfe0f']
+        displayTerminalText "🙂" `shouldBe` "？"
+        displayTerminalText heart `shouldBe` "？"
+        V.imageWidth (terminalTextImage V.defAttr "🙂")
+            `shouldBe` 2
+        V.imageWidth (terminalTextImage V.defAttr heart)
+            `shouldBe` 2
+
+    it "does not classify invalid keycaps or standalone tags as emoji" do
+        let invalidKeycap =
+                Text.pack ['a', '\x20e3']
+            standaloneTag =
+                Text.singleton '\xe0067'
+        graphemeCellWidth invalidKeycap `shouldBe` 1
+        displayTerminalText invalidKeycap `shouldBe` "a�"
+        graphemeCellWidth standaloneTag `shouldBe` 0
+        displayTerminalText standaloneTag `shouldBe` "�"
+
+    it "preserves valid emoji formatting but neutralizes standalone formats" do
+        let womanTechnologist =
+                Text.pack ['\x1f469', '\x200d', '\x1f4bb']
+        displayTerminalText womanTechnologist
+            `shouldBe` womanTechnologist
+        displayTerminalText (Text.singleton '\x200d')
+            `shouldBe` "�"
+
+    it "drops variation selectors that could attach across widget boundaries" do
+        let emojiCheck =
+                Text.pack ['\x2713', '\xfe0f']
+            ordinaryVariation =
+                Text.pack ['w', '\xfe0f']
+        displayTerminalText emojiCheck `shouldBe` "？"
+        displayTerminalText ordinaryVariation `shouldBe` "w"
+        displayTerminalText (Text.singleton '\xfe0f') `shouldBe` ""
+        V.safeWctwidth (displayTerminalText ordinaryVariation)
+            `shouldBe` graphemeCellWidth ordinaryVariation


### PR DESCRIPTION
## Summary
- add generated fullscreen TUI action traces that validate frame, layer, cursor, incremental-redraw, and terminal span-width invariants
- make editor, composer, Markdown, pane, and dynamic TUI rendering grapheme-aware and terminal-safe
- add QuickCheck coverage for arbitrary SSE chunk boundaries and session response-item/content storage codecs

## Bugs found and fixed
- prevent variation selectors from crossing adjacent widget boundaries and changing glyph widths after layout
- preserve emoji, keycap, and ZWJ graphemes across wrapping, truncation, cursor edits, and streaming Markdown chunks
- fix Unicode and control-character widths in Markdown tables and split-pane layouts
- distinguish composer cursor positions before and after an explicit newline at a full visual row

## Testing
- `nix develop -c cabal build all`
- `agent-tui-test`: 151 examples, 0 failures
- `agent-responses-test`: 33 examples, 0 failures
- `agent-cli-test --seed 220452306`: 869 examples, 0 failures
