### PR TITLE
Keep pasted images visible in chat scrollback

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Commands.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Commands.hs
@@ -133,6 +133,7 @@ import Agent.CLI.Style
 import Agent.CLI.Subagents.Runtime ()
 import Agent.CLI.TUI.App
     ( FullscreenRuntime,
+      commitFullscreenImagePreviews,
       commitFullscreenHistoryTurn,
       emitUiEvent,
       setFullscreenImagePreviews,
@@ -354,7 +355,7 @@ handleReplLine
                             _ -> do
                                 pendingImages <- modifyLiveAttachments conversationRef \imgs -> ([], imgs)
                                 forM_ fullscreen \runtime ->
-                                    setFullscreenImagePreviews runtime []
+                                    commitFullscreenImagePreviews runtime pendingImages
                                 resetRenderPrintedText render
                                 let turnInputs =
                                         if null pendingImages
@@ -391,7 +392,7 @@ handleReplLine
                                     modifyLiveAttachments conversationRef
                                         \imgs -> ([], imgs)
                                 forM_ fullscreen \runtime ->
-                                    setFullscreenImagePreviews runtime []
+                                    commitFullscreenImagePreviews runtime pendingImages
                                 let userText =
                                         if Text.null arguments
                                             then "Use the "
@@ -692,7 +693,7 @@ handleReplLine
         pendingImages <-
             modifyLiveAttachments conversationRef \imgs -> ([], imgs)
         forM_ fullscreen \runtime ->
-            setFullscreenImagePreviews runtime []
+            commitFullscreenImagePreviews runtime pendingImages
         let turnInputs =
                 if null pendingImages
                     then [UserMessage expanded]

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -48,6 +48,7 @@ module Agent.CLI.TUI.App
     , requestFullscreenSecret
     , requestFullscreenText
     , runFullscreen
+    , commitFullscreenImagePreviews
     , commitFullscreenHistoryTurn
     , clearFullscreenHistorySource
     , reloadFullscreenHistorySource
@@ -566,26 +567,48 @@ setFullscreenImagePreviews runtime images = do
     prepared <-
         if map fst previous == images
             then pure previous
-            else do
-                let next =
-                        mapMaybe
-                            (\image ->
-                                case prepareTuiImagePreview image of
-                                    Left _ -> Nothing
-                                    Right preview -> Just (image, preview))
-                            images
-                -- ANSI previews force the sampled image during Brick drawing.
-                -- Build that sample here on the model worker instead of
-                -- stalling the Brick event/render thread.
-                unless runtime.runtimeNativeImagePreviews $
-                    mapM_
-                        (\(_, preview) ->
-                            void $
-                                pure $!
-                                    pixelAt preview.previewSample 0 0)
-                        next
-                pure next
+            else prepareFullscreenImagePreviews runtime images
     enqueueAppEvent runtime (AppSetImagePreviews prepared)
+
+-- | Move pending composer previews into the next submitted user message.
+commitFullscreenImagePreviews
+    :: FullscreenRuntime
+    -> [ImageAttachment]
+    -> IO ()
+commitFullscreenImagePreviews runtime images = do
+    previous <- readIORef runtime.runtimeImagePreviews
+    prepared <-
+        if map fst previous == images
+            then pure previous
+            else prepareFullscreenImagePreviews runtime images
+    -- Submitted images use the ANSI renderer even when the transient overlay
+    -- used Kitty placement, so finish sampling before the Brick render thread.
+    mapM_
+        (\(_, preview) ->
+            void $ pure $! pixelAt preview.previewSample 0 0)
+        prepared
+    enqueueAppEvent runtime (AppCommitImagePreviews prepared)
+
+prepareFullscreenImagePreviews
+    :: FullscreenRuntime
+    -> [ImageAttachment]
+    -> IO [(ImageAttachment, TuiImagePreview)]
+prepareFullscreenImagePreviews runtime images = do
+    let prepared =
+            mapMaybe
+                (\image ->
+                    case prepareTuiImagePreview image of
+                        Left _ -> Nothing
+                        Right preview -> Just (image, preview))
+                images
+    -- ANSI previews force the sampled image during Brick drawing. Build that
+    -- sample here on the model worker instead of stalling the render thread.
+    unless runtime.runtimeNativeImagePreviews $
+        mapM_
+            (\(_, preview) ->
+                void $ pure $! pixelAt preview.previewSample 0 0)
+            prepared
+    pure prepared
 
 hasQueuedFullscreenInput :: FullscreenRuntime -> IO Bool
 hasQueuedFullscreenInput runtime =
@@ -1046,6 +1069,7 @@ initialFullscreenAppState runtime history initialAgent initialAgents initialCloc
         , appKillBuffer = ""
         , appSlashCatalog = defaultSlashCatalog
         , appImagePreviews = []
+        , appSubmittedImagePreviews = Map.empty
         , appAgentSelected = initialAgent
         , appAgentEntries = initialAgents
         , appAgentHover = Nothing
@@ -3131,7 +3155,7 @@ drawBlock state target ui block =
                             , timestampedMessage
                                 Theme.userMutedAttr
                                 block.blockTimestamp
-                                (terminalTxtWrap block.blockBody)
+                                (submittedUserMessage state target block)
                             ]
             BlockAssistant ->
                 padLeft (Pad 3) $
@@ -3218,6 +3242,39 @@ drawBlock state target ui block =
                 (codeCopyCacheState state target block.blockId))
             rendered
         else rendered
+
+submittedUserMessage
+    :: AppState
+    -> AgentTarget
+    -> UiBlock
+    -> Widget Name
+submittedUserMessage state target block =
+    vBox $
+        [terminalTxtWrap block.blockBody]
+            <> case target of
+                AgentChild _ -> []
+                AgentRoot ->
+                    map submittedImage $
+                        Map.findWithDefault
+                            []
+                            block.blockId
+                            state.appSubmittedImagePreviews
+  where
+    submittedImage preview =
+        padTop (Pad 1) $
+            vBox
+                [ hLimit 36 (renderTuiImagePreview 36 12 preview)
+                , withAttr Theme.userMutedAttr $
+                    terminalTxt $
+                        "🖼 "
+                            <> preview.previewMime
+                            <> " · "
+                            <> Text.pack (show preview.previewSourceWidth)
+                            <> "×"
+                            <> Text.pack (show preview.previewSourceHeight)
+                            <> " · "
+                            <> formatImageSize preview.previewBytes
+                ]
 
 timestampedMessage :: AttrName -> Text -> Widget Name -> Widget Name
 timestampedMessage timestampAttr timestamp body
@@ -4089,6 +4146,7 @@ applyConversationUiEvent renderedContentHeight uiEvent state =
                 , appHistorySelectedBlock = Nothing
                 , appHistoryLiveStart = Nothing
                 , appNextHistoryBlockId = -1
+                , appSubmittedImagePreviews = Map.empty
                 }
         _ -> state
 
@@ -4418,6 +4476,29 @@ handleEventInner event = case event of
                 current
                     { appImagePreviews = map snd prepared
                     }
+    AppEvent (AppCommitImagePreviews prepared) -> do
+        state <- get
+        let previews = map snd prepared
+            nextBlockId = BlockId state.appUi.uiNextBlockId
+            submitted =
+                if null previews
+                    then Map.delete
+                        nextBlockId
+                        state.appSubmittedImagePreviews
+                    else Map.insert
+                        nextBlockId
+                        previews
+                        state.appSubmittedImagePreviews
+        liftIO do
+            writeIORef state.appRuntime.runtimeImagePreviews []
+            modifyIORef'
+                state.appRuntime.runtimeImagePreviewRevision
+                (+ 1)
+        modify' \current ->
+            current
+                { appImagePreviews = []
+                , appSubmittedImagePreviews = submitted
+                }
     AppEvent (AppDictationFinished result) ->
         case result of
             Left message ->

--- a/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
@@ -124,6 +124,7 @@ data AppEvent
     | AppSetModelIds ![Text]
       -- ^ Legacy compatibility; prefer 'AppSetSlashCatalog'.
     | AppSetImagePreviews ![(ImageAttachment, TuiImagePreview)]
+    | AppCommitImagePreviews ![(ImageAttachment, TuiImagePreview)]
     | AppDictationFinished !(Either Text Text)
     | AppAgentSnapshot !AgentTarget ![AgentEntry]
     | AppSetWindowTitle !Text
@@ -247,6 +248,7 @@ data AppState = AppState
     , appKillBuffer :: !Text
     , appSlashCatalog :: !SlashCatalog
     , appImagePreviews :: ![TuiImagePreview]
+    , appSubmittedImagePreviews :: !(Map.Map BlockId [TuiImagePreview])
     , appAgentSelected :: !AgentTarget
     , appAgentEntries :: ![AgentEntry]
     , appAgentHover :: !(Maybe AgentHover)


### PR DESCRIPTION
## Summary
- retain submitted image previews on their corresponding user message
- render image thumbnails with MIME type, dimensions, and size in chat scrollback
- clear only the transient composer overlay after submission and clean retained previews when the conversation is cleared

## Validation
- `nix develop -c cabal repl agent-cli:lib:agent-cli` (all 134 modules loaded)
- live tmux TTY smoke test with a generated PNG; confirmed the image remained inside the submitted user message after the composer returned to Ready
- `git diff --check`

## Current limitation
- resumed historical sessions do not yet reconstruct image thumbnails