### PR TITLE
fix(openai): keep parallel_tool_calls false on Responses Lite

### DIFF
--- a/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
@@ -255,6 +255,35 @@ spec = do
             map requestItems seen
                 `shouldBe` [history <> [compactionTriggerItem]]
 
+        it "disables parallel tool calls for Responses Lite remote compaction" do
+            requests <- newIORef []
+            let provider = tokenProvider SubscriptionBilled \_ ->
+                    error "remote compaction unexpectedly requested credentials"
+                send _ request = do
+                    modifyIORef' requests (<> [request])
+                    pure (Right remoteCompactionResponse)
+                history = [userTextItem "old context"]
+                params = defaultResponseCreateParams
+                    { model = Just "gpt-5.6-sol"
+                    , instructions = Just "keep these instructions"
+                    , store = Just True
+                    , tools = Just []
+                    }
+            result <- runExceptT $
+                compactOpenAIWith send
+                    (Just provider)
+                    params
+                    history
+                    100
+                    Nothing
+            case result of
+                Left err -> expectationFailure (show err)
+                Right outcome ->
+                    outcome.compactSummary
+                        `shouldBe` "Context compacted remotely."
+            map (.parallelToolCalls) <$> readIORef requests
+                `shouldReturn` [Just False]
+
         it "keeps focused manual compaction on local summarization" do
             requests <- newIORef []
             let provider = tokenProvider SubscriptionBilled \_ ->

--- a/packages/agent-openai/src/Agent/OpenAI/Compaction.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Compaction.hs
@@ -27,6 +27,7 @@ module Agent.OpenAI.Compaction
     , newSessionUserText
     ) where
 
+import Agent.OpenAI.ModelMetadata (isCodexResponsesLiteModel)
 import Agent.Responses.LoopBackend (withRequestInput)
 import Agent.Responses.Types
 import qualified Data.Aeson as Aeson
@@ -64,6 +65,9 @@ compactionTriggerItem =
 
 -- | Build a normal streaming Responses request whose final input item asks the
 -- model to emit an opaque compaction checkpoint.
+--
+-- Regular Codex compaction enables parallel tool calls. Responses Lite
+-- rejects that value, so keep the flag false for sol/terra/luna.
 buildRemoteCompactionRequest
     :: ResponseCreateParams
     -> [ResponseItem]
@@ -72,7 +76,8 @@ buildRemoteCompactionRequest params history =
     case withRequestInput params (history <> [compactionTriggerItem]) of
         ResponseCreateParams{..} ->
             ResponseCreateParams
-                { parallelToolCalls = Just True
+                { parallelToolCalls =
+                    Just (not (maybe False isCodexResponsesLiteModel model))
                 , previousResponseId = Nothing
                 , store = Just False
                 , stream = Just True

--- a/packages/agent-openai/src/Agent/OpenAI/Request.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Request.hs
@@ -3,6 +3,7 @@ module Agent.OpenAI.Request
     ( sanitizeCodexRequest
     ) where
 
+import Agent.OpenAI.ModelMetadata (isCodexResponsesLiteModel)
 import Agent.Responses.Types
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Key as Key
@@ -19,11 +20,24 @@ import qualified Data.Aeson.KeyMap as KeyMap
 -- client feature flag is on; the current Responses Lite endpoint rejects it as
 -- an unknown parameter, so strip it at the wire boundary and leave the
 -- in-memory request params unchanged.
+--
+-- Responses Lite also requires @parallel_tool_calls=false@. Compaction and
+-- other request rebuilds can flip that flag back to true, so restore the
+-- Lite contract here for both HTTP and WebSocket.
 sanitizeCodexRequest :: ResponseCreateParams -> ResponseCreateParams
-sanitizeCodexRequest ResponseCreateParams{promptCacheRetention = _, input, ..} =
+sanitizeCodexRequest ResponseCreateParams
+        { promptCacheRetention = _
+        , input
+        , parallelToolCalls
+        , ..
+        } =
     ResponseCreateParams
         { promptCacheRetention = Nothing
         , input = fmap stripContentItemKindsInput input
+        , parallelToolCalls =
+            if maybe False isCodexResponsesLiteModel model
+                then Just False
+                else parallelToolCalls
         , ..
         }
 

--- a/packages/agent-openai/test/Agent/OpenAI/CompactionSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/CompactionSpec.hs
@@ -49,6 +49,15 @@ spec = do
             Aeson.toJSON compactionTriggerItem
                 `shouldBe` Aeson.object ["type" .= ("compaction_trigger" :: Text.Text)]
 
+        it "disables parallel tool calls for Responses Lite compaction" do
+            let params = defaultResponseCreateParams
+                    { model = Just "gpt-5.6-sol"
+                    , store = Just True
+                    , parallelToolCalls = Just True
+                    }
+                request = buildRemoteCompactionRequest params [user "hello"]
+            request.parallelToolCalls `shouldBe` Just False
+
         it "accepts exactly one compaction item alongside unrelated output" do
             let opaque = checkpoint "opaque"
                 response = completedResponse [assistant "ignored", opaque]

--- a/packages/agent-openai/test/Agent/OpenAI/WebSocketClientSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/WebSocketClientSpec.hs
@@ -87,6 +87,17 @@ spec = do
         field "previous_response_id" payload
             `shouldBe` Just (Aeson.String "previous-1")
 
+    it "forces parallel_tool_calls false on Responses Lite requests" do
+        let request = withParallelToolCalls (Just True) sampleRequest
+            payload = buildWsPayloadWithOptions
+                defaultCodexWsOptions request Nothing
+        field "parallel_tool_calls" payload `shouldBe` Just (Aeson.Bool False)
+
+        let generic = withModel (Just "gpt-generic") request
+        field "parallel_tool_calls"
+            (buildWsPayloadWithOptions defaultCodexWsOptions generic Nothing)
+            `shouldBe` Just (Aeson.Bool True)
+
     it "strips Responses Lite content_item_kinds from the wire payload" do
         let payload = buildWsPayloadWithOptions
                 defaultCodexWsOptions sampleLitePrefixRequest Nothing
@@ -357,6 +368,11 @@ withPromptCacheRetention
 withPromptCacheRetention nextRetention
         ResponseCreateParams { promptCacheRetention = _, .. } =
     ResponseCreateParams { promptCacheRetention = nextRetention, .. }
+
+withParallelToolCalls
+    :: Maybe Bool -> ResponseCreateParams -> ResponseCreateParams
+withParallelToolCalls nextValue ResponseCreateParams { parallelToolCalls = _, .. } =
+    ResponseCreateParams { parallelToolCalls = nextValue, .. }
 
 withModel :: Maybe Text -> ResponseCreateParams -> ResponseCreateParams
 withModel nextModel ResponseCreateParams { model = _, .. } =


### PR DESCRIPTION
## Summary
- Automatic compaction on Responses Lite (`gpt-5.6-sol` / terra / luna) failed with `X-OpenAI-Internal-Codex-Responses-Lite requires parallel_tool_calls to be false`.
- Remote compaction v2 always forced `parallel_tool_calls=true`, which is correct for ordinary Codex models but rejected by Lite.
- Set the flag from `isCodexResponsesLiteModel` in `buildRemoteCompactionRequest`, and restore `false` in `sanitizeCodexRequest` so HTTP and WebSocket both send the Lite contract.

## Test plan
- [x] `cabal test agent-openai:test:agent-openai-test --test-options='-m "parallel tool"'`
- [x] `cabal test agent-openai:test:agent-openai-test --test-options='-m "forces parallel_tool_calls"'`
- [x] `cabal test agent-openai:test:agent-openai-test --test-options='-m "builds an exact final compaction trigger"'`
- [x] `TMPDIR=/tmp HASKELL_AGENT_TMPDIR=/tmp cabal test agent-cli:test:agent-cli-test --test-options='-m "compactOpenAIWith"'`
- [ ] CI on this PR