### PR TITLE
fix(cli): handle unavailable Linux clipboards

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Clipboard.hs
+++ b/packages/agent-cli/src/Agent/CLI/Clipboard.hs
@@ -21,11 +21,11 @@ import Control.Monad (filterM)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import Data.Char (toLower)
-import Data.List (foldl')
 import Data.Text (Text)
 import qualified Data.Text as Text
 import System.Directory
     ( doesFileExist
+    , findExecutable
     , getTemporaryDirectory
     , removeFile
     )
@@ -349,30 +349,75 @@ readMacClipboardClass typeClass = do
 
 readLinuxClipboardImage :: IO (Either Text ImageAttachment)
 readLinuxClipboardImage = do
-    png <- firstRight
-        [ runBytesCmd "wl-paste" ["-t", "image/png"]
-        , runBytesCmd "xclip" ["-selection", "clipboard", "-t", "image/png", "-o"]
-        ]
-    case png of
-        Right bytes | not (BS.null bytes) ->
-            pure (Right (ImageAttachment "image/png" bytes))
+    tools <- findLinuxClipboardTools
+    case tools of
+        [] -> pure (Left linuxClipboardUnavailableError)
         _ -> do
-            jpg <- firstRight
-                [ runBytesCmd "wl-paste" ["-t", "image/jpeg"]
-                , runBytesCmd "xclip" ["-selection", "clipboard", "-t", "image/jpeg", "-o"]
+            png <- firstRight
+                [ runBytesCmd executable (linuxImageArgs tool "image/png")
+                | tool <- tools
+                , let executable = linuxClipboardExecutable tool
                 ]
-            case jpg of
+            case png of
                 Right bytes | not (BS.null bytes) ->
-                    pure (Right (ImageAttachment "image/jpeg" bytes))
-                Left err -> pure (Left err)
-                Right _ -> pure (Left "no image found on the clipboard")
+                    pure (Right (ImageAttachment "image/png" bytes))
+                _ -> do
+                    jpg <- firstRight
+                        [ runBytesCmd executable
+                            (linuxImageArgs tool "image/jpeg")
+                        | tool <- tools
+                        , let executable = linuxClipboardExecutable tool
+                        ]
+                    case jpg of
+                        Right bytes | not (BS.null bytes) ->
+                            pure (Right (ImageAttachment "image/jpeg" bytes))
+                        Left err -> pure (Left err)
+                        Right _ -> pure (Left "no image found on the clipboard")
 
 readLinuxClipboardText :: IO (Either Text Text)
-readLinuxClipboardText =
-    firstRight
-        [ runTextCmd "wl-paste" ["-n"]
-        , runTextCmd "xclip" ["-selection", "clipboard", "-o"]
-        ]
+readLinuxClipboardText = do
+    tools <- findLinuxClipboardTools
+    case tools of
+        [] -> pure (Left linuxClipboardUnavailableError)
+        _ ->
+            firstRight
+                [ runTextCmd executable (linuxTextArgs tool)
+                | tool <- tools
+                , let executable = linuxClipboardExecutable tool
+                ]
+
+data LinuxClipboardTool
+    = WlPaste FilePath
+    | Xclip FilePath
+
+findLinuxClipboardTools :: IO [LinuxClipboardTool]
+findLinuxClipboardTools = do
+    wlPaste <- findExecutable "wl-paste"
+    xclip <- findExecutable "xclip"
+    pure $
+        maybe [] (pure . WlPaste) wlPaste
+            <> maybe [] (pure . Xclip) xclip
+
+linuxClipboardExecutable :: LinuxClipboardTool -> FilePath
+linuxClipboardExecutable = \case
+    WlPaste executable -> executable
+    Xclip executable -> executable
+
+linuxImageArgs :: LinuxClipboardTool -> String -> [String]
+linuxImageArgs tool mime = case tool of
+    WlPaste _ -> ["-t", mime]
+    Xclip _ -> ["-selection", "clipboard", "-t", mime, "-o"]
+
+linuxTextArgs :: LinuxClipboardTool -> [String]
+linuxTextArgs = \case
+    WlPaste _ -> ["-n"]
+    Xclip _ -> ["-selection", "clipboard", "-o"]
+
+linuxClipboardUnavailableError :: Text
+linuxClipboardUnavailableError =
+    "no clipboard reader is available on this Linux host; install \
+    \wl-clipboard (Wayland) or xclip (X11). On a remote server, upload the \
+    \image and paste its server-side path instead."
 
 --------------------------------------------------------------------------------
 -- Shared helpers

--- a/packages/agent-cli/test/Agent/CLI/ClipboardSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ClipboardSpec.hs
@@ -2,10 +2,16 @@ module Agent.CLI.ClipboardSpec (spec) where
 
 import Agent.CLI.Clipboard
 import Agent.Loop (ImageAttachment(..))
-import Control.Exception (bracket)
+import Control.Exception.Safe (bracket)
 import qualified Data.ByteString as BS
 import qualified Data.Text as Text
-import System.Directory (getTemporaryDirectory, removeFile)
+import System.Directory
+    ( createDirectory
+    , getTemporaryDirectory
+    , removeDirectory
+    , removeFile
+    )
+import System.Environment (lookupEnv, setEnv, unsetEnv)
 import System.Info (os)
 import System.IO (hClose, openBinaryTempFile)
 import Test.Hspec
@@ -37,6 +43,17 @@ spec = do
                             BS.length imageBytes `shouldSatisfy` (> 0)
                     else result `shouldBe`
                         Left "clipboard images are not supported on this platform yet"
+
+        it "explains clipboard limitations when Linux readers are unavailable" do
+            if os /= "linux"
+                then pendingWith "Linux-only clipboard behavior"
+                else withEmptyPath do
+                    readClipboardImage `shouldReturn`
+                        Left
+                            "no clipboard reader is available on this Linux host; \
+                            \install wl-clipboard (Wayland) or xclip (X11). On a \
+                            \remote server, upload the image and paste its \
+                            \server-side path instead."
 
     describe "nonEmptyClipboardImages" do
         it "keeps only successful non-empty image reads" do
@@ -99,3 +116,20 @@ spec = do
                     check "path" result
                     check "quoted" quoted
                     check "file-url" filed
+
+withEmptyPath :: IO a -> IO a
+withEmptyPath action = do
+    tmp <- getTemporaryDirectory
+    bracket
+        (do
+            (path, handle) <- openBinaryTempFile tmp "agent-empty-path-"
+            hClose handle
+            removeFile path
+            createDirectory path
+            originalPath <- lookupEnv "PATH"
+            setEnv "PATH" path
+            pure (path, originalPath))
+        (\(path, originalPath) -> do
+            maybe (unsetEnv "PATH") (setEnv "PATH") originalPath
+            removeDirectory path)
+        (const action)


### PR DESCRIPTION
## Summary
- discover installed Linux clipboard readers before invoking them
- fall back to `xclip` when `wl-paste` is unavailable
- show an actionable headless/remote-server message instead of a shell `command not found` error
- add a regression test for Linux hosts with no clipboard reader on `PATH`

## Testing
- `nix develop -c cabal repl agent-cli:lib:agent-cli --repl-options=-fno-code`
- `nix develop -c cabal repl agent-cli:test:agent-cli-test --repl-options=-fno-code`
- focused Hspec example: `explains clipboard limitations when Linux readers are unavailable`
- live `/paste` smoke test in tmux with neither `wl-paste` nor `xclip` available
- `git diff --check`
