### PR TITLE
Preserve scrollback after context compaction

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Commands.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Commands.hs
@@ -175,8 +175,8 @@ import Agent.Subagents.TaskPath ()
 import Agent.TUI.Model
     ( infoNotice,
       progressNotice,
-      UiEvent(UiUserSubmitted, UiRecapStarted, UiConversationCleared,
-              UiSetNotice, UiErrorMessage, UiSystemMessage) )
+      UiEvent(UiUserSubmitted, UiRecapStarted, UiSetNotice, UiErrorMessage,
+              UiSystemMessage) )
 import Agent.TUI.Motion ()
 import Agent.ToolDispatch ()
 import Agent.Tools.MultiAgents ()
@@ -564,7 +564,6 @@ handleReplLine
                                     Text.hPutStrLn stderr (roleError color err)
                                 continue
                             Right outcome -> do
-                                fullscreenEvent UiConversationCleared
                                 fullscreenEvent
                                     (UiSystemMessage outcome.compactSummary)
                                 let message =

--- a/packages/agent-cli/src/Agent/CLI/Session/History.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/History.hs
@@ -21,7 +21,8 @@ import Agent.CLI.Session
     )
 import Agent.Loop (ImageAttachment)
 import Agent.OpenAI.Compaction
-    ( isTranscriptResetTurn
+    ( isCompactSessionTurn
+    , isTranscriptResetTurn
     )
 import Agent.Responses.Types (ResponseItem)
 import Agent.Tools.PlanMode
@@ -155,10 +156,20 @@ hydrateUiHistory :: [SessionTurn] -> UiState
 hydrateUiHistory = foldl' addTurn initialUiState
   where
     addTurn state turn
+        | isCompactSessionTurn turn.turnUserText =
+            addCompactTurn state turn
         | isTranscriptResetTurn turn.turnUserText =
             addResetTurn state turn
         | otherwise =
             addRegularTurn state turn
+
+    -- Compaction replaces the model's inference context, not the transcript
+    -- presented to the user. Keep earlier blocks scrollable and append the
+    -- compaction summary as the live UI does.
+    addCompactTurn state turn =
+        case turn.turnAssistantText of
+            Nothing -> state
+            Just text -> reduceUi (UiSystemMessage text) state
 
     addResetTurn state turn =
         let cleared = reduceUi UiConversationCleared state

--- a/packages/agent-cli/test/Agent/CLI/SessionHistorySpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SessionHistorySpec.hs
@@ -2,21 +2,31 @@ module Agent.CLI.SessionHistorySpec (spec) where
 
 import Agent.CLI.Session.History
     ( LiveConversation(..)
+    , hydrateUiHistory
     , resetLiveConversationState
     , resetLiveConversationWith
+    )
+import Agent.CLI.Session
+    ( SessionTurn(..)
+    , TranscriptEffect(..)
     )
 import Agent.Loop (ImageAttachment(..))
 import Agent.Responses.LoopBackend (turnInputsToItems)
 import Agent.Loop (TurnInput(..))
+import Agent.TUI.Model (BlockKind(..), UiBlock(..), UiState(..))
 import qualified Data.ByteString.Char8 as ByteString
+import qualified Data.Foldable as Foldable
 import Data.IORef (newIORef, readIORef, writeIORef)
+import Data.Text (Text)
+import Data.Time (UTCTime(..), fromGregorian)
 import Agent.Tools.PlanMode (newPlanModeEnv)
 import System.OsPath (unsafeEncodeUtf)
 import Test.Hspec (Spec, describe, it, shouldBe, shouldReturn)
 
 spec :: Spec
-spec = describe "LiveConversation" do
-    it "resets all coordinated fields together" do
+spec = do
+    describe "LiveConversation" do
+      it "resets all coordinated fields together" do
         let state = LiveConversation
                 { livePreviousResponseId = Just "resp-1"
                 , liveTranscript = turnInputsToItems [UserMessage "hello"]
@@ -30,7 +40,7 @@ spec = describe "LiveConversation" do
                 , liveAttachments = []
                 }
 
-    it "is idempotent" do
+      it "is idempotent" do
         let state = LiveConversation
                 { livePreviousResponseId = Just "resp-1"
                 , liveTranscript = []
@@ -39,7 +49,7 @@ spec = describe "LiveConversation" do
             reset = resetLiveConversationState state
         resetLiveConversationState reset `shouldBe` reset
 
-    it "clears provider-owned transcript state at the same reset boundary" do
+      it "clears provider-owned transcript state at the same reset boundary" do
         let transcript = turnInputsToItems [UserMessage "old context"]
         conversationRef <- newIORef LiveConversation
             { livePreviousResponseId = Just "resp-1"
@@ -59,3 +69,39 @@ spec = describe "LiveConversation" do
                 , liveTranscript = []
                 , liveAttachments = []
                 }
+
+    describe "hydrateUiHistory" do
+      it "keeps pre-compaction blocks scrollable while appending the summary" do
+        let before = sessionTurn "question" (Just "answer") TranscriptAppend
+            compacted =
+                sessionTurn
+                    "/compact"
+                    (Just "Context compacted remotely.")
+                    TranscriptReplace
+            blocks =
+                Foldable.toList
+                    (hydrateUiHistory [before, compacted]).uiBlocks
+        map (\block -> (block.blockKind, block.blockBody)) blocks
+            `shouldBe`
+                [ (BlockUser, "question")
+                , (BlockAssistant, "answer")
+                , (BlockSystem, "Context compacted remotely.")
+                ]
+
+      it "still clears displayed history for an explicit clear" do
+        let before = sessionTurn "question" (Just "answer") TranscriptAppend
+            cleared = sessionTurn "/clear" Nothing TranscriptReset
+        Foldable.toList (hydrateUiHistory [before, cleared]).uiBlocks
+            `shouldBe` []
+
+sessionTurn :: Text -> Maybe Text -> TranscriptEffect -> SessionTurn
+sessionTurn user assistant effect = SessionTurn
+    { turnAt = UTCTime (fromGregorian 2026 8 25) 0
+    , turnUserText = user
+    , turnAssistantText = assistant
+    , turnError = Nothing
+    , turnResponseId = Nothing
+    , turnEffect = effect
+    , turnItems = []
+    , turnUsage = Nothing
+    }


### PR DESCRIPTION
## Summary
- preserve retained fullscreen transcript blocks when `/compact` replaces model context
- append the compaction summary without clearing scrollback
- preserve the same visible history when resuming a compacted session, while keeping `/clear` and `/new` reset behavior

## Testing
- focused `hydrateUiHistory` Hspec tests in GHCi (2 examples, 0 failures)
- `cabal repl agent-cli:lib:agent-cli` typecheck
- live fullscreen startup and exit in tmux
- `git diff --check`
