### PR TITLE
Preserve terminal title motion semantics

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration.hs
@@ -2218,7 +2218,8 @@ runAgentInitializedWithLock
                 Nothing ->
                     fmap (\request -> sessionTitleFromPrompt request.managedTurnText)
                         promptRequest
-        setWindowTitle (cliWindowTitle cwd titleHint)
+            startupWindowTitle = cliWindowTitle cwd titleHint
+        setWindowTitle startupWindowTitle
         markStartupStage startup "Loading instructions…"
         startupContext <-
             loadAgentsContext
@@ -2304,6 +2305,7 @@ runAgentInitializedWithLock
                                 , conversationRef
                                 , initialTurns
                                 , persist
+                                , startupWindowTitle
                                 , projectRoot
                                 , home
                                 , cwd

--- a/packages/agent-cli/src/Agent/CLI/Session/Runner.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner.hs
@@ -233,16 +233,6 @@ runSession
 runSession callbacks SessionRequest{..} SessionBackend{..} = do
   initialPrevious <- readLivePreviousResponseId conversationRef
   ioLock <- newMVar ()
-  initialWindowTitle <- case persist of
-      PersistenceEnabled slotRef ->
-          readIORef slotRef >>= \case
-              PersistenceActive handle ->
-                  pure
-                      (cliWindowTitle
-                          handle.sessionMeta.metaCwd
-                          (Just handle.sessionMeta.metaTitle))
-              _ -> pure (cliWindowTitle cwd Nothing)
-      PersistenceDisabled -> pure (cliWindowTitle cwd Nothing)
   let fullscreen = startup.startupFullscreen
       terminal = startup.startupTerminal
       stdoutHandle = startup.startupStdout
@@ -257,7 +247,7 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
       withIoLock action = withMVar ioLock (const action)
   windowTitle <- newWindowTitleController
       options.optMotionMode
-      initialWindowTitle
+      startupWindowTitle
       withIoLock
       writeWindowTitle
   let setWindowTitle = windowTitle.windowTitleSet

--- a/packages/agent-cli/src/Agent/CLI/Session/Runtime/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runtime/Types.hs
@@ -113,6 +113,7 @@ data SessionRequest = SessionRequest
     , conversationRef :: !(IORef LiveConversation)
     , initialTurns :: ![SessionTurn]
     , persist :: !Persistence
+    , startupWindowTitle :: !Text
     , projectRoot :: !OsPath
     , home :: !OsPath
     , cwd :: !OsPath

--- a/packages/agent-cli/src/Agent/CLI/WindowTitle.hs
+++ b/packages/agent-cli/src/Agent/CLI/WindowTitle.hs
@@ -20,7 +20,7 @@ import Control.Concurrent.STM
     , readTVar
     , writeTVar
     )
-import Control.Monad (forM_, unless, when)
+import Control.Monad (forM_, when)
 import Data.Text (Text)
 
 data WindowTitleController = WindowTitleController
@@ -88,7 +88,7 @@ newWindowTitleController motionMode initialTitle withOutputLock writeTitle = do
                 when (state.titleBusyDepth == 0) $
                     writeTitle state.titleBase
         worker =
-            unless (motionMode == MotionOff) $
+            when (motionMode == MotionFull) $
                 forM_ (cycle frames) \frame -> do
                     atomically do
                         state <- readTVar stateVar

--- a/packages/agent-cli/test/Agent/CLI/StyleSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/StyleSpec.hs
@@ -106,3 +106,18 @@ spec = do
                 , firstFrame <> " renamed"
                 , "renamed"
                 ]
+
+        it "keeps reduced-motion busy titles static" do
+            written <- newIORef []
+            let firstFrame = case spinnerFrames of
+                    frame : _ -> frame
+                    [] -> "*"
+            controller <- newWindowTitleController
+                MotionReduced
+                "initial"
+                id
+                (\title -> modifyIORef' written (<> [title]))
+            controller.windowTitleBeginBusy
+            controller.windowTitleWorker
+            actual <- readIORef written
+            actual `shouldBe` [firstFrame <> " initial"]


### PR DESCRIPTION
## Summary

Follow-up to #539 addressing both automated review findings:

- pass the exact startup window title into the session runner so prompt-derived titles survive pending and non-persistent one-shot sessions
- animate terminal-title spinner frames only in full-motion mode; reduced and off modes keep the static busy frame
- add a focused regression test for reduced-motion behavior

## Validation

- GHCi loaded `Agent.CLI.Runtime.Orchestration`, `Agent.CLI.Session.Runner`, and `Agent.CLI.WindowTitle`
- focused `WindowTitleController` specs: 3 examples, 0 failures
- tmux one-shot smoke test with `--motion reduced`: five title samples remained `⠋ Use shell_command to sleep 5 seconds, then reply done.` and never fell back to `New session`
- `git diff --check`
