### PR TITLE
fix(cli): keep dictation inside the fullscreen TUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,10 +288,12 @@ Works with your Codex, Grok, and Claude subscriptions, plus provider API keys.
 
 ### Voice dictation
 
-Press `Ctrl+R` in the prompt composer, speak, and press `Enter` to stop.
-On macOS, the agent records audio with `ffmpeg`, streams 16 kHz mono PCM directly to
-`wss://api.x.ai/v1/stt`, and inserts the final transcript at the current cursor.
-Audio is sent while you speak, and xAI's partial transcript is displayed live.
+Press `Ctrl+R` in the prompt composer, speak, and press `Enter` to stop
+(or `Esc` to cancel). Recording stays in the TUI; it does not suspend or close
+the session. On macOS, the agent records audio with `ffmpeg`, streams 16 kHz mono PCM
+directly to `wss://api.x.ai/v1/stt`, and inserts the final transcript at the current cursor.
+Audio is sent while you speak, and xAI's partial transcript is displayed live in the
+status notice.
 Dictation uses the same configured Grok OAuth subscription or managed xAI
 API-key credential as the xAI provider; it does not run an external app server. Set
 `XAI_STT_LANGUAGE` to a supported language code to override the default `en`.

--- a/packages/agent-cli/src/Agent/CLI/Dictation.hs
+++ b/packages/agent-cli/src/Agent/CLI/Dictation.hs
@@ -1,6 +1,9 @@
 -- | Terminal microphone recording and xAI streaming transcription.
 module Agent.CLI.Dictation
-    ( dictate
+    ( DictationControl(..)
+    , DictationResult(..)
+    , dictate
+    , dictateWith
     , insertDictation
     , transcribeAudio
     ) where
@@ -17,9 +20,12 @@ import Control.Concurrent.Async
     , withAsync
     )
 import Control.Exception.Safe
-    ( bracket
+    ( SomeException
+    , bracket
+    , displayException
     , finally
     , throwIO
+    , try
     , tryAny
     )
 import Control.Exception (AsyncException(UserInterrupt))
@@ -53,25 +59,60 @@ import System.Process
     , waitForProcess
     )
 
+data DictationControl = DictationControl
+    { dictationWaitForStop :: IO ()
+    , dictationOnTranscript :: Text -> IO ()
+    }
+
+data DictationResult
+    = DictationTranscript !Text
+    | DictationFailed !Text
+    deriving (Eq, Show)
+
 -- | Stream the default microphone to xAI until Enter and return the transcript.
 dictate :: IO Text
 dictate = do
-    requireExecutable "ffmpeg"
     Text.hPutStrLn stderr "● Starting dictation…"
     hFlush stderr
-    loadAuth (Just XAIProvider) >>= \case
-        Left err ->
-            fail (Text.unpack err)
-        Right loaded -> do
-            result <-
-                transcribePcmWithXAI
-                    loaded.loadedTokenProvider
-                    streamMicrophone
-                    renderLiveTranscript
-                    `finally` clearLiveTranscript
-            case result of
-                Left err -> fail (show err)
-                Right transcript -> pure (Text.strip transcript)
+    result <-
+        dictateWith
+            DictationControl
+                { dictationWaitForStop = do
+                    Text.hPutStr stderr "● Listening… press Enter to stop"
+                    hFlush stderr
+                    waitForStopKey
+                , dictationOnTranscript = renderLiveTranscript
+                }
+            `finally` clearLiveTranscript
+    case result of
+        DictationTranscript transcript -> pure transcript
+        DictationFailed err -> fail (Text.unpack err)
+
+-- | Stream microphone audio until the caller signals stop. Partial transcripts
+-- are delivered through the control callback so a TUI can stay on-screen.
+dictateWith :: DictationControl -> IO DictationResult
+dictateWith control =
+    try run >>= \case
+        Left (err :: SomeException) ->
+            pure (DictationFailed (Text.pack (displayException err)))
+        Right result ->
+            pure result
+  where
+    run = do
+        requireExecutable "ffmpeg"
+        loadAuth (Just XAIProvider) >>= \case
+            Left err ->
+                pure (DictationFailed err)
+            Right loaded -> do
+                result <-
+                    transcribePcmWithXAI
+                        loaded.loadedTokenProvider
+                        (streamMicrophone control.dictationWaitForStop)
+                        control.dictationOnTranscript
+                pure $ case result of
+                    Left err -> DictationFailed (Text.pack (show err))
+                    Right transcript ->
+                        DictationTranscript (Text.strip transcript)
 
 -- | Transcribe an existing audio file using the configured Grok/xAI
 -- subscription or API-key credential.
@@ -96,12 +137,10 @@ requireExecutable command =
                 command
                     <> " is required for dictation but was not found on PATH"
 
-streamMicrophone :: (BS.ByteString -> IO ()) -> IO ()
-streamMicrophone sendAudio =
-    bracket start stop \(input, output, process) -> do
-        Text.hPutStr stderr "● Listening… press Enter to stop"
-        hFlush stderr
-        withAsync waitForStopKey \stopKey ->
+streamMicrophone :: IO () -> (BS.ByteString -> IO ()) -> IO ()
+streamMicrophone waitForStop sendAudio =
+    bracket start stop \(input, output, process) ->
+        withAsync waitForStop \stopKey ->
             withAsync (pump output) \audioPump ->
                 waitEitherCatch stopKey audioPump >>= \case
                     Left (Left err) -> throwIO err
@@ -141,7 +180,7 @@ streamMicrophone sendAudio =
                     ])
                 { std_in = CreatePipe
                 , std_out = CreatePipe
-                , std_err = Inherit
+                , std_err = NoStream
                 }
         pure (input, output, process)
     stop (input, output, process) = do

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -73,7 +73,12 @@ module Agent.CLI.TUI.App
 import Agent.CLI.Clipboard
     ( formatImageSize
     )
-import Agent.CLI.Dictation (insertDictation)
+import Agent.CLI.Dictation
+    ( DictationControl(..)
+    , DictationResult(..)
+    , dictateWith
+    , insertDictation
+    )
 import Agent.CLI.Secret (sanitizeSecretPromptText)
 import Agent.CLI.Artifact (fencedCodeBlock)
 import Agent.CLI.Input
@@ -368,6 +373,7 @@ newFullscreenRuntimeWithSyntaxLoader
         historyRequests <- newTQueueIO
         historySource <- newIORef Nothing
         historyGeneration <- newIORef 0
+        dictationJobs <- newTQueueIO
         imagePreviews <- newIORef []
         imagePreviewRevision <- newIORef 0
         imagePreviewVisible <- newIORef True
@@ -428,6 +434,7 @@ newFullscreenRuntimeWithSyntaxLoader
             , runtimeHistoryRequests = historyRequests
             , runtimeHistorySource = historySource
             , runtimeHistoryGeneration = historyGeneration
+            , runtimeDictationJobs = dictationJobs
             }
 
 setFullscreenSessionActions
@@ -958,34 +965,40 @@ runFullscreen runtime workerAction = do
                             historyLoader
                             \_historyLoader ->
                             withAsync
-                                (loadSyntaxHighlighterForRuntime runtime)
-                                \_syntaxLoader ->
-                                    withAsync
-                                        (void (waitCatch worker)
-                                            >> enqueueAppEvent runtime AppStop)
-                                        \_notifier -> do
-                                            finalState <-
-                                                customMain
-                                                    initialVty
-                                                    buildVty
-                                                    (Just runtime.runtimeEvents)
-                                                    fullscreenApp
-                                                    initialState
-                                                `finally`
-                                                    runtime.runtimeNativeProgress False
-                                            when (not finalState.appWorkerStopped) $
-                                                atomically $
-                                                    Composer.appendFullscreenInput
-                                                        runtime.runtimeInput
-                                                        FullscreenInput
-                                                            { fullscreenInputLine =
-                                                                ReplEof
-                                                            , fullscreenInputQueued =
-                                                                False
-                                                            , fullscreenInputDisplay =
-                                                                Nothing
-                                                            }
-                                            wait worker
+                                dictationWorker
+                                \_dictationWorker ->
+                                withAsync
+                                    (loadSyntaxHighlighterForRuntime runtime)
+                                    \_syntaxLoader ->
+                                        withAsync
+                                            (void (waitCatch worker)
+                                                >> enqueueAppEvent runtime AppStop)
+                                            \_notifier -> do
+                                                finalState <-
+                                                    customMain
+                                                        initialVty
+                                                        buildVty
+                                                        (Just runtime.runtimeEvents)
+                                                        fullscreenApp
+                                                        initialState
+                                                    `finally`
+                                                        runtime.runtimeNativeProgress False
+                                                mapM_
+                                                    (`Composer.requestDictationStop` True)
+                                                    finalState.appDictation
+                                                when (not finalState.appWorkerStopped) $
+                                                    atomically $
+                                                        Composer.appendFullscreenInput
+                                                            runtime.runtimeInput
+                                                            FullscreenInput
+                                                                { fullscreenInputLine =
+                                                                    ReplEof
+                                                                , fullscreenInputQueued =
+                                                                    False
+                                                                , fullscreenInputDisplay =
+                                                                    Nothing
+                                                                }
+                                                wait worker
   where
     recapTicker _runtime = forever do
         threadDelay 20_000_000
@@ -1064,6 +1077,21 @@ runFullscreen runtime workerAction = do
             (AppHistoryLoaded request normalized)
         historyLoader
 
+    dictationWorker = forever do
+        job <- atomically (readTQueue runtime.runtimeDictationJobs)
+        result <-
+            dictateWith
+                DictationControl
+                    { dictationWaitForStop = job.dictationJobWaitForStop
+                    , dictationOnTranscript =
+                        enqueueAppEvent runtime . AppDictationPartial
+                    }
+        enqueueAppEvent runtime $
+            AppDictationFinished $
+                case result of
+                    DictationTranscript transcript -> Right transcript
+                    DictationFailed message -> Left message
+
 -- | Construct the retained application state shared by the live entry point
 -- and renderer tests. Generated tests should start from the same defaults as
 -- a real fullscreen session instead of assembling an approximate state.
@@ -1106,6 +1134,7 @@ initialFullscreenAppState runtime history initialAgent initialAgents initialCloc
         , appKillBuffer = ""
         , appKillChain = False
         , appUndo = []
+        , appDictation = Nothing
         , appSlashCatalog = defaultSlashCatalog
         , appImagePreviews = []
         , appSubmittedImagePreviews = Map.empty
@@ -1573,6 +1602,8 @@ appendExactAppEvent event pending =
                 rest |> PendingEvent (AppAgentSnapshot selected entries)
         (rest :> PendingEvent (AppSetWindowTitle _), AppSetWindowTitle title) ->
             rest |> PendingEvent (AppSetWindowTitle title)
+        (rest :> PendingEvent (AppDictationPartial _), AppDictationPartial text) ->
+            rest |> PendingEvent (AppDictationPartial text)
         _ ->
             pending |> PendingEvent event
 
@@ -3568,16 +3599,18 @@ drawFooter state =
         padLeftRight 2 $
             txt footer
   where
-    footer = case (state.appTextPrompt, state.appChoice, state.appUi.uiFocus) of
-        (Just _, _, _) ->
+    footer = case (state.appDictation, state.appTextPrompt, state.appChoice, state.appUi.uiFocus) of
+        (Just _, _, _, _) ->
+            "Enter stop  │  Esc cancel  │  Ctrl+R stop"
+        (_, Just _, _, _) ->
             if state.appUi.uiRunning
                 then "Enter submit  │  Shift+Enter newline  │  PgUp/PgDn scroll  │  Esc close  │  Ctrl+C cancel turn"
                 else "Enter submit  │  Shift+Enter newline  │  PgUp/PgDn scroll  │  Esc cancel"
-        (Nothing, Just _, _) ->
+        (_, Nothing, Just _, _) ->
             if state.appUi.uiRunning
                 then "↑↓ select  │  Enter choose  │  Esc close  │  Ctrl+C cancel turn"
                 else "↑↓ select  │  Enter choose  │  Esc cancel"
-        (Nothing, Nothing, focus) ->
+        (_, Nothing, Nothing, focus) ->
                 case focus of
                     FocusPermission ->
                         "↑↓ select  │  Enter choose  │  Esc deny"
@@ -4487,7 +4520,16 @@ handleEventInner event = case event of
     AppEvent AppRecapPoll ->
         maybeRequestAutoRecap
     AppEvent AppStop -> do
-        modify' \state -> state { appWorkerStopped = True }
+        state <- get
+        liftIO $
+            mapM_
+                (`Composer.requestDictationStop` True)
+                state.appDictation
+        modify' \current ->
+            current
+                { appWorkerStopped = True
+                , appDictation = Nothing
+                }
         halt
     AppEvent (AppSetSlashCatalog catalog) -> do
         state <- get
@@ -4568,23 +4610,39 @@ handleEventInner event = case event of
                 { appImagePreviews = []
                 , appSubmittedImagePreviews = submitted
                 }
-    AppEvent (AppDictationFinished result) ->
-        case result of
-            Left message ->
-                applyLocalUiEvent $
-                    UiSetNotice $
-                        Just $
-                            warningNotice ("Dictation failed: " <> message)
-            Right transcript -> do
-                state <- get
-                let ui = state.appUi
-                    (draft, cursor) =
-                        insertDictation ui.uiDraft ui.uiCursor transcript
-                applyLocalUiEvent (UiSetDraft draft cursor)
-                applyLocalUiEvent $
-                    UiSetNotice $
-                        Just $
-                            successNotice "Dictation inserted."
+    AppEvent (AppDictationPartial text) -> do
+        state <- get
+        when (isJust state.appDictation) $
+            applyLocalUiEvent
+                (UiSetNotice (Just (Composer.dictationProgressNotice text)))
+    AppEvent (AppDictationFinished result) -> do
+        state <- get
+        aborted <-
+            case state.appDictation of
+                Just session ->
+                    liftIO (readIORef session.dictationAbort)
+                Nothing ->
+                    pure False
+        modify' \current -> current { appDictation = Nothing }
+        if aborted
+            then applyLocalUiEvent $
+                UiSetNotice $
+                    Just (infoNotice "Dictation cancelled.")
+            else case result of
+                Left message ->
+                    applyLocalUiEvent $
+                        UiSetNotice $
+                            Just $
+                                warningNotice ("Dictation failed: " <> message)
+                Right transcript -> do
+                    let ui = state.appUi
+                        (draft, cursor) =
+                            insertDictation ui.uiDraft ui.uiCursor transcript
+                    applyLocalUiEvent (UiSetDraft draft cursor)
+                    applyLocalUiEvent $
+                        UiSetNotice $
+                            Just $
+                                successNotice "Dictation inserted."
     AppEvent (AppSetWindowTitle title) -> do
         vty <- getVtyHandle
         liftIO (writeOutputWindowTitle (V.outputIface vty) title)
@@ -5027,30 +5085,34 @@ handleCtrlC = do
     pure decision
 
 handleNormalKey :: V.Event -> EventM Name AppState ()
-handleNormalKey event
-    | Bridge.isSendNowKey event =
-        Composer.handleComposerKey
-            applyLocalUiEventWith
-            handleCtrlC
-            scrollConversationPage
-            event
-    | otherwise = do
-        case event of
-            V.EvMouseDown _ _ V.BScrollUp _ ->
-                scrollConversationBy (-mouseScrollLines)
-            V.EvMouseDown _ _ V.BScrollDown _ ->
-                scrollConversationBy mouseScrollLines
-            _ -> do
-                state <- get
-                case state.appUi.uiFocus of
-                    FocusScrollback -> handleScrollbackKey event
-                    FocusComposer ->
-                        Composer.handleComposerKey
-                            applyLocalUiEventWith
-                            handleCtrlC
-                            scrollConversationPage
-                            event
-                    FocusPermission -> pure ()
+handleNormalKey event = do
+    state <- get
+    case state.appDictation of
+        Just session ->
+            Composer.handleDictationKey handleCtrlC session event
+        Nothing
+            | Bridge.isSendNowKey event ->
+                Composer.handleComposerKey
+                    applyLocalUiEventWith
+                    handleCtrlC
+                    scrollConversationPage
+                    event
+            | otherwise ->
+                case event of
+                    V.EvMouseDown _ _ V.BScrollUp _ ->
+                        scrollConversationBy (-mouseScrollLines)
+                    V.EvMouseDown _ _ V.BScrollDown _ ->
+                        scrollConversationBy mouseScrollLines
+                    _ ->
+                        case state.appUi.uiFocus of
+                            FocusScrollback -> handleScrollbackKey event
+                            FocusComposer ->
+                                Composer.handleComposerKey
+                                    applyLocalUiEventWith
+                                    handleCtrlC
+                                    scrollConversationPage
+                                    event
+                            FocusPermission -> pure ()
 
 rememberAgentHover :: AgentTarget -> EventM Name AppState ()
 rememberAgentHover target = do

--- a/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
@@ -11,11 +11,15 @@ module Agent.CLI.TUI.Composer
     , controlAttr
     , controlInteractionAttr
     , decodePaste
+    , DictationKeyAction(..)
+    , dictationKeyAction
+    , dictationProgressNotice
     , draftCursorLocation
     , drawComposer
     , drawQueuedInputs
     , drawSlashMenu
     , handleComposerKey
+    , handleDictationKey
     , handleControlMouseDown
     , handleControlMouseUp
     , handleEffortControlClick
@@ -29,6 +33,7 @@ module Agent.CLI.TUI.Composer
     , slashMenuWindowStart
     , takeFullscreenInput
     , takeFullscreenInputOr
+    , requestDictationStop
     , verticalCursorMove
     , wrapDraft
     ) where
@@ -37,7 +42,6 @@ import Agent.CLI.Clipboard
     ( nonEmptyClipboardText
     , readClipboardText
     )
-import Agent.CLI.Dictation (dictate)
 import Agent.CLI.Command
     ( ReplAction(..)
     , SlashMenu(..)
@@ -67,16 +71,16 @@ import Agent.TUI.TextWidth
     , terminalTextImage
     )
 import Brick
-import Brick.BChan (writeBChan)
 import qualified Brick.Types as B
 import qualified Brick.Widgets.Border as Border
 import Brick.Widgets.Border.Style (unicodeRounded)
 import qualified Brick.Widgets.Border.Style as BorderStyle
-import Control.Concurrent.STM (atomically)
-import Control.Exception.Safe (tryAny)
+import Control.Concurrent (newEmptyMVar, takeMVar, tryPutMVar)
+import Control.Concurrent.STM (atomically, writeTQueue)
 import Control.Monad (void, when)
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.State.Strict (modify')
+import Data.IORef (newIORef, writeIORef)
 import Data.List (elemIndex, intersperse)
 import Data.Maybe (fromMaybe)
 import Data.Sequence (ViewL(..))
@@ -89,6 +93,59 @@ type ApplyLocalUiEvent =
     UiEvent
     -> (AppState -> AppState)
     -> EventM Name AppState ()
+
+data DictationKeyAction
+    = DictationCommit
+    | DictationAbort
+    deriving (Eq, Show)
+
+dictationKeyAction :: V.Event -> Maybe DictationKeyAction
+dictationKeyAction = \case
+    V.EvKey V.KEnter [] -> Just DictationCommit
+    V.EvKey V.KEsc [] -> Just DictationAbort
+    V.EvKey (V.KChar 'r') modifiers
+        | V.MCtrl `elem` modifiers ->
+            Just DictationCommit
+    V.EvKey (V.KChar '\DC2') _ ->
+        Just DictationCommit
+    V.EvKey (V.KChar 'c') modifiers
+        | V.MCtrl `elem` modifiers ->
+            Just DictationAbort
+    _ -> Nothing
+
+dictationProgressNotice :: Text -> UiNotice
+dictationProgressNotice transcript =
+    progressNotice $
+        case Text.strip transcript of
+            "" -> "Listening… Enter to stop · Esc to cancel"
+            text ->
+                "Listening… "
+                    <> Text.takeEnd 80 (Text.unwords (Text.lines text))
+
+requestDictationStop :: DictationSession -> Bool -> IO ()
+requestDictationStop session abort = do
+    when abort $ writeIORef session.dictationAbort True
+    void (tryPutMVar session.dictationStop ())
+
+handleDictationKey
+    :: EventM Name AppState CtrlCDecision
+    -> DictationSession
+    -> V.Event
+    -> EventM Name AppState ()
+handleDictationKey handleCtrlC session event =
+    case dictationKeyAction event of
+        Just DictationCommit ->
+            liftIO (requestDictationStop session False)
+        Just DictationAbort -> do
+            liftIO (requestDictationStop session True)
+            case event of
+                V.EvKey (V.KChar 'c') modifiers
+                    | V.MCtrl `elem` modifiers ->
+                        void handleCtrlC
+                _ ->
+                    pure ()
+        Nothing ->
+            pure ()
 
 composerScrollbackAvailable :: UiState -> HistoryWindow -> Bool
 composerScrollbackAvailable ui history =
@@ -723,15 +780,26 @@ handleComposerKey
   where
     startDictation = do
         current <- get
-        suspendAndResume do
-            result <- tryAny dictate
-            writeBChan
-                current.appRuntime.runtimeEvents
-                (AppDictationFinished
-                    (case result of
-                        Left err -> Left (Text.pack (show err))
-                        Right transcript -> Right transcript))
-            pure current
+        case current.appDictation of
+            Just session ->
+                liftIO (requestDictationStop session False)
+            Nothing -> do
+                stop <- liftIO newEmptyMVar
+                abort <- liftIO (newIORef False)
+                let session =
+                        DictationSession
+                            { dictationStop = stop
+                            , dictationAbort = abort
+                            }
+                applyUiEvent
+                    (UiSetNotice (Just (dictationProgressNotice "")))
+                    \state -> state { appDictation = Just session }
+                liftIO $ atomically $
+                    writeTQueue
+                        current.appRuntime.runtimeDictationJobs
+                        DictationJob
+                            { dictationJobWaitForStop = takeMVar stop
+                            }
 
     submitRaw replLine = do
         state <- get

--- a/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
@@ -4,6 +4,8 @@ module Agent.CLI.TUI.Types
     , AppEventMailbox(..)
     , AppState(..)
     , AgentHover(..)
+    , DictationJob(..)
+    , DictationSession(..)
     , ChoicePresentation(..)
     , ChoiceOverlay(..)
     , FullscreenInput(..)
@@ -42,6 +44,7 @@ import Agent.Syntax (SyntaxHighlighter)
 import Agent.TUI.Motion (MotionDemand, MotionMode)
 import Brick (Location)
 import Brick.BChan (BChan)
+import Control.Concurrent (MVar)
 import Control.Concurrent.STM (TMVar, TQueue, TVar)
 import Control.Exception.Safe (SomeException)
 import Data.IORef (IORef)
@@ -125,6 +128,7 @@ data AppEvent
       -- ^ Legacy compatibility; prefer 'AppSetSlashCatalog'.
     | AppSetImagePreviews ![(ImageAttachment, TuiImagePreview)]
     | AppCommitImagePreviews ![(ImageAttachment, TuiImagePreview)]
+    | AppDictationPartial !Text
     | AppDictationFinished !(Either Text Text)
     | AppAgentSnapshot !AgentTarget ![AgentEntry]
     | AppSetWindowTitle !Text
@@ -208,6 +212,16 @@ data FullscreenRuntime = FullscreenRuntime
     , runtimeHistoryRequests :: !(TQueue HistoryRequest)
     , runtimeHistorySource :: !(IORef (Maybe FullscreenHistorySource))
     , runtimeHistoryGeneration :: !(IORef Int64)
+    , runtimeDictationJobs :: !(TQueue DictationJob)
+    }
+
+data DictationJob = DictationJob
+    { dictationJobWaitForStop :: IO ()
+    }
+
+data DictationSession = DictationSession
+    { dictationStop :: !(MVar ())
+    , dictationAbort :: !(IORef Bool)
     }
 
 -- | Provider/session-scoped actions behind one long-lived terminal runtime.
@@ -252,6 +266,7 @@ data AppState = AppState
     , appKillChain :: !Bool
       -- | Editor undo log of (draft, cursor) states, most recent first.
     , appUndo :: ![(Text, Int)]
+    , appDictation :: !(Maybe DictationSession)
     , appSlashCatalog :: !SlashCatalog
     , appImagePreviews :: ![TuiImagePreview]
     , appSubmittedImagePreviews :: !(Map.Map BlockId [TuiImagePreview])

--- a/packages/agent-cli/test/Agent/CLI/TUIComposerSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIComposerSpec.hs
@@ -8,7 +8,12 @@ import Agent.CLI.Input
     )
 import Agent.CLI.TUI.Composer
 import Agent.CLI.TUI.Types
-import Agent.TUI.Model (UiState(..), initialUiState)
+import Agent.TUI.Model
+    ( NoticeKind(..)
+    , UiNotice(..)
+    , UiState(..)
+    , initialUiState
+    )
 import Agent.TUI.TextWidth
     ( clampGraphemeCursor
     , graphemeCellWidth
@@ -27,6 +32,7 @@ import qualified Data.Text.Encoding as Text
 import qualified Graphics.Vty as V
 import Test.Hspec
 import Test.Hspec.QuickCheck (modifyMaxSuccess, prop)
+import qualified Graphics.Vty as V
 import Test.QuickCheck
     ( Arbitrary(..)
     , Gen
@@ -170,6 +176,29 @@ spec = describe "fullscreen composer" do
             `shouldBe` ("please fix this now", 15)
         insertDictation "hello" 5 ", world"
             `shouldBe` ("hello, world", 12)
+
+    it "keeps dictation stop keys inside the composer" do
+        dictationKeyAction (V.EvKey V.KEnter [])
+            `shouldBe` Just DictationCommit
+        dictationKeyAction (V.EvKey (V.KChar 'r') [V.MCtrl])
+            `shouldBe` Just DictationCommit
+        dictationKeyAction (V.EvKey (V.KChar '\DC2') [])
+            `shouldBe` Just DictationCommit
+        dictationKeyAction (V.EvKey V.KEsc [])
+            `shouldBe` Just DictationAbort
+        dictationKeyAction (V.EvKey (V.KChar 'c') [V.MCtrl])
+            `shouldBe` Just DictationAbort
+        dictationKeyAction (V.EvKey (V.KChar 'x') [])
+            `shouldBe` Nothing
+
+    it "renders a non-transient listening notice for live transcripts" do
+        let idle = dictationProgressNotice ""
+            live = dictationProgressNotice "hello from the mic"
+        idle.noticeKind `shouldBe` NoticeProgress
+        idle.noticeTransient `shouldBe` False
+        idle.noticeText
+            `shouldBe` "Listening… Enter to stop · Esc to cancel"
+        live.noticeText `shouldBe` "Listening… hello from the mic"
 
     modifyMaxSuccess (const 300) $
         prop "decodes arbitrary paste bytes into stable safe text" $

--- a/packages/agent-xai/src/Agent/XAI/Transcription.hs
+++ b/packages/agent-xai/src/Agent/XAI/Transcription.hs
@@ -35,6 +35,7 @@ import Control.Exception.Safe
     , displayException
     , finally
     , fromException
+    , isSyncException
     , throwIO
     , tryAny
     )
@@ -141,10 +142,14 @@ transcribePcmWithXAI provider produceAudio onTranscript =
             else do
                 result <- tryAny
                     (transcribe credential produceAudio onTranscript)
-                pure $ case result of
-                    Left err -> Left (transcriptionException err)
+                case result of
+                    Left err
+                        | isSyncException err ->
+                            pure (Left (transcriptionException err))
+                        | otherwise ->
+                            throwIO err
                     Right transcript ->
-                        Right transcript
+                        pure (Right transcript)
 
 transcriptionException :: SomeException -> ApiError
 transcriptionException err =


### PR DESCRIPTION
## Summary
- Ctrl+R dictation no longer uses Brick `suspendAndResume`, which tore down the fullscreen TUI while recording.
- Microphone transcription now runs from a scoped background worker; live partials stay in the composer notice, Enter/Ctrl+R stop and insert, Esc cancels.
- xAI STT now rethrows async exceptions so TUI shutdown can cancel an in-flight recording instead of swallowing `AsyncCancelled`.

## Test plan
- [x] `cabal test agent-cli --test-options='--match "fullscreen composer"'` (includes dictation stop-key and listening-notice cases)
- [ ] In the fullscreen TUI, press Ctrl+R: the session stays open, a Listening notice appears, and the transcript inserts at the cursor after Enter
- [ ] Esc during listening cancels without inserting; Ctrl+R while already listening stops recording