### PR TITLE
Recover overflowing tool continuations and incomplete WebSocket turns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 /dist-newstyle/
 /.direnv/
+# Project-local last-model / approval state. Must not be committed or new
+# worktrees inherit a stale default such as Claude fable.
 /.haskell-agent/
 /result
 /result-*

--- a/packages/agent-cli/src/Agent/CLI/Compaction.hs
+++ b/packages/agent-cli/src/Agent/CLI/Compaction.hs
@@ -9,6 +9,7 @@ module Agent.CLI.Compaction
     , autoCompactOpenAiBackendWithSenderAndHook
     , autoCompactOpenAiBackendWith
     , autoCompactOpenAiBackendWithApi
+    , boundCompletedToolContinuations
     , compactOpenAIWith
     , installCompactOutcome
     , installLiveCompactOutcome
@@ -81,11 +82,12 @@ import Control.Monad.Trans.Except
     ( ExceptT
     , throwE
     )
-import Control.Exception.Safe (catchAny, mask, onException)
 import Control.Applicative ((<|>))
+import Control.Exception.Safe (catchAny, mask, onException)
 import Control.Monad (when)
 import Data.IORef (IORef, readIORef, writeIORef)
-import Data.Maybe (fromMaybe)
+import Data.List (partition)
+import Data.Maybe (fromMaybe, isJust)
 import Data.Text (Text)
 import qualified Data.Text as Text
 
@@ -737,7 +739,10 @@ autoCompactOpenAiBackendWithSenderAndHook
 autoCompactOpenAiBackendWithSenderAndHook configuredThreshold send recordUsage
         getParams onCompacted contextTokensRef backend =
     rejectOversizedInitialRequest getParams $
-        boundCompletedToolContinuations getParams contextTokensRef $
+        boundCompletedToolContinuations
+            (codexEffectiveContextWindowFor . (.model) <$> getParams)
+            getParams
+            contextTokensRef $
             autoCompactOpenAiBackendWithLimit
                 getLimit
                 compactAction
@@ -878,29 +883,48 @@ rejectOversizedInitialRequest getParams (Backend submit) =
 -- protocol identifiers and continuation id. Prefer the last provider-reported
 -- occupancy so skills, instructions, and tool schemas already counted in
 -- @input_tokens@ are not re-estimated with JSON length.
+--
+-- When a previous_response_id is present and occupancy is unknown, Codex only
+-- sends the new tool outputs, so size the continuation against that delta.
+-- Stateless providers and full-history replays trim older transcript items,
+-- keeping the unpaired function calls that match the in-flight results.
 boundCompletedToolContinuations
-    :: IO ResponseCreateParams
+    :: IO Int
+    -> IO ResponseCreateParams
     -> IORef (Maybe OccupancySnapshot)
     -> Backend
     -> Backend
-boundCompletedToolContinuations getParams contextTokensRef (Backend submit) =
+boundCompletedToolContinuations getWindow getParams contextTokensRef (Backend submit) =
     Backend \history previous inputs onEvent ->
-        if any isCompletedTool inputs
-            then do
+        if not (any isCompletedTool inputs)
+            then submit history previous inputs onEvent
+            else do
                 params <- getParams
+                contextWindow <- getWindow
                 occupancy <- readIORef contextTokensRef
-                let contextWindow =
-                        codexEffectiveContextWindowFor params.model
-                    requestTokens candidate =
-                        projectRequestTokens
-                            (Just params)
-                            occupancy
-                            history
-                            candidate
-                if requestTokens inputs <= contextWindow
-                    then submit history previous inputs onEvent
-                    else
-                        case
+                let liveChain = isJust previous
+                    requestTokens candidate
+                        | liveChain =
+                            case occupancy of
+                                Just snapshot
+                                    | snapshot.occupancyLength == length history
+                                    , snapshot.occupancyTokens > 0
+                                    , snapshot.occupancyKind == ReportedOccupancy ->
+                                        snapshot.occupancyTokens
+                                            + estimateItemsTokens
+                                                (turnInputsToItems candidate)
+                                _ ->
+                                    estimateRequestTokensWithItems
+                                        params
+                                        (turnInputsToItems candidate)
+                        | otherwise =
+                            projectRequestTokens
+                                (Just params)
+                                occupancy
+                                history
+                                candidate
+                    truncated =
+                        fromMaybe inputs $
                             fitCompletedToolOutputsToLimit
                                 ( max 0
                                     ( contextWindow
@@ -910,26 +934,56 @@ boundCompletedToolContinuations getParams contextTokensRef (Backend submit) =
                                 )
                                 requestTokens
                                 inputs
-                        of
-                            Just bounded ->
-                                submit history previous bounded onEvent
-                            Nothing ->
-                                case
-                                    fitCompletedToolOutputsToLimit
-                                        contextWindow
-                                        requestTokens
-                                        inputs
-                                of
-                                    Just bounded ->
-                                        submit history previous bounded onEvent
-                                    Nothing ->
-                                        pure $
-                                            Left toolContinuationTooLargeError
-            else submit history previous inputs onEvent
+                            <|> fitCompletedToolOutputsToLimit
+                                contextWindow
+                                requestTokens
+                                inputs
+                if requestTokens inputs <= contextWindow
+                    then submit history previous inputs onEvent
+                    else if requestTokens truncated <= contextWindow
+                        then submit history previous truncated onEvent
+                        else submitTrimmedHistory
+                            params
+                            contextWindow
+                            history
+                            truncated
+                            onEvent
   where
     isCompletedTool = \case
         CompletedTool{} -> True
         _ -> False
+
+    submitTrimmedHistory params contextWindow history inputs onEvent = do
+        let callIds = pendingToolCallIds inputs
+            (danglingCalls, prefix) =
+                partition (isPendingToolCall callIds) history
+            trailing = danglingCalls <> turnInputsToItems inputs
+            fittedPrefix =
+                trimResponseHistoryToFit
+                    contextWindow
+                    params
+                    trailing
+                    prefix
+            fittedHistory = fittedPrefix <> danglingCalls
+            fittedTokens =
+                estimateRequestTokensWithItems
+                    params
+                    (fittedHistory <> turnInputsToItems inputs)
+        if fittedTokens <= contextWindow
+            then submit fittedHistory Nothing inputs onEvent
+            else pure (Left toolContinuationTooLargeError)
+
+pendingToolCallIds :: [TurnInput] -> [Text]
+pendingToolCallIds inputs =
+    [ result.callId
+    | CompletedTool result <- inputs
+    ]
+
+isPendingToolCall :: [Text] -> ResponseItem -> Bool
+isPendingToolCall callIds = \case
+    FunctionCallItem call -> call.callId `elem` callIds
+    CustomToolCallItem call -> call.callId `elem` callIds
+    _ -> False
 
 fitCompletedToolOutputsToLimit
     :: Int

--- a/packages/agent-cli/src/Agent/CLI/Compaction.hs
+++ b/packages/agent-cli/src/Agent/CLI/Compaction.hs
@@ -740,7 +740,7 @@ autoCompactOpenAiBackendWithSenderAndHook configuredThreshold send recordUsage
         getParams onCompacted contextTokensRef backend =
     rejectOversizedInitialRequest getParams $
         boundCompletedToolContinuations
-            (codexEffectiveContextWindowFor . (.model) <$> getParams)
+            (codexEffectiveContextWindowFor . (.model))
             getParams
             contextTokensRef $
             autoCompactOpenAiBackendWithLimit
@@ -889,19 +889,19 @@ rejectOversizedInitialRequest getParams (Backend submit) =
 -- Stateless providers and full-history replays trim older transcript items,
 -- keeping the unpaired function calls that match the in-flight results.
 boundCompletedToolContinuations
-    :: IO Int
+    :: (ResponseCreateParams -> Int)
     -> IO ResponseCreateParams
     -> IORef (Maybe OccupancySnapshot)
     -> Backend
     -> Backend
-boundCompletedToolContinuations getWindow getParams contextTokensRef (Backend submit) =
+boundCompletedToolContinuations contextWindowFor getParams contextTokensRef (Backend submit) =
     Backend \history previous inputs onEvent ->
         if not (any isCompletedTool inputs)
             then submit history previous inputs onEvent
             else do
                 params <- getParams
-                contextWindow <- getWindow
                 occupancy <- readIORef contextTokensRef
+                let contextWindow = contextWindowFor params
                 let liveChain = isJust previous
                     requestTokens candidate
                         | liveChain =

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration.hs
@@ -28,7 +28,8 @@ import Agent.CLI.Auth
 import Agent.CLI.Clipboard ()
 import Agent.CLI.Command ()
 import Agent.CLI.Compaction
-    ( installLiveCompactOutcome,
+    ( boundCompletedToolContinuations,
+      installLiveCompactOutcome,
       runProviderCompactWith,
       runResponsesCompactWithContextWindow )
 import Agent.CLI.Config
@@ -2544,6 +2545,11 @@ runAgentInitializedWithLock
                                 Right result -> pure result
                     XAIProvider -> do
                         xaiOptions <- XAI.clientOptionsFromEnv
+                        let xaiWindow =
+                                fmap (fromMaybe 500_000)
+                                    (currentModelContextWindow
+                                        (XAIRequest.mapModel xaiOptions))
+                        xaiOccupancy <- newIORef Nothing
                         case multiCtx of
                             Just ctx ->
                                 setSubagentRunner ctx.multiRegistry $
@@ -2553,14 +2559,22 @@ runAgentInitializedWithLock
                                         XAIProvider
                                         ctx.multiSendToRoot
                                         (\childParams ->
-                                            xaiBackend xaiOptions tokenProvider
-                                                (pure childParams))
+                                            boundCompletedToolContinuations
+                                                xaiWindow
+                                                (pure childParams)
+                                                xaiOccupancy
+                                                (xaiBackend xaiOptions tokenProvider
+                                                    (pure childParams)))
                             Nothing -> pure ()
                         let backend =
                                 withPendingInputs pendingNotices $
                                     withConnectionRecovery $
-                                        xaiBackend xaiOptions tokenProvider
+                                        boundCompletedToolContinuations
+                                            xaiWindow
                                             (readIORef paramsRef)
+                                            xaiOccupancy
+                                            (xaiBackend xaiOptions tokenProvider
+                                                (readIORef paramsRef))
                             btwBackend privateParams =
                                 xaiBackend xaiOptions tokenProvider
                                     (pure privateParams)
@@ -2678,7 +2692,11 @@ runAgentInitializedWithLock
                                     =<< readIORef claudeTranscriptRef
                                 pure result
                     OpenRouterProvider -> do
-                        let makeBackend params =
+                        openRouterOccupancy <- newIORef Nothing
+                        let openRouterWindow =
+                                fmap (fromMaybe 1_048_576)
+                                    (currentModelContextWindow transportModel)
+                            makeBackend params =
                                 case customGenericOptions of
                                     Just genericOptions ->
                                         genericResponsesBackendWith
@@ -2697,6 +2715,12 @@ runAgentInitializedWithLock
                                     Nothing ->
                                         openRouterBackend openRouterOptions
                                             tokenProvider params
+                            protectOverflow params backend =
+                                boundCompletedToolContinuations
+                                    openRouterWindow
+                                    params
+                                    openRouterOccupancy
+                                    backend
                         case multiCtx of
                             Just ctx ->
                                 setSubagentRunner ctx.multiRegistry $
@@ -2706,14 +2730,18 @@ runAgentInitializedWithLock
                                         OpenRouterProvider
                                         ctx.multiSendToRoot
                                         (\childParams ->
-                                            makeBackend
-                                                (pure childParams))
+                                            protectOverflow
+                                                (pure childParams)
+                                                (makeBackend
+                                                    (pure childParams)))
                             Nothing -> pure ()
                         let backend =
                                 withPendingInputs pendingNotices $
                                     withConnectionRecovery $
-                                        makeBackend
+                                        protectOverflow
                                             (readIORef paramsRef)
+                                            (makeBackend
+                                                (readIORef paramsRef))
                             btwBackend privateParams =
                                 makeBackend
                                     (pure privateParams)

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration.hs
@@ -2056,13 +2056,20 @@ runAgentInitializedWithLock
         generatedContextReloadRef <- newIORef (pure ())
         let currentModelContextWindow mapTransportModel = do
                 currentParams <- readIORef paramsRef
-                pure $ do
-                    currentModel <- currentParams.model
-                    catalogContextWindowForTransport
-                        catalog
-                        inferredTarget.targetConnectionId
-                        currentModel
-                        (mapTransportModel currentModel)
+                pure $
+                    catalogContextWindowForParams
+                        mapTransportModel
+                        currentParams
+            catalogContextWindowForParams mapTransportModel params = do
+                currentModel <- params.model
+                catalogContextWindowForTransport
+                    catalog
+                    inferredTarget.targetConnectionId
+                    currentModel
+                    (mapTransportModel currentModel)
+            contextWindowForParams mapTransportModel fallback params =
+                fromMaybe fallback
+                    (catalogContextWindowForParams mapTransportModel params)
             subagentRuntime = SubagentRuntime
                 { subagentOptions = options
                 , subagentGhciEnabled = ghciEnabledRef
@@ -2545,10 +2552,16 @@ runAgentInitializedWithLock
                                 Right result -> pure result
                     XAIProvider -> do
                         xaiOptions <- XAI.clientOptionsFromEnv
-                        let xaiWindow =
-                                fmap (fromMaybe 500_000)
-                                    (currentModelContextWindow
-                                        (XAIRequest.mapModel xaiOptions))
+                        let xaiContextWindow =
+                                contextWindowForParams
+                                    (XAIRequest.mapModel xaiOptions)
+                                    500_000
+                            protectXaiOverflow occupancy getParams backend =
+                                boundCompletedToolContinuations
+                                    xaiContextWindow
+                                    getParams
+                                    occupancy
+                                    backend
                         xaiOccupancy <- newIORef Nothing
                         case multiCtx of
                             Just ctx ->
@@ -2559,20 +2572,18 @@ runAgentInitializedWithLock
                                         XAIProvider
                                         ctx.multiSendToRoot
                                         (\childParams ->
-                                            boundCompletedToolContinuations
-                                                xaiWindow
-                                                (pure childParams)
+                                            protectXaiOverflow
                                                 xaiOccupancy
+                                                (pure childParams)
                                                 (xaiBackend xaiOptions tokenProvider
                                                     (pure childParams)))
                             Nothing -> pure ()
                         let backend =
                                 withPendingInputs pendingNotices $
                                     withConnectionRecovery $
-                                        boundCompletedToolContinuations
-                                            xaiWindow
-                                            (readIORef paramsRef)
+                                        protectXaiOverflow
                                             xaiOccupancy
+                                            (readIORef paramsRef)
                                             (xaiBackend xaiOptions tokenProvider
                                                 (readIORef paramsRef))
                             btwBackend privateParams =
@@ -2693,9 +2704,8 @@ runAgentInitializedWithLock
                                 pure result
                     OpenRouterProvider -> do
                         openRouterOccupancy <- newIORef Nothing
-                        let openRouterWindow =
-                                fmap (fromMaybe 1_048_576)
-                                    (currentModelContextWindow transportModel)
+                        let openRouterContextWindow =
+                                contextWindowForParams transportModel 1_048_576
                             makeBackend params =
                                 case customGenericOptions of
                                     Just genericOptions ->
@@ -2715,11 +2725,11 @@ runAgentInitializedWithLock
                                     Nothing ->
                                         openRouterBackend openRouterOptions
                                             tokenProvider params
-                            protectOverflow params backend =
+                            protectOverflow occupancy getParams backend =
                                 boundCompletedToolContinuations
-                                    openRouterWindow
-                                    params
-                                    openRouterOccupancy
+                                    openRouterContextWindow
+                                    getParams
+                                    occupancy
                                     backend
                         case multiCtx of
                             Just ctx ->
@@ -2731,6 +2741,7 @@ runAgentInitializedWithLock
                                         ctx.multiSendToRoot
                                         (\childParams ->
                                             protectOverflow
+                                                openRouterOccupancy
                                                 (pure childParams)
                                                 (makeBackend
                                                     (pure childParams)))
@@ -2739,6 +2750,7 @@ runAgentInitializedWithLock
                                 withPendingInputs pendingNotices $
                                     withConnectionRecovery $
                                         protectOverflow
+                                            openRouterOccupancy
                                             (readIORef paramsRef)
                                             (makeBackend
                                                 (readIORef paramsRef))

--- a/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
@@ -1671,6 +1671,138 @@ spec = do
             result `shouldSatisfy` either (const False) (const True)
             readIORef contextState `shouldReturn` Nothing
 
+        it "continues a live tool chain without counting retained history against the window" do
+            let params = defaultResponseCreateParams
+                contextWindow =
+                    codexEffectiveContextWindowFor params.model
+                danglingCall = FunctionCallItem FunctionCall
+                    { itemId = Nothing
+                    , callId = "call-live"
+                    , name = "shell_command"
+                    , namespace = Nothing
+                    , arguments = "{}"
+                    , encryptedFunctionArgs = Nothing
+                    , status = Nothing
+                    , extraFields = mempty
+                    }
+                oldHistory =
+                    [ userTextItem
+                        (Text.replicate ((contextWindow + 1_000) * 4) "x")
+                    , danglingCall
+                    ]
+                toolResult = ToolCallResult
+                    { callId = "call-live"
+                    , output = "ok"
+                    , callKind = FunctionCallKind
+                    }
+                inputs = [CompletedTool toolResult]
+            estimateRequestTokensWithItems
+                params
+                (oldHistory <> turnInputsToItems inputs)
+                `shouldSatisfy` (> contextWindow)
+            contextState <- newIORef Nothing
+            compactCalls <- newIORef (0 :: Int)
+            seenPrevious <- newIORef []
+            seenInputs <- newIORef []
+            let sender _request = do
+                    modifyIORef' compactCalls (+ 1)
+                    pure (Right remoteCompactionResponse)
+                base = Backend \state previous submitted _ -> do
+                    modifyIORef' seenPrevious (<> [previous])
+                    modifyIORef' seenInputs (<> [submitted])
+                    pure $ successful state TurnOutput
+                        { responseId = "resp-new"
+                        , toolCalls = []
+                        , assistantText = Just "ok"
+                        , tokenUsage = TokenUsage 20 5 0
+                        }
+                backend =
+                    autoCompactOpenAiBackendWithSender
+                        Nothing
+                        sender
+                        (const (pure ()))
+                        (pure params)
+                        contextState
+                        base
+            result <- backend.submitTurn oldHistory (Just "resp-tool") inputs
+                (const (pure ()))
+            result `shouldSatisfy` either (const False) (const True)
+            readIORef compactCalls `shouldReturn` 0
+            readIORef seenPrevious `shouldReturn` [Just "resp-tool"]
+            readIORef seenInputs `shouldReturn` [inputs]
+
+        it "trims replay history when a tool continuation cannot fit the full transcript" do
+            let params = defaultResponseCreateParams
+                contextWindow =
+                    codexEffectiveContextWindowFor params.model
+                danglingCall = FunctionCallItem FunctionCall
+                    { itemId = Nothing
+                    , callId = "call-replay"
+                    , name = "shell_command"
+                    , namespace = Nothing
+                    , arguments = "{}"
+                    , encryptedFunctionArgs = Nothing
+                    , status = Nothing
+                    , extraFields = mempty
+                    }
+                oldHistory =
+                    [ userTextItem
+                        (Text.replicate ((contextWindow + 1_000) * 4) "x")
+                    , danglingCall
+                    ]
+                toolResult = ToolCallResult
+                    { callId = "call-replay"
+                    , output = "ok"
+                    , callKind = FunctionCallKind
+                    }
+                inputs = [CompletedTool toolResult]
+            estimateRequestTokensWithItems
+                params
+                (oldHistory <> turnInputsToItems inputs)
+                `shouldSatisfy` (> contextWindow)
+            contextState <- newIORef Nothing
+            compactCalls <- newIORef (0 :: Int)
+            seenHistory <- newIORef []
+            let sender _request = do
+                    modifyIORef' compactCalls (+ 1)
+                    pure (Right remoteCompactionResponse)
+                base = Backend \state _previous _submitted _ -> do
+                    modifyIORef' seenHistory (<> [state])
+                    pure $ successful state TurnOutput
+                        { responseId = "resp-new"
+                        , toolCalls = []
+                        , assistantText = Just "ok"
+                        , tokenUsage = TokenUsage 20 5 0
+                        }
+                backend =
+                    autoCompactOpenAiBackendWithSender
+                        Nothing
+                        sender
+                        (const (pure ()))
+                        (pure params)
+                        contextState
+                        base
+            result <- backend.submitTurn oldHistory Nothing inputs
+                (const (pure ()))
+            result `shouldSatisfy` either (const False) (const True)
+            readIORef compactCalls `shouldReturn` 0
+            readIORef seenHistory >>= \case
+                [fitted] -> do
+                    estimateRequestTokensWithItems
+                        params
+                        (fitted <> turnInputsToItems inputs)
+                        `shouldSatisfy` (<= contextWindow)
+                    any
+                        (\case
+                            FunctionCallItem call -> call.callId == "call-replay"
+                            _ -> False)
+                        fitted
+                        `shouldBe` True
+                seen ->
+                    expectationFailure
+                        ("expected one trimmed continuation, got "
+                            <> show (length seen))
+
         it "preserves typed provider failures from automatic compaction" do
             let history = [userTextItem "old"]
                 compactError =

--- a/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
@@ -841,7 +841,8 @@ spec = do
         it "reports a throwing post-compaction hook instead of swallowing it" do
             let history = [userTextItem "old"]
                 threshold = 20
-            contextState <- newIORef (Just (threshold, length history))
+            contextState <- newIORef
+                (Just (reportedOccupancy threshold (length history)))
             events <- newIORef []
             let sender _request =
                     pure (Right remoteCompactionResponse)

--- a/packages/agent-openai/src/Agent/OpenAI/Http.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Http.hs
@@ -109,7 +109,8 @@ decodeCodexHttpBodyWithModel
 decodeCodexHttpBodyWithModel modelHint bodyText
     | looksLikeSse bodyText = do
         events <- parseSseEvents bodyText
-        buildStreamResponseWithModel streamConfig modelHint events
+        response <- buildStreamResponseWithModel streamConfig modelHint events
+        rejectFailedCodexResponse response
     | otherwise =
         case decodeJsonResponseBody bodyText of
             Just jsonValue -> decodeResponseValue jsonValue bodyText

--- a/packages/agent-openai/src/Agent/OpenAI/Http.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Http.hs
@@ -8,6 +8,7 @@ module Agent.OpenAI.Http
 import Agent.Error (ApiError(..), ErrorType(..), errorTypeFromText)
 import Agent.OpenAI.Error (mkOpenAIError)
 import Agent.Responses.SSE (parseSseEvents)
+import Agent.Responses.LoopBackend (hasRecoverableIncompleteOutput)
 import Agent.Responses.StreamAssembly
     ( ResponseFailure(..)
     , StreamAssemblyConfig(..)
@@ -138,7 +139,9 @@ rejectFailedCodexResponse :: OpenAI.Response -> Either ApiError OpenAI.Response
 rejectFailedCodexResponse response =
     case response.status of
         OpenAI.ResponseFailed -> Left (terminalResponseError response)
-        OpenAI.ResponseIncomplete -> Left (terminalResponseError response)
+        OpenAI.ResponseIncomplete
+            | hasRecoverableIncompleteOutput response -> Right response
+            | otherwise -> Left (terminalResponseError response)
         _ -> Right response
 
 streamConfig :: StreamAssemblyConfig
@@ -155,7 +158,7 @@ streamConfig = StreamAssemblyConfig
             streamError.code
             streamError.retryAfter
     , classifyFailedResponse = failedStreamResponseError
-    , incompleteAsFailure = True
+    , incompleteAsFailure = False
     }
 
 failedStreamResponseError :: ResponseFailure -> ApiError

--- a/packages/agent-openai/src/Agent/OpenAI/WebSocketClient.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/WebSocketClient.hs
@@ -39,6 +39,7 @@ import Agent.Error
 import Agent.Http.Header (parseRetryAfterSeconds)
 import Agent.OpenAI.Error (isPreviousResponseIdError, mkOpenAIError)
 import Agent.OpenAI.Features (remoteCompactionV2Feature)
+import Agent.OpenAI.Http (rejectFailedCodexResponse)
 import Agent.OpenAI.ModelMetadata (isCodexResponsesLiteModel)
 import Agent.OpenAI.Request (sanitizeCodexRequest)
 import Agent.Responses.StreamAssembly
@@ -46,6 +47,7 @@ import Agent.Responses.StreamAssembly
     , applyStreamEvent
     , emptyStreamAssemblyState
     , failedStreamResponseMessage
+    , finishAssembledIncomplete
     , finishStreamResponse
     , responseFailureFromState
     )
@@ -648,9 +650,15 @@ receiveWsResponseWithActions modelHint actions onEvent =
     loop assembly frames bytes = do
         msgResult <- actions.receiveFrame
         case msgResult of
-            Left e -> do
-                logStreamStats "connection_error" frames bytes
-                pure $ Left e
+            Left e ->
+                case recoverAssembledResponse modelHint assembly of
+                    Just response -> do
+                        logStreamStats "recovered_incomplete" frames bytes
+                        actions.completeRequest
+                        pure (Right response)
+                    Nothing -> do
+                        logStreamStats "connection_error" frames bytes
+                        pure (Left e)
             Right (msgBytes :: LBS.ByteString) -> do
                 let frames' = frames + 1
                     bytes' = bytes + LBS.length msgBytes
@@ -684,15 +692,7 @@ receiveWsResponseWithActions modelHint actions onEvent =
                                 finishTerminal "done" assembly' frames' bytes' event
 
                             ResponseIncompleteEvent{} ->
-                                do
-                                    logStreamStats "incomplete" frames' bytes'
-                                    actions.invalidateRequest
-                                        "WebSocket response incomplete"
-                                    pure $ Left
-                                        (failedResponseError
-                                            ((responseFailureFromState assembly')
-                                                { failureStatus =
-                                                    Just "incomplete" }))
+                                finishIncomplete assembly' frames' bytes' event
 
                             ResponseFailedEvent{} -> do
                                 logStreamStats "response_failed" frames' bytes'
@@ -710,6 +710,31 @@ receiveWsResponseWithActions modelHint actions onEvent =
         logStreamStats label frames bytes
         actions.completeRequest
         pure (finishStreamResponse modelHint assembly event)
+
+    finishIncomplete assembly frames bytes event =
+        case finishStreamResponse modelHint assembly event of
+            Right response ->
+                case rejectFailedCodexResponse response of
+                    Right accepted -> do
+                        logStreamStats "incomplete" frames bytes
+                        actions.completeRequest
+                        pure (Right accepted)
+                    Left err -> do
+                        logStreamStats "incomplete" frames bytes
+                        actions.invalidateRequest "WebSocket response incomplete"
+                        pure (Left err)
+            Left err -> do
+                logStreamStats "incomplete" frames bytes
+                actions.invalidateRequest "WebSocket response incomplete"
+                pure (Left err)
+
+    recoverAssembledResponse modelHint assembly =
+        case finishAssembledIncomplete modelHint assembly of
+            Right response ->
+                case rejectFailedCodexResponse response of
+                    Right accepted -> Just accepted
+                    Left _ -> Nothing
+            Left _ -> Nothing
 
     logStreamStats :: Text -> Int -> Int64 -> IO ()
     logStreamStats _label _frames _bytes = pure ()

--- a/packages/agent-openai/test/Agent/OpenAI/ClientSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/ClientSpec.hs
@@ -118,6 +118,31 @@ spec = do
             readIORef attempts `shouldReturn` 1
 
     describe "decodeCodexHttpBody" do
+        it "rejects an empty incomplete SSE response" do
+            let body = Text.concat
+                    [ "event: response.created\n"
+                    , "data: {\"type\":\"response.created\","
+                    , "\"response\":{\"id\":\"resp-empty-incomplete\"}}\n\n"
+                    , "event: response.incomplete\n"
+                    , "data: "
+                    , Text.decodeUtf8 (LBS.toStrict (Aeson.encode (Aeson.object
+                        [ "response" .= Aeson.object
+                            [ "id" .= ("resp-empty-incomplete" :: Text)
+                            , "created_at" .= (0 :: Int)
+                            , "model" .= ("gpt-test" :: Text)
+                            , "status" .= ("incomplete" :: Text)
+                            , "incomplete_details" .= Aeson.object
+                                [ "reason" .= ("max_output_tokens" :: Text) ]
+                            , "output" .= ([] :: [Aeson.Value])
+                            ]
+                        ])))
+                    , "\n\n"
+                    ]
+            decodeCodexHttpBody body `shouldBe` Left
+                (ProviderError ApiErrorType
+                    "response.incomplete: max_output_tokens"
+                    Nothing)
+
         it "reads an incomplete SSE response that already contains a function call" do
             let body = Text.concat
                     [ "event: response.output_item.done\n"

--- a/packages/agent-openai/test/Agent/OpenAI/ClientSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/ClientSpec.hs
@@ -61,6 +61,25 @@ spec = do
                     "response.incomplete: max_output_tokens"
                     Nothing)
 
+        it "keeps an incomplete response that already contains tool calls" do
+            let response = decodeResponse (Aeson.object
+                    [ "id" .= ("response-id" :: Text)
+                    , "created_at" .= (0 :: Int)
+                    , "model" .= ("gpt-5.6-sol" :: Text)
+                    , "status" .= ("incomplete" :: Text)
+                    , "incomplete_details" .= Aeson.object
+                        [ "reason" .= ("max_output_tokens" :: Text) ]
+                    , "output" .=
+                        [ Aeson.object
+                            [ "type" .= ("function_call" :: Text)
+                            , "call_id" .= ("call-1" :: Text)
+                            , "name" .= ("shell_command" :: Text)
+                            , "arguments" .= ("{}" :: Text)
+                            ]
+                        ]
+                    ])
+            rejectFailedCodexResponse response `shouldBe` Right response
+
     describe "retryTransientCodexResultWithPolicy" do
         it "retries ordinary Left overloads before returning success" do
             let overload = ProviderError OverloadedError "server_is_overloaded" Nothing
@@ -99,6 +118,35 @@ spec = do
             readIORef attempts `shouldReturn` 1
 
     describe "decodeCodexHttpBody" do
+        it "reads an incomplete SSE response that already contains a function call" do
+            let body = Text.concat
+                    [ "event: response.output_item.done\n"
+                    , "data: {\"item\":"
+                    , "{\"type\":\"function_call\",\"call_id\":\"call-1\",\"name\":\"shell_command\",\"arguments\":\"{}\"}"
+                    , "}\n\n"
+                    , "event: response.incomplete\n"
+                    , "data: "
+                    , Text.decodeUtf8 (LBS.toStrict (Aeson.encode (Aeson.object
+                        [ "response" .= Aeson.object
+                            [ "id" .= ("resp-incomplete" :: Text)
+                            , "created_at" .= (0 :: Int)
+                            , "model" .= ("gpt-test" :: Text)
+                            , "status" .= ("incomplete" :: Text)
+                            , "incomplete_details" .= Aeson.object
+                                [ "reason" .= ("max_output_tokens" :: Text) ]
+                            , "output" .= ([] :: [Aeson.Value])
+                            ]
+                        ])))
+                    , "\n\n"
+                    ]
+            case decodeCodexHttpBody body of
+                Right response -> do
+                    response.responseId `shouldBe` "resp-incomplete"
+                    response.status `shouldBe` ResponseIncomplete
+                    [name | FunctionCallItem FunctionCall { name } <- response.output]
+                        `shouldBe` ["shell_command"]
+                Left err -> expectationFailure ("expected response, got " <> show err)
+
         it "reads the terminal SSE response.completed event" do
             let body = Text.concat
                     [ "event: response.output_item.done\n"

--- a/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
@@ -335,6 +335,12 @@ spec = do
                 `shouldBe` True
             streamOutputObserved
                 (ResponseIncompleteEvent (Aeson.object []) Nothing KeyMap.empty)
+                `shouldBe` False
+            streamOutputObserved
+                (ResponseIncompleteEvent
+                    (Aeson.object ["output" Aeson..= [Aeson.object []]])
+                    Nothing
+                    KeyMap.empty)
                 `shouldBe` True
 
         it "treats failed lifecycle events as output only when output is present" do

--- a/packages/agent-openai/test/Agent/OpenAI/WebSocketClientSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/WebSocketClientSpec.hs
@@ -260,7 +260,9 @@ spec = do
             (Just "gpt-test") actions onEvent
 
         result `shouldBe` Left
-            (ConnectionError "response.incomplete: max_output_tokens")
+            (ProviderError ApiErrorType
+                "response.incomplete: max_output_tokens"
+                Nothing)
         readIORef callbackTypes `shouldReturn`
             [EventResponseCreated, EventResponseIncomplete]
         readIORef receiveCount `shouldReturn` 2
@@ -268,6 +270,98 @@ spec = do
         readIORef invalidations `shouldReturn`
             ["WebSocket response incomplete"]
         readIORef frames `shouldReturn` []
+
+    it "keeps an incomplete response that already contains a function call" do
+        frames <- newIORef
+            [ lifecycleFrame "response.created"
+                (Aeson.object ["id" Aeson..= ("resp-test" :: Text)])
+            , Aeson.encode $ Aeson.object
+                [ "type" Aeson..= ("response.output_item.done" :: Text)
+                , "item" Aeson..= Aeson.object
+                    [ "type" Aeson..= ("function_call" :: Text)
+                    , "call_id" Aeson..= ("call-test" :: Text)
+                    , "name" Aeson..= ("shell_command" :: Text)
+                    , "arguments" Aeson..= ("{}" :: Text)
+                    ]
+                ]
+            , lifecycleFrame "response.incomplete"
+                (Aeson.object
+                    [ "incomplete_details" Aeson..= Aeson.object
+                        [ "reason" Aeson..=
+                            ("max_output_tokens" :: Text)
+                        ]
+                    ])
+            ]
+        receiveCount <- newIORef (0 :: Int)
+        completeCount <- newIORef (0 :: Int)
+        invalidations <- newIORef ([] :: [Text])
+        callbackTypes <- newIORef ([] :: [StreamEventType])
+        let actions = WebSocketReceiveActions
+                { receiveFrame = do
+                    modifyIORef' receiveCount (+ 1)
+                    atomicModifyIORef' frames \case
+                        frame : rest -> (rest, Right frame)
+                        [] -> error "unexpected receive after terminal event"
+                , completeRequest = modifyIORef' completeCount (+ 1)
+                , invalidateRequest = \reason ->
+                    modifyIORef' invalidations (<> [reason])
+                }
+            onEvent event =
+                modifyIORef' callbackTypes
+                    (<> [responseStreamEventType event])
+
+        result <- receiveWsResponseWithActions
+            (Just "gpt-test") actions onEvent
+
+        case result of
+            Right response -> do
+                response.responseId `shouldBe` "resp-test"
+                response.status `shouldBe` ResponseIncomplete
+                [name | FunctionCallItem FunctionCall { name } <- response.output]
+                    `shouldBe` ["shell_command"]
+            other -> expectationFailure ("expected incomplete response, got " <> show other)
+        readIORef callbackTypes `shouldReturn`
+            [EventResponseCreated, EventOutputItemDone, EventResponseIncomplete]
+        readIORef completeCount `shouldReturn` 1
+        readIORef invalidations `shouldReturn` []
+
+    it "recovers assembled tool calls when the socket dies after output_item.done" do
+        remaining <- newIORef
+            [ Right $ lifecycleFrame "response.created"
+                (Aeson.object ["id" Aeson..= ("resp-test" :: Text)])
+            , Right $ Aeson.encode $ Aeson.object
+                [ "type" Aeson..= ("response.output_item.done" :: Text)
+                , "item" Aeson..= Aeson.object
+                    [ "type" Aeson..= ("function_call" :: Text)
+                    , "call_id" Aeson..= ("call-test" :: Text)
+                    , "name" Aeson..= ("shell_command" :: Text)
+                    , "arguments" Aeson..= ("{}" :: Text)
+                    ]
+                ]
+            , Left (ConnectionError "WebSocket receive idle timeout")
+            ]
+        completeCount <- newIORef (0 :: Int)
+        invalidations <- newIORef ([] :: [Text])
+        let actions = WebSocketReceiveActions
+                { receiveFrame = atomicModifyIORef' remaining \case
+                    next : rest -> (rest, next)
+                    [] -> error "unexpected receive after frames were exhausted"
+                , completeRequest = modifyIORef' completeCount (+ 1)
+                , invalidateRequest = \reason ->
+                    modifyIORef' invalidations (<> [reason])
+                }
+
+        result <- receiveWsResponseWithActions
+            (Just "gpt-test") actions (const (pure ()))
+
+        case result of
+            Right response -> do
+                response.responseId `shouldBe` "resp-test"
+                [name | FunctionCallItem FunctionCall { name } <- response.output]
+                    `shouldBe` ["shell_command"]
+            other -> expectationFailure ("expected recovered response, got " <> show other)
+        readIORef completeCount `shouldReturn` 1
+        readIORef invalidations `shouldReturn` []
 
 testPartialTerminalResponse
     :: [LBS.ByteString]

--- a/packages/agent-responses/src/Agent/Responses/LoopBackend.hs
+++ b/packages/agent-responses/src/Agent/Responses/LoopBackend.hs
@@ -10,6 +10,7 @@ module Agent.Responses.LoopBackend
     , streamEventToLoopEvent
     , streamEventToLoopEventWithRawReasoning
     , streamOutputObserved
+    , hasRecoverableIncompleteOutput
     , assistantTextFromResponse
     , toolResultToItem
     , withRequestInput
@@ -372,6 +373,15 @@ responseToTurnOutput response = TurnOutput
     , tokenUsage = responseTokenUsage response
     }
 
+-- | An incomplete response can still finish the turn when it already contains
+-- executable tool calls or assistant text. Empty @max_output_tokens@ stops
+-- remain transport failures so a replay-safe fallback can still run.
+hasRecoverableIncompleteOutput :: Response -> Bool
+hasRecoverableIncompleteOutput response =
+    not (null (mapMaybe responseItemToToolCall response.output))
+        || maybe False (not . Text.null . Text.strip)
+            (assistantTextFromResponse response)
+
 responseTokenUsage :: Response -> TokenUsage
 responseTokenUsage response =
     tokenUsageFromResponse response.usage
@@ -566,7 +576,8 @@ streamOutputObserved :: ResponseStreamEvent -> Bool
 streamOutputObserved event = case event of
     ResponseCompletedEvent{} -> True
     ResponseDoneEvent{} -> True
-    ResponseIncompleteEvent{} -> True
+    ResponseIncompleteEvent { responseValue } ->
+        responseFragmentHasOutput responseValue
     ResponseFailedEvent { responseValue } ->
         responseFragmentHasOutput responseValue
     ResponseOutputItemAddedEvent{} -> True

--- a/packages/agent-responses/src/Agent/Responses/StreamAssembly.hs
+++ b/packages/agent-responses/src/Agent/Responses/StreamAssembly.hs
@@ -6,6 +6,7 @@ module Agent.Responses.StreamAssembly
     , emptyStreamAssemblyState
     , applyStreamEvent
     , finishStreamResponse
+    , finishAssembledIncomplete
     , buildStreamResponse
     , buildStreamResponseWithModel
     , assembleDoneResponse
@@ -201,6 +202,20 @@ finishStreamResponse modelHint state terminalEvent = do
         _ -> Left $ JsonDecodeError
             "Streamed response did not contain a response id"
             (jsonPreview assembled)
+
+-- | Assemble the current stream state as an incomplete response. Used when the
+-- provider emits @response.incomplete@ or the socket dies after output items
+-- were already collected.
+finishAssembledIncomplete
+    :: Maybe Text
+    -> StreamAssemblyState
+    -> Either ApiError Response
+finishAssembledIncomplete modelHint state =
+    finishStreamResponse modelHint state
+        (ResponseIncompleteEvent
+            (Aeson.Object state.responseObject)
+            Nothing
+            KeyMap.empty)
 
 -- | Build a response without a request-model hint. This remains the shared
 -- entry point used by provider SSE transports.

--- a/packages/agent-xai/src/Agent/XAI/Request.hs
+++ b/packages/agent-xai/src/Agent/XAI/Request.hs
@@ -12,6 +12,7 @@ import Agent.Responses.Request
     )
 import Agent.Responses.Types
 import Agent.XAI.Options (ClientOptions(..))
+import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KeyMap
 import qualified Data.Maybe as Maybe
 import Data.Text (Text)
@@ -145,19 +146,91 @@ requestInputItems request = case request.input of
 -- user switches to Grok, whose Responses union does not recognize that tag.
 -- Preserve the readable collaboration context as an ordinary user message.
 normalizeInputItem :: ResponseItem -> ResponseItem
-normalizeInputItem = \case
-    AgentMessageItem message ->
-        MessageItem ResponseMessage
-            { messageId = Nothing
-            , content = MessageContentParts
-                [InputTextPart (agentMessageText message) Nothing KeyMap.empty]
-            , role = RoleUser
-            , status = Nothing
-            , phase = Nothing
-            , passthrough = Nothing
-            , extraFields = KeyMap.empty
+normalizeInputItem =
+    stripItemStatus . \case
+        AgentMessageItem message ->
+            MessageItem ResponseMessage
+                { messageId = Nothing
+                , content = MessageContentParts
+                    [InputTextPart (agentMessageText message) Nothing KeyMap.empty]
+                , role = RoleUser
+                , status = Nothing
+                , phase = Nothing
+                , passthrough = Nothing
+                , extraFields = KeyMap.empty
+                }
+        item -> item
+
+-- The Grok proxy rejects OpenAI item @status@ as an unknown parameter
+-- (@input[n].status@). Strip it from every input item at the wire boundary.
+stripItemStatus :: ResponseItem -> ResponseItem
+stripItemStatus = \case
+    MessageItem message ->
+        MessageItem message
+            { status = Nothing
+            , extraFields = withoutStatusFields message.extraFields
+            }
+    FunctionCallItem call ->
+        FunctionCallItem call
+            { status = Nothing
+            , extraFields = withoutStatusFields call.extraFields
+            }
+    FunctionCallOutputItem output ->
+        FunctionCallOutputItem output
+            { status = Nothing
+            , extraFields = withoutStatusFields output.extraFields
+            }
+    CustomToolCallItem call ->
+        CustomToolCallItem call
+            { status = Nothing
+            , extraFields = withoutStatusFields call.extraFields
+            }
+    CustomToolCallOutputItem output ->
+        CustomToolCallOutputItem output
+            { status = Nothing
+            , extraFields = withoutStatusFields output.extraFields
+            }
+    ReasoningItemValue item ->
+        ReasoningItemValue item
+            { status = Nothing
+            , extraFields = withoutStatusFields item.extraFields
+            }
+    LocalShellCallItem item ->
+        LocalShellCallItem item
+            { status = Nothing
+            , extraFields = withoutStatusFields item.extraFields
+            }
+    ToolSearchCallItem item ->
+        ToolSearchCallItem item
+            { status = Nothing
+            , extraFields = withoutStatusFields item.extraFields
+            }
+    ToolSearchOutputItem item ->
+        ToolSearchOutputItem item
+            { status = Nothing
+            , extraFields = withoutStatusFields item.extraFields
+            }
+    WebSearchCallItem item ->
+        WebSearchCallItem item
+            { status = Nothing
+            , extraFields = withoutStatusFields item.extraFields
+            }
+    ImageGenerationCallItem item ->
+        ImageGenerationCallItem item
+            { status = Nothing
+            , extraFields = withoutStatusFields item.extraFields
+            }
+    KnownResponseItem itemType tagged ->
+        KnownResponseItem itemType tagged
+            { fields = withoutStatusFields tagged.fields
+            }
+    UnknownResponseItem tagged ->
+        UnknownResponseItem tagged
+            { fields = withoutStatusFields tagged.fields
             }
     item -> item
+
+withoutStatusFields = KeyMap.delete (Key.fromText "status")
 
 agentMessageText :: ResponseAgentMessage -> Text
 agentMessageText message =

--- a/packages/agent-xai/test/Agent/XAI/ResponsesSpec.hs
+++ b/packages/agent-xai/test/Agent/XAI/ResponsesSpec.hs
@@ -78,6 +78,43 @@ spec = do
             input <- expectArray (KeyMap.lookup "input" object)
             length input `shouldBe` 1
 
+        it "omits OpenAI item status fields the Grok proxy rejects" do
+            let call = FunctionCallItem FunctionCall
+                    { itemId = Just "fc_1"
+                    , callId = "call-1"
+                    , name = "shell_command"
+                    , namespace = Nothing
+                    , arguments = "{}"
+                    , encryptedFunctionArgs = Nothing
+                    , status = Just ItemCompleted
+                    , extraFields =
+                        KeyMap.singleton "status" (Aeson.String "completed")
+                    }
+                message = MessageItem ResponseMessage
+                    { messageId = Just "msg_1"
+                    , content = MessageContentParts
+                        [InputTextPart "hello" Nothing KeyMap.empty]
+                    , role = RoleUser
+                    , status = Just ItemCompleted
+                    , phase = Nothing
+                    , passthrough = Nothing
+                    , extraFields =
+                        KeyMap.singleton "status" (Aeson.String "completed")
+                    }
+                request = setInstructions Nothing $
+                    setInput
+                        (Just (ResponseInputItems [message, call]))
+                        sampleRequest
+                value = requestValue defaultClientOptions request
+            object <- expectObject value
+            input <- expectArray (KeyMap.lookup "input" object)
+            itemObjects <- traverse expectObject input
+            map (KeyMap.lookup "status") itemObjects `shouldBe` [Nothing, Nothing]
+            map (KeyMap.lookup "type") itemObjects `shouldBe`
+                [ Just (Aeson.String "message")
+                , Just (Aeson.String "function_call")
+                ]
+
         it "flattens resumed OpenAI agent messages into Grok user messages" do
             let agentMessage = AgentMessageItem ResponseAgentMessage
                     { messageId = Nothing


### PR DESCRIPTION
## Summary
- Live Codex tool continuations are sized against occupancy (when known) or the delta request, not the JSON length of retained history. If that still cannot fit, replay history is trimmed while keeping unpaired function calls. The same overflow wrapper now covers Grok and OpenRouter.
- Grok wire requests drop OpenAI item `status` fields (`input[n].status`), which the proxy rejects as an unknown parameter.
- Incomplete Codex responses that already contain tool calls or assistant text finish the turn instead of becoming `replay_unsafe` connection errors. The same recovery applies when the socket dies after `output_item.done`.
- `.haskell-agent/` remains gitignored (already on master) with a comment so committed `lastModel` cannot sneak back in.

## Validation
- GHCi: `agent-cli:lib:agent-cli` loaded (141 modules)
- `autoCompactOpenAiBackendWith`: 19 examples, 0 failures (includes occupancy tests plus live-chain and replay-trim cases)
- `receiveWsResponseWithActions`: 6 examples, 0 failures
- xAI `omits OpenAI item status fields the Grok proxy rejects`
- `git diff --check`