### PR TITLE
Raise default Luna subagent effort to high

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
@@ -957,13 +957,18 @@ resolveChildModelAndEffort
 resolveChildModelAndEffort
         provider parentParams inheritedModel childModel childEffort =
     ( model
-    , fromMaybe inheritedEffort childEffort
+    , fromMaybe defaultChildEffort childEffort
     )
   where
     model = fromMaybe inheritedModel childModel
     inheritedEffort = case parentParams.reasoning of
         Just cfg -> fromMaybe (defaultEffortFor provider) cfg.effort
         Nothing -> defaultEffortFor provider
+    defaultChildEffort
+        | provider == OpenAIProvider
+        , model == "gpt-5.6-luna"
+        , inheritedEffort `notElem` ["xhigh", "max"] = "high"
+        | otherwise = inheritedEffort
 
 runPreparedChild
     :: SubagentRuntime

--- a/packages/agent-cli/test/Agent/CLI/SubagentStoreSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SubagentStoreSpec.hs
@@ -86,7 +86,7 @@ spec = describe "Agent.CLI.SubagentStore" do
                 session.subSessionEffectiveModel
                 Nothing
                 Nothing
-                `shouldBe` ("gpt-5.6-luna", "medium")
+                `shouldBe` ("gpt-5.6-luna", "high")
 
         it "keeps an explicit child model override" do
             let rootParams =
@@ -98,6 +98,39 @@ spec = describe "Agent.CLI.SubagentStore" do
                 (Just "gpt-5.6-nano")
                 (Just "high")
                 `shouldBe` ("gpt-5.6-nano", "high")
+
+        it "honors an explicit Luna effort below the default high floor" do
+            let rootParams =
+                    requestParams OpenAIProvider "gpt-5.6-sol" "" [] "medium"
+            resolveChildModelAndEffort
+                OpenAIProvider
+                rootParams
+                "gpt-5.6-sol"
+                (Just "gpt-5.6-luna")
+                (Just "medium")
+                `shouldBe` ("gpt-5.6-luna", "medium")
+
+        it "does not lower a higher inherited Luna effort" do
+            let rootParams =
+                    requestParams OpenAIProvider "gpt-5.6-sol" "" [] "xhigh"
+            resolveChildModelAndEffort
+                OpenAIProvider
+                rootParams
+                "gpt-5.6-luna"
+                Nothing
+                Nothing
+                `shouldBe` ("gpt-5.6-luna", "xhigh")
+
+        it "keeps inherited effort unchanged for other OpenAI models" do
+            let rootParams =
+                    requestParams OpenAIProvider "gpt-5.6-sol" "" [] "medium"
+            resolveChildModelAndEffort
+                OpenAIProvider
+                rootParams
+                "gpt-5.6-terra"
+                Nothing
+                Nothing
+                `shouldBe` ("gpt-5.6-terra", "medium")
 
     it "round-trips transcript items and meta" do
         withTempDir \dir -> do


### PR DESCRIPTION
## Summary
- default GPT-5.6 Luna subagents to high reasoning effort when no child override is supplied
- preserve inherited xhigh/max effort and all explicit child effort overrides
- leave effort inheritance unchanged for other models

## Validation
- `nix develop -c cabal repl agent-cli:test:agent-cli-test`
- `:main --match "nested subagent model inheritance"` (5 examples, 0 failures)
- `git diff --check`