### PR TITLE
Remove private backend parameter IORefs

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Btw.hs
+++ b/packages/agent-cli/src/Agent/CLI/Btw.hs
@@ -28,7 +28,7 @@ import Agent.Responses.Types
     , ToolChoiceMode(..)
     )
 import Control.Concurrent.Async (race)
-import Data.IORef (IORef, newIORef, readIORef)
+import Data.IORef (IORef, readIORef)
 import Data.List (findIndex)
 import Data.Set (Set)
 import qualified Data.Set as Set
@@ -37,7 +37,7 @@ import qualified Data.Text as Text
 
 -- | Construct a provider backend over private request parameters and transcript.
 type BtwBackendFactory =
-    IORef ResponseCreateParams -> Backend
+    ResponseCreateParams -> Backend
 
 data BtwError
     = BtwTransport !ApiError
@@ -124,9 +124,8 @@ runBtwWithCancel
 runBtwWithCancel withCancelScope makeBackend paramsRef transcriptRef question = do
     params <- clearTurnSpecificParams <$> readIORef paramsRef
     transcript <- trimDanglingToolSuffix <$> readIORef transcriptRef
-    privateParams <- newIORef params
     cancel <- newCancelFlag
-    let Backend submit = makeBackend privateParams
+    let Backend submit = makeBackend params
         request =
             submit transcript Nothing
                 [UserMessage (sideQuestionPrompt question)] (\_ -> pure ())

--- a/packages/agent-cli/src/Agent/CLI/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime.hs
@@ -2679,7 +2679,7 @@ runAgentInitializedWithLock
                                         freshOpenAiBackend
                                             options.optShowRawReasoning
                                             tokenProvider
-                                            (readIORef privateParams)
+                                            (pure privateParams)
                                     compactRunner focus =
                                         withMVar wsLock \_ ->
                                             installCompactOutcome
@@ -2747,9 +2747,9 @@ runAgentInitializedWithLock
                                         dialect
                                         XAIProvider
                                         ctx.multiSendToRoot
-                                        (\childParamsRef ->
+                                        (\childParams ->
                                             xaiBackend xaiOptions tokenProvider
-                                                (readIORef childParamsRef))
+                                                (pure childParams))
                             Nothing -> pure ()
                         let backend =
                                 withPendingInputs pendingNotices $
@@ -2758,7 +2758,7 @@ runAgentInitializedWithLock
                                             (readIORef paramsRef)
                             btwBackend privateParams =
                                 xaiBackend xaiOptions tokenProvider
-                                    (readIORef privateParams)
+                                    (pure privateParams)
                             compactRunner =
                                 installCompactOutcome previousRef transcriptRef Nothing $
                                     runProviderCompactWith
@@ -2811,7 +2811,7 @@ runAgentInitializedWithLock
                                                     { permission =
                                                         ClaudeCodeDontAsk
                                                     }
-                                                (readIORef privateParams)
+                                                (pure privateParams)
                                                 privateTranscript
                                     privateBackend.submitTurn
                                         state
@@ -2881,9 +2881,9 @@ runAgentInitializedWithLock
                                         dialect
                                         OpenRouterProvider
                                         ctx.multiSendToRoot
-                                        (\childParamsRef ->
+                                        (\childParams ->
                                             makeBackend
-                                                (readIORef childParamsRef))
+                                                (pure childParams))
                             Nothing -> pure ()
                         let backend =
                                 withPendingInputs pendingNotices $
@@ -2891,8 +2891,7 @@ runAgentInitializedWithLock
                                         makeBackend
                                             (readIORef paramsRef)
                             btwBackend privateParams =
-                                makeBackend
-                                    (readIORef privateParams)
+                                makeBackend (pure privateParams)
                             compactRunner =
                                 installCompactOutcome previousRef transcriptRef Nothing $
                                     case customGenericOptions of
@@ -3161,7 +3160,7 @@ runSession SessionRequest{..} SessionBackend{..} = do
                                               (roleWarn color
                                                   (glyphWarn <> message))
                       _ -> pure ()
-  withSessionTitleManager btwBackend paramsRef showTitleEvent \titleManager -> do
+  withSessionTitleManager btwBackend (readIORef paramsRef) showTitleEvent \titleManager -> do
     toolRegistry <- requireToolRegistry allTools
     printed <- newIORef False
     let attachmentsRef = startup.startupSessionState.sessionAttachments

--- a/packages/agent-cli/src/Agent/CLI/SessionTitle.hs
+++ b/packages/agent-cli/src/Agent/CLI/SessionTitle.hs
@@ -31,7 +31,6 @@ import Control.Concurrent.Async (withAsync)
 import Control.Concurrent.STM
 import Control.Exception.Safe (displayException, tryAny)
 import Control.Monad (forever, void)
-import Data.IORef (IORef, newIORef, readIORef)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Set (Set)
@@ -72,12 +71,12 @@ data SessionTitleManager = SessionTitleManager
     , titleRequested :: !(TVar (Set (Text, Int, Int)))
     , titleGenerations :: !(TVar (Map Text Int))
     , titleBackendFactory :: !BtwBackendFactory
-    , titleParams :: !(IORef ResponseCreateParams)
+    , titleParams :: !(IO ResponseCreateParams)
     }
 
 withSessionTitleManager
     :: BtwBackendFactory
-    -> IORef ResponseCreateParams
+    -> IO ResponseCreateParams
     -> (SessionTitleEvent -> IO ())
     -> (SessionTitleManager -> IO a)
     -> IO a
@@ -210,11 +209,10 @@ titleWorker onEvent manager = forever do
 
 generateTitle :: SessionTitleManager -> SessionTitleJob -> IO (Either Text Text)
 generateTitle manager job = do
-    baseParams <- readIORef manager.titleParams
+    baseParams <- manager.titleParams
     let params = titleRequestParams baseParams
-    privateParams <- newIORef params
     let Backend submit =
-            manager.titleBackendFactory privateParams
+            manager.titleBackendFactory params
     timeout 45000000
         (submit [] Nothing
             [UserMessage (titlePrompt job.jobSource)] (\_ -> pure ()))

--- a/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
@@ -634,20 +634,19 @@ runCodexSubagent runtime tokenProvider sendToRoot =
                         childParams = requestParams OpenAIProvider model instructions
                             (schemasFromAppTools codexDialect tools) effort
                     toolRegistry <- requireToolRegistry tools
-                    childParamsRef <- newIORef childParams
                     httpFallbackActive <- newIORef False
                     let websocketBackend =
                             freshOpenAiBackend
                                 runtime.subagentOptions.optShowRawReasoning
                                 tokenProvider
-                                (readIORef childParamsRef)
+                                (pure childParams)
                         httpBackend =
                             statelessResponsesBackendWithRawReasoning
                                 runtime.subagentOptions.optShowRawReasoning
                                 (\request _onEvent ->
                                     OpenAI.createCodexMessageWithProvider
                                         tokenProvider request)
-                                (readIORef childParamsRef)
+                                (pure childParams)
                         baseBackend =
                             openAiBackendWithTransportFallback
                                 httpFallbackActive
@@ -658,7 +657,7 @@ runCodexSubagent runtime tokenProvider sendToRoot =
                                 autoCompactOpenAiBackendWithThreshold
                                     runtime.subagentOptions.optCompactThreshold
                                     tokenProvider
-                                    (readIORef childParamsRef)
+                                    (pure childParams)
                                     prepared.preparedSession.subSessionContextTokens
                                     baseBackend
                     runPreparedChild
@@ -673,7 +672,7 @@ runHttpSubagent
     -> Dialect
     -> Provider
     -> Maybe (InterAgentMessage -> IO (Either Text Text))
-    -> (IORef ResponseCreateParams -> Backend)
+    -> (ResponseCreateParams -> Backend)
     -> RunSubagent
 runHttpSubagent runtime dialect provider sendToRoot mkBackend =
     \env previous prompt onEvent -> do
@@ -808,10 +807,9 @@ runHttpSubagent runtime dialect provider sendToRoot mkBackend =
                         childParams = requestParams provider model instructions
                             (schemasFromAppTools childDialect tools) effort
                     toolRegistry <- requireToolRegistry tools
-                    childParamsRef <- newIORef childParams
                     let backend =
                             withConnectionRecovery $
-                                mkBackend childParamsRef
+                                mkBackend childParams
                     runPreparedChild
                         runtime env prepared.preparedSession toolRegistry
                         backend onEvent

--- a/packages/agent-cli/test/Agent/CLI/BtwSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/BtwSpec.hs
@@ -75,7 +75,7 @@ spec = do
                     Backend \privateTranscript previous inputs _onEvent -> do
                         writeIORef seenPrevious previous
                         writeIORef seenInputs inputs
-                        writeIORef seenPrivateParams . Just =<< readIORef privateParams
+                        writeIORef seenPrivateParams (Just privateParams)
                         writeIORef seenPrivateTranscript privateTranscript
                         pure $ Right BackendResult
                             { backendOutput =

--- a/packages/agent-cli/test/Agent/CLI/SessionTitleSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SessionTitleSpec.hs
@@ -62,10 +62,9 @@ spec = describe "Agent.CLI.SessionTitle" do
                             { reasoning = Just sessionReasoning
                             , ..
                             }
-        paramsRef <- newIORef baseParams
         let backendFactory privateParams =
                 Backend \state _ inputs _ -> do
-                    writeIORef seenParams . Just =<< readIORef privateParams
+                    writeIORef seenParams (Just privateParams)
                     writeIORef seenInputs inputs
                     pure $ Right BackendResult
                         { backendOutput =
@@ -73,7 +72,7 @@ spec = describe "Agent.CLI.SessionTitle" do
                                 (Just "Auth race cleanup")
                         , backendState = state
                         }
-        withSessionTitleManager backendFactory paramsRef (putMVar notified) \manager -> do
+        withSessionTitleManager backendFactory (pure baseParams) (putMVar notified) \manager -> do
             requestSessionTitle manager "session-1" 3
                 "User:\nFix auth\n\nAssistant:\nI found the race"
             results <- waitForResults manager 100
@@ -98,7 +97,6 @@ spec = describe "Agent.CLI.SessionTitle" do
     it "drops a stale result after a manual rename invalidates generation" do
         started <- newEmptyMVar
         release <- newEmptyMVar
-        paramsRef <- newIORef (defaultResponseCreateParams :: ResponseCreateParams)
         let backendFactory _ =
                 Backend \state _ _ _ -> do
                     putMVar started ()
@@ -109,7 +107,7 @@ spec = describe "Agent.CLI.SessionTitle" do
                                 (Just "Stale title")
                         , backendState = state
                         }
-        withSessionTitleManager backendFactory paramsRef (\_ -> pure ()) \manager -> do
+        withSessionTitleManager backendFactory (pure defaultResponseCreateParams) (\_ -> pure ()) \manager -> do
             requestSessionTitle manager "session-1" 1 "conversation"
             takeMVar started
             invalidateSessionTitles manager "session-1"
@@ -118,7 +116,6 @@ spec = describe "Agent.CLI.SessionTitle" do
             takeSessionTitleResults manager `shouldReturn` []
 
     it "waits for an in-flight title before shutdown" do
-        paramsRef <- newIORef (defaultResponseCreateParams :: ResponseCreateParams)
         let backendFactory _ =
                 Backend \state _ _ _ -> do
                     threadDelay 20000
@@ -128,7 +125,7 @@ spec = describe "Agent.CLI.SessionTitle" do
                                 (Just "Finished title")
                         , backendState = state
                         }
-        withSessionTitleManager backendFactory paramsRef (\_ -> pure ()) \manager -> do
+        withSessionTitleManager backendFactory (pure defaultResponseCreateParams) (\_ -> pure ()) \manager -> do
             requestSessionTitle manager "session-1" 6 "conversation"
             waitForSessionTitleResults 1000000 manager
                 `shouldReturn`
@@ -142,7 +139,6 @@ spec = describe "Agent.CLI.SessionTitle" do
 
     it "reports provider failures instead of silently dropping them" do
         notified <- newEmptyMVar
-        paramsRef <- newIORef (defaultResponseCreateParams :: ResponseCreateParams)
         let backendFactory _ =
                 Backend \state _ _ _ ->
                     pure $ Right BackendResult
@@ -150,7 +146,7 @@ spec = describe "Agent.CLI.SessionTitle" do
                             emptyTurnOutput "title-response" [] Nothing
                         , backendState = state
                         }
-        withSessionTitleManager backendFactory paramsRef (putMVar notified) \manager -> do
+        withSessionTitleManager backendFactory (pure defaultResponseCreateParams) (putMVar notified) \manager -> do
             requestSessionTitle manager "session-1" 3 "conversation"
             takeMVar notified
                 `shouldReturn`


### PR DESCRIPTION
## Summary
- make Btw backend factories accept immutable request parameters
- let session-title generation use an effectful parameter supplier without allocating a private IORef
- remove constant child-parameter refs from subagent backend construction
- preserve dynamic parameter reads where parameters genuinely change

## Validation
- focused Btw and SessionTitle tests
- 8 examples, 0 failures
- `git diff --check`