### PR TITLE
fix(xai): match Grok Build 1.0.8 proxy contract

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Prompt.hs
+++ b/packages/agent-cli/src/Agent/CLI/Prompt.hs
@@ -17,6 +17,7 @@ import Agent.Dialect
     , PromptStyle(..)
     , dialectPromptStyle
     )
+import Agent.CLI.Tools (hostedSearchToolNames)
 import Agent.GrokBuild.Dialect.Prompt
     ( codingGrokPromptTools
     , grokSystemPrompt
@@ -89,7 +90,7 @@ systemPromptForTools
             , timeContextGuidance
             ]
   where
-    available = hostedSearchTools dialect ++ toolNames
+    available = hostedSearchToolNames dialect ++ toolNames
     base = case dialectPromptStyle dialect of
         GrokBuildPromptStyle ->
             grokSystemPromptForTools
@@ -108,11 +109,6 @@ systemPromptForTools
                 isNonInteractive
         ClaudeCodePromptStyle ->
             claudeCodeSystemPrompt cwd today
-
-hostedSearchTools :: Dialect -> [Text]
-hostedSearchTools dialect =
-    "web_search"
-        : ["x_search" | dialectPromptStyle dialect == GrokBuildPromptStyle]
 
 -- | Tell the model about its second filesystem sandbox root without changing
 -- the project/worktree used for relative paths.

--- a/packages/agent-cli/src/Agent/CLI/Prompt.hs
+++ b/packages/agent-cli/src/Agent/CLI/Prompt.hs
@@ -68,7 +68,7 @@ systemPrompt dialect cwd sessionTmp today isNonInteractive =
             claudeCodeSystemPrompt cwd today
 
 -- | Render a child prompt against the final filtered application-tool set.
--- @web_search@ is server-side and remains available independently.
+-- Hosted search tools are server-side and remain available independently.
 systemPromptForTools
     :: Dialect
     -> [Text]
@@ -89,7 +89,7 @@ systemPromptForTools
             , timeContextGuidance
             ]
   where
-    available = "web_search" : toolNames
+    available = hostedSearchTools dialect ++ toolNames
     base = case dialectPromptStyle dialect of
         GrokBuildPromptStyle ->
             grokSystemPromptForTools
@@ -108,6 +108,11 @@ systemPromptForTools
                 isNonInteractive
         ClaudeCodePromptStyle ->
             claudeCodeSystemPrompt cwd today
+
+hostedSearchTools :: Dialect -> [Text]
+hostedSearchTools dialect =
+    "web_search"
+        : ["x_search" | dialectPromptStyle dialect == GrokBuildPromptStyle]
 
 -- | Tell the model about its second filesystem sandbox root without changing
 -- the project/worktree used for relative paths.

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration.hs
@@ -659,6 +659,7 @@ mcpToolCollision existingTools = go
     existing =
         Map.fromList $
             ("web_search", "built-in web search")
+                : ("x_search", "built-in X search")
                 : [ (canonicalToolName tool.appToolName, "built-in tool")
                   | tool <- existingTools
                   ]

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration.hs
@@ -251,7 +251,7 @@ import Agent.CLI.Terminal
       reportTerminalCwd,
       resolveColor,
       TerminalCapabilities(terminalNativeProgress) )
-import Agent.CLI.Tools ( schemasFromAppTools )
+import Agent.CLI.Tools ( hostedSearchToolCollisions, schemasFromAppTools )
 import Agent.CLI.Turn ()
 import Agent.CLI.Usage ()
 import Agent.CLI.WebFetch
@@ -658,11 +658,10 @@ mcpToolCollision existingTools = go
   where
     existing =
         Map.fromList $
-            ("web_search", "built-in web search")
-                : ("x_search", "built-in X search")
-                : [ (canonicalToolName tool.appToolName, "built-in tool")
-                  | tool <- existingTools
-                  ]
+            hostedSearchToolCollisions
+                ++ [ (canonicalToolName tool.appToolName, "built-in tool")
+                   | tool <- existingTools
+                   ]
 
     go [] = Nothing
     go (registration : rest) =

--- a/packages/agent-cli/src/Agent/CLI/Session/Runner.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner.hs
@@ -821,7 +821,10 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
             pure $
                 case dialectToolLayout dialect of
                     NoHostToolLayout -> []
-                    _ -> "web_search" : projectedNames
+                    _
+                        | dialectId dialect == GrokBuildDialect ->
+                            "web_search" : "x_search" : projectedNames
+                        | otherwise -> "web_search" : projectedNames
         shellModeFlags = \case
             ShellGhci -> (True, False)
             ShellBash -> (False, True)

--- a/packages/agent-cli/src/Agent/CLI/Session/Runner.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner.hs
@@ -120,7 +120,11 @@ import Agent.CLI.Terminal
     , resolveColor
     )
 import Agent.CLI.Request (setRequestInstructionsAndTools)
-import Agent.CLI.Tools (requireToolRegistry, schemasFromAppTools)
+import Agent.CLI.Tools
+    ( hostedSearchToolNames
+    , requireToolRegistry
+    , schemasFromAppTools
+    )
 import Agent.CLI.Dialects
     ( filterBashTools
     , filterGhciTools
@@ -821,10 +825,7 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
             pure $
                 case dialectToolLayout dialect of
                     NoHostToolLayout -> []
-                    _
-                        | dialectId dialect == GrokBuildDialect ->
-                            "web_search" : "x_search" : projectedNames
-                        | otherwise -> "web_search" : projectedNames
+                    _ -> hostedSearchToolNames dialect ++ projectedNames
         shellModeFlags = \case
             ShellGhci -> (True, False)
             ShellBash -> (False, True)

--- a/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
@@ -813,7 +813,7 @@ runHttpSubagent runtime dialect provider sendToRoot mkBackend =
                                         filter (not . Text.null)
                                             [ grokSubagentSystemPrompt
                                                 codingGrokPromptTools
-                                                ("web_search" : map (.appToolName) tools)
+                                                ("web_search" : "x_search" : map (.appToolName) tools)
                                                 env.subCwd
                                                 today
                                                 (Text.pack SystemInfo.os)

--- a/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
@@ -43,7 +43,11 @@ import Agent.CLI.SubagentStore
     , saveSubagentState
     , subagentDiskFields
     )
-import Agent.CLI.Tools (requireToolRegistry, schemasFromAppTools)
+import Agent.CLI.Tools
+    ( hostedSearchToolNames
+    , requireToolRegistry
+    , schemasFromAppTools
+    )
 import Agent.CLI.Dialects
     ( CodingTools(..)
     , codingToolsFor
@@ -813,7 +817,8 @@ runHttpSubagent runtime dialect provider sendToRoot mkBackend =
                                         filter (not . Text.null)
                                             [ grokSubagentSystemPrompt
                                                 codingGrokPromptTools
-                                                ("web_search" : "x_search" : map (.appToolName) tools)
+                                                (hostedSearchToolNames childDialect
+                                                    ++ map (.appToolName) tools)
                                                 env.subCwd
                                                 today
                                                 (Text.pack SystemInfo.os)

--- a/packages/agent-cli/src/Agent/CLI/Tools.hs
+++ b/packages/agent-cli/src/Agent/CLI/Tools.hs
@@ -3,7 +3,10 @@ module Agent.CLI.Tools
     ( requireToolRegistry
     , lookupAppTool
     , schemasFromAppTools
+    , hostedSearchToolNames
+    , hostedSearchToolCollisions
     , webSearchTool
+    , xSearchTool
     ) where
 
 import Agent.Responses.Types
@@ -48,21 +51,44 @@ lookupAppTool name =
 -- | Built-in Responses @web_search@ tool, enabled for every provider by default.
 -- The host runs the search server-side; the agent loop never dispatches it.
 webSearchTool :: ResponseTool
-webSearchTool = KnownResponseTool ToolWebSearch TaggedObject
-    { tag = "web_search"
-    , fields = KeyMap.empty
-    }
+webSearchTool = knownResponseTool ToolWebSearch KeyMap.empty
+
+-- | Grok Build hosted @x_search@ tool. Server-side; the loop never dispatches it.
+xSearchTool :: ResponseTool
+xSearchTool = knownResponseTool ToolXSearch KeyMap.empty
+
+hostedSearchToolTypes :: Dialect -> [ResponseToolType]
+hostedSearchToolTypes dialect =
+    ToolWebSearch
+        : [ToolXSearch | dialectId dialect == GrokBuildDialect]
+
+hostedSearchTools :: Dialect -> [ResponseTool]
+hostedSearchTools dialect =
+    map (`knownResponseTool` KeyMap.empty) (hostedSearchToolTypes dialect)
+
+-- | Model-facing names for hosted search tools advertised in this dialect.
+hostedSearchToolNames :: Dialect -> [Text]
+hostedSearchToolNames =
+    map responseToolTypeText . hostedSearchToolTypes
+
+-- | Names reserved so MCP servers cannot shadow hosted search tools.
+hostedSearchToolCollisions :: [(Text, Text)]
+hostedSearchToolCollisions =
+    [ (responseToolTypeText ToolWebSearch, "built-in web search")
+    , (responseToolTypeText ToolXSearch, "built-in X search")
+    ]
 
 schemasFromAppTools :: Dialect -> [AppTool] -> [ResponseTool]
 schemasFromAppTools dialect tools = case dialectToolLayout dialect of
     CollaborationNamespaceLayout ->
         let (multi, rest) = partition isMultiAgentTool tools
-            base = webSearchTool : mapMaybe (schemaFromAppTool dialect) rest
+            base = hostedSearchTools dialect
+                ++ mapMaybe (schemaFromAppTool dialect) rest
         in if null multi
             then base
             else base ++ [multiAgentNamespaceTool multi]
     FlatToolLayout ->
-        webSearchTool : mapMaybe (schemaFromAppTool dialect) tools
+        hostedSearchTools dialect ++ mapMaybe (schemaFromAppTool dialect) tools
     NoHostToolLayout ->
         []
 
@@ -142,15 +168,13 @@ grokPublicText =
 
 -- | Codex collaboration namespace: nested non-strict function tools.
 multiAgentNamespaceTool :: [AppTool] -> ResponseTool
-multiAgentNamespaceTool tools = KnownResponseTool ToolNamespace TaggedObject
-    { tag = "namespace"
-    , fields = KeyMap.fromList
+multiAgentNamespaceTool tools = knownResponseTool ToolNamespace $
+    KeyMap.fromList
         [ (Key.fromText "name", Aeson.String multiAgentNamespace)
         , (Key.fromText "description", Aeson.String
             "Tools for spawning and managing sub-agents.")
         , (Key.fromText "tools", Aeson.toJSON (map nestedFunction tools))
         ]
-    }
   where
     nestedFunction tool = Aeson.object
         [ "type" .= ("function" :: Text)
@@ -174,9 +198,8 @@ appToolJsonParameters tool = case tool.appToolSchema of
 
 -- | Codex registers apply_patch as a Responses custom tool with a Lark grammar.
 applyPatchCustomTool :: Text -> Text -> ResponseTool
-applyPatchCustomTool name description = KnownResponseTool ToolCustom TaggedObject
-    { tag = "custom"
-    , fields = KeyMap.fromList
+applyPatchCustomTool name description = knownResponseTool ToolCustom $
+    KeyMap.fromList
         [ (Key.fromText "name", Aeson.String name)
         , (Key.fromText "description", Aeson.String description)
         , (Key.fromText "format", Aeson.object
@@ -185,4 +208,3 @@ applyPatchCustomTool name description = KnownResponseTool ToolCustom TaggedObjec
             , "definition" .= applyPatchGrammar
             ])
         ]
-    }

--- a/packages/agent-cli/test/Agent/CLI/PromptSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/PromptSpec.hs
@@ -46,6 +46,7 @@ spec = describe "systemPrompt" do
         grok `shouldSatisfy` Text.isInfixOf "monitor"
         grok `shouldSatisfy` Text.isInfixOf "spawn_subagent"
         grok `shouldSatisfy` Text.isInfixOf "web_search"
+        grok `shouldSatisfy` Text.isInfixOf "x_search"
         grok `shouldSatisfy` Text.isInfixOf "<plan_mode>"
         grok `shouldSatisfy` Text.isInfixOf "enter_plan_mode"
         grok `shouldSatisfy` Text.isInfixOf "exit_plan_mode"
@@ -113,6 +114,7 @@ spec = describe "systemPrompt" do
                     True
         prompt `shouldSatisfy` Text.isInfixOf "read_file"
         prompt `shouldSatisfy` Text.isInfixOf "web_search"
+        prompt `shouldSatisfy` Text.isInfixOf "x_search"
         prompt `shouldNotSatisfy` Text.isInfixOf "search_replace"
         prompt `shouldNotSatisfy` Text.isInfixOf "run_terminal_cmd"
         prompt `shouldNotSatisfy` Text.isInfixOf "run_ghci"

--- a/packages/agent-cli/test/Agent/CLI/ToolsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ToolsSpec.hs
@@ -75,7 +75,8 @@ spec = describe "schemasFromAppTools" do
             killTask = testTool "kill_task"
         case schemasFromAppTools grokBuildDialect
             [terminal, task, getOutput, waitTasks, killTask] of
-            [ _
+            [ KnownResponseTool ToolWebSearch _
+                , KnownResponseTool ToolXSearch _
                 , FunctionToolValue terminalTool
                 , FunctionToolValue taskTool
                 , FunctionToolValue getOutputTool
@@ -118,7 +119,7 @@ spec = describe "schemasFromAppTools" do
 
     it "builds a loose grok-build function tool for xAI" do
         case schemasFromAppTools grokBuildDialect [jsonTool] of
-            [_, FunctionToolValue tool] -> do
+            [KnownResponseTool ToolWebSearch _, KnownResponseTool ToolXSearch _, FunctionToolValue tool] -> do
                 tool.name `shouldBe` "read_file"
                 tool.strict `shouldBe` Nothing
                 required_ tool `shouldBe` Just (Aeson.toJSON (["target_file"] :: [Text]))
@@ -162,7 +163,7 @@ spec = describe "schemasFromAppTools" do
                 AlwaysReadOnly
                 (noArgsTool "seo_auth_status" (pure (Right "ok")))
         case schemasFromAppTools grokBuildDialect [tool] of
-            [_, FunctionToolValue function] -> do
+            [KnownResponseTool ToolWebSearch _, KnownResponseTool ToolXSearch _, FunctionToolValue function] -> do
                 function.name `shouldBe` "seo_auth_status"
                 function.parameters `shouldBe` Just parameters
                 function.strict `shouldBe` Nothing

--- a/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Prompt.hs
+++ b/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Prompt.hs
@@ -170,6 +170,7 @@ toolCalling tools =
         <> tools.grokExecute
         <> "` exclusively for actual system commands and terminal operations that require shell execution. NEVER use bash echo or other command-line tools to communicate thoughts, explanations, or instructions to the user. Output all communication directly in your response text instead.\n\
     \- Use `web_search` to look up current public information on the internet.\n\
+    \- Use `x_search` to look up current posts and discussions on X.\n\
     \- Do not mention tools this session does not register.\n\
     \</tool_calling>"
 
@@ -193,6 +194,8 @@ toolCallingForTools tools available =
                 )
             <> toolLine "web_search"
                 "- Use `web_search` to look up current public information on the internet."
+            <> toolLine "x_search"
+                "- Use `x_search` to look up current posts and discussions on X."
             <> ["- Do not mention tools this session does not register."]
   where
     toolLine name line

--- a/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Prompt.hs
+++ b/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Prompt.hs
@@ -32,6 +32,8 @@ data GrokPromptTools = GrokPromptTools
     , grokEnterPlan :: !Text
     , grokExitPlan :: !Text
     , grokAskUser :: !Text
+    , grokWebSearch :: !Text
+    , grokXSearch :: !Text
     } deriving (Eq, Show)
 
 codingGrokPromptTools :: GrokPromptTools
@@ -48,6 +50,8 @@ codingGrokPromptTools = GrokPromptTools
     , grokEnterPlan = "enter_plan_mode"
     , grokExitPlan = "exit_plan_mode"
     , grokAskUser = "ask_user_question"
+    , grokWebSearch = "web_search"
+    , grokXSearch = "x_search"
     }
 
 grokSystemPrompt :: GrokPromptTools -> OsPath -> Day -> Bool -> Text
@@ -169,8 +173,12 @@ toolCalling tools =
         <> "` instead of ls). Reserve `"
         <> tools.grokExecute
         <> "` exclusively for actual system commands and terminal operations that require shell execution. NEVER use bash echo or other command-line tools to communicate thoughts, explanations, or instructions to the user. Output all communication directly in your response text instead.\n\
-    \- Use `web_search` to look up current public information on the internet.\n\
-    \- Use `x_search` to look up current posts and discussions on X.\n\
+    \- Use `"
+        <> tools.grokWebSearch
+        <> "` to look up current public information on the internet.\n\
+    \- Use `"
+        <> tools.grokXSearch
+        <> "` to look up current posts and discussions on X.\n\
     \- Do not mention tools this session does not register.\n\
     \</tool_calling>"
 
@@ -192,10 +200,12 @@ toolCallingForTools tools available =
                     <> tools.grokExecute
                     <> "` for system commands and terminal operations."
                 )
-            <> toolLine "web_search"
-                "- Use `web_search` to look up current public information on the internet."
-            <> toolLine "x_search"
-                "- Use `x_search` to look up current posts and discussions on X."
+            <> toolLine tools.grokWebSearch
+                ("- Use `" <> tools.grokWebSearch
+                    <> "` to look up current public information on the internet.")
+            <> toolLine tools.grokXSearch
+                ("- Use `" <> tools.grokXSearch
+                    <> "` to look up current posts and discussions on X.")
             <> ["- Do not mention tools this session does not register."]
   where
     toolLine name line

--- a/packages/agent-responses-types/src/Agent/Responses/Types.hs
+++ b/packages/agent-responses-types/src/Agent/Responses/Types.hs
@@ -52,6 +52,7 @@ module Agent.Responses.Types
     , ResponseTool(..)
     , ResponseToolType(..)
     , responseToolTypeText
+    , knownResponseTool
     , FunctionTool(..)
 
       -- * Response

--- a/packages/agent-responses-types/src/Agent/Responses/Types/Tools.hs
+++ b/packages/agent-responses-types/src/Agent/Responses/Types/Tools.hs
@@ -3,6 +3,7 @@ module Agent.Responses.Types.Tools
     ( ResponseTool(..)
     , ResponseToolType(..)
     , responseToolTypeText
+    , knownResponseTool
     , FunctionTool(..)
     ) where
 
@@ -110,9 +111,19 @@ data ResponseTool
     | UnknownResponseTool !TaggedObject
     deriving stock (Eq, Show)
 
+-- | Hosted or built-in Responses tool whose wire @type@ comes from
+-- 'ResponseToolType', not a caller-supplied tag string.
+knownResponseTool :: ResponseToolType -> Aeson.Object -> ResponseTool
+knownResponseTool toolType fields =
+    KnownResponseTool toolType TaggedObject
+        { tag = responseToolTypeText toolType
+        , fields
+        }
+
 instance ToJSON ResponseTool where
     toJSON (FunctionToolValue value) = toJSON value
-    toJSON (KnownResponseTool _ value) = toJSON value
+    toJSON (KnownResponseTool toolType TaggedObject { fields }) =
+        objectWith fields [Just (field "type" (responseToolTypeText toolType))]
     toJSON (UnknownResponseTool value) = toJSON value
 
 instance FromJSON ResponseTool where

--- a/packages/agent-responses-types/src/Agent/Responses/Types/Tools.hs
+++ b/packages/agent-responses-types/src/Agent/Responses/Types/Tools.hs
@@ -17,6 +17,7 @@ data ResponseToolType
     | ToolComputer
     | ToolComputerUsePreview
     | ToolWebSearch
+    | ToolXSearch
     | ToolMcp
     | ToolCodeInterpreter
     | ToolProgrammaticToolCalling
@@ -38,6 +39,7 @@ responseToolTypeText = \case
     ToolComputer -> "computer"
     ToolComputerUsePreview -> "computer_use_preview"
     ToolWebSearch -> "web_search"
+    ToolXSearch -> "x_search"
     ToolMcp -> "mcp"
     ToolCodeInterpreter -> "code_interpreter"
     ToolProgrammaticToolCalling -> "programmatic_tool_calling"
@@ -59,6 +61,7 @@ parseResponseToolType value = case value of
     "computer_use_preview" -> ToolComputerUsePreview
     "computer_use" -> ToolComputer
     "web_search" -> ToolWebSearch
+    "x_search" -> ToolXSearch
     "mcp" -> ToolMcp
     "code_interpreter" -> ToolCodeInterpreter
     "programmatic_tool_calling" -> ToolProgrammaticToolCalling

--- a/packages/agent-xai/src/Agent/XAI/Client.hs
+++ b/packages/agent-xai/src/Agent/XAI/Client.hs
@@ -135,12 +135,17 @@ createResponseWithMaybeEventsPolicy policy options credential request onEvent
     configureRequest =
         setRequestHeader "Authorization"
             ["Bearer " <> Text.encodeUtf8 credential.accessToken]
-            . setRequestHeader "X-XAI-Token-Auth" ["xai-grok-cli"]
+            . setRequestHeader "X-XAI-Token-Auth"
+                [Text.encodeUtf8 grokTokenAuthValue]
+            . setRequestHeader "x-authenticateresponse"
+                [Text.encodeUtf8 grokAuthenticateResponseValue]
             . setRequestHeader "x-grok-client-version"
                 [Text.encodeUtf8 options.clientVersion]
-            . setRequestHeader "x-grok-client-identifier" ["grok-shell"]
+            . setRequestHeader "x-grok-client-identifier"
+                [Text.encodeUtf8 grokClientIdentifier]
             . setRequestHeader "x-grok-client-mode" ["interactive"]
-            . setRequestHeader "User-Agent" ["codex-hs"]
+            . setRequestHeader "User-Agent"
+                [Text.encodeUtf8 (grokUserAgent options.clientVersion)]
 
 defaultTransientPolicy :: RetryPolicyM IO
 defaultTransientPolicy =

--- a/packages/agent-xai/src/Agent/XAI/Options.hs
+++ b/packages/agent-xai/src/Agent/XAI/Options.hs
@@ -3,6 +3,11 @@ module Agent.XAI.Options
     ( ClientOptions(..)
     , defaultClientOptions
     , clientOptionsFromEnv
+    , defaultGrokClientVersion
+    , grokAuthenticateResponseValue
+    , grokClientIdentifier
+    , grokTokenAuthValue
+    , grokUserAgent
     ) where
 
 import Agent.Provider.Options
@@ -13,6 +18,47 @@ import Agent.Provider.Options
 import qualified Data.Maybe as Maybe
 import Data.Text (Text)
 import qualified Data.Text as Text
+import qualified System.Info as SysInfo
+
+-- | Process identity Grok Build sends as @x-grok-client-identifier@.
+grokClientIdentifier :: Text
+grokClientIdentifier = "grok-shell"
+
+-- | Current Grok Build crate version (@xai-grok-version@). The proxy
+-- version-gates on @x-grok-client-version@.
+defaultGrokClientVersion :: Text
+defaultGrokClientVersion = "1.0.8"
+
+-- | Value Grok Build injects as @X-XAI-Token-Auth@ on cli-chat-proxy.
+grokTokenAuthValue :: Text
+grokTokenAuthValue = "xai-grok-cli"
+
+-- | Value Grok Build injects as @x-authenticateresponse@ on cli-chat-proxy.
+grokAuthenticateResponseValue :: Text
+grokAuthenticateResponseValue = "authenticate-response"
+
+-- | User-Agent Grok Build sends when the origin product is @grok-shell@.
+grokUserAgent :: Text -> Text
+grokUserAgent version =
+    grokClientIdentifier
+        <> "/"
+        <> version
+        <> " ("
+        <> grokPlatformOs
+        <> "; "
+        <> grokPlatformArch
+        <> ")"
+
+grokPlatformOs :: Text
+grokPlatformOs = case SysInfo.os of
+    "darwin" -> "macos"
+    "mingw32" -> "windows"
+    other -> Text.pack other
+
+grokPlatformArch :: Text
+grokPlatformArch = case SysInfo.arch of
+    "arm64" -> "aarch64"
+    other -> Text.pack other
 
 data ClientOptions = ClientOptions
     { baseUrl :: !String
@@ -33,7 +79,7 @@ defaultClientOptions = ClientOptions
     , modelOverrides = []
     , defaultModel = "grok-4.6"
     , requestTimeoutSeconds = 600
-    , clientVersion = "0.2.118"
+    , clientVersion = defaultGrokClientVersion
     }
 
 -- | Load optional transport overrides from the environment.

--- a/packages/agent-xai/src/Agent/XAI/Request.hs
+++ b/packages/agent-xai/src/Agent/XAI/Request.hs
@@ -99,22 +99,15 @@ withHostedXSearch ResponseCreateParams { tools = existing, .. } =
 isHostedXSearch :: ResponseTool -> Bool
 isHostedXSearch = \case
     KnownResponseTool ToolXSearch _ -> True
-    UnknownResponseTool tagged | tagged.tag == "x_search" -> True
+    UnknownResponseTool tagged
+        | tagged.tag == responseToolTypeText ToolXSearch -> True
     _ -> False
 
 hostedWebSearchTool :: ResponseTool
-hostedWebSearchTool =
-    KnownResponseTool ToolWebSearch TaggedObject
-        { tag = "web_search"
-        , fields = KeyMap.empty
-        }
+hostedWebSearchTool = knownResponseTool ToolWebSearch KeyMap.empty
 
 hostedXSearchTool :: ResponseTool
-hostedXSearchTool =
-    KnownResponseTool ToolXSearch TaggedObject
-        { tag = "x_search"
-        , fields = KeyMap.empty
-        }
+hostedXSearchTool = knownResponseTool ToolXSearch KeyMap.empty
 
 xaiReasoningEffort :: Maybe Text -> Text
 xaiReasoningEffort = \case

--- a/packages/agent-xai/src/Agent/XAI/Request.hs
+++ b/packages/agent-xai/src/Agent/XAI/Request.hs
@@ -13,6 +13,7 @@ import Agent.Responses.Request
 import Agent.Responses.Types
 import Agent.XAI.Options (ClientOptions(..))
 import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.Maybe as Maybe
 import Data.Text (Text)
 import qualified Data.Text as Text
 
@@ -34,8 +35,9 @@ mapModel options model =
 -- never stored server-side.
 buildRequest :: ClientOptions -> ResponseCreateParams -> ResponseCreateParams
 buildRequest options request =
-    mapResponseTools xaiTool $
-        forceStatelessStreaming defaultResponseCreateParams
+    withHostedXSearch $
+        mapResponseTools xaiTool $
+            forceStatelessStreaming defaultResponseCreateParams
             { model = Just $
                 selectConfiguredModel
                     options.modelOverrides
@@ -74,12 +76,45 @@ buildRequest options request =
 
     xaiTool tool = case tool of
         FunctionToolValue {} -> Just tool
-        KnownResponseTool ToolWebSearch _ -> Just (KnownResponseTool ToolWebSearch TaggedObject
-            { tag = "web_search"
-            , fields = KeyMap.empty
-            })
+        KnownResponseTool ToolWebSearch _ -> Just hostedWebSearchTool
+        KnownResponseTool ToolXSearch _ -> Just hostedXSearchTool
         KnownResponseTool ToolComputer _ -> Nothing
         _ -> Just tool
+
+-- | Grok Build always splices hosted @x_search@ onto grok-4.6 Responses
+-- requests. Keep a single empty-fields entry even when the caller omitted
+-- tools or already listed web search.
+withHostedXSearch :: ResponseCreateParams -> ResponseCreateParams
+withHostedXSearch ResponseCreateParams { tools = existing, .. } =
+    ResponseCreateParams
+        { tools = Just (current <> extra)
+        , ..
+        }
+  where
+    current = Maybe.fromMaybe [] existing
+    extra
+        | any isHostedXSearch current = []
+        | otherwise = [hostedXSearchTool]
+
+isHostedXSearch :: ResponseTool -> Bool
+isHostedXSearch = \case
+    KnownResponseTool ToolXSearch _ -> True
+    UnknownResponseTool tagged | tagged.tag == "x_search" -> True
+    _ -> False
+
+hostedWebSearchTool :: ResponseTool
+hostedWebSearchTool =
+    KnownResponseTool ToolWebSearch TaggedObject
+        { tag = "web_search"
+        , fields = KeyMap.empty
+        }
+
+hostedXSearchTool :: ResponseTool
+hostedXSearchTool =
+    KnownResponseTool ToolXSearch TaggedObject
+        { tag = "x_search"
+        , fields = KeyMap.empty
+        }
 
 xaiReasoningEffort :: Maybe Text -> Text
 xaiReasoningEffort = \case
@@ -89,8 +124,8 @@ xaiReasoningEffort = \case
     Just "minimal" -> "low"
     Just "medium" -> "medium"
     Just "high" -> "high"
-    Just "xhigh" -> "high"
-    Just "max" -> "high"
+    Just "xhigh" -> "xhigh"
+    Just "max" -> "max"
     _ -> "high"
 
 requestInputItems :: ResponseCreateParams -> [ResponseItem]

--- a/packages/agent-xai/src/Agent/XAI/Transcription.hs
+++ b/packages/agent-xai/src/Agent/XAI/Transcription.hs
@@ -7,6 +7,11 @@ module Agent.XAI.Transcription
     ) where
 
 import Agent.Error (ApiError(..))
+import Agent.XAI.Options
+    ( defaultGrokClientVersion
+    , grokClientIdentifier
+    , grokUserAgent
+    )
 import Agent.Provider
     ( Credential(..)
     , Provider(XAIProvider)
@@ -173,8 +178,9 @@ transcribe credential produceAudio onTranscript = do
         WS.defaultConnectionOptions
         [ ("Authorization"
           , "Bearer " <> Text.encodeUtf8 credential.accessToken)
-        , ("x-grok-client-identifier", "haskell-agent")
-        , ("User-Agent", "haskell-agent")
+        , ("x-grok-client-identifier", Text.encodeUtf8 grokClientIdentifier)
+        , ("User-Agent"
+          , Text.encodeUtf8 (grokUserAgent defaultGrokClientVersion))
         ]
         \connection -> do
             awaitCreated connection

--- a/packages/agent-xai/src/Agent/XAI/Usage.hs
+++ b/packages/agent-xai/src/Agent/XAI/Usage.hs
@@ -9,6 +9,11 @@ module Agent.XAI.Usage
 
 import Control.Exception.Safe (tryAny)
 import Agent.Provider (Credential(..))
+import Agent.XAI.Options
+    ( defaultGrokClientVersion
+    , grokTokenAuthValue
+    , grokUserAgent
+    )
 import qualified Data.Aeson as Aeson
 import Data.Aeson ((.:), (.:?))
 import Data.Aeson.Types (Parser)
@@ -105,13 +110,17 @@ fetchGrokUsageFrom endpoint credential =
             $ setRequestHeader
                 "Authorization"
                 ["Bearer " <> Text.encodeUtf8 credential.accessToken]
-            $ setRequestHeader "X-XAI-Token-Auth" ["xai-grok-cli"]
+            $ setRequestHeader "X-XAI-Token-Auth"
+                [Text.encodeUtf8 grokTokenAuthValue]
             $ setRequestHeader
                 "x-userid"
                 [Text.encodeUtf8 credential.accountId]
             $ setRequestHeader "Accept" ["application/json"]
             $ setRequestHeader "x-grok-client-mode" ["shell"]
-            $ setRequestHeader "x-grok-client-version" ["0.2.118"]
+            $ setRequestHeader "x-grok-client-version"
+                [Text.encodeUtf8 defaultGrokClientVersion]
+            $ setRequestHeader "User-Agent"
+                [Text.encodeUtf8 (grokUserAgent defaultGrokClientVersion)]
             $ setRequestResponseTimeout
                 (HttpClient.responseTimeoutMicro (30 * 1_000_000))
                 request

--- a/packages/agent-xai/test/Agent/XAI/ClientSpec.hs
+++ b/packages/agent-xai/test/Agent/XAI/ClientSpec.hs
@@ -45,7 +45,15 @@ spec = do
             [request] <- readIORef recorded
             request.path `shouldBe` "/v1/responses"
             lookup "Authorization" request.headers `shouldBe` Just "Bearer token-a"
-            lookup "X-XAI-Token-Auth" request.headers `shouldBe` Just "xai-grok-cli"
+            lookup "X-XAI-Token-Auth" request.headers `shouldBe` Just grokTokenAuthValue
+            lookup "x-authenticateresponse" request.headers
+                `shouldBe` Just grokAuthenticateResponseValue
+            lookup "x-grok-client-identifier" request.headers
+                `shouldBe` Just grokClientIdentifier
+            lookup "x-grok-client-version" request.headers
+                `shouldBe` Just defaultGrokClientVersion
+            lookup "User-Agent" request.headers
+                `shouldBe` Just (grokUserAgent defaultGrokClientVersion)
             requestModel request `shouldBe` Just "grok-4.6"
             -- instructions travel as the leading system item
             (inputRoles <$> requestBodyObject request) `shouldBe` Just ["system", "user"]

--- a/packages/agent-xai/test/Agent/XAI/ResponsesSpec.hs
+++ b/packages/agent-xai/test/Agent/XAI/ResponsesSpec.hs
@@ -123,6 +123,7 @@ spec = do
             map (KeyMap.lookup "type") toolObjects `shouldBe`
                 [ Just (Aeson.String "function")
                 , Just (Aeson.String "web_search")
+                , Just (Aeson.String "x_search")
                 ]
             -- external_web_access is a ChatGPT knob the proxy does not know.
             Maybe.mapMaybe (KeyMap.lookup "external_web_access") toolObjects `shouldBe` []
@@ -133,7 +134,16 @@ spec = do
             object <- expectObject value
             KeyMap.lookup "include" object `shouldBe` Nothing
 
-        it "clamps reasoning efforts grok does not offer" do
+        it "injects hosted x_search when the caller omitted it" do
+            let value = requestValue defaultClientOptions
+                    (setTools (Just []) sampleRequest)
+            object <- expectObject value
+            tools <- expectArray (KeyMap.lookup "tools" object)
+            toolObjects <- traverse expectObject tools
+            map (KeyMap.lookup "type") toolObjects `shouldBe`
+                [Just (Aeson.String "x_search")]
+
+        it "maps OpenAI-only efforts down and passes grok-4.6 xhigh/max through" do
             let effortOf request = do
                     object <- expectObject (requestValue defaultClientOptions request)
                     reasoning <- expectObject =<< maybe
@@ -150,9 +160,9 @@ spec = do
             effortOf (withEffort "low" sampleRequest)
                 >>= (`shouldBe` Just (Aeson.String "low"))
             effortOf (withEffort "xhigh" sampleRequest)
-                >>= (`shouldBe` Just (Aeson.String "high"))
+                >>= (`shouldBe` Just (Aeson.String "xhigh"))
             effortOf (withEffort "max" sampleRequest)
-                >>= (`shouldBe` Just (Aeson.String "high"))
+                >>= (`shouldBe` Just (Aeson.String "max"))
             -- Unset effort defaults to high for Grok.
             effortOf (clearEffort sampleRequest)
                 >>= (`shouldBe` Just (Aeson.String "high"))
@@ -361,6 +371,10 @@ setModel newModel ResponseCreateParams { model = _, .. } =
 setInput :: Maybe ResponseInput -> ResponseCreateParams -> ResponseCreateParams
 setInput newInput ResponseCreateParams { input = _, .. } =
     ResponseCreateParams { input = newInput, .. }
+
+setTools :: Maybe [ResponseTool] -> ResponseCreateParams -> ResponseCreateParams
+setTools newTools ResponseCreateParams { tools = _, .. } =
+    ResponseCreateParams { tools = newTools, .. }
 
 expectObject :: Aeson.Value -> IO Aeson.Object
 expectObject = \case

--- a/packages/agent-xai/test/Agent/XAI/ResponsesSpec.hs
+++ b/packages/agent-xai/test/Agent/XAI/ResponsesSpec.hs
@@ -134,6 +134,14 @@ spec = do
             object <- expectObject value
             KeyMap.lookup "include" object `shouldBe` Nothing
 
+        it "serializes hosted tools from ResponseToolType, not a tag string" do
+            let mismatched = KnownResponseTool ToolXSearch TaggedObject
+                    { tag = "web_search"
+                    , fields = KeyMap.empty
+                    }
+            Aeson.toJSON mismatched `shouldBe` Aeson.object
+                ["type" .= ("x_search" :: Text)]
+
         it "injects hosted x_search when the caller omitted it" do
             let value = requestValue defaultClientOptions
                     (setTools (Just []) sampleRequest)
@@ -324,14 +332,9 @@ sampleRequest = defaultResponseCreateParams
             , strict = Nothing
             , extraFields = mempty
             }
-        , KnownResponseTool ToolWebSearch TaggedObject
-            { tag = "web_search"
-            , fields = KeyMap.singleton "external_web_access" (Aeson.Bool True)
-            }
-        , KnownResponseTool ToolComputer TaggedObject
-            { tag = "computer"
-            , fields = mempty
-            }
+        , knownResponseTool ToolWebSearch
+            (KeyMap.singleton "external_web_access" (Aeson.Bool True))
+        , knownResponseTool ToolComputer mempty
         ]
     , reasoning = Just (reasoningConfig "high")
     , include = Just [ResponseInclude "reasoning.encrypted_content"]

--- a/packages/agent-xai/test/Agent/XAI/UsageSpec.hs
+++ b/packages/agent-xai/test/Agent/XAI/UsageSpec.hs
@@ -1,6 +1,11 @@
 module Agent.XAI.UsageSpec (spec) where
 
 import Agent.Provider (Credential(..), Provider(..))
+import Agent.XAI.Options
+    ( defaultGrokClientVersion
+    , grokTokenAuthValue
+    , grokUserAgent
+    )
 import Agent.XAI.Usage
 import Control.Concurrent.MVar (MVar, newEmptyMVar, putMVar, takeMVar)
 import qualified Data.ByteString.Lazy.Char8 as LBS
@@ -75,9 +80,13 @@ spec = do
             lookup "Authorization" headers
                 `shouldBe` Just "Bearer token-a"
             lookup "X-XAI-Token-Auth" headers
-                `shouldBe` Just "xai-grok-cli"
+                `shouldBe` Just grokTokenAuthValue
             lookup "x-userid" headers
                 `shouldBe` Just "user-a"
+            lookup "x-grok-client-version" headers
+                `shouldBe` Just defaultGrokClientVersion
+            lookup "User-Agent" headers
+                `shouldBe` Just (grokUserAgent defaultGrokClientVersion)
             lookup "X-Auth-Token" headers `shouldBe` Nothing
 
 billingApp


### PR DESCRIPTION
## Summary

Align the Grok subscription proxy client with current Grok Build 1.0.8 (`xai-org/grok-build` `SOURCE_REV` `437c7c92`).

The proxy now sees the same identity, hosted tools, and reasoning-effort dialect as Grok Build:

- `x-grok-client-version: 1.0.8` (was `0.2.118`)
- `User-Agent: grok-shell/1.0.8 (<os>; <arch>)` (was `codex-hs`)
- `x-authenticateresponse: authenticate-response` on inference
- hosted `x_search` spliced into Responses `tools`
- `reasoning.effort` `xhigh` / `max` passed through instead of clamped to `high`

Grok prompts mention `x_search` next to `web_search`. Billing and STT reuse the same version and User-Agent constants so they cannot drift.

## Test plan

- [x] `cabal test agent-xai` (54 examples)
- [x] `cabal test agent-grok-build-dialect`
- [x] `cabal test agent-cli --test-option='--match=systemPrompt'`
- [x] GHCi load of `agent-cli:lib:agent-cli` + `agent-xai:lib:agent-xai` after rebasing onto master