### PR TITLE
Extract PostgreSQL session types to reduce compile time

### DIFF
--- a/packages/agent-store/agent-store.cabal
+++ b/packages/agent-store/agent-store.cabal
@@ -49,6 +49,7 @@ library
                     , Agent.Store.Postgres.Skill
     other-modules:    Agent.Store.Custom.QueryResult
                     , Agent.Store.Postgres.Custom.Sql
+                    , Agent.Store.Postgres.Session.Types
                     , Agent.Store.Postgres.Hasql
                     , Agent.Store.Postgres.Sql
                     , Agent.Store.Postgres.SessionItem

--- a/packages/agent-store/src/Agent/Store/Postgres/Session.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Session.hs
@@ -46,7 +46,7 @@ module Agent.Store.Postgres.Session
 import Control.Monad (forM, forM_, unless)
 import Data.ByteString (ByteString)
 import Data.Functor.Contravariant ((>$<))
-import Data.Int (Int32, Int64)
+import Data.Int (Int64)
 import qualified Data.Map.Strict as Map
 import Data.Text (Text)
 import Data.Time.Clock (UTCTime)
@@ -57,7 +57,6 @@ import qualified Hasql.Transaction as Transaction
 import qualified Hasql.Transaction.Sessions as Transactions
 import Hasql.Statement (Statement)
 
-import Agent.Store.SessionItem (StoredResponseItem)
 import Agent.Store.Postgres.Connection
     ( StorePool
     , withSession
@@ -68,125 +67,8 @@ import Agent.Store.Postgres.SessionItem
     , loadResponseItems
     , sessionItemSchemaStatements
     )
+import Agent.Store.Postgres.Session.Types
 import Agent.Store.Types (StoreError(..))
-
-data SessionLegacyTarget = SessionLegacyTarget
-    { sessionLegacyProvider :: !Text
-    , sessionLegacyConnection :: !Text
-    , sessionLegacyEffectiveModel :: !Text
-    , sessionLegacyDialect :: !Text
-    }
-    deriving (Eq, Show)
-
-data SessionTurnPage = SessionTurnPage
-    { sessionPageTurns :: ![StoredTurn]
-    , sessionPageGenerationStart :: !Int64
-    , sessionPageTotal :: !Int64
-    , sessionPageHasOlder :: !Bool
-    , sessionPageHasNewer :: !Bool
-    }
-    deriving (Eq, Show)
-
--- | Full-session aggregates for resume UI. The transcript preview stays
--- paged; these fields describe the whole stored conversation.
-data SessionResumeStats = SessionResumeStats
-    { sessionResumeTurnCount :: !Int64
-    , sessionResumeMessageCount :: !Int64
-    , sessionResumeToolCount :: !Int64
-    , sessionResumeFirstPrompt :: !(Maybe Text)
-    }
-    deriving (Eq, Show)
-
-data SessionMetadata = SessionMetadata
-    { sessionMetadataKey :: !Text
-    , sessionMetadataVersion :: !Int32
-    , sessionMetadataCreatedAt :: !UTCTime
-    , sessionMetadataUpdatedAt :: !UTCTime
-    , sessionMetadataProvider :: !Text
-    , sessionMetadataConnection :: !Text
-    , sessionMetadataModel :: !Text
-    , sessionMetadataTransportModel :: !(Maybe Text)
-    , sessionMetadataDialect :: !Text
-    , sessionMetadataLegacyTarget :: !(Maybe SessionLegacyTarget)
-    , sessionMetadataCwd :: !Text
-    , sessionMetadataEffort :: !Text
-    , sessionMetadataTitle :: !Text
-    , sessionMetadataTitleIsManual :: !Bool
-    , sessionMetadataTitleRefreshIndex :: !Int64
-    , sessionMetadataTitleUserTurns :: !Int64
-    , sessionMetadataLastResponseId :: !(Maybe Text)
-    , sessionMetadataInputTokens :: !Int64
-    , sessionMetadataOutputTokens :: !Int64
-    , sessionMetadataCachedTokens :: !Int64
-    , sessionMetadataLastRecap :: !(Maybe Text)
-    , sessionMetadataLastTurnSummary :: !(Maybe Text)
-    , sessionMetadataLastRecapMainTurns :: !Int64
-    }
-    deriving (Eq, Show)
-
-data SessionUsage = SessionUsage
-    { sessionUsageInputTokens :: !Int64
-    , sessionUsageOutputTokens :: !Int64
-    , sessionUsageCachedTokens :: !Int64
-    }
-    deriving (Eq, Show)
-
-data TranscriptEffect
-    = TranscriptAppend
-    | TranscriptReplace
-    | TranscriptReset
-    deriving (Eq, Show)
-
-data SessionTurn = SessionTurn
-    { sessionTurnOccurredAt :: !UTCTime
-    , sessionTurnUserText :: !Text
-    , sessionTurnAssistantText :: !(Maybe Text)
-    , sessionTurnError :: !(Maybe Text)
-    , sessionTurnResponseId :: !(Maybe Text)
-    , sessionTurnEffect :: !TranscriptEffect
-    , sessionTurnItems :: ![StoredResponseItem]
-    , sessionTurnUsage :: !(Maybe SessionUsage)
-    }
-    deriving (Eq, Show)
-
-data StoredSession = StoredSession
-    { storedMetadata :: !SessionMetadata
-    , storedTurns :: ![StoredTurn]
-    }
-    deriving (Eq, Show)
-
-data StoredEvent = StoredEvent
-    { storedEventSequence :: !Int64
-    , storedEventKind :: !Text
-    , storedEventOccurredAt :: !UTCTime
-    }
-    deriving (Eq, Show)
-
-data StoredTurn = StoredTurn
-    { storedTurnIndex :: !Int64
-    , storedEventSequence :: !Int64
-    , storedTurn :: !SessionTurn
-    }
-    deriving (Eq, Show)
-
-data ConversationSearchResult = ConversationSearchResult
-    { searchSessionId :: !Text
-    , searchTurnIndex :: !Int64
-    , searchOccurredAt :: !UTCTime
-    , searchUserText :: !Text
-    , searchAssistantText :: !(Maybe Text)
-    , searchRank :: !Double
-    }
-    deriving (Eq, Show)
-
--- | One fully decoded legacy JSONL session ready for an atomic import.
-data LegacySession = LegacySession
-    { legacySourcePath :: !Text
-    , legacyContentHash :: !Text
-    , legacyMetadata :: !SessionMetadata
-    , legacyTurns :: ![SessionTurn]
-    }
-    deriving (Eq, Show)
 
 sessionSchemaStatements :: [ByteString]
 sessionSchemaStatements =

--- a/packages/agent-store/src/Agent/Store/Postgres/Session/Types.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Session/Types.hs
@@ -1,0 +1,140 @@
+{-# LANGUAGE NoFieldSelectors #-}
+
+module Agent.Store.Postgres.Session.Types
+    ( SessionMetadata(..)
+    , SessionLegacyTarget(..)
+    , TranscriptEffect(..)
+    , SessionTurn(..)
+    , SessionUsage(..)
+    , StoredSession(..)
+    , StoredEvent(..)
+    , StoredTurn(..)
+    , LegacySession(..)
+    , ConversationSearchResult(..)
+    , SessionTurnPage(..)
+    , SessionResumeStats(..)
+    ) where
+
+import Data.Int (Int32, Int64)
+import Data.Text (Text)
+import Data.Time.Clock (UTCTime)
+
+import Agent.Store.SessionItem (StoredResponseItem)
+
+data SessionLegacyTarget = SessionLegacyTarget
+    { sessionLegacyProvider :: !Text
+    , sessionLegacyConnection :: !Text
+    , sessionLegacyEffectiveModel :: !Text
+    , sessionLegacyDialect :: !Text
+    }
+    deriving (Eq, Show)
+
+data SessionTurnPage = SessionTurnPage
+    { sessionPageTurns :: ![StoredTurn]
+    , sessionPageGenerationStart :: !Int64
+    , sessionPageTotal :: !Int64
+    , sessionPageHasOlder :: !Bool
+    , sessionPageHasNewer :: !Bool
+    }
+    deriving (Eq, Show)
+
+-- | Full-session aggregates for resume UI. The transcript preview stays
+-- paged; these fields describe the whole stored conversation.
+data SessionResumeStats = SessionResumeStats
+    { sessionResumeTurnCount :: !Int64
+    , sessionResumeMessageCount :: !Int64
+    , sessionResumeToolCount :: !Int64
+    , sessionResumeFirstPrompt :: !(Maybe Text)
+    }
+    deriving (Eq, Show)
+
+data SessionMetadata = SessionMetadata
+    { sessionMetadataKey :: !Text
+    , sessionMetadataVersion :: !Int32
+    , sessionMetadataCreatedAt :: !UTCTime
+    , sessionMetadataUpdatedAt :: !UTCTime
+    , sessionMetadataProvider :: !Text
+    , sessionMetadataConnection :: !Text
+    , sessionMetadataModel :: !Text
+    , sessionMetadataTransportModel :: !(Maybe Text)
+    , sessionMetadataDialect :: !Text
+    , sessionMetadataLegacyTarget :: !(Maybe SessionLegacyTarget)
+    , sessionMetadataCwd :: !Text
+    , sessionMetadataEffort :: !Text
+    , sessionMetadataTitle :: !Text
+    , sessionMetadataTitleIsManual :: !Bool
+    , sessionMetadataTitleRefreshIndex :: !Int64
+    , sessionMetadataTitleUserTurns :: !Int64
+    , sessionMetadataLastResponseId :: !(Maybe Text)
+    , sessionMetadataInputTokens :: !Int64
+    , sessionMetadataOutputTokens :: !Int64
+    , sessionMetadataCachedTokens :: !Int64
+    , sessionMetadataLastRecap :: !(Maybe Text)
+    , sessionMetadataLastTurnSummary :: !(Maybe Text)
+    , sessionMetadataLastRecapMainTurns :: !Int64
+    }
+    deriving (Eq, Show)
+
+data SessionUsage = SessionUsage
+    { sessionUsageInputTokens :: !Int64
+    , sessionUsageOutputTokens :: !Int64
+    , sessionUsageCachedTokens :: !Int64
+    }
+    deriving (Eq, Show)
+
+data TranscriptEffect
+    = TranscriptAppend
+    | TranscriptReplace
+    | TranscriptReset
+    deriving (Eq, Show)
+
+data SessionTurn = SessionTurn
+    { sessionTurnOccurredAt :: !UTCTime
+    , sessionTurnUserText :: !Text
+    , sessionTurnAssistantText :: !(Maybe Text)
+    , sessionTurnError :: !(Maybe Text)
+    , sessionTurnResponseId :: !(Maybe Text)
+    , sessionTurnEffect :: !TranscriptEffect
+    , sessionTurnItems :: ![StoredResponseItem]
+    , sessionTurnUsage :: !(Maybe SessionUsage)
+    }
+    deriving (Eq, Show)
+
+data StoredSession = StoredSession
+    { storedMetadata :: !SessionMetadata
+    , storedTurns :: ![StoredTurn]
+    }
+    deriving (Eq, Show)
+
+data StoredEvent = StoredEvent
+    { storedEventSequence :: !Int64
+    , storedEventKind :: !Text
+    , storedEventOccurredAt :: !UTCTime
+    }
+    deriving (Eq, Show)
+
+data StoredTurn = StoredTurn
+    { storedTurnIndex :: !Int64
+    , storedEventSequence :: !Int64
+    , storedTurn :: !SessionTurn
+    }
+    deriving (Eq, Show)
+
+data ConversationSearchResult = ConversationSearchResult
+    { searchSessionId :: !Text
+    , searchTurnIndex :: !Int64
+    , searchOccurredAt :: !UTCTime
+    , searchUserText :: !Text
+    , searchAssistantText :: !(Maybe Text)
+    , searchRank :: !Double
+    }
+    deriving (Eq, Show)
+
+-- | One fully decoded legacy JSONL session ready for an atomic import.
+data LegacySession = LegacySession
+    { legacySourcePath :: !Text
+    , legacyContentHash :: !Text
+    , legacyMetadata :: !SessionMetadata
+    , legacyTurns :: ![SessionTurn]
+    }
+    deriving (Eq, Show)


### PR DESCRIPTION
## Summary

- extract PostgreSQL session data types into an internal module
- preserve the existing `Agent.Store.Postgres.Session` API through re-exports
- reduce the size and compile cost of the previous slowest module

## Compile-time benchmark

Fresh serial `agent-store` builds with GHC `-ddump-timings` (three samples per version):

| Version | Median `Agent.Store.Postgres.Session` |
| --- | ---: |
| `master` | 5.30s |
| this PR | 4.69s |

This reduces the module median by roughly 11%. `Agent.Store.Postgres.SessionItem` is now close to the next bottleneck at about 4.0s.

## Validation

- `nix develop -c env TMPDIR=/tmp cabal test --offline --jobs=1 agent-store:test:agent-store-test --test-show-details=direct` (33 examples)
- `nix build .#default --no-link`
- `git diff --check`
