### PR TITLE
Harden reducer edge cases with QuickCheck

### DIFF
--- a/packages/agent-core/agent-core.cabal
+++ b/packages/agent-core/agent-core.cabal
@@ -208,6 +208,7 @@ test-suite agent-core-test
                     , filepath
                     , containers
                     , hspec
+                    , QuickCheck >= 2.14 && < 2.16
                     , retry >= 0.9.3.1 && < 0.10
                     , safe-exceptions
                     , stm

--- a/packages/agent-core/package.nix
+++ b/packages/agent-core/package.nix
@@ -1,9 +1,9 @@
 { mkDerivation, aeson, agent-process, agent-responses-types, async
 , base, base64-bytestring, bytestring, containers
 , crypton-connection, directory, filepath, hspec, lib, process
-, resourcet, retry, safe-exceptions, scientific, stm, text
-, text-builder, time, tls, transformers, unix, vector, websockets
-, yaml
+, QuickCheck, resourcet, retry, safe-exceptions, scientific, stm
+, text, text-builder, time, tls, transformers, unix, vector
+, websockets, yaml
 }:
 mkDerivation {
   pname = "agent-core";
@@ -18,8 +18,8 @@ mkDerivation {
   ];
   testHaskellDepends = [
     aeson agent-responses-types async base base64-bytestring bytestring
-    containers crypton-connection directory filepath hspec retry
-    safe-exceptions stm text time tls unix websockets yaml
+    containers crypton-connection directory filepath hspec QuickCheck
+    retry safe-exceptions stm text time tls unix websockets yaml
   ];
   benchmarkHaskellDepends = [
     aeson base bytestring directory safe-exceptions text text-builder

--- a/packages/agent-core/src/Agent/Tools/Dangerous.hs
+++ b/packages/agent-core/src/Agent/Tools/Dangerous.hs
@@ -79,13 +79,15 @@ isRmCommand cmd =
 flagsHaveRecursiveForce :: [Text] -> Bool
 flagsHaveRecursiveForce args =
     let flags = takeWhile isFlag args
-        clustered = Text.concat (map stripDashes flags)
+        shortFlags = filter (not . isLongFlag) flags
+        clustered = Text.concat (map stripDashes shortFlags)
         lower = Text.map toLower clustered
         hasR = Text.any (== 'r') lower || any isLongRecursive flags
         hasF = Text.any (== 'f') lower || any isLongForce flags
     in hasR && hasF
   where
     isFlag t = Text.isPrefixOf "-" t
+    isLongFlag t = Text.isPrefixOf "--" t
     stripDashes = Text.dropWhile (== '-')
     isLongRecursive t =
         let x = Text.toLower t

--- a/packages/agent-core/test/Agent/Tools/DangerousSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/DangerousSpec.hs
@@ -5,8 +5,98 @@ import Agent.Tools.Dangerous
     , forbiddenRmRfReason
     , shellCommandBlocked
     )
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString.Lazy as LazyByteString
 import qualified Data.Text as Text
+import qualified Data.Text.Encoding as TextEncoding
 import Test.Hspec
+import Test.Hspec.QuickCheck (modifyMaxSuccess, prop)
+import Test.QuickCheck
+    ( Arbitrary(..)
+    , choose
+    , conjoin
+    , elements
+    , (===)
+    )
+
+newtype DangerousCommand = DangerousCommand Text.Text
+    deriving (Show)
+
+instance Arbitrary DangerousCommand where
+    arbitrary = DangerousCommand <$> do
+        prefix <- elements
+            [ ""
+            , "true; "
+            , "ls && "
+            , "echo hi | "
+            ]
+        environment <- elements
+            [ ""
+            , "FOO=1 "
+            , "FOO=1 BAR=2 "
+            ]
+        wrapper <- elements
+            [ ""
+            , "sudo "
+            , "env "
+            , "command "
+            , "nice "
+            , "nohup "
+            , "time "
+            , "stdbuf "
+            ]
+        command <- elements ["rm", "RM", "/bin/rm", "rm.exe"]
+        flags <- elements
+            [ "-rf"
+            , "-fr"
+            , "-Rf"
+            , "-fR"
+            , "-r -f"
+            , "-f -r"
+            , "--recursive --force"
+            , "--force --recursive"
+            , "--recursive=true --force=false"
+            ]
+        spacing <- elements [" ", "  ", "\t"]
+        target <- elements ["tmp", "./build", "/tmp/x", "C:\\Temp\\x"]
+        suffix <- elements ["", " || true", "; true"]
+        pure
+            ( prefix
+                <> environment
+                <> wrapper
+                <> command
+                <> spacing
+                <> flags
+                <> spacing
+                <> target
+                <> suffix
+            )
+
+newtype BenignCommand = BenignCommand Text.Text
+    deriving (Show)
+
+instance Arbitrary BenignCommand where
+    arbitrary = BenignCommand <$> do
+        choice <- choose (0 :: Int, 4)
+        case choice of
+            0 -> do
+                flag <- elements ["", "-r", "-f", "--recursive", "--force"]
+                pure ("rm " <> flag <> " build")
+            1 -> elements
+                [ "ls -la"
+                , "git status"
+                , "rmdir empty-dir"
+                , "rclone sync --force"
+                ]
+            2 -> elements
+                [ "echo 'rm -rf tmp'"
+                , "echo \"rm -rf tmp\""
+                , "bash -lc 'rm -rf tmp'"
+                ]
+            3 -> do
+                wrapper <- elements ["sudo ", "env ", "command "]
+                pure (wrapper <> "rm -r build")
+            _ -> pure "rm -r -x file"
 
 spec :: Spec
 spec = do
@@ -43,6 +133,8 @@ spec = do
         it "allows safe rm and unrelated commands" do
             commandLooksLikeRmRf "rm -r build" `shouldBe` False
             commandLooksLikeRmRf "rm -f file.txt" `shouldBe` False
+            commandLooksLikeRmRf "rm --recursive build" `shouldBe` False
+            commandLooksLikeRmRf "rm --force build" `shouldBe` False
             commandLooksLikeRmRf "rm file.txt" `shouldBe` False
             commandLooksLikeRmRf "ls -la" `shouldBe` False
             commandLooksLikeRmRf "git status" `shouldBe` False
@@ -52,6 +144,16 @@ spec = do
             commandLooksLikeRmRf "rclone sync --force" `shouldBe` False
             -- Nested shells are out of scope for this best-effort gate.
             commandLooksLikeRmRf "bash -lc 'rm -rf tmp'" `shouldBe` False
+
+        modifyMaxSuccess (const 500) $
+            prop "detects generated equivalent recursive-force forms" $
+                \(DangerousCommand command) ->
+                    commandLooksLikeRmRf command === True
+
+        modifyMaxSuccess (const 500) $
+            prop "does not classify generated benign near-misses as dangerous" $
+                \(BenignCommand command) ->
+                    commandLooksLikeRmRf command === False
 
     describe "shellCommandBlocked" do
         it "blocks shell tools with a clear reason" do
@@ -67,6 +169,20 @@ spec = do
 
         it "parses JSON with whitespace around the command value" do
             shouldBlock "run_terminal_cmd" "{\"command\" : \"rm -rf x\"}"
+
+        modifyMaxSuccess (const 500) $
+            prop "blocks dangerous generated commands for every shell tool name" $
+                \(DangerousCommand command) ->
+                    let arguments = encodeCommand command
+                    in conjoin
+                        [ isBlocked (shellCommandBlocked tool arguments)
+                            === True
+                        | tool <-
+                            [ "run_terminal_cmd"
+                            , "run_terminal_command"
+                            , "shell_command"
+                            ]
+                        ]
 
         it "allows non-matching shell commands" do
             shouldAllow "run_terminal_cmd" "{\"command\":\"rm -r build\"}"
@@ -90,3 +206,12 @@ spec = do
             Nothing -> expectationFailure ("expected block for " <> Text.unpack args)
     shouldAllow tool args =
         shellCommandBlocked tool args `shouldBe` Nothing
+
+    isBlocked (Just message) =
+        Text.isInfixOf "Blocked dangerous shell command" message
+    isBlocked Nothing = False
+
+    encodeCommand command =
+        TextEncoding.decodeUtf8
+            (LazyByteString.toStrict
+                (Aeson.encode (Aeson.object ["command" Aeson..= command])))

--- a/packages/agent-responses/agent-responses.cabal
+++ b/packages/agent-responses/agent-responses.cabal
@@ -88,6 +88,7 @@ test-suite agent-responses-test
                     , agent-responses-types
                     , aeson >= 2.0
                     , bytestring
+                    , containers
                     , hspec
                     , QuickCheck >= 2.14 && < 2.16
                     , retry

--- a/packages/agent-responses/package.nix
+++ b/packages/agent-responses/package.nix
@@ -13,8 +13,8 @@ mkDerivation {
     retry safe-exceptions scientific text vector
   ];
   testHaskellDepends = [
-    aeson agent-core agent-responses-types base bytestring hspec
-    QuickCheck retry text
+    aeson agent-core agent-responses-types base bytestring containers
+    hspec QuickCheck retry text
   ];
   description = "Provider-neutral Responses codecs and adapters";
   license = lib.meta.getLicenseFromSpdxId "BSD-3-Clause";

--- a/packages/agent-responses/test/Agent/Responses/ResponseMergeSpec.hs
+++ b/packages/agent-responses/test/Agent/Responses/ResponseMergeSpec.hs
@@ -4,8 +4,20 @@ import qualified Agent.Responses.Types as Responses
 import Agent.Responses.ResponseMerge
 import qualified Data.Aeson as Aeson
 import Data.Aeson ((.=))
+import Data.List (nub)
 import Data.Text (Text)
+import qualified Data.Text as Text
 import Test.Hspec
+import Test.Hspec.QuickCheck (modifyMaxSuccess, prop)
+import Test.QuickCheck
+    ( Arbitrary(..)
+    , Gen
+    , chooseInt
+    , elements
+    , listOf
+    , vectorOf
+    , (===)
+    )
 
 spec :: Spec
 spec = describe "mergeCompletedResponseOutput" do
@@ -24,6 +36,47 @@ spec = describe "mergeCompletedResponseOutput" do
                     , Responses.extraFields = mempty
                     }
                 ]
+
+    modifyMaxSuccess (const 300) $
+        prop "overlaying object fragments is associative" $
+            \(ObjectFragments (first, second, third)) ->
+                mergeResponseFragments
+                    [first, second, third]
+                    === mergeResponseFragments
+                        [ mergeResponseFragments [first, second]
+                        , third
+                        ]
+
+    modifyMaxSuccess (const 300) $
+        prop "later lifecycle fields win while unrelated fields survive" $
+            \(GeneratedLifecycle (firstValue, secondValue)) ->
+                let first =
+                        Aeson.object
+                            [ "id" .= ("first" :: Text)
+                            , "model" .= ("test-model" :: Text)
+                            , "stable" .= firstValue
+                            ]
+                    second =
+                        Aeson.object
+                            [ "id" .= ("second" :: Text)
+                            , "vendor_field" .= secondValue
+                            ]
+                    expected =
+                        Aeson.object
+                            [ "id" .= ("second" :: Text)
+                            , "model" .= ("test-model" :: Text)
+                            , "stable" .= firstValue
+                            , "vendor_field" .= secondValue
+                            ]
+                in mergeResponseFragments [first, second] === expected
+
+    modifyMaxSuccess (const 300) $
+        prop "merging identifiable streamed items is idempotent" $
+            \(GeneratedItems items) ->
+                let response = completedResponse []
+                    once = mergeCompletedResponseOutput items response
+                    twice = mergeCompletedResponseOutput items once
+                in twice === once
 
     it "keeps final output and appends streamed items missing from the completed event" do
         decodedOutput (mergeCompletedResponseOutput [toolCall] (completedResponse [assistantMessage]))
@@ -112,3 +165,50 @@ toolCall =
         , "name" .= ("echo_text" :: Text)
         , "arguments" .= ("{\"text\":\"ok\"}" :: Text)
         ]
+
+newtype ObjectFragments = ObjectFragments
+    (Aeson.Value, Aeson.Value, Aeson.Value)
+
+instance Show ObjectFragments where
+    show (ObjectFragments values) = show values
+
+instance Arbitrary ObjectFragments where
+    arbitrary =
+        ObjectFragments <$> ((,,) <$> genObject <*> genObject <*> genObject)
+    shrink _ = []
+
+genObject :: Gen Aeson.Value
+genObject = do
+    fields <- listOf $ do
+        key <- elements ["id", "status", "model", "vendor_field"]
+        value <- chooseInt (-10, 10)
+        pure (key .= value)
+    pure (Aeson.object fields)
+
+newtype GeneratedItems = GeneratedItems [Aeson.Value]
+
+instance Show GeneratedItems where
+    show (GeneratedItems items) = show items
+
+instance Arbitrary GeneratedItems where
+    arbitrary = do
+        identifiers <- vectorOf 6 (chooseInt (0, 20))
+        let uniqueIdentifiers = nub identifiers
+        pure $ GeneratedItems
+            [ Aeson.object
+                [ "type" .= ("function_call" :: Text)
+                , "id" .= ("streamed-" <> Text.pack (show identifier))
+                , "call_id" .= ("call-" <> Text.pack (show identifier))
+                , "name" .= ("generated" :: Text)
+                , "arguments" .= ("{}" :: Text)
+                ]
+            | identifier <- uniqueIdentifiers
+            ]
+    shrink _ = []
+
+newtype GeneratedLifecycle = GeneratedLifecycle (Int, Int)
+    deriving (Eq, Show)
+
+instance Arbitrary GeneratedLifecycle where
+    arbitrary = GeneratedLifecycle <$> ((,) <$> chooseInt (-100, 100) <*> chooseInt (-100, 100))
+    shrink _ = []

--- a/packages/agent-responses/test/Agent/Responses/StreamAssemblySpec.hs
+++ b/packages/agent-responses/test/Agent/Responses/StreamAssemblySpec.hs
@@ -4,9 +4,27 @@ import Agent.Error (ApiError(..))
 import Agent.Responses.SSE (parseSseEvents)
 import Agent.Responses.StreamAssembly
 import Agent.Responses.Types
+import Control.Applicative ((<|>))
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.Map.Strict as Map
+import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Test.Hspec
+import Test.Hspec.QuickCheck (modifyMaxSuccess, prop)
+import Test.QuickCheck
+    ( Arbitrary(..)
+    , chooseInt
+    , conjoin
+    , counterexample
+    , elements
+    , listOf
+    , listOf1
+    , oneof
+    , (===)
+    )
 
 spec :: Spec
 spec = describe "buildStreamResponse" do
@@ -215,6 +233,99 @@ spec = describe "buildStreamResponse" do
                 message `shouldBe` "custom missing completion"
             other -> expectationFailure
                 ("expected missing-completion JsonDecodeError, got " <> show other)
+
+    modifyMaxSuccess (const 500) $
+        prop "matches an independent model for adversarial indexed events" $
+            \(AdversarialOperations operations) ->
+                let events =
+                        [ ResponseCreatedEvent
+                            (responseFragment "adversarial")
+                            Nothing
+                            mempty
+                        ]
+                        <> map operationEvent operations
+                        <> [ ResponseCompletedEvent
+                                (responseFragment "adversarial")
+                                Nothing
+                                mempty
+                           ]
+                    expectedModel =
+                        foldl applyExpected Map.empty operations
+                    expected =
+                        expectedOutput expectedModel
+                in case buildStreamResponse config events of
+                    Left err ->
+                        counterexample
+                            ( "unexpected assembly failure: "
+                                <> show err
+                                <> "\noperations: "
+                                <> show operations
+                            )
+                            False
+                    Right response ->
+                        let actual = map Aeson.toJSON response.output
+                        in counterexample
+                            ( "operations: " <> show operations
+                                <> "\nexpected: " <> show expected
+                                <> "\nactual: " <> show actual
+                            )
+                            (actual === expected)
+
+    modifyMaxSuccess (const 300) $
+        prop "keeps done precedence when a late added event is merged" $
+            \doneFragment lateFragment terminalFragment ->
+                let doneOperation = IndexedOperation (Just 0) True doneFragment
+                    lateOperation = IndexedOperation (Just 0) False lateFragment
+                    terminalValue =
+                        Aeson.toJSON (toResponseItem terminalFragment)
+                    streamedValue =
+                        mergeModelValues
+                            (Aeson.toJSON (toResponseItem doneFragment))
+                            (Aeson.toJSON (toResponseItem lateFragment))
+                    expected =
+                        [mergeModelValues terminalValue streamedValue]
+                    events =
+                        [ ResponseCreatedEvent
+                            (responseFragment "sticky-done")
+                            Nothing
+                            mempty
+                        , operationEvent doneOperation
+                        , operationEvent lateOperation
+                        , ResponseCompletedEvent
+                            (responseFragmentWithOutput
+                                "sticky-done"
+                                [toResponseItem terminalFragment])
+                            Nothing
+                            mempty
+                        ]
+                in case buildStreamResponse config events of
+                    Left err ->
+                        counterexample
+                            ("unexpected assembly failure: " <> show err)
+                            False
+                    Right response ->
+                        map Aeson.toJSON response.output === expected
+
+    modifyMaxSuccess (const 300) $
+        prop "ignores all events after the first terminal lifecycle event" $
+            \(LifecycleTrace before terminal after) ->
+                let events =
+                        map lifecycleEvent before
+                        <> [lifecycleEvent terminal]
+                        <> map lifecycleEvent after
+                    expectedId = terminal.lifecycleId
+                in case buildStreamResponse config events of
+                    Left err ->
+                        counterexample
+                            ("unexpected assembly failure: " <> show err)
+                            False
+                    Right response ->
+                        conjoin
+                            [ counterexample
+                                ("terminal: " <> show terminal
+                                    <> "\nafter: " <> show after)
+                                (response.responseId === expectedId)
+                            ]
   where
     config = StreamAssemblyConfig
         { missingCompletionMessage = "custom missing completion"
@@ -226,6 +337,299 @@ spec = describe "buildStreamResponse" do
                     ("failed: " <> failedStreamResponseMessage failure)
         , incompleteAsFailure = True
         }
+
+responseFragment :: Text -> Aeson.Value
+responseFragment responseId =
+    Aeson.object
+        [ "id" Aeson..= responseId
+        , "created_at" Aeson..= (0 :: Int)
+        , "model" Aeson..= ("generated-model" :: Text)
+        , "status" Aeson..= ("completed" :: Text)
+        , "output" Aeson..= ([] :: [Aeson.Value])
+        ]
+
+responseFragmentWithOutput :: Text -> [ResponseItem] -> Aeson.Value
+responseFragmentWithOutput responseId output =
+    Aeson.object
+        [ "id" Aeson..= responseId
+        , "created_at" Aeson..= (0 :: Int)
+        , "model" Aeson..= ("generated-model" :: Text)
+        , "status" Aeson..= ("completed" :: Text)
+        , "output" Aeson..= output
+        ]
+
+-- This model deliberately stores raw item values rather than reusing the
+-- implementation's progress type. An explicit output index identifies one
+-- item, and later object fields overlay earlier fields.
+type StreamModel = Map.Map Int (Aeson.Value, Bool)
+
+data CallFragment = CallFragment
+    { fragmentItemId    :: !(Maybe Text)
+    , fragmentCallId    :: !Text
+    , fragmentName      :: !Text
+    , fragmentNamespace :: !(Maybe Text)
+    , fragmentArguments  :: !Text
+    , fragmentStatus     :: !(Maybe ItemStatus)
+    , fragmentMarker     :: !Text
+    }
+    deriving (Eq, Show)
+
+data LifecycleStep = LifecycleStep
+    { lifecycleId       :: !Text
+    , lifecycleTerminal :: !Bool
+    }
+    deriving (Eq, Show)
+
+instance Arbitrary LifecycleStep where
+    arbitrary = LifecycleStep
+        <$> elements ["response-before-a", "response-before-b", "response-final"]
+        <*> arbitrary
+
+data LifecycleTrace = LifecycleTrace
+    { lifecycleBefore   :: ![LifecycleStep]
+    , lifecycleTerminalStep :: !LifecycleStep
+    , lifecycleAfter    :: ![LifecycleStep]
+    }
+    deriving (Eq, Show)
+
+instance Arbitrary LifecycleTrace where
+    arbitrary = do
+        beforeIds <- listOf
+            (elements ["response-before-a", "response-before-b"])
+        terminal <- LifecycleStep
+            <$> elements ["response-final", "response-final-b"]
+            <*> pure True
+        after <- listOf arbitrary
+        pure (LifecycleTrace
+            (map (`LifecycleStep` False) beforeIds)
+            terminal
+            after)
+    shrink (LifecycleTrace before terminal after) =
+        [ LifecycleTrace before' terminal after
+        | before' <- shrink before
+        ]
+        <> [ LifecycleTrace before terminal after'
+           | after' <- shrink after
+           ]
+
+lifecycleEvent :: LifecycleStep -> ResponseStreamEvent
+lifecycleEvent step
+    | step.lifecycleTerminal =
+        ResponseCompletedEvent
+            (responseFragment step.lifecycleId)
+            Nothing
+            mempty
+    | otherwise =
+        ResponseCreatedEvent
+            (responseFragment step.lifecycleId)
+            Nothing
+            mempty
+
+instance Arbitrary CallFragment where
+    arbitrary = CallFragment
+        <$> arbitraryOptional
+        <*> elements ["call-a", "call-b", "call-c", "call-latest"]
+        <*> elements ["first", "second", "third", "latest"]
+        <*> arbitraryOptional
+        <*> elements ["{}", "{\"value\":1}", "{\"value\":2}", ""]
+        <*> arbitraryOptionalStatus
+        <*> elements ["marker-a", "marker-b", "marker-c", "marker-latest"]
+      where
+        arbitraryOptional =
+            elements
+                [ Nothing
+                , Just "item-a"
+                , Just "item-b"
+                , Just "item-c"
+                ]
+        arbitraryOptionalStatus =
+            elements
+                [ Nothing
+                , Just ItemInProgress
+                , Just ItemCompleted
+                , Just ItemIncomplete
+                ]
+
+data IndexedOperation = IndexedOperation
+    { operationIndex :: !(Maybe Int)
+    , operationDone  :: !Bool
+    , operationCall  :: !CallFragment
+    }
+    deriving (Eq, Show)
+
+instance Arbitrary IndexedOperation where
+    arbitrary = IndexedOperation
+        <$> oneof
+            [ pure Nothing
+            , Just <$> chooseInt (-3, 100)
+            ]
+        <*> arbitrary
+        <*> arbitrary
+
+newtype AdversarialOperations = AdversarialOperations [IndexedOperation]
+    deriving (Eq, Show)
+
+instance Arbitrary AdversarialOperations where
+    arbitrary = do
+        -- Keep these operations in every generated stream so that each
+        -- property run exercises duplicates, both orderings, and sparse,
+        -- out-of-order indexes. Additional operations remain arbitrary.
+        doneBeforeAddedIndex <- chooseInt (30, 40)
+        addedBeforeDoneIndex <- chooseInt (60, 70)
+        lateAddedIndex <- chooseInt (0, 10)
+        forced <- traverse
+            (\(index, done) ->
+                IndexedOperation index done <$> arbitrary)
+            [ (Just doneBeforeAddedIndex, True)
+            , (Just doneBeforeAddedIndex, False)
+            , (Just addedBeforeDoneIndex, False)
+            , (Just addedBeforeDoneIndex, True)
+            , (Just lateAddedIndex, True)
+            , (Just lateAddedIndex, False)
+            ]
+        noise <- listOf1
+            (IndexedOperation
+                <$> (oneof
+                    [ pure Nothing
+                    , Just <$> chooseInt (0, 100)
+                    ])
+                <*> arbitrary
+                <*> arbitrary)
+        let shared = CallFragment
+                { fragmentItemId = Just "shared-item"
+                , fragmentCallId = "shared-call"
+                , fragmentName = "shared"
+                , fragmentNamespace = Nothing
+                , fragmentArguments = "{}"
+                , fragmentStatus = Just ItemInProgress
+                , fragmentMarker = "shared"
+                }
+            conflicting = shared
+                { fragmentCallId = "other-call"
+                , fragmentName = "conflicting"
+                , fragmentMarker = "conflicting"
+                }
+            identityOperations =
+                [ IndexedOperation Nothing True shared
+                , IndexedOperation Nothing False conflicting
+                ]
+        pure (AdversarialOperations
+            (forced <> identityOperations <> noise))
+    shrink (AdversarialOperations operations) =
+        AdversarialOperations <$> shrink operations
+
+operationEvent :: IndexedOperation -> ResponseStreamEvent
+operationEvent operation
+    | operation.operationDone =
+        ResponseOutputItemDoneEvent
+            (toResponseItem operation.operationCall)
+            operation.operationIndex
+            Nothing
+            mempty
+    | otherwise =
+        ResponseOutputItemAddedEvent
+            (toResponseItem operation.operationCall)
+            operation.operationIndex
+            Nothing
+            mempty
+
+toResponseItem :: CallFragment -> ResponseItem
+toResponseItem fragment =
+    FunctionCallItem FunctionCall
+        { itemId = fragment.fragmentItemId
+        , callId = fragment.fragmentCallId
+        , name = fragment.fragmentName
+        , namespace = fragment.fragmentNamespace
+        , arguments = fragment.fragmentArguments
+        , encryptedFunctionArgs = Nothing
+        , status = fragment.fragmentStatus
+        , extraFields =
+            KeyMap.singleton
+                "model_test_marker"
+                (Aeson.String fragment.fragmentMarker)
+        }
+
+applyExpected :: StreamModel -> IndexedOperation -> StreamModel
+applyExpected expected operation =
+    Map.alter update outputIndex expected
+  where
+    newValue = Aeson.toJSON (toResponseItem operation.operationCall)
+    outputIndex =
+        fromMaybe (nextModelIndex expected) $
+            operation.operationIndex
+                <|> findModelItemIndex newValue expected
+                <|> if operation.operationDone
+                    then findPendingModelIndex newValue expected
+                    else Nothing
+    update Nothing = Just (newValue, operation.operationDone)
+    update (Just (oldValue, wasDone)) =
+        Just
+            ( mergeModelValues oldValue newValue
+            , wasDone || operation.operationDone
+            )
+
+mergeModelValues :: Aeson.Value -> Aeson.Value -> Aeson.Value
+mergeModelValues (Aeson.Object oldObject) (Aeson.Object newObject) =
+    Aeson.Object (KeyMap.union newObject oldObject)
+mergeModelValues _ newValue = newValue
+
+expectedOutput :: StreamModel -> [Aeson.Value]
+expectedOutput = map fst . Map.elems
+
+nextModelIndex :: StreamModel -> Int
+nextModelIndex model =
+    maybe 0 ((+ 1) . fst) (Map.lookupMax model)
+
+findModelItemIndex :: Aeson.Value -> StreamModel -> Maybe Int
+findModelItemIndex value model =
+    firstJustModel
+        [ findIdentityModel identity model
+        | identity <- itemIdentitiesModel value
+        ]
+
+findIdentityModel :: Text -> StreamModel -> Maybe Int
+findIdentityModel wanted model =
+    fst <$> Map.lookupMin
+        (Map.filter
+            (matchesIdentityValue wanted . fst)
+            model)
+
+matchesIdentityValue :: Text -> Aeson.Value -> Bool
+matchesIdentityValue wanted candidate =
+    objectTextFieldModel "id" candidate == Just wanted
+        || objectTextFieldModel "call_id" candidate == Just wanted
+
+itemIdentitiesModel :: Aeson.Value -> [Text]
+itemIdentitiesModel value =
+    [ identity
+    | fieldName <- ["id", "call_id"]
+    , Just identity <- [objectTextFieldModel fieldName value]
+    ]
+
+findPendingModelIndex :: Aeson.Value -> StreamModel -> Maybe Int
+findPendingModelIndex value model =
+    case objectTextFieldModel "type" value of
+        Nothing -> Nothing
+        Just wantedType ->
+            fst <$> Map.lookupMin
+                (Map.filter
+                    (\(item, done) ->
+                        not done
+                            && objectTextFieldModel "type" item
+                                == Just wantedType)
+                    model)
+
+firstJustModel :: [Maybe value] -> Maybe value
+firstJustModel = foldr (<|>) Nothing
+
+objectTextFieldModel :: Text -> Aeson.Value -> Maybe Text
+objectTextFieldModel fieldName value =
+    case value of
+        Aeson.Object object ->
+            case KeyMap.lookup (Key.fromText fieldName) object of
+                Just (Aeson.String text) -> Just text
+                _ -> Nothing
+        _ -> Nothing
 
 sseBlock :: Text -> Text -> Text
 sseBlock eventType dataText =

--- a/packages/agent-tui/agent-tui.cabal
+++ b/packages/agent-tui/agent-tui.cabal
@@ -64,6 +64,7 @@ test-suite agent-tui-test
                     , Agent.TUI.MarkdownSpec
                     , Agent.TUI.MotionSpec
                     , Agent.TUI.ModelSpec
+                    , Agent.TUI.ModelPropertySpec
                     , Agent.TUI.PresentationSpec
                     , Agent.TUI.ThemeSpec
                     , Agent.TUI.TextWidthSpec
@@ -72,6 +73,8 @@ test-suite agent-tui-test
                     , agent-syntax
                     , base >= 4.17 && < 5
                     , brick >= 2.9 && < 3
+                    , containers >= 0.6 && < 0.8
                     , hspec >= 2.11 && < 2.12
+                    , QuickCheck >= 2.14 && < 2.16
                     , text
                     , vty

--- a/packages/agent-tui/package.nix
+++ b/packages/agent-tui/package.nix
@@ -1,5 +1,5 @@
 { mkDerivation, aeson, agent-core, agent-syntax, base, brick
-, containers, hspec, lib, text, vty
+, containers, hspec, lib, QuickCheck, text, vty
 }:
 mkDerivation {
   pname = "agent-tui";
@@ -9,8 +9,9 @@ mkDerivation {
     aeson agent-core agent-syntax base brick containers text vty
   ];
   testHaskellDepends = [
-    agent-core agent-syntax base brick hspec text vty
+    agent-core agent-syntax base brick containers hspec QuickCheck text
+    vty
   ];
   description = "Retained terminal UI for the universal agent harness";
-  license = lib.meta.getLicenseFromSpdxId "BSD-3-Clause";
+  license = lib.meta.getLicenseFromSpdxId "MIT";
 }

--- a/packages/agent-tui/src/Agent/TUI/Model.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model.hs
@@ -956,6 +956,7 @@ finalizeTurn terminalState state =
             Just notice
                 | notice.noticeKind == NoticeProgress -> 0
             _ -> state.uiNoticeElapsedMillis
+        , uiToolCalls = Map.empty
         }
 
 infoNotice, successNotice, warningNotice, progressNotice, errorNotice

--- a/packages/agent-tui/test/Agent/TUI/ModelPropertySpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ModelPropertySpec.hs
@@ -1,0 +1,571 @@
+module Agent.TUI.ModelPropertySpec (spec) where
+
+import Agent.Loop (LoopEvent(..))
+import Agent.TUI.Model
+    ( BlockId(..)
+    , BlockState(..)
+    , Focus(..)
+    , PermissionOverlay(..)
+    , UiNotice
+    , UiBlock(..)
+    , UiEvent(..)
+    , UiState(..)
+    , errorNotice
+    , initialUiState
+    , reduceUi
+    , warningNotice
+    )
+import Agent.TUI.TextWidth (graphemeClusters)
+import Agent.ToolDispatch
+    ( ToolCallResult(..)
+    , ToolCallKind(..)
+    , functionToolCall
+    )
+import qualified Data.List as List
+import qualified Data.Map.Strict as Map
+import qualified Data.Foldable as Foldable
+import qualified Data.Sequence as Seq
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Test.Hspec
+import Test.Hspec.QuickCheck (modifyMaxSuccess, prop)
+import Test.QuickCheck
+    ( Arbitrary(..)
+    , Gen
+    , Property
+    , chooseInt
+    , conjoin
+    , counterexample
+    , elements
+    , frequency
+    , listOf
+    , property
+    , resize
+    , shrinkList
+    , (===)
+    , (.&&.)
+    , (=/=)
+    )
+
+spec :: Spec
+spec =
+    describe "generated fullscreen reducer traces" do
+        modifyMaxSuccess (const 500) $
+            prop "preserve UiState invariants after every event prefix" $
+                \(EventTrace events) -> traceProperty events
+        modifyMaxSuccess (const 500) $
+            prop "matches navigation and permission reference semantics" $
+                \(NavigationTrace commands) ->
+                    navigationTraceProperty commands
+        modifyMaxSuccess (const 500) $
+            prop "keeps state-aware tool lifecycles consistent" $
+                \(ToolTrace commands) -> toolTraceProperty commands
+
+newtype EventTrace = EventTrace [UiEvent]
+    deriving (Show)
+
+instance Arbitrary EventTrace where
+    arbitrary = EventTrace <$> listOf generatedUiEvent
+
+traceProperty :: [UiEvent] -> Property
+traceProperty events =
+    conjoin
+        [ counterexample ("event prefix: " <> show prefix)
+            (stateInvariant state)
+        | (prefix, state) <- traceStates events
+        ]
+
+traceStates :: [UiEvent] -> [([UiEvent], UiState)]
+traceStates events =
+    drop 1 (scanl step ([], initialUiState) events)
+  where
+    step (prefix, state) event =
+        (prefix <> [event], reduceUi event state)
+
+stateInvariant :: UiState -> Property
+stateInvariant state =
+    conjoin
+        [ counterexample "block IDs must be unique"
+            (ids == List.nub ids)
+        , counterexample "block index map must match the sequence"
+            (state.uiBlockIndices === expectedIndices)
+        , counterexample "next block ID must be fresh"
+            (all (< state.uiNextBlockId) numericIds)
+        , counterexample "selected block and index must agree"
+            selectedInvariant
+        , counterexample "cursor must stay within the draft"
+            (state.uiCursor >= 0
+                && state.uiCursor <= Text.length state.uiDraft)
+        , counterexample "cursor must stay on a grapheme boundary"
+            (state.uiCursor `elem` graphemeBoundaries state.uiDraft)
+        , counterexample "permission choices must stay in range"
+            permissionInvariant
+        ]
+  where
+    blocks = Foldable.toList state.uiBlocks
+    ids = map (.blockId) blocks
+    numericIds = [number | BlockId number <- ids]
+    expectedIndices =
+        Map.fromList
+            [ (block.blockId, index)
+            | (index, block) <- zip [0 ..] blocks
+            ]
+    selectedInvariant =
+        case state.uiSelectedBlock of
+            Nothing -> state.uiSelectedBlockIndex === Nothing
+            Just ident ->
+                case List.findIndex ((== ident) . (.blockId)) blocks of
+                    Nothing -> property False
+                    Just index -> state.uiSelectedBlockIndex === Just index
+    permissionInvariant =
+        case state.uiPermission of
+            Nothing -> True
+            Just (PermissionOverlay _ index) ->
+                index >= 0 && index < 4
+
+graphemeBoundaries :: Text -> [Int]
+graphemeBoundaries text =
+    scanl (+) 0 (map Text.length (graphemeClusters text))
+
+-- Keep the generator deliberately focused on reducer inputs which do not
+-- require constructing provider/tool values. The reducer is still exercised
+-- through long mixed traces, including stream boundaries and destructive
+-- conversation operations.
+generatedUiEvent :: Gen UiEvent
+generatedUiEvent = frequency
+    [ (5, UiUserSubmitted <$> generatedText)
+    , (4, UiAssistantHistory <$> generatedText)
+    , (4, UiHistory <$> generatedText)
+    , (4, UiSystemMessage <$> generatedText)
+    , (4, UiErrorMessage <$> generatedText)
+    , (4, UiSetDraft <$> generatedText <*> chooseInt (-20, 120))
+    , (3, UiInputQueued <$> generatedText)
+    , (3, UiInputPromoted <$> generatedText)
+    , (3, UiSetPromptEffort <$> generatedText)
+    , (3, UiSetRepository <$> generatedText <*> generatedText)
+    , (3, UiSetNotice <$> generatedNotice)
+    , (3, UiMoveSelection <$> chooseInt (-20, 20))
+    , (3, UiSelectBlock . BlockId <$> chooseInt (-10, 30))
+    , (3, UiActivateBlock . BlockId <$> chooseInt (-10, 30))
+    , (3, UiFocusChanged <$> elements
+        [FocusComposer, FocusScrollback, FocusPermission])
+    , (3, UiPermissionShown <$> generatedText)
+    , (3, UiPermissionMoved <$> chooseInt (-20, 20))
+    , (3, pure UiPermissionHidden)
+    , (3, UiRetryCountdown <$> generatedText
+        <*> chooseInt (-1000, 120000)
+        <*> generatedText)
+    , (3, UiSetFollow <$> arbitraryBool)
+    , (3, UiSetAwaitingInput <$> arbitraryBool)
+    , (3, UiTurnEnded <$> elements
+        [BlockComplete, BlockFailed, BlockCancelled, BlockDenied])
+    , (3, pure UiTurnRestarted)
+    , (2, pure UiConversationCleared)
+    , (2, pure UiDraftSubmitted)
+    , (2, pure UiQueuedInputStarted)
+    , (2, UiLoop <$> generatedLoopEvent)
+    ]
+
+generatedLoopEvent :: Gen LoopEvent
+generatedLoopEvent = frequency
+    [ (4, TextDelta <$> generatedText)
+    , (4, ReasoningDelta <$> generatedText)
+    , (3, ActivityUpdated <$> generatedText)
+    , (3, WarningRaised <$> generatedText)
+    , (2, ResponseRestarted <$> generatedText)
+    , (2, pure TurnStarted)
+    ]
+
+generatedNotice :: Gen (Maybe UiNotice)
+generatedNotice = frequency
+    [ (2, pure Nothing)
+    , (1, Just . warningNotice <$> generatedText)
+    , (1, Just . errorNotice <$> generatedText)
+    ]
+
+generatedText :: Gen Text
+generatedText =
+    Text.pack <$> resize 24 (listOf (elements alphabet))
+  where
+    alphabet =
+        "abc XYZ012-_/\n\té界🚀e\769"
+
+arbitraryBool :: Gen Bool
+arbitraryBool = elements [False, True]
+
+data NavigationCommand
+    = AppendBlock !Text
+    | MoveSelection !Int
+    | SelectSlot !Int
+    | SetFollow !Bool
+    | ShowPermission
+    | MovePermission !Int
+    | HidePermission
+    | SetFocus !Focus
+    | ClearNavigation
+    deriving (Eq, Show)
+
+newtype NavigationTrace = NavigationTrace [NavigationCommand]
+    deriving (Eq, Show)
+
+instance Arbitrary NavigationTrace where
+    arbitrary =
+        NavigationTrace <$> resize 40 (listOf generatedNavigationCommand)
+    shrink (NavigationTrace commands) =
+        NavigationTrace <$> shrinkList (const []) commands
+
+generatedNavigationCommand :: Gen NavigationCommand
+generatedNavigationCommand = frequency
+    [ (5, AppendBlock <$> generatedText)
+    , (4, MoveSelection <$> chooseInt (-20, 20))
+    , (4, SelectSlot <$> chooseInt (-5, 20))
+    , (3, SetFollow <$> arbitraryBool)
+    , (3, pure ShowPermission)
+    , (4, MovePermission <$> chooseInt (-20, 20))
+    , (3, pure HidePermission)
+    , (2, SetFocus <$> elements
+        [FocusComposer, FocusScrollback, FocusPermission])
+    , (2, pure ClearNavigation)
+    ]
+
+data NavigationModel = NavigationModel
+    { navigationBlockIds      :: ![Int]
+    , navigationNextBlockId   :: !Int
+    , navigationSelectedIndex :: !(Maybe Int)
+    , navigationFollow        :: !Bool
+    , navigationPermission    :: !(Maybe Int)
+    , navigationFocus         :: !Focus
+    }
+    deriving (Eq, Show)
+
+initialNavigationModel :: NavigationModel
+initialNavigationModel = NavigationModel
+    { navigationBlockIds = []
+    , navigationNextBlockId = 1
+    , navigationSelectedIndex = Nothing
+    , navigationFollow = True
+    , navigationPermission = Nothing
+    , navigationFocus = FocusComposer
+    }
+
+navigationTraceProperty :: [NavigationCommand] -> Property
+navigationTraceProperty commands =
+    conjoin
+        [ counterexample
+            ("navigation command prefix: " <> show prefix)
+            (navigationProjection state === expectedProjection expected)
+        | (prefix, expected, state) <- traceNavigationStates commands
+        ]
+
+traceNavigationStates
+    :: [NavigationCommand]
+    -> [([NavigationCommand], NavigationModel, UiState)]
+traceNavigationStates commands =
+    go [] initialNavigationModel initialUiState commands
+  where
+    go _ _ _ [] = []
+    go prefix expected state (command : rest) =
+        let event = navigationEvent expected command
+            expected' = applyNavigationModel command expected
+            state' = reduceUi event state
+            prefix' = prefix <> [command]
+        in (prefix', expected', state')
+            : go prefix' expected' state' rest
+
+applyNavigationModel
+    :: NavigationCommand
+    -> NavigationModel
+    -> NavigationModel
+applyNavigationModel command model = case command of
+    AppendBlock _ ->
+        let index = length model.navigationBlockIds
+        in model
+            { navigationBlockIds =
+                model.navigationBlockIds <> [model.navigationNextBlockId]
+            , navigationNextBlockId = model.navigationNextBlockId + 1
+            , navigationSelectedIndex = Just index
+            }
+    MoveSelection delta ->
+        case model.navigationBlockIds of
+            [] -> model { navigationSelectedIndex = Nothing }
+            blockIds ->
+                let lastIndex = length blockIds - 1
+                    current =
+                        maybe lastIndex id model.navigationSelectedIndex
+                    selected = max 0 (min lastIndex (current + delta))
+                in model
+                    { navigationSelectedIndex = Just selected
+                    , navigationFollow = selected == lastIndex
+                    }
+    SelectSlot slot ->
+        case selectedSlotIndex slot model.navigationBlockIds of
+            Nothing -> model
+            Just selected ->
+                model
+                    { navigationSelectedIndex = Just selected
+                    , navigationFollow =
+                        selected == length model.navigationBlockIds - 1
+                    }
+    SetFollow follow ->
+        model
+            { navigationFollow = follow
+            , navigationSelectedIndex =
+                if follow
+                    then case model.navigationBlockIds of
+                        [] -> Nothing
+                        blockIds -> Just (length blockIds - 1)
+                    else model.navigationSelectedIndex
+            }
+    ShowPermission ->
+        model
+            { navigationPermission = Just 0
+            , navigationFocus = FocusPermission
+            }
+    MovePermission delta ->
+        model
+            { navigationPermission =
+                (\index -> (index + delta) `mod` 4)
+                    <$> model.navigationPermission
+            }
+    HidePermission ->
+        model
+            { navigationPermission = Nothing
+            , navigationFocus = FocusComposer
+            }
+    SetFocus focus ->
+        model { navigationFocus = focus }
+    ClearNavigation ->
+        model
+            { navigationBlockIds = []
+            , navigationNextBlockId = 1
+            , navigationSelectedIndex = Nothing
+            }
+
+navigationEvent :: NavigationModel -> NavigationCommand -> UiEvent
+navigationEvent model command = case command of
+    AppendBlock text -> UiSystemMessage text
+    MoveSelection delta -> UiMoveSelection delta
+    SelectSlot slot ->
+        UiSelectBlock
+            (case selectedSlotIndex slot model.navigationBlockIds
+                    >>= (`listAt` model.navigationBlockIds) of
+                Just ident -> BlockId ident
+                Nothing -> BlockId (-1000 - abs slot))
+    SetFollow follow -> UiSetFollow follow
+    ShowPermission -> UiPermissionShown "generated permission"
+    MovePermission delta -> UiPermissionMoved delta
+    HidePermission -> UiPermissionHidden
+    SetFocus focus -> UiFocusChanged focus
+    ClearNavigation -> UiConversationCleared
+
+selectedSlotIndex :: Int -> [Int] -> Maybe Int
+selectedSlotIndex slot blockIds
+    | slot < 0 || null blockIds = Nothing
+    | otherwise = Just (slot `mod` length blockIds)
+
+type NavigationProjection =
+    ([BlockId], Int, Maybe BlockId, Maybe Int, Bool, Maybe Int, Focus)
+
+navigationProjection :: UiState -> NavigationProjection
+navigationProjection state =
+    ( map (.blockId) (Foldable.toList state.uiBlocks)
+    , state.uiNextBlockId
+    , state.uiSelectedBlock
+    , state.uiSelectedBlockIndex
+    , state.uiFollow
+    , (.permissionIndex) <$> state.uiPermission
+    , state.uiFocus
+    )
+
+expectedProjection :: NavigationModel -> NavigationProjection
+expectedProjection model =
+    ( map BlockId model.navigationBlockIds
+    , model.navigationNextBlockId
+    , BlockId <$> (model.navigationSelectedIndex
+        >>= (`listAt` model.navigationBlockIds))
+    , model.navigationSelectedIndex
+    , model.navigationFollow
+    , model.navigationPermission
+    , model.navigationFocus
+    )
+
+listAt :: Int -> [value] -> Maybe value
+listAt index values
+    | index < 0 = Nothing
+    | otherwise = case drop index values of
+        value : _ -> Just value
+        [] -> Nothing
+
+-- | Commands are generated with knowledge of which call ids are currently
+-- active. Updates and completions therefore exercise meaningful tool
+-- lifecycles, while unknown ids provide adversarial noise.
+data ToolCommand
+    = StartTool !Text
+    | UpdateTool !Text !Text
+    | FinishTool !Text !Text
+    | BeginTurn
+    | EndTurn
+    | ClearConversation
+    | RestartTurn
+    deriving (Eq, Show)
+
+newtype ToolTrace = ToolTrace [ToolCommand]
+    deriving (Eq, Show)
+
+instance Arbitrary ToolTrace where
+    arbitrary = ToolTrace <$> generateToolCommands 24 [] [] 1
+    -- The oracle treats inactive IDs as noise, so deleting commands preserves
+    -- validity while yielding useful minimal lifecycle counterexamples.
+    shrink (ToolTrace commands) =
+        ToolTrace <$> shrinkList (const []) commands
+
+generateToolCommands :: Int -> [Text] -> [Text] -> Int -> Gen [ToolCommand]
+generateToolCommands remaining active known nextId
+    | remaining <= 0 = pure []
+    | otherwise = do
+        (command, nextActive, nextId') <- frequency
+            ( [ (5, do
+                    let callId = "generated-" <> Text.pack (show nextId)
+                    pure (StartTool callId, callId : active, nextId + 1))
+              , (if null active then 1 else 5, do
+                    callId <- chooseActiveOrUnknown active known
+                    output <- generatedOutput
+                    pure (UpdateTool callId output, active, nextId))
+              , (if null active then 1 else 5, do
+                    callId <- chooseActiveOrUnknown active known
+                    output <- generatedOutput
+                    pure (FinishTool callId output, deleteOne callId active, nextId))
+              , (2, pure (EndTurn, [], nextId))
+              , (2, pure (ClearConversation, [], nextId))
+              , (2, pure (RestartTurn, [], nextId))
+              ]
+                <> [ (2, pure (BeginTurn, [], nextId))
+                   | null active
+                   ])
+        let nextKnown = List.nub (known <> case command of
+                StartTool callId -> [callId]
+                _ -> [])
+        rest <- generateToolCommands (remaining - 1) nextActive nextKnown nextId'
+        pure (command : rest)
+
+chooseActiveOrUnknown :: [Text] -> [Text] -> Gen Text
+chooseActiveOrUnknown active known =
+    elements (List.nub (if null active then ["unknown"] else active
+        <> known <> ["unknown"]))
+
+deleteOne :: Eq value => value -> [value] -> [value]
+deleteOne _ [] = []
+deleteOne wanted (value : values)
+    | wanted == value = values
+    | otherwise = value : deleteOne wanted values
+
+generatedOutput :: Gen Text
+generatedOutput =
+    Text.pack <$> resize 18 (listOf (elements ("output-012 XYZ\n" :: String)))
+
+toolTraceProperty :: [ToolCommand] -> Property
+toolTraceProperty commands =
+    conjoin
+        [ counterexample
+            ("tool command prefix: " <> show prefix)
+            (toolStateInvariant expected after
+                .&&. toolCommandPostcondition command before after)
+        | (prefix, command, expected, before, after) <- traceToolStates commands
+        ]
+
+traceToolStates
+    :: [ToolCommand]
+    -> [([ToolCommand], ToolCommand, Map.Map Text Text, UiState, UiState)]
+traceToolStates commands =
+    go [] Map.empty initialUiState commands
+  where
+    go _ _ _ [] = []
+    go prefix expected state (command : rest) =
+        let expected' = expectedToolState command expected
+            state' = reduceUi (toolEvent command) state
+            prefix' = prefix <> [command]
+        in (prefix', command, expected', state, state')
+            : go prefix' expected' state' rest
+
+expectedToolState :: ToolCommand -> Map.Map Text Text -> Map.Map Text Text
+expectedToolState command active = case command of
+    StartTool callId -> Map.insert callId "" active
+    UpdateTool callId output
+        | Map.member callId active -> Map.insert callId output active
+        | otherwise -> active
+    FinishTool callId _ -> Map.delete callId active
+    BeginTurn -> Map.empty
+    EndTurn -> Map.empty
+    ClearConversation -> Map.empty
+    RestartTurn -> Map.empty
+
+toolStateInvariant :: Map.Map Text Text -> UiState -> Property
+toolStateInvariant expected state =
+    conjoin
+        [ counterexample "active call IDs must match the reducer map"
+            (Map.keysSet expected === Map.keysSet state.uiToolCalls)
+        , counterexample "every active call must point to its running block"
+            (conjoin (map activeEntryInvariant (Map.toList expected)))
+        , counterexample "every running tool block must be active"
+            (conjoin
+                [ case block.blockCallId of
+                    Nothing -> property True
+                    Just callId ->
+                        case Map.lookup callId state.uiToolCalls of
+                            Just (index, _call) ->
+                                Seq.lookup index state.uiBlocks === Just block
+                            Nothing -> property False
+                | block <- Foldable.toList state.uiBlocks
+                , block.blockState == BlockRunning
+                ])
+        ]
+  where
+    activeEntryInvariant (callId, expectedOutput) =
+        case Map.lookup callId state.uiToolCalls of
+            Nothing -> property False
+            Just (index, _call) ->
+                case Seq.lookup index state.uiBlocks of
+                    Just block ->
+                        conjoin
+                            [ block.blockCallId === Just callId
+                            , block.blockState === BlockRunning
+                            , block.blockBody === expectedOutput
+                            ]
+                    Nothing -> property False
+toolCommandPostcondition :: ToolCommand -> UiState -> UiState -> Property
+toolCommandPostcondition command before state = case command of
+    FinishTool callId output ->
+        if Map.member callId before.uiToolCalls
+            then case List.find ((== Just callId) . (.blockCallId))
+                    (reverse (Foldable.toList state.uiBlocks)) of
+                Just block ->
+                    conjoin
+                        [ block.blockState =/= BlockRunning
+                        , block.blockBody === output
+                        ]
+                Nothing -> property False
+            else property True
+    EndTurn ->
+        conjoin
+            [ Map.null state.uiToolCalls === True
+            , all ((/= BlockRunning) . (.blockState))
+                (Foldable.toList state.uiBlocks) === True
+            ]
+    _ -> property True
+
+toolEvent :: ToolCommand -> UiEvent
+toolEvent command = case command of
+    StartTool callId ->
+        UiLoop (ToolStarted (functionToolCall callId "echo" "{}"))
+    UpdateTool callId output ->
+        UiLoop (ToolOutputUpdated callId output)
+    FinishTool callId output ->
+        UiLoop (ToolFinished ToolCallResult
+            { callId
+            , output
+            , callKind = FunctionCallKind
+            })
+    BeginTurn -> UiLoop TurnStarted
+    EndTurn -> UiTurnEnded BlockCancelled
+    ClearConversation -> UiConversationCleared
+    RestartTurn -> UiTurnRestarted

--- a/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
@@ -483,6 +483,36 @@ spec = describe "fullscreen UI reducer" do
                 replacementBlock.blockState `shouldBe` BlockComplete
             _ -> expectationFailure "expected retained and replacement blocks"
 
+    it "drops tool block positions when a running turn ends" do
+        let call =
+                functionToolCall
+                    "c1"
+                    "run_terminal_cmd"
+                    "{\"command\":\"work\"}"
+            result = ToolCallResult
+                { callId = "c1"
+                , output = "exit: 0\nlate final output"
+                , callKind = FunctionCallKind
+                }
+            ended =
+                reduceUi (UiTurnEnded BlockCancelled) $
+                    apply
+                        [ UiLoop TurnStarted
+                        , UiLoop (ToolStarted call)
+                        ]
+            afterLateEvents =
+                applyFrom
+                    ended
+                    [ UiLoop (ToolOutputUpdated "c1" "late live output")
+                    , UiLoop (ToolFinished result)
+                    ]
+        ended.uiToolCalls `shouldBe` mempty
+        case Foldable.toList afterLateEvents.uiBlocks of
+            [block] -> do
+                block.blockBody `shouldBe` ""
+                block.blockState `shouldBe` BlockCancelled
+            _ -> expectationFailure "expected one cancelled tool block"
+
     it "replaces a live snapshot with the final tool result" do
         let call = functionToolCall "c1" "run_terminal_cmd" "{\"command\":\"work\"}"
             result = ToolCallResult

--- a/packages/agent-tui/test/Spec.hs
+++ b/packages/agent-tui/test/Spec.hs
@@ -6,6 +6,7 @@ import qualified Agent.TUI.Markdown.InlineSpec as MarkdownInlineSpec
 import qualified Agent.TUI.MarkdownSpec as MarkdownSpec
 import qualified Agent.TUI.MotionSpec as MotionSpec
 import qualified Agent.TUI.ModelSpec as ModelSpec
+import qualified Agent.TUI.ModelPropertySpec as ModelPropertySpec
 import qualified Agent.TUI.PresentationSpec as PresentationSpec
 import qualified Agent.TUI.ThemeSpec as ThemeSpec
 import qualified Agent.TUI.TextWidthSpec as TextWidthSpec
@@ -19,6 +20,7 @@ main = hspec do
     MarkdownSpec.spec
     MotionSpec.spec
     ModelSpec.spec
+    ModelPropertySpec.spec
     PresentationSpec.spec
     ThemeSpec.spec
     TextWidthSpec.spec


### PR DESCRIPTION
## Summary
- add independent adversarial models for response stream assembly and merge precedence
- add generated TUI invariant, navigation/permission, and state-aware tool lifecycle traces
- add generated dangerous-command and benign near-miss coverage
- clear stale TUI tool-call positions when a turn ends and avoid scanning long-option text as clustered short flags

## Validation
- `nix develop -c cabal test agent-core:test:agent-core-test agent-responses:test:agent-responses-test agent-tui:test:agent-tui-test --test-show-details=failures`
- `git diff --check`
- temporary mutation checks confirmed the new properties reject non-sticky stream completion, modulo-3 permission wrapping, stale tool-call tracking, and long-flag character scanning
