### PR TITLE
fix(compaction): distinguish estimated occupancy from provider usage

### DIFF
--- a/packages/agent-cli/benchmark/SubagentRetention.hs
+++ b/packages/agent-cli/benchmark/SubagentRetention.hs
@@ -1,5 +1,6 @@
 module Main (main) where
 
+import Agent.CLI.Compaction (OccupancySnapshot(..), estimatedOccupancy)
 import Agent.CLI.Subagents.Runtime (SubagentSession(..))
 import Agent.Dialect (DialectId(..))
 import Agent.Provider (Provider(..))
@@ -145,7 +146,7 @@ buildSessions agentCount itemCount payloadBytes sampleIndex =
                 | itemIndex <- [1 .. itemCount]
                 ]
         transcript <- newIORef items
-        contextTokens <- newIORef (Just (itemCount, payloadBytes))
+        contextTokens <- newIORef (Just (estimatedOccupancy itemCount payloadBytes))
         pinned <- newIORef False
         hydrated <- newMVar True
         pure
@@ -178,7 +179,12 @@ checksumSessions sessions =
         pure $
             foldl'
                 checksumItem
-                (checksum * 33 + agentIndex + maybe 0 (uncurry (+)) context)
+                ( checksum * 33 + agentIndex
+                    + maybe 0
+                        (\snapshot ->
+                            snapshot.occupancyTokens + snapshot.occupancyLength)
+                        context
+                )
                 items
 
 checksumItem :: Int -> ResponseItem -> Int

--- a/packages/agent-cli/src/Agent/CLI/Compaction.hs
+++ b/packages/agent-cli/src/Agent/CLI/Compaction.hs
@@ -17,6 +17,10 @@ module Agent.CLI.Compaction
     , runProviderCompactWithContextWindow
     , runResponsesCompactWith
     , runResponsesCompactWithContextWindow
+    , OccupancyKind(..)
+    , OccupancySnapshot(..)
+    , estimatedOccupancy
+    , reportedOccupancy
     ) where
 
 import Agent.CLI.Error (formatApiError)
@@ -94,6 +98,36 @@ data CompactOutcome = CompactOutcome
     , compactHistory :: ![ResponseItem]
     , compactSummary :: !Text
     } deriving (Eq, Show)
+
+-- | Whether cached occupancy is provider-reported full-request usage or an
+-- items-only estimate. Estimated snapshots must not be treated as complete
+-- occupancy because they omit instructions, skills, and tool schemas.
+data OccupancyKind
+    = ReportedOccupancy
+    | EstimatedOccupancy
+    deriving (Eq, Show)
+
+data OccupancySnapshot = OccupancySnapshot
+    { occupancyTokens :: !Int
+    , occupancyLength :: !Int
+    , occupancyKind :: !OccupancyKind
+    } deriving (Eq, Show)
+
+reportedOccupancy :: Int -> Int -> OccupancySnapshot
+reportedOccupancy tokens historyLength =
+    OccupancySnapshot
+        { occupancyTokens = tokens
+        , occupancyLength = historyLength
+        , occupancyKind = ReportedOccupancy
+        }
+
+estimatedOccupancy :: Int -> Int -> OccupancySnapshot
+estimatedOccupancy tokens historyLength =
+    OccupancySnapshot
+        { occupancyTokens = tokens
+        , occupancyLength = historyLength
+        , occupancyKind = EstimatedOccupancy
+        }
 
 type OpenAiCompactionSender =
     ResponseCreateParams -> IO (Either ApiError Response)
@@ -320,7 +354,7 @@ runAttemptAndRecord recordUsage action =
 installCompactOutcome
     :: IORef (Maybe Text)
     -> IORef [ResponseItem]
-    -> Maybe (IORef (Maybe (Int, Int)))
+    -> Maybe (IORef (Maybe OccupancySnapshot))
     -> (Maybe Text -> IO (Either Text CompactOutcome))
     -> Maybe Text
     -> IO (Either Text CompactOutcome)
@@ -335,15 +369,15 @@ installCompactOutcome previous transcript contextTokens runCompact focus =
                 case contextTokens of
                     Nothing -> pure ()
                     Just ref ->
-                        writeIORef ref $ Just
-                            ( outcome.compactAfterTokens
-                            , length outcome.compactHistory
-                            )
+                        writeIORef ref $ Just $
+                            estimatedOccupancy
+                                outcome.compactAfterTokens
+                                (length outcome.compactHistory)
         pure result
 
 installLiveCompactOutcome
     :: IORef LiveConversation
-    -> Maybe (IORef (Maybe (Int, Int)))
+    -> Maybe (IORef (Maybe OccupancySnapshot))
     -> (Maybe Text -> IO (Either Text CompactOutcome))
     -> Maybe Text
     -> IO (Either Text CompactOutcome)
@@ -358,10 +392,10 @@ installLiveCompactOutcome conversationRef contextTokens runCompact focus =
                 case contextTokens of
                     Nothing -> pure ()
                     Just ref ->
-                        writeIORef ref $ Just
-                            ( outcome.compactAfterTokens
-                            , length outcome.compactHistory
-                            )
+                        writeIORef ref $ Just $
+                            estimatedOccupancy
+                                outcome.compactAfterTokens
+                                (length outcome.compactHistory)
         pure result
 
 sendOpenAIRemoteCompaction
@@ -641,7 +675,7 @@ isPortableLocalSummaryItem = \case
 autoCompactOpenAiBackend
     :: TokenProvider
     -> IO ResponseCreateParams
-    -> IORef (Maybe (Int, Int))
+    -> IORef (Maybe OccupancySnapshot)
     -> Backend
     -> Backend
 autoCompactOpenAiBackend =
@@ -653,7 +687,7 @@ autoCompactOpenAiBackendWithThreshold
     :: Maybe Int
     -> TokenProvider
     -> IO ResponseCreateParams
-    -> IORef (Maybe (Int, Int))
+    -> IORef (Maybe OccupancySnapshot)
     -> Backend
     -> Backend
 autoCompactOpenAiBackendWithThreshold configuredThreshold tokenProvider
@@ -674,7 +708,7 @@ autoCompactOpenAiBackendWithSender
     -> OpenAiCompactionSender
     -> (TokenUsage -> IO ())
     -> IO ResponseCreateParams
-    -> IORef (Maybe (Int, Int))
+    -> IORef (Maybe OccupancySnapshot)
     -> Backend
     -> Backend
 autoCompactOpenAiBackendWithSender configuredThreshold send recordUsage
@@ -697,7 +731,7 @@ autoCompactOpenAiBackendWithSenderAndHook
     -> (TokenUsage -> IO ())
     -> IO ResponseCreateParams
     -> IO ()
-    -> IORef (Maybe (Int, Int))
+    -> IORef (Maybe OccupancySnapshot)
     -> Backend
     -> Backend
 autoCompactOpenAiBackendWithSenderAndHook configuredThreshold send recordUsage
@@ -846,7 +880,7 @@ rejectOversizedInitialRequest getParams (Backend submit) =
 -- @input_tokens@ are not re-estimated with JSON length.
 boundCompletedToolContinuations
     :: IO ResponseCreateParams
-    -> IORef (Maybe (Int, Int))
+    -> IORef (Maybe OccupancySnapshot)
     -> Backend
     -> Backend
 boundCompletedToolContinuations getParams contextTokensRef (Backend submit) =
@@ -957,7 +991,7 @@ toolOutputTruncationNotice =
 
 autoCompactOpenAiBackendWith
     :: IO (Either Text CompactOutcome)
-    -> IORef (Maybe (Int, Int))
+    -> IORef (Maybe OccupancySnapshot)
     -> Backend
     -> Backend
 autoCompactOpenAiBackendWith compactAction =
@@ -976,7 +1010,7 @@ autoCompactOpenAiBackendWith compactAction =
 
 autoCompactOpenAiBackendWithApi
     :: IO (Either ApiError CompactOutcome)
-    -> IORef (Maybe (Int, Int))
+    -> IORef (Maybe OccupancySnapshot)
     -> Backend
     -> Backend
 autoCompactOpenAiBackendWithApi compactAction =
@@ -992,9 +1026,9 @@ autoCompactOpenAiBackendWithLimit
     :: IO Int
     -> ([ResponseItem] -> [TurnInput] -> IO (CompactAttempt ApiError))
     -> (TokenUsage -> IO ())
-    -> (Maybe (Int, Int) -> [ResponseItem] -> [TurnInput] -> IO Int)
+    -> (Maybe OccupancySnapshot -> [ResponseItem] -> [TurnInput] -> IO Int)
     -> IO ()
-    -> IORef (Maybe (Int, Int))
+    -> IORef (Maybe OccupancySnapshot)
     -> Backend
     -> Backend
 autoCompactOpenAiBackendWithLimit getLimit compactAction recordUsage
@@ -1051,7 +1085,10 @@ autoCompactOpenAiBackendWithLimit getLimit compactAction recordUsage
     installSubmitAndTrack restore rollback outcome inputs onEvent = do
         let compactedHistory = outcome.compactHistory
             compactSnapshot =
-                Just (outcome.compactAfterTokens, length compactedHistory)
+                Just $
+                    estimatedOccupancy
+                        outcome.compactAfterTokens
+                        (length compactedHistory)
         writeIORef contextTokensRef compactSnapshot
         result <- restore (submit compactedHistory Nothing inputs onEvent)
         case result of
@@ -1084,7 +1121,7 @@ autoCompactOpenAiBackendWithLimit getLimit compactAction recordUsage
         err -> err
 
 estimateProjectedFromCache
-    :: Maybe (Int, Int)
+    :: Maybe OccupancySnapshot
     -> [ResponseItem]
     -> [TurnInput]
     -> IO Int
@@ -1100,29 +1137,37 @@ reportedContextTokens usage
     | otherwise =
         Just (max 0 usage.inputTokens + max 0 usage.outputTokens)
 
-occupancySnapshot :: BackendResult -> Maybe (Int, Int)
+occupancySnapshot :: BackendResult -> Maybe OccupancySnapshot
 occupancySnapshot result
     | Text.null result.backendOutput.responseId = Nothing
     | otherwise =
         reportedContextTokens result.backendOutput.tokenUsage >>= \tokens ->
-            Just (tokens, length result.backendState)
+            Just (reportedOccupancy tokens (length result.backendState))
 
--- | Project the next request from last reported occupancy when that snapshot
--- still describes @history@. Only unsent items are estimated; without a
--- snapshot, fall back to encoding the complete request (or items only when
--- request params are unavailable).
+-- | Project the next request from last occupancy when that snapshot still
+-- describes @history@. Provider-reported occupancy already includes
+-- instructions, tools, and skills, so only unsent items are estimated.
+-- Estimated compaction snapshots are items-only; recompute against the
+-- complete request when params are available so those fields are counted.
 projectRequestTokens
     :: Maybe ResponseCreateParams
-    -> Maybe (Int, Int)
+    -> Maybe OccupancySnapshot
     -> [ResponseItem]
     -> [TurnInput]
     -> Int
 projectRequestTokens params occupancy history inputs =
     case occupancy of
-        Just (tokens, observedLength)
-            | observedLength == length history
-            , tokens > 0 ->
-                tokens + estimateItemsTokens pendingItems
+        Just snapshot
+            | snapshot.occupancyLength == length history
+            , snapshot.occupancyTokens > 0
+            , snapshot.occupancyKind == ReportedOccupancy ->
+                snapshot.occupancyTokens + estimateItemsTokens pendingItems
+        Just snapshot
+            | snapshot.occupancyLength == length history
+            , snapshot.occupancyTokens > 0
+            , snapshot.occupancyKind == EstimatedOccupancy
+            , Nothing <- params ->
+                snapshot.occupancyTokens + estimateItemsTokens pendingItems
         _ ->
             case params of
                 Just requestParams ->

--- a/packages/agent-cli/src/Agent/CLI/Provider/OpenAI.hs
+++ b/packages/agent-cli/src/Agent/CLI/Provider/OpenAI.hs
@@ -5,7 +5,8 @@ module Agent.CLI.Provider.OpenAI
     ) where
 
 import Agent.CLI.Compaction
-    ( OpenAiCompactionSender
+    ( OccupancySnapshot
+    , OpenAiCompactionSender
     , autoCompactOpenAiBackendWithSenderAndHook
     )
 import Agent.CLI.Connectivity (withConnectionRecovery)
@@ -60,7 +61,7 @@ lockedOpenAiSession
     -> TokenProvider
     -> IORef OpenAiPersistentConnection
     -> IO ResponseCreateParams
-    -> IORef (Maybe (Int, Int))
+    -> IORef (Maybe OccupancySnapshot)
     -> (TokenUsage -> IO ())
     -> IO ()
     -> (OpenAiCompactionSender, Backend)

--- a/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
@@ -18,7 +18,10 @@ module Agent.CLI.Subagents.Runtime
 
 import Agent.CLI.Approval (childApprove)
 import Agent.CLI.Btw (trimDanglingToolSuffix)
-import Agent.CLI.Compaction (autoCompactOpenAiBackendWithSender)
+import Agent.CLI.Compaction
+    ( OccupancySnapshot
+    , autoCompactOpenAiBackendWithSender
+    )
 import Agent.CLI.Connectivity (withConnectionRecovery)
 import Agent.CLI.Options
     ( ApprovalPolicy
@@ -176,7 +179,7 @@ import qualified System.Info as SystemInfo
 
 data SubagentSession = SubagentSession
     { subSessionTranscript :: !(IORef [ResponseItem])
-    , subSessionContextTokens :: !(IORef (Maybe (Int, Int)))
+    , subSessionContextTokens :: !(IORef (Maybe OccupancySnapshot))
     , subSessionProvider :: !Provider
     , subSessionConnection :: !Text
     , subSessionEffectiveModel :: !Text

--- a/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
@@ -9,7 +9,9 @@ import Agent.CLI.Compaction
     , autoCompactOpenAiBackendWithThreshold
     , codexAutoCompactTokenLimit
     , compactOpenAIWith
+    , estimatedOccupancy
     , installCompactOutcome
+    , reportedOccupancy
     , runProviderCompact
     , runProviderCompactWith
     , runResponsesCompactWith
@@ -567,7 +569,7 @@ spec = do
         it "clears the previous response id with transcript and token state" do
             previous <- newIORef (Just "resp-old")
             transcript <- newIORef [userTextItem "old context"]
-            contextState <- newIORef (Just (100, 1))
+            contextState <- newIORef (Just (reportedOccupancy 100 1))
             actionMasking <- newIORef MaskedUninterruptible
             let compactedHistory = [userTextItem "compacted context"]
                 outcome = CompactOutcome
@@ -590,11 +592,16 @@ spec = do
             readIORef previous `shouldReturn` Nothing
             readIORef transcript `shouldReturn` compactedHistory
             readIORef contextState `shouldReturn`
-                Just (outcome.compactAfterTokens, length compactedHistory)
+                Just
+                    ( estimatedOccupancy
+                        outcome.compactAfterTokens
+                        (length compactedHistory)
+                    )
 
         it "leaves live state unchanged when compaction fails" do
             let oldHistory = [userTextItem "old context"]
-                oldContextState = Just (100, length oldHistory)
+                oldContextState =
+                    Just (reportedOccupancy 100 (length oldHistory))
             previous <- newIORef (Just "resp-old")
             transcript <- newIORef oldHistory
             contextState <- newIORef oldContextState
@@ -662,6 +669,62 @@ spec = do
                         base
             result <- backend.submitTurn history (Just "resp-old")
                 [UserMessage "new"] (const (pure ()))
+            result `shouldSatisfy` either (const False) (const True)
+            readIORef compactCalls `shouldReturn` 1
+
+        it "does not treat estimated compact occupancy as full request usage" do
+            let history =
+                    [userTextItem (Text.replicate 12_000 "old context ")]
+                params = (defaultResponseCreateParams :: ResponseCreateParams)
+                    { tools = Just
+                        [ FunctionToolValue FunctionTool
+                            { name = "large_tool"
+                            , description =
+                                Just (Text.replicate 4_000 "schema")
+                            , parameters = Nothing
+                            , strict = Just True
+                            , extraFields = mempty
+                            }
+                        ]
+                    }
+                pending = [UserMessage "new"]
+                projectedItems = history <> [userTextItem "new"]
+                projectedWithoutTools =
+                    estimateRequestTokensWithItems
+                        defaultResponseCreateParams
+                        projectedItems
+                projectedWithTools =
+                    estimateRequestTokensWithItems params projectedItems
+                threshold =
+                    projectedWithoutTools
+                        + ((projectedWithTools - projectedWithoutTools) `div` 2)
+                estimatedTokens = 50
+            projectedWithoutTools `shouldSatisfy` (< threshold)
+            projectedWithTools `shouldSatisfy` (>= threshold)
+            estimatedTokens + 20 `shouldSatisfy` (< threshold)
+            contextState <- newIORef
+                (Just (estimatedOccupancy estimatedTokens (length history)))
+            compactCalls <- newIORef (0 :: Int)
+            let sender _request = do
+                    modifyIORef' compactCalls (+ 1)
+                    pure (Right remoteCompactionResponse)
+                base = Backend \state _ _ _ ->
+                    pure $ successful state TurnOutput
+                        { responseId = "resp-new"
+                        , toolCalls = []
+                        , assistantText = Just "ok"
+                        , tokenUsage = TokenUsage 20 5 0
+                        }
+                backend =
+                    autoCompactOpenAiBackendWithSender
+                        (Just threshold)
+                        sender
+                        (const (pure ()))
+                        (pure params)
+                        contextState
+                        base
+            result <- backend.submitTurn history (Just "resp-old") pending
+                (const (pure ()))
             result `shouldSatisfy` either (const False) (const True)
             readIORef compactCalls `shouldReturn` 1
 
@@ -777,7 +840,8 @@ spec = do
         it "runs the post-compaction hook only after a successful continuation" do
             let history = [userTextItem "old"]
                 threshold = 20
-            contextState <- newIORef (Just (threshold, length history))
+            contextState <- newIORef
+                (Just (reportedOccupancy threshold (length history)))
             hookCalls <- newIORef (0 :: Int)
             let sender _request =
                     pure (Right remoteCompactionResponse)
@@ -970,7 +1034,7 @@ spec = do
                 base = Backend \_ _ _ _ ->
                     error "configured compaction threshold should run first"
             contextState <- newIORef
-                (Just (threshold, length history))
+                (Just (reportedOccupancy threshold (length history)))
             let backend =
                     autoCompactOpenAiBackendWithThreshold
                         (Just threshold)
@@ -1080,7 +1144,8 @@ spec = do
             let oldHistory = [userTextItem "old"]
                 compactedHistory = [userTextItem "compacted"]
             contextState <- newIORef
-                (Just (codexAutoCompactTokenLimit, length oldHistory))
+                (Just (reportedOccupancy
+                    codexAutoCompactTokenLimit (length oldHistory)))
             compactCalls <- newIORef (0 :: Int)
             seenPrevious <- newIORef []
             events <- newIORef []
@@ -1111,14 +1176,15 @@ spec = do
             readIORef compactCalls `shouldReturn` 1
             readIORef seenPrevious `shouldReturn` [Nothing]
             readIORef contextState `shouldReturn`
-                Just (25, length compactedHistory)
+                Just (reportedOccupancy 25 (length compactedHistory))
             readIORef events `shouldReturn`
                 [ActivityUpdated "Compacting context…"]
 
         it "records active-session compaction usage before a failed continuation" do
             let history = [userTextItem "old"]
                 threshold = 20
-                oldContextState = Just (threshold - 2, length history)
+                oldContextState =
+                    Just (reportedOccupancy (threshold - 2) (length history))
             contextState <- newIORef oldContextState
             requests <- newIORef []
             recordedUsage <- newIORef []
@@ -1149,7 +1215,8 @@ spec = do
         it "rolls back compacted state when the continuation is cancelled" do
             let history = [userTextItem "old"]
                 threshold = 20
-                oldContextState = Just (threshold, length history)
+                oldContextState =
+                    Just (reportedOccupancy threshold (length history))
             contextState <- newIORef oldContextState
             continuationMasking <- newIORef MaskedUninterruptible
             let sender _request =
@@ -1181,7 +1248,7 @@ spec = do
             let history = [userTextItem "old"]
                 threshold = 20
             contextState <- newIORef
-                (Just (threshold, length history))
+                (Just (reportedOccupancy threshold (length history)))
             compactCalls <- newIORef (0 :: Int)
             continuationCalls <- newIORef (0 :: Int)
             recordedUsage <- newIORef []
@@ -1244,7 +1311,8 @@ spec = do
                     , callKind = FunctionCallKind
                     }
             contextState <- newIORef
-                (Just (codexAutoCompactTokenLimit - 10, length oldHistory))
+                (Just (reportedOccupancy
+                    (codexAutoCompactTokenLimit - 10) (length oldHistory)))
             compactCalls <- newIORef (0 :: Int)
             recordedUsage <- newIORef []
             seenPrevious <- newIORef []
@@ -1278,7 +1346,7 @@ spec = do
             readIORef seenInputs `shouldReturn` [inputs]
             fmap (.backendState) result `shouldBe` Right oldHistory
             readIORef contextState `shouldReturn`
-                Just (25, length oldHistory)
+                Just (reportedOccupancy 25 (length oldHistory))
             readIORef recordedUsage `shouldReturn` []
 
         it "truncates oversized tool output before continuing the call" do
@@ -1381,7 +1449,9 @@ spec = do
                 [UserMessage "new"] (const (pure ()))
             result `shouldSatisfy` either (const False) (const True)
             readIORef contextState `shouldReturn`
-                Just (usage.inputTokens + usage.outputTokens, length history)
+                Just (reportedOccupancy
+                    (usage.inputTokens + usage.outputTokens)
+                    (length history))
 
         it "uses last reported occupancy instead of JSON length to decide compaction" do
             let history =
@@ -1395,7 +1465,8 @@ spec = do
                         (history <> turnInputsToItems pending)
                 threshold = occupancy + 1_000
             jsonEstimate `shouldSatisfy` (> threshold)
-            contextState <- newIORef (Just (occupancy, length history))
+            contextState <- newIORef
+                (Just (reportedOccupancy occupancy (length history)))
             compactCalls <- newIORef (0 :: Int)
             let sender _request = do
                     modifyIORef' compactCalls (+ 1)
@@ -1420,7 +1491,7 @@ spec = do
             result `shouldSatisfy` either (const False) (const True)
             readIORef compactCalls `shouldReturn` 0
             readIORef contextState `shouldReturn`
-                Just (25, length history)
+                Just (reportedOccupancy 25 (length history))
 
         it "does not truncate tool output when reported occupancy still fits" do
             let params = defaultResponseCreateParams
@@ -1452,7 +1523,8 @@ spec = do
                 params
                 (oldHistory <> turnInputsToItems inputs)
                 `shouldSatisfy` (> contextWindow)
-            contextState <- newIORef (Just (occupancy, length oldHistory))
+            contextState <- newIORef
+                (Just (reportedOccupancy occupancy (length oldHistory)))
             seenInputs <- newIORef []
             let base = Backend \_state _previous submitted _ -> do
                     modifyIORef' seenInputs (<> [submitted])
@@ -1502,7 +1574,8 @@ spec = do
                 params
                 (oldHistory <> turnInputsToItems inputs)
                 `shouldSatisfy` (<= contextWindow)
-            contextState <- newIORef (Just (occupancy, length oldHistory))
+            contextState <- newIORef
+                (Just (reportedOccupancy occupancy (length oldHistory)))
             seenInputs <- newIORef []
             let base = Backend \_state _previous submitted _ -> do
                     modifyIORef' seenInputs (<> [submitted])
@@ -1539,7 +1612,8 @@ spec = do
 
         it "forgets occupancy when the provider omits usage" do
             let history = [userTextItem "old"]
-                oldContextState = Just (1_000, length history)
+                oldContextState =
+                    Just (reportedOccupancy 1_000 (length history))
             contextState <- newIORef oldContextState
             let base = Backend \state _ _ _ ->
                     pure $ successful state TurnOutput
@@ -1566,7 +1640,8 @@ spec = do
                 compactError =
                     ProviderError UsageLimitReached "quota exhausted" (Just 120)
             contextState <- newIORef
-                (Just (codexAutoCompactTokenLimit, length history))
+                (Just (reportedOccupancy
+                    codexAutoCompactTokenLimit (length history)))
             let compactAction =
                     pure (Left compactError)
                 base = Backend \_ _ _ _ ->
@@ -1584,7 +1659,8 @@ spec = do
         it "rejects compacted snapshots at or above the trigger" do
             let history = [userTextItem "old"]
                 oldContextState =
-                    Just (codexAutoCompactTokenLimit, length history)
+                    Just (reportedOccupancy
+                        codexAutoCompactTokenLimit (length history))
                 compactedHistory = [userTextItem "still too large"]
                 compactAction =
                     pure $ Right CompactOutcome

--- a/packages/agent-cli/test/Agent/CLI/SubagentStoreSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SubagentStoreSpec.hs
@@ -1,5 +1,6 @@
 module Agent.CLI.SubagentStoreSpec (spec) where
 
+import Agent.CLI.Compaction (estimatedOccupancy)
 import Agent.CLI.SubagentStore
 import Agent.CLI.Session (LegacySubagentTarget(..))
 import Agent.Dialect (DialectId(..))
@@ -478,7 +479,8 @@ spec = describe "Agent.CLI.SubagentStore" do
                 lookupTestSession
                     sessionsRef storeRootRef typesRef agentId
             writeIORef session.subSessionTranscript items
-            writeIORef session.subSessionContextTokens (Just (100, 200))
+            writeIORef session.subSessionContextTokens
+                (Just (estimatedOccupancy 100 200))
             bracket
                 (newSubagentRegistry defaultSubagentConfig dir
                     (\_ _ _ _ -> fail "unexpected subagent runner invocation")


### PR DESCRIPTION
## Summary
Follow-up to #573. Manual `/compact` stores `compactAfterTokens` as an items-only estimate. That value was then treated as provider-reported full occupancy, so instructions, skills, and tool schemas were omitted on the next request.

Occupancy snapshots are now tagged `ReportedOccupancy` vs `EstimatedOccupancy`. Estimated snapshots recompute the complete request until the next provider `usage` arrives.

## Test plan
- [x] `env TMPDIR=/tmp HASKELL_AGENT_TMPDIR=/tmp nix develop -c cabal test agent-cli-test --test-options='--match autoCompactOpenAiBackendWith --match runProviderCompact --match installCompactOutcome --match compactOpenAIWith'` (48 examples)
- [ ] CI on this PR