### PR TITLE
fix(compaction): use provider-reported occupancy for context fitting

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Compaction.hs
+++ b/packages/agent-cli/src/Agent/CLI/Compaction.hs
@@ -28,9 +28,11 @@ import Agent.CLI.Session.History
 import Agent.Error (ApiError(..), ErrorType(..))
 import Agent.Loop
     ( Backend(..)
+    , BackendResult(..)
     , LoopEvent(..)
     , TokenUsage(..)
     , TurnInput(..)
+    , TurnOutput(..)
     , emptyTokenUsage
     )
 import qualified Agent.OpenAI.Client as OpenAI
@@ -76,6 +78,7 @@ import Control.Monad.Trans.Except
     , throwE
     )
 import Control.Exception.Safe (catchAny, mask, onException)
+import Control.Applicative ((<|>))
 import Control.Monad (when)
 import Data.IORef (IORef, readIORef, writeIORef)
 import Data.Maybe (fromMaybe)
@@ -700,7 +703,7 @@ autoCompactOpenAiBackendWithSenderAndHook
 autoCompactOpenAiBackendWithSenderAndHook configuredThreshold send recordUsage
         getParams onCompacted contextTokensRef backend =
     rejectOversizedInitialRequest getParams $
-        boundCompletedToolContinuations getParams $
+        boundCompletedToolContinuations getParams contextTokensRef $
             autoCompactOpenAiBackendWithLimit
                 getLimit
                 compactAction
@@ -808,12 +811,9 @@ autoCompactOpenAiBackendWithSenderAndHook configuredThreshold send recordUsage
                                                 }
                                         else attempt
                         _ -> attempt
-    estimateProjectedRequest _ history inputs = do
+    estimateProjectedRequest occupancy history inputs = do
         params <- getParams
-        pure $
-            estimateRequestTokensWithItems
-                params
-                (history <> turnInputsToItems inputs)
+        pure (projectRequestTokens (Just params) occupancy history inputs)
 
 rejectOversizedInitialRequest
     :: IO ResponseCreateParams
@@ -841,22 +841,28 @@ rejectOversizedInitialRequest getParams (Backend submit) =
 -- A completed tool result must be submitted against its live response chain
 -- before that call/output pair can be compacted. If the result itself would
 -- overflow the model context, cap only its output text while preserving the
--- protocol identifiers and continuation id.
+-- protocol identifiers and continuation id. Prefer the last provider-reported
+-- occupancy so skills, instructions, and tool schemas already counted in
+-- @input_tokens@ are not re-estimated with JSON length.
 boundCompletedToolContinuations
     :: IO ResponseCreateParams
+    -> IORef (Maybe (Int, Int))
     -> Backend
     -> Backend
-boundCompletedToolContinuations getParams (Backend submit) =
+boundCompletedToolContinuations getParams contextTokensRef (Backend submit) =
     Backend \history previous inputs onEvent ->
         if any isCompletedTool inputs
             then do
                 params <- getParams
+                occupancy <- readIORef contextTokensRef
                 let contextWindow =
                         codexEffectiveContextWindowFor params.model
                     requestTokens candidate =
-                        estimateRequestTokensWithItems
-                            params
-                            (history <> turnInputsToItems candidate)
+                        projectRequestTokens
+                            (Just params)
+                            occupancy
+                            history
+                            candidate
                 if requestTokens inputs <= contextWindow
                     then submit history previous inputs onEvent
                     else
@@ -1044,13 +1050,15 @@ autoCompactOpenAiBackendWithLimit getLimit compactAction recordUsage
 
     installSubmitAndTrack restore rollback outcome inputs onEvent = do
         let compactedHistory = outcome.compactHistory
-        writeIORef contextTokensRef $
-            Just (outcome.compactAfterTokens, length compactedHistory)
+            compactSnapshot =
+                Just (outcome.compactAfterTokens, length compactedHistory)
+        writeIORef contextTokensRef compactSnapshot
         result <- restore (submit compactedHistory Nothing inputs onEvent)
         case result of
             Left _ -> rollback
-            Right _ -> do
-                invalidateContextTokens
+            Right backendResult -> do
+                writeIORef contextTokensRef $
+                    occupancySnapshot backendResult <|> compactSnapshot
                 onCompacted `catchAny` const (pure ())
         pure result
 
@@ -1060,15 +1068,9 @@ autoCompactOpenAiBackendWithLimit getLimit compactAction recordUsage
                 `onException` writeIORef contextTokensRef oldTokens
         case result of
             Left _ -> writeIORef contextTokensRef oldTokens
-            Right _ -> invalidateContextTokens
+            Right backendResult ->
+                writeIORef contextTokensRef (occupancySnapshot backendResult)
         pure result
-
-    -- Transcript state is committed by the loop after validating the response.
-    -- Keep this separate cache conservative until it becomes part of that
-    -- explicit state; otherwise cancellation or an invalid response id could
-    -- leave token metadata describing an uncommitted transcript.
-    invalidateContextTokens =
-        writeIORef contextTokensRef Nothing
 
     automaticCompactionError = \case
         ProviderError errorType message retryAfter ->
@@ -1086,15 +1088,49 @@ estimateProjectedFromCache
     -> [ResponseItem]
     -> [TurnInput]
     -> IO Int
-estimateProjectedFromCache contextState history inputs =
-    pure $
-        case contextState of
-            Just (tokens, observedLength)
-                | observedLength >= 0
-                , observedLength == length history ->
-                    tokens + estimateItemsTokens pendingItems
-            _ ->
-                estimateItemsTokens (history <> pendingItems)
+estimateProjectedFromCache occupancy history inputs =
+    pure (projectRequestTokens Nothing occupancy history inputs)
+
+-- | Last provider-reported context occupancy after a committed response.
+-- @input_tokens@ already includes instructions, tools, and skills in the
+-- request; @output_tokens@ remain in the next turn's context.
+reportedContextTokens :: TokenUsage -> Maybe Int
+reportedContextTokens usage
+    | usage.inputTokens <= 0 && usage.outputTokens <= 0 = Nothing
+    | otherwise =
+        Just (max 0 usage.inputTokens + max 0 usage.outputTokens)
+
+occupancySnapshot :: BackendResult -> Maybe (Int, Int)
+occupancySnapshot result
+    | Text.null result.backendOutput.responseId = Nothing
+    | otherwise =
+        reportedContextTokens result.backendOutput.tokenUsage >>= \tokens ->
+            Just (tokens, length result.backendState)
+
+-- | Project the next request from last reported occupancy when that snapshot
+-- still describes @history@. Only unsent items are estimated; without a
+-- snapshot, fall back to encoding the complete request (or items only when
+-- request params are unavailable).
+projectRequestTokens
+    :: Maybe ResponseCreateParams
+    -> Maybe (Int, Int)
+    -> [ResponseItem]
+    -> [TurnInput]
+    -> Int
+projectRequestTokens params occupancy history inputs =
+    case occupancy of
+        Just (tokens, observedLength)
+            | observedLength == length history
+            , tokens > 0 ->
+                tokens + estimateItemsTokens pendingItems
+        _ ->
+            case params of
+                Just requestParams ->
+                    estimateRequestTokensWithItems
+                        requestParams
+                        (history <> pendingItems)
+                Nothing ->
+                    estimateItemsTokens (history <> pendingItems)
   where
     pendingItems = turnInputsToItems inputs
 

--- a/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
@@ -640,8 +640,7 @@ spec = do
                 `shouldSatisfy` (< threshold)
             projectedWithoutTools `shouldSatisfy` (< threshold)
             projectedWithTools `shouldSatisfy` (>= threshold)
-            contextState <-
-                newIORef (Just (projectedWithoutTools, length history))
+            contextState <- newIORef Nothing
             compactCalls <- newIORef (0 :: Int)
             let sender _request = do
                     modifyIORef' compactCalls (+ 1)
@@ -1111,7 +1110,8 @@ spec = do
             fmap (.backendState) result `shouldBe` Right compactedHistory
             readIORef compactCalls `shouldReturn` 1
             readIORef seenPrevious `shouldReturn` [Nothing]
-            readIORef contextState `shouldReturn` Nothing
+            readIORef contextState `shouldReturn`
+                Just (25, length compactedHistory)
             readIORef events `shouldReturn`
                 [ActivityUpdated "Compacting context…"]
 
@@ -1277,7 +1277,8 @@ spec = do
             readIORef seenPrevious `shouldReturn` [Just "resp-tool"]
             readIORef seenInputs `shouldReturn` [inputs]
             fmap (.backendState) result `shouldBe` Right oldHistory
-            readIORef contextState `shouldReturn` Nothing
+            readIORef contextState `shouldReturn`
+                Just (25, length oldHistory)
             readIORef recordedUsage `shouldReturn` []
 
         it "truncates oversized tool output before continuing the call" do
@@ -1356,6 +1357,209 @@ spec = do
                     expectationFailure
                         ("expected one bounded tool result, got "
                             <> show submitted)
+
+        it "records provider-reported occupancy after a successful turn" do
+            let history = [userTextItem "old"]
+                usage = TokenUsage 1_200 80 400
+            contextState <- newIORef Nothing
+            let base = Backend \state _ _ _ ->
+                    pure $ successful state TurnOutput
+                        { responseId = "resp-new"
+                        , toolCalls = []
+                        , assistantText = Just "ok"
+                        , tokenUsage = usage
+                        }
+                backend =
+                    autoCompactOpenAiBackendWithSender
+                        Nothing
+                        (\_ -> error "occupancy tracking should not compact")
+                        (const (pure ()))
+                        (pure defaultResponseCreateParams)
+                        contextState
+                        base
+            result <- backend.submitTurn history (Just "resp-old")
+                [UserMessage "new"] (const (pure ()))
+            result `shouldSatisfy` either (const False) (const True)
+            readIORef contextState `shouldReturn`
+                Just (usage.inputTokens + usage.outputTokens, length history)
+
+        it "uses last reported occupancy instead of JSON length to decide compaction" do
+            let history =
+                    [userTextItem (Text.replicate 20_000 "old context ")]
+                params = defaultResponseCreateParams
+                occupancy = 200
+                pending = [UserMessage "new"]
+                jsonEstimate =
+                    estimateRequestTokensWithItems
+                        params
+                        (history <> turnInputsToItems pending)
+                threshold = occupancy + 1_000
+            jsonEstimate `shouldSatisfy` (> threshold)
+            contextState <- newIORef (Just (occupancy, length history))
+            compactCalls <- newIORef (0 :: Int)
+            let sender _request = do
+                    modifyIORef' compactCalls (+ 1)
+                    pure (Right remoteCompactionResponse)
+                base = Backend \state _ _ _ ->
+                    pure $ successful state TurnOutput
+                        { responseId = "resp-new"
+                        , toolCalls = []
+                        , assistantText = Just "ok"
+                        , tokenUsage = TokenUsage 20 5 0
+                        }
+                backend =
+                    autoCompactOpenAiBackendWithSender
+                        (Just threshold)
+                        sender
+                        (const (pure ()))
+                        (pure params)
+                        contextState
+                        base
+            result <- backend.submitTurn history (Just "resp-old") pending
+                (const (pure ()))
+            result `shouldSatisfy` either (const False) (const True)
+            readIORef compactCalls `shouldReturn` 0
+            readIORef contextState `shouldReturn`
+                Just (25, length history)
+
+        it "does not truncate tool output when reported occupancy still fits" do
+            let params = defaultResponseCreateParams
+                contextWindow =
+                    codexEffectiveContextWindowFor params.model
+                danglingCall = FunctionCallItem FunctionCall
+                    { itemId = Nothing
+                    , callId = "call-keep"
+                    , name = "shell_command"
+                    , namespace = Nothing
+                    , arguments = "{}"
+                    , encryptedFunctionArgs = Nothing
+                    , status = Nothing
+                    , extraFields = mempty
+                    }
+                oldHistory =
+                    [ userTextItem
+                        (Text.replicate ((contextWindow + 1_000) * 4) "x")
+                    , danglingCall
+                    ]
+                toolResult = ToolCallResult
+                    { callId = "call-keep"
+                    , output = "hello from the tool"
+                    , callKind = FunctionCallKind
+                    }
+                inputs = [CompletedTool toolResult]
+                occupancy = 500
+            estimateRequestTokensWithItems
+                params
+                (oldHistory <> turnInputsToItems inputs)
+                `shouldSatisfy` (> contextWindow)
+            contextState <- newIORef (Just (occupancy, length oldHistory))
+            seenInputs <- newIORef []
+            let base = Backend \_state _previous submitted _ -> do
+                    modifyIORef' seenInputs (<> [submitted])
+                    pure $ successful oldHistory TurnOutput
+                        { responseId = "resp-new"
+                        , toolCalls = []
+                        , assistantText = Just "ok"
+                        , tokenUsage = TokenUsage 20 5 0
+                        }
+                backend =
+                    autoCompactOpenAiBackendWithSender
+                        Nothing
+                        (\_ -> error "fitting tool output should not compact")
+                        (const (pure ()))
+                        (pure params)
+                        contextState
+                        base
+            result <- backend.submitTurn oldHistory (Just "resp-tool") inputs
+                (const (pure ()))
+            result `shouldSatisfy` either (const False) (const True)
+            readIORef seenInputs `shouldReturn` [inputs]
+
+        it "truncates tool output against last reported occupancy" do
+            let params = defaultResponseCreateParams
+                contextWindow =
+                    codexEffectiveContextWindowFor params.model
+                danglingCall = FunctionCallItem FunctionCall
+                    { itemId = Nothing
+                    , callId = "call-occupancy"
+                    , name = "shell_command"
+                    , namespace = Nothing
+                    , arguments = "{}"
+                    , encryptedFunctionArgs = Nothing
+                    , status = Nothing
+                    , extraFields = mempty
+                    }
+                oldHistory = [userTextItem "run it", danglingCall]
+                originalOutput = Text.replicate 80_000 "x"
+                toolResult = ToolCallResult
+                    { callId = "call-occupancy"
+                    , output = originalOutput
+                    , callKind = FunctionCallKind
+                    }
+                inputs = [CompletedTool toolResult]
+                occupancy = contextWindow - 10_000
+            estimateRequestTokensWithItems
+                params
+                (oldHistory <> turnInputsToItems inputs)
+                `shouldSatisfy` (<= contextWindow)
+            contextState <- newIORef (Just (occupancy, length oldHistory))
+            seenInputs <- newIORef []
+            let base = Backend \_state _previous submitted _ -> do
+                    modifyIORef' seenInputs (<> [submitted])
+                    pure $ successful oldHistory TurnOutput
+                        { responseId = "resp-new"
+                        , toolCalls = []
+                        , assistantText = Just "ok"
+                        , tokenUsage = TokenUsage 20 5 0
+                        }
+                backend =
+                    autoCompactOpenAiBackendWithSender
+                        Nothing
+                        (\_ -> error "occupancy-bounded tool output should not compact")
+                        (const (pure ()))
+                        (pure params)
+                        contextState
+                        base
+            result <- backend.submitTurn oldHistory (Just "resp-tool") inputs
+                (const (pure ()))
+            result `shouldSatisfy` either (const False) (const True)
+            readIORef seenInputs >>= \case
+                [[CompletedTool bounded]] -> do
+                    bounded.callId `shouldBe` toolResult.callId
+                    Text.length bounded.output
+                        `shouldSatisfy` (< Text.length originalOutput)
+                    bounded.output
+                        `shouldSatisfy`
+                            Text.isSuffixOf
+                                "[tool output truncated to fit the model context]"
+                submitted ->
+                    expectationFailure
+                        ("expected occupancy-bounded tool result, got "
+                            <> show submitted)
+
+        it "forgets occupancy when the provider omits usage" do
+            let history = [userTextItem "old"]
+                oldContextState = Just (1_000, length history)
+            contextState <- newIORef oldContextState
+            let base = Backend \state _ _ _ ->
+                    pure $ successful state TurnOutput
+                        { responseId = "resp-new"
+                        , toolCalls = []
+                        , assistantText = Just "ok"
+                        , tokenUsage = emptyTokenUsage
+                        }
+                backend =
+                    autoCompactOpenAiBackendWithSender
+                        Nothing
+                        (\_ -> error "missing usage should not compact")
+                        (const (pure ()))
+                        (pure defaultResponseCreateParams)
+                        contextState
+                        base
+            result <- backend.submitTurn history (Just "resp-old")
+                [UserMessage "new"] (const (pure ()))
+            result `shouldSatisfy` either (const False) (const True)
+            readIORef contextState `shouldReturn` Nothing
 
         it "preserves typed provider failures from automatic compaction" do
             let history = [userTextItem "old"]


### PR DESCRIPTION
## Summary
Auto-compact and tool-result bounding now use the last model-reported occupancy (`input_tokens + output_tokens`) instead of re-encoding the full request as JSON length / 4.

`input_tokens` already includes skills, instructions, and tool schemas. The next request is projected as occupancy plus an estimate of only unsent items. JSON length / 4 remains the fallback for first turns, resume, omitted usage, or a history-length mismatch.

## Test plan
- [x] `env TMPDIR=/tmp HASKELL_AGENT_TMPDIR=/tmp nix develop -c cabal test agent-cli-test --test-options='--match autoCompactOpenAiBackendWith --match runProviderCompact --match installCompactOutcome --match compactOpenAIWith'` (47 examples)
- [ ] CI `agent-cli-test` / GitHub Actions on this PR