### PR TITLE
Hide persisted reasoning from virtualized session history

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TUI/SessionHistory.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/SessionHistory.hs
@@ -30,8 +30,6 @@ import Agent.Responses.Types
     , FunctionCall(..)
     , FunctionCallOutput(..)
     , MessageContent(..)
-    , ReasoningItem(..)
-    , ReasoningSummaryPart(..)
     , ResponseContentPart(..)
     , ResponseItem(..)
     , ResponseMessage(..)
@@ -55,7 +53,6 @@ import Agent.TUI.Model
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy as LazyByteString
 import Data.Foldable (toList)
-import Data.Maybe (mapMaybe)
 import qualified Data.Sequence as Seq
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
@@ -165,11 +162,11 @@ projectItem state = \case
         | message.role == RoleAssistant ->
             appendText (UiLoop . TextDelta) (messageText message.content) state
         | otherwise -> state
-    ReasoningItemValue reasoning ->
-        appendText
-            (UiLoop . ReasoningDelta)
-            (reasoningText reasoning)
-            state
+    -- Persisted reasoning summaries are model scratchpad, not conversation
+    -- history. Replaying them after a tab switch makes old drafting notes look
+    -- like newly surfaced user-visible output. Live turns still render streamed
+    -- ReasoningDelta events; only durable history projection omits them.
+    ReasoningItemValue _ -> state
     FunctionCallItem call ->
         reduceUi
             (UiLoop
@@ -222,16 +219,6 @@ hasAssistantBlock =
         . toList
         . (.uiBlocks)
 
-reasoningText :: ReasoningItem -> Text.Text
-reasoningText reasoning =
-    firstNonEmpty
-        [ Text.intercalate "\n" $
-            mapMaybe (.text) reasoning.summary
-        , Text.intercalate "\n" $
-            concatMap responseContentText $
-                maybe [] id reasoning.content
-        ]
-
 messageText :: MessageContent -> Text.Text
 messageText = \case
     MessageContentText text -> text
@@ -245,18 +232,6 @@ responseContentText = \case
     SummaryTextPart{text} -> [text]
     RefusalPart{refusal} -> [refusal]
     _ -> []
-
-firstNonEmpty :: [Text.Text] -> Text.Text
-firstNonEmpty =
-    maybe "" id
-        . findFirst (not . Text.null . Text.strip)
-
-findFirst :: (a -> Bool) -> [a] -> Maybe a
-findFirst predicate = \case
-    [] -> Nothing
-    value : rest
-        | predicate value -> Just value
-        | otherwise -> findFirst predicate rest
 
 renderJsonValue :: Aeson.Value -> Text.Text
 renderJsonValue = \case

--- a/packages/agent-cli/test/Agent/CLI/TUIHistorySpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIHistorySpec.hs
@@ -267,7 +267,7 @@ spec = describe "bounded fullscreen history window" do
             `shouldBe` Seq.singleton (HistoryCursor 2)
         historyWindowLoadedBytes window `shouldSatisfy` (<= 180)
 
-    it "projects reasoning, tool calls, outputs, and assistant text" do
+    it "omits persisted reasoning while projecting tool and assistant history" do
         let projected =
                 sessionHistoryTurn
                     (12 :: Int)
@@ -280,7 +280,9 @@ spec = describe "bounded fullscreen history window" do
                             , summary =
                                 [ ReasoningSummaryPart
                                     { partType = "summary_text"
-                                    , text = Just "Checked the schema"
+                                    , text =
+                                        Just
+                                            "Don't mention skills. Brief summary for the user."
                                     , extraFields = KeyMap.empty
                                     }
                                 ]
@@ -293,13 +295,17 @@ spec = describe "bounded fullscreen history window" do
                             { itemId = Nothing
                             , callId = "call-1"
                             , name = "shell_command"
+                            , namespace = Nothing
                             , arguments = "{\"command\":\"pwd\"}"
+                            , encryptedFunctionArgs = Nothing
                             , status = Nothing
                             , extraFields = KeyMap.empty
                             }
                         , FunctionCallOutputItem FunctionCallOutput
                             { itemId = Nothing
                             , callId = "call-1"
+                            , name = Nothing
+                            , namespace = Nothing
                             , output = Aeson.String "/tmp/project"
                             , status = Nothing
                             , extraFields = KeyMap.empty
@@ -310,13 +316,15 @@ spec = describe "bounded fullscreen history window" do
         map (.blockKind) blocks
             `shouldBe`
                 [ BlockUser
-                , BlockThinking
                 , BlockShell
                 , BlockAssistant
                 ]
         map (.blockBody) blocks
             `shouldSatisfy`
                 any (Text.isInfixOf "/tmp/project")
+        map (.blockBody) blocks
+            `shouldSatisfy`
+                all (not . Text.isInfixOf "Don't mention skills")
 
     it "does not rematerialise the compacted prefix of replacement turns" do
         let projected =
@@ -406,6 +414,7 @@ userMessage text =
         , role = RoleUser
         , status = Nothing
         , phase = Nothing
+        , passthrough = Nothing
         , extraFields = KeyMap.empty
         }
 
@@ -417,6 +426,7 @@ assistantMessage text =
         , role = RoleAssistant
         , status = Nothing
         , phase = Nothing
+        , passthrough = Nothing
         , extraFields = KeyMap.empty
         }
 


### PR DESCRIPTION
## Summary
- omit persisted reasoning items when rebuilding virtualized fullscreen history
- keep live streamed reasoning unchanged
- add a regression for scratchpad text appearing after a tab switch

## Validation
- `nix develop -c cabal repl agent-cli:test:agent-cli-test` + `hspec Agent.CLI.TUIHistorySpec.spec` (13 examples, 0 failures)
- live fullscreen startup smoke-tested through tmux
- `git diff --check`