### PR TITLE
feat(tui): add traveling accent-rail motion

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -200,12 +200,14 @@ import qualified Agent.CLI.TUI.Scroll as Scroll
 import qualified Agent.CLI.TUI.Transcript as Transcript
 import Agent.CLI.TUI.Types
 import Agent.TUI.Model
+import Agent.TUI.Accent (accentRail, waveHeader)
 import Agent.TUI.Motion
     ( MotionDemand(..)
     , MotionMode(..)
     , backgroundIndicator
     , completionFlashDurationMillis
     , foregroundIndicator
+    , nativeProgressAnimationEnabled
     , quietIndicator
     , waitingIndicator
     )
@@ -368,6 +370,7 @@ newFullscreenRuntimeWithSyntaxLoader
         imagePreviewIdBase <- allocateNativePreviewImageIdBase
         imagePreviewProtocol <- detectImagePreviewProtocol stdout
         imagePreviewInTmux <- isJust <$> lookupEnv "TMUX"
+        colorFgBg <- lookupEnv "COLORFGBG"
         sessionActions <- newIORef FullscreenSessionActions
             { sessionCancel = cancelAction
             , sessionBtw = const (pure ())
@@ -413,6 +416,7 @@ newFullscreenRuntimeWithSyntaxLoader
                 imagePreviewProtocol == PreviewKitty
                     && not imagePreviewInTmux
             , runtimeColor = color
+            , runtimeWaveTrough = Theme.waveTroughFromColorFgBg colorFgBg
             , runtimeLoadSyntaxHighlighter = syntaxLoader
             , runtimeSyntaxLoadFinished = syntaxLoadFinished
             , runtimeInitial = initial
@@ -2778,62 +2782,69 @@ todoLineStatusFromText line
     | otherwise = TodoDisplayPending
 
 drawPromptActivity :: AppState -> Widget Name
-drawPromptActivity state =
-    padLeftRight 2 $
-        hBox
-            [ activityWidget
-            , withAttr Theme.mutedAttr (terminalTxt elapsed)
-            ]
+drawPromptActivity state
+    | not busy = emptyWidget
+    | otherwise =
+        padLeftRight 2 $
+            hBox
+                [ left
+                , vLimit 1 (fill ' ')
+                , withAttr Theme.mutedAttr (terminalTxt right)
+                ]
   where
     ui = state.appUi
     waiting = userActionPending state
     background = hasBackgroundActivity state.appAgentEntries
     mode = state.appRuntime.runtimeMotionMode
     motionMillis = state.appMotionElapsedMillis
-    activityWidget
+    trough = state.appRuntime.runtimeWaveTrough
+    busy =
+        ui.uiRunning
+            || waiting
+            || background
+            || ui.uiCompletionRemainingMillis > 0
+    diamond =
+        raw
+            ( V.char
+                (Theme.waitingPulseAttr trough motionMillis)
+                ( case Text.uncons
+                    (waitingIndicator motionGlyphSet mode motionMillis) of
+                    Just (character, _) -> character
+                    Nothing -> '◆'
+                )
+            )
+    left
         | waiting =
             hBox
-                [ withAttr (waitingIndicatorAttr state) $
-                    txt (waitingIndicator motionGlyphSet mode motionMillis)
-                , withAttr Theme.thinkingAttr (txt " Waiting for you")
+                [ diamond
+                , withAttr Theme.mutedAttr (txt " Waiting for you")
                 ]
-        | otherwise =
-            withAttr activityAttr (terminalTxt activity)
-    activityAttr
-        | ui.uiRunning = Theme.thinkingAttr
-        | ui.uiCompletionRemainingMillis > 0 = Theme.successAttr
-        | background = Theme.toolAttr
-        | otherwise = Theme.mutedAttr
-    activity
         | ui.uiRunning =
-            foregroundIndicator motionGlyphSet mode motionMillis
-                <> " "
-                <> ui.uiActivity
+            hBox
+                [ withAttr Theme.thinkingAttr $
+                    txt
+                        (foregroundIndicator
+                            motionGlyphSet
+                            mode
+                            motionMillis)
+                , withAttr Theme.mutedAttr
+                    (txt (" " <> ui.uiActivity <> elapsed))
+                ]
         | ui.uiCompletionRemainingMillis > 0 =
-            ui.uiActivity
+            withAttr Theme.successAttr (terminalTxt ui.uiActivity)
         | background =
-            backgroundIndicator motionGlyphSet mode motionMillis
-                <> " Background work"
-        | otherwise =
-            ui.uiActivity
+            withAttr Theme.mutedAttr $
+                terminalTxt
+                    (backgroundIndicator motionGlyphSet mode motionMillis
+                        <> " Background work")
+        | otherwise = emptyWidget
     elapsed =
+        " · "
+            <> formatElapsed (fromIntegral ui.uiElapsedMillis / 1000)
+    right =
         if ui.uiRunning
-            then " · "
-                <> formatElapsed
-                    (fromIntegral ui.uiElapsedMillis / 1000)
+            then formatTokenUsage ui.uiPrompt.promptUsage
             else ""
-
-waitingIndicatorAttr :: AppState -> AttrName
-waitingIndicatorAttr state =
-    case waitingIndicator
-        motionGlyphSet
-        state.appRuntime.runtimeMotionMode
-        state.appMotionElapsedMillis of
-        "◇" -> Theme.waitingDimAttr
-        "." -> Theme.waitingDimAttr
-        "◈" -> Theme.waitingMidAttr
-        "*" -> Theme.waitingMidAttr
-        _ -> Theme.thinkingAttr
 
 drawTranscript :: AppState -> Widget Name
 drawTranscript state =
@@ -3059,10 +3070,13 @@ drawEmptyConversation state =
   where
     frame
         | userActionPending state = 0
-        | otherwise = case state.appRuntime.runtimeMotionMode of
-            MotionFull -> state.appMotionElapsedMillis `div` 160
-            MotionReduced -> 0
-            MotionOff -> 0
+        | otherwise =
+            case motionModeForTerminalFocus
+                state.appTerminalFocus
+                state.appRuntime.runtimeMotionMode of
+                MotionFull -> state.appMotionElapsedMillis
+                MotionReduced -> 0
+                MotionOff -> 0
 
 quickStartReservedRows :: Int
 quickStartReservedRows = 9
@@ -3116,6 +3130,7 @@ drawBlock state target ui block =
             selected
                 && state.appUi.uiFocus == FocusScrollback
                 && state.appAgentSelected == target
+        waveElapsed = accentWaveElapsed state target block
         marker =
             txt (if highlighted then "❯ " else "  ")
         content = case block.blockKind of
@@ -3153,28 +3168,57 @@ drawBlock state target ui block =
                                         block.blockId)
                                     block.blockBody)
             BlockThinking ->
-                accentMarkdownBlock (thinkingBlockAttr state target block)
+                accentMarkdownBlock
+                    state
+                    target
+                    ui
+                    block
+                    waveElapsed
+                    (thinkingBlockAttr state target block)
                     (blockStateGlyph state target block <> block.blockTitle)
                     (visibleBody block)
             BlockTool ->
-                accentBlock (statusAttr state target block)
+                accentBlock
+                    state
+                    target
+                    ui
+                    block
+                    waveElapsed
+                    (statusAttr state target block)
                     (blockStateGlyph state target block
                         <> block.blockTitle
                         <> detailSuffix block)
                     (visibleBody block)
             BlockTodo ->
-                accentBlockWithSections (statusAttr state target block)
+                accentBlockWithSections
+                    state
+                    target
+                    ui
+                    block
+                    waveElapsed
+                    (statusAttr state target block)
                     (blockStateGlyph state target block <> block.blockTitle)
                     (todoBodyWidgets block)
             BlockShell ->
                 accentCodeBlock
+                    state
+                    target
+                    ui
+                    block
                     state.appSyntaxHighlighter
+                    waveElapsed
                     (statusAttr state target block)
                     (blockStateGlyph state target block <> block.blockTitle)
                     block.blockDetail
                     (visibleShellBody block)
             BlockEdit ->
-                accentBlock (statusAttr state target block)
+                accentBlock
+                    state
+                    target
+                    ui
+                    block
+                    waveElapsed
+                    (statusAttr state target block)
                     (blockStateGlyph state target block
                         <> block.blockTitle
                         <> detailSuffix block)
@@ -3184,6 +3228,11 @@ drawBlock state target ui block =
                     (terminalTxtWrap block.blockBody)
             BlockRecap ->
                 accentBlock
+                    state
+                    target
+                    ui
+                    block
+                    waveElapsed
                     (statusAttr state target block)
                     (blockStateGlyph state target block <> "Recap")
                     (visibleBody block)
@@ -3301,29 +3350,65 @@ blockStateGlyph state target block = case block.blockState of
                 state.appMotionElapsedMillis
                 <> " "
 
-accentBlock :: AttrName -> Text -> Text -> Widget Name
-accentBlock accent title body =
-    accentBlockWithSections accent title $
+accentBlock
+    :: AppState
+    -> AgentTarget
+    -> UiState
+    -> UiBlock
+    -> Maybe Int
+    -> AttrName
+    -> Text
+    -> Text
+    -> Widget Name
+accentBlock state target ui block waveElapsed accent title body =
+    accentBlockWithSections state target ui block waveElapsed accent title $
         if Text.null (Text.strip body)
             then []
             else [terminalTxtWrap body]
 
-accentMarkdownBlock :: AttrName -> Text -> Text -> Widget Name
-accentMarkdownBlock accent title body =
-    accentBlockWithSections accent title $
+accentMarkdownBlock
+    :: AppState
+    -> AgentTarget
+    -> UiState
+    -> UiBlock
+    -> Maybe Int
+    -> AttrName
+    -> Text
+    -> Text
+    -> Widget Name
+accentMarkdownBlock state target ui block waveElapsed accent title body =
+    accentBlockWithSections state target ui block waveElapsed accent title $
         if Text.null (Text.strip body)
             then []
-            else [markdownWidgetWithLinks MarkdownLink body]
+            else
+                [ withAttr Theme.thinkingBodyAttr $
+                    markdownWidgetWithLinks MarkdownLink body
+                ]
 
 accentCodeBlock
-    :: Maybe SyntaxHighlighter
+    :: AppState
+    -> AgentTarget
+    -> UiState
+    -> UiBlock
+    -> Maybe SyntaxHighlighter
+    -> Maybe Int
     -> AttrName
     -> Text
     -> Text
     -> Text
     -> Widget Name
-accentCodeBlock syntaxHighlighter accent title code body =
-    accentBlockWithSections accent title $
+accentCodeBlock
+    state
+    target
+    ui
+    block
+    syntaxHighlighter
+    waveElapsed
+    accent
+    title
+    code
+    body =
+    accentBlockWithSections state target ui block waveElapsed accent title $
         [ codeWidgetWithSyntaxHighlighting syntaxHighlighter "haskell" code
         | not (Text.null (Text.strip code))
         ]
@@ -3332,18 +3417,75 @@ accentCodeBlock syntaxHighlighter accent title code body =
                ]
 
 accentBlockWithSections
-    :: AttrName
+    :: AppState
+    -> AgentTarget
+    -> UiState
+    -> UiBlock
+    -> Maybe Int
+    -> AttrName
     -> Text
     -> [Widget Name]
     -> Widget Name
-accentBlockWithSections accent title sections =
-    hBox
-        [ withAttr accent (txt "❙")
-        , padLeft (Pad 2) $
-            vBox $
-                [withAttr accent (terminalTxtWrap title)]
-                    <> map (padTop (Pad 1)) sections
-        ]
+accentBlockWithSections
+    state
+    target
+    ui
+    block
+    waveElapsed
+    accent
+    title
+    sections =
+    accentRail
+        motionGlyphSet
+        accent
+        state.appRuntime.runtimeWaveTrough
+        waveElapsed $
+        padLeft (Pad 2) $
+            vBox (titleWidget : bodyWidgets)
+  where
+    titleWidget = case waveElapsed of
+        Nothing ->
+            withAttr accent (terminalTxtWrap title)
+        Just elapsedMillis ->
+            waveHeader
+                accent
+                state.appRuntime.runtimeWaveTrough
+                elapsedMillis
+                title
+    paddedBody = map (padTop (Pad 1)) sections
+    bodyWidgets
+        | cacheableRunningBody state target ui block
+        , not (null paddedBody) =
+            [ cached
+                (ConversationBodyCache
+                    target
+                    block.blockId
+                    block.blockExpanded)
+                (vBox paddedBody)
+            ]
+        | otherwise = paddedBody
+
+cacheableRunningBody :: AppState -> AgentTarget -> UiState -> UiBlock -> Bool
+cacheableRunningBody state target ui block =
+    block.blockState == BlockRunning
+        && maybe
+            True
+            ((/= block.blockId) . (.retryCountdownBlockId))
+            ui.uiRetryCountdown
+        && not (blockFlashing state target block)
+
+accentWaveElapsed :: AppState -> AgentTarget -> UiBlock -> Maybe Int
+accentWaveElapsed state target block
+    | not (nativeProgressAnimationEnabled effectiveMode) = Nothing
+    | target == AgentRoot && userActionPending state = Nothing
+    | block.blockState `elem` [BlockRunning, BlockStreaming] =
+        Just state.appMotionElapsedMillis
+    | otherwise = Nothing
+  where
+    effectiveMode =
+        motionModeForTerminalFocus
+            state.appTerminalFocus
+            state.appRuntime.runtimeMotionMode
 
 visibleBody :: UiBlock -> Text
 visibleBody block
@@ -3873,12 +4015,20 @@ waitingOverlayLabel :: AppState -> Text -> Widget Name
 waitingOverlayLabel state label =
     hBox
         [ txt " "
-        , withAttr (waitingIndicatorAttr state) $
-            txt
-                (waitingIndicator
-                    motionGlyphSet
-                    state.appRuntime.runtimeMotionMode
+        , raw
+            ( V.char
+                (Theme.waitingPulseAttr
+                    state.appRuntime.runtimeWaveTrough
                     state.appMotionElapsedMillis)
+                ( case Text.uncons
+                    (waitingIndicator
+                        motionGlyphSet
+                        state.appRuntime.runtimeMotionMode
+                        state.appMotionElapsedMillis) of
+                    Just (character, _) -> character
+                    Nothing -> '◆'
+                )
+            )
         , terminalTxt (" " <> label <> " ")
         ]
 

--- a/packages/agent-cli/src/Agent/CLI/TUI/LambdaArt.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/LambdaArt.hs
@@ -4,6 +4,7 @@ module Agent.CLI.TUI.LambdaArt
     ) where
 
 import Agent.CLI.TUI.Types (Name)
+import Agent.TUI.Motion (shineOpacity)
 import qualified Agent.TUI.Theme as Theme
 import Brick (Widget)
 import qualified Brick.Types as B
@@ -27,7 +28,7 @@ data LambdaPalette = LambdaPalette
     }
 
 lambdaArtWidget :: Int -> Widget Name
-lambdaArtWidget frame =
+lambdaArtWidget elapsedMillis =
     B.Widget B.Fixed B.Fixed do
         context <- B.getContext
         dimAttr <- B.lookupAttrName Theme.lambdaDimAttr
@@ -49,12 +50,13 @@ lambdaArtWidget frame =
                     composition.lambdaLowerHeight
                     composition.lambdaStrokeWidth
             logoWidth = maximum (0 : map length rows)
+            logoHeight = length rows
             canvasWidth = logoWidth + 2 * composition.lambdaMarginX
-            canvasHeight = length rows + 2 * composition.lambdaMarginY
+            canvasHeight = logoHeight + 2 * composition.lambdaMarginY
             particles =
                 lambdaOrbitParticles
                     palette
-                    frame
+                    (elapsedMillis `div` 160)
                     canvasWidth
                     canvasHeight
                     composition.lambdaHasOrbit
@@ -63,9 +65,11 @@ lambdaArtWidget frame =
                     [ V.horizCat
                         [ renderLambdaCell
                             palette
-                            frame
+                            elapsedMillis
                             composition
                             rows
+                            logoWidth
+                            logoHeight
                             particles
                             x
                             y
@@ -145,11 +149,22 @@ renderLambdaCell
     -> Int
     -> LambdaComposition
     -> [String]
+    -> Int
+    -> Int
     -> [((Int, Int), Char, V.Attr)]
     -> Int
     -> Int
     -> V.Image
-renderLambdaCell palette frame composition rows particles x y =
+renderLambdaCell
+    palette
+    elapsedMillis
+    composition
+    rows
+    logoWidth
+    logoHeight
+    particles
+    x
+    y =
     case lambdaLogoChar rows composition.lambdaMarginX
         composition.lambdaMarginY x y of
         ' ' ->
@@ -167,7 +182,9 @@ renderLambdaCell palette frame composition rows particles x y =
                 (attr, animatedCharacter) =
                     animatedLambdaStroke
                         palette
-                        frame
+                        elapsedMillis
+                        logoWidth
+                        logoHeight
                         localX
                         localY
                         character
@@ -192,36 +209,30 @@ animatedLambdaStroke
     -> Int
     -> Int
     -> Int
+    -> Int
+    -> Int
     -> Char
     -> (V.Attr, Char)
-animatedLambdaStroke palette frame x y character
-    | distance == 0 =
-        (palette.lambdaSpark, energizedStroke character)
-    | distance <= 2 =
-        (palette.lambdaGlow, character)
-    | distance <= 5 =
-        (palette.lambdaTrail, character)
-    | otherwise =
-        (palette.lambdaDim, character)
+animatedLambdaStroke palette elapsedMillis width height x y character =
+    ( Theme.interpolateForeground
+        palette.lambdaDim
+        palette.lambdaSpark
+        opacity
+    , if opacity >= 0.24
+        then energizedStroke character
+        else character
+    )
   where
-    period = 36
-    phase = frame `mod` period
-    oppositePhase = (phase + period `div` 2) `mod` period
-    cellPhase = (y * 5 + x * 3) `mod` period
-    distance =
-        min
-            (circularDistance period phase cellPhase)
-            (circularDistance period oppositePhase cellPhase)
+    diagonal =
+        (fromIntegral x + fromIntegral (max 0 (height - 1 - y)))
+            / fromIntegral (max 1 (width + height))
+    opacity =
+        shineOpacity diagonal (fromIntegral (max 0 elapsedMillis) / 1000)
 
 energizedStroke :: Char -> Char
 energizedStroke = \case
     '_' -> '='
     _ -> '*'
-
-circularDistance :: Int -> Int -> Int -> Int
-circularDistance period left right =
-    let direct = abs (left - right)
-    in min direct (period - direct)
 
 lambdaOrbitParticles
     :: LambdaPalette

--- a/packages/agent-cli/src/Agent/CLI/TUI/LambdaArt.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/LambdaArt.hs
@@ -27,8 +27,8 @@ data LambdaPalette = LambdaPalette
     , lambdaSpark :: !V.Attr
     }
 
-lambdaArtWidget :: Int -> Widget Name
-lambdaArtWidget elapsedMillis =
+lambdaArtWidget :: Bool -> Int -> Widget Name
+lambdaArtWidget colorEnabled elapsedMillis =
     B.Widget B.Fixed B.Fixed do
         context <- B.getContext
         dimAttr <- B.lookupAttrName Theme.lambdaDimAttr
@@ -64,6 +64,7 @@ lambdaArtWidget elapsedMillis =
                 V.vertCat
                     [ V.horizCat
                         [ renderLambdaCell
+                            colorEnabled
                             palette
                             elapsedMillis
                             composition
@@ -145,7 +146,8 @@ buildSolidLambdaRows upperHeight lowerHeight strokeWidth =
         mainStart + index
 
 renderLambdaCell
-    :: LambdaPalette
+    :: Bool
+    -> LambdaPalette
     -> Int
     -> LambdaComposition
     -> [String]
@@ -156,6 +158,7 @@ renderLambdaCell
     -> Int
     -> V.Image
 renderLambdaCell
+    colorEnabled
     palette
     elapsedMillis
     composition
@@ -181,6 +184,7 @@ renderLambdaCell
                 localY = y - composition.lambdaMarginY
                 (attr, animatedCharacter) =
                     animatedLambdaStroke
+                        colorEnabled
                         palette
                         elapsedMillis
                         logoWidth
@@ -205,7 +209,8 @@ lambdaLogoChar rows marginX marginY x y
     localY = y - marginY
 
 animatedLambdaStroke
-    :: LambdaPalette
+    :: Bool
+    -> LambdaPalette
     -> Int
     -> Int
     -> Int
@@ -213,8 +218,9 @@ animatedLambdaStroke
     -> Int
     -> Char
     -> (V.Attr, Char)
-animatedLambdaStroke palette elapsedMillis width height x y character =
+animatedLambdaStroke colorEnabled palette elapsedMillis width height x y character =
     ( Theme.interpolateForeground
+        colorEnabled
         palette.lambdaDim
         palette.lambdaSpark
         opacity

--- a/packages/agent-cli/src/Agent/CLI/TUI/Render.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Render.hs
@@ -1251,11 +1251,12 @@ drawEmptyConversation state =
                         vBox
                             [ vLimit
                                 (max 8 (height - quickStartReservedRows))
-                                (hCenter (lambdaArtWidget frame))
+                                (hCenter (lambdaArtWidget colorEnabled frame))
                             , hCenter (drawQuickStartPanel state)
                             ]
-                else center (lambdaArtWidget frame)
+                else center (lambdaArtWidget colorEnabled frame)
   where
+    colorEnabled = state.appRuntime.runtimeColor
     frame
         | userActionPending state = 0
         | otherwise =

--- a/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
@@ -52,6 +52,7 @@ import Data.Sequence (Seq)
 import Data.Text (Text)
 import Data.Time.Clock (NominalDiffTime)
 import Data.Word (Word64)
+import qualified Graphics.Vty as V
 
 data Name
     = ConversationViewport
@@ -68,6 +69,10 @@ data Name
         !Bool
         !Bool
         !(Maybe (Int, Bool))
+    | ConversationBodyCache
+        !AgentTarget
+        !BlockId
+        !Bool
     | CodeBlockCache !AgentTarget !BlockId !Int
     | CodeCopy !AgentTarget !BlockId !Int
     | MarkdownLink !Text
@@ -198,6 +203,7 @@ data FullscreenRuntime = FullscreenRuntime
     , runtimeImagePreviewIdBase :: !Int
     , runtimeNativeImagePreviews :: !Bool
     , runtimeColor :: !Bool
+    , runtimeWaveTrough :: !V.Color
     , runtimeLoadSyntaxHighlighter
         :: !(IO (Either Text SyntaxHighlighter))
     , runtimeSyntaxLoadFinished :: !(NominalDiffTime -> IO ())

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -408,14 +408,14 @@ spec = do
         it "crops the empty-conversation art to tiny render contexts" do
             let image =
                     V.picImage $
-                        renderWidget Nothing [lambdaArtWidget 0] (5, 3)
+                        renderWidget Nothing [lambdaArtWidget True 0] (5, 3)
             V.imageWidth image `shouldSatisfy` (<= 5)
             V.imageHeight image `shouldSatisfy` (<= 3)
 
         it "sweeps the empty-conversation sheen over time" do
             let rendered elapsed =
                     show $
-                        renderWidget Nothing [lambdaArtWidget elapsed] (42, 21)
+                        renderWidget Nothing [lambdaArtWidget True elapsed] (42, 21)
             rendered 0 `shouldNotBe` rendered 400
 
         it "shows quick-start actions only when the empty pane has room" do

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -374,6 +374,12 @@ spec = do
             V.imageWidth image `shouldSatisfy` (<= 5)
             V.imageHeight image `shouldSatisfy` (<= 3)
 
+        it "sweeps the empty-conversation sheen over time" do
+            let rendered elapsed =
+                    show $
+                        renderWidget Nothing [lambdaArtWidget elapsed] (42, 21)
+            rendered 0 `shouldNotBe` rendered 400
+
         it "shows quick-start actions only when the empty pane has room" do
             quickStartVisible 100 30 `shouldBe` True
             quickStartVisible 47 30 `shouldBe` False

--- a/packages/agent-tui/agent-tui.cabal
+++ b/packages/agent-tui/agent-tui.cabal
@@ -35,7 +35,8 @@ common common-options
 library
     import:           common-options
     hs-source-dirs:   src
-    exposed-modules:  Agent.TUI.FencedCode
+    exposed-modules:  Agent.TUI.Accent
+                    , Agent.TUI.FencedCode
                     , Agent.TUI.Markdown
                     , Agent.TUI.Markdown.Block
                     , Agent.TUI.Markdown.Inline
@@ -58,7 +59,8 @@ test-suite agent-tui-test
     type:             exitcode-stdio-1.0
     hs-source-dirs:   test
     main-is:          Spec.hs
-    other-modules:    Agent.TUI.FencedCodeSpec
+    other-modules:    Agent.TUI.AccentSpec
+                    , Agent.TUI.FencedCodeSpec
                     , Agent.TUI.Markdown.BlockSpec
                     , Agent.TUI.Markdown.InlineSpec
                     , Agent.TUI.MarkdownSpec

--- a/packages/agent-tui/src/Agent/TUI/Accent.hs
+++ b/packages/agent-tui/src/Agent/TUI/Accent.hs
@@ -1,0 +1,78 @@
+-- | Full-height scrollback accent rail, including a traveling brightness wave.
+module Agent.TUI.Accent
+    ( accentRail
+    , waveHeader
+    ) where
+
+import Agent.TUI.Motion
+    ( MotionGlyphSet
+    , accentBarGlyph
+    , waveBrightness
+    , waveRowsFor
+    )
+import qualified Agent.TUI.Theme as Theme
+import Brick
+import qualified Data.Text as Text
+import qualified Graphics.Vty as V
+
+-- | Paint a one-column rail beside @content@, matching that widget's height.
+--
+-- The rail is Fixed vertically so it can live inside a vertical viewport.
+-- @Nothing@ paints a static accent. @Just elapsedMillis@ walks a brightness
+-- wave down the bar for running or streaming blocks.
+accentRail
+    :: MotionGlyphSet
+    -> AttrName
+    -> V.Color
+    -> Maybe Int
+    -> Widget n
+    -> Widget n
+accentRail glyphs attrName trough waveElapsed content =
+    Widget Greedy Fixed do
+        context <- getContext
+        attr <- lookupAttrName attrName
+        let innerWidth = max 0 (context.availWidth - 1)
+        inner <- render (hLimit innerWidth content)
+        let
+            height = max 1 (V.imageHeight inner.image)
+            glyph = accentBarChar glyphs
+            peak = Theme.wavePeakFor attrName
+            rows = waveRowsFor height
+            rail = case waveElapsed of
+                Nothing ->
+                    V.charFill attr glyph 1 height
+                Just elapsedMillis ->
+                    V.vertCat
+                        [ Theme.waveCell
+                            trough
+                            peak
+                            (waveBrightness elapsedMillis row rows)
+                            glyph
+                        | row <- [0 .. height - 1]
+                        ]
+            image = V.horizJoin rail inner.image
+        pure (addResultOffset (Location (1, 0)) inner) { image = image }
+
+-- | Live header: the leading spinner rides the same wave as row 0 of the
+-- rail; the rest of the title stays muted so the rail is what moves.
+waveHeader :: AttrName -> V.Color -> Int -> Text.Text -> Widget n
+waveHeader attrName trough elapsedMillis title =
+    case Text.uncons title of
+        Nothing -> emptyWidget
+        Just (glyph, rest) ->
+            hBox
+                [ raw
+                    ( Theme.waveCell
+                        trough
+                        (Theme.wavePeakFor attrName)
+                        (waveBrightness elapsedMillis 0 (waveRowsFor 1))
+                        glyph
+                    )
+                , withAttr Theme.mutedAttr (txtWrap rest)
+                ]
+
+accentBarChar :: MotionGlyphSet -> Char
+accentBarChar glyphs =
+    case Text.uncons (accentBarGlyph glyphs) of
+        Just (character, _) -> character
+        Nothing -> '|'

--- a/packages/agent-tui/src/Agent/TUI/Motion.hs
+++ b/packages/agent-tui/src/Agent/TUI/Motion.hs
@@ -17,13 +17,20 @@ module Agent.TUI.Motion
     , motionDelayMicros
     , motionIntervalMicros
     , nativeProgressAnimationEnabled
+    , accentBarGlyph
+    , pulseBrightness
     , quietIndicator
     , quietSpinnerFrames
+    , shineOpacity
     , transientNoticeDurationMillis
     , waitingIndicator
     , waitingPulseFrames
+    , waveBrightness
+    , waveRows
+    , waveRowsFor
     ) where
 
+import Data.Fixed (mod')
 import Data.Text (Text)
 import Data.List.NonEmpty (NonEmpty(..))
 import qualified Data.List.NonEmpty as NonEmpty
@@ -131,11 +138,10 @@ waitingIndicator
     -> MotionMode
     -> Int
     -> Text
-waitingIndicator =
-    motionIndicator
-        waitingFrameDurationMillis
-        waitingPulseFamily
-        staticWaiting
+waitingIndicator glyphs _mode _elapsed =
+    -- Keep a static diamond; color renderers breathe its brightness instead
+    -- of cycling glyphs.
+    staticWaiting glyphs
 
 motionIndicator
     :: Int
@@ -161,13 +167,13 @@ motionFrameAt frameDurationMillis elapsedMillis frames =
         !! ((max 0 elapsedMillis `div` max 1 frameDurationMillis)
             `mod` NonEmpty.length frames)
 
--- | Scheduler cadence. Full motion deliberately stays below 30 FPS until the
--- Brick/Vty cursor-blink path has been audited at that rate.
+-- | Scheduler cadence. Fast is ~30 FPS for live rails; slow is ~12 FPS
+-- for the empty-state sheen.
 motionIntervalMicros :: MotionMode -> MotionDemand -> Int
 motionIntervalMicros mode demand = case (mode, demand) of
     (_, MotionNone) -> 1000000
-    (MotionFull, MotionSlow) -> 160000
-    (MotionFull, MotionFast) -> 80000
+    (MotionFull, MotionSlow) -> 80000
+    (MotionFull, MotionFast) -> 33000
     (MotionReduced, _) -> 500000
     (MotionOff, _) -> 1000000
 
@@ -209,9 +215,6 @@ quietFrameDurationMillis = 160
 backgroundFrameDurationMillis :: Int
 backgroundFrameDurationMillis = 320
 
-waitingFrameDurationMillis :: Int
-waitingFrameDurationMillis = 320
-
 staticForeground :: MotionGlyphSet -> Text
 staticForeground = \case
     MotionUnicode -> "●"
@@ -231,3 +234,104 @@ staticWaiting :: MotionGlyphSet -> Text
 staticWaiting = \case
     MotionUnicode -> "◆"
     MotionAscii -> "!"
+
+-- | Full-height scrollback accent rail. The heavy vertical bar lets a
+-- traveling wave paint every row without shifting layout.
+accentBarGlyph :: MotionGlyphSet -> Text
+accentBarGlyph = \case
+    MotionUnicode -> "┃"
+    MotionAscii -> "|"
+
+-- | Rows per wave cycle on a live accent rail. Lower is a tighter/faster
+-- spatial period.
+waveRows :: Int
+waveRows = 32
+
+-- | Tighten the spatial period on short rails so a 4–6 row thinking
+-- block still shows a traveling highlight instead of a flat pulse.
+waveRowsFor :: Int -> Int
+waveRowsFor height =
+    max 8 (min waveRows (max 1 height * 3))
+
+-- | 0.15 rad/tick at 30fps.
+waveRadiansPerSecond :: Double
+waveRadiansPerSecond = 0.15 * 30
+
+-- | 0.08 rad/tick at 30fps, about 1.3s per visible pulse.
+pulseRadiansPerSecond :: Double
+pulseRadiansPerSecond = 0.08 * 30
+
+-- | Traveling-wave brightness in @[0, 1]@ for one rail row.
+--
+-- @sin²(t + phase)@ with a per-row phase so the bright band walks down
+-- the rail independently of block height.
+waveBrightness
+    :: Int
+    -- ^ Elapsed milliseconds.
+    -> Int
+    -- ^ Row within the block, 0 = top.
+    -> Int
+    -- ^ Rows per full wave cycle.
+    -> Double
+waveBrightness elapsedMillis row rowsPerCycle =
+    let
+        rows = fromIntegral (max 1 rowsPerCycle)
+        phase = (fromIntegral row / rows) * 2 * pi
+        t = seconds elapsedMillis * waveRadiansPerSecond
+        sine = sin (t + phase)
+    in sine * sine
+
+-- | Temporal pulse in @[0, 1]@ shared by every "waiting on you" cue.
+pulseBrightness :: Int -> Double
+pulseBrightness elapsedMillis =
+    let
+        t = seconds elapsedMillis * pulseRadiansPerSecond
+        sine = sin t
+    in sine * sine
+
+-- | Diagonal sheen opacity in @[0, 1]@ for empty-state logo art.
+--
+-- A raised-cosine band sweeps bottom-left → top-right, then parks
+-- off-screen while a small global pulse keeps the glyph breathing.
+shineOpacity
+    :: Double
+    -- ^ Normalized diagonal position, 0 = bottom-left, 1 = top-right.
+    -> Double
+    -- ^ Seconds since the animation started.
+    -> Double
+shineOpacity diag secs =
+    let
+        p = (secs `mod'` shineCycleSeconds) / shineCycleSeconds
+        q = min 1.0 (p / shineSweepFrac)
+        bandPos = negate shineBandHalf + q * (1.0 + 2.0 * shineBandHalf)
+        pulse =
+            shinePulseAmount
+                * (0.5 - 0.5 * cos (2 * pi * secs / shinePulseSeconds))
+        distance = abs (diag - bandPos)
+        shine
+            | distance < shineBandHalf =
+                0.5 * (1.0 + cos (pi * distance / shineBandHalf))
+            | otherwise = 0.0
+    in max 0.0 (min 1.0 (pulse + shinePeak * shine))
+
+shineBandHalf :: Double
+shineBandHalf = 0.38
+
+shineCycleSeconds :: Double
+shineCycleSeconds = 4.0
+
+shineSweepFrac :: Double
+shineSweepFrac = 0.32
+
+shinePeak :: Double
+shinePeak = 0.33
+
+shinePulseAmount :: Double
+shinePulseAmount = 0.06
+
+shinePulseSeconds :: Double
+shinePulseSeconds = 5.0
+
+seconds :: Int -> Double
+seconds elapsedMillis =
+    fromIntegral (max 0 elapsedMillis) / 1000

--- a/packages/agent-tui/src/Agent/TUI/Theme.hs
+++ b/packages/agent-tui/src/Agent/TUI/Theme.hs
@@ -328,6 +328,7 @@ waitingPulseAttr True mode trough elapsedMillis
         V.defAttr `V.withForeColor` waitingAccentPeak
     | otherwise =
         waveForegroundFrom
+            True
             trough
             waitingAccentPeak
             (0.3 + 0.7 * pulseBrightness elapsedMillis)
@@ -342,7 +343,7 @@ waveCell True trough peak brightness glyph
     | brightness <= 0.04 =
         V.char V.defAttr ' '
     | otherwise =
-        V.char (waveForegroundFrom trough peak brightness) glyph
+        V.char (waveForegroundFrom True trough peak brightness) glyph
 
 wavePeakFor :: AttrName -> V.Color
 wavePeakFor attr
@@ -351,11 +352,14 @@ wavePeakFor attr
 
 -- | Paint a live accent cell at the given traveling-wave brightness.
 --
--- Blends peak toward trough as 24-bit sRGB (@RGBColor@, not Vty's linear
--- conversion). Brightness 0 is the trough, 1 is the peak — no extra floor,
--- so the bar can disappear into the page.
-waveForegroundFrom :: V.Color -> V.Color -> Double -> V.Attr
-waveForegroundFrom trough peak brightness =
+-- When color is enabled, blends peak toward trough as 24-bit sRGB
+-- (@RGBColor@, not Vty's linear conversion). Brightness 0 is the trough,
+-- 1 is the peak. When color is disabled, keep the default attribute so
+-- @NO_COLOR@ / monochrome maps are not bypassed by raw RGB.
+waveForegroundFrom :: Bool -> V.Color -> V.Color -> Double -> V.Attr
+waveForegroundFrom False _ _ _ =
+    V.defAttr
+waveForegroundFrom True trough peak brightness =
     case blendRgb trough peak (max 0.0 (min 1.0 brightness)) of
         Just blended -> V.defAttr `V.withForeColor` blended
         Nothing -> V.defAttr `V.withForeColor` peak
@@ -368,15 +372,17 @@ waveForeground bgAttr fgAttr brightness =
             let
                 peak = brightenColor fg
                 trough = fromMaybe waveTrough (backgroundColor bgAttr)
-            in waveForegroundFrom trough peak brightness
+            in waveForegroundFrom True trough peak brightness
         Nothing ->
             styleSteps fgAttr (max 0.0 (min 1.0 brightness))
 
 -- | Blend @from@'s foreground toward @to@'s foreground. Used for the empty
 -- conversation sheen so the highlight sweeps instead of jumping between
 -- four named attributes.
-interpolateForeground :: V.Attr -> V.Attr -> Double -> V.Attr
-interpolateForeground fromAttr toAttr opacity =
+interpolateForeground :: Bool -> V.Attr -> V.Attr -> Double -> V.Attr
+interpolateForeground False fromAttr toAttr opacity =
+    if opacity >= 0.5 then toAttr else fromAttr
+interpolateForeground True fromAttr toAttr opacity =
     case (attrColor (V.attrForeColor fromAttr), attrColor (V.attrForeColor toAttr)) of
         (Just from, Just to) ->
             case blendRgb from to opacity of

--- a/packages/agent-tui/src/Agent/TUI/Theme.hs
+++ b/packages/agent-tui/src/Agent/TUI/Theme.hs
@@ -39,6 +39,7 @@ module Agent.TUI.Theme
     , syntaxWarningAttr
     , syntaxClassAttr
     , thinkingAttr
+    , thinkingBodyAttr
     , todoCancelledAttr
     , todoCompletedAttr
     , todoInProgressAttr
@@ -48,18 +49,35 @@ module Agent.TUI.Theme
     , userMutedAttr
     , waitingDimAttr
     , waitingMidAttr
+    , waitingPulseAttr
     , completionFlashAttr
     , monochrome
     , terminalDefault
+    , interpolateForeground
+    , runningWavePeak
+    , thinkingWavePeak
+    , waitingAccentPeak
+    , waveCell
+    , waveForeground
+    , waveForegroundFrom
+    , wavePeakFor
+    , waveTrough
+    , waveTroughFromColorFgBg
     ) where
 
 import Agent.Syntax (SyntaxClass(..))
+import Agent.TUI.Motion (pulseBrightness)
 import Brick (AttrMap, AttrName, attrMap, attrName)
+import Control.Applicative ((<|>))
 import Data.Bits ((.|.))
+import Data.Maybe (fromMaybe)
+import Data.Word (Word8)
+import Text.Read (readMaybe)
 import qualified Graphics.Vty as V
+import Graphics.Vty.Attributes.Color (Color(..))
 
 baseAttr, headerAttr, footerAttr, mutedAttr :: AttrName
-userAttr, userMutedAttr, assistantAttr, thinkingAttr, toolAttr :: AttrName
+userAttr, userMutedAttr, assistantAttr, thinkingAttr, thinkingBodyAttr, toolAttr :: AttrName
 todoPendingAttr, todoInProgressAttr, todoCompletedAttr, todoCancelledAttr :: AttrName
 errorAttr, successAttr, selectedAttr, borderAttr, borderActiveAttr :: AttrName
 headingAttr, codeAttr, dimAttr, emphasisAttr, inlineCodeAttr, linkAttr, strongAttr :: AttrName
@@ -78,6 +96,7 @@ userAttr = attrName "user"
 userMutedAttr = attrName "user-muted"
 assistantAttr = attrName "assistant"
 thinkingAttr = attrName "thinking"
+thinkingBodyAttr = attrName "thinking-body"
 toolAttr = attrName "tool"
 todoPendingAttr = attrName "todo-pending"
 todoInProgressAttr = attrName "todo-in-progress"
@@ -149,6 +168,7 @@ terminalDefault =
         , (userMutedAttr, userPanelAttr `V.withStyle` V.dim)
         , (assistantAttr, V.defAttr)
         , (thinkingAttr, palette V.yellow)
+        , (thinkingBodyAttr, palette V.brightBlack `V.withStyle` (V.dim .|. V.italic))
         , (waitingDimAttr, palette V.brightBlack)
         , (waitingMidAttr, palette V.yellow)
         , (toolAttr, palette V.cyan)
@@ -207,6 +227,7 @@ monochrome =
         , (userMutedAttr, V.defAttr `V.withStyle` V.dim)
         , (assistantAttr, V.defAttr)
         , (thinkingAttr, V.defAttr)
+        , (thinkingBodyAttr, V.defAttr `V.withStyle` (V.dim .|. V.italic))
         , (waitingDimAttr, V.defAttr)
         , (waitingMidAttr, V.defAttr)
         , (toolAttr, V.defAttr)
@@ -255,8 +276,189 @@ monochrome =
 palette :: V.Color -> V.Attr
 palette = V.withForeColor V.defAttr
 
--- | Grok-style user-prompt panel: a full-width wash one step off the page
--- background. Bright black is the ANSI gray slot, so Ghostty light/dark
--- palettes keep the card readable without fixing an RGB background.
+-- | User-prompt panel: a full-width wash one step off the page background.
+-- Bright black is the ANSI gray slot, so Ghostty light/dark palettes keep
+-- the card readable without fixing an RGB background.
 userPanelAttr :: V.Attr
 userPanelAttr = V.withBackColor V.defAttr V.brightBlack
+
+-- | Default dark-page trough (#24283b). Live rails blend toward this so the
+-- bar nearly vanishes when @COLORFGBG@ is unavailable.
+waveTrough :: V.Color
+waveTrough = RGBColor 36 40 59
+
+-- | Magenta peak (#bb9af7) for live tool rails, distinct from static chrome.
+runningWavePeak :: V.Color
+runningWavePeak = RGBColor 187 154 247
+
+-- | Quiet gray-blue peak (#3b4261) so reasoning rails sit behind tool rails.
+thinkingWavePeak :: V.Color
+thinkingWavePeak = RGBColor 59 66 97
+
+-- | Blue peak (#7aa2f7) for "waiting on you" diamonds.
+waitingAccentPeak :: V.Color
+waitingAccentPeak = RGBColor 122 162 247
+
+-- | Resolve the rail trough from @COLORFGBG@ (@fg;bg@ ANSI indexes). Missing
+-- or unparsable values keep the default dark trough.
+waveTroughFromColorFgBg :: Maybe String -> V.Color
+waveTroughFromColorFgBg env =
+    maybe waveTrough ansiIndexRgb (env >>= colorFgBgBackground)
+
+colorFgBgBackground :: String -> Maybe Word8
+colorFgBgBackground spec =
+    case break (== ';') spec of
+        (_, ';' : background) ->
+            readMaybe (takeWhile (/= ';') background)
+        _ ->
+            Nothing
+
+ansiIndexRgb :: Word8 -> V.Color
+ansiIndexRgb index =
+    let (red, green, blue)
+            | index <= 15 = ansiRgb index
+            | otherwise = color240Rgb index
+    in RGBColor red green blue
+
+waitingPulseAttr :: V.Color -> Int -> V.Attr
+waitingPulseAttr trough elapsedMillis =
+    waveForegroundFrom
+        trough
+        waitingAccentPeak
+        (0.3 + 0.7 * pulseBrightness elapsedMillis)
+
+-- | Paint a rail cell. Near-zero brightness uses a default-attr space so the
+-- bar disappears into the real page even when the trough RGB is approximate.
+waveCell :: V.Color -> V.Color -> Double -> Char -> V.Image
+waveCell trough peak brightness glyph
+    | brightness <= 0.04 =
+        V.char V.defAttr ' '
+    | otherwise =
+        V.char (waveForegroundFrom trough peak brightness) glyph
+
+wavePeakFor :: AttrName -> V.Color
+wavePeakFor attr
+    | attr == thinkingAttr = thinkingWavePeak
+    | otherwise = runningWavePeak
+
+-- | Paint a live accent cell at the given traveling-wave brightness.
+--
+-- Blends peak toward trough as 24-bit sRGB (@RGBColor@, not Vty's linear
+-- conversion). Brightness 0 is the trough, 1 is the peak — no extra floor,
+-- so the bar can disappear into the page.
+waveForegroundFrom :: V.Color -> V.Color -> Double -> V.Attr
+waveForegroundFrom trough peak brightness =
+    case blendRgb trough peak (max 0.0 (min 1.0 brightness)) of
+        Just blended -> V.defAttr `V.withForeColor` blended
+        Nothing -> V.defAttr `V.withForeColor` peak
+
+-- | Semantic-attribute variant used by tests and sheen helpers.
+waveForeground :: V.Attr -> V.Attr -> Double -> V.Attr
+waveForeground bgAttr fgAttr brightness =
+    case attrColor (V.attrForeColor fgAttr) of
+        Just fg ->
+            let
+                peak = brightenColor fg
+                trough = fromMaybe waveTrough (backgroundColor bgAttr)
+            in waveForegroundFrom trough peak brightness
+        Nothing ->
+            styleSteps fgAttr (max 0.0 (min 1.0 brightness))
+
+-- | Blend @from@'s foreground toward @to@'s foreground. Used for the empty
+-- conversation sheen so the highlight sweeps instead of jumping between
+-- four named attributes.
+interpolateForeground :: V.Attr -> V.Attr -> Double -> V.Attr
+interpolateForeground fromAttr toAttr opacity =
+    case (attrColor (V.attrForeColor fromAttr), attrColor (V.attrForeColor toAttr)) of
+        (Just from, Just to) ->
+            case blendRgb from to opacity of
+                Just blended -> withRgb toAttr blended
+                Nothing ->
+                    if opacity >= 0.5 then toAttr else fromAttr
+        _ ->
+            if opacity >= 0.5 then toAttr else fromAttr
+
+backgroundColor :: V.Attr -> Maybe V.Color
+backgroundColor attr =
+    attrColor (V.attrBackColor attr) <|> attrColor (V.attrForeColor attr)
+
+attrColor :: V.MaybeDefault V.Color -> Maybe V.Color
+attrColor = \case
+    V.SetTo color -> Just color
+    _ -> Nothing
+
+styleSteps :: V.Attr -> Double -> V.Attr
+styleSteps attr brightness
+    | brightness < 0.33 = attr `V.withStyle` V.dim
+    | brightness > 0.66 = attr `V.withStyle` V.bold
+    | otherwise = attr
+
+brightenColor :: V.Color -> V.Color
+brightenColor = \case
+    ISOColor n | n < 8 -> ISOColor (n + 8)
+    color -> color
+
+withRgb :: V.Attr -> V.Color -> V.Attr
+withRgb attr color =
+    case attrColor (V.attrBackColor attr) of
+        Just background ->
+            V.defAttr
+                `V.withForeColor` color
+                `V.withBackColor` background
+        Nothing ->
+            V.defAttr `V.withForeColor` color
+
+blendRgb :: V.Color -> V.Color -> Double -> Maybe V.Color
+blendRgb base original opacity = do
+    (baseR, baseG, baseB) <- colorRgb base
+    (origR, origG, origB) <- colorRgb original
+    let
+        mix :: Word8 -> Word8 -> Word8
+        mix from to =
+            round
+                (fromIntegral from
+                    + (fromIntegral to - fromIntegral from) * clamped :: Double)
+        clamped = max 0.0 (min 1.0 opacity)
+    -- Emit sRGB bytes so truecolor terminals get a continuous gradient.
+    pure (RGBColor (mix baseR origR) (mix baseG origG) (mix baseB origB))
+
+colorRgb :: V.Color -> Maybe (Word8, Word8, Word8)
+colorRgb = \case
+    RGBColor red green blue -> Just (red, green, blue)
+    ISOColor n -> Just (ansiRgb n)
+    Color240 n -> Just (color240Rgb n)
+
+-- | xterm defaults for ISO 0–15. Only used when blending truecolor cells;
+-- palette-painted chrome stays on the named ANSI slots.
+ansiRgb :: Word8 -> (Word8, Word8, Word8)
+ansiRgb = \case
+    0 -> (0, 0, 0)
+    1 -> (128, 0, 0)
+    2 -> (0, 128, 0)
+    3 -> (128, 128, 0)
+    4 -> (0, 0, 128)
+    5 -> (128, 0, 128)
+    6 -> (0, 128, 128)
+    7 -> (192, 192, 192)
+    8 -> (128, 128, 128)
+    9 -> (255, 0, 0)
+    10 -> (0, 255, 0)
+    11 -> (255, 255, 0)
+    12 -> (0, 0, 255)
+    13 -> (255, 0, 255)
+    14 -> (0, 255, 255)
+    _ -> (255, 255, 255)
+
+-- | 256-color cube + grayscale ramp.
+color240Rgb :: Word8 -> (Word8, Word8, Word8)
+color240Rgb index
+    | index < 16 = ansiRgb index
+    | index <= 231 =
+        let
+            n = index - 16
+            cube = [0, 95, 135, 175, 215, 255] :: [Word8]
+            at offset = cube !! fromIntegral offset
+        in (at (n `div` 36), at ((n `mod` 36) `div` 6), at (n `mod` 6))
+    | otherwise =
+        let value = 8 + (index - 232) * 10
+        in (value, value, value)

--- a/packages/agent-tui/test/Agent/TUI/AccentSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/AccentSpec.hs
@@ -1,0 +1,72 @@
+module Agent.TUI.AccentSpec (spec) where
+
+import Agent.TUI.Accent (accentRail)
+import Agent.TUI.Motion (MotionGlyphSet(..), accentBarGlyph)
+import qualified Agent.TUI.Theme as Theme
+import Brick
+    ( Widget
+    , renderWidget
+    , str
+    , vBox
+    , viewport
+    )
+import Brick.Types (ViewportType(..))
+import Control.Exception (evaluate)
+import Data.List (isInfixOf)
+import qualified Data.Text as Text
+import qualified Graphics.Vty as V
+import Test.Hspec
+
+spec :: Spec
+spec = describe "accent rail" do
+    it "paints a static one-column bar across the content height" do
+        let widget :: Widget ()
+            widget = sampleRail Nothing 4
+            image =
+                V.picImage $
+                    renderWidget
+                        (Just Theme.terminalDefault)
+                        [widget]
+                        (8, 4)
+        V.imageWidth image `shouldBe` 8
+        V.imageHeight image `shouldBe` 4
+        show image `shouldSatisfy` containsAccentBar
+
+    it "walks brightness down the rail so adjacent wave rows differ" do
+        let rendered elapsed =
+                let widget :: Widget ()
+                    widget = sampleRail (Just elapsed) 8
+                in show $
+                    renderWidget
+                        (Just Theme.terminalDefault)
+                        [widget]
+                        (8, 8)
+            early = rendered 0
+            later = rendered 400
+        early `shouldNotBe` later
+        early `shouldSatisfy` isInfixOf "RGBColor"
+        later `shouldSatisfy` isInfixOf "RGBColor"
+
+    it "fits inside a vertical viewport" do
+        let widget :: Widget ()
+            widget =
+                viewport () Vertical $
+                    sampleRail Nothing 3
+        _ <-
+            evaluate $
+                renderWidget
+                    (Just Theme.terminalDefault)
+                    [widget]
+                    (20, 6)
+        pure ()
+
+sampleRail :: Maybe Int -> Int -> Widget ()
+sampleRail waveElapsed rows =
+    accentRail MotionUnicode Theme.toolAttr Theme.waveTrough waveElapsed $
+        vBox (replicate rows (str "body"))
+
+containsAccentBar :: String -> Bool
+containsAccentBar haystack =
+    let glyph = Text.unpack (accentBarGlyph MotionUnicode)
+    in glyph `isInfixOf` haystack
+        || show glyph `isInfixOf` haystack

--- a/packages/agent-tui/test/Agent/TUI/MotionSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/MotionSpec.hs
@@ -56,14 +56,15 @@ spec = describe "terminal motion vocabulary" do
                     glyphs
                     320
                     (backgroundPulseFrames glyphs)
-                cyclesThrough
-                    waitingIndicator
-                    glyphs
-                    320
-                    (waitingPulseFrames glyphs))
+                waitingIndicator glyphs MotionFull 0
+                    `shouldBe` waitingIndicator glyphs MotionFull 10000)
             [MotionUnicode, MotionAscii]
 
     it "uses fast cadence only when full motion is enabled" do
+        motionIntervalMicros MotionFull MotionFast
+            `shouldBe` 33000
+        motionIntervalMicros MotionFull MotionSlow
+            `shouldBe` 80000
         motionIntervalMicros MotionFull MotionFast
             `shouldSatisfy`
                 (< motionIntervalMicros MotionFull MotionSlow)
@@ -84,6 +85,44 @@ spec = describe "terminal motion vocabulary" do
         nativeProgressAnimationEnabled MotionFull `shouldBe` True
         nativeProgressAnimationEnabled MotionReduced `shouldBe` False
         nativeProgressAnimationEnabled MotionOff `shouldBe` False
+
+    it "keeps the accent rail one terminal cell wide" do
+        mapM_
+            (\glyphs -> do
+                let frame = accentBarGlyph glyphs
+                V.safeWcswidth (Text.unpack frame) `shouldBe` 1
+                V.imageWidth (V.text' V.defAttr frame) `shouldBe` 1)
+            [MotionUnicode, MotionAscii]
+
+    it "tightens the wave period on short rails" do
+        waveRowsFor 4 `shouldSatisfy` (< waveRows)
+        waveRowsFor 4 `shouldSatisfy` (>= 8)
+        waveRowsFor 40 `shouldBe` waveRows
+
+    it "keeps traveling-wave brightness in unit range and spatially offset" do
+        let samples =
+                [ waveBrightness elapsed row waveRows
+                | elapsed <- [0, 80, 400, 1000]
+                , row <- [0 .. 15]
+                ]
+        samples `shouldSatisfy` all (\value -> value >= 0 && value <= 1)
+        waveBrightness 0 0 waveRows
+            `shouldNotBe` waveBrightness 0 8 waveRows
+
+    it "sweeps the logo sheen along the diagonal then rests dim" do
+        let brightest secs =
+                snd $
+                    maximum
+                        [ (shineOpacity (fromIntegral i / 100) secs, fromIntegral i / 100)
+                        | i <- [0 .. 100 :: Int]
+                        ]
+            early = brightest 0.1 :: Double
+            mid = brightest 0.4
+            late = brightest 0.7
+        early < mid `shouldBe` True
+        mid < late `shouldBe` True
+        shineOpacity 0.5 6.0 `shouldSatisfy` (< 0.2)
+        shineOpacity 0.5 0.4 `shouldSatisfy` (\value -> value >= 0 && value <= 1)
 
 allEqual :: Eq a => [a] -> Bool
 allEqual [] = True

--- a/packages/agent-tui/test/Agent/TUI/ThemeSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ThemeSpec.hs
@@ -4,7 +4,9 @@ import Agent.Syntax (SyntaxClass(..))
 import qualified Agent.TUI.Theme as Theme
 import Brick (AttrName)
 import Brick.AttrMap (attrMapLookup)
+import Data.List (nub)
 import qualified Graphics.Vty as V
+import Graphics.Vty.Attributes.Color (Color(..))
 import Test.Hspec
 
 spec :: Spec
@@ -81,9 +83,59 @@ spec = do
                 (attrMapLookup Theme.userMutedAttr Theme.monochrome)
                 `shouldBe` V.Default
 
+    describe "live accent wave" do
+        it "fades a named accent through distinct RGB values" do
+            let tool = attrMapLookup Theme.toolAttr Theme.terminalDefault
+                samples =
+                    [ Theme.waveForeground V.defAttr tool (fromIntegral step / 20)
+                    | step <- [0 .. 20 :: Int]
+                    ]
+                colors = map V.attrForeColor samples
+            length (nub colors) `shouldSatisfy` (> 5)
+            case (samples, reverse samples) of
+                (first : _, lastSample : _) ->
+                    V.attrForeColor first
+                        `shouldNotBe` V.attrForeColor lastSample
+                _ ->
+                    expectationFailure "expected wave samples"
+            colors `shouldSatisfy` all isRgbForeground
+
+        it "uses a magenta running peak and dark trough" do
+            Theme.runningWavePeak `shouldBe` RGBColor 187 154 247
+            Theme.waveTrough `shouldBe` RGBColor 36 40 59
+            Theme.wavePeakFor Theme.thinkingAttr
+                `shouldBe` Theme.thinkingWavePeak
+            Theme.wavePeakFor Theme.toolAttr
+                `shouldBe` Theme.runningWavePeak
+            let trough = Theme.waveForegroundFrom Theme.waveTrough Theme.runningWavePeak 0.0
+                peak = Theme.waveForegroundFrom Theme.waveTrough Theme.runningWavePeak 1.0
+            V.attrForeColor trough `shouldBe` V.SetTo Theme.waveTrough
+            V.attrForeColor peak `shouldBe` V.SetTo Theme.runningWavePeak
+
+        it "reads the page background from COLORFGBG" do
+            Theme.waveTroughFromColorFgBg (Just "15;0")
+                `shouldBe` RGBColor 0 0 0
+            Theme.waveTroughFromColorFgBg (Just "0;15")
+                `shouldBe` RGBColor 255 255 255
+            Theme.waveTroughFromColorFgBg Nothing
+                `shouldBe` Theme.waveTrough
+
+        it "breathes the waiting diamond without leaving the unit range" do
+            let samples =
+                    [ Theme.waitingPulseAttr Theme.waveTrough elapsed
+                    | elapsed <- [0, 200, 650, 1300]
+                    ]
+            length (nub (map V.attrForeColor samples))
+                `shouldSatisfy` (> 1)
+
 terminalForeground :: AttrName -> V.MaybeDefault V.Color
 terminalForeground =
     V.attrForeColor . (`attrMapLookup` Theme.terminalDefault)
+
+isRgbForeground :: V.MaybeDefault V.Color -> Bool
+isRgbForeground = \case
+    V.SetTo RGBColor{} -> True
+    _ -> False
 
 allSyntaxClasses :: [SyntaxClass]
 allSyntaxClasses = [minBound .. maxBound]

--- a/packages/agent-tui/test/Agent/TUI/ThemeSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ThemeSpec.hs
@@ -108,8 +108,8 @@ spec = do
                 `shouldBe` Theme.thinkingWavePeak
             Theme.wavePeakFor Theme.toolAttr
                 `shouldBe` Theme.runningWavePeak
-            let trough = Theme.waveForegroundFrom Theme.waveTrough Theme.runningWavePeak 0.0
-                peak = Theme.waveForegroundFrom Theme.waveTrough Theme.runningWavePeak 1.0
+            let trough = Theme.waveForegroundFrom True Theme.waveTrough Theme.runningWavePeak 0.0
+                peak = Theme.waveForegroundFrom True Theme.waveTrough Theme.runningWavePeak 1.0
             V.attrForeColor trough `shouldBe` V.SetTo Theme.waveTrough
             V.attrForeColor peak `shouldBe` V.SetTo Theme.runningWavePeak
 
@@ -133,6 +133,9 @@ spec = do
                     Theme.waitingPulseAttr True MotionOff Theme.waveTrough 1300
             V.attrForeColor
                 (Theme.waitingPulseAttr False MotionFull Theme.waveTrough 200)
+                `shouldBe` V.Default
+            V.attrForeColor
+                (Theme.waveForegroundFrom False Theme.waveTrough Theme.runningWavePeak 0.8)
                 `shouldBe` V.Default
 
 terminalForeground :: AttrName -> V.MaybeDefault V.Color

--- a/packages/agent-tui/test/Spec.hs
+++ b/packages/agent-tui/test/Spec.hs
@@ -1,5 +1,6 @@
 module Main (main) where
 
+import qualified Agent.TUI.AccentSpec as AccentSpec
 import qualified Agent.TUI.FencedCodeSpec as FencedCodeSpec
 import qualified Agent.TUI.Markdown.BlockSpec as MarkdownBlockSpec
 import qualified Agent.TUI.Markdown.InlineSpec as MarkdownInlineSpec
@@ -13,6 +14,7 @@ import Test.Hspec (hspec)
 
 main :: IO ()
 main = hspec do
+    AccentSpec.spec
     FencedCodeSpec.spec
     MarkdownBlockSpec.spec
     MarkdownInlineSpec.spec


### PR DESCRIPTION
## Summary
- Add a full-height accent rail on live thinking/tool blocks whose truecolor brightness travels down the column at ~30fps.
- Mute live titles, dim thinking bodies, and pulse a static waiting diamond instead of cycling glyphs.
- Hide the turn-status row when idle, show spinner + activity + elapsed/tokens while a turn is running.
- Cache stable running-block bodies so the 30fps path only repaints the rail and header.
- Sweep a diagonal sheen across the empty-conversation lambda.

## Test plan
- [x] `nix develop -c cabal test agent-tui`
- [x] `cabal test agent-cli-test` (bounded custom rendering / motion demand)
- [x] Live tmux TUI: empty-session sheen, then a slow tool turn (`sleep 12; ls`) to watch the rail and status row
- [ ] Confirm waiting-for-you diamond pulses without cycling glyphs
- [ ] Confirm a light `COLORFGBG` (`0;15`) still produces a readable trough