### PR TITLE
refactor(cli): extract runtime repl

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -56,6 +56,7 @@ library
                     , Agent.CLI.Runtime.Internal
                     , Agent.CLI.Runtime.Persistence
                     , Agent.CLI.Runtime.Recap
+                    , Agent.CLI.Runtime.Repl
                     , Agent.CLI.Runtime.Types
                     , Agent.CLI.Session.Attachments
                     , Agent.CLI.Session.Choices

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Internal.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Internal.hs
@@ -21,589 +21,465 @@ module Agent.CLI.Runtime.Internal
     , withRestoredCurrentDirectory
     ) where
 
-import Agent.CLI.Artifact (fencedCodeBlock, lastDiffBlock)
-import Agent.CLI.Afk
-    ( AfkTarget(..)
-    , handoffLocal
-    , handoffRemote
-    , parseAfkTarget
-    )
+import Agent.CLI.AccountPicker ()
 import Agent.CLI.AccountSelection
-    ( SelectedAccount(..)
-    , providerSupportsUsageAccountSelection
-    , selectProviderAccount
-    )
-import Agent.CLI.Auth
-    ( LoadedAuth(..)
-    , loadAuthForAccount
-    , preferredOpenAiTokenProvider
-    , probeLoadedAuthCredential
-    , staticCredentialProvider
-    )
-import Agent.CLI.Secret (promptSecretLine)
-import Agent.CLI.AgentViewport
-    ( AgentTarget(..)
-    , AgentViewportEnv(..)
-    , renderAgentViewportPanelFor
-    )
-import Agent.CLI.SessionTitle
-    ( invalidateSessionTitles
-    , requestSessionTitle
-    )
+    ( SelectedAccount(..),
+      providerSupportsUsageAccountSelection,
+      selectProviderAccount )
+import Agent.CLI.Afk ()
 import Agent.CLI.AgentSessions
-    ( AgentSessionToolsEnv(..)
-    , SessionThreadManager
-    , agentSessionTools
-    , closeSessionThreadManager
-    , launchSessionThread
-    , newSessionThreadManager
-    , signalManagedSessionReady
-    , sessionThreadStatus
-    )
-import Agent.CLI.ManagedTurn (ManagedTurnRequest(..))
-import Agent.CLI.GatewayBridge (managedGatewayTools)
-import Agent.CLI.Approval (toggleAlwaysApprove)
-import Agent.CLI.AccountPicker
-    ( AccountPickerOption(..)
-    , accountPickerMatches
-    , accountPickerRow
-    , loadAllAccountPickerOptions
-    )
-import Agent.CLI.Recap
-    ( RecapKind(..)
-    , RecapRequest(..)
-    )
-import Agent.CLI.Clipboard
-    ( formatImageSize
-    , loadImagesFromPastedText
-    , nonEmptyClipboardImages
-    , readClipboardImagesForPaste
-    , readClipboardImagesImageFirst
-    )
-import Agent.CLI.Command
-import Agent.CLI.Config
-    ( HarnessConfig(..)
-    , McpServerConfig(..)
-    , loadHarnessConfig
-    , useProgressiveMcp
-    )
+    ( AgentSessionToolsEnv(..),
+      SessionThreadManager,
+      agentSessionTools,
+      closeSessionThreadManager,
+      launchSessionThread,
+      newSessionThreadManager,
+      signalManagedSessionReady,
+      sessionThreadStatus )
+import Agent.CLI.AgentViewport ( AgentTarget(AgentRoot) )
+import Agent.CLI.Approval ()
+import Agent.CLI.Artifact ()
+import Agent.CLI.Auth
+    ( LoadedAuth(..),
+      loadAuthForAccount,
+      preferredOpenAiTokenProvider,
+      probeLoadedAuthCredential,
+      staticCredentialProvider )
+import Agent.CLI.Clipboard ()
+import Agent.CLI.Command ()
 import Agent.CLI.Compaction
-    ( CompactOutcome(..)
-    , installLiveCompactOutcome
-    , runProviderCompactWith
-    , runResponsesCompactWith
-    )
-import Agent.CLI.Connectivity (withConnectionRecovery)
-import Agent.CLI.Database (databaseTools)
+    ( installLiveCompactOutcome,
+      runProviderCompactWith,
+      runResponsesCompactWith )
+import Agent.CLI.Config
+    ( HarnessConfig(..),
+      McpServerConfig(..),
+      loadHarnessConfig,
+      useProgressiveMcp )
+import Agent.CLI.Connectivity ( withConnectionRecovery )
+import Agent.CLI.Database ( databaseTools )
 import Agent.CLI.Database.Store
-    ( databaseToolsEnvForStore
-    , deriveDatabaseScopes
-    )
-import Agent.CLI.LearnedSkills (learnedSkillTools)
-import Agent.CLI.LearnedSkills.Store (learnedSkillToolsEnvForStore)
-import Agent.CLI.Error
-    ( formatException
-    , formatApiErrorAt
-    , formatApiErrorInlineAt
-    )
-import Agent.CLI.Input
-    ( ReplLine(..)
-    , formatPasteChip
-    , readReplLineWithCatalog
-    , submissionPromptText
-    )
-import Agent.CLI.ReplMode
-    ( ReplMode(..)
-    , replModeLabel
-    , replModeFromState
-    )
-import Agent.CLI.PromptHooks
-    ( fullscreenAwarePlanHooks
-    , fullscreenAwareSecretHooks
-    )
-import Agent.CLI.Runtime.Types
-    ( DevResult(..)
-    , PendingTurnPresentation(..)
-    , PreparedAgent(..)
-    , RunResult(..)
-    )
-import Agent.CLI.Runtime.Persistence (preparePersistence)
-import Agent.CLI.Runtime.Recap
-    ( runSessionRecap
-    , runSessionTurnSummary
-    )
-import Agent.CLI.Session.Runtime.Types
-    ( SessionBackend(..)
-    , SessionRequest(..)
-    , StartupCancelled(..)
-    , StartupFailure(..)
-    , StartupRuntime(..)
-    )
-import Agent.CLI.Interrupt
-    ( CtrlCDecision(..)
-    , catchUserInterrupt
-    , newInterruptState
-    , noteFullscreenCtrlC
-    , withCtrlCHandler
-    )
-import Agent.CLI.Login
-    ( connectProviderAccount
-    , runLoginManager
-    )
-import Agent.CLI.Lsp
-    ( LspStartup(..)
-    , closeLspRuntime
-    , lspRuntimeTool
-    , newLspRuntime
-    )
-import Agent.CLI.McpManager (runMcpManager)
-import Agent.CLI.McpStatus
-    ( formatMcpModelNotice
-    , formatMcpModelNoticeFor
-    , formatMcpProgress
-    , summarizeMcpStatuses
-    )
-import Agent.CLI.ModelConfig
-    ( ConnectionKind(..)
-    , ModelConnection(..)
-    , ResponsesConnection(..)
-    , builtinConnectionId
-    , catalogConnection
-    , loadModelCatalogAt
-    )
-import Agent.CLI.Models
-    ( ModelOption(..)
-    , ModelTarget(..)
-    , catalogModelIds
-    , defaultModelFor
-    , modelTargetRequiresRebuild
-    , rawModelOption
-    , resolveConfiguredModel
-    , resolveModelOptionDialect
-    , resolvePersistedDialect
-    )
-import Agent.CLI.Options
-import Agent.Store.Postgres
-    ( Store
-    , closeStore
-    , openStore
-    , trustedPool
-    )
-import Agent.Store.Types (renderStoreError)
-import Agent.CLI.PendingInputs (withPendingInputs)
-import Agent.CLI.Plan (cliPlanHooks)
-import Agent.CLI.Progress
-    ( osc9ProgressIndeterminate
-    , osc9ProgressRemove
-    , wrapOscForTmux
-    )
-import Agent.CLI.Project
-    ( ProjectAccount(..)
-    , ProjectModel(..)
-    , ProjectSettings(..)
-    , loadProjectSettings
-    , projectAccountFor
-    , projectModelProvider
-    , resolveProjectRoot
-    , saveProjectModel
-    )
-import Agent.CLI.Prompt
-    ( subscriptionSubagentModelGuidance
-    , systemPromptForTools
-    )
-import Agent.CLI.Request (requestParams)
-import Agent.CLI.ProviderFallback
-    ( allowsAutomaticBillingFallback
-    , isProviderUnavailable
-    )
-import Agent.CLI.Provider.OpenAI
-    ( OpenAiPersistentConnection(..)
-    , lockedOpenAiSession
-    )
-import Agent.CLI.ProviderAvailability (probeLoadedAvailability)
-import Agent.CLI.Provider.Switch
-    ( accountSwitchTarget
-    , applyModelChange
-    , chooseStartupProviderTransition
-    , continueAutomaticFallback
-    , loadSelectedAccountAuth
-    , prepareTransitionBackend
-    , reloadAuth
-    , reportProviderUnavailable
-    , requestAccountProviderSwitch
-    , requestAutomaticProviderFallback
-    , requestModelTargetSwitch
-    , requestStartupProviderFallback
-    )
-import Agent.CLI.ProviderTransition
-    ( PendingTurn(..)
-    , ProviderTransition(..)
-    , TransitionCause(..)
-    , TurnResult(..)
-    , applyProviderTransition
-    )
-import Agent.CLI.SessionState (SessionState(..), newSessionState)
-import Agent.CLI.Render
-    ( RenderConfig(..)
-    , clearThinking
-    , putTextLn
-    , renderEvent
-    , renderPrintedText
-    , resetRenderPrintedText
-    )
-import Agent.CLI.Session
-import Agent.CLI.Session.Attachments
-    ( putImagePreview
-    , queueAttachedImages
-    , queueClipboardImages
-    )
-import Agent.CLI.Session.Choices
-    ( accountUsageText
-    , atMay
-    , effortChoice
-    , modelChoice
-    , showAccountUsage
-    )
-import Agent.CLI.Session.History
-    ( detectGitBranch
-    , foldSessionItems
-    , hydrateUiHistory
-    , LiveConversation(..)
-    , readLiveAttachments
-    , readLiveTranscript
-    , modifyLiveAttachments
-    , writeLiveTranscript
-    )
-import Agent.CLI.Session.Interaction
-    ( buildPromptState
-    , runBtwQuestion
-    , setSessionEffort
-    )
-import Agent.CLI.Session.Lifecycle (SessionContinuation(..))
-import qualified Agent.CLI.Session.Lifecycle as SessionLifecycle
-import qualified Agent.CLI.Session.Runner as SessionRunner
-import Agent.CLI.Session.Selection
-    ( currentSessionId
-    , handleConversationSearch
-    , handleResume
-    , loadPrompt
-    , pickAgentChoice
-    , reservedSessionId
-    )
-import Agent.CLI.SessionAdmin
-    ( managedPostgresConfigForHome
-    , runImportSession
-    , runListSessions
-    , runShowSession
-    , runStorageAdmin
-    , runWaitSession
-    )
-import Agent.CLI.SessionEnv (SessionEnv(..))
-import Agent.CLI.SessionLock
-    ( SessionLock
-    , acquireSessionLock
-    , releaseSessionLock
-    , sessionLockFilePath
-    , sessionLockPath
-    )
-import Agent.CLI.Skills
-    ( formatSkillsListing
-    , skillInvocationCommand
-    )
-import Agent.CLI.Status
-    ( applyReplMode
-    , cycleReplInteraction
-    , formatReplStatusLine
-    , formatTokenUsage
-    )
-import Agent.CLI.StartupContext (loadAgentsContext)
-import Agent.CLI.Startup.Format
-    ( formatRepositoryPath
-    , formatStartupDuration
-    , formatStartupTimings
-    )
-import Agent.CLI.Startup.Auth
-    ( learnAboutUserOnboardingPrompt
-    , loadStartupAuth
-    , markStartupStage
-    , recordStartupTiming
-    , setStartupNotice
-    , startupDie
-    )
-import Agent.CLI.Subagents.Runtime
-    ( SubagentRuntime(..)
-    , flushAllSubagentSnapshots
-    , freshOpenAiBackend
-    , persistAndEvictSubagentSessionWithStatus
-    , prepareCollaborationSpawn
-    , restoreAgentFromDisk
-    , runCodexSubagent
-    , runHttpSubagent
-    )
-import Agent.CLI.Style
-    ( beginBackground
-    , cliWindowTitle
-    , endBackground
-    , glyphOk
-    , glyphSession
-    , glyphWarn
-    , roleError
-    , roleMuted
-    , rolePrompt
-    , roleSuccess
-    , roleWarn
-    , setCliWindowTitle
-    , userBackground
-    )
-import Agent.CLI.Terminal
-    ( TerminalCapabilities(..)
-    , copyTerminalClipboard
-    , detectTerminalCapabilities
-    , emitTerminalSequence
-    , formatTerminalCapabilities
-    , osc133PromptEnd
-    , osc133PromptStart
-    , reportTerminalCwd
-    , resolveColor
-    , withSynchronizedOutput
-    )
-import Agent.CLI.Tools (schemasFromAppTools)
+    ( databaseToolsEnvForStore, deriveDatabaseScopes )
 import Agent.CLI.Dialects
-    ( CodingTools(..)
-    , codingToolsForWithTypes
-    , filterBashTools
-    , filterGhciTools
-    )
+    ( CodingTools(..),
+      codingToolsForWithTypes,
+      filterBashTools,
+      filterGhciTools )
+import Agent.CLI.Error ( formatApiErrorAt, formatException )
+import Agent.CLI.GatewayBridge ( managedGatewayTools )
+import Agent.CLI.Input ()
+import Agent.CLI.Interrupt
+    ( CtrlCDecision(..),
+      catchUserInterrupt,
+      newInterruptState,
+      noteFullscreenCtrlC,
+      withCtrlCHandler )
+import Agent.CLI.LearnedSkills ( learnedSkillTools )
+import Agent.CLI.LearnedSkills.Store
+    ( learnedSkillToolsEnvForStore )
+import Agent.CLI.Login ( runLoginManager )
+import Agent.CLI.Lsp
+    ( LspStartup(..), closeLspRuntime, lspRuntimeTool, newLspRuntime )
+import Agent.CLI.ManagedTurn ( ManagedTurnRequest(..) )
+import Agent.CLI.McpManager ()
+import Agent.CLI.McpStatus
+    ( formatMcpModelNotice,
+      formatMcpModelNoticeFor,
+      formatMcpProgress,
+      summarizeMcpStatuses )
+import Agent.CLI.ModelConfig
+    ( ConnectionKind(..),
+      ModelConnection(..),
+      ResponsesConnection(..),
+      builtinConnectionId,
+      catalogConnection,
+      loadModelCatalogAt )
+import Agent.CLI.Models
+    ( defaultModelFor,
+      rawModelOption,
+      resolveConfiguredModel,
+      resolvePersistedDialect,
+      ModelOption(modelTarget),
+      ModelTarget(targetProvider, ModelTarget, targetModelId,
+                  targetDialect, targetWireModelId, targetConnectionId) )
+import Agent.CLI.Options
+    ( defaultEffortFor,
+      isOneShot,
+      parseArgs,
+      resolveApprovalPolicy,
+      usage,
+      ApprovalPolicy(..),
+      CliOptions(optMotionMode, optManagedDenyMutations, optNoYolo,
+                 optYolo, optMaxConcurrentAgents, optCompactThreshold,
+                 optShowRawReasoning, optProvider, optModel, optWorktree, optEffort,
+                 optPrompt, optPromptFile, optManagedTurnFile, optSaveSession,
+                 optScreenMode, optGhci, optBash, optResume, optCwd),
+      Command(RunAgent, ShowHelp, ShowVersion, Login, ListSessions,
+              ShowSession, WaitSession, ImportSession, Storage),
+      ScreenMode(ScreenMinimal) )
+import Agent.CLI.PendingInputs ( withPendingInputs )
+import Agent.CLI.Plan ( cliPlanHooks )
+import Agent.CLI.Progress
+    ( osc9ProgressIndeterminate, osc9ProgressRemove, wrapOscForTmux )
+import Agent.CLI.Project
+    ( ProjectAccount(..),
+      ProjectModel(..),
+      ProjectSettings(..),
+      loadProjectSettings,
+      projectAccountFor,
+      projectModelProvider,
+      resolveProjectRoot,
+      saveProjectModel )
+import Agent.CLI.Prompt
+    ( subscriptionSubagentModelGuidance, systemPromptForTools )
+import Agent.CLI.PromptHooks
+    ( fullscreenAwarePlanHooks, fullscreenAwareSecretHooks )
+import Agent.CLI.Provider.OpenAI
+    ( OpenAiPersistentConnection(..), lockedOpenAiSession )
+import Agent.CLI.Provider.Switch
+    ( accountSwitchTarget,
+      chooseStartupProviderTransition,
+      continueAutomaticFallback,
+      loadSelectedAccountAuth,
+      prepareTransitionBackend,
+      reportProviderUnavailable )
+import Agent.CLI.ProviderAvailability ( probeLoadedAvailability )
+import Agent.CLI.ProviderFallback
+    ( allowsAutomaticBillingFallback, isProviderUnavailable )
+import Agent.CLI.ProviderTransition
+    ( applyProviderTransition,
+      ProviderTransition(transitionCause, transitionUnavailableProviders,
+                         transitionPendingTurn, transitionTarget,
+                         transitionAccountSelectionId, transitionAccountId,
+                         transitionAutomaticBilling),
+      TransitionCause(AutomaticFallback) )
+import Agent.CLI.Recap ()
+import Agent.CLI.Render ( putTextLn )
+import Agent.CLI.ReplMode ()
+import Agent.CLI.Request ( requestParams )
+import Agent.CLI.Runtime.Persistence ( preparePersistence )
+import Agent.CLI.Runtime.Recap
+    ( runSessionRecap, runSessionTurnSummary )
+import Agent.CLI.Runtime.Repl
+    ( finishTurn,
+      preparePromptSkillInputs,
+      repl,
+      replWithDraft,
+      runPendingTurn )
+import Agent.CLI.Runtime.Types
+    ( DevResult(..), PreparedAgent(..), RunResult(..) )
+import Agent.CLI.Secret ( promptSecretLine )
+import Agent.CLI.Session
+    ( addSessionUsage,
+      allocateSessionTemp,
+      cleanupPendingPersistence,
+      ensureSession,
+      loadSession,
+      persistenceTempDir,
+      removeSessionTemp,
+      resumeHint,
+      sessionDirForId,
+      sessionLegacySubagentTarget,
+      sessionTitleFromPrompt,
+      sessionUsageFromTurns,
+      sessionsRoot,
+      Persistence(..),
+      PersistenceState(PersistenceActive, PersistencePending),
+      SessionHandle(sessionMeta, sessionDir),
+      SessionMeta(metaCwd, metaTransportModel, metaConnection, metaModel,
+                  metaDialect, metaEffort, metaLastResponseId, metaTitle, metaId,
+                  metaProvider),
+      SessionTurn )
+import Agent.CLI.Session.Attachments ()
+import Agent.CLI.Session.Choices ()
+import Agent.CLI.Session.History
+    ( detectGitBranch,
+      foldSessionItems,
+      hydrateUiHistory,
+      readLiveTranscript,
+      writeLiveTranscript,
+      LiveConversation(liveTranscript, livePreviousResponseId) )
+import Agent.CLI.Session.Interaction ( buildPromptState )
+import Agent.CLI.Session.Lifecycle ()
+import Agent.CLI.Session.Runtime.Types
+    ( SessionBackend(..),
+      SessionRequest(..),
+      StartupCancelled(..),
+      StartupFailure(..),
+      StartupRuntime(..) )
+import Agent.CLI.Session.Selection
+    ( currentSessionId, loadPrompt, reservedSessionId )
+import Agent.CLI.SessionAdmin
+    ( managedPostgresConfigForHome,
+      runImportSession,
+      runListSessions,
+      runShowSession,
+      runStorageAdmin,
+      runWaitSession )
+import Agent.CLI.SessionEnv ()
+import Agent.CLI.SessionLock
+    ( SessionLock,
+      acquireSessionLock,
+      releaseSessionLock,
+      sessionLockFilePath,
+      sessionLockPath )
+import Agent.CLI.SessionState ( SessionState(..), newSessionState )
+import Agent.CLI.SessionTitle ()
+import Agent.CLI.Skills ()
+import Agent.CLI.Startup.Auth
+    ( learnAboutUserOnboardingPrompt,
+      loadStartupAuth,
+      markStartupStage,
+      recordStartupTiming,
+      setStartupNotice,
+      startupDie )
+import Agent.CLI.Startup.Format
+    ( formatRepositoryPath,
+      formatStartupDuration,
+      formatStartupTimings )
+import Agent.CLI.StartupContext ( loadAgentsContext )
+import Agent.CLI.Status
+    ( applyReplMode,
+      cycleReplInteraction,
+      formatReplStatusLine,
+      formatTokenUsage )
+import Agent.CLI.Style
+    ( cliWindowTitle,
+      glyphSession,
+      glyphWarn,
+      roleMuted,
+      roleWarn,
+      setCliWindowTitle )
+import Agent.CLI.Subagents.Runtime
+    ( SubagentRuntime(..),
+      flushAllSubagentSnapshots,
+      freshOpenAiBackend,
+      persistAndEvictSubagentSessionWithStatus,
+      prepareCollaborationSpawn,
+      restoreAgentFromDisk,
+      runCodexSubagent,
+      runHttpSubagent )
 import Agent.CLI.TUI.App
-    ( FullscreenInputBuffer
-    , FullscreenRuntime
-    , emitUiEvent
-    , newFullscreenInputBuffer
-    , newFullscreenRuntime
-    , queuedFullscreenInputDisplays
-    , readFullscreenLineOrWithCatalog
-    , readFullscreenLineWithCatalog
-    , requestFullscreenChoiceWithBody
-    , runFullscreen
-    , setFullscreenSessionActions
-    , setFullscreenImagePreviews
-    , setFullscreenWindowTitle
-    , withFullscreenSuspended
-    )
-import Agent.TUI.Model
-    ( UiEvent(..)
-    , UiState(..)
-    , infoNotice
-    , progressNotice
-    , warningNotice
-    , reduceUi
-    )
-import Agent.TUI.Motion (nativeProgressAnimationEnabled)
-import Agent.CLI.Turn (runOneTurn)
-import Agent.CLI.Usage
-    ( formatGrokLimitStatus
-    , formatOpenAiLimitStatus
-    , formatOpenRouterLimitStatus
-    )
+    ( FullscreenInputBuffer,
+      FullscreenRuntime,
+      emitUiEvent,
+      newFullscreenInputBuffer,
+      newFullscreenRuntime,
+      queuedFullscreenInputDisplays,
+      requestFullscreenChoiceWithBody,
+      runFullscreen,
+      setFullscreenSessionActions,
+      setFullscreenWindowTitle,
+      withFullscreenSuspended )
+import Agent.CLI.Terminal
+    ( copyTerminalClipboard,
+      detectTerminalCapabilities,
+      reportTerminalCwd,
+      resolveColor,
+      TerminalCapabilities(terminalNativeProgress) )
+import Agent.CLI.Tools ( schemasFromAppTools )
+import Agent.CLI.Turn ()
+import Agent.CLI.Usage ()
 import Agent.CLI.WebFetch
-    ( closeWebFetchRuntime
-    , newWebFetchRuntime
-    , webFetchRuntimeTool
-    )
+    ( closeWebFetchRuntime, newWebFetchRuntime, webFetchRuntimeTool )
 import Agent.CLI.Worktree
-    ( createWorktree
-    , isUnderWorktreeRoot
-    , removeWorktree
-    , worktreeRoot
-    )
-import Agent.Cancel (requestCancel)
+    ( createWorktree,
+      isUnderWorktreeRoot,
+      removeWorktree,
+      worktreeRoot )
+import Agent.Cancel ( requestCancel )
 import Agent.Claude
-    ( ClaudeCodeAuth(..)
-    , ClaudeCodeOptions(..)
-    , ClaudeCodePermission(..)
-    , claudeCodeOneShotBackend
-    , defaultClaudeCodeOptions
-    , loadClaudeCodeAuth
-    , withClaudeCodeBackend
-    )
+    ( ClaudeCodeAuth(..),
+      ClaudeCodeOptions(..),
+      ClaudeCodePermission(..),
+      claudeCodeOneShotBackend,
+      defaultClaudeCodeOptions,
+      loadClaudeCodeAuth,
+      withClaudeCodeBackend )
+import Agent.Dialect ( dialectForId, DialectId(GrokBuildDialect) )
+import Agent.Error ( ApiError(..) )
+import Agent.GrokBuild.Dialect.Goal ()
+import Agent.GrokBuild.Dialect.Runtime ()
+import Agent.GrokBuild.Dialect.Workflow ()
 import Agent.Loop
-import qualified Agent.MCP as MCP
-import Agent.Error
-    ( ApiError(..) )
-import Agent.Dialect
-    ( DialectId(..)
-    , dialectForId
-    , dialectId
-    , dialectSlug
-    )
-import Agent.Skills
-    ( Skill(..)
-    , SkillCatalog(..)
-    , SkillInvocation(..)
-    , formatSkillActivation
-    , resolveSkillInvocation
-    , resolveSkillMentions
-    )
-import Agent.OpenAI.Compaction
-    ( clearSessionUserText
-    , compactSessionUserText
-    , newSessionUserText
-    )
-import qualified Agent.OpenAI.Auth as OpenAI
-import Agent.Responses.Types
-import Agent.Responses.GenericBackend (genericResponsesBackendWith)
-import Agent.Responses.GenericClient (GenericClientOptions(..))
-import qualified Agent.Responses.GenericClient as GenericResponses
-import Agent.OpenAI.Usage (fetchUsage)
+    ( Backend(submitTurn, Backend),
+      TurnInput(UserMessage, AgentMessage),
+      addTokenUsage,
+      emptyTokenUsage,
+      LoopError(LoopNoResponseId) )
+import Agent.OpenAI.Compaction ()
+import Agent.OpenAI.Usage ()
 import Agent.OpenAI.WebSocketClient
-    ( CodexAuthFailed(..)
-    , closeCodexConn
-    , codexConnTurnState
-    , resetCodexTurnState
-    , withCodexWsCredential
-    , withCodexWsWithProvider
-    )
+    ( CodexAuthFailed(..),
+      closeCodexConn,
+      codexConnTurnState,
+      resetCodexTurnState,
+      withCodexWsCredential,
+      withCodexWsWithProvider )
+import Agent.OpenRouter.LoopBackend ( openRouterBackend )
+import Agent.OsPath ( toText, unsafeToFilePath )
 import Agent.Provider
-    ( BillingMode(..)
-    , Credential(..)
-    , FailedCredential(..)
-    , Provider(..)
-    , TokenProvider
-    , getNextToken
-    , providerSlug
-    , tokenProvider
-    , tokenProviderBillingMode
-    )
-import qualified Agent.Provider as Provider
+    ( BillingMode(..),
+      Credential(..),
+      FailedCredential(..),
+      Provider(..),
+      TokenProvider,
+      getNextToken,
+      providerSlug,
+      tokenProvider,
+      tokenProviderBillingMode )
+import Agent.Responses.GenericBackend
+    ( genericResponsesBackendWith )
+import Agent.Responses.GenericClient ( GenericClientOptions(..) )
+import Agent.Responses.Types
+    ( ResponseItem, ResponseCreateParams(model) )
+import Agent.Skills ( SkillCatalog(SkillCatalog) )
+import Agent.Store.Postgres
+    ( Store, closeStore, openStore, trustedPool )
+import Agent.Store.Types ( renderStoreError )
 import Agent.Subagents
-    ( RootTurnId
-    , SubagentConfig(..)
-    , closeSubagentRegistry
-    , defaultMaxConcurrent
-    , defaultSubagentConfig
-    , formatCompletionNotice
-    , interruptActiveSubagents
-    , newSubagentRegistry
-    , setSubagentOnComplete
-    , setSubagentOnSettled
-    , setSubagentRunner
-    )
-import Agent.GrokBuild.Dialect.Goal
-    ( activateGoal
-    , clearGoal
-    , formatGoalSnapshot
-    , pauseGoal
-    , readGoal
-    , resumeGoal
-    )
-import Agent.GrokBuild.Dialect.Runtime (GrokRuntimeControl(..))
-import Agent.GrokBuild.Dialect.Workflow
-    ( formatWorkflowRuns
-    , workflowRunSnapshots
-    )
-import Agent.Subagents.TaskPath (taskPathRoot)
-import Agent.ToolDispatch (canonicalToolName)
+    ( RootTurnId,
+      SubagentConfig(..),
+      closeSubagentRegistry,
+      defaultMaxConcurrent,
+      defaultSubagentConfig,
+      formatCompletionNotice,
+      interruptActiveSubagents,
+      newSubagentRegistry,
+      setSubagentOnComplete,
+      setSubagentOnSettled,
+      setSubagentRunner )
+import Agent.Subagents.TaskPath ( taskPathRoot )
+import Agent.TUI.Model
+    ( progressNotice,
+      reduceUi,
+      warningNotice,
+      UiEvent(UiSystemMessage, UiSetRepository, UiSetNotice),
+      UiState(uiQueuedInputs) )
+import Agent.TUI.Motion ( nativeProgressAnimationEnabled )
+import Agent.ToolDispatch ( canonicalToolName )
 import Agent.Tools.MultiAgents
-    ( MultiAgentContext(..)
-    , SubagentWorktree(..)
-    )
+    ( MultiAgentContext(..), SubagentWorktree(..) )
 import Agent.Tools.PlanMode
-    ( PlanDecision(..)
-    , PlanModeEnv(..)
-    , PlanModeHooks(..)
-    , PlanModeState(..)
-    , activatePlanMode
-    , planFilePath
-    )
+    ( PlanModeEnv(planSessionDir),
+      PlanModeHooks(planAskQuestion, PlanModeHooks, planConfirmEnter,
+                    planDecideExit),
+      PlanDecision(PlanCancel) )
 import Agent.Tools.Secret
-    ( SecretPrompt(..)
-    , SecretPromptHooks(..)
-    )
+    ( SecretPrompt(..), SecretPromptHooks(..) )
 import Agent.Tools.Types
-    ( AppTool(..)
-    , ToolEnv(..)
-    , defaultToolEnv
-    , setToolSessionTmp
-    )
-import Agent.OpenRouter.LoopBackend (openRouterBackend)
-import qualified Agent.OpenRouter as OpenRouter
-import qualified Agent.OpenRouter.Usage as OpenRouterUsage
-import Agent.OsPath (toText, unsafeToFilePath)
-import Agent.XAI.LoopBackend (xaiBackend)
-import qualified Agent.XAI.Options as XAI
-import qualified Agent.XAI.Usage as XAIUsage
-import Control.Applicative ((<|>))
+    ( AppTool(..), ToolEnv(..), defaultToolEnv, setToolSessionTmp )
+import Agent.XAI.LoopBackend ( xaiBackend )
+import Control.Applicative ( (<|>) )
 import Control.Concurrent.Async
-    ( cancel
-    , concurrently
-    , concurrently_
-    , link
-    , waitCatch
-    , waitEitherCatch
-    , waitSTM
-    , withAsync
-    )
-import Control.Concurrent.Chan (Chan, newChan, readChan, writeChan)
+    ( cancel,
+      concurrently,
+      concurrently_,
+      link,
+      waitCatch,
+      waitEitherCatch,
+      waitSTM,
+      withAsync )
+import Control.Concurrent.Chan
+    ( Chan, newChan, readChan, writeChan )
 import Control.Concurrent.MVar
-    ( MVar
-    , modifyMVar_
-    , newEmptyMVar
-    , newMVar
-    , putMVar
-    , readMVar
-    , takeMVar
-    , tryPutMVar
-    , withMVar
-    )
-import Control.Concurrent.STM (retry)
-import Control.Exception (AsyncException(UserInterrupt))
+    ( MVar,
+      modifyMVar_,
+      newEmptyMVar,
+      newMVar,
+      putMVar,
+      readMVar,
+      takeMVar,
+      tryPutMVar,
+      withMVar )
+import Control.Concurrent.STM ( retry )
+import Control.Exception ()
 import Control.Exception.Safe
-    ( SomeException
-    , catchAny
-    , finally
-    , mask
-    , mask_
-    , onException
-    , throwIO
-    , try
-    )
-import Control.Monad (forM_, unless, void, when)
-import qualified Data.ByteString as BS
+    ( SomeException,
+      catchAny,
+      finally,
+      mask,
+      mask_,
+      onException,
+      throwIO,
+      try )
+import Control.Monad ( forM_, unless, void, when )
 import Data.IORef
-import Data.List (findIndex)
-import qualified Data.Map.Strict as Map
-import Data.Maybe (fromMaybe, isJust, isNothing, listToMaybe)
-import Data.Text (Text)
-import qualified Data.Text as Text
-import qualified Data.Text.IO as Text
-import qualified Data.Set as Set
-import Data.Time.Clock
-    ( getCurrentTime
-    , utctDay
-    )
+    ( IORef,
+      modifyIORef',
+      atomicModifyIORef',
+      newIORef,
+      readIORef,
+      writeIORef )
+import Data.List ()
+import Data.Maybe ( isNothing, fromMaybe, isJust )
+import Data.Text ( Text )
+import Data.Time.Clock ( getCurrentTime, utctDay )
+import System.Console.ANSI ()
+import System.Console.ANSI.Codes ()
 import System.Directory.OsPath
-    ( doesDirectoryExist
-    , getCurrentDirectory
-    , getHomeDirectory
-    , makeAbsolute
-    , setCurrentDirectory
-    )
-import System.Environment (getArgs, getProgName, lookupEnv)
-import System.OsPath (OsPath, decodeFS, unsafeEncodeUtf, (</>), takeDirectory, takeFileName)
-import System.Console.ANSI (getTerminalSize)
-import System.Console.ANSI.Codes (clearFromCursorToLineEndCode)
-import System.Exit (die)
+    ( doesDirectoryExist,
+      getCurrentDirectory,
+      getHomeDirectory,
+      makeAbsolute,
+      setCurrentDirectory )
+import System.Environment ( getArgs, getProgName, lookupEnv )
+import System.Exit ( die )
 import System.IO
-    ( Handle
-    , IOMode(AppendMode)
-    , hFlush
-    , hIsTerminalDevice
-    , stderr
-    , stdin
-    , stdout
-    , withFile
-    )
-import System.Posix.Files (setFileMode)
+    ( Handle,
+      IOMode(AppendMode),
+      hFlush,
+      hIsTerminalDevice,
+      stderr,
+      stdin,
+      stdout,
+      withFile )
+import System.OsPath
+    ( OsPath,
+      decodeFS,
+      unsafeEncodeUtf,
+      (</>),
+      takeDirectory,
+      takeFileName )
+import System.Posix.Files ( setFileMode )
+import qualified Data.ByteString as BS ()
+import qualified Agent.Responses.GenericClient as GenericResponses
+    ( GenericClientOptions(model),
+      createResponseWith,
+      createResponseWithEvents )
+import qualified Agent.MCP as MCP
+    ( acquireMcpFleetProgressive,
+      acquireMcpFleetWithProgress,
+      closeMcpSupervisor,
+      mcpFleetGrokMetaTools,
+      mcpFleetMetaTools,
+      mcpFleetTools,
+      newMcpSupervisor,
+      releaseMcpFleetLease,
+      McpFleet(mcpFleetRegistrations, mcpFleetWarnings),
+      McpFleetLease(mcpLeaseFleet),
+      McpServerConfig(mcpServerRequestTimeoutSeconds, McpServerConfig,
+                      mcpServerName, mcpServerCommand, mcpServerArgs, mcpServerCwd,
+                      mcpServerEnv, mcpServerStartupTimeoutSeconds),
+      McpSupervisor,
+      McpToolRegistration(mcpRegistrationTool, mcpRegistrationServer) )
+import qualified Data.Map.Strict as Map
+    ( toAscList, fromList, empty, lookup )
+import qualified Agent.OpenAI.Auth as OpenAI
+    ( discoverAccounts, getAccessTokenForAccount )
+import qualified Agent.OpenRouter as OpenRouter
+    ( clientOptionsFromEnv, mapModel )
+import qualified Agent.OpenRouter.Usage as OpenRouterUsage ()
+import qualified Agent.Provider as Provider ( tokenProvider )
+import qualified Agent.CLI.Session.Lifecycle as SessionLifecycle ()
+import qualified Agent.CLI.Session.Runner as SessionRunner
+    ( runSession, SessionRunnerContinuation(..) )
+import qualified Data.Set as Set ()
+import qualified Data.Text as Text
+    ( intercalate, null, pack, unpack )
+import qualified Data.Text.IO as Text ( hPutStr )
+import qualified Agent.XAI.Options as XAI ( clientOptionsFromEnv )
+import qualified Agent.XAI.Usage as XAIUsage ()
 
 data ActiveHttpAuth = ActiveHttpAuth
     { activeHttpGeneration :: !Int
@@ -3190,1683 +3066,19 @@ runSession
     -> IO RunResult
 runSession = SessionRunner.runSession sessionRunnerContinuation
 
-sessionContinuation :: SessionContinuation
-sessionContinuation =
-    SessionContinuation
-        { resumeSession = repl
-        , resumeSessionWithDraft = replWithDraft
+restartSessionOptions :: CliOptions -> Text -> CliOptions
+restartSessionOptions options sessionId =
+    options
+        { optProvider = Nothing
+        , optModel = Nothing
+        , optCwd = Nothing
+        , optWorktree = False
+        , optEffort = Nothing
+        , optPrompt = Nothing
+        , optPromptFile = Nothing
+        , optManagedTurnFile = Nothing
+        , optResume = Just sessionId
         }
-
-runPendingTurn
-    :: PendingTurnPresentation
-    -> SessionEnv
-    -> PendingTurn
-    -> IO RunResult
-runPendingTurn = SessionLifecycle.runPendingTurn sessionContinuation
-
-finishTurn
-    :: SessionEnv
-    -> Bool
-    -> TurnResult
-    -> IO RunResult
-finishTurn = SessionLifecycle.finishTurn sessionContinuation
-
-repl :: SessionEnv -> IO RunResult
-repl env = replWithDraft env ""
-
-replWithDraft :: SessionEnv -> Text -> IO RunResult
-replWithDraft env@SessionEnv
-    { sessionCompact = compactRunner
-    , sessionRender = render
-    , sessionConversation = conversationRef
-    , sessionProvider = provider
-    , sessionConnection = connectionId
-    , sessionModelCatalog = catalog
-    , sessionDialect = dialect
-    , sessionStartupUnavailable = startupUnavailableRef
-    , sessionParams = paramsRef
-    , sessionPolicy = policyRef
-    , sessionPersist = persist
-    , sessionDatabasePool = databasePool
-    , sessionPlanMode = planMode
-    , sessionProjectRoot = projectRoot
-    , sessionCwd = cwd
-    , sessionTokenProvider = tokenProvider
-    , sessionOpenAiPool = openAiPool
-    , sessionSkills = skillsRef
-    , sessionSkillInvocations = skillInvocationsRef
-    , sessionRefreshSkills = refreshSkills
-    , sessionActiveToolNames = readActiveToolNames
-    , sessionGrokRuntime = grokRuntime
-    , sessionDraft = draftRef
-    , sessionPreviewId = previewIdRef
-    , sessionInterrupt = interrupt
-    , sessionStoreRoot = storeRoot
-    , sessionUsage = usageRef
-    , sessionAccount = accountRef
-    , sessionAccountId = accountIdRef
-    , sessionAccountSelectionId = selectionRef
-    , sessionSelectAccount = selectAccount
-    , sessionLastAssistant = lastAssistantRef
-    , sessionTerminal = terminal
-    , sessionFullscreen = fullscreen
-    , sessionSetWindowTitle = setWindowTitle
-    , sessionAgentViewport = agentViewport
-    , sessionConcurrentLimit = _
-    , sessionSetConcurrentLimit = _
-    , sessionReset = sessionReset
-    } draft = do
-    writeIORef draftRef draft
-    refreshSkills False
-    skillInvocations <- readIORef skillInvocationsRef
-    let skillCommands =
-            map skillInvocationCommand
-                (filter (.invocationSkill.skillUserInvocable) skillInvocations)
-    activeToolNames <- readActiveToolNames
-    let slashCatalog =
-            mkSlashCatalog
-                (dialectId dialect)
-                activeToolNames
-                skillCommands
-                (catalogModelIds catalog)
-    stdoutColor <- resolveColor stdout
-    planState <- readIORef planMode.planStateRef
-    let planActive = planState == PlanActive
-        planPending = planState == PlanPending
-    params <- readIORef paramsRef
-    policy <- readIORef policyRef
-    pendingAttachments <- readLiveAttachments conversationRef
-    let idleMode = replModeFromState planState policy
-    usage <- readIORef usageRef
-    account <- readIORef accountRef
-    mlineResult <- case fullscreen of
-        Just runtime -> do
-            setFullscreenImagePreviews runtime pendingAttachments
-            let promptState =
-                    buildPromptState
-                        params
-                        planState
-                        policy
-                        account
-                        (isJust selectAccount)
-                        usage
-                        (length pendingAttachments)
-                readPrompt =
-                    readIORef startupUnavailableRef >>= \case
-                        Nothing ->
-                            Right
-                                <$> readFullscreenLineWithCatalog
-                                    runtime
-                                    slashCatalog
-                                    promptState
-                                    draft
-                        Just unavailable ->
-                            readFullscreenLineOrWithCatalog
-                                runtime
-                                slashCatalog
-                                promptState
-                                draft
-                                unavailable
-            withAsync (refreshAccountLimit runtime) \_ ->
-                readPrompt
-        Nothing -> Right <$> withMVar render.renderLock \_ -> do
-            -- The inline editor redraws its ANSI frame with several writes.
-            -- Keep the renderer out for the complete prompt lifetime so a
-            -- late tool event cannot be spliced into the composer row.
-            when terminal.terminalSemanticPrompts $
-                emitTerminalSequence terminal stdout osc133PromptStart
-            termCols <- fmap snd <$> getTerminalSize
-            case agentViewport of
-                Nothing -> pure ()
-                Just viewport -> do
-                    entries <- viewport.viewportEntries
-                    selected <- readIORef viewport.viewportSelected
-                    let panel =
-                            renderAgentViewportPanelFor
-                                stdoutColor
-                                (fromMaybe 100 termCols)
-                                selected
-                                entries
-                    when (not (Text.null panel)) (Text.putStrLn panel)
-            -- Status sits on the line above λ in minimal mode.
-            withSynchronizedOutput terminal stdout do
-                Text.putStrLn $ formatReplStatusLine stdoutColor termCols
-                    (currentModel params)
-                    (currentEffort params)
-                    idleMode
-                    account
-                    usage
-                hFlush stdout
-            let modeTag
-                    | planActive = roleWarn stdoutColor "[plan] "
-                    | planPending = roleMuted stdoutColor "[plan…] "
-                    | idleMode == ReplModeAlwaysApprove =
-                        roleSuccess stdoutColor "[yolo] "
-                    | otherwise = ""
-                chromePrompt =
-                    beginBackground stdoutColor userBackground
-                        <> modeTag
-                        <> if null pendingAttachments
-                            then ""
-                            else roleMuted stdoutColor
-                                ("[📎 " <> Text.pack (show (length pendingAttachments)) <> "] ")
-                        <> rolePrompt stdoutColor "λ "
-                        <> if stdoutColor
-                            then Text.pack clearFromCursorToLineEndCode
-                            else mempty
-            result <- readReplLineWithCatalog
-                slashCatalog
-                interrupt chromePrompt draft
-            when terminal.terminalSemanticPrompts $
-                emitTerminalSequence terminal stdout osc133PromptEnd
-            Text.putStr (endBackground stdoutColor)
-            hFlush stdout
-            pure result
-    case mlineResult of
-        Left apiError -> do
-            -- The startup check is one-shot. If no fallback account is usable,
-            -- leave request-time error handling in charge of later submits.
-            writeIORef startupUnavailableRef Nothing
-            requestStartupProviderFallback env apiError >>= \case
-                Just providerTransition ->
-                    pure (RunSwitchProvider providerTransition)
-                Nothing -> do
-                    reportProviderUnavailable fullscreen apiError
-                    replWithDraft env ""
-        Right mline -> do
-            -- Any user action wins the startup race. In particular, a prompt
-            -- already submitted while the preflight was running proceeds on
-            -- the selected provider and leaves request-time fallback in charge.
-            writeIORef startupUnavailableRef Nothing
-            handleReplLine
-                slashCatalog
-                skillInvocations
-                stdoutColor
-                planState
-                policy
-                mline
-  where
-    refreshAccountLimit runtime =
-        case (provider, tokenProvider) of
-            (XAIProvider, Just tokens)
-                | tokenProviderBillingMode tokens == SubscriptionBilled ->
-                    refreshWith
-                        tokens
-                        XAIUsage.fetchGrokUsage
-                        formatGrokLimitStatus
-            (OpenAIProvider, Just tokens)
-                | tokenProviderBillingMode tokens == SubscriptionBilled ->
-                    getNextToken tokens Nothing >>= \case
-                        Left _ -> pure ()
-                        Right credential
-                            | Text.null (Text.strip credential.accountId) ->
-                                pure ()
-                            | otherwise ->
-                                fetchUsage
-                                    credential.accessToken
-                                    credential.accountId >>= \case
-                                        Left _ -> pure ()
-                                        Right snapshot ->
-                                            publish
-                                                (formatOpenAiLimitStatus snapshot)
-            (OpenRouterProvider, Just tokens) ->
-                getNextToken tokens Nothing >>= \case
-                    Left _ -> pure ()
-                    Right credential ->
-                        OpenRouterUsage.fetchOpenRouterUsage
-                            credential.accessToken >>= \case
-                                Left _ -> pure ()
-                                Right snapshot ->
-                                    publish
-                                        (formatOpenRouterLimitStatus snapshot)
-            _ -> pure ()
-      where
-        refreshWith tokens fetch formatStatus =
-            getNextToken tokens Nothing >>= \case
-                Left _ -> pure ()
-                Right credential ->
-                    fetch credential >>= \case
-                        Left _ -> pure ()
-                        Right snapshot -> publish (formatStatus snapshot)
-        publish limitStatus =
-            forM_
-                limitStatus
-                (emitUiEvent runtime . UiSetPromptLimitStatus . Just)
-
-    handleReplLine
-            slashCatalog skillInvocations
-            stdoutColor planState policy = \case
-        ReplEof -> do
-            when (isNothing fullscreen) $
-                putStrLn ""
-            pure RunQuit
-        ReplQuitInterrupt ->
-            -- Confirmed double Ctrl-C: rethrow so withInterruptResume prints
-            -- the --resume hint and the process exits.
-            throwIO UserInterrupt
-        ReplCycleMode keptDraft
-            | provider == ClaudeCodeProvider -> do
-                let message =
-                        "Claude Code permissions are fixed when the provider starts; restart with --yolo or --no-yolo to change them."
-                color <- resolveColor stderr
-                displayInfo message $
-                    putTextLn stderr (roleMuted color message)
-                continueWith keptDraft
-            | otherwise -> do
-                let next = cycleReplInteraction planState policy
-                applyReplMode planMode policyRef projectRoot next
-                case fullscreen of
-                    Just runtime ->
-                        emitUiEvent runtime $
-                            UiSetNotice $
-                                Just $
-                                    infoNotice
-                                        ("Switched to "
-                                            <> replModeLabel next
-                                            <> " mode.")
-                    Nothing -> do
-                        -- Minimal editor advanced a line; replace its old chrome.
-                        putStr "\ESC[2A\r\ESC[J"
-                        hFlush stdout
-                continueWith keptDraft
-        ReplClipboardPaste keptDraft clipboardPasteImages -> do
-            case clipboardPasteImages of
-                Just images@(_:_) -> do
-                    message <- queueAttachedImages
-                        conversationRef
-                        previewIdRef
-                        stdoutColor
-                        (isNothing fullscreen)
-                        images
-                    syncFullscreenImagePreviews
-                    fullscreenEvent (UiSetNotice Nothing)
-                    displayInfo message $
-                        Text.putStrLn
-                            (roleMuted stdoutColor
-                                (glyphOk <> message))
-                _ ->
-                    queueClipboardImages
-                        conversationRef
-                        previewIdRef
-                        stdoutColor
-                        (isNothing fullscreen)
-                        >>= \case
-                            Left err ->
-                                displayError err do
-                                    errColor <- resolveColor stderr
-                                    Text.hPutStrLn stderr (roleError errColor err)
-                            Right message -> do
-                                syncFullscreenImagePreviews
-                                displayInfo message $
-                                    Text.putStrLn
-                                        (roleMuted stdoutColor
-                                            (glyphOk <> message))
-            continueWith keptDraft
-        ReplClipboardPasteOrText keptDraft pasted pastedDraft -> do
-            pastedImages <- loadImagesFromPastedText pasted
-            imagesResult <- case pastedImages of
-                Just images@(_:_) -> pure (Just images)
-                _ ->
-                    nonEmptyClipboardImages
-                        <$> readClipboardImagesImageFirst
-            case imagesResult of
-                Just images -> do
-                    message <- queueAttachedImages
-                        conversationRef
-                        previewIdRef
-                        stdoutColor
-                        (isNothing fullscreen)
-                        images
-                    syncFullscreenImagePreviews
-                    fullscreenEvent (UiSetNotice Nothing)
-                    displayInfo message $
-                        Text.putStrLn
-                            (roleMuted stdoutColor
-                                (glyphOk <> message))
-                    continueWith keptDraft
-                _ -> do
-                    fullscreenEvent (UiSetNotice Nothing)
-                    continueWith pastedDraft
-        ReplChooseModel keptDraft -> do
-            writeIORef draftRef keptDraft
-            chooseModel (continueWith keptDraft)
-        ReplChooseEffort keptDraft ->
-            chooseEffort (continueWith keptDraft)
-        ReplChooseAccount keptDraft -> do
-            writeIORef draftRef keptDraft
-            chooseAccount (continueWith keptDraft)
-        ReplPasted pasted ->
-            submitLine slashCatalog skillInvocations
-                continue stdoutColor True pasted
-        ReplText line ->
-            submitLine slashCatalog skillInvocations
-                continue stdoutColor False line
-    submitLine
-            slashCatalog skillInvocations
-            continue color pasted line = do
-        attachmentCount <- length <$> readLiveAttachments conversationRef
-        case submissionPromptText attachmentCount line of
-            Nothing -> continue
-            Just promptLine -> do
-                let stripped = Text.strip promptLine
-                when pasted do
-                    let chip = formatPasteChip stripped
-                    when (chip /= stripped && isNothing fullscreen) do
-                        Text.putStrLn (roleMuted color chip)
-                case parseReplLineWithCatalog slashCatalog promptLine of
-                    ReplQuit -> pure RunQuit
-                    ReplReload -> requestReload fullscreen persist
-                    ReplPrompt text -> do
-                        -- Native Cmd+V of a Finder image often pastes a path
-                        -- rather than bitmap bytes. Treat a prompt that is
-                        -- only image path(s) as an attach + in-terminal preview,
-                        -- matching Grok Build's paste chip.
-                        pastedImages <- loadImagesFromPastedText text
-                        case pastedImages of
-                            Just images@(_:_) -> do
-                                message <- queueAttachedImages
-                                    conversationRef
-                                    previewIdRef
-                                    color
-                                    (isNothing fullscreen)
-                                    images
-                                syncFullscreenImagePreviews
-                                displayInfo message $
-                                    Text.putStrLn
-                                        (roleMuted color
-                                            (glyphOk <> message))
-                                continue
-                            _ -> do
-                                pendingImages <- modifyLiveAttachments conversationRef \imgs -> ([], imgs)
-                                forM_ fullscreen \runtime ->
-                                    setFullscreenImagePreviews runtime []
-                                resetRenderPrintedText render
-                                let turnInputs =
-                                        if null pendingImages
-                                            then [UserMessage text]
-                                            else
-                                                [ UserMultimodal
-                                                    { userText = text
-                                                    , userImages = pendingImages
-                                                    }
-                                                ]
-                                preparePromptSkillInputs env text turnInputs >>= \case
-                                    Left err -> do
-                                        displayError err $
-                                            Text.hPutStrLn stderr
-                                                (roleError color err)
-                                        continue
-                                    Right skillInputs -> do
-                                        fullscreenEvent (UiUserSubmitted text)
-                                        result <- runOneTurn env text skillInputs
-                                        finishTurn env False result
-                    ReplExpandedPrompt original expanded ->
-                        submitExpandedTurn
-                            continue color original expanded
-                    ReplInvokeSkill invocationName arguments ->
-                        case resolveSkillInvocation
-                            skillInvocations invocationName of
-                            Left err -> do
-                                displayError err $
-                                    Text.hPutStrLn stderr
-                                        (roleError color err)
-                                continue
-                            Right invocation -> do
-                                pendingImages <-
-                                    modifyLiveAttachments conversationRef
-                                        \imgs -> ([], imgs)
-                                forM_ fullscreen \runtime ->
-                                    setFullscreenImagePreviews runtime []
-                                let userText =
-                                        if Text.null arguments
-                                            then "Use the "
-                                                <> invocation.invocationSkill.skillName
-                                                <> " skill."
-                                            else arguments
-                                    userInput =
-                                        if null pendingImages
-                                            then UserMessage userText
-                                            else UserMultimodal
-                                                { userText = userText
-                                                , userImages = pendingImages
-                                                }
-                                    skillInputs =
-                                        [ UserMessage
-                                            (formatSkillActivation
-                                                invocation arguments)
-                                        , userInput
-                                        ]
-                                resetRenderPrintedText render
-                                fullscreenEvent (UiUserSubmitted line)
-                                result <- runOneTurn env line skillInputs
-                                finishTurn env False result
-                    ReplSkills reloadFirst -> do
-                        when reloadFirst (refreshSkills True)
-                        current <- readIORef skillsRef
-                        invocations <- readIORef skillInvocationsRef
-                        let listing =
-                                formatSkillsListing color current invocations
-                        displayInfo (formatSkillsListing False current invocations) $
-                            Text.putStrLn listing
-                        continue
-                    ReplShowShell -> do
-                        mode <- env.sessionShellMode
-                        let message = "shell tools: " <> case mode of
-                                ShellGhci -> "ghci"
-                                ShellBash -> "bash"
-                                ShellBoth -> "ghci + bash"
-                                ShellNone -> "none"
-                        displayInfo message $
-                            Text.putStrLn
-                                (roleMuted color (glyphSession <> message))
-                        continue
-                    ReplSetShell mode -> do
-                        message <- env.sessionSetShellMode mode
-                        displayInfo message $
-                            Text.putStrLn
-                                (roleMuted color (glyphOk <> message))
-                        continue
-                    ReplPaste pasteImmediate pasteCaption -> do
-                        color <- resolveColor stdout
-                        errColor <- resolveColor stderr
-                        imagesResult <- readClipboardImagesForPaste
-                        case imagesResult of
-                            Left err -> do
-                                displayError err $
-                                    Text.hPutStrLn stderr
-                                        (roleError errColor err)
-                                continue
-                            Right [] -> do
-                                displayError "no image found on the clipboard" $
-                                    Text.hPutStrLn stderr
-                                        (roleError errColor
-                                            "no image found on the clipboard")
-                                continue
-                            Right images -> do
-                                let sizes =
-                                        Text.intercalate ", "
-                                            [ img.imageMime <> " (" <> formatImageSize (BS.length img.imageBytes) <> ")"
-                                            | img <- images
-                                            ]
-                                if pasteImmediate
-                                    then do
-                                        let promptText =
-                                                if Text.null pasteCaption
-                                                    then "See attached image."
-                                                    else pasteCaption
-                                        when (isNothing fullscreen) $
-                                            putImagePreview previewIdRef color images
-                                        displayInfo ("pasted " <> sizes) $
-                                            Text.putStrLn
-                                                (roleMuted color
-                                                    (glyphOk <> "pasted " <> sizes))
-                                        resetRenderPrintedText render
-                                        fullscreenEvent
-                                            (UiUserSubmitted promptText)
-                                        let turnInputs =
-                                                [ UserMultimodal
-                                                    { userText = promptText
-                                                    , userImages = images
-                                                    }
-                                                ]
-                                        result <- runOneTurn env promptText turnInputs
-                                        finishTurn env False result
-                                    else do
-                                        message <- queueAttachedImages
-                                            conversationRef
-                                            previewIdRef
-                                            color
-                                            (isNothing fullscreen)
-                                            images
-                                        syncFullscreenImagePreviews
-                                        displayInfo message $
-                                            Text.putStrLn
-                                                (roleMuted color
-                                                    (glyphOk <> message))
-                                        continue
-                    ReplShowAttachments -> do
-                        pending <- readLiveAttachments conversationRef
-                        color <- resolveColor stdout
-                        let message =
-                                if null pending
-                                    then "attachments: (none)"
-                                    else "attachments: "
-                                        <> Text.intercalate ", "
-                                            [ img.imageMime
-                                                <> " ("
-                                                <> formatImageSize
-                                                    (BS.length img.imageBytes)
-                                                <> ")"
-                                            | img <- pending
-                                            ]
-                        displayInfo message $
-                            Text.putStrLn
-                                (roleMuted color (glyphSession <> message))
-                        continue
-                    ReplClearAttachments -> do
-                        modifyLiveAttachments conversationRef (\_ -> ([], ()))
-                        forM_ fullscreen \runtime ->
-                            setFullscreenImagePreviews runtime []
-                        color <- resolveColor stdout
-                        displayInfo "attachments cleared" $
-                            Text.putStrLn
-                                (roleMuted color
-                                    (glyphOk <> "attachments cleared"))
-                        continue
-                    ReplShowAgentLimit -> do
-                        limit <- env.sessionConcurrentLimit
-                        let message =
-                                "concurrent agent limit: "
-                                    <> Text.pack (show limit)
-                        color <- resolveColor stdout
-                        displayInfo message $
-                            Text.putStrLn
-                                (roleMuted color (glyphSession <> message))
-                        continue
-                    ReplSetAgentLimit limit -> do
-                        message <- env.sessionSetConcurrentLimit limit
-                        color <- resolveColor stdout
-                        displayInfo message $
-                            Text.putStrLn
-                                (roleMuted color (glyphOk <> message))
-                        continue
-                    ReplAgents -> do
-                        case agentViewport of
-                            Nothing -> continue
-                            Just viewport -> do
-                                entries <- viewport.viewportEntries
-                                selected <- readIORef viewport.viewportSelected
-                                color <- resolveColor stderr
-                                pickAgentChoice
-                                    fullscreen color selected entries >>= \case
-                                    Nothing -> pure ()
-                                    Just target ->
-                                        viewport.viewportSelect target
-                                continue
-                    ReplMcp -> do
-                        color <- resolveColor stderr
-                        restart <-
-                            legacy $
-                                runMcpManager
-                                    color
-                                    env.sessionHome
-                                    env.sessionMcpRegistrations
-                                    env.sessionMcpWarnings
-                        if restart
-                            then requestMcpRestart
-                                fullscreen persist
-                            else continue
-                    ReplGoalStatus -> do
-                        color <- resolveColor stdout
-                        case grokRuntime of
-                            Nothing ->
-                                displayError
-                                    "goal commands are unavailable in this session" $
-                                    Text.hPutStrLn stderr
-                                        (roleError color
-                                            "goal commands are unavailable in this session")
-                            Just control ->
-                                readGoal control.grokGoalRuntime >>= \case
-                                    Nothing ->
-                                        displayInfo "No goal is active." $
-                                            Text.putStrLn
-                                                (roleMuted color
-                                                    "No goal is active.")
-                                    Just goal -> do
-                                        let message =
-                                                formatGoalSnapshot goal
-                                        displayInfo message $
-                                            Text.putStrLn
-                                                (roleMuted color message)
-                        continue
-                    ReplGoalPause -> do
-                        color <- resolveColor stderr
-                        case grokRuntime of
-                            Nothing ->
-                                displayError
-                                    "goal commands are unavailable in this session" $
-                                    Text.hPutStrLn stderr
-                                        (roleError color
-                                            "goal commands are unavailable in this session")
-                            Just control ->
-                                pauseGoal control.grokGoalRuntime >>= \case
-                                    Left err ->
-                                        displayError err $
-                                            Text.hPutStrLn stderr
-                                                (roleError color err)
-                                    Right goal -> do
-                                        let message =
-                                                "Goal paused.\n"
-                                                    <> formatGoalSnapshot goal
-                                        displayInfo message $
-                                            Text.hPutStrLn stderr
-                                                (roleMuted color message)
-                        continue
-                    ReplGoalResume -> do
-                        color <- resolveColor stderr
-                        case grokRuntime of
-                            Nothing ->
-                                displayError
-                                    "goal commands are unavailable in this session" $
-                                    Text.hPutStrLn stderr
-                                        (roleError color
-                                            "goal commands are unavailable in this session")
-                            Just control ->
-                                resumeGoal control.grokGoalRuntime >>= \case
-                                    Left err ->
-                                        displayError err $
-                                            Text.hPutStrLn stderr
-                                                (roleError color err)
-                                    Right goal -> do
-                                        let message =
-                                                "Goal resumed.\n"
-                                                    <> formatGoalSnapshot goal
-                                        displayInfo message $
-                                            Text.hPutStrLn stderr
-                                                (roleMuted color message)
-                        continue
-                    ReplGoalClear -> do
-                        color <- resolveColor stderr
-                        case grokRuntime of
-                            Nothing ->
-                                displayError
-                                    "goal commands are unavailable in this session" $
-                                    Text.hPutStrLn stderr
-                                        (roleError color
-                                            "goal commands are unavailable in this session")
-                            Just control -> do
-                                cleared <-
-                                    clearGoal control.grokGoalRuntime
-                                let message =
-                                        if cleared
-                                            then "Goal cleared."
-                                            else "No goal was active."
-                                displayInfo message $
-                                    Text.hPutStrLn stderr
-                                        (roleMuted color message)
-                        continue
-                    ReplGoalSet original objective budget expanded ->
-                        case grokRuntime of
-                            Nothing -> do
-                                color <- resolveColor stderr
-                                let err =
-                                        "goal commands are unavailable in this session"
-                                displayError err $
-                                    Text.hPutStrLn stderr
-                                        (roleError color err)
-                                continue
-                            Just control ->
-                                activateGoal
-                                    control.grokGoalRuntime
-                                    objective
-                                    budget >>= \case
-                                        Left err -> do
-                                            color <- resolveColor stderr
-                                            displayError err $
-                                                Text.hPutStrLn stderr
-                                                    (roleError color err)
-                                            continue
-                                        Right _ ->
-                                            submitExpandedTurn
-                                                continue
-                                                color
-                                                original
-                                                expanded
-                    ReplWorkflowRuns -> do
-                        color <- resolveColor stdout
-                        case grokRuntime >>= (.grokWorkflowRuntime) of
-                            Nothing ->
-                                displayError
-                                    "workflow commands are unavailable in this session" $
-                                    Text.hPutStrLn stderr
-                                        (roleError color
-                                            "workflow commands are unavailable in this session")
-                            Just runtime -> do
-                                runs <- workflowRunSnapshots runtime
-                                let message = formatWorkflowRuns runs
-                                displayInfo message $
-                                    Text.putStrLn
-                                        (roleMuted color message)
-                        continue
-                    ReplWorkflowManage operation target -> do
-                        color <- resolveColor stderr
-                        let err =
-                                "workflow_management_unsupported: /workflow "
-                                    <> operation
-                                    <> maybe "" (" " <>) target
-                                    <> " is not supported by this host; use /workflow runs to inspect tracked runs."
-                        displayError err $
-                            Text.hPutStrLn stderr
-                                (roleError color err)
-                        continue
-
-                    ReplCopyLast -> do
-                        answer <- readIORef lastAssistantRef
-                        copyCommand
-                            "last response"
-                            "no assistant response to copy"
-                            answer
-                        continue
-                    ReplCopyCode index -> do
-                        answer <- readIORef lastAssistantRef
-                        let label =
-                                "code block " <> Text.pack (show index)
-                        copyCommand
-                            label
-                            (label <> " was not found")
-                            (answer >>= fencedCodeBlock index)
-                        continue
-                    ReplCopyDiff -> do
-                        answer <- readIORef lastAssistantRef
-                        copyCommand
-                            "diff block"
-                            "no diff block was found"
-                            (answer >>= lastDiffBlock)
-                        continue
-                    ReplCopyPath -> do
-                        copyCommand
-                            "worktree path"
-                            "worktree path is unavailable"
-                            (Just (toText cwd))
-                        continue
-                    ReplCopySession -> do
-                        sessionId <- currentSessionId persist
-                        copyCommand
-                            "session id"
-                            "this session has no persisted id yet"
-                            sessionId
-                        continue
-                    ReplShowTerminal -> do
-                        let message = formatTerminalCapabilities terminal
-                        displayInfo message $
-                            Text.putStrLn (roleMuted color message)
-                        continue
-                    ReplShowEffort -> do
-                        color <- resolveColor stdout
-                        params <- readIORef paramsRef
-                        let message = "effort: " <> currentEffort params
-                        displayInfo message $
-                            Text.putStrLn
-                                (roleMuted color (glyphSession <> message))
-                        continue
-                    ReplSetEffort level -> do
-                        setEffort level
-                        continue
-                    ReplShowModel -> do
-                        chooseModel continue
-                    ReplSetModel name -> do
-                        color <- resolveColor stdout
-                        let rawChoice = rawModelOption provider name
-                        choice <-
-                            resolveModelOptionDialect $
-                                fromMaybe
-                                    (rawChoice
-                                        { modelTarget =
-                                            rawChoice.modelTarget
-                                                { targetConnectionId = connectionId
-                                                , targetDialect = dialectId dialect
-                                                }
-                                        })
-                                    (resolveConfiguredModel catalog name)
-                        if modelTargetRequiresRebuild
-                                connectionId provider (dialectId dialect) choice
-                            then
-                                requestModelTargetSwitch
-                                    fullscreen choice persist >>= \case
-                                    Left err -> do
-                                        displayError err $
-                                            Text.hPutStrLn stderr
-                                                (roleError color err)
-                                        continue
-                                    Right result -> pure result
-                            else do
-                                message <- applyModelChange
-                                    projectRoot provider connectionId name
-                                    choice.modelTarget.targetWireModelId
-                                    choice.modelTarget.targetDialect
-                                    paramsRef render conversationRef persist
-                                displayInfo message $
-                                    Text.putStrLn
-                                        (roleMuted color (glyphOk <> message))
-                                continue
-                    ReplToggleAlwaysApprove
-                        | provider == ClaudeCodeProvider -> do
-                            let message =
-                                    "Claude Code permissions are fixed for this provider session; restart with --yolo or --no-yolo."
-                            color <- resolveColor stderr
-                            displayInfo message $
-                                putTextLn stderr (roleMuted color message)
-                            continue
-                        | otherwise -> do
-                            message <- toggleAlwaysApprove policyRef projectRoot
-                            color <- resolveColor stderr
-                            displayInfo message $
-                                putTextLn stderr (roleMuted color message)
-                            continue
-                    ReplCompact focus -> do
-                        color <- resolveColor stderr
-                        result <-
-                            withReplActivity "Compacting context…" $
-                                compactRunner focus
-                        case result of
-                            Left err -> do
-                                displayError err $
-                                    Text.hPutStrLn stderr (roleError color err)
-                                continue
-                            Right outcome -> do
-                                fullscreenEvent UiConversationCleared
-                                fullscreenEvent
-                                    (UiSystemMessage outcome.compactSummary)
-                                let message =
-                                        "compacted "
-                                            <> Text.pack
-                                                (show outcome.compactBeforeTokens)
-                                            <> " → "
-                                            <> Text.pack
-                                                (show outcome.compactAfterTokens)
-                                            <> " tokens ("
-                                            <> Text.pack
-                                                (show (length outcome.compactHistory))
-                                            <> " items)"
-                                displayInfo message $
-                                    Text.hPutStrLn stderr
-                                        (roleMuted color
-                                            (glyphSession <> message))
-                                case persist of
-                                    PersistenceDisabled -> pure ()
-                                    PersistenceEnabled slotRef -> do
-                                        now <- getCurrentTime
-                                        handle <- ensureSession slotRef
-                                        let turn = SessionTurn
-                                                { turnAt = now
-                                                , turnUserText = compactSessionUserText focus
-                                                , turnAssistantText = Just outcome.compactSummary
-                                                , turnError = Nothing
-                                                , turnResponseId = Nothing
-                                                , turnItems = outcome.compactHistory
-                                                -- Compaction response usage is
-                                                -- recorded immediately by
-                                                -- compactRunner, including
-                                                -- response-level failures.
-                                                , turnUsage = Nothing
-                                                }
-                                        handle' <-
-                                            appendTurnWithMetaUpdate handle turn
-                                                \meta -> meta
-                                                    { metaLastResponseId = Nothing
-                                                    }
-                                        writeIORef slotRef
-                                            (PersistenceActive handle')
-                                continue
-                    ReplPlan _
-                        | provider == ClaudeCodeProvider -> do
-                            let message =
-                                    "Outer plan mode is unavailable for Claude Code because its tools run inside the Claude CLI."
-                            color <- resolveColor stderr
-                            displayInfo message $
-                                putTextLn stderr (roleMuted color message)
-                            continue
-                    ReplPlan maybeDescription ->
-                        enterPlanFromSlash env maybeDescription >>= \case
-                            Just providerSwitch ->
-                                pure (RunSwitchProvider providerSwitch)
-                            Nothing -> continue
-                    ReplBtw question -> do
-                        runBtwQuestion True env question
-                        continue
-                    ReplRecap ->
-                        case fullscreen of
-                            Just runtime -> do
-                                emitUiEvent runtime UiRecapStarted
-                                env.sessionQueueRecap (RecapSession RecapManual)
-                                continue
-                            Nothing -> do
-                                runSessionRecap True env RecapManual
-                                continue
-                    ReplResume maybeId -> do
-                        handleResume databasePool fullscreen maybeId persist >>= \case
-                            Nothing -> continue
-                            Just result -> pure result
-                    ReplSearch query -> do
-                        handleConversationSearch
-                            databasePool fullscreen query persist >>= \case
-                                Nothing -> continue
-                                Just result -> pure result
-                    ReplClear -> do
-                        sessionReset
-                        fullscreenEvent UiConversationCleared
-                        color <- resolveColor stderr
-                        message <- case persist of
-                            PersistenceDisabled ->
-                                pure "conversation cleared"
-                            PersistenceEnabled slotRef -> do
-                                now <- getCurrentTime
-                                slot <- readIORef slotRef
-                                case slot of
-                                    PersistencePending _ _ _ ->
-                                        pure "conversation cleared"
-                                    PersistenceActive handle -> do
-                                        let turn = SessionTurn
-                                                { turnAt = now
-                                                , turnUserText = clearSessionUserText
-                                                , turnAssistantText =
-                                                    Just "Conversation cleared."
-                                                , turnError = Nothing
-                                                , turnResponseId = Nothing
-                                                , turnItems = []
-                                                , turnUsage = Nothing
-                                                }
-                                        handle' <- appendTurnKeepTitle handle turn
-                                        let meta = handle'.sessionMeta
-                                                { metaLastResponseId = Nothing
-                                                , metaUpdatedAt = now
-                                                , metaInputTokens = 0
-                                                , metaOutputTokens = 0
-                                                , metaCachedTokens = 0
-                                                , metaLastRecap = Nothing
-                                                , metaLastTurnSummary = Nothing
-                                                , metaLastRecapMainTurns = 0
-                                                }
-                                        writeSessionMeta
-                                            handle'.sessionPool
-                                            handle'.sessionMetaPath
-                                            meta
-                                        writeIORef slotRef
-                                            (PersistenceActive handle'{sessionMeta = meta})
-                                        pure
-                                            ("conversation cleared (session "
-                                                <> meta.metaId
-                                                <> ")")
-                        displayInfo message $
-                            Text.hPutStrLn stderr
-                                (roleMuted color (glyphOk <> message))
-                        continue
-                    ReplNew -> do
-                        sessionReset
-                        fullscreenEvent UiConversationCleared
-                        color <- resolveColor stderr
-                        case persist of
-                            PersistenceDisabled -> do
-                                displayInfo "started a fresh conversation" $
-                                    Text.hPutStrLn stderr
-                                        (roleMuted color
-                                            (glyphOk
-                                                <> "started a fresh conversation"))
-                                continue
-                            PersistenceEnabled slotRef -> do
-                                params <- readIORef paramsRef
-                                slot <- readIORef slotRef
-                                let model = currentModel params
-                                    effort = currentEffort params
-                                    create = case slot of
-                                        PersistencePending pending _ _ ->
-                                            pending
-                                                { createTarget =
-                                                    pending.createTarget
-                                                        { targetModelId = model }
-                                                , createEffort = effort
-                                                , createTitleHint = Nothing
-                                                , createTitleIsManual = False
-                                                }
-                                        PersistenceActive handle ->
-                                            SessionCreate
-                                                { createPool = handle.sessionPool
-                                                , createRoot =
-                                                    takeDirectory handle.sessionDir
-                                                , createTarget = ModelTarget
-                                                    { targetProvider = provider
-                                                    , targetConnectionId =
-                                                        connectionId
-                                                    , targetModelId = model
-                                                    , targetWireModelId =
-                                                        fromMaybe
-                                                            model
-                                                            handle.sessionMeta.metaTransportModel
-                                                    , targetDialect =
-                                                        dialectId dialect
-                                                    }
-                                                , createCwd =
-                                                    handle.sessionMeta.metaCwd
-                                                , createEffort = effort
-                                                , createTitleHint = Nothing
-                                                , createTitleIsManual = False
-                                                }
-                                handle <- createSession create
-                                case slot of
-                                    PersistencePending pending sessionId _ -> do
-                                        _ <- removeSessionTemp
-                                            pending.createRoot
-                                            sessionId
-                                        pure ()
-                                    PersistenceActive _ -> pure ()
-                                now <- getCurrentTime
-                                let turn = SessionTurn
-                                        { turnAt = now
-                                        , turnUserText = newSessionUserText
-                                        , turnAssistantText =
-                                            Just "Started a new session."
-                                        , turnError = Nothing
-                                        , turnResponseId = Nothing
-                                        , turnItems = []
-                                        , turnUsage = Nothing
-                                        }
-                                handle' <- appendTurnKeepTitle handle turn
-                                let meta = handle'.sessionMeta
-                                env.sessionOnPersisted handle'
-                                env.sessionSetTempDir handle'.sessionTempDir
-                                writeIORef slotRef
-                                    (PersistenceActive handle')
-                                writeIORef env.sessionTitleTurnCount 0
-                                writeIORef planMode.planSessionDir
-                                    (Just handle'.sessionDir)
-                                writeIORef storeRoot (Just handle'.sessionDir)
-                                setWindowTitle
-                                    (cliWindowTitle meta.metaCwd
-                                        (Just meta.metaTitle))
-                                let message = "new session: " <> meta.metaId
-                                displayInfo message $
-                                    Text.hPutStrLn stderr
-                                        (roleMuted color
-                                            (glyphOk <> message))
-                                continue
-                    ReplShowSession -> do
-                        color <- resolveColor stdout
-                        case persist of
-                            PersistenceDisabled ->
-                                displayInfo "session: (not persisted)" $
-                                    Text.putStrLn
-                                        (roleMuted color
-                                            "session: (not persisted)")
-                            PersistenceEnabled slotRef -> do
-                                slot <- readIORef slotRef
-                                case slot of
-                                    PersistencePending _ _ _ ->
-                                        displayInfo
-                                            "session: (pending until first turn)" $
-                                            Text.putStrLn
-                                                (roleMuted color
-                                                    "session: (pending until first turn)")
-                                    PersistenceActive handle ->
-                                        let message =
-                                                "session: "
-                                                    <> handle.sessionMeta.metaId
-                                        in displayInfo message $
-                                            Text.putStrLn
-                                                (roleMuted color
-                                                    (glyphSession <> message))
-                        continue
-                    ReplShowSessionInfo -> do
-                        color <- resolveColor stdout
-                        params <- readIORef paramsRef
-                        usage <- readIORef usageRef
-                        shellMode <- env.sessionShellMode
-                        (persistenceState, sessionId, sessionTitle) <-
-                            case persist of
-                                PersistenceDisabled ->
-                                    pure ("not_persisted", Nothing, Nothing)
-                                PersistenceEnabled slotRef -> do
-                                    slot <- readIORef slotRef
-                                    pure $ case slot of
-                                        PersistencePending _ pendingId _ ->
-                                            ("pending", Just pendingId, Nothing)
-                                        PersistenceActive handle ->
-                                            ( "active"
-                                            , Just handle.sessionMeta.metaId
-                                            , Just handle.sessionMeta.metaTitle
-                                            )
-                        let toolNames =
-                                Set.toAscList
-                                    slashCatalog.slashCatalogToolNames
-                            usageText =
-                                let formatted = formatTokenUsage usage
-                                in if Text.null formatted
-                                    then "0 in · 0 out"
-                                    else formatted
-                            message = Text.unlines $
-                                [ "session: "
-                                    <> fromMaybe "(not persisted)" sessionId
-                                , "state: " <> persistenceState
-                                ]
-                                    <> maybe
-                                        []
-                                        (\title -> ["title: " <> title])
-                                        sessionTitle
-                                    <> [ "provider: " <> providerSlug provider
-                                       , "connection: " <> connectionId
-                                       , "model: " <> currentModel params
-                                       , "dialect: "
-                                            <> dialectSlug
-                                                (dialectId dialect)
-                                       , "effort: " <> currentEffort params
-                                       , "cwd: " <> toText cwd
-                                       , "shell: "
-                                            <> shellModeText shellMode
-                                       , "tokens: " <> usageText
-                                       , "tools: "
-                                            <> if null toolNames
-                                                then "(none)"
-                                                else
-                                                    Text.intercalate
-                                                        ", "
-                                                        toolNames
-                                       ]
-                        displayInfo message $
-                            Text.putStrLn (roleMuted color message)
-                        continue
-                    ReplAfk rawTarget -> do
-                        let failAfk err = do
-                                color <- resolveColor stderr
-                                displayError err $
-                                    putTextLn stderr (roleError color err)
-                                continue
-                            finishAfk message = do
-                                color <- resolveColor stderr
-                                displayInfo message $
-                                    putTextLn stderr
-                                        (roleMuted color (glyphOk <> message))
-                                pure RunQuit
-                        case parseAfkTarget rawTarget of
-                            Left err -> failAfk err
-                            Right target -> case persist of
-                                PersistenceDisabled ->
-                                    failAfk "/afk requires a persisted interactive session"
-                                PersistenceEnabled slotRef ->
-                                    readIORef slotRef >>= \case
-                                        PersistencePending _ _ _ ->
-                                            failAfk
-                                                "/afk is available after the first persisted turn"
-                                        PersistenceActive handle ->
-                                            case target of
-                                                AfkLocal ->
-                                                    handoffLocal
-                                                        handle.sessionMeta.metaId
-                                                        cwd >>= \case
-                                                            Left err -> failAfk err
-                                                            Right message ->
-                                                                finishAfk message
-                                                AfkRemote host path ->
-                                                    loadSession
-                                                        databasePool
-                                                        (sessionsRoot env.sessionHome)
-                                                        handle.sessionMeta.metaId
-                                                        >>= \case
-                                                            Left err -> failAfk err
-                                                            Right (meta, turns) ->
-                                                                handoffRemote
-                                                                    host
-                                                                    path
-                                                                    handle.sessionDir
-                                                                    SessionTransfer
-                                                                        { transferMeta = meta
-                                                                        , transferTurns = turns
-                                                                        }
-                                                                    >>= \case
-                                                                        Left err -> failAfk err
-                                                                        Right message ->
-                                                                            finishAfk message
-                    ReplWorktree -> do
-                        result <- withReplActivity "Creating worktree…" $
-                            createWorktree cwd (worktreeRoot env.sessionHome)
-                        case result of
-                            Left err -> do
-                                color <- resolveColor stderr
-                                displayError err $
-                                    putTextLn stderr (roleError color err)
-                                continue
-                            Right path -> do
-                                color <- resolveColor stderr
-                                params <- readIORef paramsRef
-                                let message = "worktree: " <> toText path
-                                displayInfo message $
-                                    putTextLn stderr
-                                        (roleMuted color
-                                            (glyphSession <> message))
-                                pure
-                                    (RunSwitchWorktree
-                                        path
-                                        provider
-                                        (currentModel params)
-                                        (currentEffort params))
-                    ReplRename title -> do
-                        color <- resolveColor stderr
-                        case persist of
-                            PersistenceDisabled ->
-                                displayError
-                                    "cannot rename a session that is not persisted" $
-                                    putTextLn stderr
-                                        (roleError color
-                                            "cannot rename a session that is not persisted")
-                            PersistenceEnabled slotRef ->
-                                readIORef slotRef >>= \case
-                                    PersistencePending pending sessionId tempDir -> do
-                                        writeIORef slotRef
-                                            (PersistencePending
-                                                pending
-                                                    { createTitleHint = Just title
-                                                    , createTitleIsManual = True
-                                                    }
-                                                sessionId
-                                                tempDir)
-                                        setWindowTitle
-                                            (cliWindowTitle pending.createCwd
-                                                (Just title))
-                                        let message = "session title: " <> title
-                                        displayInfo message $
-                                            putTextLn stderr
-                                                (roleMuted color
-                                                    (glyphOk <> message))
-                                    PersistenceActive handle -> do
-                                        invalidateSessionTitles
-                                            env.sessionTitleManager
-                                            handle.sessionMeta.metaId
-                                        updated <- setManualSessionTitle title handle
-                                        writeIORef slotRef (PersistenceActive updated)
-                                        setWindowTitle
-                                            (cliWindowTitle updated.sessionMeta.metaCwd
-                                                (Just updated.sessionMeta.metaTitle))
-                                        let message =
-                                                "session title: "
-                                                    <> updated.sessionMeta.metaTitle
-                                        displayInfo message $
-                                            putTextLn stderr
-                                                (roleMuted color
-                                                    (glyphOk <> message))
-                        continue
-                    ReplRenameAuto -> do
-                        color <- resolveColor stderr
-                        case persist of
-                            PersistenceDisabled ->
-                                displayError
-                                    "cannot rename a session that is not persisted" $
-                                    putTextLn stderr
-                                        (roleError color
-                                            "cannot rename a session that is not persisted")
-                            PersistenceEnabled slotRef ->
-                                readIORef slotRef >>= \case
-                                    PersistencePending pending sessionId tempDir -> do
-                                        writeIORef slotRef
-                                            (PersistencePending
-                                                pending
-                                                    { createTitleHint = Nothing
-                                                    , createTitleIsManual = False
-                                                    }
-                                                sessionId
-                                                tempDir)
-                                        setWindowTitle
-                                            (cliWindowTitle pending.createCwd Nothing)
-                                        displayInfo
-                                            "automatic session titles enabled" $
-                                            putTextLn stderr
-                                                (roleMuted color
-                                                    (glyphOk
-                                                        <> "automatic session titles enabled"))
-                                    PersistenceActive handle -> do
-                                        invalidateSessionTitles
-                                            env.sessionTitleManager
-                                            handle.sessionMeta.metaId
-                                        updated <- resetSessionTitleToAuto handle
-                                        writeIORef slotRef (PersistenceActive updated)
-                                        loadSession
-                                            updated.sessionPool
-                                            (takeDirectory updated.sessionDir)
-                                            updated.sessionMeta.metaId
-                                            >>= \case
-                                                Left _ -> pure ()
-                                                Right (_, turns) -> do
-                                                    let source =
-                                                            sessionConversationText turns
-                                                    requestSessionTitle
-                                                        env.sessionTitleManager
-                                                        updated.sessionMeta.metaId
-                                                        1
-                                                        source
-                                        displayInfo
-                                            "automatic session titles enabled" $
-                                            putTextLn stderr
-                                                (roleMuted color
-                                                    (glyphOk
-                                                        <> "automatic session titles enabled"))
-                        continue
-                    ReplLogin -> do
-                        color <- resolveColor stderr
-                        legacy (runLoginManager color)
-                        continue
-                    ReplUsage -> do
-                        case fullscreen of
-                            Nothing ->
-                                showAccountUsage
-                                    provider tokenProvider openAiPool
-                            Just runtime ->
-                                accountUsageText
-                                    False provider tokenProvider openAiPool
-                                    >>= emitUiEvent runtime . UiSystemMessage
-                        continue
-                    ReplReloadAuth -> do
-                        reloadResult <- reloadAuth provider tokenProvider
-                        color <- resolveColor stderr
-                        case reloadResult of
-                            Left err ->
-                                displayError err $
-                                    putTextLn stderr (roleError color err)
-                            Right message ->
-                                displayInfo message $
-                                    putTextLn stderr (roleMuted color message)
-                        continue
-                    ReplHelp maybeName -> do
-                        color <- resolveColor stdout
-                        displayInfo
-                            (formatSlashHelpWithCatalog
-                                False slashCatalog maybeName) $
-                            Text.putStrLn
-                                (formatSlashHelpWithCatalog
-                                    color slashCatalog maybeName)
-                        continue
-                    ReplCommandError err -> do
-                        color <- resolveColor stderr
-                        displayError err $
-                            Text.hPutStrLn stderr (roleError color err)
-                        continue
-    submitExpandedTurn next color original expanded = do
-        pendingImages <-
-            modifyLiveAttachments conversationRef \imgs -> ([], imgs)
-        forM_ fullscreen \runtime ->
-            setFullscreenImagePreviews runtime []
-        let turnInputs =
-                if null pendingImages
-                    then [UserMessage expanded]
-                    else
-                        [ UserMultimodal
-                            { userText = expanded
-                            , userImages = pendingImages
-                            }
-                        ]
-        preparePromptSkillInputs env original turnInputs >>= \case
-            Left err -> do
-                displayError err $
-                    Text.hPutStrLn stderr (roleError color err)
-                next
-            Right skillInputs -> do
-                resetRenderPrintedText render
-                fullscreenEvent (UiUserSubmitted original)
-                result <- runOneTurn env original skillInputs
-                finishTurn env False result
-    continue = continueWith ""
-    continueWith keptDraft =
-        replWithDraft env keptDraft
-    legacy action = case fullscreen of
-        Nothing -> action
-        Just runtime -> withFullscreenSuspended runtime action
-    fullscreenEvent event = case fullscreen of
-        Nothing -> pure ()
-        Just runtime -> emitUiEvent runtime event
-    syncFullscreenImagePreviews =
-        forM_ fullscreen \runtime ->
-            readLiveAttachments conversationRef
-                >>= setFullscreenImagePreviews runtime
-    displayInfo message minimalAction = case fullscreen of
-        Nothing -> minimalAction
-        Just runtime -> emitUiEvent runtime (UiSystemMessage message)
-    displayError message minimalAction = case fullscreen of
-        Nothing -> minimalAction
-        Just runtime -> emitUiEvent runtime (UiErrorMessage message)
-    shellModeText = \case
-        ShellGhci -> "ghci"
-        ShellBash -> "bash"
-        ShellBoth -> "ghci + bash"
-        ShellNone -> "none"
-    withReplActivity message action = do
-        case fullscreen of
-            Nothing ->
-                renderEvent render (ActivityUpdated message)
-            Just runtime ->
-                emitUiEvent runtime
-                    (UiSetNotice (Just (progressNotice message)))
-        action `finally`
-            case fullscreen of
-                Nothing -> clearThinking render
-                Just runtime -> emitUiEvent runtime (UiSetNotice Nothing)
-    setEffort level = do
-        color <- resolveColor stdout
-        setSessionEffort env level
-        displayInfo ("effort set to " <> level) $
-            Text.putStrLn
-                (roleMuted color
-                    (glyphOk <> "effort set to " <> level))
-    chooseEffort next = do
-        params <- readIORef paramsRef
-        effortChoice fullscreen (currentEffort params) >>= \case
-            Nothing -> next
-            Just level -> setEffort level >> next
-    chooseModel next = do
-        color <- resolveColor stderr
-        params <- readIORef paramsRef
-        let current = currentModel params
-        modelChoice
-            catalog fullscreen color connectionId provider current
-                (dialectId dialect) >>= \case
-            Nothing -> next
-            Just rawChoice -> do
-                choice <- resolveModelOptionDialect rawChoice
-                if choice.modelTarget.targetProvider == provider
-                    && choice.modelTarget.targetConnectionId == connectionId
-                    && choice.modelTarget.targetModelId == current
-                    && choice.modelTarget.targetDialect == dialectId dialect
-                  then do
-                    let message =
-                            "model: "
-                                <> connectionId
-                                <> "/"
-                                <> choice.modelTarget.targetModelId
-                    displayInfo message $
-                        Text.putStrLn
-                            (roleMuted color
-                                (glyphSession <> message))
-                    next
-                  else if not
-                        (modelTargetRequiresRebuild
-                            connectionId provider (dialectId dialect) choice)
-                  then do
-                    message <- applyModelChange
-                        projectRoot provider connectionId
-                        choice.modelTarget.targetModelId
-                        choice.modelTarget.targetWireModelId
-                        choice.modelTarget.targetDialect
-                        paramsRef render conversationRef persist
-                    displayInfo message $
-                        Text.putStrLn
-                            (roleMuted color
-                                (glyphOk <> message))
-                    next
-                  else
-                    requestModelTargetSwitch fullscreen choice persist >>= \case
-                        Left err -> do
-                            displayError err $
-                                Text.hPutStrLn stderr
-                                    (roleError color err)
-                            next
-                        Right result -> pure result
-    chooseAccount next =
-        case fullscreen of
-            Just runtime -> do
-                currentSelectionId <- readIORef selectionRef
-                currentAccountId <- readIORef accountIdRef
-                options <- withReplActivity
-                    "Loading account usage…"
-                    (loadAllAccountPickerOptions provider)
-                let initial =
-                        fromMaybe 0 $
-                            findIndex
-                                (accountPickerMatches
-                                    provider
-                                    currentSelectionId
-                                    currentAccountId)
-                                options
-                requestFullscreenChoiceWithBody
-                    runtime
-                    "Accounts"
-                    "Choose any account. Switching provider also switches to its default model."
-                    initial
-                    (map
-                        (accountPickerRow
-                            provider
-                            currentSelectionId
-                            currentAccountId)
-                        options)
-                    >>= \case
-                        Just index
-                            | Just option <- atMay index options ->
-                                case option of
-                                    AccountPickerAccount
-                                        selectedProvider
-                                        selectedBilling
-                                        selectedSelectionId
-                                        selectedAccountId
-                                        selectedLabel
-                                        _
-                                            -- Claude exposes display metadata,
-                                            -- not a stable account identity.
-                                            -- Revalidate and restart even when
-                                            -- the synthetic id still matches.
-                                            | selectedProvider == provider
-                                            , selectedProvider
-                                                /= ClaudeCodeProvider
-                                            , selectedAccountId
-                                                == currentAccountId ->
-                                                displayInfo
-                                                    ("account: " <> selectedLabel)
-                                                    (pure ())
-                                                    >> next
-                                            | otherwise ->
-                                                chooseSelectedAccount
-                                                    selectedProvider
-                                                    selectedBilling
-                                                    selectedSelectionId
-                                                    selectedAccountId
-                                                    selectedLabel
-                                    AccountPickerConnect selectedProvider -> do
-                                        color <- resolveColor stderr
-                                        connected <-
-                                            withFullscreenSuspended runtime $
-                                                connectProviderAccount
-                                                    color
-                                                    selectedProvider
-                                        case connected of
-                                            Nothing -> next
-                                            Just selectedAccountId -> do
-                                                refreshed <-
-                                                    loadAllAccountPickerOptions
-                                                        provider
-                                                case listToMaybe
-                                                        [ account
-                                                        | account@(AccountPickerAccount
-                                                            accountProvider
-                                                            _
-                                                            _
-                                                            accountId
-                                                            _
-                                                            _) <- refreshed
-                                                        , accountProvider
-                                                            == selectedProvider
-                                                        , accountId
-                                                            == selectedAccountId
-                                                        ] of
-                                                    Just
-                                                        (AccountPickerAccount
-                                                            accountProvider
-                                                            billing
-                                                            selectionId
-                                                            accountId
-                                                            label
-                                                            _) ->
-                                                        chooseSelectedAccount
-                                                            accountProvider
-                                                            billing
-                                                            selectionId
-                                                            accountId
-                                                            label
-                                                    _ -> do
-                                                        displayError
-                                                            "Connected account could not be loaded."
-                                                            (pure ())
-                                                        next
-                        _ -> next
-              where
-                currentBilling =
-                    tokenProviderBillingMode
-                        <$> tokenProvider
-                chooseSelectedAccount
-                    selectedProvider
-                    selectedBilling
-                    selectedSelectionId
-                    selectedAccountId
-                    selectedLabel
-                        | selectedProvider == provider
-                        , Just selectedBilling == currentBilling
-                        , Just select <- selectAccount =
-                            let liveSelectionId =
-                                    case selectedProvider of
-                                        OpenAIProvider -> selectedAccountId
-                                        _ -> selectedSelectionId
-                            in select liveSelectionId >>= \case
-                                Left err -> do
-                                    now <- getCurrentTime
-                                    let message =
-                                            "could not select account: "
-                                                <> formatApiErrorInlineAt
-                                                    now
-                                                    err
-                                    displayError message (pure ())
-                                    next
-                                Right label -> do
-                                    displayInfo
-                                        ("account switched to " <> label)
-                                        (pure ())
-                                    next
-                        | otherwise =
-                            readIORef paramsRef >>= \params ->
-                                requestAccountProviderSwitch
-                                    catalog fullscreen provider connectionId
-                                    (currentModel params) (dialectId dialect)
-                                    selectedProvider selectedSelectionId
-                                    selectedAccountId persist >>= \case
-                                        Left err -> do
-                                            displayError err (pure ())
-                                            next
-                                        Right result -> do
-                                            displayInfo
-                                                ("switching to "
-                                                    <> selectedLabel
-                                                    <> " ("
-                                                    <> providerSlug
-                                                        selectedProvider
-                                                    <> ")")
-                                                (pure ())
-                                            pure result
-            Nothing -> do
-                displayError
-                    "Account switching is unavailable for this session."
-                    (pure ())
-                next
-    copyCommand label missing payload = case payload of
-        Nothing ->
-            displayError missing do
-                color <- resolveColor stderr
-                Text.hPutStrLn stderr (roleError color missing)
-        Just value -> do
-            copied <- copyTerminalClipboard terminal stdout value
-            if copied
-                then
-                    let message = "copied " <> label
-                    in displayInfo message do
-                        color <- resolveColor stderr
-                        Text.hPutStrLn stderr
-                            (roleSuccess color (glyphOk <> message))
-                else
-                    displayError "terminal clipboard is unavailable" do
-                        color <- resolveColor stderr
-                        Text.hPutStrLn stderr
-                            (roleError color
-                                "terminal clipboard is unavailable")
 
 concurrentlyAcquire
     :: IO a
@@ -4921,141 +3133,6 @@ concurrentlyAcquire acquireLeft releaseLeft acquireRight releaseRight =
                             Right leftValue ->
                                 pure (leftValue, rightValue)
 
-requestReload
-    :: Maybe FullscreenRuntime
-    -> Persistence
-    -> IO RunResult
-requestReload fullscreen persist = do
-    color <- resolveColor stderr
-    let reportInfo message =
-            case fullscreen of
-                Nothing ->
-                    putTextLn stderr
-                        (roleMuted color (glyphSession <> message))
-                Just runtime ->
-                    emitUiEvent runtime (UiSystemMessage message)
-        reportError message =
-            case fullscreen of
-                Nothing ->
-                    putTextLn stderr (roleError color message)
-                Just runtime ->
-                    emitUiEvent runtime (UiErrorMessage message)
-    case persist of
-        PersistenceDisabled -> do
-            reportError ":reload needs a persisted REPL session"
-            pure RunQuit
-        PersistenceEnabled slotRef -> do
-            handle <- ensureSession slotRef
-            reportInfo ("reloading; session " <> handle.sessionMeta.metaId)
-            pure (RunReload handle.sessionMeta.metaId)
-
-requestMcpRestart
-    :: Maybe FullscreenRuntime
-    -> Persistence
-    -> IO RunResult
-requestMcpRestart fullscreen persist = do
-    color <- resolveColor stderr
-    let report message =
-            case fullscreen of
-                Nothing ->
-                    putTextLn stderr
-                        (roleMuted color (glyphSession <> message))
-                Just runtime ->
-                    emitUiEvent runtime (UiSystemMessage message)
-    case persist of
-        PersistenceDisabled -> do
-            report
-                "MCP configuration saved; restart the agent to apply it"
-            pure RunQuit
-        PersistenceEnabled slotRef -> do
-            handle <- ensureSession slotRef
-            report "restarting MCP servers…"
-            pure (RunRestart handle.sessionMeta.metaId)
-
-restartSessionOptions :: CliOptions -> Text -> CliOptions
-restartSessionOptions options sessionId =
-    options
-        { optProvider = Nothing
-        , optModel = Nothing
-        , optCwd = Nothing
-        , optWorktree = False
-        , optEffort = Nothing
-        , optPrompt = Nothing
-        , optPromptFile = Nothing
-        , optManagedTurnFile = Nothing
-        , optResume = Just sessionId
-        }
-
-enterPlanFromSlash :: SessionEnv -> Maybe Text -> IO (Maybe ProviderTransition)
-enterPlanFromSlash env@SessionEnv
-    { sessionPlanMode = planMode
-    , sessionPersist = persist
-    , sessionRender = render
-    , sessionFullscreen = fullscreen
-    } maybeDescription = do
-    discardStore <- newIORef Nothing
-    color <- resolveColor stderr
-    let report message minimal = case fullscreen of
-            Nothing -> putTextLn stderr (roleMuted color minimal)
-            Just runtime -> emitUiEvent runtime (UiSystemMessage message)
-    case persist of
-        PersistenceEnabled slotRef -> do
-            handle <- ensureSession slotRef
-            writeIORef planMode.planSessionDir (Just handle.sessionDir)
-            report
-                ("session: " <> handle.sessionMeta.metaId)
-                (glyphSession <> "session: " <> handle.sessionMeta.metaId)
-        PersistenceDisabled -> pure ()
-    case maybeDescription of
-        Nothing -> do
-            writeIORef planMode.planStateRef PlanPending
-            let message =
-                    "plan mode armed; send a prompt to activate \
-                    \(or /plan <description>)"
-            report message (glyphSession <> message)
-            pure Nothing
-        Just description -> do
-            activatePlanMode planMode
-            path <- planFilePath planMode
-            let message = "plan mode on (" <> toText path <> ")"
-            report message (glyphSession <> message)
-            resetRenderPrintedText render
-            case fullscreen of
-                Nothing -> pure ()
-                Just runtime ->
-                    emitUiEvent runtime (UiUserSubmitted description)
-            let planEnv = env { sessionStoreRoot = discardStore }
-                inputs = [UserMessage description]
-            result <- runOneTurn planEnv description inputs
-            case result of
-                TurnProviderUnavailable apiError pending ->
-                    requestAutomaticProviderFallback
-                        planEnv apiError pending >>= \case
-                            Nothing -> do
-                                reportProviderUnavailable fullscreen apiError
-                                pure Nothing
-                            Just providerTransition ->
-                                pure (Just providerTransition)
-                _ -> do
-                    when (isNothing fullscreen) $
-                        putTrailingNewline render
-                    pure Nothing
-
-preparePromptSkillInputs
-    :: SessionEnv
-    -> Text
-    -> [TurnInput]
-    -> IO (Either Text [TurnInput])
-preparePromptSkillInputs env prompt inputs = do
-    invocations <- readIORef env.sessionSkillInvocations
-    pure do
-        selected <- resolveSkillMentions invocations prompt
-        let activations =
-                [ UserMessage (formatSkillActivation invocation prompt)
-                | invocation <- selected
-                ]
-        pure (activations <> inputs)
-
 -- | Drop Ghostty / Windows Terminal native progress (OSC 9;4) on stderr.
 -- Safe when the bar was never shown; unknown terminals ignore the sequence.
 clearNativeProgress :: Handle -> IO ()
@@ -5072,8 +3149,3 @@ setNativeProgress handle active = do
                 | otherwise = osc9ProgressRemove
         Text.hPutStr handle (wrapOscForTmux inTmux sequence_)
         hFlush handle
-
-putTrailingNewline :: RenderConfig -> IO ()
-putTrailingNewline render = do
-    didPrint <- renderPrintedText render
-    when didPrint (putTextLn render.renderStdout "")

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl.hs
@@ -1,0 +1,2132 @@
+-- | Interactive session loop and slash-command dispatch.
+module Agent.CLI.Runtime.Repl
+    ( repl
+    , replWithDraft
+    , runPendingTurn
+    , finishTurn
+    , preparePromptSkillInputs
+    ) where
+
+import Agent.CLI.AccountPicker
+    ( AccountPickerOption(..),
+      accountPickerMatches,
+      accountPickerRow,
+      loadAllAccountPickerOptions )
+import Agent.CLI.AccountSelection ()
+import Agent.CLI.Afk
+    ( AfkTarget(..), handoffLocal, handoffRemote, parseAfkTarget )
+import Agent.CLI.AgentSessions ()
+import Agent.CLI.AgentViewport
+    ( renderAgentViewportPanelFor,
+      AgentViewportEnv(viewportSelected, viewportSelect,
+                       viewportEntries) )
+import Agent.CLI.Approval ( toggleAlwaysApprove )
+import Agent.CLI.Artifact ( fencedCodeBlock, lastDiffBlock )
+import Agent.CLI.Auth ()
+import Agent.CLI.Clipboard
+    ( formatImageSize,
+      loadImagesFromPastedText,
+      nonEmptyClipboardImages,
+      readClipboardImagesForPaste,
+      readClipboardImagesImageFirst )
+import Agent.CLI.Command
+    ( currentEffort,
+      currentModel,
+      formatSlashHelpWithCatalog,
+      mkSlashCatalog,
+      parseReplLineWithCatalog,
+      ReplAction(ReplCommandError, ReplQuit, ReplReload, ReplPrompt,
+                 ReplExpandedPrompt, ReplInvokeSkill, ReplSkills, ReplShowShell,
+                 ReplSetShell, ReplPaste, ReplShowAttachments, ReplClearAttachments,
+                 ReplShowAgentLimit, ReplSetAgentLimit, ReplAgents, ReplMcp,
+                 ReplGoalStatus, ReplGoalPause, ReplGoalResume, ReplGoalClear,
+                 ReplGoalSet, ReplWorkflowRuns, ReplWorkflowManage, ReplCopyLast,
+                 ReplCopyCode, ReplCopyDiff, ReplCopyPath, ReplCopySession,
+                 ReplShowTerminal, ReplShowEffort, ReplSetEffort, ReplShowModel,
+                 ReplSetModel, ReplToggleAlwaysApprove, ReplCompact, ReplPlan,
+                 ReplBtw, ReplRecap, ReplResume, ReplSearch, ReplClear, ReplNew,
+                 ReplShowSession, ReplShowSessionInfo, ReplAfk, ReplWorktree,
+                 ReplRename, ReplRenameAuto, ReplLogin, ReplUsage, ReplReloadAuth,
+                 ReplHelp),
+      ShellMode(ShellNone, ShellGhci, ShellBash, ShellBoth),
+      SlashCatalog(slashCatalogToolNames) )
+import Agent.CLI.Compaction
+    ( CompactOutcome(compactSummary, compactBeforeTokens,
+                     compactAfterTokens, compactHistory) )
+import Agent.CLI.Config ()
+import Agent.CLI.Connectivity ()
+import Agent.CLI.Database ()
+import Agent.CLI.Database.Store ()
+import Agent.CLI.Dialects ()
+import Agent.CLI.Error ( formatApiErrorInlineAt )
+import Agent.CLI.GatewayBridge ()
+import Agent.CLI.Input
+    ( ReplLine(..),
+      formatPasteChip,
+      readReplLineWithCatalog,
+      submissionPromptText )
+import Agent.CLI.Interrupt ()
+import Agent.CLI.LearnedSkills ()
+import Agent.CLI.LearnedSkills.Store ()
+import Agent.CLI.Login ( connectProviderAccount, runLoginManager )
+import Agent.CLI.Lsp ()
+import Agent.CLI.ManagedTurn ()
+import Agent.CLI.McpManager ( runMcpManager )
+import Agent.CLI.McpStatus ()
+import Agent.CLI.ModelConfig ()
+import Agent.CLI.Models
+    ( catalogModelIds,
+      modelTargetRequiresRebuild,
+      rawModelOption,
+      resolveConfiguredModel,
+      resolveModelOptionDialect,
+      ModelOption(modelTarget),
+      ModelTarget(targetDialect, ModelTarget, targetProvider,
+                  targetConnectionId, targetModelId, targetWireModelId) )
+import Agent.CLI.Options ()
+import Agent.CLI.PendingInputs ()
+import Agent.CLI.Plan ()
+import Agent.CLI.Progress ()
+import Agent.CLI.Project ()
+import Agent.CLI.Prompt ()
+import Agent.CLI.PromptHooks ()
+import Agent.CLI.Provider.OpenAI ()
+import Agent.CLI.Provider.Switch
+    ( applyModelChange,
+      reloadAuth,
+      reportProviderUnavailable,
+      requestAccountProviderSwitch,
+      requestAutomaticProviderFallback,
+      requestModelTargetSwitch,
+      requestStartupProviderFallback )
+import Agent.CLI.ProviderAvailability ()
+import Agent.CLI.ProviderFallback ()
+import Agent.CLI.ProviderTransition
+    ( PendingTurn,
+      ProviderTransition,
+      TurnResult(TurnProviderUnavailable) )
+import Agent.CLI.Recap ( RecapKind(..), RecapRequest(..) )
+import Agent.CLI.Render
+    ( RenderConfig(..),
+      clearThinking,
+      putTextLn,
+      renderEvent,
+      renderPrintedText,
+      resetRenderPrintedText )
+import Agent.CLI.ReplMode
+    ( ReplMode(..), replModeLabel, replModeFromState )
+import Agent.CLI.Request ()
+import Agent.CLI.Runtime.Persistence ()
+import Agent.CLI.Runtime.Recap ( runSessionRecap )
+import Agent.CLI.Runtime.Types
+    ( PendingTurnPresentation,
+      RunResult(RunRestart, RunSwitchWorktree, RunSwitchProvider,
+                RunReload, RunQuit) )
+import Agent.CLI.Secret ()
+import Agent.CLI.Session
+    ( appendTurnKeepTitle,
+      appendTurnWithMetaUpdate,
+      createSession,
+      ensureSession,
+      loadSession,
+      removeSessionTemp,
+      resetSessionTitleToAuto,
+      sessionConversationText,
+      sessionsRoot,
+      setManualSessionTitle,
+      writeSessionMeta,
+      Persistence(..),
+      PersistenceState(PersistenceActive, PersistencePending),
+      SessionCreate(createCwd, SessionCreate, createPool, createEffort,
+                    createTarget, createTitleHint, createTitleIsManual, createRoot),
+      SessionHandle(sessionMeta, sessionPool, sessionMetaPath,
+                    sessionTempDir, sessionDir),
+      SessionMeta(metaId, metaLastResponseId, metaUpdatedAt,
+                  metaInputTokens, metaOutputTokens, metaCachedTokens, metaLastRecap,
+                  metaLastTurnSummary, metaLastRecapMainTurns, metaTransportModel,
+                  metaCwd, metaTitle),
+      SessionTransfer(transferTurns, SessionTransfer, transferMeta),
+      SessionTurn(turnUsage, SessionTurn, turnAt, turnUserText,
+                  turnAssistantText, turnError, turnResponseId, turnItems) )
+import Agent.CLI.Session.Attachments
+    ( putImagePreview, queueAttachedImages, queueClipboardImages )
+import Agent.CLI.Session.Choices
+    ( accountUsageText,
+      atMay,
+      effortChoice,
+      modelChoice,
+      showAccountUsage )
+import Agent.CLI.Session.History
+    ( modifyLiveAttachments, readLiveAttachments )
+import Agent.CLI.Session.Interaction
+    ( buildPromptState, runBtwQuestion, setSessionEffort )
+import Agent.CLI.Session.Lifecycle ( SessionContinuation(..) )
+import Agent.CLI.Session.Runtime.Types ()
+import Agent.CLI.Session.Selection
+    ( currentSessionId,
+      handleConversationSearch,
+      handleResume,
+      pickAgentChoice )
+import Agent.CLI.SessionAdmin ()
+import Agent.CLI.SessionEnv ( SessionEnv(..) )
+import Agent.CLI.SessionLock ()
+import Agent.CLI.SessionState ()
+import Agent.CLI.SessionTitle
+    ( invalidateSessionTitles, requestSessionTitle )
+import Agent.CLI.Skills
+    ( formatSkillsListing, skillInvocationCommand )
+import Agent.CLI.Startup.Auth ()
+import Agent.CLI.Startup.Format ()
+import Agent.CLI.StartupContext ()
+import Agent.CLI.Status
+    ( applyReplMode,
+      cycleReplInteraction,
+      formatReplStatusLine,
+      formatTokenUsage )
+import Agent.CLI.Style
+    ( beginBackground,
+      cliWindowTitle,
+      endBackground,
+      glyphOk,
+      glyphSession,
+      roleError,
+      roleMuted,
+      rolePrompt,
+      roleSuccess,
+      roleWarn,
+      userBackground )
+import Agent.CLI.Subagents.Runtime ()
+import Agent.CLI.TUI.App
+    ( FullscreenRuntime,
+      emitUiEvent,
+      readFullscreenLineOrWithCatalog,
+      readFullscreenLineWithCatalog,
+      requestFullscreenChoiceWithBody,
+      setFullscreenImagePreviews,
+      withFullscreenSuspended )
+import Agent.CLI.Terminal
+    ( copyTerminalClipboard,
+      emitTerminalSequence,
+      formatTerminalCapabilities,
+      osc133PromptEnd,
+      osc133PromptStart,
+      resolveColor,
+      withSynchronizedOutput,
+      TerminalCapabilities(terminalSemanticPrompts) )
+import Agent.CLI.Tools ()
+import Agent.CLI.Turn ( runOneTurn )
+import Agent.CLI.Usage
+    ( formatGrokLimitStatus,
+      formatOpenAiLimitStatus,
+      formatOpenRouterLimitStatus )
+import Agent.CLI.WebFetch ()
+import Agent.CLI.Worktree ( createWorktree, worktreeRoot )
+import Agent.Cancel ()
+import Agent.Claude ()
+import Agent.Dialect ( dialectId, dialectSlug )
+import Agent.Error ()
+import Agent.GrokBuild.Dialect.Goal
+    ( activateGoal,
+      clearGoal,
+      formatGoalSnapshot,
+      pauseGoal,
+      readGoal,
+      resumeGoal )
+import Agent.GrokBuild.Dialect.Runtime ( GrokRuntimeControl(..) )
+import Agent.GrokBuild.Dialect.Workflow
+    ( formatWorkflowRuns, workflowRunSnapshots )
+import Agent.Loop
+    ( TurnInput(UserMessage, UserMultimodal, userText, userImages),
+      LoopEvent(ActivityUpdated),
+      ImageAttachment(imageBytes, imageMime) )
+import Agent.OpenAI.Compaction
+    ( clearSessionUserText,
+      compactSessionUserText,
+      newSessionUserText )
+import Agent.OpenAI.Usage ( fetchUsage )
+import Agent.OpenAI.WebSocketClient ()
+import Agent.OpenRouter.LoopBackend ()
+import Agent.OsPath ( toText )
+import Agent.Provider
+    ( Provider(ClaudeCodeProvider, XAIProvider, OpenRouterProvider,
+               OpenAIProvider),
+      Credential(accessToken, accountId),
+      getNextToken,
+      providerSlug,
+      tokenProviderBillingMode,
+      BillingMode(SubscriptionBilled) )
+import Agent.Responses.GenericBackend ()
+import Agent.Responses.GenericClient ()
+import Agent.Responses.Types ()
+import Agent.Skills
+    ( SkillInvocation(invocationSkill),
+      formatSkillActivation,
+      resolveSkillInvocation,
+      resolveSkillMentions,
+      Skill(skillUserInvocable, skillName) )
+import Agent.Store.Postgres ()
+import Agent.Store.Types ()
+import Agent.Subagents ()
+import Agent.Subagents.TaskPath ()
+import Agent.TUI.Model
+    ( infoNotice,
+      progressNotice,
+      UiEvent(UiUserSubmitted, UiSetPromptLimitStatus, UiRecapStarted,
+              UiConversationCleared, UiSetNotice, UiErrorMessage,
+              UiSystemMessage) )
+import Agent.TUI.Motion ()
+import Agent.ToolDispatch ()
+import Agent.Tools.MultiAgents ()
+import Agent.Tools.PlanMode
+    ( PlanModeEnv(planStateRef, planSessionDir),
+      activatePlanMode,
+      planFilePath,
+      PlanModeState(PlanPending, PlanActive) )
+import Agent.Tools.Secret ()
+import Agent.Tools.Types ()
+import Agent.XAI.LoopBackend ()
+import Control.Applicative ()
+import Control.Concurrent.Async ( withAsync )
+import Control.Concurrent.Chan ()
+import Control.Concurrent.MVar ( withMVar )
+import Control.Concurrent.STM ()
+import Control.Exception ( AsyncException(UserInterrupt) )
+import Control.Exception.Safe ( finally, throwIO )
+import Control.Monad ( when, forM_ )
+import Data.IORef ( newIORef, readIORef, writeIORef )
+import Data.List ( findIndex )
+import Data.Maybe ( fromMaybe, isJust, isNothing, listToMaybe )
+import Data.Text ( Text )
+import Data.Time.Clock ( getCurrentTime )
+import System.Console.ANSI ( getTerminalSize )
+import System.Console.ANSI.Codes ( clearFromCursorToLineEndCode )
+import System.Directory.OsPath ()
+import System.Environment ()
+import System.Exit ()
+import System.IO ( stdout, hFlush, stderr )
+import System.OsPath ( takeDirectory )
+import System.Posix.Files ()
+import qualified Data.ByteString as BS ( length )
+import qualified Agent.Responses.GenericClient as GenericResponses
+    ()
+import qualified Agent.MCP as MCP ()
+import qualified Data.Map.Strict as Map ()
+import qualified Agent.OpenAI.Auth as OpenAI ()
+import qualified Agent.OpenRouter as OpenRouter ()
+import qualified Agent.OpenRouter.Usage as OpenRouterUsage
+    ( fetchOpenRouterUsage )
+import qualified Agent.Provider as Provider ()
+import qualified Agent.CLI.Session.Lifecycle as SessionLifecycle
+    ( finishTurn, runPendingTurn )
+import qualified Agent.CLI.Session.Runner as SessionRunner ()
+import qualified Data.Set as Set ( toAscList )
+import qualified Data.Text as Text
+    ( intercalate, null, strip, unlines, pack )
+import qualified Data.Text.IO as Text
+    ( putStr, putStrLn, hPutStrLn )
+import qualified Agent.XAI.Options as XAI ()
+import qualified Agent.XAI.Usage as XAIUsage ( fetchGrokUsage )
+
+sessionContinuation :: SessionContinuation
+sessionContinuation =
+    SessionContinuation
+        { resumeSession = repl
+        , resumeSessionWithDraft = replWithDraft
+        }
+
+runPendingTurn
+    :: PendingTurnPresentation
+    -> SessionEnv
+    -> PendingTurn
+    -> IO RunResult
+runPendingTurn = SessionLifecycle.runPendingTurn sessionContinuation
+
+finishTurn
+    :: SessionEnv
+    -> Bool
+    -> TurnResult
+    -> IO RunResult
+finishTurn = SessionLifecycle.finishTurn sessionContinuation
+
+repl :: SessionEnv -> IO RunResult
+repl env = replWithDraft env ""
+
+replWithDraft :: SessionEnv -> Text -> IO RunResult
+replWithDraft env@SessionEnv
+    { sessionCompact = compactRunner
+    , sessionRender = render
+    , sessionConversation = conversationRef
+    , sessionProvider = provider
+    , sessionConnection = connectionId
+    , sessionModelCatalog = catalog
+    , sessionDialect = dialect
+    , sessionStartupUnavailable = startupUnavailableRef
+    , sessionParams = paramsRef
+    , sessionPolicy = policyRef
+    , sessionPersist = persist
+    , sessionDatabasePool = databasePool
+    , sessionPlanMode = planMode
+    , sessionProjectRoot = projectRoot
+    , sessionCwd = cwd
+    , sessionTokenProvider = tokenProvider
+    , sessionOpenAiPool = openAiPool
+    , sessionSkills = skillsRef
+    , sessionSkillInvocations = skillInvocationsRef
+    , sessionRefreshSkills = refreshSkills
+    , sessionActiveToolNames = readActiveToolNames
+    , sessionGrokRuntime = grokRuntime
+    , sessionDraft = draftRef
+    , sessionPreviewId = previewIdRef
+    , sessionInterrupt = interrupt
+    , sessionStoreRoot = storeRoot
+    , sessionUsage = usageRef
+    , sessionAccount = accountRef
+    , sessionAccountId = accountIdRef
+    , sessionAccountSelectionId = selectionRef
+    , sessionSelectAccount = selectAccount
+    , sessionLastAssistant = lastAssistantRef
+    , sessionTerminal = terminal
+    , sessionFullscreen = fullscreen
+    , sessionSetWindowTitle = setWindowTitle
+    , sessionAgentViewport = agentViewport
+    , sessionConcurrentLimit = _
+    , sessionSetConcurrentLimit = _
+    , sessionReset = sessionReset
+    } draft = do
+    writeIORef draftRef draft
+    refreshSkills False
+    skillInvocations <- readIORef skillInvocationsRef
+    let skillCommands =
+            map skillInvocationCommand
+                (filter (.invocationSkill.skillUserInvocable) skillInvocations)
+    activeToolNames <- readActiveToolNames
+    let slashCatalog =
+            mkSlashCatalog
+                (dialectId dialect)
+                activeToolNames
+                skillCommands
+                (catalogModelIds catalog)
+    stdoutColor <- resolveColor stdout
+    planState <- readIORef planMode.planStateRef
+    let planActive = planState == PlanActive
+        planPending = planState == PlanPending
+    params <- readIORef paramsRef
+    policy <- readIORef policyRef
+    pendingAttachments <- readLiveAttachments conversationRef
+    let idleMode = replModeFromState planState policy
+    usage <- readIORef usageRef
+    account <- readIORef accountRef
+    mlineResult <- case fullscreen of
+        Just runtime -> do
+            setFullscreenImagePreviews runtime pendingAttachments
+            let promptState =
+                    buildPromptState
+                        params
+                        planState
+                        policy
+                        account
+                        (isJust selectAccount)
+                        usage
+                        (length pendingAttachments)
+                readPrompt =
+                    readIORef startupUnavailableRef >>= \case
+                        Nothing ->
+                            Right
+                                <$> readFullscreenLineWithCatalog
+                                    runtime
+                                    slashCatalog
+                                    promptState
+                                    draft
+                        Just unavailable ->
+                            readFullscreenLineOrWithCatalog
+                                runtime
+                                slashCatalog
+                                promptState
+                                draft
+                                unavailable
+            withAsync (refreshAccountLimit runtime) \_ ->
+                readPrompt
+        Nothing -> Right <$> withMVar render.renderLock \_ -> do
+            -- The inline editor redraws its ANSI frame with several writes.
+            -- Keep the renderer out for the complete prompt lifetime so a
+            -- late tool event cannot be spliced into the composer row.
+            when terminal.terminalSemanticPrompts $
+                emitTerminalSequence terminal stdout osc133PromptStart
+            termCols <- fmap snd <$> getTerminalSize
+            case agentViewport of
+                Nothing -> pure ()
+                Just viewport -> do
+                    entries <- viewport.viewportEntries
+                    selected <- readIORef viewport.viewportSelected
+                    let panel =
+                            renderAgentViewportPanelFor
+                                stdoutColor
+                                (fromMaybe 100 termCols)
+                                selected
+                                entries
+                    when (not (Text.null panel)) (Text.putStrLn panel)
+            -- Status sits on the line above λ in minimal mode.
+            withSynchronizedOutput terminal stdout do
+                Text.putStrLn $ formatReplStatusLine stdoutColor termCols
+                    (currentModel params)
+                    (currentEffort params)
+                    idleMode
+                    account
+                    usage
+                hFlush stdout
+            let modeTag
+                    | planActive = roleWarn stdoutColor "[plan] "
+                    | planPending = roleMuted stdoutColor "[plan…] "
+                    | idleMode == ReplModeAlwaysApprove =
+                        roleSuccess stdoutColor "[yolo] "
+                    | otherwise = ""
+                chromePrompt =
+                    beginBackground stdoutColor userBackground
+                        <> modeTag
+                        <> if null pendingAttachments
+                            then ""
+                            else roleMuted stdoutColor
+                                ("[📎 " <> Text.pack (show (length pendingAttachments)) <> "] ")
+                        <> rolePrompt stdoutColor "λ "
+                        <> if stdoutColor
+                            then Text.pack clearFromCursorToLineEndCode
+                            else mempty
+            result <- readReplLineWithCatalog
+                slashCatalog
+                interrupt chromePrompt draft
+            when terminal.terminalSemanticPrompts $
+                emitTerminalSequence terminal stdout osc133PromptEnd
+            Text.putStr (endBackground stdoutColor)
+            hFlush stdout
+            pure result
+    case mlineResult of
+        Left apiError -> do
+            -- The startup check is one-shot. If no fallback account is usable,
+            -- leave request-time error handling in charge of later submits.
+            writeIORef startupUnavailableRef Nothing
+            requestStartupProviderFallback env apiError >>= \case
+                Just providerTransition ->
+                    pure (RunSwitchProvider providerTransition)
+                Nothing -> do
+                    reportProviderUnavailable fullscreen apiError
+                    replWithDraft env ""
+        Right mline -> do
+            -- Any user action wins the startup race. In particular, a prompt
+            -- already submitted while the preflight was running proceeds on
+            -- the selected provider and leaves request-time fallback in charge.
+            writeIORef startupUnavailableRef Nothing
+            handleReplLine
+                slashCatalog
+                skillInvocations
+                stdoutColor
+                planState
+                policy
+                mline
+  where
+    refreshAccountLimit runtime =
+        case (provider, tokenProvider) of
+            (XAIProvider, Just tokens)
+                | tokenProviderBillingMode tokens == SubscriptionBilled ->
+                    refreshWith
+                        tokens
+                        XAIUsage.fetchGrokUsage
+                        formatGrokLimitStatus
+            (OpenAIProvider, Just tokens)
+                | tokenProviderBillingMode tokens == SubscriptionBilled ->
+                    getNextToken tokens Nothing >>= \case
+                        Left _ -> pure ()
+                        Right credential
+                            | Text.null (Text.strip credential.accountId) ->
+                                pure ()
+                            | otherwise ->
+                                fetchUsage
+                                    credential.accessToken
+                                    credential.accountId >>= \case
+                                        Left _ -> pure ()
+                                        Right snapshot ->
+                                            publish
+                                                (formatOpenAiLimitStatus snapshot)
+            (OpenRouterProvider, Just tokens) ->
+                getNextToken tokens Nothing >>= \case
+                    Left _ -> pure ()
+                    Right credential ->
+                        OpenRouterUsage.fetchOpenRouterUsage
+                            credential.accessToken >>= \case
+                                Left _ -> pure ()
+                                Right snapshot ->
+                                    publish
+                                        (formatOpenRouterLimitStatus snapshot)
+            _ -> pure ()
+      where
+        refreshWith tokens fetch formatStatus =
+            getNextToken tokens Nothing >>= \case
+                Left _ -> pure ()
+                Right credential ->
+                    fetch credential >>= \case
+                        Left _ -> pure ()
+                        Right snapshot -> publish (formatStatus snapshot)
+        publish limitStatus =
+            forM_
+                limitStatus
+                (emitUiEvent runtime . UiSetPromptLimitStatus . Just)
+
+    handleReplLine
+            slashCatalog skillInvocations
+            stdoutColor planState policy = \case
+        ReplEof -> do
+            when (isNothing fullscreen) $
+                putStrLn ""
+            pure RunQuit
+        ReplQuitInterrupt ->
+            -- Confirmed double Ctrl-C: rethrow so withInterruptResume prints
+            -- the --resume hint and the process exits.
+            throwIO UserInterrupt
+        ReplCycleMode keptDraft
+            | provider == ClaudeCodeProvider -> do
+                let message =
+                        "Claude Code permissions are fixed when the provider starts; restart with --yolo or --no-yolo to change them."
+                color <- resolveColor stderr
+                displayInfo message $
+                    putTextLn stderr (roleMuted color message)
+                continueWith keptDraft
+            | otherwise -> do
+                let next = cycleReplInteraction planState policy
+                applyReplMode planMode policyRef projectRoot next
+                case fullscreen of
+                    Just runtime ->
+                        emitUiEvent runtime $
+                            UiSetNotice $
+                                Just $
+                                    infoNotice
+                                        ("Switched to "
+                                            <> replModeLabel next
+                                            <> " mode.")
+                    Nothing -> do
+                        -- Minimal editor advanced a line; replace its old chrome.
+                        putStr "\ESC[2A\r\ESC[J"
+                        hFlush stdout
+                continueWith keptDraft
+        ReplClipboardPaste keptDraft clipboardPasteImages -> do
+            case clipboardPasteImages of
+                Just images@(_:_) -> do
+                    message <- queueAttachedImages
+                        conversationRef
+                        previewIdRef
+                        stdoutColor
+                        (isNothing fullscreen)
+                        images
+                    syncFullscreenImagePreviews
+                    fullscreenEvent (UiSetNotice Nothing)
+                    displayInfo message $
+                        Text.putStrLn
+                            (roleMuted stdoutColor
+                                (glyphOk <> message))
+                _ ->
+                    queueClipboardImages
+                        conversationRef
+                        previewIdRef
+                        stdoutColor
+                        (isNothing fullscreen)
+                        >>= \case
+                            Left err ->
+                                displayError err do
+                                    errColor <- resolveColor stderr
+                                    Text.hPutStrLn stderr (roleError errColor err)
+                            Right message -> do
+                                syncFullscreenImagePreviews
+                                displayInfo message $
+                                    Text.putStrLn
+                                        (roleMuted stdoutColor
+                                            (glyphOk <> message))
+            continueWith keptDraft
+        ReplClipboardPasteOrText keptDraft pasted pastedDraft -> do
+            pastedImages <- loadImagesFromPastedText pasted
+            imagesResult <- case pastedImages of
+                Just images@(_:_) -> pure (Just images)
+                _ ->
+                    nonEmptyClipboardImages
+                        <$> readClipboardImagesImageFirst
+            case imagesResult of
+                Just images -> do
+                    message <- queueAttachedImages
+                        conversationRef
+                        previewIdRef
+                        stdoutColor
+                        (isNothing fullscreen)
+                        images
+                    syncFullscreenImagePreviews
+                    fullscreenEvent (UiSetNotice Nothing)
+                    displayInfo message $
+                        Text.putStrLn
+                            (roleMuted stdoutColor
+                                (glyphOk <> message))
+                    continueWith keptDraft
+                _ -> do
+                    fullscreenEvent (UiSetNotice Nothing)
+                    continueWith pastedDraft
+        ReplChooseModel keptDraft -> do
+            writeIORef draftRef keptDraft
+            chooseModel (continueWith keptDraft)
+        ReplChooseEffort keptDraft ->
+            chooseEffort (continueWith keptDraft)
+        ReplChooseAccount keptDraft -> do
+            writeIORef draftRef keptDraft
+            chooseAccount (continueWith keptDraft)
+        ReplPasted pasted ->
+            submitLine slashCatalog skillInvocations
+                continue stdoutColor True pasted
+        ReplText line ->
+            submitLine slashCatalog skillInvocations
+                continue stdoutColor False line
+    submitLine
+            slashCatalog skillInvocations
+            continue color pasted line = do
+        attachmentCount <- length <$> readLiveAttachments conversationRef
+        case submissionPromptText attachmentCount line of
+            Nothing -> continue
+            Just promptLine -> do
+                let stripped = Text.strip promptLine
+                when pasted do
+                    let chip = formatPasteChip stripped
+                    when (chip /= stripped && isNothing fullscreen) do
+                        Text.putStrLn (roleMuted color chip)
+                case parseReplLineWithCatalog slashCatalog promptLine of
+                    ReplQuit -> pure RunQuit
+                    ReplReload -> requestReload fullscreen persist
+                    ReplPrompt text -> do
+                        -- Native Cmd+V of a Finder image often pastes a path
+                        -- rather than bitmap bytes. Treat a prompt that is
+                        -- only image path(s) as an attach + in-terminal preview,
+                        -- matching Grok Build's paste chip.
+                        pastedImages <- loadImagesFromPastedText text
+                        case pastedImages of
+                            Just images@(_:_) -> do
+                                message <- queueAttachedImages
+                                    conversationRef
+                                    previewIdRef
+                                    color
+                                    (isNothing fullscreen)
+                                    images
+                                syncFullscreenImagePreviews
+                                displayInfo message $
+                                    Text.putStrLn
+                                        (roleMuted color
+                                            (glyphOk <> message))
+                                continue
+                            _ -> do
+                                pendingImages <- modifyLiveAttachments conversationRef \imgs -> ([], imgs)
+                                forM_ fullscreen \runtime ->
+                                    setFullscreenImagePreviews runtime []
+                                resetRenderPrintedText render
+                                let turnInputs =
+                                        if null pendingImages
+                                            then [UserMessage text]
+                                            else
+                                                [ UserMultimodal
+                                                    { userText = text
+                                                    , userImages = pendingImages
+                                                    }
+                                                ]
+                                preparePromptSkillInputs env text turnInputs >>= \case
+                                    Left err -> do
+                                        displayError err $
+                                            Text.hPutStrLn stderr
+                                                (roleError color err)
+                                        continue
+                                    Right skillInputs -> do
+                                        fullscreenEvent (UiUserSubmitted text)
+                                        result <- runOneTurn env text skillInputs
+                                        finishTurn env False result
+                    ReplExpandedPrompt original expanded ->
+                        submitExpandedTurn
+                            continue color original expanded
+                    ReplInvokeSkill invocationName arguments ->
+                        case resolveSkillInvocation
+                            skillInvocations invocationName of
+                            Left err -> do
+                                displayError err $
+                                    Text.hPutStrLn stderr
+                                        (roleError color err)
+                                continue
+                            Right invocation -> do
+                                pendingImages <-
+                                    modifyLiveAttachments conversationRef
+                                        \imgs -> ([], imgs)
+                                forM_ fullscreen \runtime ->
+                                    setFullscreenImagePreviews runtime []
+                                let userText =
+                                        if Text.null arguments
+                                            then "Use the "
+                                                <> invocation.invocationSkill.skillName
+                                                <> " skill."
+                                            else arguments
+                                    userInput =
+                                        if null pendingImages
+                                            then UserMessage userText
+                                            else UserMultimodal
+                                                { userText = userText
+                                                , userImages = pendingImages
+                                                }
+                                    skillInputs =
+                                        [ UserMessage
+                                            (formatSkillActivation
+                                                invocation arguments)
+                                        , userInput
+                                        ]
+                                resetRenderPrintedText render
+                                fullscreenEvent (UiUserSubmitted line)
+                                result <- runOneTurn env line skillInputs
+                                finishTurn env False result
+                    ReplSkills reloadFirst -> do
+                        when reloadFirst (refreshSkills True)
+                        current <- readIORef skillsRef
+                        invocations <- readIORef skillInvocationsRef
+                        let listing =
+                                formatSkillsListing color current invocations
+                        displayInfo (formatSkillsListing False current invocations) $
+                            Text.putStrLn listing
+                        continue
+                    ReplShowShell -> do
+                        mode <- env.sessionShellMode
+                        let message = "shell tools: " <> case mode of
+                                ShellGhci -> "ghci"
+                                ShellBash -> "bash"
+                                ShellBoth -> "ghci + bash"
+                                ShellNone -> "none"
+                        displayInfo message $
+                            Text.putStrLn
+                                (roleMuted color (glyphSession <> message))
+                        continue
+                    ReplSetShell mode -> do
+                        message <- env.sessionSetShellMode mode
+                        displayInfo message $
+                            Text.putStrLn
+                                (roleMuted color (glyphOk <> message))
+                        continue
+                    ReplPaste pasteImmediate pasteCaption -> do
+                        color <- resolveColor stdout
+                        errColor <- resolveColor stderr
+                        imagesResult <- readClipboardImagesForPaste
+                        case imagesResult of
+                            Left err -> do
+                                displayError err $
+                                    Text.hPutStrLn stderr
+                                        (roleError errColor err)
+                                continue
+                            Right [] -> do
+                                displayError "no image found on the clipboard" $
+                                    Text.hPutStrLn stderr
+                                        (roleError errColor
+                                            "no image found on the clipboard")
+                                continue
+                            Right images -> do
+                                let sizes =
+                                        Text.intercalate ", "
+                                            [ img.imageMime <> " (" <> formatImageSize (BS.length img.imageBytes) <> ")"
+                                            | img <- images
+                                            ]
+                                if pasteImmediate
+                                    then do
+                                        let promptText =
+                                                if Text.null pasteCaption
+                                                    then "See attached image."
+                                                    else pasteCaption
+                                        when (isNothing fullscreen) $
+                                            putImagePreview previewIdRef color images
+                                        displayInfo ("pasted " <> sizes) $
+                                            Text.putStrLn
+                                                (roleMuted color
+                                                    (glyphOk <> "pasted " <> sizes))
+                                        resetRenderPrintedText render
+                                        fullscreenEvent
+                                            (UiUserSubmitted promptText)
+                                        let turnInputs =
+                                                [ UserMultimodal
+                                                    { userText = promptText
+                                                    , userImages = images
+                                                    }
+                                                ]
+                                        result <- runOneTurn env promptText turnInputs
+                                        finishTurn env False result
+                                    else do
+                                        message <- queueAttachedImages
+                                            conversationRef
+                                            previewIdRef
+                                            color
+                                            (isNothing fullscreen)
+                                            images
+                                        syncFullscreenImagePreviews
+                                        displayInfo message $
+                                            Text.putStrLn
+                                                (roleMuted color
+                                                    (glyphOk <> message))
+                                        continue
+                    ReplShowAttachments -> do
+                        pending <- readLiveAttachments conversationRef
+                        color <- resolveColor stdout
+                        let message =
+                                if null pending
+                                    then "attachments: (none)"
+                                    else "attachments: "
+                                        <> Text.intercalate ", "
+                                            [ img.imageMime
+                                                <> " ("
+                                                <> formatImageSize
+                                                    (BS.length img.imageBytes)
+                                                <> ")"
+                                            | img <- pending
+                                            ]
+                        displayInfo message $
+                            Text.putStrLn
+                                (roleMuted color (glyphSession <> message))
+                        continue
+                    ReplClearAttachments -> do
+                        modifyLiveAttachments conversationRef (\_ -> ([], ()))
+                        forM_ fullscreen \runtime ->
+                            setFullscreenImagePreviews runtime []
+                        color <- resolveColor stdout
+                        displayInfo "attachments cleared" $
+                            Text.putStrLn
+                                (roleMuted color
+                                    (glyphOk <> "attachments cleared"))
+                        continue
+                    ReplShowAgentLimit -> do
+                        limit <- env.sessionConcurrentLimit
+                        let message =
+                                "concurrent agent limit: "
+                                    <> Text.pack (show limit)
+                        color <- resolveColor stdout
+                        displayInfo message $
+                            Text.putStrLn
+                                (roleMuted color (glyphSession <> message))
+                        continue
+                    ReplSetAgentLimit limit -> do
+                        message <- env.sessionSetConcurrentLimit limit
+                        color <- resolveColor stdout
+                        displayInfo message $
+                            Text.putStrLn
+                                (roleMuted color (glyphOk <> message))
+                        continue
+                    ReplAgents -> do
+                        case agentViewport of
+                            Nothing -> continue
+                            Just viewport -> do
+                                entries <- viewport.viewportEntries
+                                selected <- readIORef viewport.viewportSelected
+                                color <- resolveColor stderr
+                                pickAgentChoice
+                                    fullscreen color selected entries >>= \case
+                                    Nothing -> pure ()
+                                    Just target ->
+                                        viewport.viewportSelect target
+                                continue
+                    ReplMcp -> do
+                        color <- resolveColor stderr
+                        restart <-
+                            legacy $
+                                runMcpManager
+                                    color
+                                    env.sessionHome
+                                    env.sessionMcpRegistrations
+                                    env.sessionMcpWarnings
+                        if restart
+                            then requestMcpRestart
+                                fullscreen persist
+                            else continue
+                    ReplGoalStatus -> do
+                        color <- resolveColor stdout
+                        case grokRuntime of
+                            Nothing ->
+                                displayError
+                                    "goal commands are unavailable in this session" $
+                                    Text.hPutStrLn stderr
+                                        (roleError color
+                                            "goal commands are unavailable in this session")
+                            Just control ->
+                                readGoal control.grokGoalRuntime >>= \case
+                                    Nothing ->
+                                        displayInfo "No goal is active." $
+                                            Text.putStrLn
+                                                (roleMuted color
+                                                    "No goal is active.")
+                                    Just goal -> do
+                                        let message =
+                                                formatGoalSnapshot goal
+                                        displayInfo message $
+                                            Text.putStrLn
+                                                (roleMuted color message)
+                        continue
+                    ReplGoalPause -> do
+                        color <- resolveColor stderr
+                        case grokRuntime of
+                            Nothing ->
+                                displayError
+                                    "goal commands are unavailable in this session" $
+                                    Text.hPutStrLn stderr
+                                        (roleError color
+                                            "goal commands are unavailable in this session")
+                            Just control ->
+                                pauseGoal control.grokGoalRuntime >>= \case
+                                    Left err ->
+                                        displayError err $
+                                            Text.hPutStrLn stderr
+                                                (roleError color err)
+                                    Right goal -> do
+                                        let message =
+                                                "Goal paused.\n"
+                                                    <> formatGoalSnapshot goal
+                                        displayInfo message $
+                                            Text.hPutStrLn stderr
+                                                (roleMuted color message)
+                        continue
+                    ReplGoalResume -> do
+                        color <- resolveColor stderr
+                        case grokRuntime of
+                            Nothing ->
+                                displayError
+                                    "goal commands are unavailable in this session" $
+                                    Text.hPutStrLn stderr
+                                        (roleError color
+                                            "goal commands are unavailable in this session")
+                            Just control ->
+                                resumeGoal control.grokGoalRuntime >>= \case
+                                    Left err ->
+                                        displayError err $
+                                            Text.hPutStrLn stderr
+                                                (roleError color err)
+                                    Right goal -> do
+                                        let message =
+                                                "Goal resumed.\n"
+                                                    <> formatGoalSnapshot goal
+                                        displayInfo message $
+                                            Text.hPutStrLn stderr
+                                                (roleMuted color message)
+                        continue
+                    ReplGoalClear -> do
+                        color <- resolveColor stderr
+                        case grokRuntime of
+                            Nothing ->
+                                displayError
+                                    "goal commands are unavailable in this session" $
+                                    Text.hPutStrLn stderr
+                                        (roleError color
+                                            "goal commands are unavailable in this session")
+                            Just control -> do
+                                cleared <-
+                                    clearGoal control.grokGoalRuntime
+                                let message =
+                                        if cleared
+                                            then "Goal cleared."
+                                            else "No goal was active."
+                                displayInfo message $
+                                    Text.hPutStrLn stderr
+                                        (roleMuted color message)
+                        continue
+                    ReplGoalSet original objective budget expanded ->
+                        case grokRuntime of
+                            Nothing -> do
+                                color <- resolveColor stderr
+                                let err =
+                                        "goal commands are unavailable in this session"
+                                displayError err $
+                                    Text.hPutStrLn stderr
+                                        (roleError color err)
+                                continue
+                            Just control ->
+                                activateGoal
+                                    control.grokGoalRuntime
+                                    objective
+                                    budget >>= \case
+                                        Left err -> do
+                                            color <- resolveColor stderr
+                                            displayError err $
+                                                Text.hPutStrLn stderr
+                                                    (roleError color err)
+                                            continue
+                                        Right _ ->
+                                            submitExpandedTurn
+                                                continue
+                                                color
+                                                original
+                                                expanded
+                    ReplWorkflowRuns -> do
+                        color <- resolveColor stdout
+                        case grokRuntime >>= (.grokWorkflowRuntime) of
+                            Nothing ->
+                                displayError
+                                    "workflow commands are unavailable in this session" $
+                                    Text.hPutStrLn stderr
+                                        (roleError color
+                                            "workflow commands are unavailable in this session")
+                            Just runtime -> do
+                                runs <- workflowRunSnapshots runtime
+                                let message = formatWorkflowRuns runs
+                                displayInfo message $
+                                    Text.putStrLn
+                                        (roleMuted color message)
+                        continue
+                    ReplWorkflowManage operation target -> do
+                        color <- resolveColor stderr
+                        let err =
+                                "workflow_management_unsupported: /workflow "
+                                    <> operation
+                                    <> maybe "" (" " <>) target
+                                    <> " is not supported by this host; use /workflow runs to inspect tracked runs."
+                        displayError err $
+                            Text.hPutStrLn stderr
+                                (roleError color err)
+                        continue
+
+                    ReplCopyLast -> do
+                        answer <- readIORef lastAssistantRef
+                        copyCommand
+                            "last response"
+                            "no assistant response to copy"
+                            answer
+                        continue
+                    ReplCopyCode index -> do
+                        answer <- readIORef lastAssistantRef
+                        let label =
+                                "code block " <> Text.pack (show index)
+                        copyCommand
+                            label
+                            (label <> " was not found")
+                            (answer >>= fencedCodeBlock index)
+                        continue
+                    ReplCopyDiff -> do
+                        answer <- readIORef lastAssistantRef
+                        copyCommand
+                            "diff block"
+                            "no diff block was found"
+                            (answer >>= lastDiffBlock)
+                        continue
+                    ReplCopyPath -> do
+                        copyCommand
+                            "worktree path"
+                            "worktree path is unavailable"
+                            (Just (toText cwd))
+                        continue
+                    ReplCopySession -> do
+                        sessionId <- currentSessionId persist
+                        copyCommand
+                            "session id"
+                            "this session has no persisted id yet"
+                            sessionId
+                        continue
+                    ReplShowTerminal -> do
+                        let message = formatTerminalCapabilities terminal
+                        displayInfo message $
+                            Text.putStrLn (roleMuted color message)
+                        continue
+                    ReplShowEffort -> do
+                        color <- resolveColor stdout
+                        params <- readIORef paramsRef
+                        let message = "effort: " <> currentEffort params
+                        displayInfo message $
+                            Text.putStrLn
+                                (roleMuted color (glyphSession <> message))
+                        continue
+                    ReplSetEffort level -> do
+                        setEffort level
+                        continue
+                    ReplShowModel -> do
+                        chooseModel continue
+                    ReplSetModel name -> do
+                        color <- resolveColor stdout
+                        let rawChoice = rawModelOption provider name
+                        choice <-
+                            resolveModelOptionDialect $
+                                fromMaybe
+                                    (rawChoice
+                                        { modelTarget =
+                                            rawChoice.modelTarget
+                                                { targetConnectionId = connectionId
+                                                , targetDialect = dialectId dialect
+                                                }
+                                        })
+                                    (resolveConfiguredModel catalog name)
+                        if modelTargetRequiresRebuild
+                                connectionId provider (dialectId dialect) choice
+                            then
+                                requestModelTargetSwitch
+                                    fullscreen choice persist >>= \case
+                                    Left err -> do
+                                        displayError err $
+                                            Text.hPutStrLn stderr
+                                                (roleError color err)
+                                        continue
+                                    Right result -> pure result
+                            else do
+                                message <- applyModelChange
+                                    projectRoot provider connectionId name
+                                    choice.modelTarget.targetWireModelId
+                                    choice.modelTarget.targetDialect
+                                    paramsRef render conversationRef persist
+                                displayInfo message $
+                                    Text.putStrLn
+                                        (roleMuted color (glyphOk <> message))
+                                continue
+                    ReplToggleAlwaysApprove
+                        | provider == ClaudeCodeProvider -> do
+                            let message =
+                                    "Claude Code permissions are fixed for this provider session; restart with --yolo or --no-yolo."
+                            color <- resolveColor stderr
+                            displayInfo message $
+                                putTextLn stderr (roleMuted color message)
+                            continue
+                        | otherwise -> do
+                            message <- toggleAlwaysApprove policyRef projectRoot
+                            color <- resolveColor stderr
+                            displayInfo message $
+                                putTextLn stderr (roleMuted color message)
+                            continue
+                    ReplCompact focus -> do
+                        color <- resolveColor stderr
+                        result <-
+                            withReplActivity "Compacting context…" $
+                                compactRunner focus
+                        case result of
+                            Left err -> do
+                                displayError err $
+                                    Text.hPutStrLn stderr (roleError color err)
+                                continue
+                            Right outcome -> do
+                                fullscreenEvent UiConversationCleared
+                                fullscreenEvent
+                                    (UiSystemMessage outcome.compactSummary)
+                                let message =
+                                        "compacted "
+                                            <> Text.pack
+                                                (show outcome.compactBeforeTokens)
+                                            <> " → "
+                                            <> Text.pack
+                                                (show outcome.compactAfterTokens)
+                                            <> " tokens ("
+                                            <> Text.pack
+                                                (show (length outcome.compactHistory))
+                                            <> " items)"
+                                displayInfo message $
+                                    Text.hPutStrLn stderr
+                                        (roleMuted color
+                                            (glyphSession <> message))
+                                case persist of
+                                    PersistenceDisabled -> pure ()
+                                    PersistenceEnabled slotRef -> do
+                                        now <- getCurrentTime
+                                        handle <- ensureSession slotRef
+                                        let turn = SessionTurn
+                                                { turnAt = now
+                                                , turnUserText = compactSessionUserText focus
+                                                , turnAssistantText = Just outcome.compactSummary
+                                                , turnError = Nothing
+                                                , turnResponseId = Nothing
+                                                , turnItems = outcome.compactHistory
+                                                -- Compaction response usage is
+                                                -- recorded immediately by
+                                                -- compactRunner, including
+                                                -- response-level failures.
+                                                , turnUsage = Nothing
+                                                }
+                                        handle' <-
+                                            appendTurnWithMetaUpdate handle turn
+                                                \meta -> meta
+                                                    { metaLastResponseId = Nothing
+                                                    }
+                                        writeIORef slotRef
+                                            (PersistenceActive handle')
+                                continue
+                    ReplPlan _
+                        | provider == ClaudeCodeProvider -> do
+                            let message =
+                                    "Outer plan mode is unavailable for Claude Code because its tools run inside the Claude CLI."
+                            color <- resolveColor stderr
+                            displayInfo message $
+                                putTextLn stderr (roleMuted color message)
+                            continue
+                    ReplPlan maybeDescription ->
+                        enterPlanFromSlash env maybeDescription >>= \case
+                            Just providerSwitch ->
+                                pure (RunSwitchProvider providerSwitch)
+                            Nothing -> continue
+                    ReplBtw question -> do
+                        runBtwQuestion True env question
+                        continue
+                    ReplRecap ->
+                        case fullscreen of
+                            Just runtime -> do
+                                emitUiEvent runtime UiRecapStarted
+                                env.sessionQueueRecap (RecapSession RecapManual)
+                                continue
+                            Nothing -> do
+                                runSessionRecap True env RecapManual
+                                continue
+                    ReplResume maybeId -> do
+                        handleResume databasePool fullscreen maybeId persist >>= \case
+                            Nothing -> continue
+                            Just result -> pure result
+                    ReplSearch query -> do
+                        handleConversationSearch
+                            databasePool fullscreen query persist >>= \case
+                                Nothing -> continue
+                                Just result -> pure result
+                    ReplClear -> do
+                        sessionReset
+                        fullscreenEvent UiConversationCleared
+                        color <- resolveColor stderr
+                        message <- case persist of
+                            PersistenceDisabled ->
+                                pure "conversation cleared"
+                            PersistenceEnabled slotRef -> do
+                                now <- getCurrentTime
+                                slot <- readIORef slotRef
+                                case slot of
+                                    PersistencePending _ _ _ ->
+                                        pure "conversation cleared"
+                                    PersistenceActive handle -> do
+                                        let turn = SessionTurn
+                                                { turnAt = now
+                                                , turnUserText = clearSessionUserText
+                                                , turnAssistantText =
+                                                    Just "Conversation cleared."
+                                                , turnError = Nothing
+                                                , turnResponseId = Nothing
+                                                , turnItems = []
+                                                , turnUsage = Nothing
+                                                }
+                                        handle' <- appendTurnKeepTitle handle turn
+                                        let meta = handle'.sessionMeta
+                                                { metaLastResponseId = Nothing
+                                                , metaUpdatedAt = now
+                                                , metaInputTokens = 0
+                                                , metaOutputTokens = 0
+                                                , metaCachedTokens = 0
+                                                , metaLastRecap = Nothing
+                                                , metaLastTurnSummary = Nothing
+                                                , metaLastRecapMainTurns = 0
+                                                }
+                                        writeSessionMeta
+                                            handle'.sessionPool
+                                            handle'.sessionMetaPath
+                                            meta
+                                        writeIORef slotRef
+                                            (PersistenceActive handle'{sessionMeta = meta})
+                                        pure
+                                            ("conversation cleared (session "
+                                                <> meta.metaId
+                                                <> ")")
+                        displayInfo message $
+                            Text.hPutStrLn stderr
+                                (roleMuted color (glyphOk <> message))
+                        continue
+                    ReplNew -> do
+                        sessionReset
+                        fullscreenEvent UiConversationCleared
+                        color <- resolveColor stderr
+                        case persist of
+                            PersistenceDisabled -> do
+                                displayInfo "started a fresh conversation" $
+                                    Text.hPutStrLn stderr
+                                        (roleMuted color
+                                            (glyphOk
+                                                <> "started a fresh conversation"))
+                                continue
+                            PersistenceEnabled slotRef -> do
+                                params <- readIORef paramsRef
+                                slot <- readIORef slotRef
+                                let model = currentModel params
+                                    effort = currentEffort params
+                                    create = case slot of
+                                        PersistencePending pending _ _ ->
+                                            pending
+                                                { createTarget =
+                                                    pending.createTarget
+                                                        { targetModelId = model }
+                                                , createEffort = effort
+                                                , createTitleHint = Nothing
+                                                , createTitleIsManual = False
+                                                }
+                                        PersistenceActive handle ->
+                                            SessionCreate
+                                                { createPool = handle.sessionPool
+                                                , createRoot =
+                                                    takeDirectory handle.sessionDir
+                                                , createTarget = ModelTarget
+                                                    { targetProvider = provider
+                                                    , targetConnectionId =
+                                                        connectionId
+                                                    , targetModelId = model
+                                                    , targetWireModelId =
+                                                        fromMaybe
+                                                            model
+                                                            handle.sessionMeta.metaTransportModel
+                                                    , targetDialect =
+                                                        dialectId dialect
+                                                    }
+                                                , createCwd =
+                                                    handle.sessionMeta.metaCwd
+                                                , createEffort = effort
+                                                , createTitleHint = Nothing
+                                                , createTitleIsManual = False
+                                                }
+                                handle <- createSession create
+                                case slot of
+                                    PersistencePending pending sessionId _ -> do
+                                        _ <- removeSessionTemp
+                                            pending.createRoot
+                                            sessionId
+                                        pure ()
+                                    PersistenceActive _ -> pure ()
+                                now <- getCurrentTime
+                                let turn = SessionTurn
+                                        { turnAt = now
+                                        , turnUserText = newSessionUserText
+                                        , turnAssistantText =
+                                            Just "Started a new session."
+                                        , turnError = Nothing
+                                        , turnResponseId = Nothing
+                                        , turnItems = []
+                                        , turnUsage = Nothing
+                                        }
+                                handle' <- appendTurnKeepTitle handle turn
+                                let meta = handle'.sessionMeta
+                                env.sessionOnPersisted handle'
+                                env.sessionSetTempDir handle'.sessionTempDir
+                                writeIORef slotRef
+                                    (PersistenceActive handle')
+                                writeIORef env.sessionTitleTurnCount 0
+                                writeIORef planMode.planSessionDir
+                                    (Just handle'.sessionDir)
+                                writeIORef storeRoot (Just handle'.sessionDir)
+                                setWindowTitle
+                                    (cliWindowTitle meta.metaCwd
+                                        (Just meta.metaTitle))
+                                let message = "new session: " <> meta.metaId
+                                displayInfo message $
+                                    Text.hPutStrLn stderr
+                                        (roleMuted color
+                                            (glyphOk <> message))
+                                continue
+                    ReplShowSession -> do
+                        color <- resolveColor stdout
+                        case persist of
+                            PersistenceDisabled ->
+                                displayInfo "session: (not persisted)" $
+                                    Text.putStrLn
+                                        (roleMuted color
+                                            "session: (not persisted)")
+                            PersistenceEnabled slotRef -> do
+                                slot <- readIORef slotRef
+                                case slot of
+                                    PersistencePending _ _ _ ->
+                                        displayInfo
+                                            "session: (pending until first turn)" $
+                                            Text.putStrLn
+                                                (roleMuted color
+                                                    "session: (pending until first turn)")
+                                    PersistenceActive handle ->
+                                        let message =
+                                                "session: "
+                                                    <> handle.sessionMeta.metaId
+                                        in displayInfo message $
+                                            Text.putStrLn
+                                                (roleMuted color
+                                                    (glyphSession <> message))
+                        continue
+                    ReplShowSessionInfo -> do
+                        color <- resolveColor stdout
+                        params <- readIORef paramsRef
+                        usage <- readIORef usageRef
+                        shellMode <- env.sessionShellMode
+                        (persistenceState, sessionId, sessionTitle) <-
+                            case persist of
+                                PersistenceDisabled ->
+                                    pure ("not_persisted", Nothing, Nothing)
+                                PersistenceEnabled slotRef -> do
+                                    slot <- readIORef slotRef
+                                    pure $ case slot of
+                                        PersistencePending _ pendingId _ ->
+                                            ("pending", Just pendingId, Nothing)
+                                        PersistenceActive handle ->
+                                            ( "active"
+                                            , Just handle.sessionMeta.metaId
+                                            , Just handle.sessionMeta.metaTitle
+                                            )
+                        let toolNames =
+                                Set.toAscList
+                                    slashCatalog.slashCatalogToolNames
+                            usageText =
+                                let formatted = formatTokenUsage usage
+                                in if Text.null formatted
+                                    then "0 in · 0 out"
+                                    else formatted
+                            message = Text.unlines $
+                                [ "session: "
+                                    <> fromMaybe "(not persisted)" sessionId
+                                , "state: " <> persistenceState
+                                ]
+                                    <> maybe
+                                        []
+                                        (\title -> ["title: " <> title])
+                                        sessionTitle
+                                    <> [ "provider: " <> providerSlug provider
+                                       , "connection: " <> connectionId
+                                       , "model: " <> currentModel params
+                                       , "dialect: "
+                                            <> dialectSlug
+                                                (dialectId dialect)
+                                       , "effort: " <> currentEffort params
+                                       , "cwd: " <> toText cwd
+                                       , "shell: "
+                                            <> shellModeText shellMode
+                                       , "tokens: " <> usageText
+                                       , "tools: "
+                                            <> if null toolNames
+                                                then "(none)"
+                                                else
+                                                    Text.intercalate
+                                                        ", "
+                                                        toolNames
+                                       ]
+                        displayInfo message $
+                            Text.putStrLn (roleMuted color message)
+                        continue
+                    ReplAfk rawTarget -> do
+                        let failAfk err = do
+                                color <- resolveColor stderr
+                                displayError err $
+                                    putTextLn stderr (roleError color err)
+                                continue
+                            finishAfk message = do
+                                color <- resolveColor stderr
+                                displayInfo message $
+                                    putTextLn stderr
+                                        (roleMuted color (glyphOk <> message))
+                                pure RunQuit
+                        case parseAfkTarget rawTarget of
+                            Left err -> failAfk err
+                            Right target -> case persist of
+                                PersistenceDisabled ->
+                                    failAfk "/afk requires a persisted interactive session"
+                                PersistenceEnabled slotRef ->
+                                    readIORef slotRef >>= \case
+                                        PersistencePending _ _ _ ->
+                                            failAfk
+                                                "/afk is available after the first persisted turn"
+                                        PersistenceActive handle ->
+                                            case target of
+                                                AfkLocal ->
+                                                    handoffLocal
+                                                        handle.sessionMeta.metaId
+                                                        cwd >>= \case
+                                                            Left err -> failAfk err
+                                                            Right message ->
+                                                                finishAfk message
+                                                AfkRemote host path ->
+                                                    loadSession
+                                                        databasePool
+                                                        (sessionsRoot env.sessionHome)
+                                                        handle.sessionMeta.metaId
+                                                        >>= \case
+                                                            Left err -> failAfk err
+                                                            Right (meta, turns) ->
+                                                                handoffRemote
+                                                                    host
+                                                                    path
+                                                                    handle.sessionDir
+                                                                    SessionTransfer
+                                                                        { transferMeta = meta
+                                                                        , transferTurns = turns
+                                                                        }
+                                                                    >>= \case
+                                                                        Left err -> failAfk err
+                                                                        Right message ->
+                                                                            finishAfk message
+                    ReplWorktree -> do
+                        result <- withReplActivity "Creating worktree…" $
+                            createWorktree cwd (worktreeRoot env.sessionHome)
+                        case result of
+                            Left err -> do
+                                color <- resolveColor stderr
+                                displayError err $
+                                    putTextLn stderr (roleError color err)
+                                continue
+                            Right path -> do
+                                color <- resolveColor stderr
+                                params <- readIORef paramsRef
+                                let message = "worktree: " <> toText path
+                                displayInfo message $
+                                    putTextLn stderr
+                                        (roleMuted color
+                                            (glyphSession <> message))
+                                pure
+                                    (RunSwitchWorktree
+                                        path
+                                        provider
+                                        (currentModel params)
+                                        (currentEffort params))
+                    ReplRename title -> do
+                        color <- resolveColor stderr
+                        case persist of
+                            PersistenceDisabled ->
+                                displayError
+                                    "cannot rename a session that is not persisted" $
+                                    putTextLn stderr
+                                        (roleError color
+                                            "cannot rename a session that is not persisted")
+                            PersistenceEnabled slotRef ->
+                                readIORef slotRef >>= \case
+                                    PersistencePending pending sessionId tempDir -> do
+                                        writeIORef slotRef
+                                            (PersistencePending
+                                                pending
+                                                    { createTitleHint = Just title
+                                                    , createTitleIsManual = True
+                                                    }
+                                                sessionId
+                                                tempDir)
+                                        setWindowTitle
+                                            (cliWindowTitle pending.createCwd
+                                                (Just title))
+                                        let message = "session title: " <> title
+                                        displayInfo message $
+                                            putTextLn stderr
+                                                (roleMuted color
+                                                    (glyphOk <> message))
+                                    PersistenceActive handle -> do
+                                        invalidateSessionTitles
+                                            env.sessionTitleManager
+                                            handle.sessionMeta.metaId
+                                        updated <- setManualSessionTitle title handle
+                                        writeIORef slotRef (PersistenceActive updated)
+                                        setWindowTitle
+                                            (cliWindowTitle updated.sessionMeta.metaCwd
+                                                (Just updated.sessionMeta.metaTitle))
+                                        let message =
+                                                "session title: "
+                                                    <> updated.sessionMeta.metaTitle
+                                        displayInfo message $
+                                            putTextLn stderr
+                                                (roleMuted color
+                                                    (glyphOk <> message))
+                        continue
+                    ReplRenameAuto -> do
+                        color <- resolveColor stderr
+                        case persist of
+                            PersistenceDisabled ->
+                                displayError
+                                    "cannot rename a session that is not persisted" $
+                                    putTextLn stderr
+                                        (roleError color
+                                            "cannot rename a session that is not persisted")
+                            PersistenceEnabled slotRef ->
+                                readIORef slotRef >>= \case
+                                    PersistencePending pending sessionId tempDir -> do
+                                        writeIORef slotRef
+                                            (PersistencePending
+                                                pending
+                                                    { createTitleHint = Nothing
+                                                    , createTitleIsManual = False
+                                                    }
+                                                sessionId
+                                                tempDir)
+                                        setWindowTitle
+                                            (cliWindowTitle pending.createCwd Nothing)
+                                        displayInfo
+                                            "automatic session titles enabled" $
+                                            putTextLn stderr
+                                                (roleMuted color
+                                                    (glyphOk
+                                                        <> "automatic session titles enabled"))
+                                    PersistenceActive handle -> do
+                                        invalidateSessionTitles
+                                            env.sessionTitleManager
+                                            handle.sessionMeta.metaId
+                                        updated <- resetSessionTitleToAuto handle
+                                        writeIORef slotRef (PersistenceActive updated)
+                                        loadSession
+                                            updated.sessionPool
+                                            (takeDirectory updated.sessionDir)
+                                            updated.sessionMeta.metaId
+                                            >>= \case
+                                                Left _ -> pure ()
+                                                Right (_, turns) -> do
+                                                    let source =
+                                                            sessionConversationText turns
+                                                    requestSessionTitle
+                                                        env.sessionTitleManager
+                                                        updated.sessionMeta.metaId
+                                                        1
+                                                        source
+                                        displayInfo
+                                            "automatic session titles enabled" $
+                                            putTextLn stderr
+                                                (roleMuted color
+                                                    (glyphOk
+                                                        <> "automatic session titles enabled"))
+                        continue
+                    ReplLogin -> do
+                        color <- resolveColor stderr
+                        legacy (runLoginManager color)
+                        continue
+                    ReplUsage -> do
+                        case fullscreen of
+                            Nothing ->
+                                showAccountUsage
+                                    provider tokenProvider openAiPool
+                            Just runtime ->
+                                accountUsageText
+                                    False provider tokenProvider openAiPool
+                                    >>= emitUiEvent runtime . UiSystemMessage
+                        continue
+                    ReplReloadAuth -> do
+                        reloadResult <- reloadAuth provider tokenProvider
+                        color <- resolveColor stderr
+                        case reloadResult of
+                            Left err ->
+                                displayError err $
+                                    putTextLn stderr (roleError color err)
+                            Right message ->
+                                displayInfo message $
+                                    putTextLn stderr (roleMuted color message)
+                        continue
+                    ReplHelp maybeName -> do
+                        color <- resolveColor stdout
+                        displayInfo
+                            (formatSlashHelpWithCatalog
+                                False slashCatalog maybeName) $
+                            Text.putStrLn
+                                (formatSlashHelpWithCatalog
+                                    color slashCatalog maybeName)
+                        continue
+                    ReplCommandError err -> do
+                        color <- resolveColor stderr
+                        displayError err $
+                            Text.hPutStrLn stderr (roleError color err)
+                        continue
+    submitExpandedTurn next color original expanded = do
+        pendingImages <-
+            modifyLiveAttachments conversationRef \imgs -> ([], imgs)
+        forM_ fullscreen \runtime ->
+            setFullscreenImagePreviews runtime []
+        let turnInputs =
+                if null pendingImages
+                    then [UserMessage expanded]
+                    else
+                        [ UserMultimodal
+                            { userText = expanded
+                            , userImages = pendingImages
+                            }
+                        ]
+        preparePromptSkillInputs env original turnInputs >>= \case
+            Left err -> do
+                displayError err $
+                    Text.hPutStrLn stderr (roleError color err)
+                next
+            Right skillInputs -> do
+                resetRenderPrintedText render
+                fullscreenEvent (UiUserSubmitted original)
+                result <- runOneTurn env original skillInputs
+                finishTurn env False result
+    continue = continueWith ""
+    continueWith keptDraft =
+        replWithDraft env keptDraft
+    legacy action = case fullscreen of
+        Nothing -> action
+        Just runtime -> withFullscreenSuspended runtime action
+    fullscreenEvent event = case fullscreen of
+        Nothing -> pure ()
+        Just runtime -> emitUiEvent runtime event
+    syncFullscreenImagePreviews =
+        forM_ fullscreen \runtime ->
+            readLiveAttachments conversationRef
+                >>= setFullscreenImagePreviews runtime
+    displayInfo message minimalAction = case fullscreen of
+        Nothing -> minimalAction
+        Just runtime -> emitUiEvent runtime (UiSystemMessage message)
+    displayError message minimalAction = case fullscreen of
+        Nothing -> minimalAction
+        Just runtime -> emitUiEvent runtime (UiErrorMessage message)
+    shellModeText = \case
+        ShellGhci -> "ghci"
+        ShellBash -> "bash"
+        ShellBoth -> "ghci + bash"
+        ShellNone -> "none"
+    withReplActivity message action = do
+        case fullscreen of
+            Nothing ->
+                renderEvent render (ActivityUpdated message)
+            Just runtime ->
+                emitUiEvent runtime
+                    (UiSetNotice (Just (progressNotice message)))
+        action `finally`
+            case fullscreen of
+                Nothing -> clearThinking render
+                Just runtime -> emitUiEvent runtime (UiSetNotice Nothing)
+    setEffort level = do
+        color <- resolveColor stdout
+        setSessionEffort env level
+        displayInfo ("effort set to " <> level) $
+            Text.putStrLn
+                (roleMuted color
+                    (glyphOk <> "effort set to " <> level))
+    chooseEffort next = do
+        params <- readIORef paramsRef
+        effortChoice fullscreen (currentEffort params) >>= \case
+            Nothing -> next
+            Just level -> setEffort level >> next
+    chooseModel next = do
+        color <- resolveColor stderr
+        params <- readIORef paramsRef
+        let current = currentModel params
+        modelChoice
+            catalog fullscreen color connectionId provider current
+                (dialectId dialect) >>= \case
+            Nothing -> next
+            Just rawChoice -> do
+                choice <- resolveModelOptionDialect rawChoice
+                if choice.modelTarget.targetProvider == provider
+                    && choice.modelTarget.targetConnectionId == connectionId
+                    && choice.modelTarget.targetModelId == current
+                    && choice.modelTarget.targetDialect == dialectId dialect
+                  then do
+                    let message =
+                            "model: "
+                                <> connectionId
+                                <> "/"
+                                <> choice.modelTarget.targetModelId
+                    displayInfo message $
+                        Text.putStrLn
+                            (roleMuted color
+                                (glyphSession <> message))
+                    next
+                  else if not
+                        (modelTargetRequiresRebuild
+                            connectionId provider (dialectId dialect) choice)
+                  then do
+                    message <- applyModelChange
+                        projectRoot provider connectionId
+                        choice.modelTarget.targetModelId
+                        choice.modelTarget.targetWireModelId
+                        choice.modelTarget.targetDialect
+                        paramsRef render conversationRef persist
+                    displayInfo message $
+                        Text.putStrLn
+                            (roleMuted color
+                                (glyphOk <> message))
+                    next
+                  else
+                    requestModelTargetSwitch fullscreen choice persist >>= \case
+                        Left err -> do
+                            displayError err $
+                                Text.hPutStrLn stderr
+                                    (roleError color err)
+                            next
+                        Right result -> pure result
+    chooseAccount next =
+        case fullscreen of
+            Just runtime -> do
+                currentSelectionId <- readIORef selectionRef
+                currentAccountId <- readIORef accountIdRef
+                options <- withReplActivity
+                    "Loading account usage…"
+                    (loadAllAccountPickerOptions provider)
+                let initial =
+                        fromMaybe 0 $
+                            findIndex
+                                (accountPickerMatches
+                                    provider
+                                    currentSelectionId
+                                    currentAccountId)
+                                options
+                requestFullscreenChoiceWithBody
+                    runtime
+                    "Accounts"
+                    "Choose any account. Switching provider also switches to its default model."
+                    initial
+                    (map
+                        (accountPickerRow
+                            provider
+                            currentSelectionId
+                            currentAccountId)
+                        options)
+                    >>= \case
+                        Just index
+                            | Just option <- atMay index options ->
+                                case option of
+                                    AccountPickerAccount
+                                        selectedProvider
+                                        selectedBilling
+                                        selectedSelectionId
+                                        selectedAccountId
+                                        selectedLabel
+                                        _
+                                            -- Claude exposes display metadata,
+                                            -- not a stable account identity.
+                                            -- Revalidate and restart even when
+                                            -- the synthetic id still matches.
+                                            | selectedProvider == provider
+                                            , selectedProvider
+                                                /= ClaudeCodeProvider
+                                            , selectedAccountId
+                                                == currentAccountId ->
+                                                displayInfo
+                                                    ("account: " <> selectedLabel)
+                                                    (pure ())
+                                                    >> next
+                                            | otherwise ->
+                                                chooseSelectedAccount
+                                                    selectedProvider
+                                                    selectedBilling
+                                                    selectedSelectionId
+                                                    selectedAccountId
+                                                    selectedLabel
+                                    AccountPickerConnect selectedProvider -> do
+                                        color <- resolveColor stderr
+                                        connected <-
+                                            withFullscreenSuspended runtime $
+                                                connectProviderAccount
+                                                    color
+                                                    selectedProvider
+                                        case connected of
+                                            Nothing -> next
+                                            Just selectedAccountId -> do
+                                                refreshed <-
+                                                    loadAllAccountPickerOptions
+                                                        provider
+                                                case listToMaybe
+                                                        [ account
+                                                        | account@(AccountPickerAccount
+                                                            accountProvider
+                                                            _
+                                                            _
+                                                            accountId
+                                                            _
+                                                            _) <- refreshed
+                                                        , accountProvider
+                                                            == selectedProvider
+                                                        , accountId
+                                                            == selectedAccountId
+                                                        ] of
+                                                    Just
+                                                        (AccountPickerAccount
+                                                            accountProvider
+                                                            billing
+                                                            selectionId
+                                                            accountId
+                                                            label
+                                                            _) ->
+                                                        chooseSelectedAccount
+                                                            accountProvider
+                                                            billing
+                                                            selectionId
+                                                            accountId
+                                                            label
+                                                    _ -> do
+                                                        displayError
+                                                            "Connected account could not be loaded."
+                                                            (pure ())
+                                                        next
+                        _ -> next
+              where
+                currentBilling =
+                    tokenProviderBillingMode
+                        <$> tokenProvider
+                chooseSelectedAccount
+                    selectedProvider
+                    selectedBilling
+                    selectedSelectionId
+                    selectedAccountId
+                    selectedLabel
+                        | selectedProvider == provider
+                        , Just selectedBilling == currentBilling
+                        , Just select <- selectAccount =
+                            let liveSelectionId =
+                                    case selectedProvider of
+                                        OpenAIProvider -> selectedAccountId
+                                        _ -> selectedSelectionId
+                            in select liveSelectionId >>= \case
+                                Left err -> do
+                                    now <- getCurrentTime
+                                    let message =
+                                            "could not select account: "
+                                                <> formatApiErrorInlineAt
+                                                    now
+                                                    err
+                                    displayError message (pure ())
+                                    next
+                                Right label -> do
+                                    displayInfo
+                                        ("account switched to " <> label)
+                                        (pure ())
+                                    next
+                        | otherwise =
+                            readIORef paramsRef >>= \params ->
+                                requestAccountProviderSwitch
+                                    catalog fullscreen provider connectionId
+                                    (currentModel params) (dialectId dialect)
+                                    selectedProvider selectedSelectionId
+                                    selectedAccountId persist >>= \case
+                                        Left err -> do
+                                            displayError err (pure ())
+                                            next
+                                        Right result -> do
+                                            displayInfo
+                                                ("switching to "
+                                                    <> selectedLabel
+                                                    <> " ("
+                                                    <> providerSlug
+                                                        selectedProvider
+                                                    <> ")")
+                                                (pure ())
+                                            pure result
+            Nothing -> do
+                displayError
+                    "Account switching is unavailable for this session."
+                    (pure ())
+                next
+    copyCommand label missing payload = case payload of
+        Nothing ->
+            displayError missing do
+                color <- resolveColor stderr
+                Text.hPutStrLn stderr (roleError color missing)
+        Just value -> do
+            copied <- copyTerminalClipboard terminal stdout value
+            if copied
+                then
+                    let message = "copied " <> label
+                    in displayInfo message do
+                        color <- resolveColor stderr
+                        Text.hPutStrLn stderr
+                            (roleSuccess color (glyphOk <> message))
+                else
+                    displayError "terminal clipboard is unavailable" do
+                        color <- resolveColor stderr
+                        Text.hPutStrLn stderr
+                            (roleError color
+                                "terminal clipboard is unavailable")
+
+requestReload
+    :: Maybe FullscreenRuntime
+    -> Persistence
+    -> IO RunResult
+requestReload fullscreen persist = do
+    color <- resolveColor stderr
+    let reportInfo message =
+            case fullscreen of
+                Nothing ->
+                    putTextLn stderr
+                        (roleMuted color (glyphSession <> message))
+                Just runtime ->
+                    emitUiEvent runtime (UiSystemMessage message)
+        reportError message =
+            case fullscreen of
+                Nothing ->
+                    putTextLn stderr (roleError color message)
+                Just runtime ->
+                    emitUiEvent runtime (UiErrorMessage message)
+    case persist of
+        PersistenceDisabled -> do
+            reportError ":reload needs a persisted REPL session"
+            pure RunQuit
+        PersistenceEnabled slotRef -> do
+            handle <- ensureSession slotRef
+            reportInfo ("reloading; session " <> handle.sessionMeta.metaId)
+            pure (RunReload handle.sessionMeta.metaId)
+
+requestMcpRestart
+    :: Maybe FullscreenRuntime
+    -> Persistence
+    -> IO RunResult
+requestMcpRestart fullscreen persist = do
+    color <- resolveColor stderr
+    let report message =
+            case fullscreen of
+                Nothing ->
+                    putTextLn stderr
+                        (roleMuted color (glyphSession <> message))
+                Just runtime ->
+                    emitUiEvent runtime (UiSystemMessage message)
+    case persist of
+        PersistenceDisabled -> do
+            report
+                "MCP configuration saved; restart the agent to apply it"
+            pure RunQuit
+        PersistenceEnabled slotRef -> do
+            handle <- ensureSession slotRef
+            report "restarting MCP servers…"
+            pure (RunRestart handle.sessionMeta.metaId)
+
+enterPlanFromSlash :: SessionEnv -> Maybe Text -> IO (Maybe ProviderTransition)
+enterPlanFromSlash env@SessionEnv
+    { sessionPlanMode = planMode
+    , sessionPersist = persist
+    , sessionRender = render
+    , sessionFullscreen = fullscreen
+    } maybeDescription = do
+    discardStore <- newIORef Nothing
+    color <- resolveColor stderr
+    let report message minimal = case fullscreen of
+            Nothing -> putTextLn stderr (roleMuted color minimal)
+            Just runtime -> emitUiEvent runtime (UiSystemMessage message)
+    case persist of
+        PersistenceEnabled slotRef -> do
+            handle <- ensureSession slotRef
+            writeIORef planMode.planSessionDir (Just handle.sessionDir)
+            report
+                ("session: " <> handle.sessionMeta.metaId)
+                (glyphSession <> "session: " <> handle.sessionMeta.metaId)
+        PersistenceDisabled -> pure ()
+    case maybeDescription of
+        Nothing -> do
+            writeIORef planMode.planStateRef PlanPending
+            let message =
+                    "plan mode armed; send a prompt to activate \
+                    \(or /plan <description>)"
+            report message (glyphSession <> message)
+            pure Nothing
+        Just description -> do
+            activatePlanMode planMode
+            path <- planFilePath planMode
+            let message = "plan mode on (" <> toText path <> ")"
+            report message (glyphSession <> message)
+            resetRenderPrintedText render
+            case fullscreen of
+                Nothing -> pure ()
+                Just runtime ->
+                    emitUiEvent runtime (UiUserSubmitted description)
+            let planEnv = env { sessionStoreRoot = discardStore }
+                inputs = [UserMessage description]
+            result <- runOneTurn planEnv description inputs
+            case result of
+                TurnProviderUnavailable apiError pending ->
+                    requestAutomaticProviderFallback
+                        planEnv apiError pending >>= \case
+                            Nothing -> do
+                                reportProviderUnavailable fullscreen apiError
+                                pure Nothing
+                            Just providerTransition ->
+                                pure (Just providerTransition)
+                _ -> do
+                    when (isNothing fullscreen) $
+                        putTrailingNewline render
+                    pure Nothing
+
+preparePromptSkillInputs
+    :: SessionEnv
+    -> Text
+    -> [TurnInput]
+    -> IO (Either Text [TurnInput])
+preparePromptSkillInputs env prompt inputs = do
+    invocations <- readIORef env.sessionSkillInvocations
+    pure do
+        selected <- resolveSkillMentions invocations prompt
+        let activations =
+                [ UserMessage (formatSkillActivation invocation prompt)
+                | invocation <- selected
+                ]
+        pure (activations <> inputs)
+
+putTrailingNewline :: RenderConfig -> IO ()
+putTrailingNewline render = do
+    didPrint <- renderPrintedText render
+    when didPrint (putTextLn render.renderStdout "")


### PR DESCRIPTION
## Summary
- move the interactive session loop and slash-command dispatch into `Agent.CLI.Runtime.Repl`
- keep startup and session wiring in `Agent.CLI.Runtime.Internal`
- reduce `Runtime.Internal` from 5,079 to 3,151 lines
- preserve the moved REPL implementation unchanged

## Validation
- loaded `Agent.CLI.Runtime` in GHCi after merging latest `master`
- ran `Agent.CLI.CommandSpec`: 64 examples, 0 failures
- smoke-tested actual minimal REPL startup in tmux
- regenerated `package.nix` with `cabal2nix`; no diff
- `git diff --check`
