### PR TITLE
Fix terminal cleanup after interrupted resume

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -58,6 +58,7 @@ module Agent.CLI.TUI.App
     , fullscreenVtyConfig
     , fullscreenSurface
     , wrapFullscreenKeyboardVty
+    , withTrackedVtyBuilder
     , setFullscreenImagePreviews
     , setFullscreenWindowTitle
     , applyStoredFullscreenWindowTitle
@@ -270,7 +271,7 @@ import Agent.CLI.Recap
     )
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.State.Strict (modify')
-import Control.Exception.Safe (finally, onException, throwIO, tryAny)
+import Control.Exception.Safe (finally, mask, onException, throwIO, tryAny)
 import Control.Exception (AsyncException(UserInterrupt))
 import Data.Char (isControl, isSpace)
 import Data.Foldable (toList)
@@ -814,6 +815,25 @@ wrapFullscreenKeyboardVty enabled vty
         V.outputByteBuffer (V.outputIface vty)
             . TextEncoding.encodeUtf8
 
+-- | Run an action with a Vty builder while retaining ownership of the most
+-- recently built handle. Brick replaces its Vty during 'suspendAndResume',
+-- but its exception cleanup can still target the original handle. Shutting
+-- down the latest handle here ensures terminal modes are restored on exit.
+withTrackedVtyBuilder
+    :: IO V.Vty
+    -> (IO V.Vty -> IO a)
+    -> IO a
+withTrackedVtyBuilder build action = do
+    latestVty <- newIORef Nothing
+    let trackedBuild =
+            mask \restore -> do
+                vty <- restore build
+                writeIORef latestVty (Just vty)
+                pure vty
+        shutdownLatest =
+            readIORef latestVty >>= maybe (pure ()) V.shutdown
+    action trackedBuild `finally` shutdownLatest
+
 requestFullscreenPermission
     :: FullscreenRuntime
     -> ToolCall
@@ -915,90 +935,95 @@ runFullscreen runtime workerAction = do
     (initialAgent, initialAgents) <- runtime.runtimeAgentSnapshot
     initialClock <- getMonotonicTimeNSec
     terminal <- detectTerminalCapabilities stdout
-    let buildVty = do
+    let makeVty = do
             vty <- Vty.mkVty fullscreenVtyConfig
-            let output = V.outputIface vty
-            -- Without this mode terminals paste image clipboard fallbacks
-            -- (paths, URLs, or other text representations) as ordinary key
-            -- events, so the composer renders them as text. Vty turns the
-            -- bracketed sequence into one EvPaste that we can classify.
-            when (V.supportsMode output V.BracketedPaste) $
-                V.setMode output V.BracketedPaste True
-            when (V.supportsMode output V.Mouse) $
-                V.setMode output V.Mouse True
-            when (V.supportsMode output V.Focus) $
-                V.setMode output V.Focus True
-            -- Vty deliberately leaves OSC 8 output disabled by default even
-            -- when rendered attributes contain URLs.
-            when (V.supportsMode output V.Hyperlink) $
-                V.setMode output V.Hyperlink True
-            when (V.supportsMode output V.Focus) $
-                V.setMode output V.Focus True
-            wrapped <-
-                wrapNativePreviewVty runtime vty
-                    >>= wrapFullscreenKeyboardVty terminal.terminalKittyKeyboard
-            applyStoredFullscreenWindowTitle
-                runtime
-                (V.outputIface wrapped)
-            pure wrapped
-    initialVty <- buildVty
-    let
-        initialState =
-            initialFullscreenAppState
-                runtime
-                history
-                initialAgent
-                initialAgents
-                initialClock
-        (initialDemand, initialDelay) =
-            appMotionTiming initialState
-    atomically $
-        writeTVar
-            runtime.runtimeMotionSchedule
-            (initialDemand, initialDelay, 0)
-    withAsync workerAction \worker ->
-        withAsync uiTicker \_uiTicker ->
-            withAsync (agentTicker (initialAgent, initialAgents)) \_agentTicker ->
-                withAsync (eventPump runtime) \_eventPump ->
-                    withAsync (recapTicker runtime) \_recapTicker ->
-                        withAsync
-                            historyLoader
-                            \_historyLoader ->
+            let setupVty = do
+                    let output = V.outputIface vty
+                    -- Without this mode terminals paste image clipboard
+                    -- fallbacks (paths, URLs, or other text representations)
+                    -- as ordinary key events, so the composer renders them as
+                    -- text. Vty turns the bracketed sequence into one EvPaste
+                    -- that we can classify.
+                    when (V.supportsMode output V.BracketedPaste) $
+                        V.setMode output V.BracketedPaste True
+                    when (V.supportsMode output V.Mouse) $
+                        V.setMode output V.Mouse True
+                    when (V.supportsMode output V.Focus) $
+                        V.setMode output V.Focus True
+                    -- Vty deliberately leaves OSC 8 output disabled by
+                    -- default even when rendered attributes contain URLs.
+                    when (V.supportsMode output V.Hyperlink) $
+                        V.setMode output V.Hyperlink True
+                    when (V.supportsMode output V.Focus) $
+                        V.setMode output V.Focus True
+                    wrapped <-
+                        wrapNativePreviewVty runtime vty
+                            >>= wrapFullscreenKeyboardVty
+                                terminal.terminalKittyKeyboard
+                    applyStoredFullscreenWindowTitle
+                        runtime
+                        (V.outputIface wrapped)
+                    pure wrapped
+            setupVty `onException` V.shutdown vty
+    withTrackedVtyBuilder makeVty \buildVty -> do
+        initialVty <- buildVty
+        let
+            initialState =
+                initialFullscreenAppState
+                    runtime
+                    history
+                    initialAgent
+                    initialAgents
+                    initialClock
+            (initialDemand, initialDelay) =
+                appMotionTiming initialState
+        atomically $
+            writeTVar
+                runtime.runtimeMotionSchedule
+                (initialDemand, initialDelay, 0)
+        withAsync workerAction \worker ->
+            withAsync uiTicker \_uiTicker ->
+                withAsync (agentTicker (initialAgent, initialAgents)) \_agentTicker ->
+                    withAsync (eventPump runtime) \_eventPump ->
+                        withAsync (recapTicker runtime) \_recapTicker ->
                             withAsync
-                                dictationWorker
-                                \_dictationWorker ->
+                                historyLoader
+                                \_historyLoader ->
                                 withAsync
-                                    (loadSyntaxHighlighterForRuntime runtime)
-                                    \_syntaxLoader ->
-                                        withAsync
-                                            (void (waitCatch worker)
-                                                >> enqueueAppEvent runtime AppStop)
-                                            \_notifier -> do
-                                                finalState <-
-                                                    customMain
-                                                        initialVty
-                                                        buildVty
-                                                        (Just runtime.runtimeEvents)
-                                                        fullscreenApp
-                                                        initialState
-                                                    `finally`
-                                                        runtime.runtimeNativeProgress False
-                                                mapM_
-                                                    (`Composer.requestDictationStop` True)
-                                                    finalState.appDictation
-                                                when (not finalState.appWorkerStopped) $
-                                                    atomically $
-                                                        Composer.appendFullscreenInput
-                                                            runtime.runtimeInput
-                                                            FullscreenInput
-                                                                { fullscreenInputLine =
-                                                                    ReplEof
-                                                                , fullscreenInputQueued =
-                                                                    False
-                                                                , fullscreenInputDisplay =
-                                                                    Nothing
-                                                                }
-                                                wait worker
+                                    dictationWorker
+                                    \_dictationWorker ->
+                                    withAsync
+                                        (loadSyntaxHighlighterForRuntime runtime)
+                                        \_syntaxLoader ->
+                                            withAsync
+                                                (void (waitCatch worker)
+                                                    >> enqueueAppEvent runtime AppStop)
+                                                \_notifier -> do
+                                                    finalState <-
+                                                        customMain
+                                                            initialVty
+                                                            buildVty
+                                                            (Just runtime.runtimeEvents)
+                                                            fullscreenApp
+                                                            initialState
+                                                        `finally`
+                                                            runtime.runtimeNativeProgress False
+                                                    mapM_
+                                                        (`Composer.requestDictationStop` True)
+                                                        finalState.appDictation
+                                                    when (not finalState.appWorkerStopped) $
+                                                        atomically $
+                                                            Composer.appendFullscreenInput
+                                                                runtime.runtimeInput
+                                                                FullscreenInput
+                                                                    { fullscreenInputLine =
+                                                                        ReplEof
+                                                                    , fullscreenInputQueued =
+                                                                        False
+                                                                    , fullscreenInputDisplay =
+                                                                        Nothing
+                                                                    }
+                                                    wait worker
   where
     recapTicker _runtime = forever do
         threadDelay 20_000_000

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -22,6 +22,7 @@ import Agent.CLI.TUI.App
     , mergeConversationView
     , newFullscreenInputBuffer
     , newFullscreenRuntime
+    , withTrackedVtyBuilder
     , wrapFullscreenKeyboardVty
     , motionDemandFor
     , motionDemandForTerminalFocus
@@ -80,7 +81,7 @@ import Agent.TUI.Motion
 import Control.Concurrent.STM (newTChanIO)
 import qualified Data.ByteString as ByteString
 import Data.Foldable (find)
-import Data.IORef (modifyIORef', newIORef, readIORef)
+import Data.IORef (modifyIORef', newIORef, readIORef, writeIORef)
 import qualified Data.Map.Strict as Map
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -391,6 +392,34 @@ spec = do
                         \title -> modifyIORef' titles (<> [title])
                     }
             readIORef titles `shouldReturn` ["New session"]
+
+    describe "fullscreen Vty ownership" do
+        it "shuts down the rebuilt Vty when exit follows suspension" do
+            shutdowns <- newIORef ([] :: [String])
+            useInitial <- newIORef True
+            (_, output) <- VMock.mockTerminal (80, 24)
+            initialVty <- mockVty
+                output
+                (modifyIORef' shutdowns (<> ["initial"]))
+                (pure False)
+            resumedVty <- mockVty
+                output
+                (modifyIORef' shutdowns (<> ["resumed"]))
+                (pure False)
+            let makeVty = do
+                    initial <- readIORef useInitial
+                    writeIORef useInitial False
+                    pure (if initial then initialVty else resumedVty)
+
+            (withTrackedVtyBuilder makeVty \buildVty -> do
+                first <- buildVty
+                V.shutdown first
+                _ <- buildVty
+                ioError (userError "forced exit"))
+                `shouldThrow` anyIOException
+
+            readIORef shutdowns
+                `shouldReturn` ["initial", "resumed"]
 
     describe "repositoryHeaderText" do
         it "puts the git state before the full checkout path" do


### PR DESCRIPTION
## Summary
- track the currently active Vty handle across Brick suspend/resume cycles
- always shut down the latest handle when fullscreen mode exits
- add regression coverage for interruption after a Vty rebuild

## Validation
- agent-cli test suite: 985 examples, 0 failures, 1 pending
- live tmux suspend → Ctrl-C smoke test: mouse and alternate-screen modes balanced
- git diff --check