### PR TITLE
Add declarative MCP servers to Telegram module

### DIFF
--- a/nix/modules/telegram.nix
+++ b/nix/modules/telegram.nix
@@ -26,6 +26,48 @@ let
   isAbsoluteEnvironmentFile =
     path: hasPrefix "/" path || (hasPrefix "-/" path && builtins.stringLength path > 2);
 
+  mcpServerType = types.submodule {
+    options = {
+      enabled = mkOption {
+        type = types.bool;
+        default = true;
+        description = "Whether this MCP server is enabled.";
+      };
+      command = mkOption {
+        type = types.str;
+        description = "Executable used to start the stdio MCP server.";
+      };
+      args = mkOption {
+        type = types.listOf types.str;
+        default = [ ];
+        description = "Arguments passed to the MCP server executable.";
+      };
+      cwd = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = "Optional working directory for the MCP server.";
+      };
+      environment = mkOption {
+        type = types.attrsOf types.str;
+        default = { };
+        description = ''
+          Environment passed to the MCP server. Values are written to the Nix
+          store; use paths to runtime credential files rather than secrets.
+        '';
+      };
+      startupTimeoutSeconds = mkOption {
+        type = types.ints.positive;
+        default = 30;
+        description = "Maximum time allowed for MCP server initialization.";
+      };
+      requestTimeoutSeconds = mkOption {
+        type = types.ints.positive;
+        default = 60;
+        description = "Maximum time allowed for one MCP request.";
+      };
+    };
+  };
+
   instanceType = types.submodule (
     { name, config, ... }:
     {
@@ -183,6 +225,27 @@ let
             missing file.
           '';
         };
+
+        mcpInitStrategy = mkOption {
+          type = types.enum [
+            "auto"
+            "progressive"
+          ];
+          default = "auto";
+          description = "MCP initialization strategy used by agent-cli.";
+        };
+
+        mcpServers = mkOption {
+          type = types.nullOr (types.attrsOf mcpServerType);
+          default = null;
+          description = ''
+            Declarative agent-cli MCP servers for this instance. Null leaves
+            the existing machine-wide MCP configuration untouched. Any
+            attribute set, including an empty one, makes this module own the
+            complete mcpServers value in
+            <filename>~/.haskell-agent/config.json</filename>.
+          '';
+        };
       };
     }
   );
@@ -200,6 +263,25 @@ let
         yolo = instance.yolo;
         allowedUsers = instance.allowedUsers;
         inherit (instance) respondToAllGroupMessages;
+      }
+    );
+
+  managedMcpConfig =
+    name: instance:
+    pkgs.writeText "haskell-agent-telegram-${name}-mcp.json" (
+      builtins.toJSON {
+        mcpInitStrategy = instance.mcpInitStrategy;
+        mcpServers = lib.mapAttrs (_: server: {
+          inherit (server)
+            args
+            command
+            cwd
+            enabled
+            requestTimeoutSeconds
+            startupTimeoutSeconds
+            ;
+          env = server.environment;
+        }) instance.mcpServers;
       }
     );
 
@@ -307,6 +389,7 @@ in
       let
         directory = gatewayDirectory instance;
         generatedConfig = gatewayConfig name instance;
+        generatedMcpConfig = managedMcpConfig name instance;
       in
       nameValuePair (serviceName name) {
         description = "Haskell Agent Telegram gateway (${name})";
@@ -332,6 +415,7 @@ in
           pkgs.coreutils
           pkgs.git
         ]
+        ++ lib.optional (instance.mcpServers != null) pkgs.jq
         ++ instance.extraPackages;
 
         preStart = ''
@@ -344,6 +428,25 @@ in
           ln -sfn \
               "$CREDENTIALS_DIRECTORY/telegram-token" \
               ${lib.escapeShellArg "${directory}/token"}
+        ''
+        + lib.optionalString (instance.mcpServers != null) ''
+
+          harness_config=${lib.escapeShellArg "${instance.homeDirectory}/.haskell-agent/config.json"}
+          managed_config="$(mktemp "$harness_config.XXXXXX")"
+          if [ -f "$harness_config" ]; then
+            jq --slurpfile managed ${lib.escapeShellArg generatedMcpConfig} \
+              '.mcpInitStrategy = $managed[0].mcpInitStrategy
+               | .mcpServers = $managed[0].mcpServers' \
+              "$harness_config" > "$managed_config"
+          else
+            jq --slurpfile managed ${lib.escapeShellArg generatedMcpConfig} \
+              '{ version: 1,
+                 mcpInitStrategy: $managed[0].mcpInitStrategy,
+                 mcpServers: $managed[0].mcpServers }' \
+              /dev/null > "$managed_config"
+          fi
+          chmod 0600 "$managed_config"
+          mv -f "$managed_config" "$harness_config"
         '';
 
         serviceConfig = {

--- a/nix/tests/telegram-module.nix
+++ b/nix/tests/telegram-module.nix
@@ -44,6 +44,14 @@ let
           "/run/keys/provider"
           "-/run/keys/optional-provider"
         ];
+        mcpInitStrategy = "progressive";
+        mcpServers.example = {
+          command = "/nix/store/example/bin/example-mcp";
+          args = [ "--stdio" ];
+          environment.CREDENTIAL_FILE = "/run/keys/example";
+          startupTimeoutSeconds = 12;
+          requestTimeoutSeconds = 34;
+        };
       };
 
       secondary = {
@@ -181,9 +189,16 @@ pkgs.runCommand "haskell-agent-telegram-module-test"
         grep -o "/nix/store/[^ ']*-haskell-agent-telegram-secondary.json" |
         head -n1
     )"
+    primary_mcp_config="$(
+      printf '%s\n' "$primaryService" |
+        jq -r .preStart |
+        grep -o "/nix/store/[^ ']*-haskell-agent-telegram-primary-mcp.json" |
+        head -n1
+    )"
 
     test -f "$primary_config"
     test -f "$secondary_config"
+    test -f "$primary_mcp_config"
 
     jq -e '
       . == {
@@ -196,6 +211,23 @@ pkgs.runCommand "haskell-agent-telegram-module-test"
         yolo: false
       }
     ' "$primary_config" >/dev/null
+
+    jq -e '
+      . == {
+        mcpInitStrategy: "progressive",
+        mcpServers: {
+          example: {
+            args: ["--stdio"],
+            command: "/nix/store/example/bin/example-mcp",
+            cwd: null,
+            enabled: true,
+            env: { CREDENTIAL_FILE: "/run/keys/example" },
+            requestTimeoutSeconds: 34,
+            startupTimeoutSeconds: 12
+          }
+        }
+      }
+    ' "$primary_mcp_config" >/dev/null
 
     jq -e '
       . == {
@@ -225,6 +257,8 @@ pkgs.runCommand "haskell-agent-telegram-module-test"
       and .environment.MODULE_TEST == "present"
       and (.ExecStart | endswith("/bin/agent-telegram run"))
       and (.preStart | contains("$CREDENTIALS_DIRECTORY/telegram-token"))
+      and (.preStart | contains(".mcpInitStrategy = $managed[0].mcpInitStrategy"))
+      and (.preStart | contains(".mcpServers = $managed[0].mcpServers"))
     ' >/dev/null
 
     printf '%s\n' "$secondaryService" | jq -e '


### PR DESCRIPTION
## Summary
- add typed per-instance MCP server options to the Telegram NixOS module
- merge the managed MCP configuration into agent-cli's native config while preserving unrelated settings
- make null leave manual MCP configuration untouched and an attribute set declaratively own the MCP server map
- test generated MCP JSON and service integration

## Validation
- `nix build .#checks.x86_64-linux.nixos-module --no-link`
- `nixfmt`
- `git diff --check`