### PR TITLE
Animate terminal title while the agent runs

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -175,6 +175,7 @@ library
                     , Agent.CLI.TurnState
                     , Agent.CLI.Usage
                     , Agent.CLI.WebFetch
+                    , Agent.CLI.WindowTitle
                     , Agent.CLI.Worktree
     build-depends:    agent-core >= 0.1 && < 0.2
                     , agent-process >= 0.1 && < 0.2

--- a/packages/agent-cli/src/Agent/CLI/Session/Runner.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner.hs
@@ -107,7 +107,16 @@ import Agent.CLI.Subagents.Runtime
     , lookupOrCreateSubagentSession
     , persistAndEvictSubagentSessionWithStatus
     )
-import Agent.CLI.Style (glyphSession, glyphWarn, roleMuted, roleWarn, cliWindowTitle, setCliWindowTitle)
+import Agent.CLI.Style
+    ( busyCliWindowTitle
+    , cliWindowTitle
+    , glyphSession
+    , glyphWarn
+    , roleMuted
+    , roleWarn
+    , setCliWindowTitle
+    , spinnerFrames
+    )
 import Agent.CLI.Terminal
     ( TerminalCapabilities(..)
     , resolveColor
@@ -135,7 +144,12 @@ import Agent.TUI.Model
     , initialUiState
     , reduceUi
     )
-import Agent.TUI.Motion (nativeProgressAnimationEnabled)
+import Agent.TUI.Motion
+    ( MotionDemand(..)
+    , MotionMode(..)
+    , motionIntervalMicros
+    , nativeProgressAnimationEnabled
+    )
 import Agent.CLI.Turn (applyPendingSessionTitles, runOneTurn)
 import Agent.Cancel (requestCancel)
 import Agent.Loop
@@ -180,8 +194,17 @@ import Agent.OsPath (toText)
 import Control.Concurrent.Async
     ( withAsync )
 import Control.Concurrent.Chan (newChan, readChan, writeChan)
+import Control.Concurrent (threadDelay)
 import Control.Concurrent.MVar
     ( newMVar, withMVar )
+import Control.Concurrent.STM
+    ( atomically
+    , check
+    , modifyTVar'
+    , newTVarIO
+    , readTVar
+    , writeTVar
+    )
 import Control.Exception.Safe
     ( catchAny )
 import Control.Monad (forM_, unless, void, when)
@@ -203,6 +226,11 @@ data AgentStepCache = AgentStepCache
     , cachedSteps :: ![AgentStep]
     }
 
+data WindowTitleAnimationState = WindowTitleAnimationState
+    { windowTitleBase :: !Text
+    , windowTitleBusyDepth :: !Int
+    }
+
 data SessionRunnerContinuation = SessionRunnerContinuation
     { runnerFinishStartup :: StartupRuntime -> IO ()
     , runnerRepl :: SessionEnv -> IO RunResult
@@ -222,6 +250,21 @@ runSession
 runSession callbacks SessionRequest{..} SessionBackend{..} = do
   initialPrevious <- readLivePreviousResponseId conversationRef
   ioLock <- newMVar ()
+  initialWindowTitle <- case persist of
+      PersistenceEnabled slotRef ->
+          readIORef slotRef >>= \case
+              PersistenceActive handle ->
+                  pure
+                      (cliWindowTitle
+                          handle.sessionMeta.metaCwd
+                          (Just handle.sessionMeta.metaTitle))
+              _ -> pure (cliWindowTitle cwd Nothing)
+      PersistenceDisabled -> pure (cliWindowTitle cwd Nothing)
+  windowTitleState <- newTVarIO
+      WindowTitleAnimationState
+          { windowTitleBase = initialWindowTitle
+          , windowTitleBusyDepth = 0
+          }
   let fullscreen = startup.startupFullscreen
       terminal = startup.startupTerminal
       stdoutHandle = startup.startupStdout
@@ -229,10 +272,62 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
       useColor = startup.startupUseColor
       stderrTty = startup.startupStderrTty
       stdoutTty = startup.startupStdoutTty
-      setWindowTitle title =
+      writeWindowTitle title =
           case fullscreen of
               Just runtime -> setFullscreenWindowTitle runtime title
               Nothing -> setCliWindowTitle stdoutTty stdoutHandle title
+      firstSpinnerFrame = case spinnerFrames of
+          frame : _ -> frame
+          [] -> "*"
+      setWindowTitle title =
+          withMVar ioLock \_ -> do
+              state <- atomically do
+                  current <- readTVar windowTitleState
+                  let updated = current { windowTitleBase = title }
+                  writeTVar windowTitleState updated
+                  pure updated
+              writeWindowTitle
+                  (if state.windowTitleBusyDepth > 0
+                      then busyCliWindowTitle firstSpinnerFrame title
+                      else title)
+      beginWindowTitleBusy =
+          withMVar ioLock \_ -> do
+              state <- atomically do
+                  modifyTVar' windowTitleState \current ->
+                      current
+                          { windowTitleBusyDepth =
+                              current.windowTitleBusyDepth + 1
+                          }
+                  readTVar windowTitleState
+              when (state.windowTitleBusyDepth == 1) $
+                  writeWindowTitle
+                      (busyCliWindowTitle
+                          firstSpinnerFrame
+                          state.windowTitleBase)
+      endWindowTitleBusy =
+          withMVar ioLock \_ -> do
+              state <- atomically do
+                  modifyTVar' windowTitleState \current ->
+                      current
+                          { windowTitleBusyDepth =
+                              max 0 (current.windowTitleBusyDepth - 1)
+                          }
+                  readTVar windowTitleState
+              when (state.windowTitleBusyDepth == 0) $
+                  writeWindowTitle state.windowTitleBase
+      windowTitleWorker =
+          unless (options.optMotionMode == MotionOff) $
+              forM_ (cycle spinnerFrames) \frame -> do
+                  atomically do
+                      state <- readTVar windowTitleState
+                      check (state.windowTitleBusyDepth > 0)
+                  withMVar ioLock \_ -> do
+                      state <- atomically (readTVar windowTitleState)
+                      when (state.windowTitleBusyDepth > 0) $
+                          writeWindowTitle
+                              (busyCliWindowTitle frame state.windowTitleBase)
+                  threadDelay
+                      (motionIntervalMicros options.optMotionMode MotionSlow)
       showTitleEvent = \case
         SessionTitleGenerated SessionTitleResult{..} ->
           case persist of
@@ -242,10 +337,9 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
                       PersistenceActive handle
                           | handle.sessionMeta.metaId == resultSessionId
                           , not handle.sessionMeta.metaTitleIsManual ->
-                              withMVar ioLock \_ ->
-                                  setWindowTitle
-                                      (cliWindowTitle handle.sessionMeta.metaCwd
-                                          (Just resultTitle))
+                              setWindowTitle
+                                  (cliWindowTitle handle.sessionMeta.metaCwd
+                                      (Just resultTitle))
                       _ -> pure ()
         SessionTitleFailed SessionTitleFailure{..} ->
           case persist of
@@ -900,6 +994,8 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
             , sessionTerminal = terminal
             , sessionFullscreen = fullscreen
             , sessionSetWindowTitle = setWindowTitle
+            , sessionBeginWindowTitleBusy = beginWindowTitleBusy
+            , sessionEndWindowTitleBusy = endWindowTitleBusy
             , sessionAgentViewport = Just agentViewport
             , sessionBeginSubagentTurn = beginSubagentTurn
             , sessionFinishSubagentTurn = finishSubagentTurn
@@ -1002,12 +1098,13 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
                 RecapSession kind -> callbacks.runnerRunSessionRecap False env kind
                 RecapTurnSummary -> callbacks.runnerRunSessionTurnSummary env
             recapWorker
-    result <- case fullscreen of
-        Just _ ->
-            withAsync btwWorker \_ ->
+    result <- withAsync windowTitleWorker \_ ->
+        case fullscreen of
+            Just _ ->
+                withAsync btwWorker \_ ->
+                    withAsync recapWorker (const sessionAction)
+            Nothing ->
                 withAsync recapWorker (const sessionAction)
-        Nothing ->
-            withAsync recapWorker (const sessionAction)
     _ <- waitForSessionTitleResults 5000000 titleManager
     applyPendingSessionTitles env
     pure result

--- a/packages/agent-cli/src/Agent/CLI/Session/Runner.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner.hs
@@ -108,14 +108,12 @@ import Agent.CLI.Subagents.Runtime
     , persistAndEvictSubagentSessionWithStatus
     )
 import Agent.CLI.Style
-    ( busyCliWindowTitle
-    , cliWindowTitle
+    ( cliWindowTitle
     , glyphSession
     , glyphWarn
     , roleMuted
     , roleWarn
     , setCliWindowTitle
-    , spinnerFrames
     )
 import Agent.CLI.Terminal
     ( TerminalCapabilities(..)
@@ -144,11 +142,10 @@ import Agent.TUI.Model
     , initialUiState
     , reduceUi
     )
-import Agent.TUI.Motion
-    ( MotionDemand(..)
-    , MotionMode(..)
-    , motionIntervalMicros
-    , nativeProgressAnimationEnabled
+import Agent.TUI.Motion (nativeProgressAnimationEnabled)
+import Agent.CLI.WindowTitle
+    ( WindowTitleController(..)
+    , newWindowTitleController
     )
 import Agent.CLI.Turn (applyPendingSessionTitles, runOneTurn)
 import Agent.Cancel (requestCancel)
@@ -194,17 +191,8 @@ import Agent.OsPath (toText)
 import Control.Concurrent.Async
     ( withAsync )
 import Control.Concurrent.Chan (newChan, readChan, writeChan)
-import Control.Concurrent (threadDelay)
 import Control.Concurrent.MVar
     ( newMVar, withMVar )
-import Control.Concurrent.STM
-    ( atomically
-    , check
-    , modifyTVar'
-    , newTVarIO
-    , readTVar
-    , writeTVar
-    )
 import Control.Exception.Safe
     ( catchAny )
 import Control.Monad (forM_, unless, void, when)
@@ -224,11 +212,6 @@ data AgentStepCache = AgentStepCache
     { cachedTranscript :: !(StableName [ResponseItem])
     , cachedVariant :: !(Maybe SubagentStatus)
     , cachedSteps :: ![AgentStep]
-    }
-
-data WindowTitleAnimationState = WindowTitleAnimationState
-    { windowTitleBase :: !Text
-    , windowTitleBusyDepth :: !Int
     }
 
 data SessionRunnerContinuation = SessionRunnerContinuation
@@ -260,11 +243,6 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
                           (Just handle.sessionMeta.metaTitle))
               _ -> pure (cliWindowTitle cwd Nothing)
       PersistenceDisabled -> pure (cliWindowTitle cwd Nothing)
-  windowTitleState <- newTVarIO
-      WindowTitleAnimationState
-          { windowTitleBase = initialWindowTitle
-          , windowTitleBusyDepth = 0
-          }
   let fullscreen = startup.startupFullscreen
       terminal = startup.startupTerminal
       stdoutHandle = startup.startupStdout
@@ -276,58 +254,16 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
           case fullscreen of
               Just runtime -> setFullscreenWindowTitle runtime title
               Nothing -> setCliWindowTitle stdoutTty stdoutHandle title
-      firstSpinnerFrame = case spinnerFrames of
-          frame : _ -> frame
-          [] -> "*"
-      setWindowTitle title =
-          withMVar ioLock \_ -> do
-              state <- atomically do
-                  current <- readTVar windowTitleState
-                  let updated = current { windowTitleBase = title }
-                  writeTVar windowTitleState updated
-                  pure updated
-              writeWindowTitle
-                  (if state.windowTitleBusyDepth > 0
-                      then busyCliWindowTitle firstSpinnerFrame title
-                      else title)
-      beginWindowTitleBusy =
-          withMVar ioLock \_ -> do
-              state <- atomically do
-                  modifyTVar' windowTitleState \current ->
-                      current
-                          { windowTitleBusyDepth =
-                              current.windowTitleBusyDepth + 1
-                          }
-                  readTVar windowTitleState
-              when (state.windowTitleBusyDepth == 1) $
-                  writeWindowTitle
-                      (busyCliWindowTitle
-                          firstSpinnerFrame
-                          state.windowTitleBase)
-      endWindowTitleBusy =
-          withMVar ioLock \_ -> do
-              state <- atomically do
-                  modifyTVar' windowTitleState \current ->
-                      current
-                          { windowTitleBusyDepth =
-                              max 0 (current.windowTitleBusyDepth - 1)
-                          }
-                  readTVar windowTitleState
-              when (state.windowTitleBusyDepth == 0) $
-                  writeWindowTitle state.windowTitleBase
-      windowTitleWorker =
-          unless (options.optMotionMode == MotionOff) $
-              forM_ (cycle spinnerFrames) \frame -> do
-                  atomically do
-                      state <- readTVar windowTitleState
-                      check (state.windowTitleBusyDepth > 0)
-                  withMVar ioLock \_ -> do
-                      state <- atomically (readTVar windowTitleState)
-                      when (state.windowTitleBusyDepth > 0) $
-                          writeWindowTitle
-                              (busyCliWindowTitle frame state.windowTitleBase)
-                  threadDelay
-                      (motionIntervalMicros options.optMotionMode MotionSlow)
+      withIoLock action = withMVar ioLock (const action)
+  windowTitle <- newWindowTitleController
+      options.optMotionMode
+      initialWindowTitle
+      withIoLock
+      writeWindowTitle
+  let setWindowTitle = windowTitle.windowTitleSet
+      beginWindowTitleBusy = windowTitle.windowTitleBeginBusy
+      endWindowTitleBusy = windowTitle.windowTitleEndBusy
+      windowTitleWorker = windowTitle.windowTitleWorker
       showTitleEvent = \case
         SessionTitleGenerated SessionTitleResult{..} ->
           case persist of

--- a/packages/agent-cli/src/Agent/CLI/SessionEnv.hs
+++ b/packages/agent-cli/src/Agent/CLI/SessionEnv.hs
@@ -88,6 +88,8 @@ data SessionEnv = SessionEnv
     , sessionTerminal :: !TerminalCapabilities
     , sessionFullscreen :: !(Maybe FullscreenRuntime)
     , sessionSetWindowTitle :: !(Text -> IO ())
+    , sessionBeginWindowTitleBusy :: !(IO ())
+    , sessionEndWindowTitleBusy :: !(IO ())
     , sessionAgentViewport :: !(Maybe AgentViewportEnv)
     , sessionBeginSubagentTurn :: !(IO (Maybe RootTurnId))
     , sessionFinishSubagentTurn :: !(Maybe RootTurnId -> IO ())

--- a/packages/agent-cli/src/Agent/CLI/Style.hs
+++ b/packages/agent-cli/src/Agent/CLI/Style.hs
@@ -50,7 +50,6 @@ module Agent.CLI.Style
     , terminalOrange
     , terminalMuted
     , cliWindowTitle
-    , busyCliWindowTitle
     , setCliWindowTitle
     ) where
 
@@ -309,10 +308,6 @@ cliWindowTitle _cwd sessionTitle =
             | not (Text.null title)
             , title /= "untitled" -> title
         _ -> "New session"
-
--- | Prefix a session title with one frame of the busy animation.
-busyCliWindowTitle :: Text -> Text -> Text
-busyCliWindowTitle frame title = frame <> " " <> title
 
 -- | Set the terminal window title when @tty@ is 'True'; no-op otherwise.
 setCliWindowTitle :: Bool -> Handle -> Text -> IO ()

--- a/packages/agent-cli/src/Agent/CLI/Style.hs
+++ b/packages/agent-cli/src/Agent/CLI/Style.hs
@@ -50,6 +50,7 @@ module Agent.CLI.Style
     , terminalOrange
     , terminalMuted
     , cliWindowTitle
+    , busyCliWindowTitle
     , setCliWindowTitle
     ) where
 
@@ -308,6 +309,10 @@ cliWindowTitle _cwd sessionTitle =
             | not (Text.null title)
             , title /= "untitled" -> title
         _ -> "New session"
+
+-- | Prefix a session title with one frame of the busy animation.
+busyCliWindowTitle :: Text -> Text -> Text
+busyCliWindowTitle frame title = frame <> " " <> title
 
 -- | Set the terminal window title when @tty@ is 'True'; no-op otherwise.
 setCliWindowTitle :: Bool -> Handle -> Text -> IO ()

--- a/packages/agent-cli/src/Agent/CLI/Turn.hs
+++ b/packages/agent-cli/src/Agent/CLI/Turn.hs
@@ -131,7 +131,7 @@ import Agent.Tools.PlanMode
     )
 import Agent.OsPath (toText, unsafeToFilePath)
 import Control.Monad (forM_, when)
-import Control.Exception.Safe (onException, tryAny)
+import Control.Exception.Safe (bracket_, onException, tryAny)
 import Data.IORef
     ( atomicModifyIORef'
     , readIORef
@@ -157,7 +157,14 @@ import System.Process
 import System.Timeout (timeout)
 
 runOneTurn :: SessionEnv -> Text -> [TurnInput] -> IO TurnResult
-runOneTurn env@SessionEnv
+runOneTurn env promptText inputs =
+    bracket_
+        env.sessionBeginWindowTitleBusy
+        env.sessionEndWindowTitleBusy
+        (runOneTurnBusy env promptText inputs)
+
+runOneTurnBusy :: SessionEnv -> Text -> [TurnInput] -> IO TurnResult
+runOneTurnBusy env@SessionEnv
     { sessionLoop = config
     , sessionRender = render
     , sessionConversation = conversationRef

--- a/packages/agent-cli/src/Agent/CLI/WindowTitle.hs
+++ b/packages/agent-cli/src/Agent/CLI/WindowTitle.hs
@@ -1,0 +1,110 @@
+-- | Coordinate the terminal window title with agent turn activity.
+module Agent.CLI.WindowTitle
+    ( WindowTitleController(..)
+    , busyWindowTitle
+    , newWindowTitleController
+    ) where
+
+import Agent.CLI.Style (spinnerFrames)
+import Agent.TUI.Motion
+    ( MotionDemand(..)
+    , MotionMode(..)
+    , motionIntervalMicros
+    )
+import Control.Concurrent (threadDelay)
+import Control.Concurrent.STM
+    ( atomically
+    , check
+    , modifyTVar'
+    , newTVarIO
+    , readTVar
+    , writeTVar
+    )
+import Control.Monad (forM_, unless, when)
+import Data.Text (Text)
+
+data WindowTitleController = WindowTitleController
+    { windowTitleSet :: !(Text -> IO ())
+    , windowTitleBeginBusy :: !(IO ())
+    , windowTitleEndBusy :: !(IO ())
+    , windowTitleWorker :: !(IO ())
+    }
+
+data WindowTitleState = WindowTitleState
+    { titleBase :: !Text
+    , titleBusyDepth :: !Int
+    }
+
+-- | Build a title controller. The caller supplies a shared output lock and the
+-- renderer-specific title writer, then scopes 'windowTitleWorker' with
+-- structured concurrency for the session lifetime.
+newWindowTitleController
+    :: MotionMode
+    -> Text
+    -> (IO () -> IO ())
+    -> (Text -> IO ())
+    -> IO WindowTitleController
+newWindowTitleController motionMode initialTitle withOutputLock writeTitle = do
+    stateVar <- newTVarIO
+        WindowTitleState
+            { titleBase = initialTitle
+            , titleBusyDepth = 0
+            }
+    let frames = case spinnerFrames of
+            [] -> ["*"]
+            available -> available
+        firstFrame = case frames of
+            frame : _ -> frame
+            [] -> "*"
+        setTitle title =
+            withOutputLock do
+                state <- atomically do
+                    current <- readTVar stateVar
+                    let updated = current { titleBase = title }
+                    writeTVar stateVar updated
+                    pure updated
+                writeTitle
+                    (if state.titleBusyDepth > 0
+                        then busyWindowTitle firstFrame title
+                        else title)
+        beginBusy =
+            withOutputLock do
+                state <- atomically do
+                    modifyTVar' stateVar \current ->
+                        current
+                            { titleBusyDepth = current.titleBusyDepth + 1 }
+                    readTVar stateVar
+                when (state.titleBusyDepth == 1) $
+                    writeTitle (busyWindowTitle firstFrame state.titleBase)
+        endBusy =
+            withOutputLock do
+                state <- atomically do
+                    modifyTVar' stateVar \current ->
+                        current
+                            { titleBusyDepth =
+                                max 0 (current.titleBusyDepth - 1)
+                            }
+                    readTVar stateVar
+                when (state.titleBusyDepth == 0) $
+                    writeTitle state.titleBase
+        worker =
+            unless (motionMode == MotionOff) $
+                forM_ (cycle frames) \frame -> do
+                    atomically do
+                        state <- readTVar stateVar
+                        check (state.titleBusyDepth > 0)
+                    withOutputLock do
+                        state <- atomically (readTVar stateVar)
+                        when (state.titleBusyDepth > 0) $
+                            writeTitle
+                                (busyWindowTitle frame state.titleBase)
+                    threadDelay (motionIntervalMicros motionMode MotionSlow)
+    pure WindowTitleController
+        { windowTitleSet = setTitle
+        , windowTitleBeginBusy = beginBusy
+        , windowTitleEndBusy = endBusy
+        , windowTitleWorker = worker
+        }
+
+busyWindowTitle :: Text -> Text -> Text
+busyWindowTitle frame title = frame <> " " <> title

--- a/packages/agent-cli/test/Agent/CLI/StyleSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/StyleSpec.hs
@@ -73,3 +73,7 @@ spec = do
         it "ignores untitled placeholders" do
             cliWindowTitle (fromFilePath "/tmp/haskell-agent") (Just "untitled")
                 `shouldBe` "New session"
+
+        it "prefixes busy titles with a spinner frame" do
+            busyCliWindowTitle "⠋" "fix the title"
+                `shouldBe` "⠋ fix the title"

--- a/packages/agent-cli/test/Agent/CLI/StyleSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/StyleSpec.hs
@@ -1,6 +1,13 @@
 module Agent.CLI.StyleSpec (spec) where
 
 import Agent.CLI.Style
+import Agent.CLI.WindowTitle
+    ( WindowTitleController(..)
+    , busyWindowTitle
+    , newWindowTitleController
+    )
+import Agent.TUI.Motion (MotionMode(..))
+import Data.IORef (modifyIORef', newIORef, readIORef)
 import System.OsPath (unsafeEncodeUtf)
 import qualified Data.Text as Text
 import Test.Hspec
@@ -74,6 +81,28 @@ spec = do
             cliWindowTitle (fromFilePath "/tmp/haskell-agent") (Just "untitled")
                 `shouldBe` "New session"
 
+    describe "WindowTitleController" do
         it "prefixes busy titles with a spinner frame" do
-            busyCliWindowTitle "⠋" "fix the title"
+            busyWindowTitle "⠋" "fix the title"
                 `shouldBe` "⠋ fix the title"
+
+        it "coordinates busy, renamed, and restored titles" do
+            written <- newIORef []
+            let firstFrame = case spinnerFrames of
+                    frame : _ -> frame
+                    [] -> "*"
+            controller <- newWindowTitleController
+                MotionOff
+                "initial"
+                id
+                (\title -> modifyIORef' written (<> [title]))
+            controller.windowTitleBeginBusy
+            controller.windowTitleSet "renamed"
+            controller.windowTitleEndBusy
+            actual <- readIORef written
+            actual
+                `shouldBe`
+                [ firstFrame <> " initial"
+                , firstFrame <> " renamed"
+                , "renamed"
+                ]


### PR DESCRIPTION
## Summary

- prefix the terminal title with the shared spinner while an agent turn is active
- restore the current session title as soon as the agent returns to user input
- encapsulate title state, synchronization, motion policy, and the animation worker in `Agent.CLI.WindowTitle`
- keep `Session.Runner` limited to renderer-specific wiring and lifecycle scoping
- keep nested/follow-up turns flicker-free with a re-entrant busy depth
- support minimal and fullscreen rendering while respecting full, reduced, and off motion modes
- scope the title worker to the session with structured concurrency

## Validation

- `nix develop -c cabal repl agent-cli:lib:agent-cli` and loaded `Agent.CLI.WindowTitle` and `Agent.CLI.Session.Runner`
- focused `WindowTitleController` specs: 2 examples, 0 failures
- live tmux smoke test: title cycled through multiple spinner frames during a turn and restored the plain session title while awaiting input
- regenerated the checked-in Cabal Nix expression (no output change was required for the module-list-only Cabal edit)
- `git diff --check`
