### PR TITLE
Raise default max turn limit to 2000

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Options.hs
+++ b/packages/agent-cli/src/Agent/CLI/Options.hs
@@ -21,6 +21,7 @@ module Agent.CLI.Options
 
 import System.OsPath (OsPath, unsafeEncodeUtf)
 import Agent.Dialect (DialectId(..))
+import Agent.Loop (defaultLoopMaxTurns)
 import Agent.Provider (Provider(..), parseProvider)
 import Agent.TUI.Motion (MotionMode(..))
 import Data.Foldable (asum)
@@ -130,7 +131,7 @@ defaultCliOptions = CliOptions
     , optYolo = False
     , optNoYolo = False
     , optManagedDenyMutations = False
-    , optMaxTurns = 500
+    , optMaxTurns = defaultLoopMaxTurns
     , optMaxConcurrentAgents = Nothing
     , optCompactThreshold = Nothing
     , optEffort = Nothing
@@ -524,7 +525,8 @@ usage = unlines
     , "      --motion MODE       Animation policy: full, reduced, or off"
     , "      --yolo              Auto-approve every tool"
     , "      --no-yolo           Never auto-approve; deny mutating tools without a TTY"
-    , "      --max-turns N       Stop after N model turns (default: 500)"
+    , "      --max-turns N       Stop after N model turns (default: "
+        <> show defaultLoopMaxTurns <> ")"
     , "      --max-concurrent-agents N"
     , "                          Concurrent subagent cap (default: 32;"
     , "                          project settings, then ~/.haskell-agent/config.json)"

--- a/packages/agent-cli/test/Agent/CLI/OptionsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/OptionsSpec.hs
@@ -2,6 +2,7 @@ module Agent.CLI.OptionsSpec (spec) where
 
 import Agent.CLI.Options
 import Agent.Dialect (DialectId(..))
+import Agent.Loop (defaultLoopMaxTurns)
 import System.OsPath (unsafeEncodeUtf)
 import Agent.Provider (Provider(..))
 import Agent.TUI.Motion (MotionMode(..))
@@ -136,6 +137,14 @@ spec = do
             parseArgs ["--managed-turn-file", "turn.json"]
                 `shouldBe` Right (RunAgent defaultCliOptions
                     { optManagedTurnFile = Just (fromFilePath "turn.json") })
+
+        it "defaults max turns from agent-core and requires a positive override" do
+            defaultCliOptions.optMaxTurns `shouldBe` defaultLoopMaxTurns
+            defaultLoopMaxTurns `shouldBe` 2000
+            parseArgs ["--max-turns", "0"] `shouldSatisfy` isLeft
+            parseArgs ["--max-turns", "-1"] `shouldSatisfy` isLeft
+            parseArgs ["--max-turns", "nope"] `shouldSatisfy` isLeft
+            usage `shouldContain` ("default: " <> show defaultLoopMaxTurns)
 
         it "requires a positive concurrent agent limit" do
             parseArgs ["--max-concurrent-agents", "0"] `shouldSatisfy` isLeft

--- a/packages/agent-core/src/Agent/Loop.hs
+++ b/packages/agent-core/src/Agent/Loop.hs
@@ -300,7 +300,7 @@ data LoopError
     deriving (Eq, Show)
 
 defaultLoopMaxTurns :: Int
-defaultLoopMaxTurns = 500
+defaultLoopMaxTurns = 2000
 
 -- | CLI-facing formatter: unknown tools, handler errors, and crashes stay
 -- in-band as tool output so the model can continue.

--- a/packages/agent-core/test/Agent/LoopSpec.hs
+++ b/packages/agent-core/test/Agent/LoopSpec.hs
@@ -804,6 +804,9 @@ spec = describe "runLoop" do
                 denied.output `shouldBe` "Tool call rejected by user."
             other -> expectationFailure ("unexpected submissions: " <> show other)
 
+    it "defaults to a 2000-turn budget" do
+        defaultLoopMaxTurns `shouldBe` 2000
+
     it "returns LoopMaxTurns when the model keeps calling tools" do
         backend <- endlessToolsBackend
         config0 <- testConfig backend


### PR DESCRIPTION
Long-running autonomous sessions were hitting the 500-turn cap.

- `defaultLoopMaxTurns` (agent-core) raised from 500 to 2000
- `agent-cli` now derives `optMaxTurns` and the `--max-turns` usage text from `defaultLoopMaxTurns` instead of hardcoding 500, so the CLI default and help text can't drift from the core constant
- `--max-turns N` still overrides per invocation
- LoopSpec and OptionsSpec lock the 2000 default, reject non-positive `--max-turns`, and keep help text in sync

Typechecked via `cabal repl agent-core:lib:agent-core agent-cli:lib:agent-cli` (275 modules, clean load).
Ran `runLoop` max-turn specs and the OptionsSpec default/validation example in GHCi.