### PR TITLE
Retry transient provider failures automatically

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Connectivity.hs
+++ b/packages/agent-cli/src/Agent/CLI/Connectivity.hs
@@ -1,15 +1,20 @@
--- | Keep a provider submission alive while the machine is offline.
+-- | Recover one provider submission from transient transport/server failures.
 --
 -- Recovery wraps one 'Backend' submission rather than an entire agent turn.
 -- If a connection drops after tools have run, the loop can therefore retry
 -- the exact model continuation without executing those tools again.
 module Agent.CLI.Connectivity
     ( reconnectDelayMicros
+    , transientRetryDelayMicros
     , withConnectionRecovery
     , withConnectionRecoveryUsing
     ) where
 
-import Agent.Error (ApiError(..))
+import Agent.Error
+    ( ApiError(..)
+    , apiErrorRetryAfter
+    , isInlineRetryableProviderError
+    )
 import Agent.Loop (Backend(..), LoopEvent(..))
 import Control.Concurrent (threadDelay)
 import Control.Monad (when)
@@ -27,14 +32,28 @@ reconnectDelayMicros attempt =
         4 -> 8_000_000
         _ -> 15_000_000
 
+-- | Retry transient provider failures after 3s, 6s, then 12s. A provider
+-- supplied Retry-After takes precedence, capped at one minute.
+transientRetryDelayMicros :: ApiError -> Int -> Int
+transientRetryDelayMicros apiError attempt =
+    case apiErrorRetryAfter apiError of
+        Just seconds | seconds > 0 ->
+            min 60 seconds * 1_000_000
+        _ ->
+            case max 1 attempt of
+                1 -> 3_000_000
+                2 -> 6_000_000
+                _ -> 12_000_000
+
 -- | Automatically retry connection failures until the submission succeeds or
--- its owner cancels it. 'runLoopInputs' races every backend submission against
--- the session cancel flag, so the sleep and all retries remain scoped to the
--- current turn.
+-- its owner cancels it. Transient provider errors are retried a bounded number
+-- of times after their lower-level, replay-safe retry policy gives up.
+-- 'runLoopInputs' races every backend submission against the session cancel
+-- flag, so the sleep and all retries remain scoped to the current turn.
 withConnectionRecovery :: Backend -> Backend
 withConnectionRecovery =
     withConnectionRecoveryUsing
-        (threadDelay . reconnectDelayMicros)
+        threadDelay
 
 -- | Injectable variant used by tests. If a response already streamed, emit a
 -- structural restart boundary before the next attempt. Providers may generate
@@ -44,9 +63,9 @@ withConnectionRecoveryUsing
     :: (Int -> IO ())
     -> Backend
     -> Backend
-withConnectionRecoveryUsing waitBeforeRetry (Backend submit) =
+withConnectionRecoveryUsing waitMicros (Backend submit) =
     Backend \state previous inputs onEvent ->
-        let go attempt = do
+        let go reconnectAttempt transientAttempt = do
                 streamed <- newIORef False
                 result <- submit state previous inputs \event -> do
                     when (isStreamOutput event) (writeIORef streamed True)
@@ -54,16 +73,44 @@ withConnectionRecoveryUsing waitBeforeRetry (Backend submit) =
                 didStream <- readIORef streamed
                 case result of
                     Left ConnectionError{} -> do
-                        onEvent (ActivityUpdated (waitingMessage attempt))
-                        waitBeforeRetry attempt
+                        let delay = reconnectDelayMicros reconnectAttempt
+                        onEvent
+                            (ActivityUpdated
+                                (connectionWaitingMessage delay))
+                        waitMicros delay
                         onEvent
                             (ActivityUpdated
                                 "Checking internet connection…")
                         when didStream $
-                            onEvent (ResponseRestarted restartMessage)
-                        go (attempt + 1)
+                            onEvent
+                                (ResponseRestarted
+                                    connectionRestartMessage)
+                        go (reconnectAttempt + 1) transientAttempt
+                    Left apiError
+                        | isInlineRetryableProviderError apiError
+                        , transientAttempt <= maxTransientRetries -> do
+                            let delay =
+                                    transientRetryDelayMicros
+                                        apiError transientAttempt
+                            onEvent
+                                (ActivityUpdated
+                                    (transientWaitingMessage
+                                        transientAttempt delay))
+                            waitMicros delay
+                            onEvent
+                                (ActivityUpdated
+                                    (transientRetryingMessage
+                                        transientAttempt))
+                            when didStream $
+                                onEvent
+                                    (ResponseRestarted
+                                        transientRestartMessage)
+                            go reconnectAttempt (transientAttempt + 1)
                     _ -> pure result
-        in go 1
+        in go 1 1
+
+maxTransientRetries :: Int
+maxTransientRetries = 2
 
 isStreamOutput :: LoopEvent -> Bool
 isStreamOutput = \case
@@ -71,15 +118,38 @@ isStreamOutput = \case
     ReasoningDelta _ -> True
     _ -> False
 
-waitingMessage :: Int -> Text
-waitingMessage attempt =
+connectionWaitingMessage :: Int -> Text
+connectionWaitingMessage delay =
     "Connection lost; waiting for internet. Retrying automatically in "
-        <> formatDelay (reconnectDelayMicros attempt)
+        <> formatDelay delay
         <> " (Esc or Ctrl-C to cancel)…"
 
-restartMessage :: Text
-restartMessage =
+connectionRestartMessage :: Text
+connectionRestartMessage =
     "Connection interrupted the response; restarting automatically. "
+        <> "The new attempt may repeat partial output shown above."
+
+transientWaitingMessage :: Int -> Int -> Text
+transientWaitingMessage attempt delay =
+    "Provider returned a temporary error; retrying automatically in "
+        <> formatDelay delay
+        <> " (attempt "
+        <> Text.pack (show attempt)
+        <> "/"
+        <> Text.pack (show maxTransientRetries)
+        <> "; Esc or Ctrl-C to cancel)…"
+
+transientRetryingMessage :: Int -> Text
+transientRetryingMessage attempt =
+    "Retrying provider request (attempt "
+        <> Text.pack (show attempt)
+        <> "/"
+        <> Text.pack (show maxTransientRetries)
+        <> ")…"
+
+transientRestartMessage :: Text
+transientRestartMessage =
+    "Provider interrupted the response; restarting automatically. "
         <> "The new attempt may repeat partial output shown above."
 
 formatDelay :: Int -> Text

--- a/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
@@ -461,7 +461,7 @@ spec = do
                                     }
                 reconnectingContinuation =
                     withConnectionRecoveryUsing
-                        (\attempt -> modifyIORef' waits (<> [attempt]))
+                        (\delay -> modifyIORef' waits (<> [delay]))
                         continuation
                 backend =
                     autoCompactOpenAiBackendWithSender
@@ -476,7 +476,7 @@ spec = do
             result `shouldSatisfy` either (const False) (const True)
             readIORef compactCalls `shouldReturn` 1
             readIORef continuationCalls `shouldReturn` 2
-            readIORef waits `shouldReturn` [1]
+            readIORef waits `shouldReturn` [1_000_000]
             readIORef seenPrevious `shouldReturn` [Nothing, Nothing]
             readIORef recordedUsage `shouldReturn` [compactionUsage]
 

--- a/packages/agent-cli/test/Agent/CLI/ConnectivitySpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ConnectivitySpec.hs
@@ -2,10 +2,11 @@ module Agent.CLI.ConnectivitySpec (spec) where
 
 import Agent.CLI.Connectivity
     ( reconnectDelayMicros
+    , transientRetryDelayMicros
     , withConnectionRecoveryUsing
     )
 import Agent.CLI.PendingInputs (withPendingInputs)
-import Agent.Error (ApiError(..))
+import Agent.Error (ApiError(..), ErrorType(..))
 import Agent.Loop
     ( Backend(..)
     , BackendResult(..)
@@ -24,7 +25,7 @@ spec = describe "withConnectionRecovery" do
         seen <- newIORef []
         events <- newIORef []
         let backend = withConnectionRecoveryUsing
-                (\attempt -> modifyIORef' waits (<> [attempt]))
+                (\delay -> modifyIORef' waits (<> [delay]))
                 (Backend \state previous inputs _ -> do
                     modifyIORef' seen (<> [(previous, inputs)])
                     attempt <- atomicModifyIORef' attempts \n -> (n + 1, n + 1)
@@ -47,7 +48,7 @@ spec = describe "withConnectionRecovery" do
                     emptyTurnOutput "response" [] (Just "done")
                 , backendState = []
                 }
-        readIORef waits `shouldReturn` [1, 2]
+        readIORef waits `shouldReturn` [1_000_000, 2_000_000]
         readIORef seen `shouldReturn`
             [ (Just "previous", inputs)
             , (Just "previous", inputs)
@@ -62,11 +63,12 @@ spec = describe "withConnectionRecovery" do
             , ActivityUpdated "Checking internet connection…"
             ]
 
-    it "does not retry non-connection provider errors" do
+    it "does not retry non-transient provider errors" do
         waits <- newIORef []
-        let expected = HttpError 503 "unavailable"
+        let expected =
+                ProviderError InvalidRequestError "bad request" Nothing
             backend = withConnectionRecoveryUsing
-                (\attempt -> modifyIORef' waits (<> [attempt]))
+                (\delay -> modifyIORef' waits (<> [delay]))
                 (Backend \_ _ _ _ -> pure (Left expected))
         result <- backend.submitTurn [] Nothing [] (const (pure ()))
         result `shouldBe` Left expected
@@ -102,7 +104,7 @@ spec = describe "withConnectionRecovery" do
         waits <- newIORef []
         events <- newIORef []
         let backend = withConnectionRecoveryUsing
-                (\attempt -> modifyIORef' waits (<> [attempt]))
+                (\delay -> modifyIORef' waits (<> [delay]))
                 (Backend \state _ _ onEvent -> do
                     attempt <- atomicModifyIORef' attempts
                         \n -> (n + 1, n + 1)
@@ -130,7 +132,7 @@ spec = describe "withConnectionRecovery" do
                 , backendState = []
                 }
         readIORef attempts `shouldReturn` 2
-        readIORef waits `shouldReturn` [1]
+        readIORef waits `shouldReturn` [1_000_000]
         readIORef events `shouldReturn`
             [ TextDelta "partial"
             , ActivityUpdated
@@ -173,6 +175,77 @@ spec = describe "withConnectionRecovery" do
                 }
         readIORef seen `shouldReturn` [expected, expected]
         readIORef pending `shouldReturn` []
+
+    it "restarts partial output after a transient provider error" do
+        attempts <- newIORef (0 :: Int)
+        waits <- newIORef []
+        events <- newIORef []
+        let backend = withConnectionRecoveryUsing
+                (\delay -> modifyIORef' waits (<> [delay]))
+                (Backend \state _ _ onEvent -> do
+                    attempt <- atomicModifyIORef' attempts
+                        \n -> (n + 1, n + 1)
+                    if attempt == 1
+                        then do
+                            onEvent (ReasoningDelta "partial thought")
+                            pure $
+                                Left
+                                    (ProviderError
+                                        ApiErrorType
+                                        "internal error"
+                                        Nothing)
+                        else
+                            pure $
+                                Right BackendResult
+                                    { backendOutput =
+                                        emptyTurnOutput
+                                            "response" [] (Just "done")
+                                    , backendState = state
+                                    })
+        result <- backend.submitTurn [] Nothing []
+            (\event -> modifyIORef' events (<> [event]))
+        result `shouldBe`
+            Right BackendResult
+                { backendOutput =
+                    emptyTurnOutput "response" [] (Just "done")
+                , backendState = []
+                }
+        readIORef attempts `shouldReturn` 2
+        readIORef waits `shouldReturn` [3_000_000]
+        readIORef events `shouldReturn`
+            [ ReasoningDelta "partial thought"
+            , ActivityUpdated
+                "Provider returned a temporary error; retrying automatically in 3s (attempt 1/2; Esc or Ctrl-C to cancel)…"
+            , ActivityUpdated
+                "Retrying provider request (attempt 1/2)…"
+            , ResponseRestarted
+                "Provider interrupted the response; restarting automatically. The new attempt may repeat partial output shown above."
+            ]
+
+    it "stops after two transient provider retries" do
+        attempts <- newIORef (0 :: Int)
+        waits <- newIORef []
+        let expected =
+                ProviderError ApiErrorType "internal error" Nothing
+            backend = withConnectionRecoveryUsing
+                (\delay -> modifyIORef' waits (<> [delay]))
+                (Backend \_ _ _ _ -> do
+                    modifyIORef' attempts (+ 1)
+                    pure (Left expected))
+        result <- backend.submitTurn [] Nothing [] (const (pure ()))
+        result `shouldBe` Left expected
+        readIORef attempts `shouldReturn` 3
+        readIORef waits `shouldReturn` [3_000_000, 6_000_000]
+
+    it "honors a bounded provider Retry-After" do
+        transientRetryDelayMicros
+            (ProviderError ServiceUnavailableError "later" (Just 9))
+            1
+            `shouldBe` 9_000_000
+        transientRetryDelayMicros
+            (ProviderError ServiceUnavailableError "later" (Just 120))
+            1
+            `shouldBe` 60_000_000
 
     it "backs off to a bounded polling interval" do
         map reconnectDelayMicros [1 .. 7]


### PR DESCRIPTION
## Summary
- retry transient provider/internal failures at the backend submission boundary
- wait 3s and 6s before two bounded retries, honoring provider `Retry-After` up to 60s
- preserve partial streamed output behind a response restart boundary and keep waits cancellable
- leave invalid requests, authentication, quota, and other non-transient failures terminal

## Testing
- `printf ':main --match withConnectionRecovery\\n:q\\n' | nix develop -c cabal repl agent-cli:test:agent-cli-test` — 9 examples, 0 failures before rebasing onto current `origin/master`
- after rebasing, the modified `Agent.CLI.Connectivity` module compiles, but loading the test REPL is blocked by an unrelated existing type error in `packages/agent-cli/src/Agent/CLI/Recap.hs:313` (`makeBackend` expects `ResponseCreateParams`, receives `IORef ResponseCreateParams`)
- `git diff origin/master --check`
- live CLI smoke-tested in tmux before the rebase
