### PR TITLE
Set fullscreen window title through Vty

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -60,6 +60,7 @@ module Agent.CLI.TUI.App
     , wrapFullscreenKeyboardVty
     , setFullscreenImagePreviews
     , setFullscreenWindowTitle
+    , applyStoredFullscreenWindowTitle
     , turnCompletionRequiresRedraw
     , uiEventRestartsMotionSchedule
     , applyTextPromptEdit
@@ -371,6 +372,7 @@ newFullscreenRuntimeWithSyntaxLoader
         imagePreviewIdBase <- allocateNativePreviewImageIdBase
         imagePreviewProtocol <- detectImagePreviewProtocol stdout
         imagePreviewInTmux <- isJust <$> lookupEnv "TMUX"
+        windowTitle <- newIORef Nothing
         sessionActions <- newIORef FullscreenSessionActions
             { sessionCancel = cancelAction
             , sessionBtw = const (pure ())
@@ -398,6 +400,7 @@ newFullscreenRuntimeWithSyntaxLoader
                 readIORef sessionActions >>= (.sessionCtrlC)
             , runtimeCopy = copyAction
             , runtimeSetWindowTitle = setWindowTitle
+            , runtimeWindowTitle = windowTitle
             , runtimeNativeProgress = nativeProgress
             , runtimeAgentSnapshot =
                 readIORef sessionActions >>= (.sessionAgentSnapshot)
@@ -557,8 +560,20 @@ emitUiEvent runtime event =
     enqueueAppEvent runtime (AppUi event)
 
 setFullscreenWindowTitle :: FullscreenRuntime -> Text -> IO ()
-setFullscreenWindowTitle runtime =
-    enqueueAppEvent runtime . AppSetWindowTitle
+setFullscreenWindowTitle runtime title = do
+    writeIORef runtime.runtimeWindowTitle (Just title)
+    enqueueAppEvent runtime (AppSetWindowTitle title)
+
+-- | Brick/Vty owns the terminal, so titles must go through Vty output
+-- rather than stdout OSC writes.
+applyStoredFullscreenWindowTitle :: FullscreenRuntime -> V.Output -> IO ()
+applyStoredFullscreenWindowTitle runtime output =
+    readIORef runtime.runtimeWindowTitle
+        >>= mapM_ (writeOutputWindowTitle output)
+
+writeOutputWindowTitle :: V.Output -> Text -> IO ()
+writeOutputWindowTitle output title =
+    V.setOutputWindowTitle output (Text.unpack title)
 
 setFullscreenImagePreviews
     :: FullscreenRuntime
@@ -897,8 +912,13 @@ runFullscreen runtime workerAction = do
                 V.setMode output V.Hyperlink True
             when (V.supportsMode output V.Focus) $
                 V.setMode output V.Focus True
-            wrapNativePreviewVty runtime vty
-                >>= wrapFullscreenKeyboardVty terminal.terminalKittyKeyboard
+            wrapped <-
+                wrapNativePreviewVty runtime vty
+                    >>= wrapFullscreenKeyboardVty terminal.terminalKittyKeyboard
+            applyStoredFullscreenWindowTitle
+                runtime
+                (V.outputIface wrapped)
+            pure wrapped
     initialVty <- buildVty
     let
         initialState =
@@ -4526,8 +4546,8 @@ handleEventInner event = case event of
                         Just $
                             successNotice "Dictation inserted."
     AppEvent (AppSetWindowTitle title) -> do
-        state <- get
-        liftIO (state.appRuntime.runtimeSetWindowTitle title)
+        vty <- getVtyHandle
+        liftIO (writeOutputWindowTitle (V.outputIface vty) title)
         modify' \current -> current { appWindowTitle = Just title }
     AppEvent (AppSyntaxHighlighterLoaded highlighter) ->
         case highlighter of

--- a/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
@@ -186,6 +186,7 @@ data FullscreenRuntime = FullscreenRuntime
     , runtimeCtrlC :: !(IO CtrlCDecision)
     , runtimeCopy :: !(Text -> IO Bool)
     , runtimeSetWindowTitle :: !(Text -> IO ())
+    , runtimeWindowTitle :: !(IORef (Maybe Text))
     , runtimeNativeProgress :: !(Bool -> IO ())
     , runtimeAgentSnapshot :: !(IO (AgentTarget, [AgentEntry]))
     , runtimeAgentSelect :: !(AgentTarget -> IO ())

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -2,8 +2,10 @@ module Agent.CLI.TUIAppSpec (spec) where
 
 import Agent.CLI.AgentViewport (AgentEntry(..), AgentTarget(..))
 import Agent.CLI.Input (terminalTextWidth)
+import Agent.CLI.Interrupt (CtrlCDecision(..))
 import Agent.CLI.TUI.App
-    ( applyTextPromptEdit
+    ( applyStoredFullscreenWindowTitle
+    , applyTextPromptEdit
     , advanceCompletionFlashes
     , agentEntryWindow
     , agentPaneEntryLimit
@@ -18,6 +20,8 @@ import Agent.CLI.TUI.App
     , fullscreenVtyConfig
     , fullscreenSurface
     , mergeConversationView
+    , newFullscreenInputBuffer
+    , newFullscreenRuntime
     , wrapFullscreenKeyboardVty
     , motionDemandFor
     , motionDemandForTerminalFocus
@@ -33,6 +37,7 @@ import Agent.CLI.TUI.App
     , repositoryHeaderText
     , resumeSearchCursorColumn
     , selectedAgentConversation
+    , setFullscreenWindowTitle
     , textOverlayDisplayText
     , turnCompletionRequiresRedraw
     , uiEventRestartsMotionSchedule
@@ -40,6 +45,7 @@ import Agent.CLI.TUI.App
 import Agent.CLI.TUI.Types
     ( ChoiceOverlay(..)
     , ChoicePresentation(..)
+    , FullscreenRuntime(..)
     , Name(..)
     , TerminalFocus(..)
     , TextInputMode(..)
@@ -354,6 +360,37 @@ spec = do
 
             V.shutdown wrapped
             readIORef events `shouldReturn` [Right ()]
+
+    describe "fullscreen window title" do
+        it "replays the stored session title through Vty output" do
+            titles <- newIORef ([] :: [String])
+            input <- newFullscreenInputBuffer
+            runtime <- newFullscreenRuntime
+                input
+                (pure ())
+                (const (pure ()))
+                (pure WarnExit)
+                (const (pure True))
+                (const (pure ()))
+                (const (pure ()))
+                (pure (AgentRoot, []))
+                (const (pure ()))
+                (pure ())
+                (const (pure ()))
+                MotionFull
+                False
+                initialUiState
+            (_, output) <- VMock.mockTerminal (80, 24)
+            setFullscreenWindowTitle runtime "New session"
+            readIORef runtime.runtimeWindowTitle
+                `shouldReturn` Just "New session"
+            applyStoredFullscreenWindowTitle
+                runtime
+                output
+                    { V.setOutputWindowTitle =
+                        \title -> modifyIORef' titles (<> [title])
+                    }
+            readIORef titles `shouldReturn` ["New session"]
 
     describe "repositoryHeaderText" do
         it "puts the git state before the full checkout path" do


### PR DESCRIPTION
## Summary
- restore fullscreen session titles by writing them through Vty `setOutputWindowTitle` instead of stdout `hSetTitle`
- store the last requested title on the fullscreen runtime and replay it when Vty starts or is rebuilt
- add a regression test that the stored title is applied on the Vty output interface

Fullscreen Brick sessions currently leave the window titled `agent-cli --yolo --worktree` because OSC title writes go to stdout after Vty has taken over the terminal.

## Validation
- `nix develop -c cabal repl agent-cli:lib:agent-cli` loaded `Agent.CLI.TUI.App`
- `nix develop -c cabal test agent-cli:test:agent-cli-test --test-options='--match "fullscreen window title"'`