### PR TITLE
feat(tui): distinguish user and assistant message backgrounds

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -2586,16 +2586,27 @@ drawBlock state target ui block =
             selected
                 && state.appUi.uiFocus == FocusScrollback
                 && state.appAgentSelected == target
+        marker =
+            txt (if highlighted then "❯ " else "  ")
         content = case block.blockKind of
             BlockUser ->
                 withAttr Theme.userAttr $
                     padAll 1 $
-                        timestampedMessage block.blockTimestamp
-                            (terminalTxtWrap block.blockBody)
+                        hBox
+                            [ withAttr
+                                (if highlighted
+                                    then Theme.borderActiveAttr
+                                    else Theme.userMutedAttr)
+                                marker
+                            , timestampedMessage
+                                Theme.userMutedAttr
+                                block.blockTimestamp
+                                (terminalTxtWrap block.blockBody)
+                            ]
             BlockAssistant ->
                 padLeft (Pad 3) $
                     padRight (Pad 1) $
-                        timestampedMessage block.blockTimestamp $
+                        timestampedMessage Theme.mutedAttr block.blockTimestamp $
                             withAttr Theme.assistantAttr
                                 (markdownWidgetWithSyntaxHighlightingAndLinks
                                     state.appSyntaxHighlighter
@@ -2656,14 +2667,17 @@ drawBlock state target ui block =
         rendered =
             clickable (ConversationBlock target block.blockId) $
                 padBottom (Pad 1) $
-                    hBox
-                        [ withAttr
-                            (if highlighted
-                                then Theme.borderActiveAttr
-                                else Theme.mutedAttr)
-                            (txt (if highlighted then "❯ " else "  "))
-                        , framed
-                        ]
+                    case block.blockKind of
+                        BlockUser -> framed
+                        _ ->
+                            hBox
+                                [ withAttr
+                                    (if highlighted
+                                        then Theme.borderActiveAttr
+                                        else Theme.mutedAttr)
+                                    marker
+                                , framed
+                                ]
     in if cacheableBlock state target ui block
         then cached
             (ConversationBlockCache
@@ -2675,13 +2689,13 @@ drawBlock state target ui block =
             rendered
         else rendered
 
-timestampedMessage :: Text -> Widget Name -> Widget Name
-timestampedMessage timestamp body
+timestampedMessage :: AttrName -> Text -> Widget Name -> Widget Name
+timestampedMessage timestampAttr timestamp body
     | Text.null timestamp = body
     | otherwise =
         hBox
             [ padRight Max body
-            , withAttr Theme.mutedAttr
+            , withAttr timestampAttr
                 (terminalTxt ("  " <> timestamp))
             ]
 

--- a/packages/agent-tui/src/Agent/TUI/Theme.hs
+++ b/packages/agent-tui/src/Agent/TUI/Theme.hs
@@ -45,6 +45,7 @@ module Agent.TUI.Theme
     , todoPendingAttr
     , toolAttr
     , userAttr
+    , userMutedAttr
     , waitingDimAttr
     , waitingMidAttr
     , completionFlashAttr
@@ -58,7 +59,7 @@ import Data.Bits ((.|.))
 import qualified Graphics.Vty as V
 
 baseAttr, headerAttr, footerAttr, mutedAttr :: AttrName
-userAttr, assistantAttr, thinkingAttr, toolAttr :: AttrName
+userAttr, userMutedAttr, assistantAttr, thinkingAttr, toolAttr :: AttrName
 todoPendingAttr, todoInProgressAttr, todoCompletedAttr, todoCancelledAttr :: AttrName
 errorAttr, successAttr, selectedAttr, borderAttr, borderActiveAttr :: AttrName
 headingAttr, codeAttr, dimAttr, emphasisAttr, inlineCodeAttr, linkAttr, strongAttr :: AttrName
@@ -74,6 +75,7 @@ headerAttr = attrName "header"
 footerAttr = attrName "footer"
 mutedAttr = attrName "muted"
 userAttr = attrName "user"
+userMutedAttr = attrName "user-muted"
 assistantAttr = attrName "assistant"
 thinkingAttr = attrName "thinking"
 toolAttr = attrName "tool"
@@ -143,7 +145,8 @@ terminalDefault =
         , (headerAttr, V.defAttr `V.withStyle` V.bold)
         , (footerAttr, palette V.brightBlack)
         , (mutedAttr, palette V.brightBlack)
-        , (userAttr, V.defAttr `V.withStyle` V.bold)
+        , (userAttr, userPanelAttr `V.withStyle` V.bold)
+        , (userMutedAttr, userPanelAttr `V.withStyle` V.dim)
         , (assistantAttr, V.defAttr)
         , (thinkingAttr, palette V.yellow)
         , (waitingDimAttr, palette V.brightBlack)
@@ -201,6 +204,7 @@ monochrome =
         , (footerAttr, V.defAttr)
         , (mutedAttr, V.defAttr)
         , (userAttr, V.defAttr `V.withStyle` V.bold)
+        , (userMutedAttr, V.defAttr `V.withStyle` V.dim)
         , (assistantAttr, V.defAttr)
         , (thinkingAttr, V.defAttr)
         , (waitingDimAttr, V.defAttr)
@@ -250,3 +254,9 @@ monochrome =
 
 palette :: V.Color -> V.Attr
 palette = V.withForeColor V.defAttr
+
+-- | Grok-style user-prompt panel: a full-width wash one step off the page
+-- background. Bright black is the ANSI gray slot, so Ghostty light/dark
+-- palettes keep the card readable without fixing an RGB background.
+userPanelAttr :: V.Attr
+userPanelAttr = V.withBackColor V.defAttr V.brightBlack

--- a/packages/agent-tui/test/Agent/TUI/ThemeSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ThemeSpec.hs
@@ -49,6 +49,15 @@ spec = do
                 (attrMapLookup Theme.selectedAttr Theme.terminalDefault)
                 `shouldBe` V.SetTo V.reverseVideo
 
+        it "gives user messages a palette gray panel distinct from assistant messages" do
+            let user = attrMapLookup Theme.userAttr Theme.terminalDefault
+                userMuted = attrMapLookup Theme.userMutedAttr Theme.terminalDefault
+                assistant = attrMapLookup Theme.assistantAttr Theme.terminalDefault
+            V.attrBackColor user `shouldBe` V.SetTo V.brightBlack
+            V.attrBackColor userMuted `shouldBe` V.SetTo V.brightBlack
+            V.attrBackColor assistant `shouldBe` V.Default
+            V.attrForeColor userMuted `shouldBe` V.Default
+
         it "does not introduce colors in monochrome mode" do
             map
                 ( \syntaxClass ->
@@ -63,6 +72,14 @@ spec = do
                     replicate
                         (length allSyntaxClasses)
                         (V.Default, V.Default)
+
+        it "does not paint user message panels in monochrome mode" do
+            V.attrBackColor
+                (attrMapLookup Theme.userAttr Theme.monochrome)
+                `shouldBe` V.Default
+            V.attrBackColor
+                (attrMapLookup Theme.userMutedAttr Theme.monochrome)
+                `shouldBe` V.Default
 
 terminalForeground :: AttrName -> V.MaybeDefault V.Color
 terminalForeground =


### PR DESCRIPTION
## Summary
- Give user prompts a full-width raised panel, like Grok Build's `bg = "light"` user cards.
- Keep assistant replies on the terminal default background.
- Use the ANSI bright-black slot so Ghostty light/dark palettes still apply; timestamps stay on the same panel.

## Test plan
- [x] `cabal test agent-tui`
- [x] `cabal build agent-cli:lib:agent-cli`
- [x] tmux smoke: user rows emit SGR 100; assistant rows do not