### PR TITLE
Fix fullscreen Ctrl-C decoding

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -129,7 +129,7 @@ import Agent.CLI.Timestamp (currentShortMessageTimestamp)
 import Agent.CLI.Terminal
     ( TerminalCapabilities(..)
     , detectTerminalCapabilities
-    , kittyCtrlVCsiBodies
+    , kittyCtrlCsiBodies
     , kittyKeyboardDisambiguatePush
     , kittyKeyboardPop
     , kittySuperVCsiBodies
@@ -718,13 +718,16 @@ fullscreenVtyConfig =
             ]
             <> [ ( Nothing
                  , "\ESC[" <> body
-                 , V.EvKey (V.KChar 'v') [modifier]
+                 , V.EvKey (V.KChar character) [V.MCtrl]
                  )
-               | (modifier, bodies) <-
-                    [ (V.MCtrl, kittyCtrlVCsiBodies)
-                    , (V.MMeta, kittySuperVCsiBodies)
-                    ]
-               , body <- bodies
+               | character <- ['a'..'z']
+               , body <- kittyCtrlCsiBodies character
+               ]
+            <> [ ( Nothing
+                 , "\ESC[" <> body
+                 , V.EvKey (V.KChar 'v') [V.MMeta]
+                 )
+               | body <- kittySuperVCsiBodies
                ]
         }
 

--- a/packages/agent-cli/src/Agent/CLI/Terminal.hs
+++ b/packages/agent-cli/src/Agent/CLI/Terminal.hs
@@ -17,6 +17,7 @@ module Agent.CLI.Terminal
     , synchronizedOutputBegin
     , synchronizedOutputEnd
     , stripAnsi
+    , kittyCtrlCsiBodies
     , kittyCtrlVCsiBodies
     , kittySuperVCsiBodies
     , shiftEnterCsiBodies
@@ -34,7 +35,7 @@ module Agent.CLI.Terminal
 import Agent.CLI.FileUri (fileUri)
 import Control.Exception.Safe (bracket_)
 import qualified Data.ByteString.Base64 as Base64
-import Data.Char (toLower)
+import Data.Char (ord, toLower, toUpper)
 import Data.Maybe (fromMaybe, isJust)
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -212,18 +213,29 @@ shiftEnterCsiBodies =
     , "13;2u"
     ]
 
--- | CSI bodies emitted by Kitty's keyboard protocol for Ctrl+V and Cmd+V.
+-- | CSI bodies emitted by Kitty's keyboard protocol for Ctrl+letter chords.
 --
 -- The longer key-code form includes the shifted and base-layout codepoints.
 -- Event type 1 is an explicit key press; terminals may omit it.
-kittyCtrlVCsiBodies, kittySuperVCsiBodies :: [String]
-kittyCtrlVCsiBodies = kittyModifiedVCsiBodies 5
-kittySuperVCsiBodies = kittyModifiedVCsiBodies 9
+kittyCtrlCsiBodies :: Char -> [String]
+kittyCtrlCsiBodies character = kittyModifiedCsiBodies character 5
 
-kittyModifiedVCsiBodies :: Int -> [String]
-kittyModifiedVCsiBodies encodedModifier =
+-- | Paste chords retained as named lists for inline and fullscreen input.
+kittyCtrlVCsiBodies, kittySuperVCsiBodies :: [String]
+kittyCtrlVCsiBodies = kittyCtrlCsiBodies 'v'
+kittySuperVCsiBodies = kittyModifiedCsiBodies 'v' 9
+
+kittyModifiedCsiBodies :: Char -> Int -> [String]
+kittyModifiedCsiBodies character encodedModifier =
     [ keyCode <> ";" <> show encodedModifier <> event <> "u"
-    | keyCode <- ["118", "118:86:86"]
+    | keyCode <-
+        [ show (ord character)
+        , show (ord character)
+            <> ":"
+            <> show (ord (toUpper character))
+            <> ":"
+            <> show (ord (toUpper character))
+        ]
     , event <- ["", ":1"]
     ]
 

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -283,6 +283,14 @@ spec = do
                   , V.EvKey (V.KChar 'v') [V.MCtrl]
                   )
                 , ( Nothing
+                  , "\ESC[99;5u"
+                  , V.EvKey (V.KChar 'c') [V.MCtrl]
+                  )
+                , ( Nothing
+                  , "\ESC[99:67:67;5:1u"
+                  , V.EvKey (V.KChar 'c') [V.MCtrl]
+                  )
+                , ( Nothing
                   , "\ESC[118;9u"
                   , V.EvKey (V.KChar 'v') [V.MMeta]
                   )


### PR DESCRIPTION
## Summary
- decode Kitty keyboard Ctrl+A–Z sequences in the fullscreen Vty input map
- prevent Ctrl+C (`CSI 99;5u`) from leaking printable bytes into the composer
- cover compact and extended Ctrl+C encodings with a regression test

## Validation
- `nix develop -c cabal repl agent-cli:lib:agent-cli` (loaded `Agent.CLI.TUI.App`)
- `nix develop -c cabal test agent-cli:test:agent-cli-test --test-options='--match fullscreenVtyConfig'`\n- live tmux smoke test: injected `ESC[99;5u`; the app displayed `Press Ctrl-C again to exit.` and kept the composer empty