### PR TITLE
Check startup usage limits in the background

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Runtime/Internal.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Internal.hs
@@ -1511,6 +1511,12 @@ runAgentInitializedWithLock
                 CustomResponsesConnection responses -> Just
                     (connection.connectionId, responses)
                 BuiltinConnection _ -> Nothing
+        checkStartupUsageInBackground =
+            isJust fullscreen
+                && isNothing transition
+                && isNothing resumed
+                && isNothing options.optProvider
+                && isNothing options.optModel
     ((initialLoaded, learnAboutUserRequested), customBearerToken) <-
         case customResponses of
             Nothing -> do
@@ -1573,6 +1579,28 @@ runAgentInitializedWithLock
                 (providerSupportsUsageAccountSelection
                     initialLoaded.loadedProvider) ->
                         pure (initialLoaded, Nothing)
+            | checkStartupUsageInBackground -> do
+                -- Make the remembered model/account usable immediately. The
+                -- scoped availability worker below checks the account pool
+                -- after the prompt is ready and triggers startup fallback if
+                -- every credential is exhausted.
+                let provider = initialLoaded.loadedProvider
+                case projectAccountFor provider projectSettings of
+                    Nothing -> pure (initialLoaded, Nothing)
+                    Just remembered ->
+                        loadSelectedAccountAuth
+                            provider
+                            remembered.projectAccountSelectionId
+                            remembered.projectAccountId >>= \case
+                                Left _ -> pure (initialLoaded, Nothing)
+                                Right selectedLoaded ->
+                                    pure
+                                        ( selectedLoaded
+                                        , Just
+                                            ( remembered.projectAccountSelectionId
+                                            , remembered.projectAccountId
+                                            )
+                                        )
             | otherwise -> do
                 let provider = initialLoaded.loadedProvider
                     rememberedIds = fmap
@@ -2430,11 +2458,7 @@ runAgentInitializedWithLock
                             fullscreen progName persist RunQuit action
         runWithInterruptHandling do
                 let shouldProbeAtStartup =
-                        isJust fullscreen
-                            && isNothing transition
-                            && isNothing resumed
-                            && isNothing options.optProvider
-                            && isNothing options.optModel
+                        checkStartupUsageInBackground
                             && isNothing promptRequest
                     sessionRequest
                         startupUnavailable


### PR DESCRIPTION
## Summary
- load the remembered model and provider account immediately during ordinary interactive startup
- defer account-pool usage validation to the existing scoped background availability worker
- preserve strict preflight validation for explicit switches and automatic provider fallback

## Validation
- `printf ':quit\\n' | nix develop -c cabal repl agent-cli:lib:agent-cli`
- `env TMPDIR=/tmp HASKELL_AGENT_TMPDIR=/tmp nix develop -c cabal test agent-cli-test --test-show-details=direct` (978 examples, 0 failures, 1 pending)
- live tmux smoke check: the prompt reached Ready with `gpt-5.6-sol`, then the weekly limit populated asynchronously
- `git diff --check`
