### PR TITLE
Extract custom PostgreSQL types to reduce compile time

### DIFF
--- a/packages/agent-store/agent-store.cabal
+++ b/packages/agent-store/agent-store.cabal
@@ -49,6 +49,7 @@ library
                     , Agent.Store.Postgres.Skill
     other-modules:    Agent.Store.Custom.QueryResult
                     , Agent.Store.Postgres.Custom.Sql
+                    , Agent.Store.Postgres.Custom.Types
                     , Agent.Store.Postgres.Skill.Types
                     , Agent.Store.Postgres.Session.Types
                     , Agent.Store.Postgres.Hasql

--- a/packages/agent-store/src/Agent/Store/Postgres/Custom.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Custom.hs
@@ -30,7 +30,7 @@ module Agent.Store.Postgres.Custom
 import Control.Monad (forM_, unless)
 import qualified Data.ByteString as ByteString
 import Data.Functor.Contravariant ((>$<))
-import Data.Int (Int32, Int64)
+import Data.Int (Int32)
 import qualified Data.Map.Strict as Map
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -61,77 +61,7 @@ import Agent.Store.Postgres.Custom.Sql
     ( normalizeCustomExecution
     , normalizeCustomQuery
     )
-
-data QueryLimits = QueryLimits
-    { queryMaxRows :: !Int64
-    , queryMaxOutputBytes :: !Int
-    , queryStatementTimeoutMs :: !Int
-    , queryLockTimeoutMs :: !Int
-    }
-    deriving (Eq, Show)
-
-defaultQueryLimits :: QueryLimits
-defaultQueryLimits = QueryLimits
-    { queryMaxRows = 500
-    , queryMaxOutputBytes = 100000
-    , queryStatementTimeoutMs = 30000
-    , queryLockTimeoutMs = 5000
-    }
-
-data CatalogObject = CatalogObject
-    { catalogObjectKind :: !Text
-    , catalogObjectName :: !Text
-    , catalogObjectDefinition :: !CatalogDefinition
-    }
-    deriving (Eq, Show)
-
-data CatalogDefinition = CatalogDefinition
-    { definitionOwner :: !(Maybe Text)
-    , definitionComment :: !(Maybe Text)
-    , definitionView :: !(Maybe Text)
-    , definitionColumns :: ![CatalogColumn]
-    , definitionConstraints :: ![CatalogConstraint]
-    , definitionIndexes :: ![CatalogIndex]
-    }
-    deriving (Eq, Show)
-
-data CatalogColumn = CatalogColumn
-    { columnName :: !Text
-    , columnType :: !Text
-    , columnNullable :: !Bool
-    , columnDefault :: !(Maybe Text)
-    , columnIdentity :: !(Maybe Text)
-    , columnGenerated :: !(Maybe Text)
-    , columnComment :: !(Maybe Text)
-    }
-    deriving (Eq, Show)
-
-data CatalogConstraint = CatalogConstraint
-    { constraintName :: !Text
-    , constraintType :: !Text
-    , constraintDefinition :: !Text
-    }
-    deriving (Eq, Show)
-
-data CatalogIndex = CatalogIndex
-    { indexName :: !Text
-    , indexDefinition :: !Text
-    }
-    deriving (Eq, Show)
-
-data CustomAuditContext = CustomAuditContext
-    { customAuditSessionId :: !(Maybe Text)
-    , customAuditAgentId :: !(Maybe Text)
-    }
-    deriving (Eq, Show)
-
-data CustomExecutionResult = CustomExecutionResult
-    { customExecutionAuditId :: !Text
-    , customExecutionCatalogBefore :: ![CatalogObject]
-    , customExecutionCatalogAfter :: ![CatalogObject]
-    , customExecutionWarning :: !(Maybe Text)
-    }
-    deriving (Eq, Show)
+import Agent.Store.Postgres.Custom.Types
 
 inspectCustomSchema
     :: Pool

--- a/packages/agent-store/src/Agent/Store/Postgres/Custom/Types.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Custom/Types.hs
@@ -1,0 +1,87 @@
+{-# LANGUAGE NoFieldSelectors #-}
+
+module Agent.Store.Postgres.Custom.Types
+    ( QueryLimits(..)
+    , defaultQueryLimits
+    , CatalogObject(..)
+    , CatalogDefinition(..)
+    , CatalogColumn(..)
+    , CatalogConstraint(..)
+    , CatalogIndex(..)
+    , CustomAuditContext(..)
+    , CustomExecutionResult(..)
+    ) where
+
+import Data.Int (Int64)
+import Data.Text (Text)
+
+data QueryLimits = QueryLimits
+    { queryMaxRows :: !Int64
+    , queryMaxOutputBytes :: !Int
+    , queryStatementTimeoutMs :: !Int
+    , queryLockTimeoutMs :: !Int
+    }
+    deriving (Eq, Show)
+
+defaultQueryLimits :: QueryLimits
+defaultQueryLimits = QueryLimits
+    { queryMaxRows = 500
+    , queryMaxOutputBytes = 100000
+    , queryStatementTimeoutMs = 30000
+    , queryLockTimeoutMs = 5000
+    }
+
+data CatalogObject = CatalogObject
+    { catalogObjectKind :: !Text
+    , catalogObjectName :: !Text
+    , catalogObjectDefinition :: !CatalogDefinition
+    }
+    deriving (Eq, Show)
+
+data CatalogDefinition = CatalogDefinition
+    { definitionOwner :: !(Maybe Text)
+    , definitionComment :: !(Maybe Text)
+    , definitionView :: !(Maybe Text)
+    , definitionColumns :: ![CatalogColumn]
+    , definitionConstraints :: ![CatalogConstraint]
+    , definitionIndexes :: ![CatalogIndex]
+    }
+    deriving (Eq, Show)
+
+data CatalogColumn = CatalogColumn
+    { columnName :: !Text
+    , columnType :: !Text
+    , columnNullable :: !Bool
+    , columnDefault :: !(Maybe Text)
+    , columnIdentity :: !(Maybe Text)
+    , columnGenerated :: !(Maybe Text)
+    , columnComment :: !(Maybe Text)
+    }
+    deriving (Eq, Show)
+
+data CatalogConstraint = CatalogConstraint
+    { constraintName :: !Text
+    , constraintType :: !Text
+    , constraintDefinition :: !Text
+    }
+    deriving (Eq, Show)
+
+data CatalogIndex = CatalogIndex
+    { indexName :: !Text
+    , indexDefinition :: !Text
+    }
+    deriving (Eq, Show)
+
+data CustomAuditContext = CustomAuditContext
+    { customAuditSessionId :: !(Maybe Text)
+    , customAuditAgentId :: !(Maybe Text)
+    }
+    deriving (Eq, Show)
+
+data CustomExecutionResult = CustomExecutionResult
+    { customExecutionAuditId :: !Text
+    , customExecutionCatalogBefore :: ![CatalogObject]
+    , customExecutionCatalogAfter :: ![CatalogObject]
+    , customExecutionWarning :: !(Maybe Text)
+    }
+    deriving (Eq, Show)


### PR DESCRIPTION
## Summary

- extract custom PostgreSQL catalog and execution types into an internal module
- preserve the existing `Agent.Store.Postgres.Custom` API through re-exports
- reduce the size of the custom persistence module without changing behavior

## Validation

- `nix develop -c cabal build --offline --jobs=1 agent-store:lib:agent-store`
- `TMPDIR=/tmp nix develop -c cabal test --offline --jobs=1 agent-store:test:agent-store-test --test-show-details=direct` (33 examples)
- `git diff --check`
