### PR TITLE
perf(store): pipeline custom catalog inspection

### DIFF
--- a/packages/agent-store/agent-store.cabal
+++ b/packages/agent-store/agent-store.cabal
@@ -85,6 +85,18 @@ benchmark pool-cache-bench
                     , containers
                     , time
 
+benchmark custom-catalog-inspection-bench
+    import:           common-opts
+    type:             exitcode-stdio-1.0
+    hs-source-dirs:   benchmark
+    main-is:          CustomCatalogInspection.hs
+    ghc-options:      -O2 -threaded -rtsopts
+    build-depends:    agent-store
+                    , base >= 4.14 && < 5
+                    , safe-exceptions
+                    , temporary
+                    , text
+
 test-suite agent-store-test
     import:           common-opts
     type:             exitcode-stdio-1.0

--- a/packages/agent-store/benchmark/CustomCatalogInspection.hs
+++ b/packages/agent-store/benchmark/CustomCatalogInspection.hs
@@ -36,15 +36,34 @@ import Agent.Store.Postgres.Scope
 main :: IO ()
 main = do
     getArgs >>= \case
-        [tableCount, iterations, sampleCount] ->
-            benchmark (read tableCount) (read iterations) (read sampleCount)
+        [workload, tableCount, iterations, sampleCount] ->
+            benchmark
+                (parseWorkload workload)
+                (read tableCount)
+                (read iterations)
+                (read sampleCount)
         _ ->
             fail
                 "usage: custom-catalog-inspection-bench \
-                \<table-count> <iterations> <samples>"
+                \<sequential|pipeline> <table-count> <iterations> <samples>"
 
-benchmark :: Int -> Int -> Int -> IO ()
-benchmark tableCount iterations sampleCount =
+data Workload
+    = Sequential
+    | Pipeline
+
+parseWorkload :: String -> Workload
+parseWorkload = \case
+    "sequential" -> Sequential
+    "pipeline" -> Pipeline
+    value -> error ("unknown workload: " <> value)
+
+workloadName :: Workload -> String
+workloadName = \case
+    Sequential -> "sequential"
+    Pipeline -> "pipeline"
+
+benchmark :: Workload -> Int -> Int -> Int -> IO ()
+benchmark workload tableCount iterations sampleCount =
     if tableCount < 0 || iterations <= 0 || sampleCount <= 0
         then fail "table count must be non-negative; iterations and samples must be positive"
         else
@@ -53,12 +72,12 @@ benchmark tableCount iterations sampleCount =
                 (openStore config
                     >>= either
                         (fail . show)
-                        (run tableCount iterations sampleCount))
+                        (run workload tableCount iterations sampleCount))
                     `finally` do
                         _ <- stopManagedPostgres config
                         pure ()
 
-run tableCount iterations sampleCount store =
+run workload tableCount iterations sampleCount store =
     finally
         (do
             scopeId <- either (fail . Text.unpack) pure $
@@ -90,13 +109,14 @@ run tableCount iterations sampleCount store =
                 else pure ()
             samples <- replicateM sampleCount $
                 measure $
-                    replicateM iterations (inspectCustomSchema pool database)
+                    replicateM iterations (inspect pool database)
                         >>= traverse (either (fail . Text.unpack) pure)
             let elapsed = sort [wall | (wall, _, _) <- samples]
                 cpu = sort [cpuTime | (_, cpuTime, _) <- samples]
                 checksum = sum [value | (_, _, value) <- samples]
             putStrLn $
-                "tables=" <> show tableCount
+                "workload=" <> workloadName workload
+                    <> " tables=" <> show tableCount
                     <> " iterations=" <> show iterations
                     <> " samples=" <> show sampleCount
                     <> " median-wall-ms=" <> show (median elapsed / 1e6)
@@ -105,6 +125,10 @@ run tableCount iterations sampleCount store =
         )
         (closeStore store)
   where
+    inspect = case workload of
+        Sequential -> inspectCustomSchemaSequential
+        Pipeline -> inspectCustomSchema
+
     measure action = do
         wallStart <- getMonotonicTimeNSec
         cpuStart <- getCPUTime

--- a/packages/agent-store/benchmark/CustomCatalogInspection.hs
+++ b/packages/agent-store/benchmark/CustomCatalogInspection.hs
@@ -7,6 +7,7 @@ module Main (main) where
 
 import Control.Exception.Safe (finally)
 import Control.Monad (replicateM)
+import Data.Char (ord)
 import Data.List (sort)
 import qualified Data.Text as Text
 import GHC.Clock (getMonotonicTimeNSec)
@@ -133,13 +134,79 @@ run workload tableCount iterations sampleCount store =
         wallStart <- getMonotonicTimeNSec
         cpuStart <- getCPUTime
         catalogs <- action
+        let checksum = catalogRunsChecksum catalogs
+        checksum `seq` pure ()
         cpuEnd <- getCPUTime
         wallEnd <- getMonotonicTimeNSec
         pure
             ( fromIntegral (wallEnd - wallStart) :: Double
             , fromIntegral (cpuEnd - cpuStart) :: Double
-            , sum (map length catalogs)
+            , checksum
             )
 
 median :: [Double] -> Double
 median values = values !! (length values `div` 2)
+
+catalogRunsChecksum :: [[CatalogObject]] -> Int
+catalogRunsChecksum = listChecksum catalogChecksum
+
+catalogChecksum :: [CatalogObject] -> Int
+catalogChecksum = listChecksum objectChecksum
+
+objectChecksum :: CatalogObject -> Int
+objectChecksum object =
+    listChecksum id
+        [ textChecksum object.catalogObjectKind
+        , textChecksum object.catalogObjectName
+        , definitionChecksum object.catalogObjectDefinition
+        ]
+
+definitionChecksum :: CatalogDefinition -> Int
+definitionChecksum definition =
+    listChecksum id
+        [ maybeChecksum textChecksum definition.definitionOwner
+        , maybeChecksum textChecksum definition.definitionComment
+        , maybeChecksum textChecksum definition.definitionView
+        , listChecksum columnChecksum definition.definitionColumns
+        , listChecksum constraintChecksum definition.definitionConstraints
+        , listChecksum indexChecksum definition.definitionIndexes
+        ]
+
+columnChecksum :: CatalogColumn -> Int
+columnChecksum column =
+    listChecksum id
+        [ textChecksum column.columnName
+        , textChecksum column.columnType
+        , fromEnum column.columnNullable
+        , maybeChecksum textChecksum column.columnDefault
+        , maybeChecksum textChecksum column.columnIdentity
+        , maybeChecksum textChecksum column.columnGenerated
+        , maybeChecksum textChecksum column.columnComment
+        ]
+
+constraintChecksum :: CatalogConstraint -> Int
+constraintChecksum constraint =
+    listChecksum id
+        [ textChecksum constraint.constraintName
+        , textChecksum constraint.constraintType
+        , textChecksum constraint.constraintDefinition
+        ]
+
+indexChecksum :: CatalogIndex -> Int
+indexChecksum index =
+    listChecksum id
+        [ textChecksum index.indexName
+        , textChecksum index.indexDefinition
+        ]
+
+textChecksum :: Text.Text -> Int
+textChecksum = Text.foldl' (\checksum char -> mix checksum (ord char)) 5381
+
+maybeChecksum :: (value -> Int) -> Maybe value -> Int
+maybeChecksum checksum = maybe 0 (mix 1 . checksum)
+
+listChecksum :: (value -> Int) -> [value] -> Int
+listChecksum checksum = foldl' (\total value -> mix total (checksum value)) 5381
+
+mix :: Int -> Int -> Int
+mix left right = left * 33 + right

--- a/packages/agent-store/benchmark/CustomCatalogInspection.hs
+++ b/packages/agent-store/benchmark/CustomCatalogInspection.hs
@@ -1,0 +1,121 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Main (main) where
+
+import Control.Exception.Safe (finally)
+import Control.Monad (replicateM)
+import Data.List (sort)
+import qualified Data.Text as Text
+import GHC.Clock (getMonotonicTimeNSec)
+import System.CPUTime (getCPUTime)
+import System.Environment (getArgs)
+import System.IO.Temp (withSystemTempDirectory)
+
+import Agent.Store.Postgres
+    ( closeStore
+    , defaultManagedPostgresConfig
+    , openStore
+    , provisioningPool
+    , scopePool
+    , trustedPool
+    )
+import Agent.Store.Postgres.Connection (storePool)
+import Agent.Store.Postgres.Custom
+import Agent.Store.Postgres.Managed (stopManagedPostgres)
+import Agent.Store.Postgres.Scope
+    ( Scope(..)
+    , ScopeDatabase(..)
+    , ScopeKind(..)
+    , mkScopeId
+    , provisionScope
+    )
+
+main :: IO ()
+main = do
+    getArgs >>= \case
+        [tableCount, iterations, sampleCount] ->
+            benchmark (read tableCount) (read iterations) (read sampleCount)
+        _ ->
+            fail
+                "usage: custom-catalog-inspection-bench \
+                \<table-count> <iterations> <samples>"
+
+benchmark :: Int -> Int -> Int -> IO ()
+benchmark tableCount iterations sampleCount =
+    if tableCount < 0 || iterations <= 0 || sampleCount <= 0
+        then fail "table count must be non-negative; iterations and samples must be positive"
+        else
+            withSystemTempDirectory "ha-bench" \stateDirectory -> do
+                let config = defaultManagedPostgresConfig stateDirectory ""
+                (openStore config
+                    >>= either
+                        (fail . show)
+                        (run tableCount iterations sampleCount))
+                    `finally` do
+                        _ <- stopManagedPostgres config
+                        pure ()
+
+run tableCount iterations sampleCount store =
+    finally
+        (do
+            scopeId <- either (fail . Text.unpack) pure $
+                mkScopeId "0123456789abcdef0123456789abcdef"
+            database <- provisionScope
+                (storePool (provisioningPool store))
+                (Scope RepositoryScope scopeId)
+                >>= either (fail . Text.unpack) pure
+            scoped <- scopePool store database.scopeDatabaseRole
+                >>= either (fail . show) pure
+            let pool = storePool scoped
+                ddl = Text.intercalate ";"
+                    [ "CREATE TABLE bench_" <> Text.pack (show index)
+                        <> " (id bigint PRIMARY KEY, value text NOT NULL)"
+                    | index <- [1 .. tableCount]
+                    ]
+            if tableCount > 0
+                then do
+                    _ <- executeCustom
+                        (storePool (trustedPool store))
+                        pool
+                        database
+                        (CustomAuditContext Nothing Nothing)
+                        defaultQueryLimits
+                        "catalog benchmark setup"
+                        ddl
+                        >>= either (fail . Text.unpack) pure
+                    pure ()
+                else pure ()
+            samples <- replicateM sampleCount $
+                measure $
+                    replicateM iterations (inspectCustomSchema pool database)
+                        >>= traverse (either (fail . Text.unpack) pure)
+            let elapsed = sort [wall | (wall, _, _) <- samples]
+                cpu = sort [cpuTime | (_, cpuTime, _) <- samples]
+                checksum = sum [value | (_, _, value) <- samples]
+            putStrLn $
+                "tables=" <> show tableCount
+                    <> " iterations=" <> show iterations
+                    <> " samples=" <> show sampleCount
+                    <> " median-wall-ms=" <> show (median elapsed / 1e6)
+                    <> " median-cpu-ms=" <> show (median cpu / 1e9)
+                    <> " checksum=" <> show checksum
+        )
+        (closeStore store)
+  where
+    measure action = do
+        wallStart <- getMonotonicTimeNSec
+        cpuStart <- getCPUTime
+        catalogs <- action
+        cpuEnd <- getCPUTime
+        wallEnd <- getMonotonicTimeNSec
+        pure
+            ( fromIntegral (wallEnd - wallStart) :: Double
+            , fromIntegral (cpuEnd - cpuStart) :: Double
+            , sum (map length catalogs)
+            )
+
+median :: [Double] -> Double
+median values = values !! (length values `div` 2)

--- a/packages/agent-store/package.nix
+++ b/packages/agent-store/package.nix
@@ -16,7 +16,9 @@ mkDerivation {
     async base bytestring hasql hspec safe-exceptions temporary text
     time
   ];
-  benchmarkHaskellDepends = [ async base containers time ];
+  benchmarkHaskellDepends = [
+    async base containers safe-exceptions temporary text time
+  ];
   description = "PostgreSQL persistence for the agent harness";
   license = lib.meta.getLicenseFromSpdxId "MIT";
 }

--- a/packages/agent-store/src/Agent/Store/Postgres/Custom.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Custom.hs
@@ -20,6 +20,7 @@ module Agent.Store.Postgres.Custom
     , CustomAuditContext(..)
     , CustomExecutionResult(..)
     , inspectCustomSchema
+    , inspectCustomSchemaSequential
     , queryCustom
     , executeCustom
     , normalizeCustomQuery
@@ -136,7 +137,23 @@ inspectCustomSchema
     :: Pool
     -> ScopeDatabase
     -> IO (Either Text [CatalogObject])
-inspectCustomSchema scopePool database =
+inspectCustomSchema =
+    inspectCustomSchemaWith catalogSchemaRowsPipelined
+
+-- | Sequential baseline retained for the catalog-inspection benchmark.
+inspectCustomSchemaSequential
+    :: Pool
+    -> ScopeDatabase
+    -> IO (Either Text [CatalogObject])
+inspectCustomSchemaSequential =
+    inspectCustomSchemaWith catalogSchemaRowsSequential
+
+inspectCustomSchemaWith
+    :: (Text -> Session.Session CatalogSchemaRows)
+    -> Pool
+    -> ScopeDatabase
+    -> IO (Either Text [CatalogObject])
+inspectCustomSchemaWith loadCatalogRows scopePool database =
     runPool scopePool session >>= \case
         Left err -> pure (Left err)
         Right (Left err) -> pure (Left err)
@@ -150,22 +167,33 @@ inspectCustomSchema scopePool database =
             then pure (Left scopeIdentityError)
             else do
                 (objects, columns, constraints, indexes) <-
-                    Session.pipeline $
-                        (,,,)
-                            <$> Pipeline.statement
-                                database.scopeDatabaseSchema
-                                catalogObjectsStatement
-                            <*> Pipeline.statement
-                                database.scopeDatabaseSchema
-                                catalogColumnsStatement
-                            <*> Pipeline.statement
-                                database.scopeDatabaseSchema
-                                catalogConstraintsStatement
-                            <*> Pipeline.statement
-                                database.scopeDatabaseSchema
-                                catalogIndexesStatement
+                    loadCatalogRows database.scopeDatabaseSchema
                 pure $ Right $
                     assembleCatalog objects columns constraints indexes
+
+type CatalogSchemaRows =
+    ( [CatalogObjectRow]
+    , [CatalogColumnRow]
+    , [CatalogConstraintRow]
+    , [CatalogIndexRow]
+    )
+
+catalogSchemaRowsPipelined :: Text -> Session.Session CatalogSchemaRows
+catalogSchemaRowsPipelined schema =
+    Session.pipeline $
+        (,,,)
+            <$> Pipeline.statement schema catalogObjectsStatement
+            <*> Pipeline.statement schema catalogColumnsStatement
+            <*> Pipeline.statement schema catalogConstraintsStatement
+            <*> Pipeline.statement schema catalogIndexesStatement
+
+catalogSchemaRowsSequential :: Text -> Session.Session CatalogSchemaRows
+catalogSchemaRowsSequential schema = do
+    objects <- Session.statement schema catalogObjectsStatement
+    columns <- Session.statement schema catalogColumnsStatement
+    constraints <- Session.statement schema catalogConstraintsStatement
+    indexes <- Session.statement schema catalogIndexesStatement
+    pure (objects, columns, constraints, indexes)
 
 queryCustom
     :: Pool

--- a/packages/agent-store/src/Agent/Store/Postgres/Custom.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Custom.hs
@@ -37,6 +37,7 @@ import qualified Data.Text.Encoding as Text
 import Data.Time.Clock (UTCTime, getCurrentTime)
 import qualified Hasql.Decoders as Decoders
 import qualified Hasql.Encoders as Encoders
+import qualified Hasql.Pipeline as Pipeline
 import Hasql.Pool (Pool)
 import qualified Hasql.Pool as Pool
 import qualified Hasql.Session as Session
@@ -148,18 +149,21 @@ inspectCustomSchema scopePool database =
         if not expectedIdentity
             then pure (Left scopeIdentityError)
             else do
-                objects <- Session.statement
-                    database.scopeDatabaseSchema
-                    catalogObjectsStatement
-                columns <- Session.statement
-                    database.scopeDatabaseSchema
-                    catalogColumnsStatement
-                constraints <- Session.statement
-                    database.scopeDatabaseSchema
-                    catalogConstraintsStatement
-                indexes <- Session.statement
-                    database.scopeDatabaseSchema
-                    catalogIndexesStatement
+                (objects, columns, constraints, indexes) <-
+                    Session.pipeline $
+                        (,,,)
+                            <$> Pipeline.statement
+                                database.scopeDatabaseSchema
+                                catalogObjectsStatement
+                            <*> Pipeline.statement
+                                database.scopeDatabaseSchema
+                                catalogColumnsStatement
+                            <*> Pipeline.statement
+                                database.scopeDatabaseSchema
+                                catalogConstraintsStatement
+                            <*> Pipeline.statement
+                                database.scopeDatabaseSchema
+                                catalogIndexesStatement
                 pure $ Right $
                     assembleCatalog objects columns constraints indexes
 

--- a/packages/agent-store/test/Agent/Store/Postgres/CustomSpec.hs
+++ b/packages/agent-store/test/Agent/Store/Postgres/CustomSpec.hs
@@ -109,6 +109,12 @@ spec = describe "custom PostgreSQL SQL normalization" do
                                                                         == "table"
                                                                         && object.catalogObjectName
                                                                             == "todos"))
+                                                    sequentialCatalog <-
+                                                        inspectCustomSchemaSequential
+                                                            rawScope
+                                                            database
+                                                    sequentialCatalog
+                                                        `shouldBe` catalog
                                                     result <- queryCustom
                                                         rawScope
                                                         database


### PR DESCRIPTION
## Summary

- pipeline the four independent custom-schema catalog reads after validating the scoped role identity
- preserve the existing non-transactional consistency and error semantics while reducing synchronization points
- retain selectable sequential and pipelined workloads in an optimized managed-PostgreSQL benchmark
- deeply force every catalog object, column, constraint, index, and text field inside the timed interval
- verify both implementations return identical typed catalogs and regenerate `package.nix`

## Performance

Each result is the median of 11 samples with 500 complete catalog inspections per sample.

| Tables | Workload | Median wall time | Median client CPU | Deep checksum |
| ---: | --- | ---: | ---: | ---: |
| 0 | Sequential | 168.593 ms | 52.026 ms | 7246744380944391267 |
| 0 | Pipeline | 153.769 ms | 48.099 ms | 7246744380944391267 |
| 10 | Sequential | 857.506 ms | 606.683 ms | -2105700843429382429 |
| 10 | Pipeline | 838.118 ms | 607.232 ms | -2105700843429382429 |
| 50 | Sequential | 3586.679 ms | 3156.215 ms | 3888762733436878579 |
| 50 | Pipeline | 3293.983 ms | 3172.817 ms | 3888762733436878579 |

Pipeline median wall-time improvements were 8.79% for an empty catalog, 2.26% for 10 tables, and 8.16% for 50 tables. Client CPU changed by -7.55%, +0.09%, and +0.53%, respectively. Matching deep checksums confirm equivalent fully forced output for each size.

Benchmark setup:

```bash
env TMPDIR=/tmp HASKELL_AGENT_TMPDIR=/tmp \
  nix develop -c cabal build --offline \
  agent-store:bench:custom-catalog-inspection-bench

bin=$(nix develop -c cabal list-bin \
  agent-store:bench:custom-catalog-inspection-bench)

for tables in 0 10 50; do
  "$bin" sequential "$tables" 500 11
  "$bin" pipeline "$tables" 500 11
done
```

## Validation

- `cabal repl agent-store:lib:agent-store` followed by `:reload`
- `env TMPDIR=/tmp HASKELL_AGENT_TMPDIR=/tmp nix develop -c cabal test --offline agent-store-test` — 31 examples, 0 failures
- optimized sequential and pipeline benchmark runs at 0, 10, and 50 tables
- `git diff --check`
