### PR TITLE
Redraw fullscreen UI when background turns finish

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -59,6 +59,7 @@ module Agent.CLI.TUI.App
     , wrapFullscreenKeyboardVty
     , setFullscreenImagePreviews
     , setFullscreenWindowTitle
+    , turnCompletionRequiresRedraw
     , uiEventRestartsMotionSchedule
     , applyTextPromptEdit
     , maskedSecretText
@@ -169,6 +170,7 @@ import Agent.CLI.TUI.Motion
     , motionModeForTerminalFocus
     , nativeProgressKeepaliveDue
     , nextMotionSchedule
+    , turnCompletionRequiresRedraw
     , uiEventRestartsMotionSchedule
     , userActionPending
     )
@@ -4295,6 +4297,7 @@ refreshNativeProgressKeepalive = do
 handleEvent :: BrickEvent Name AppEvent -> EventM Name AppState ()
 handleEvent event = do
     advanceAppClockNow
+    stateBeforeEvent <- get
     when (isMotionTick event) refreshNativeProgressKeepalive
     handleEventInner event
     state <- get
@@ -4316,7 +4319,13 @@ handleEvent event = do
                 (+ 1)
     syncMotionDemand
     stateAfterMotionSync <- get
-    when (stateAfterMotionSync.appTerminalFocus == TerminalUnfocused) $
+    when
+        ( stateAfterMotionSync.appTerminalFocus == TerminalUnfocused
+            && not
+                (turnCompletionRequiresRedraw
+                    stateBeforeEvent.appUi
+                    stateAfterMotionSync.appUi)
+        ) $
         continueWithoutRedraw
   where
     isMotionTick = \case

--- a/packages/agent-cli/src/Agent/CLI/TUI/Motion.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Motion.hs
@@ -12,6 +12,7 @@ module Agent.CLI.TUI.Motion
     , motionModeForTerminalFocus
     , nativeProgressKeepaliveDue
     , nextMotionSchedule
+    , turnCompletionRequiresRedraw
     , uiEventRestartsMotionSchedule
     , userActionPending
     ) where
@@ -267,3 +268,9 @@ nativeProgressKeepaliveDue blocked previousBucket ui =
     not blocked
         && ui.uiRunning
         && ui.uiElapsedMillis `div` 5000 > previousBucket
+
+-- | A completed turn gets one final frame even while terminal focus throttling
+-- suppresses ordinary streaming and animation redraws.
+turnCompletionRequiresRedraw :: UiState -> UiState -> Bool
+turnCompletionRequiresRedraw previous next =
+    previous.uiRunning && not next.uiRunning

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -34,6 +34,7 @@ import Agent.CLI.TUI.App
     , resumeSearchCursorColumn
     , selectedAgentConversation
     , textOverlayDisplayText
+    , turnCompletionRequiresRedraw
     , uiEventRestartsMotionSchedule
     )
 import Agent.CLI.TUI.Types
@@ -693,6 +694,27 @@ spec = do
                 400000
                 (MotionSlow, 500000, 4)
                 `shouldBe` (MotionSlow, 400000, 5)
+
+        it "requests one unfocused redraw when a running turn becomes idle" do
+            let running = reduceUi (UiLoop TurnStarted) initialUiState
+                finished =
+                    reduceUi
+                        (UiLoop
+                            (TurnFinished
+                                (emptyTurnOutput "response-1" [] Nothing)))
+                        running
+                continuing =
+                    reduceUi
+                        (UiLoop
+                            (TurnFinished
+                                (emptyTurnOutput
+                                    "response-1"
+                                    [functionToolCall "call-1" "read_file" "{}"]
+                                    Nothing)))
+                        running
+            turnCompletionRequiresRedraw running finished `shouldBe` True
+            turnCompletionRequiresRedraw running continuing `shouldBe` False
+            turnCompletionRequiresRedraw finished finished `shouldBe` False
 
         it "retains sub-millisecond time across clock samples" do
             elapsedMillisSince 1000000 1499999


### PR DESCRIPTION
## Summary
- keep background-tab streaming and animation redraws throttled
- emit one final frame when a running turn transitions to idle
- cover completed and tool-continuing transitions with a regression test

## Validation
- `nix develop -c cabal repl agent-cli:lib:agent-cli agent-cli:test:agent-cli-test`
- targeted `turnCompletionRequiresRedraw` test: 1 example, 0 failures
- live fullscreen TUI smoke test in tmux
- `git diff --check`