### PR TITLE
Load syntax grammars on demand

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -63,6 +63,7 @@ module Agent.CLI.TUI.App
     , setFullscreenWindowTitle
     , applyStoredFullscreenWindowTitle
     , turnCompletionRequiresRedraw
+    , syntaxLanguagesForBlocks
     , uiEventRestartsMotionSchedule
     , applyTextPromptEdit
     , maskedSecretText
@@ -219,6 +220,10 @@ import Agent.TUI.Markdown
     , markdownWidgetWithLinks
     , markdownWidgetWithSyntaxHighlightingAndLinks
     )
+import Agent.TUI.FencedCode
+    ( FencedBlock(..)
+    , fencedBlocks
+    )
 import Agent.TUI.TextWidth
     ( clampGraphemeCursor
     , displayTerminalText
@@ -227,7 +232,9 @@ import Agent.TUI.TextWidth
     )
 import Agent.Syntax
     ( SyntaxHighlighter
-    , loadSyntaxHighlighter
+    , loadSyntaxLanguage
+    , newSyntaxHighlighter
+    , resolveFenceLanguage
     )
 import qualified Agent.CLI.TUI.Scroll as Scroll
 import qualified Agent.CLI.TUI.Transcript as Transcript
@@ -271,6 +278,7 @@ import Control.Concurrent.STM
     ( STM
     , atomically
     , check
+    , flushTQueue
     , newEmptyTMVarIO
     , newTQueueIO
     , newTVarIO
@@ -353,7 +361,7 @@ newFullscreenRuntime
     -> UiState
     -> IO FullscreenRuntime
 newFullscreenRuntime =
-    newFullscreenRuntimeWithSyntaxLoader loadSyntaxHighlighter
+    newFullscreenRuntimeWithSyntaxLoader newSyntaxHighlighter
 
 newFullscreenRuntimeWithSyntaxLoader
     :: IO (Either Text SyntaxHighlighter)
@@ -393,6 +401,8 @@ newFullscreenRuntimeWithSyntaxLoader
         motionSchedule <- newTVarIO (MotionNone, 1000000, 0)
         motionTickQueued <- newTVarIO False
         historyRequests <- newTQueueIO
+        syntaxRequests <- newTQueueIO
+        syntaxHighlighter <- newIORef Nothing
         historySource <- newIORef Nothing
         historyGeneration <- newIORef 0
         dictationJobs <- newTQueueIO
@@ -453,6 +463,8 @@ newFullscreenRuntimeWithSyntaxLoader
             , runtimeWaveTrough = Theme.waveTroughFromColorFgBg colorFgBg
             , runtimeLoadSyntaxHighlighter = syntaxLoader
             , runtimeSyntaxLoadFinished = syntaxLoadFinished
+            , runtimeSyntaxRequests = syntaxRequests
+            , runtimeSyntaxHighlighter = syntaxHighlighter
             , runtimeInitial = initial
             , runtimeSessionActions = sessionActions
             , runtimeHistoryRequests = historyRequests
@@ -578,11 +590,41 @@ loadSyntaxHighlighterForRuntime runtime = do
     let highlighter = case result of
             Left _ -> Nothing
             Right loaded -> either (const Nothing) Just loaded
+    writeIORef runtime.runtimeSyntaxHighlighter highlighter
     enqueueAppEvent runtime (AppSyntaxHighlighterLoaded highlighter)
     void $
         tryAny $
             runtime.runtimeSyntaxLoadFinished
                 (nanosecondsToNominalDiffTime (finishedAt - startedAt))
+
+runSyntaxHighlighterForRuntime :: FullscreenRuntime -> IO ()
+runSyntaxHighlighterForRuntime runtime = do
+    loadSyntaxHighlighterForRuntime runtime
+    forever do
+        languages <-
+            atomically $
+                (:) <$> readTQueue runtime.runtimeSyntaxRequests
+                    <*> flushTQueue runtime.runtimeSyntaxRequests
+        readIORef runtime.runtimeSyntaxHighlighter >>= \case
+            Nothing -> pure ()
+            Just highlighter -> do
+                (changed, loaded) <-
+                    foldSyntaxRequests highlighter languages
+                when changed do
+                    writeIORef runtime.runtimeSyntaxHighlighter (Just loaded)
+                    enqueueAppEvent
+                        runtime
+                        (AppSyntaxHighlighterLoaded (Just loaded))
+  where
+    foldSyntaxRequests current = \case
+        [] -> pure (False, current)
+        language : remaining ->
+            tryAny (loadSyntaxLanguage current language) >>= \case
+                Left _ -> foldSyntaxRequests current remaining
+                Right (Left _) -> foldSyntaxRequests current remaining
+                Right (Right loaded) -> do
+                    (_, final) <- foldSyntaxRequests loaded remaining
+                    pure (True, final)
 
 nanosecondsToNominalDiffTime :: Word64 -> NominalDiffTime
 nanosecondsToNominalDiffTime nanoseconds =
@@ -1016,7 +1058,7 @@ runFullscreen runtime workerAction = do
                                     dictationWorker
                                     \_dictationWorker ->
                                     withAsync
-                                        (loadSyntaxHighlighterForRuntime runtime)
+                                        (runSyntaxHighlighterForRuntime runtime)
                                         \_syntaxLoader ->
                                             withAsync
                                                 (void (waitCatch worker)
@@ -1205,6 +1247,7 @@ initialFullscreenAppState runtime history initialAgent initialAgents initialCloc
         , appClockNanos = initialClock
         , appNativeProgressKeepaliveBucket = 0
         , appSyntaxHighlighter = Nothing
+        , appSyntaxRequested = Set.empty
         , appTerminalFocus = TerminalFocusUnknown
         }
 
@@ -2586,6 +2629,7 @@ handleEvent event = do
     stateBeforeEvent <- get
     when (isMotionTick event) refreshNativeProgressKeepalive
     handleEventInner event
+    when (eventMayExposeSyntax event) requestVisibleSyntaxLanguages
     state <- get
     let visible =
             isNothing state.appTextPrompt
@@ -2617,6 +2661,86 @@ handleEvent event = do
     isMotionTick = \case
         AppEvent AppMotionTick -> True
         _ -> False
+
+eventMayExposeSyntax :: BrickEvent Name AppEvent -> Bool
+eventMayExposeSyntax = \case
+    AppEvent (AppUi uiEvent) ->
+        uiEventMayExposeSyntax uiEvent
+    AppEvent (AppUiBatch uiEvents) ->
+        any uiEventMayExposeSyntax uiEvents
+    AppEvent (AppSyntaxHighlighterLoaded _) -> True
+    AppEvent (AppHistoryReset _) -> True
+    AppEvent (AppHistoryLoaded _ _) -> True
+    AppEvent (AppHistoryCommitted _ _ _) -> True
+    AppEvent (AppAgentSnapshot _ _) -> True
+    _ -> False
+
+uiEventMayExposeSyntax :: UiEvent -> Bool
+uiEventMayExposeSyntax = \case
+    UiLoop (TextDelta delta) ->
+        Text.isInfixOf "```" delta
+            || Text.isInfixOf "~~~" delta
+    UiLoop (ReasoningDelta _) -> False
+    UiLoop (ActivityUpdated _) -> False
+    UiLoop (WarningRaised _) -> False
+    UiLoop (ToolOutputUpdated _ _) -> False
+    UiSetDraft _ _ -> False
+    UiSetPrompt _ -> False
+    UiSetPromptEffort _ -> False
+    UiSetPromptLimitStatus _ -> False
+    UiSetAwaitingInput _ -> False
+    UiSetRepository _ _ -> False
+    UiSetNotice _ -> False
+    UiMoveSelection _ -> False
+    UiSelectBlock _ -> False
+    UiActivateBlock _ -> False
+    UiToggleSelected -> False
+    UiFocusChanged _ -> False
+    UiPermissionShown _ -> False
+    UiPermissionMoved _ -> False
+    UiPermissionHidden -> False
+    UiSetFollow _ -> False
+    _ -> True
+
+requestVisibleSyntaxLanguages :: EventM Name AppState ()
+requestVisibleSyntaxLanguages = do
+    state <- get
+    let
+        languages =
+            syntaxLanguagesForBlocks (visibleConversationBlocks state)
+        missing =
+            Set.difference languages state.appSyntaxRequested
+    unless (Set.null missing) do
+        liftIO $
+            atomically $
+                mapM_
+                    (writeTQueue state.appRuntime.runtimeSyntaxRequests)
+                    (Set.toList missing)
+        modify' \current ->
+            current
+                { appSyntaxRequested =
+                    Set.union current.appSyntaxRequested missing
+                }
+
+visibleConversationBlocks :: AppState -> [UiBlock]
+visibleConversationBlocks state =
+    conversationBlocks state.appAgentSelected state
+
+syntaxLanguagesForBlocks :: [UiBlock] -> Set.Set Text
+syntaxLanguagesForBlocks =
+    Set.fromList . concatMap syntaxLanguagesForBlock
+
+syntaxLanguagesForBlock :: UiBlock -> [Text]
+syntaxLanguagesForBlock block =
+    case block.blockKind of
+        BlockAssistant ->
+            mapMaybe
+                (resolveFenceLanguage . (.fencedInfo))
+                (fencedBlocks block.blockBody)
+        BlockShell
+            | not (Text.null (Text.strip block.blockDetail)) ->
+                ["haskell"]
+        _ -> []
 
 syncMotionDemand :: EventM Name AppState ()
 syncMotionDemand = do
@@ -3302,6 +3426,7 @@ selectAgentView target = do
     when (state.appAgentSelected /= target) do
         modify' \current ->
             current { appAgentSelected = target }
+        requestVisibleSyntaxLanguages
         resumeConversationFollow
 
 isAgentHoverSurface :: Name -> Bool

--- a/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
@@ -52,6 +52,7 @@ import Data.Int (Int64)
 import Data.List.NonEmpty (NonEmpty)
 import qualified Data.Map.Strict as Map
 import Data.Sequence (Seq)
+import qualified Data.Set as Set
 import Data.Text (Text)
 import Data.Time.Clock (NominalDiffTime)
 import Data.Word (Word64)
@@ -213,6 +214,9 @@ data FullscreenRuntime = FullscreenRuntime
     , runtimeLoadSyntaxHighlighter
         :: !(IO (Either Text SyntaxHighlighter))
     , runtimeSyntaxLoadFinished :: !(NominalDiffTime -> IO ())
+    , runtimeSyntaxRequests :: !(TQueue Text)
+    , runtimeSyntaxHighlighter
+        :: !(IORef (Maybe SyntaxHighlighter))
     , runtimeInitial :: !UiState
     , runtimeSessionActions :: !(IORef FullscreenSessionActions)
     , runtimeHistoryRequests :: !(TQueue HistoryRequest)
@@ -295,6 +299,7 @@ data AppState = AppState
     , appClockNanos :: !Word64
     , appNativeProgressKeepaliveBucket :: !Int
     , appSyntaxHighlighter :: !(Maybe SyntaxHighlighter)
+    , appSyntaxRequested :: !(Set.Set Text)
     , appTerminalFocus :: !TerminalFocus
     }
 

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -39,6 +39,7 @@ import Agent.CLI.TUI.App
     , resumeSearchCursorColumn
     , selectedAgentConversation
     , setFullscreenWindowTitle
+    , syntaxLanguagesForBlocks
     , textOverlayDisplayText
     , turnCompletionRequiresRedraw
     , uiEventRestartsMotionSchedule
@@ -80,9 +81,10 @@ import Agent.TUI.Presentation
 import Agent.TUI.Motion
 import Control.Concurrent.STM (newTChanIO)
 import qualified Data.ByteString as ByteString
-import Data.Foldable (find)
+import Data.Foldable (find, toList)
 import Data.IORef (modifyIORef', newIORef, readIORef, writeIORef)
 import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
@@ -92,6 +94,17 @@ import Test.Hspec
 
 spec :: Spec
 spec = do
+    describe "on-demand syntax loading" do
+        it "requests grammars used by fenced file paths" do
+            let conversation =
+                    reduceUi
+                        (UiAssistantHistory
+                            "```src/Agent/Syntax.hs\nmain = pure ()\n```\n\
+                            \```python\nprint('hello')\n```")
+                        initialUiState
+            syntaxLanguagesForBlocks (toList conversation.uiBlocks)
+                `shouldBe` Set.fromList ["haskell", "python"]
+
     describe "externalUrlCommand" do
         it "opens HTTP(S) URLs without passing through a shell" do
             let url = "https://github.com/digitallyinduced/haskell-agent"

--- a/packages/agent-syntax/README.md
+++ b/packages/agent-syntax/README.md
@@ -10,8 +10,14 @@ The package owns:
 - a stable semantic token-class model for renderers
 
 Syntax definitions are supplied at runtime through `AGENT_SYNTAX_DIR`. The
-repository's Nix flake fetches the pinned upstream definitions and configures
-the variable for tests, development shells, and packaged executables.
+interactive path uses `newSyntaxHighlighter` to index filenames without parsing
+their XML, then `loadSyntaxLanguage` parses only a requested definition and its
+transitive grammar dependencies. The eager `loadSyntaxHighlighter` API remains
+available for batch callers.
+
+The repository's Nix flake fetches the pinned upstream definitions and
+configures the variable for tests, development shells, and packaged
+executables.
 
 Terminal colors, Brick attributes, Markdown layout, and widget caching remain
 in `agent-tui`.

--- a/packages/agent-syntax/agent-syntax.cabal
+++ b/packages/agent-syntax/agent-syntax.cabal
@@ -36,7 +36,9 @@ library
     hs-source-dirs:   src
     exposed-modules:  Agent.Syntax
     build-depends:    base >= 4.17 && < 5
+                    , bytestring >= 0.11 && < 0.13
                     , containers >= 0.6 && < 0.8
+                    , directory >= 1.3 && < 1.4
                     , filepath >= 1.4 && < 1.6
                     , skylighting-core >= 0.14.7 && < 0.15
                     , text >= 2.0 && < 2.2

--- a/packages/agent-syntax/src/Agent/Syntax.hs
+++ b/packages/agent-syntax/src/Agent/Syntax.hs
@@ -8,25 +8,54 @@ module Agent.Syntax
     , SyntaxHighlighter
     , SyntaxSpan(..)
     , highlightCode
+    , loadSyntaxLanguage
     , loadSyntaxHighlighter
     , loadSyntaxHighlighterFrom
+    , newSyntaxHighlighter
+    , newSyntaxHighlighterFrom
     , resolveFenceLanguage
     ) where
 
+import Control.Applicative ((<|>))
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as ByteString
+import Data.Char (isAlphaNum)
+import Data.List (find, sort)
 import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as Text
+import qualified Data.Text.Encoding as TextEncoding
+import qualified Data.Text.Encoding.Error as TextEncodingError
 import qualified Data.Text.Unsafe as TextUnsafe
 import Skylighting.Core
-    ( SyntaxMap
+    ( Context(..)
+    , ContextSwitch(..)
+    , ListItem(..)
+    , Matcher(..)
+    , Rule(..)
+    , Syntax(..)
+    , SyntaxMap
     , TokenType(..)
     , TokenizerConfig(..)
     , loadValidSyntaxesFromDir
     , lookupSyntax
     , tokenize
     )
+import Skylighting.Loader (loadSyntaxFromFile)
+import Skylighting.Parser
+    ( addSyntaxDefinition
+    , resolveKeywords
+    )
+import System.Directory (listDirectory)
 import System.Environment (lookupEnv)
-import System.FilePath (takeExtension, takeFileName)
+import System.FilePath
+    ( (</>)
+    , dropExtension
+    , takeExtension
+    , takeFileName
+    )
+import System.IO (IOMode(ReadMode), withBinaryFile)
 import System.IO.Error (tryIOError)
 
 -- | A small, stable set of semantic token classes.
@@ -54,7 +83,12 @@ data SyntaxSpan = SyntaxSpan
 
 type HighlightedLine = [SyntaxSpan]
 
-newtype SyntaxHighlighter = SyntaxHighlighter SyntaxMap
+data SyntaxHighlighter = SyntaxHighlighter
+    { syntaxFiles :: !(Map.Map Text FilePath)
+    , syntaxHeadersIndexed :: !Bool
+    , syntaxRawMap :: !SyntaxMap
+    , syntaxResolvedMap :: !SyntaxMap
+    }
 
 maxHighlightBytes :: Int
 maxHighlightBytes = 256 * 1024
@@ -76,11 +110,14 @@ loadSyntaxHighlighter =
 
 loadSyntaxHighlighterFrom :: FilePath -> IO (Either Text SyntaxHighlighter)
 loadSyntaxHighlighterFrom syntaxDirectory = do
+    filesResult <- syntaxFilesFrom syntaxDirectory
     result <- tryIOError (loadValidSyntaxesFromDir syntaxDirectory)
-    pure case result of
-        Left exception ->
+    pure case (filesResult, result) of
+        (Left message, _) ->
+            Left message
+        (_, Left exception) ->
             Left ("Could not load syntax definitions: " <> Text.pack (show exception))
-        Right (loadErrors, syntaxMap)
+        (Right _, Right (loadErrors, _))
             | not (Map.null loadErrors) ->
                 Left
                     ( "Could not load syntax definitions: "
@@ -90,10 +127,386 @@ loadSyntaxHighlighterFrom syntaxDirectory = do
                             | (path, message) <- Map.toList loadErrors
                             ]
                     )
+        (Right _, Right (_, syntaxMap))
             | Map.null syntaxMap ->
                 Left "No syntax definitions were installed"
+        (Right files, Right (_, syntaxMap)) ->
+            Right
+                SyntaxHighlighter
+                    { syntaxFiles = files
+                    , syntaxHeadersIndexed = False
+                    , syntaxRawMap = syntaxMap
+                    , syntaxResolvedMap = syntaxMap
+                    }
+
+-- | Discover the installed syntax files without parsing their XML bodies.
+--
+-- This is the lightweight initializer used by interactive clients. Individual
+-- definitions are loaded later with 'loadSyntaxLanguage'.
+newSyntaxHighlighter :: IO (Either Text SyntaxHighlighter)
+newSyntaxHighlighter =
+    lookupEnv "AGENT_SYNTAX_DIR" >>= \case
+        Nothing ->
+            pure (Left "AGENT_SYNTAX_DIR is not configured")
+        Just syntaxDirectory ->
+            newSyntaxHighlighterFrom syntaxDirectory
+
+newSyntaxHighlighterFrom :: FilePath -> IO (Either Text SyntaxHighlighter)
+newSyntaxHighlighterFrom syntaxDirectory =
+    fmap
+        ( fmap
+            \files ->
+                SyntaxHighlighter
+                    { syntaxFiles = files
+                    , syntaxHeadersIndexed = False
+                    , syntaxRawMap = Map.empty
+                    , syntaxResolvedMap = Map.empty
+                    }
+        )
+        (syntaxFilesFrom syntaxDirectory)
+
+syntaxFilesFrom :: FilePath -> IO (Either Text (Map.Map Text FilePath))
+syntaxFilesFrom syntaxDirectory = do
+    result <- tryIOError (listDirectory syntaxDirectory)
+    pure case result of
+        Left exception ->
+            Left ("Could not load syntax definitions: " <> Text.pack (show exception))
+        Right entries
+            | null syntaxEntries ->
+                Left "No syntax definitions were installed"
             | otherwise ->
-                Right (SyntaxHighlighter syntaxMap)
+                Right $
+                    Map.fromList
+                        [ ( Text.toLower
+                                (Text.pack (dropExtension entry))
+                          , syntaxDirectory </> entry
+                          )
+                        | entry <- syntaxEntries
+                        ]
+          where
+            syntaxEntries =
+                sort
+                    [ entry
+                    | entry <- entries
+                    , takeExtension entry == ".xml"
+                    ]
+
+-- | Add one requested syntax and the transitive definitions it includes.
+--
+-- The returned value is an immutable cache snapshot. Callers can safely keep
+-- rendering with the old value while this IO action runs on a worker thread.
+loadSyntaxLanguage
+    :: SyntaxHighlighter
+    -> Text
+    -> IO (Either Text SyntaxHighlighter)
+loadSyntaxLanguage highlighter fenceInfo =
+    case resolveFenceLanguage fenceInfo of
+        Nothing ->
+            pure (Left "Fence does not specify a highlighted language")
+        Just language
+            | Just _ <-
+                lookupLoadedSyntax
+                    highlighter
+                    highlighter.syntaxResolvedMap
+                    language ->
+                pure (Right highlighter)
+            | otherwise ->
+                loadSyntaxClosure highlighter language
+
+loadSyntaxClosure
+    :: SyntaxHighlighter
+    -> Text
+    -> IO (Either Text SyntaxHighlighter)
+loadSyntaxClosure highlighter firstLanguage =
+    go
+        Set.empty
+        highlighter
+        highlighter.syntaxRawMap
+        [firstLanguage]
+  where
+    go _ current rawMap [] =
+        let resolvedMap = Map.map (resolveKeywords rawMap) rawMap
+        in pure $
+            Right
+                current
+                    { syntaxRawMap = rawMap
+                    , syntaxResolvedMap = resolvedMap
+                    }
+    go attemptedFiles current rawMap (language : remaining)
+        | Just _ <- lookupLoadedSyntax current rawMap language =
+            go attemptedFiles current rawMap remaining
+        | otherwise = do
+            (indexed, fileResult) <- findSyntaxFile current language
+            case fileResult of
+                Nothing ->
+                    pure (Left ("Unknown syntax language: " <> language))
+                Just syntaxFile
+                    | Set.member syntaxFile attemptedFiles ->
+                        pure
+                            (Left
+                                ("Syntax definition did not provide language: "
+                                    <> language))
+                    | otherwise -> do
+                        syntaxResult <-
+                            tryIOError (loadSyntaxFromFile syntaxFile)
+                        case syntaxResult of
+                            Left exception ->
+                                pure $
+                                    Left
+                                        ( "Could not load syntax definition "
+                                            <> Text.pack syntaxFile
+                                            <> ": "
+                                            <> Text.pack (show exception)
+                                        )
+                            Right (Left message) ->
+                                pure $
+                                    Left
+                                        ( "Could not load syntax definition "
+                                            <> Text.pack syntaxFile
+                                            <> ": "
+                                            <> Text.pack message
+                                        )
+                            Right (Right syntax) ->
+                                let
+                                    nextRawMap =
+                                        addSyntaxDefinition syntax rawMap
+                                    dependencies =
+                                        [ dependency
+                                        | dependency <-
+                                            syntaxDependencies syntax
+                                        , lookupLoadedSyntax
+                                            indexed
+                                            nextRawMap
+                                            dependency
+                                            == Nothing
+                                        , Set.notMember
+                                            dependency
+                                            (Set.fromList remaining)
+                                        ]
+                                in go
+                                    (Set.insert syntaxFile attemptedFiles)
+                                    indexed
+                                    nextRawMap
+                                    (dependencies <> remaining)
+
+syntaxDependencies :: Syntax -> [Text]
+syntaxDependencies syntax =
+    Set.toList $
+        Set.delete Text.empty $
+            Set.delete syntax.sName $
+            Set.unions
+                [ foldMap listItemDependencies $
+                    concat (Map.elems syntax.sLists)
+                , foldMap contextDependencies $
+                    Map.elems syntax.sContexts
+                ]
+
+listItemDependencies :: ListItem -> Set.Set Text
+listItemDependencies = \case
+    Item _ -> Set.empty
+    IncludeList (language, _) ->
+        Set.singleton language
+
+contextDependencies :: Context -> Set.Set Text
+contextDependencies context =
+    foldMap ruleDependencies context.cRules
+        <> foldMap contextSwitchDependencies context.cLineEmptyContext
+        <> foldMap contextSwitchDependencies context.cLineEndContext
+        <> foldMap contextSwitchDependencies context.cLineBeginContext
+        <> foldMap contextSwitchDependencies context.cFallthroughContext
+
+ruleDependencies :: Rule -> Set.Set Text
+ruleDependencies rule =
+    matcherDependencies rule.rMatcher
+        <> foldMap contextSwitchDependencies rule.rContextSwitch
+        <> foldMap ruleDependencies rule.rChildren
+
+matcherDependencies :: Matcher -> Set.Set Text
+matcherDependencies = \case
+    IncludeRules (language, _) ->
+        Set.singleton language
+    _ -> Set.empty
+
+contextSwitchDependencies :: ContextSwitch -> Set.Set Text
+contextSwitchDependencies = \case
+    Pop -> Set.empty
+    Push (language, _) ->
+        Set.singleton language
+
+findSyntaxFile
+    :: SyntaxHighlighter
+    -> Text
+    -> IO (SyntaxHighlighter, Maybe FilePath)
+findSyntaxFile highlighter language =
+    case directSyntaxFile highlighter language of
+        Just syntaxFile ->
+            pure (highlighter, Just syntaxFile)
+        Nothing
+            | highlighter.syntaxHeadersIndexed ->
+                pure (highlighter, Nothing)
+            | otherwise -> do
+                identifierFiles <-
+                    syntaxHeaderIndex $
+                        Set.toList $
+                            Set.fromList $
+                                Map.elems highlighter.syntaxFiles
+                let indexed =
+                        highlighter
+                            { syntaxFiles =
+                                Map.union
+                                    highlighter.syntaxFiles
+                                    identifierFiles
+                            , syntaxHeadersIndexed = True
+                            }
+                pure (indexed, directSyntaxFile indexed language)
+
+syntaxHeaderIndex :: [FilePath] -> IO (Map.Map Text FilePath)
+syntaxHeaderIndex syntaxFiles =
+    fmap (Map.fromList . concat) $
+        mapM
+            (\syntaxFile ->
+                map (,syntaxFile)
+                    <$> syntaxHeaderIdentifiersFromFile syntaxFile)
+            syntaxFiles
+
+syntaxHeaderIdentifiersFromFile :: FilePath -> IO [Text]
+syntaxHeaderIdentifiersFromFile syntaxFile = do
+    result <-
+        tryIOError $
+            withBinaryFile syntaxFile ReadMode \handle ->
+                ByteString.hGet handle syntaxHeaderByteLimit
+    pure case result of
+        Left _ -> []
+        Right header -> syntaxHeaderIdentifiers header
+
+directSyntaxFile :: SyntaxHighlighter -> Text -> Maybe FilePath
+directSyntaxFile highlighter language =
+    let
+        key = syntaxLanguageKey language
+    in Map.lookup key highlighter.syntaxFiles
+        <|> Map.lookup (filenameKey key) highlighter.syntaxFiles
+
+lookupLoadedSyntax
+    :: SyntaxHighlighter
+    -> SyntaxMap
+    -> Text
+    -> Maybe Syntax
+lookupLoadedSyntax highlighter syntaxMap language =
+    lookupSyntax normalized syntaxMap
+        <|> lookupSyntax (syntaxLanguageKey normalized) syntaxMap
+        <|> do
+            syntaxFile <- directSyntaxFile highlighter normalized
+            find
+                ((== takeFileName syntaxFile) . (.sFilename))
+                (Map.elems syntaxMap)
+  where
+    normalized = Text.toLower (Text.strip language)
+
+syntaxLanguageKey :: Text -> Text
+syntaxLanguageKey language =
+    let normalized = Text.toLower (Text.strip language)
+    in Map.findWithDefault normalized normalized syntaxFilenameAliases
+
+syntaxFilenameAliases :: Map.Map Text Text
+syntaxFilenameAliases =
+    Map.fromList
+        [ ("actionscript 2.0", "actionscript")
+        , ("alerts", "alert")
+        , ("apache configuration", "apache")
+        , ("c#", "cs")
+        , ("csharp", "cs")
+        , ("c++", "cpp")
+        , ("coffeescript", "coffee")
+        , ("common lisp", "commonlisp")
+        , ("fortran (fixed format)", "fortran-fixed")
+        , ("fortran (free format)", "fortran-free")
+        , ("gccextensions", "gcc")
+        , ("godot", "gd-script")
+        , ("ini files", "ini")
+        , ("intel x86 (nasm)", "nasm")
+        , ("iso c++", "isocpp")
+        , ("javascript react (jsx)", "javascript-react")
+        , ("jsx", "javascript-react")
+        , ("mustache/handlebars (html)", "mustache")
+        , ("objective caml", "ocaml")
+        , ("objective-c", "objectivec")
+        , ("objective-c++", "objectivecpp")
+        , ("php/php", "php")
+        , ("pov-ray", "povray")
+        , ("r script", "r")
+        , ("relaxng-compact", "relaxngcompact")
+        , ("restructuredtext", "rest")
+        , ("ruby/rails/rhtml", "rhtml")
+        , ("scilab", "sci")
+        , ("tcl/tk", "tcl")
+        , ("x.org configuration", "xorg")
+        ]
+
+filenameKey :: Text -> Text
+filenameKey =
+    Text.dropAround (== '-')
+        . Text.map
+            (\character ->
+                if isAlphaNum character
+                    then character
+                    else '-')
+        . Text.toLower
+
+syntaxHeaderByteLimit :: Int
+syntaxHeaderByteLimit = 32 * 1024
+
+syntaxHeaderIdentifiers :: ByteString -> [Text]
+syntaxHeaderIdentifiers =
+    go
+        . TextEncoding.decodeUtf8With TextEncodingError.lenientDecode
+  where
+    go source =
+        case Text.breakOn "<language" source of
+            (_, rest)
+                | Text.null rest -> []
+                | otherwise ->
+                    let
+                        afterStart = Text.drop (Text.length "<language") rest
+                        (tag, afterTag) = Text.breakOn ">" afterStart
+                        identifiers =
+                            case xmlAttribute "name" tag of
+                                Nothing -> []
+                                Just name ->
+                                    name
+                                        : maybe
+                                            []
+                                            (Text.splitOn ";")
+                                            (xmlAttribute
+                                                "alternativeNames"
+                                                tag)
+                    in map
+                        (Text.toLower . Text.strip . decodeXmlAttribute)
+                        identifiers
+                        <> go (Text.drop 1 afterTag)
+
+xmlAttribute :: Text -> Text -> Maybe Text
+xmlAttribute attribute tag =
+    let needle = attribute <> "=\""
+        (_, match) = Text.breakOn needle tag
+    in if Text.null match
+        then Nothing
+        else
+            Just $
+                Text.takeWhile (/= '"') $
+                    Text.drop (Text.length needle) match
+
+decodeXmlAttribute :: Text -> Text
+decodeXmlAttribute value =
+    foldl
+        (\current (encoded, decoded) ->
+            Text.replace encoded decoded current)
+        value
+        [ ("&quot;", "\"")
+        , ("&apos;", "'")
+        , ("&lt;", "<")
+        , ("&gt;", ">")
+        , ("&amp;", "&")
+        ]
 
 -- | Highlight a fenced code block.
 --
@@ -105,7 +518,7 @@ highlightCode
     -> Text
     -> Text
     -> Either Text [HighlightedLine]
-highlightCode (SyntaxHighlighter syntaxMap) fenceInfo source
+highlightCode highlighter fenceInfo source
     | utf8Length source > maxHighlightBytes =
         Left "Code block exceeds the syntax-highlighting byte limit"
     | sourceLineCount source > maxHighlightLines =
@@ -120,12 +533,15 @@ highlightCode (SyntaxHighlighter syntaxMap) fenceInfo source
             maybe
                 (Left ("Unknown syntax language: " <> language))
                 Right
-                (lookupSyntax language syntaxMap)
+                (lookupLoadedSyntax
+                    highlighter
+                    highlighter.syntaxResolvedMap
+                    language)
         tokenLines <-
             either (Left . Text.pack) Right $
                 tokenize
                     TokenizerConfig
-                        { syntaxMap
+                        { syntaxMap = highlighter.syntaxResolvedMap
                         , traceOutput = False
                         }
                     syntax
@@ -148,7 +564,18 @@ resolveFenceLanguage info = do
         [] -> Nothing
     let normalized = Text.toLower (Text.strip firstToken)
         candidate =
-            maybe normalized languageFromPath (lineRangePath normalized)
+            case lineRangePath normalized of
+                Just path -> languageFromPath path
+                Nothing
+                    | Text.any (`elem` ['/', '\\']) normalized ->
+                        languageFromPath $
+                            Text.map
+                                (\character ->
+                                    if character == '\\'
+                                        then '/'
+                                        else character)
+                                normalized
+                    | otherwise -> normalized
         aliased = Map.findWithDefault candidate candidate languageAliases
     if aliased `elem` plainTextAliases || Text.null aliased
         then Nothing

--- a/packages/agent-syntax/test/Agent/SyntaxSpec.hs
+++ b/packages/agent-syntax/test/Agent/SyntaxSpec.hs
@@ -19,10 +19,16 @@ spec = describe "syntax highlighting" do
         it "resolves Grok line-range file paths by extension" do
             resolveFenceLanguage "12:40:src/Agent/TUI/Markdown.hs"
                 `shouldBe` Just "haskell"
+            resolveFenceLanguage "src/Agent/TUI/Markdown.hs"
+                `shouldBe` Just "haskell"
+            resolveFenceLanguage "src\\Agent\\TUI\\Markdown.hs"
+                `shouldBe` Just "haskell"
             resolveFenceLanguage "1:8:flake.nix"
                 `shouldBe` Just "nix"
             resolveFenceLanguage "1:8:Dockerfile"
                 `shouldBe` Just "dockerfile"
+            resolveFenceLanguage "asp.net"
+                `shouldBe` Just "asp.net"
 
         it "keeps unknown languages available for a recoverable lookup failure" do
             resolveFenceLanguage "made-up-language"
@@ -65,6 +71,49 @@ spec = describe "syntax highlighting" do
             , ("yml", "answer: 42")
             , ("zig", "pub fn main() void {}")
             ]
+
+    it "loads only a requested syntax and its include dependencies" do
+        syntaxDirectory <- sourceSyntaxDirectory
+        emptyHighlighter <-
+            requireLoaded =<< newSyntaxHighlighterFrom syntaxDirectory
+        highlightCode emptyHighlighter "haskell" "main = pure ()"
+            `shouldSatisfy` isLeft
+        haskellHighlighter <-
+            requireLoaded
+                =<< loadSyntaxLanguage emptyHighlighter "haskell"
+        highlightCode haskellHighlighter "haskell" "main = pure ()"
+            `shouldSatisfy` either (const False) (not . null)
+        -- Haskell embeds JavaScript quasiquotes, so that dependency is loaded.
+        highlightCode haskellHighlighter "javascript" "const answer = 42"
+            `shouldSatisfy` either (const False) (not . null)
+        -- An unrelated definition remains absent until it is requested.
+        highlightCode haskellHighlighter "python" "print('hello')"
+            `shouldSatisfy` isLeft
+
+    it "resolves alternative syntax names without eagerly parsing all XML" do
+        syntaxDirectory <- sourceSyntaxDirectory
+        emptyHighlighter <-
+            requireLoaded =<< newSyntaxHighlighterFrom syntaxDirectory
+        csharpHighlighter <-
+            requireLoaded
+                =<< loadSyntaxLanguage emptyHighlighter "csharp"
+        highlightCode csharpHighlighter "cs" "class Program {}"
+            `shouldSatisfy` either (const False) (not . null)
+
+    it "loads dependencies referenced by context switches and keyword lists" do
+        syntaxDirectory <- sourceSyntaxDirectory
+        emptyHighlighter <-
+            requireLoaded =<< newSyntaxHighlighterFrom syntaxDirectory
+        dockerHighlighter <-
+            requireLoaded
+                =<< loadSyntaxLanguage emptyHighlighter "dockerfile"
+        highlightCode dockerHighlighter "bash" "printf '%s\\n' hello"
+            `shouldSatisfy` either (const False) (not . null)
+        groovyHighlighter <-
+            requireLoaded
+                =<< loadSyntaxLanguage dockerHighlighter "groovy"
+        highlightCode groovyHighlighter "java" "class Main {}"
+            `shouldSatisfy` either (const False) (not . null)
 
     it "preserves source text including Unicode, blank lines, and a trailing newline" do
         highlighter <- requireHighlighter
@@ -116,9 +165,12 @@ spec = describe "syntax highlighting" do
 requireHighlighter :: IO SyntaxHighlighter
 requireHighlighter = do
     syntaxDirectory <- sourceSyntaxDirectory
-    loadSyntaxHighlighterFrom syntaxDirectory >>= \case
-        Left message -> expectationFailure (Text.unpack message) >> fail "unreachable"
-        Right highlighter -> pure highlighter
+    requireLoaded =<< loadSyntaxHighlighterFrom syntaxDirectory
+
+requireLoaded :: Either Text SyntaxHighlighter -> IO SyntaxHighlighter
+requireLoaded = \case
+    Left message -> expectationFailure (Text.unpack message) >> fail "unreachable"
+    Right highlighter -> pure highlighter
 
 sourceSyntaxDirectory :: IO FilePath
 sourceSyntaxDirectory =


### PR DESCRIPTION
## Summary
- index syntax-definition filenames at startup without parsing every XML grammar
- load only fenced-code languages and their transitive Skylighting dependencies on a background worker
- cache immutable highlighter snapshots and redraw the fullscreen TUI when a requested grammar is ready
- support language aliases, source-file fence paths, and retain the eager API for batch callers

## Memory impact
Isolated benchmark measurements:
- requested Haskell grammar closure: 1.6 MB maximum live heap / 15.2 MB peak footprint
- eager all-grammar load: 87.8 MB maximum live heap / 206 MB peak footprint
- fresh fullscreen process after this change: 47.8 MB physical footprint

## Validation
- `cabal test --offline agent-syntax-test` (13 examples)
- `cabal test --offline agent-tui-test` (157 examples)
- `cabal test --offline agent-cli-test` (984 examples, 1 platform-pending)
- verified each of the 166 packaged grammars loads successfully on demand
- validated the fullscreen UI in a real tmux TTY
