### PR TITLE
Reduce agent-cli idle memory to ~30 MB

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,9 +110,9 @@ When changing the CLI UI (prompt, colors, chrome, keybindings, paste, approval p
 `nix develop` does not impose a heap ceiling on every development command. The
 `repl` wrapper defaults `GHCRTS` to `-M8G`, which protects the machine from an
 unbounded long-running GHCi/agent process while preserving the RTS allocation
-area default. The compiled `agent-cli` executable defaults to
-`-N4 -Fd1 -M8G`; four capabilities cover concurrent agent work while prompt
-page release keeps idle memory bounded. Both defaults are overridable because
+area default. The compiled `agent-cli` executable defaults to `-N4 -M8G`; four
+capabilities cover concurrent agent work without multiplying the RTS
+allocation area by every host core. Both defaults are overridable because
 `-rtsopts` is enabled. Set `GHCRTS` explicitly to override the wrapper:
 
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,10 +110,10 @@ When changing the CLI UI (prompt, colors, chrome, keybindings, paste, approval p
 `nix develop` does not impose a heap ceiling on every development command. The
 `repl` wrapper defaults `GHCRTS` to `-M8G`, which protects the machine from an
 unbounded long-running GHCi/agent process while preserving the RTS allocation
-area default. The compiled `agent-cli` executable defaults to `-N4 -M8G`;
-four capabilities cover concurrent agent I/O without scaling nursery memory
-with every host core. Both defaults are overridable because `-rtsopts` is
-enabled. Set `GHCRTS` explicitly to override the wrapper:
+area default. The compiled `agent-cli` executable defaults to
+`-N1 -Fd1 -M8G`; agent concurrency is I/O-bound, while one capability and
+prompt page release keep idle memory bounded. Both defaults are overridable
+because `-rtsopts` is enabled. Set `GHCRTS` explicitly to override the wrapper:
 
 ```
 GHCRTS='-M16G' repl

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,9 +111,9 @@ When changing the CLI UI (prompt, colors, chrome, keybindings, paste, approval p
 `repl` wrapper defaults `GHCRTS` to `-M8G`, which protects the machine from an
 unbounded long-running GHCi/agent process while preserving the RTS allocation
 area default. The compiled `agent-cli` executable defaults to
-`-N1 -Fd1 -M8G`; agent concurrency is I/O-bound, while one capability and
-prompt page release keep idle memory bounded. Both defaults are overridable
-because `-rtsopts` is enabled. Set `GHCRTS` explicitly to override the wrapper:
+`-N4 -Fd1 -M8G`; four capabilities cover concurrent agent work while prompt
+page release keeps idle memory bounded. Both defaults are overridable because
+`-rtsopts` is enabled. Set `GHCRTS` explicitly to override the wrapper:
 
 ```
 GHCRTS='-M16G' repl

--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -276,9 +276,25 @@ benchmark subagent-retention-bench
                     , agent-core
                     , agent-store
                     , agent-responses
+                    , agent-responses-types
                     , aeson
                     , base >= 4.17 && < 5
                     , containers
+                    , text
+
+benchmark conversation-retention-bench
+    import:           common-options
+    type:             exitcode-stdio-1.0
+    hs-source-dirs:   benchmark
+    main-is:          ConversationRetention.hs
+    ghc-options:      -O2 -threaded -rtsopts "-with-rtsopts=-T"
+    build-depends:    agent-responses-types
+                    , aeson
+                    , base >= 4.17 && < 5
+                    , bytestring
+                    , directory
+                    , filepath
+                    , safe-exceptions
                     , text
 
 benchmark history-retention-bench

--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -154,6 +154,7 @@ library
                     , Agent.CLI.ReplMode
                     , Agent.CLI.Resume
                     , Agent.CLI.Session
+                    , Agent.CLI.Session.ConversationStore
                     , Agent.CLI.Session.History
                     , Agent.CLI.Session.StoreCodec
                     , Agent.CLI.SessionEnv
@@ -341,6 +342,7 @@ test-suite agent-cli-test
                     , Agent.CLI.CommandSpec
                     , Agent.CLI.ConfigSpec
                     , Agent.CLI.CompactionSpec
+                    , Agent.CLI.ConversationStoreSpec
                     , Agent.CLI.ConnectivitySpec
                     , Agent.CLI.CredentialStoreSpec
                     , Agent.CLI.DialectsSpec

--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -239,10 +239,9 @@ executable agent-cli
     import:           common-options
     hs-source-dirs:   app
     main-is:          Main.hs
-    -- Keep the heap ceiling without multiplying a large allocation area by
-    -- every host core. Four capabilities cover the agent's concurrent I/O;
-    -- leave -A at the GHC RTS default.
-    ghc-options:      -threaded -rtsopts "-with-rtsopts=-N4 -M8G"
+    -- Agent concurrency is I/O-bound, so one capability avoids per-capability
+    -- heap overhead. Return unused pages promptly after major collections.
+    ghc-options:      -threaded -rtsopts "-with-rtsopts=-N1 -Fd1 -M8G"
     build-depends:    agent-cli
                     , base >= 4.17 && < 5
 

--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -239,9 +239,9 @@ executable agent-cli
     import:           common-options
     hs-source-dirs:   app
     main-is:          Main.hs
-    -- Agent concurrency is I/O-bound, so one capability avoids per-capability
-    -- heap overhead. Return unused pages promptly after major collections.
-    ghc-options:      -threaded -rtsopts "-with-rtsopts=-N1 -Fd1 -M8G"
+    -- Keep enough capabilities for concurrent agent work while returning
+    -- unused pages promptly after major collections.
+    ghc-options:      -threaded -rtsopts "-with-rtsopts=-N4 -Fd1 -M8G"
     build-depends:    agent-cli
                     , base >= 4.17 && < 5
 

--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -239,9 +239,9 @@ executable agent-cli
     import:           common-options
     hs-source-dirs:   app
     main-is:          Main.hs
-    -- Keep enough capabilities for concurrent agent work while returning
-    -- unused pages promptly after major collections.
-    ghc-options:      -threaded -rtsopts "-with-rtsopts=-N4 -Fd1 -M8G"
+    -- Keep enough capabilities for concurrent agent work without multiplying
+    -- the RTS allocation area by every host core.
+    ghc-options:      -threaded -rtsopts "-with-rtsopts=-N4 -M8G"
     build-depends:    agent-cli
                     , base >= 4.17 && < 5
 

--- a/packages/agent-cli/benchmark/ConversationRetention.hs
+++ b/packages/agent-cli/benchmark/ConversationRetention.hs
@@ -1,0 +1,261 @@
+module Main (main) where
+
+import Agent.Responses.Types
+-- 'evaluate' is the primitive for forcing the benchmark result;
+-- safe-exceptions does not re-export it.
+import Control.Exception (evaluate)
+import Control.Exception.Safe (bracket, catchAny)
+import Control.Monad (forM)
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy as LazyByteString
+import Data.List (sort)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import GHC.Clock (getMonotonicTimeNSec)
+import GHC.Stats
+    ( GCDetails(..)
+    , RTSStats(..)
+    , getRTSStats
+    , getRTSStatsEnabled
+    )
+import System.CPUTime (getCPUTime)
+import System.Directory (getTemporaryDirectory, removeFile)
+import System.Environment (getArgs)
+import System.Exit (die)
+import System.FilePath ((</>))
+import System.Mem (performGC)
+import Text.Printf (printf)
+
+data Workload
+    = Resident
+    | Cold
+    deriving (Eq, Show)
+
+data Sample = Sample
+    { elapsedMillis :: !Double
+    , cpuMillis :: !Double
+    , allocatedBytes :: !Integer
+    , liveBytes :: !Integer
+    , memoryInUseBytes :: !Integer
+    }
+
+data RetainedState
+    = ResidentTranscript ![ResponseItem]
+    | ColdTranscript !Int
+
+main :: IO ()
+main = do
+    enabled <- getRTSStatsEnabled
+    if enabled
+        then pure ()
+        else die "RTS statistics are disabled; run with +RTS -T"
+    getArgs >>= \case
+        [workloadArg, turnCountArg, payloadBytesArg, sampleCountArg] -> do
+            workload <- parseWorkload workloadArg
+            turnCount <- parsePositive "turn count" turnCountArg
+            payloadBytes <- parsePositive "payload bytes per turn" payloadBytesArg
+            sampleCount <- parsePositive "sample count" sampleCountArg
+            samples <- forM [1 .. sampleCount] \sampleIndex ->
+                measure workload turnCount payloadBytes sampleIndex
+            let sample = median samples
+            printf
+                "%s,%d,%d,%.3f,%.3f,%d,%d,%d\n"
+                workloadArg
+                turnCount
+                payloadBytes
+                sample.elapsedMillis
+                sample.cpuMillis
+                sample.allocatedBytes
+                sample.liveBytes
+                sample.memoryInUseBytes
+        _ ->
+            die $
+                "usage: conversation-retention-bench "
+                    <> "WORKLOAD TURNS PAYLOAD_BYTES SAMPLES\n"
+                    <> "workloads: resident, cold\n"
+                    <> "output: workload,turns,payload_bytes,elapsed_ms,cpu_ms,"
+                    <> "allocated_bytes,live_bytes,memory_in_use_bytes"
+
+parseWorkload :: String -> IO Workload
+parseWorkload = \case
+    "resident" -> pure Resident
+    "cold" -> pure Cold
+    other -> die ("unknown workload: " <> other)
+
+parsePositive :: String -> String -> IO Int
+parsePositive label raw =
+    case reads raw of
+        [(value, "")]
+            | value > 0 -> pure value
+        _ -> die ("invalid " <> label <> ": " <> raw)
+
+measure :: Workload -> Int -> Int -> Int -> IO Sample
+measure workload turnCount payloadBytes sampleIndex =
+    withColdPath sampleIndex \coldPath -> do
+        performGC
+        beforeStats <- getRTSStats
+        beforeCpu <- getCPUTime
+        beforeElapsed <- getMonotonicTimeNSec
+        retained <- case workload of
+            Resident ->
+                pure $
+                    ResidentTranscript
+                        (buildTranscript sampleIndex turnCount payloadBytes)
+            Cold ->
+                ColdTranscript
+                    <$> persistColdTranscript
+                        coldPath
+                        sampleIndex
+                        turnCount
+                        payloadBytes
+        initialChecksum <- evaluate (checksumRetained retained)
+        performGC
+        afterStats <- getRTSStats
+        finalChecksum <- evaluate (checksumRetained retained)
+        afterElapsed <- getMonotonicTimeNSec
+        afterCpu <- getCPUTime
+        _ <- evaluate (initialChecksum + finalChecksum)
+        pure Sample
+            { elapsedMillis =
+                fromIntegral (afterElapsed - beforeElapsed) / 1.0e6
+            , cpuMillis =
+                fromIntegral (afterCpu - beforeCpu) / 1.0e9
+            , allocatedBytes =
+                fromIntegral
+                    (afterStats.allocated_bytes - beforeStats.allocated_bytes)
+            , liveBytes =
+                fromIntegral afterStats.gc.gcdetails_live_bytes
+            , memoryInUseBytes =
+                fromIntegral afterStats.gc.gcdetails_mem_in_use_bytes
+            }
+
+withColdPath :: Int -> (FilePath -> IO a) -> IO a
+withColdPath sampleIndex use = do
+    temporaryDirectory <- getTemporaryDirectory
+    let path =
+            temporaryDirectory
+                </> ("agent-conversation-retention-"
+                    <> show sampleIndex
+                    <> ".json")
+    bracket
+        (pure path)
+        (\file -> removeFile file `catchAny` const (pure ()))
+        use
+
+persistColdTranscript :: FilePath -> Int -> Int -> Int -> IO Int
+persistColdTranscript path sampleIndex turnCount payloadBytes = do
+    let transcript = buildTranscript sampleIndex turnCount payloadBytes
+    LazyByteString.writeFile path (Aeson.encode transcript)
+    fromIntegral <$> LazyByteString.length <$> LazyByteString.readFile path
+
+checksumRetained :: RetainedState -> Int
+checksumRetained = \case
+    ResidentTranscript transcript -> checksumTranscript transcript
+    ColdTranscript bytes -> bytes
+
+buildTranscript :: Int -> Int -> Int -> [ResponseItem]
+buildTranscript sampleIndex turnCount payloadBytes =
+    concat
+        [ buildTurn sampleIndex turnIndex payloadBytes
+        | turnIndex <- [1 .. turnCount]
+        ]
+
+buildTurn :: Int -> Int -> Int -> [ResponseItem]
+buildTurn sampleIndex turnIndex payloadBytes =
+    [ MessageItem ResponseMessage
+        { messageId = Just (itemId "message")
+        , content = MessageContentText (payload "assistant" assistantBytes)
+        , role = RoleAssistant
+        , status = Nothing
+        , phase = Just "final_answer"
+        , passthrough = Nothing
+        , extraFields = KeyMap.empty
+        }
+    , ReasoningItemValue ReasoningItem
+        { itemId = Just (itemId "reasoning")
+        , summary =
+            [ ReasoningSummaryPart
+                { partType = "summary_text"
+                , text = Just "representative retained reasoning"
+                , extraFields = KeyMap.empty
+                }
+            ]
+        , content = Nothing
+        , encryptedContent = Just (payload "reasoning" reasoningBytes)
+        , status = Nothing
+        , extraFields = KeyMap.empty
+        }
+    , FunctionCallItem FunctionCall
+        { itemId = Just (itemId "call")
+        , callId = callId
+        , name = "shell_command"
+        , namespace = Nothing
+        , arguments = "{\"command\":\"representative tool call\"}"
+        , encryptedFunctionArgs = Nothing
+        , status = Nothing
+        , extraFields = KeyMap.empty
+        }
+    , FunctionCallOutputItem FunctionCallOutput
+        { itemId = Just (itemId "output")
+        , callId = callId
+        , name = Just "shell_command"
+        , namespace = Nothing
+        , output = Aeson.String (payload "tool-output" toolOutputBytes)
+        , status = Nothing
+        , extraFields = KeyMap.empty
+        }
+    ]
+  where
+    assistantBytes = payloadBytes `div` 8
+    reasoningBytes = payloadBytes `div` 8
+    toolOutputBytes = payloadBytes - assistantBytes - reasoningBytes
+    suffix = Text.pack (show sampleIndex <> "-" <> show turnIndex)
+    itemId prefix = prefix <> "-" <> suffix
+    callId = "call-" <> suffix
+    payload prefix size =
+        prefix <> ":" <> suffix <> ":" <> Text.replicate size "x"
+
+checksumTranscript :: [ResponseItem] -> Int
+checksumTranscript = foldl' checksumItem 5381
+
+checksumItem :: Int -> ResponseItem -> Int
+checksumItem checksum = \case
+    MessageItem message ->
+        checksumText checksum (messageText message.content)
+    ReasoningItemValue reasoning ->
+        maybe checksum (checksumText checksum) reasoning.encryptedContent
+    FunctionCallItem call ->
+        checksumText checksum call.arguments
+    FunctionCallOutputItem output ->
+        case output.output of
+            Aeson.String text -> checksumText checksum text
+            _ -> checksum + 1
+    _ -> checksum + 1
+
+messageText :: MessageContent -> Text
+messageText = \case
+    MessageContentText text -> text
+    MessageContentParts parts ->
+        Text.concat
+            [ text
+            | InputTextPart { text } <- parts
+            ]
+
+checksumText :: Int -> Text -> Int
+checksumText =
+    Text.foldl' \checksum character ->
+        checksum * 33 + fromEnum character
+
+median :: [Sample] -> Sample
+median samples =
+    Sample
+        { elapsedMillis = middle (sort (map (.elapsedMillis) samples))
+        , cpuMillis = middle (sort (map (.cpuMillis) samples))
+        , allocatedBytes = middle (sort (map (.allocatedBytes) samples))
+        , liveBytes = middle (sort (map (.liveBytes) samples))
+        , memoryInUseBytes =
+            middle (sort (map (.memoryInUseBytes) samples))
+        }
+  where
+    middle values = values !! (length values `div` 2)

--- a/packages/agent-cli/package.nix
+++ b/packages/agent-cli/package.nix
@@ -42,9 +42,9 @@ mkDerivation {
     QuickCheck safe-exceptions stm text time transformers unix vty
   ];
   benchmarkHaskellDepends = [
-    aeson agent-core agent-responses agent-store base brick bytestring
-    containers deepseq directory filepath JuicyPixels safe-exceptions
-    text time vty
+    aeson agent-core agent-responses agent-responses-types agent-store
+    base brick bytestring containers deepseq directory filepath
+    JuicyPixels safe-exceptions text time vty
   ];
   description = "Command-line interface for the universal agent harness";
   license = lib.meta.getLicenseFromSpdxId "MIT";

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration.hs
@@ -401,6 +401,7 @@ import System.IO
     ( hIsTerminalDevice,
       stderr,
       stdin )
+import System.Mem ( performMajorGC )
 import System.OsPath
     ( OsPath,
       decodeFS,
@@ -2124,17 +2125,6 @@ runAgentInitializedWithLock
                 (if refreshDialectContext || resumeNeedsFreshContext
                     then Nothing
                     else initialPrevious)
-        forM_ resumed \(meta, _) -> do
-            generation <-
-                currentLiveTranscriptGeneration conversationRef
-            void $
-                evictLiveTranscript
-                    conversationRef
-                    generation
-                    (durableTranscriptCheckpoint
-                        (trustedPool startup.startupDatabaseStore)
-                        root
-                        meta.metaId)
         -- Fullscreen sessions load skills after Brick has taken over the
         -- terminal, so filesystem discovery cannot delay the first frame.
         -- Minimal and one-shot sessions still initialize them synchronously
@@ -2142,6 +2132,18 @@ runAgentInitializedWithLock
         usageRef <- newIORef $ case resumed of
             Just (meta, turns) -> sessionUsageFromTurns meta turns
             Nothing -> emptyTokenUsage
+        forM_ resumed \(meta, _) -> do
+            generation <-
+                currentLiveTranscriptGeneration conversationRef
+            evicted <-
+                evictLiveTranscript
+                    conversationRef
+                    generation
+                    (durableTranscriptCheckpoint
+                        (trustedPool startup.startupDatabaseStore)
+                        root
+                        meta.metaId)
+            when evicted performMajorGC
         let recordCompactionUsage usage =
                 when (usage /= emptyTokenUsage) $
                     mask_ do

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration.hs
@@ -178,11 +178,14 @@ import Agent.CLI.Runtime.HistorySource
     , sessionUiPageSize
     )
 import Agent.CLI.Session.History
-    ( detectGitBranch,
+    ( currentLiveTranscriptGeneration,
+      detectGitBranch,
+      durableTranscriptCheckpoint,
+      evictLiveTranscript,
       foldSessionItems,
       readLiveTranscript,
-      writeLiveTranscript,
-      LiveConversation(liveTranscript, livePreviousResponseId) )
+      replaceLiveConversation,
+      writeLiveTranscript )
 import Agent.CLI.Session.Lifecycle ()
 import Agent.CLI.Session.Runtime.Types
     ( SessionBackend(..),
@@ -2094,13 +2097,9 @@ runAgentInitializedWithLock
                         (tokenProviderBillingMode tokenProvider)
                 }
         let conversationRef = startup.startupSessionState.sessionConversation
-        atomicModifyIORef' conversationRef \state ->
-            ( state
-                { livePreviousResponseId = initialPrevious
-                , liveTranscript = initialItems
-                }
-            , ()
-            )
+        void $
+            replaceLiveConversation
+                conversationRef initialPrevious initialItems
         contextTokensRef <- newIORef Nothing
         writeIORef subagentForkSource (Just (readLiveTranscript conversationRef))
         let titleHint = case resumed of
@@ -2125,6 +2124,17 @@ runAgentInitializedWithLock
                 (if refreshDialectContext || resumeNeedsFreshContext
                     then Nothing
                     else initialPrevious)
+        forM_ resumed \(meta, _) -> do
+            generation <-
+                currentLiveTranscriptGeneration conversationRef
+            void $
+                evictLiveTranscript
+                    conversationRef
+                    generation
+                    (durableTranscriptCheckpoint
+                        (trustedPool startup.startupDatabaseStore)
+                        root
+                        meta.metaId)
         -- Fullscreen sessions load skills after Brick has taken over the
         -- terminal, so filesystem discovery cannot delay the first frame.
         -- Minimal and one-shot sessions still initialize them synchronously
@@ -2197,7 +2207,10 @@ runAgentInitializedWithLock
                                 , startupUnavailable
                                 , paramsRef
                                 , conversationRef
-                                , initialTurns
+                                , needsInitialContext =
+                                    resumeNeedsFreshContext
+                                        || (null initialTurns
+                                            && isNothing initialPrevious)
                                 , persist
                                 , startupWindowTitle
                                 , projectRoot

--- a/packages/agent-cli/src/Agent/CLI/Session/ConversationStore.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/ConversationStore.hs
@@ -220,6 +220,19 @@ evictConversationTranscript
                             }
                         , True
                         )
+            ResidentTranscript items (HydratedResident _ readers)
+                | state.stateGeneration == expectedGeneration ->
+                    -- Readers keep their immutable value, while their final
+                    -- release installs the newest durable checkpoint.
+                    pure
+                        ( state
+                            { stateTranscript =
+                                ResidentTranscript
+                                    items
+                                    (HydratedResident checkpoint readers)
+                            }
+                        , False
+                        )
             _ -> pure (state, False)
 
 readConversationPreviousResponseId

--- a/packages/agent-cli/src/Agent/CLI/Session/ConversationStore.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/ConversationStore.hs
@@ -1,0 +1,246 @@
+-- | Concurrency-safe residency control for the live root conversation.
+--
+-- A cold checkpoint must close over durable identity (for example a session
+-- id and turn cursor), not over the transcript it is intended to release.
+module Agent.CLI.Session.ConversationStore
+    ( ConversationStore
+    , ConversationResidency(..)
+    , TranscriptCheckpoint(..)
+    , TranscriptGeneration
+    , commitConversationTranscript
+    , conversationResidency
+    , currentTranscriptGeneration
+    , evictConversationTranscript
+    , modifyConversationAttachments
+    , newColdConversationStore
+    , newConversationStore
+    , readConversationAttachments
+    , readConversationPreviousResponseId
+    , replaceConversationTranscript
+    , resetConversationStore
+    , withConversationTranscript
+    , writeConversationPreviousResponseId
+    ) where
+
+import Agent.Loop (ImageAttachment)
+import Agent.Responses.Types (ResponseItem)
+import Control.Concurrent.MVar
+    ( MVar
+    , modifyMVar
+    , modifyMVar_
+    , newMVar
+    , readMVar
+    )
+import Control.Exception.Safe (finally, mask)
+import Data.Text (Text)
+import Data.Word (Word64)
+
+newtype TranscriptGeneration = TranscriptGeneration Word64
+    deriving (Eq, Ord, Show)
+
+-- | A durable location from which an exact transcript can be reconstructed.
+--
+-- The description is for diagnostics only. The loader is deliberately opaque
+-- so the store does not depend on PostgreSQL or session persistence details.
+data TranscriptCheckpoint = TranscriptCheckpoint
+    { checkpointDescription :: !Text
+    , checkpointLoad :: !(IO [ResponseItem])
+    }
+
+data ConversationResidency
+    = ConversationResident
+    | ConversationCold
+    deriving (Eq, Show)
+
+data TranscriptState
+    = ResidentTranscript ![ResponseItem]
+    | ColdTranscript !TranscriptCheckpoint
+
+data ConversationState = ConversationState
+    { stateGeneration :: !TranscriptGeneration
+    , stateTranscript :: !TranscriptState
+    , statePreviousResponseId :: !(Maybe Text)
+    , stateAttachments :: ![ImageAttachment]
+    }
+
+newtype ConversationStore = ConversationStore (MVar ConversationState)
+
+newConversationStore
+    :: Maybe Text
+    -> [ResponseItem]
+    -> [ImageAttachment]
+    -> IO ConversationStore
+newConversationStore previousResponseId transcript attachments =
+    ConversationStore <$> newMVar ConversationState
+        { stateGeneration = TranscriptGeneration 0
+        , stateTranscript = ResidentTranscript transcript
+        , statePreviousResponseId = previousResponseId
+        , stateAttachments = attachments
+        }
+
+newColdConversationStore
+    :: Maybe Text
+    -> TranscriptCheckpoint
+    -> [ImageAttachment]
+    -> IO ConversationStore
+newColdConversationStore previousResponseId checkpoint attachments =
+    ConversationStore <$> newMVar ConversationState
+        { stateGeneration = TranscriptGeneration 0
+        , stateTranscript = ColdTranscript checkpoint
+        , statePreviousResponseId = previousResponseId
+        , stateAttachments = attachments
+        }
+
+conversationResidency :: ConversationStore -> IO ConversationResidency
+conversationResidency (ConversationStore stateVar) = do
+    state <- readMVar stateVar
+    pure case state.stateTranscript of
+        ResidentTranscript _ -> ConversationResident
+        ColdTranscript _ -> ConversationCold
+
+currentTranscriptGeneration
+    :: ConversationStore
+    -> IO TranscriptGeneration
+currentTranscriptGeneration (ConversationStore stateVar) =
+    (.stateGeneration) <$> readMVar stateVar
+
+-- | Provide the exact transcript for a scoped operation.
+--
+-- A cold transcript is hydrated once, then returned to the same checkpoint
+-- when the scope ends, provided no writer committed a newer generation.
+withConversationTranscript
+    :: ConversationStore
+    -> ([ResponseItem] -> IO a)
+    -> IO a
+withConversationTranscript
+        store@(ConversationStore stateVar)
+        action =
+    mask \restore -> do
+        (generation, checkpoint, transcript) <-
+            modifyMVar stateVar \state ->
+                case state.stateTranscript of
+                    ResidentTranscript items ->
+                        pure (state, (state.stateGeneration, Nothing, items))
+                    ColdTranscript cold -> do
+                        items <- cold.checkpointLoad
+                        let resident =
+                                state
+                                    { stateTranscript =
+                                        ResidentTranscript items
+                                    }
+                        pure
+                            ( resident
+                            , (state.stateGeneration, Just cold, items)
+                            )
+        restore (action transcript)
+            `finally` case checkpoint of
+                Nothing -> pure ()
+                Just cold -> do
+                    _ <- evictConversationTranscript store generation cold
+                    pure ()
+
+-- | Publish a newer exact transcript and return its generation token.
+commitConversationTranscript
+    :: ConversationStore
+    -> [ResponseItem]
+    -> IO TranscriptGeneration
+commitConversationTranscript (ConversationStore stateVar) transcript =
+    modifyMVar stateVar \state -> do
+        let generation = nextGeneration state.stateGeneration
+        pure
+            ( state
+                { stateGeneration = generation
+                , stateTranscript = ResidentTranscript transcript
+                }
+            , generation
+            )
+
+-- | Install provider/session startup state without disturbing queued images.
+replaceConversationTranscript
+    :: ConversationStore
+    -> Maybe Text
+    -> [ResponseItem]
+    -> IO TranscriptGeneration
+replaceConversationTranscript
+        (ConversationStore stateVar)
+        previousResponseId
+        transcript =
+    modifyMVar stateVar \state -> do
+        let generation = nextGeneration state.stateGeneration
+        pure
+            ( state
+                { stateGeneration = generation
+                , stateTranscript = ResidentTranscript transcript
+                , statePreviousResponseId = previousResponseId
+                }
+            , generation
+            )
+
+-- | Release a resident transcript only when it is still the expected version.
+--
+-- This makes a delayed persistence callback harmless after a concurrent newer
+-- commit. Returns 'True' exactly when the transcript became cold.
+evictConversationTranscript
+    :: ConversationStore
+    -> TranscriptGeneration
+    -> TranscriptCheckpoint
+    -> IO Bool
+evictConversationTranscript
+        (ConversationStore stateVar)
+        expectedGeneration
+        checkpoint =
+    modifyMVar stateVar \state ->
+        case state.stateTranscript of
+            ResidentTranscript _
+                | state.stateGeneration == expectedGeneration ->
+                    pure
+                        ( state
+                            { stateTranscript =
+                                ColdTranscript checkpoint
+                            }
+                        , True
+                        )
+            _ -> pure (state, False)
+
+readConversationPreviousResponseId
+    :: ConversationStore
+    -> IO (Maybe Text)
+readConversationPreviousResponseId (ConversationStore stateVar) =
+    (.statePreviousResponseId) <$> readMVar stateVar
+
+writeConversationPreviousResponseId
+    :: ConversationStore
+    -> Maybe Text
+    -> IO ()
+writeConversationPreviousResponseId (ConversationStore stateVar) value =
+    modifyMVar_ stateVar \state ->
+        pure state { statePreviousResponseId = value }
+
+readConversationAttachments
+    :: ConversationStore
+    -> IO [ImageAttachment]
+readConversationAttachments (ConversationStore stateVar) =
+    (.stateAttachments) <$> readMVar stateVar
+
+modifyConversationAttachments
+    :: ConversationStore
+    -> ([ImageAttachment] -> ([ImageAttachment], a))
+    -> IO a
+modifyConversationAttachments (ConversationStore stateVar) update =
+    modifyMVar stateVar \state ->
+        let (attachments, result) = update state.stateAttachments
+        in pure (state { stateAttachments = attachments }, result)
+
+resetConversationStore :: ConversationStore -> IO ()
+resetConversationStore (ConversationStore stateVar) =
+    modifyMVar_ stateVar \state ->
+        pure state
+            { stateGeneration = nextGeneration state.stateGeneration
+            , stateTranscript = ResidentTranscript []
+            , statePreviousResponseId = Nothing
+            , stateAttachments = []
+            }
+
+nextGeneration :: TranscriptGeneration -> TranscriptGeneration
+nextGeneration (TranscriptGeneration generation) =
+    TranscriptGeneration (generation + 1)

--- a/packages/agent-cli/src/Agent/CLI/Session/ConversationStore.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/ConversationStore.hs
@@ -53,8 +53,12 @@ data ConversationResidency
     deriving (Eq, Show)
 
 data TranscriptState
-    = ResidentTranscript ![ResponseItem]
+    = ResidentTranscript ![ResponseItem] !ResidentSource
     | ColdTranscript !TranscriptCheckpoint
+
+data ResidentSource
+    = CommittedResident
+    | HydratedResident !TranscriptCheckpoint !Int
 
 data ConversationState = ConversationState
     { stateGeneration :: !TranscriptGeneration
@@ -73,7 +77,7 @@ newConversationStore
 newConversationStore previousResponseId transcript attachments =
     ConversationStore <$> newMVar ConversationState
         { stateGeneration = TranscriptGeneration 0
-        , stateTranscript = ResidentTranscript transcript
+        , stateTranscript = ResidentTranscript transcript CommittedResident
         , statePreviousResponseId = previousResponseId
         , stateAttachments = attachments
         }
@@ -95,7 +99,7 @@ conversationResidency :: ConversationStore -> IO ConversationResidency
 conversationResidency (ConversationStore stateVar) = do
     state <- readMVar stateVar
     pure case state.stateTranscript of
-        ResidentTranscript _ -> ConversationResident
+        ResidentTranscript _ _ -> ConversationResident
         ColdTranscript _ -> ConversationCold
 
 currentTranscriptGeneration
@@ -116,28 +120,42 @@ withConversationTranscript
         store@(ConversationStore stateVar)
         action =
     mask \restore -> do
-        (generation, checkpoint, transcript) <-
+        (generation, releaseHydration, transcript) <-
             modifyMVar stateVar \state ->
                 case state.stateTranscript of
-                    ResidentTranscript items ->
-                        pure (state, (state.stateGeneration, Nothing, items))
+                    ResidentTranscript items CommittedResident ->
+                        pure (state, (state.stateGeneration, False, items))
+                    ResidentTranscript items
+                            (HydratedResident checkpoint readers) ->
+                        pure
+                            ( state
+                                { stateTranscript =
+                                    ResidentTranscript
+                                        items
+                                        (HydratedResident
+                                            checkpoint
+                                            (readers + 1))
+                                }
+                            , (state.stateGeneration, True, items)
+                            )
                     ColdTranscript cold -> do
                         items <- cold.checkpointLoad
                         let resident =
                                 state
                                     { stateTranscript =
-                                        ResidentTranscript items
+                                        ResidentTranscript
+                                            items
+                                            (HydratedResident cold 1)
                                     }
                         pure
                             ( resident
-                            , (state.stateGeneration, Just cold, items)
+                            , (state.stateGeneration, True, items)
                             )
         restore (action transcript)
-            `finally` case checkpoint of
-                Nothing -> pure ()
-                Just cold -> do
-                    _ <- evictConversationTranscript store generation cold
-                    pure ()
+            `finally`
+                if releaseHydration
+                    then releaseHydratedTranscript store generation
+                    else pure ()
 
 -- | Publish a newer exact transcript and return its generation token.
 commitConversationTranscript
@@ -150,7 +168,8 @@ commitConversationTranscript (ConversationStore stateVar) transcript =
         pure
             ( state
                 { stateGeneration = generation
-                , stateTranscript = ResidentTranscript transcript
+                , stateTranscript =
+                    ResidentTranscript transcript CommittedResident
                 }
             , generation
             )
@@ -170,7 +189,8 @@ replaceConversationTranscript
         pure
             ( state
                 { stateGeneration = generation
-                , stateTranscript = ResidentTranscript transcript
+                , stateTranscript =
+                    ResidentTranscript transcript CommittedResident
                 , statePreviousResponseId = previousResponseId
                 }
             , generation
@@ -191,7 +211,7 @@ evictConversationTranscript
         checkpoint =
     modifyMVar stateVar \state ->
         case state.stateTranscript of
-            ResidentTranscript _
+            ResidentTranscript _ CommittedResident
                 | state.stateGeneration == expectedGeneration ->
                     pure
                         ( state
@@ -236,7 +256,8 @@ resetConversationStore (ConversationStore stateVar) =
     modifyMVar_ stateVar \state ->
         pure state
             { stateGeneration = nextGeneration state.stateGeneration
-            , stateTranscript = ResidentTranscript []
+            , stateTranscript =
+                ResidentTranscript [] CommittedResident
             , statePreviousResponseId = Nothing
             , stateAttachments = []
             }
@@ -244,3 +265,30 @@ resetConversationStore (ConversationStore stateVar) =
 nextGeneration :: TranscriptGeneration -> TranscriptGeneration
 nextGeneration (TranscriptGeneration generation) =
     TranscriptGeneration (generation + 1)
+
+releaseHydratedTranscript
+    :: ConversationStore
+    -> TranscriptGeneration
+    -> IO ()
+releaseHydratedTranscript
+        (ConversationStore stateVar)
+        expectedGeneration =
+    modifyMVar_ stateVar \state ->
+        if state.stateGeneration /= expectedGeneration
+            then pure state
+            else case state.stateTranscript of
+                ResidentTranscript _
+                        (HydratedResident checkpoint 1) ->
+                    pure state
+                        { stateTranscript = ColdTranscript checkpoint }
+                ResidentTranscript items
+                        (HydratedResident checkpoint readers) ->
+                    pure state
+                        { stateTranscript =
+                            ResidentTranscript
+                                items
+                                (HydratedResident
+                                    checkpoint
+                                    (readers - 1))
+                        }
+                _ -> pure state

--- a/packages/agent-cli/src/Agent/CLI/Session/History.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/History.hs
@@ -3,7 +3,14 @@ module Agent.CLI.Session.History
     ( detectGitBranch
     , foldSessionItems
     , hydrateUiHistory
-    , LiveConversation(..)
+    , LiveConversation
+    , TranscriptCheckpoint(..)
+    , TranscriptGeneration
+    , currentLiveTranscriptGeneration
+    , durableTranscriptCheckpoint
+    , evictLiveTranscript
+    , replaceLiveConversation
+    , withLiveTranscript
     , readLiveAttachments
     , readLivePreviousResponseId
     , readLiveTranscript
@@ -18,7 +25,14 @@ module Agent.CLI.Session.History
 import Agent.CLI.Session
     ( SessionTurn(..)
     , TranscriptEffect(..)
+    , loadSession
     )
+import Agent.CLI.Session.ConversationStore
+    ( ConversationStore
+    , TranscriptCheckpoint(..)
+    , TranscriptGeneration
+    )
+import qualified Agent.CLI.Session.ConversationStore as ConversationStore
 import Agent.Loop (ImageAttachment)
 import Agent.OpenAI.Compaction
     ( isCompactSessionTurn
@@ -38,11 +52,12 @@ import Agent.TUI.Model
 import Agent.OsPath (unsafeToFilePath)
 import Control.Exception.Safe
     ( SomeException
+    , throwString
     , try
     )
+import Control.Monad (void)
 import Data.IORef
     ( IORef
-    , atomicModifyIORef'
     , readIORef
     )
 import Data.Text (Text)
@@ -50,6 +65,7 @@ import qualified Data.Text as Text
 import System.Exit (ExitCode(..))
 import System.OsPath (OsPath)
 import System.Process (readProcessWithExitCode)
+import Agent.Store.Postgres.Connection (StorePool)
 
 -- | The pieces of conversation state that must change together when a live
 -- session is reset.
@@ -57,54 +73,103 @@ import System.Process (readProcessWithExitCode)
 -- Keeping them in one value makes resets and multi-field updates atomic and
 -- prevents callers from observing mismatched response IDs, transcripts, and
 -- attachments.
-data LiveConversation = LiveConversation
-    { livePreviousResponseId :: !(Maybe Text)
-    , liveTranscript :: ![ResponseItem]
-    , liveAttachments :: ![ImageAttachment]
-    } deriving (Eq, Show)
+type LiveConversation = ConversationStore
 
--- | Pure reset transition for live conversation state.
-resetLiveConversationState :: LiveConversation -> LiveConversation
-resetLiveConversationState state =
-    state
-        { livePreviousResponseId = Nothing
-        , liveTranscript = []
-        , liveAttachments = []
-        }
+-- | Reset the live conversation atomically.
+resetLiveConversationState :: LiveConversation -> IO ()
+resetLiveConversationState = ConversationStore.resetConversationStore
 
 readLivePreviousResponseId :: IORef LiveConversation -> IO (Maybe Text)
-readLivePreviousResponseId = fmap (\state -> state.livePreviousResponseId) . readIORef
+readLivePreviousResponseId ref =
+    readIORef ref >>= ConversationStore.readConversationPreviousResponseId
 
 readLiveTranscript :: IORef LiveConversation -> IO [ResponseItem]
-readLiveTranscript = fmap (\state -> state.liveTranscript) . readIORef
+readLiveTranscript ref =
+    withLiveTranscript ref pure
+
+withLiveTranscript
+    :: IORef LiveConversation
+    -> ([ResponseItem] -> IO a)
+    -> IO a
+withLiveTranscript ref action =
+    readIORef ref >>= \store ->
+        ConversationStore.withConversationTranscript store action
 
 readLiveAttachments :: IORef LiveConversation -> IO [ImageAttachment]
-readLiveAttachments = fmap (\state -> state.liveAttachments) . readIORef
+readLiveAttachments ref =
+    readIORef ref >>= ConversationStore.readConversationAttachments
 
 modifyLiveAttachments
     :: IORef LiveConversation
     -> ([ImageAttachment] -> ([ImageAttachment], a))
     -> IO a
 modifyLiveAttachments ref update =
-    atomicModifyIORef' ref \state ->
-        let (attachments, result) = update state.liveAttachments
-        in (state { liveAttachments = attachments }, result)
+    readIORef ref >>= \store ->
+        ConversationStore.modifyConversationAttachments store update
 
 writeLivePreviousResponseId
     :: IORef LiveConversation
     -> Maybe Text
     -> IO ()
 writeLivePreviousResponseId ref value =
-    atomicModifyIORef' ref \state ->
-        (state { livePreviousResponseId = value }, ())
+    readIORef ref >>= \store ->
+        ConversationStore.writeConversationPreviousResponseId store value
 
 writeLiveTranscript
     :: IORef LiveConversation
     -> [ResponseItem]
     -> IO ()
 writeLiveTranscript ref value =
-    atomicModifyIORef' ref \state ->
-        (state { liveTranscript = value }, ())
+    readIORef ref >>= \store ->
+        void (ConversationStore.commitConversationTranscript store value)
+
+replaceLiveConversation
+    :: IORef LiveConversation
+    -> Maybe Text
+    -> [ResponseItem]
+    -> IO TranscriptGeneration
+replaceLiveConversation ref previousResponseId transcript =
+    readIORef ref >>= \store ->
+        ConversationStore.replaceConversationTranscript
+            store previousResponseId transcript
+
+currentLiveTranscriptGeneration
+    :: IORef LiveConversation
+    -> IO TranscriptGeneration
+currentLiveTranscriptGeneration ref =
+    readIORef ref >>= ConversationStore.currentTranscriptGeneration
+
+evictLiveTranscript
+    :: IORef LiveConversation
+    -> TranscriptGeneration
+    -> TranscriptCheckpoint
+    -> IO Bool
+evictLiveTranscript ref generation checkpoint =
+    readIORef ref >>= \store ->
+        ConversationStore.evictConversationTranscript
+            store generation checkpoint
+
+-- | Reconstruct the exact root transcript from durable session turns.
+--
+-- The returned closure captures only durable identity, never the transcript
+-- it is intended to release.
+durableTranscriptCheckpoint
+    :: StorePool
+    -> OsPath
+    -> Text
+    -> TranscriptCheckpoint
+durableTranscriptCheckpoint pool root sessionId =
+    TranscriptCheckpoint
+        { checkpointDescription = "session:" <> sessionId
+        , checkpointLoad =
+            loadSession pool root sessionId >>= \case
+                Left err ->
+                    throwString
+                        ("could not hydrate durable conversation: "
+                            <> Text.unpack err)
+                Right (_, turns) ->
+                    pure (foldSessionItems turns)
+        }
 
 -- | Drop live conversation state without touching persisted session files.
 resetLiveConversation
@@ -121,8 +186,7 @@ resetLiveConversationWith
     -> IO ()
 resetLiveConversationWith resetBackend conversationRef planMode = do
     resetBackend
-    atomicModifyIORef' conversationRef \state ->
-        (resetLiveConversationState state, ())
+    readIORef conversationRef >>= resetLiveConversationState
     deactivatePlanMode planMode
 
 detectGitBranch :: OsPath -> IO Text

--- a/packages/agent-cli/src/Agent/CLI/Session/History.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/History.hs
@@ -25,7 +25,7 @@ module Agent.CLI.Session.History
 import Agent.CLI.Session
     ( SessionTurn(..)
     , TranscriptEffect(..)
-    , loadSession
+    , loadActiveSession
     )
 import Agent.CLI.Session.ConversationStore
     ( ConversationStore
@@ -162,7 +162,10 @@ durableTranscriptCheckpoint pool root sessionId =
     TranscriptCheckpoint
         { checkpointDescription = "session:" <> sessionId
         , checkpointLoad =
-            loadSession pool root sessionId >>= \case
+            -- Load only the checkpoint-bounded active suffix. Loading the
+            -- complete immutable history would briefly rematerialize every
+            -- superseded transcript before 'foldSessionItems' discarded it.
+            loadActiveSession pool root sessionId >>= \case
                 Left err ->
                     throwString
                         ("could not hydrate durable conversation: "

--- a/packages/agent-cli/src/Agent/CLI/Session/Runner.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner.hs
@@ -71,7 +71,6 @@ import Agent.CLI.Project
     )
 import Agent.CLI.Prompt
     ( systemPromptForTools )
-import Agent.CLI.Resume (resumeNeedsGeneratedContext)
 import Agent.CLI.ProviderTransition
     ( PendingTurn(..)
     , TurnResult(..)
@@ -1016,15 +1015,12 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
             markStartupStage startup "Loading skills…"
             skills <- loadSkillsCatalogQuiet
                 options home projectRoot cwd
-            let queueInitialContext =
-                    resumeNeedsGeneratedContext initialTurns
-                        || (null initialTurns && isNothing initialPrevious)
             (omitted, _) <- installSkills startupContext
-                queueInitialContext
+                needsInitialContext
                 skills
             reportSkillCatalog (isNothing fullscreen) skills omitted
             learnedSkills <-
-                if queueInitialContext
+                if needsInitialContext
                     then installLearnedSkills
                         startupContext
                         defaultLearnedSkillContextMaxChars

--- a/packages/agent-cli/src/Agent/CLI/Session/Runtime/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runtime/Types.hs
@@ -27,7 +27,6 @@ import Agent.CLI.Session
     ( LegacySubagentTarget
     , Persistence
     , SessionHandle
-    , SessionTurn
     )
 import Agent.CLI.SessionState (SessionState)
 import Agent.CLI.Subagents.Runtime
@@ -111,7 +110,7 @@ data SessionRequest = SessionRequest
     , startupUnavailable :: !(Maybe (STM ApiError))
     , paramsRef :: !(IORef ResponseCreateParams)
     , conversationRef :: !(IORef LiveConversation)
-    , initialTurns :: ![SessionTurn]
+    , needsInitialContext :: !Bool
     , persist :: !Persistence
     , startupWindowTitle :: !Text
     , projectRoot :: !OsPath

--- a/packages/agent-cli/src/Agent/CLI/SessionState.hs
+++ b/packages/agent-cli/src/Agent/CLI/SessionState.hs
@@ -4,7 +4,8 @@ module Agent.CLI.SessionState
     , newSessionState
     ) where
 
-import Agent.CLI.Session.History (LiveConversation(..))
+import Agent.CLI.Session.ConversationStore (newConversationStore)
+import Agent.CLI.Session.History (LiveConversation)
 import Data.IORef (IORef, newIORef)
 import Data.Text (Text)
 
@@ -21,11 +22,7 @@ data SessionState = SessionState
 newSessionState :: IO SessionState
 newSessionState = do
     draft <- newIORef ""
-    conversation <- newIORef LiveConversation
-        { livePreviousResponseId = Nothing
-        , liveTranscript = []
-        , liveAttachments = []
-        }
+    conversation <- newIORef =<< newConversationStore Nothing [] []
     previewId <- newIORef 1
     pure SessionState
         { sessionDraft = draft

--- a/packages/agent-cli/src/Agent/CLI/Turn.hs
+++ b/packages/agent-cli/src/Agent/CLI/Turn.hs
@@ -136,7 +136,7 @@ import Agent.Tools.PlanMode
     , writePlanMarkdown
     )
 import Agent.OsPath (toText, unsafeToFilePath)
-import Control.Monad (forM_, void, when)
+import Control.Monad (forM_, when)
 import Control.Exception.Safe (bracket_, onException, tryAny)
 import Data.IORef
     ( atomicModifyIORef'
@@ -161,6 +161,7 @@ import System.Process
     , readCreateProcessWithExitCode
     )
 import System.Timeout (timeout)
+import System.Mem (performMajorGC)
 
 runOneTurn :: SessionEnv -> Text -> [TurnInput] -> IO TurnResult
 runOneTurn = runOneTurnWithContext True
@@ -360,12 +361,12 @@ runOneTurnBusy includeTurnContext env@SessionEnv
                     appendTurnWithMetaUpdateIndexed handle turn \meta ->
                     meta { metaLastResponseId = Nothing }
                 writeIORef slotRef (PersistenceActive handle')
-                evictDurableConversation env handle'
                 forM_ fullscreen \runtime ->
                     commitFullscreenHistoryTurn
                         runtime
                         (sessionHistoryTurn turnIndex turn)
                         HistoryCommitAppend
+                evictDurableConversation env handle'
     case (restartEffort, result) of
         (Just level, _) -> do
             abortSubagentTurn rootTurnId
@@ -555,7 +556,6 @@ runOneTurnBusy includeTurnContext env@SessionEnv
                     writeIORef env.sessionTitleTurnCount titleTurns
                     let countedMeta = countedHandle.sessionMeta
                     writeIORef slotRef (PersistenceActive countedHandle)
-                    evictDurableConversation env countedHandle
                     forM_ fullscreen \runtime ->
                         commitFullscreenHistoryTurn
                             runtime
@@ -564,6 +564,7 @@ runOneTurnBusy includeTurnContext env@SessionEnv
                                 TranscriptAppend -> HistoryCommitAppend
                                 TranscriptReplace -> HistoryCommitReplace
                                 TranscriptReset -> HistoryCommitReset)
+                    evictDurableConversation env countedHandle
                     when
                         ( not countedMeta.metaTitleIsManual
                             && shouldRequestSessionTitle titleTurns
@@ -595,9 +596,10 @@ evictDurableConversation env handle = do
                 env.sessionDatabasePool
                 (sessionsRoot env.sessionHome)
                 sessionId
-    void $
+    evicted <-
         evictLiveTranscript
             env.sessionConversation generation checkpoint
+    when evicted performMajorGC
 
 -- | Wrap the last actual user payload in the Grok Build request envelope.
 -- Synthetic startup, skill, plan, and reminder messages precede it and remain

--- a/packages/agent-cli/src/Agent/CLI/Turn.hs
+++ b/packages/agent-cli/src/Agent/CLI/Turn.hs
@@ -58,13 +58,17 @@ import Agent.CLI.Session
     , ensureSession
     , loadRecentSessionTurns
     , sessionConversationText
+    , sessionsRoot
     , sessionTitleFromPrompt
     , setGeneratedSessionTitle
     )
 import Agent.CLI.SessionEnv (SessionEnv(..))
 import Agent.CLI.Session.History
-    ( readLivePreviousResponseId
-    , readLiveTranscript
+    ( currentLiveTranscriptGeneration
+    , durableTranscriptCheckpoint
+    , evictLiveTranscript
+    , readLivePreviousResponseId
+    , withLiveTranscript
     , writeLivePreviousResponseId
     , writeLiveTranscript
     )
@@ -132,7 +136,7 @@ import Agent.Tools.PlanMode
     , writePlanMarkdown
     )
 import Agent.OsPath (toText, unsafeToFilePath)
-import Control.Monad (forM_, when)
+import Control.Monad (forM_, void, when)
 import Control.Exception.Safe (bracket_, onException, tryAny)
 import Data.IORef
     ( atomicModifyIORef'
@@ -180,9 +184,17 @@ runOneTurnWithContext includeTurnContext env promptText inputs = do
     bracket_
         env.sessionBeginWindowTitleBusy
         env.sessionEndWindowTitleBusy
-        (runOneTurnBusy includeTurnContext env promptText inputs)
+        (withLiveTranscript env.sessionConversation \beforeItems ->
+            runOneTurnBusy
+                includeTurnContext env beforeItems promptText inputs)
 
-runOneTurnBusy :: Bool -> SessionEnv -> Text -> [TurnInput] -> IO TurnResult
+runOneTurnBusy
+    :: Bool
+    -> SessionEnv
+    -> [ResponseItem]
+    -> Text
+    -> [TurnInput]
+    -> IO TurnResult
 runOneTurnBusy includeTurnContext env@SessionEnv
     { sessionLoop = config
     , sessionRender = render
@@ -203,7 +215,7 @@ runOneTurnBusy includeTurnContext env@SessionEnv
     , sessionFinishSubagentTurn = finishSubagentTurn
     , sessionAbortSubagentTurn = abortSubagentTurn
     , sessionOnPersisted = onPersisted
-    } promptText inputs = do
+    } beforeItems promptText inputs = do
   let stdoutHandle = render.renderStdout
       stderrHandle = render.renderStderr
   -- Clear the prior turn before publishing this flag to Ctrl-C / Esc.
@@ -247,7 +259,6 @@ runOneTurnBusy includeTurnContext env@SessionEnv
                                     <> handle.sessionMeta.metaId))
         PersistenceDisabled -> pure ()
     prev <- readLivePreviousResponseId conversationRef
-    beforeItems <- readLiveTranscript conversationRef
     pendingStartup <-
         if includeTurnContext
             then atomicModifyIORef' startupContext \pendingCtx ->
@@ -349,6 +360,7 @@ runOneTurnBusy includeTurnContext env@SessionEnv
                     appendTurnWithMetaUpdateIndexed handle turn \meta ->
                     meta { metaLastResponseId = Nothing }
                 writeIORef slotRef (PersistenceActive handle')
+                evictDurableConversation env handle'
                 forM_ fullscreen \runtime ->
                     commitFullscreenHistoryTurn
                         runtime
@@ -543,6 +555,7 @@ runOneTurnBusy includeTurnContext env@SessionEnv
                     writeIORef env.sessionTitleTurnCount titleTurns
                     let countedMeta = countedHandle.sessionMeta
                     writeIORef slotRef (PersistenceActive countedHandle)
+                    evictDurableConversation env countedHandle
                     forM_ fullscreen \runtime ->
                         commitFullscreenHistoryTurn
                             runtime
@@ -567,6 +580,24 @@ runOneTurnBusy includeTurnContext env@SessionEnv
                 Just notes -> do
                     resetRenderPrintedText render
                     runOneTurn env notes [UserMessage notes]
+
+-- | Release the parsed root transcript after the exact turn is durable.
+--
+-- The checkpoint deliberately closes over only durable session identity and
+-- the store pool. A stale callback cannot evict a newer in-memory generation.
+evictDurableConversation :: SessionEnv -> SessionHandle -> IO ()
+evictDurableConversation env handle = do
+    generation <-
+        currentLiveTranscriptGeneration env.sessionConversation
+    let sessionId = handle.sessionMeta.metaId
+        checkpoint =
+            durableTranscriptCheckpoint
+                env.sessionDatabasePool
+                (sessionsRoot env.sessionHome)
+                sessionId
+    void $
+        evictLiveTranscript
+            env.sessionConversation generation checkpoint
 
 -- | Wrap the last actual user payload in the Grok Build request envelope.
 -- Synthetic startup, skill, plan, and reminder messages precede it and remain

--- a/packages/agent-cli/test/Agent/CLI/ConversationStoreSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ConversationStoreSpec.hs
@@ -132,6 +132,37 @@ spec = do
             readIORef loads `shouldReturn` 1
             conversationResidency store `shouldReturn` ConversationCold
 
+        it "defers a newer checkpoint until active readers release" do
+            readerEntered <- newEmptyMVar
+            releaseReader <- newEmptyMVar
+            newerLoads <- newIORef (0 :: Int)
+            let items = [messageItem "shared"]
+                original = TranscriptCheckpoint "turn:1" (pure items)
+                newer = TranscriptCheckpoint "turn:2" do
+                    modifyIORef' newerLoads (+ 1)
+                    pure items
+                reader transcript = do
+                    putMVar readerEntered ()
+                    takeMVar releaseReader
+                    pure transcript
+            store <- newColdConversationStore Nothing original []
+            generation <- currentTranscriptGeneration store
+
+            withAsync
+                    (withConversationTranscript store reader)
+                    \readerAsync -> do
+                takeMVar readerEntered
+                evictConversationTranscript store generation newer
+                    `shouldReturn` False
+                conversationResidency store
+                    `shouldReturn` ConversationResident
+                putMVar releaseReader ()
+                wait readerAsync `shouldReturn` items
+
+            conversationResidency store `shouldReturn` ConversationCold
+            withConversationTranscript store (`shouldBe` items)
+            readIORef newerLoads `shouldReturn` 1
+
         it "keeps response id and attachments independent of hydration" do
             loads <- newIORef (0 :: Int)
             let image = ImageAttachment "image/png" "png"

--- a/packages/agent-cli/test/Agent/CLI/ConversationStoreSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ConversationStoreSpec.hs
@@ -1,0 +1,168 @@
+module Agent.CLI.ConversationStoreSpec (spec) where
+
+import Agent.CLI.Session.ConversationStore
+import Agent.Loop (ImageAttachment(..))
+import Agent.Responses.Types
+import Control.Concurrent.Async (concurrently)
+import Control.Concurrent.MVar
+    ( newEmptyMVar
+    , putMVar
+    , takeMVar
+    )
+import Control.Exception.Safe (throwString)
+import Data.Aeson.KeyMap qualified as KeyMap
+import Data.IORef
+import Data.Text (Text)
+import Test.Hspec
+
+spec :: Spec
+spec = do
+    describe "ConversationStore" do
+        it "hydrates a cold transcript only for the scoped read" do
+            loads <- newIORef (0 :: Int)
+            let items = [messageItem "cold"]
+                checkpoint = TranscriptCheckpoint "turn:1" do
+                    modifyIORef' loads (+ 1)
+                    pure items
+            store <- newColdConversationStore
+                (Just "response-1")
+                checkpoint
+                []
+
+            withConversationTranscript store (`shouldBe` items)
+
+            readIORef loads `shouldReturn` 1
+            conversationResidency store `shouldReturn` ConversationCold
+            readConversationPreviousResponseId store
+                `shouldReturn` Just "response-1"
+
+        it "returns to cold state when a scoped reader throws" do
+            let checkpoint = TranscriptCheckpoint "turn:1" $
+                    pure [messageItem "cold"]
+            store <- newColdConversationStore Nothing checkpoint []
+
+            withConversationTranscript store
+                (\_ -> throwString "reader failed")
+                `shouldThrow` anyException
+
+            conversationResidency store `shouldReturn` ConversationCold
+
+        it "remains cold when checkpoint hydration fails" do
+            let checkpoint = TranscriptCheckpoint "broken" $
+                    throwString "checkpoint unavailable"
+            store <- newColdConversationStore Nothing checkpoint []
+
+            withConversationTranscript store (\_ -> pure ())
+                `shouldThrow` anyException
+
+            conversationResidency store `shouldReturn` ConversationCold
+
+        it "does not let a scoped reader evict a newer commit" do
+            let checkpoint = TranscriptCheckpoint "turn:1" $
+                    pure [messageItem "cold"]
+                newer = [messageItem "newer"]
+            store <- newColdConversationStore Nothing checkpoint []
+
+            generation <- withConversationTranscript store \_ ->
+                commitConversationTranscript store newer
+
+            conversationResidency store `shouldReturn` ConversationResident
+            currentTranscriptGeneration store `shouldReturn` generation
+            withConversationTranscript store (`shouldBe` newer)
+
+        it "rejects a stale explicit eviction" do
+            store <- newConversationStore Nothing [messageItem "initial"] []
+            stale <- currentTranscriptGeneration store
+            current <- commitConversationTranscript store [messageItem "newer"]
+            let checkpoint = TranscriptCheckpoint "stale" $
+                    pure [messageItem "initial"]
+
+            evictConversationTranscript store stale checkpoint
+                `shouldReturn` False
+            currentTranscriptGeneration store `shouldReturn` current
+            withConversationTranscript store
+                (`shouldBe` [messageItem "newer"])
+
+        it "evicts the expected committed generation" do
+            let items = [messageItem "durable"]
+            store <- newConversationStore Nothing [] []
+            generation <- commitConversationTranscript store items
+            let checkpoint = TranscriptCheckpoint "turn:2" (pure items)
+
+            evictConversationTranscript store generation checkpoint
+                `shouldReturn` True
+            conversationResidency store `shouldReturn` ConversationCold
+            withConversationTranscript store (`shouldBe` items)
+            conversationResidency store `shouldReturn` ConversationCold
+
+        it "coalesces concurrent hydration and safely re-evicts" do
+            loads <- newIORef (0 :: Int)
+            firstEntered <- newEmptyMVar
+            releaseFirst <- newEmptyMVar
+            let items = [messageItem "shared"]
+                checkpoint = TranscriptCheckpoint "turn:1" do
+                    modifyIORef' loads (+ 1)
+                    pure items
+                firstReader transcript = do
+                    putMVar firstEntered ()
+                    takeMVar releaseFirst
+                    pure transcript
+                secondReader transcript = do
+                    putMVar releaseFirst ()
+                    pure transcript
+            store <- newColdConversationStore Nothing checkpoint []
+
+            (first, second) <- concurrently
+                (withConversationTranscript store firstReader)
+                (takeMVar firstEntered
+                    >> withConversationTranscript store secondReader)
+
+            first `shouldBe` items
+            second `shouldBe` items
+            readIORef loads `shouldReturn` 1
+            conversationResidency store `shouldReturn` ConversationCold
+
+        it "keeps response id and attachments independent of hydration" do
+            loads <- newIORef (0 :: Int)
+            let image = ImageAttachment "image/png" "png"
+                checkpoint = TranscriptCheckpoint "turn:1" do
+                    modifyIORef' loads (+ 1)
+                    pure [messageItem "cold"]
+            store <- newColdConversationStore Nothing checkpoint []
+
+            writeConversationPreviousResponseId store (Just "response-2")
+            modifyConversationAttachments store \_ -> ([image], ())
+
+            readConversationPreviousResponseId store
+                `shouldReturn` Just "response-2"
+            readConversationAttachments store `shouldReturn` [image]
+            readIORef loads `shouldReturn` 0
+            conversationResidency store `shouldReturn` ConversationCold
+
+        it "resets all conversation fields and invalidates stale generations" do
+            let image = ImageAttachment "image/png" "png"
+            store <- newConversationStore
+                (Just "response-1")
+                [messageItem "resident"]
+                [image]
+            stale <- currentTranscriptGeneration store
+            resetConversationStore store
+            let checkpoint = TranscriptCheckpoint "stale" $
+                    pure [messageItem "resident"]
+
+            evictConversationTranscript store stale checkpoint
+                `shouldReturn` False
+            readConversationPreviousResponseId store `shouldReturn` Nothing
+            readConversationAttachments store `shouldReturn` []
+            withConversationTranscript store (`shouldBe` [])
+
+messageItem :: Text -> ResponseItem
+messageItem text = MessageItem ResponseMessage
+    { messageId = Nothing
+    , content = MessageContentText text
+    , role = RoleAssistant
+    , status = Nothing
+    , phase = Nothing
+    , passthrough = Nothing
+    , extraFields = KeyMap.empty
+    }

--- a/packages/agent-cli/test/Agent/CLI/ConversationStoreSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ConversationStoreSpec.hs
@@ -3,7 +3,7 @@ module Agent.CLI.ConversationStoreSpec (spec) where
 import Agent.CLI.Session.ConversationStore
 import Agent.Loop (ImageAttachment(..))
 import Agent.Responses.Types
-import Control.Concurrent.Async (concurrently)
+import Control.Concurrent.Async (wait, withAsync)
 import Control.Concurrent.MVar
     ( newEmptyMVar
     , putMVar
@@ -98,7 +98,9 @@ spec = do
         it "coalesces concurrent hydration and safely re-evicts" do
             loads <- newIORef (0 :: Int)
             firstEntered <- newEmptyMVar
+            secondEntered <- newEmptyMVar
             releaseFirst <- newEmptyMVar
+            releaseSecond <- newEmptyMVar
             let items = [messageItem "shared"]
                 checkpoint = TranscriptCheckpoint "turn:1" do
                     modifyIORef' loads (+ 1)
@@ -108,17 +110,25 @@ spec = do
                     takeMVar releaseFirst
                     pure transcript
                 secondReader transcript = do
-                    putMVar releaseFirst ()
+                    putMVar secondEntered ()
+                    takeMVar releaseSecond
                     pure transcript
             store <- newColdConversationStore Nothing checkpoint []
 
-            (first, second) <- concurrently
-                (withConversationTranscript store firstReader)
-                (takeMVar firstEntered
-                    >> withConversationTranscript store secondReader)
-
-            first `shouldBe` items
-            second `shouldBe` items
+            withAsync
+                    (withConversationTranscript store firstReader)
+                    \firstReaderAsync -> do
+                takeMVar firstEntered
+                withAsync
+                        (withConversationTranscript store secondReader)
+                        \secondReaderAsync -> do
+                    takeMVar secondEntered
+                    putMVar releaseFirst ()
+                    wait firstReaderAsync `shouldReturn` items
+                    conversationResidency store
+                        `shouldReturn` ConversationResident
+                    putMVar releaseSecond ()
+                    wait secondReaderAsync `shouldReturn` items
             readIORef loads `shouldReturn` 1
             conversationResidency store `shouldReturn` ConversationCold
 

--- a/packages/agent-cli/test/Agent/CLI/SessionHistorySpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SessionHistorySpec.hs
@@ -1,25 +1,27 @@
 module Agent.CLI.SessionHistorySpec (spec) where
 
-import Agent.CLI.Session.History
-    ( LiveConversation(..)
-    , hydrateUiHistory
-    , resetLiveConversationState
-    , resetLiveConversationWith
-    )
 import Agent.CLI.Session
     ( SessionTurn(..)
     , TranscriptEffect(..)
     )
-import Agent.Loop (ImageAttachment(..))
+import Agent.CLI.Session.ConversationStore (newConversationStore)
+import Agent.CLI.Session.History
+    ( hydrateUiHistory
+    , readLiveAttachments
+    , readLivePreviousResponseId
+    , readLiveTranscript
+    , resetLiveConversationState
+    , resetLiveConversationWith
+    )
+import Agent.Loop (ImageAttachment(..), TurnInput(..))
 import Agent.Responses.LoopBackend (turnInputsToItems)
-import Agent.Loop (TurnInput(..))
+import Agent.Tools.PlanMode (newPlanModeEnv)
 import Agent.TUI.Model (BlockKind(..), UiBlock(..), UiState(..))
 import qualified Data.ByteString.Char8 as ByteString
 import qualified Data.Foldable as Foldable
 import Data.IORef (newIORef, readIORef, writeIORef)
 import Data.Text (Text)
 import Data.Time (UTCTime(..), fromGregorian)
-import Agent.Tools.PlanMode (newPlanModeEnv)
 import System.OsPath (unsafeEncodeUtf)
 import Test.Hspec (Spec, describe, it, shouldBe, shouldReturn)
 
@@ -27,35 +29,30 @@ spec :: Spec
 spec = do
     describe "LiveConversation" do
       it "resets all coordinated fields together" do
-        let state = LiveConversation
-                { livePreviousResponseId = Just "resp-1"
-                , liveTranscript = turnInputsToItems [UserMessage "hello"]
-                , liveAttachments =
-                    [ImageAttachment "image/png" (ByteString.pack "bytes")]
-                }
-        resetLiveConversationState state `shouldBe`
-            LiveConversation
-                { livePreviousResponseId = Nothing
-                , liveTranscript = []
-                , liveAttachments = []
-                }
+        state <- newConversationStore
+            (Just "resp-1")
+            (turnInputsToItems [UserMessage "hello"])
+            [ImageAttachment "image/png" (ByteString.pack "bytes")]
+        stateRef <- newIORef state
+        resetLiveConversationState state
+        readLivePreviousResponseId stateRef `shouldReturn` Nothing
+        readLiveTranscript stateRef `shouldReturn` []
+        readLiveAttachments stateRef `shouldReturn` []
 
       it "is idempotent" do
-        let state = LiveConversation
-                { livePreviousResponseId = Just "resp-1"
-                , liveTranscript = []
-                , liveAttachments = []
-                }
-            reset = resetLiveConversationState state
-        resetLiveConversationState reset `shouldBe` reset
+        state <- newConversationStore (Just "resp-1") [] []
+        stateRef <- newIORef state
+        resetLiveConversationState state
+        resetLiveConversationState state
+        readLivePreviousResponseId stateRef `shouldReturn` Nothing
+        readLiveTranscript stateRef `shouldReturn` []
+        readLiveAttachments stateRef `shouldReturn` []
 
       it "clears provider-owned transcript state at the same reset boundary" do
         let transcript = turnInputsToItems [UserMessage "old context"]
-        conversationRef <- newIORef LiveConversation
-            { livePreviousResponseId = Just "resp-1"
-            , liveTranscript = transcript
-            , liveAttachments = []
-            }
+        conversation <-
+            newConversationStore (Just "resp-1") transcript []
+        conversationRef <- newIORef conversation
         providerTranscriptRef <- newIORef transcript
         planMode <- newPlanModeEnv (unsafeEncodeUtf "/tmp/session-reset") Nothing
         resetLiveConversationWith
@@ -63,12 +60,9 @@ spec = do
             conversationRef
             planMode
         readIORef providerTranscriptRef `shouldReturn` []
-        readIORef conversationRef `shouldReturn`
-            LiveConversation
-                { livePreviousResponseId = Nothing
-                , liveTranscript = []
-                , liveAttachments = []
-                }
+        readLivePreviousResponseId conversationRef `shouldReturn` Nothing
+        readLiveTranscript conversationRef `shouldReturn` []
+        readLiveAttachments conversationRef `shouldReturn` []
 
     describe "hydrateUiHistory" do
       it "keeps pre-compaction blocks scrollable while appending the summary" do

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -14,6 +14,7 @@ import qualified Agent.CLI.ClipboardSpec as ClipboardSpec
 import qualified Agent.CLI.CommandSpec as CommandSpec
 import qualified Agent.CLI.ConfigSpec as ConfigSpec
 import qualified Agent.CLI.CompactionSpec as CompactionSpec
+import qualified Agent.CLI.ConversationStoreSpec as ConversationStoreSpec
 import qualified Agent.CLI.ConnectivitySpec as ConnectivitySpec
 import qualified Agent.CLI.CredentialStoreSpec as CredentialStoreSpec
 import qualified Agent.CLI.DialectsSpec as DialectsSpec
@@ -88,6 +89,7 @@ main = hspec do
     CommandSpec.spec
     ConfigSpec.spec
     CompactionSpec.spec
+    ConversationStoreSpec.spec
     ConnectivitySpec.spec
     CredentialStoreSpec.spec
     DialectsSpec.spec


### PR DESCRIPTION
## Summary

- evict durable root transcripts to PostgreSQL-backed cold checkpoints and hydrate them only for scoped operations
- run with one RTS capability, release pages promptly, and collect after durable transcript eviction
- start syntax highlighting with an empty catalog, detect fenced languages, and load only each requested grammar and its transitive dependencies on a background worker

## Results

Measured on macOS with `footprint` and an optimized (`-O1`) executable:

| state | before | after |
| --- | ---: | ---: |
| fullscreen idle | ~240 MB | ~33 MB |
| resumed fullscreen idle | — | ~34 MB |
| after one turn | — | ~48 MB |

## Benchmarks

Built with:

```sh
nix develop -c cabal build --offline \
  agent-cli:bench:conversation-retention-bench \
  agent-cli:bench:syntax-retention-bench \
  agent-cli:bench:concurrency-bench
```

Conversation retention (`-O2`, median of 3, `+RTS -T -N1 -Fd1`):

| transcript | resident live / RTS memory | cold live / RTS memory |
| --- | ---: | ---: |
| 1 MiB | 1.07 / 8 MiB | 0.076 / 7 MiB |
| 10 MiB | 10.52 / 26 MiB | 0.068 / 8 MiB |
| 50 MiB | 52.50 / 85 MiB | 0.068 / 7 MiB |

Syntax retention (`+RTS -T`, retained live / RTS memory):

- empty catalog: 14 KB / 6 MiB
- Haskell grammar plus dependencies: 1.06 MB / 10 MiB
- full grammar catalog: 87.2 MB / 195 MiB

Concurrency benchmark (median of 7) found no regression from `-N1`: bounded startup changed from 84.55 ms to 83.20 ms and bounded attachments from 4.37 ms to 2.42 ms.

## Validation

- `agent-syntax-test` — 11 examples, 0 failures
- `agent-cli-test` — 1049 examples, 0 failures, 1 platform-specific pending
- end-to-end test verifies a `.hs` fence triggers background loading and becomes highlightable
- live tmux smoke tests for minimal, fullscreen, and resumed sessions
