### PR TITLE
fix(xai): resume OpenAI transcripts on Grok

### DIFF
--- a/packages/agent-xai/src/Agent/XAI/Request.hs
+++ b/packages/agent-xai/src/Agent/XAI/Request.hs
@@ -12,7 +12,11 @@ import Agent.Responses.Request
     )
 import Agent.Responses.Types
 import Agent.XAI.Options (ClientOptions(..))
+import qualified Data.Aeson as Aeson
+import Data.Aeson.Key (fromText)
 import qualified Data.Aeson.KeyMap as KeyMap
+import Data.Foldable (toList)
+import Data.Maybe (mapMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
 
@@ -94,7 +98,7 @@ xaiReasoningEffort = \case
 
 requestInputItems :: ResponseCreateParams -> [ResponseItem]
 requestInputItems request = case request.input of
-    Just (ResponseInputItems items) -> items
+    Just (ResponseInputItems items) -> map normalizeInputItem items
     Just (ResponseInputText inputText) ->
         [ MessageItem ResponseMessage
             { messageId = Nothing
@@ -106,3 +110,52 @@ requestInputItems request = case request.input of
             }
         ]
     Nothing -> []
+
+-- OpenAI stores inter-agent collaboration messages as the provider-specific
+-- @agent_message@ item. Resumed transcripts can retain those items when the
+-- user switches to Grok, whose Responses union does not recognize that tag.
+-- Preserve the readable collaboration context as an ordinary user message.
+normalizeInputItem :: ResponseItem -> ResponseItem
+normalizeInputItem = \case
+    KnownResponseItem ItemAgentMessage tagged ->
+        MessageItem ResponseMessage
+            { messageId = Nothing
+            , content = MessageContentParts
+                [InputTextPart (agentMessageText tagged) Nothing KeyMap.empty]
+            , role = RoleUser
+            , status = Nothing
+            , phase = Nothing
+            , extraFields = KeyMap.empty
+            }
+    item -> item
+
+agentMessageText :: TaggedObject -> Text
+agentMessageText tagged =
+    case KeyMap.lookup (fromText "content") tagged.fields of
+        Just (Aeson.Array parts)
+            | not (null texts) -> Text.intercalate "\n" texts
+          where
+            texts = mapMaybe contentPartText (toList parts)
+        _ -> fallback
+  where
+    fallback = case
+        ( textField "author" tagged.fields
+        , textField "recipient" tagged.fields
+        ) of
+        (Just author, Just recipient) ->
+            "Agent message from " <> author <> " to " <> recipient
+        (Just author, Nothing) -> "Agent message from " <> author
+        (Nothing, Just recipient) -> "Agent message to " <> recipient
+        (Nothing, Nothing) -> "Agent message"
+
+contentPartText :: Aeson.Value -> Maybe Text
+contentPartText = \case
+    Aeson.Object object
+        | textField "type" object == Just "input_text" ->
+            textField "text" object
+    _ -> Nothing
+
+textField :: Text -> Aeson.Object -> Maybe Text
+textField name object = case KeyMap.lookup (fromText name) object of
+    Just (Aeson.String value) -> Just value
+    _ -> Nothing

--- a/packages/agent-xai/test/Agent/XAI/ResponsesSpec.hs
+++ b/packages/agent-xai/test/Agent/XAI/ResponsesSpec.hs
@@ -78,6 +78,44 @@ spec = do
             input <- expectArray (KeyMap.lookup "input" object)
             length input `shouldBe` 1
 
+        it "flattens resumed OpenAI agent messages into Grok user messages" do
+            let agentMessage = KnownResponseItem ItemAgentMessage TaggedObject
+                    { tag = "agent_message"
+                    , fields = KeyMap.fromList
+                        [ ("author", Aeson.String "researcher")
+                        , ("recipient", Aeson.String "root")
+                        , ("content", Aeson.toJSON
+                            [ Aeson.object
+                                [ "type" .= ("input_text" :: Text)
+                                , "text" .= ("Message Type: MESSAGE\nSender: researcher\nPayload:\nFound it." :: Text)
+                                ]
+                            , Aeson.object
+                                [ "type" .= ("encrypted_content" :: Text)
+                                , "encrypted_content" .= ("opaque-provider-payload" :: Text)
+                                ]
+                            ])
+                        ]
+                    }
+                request = setInstructions Nothing $
+                    setInput
+                        (Just (ResponseInputItems [agentMessage]))
+                        sampleRequest
+                value = requestValue defaultClientOptions request
+            object <- expectObject value
+            input <- expectArray (KeyMap.lookup "input" object)
+            input `shouldBe`
+                [ Aeson.object
+                    [ "type" .= ("message" :: Text)
+                    , "role" .= ("user" :: Text)
+                    , "content" .=
+                        [ Aeson.object
+                            [ "type" .= ("input_text" :: Text)
+                            , "text" .= ("Message Type: MESSAGE\nSender: researcher\nPayload:\nFound it." :: Text)
+                            ]
+                        ]
+                    ]
+                ]
+
         it "maps web_search, keeps function tools, and drops the computer tool" do
             let value = requestValue defaultClientOptions sampleRequest
             object <- expectObject value
@@ -319,6 +357,10 @@ setInclude newInclude ResponseCreateParams { include = _, .. } =
 setModel :: Maybe Text -> ResponseCreateParams -> ResponseCreateParams
 setModel newModel ResponseCreateParams { model = _, .. } =
     ResponseCreateParams { model = newModel, .. }
+
+setInput :: Maybe ResponseInput -> ResponseCreateParams -> ResponseCreateParams
+setInput newInput ResponseCreateParams { input = _, .. } =
+    ResponseCreateParams { input = newInput, .. }
 
 expectObject :: Aeson.Value -> IO Aeson.Object
 expectObject = \case


### PR DESCRIPTION
## Summary
- normalize persisted OpenAI `agent_message` items at the xAI request boundary
- preserve readable collaboration context as ordinary user input
- omit OpenAI-only encrypted payloads that Grok cannot decode
- add regression coverage for resumed provider switches

## Root cause
Resumed OpenAI sessions retain provider-specific `agent_message` input items. The xAI adapter serialized those items unchanged, so Grok rejected the unsupported input union variant before generating a response.

## Testing
- `nix develop --command cabal test agent-xai-test --test-show-details=direct` (53 examples, 0 failures, 1 pending live test)
- `nix develop --command cabal test agent-cli-test --test-show-details=direct` reached 961 examples; 26 PostgreSQL-backed tests could not start because the deeply nested temporary directory made their Unix socket paths exceed the macOS limit
