### PR TITLE
fix(cli): restore reserved collaboration schema

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Tools.hs
+++ b/packages/agent-cli/src/Agent/CLI/Tools.hs
@@ -157,8 +157,19 @@ multiAgentNamespaceTool tools = KnownResponseTool ToolNamespace TaggedObject
         , "name" .= tool.appToolName
         , "description" .= tool.appToolDescription
         , "strict" .= False
-        , "parameters" .= namespaceParameters (appToolJsonParameters tool)
+        , "parameters" .= namespaceParameters
+            (reservedCollaborationParameters tool)
         ]
+
+    -- OpenAI reserves collaboration.spawn_agent and rejects the entire request
+    -- unless its schema exactly matches the provider-owned definition.
+    -- Worktree isolation remains available to dialects that expose app tools
+    -- directly, but cannot be added to this reserved namespace function.
+    reservedCollaborationParameters tool
+        | tool.appToolName == "spawn_agent" =
+            filter ((/= "isolation") . (.propertyName))
+                (appToolJsonParameters tool)
+        | otherwise = appToolJsonParameters tool
 
     namespaceParameters parameters = case parametersObjectLoose parameters of
         Aeson.Object schema

--- a/packages/agent-cli/test/Agent/CLI/AgentSessionsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/AgentSessionsSpec.hs
@@ -177,9 +177,12 @@ spec = describe "Agent.CLI.AgentSessions" do
     it "closes scoped children concurrently and rejects later launches" $
         withTempStoreDir "agent-session-runtime-" \pool root -> do
             let marker = toFilePath root FilePath.</> "stopped"
+                started = toFilePath root FilePath.</> "started"
             script <- writeFakeAgentBody root
                 ("trap 'printf stopped > " <> shellQuote marker
-                    <> "; exit 0' TERM INT\nsleep 30\n")
+                    <> "; exit 0' TERM INT\nprintf started > "
+                    <> shellQuote started
+                    <> "\nsleep 30\n")
             withExecutableOverride script do
                 handle <- createSession (testCreateAt pool root root)
                 manager <-
@@ -190,6 +193,7 @@ spec = describe "Agent.CLI.AgentSessions" do
                     manager True ApproveAll True False handle "one"
                     `shouldReturn`
                         Right ("started session " <> handle.sessionMeta.metaId)
+                waitForFile started
                 closeSessionProcessManager manager
                 waitForFile marker
                 launchSessionTurn

--- a/packages/agent-cli/test/Agent/CLI/ToolsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ToolsSpec.hs
@@ -219,7 +219,7 @@ spec = describe "schemasFromAppTools" do
             other -> expectationFailure
                 ("expected collaboration namespace, got " <> show other)
 
-    it "matches the reserved wait_agent schema with the production tool" do
+    it "matches the reserved collaboration schemas with the production tools" do
         bracket
             (newSubagentRegistry
                 defaultSubagentConfig
@@ -252,6 +252,29 @@ spec = describe "schemasFromAppTools" do
                     [tagged] ->
                         case KeyMap.lookup "tools" tagged.fields of
                             Just (Aeson.Array tools) -> do
+                                let spawnTools =
+                                        mapMaybe spawnAgentObject (toList tools)
+                                case spawnTools of
+                                    [tool] -> do
+                                        Just (Aeson.Object parameters) <-
+                                            pure (KeyMap.lookup "parameters" tool)
+                                        KeyMap.lookup "required" parameters
+                                            `shouldBe` Just
+                                                (Aeson.toJSON
+                                                    (["task_name", "message"] :: [Text]))
+                                        Just (Aeson.Object properties) <-
+                                            pure (KeyMap.lookup "properties" parameters)
+                                        map Key.toText (KeyMap.keys properties)
+                                            `shouldMatchList`
+                                                [ "task_name"
+                                                , "message"
+                                                , "model"
+                                                , "reasoning_effort"
+                                                , "fork_turns"
+                                                ]
+                                    other -> expectationFailure
+                                        ("expected production spawn_agent, got "
+                                            <> show other)
                                 let waitTools =
                                         mapMaybe waitAgentObject (toList tools)
                                 case waitTools of
@@ -303,6 +326,12 @@ waitAgentObject (Aeson.Object tool)
     | KeyMap.lookup "name" tool == Just (Aeson.String "wait_agent") =
         Just tool
 waitAgentObject _ = Nothing
+
+spawnAgentObject :: Aeson.Value -> Maybe Aeson.Object
+spawnAgentObject (Aeson.Object tool)
+    | KeyMap.lookup "name" tool == Just (Aeson.String "spawn_agent") =
+        Just tool
+spawnAgentObject _ = Nothing
 
 required_ :: FunctionTool -> Maybe Aeson.Value
 required_ tool = do


### PR DESCRIPTION
## Summary
- keep worktree isolation out of OpenAI's reserved `collaboration.spawn_agent` schema
- add a regression assertion for the exact production reserved schema
- remove a race from the scoped child shutdown test by waiting until its signal trap is installed

## Root cause
The worktree-isolation change advertised an extra `isolation` property on OpenAI's provider-reserved `collaboration.spawn_agent`, causing the provider to reject requests before agent execution. Separately, the Nix install failure was a test race: shutdown could send TERM before the fake child installed its trap.

The FlakeHub HTTP 401 remains a non-fatal cache warning; Nix falls back to the configured builder. The actual build failure was the flaky test.

## Validation
- GHCi `-fno-code` compile of `agent-cli-test` (72 modules)
- reserved collaboration schema test
- scoped shutdown test repeated 20 times
- full `agent-cli` suite: 950 examples, 0 failures
- `nix build .#packages.aarch64-darwin.default --no-link`
