### PR TITLE
Fix clickable displayed Markdown URLs

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Markdown.hs
+++ b/packages/agent-cli/src/Agent/CLI/Markdown.hs
@@ -232,14 +232,14 @@ renderInlineWith base = Text.concat . map (go base)
         InlineLink url children ->
             let label =
                     renderInlineWith (context <> linkStyle) children
-                linked
-                    | safeUrl url = osc8Link True url label
-                    | otherwise = label
                 suffix
                     | Text.null url || inlinePlainText children == url = ""
                     | otherwise =
                         styled (context <> urlStyle) (" (" <> url <> ")")
-            in linked <> suffix
+                displayedLink = label <> suffix
+            in if safeUrl url
+                then osc8Link True url displayedLink
+                else displayedLink
 
     styled [] value = value
     styled styles value = md styles value

--- a/packages/agent-cli/test/Agent/CLI/MarkdownSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/MarkdownSpec.hs
@@ -139,6 +139,15 @@ spec = do
             out `shouldSatisfy` Text.isInfixOf url
             out `shouldSatisfy` Text.isInfixOf "\ESC]8;;\ESC\\"
 
+        it "keeps a link's displayed URL suffix inside its OSC 8 hyperlink" do
+            let url = "https://github.com/digitallyinduced/haskell-agent/pull/537"
+                opener = "\ESC]8;;" <> url <> "\ESC\\"
+                out = renderMarkdown True ("Merged PR [#537](" <> url <> ").")
+                afterOpener = Text.drop (Text.length opener) (snd (Text.breakOn opener out))
+                linkedPayload = fst (Text.breakOn "\ESC]8;;\ESC\\" afterOpener)
+            linkedPayload `shouldSatisfy` Text.isInfixOf "#537"
+            linkedPayload `shouldSatisfy` Text.isInfixOf url
+
         it "restores heading styling after nested code" do
             let out = renderMarkdown True "# before `code` after"
                 afterCode = snd (Text.breakOn "code" out)


### PR DESCRIPTION
## Summary
- include the displayed URL suffix in the same OSC-8 hyperlink as its Markdown label
- make both the label and visible URL clickable in inline CLI output
- add regression coverage for labeled PR links

## Validation
- `agent-cli-test --match renderMarkdown` (27 examples, 0 failures)
- tmux/GHCi TTY smoke check confirming the OSC-8 span covers the label and displayed URL
- `git diff --check`