### PR TITLE
Extract pure Claude transcript appending

### DIFF
--- a/packages/agent-claude/src/Agent/Claude/LoopBackend.hs
+++ b/packages/agent-claude/src/Agent/Claude/LoopBackend.hs
@@ -3,6 +3,7 @@
 module Agent.Claude.LoopBackend
     ( withClaudeCodeBackend
     , claudeCodeOneShotBackend
+    , appendHostTranscript
     ) where
 
 import Agent.Claude.Options
@@ -547,7 +548,7 @@ commitHostTranscript
     sessionId
     inputs
     assistantText = do
-    appendHostTranscript transcript inputs assistantText
+    appendHostTranscriptRef transcript inputs assistantText
     -- Read and enter the exact object installed in the IORef before taking its
     -- StableName. Otherwise the lazy append thunk can later be entered by the
     -- CLI, changing the StableName despite no host-side transcript change.
@@ -563,17 +564,23 @@ commitHostTranscript
             }
 
 appendHostTranscript
+    :: [ResponseItem]
+    -> [TurnInput]
+    -> Maybe Text
+    -> [ResponseItem]
+appendHostTranscript history inputs assistantText =
+    history
+        <> turnInputsToItems inputs
+        <> [assistantMessageItem assistantText]
+
+appendHostTranscriptRef
     :: IORef [ResponseItem]
     -> [TurnInput]
     -> Maybe Text
     -> IO ()
-appendHostTranscript transcript inputs assistantText =
+appendHostTranscriptRef transcript inputs assistantText =
     atomicModifyIORef' transcript \history ->
-        ( history
-            <> turnInputsToItems inputs
-            <> [assistantMessageItem assistantText]
-        , ()
-        )
+        (appendHostTranscript history inputs assistantText, ())
 
 assistantMessageItem :: Maybe Text -> ResponseItem
 assistantMessageItem assistantText =

--- a/packages/agent-claude/test/Agent/Claude/LoopBackendSpec.hs
+++ b/packages/agent-claude/test/Agent/Claude/LoopBackendSpec.hs
@@ -1,7 +1,8 @@
 module Agent.Claude.LoopBackendSpec (spec) where
 
 import Agent.Claude.LoopBackend
-    ( claudeCodeOneShotBackend
+    ( appendHostTranscript
+    , claudeCodeOneShotBackend
     , withClaudeCodeBackend
     )
 import Agent.Claude.Options
@@ -74,6 +75,24 @@ submitBackend backend previous inputs onEvent =
 
 spec :: Spec
 spec = do
+    describe "appendHostTranscript" do
+        it "appends turn inputs followed by assistant text" $ do
+            let history =
+                    appendHostTranscript
+                        []
+                        [UserMessage "hello", UserMessage "world"]
+                        (Just "response")
+            map responseMessageText
+                [message | MessageItem message <- history]
+                `shouldBe` ["hello", "world", "response"]
+
+        it "preserves existing history and uses empty text when absent" $ do
+            let initial = turnInputsToItems [UserMessage "prior"]
+                history = appendHostTranscript initial [] Nothing
+            map responseMessageText
+                [message | MessageItem message <- history]
+                `shouldBe` ["prior", ""]
+
     describe "Claude Code loop backend" do
         it "renders validated structured JSONL and persists normalized host messages" $
             withFakeClaude \fake -> do


### PR DESCRIPTION
## Summary
- extract host transcript construction into a pure `appendHostTranscript` function
- keep the IORef update in a small boundary wrapper
- add focused tests for ordering, preserved history, and absent assistant text

## Validation
- `nix develop -c cabal test agent-claude:test:agent-claude-test --offline`
- 30 examples, 0 failures