### PR TITLE
Fix fullscreen live-output auto-scroll

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -3996,7 +3996,30 @@ choiceRowColumns width label detail
 
 handleUiEvents :: NonEmpty UiEvent -> EventM Name AppState ()
 handleUiEvents uiEvents = do
-    initial <- get
+    stored <- get
+    viewportBounds <-
+        if stored.appAgentSelected == AgentRoot
+            then
+                lookupViewport ConversationViewport >>= \case
+                    Just (VP _ top (_, height) (_, contentHeight)) ->
+                        pure (Just (top, height, contentHeight))
+                    Nothing ->
+                        pure Nothing
+            else pure Nothing
+    let reconciledFollow =
+            if stored.appAgentSelected == AgentRoot
+                then
+                    Scroll.reconcileConversationFollow
+                        stored.appUi.uiFollow
+                        viewportBounds
+                else stored.appUi.uiFollow
+        initial =
+            stored
+                { appUi =
+                    stored.appUi
+                        { uiFollow = reconciledFollow
+                        }
+                }
     timestamp <- liftIO currentShortMessageTimestamp
     renderedContentHeight <-
         if any isSubmittedPrompt uiEvents

--- a/packages/agent-cli/src/Agent/CLI/TUI/Scroll.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Scroll.hs
@@ -7,6 +7,7 @@ module Agent.CLI.TUI.Scroll
     , conversationScrollGesture
     , conversationAnchorSticky
     , followConversationTail
+    , reconcileConversationFollow
     , reflowConversationAnchor
     , startConversationAnchor
     ) where
@@ -64,6 +65,21 @@ conversationScrollGesture amount viewport
                     ResumeConversationFollow
                 | otherwise ->
                     PauseAndScrollConversation
+
+-- | Reconcile the stored follow flag with the viewport that was visible
+-- immediately before new conversation output arrived.
+--
+-- A visible tail repairs a stale paused flag. A viewport above the tail does
+-- not itself pause following, because the submitted-prompt page-fill reflow
+-- can transiently expose that geometry before its reserve rows are installed.
+-- Explicit user scroll gestures remain responsible for pausing follow mode.
+-- Before the first render there is no viewport, so retain the stored flag.
+reconcileConversationFollow :: Bool -> Maybe (Int, Int, Int) -> Bool
+reconcileConversationFollow storedFollow = \case
+    Nothing -> storedFollow
+    Just (top, height, contentHeight) ->
+        storedFollow
+            || top + max 0 height >= max 0 contentHeight
 
 startConversationAnchor :: BlockId -> Text -> Int -> ConversationAnchor
 startConversationAnchor blockId text top = ConversationAnchor

--- a/packages/agent-cli/test/Agent/CLI/TUIScrollSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIScrollSpec.hs
@@ -25,6 +25,23 @@ spec = describe "fullscreen conversation scrolling" do
             conversationScrollGesture 10 (Just (31, 20, 60))
                 `shouldBe` ResumeConversationFollow
 
+    describe "reconcileConversationFollow" do
+        it "repairs a stale paused flag when the tail is visible" do
+            reconcileConversationFollow False (Just (40, 20, 60))
+                `shouldBe` True
+
+        it "does not override active following during page-fill reflow" do
+            reconcileConversationFollow True (Just (12, 20, 60))
+                `shouldBe` True
+
+        it "keeps a paused viewport paused while it is above the tail" do
+            reconcileConversationFollow False (Just (12, 20, 60))
+                `shouldBe` False
+
+        it "retains the stored state before the first viewport render" do
+            reconcileConversationFollow True Nothing `shouldBe` True
+            reconcileConversationFollow False Nothing `shouldBe` False
+
     it "reserves the rest of the viewport below a submitted prompt" do
         let anchor = startConversationAnchor (BlockId 7) "question" 40
             (next, action) =


### PR DESCRIPTION
## Summary
- reconcile fullscreen follow mode with the viewport position before applying new conversation output
- resume automatic scrolling when a stale paused flag remains even though the tail is visible
- preserve explicitly paused scrollback and avoid treating transient page-fill geometry as a pause
- add focused regression coverage for follow-state reconciliation

## Validation
- `nix develop -c cabal test agent-cli:test:agent-cli-test --test-show-details=direct --test-options='--match reconcileConversationFollow'`
- GHCi loaded the changed `agent-cli` modules successfully
- live tmux TUI smoke test:
  - a 200-line streamed response followed through line 200 while at the tail
  - Page Up during a longer streamed response showed `Live output paused` and preserved the viewed position
- `git diff --check`
