### PR TITLE
Fix unsupported max reasoning effort for Grok

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Command.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command.hs
@@ -38,7 +38,10 @@ module Agent.CLI.Command
     , workflowInstruction
     ) where
 
-import Agent.CLI.Options (parseEffort, reasoningEfforts)
+import Agent.CLI.Options
+    ( parseEffort
+    , reasoningEffortsForDialect
+    )
 import Agent.CLI.Style (roleMuted, rolePrompt)
 import Agent.Dialect (DialectId(..))
 import Agent.Responses.Types
@@ -248,14 +251,29 @@ mkSlashCatalog dialect toolNames skills modelIds =
     let tools =
             Set.fromList
                 (map (Text.toLower . Text.strip) toolNames)
+        commands =
+            map (commandForDialect dialect) slashCommands
     in SlashCatalog
         { slashCatalogDialect = dialect
         , slashCatalogToolNames = tools
         , slashCatalogCommands =
-            filter (commandAvailable dialect tools) slashCommands
+            filter (commandAvailable dialect tools) commands
         , slashCatalogSkills = skills
         , slashCatalogModelIds = modelIds
         }
+
+commandForDialect :: DialectId -> SlashCommand -> SlashCommand
+commandForDialect dialect command
+    | command.slashName == "effort" =
+        command
+            { slashUsage =
+                "/effort ["
+                    <> Text.intercalate
+                        "|"
+                        (reasoningEffortsForDialect dialect)
+                    <> "]"
+            }
+    | otherwise = command
 
 commandAvailable :: DialectId -> Set Text -> SlashCommand -> Bool
 commandAvailable dialect tools command =
@@ -915,7 +933,7 @@ completeSlashArgs catalog cmd word =
 argCompletions :: SlashCatalog -> SlashCommand -> [Text]
 argCompletions catalog spec = case spec.slashName of
     "agents" -> ["limit"]
-    "effort" -> reasoningEfforts
+    "effort" -> reasoningEffortsForDialect catalog.slashCatalogDialect
     "model" -> catalog.slashCatalogModelIds
     "shell" -> ["ghci", "bash", "both", "none"]
     "help" ->

--- a/packages/agent-cli/src/Agent/CLI/Options.hs
+++ b/packages/agent-cli/src/Agent/CLI/Options.hs
@@ -12,12 +12,15 @@ module Agent.CLI.Options
     , parseApprovalAnswer
     , parseArgs
     , parseEffort
+    , normalizeReasoningEffortForDialect
     , reasoningEfforts
+    , reasoningEffortsForDialect
     , resolveApprovalPolicy
     , usage
     ) where
 
 import System.OsPath (OsPath, unsafeEncodeUtf)
+import Agent.Dialect (DialectId(..))
 import Agent.Provider (Provider(..), parseProvider)
 import Agent.TUI.Motion (MotionMode(..))
 import Data.Foldable (asum)
@@ -463,6 +466,22 @@ parseMotionMode raw = case Text.toLower (Text.pack raw) of
 
 reasoningEfforts :: [Text]
 reasoningEfforts = ["none", "low", "medium", "high", "xhigh", "max"]
+
+-- | Efforts exposed by the active model-facing protocol. Grok accepts
+-- @xhigh@ but rejects the OpenAI-only @max@ value.
+reasoningEffortsForDialect :: DialectId -> [Text]
+reasoningEffortsForDialect = \case
+    GrokBuildDialect -> filter (/= "max") reasoningEfforts
+    _ -> reasoningEfforts
+
+-- | Replace an effort unsupported by the active model-facing protocol with
+-- its closest supported value. This also cleans up resumed sessions and
+-- provider switches that inherited an effort from another dialect.
+normalizeReasoningEffortForDialect :: DialectId -> Text -> Text
+normalizeReasoningEffortForDialect dialect effort
+    | effort `elem` reasoningEffortsForDialect dialect = effort
+    | dialect == GrokBuildDialect = "high"
+    | otherwise = effort
 
 parseEffort :: Text -> Either String Text
 parseEffort raw =

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration.hs
@@ -86,6 +86,7 @@ import Agent.CLI.Models
 import Agent.CLI.Options
     ( defaultEffortFor,
       isOneShot,
+      normalizeReasoningEffortForDialect,
       resolveApprovalPolicy,
       CliOptions(optMotionMode, optNoYolo,
                  optYolo, optMaxConcurrentAgents, optCompactThreshold,
@@ -1615,9 +1616,14 @@ runAgentInitializedWithLock
             Nothing -> False
         legacySubagentTarget =
             sessionLegacySubagentTarget . fst <$> resumed
-        effort = fromMaybe
-            (maybe (defaultEffortFor provider) (.metaEffort) (fst <$> resumed))
-            options.optEffort
+        effort =
+            normalizeReasoningEffortForDialect dialectId $
+                fromMaybe
+                    (maybe
+                        (defaultEffortFor provider)
+                        (.metaEffort)
+                        (fst <$> resumed))
+                    options.optEffort
         policy = resolveApprovalPolicy options isTty
             projectSettings.settingsAutoApprove
         claudeBypassEnabled =

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl.hs
@@ -265,6 +265,7 @@ replWithDraft env@SessionEnv
             setFullscreenImagePreviews runtime pendingAttachments
             let promptState =
                     buildPromptState
+                        (dialectId dialect)
                         params
                         planState
                         policy

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Selection.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Selection.hs
@@ -49,7 +49,10 @@ import Agent.CLI.Models
       ModelOption(modelTarget),
       ModelTarget(targetDialect, targetProvider, targetModelId,
                   targetConnectionId, targetWireModelId) )
-import Agent.CLI.Options ()
+import Agent.CLI.Options
+    ( normalizeReasoningEffortForDialect
+    , reasoningEffortsForDialect
+    )
 import Agent.CLI.PendingInputs ()
 import Agent.CLI.Plan ()
 import Agent.CLI.Progress ()
@@ -222,7 +225,11 @@ handleSelection
     Right ReplShowEffort -> do
         color <- resolveColor stdout
         params <- readIORef paramsRef
-        let message = "effort: " <> currentEffort params
+        let message =
+                "effort: "
+                    <> normalizeReasoningEffortForDialect
+                        (dialectId dialect)
+                        (currentEffort params)
         displayInfo message $
             Text.putStrLn
                 (roleMuted color (glyphSession <> message))
@@ -287,14 +294,27 @@ handleSelection
                 Just runtime -> emitUiEvent runtime (UiSetNotice Nothing)
     setEffort level = do
         color <- resolveColor stdout
-        setSessionEffort env level
-        displayInfo ("effort set to " <> level) $
-            Text.putStrLn
-                (roleMuted color
-                    (glyphOk <> "effort set to " <> level))
+        let supported = reasoningEffortsForDialect (dialectId dialect)
+        if level `elem` supported
+            then do
+                setSessionEffort env level
+                displayInfo ("effort set to " <> level) $
+                    Text.putStrLn
+                        (roleMuted color
+                            (glyphOk <> "effort set to " <> level))
+            else do
+                let message =
+                        "effort "
+                            <> level
+                            <> " is not supported by the active model"
+                displayError message $
+                    Text.hPutStrLn stderr (roleError color message)
     chooseEffort next = do
         params <- readIORef paramsRef
-        effortChoice fullscreen (currentEffort params) >>= \case
+        effortChoice
+            fullscreen
+            (reasoningEffortsForDialect (dialectId dialect))
+            (currentEffort params) >>= \case
             Nothing -> next
             Just level -> setEffort level >> next
     chooseModel next = do

--- a/packages/agent-cli/src/Agent/CLI/Session/Choices.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Choices.hs
@@ -17,7 +17,6 @@ import Agent.CLI.Models
     , initialPickerStateResolved
     )
 import Agent.Concurrent (mapConcurrentlyBounded)
-import Agent.CLI.Options (reasoningEfforts)
 import Agent.CLI.Style
     ( roleError
     , roleMuted
@@ -98,13 +97,13 @@ modelChoice
 
 effortChoice
     :: Maybe FullscreenRuntime
+    -> [Text]
     -> Text
     -> IO (Maybe Text)
-effortChoice fullscreen current = case fullscreen of
+effortChoice fullscreen efforts current = case fullscreen of
     Nothing -> pure Nothing
     Just runtime -> do
-        let efforts = reasoningEfforts
-            initial = fromMaybe 0 (elemIndex current efforts)
+        let initial = fromMaybe 0 (elemIndex current efforts)
         requestFullscreenChoice
             runtime
             "Reasoning effort"

--- a/packages/agent-cli/src/Agent/CLI/Session/Interaction.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Interaction.hs
@@ -17,7 +17,11 @@ import Agent.CLI.Command
     , setReasoningEffort
     )
 import Agent.CLI.Interrupt (withTurnCancel)
-import Agent.CLI.Options (ApprovalPolicy)
+import Agent.CLI.Options
+    ( ApprovalPolicy
+    , normalizeReasoningEffortForDialect
+    , reasoningEffortsForDialect
+    )
 import Agent.CLI.Render
     ( RenderConfig(..)
     , putTextLn
@@ -46,6 +50,7 @@ import Agent.CLI.TUI.App
     ( emitUiEvent
     )
 import Agent.Loop (TokenUsage)
+import Agent.Dialect (DialectId, dialectId)
 import Agent.Responses.Types (ResponseCreateParams)
 import Agent.Tools.PlanMode
     ( PlanModeEnv(..)
@@ -79,6 +84,7 @@ syncFullscreenPrompt env =
         attachments <- readLiveAttachments env.sessionConversation
         emitUiEvent runtime $ UiSetPrompt $
             buildPromptState
+                (dialectId env.sessionDialect)
                 params
                 planState
                 policy
@@ -88,7 +94,8 @@ syncFullscreenPrompt env =
                 (length attachments)
 
 buildPromptState
-    :: ResponseCreateParams
+    :: DialectId
+    -> ResponseCreateParams
     -> PlanModeState
     -> ApprovalPolicy
     -> Text
@@ -96,10 +103,14 @@ buildPromptState
     -> TokenUsage
     -> Int
     -> PromptState
-buildPromptState params planState policy account accountSelectable usage attachments =
+buildPromptState activeDialect params planState policy account accountSelectable usage attachments =
     PromptState
         { promptModel = currentModel params
-        , promptEffort = currentEffort params
+        , promptEffort =
+            normalizeReasoningEffortForDialect
+                activeDialect
+                (currentEffort params)
+        , promptEffortOptions = reasoningEffortsForDialect activeDialect
         , promptMode =
             replModeLabel (replModeFromState planState policy)
         , promptAccount = account

--- a/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
@@ -59,7 +59,6 @@ import Agent.CLI.Input
     , truncateDisplayText
     )
 import Agent.CLI.Interrupt (CtrlCDecision)
-import Agent.CLI.Options (reasoningEfforts)
 import qualified Agent.CLI.TUI.Bridge as Bridge
 import Agent.CLI.TUI.Composer.Buffer
 import Agent.CLI.TUI.Composer.Edit
@@ -508,7 +507,7 @@ handleEffortControlClick applyUiEvent = do
         then handlePromptControlClick applyUiEvent ReplChooseEffort
         else if ui.uiRunning && not overlayOpen
             then do
-                let efforts = reasoningEfforts
+                let efforts = ui.uiPrompt.promptEffortOptions
                     current = ui.uiPrompt.promptEffort
                     initial = fromMaybe 0 (elemIndex current efforts)
                     choose = \case

--- a/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
@@ -351,6 +351,15 @@ spec = do
             slashCompletionCandidates "troffe/" "h" `shouldBe` ["high"]
             slashCompletionCandidates "troffe/" "m" `shouldBe` ["medium", "max"]
             slashCompletionCandidates "troffe/" "n" `shouldBe` ["none"]
+            let grokCatalog = mkSlashCatalog GrokBuildDialect [] [] []
+            slashCompletionCandidatesWithCatalog
+                grokCatalog
+                "troffe/"
+                "m"
+                `shouldBe` ["medium"]
+            fmap (.slashUsage) (lookupSlashCommandIn grokCatalog "effort")
+                `shouldBe`
+                    Just "/effort [none|low|medium|high|xhigh]"
             slashCompletionCandidatesWithModels
                 ["grok-4.6", "grok-4.5", "grok-4.5-mini", "qwen-local"]
                 "m/"

--- a/packages/agent-cli/test/Agent/CLI/OptionsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/OptionsSpec.hs
@@ -1,6 +1,7 @@
 module Agent.CLI.OptionsSpec (spec) where
 
 import Agent.CLI.Options
+import Agent.Dialect (DialectId(..))
 import System.OsPath (unsafeEncodeUtf)
 import Agent.Provider (Provider(..))
 import Agent.TUI.Motion (MotionMode(..))
@@ -320,6 +321,21 @@ spec = do
             defaultEffortFor OpenAIProvider `shouldBe` "medium"
             defaultEffortFor OpenRouterProvider `shouldBe` "medium"
             defaultEffortFor ClaudeCodeProvider `shouldBe` "xhigh"
+
+    describe "reasoningEffortsForDialect" do
+        it "does not offer OpenAI max effort to Grok models" do
+            reasoningEffortsForDialect GrokBuildDialect
+                `shouldBe` ["none", "low", "medium", "high", "xhigh"]
+            reasoningEffortsForDialect CodexDialect
+                `shouldBe` reasoningEfforts
+
+        it "maps inherited max effort to high for Grok models" do
+            normalizeReasoningEffortForDialect GrokBuildDialect "max"
+                `shouldBe` "high"
+            normalizeReasoningEffortForDialect GrokBuildDialect "xhigh"
+                `shouldBe` "xhigh"
+            normalizeReasoningEffortForDialect CodexDialect "max"
+                `shouldBe` "max"
 
     describe "isOneShot" do
         it "is true for text, prompt-file, and managed-turn-file input" do

--- a/packages/agent-cli/test/Agent/CLI/ReplStatusSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ReplStatusSpec.hs
@@ -240,6 +240,7 @@ spec = do
                         setModel "gpt-5.6-sol" defaultResponseCreateParams
                 replacement =
                     buildPromptState
+                        CodexDialect
                         openAiParams
                         PlanInactive
                         PromptMutating
@@ -254,7 +255,24 @@ spec = do
                                 reduceUi (UiSetPrompt stalePrompt) initialUiState
             running.uiPrompt.promptModel `shouldBe` "gpt-5.6-sol"
             running.uiPrompt.promptEffort `shouldBe` "medium"
+            running.uiPrompt.promptEffortOptions
+                `shouldBe` ["none", "low", "medium", "high", "xhigh", "max"]
             running.uiPrompt.promptAccount `shouldBe` "openai@example.com"
+
+        it "omits max for the Grok effort control" do
+            let prompt =
+                    buildPromptState
+                        GrokBuildDialect
+                        (setReasoningEffort "max" defaultResponseCreateParams)
+                        PlanInactive
+                        PromptMutating
+                        "grok@example.com"
+                        True
+                        emptyTokenUsage
+                        0
+            prompt.promptEffortOptions
+                `shouldBe` ["none", "low", "medium", "high", "xhigh"]
+            prompt.promptEffort `shouldBe` "high"
 
     describe "formatStartupTimings" do
         it "sorts cumulative startup markers and keeps subsecond precision" do

--- a/packages/agent-tui/src/Agent/TUI/Model.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model.hs
@@ -156,6 +156,7 @@ data PromptLimitStatus = PromptLimitStatus
 data PromptState = PromptState
     { promptModel :: !Text
     , promptEffort :: !Text
+    , promptEffortOptions :: ![Text]
     , promptMode :: !Text
     , promptAccount :: !Text
     , promptAccountSelectable :: !Bool
@@ -250,6 +251,7 @@ initialUiState = UiState
     , uiPrompt = PromptState
         { promptModel = ""
         , promptEffort = ""
+        , promptEffortOptions = []
         , promptMode = "ask"
         , promptAccount = ""
         , promptAccountSelectable = False

--- a/packages/agent-xai/src/Agent/XAI/Request.hs
+++ b/packages/agent-xai/src/Agent/XAI/Request.hs
@@ -118,7 +118,10 @@ xaiReasoningEffort = \case
     Just "medium" -> "medium"
     Just "high" -> "high"
     Just "xhigh" -> "xhigh"
-    Just "max" -> "max"
+    -- The shared UI supports OpenAI's @max@ effort, but Grok's proxy rejects
+    -- it. Keep this projection defensive for resumed sessions and callers
+    -- that construct canonical requests directly.
+    Just "max" -> "high"
     _ -> "high"
 
 requestInputItems :: ResponseCreateParams -> [ResponseItem]

--- a/packages/agent-xai/test/Agent/XAI/ResponsesSpec.hs
+++ b/packages/agent-xai/test/Agent/XAI/ResponsesSpec.hs
@@ -151,7 +151,7 @@ spec = do
             map (KeyMap.lookup "type") toolObjects `shouldBe`
                 [Just (Aeson.String "x_search")]
 
-        it "maps OpenAI-only efforts down and passes grok-4.6 xhigh/max through" do
+        it "maps OpenAI-only efforts down and passes grok-4.6 xhigh through" do
             let effortOf request = do
                     object <- expectObject (requestValue defaultClientOptions request)
                     reasoning <- expectObject =<< maybe
@@ -170,7 +170,7 @@ spec = do
             effortOf (withEffort "xhigh" sampleRequest)
                 >>= (`shouldBe` Just (Aeson.String "xhigh"))
             effortOf (withEffort "max" sampleRequest)
-                >>= (`shouldBe` Just (Aeson.String "max"))
+                >>= (`shouldBe` Just (Aeson.String "high"))
             -- Unset effort defaults to high for Grok.
             effortOf (clearEffort sampleRequest)
                 >>= (`shouldBe` Just (Aeson.String "high"))


### PR DESCRIPTION
## Summary
- hide the OpenAI-only `max` effort from Grok slash completion and fullscreen effort controls
- reject an explicitly entered `/effort max` while a Grok dialect model is active
- normalize inherited/resumed Grok `max` settings to `high`
- defensively serialize `max` as `high` in the xAI request projection

## Root cause
`c87b3aa3` changed the xAI projection from clamping `max` to `high` to passing `max` through. The Grok 4.6 subscription proxy rejects that request with `Invalid reasoning effort`.

## Validation
- `nix develop -c cabal repl agent-xai:test:agent-xai-test` → focused request projection regression passed
- `nix develop -c cabal repl agent-cli:test:agent-cli-test` → effort capability, prompt state, and slash completion regressions passed
- tmux fullscreen smoke test with `--provider xai --model grok-4.6`:
  - `/effort m` offered only `medium`, not `max`
  - `/effort max` displayed `effort max is not supported by the active model`
  - status remained `grok-4.6 (high)`
