### PR TITLE
feat(tui): hide pending todos once the turn is idle

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -2332,11 +2332,18 @@ drawLiveTodos ui =
                 vBox (map (vLimit 1 . drawLiveTodoLine) lines_)
 
 drawLiveTodoLine :: Text -> Widget Name
-drawLiveTodoLine line
-    | "… +" `Text.isPrefixOf` line =
-        withAttr Theme.mutedAttr (txt line)
-    | otherwise =
-        withAttr (todoStatusAttr (todoLineStatusFromText line)) (txt line)
+drawLiveTodoLine line =
+    Widget Fixed Fixed do
+        context <- getContext
+        let truncated = truncateDisplayText context.availWidth line
+            painted
+                | "… +" `Text.isPrefixOf` line =
+                    withAttr Theme.mutedAttr (terminalTxt truncated)
+                | otherwise =
+                    withAttr
+                        (todoStatusAttr (todoLineStatusFromText line))
+                        (terminalTxt truncated)
+        render painted
 
 todoLineStatusFromText :: Text -> TodoDisplayStatus
 todoLineStatusFromText line

--- a/packages/agent-tui/src/Agent/TUI/Model.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model.hs
@@ -41,6 +41,7 @@ import Agent.TUI.Presentation
     , formatSearchReplaceDiff
     , formatToolOutput
     , todoListFromToolOutput
+    , todoListHasInProgress
     , todoListHasOpenWork
     , toolCallInput
     , toolCallTitle
@@ -269,11 +270,13 @@ initialUiState = UiState
     , uiTodos = []
     }
 
--- | Checklist shown above the prompt. Hidden once every item is done so a
--- finished list does not linger into the next turn.
+-- | Checklist shown above the prompt during a turn, or while an item is still
+-- in progress. Pending-only lists hide once the session is idle so they do
+-- not linger into the next prompt.
 visibleTodoList :: UiState -> [TodoDisplayLine]
 visibleTodoList state
-    | todoListHasOpenWork state.uiTodos = state.uiTodos
+    | todoListHasInProgress state.uiTodos = state.uiTodos
+    | state.uiRunning && todoListHasOpenWork state.uiTodos = state.uiTodos
     | otherwise = []
 
 -- | Status-only blocks can appear before the first user turn, but the

--- a/packages/agent-tui/src/Agent/TUI/Presentation.hs
+++ b/packages/agent-tui/src/Agent/TUI/Presentation.hs
@@ -15,6 +15,7 @@ module Agent.TUI.Presentation
     , todoListFromToolOutput
     , summarizeToolCall
     , todoCallPreview
+    , todoListHasInProgress
     , todoListHasOpenWork
     , todoStatusGlyph
     , toolCallInput
@@ -208,6 +209,10 @@ todoListHasOpenWork :: [TodoDisplayLine] -> Bool
 todoListHasOpenWork =
     any \line ->
         line.todoLineStatus `elem` [TodoDisplayPending, TodoDisplayInProgress]
+
+todoListHasInProgress :: [TodoDisplayLine] -> Bool
+todoListHasInProgress =
+    any \line -> line.todoLineStatus == TodoDisplayInProgress
 
 -- | Replace the live list only when tool output is an actual checklist.
 -- Unrecognized output is ignored so ordinary tools cannot clobber it.

--- a/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
@@ -724,6 +724,38 @@ spec = describe "fullscreen UI reducer" do
         done.uiTodos
             `shouldBe` [TodoDisplayLine TodoDisplayCompleted "Find and clone repos"]
 
+    it "hides pending todos once the turn is idle" do
+        let call =
+                functionToolCall
+                    "todo-1"
+                    "todo_write"
+                    "{\"todos\":[{\"id\":\"1\",\"content\":\"Inspect Model.hs\"}]}"
+            result = ToolCallResult
+                { callId = "todo-1"
+                , output =
+                    "- [completed] 1: Open the file\n\
+                    \- [pending] 2: Inspect Model.hs"
+                , callKind = FunctionCallKind
+                }
+            running =
+                apply
+                    [ UiLoop TurnStarted
+                    , UiLoop (ToolStarted call)
+                    , UiLoop (ToolFinished result)
+                    ]
+            idle =
+                apply
+                    [ UiLoop TurnStarted
+                    , UiLoop (ToolStarted call)
+                    , UiLoop (ToolFinished result)
+                    , UiLoop (TurnFinished (emptyTurnOutput "r1" [] Nothing))
+                    ]
+        map (.todoLineText) (visibleTodoList running)
+            `shouldBe` ["Open the file", "Inspect Model.hs"]
+        visibleTodoList idle `shouldBe` []
+        map (.todoLineText) idle.uiTodos
+            `shouldBe` ["Open the file", "Inspect Model.hs"]
+
     it "does not let ordinary tool output clobber the live todo list" do
         let todoCall =
                 functionToolCall

--- a/packages/agent-tui/test/Agent/TUI/PresentationSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/PresentationSpec.hs
@@ -205,6 +205,11 @@ spec = describe "tool presentation" do
                 , TodoDisplayLine TodoDisplayPending "Investigate Codex"
                 ]
         todoListHasOpenWork todos `shouldBe` True
+        todoListHasInProgress todos `shouldBe` True
+        todoListHasOpenWork [TodoDisplayLine TodoDisplayPending "later"]
+            `shouldBe` True
+        todoListHasInProgress [TodoDisplayLine TodoDisplayPending "later"]
+            `shouldBe` False
         todoListHasOpenWork [TodoDisplayLine TodoDisplayCompleted "done"]
             `shouldBe` False
         liveTodoPanelLines 2 todos


### PR DESCRIPTION
## Summary
- Keep the live todo list visible during a turn, or while any item is still in progress.
- Hide pending-only lists once the session is idle so they do not linger above the next prompt.
- Clip live todo rows to the available terminal width.

## Test plan
- [x] `cabal test agent-tui:test:agent-tui-test`
- [x] CLI tests matching `live todo`
- [ ] Visual check that a pending-only list disappears after `Finished`