### PR TITLE
Fix oversized tool arguments during remote compaction

### DIFF
--- a/packages/agent-openai/src/Agent/OpenAI/Compaction.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Compaction.hs
@@ -4,6 +4,7 @@ module Agent.OpenAI.Compaction
     ( summaryPrefix
     , summarizationPrompt
     , remoteCompactionRetainedTokenBudget
+    , remoteCompactionMaxStringLength
     , compactionTriggerItem
     , buildRemoteCompactionRequest
     , trimRemoteCompactionHistoryToFit
@@ -45,6 +46,10 @@ summaryPrefix = "Compacted conversation summary:"
 -- | Matches the retained-message budget used by Codex remote compaction v2.
 remoteCompactionRetainedTokenBudget :: Int
 remoteCompactionRetainedTokenBudget = 64_000
+
+-- | Maximum length accepted for an individual string in a compaction input.
+remoteCompactionMaxStringLength :: Int
+remoteCompactionMaxStringLength = 1_048_576
 
 maxRetainedAgentMessageTokens :: Int
 maxRetainedAgentMessageTokens = 10_000
@@ -88,11 +93,13 @@ trimRemoteCompactionHistoryToFit
     -> [ResponseItem]
     -> [ResponseItem]
 trimRemoteCompactionHistoryToFit contextWindow instructionText history =
-    go initialTokens (reverse history) []
+    go initialTokens (reverse sanitizedHistory) []
   where
+    sanitizedHistory = map sanitizeOversizedToolCall history
+
     initialTokens =
         maybe 0 estimateTokens instructionText
-            + estimateItemsTokens history
+            + estimateItemsTokens sanitizedHistory
 
     go _ [] rewritten = rewritten
     go tokens remaining rewritten
@@ -108,6 +115,40 @@ trimRemoteCompactionHistoryToFit contextWindow instructionText history =
                             - estimateItemsTokens [item]
                             + estimateItemsTokens [replacement]
                 in go nextTokens remaining (replacement : rewritten)
+
+oversizedToolArgumentsMessage :: Text
+oversizedToolArgumentsMessage =
+    "Tool arguments exceeded the provider string limit and were omitted during compaction."
+
+oversizedFunctionArguments :: Text
+oversizedFunctionArguments =
+    TextEncoding.decodeUtf8 . LBS.toStrict . Aeson.encode $ Aeson.object
+        [ "compaction_notice" Aeson..= oversizedToolArgumentsMessage
+        ]
+
+sanitizeOversizedToolCall :: ResponseItem -> ResponseItem
+sanitizeOversizedToolCall = \case
+    FunctionCallItem call
+        | Text.length call.arguments > remoteCompactionMaxStringLength ->
+            FunctionCallItem FunctionCall
+                { itemId = call.itemId
+                , callId = call.callId
+                , name = call.name
+                , arguments = oversizedFunctionArguments
+                , status = call.status
+                , extraFields = call.extraFields
+                }
+    CustomToolCallItem call
+        | Text.length call.input > remoteCompactionMaxStringLength ->
+            CustomToolCallItem CustomToolCall
+                { itemId = call.itemId
+                , callId = call.callId
+                , name = call.name
+                , input = oversizedToolArgumentsMessage
+                , status = call.status
+                , extraFields = call.extraFields
+                }
+    item -> item
 
 rewriteOversizedToolOutput :: ResponseItem -> Maybe ResponseItem
 rewriteOversizedToolOutput = \case

--- a/packages/agent-openai/test/Agent/OpenAI/CompactionSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/CompactionSpec.hs
@@ -11,6 +11,7 @@ import Agent.Responses.Types
 import qualified Data.Aeson.KeyMap as KeyMap
 import Data.Either (isLeft)
 import qualified Data.Text as Text
+import qualified Data.Text.Encoding as TextEncoding
 import Test.Hspec
 
 spec :: Spec
@@ -139,6 +140,65 @@ spec = do
                 other ->
                     expectationFailure
                         ("expected rewritten tool output, got " <> show other)
+
+        it "omits function arguments above the provider string limit" do
+            let oversized = FunctionCallItem FunctionCall
+                    { itemId = Nothing
+                    , callId = "call-oversized"
+                    , name = "apply_patch"
+                    , arguments =
+                        Text.replicate
+                            (remoteCompactionMaxStringLength + 1)
+                            "x"
+                    , status = Just ItemCompleted
+                    , extraFields = KeyMap.empty
+                    }
+                trimmed =
+                    trimRemoteCompactionHistoryToFit
+                        2_000_000
+                        Nothing
+                        [user "keep", oversized]
+            case trimmed of
+                [_, FunctionCallItem call] -> do
+                    call.callId `shouldBe` "call-oversized"
+                    call.name `shouldBe` "apply_patch"
+                    Text.length call.arguments
+                        `shouldSatisfy` (<= remoteCompactionMaxStringLength)
+                    Aeson.eitherDecodeStrict'
+                        (TextEncoding.encodeUtf8 call.arguments)
+                        `shouldSatisfy`
+                            (either (const False) (const True)
+                                :: Either String Aeson.Value -> Bool)
+                other ->
+                    expectationFailure
+                        ("expected sanitized function call, got " <> show other)
+
+        it "omits custom-tool input above the provider string limit" do
+            let oversized = CustomToolCallItem CustomToolCall
+                    { itemId = Nothing
+                    , callId = "call-custom"
+                    , name = "apply_patch"
+                    , input =
+                        Text.replicate
+                            (remoteCompactionMaxStringLength + 1)
+                            "x"
+                    , status = Just ItemCompleted
+                    , extraFields = KeyMap.empty
+                    }
+                trimmed =
+                    trimRemoteCompactionHistoryToFit
+                        2_000_000
+                        Nothing
+                        [oversized]
+            case trimmed of
+                [CustomToolCallItem call] -> do
+                    call.callId `shouldBe` "call-custom"
+                    call.name `shouldBe` "apply_patch"
+                    Text.length call.input
+                        `shouldSatisfy` (<= remoteCompactionMaxStringLength)
+                other ->
+                    expectationFailure
+                        ("expected sanitized custom tool call, got " <> show other)
 
     describe "Codex model metadata" do
         it "derives the 90% auto-compaction limit for curated 272k models" do


### PR DESCRIPTION
## Summary

- sanitize oversized `function_call.arguments` before remote compaction requests
- sanitize oversized custom-tool input while preserving call identity and pairing
- calculate compaction request size from the sanitized history
- add regression coverage for the provider's 1,048,576-character per-string limit

## Problem

Automatic compaction only rewrote oversized tool outputs. A large historical tool call could still leave `input[n].arguments` above the provider's individual string limit, causing compaction to fail before the conversation could continue.

## Validation

Run through Cabal GHCi inside `nix develop`:

- OpenAI remote compaction: 12 examples, 0 failures
- CLI `compactOpenAIWith`: 3 examples, 0 failures
- CLI automatic compaction: 8 examples, 0 failures
- `git diff --check`
