### PR TITLE
fix(agent-sessions): run persisted sessions in process

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/AgentSessions.hs
+++ b/packages/agent-cli/src/Agent/CLI/AgentSessions.hs
@@ -1,18 +1,23 @@
 -- | Tools for creating, inspecting, and continuing persisted top-level agent
--- sessions. Turns run in managed background @agent-cli@ processes so they are
--- independent from the caller's model loop while remaining resumable.
+-- sessions. CLI callers can run turns in tracked background threads, while
+-- gateways retain the managed @agent-cli@ process runner.
 module Agent.CLI.AgentSessions
     ( AgentSessionToolsEnv(..)
+    , SessionThreadManager
     , SessionProcessLifetime(..)
     , SessionProcessManager
     , agentSessionTools
+    , closeSessionThreadManager
     , closeSessionProcessManager
+    , launchSessionThread
     , launchManagedTurn
     , launchManagedTurnBounded
     , launchSessionTurn
+    , newSessionThreadManager
     , newSessionProcessManager
     , newSessionProcessManagerWithLifetime
     , signalManagedSessionReady
+    , sessionThreadStatus
     , sessionProcessStatus
     ) where
 
@@ -62,6 +67,13 @@ import Agent.Tools.Types
     , jsonTool
     )
 import Control.Concurrent (threadDelay)
+import Control.Concurrent.Async
+    ( Async
+    , asyncWithUnmask
+    , cancel
+    , poll
+    , waitCatch
+    )
 import Control.Concurrent.MVar
     ( MVar
     , modifyMVar
@@ -70,8 +82,15 @@ import Control.Concurrent.MVar
     , newMVar
     , putMVar
     , readMVar
+    , takeMVar
     )
-import Control.Exception.Safe (SomeException, finally, try)
+import Control.Exception.Safe
+    ( SomeException
+    , finally
+    , mask
+    , try
+    , tryAny
+    )
 import Control.Monad (void)
 import Data.Aeson (FromJSON(..), encode)
 import qualified Data.ByteString.Lazy as LBS
@@ -120,6 +139,21 @@ data AgentSessionToolsEnv = AgentSessionToolsEnv
     , toolsSessionStatus :: !(Text -> IO Text)
     }
 
+data ManagedSessionThread
+    = ManagedSessionThreadRunning !(Async ())
+    | ManagedSessionThreadCompleted
+    | ManagedSessionThreadFailed !Text
+
+data SessionThreadManagerState = SessionThreadManagerState
+    { threadManagerClosed :: !Bool
+    , managedThreads :: !(Map Text ManagedSessionThread)
+    }
+
+data SessionThreadManager = SessionThreadManager
+    { threadManagerRoot :: !OsPath
+    , threadManagerState :: !(MVar SessionThreadManagerState)
+    }
+
 data ManagedSessionProcess
     = ManagedSessionStarting !(MVar ())
     | ManagedSessionRunning !ProcessHandle
@@ -144,6 +178,139 @@ data SessionProcessLifetime
     = DetachedSessionProcesses
     | ScopedSessionProcesses
     deriving (Eq, Show)
+
+newSessionThreadManager :: OsPath -> IO SessionThreadManager
+newSessionThreadManager root = do
+    state <- newMVar SessionThreadManagerState
+        { threadManagerClosed = False
+        , managedThreads = Map.empty
+        }
+    pure SessionThreadManager
+        { threadManagerRoot = root
+        , threadManagerState = state
+        }
+
+-- | Start one in-process background turn. The task is registered before it is
+-- allowed to execute, so shutdown can always cancel and join every live turn.
+launchSessionThread
+    :: SessionThreadManager
+    -> Text
+    -> IO (Either Text ())
+    -> IO (Either Text Text)
+launchSessionThread manager sessionId action =
+    mask \_ -> do
+        launched <- modifyMVar manager.threadManagerState \state ->
+            if state.threadManagerClosed
+                then pure (state, Left "agent session manager is closed")
+                else case Map.lookup sessionId state.managedThreads of
+                    Just (ManagedSessionThreadRunning _) ->
+                        pure
+                            ( state
+                            , Left
+                                ("session " <> sessionId
+                                    <> " is already running")
+                            )
+                    _ -> do
+                        gate <- newEmptyMVar
+                        started <- tryAny $
+                            asyncWithUnmask \unmask -> do
+                                takeMVar gate
+                                result <- tryAny (unmask action)
+                                let terminal = case result of
+                                        Left err ->
+                                            ManagedSessionThreadFailed
+                                                (formatException err)
+                                        Right (Left err) ->
+                                            ManagedSessionThreadFailed err
+                                        Right (Right ()) ->
+                                            ManagedSessionThreadCompleted
+                                modifyMVar_ manager.threadManagerState \current ->
+                                    pure $
+                                        if current.threadManagerClosed
+                                            then current
+                                            else current
+                                                { managedThreads =
+                                                    Map.insert
+                                                        sessionId
+                                                        terminal
+                                                        current.managedThreads
+                                                }
+                        case started of
+                            Left err ->
+                                pure
+                                    ( state
+                                    , Left
+                                        ("failed to start agent session: "
+                                            <> formatException err)
+                                    )
+                            Right worker -> do
+                                let running = state
+                                        { managedThreads =
+                                            Map.insert
+                                                sessionId
+                                                (ManagedSessionThreadRunning worker)
+                                                state.managedThreads
+                                        }
+                                putMVar gate ()
+                                pure
+                                    ( running
+                                    , Right ("started session " <> sessionId)
+                                    )
+        pure launched
+
+sessionThreadStatus :: SessionThreadManager -> Text -> IO Text
+sessionThreadStatus manager sessionId =
+    modifyMVar manager.threadManagerState \state ->
+        case Map.lookup sessionId state.managedThreads of
+            Nothing -> do
+                locked <- lockIsActive
+                pure (state, if locked then "running" else "idle")
+            Just (ManagedSessionThreadRunning worker) ->
+                poll worker >>= \case
+                    Nothing -> pure (state, "running")
+                    Just (Right ()) ->
+                        terminalStatus state "completed"
+                    Just (Left err) ->
+                        terminalStatus
+                            state
+                            ("failed (" <> formatException err <> ")")
+            Just ManagedSessionThreadCompleted ->
+                terminalStatus state "completed"
+            Just (ManagedSessionThreadFailed err) ->
+                terminalStatus state ("failed (" <> err <> ")")
+  where
+    lockIsActive =
+        sessionLockIsActive
+            (sessionLockPath
+                (manager.threadManagerRoot
+                    </> unsafeEncodeUtf (Text.unpack sessionId)))
+    terminalStatus state terminal = do
+        locked <- lockIsActive
+        pure
+            ( state
+                { managedThreads =
+                    Map.delete sessionId state.managedThreads
+                }
+            , if locked then "running" else terminal
+            )
+
+closeSessionThreadManager :: SessionThreadManager -> IO ()
+closeSessionThreadManager manager = do
+    workers <- modifyMVar manager.threadManagerState \state ->
+        let running =
+                [ worker
+                | ManagedSessionThreadRunning worker <-
+                    Map.elems state.managedThreads
+                ]
+        in pure
+            ( state
+                { threadManagerClosed = True
+                , managedThreads = Map.empty
+                }
+            , running
+            )
+    mapM_ cancel workers
+    mapM_ (void . waitCatch) workers
 
 newSessionProcessManager :: OsPath -> IO SessionProcessManager
 newSessionProcessManager =

--- a/packages/agent-cli/src/Agent/CLI/ModelConfig.hs
+++ b/packages/agent-cli/src/Agent/CLI/ModelConfig.hs
@@ -17,6 +17,7 @@ module Agent.CLI.ModelConfig
     , connectionBuiltinProvider
     , decodeModelConfig
     , loadModelCatalog
+    , loadModelCatalogAt
     , loadModelCatalogWith
     , mergeModelConfigs
     , modelCatalogUserPath
@@ -198,17 +199,27 @@ mergeModelConfigs (defaultSource, defaultBytes) user = do
 
 loadModelCatalog :: OsPath -> IO (Either Text ModelCatalog)
 loadModelCatalog home = do
-    defaultPath <- packagedModelCatalogPath
+    cwd <- unsafeEncodeUtf <$> Directory.getCurrentDirectory
+    loadModelCatalogAt home cwd
+
+loadModelCatalogAt :: OsPath -> OsPath -> IO (Either Text ModelCatalog)
+loadModelCatalogAt home cwd = do
+    defaultPath <- packagedModelCatalogPathAt cwd
     loadModelCatalogWith defaultPath home
 
 packagedModelCatalogPath :: IO FilePath
 packagedModelCatalogPath = do
+    cwd <- unsafeEncodeUtf <$> Directory.getCurrentDirectory
+    packagedModelCatalogPathAt cwd
+
+packagedModelCatalogPathAt :: OsPath -> IO FilePath
+packagedModelCatalogPathAt cwd = do
     installed <- getDataFileName "config/models.default.json"
     executable <- Environment.getExecutablePath
-    cwd <- Directory.getCurrentDirectory
     let roots =
             take 16 (iterate FilePath.takeDirectory executable)
-                <> take 8 (iterate FilePath.takeDirectory cwd)
+                <> take 8
+                    (iterate FilePath.takeDirectory (unsafeToFilePath cwd))
         sourceCandidates =
             [ root FilePath.</> "packages/agent-cli/config/models.default.json"
             | root <- roots

--- a/packages/agent-cli/src/Agent/CLI/Provider/Switch.hs
+++ b/packages/agent-cli/src/Agent/CLI/Provider/Switch.hs
@@ -40,7 +40,7 @@ import Agent.CLI.Error
 import Agent.CLI.ModelConfig
     ( ModelCatalog
     , builtinConnectionId
-    , loadModelCatalog
+    , loadModelCatalogAt
     )
 import Agent.CLI.Models
     ( ModelOption(..)
@@ -145,7 +145,8 @@ import System.Directory.OsPath
     , getHomeDirectory
     )
 import System.IO
-    ( stderr
+    ( Handle
+    , stderr
     , stdout
     )
 import System.OsPath (OsPath)
@@ -470,6 +471,8 @@ requestAutomaticProviderFallback env apiError pending = do
         Just tokenProvider ->
             chooseAutomaticProviderTransition
                 env.sessionModelCatalog
+                env.sessionCwd
+                env.sessionRender.renderStderr
                 env.sessionFullscreen
                 (tokenProviderBillingMode tokenProvider)
                 env.sessionProvider
@@ -489,6 +492,7 @@ requestStartupProviderFallback env apiError = do
         Just tokenProvider ->
             chooseStartupProviderTransition
                 env.sessionModelCatalog
+                env.sessionCwd
                 env.sessionFullscreen
                 (tokenProviderBillingMode tokenProvider)
                 env.sessionProvider
@@ -497,21 +501,26 @@ requestStartupProviderFallback env apiError = do
                 apiError
 
 continueAutomaticFallback
-    :: Maybe FullscreenRuntime
+    :: Maybe OsPath
+    -> Handle
+    -> Maybe FullscreenRuntime
     -> ProviderTransition
     -> ApiError
     -> IO (Maybe ProviderTransition)
-continueAutomaticFallback fullscreen failed apiError =
+continueAutomaticFallback cwdHint stderrHandle fullscreen failed apiError =
     case ( failed.transitionAutomaticBilling
          , failed.transitionPendingTurn
          ) of
         (Just billing, Just pending) -> do
             home <- getHomeDirectory
-            loadModelCatalog home >>= \case
+            cwd <- maybe getCurrentDirectory pure cwdHint
+            loadModelCatalogAt home cwd >>= \case
                 Left _ -> pure Nothing
                 Right catalog ->
                     chooseAutomaticProviderTransition
                         catalog
+                        cwd
+                        stderrHandle
                         fullscreen
                         billing
                         failed.transitionTarget.targetProvider
@@ -523,6 +532,8 @@ continueAutomaticFallback fullscreen failed apiError =
 
 chooseAutomaticProviderTransition
     :: ModelCatalog
+    -> OsPath
+    -> Handle
     -> Maybe FullscreenRuntime
     -> BillingMode
     -> Provider
@@ -532,7 +543,8 @@ chooseAutomaticProviderTransition
     -> ApiError
     -> IO (Maybe ProviderTransition)
 chooseAutomaticProviderTransition
-    catalog fullscreen sourceBilling current unavailable0 sessionId pending apiError =
+    catalog cwd stderrHandle fullscreen
+        sourceBilling current unavailable0 sessionId pending apiError =
     tryCandidates unavailable candidates
   where
     unavailable = markUnavailable current unavailable0
@@ -542,7 +554,7 @@ chooseAutomaticProviderTransition
         [] -> pure Nothing
         rawChoice : rest -> do
             choice <- resolveModelOptionDialect rawChoice
-            validateAutomaticProviderTarget sourceBilling choice >>= \case
+            validateAutomaticProviderTarget cwd sourceBilling choice >>= \case
                 Left err -> do
                     let message =
                             "skipping "
@@ -551,8 +563,8 @@ chooseAutomaticProviderTransition
                             <> err
                     case fullscreen of
                         Nothing -> do
-                            color <- resolveColor stderr
-                            putTextLn stderr (roleMuted color message)
+                            color <- resolveColor stderrHandle
+                            putTextLn stderrHandle (roleMuted color message)
                         Just runtime ->
                             emitUiEvent runtime (UiSystemMessage message)
                     tryCandidates
@@ -567,8 +579,8 @@ chooseAutomaticProviderTransition
                             <> choice.modelTarget.targetModelId
                     case fullscreen of
                         Nothing -> do
-                            color <- resolveColor stderr
-                            putTextLn stderr
+                            color <- resolveColor stderrHandle
+                            putTextLn stderrHandle
                                 (roleWarn color (glyphWarn <> message))
                         Just runtime ->
                             emitUiEvent runtime (UiSystemMessage message)
@@ -587,6 +599,7 @@ chooseAutomaticProviderTransition
 
 chooseStartupProviderTransition
     :: ModelCatalog
+    -> OsPath
     -> Maybe FullscreenRuntime
     -> BillingMode
     -> Provider
@@ -595,7 +608,7 @@ chooseStartupProviderTransition
     -> ApiError
     -> IO (Maybe ProviderTransition)
 chooseStartupProviderTransition
-    catalog fullscreen sourceBilling current unavailable0 sessionId apiError =
+    catalog cwd fullscreen sourceBilling current unavailable0 sessionId apiError =
     tryCandidates unavailable candidates
   where
     unavailable = markUnavailable current unavailable0
@@ -605,7 +618,7 @@ chooseStartupProviderTransition
         [] -> pure Nothing
         rawChoice : rest -> do
             choice <- resolveModelOptionDialect rawChoice
-            validateAutomaticProviderTarget sourceBilling choice >>= \case
+            validateAutomaticProviderTarget cwd sourceBilling choice >>= \case
                 Left err -> do
                     let message =
                             "skipping "
@@ -673,10 +686,11 @@ validateProviderTarget choice =
         loadValidatedProviderTarget probeLoadedAvailability choice
 
 validateAutomaticProviderTarget
-    :: BillingMode
+    :: OsPath
+    -> BillingMode
     -> ModelOption
     -> IO (Either Text (Maybe SelectedAccount))
-validateAutomaticProviderTarget sourceBilling choice = do
+validateAutomaticProviderTarget cwd sourceBilling choice = do
     let provider = choice.modelTarget.targetProvider
     if not (providerSupportsUsageAccountSelection provider)
         then fmap (Nothing <$) $
@@ -684,7 +698,6 @@ validateAutomaticProviderTarget sourceBilling choice = do
                 probeLoadedAutomaticAvailability
                 choice
         else do
-            cwd <- getCurrentDirectory
             projectRoot <- resolveProjectRoot cwd
             settings <- loadProjectSettings projectRoot
             let rememberedIds = fmap

--- a/packages/agent-cli/src/Agent/CLI/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime.hs
@@ -68,12 +68,13 @@ import Agent.CLI.SessionTitle
     )
 import Agent.CLI.AgentSessions
     ( AgentSessionToolsEnv(..)
+    , SessionThreadManager
     , agentSessionTools
-    , closeSessionProcessManager
-    , launchSessionTurn
-    , newSessionProcessManager
+    , closeSessionThreadManager
+    , launchSessionThread
+    , newSessionThreadManager
     , signalManagedSessionReady
-    , sessionProcessStatus
+    , sessionThreadStatus
     )
 import Agent.CLI.ManagedTurn
     ( ManagedTurnRequest(..)
@@ -161,7 +162,8 @@ import Agent.CLI.LearnedSkills.Store
     , loadApplicableLearnedSkillsForStore
     )
 import Agent.CLI.Error
-    ( formatApiErrorAt
+    ( formatException
+    , formatApiErrorAt
     , formatApiErrorInlineAt
     , formatApiErrorRetryCountdownParts
     )
@@ -224,7 +226,7 @@ import Agent.CLI.ModelConfig
     , ResponsesConnection(..)
     , builtinConnectionId
     , catalogConnection
-    , loadModelCatalog
+    , loadModelCatalogAt
     )
 import Agent.CLI.Models
     ( ModelOption(..)
@@ -728,8 +730,18 @@ import System.OsPath (OsPath, decodeFS, unsafeEncodeUtf, (</>), takeDirectory, t
 import System.Console.ANSI (getTerminalSize)
 import System.Console.ANSI.Codes (clearFromCursorToLineEndCode)
 import System.Exit (ExitCode(..), die)
-import System.IO (Handle, hFlush, hIsTerminalDevice, stderr, stdin, stdout)
+import System.IO
+    ( Handle
+    , IOMode(AppendMode)
+    , hFlush
+    , hIsTerminalDevice
+    , stderr
+    , stdin
+    , stdout
+    , withFile
+    )
 import System.Mem.StableName (StableName, makeStableName)
+import System.Posix.Files (setFileMode)
 import System.Process (readProcessWithExitCode)
 
 data ActiveHttpAuth = ActiveHttpAuth
@@ -746,6 +758,34 @@ data AgentStepCache = AgentStepCache
     { cachedTranscript :: !(StableName [ResponseItem])
     , cachedVariant :: !(Maybe SubagentStatus)
     , cachedSteps :: ![AgentStep]
+    }
+
+data AgentProcessRuntime = AgentProcessRuntime
+    { processMcpSupervisor :: !MCP.McpSupervisor
+    , processSessionThreads :: !SessionThreadManager
+    }
+
+data AgentRunMode = AgentRunMode
+    { runStdout :: !Handle
+    , runStderr :: !Handle
+    , runInBackground :: !Bool
+    , runCwdHint :: !(Maybe OsPath)
+    }
+
+foregroundRunMode :: AgentRunMode
+foregroundRunMode = AgentRunMode
+    { runStdout = stdout
+    , runStderr = stderr
+    , runInBackground = False
+    , runCwdHint = Nothing
+    }
+
+backgroundRunMode :: Handle -> OsPath -> AgentRunMode
+backgroundRunMode output cwd = AgentRunMode
+    { runStdout = output
+    , runStderr = output
+    , runInBackground = True
+    , runCwdHint = Just cwd
     }
 
 -- | GHCi @:cmd@ helper: on 'DevReload', reload modules and resume that exact
@@ -845,19 +885,44 @@ runAgentWithRestarts :: CliOptions -> IO DevResult
 runAgentWithRestarts options =
     catchUserInterrupt
         (do
-            fullscreenInputs <- newFullscreenInputBuffer
-            sessionState <- newSessionState
+            home <- getHomeDirectory
+            let root = sessionsRoot home
             mcpSupervisor <- MCP.newMcpSupervisor
+            sessionThreads <-
+                newSessionThreadManager root
+                    `onException` MCP.closeMcpSupervisor mcpSupervisor
+            let processRuntime = AgentProcessRuntime
+                    { processMcpSupervisor = mcpSupervisor
+                    , processSessionThreads = sessionThreads
+                    }
             withRestoredCurrentDirectory
-                (go mcpSupervisor fullscreenInputs sessionState options Nothing)
-                `finally` MCP.closeMcpSupervisor mcpSupervisor)
+                (runAgentWithRuntime processRuntime foregroundRunMode options)
+                `finally`
+                    (closeSessionThreadManager sessionThreads
+                        `finally` MCP.closeMcpSupervisor mcpSupervisor))
         (pure DevQuit)
+
+runAgentWithRuntime
+    :: AgentProcessRuntime
+    -> AgentRunMode
+    -> CliOptions
+    -> IO DevResult
+runAgentWithRuntime processRuntime runMode options = do
+    fullscreenInputs <- newFullscreenInputBuffer
+    sessionState <- newSessionState
+    go fullscreenInputs sessionState options Nothing
   where
-    go mcpSupervisor fullscreenInputs sessionState current transition =
-        runAgent mcpSupervisor fullscreenInputs sessionState current transition >>= \case
+    go fullscreenInputs sessionState current transition =
+        runAgent
+            processRuntime
+            runMode
+            fullscreenInputs
+            sessionState
+            current
+            transition >>= \case
             RunResumeSession sessionId ->
                 newSessionState >>= \nextState ->
-                    go mcpSupervisor fullscreenInputs nextState
+                    go fullscreenInputs nextState
                         current
                             { optProvider = Nothing
                             , optModel = Nothing
@@ -871,7 +936,7 @@ runAgentWithRestarts options =
                         Nothing
             RunSwitchWorktree path provider model effort ->
                 newSessionState >>= \nextState ->
-                    go mcpSupervisor fullscreenInputs nextState
+                    go fullscreenInputs nextState
                         current
                             { optProvider = Just provider
                             , optModel = Just model
@@ -884,11 +949,11 @@ runAgentWithRestarts options =
                             }
                         Nothing
             RunSwitchProvider next ->
-                go mcpSupervisor fullscreenInputs sessionState
+                go fullscreenInputs sessionState
                     (applyProviderTransition current next)
                     (Just next)
             RunRestart sessionId ->
-                go mcpSupervisor fullscreenInputs sessionState
+                go fullscreenInputs sessionState
                     (restartSessionOptions current sessionId)
                     Nothing
             RunProviderStartFailed apiError ->
@@ -896,17 +961,104 @@ runAgentWithRestarts options =
                     Just failed
                         | failed.transitionCause == AutomaticFallback ->
                             continueAutomaticFallback
-                                Nothing failed apiError >>= \case
+                                runMode.runCwdHint
+                                runMode.runStderr
+                                Nothing
+                                failed
+                                apiError >>= \case
                                 Just next ->
-                                    go mcpSupervisor fullscreenInputs sessionState
+                                    go fullscreenInputs sessionState
                                         (applyProviderTransition current next)
                                         (Just next)
-                                Nothing -> do
-                                    reportProviderUnavailable Nothing apiError
-                                    pure DevQuit
-                    _ -> pure DevQuit
+                                Nothing
+                                    | runMode.runInBackground -> do
+                                        now <- getCurrentTime
+                                        throwIO $
+                                            StartupFailure
+                                                (Text.unpack
+                                                    (formatApiErrorAt
+                                                        now
+                                                        apiError))
+                                    | otherwise -> do
+                                        reportProviderUnavailable Nothing apiError
+                                        pure DevQuit
+                    _
+                        | runMode.runInBackground -> do
+                            now <- getCurrentTime
+                            throwIO $
+                                StartupFailure
+                                    (Text.unpack
+                                        (formatApiErrorAt now apiError))
+                        | otherwise -> pure DevQuit
             RunQuit -> pure DevQuit
             RunReload sessionId -> pure (DevReload sessionId)
+
+runInProcessSessionTurn
+    :: AgentProcessRuntime
+    -> CliOptions
+    -> ApprovalPolicy
+    -> Bool
+    -> Bool
+    -> SessionHandle
+    -> Text
+    -> IO (Either Text ())
+runInProcessSessionTurn
+        processRuntime parentOptions policy ghciEnabled bashEnabled handle message =
+    withFile logPath AppendMode \logHandle -> do
+        setFileMode logPath 0o600
+        runAgentWithRuntime
+            processRuntime
+            (backgroundRunMode logHandle handle.sessionMeta.metaCwd)
+            childOptions >>= \case
+                DevQuit -> pure (Right ())
+                DevReload _ ->
+                    pure (Left "background agent session requested a reload")
+  where
+    logPath =
+        unsafeToFilePath
+            (handle.sessionDir </> unsafeEncodeUtf "agent.log")
+    childOptions =
+        applyBackgroundApproval policy $
+            parentOptions
+                { optProvider = Nothing
+                , optModel = Nothing
+                , optCwd = Nothing
+                , optWorktree = False
+                , optEffort = Nothing
+                , optPrompt = Just message
+                , optPromptFile = Nothing
+                , optManagedTurnFile = Nothing
+                , optResume = Just handle.sessionMeta.metaId
+                , optSaveSession = True
+                , optGhci = ghciEnabled
+                , optBash = bashEnabled
+                , optScreenMode = ScreenMinimal
+                }
+
+applyBackgroundApproval :: ApprovalPolicy -> CliOptions -> CliOptions
+applyBackgroundApproval policy options =
+    case policy of
+        ApproveAll ->
+            options
+                { optYolo = True
+                , optNoYolo = False
+                , optManagedDenyMutations = False
+                }
+        DenyMutating ->
+            options
+                { optYolo = False
+                , optNoYolo = True
+                , optManagedDenyMutations = True
+                }
+        PromptMutating ->
+            -- Background sessions cannot safely borrow the caller's stdin.
+            -- Keep the prompt policy marker; non-TTY one-shot resolution
+            -- conservatively denies mutating calls.
+            options
+                { optYolo = False
+                , optNoYolo = True
+                , optManagedDenyMutations = False
+                }
 
 -- | Restore the process cwd after an action succeeds or throws. Cabal gives
 -- GHCi relative source paths, so returning from an agent session in its cwd
@@ -938,14 +1090,14 @@ finishStartup startup = do
                                     <> formatStartupDuration duration)
                             syntaxLoadDuration
             case startup.startupFullscreen of
-                Nothing -> putTextLn stderr message
+                Nothing -> putTextLn startup.startupStderr message
                 Just runtime -> emitUiEvent runtime (UiSystemMessage message)
         _ -> pure ()
 
 reportStartupWarning :: StartupRuntime -> Text -> IO ()
 reportStartupWarning startup message =
     case startup.startupFullscreen of
-        Nothing -> putTextLn stderr ("warning: " <> message)
+        Nothing -> putTextLn startup.startupStderr ("warning: " <> message)
         Just runtime ->
             emitUiEvent runtime (UiSystemMessage ("warning: " <> message))
 
@@ -990,22 +1142,31 @@ setStartupRepository fullscreen home branch cwd =
                     (formatRepositoryPath home cwd)
 
 runAgent
-    :: MCP.McpSupervisor
+    :: AgentProcessRuntime
+    -> AgentRunMode
     -> FullscreenInputBuffer
     -> SessionState
     -> CliOptions
     -> Maybe ProviderTransition
     -> IO RunResult
-runAgent mcpSupervisor fullscreenInputs sessionState options transition = do
+runAgent
+        processRuntime runMode fullscreenInputs sessionState options transition = do
     prepared <-
         prepareAgentIteration
-            mcpSupervisor fullscreenInputs sessionState Nothing options transition
+            processRuntime
+            runMode
+            fullscreenInputs
+            sessionState
+            Nothing
+            options
+            transition
     let runPrepared = case prepared.preparedFullscreen of
             Nothing -> prepared.preparedRun
             Just runtime ->
                 runFullscreen runtime $
                     runFullscreenRestartLoop
-                        mcpSupervisor
+                        processRuntime
+                        runMode
                         fullscreenInputs
                         sessionState
                         runtime
@@ -1016,7 +1177,13 @@ runAgent mcpSupervisor fullscreenInputs sessionState options transition = do
     result <- case outcome of
         Left StartupCancelled -> pure RunQuit
         Right startupOutcome ->
-            either (\(StartupFailure message) -> die message) pure startupOutcome
+            either
+                (\failure@(StartupFailure message) ->
+                    if runMode.runInBackground
+                        then throwIO failure
+                        else die message)
+                pure
+                startupOutcome
     case (prepared.preparedFullscreen, result) of
         -- The retained screen has been restored before this persistent final
         -- diagnostic is printed.
@@ -1030,7 +1197,8 @@ runAgent mcpSupervisor fullscreenInputs sessionState options transition = do
 -- alternate screen until the whole provider-restart chain finishes. Session
 -- resumes still return to 'runAgentWithRestarts' and start a fresh UI.
 prepareAgentIteration
-    :: MCP.McpSupervisor
+    :: AgentProcessRuntime
+    -> AgentRunMode
     -> FullscreenInputBuffer
     -> SessionState
     -> Maybe FullscreenRuntime
@@ -1038,16 +1206,50 @@ prepareAgentIteration
     -> Maybe ProviderTransition
     -> IO PreparedAgent
 prepareAgentIteration
-        mcpSupervisor
+        processRuntime runMode
         fullscreenInputs sessionState activeFullscreen options transition = do
-    forM_ activeFullscreen resetFullscreenSessionActions
     resumeLockRef <- newIORef (Nothing :: Maybe SessionLock)
     databaseStoreRef <- newIORef (Nothing :: Maybe Store)
-    let failPreparation message =
-            readIORef resumeLockRef >>= mapM_ releaseSessionLock >>
-            readIORef databaseStoreRef >>= mapM_ closeStore >>
+    prepareAgentIterationTracked
+        resumeLockRef
+        databaseStoreRef
+        processRuntime
+        runMode
+        fullscreenInputs
+        sessionState
+        activeFullscreen
+        options
+        transition
+        `onException`
+            releasePreparationResources resumeLockRef databaseStoreRef
+
+prepareAgentIterationTracked
+    :: IORef (Maybe SessionLock)
+    -> IORef (Maybe Store)
+    -> AgentProcessRuntime
+    -> AgentRunMode
+    -> FullscreenInputBuffer
+    -> SessionState
+    -> Maybe FullscreenRuntime
+    -> CliOptions
+    -> Maybe ProviderTransition
+    -> IO PreparedAgent
+prepareAgentIterationTracked
+        resumeLockRef databaseStoreRef
+        processRuntime runMode
+        fullscreenInputs sessionState activeFullscreen options transition = do
+    forM_ activeFullscreen resetFullscreenSessionActions
+    let stdoutHandle = runMode.runStdout
+        stderrHandle = runMode.runStderr
+        background = runMode.runInBackground
+        signalReady result =
+            unless background (signalManagedSessionReady result)
+        failPreparation message =
+            releasePreparationResources resumeLockRef databaseStoreRef >>
                 case activeFullscreen of
-                    Nothing -> die message
+                    Nothing
+                        | background -> throwIO (StartupFailure message)
+                        | otherwise -> die message
                     Just _ -> throwIO (StartupFailure message)
     startedAt <- getCurrentTime
     startupTimingsRef <- newIORef []
@@ -1065,35 +1267,36 @@ prepareAgentIteration
         Just sessionId -> do
             dir <- either
                 (\err -> do
-                    signalManagedSessionReady (Left err)
+                    signalReady (Left err)
                     failPreparation (Text.unpack err))
                 pure
                 (sessionDirForId root sessionId)
             exists <- doesDirectoryExist dir
             when (not exists) do
                 let err = "session not found: " <> sessionId
-                signalManagedSessionReady (Left err)
+                signalReady (Left err)
                 failPreparation (Text.unpack err)
             acquireSessionLock dir sessionId >>= \case
                 Left err -> do
-                    signalManagedSessionReady (Left err)
+                    signalReady (Left err)
                     failPreparation (Text.unpack err)
                 Right lock -> do
                     writeIORef resumeLockRef (Just lock)
                     loadSession sessionPool root sessionId >>= \case
                         Left err -> do
-                            signalManagedSessionReady (Left err)
+                            signalReady (Left err)
                             failPreparation (Text.unpack err)
                         Right loaded -> do
-                            signalManagedSessionReady (Right ())
+                            signalReady (Right ())
                             pure (Just loaded)
 
-    source <- maybe getCurrentDirectory makeAbsolute options.optCwd
-    initialCwd <- case resumed of
-        Just (meta, _)
-            | isJustCwd options -> pure source
-            | otherwise -> makeAbsolute meta.metaCwd
-        Nothing -> pure source
+    source <- case options.optCwd of
+        Just requestedCwd -> makeAbsolute requestedCwd
+        Nothing -> case resumed of
+            Just (meta, _) -> makeAbsolute meta.metaCwd
+            Nothing ->
+                maybe getCurrentDirectory makeAbsolute runMode.runCwdHint
+    let initialCwd = source
     uiRuntimeRef <- newIORef Nothing
     cancelToolRef <- newIORef (pure ())
     interrupt <- newInterruptState \msg -> do
@@ -1103,17 +1306,19 @@ prepareAgentIteration
                     (UiSetNotice (Just (warningNotice msg)))
             Nothing -> do
                 -- Drop an in-place "Thinking…" status so the hint is its own line.
-                Text.hPutStr stderr "\r\ESC[K"
-                clearNativeProgress stderr
-                color <- resolveColor stderr
-                putTextLn stderr (roleMuted color msg)
+                Text.hPutStr stderrHandle "\r\ESC[K"
+                clearNativeProgress stderrHandle
+                color <- resolveColor stderrHandle
+                putTextLn stderrHandle (roleMuted color msg)
     -- Shared with Esc cancel and plan prompts so arrow-key pickers own stdin.
     escPaused <- newIORef False
-    stderrTty <- hIsTerminalDevice stderr
-    stdinTty <- hIsTerminalDevice stdin
-    stdoutTty <- hIsTerminalDevice stdout
-    terminal <- detectTerminalCapabilities stdout
-    useColor <- resolveColor stdout
+    stderrTty <-
+        if background then pure False else hIsTerminalDevice stderrHandle
+    stdinTty <- if background then pure False else hIsTerminalDevice stdin
+    stdoutTty <-
+        if background then pure False else hIsTerminalDevice stdoutHandle
+    terminal <- detectTerminalCapabilities stdoutHandle
+    useColor <- if background then pure False else resolveColor stdoutHandle
     agentSnapshotRef <- newIORef (pure (AgentRoot, []))
     agentSelectRef <- newIORef (\_ -> pure ())
     restartEffortActionRef <- newIORef (\_ -> pure ())
@@ -1153,14 +1358,14 @@ prepareAgentIteration
                     (\level ->
                         readIORef restartEffortActionRef >>= ($ level))
                     (noteFullscreenCtrlC interrupt)
-                    (copyTerminalClipboard terminal stdout)
-                    (setCliWindowTitle stdoutTty stdout)
+                    (copyTerminalClipboard terminal stdoutHandle)
+                    (setCliWindowTitle stdoutTty stdoutHandle)
                     (\active ->
                         when
                             (terminal.terminalNativeProgress
                                 && nativeProgressAnimationEnabled
                                     options.optMotionMode) $
-                            setNativeProgress stderr active)
+                            setNativeProgress stderrHandle active)
                     (readIORef agentSnapshotRef >>= id)
                     (\target -> readIORef agentSelectRef >>= ($ target))
                     (do
@@ -1184,7 +1389,7 @@ prepareAgentIteration
                             case fullscreen of
                                 Just _ -> pure ()
                                 Nothing ->
-                                    putTextLn stderr "Creating worktree…"
+                                    putTextLn stderrHandle "Creating worktree…"
                             createWorktree source (worktreeRoot home)
                                 >>= either
                                     (\err -> do
@@ -1196,10 +1401,10 @@ prepareAgentIteration
                                                     (StartupFailure
                                                         (Text.unpack err)))
                                     (\path -> do
-                                        color <- resolveColor stderr
+                                        color <- resolveColor stderrHandle
                                         case fullscreen of
                                             Nothing ->
-                                                putTextLn stderr
+                                                putTextLn stderrHandle
                                                     (roleMuted color
                                                         (glyphSession
                                                             <> "worktree: "
@@ -1214,9 +1419,9 @@ prepareAgentIteration
                                             "Loading project…"
                                         pure path)
                         | otherwise -> pure initialCwd
-                setCurrentDirectory cwd
+                unless background (setCurrentDirectory cwd)
                 terminalCwd <- decodeFS cwd
-                reportTerminalCwd terminal stdout terminalCwd
+                reportTerminalCwd terminal stdoutHandle terminalCwd
                 toolEnv <- defaultToolEnv cwd
                 writeIORef cancelToolRef (requestCancel toolEnv.toolCancel)
                 forM_ fullscreen \runtime ->
@@ -1238,6 +1443,9 @@ prepareAgentIteration
                         , startupUiRuntimeRef = uiRuntimeRef
                         , startupFullscreen = fullscreen
                         , startupTerminal = terminal
+                        , startupStdout = stdoutHandle
+                        , startupStderr = stderrHandle
+                        , startupBackground = background
                         , startupUseColor = useColor
                         , startupStderrTty = stderrTty
                         , startupStdinTty = stdinTty
@@ -1253,7 +1461,7 @@ prepareAgentIteration
                         , startupSessionState = sessionState
                         }
                 runAgentInitialized
-                    mcpSupervisor
+                    processRuntime
                     options
                     transition
                     home
@@ -1272,6 +1480,16 @@ prepareAgentIteration
         , preparedRun = action `finally` cleanup
         }
 
+releasePreparationResources
+    :: IORef (Maybe SessionLock)
+    -> IORef (Maybe Store)
+    -> IO ()
+releasePreparationResources resumeLockRef databaseStoreRef = do
+    atomicModifyIORef' resumeLockRef (\current -> (Nothing, current))
+        >>= mapM_ releaseSessionLock
+    atomicModifyIORef' databaseStoreRef (\current -> (Nothing, current))
+        >>= mapM_ closeStore
+
 resetFullscreenSessionActions :: FullscreenRuntime -> IO ()
 resetFullscreenSessionActions runtime =
     setFullscreenSessionActions
@@ -1287,7 +1505,8 @@ resetFullscreenSessionActions runtime =
         (const (pure ()))
 
 runFullscreenRestartLoop
-    :: MCP.McpSupervisor
+    :: AgentProcessRuntime
+    -> AgentRunMode
     -> FullscreenInputBuffer
     -> SessionState
     -> FullscreenRuntime
@@ -1296,7 +1515,8 @@ runFullscreenRestartLoop
     -> IO RunResult
     -> IO RunResult
 runFullscreenRestartLoop
-    mcpSupervisor
+    processRuntime
+    runMode
     fullscreenInputs
     sessionState
     runtime =
@@ -1320,7 +1540,11 @@ runFullscreenRestartLoop
                         Just failed
                             | failed.transitionCause == AutomaticFallback ->
                                 continueAutomaticFallback
-                                    (Just runtime) failed apiError >>= \case
+                                    runMode.runCwdHint
+                                    runMode.runStderr
+                                    (Just runtime)
+                                    failed
+                                    apiError >>= \case
                                     Just next -> do
                                         let nextOptions =
                                                 applyProviderTransition
@@ -1345,7 +1569,8 @@ runFullscreenRestartLoop
             UiSetNotice (Just (progressNotice "Retrying startup…"))
         try @_ @StartupFailure
             (prepareAgentIteration
-                mcpSupervisor
+                processRuntime
+                runMode
                 fullscreenInputs
                 sessionState
                 (Just runtime)
@@ -1381,7 +1606,7 @@ runFullscreenRestartLoop
                 _ -> pure RunQuit
 
 runAgentInitialized
-    :: MCP.McpSupervisor
+    :: AgentProcessRuntime
     -> CliOptions
     -> Maybe ProviderTransition
     -> OsPath
@@ -1392,13 +1617,13 @@ runAgentInitialized
     -> StartupRuntime
     -> IO RunResult
 runAgentInitialized
-        mcpSupervisor options transition home root resumed resumeLock cwd startup =
+        processRuntime options transition home root resumed resumeLock cwd startup =
     runAgentInitializedWithLock
-        mcpSupervisor options transition home root resumed resumeLock cwd startup
+        processRuntime options transition home root resumed resumeLock cwd startup
         `onException` mapM_ releaseSessionLock resumeLock
 
 runAgentInitializedWithLock
-    :: MCP.McpSupervisor
+    :: AgentProcessRuntime
     -> CliOptions
     -> Maybe ProviderTransition
     -> OsPath
@@ -1409,19 +1634,22 @@ runAgentInitializedWithLock
     -> StartupRuntime
     -> IO RunResult
 runAgentInitializedWithLock
-        mcpSupervisor
+        processRuntime
         options transition home root resumed resumeLock cwd startup = do
     let baseToolEnv = startup.startupToolEnv
+        mcpSupervisor = processRuntime.processMcpSupervisor
         interrupt = startup.startupInterrupt
         escPaused = startup.startupEscPaused
         uiRuntimeRef = startup.startupUiRuntimeRef
         fullscreen = startup.startupFullscreen
         isTty = startup.startupStdinTty
         stdoutTty = startup.startupStdoutTty
+        stdoutHandle = startup.startupStdout
+        stderrHandle = startup.startupStderr
         setWindowTitle title =
             case fullscreen of
                 Just runtime -> setFullscreenWindowTitle runtime title
-                Nothing -> setCliWindowTitle stdoutTty stdout title
+                Nothing -> setCliWindowTitle stdoutTty stdoutHandle title
     projectRoot <- resolveProjectRoot cwd
     stateDirectory <- decodeFS (home </> unsafeEncodeUtf ".haskell-agent")
     projectRootPath <- decodeFS projectRoot
@@ -1433,7 +1661,7 @@ runAgentInitializedWithLock
         concurrently
             (loadProjectSettings projectRoot)
             (concurrently
-                (loadModelCatalog home)
+                (loadModelCatalogAt home cwd)
                 (detectGitBranch cwd))
     catalog <- either
         (startupDie startup . Text.unpack)
@@ -1811,8 +2039,15 @@ runAgentInitializedWithLock
         loadHarnessConfig home >>= \case
             Left err -> startupDie startup (Text.unpack err)
             Right config -> pure config
-    let basePlanHooks =
-            cliPlanHooks interrupt escPaused (resolveColor stderr)
+    let basePlanHooks
+            | startup.startupBackground =
+                PlanModeHooks
+                    { planConfirmEnter = \_ -> pure False
+                    , planDecideExit = \_ -> pure PlanCancel
+                    , planAskQuestion = \_ _ -> pure Nothing
+                    }
+            | otherwise =
+                cliPlanHooks interrupt escPaused (resolveColor stderrHandle)
         planHooks = fullscreenAwarePlanHooks uiRuntimeRef basePlanHooks
         baseSecretHooks = SecretPromptHooks \request ->
             Right <$> promptSecretLine
@@ -1936,7 +2171,6 @@ runAgentInitializedWithLock
     when (isNothing transition) $
         saveProjectModel projectRoot
             inferredTarget { targetDialect = dialectId }
-    sessionProcessManager <- newSessionProcessManager root
     activeSessionLock <- newIORef resumeLock
     persistSlotRef <- newIORef PersistenceDisabled
     -- Per-subagent transcripts / previous ids, shared across send_input / task.
@@ -2011,7 +2245,7 @@ runAgentInitializedWithLock
     persist <-
         preparePersistence
             (trustedPool startup.startupDatabaseStore)
-            fullscreen options root
+            startup options root
                 inferredTarget { targetDialect = dialectId }
                 (isNothing transition) cwd effort promptText resumed
     writeIORef persistSlotRef persist
@@ -2202,11 +2436,32 @@ runAgentInitializedWithLock
             , toolsLaunchTurn = \handle message -> do
                 ghciEnabled <- readIORef ghciEnabledRef
                 bashEnabled <- readIORef bashEnabledRef
-                launchSessionTurn sessionProcessManager
-                    (not (isOneShot options)) policy
-                    ghciEnabled bashEnabled handle message
+                let action =
+                        runInProcessSessionTurn
+                            processRuntime
+                            options
+                            policy
+                            ghciEnabled
+                            bashEnabled
+                            handle
+                            message
+                if isOneShot options
+                    then
+                        try @_ @SomeException action >>= \case
+                            Left err -> pure (Left (formatException err))
+                            Right (Left err) -> pure (Left err)
+                            Right (Right ()) ->
+                                pure
+                                    (Right
+                                        ("completed session "
+                                            <> handle.sessionMeta.metaId))
+                    else
+                        launchSessionThread
+                            processRuntime.processSessionThreads
+                            handle.sessionMeta.metaId
+                            action
             , toolsSessionStatus =
-                sessionProcessStatus sessionProcessManager
+                sessionThreadStatus processRuntime.processSessionThreads
             }
         mcpTools =
             if null mcpServerConfigs
@@ -2264,18 +2519,16 @@ runAgentInitializedWithLock
         closeAll =
             closeAgents
                 `finally`
-                    (closeSessionProcessManager sessionProcessManager
+                    ((readIORef activeSessionLock
+                        >>= mapM_ releaseSessionLock)
                         `finally`
-                            ((readIORef activeSessionLock
-                                >>= mapM_ releaseSessionLock)
+                            (closeExtraTools
                                 `finally`
-                                    (closeExtraTools
+                                    (MCP.releaseMcpFleetLease mcpLease
                                         `finally`
-                                            (MCP.releaseMcpFleetLease mcpLease
+                                            (coding.codingClose
                                                 `finally`
-                                                    (coding.codingClose
-                                                        `finally`
-                                                            cleanupScratch)))))
+                                                    cleanupScratch))))
     flip finally closeAll do
         case
                 mcpToolCollision
@@ -2354,6 +2607,7 @@ runAgentInitializedWithLock
         markStartupStage startup "Loading instructions…"
         startupContext <-
             loadAgentsContext
+                stderrHandle
                 fullscreen
                 options
                 dialect
@@ -2390,8 +2644,13 @@ runAgentInitializedWithLock
             PersistenceDisabled -> pure ()
         progName <- getProgName
         markStartupStage startup "Connecting to provider…"
-        withCtrlCHandler interrupt $
-            withInterruptResume fullscreen progName persist RunQuit do
+        let runWithInterruptHandling action
+                | startup.startupBackground = action
+                | otherwise =
+                    withCtrlCHandler interrupt $
+                        withInterruptResume
+                            fullscreen progName persist RunQuit action
+        runWithInterruptHandling do
                 let shouldProbeAtStartup =
                         isJust fullscreen
                             && isNothing transition
@@ -2745,6 +3004,7 @@ runAgentInitializedWithLock
                                             , isProviderUnavailable err ->
                                                 chooseStartupProviderTransition
                                                     catalog
+                                                    cwd
                                                     fullscreen
                                                     (tokenProviderBillingMode
                                                         tokenProvider)
@@ -2855,8 +3115,8 @@ runAgentInitializedWithLock
                                             (UiSystemMessage
                                                 "Claude Code is in non-blocking restricted mode; restart with --yolo to bypass Claude Code permission checks.")
                                     Nothing -> do
-                                        color <- resolveColor stderr
-                                        putTextLn stderr $
+                                        color <- resolveColor stderrHandle
+                                        putTextLn stderrHandle $
                                             roleWarn color $
                                                 glyphWarn
                                                     <> "Claude Code is restricted; restart with --yolo to bypass Claude Code permission checks."
@@ -2999,7 +3259,7 @@ trackCredentialAccount accountRef accountIdRef selectionRef resolveLabel provide
 
 preparePersistence
     :: StorePool
-    -> Maybe FullscreenRuntime
+    -> StartupRuntime
     -> CliOptions
     -> OsPath
     -> ModelTarget
@@ -3010,7 +3270,7 @@ preparePersistence
     -> Maybe (SessionMeta, [SessionTurn])
     -> IO Persistence
 preparePersistence
-        sessionPool fullscreen options root target
+        sessionPool startup options root target
         retargetResumed cwd effort prompt resumed =
     case resumed of
         Just (meta, _) -> do
@@ -3075,10 +3335,10 @@ preparePersistence
                     handle.sessionMetaPath
                     activeMeta
             let message = "session: " <> activeMeta.metaId <> " (resumed)"
-            case fullscreen of
+            case startup.startupFullscreen of
                 Nothing -> do
-                    color <- resolveColor stderr
-                    putTextLn stderr
+                    color <- resolveColor startup.startupStderr
+                    putTextLn startup.startupStderr
                         (roleMuted color (glyphSession <> message))
                 Just runtime ->
                     emitUiEvent runtime (UiSystemMessage message)
@@ -3142,12 +3402,6 @@ printResumeHint progName = \case
 shouldPersist :: CliOptions -> Bool
 shouldPersist options = not (isOneShot options) || options.optSaveSession
 
-isJustCwd :: CliOptions -> Bool
-isJustCwd options = case options.optCwd of
-    Just _ -> True
-    Nothing -> False
-
-
 runSession
     :: SessionRequest
     -> SessionBackend
@@ -3157,13 +3411,15 @@ runSession SessionRequest{..} SessionBackend{..} = do
   ioLock <- newMVar ()
   let fullscreen = startup.startupFullscreen
       terminal = startup.startupTerminal
+      stdoutHandle = startup.startupStdout
+      stderrHandle = startup.startupStderr
       useColor = startup.startupUseColor
       stderrTty = startup.startupStderrTty
       stdoutTty = startup.startupStdoutTty
       setWindowTitle title =
           case fullscreen of
               Just runtime -> setFullscreenWindowTitle runtime title
-              Nothing -> setCliWindowTitle stdoutTty stdout title
+              Nothing -> setCliWindowTitle stdoutTty stdoutHandle title
       showTitleEvent = \case
         SessionTitleGenerated SessionTitleResult{..} ->
           case persist of
@@ -3195,8 +3451,8 @@ runSession SessionRequest{..} SessionBackend{..} = do
                                           emitUiEvent runtime
                                               (UiErrorMessage message)
                                       Nothing -> do
-                                          color <- resolveColor stderr
-                                          putTextLn stderr
+                                          color <- resolveColor stderrHandle
+                                          putTextLn stderrHandle
                                               (roleWarn color
                                                   (glyphWarn <> message))
                       _ -> pure ()
@@ -3474,7 +3730,15 @@ runSession SessionRequest{..} SessionBackend{..} = do
                 Just ctx -> resetSubagentRegistry ctx.multiRegistry
                 Nothing -> pure ()
             freshAgents <-
-                loadAgentsContext fullscreen options dialect home cwd [] Nothing
+                loadAgentsContext
+                    stderrHandle
+                    fullscreen
+                    options
+                    dialect
+                    home
+                    cwd
+                    []
+                    Nothing
             freshSkills <- loadSkillsCatalogQuiet options home projectRoot cwd
             (omitted, _) <-
                 installSkills freshAgents True freshSkills
@@ -3504,18 +3768,18 @@ runSession SessionRequest{..} SessionBackend{..} = do
         reportLearnedSkillWarning message =
             case fullscreen of
                 Nothing -> do
-                    color <- resolveColor stderr
-                    putTextLn stderr $
+                    color <- resolveColor stderrHandle
+                    putTextLn stderrHandle $
                         roleWarn color (glyphWarn <> message)
                 Just runtime ->
                     emitUiEvent runtime (UiSystemMessage message)
         reportSkillCatalog includeSummary catalog omitted =
             case fullscreen of
                 Nothing -> do
-                    color <- resolveColor stderr
+                    color <- resolveColor stderrHandle
                     when includeSummary do
                         let count = length catalog.catalogSkills
-                        putTextLn stderr $
+                        putTextLn stderrHandle $
                             roleMuted color
                                 (glyphSession
                                     <> "skills: loaded "
@@ -3524,13 +3788,13 @@ runSession SessionRequest{..} SessionBackend{..} = do
                                         then " skill"
                                         else " skills")
                     mapM_
-                        (putTextLn stderr
+                        (putTextLn stderrHandle
                             . roleWarn color
                             . (glyphWarn <>)
                             . formatSkillWarning)
                         catalog.catalogWarnings
                     when (omitted > 0) $
-                        putTextLn stderr $
+                        putTextLn stderrHandle $
                             roleWarn color
                                 (glyphWarn <> formatSkillOmission omitted)
                 Just runtime -> do
@@ -3565,8 +3829,8 @@ runSession SessionRequest{..} SessionBackend{..} = do
             , renderState = renderStateRef
             , renderColor = useColor
             , renderLock = ioLock
-            , renderStdout = stdout
-            , renderStderr = stderr
+            , renderStdout = stdoutHandle
+            , renderStderr = stderrHandle
             , renderModelRef = modelRef
             -- OSC 9;4 is ignored by terminals that do not implement it.
             -- Gate on the same TTY check as the in-pane spinner so pipes
@@ -3808,6 +4072,7 @@ runSession SessionRequest{..} SessionBackend{..} = do
             , sessionGrokRuntime = grokRuntime
             , sessionShellMode = currentShellMode
             , sessionSetShellMode = setShellMode
+            , sessionBackground = startup.startupBackground
             , sessionEscPaused = escPaused
             , sessionDraft = startup.startupSessionState.sessionDraft
             , sessionPreviewId = previewIdRef
@@ -3885,7 +4150,9 @@ runSession SessionRequest{..} SessionBackend{..} = do
                                 env
                                 request.managedTurnText
                                 inputs
-                                >>= either (die . Text.unpack) pure
+                                >>= either
+                                    (startupDie startup . Text.unpack)
+                                    pure
                         result <- runOneTurn env request.managedTurnText skillInputs
                         finishTurn env True result
                     Nothing ->
@@ -3898,7 +4165,9 @@ runSession SessionRequest{..} SessionBackend{..} = do
                                             env
                                             onboardingPrompt
                                             [UserMessage onboardingPrompt]
-                                            >>= either (die . Text.unpack) pure
+                                            >>= either
+                                                (startupDie startup . Text.unpack)
+                                                pure
                                     forM_ fullscreen \runtime ->
                                         emitUiEvent runtime
                                             (UiUserSubmitted onboardingPrompt)
@@ -3956,8 +4225,9 @@ finishTurn = SessionLifecycle.finishTurn sessionContinuation
 runSessionRecap :: Bool -> SessionEnv -> RecapKind -> IO ()
 runSessionRecap registerCancel env kind = do
     let fullscreen = env.sessionFullscreen
+        stdoutHandle = env.sessionRender.renderStdout
     transcriptRef <- newIORef =<< readLiveTranscript env.sessionConversation
-    color <- resolveColor stdout
+    color <- resolveColor stdoutHandle
     transcript <- readIORef transcriptRef
     let mainTurns = mainTurnCount transcript
         hasMessages = mainTurns > 0
@@ -3985,11 +4255,13 @@ runSessionRecap registerCancel env kind = do
                             then
                                 withTurnCancel env.sessionInterrupt cancel $
                                     case fullscreen of
-                                        Nothing ->
-                                            withEscCancel
-                                                cancel
-                                                env.sessionEscPaused
-                                                action
+                                        Nothing
+                                            | env.sessionBackground -> action
+                                            | otherwise ->
+                                                withEscCancel
+                                                    cancel
+                                                    env.sessionEscPaused
+                                                    action
                                         Just _ -> action
                             else action)
                     env.sessionBtwBackend
@@ -4057,7 +4329,7 @@ displayRecap env color summary =
         Just runtime ->
             emitUiEvent runtime (UiRecapReady summary)
         Nothing ->
-            putTextLn stdout (roleMuted color message)
+            putTextLn env.sessionRender.renderStdout (roleMuted color message)
 
 recapUnavailable :: SessionEnv -> Bool -> IO ()
 recapUnavailable env hasMessages =
@@ -4065,12 +4337,13 @@ recapUnavailable env hasMessages =
 
 recapFailed :: SessionEnv -> Text -> IO ()
 recapFailed env message = do
-    color <- resolveColor stderr
+    let stderrHandle = env.sessionRender.renderStderr
+    color <- resolveColor stderrHandle
     case env.sessionFullscreen of
         Just runtime ->
             emitUiEvent runtime (UiRecapUnavailable message)
         Nothing ->
-            putTextLn stderr (roleMuted color message)
+            putTextLn stderrHandle (roleMuted color message)
 
 runSessionTurnSummary :: SessionEnv -> IO ()
 runSessionTurnSummary env = do
@@ -6041,5 +6314,5 @@ putImagePreview previewIdRef color images = do
 putTrailingNewline :: RenderConfig -> IO ()
 putTrailingNewline render = do
     didPrint <- renderPrintedText render
-    if didPrint then putStrLn "" else pure ()
+    when didPrint (putTextLn render.renderStdout "")
 

--- a/packages/agent-cli/src/Agent/CLI/Session/Interaction.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Interaction.hs
@@ -19,7 +19,8 @@ import Agent.CLI.Command
 import Agent.CLI.Interrupt (withTurnCancel)
 import Agent.CLI.Options (ApprovalPolicy)
 import Agent.CLI.Render
-    ( putTextLn
+    ( RenderConfig(..)
+    , putTextLn
     , renderAssistantText
     )
 import Agent.CLI.ReplMode
@@ -64,7 +65,6 @@ import Data.IORef
     )
 import Data.Maybe (isJust)
 import Data.Text (Text)
-import System.IO (stderr, stdout)
 
 -- | Publish the current session prompt metadata to a retained fullscreen
 -- runtime before replaying a pending turn after a provider rebuild.
@@ -139,7 +139,9 @@ setSessionEffort env level = do
 runBtwQuestion :: Bool -> SessionEnv -> Text -> IO ()
 runBtwQuestion registerCancel env question = do
     let fullscreen = env.sessionFullscreen
-    color <- resolveColor stdout
+        stdoutHandle = env.sessionRender.renderStdout
+        stderrHandle = env.sessionRender.renderStderr
+    color <- resolveColor stdoutHandle
     transcriptRef <- newIORef =<< readLiveTranscript env.sessionConversation
     forM_ fullscreen \runtime ->
         emitUiEvent runtime
@@ -151,11 +153,13 @@ runBtwQuestion registerCancel env question = do
                     then
                         withTurnCancel env.sessionInterrupt cancel $
                             case fullscreen of
-                                Nothing ->
-                                    withEscCancel
-                                        cancel
-                                        env.sessionEscPaused
-                                        action
+                                Nothing
+                                    | env.sessionBackground -> action
+                                    | otherwise ->
+                                        withEscCancel
+                                            cancel
+                                            env.sessionEscPaused
+                                            action
                                 Just _ -> action
                     else action)
             env.sessionBtwBackend
@@ -166,16 +170,16 @@ runBtwQuestion registerCancel env question = do
         emitUiEvent runtime (UiSetNotice Nothing)
     case result of
         Left err -> do
-            errorColor <- resolveColor stderr
+            errorColor <- resolveColor stderrHandle
             let message = formatBtwError err
             case fullscreen of
                 Just runtime ->
                     emitUiEvent runtime (UiErrorMessage message)
                 Nothing ->
-                    putTextLn stderr (roleError errorColor message)
+                    putTextLn stderrHandle (roleError errorColor message)
         Right answer ->
             case fullscreen of
                 Just runtime ->
                     emitUiEvent runtime (UiAssistantHistory answer)
                 Nothing ->
-                    putTextLn stdout (renderAssistantText color answer)
+                    putTextLn stdoutHandle (renderAssistantText color answer)

--- a/packages/agent-cli/src/Agent/CLI/Session/Lifecycle.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Lifecycle.hs
@@ -9,6 +9,7 @@ import Agent.CLI.Notification
     ( AttentionRequest(InputRequested)
     , notifyAttention
     )
+import Agent.CLI.Error (formatApiErrorAt)
 import Agent.CLI.Project (saveProjectAccount)
 import Agent.CLI.Recap (RecapRequest(RecapTurnSummary))
 import Agent.CLI.Provider.Switch
@@ -27,6 +28,7 @@ import Agent.CLI.ProviderTransition
 import Agent.CLI.Runtime.Types
     ( PendingTurnPresentation(..)
     , RunResult(..)
+    , StartupFailure(..)
     )
 import Agent.CLI.Session.Interaction
     ( setSessionEffort
@@ -34,7 +36,11 @@ import Agent.CLI.Session.Interaction
     )
 import Agent.CLI.Session.Retry (waitAndRetryPendingTurn)
 import Agent.CLI.SessionEnv (SessionEnv(..))
-import Agent.CLI.Render (RenderConfig, renderPrintedText)
+import Agent.CLI.Render
+    ( RenderConfig(..)
+    , putTextLn
+    , renderPrintedText
+    )
 import Agent.CLI.TUI.App
     ( emitUiEvent
     , hasQueuedFullscreenInput
@@ -42,7 +48,8 @@ import Agent.CLI.TUI.App
 import Agent.CLI.Turn (runOneTurn)
 import Agent.Tools.PlanMode (PlanModeEnv(..))
 import Agent.TUI.Model (UiEvent(..))
-import Control.Monad (when)
+import Control.Exception.Safe (throwIO)
+import Control.Monad (unless, when)
 import Data.IORef
     ( readIORef
     , writeIORef
@@ -51,7 +58,6 @@ import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Time.Clock (getCurrentTime)
 import System.Exit (exitFailure)
-import System.IO (stderr)
 
 data SessionContinuation = SessionContinuation
     { resumeSession :: SessionEnv -> IO RunResult
@@ -137,7 +143,10 @@ finishTurnWithCooldownRetry continuation allowCooldownRetry env exitAfter = \cas
             else continuation.resumeSession env
     TurnFailed ->
         if exitAfter
-            then exitFailure
+            then
+                if env.sessionBackground
+                    then throwIO (StartupFailure "agent turn failed")
+                    else exitFailure
             else do
                 case env.sessionFullscreen of
                     Nothing -> putTrailingNewline env.sessionRender
@@ -175,12 +184,26 @@ finishTurnWithCooldownRetry continuation allowCooldownRetry env exitAfter = \cas
                         Just providerTransition ->
                             pure (RunSwitchProvider providerTransition)
                         Nothing -> do
-                            reportProviderUnavailable
-                                env.sessionFullscreen apiError
+                            if env.sessionBackground
+                                then
+                                    putTextLn
+                                        env.sessionRender.renderStderr
+                                        (formatApiErrorAt now apiError)
+                                else
+                                    reportProviderUnavailable
+                                        env.sessionFullscreen apiError
                             if exitAfter
-                                then exitFailure
+                                then
+                                    if env.sessionBackground
+                                        then throwIO
+                                            (StartupFailure
+                                                "agent provider unavailable")
+                                        else exitFailure
                                 else do
-                                    notifyAttention stderr InputRequested
+                                    unless env.sessionBackground $
+                                        notifyAttention
+                                            env.sessionRender.renderStderr
+                                            InputRequested
                                     continuation.resumeSessionWithDraft
                                         env
                                         pending.pendingPromptText
@@ -193,11 +216,11 @@ continueAfterTurn continuation env = do
     queued <- case env.sessionFullscreen of
         Nothing -> pure False
         Just runtime -> hasQueuedFullscreenInput runtime
-    when (not queued) $
-        notifyAttention stderr InputRequested
+    when (not queued && not env.sessionBackground) $
+        notifyAttention env.sessionRender.renderStderr InputRequested
     continuation.resumeSession env
 
 putTrailingNewline :: RenderConfig -> IO ()
 putTrailingNewline render = do
     didPrint <- renderPrintedText render
-    when didPrint (putStrLn "")
+    when didPrint (putTextLn render.renderStdout "")

--- a/packages/agent-cli/src/Agent/CLI/Session/Retry.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Retry.hs
@@ -9,7 +9,8 @@ import Agent.CLI.Interrupt (withTurnCancel)
 import Agent.CLI.ProviderFallback (automaticRetryCountdownText)
 import Agent.CLI.ProviderTransition (PendingTurn(..))
 import Agent.CLI.Render
-    ( clearThinking
+    ( RenderConfig(..)
+    , clearThinking
     , putTextLn
     , renderEvent
     )
@@ -42,7 +43,6 @@ import Data.Time.Clock
     , diffUTCTime
     , getCurrentTime
     )
-import System.IO (stderr)
 import System.Timeout (timeout)
 
 waitAndRetryPendingTurn
@@ -91,8 +91,10 @@ waitAndRetryPendingTurn resumeDraft retryPending env delay pending = do
             poll Nothing
         waitAction = case env.sessionFullscreen of
             Just _ -> waitForCancel
-            Nothing ->
-                withEscCancel cancel env.sessionEscPaused waitForCancel
+            Nothing
+                | env.sessionBackground -> waitForCancel
+                | otherwise ->
+                    withEscCancel cancel env.sessionEscPaused waitForCancel
     setPersistenceActivity
         env.sessionPersist
         "provider_cooldown"
@@ -120,8 +122,9 @@ waitAndRetryPendingTurn resumeDraft retryPending env delay pending = do
                                 (infoNotice
                                     "automatic retry cancelled")))
                 Nothing -> do
-                    color <- resolveColor stderr
-                    putTextLn stderr
+                    let output = env.sessionRender.renderStderr
+                    color <- resolveColor output
+                    putTextLn output
                         (roleMuted color "automatic retry cancelled")
             if pending.pendingExitAfter
                 then pure RunQuit
@@ -133,8 +136,9 @@ waitAndRetryPendingTurn resumeDraft retryPending env delay pending = do
                         (UiSetNotice
                             (Just (successNotice "retrying turn")))
                 Nothing -> do
-                    color <- resolveColor stderr
-                    putTextLn stderr
+                    let output = env.sessionRender.renderStderr
+                    color <- resolveColor output
+                    putTextLn output
                         (roleMuted color (glyphOk <> "retrying turn"))
             setPersistenceActivity
                 env.sessionPersist

--- a/packages/agent-cli/src/Agent/CLI/Session/Runtime/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runtime/Types.hs
@@ -77,6 +77,7 @@ import Data.Time.Clock
     ( NominalDiffTime
     , UTCTime
     )
+import System.IO (Handle)
 import System.OsPath (OsPath)
 
 data SessionBackend = SessionBackend
@@ -147,6 +148,9 @@ data StartupRuntime = StartupRuntime
     , startupUiRuntimeRef :: !(IORef (Maybe FullscreenRuntime))
     , startupFullscreen :: !(Maybe FullscreenRuntime)
     , startupTerminal :: !TerminalCapabilities
+    , startupStdout :: !Handle
+    , startupStderr :: !Handle
+    , startupBackground :: !Bool
     , startupUseColor :: !Bool
     , startupStderrTty :: !Bool
     , startupStdinTty :: !Bool

--- a/packages/agent-cli/src/Agent/CLI/SessionEnv.hs
+++ b/packages/agent-cli/src/Agent/CLI/SessionEnv.hs
@@ -70,6 +70,7 @@ data SessionEnv = SessionEnv
     , sessionGrokRuntime :: !(Maybe GrokRuntimeControl)
     , sessionShellMode :: !(IO ShellMode)
     , sessionSetShellMode :: !(ShellMode -> IO Text)
+    , sessionBackground :: !Bool
     , sessionEscPaused :: !(IORef Bool)
     , sessionDraft :: !(IORef Text)
     , sessionPreviewId :: !(IORef Int)

--- a/packages/agent-cli/src/Agent/CLI/Skills.hs
+++ b/packages/agent-cli/src/Agent/CLI/Skills.hs
@@ -27,7 +27,7 @@ import Agent.CLI.Style
     , roleWarn
     )
 import Agent.CLI.Terminal (resolveColor)
-import Agent.OsPath (toText)
+import Agent.OsPath (toText, unsafeToFilePath)
 import Agent.Skills
 import Agent.Tools.Types (ToolEnv, setToolSkillRoots)
 import Control.Monad (void, when)
@@ -80,7 +80,7 @@ loadSkillsCatalogQuiet
 loadSkillsCatalogQuiet options home projectRoot cwd
     | not options.optSkills = pure (SkillCatalog [] [])
     | otherwise = do
-        builtinRoot <- packagedSkillsRoot
+        builtinRoot <- packagedSkillsRoot cwd
         discoverSkills SkillDiscoverOptions
             { skillsHome = home
             , skillsProjectRoot = projectRoot
@@ -90,14 +90,14 @@ loadSkillsCatalogQuiet options home projectRoot cwd
                 [(AgentSkills, unsafeEncodeUtf builtinRoot)]
             }
 
-packagedSkillsRoot :: IO FilePath
-packagedSkillsRoot = do
+packagedSkillsRoot :: OsPath -> IO FilePath
+packagedSkillsRoot cwd = do
     installedSkill <- getDataFileName "skills/add-model/SKILL.md"
     executable <- Environment.getExecutablePath
-    cwd <- Directory.getCurrentDirectory
     let roots =
             take 16 (iterate FilePath.takeDirectory executable)
-                <> take 8 (iterate FilePath.takeDirectory cwd)
+                <> take 8
+                    (iterate FilePath.takeDirectory (unsafeToFilePath cwd))
         candidates =
             FilePath.takeDirectory (FilePath.takeDirectory installedSkill)
                 : [ root FilePath.</> "packages/agent-cli/skills"

--- a/packages/agent-cli/src/Agent/CLI/Startup/Auth.hs
+++ b/packages/agent-cli/src/Agent/CLI/Startup/Auth.hs
@@ -55,7 +55,6 @@ import Data.Time.Clock
     , getCurrentTime
     )
 import System.Exit (die)
-import System.IO (stderr)
 
 setStartupNotice :: Maybe FullscreenRuntime -> Text -> IO ()
 setStartupNotice fullscreen message =
@@ -83,7 +82,10 @@ markStartupStage startup label = do
 startupDie :: StartupRuntime -> String -> IO a
 startupDie startup message =
     case startup.startupFullscreen of
-        Nothing -> die message
+        Nothing
+            | startup.startupBackground ->
+                throwIO (StartupFailure message)
+            | otherwise -> die message
         Just _ -> throwIO (StartupFailure message)
 
 loadStartupAuth
@@ -154,7 +156,7 @@ runCredentialOnboarding startup runtime = do
                         Just (provider, _) -> do
                             connected <-
                                 withFullscreenSuspended runtime $
-                                    resolveColor stderr >>= \color ->
+                                    resolveColor startup.startupStderr >>= \color ->
                                         connectProviderAccount color provider
                             case connected of
                                 Nothing -> loop

--- a/packages/agent-cli/src/Agent/CLI/StartupContext.hs
+++ b/packages/agent-cli/src/Agent/CLI/StartupContext.hs
@@ -34,13 +34,14 @@ import Data.IORef
 import Data.Maybe (isJust)
 import Data.Text (Text)
 import qualified Data.Text as Text
-import System.IO (stderr)
+import System.IO (Handle)
 import System.OsPath (OsPath)
 
 -- | Discover AGENTS.md once for a fresh session. Resumed transcripts keep
 -- whatever instructions were already in history.
 loadAgentsContext
-    :: Maybe FullscreenRuntime
+    :: Handle
+    -> Maybe FullscreenRuntime
     -> CliOptions
     -> Dialect
     -> OsPath
@@ -48,7 +49,8 @@ loadAgentsContext
     -> [ResponseItem]
     -> Maybe Text
     -> IO (IORef (Maybe Text))
-loadAgentsContext fullscreen options dialect home cwd initialItems initialPrevious
+loadAgentsContext
+        stderrHandle fullscreen options dialect home cwd initialItems initialPrevious
     | not options.optAgentsMd = newIORef Nothing
     | not (null initialItems) || isJust initialPrevious = newIORef Nothing
     | otherwise = do
@@ -68,8 +70,8 @@ loadAgentsContext fullscreen options dialect home cwd initialItems initialPrevio
                             <> if length files == 1 then " file" else " files"
                 case fullscreen of
                     Nothing -> do
-                        color <- resolveColor stderr
-                        putTextLn stderr
+                        color <- resolveColor stderrHandle
+                        putTextLn stderrHandle
                             (roleMuted color (glyphSession <> message))
                     Just runtime ->
                         emitUiEvent runtime (UiSystemMessage message)

--- a/packages/agent-cli/src/Agent/CLI/Turn.hs
+++ b/packages/agent-cli/src/Agent/CLI/Turn.hs
@@ -140,7 +140,7 @@ import Data.Time.Format (defaultTimeLocale, formatTime)
 import Data.Time.LocalTime (getZonedTime, localDay, zonedTimeToLocalTime)
 import System.Environment (lookupEnv)
 import System.Exit (ExitCode(..))
-import System.IO (stderr, stdout)
+import System.IO (Handle)
 import System.Info (os)
 import qualified System.OsPath
 import System.Process
@@ -158,6 +158,7 @@ runOneTurn env@SessionEnv
     , sessionPersist = persist
     , sessionPlanMode = planMode
     , sessionStartupContext = startupContext
+    , sessionBackground = background
     , sessionEscPaused = escPaused
     , sessionInterrupt = interrupt
     , sessionStoreRoot = storeRoot
@@ -171,12 +172,14 @@ runOneTurn env@SessionEnv
     , sessionAbortSubagentTurn = abortSubagentTurn
     , sessionOnPersisted = onPersisted
     } promptText inputs = do
+  let stdoutHandle = render.renderStdout
+      stderrHandle = render.renderStderr
   -- Clear the prior turn before publishing this flag to Ctrl-C / Esc.
   -- Resetting inside runLoopInputs could erase the one-shot Esc signal.
   resetCancel config.loopCancel
   writeIORef env.sessionRestartEffort Nothing
   withTurnCancel interrupt config.loopCancel $
-    (if isJust fullscreen
+    (if isJust fullscreen || background
         then id
         else withEscCancel config.loopCancel escPaused) do
     applyPendingSessionTitles env
@@ -205,8 +208,8 @@ runOneTurn env@SessionEnv
                             (UiSystemMessage
                                 ("session: " <> handle.sessionMeta.metaId))
                     Nothing -> do
-                        color <- resolveColor stderr
-                        putTextLn stderr
+                        color <- resolveColor stderrHandle
+                        putTextLn stderrHandle
                             (roleMuted color
                                 (glyphSession <> "session: "
                                     <> handle.sessionMeta.metaId))
@@ -264,7 +267,7 @@ runOneTurn env@SessionEnv
     startedAt <- stateStartedAt <$> readIORef render.renderState
     wallStarted <- getCurrentTime
     when (isNothing fullscreen && terminal.terminalSemanticPrompts) $
-        emitTerminalSequence terminal stdout osc133CommandStart
+        emitTerminalSequence terminal stdoutHandle osc133CommandStart
     rootTurnId <- beginSubagentTurn
     execution <- runLoopInputsDetailed config prev turnInputs
         `onException`
@@ -320,7 +323,7 @@ runOneTurn env@SessionEnv
         (Nothing, Left cancelled@(LoopCancelled _)) -> do
             restorePlanStateAfterIncomplete planMode initialPlanState
             finishTerminal (isNothing fullscreen)
-                terminal wallStarted finishedAt 130 Nothing
+                stdoutHandle terminal wallStarted finishedAt 130 Nothing
             abortSubagentTurn rootTurnId
             -- turnInputs already contains any startup context consumed above.
             -- Checkpoint it instead of restoring it separately, which would
@@ -336,9 +339,10 @@ runOneTurn env@SessionEnv
                         (UiSystemMessage
                             ("cancelled · " <> elapsedDetail model))
                 Nothing -> do
-                    color <- resolveColor stderr
-                    putTextLn stderr (formatLoopErrorColored color cancelled)
-                    putTextLn stderr
+                    color <- resolveColor stderrHandle
+                    putTextLn stderrHandle
+                        (formatLoopErrorColored color cancelled)
+                    putTextLn stderrHandle
                         (formatTurnStatus color "cancelled" (elapsedDetail model))
             persistIncomplete (inputOnlyTurnItems prepared) "cancelled"
             pure TurnCancelled
@@ -358,7 +362,7 @@ runOneTurn env@SessionEnv
                                 emitUiEvent runtime
                                     (UiTurnEnded BlockFailed)
                         finishTerminal (isNothing fullscreen)
-                            terminal wallStarted finishedAt 1
+                            stdoutHandle terminal wallStarted finishedAt 1
                             (Just "Agent provider unavailable")
                         planState <- readIORef planMode.planStateRef
                         pure $ TurnProviderUnavailable apiError PendingTurn
@@ -370,7 +374,7 @@ runOneTurn env@SessionEnv
                 _ -> do
                     restorePlanStateAfterIncomplete planMode initialPlanState
                     finishTerminal (isNothing fullscreen)
-                        terminal wallStarted finishedAt 1
+                        stdoutHandle terminal wallStarted finishedAt 1
                         (Just "Agent turn failed")
                     commitConversationPatch
                         (finishConversation prepared ConversationFailed)
@@ -386,17 +390,18 @@ runOneTurn env@SessionEnv
                                             <> "\n"
                                             <> elapsedDetail model))
                         Nothing -> do
-                            color <- resolveColor stderr
-                            putTextLn stderr
+                            color <- resolveColor stderrHandle
+                            putTextLn stderrHandle
                                 (formatLoopErrorColoredAt color finishedAt err)
-                            putTextLn stderr
+                            putTextLn stderrHandle
                                 (formatTurnStatus color "error" (elapsedDetail model))
                     persistIncomplete (inputOnlyTurnItems prepared)
                         (formatLoopErrorPersistedAt finishedAt err)
                     pure TurnFailed
         (Nothing, Right loopResult) -> do
             finishTerminal (isNothing fullscreen)
-                terminal wallStarted finishedAt 0 (Just "Agent finished")
+                stdoutHandle terminal wallStarted finishedAt 0
+                (Just "Agent finished")
             finishSubagentTurn rootTurnId
             let assistantText =
                     fmap stripBracketedTimestamps loopResult.finalText
@@ -424,16 +429,16 @@ runOneTurn env@SessionEnv
                                     (successNotice
                                         ("Finished · " <> detail))))
                     Nothing -> do
-                        color <- resolveColor stderr
-                        putTextLn stderr
+                        color <- resolveColor stderrHandle
+                        putTextLn stderrHandle
                             (formatTurnStatus color "ok" detail)
             followUp <- handleProposedPlan planMode loopResult.finalText
             printedText <- renderPrintedText render
             case (fullscreen, printedText, assistantText) of
                 (Just _, _, _) -> pure ()
                 (Nothing, False, Just text) | not (Text.null (Text.strip text)) -> do
-                    useColor <- resolveColor stdout
-                    putTextLn stdout (renderAssistantText useColor text)
+                    useColor <- resolveColor stdoutHandle
+                    putTextLn stdoutHandle (renderAssistantText useColor text)
                 _ -> pure ()
             let newItems =
                     turnNewItems beforeItems execution.executionState
@@ -665,21 +670,23 @@ restorePlanStateAfterIncomplete planMode =
 
 finishTerminal
     :: Bool
+    -> Handle
     -> TerminalCapabilities
     -> UTCTime
     -> UTCTime
     -> Int
     -> Maybe Text
     -> IO ()
-finishTerminal semanticPrompts terminal started finished exitCode notification = do
+finishTerminal
+        semanticPrompts output terminal started finished exitCode notification = do
     when (semanticPrompts && terminal.terminalSemanticPrompts) $
-        emitTerminalSequence terminal stdout
+        emitTerminalSequence terminal output
             (osc133CommandFinished (Just exitCode))
     let seconds = realToFrac (diffUTCTime finished started) :: Double
     case notification of
         Just message
             | exitCode /= 0 || seconds >= 10 ->
-                notifyTerminal terminal stdout message
+                notifyTerminal terminal output message
         _ -> pure ()
 
 handleProposedPlan

--- a/packages/agent-cli/test/Agent/CLI/AgentSessionsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/AgentSessionsSpec.hs
@@ -8,7 +8,7 @@ import Agent.CLI.Session
 import Agent.CLI.SessionLock
 import Agent.Dialect (DialectId(..))
 import Agent.Loop (defaultLoopDispatch)
-import System.OsPath (OsPath, decodeUtf, unsafeEncodeUtf)
+import System.OsPath (OsPath, decodeUtf, unsafeEncodeUtf, (</>))
 import Agent.Provider (Provider(..))
 import Agent.ToolDispatch
     ( ToolCallResult(..)
@@ -31,6 +31,7 @@ import Agent.Store.Postgres.Connection (StorePool)
 import Agent.Store.Postgres.Managed (stopManagedPostgres)
 import Agent.Store.Types (renderStoreError)
 import Control.Concurrent (threadDelay)
+import Control.Concurrent.MVar (newEmptyMVar, putMVar, takeMVar)
 import Control.Exception.Safe (SomeException, bracket, finally, try)
 import Data.IORef
 import qualified Data.Text as Text
@@ -40,7 +41,7 @@ import qualified System.Directory as Directory
 import System.Environment (lookupEnv, setEnv, unsetEnv)
 import qualified System.FilePath as FilePath
 import System.Posix.Temp (mkdtemp)
-import System.Posix.Process (forkProcess, getProcessStatus)
+import System.Posix.Process (forkProcess, getProcessID, getProcessStatus)
 import System.Posix.Signals (sigKILL, signalProcess)
 import Test.Hspec
 
@@ -155,6 +156,80 @@ spec = describe "Agent.CLI.AgentSessions" do
             result <- runTool env "read_agent_session"
                 "{\"session_id\":\"../outside\"}"
             result `shouldSatisfy` Text.isInfixOf "invalid session id"
+
+    it "runs CLI session turns inside the current process" $
+        withTempSessionThreadManager ["same-process"] \_ manager -> do
+            parentPid <- getProcessID
+            observedPid <- newEmptyMVar
+            launched <- launchSessionThread manager "same-process" do
+                getProcessID >>= putMVar observedPid
+                pure (Right ())
+            launched `shouldBe` Right "started session same-process"
+            takeMVar observedPid `shouldReturn` parentPid
+            waitForThreadStatus manager "same-process" "completed"
+
+    it "serializes and reports in-process session turns" $
+        withTempSessionThreadManager ["blocked", "failed"] \_ manager -> do
+            started <- newEmptyMVar
+            release <- newEmptyMVar
+            first <- launchSessionThread manager "blocked" do
+                putMVar started ()
+                takeMVar release
+                pure (Right ())
+            first `shouldBe` Right "started session blocked"
+            takeMVar started
+            second <- launchSessionThread
+                manager
+                "blocked"
+                (pure (Right ()))
+            second `shouldSatisfy` \case
+                Left err -> "already running" `Text.isInfixOf` err
+                Right _ -> False
+            putMVar release ()
+            waitForThreadStatus manager "blocked" "completed"
+
+            failed <- launchSessionThread
+                manager
+                "failed"
+                (pure (Left "boom"))
+            failed `shouldBe` Right "started session failed"
+            waitForThreadStatus manager "failed" "failed (boom)"
+
+    it "cancels and joins in-process turns when the runtime closes" $ do
+        withTempSessionThreadManager ["long-running"] \_ manager -> do
+            started <- newEmptyMVar
+            stopped <- newEmptyMVar
+            launched <- launchSessionThread manager "long-running" $
+                (do
+                    putMVar started ()
+                    threadDelay 30000000
+                    pure (Right ()))
+                `finally` putMVar stopped ()
+            launched `shouldBe` Right "started session long-running"
+            takeMVar started
+            closeSessionThreadManager manager
+            takeMVar stopped
+            launchSessionThread manager "later" (pure (Right ()))
+                `shouldReturn` Left "agent session manager is closed"
+
+    it "evicts terminal in-process status before checking external locks" $
+        withTempSessionThreadManager ["terminal"] \root manager -> do
+            launched <- launchSessionThread
+                manager
+                "terminal"
+                (pure (Right ()))
+            launched `shouldBe` Right "started session terminal"
+            waitForThreadStatus manager "terminal" "completed"
+            acquired <-
+                acquireSessionLock
+                    (root </> unsafeEncodeUtf "terminal")
+                    "terminal"
+            lock <- either (fail . Text.unpack) pure acquired
+            sessionThreadStatus manager "terminal"
+                `shouldReturn` "running"
+            releaseSessionLock lock
+            sessionThreadStatus manager "terminal"
+                `shouldReturn` "idle"
 
     it "serializes background turns with a cross-process session lock" $
         withTempStoreDir "agent-session-runtime-" \pool root -> do
@@ -507,6 +582,44 @@ waitForSessionStatus manager sessionId expected = go (100 :: Int)
             if actual == expected
                 then pure ()
                 else threadDelay 20000 >> go (attempts - 1)
+
+waitForThreadStatus
+    :: SessionThreadManager
+    -> Text.Text
+    -> Text.Text
+    -> IO ()
+waitForThreadStatus manager sessionId expected = go (100 :: Int)
+  where
+    go attempts
+        | attempts <= 0 = do
+            actual <- sessionThreadStatus manager sessionId
+            actual `shouldBe` expected
+        | otherwise = do
+            actual <- sessionThreadStatus manager sessionId
+            if actual == expected
+                then pure ()
+                else threadDelay 20000 >> go (attempts - 1)
+
+withTempSessionThreadManager
+    :: [Text.Text]
+    -> (OsPath -> SessionThreadManager -> IO a)
+    -> IO a
+withTempSessionThreadManager sessionIds action = do
+    tmp <- Directory.getTemporaryDirectory
+    bracket
+        (mkdtemp (tmp FilePath.</> "ha-threads"))
+        Directory.removeDirectoryRecursive
+        \basePath -> do
+            mapM_
+                (Directory.createDirectory
+                    . (basePath FilePath.</>)
+                    . Text.unpack)
+                sessionIds
+            let root = fromFilePath basePath
+            bracket
+                (newSessionThreadManager root)
+                closeSessionThreadManager
+                (action root)
 
 shellQuote :: FilePath -> String
 shellQuote path = "'" <> concatMap escape path <> "'"


### PR DESCRIPTION
## Summary

- Run `create_agent_session` and `send_agent_session_message` turns as tracked async workers in the current CLI process.
- Reuse the parent process runtime and MCP supervisor instead of launching another `agent-cli` executable.
- Keep gateway-managed `agent-cli` subprocesses unchanged.
- Isolate background-session output and working-directory context from process-global terminal state.
- Track per-session lifecycle, serialize duplicate turns, and cancel/join workers during runtime shutdown.

This removes the CLI dependency on locating `agent-cli` via `HASKELL_AGENT_EXECUTABLE` for persisted session turns.

## Validation

- `nix develop -c env TMPDIR=/tmp cabal build agent-cli`
- `nix develop -c env TMPDIR=/tmp cabal test agent-cli:agent-cli-test --test-options='--match Agent.CLI.AgentSessions'` — 23 examples, 0 failures
- `nix develop -c env TMPDIR=/tmp cabal test agent-cli:agent-cli-test` — 950 examples, 0 failures
- `git diff --check origin/master...HEAD`
