### PR TITLE
Fix Nix build after Responses fixture changes

### DIFF
--- a/packages/agent-cli/test/Agent/CLI/TUIHistorySpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIHistorySpec.hs
@@ -293,13 +293,17 @@ spec = describe "bounded fullscreen history window" do
                             { itemId = Nothing
                             , callId = "call-1"
                             , name = "shell_command"
+                            , namespace = Nothing
                             , arguments = "{\"command\":\"pwd\"}"
+                            , encryptedFunctionArgs = Nothing
                             , status = Nothing
                             , extraFields = KeyMap.empty
                             }
                         , FunctionCallOutputItem FunctionCallOutput
                             { itemId = Nothing
                             , callId = "call-1"
+                            , name = Nothing
+                            , namespace = Nothing
                             , output = Aeson.String "/tmp/project"
                             , status = Nothing
                             , extraFields = KeyMap.empty
@@ -406,6 +410,7 @@ userMessage text =
         , role = RoleUser
         , status = Nothing
         , phase = Nothing
+        , passthrough = Nothing
         , extraFields = KeyMap.empty
         }
 
@@ -417,6 +422,7 @@ assistantMessage text =
         , role = RoleAssistant
         , status = Nothing
         , phase = Nothing
+        , passthrough = Nothing
         , extraFields = KeyMap.empty
         }
 


### PR DESCRIPTION
## Summary
- update fullscreen history test fixtures for the new canonical Responses fields
- preserve existing fixture behavior with explicit absent optional metadata

## Validation
- `nix build -L`
- agent-cli: 978 examples, 0 failures
- `git diff --check`