### PR TITLE
Add dedicated worktree agent spawn tool

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Tools.hs
+++ b/packages/agent-cli/src/Agent/CLI/Tools.hs
@@ -157,19 +157,8 @@ multiAgentNamespaceTool tools = KnownResponseTool ToolNamespace TaggedObject
         , "name" .= tool.appToolName
         , "description" .= tool.appToolDescription
         , "strict" .= False
-        , "parameters" .= namespaceParameters
-            (reservedCollaborationParameters tool)
+        , "parameters" .= namespaceParameters (appToolJsonParameters tool)
         ]
-
-    -- OpenAI reserves collaboration.spawn_agent and rejects the entire request
-    -- unless its schema exactly matches the provider-owned definition.
-    -- Worktree isolation remains available to dialects that expose app tools
-    -- directly, but cannot be added to this reserved namespace function.
-    reservedCollaborationParameters tool
-        | tool.appToolName == "spawn_agent" =
-            filter ((/= "isolation") . (.propertyName))
-                (appToolJsonParameters tool)
-        | otherwise = appToolJsonParameters tool
 
     namespaceParameters parameters = case parametersObjectLoose parameters of
         Aeson.Object schema

--- a/packages/agent-cli/test/Agent/CLI/ToolsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ToolsSpec.hs
@@ -219,7 +219,7 @@ spec = describe "schemasFromAppTools" do
             other -> expectationFailure
                 ("expected collaboration namespace, got " <> show other)
 
-    it "matches the reserved collaboration schemas with the production tools" do
+    it "keeps reserved collaboration schemas exact and exposes worktree spawn separately" do
         bracket
             (newSubagentRegistry
                 defaultSubagentConfig
@@ -236,18 +236,54 @@ spec = describe "schemasFromAppTools" do
                         , multiTaskPath = taskPathRoot
                         , multiRootTurnId = pure Nothing
                         , multiResumeFromDisk = Nothing
-                        , multiCreateWorktree = Nothing
+                        , multiCreateWorktree = Just
+                            (\_ -> pure (Left "not used"))
                         , multiPrepareSpawn = Nothing
                         , multiSendToRoot = Nothing
                         , multiSpawnModelGuidance = Nothing
                         }
+                    schemas =
+                        schemasFromAppTools
+                            codexDialect
+                            (multiAgentTools context)
                     namespaces =
                         [ tagged
                         | KnownResponseTool ToolNamespace tagged <-
-                            schemasFromAppTools
-                                codexDialect
-                                (multiAgentTools context)
+                            schemas
                         ]
+                    worktreeFunctions =
+                        [ function
+                        | FunctionToolValue function <- schemas
+                        , function.name == "spawn_agent_in_worktree"
+                        ]
+                case worktreeFunctions of
+                    [function] -> do
+                        function.strict `shouldBe` Just True
+                        Just (Aeson.Object parameters) <-
+                            pure function.parameters
+                        KeyMap.lookup "required" parameters
+                            `shouldBe` Just
+                                (Aeson.toJSON
+                                    ( [ "task_name"
+                                      , "message"
+                                      , "model"
+                                      , "reasoning_effort"
+                                      , "fork_turns"
+                                      ] :: [Text]
+                                    ))
+                        Just (Aeson.Object properties) <-
+                            pure (KeyMap.lookup "properties" parameters)
+                        map Key.toText (KeyMap.keys properties)
+                            `shouldMatchList`
+                                [ "task_name"
+                                , "message"
+                                , "model"
+                                , "reasoning_effort"
+                                , "fork_turns"
+                                ]
+                    other -> expectationFailure
+                        ("expected top-level spawn_agent_in_worktree, got "
+                            <> show other)
                 case namespaces of
                     [tagged] ->
                         case KeyMap.lookup "tools" tagged.fields of

--- a/packages/agent-core/src/Agent/ToolDispatch.hs
+++ b/packages/agent-core/src/Agent/ToolDispatch.hs
@@ -222,6 +222,7 @@ renameObjectKey _ _ value = value
 multiAgentBareNames :: [Text]
 multiAgentBareNames =
     [ "spawn_agent"
+    , "spawn_agent_in_worktree"
     , "wait_agent"
     , "send_message"
     , "followup_task"

--- a/packages/agent-core/src/Agent/Tools/MultiAgents.hs
+++ b/packages/agent-core/src/Agent/Tools/MultiAgents.hs
@@ -126,8 +126,9 @@ multiAgentToolNames =
 
 multiAgentTools :: MultiAgentContext -> [AppTool]
 multiAgentTools ctx =
-    [ spawnAgentTool ctx
-    , waitAgentTool ctx
+    [spawnAgentTool ctx]
+    <> maybe [] (const [spawnAgentInWorktreeTool ctx]) ctx.multiCreateWorktree
+    <> [ waitAgentTool ctx
     , sendMessageTool ctx
     , followupTaskTool ctx
     , listAgentsTool ctx
@@ -144,24 +145,48 @@ data SpawnAgentArgs = SpawnAgentArgs
     , model :: Maybe Text
     , reasoningEffort :: Maybe Text
     , forkTurns :: Maybe Text
-    , isolation :: Maybe Text
     }
 
 instance FromJSON SpawnAgentArgs where
-    parseJSON = objectArgs \object_ -> SpawnAgentArgs
-        <$> reqText object_ "task_name"
-        <*> reqText object_ "message"
-        <*> optText object_ "model"
-        <*> optText object_ "reasoning_effort"
-        <*> optText object_ "fork_turns"
-        <*> optText object_ "isolation"
+    parseJSON = objectArgs \object_ ->
+        if KeyMap.member (Key.fromText "isolation") object_
+            then fail
+                "isolation is no longer supported; use spawn_agent_in_worktree"
+            else SpawnAgentArgs
+                <$> reqText object_ "task_name"
+                <*> reqText object_ "message"
+                <*> optText object_ "model"
+                <*> optText object_ "reasoning_effort"
+                <*> optText object_ "fork_turns"
 
 spawnAgentTool :: MultiAgentContext -> AppTool
 spawnAgentTool ctx = jsonTool "spawn_agent" spawnAgentDescription
+    (spawnAgentParameters ctx True)
+    True
+    TurnSequential
+    (typedToolWithCall "spawn_agent" (runSpawn ctx SharedWorkspace))
+
+spawnAgentInWorktreeTool :: MultiAgentContext -> AppTool
+spawnAgentInWorktreeTool ctx =
+    jsonTool "spawn_agent_in_worktree" spawnAgentInWorktreeDescription
+        (spawnAgentParameters ctx False)
+        True
+        TurnSequential
+        (typedToolWithCall
+            "spawn_agent_in_worktree"
+            (runSpawn ctx IsolatedWorktree))
+
+spawnAgentParameters :: MultiAgentContext -> Bool -> [PropertySchema]
+spawnAgentParameters ctx encryptMessage =
     [ PropertySchema "task_name" PropertyString True $ Just
         "Task name for the new agent. Use lowercase letters, digits, and underscores."
-    , PropertySchema "message"
-        (encryptedString "Initial plain-text task for the new agent.") True Nothing
+    , if encryptMessage
+        then PropertySchema "message"
+            (encryptedString "Initial plain-text task for the new agent.")
+            True
+            Nothing
+        else PropertySchema "message" PropertyString True $ Just
+            "Initial plain-text task for the new agent."
     , PropertySchema "model" PropertyString False $ Just
         (Text.intercalate " " $
             [ "Model override for the new agent. Omit unless an explicit override is needed."
@@ -171,12 +196,7 @@ spawnAgentTool ctx = jsonTool "spawn_agent" spawnAgentDescription
         "Reasoning effort override for the new agent. Omit to inherit the parent effort."
     , PropertySchema "fork_turns" PropertyString False $ Just
         "Optional number of turns to fork. Defaults to `all`. Use `none`, `all`, or a positive integer string such as `3` to fork only the most recent turns."
-    , PropertySchema "isolation" (PropertyEnum ["none", "worktree"]) False $ Just
-        "Workspace isolation for the new agent. Defaults to `none`. Use `worktree` to create a dedicated git worktree whose lifetime is tied to the agent."
     ]
-    True
-    TurnSequential
-    (typedToolWithCall "spawn_agent" (runSpawn ctx))
 
 spawnAgentDescription :: Text
 spawnAgentDescription =
@@ -185,19 +205,37 @@ spawnAgentDescription =
     \have canonical task name /root/task1/task_3. You may refer to this agent \
     \as task_3 or /root/task1/task_3. Returns the canonical task_name."
 
-runSpawn :: MultiAgentContext -> ToolCall -> SpawnAgentArgs -> IO (Either Text Text)
-runSpawn ctx call args
+spawnAgentInWorktreeDescription :: Text
+spawnAgentInWorktreeDescription =
+    "Creates a dedicated git worktree and spawns an agent inside it. The \
+    \worktree is owned by the child agent and removed when that agent is \
+    \closed. Returns the canonical task_name and worktree path."
+
+data SpawnWorkspace
+    = SharedWorkspace
+    | IsolatedWorktree
+
+runSpawn
+    :: MultiAgentContext
+    -> SpawnWorkspace
+    -> ToolCall
+    -> SpawnAgentArgs
+    -> IO (Either Text Text)
+runSpawn ctx workspace call args
     | Text.null (Text.strip args.message) =
-        pure (Left "spawn_agent requires a non-empty message")
+        pure (Left (spawnToolName workspace <> " requires a non-empty message"))
     | not (validForkTurns args.forkTurns) =
         pure (Left "fork_turns must be none, all, or a positive integer string")
-    | not (validIsolation args.isolation) =
-        pure (Left "isolation must be none or worktree")
     | otherwise = mask \restore ->
-        resolveSpawnWorkspace ctx args.isolation >>= \case
+        resolveSpawnWorkspace ctx workspace >>= \case
             Left err -> pure (Left err)
             Right (childCwd, worktree) ->
                 restore (spawnInWorkspace ctx call args childCwd worktree)
+
+spawnToolName :: SpawnWorkspace -> Text
+spawnToolName = \case
+    SharedWorkspace -> "spawn_agent"
+    IsolatedWorktree -> "spawn_agent_in_worktree"
 
 spawnInWorkspace
     :: MultiAgentContext
@@ -248,28 +286,19 @@ spawnInWorkspace ctx call args childCwd worktree = mask \restore -> do
 
 resolveSpawnWorkspace
     :: MultiAgentContext
-    -> Maybe Text
+    -> SpawnWorkspace
     -> IO (Either Text (OsPath, Maybe SubagentWorktree))
-resolveSpawnWorkspace ctx isolation
-    | usesWorktree isolation =
+resolveSpawnWorkspace ctx = \case
+    SharedWorkspace -> pure (Right (ctx.multiCwd, Nothing))
+    IsolatedWorktree ->
         case ctx.multiCreateWorktree of
             Nothing ->
-                pure (Left "isolation=\"worktree\" is unavailable in this host.")
+                pure (Left "spawn_agent_in_worktree is unavailable in this host.")
             Just create ->
                 create ctx.multiCwd >>= \case
                     Left err -> pure (Left err)
                     Right worktree ->
                         pure (Right (worktree.subagentWorktreePath, Just worktree))
-    | otherwise = pure (Right (ctx.multiCwd, Nothing))
-
-validIsolation :: Maybe Text -> Bool
-validIsolation = \case
-    Nothing -> True
-    Just raw -> Text.toLower (Text.strip raw) `elem` ["", "none", "worktree"]
-
-usesWorktree :: Maybe Text -> Bool
-usesWorktree =
-    maybe False ((== "worktree") . Text.toLower . Text.strip)
 
 makeIdempotentWorktree :: SubagentWorktree -> IO SubagentWorktree
 makeIdempotentWorktree worktree = do
@@ -422,7 +451,7 @@ instance FromJSON MessageArgs where
 sendMessageTool :: MultiAgentContext -> AppTool
 sendMessageTool ctx = jsonTool "send_message" sendMessageDescription
     [ PropertySchema "target" PropertyString True $ Just
-        "Relative or canonical task name to message (from spawn_agent)."
+        "Relative or canonical task name to message (from a spawn tool)."
     , PropertySchema "message"
         (encryptedString "Message text to queue on the target agent.") True Nothing
     ]
@@ -453,7 +482,7 @@ runSendMessage ctx call args
 followupTaskTool :: MultiAgentContext -> AppTool
 followupTaskTool ctx = jsonTool "followup_task" followupDescription
     [ PropertySchema "target" PropertyString True $ Just
-        "Agent id or canonical task name to send a follow-up task to (from spawn_agent)."
+        "Agent id or canonical task name to follow up with (from a spawn tool)."
     , PropertySchema "message"
         (encryptedString "Message text to send to the target agent.") True Nothing
     ]

--- a/packages/agent-core/test/Agent/Tools/MultiAgentsSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/MultiAgentsSpec.hs
@@ -59,10 +59,15 @@ spec = describe "Agent.Tools.MultiAgents" do
         registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
             (\_ _ _ _ -> pure $ Left LoopNoResponseId)
             (\_ _ -> pure ())
-        let tools = multiAgentTools (rootContext registry Nothing)
+        let context = (rootContext registry Nothing)
+                { multiCreateWorktree = Just
+                    (\_ -> pure (Left "not used"))
+                }
+            tools = multiAgentTools context
         map (\tool -> (tool.appToolName, isReadOnly tool.appToolApproval)) tools
             `shouldBe`
                 [ ("spawn_agent", True)
+                , ("spawn_agent_in_worktree", True)
                 , ("wait_agent", True)
                 , ("send_message", True)
                 , ("followup_task", True)
@@ -114,17 +119,23 @@ spec = describe "Agent.Tools.MultiAgents" do
             any (Text.isInfixOf "Prefer `gpt-5.6-luna` for small tasks.")
         closeSubagentRegistry registry
 
-    it "advertises optional worktree isolation on spawn_agent" do
+    it "keeps isolation off spawn_agent and exposes a dedicated worktree tool" do
         registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
             (\_ _ _ _ -> pure $ Left LoopNoResponseId)
             (\_ _ -> pure ())
-        let propertyNames =
+        let context = (rootContext registry Nothing)
+                { multiCreateWorktree = Just
+                    (\_ -> pure (Left "not used"))
+                }
+            propertyNames name =
                 [ property.propertyName
-                | tool <- multiAgentTools (rootContext registry Nothing)
-                , tool.appToolName == "spawn_agent"
+                | tool <- multiAgentTools context
+                , tool.appToolName == name
                 , property <- fromMaybe [] (jsonToolParameters tool)
                 ]
-        propertyNames `shouldContain` ["isolation"]
+        propertyNames "spawn_agent" `shouldNotContain` ["isolation"]
+        propertyNames "spawn_agent_in_worktree"
+            `shouldMatchList` propertyNames "spawn_agent"
         closeSubagentRegistry registry
 
     it "preserves encrypted spawn payloads" do
@@ -202,10 +213,9 @@ spec = describe "Agent.Tools.MultiAgents" do
                 }
             call = ToolCall
                 { callId = "spawn-worktree"
-                , name = "collaboration.spawn_agent"
+                , name = "collaboration.spawn_agent_in_worktree"
                 , arguments =
-                    "{\"task_name\":\"worker\",\"message\":\"task\",\
-                    \\"isolation\":\"worktree\"}"
+                    "{\"task_name\":\"worker\",\"message\":\"task\"}"
                 , callKind = FunctionCallKind
                 , argumentsEncrypted = False
                 }
@@ -217,12 +227,20 @@ spec = describe "Agent.Tools.MultiAgents" do
         closeSubagentRegistry registry
         readIORef cleaned `shouldReturn` True
 
-    it "rejects worktree isolation when the host does not provide it" do
+    it "omits spawn_agent_in_worktree when the host does not provide it" do
+        registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
+            (\_ _ _ _ -> pure $ Left LoopNoResponseId)
+            (\_ _ -> pure ())
+        map (.appToolName) (multiAgentTools (rootContext registry Nothing))
+            `shouldNotContain` ["spawn_agent_in_worktree"]
+        closeSubagentRegistry registry
+
+    it "rejects the removed spawn_agent isolation argument" do
         registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
             (\_ _ _ _ -> pure $ Left LoopNoResponseId)
             (\_ _ -> pure ())
         let call = ToolCall
-                { callId = "spawn-worktree-unavailable"
+                { callId = "spawn-legacy-isolation"
                 , name = "collaboration.spawn_agent"
                 , arguments =
                     "{\"task_name\":\"worker\",\"message\":\"task\",\
@@ -232,7 +250,8 @@ spec = describe "Agent.Tools.MultiAgents" do
                 }
         result <- dispatchToolCall defaultLoopDispatch
             (appToolHandlers (multiAgentTools (rootContext registry Nothing))) call
-        result.output `shouldSatisfy` Text.isInfixOf "unavailable"
+        result.output `shouldSatisfy`
+            Text.isInfixOf "use spawn_agent_in_worktree"
         closeSubagentRegistry registry
 
     it "rejects zero fork turns" do

--- a/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
@@ -184,8 +184,14 @@ spec = do
                             [ (Key.fromText "namespace", Aeson.String "collaboration")
                             , (Key.fromText "encrypted_function_args", Aeson.Array mempty)
                             ])]
+                worktree = responseToTurnOutput $ testResponse "resp-worktree"
+                    [functionCallItemWithExtras "fc3" "spawn_agent_in_worktree"
+                        "{\"task_name\":\"worker\",\"message\":\"gAAAAA\"}"
+                        (KeyMap.fromList
+                            [(Key.fromText "namespace", Aeson.String "collaboration")])]
             map (.argumentsEncrypted) encrypted.toolCalls `shouldBe` [True]
             map (.argumentsEncrypted) plaintext.toolCalls `shouldBe` [False]
+            map (.argumentsEncrypted) worktree.toolCalls `shouldBe` [False]
 
         it "joins multiple assistant messages" do
             let turn = responseToTurnOutput $ testResponse "resp-text"

--- a/packages/agent-tui/src/Agent/TUI/Presentation.hs
+++ b/packages/agent-tui/src/Agent/TUI/Presentation.hs
@@ -151,7 +151,7 @@ formatSearchReplaceDiff arguments =
 
 formatToolOutput :: ToolCall -> Text -> Text
 formatToolOutput call output = case canonicalToolName call.name of
-    "spawn_agent" ->
+    name | name `elem` ["spawn_agent", "spawn_agent_in_worktree"] ->
         maybe output ("Agent: " <>) (nonEmptyJsonText "task_name" output)
     "wait_agent" ->
         fromMaybe output (nonEmptyJsonText "message" output)
@@ -358,6 +358,7 @@ toolVerb name = case canonicalToolName name of
     "kill_task" -> "Killed"
     "task" -> "Ran"
     "spawn_agent" -> "Spawned agent"
+    "spawn_agent_in_worktree" -> "Spawned worktree agent"
     "wait_agent" -> "Waited for agent updates"
     "send_message" -> "Sent message to"
     "followup_task" -> "Followed up with"
@@ -403,6 +404,8 @@ toolDetail call = case canonicalToolName call.name of
                 then jsonTextFieldDefault "prompt" call.arguments
                 else purpose
     "spawn_agent" -> jsonTextFieldDefault "task_name" call.arguments
+    "spawn_agent_in_worktree" ->
+        jsonTextFieldDefault "task_name" call.arguments
     "send_message" -> jsonTextFieldDefault "target" call.arguments
     "followup_task" -> jsonTextFieldDefault "target" call.arguments
     "interrupt_agent" -> jsonTextFieldDefault "target" call.arguments

--- a/packages/agent-tui/test/Agent/TUI/PresentationSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/PresentationSpec.hs
@@ -145,6 +145,14 @@ spec = describe "tool presentation" do
         formatToolOutput call
             "{\"agents\":[{\"agent_status\":\"running\"},null]}"
             `shouldBe` "(no live agents)"
+        let worktreeSpawn = functionToolCall
+                "spawn" "collaboration.spawn_agent_in_worktree"
+                "{\"task_name\":\"worker\",\"message\":\"task\"}"
+        summarizeToolCall worktreeSpawn
+            `shouldBe` "Spawned worktree agent worker"
+        formatToolOutput worktreeSpawn
+            "{\"task_name\":\"/root/worker\",\"worktree\":\"/tmp/worker\"}"
+            `shouldBe` "Agent: /root/worker"
 
     it "summarizes conversation search calls while preserving text output" do
         let call = functionToolCall


### PR DESCRIPTION
## Summary

Follow-up to #515.

- remove the `isolation` argument from the reserved `collaboration.spawn_agent` schema
- add a host-gated `spawn_agent_in_worktree` tool that owns the child worktree lifecycle
- keep the provider-reserved collaboration namespace exact by exposing the new operation as a separate top-level function for namespace dialects; canonical dispatch still accepts the collaboration-qualified alias
- add schema, dispatch, lifecycle, encryption, and TUI presentation coverage

## Testing

- `Agent.Tools.MultiAgentsSpec`: 18 examples, 0 failures
- `Agent.CLI.ToolsSpec`: 12 examples, 0 failures
- `Agent.OpenAI.LoopBackendSpec`: 57 examples, 0 failures
- `Agent.TUI.PresentationSpec`: 12 examples, 0 failures
- live tmux smoke with `gpt-5.6-terra`: provider accepted the schema, invoked the new tool, created a real worktree, and rendered the spawn in the TUI; child completion remained blocked by an existing provider/runtime issue
