### PR TITLE
feat(cli): virtualize persisted session history

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -156,6 +156,8 @@ library
                     , Agent.CLI.TUI.App
                     , Agent.CLI.TUI.Bridge
                     , Agent.CLI.TUI.Composer
+                    , Agent.CLI.TUI.History
+                    , Agent.CLI.TUI.SessionHistory
                     , Agent.CLI.TUI.ImagePreview
                     , Agent.CLI.TUI.Scroll
                     , Agent.CLI.TUI.Transcript
@@ -358,6 +360,7 @@ test-suite agent-cli-test
                     , Agent.CLI.TUIComposerSpec
                     , Agent.CLI.TUIImagePreviewSpec
                     , Agent.CLI.TUIPropertySpec
+                    , Agent.CLI.TUIHistorySpec
                     , Agent.CLI.TUIScrollSpec
                     , Agent.CLI.TUITranscriptSpec
                     , Agent.CLI.UsageSpec

--- a/packages/agent-cli/src/Agent/CLI/AgentSessions.hs
+++ b/packages/agent-cli/src/Agent/CLI/AgentSessions.hs
@@ -34,9 +34,11 @@ import Agent.CLI.Session
     , SessionHandle(..)
     , SessionMeta(..)
     , SessionTurn(..)
+    , SessionTurnPage(..)
     , createSession
     , loadSessionActivity
-    , loadSession
+    , loadRecentSessionTurns
+    , loadSessionMeta
     , sessionTempDirForId
     , sessionTitleFromPrompt
     )
@@ -875,17 +877,26 @@ runReadAgentSession
     -> ReadAgentSessionArgs
     -> IO (Either Text Text)
 runReadAgentSession env args =
-    loadSession env.toolsPool env.toolsRoot args.sessionId >>= \case
+    loadSessionMeta env.toolsPool env.toolsRoot args.sessionId >>= \case
         Left err -> pure (Left err)
-        Right (meta, turns) -> do
-            status <- env.toolsSessionStatus args.sessionId
-            activity <-
-                if status == "running"
-                    then loadSessionActivity env.toolsRoot args.sessionId
-                    else pure Nothing
+        Right meta -> do
             let limit = min 100 (max 1 (fromMaybe 20 args.limit))
-                recent = drop (max 0 (length turns - limit)) turns
-            pure $ Right $ renderAgentSession meta status activity recent
+            loadRecentSessionTurns
+                env.toolsPool env.toolsRoot args.sessionId limit >>= \case
+                    Left err -> pure (Left err)
+                    Right page -> do
+                        status <- env.toolsSessionStatus args.sessionId
+                        activity <-
+                            if status == "running"
+                                then loadSessionActivity
+                                    env.toolsRoot args.sessionId
+                                else pure Nothing
+                        pure $ Right $
+                            renderAgentSession
+                                meta
+                                status
+                                activity
+                                (map snd page.pageTurns)
 
 data SendAgentSessionMessageArgs = SendAgentSessionMessageArgs
     { sessionId :: Text
@@ -921,9 +932,10 @@ runSendAgentSessionMessage env args
         current <- env.toolsCurrentSessionId
         if current == Just args.sessionId
             then pure (Left "cannot message the current agent session")
-            else loadSession env.toolsPool env.toolsRoot args.sessionId >>= \case
+            else loadSessionMeta
+                    env.toolsPool env.toolsRoot args.sessionId >>= \case
                 Left err -> pure (Left err)
-                Right (meta, _) ->
+                Right meta ->
                     launchToolSessionTurn
                         env
                         (sessionHandle env.toolsPool env.toolsRoot meta)

--- a/packages/agent-cli/src/Agent/CLI/Resume.hs
+++ b/packages/agent-cli/src/Agent/CLI/Resume.hs
@@ -39,8 +39,10 @@ import Agent.CLI.Picker (PickerKey(..), runOverlay)
 import Agent.CLI.Session
     ( SessionMeta(..)
     , SessionTurn(..)
-    , loadSession
-    , loadSessions
+    , SessionTurnPage(..)
+    , TranscriptEffect(..)
+    , loadRecentSessionTurns
+    , loadSessionMeta
     )
 import Agent.CLI.Style (roleMuted, rolePrompt, roleSuccess)
 import Agent.CLI.TextLayout
@@ -53,6 +55,7 @@ import Agent.Provider (providerSlug)
 import Agent.Responses.Types (ResponseItem(..))
 import Agent.Store.Postgres.Connection (StorePool)
 import Agent.Store.Postgres.Session (ConversationSearchResult(..))
+import Control.Monad (forM)
 import Data.Char (isAlphaNum)
 import Data.List (nub)
 import qualified Data.Map.Strict as Map
@@ -124,7 +127,13 @@ resumeEntryFromMeta meta = entryFromWith False meta []
 
 loadResumeEntry :: StorePool -> OsPath -> Text -> IO (Either Text ResumeEntry)
 loadResumeEntry pool root sessionId =
-    fmap (fmap (uncurry entryFrom)) (loadSession pool root sessionId)
+    loadSessionMeta pool root sessionId >>= \case
+        Left err -> pure (Left err)
+        Right meta ->
+            loadRecentSessionTurns pool root sessionId 50 >>= \case
+                Left err -> pure (Left err)
+                Right page ->
+                    pure (Right (entryFrom meta (map snd page.pageTurns)))
 
 entryFrom :: SessionMeta -> [SessionTurn] -> ResumeEntry
 entryFrom = entryFromWith True
@@ -644,24 +653,23 @@ loadRecentSessions
     -> OsPath
     -> [SessionMeta]
     -> IO [(SessionMeta, [SessionTurn])]
-loadRecentSessions pool root metas = do
-    let recent = take 20 metas
-    loaded <- loadSessions pool root (map (.metaId) recent)
-    pure (zipWith loadedOrUnavailable recent loaded)
-  where
-    loadedOrUnavailable meta = \case
-        Right session -> session
-        Left err ->
-            ( meta
-            , [ SessionTurn
-                    { turnAt = meta.metaUpdatedAt
-                    , turnUserText = ""
-                    , turnAssistantText =
-                        Just ("Transcript unavailable: " <> err)
-                    , turnError = Nothing
-                    , turnResponseId = Nothing
-                    , turnItems = []
-                    , turnUsage = Nothing
-                    }
-              ]
-            )
+loadRecentSessions pool root metas =
+    forM (take 20 metas) \meta ->
+        loadRecentSessionTurns pool root meta.metaId 4 >>= \case
+            Right page -> pure (meta, map snd page.pageTurns)
+            Left err ->
+                pure
+                    ( meta
+                    , [ SessionTurn
+                            { turnAt = meta.metaUpdatedAt
+                            , turnUserText = ""
+                            , turnAssistantText =
+                                Just ("Transcript unavailable: " <> err)
+                            , turnError = Nothing
+                            , turnResponseId = Nothing
+                            , turnEffect = TranscriptAppend
+                            , turnItems = []
+                            , turnUsage = Nothing
+                            }
+                      ]
+                    )

--- a/packages/agent-cli/src/Agent/CLI/Resume.hs
+++ b/packages/agent-cli/src/Agent/CLI/Resume.hs
@@ -15,6 +15,7 @@ module Agent.CLI.Resume
     , initialResumeState
     , insertResumeSearch
     , loadResumeEntry
+    , resumeEntryFromPage
     , moveResumeBrowser
     , pickResumeEntries
     , pickResumeSession
@@ -40,9 +41,11 @@ import Agent.CLI.Session
     ( SessionMeta(..)
     , SessionTurn(..)
     , SessionTurnPage(..)
+    , SessionResumeStats(..)
     , TranscriptEffect(..)
     , loadRecentSessionTurns
     , loadSessionMeta
+    , loadSessionResumeStats
     )
 import Agent.CLI.Style (roleMuted, rolePrompt, roleSuccess)
 import Agent.CLI.TextLayout
@@ -133,7 +136,30 @@ loadResumeEntry pool root sessionId =
             loadRecentSessionTurns pool root sessionId 50 >>= \case
                 Left err -> pure (Left err)
                 Right page ->
-                    pure (Right (entryFrom meta (map snd page.pageTurns)))
+                    loadSessionResumeStats pool root sessionId >>= \case
+                        Left err -> pure (Left err)
+                        Right stats ->
+                            pure $ Right $
+                                resumeEntryFromPage
+                                    meta
+                                    stats
+                                    (map snd page.pageTurns)
+
+-- | Build a loaded resume entry from a bounded transcript page plus
+-- full-session aggregates. Counts and the first prompt describe the whole
+-- conversation; @turns@ is only the preview window.
+resumeEntryFromPage
+    :: SessionMeta
+    -> SessionResumeStats
+    -> [SessionTurn]
+    -> ResumeEntry
+resumeEntryFromPage meta stats turns =
+    (entryFromWith True meta turns)
+        { resumeMessageCount = stats.resumeStatsMessageCount
+        , resumeTurnCount = stats.resumeStatsTurnCount
+        , resumeToolCount = stats.resumeStatsToolCount
+        , resumePrompt = fromMaybe "" stats.resumeStatsFirstPrompt
+        }
 
 entryFrom :: SessionMeta -> [SessionTurn] -> ResumeEntry
 entryFrom = entryFromWith True

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Internal.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Internal.hs
@@ -189,6 +189,7 @@ import Agent.Store.Postgres
     , openStore
     , trustedPool
     )
+import Agent.Store.Postgres.Connection (StorePool)
 import Agent.Store.Types (renderStoreError)
 import Agent.CLI.PendingInputs (withPendingInputs)
 import Agent.CLI.Plan (cliPlanHooks)
@@ -267,7 +268,6 @@ import Agent.CLI.Session.Choices
 import Agent.CLI.Session.History
     ( detectGitBranch
     , foldSessionItems
-    , hydrateUiHistory
     , LiveConversation(..)
     , readLiveAttachments
     , readLiveTranscript
@@ -377,6 +377,8 @@ import Agent.CLI.Dialects
 import Agent.CLI.TUI.App
     ( FullscreenInputBuffer
     , FullscreenRuntime
+    , clearFullscreenHistorySource
+    , commitFullscreenHistoryTurn
     , emitUiEvent
     , newFullscreenInputBuffer
     , newFullscreenRuntime
@@ -384,16 +386,31 @@ import Agent.CLI.TUI.App
     , readFullscreenLineOrWithCatalog
     , readFullscreenLineWithCatalog
     , requestFullscreenChoiceWithBody
+    , reloadFullscreenHistorySource
     , runFullscreen
+    , setFullscreenHistorySource
     , setFullscreenSessionActions
     , setFullscreenImagePreviews
     , setFullscreenWindowTitle
     , withFullscreenSuspended
     )
+import Agent.CLI.TUI.History
+    ( HistoryCursor(..)
+    , HistoryDirection(..)
+    , HistoryGeneration(..)
+    , HistoryPage(..)
+    , HistoryRequest(..)
+    )
+import Agent.CLI.TUI.SessionHistory
+    ( sessionHistoryPage
+    , sessionHistoryTurn
+    )
+import Agent.CLI.TUI.Types (HistoryCommit(..))
 import Agent.TUI.Model
     ( UiEvent(..)
     , UiState(..)
     , infoNotice
+    , initialUiState
     , progressNotice
     , warningNotice
     , reduceUi
@@ -573,6 +590,7 @@ import Data.IORef
 import Data.List (findIndex)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe, isJust, isNothing, listToMaybe)
+import qualified Data.Sequence as Seq
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
@@ -1136,7 +1154,7 @@ prepareAgentIterationTracked
                     failPreparation (Text.unpack err)
                 Right lock -> do
                     writeIORef resumeLockRef (Just lock)
-                    loadSession sessionPool root sessionId >>= \case
+                    loadActiveSession sessionPool root sessionId >>= \case
                         Left err -> do
                             signalReady (Left err)
                             failPreparation (Text.unpack err)
@@ -1177,8 +1195,7 @@ prepareAgentIterationTracked
     agentSelectRef <- newIORef (\_ -> pure ())
     restartEffortActionRef <- newIORef (\_ -> pure ())
     queuedInputDisplays <- queuedFullscreenInputDisplays fullscreenInputs
-    let initialTurns = maybe [] snd resumed
-        fullscreenEnabled =
+    let fullscreenEnabled =
             stdinTty
                 && stdoutTty
                 && not (isOneShot options)
@@ -1196,7 +1213,7 @@ prepareAgentIterationTracked
                         (toText (takeFileName (takeDirectory initialCwd))
                             <> "/"
                             <> toText (takeFileName initialCwd)))
-                    (hydrateUiHistory initialTurns)))
+                    initialUiState))
                         { uiQueuedInputs = queuedInputDisplays }
     firstFrameReady <-
         if isJust activeFullscreen || not fullscreenEnabled
@@ -1231,6 +1248,28 @@ prepareAgentIterationTracked
                     useColor
                     initialFullscreenState
             | otherwise -> pure Nothing
+    forM_ fullscreen \runtime ->
+        case resumed of
+            Nothing ->
+                clearFullscreenHistorySource runtime
+            Just (meta, _) ->
+                loadRecentSessionTurns
+                    sessionPool
+                    root
+                    meta.metaId
+                    sessionUiPageSize >>= \case
+                        Left err ->
+                            failPreparation (Text.unpack err)
+                        Right page ->
+                            setFullscreenHistorySource
+                                runtime
+                                meta.metaId
+                                (loadFullscreenHistoryPage
+                                    sessionPool root meta.metaId)
+                                (sessionHistoryPage
+                                    (HistoryGeneration 0)
+                                    HistoryNewer
+                                    page)
     writeIORef uiRuntimeRef fullscreen
     resumeLock <- readIORef resumeLockRef
     let action =
@@ -2103,6 +2142,20 @@ runAgentInitializedWithLock
                 inferredTarget { targetDialect = dialectId }
                 (isNothing transition) cwd effort promptText resumed
     writeIORef persistSlotRef persist
+    forM_ fullscreen \runtime ->
+        reservedSessionId persist >>= \case
+            Nothing ->
+                clearFullscreenHistorySource runtime
+            Just sessionId ->
+                setFullscreenHistorySource
+                    runtime
+                    sessionId
+                    (loadFullscreenHistoryPage
+                        (trustedPool startup.startupDatabaseStore)
+                        root
+                        sessionId)
+                    (emptyFullscreenHistoryPage
+                        (HistoryGeneration 0))
     (sessionTmp, ephemeralSessionId) <-
         persistenceTempDir persist >>= \case
             Just tempDir -> pure (tempDir, Nothing)
@@ -3131,6 +3184,79 @@ trackCredentialAccount accountRef accountIdRef selectionRef resolveLabel provide
                 resolveLabel credential >>= writeIORef accountRef
                 pure (Right credential)
 
+sessionUiPageSize :: Int
+sessionUiPageSize = 80
+
+emptyFullscreenHistoryPage :: HistoryGeneration -> HistoryPage
+emptyFullscreenHistoryPage generation =
+    HistoryPage
+        { historyPageGeneration = generation
+        , historyPageDirection = HistoryNewer
+        , historyPageTurns = Seq.empty
+        , historyPageGenerationStart = HistoryCursor 0
+        , historyPageTotalTurns = 0
+        , historyPageHasOlder = False
+        , historyPageHasNewer = False
+        }
+
+loadFullscreenHistoryPage
+    :: StorePool
+    -> OsPath
+    -> Text
+    -> HistoryRequest
+    -> IO (Either Text HistoryPage)
+loadFullscreenHistoryPage pool root sessionId request = do
+    let loadPage =
+            case ( request.historyRequestDirection
+                 , request.historyRequestCursor
+                 ) of
+                (HistoryOlder, Just (HistoryCursor cursor)) ->
+                    loadSessionTurnsBefore
+                        pool root sessionId cursor sessionUiPageSize
+                (HistoryNewer, Just (HistoryCursor cursor)) ->
+                    loadSessionTurnsAfter
+                        pool root sessionId cursor sessionUiPageSize
+                _ ->
+                    loadRecentSessionTurns
+                        pool root sessionId sessionUiPageSize
+    fmap
+        (sessionHistoryPage
+            request.historyRequestGeneration
+            request.historyRequestDirection)
+        <$> loadPage
+
+reloadFullscreenHistoryForHandle
+    :: FullscreenRuntime
+    -> SessionHandle
+    -> IO ()
+reloadFullscreenHistoryForHandle runtime handle = do
+    let root = takeDirectory handle.sessionDir
+        sessionId = handle.sessionMeta.metaId
+        loader =
+            loadFullscreenHistoryPage
+                handle.sessionPool
+                root
+                sessionId
+    loadRecentSessionTurns
+        handle.sessionPool
+        root
+        sessionId
+        sessionUiPageSize >>= \case
+            Left err ->
+                emitUiEvent runtime
+                    (UiSetNotice
+                        (Just (warningNotice
+                            ("Could not refresh session history: " <> err))))
+            Right page ->
+                reloadFullscreenHistorySource
+                    runtime
+                    sessionId
+                    loader
+                    (sessionHistoryPage
+                        (HistoryGeneration 0)
+                        HistoryNewer
+                        page)
+
 -- | On Ctrl-C, print a copy-pasteable --resume line when a session exists.
 withInterruptResume
     :: Maybe FullscreenRuntime
@@ -4083,6 +4209,7 @@ replWithDraft env@SessionEnv
                                                 , turnAssistantText = Just outcome.compactSummary
                                                 , turnError = Nothing
                                                 , turnResponseId = Nothing
+                                                , turnEffect = TranscriptReplace
                                                 , turnItems = outcome.compactHistory
                                                 -- Compaction response usage is
                                                 -- recorded immediately by
@@ -4090,13 +4217,18 @@ replWithDraft env@SessionEnv
                                                 -- response-level failures.
                                                 , turnUsage = Nothing
                                                 }
-                                        handle' <-
-                                            appendTurnWithMetaUpdate handle turn
+                                        (handle', turnIndex) <-
+                                            appendTurnWithMetaUpdateIndexed handle turn
                                                 \meta -> meta
                                                     { metaLastResponseId = Nothing
                                                     }
                                         writeIORef slotRef
                                             (PersistenceActive handle')
+                                        forM_ fullscreen \runtime ->
+                                            commitFullscreenHistoryTurn
+                                                runtime
+                                                (sessionHistoryTurn turnIndex turn)
+                                                HistoryCommitReplace
                                 continue
                     ReplPlan _
                         | provider == ClaudeCodeProvider -> do
@@ -4153,10 +4285,12 @@ replWithDraft env@SessionEnv
                                                     Just "Conversation cleared."
                                                 , turnError = Nothing
                                                 , turnResponseId = Nothing
+                                                , turnEffect = TranscriptReset
                                                 , turnItems = []
                                                 , turnUsage = Nothing
                                                 }
-                                        handle' <- appendTurnKeepTitle handle turn
+                                        (handle', turnIndex) <-
+                                            appendTurnKeepTitleIndexed handle turn
                                         let meta = handle'.sessionMeta
                                                 { metaLastResponseId = Nothing
                                                 , metaUpdatedAt = now
@@ -4173,6 +4307,11 @@ replWithDraft env@SessionEnv
                                             meta
                                         writeIORef slotRef
                                             (PersistenceActive handle'{sessionMeta = meta})
+                                        forM_ fullscreen \runtime ->
+                                            commitFullscreenHistoryTurn
+                                                runtime
+                                                (sessionHistoryTurn turnIndex turn)
+                                                HistoryCommitReset
                                         pure
                                             ("conversation cleared (session "
                                                 <> meta.metaId
@@ -4247,10 +4386,12 @@ replWithDraft env@SessionEnv
                                             Just "Started a new session."
                                         , turnError = Nothing
                                         , turnResponseId = Nothing
+                                        , turnEffect = TranscriptReset
                                         , turnItems = []
                                         , turnUsage = Nothing
                                         }
-                                handle' <- appendTurnKeepTitle handle turn
+                                (handle', _) <-
+                                    appendTurnKeepTitleIndexed handle turn
                                 let meta = handle'.sessionMeta
                                 env.sessionOnPersisted handle'
                                 env.sessionSetTempDir handle'.sessionTempDir
@@ -4260,6 +4401,10 @@ replWithDraft env@SessionEnv
                                 writeIORef planMode.planSessionDir
                                     (Just handle'.sessionDir)
                                 writeIORef storeRoot (Just handle'.sessionDir)
+                                forM_ fullscreen \runtime ->
+                                    reloadFullscreenHistoryForHandle
+                                        runtime
+                                        handle'
                                 setWindowTitle
                                     (cliWindowTitle meta.metaCwd
                                         (Just meta.metaTitle))

--- a/packages/agent-cli/src/Agent/CLI/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session.hs
@@ -3,7 +3,9 @@ module Agent.CLI.Session
     ( SessionHandle(..)
     , SessionMeta(..)
     , LegacySubagentTarget(..)
+    , TranscriptEffect(..)
     , SessionTurn(..)
+    , SessionTurnPage(..)
     , SessionActivity(..)
     , SessionTransfer(..)
     , SessionCreate(..)
@@ -19,12 +21,20 @@ module Agent.CLI.Session
     , cleanupPendingPersistence
     , createSession
     , appendTurn
+    , appendTurnIndexed
     , appendTurnWithMetaUpdate
+    , appendTurnWithMetaUpdateIndexed
     , appendTurnKeepTitle
+    , appendTurnKeepTitleIndexed
     , addSessionUsage
     , deleteSession
     , loadSession
     , loadSessions
+    , loadActiveSession
+    , loadSessionMeta
+    , loadRecentSessionTurns
+    , loadSessionTurnsBefore
+    , loadSessionTurnsAfter
     , importSessionTransfer
     , loadSessionHandle
     , isValidSessionId
@@ -71,11 +81,18 @@ import Agent.Dialect
     )
 import Agent.OsPath (toText, unsafeToFilePath)
 import Agent.Responses.Types (ResponseItem)
+import Agent.OpenAI.Compaction
+    ( hasCompactionCheckpoint
+    , isClearSessionTurn
+    , isCompactSessionTurn
+    , isNewSessionTurn
+    )
 import Agent.Provider (Provider(..), parseProvider, providerSlug)
 import Agent.Store.Postgres (normalizePostgresTimestamp)
 import Agent.Store.Postgres.Connection (StorePool)
+import Agent.Store.Postgres.Session (TranscriptEffect(..))
 import qualified Agent.Store.Postgres.Session as Store
-import Agent.Store.Types (renderStoreError)
+import Agent.Store.Types (StoreError, renderStoreError)
 import Control.Applicative ((<|>))
 import Control.Exception.Safe (displayException, finally, onException, tryIO)
 import Control.Monad (unless, when)
@@ -90,6 +107,7 @@ import Data.Aeson (FromJSON(..), ToJSON(..), object, withObject, (.:), (.:?), (.
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy as LBS
 import Data.Bits (xor)
+import Data.Int (Int64)
 import Data.IORef
 import Data.Functor ((<&>))
 import Data.Maybe (catMaybes, fromMaybe)
@@ -299,8 +317,17 @@ data SessionTurn = SessionTurn
     , turnAssistantText :: !(Maybe Text)
     , turnError :: !(Maybe Text)
     , turnResponseId :: !(Maybe Text)
+    , turnEffect :: !TranscriptEffect
     , turnItems :: ![ResponseItem]
     , turnUsage :: !(Maybe TokenUsage)
+    } deriving (Eq, Show)
+
+data SessionTurnPage = SessionTurnPage
+    { pageTurns :: ![(Int64, SessionTurn)]
+    , pageGenerationStart :: !Int64
+    , pageTotalTurns :: !Int64
+    , pageHasOlder :: !Bool
+    , pageHasNewer :: !Bool
     } deriving (Eq, Show)
 
 instance ToJSON SessionTurn where
@@ -310,20 +337,56 @@ instance ToJSON SessionTurn where
         , "assistantText" .= turn.turnAssistantText
         , "error" .= turn.turnError
         , "responseId" .= turn.turnResponseId
+        , "effect" .= transcriptEffectText turn.turnEffect
         , "items" .= turn.turnItems
         , "usage" .= turn.turnUsage
         ]
 
 instance FromJSON SessionTurn where
-    parseJSON = withObject "SessionTurn" \o ->
-        SessionTurn
-            <$> o .: "at"
-            <*> o .: "userText"
-            <*> o .:? "assistantText"
-            <*> o .:? "error"
-            <*> o .:? "responseId"
-            <*> o .: "items"
-            <*> o .:? "usage"
+    parseJSON = withObject "SessionTurn" \o -> do
+        at <- o .: "at"
+        userText <- o .: "userText"
+        assistantText <- o .:? "assistantText"
+        turnErrorValue <- o .:? "error"
+        responseId <- o .:? "responseId"
+        items <- o .: "items"
+        usage <- o .:? "usage"
+        effect <- o .:? "effect" >>= \case
+            Nothing -> pure (inferTranscriptEffect userText items)
+            Just value ->
+                either (fail . Text.unpack) pure
+                    (parseTranscriptEffect value)
+        pure SessionTurn
+            { turnAt = at
+            , turnUserText = userText
+            , turnAssistantText = assistantText
+            , turnError = turnErrorValue
+            , turnResponseId = responseId
+            , turnEffect = effect
+            , turnItems = items
+            , turnUsage = usage
+            }
+
+transcriptEffectText :: TranscriptEffect -> Text
+transcriptEffectText = \case
+    TranscriptAppend -> "append"
+    TranscriptReplace -> "replace"
+    TranscriptReset -> "reset"
+
+parseTranscriptEffect :: Text -> Either Text TranscriptEffect
+parseTranscriptEffect = \case
+    "append" -> Right TranscriptAppend
+    "replace" -> Right TranscriptReplace
+    "reset" -> Right TranscriptReset
+    value -> Left ("unknown transcript effect: " <> value)
+
+inferTranscriptEffect :: Text -> [ResponseItem] -> TranscriptEffect
+inferTranscriptEffect userText items
+    | isClearSessionTurn userText || isNewSessionTurn userText =
+        TranscriptReset
+    | isCompactSessionTurn userText || hasCompactionCheckpoint items =
+        TranscriptReplace
+    | otherwise = TranscriptAppend
 
 -- | Ephemeral progress for a running persisted session. This lives in the
 -- session temp directory rather than the transcript so polling clients can
@@ -575,6 +638,10 @@ appendTurn :: SessionHandle -> SessionTurn -> IO SessionHandle
 appendTurn handle turn =
     appendTurnWithMetaUpdate handle turn id
 
+appendTurnIndexed :: SessionHandle -> SessionTurn -> IO (SessionHandle, Int64)
+appendTurnIndexed handle turn =
+    appendTurnWithMetaUpdateIndexed handle turn id
+
 -- | Append one transcript turn, then apply an additional metadata transition
 -- before the append's single metadata write.
 appendTurnWithMetaUpdate
@@ -584,6 +651,15 @@ appendTurnWithMetaUpdate
     -> IO SessionHandle
 appendTurnWithMetaUpdate handle turn updateMeta =
     appendTurnWithMetaTransition handle turn
+        (updateMeta . applyTurnMetadata turn)
+
+appendTurnWithMetaUpdateIndexed
+    :: SessionHandle
+    -> SessionTurn
+    -> (SessionMeta -> SessionMeta)
+    -> IO (SessionHandle, Int64)
+appendTurnWithMetaUpdateIndexed handle turn updateMeta =
+    appendTurnWithMetaTransitionIndexed handle turn
         (updateMeta . applyTurnMetadata turn)
 
 -- | Append a transcript turn and persist one metadata transition. Timestamp
@@ -596,6 +672,14 @@ appendTurnWithMetaTransition
     -> (SessionMeta -> SessionMeta)
     -> IO SessionHandle
 appendTurnWithMetaTransition handle turn transition = do
+    fst <$> appendTurnWithMetaTransitionIndexed handle turn transition
+
+appendTurnWithMetaTransitionIndexed
+    :: SessionHandle
+    -> SessionTurn
+    -> (SessionMeta -> SessionMeta)
+    -> IO (SessionHandle, Int64)
+appendTurnWithMetaTransitionIndexed handle turn transition = do
     let pool = handle.sessionPool
     now <- normalizePostgresTimestamp <$> getCurrentTime
     let meta0 = handle.sessionMeta
@@ -604,7 +688,7 @@ appendTurnWithMetaTransition handle turn transition = do
             , metaLastResponseId = turn.turnResponseId <|> meta0.metaLastResponseId
             }
         finalMeta = transition meta
-    Store.appendSessionTurn
+    Store.appendSessionTurnIndexed
         pool
         (toStoredTurn turn)
         (toStoredMetadata finalMeta) >>= \case
@@ -612,10 +696,10 @@ appendTurnWithMetaTransition handle turn transition = do
                 fail
                     ("could not append PostgreSQL session turn: "
                         <> Text.unpack (renderStoreError err))
-            Right False ->
+            Right Nothing ->
                 fail ("session not found: " <> Text.unpack finalMeta.metaId)
-            Right True ->
-                pure handle { sessionMeta = finalMeta }
+            Right (Just turnIndex) ->
+                pure (handle { sessionMeta = finalMeta }, turnIndex)
 
 applyTurnMetadata :: SessionTurn -> SessionMeta -> SessionMeta
 applyTurnMetadata turn meta =
@@ -704,6 +788,13 @@ appendTurnKeepTitle :: SessionHandle -> SessionTurn -> IO SessionHandle
 appendTurnKeepTitle handle turn =
     appendTurnWithMetaTransition handle turn id
 
+appendTurnKeepTitleIndexed
+    :: SessionHandle
+    -> SessionTurn
+    -> IO (SessionHandle, Int64)
+appendTurnKeepTitleIndexed handle turn =
+    appendTurnWithMetaTransitionIndexed handle turn id
+
 
 loadSession
     :: StorePool
@@ -712,7 +803,94 @@ loadSession
     -> IO (Either Text (SessionMeta, [SessionTurn]))
 loadSession pool root sessionId = runExceptT do
     _ <- except (sessionDirForId root sessionId)
-    stored <- lift (Store.loadSession pool sessionId)
+    stored <- loadWithLegacyImport root pool sessionId Store.loadSession
+    decodeStoredSession sessionId stored
+
+loadActiveSession
+    :: StorePool
+    -> OsPath
+    -> Text
+    -> IO (Either Text (SessionMeta, [SessionTurn]))
+loadActiveSession pool root sessionId = runExceptT do
+    _ <- except (sessionDirForId root sessionId)
+    stored <- loadWithLegacyImport root pool sessionId Store.loadActiveSession
+    decodeStoredSession sessionId stored
+
+loadSessionMeta
+    :: StorePool
+    -> OsPath
+    -> Text
+    -> IO (Either Text SessionMeta)
+loadSessionMeta pool root sessionId = runExceptT do
+    _ <- except (sessionDirForId root sessionId)
+    stored <- loadWithLegacyImport root pool sessionId Store.loadSessionMetadata
+    meta <- except (fromStoredMetadata stored)
+    validateSessionMeta sessionId meta
+    pure meta
+
+loadRecentSessionTurns
+    :: StorePool
+    -> OsPath
+    -> Text
+    -> Int
+    -> IO (Either Text SessionTurnPage)
+loadRecentSessionTurns pool root sessionId limit =
+    loadSessionTurnPage root pool sessionId
+        (\pool' key -> Store.loadRecentSessionTurns pool' key limit)
+
+loadSessionTurnsBefore
+    :: StorePool
+    -> OsPath
+    -> Text
+    -> Int64
+    -> Int
+    -> IO (Either Text SessionTurnPage)
+loadSessionTurnsBefore pool root sessionId cursor limit =
+    loadSessionTurnPage root pool sessionId
+        (\pool' key -> Store.loadSessionTurnsBefore pool' key cursor limit)
+
+loadSessionTurnsAfter
+    :: StorePool
+    -> OsPath
+    -> Text
+    -> Int64
+    -> Int
+    -> IO (Either Text SessionTurnPage)
+loadSessionTurnsAfter pool root sessionId cursor limit =
+    loadSessionTurnPage root pool sessionId
+        (\pool' key -> Store.loadSessionTurnsAfter pool' key cursor limit)
+
+loadSessionTurnPage
+    :: OsPath
+    -> StorePool
+    -> Text
+    -> (StorePool -> Text
+        -> IO (Either StoreError (Maybe Store.SessionTurnPage)))
+    -> IO (Either Text SessionTurnPage)
+loadSessionTurnPage root pool sessionId loader = runExceptT do
+    _ <- except (sessionDirForId root sessionId)
+    stored <- loadWithLegacyImport root pool sessionId loader
+    turns <- except $ traverse
+        (\storedTurn -> do
+            turn <- fromStoredTurn storedTurn.storedTurn
+            pure (storedTurn.storedTurnIndex, turn))
+        stored.sessionPageTurns
+    pure SessionTurnPage
+        { pageTurns = turns
+        , pageGenerationStart = stored.sessionPageGenerationStart
+        , pageTotalTurns = stored.sessionPageTotal
+        , pageHasOlder = stored.sessionPageHasOlder
+        , pageHasNewer = stored.sessionPageHasNewer
+        }
+
+loadWithLegacyImport
+    :: OsPath
+    -> StorePool
+    -> Text
+    -> (StorePool -> Text -> IO (Either StoreError (Maybe a)))
+    -> ExceptT Text IO a
+loadWithLegacyImport root pool sessionId loader = do
+    stored <- lift (loader pool sessionId)
         >>= either (throwE . renderStoreError) pure
     stored' <- case stored of
         Just value -> pure (Just value)
@@ -720,11 +898,9 @@ loadSession pool root sessionId = runExceptT do
             _ <- importLegacySession root pool sessionId
             -- Another process may win the import race and return False from
             -- its idempotent insert. Always reload the canonical row.
-            lift (Store.loadSession pool sessionId)
+            lift (loader pool sessionId)
                 >>= either (throwE . renderStoreError) pure
-    case stored' of
-        Nothing -> throwE ("session not found: " <> sessionId)
-        Just value -> decodeStoredSession sessionId value
+    maybe (throwE ("session not found: " <> sessionId)) pure stored'
 
 -- | Load several sessions with one batched PostgreSQL read while preserving
 -- request order. A missing database row still takes the legacy import path.
@@ -762,7 +938,7 @@ loadSessionHandle
     -> Text
     -> IO (Either Text (SessionHandle, [SessionTurn]))
 loadSessionHandle pool root sessionId =
-    loadSession pool root sessionId >>= \case
+    loadActiveSession pool root sessionId >>= \case
         Left err -> pure (Left err)
         Right (meta, turns) ->
             pure do
@@ -1217,6 +1393,7 @@ toStoredTurn turn = Store.SessionTurn
     , sessionTurnAssistantText = turn.turnAssistantText
     , sessionTurnError = turn.turnError
     , sessionTurnResponseId = turn.turnResponseId
+    , sessionTurnEffect = turn.turnEffect
     , sessionTurnItems = map toStoredResponseItem turn.turnItems
     , sessionTurnUsage = toStoredUsage <$> turn.turnUsage
     }
@@ -1230,6 +1407,7 @@ fromStoredTurn stored = do
         , turnAssistantText = stored.sessionTurnAssistantText
         , turnError = stored.sessionTurnError
         , turnResponseId = stored.sessionTurnResponseId
+        , turnEffect = stored.sessionTurnEffect
         , turnItems = items
         , turnUsage = fromStoredUsage <$> stored.sessionTurnUsage
         }

--- a/packages/agent-cli/src/Agent/CLI/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session.hs
@@ -6,6 +6,7 @@ module Agent.CLI.Session
     , TranscriptEffect(..)
     , SessionTurn(..)
     , SessionTurnPage(..)
+    , SessionResumeStats(..)
     , SessionActivity(..)
     , SessionTransfer(..)
     , SessionCreate(..)
@@ -35,6 +36,7 @@ module Agent.CLI.Session
     , loadRecentSessionTurns
     , loadSessionTurnsBefore
     , loadSessionTurnsAfter
+    , loadSessionResumeStats
     , importSessionTransfer
     , loadSessionHandle
     , isValidSessionId
@@ -328,6 +330,13 @@ data SessionTurnPage = SessionTurnPage
     , pageTotalTurns :: !Int64
     , pageHasOlder :: !Bool
     , pageHasNewer :: !Bool
+    } deriving (Eq, Show)
+
+data SessionResumeStats = SessionResumeStats
+    { resumeStatsTurnCount :: !Int
+    , resumeStatsMessageCount :: !Int
+    , resumeStatsToolCount :: !Int
+    , resumeStatsFirstPrompt :: !(Maybe Text)
     } deriving (Eq, Show)
 
 instance ToJSON SessionTurn where
@@ -859,6 +868,22 @@ loadSessionTurnsAfter
 loadSessionTurnsAfter pool root sessionId cursor limit =
     loadSessionTurnPage root pool sessionId
         (\pool' key -> Store.loadSessionTurnsAfter pool' key cursor limit)
+
+loadSessionResumeStats
+    :: StorePool
+    -> OsPath
+    -> Text
+    -> IO (Either Text SessionResumeStats)
+loadSessionResumeStats pool root sessionId = runExceptT do
+    _ <- except (sessionDirForId root sessionId)
+    stored <- loadWithLegacyImport root pool sessionId Store.loadSessionResumeStats
+    pure SessionResumeStats
+        { resumeStatsTurnCount = fromIntegral stored.sessionResumeTurnCount
+        , resumeStatsMessageCount = fromIntegral stored.sessionResumeMessageCount
+        , resumeStatsToolCount = fromIntegral stored.sessionResumeToolCount
+        , resumeStatsFirstPrompt =
+            fmap Text.strip stored.sessionResumeFirstPrompt
+        }
 
 loadSessionTurnPage
     :: OsPath

--- a/packages/agent-cli/src/Agent/CLI/Session/History.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/History.hs
@@ -15,11 +15,13 @@ module Agent.CLI.Session.History
     , writeLiveTranscript
     ) where
 
-import Agent.CLI.Session (SessionTurn(..))
+import Agent.CLI.Session
+    ( SessionTurn(..)
+    , TranscriptEffect(..)
+    )
 import Agent.Loop (ImageAttachment)
 import Agent.OpenAI.Compaction
-    ( hasCompactionCheckpoint
-    , isTranscriptResetTurn
+    ( isTranscriptResetTurn
     )
 import Agent.Responses.Types (ResponseItem)
 import Agent.Tools.PlanMode
@@ -144,15 +146,10 @@ foldSessionItems :: [SessionTurn] -> [ResponseItem]
 foldSessionItems =
     concat . reverse . foldl' addTurn []
   where
-    addTurn chunks turn
-        | isTranscriptResetTurn turn.turnUserText =
-            -- /clear and /new store an empty snapshot; /compact stores the
-            -- rebuilt history. Either way, turnItems replaces prior history.
-            [turn.turnItems]
-        | hasCompactionCheckpoint turn.turnItems =
-            [turn.turnItems]
-        | otherwise =
-            turn.turnItems : chunks
+    addTurn chunks turn = case turn.turnEffect of
+        TranscriptAppend -> turn.turnItems : chunks
+        TranscriptReplace -> [turn.turnItems]
+        TranscriptReset -> [turn.turnItems]
 
 hydrateUiHistory :: [SessionTurn] -> UiState
 hydrateUiHistory = foldl' addTurn initialUiState

--- a/packages/agent-cli/src/Agent/CLI/Session/Selection.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Selection.hs
@@ -37,7 +37,7 @@ import Agent.CLI.Session
     , SessionMeta(..)
     , deleteSession
     , listSessions
-    , loadSession
+    , loadSessionMeta
     , sessionsRoot
     )
 import Agent.CLI.Style
@@ -114,7 +114,7 @@ handleResume databasePool fullscreen maybeId persist = do
                     reportInfo ("already on session " <> sessionId)
                     pure Nothing
                 else
-                    loadSession databasePool root sessionId >>= \case
+                    loadSessionMeta databasePool root sessionId >>= \case
                         Left err -> do
                             reportError err
                             pure Nothing

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -48,6 +48,10 @@ module Agent.CLI.TUI.App
     , requestFullscreenSecret
     , requestFullscreenText
     , runFullscreen
+    , commitFullscreenHistoryTurn
+    , clearFullscreenHistorySource
+    , reloadFullscreenHistorySource
+    , setFullscreenHistorySource
     , setFullscreenSessionActions
     , fullscreenBounds
     , fullscreenVtyConfig
@@ -134,6 +138,22 @@ import Agent.CLI.Terminal
 import qualified Agent.TUI.Theme as Theme
 import qualified Agent.CLI.TUI.Bridge as Bridge
 import qualified Agent.CLI.TUI.Composer as Composer
+import Agent.CLI.TUI.History
+    ( HistoryCursor(..)
+    , HistoryDirection(..)
+    , HistoryGeneration(..)
+    , HistoryPage(..)
+    , HistoryRequest(..)
+    , HistoryTurn(..)
+    , HistoryWindow(..)
+    , appendHistoryTurn
+    , applyHistoryPage
+    , clearHistoryRequest
+    , emptyHistoryWindow
+    , historyWindowRequest
+    , historyWindowSetAnchors
+    , markHistoryRequest
+    )
 import Agent.CLI.TUI.LambdaArt
     ( lambdaArtWidget
     )
@@ -210,6 +230,7 @@ import qualified Brick.Widgets.Border as Border
 import Brick.Widgets.Border.Style (unicodeRounded)
 import Brick.Widgets.Center (center, centerLayer, hCenter)
 import Codec.Picture (pixelAt)
+import Control.Applicative ((<|>))
 import Control.Concurrent.Async (wait, waitCatch, withAsync)
 import Control.Concurrent (threadDelay)
 import Control.Monad (forever, unless, void, when, (>=>))
@@ -218,14 +239,17 @@ import Control.Concurrent.STM
     , atomically
     , check
     , newEmptyTMVarIO
+    , newTQueueIO
     , newTVarIO
     , orElse
     , putTMVar
     , readTVar
     , readTMVar
+    , readTQueue
     , registerDelay
     , retry
     , takeTMVar
+    , writeTQueue
     , writeTVar
     )
 import Agent.CLI.Recap
@@ -240,17 +264,26 @@ import Control.Exception (AsyncException(UserInterrupt))
 import Data.Char (isControl, isSpace)
 import Data.Foldable (toList)
 import Data.IORef
-    ( modifyIORef'
+    ( atomicModifyIORef'
+    , modifyIORef'
     , newIORef
     , readIORef
     , writeIORef
     )
-import Data.List (find, findIndex, intersperse, nub, sort, sortOn)
+import Data.List
+    ( find
+    , findIndex
+    , intersperse
+    , nub
+    , sort
+    , sortOn
+    )
 import Data.List.NonEmpty (NonEmpty(..))
 import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe, isJust, isNothing, mapMaybe, maybeToList)
 import Data.Sequence (Seq, ViewL(..), ViewR(..), (|>))
 import qualified Data.Sequence as Seq
+import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
@@ -326,6 +359,9 @@ newFullscreenRuntimeWithSyntaxLoader
         mailbox <- AppEventMailbox <$> newTVarIO Seq.empty
         motionSchedule <- newTVarIO (MotionNone, 1000000, 0)
         motionTickQueued <- newTVarIO False
+        historyRequests <- newTQueueIO
+        historySource <- newIORef Nothing
+        historyGeneration <- newIORef 0
         imagePreviews <- newIORef []
         imagePreviewRevision <- newIORef 0
         imagePreviewVisible <- newIORef True
@@ -381,6 +417,9 @@ newFullscreenRuntimeWithSyntaxLoader
             , runtimeSyntaxLoadFinished = syntaxLoadFinished
             , runtimeInitial = initial
             , runtimeSessionActions = sessionActions
+            , runtimeHistoryRequests = historyRequests
+            , runtimeHistorySource = historySource
+            , runtimeHistoryGeneration = historyGeneration
             }
 
 setFullscreenSessionActions
@@ -411,6 +450,86 @@ setFullscreenSessionActions
             , sessionAgentSnapshot = agentSnapshot
             , sessionAgentSelect = agentSelect
             }
+
+setFullscreenHistorySource
+    :: FullscreenRuntime
+    -> Text
+    -> (HistoryRequest -> IO (Either Text HistoryPage))
+    -> HistoryPage
+    -> IO ()
+setFullscreenHistorySource runtime key loader initialPage = do
+    previous <- readIORef runtime.runtimeHistorySource
+    writeIORef runtime.runtimeHistorySource $
+        Just FullscreenHistorySource
+            { historySourceKey = key
+            , historySourceLoad = loader
+            }
+    case previous of
+        Just source
+            | source.historySourceKey == key -> pure ()
+        _ -> resetFullscreenHistory runtime initialPage
+
+reloadFullscreenHistorySource
+    :: FullscreenRuntime
+    -> Text
+    -> (HistoryRequest -> IO (Either Text HistoryPage))
+    -> HistoryPage
+    -> IO ()
+reloadFullscreenHistorySource runtime key loader initialPage = do
+    writeIORef runtime.runtimeHistorySource $
+        Just FullscreenHistorySource
+            { historySourceKey = key
+            , historySourceLoad = loader
+            }
+    resetFullscreenHistory runtime initialPage
+
+clearFullscreenHistorySource :: FullscreenRuntime -> IO ()
+clearFullscreenHistorySource runtime = do
+    writeIORef runtime.runtimeHistorySource Nothing
+    resetFullscreenHistory runtime
+        (HistoryPage
+            { historyPageGeneration = HistoryGeneration 0
+            , historyPageDirection = HistoryNewer
+            , historyPageTurns = Seq.empty
+            , historyPageGenerationStart = HistoryCursor 0
+            , historyPageTotalTurns = 0
+            , historyPageHasOlder = False
+            , historyPageHasNewer = False
+            })
+
+commitFullscreenHistoryTurn
+    :: FullscreenRuntime
+    -> HistoryTurn
+    -> HistoryCommit
+    -> IO ()
+commitFullscreenHistoryTurn runtime turn commit = do
+    source <- readIORef runtime.runtimeHistorySource
+    case source of
+        Nothing -> pure ()
+        Just _ -> do
+            generation <- case commit of
+                HistoryCommitAppend ->
+                    HistoryGeneration
+                        <$> readIORef runtime.runtimeHistoryGeneration
+                _ ->
+                    atomicModifyIORef'
+                        runtime.runtimeHistoryGeneration
+                        \current ->
+                            let next = current + 1
+                            in (next, HistoryGeneration next)
+            enqueueAppEvent runtime
+                (AppHistoryCommitted generation turn commit)
+
+resetFullscreenHistory :: FullscreenRuntime -> HistoryPage -> IO ()
+resetFullscreenHistory runtime initialPage = do
+    generation <- atomicModifyIORef'
+        runtime.runtimeHistoryGeneration
+        \current ->
+            let next = current + 1
+            in (next, HistoryGeneration next)
+    enqueueAppEvent runtime
+        (AppHistoryReset
+            initialPage { historyPageGeneration = generation })
 
 loadSyntaxHighlighterForRuntime :: FullscreenRuntime -> IO ()
 loadSyntaxHighlighterForRuntime runtime = do
@@ -773,34 +892,37 @@ runFullscreen runtime workerAction = do
                 withAsync (eventPump runtime) \_eventPump ->
                     withAsync (recapTicker runtime) \_recapTicker ->
                         withAsync
-                            (loadSyntaxHighlighterForRuntime runtime)
-                            \_syntaxLoader ->
+                            historyLoader
+                            \_historyLoader ->
                             withAsync
-                                (void (waitCatch worker)
-                                    >> enqueueAppEvent runtime AppStop)
-                                \_notifier -> do
-                                    finalState <-
-                                        customMain
-                                            initialVty
-                                            buildVty
-                                            (Just runtime.runtimeEvents)
-                                            fullscreenApp
-                                            initialState
-                                        `finally`
-                                            runtime.runtimeNativeProgress False
-                                    when (not finalState.appWorkerStopped) $
-                                        atomically $
-                                            Composer.appendFullscreenInput
-                                                runtime.runtimeInput
-                                                FullscreenInput
-                                                    { fullscreenInputLine =
-                                                        ReplEof
-                                                    , fullscreenInputQueued =
-                                                        False
-                                                    , fullscreenInputDisplay =
-                                                        Nothing
-                                                    }
-                                    wait worker
+                                (loadSyntaxHighlighterForRuntime runtime)
+                                \_syntaxLoader ->
+                                    withAsync
+                                        (void (waitCatch worker)
+                                            >> enqueueAppEvent runtime AppStop)
+                                        \_notifier -> do
+                                            finalState <-
+                                                customMain
+                                                    initialVty
+                                                    buildVty
+                                                    (Just runtime.runtimeEvents)
+                                                    fullscreenApp
+                                                    initialState
+                                                `finally`
+                                                    runtime.runtimeNativeProgress False
+                                            when (not finalState.appWorkerStopped) $
+                                                atomically $
+                                                    Composer.appendFullscreenInput
+                                                        runtime.runtimeInput
+                                                        FullscreenInput
+                                                            { fullscreenInputLine =
+                                                                ReplEof
+                                                            , fullscreenInputQueued =
+                                                                False
+                                                            , fullscreenInputDisplay =
+                                                                Nothing
+                                                            }
+                                            wait worker
   where
     recapTicker _runtime = forever do
         threadDelay 20_000_000
@@ -853,6 +975,32 @@ runFullscreen runtime workerAction = do
                     pure snapshot
         agentTicker previous'
 
+    historyLoader = do
+        request <- atomically (readTQueue runtime.runtimeHistoryRequests)
+        source <- readIORef runtime.runtimeHistorySource
+        result <- case source of
+            Nothing ->
+                pure (Left "Session history is unavailable.")
+            Just current ->
+                tryAny (current.historySourceLoad request) >>= \case
+                    Left err ->
+                        pure (Left (Text.pack (show err)))
+                    Right loaded ->
+                        pure loaded
+        let normalized =
+                fmap
+                    (\page ->
+                        page
+                            { historyPageGeneration =
+                                request.historyRequestGeneration
+                            , historyPageDirection =
+                                request.historyRequestDirection
+                            })
+                    result
+        enqueueAppEvent runtime
+            (AppHistoryLoaded request normalized)
+        historyLoader
+
 -- | Construct the retained application state shared by the live entry point
 -- and renderer tests. Generated tests should start from the same defaults as
 -- a real fullscreen session instead of assembling an approximate state.
@@ -866,6 +1014,15 @@ initialFullscreenAppState
 initialFullscreenAppState runtime history initialAgent initialAgents initialClock =
     AppState
         { appUi = runtime.runtimeInitial
+        , appHistoryWindow =
+            emptyHistoryWindow
+                (HistoryGeneration 0)
+                historyWindowTurnBudget
+                historyWindowBlockBudget
+                historyWindowByteBudget
+        , appHistorySelectedBlock = Nothing
+        , appHistoryLiveStart = Nothing
+        , appNextHistoryBlockId = -1
         , appPermissionReply = Nothing
         , appRuntime = runtime
         , appSlashIndex = 0
@@ -907,6 +1064,259 @@ initialFullscreenAppState runtime history initialAgent initialAgents initialCloc
         , appSyntaxHighlighter = Nothing
         , appTerminalFocus = TerminalFocusUnknown
         }
+
+historyWindowTurnBudget :: Int
+historyWindowTurnBudget = 200
+
+historyWindowBlockBudget :: Int
+historyWindowBlockBudget = 1200
+
+historyWindowByteBudget :: Int
+historyWindowByteBudget = 8 * 1024 * 1024
+
+resetHistoryPage :: HistoryPage -> AppState -> AppState
+resetHistoryPage page state =
+    let
+        empty =
+            emptyHistoryWindow
+                page.historyPageGeneration
+                historyWindowTurnBudget
+                historyWindowBlockBudget
+                historyWindowByteBudget
+        (nextBlockId, remapped) =
+            remapHistoryPage state.appNextHistoryBlockId page
+        window =
+            either (const empty) id (applyHistoryPage remapped empty)
+    in state
+        { appUi = reduceUi UiConversationCleared state.appUi
+        , appHistoryWindow = window
+        , appHistorySelectedBlock = Nothing
+        , appHistoryLiveStart = Nothing
+        , appNextHistoryBlockId = nextBlockId
+        , appCompletionFlashes = Map.empty
+        , appConversationAnchor = Nothing
+        }
+
+setHistoryGeneration :: HistoryGeneration -> AppState -> AppState
+setHistoryGeneration generation state =
+    state
+        { appHistoryWindow =
+            state.appHistoryWindow
+                { historyWindowGeneration = generation
+                , historyWindowPending = Set.empty
+                }
+        }
+
+applyLoadedHistoryPage :: HistoryPage -> AppState -> AppState
+applyLoadedHistoryPage page state =
+    if page.historyPageGeneration
+        /= state.appHistoryWindow.historyWindowGeneration
+        then state
+        else
+            let
+                (nextBlockId, remapped) =
+                    remapHistoryPage state.appNextHistoryBlockId page
+                anchored =
+                    historyWindowSetAnchors
+                        (historyEdgeCursor
+                            page.historyPageDirection
+                            state.appHistoryWindow)
+                        (state.appHistorySelectedBlock >>=
+                            historyCursorForBlock
+                                state.appHistoryWindow)
+                        state.appHistoryWindow
+                window =
+                    either
+                        (const anchored)
+                        id
+                        (applyHistoryPage remapped anchored)
+                selected =
+                    state.appHistorySelectedBlock >>= \blockId ->
+                        if historyContainsBlock blockId window
+                            then Just blockId
+                            else Nothing
+            in state
+                { appHistoryWindow = window
+                , appHistorySelectedBlock = selected
+                , appNextHistoryBlockId = nextBlockId
+                }
+
+clearHistoryPending :: HistoryRequest -> AppState -> AppState
+clearHistoryPending request state =
+    state
+        { appHistoryWindow =
+            clearHistoryRequest request state.appHistoryWindow
+        }
+
+commitLiveHistoryTurn
+    :: HistoryTurn
+    -> HistoryCommit
+    -> AppState
+    -> AppState
+commitLiveHistoryTurn durableTurn commit state =
+    let
+        start =
+            case state.appHistoryLiveStart of
+                Just index -> index
+                Nothing
+                    | commit == HistoryCommitAppend ->
+                        Seq.length state.appUi.uiBlocks
+                    | otherwise -> 0
+        (nextBlockId, remappedBlocks) =
+            remapHistoryBlocks
+                state.appNextHistoryBlockId
+                durableTurn.historyTurnBlocks
+        remappedTurn =
+            durableTurn { historyTurnBlocks = remappedBlocks }
+        baseWindow =
+            case commit of
+                HistoryCommitAppend -> state.appHistoryWindow
+                HistoryCommitReplace ->
+                    emptyHistoryWindow
+                        state.appHistoryWindow.historyWindowGeneration
+                        historyWindowTurnBudget
+                        historyWindowBlockBudget
+                        historyWindowByteBudget
+                HistoryCommitReset ->
+                    emptyHistoryWindow
+                        state.appHistoryWindow.historyWindowGeneration
+                        historyWindowTurnBudget
+                        historyWindowBlockBudget
+                        historyWindowByteBudget
+        replacementPage =
+            HistoryPage
+                { historyPageGeneration =
+                    state.appHistoryWindow.historyWindowGeneration
+                , historyPageDirection = HistoryNewer
+                , historyPageTurns = Seq.singleton remappedTurn
+                , historyPageGenerationStart =
+                    remappedTurn.historyTurnCursor
+                , historyPageTotalTurns = 1
+                , historyPageHasOlder = False
+                , historyPageHasNewer = False
+                }
+        window =
+            case commit of
+                HistoryCommitAppend ->
+                    appendHistoryTurn remappedTurn baseWindow
+                _ ->
+                    either
+                        (const baseWindow)
+                        id
+                        (applyHistoryPage replacementPage baseWindow)
+        ui = truncateUiBlocks start state.appUi
+    in state
+        { appUi = ui
+        , appHistoryWindow = window
+        , appHistorySelectedBlock = Nothing
+        , appHistoryLiveStart = Nothing
+        , appNextHistoryBlockId = nextBlockId
+        , appConversationAnchor = Nothing
+        , appCompletionFlashes =
+            retainExistingFlashes ui state.appCompletionFlashes
+        }
+
+truncateUiBlocks :: Int -> UiState -> UiState
+truncateUiBlocks count ui =
+    let
+        blocks = Seq.take (max 0 count) ui.uiBlocks
+        indices =
+            Map.fromList
+                [ (block.blockId, index)
+                | (index, block) <- zip [0 ..] (toList blocks)
+                ]
+        selectedIndex =
+            ui.uiSelectedBlock >>= (`Map.lookup` indices)
+    in ui
+        { uiBlocks = blocks
+        , uiSelectedBlock =
+            selectedIndex >>= \index ->
+                (.blockId) <$> Seq.lookup index blocks
+        , uiSelectedBlockIndex = selectedIndex
+        , uiBlockIndices = indices
+        , uiTurnStartBlock = min count ui.uiTurnStartBlock
+        , uiAttemptStartBlock = min count ui.uiAttemptStartBlock
+        , uiToolCalls =
+            Map.filter
+                (\(index, _) -> index < count)
+                ui.uiToolCalls
+        , uiRetryCountdown = Nothing
+        }
+
+remapHistoryPage :: Int -> HistoryPage -> (Int, HistoryPage)
+remapHistoryPage nextId page =
+    let
+        (remaining, turns) =
+            foldl'
+                (\(current, accumulated) turn ->
+                    let (next, blocks) =
+                            remapHistoryBlocks
+                                current
+                                turn.historyTurnBlocks
+                    in (next, accumulated |> turn
+                        { historyTurnBlocks = blocks }))
+                (nextId, Seq.empty)
+                page.historyPageTurns
+    in (remaining, page { historyPageTurns = turns })
+
+remapHistoryBlocks :: Int -> Seq UiBlock -> (Int, Seq UiBlock)
+remapHistoryBlocks nextId =
+    foldl'
+        (\(current, blocks) block ->
+            ( current - 1
+            , blocks |> block { blockId = BlockId current }
+            ))
+        (nextId, Seq.empty)
+
+historyContainsBlock :: BlockId -> HistoryWindow -> Bool
+historyContainsBlock blockId =
+    any
+        (any ((== blockId) . (.blockId))
+            . toList
+            . (.historyTurnBlocks))
+        . toList
+        . (.historyWindowTurns)
+
+historyCursorForBlock
+    :: HistoryWindow
+    -> BlockId
+    -> Maybe HistoryCursor
+historyCursorForBlock window blockId =
+    (.historyTurnCursor)
+        <$> find
+            (any ((== blockId) . (.blockId))
+                . toList
+                . (.historyTurnBlocks))
+            (toList window.historyWindowTurns)
+
+historyEdgeCursor
+    :: HistoryDirection
+    -> HistoryWindow
+    -> Maybe HistoryCursor
+historyEdgeCursor direction window =
+    (.historyTurnCursor) <$> case direction of
+        HistoryOlder -> window.historyWindowTurns Seq.!? 0
+        HistoryNewer ->
+            window.historyWindowTurns
+                Seq.!? (Seq.length window.historyWindowTurns - 1)
+
+historyPageAnchorBlock
+    :: HistoryDirection
+    -> HistoryWindow
+    -> Maybe BlockId
+historyPageAnchorBlock direction window =
+    edgeTurn >>= edgeBlock
+  where
+    turns = window.historyWindowTurns
+    edgeTurn = case direction of
+        HistoryOlder -> turns Seq.!? 0
+        HistoryNewer -> turns Seq.!? (Seq.length turns - 1)
+    edgeBlock turn =
+        let blocks = turn.historyTurnBlocks
+        in case direction of
+            HistoryOlder -> (.blockId) <$> blocks Seq.!? 0
+            HistoryNewer ->
+                (.blockId) <$> blocks Seq.!? (Seq.length blocks - 1)
 
 wrapNativePreviewVty :: FullscreenRuntime -> V.Vty -> IO V.Vty
 wrapNativePreviewVty runtime vty
@@ -1522,8 +1932,13 @@ copyCodeBlock
 copyCodeBlock target blockId codeIndex = do
     state <- get
     let code =
-            conversationUiForTarget target state
-                >>= \ui -> selectedBlock ui blockId
+            (case target of
+                AgentRoot ->
+                    historyBlock state.appHistoryWindow blockId
+                        <|> selectedBlock state.appUi blockId
+                AgentChild _ ->
+                    conversationUiForTarget target state
+                        >>= \ui -> selectedBlock ui blockId)
                 >>= fencedCodeBlock codeIndex . (.blockBody)
     case code of
         Nothing ->
@@ -1918,17 +2333,24 @@ drawConversationPane state =
                     viewport ConversationViewport Vertical $
                         padLeftRight 2 (drawAgentConversation state entry)
         Nothing
-            | conversationIsEmpty state.appUi ->
+            | conversationIsEmpty state.appUi
+                && Seq.null
+                    state.appHistoryWindow.historyWindowTurns ->
                 padLeftRight 2 $
                     vBox
                         [ drawTranscript state
                         , drawEmptyConversation state
                         ]
             | otherwise ->
-                withVScrollBarRenderer conversationScrollbarRenderer $
-                    withVScrollBars OnRight $
-                        viewport ConversationViewport Vertical $
-                            padLeftRight 2 (drawTranscript state)
+                vBox $
+                    historyRangeWidgets state
+                        <> [ withVScrollBarRenderer
+                                conversationScrollbarRenderer $
+                                withVScrollBars OnRight $
+                                    viewport ConversationViewport Vertical $
+                                        padLeftRight 2
+                                            (drawTranscript state)
+                           ]
 
 selectedChildEntry :: AppState -> Maybe AgentEntry
 selectedChildEntry state =
@@ -2413,9 +2835,30 @@ waitingIndicatorAttr state =
 drawTranscript :: AppState -> Widget Name
 drawTranscript state =
     vBox $
-        [drawConversationBlocks state AgentRoot state.appUi]
+        [ vBox $
+            olderGap
+                <> map
+                    (drawBlock state AgentRoot state.appUi)
+                    historicalBlocks
+                <> newerGap
+                <> [drawConversationBlocks state AgentRoot state.appUi]
+        ]
             <> conversationReserveWidgets anchor
   where
+    historicalBlocks =
+        concatMap
+            (toList . (.historyTurnBlocks))
+            (toList state.appHistoryWindow.historyWindowTurns)
+    olderGap =
+        historyGapWidget
+            HistoryOlder
+            state.appHistoryWindow.historyWindowHasOlder
+            state.appHistoryWindow.historyWindowPending
+    newerGap =
+        historyGapWidget
+            HistoryNewer
+            state.appHistoryWindow.historyWindowHasNewer
+            state.appHistoryWindow.historyWindowPending
     anchor = state.appConversationAnchor
 
 -- | Cache completed transcript blocks in moderately sized groups.
@@ -2473,6 +2916,87 @@ drawConversationBlocks state target ui =
         map
             (drawTranscriptChunk state target ui)
             (Transcript.transcriptChunks ui.uiBlocks)
+
+historyRangeWidgets :: AppState -> [Widget Name]
+historyRangeWidgets state =
+    case historyRangeText state.appHistoryWindow of
+        Nothing -> []
+        Just range ->
+            [ padLeftRight 2 $
+                withAttr Theme.mutedAttr $
+                    hCenter (txt range)
+            ]
+
+historyRangeText :: HistoryWindow -> Maybe Text
+historyRangeText window = do
+    firstTurn <- window.historyWindowTurns Seq.!? 0
+    lastTurn <-
+        window.historyWindowTurns
+            Seq.!? (Seq.length window.historyWindowTurns - 1)
+    let HistoryCursor generationStart =
+            window.historyWindowGenerationStart
+        HistoryCursor firstCursor = firstTurn.historyTurnCursor
+        HistoryCursor lastCursor = lastTurn.historyTurnCursor
+        total = window.historyWindowTotalTurns
+        firstPosition = max 1 (firstCursor - generationStart + 1)
+        lastPosition = max firstPosition (lastCursor - generationStart + 1)
+        virtualized =
+            window.historyWindowHasOlder
+                || window.historyWindowHasNewer
+                || fromIntegral (Seq.length window.historyWindowTurns) < total
+        available =
+            [ label
+            | (isAvailable, label) <-
+                [ (window.historyWindowHasOlder, "older")
+                , (window.historyWindowHasNewer, "newer")
+                ]
+            , isAvailable
+            ]
+        suffix =
+            case available of
+                [] -> ""
+                labels ->
+                    " · "
+                        <> Text.intercalate "/" labels
+                        <> " load on scroll"
+    if total <= 0 || not virtualized
+        then Nothing
+        else
+            Just $
+                "Turns "
+                    <> showText firstPosition
+                    <> "–"
+                    <> showText (min total lastPosition)
+                    <> " of "
+                    <> showText total
+                    <> suffix
+
+historyGapWidget
+    :: HistoryDirection
+    -> Bool
+    -> Set.Set HistoryDirection
+    -> [Widget Name]
+historyGapWidget direction available pending
+    | not available = []
+    | otherwise =
+        [ padTopBottom 1 $
+            withAttr Theme.mutedAttr $
+                hCenter $
+                    txt $
+                        if direction `Set.member` pending
+                            then "… loading " <> directionLabel <> " turns …"
+                            else
+                                "… "
+                                    <> directionLabel
+                                    <> " persisted turns are unloaded …"
+        ]
+  where
+    directionLabel = case direction of
+        HistoryOlder -> "older"
+        HistoryNewer -> "newer"
+
+showText :: Show a => a -> Text
+showText = Text.pack . show
 
 stickyPromptLayers :: AppState -> [Widget Name]
 stickyPromptLayers state =
@@ -2581,7 +3105,10 @@ drawQuickStartPanel state =
 
 drawBlock :: AppState -> AgentTarget -> UiState -> UiBlock -> Widget Name
 drawBlock state target ui block =
-    let selected = ui.uiSelectedBlock == Just block.blockId
+    let selected =
+            ui.uiSelectedBlock == Just block.blockId
+                || (target == AgentRoot
+                    && state.appHistorySelectedBlock == Just block.blockId)
         highlighted =
             selected
                 && state.appUi.uiFocus == FocusScrollback
@@ -3527,11 +4054,24 @@ applyConversationUiEvent renderedContentHeight uiEvent state =
                             (if null state.appUi.uiBlocks
                                 then 0
                                 else renderedContentHeight)
+                , appHistoryLiveStart =
+                    case state.appHistoryLiveStart of
+                        Just start -> Just start
+                        Nothing -> Just (Seq.length state.appUi.uiBlocks)
                 }
         UiConversationCleared ->
             state
                 { appConversationAnchor = Nothing
                 , appConversationReflowQueued = False
+                , appHistoryWindow =
+                    emptyHistoryWindow
+                        state.appHistoryWindow.historyWindowGeneration
+                        historyWindowTurnBudget
+                        historyWindowBlockBudget
+                        historyWindowByteBudget
+                , appHistorySelectedBlock = Nothing
+                , appHistoryLiveStart = Nothing
+                , appNextHistoryBlockId = -1
                 }
         _ -> state
 
@@ -3889,6 +4429,53 @@ handleEventInner event = case event of
                 modify' \current ->
                     current { appSyntaxHighlighter = Just loaded }
                 invalidateCache
+    AppEvent (AppHistoryReset page) -> do
+        modify' (resetHistoryPage page)
+        invalidateCache
+        queueConversationReflow
+    AppEvent (AppHistoryLoaded request result) -> do
+        state <- get
+        when
+            (request.historyRequestGeneration
+                == state.appHistoryWindow.historyWindowGeneration)
+            do
+                let anchorBlock =
+                        historyPageAnchorBlock
+                            request.historyRequestDirection
+                            state.appHistoryWindow
+                case result of
+                    Left err ->
+                        modify' \current ->
+                            applyUiEvent
+                                (UiSetNotice
+                                    (Just (warningNotice
+                                        ("Could not load session history: "
+                                            <> err))))
+                                (clearHistoryPending request current)
+                    Right page ->
+                        modify' (applyLoadedHistoryPage page)
+                invalidateCache
+                case anchorBlock of
+                    Nothing -> pure ()
+                    Just blockId ->
+                        makeVisible
+                            (ConversationBlock AgentRoot blockId)
+                queueConversationReflow
+    AppEvent (AppHistoryCommitted generation turn commit) -> do
+        state <- get
+        let currentGeneration =
+                state.appHistoryWindow.historyWindowGeneration
+            applicable = case commit of
+                HistoryCommitAppend ->
+                    currentGeneration == generation
+                _ ->
+                    currentGeneration < generation
+        when applicable do
+            modify'
+                (commitLiveHistoryTurn turn commit
+                    . setHistoryGeneration generation)
+            invalidateCache
+            queueConversationReflow
     AppEvent (AppAgentSnapshot selected entries) -> do
         state <- get
         let normalized =
@@ -4452,20 +5039,7 @@ handleMouseDown name button =
         V.BScrollDown -> scrollConversationBy mouseScrollLines
         V.BLeft -> case name of
             ConversationBlock target ident ->
-                case target of
-                    AgentRoot ->
-                        applyLocalUiEventWith
-                            (UiActivateBlock ident)
-                            (applyUiEvent
-                                (UiFocusChanged FocusScrollback))
-                    AgentChild _ -> do
-                        modify' $
-                            applyChildConversationUiEvent
-                                target
-                                (UiActivateBlock ident)
-                        applyLocalUiEvent
-                            (UiFocusChanged FocusScrollback)
-                        queueConversationReflow
+                activateConversationBlock target ident
             ComposerArea ->
                 applyLocalUiEvent (UiFocusChanged FocusComposer)
             _ -> pure ()
@@ -4490,11 +5064,13 @@ handleScrollbackKey = \case
         | V.MCtrl `elem` modifiers -> scrollConversationHalfPage Down
     V.EvKey V.KHome [] -> do
         leaveFollow
+        requestHistoryPage HistoryOlder
         vScrollToBeginning scroll
         queueConversationReflow
     V.EvKey V.KEnd [] -> resumeConversationFollow
     V.EvKey (V.KChar 'g') [] -> do
         leaveFollow
+        requestHistoryPage HistoryOlder
         vScrollToBeginning scroll
         queueConversationReflow
     V.EvKey (V.KChar 'G') [] -> resumeConversationFollow
@@ -4511,24 +5087,49 @@ handleScrollbackKey = \case
     moveBlock delta = do
         state <- get
         let target = state.appAgentSelected
-        applyActiveConversationUiEvent (UiMoveSelection delta)
-        state <- get
-        case (.uiSelectedBlock) =<< conversationUiForTarget target state of
-            Just ident -> do
-                makeVisible (ConversationBlock target ident)
+            blocks = conversationBlocks target state
+            selected =
+                selectedConversationBlockId target state
+            current =
+                fromMaybe
+                    (if delta < 0 then length blocks else -1)
+                    (selected >>= \ident ->
+                        findIndex ((== ident) . (.blockId)) blocks)
+            nextIndex =
+                max 0 (min (length blocks - 1) (current + delta))
+        case drop nextIndex blocks of
+            block : _ -> do
+                selectConversationBlock target block.blockId
+                makeVisible (ConversationBlock target block.blockId)
                 queueConversationReflow
-            Nothing -> pure ()
+            [] -> pure ()
     toggle = do
-        applyActiveConversationUiEvent UiToggleSelected
+        state <- get
+        case (state.appAgentSelected, state.appHistorySelectedBlock) of
+            (AgentRoot, Just blockId) ->
+                modify' \current ->
+                    current
+                        { appHistoryWindow =
+                            mapHistoryBlock
+                                blockId
+                                (\block ->
+                                    block
+                                        { blockExpanded =
+                                            not block.blockExpanded
+                                        })
+                                current.appHistoryWindow
+                        }
+            _ -> applyActiveConversationUiEvent UiToggleSelected
         queueConversationReflow
     focusComposer =
-        applyLocalUiEvent (UiFocusChanged FocusComposer)
+        do
+            modify' \state -> state { appHistorySelectedBlock = Nothing }
+            applyLocalUiEvent (UiFocusChanged FocusComposer)
     leaveFollow =
         applyLocalUiEvent (UiSetFollow False)
     copySelected = do
         state <- get
-        let ui = activeConversationUi state
-        case ui.uiSelectedBlock >>= selectedBlock ui of
+        case selectedConversationBlock state.appAgentSelected state of
             Nothing -> pure ()
             Just block -> do
                 copied <- liftIO $
@@ -4587,6 +5188,11 @@ conversationViewportHeight =
 
 scrollConversationBy :: Int -> EventM Name AppState ()
 scrollConversationBy amount = do
+    state <- get
+    when (state.appAgentSelected == AgentRoot && amount /= 0) $
+        requestHistoryNear
+            (if amount < 0 then HistoryOlder else HistoryNewer)
+            amount
     viewportBounds <-
         lookupViewport ConversationViewport >>= \case
             Just (VP _ top (_, height) (_, contentHeight)) ->
@@ -4606,6 +5212,46 @@ scrollConversationBy amount = do
             queueConversationReflow
   where
     scroll = viewportScroll ConversationViewport
+
+requestHistoryNear
+    :: HistoryDirection
+    -> Int
+    -> EventM Name AppState ()
+requestHistoryNear direction amount =
+    lookupViewport ConversationViewport >>= \case
+        Nothing -> requestHistoryPage direction
+        Just (VP _ top (_, height) (_, contentHeight)) ->
+            let nearEdge = case direction of
+                    HistoryOlder ->
+                        top + amount <= max 1 height
+                    HistoryNewer ->
+                        top + height + amount
+                            >= contentHeight - max 1 height
+            in when nearEdge (requestHistoryPage direction)
+
+requestHistoryPage
+    :: HistoryDirection
+    -> EventM Name AppState ()
+requestHistoryPage direction = do
+    state <- get
+    case
+        if state.appAgentSelected == AgentRoot
+            then historyWindowRequest direction state.appHistoryWindow
+            else Nothing of
+        Nothing -> pure ()
+        Just request -> do
+            modify' \current ->
+                current
+                    { appHistoryWindow =
+                        markHistoryRequest
+                            direction
+                            current.appHistoryWindow
+                    }
+            liftIO $
+                atomically $
+                    writeTQueue
+                        state.appRuntime.runtimeHistoryRequests
+                        request
 
 setConversationFollow :: Bool -> EventM Name AppState ()
 setConversationFollow follow =
@@ -4673,3 +5319,151 @@ isSubmittedPrompt = \case
 selectedBlock :: UiState -> BlockId -> Maybe UiBlock
 selectedBlock state ident =
     find ((== ident) . (.blockId)) (toList state.uiBlocks)
+
+conversationBlocks :: AgentTarget -> AppState -> [UiBlock]
+conversationBlocks target state =
+    case target of
+        AgentRoot ->
+            concatMap
+                (toList . (.historyTurnBlocks))
+                (toList state.appHistoryWindow.historyWindowTurns)
+                <> toList state.appUi.uiBlocks
+        AgentChild _ ->
+            maybe [] (toList . (.uiBlocks))
+                (conversationUiForTarget target state)
+
+historyBlock :: HistoryWindow -> BlockId -> Maybe UiBlock
+historyBlock window ident =
+    find ((== ident) . (.blockId)) $
+        concatMap
+            (toList . (.historyTurnBlocks))
+            (toList window.historyWindowTurns)
+
+selectedConversationBlockId
+    :: AgentTarget
+    -> AppState
+    -> Maybe BlockId
+selectedConversationBlockId target state =
+    case target of
+        AgentRoot ->
+            state.appHistorySelectedBlock
+                <|> state.appUi.uiSelectedBlock
+        AgentChild _ ->
+            conversationUiForTarget target state
+                >>= (.uiSelectedBlock)
+
+selectedConversationBlock
+    :: AgentTarget
+    -> AppState
+    -> Maybe UiBlock
+selectedConversationBlock target state =
+    selectedConversationBlockId target state >>= \ident ->
+        find ((== ident) . (.blockId))
+            (conversationBlocks target state)
+
+selectConversationBlock
+    :: AgentTarget
+    -> BlockId
+    -> EventM Name AppState ()
+selectConversationBlock target ident = do
+    state <- get
+    case target of
+        AgentRoot ->
+            case historyBlock state.appHistoryWindow ident of
+                Just _ ->
+                    modify' \current ->
+                        current
+                            { appHistorySelectedBlock = Just ident
+                            , appUi =
+                                (reduceUi
+                                    (UiFocusChanged FocusScrollback)
+                                    current.appUi)
+                                    { uiSelectedBlock = Nothing
+                                    , uiSelectedBlockIndex = Nothing
+                                    }
+                            }
+                Nothing -> do
+                    modify' \current ->
+                        current { appHistorySelectedBlock = Nothing }
+                    applyLocalUiEventWith
+                        (UiSelectBlock ident)
+                        (applyUiEvent
+                            (UiFocusChanged FocusScrollback))
+        AgentChild _ -> do
+            modify' \current ->
+                (applyChildConversationUiEvent
+                    target
+                    (UiSelectBlock ident)
+                    current)
+                    { appHistorySelectedBlock = Nothing
+                    , appUi =
+                        reduceUi
+                            (UiFocusChanged FocusScrollback)
+                            current.appUi
+                    }
+
+activateConversationBlock
+    :: AgentTarget
+    -> BlockId
+    -> EventM Name AppState ()
+activateConversationBlock target ident = do
+    state <- get
+    case target of
+        AgentRoot ->
+            case historyBlock state.appHistoryWindow ident of
+                Just _ -> do
+                    selectConversationBlock target ident
+                    modify' \current ->
+                        current
+                            { appHistoryWindow =
+                                mapHistoryBlock
+                                    ident
+                                    (\block ->
+                                        block
+                                            { blockExpanded =
+                                                not block.blockExpanded
+                                            })
+                                    current.appHistoryWindow
+                            }
+                Nothing -> do
+                    modify' \current ->
+                        current { appHistorySelectedBlock = Nothing }
+                    applyLocalUiEventWith
+                        (UiActivateBlock ident)
+                        (applyUiEvent
+                            (UiFocusChanged FocusScrollback))
+        AgentChild _ -> do
+            modify' \current ->
+                (applyChildConversationUiEvent
+                    target
+                    (UiActivateBlock ident)
+                    current)
+                    { appHistorySelectedBlock = Nothing
+                    , appUi =
+                        reduceUi
+                            (UiFocusChanged FocusScrollback)
+                            current.appUi
+                    }
+    queueConversationReflow
+
+mapHistoryBlock
+    :: BlockId
+    -> (UiBlock -> UiBlock)
+    -> HistoryWindow
+    -> HistoryWindow
+mapHistoryBlock ident update window =
+    window
+        { historyWindowTurns =
+            fmap
+                (\turn ->
+                    turn
+                        { historyTurnBlocks =
+                            fmap
+                                (\block ->
+                                    if block.blockId == ident
+                                        then update block
+                                        else block)
+                                turn.historyTurnBlocks
+                        })
+                window.historyWindowTurns
+        }

--- a/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
@@ -5,6 +5,7 @@ module Agent.CLI.TUI.Composer
     , appendFullscreenInput
     , applyComposerUiEvent
     , composerEscapeAction
+    , composerScrollbackAvailable
     , controlAttr
     , controlInteractionAttr
     , decodePaste
@@ -51,6 +52,7 @@ import Agent.CLI.Options (reasoningEfforts)
 import qualified Agent.CLI.TUI.Bridge as Bridge
 import Agent.CLI.TUI.Composer.Buffer
 import Agent.CLI.TUI.Composer.Edit
+import Agent.CLI.TUI.History (HistoryWindow, historyWindowHasBlocks)
 import Agent.CLI.TUI.Types
 import qualified Agent.TUI.Theme as Theme
 import Agent.TUI.Model
@@ -82,6 +84,10 @@ type ApplyLocalUiEvent =
     UiEvent
     -> (AppState -> AppState)
     -> EventM Name AppState ()
+
+composerScrollbackAvailable :: UiState -> HistoryWindow -> Bool
+composerScrollbackAvailable ui history =
+    not (Seq.null ui.uiBlocks) || historyWindowHasBlocks history
 
 drawSlashMenu :: AppState -> Widget Name
 drawSlashMenu state = case currentSlashMenu state of
@@ -550,7 +556,10 @@ handleComposerKey
             case slashMenu of
                 Just menu -> acceptSlash menu
                 Nothing ->
-                    when (not (Seq.null ui.uiBlocks)) $
+                    when
+                        (composerScrollbackAvailable
+                            ui
+                            state.appHistoryWindow) $
                         modifyUi (UiFocusChanged FocusScrollback)
         V.EvKey V.KEnter [V.MShift] ->
             insertText "\n"

--- a/packages/agent-cli/src/Agent/CLI/TUI/History.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/History.hs
@@ -1,0 +1,442 @@
+{-# LANGUAGE NoFieldSelectors #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+
+-- | Pure state transitions for a bounded, cursor-backed transcript window.
+--
+-- The fullscreen renderer owns the actual request worker.  This module only
+-- describes the durable turn range currently materialised in memory, making
+-- page insertion, stale-result rejection, and budgeted eviction testable
+-- without Brick or PostgreSQL.
+module Agent.CLI.TUI.History
+    ( HistoryCursor(..)
+    , HistoryDirection(..)
+    , HistoryGeneration(..)
+    , HistoryPage(..)
+    , HistoryPageRejection(..)
+    , HistoryRequest(..)
+    , HistoryTurn(..)
+    , HistoryWindow(..)
+    , appendHistoryTurn
+    , applyHistoryPage
+    , clearHistoryRequest
+    , emptyHistoryWindow
+    , historyWindowCanRequest
+    , historyWindowCursors
+    , historyWindowHasBlocks
+    , historyWindowLoadedBytes
+    , historyWindowOlderAvailable
+    , historyWindowNewerAvailable
+    , historyWindowLoadedBlocks
+    , historyWindowLoadedTurns
+    , historyWindowRequest
+    , historyWindowSelected
+    , historyWindowSetAnchors
+    , historyWindowSetGeneration
+    , historyWindowTurn
+    , historyWindowVisible
+    , markHistoryRequest
+    ) where
+
+import Agent.TUI.Model (UiBlock(..))
+import Data.Foldable (find, toList)
+import Data.Int (Int64)
+import Data.List (sortOn)
+import qualified Data.Sequence as Seq
+import Data.Sequence (Seq)
+import qualified Data.Set as Set
+import Data.Set (Set)
+import qualified Data.Text as Text
+
+newtype HistoryCursor = HistoryCursor Int64
+    deriving (Eq, Ord, Show)
+
+newtype HistoryGeneration = HistoryGeneration Int64
+    deriving (Eq, Ord, Show)
+
+data HistoryDirection
+    = HistoryOlder
+    | HistoryNewer
+    deriving (Eq, Ord, Show)
+
+data HistoryTurn = HistoryTurn
+    { historyTurnCursor :: !HistoryCursor
+    , historyTurnBlocks :: !(Seq UiBlock)
+    }
+    deriving (Eq, Show)
+
+-- | A page is ordered in ascending durable turn order, irrespective of the
+-- direction in which it was requested.
+data HistoryPage = HistoryPage
+    { historyPageGeneration :: !HistoryGeneration
+    , historyPageDirection :: !HistoryDirection
+    , historyPageTurns :: !(Seq HistoryTurn)
+    , historyPageGenerationStart :: !HistoryCursor
+    , historyPageTotalTurns :: !Int64
+    , historyPageHasOlder :: !Bool
+    , historyPageHasNewer :: !Bool
+    }
+    deriving (Eq, Show)
+
+data HistoryRequest = HistoryRequest
+    { historyRequestGeneration :: !HistoryGeneration
+    , historyRequestDirection :: !HistoryDirection
+    , historyRequestCursor :: !(Maybe HistoryCursor)
+    }
+    deriving (Eq, Show)
+
+data HistoryWindow = HistoryWindow
+    { historyWindowGeneration :: !HistoryGeneration
+    , historyWindowTurns :: !(Seq HistoryTurn)
+    , historyWindowHasOlder :: !Bool
+    , historyWindowHasNewer :: !Bool
+    , historyWindowMaxTurns :: !Int
+    , historyWindowMaxBlocks :: !Int
+    , historyWindowMaxBytes :: !Int
+    , historyWindowGenerationStart :: !HistoryCursor
+    , historyWindowTotalTurns :: !Int64
+    , historyWindowPending :: !(Set HistoryDirection)
+    , historyWindowVisibleAnchor :: !(Maybe HistoryCursor)
+    , historyWindowSelectedAnchor :: !(Maybe HistoryCursor)
+    }
+    deriving (Eq, Show)
+
+data HistoryPageRejection
+    = HistoryPageStale !HistoryGeneration
+    | HistoryPageWrongDirection !HistoryDirection
+    deriving (Eq, Show)
+
+emptyHistoryWindow
+    :: HistoryGeneration
+    -> Int
+    -> Int
+    -> Int
+    -> HistoryWindow
+emptyHistoryWindow generation maxTurns maxBlocks maxBytes =
+    HistoryWindow
+        { historyWindowGeneration = generation
+        , historyWindowTurns = Seq.empty
+        , historyWindowHasOlder = False
+        , historyWindowHasNewer = False
+        , historyWindowMaxTurns = max 1 maxTurns
+        , historyWindowMaxBlocks = max 1 maxBlocks
+        , historyWindowMaxBytes = max 1 maxBytes
+        , historyWindowGenerationStart = HistoryCursor 0
+        , historyWindowTotalTurns = 0
+        , historyWindowPending = Set.empty
+        , historyWindowVisibleAnchor = Nothing
+        , historyWindowSelectedAnchor = Nothing
+        }
+
+historyWindowLoadedTurns :: HistoryWindow -> Int
+historyWindowLoadedTurns = Seq.length . (.historyWindowTurns)
+
+historyWindowLoadedBlocks :: HistoryWindow -> Int
+historyWindowLoadedBlocks =
+    sum . fmap (Seq.length . (.historyTurnBlocks)) . (.historyWindowTurns)
+
+historyWindowLoadedBytes :: HistoryWindow -> Int
+historyWindowLoadedBytes =
+    sum . fmap historyTurnBytes . (.historyWindowTurns)
+
+historyWindowHasBlocks :: HistoryWindow -> Bool
+historyWindowHasBlocks = not . Seq.null . (.historyWindowTurns)
+
+historyWindowOlderAvailable :: HistoryWindow -> Bool
+historyWindowOlderAvailable = (.historyWindowHasOlder)
+
+historyWindowNewerAvailable :: HistoryWindow -> Bool
+historyWindowNewerAvailable = (.historyWindowHasNewer)
+
+historyWindowVisible :: HistoryWindow -> Maybe HistoryCursor
+historyWindowVisible = (.historyWindowVisibleAnchor)
+
+historyWindowSelected :: HistoryWindow -> Maybe HistoryCursor
+historyWindowSelected = (.historyWindowSelectedAnchor)
+
+historyWindowCursors :: HistoryWindow -> Seq HistoryCursor
+historyWindowCursors = fmap (.historyTurnCursor) . (.historyWindowTurns)
+
+historyWindowTurn
+    :: HistoryCursor
+    -> HistoryWindow
+    -> Maybe HistoryTurn
+historyWindowTurn cursor =
+    find (\turn -> turn.historyTurnCursor == cursor)
+        . (.historyWindowTurns)
+
+historyWindowSetAnchors
+    :: Maybe HistoryCursor
+    -> Maybe HistoryCursor
+    -> HistoryWindow
+    -> HistoryWindow
+historyWindowSetAnchors visible selected window =
+    window
+        { historyWindowVisibleAnchor = keepLoaded visible
+        , historyWindowSelectedAnchor = keepLoaded selected
+        }
+  where
+    keepLoaded cursor =
+        cursor >>= \value ->
+            if value `Set.member` loaded
+                then Just value
+                else Nothing
+
+    loaded = Set.fromList (toList (historyWindowCursors window))
+
+-- | Switch to a new provider/session generation and discard all materialised
+-- blocks.  Budgets are intentionally retained across the switch.
+historyWindowSetGeneration
+    :: HistoryGeneration
+    -> HistoryWindow
+    -> HistoryWindow
+historyWindowSetGeneration generation window =
+    window
+        { historyWindowGeneration = generation
+        , historyWindowTurns = Seq.empty
+        , historyWindowHasOlder = False
+        , historyWindowHasNewer = False
+        , historyWindowGenerationStart = HistoryCursor 0
+        , historyWindowTotalTurns = 0
+        , historyWindowPending = Set.empty
+        , historyWindowVisibleAnchor = Nothing
+        , historyWindowSelectedAnchor = Nothing
+        }
+
+historyWindowCanRequest
+    :: HistoryDirection
+    -> HistoryWindow
+    -> Bool
+historyWindowCanRequest direction window =
+    not (direction `Set.member` window.historyWindowPending)
+        && case direction of
+            HistoryOlder -> window.historyWindowHasOlder
+            HistoryNewer -> window.historyWindowHasNewer
+
+historyWindowRequest
+    :: HistoryDirection
+    -> HistoryWindow
+    -> Maybe HistoryRequest
+historyWindowRequest direction window
+    | not (historyWindowCanRequest direction window) = Nothing
+    | otherwise =
+        Just HistoryRequest
+            { historyRequestGeneration = window.historyWindowGeneration
+            , historyRequestDirection = direction
+            , historyRequestCursor =
+                case direction of
+                    HistoryOlder ->
+                        window.historyWindowTurns
+                            Seq.!? 0
+                            >>= Just . (.historyTurnCursor)
+                    HistoryNewer ->
+                        window.historyWindowTurns
+                            Seq.!? (Seq.length window.historyWindowTurns - 1)
+                            >>= Just . (.historyTurnCursor)
+            }
+
+-- | Mark a request as in flight.  A request that cannot currently be made is
+-- ignored, which keeps event handlers idempotent when scroll ticks coalesce.
+markHistoryRequest
+    :: HistoryDirection
+    -> HistoryWindow
+    -> HistoryWindow
+markHistoryRequest direction window =
+    case historyWindowRequest direction window of
+        Nothing -> window
+        Just _ ->
+            window
+                { historyWindowPending =
+                    Set.insert direction window.historyWindowPending
+                }
+
+clearHistoryRequest :: HistoryRequest -> HistoryWindow -> HistoryWindow
+clearHistoryRequest request window
+    | request.historyRequestGeneration /= window.historyWindowGeneration =
+        window
+    | otherwise =
+        window
+            { historyWindowPending =
+                Set.delete
+                    request.historyRequestDirection
+                    window.historyWindowPending
+            }
+
+-- | Archive a newly committed latest turn. If the current window is not at
+-- the durable tail, reset it to that turn rather than creating an internal
+-- cursor gap that the edge-only paging model cannot represent.
+appendHistoryTurn :: HistoryTurn -> HistoryWindow -> HistoryWindow
+appendHistoryTurn turn window =
+    either (const base) id (applyHistoryPage page base)
+  where
+    disconnected = window.historyWindowHasNewer
+    base
+        | disconnected =
+            emptyHistoryWindow
+                window.historyWindowGeneration
+                window.historyWindowMaxTurns
+                window.historyWindowMaxBlocks
+                window.historyWindowMaxBytes
+        | otherwise = window
+    page =
+        HistoryPage
+            { historyPageGeneration = window.historyWindowGeneration
+            , historyPageDirection = HistoryNewer
+            , historyPageTurns = Seq.singleton turn
+            , historyPageGenerationStart =
+                window.historyWindowGenerationStart
+            , historyPageTotalTurns =
+                window.historyWindowTotalTurns + 1
+            , historyPageHasOlder =
+                if disconnected
+                    then window.historyWindowTotalTurns > 0
+                    else window.historyWindowHasOlder
+            , historyPageHasNewer = False
+            }
+
+applyHistoryPage
+    :: HistoryPage
+    -> HistoryWindow
+    -> Either HistoryPageRejection HistoryWindow
+applyHistoryPage page window
+    | page.historyPageGeneration /= window.historyWindowGeneration =
+        Left (HistoryPageStale page.historyPageGeneration)
+    | otherwise =
+        Right (mergePage page window)
+
+mergePage :: HistoryPage -> HistoryWindow -> HistoryWindow
+mergePage page window =
+    trimWindowPrefer
+        (case direction of
+            HistoryOlder -> HistoryNewer
+            HistoryNewer -> HistoryOlder)
+        window'
+            { historyWindowPending =
+                Set.delete direction window.historyWindowPending
+            , historyWindowGenerationStart =
+                page.historyPageGenerationStart
+            , historyWindowTotalTurns =
+                page.historyPageTotalTurns
+            , historyWindowHasOlder =
+                page.historyPageHasOlder
+            , historyWindowHasNewer =
+                page.historyPageHasNewer
+            }
+  where
+    direction = page.historyPageDirection
+    incoming = uniqueTurns page.historyPageTurns
+    existing = window.historyWindowTurns
+    merged =
+        case direction of
+            HistoryOlder -> incoming <> existing
+            HistoryNewer -> existing <> incoming
+    window' = window { historyWindowTurns = uniqueTurns (sortTurns merged) }
+
+sortTurns :: Seq HistoryTurn -> Seq HistoryTurn
+sortTurns = Seq.fromList . sortOn (.historyTurnCursor) . toList
+
+uniqueTurns :: Seq HistoryTurn -> Seq HistoryTurn
+uniqueTurns turns = Seq.fromList (reverse uniqueReversed)
+  where
+    (uniqueReversed, _) =
+        foldl
+            (\(kept, seen) turn ->
+                if turn.historyTurnCursor `Set.member` seen
+                    then (kept, seen)
+                    else
+                        ( turn : kept
+                        , Set.insert turn.historyTurnCursor seen
+                        )
+            )
+            ([], Set.empty)
+            (toList turns)
+
+trimWindowPrefer
+    :: HistoryDirection
+    -> HistoryWindow
+    -> HistoryWindow
+trimWindowPrefer preferred window
+    | withinBudget window = window
+    | otherwise =
+        case preferredEvictionDirection preferred window of
+            Nothing -> window
+            Just direction ->
+                trimWindowPrefer preferred (evictOne direction window)
+
+withinBudget :: HistoryWindow -> Bool
+withinBudget window =
+    historyWindowLoadedTurns window <= window.historyWindowMaxTurns
+        && historyWindowLoadedBlocks window <= window.historyWindowMaxBlocks
+        && historyWindowLoadedBytes window <= window.historyWindowMaxBytes
+
+historyTurnBytes :: HistoryTurn -> Int
+historyTurnBytes =
+    sum
+        . fmap historyBlockBytes
+        . toList
+        . (.historyTurnBlocks)
+
+historyBlockBytes :: UiBlock -> Int
+historyBlockBytes block =
+    96
+        + textBytes block.blockTitle
+        + textBytes block.blockBody
+        + textBytes block.blockTimestamp
+        + textBytes block.blockDetail
+        + maybe 0 textBytes block.blockCallId
+  where
+    -- UTF-16-ish accounting deliberately overestimates common ASCII content
+    -- and keeps retained history bounded without serialising blocks again.
+    textBytes = (2 *) . Text.length
+
+preferredEvictionDirection
+    :: HistoryDirection
+    -> HistoryWindow
+    -> Maybe HistoryDirection
+preferredEvictionDirection preferred window
+    | canEvict preferred = Just preferred
+    | canEvict fallback = Just fallback
+    | otherwise = Nothing
+  where
+    fallback = case preferred of
+        HistoryOlder -> HistoryNewer
+        HistoryNewer -> HistoryOlder
+    canEvict direction =
+        case edgeTurn direction window of
+            Nothing -> False
+            Just turn ->
+                let cursor = turn.historyTurnCursor
+                in Just cursor /= window.historyWindowVisibleAnchor
+                    && Just cursor
+                        /= window.historyWindowSelectedAnchor
+
+edgeTurn :: HistoryDirection -> HistoryWindow -> Maybe HistoryTurn
+edgeTurn direction window =
+    case direction of
+        HistoryOlder -> window.historyWindowTurns Seq.!? 0
+        HistoryNewer ->
+            window.historyWindowTurns
+                Seq.!? (Seq.length (window.historyWindowTurns) - 1)
+
+evictOne :: HistoryDirection -> HistoryWindow -> HistoryWindow
+evictOne direction window =
+    case direction of
+        HistoryOlder ->
+            window
+                { historyWindowTurns = dropFirst
+                , historyWindowHasOlder = True
+                }
+        HistoryNewer ->
+            window
+                { historyWindowTurns = dropLast
+                , historyWindowHasNewer = True
+                }
+  where
+    turns = window.historyWindowTurns
+    dropFirst =
+        case turns of
+            _ Seq.:<| rest -> rest
+            _ -> Seq.empty
+    dropLast =
+        case Seq.viewr turns of
+            Seq.EmptyR -> Seq.empty
+            rest Seq.:> _ -> rest

--- a/packages/agent-cli/src/Agent/CLI/TUI/SessionHistory.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/SessionHistory.hs
@@ -1,0 +1,266 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Project durable session turns into the bounded fullscreen history model.
+module Agent.CLI.TUI.SessionHistory
+    ( sessionHistoryPage
+    , sessionHistoryTurn
+    ) where
+
+import Agent.CLI.Session
+    ( SessionTurn(..)
+    , SessionTurnPage(..)
+    , TranscriptEffect(..)
+    )
+import Agent.CLI.TUI.History
+    ( HistoryCursor(..)
+    , HistoryDirection
+    , HistoryGeneration
+    , HistoryPage(..)
+    , HistoryTurn(..)
+    )
+import Agent.Loop
+    ( LoopEvent(..)
+    )
+import Agent.OpenAI.Compaction (isCompactSessionTurn)
+import Agent.Responses.Types
+    ( CustomToolCall(..)
+    , CustomToolCallOutput(..)
+    , FunctionCall(..)
+    , FunctionCallOutput(..)
+    , MessageContent(..)
+    , ReasoningItem(..)
+    , ReasoningSummaryPart(..)
+    , ResponseContentPart(..)
+    , ResponseItem(..)
+    , ResponseMessage(..)
+    , ResponseRole(..)
+    )
+import Agent.ToolDispatch
+    ( ToolCallKind(..)
+    , ToolCallResult(..)
+    , customToolCall
+    , functionToolCall
+    )
+import Agent.TUI.Model
+    ( BlockKind(..)
+    , BlockState(..)
+    , UiBlock(..)
+    , UiEvent(..)
+    , UiState(..)
+    , initialUiState
+    , reduceUi
+    )
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString.Lazy as LazyByteString
+import Data.Foldable (toList)
+import Data.Maybe (mapMaybe)
+import qualified Data.Sequence as Seq
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as TextEncoding
+import Data.Text.Encoding.Error (lenientDecode)
+
+sessionHistoryPage
+    :: HistoryGeneration
+    -> HistoryDirection
+    -> SessionTurnPage
+    -> HistoryPage
+sessionHistoryPage generation direction page =
+    HistoryPage
+        { historyPageGeneration = generation
+        , historyPageDirection = direction
+        , historyPageTurns =
+            Seq.fromList
+                [ sessionHistoryTurn cursor turn
+                | (cursor, turn) <- page.pageTurns
+                ]
+        , historyPageGenerationStart =
+            HistoryCursor page.pageGenerationStart
+        , historyPageTotalTurns = page.pageTotalTurns
+        , historyPageHasOlder = page.pageHasOlder
+        , historyPageHasNewer = page.pageHasNewer
+        }
+
+sessionHistoryTurn :: Integral cursor => cursor -> SessionTurn -> HistoryTurn
+sessionHistoryTurn cursor turn =
+    HistoryTurn
+        { historyTurnCursor =
+            HistoryCursor (fromIntegral cursor)
+        , historyTurnBlocks =
+            (projectTurn turn).uiBlocks
+        }
+
+projectTurn :: SessionTurn -> UiState
+projectTurn turn =
+    case turn.turnEffect of
+        TranscriptAppend -> addRegularTurn turn.turnItems initialUiState turn
+        TranscriptReset -> addResetTurn initialUiState turn
+        TranscriptReplace
+            | isCompactSessionTurn turn.turnUserText ->
+                addResetTurn initialUiState turn
+            | otherwise ->
+                addRegularTurn
+                    (replacementDisplayItems turn)
+                    initialUiState
+                    turn
+
+addResetTurn :: UiState -> SessionTurn -> UiState
+addResetTurn state turn =
+    case turn.turnAssistantText of
+        Nothing -> state
+        Just text -> reduceUi (UiHistory text) state
+
+addRegularTurn :: [ResponseItem] -> UiState -> SessionTurn -> UiState
+addRegularTurn items state turn =
+    let withUser =
+            if Text.null (Text.strip turn.turnUserText)
+                then state
+                else reduceUi
+                    (UiUserSubmitted turn.turnUserText)
+                    state
+        withItems = foldl' projectItem withUser items
+        withAssistant =
+            if hasAssistantBlock withItems
+                then withItems
+                else case turn.turnAssistantText of
+                    Nothing -> withItems
+                    Just text ->
+                        reduceUi (UiAssistantHistory text) withItems
+        terminalState =
+            if turn.turnError == Nothing
+                then BlockComplete
+                else BlockFailed
+        finalized = reduceUi (UiTurnEnded terminalState) withAssistant
+    in case turn.turnError of
+        Nothing -> finalized
+        Just err -> reduceUi (UiErrorMessage err) finalized
+
+-- Automatic compaction persists a complete replacement transcript. The
+-- history row should display only the current user turn after that checkpoint,
+-- not rematerialise the entire compacted context into one virtualised page.
+replacementDisplayItems :: SessionTurn -> [ResponseItem]
+replacementDisplayItems turn =
+    case lastMatchingUserIndex turn.turnUserText turn.turnItems of
+        Nothing -> []
+        Just index -> drop (index + 1) turn.turnItems
+
+lastMatchingUserIndex :: Text.Text -> [ResponseItem] -> Maybe Int
+lastMatchingUserIndex prompt =
+    foldl'
+        (\found (index, item) ->
+            case item of
+                MessageItem message
+                    | message.role == RoleUser
+                    , Text.strip (messageText message.content)
+                        == Text.strip prompt ->
+                        Just index
+                _ -> found)
+        Nothing
+        . zip [0 ..]
+
+projectItem :: UiState -> ResponseItem -> UiState
+projectItem state = \case
+    MessageItem message
+        | message.role == RoleAssistant ->
+            appendText (UiLoop . TextDelta) (messageText message.content) state
+        | otherwise -> state
+    ReasoningItemValue reasoning ->
+        appendText
+            (UiLoop . ReasoningDelta)
+            (reasoningText reasoning)
+            state
+    FunctionCallItem call ->
+        reduceUi
+            (UiLoop
+                (ToolStarted
+                    (functionToolCall
+                        call.callId
+                        call.name
+                        call.arguments)))
+            state
+    CustomToolCallItem call ->
+        reduceUi
+            (UiLoop
+                (ToolStarted
+                    (customToolCall
+                        call.callId
+                        call.name
+                        call.input)))
+            state
+    FunctionCallOutputItem output ->
+        reduceUi
+            (UiLoop
+                (ToolFinished
+                    (ToolCallResult
+                        output.callId
+                        (renderJsonValue output.output)
+                        FunctionCallKind)))
+            state
+    CustomToolCallOutputItem output ->
+        reduceUi
+            (UiLoop
+                (ToolFinished
+                    (ToolCallResult
+                        output.callId
+                        (renderJsonValue output.output)
+                        CustomCallKind)))
+            state
+    _ -> state
+
+appendText :: (Text.Text -> UiEvent) -> Text.Text -> UiState -> UiState
+appendText event text state
+    | Text.null (Text.strip text) = state
+    | otherwise = reduceUi (event text) state
+
+hasAssistantBlock :: UiState -> Bool
+hasAssistantBlock =
+    any
+        (\block ->
+            block.blockKind == BlockAssistant
+                && not (Text.null (Text.strip block.blockBody)))
+        . toList
+        . (.uiBlocks)
+
+reasoningText :: ReasoningItem -> Text.Text
+reasoningText reasoning =
+    firstNonEmpty
+        [ Text.intercalate "\n" $
+            mapMaybe (.text) reasoning.summary
+        , Text.intercalate "\n" $
+            concatMap responseContentText $
+                maybe [] id reasoning.content
+        ]
+
+messageText :: MessageContent -> Text.Text
+messageText = \case
+    MessageContentText text -> text
+    MessageContentParts parts ->
+        Text.intercalate "\n" (concatMap responseContentText parts)
+
+responseContentText :: ResponseContentPart -> [Text.Text]
+responseContentText = \case
+    OutputTextPart{text} -> [text]
+    ReasoningTextPart{text} -> [text]
+    SummaryTextPart{text} -> [text]
+    RefusalPart{refusal} -> [refusal]
+    _ -> []
+
+firstNonEmpty :: [Text.Text] -> Text.Text
+firstNonEmpty =
+    maybe "" id
+        . findFirst (not . Text.null . Text.strip)
+
+findFirst :: (a -> Bool) -> [a] -> Maybe a
+findFirst predicate = \case
+    [] -> Nothing
+    value : rest
+        | predicate value -> Just value
+        | otherwise -> findFirst predicate rest
+
+renderJsonValue :: Aeson.Value -> Text.Text
+renderJsonValue = \case
+    Aeson.String text -> text
+    value ->
+        TextEncoding.decodeUtf8With lenientDecode
+            (LazyByteString.toStrict (Aeson.encode value))

--- a/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
@@ -8,6 +8,8 @@ module Agent.CLI.TUI.Types
     , ChoiceOverlay(..)
     , FullscreenInput(..)
     , FullscreenInputBuffer(..)
+    , FullscreenHistorySource(..)
+    , HistoryCommit(..)
     , FullscreenRuntime(..)
     , FullscreenSessionActions(..)
     , Name(..)
@@ -26,6 +28,13 @@ import Agent.CLI.Interrupt (CtrlCDecision)
 import Agent.CLI.Permission (PermissionChoice)
 import Agent.CLI.Resume (ResumeBrowser, ResumeEntry)
 import Agent.CLI.TUI.ImagePreview (TuiImagePreview)
+import Agent.CLI.TUI.History
+    ( HistoryGeneration
+    , HistoryPage
+    , HistoryRequest
+    , HistoryTurn
+    , HistoryWindow
+    )
 import qualified Agent.CLI.TUI.Scroll as Scroll
 import Agent.Loop (ImageAttachment)
 import Agent.TUI.Model (BlockId, UiEvent, UiState)
@@ -33,9 +42,10 @@ import Agent.Syntax (SyntaxHighlighter)
 import Agent.TUI.Motion (MotionDemand, MotionMode)
 import Brick (Location)
 import Brick.BChan (BChan)
-import Control.Concurrent.STM (TMVar, TVar)
+import Control.Concurrent.STM (TMVar, TQueue, TVar)
 import Control.Exception.Safe (SomeException)
 import Data.IORef (IORef)
+import Data.Int (Int64)
 import Data.List.NonEmpty (NonEmpty)
 import qualified Data.Map.Strict as Map
 import Data.Sequence (Seq)
@@ -118,6 +128,14 @@ data AppEvent
     | AppAgentSnapshot !AgentTarget ![AgentEntry]
     | AppSetWindowTitle !Text
     | AppSyntaxHighlighterLoaded !(Maybe SyntaxHighlighter)
+    | AppHistoryReset !HistoryPage
+    | AppHistoryLoaded
+        !HistoryRequest
+        !(Either Text HistoryPage)
+    | AppHistoryCommitted
+        !HistoryGeneration
+        !HistoryTurn
+        !HistoryCommit
     | AppConversationReflow
     | AppMotionTick
     | AppRecapPoll
@@ -143,6 +161,18 @@ data FullscreenInput = FullscreenInput
 
 newtype FullscreenInputBuffer =
     FullscreenInputBuffer (TVar (Seq FullscreenInput))
+
+data FullscreenHistorySource = FullscreenHistorySource
+    { historySourceKey :: !Text
+    , historySourceLoad
+        :: !(HistoryRequest -> IO (Either Text HistoryPage))
+    }
+
+data HistoryCommit
+    = HistoryCommitAppend
+    | HistoryCommitReplace
+    | HistoryCommitReset
+    deriving (Eq, Show)
 
 data FullscreenRuntime = FullscreenRuntime
     { runtimeEvents :: !(BChan AppEvent)
@@ -173,6 +203,9 @@ data FullscreenRuntime = FullscreenRuntime
     , runtimeSyntaxLoadFinished :: !(NominalDiffTime -> IO ())
     , runtimeInitial :: !UiState
     , runtimeSessionActions :: !(IORef FullscreenSessionActions)
+    , runtimeHistoryRequests :: !(TQueue HistoryRequest)
+    , runtimeHistorySource :: !(IORef (Maybe FullscreenHistorySource))
+    , runtimeHistoryGeneration :: !(IORef Int64)
     }
 
 -- | Provider/session-scoped actions behind one long-lived terminal runtime.
@@ -190,6 +223,10 @@ data FullscreenSessionActions = FullscreenSessionActions
 
 data AppState = AppState
     { appUi :: !UiState
+    , appHistoryWindow :: !HistoryWindow
+    , appHistorySelectedBlock :: !(Maybe BlockId)
+    , appHistoryLiveStart :: !(Maybe Int)
+    , appNextHistoryBlockId :: !Int
     , appPermissionReply :: !(Maybe (TMVar (Maybe PermissionChoice)))
     , appRuntime :: !FullscreenRuntime
     , appSlashIndex :: !Int

--- a/packages/agent-cli/src/Agent/CLI/Turn.hs
+++ b/packages/agent-cli/src/Agent/CLI/Turn.hs
@@ -20,8 +20,11 @@ import Agent.CLI.ProviderTransition
     , TurnResult(..)
     )
 import Agent.CLI.TUI.App
-    ( emitUiEvent
+    ( commitFullscreenHistoryTurn
+    , emitUiEvent
     )
+import Agent.CLI.TUI.SessionHistory (sessionHistoryTurn)
+import Agent.CLI.TUI.Types (HistoryCommit(..))
 import Agent.TUI.Model
     ( BlockState(..)
     , UiEvent(..)
@@ -46,11 +49,13 @@ import Agent.CLI.Session
     ( SessionHandle(..)
     , SessionMeta(..)
     , SessionTurn(..)
+    , SessionTurnPage(..)
+    , TranscriptEffect(..)
     , Persistence(..)
     , PersistenceState(..)
-    , appendTurnWithMetaUpdate
+    , appendTurnWithMetaUpdateIndexed
     , ensureSession
-    , loadSession
+    , loadRecentSessionTurns
     , sessionConversationText
     , sessionTitleFromPrompt
     , setGeneratedSessionTitle
@@ -95,6 +100,7 @@ import Agent.CLI.TurnState
     , restoreStartupContext
     , turnInputsWithContext
     , turnNewItems
+    , turnReplacesTranscript
     )
 import Agent.Dialect (DialectId(..), dialectId)
 import Agent.Loop
@@ -124,7 +130,7 @@ import Agent.Tools.PlanMode
     , writePlanMarkdown
     )
 import Agent.OsPath (toText, unsafeToFilePath)
-import Control.Monad (when)
+import Control.Monad (forM_, when)
 import Control.Exception.Safe (onException, tryAny)
 import Data.IORef
     ( atomicModifyIORef'
@@ -298,12 +304,19 @@ runOneTurn env@SessionEnv
                         , turnAssistantText = Nothing
                         , turnError = Just errorText
                         , turnResponseId = Nothing
+                        , turnEffect = TranscriptAppend
                         , turnItems = retainedItems
                         , turnUsage = Nothing
                         }
-                handle' <- appendTurnWithMetaUpdate handle turn \meta ->
+                (handle', turnIndex) <-
+                    appendTurnWithMetaUpdateIndexed handle turn \meta ->
                     meta { metaLastResponseId = Nothing }
                 writeIORef slotRef (PersistenceActive handle')
+                forM_ fullscreen \runtime ->
+                    commitFullscreenHistoryTurn
+                        runtime
+                        (sessionHistoryTurn turnIndex turn)
+                        HistoryCommitAppend
     case (restartEffort, result) of
         (Just level, _) -> do
             abortSubagentTurn rootTurnId
@@ -442,6 +455,12 @@ runOneTurn env@SessionEnv
                 _ -> pure ()
             let newItems =
                     turnNewItems beforeItems execution.executionState
+                effect =
+                    if turnReplacesTranscript
+                        beforeItems
+                        execution.executionState
+                        then TranscriptReplace
+                        else TranscriptAppend
             case persist of
                 PersistenceDisabled -> pure ()
                 PersistenceEnabled slotRef -> do
@@ -455,15 +474,25 @@ runOneTurn env@SessionEnv
                             , turnAssistantText = assistantText
                             , turnError = Nothing
                             , turnResponseId = Just loopResult.finalResponseId
+                            , turnEffect = effect
                             , turnItems = newItems
                             , turnUsage = Just loopResult.tokenUsage
                             }
                     titleTurns <- (+ 1) <$> readIORef env.sessionTitleTurnCount
-                    countedHandle <- appendTurnWithMetaUpdate handle turn \meta ->
-                        meta { metaTitleUserTurns = titleTurns }
+                    (countedHandle, turnIndex) <-
+                        appendTurnWithMetaUpdateIndexed handle turn \meta ->
+                            meta { metaTitleUserTurns = titleTurns }
                     writeIORef env.sessionTitleTurnCount titleTurns
                     let countedMeta = countedHandle.sessionMeta
                     writeIORef slotRef (PersistenceActive countedHandle)
+                    forM_ fullscreen \runtime ->
+                        commitFullscreenHistoryTurn
+                            runtime
+                            (sessionHistoryTurn turnIndex turn)
+                            (case effect of
+                                TranscriptAppend -> HistoryCommitAppend
+                                TranscriptReplace -> HistoryCommitReplace
+                                TranscriptReset -> HistoryCommitReset)
                     when
                         ( not countedMeta.metaTitleIsManual
                             && shouldRequestSessionTitle titleTurns
@@ -623,17 +652,18 @@ checkpointIncompleteTurn beforeItems turnInputs =
 
 requestConversationTitle :: SessionEnv -> SessionHandle -> Int -> IO ()
 requestConversationTitle env handle milestone =
-    loadSession
+    loadRecentSessionTurns
         env.sessionDatabasePool
         (System.OsPath.takeDirectory handle.sessionDir)
         handle.sessionMeta.metaId
+        24
         >>= \case
             Left _ -> pure ()
-            Right (_, turns) ->
+            Right page ->
                 requestSessionTitle env.sessionTitleManager
                     handle.sessionMeta.metaId
                     milestone
-                    (sessionConversationText turns)
+                    (sessionConversationText (map snd page.pageTurns))
 
 applyPendingSessionTitles :: SessionEnv -> IO ()
 applyPendingSessionTitles env =

--- a/packages/agent-cli/src/Agent/CLI/TurnState.hs
+++ b/packages/agent-cli/src/Agent/CLI/TurnState.hs
@@ -12,6 +12,7 @@ module Agent.CLI.TurnState
     , restoreStartupContext
     , turnInputsWithContext
     , turnNewItems
+    , turnReplacesTranscript
     ) where
 
 import Agent.Loop
@@ -158,6 +159,10 @@ turnNewItems beforeItems afterItems
     | beforeItems `isPrefixOf` afterItems =
         drop (length beforeItems) afterItems
     | otherwise = afterItems
+
+turnReplacesTranscript :: [ResponseItem] -> [ResponseItem] -> Bool
+turnReplacesTranscript beforeItems afterItems =
+    not (beforeItems `isPrefixOf` afterItems)
 
 applyField :: FieldUpdate a -> a -> a
 applyField update current = case update of

--- a/packages/agent-cli/test/Agent/CLI/AgentSessionsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/AgentSessionsSpec.hs
@@ -113,6 +113,7 @@ spec = describe "Agent.CLI.AgentSessions" do
                 , turnResponseId = Nothing
                 , turnItems = []
                 , turnUsage = Nothing
+                , turnEffect = TranscriptAppend
                 }
             result <- runTool env "read_agent_session" $
                 "{\"session_id\":\"" <> handle.sessionMeta.metaId <> "\"}"

--- a/packages/agent-cli/test/Agent/CLI/ResumeSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ResumeSpec.hs
@@ -5,6 +5,7 @@ import Agent.CLI.Resume
 import Agent.CLI.Session
     ( LegacySubagentTarget(..)
     , SessionMeta(..)
+    , SessionResumeStats(..)
     , SessionTurn(..)
     , TranscriptEffect(..)
     )
@@ -47,6 +48,27 @@ spec = do
             let entry = resumeEntryFromMeta (sampleMeta "abc" "first")
             entry.resumeLoaded `shouldBe` False
             entry.resumeTurnCount `shouldBe` 0
+
+        it "keeps full-session counts and first prompt when the preview is truncated" do
+            let recent = [sampleTurn { turnUserText = "later question" }]
+                stats = SessionResumeStats
+                    { resumeStatsTurnCount = 80
+                    , resumeStatsMessageCount = 160
+                    , resumeStatsToolCount = 12
+                    , resumeStatsFirstPrompt = Just "hello"
+                    }
+                entry =
+                    resumeEntryFromPage
+                        (sampleMeta "abc" "first")
+                        stats
+                        recent
+            entry.resumeLoaded `shouldBe` True
+            entry.resumeTurnCount `shouldBe` 80
+            entry.resumeMessageCount `shouldBe` 160
+            entry.resumeToolCount `shouldBe` 12
+            entry.resumePrompt `shouldBe` "hello"
+            entry.resumeTranscript
+                `shouldSatisfy` any (Text.isInfixOf "later question")
 
     describe "applyResumeKey" do
         let entries =

--- a/packages/agent-cli/test/Agent/CLI/ResumeSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ResumeSpec.hs
@@ -6,6 +6,7 @@ import Agent.CLI.Session
     ( LegacySubagentTarget(..)
     , SessionMeta(..)
     , SessionTurn(..)
+    , TranscriptEffect(..)
     )
 import Agent.Dialect (DialectId(..))
 import System.OsPath (unsafeEncodeUtf)
@@ -223,6 +224,7 @@ sampleTurn =
         , turnResponseId = Nothing
         , turnItems = []
         , turnUsage = Nothing
+        , turnEffect = TranscriptAppend
         }
 
 sampleMeta :: Text.Text -> Text.Text -> SessionMeta

--- a/packages/agent-cli/test/Agent/CLI/SessionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SessionSpec.hs
@@ -603,6 +603,7 @@ spec = describe "Agent.CLI.Session" do
                             , outputTokens = 4
                             , cachedTokens = 2
                             }
+                        , turnEffect = TranscriptAppend
                         }
                     compactTurn = SessionTurn
                         { turnAt = fixedTime
@@ -612,6 +613,7 @@ spec = describe "Agent.CLI.Session" do
                         , turnResponseId = Nothing
                         , turnItems = []
                         , turnUsage = Nothing
+                        , turnEffect = TranscriptReplace
                         }
                 withNormal <- appendTurn handle normalTurn
                 final <- appendTurnWithMetaUpdate withNormal compactTurn
@@ -669,6 +671,7 @@ spec = describe "Agent.CLI.Session" do
                         , turnResponseId = Nothing
                         , turnItems = []
                         , turnUsage = Nothing
+                        , turnEffect = TranscriptAppend
                         }
                 createDirectory dir
                 LBS.writeFile (toFilePath metaPath) (Aeson.encode meta)
@@ -729,6 +732,7 @@ spec = describe "Agent.CLI.Session" do
                     , turnResponseId = Nothing
                     , turnItems = []
                     , turnUsage = Nothing
+                    , turnEffect = TranscriptAppend
                     }
             Aeson.eitherDecode (Aeson.encode turn) `shouldBe` Right turn
 
@@ -740,6 +744,22 @@ spec = describe "Agent.CLI.Session" do
                         , metaLastRecapMainTurns = 3
                         }
             Aeson.eitherDecode (Aeson.encode meta) `shouldBe` Right meta
+
+        it "infers transcript effects when importing legacy JSON turns" do
+            let legacy = Aeson.object
+                    [ "at" Aeson..= fixedTime
+                    , "userText" Aeson..= ("/compact focus" :: Text.Text)
+                    , "assistantText" Aeson..= (Nothing :: Maybe Text.Text)
+                    , "error" Aeson..= (Nothing :: Maybe Text.Text)
+                    , "responseId" Aeson..= (Nothing :: Maybe Text.Text)
+                    , "items" Aeson..= ([] :: [ResponseItem])
+                    , "usage" Aeson..= (Nothing :: Maybe TokenUsage)
+                    ]
+                decoded =
+                    Aeson.eitherDecode (Aeson.encode legacy)
+                        :: Either String SessionTurn
+            fmap (\turn -> turn.turnEffect) decoded
+                `shouldBe` Right TranscriptReplace
 
 testCreate :: StorePool -> OsPath -> SessionCreate
 testCreate pool root = SessionCreate

--- a/packages/agent-cli/test/Agent/CLI/TUIHistorySpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIHistorySpec.hs
@@ -1,0 +1,427 @@
+{-# LANGUAGE OverloadedRecordDot #-}
+
+module Agent.CLI.TUIHistorySpec (spec) where
+
+import Agent.CLI.Session
+    ( SessionTurn(..)
+    , TranscriptEffect(..)
+    )
+import Agent.CLI.TUI.History
+import Agent.CLI.TUI.Composer (composerScrollbackAvailable)
+import Agent.CLI.TUI.SessionHistory (sessionHistoryTurn)
+import Agent.Responses.Types
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.KeyMap as KeyMap
+import Data.Foldable (toList)
+import Agent.TUI.Model
+    ( BlockId(..)
+    , BlockState(..)
+    , BlockKind(..)
+    , UiBlock(..)
+    , initialUiState
+    )
+import qualified Data.Sequence as Seq
+import Data.Int (Int64)
+import qualified Data.Text as Text
+import Data.Time.Calendar (fromGregorian)
+import Data.Time.Clock (UTCTime(..), secondsToDiffTime)
+import Test.Hspec
+
+spec :: Spec
+spec = describe "bounded fullscreen history window" do
+    it "allows keyboard scrollback when only persisted history is loaded" do
+        let generation = HistoryGeneration 1
+            empty = emptyHistoryWindow generation 10 20 1_000_000
+            page =
+                HistoryPage
+                    { historyPageGeneration = generation
+                    , historyPageDirection = HistoryNewer
+                    , historyPageTurns = Seq.singleton (turn 1 1)
+                    , historyPageGenerationStart = HistoryCursor 0
+                    , historyPageTotalTurns = 2
+                    , historyPageHasOlder = True
+                    , historyPageHasNewer = False
+                    }
+        window <- expectRight (applyHistoryPage page empty)
+        composerScrollbackAvailable initialUiState empty `shouldBe` False
+        composerScrollbackAvailable initialUiState window `shouldBe` True
+
+    it "accepts an initial page and requests the adjacent older cursor" do
+        let generation = HistoryGeneration 4
+            initial = emptyHistoryWindow generation 10 20 1_000_000
+            page =
+                HistoryPage
+                    { historyPageGeneration = generation
+                    , historyPageDirection = HistoryNewer
+                    , historyPageTurns =
+                        Seq.fromList
+                            [ turn 10 1
+                            , turn 11 1
+                            , turn 12 1
+                            ]
+                    , historyPageGenerationStart = HistoryCursor 0
+                    , historyPageTotalTurns = 13
+                    , historyPageHasOlder = True
+                    , historyPageHasNewer = False
+                    }
+            loaded = applyHistoryPage page initial
+        loaded `shouldSatisfy` isRight
+        case loaded of
+            Left err -> expectationFailure (show err)
+            Right window -> do
+                historyWindowCursors window
+                    `shouldBe` Seq.fromList (map HistoryCursor [10, 11, 12])
+                historyWindowRequest HistoryOlder window
+                    `shouldBe`
+                        Just HistoryRequest
+                            { historyRequestGeneration = generation
+                            , historyRequestDirection = HistoryOlder
+                            , historyRequestCursor = Just (HistoryCursor 10)
+                            }
+
+    it "deduplicates overlapping pages and blocks duplicate requests" do
+        let generation = HistoryGeneration 1
+            initial = emptyHistoryWindow generation 20 20 1_000_000
+            first =
+                HistoryPage
+                    { historyPageGeneration = generation
+                    , historyPageDirection = HistoryNewer
+                    , historyPageTurns = Seq.fromList [turn 10 1, turn 11 1]
+                    , historyPageGenerationStart = HistoryCursor 0
+                    , historyPageTotalTurns = 12
+                    , historyPageHasOlder = True
+                    , historyPageHasNewer = False
+                    }
+            older =
+                HistoryPage
+                    { historyPageGeneration = generation
+                    , historyPageDirection = HistoryOlder
+                    , historyPageTurns = Seq.fromList [turn 8 1, turn 9 1, turn 10 4]
+                    , historyPageGenerationStart = HistoryCursor 0
+                    , historyPageTotalTurns = 12
+                    , historyPageHasOlder = True
+                    , historyPageHasNewer = True
+                    }
+        loaded <- expectRight (applyHistoryPage first initial)
+        let requested = markHistoryRequest HistoryOlder loaded
+        merged <- expectRight (applyHistoryPage older requested)
+        historyWindowCursors merged
+            `shouldBe` Seq.fromList (map HistoryCursor [8, 9, 10, 11])
+        historyWindowLoadedBlocks merged `shouldBe` 7
+        historyWindowRequest HistoryOlder requested
+            `shouldBe` Nothing
+
+    it "resets a non-tail window before archiving a new latest turn" do
+        let generation = HistoryGeneration 7
+            initial = emptyHistoryWindow generation 200 400 1_000_000
+            middlePage =
+                HistoryPage
+                    { historyPageGeneration = generation
+                    , historyPageDirection = HistoryNewer
+                    , historyPageTurns =
+                        Seq.fromList [turn 100 1, turn 101 1]
+                    , historyPageGenerationStart = HistoryCursor 0
+                    , historyPageTotalTurns = 500
+                    , historyPageHasOlder = True
+                    , historyPageHasNewer = True
+                    }
+        middle <- expectRight (applyHistoryPage middlePage initial)
+        let latest = appendHistoryTurn (turn 500 1) middle
+        historyWindowCursors latest
+            `shouldBe` Seq.singleton (HistoryCursor 500)
+        latest.historyWindowTotalTurns `shouldBe` 501
+        historyWindowOlderAvailable latest `shouldBe` True
+        historyWindowNewerAvailable latest `shouldBe` False
+
+    it "does not let a stale failure clear a current page request" do
+        let currentGeneration = HistoryGeneration 8
+            initial =
+                (emptyHistoryWindow currentGeneration 10 20 1_000_000)
+                    { historyWindowHasOlder = True
+                    }
+            currentRequest =
+                HistoryRequest
+                    { historyRequestGeneration = currentGeneration
+                    , historyRequestDirection = HistoryOlder
+                    , historyRequestCursor = Nothing
+                    }
+            staleRequest =
+                currentRequest
+                    { historyRequestGeneration = HistoryGeneration 7
+                    }
+            pending = markHistoryRequest HistoryOlder initial
+        historyWindowRequest HistoryOlder
+            (clearHistoryRequest staleRequest pending)
+            `shouldBe` Nothing
+        historyWindowRequest HistoryOlder
+            (clearHistoryRequest currentRequest pending)
+            `shouldBe` Just currentRequest
+
+    it "rejects a page from an old provider or session generation" do
+        let current =
+                emptyHistoryWindow (HistoryGeneration 9) 10 20 1_000_000
+            stale =
+                HistoryPage
+                    { historyPageGeneration = HistoryGeneration 8
+                    , historyPageDirection = HistoryNewer
+                    , historyPageTurns = Seq.singleton (turn 1 1)
+                    , historyPageGenerationStart = HistoryCursor 0
+                    , historyPageTotalTurns = 2
+                    , historyPageHasOlder = False
+                    , historyPageHasNewer = False
+                    }
+        applyHistoryPage stale current
+            `shouldBe` Left (HistoryPageStale (HistoryGeneration 8))
+
+    it "evicts oldest completed turns to stay within budget" do
+        let generation = HistoryGeneration 2
+            initial = emptyHistoryWindow generation 2 100 1_000_000
+            page =
+                HistoryPage
+                    { historyPageGeneration = generation
+                    , historyPageDirection = HistoryNewer
+                    , historyPageTurns =
+                        Seq.fromList [turn 1 1, turn 2 1, turn 3 1]
+                    , historyPageGenerationStart = HistoryCursor 0
+                    , historyPageTotalTurns = 4
+                    , historyPageHasOlder = False
+                    , historyPageHasNewer = False
+                    }
+        window <- expectRight (applyHistoryPage page initial)
+        historyWindowCursors window
+            `shouldBe` Seq.fromList (map HistoryCursor [2, 3])
+        historyWindowOlderAvailable window `shouldBe` True
+
+    it "does not evict the visible or selected anchor" do
+        let generation = HistoryGeneration 3
+            initial = emptyHistoryWindow generation 1 100 1_000_000
+            firstPage =
+                HistoryPage
+                    { historyPageGeneration = generation
+                    , historyPageDirection = HistoryNewer
+                    , historyPageTurns = Seq.singleton (turn 1 1)
+                    , historyPageGenerationStart = HistoryCursor 0
+                    , historyPageTotalTurns = 3
+                    , historyPageHasOlder = False
+                    , historyPageHasNewer = False
+                    }
+            nextPage =
+                HistoryPage
+                    { historyPageGeneration = generation
+                    , historyPageDirection = HistoryNewer
+                    , historyPageTurns = Seq.singleton (turn 2 1)
+                    , historyPageGenerationStart = HistoryCursor 0
+                    , historyPageTotalTurns = 3
+                    , historyPageHasOlder = True
+                    , historyPageHasNewer = False
+                    }
+        window <- expectRight (applyHistoryPage firstPage initial)
+        let pinned =
+                historyWindowSetAnchors
+                    (Just (HistoryCursor 1))
+                    Nothing
+                    window
+        trimmed <- expectRight (applyHistoryPage nextPage pinned)
+        historyWindowCursors trimmed
+            `shouldBe` Seq.singleton (HistoryCursor 1)
+
+    it "drops anchors that no longer belong to the loaded window" do
+        let generation = HistoryGeneration 5
+            initial = emptyHistoryWindow generation 10 10 1_000_000
+            page =
+                HistoryPage
+                    { historyPageGeneration = generation
+                    , historyPageDirection = HistoryNewer
+                    , historyPageTurns = Seq.singleton (turn 4 1)
+                    , historyPageGenerationStart = HistoryCursor 0
+                    , historyPageTotalTurns = 5
+                    , historyPageHasOlder = False
+                    , historyPageHasNewer = False
+                    }
+        window <- expectRight (applyHistoryPage page initial)
+        let anchored =
+                historyWindowSetAnchors
+                    (Just (HistoryCursor 99))
+                    (Just (HistoryCursor 4))
+                    window
+        historyWindowVisible anchored `shouldBe` Nothing
+        historyWindowSelected anchored
+            `shouldBe` Just (HistoryCursor 4)
+
+    it "evicts completed turns when the estimated byte budget is exceeded" do
+        let generation = HistoryGeneration 6
+            initial = emptyHistoryWindow generation 100 100 180
+            page =
+                HistoryPage
+                    { historyPageGeneration = generation
+                    , historyPageDirection = HistoryNewer
+                    , historyPageTurns =
+                        Seq.fromList [turn 1 1, turn 2 1]
+                    , historyPageGenerationStart = HistoryCursor 0
+                    , historyPageTotalTurns = 3
+                    , historyPageHasOlder = False
+                    , historyPageHasNewer = False
+                    }
+        window <- expectRight (applyHistoryPage page initial)
+        historyWindowCursors window
+            `shouldBe` Seq.singleton (HistoryCursor 2)
+        historyWindowLoadedBytes window `shouldSatisfy` (<= 180)
+
+    it "projects reasoning, tool calls, outputs, and assistant text" do
+        let projected =
+                sessionHistoryTurn
+                    (12 :: Int)
+                    (sessionTurn
+                        TranscriptAppend
+                        "inspect the repository"
+                        [ userMessage "inspect the repository"
+                        , ReasoningItemValue ReasoningItem
+                            { itemId = Nothing
+                            , summary =
+                                [ ReasoningSummaryPart
+                                    { partType = "summary_text"
+                                    , text = Just "Checked the schema"
+                                    , extraFields = KeyMap.empty
+                                    }
+                                ]
+                            , content = Nothing
+                            , encryptedContent = Nothing
+                            , status = Nothing
+                            , extraFields = KeyMap.empty
+                            }
+                        , FunctionCallItem FunctionCall
+                            { itemId = Nothing
+                            , callId = "call-1"
+                            , name = "shell_command"
+                            , arguments = "{\"command\":\"pwd\"}"
+                            , status = Nothing
+                            , extraFields = KeyMap.empty
+                            }
+                        , FunctionCallOutputItem FunctionCallOutput
+                            { itemId = Nothing
+                            , callId = "call-1"
+                            , output = Aeson.String "/tmp/project"
+                            , status = Nothing
+                            , extraFields = KeyMap.empty
+                            }
+                        , assistantMessage "Done"
+                        ])
+            blocks = toList projected.historyTurnBlocks
+        map (.blockKind) blocks
+            `shouldBe`
+                [ BlockUser
+                , BlockThinking
+                , BlockShell
+                , BlockAssistant
+                ]
+        map (.blockBody) blocks
+            `shouldSatisfy`
+                any (Text.isInfixOf "/tmp/project")
+
+    it "does not rematerialise the compacted prefix of replacement turns" do
+        let projected =
+                sessionHistoryTurn
+                    (20 :: Int)
+                    (sessionTurn
+                        TranscriptReplace
+                        "current prompt"
+                        [ assistantMessage "old compacted answer"
+                        , userMessage "current prompt"
+                        , assistantMessage "current answer"
+                        ])
+            blocks = toList projected.historyTurnBlocks
+        map (.blockKind) blocks `shouldBe` [BlockUser, BlockAssistant]
+        map (.blockBody) blocks
+            `shouldBe` ["current prompt", "current answer"]
+
+    it "renders manual compaction as a single checkpoint summary" do
+        let turnValue =
+                (sessionTurn TranscriptReplace "/compact" [])
+                    { turnAssistantText = Just "Earlier conversation summary"
+                    }
+            projected = sessionHistoryTurn (30 :: Int) turnValue
+            blocks = toList projected.historyTurnBlocks
+        map (.blockKind) blocks `shouldBe` [BlockSystem]
+        map (.blockBody) blocks `shouldBe` ["Earlier conversation summary"]
+
+turn :: Int64 -> Int -> HistoryTurn
+turn cursor blocks =
+    HistoryTurn
+        { historyTurnCursor = HistoryCursor cursor
+        , historyTurnBlocks =
+            Seq.fromList
+                [ block (fromIntegral cursor * 10 + index)
+                | index <- [0 .. blocks - 1]
+                ]
+        }
+
+block :: Int -> UiBlock
+block identifier =
+    UiBlock
+        { blockId = BlockId identifier
+        , blockKind = BlockAssistant
+        , blockTitle = "Assistant"
+        , blockBody = "body"
+        , blockTimestamp = ""
+        , blockDetail = ""
+        , blockState = BlockComplete
+        , blockExpanded = False
+        , blockCallId = Nothing
+        }
+
+isRight :: Either a b -> Bool
+isRight value =
+    case value of
+        Left _ -> False
+        Right _ -> True
+
+expectRight :: (Show a) => Either a b -> IO b
+expectRight value =
+    case value of
+        Left err -> expectationFailure (show err) >> fail "unexpected history page rejection"
+        Right result -> pure result
+
+sessionTurn
+    :: TranscriptEffect
+    -> Text.Text
+    -> [ResponseItem]
+    -> SessionTurn
+sessionTurn effect userText items =
+    SessionTurn
+        { turnAt = fixedTime
+        , turnUserText = userText
+        , turnAssistantText = Nothing
+        , turnError = Nothing
+        , turnResponseId = Nothing
+        , turnEffect = effect
+        , turnItems = items
+        , turnUsage = Nothing
+        }
+
+userMessage :: Text.Text -> ResponseItem
+userMessage text =
+    MessageItem ResponseMessage
+        { messageId = Nothing
+        , content = MessageContentText text
+        , role = RoleUser
+        , status = Nothing
+        , phase = Nothing
+        , extraFields = KeyMap.empty
+        }
+
+assistantMessage :: Text.Text -> ResponseItem
+assistantMessage text =
+    MessageItem ResponseMessage
+        { messageId = Nothing
+        , content = MessageContentText text
+        , role = RoleAssistant
+        , status = Nothing
+        , phase = Nothing
+        , extraFields = KeyMap.empty
+        }
+
+fixedTime :: UTCTime
+fixedTime =
+    UTCTime
+        (fromGregorian 2026 8 25)
+        (secondsToDiffTime 0)

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -66,6 +66,7 @@ import qualified Agent.CLI.TUIAppSpec as TUIAppSpec
 import qualified Agent.CLI.TUIBridgeSpec as TUIBridgeSpec
 import qualified Agent.CLI.TUIComposerSpec as TUIComposerSpec
 import qualified Agent.CLI.TUIImagePreviewSpec as TUIImagePreviewSpec
+import qualified Agent.CLI.TUIHistorySpec as TUIHistorySpec
 import qualified Agent.CLI.TUIPropertySpec as TUIPropertySpec
 import qualified Agent.CLI.TUIScrollSpec as TUIScrollSpec
 import qualified Agent.CLI.TUITranscriptSpec as TUITranscriptSpec
@@ -139,6 +140,7 @@ main = hspec do
     TUIBridgeSpec.spec
     TUIComposerSpec.spec
     TUIImagePreviewSpec.spec
+    TUIHistorySpec.spec
     TUIPropertySpec.spec
     TUIScrollSpec.spec
     TUITranscriptSpec.spec

--- a/packages/agent-store/agent-store.cabal
+++ b/packages/agent-store/agent-store.cabal
@@ -97,6 +97,21 @@ benchmark custom-catalog-inspection-bench
                     , temporary
                     , text
 
+benchmark session-history-paging-bench
+    import:           common-opts
+    type:             exitcode-stdio-1.0
+    hs-source-dirs:   benchmark
+    main-is:          SessionHistoryPaging.hs
+    ghc-options:      -O2 -threaded -rtsopts "-with-rtsopts=-T"
+    build-depends:    agent-store
+                    , base >= 4.14 && < 5
+                    , contravariant
+                    , hasql
+                    , safe-exceptions
+                    , temporary
+                    , text
+                    , time
+
 test-suite agent-store-test
     import:           common-opts
     type:             exitcode-stdio-1.0

--- a/packages/agent-store/benchmark/SessionHistoryPaging.hs
+++ b/packages/agent-store/benchmark/SessionHistoryPaging.hs
@@ -1,0 +1,358 @@
+{-# LANGUAGE NumericUnderscores #-}
+
+module Main (main) where
+
+import Agent.Store.Postgres
+    ( Store
+    , closeStore
+    , defaultManagedPostgresConfig
+    , openStore
+    , provisioningPool
+    , trustedPool
+    )
+import Agent.Store.Postgres.Connection
+    ( withSession
+    )
+import Agent.Store.Postgres.Managed (stopManagedPostgres)
+import Agent.Store.Postgres.Session
+import Agent.Store.Types (StoreError(..), renderStoreError)
+import Control.Exception (evaluate)
+import Control.Exception.Safe (bracket, finally)
+import Control.Monad (forM, forM_, void)
+import Data.Functor.Contravariant ((>$<))
+import Data.Int (Int32, Int64)
+import Data.List (sort)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Data.Time.Clock (getCurrentTime)
+import GHC.Clock (getMonotonicTimeNSec)
+import GHC.Stats
+    ( RTSStats(..)
+    , getRTSStats
+    , getRTSStatsEnabled
+    )
+import qualified Hasql.Decoders as Decoders
+import qualified Hasql.Encoders as Encoders
+import qualified Hasql.Session as Session
+import Hasql.Statement (Statement)
+import qualified Hasql.Statement as Statement
+import System.CPUTime (getCPUTime)
+import System.Environment (getArgs)
+import System.Exit (die)
+import System.IO.Temp (withSystemTempDirectory)
+import System.Mem (performGC)
+import Text.Printf (printf)
+
+data Workload
+    = FullTranscript
+    | ActiveTranscript
+    | RecentPage
+    deriving (Eq, Show)
+
+data Sample = Sample
+    { elapsedMillis :: !Double
+    , cpuMillis :: !Double
+    , allocatedBytes :: !Integer
+    , checksum :: !Int
+    }
+
+data SeedParams = SeedParams
+    { seedSessionKey :: !Text
+    , seedTurnCount :: !Int64
+    , seedCheckpoint :: !Int64
+    , seedPayloadBytes :: !Int32
+    }
+
+main :: IO ()
+main = do
+    enabled <- getRTSStatsEnabled
+    if enabled
+        then pure ()
+        else die "RTS statistics are disabled; run with +RTS -T"
+    (turnCounts, payloadBytes, sampleCount) <- parseArguments =<< getArgs
+    withSystemTempDirectory "hah" \stateDirectory -> do
+        let config = defaultManagedPostgresConfig stateDirectory ""
+        (bracket
+            (openStore config >>= either (die . Text.unpack . renderStoreError) pure)
+            closeStore
+            \store -> runMatrix store turnCounts payloadBytes sampleCount)
+            `finally` void (stopManagedPostgres config)
+
+parseArguments :: [String] -> IO ([Int], Int, Int)
+parseArguments = \case
+    [] -> pure ([1_000, 5_000, 10_000], 4 * 1024, 5)
+    [turnCountsArg, payloadArg, samplesArg] -> do
+        turnCounts <- traverse (parsePositive "turn count")
+            (splitCommas turnCountsArg)
+        payload <- parsePositive "payload bytes" payloadArg
+        samples <- parsePositive "sample count" samplesArg
+        pure (turnCounts, payload, samples)
+    _ ->
+        die $
+            "usage: session-history-paging-bench "
+                <> "[TURN_COUNTS_CSV PAYLOAD_BYTES SAMPLES]"
+
+splitCommas :: String -> [String]
+splitCommas input =
+    case break (== ',') input of
+        (value, []) -> [value]
+        (value, _ : rest) -> value : splitCommas rest
+
+parsePositive :: String -> String -> IO Int
+parsePositive label raw =
+    case reads raw of
+        [(value, "")]
+            | value > 0 -> pure value
+        _ -> die ("invalid " <> label <> ": " <> raw)
+
+runMatrix :: Store -> [Int] -> Int -> Int -> IO ()
+runMatrix store turnCounts payloadBytes sampleCount = do
+    putStrLn $
+        "turns,payload_bytes,active_turns,workload,elapsed_ms,"
+            <> "cpu_ms,allocated_bytes,checksum"
+    forM_ turnCounts \turnCount -> do
+        let activeTurns = min 80 turnCount
+            sessionKey = "history-bench-" <> Text.pack (show turnCount)
+        seedBenchmarkSession
+            store
+            sessionKey
+            turnCount
+            activeTurns
+            payloadBytes
+        forM_ [FullTranscript, ActiveTranscript, RecentPage] \workload -> do
+            _ <- measure (workloadAction store sessionKey workload)
+            samples <- forM [1 .. sampleCount] \_ ->
+                measure (workloadAction store sessionKey workload)
+            printSample
+                turnCount
+                payloadBytes
+                activeTurns
+                workload
+                (median samples)
+
+seedBenchmarkSession
+    :: Store
+    -> Text
+    -> Int
+    -> Int
+    -> Int
+    -> IO ()
+seedBenchmarkSession store sessionKey turnCount activeTurns payloadBytes = do
+    now <- getCurrentTime
+    let metadata = SessionMetadata
+            { sessionMetadataKey = sessionKey
+            , sessionMetadataVersion = 1
+            , sessionMetadataCreatedAt = now
+            , sessionMetadataUpdatedAt = now
+            , sessionMetadataProvider = "openai"
+            , sessionMetadataConnection = "openai"
+            , sessionMetadataModel = "benchmark"
+            , sessionMetadataTransportModel = Nothing
+            , sessionMetadataDialect = "codex"
+            , sessionMetadataLegacyTarget = Nothing
+            , sessionMetadataCwd = "/benchmark"
+            , sessionMetadataEffort = "medium"
+            , sessionMetadataTitle = "Session history benchmark"
+            , sessionMetadataTitleIsManual = False
+            , sessionMetadataTitleRefreshIndex = 0
+            , sessionMetadataTitleUserTurns = fromIntegral turnCount
+            , sessionMetadataLastResponseId = Nothing
+            , sessionMetadataInputTokens = 0
+            , sessionMetadataOutputTokens = 0
+            , sessionMetadataCachedTokens = 0
+            , sessionMetadataLastRecap = Nothing
+            , sessionMetadataLastTurnSummary = Nothing
+            , sessionMetadataLastRecapMainTurns = 0
+            }
+        checkpoint = fromIntegral (turnCount - activeTurns)
+        params = SeedParams
+            { seedSessionKey = sessionKey
+            , seedTurnCount = fromIntegral turnCount
+            , seedCheckpoint = checkpoint
+            , seedPayloadBytes = fromIntegral payloadBytes
+            }
+    createSession (trustedPool store) metadata
+        >>= requireStore "create benchmark session"
+        >>= \created ->
+            if created
+                then pure ()
+                else die ("benchmark session already exists: " <> Text.unpack sessionKey)
+    withSession
+        (provisioningPool store)
+        (Session.statement params seedSessionStatement)
+        >>= requireStore "seed benchmark session"
+        >>= \inserted ->
+            if inserted == fromIntegral turnCount
+                then pure ()
+                else
+                    die $
+                        "seeded "
+                            <> show inserted
+                            <> " turns, expected "
+                            <> show turnCount
+
+workloadAction
+    :: Store
+    -> Text
+    -> Workload
+    -> IO (Either StoreError Int)
+workloadAction store sessionKey = \case
+    FullTranscript ->
+        fmap (fmap checksumStoredSession . joinMaybe "full transcript") $
+            loadSession (trustedPool store) sessionKey
+    ActiveTranscript ->
+        fmap (fmap checksumStoredSession . joinMaybe "active transcript") $
+            loadActiveSession (trustedPool store) sessionKey
+    RecentPage ->
+        fmap (fmap checksumPage . joinMaybe "recent page") $
+            loadRecentSessionTurns (trustedPool store) sessionKey 80
+
+joinMaybe
+    :: Text
+    -> Either StoreError (Maybe a)
+    -> Either StoreError a
+joinMaybe label = \case
+    Left err -> Left err
+    Right Nothing ->
+        Left (errorStore ("missing " <> label))
+    Right (Just value) -> Right value
+
+errorStore :: Text -> StoreError
+errorStore = StoreDataError
+
+measure :: IO (Either StoreError Int) -> IO Sample
+measure action = do
+    performGC
+    beforeStats <- getRTSStats
+    beforeCpu <- getCPUTime
+    beforeElapsed <- getMonotonicTimeNSec
+    result <- action >>= requireStore "run benchmark query"
+    forced <- evaluate result
+    afterElapsed <- getMonotonicTimeNSec
+    afterCpu <- getCPUTime
+    -- Allocation counters are published at collection boundaries. Keep the
+    -- timed query separate, then collect before reading the allocation delta.
+    performGC
+    afterStats <- getRTSStats
+    pure Sample
+        { elapsedMillis =
+            fromIntegral (afterElapsed - beforeElapsed) / 1.0e6
+        , cpuMillis =
+            fromIntegral (afterCpu - beforeCpu) / 1.0e9
+        , allocatedBytes =
+            fromIntegral
+                (afterStats.allocated_bytes - beforeStats.allocated_bytes)
+        , checksum = forced
+        }
+
+requireStore :: String -> Either StoreError a -> IO a
+requireStore label =
+    either
+        (\err ->
+            die $
+                label
+                    <> ": "
+                    <> Text.unpack (renderStoreError err))
+        pure
+
+checksumStoredSession :: StoredSession -> Int
+checksumStoredSession stored =
+    foldl'
+        checksumTurn
+        (Text.length stored.storedMetadata.sessionMetadataTitle)
+        stored.storedTurns
+
+checksumPage :: SessionTurnPage -> Int
+checksumPage page =
+    foldl'
+        checksumTurn
+        (fromIntegral
+            (page.sessionPageGenerationStart + page.sessionPageTotal))
+        page.sessionPageTurns
+
+checksumTurn :: Int -> StoredTurn -> Int
+checksumTurn current stored =
+    let turn = stored.storedTurn
+    in current
+        + fromIntegral stored.storedTurnIndex
+        + Text.length turn.sessionTurnUserText
+        + maybe 0 Text.length turn.sessionTurnAssistantText
+        + maybe 0 Text.length turn.sessionTurnError
+        + maybe 0 Text.length turn.sessionTurnResponseId
+        + length turn.sessionTurnItems
+
+median :: [Sample] -> Sample
+median samples =
+    Sample
+        { elapsedMillis = middle (sort (map (.elapsedMillis) samples))
+        , cpuMillis = middle (sort (map (.cpuMillis) samples))
+        , allocatedBytes = middle (sort (map (.allocatedBytes) samples))
+        , checksum = middle (sort (map (.checksum) samples))
+        }
+  where
+    middle values = values !! (length values `div` 2)
+
+printSample :: Int -> Int -> Int -> Workload -> Sample -> IO ()
+printSample turnCount payloadBytes activeTurns workload sample =
+    printf
+        "%d,%d,%d,%s,%.3f,%.3f,%d,%d\n"
+        turnCount
+        payloadBytes
+        activeTurns
+        (case workload of
+            FullTranscript -> "full"
+            ActiveTranscript -> "active"
+            RecentPage -> "recent"
+            :: String)
+        sample.elapsedMillis
+        sample.cpuMillis
+        sample.allocatedBytes
+        sample.checksum
+
+seedSessionStatement :: Statement SeedParams Int64
+seedSessionStatement =
+    Statement.preparable
+        "WITH target AS (\
+        \ SELECT session_id\
+        \ FROM harness.sessions\
+        \ WHERE session_key = $1 AND deleted_at IS NULL\
+        \ ), generated AS (\
+        \ SELECT turn_index, pg_catalog.uuidv7() AS event_id\
+        \ FROM generate_series(0::bigint, $2 - 1) AS turn_index\
+        \ ), inserted_events AS (\
+        \ INSERT INTO harness.session_events (\
+        \   event_id, session_id, sequence, event_kind, occurred_at\
+        \ )\
+        \ SELECT generated.event_id, target.session_id,\
+        \   generated.turn_index + 1, 'turn.appended', now()\
+        \ FROM generated CROSS JOIN target\
+        \ RETURNING event_id, session_id, sequence\
+        \ ), inserted_turns AS (\
+        \ INSERT INTO harness.session_turns (\
+        \   session_id, event_id, turn_index, event_sequence, occurred_at,\
+        \   user_text, assistant_text, transcript_effect\
+        \ )\
+        \ SELECT inserted_events.session_id, inserted_events.event_id,\
+        \   inserted_events.sequence - 1, inserted_events.sequence, now(),\
+        \   'prompt-' || (inserted_events.sequence - 1)::text,\
+        \   repeat('x', $4),\
+        \   CASE WHEN inserted_events.sequence - 1 = $3\
+        \     THEN 'replace' ELSE 'append' END\
+        \ FROM inserted_events\
+        \ RETURNING turn_id\
+        \ )\
+        \ UPDATE harness.sessions\
+        \ SET next_event_sequence = $2 + 1, next_turn_index = $2\
+        \ WHERE session_key = $1\
+        \ RETURNING (SELECT count(*)::bigint FROM inserted_turns)"
+        ( ((.seedSessionKey)
+            >$< Encoders.param (Encoders.nonNullable Encoders.text))
+            <> ((.seedTurnCount)
+                >$< Encoders.param (Encoders.nonNullable Encoders.int8))
+            <> ((.seedCheckpoint)
+                >$< Encoders.param (Encoders.nonNullable Encoders.int8))
+            <> ((.seedPayloadBytes)
+                >$< Encoders.param (Encoders.nonNullable Encoders.int4))
+        )
+        (Decoders.singleRow $
+            Decoders.column (Decoders.nonNullable Decoders.int8))

--- a/packages/agent-store/package.nix
+++ b/packages/agent-store/package.nix
@@ -17,7 +17,8 @@ mkDerivation {
     time
   ];
   benchmarkHaskellDepends = [
-    async base containers safe-exceptions temporary text time
+    async base containers contravariant hasql safe-exceptions temporary
+    text time
   ];
   description = "PostgreSQL persistence for the agent harness";
   license = lib.meta.getLicenseFromSpdxId "MIT";

--- a/packages/agent-store/src/Agent/Store/Postgres/Migrations.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Migrations.hs
@@ -144,6 +144,12 @@ coreMigrations =
               \ bigint NOT NULL DEFAULT 0"
             ]
         }
+    , Migration
+        { migrationVersion = 8
+        , migrationName = "session transcript effects and paging"
+        , migrationStatements =
+            [migrateSessionTranscriptEffectsStatement]
+        }
     ]
 
 -- Version 1 shipped only on the in-development PostgreSQL branch. Empty
@@ -175,6 +181,92 @@ prepareTypedSessionSchemaStatement =
     \     DROP TABLE IF EXISTS harness.structured_values CASCADE;\
     \     DROP FUNCTION IF EXISTS\
     \       harness.raise_normalized_value_error(text);\
+    \   END IF;\
+    \ END\
+    \ $ha$"
+
+migrateSessionTranscriptEffectsStatement :: ByteString
+migrateSessionTranscriptEffectsStatement =
+    "DO $ha$\
+    \ BEGIN\
+    \   IF to_regclass('harness.session_turns') IS NULL THEN\
+    \     RETURN;\
+    \   END IF;\
+    \   ALTER TABLE harness.session_turns\
+    \     ADD COLUMN IF NOT EXISTS transcript_effect text;\
+    \   DROP TRIGGER IF EXISTS session_turns_immutable\
+    \     ON harness.session_turns;\
+    \   UPDATE harness.session_turns\
+    \     SET transcript_effect = 'append'\
+    \     WHERE transcript_effect IS NULL;\
+    \   UPDATE harness.session_turns\
+    \     SET transcript_effect = 'replace'\
+    \     WHERE btrim(user_text) = '/compact'\
+    \       OR btrim(user_text) LIKE '/compact %';\
+    \   IF to_regclass('harness.session_response_items') IS NOT NULL THEN\
+    \     UPDATE harness.session_turns turn_row\
+    \       SET transcript_effect = 'replace'\
+    \       WHERE EXISTS (\
+    \         SELECT 1\
+    \         FROM harness.session_response_items item\
+    \         WHERE item.turn_id = turn_row.turn_id\
+    \           AND item.item_type = 'compaction'\
+    \       );\
+    \   END IF;\
+    \   IF to_regclass('harness.session_response_items') IS NOT NULL\
+    \     AND to_regclass('harness.session_messages') IS NOT NULL\
+    \     AND to_regclass('harness.session_response_content_parts')\
+    \       IS NOT NULL THEN\
+    \     UPDATE harness.session_turns turn_row\
+    \       SET transcript_effect = 'replace'\
+    \       WHERE EXISTS (\
+    \         SELECT 1\
+    \         FROM harness.session_response_items item\
+    \         JOIN harness.session_messages message\
+    \           ON message.response_item_id = item.response_item_id\
+    \         LEFT JOIN harness.session_response_content_parts part\
+    \           ON part.response_item_id = item.response_item_id\
+    \         WHERE item.turn_id = turn_row.turn_id\
+    \           AND message.role_name = 'assistant'\
+    \           AND btrim(coalesce(\
+    \             message.content_text, part.text_value, ''))\
+    \             LIKE 'Compacted conversation summary:%'\
+    \       );\
+    \   END IF;\
+    \   UPDATE harness.session_turns\
+    \     SET transcript_effect = 'reset'\
+    \     WHERE btrim(user_text) IN ('/clear', '/new');\
+    \   ALTER TABLE harness.session_turns\
+    \     ALTER COLUMN transcript_effect SET DEFAULT 'append';\
+    \   ALTER TABLE harness.session_turns\
+    \     ALTER COLUMN transcript_effect SET NOT NULL;\
+    \   IF NOT EXISTS (\
+    \     SELECT 1\
+    \     FROM pg_catalog.pg_constraint constraint_row\
+    \     JOIN pg_catalog.pg_class relation\
+    \       ON relation.oid = constraint_row.conrelid\
+    \     JOIN pg_catalog.pg_namespace schema_row\
+    \       ON schema_row.oid = relation.relnamespace\
+    \     WHERE schema_row.nspname = 'harness'\
+    \       AND relation.relname = 'session_turns'\
+    \       AND constraint_row.conname =\
+    \         'session_turns_transcript_effect_check'\
+    \   ) THEN\
+    \     ALTER TABLE harness.session_turns\
+    \       ADD CONSTRAINT session_turns_transcript_effect_check\
+    \       CHECK (transcript_effect IN ('append', 'replace', 'reset'));\
+    \   END IF;\
+    \   CREATE INDEX IF NOT EXISTS session_turns_session_index_idx\
+    \     ON harness.session_turns (session_id, turn_index);\
+    \   CREATE INDEX IF NOT EXISTS session_turns_checkpoint_idx\
+    \     ON harness.session_turns (session_id, turn_index DESC)\
+    \     WHERE transcript_effect <> 'append';\
+    \   IF to_regprocedure(\
+    \     'harness.reject_session_fact_mutation()') IS NOT NULL THEN\
+    \     CREATE TRIGGER session_turns_immutable\
+    \       BEFORE UPDATE OR DELETE ON harness.session_turns\
+    \       FOR EACH ROW EXECUTE FUNCTION\
+    \         harness.reject_session_fact_mutation();\
     \   END IF;\
     \ END\
     \ $ha$"

--- a/packages/agent-store/src/Agent/Store/Postgres/Session.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Session.hs
@@ -30,9 +30,11 @@ module Agent.Store.Postgres.Session
     , loadSessionMetadata
     , loadActiveSession
     , SessionTurnPage(..)
+    , SessionResumeStats(..)
     , loadRecentSessionTurns
     , loadSessionTurnsBefore
     , loadSessionTurnsAfter
+    , loadSessionResumeStats
     , loadSessionEvents
     , listSessionMetadata
     , searchConversationTurns
@@ -82,6 +84,16 @@ data SessionTurnPage = SessionTurnPage
     , sessionPageTotal :: !Int64
     , sessionPageHasOlder :: !Bool
     , sessionPageHasNewer :: !Bool
+    }
+    deriving (Eq, Show)
+
+-- | Full-session aggregates for resume UI. The transcript preview stays
+-- paged; these fields describe the whole stored conversation.
+data SessionResumeStats = SessionResumeStats
+    { sessionResumeTurnCount :: !Int64
+    , sessionResumeMessageCount :: !Int64
+    , sessionResumeToolCount :: !Int64
+    , sessionResumeFirstPrompt :: !(Maybe Text)
     }
     deriving (Eq, Show)
 
@@ -543,6 +555,15 @@ loadSessionTurnsAfter pool sessionKey cursor limit =
             loadTurnsAfterStatement)
         (max 1 limit)
         PageAfter
+
+loadSessionResumeStats
+    :: StorePool
+    -> Text
+    -> IO (Either StoreError (Maybe SessionResumeStats))
+loadSessionResumeStats pool sessionKey =
+    withSession pool $
+        Transactions.transaction Transactions.RepeatableRead Transactions.Read $
+            Transaction.statement sessionKey loadResumeStatsStatement
 
 data PageMode = PageRecent | PageBefore | PageAfter
     deriving (Eq, Show)
@@ -1134,6 +1155,45 @@ currentGenerationStatement = mkStatement
         (,)
             <$> Decoders.column (Decoders.nonNullable Decoders.int8)
             <*> Decoders.column (Decoders.nonNullable Decoders.int8))
+    True
+
+loadResumeStatsStatement :: Statement Text (Maybe SessionResumeStats)
+loadResumeStatsStatement = mkStatement
+    "WITH target AS (\
+    \ SELECT session_id\
+    \ FROM harness.sessions\
+    \ WHERE session_key = $1 AND deleted_at IS NULL\
+    \ )\
+    \ SELECT\
+    \   (SELECT count(*)::bigint\
+    \    FROM harness.session_turns t\
+    \    JOIN target ON target.session_id = t.session_id),\
+    \   (SELECT COALESCE(sum(\
+    \      (CASE WHEN btrim(t.user_text) <> '' THEN 1 ELSE 0 END)\
+    \      + (CASE WHEN t.assistant_text IS NOT NULL\
+    \               AND btrim(t.assistant_text) <> '' THEN 1 ELSE 0 END)\
+    \    ), 0)::bigint\
+    \    FROM harness.session_turns t\
+    \    JOIN target ON target.session_id = t.session_id),\
+    \   (SELECT count(*)::bigint\
+    \    FROM harness.session_response_items i\
+    \    JOIN harness.session_turns t ON t.turn_id = i.turn_id\
+    \    JOIN target ON target.session_id = t.session_id\
+    \    WHERE i.storage_kind IN ('function_call', 'custom_tool_call')),\
+    \   (SELECT t.user_text\
+    \    FROM harness.session_turns t\
+    \    JOIN target ON target.session_id = t.session_id\
+    \    WHERE btrim(t.user_text) <> ''\
+    \    ORDER BY t.turn_index ASC\
+    \    LIMIT 1)\
+    \ FROM target"
+    (Encoders.param (Encoders.nonNullable Encoders.text))
+    (Decoders.rowMaybe $
+        SessionResumeStats
+            <$> Decoders.column (Decoders.nonNullable Decoders.int8)
+            <*> Decoders.column (Decoders.nonNullable Decoders.int8)
+            <*> Decoders.column (Decoders.nonNullable Decoders.int8)
+            <*> Decoders.column (Decoders.nullable Decoders.text))
     True
 
 turnSelectSql :: Text

--- a/packages/agent-store/src/Agent/Store/Postgres/Session.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Session.hs
@@ -12,6 +12,7 @@
 module Agent.Store.Postgres.Session
     ( SessionMetadata(..)
     , SessionLegacyTarget(..)
+    , TranscriptEffect(..)
     , SessionTurn(..)
     , SessionUsage(..)
     , StoredSession(..)
@@ -23,8 +24,15 @@ module Agent.Store.Postgres.Session
     , createSession
     , replaceSessionMetadata
     , appendSessionTurn
+    , appendSessionTurnIndexed
     , loadSession
     , loadSessions
+    , loadSessionMetadata
+    , loadActiveSession
+    , SessionTurnPage(..)
+    , loadRecentSessionTurns
+    , loadSessionTurnsBefore
+    , loadSessionTurnsAfter
     , loadSessionEvents
     , listSessionMetadata
     , searchConversationTurns
@@ -68,6 +76,15 @@ data SessionLegacyTarget = SessionLegacyTarget
     }
     deriving (Eq, Show)
 
+data SessionTurnPage = SessionTurnPage
+    { sessionPageTurns :: ![StoredTurn]
+    , sessionPageGenerationStart :: !Int64
+    , sessionPageTotal :: !Int64
+    , sessionPageHasOlder :: !Bool
+    , sessionPageHasNewer :: !Bool
+    }
+    deriving (Eq, Show)
+
 data SessionMetadata = SessionMetadata
     { sessionMetadataKey :: !Text
     , sessionMetadataVersion :: !Int32
@@ -102,12 +119,19 @@ data SessionUsage = SessionUsage
     }
     deriving (Eq, Show)
 
+data TranscriptEffect
+    = TranscriptAppend
+    | TranscriptReplace
+    | TranscriptReset
+    deriving (Eq, Show)
+
 data SessionTurn = SessionTurn
     { sessionTurnOccurredAt :: !UTCTime
     , sessionTurnUserText :: !Text
     , sessionTurnAssistantText :: !(Maybe Text)
     , sessionTurnError :: !(Maybe Text)
     , sessionTurnResponseId :: !(Maybe Text)
+    , sessionTurnEffect :: !TranscriptEffect
     , sessionTurnItems :: ![StoredResponseItem]
     , sessionTurnUsage :: !(Maybe SessionUsage)
     }
@@ -231,6 +255,8 @@ sessionSchemaStatements =
       \ assistant_text text,\
       \ error_text text,\
       \ response_id text,\
+      \ transcript_effect text NOT NULL DEFAULT 'append'\
+      \   CHECK (transcript_effect IN ('append', 'replace', 'reset')),\
       \ usage_input_tokens bigint,\
       \ usage_output_tokens bigint,\
       \ usage_cached_tokens bigint,\
@@ -256,6 +282,11 @@ sessionSchemaStatements =
       \ ON harness.session_turns USING gin (search_vector)"
     , "CREATE INDEX IF NOT EXISTS session_turns_session_time_idx\
       \ ON harness.session_turns (session_id, occurred_at DESC)"
+    , "CREATE INDEX IF NOT EXISTS session_turns_session_index_idx\
+      \ ON harness.session_turns (session_id, turn_index)"
+    , "CREATE INDEX IF NOT EXISTS session_turns_checkpoint_idx\
+      \ ON harness.session_turns (session_id, turn_index DESC)\
+      \ WHERE transcript_effect <> 'append'"
     ]
     <> sessionItemSchemaStatements
     <> [ "CREATE TABLE IF NOT EXISTS harness.legacy_session_imports (\
@@ -345,6 +376,15 @@ appendSessionTurn
     -> SessionMetadata
     -> IO (Either StoreError Bool)
 appendSessionTurn pool turn metadata =
+    fmap (fmap (maybe False (const True))) $
+        appendSessionTurnIndexed pool turn metadata
+
+appendSessionTurnIndexed
+    :: StorePool
+    -> SessionTurn
+    -> SessionMetadata
+    -> IO (Either StoreError (Maybe Int64))
+appendSessionTurnIndexed pool turn metadata =
     withSession pool $
         Transactions.transaction Transactions.Serializable Transactions.Write do
             _ <- Transaction.statement
@@ -352,7 +392,7 @@ appendSessionTurn pool turn metadata =
                 blockingAdvisoryLockStatement
             changed <- Transaction.statement metadata appendProjectionStatement
             case changed of
-                Nothing -> pure False
+                Nothing -> pure Nothing
                 Just (sessionId, sequence, turnIndex) -> do
                     eventId <- Transaction.statement
                         EventInsert
@@ -372,7 +412,7 @@ appendSessionTurn pool turn metadata =
                             }
                         insertTurnStatement
                     insertResponseItems turnId turn.sessionTurnItems
-                    pure True
+                    pure (Just turnIndex)
 
 loadSession
     :: StorePool
@@ -433,6 +473,132 @@ assembleSessions sessionKeys metadata turns =
                     { storedMetadata = value
                     , storedTurns = decodedTurns
                     }
+
+loadSessionMetadata
+    :: StorePool
+    -> Text
+    -> IO (Either StoreError (Maybe SessionMetadata))
+loadSessionMetadata pool sessionKey =
+    withSession pool $
+        Transactions.transaction Transactions.RepeatableRead Transactions.Read $
+            Transaction.statement sessionKey loadMetadataStatement
+
+loadActiveSession
+    :: StorePool
+    -> Text
+    -> IO (Either StoreError (Maybe StoredSession))
+loadActiveSession pool sessionKey =
+    withSession pool
+        (Transactions.transaction Transactions.RepeatableRead Transactions.Read do
+            metadata <- Transaction.statement sessionKey loadMetadataStatement
+            case metadata of
+                Nothing -> pure (Right Nothing)
+                Just value -> do
+                    rows <- Transaction.statement sessionKey loadActiveTurnsStatement
+                    turns <- forM rows loadStoredTurn
+                    pure do
+                        decodedTurns <- sequence turns
+                        pure $ Just StoredSession
+                            { storedMetadata = value
+                            , storedTurns = decodedTurns
+                            })
+        >>= flattenDataResult
+
+loadRecentSessionTurns
+    :: StorePool
+    -> Text
+    -> Int
+    -> IO (Either StoreError (Maybe SessionTurnPage))
+loadRecentSessionTurns pool sessionKey limit =
+    loadTurnPage pool sessionKey
+        (Transaction.statement (sessionKey, fromIntegral (max 1 limit + 1))
+            loadRecentTurnsStatement)
+        (max 1 limit)
+        PageRecent
+
+loadSessionTurnsBefore
+    :: StorePool
+    -> Text
+    -> Int64
+    -> Int
+    -> IO (Either StoreError (Maybe SessionTurnPage))
+loadSessionTurnsBefore pool sessionKey cursor limit =
+    loadTurnPage pool sessionKey
+        (Transaction.statement
+            (sessionKey, cursor, fromIntegral (max 1 limit + 1))
+            loadTurnsBeforeStatement)
+        (max 1 limit)
+        PageBefore
+
+loadSessionTurnsAfter
+    :: StorePool
+    -> Text
+    -> Int64
+    -> Int
+    -> IO (Either StoreError (Maybe SessionTurnPage))
+loadSessionTurnsAfter pool sessionKey cursor limit =
+    loadTurnPage pool sessionKey
+        (Transaction.statement
+            (sessionKey, cursor, fromIntegral (max 1 limit + 1))
+            loadTurnsAfterStatement)
+        (max 1 limit)
+        PageAfter
+
+data PageMode = PageRecent | PageBefore | PageAfter
+    deriving (Eq, Show)
+
+loadTurnPage
+    :: StorePool
+    -> Text
+    -> Transaction.Transaction [TurnRow]
+    -> Int
+    -> PageMode
+    -> IO (Either StoreError (Maybe SessionTurnPage))
+loadTurnPage pool sessionKey loadRows limit mode =
+    withSession pool
+        (Transactions.transaction Transactions.RepeatableRead Transactions.Read do
+            metadata <- Transaction.statement sessionKey loadMetadataStatement
+            case metadata of
+                Nothing -> pure (Right Nothing)
+                Just _ -> do
+                    rows0 <- loadRows
+                    (generationStart, total) <-
+                        Transaction.statement sessionKey currentGenerationStatement
+                    let visibleRows = case mode of
+                            PageRecent -> reverse (take limit rows0)
+                            PageBefore -> reverse (take limit rows0)
+                            PageAfter -> take limit rows0
+                    turns <- forM visibleRows loadStoredTurn
+                    pure do
+                        decoded <- sequence turns
+                        let generationEnd =
+                                generationStart + max 0 total - 1
+                            (hasOlder, hasNewer) =
+                                case decoded of
+                                    firstTurn : rest ->
+                                        let lastTurn =
+                                                foldl
+                                                    (\_ current -> current)
+                                                    firstTurn
+                                                    rest
+                                        in
+                                            ( firstTurn.storedTurnIndex
+                                                > generationStart
+                                            , lastTurn.storedTurnIndex
+                                                < generationEnd
+                                            )
+                                    [] -> case mode of
+                                        PageRecent -> (False, False)
+                                        PageBefore -> (False, total > 0)
+                                        PageAfter -> (total > 0, False)
+                        pure $ Just SessionTurnPage
+                            { sessionPageTurns = decoded
+                            , sessionPageGenerationStart = generationStart
+                            , sessionPageTotal = total
+                            , sessionPageHasOlder = hasOlder
+                            , sessionPageHasNewer = hasNewer
+                            })
+        >>= flattenDataResult
 
 loadSessionEvents
     :: StorePool
@@ -599,6 +765,7 @@ data TurnRow = TurnRow
     , turnRowAssistantText :: !(Maybe Text)
     , turnRowError :: !(Maybe Text)
     , turnRowResponseId :: !(Maybe Text)
+    , turnRowEffect :: !Text
     , turnRowUsageInput :: !(Maybe Int64)
     , turnRowUsageOutput :: !(Maybe Int64)
     , turnRowUsageCached :: !(Maybe Int64)
@@ -609,6 +776,7 @@ loadStoredTurn row = do
     items <- loadResponseItems row.turnRowId
     pure do
         decodedItems <- items
+        effect <- decodeTranscriptEffect row.turnRowEffect
         usage <- decodeUsage
             row.turnRowUsageInput
             row.turnRowUsageOutput
@@ -622,6 +790,7 @@ loadStoredTurn row = do
                 , sessionTurnAssistantText = row.turnRowAssistantText
                 , sessionTurnError = row.turnRowError
                 , sessionTurnResponseId = row.turnRowResponseId
+                , sessionTurnEffect = effect
                 , sessionTurnItems = decodedItems
                 , sessionTurnUsage = usage
                 }
@@ -642,6 +811,27 @@ decodeUsage input output cached =
                 , sessionUsageCachedTokens = cached'
                 }
         _ -> Left "stored session turn has partial usage counters"
+
+decodeTranscriptEffect :: Text -> Either Text TranscriptEffect
+decodeTranscriptEffect value = case value of
+    "append" -> Right TranscriptAppend
+    "replace" -> Right TranscriptReplace
+    "reset" -> Right TranscriptReset
+    _ -> Left ("unknown transcript effect: " <> value)
+
+transcriptEffectText :: TranscriptEffect -> Text
+transcriptEffectText effect = case effect of
+    TranscriptAppend -> "append"
+    TranscriptReplace -> "replace"
+    TranscriptReset -> "reset"
+
+flattenDataResult
+    :: Either StoreError (Either Text a)
+    -> IO (Either StoreError a)
+flattenDataResult = pure . \case
+    Left err -> Left err
+    Right (Left err) -> Left (StoreDataError err)
+    Right (Right value) -> Right value
 
 sessionExistsStatement :: Statement Text Bool
 sessionExistsStatement = mkStatement
@@ -732,9 +922,10 @@ insertTurnStatement = mkStatement
     "INSERT INTO harness.session_turns (\
     \ session_id, event_id, turn_index, event_sequence, occurred_at,\
     \ user_text, assistant_text, error_text, response_id,\
+    \ transcript_effect,\
     \ usage_input_tokens, usage_output_tokens, usage_cached_tokens\
     \ ) VALUES (\
-    \ $1::uuid, $2::uuid, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12\
+    \ $1::uuid, $2::uuid, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13\
     \ ) RETURNING turn_id::text"
     ( ((.turnInsertSessionId) >$< Encoders.param (Encoders.nonNullable Encoders.text))
         <> ((.turnInsertEventId) >$< Encoders.param (Encoders.nonNullable Encoders.text))
@@ -745,6 +936,7 @@ insertTurnStatement = mkStatement
         <> (turnAssistantText >$< Encoders.param (Encoders.nullable Encoders.text))
         <> (turnError >$< Encoders.param (Encoders.nullable Encoders.text))
         <> (turnResponseId >$< Encoders.param (Encoders.nullable Encoders.text))
+        <> (turnEffect >$< Encoders.param (Encoders.nonNullable Encoders.text))
         <> ((usageField (.sessionUsageInputTokens) . (.turnInsertTurn))
             >$< Encoders.param (Encoders.nullable Encoders.int8))
         <> ((usageField (.sessionUsageOutputTokens) . (.turnInsertTurn))
@@ -770,6 +962,8 @@ insertTurnStatement = mkStatement
     turnError value = value.turnInsertTurn.sessionTurnError
     turnResponseId :: TurnInsert -> Maybe Text
     turnResponseId value = value.turnInsertTurn.sessionTurnResponseId
+    turnEffect :: TurnInsert -> Text
+    turnEffect value = transcriptEffectText value.turnInsertTurn.sessionTurnEffect
 
 loadMetadataManyStatement :: Statement [Text] [SessionMetadata]
 loadMetadataManyStatement = mkStatement
@@ -778,6 +972,14 @@ loadMetadataManyStatement = mkStatement
            \ ORDER BY array_position($1::text[], session_key)")
     textArrayParams
     (Decoders.rowList metadataRow)
+    True
+
+loadMetadataStatement :: Statement Text (Maybe SessionMetadata)
+loadMetadataStatement = mkStatement
+    (metadataSelectSql
+        <> " WHERE session_key = $1 AND deleted_at IS NULL")
+    (Encoders.param (Encoders.nonNullable Encoders.text))
+    (Decoders.rowMaybe metadataRow)
     True
 
 listMetadataStatement :: Statement () [SessionMetadata]
@@ -803,9 +1005,9 @@ metadataSelectSql =
 loadTurnsManyStatement :: Statement [Text] [(Text, TurnRow)]
 loadTurnsManyStatement = mkStatement
     "SELECT s.session_key, t.turn_id::text, t.turn_index, t.event_sequence,\
-    \ t.occurred_at,\
-    \ t.user_text, t.assistant_text, t.error_text, t.response_id,\
-    \ t.usage_input_tokens, t.usage_output_tokens, t.usage_cached_tokens\
+    \ t.occurred_at, t.user_text, t.assistant_text, t.error_text,\
+    \ t.response_id, t.transcript_effect, t.usage_input_tokens,\
+    \ t.usage_output_tokens, t.usage_cached_tokens\
     \ FROM harness.session_turns t\
     \ JOIN harness.sessions s ON s.session_id = t.session_id\
     \ WHERE s.session_key = ANY($1::text[]) AND s.deleted_at IS NULL\
@@ -816,6 +1018,132 @@ loadTurnsManyStatement = mkStatement
             <$> Decoders.column (Decoders.nonNullable Decoders.text)
             <*> turnRowDecoder)
     True
+
+loadActiveTurnsStatement :: Statement Text [TurnRow]
+loadActiveTurnsStatement = mkStatement
+    (turnSelectSql
+        <> " WHERE s.session_key = $1\
+           \ AND t.turn_index >= COALESCE((\
+           \   SELECT checkpoint.turn_index\
+           \   FROM harness.session_turns checkpoint\
+           \   WHERE checkpoint.session_id = s.session_id\
+           \     AND checkpoint.transcript_effect <> 'append'\
+           \   ORDER BY checkpoint.turn_index DESC\
+           \   LIMIT 1\
+           \ ), 0)\
+           \ ORDER BY t.turn_index ASC")
+    (Encoders.param (Encoders.nonNullable Encoders.text))
+    (Decoders.rowList turnRowDecoder)
+    True
+
+loadRecentTurnsStatement :: Statement (Text, Int64) [TurnRow]
+loadRecentTurnsStatement = mkStatement
+    (turnSelectSql
+        <> " WHERE s.session_key = $1\
+           \ AND t.turn_index >= COALESCE((\
+           \   SELECT checkpoint.turn_index\
+           \   FROM harness.session_turns checkpoint\
+           \   WHERE checkpoint.session_id = s.session_id\
+           \     AND checkpoint.transcript_effect <> 'append'\
+           \   ORDER BY checkpoint.turn_index DESC\
+           \   LIMIT 1\
+           \ ), 0)\
+           \ ORDER BY t.turn_index DESC\
+           \ LIMIT $2")
+    ( (fst >$< Encoders.param (Encoders.nonNullable Encoders.text))
+        <> (snd >$< Encoders.param (Encoders.nonNullable Encoders.int8))
+    )
+    (Decoders.rowList turnRowDecoder)
+    True
+
+loadTurnsBeforeStatement :: Statement (Text, Int64, Int64) [TurnRow]
+loadTurnsBeforeStatement = mkStatement
+    (turnSelectSql
+        <> " WHERE s.session_key = $1\
+           \ AND t.turn_index < $2\
+           \ AND t.turn_index >= COALESCE((\
+           \   SELECT checkpoint.turn_index\
+           \   FROM harness.session_turns checkpoint\
+           \   WHERE checkpoint.session_id = s.session_id\
+           \     AND checkpoint.transcript_effect <> 'append'\
+           \   ORDER BY checkpoint.turn_index DESC\
+           \   LIMIT 1\
+           \ ), 0)\
+           \ ORDER BY t.turn_index DESC\
+           \ LIMIT $3")
+    ( ((\(value, _, _) -> value)
+        >$< Encoders.param (Encoders.nonNullable Encoders.text))
+        <> ((\(_, value, _) -> value)
+            >$< Encoders.param (Encoders.nonNullable Encoders.int8))
+        <> ((\(_, _, value) -> value)
+            >$< Encoders.param (Encoders.nonNullable Encoders.int8))
+    )
+    (Decoders.rowList turnRowDecoder)
+    True
+
+loadTurnsAfterStatement :: Statement (Text, Int64, Int64) [TurnRow]
+loadTurnsAfterStatement = mkStatement
+    (turnSelectSql
+        <> " WHERE s.session_key = $1\
+           \ AND t.turn_index > $2\
+           \ AND t.turn_index >= COALESCE((\
+           \   SELECT checkpoint.turn_index\
+           \   FROM harness.session_turns checkpoint\
+           \   WHERE checkpoint.session_id = s.session_id\
+           \     AND checkpoint.transcript_effect <> 'append'\
+           \   ORDER BY checkpoint.turn_index DESC\
+           \   LIMIT 1\
+           \ ), 0)\
+           \ ORDER BY t.turn_index ASC\
+           \ LIMIT $3")
+    ( ((\(value, _, _) -> value)
+        >$< Encoders.param (Encoders.nonNullable Encoders.text))
+        <> ((\(_, value, _) -> value)
+            >$< Encoders.param (Encoders.nonNullable Encoders.int8))
+        <> ((\(_, _, value) -> value)
+            >$< Encoders.param (Encoders.nonNullable Encoders.int8))
+    )
+    (Decoders.rowList turnRowDecoder)
+    True
+
+currentGenerationStatement :: Statement Text (Int64, Int64)
+currentGenerationStatement = mkStatement
+    "WITH target AS (\
+    \ SELECT session_id\
+    \ FROM harness.sessions\
+    \ WHERE session_key = $1 AND deleted_at IS NULL\
+    \ ), generation AS (\
+    \ SELECT COALESCE((\
+    \   SELECT t.turn_index\
+    \   FROM harness.session_turns t\
+    \   JOIN target ON target.session_id = t.session_id\
+    \   WHERE t.transcript_effect <> 'append'\
+    \   ORDER BY t.turn_index DESC\
+    \   LIMIT 1\
+    \ ), 0) AS start_index\
+    \ )\
+    \ SELECT generation.start_index, count(t.turn_id)::bigint\
+    \ FROM generation\
+    \ LEFT JOIN target ON true\
+    \ LEFT JOIN harness.session_turns t\
+    \   ON t.session_id = target.session_id\
+    \   AND t.turn_index >= generation.start_index\
+    \ GROUP BY generation.start_index"
+    (Encoders.param (Encoders.nonNullable Encoders.text))
+    (Decoders.singleRow $
+        (,)
+            <$> Decoders.column (Decoders.nonNullable Decoders.int8)
+            <*> Decoders.column (Decoders.nonNullable Decoders.int8))
+    True
+
+turnSelectSql :: Text
+turnSelectSql =
+    "SELECT t.turn_id::text, t.turn_index, t.event_sequence, t.occurred_at,\
+    \ t.user_text, t.assistant_text, t.error_text, t.response_id,\
+    \ t.transcript_effect,\
+    \ t.usage_input_tokens, t.usage_output_tokens, t.usage_cached_tokens\
+    \ FROM harness.session_turns t\
+    \ JOIN harness.sessions s ON s.session_id = t.session_id"
 
 turnRowDecoder :: Decoders.Row TurnRow
 turnRowDecoder =
@@ -828,6 +1156,7 @@ turnRowDecoder =
         <*> Decoders.column (Decoders.nullable Decoders.text)
         <*> Decoders.column (Decoders.nullable Decoders.text)
         <*> Decoders.column (Decoders.nullable Decoders.text)
+        <*> Decoders.column (Decoders.nonNullable Decoders.text)
         <*> Decoders.column (Decoders.nullable Decoders.int8)
         <*> Decoders.column (Decoders.nullable Decoders.int8)
         <*> Decoders.column (Decoders.nullable Decoders.int8)

--- a/packages/agent-store/test/Agent/Store/Postgres/ManagedSpec.hs
+++ b/packages/agent-store/test/Agent/Store/Postgres/ManagedSpec.hs
@@ -132,6 +132,49 @@ spec =
                                 (closeStorePool ownerPool)
                     ) `finally` cleanup
 
+        it "backfills transcript effects and restores turn immutability" $
+            withSystemTempDirectory "ha" \stateDirectory -> do
+                let
+                    config = defaultManagedPostgresConfig stateDirectory ""
+                    cleanup = do
+                        _ <- stopManagedPostgres config
+                        pure ()
+                (do
+                    ensureManagedPostgres config
+                        >>= (`shouldSatisfy` isRight)
+                    openStorePool config defaultPoolConfig >>= \case
+                        Left err ->
+                            expectationFailure
+                                ("could not open migration pool: " <> show err)
+                        Right ownerPool ->
+                            finally
+                                (do
+                                    runMigrations ownerPool
+                                        legacyTranscriptEffectMigrations
+                                        `shouldReturn` Right ()
+                                    runMigrations ownerPool coreMigrations
+                                        `shouldReturn` Right ()
+                                    withSession ownerPool
+                                        (Session.statement ()
+                                            migratedTranscriptEffectsStatement)
+                                        `shouldReturn`
+                                            Right
+                                                [ "append"
+                                                , "replace"
+                                                , "replace"
+                                                , "replace"
+                                                , "reset"
+                                                ]
+                                    immutable <- withSession ownerPool
+                                        (Session.script
+                                            "UPDATE harness.session_turns\
+                                            \ SET user_text = 'mutated'\
+                                            \ WHERE turn_index = 0")
+                                    immutable `shouldSatisfy` isLeft
+                                )
+                                (closeStorePool ownerPool)
+                    ) `finally` cleanup
+
         it "migrates opaque response fields to text columns" $
             withSystemTempDirectory "ha" \stateDirectory -> do
                 let
@@ -190,6 +233,97 @@ legacyMigrations =
             , "GRANT USAGE ON SCHEMA harness TO ha_runtime"
             , "GRANT SELECT ON harness.schema_migrations TO ha_runtime"
             ]
+        }
+    ]
+
+legacyTranscriptEffectMigrations :: [Migration]
+legacyTranscriptEffectMigrations =
+    [ Migration
+        { migrationVersion = 1
+        , migrationName = "initial harness storage"
+        , migrationStatements =
+            [ "CREATE TABLE harness.session_turns (\
+              \ turn_id uuid PRIMARY KEY,\
+              \ session_id uuid NOT NULL,\
+              \ turn_index bigint NOT NULL,\
+              \ user_text text NOT NULL\
+              \ )"
+            , "CREATE TABLE harness.session_response_items (\
+              \ response_item_id uuid PRIMARY KEY,\
+              \ turn_id uuid NOT NULL,\
+              \ item_type text NOT NULL\
+              \ )"
+            , "CREATE TABLE harness.session_messages (\
+              \ response_item_id uuid PRIMARY KEY,\
+              \ role_name text NOT NULL,\
+              \ content_text text\
+              \ )"
+            , "CREATE TABLE harness.session_response_content_parts (\
+              \ content_part_id uuid PRIMARY KEY,\
+              \ response_item_id uuid NOT NULL,\
+              \ text_value text\
+              \ )"
+            , "CREATE OR REPLACE FUNCTION\
+              \ harness.reject_session_fact_mutation()\
+              \ RETURNS trigger\
+              \ LANGUAGE plpgsql\
+              \ AS $$ BEGIN\
+              \ RAISE EXCEPTION 'session events and turns are immutable';\
+              \ END $$"
+            , "CREATE TRIGGER session_turns_immutable\
+              \ BEFORE UPDATE OR DELETE ON harness.session_turns\
+              \ FOR EACH ROW EXECUTE FUNCTION\
+              \ harness.reject_session_fact_mutation()"
+            , "INSERT INTO harness.session_turns\
+              \ (turn_id, session_id, turn_index, user_text) VALUES\
+              \ ('10000000-0000-0000-0000-000000000001',\
+              \  '20000000-0000-0000-0000-000000000001', 0, 'hello'),\
+              \ ('10000000-0000-0000-0000-000000000002',\
+              \  '20000000-0000-0000-0000-000000000001', 1, '/compact'),\
+              \ ('10000000-0000-0000-0000-000000000003',\
+              \  '20000000-0000-0000-0000-000000000001', 2, 'automatic'),\
+              \ ('10000000-0000-0000-0000-000000000004',\
+              \  '20000000-0000-0000-0000-000000000001', 3, 'summary'),\
+              \ ('10000000-0000-0000-0000-000000000005',\
+              \  '20000000-0000-0000-0000-000000000001', 4, '/clear')"
+            , "INSERT INTO harness.session_response_items\
+              \ (response_item_id, turn_id, item_type) VALUES\
+              \ ('30000000-0000-0000-0000-000000000001',\
+              \  '10000000-0000-0000-0000-000000000003', 'compaction'),\
+              \ ('30000000-0000-0000-0000-000000000002',\
+              \  '10000000-0000-0000-0000-000000000004', 'message'),\
+              \ ('30000000-0000-0000-0000-000000000003',\
+              \  '10000000-0000-0000-0000-000000000005', 'compaction')"
+            , "INSERT INTO harness.session_messages\
+              \ (response_item_id, role_name, content_text) VALUES\
+              \ ('30000000-0000-0000-0000-000000000002', 'assistant',\
+              \  'Compacted conversation summary: retained facts')"
+            ]
+        }
+    , Migration
+        { migrationVersion = 2
+        , migrationName = "restricted harness runtime role"
+        , migrationStatements = []
+        }
+    , Migration
+        { migrationVersion = 3
+        , migrationName = "typed relational session storage"
+        , migrationStatements = []
+        }
+    , Migration
+        { migrationVersion = 4
+        , migrationName = "text tool outputs"
+        , migrationStatements = []
+        }
+    , Migration
+        { migrationVersion = 5
+        , migrationName = "versioned learned skills"
+        , migrationStatements = []
+        }
+    , Migration
+        { migrationVersion = 6
+        , migrationName = "typed response item fields"
+        , migrationStatements = []
         }
     ]
 
@@ -413,6 +547,15 @@ migratedToolOutputsStatement = Statement.preparable
             <*> Decoders.column (Decoders.nonNullable Decoders.bool)
             <*> Decoders.column (Decoders.nonNullable Decoders.bool)
             <*> Decoders.column (Decoders.nonNullable Decoders.bool))
+
+migratedTranscriptEffectsStatement :: Statement () [Text]
+migratedTranscriptEffectsStatement = Statement.preparable
+    "SELECT transcript_effect\
+    \ FROM harness.session_turns\
+    \ ORDER BY turn_index"
+    Encoders.noParams
+    (Decoders.rowList $
+        Decoders.column (Decoders.nonNullable Decoders.text))
 
 upgradedSchemaStatement :: Statement () (Bool, Bool, Bool)
 upgradedSchemaStatement = Statement.preparable

--- a/packages/agent-store/test/Agent/Store/Postgres/SessionSpec.hs
+++ b/packages/agent-store/test/Agent/Store/Postgres/SessionSpec.hs
@@ -281,6 +281,16 @@ spec = describe "PostgreSQL session schema" do
                                 other ->
                                     expectationFailure
                                         ("unexpected empty after page: " <> show other)
+                            loadSessionResumeStats pool "session-1" >>= \case
+                                Right (Just stats) -> do
+                                    stats.sessionResumeTurnCount `shouldBe` 6
+                                    stats.sessionResumeMessageCount `shouldBe` 12
+                                    stats.sessionResumeToolCount `shouldBe` 12
+                                    stats.sessionResumeFirstPrompt
+                                        `shouldBe` Just "/question--1"
+                                other ->
+                                    expectationFailure
+                                        ("unexpected resume stats: " <> show other)
                         )
                         (closeStore store)
                 ) `finally` cleanup

--- a/packages/agent-store/test/Agent/Store/Postgres/SessionSpec.hs
+++ b/packages/agent-store/test/Agent/Store/Postgres/SessionSpec.hs
@@ -6,6 +6,7 @@ import Control.Exception.Safe (finally)
 import qualified Data.ByteString as ByteString
 import qualified Data.ByteString.Char8 as ByteString.Char8
 import Data.Text (Text)
+import qualified Data.Text as Text
 import Data.Time.Calendar (fromGregorian)
 import Data.Time.Clock (UTCTime(..), picosecondsToDiffTime)
 import System.IO.Temp (withSystemTempDirectory)
@@ -174,6 +175,116 @@ spec = describe "PostgreSQL session schema" do
                         (closeStore store)
                 ) `finally` cleanup
 
+    it "pages the active transcript around the latest replacement checkpoint" $
+        withSystemTempDirectory "ha" \stateDirectory -> do
+            let
+                config = defaultManagedPostgresConfig stateDirectory ""
+                cleanup = do
+                    _ <- stopManagedPostgres config
+                    pure ()
+            (openStore config >>= \case
+                Left err -> expectationFailure ("could not open store: " <> show err)
+                Right store ->
+                    finally
+                        (do
+                            let pool = trustedPool store
+                                now = read "2026-08-23 12:00:00 UTC"
+                                metadata = testMetadata now
+                                checkpoint =
+                                    (testTurn now)
+                                        { sessionTurnUserText = "/compact"
+                                        , sessionTurnEffect = TranscriptReplace
+                                        }
+                                appendTurn index effect =
+                                    appendSessionTurn pool
+                                        (checkpoint
+                                            { sessionTurnUserText =
+                                                "/question-" <> Text.pack (show index)
+                                            , sessionTurnAssistantText =
+                                                Just ("answer-" <> Text.pack (show index))
+                                            , sessionTurnEffect = effect
+                                            })
+                                        metadata
+                            createSession pool metadata
+                                `shouldReturn` Right True
+                            appendTurn (-1 :: Int) TranscriptAppend
+                                `shouldReturn` Right True
+                            appendTurn (0 :: Int) TranscriptAppend
+                                `shouldReturn` Right True
+                            appendSessionTurnIndexed pool checkpoint metadata
+                                `shouldReturn` Right (Just 2)
+                            appendTurn (1 :: Int) TranscriptAppend
+                                `shouldReturn` Right True
+                            appendTurn (2 :: Int) TranscriptAppend
+                                `shouldReturn` Right True
+                            appendTurn (3 :: Int) TranscriptAppend
+                                `shouldReturn` Right True
+                            loadActiveSession pool "session-1" >>= \case
+                                Right (Just stored) ->
+                                    map
+                                        (\storedTurn ->
+                                            storedTurn.storedTurn.sessionTurnUserText
+                                        )
+                                        stored.storedTurns
+                                        `shouldBe`
+                                            [ "/compact"
+                                            , "/question-1"
+                                            , "/question-2"
+                                            , "/question-3"
+                                            ]
+                                other ->
+                                    expectationFailure
+                                        ("unexpected active session: " <> show other)
+                            loadRecentSessionTurns pool "session-1" 2 >>= \case
+                                Right (Just page) -> do
+                                    map (.storedTurnIndex) page.sessionPageTurns
+                                        `shouldBe` [4, 5]
+                                    page.sessionPageGenerationStart
+                                        `shouldBe` 2
+                                    page.sessionPageTotal `shouldBe` 4
+                                    page.sessionPageHasOlder `shouldBe` True
+                                    page.sessionPageHasNewer `shouldBe` False
+                                other ->
+                                    expectationFailure
+                                        ("unexpected recent page: " <> show other)
+                            loadSessionTurnsBefore pool "session-1" 4 2 >>= \case
+                                Right (Just page) -> do
+                                    map (.storedTurnIndex) page.sessionPageTurns
+                                        `shouldBe` [2, 3]
+                                    page.sessionPageHasOlder `shouldBe` False
+                                    page.sessionPageHasNewer `shouldBe` True
+                                other ->
+                                    expectationFailure
+                                        ("unexpected before page: " <> show other)
+                            loadSessionTurnsAfter pool "session-1" 3 2 >>= \case
+                                Right (Just page) -> do
+                                    map (.storedTurnIndex) page.sessionPageTurns
+                                        `shouldBe` [4, 5]
+                                    page.sessionPageHasOlder `shouldBe` True
+                                    page.sessionPageHasNewer `shouldBe` False
+                                other ->
+                                    expectationFailure
+                                        ("unexpected after page: " <> show other)
+                            loadSessionTurnsBefore pool "session-1" 2 2 >>= \case
+                                Right (Just page) -> do
+                                    page.sessionPageTurns `shouldBe` []
+                                    page.sessionPageHasOlder `shouldBe` False
+                                    page.sessionPageHasNewer `shouldBe` True
+                                other ->
+                                    expectationFailure
+                                        ("unexpected empty before page: " <> show other)
+                            loadSessionTurnsAfter pool "session-1" 5 2 >>= \case
+                                Right (Just page) -> do
+                                    page.sessionPageTurns `shouldBe` []
+                                    page.sessionPageHasOlder `shouldBe` True
+                                    page.sessionPageHasNewer `shouldBe` False
+                                other ->
+                                    expectationFailure
+                                        ("unexpected empty after page: " <> show other)
+                        )
+                        (closeStore store)
+                ) `finally` cleanup
+
 testMetadata :: UTCTime -> SessionMetadata
 testMetadata now = SessionMetadata
     { sessionMetadataKey = "session-1"
@@ -208,6 +319,7 @@ testTurn now = SessionTurn
     , sessionTurnAssistantText = Just "done"
     , sessionTurnError = Nothing
     , sessionTurnResponseId = Just "response-1"
+    , sessionTurnEffect = TranscriptReplace
     , sessionTurnItems =
         [ StoredMessageItem StoredMessage
             { storedMessageProviderItemId = Just "item-message"

--- a/packages/agent-telegram/src/Agent/Telegram.hs
+++ b/packages/agent-telegram/src/Agent/Telegram.hs
@@ -66,8 +66,10 @@ import Agent.CLI.Session
     , SessionHandle(..)
     , SessionMeta(..)
     , SessionTurn(..)
+    , SessionTurnPage(..)
     , createSession
     , loadSessionHandle
+    , loadRecentSessionTurns
     , sessionTitleFromPrompt
     , sessionsRoot
     )
@@ -142,6 +144,7 @@ import Data.Aeson
     , (.=)
     )
 import qualified Data.ByteString.Lazy as LBS
+import Data.Int (Int64)
 import qualified Data.Text.Encoding as TextEncoding
 import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe)
@@ -1058,12 +1061,8 @@ runQueuedMediaTurn runtime pending = do
             }
     createDirectoryIfMissing True bridgeDir
     setFileMode bridgePath 0o700
-    priorTurnCount <- loadSessionHandle
-        runtime.runtimePool
-        runtime.runtimeSessionsRoot
-        handle.sessionMeta.metaId >>= \case
-            Left err -> fail (Text.unpack err)
-            Right (_, turns) -> pure (length turns)
+    priorTurnIndex <-
+        latestPersistedTurnIndex runtime handle.sessionMeta.metaId
     result <-
         (withTelegramBridge bridgeEnv $
             launchManagedTurnBounded
@@ -1084,14 +1083,20 @@ runQueuedMediaTurn runtime pending = do
                 runtime.runtimeSessionsRoot
                 handle.sessionMeta.metaId >>= \case
                     Left err -> fail (Text.unpack err)
-                    Right (_, turns)
-                        | length turns > priorTurnCount
-                        , latestTurnMatches pending.pendingMediaText turns ->
-                            pure (renderLatestTurn turns)
-                        | otherwise ->
-                            fail
-                                "agent completed without recording \
-                                \the Telegram turn")
+                    Right (_, turns) ->
+                        latestPersistedTurnIndex
+                            runtime
+                            handle.sessionMeta.metaId >>= \case
+                                Just turnIndex
+                                    | maybe True (< turnIndex) priorTurnIndex
+                                    , latestTurnMatches
+                                        pending.pendingMediaText
+                                        turns ->
+                                        pure (renderLatestTurn turns)
+                                _ ->
+                                    fail
+                                        "agent completed without recording \
+                                        \the Telegram turn")
         `finally` cleanupManagedTurnMedia request
 
 checkpointVoiceTranscript
@@ -1448,12 +1453,8 @@ runManagedAgentTurn
             }
     createDirectoryIfMissing True bridgeDir
     setFileMode bridgePath 0o700
-    priorTurnCount <- loadSessionHandle
-        runtime.runtimePool
-        runtime.runtimeSessionsRoot
-        handle.sessionMeta.metaId >>= \case
-            Left err -> fail (Text.unpack err)
-            Right (_, turns) -> pure (length turns)
+    priorTurnIndex <-
+        latestPersistedTurnIndex runtime handle.sessionMeta.metaId
     (withTelegramBridge bridgeEnv $
         launchManagedTurnBounded
             runtime.runtimeProcessManager
@@ -1473,14 +1474,18 @@ runManagedAgentTurn
                     runtime.runtimeSessionsRoot
                     handle.sessionMeta.metaId >>= \case
                         Left err -> fail (Text.unpack err)
-                        Right (_, turns)
-                            | length turns > priorTurnCount
-                            , latestTurnMatches expectedPrompt turns ->
-                                pure (renderLatestTurn turns)
-                            | otherwise ->
-                                fail
-                                    "agent completed without recording \
-                                    \the Telegram turn"
+                        Right (_, turns) ->
+                            latestPersistedTurnIndex
+                                runtime
+                                handle.sessionMeta.metaId >>= \case
+                                    Just turnIndex
+                                        | maybe True (< turnIndex) priorTurnIndex
+                                        , latestTurnMatches expectedPrompt turns ->
+                                            pure (renderLatestTurn turns)
+                                    _ ->
+                                        fail
+                                            "agent completed without recording \
+                                            \the Telegram turn"
 
 telegramTurnUserId :: TelegramRuntime -> TelegramChatKey -> Integer
 telegramTurnUserId runtime key
@@ -1517,6 +1522,22 @@ latestTurnMatches :: Text -> [SessionTurn] -> Bool
 latestTurnMatches prompt turns = case reverse turns of
     turn : _ -> turn.turnUserText == prompt
     [] -> False
+
+latestPersistedTurnIndex
+    :: TelegramRuntime
+    -> Text
+    -> IO (Maybe Int64)
+latestPersistedTurnIndex runtime sessionId =
+    loadRecentSessionTurns
+        runtime.runtimePool
+        runtime.runtimeSessionsRoot
+        sessionId
+        1 >>= \case
+            Left err -> fail (Text.unpack err)
+            Right page ->
+                pure $ case reverse page.pageTurns of
+                    (turnIndex, _) : _ -> Just turnIndex
+                    [] -> Nothing
 
 sessionForPrompt
     :: TelegramRuntime


### PR DESCRIPTION
## Summary

Resume and fullscreen rendering no longer load an entire persisted transcript into memory. Durable turns are paged from PostgreSQL, and the TUI keeps a bounded, cursor-backed history window.

This ports the work from `2026-08-25-bc8e5162` onto current `master`, including the runtime facade split (`Runtime.hs` stays a re-export; history loading lives in `Runtime.Internal`).

## Changes

- Store persisted turns with a transcript effect (`append` / `replace` / `reset`) and page the active generation.
- Load recent/before/after turn windows instead of hydrating every session turn into Brick state.
- Keep the fullscreen transcript virtualized: request adjacent pages on scroll, commit new turns into the window, and reset across `/clear`, `/compact`, and `/new`.
- Use the same paged reads for resume previews, `read_agent_session`, Telegram recap, and session-title generation.
- Add `session-history-paging-bench` to compare full-transcript loads against active/recent paging.

## Tests

- `agent-store-test`: 33 examples, 0 failures (includes paging and migration coverage)
- `agent-cli-test --match "bounded fullscreen history window"`: 13 examples, 0 failures
- `agent-cli-test --match Agent.CLI.Session`: 23 examples, 0 failures
- `agent-cli-test --match Agent.CLI.AgentSessions`: 23 examples, 0 failures

Store and CLI tests used `TMPDIR=/tmp HASKELL_AGENT_TMPDIR=/tmp`.

## Benchmark

`packages/agent-store/benchmark/SessionHistoryPaging.hs` measures full transcript load vs active-generation and recent-page workloads:

```
nix develop -c cabal build --offline agent-store:bench:session-history-paging-bench
bin=$(nix develop -c cabal list-bin agent-store:bench:session-history-paging-bench)
"$bin" 1000,5000,10000 4096 5 +RTS -T
```