### PR TITLE
fix: report operational failures instead of swallowing them

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Compaction.hs
+++ b/packages/agent-cli/src/Agent/CLI/Compaction.hs
@@ -19,7 +19,7 @@ module Agent.CLI.Compaction
     , runResponsesCompactWithContextWindow
     ) where
 
-import Agent.CLI.Error (formatApiError)
+import Agent.CLI.Error (formatApiError, formatException)
 import Agent.CLI.Session.History
     ( LiveConversation
     , writeLivePreviousResponseId
@@ -1059,7 +1059,11 @@ autoCompactOpenAiBackendWithLimit getLimit compactAction recordUsage
             Right backendResult -> do
                 writeIORef contextTokensRef $
                     occupancySnapshot backendResult <|> compactSnapshot
-                onCompacted `catchAny` const (pure ())
+                onCompacted `catchAny` \err ->
+                    onEvent $
+                        WarningRaised
+                            ("failed to reload generated context after compaction: "
+                                <> formatException err)
         pure result
 
     submitAndTrack oldTokens history previous inputs onEvent = do

--- a/packages/agent-cli/src/Agent/CLI/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session.hs
@@ -112,7 +112,7 @@ import Data.Bits (xor)
 import Data.Int (Int64)
 import Data.IORef
 import Data.Functor ((<&>))
-import Data.Maybe (catMaybes, fromMaybe)
+import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
@@ -1072,14 +1072,35 @@ sessionTempDirForId root sessionId
                 </> unsafeEncodeUtf (Text.unpack sessionId))
     | otherwise = Left "invalid session id"
 
-listSessions :: StorePool -> OsPath -> IO [SessionMeta]
+listSessions :: StorePool -> OsPath -> IO ([SessionMeta], [Text])
 listSessions pool _root = do
     Store.listSessionMetadata pool >>= \case
         Left err ->
             fail
                 ("could not list PostgreSQL sessions: "
                     <> Text.unpack (renderStoreError err))
-        Right values -> pure (catMaybes (map decodeMetaQuiet values))
+        Right values ->
+            let decoded = map decodeListedSessionMeta values
+            in pure
+                ( [meta | Right meta <- decoded]
+                , [err | Left err <- decoded]
+                )
+
+-- | Decode one persisted session for listing. Corrupt or incompatible
+-- metadata becomes an error string instead of disappearing from the picker.
+decodeListedSessionMeta :: Store.SessionMetadata -> Either Text SessionMeta
+decodeListedSessionMeta value = do
+    meta <- fromStoredMetadata value
+    unless (meta.metaVersion == sessionSchemaVersion) $
+        Left $
+            "unsupported session schema version "
+                <> Text.pack (show meta.metaVersion)
+                <> " for session "
+                <> meta.metaId
+                <> " (expected "
+                <> Text.pack (show sessionSchemaVersion)
+                <> ")"
+    pure meta
 
 writeSessionMeta :: StorePool -> OsPath -> SessionMeta -> IO ()
 writeSessionMeta pool _path meta = do
@@ -1450,12 +1471,6 @@ fromStoredUsage usage = TokenUsage
     , outputTokens = fromIntegral usage.sessionUsageOutputTokens
     , cachedTokens = fromIntegral usage.sessionUsageCachedTokens
     }
-
-decodeMetaQuiet :: Store.SessionMetadata -> Maybe SessionMeta
-decodeMetaQuiet value =
-    case fromStoredMetadata value of
-        Right meta | meta.metaVersion == sessionSchemaVersion -> Just meta
-        _ -> Nothing
 
 validateSessionMeta :: Text -> SessionMeta -> ExceptT Text IO ()
 validateSessionMeta sessionId meta = do

--- a/packages/agent-cli/src/Agent/CLI/Session/Runner.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner.hs
@@ -127,6 +127,7 @@ import Agent.CLI.Tools
     , requireToolRegistry
     , schemasFromAppTools
     )
+import Agent.CLI.Error (formatException)
 import Agent.CLI.Dialects
     ( filterBashTools
     , filterGhciTools
@@ -251,6 +252,14 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
               Just runtime -> setFullscreenWindowTitle runtime title
               Nothing -> setCliWindowTitle stdoutTty stdoutHandle title
       withIoLock action = withMVar ioLock (const action)
+      reportSessionError message =
+          case fullscreen of
+              Just runtime ->
+                  emitUiEvent runtime (UiErrorMessage message)
+              Nothing -> do
+                  color <- resolveColor stderrHandle
+                  putTextLn stderrHandle
+                      (roleWarn color (glyphWarn <> message))
   windowTitle <- newWindowTitleController
       options.optMotionMode
       startupWindowTitle
@@ -491,7 +500,11 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
                     session <-
                         (Just <$>
                             hydrateSelectedAgent agentId)
-                            `catchAny` \_ -> pure Nothing
+                            `catchAny` \err -> do
+                                reportSessionError
+                                    ("failed to load selected agent: "
+                                        <> formatException err)
+                                pure Nothing
                     forM_ session \selectedSession -> do
                         withMVar selectedSession.subSessionHydrated \_ ->
                             writeIORef selectedSession.subSessionPinned True
@@ -499,7 +512,10 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
                         -- refill the same stable object now that it is pinned.
                         void
                             (hydrateSelectedAgent agentId)
-                            `catchAny` \_ -> pure ()
+                            `catchAny` \err ->
+                                reportSessionError
+                                    ("failed to pin selected agent: "
+                                        <> formatException err)
             writeIORef selectedAgent target
         releaseSelectedAgent = \case
             AgentRoot -> pure ()
@@ -884,12 +900,16 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
     btwRequests <- newChan
     recapRequests <- newChan
     let
+        reloadGeneratedContextSafely =
+            reloadGeneratedContext `catchAny` \err ->
+                reportSessionError
+                    ("failed to reload generated context: "
+                        <> formatException err)
         compactRunnerWithContext focus = do
             result <- compactRunner focus
             case result of
                 Left _ -> pure ()
-                Right _ ->
-                    reloadGeneratedContext `catchAny` \_ -> pure ()
+                Right _ -> reloadGeneratedContextSafely
             pure result
         env = SessionEnv
             { sessionLoop = config
@@ -956,7 +976,7 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
             , sessionOnPersisted = onPersisted
             , sessionReset = sessionReset
             }
-    writeIORef generatedContextReloadRef reloadGeneratedContext
+    writeIORef generatedContextReloadRef reloadGeneratedContextSafely
     writeIORef startup.startupRestartEffort \level -> do
         setSessionEffort env level
         writeIORef restartEffortRef (Just level)

--- a/packages/agent-cli/src/Agent/CLI/Session/Selection.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Selection.hs
@@ -122,7 +122,8 @@ handleResume databasePool fullscreen maybeId persist = do
     case maybeId of
         Just sessionId -> resume sessionId
         Nothing -> do
-            sessions <- listSessions databasePool root
+            (sessions, warnings) <- listSessions databasePool root
+            mapM_ reportError warnings
             currentId <- currentSessionId persist
             pickResumeChoice
                 databasePool fullscreen color root currentId sessions >>= \case
@@ -152,7 +153,8 @@ handleConversationSearch databasePool fullscreen query persist = do
                         (roleMuted color (glyphSession <> message))
                 Just runtime ->
                     emitUiEvent runtime (UiSystemMessage message)
-    sessions <- listSessions databasePool root
+    (sessions, warnings) <- listSessions databasePool root
+    mapM_ reportError warnings
     searchResumeEntries databasePool sessions query >>= \case
         Left err -> do
             reportError err

--- a/packages/agent-cli/src/Agent/CLI/SessionAdmin.hs
+++ b/packages/agent-cli/src/Agent/CLI/SessionAdmin.hs
@@ -54,6 +54,7 @@ import System.Directory.OsPath
     , getHomeDirectory
     )
 import System.Exit (die)
+import System.IO (stderr)
 import System.OsPath
     ( OsPath
     , decodeFS
@@ -79,7 +80,8 @@ runListSessions :: IO ()
 runListSessions = do
     home <- getHomeDirectory
     withStoreForHome home \store -> do
-        sessions <- listSessions (trustedPool store) (sessionsRoot home)
+        (sessions, warnings) <- listSessions (trustedPool store) (sessionsRoot home)
+        mapM_ (\warning -> Text.hPutStrLn stderr ("warning: " <> warning)) warnings
         if null sessions
             then putStrLn "No sessions in ~/.haskell-agent/sessions"
             else mapM_ printSessionSummary sessions

--- a/packages/agent-cli/src/Agent/CLI/StartupContext.hs
+++ b/packages/agent-cli/src/Agent/CLI/StartupContext.hs
@@ -11,7 +11,9 @@ import Agent.CLI.Options (CliOptions(..))
 import Agent.CLI.Render (putTextLn)
 import Agent.CLI.Style
     ( glyphSession
+    , glyphWarn
     , roleMuted
+    , roleWarn
     )
 import Agent.CLI.Terminal (resolveColor)
 import Agent.CLI.TUI.App
@@ -19,11 +21,14 @@ import Agent.CLI.TUI.App
     , emitUiEvent
     )
 import Agent.Dialect (Dialect)
+import Agent.OsPath (toText)
 import Agent.ProjectInstructions
     ( DiscoverOptions(..)
+    , InstructionWarning(..)
     , defaultDiscoverOptions
     , discoverProjectInstructions
     , loadedInstructionFiles
+    , loadedInstructionWarnings
     )
 import Agent.Responses.Types (ResponseItem)
 import Agent.TUI.Model (UiEvent(..))
@@ -61,6 +66,8 @@ loadAgentsContext
                 , discoverRootMarkers = defaultDiscoverOptions.discoverRootMarkers
                 }
         loaded <- discoverProjectInstructions discoverOptions cwd
+        mapM_ (reportInstructionWarning stderrHandle fullscreen)
+            (loadedInstructionWarnings loaded)
         let files = loadedInstructionFiles loaded
         case formatAgentsMdForDialect dialect cwd loaded of
             Nothing -> newIORef Nothing
@@ -77,3 +84,21 @@ loadAgentsContext
                     Just runtime ->
                         emitUiEvent runtime (UiSystemMessage message)
                 newIORef (Just text)
+
+reportInstructionWarning
+    :: Handle
+    -> Maybe FullscreenRuntime
+    -> InstructionWarning
+    -> IO ()
+reportInstructionWarning stderrHandle fullscreen warning = do
+    let message =
+            "agents.md ignored: "
+                <> toText warning.instructionWarningPath
+                <> ": "
+                <> warning.instructionWarningMessage
+    case fullscreen of
+        Nothing -> do
+            color <- resolveColor stderrHandle
+            putTextLn stderrHandle (roleWarn color (glyphWarn <> message))
+        Just runtime ->
+            emitUiEvent runtime (UiErrorMessage message)

--- a/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
@@ -43,6 +43,7 @@ import Agent.Provider
     )
 import Control.Exception
     ( AsyncException(..)
+    , ErrorCall(..)
     , MaskingState(..)
     , getMaskingState
     , throwIO
@@ -773,6 +774,41 @@ spec = do
             readIORef compactCalls `shouldReturn` 0
             readIORef continuationCalls `shouldReturn` 0
             readIORef contextState `shouldReturn` Nothing
+
+        it "reports a throwing post-compaction hook instead of swallowing it" do
+            let history = [userTextItem "old"]
+                threshold = 20
+            contextState <- newIORef (Just (threshold, length history))
+            events <- newIORef []
+            let sender _request =
+                    pure (Right remoteCompactionResponse)
+                base = Backend \state _ _ _ ->
+                    pure $ successful state TurnOutput
+                        { responseId = "resp-new"
+                        , toolCalls = []
+                        , assistantText = Just "ok"
+                        , tokenUsage = TokenUsage 20 5 0
+                        }
+                backend =
+                    autoCompactOpenAiBackendWithSenderAndHook
+                        (Just threshold)
+                        sender
+                        (const (pure ()))
+                        (pure defaultResponseCreateParams)
+                        (throwIO (ErrorCall "reload failed"))
+                        contextState
+                        base
+            result <- backend.submitTurn history Nothing
+                [UserMessage "new"]
+                (\event -> modifyIORef' events (<> [event]))
+            result `shouldSatisfy` either (const False) (const True)
+            events' <- readIORef events
+            events' `shouldSatisfy` any \case
+                WarningRaised message ->
+                    "failed to reload generated context after compaction"
+                        `Text.isInfixOf` message
+                    && "reload failed" `Text.isInfixOf` message
+                _ -> False
 
         it "runs the post-compaction hook only after a successful continuation" do
             let history = [userTextItem "old"]

--- a/packages/agent-cli/test/Agent/CLI/DialectsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/DialectsSpec.hs
@@ -41,6 +41,7 @@ spec = describe "Agent.CLI.Dialects" do
                 { loadedGlobal = Nothing
                 , loadedProject =
                     [InstructionFile (unsafeEncodeUtf "/repo/AGENTS.md") "rules"]
+                , loadedWarnings = []
                 }
         formatAgentsMdForDialect codexDialect cwd loaded
             `shouldSatisfy`

--- a/packages/agent-cli/test/Agent/CLI/SessionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SessionSpec.hs
@@ -769,8 +769,9 @@ spec = describe "Agent.CLI.Session" do
                                     (final.sessionMeta.metaId, [normalTurn, compactTurn])
                                 ]
 
-                listed <- listSessions pool root
+                (listed, warnings) <- listSessions pool root
                 map (.metaId) listed `shouldBe` [handle.sessionMeta.metaId]
+                warnings `shouldBe` []
                 deleteSession pool root handle.sessionMeta.metaId
                     `shouldReturn` Right ()
                 doesDirectoryExist handle.sessionDir `shouldReturn` False

--- a/packages/agent-codex-dialect/test/Agent/Codex/DialectSpec.hs
+++ b/packages/agent-codex-dialect/test/Agent/Codex/DialectSpec.hs
@@ -68,6 +68,7 @@ spec = describe "Codex dialect" do
                         (unsafeEncodeUtf "/repo/AGENTS.md")
                         "project"
                     ]
+                , loadedWarnings = []
                 }
         formatCodexAgentsMd (unsafeEncodeUtf "/repo") loaded
             `shouldBe` Just

--- a/packages/agent-core/src/Agent/ProjectInstructions.hs
+++ b/packages/agent-core/src/Agent/ProjectInstructions.hs
@@ -6,24 +6,24 @@
 -- formatting of the discovered documents.
 module Agent.ProjectInstructions
     ( InstructionFile(..)
+    , InstructionWarning(..)
     , LoadedAgentsMd(..)
     , DiscoverOptions(..)
     , defaultDiscoverOptions
     , defaultProjectDocMaxBytes
     , discoverProjectInstructions
     , loadedInstructionFiles
+    , loadedInstructionWarnings
     , nonEmptyInstructionContent
     ) where
 
 import Agent.Concurrent (mapConcurrentlyBounded)
 import Agent.FileRetry (retryOnFileBusy)
 import Agent.OsPath (directoryChain, toText, unsafeToFilePath)
-import Control.Applicative ((<|>))
 import Control.Concurrent.Async (concurrently)
-import Control.Exception.Safe (tryAny)
+import Control.Exception.Safe (SomeException, displayException, tryAny)
 import qualified Data.ByteString as BS
 import Data.List (sort)
-import Data.Maybe (mapMaybe)
 import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -52,15 +52,38 @@ data InstructionFile = InstructionFile
     , instructionContent :: !Text
     } deriving (Eq, Show)
 
+-- | A discovered instruction path that existed but could not be used.
+data InstructionWarning = InstructionWarning
+    { instructionWarningPath :: !OsPath
+    , instructionWarningMessage :: !Text
+    } deriving (Eq, Show)
+
 -- | Global home instructions plus project files from root -> cwd.
 data LoadedAgentsMd = LoadedAgentsMd
     { loadedGlobal :: !(Maybe InstructionFile)
     , loadedProject :: ![InstructionFile]
+    , loadedWarnings :: ![InstructionWarning]
     } deriving (Eq, Show)
+
+-- | One discovery pass: loaded files plus warnings for paths that failed.
+data InstructionLoad = InstructionLoad
+    { loadFiles :: ![InstructionFile]
+    , loadWarnings :: ![InstructionWarning]
+    }
+
+instance Semigroup InstructionLoad where
+    InstructionLoad filesA warningsA <> InstructionLoad filesB warningsB =
+        InstructionLoad (filesA <> filesB) (warningsA <> warningsB)
+
+instance Monoid InstructionLoad where
+    mempty = InstructionLoad [] []
 
 loadedInstructionFiles :: LoadedAgentsMd -> [InstructionFile]
 loadedInstructionFiles loaded =
     maybe id (:) loaded.loadedGlobal loaded.loadedProject
+
+loadedInstructionWarnings :: LoadedAgentsMd -> [InstructionWarning]
+loadedInstructionWarnings loaded = loaded.loadedWarnings
 
 nonEmptyInstructionContent :: InstructionFile -> Maybe Text
 nonEmptyInstructionContent file
@@ -88,8 +111,10 @@ defaultDiscoverOptions = DiscoverOptions
     , discoverRootMarkers = [unsafeEncodeUtf ".git"]
     }
 
--- | Load global + project instruction files for @cwd@. Empty / unreadable
--- files are skipped. Project files are ordered root -> cwd.
+-- | Load global + project instruction files for @cwd@. Empty files are
+-- skipped. Files that exist but cannot be read are reported in
+-- 'loadedWarnings' instead of disappearing. Project files are ordered
+-- root -> cwd.
 --
 -- A @.codex@ global directory selects Codex's narrow discovery contract.
 -- Other homes (including @.grok@, @.claude@, and @.haskell-agent@), and calls
@@ -97,7 +122,7 @@ defaultDiscoverOptions = DiscoverOptions
 discoverProjectInstructions :: DiscoverOptions -> OsPath -> IO LoadedAgentsMd
 discoverProjectInstructions options cwd
     | options.discoverMaxBytes <= 0 =
-        pure LoadedAgentsMd { loadedGlobal = Nothing, loadedProject = [] }
+        pure emptyLoadedAgentsMd
     | otherwise = do
         root <- findProjectRoot options.discoverRootMarkers cwd
         let dirs = directoryChain root cwd
@@ -105,18 +130,33 @@ discoverProjectInstructions options cwd
             if usesCodexDiscovery options
                 then do
                     (global, projectFiles) <- concurrently
-                        (maybe (pure Nothing) readPreferredAgentsMd
+                        (maybe (pure mempty) readPreferredAgentsMd
                             options.discoverGlobalDir)
                         (mapConcurrentlyBounded instructionDirectoryConcurrency
                             readPreferredAgentsMd
                             dirs)
-                    let project = mapMaybe id projectFiles
-                    pure LoadedAgentsMd
-                        { loadedGlobal = global
-                        , loadedProject = project
-                        }
+                    let project = mconcat projectFiles
+                    pure $ loadedAgentsFromPreferred global project
                 else discoverGrokInstructions options dirs
         pure (applyByteBudget options.discoverMaxBytes loaded)
+
+emptyLoadedAgentsMd :: LoadedAgentsMd
+emptyLoadedAgentsMd =
+    LoadedAgentsMd
+        { loadedGlobal = Nothing
+        , loadedProject = []
+        , loadedWarnings = []
+        }
+
+loadedAgentsFromPreferred :: InstructionLoad -> InstructionLoad -> LoadedAgentsMd
+loadedAgentsFromPreferred global project =
+    LoadedAgentsMd
+        { loadedGlobal = case global.loadFiles of
+            file : _ -> Just file
+            [] -> Nothing
+        , loadedProject = project.loadFiles
+        , loadedWarnings = global.loadWarnings <> project.loadWarnings
+        }
 
 usesCodexDiscovery :: DiscoverOptions -> Bool
 usesCodexDiscovery options =
@@ -130,32 +170,39 @@ discoverGrokInstructions
     -> IO LoadedAgentsMd
 discoverGrokInstructions options dirs = do
     (home, projectParts) <- concurrently
-        (maybe (pure []) readGrokHomeInstructions options.discoverGlobalDir)
+        (maybe (pure mempty) readGrokHomeInstructions options.discoverGlobalDir)
         (mapConcurrentlyBounded instructionDirectoryConcurrency
             readGrokDirectoryInstructions
             dirs)
-    let project = concat projectParts
-    combined <- dedupeInstructionFiles (home <> project)
-    pure $ case (home, combined) of
-        ([], _) -> LoadedAgentsMd
-            { loadedGlobal = Nothing
-            , loadedProject = combined
-            }
-        (_, first : rest) -> LoadedAgentsMd
-            { loadedGlobal = Just first
-            , loadedProject = rest
-            }
-        (_, []) -> LoadedAgentsMd
-            { loadedGlobal = Nothing
-            , loadedProject = []
-            }
+    let project = mconcat projectParts
+        combinedLoad = home <> project
+    combined <- dedupeInstructionFiles combinedLoad.loadFiles
+    pure $ case (home.loadFiles, combined) of
+        ([], _) ->
+            LoadedAgentsMd
+                { loadedGlobal = Nothing
+                , loadedProject = combined
+                , loadedWarnings = combinedLoad.loadWarnings
+                }
+        (_, first : rest) ->
+            LoadedAgentsMd
+                { loadedGlobal = Just first
+                , loadedProject = rest
+                , loadedWarnings = combinedLoad.loadWarnings
+                }
+        (_, []) ->
+            LoadedAgentsMd
+                { loadedGlobal = Nothing
+                , loadedProject = []
+                , loadedWarnings = combinedLoad.loadWarnings
+                }
 
 -- | Grok Build reads its own home first, followed by compatible Claude and
 -- Cursor homes. For custom harness homes, only that explicit directory is
 -- inspected.
-readGrokHomeInstructions :: OsPath -> IO [InstructionFile]
+readGrokHomeInstructions :: OsPath -> IO InstructionLoad
 readGrokHomeInstructions globalDir =
-    concat
+    mconcat
         <$> mapConcurrentlyBounded instructionDirectoryConcurrency
             readGrokHomeRoot
             roots
@@ -168,22 +215,21 @@ readGrokHomeInstructions globalDir =
             ]
         | otherwise = [globalDir]
 
-readGrokHomeRoot :: OsPath -> IO [InstructionFile]
+readGrokHomeRoot :: OsPath -> IO InstructionLoad
 readGrokHomeRoot dir = do
     (named, rules) <- concurrently
         (readNamedInstructionFiles dir)
         (readRulesDirectory (dir </> unsafeEncodeUtf "rules"))
     pure (named <> rules)
 
-readGrokDirectoryInstructions :: OsPath -> IO [InstructionFile]
+readGrokDirectoryInstructions :: OsPath -> IO InstructionLoad
 readGrokDirectoryInstructions dir = do
     (named, ruleGroups) <- concurrently
         (readNamedInstructionFiles dir)
         (mapConcurrentlyBounded instructionDirectoryConcurrency
             (readRulesDirectory . (dir </>))
             grokProjectRulesDirectories)
-    let rules = concat ruleGroups
-    pure (named <> rules)
+    pure (named <> mconcat ruleGroups)
 
 grokProjectRulesDirectories :: [OsPath]
 grokProjectRulesDirectories =
@@ -192,7 +238,7 @@ grokProjectRulesDirectories =
     , unsafeEncodeUtf ".cursor/rules"
     ]
 
-readNamedInstructionFiles :: OsPath -> IO [InstructionFile]
+readNamedInstructionFiles :: OsPath -> IO InstructionLoad
 readNamedInstructionFiles dir = do
     (preferredAgents, loadedOthers) <- concurrently
         (readPreferredAgentsMd dir)
@@ -201,20 +247,29 @@ readNamedInstructionFiles dir = do
                 loaded <- readAgentsFile (dir </> name)
                 pure (name, loaded))
             grokInstructionNames)
-    let names = case preferredAgents of
-            Just file
-                | takeFileName file.instructionPath
-                    == unsafeEncodeUtf "AGENTS.override.md" ->
-                    filter (not . isAgentsMdSpelling) grokInstructionNames
-            _ -> grokInstructionNames
+    let usedOverride =
+            any
+                (\file ->
+                    takeFileName file.instructionPath
+                        == unsafeEncodeUtf "AGENTS.override.md")
+                preferredAgents.loadFiles
+        names =
+            if usedOverride
+                then filter (not . isAgentsMdSpelling) grokInstructionNames
+                else grokInstructionNames
         allowedNames = Set.fromList names
         other =
-            mapMaybe snd
+            mconcat
                 [ loaded
-                | loaded@(name, _) <- loadedOthers
+                | (name, loaded) <- loadedOthers
                 , name `Set.member` allowedNames
                 ]
-    dedupeInstructionFiles (maybe [] pure preferredAgents <> other)
+        combined = preferredAgents <> other
+    files <- dedupeInstructionFiles combined.loadFiles
+    pure InstructionLoad
+        { loadFiles = files
+        , loadWarnings = combined.loadWarnings
+        }
 
 isAgentsMdSpelling :: OsPath -> Bool
 isAgentsMdSpelling name =
@@ -233,28 +288,30 @@ grokInstructionNames =
     , unsafeEncodeUtf ".claude/CLAUDE.local.md"
     ]
 
-readRulesDirectory :: OsPath -> IO [InstructionFile]
+readRulesDirectory :: OsPath -> IO InstructionLoad
 readRulesDirectory dir = do
     exists <- doesDirectoryExist dir
     if not exists
-        then pure []
-        else do
-            entries <- sort <$> listDirectory dir
-            let candidates =
-                    [ name
-                    | name <- entries
-                    , Text.toLower (toText (takeExtension name)) == ".md"
-                    ]
-            classified <-
-                mapConcurrentlyBounded instructionFileConcurrency
-                    (\name -> do
-                        exists <- doesFileExist (dir </> name)
-                        pure (name, exists))
-                    candidates
-            mapMaybe id
-                <$> mapConcurrentlyBounded instructionFileConcurrency
-                    (readAgentsFile . (dir </>))
-                    [name | (name, True) <- classified]
+        then pure mempty
+        else tryAny (listDirectory dir) >>= \case
+            Left err ->
+                pure (instructionIoWarning dir err)
+            Right entries -> do
+                let candidates =
+                        [ name
+                        | name <- sort entries
+                        , Text.toLower (toText (takeExtension name)) == ".md"
+                        ]
+                classified <-
+                    mapConcurrentlyBounded instructionFileConcurrency
+                        (\name -> do
+                            fileExists <- doesFileExist (dir </> name)
+                            pure (name, fileExists))
+                        candidates
+                mconcat
+                    <$> mapConcurrentlyBounded instructionFileConcurrency
+                        (readAgentsFile . (dir </>))
+                        [name | (name, True) <- classified]
 
 -- | Case-insensitive filesystems can resolve several compatibility spellings
 -- to the same file. Symlinked rule files can do the same. Keep the first
@@ -296,37 +353,73 @@ findProjectRoot markers start = go start
                     else go parent
 
 -- | Prefer @AGENTS.override.md@ over @AGENTS.md@ in a directory.
-readPreferredAgentsMd :: OsPath -> IO (Maybe InstructionFile)
+readPreferredAgentsMd :: OsPath -> IO InstructionLoad
 readPreferredAgentsMd dir = do
     (override, base) <- concurrently
         (readAgentsFile (dir </> unsafeEncodeUtf "AGENTS.override.md"))
         (readAgentsFile (dir </> unsafeEncodeUtf "AGENTS.md"))
-    pure (override <|> base)
+    pure $ case override.loadFiles of
+        _ : _ ->
+            InstructionLoad
+                { loadFiles = override.loadFiles
+                , loadWarnings = override.loadWarnings <> base.loadWarnings
+                }
+        [] ->
+            base <> InstructionLoad [] override.loadWarnings
 
-readAgentsFile :: OsPath -> IO (Maybe InstructionFile)
+readAgentsFile :: OsPath -> IO InstructionLoad
 readAgentsFile path = do
     exists <- doesFileExist path
     if not exists
-        then pure Nothing
+        then pure mempty
         else tryAny (retryOnFileBusy (Text.readFile (unsafeToFilePath path))) >>= \case
-            Left _ -> pure Nothing
+            Left err ->
+                pure (instructionIoWarning path err)
             Right text ->
                 if Text.null (Text.strip text)
-                    then pure Nothing
-                    else pure $ Just InstructionFile
-                        { instructionPath = path
-                        , instructionContent = text
+                    then pure mempty
+                    else pure InstructionLoad
+                        { loadFiles =
+                            [ InstructionFile
+                                { instructionPath = path
+                                , instructionContent = text
+                                }
+                            ]
+                        , loadWarnings = []
                         }
+
+instructionIoWarning :: OsPath -> SomeException -> InstructionLoad
+instructionIoWarning path err =
+    InstructionLoad
+        { loadFiles = []
+        , loadWarnings =
+            [ InstructionWarning
+                { instructionWarningPath = path
+                , instructionWarningMessage = Text.pack (displayException err)
+                }
+            ]
+        }
 
 applyByteBudget :: Int -> LoadedAgentsMd -> LoadedAgentsMd
 applyByteBudget maxBytes loaded =
     case go maxBytes (loadedInstructionFiles loaded) of
-        [] -> LoadedAgentsMd Nothing []
+        [] ->
+            loaded
+                { loadedGlobal = Nothing
+                , loadedProject = []
+                }
         files@(first : rest) -> case loaded.loadedGlobal of
             Just global
                 | first.instructionPath == global.instructionPath ->
-                    LoadedAgentsMd (Just first) rest
-            _ -> LoadedAgentsMd Nothing files
+                    loaded
+                        { loadedGlobal = Just first
+                        , loadedProject = rest
+                        }
+            _ ->
+                loaded
+                    { loadedGlobal = Nothing
+                    , loadedProject = files
+                    }
   where
     go _ [] = []
     go remaining (file : rest)

--- a/packages/agent-core/src/Agent/Skills.hs
+++ b/packages/agent-core/src/Agent/Skills.hs
@@ -29,7 +29,7 @@ import Control.Concurrent.STM
     , newTVarIO
     , readTVar
     )
-import Control.Exception.Safe (displayException, tryAny)
+import Control.Exception.Safe (SomeException, displayException, tryAny)
 import Control.Monad (filterM)
 import Data.Aeson
     ( FromJSON(..)
@@ -231,24 +231,32 @@ defaultSkillCatalogMaxChars = 8000
 discoverSkills :: SkillDiscoverOptions -> IO SkillCatalog
 discoverSkills options = do
     roots <- skillRoots options
-    results <- fmap concat $
+    discovered <-
         mapConcurrentlyBounded skillRootConcurrency
-            (\(scope, origin, root) -> do
-                exists <- doesDirectoryExist root
-                if exists
-                    then do
-                        files <- findSkillFiles options.skillsMaxDepth root
-                        mapConcurrentlyBounded skillFileConcurrency
-                            (loadSkillFile scope origin)
-                            files
-                    else pure [])
+            discoverRoot
             roots
-    let skills = [skill | Right skill <- results]
-        warnings = [warning | Left warning <- results]
+    let skills = concatMap fst discovered
+        warnings = concatMap snd discovered
     pure SkillCatalog
         { catalogSkills = sortOn skillSortKey skills
         , catalogWarnings = warnings
         }
+  where
+    discoverRoot (scope, origin, root) = do
+        exists <- doesDirectoryExist root
+        if not exists
+            then pure ([], [])
+            else do
+                (files, walkWarnings) <-
+                    findSkillFiles options.skillsMaxDepth root
+                loaded <-
+                    mapConcurrentlyBounded skillFileConcurrency
+                        (loadSkillFile scope origin)
+                        files
+                pure
+                    ( [skill | Right skill <- loaded]
+                    , walkWarnings <> [warning | Left warning <- loaded]
+                    )
 
 skillRoots :: SkillDiscoverOptions -> IO [(SkillScope, SkillOrigin, FilePath)]
 skillRoots options = do
@@ -291,19 +299,26 @@ skillRoots options = do
         GrokSkills -> ".grok" </> "skills"
         CodexSkills -> ".codex" </> "skills"
 
-findSkillFiles :: Int -> FilePath -> IO [FilePath]
+findSkillFiles :: Int -> FilePath -> IO ([FilePath], [SkillWarning])
 findSkillFiles maxDepth root = do
     seen <- newTVarIO Set.empty
-    sort <$> go seen 0 [root]
+    (files, warnings) <- go seen 0 [root]
+    pure (sort files, warnings)
   where
-    go _ depth _ | depth > maxDepth = pure []
-    go _ _ [] = pure []
+    go _ depth _ | depth > maxDepth = pure ([], [])
+    go _ _ [] = pure ([], [])
     go seen depth dirs = do
         let orderedDirs = sort dirs
         canonicalized <-
             mapConcurrentlyBounded skillDirectoryConcurrency
-                (\dir -> fmap ((,) dir) <$> tryAny (canonicalizePath dir))
+                (\dir ->
+                    tryAny (canonicalizePath dir) >>= \case
+                        Left err ->
+                            pure (Left (skillIoWarning dir err))
+                        Right canonical ->
+                            pure (Right (dir, canonical)))
                 orderedDirs
+        let walkWarnings = [warning | Left warning <- canonicalized]
         claimed <- atomically do
             visited <- readTVar seen
             let claim (current, selected) = \case
@@ -321,22 +336,33 @@ findSkillFiles maxDepth root = do
             mapConcurrentlyBounded skillDirectoryConcurrency
                 inspectDirectory
                 claimed
-        let found = concatMap fst inspected
-            children = concatMap snd inspected
-        nested <- go seen (depth + 1) children
-        pure (found <> nested)
+        let found = concatMap (\(files, _, _) -> files) inspected
+            children = concatMap (\(_, nested, _) -> nested) inspected
+            inspectWarnings = concatMap (\(_, _, warnings) -> warnings) inspected
+        (nested, nestedWarnings) <- go seen (depth + 1) children
+        pure
+            ( found <> nested
+            , walkWarnings <> inspectWarnings <> nestedWarnings
+            )
 
     inspectDirectory dir = do
         entriesResult <- tryAny (listDirectory dir)
         case entriesResult of
-            Left _ -> pure ([], [])
+            Left err ->
+                pure ([], [], [skillIoWarning dir err])
             Right entries -> do
                 let skillPath = dir </> "SKILL.md"
                 hasSkill <- doesFileExist skillPath
                 children <-
                     filterM doesDirectoryExist
                         [dir </> entry | entry <- sort entries]
-                pure ([skillPath | hasSkill], children)
+                pure ([skillPath | hasSkill], children, [])
+
+skillIoWarning :: FilePath -> SomeException -> SkillWarning
+skillIoWarning path err =
+    SkillWarning
+        (unsafeEncodeUtf path)
+        (Text.pack (displayException err))
 
 skillRootConcurrency :: Int
 skillRootConcurrency = 4
@@ -369,58 +395,69 @@ loadSkillFile scope origin path = do
                         Right frontmatter ->
                             case validateFrontmatter scope path frontmatter of
                                 Left err -> pure (Left (warning err))
-                                Right () -> do
-                                    openAi <- loadOpenAiMetadata (takeDirectory path)
-                                    let argumentHint =
-                                            frontmatter.fmArgumentHint
-                                                <|> (openAi >>= (.openAiArgumentHint))
-                                        modelInvocable =
-                                            not frontmatter.fmDisableModelInvocation
-                                                && fromMaybe True
-                                                    (openAi >>= (.openAiAllowImplicit))
-                                    pure $ Right Skill
-                                        { skillName = frontmatter.fmName
-                                        , skillDescription = frontmatter.fmDescription
-                                        , skillDisplayName =
-                                            openAi >>= (.openAiDisplayName)
-                                        , skillShortDescription =
-                                            (openAi >>= (.openAiShortDescription))
-                                                <|> Map.lookup "short-description"
-                                                    frontmatter.fmMetadata
-                                        , skillDefaultPrompt =
-                                            openAi >>= (.openAiDefaultPrompt)
-                                        , skillWhenToUse = frontmatter.fmWhenToUse
-                                        , skillContextMode = frontmatter.fmContextMode
-                                        , skillArgumentHint = argumentHint
-                                        , skillUserInvocable = frontmatter.fmUserInvocable
-                                        , skillModelInvocable = modelInvocable
-                                        , skillAllowedTools = frontmatter.fmAllowedTools
-                                        , skillModelOverride = frontmatter.fmModel
-                                        , skillEffortOverride = frontmatter.fmEffort
-                                        , skillLicense = frontmatter.fmLicense
-                                        , skillCompatibility = frontmatter.fmCompatibility
-                                        , skillMetadata = frontmatter.fmMetadata
-                                        , skillPath = unsafeEncodeUtf path
-                                        , skillDirectory = unsafeEncodeUtf (takeDirectory path)
-                                        , skillBody = Text.strip body
-                                        , skillFileText = fileText
-                                        , skillScope = scope
-                                        , skillOrigin = origin
-                                        }
+                                Right () ->
+                                    loadOpenAiMetadata (takeDirectory path) >>= \case
+                                        Left err ->
+                                            pure $ Left
+                                                (warning
+                                                    ("agents/openai.yaml: " <> err))
+                                        Right openAi -> do
+                                            let argumentHint =
+                                                    frontmatter.fmArgumentHint
+                                                        <|> (openAi >>= (.openAiArgumentHint))
+                                                modelInvocable =
+                                                    not frontmatter.fmDisableModelInvocation
+                                                        && fromMaybe True
+                                                            (openAi >>= (.openAiAllowImplicit))
+                                            pure $ Right Skill
+                                                { skillName = frontmatter.fmName
+                                                , skillDescription = frontmatter.fmDescription
+                                                , skillDisplayName =
+                                                    openAi >>= (.openAiDisplayName)
+                                                , skillShortDescription =
+                                                    (openAi >>= (.openAiShortDescription))
+                                                        <|> Map.lookup "short-description"
+                                                            frontmatter.fmMetadata
+                                                , skillDefaultPrompt =
+                                                    openAi >>= (.openAiDefaultPrompt)
+                                                , skillWhenToUse = frontmatter.fmWhenToUse
+                                                , skillContextMode = frontmatter.fmContextMode
+                                                , skillArgumentHint = argumentHint
+                                                , skillUserInvocable = frontmatter.fmUserInvocable
+                                                , skillModelInvocable = modelInvocable
+                                                , skillAllowedTools = frontmatter.fmAllowedTools
+                                                , skillModelOverride = frontmatter.fmModel
+                                                , skillEffortOverride = frontmatter.fmEffort
+                                                , skillLicense = frontmatter.fmLicense
+                                                , skillCompatibility = frontmatter.fmCompatibility
+                                                , skillMetadata = frontmatter.fmMetadata
+                                                , skillPath = unsafeEncodeUtf path
+                                                , skillDirectory = unsafeEncodeUtf (takeDirectory path)
+                                                , skillBody = Text.strip body
+                                                , skillFileText = fileText
+                                                , skillScope = scope
+                                                , skillOrigin = origin
+                                                }
   where
     warning message = SkillWarning (unsafeEncodeUtf path) message
 
-loadOpenAiMetadata :: FilePath -> IO (Maybe OpenAiMetadata)
+loadOpenAiMetadata :: FilePath -> IO (Either Text (Maybe OpenAiMetadata))
 loadOpenAiMetadata dir = do
     let path = dir </> "agents" </> "openai.yaml"
     exists <- doesFileExist path
     if not exists
-        then pure Nothing
+        then pure (Right Nothing)
         else do
             result <- tryAny (retryOnFileBusy (BS.readFile path))
             pure $ case result of
-                Left _ -> Nothing
-                Right bytes -> either (const Nothing) Just (decodeEither' bytes)
+                Left err ->
+                    Left (Text.pack (displayException err))
+                Right bytes ->
+                    case decodeEither' bytes of
+                        Left err ->
+                            Left (Text.pack (prettyPrintParseException err))
+                        Right metadata ->
+                            Right (Just metadata)
 
 splitFrontmatter :: Text -> Either Text (Text, Text)
 splitFrontmatter text =

--- a/packages/agent-core/src/Agent/Tools/FileSystem/ListDir.hs
+++ b/packages/agent-core/src/Agent/Tools/FileSystem/ListDir.hs
@@ -86,34 +86,41 @@ runListDir env args = resolveForRead env (fromText args.targetDirectory) >>= \ca
     Right path -> doesDirectoryExist path >>= \case
         False -> pure $ Left $
             "Error: " <> args.targetDirectory <> " is not a valid directory"
-        True -> do
-            entries <- collectDir env.toolCwd path
-            let (shown, truncated) = capNodes maxListItems entries
-                tree = renderTree 0 shown
-                notice
-                    | truncated =
-                        "\nLarge directory summarized; some nested entries were omitted."
-                    | otherwise = ""
-            pure $ Right $
-                "Directory listing for " <> args.targetDirectory <> ":\n" <> tree <> notice
+        True ->
+            collectDir env.toolCwd path >>= \case
+                Left err -> pure (Left err)
+                Right entries -> do
+                    let (shown, truncated) = capNodes maxListItems entries
+                        tree = renderTree 0 shown
+                        notice
+                            | truncated =
+                                "\nLarge directory summarized; some nested entries were omitted."
+                            | otherwise = ""
+                    pure $ Right $
+                        "Directory listing for "
+                            <> args.targetDirectory
+                            <> ":\n"
+                            <> tree
+                            <> notice
 
 data DirNode
     = FileNode OsPath
     | DirectoryNode OsPath [DirNode]
+    | ErrorNode OsPath Text
     deriving (Eq, Show)
 
-collectDir :: OsPath -> OsPath -> IO [DirNode]
+collectDir :: OsPath -> OsPath -> IO (Either Text [DirNode])
 collectDir cwd path = do
     listed <- listDirectoryEntries path
     case listed of
-        Left _ -> pure []
+        Left err -> pure (Left err)
         Right raw -> do
             let visible = sortOn fst
                     [ (name, isDir)
                     | (name, isDir) <- raw
                     , not ("." `Text.isPrefixOf` toText name)
                     ]
-            fmap concat $ mapM (toNode cwd path) visible
+            Right <$> (fmap concat $ mapM (toNode cwd path) visible)
 
 toNode :: OsPath -> OsPath -> (OsPath, Bool) -> IO [DirNode]
 toNode cwd parent (name, isDir) = do
@@ -127,9 +134,12 @@ toNode cwd parent (name, isDir) = do
                 isLink <- pathIsSymbolicLink full
                 if isLink
                     then pure [FileNode name]
-                    else do
-                        children <- collectDir cwd full
-                        pure [summarizeDir name children]
+                    else
+                        collectDir cwd full >>= \case
+                            Left err ->
+                                pure [ErrorNode name err]
+                            Right children ->
+                                pure [summarizeDir name children]
 
 -- | Keep as many nodes as @budget@ allows. A directory that does not fit in
 -- full is included as a stub (and maybe a truncated child list) rather than
@@ -155,6 +165,7 @@ fill remaining restCount (node : rest) =
 takeNode :: Int -> DirNode -> (DirNode, Int, Bool)
 takeNode budget node = case node of
     FileNode name -> (FileNode name, 1, False)
+    ErrorNode name message -> (ErrorNode name message, 1, False)
     DirectoryNode name children
         | budget <= 1 ->
             ( DirectoryNode name []
@@ -174,12 +185,14 @@ countNodes :: [DirNode] -> Int
 countNodes = sum . map \case
     FileNode _ -> 1
     DirectoryNode _ children -> 1 + countNodes children
+    ErrorNode _ _ -> 1
 
 summarizeDir :: OsPath -> [DirNode] -> DirNode
 summarizeDir name children =
     let files = [file | FileNode file <- children]
         dirs = [dir | dir@DirectoryNode{} <- children]
-    in if length files > 20 && null dirs
+        errors = [err | err@ErrorNode{} <- children]
+    in if length files > 20 && null dirs && null errors
         then DirectoryNode
             (fromText (toText name <> " " <> extensionSummary files)) []
         else DirectoryNode name children
@@ -209,6 +222,14 @@ renderNodeLines depth = \case
     DirectoryNode name children ->
         (indent <> "- " <> directoryLabel name)
             : concatMap (renderNodeLines (depth + 1)) children
+    ErrorNode name message ->
+        [ indent
+            <> "- "
+            <> toText name
+            <> "/ (listing failed: "
+            <> message
+            <> ")"
+        ]
   where
     indent = Text.replicate depth "  "
 

--- a/packages/agent-core/test/Agent/ProjectInstructionsSpec.hs
+++ b/packages/agent-core/test/Agent/ProjectInstructionsSpec.hs
@@ -3,11 +3,15 @@ module Agent.ProjectInstructionsSpec (spec) where
 import Agent.ProjectInstructions
 import System.OsPath (unsafeEncodeUtf)
 import Control.Concurrent (forkIO, threadDelay)
-import Control.Exception.Safe (bracket)
+import Control.Exception.Safe (bracket, finally)
 import System.Directory
     ( createDirectoryIfMissing
+    , emptyPermissions
     , getTemporaryDirectory
     , removeDirectoryRecursive
+    , setOwnerReadable
+    , setOwnerWritable
+    , setPermissions
     )
 import System.FilePath ((</>))
 import System.IO (IOMode(AppendMode), hClose, openFile)
@@ -146,6 +150,20 @@ spec = describe "Agent.ProjectInstructions" do
         it "waits for a transient lock instead of dropping instructions" do
             withTempDir checkLockedInstructions
 
+        it "warns when an instruction file exists but cannot be read" do
+            withTempDir \dir -> do
+                createDirectoryIfMissing True (dir </> ".git")
+                let path = dir </> "AGENTS.md"
+                writeFile path "secret rules\n"
+                loaded <-
+                    withUnreadableFile path $
+                        discoverProjectInstructions
+                            defaultDiscoverOptions
+                            (fromFilePath dir)
+                loadedInstructionFiles loaded `shouldBe` []
+                map (.instructionWarningMessage) loaded.loadedWarnings
+                    `shouldNotBe` []
+
         it "loads a global home file before project files" do
             withTempDir \dir -> do
                 createDirectoryIfMissing True (dir </> ".git")
@@ -212,6 +230,13 @@ checkLockedInstructions dir = do
         hClose handle
     loaded <- discoverProjectInstructions defaultDiscoverOptions (fromFilePath dir)
     map (.instructionContent) loaded.loadedProject `shouldBe` ["locked rules\n"]
+
+withUnreadableFile :: FilePath -> IO a -> IO a
+withUnreadableFile path action = do
+    setPermissions path emptyPermissions
+    action `finally`
+        setPermissions path
+            (setOwnerWritable True (setOwnerReadable True emptyPermissions))
 
 withTempDir :: (FilePath -> IO a) -> IO a
 withTempDir action = do

--- a/packages/agent-core/test/Agent/SkillsSpec.hs
+++ b/packages/agent-core/test/Agent/SkillsSpec.hs
@@ -2,13 +2,18 @@ module Agent.SkillsSpec (spec) where
 
 import System.OsPath (unsafeEncodeUtf)
 import Agent.Skills
-import Control.Exception.Safe (bracket)
+import Control.Exception.Safe (bracket, finally)
 import qualified Data.Text as Text
 import System.Directory
     ( createDirectoryIfMissing
     , createDirectoryLink
+    , emptyPermissions
     , getTemporaryDirectory
     , removeDirectoryRecursive
+    , setOwnerReadable
+    , setOwnerSearchable
+    , setOwnerWritable
+    , setPermissions
     )
 import System.FilePath ((</>))
 import System.Posix.Temp (mkdtemp)
@@ -119,6 +124,31 @@ spec = describe "Agent.Skills" do
             catalog.catalogSkills `shouldBe` []
             length catalog.catalogWarnings `shouldBe` 1
 
+    it "warns when a skill directory cannot be listed" do
+        withTempDir \dir -> do
+            let home = dir </> "home"
+                repo = dir </> "repo"
+                blocked = repo </> ".agents" </> "skills" </> "blocked"
+            writeSkill blocked "blocked" "blocked skill" []
+            catalog <-
+                withUnreadableDirectory blocked $
+                    discoverSkills (options home repo repo)
+            catalog.catalogSkills `shouldBe` []
+            catalog.catalogWarnings `shouldNotBe` []
+
+    it "warns when agents/openai.yaml exists but cannot be parsed" do
+        withTempDir \dir -> do
+            let home = dir </> "home"
+                repo = dir </> "repo"
+                skillDir = repo </> ".agents" </> "skills" </> "deploy"
+            writeSkill skillDir "deploy" "Deploy the service" []
+            createDirectoryIfMissing True (skillDir </> "agents")
+            writeFile (skillDir </> "agents" </> "openai.yaml") "not: [valid"
+            catalog <- discoverSkills (options home repo repo)
+            catalog.catalogSkills `shouldBe` []
+            map (.skillWarningMessage) catalog.catalogWarnings
+                `shouldSatisfy` any (Text.isInfixOf "openai.yaml")
+
     it "follows symlinked skill directories" do
         withTempDir \dir -> do
             let home = dir </> "home"
@@ -223,6 +253,14 @@ options home repo cwd = SkillDiscoverOptions
     , skillsMaxDepth = 6
     , skillsBuiltinRoots = []
     }
+
+withUnreadableDirectory :: FilePath -> IO a -> IO a
+withUnreadableDirectory path action = do
+    setPermissions path emptyPermissions
+    action `finally`
+        setPermissions path
+            (setOwnerSearchable True
+                (setOwnerWritable True (setOwnerReadable True emptyPermissions)))
 
 writeSkill :: FilePath -> String -> String -> [String] -> IO ()
 writeSkill dir name description extras = do

--- a/packages/agent-core/test/Agent/Tools/FileSystem/ListDirSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/FileSystem/ListDirSpec.hs
@@ -14,13 +14,19 @@ import Agent.Tools.FileSystem.ListDir
     , renderTree
     )
 import Agent.Tools.Types (AppTool(..), defaultToolEnv)
-import Control.Exception.Safe (bracket)
+import Control.Exception.Safe (bracket, finally)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import System.Directory
     ( createDirectory
+    , createDirectoryIfMissing
+    , emptyPermissions
     , getTemporaryDirectory
     , removeDirectoryRecursive
+    , setOwnerReadable
+    , setOwnerSearchable
+    , setOwnerWritable
+    , setPermissions
     )
 import System.FilePath ((</>))
 import System.OsPath (unsafeEncodeUtf)
@@ -131,15 +137,53 @@ spec = do
                         , "- flake.lock"
                         ]
 
+        it "fails when the target directory cannot be listed" do
+            withTempDir \dir -> do
+                let workspace = dir </> "workspace"
+                    locked = workspace </> "locked"
+                createDirectory workspace
+                createDirectory locked
+                writeFile (locked </> "secret.txt") "hidden\n"
+                env <- defaultToolEnv (unsafeEncodeUtf workspace)
+                result <-
+                    withUnreadableDirectory locked $
+                        dispatchToolCall testConfig
+                            [(listDirTool env).appToolHandler]
+                            (functionToolCall "list-locked" "list_dir"
+                                "{\"target_directory\":\"locked\"}")
+                result.output `shouldSatisfy` Text.isInfixOf "Failed to list directory"
+
+        it "includes nested listing failures instead of pretending the directory is empty" do
+            withTempDir \dir -> do
+                let workspace = dir </> "workspace"
+                    visible = workspace </> "visible"
+                    nested = visible </> "locked"
+                createDirectory workspace
+                createDirectoryIfMissing True nested
+                writeFile (visible </> "ok.txt") "ok\n"
+                writeFile (nested </> "secret.txt") "hidden\n"
+                env <- defaultToolEnv (unsafeEncodeUtf workspace)
+                result <-
+                    withUnreadableDirectory nested $
+                        dispatchToolCall testConfig
+                            [(listDirTool env).appToolHandler]
+                            (functionToolCall "list-visible" "list_dir"
+                                "{\"target_directory\":\"visible\"}")
+                result.output `shouldSatisfy` Text.isInfixOf "ok.txt"
+                result.output `shouldSatisfy` Text.isInfixOf "listing failed"
+                result.output `shouldSatisfy` (not . Text.isInfixOf "secret.txt")
+
 nodeName :: DirNode -> Text
 nodeName = \case
     FileNode name -> toText name
     DirectoryNode name _ -> toText name
+    ErrorNode name _ -> toText name
 
 childCount :: DirNode -> Int
 childCount = \case
     FileNode _ -> 0
     DirectoryNode _ children -> length children
+    ErrorNode _ _ -> 0
 
 testConfig :: ToolDispatchConfig
 testConfig = ToolDispatchConfig
@@ -149,6 +193,14 @@ testConfig = ToolDispatchConfig
     , toolDispatchOnException = \_ _ -> pure ()
     , toolDispatchOnOutput = \_ _ -> pure ()
     }
+
+withUnreadableDirectory :: FilePath -> IO a -> IO a
+withUnreadableDirectory path action = do
+    setPermissions path emptyPermissions
+    action `finally`
+        setPermissions path
+            (setOwnerSearchable True
+                (setOwnerWritable True (setOwnerReadable True emptyPermissions)))
 
 withTempDir :: (FilePath -> IO a) -> IO a
 withTempDir action = do

--- a/packages/agent-grok-build-dialect/test/Agent/GrokBuild/DialectSpec.hs
+++ b/packages/agent-grok-build-dialect/test/Agent/GrokBuild/DialectSpec.hs
@@ -94,6 +94,7 @@ spec = describe "Grok Build dialect" do
                         (unsafeEncodeUtf "/repo/AGENTS.md")
                         "</system-reminder>owned"
                     ]
+                , loadedWarnings = []
                 }
         case formatGrokAgentsMd loaded of
             Just text -> do

--- a/packages/agent-telegram/src/Agent/Telegram.hs
+++ b/packages/agent-telegram/src/Agent/Telegram.hs
@@ -1556,17 +1556,20 @@ sessionForPrompt
     -> IO SessionHandle
 sessionForPrompt runtime key prompt = do
     state <- readMVar runtime.runtimeStateVar
-    existing <- case lookupBinding key state of
-        Nothing -> pure Nothing
+    case lookupBinding key state of
         Just sessionId ->
             loadSessionHandle
                 runtime.runtimePool
                 runtime.runtimeSessionsRoot
                 sessionId >>= \case
-                Left _ -> pure Nothing
-                Right (handle, _) -> pure (Just handle)
-    case existing of
-        Just handle -> pure handle
+                Left err ->
+                    fail . Text.unpack $
+                        "could not load Telegram session "
+                            <> sessionId
+                            <> ": "
+                            <> err
+                Right (handle, _) ->
+                    pure handle
         Nothing -> do
             handle <- createSession SessionCreate
                 { createPool = runtime.runtimePool

--- a/packages/agent-telegram/src/Agent/Telegram/Bridge.hs
+++ b/packages/agent-telegram/src/Agent/Telegram/Bridge.hs
@@ -2,6 +2,7 @@
 module Agent.Telegram.Bridge
     ( TelegramBridgeEnv(..)
     , withTelegramBridge
+    , withTelegramBridgeUsing
     , processTelegramCallbacks
     , processBridgeRequestBatch
     , telegramActivityDraftHtml
@@ -24,7 +25,7 @@ import qualified Agent.Telegram.Client as Client
 import Agent.Telegram.Types
 import Control.Applicative ((<|>))
 import Control.Concurrent (threadDelay)
-import Control.Concurrent.Async (withAsync)
+import Control.Concurrent.Async (race, wait, withAsync)
 import Control.Exception.Safe (SomeException, displayException, try)
 import Control.Monad (forM_, void, when)
 import Data.Aeson
@@ -111,8 +112,20 @@ instance FromJSON ApprovalRequest where
         ApprovalRequest <$> o .: "tool_name" <*> o .: "arguments"
 
 withTelegramBridge :: TelegramBridgeEnv -> IO a -> IO a
-withTelegramBridge env action =
-    withAsync (bridgeLoop env) (const action)
+withTelegramBridge env =
+    withTelegramBridgeUsing (bridgeLoop env)
+
+-- | Run a managed turn against a bridge worker. If the worker dies, the
+-- exception is raised in the owning action instead of leaving gateway
+-- requests waiting until they time out.
+withTelegramBridgeUsing :: IO () -> IO a -> IO a
+withTelegramBridgeUsing loop action =
+    withAsync loop \worker ->
+        race (wait worker) action >>= \case
+            Left () ->
+                fail "Telegram gateway bridge polling stopped"
+            Right value ->
+                pure value
 
 bridgeLoop :: TelegramBridgeEnv -> IO ()
 bridgeLoop env = go Set.empty Nothing (0 :: Int)
@@ -140,7 +153,7 @@ processBridgeRequests env seen = do
                 Left err -> do
                     respondDecodeError env name err
                     pure Nothing
-    files <- tryIOError (listDirectory directory) >>= \case
+    files <- tryIOError (retryOnFileBusy (listDirectory directory)) >>= \case
         Left err
             | isDoesNotExistError err ->
                 pure []

--- a/packages/agent-telegram/src/Agent/Telegram/Bridge.hs
+++ b/packages/agent-telegram/src/Agent/Telegram/Bridge.hs
@@ -53,9 +53,11 @@ import System.Directory
     )
 import System.FilePath
     ( addTrailingPathSeparator
+    , takeBaseName
     , takeExtension
     , (</>)
     )
+import System.IO.Error (isDoesNotExistError, tryIOError)
 
 data TelegramBridgeEnv = TelegramBridgeEnv
     { telegramBridgeClient :: !TelegramClient
@@ -132,17 +134,29 @@ processBridgeRequests env seen = do
     let directory =
             unsafeToFilePath
                 (managedBridgeRequestsDirectory env.telegramBridgeRequest)
-    files <- try @_ @SomeException (listDirectory directory) >>= \case
-        Left _ -> pure []
-        Right values -> pure values
+        decode name =
+            decodeBridgeRequest (directory </> name) >>= \case
+                Right request -> pure (Just request)
+                Left err -> do
+                    respondDecodeError env name err
+                    pure Nothing
+    files <- tryIOError (listDirectory directory) >>= \case
+        Left err
+            | isDoesNotExistError err ->
+                pure []
+            | otherwise ->
+                ioError err
+        Right values ->
+            pure values
     processBridgeRequestBatch
         seen
         files
-        (decodeBridgeRequest . (directory </>))
+        decode
         (processBridgeRequest env)
 
--- | Decode and dispatch one deterministic bridge polling batch. Successfully
--- decoded names are admitted exactly once before concurrent dispatch begins.
+-- | Decode and dispatch one deterministic bridge polling batch. Published
+-- JSON names are admitted exactly once, including files that fail to decode,
+-- so a malformed request cannot be retried forever.
 processBridgeRequestBatch
     :: Set.Set FilePath
     -> [FilePath]
@@ -166,18 +180,25 @@ processBridgeRequestBatch seen files decode dispatch = do
         mapConcurrentlyBounded telegramBridgeConcurrency
             (dispatch . snd)
             admitted
-    pure (foldr (Set.insert . fst) seen admitted)
+    pure (foldr Set.insert seen published)
 
 telegramBridgeConcurrency :: Int
 telegramBridgeConcurrency = 4
 
-decodeBridgeRequest :: FilePath -> IO (Maybe ManagedBridgeRequest)
+decodeBridgeRequest :: FilePath -> IO (Either Text ManagedBridgeRequest)
 decodeBridgeRequest path =
     try @_ @SomeException
         (retryOnFileBusy (LBS.readFile path)) >>= \case
-            Left _ -> pure Nothing
+            Left err ->
+                pure $ Left $
+                    "failed to read bridge request: "
+                        <> Text.pack (displayException err)
             Right bytes ->
-                pure (either (const Nothing) Just (eitherDecode bytes))
+                pure $ case eitherDecode bytes of
+                    Left err ->
+                        Left ("invalid bridge request JSON: " <> Text.pack err)
+                    Right request ->
+                        Right request
 
 processBridgeRequest :: TelegramBridgeEnv -> ManagedBridgeRequest -> IO ()
 processBridgeRequest env request =
@@ -528,6 +549,16 @@ respondError env request err =
     writeManagedBridgeResponse env.telegramBridgeRequest ManagedBridgeResponse
         { bridgeResponseVersion = 1
         , bridgeResponseId = request.bridgeRequestId
+        , bridgeResponseOk = False
+        , bridgeResponseResult = Nothing
+        , bridgeResponseError = Just err
+        }
+
+respondDecodeError :: TelegramBridgeEnv -> FilePath -> Text -> IO ()
+respondDecodeError env name err =
+    writeManagedBridgeResponse env.telegramBridgeRequest ManagedBridgeResponse
+        { bridgeResponseVersion = 1
+        , bridgeResponseId = Text.pack (takeBaseName name)
         , bridgeResponseOk = False
         , bridgeResponseResult = Nothing
         , bridgeResponseError = Just err

--- a/packages/agent-telegram/test/Agent/TelegramSpec.hs
+++ b/packages/agent-telegram/test/Agent/TelegramSpec.hs
@@ -262,6 +262,21 @@ spec = describe "Agent.Telegram" do
                     dispatch
             readIORef decoded `shouldReturn` ["bad.json"]
 
+        it "propagates bridge polling failures to the managed turn" do
+            started <- newEmptyMVar
+            Bridge.withTelegramBridgeUsing
+                (do
+                    putMVar started ()
+                    fail "bridge listing failed")
+                (takeMVar started >> threadDelay 2_000_000)
+                `shouldThrow` anyException
+
+        it "keeps the managed turn running while the bridge polls" do
+            Bridge.withTelegramBridgeUsing
+                (threadDelay 10_000_000)
+                (pure (41 + 1 :: Int))
+                `shouldReturn` 42
+
     describe "splitTelegramText" do
         it "keeps messages within the requested limit" do
             splitTelegramText 4 "abcdefghij"

--- a/packages/agent-telegram/test/Agent/TelegramSpec.hs
+++ b/packages/agent-telegram/test/Agent/TelegramSpec.hs
@@ -240,6 +240,28 @@ spec = describe "Agent.Telegram" do
             observed <- readIORef maximumActive
             observed `shouldSatisfy` (\value -> value > 1 && value <= 4)
 
+        it "does not retry JSON files that fail to decode" do
+            decoded <- newIORef []
+            let decode name = do
+                    modifyIORef' decoded (name :)
+                    pure Nothing
+                dispatch _ =
+                    fail "undecodable requests must not be dispatched"
+            seen <-
+                Bridge.processBridgeRequestBatch
+                    Set.empty
+                    ["bad.json", "ignored.tmp"]
+                    decode
+                    dispatch
+            seen `shouldBe` Set.fromList ["bad.json"]
+            _ <-
+                Bridge.processBridgeRequestBatch
+                    seen
+                    ["bad.json"]
+                    decode
+                    dispatch
+            readIORef decoded `shouldReturn` ["bad.json"]
+
     describe "splitTelegramText" do
         it "keeps messages within the requested limit" do
             splitTelegramText 4 "abcdefghij"


### PR DESCRIPTION
## Summary
- Instruction files, skills, `list_dir`, session listings, compaction hooks, subagent hydration, and Telegram session loads now report failures instead of dropping them.
- Unreadable `AGENTS.md` / skill directories and broken `agents/openai.yaml` become warnings. `list_dir` fails the root listing and shows nested `listing failed` nodes instead of empty folders. Corrupt session metadata is warned about instead of omitted. Compaction context-reload exceptions raise `WarningRaised`. A bound Telegram chat that cannot load its session fails instead of silently starting a new one; undecodable bridge requests get an error response and are not retried forever.
- Best-effort teardown (closed handles, missing temp files) is unchanged.

## Test plan
- [x] `cabal test agent-core:test:agent-core-test` (365 examples)
- [x] `cabal test agent-telegram:test:agent-telegram-test`
- [x] CLI compaction hook, dialect, and session tests