### PR TITLE
fix(cli): inherit last model for new worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /dist-newstyle/
 /.direnv/
+/.haskell-agent/
 /result
 /result-*
 /eval-results/

--- a/.haskell-agent/settings.json
+++ b/.haskell-agent/settings.json
@@ -1,1 +1,0 @@
-{"autoApprove":false,"lastAccounts":[{"accountId":"claude-code","provider":"claude-code","selectionId":"claude-code"}],"lastModel":{"connection":"claude-code","dialect":"claude-code","model":"fable","provider":"claude-code","transportModel":"fable"},"maxConcurrentAgents":null,"version":1}

--- a/packages/agent-cli/src/Agent/CLI/Options.hs
+++ b/packages/agent-cli/src/Agent/CLI/Options.hs
@@ -286,7 +286,7 @@ optionUpdateParser = asum
     [ optionUpdate "provider" "NAME"
         "Provider: openai, xai, openrouter, or claude-code"
         providerReader (\value options -> options { optProvider = Just value })
-    , optionUpdate "model" "NAME" "Override the saved/default model"
+    , optionUpdate "model" "NAME" "Override the saved last model"
         textReader (\value options -> options { optModel = Just value })
     , optionUpdate "cwd" "DIR" "Working directory for tools"
         pathReader (\value options -> options { optCwd = Just value })
@@ -487,7 +487,7 @@ usage = unlines
     , "      --prompt-file FILE  Read the one-shot prompt from a file"
     , "      --provider NAME     openai, xai, openrouter, or claude-code"
     , "                          (default: detect from API/OAuth auth)"
-    , "      --model NAME        Override the project's saved/default model"
+    , "      --model NAME        Override the saved last model"
     , "      --cwd DIR           Working directory for tools (default: current)"
     , "      --worktree          Create a new git worktree under ~/.haskell-agent/worktrees"
     , "      --resume ID         Resume a persisted session from ~/.haskell-agent/sessions"

--- a/packages/agent-cli/src/Agent/CLI/Project.hs
+++ b/packages/agent-cli/src/Agent/CLI/Project.hs
@@ -1,10 +1,12 @@
--- | Project-scoped settings under @<project>/.haskell-agent/settings.json@.
+-- | Project-scoped settings under @<project>/.haskell-agent/settings.json@,
+-- plus the user-level last model under @~/.haskell-agent/settings.json@.
 module Agent.CLI.Project
     ( ProjectAccount(..)
     , ProjectModel(..)
     , ProjectSettings(..)
     , defaultProjectSettings
     , loadProjectSettings
+    , loadUserSettings
     , projectDialectFor
     , projectAccountFor
     , projectModelFor
@@ -15,6 +17,9 @@ module Agent.CLI.Project
     , saveProjectMaxConcurrentAgents
     , saveProjectAccount
     , saveProjectModel
+    , saveRememberedModel
+    , userSettingsPath
+    , withInheritedLastModel
     ) where
 
 import Agent.FileRetry (retryOnFileBusy, writeLazyFileAtomically)
@@ -67,6 +72,10 @@ projectSettingsPath projectRoot =
     projectRoot
         </> unsafeEncodeUtf ".haskell-agent"
         </> unsafeEncodeUtf "settings.json"
+
+-- | @~/.haskell-agent/settings.json@ given the user's home directory.
+userSettingsPath :: OsPath -> OsPath
+userSettingsPath = projectSettingsPath
 
 data ProjectModel = ProjectModel
     { projectModelTarget :: !ModelTarget
@@ -222,6 +231,22 @@ loadProjectSettings projectRoot = do
                         Left _ -> defaultProjectSettings
                         Right settings -> settings
 
+-- | User-level settings under @~/.haskell-agent/settings.json@.
+loadUserSettings :: OsPath -> IO ProjectSettings
+loadUserSettings = loadProjectSettings
+
+-- | Prefer the checkout's last model. A missing checkout value falls back to
+-- the user-level last model so a freshly created worktree inherits the model
+-- from the previous session instead of catalog or auth defaults.
+withInheritedLastModel
+    :: ProjectSettings
+    -> ProjectSettings
+    -> ProjectSettings
+withInheritedLastModel project user =
+    case project.settingsLastModel of
+        Just _ -> project
+        Nothing -> project { settingsLastModel = user.settingsLastModel }
+
 -- | Persist the project-wide auto-approve flag, creating @.haskell-agent@ as needed.
 saveProjectAutoApprove :: OsPath -> Bool -> IO ()
 saveProjectAutoApprove projectRoot autoApprove =
@@ -277,6 +302,19 @@ saveProjectModel projectRoot target =
             { settingsLastModel = Just ProjectModel
                 { projectModelTarget = target }
             }
+
+-- | Persist the selected model on the current checkout and as the user-level
+-- default so the next freshly created worktree can inherit it.
+saveRememberedModel
+    :: OsPath
+    -- ^ User home (@~/.haskell-agent/settings.json@).
+    -> OsPath
+    -- ^ Checkout root.
+    -> ModelTarget
+    -> IO ()
+saveRememberedModel home projectRoot target = do
+    saveProjectModel projectRoot target
+    saveProjectModel home target
 
 projectModelProvider :: ProjectSettings -> Maybe Provider
 projectModelProvider settings =

--- a/packages/agent-cli/src/Agent/CLI/Provider/Switch.hs
+++ b/packages/agent-cli/src/Agent/CLI/Provider/Switch.hs
@@ -53,7 +53,7 @@ import Agent.CLI.Project
     , loadProjectSettings
     , projectAccountFor
     , resolveProjectRoot
-    , saveProjectModel
+    , saveRememberedModel
     )
 import Agent.CLI.Request (setRequestModel)
 import Agent.CLI.ProviderAvailability
@@ -211,6 +211,7 @@ reportProviderUnavailable fullscreen apiError = do
 
 applyModelChange
     :: OsPath
+    -> OsPath
     -> Provider
     -> Text
     -> Text
@@ -222,11 +223,11 @@ applyModelChange
     -> Persistence
     -> IO Text
 applyModelChange
-        projectRoot provider connection name transportModel dialectId
+        home projectRoot provider connection name transportModel dialectId
         paramsRef render previous persist = do
     modifyIORef' paramsRef (setRequestModel provider name)
     writeIORef render.renderModelRef name
-    saveProjectModel projectRoot ModelTarget
+    saveRememberedModel home projectRoot ModelTarget
         { targetProvider = provider
         , targetConnectionId = connection
         , targetModelId = name
@@ -789,12 +790,13 @@ ensureTransitionSessionId (PersistenceEnabled slotRef) = do
 
 commitProviderTransition
     :: OsPath
+    -> OsPath
     -> Maybe ProviderTransition
     -> Persistence
     -> IO ()
-commitProviderTransition _ Nothing _ = pure ()
-commitProviderTransition projectRoot (Just transition) persist = do
-    saveProjectModel projectRoot transition.transitionTarget
+commitProviderTransition _ _ Nothing _ = pure ()
+commitProviderTransition home projectRoot (Just transition) persist = do
+    saveRememberedModel home projectRoot transition.transitionTarget
     case persist of
         PersistenceDisabled -> pure ()
         PersistenceEnabled slotRef -> do
@@ -832,29 +834,31 @@ commitProviderTransition projectRoot (Just transition) persist = do
 
 prepareTransitionBackend
     :: OsPath
+    -> OsPath
     -> Maybe ProviderTransition
     -> Persistence
     -> Backend
     -> IO Backend
-prepareTransitionBackend _ Nothing _ backend = pure backend
-prepareTransitionBackend projectRoot (Just transition) persist backend
+prepareTransitionBackend _ _ Nothing _ backend = pure backend
+prepareTransitionBackend home projectRoot (Just transition) persist backend
     | transitionCommitsImmediately transition = do
-        commitProviderTransition projectRoot (Just transition) persist
+        commitProviderTransition home projectRoot (Just transition) persist
         pure backend
     | otherwise = do
         committed <- newIORef False
         pure $
             commitBackendOnSuccess
-                projectRoot committed transition persist backend
+                home projectRoot committed transition persist backend
 
 commitBackendOnSuccess
     :: OsPath
+    -> OsPath
     -> IORef Bool
     -> ProviderTransition
     -> Persistence
     -> Backend
     -> Backend
-commitBackendOnSuccess projectRoot committed transition persist (Backend submit) =
+commitBackendOnSuccess home projectRoot committed transition persist (Backend submit) =
     Backend \state previous inputs onEvent -> do
         result <- submit state previous inputs onEvent
         case result of
@@ -862,7 +866,8 @@ commitBackendOnSuccess projectRoot committed transition persist (Backend submit)
                 shouldCommit <- atomicModifyIORef' committed \done ->
                     (True, not done)
                 when shouldCommit $
-                    commitProviderTransition projectRoot (Just transition) persist
+                    commitProviderTransition
+                        home projectRoot (Just transition) persist
             Left _ -> pure ()
         pure result
 

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration.hs
@@ -100,10 +100,12 @@ import Agent.CLI.Project
       ProjectModel(..),
       ProjectSettings(..),
       loadProjectSettings,
+      loadUserSettings,
       projectAccountFor,
       projectModelProvider,
       resolveProjectRoot,
-      saveProjectModel )
+      saveRememberedModel,
+      withInheritedLastModel )
 import Agent.CLI.Prompt
     ( subscriptionSubagentModelGuidance, systemPromptForTools )
 import Agent.CLI.PromptHooks
@@ -1086,12 +1088,16 @@ runAgentInitializedWithLock
         deriveDatabaseScopes stateDirectory projectRootPath >>= \case
             Left err -> startupDie startup (Text.unpack err)
             Right scopes -> pure scopes
-    (projectSettings, (catalogResult, branch)) <-
+    ((projectSettings0, userSettings), (catalogResult, branch)) <-
         concurrently
-            (loadProjectSettings projectRoot)
+            (concurrently
+                (loadProjectSettings projectRoot)
+                (loadUserSettings home))
             (concurrently
                 (loadModelCatalogAt home cwd)
                 (detectGitBranch cwd))
+    let projectSettings =
+            withInheritedLastModel projectSettings0 userSettings
     catalog <- either
         (startupDie startup . Text.unpack)
         pure
@@ -1626,7 +1632,7 @@ runAgentInitializedWithLock
     -- Provider transitions commit their selection separately: manual switches
     -- immediately, automatic fallbacks only after the replacement succeeds.
     when (isNothing transition) $
-        saveProjectModel projectRoot
+        saveRememberedModel home projectRoot
             inferredTarget { targetDialect = dialectId }
     activeSessionLock <- newIORef resumeLock
     persistSlotRef <- newIORef PersistenceDisabled
@@ -2478,7 +2484,7 @@ runAgentInitializedWithLock
                                                 resetCodexTurnState turnState
                                 activeBackend <-
                                     prepareTransitionBackend
-                                        projectRoot transition persist noticingBackend
+                                        home projectRoot transition persist noticingBackend
                                 withAsync switchLoop \switchWorker -> do
                                     link switchWorker
                                     runSession
@@ -2572,7 +2578,7 @@ runAgentInitializedWithLock
                                     focus
                         activeBackend <-
                             prepareTransitionBackend
-                                projectRoot transition persist backend
+                                home projectRoot transition persist backend
                         runSession
                             (sessionRequest
                                 startupUnavailable
@@ -2646,7 +2652,7 @@ runAgentInitializedWithLock
                             \backend -> do
                                 activeBackend <-
                                     prepareTransitionBackend
-                                        projectRoot transition persist backend
+                                        home projectRoot transition persist backend
                                 result <- runSession
                                     (sessionRequest
                                         startupUnavailable
@@ -2743,7 +2749,7 @@ runAgentInitializedWithLock
                                     focus
                         activeBackend <-
                             prepareTransitionBackend
-                                projectRoot transition persist backend
+                                home projectRoot transition persist backend
                         runSession
                             (sessionRequest
                                 startupUnavailable

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Selection.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Selection.hs
@@ -204,6 +204,7 @@ handleSelection
             , sessionParams = paramsRef
             , sessionPersist = persist
             , sessionProjectRoot = projectRoot
+            , sessionHome = home
             , sessionDraft = draftRef
             , sessionAccountId = accountIdRef
             , sessionAccountSelectionId = selectionRef
@@ -259,7 +260,7 @@ handleSelection
                     Right result -> pure result
             else do
                 message <- applyModelChange
-                    projectRoot provider connectionId name
+                    home projectRoot provider connectionId name
                     choice.modelTarget.targetWireModelId
                     choice.modelTarget.targetDialect
                     paramsRef render conversationRef persist
@@ -327,7 +328,7 @@ handleSelection
                             connectionId provider (dialectId dialect) choice)
                   then do
                     message <- applyModelChange
-                        projectRoot provider connectionId
+                        home projectRoot provider connectionId
                         choice.modelTarget.targetModelId
                         choice.modelTarget.targetWireModelId
                         choice.modelTarget.targetDialect

--- a/packages/agent-cli/test/Agent/CLI/ProjectSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ProjectSpec.hs
@@ -50,6 +50,50 @@ spec = describe "Agent.CLI.Project" do
             projectSettingsPath (fromFilePath "/tmp/repo")
                 `shouldBe` fromFilePath "/tmp/repo/.haskell-agent/settings.json"
 
+    describe "userSettingsPath" do
+        it "is <home>/.haskell-agent/settings.json" do
+            userSettingsPath (fromFilePath "/Users/marc")
+                `shouldBe` fromFilePath "/Users/marc/.haskell-agent/settings.json"
+
+    describe "withInheritedLastModel" do
+        it "inherits the user last model when the checkout has none" do
+            let userModel =
+                    ProjectModel
+                        { projectModelTarget =
+                            target XAIProvider "xai"
+                                "grok-4.6" "grok-4.6" GrokBuildDialect
+                        }
+                user = defaultProjectSettings
+                    { settingsLastModel = Just userModel }
+                project = defaultProjectSettings
+                    { settingsAutoApprove = True }
+                merged = withInheritedLastModel project user
+            merged.settingsLastModel `shouldBe` Just userModel
+            merged.settingsAutoApprove `shouldBe` True
+
+        it "keeps a checkout last model instead of the user default" do
+            let checkoutModel =
+                    ProjectModel
+                        { projectModelTarget =
+                            target OpenAIProvider "openai"
+                                "gpt-5.6-sol" "gpt-5.6-sol" CodexDialect
+                        }
+                userModel =
+                    ProjectModel
+                        { projectModelTarget =
+                            target XAIProvider "xai"
+                                "grok-4.6" "grok-4.6" GrokBuildDialect
+                        }
+                user = defaultProjectSettings
+                    { settingsLastModel = Just userModel }
+                project = defaultProjectSettings
+                    { settingsLastModel = Just checkoutModel
+                    , settingsAutoApprove = True
+                    }
+                merged = withInheritedLastModel project user
+            merged.settingsLastModel `shouldBe` Just checkoutModel
+            merged.settingsAutoApprove `shouldBe` True
+
     describe "loadProjectSettings/saveProjectAutoApprove" do
         it "defaults when settings are missing" $
             withTempDir "agent-project-" \root -> do
@@ -113,6 +157,28 @@ spec = describe "Agent.CLI.Project" do
                 updated.settingsAutoApprove `shouldBe` False
                 projectModelFor OpenAIProvider updated
                     `shouldBe` Just "gpt-project"
+
+        it "writes the last model to both the checkout and user home" $
+            withTempDir "agent-project-" \project ->
+                withTempDir "agent-home-" \home -> do
+                    saveProjectAutoApprove home True
+                    saveProjectAutoApprove project False
+                    saveRememberedModel home project
+                        (target XAIProvider "xai"
+                            "grok-4.6" "grok-4.6" GrokBuildDialect)
+
+                    projectSettings <- loadProjectSettings project
+                    userSettings <- loadUserSettings home
+                    projectSettings.settingsAutoApprove `shouldBe` False
+                    userSettings.settingsAutoApprove `shouldBe` True
+                    projectSettings.settingsLastModel `shouldBe` Just ProjectModel
+                        { projectModelTarget =
+                            target XAIProvider "xai"
+                                "grok-4.6" "grok-4.6" GrokBuildDialect
+                        }
+                    userSettings.settingsLastModel
+                        `shouldBe` projectSettings.settingsLastModel
+                    userSettingsPath home `shouldBe` projectSettingsPath home
 
         it "replaces the remembered provider/model without resetting approval" $
             withTempDir "agent-project-" \root -> do


### PR DESCRIPTION
## Summary
- Persist the last-used model in `~/.haskell-agent/settings.json` and inherit it when a checkout has no `lastModel`, so a freshly created worktree starts on the previous session's model instead of catalog/auth defaults.
- Keep an existing checkout `lastModel` if present; still write both locations whenever the model changes.
- Gitignore `.haskell-agent/` and untrack the committed checkout `settings.json` so `git worktree add` no longer copies a stale selection (this is why new worktrees were opening on fable).

## Test plan
- [x] `env TMPDIR=/tmp HASKELL_AGENT_TMPDIR=/tmp nix develop -c cabal test agent-cli-test --offline --test-options='--match Agent.CLI.Project'`
- [ ] Start `agent-cli` / `repl --worktree` after using grok; the new worktree should open on grok rather than fable or a catalog default.