### PR TITLE
test: run hello-world check for OpenAI and xAI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,29 +63,27 @@ jobs:
             credential_source_home="$account_home"
           fi
 
-          credentials_found=0
           if [[ -f "$credential_source_home/.codex/auth.json" ]]; then
             mkdir -p "$credential_home/.codex"
             install -m 600 "$credential_source_home/.codex/auth.json" \
               "$credential_home/.codex/auth.json"
-            credentials_found=1
+          else
+            echo "::error title=Missing OpenAI credentials::the CI runner must provide .codex/auth.json"
+            exit 1
           fi
           if [[ -f "$credential_source_home/.grok/auth.json" ]]; then
             mkdir -p "$credential_home/.grok"
             install -m 600 "$credential_source_home/.grok/auth.json" \
               "$credential_home/.grok/auth.json"
-            credentials_found=1
+          else
+            echo "::error title=Missing xAI credentials::the CI runner must provide .grok/auth.json"
+            exit 1
           fi
           if [[ -d "$credential_source_home/.haskell-agent/credentials" ]]; then
             mkdir -p "$credential_home/.haskell-agent"
             cp -R "$credential_source_home/.haskell-agent/credentials" \
               "$credential_home/.haskell-agent/credentials"
             chmod -R go-rwx "$credential_home/.haskell-agent/credentials"
-            credentials_found=1
-          fi
-          if [[ "$credentials_found" -eq 0 ]]; then
-            echo "::error title=Missing agent credentials::the CI runner must provide OpenAI, xAI, or managed agent credentials"
-            exit 1
           fi
 
           # The runner is user-namespaced, so it cannot create ACL entries for

--- a/flake.nix
+++ b/flake.nix
@@ -447,16 +447,20 @@
                 functionalTestEnabled =
                     functionalTestCredentialHome != ""
                     && pkgs.stdenv.hostPlatform.isLinux;
-                agentCliHelloWorldFunctional =
-                    pkgs.runCommand "agent-cli-functional-hello-world"
+                functionalTestModel = provider: default:
+                    let
+                        configured = builtins.getEnv
+                            "AGENT_FUNCTIONAL_TEST_${provider}_MODEL";
+                    in
+                    if configured == "" then default else configured;
+                agentCliHelloWorldFunctional = provider: model:
+                    pkgs.runCommand "agent-cli-functional-${provider}-hello-world"
                         {
                             __noChroot = true;
                             AGENT_FUNCTIONAL_TEST_CREDENTIAL_HOME =
                                 functionalTestCredentialHome;
-                            AGENT_FUNCTIONAL_TEST_PROVIDER =
-                                builtins.getEnv "AGENT_FUNCTIONAL_TEST_PROVIDER";
-                            AGENT_FUNCTIONAL_TEST_MODEL =
-                                builtins.getEnv "AGENT_FUNCTIONAL_TEST_MODEL";
+                            AGENT_FUNCTIONAL_TEST_PROVIDER = provider;
+                            AGENT_FUNCTIONAL_TEST_MODEL = model;
                             LANG = "C.UTF-8";
                             LC_ALL = "C.UTF-8";
                             SSL_CERT_FILE =
@@ -643,8 +647,12 @@
                         inherit self nixpkgs pkgs system;
                     };
                 } // pkgs.lib.optionalAttrs functionalTestEnabled {
-                    agent-cli-functional-hello-world =
-                        agentCliHelloWorldFunctional;
+                    agent-cli-functional-openai-hello-world =
+                        agentCliHelloWorldFunctional "openai"
+                            (functionalTestModel "OPENAI" "gpt-5.6-terra");
+                    agent-cli-functional-xai-hello-world =
+                        agentCliHelloWorldFunctional "xai"
+                            (functionalTestModel "XAI" "grok-4.6");
                 };
 
                 formatter = pkgs.nixfmt-rfc-style;


### PR DESCRIPTION
## Summary
- split the agent-cli hello-world functional check into separate OpenAI and xAI derivations
- run OpenAI with gpt-5.6-terra and xAI with grok-4.6
- require both credential files on the CI runner

## Validation
- both live checks pass locally
- impure `nix flake check --no-build` evaluates both checks