### PR TITLE
Match prompt limit status color

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
@@ -337,9 +337,7 @@ drawComposerStatus state =
     account = prompt.promptAccount
     accountLimit =
         [ withAttr
-            (if limitStatus.promptLimitWarning
-                then Theme.syntaxWarningAttr
-                else Theme.successAttr)
+            Theme.controlLinkAttr
             (terminalTxt limitStatus.promptLimitText)
         | limitStatus <- maybeToList prompt.promptLimitStatus
         ]


### PR DESCRIPTION
## Summary
- render prompt limit status with the same metadata color as model, effort, and mode
- keep the bottom-right composer status visually consistent

## Validation
- loaded `Agent.CLI.TUI.Composer` successfully in GHCi
- exercised the live fullscreen agent in tmux
- confirmed the limit and model share the same ANSI color sequence
- `git diff --check`