### PR TITLE
Fix Markdown rendering in recap blocks

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -3183,7 +3183,7 @@ drawBlock state target ui block =
                 withAttr Theme.mutedAttr
                     (terminalTxtWrap block.blockBody)
             BlockRecap ->
-                accentBlock
+                accentMarkdownBlock
                     (statusAttr state target block)
                     (blockStateGlyph state target block <> "Recap")
                     (visibleBody block)


### PR DESCRIPTION
## Summary
- render fullscreen recap bodies with the Markdown-aware accent renderer
- preserve the existing recap chrome and status styling

## Validation
- loaded `Agent.CLI.TUI.App` successfully in GHCi
- exercised the fullscreen UI in tmux with a recap containing `` `Runtime.Repl.Commands` `` and confirmed the backticks are removed and the inline code is rendered