### PR TITLE
fix(core): keep list_dir siblings and correct read_file offsets

### DIFF
--- a/packages/agent-core/agent-core.cabal
+++ b/packages/agent-core/agent-core.cabal
@@ -191,6 +191,8 @@ test-suite agent-core-test
                     , Agent.ToolDispatchSpec
                     , Agent.Tools.DangerousSpec
                     , Agent.Tools.FileSystem.GrepSpec
+                    , Agent.Tools.FileSystem.ListDirSpec
+                    , Agent.Tools.FileSystem.ReadFileSpec
                     , Agent.Tools.GhciSpec
                     , Agent.Tools.IOSpec
                     , Agent.Tools.MultiAgentsSpec

--- a/packages/agent-core/src/Agent/Tools/FileSystem/ListDir.hs
+++ b/packages/agent-core/src/Agent/Tools/FileSystem/ListDir.hs
@@ -1,4 +1,9 @@
-module Agent.Tools.FileSystem.ListDir (listDirTool) where
+module Agent.Tools.FileSystem.ListDir
+    ( listDirTool
+    , DirNode(..)
+    , capNodes
+    , renderTree
+    ) where
 
 import Agent.OsPath (fromText, toText)
 import Agent.ToolArgs (objectArgs, reqText)
@@ -126,19 +131,40 @@ toNode cwd parent (name, isDir) = do
                         children <- collectDir cwd full
                         pure [summarizeDir name children]
 
+-- | Keep as many nodes as @budget@ allows. A directory that does not fit in
+-- full is included as a stub (and maybe a truncated child list) rather than
+-- dropped. Later siblings keep a reserved slot so a large subdirectory cannot
+-- hide the rest of the listing.
 capNodes :: Int -> [DirNode] -> ([DirNode], Bool)
 capNodes budget nodes =
-    let (kept, remaining) = go budget nodes
-    in (kept, remaining <= 0 && countNodes nodes > budget)
-  where
-    go remaining [] = ([], remaining)
-    go remaining _ | remaining <= 0 = ([], remaining)
-    go remaining (node : rest) =
-        let size = countNodes [node]
-            (more, left) = go (remaining - min size remaining) rest
-        in if size > remaining
-            then ([], 0)
-            else (node : more, left)
+    fill (max 0 budget) nodes
+
+fill :: Int -> [DirNode] -> ([DirNode], Bool)
+fill _ [] = ([], False)
+fill remaining _ | remaining <= 0 = ([], True)
+fill remaining (node : rest) =
+    let reserved = min (remaining - 1) (length rest)
+        available = remaining - reserved
+        (keptNode, used, nodeTruncated) = takeNode available node
+        (more, restTruncated) = fill (remaining - used) rest
+    in (keptNode : more, nodeTruncated || restTruncated)
+
+takeNode :: Int -> DirNode -> (DirNode, Int, Bool)
+takeNode budget node = case node of
+    FileNode name -> (FileNode name, 1, False)
+    DirectoryNode name children
+        | budget <= 1 ->
+            ( DirectoryNode name []
+            , 1
+            , not (null children)
+            )
+        | otherwise ->
+            let (keptChildren, truncated) = fill (budget - 1) children
+            in
+                ( DirectoryNode name keptChildren
+                , 1 + countNodes keptChildren
+                , truncated
+                )
 
 countNodes :: [DirNode] -> Int
 countNodes = sum . map \case
@@ -171,18 +197,20 @@ extensionSummary files =
         <> Text.intercalate ", " (take 4 rendered) <> ")"
 
 renderTree :: Int -> [DirNode] -> Text
-renderTree depth = Text.unlines . map (renderNode depth)
+renderTree depth = Text.unlines . concatMap (renderNodeLines depth)
 
-renderNode :: Int -> DirNode -> Text
-renderNode depth = \case
-    FileNode name -> indent <> "- " <> toText name
+renderNodeLines :: Int -> DirNode -> [Text]
+renderNodeLines depth = \case
+    FileNode name -> [indent <> "- " <> toText name]
     DirectoryNode name children ->
-        let header = indent <> "- " <> toText name
-                <> if "/" `Text.isSuffixOf` toText name || "(" `Text.isInfixOf` toText name
-                    then ""
-                    else "/"
-        in if null children
-            then header
-            else header <> "\n" <> renderTree (depth + 1) children
+        (indent <> "- " <> directoryLabel name)
+            : concatMap (renderNodeLines (depth + 1)) children
   where
     indent = Text.replicate depth "  "
+
+directoryLabel :: OsPath -> Text
+directoryLabel name =
+    let label = toText name
+    in if "/" `Text.isSuffixOf` label || "(" `Text.isInfixOf` label
+        then label
+        else label <> "/"

--- a/packages/agent-core/src/Agent/Tools/FileSystem/ListDir.hs
+++ b/packages/agent-core/src/Agent/Tools/FileSystem/ListDir.hs
@@ -137,16 +137,19 @@ toNode cwd parent (name, isDir) = do
 -- hide the rest of the listing.
 capNodes :: Int -> [DirNode] -> ([DirNode], Bool)
 capNodes budget nodes =
-    fill (max 0 budget) nodes
+    fill (max 0 budget) (length nodes) nodes
 
-fill :: Int -> [DirNode] -> ([DirNode], Bool)
-fill _ [] = ([], False)
-fill remaining _ | remaining <= 0 = ([], True)
-fill remaining (node : rest) =
-    let reserved = min (remaining - 1) (length rest)
+-- | @fill remaining restCount nodes@ spends at most @remaining@ slots. @restCount@
+-- is the length of @nodes@, carried so later-sibling reservation stays linear.
+fill :: Int -> Int -> [DirNode] -> ([DirNode], Bool)
+fill _ _ [] = ([], False)
+fill remaining _ _ | remaining <= 0 = ([], True)
+fill remaining restCount (node : rest) =
+    let reserved = min (remaining - 1) (restCount - 1)
         available = remaining - reserved
         (keptNode, used, nodeTruncated) = takeNode available node
-        (more, restTruncated) = fill (remaining - used) rest
+        (more, restTruncated) =
+            fill (remaining - used) (restCount - 1) rest
     in (keptNode : more, nodeTruncated || restTruncated)
 
 takeNode :: Int -> DirNode -> (DirNode, Int, Bool)
@@ -159,7 +162,8 @@ takeNode budget node = case node of
             , not (null children)
             )
         | otherwise ->
-            let (keptChildren, truncated) = fill (budget - 1) children
+            let (keptChildren, truncated) =
+                    fill (budget - 1) (length children) children
             in
                 ( DirectoryNode name keptChildren
                 , 1 + countNodes keptChildren

--- a/packages/agent-core/src/Agent/Tools/FileSystem/ReadFile.hs
+++ b/packages/agent-core/src/Agent/Tools/FileSystem/ReadFile.hs
@@ -1,4 +1,8 @@
-module Agent.Tools.FileSystem.ReadFile (readFileTool) where
+module Agent.Tools.FileSystem.ReadFile
+    ( readFileTool
+    , ReadFileArgs(..)
+    , formatReadFile
+    ) where
 
 import Agent.OsPath (fromText)
 import Agent.ToolArgs (objectArgs, optInt, optText, reqText)
@@ -50,9 +54,9 @@ readFileTool env = withToolResourceClaims (readFileClaims env) $
     [ PropertySchema "target_file" PropertyString True $ Just
         "The path of the file to read. Relative paths use the workspace; absolute paths may resolve within the workspace or session temp directory."
     , PropertySchema "offset" PropertyInteger False $ Just
-        "The line number to start reading from. Only provide if the file is too large to read at once."
+        "The 1-based line number to start reading from. Negative values count from the end of the file (-1 is the last line). Only provide if the file is too large to read at once."
     , PropertySchema "limit" PropertyInteger False $ Just
-        "The number of lines to read. Only provide if the file is too large to read at once."
+        "The number of lines to read, starting at offset. Must be a positive integer. Only provide if the file is too large to read at once."
     ]
     True
     ParallelSafe
@@ -80,6 +84,7 @@ readFileDescription =
     \\n\
     \- The target_file parameter can be relative to the workspace or an absolute path in an allowed filesystem root\n\
     \- By default, it reads up to 1000 lines starting from the beginning of the file\n\
+    \- offset is 1-based. Negative offsets count from the end of the file (-1 is the last line).\n\
     \- Line numbers (1-based) appear as anchors in the format LINE_NUMBER\8594LINE_CONTENT on the first returned line and on every 10th line of the file; the lines in between show content only. Count from the nearest anchor when referring to a specific line"
 
 maxReadLines :: Int
@@ -105,33 +110,43 @@ runReadFile env args = resolveForRead env (fromText args.targetFile) >>= \case
 
 formatReadFile :: Text -> ReadFileArgs -> Either Text Text
 formatReadFile content args =
-    let allLines = Text.splitOn "\n" content
-        total = length allLines
-        start = resolveReadStartLine content args.offset
-        window = drop (start - 1) allLines
-        takeCount = min maxReadLines (fromMaybe maxReadLines args.limit)
-        taken = take takeCount window
-        numbered = formatNumbered start taken
-        tokens = estimateTokens numbered
-        rangeSpecified = args.offset /= Nothing || args.limit /= Nothing
-    in if start > total && total > 0
-        then Right $ "Offset " <> Text.pack (show start)
-            <> " is beyond the end of the file ("
-            <> Text.pack (show total) <> " lines)."
-        else if tokens > maxReadTokens
-            then Left (tokenLimitMessage tokens rangeSpecified args)
-            else Right numbered
+    case args.limit of
+        Just n | n <= 0 ->
+            Left "limit must be a positive integer"
+        _ ->
+            let allLines = readFileLines content
+                total = length allLines
+                start = resolveReadStartLine total args.offset
+                window = drop (start - 1) allLines
+                takeCount = min maxReadLines (fromMaybe maxReadLines args.limit)
+                taken = take takeCount window
+                numbered = formatNumbered start taken
+                tokens = estimateTokens numbered
+                rangeSpecified = args.offset /= Nothing || args.limit /= Nothing
+            in if start > total && total > 0
+                then Right $ "Offset " <> Text.pack (show start)
+                    <> " is beyond the end of the file ("
+                    <> Text.pack (show total) <> " lines)."
+                else if tokens > maxReadTokens
+                    then Left (tokenLimitMessage tokens rangeSpecified args)
+                    else Right numbered
 
-resolveReadStartLine :: Text -> Maybe Int -> Int
-resolveReadStartLine content offset = case fromMaybe 1 offset of
+-- | Split into display lines without treating a POSIX trailing newline as an
+-- extra empty line.
+readFileLines :: Text -> [Text]
+readFileLines content =
+    let fields = Text.splitOn "\n" content
+    in if Text.isSuffixOf "\n" content
+        then case reverse fields of
+            "" : rest -> reverse rest
+            _ -> fields
+        else fields
+
+resolveReadStartLine :: Int -> Maybe Int -> Int
+resolveReadStartLine totalLines offset = case fromMaybe 1 offset of
     0 -> 1
     n | n > 0 -> n
-    n ->
-        let totalFields = length (Text.splitOn "\n" content)
-            extra
-                | not (Text.null content) && not (Text.isSuffixOf "\n" content) = 1
-                | otherwise = 0
-        in max 1 (totalFields + extra + n + 1)
+    n -> max 1 (totalLines + n + 1)
 
 estimateTokens :: Text -> Int
 estimateTokens text = max 1 (Text.length text `div` 4)

--- a/packages/agent-core/test/Agent/Tools/FileSystem/ListDirSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/FileSystem/ListDirSpec.hs
@@ -71,6 +71,15 @@ spec = do
                     ]
             capNodes 10 tree `shouldBe` (tree, False)
 
+        it "keeps a prefix of a large flat listing without walking the tail each step" do
+            let tree =
+                    map
+                        (FileNode . fromText . Text.pack . show)
+                        [1 .. 10000 :: Int]
+                (shown, truncated) = capNodes 5 tree
+            truncated `shouldBe` True
+            map nodeName shown `shouldBe` ["1", "2", "3", "4", "5"]
+
     describe "renderTree" do
         it "does not insert blank lines after nested directories" do
             let tree =

--- a/packages/agent-core/test/Agent/Tools/FileSystem/ListDirSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/FileSystem/ListDirSpec.hs
@@ -1,0 +1,150 @@
+module Agent.Tools.FileSystem.ListDirSpec (spec) where
+
+import Agent.OsPath (fromText, toText)
+import Agent.ToolDispatch
+    ( ToolCallResult(..)
+    , ToolDispatchConfig(..)
+    , dispatchToolCall
+    , functionToolCall
+    )
+import Agent.Tools.FileSystem.ListDir
+    ( DirNode(..)
+    , capNodes
+    , listDirTool
+    , renderTree
+    )
+import Agent.Tools.Types (AppTool(..), defaultToolEnv)
+import Control.Exception.Safe (bracket)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import System.Directory
+    ( createDirectory
+    , getTemporaryDirectory
+    , removeDirectoryRecursive
+    )
+import System.FilePath ((</>))
+import System.OsPath (unsafeEncodeUtf)
+import System.Posix.Temp (mkdtemp)
+import Test.Hspec
+
+spec :: Spec
+spec = do
+    describe "capNodes" do
+        it "keeps a stub for an oversized directory and later siblings" do
+            let packages =
+                    DirectoryNode
+                        (fromText "packages")
+                        (map (FileNode . fromText . Text.pack . show) [1 .. 50 :: Int])
+                tree =
+                    [ FileNode (fromText "LICENSE")
+                    , packages
+                    , FileNode (fromText "patches")
+                    , FileNode (fromText "scripts")
+                    , FileNode (fromText "tests")
+                    ]
+                (shown, truncated) = capNodes 10 tree
+            truncated `shouldBe` True
+            map nodeName shown
+                `shouldBe` ["LICENSE", "packages", "patches", "scripts", "tests"]
+            case shown of
+                _ : packagesNode : _ ->
+                    childCount packagesNode `shouldSatisfy` (< 50)
+                _ -> expectationFailure "expected packages to remain in the listing"
+
+        it "includes a directory name even when no children fit" do
+            let tree =
+                    [ DirectoryNode
+                        (fromText "packages")
+                        [FileNode (fromText "a"), FileNode (fromText "b")]
+                    ]
+                (shown, truncated) = capNodes 1 tree
+            truncated `shouldBe` True
+            map nodeName shown `shouldBe` ["packages"]
+            case shown of
+                [packagesNode] -> childCount packagesNode `shouldBe` 0
+                _ -> expectationFailure "expected only the packages stub"
+
+        it "does not mark a fully visible tree as truncated" do
+            let tree =
+                    [ FileNode (fromText "a")
+                    , DirectoryNode (fromText "docs") [FileNode (fromText "readme")]
+                    ]
+            capNodes 10 tree `shouldBe` (tree, False)
+
+    describe "renderTree" do
+        it "does not insert blank lines after nested directories" do
+            let tree =
+                    [ DirectoryNode
+                        (fromText "docs")
+                        [ DirectoryNode
+                            (fromText "evals")
+                            [FileNode (fromText "ghci-vs-bash.md")]
+                        , FileNode (fromText "ghostty.md")
+                        , FileNode (fromText "nixos.md")
+                        ]
+                    , FileNode (fromText "flake.lock")
+                    ]
+            renderTree 0 tree
+                `shouldBe` Text.unlines
+                    [ "- docs/"
+                    , "  - evals/"
+                    , "    - ghci-vs-bash.md"
+                    , "  - ghostty.md"
+                    , "  - nixos.md"
+                    , "- flake.lock"
+                    ]
+
+    describe "listDirTool" do
+        it "renders nested directories without extra blank lines" do
+            withTempDir \dir -> do
+                let workspace = dir </> "workspace"
+                    docs = workspace </> "docs"
+                    evals = docs </> "evals"
+                createDirectory workspace
+                createDirectory docs
+                createDirectory evals
+                writeFile (evals </> "ghci-vs-bash.md") "ok\n"
+                writeFile (docs </> "ghostty.md") "ok\n"
+                writeFile (workspace </> "flake.lock") "{}\n"
+                env <- defaultToolEnv (unsafeEncodeUtf workspace)
+                result <-
+                    dispatchToolCall testConfig
+                        [(listDirTool env).appToolHandler]
+                        (functionToolCall "list-1" "list_dir"
+                            "{\"target_directory\":\".\"}")
+                result.output
+                    `shouldBe` Text.unlines
+                        [ "Directory listing for .:"
+                        , "- docs/"
+                        , "  - evals/"
+                        , "    - ghci-vs-bash.md"
+                        , "  - ghostty.md"
+                        , "- flake.lock"
+                        ]
+
+nodeName :: DirNode -> Text
+nodeName = \case
+    FileNode name -> toText name
+    DirectoryNode name _ -> toText name
+
+childCount :: DirNode -> Int
+childCount = \case
+    FileNode _ -> 0
+    DirectoryNode _ children -> length children
+
+testConfig :: ToolDispatchConfig
+testConfig = ToolDispatchConfig
+    { toolDispatchUnknownTool = \name -> "unknown:" <> name
+    , toolDispatchFormatResult = either ("ERR " <>) id
+    , toolDispatchFormatException = \name _ -> "EX " <> name
+    , toolDispatchOnException = \_ _ -> pure ()
+    , toolDispatchOnOutput = \_ _ -> pure ()
+    }
+
+withTempDir :: (FilePath -> IO a) -> IO a
+withTempDir action = do
+    base <- getTemporaryDirectory
+    bracket
+        (mkdtemp (base </> "agent-core-listdir-"))
+        removeDirectoryRecursive
+        action

--- a/packages/agent-core/test/Agent/Tools/FileSystem/ReadFileSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/FileSystem/ReadFileSpec.hs
@@ -1,0 +1,71 @@
+module Agent.Tools.FileSystem.ReadFileSpec (spec) where
+
+import Agent.Tools.FileSystem.ReadFile
+    ( ReadFileArgs(..)
+    , formatReadFile
+    )
+import Data.Either (isLeft)
+import qualified Data.Text as Text
+import Test.Hspec
+
+spec :: Spec
+spec = describe "formatReadFile" do
+    it "treats offset -1 as the last content line when the file ends with a newline" do
+        formatReadFile "a\nb\nc\n" (readArgs (Just (-1)) Nothing)
+            `shouldBe` Right "3\8594c"
+
+    it "treats offset -1 as the last content line when the file has no trailing newline" do
+        formatReadFile "a\nb\nc" (readArgs (Just (-1)) Nothing)
+            `shouldBe` Right "3\8594c"
+
+    it "reads the last N lines with a negative offset" do
+        formatReadFile "a\nb\nc\n" (readArgs (Just (-2)) (Just 2))
+            `shouldBe` Right "2\8594b\nc"
+
+    it "clamps an offset past the start of the file to the first line" do
+        formatReadFile "a\nb\nc\n" (readArgs (Just (-80)) (Just 1))
+            `shouldBe` Right "1\8594a"
+
+    it "does not count a trailing newline as an extra empty line" do
+        formatReadFile "a\nb\n" (readArgs (Just 1) Nothing)
+            `shouldBe` Right "1\8594a\nb"
+
+    it "reports when a positive offset is past the last line" do
+        formatReadFile "a\nb\nc\n" (readArgs (Just 4) Nothing)
+            `shouldBe` Right "Offset 4 is beyond the end of the file (3 lines)."
+
+    it "rejects a non-positive limit" do
+        formatReadFile "a\nb\n" (readArgs (Just 1) (Just (-1)))
+            `shouldSatisfy` isLeft
+        formatReadFile "a\nb\n" (readArgs (Just 1) (Just 0))
+            `shouldSatisfy` isLeft
+
+    it "numbers the first line and every tenth line" do
+        let content = Text.unlines (map (Text.pack . show) [1 .. 12 :: Int])
+        formatReadFile content (readArgs Nothing Nothing)
+            `shouldBe` Right
+                ( Text.intercalate "\n"
+                    [ "1\8594" <> "1"
+                    , "2"
+                    , "3"
+                    , "4"
+                    , "5"
+                    , "6"
+                    , "7"
+                    , "8"
+                    , "9"
+                    , "10\8594" <> "10"
+                    , "11"
+                    , "12"
+                    ]
+                )
+
+readArgs :: Maybe Int -> Maybe Int -> ReadFileArgs
+readArgs offset limit =
+    ReadFileArgs
+        { targetFile = "example.txt"
+        , offset = offset
+        , limit = limit
+        , pages = Nothing
+        , format = Nothing
+        }

--- a/packages/agent-core/test/Spec.hs
+++ b/packages/agent-core/test/Spec.hs
@@ -23,6 +23,8 @@ import qualified Agent.ToolDispatchSpec as ToolDispatchSpec
 import qualified Agent.ToolDSLSpec as ToolDSLSpec
 import qualified Agent.Tools.DangerousSpec as DangerousSpec
 import qualified Agent.Tools.FileSystem.GrepSpec as GrepSpec
+import qualified Agent.Tools.FileSystem.ListDirSpec as ListDirSpec
+import qualified Agent.Tools.FileSystem.ReadFileSpec as ReadFileSpec
 import qualified Agent.Tools.GhciSpec as GhciSpec
 import qualified Agent.Tools.IOSpec as IOSpec
 import qualified Agent.Tools.MultiAgentsSpec as MultiAgentsSpec
@@ -55,6 +57,8 @@ main = hspec do
     ToolDispatchSpec.spec
     ToolDSLSpec.spec
     GrepSpec.spec
+    ListDirSpec.spec
+    ReadFileSpec.spec
     GhciSpec.spec
     IOSpec.spec
     MultiAgentsSpec.spec


### PR DESCRIPTION
## Summary
- `list_dir` no longer drops an oversized directory and every later sibling. A directory that does not fit in the 200-node budget is kept as a stub (with truncated children if there is room), and later siblings get reserved slots so a huge `packages/` cannot hide `patches/`, `scripts/`, and `tests/`. Nested listings also no longer pick up extra blank lines from double `Text.unlines`.
- `read_file` no longer treats a POSIX trailing newline as an extra empty line. `offset: -1` is the last content line, with or without a trailing newline. Non-positive `limit` values are rejected.

## Test plan
- [x] `cabal test agent-core:test:agent-core-test --test-options='--match capNodes'`
- [x] `cabal test agent-core:test:agent-core-test --test-options='--match formatReadFile'`
- [x] `cabal test agent-core:test:agent-core-test --test-options='--match renderTree'`
- [x] `cabal test agent-core:test:agent-core-test --test-options='--match listDirTool'`