### PR TITLE
fix(cli): unblock interactive REPL startup

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime.hs
@@ -3368,7 +3368,6 @@ replWithDraft env@SessionEnv
     , sessionSetConcurrentLimit = _
     , sessionReset = sessionReset
     } draft = do
-    let conversationRef = conversationRef
     writeIORef draftRef draft
     refreshSkills False
     skillInvocations <- readIORef skillInvocationsRef


### PR DESCRIPTION
## Summary
- remove a self-recursive `conversationRef` binding from the interactive REPL startup path
- allow startup to read live attachments and enter the input loop
- restore the fullscreen model/effort controls and prevent early input from remaining queued forever

## Root cause
`let conversationRef = conversationRef` shadowed the `SessionEnv` field with a recursive local thunk. The first strict use in `readLiveAttachments conversationRef` black-holed the startup thread. Fullscreen rendering had already started, so the UI misleadingly showed `Ready` with an empty model control while all input was queued.

## Validation
- `GHCRTS='-M4G' nix develop -c cabal repl agent-cli:lib:agent-cli`
- loaded all 119 `agent-cli` modules successfully in GHCi
- exercised the live fullscreen agent in tmux
- confirmed the prompt becomes active and renders `gpt-5.6-sol (medium)`, interaction mode, and account
- `git diff --check`
