### PR TITLE
feat(tui): show live todos in selected agent views

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/AgentViewport.hs
+++ b/packages/agent-cli/src/Agent/CLI/AgentViewport.hs
@@ -55,7 +55,9 @@ import Agent.TUI.Model
     , UiState(..)
     , initialUiState
     , reduceUi
+    , visibleTodoList
     )
+import Agent.TUI.Presentation (liveTodoPanelLines)
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.KeyMap as KeyMap
 import qualified Data.ByteString.Lazy as LBS
@@ -297,7 +299,7 @@ renderAgentViewportFor color bodyRows terminalCols footerText state =
         , splitPaneItems = rows
         , splitPaneSelectedIndex = state.viewportIndex
         , splitPaneLeftLabel = \_ -> agentTreeRowLabel
-        , splitPaneTranscript = (.treeRowEntry.agentTranscript)
+        , splitPaneTranscript = agentViewportTranscript
         , splitPaneEmptyTranscript = "(no agents)"
         , splitPaneFooter = footerText
         , splitPanePromptStyle = rolePrompt color
@@ -306,6 +308,11 @@ renderAgentViewportFor color bodyRows terminalCols footerText state =
         }
   where
     rows = agentTreeRows state.viewportAll
+
+agentViewportTranscript :: AgentTreeRow -> [Text]
+agentViewportTranscript row =
+    liveTodoPanelLines 3 (visibleTodoList row.treeRowEntry.agentConversation)
+        <> row.treeRowEntry.agentTranscript
 
 pickAgentViewport
     :: Bool

--- a/packages/agent-cli/src/Agent/CLI/AgentViewport.hs
+++ b/packages/agent-cli/src/Agent/CLI/AgentViewport.hs
@@ -311,8 +311,8 @@ renderAgentViewportFor color bodyRows terminalCols footerText state =
 
 agentViewportTranscript :: AgentTreeRow -> [Text]
 agentViewportTranscript row =
-    liveTodoPanelLines 3 (visibleTodoList row.treeRowEntry.agentConversation)
-        <> row.treeRowEntry.agentTranscript
+    row.treeRowEntry.agentTranscript
+        <> liveTodoPanelLines 3 (visibleTodoList row.treeRowEntry.agentConversation)
 
 pickAgentViewport
     :: Bool

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -1712,7 +1712,7 @@ drawMain state =
                 , Composer.drawQueuedInputs state.appUi
                 , Composer.drawSlashMenu state
                 , drawFollowStatus state.appUi
-                , drawLiveTodos state.appUi
+                , drawLiveTodos (activeConversationUi state)
                 , drawPromptActivity state
                 , Composer.drawComposer state
                 , drawFooter state
@@ -1959,6 +1959,7 @@ drawAgentConversation state entry =
             terminalTxt
                 (entry.agentStatus
                     <> " · input is sent to /root")
+        , drawLiveTodos entry.agentConversation
         , padTop (Pad 1) $
             if Seq.null entry.agentConversation.uiBlocks
                 then
@@ -4354,13 +4355,18 @@ preserveAgentConversationView selected previous =
 
 mergeConversationView :: UiState -> UiState -> UiState
 mergeConversationView previous incoming
-    | Seq.null incoming.uiBlocks = incoming
+    | Seq.null incoming.uiBlocks =
+        incoming { uiTodos = previous.uiTodos }
     | otherwise =
         incoming
             { uiBlocks = mergedBlocks
             , uiSelectedBlock = selected
             , uiSelectedBlockIndex =
                 selected >>= (`Map.lookup` incoming.uiBlockIndices)
+            , uiTodos =
+                if null incoming.uiTodos
+                    then previous.uiTodos
+                    else incoming.uiTodos
             }
   where
     previousBlocks =

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -1959,7 +1959,6 @@ drawAgentConversation state entry =
             terminalTxt
                 (entry.agentStatus
                     <> " · input is sent to /root")
-        , drawLiveTodos entry.agentConversation
         , padTop (Pad 1) $
             if Seq.null entry.agentConversation.uiBlocks
                 then
@@ -4356,7 +4355,12 @@ preserveAgentConversationView selected previous =
 mergeConversationView :: UiState -> UiState -> UiState
 mergeConversationView previous incoming
     | Seq.null incoming.uiBlocks =
-        incoming { uiTodos = previous.uiTodos }
+        incoming
+            { uiTodos =
+                if null incoming.uiTodos
+                    then previous.uiTodos
+                    else incoming.uiTodos
+            }
     | otherwise =
         incoming
             { uiBlocks = mergedBlocks

--- a/packages/agent-cli/test/Agent/CLI/AgentViewportSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/AgentViewportSpec.hs
@@ -8,8 +8,16 @@ import Agent.TUI.Model
     ( BlockKind(..)
     , BlockState(..)
     , UiBlock(..)
+    , UiEvent(..)
     , UiState(..)
     , initialUiState
+    , reduceUi
+    )
+import Agent.Loop (LoopEvent(..))
+import Agent.ToolDispatch
+    ( ToolCallKind(..)
+    , ToolCallResult(..)
+    , functionToolCall
     )
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.KeyMap as KeyMap
@@ -121,6 +129,37 @@ spec = do
             panel `shouldSatisfy` Text.isInfixOf "transcript · /root/alpha"
             panel `shouldSatisfy` Text.isInfixOf "assistant: working"
             panel `shouldSatisfy` Text.isInfixOf "input routes to /root"
+
+        it "shows a selected child's live todos in the transcript pane" do
+            let todoCall =
+                    functionToolCall
+                        "todo-1"
+                        "todo_write"
+                        "{\"todos\":[{\"id\":\"1\",\"content\":\"Review Model.hs\"}]}"
+                conversation =
+                    foldl
+                        (flip reduceUi)
+                        initialUiState
+                        [ UiLoop TurnStarted
+                        , UiLoop (ToolStarted todoCall)
+                        , UiLoop
+                            (ToolFinished ToolCallResult
+                                { callId = "todo-1"
+                                , output = "- [in_progress] 1: Review Model.hs"
+                                , callKind = FunctionCallKind
+                                })
+                        ]
+                selected = AgentChild (SubagentId "alpha")
+                withTodos =
+                    map
+                        (\entry ->
+                            if entry.agentTarget == selected
+                                then entry { agentConversation = conversation }
+                                else entry)
+                        entries
+                panel = renderAgentViewportPanelFor False 70 selected withTodos
+            panel `shouldSatisfy` Text.isInfixOf "Review Model.hs"
+            panel `shouldSatisfy` Text.isInfixOf "transcript · /root/alpha"
 
     describe "formatAgentStatus" do
         it "uses compact status labels" do

--- a/packages/agent-cli/test/Agent/CLI/AgentViewportSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/AgentViewportSpec.hs
@@ -154,12 +154,19 @@ spec = do
                     map
                         (\entry ->
                             if entry.agentTarget == selected
-                                then entry { agentConversation = conversation }
+                                then
+                                    entry
+                                        { agentConversation = conversation
+                                        , agentTranscript =
+                                            replicate 8 "assistant: filler"
+                                                <> ["assistant: working"]
+                                        }
                                 else entry)
                         entries
                 panel = renderAgentViewportPanelFor False 70 selected withTodos
             panel `shouldSatisfy` Text.isInfixOf "Review Model.hs"
             panel `shouldSatisfy` Text.isInfixOf "transcript · /root/alpha"
+            panel `shouldSatisfy` Text.isInfixOf "assistant: working"
 
     describe "formatAgentStatus" do
         it "uses compact status labels" do

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -64,6 +64,7 @@ import Agent.ToolDispatch
     , functionToolCall
     )
 import Agent.TUI.Model
+import Agent.TUI.Presentation (TodoDisplayLine(..))
 import Agent.TUI.Motion
 import Control.Concurrent.STM (newTChanIO)
 import qualified Data.ByteString as ByteString
@@ -448,7 +449,31 @@ spec = do
                             merged.uiBlocks)
                         `shouldBe` Just True
                     mergeConversationView previous initialUiState
-                        `shouldBe` initialUiState
+                        `shouldBe`
+                            initialUiState { uiTodos = previous.uiTodos }
+
+        it "keeps a child's live todo list across empty snapshot refreshes" do
+            let todoCall =
+                    functionToolCall
+                        "todo-1"
+                        "todo_write"
+                        "{\"todos\":[{\"id\":\"1\",\"content\":\"Keep this list\"}]}"
+                previous =
+                    foldl
+                        (flip reduceUi)
+                        initialUiState
+                        [ UiLoop TurnStarted
+                        , UiLoop (ToolStarted todoCall)
+                        , UiLoop
+                            (ToolFinished ToolCallResult
+                                { callId = "todo-1"
+                                , output = "- [in_progress] 1: Keep this list"
+                                , callKind = FunctionCallKind
+                                })
+                        ]
+                merged = mergeConversationView previous initialUiState
+            map (.todoLineText) (visibleTodoList merged)
+                `shouldBe` ["Keep this list"]
 
     describe "conversation scrollbar" do
         it "uses a visible trough that repaints old thumb cells" do

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -64,7 +64,10 @@ import Agent.ToolDispatch
     , functionToolCall
     )
 import Agent.TUI.Model
-import Agent.TUI.Presentation (TodoDisplayLine(..))
+import Agent.TUI.Presentation
+    ( TodoDisplayLine(..)
+    , TodoDisplayStatus(..)
+    )
 import Agent.TUI.Motion
 import Control.Concurrent.STM (newTChanIO)
 import qualified Data.ByteString as ByteString
@@ -472,8 +475,20 @@ spec = do
                                 })
                         ]
                 merged = mergeConversationView previous initialUiState
+                updated =
+                    mergeConversationView
+                        previous
+                        (initialUiState
+                            { uiTodos =
+                                [ TodoDisplayLine
+                                    TodoDisplayCompleted
+                                    "Keep this list"
+                                ]
+                            })
             map (.todoLineText) (visibleTodoList merged)
                 `shouldBe` ["Keep this list"]
+            map (.todoLineStatus) updated.uiTodos
+                `shouldBe` [TodoDisplayCompleted]
 
     describe "conversation scrollbar" do
         it "uses a visible trough that repaints old thumb cells" do

--- a/packages/agent-cli/test/Agent/CLI/TUIPropertySpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIPropertySpec.hs
@@ -343,6 +343,55 @@ spec = do
                         (RenderHarness baseState (80, 24))
             assertFrame harness
 
+        it "shows a selected child's live todo list above its transcript" do
+            let target = AgentChild (SubagentId "reviewer")
+                todoCall =
+                    functionToolCall
+                        "todo-1"
+                        "todo_write"
+                        "{\"todos\":[{\"id\":\"1\",\"content\":\"Review Model.hs\"}]}"
+                todoResult = ToolCallResult
+                    { callId = "todo-1"
+                    , output = "- [in_progress] 1: Review Model.hs"
+                    , callKind = FunctionCallKind
+                    }
+                conversation =
+                    foldl
+                        (flip reduceUi)
+                        initialUiState
+                        [ UiLoop TurnStarted
+                        , UiLoop (ToolStarted todoCall)
+                        , UiLoop (ToolFinished todoResult)
+                        ]
+                child =
+                    AgentEntry
+                        { agentTarget = target
+                        , agentPath = "/root/reviewer"
+                        , agentStatus = "running"
+                        , agentModel = Just "gpt-5.6-luna"
+                        , agentSteps = []
+                        , agentTranscript = []
+                        , agentConversation = conversation
+                        }
+                app =
+                    baseState
+                        { appAgentSelected = target
+                        , appAgentEntries = [rootEntry, child]
+                        }
+                size = (120, 32)
+                frame =
+                    Text.unlines $
+                        pictureRows
+                            (renderWidget
+                                (Just Theme.monochrome)
+                                (drawApp app)
+                                size)
+                            size
+            frame `shouldSatisfy` Text.isInfixOf "Viewing /root/reviewer"
+            length (filter (Text.isInfixOf "Review Model.hs") (Text.lines frame))
+                `shouldBe` 1
+            frame `shouldNotSatisfy` Text.isInfixOf "todo_write"
+
 renderTraceProperty :: AppState -> RenderTrace -> Property
 renderTraceProperty baseState (RenderTrace actions) =
     conjoin $


### PR DESCRIPTION
## Summary
- Draw the live todo list from the selected conversation, so a child agent view shows its own checklist instead of the root one.
- Preserve that list across empty child snapshot refreshes.
- Include a compact copy in the linear agent transcript pane.

## Test plan
- [x] CLI tests matching `live todo`
- [ ] Visual check of a selected child agent with an in-progress todo list