### PR TITLE
Add reproducible syntax loading benchmark

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -116,6 +116,7 @@
                     include = [
                         "src"
                         "test"
+                        "benchmark"
                         "agent-syntax.cabal"
                         "LICENSE"
                         "README.md"

--- a/packages/agent-syntax/README.md
+++ b/packages/agent-syntax/README.md
@@ -2,6 +2,37 @@
 
 Renderer-independent syntax highlighting for the universal agent harness.
 
+## Syntax loading benchmark
+
+`syntax-loading-bench` retains the previous eager-loading path as a baseline
+and compares it with initialization plus on-demand grammar loading. Each sample
+loads from `AGENT_SYNTAX_DIR`, highlights a generated source block with every
+requested grammar to force the result, performs a major GC while the grammar
+cache remains live, and reports median wall time, CPU time, allocated bytes,
+and live bytes.
+
+Build the optimized benchmark and run equivalent workloads with:
+
+```sh
+nix develop
+cabal build --offline --enable-optimization=2 \
+  agent-syntax:bench:syntax-loading-bench
+bin=$(cabal list-bin agent-syntax:bench:syntax-loading-bench)
+
+"$bin" eager none 50 7
+"$bin" on-demand none 50 7
+"$bin" eager haskell 50 7
+"$bin" on-demand haskell 50 7
+"$bin" eager haskell,javascript,python,typescript,json,xml,bash 500 7
+"$bin" on-demand haskell,javascript,python,typescript,json,xml,bash 500 7
+"$bin" eager haskell 5000 7
+"$bin" on-demand haskell 5000 7
+```
+
+Output columns are workload, requested language count, source line count,
+sample count, elapsed milliseconds, CPU milliseconds, allocated bytes, and
+live bytes. RTS statistics are enabled by the benchmark executable.
+
 The package owns:
 
 - loading KDE XML syntax definitions through Skylighting

--- a/packages/agent-syntax/agent-syntax.cabal
+++ b/packages/agent-syntax/agent-syntax.cabal
@@ -43,6 +43,16 @@ library
                     , skylighting-core >= 0.14.7 && < 0.15
                     , text >= 2.0 && < 2.2
 
+benchmark syntax-loading-bench
+    import:           common-options
+    type:             exitcode-stdio-1.0
+    hs-source-dirs:   benchmark
+    main-is:          SyntaxLoading.hs
+    ghc-options:      -O2 -rtsopts "-with-rtsopts=-T"
+    build-depends:    agent-syntax
+                    , base >= 4.17 && < 5
+                    , text >= 2.0 && < 2.2
+
 test-suite agent-syntax-test
     import:           common-options
     type:             exitcode-stdio-1.0

--- a/packages/agent-syntax/benchmark/SyntaxLoading.hs
+++ b/packages/agent-syntax/benchmark/SyntaxLoading.hs
@@ -1,0 +1,192 @@
+module Main (main) where
+
+import Agent.Syntax
+    ( SyntaxHighlighter
+    , SyntaxSpan(..)
+    , highlightCode
+    , loadSyntaxHighlighterFrom
+    , loadSyntaxLanguage
+    , newSyntaxHighlighterFrom
+    )
+
+-- 'evaluate' is required to keep work inside the measured IO interval;
+-- safe-exceptions does not re-export it.
+import Control.Exception (evaluate)
+import Control.Monad (foldM, forM)
+import Data.List (sort)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import GHC.Clock (getMonotonicTimeNSec)
+import GHC.Stats
+    ( GCDetails(..)
+    , RTSStats(..)
+    , getRTSStats
+    , getRTSStatsEnabled
+    )
+import System.CPUTime (getCPUTime)
+import System.Environment (getArgs, lookupEnv)
+import System.Exit (die)
+import System.Mem (performGC)
+import Text.Printf (printf)
+
+data Workload
+    = Eager
+    | OnDemand
+
+data Sample = Sample
+    { elapsedMillis :: !Double
+    , cpuMillis :: !Double
+    , allocatedBytes :: !Integer
+    , liveBytes :: !Integer
+    }
+
+main :: IO ()
+main = do
+    enabled <- getRTSStatsEnabled
+    if enabled
+        then pure ()
+        else die "RTS statistics are disabled; run with +RTS -T"
+    syntaxDirectory <-
+        lookupEnv "AGENT_SYNTAX_DIR" >>= \case
+            Just directory -> pure directory
+            Nothing -> die "AGENT_SYNTAX_DIR is not configured"
+    getArgs >>= \case
+        [workloadArg, languagesArg, sourceLineCountArg, sampleCountArg] -> do
+            workload <- parseWorkload workloadArg
+            languages <- parseLanguages languagesArg
+            sourceLineCount <-
+                parsePositive "source line count" sourceLineCountArg
+            sampleCount <- parsePositive "sample count" sampleCountArg
+            let source = sampleSource sourceLineCount
+            _ <- evaluate (Text.length source)
+            samples <-
+                forM [1 .. sampleCount] \_ ->
+                    measure workload syntaxDirectory languages source
+            let sample = median samples
+            printf
+                "%s,%d,%d,%d,%.3f,%.3f,%d,%d\n"
+                workloadArg
+                (length languages)
+                sourceLineCount
+                sampleCount
+                sample.elapsedMillis
+                sample.cpuMillis
+                sample.allocatedBytes
+                sample.liveBytes
+        _ ->
+            die $
+                "usage: syntax-loading-bench WORKLOAD LANGUAGES "
+                    <> "SOURCE_LINES SAMPLES\n"
+                    <> "workloads: eager, on-demand\n"
+                    <> "LANGUAGES is none or a comma-separated list\n"
+                    <> "output: workload,language_count,source_lines,samples,"
+                    <> "elapsed_ms,cpu_ms,allocated_bytes,live_bytes"
+
+parseWorkload :: String -> IO Workload
+parseWorkload = \case
+    "eager" -> pure Eager
+    "on-demand" -> pure OnDemand
+    other -> die ("unknown workload: " <> other)
+
+parseLanguages :: String -> IO [Text]
+parseLanguages "none" = pure []
+parseLanguages raw =
+    case filter (not . Text.null) $
+        map Text.strip $
+            Text.splitOn "," (Text.pack raw) of
+        [] -> die "LANGUAGES must be none or a non-empty comma-separated list"
+        languages -> pure languages
+
+parsePositive :: String -> String -> IO Int
+parsePositive label raw =
+    case reads raw of
+        [(value, "")]
+            | value > 0 -> pure value
+        _ -> die ("invalid " <> label <> ": " <> raw)
+
+measure :: Workload -> FilePath -> [Text] -> Text -> IO Sample
+measure workload syntaxDirectory languages source = do
+    performGC
+    beforeStats <- getRTSStats
+    beforeCpu <- getCPUTime
+    beforeElapsed <- getMonotonicTimeNSec
+    highlighter <- buildHighlighter workload syntaxDirectory languages
+    checksum <- evaluate (highlightChecksum highlighter languages source)
+    performGC
+    afterStats <- getRTSStats
+    afterElapsed <- getMonotonicTimeNSec
+    afterCpu <- getCPUTime
+    -- Keep the loaded grammar cache live through the measured collection.
+    _ <- evaluate highlighter
+    _ <- evaluate checksum
+    pure
+        Sample
+            { elapsedMillis =
+                fromIntegral (afterElapsed - beforeElapsed) / 1.0e6
+            , cpuMillis =
+                fromIntegral (afterCpu - beforeCpu) / 1.0e9
+            , allocatedBytes =
+                fromIntegral
+                    (afterStats.allocated_bytes - beforeStats.allocated_bytes)
+            , liveBytes =
+                fromIntegral afterStats.gc.gcdetails_live_bytes
+            }
+
+buildHighlighter
+    :: Workload
+    -> FilePath
+    -> [Text]
+    -> IO SyntaxHighlighter
+buildHighlighter workload syntaxDirectory languages =
+    case workload of
+        Eager ->
+            loadSyntaxHighlighterFrom syntaxDirectory >>= requireHighlighter
+        OnDemand -> do
+            initial <-
+                newSyntaxHighlighterFrom syntaxDirectory
+                    >>= requireHighlighter
+            foldM
+                (\current language ->
+                    loadSyntaxLanguage current language
+                        >>= requireHighlighter)
+                initial
+                languages
+
+requireHighlighter
+    :: Either Text SyntaxHighlighter
+    -> IO SyntaxHighlighter
+requireHighlighter =
+    either (die . Text.unpack) pure
+
+highlightChecksum :: SyntaxHighlighter -> [Text] -> Text -> Int
+highlightChecksum highlighter languages source =
+    foldl' checksumLanguage 5381 languages
+  where
+    checksumLanguage checksum language =
+        case highlightCode highlighter language source of
+            Left message ->
+                error (Text.unpack message)
+            Right lines' ->
+                foldl' (foldl' checksumSpan) checksum lines'
+    checksumSpan checksum SyntaxSpan{syntaxClass, syntaxText} =
+        Text.foldl'
+            (\value character -> value * 33 + fromEnum character)
+            (checksum * 33 + fromEnum syntaxClass)
+            syntaxText
+
+sampleSource :: Int -> Text
+sampleSource lineCount =
+    Text.intercalate
+        "\n"
+        (replicate lineCount "value = value + 42 -- benchmark")
+
+median :: [Sample] -> Sample
+median samples =
+    Sample
+        { elapsedMillis = middle (sort (map (.elapsedMillis) samples))
+        , cpuMillis = middle (sort (map (.cpuMillis) samples))
+        , allocatedBytes = middle (sort (map (.allocatedBytes) samples))
+        , liveBytes = middle (sort (map (.liveBytes) samples))
+        }
+  where
+    middle values = values !! (length values `div` 2)

--- a/packages/agent-syntax/package.nix
+++ b/packages/agent-syntax/package.nix
@@ -1,14 +1,15 @@
-{ mkDerivation, base, containers, filepath, hspec, lib
-, skylighting-core, text
+{ mkDerivation, base, bytestring, containers, directory, filepath
+, hspec, lib, skylighting-core, text
 }:
 mkDerivation {
   pname = "agent-syntax";
   version = "0.1.0.0";
   src = ./.;
   libraryHaskellDepends = [
-    base containers filepath skylighting-core text
+    base bytestring containers directory filepath skylighting-core text
   ];
   testHaskellDepends = [ base hspec text ];
+  benchmarkHaskellDepends = [ base text ];
   description = "Syntax highlighting for the universal agent harness";
-  license = lib.meta.getLicenseFromSpdxId "BSD-3-Clause";
+  license = lib.meta.getLicenseFromSpdxId "MIT";
 }


### PR DESCRIPTION
## Summary

Follow-up to #572 addressing both review comments:

- regenerate `packages/agent-syntax/package.nix` so the direct `bytestring` and
  `directory` library dependencies are supplied explicitly
- retain eager loading as a benchmark baseline and add a reproducible
  eager-vs-on-demand syntax loading benchmark
- include the benchmark in the filtered Nix source and document optimized,
  repeatable commands

## Benchmark

Environment:

- Apple M3 Max, macOS 26.6.1
- GHC 9.10.3, optimized Cabal build (`--enable-optimization=2`)
- 166 Skylighting XML definitions (5.9 MiB)
- RTS statistics enabled; 7 samples per workload; table entries are medians
- identical grammar requests and generated source are highlighted in both paths

Commands:

```sh
nix develop
cabal build --offline --enable-optimization=2 \
  agent-syntax:bench:syntax-loading-bench
bin=$(cabal list-bin agent-syntax:bench:syntax-loading-bench)

"$bin" eager none 50 7
"$bin" on-demand none 50 7
"$bin" eager haskell 50 7
"$bin" on-demand haskell 50 7
"$bin" eager haskell,javascript,python,typescript,json,xml,bash 500 7
"$bin" on-demand haskell,javascript,python,typescript,json,xml,bash 500 7
"$bin" eager haskell 5000 7
"$bin" on-demand haskell 5000 7
```

| Path | Languages | Source lines | Wall ms | CPU ms | Allocated bytes | Live bytes |
|---|---:|---:|---:|---:|---:|---:|
| eager | 0 | 50 | 529.637 | 528.024 | 2,662,203,488 | 87,471,208 |
| on-demand | 0 | 50 | 0.405 | 0.404 | 315,304 | 92,144 |
| eager | 1 | 50 | 542.476 | 540.548 | 2,689,378,264 | 86,992,280 |
| on-demand | 1 | 50 | 19.260 | 19.025 | 118,755,360 | 926,880 |
| eager | 7 | 500 | 742.295 | 739.454 | 4,164,106,080 | 83,986,912 |
| on-demand | 7 | 500 | 226.559 | 226.199 | 1,722,412,936 | 2,418,840 |
| eager | 1 | 5000 | 870.974 | 865.243 | 5,240,158,792 | 87,269,336 |
| on-demand | 1 | 5000 | 330.388 | 329.515 | 2,669,535,776 | 1,252,800 |

The initialization-only workload reduces median live memory from 83.4 MiB to
90 KiB. Loading and using Haskell keeps the grammar cache below 1 MiB instead
of roughly 83 MiB. The larger inputs also confirm that highlighting work scales
with source size while the on-demand cache retains its memory advantage.

## Validation

- `nix develop -c cabal test --offline agent-syntax-test --test-show-details=direct`
- `nix develop -c cabal build --offline --enable-optimization=2 agent-syntax:bench:syntax-loading-bench`
- `nix build .#checks.aarch64-darwin.agent-syntax --no-link`
