### PR TITLE
fix(cli): recognize Kitty Ctrl+R as dictation

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Dictation.hs
+++ b/packages/agent-cli/src/Agent/CLI/Dictation.hs
@@ -57,6 +57,8 @@ import System.Process
 dictate :: IO Text
 dictate = do
     requireExecutable "ffmpeg"
+    Text.hPutStrLn stderr "● Starting dictation…"
+    hFlush stderr
     loadAuth (Just XAIProvider) >>= \case
         Left err ->
             fail (Text.unpack err)

--- a/packages/agent-cli/src/Agent/CLI/Input/KeyDecoder.hs
+++ b/packages/agent-cli/src/Agent/CLI/Input/KeyDecoder.hs
@@ -92,6 +92,7 @@ decodeKittyControl modifiers codepoint
         108 -> EditorClearScreen
         110 -> EditorDown
         112 -> EditorUp
+        114 -> EditorDictate
         117 -> EditorKillStart
         119 -> EditorKillWord
         121 -> EditorYank

--- a/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
@@ -588,15 +588,9 @@ handleComposerKey
                 invalidateCache
         V.EvKey (V.KChar 'r') modifiers
             | V.MCtrl `elem` modifiers ->
-                suspendAndResume do
-                    result <- tryAny dictate
-                    writeBChan
-                        state.appRuntime.runtimeEvents
-                        (AppDictationFinished
-                            (case result of
-                                Left err -> Left (Text.pack (show err))
-                                Right transcript -> Right transcript))
-                    pure state
+                startDictation
+        V.EvKey (V.KChar '\DC2') _ ->
+            startDictation
         V.EvKey (V.KChar 'a') modifiers
             | V.MCtrl `elem` modifiers ->
                 setCursor (lineStartCursor ui.uiDraft ui.uiCursor)
@@ -659,6 +653,18 @@ handleComposerKey
                             pastedDraft)
         _ -> pure ()
   where
+    startDictation = do
+        current <- get
+        suspendAndResume do
+            result <- tryAny dictate
+            writeBChan
+                current.appRuntime.runtimeEvents
+                (AppDictationFinished
+                    (case result of
+                        Left err -> Left (Text.pack (show err))
+                        Right transcript -> Right transcript))
+            pure current
+
     submitRaw replLine = do
         state <- get
         enqueueInput state replLine Nothing False

--- a/packages/agent-cli/test/Agent/CLI/InputSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/InputSpec.hs
@@ -18,6 +18,8 @@ import Agent.CLI.Input
     , truncateDisplayText
     , visibleEditorText
     )
+import Agent.CLI.Input.KeyDecoder (decodeKittyEditorKey)
+import Agent.CLI.Input.Types (EditorKey(..))
 import Data.Char (isControl)
 import Data.Either (isLeft)
 import qualified Data.Text as Text
@@ -208,6 +210,14 @@ spec = do
             isClipboardPasteCsiBody "99;9u" `shouldBe` False
             isClipboardPasteCsiBody "118;9:3u" `shouldBe` False
             isClipboardPasteCsiBody "not-a-key" `shouldBe` False
+
+    describe "Kitty Ctrl+R dictation" do
+        it "decodes press events as dictation and ignores key releases" do
+            decodeKittyEditorKey "114;5u" `shouldBe` Just EditorDictate
+            decodeKittyEditorKey "114;5:1u" `shouldBe` Just EditorDictate
+            decodeKittyEditorKey "114:82:82;5u" `shouldBe` Just EditorDictate
+            decodeKittyEditorKey "114;5:3u" `shouldBe` Just EditorIgnore
+            decodeKittyEditorKey "117;5u" `shouldBe` Just EditorKillStart
 
     describe "Shift+Enter" do
         it "recognizes xterm modifyOtherKeys and Kitty CSI-u encodings" do

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -298,6 +298,14 @@ spec = do
                   , "\ESC[118:86:86;9:1u"
                   , V.EvKey (V.KChar 'v') [V.MMeta]
                   )
+                , ( Nothing
+                  , "\ESC[114;5u"
+                  , V.EvKey (V.KChar 'r') [V.MCtrl]
+                  )
+                , ( Nothing
+                  , "\ESC[114:82:82;5:1u"
+                  , V.EvKey (V.KChar 'r') [V.MCtrl]
+                  )
                 ]
 
     describe "fullscreen keyboard protocol lifecycle" do


### PR DESCRIPTION
## Summary
- Ctrl+R dictation was a no-op on Ghostty/Kitty because the inline editor treated Kitty CSI-u `114;5u` as `EditorIgnore`.
- Map that sequence to `EditorDictate`, accept a raw `^R` in the fullscreen composer, and print `Starting dictation…` before the xAI STT handshake.

## Test plan
- [x] `agent-cli-test` examples for Kitty Ctrl+R decoding and fullscreen `114;5u` Vty mapping
- [x] tmux live fullscreen TUI smoke test (`tmux send-keys C-r` / `capture-pane`):
  - Footer shows `Ctrl+R dictate`
  - Ctrl+R suspends Brick and prints `● Starting dictation…` then `● Listening… press Enter to stop`
  - Enter resumes the composer with a dictation notice (silent recording produced no transcript, as expected)