### PR TITLE
Stream Telegram agent progress in native drafts

### DIFF
--- a/packages/agent-cli/skills/telegram-agent/SKILL.md
+++ b/packages/agent-cli/skills/telegram-agent/SKILL.md
@@ -74,8 +74,8 @@ disables terminal echo and stores the token in a private gateway file.
 
 ## Telegram delivery behavior
 
-- The gateway shows typing and a native rich-message draft whose text follows
-  current model/tool/retry activity.
+- The gateway shows typing and a native rich-message draft that streams the
+  current answer, available reasoning summaries, and model/tool/retry activity.
 - Agent Markdown is converted to Telegram-safe HTML, with a plain-text fallback.
 - Group and supergroup responses reply to the triggering message. Forum topics
   are isolated from one another.

--- a/packages/agent-cli/src/Agent/CLI/GatewayBridge.hs
+++ b/packages/agent-cli/src/Agent/CLI/GatewayBridge.hs
@@ -4,7 +4,7 @@ module Agent.CLI.GatewayBridge
     , ManagedBridgeResponse(..)
     , ManagedActivity(..)
     , managedGatewayTools
-    , publishManagedLoopEvent
+    , newManagedLoopEventPublisher
     , requestManagedApproval
     , managedBridgeRequestsDirectory
     , managedBridgeResponsesDirectory
@@ -18,6 +18,12 @@ import Agent.CLI.Permission (PermissionChoice(..))
 import Agent.FileRetry (retryOnFileBusy, writeLazyFileAtomically)
 import Agent.Loop (LoopEvent(..))
 import Agent.OsPath (unsafeToFilePath)
+import Agent.TextBuffer
+    ( TextBuffer
+    , appendTextBuffer
+    , emptyTextBuffer
+    , textBufferToText
+    )
 import Agent.ToolArgs (objectArgs, optInt, optText, reqText)
 import Agent.ToolDSL (PropertySchema(..), PropertyType(..))
 import Agent.ToolDispatch
@@ -49,6 +55,7 @@ import qualified Data.Aeson.KeyMap as KeyMap
 import qualified Data.ByteString.Lazy as LBS
 import Data.Char (isAlphaNum)
 import Data.Maybe (fromMaybe)
+import Data.IORef (newIORef, readIORef, writeIORef)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
@@ -119,6 +126,8 @@ data ManagedActivity = ManagedActivity
     { managedActivityVersion :: !Int
     , managedActivityKind :: !Text
     , managedActivityMessage :: !Text
+    , managedActivityReasoning :: !Text
+    , managedActivityResponse :: !Text
     , managedActivityUpdatedAt :: !UTCTime
     } deriving (Eq, Show)
 
@@ -127,6 +136,8 @@ instance ToJSON ManagedActivity where
         [ "version" .= activity.managedActivityVersion
         , "kind" .= activity.managedActivityKind
         , "message" .= activity.managedActivityMessage
+        , "reasoning" .= activity.managedActivityReasoning
+        , "response" .= activity.managedActivityResponse
         , "updated_at" .= activity.managedActivityUpdatedAt
         ]
 
@@ -136,6 +147,8 @@ instance FromJSON ManagedActivity where
             <$> (o .:? "version" .!= bridgeSchemaVersion)
             <*> o .: "kind"
             <*> o .: "message"
+            <*> (o .:? "reasoning" .!= "")
+            <*> (o .:? "response" .!= "")
             <*> o .: "updated_at"
 
 managedGatewayTools :: ManagedTurnRequest -> [AppTool]
@@ -290,36 +303,105 @@ requestManagedApproval request call =
             Right (String "deny") -> pure (Just PermissionDeny)
             _ -> pure Nothing
 
-publishManagedLoopEvent :: ManagedTurnRequest -> LoopEvent -> IO ()
-publishManagedLoopEvent request event =
-    case request.managedTurnBridgeDirectory of
-        Nothing -> pure ()
-        Just _ -> do
-            now <- getCurrentTime
-            let (kind, message) = activityFor event
-            void $ try @_ @SomeException $
-                writeLazyFileAtomically
-                    (managedBridgeActivityPath request)
-                    0o600
-                    (encode ManagedActivity
-                        { managedActivityVersion = bridgeSchemaVersion
-                        , managedActivityKind = kind
-                        , managedActivityMessage = message
-                        , managedActivityUpdatedAt = now
-                        })
-  where
-    activityFor = \case
-        TurnStarted -> ("thinking", "Thinking…")
-        ReasoningDelta _ -> ("thinking", "Thinking…")
-        TextDelta _ -> ("writing", "Writing reply…")
-        ActivityUpdated message -> ("activity", nonEmpty "Working…" message)
-        WarningRaised message -> ("warning", nonEmpty "Warning" message)
-        ResponseRestarted _ -> ("retrying", "Retrying response…")
-        ToolStarted call -> ("tool", "Running " <> call.name <> "…")
-        ToolOutputUpdated name _ -> ("tool", "Running " <> name <> "…")
-        ToolFinished _ -> ("thinking", "Thinking…")
-        TurnFinished _ -> ("finished", "Finishing…")
+data ManagedActivityAccumulator = ManagedActivityAccumulator
+    { accumulatorKind :: !Text
+    , accumulatorMessage :: !Text
+    , accumulatorReasoning :: !TextBuffer
+    , accumulatorResponse :: !TextBuffer
+    }
 
+newManagedLoopEventPublisher
+    :: ManagedTurnRequest
+    -> IO (LoopEvent -> IO ())
+newManagedLoopEventPublisher request =
+    case request.managedTurnBridgeDirectory of
+        Nothing -> pure (const (pure ()))
+        Just _ -> do
+            stateRef <- newIORef emptyManagedActivityAccumulator
+            pure \event -> do
+                state <- updateManagedActivity event <$> readIORef stateRef
+                writeIORef stateRef state
+                now <- getCurrentTime
+                void $ try @_ @SomeException $
+                    writeLazyFileAtomically
+                        (managedBridgeActivityPath request)
+                        0o600
+                        (encode ManagedActivity
+                            { managedActivityVersion = bridgeSchemaVersion
+                            , managedActivityKind = state.accumulatorKind
+                            , managedActivityMessage = state.accumulatorMessage
+                            , managedActivityReasoning =
+                                textBufferToText state.accumulatorReasoning
+                            , managedActivityResponse =
+                                textBufferToText state.accumulatorResponse
+                            , managedActivityUpdatedAt = now
+                            })
+
+emptyManagedActivityAccumulator :: ManagedActivityAccumulator
+emptyManagedActivityAccumulator = ManagedActivityAccumulator
+    { accumulatorKind = "thinking"
+    , accumulatorMessage = "Thinking…"
+    , accumulatorReasoning = emptyTextBuffer
+    , accumulatorResponse = emptyTextBuffer
+    }
+
+updateManagedActivity
+    :: LoopEvent
+    -> ManagedActivityAccumulator
+    -> ManagedActivityAccumulator
+updateManagedActivity event state =
+    case event of
+        TurnStarted -> emptyManagedActivityAccumulator
+        ReasoningDelta delta ->
+            state
+                { accumulatorKind = "thinking"
+                , accumulatorMessage = "Thinking…"
+                , accumulatorReasoning =
+                    appendTextBuffer delta state.accumulatorReasoning
+                }
+        TextDelta delta ->
+            state
+                { accumulatorKind = "writing"
+                , accumulatorMessage = "Writing reply…"
+                , accumulatorResponse =
+                    appendTextBuffer delta state.accumulatorResponse
+                }
+        ActivityUpdated message ->
+            state
+                { accumulatorKind = "activity"
+                , accumulatorMessage = nonEmpty "Working…" message
+                }
+        WarningRaised message ->
+            state
+                { accumulatorKind = "warning"
+                , accumulatorMessage = nonEmpty "Warning" message
+                }
+        ResponseRestarted _ ->
+            emptyManagedActivityAccumulator
+                { accumulatorKind = "retrying"
+                , accumulatorMessage = "Retrying response…"
+                }
+        ToolStarted call ->
+            state
+                { accumulatorKind = "tool"
+                , accumulatorMessage = "Running " <> call.name <> "…"
+                }
+        ToolOutputUpdated name _ ->
+            state
+                { accumulatorKind = "tool"
+                , accumulatorMessage = "Running " <> name <> "…"
+                }
+        ToolFinished _ ->
+            state
+                { accumulatorKind = "thinking"
+                , accumulatorMessage = "Thinking…"
+                }
+        TurnFinished _ ->
+            state
+                { accumulatorKind = "finished"
+                , accumulatorMessage = "Finishing…"
+                }
+  where
     nonEmpty fallback value
         | Text.null (Text.strip value) = fallback
         | otherwise = Text.strip value

--- a/packages/agent-cli/src/Agent/CLI/Session/Runner.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner.hs
@@ -30,7 +30,7 @@ import Agent.CLI.ManagedTurn
     , managedTurnInputs
     )
 import Agent.CLI.GatewayBridge
-    ( publishManagedLoopEvent
+    ( newManagedLoopEventPublisher
     , requestManagedApproval
     )
 import Agent.CLI.Approval
@@ -659,6 +659,11 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
                         emitUiEvent runtime
                             (UiSystemMessage (formatSkillOmission omitted))
     policyRef <- newIORef policy
+    managedLoopPublisher <-
+        maybe
+            (pure (const (pure ())))
+            newManagedLoopEventPublisher
+            promptRequest
     -- Mirror plan session dir into the subagent store root for this session.
     let syncStore = do
             sessionDir <- readIORef planMode.planSessionDir
@@ -686,8 +691,7 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
             , renderMotionMode = options.optMotionMode
             }
         emitLoop event = do
-            forM_ promptRequest \request ->
-                publishManagedLoopEvent request event
+            managedLoopPublisher event
             case fullscreen of
                 Nothing -> renderEvent render event
                 Just runtime -> do

--- a/packages/agent-cli/test/Agent/CLI/GatewayBridgeSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/GatewayBridgeSpec.hs
@@ -71,9 +71,13 @@ spec = describe "Agent.CLI.GatewayBridge" do
                     }
                 wait running `shouldReturn` Just PermissionAllowOnce
 
-    it "publishes redacted activity rather than streamed content" $
+    it "publishes accumulated reasoning summaries and response text" $
         withBridgeRequest \request -> do
-            publishManagedLoopEvent request (TextDelta "secret response text")
+            publish <- newManagedLoopEventPublisher request
+            publish (ReasoningDelta "Checking ")
+            publish (ReasoningDelta "the files")
+            publish (TextDelta "Found ")
+            publish (TextDelta "the issue.")
             bytes <- LBS.readFile
                 (unsafeToFilePath (managedBridgeActivityPath request))
             activity <- case
@@ -84,6 +88,8 @@ spec = describe "Agent.CLI.GatewayBridge" do
                 Right value -> pure value
             activity.managedActivityKind `shouldBe` "writing"
             activity.managedActivityMessage `shouldBe` "Writing reply…"
+            activity.managedActivityReasoning `shouldBe` "Checking the files"
+            activity.managedActivityResponse `shouldBe` "Found the issue."
 
 withBridgeRequest :: (ManagedTurnRequest -> IO a) -> IO a
 withBridgeRequest action =

--- a/packages/agent-telegram/src/Agent/Telegram.hs
+++ b/packages/agent-telegram/src/Agent/Telegram.hs
@@ -30,6 +30,7 @@ module Agent.Telegram
     , reactionMessageText
     , telegramReactionEmoji
     , telegramReplyText
+    , telegramAgentPrompt
     , transcribeWithXAI
     , downloadTelegramMediaAttachmentsWith
     ) where
@@ -1012,6 +1013,7 @@ rekeyPendingAction updateId = \case
 runQueuedMediaTurn :: TelegramRuntime -> TelegramPendingMediaTurn -> IO Text
 runQueuedMediaTurn runtime pending = do
     handle <- sessionForPrompt runtime pending.pendingMediaChat pending.pendingMediaText
+    let agentPrompt = telegramAgentPrompt pending.pendingMediaText
     attachments <- downloadTelegramMediaAttachments runtime handle pending
     let imageAttachments =
             [ media
@@ -1024,7 +1026,7 @@ runQueuedMediaTurn runtime pending = do
             ]
         request = ManagedTurnRequest
             { managedTurnVersion = 1
-            , managedTurnText = pending.pendingMediaText
+            , managedTurnText = agentPrompt
             , managedTurnImages = imageAttachments
             , managedTurnFiles = fileAttachments
             , managedTurnBridgeDirectory = Nothing
@@ -1090,7 +1092,7 @@ runQueuedMediaTurn runtime pending = do
                                 Just turnIndex
                                     | maybe True (< turnIndex) priorTurnIndex
                                     , latestTurnMatches
-                                        pending.pendingMediaText
+                                        agentPrompt
                                         turns ->
                                         pure (renderLatestTurn turns)
                                 _ ->
@@ -1398,12 +1400,7 @@ runAgentTurn
     -> IO Text
 runAgentTurn runtime key userId replyToMessageId prompt = do
     handle <- sessionForPrompt runtime key prompt
-    let agentPrompt =
-            prompt
-                <> "\n\n[Telegram delivery context: If the best response is \
-                \only a lightweight acknowledgement, you may respond with \
-                \exactly one standard Telegram reaction emoji. Otherwise \
-                \respond normally. Do not mention this delivery context.]"
+    let agentPrompt = telegramAgentPrompt prompt
     runManagedAgentTurn
         runtime
         handle
@@ -1412,6 +1409,19 @@ runAgentTurn runtime key userId replyToMessageId prompt = do
         replyToMessageId
         (managedTurnRequestFromText agentPrompt)
         agentPrompt
+
+telegramAgentPrompt :: Text -> Text
+telegramAgentPrompt prompt =
+    prompt
+        <> "\n\n[Telegram delivery context: You are conversing in Telegram. \
+        \Keep messages concise and conversational; avoid terminal-style \
+        \verbosity unless the user asks for detail. Your answer and available \
+        \reasoning summaries are shown to the user as a live Telegram draft \
+        \while you work, followed by your normal final response. If the best \
+        \complete response \
+        \is only a lightweight acknowledgement, you may instead respond with \
+        \exactly one standard Telegram reaction emoji. Do not mention these \
+        \delivery instructions.]"
 
 runManagedAgentTurn
     :: TelegramRuntime
@@ -1659,20 +1669,19 @@ withTelegramProgress client key action =
         action
 
 withTelegramProgressUsing :: IO () -> IO () -> IO a -> IO a
-withTelegramProgressUsing sendTyping sendDraft action =
+withTelegramProgressUsing sendTyping sendDraft action = do
+    -- Seed the native draft once. The managed-turn bridge takes ownership of
+    -- refreshing it with live reasoning, response, and tool activity.
+    void (tryAny sendDraft)
     withAsync progressLoop (const action)
   where
-    progressLoop = loop (0 :: Int)
-    loop tick = do
-        -- Chat actions expire after roughly five seconds. Rich drafts last
-        -- longer, so refresh typing every four seconds and the draft every
-        -- fifth tick. Both are best-effort: the final reply remains durable
-        -- even when a client or Bot API version does not support rich drafts.
+    progressLoop = loop
+    loop = do
+        -- Chat actions expire after roughly five seconds. Keep typing as a
+        -- fallback for clients that do not support native rich drafts.
         void (tryAny sendTyping)
-        when (tick `mod` 5 == 0) $
-            void (tryAny sendDraft)
         threadDelay 4_000_000
-        loop (tick + 1)
+        loop
 
 loadTelegramState :: OsPath -> IO TelegramState
 loadTelegramState path = do

--- a/packages/agent-telegram/src/Agent/Telegram/Bridge.hs
+++ b/packages/agent-telegram/src/Agent/Telegram/Bridge.hs
@@ -4,6 +4,7 @@ module Agent.Telegram.Bridge
     , withTelegramBridge
     , processTelegramCallbacks
     , processBridgeRequestBatch
+    , telegramActivityDraftHtml
     ) where
 
 import Agent.CLI.GatewayBridge
@@ -21,6 +22,7 @@ import Agent.Concurrent (mapConcurrentlyBounded)
 import Agent.OsPath (unsafeToFilePath)
 import qualified Agent.Telegram.Client as Client
 import Agent.Telegram.Types
+import Control.Applicative ((<|>))
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async (withAsync)
 import Control.Exception.Safe (SomeException, displayException, try)
@@ -37,6 +39,7 @@ import Data.Aeson
     )
 import qualified Data.ByteString.Lazy as LBS
 import Data.List (isPrefixOf, sort)
+import Data.Functor ((<&>))
 import qualified Data.Map.Strict as Map
 import Data.Maybe (catMaybes, fromMaybe)
 import qualified Data.Set as Set
@@ -110,13 +113,16 @@ withTelegramBridge env action =
     withAsync (bridgeLoop env) (const action)
 
 bridgeLoop :: TelegramBridgeEnv -> IO ()
-bridgeLoop env = go Set.empty (0 :: Int)
+bridgeLoop env = go Set.empty Nothing (0 :: Int)
   where
-    go seen tick = do
+    go seen lastDraft tick = do
         seen' <- processBridgeRequests env seen
-        when (tick `mod` 40 == 0) (publishActivity env)
+        lastDraft' <-
+            if tick `mod` 10 == 0
+                then publishActivity env lastDraft (tick `mod` 200 == 0)
+                else pure lastDraft
         threadDelay 100_000
-        go seen' (tick + 1)
+        go seen' lastDraft' (tick + 1)
 
 processBridgeRequests
     :: TelegramBridgeEnv
@@ -439,36 +445,73 @@ callbackChatMatches binding callback =
         Nothing -> False
         Just key -> key == binding.callbackBindingChat
 
-publishActivity :: TelegramBridgeEnv -> IO ()
-publishActivity env = do
+publishActivity
+    :: TelegramBridgeEnv
+    -> Maybe Text
+    -> Bool
+    -> IO (Maybe Text)
+publishActivity env previous forceRefresh = do
     let path = unsafeToFilePath
             (managedBridgeActivityPath env.telegramBridgeRequest)
     exists <- doesFileExist path
-    status <-
+    activity <-
         if not exists
-            then pure "Thinking…"
+            then pure Nothing
             else
                 try @_ @SomeException
                     (retryOnFileBusy (LBS.readFile path)) >>= \case
-                        Left _ -> pure "Thinking…"
+                        Left _ -> pure Nothing
                         Right bytes ->
                             pure case
                                     eitherDecode bytes
                                         :: Either String ManagedActivity
                                 of
-                                Right activity ->
-                                    Text.take 100
-                                        activity.managedActivityMessage
-                                Left _ -> "Thinking…"
-    void $ try @_ @SomeException $
-        Client.sendTypingAction
-            env.telegramBridgeClient
-            env.telegramBridgeChat
-    void $ try @_ @SomeException $
-        Client.sendThinkingDraft
-            env.telegramBridgeClient
-            env.telegramBridgeChat
-            status
+                                Right value -> Just value
+                                Left _ -> Nothing
+    let next = activity <&> \value ->
+            telegramActivityDraftHtml
+                value.managedActivityMessage
+                value.managedActivityReasoning
+                value.managedActivityResponse
+    forM_ next \html ->
+        when (forceRefresh || Just html /= previous) $
+            void $ try @_ @SomeException $
+                Client.sendStreamingDraft
+                    env.telegramBridgeClient
+                    env.telegramBridgeChat
+                    html
+    pure (next <|> previous)
+
+telegramActivityDraftHtml :: Text -> Text -> Text -> Text
+telegramActivityDraftHtml status reasoningText responseText =
+    "<tg-thinking>"
+        <> escapeDraftText thinkingText
+        <> "</tg-thinking>"
+        <> if Text.null response
+            then ""
+            else "<p>" <> escapeDraftText response <> "</p>"
+  where
+    reasoning = Text.strip reasoningText
+    thinkingText =
+        Text.takeEnd 1200 $
+            if Text.null reasoning
+                then status
+                else
+                    if status `elem`
+                        ["Thinking…", "Writing reply…", "Finishing…"]
+                        then reasoning
+                        else status <> "\n" <> reasoning
+    response = Text.takeEnd 2600 responseText
+
+escapeDraftText :: Text -> Text
+escapeDraftText =
+    Text.replace "\n" "<br>" . Text.concatMap \case
+        '<' -> "&lt;"
+        '>' -> "&gt;"
+        '&' -> "&amp;"
+        '"' -> "&quot;"
+        '\'' -> "&#39;"
+        character -> Text.singleton character
 
 respondOk :: TelegramBridgeEnv -> ManagedBridgeRequest -> Value -> IO ()
 respondOk env request result =

--- a/packages/agent-telegram/src/Agent/Telegram/Client.hs
+++ b/packages/agent-telegram/src/Agent/Telegram/Client.hs
@@ -10,6 +10,7 @@ module Agent.Telegram.Client
     , downloadTelegramFile
     , sendTypingAction
     , sendThinkingDraft
+    , sendStreamingDraft
     , setMessageReaction
     , sendRichMessage
     , sendMessageWithKeyboard
@@ -278,6 +279,20 @@ sendTypingAction client key =
         object $
             [ "chat_id" .= key.chatId
             , "action" .= ("typing" :: Text)
+            ]
+                <> threadParameters key
+
+sendStreamingDraft
+    :: TelegramClient
+    -> TelegramChatKey
+    -> Text
+    -> IO ()
+sendStreamingDraft client key html =
+    expectBool client "sendRichMessageDraft" $
+        object $
+            [ "chat_id" .= key.chatId
+            , "draft_id" .= (1 :: Int)
+            , "rich_message" .= object ["html" .= html]
             ]
                 <> threadParameters key
 

--- a/packages/agent-telegram/test/Agent/TelegramSpec.hs
+++ b/packages/agent-telegram/test/Agent/TelegramSpec.hs
@@ -43,6 +43,26 @@ import Test.Hspec
 
 spec :: Spec
 spec = describe "Agent.Telegram" do
+    describe "telegramAgentPrompt" do
+        it "injects Telegram streaming and brevity guidance" do
+            let prompt = telegramAgentPrompt "Inspect the failing tests"
+            prompt `shouldSatisfy`
+                Text.isInfixOf "shown to the user as a live Telegram draft"
+            prompt `shouldSatisfy`
+                Text.isInfixOf "Keep messages concise and conversational"
+            prompt `shouldSatisfy`
+                Text.isPrefixOf "Inspect the failing tests"
+
+    describe "telegramActivityDraftHtml" do
+        it "shows escaped reasoning summaries and streamed answer text" do
+            Bridge.telegramActivityDraftHtml
+                "Writing reply…"
+                "Checking <files>"
+                "Found & fixed\nDone"
+                `shouldBe`
+                "<tg-thinking>Checking &lt;files&gt;</tg-thinking>\
+                \<p>Found &amp; fixed<br>Done</p>"
+
     describe "parseTelegramArgs" do
         it "runs the configured gateway by default" do
             parseTelegramArgs [] `shouldBe` Right TelegramRun


### PR DESCRIPTION
## Summary
- stream live assistant response text through Telegram native rich-message drafts
- include available reasoning summaries and current tool/retry activity in the thinking section
- suppress unchanged draft updates while refreshing every 20 seconds, then preserve the durable final reply
- keep Telegram replies concise through Telegram-only delivery guidance

## Validation
- `printf ':quit\\n' | nix develop -c cabal repl agent-cli:lib:agent-cli agent-telegram:lib:agent-telegram`
- `nix develop -c cabal test agent-cli:test:agent-cli-test --test-options='--match Agent.CLI.GatewayBridge'`
- `nix develop -c cabal test agent-telegram:test:agent-telegram-test --test-options='--match telegramAgentPrompt'`
- `nix develop -c cabal test agent-telegram:test:agent-telegram-test --test-options='--match telegramActivityDraftHtml'`
- `nix develop -c cabal test agent-telegram:test:agent-telegram-test --test-options='--match "Telegram progress lifecycle"'`
- `git diff --check`
