### PR TITLE
fix(openai): omit content_item_kinds from Responses Lite

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Error.hs
+++ b/packages/agent-cli/src/Agent/CLI/Error.hs
@@ -21,7 +21,7 @@ import Agent.Error
     , errorTypeText
     )
 import Control.Exception.Safe (Exception, displayException)
-import Data.Char (isControl)
+import Data.Char (isControl, isSpace)
 import Data.List (nub)
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -479,7 +479,14 @@ safeErrorType raw =
 
 looksStructured :: Text -> Bool
 looksStructured value =
-    any (`Text.isPrefixOf` Text.stripStart value) ["{", "[", "<"]
+    case Text.uncons (Text.stripStart value) of
+        Just ('{', _) -> True
+        Just ('<', _) -> True
+        Just ('[', rest) ->
+            case Text.uncons (Text.dropWhile isSpace rest) of
+                Just (next, _) -> next == '{' || next == '"' || next == '['
+                Nothing -> True
+        _ -> False
 
 looksLikeExceptionDump :: Text -> Bool
 looksLikeExceptionDump value =

--- a/packages/agent-cli/src/Agent/CLI/Session/Runner.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner.hs
@@ -112,6 +112,7 @@ import Agent.CLI.Terminal
     ( TerminalCapabilities(..)
     , resolveColor
     )
+import Agent.CLI.Request (setRequestInstructionsAndTools)
 import Agent.CLI.Tools (requireToolRegistry, schemasFromAppTools)
 import Agent.CLI.Dialects
     ( filterBashTools
@@ -814,12 +815,10 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
                         today
                         (isOneShot options)
                 toolSchemas = schemasFromAppTools dialect enabledTools
-            modifyIORef' paramsRef \ResponseCreateParams{..} ->
-                ResponseCreateParams
-                    { instructions = Just instructionText
-                    , tools = Just toolSchemas
-                    , ..
-                    }
+            modifyIORef' paramsRef
+                (setRequestInstructionsAndTools
+                    instructionText
+                    (Just toolSchemas))
         setShellMode mode = do
             let (ghciEnabled, bashEnabled) = shellModeFlags mode
             writeIORef ghciEnabledRef ghciEnabled

--- a/packages/agent-cli/test/Agent/CLI/ErrorSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ErrorSpec.hs
@@ -184,6 +184,16 @@ spec = do
                     Nothing)
                 `shouldNotSatisfy` Text.isInfixOf "\ESC"
 
+        it "keeps Responses validation messages that start with [ObjectParam]" do
+            let rendered =
+                    formatApiErrorAt epoch
+                        (ProviderError InvalidRequestError
+                            "[ObjectParam] [input[1].internal_chat_message_metadata_passthrough.content_item_kinds] [unknown_parameter] Unknown parameter: 'input[1].internal_chat_message_metadata_passthrough.content_item_kinds'."
+                            Nothing)
+            rendered `shouldSatisfy` Text.isInfixOf "Unknown parameter"
+            rendered `shouldSatisfy` Text.isInfixOf "content_item_kinds"
+            rendered `shouldNotSatisfy` Text.isInfixOf "{"
+
     describe "formatApiErrorInlineAt" do
         it "flattens the shared rendering for compact command surfaces" do
             let rendered =

--- a/packages/agent-openai/src/Agent/OpenAI/Request.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Request.hs
@@ -3,16 +3,79 @@ module Agent.OpenAI.Request
     ( sanitizeCodexRequest
     ) where
 
-import Agent.Responses.Types (ResponseCreateParams(..))
+import Agent.Responses.Types
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
 
--- | Keep prompt-cache retention out of Codex requests.
+-- | Keep Codex-incompatible fields out of the serialized request.
 --
 -- Retention is provider-managed for this transport. Sending a retained value
 -- explicitly is model-dependent and can make an otherwise valid request fail
 -- after the provider routes a response chain to a different model.
+--
+-- @content_item_kinds@ is a local prefix marker used to keep Responses Lite
+-- instructions attached across request rebuilds. Codex only sends it when a
+-- client feature flag is on; the current Responses Lite endpoint rejects it as
+-- an unknown parameter, so strip it at the wire boundary and leave the
+-- in-memory request params unchanged.
 sanitizeCodexRequest :: ResponseCreateParams -> ResponseCreateParams
-sanitizeCodexRequest ResponseCreateParams{promptCacheRetention = _, ..} =
+sanitizeCodexRequest ResponseCreateParams{promptCacheRetention = _, input, ..} =
     ResponseCreateParams
         { promptCacheRetention = Nothing
+        , input = fmap stripContentItemKindsInput input
         , ..
         }
+
+stripContentItemKindsInput :: ResponseInput -> ResponseInput
+stripContentItemKindsInput = \case
+    ResponseInputItems items ->
+        ResponseInputItems (map stripContentItemKindsItem items)
+    other -> other
+
+stripContentItemKindsItem :: ResponseItem -> ResponseItem
+stripContentItemKindsItem = \case
+    MessageItem message ->
+        MessageItem message
+            { extraFields = stripContentItemKindsFields message.extraFields }
+    FunctionCallItem value ->
+        FunctionCallItem value
+            { extraFields = stripContentItemKindsFields value.extraFields }
+    FunctionCallOutputItem value ->
+        FunctionCallOutputItem value
+            { extraFields = stripContentItemKindsFields value.extraFields }
+    CustomToolCallItem value ->
+        CustomToolCallItem value
+            { extraFields = stripContentItemKindsFields value.extraFields }
+    CustomToolCallOutputItem value ->
+        CustomToolCallOutputItem value
+            { extraFields = stripContentItemKindsFields value.extraFields }
+    ReasoningItemValue value ->
+        ReasoningItemValue value
+            { extraFields = stripContentItemKindsFields value.extraFields }
+    ItemReferenceValue value ->
+        ItemReferenceValue value
+            { extraFields = stripContentItemKindsFields value.extraFields }
+    KnownResponseItem itemType tagged ->
+        KnownResponseItem itemType tagged
+            { fields = stripContentItemKindsFields tagged.fields }
+    UnknownResponseItem tagged ->
+        UnknownResponseItem tagged
+            { fields = stripContentItemKindsFields tagged.fields }
+
+stripContentItemKindsFields :: Aeson.Object -> Aeson.Object
+stripContentItemKindsFields fields =
+    case KeyMap.lookup passthroughKey fields of
+        Just (Aeson.Object metadata) ->
+            let cleaned = KeyMap.delete contentItemKindsKey metadata
+            in if KeyMap.null cleaned
+                then KeyMap.delete passthroughKey fields
+                else KeyMap.insert
+                    passthroughKey
+                    (Aeson.Object cleaned)
+                    fields
+        _ -> fields
+  where
+    passthroughKey =
+        Key.fromText "internal_chat_message_metadata_passthrough"
+    contentItemKindsKey = Key.fromText "content_item_kinds"

--- a/packages/agent-openai/test/Agent/OpenAI/WebSocketClientSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/WebSocketClientSpec.hs
@@ -10,6 +10,7 @@ import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KeyMap
 import qualified Data.ByteString.Lazy as LBS
+import Data.Foldable (toList)
 import Data.IORef
 import Data.Text (Text)
 
@@ -85,6 +86,28 @@ spec = do
         field "prompt_cache_retention" payload `shouldBe` Nothing
         field "previous_response_id" payload
             `shouldBe` Just (Aeson.String "previous-1")
+
+    it "strips Responses Lite content_item_kinds from the wire payload" do
+        let payload = buildWsPayloadWithOptions
+                defaultCodexWsOptions sampleLitePrefixRequest Nothing
+        case field "input" payload of
+            Just (Aeson.Array items) ->
+                case toList items of
+                    [Aeson.Object message] -> do
+                        KeyMap.lookup
+                            (Key.fromText
+                                "internal_chat_message_metadata_passthrough")
+                            message
+                            `shouldBe` Nothing
+                        field "role" (Aeson.Object message)
+                            `shouldBe` Just (Aeson.String "developer")
+                    other ->
+                        expectationFailure
+                            ("expected one developer message, got "
+                                <> show other)
+            other ->
+                expectationFailure
+                    ("expected input array, got " <> show other)
 
     it "does not request server-managed compaction by default" do
         contextManagement defaultCodexWsOptions `shouldBe` Nothing
@@ -290,6 +313,26 @@ field :: Key.Key -> Aeson.Value -> Maybe Aeson.Value
 field name = \case
     Aeson.Object object -> KeyMap.lookup name object
     _ -> Nothing
+
+sampleLitePrefixRequest :: ResponseCreateParams
+sampleLitePrefixRequest = sampleRequest
+    { input = Just (ResponseInputItems
+        [ MessageItem ResponseMessage
+            { messageId = Nothing
+            , content = MessageContentParts
+                [InputTextPart "base instructions" Nothing KeyMap.empty]
+            , role = RoleDeveloper
+            , status = Nothing
+            , phase = Nothing
+            , extraFields = KeyMap.singleton
+                (Key.fromText "internal_chat_message_metadata_passthrough")
+                (Aeson.object
+                    [ "content_item_kinds"
+                        Aeson..= (["model.base_instructions"] :: [Text])
+                    ])
+            }
+        ])
+    }
 
 sampleRequest :: ResponseCreateParams
 sampleRequest = defaultResponseCreateParams


### PR DESCRIPTION
## Summary
- Responses Lite (`gpt-5.6-sol` / terra / luna) rejected even a first-turn `hi` because the local Lite prefix marker `internal_chat_message_metadata_passthrough.content_item_kinds` was serialized on the wire. The endpoint reports `unknown_parameter` for that field.
- Strip `content_item_kinds` (and an empty passthrough object) in `sanitizeCodexRequest` so HTTP and WebSocket omit it, while the in-memory marker still identifies the Lite instruction prefix.
- Show `[ObjectParam]` provider validation text in the CLI instead of treating it as structured JSON.
- Refresh shell/tool params through `setRequestInstructionsAndTools` so Lite requests do not regain top-level `instructions`/`tools`.

## Test plan
- [x] `cabal test agent-openai:test:agent-openai-test` (includes the new wire-sanitizer example)
- [x] Live tmux smoke: `agent-cli --yolo --model gpt-5.6-sol`, send `hi`, got `Hi! How can I help?`
- [ ] CI on this PR